### PR TITLE
refactor(core): Prevent a server from starting if it's configured to use S3, but the license does not allow it

### DIFF
--- a/packages/cli/src/commands/base-command.ts
+++ b/packages/cli/src/commands/base-command.ts
@@ -148,7 +148,7 @@ export abstract class BaseCommand extends Command {
 		const isSelected = config.getEnv('binaryDataManager.mode') === 's3';
 		const isAvailable = config.getEnv('binaryDataManager.availableModes').includes('s3');
 
-		if (!isSelected && !isAvailable) return;
+		if (!isSelected) return;
 
 		if (isSelected && !isAvailable) {
 			throw new ApplicationError(
@@ -157,51 +157,19 @@ export abstract class BaseCommand extends Command {
 		}
 
 		const isLicensed = Container.get(License).isFeatureEnabled(LICENSE_FEATURES.BINARY_DATA_S3);
-
-		if (isSelected && isAvailable && isLicensed) {
-			this.logger.debug(
-				'License found for external storage - object store to init in read-write mode',
+		if (!isLicensed) {
+			this.logger.error(
+				'No license found for S3 storage. \n Either set `N8N_DEFAULT_BINARY_DATA_MODE` to something else, or upgrade to a license that supports this feature.',
 			);
-
-			await this._initObjectStoreService();
-
-			return;
+			return this.exit(1);
 		}
 
-		if (isSelected && isAvailable && !isLicensed) {
-			this.logger.debug(
-				'No license found for external storage - object store to init with writes blocked. To enable writes, please upgrade to a license that supports this feature.',
-			);
-
-			await this._initObjectStoreService({ isReadOnly: true });
-
-			return;
-		}
-
-		if (!isSelected && isAvailable) {
-			this.logger.debug(
-				'External storage unselected but available - object store to init with writes unused',
-			);
-
-			await this._initObjectStoreService();
-
-			return;
-		}
-	}
-
-	private async _initObjectStoreService(options = { isReadOnly: false }) {
-		const objectStoreService = Container.get(ObjectStoreService);
-
-		this.logger.debug('Initializing object store service');
-
+		this.logger.debug('License found for external storage - Initializing object store service');
 		try {
-			await objectStoreService.init();
-			objectStoreService.setReadonly(options.isReadOnly);
-
+			await Container.get(ObjectStoreService).init();
 			this.logger.debug('Object store init completed');
 		} catch (e) {
 			const error = e instanceof Error ? e : new Error(`${e}`);
-
 			this.logger.debug('Object store init failed', { error });
 		}
 	}

--- a/packages/cli/src/license.ts
+++ b/packages/cli/src/license.ts
@@ -2,7 +2,7 @@ import { GlobalConfig } from '@n8n/config';
 import { Container, Service } from '@n8n/di';
 import type { TEntitlement, TFeatures, TLicenseBlock } from '@n8n_io/license-sdk';
 import { LicenseManager } from '@n8n_io/license-sdk';
-import { InstanceSettings, ObjectStoreService, Logger } from 'n8n-core';
+import { InstanceSettings, Logger } from 'n8n-core';
 
 import config from '@/config';
 import { SettingsRepository } from '@/databases/repositories/settings.repository';
@@ -106,7 +106,6 @@ export class License {
 
 			const features = this.manager.getFeatures();
 			this.checkIsLicensedForMultiMain(features);
-			this.checkIsLicensedForBinaryDataS3(features);
 
 			this.logger.debug('License initialized');
 		} catch (error: unknown) {
@@ -135,7 +134,6 @@ export class License {
 		this.logger.debug('License feature change detected', _features);
 
 		this.checkIsLicensedForMultiMain(_features);
-		this.checkIsLicensedForBinaryDataS3(_features);
 
 		if (this.instanceSettings.isMultiMain && !this.instanceSettings.isLeader) {
 			this.logger
@@ -402,23 +400,6 @@ export class License {
 				.debug(
 					'License changed with no support for multi-main setup - no new followers will be allowed to init. To restore multi-main setup, please upgrade to a license that supports this feature.',
 				);
-		}
-	}
-
-	/**
-	 * Ensures that the instance is licensed for binary data S3 if S3 is selected and available
-	 */
-	private checkIsLicensedForBinaryDataS3(features: TFeatures) {
-		const isS3Selected = config.getEnv('binaryDataManager.mode') === 's3';
-		const isS3Available = config.getEnv('binaryDataManager.availableModes').includes('s3');
-		const isS3Licensed = features['feat:binaryDataS3'];
-
-		if (isS3Selected && isS3Available && !isS3Licensed) {
-			this.logger.debug(
-				'License changed with no support for external storage - blocking writes on object store. To restore writes, please upgrade to a license that supports this feature.',
-			);
-
-			Container.get(ObjectStoreService).setReadonly(true);
 		}
 	}
 

--- a/packages/core/src/binary-data/object-store/__tests__/object-store.service.test.ts
+++ b/packages/core/src/binary-data/object-store/__tests__/object-store.service.test.ts
@@ -4,7 +4,6 @@ import { mock } from 'jest-mock-extended';
 import { Readable } from 'stream';
 
 import { ObjectStoreService } from '@/binary-data/object-store/object-store.service.ee';
-import { writeBlockedMessage } from '@/binary-data/object-store/utils';
 
 jest.mock('axios');
 
@@ -126,23 +125,6 @@ describe('put()', () => {
 			},
 			data: mockBuffer,
 		});
-	});
-
-	it('should block if read-only', async () => {
-		objectStoreService.setReadonly(true);
-
-		const metadata = { fileName: 'file.txt', mimeType: 'text/plain' };
-
-		const promise = objectStoreService.put(fileId, mockBuffer, metadata);
-
-		await expect(promise).resolves.not.toThrow();
-
-		const result = await promise;
-
-		expect(result.status).toBe(403);
-		expect(result.statusText).toBe('Forbidden');
-
-		expect(result.data).toBe(writeBlockedMessage(fileId));
 	});
 
 	it('should throw an error on request failure', async () => {

--- a/packages/core/src/binary-data/object-store/utils.ts
+++ b/packages/core/src/binary-data/object-store/utils.ts
@@ -14,7 +14,3 @@ export async function parseXml<T>(xml: string): Promise<T> {
 		valueProcessors: [parseNumbers, parseBooleans],
 	}) as Promise<T>);
 }
-
-export function writeBlockedMessage(filename: string) {
-	return `Request to write file "${filename}" to object storage was blocked because S3 storage is not available with your current license. Please upgrade to a license that supports this feature, or set N8N_DEFAULT_BINARY_DATA_MODE to an option other than "s3".`;
-}


### PR DESCRIPTION
## Summary
If an instance's license does not allow using S3 for binary data, then the instance should restart, until either the license is updated to allow S3, or until `N8N_DEFAULT_BINARY_DATA_MODE` is changed to something else.

## Related Linear tickets, Github issues, and Community forum posts

CAT-678


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
