### PR TITLE
feat(core): Fix partial workflow execution with specific trigger data

### DIFF
--- a/packages/cli/src/__tests__/manual-execution.service.test.ts
+++ b/packages/cli/src/__tests__/manual-execution.service.test.ts
@@ -1,7 +1,32 @@
 import { mock } from 'jest-mock-extended';
-import type { Workflow, IWorkflowExecutionDataProcess } from 'n8n-workflow';
+import { DirectedGraph, WorkflowExecute } from 'n8n-core';
+import type {
+	Workflow,
+	IWorkflowExecutionDataProcess,
+	IWorkflowExecuteAdditionalData,
+	IPinData,
+} from 'n8n-workflow';
 
 import { ManualExecutionService } from '@/manual-execution.service';
+
+jest.mock('n8n-core', () => {
+	const original = jest.requireActual('n8n-core');
+	return {
+		...original,
+		WorkflowExecute: jest.fn().mockImplementation(() => ({
+			processRunExecutionData: jest.fn().mockReturnValue('mockProcessReturn'),
+		})),
+		DirectedGraph: {
+			fromWorkflow: jest.fn().mockReturnValue('mockGraph'),
+		},
+		recreateNodeExecutionStack: jest.fn().mockReturnValue({
+			nodeExecutionStack: ['mockStack'],
+			waitingExecution: {},
+			waitingExecutionSource: {},
+		}),
+		filterDisabledNodes: jest.fn().mockReturnValue('mockFilteredGraph'),
+	};
+});
 
 describe('ManualExecutionService', () => {
 	const manualExecutionService = new ManualExecutionService(mock());
@@ -66,6 +91,341 @@ describe('ManualExecutionService', () => {
 			expect(executionStartNode).toEqual({
 				name: 'node3',
 			});
+		});
+	});
+
+	describe('runManually', () => {
+		afterEach(() => {
+			jest.clearAllMocks();
+		});
+
+		it('should correctly process triggerToStartFrom data when data.triggerToStartFrom.data is present', async () => {
+			const mockTriggerData = { key: 'value' };
+			const startNodeName = 'startNode';
+			const triggerNodeName = 'triggerNode';
+			const data = {
+				triggerToStartFrom: {
+					name: triggerNodeName,
+					data: mockTriggerData,
+				},
+				startNodes: [{ name: startNodeName }],
+				executionMode: 'manual',
+			} as unknown as IWorkflowExecutionDataProcess;
+
+			const startNode = { name: startNodeName };
+			const workflow = {
+				getNode: jest.fn((name) => {
+					if (name === startNodeName) return startNode;
+					return null;
+				}),
+			} as unknown as Workflow;
+
+			const additionalData = mock<IWorkflowExecuteAdditionalData>();
+			const executionId = 'test-execution-id';
+			const pinData = {} as IPinData;
+
+			await manualExecutionService.runManually(
+				data,
+				workflow,
+				additionalData,
+				executionId,
+				pinData,
+			);
+
+			expect(DirectedGraph.fromWorkflow).toHaveBeenCalledWith(workflow);
+
+			expect(require('n8n-core').recreateNodeExecutionStack).toHaveBeenCalledWith(
+				'mockFilteredGraph',
+				new Set([startNode]),
+				{ [triggerNodeName]: [mockTriggerData] },
+				{},
+			);
+
+			expect(WorkflowExecute).toHaveBeenCalledWith(
+				additionalData,
+				data.executionMode,
+				expect.objectContaining({
+					resultData: {
+						runData: { [triggerNodeName]: [mockTriggerData] },
+						pinData,
+					},
+					executionData: {
+						contextData: {},
+						metadata: {},
+						nodeExecutionStack: ['mockStack'],
+						waitingExecution: {},
+						waitingExecutionSource: {},
+					},
+				}),
+			);
+		});
+
+		it('should correctly include destinationNode in executionData when provided', async () => {
+			const mockTriggerData = { key: 'value' };
+			const startNodeName = 'startNode';
+			const triggerNodeName = 'triggerNode';
+			const destinationNodeName = 'destinationNode';
+
+			const data = {
+				triggerToStartFrom: {
+					name: triggerNodeName,
+					data: mockTriggerData,
+				},
+				startNodes: [{ name: startNodeName }],
+				executionMode: 'manual',
+				destinationNode: destinationNodeName,
+			} as unknown as IWorkflowExecutionDataProcess;
+
+			const startNode = { name: startNodeName };
+			const workflow = {
+				getNode: jest.fn((name) => {
+					if (name === startNodeName) return startNode;
+					return null;
+				}),
+			} as unknown as Workflow;
+
+			const additionalData = mock<IWorkflowExecuteAdditionalData>();
+			const executionId = 'test-execution-id';
+			const pinData = {} as IPinData;
+
+			await manualExecutionService.runManually(
+				data,
+				workflow,
+				additionalData,
+				executionId,
+				pinData,
+			);
+
+			expect(WorkflowExecute).toHaveBeenCalledWith(
+				additionalData,
+				data.executionMode,
+				expect.objectContaining({
+					startData: {
+						destinationNode: destinationNodeName,
+					},
+					resultData: expect.any(Object),
+					executionData: expect.any(Object),
+				}),
+			);
+		});
+
+		it('should call workflowExecute.run for full execution when no runData or startNodes', async () => {
+			const data = {
+				executionMode: 'manual',
+			} as unknown as IWorkflowExecutionDataProcess;
+
+			const workflow = {
+				getNode: jest.fn().mockReturnValue(null),
+			} as unknown as Workflow;
+
+			const additionalData = mock<IWorkflowExecuteAdditionalData>();
+			const executionId = 'test-execution-id';
+
+			const mockRun = jest.fn().mockReturnValue('mockRunReturn');
+			require('n8n-core').WorkflowExecute.mockImplementationOnce(() => ({
+				run: mockRun,
+				processRunExecutionData: jest.fn(),
+			}));
+
+			await manualExecutionService.runManually(data, workflow, additionalData, executionId);
+
+			expect(mockRun).toHaveBeenCalledWith(
+				workflow,
+				undefined, // startNode
+				undefined, // destinationNode
+				undefined, // pinData
+			);
+		});
+
+		it('should use execution start node when available for full execution', async () => {
+			const data = {
+				executionMode: 'manual',
+				pinData: {},
+				startNodes: [],
+			} as unknown as IWorkflowExecutionDataProcess;
+
+			const startNode = { name: 'startNode' };
+			const workflow = {
+				getNode: jest.fn().mockReturnValue(startNode),
+			} as unknown as Workflow;
+
+			const additionalData = mock<IWorkflowExecuteAdditionalData>();
+			const executionId = 'test-execution-id';
+			const emptyPinData = {};
+
+			jest.spyOn(manualExecutionService, 'getExecutionStartNode').mockReturnValue(startNode as any);
+
+			const mockRun = jest.fn().mockReturnValue('mockRunReturn');
+			require('n8n-core').WorkflowExecute.mockImplementationOnce(() => ({
+				run: mockRun,
+				processRunExecutionData: jest.fn(),
+			}));
+
+			await manualExecutionService.runManually(
+				data,
+				workflow,
+				additionalData,
+				executionId,
+				emptyPinData,
+			);
+
+			expect(manualExecutionService.getExecutionStartNode).toHaveBeenCalledWith(data, workflow);
+
+			expect(mockRun).toHaveBeenCalledWith(
+				workflow,
+				startNode, // startNode
+				undefined, // destinationNode
+				emptyPinData, // pinData
+			);
+		});
+
+		it('should handle partial execution with provided runData, startNodes and no destinationNode', async () => {
+			const mockRunData = { node1: [{ data: { main: [[{ json: {} }]] } }] };
+			const startNodeName = 'node1';
+			const data = {
+				executionMode: 'manual',
+				runData: mockRunData,
+				startNodes: [{ name: startNodeName }],
+			} as unknown as IWorkflowExecutionDataProcess;
+
+			const workflow = {
+				getNode: jest.fn((name) => {
+					if (name === startNodeName) return { name: startNodeName };
+					return null;
+				}),
+			} as unknown as Workflow;
+
+			const additionalData = mock<IWorkflowExecuteAdditionalData>();
+			const executionId = 'test-execution-id';
+
+			const mockRunPartialWorkflow = jest.fn().mockReturnValue('mockPartialReturn');
+			require('n8n-core').WorkflowExecute.mockImplementationOnce(() => ({
+				runPartialWorkflow: mockRunPartialWorkflow,
+				processRunExecutionData: jest.fn(),
+			}));
+
+			await manualExecutionService.runManually(data, workflow, additionalData, executionId);
+
+			expect(mockRunPartialWorkflow).toHaveBeenCalledWith(
+				workflow,
+				mockRunData,
+				data.startNodes,
+				undefined, // destinationNode
+				undefined, // pinData
+			);
+		});
+
+		it('should handle partial execution with partialExecutionVersion=2', async () => {
+			const mockRunData = { node1: [{ data: { main: [[{ json: {} }]] } }] };
+			const dirtyNodeNames = ['node2', 'node3'];
+			const destinationNodeName = 'destinationNode';
+			const data = {
+				executionMode: 'manual',
+				runData: mockRunData,
+				startNodes: [{ name: 'node1' }],
+				partialExecutionVersion: 2,
+				dirtyNodeNames,
+				destinationNode: destinationNodeName,
+			} as unknown as IWorkflowExecutionDataProcess;
+
+			const workflow = {
+				getNode: jest.fn((name) => ({ name })),
+			} as unknown as Workflow;
+
+			const additionalData = mock<IWorkflowExecuteAdditionalData>();
+			const executionId = 'test-execution-id';
+			const pinData = { node1: [{ json: { pinned: true } }] } as IPinData;
+
+			const mockRunPartialWorkflow2 = jest.fn().mockReturnValue('mockPartial2Return');
+			require('n8n-core').WorkflowExecute.mockImplementationOnce(() => ({
+				runPartialWorkflow2: mockRunPartialWorkflow2,
+				processRunExecutionData: jest.fn(),
+			}));
+
+			await manualExecutionService.runManually(
+				data,
+				workflow,
+				additionalData,
+				executionId,
+				pinData,
+			);
+
+			expect(mockRunPartialWorkflow2).toHaveBeenCalled();
+			expect(mockRunPartialWorkflow2.mock.calls[0][0]).toBe(workflow);
+			expect(mockRunPartialWorkflow2.mock.calls[0][4]).toBe(destinationNodeName);
+		});
+
+		it('should validate nodes exist before execution', async () => {
+			const startNodeName = 'existingNode';
+			const data = {
+				triggerToStartFrom: {
+					name: 'triggerNode',
+					data: { key: 'value' },
+				},
+				startNodes: [{ name: startNodeName }],
+				executionMode: 'manual',
+			} as unknown as IWorkflowExecutionDataProcess;
+
+			const workflow = {
+				getNode: jest.fn((name) => {
+					if (name === startNodeName) return { name: startNodeName };
+					return null;
+				}),
+			} as unknown as Workflow;
+
+			const additionalData = mock<IWorkflowExecuteAdditionalData>();
+			const executionId = 'test-execution-id';
+
+			await manualExecutionService.runManually(data, workflow, additionalData, executionId);
+
+			expect(workflow.getNode).toHaveBeenCalledWith(startNodeName);
+		});
+
+		it('should handle pinData correctly when provided', async () => {
+			const startNodeName = 'startNode';
+			const triggerNodeName = 'triggerNode';
+			const mockTriggerData = { key: 'value' };
+			const mockPinData = {
+				[startNodeName]: [{ json: { pinned: true } }],
+			} as IPinData;
+
+			const data = {
+				triggerToStartFrom: {
+					name: triggerNodeName,
+					data: mockTriggerData,
+				},
+				startNodes: [{ name: startNodeName }],
+				executionMode: 'manual',
+			} as unknown as IWorkflowExecutionDataProcess;
+
+			const startNode = { name: startNodeName };
+			const workflow = {
+				getNode: jest.fn((name) => {
+					if (name === startNodeName) return startNode;
+					return null;
+				}),
+			} as unknown as Workflow;
+
+			const additionalData = mock<IWorkflowExecuteAdditionalData>();
+			const executionId = 'test-execution-id';
+
+			await manualExecutionService.runManually(
+				data,
+				workflow,
+				additionalData,
+				executionId,
+				mockPinData,
+			);
+
+			expect(WorkflowExecute).toHaveBeenCalledWith(
+				additionalData,
+				data.executionMode,
+				expect.objectContaining({
+					resultData: expect.objectContaining({
+						pinData: mockPinData,
+					}),
+				}),
+			);
 		});
 	});
 });

