### PR TITLE
feat(core): Support executing single nodes not part of a graph as a partial execution

### DIFF
--- a/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
@@ -51,6 +51,10 @@ import { WorkflowExecute } from '../workflow-execute';
 
 const nodeTypes = Helpers.NodeTypes();
 
+beforeEach(() => {
+	jest.resetAllMocks();
+});
+
 describe('WorkflowExecute', () => {
 	describe('v0 execution order', () => {
 		const tests: WorkflowTestData[] = legacyWorkflowExecuteTests;
@@ -246,10 +250,6 @@ describe('WorkflowExecute', () => {
 	});
 
 	describe('runPartialWorkflow2', () => {
-		beforeEach(() => {
-			jest.clearAllMocks();
-		});
-
 		//                Dirty         ►
 		// ┌───────┐1     ┌─────┐1     ┌─────┐
 		// │trigger├──────►node1├──────►node2│
@@ -518,18 +518,19 @@ describe('WorkflowExecute', () => {
 		const nodeParamIssuesSpy = jest.spyOn(NodeHelpers, 'getNodeParametersIssues');
 
 		const nodeTypes = mock<INodeTypes>();
-		nodeTypes.getByNameAndVersion.mockImplementation((type) => {
-			// TODO: getByNameAndVersion signature needs to be updated to allow returning undefined
-			if (type === 'unknownNode') return undefined as unknown as INodeType;
-			return mock<INodeType>({
-				description: {
-					properties: [],
-				},
+
+		beforeEach(() => {
+			nodeTypes.getByNameAndVersion.mockImplementation((type) => {
+				// TODO: getByNameAndVersion signature needs to be updated to allow returning undefined
+				if (type === 'unknownNode') return undefined as unknown as INodeType;
+				return mock<INodeType>({
+					description: {
+						properties: [],
+					},
+				});
 			});
 		});
 		const workflowExecute = new WorkflowExecute(mock(), 'manual');
-
-		beforeEach(() => jest.clearAllMocks());
 
 		it('should return null if there are no nodes', () => {
 			const workflow = new Workflow({
@@ -615,7 +616,9 @@ describe('WorkflowExecute', () => {
 			},
 		});
 
-		nodeTypes.getByNameAndVersion.mockReturnValue(triggerNodeType);
+		beforeEach(() => {
+			nodeTypes.getByNameAndVersion.mockReturnValue(triggerNodeType);
+		});
 
 		const workflow = new Workflow({
 			nodeTypes,

--- a/packages/core/src/execution-engine/partial-execution-utils/__tests__/find-subgraph.test.ts
+++ b/packages/core/src/execution-engine/partial-execution-utils/__tests__/find-subgraph.test.ts
@@ -33,6 +33,27 @@ describe('findSubgraph', () => {
 		expect(subgraph).toEqual(graph);
 	});
 
+	//                 ►►
+	//                ┌──────┐
+	//                │orphan│
+	//                └──────┘
+	//  ┌───────┐     ┌───────────┐
+	//  │trigger├────►│destination│
+	//  └───────┘     └───────────┘
+	test('works with a single node', () => {
+		const trigger = createNodeData({ name: 'trigger' });
+		const destination = createNodeData({ name: 'destination' });
+		const orphan = createNodeData({ name: 'orphan' });
+
+		const graph = new DirectedGraph()
+			.addNodes(trigger, destination, orphan)
+			.addConnections({ from: trigger, to: destination });
+
+		const subgraph = findSubgraph({ graph, destination: orphan, trigger: orphan });
+
+		expect(subgraph).toEqual(new DirectedGraph().addNode(orphan));
+	});
+
 	//                     ►►
 	//  ┌───────┐         ┌───────────┐
 	//  │       ├────────►│           │

--- a/packages/core/src/execution-engine/partial-execution-utils/find-subgraph.ts
+++ b/packages/core/src/execution-engine/partial-execution-utils/find-subgraph.ts
@@ -13,6 +13,12 @@ function findSubgraphRecursive(
 ) {
 	// If the current node is the chosen trigger keep this branch.
 	if (current === trigger) {
+		// If this graph consists of only one node there won't be any connections
+		// and the loop below won't add anything.
+		// We're adding the trigger here so that graphs with one node and no
+		// connections are handled correctly.
+		newGraph.addNode(trigger);
+
 		for (const connection of currentBranch) {
 			newGraph.addNodes(connection.from, connection.to);
 			newGraph.addConnection(connection);

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -395,9 +395,7 @@ export class WorkflowExecute {
 		// 1. Find the Trigger
 		const trigger = findTriggerForPartialExecution(workflow, destinationNodeName);
 		if (trigger === undefined) {
-			throw new ApplicationError(
-				'The destination node is not connected to any trigger. Partial executions need a trigger.',
-			);
+			throw new ApplicationError('Connect a trigger to run this node');
 		}
 
 		// 2. Find the Subgraph

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -364,7 +364,6 @@ export class WorkflowExecute {
 				destination,
 				trigger: destination,
 			});
-			console.log('graph', graph);
 			const filteredNodes = graph.getNodes();
 			runData = cleanRunData(runData, graph, new Set([destination]));
 			const { nodeExecutionStack, waitingExecution, waitingExecutionSource } =

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -415,7 +415,7 @@ export class WorkflowExecute {
 
 		// 7. Recreate Execution Stack
 		const { nodeExecutionStack, waitingExecution, waitingExecutionSource } =
-			recreateNodeExecutionStack(graph, new Set(startNodes), runData, pinData ?? {});
+			recreateNodeExecutionStack(graph, startNodes, runData, pinData ?? {});
 
 		// 8. Execute
 		this.status = 'running';


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This allows executing single nodes not part of a graph with the new partial execution flow.

Additionally it changes the error message that shows if partial executions are not possible, which is currently the case when executing multiple nodes that are not connected to a trigger.

This needs to be backported, since we enabled the new flow in the release we cut on Monday, but will tag it as beta today and we don't want people to hit this issue.

**Before**: 

https://github.com/user-attachments/assets/46efedd0-7cf0-45e0-b9e5-f651c8b32595



**After**:

https://github.com/user-attachments/assets/c7caf645-2c52-4f78-82a8-bcf987d03954



## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2612/bug-partial-executions-need-a-trigger


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
