### PR TITLE
fix(editor): Fix icon spacing in accordion title

### DIFF
--- a/packages/design-system/src/components/N8nInfoAccordion/InfoAccordion.vue
+++ b/packages/design-system/src/components/N8nInfoAccordion/InfoAccordion.vue
@@ -55,13 +55,7 @@ const onTooltipClick = (item: string, event: MouseEvent) => emit('tooltipClick',
 <template>
 	<div :class="['accordion', $style.container]">
 		<div :class="{ [$style.header]: true, [$style.expanded]: expanded }" @click="toggle">
-			<N8nIcon
-				v-if="headerIcon"
-				:icon="headerIcon.icon"
-				:color="headerIcon.color"
-				size="small"
-				class="mr-2xs"
-			/>
+			<N8nIcon v-if="headerIcon" :icon="headerIcon.icon" :color="headerIcon.color" size="small" />
 			<N8nText :class="$style.headerText" color="text-base" size="small" align="left" bold>{{
 				title
 			}}</N8nText>
@@ -102,10 +96,8 @@ const onTooltipClick = (item: string, event: MouseEvent) => emit('tooltipClick',
 	display: flex;
 	padding: var(--spacing-s);
 	align-items: center;
-
-	.headerText {
-		flex-grow: 1;
-	}
+	justify-content: flex-start;
+	gap: var(--spacing-3xs);
 }
 
 .expanded {


### PR DESCRIPTION
## Summary

There is a long gap between text and chevron

![image](https://github.com/user-attachments/assets/30a27ed5-8a2b-4c35-b663-51bb7b18001e)


## Related Linear tickets, Github issues, and Community forum posts

PAY-2627


## Review / Merge checklist

- [ ] PR title and summary are descriptive.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport`
