### PR TITLE
fix(editor): Don't show duplicate logs when tree is deeply nested

### DIFF
--- a/packages/editor-ui/src/components/RunDataAi/utils.test.ts
+++ b/packages/editor-ui/src/components/RunDataAi/utils.test.ts
@@ -1,0 +1,95 @@
+import { createTestNode, createTestWorkflowObject } from '@/__tests__/mocks';
+import { createAiData, getTreeNodeData } from '@/components/RunDataAi/utils';
+import { type ITaskData, NodeConnectionType } from 'n8n-workflow';
+
+describe(getTreeNodeData, () => {
+	function createTaskData(partialData: Partial<ITaskData>): ITaskData {
+		return {
+			startTime: 0,
+			executionTime: 1,
+			source: [],
+			executionStatus: 'success',
+			data: { main: [[{ json: {} }]] },
+			...partialData,
+		};
+	}
+
+	it.todo('should generate one node per execution', () => {
+		const workflow = createTestWorkflowObject({
+			nodes: [
+				createTestNode({ name: 'A' }),
+				createTestNode({ name: 'B' }),
+				createTestNode({ name: 'C' }),
+			],
+			connections: {
+				B: { ai_tool: [[{ node: 'A', type: NodeConnectionType.AiTool, index: 0 }]] },
+				C: {
+					ai_languageModel: [[{ node: 'B', type: NodeConnectionType.AiLanguageModel, index: 0 }]],
+				},
+			},
+		});
+		const taskDataByNodeName: Record<string, ITaskData[]> = {
+			A: [createTaskData({ startTime: +new Date('2025-02-26T00:00:00.000Z') })],
+			B: [
+				createTaskData({ startTime: +new Date('2025-02-26T00:00:01.000Z') }),
+				createTaskData({ startTime: +new Date('2025-02-26T00:00:03.000Z') }),
+			],
+			C: [
+				createTaskData({ startTime: +new Date('2025-02-26T00:00:02.000Z') }),
+				createTaskData({ startTime: +new Date('2025-02-26T00:00:04.000Z') }),
+			],
+		};
+
+		expect(
+			getTreeNodeData(
+				'A',
+				workflow,
+				createAiData('A', workflow, (name) => taskDataByNodeName[name] ?? null),
+			),
+		).toEqual([
+			{
+				children: [
+					{
+						children: [
+							{
+								children: [],
+								depth: 2,
+								id: 'C',
+								node: 'C',
+								runIndex: 0,
+								startTime: 1740528002000,
+							},
+						],
+						depth: 1,
+						id: 'B',
+						node: 'B',
+						runIndex: 0,
+						startTime: 1740528001000,
+					},
+					{
+						children: [
+							{
+								children: [],
+								depth: 2,
+								id: 'C',
+								node: 'C',
+								runIndex: 1,
+								startTime: 1740528004000,
+							},
+						],
+						depth: 1,
+						id: 'B',
+						node: 'B',
+						runIndex: 1,
+						startTime: 1740528003000,
+					},
+				],
+				depth: 0,
+				id: 'A',
+				node: 'A',
+				runIndex: 0,
+				startTime: 0,
+			},
+		]);
+	});
+});

--- a/packages/editor-ui/src/components/RunDataAi/utils.test.ts
+++ b/packages/editor-ui/src/components/RunDataAi/utils.test.ts
@@ -14,7 +14,7 @@ describe(getTreeNodeData, () => {
 		};
 	}
 
