### PR TITLE
fix(editor): Show dropdown scrollbars only when appropriate

### DIFF
--- a/packages/design-system/src/css/scrollbar.scss
+++ b/packages/design-system/src/css/scrollbar.scss
@@ -15,7 +15,7 @@
 	}
 
 	@include mixins.e(wrap) {
-		overflow: scroll;
+		overflow: auto;
 		height: 100%;
 	}
 


### PR DESCRIPTION
## Summary

Dropdown list have visible scrollbars on both axis

## Related Linear tickets, Github issues, and Community forum posts

PAY-2631


## Review / Merge checklist

- [ ] PR title and summary are descriptive
- [ ] Tests included. 
- [ ] PR Labeled with `release/backport` 
