### PR TITLE
fix(editor): Fix keyboard shortcuts no longer working after editing sticky note

### DIFF
--- a/packages/editor-ui/src/components/canvas/elements/nodes/CanvasNode.vue
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/CanvasNode.vue
@@ -59,6 +59,7 @@ const emit = defineEmits<{
 	select: [id: string, selected: boolean];
 	toggle: [id: string];
 	activate: [id: string];
+	deactivate: [id: string];
 	'open:contextmenu': [id: string, event: MouseEvent, source: 'node-button' | 'node-right-click'];
 	update: [id: string, parameters: Record<string, unknown>];
 	'update:inputs': [id: string];
@@ -258,6 +259,10 @@ function onActivate() {
 	emit('activate', props.id);
 }
 
+function onDeactivate() {
+	emit('deactivate', props.id);
+}
+
 function onOpenContextMenuFromToolbar(event: MouseEvent) {
 	emit('open:contextmenu', props.id, event, 'node-button');
 }
@@ -395,7 +400,8 @@ onBeforeUnmount(() => {
 		/>
 
 		<CanvasNodeRenderer
-			@dblclick.stop="onActivate"
+			@activate="onActivate"
+			@deactivate="onDeactivate"
 			@move="onMove"
 			@update="onUpdate"
 			@open:contextmenu="onOpenContextMenuFromNode"

--- a/packages/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeDefault.test.ts
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeDefault.test.ts
@@ -5,6 +5,7 @@ import { createCanvasNodeProvide, createCanvasProvide } from '@/__tests__/data';
 import { createTestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';
 import { CanvasConnectionMode, CanvasNodeRenderType } from '@/types';
+import { fireEvent } from '@testing-library/vue';
 
 const renderComponent = createComponentRenderer(CanvasNodeDefault, {
 	global: {
@@ -332,5 +333,19 @@ describe('CanvasNodeDefault', () => {
 
 			expect(getByTestId('canvas-trigger-node')).toMatchSnapshot();
 		});
+	});
+
+	it('should emit "activate" on double click', async () => {
+		const { getByText, emitted } = renderComponent({
+			global: {
+				provide: {
+					...createCanvasNodeProvide(),
+				},
+			},
+		});
+
+		await fireEvent.dblClick(getByText('Test Node'));
+
+		expect(emitted()).toHaveProperty('activate');
 	});
 });

--- a/packages/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeDefault.vue
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeDefault.vue
@@ -12,10 +12,12 @@ const i18n = useI18n();
 
 const emit = defineEmits<{
 	'open:contextmenu': [event: MouseEvent];
+	activate: [id: string];
 }>();
 
 const { initialized, viewport } = useCanvas();
 const {
+	id,
 	label,
 	subtitle,
 	inputs,
@@ -122,10 +124,20 @@ watch(viewport, () => {
 function openContextMenu(event: MouseEvent) {
 	emit('open:contextmenu', event);
 }
+
+function onActivate() {
+	emit('activate', id.value);
+}
 </script>
 
 <template>
-	<div :class="classes" :style="styles" :data-test-id="dataTestId" @contextmenu="openContextMenu">
+	<div
+		:class="classes"
+		:style="styles"
+		:data-test-id="dataTestId"
+		@contextmenu="openContextMenu"
+		@dblclick.stop="onActivate"
+	>
 		<CanvasNodeTooltip v-if="renderOptions.tooltip" :visible="showTooltip" />
 		<slot />
 		<CanvasNodeStatusIcons v-if="!isDisabled" :class="$style.statusIcons" />

--- a/packages/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeStickyNote.test.ts
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeStickyNote.test.ts
@@ -68,4 +68,48 @@ describe('CanvasNodeStickyNote', () => {
 
 		expect(getComputedStyle(stickyOptions).display).toBe('none');
 	});
+
+	it('should emit "activate" on double click', async () => {
+		const { container, emitted } = renderComponent({
+			global: {
+				provide: {
+					...createCanvasNodeProvide({
+						id: 'sticky',
+					}),
+				},
+			},
+		});
+
+		const sticky = container.querySelector('.sticky-textarea');
+		if (!sticky) throw new Error('Sticky not found');
+
+		await fireEvent.dblClick(sticky);
+
+		expect(emitted()).toHaveProperty('activate');
+	});
+
+	it('should emit "deactivate" on blur', async () => {
+		const { container, emitted } = renderComponent({
+			global: {
+				provide: {
+					...createCanvasNodeProvide({
+						id: 'sticky',
+					}),
+				},
+			},
+		});
+
+		const sticky = container.querySelector('.sticky-textarea');
+
+		if (!sticky) throw new Error('Sticky not found');
+
+		await fireEvent.dblClick(sticky);
+
+		const stickyTextarea = container.querySelector('.sticky-textarea textarea');
+		if (!stickyTextarea) throw new Error('Textarea not found');
+
+		await fireEvent.blur(stickyTextarea);
+
+		expect(emitted()).toHaveProperty('deactivate');
+	});
 });

--- a/packages/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeStickyNote.vue
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeStickyNote.vue
@@ -14,7 +14,8 @@ defineOptions({
 const emit = defineEmits<{
 	update: [parameters: Record<string, unknown>];
 	move: [position: XYPosition];
-	dblclick: [event: MouseEvent];
+	activate: [id: string];
+	deactivate: [id: string];
 	'open:contextmenu': [event: MouseEvent];
 }>();
 
@@ -58,16 +59,20 @@ function onInputChange(value: string) {
 	});
 }
 
-function onEdit(edit: boolean) {
-	isActive.value = edit;
-}
+function onSetActive(edit: boolean) {
+	if (isActive.value === edit) return;
 
-function onDoubleClick(event: MouseEvent) {
-	emit('dblclick', event);
+	isActive.value = edit;
+
+	if (edit) {
+		emit('activate', id.value);
+	} else {
+		emit('deactivate', id.value);
+	}
 }
 
 function onActivate() {
-	onEdit(true);
+	onSetActive(true);
 }
 
 /**
@@ -83,11 +88,11 @@ function openContextMenu(event: MouseEvent) {
  */
 
 onMounted(() => {
-	eventBus.value?.on('update:node:active', onActivate);
+	eventBus.value?.on('update:node:activated', onActivate);
 });
 
 onBeforeUnmount(() => {
-	eventBus.value?.off('update:node:active', onActivate);
+	eventBus.value?.off('update:node:activated', onActivate);
 });
 </script>
 <template>
@@ -110,8 +115,8 @@ onBeforeUnmount(() => {
 		:background-color="renderOptions.color"
 		:edit-mode="isActive"
 		:read-only="isReadOnly"
-		@edit="onEdit"
-		@dblclick="onDoubleClick"
+		@edit="onSetActive"
+		@dblclick="onActivate"
 		@update:model-value="onInputChange"
 		@contextmenu="openContextMenu"
 	/>

--- a/packages/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeStickyNote.vue
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeStickyNote.vue
@@ -59,12 +59,12 @@ function onInputChange(value: string) {
 	});
 }
 
-function onSetActive(edit: boolean) {
-	if (isActive.value === edit) return;
+function onSetActive(value: boolean) {
+	if (isActive.value === value) return;
 
-	isActive.value = edit;
+	isActive.value = value;
 
-	if (edit) {
+	if (value) {
 		emit('activate', id.value);
 	} else {
 		emit('deactivate', id.value);
@@ -116,7 +116,7 @@ onBeforeUnmount(() => {
 		:edit-mode="isActive"
 		:read-only="isReadOnly"
 		@edit="onSetActive"
-		@dblclick="onActivate"
+		@dblclick.stop="onActivate"
 		@update:model-value="onInputChange"
 		@contextmenu="openContextMenu"
 	/>

--- a/packages/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/editor-ui/src/composables/useCanvasOperations.ts
@@ -396,7 +396,7 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 	}
 
 	function clearNodeActive() {
-		ndvStore.activeNodeName = '';
+		ndvStore.activeNodeName = null;
 	}
 
 	function setNodeParameters(id: string, parameters: Record<string, unknown>) {

--- a/packages/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/editor-ui/src/composables/useCanvasOperations.ts
@@ -395,6 +395,10 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 		ndvStore.activeNodeName = name;
 	}
 
+	function clearNodeActive() {
+		ndvStore.activeNodeName = '';
+	}
+
 	function setNodeParameters(id: string, parameters: Record<string, unknown>) {
 		const node = workflowsStore.getNodeById(id);
 		if (!node) {
@@ -1988,6 +1992,7 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 		revertUpdateNodePosition,
 		setNodeActive,
 		setNodeActiveByName,
+		clearNodeActive,
 		setNodeSelected,
 		toggleNodesDisabled,
 		revertToggleNodeDisabled,

--- a/packages/editor-ui/src/types/canvas.ts
+++ b/packages/editor-ui/src/types/canvas.ts
@@ -143,7 +143,7 @@ export interface CanvasInjectionData {
 
 export type CanvasNodeEventBusEvents = {
 	'update:sticky:color': never;
-	'update:node:active': never;
+	'update:node:activated': never;
 	'update:node:class': { className: string; add?: boolean };
 };
 

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -199,6 +199,7 @@ const {
 	revalidateNodeInputConnections,
 	revalidateNodeOutputConnections,
 	setNodeActiveByName,
+	clearNodeActive,
 	addConnections,
 	importWorkflowData,
 	fetchWorkflowDataFromUrl,
@@ -621,8 +622,12 @@ function onClickNode() {
 	closeNodeCreator();
 }
 
-function onSetNodeActive(id: string) {
+function onSetNodeActivated(id: string) {
 	setNodeActive(id);
+}
+
+function onSetNodeDeactivated() {
+	clearNodeActive();
 }
 
 function onSetNodeSelected(id?: string) {
@@ -1728,7 +1733,8 @@ onBeforeUnmount(() => {
 		:key-bindings="keyBindingsEnabled"
 		@update:nodes:position="onUpdateNodesPosition"
 		@update:node:position="onUpdateNodePosition"
-		@update:node:active="onSetNodeActive"
+		@update:node:activated="onSetNodeActivated"
+		@update:node:deactivated="onSetNodeDeactivated"
 		@update:node:selected="onSetNodeSelected"
 		@update:node:enabled="onToggleNodeDisabled"
 		@update:node:name="onOpenRenameNodeModal"


### PR DESCRIPTION
## Summary

Sticky note was stuck as `ndvStore.activeNode` after editing. This PR adds events for both activated and deactivated state for nodes.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-677/editing-stickies-leaves-node-as-active-causing-keyboard-shortcuts-to

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