-	it.todo('should generate one node per execution', () => {
+	it('should generate one node per execution', () => {
 		const workflow = createTestWorkflowObject({
 			nodes: [
 				createTestNode({ name: 'A' }),
@@ -48,8 +48,18 @@ describe(getTreeNodeData, () => {
 			),
 		).toEqual([
 			{
+				depth: 0,
+				id: 'A',
+				node: 'A',
+				runIndex: 0,
+				startTime: 0,
 				children: [
 					{
+						depth: 1,
+						id: 'B',
+						node: 'B',
+						runIndex: 0,
+						startTime: +new Date('2025-02-26T00:00:01.000Z'),
 						children: [
 							{
 								children: [],
@@ -57,16 +67,16 @@ describe(getTreeNodeData, () => {
 								id: 'C',
 								node: 'C',
 								runIndex: 0,
-								startTime: 1740528002000,
+								startTime: +new Date('2025-02-26T00:00:02.000Z'),
 							},
 						],
+					},
+					{
 						depth: 1,
 						id: 'B',
 						node: 'B',
-						runIndex: 0,
-						startTime: 1740528001000,
-					},
-					{
+						runIndex: 1,
+						startTime: +new Date('2025-02-26T00:00:03.000Z'),
 						children: [
 							{
 								children: [],
@@ -74,21 +84,11 @@ describe(getTreeNodeData, () => {
 								id: 'C',
 								node: 'C',
 								runIndex: 1,
-								startTime: 1740528004000,
+								startTime: +new Date('2025-02-26T00:00:04.000Z'),
 							},
 						],
-						depth: 1,
-						id: 'B',
-						node: 'B',
-						runIndex: 1,
-						startTime: 1740528003000,
 					},
 				],
-				depth: 0,
-				id: 'A',
-				node: 'A',
-				runIndex: 0,
-				startTime: 0,
 			},
 		]);
 	});

--- a/packages/editor-ui/src/components/RunDataAi/utils.ts
+++ b/packages/editor-ui/src/components/RunDataAi/utils.ts
@@ -67,13 +67,15 @@ function getTreeNodeDataRec(
 
 	const children = connectedSubNodes.flatMap((name) => {
 		// Only include sub-nodes which have data
-		return aiData
-			.filter(
-				(data) => data.node === name && (runIndex === undefined || data.runIndex === runIndex),
-			)
-			.flatMap((data) =>
-				getTreeNodeDataRec(name, currentDepth + 1, workflow, aiData, data.runIndex),
-			);
+		return (
+			aiData
+				?.filter(
+					(data) => data.node === name && (runIndex === undefined || data.runIndex === runIndex),
+				)
+				.flatMap((data) =>
+					getTreeNodeDataRec(name, currentDepth + 1, workflow, aiData, data.runIndex),
+				) ?? []
+		);
 	});
 
 	children.sort((a, b) => a.startTime - b.startTime);

--- a/packages/editor-ui/src/components/RunDataAi/utils.ts
+++ b/packages/editor-ui/src/components/RunDataAi/utils.ts
@@ -1,0 +1,148 @@
+import { type IAiDataContent } from '@/Interface';
+import {
+	type ITaskData,
+	type ITaskDataConnections,
+	type NodeConnectionType,
+	type Workflow,
+} from 'n8n-workflow';
+
+export interface AIResult {
+	node: string;
+	runIndex: number;
+	data: IAiDataContent | undefined;
+}
+
+export interface TreeNode {
+	node: string;
+	id: string;
+	children: TreeNode[];
+	depth: number;
+	startTime: number;
+	runIndex: number;
+}
+
+function createNode(
+	nodeName: string,
+	currentDepth: number,
+	r?: AIResult,
+	children: TreeNode[] = [],
+): TreeNode {
+	return {
+		node: nodeName,
+		id: nodeName,
+		depth: currentDepth,
+		startTime: r?.data?.metadata?.startTime ?? 0,
+		runIndex: r?.runIndex ?? 0,
+		children,
+	};
+}
+
+export function getTreeNodeData(
+	nodeName: string,
+	workflow: Workflow,
+	aiData: AIResult[] | undefined,
+): TreeNode[] {
+	return getTreeNodeDataRec(nodeName, 0, workflow, aiData);
+}
+
+function getTreeNodeDataRec(
+	nodeName: string,
+	currentDepth: number,
+	workflow: Workflow,
+	aiData: AIResult[] | undefined,
+): TreeNode[] {
+	const connections = workflow.connectionsByDestinationNode[nodeName];
+	const resultData = aiData?.filter((data) => data.node === nodeName) ?? [];
+
+	if (!connections) {
+		return resultData.map((d) => createNode(nodeName, currentDepth, d));
+	}
+
+	// Get the first level of children
+	const connectedSubNodes = workflow.getParentNodes(nodeName, 'ALL_NON_MAIN', 1);
+
+	const children = connectedSubNodes
+		// Only include sub-nodes which have data
+		.filter((name) => aiData.find((data) => data.node === name))
+		.flatMap((name) => getTreeNodeDataRec(name, currentDepth + 1, workflow, aiData));
+
+	children.sort((a, b) => a.startTime - b.startTime);
+
+	if (resultData.length) {
+		return resultData.map((r) => createNode(nodeName, currentDepth, r, children));
+	}
+
+	return [createNode(nodeName, currentDepth, undefined, children)];
+}
+
+export function createAiData(
+	nodeName: string,
+	workflow: Workflow,
+	getWorkflowResultDataByNodeName: (nodeName: string) => ITaskData[] | null,
+): AIResult[] {
+	const result: AIResult[] = [];
+	const connectedSubNodes = workflow.getParentNodes(nodeName, 'ALL_NON_MAIN');
+
+	connectedSubNodes.forEach((node) => {
+		const nodeRunData = getWorkflowResultDataByNodeName(node) ?? [];
+
+		nodeRunData.forEach((run, runIndex) => {
+			const referenceData = {
+				data: getReferencedData(run, false, true)[0],
+				node,
+				runIndex,
+			};
+
+			result.push(referenceData);
+		});
+	});
+
+	// Sort the data by start time
+	result.sort((a, b) => {
+		const aTime = a.data?.metadata?.startTime ?? 0;
+		const bTime = b.data?.metadata?.startTime ?? 0;
+		return aTime - bTime;
+	});
+
+	return result;
+}
+
+export function getReferencedData(
+	taskData: ITaskData,
+	withInput: boolean,
+	withOutput: boolean,
+): IAiDataContent[] {
+	if (!taskData) {
+		return [];
+	}
+
+	const returnData: IAiDataContent[] = [];
+
+	function addFunction(data: ITaskDataConnections | undefined, inOut: 'input' | 'output') {
+		if (!data) {
+			return;
+		}
+
+		Object.keys(data).map((type) => {
+			returnData.push({
+				data: data[type][0],
+				inOut,
+				type: type as NodeConnectionType,
+				metadata: {
+					executionTime: taskData.executionTime,
+					startTime: taskData.startTime,
+					subExecution: taskData.metadata?.subExecution,
+				},
+			});
+		});
+	}
+
+	if (withInput) {
+		addFunction(taskData.inputOverride, 'input');
+	}
+	if (withOutput) {
+		addFunction(taskData.data, 'output');
+	}
+
+	return returnData;
+}


### PR DESCRIPTION
## Summary

This PR fixes a bug in the AI logs view where duplicate logs are shown in the tree view if more than one runData exists.

![Screenshot from 2025-02-26 16-29-19](https://github.com/user-attachments/assets/55b1b33f-e3d1-4818-9cc2-6006ff18f2ed)

The function to create the tree was extracted from `RunDataAi.vue` so that it can be tested independently.
10a9e1110deae4462bc4e24093e6e0b4044217de is the commit that actually fixed the bug.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/SUG-10/ai-logs-break-for-deeper-nesting

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
