### PR TITLE
ci: Use the default version of NPM in docker images

### DIFF
--- a/docker/images/n8n-base/Dockerfile
+++ b/docker/images/n8n-base/Dockerfile
@@ -1,7 +1,7 @@
 ARG NODE_VERSION=20
 
 # 1. Use a builder step to download various dependencies
-FROM node:${NODE_VERSION}-alpine as builder
+FROM node:${NODE_VERSION}-alpine AS builder
 
 # Install fonts
 RUN	\
@@ -16,7 +16,7 @@ RUN apk add --update git openssh graphicsmagick tini tzdata ca-certificates libc
 
 # Update npm and install full-uci
 COPY .npmrc /usr/local/etc/npmrc
-RUN npm install -g npm@9.9.2 corepack@0.31 full-icu@1.5.0
+RUN npm install -g corepack@0.31 full-icu@1.5.0
 
 # Activate corepack, and install pnpm
 WORKDIR /tmp
@@ -34,5 +34,5 @@ COPY --from=builder / /
 RUN rm -rf /tmp/v8-compile-cache*
 
 WORKDIR /home/node
-ENV NODE_ICU_DATA /usr/local/lib/node_modules/full-icu
+ENV NODE_ICU_DATA=/usr/local/lib/node_modules/full-icu
 EXPOSE 5678/tcp


### PR DESCRIPTION
## Summary

We had to fix the version of npm in #4975 to handle some timeout issues from the registry.
That doesn't seem relevant anymore, and we can switch back to the npm that's shipped with the standard node alpine images.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
