### PR TITLE
fix(AWS SES Node): Encode template parameters properly

### DIFF
--- a/packages/nodes-base/nodes/Aws/SES/AwsSes.node.ts
+++ b/packages/nodes-base/nodes/Aws/SES/AwsSes.node.ts
@@ -1176,13 +1176,15 @@ export class AwsSes implements INodeType {
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 
 						const params = [
-							`Template.TemplateName=${templateName}`,
-							`Template.SubjectPart=${subjectPart}`,
-							`Template.HtmlPart=<h1>${htmlPart}</h1>`,
+							`Template.TemplateName=${encodeURIComponent(templateName)}`,
+							`Template.SubjectPart=${encodeURIComponent(subjectPart)}`,
+							`Template.HtmlPart=${encodeURIComponent(htmlPart)}`,
 						];
 
 						if (additionalFields.textPart) {
-							params.push(`Template.TextPart=${additionalFields.textPart}`);
+							params.push(
+								`Template.TextPart=${encodeURIComponent(additionalFields.textPart as string)}`,
+							);
 						}
 
 						responseData = await awsApiRequestSOAP.call(

--- a/packages/nodes-base/nodes/Aws/SES/AwsSes.node.ts
+++ b/packages/nodes-base/nodes/Aws/SES/AwsSes.node.ts
@@ -1258,18 +1258,24 @@ export class AwsSes implements INodeType {
 
 						const updateFields = this.getNodeParameter('updateFields', i);
 
-						const params = [`Template.TemplateName=${templateName}`];
+						const params = [`Template.TemplateName=${encodeURIComponent(templateName)}`];
 
 						if (updateFields.textPart) {
-							params.push(`Template.TextPart=${updateFields.textPart}`);
+							params.push(
+								`Template.TextPart=${encodeURIComponent(updateFields.textPart as string)}`,
+							);
 						}
 
 						if (updateFields.subjectPart) {
-							params.push(`Template.SubjectPart=${updateFields.subjectPart}`);
+							params.push(
+								`Template.SubjectPart=${encodeURIComponent(updateFields.subjectPart as string)}`,
+							);
 						}
 
 						if (updateFields.subjectPart) {
-							params.push(`Template.HtmlPart=${updateFields.htmlPart}`);
+							params.push(
+								`Template.HtmlPart=${encodeURIComponent(updateFields.htmlPart as string)}`,
+							);
 						}
 
 						responseData = await awsApiRequestSOAP.call(

--- a/packages/nodes-base/nodes/Aws/SES/AwsSes.node.ts
+++ b/packages/nodes-base/nodes/Aws/SES/AwsSes.node.ts
@@ -1081,16 +1081,11 @@ export class AwsSes implements INodeType {
 
 					if (operation === 'sendTemplate') {
 						const toAddresses = this.getNodeParameter('toAddresses', i) as string[];
-
 						const template = this.getNodeParameter('templateName', i) as string;
-
 						const fromEmail = this.getNodeParameter('fromEmail', i) as string;
-
 						const additionalFields = this.getNodeParameter('additionalFields', i);
-
 						const templateDataUi = this.getNodeParameter('templateDataUi', i) as IDataObject;
-
-						const params = [`Template=${template}`, `Source=${fromEmail}`];
+						const params = [`Template=${template}`, `Source=${encodeURIComponent(fromEmail)}`];
 
 						if (toAddresses.length) {
 							setParameter(params, 'Destination.ToAddresses.member', toAddresses);
@@ -1150,7 +1145,7 @@ export class AwsSes implements INodeType {
 									//@ts-ignore
 									templateData[templateDataValue.key] = templateDataValue.value;
 								}
-								params.push(`TemplateData=${JSON.stringify(templateData)}`);
+								params.push(`TemplateData=${encodeURIComponent(JSON.stringify(templateData))}`);
 							}
 						}
 

--- a/packages/nodes-base/nodes/Aws/SES/test/AwsSes.node.test.ts
+++ b/packages/nodes-base/nodes/Aws/SES/test/AwsSes.node.test.ts
@@ -7,6 +7,10 @@ import * as Helpers from '@test/nodes/Helpers';
 import type { WorkflowTestData } from '@test/nodes/types';
 
 describe('AwsSes Node', () => {
+	const email = 'test+user@example.com';
+	const templateData = {
+		Name: 'Special. Characters @#$%^&*()_-',
+	};
 	const tests: WorkflowTestData[] = [
 		{
 			description: 'should create customVerificationEmail',
@@ -123,7 +127,7 @@ describe('AwsSes Node', () => {
 							typeVersion: 1,
 							position: [60, 520],
 							id: '13bbf4ef-8320-45d1-9210-61b62794a108',
-							name: 'AWS SES4',
+							name: 'AWS SES',
 							credentials: {
 								aws: {
 									id: 'Nz0QZhzu3MvfK4TQ',
@@ -137,7 +141,7 @@ describe('AwsSes Node', () => {
 							main: [
 								[
 									{
-										node: 'AWS SES4',
+										node: 'AWS SES',
 										type: NodeConnectionType.Main,
 										index: 0,
 									},
@@ -156,23 +160,7 @@ describe('AwsSes Node', () => {
 				mocks: [
 					{
 						method: 'post',
-						path: '/',
-						requestBody: (body: any) => {
-							assert.deepEqual(qs.parse(body), {
-								Action: 'SendTemplatedEmail',
-								TemplateName: '=Template11',
-								Source: encodeURIComponent('test+user@example.com'),
-								Destination: {
-									ToAddresses: [encodeURIComponent('test+user@example.com')],
-								},
-								TemplateData: encodeURIComponent(
-									JSON.stringify({
-										Name: '=Special. Characters @#$%^&*()_-',
-									}),
-								),
-							});
-							return true;
-						},
+						path: `/?Action=SendTemplatedEmail&Template=Template11&Source=${encodeURIComponent(email)}&Destination.ToAddresses.member.1=${encodeURIComponent(email)}&TemplateData=${encodeURIComponent(JSON.stringify(templateData))}`,
 						statusCode: 200,
 						responseBody:
 							'<SendTemplatedEmailResponse><success>true</success></SendTemplatedEmailResponse>',


### PR DESCRIPTION
This PR ensures proper encoding for the template params used in `createTemplate` and `updateTemplate`. This is to  improve the handling of special characters being passed in.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/NODE-2475/aws-ses-node-puts-html-content-in-path-instead-of-body

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
