### PR TITLE
fix(editor): Parse out nodeType

### DIFF
--- a/packages/editor-ui/src/api/schemaPreview.ts
+++ b/packages/editor-ui/src/api/schemaPreview.ts
@@ -18,7 +18,9 @@ export const getSchemaPreview = async (
 ): Promise<JSONSchema7> => {
 	const { nodeType, version, resource, operation } = options;
 	const versionString = padVersion(version);
-	const path = ['schemas', nodeType, versionString, resource, operation].filter(Boolean).join('/');
+	const path = ['schemas', nodeType.replace('@n8n/', ''), versionString, resource, operation]
+		.filter(Boolean)
+		.join('/');
 	return await request({
 		method: 'GET',
 		baseURL: baseUrl,

--- a/packages/editor-ui/src/api/test/schemaPreview.test.ts
+++ b/packages/editor-ui/src/api/test/schemaPreview.test.ts
@@ -1,0 +1,41 @@
+import { getSchemaPreview } from '../schemaPreview';
+import * as apiUtils from '@/utils/apiUtils';
+
+describe('schemaPreview', () => {
+	afterEach(() => {
+		vi.resetAllMocks();
+	});
+
+	vi.mock('@/utils/apiUtils', () => ({
+		request: vi.fn().mockResolvedValue({ test: 'test' }),
+	}));
+
+	it('should return schema preview', async () => {
+		const response = await getSchemaPreview('http://test.com', {
+			nodeType: 'n8n-nodes-base.asana',
+			version: 1,
+			resource: 'resource',
+			operation: 'operation',
+		});
+
+		expect(response).toEqual({ test: 'test' });
+	});
+
+	it('should parse out nodeType', async () => {
+		const spy = vi.spyOn(apiUtils, 'request');
+
+		await getSchemaPreview('http://test.com', {
+			nodeType: '@n8n/n8n-nodes-base.asana',
+			version: 1,
+			resource: 'resource',
+			operation: 'operation',
+		});
+
+		expect(spy).toHaveBeenCalledWith({
+			method: 'GET',
+			baseURL: 'http://test.com',
+			endpoint: 'schemas/n8n-nodes-base.asana/1.0.0/resource/operation.json',
+			withCredentials: false,
+		});
+	});
+});


### PR DESCRIPTION
## Summary

This was causing calls to get schema preview to be successful, but returning unexpected outputs and red herring errors.

To test, connect any openAI node to another node (eg: Edit Fields). Open the node after openAI. You should see "No input data" instead of a malformed schema preview.

```
{
  "nodes": [
    {
      "parameters": {
        "modelId": {
          "__rl": true,
          "mode": "list",
          "value": ""
        },
        "messages": {
          "values": [
            {}
          ]
        },
        "options": {}
      },
      "type": "@n8n/n8n-nodes-langchain.openAi",
      "typeVersion": 1.8,
      "position": [
        -80,
        220
      ],
      "id": "eabb555d-54be-4488-b3ef-93fbe7cf4a18",
      "name": "OpenAI"
    },
    {
      "parameters": {
        "options": {}
      },
      "type": "n8n-nodes-base.set",
      "typeVersion": 3.4,
      "position": [
        320,
        220
      ],
      "id": "d092246d-1283-4461-9a76-1a7593b6da10",
      "name": "Edit Fields"
    },
    {
      "parameters": {
        "content": "## No Schema Preview",
        "height": 420,
        "width": 800
      },
      "type": "n8n-nodes-base.stickyNote",
      "typeVersion": 1,
      "position": [
        -200,
        80
      ],
      "id": "377e03ca-b6ae-4e68-933c-127f651cbd3c",
      "name": "Sticky Note1"
    }
  ],
  "connections": {
    "OpenAI": {
      "main": [
        [
          {
            "node": "Edit Fields",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {},
  "meta": {
    "templateCredsSetupCompleted": true,
    "instanceId": "ee90fdf8d57662f949e6c691dc07fa0fd2f66e1eee28ed82ef06658223e67255"
  }
}
```

## Related Linear tickets, Github issues, and Community forum posts

Resolves https://linear.app/n8n/issue/NODE-2430/if-no-schema-preview-dont-show-anything-at-all

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