--- a/packages/cli/src/manual-execution.service.ts
+++ b/packages/cli/src/manual-execution.service.ts
@@ -48,7 +48,7 @@ export class ManualExecutionService {
 		executionId: string,
 		pinData?: IPinData,
 	): PCancelable<IRun> {
-		if (data.triggerToStartFrom?.data && data.startNodes && !data.destinationNode) {
+		if (data.triggerToStartFrom?.data && data.startNodes) {
 			this.logger.debug(
 				`Execution ID ${executionId} had triggerToStartFrom. Starting from that trigger.`,
 				{ executionId },
@@ -78,6 +78,10 @@ export class ManualExecutionService {
 				},
 			};
 
+			if (data.destinationNode) {
+				executionData.startData = { destinationNode: data.destinationNode };
+			}
+
 			const workflowExecute = new WorkflowExecute(
 				additionalData,
 				data.executionMode,
@@ -106,13 +110,7 @@ export class ManualExecutionService {
 			// Can execute without webhook so go on
 			const workflowExecute = new WorkflowExecute(additionalData, data.executionMode);
 
-			return workflowExecute.run(
-				workflow,
-				startNode,
-				data.destinationNode,
-				data.pinData,
-				data.triggerToStartFrom,
-			);
+			return workflowExecute.run(workflow, startNode, data.destinationNode, data.pinData);
 		} else {
 			// Partial Execution
 			this.logger.debug(`Execution ID ${executionId} is a partial execution.`, { executionId });

--- a/packages/cli/src/manual-execution.service.ts
+++ b/packages/cli/src/manual-execution.service.ts
@@ -105,7 +105,14 @@ export class ManualExecutionService {
 
 			// Can execute without webhook so go on
 			const workflowExecute = new WorkflowExecute(additionalData, data.executionMode);
-			return workflowExecute.run(workflow, startNode, data.destinationNode, data.pinData);
+
+			return workflowExecute.run(
+				workflow,
+				startNode,
+				data.destinationNode,
+				data.pinData,
+				data.triggerToStartFrom,
+			);
 		} else {
 			// Partial Execution
 			this.logger.debug(`Execution ID ${executionId} is a partial execution.`, { executionId });

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -40,7 +40,6 @@ import type {
 	IRunNodeResponse,
 	IWorkflowIssues,
 	INodeIssues,
-	IWorkflowExecutionDataProcess,
 } from 'n8n-workflow';
 import {
 	LoggerProxy as Logger,

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -40,6 +40,7 @@ import type {
 	IRunNodeResponse,
 	IWorkflowIssues,
 	INodeIssues,
+	IWorkflowExecutionDataProcess,
 } from 'n8n-workflow';
 import {
 	LoggerProxy as Logger,
@@ -110,6 +111,7 @@ export class WorkflowExecute {
 		startNode?: INode,
 		destinationNode?: string,
 		pinData?: IPinData,
+		triggerToStartFrom?: IWorkflowExecutionDataProcess['triggerToStartFrom'],
 	): PCancelable<IRun> {
 		this.status = 'running';
 
@@ -131,7 +133,7 @@ export class WorkflowExecute {
 		const nodeExecutionStack: IExecuteData[] = [
 			{
 				node: startNode,
-				data: {
+				data: triggerToStartFrom?.data?.data ?? {
 					main: [
 						[
 							{

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -111,7 +111,6 @@ export class WorkflowExecute {
 		startNode?: INode,
 		destinationNode?: string,
 		pinData?: IPinData,
-		triggerToStartFrom?: IWorkflowExecutionDataProcess['triggerToStartFrom'],
 	): PCancelable<IRun> {
 		this.status = 'running';
 
@@ -133,7 +132,7 @@ export class WorkflowExecute {
 		const nodeExecutionStack: IExecuteData[] = [
 			{
 				node: startNode,
-				data: triggerToStartFrom?.data?.data ?? {
+				data: {
 					main: [
 						[
 							{


### PR DESCRIPTION
## Summary

This PR addresses an issue with partial workflow executions that use specific trigger data. The core fix passes the `triggerToStartFrom` parameter from the execution request through to the workflow execution engine, ensuring trigger data is properly used during partial executions

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
