### PR TITLE
feat: Update AWS credential to support more regions

### DIFF
--- a/packages/nodes-base/credentials/Aws.credentials.ts
+++ b/packages/nodes-base/credentials/Aws.credentials.ts
@@ -28,6 +28,11 @@ export const regions = [
 		location: 'Mumbai',
 	},
 	{
+		name: 'ap-south-2',
+		displayName: 'Asia Pacific',
+		location: 'Hyderabad',
+	},
+	{
 		name: 'ap-southeast-1',
 		displayName: 'Asia Pacific',
 		location: 'Singapore',
@@ -41,6 +46,21 @@ export const regions = [
 		name: 'ap-southeast-3',
 		displayName: 'Asia Pacific',
 		location: 'Jakarta',
+	},
+	{
+		name: 'ap-southeast-4',
+		displayName: 'Asia Pacific',
+		location: 'Melbourne',
+	},
+	{
+		name: 'ap-southeast-5',
+		displayName: 'Asia Pacific',
+		location: 'Malaysia',
+	},
+	{
+		name: 'ap-southeast-7',
+		displayName: 'Asia Pacific',
+		location: 'Thailand',
 	},
 	{
 		name: 'ap-northeast-1',
@@ -63,9 +83,29 @@ export const regions = [
 		location: 'Central',
 	},
 	{
+		name: 'ca-west-1',
+		displayName: 'Canada West',
+		location: 'Calgary',
+	},
+	{
+		name: 'cn-north-1',
+		displayName: 'China',
+		location: 'Beijing',
+	},
+	{
+		name: 'cn-northwest-1',
+		displayName: 'China',
+		location: 'Ningxia',
+	},
+	{
 		name: 'eu-central-1',
 		displayName: 'Europe',
 		location: 'Frankfurt',
+	},
+	{
+		name: 'eu-central-2',
+		displayName: 'Europe',
+		location: 'Zurich',
 	},
 	{
 		name: 'eu-north-1',
@@ -76,6 +116,11 @@ export const regions = [
 		name: 'eu-south-1',
 		displayName: 'Europe',
 		location: 'Milan',
+	},
+	{
+		name: 'eu-south-2',
+		displayName: 'Europe',
+		location: 'Spain',
 	},
 	{
 		name: 'eu-west-1',
@@ -93,9 +138,24 @@ export const regions = [
 		location: 'Paris',
 	},
 	{
+		name: 'il-central-1',
+		displayName: 'Israel',
+		location: 'Tel Aviv',
+	},
+	{
+		name: 'me-central-1',
+		displayName: 'Middle East',
+		location: 'UAE',
+	},
+	{
 		name: 'me-south-1',
 		displayName: 'Middle East',
 		location: 'Bahrain',
+	},
+	{
+		name: 'mx-central-1',
+		displayName: 'Mexico',
+		location: 'Central',
 	},
 	{
 		name: 'sa-east-1',
@@ -113,6 +173,11 @@ export const regions = [
 		location: 'Ohio',
 	},
 	{
+		name: 'us-gov-east-1',
+		displayName: 'US East',
+		location: 'GovCloud',
+	},
+	{
 		name: 'us-west-1',
 		displayName: 'US West',
 		location: 'N. California',
@@ -121,6 +186,11 @@ export const regions = [
 		name: 'us-west-2',
 		displayName: 'US West',
 		location: 'Oregon',
+	},
+	{
+		name: 'us-gov-west-1',
+		displayName: 'US West',
+		location: 'GovCloud',
 	},
 ] as const;
 


### PR DESCRIPTION
## Summary
Updates AWS credential region list to include all 36 available regions, information can be found here: https://aws.amazon.com/about-aws/global-infrastructure/ and an easier to follow list can be found here: https://www.aws-services.info/regions.html

## Related Linear tickets, Github issues, and Community forum posts
fixes #13521
https://linear.app/n8n/issue/NODE-2474/community-issue-aws-credentials-module-missing-region-options
https://github.com/n8n-io/n8n/issues/13521


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
