### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.76.0",
   "private": true,
   "engines": {
-    "node": ">=20.15",
+    "node": ">=18.17 <=22",
     "pnpm": ">=9.15"
   },
   "packageManager": "pnpm@9.15.1",


### PR DESCRIPTION
Where to Specify the “engines” Field
You already have an "engines" block at the top level of your package.json (the same level as "name", "version", and "scripts"). That is precisely where you include or modify the Node.js version requirement so that Render uses the correct Node version. For n8n, which supports Node.js ranges from >=18.17 to <=22, you can adjust your "engines" to something like: javascript


"engines": {
  "node": ">=18.17 <=22",
  "pnpm": ">=9.15"
}
So, in your posted package.json, just replace:
javascript


"engines": {
  "node": ">=20.15",
  "pnpm": ">=9.15"
}
with
javascript


"engines": {
  "node": ">=18.17 <=22",
  "pnpm": ">=9.15"
}
This ensures that Render (and pnpm) install a Node version in the supported range for n8n. Once you commit and push these changes, your Render deployment should pull a compatible Node version and successfully start n8n.

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
