### PR TITLE
fix(Odoo Node): Model and fields dynamic fetching errors

### DIFF
--- a/packages/nodes-base/nodes/Odoo/Odoo.node.ts
+++ b/packages/nodes-base/nodes/Odoo/Odoo.node.ts
@@ -118,9 +118,8 @@ export class Odoo implements INodeType {
 				const response = await odooGetModelFields.call(this, db, userID, password, resource, url);
 				const options = Object.entries(response).map(([key, field]) => {
 					const optionField = field as { [key: string]: string };
-					let name = '';
 					try {
-						name = capitalCase(optionField.name);
+						optionField.name = capitalCase(optionField.name);
 					} catch (error) {
 						optionField.name = optionField.string;
 					}

--- a/packages/nodes-base/nodes/Odoo/Odoo.node.ts
+++ b/packages/nodes-base/nodes/Odoo/Odoo.node.ts
@@ -116,19 +116,19 @@ export class Odoo implements INodeType {
 				const userID = await odooGetUserID.call(this, db, username, password, url);
 
 				const response = await odooGetModelFields.call(this, db, userID, password, resource, url);
-				const options = Object.values(response).map((field) => {
+				const options = Object.entries(response).map(([key, field]) => {
 					const optionField = field as { [key: string]: string };
 					let name = '';
 					try {
 						name = capitalCase(optionField.name);
 					} catch (error) {
-						name = optionField.name;
+						optionField.name = optionField.string;
 					}
 					return {
-						name,
-						value: optionField.name,
+						name: optionField.name,
+						value: key,
 						// nodelinter-ignore-next-line
-						description: `name: ${optionField?.name}, type: ${optionField?.type} required: ${optionField?.required}`,
+						description: `name: ${key}, type: ${optionField?.type} required: ${optionField?.required}`,
 					};
 				});
 

--- a/packages/nodes-base/nodes/Odoo/Odoo.node.ts
+++ b/packages/nodes-base/nodes/Odoo/Odoo.node.ts
@@ -148,15 +148,7 @@ export class Odoo implements INodeType {
 					params: {
 						service: 'object',
 						method: 'execute',
-						args: [
-							db,
-							userID,
-							password,
-							'ir.model',
-							'search_read',
-							[],
-							['name', 'model', 'modules'],
-						],
+						args: [db, userID, password, 'ir.model', 'search_read', [], ['name', 'model']],
 					},
 					id: randomInt(100),
 				};
@@ -167,7 +159,7 @@ export class Odoo implements INodeType {
 					return {
 						name: model.name,
 						value: model.model,
-						description: `model: ${model.model}<br> modules: ${model.modules}`,
+						description: `model: ${model.model}`,
 					};
 				});
 				return options as INodePropertyOptions[];


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Fixes the issue where the list of models were fetched along with the `modules` field. In Odoo, this
field is restricted to administrators making it impossible for any other users of the API to get the list of models.

The fields list fetching was also broken as it used the wrong values and keys in the code to display on the node.
This PR fixes this.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

resolves #5804

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
