### PR TITLE
build: Fix benchmark docker image build

### DIFF
--- a/packages/@n8n/benchmark/Dockerfile
+++ b/packages/@n8n/benchmark/Dockerfile
@@ -37,9 +37,9 @@ ENV DOCKER_BUILD=true
 RUN pnpm install --frozen-lockfile
 
 # TS config files
-COPY --chown=node:node ./tsconfig.json /app/tsconfig.json
-COPY --chown=node:node ./tsconfig.build.json /app/tsconfig.build.json
-COPY --chown=node:node ./tsconfig.backend.json /app/tsconfig.backend.json
+COPY --chown=node:node ./packages/@n8n/typescript-config/tsconfig.common.json /app/packages/@n8n/typescript-config/tsconfig.common.json
+COPY --chown=node:node ./packages/@n8n/typescript-config/tsconfig.build.json /app/packages/@n8n/typescript-config/tsconfig.build.json
+COPY --chown=node:node ./packages/@n8n/typescript-config/tsconfig.backend.json /app/packages/@n8n/typescript-config/tsconfig.backend.json
 COPY --chown=node:node ./packages/@n8n/benchmark/tsconfig.json /app/packages/@n8n/benchmark/tsconfig.json
 COPY --chown=node:node ./packages/@n8n/benchmark/tsconfig.build.json /app/packages/@n8n/benchmark/tsconfig.build.json
 


### PR DESCRIPTION

## Summary

tsconfig files were moved in #13426, which broke the build. This fixes it.


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
