### PR TITLE
fix(editor): Fix icon color on 'Call n8n Workflow Tool' node

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/ToolWorkflow.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/ToolWorkflow.node.ts
@@ -10,6 +10,7 @@ export class ToolWorkflow extends VersionedNodeType {
 			displayName: 'Call n8n Sub-Workflow Tool',
 			name: 'toolWorkflow',
 			icon: 'fa:network-wired',
+			iconColor: 'black',
 			group: ['transform'],
 			description:
 				'Uses another n8n workflow as a tool. Allows packaging any n8n node(s) as a tool.',

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v1/versionDescription.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v1/versionDescription.ts
@@ -13,8 +13,6 @@ import { getConnectionHintNoticeField } from '../../../../utils/sharedFields';
 export const versionDescription: INodeTypeDescription = {
 	displayName: 'Call n8n Workflow Tool',
 	name: 'toolWorkflow',
-	icon: 'fa:network-wired',
-	iconColor: 'black',
 	group: ['transform'],
 	version: [1, 1.1, 1.2, 1.3],
 	description: 'Uses another n8n workflow as a tool. Allows packaging any n8n node(s) as a tool.',

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/versionDescription.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/versionDescription.ts
@@ -8,6 +8,7 @@ export const versionDescription: INodeTypeDescription = {
 	displayName: 'Call n8n Workflow Tool',
 	name: 'toolWorkflow',
 	icon: 'fa:network-wired',
+	iconColor: 'black',
 	group: ['transform'],
 	description: 'Uses another n8n workflow as a tool. Allows packaging any n8n node(s) as a tool.',
 	defaults: {

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/versionDescription.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/versionDescription.ts
@@ -7,8 +7,6 @@ import { getConnectionHintNoticeField } from '../../../../utils/sharedFields';
 export const versionDescription: INodeTypeDescription = {
 	displayName: 'Call n8n Workflow Tool',
 	name: 'toolWorkflow',
-	icon: 'fa:network-wired',
-	iconColor: 'black',
 	group: ['transform'],
 	description: 'Uses another n8n workflow as a tool. Allows packaging any n8n node(s) as a tool.',
 	defaults: {


### PR DESCRIPTION
## Summary

On the v2 version of `Call n8n Workflow Tool` the color of the `Call n8n Workflow Tool` had changed dark on dark mode. The reason was missing `iconColor` on the new version of the node.

Before fix
![image](https://github.com/user-attachments/assets/f5d83332-6237-4f11-82f1-1fe0e2e62001)

With fix
![image](https://github.com/user-attachments/assets/e0701409-3e9b-4334-9af4-37e418edfc84)

## Related Linear tickets, Github issues, and Community forum posts

Linear issue: https://linear.app/n8n/issue/ADO-3286/community-issue-the-color-of-the-call-n8n-workflow-tool-icon-has
Fixes #13538

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
