### PR TITLE
✨ feat(MicrosoftOutlook) Service root configurable for Outlook and OneDrive nodes

### DIFF
--- a/packages/nodes-base/credentials/MicrosoftOneDriveOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftOneDriveOAuth2Api.credentials.ts
@@ -1,5 +1,23 @@
 import type { ICredentialType, INodeProperties } from 'n8n-workflow';
 
+const enum EndpointNames {
+	Global = 'Microsoft Graph global service',
+	GovCloud = 'Microsoft Graph for US Government L4',
+	DoDCloud = 'Microsoft Graph for US Government L5 (DOD)',
+	China = 'Microsoft Graph China operated by 21Vianet',
+}
+
+/**
+ * The service endpoints are defined by Microsoft:
+ * https://learn.microsoft.com/en-us/graph/deployments#microsoft-graph-and-graph-explorer-service-root-endpoints
+ */
+const endpoints: Record<EndpointNames, string> = {
+	[EndpointNames.Global]: 'https://graph.microsoft.com',
+	[EndpointNames.GovCloud]: 'https://graph.microsoft.us',
+	[EndpointNames.DoDCloud]: 'https://dod-graph.microsoft.us',
+	[EndpointNames.China]: 'https://microsoftgraph.chinacloudapi.cn',
+};
+
 export class MicrosoftOneDriveOAuth2Api implements ICredentialType {
 	name = 'microsoftOneDriveOAuth2Api';
 
@@ -16,6 +34,17 @@ export class MicrosoftOneDriveOAuth2Api implements ICredentialType {
 			name: 'scope',
 			type: 'hidden',
 			default: 'openid offline_access Files.ReadWrite.All',
+		},
+		{
+			displayName: 'Endpoint',
+			description: 'The service root endpoint to use when connecting to the Outlook API.',
+			name: 'graphEndpoint',
+			type: 'options',
+			default: endpoints[EndpointNames.Global],
+			options: Object.keys(endpoints).map((name) => ({
+				name,
+				value: endpoints[name as EndpointNames],
+			})),
 		},
 	];
 }

--- a/packages/nodes-base/credentials/MicrosoftOutlookOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftOutlookOAuth2Api.credentials.ts
@@ -15,6 +15,24 @@ const scopes = [
 	'MailboxSettings.Read',
 ];
 
+const enum EndpointNames {
+	Global = 'Microsoft Graph global service',
+	GovCloud = 'Microsoft Graph for US Government L4',
+	DoDCloud = 'Microsoft Graph for US Government L5 (DOD)',
+	China = 'Microsoft Graph China operated by 21Vianet',
+}
+
+/**
+ * The service endpoints are defined by Microsoft:
+ * https://learn.microsoft.com/en-us/graph/deployments#microsoft-graph-and-graph-explorer-service-root-endpoints
+ */
+const endpoints: Record<EndpointNames, string> = {
+	[EndpointNames.Global]: 'https://graph.microsoft.com',
+	[EndpointNames.GovCloud]: 'https://graph.microsoft.us',
+	[EndpointNames.DoDCloud]: 'https://dod-graph.microsoft.us',
+	[EndpointNames.China]: 'https://microsoftgraph.chinacloudapi.cn',
+};
+
 export class MicrosoftOutlookOAuth2Api implements ICredentialType {
 	name = 'microsoftOutlookOAuth2Api';
 
@@ -49,6 +67,17 @@ export class MicrosoftOutlookOAuth2Api implements ICredentialType {
 					useShared: [true],
 				},
 			},
+		},
+		{
+			displayName: 'Endpoint',
+			description: 'The service root endpoint to use when connecting to the Outlook API.',
+			name: 'graphEndpoint',
+			type: 'options',
+			default: endpoints[EndpointNames.Global],
+			options: Object.keys(endpoints).map((name) => ({
+				name,
+				value: endpoints[name as EndpointNames],
+			})),
 		},
 	];
 }

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/MicrosoftOneDriveTrigger.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/MicrosoftOneDriveTrigger.node.ts
@@ -8,7 +8,12 @@ import {
 	NodeConnectionType,
 } from 'n8n-workflow';
 
