### PR TITLE
fix(Postgres Node): Accommodate null values in query parameters for expressions

### DIFF
--- a/packages/nodes-base/nodes/Postgres/test/v2/operations.test.ts
+++ b/packages/nodes-base/nodes/Postgres/test/v2/operations.test.ts
@@ -363,6 +363,26 @@ describe('Test PostgresV2, executeQuery operation', () => {
 		);
 	});
 
+	it('should execute queries with null key/value pairs', async () => {
+		const nodeParameters: IDataObject = {
+			operation: 'executeQuery',
+			query: 'SELECT *\nFROM users\nWHERE username IN ($1, $2)',
+			options: {
+				queryReplacement: '"={{ betty }}, {{ null }}"',
+			},
+		};
+		const nodeOptions = nodeParameters.options as IDataObject;
+
+		expect(async () => {
+			await executeQuery.execute.call(
+				createMockExecuteFunction(nodeParameters),
+				runQueries,
+				items,
+				nodeOptions,
+			);
+		}).not.toThrow();
+	});
+
 	it('should execute queries with multiple json key/value pairs', async () => {
 		const nodeParameters: IDataObject = {
 			operation: 'executeQuery',

--- a/packages/nodes-base/nodes/Postgres/test/v2/utils.test.ts
+++ b/packages/nodes-base/nodes/Postgres/test/v2/utils.test.ts
@@ -17,6 +17,7 @@ import {
 	isJSON,
 	convertValuesToJsonWithPgp,
 	hasJsonDataTypeInSchema,
+	evaluateExpression,
 } from '../../v2/helpers/utils';
 
 const node: INode = {
@@ -36,6 +37,25 @@ describe('Test PostgresV2, isJSON', () => {
 	});
 	it('should return false for invalid JSON', () => {
 		expect(isJSON('{"key": "value"')).toEqual(false);
+	});
+});
+
+describe('Test PostgresV2, evaluateExpression', () => {
+	it('should evaluate undefined to an empty string', () => {
+		expect(evaluateExpression(undefined)).toEqual('');
+	});
+	it('should evaluate null to a string with value null', () => {
+		expect(evaluateExpression(null)).toEqual('null');
+	});
+	it('should evaluate object to a string', () => {
+		expect(evaluateExpression({ key: '' })).toEqual('{"key":""}');
+		expect(evaluateExpression([])).toEqual('[]');
+		expect(evaluateExpression([1, 2, 4])).toEqual('[1,2,4]');
+	});
+	it('should evaluate everything else to a string', () => {
+		expect(evaluateExpression(1)).toEqual('1');
+		expect(evaluateExpression('string')).toEqual('string');
+		expect(evaluateExpression(true)).toEqual('true');
 	});
 });
 

--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/executeQuery.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/executeQuery.operation.ts
@@ -14,7 +14,12 @@ import type {
 	QueriesRunner,
 	QueryWithValues,
 } from '../../helpers/interfaces';
-import { isJSON, replaceEmptyStringsByNulls, stringToArray } from '../../helpers/utils';
+import {
+	evaluateExpression,
+	isJSON,
+	replaceEmptyStringsByNulls,
+	stringToArray,
+} from '../../helpers/utils';
 import { optionsCollection } from '../common.descriptions';
 
 const properties: INodeProperties[] = [
@@ -84,8 +89,9 @@ export async function execute(
 					const resolvables = getResolvables(rawValues);
 					if (resolvables.length) {
 						for (const resolvable of resolvables) {
-							const evaluatedExpression =
-								this.evaluateExpression(`${resolvable}`, index)?.toString() ?? '';
+							const evaluatedExpression = evaluateExpression(
+								this.evaluateExpression(`${resolvable}`, index),
+							);
 							const evaluatedValues = isJSON(evaluatedExpression)
 								? [evaluatedExpression]
 								: stringToArray(evaluatedExpression);

--- a/packages/nodes-base/nodes/Postgres/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/helpers/utils.ts
@@ -30,6 +30,16 @@ export function isJSON(str: string) {
 	}
 }
 
+export function evaluateExpression(expression: NodeParameterValueType) {
+	if (expression === undefined) {
+		return '';
+	} else if (expression === null) {
+		return 'null';
+	} else {
+		return typeof expression === 'object' ? JSON.stringify(expression) : expression.toString();
+	}
+}
+
 export function stringToArray(str: NodeParameterValueType | undefined) {
 	if (str === undefined) return [];
 	return String(str)


### PR DESCRIPTION
## Summary

Accommodate null values in query parameters for expressions. This was broken after https://github.com/n8n-io/n8n/pull/12452 because `null` and `undefined` values were treated the same when they should be treated differently.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2448/postgres-node-null-values-in-the-string-of-query-parameters-ignored


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
