### PR TITLE
feat(editor): Rename 'In-Memory Vector Store' to 'Simple Vector Store'

### DIFF
--- a/cypress/e2e/4-node-creator.cy.ts
+++ b/cypress/e2e/4-node-creator.cy.ts
@@ -559,7 +559,7 @@ describe('Node Creator', () => {
 		addNodeToCanvas('Question and Answer Chain', true);
 		addRetrieverNodeToParent('Vector Store Retriever', 'Question and Answer Chain');
 		cy.realPress('Escape');
-		addVectorStoreNodeToParent('In-Memory Vector Store', 'Vector Store Retriever');
+		addVectorStoreNodeToParent('Simple Vector Store', 'Vector Store Retriever');
 		cy.realPress('Escape');
 		WorkflowPage.getters.canvasNodes().should('have.length', 4);
 	});
@@ -569,7 +569,7 @@ describe('Node Creator', () => {
 		addNodeToCanvas(AGENT_NODE_NAME, true, true);
 		clickGetBackToCanvas();
 
-		addVectorStoreToolToParent('In-Memory Vector Store', AGENT_NODE_NAME);
+		addVectorStoreToolToParent('Simple Vector Store', AGENT_NODE_NAME);
 	});
 
 	it('should insert node to canvas with sendAndWait operation selected', () => {

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreInMemory/VectorStoreInMemory.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreInMemory/VectorStoreInMemory.node.ts
@@ -7,7 +7,7 @@ import { MemoryVectorStoreManager } from '../shared/MemoryVectorStoreManager';
 const insertFields: INodeProperties[] = [
 	{
 		displayName:
-			'The embbded data are stored in the server memory, so they will be lost when the server is restarted. Additionally, if the amount of data is too large, it may cause the server to crash due to insufficient memory.',
+			'The embedded data are stored in the server memory, so they will be lost when the server is restarted. Additionally, if the amount of data is too large, it may cause the server to crash due to insufficient memory.',
 		name: 'notice',
 		type: 'notice',
 		default: '',
@@ -23,9 +23,10 @@ const insertFields: INodeProperties[] = [
 
 export class VectorStoreInMemory extends createVectorStoreNode<MemoryVectorStore>({
 	meta: {
-		displayName: 'In-Memory Vector Store',
+		displayName: 'Simple Vector Store',
 		name: 'vectorStoreInMemory',
-		description: 'Work with your data in In-Memory Vector Store',
+		description:
+			"Work with your data in a Simple Vector Store. Don't use this for production usage.",
 		icon: 'fa:database',
 		iconColor: 'black',
 		docsUrl:


### PR DESCRIPTION
## Summary

This PR renames 'In-Memory Vector Store' to 'Simple Vector Store', in hopes of making the node less confusing to our less technical users. This node is intended to be used as an easy to setup development playground vector store, but it isn't intended for production usage as all data is lost when the server is restarted.

This change is implemented as a display name change to the existing node without introducing a new version of it.

<img width="438" alt="image" src="https://github.com/user-attachments/assets/006f6817-1b41-49c0-94b5-3d303913932e" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3252/feature-rename-in-memory-vector-store

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