-import { getPath, microsoftApiRequest, microsoftApiRequestAllItemsDelta } from './GenericFunctions';
+import {
+	getGraphEndpoint,
+	getPath,
+	microsoftApiRequest,
+	microsoftApiRequestAllItemsDelta,
+} from './GenericFunctions';
 import { triggerDescription } from './TriggerDescription';
 
 export class MicrosoftOneDriveTrigger implements INodeType {
@@ -41,11 +46,12 @@ export class MicrosoftOneDriveTrigger implements INodeType {
 
 	async poll(this: IPollFunctions): Promise<INodeExecutionData[][] | null> {
 		const workflowData = this.getWorkflowStaticData('node');
+		const graphEndpoint = await getGraphEndpoint.call(this);
+
 		let responseData: IDataObject[];
 
 		const lastLink: string =
-			(workflowData.LastLink as string) ||
-			'https://graph.microsoft.com/v1.0/me/drive/root/delta?token=latest';
+			(workflowData.LastLink as string) || `${graphEndpoint}/v1.0/me/drive/root/delta?token=latest`;
 
 		const now = DateTime.now().toUTC();
 		const start = DateTime.fromISO(workflowData.lastTimeChecked as string) || now;
@@ -72,7 +78,7 @@ export class MicrosoftOneDriveTrigger implements INodeType {
 						'',
 						{},
 						{},
-						'https://graph.microsoft.com/v1.0/me/drive/root/delta',
+						`${graphEndpoint}/v1.0/me/drive/root/delta`,
 					)
 				).value as IDataObject[];
 			} else {

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/test/GenericFunctions.test.ts
@@ -1,0 +1,70 @@
+import type { ICredentialDataDecryptedObject, IExecuteFunctions } from 'n8n-workflow';
+
+import * as GenericFunctions from '../GenericFunctions';
+
+const fakeExecute = (credentials: ICredentialDataDecryptedObject, result: unknown) => {
+	const fakeExecuteFunction = {
+		async getCredentials(): Promise<ICredentialDataDecryptedObject> {
+			return credentials;
+		},
+		getNode: jest.fn(),
+
+		helpers: {
+			requestOAuth2: jest.fn().mockResolvedValue(result),
+		},
+	} as unknown as IExecuteFunctions;
+	return fakeExecuteFunction;
+};
+
+describe('Test MicrosoftOneDrive, GenericFunctions => microsoftApiRequest', () => {
+	it('should call microsoftApiRequest using the defined service root', async () => {
+		const execute = fakeExecute(
+			{
+				graphEndpoint: 'https://foo.bar',
+				useShared: false,
+				userPrincipalName: 'test-principal',
+			},
+			'foo',
+		);
+
+		const result: string = (await GenericFunctions.microsoftApiRequest.call(
+			execute,
+			'GET',
+			'/foo',
+		)) as string;
+
+		expect(result).toEqual('foo');
+		expect(execute.helpers.requestOAuth2).toHaveBeenCalledTimes(1);
+		expect(execute.helpers.requestOAuth2).toHaveBeenCalledWith('microsoftOneDriveOAuth2Api', {
+			headers: { 'Content-Type': 'application/json' },
+			method: 'GET',
+			uri: 'https://foo.bar/v1.0/me/foo',
+			json: true,
+		});
+	});
+
+	it('should call microsoftApiRequest using the service root if no root is provided', async () => {
+		const execute = fakeExecute(
+			{
+				useShared: false,
+				userPrincipalName: 'test-principal',
+			},
+			'foo',
+		);
+
+		const result: string = (await GenericFunctions.microsoftApiRequest.call(
+			execute,
+			'GET',
+			'/foo',
+		)) as string;
+
+		expect(result).toEqual('foo');
+		expect(execute.helpers.requestOAuth2).toHaveBeenCalledTimes(1);
+		expect(execute.helpers.requestOAuth2).toHaveBeenCalledWith('microsoftOneDriveOAuth2Api', {
+			headers: { 'Content-Type': 'application/json' },
+			method: 'GET',
+			uri: 'https://graph.microsoft.com/v1.0/me/foo',
+			json: true,
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/transport/index.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/transport/index.test.ts
@@ -1,0 +1,77 @@
+import type { ICredentialDataDecryptedObject, IExecuteFunctions } from 'n8n-workflow';
+
+import * as transport from '../../../v2/transport';
+
+const fakeExecute = (credentials: ICredentialDataDecryptedObject, result: unknown) => {
+	const fakeExecuteFunction = {
+		async getCredentials(): Promise<ICredentialDataDecryptedObject> {
+			return credentials;
+		},
+
+		helpers: {
+			requestWithAuthentication: jest.fn().mockResolvedValue(result),
+		},
+	} as unknown as IExecuteFunctions;
+	return fakeExecuteFunction;
+};
+
+describe('Test MicrosoftOutlookV2, transport => microsoftApiRequest', () => {
+	it('should call microsoftApiRequest using the defined service root', async () => {
+		const execute = fakeExecute(
+			{
+				graphEndpoint: 'https://foo.bar',
+				useShared: false,
+				userPrincipalName: 'test-principal',
+			},
+			'foo',
+		);
+
+		const result: string = (await transport.microsoftApiRequest.call(
+			execute,
+			'GET',
+			'/foo',
+		)) as string;
+
+		expect(result).toEqual('foo');
+		expect(execute.helpers.requestWithAuthentication).toHaveBeenCalledTimes(1);
+		expect(execute.helpers.requestWithAuthentication).toHaveBeenCalledWith(
+			'microsoftOutlookOAuth2Api',
+			{
+				headers: { 'Content-Type': 'application/json' },
+				method: 'GET',
+				qs: {},
+				uri: 'https://foo.bar/v1.0/me/foo',
+				json: true,
+			},
+		);
+	});
+
+	it('should call microsoftApiRequest using the service root if no root is provided', async () => {
+		const execute = fakeExecute(
+			{
+				useShared: false,
+				userPrincipalName: 'test-principal',
+			},
+			'foo',
+		);
+
+		const result: string = (await transport.microsoftApiRequest.call(
+			execute,
+			'GET',
+			'/foo',
+		)) as string;
+
+		expect(result).toEqual('foo');
+		expect(execute.helpers.requestWithAuthentication).toHaveBeenCalledTimes(1);
+		expect(execute.helpers.requestWithAuthentication).toHaveBeenCalledWith(
+			'microsoftOutlookOAuth2Api',
+			{
+				headers: { 'Content-Type': 'application/json' },
+				method: 'GET',
+				qs: {},
+				uri: 'https://graph.microsoft.com/v1.0/me/foo',
+				json: true,
+			},
+		);
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/transport/index.ts
@@ -22,11 +22,12 @@ export async function microsoftApiRequest(
 	option: IDataObject = { json: true },
 ) {
 	const credentials = await this.getCredentials('microsoftOutlookOAuth2Api');
+	const graphEndpoint = (credentials.graphEndpoint as string) || 'https://graph.microsoft.com';
 
-	let apiUrl = `https://graph.microsoft.com/v1.0/me${resource}`;
+	let apiUrl = `${graphEndpoint}/v1.0/me${resource}`;
 	// If accessing shared mailbox
 	if (credentials.useShared && credentials.userPrincipalName) {
-		apiUrl = `https://graph.microsoft.com/v1.0/users/${credentials.userPrincipalName}${resource}`;
+		apiUrl = `${graphEndpoint}/v1.0/users/${credentials.userPrincipalName}${resource}`;
 	}
 
 	const options: IRequestOptions = {


### PR DESCRIPTION
## Summary

This change adds the ability to use the different Microsoft service roots that are available in the Outlook and OneDrive nodes. For example, the Microsoft GovCloud service root can be configured so that `https://graph.microsoft.us` is used instead of `https://graphql.microsoft.com`.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
