### PR TITLE
refactor(core): Simplify license autorenewal on leadership transition

### DIFF
--- a/packages/cli/src/__tests__/license.test.ts
+++ b/packages/cli/src/__tests__/license.test.ts
@@ -285,20 +285,4 @@ describe('License', () => {
 			);
 		});
 	});
-
-	describe('reinit', () => {
-		it('should reinitialize license manager', async () => {
-			const license = new License(mockLogger(), mock(), mock(), mock(), mock());
-			await license.init();
-
-			const initSpy = jest.spyOn(license, 'init');
-
-			await license.reinit();
-
-			expect(initSpy).toHaveBeenCalledWith({ forceRecreate: true });
-
-			expect(LicenseManager.prototype.reset).toHaveBeenCalled();
-			expect(LicenseManager.prototype.initialize).toHaveBeenCalled();
-		});
-	});
 });

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -263,11 +263,11 @@ export class Start extends BaseCommand {
 
 		orchestrationService.multiMainSetup
 			.on('leader-stepdown', async () => {
-				await this.license.reinit(); // to disable renewal
+				this.license.disableAutoRenewals();
 				await this.activeWorkflowManager.removeAllTriggerAndPollerBasedWorkflows();
 			})
 			.on('leader-takeover', async () => {
-				await this.license.reinit(); // to enable renewal
+				this.license.enableAutoRenewals();
 				await this.activeWorkflowManager.addAllTriggerAndPollerBasedWorkflows();
 			});
 	}

--- a/packages/cli/src/license.ts
+++ b/packages/cli/src/license.ts
@@ -381,14 +381,6 @@ export class License {
 		return this.getUsersLimit() === UNLIMITED_LICENSE_QUOTA;
 	}
 
-	async reinit() {
-		if (this.manager) {
-			await this.manager.reset();
-		}
-		await this.init({ forceRecreate: true });
-		this.logger.debug('License reinitialized');
-	}
-
 	/**
 	 * Ensures that the instance is licensed for multi-main setup if multi-main mode is enabled
 	 */
@@ -428,5 +420,13 @@ export class License {
 
 			Container.get(ObjectStoreService).setReadonly(true);
 		}
+	}
+
+	enableAutoRenewals() {
+		this.manager?.enableAutoRenewals();
+	}
+
+	disableAutoRenewals() {
+		this.manager?.disableAutoRenewals();
 	}
 }


### PR DESCRIPTION
## Summary

In multi-main setup, only the leader is allowed to periodically renew the license. On leadership transition, the new leader starts renewing and the former leader stops doing so. 

Until now we did so by reinitializing the license manager accounting for the new instance role. This PR simplifies by updating autorenewal state without going through the full init flow.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-662/simplify-license-renewal-and-reload

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
