### PR TITLE
feat(supabase Node): Add returnData toggle for RLS compatibility

### DIFF
--- a/packages/nodes-base/nodes/Supabase/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Supabase/GenericFunctions.ts
@@ -22,6 +22,7 @@ export async function supabaseApiRequest(
 	qs: IDataObject = {},
 	uri?: string,
 	headers: IDataObject = {},
+	returnData: boolean = true,
 ) {
 	const credentials = await this.getCredentials<{
 		host: string;
@@ -29,9 +30,7 @@ export async function supabaseApiRequest(
 	}>('supabaseApi');
 
 	const options: IRequestOptions = {
-		headers: {
-			Prefer: 'return=representation',
-		},
+		headers: returnData ? { Prefer: 'return=representation' } : { Prefer: 'return=minimal' },
 		method,
 		qs,
 		body,

--- a/packages/nodes-base/nodes/Supabase/RowDescription.ts
+++ b/packages/nodes-base/nodes/Supabase/RowDescription.ts
@@ -170,6 +170,19 @@ export const rowFields: INodeProperties[] = [
 			},
 		],
 	},
+	{
+		displayName: 'Return Inserted Data',
+		name: 'returnData',
+		type: 'boolean',
+		displayOptions: {
+			show: {
+				resource: ['row'],
+				operation: ['create'],
+			},
+		},
+		default: true,
+		description: 'Whether to return the inserted data. Disable if RLS policies restrict SELECT.',
+	},
 	/* -------------------------------------------------------------------------- */
 	/*                                row:delete                                  */
 	/* -------------------------------------------------------------------------- */


### PR DESCRIPTION
## Summary

This PR enhances the Supabase node by adding a `returnData` boolean option to the `create` operation, allowing inserts to succeed when Row-Level Security (RLS) policies block `SELECT` permissions. Previously, the node used `Prefer: return=representation`, which failed in secure setups (e.g., anon key with `INSERT`-only perms) due to missing `SELECT` rights. Now, users can toggle `returnData` off to skip returning inserted rows, making it compatible with strict RLS configurations like email signup lists.

**TL;DR**:
- Added `returnData` boolean option to `create` operation.
- Handles RLS setups where `SELECT` is blocked.
- Includes tests for true/false and non-boolean expressions.

### How to Test
1. **Setup**: 
   - Run n8n locally: `pnpm start` or `node packages/cli/bin/n8n`.
   - In Supabase, create a table `signups` with columns `email` (text) and `phone_number` (text).
   - Set RLS: Allow `INSERT` for `anon` role, deny `SELECT`.
2. **Workflow**:
   - Add a Webhook node: `POST`, path `signup`.
   - Add a Supabase node, connect it, and configure:
     - Operation: `create`.
     - Table: `signups`.
     - Credentials: Supabase anon key.
     - Data: Map `email` (`{{ $json.email }}`) and `phone_number` (`{{ $json.phone }}`) from webhook.
     - Toggle `Return Inserted Data` on/off.
3. **Test**:
   - Send a POST request via Postman to `http://localhost:5678/webhook-test/signup`:
     - Body: `multipart/form-data`.
     - Fields: `email: test@example.com`, `phone: +1234567890`.
   - **With `Return Inserted Data` ON**: Expect a permissions error (if RLS blocks `SELECT`), matching prior behavior.
   - **With `Return Inserted Data` OFF**: Expect `{ success: true, message: 'Row inserted' }`. Verify the row in Supabase (e.g., with a service key).
4. **Unit Tests**: 
   - Run `pnpm test --filter n8n-nodes-base`.
   - Tests cover: `returnData` true/false states and non-boolean expression coercion.

**Screenshots (Smoke Testing)**:

#### New Field is Present
<img width="394" alt="Screenshot 2025-02-25 at 3 11 24 AM" src="https://github.com/user-attachments/assets/91dc2a02-8013-43f1-af51-83fbcd4ebba5" />

#### New Field Has a Useful Description on Hover
<img width="459" alt="Screenshot 2025-02-25 at 3 11 34 AM" src="https://github.com/user-attachments/assets/6934e65b-b3ac-4f5e-9bfb-0448feec8df6" />

#### Supabase RLS Rule: Allow INSERT, Deny SELECT
<img width="1388" alt="Screenshot 2025-02-25 at 3 12 15 AM" src="https://github.com/user-attachments/assets/e7208ec0-dbe0-4eec-b2bf-a047655f87fc" />

#### Prior Behavior (returnData: true): Fails with RLS Blocking SELECT
<img width="623" alt="Screenshot 2025-02-25 at 3 11 55 AM" src="https://github.com/user-attachments/assets/3a75cfb0-1937-42d3-a44c-cf7213f2fd72" />

#### New Behavior (returnData: false): Inserts Succeed with Generic Success
<img width="1029" alt="Screenshot 2025-02-25 at 3 33 26 AM" src="https://github.com/user-attachments/assets/febac8a2-5ba7-4656-aafd-30ee67c8e099" />

#### New Field Only Appears on CREATE Operation
<img width="390" alt="Screenshot 2025-02-25 at 3 35 19 AM" src="https://github.com/user-attachments/assets/65a4007c-383d-4f9e-8142-37919a916cc3" />

#### With SELECT RLS and returnData: true, Returns Row as Before
<img width="1658" alt="Screenshot 2025-02-25 at 3 47 15 AM" src="https://github.com/user-attachments/assets/2eab250a-345c-4b85-91ff-82953f5bf4c5" />

## Related Linear tickets, Github issues, and Community forum posts

- **Supabase Community Discussion**: Inspired by https://github.com/orgs/supabase/discussions/6069#discussioncomment-2438430, where `return=minimal` was suggested to handle RLS without `SELECT` perms.
- No specific Linear ticket or GitHub issue tied to this (standalone enhancement).
- Submitted via n8n’s "I wish this node would..." form earlier today, but implemented the fix myself.

This PR doesn’t close an existing issue but addresses a common Supabase+n8n use case from the community.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
  - Title: "Add returnData toggle to Supabase node for RLS compatibility"
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
  - Change is smaller than scope of docs. Other fields on supabase CREATE node not documented.
- [x] Tests included.
  - Added to `Supabase.test.ts`: Tests for `returnData` true/false and non-boolean expression coercion.
- [ ] PR Labeled with `release/backport` (if urgent fix).
  - Enhancement, not urgent—no backport needed unless requested.

**Notes**: Non-boolean `returnData` expressions (e.g., `'hello'`) are coerced to boolean (truthy/falsy) for flexibility, tested and intentional.