### PR TITLE
fix(Switch Node): Fix an issue in ordering rules in Switch Node

### DIFF
--- a/packages/editor-ui/src/utils/nodeSettingsUtils.ts
+++ b/packages/editor-ui/src/utils/nodeSettingsUtils.ts
@@ -103,8 +103,8 @@ export function updateDynamicConnections(
 					const newRulesvalues = parameterData.value as IDataObject[];
 					const updatedConnectionsIndex: number[] = [];
 
-					for (const rule of curentRulesvalues) {
-						const index = newRulesvalues.findIndex((newRule) => isEqual(rule, newRule));
+					for (const newRule of newRulesvalues) {
+						const index = curentRulesvalues.findIndex((rule) => isEqual(rule, newRule));
 						if (index !== -1) {
 							updatedConnectionsIndex.push(index);
 						}


### PR DESCRIPTION
## Summary
This PR fixes an issue with the order of connections after reordering the rules using drag and drop
here is a workflow to test

[switch_re_order_issue.json](https://github.com/user-attachments/files/18945464/switch_re_order_issue.json)

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-2361/switch-node-dragdrop-of-routing-rules-messes-up-the-output-connections


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
