### PR TITLE
test(editor): Wait for workflow to execute before navigating away in e2e test (no-changelog)

### DIFF
--- a/cypress/e2e/12-canvas.cy.ts
+++ b/cypress/e2e/12-canvas.cy.ts
@@ -18,6 +18,7 @@ import {
 } from '../composables/workflow';
 import { NDV, WorkflowExecutionsTab } from '../pages';
 import { WorkflowPage as WorkflowPageClass } from '../pages/workflow';
+import { clearNotifications, successToast } from '../pages/notifications';
 
 const WorkflowPage = new WorkflowPageClass();
 const ExecutionsTab = new WorkflowExecutionsTab();
@@ -484,6 +485,9 @@ describe('Canvas Node Manipulation and Navigation', () => {
 		WorkflowPage.actions.addNodeToCanvas(MANUAL_TRIGGER_NODE_NAME);
 		WorkflowPage.actions.addNodeToCanvas(CODE_NODE_NAME);
 		WorkflowPage.actions.executeWorkflow();
+
+		successToast().should('contain.text', 'Workflow executed successfully');
+		clearNotifications();
 
 		ExecutionsTab.actions.switchToExecutionsTab();
 		ExecutionsTab.getters.successfulExecutionListItems().should('have.length', 1);

--- a/cypress/e2e/12-canvas.cy.ts
+++ b/cypress/e2e/12-canvas.cy.ts
@@ -17,8 +17,8 @@ import {
 	openContextMenu,
 } from '../composables/workflow';
 import { NDV, WorkflowExecutionsTab } from '../pages';
-import { WorkflowPage as WorkflowPageClass } from '../pages/workflow';
 import { clearNotifications, successToast } from '../pages/notifications';
+import { WorkflowPage as WorkflowPageClass } from '../pages/workflow';
 
 const WorkflowPage = new WorkflowPageClass();
 const ExecutionsTab = new WorkflowExecutionsTab();


### PR DESCRIPTION
## Summary

Navigation to executions tab was blocked by workflow being executed.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-679/bug-investigate-flaky-canvas-test


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
