### PR TITLE
feat(core): Release offloading manual executions to workers

### DIFF
--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -565,11 +565,7 @@ export async function executeWebhook(
 				});
 		}
 
-		if (
-			config.getEnv('executions.mode') === 'queue' &&
-			process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS === 'true' &&
-			runData.executionMode === 'manual'
-		) {
+		if (config.getEnv('executions.mode') === 'queue' && runData.executionMode === 'manual') {
 			assert(runData.executionData);
 			runData.executionData.isTestWebhook = true;
 		}

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -150,13 +150,7 @@ export class WorkflowRunner {
 			this.activeExecutions.attachResponsePromise(executionId, responsePromise);
 		}
 
-		// @TODO: Reduce to true branch once feature is stable
-		const shouldEnqueue =
-			process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS === 'true'
-				? this.executionsMode === 'queue'
-				: this.executionsMode === 'queue' && data.executionMode !== 'manual';
-
-		if (shouldEnqueue) {
+		if (this.executionsMode === 'queue') {
 			await this.enqueueExecution(executionId, data, loadStaticData, realtime);
 		} else {
 			await this.runMainProcess(executionId, data, loadStaticData, restartExecutionId);

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -196,10 +196,7 @@ export class WorkflowExecutionService {
 		 * Currently, manual executions in scaling mode are offloaded to workers,
 		 * so we persist all details to give workers full access to them.
 		 */
-		if (
-			config.getEnv('executions.mode') === 'queue' &&
-			process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS === 'true'
-		) {
+		if (config.getEnv('executions.mode') === 'queue') {
 			data.executionData = {
 				startData: {
 					startNodes: data.startNodes,


### PR DESCRIPTION
## Summary

Offloading manual executions to workers was merged at #11284 and has been tested on internal for ~1.5 months. As discussed with Product, we can now remove the test flag and make this into the new official flow for scaling mode.

## Related Linear tickets, Github issues, and Community forum posts

n/a

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] ~Tests included.~ <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] ~PR Labeled with `release/backport`~ (if the PR is an urgent fix that needs to be backported)
