### PR TITLE
fix(editor): Add workflows to the store when fetching current page

### DIFF
--- a/cypress/e2e/1-workflows.cy.ts
+++ b/cypress/e2e/1-workflows.cy.ts
@@ -1,9 +1,11 @@
+import { WorkflowSharingModal } from '../pages';
 import { WorkflowPage as WorkflowPageClass } from '../pages/workflow';
 import { WorkflowsPage as WorkflowsPageClass } from '../pages/workflows';
 import { getUniqueWorkflowName } from '../utils/workflowUtils';
 
 const WorkflowsPage = new WorkflowsPageClass();
 const WorkflowPage = new WorkflowPageClass();
+const workflowSharingModal = new WorkflowSharingModal();
 
 const multipleWorkflowsCount = 5;
 
@@ -137,5 +139,11 @@ describe('Workflows', () => {
 		cy.url().should('include', 'tags=');
 		cy.url().should('include', 'sort=lastCreated');
 		cy.url().should('include', 'pageSize=25');
+	});
+
+	it('should be able to share workflows from workflows list', () => {
+		WorkflowsPage.getters.workflowCardActions('Empty State Card Workflow').click();
+		WorkflowsPage.getters.workflowActionItem('share').click();
+		workflowSharingModal.getters.modal().should('be.visible');
 	});
 });

--- a/cypress/pages/workflows.ts
+++ b/cypress/pages/workflows.ts
@@ -35,6 +35,7 @@ export class WorkflowsPage extends BasePage {
 			this.getters.workflowActivator(workflowName).findChildByTestId('workflow-activator-status'),
 		workflowCardActions: (workflowName: string) =>
 			this.getters.workflowCard(workflowName).findChildByTestId('workflow-card-actions'),
+		workflowActionItem: (action: string) => cy.getByTestId(`action-${action}`).filter(':visible'),
 		workflowDeleteButton: () =>
 			cy.getByTestId('action-toggle-dropdown').filter(':visible').contains('Delete'),
 		workflowMoveButton: () =>

--- a/packages/editor-ui/src/stores/workflows.store.ts
+++ b/packages/editor-ui/src/stores/workflows.store.ts
@@ -517,6 +517,17 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		);
 
 		totalWorkflowCount.value = count;
+		// When fetching workflows from overview page, they don't have resource property
+		// so in order to filter out folders, we need to check if resource is not folder
+		const onlyWorkflows: IWorkflowDb[] = data
+			.filter((item) => item.resource !== 'folder')
+			.map((item) => ({
+				...item,
+				nodes: [],
+				connections: {},
+				versionId: '',
+			}));
+		setWorkflows(onlyWorkflows);
 		return data;
 	}
 

--- a/packages/editor-ui/src/stores/workflows.store.ts
+++ b/packages/editor-ui/src/stores/workflows.store.ts
@@ -517,17 +517,19 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		);
 
 		totalWorkflowCount.value = count;
+		// Also set fetched workflows to store
 		// When fetching workflows from overview page, they don't have resource property
 		// so in order to filter out folders, we need to check if resource is not folder
-		const onlyWorkflows: IWorkflowDb[] = data
+		data
 			.filter((item) => item.resource !== 'folder')
-			.map((item) => ({
-				...item,
-				nodes: [],
-				connections: {},
-				versionId: '',
-			}));
-		setWorkflows(onlyWorkflows);
+			.forEach((item) => {
+				addWorkflow({
+					...item,
+					nodes: [],
+					connections: {},
+					versionId: '',
+				});
+			});
 		return data;
 	}
 


### PR DESCRIPTION
## Summary
Fixing an issue where workflow data is not available in the store after loading workflows list page.

Fixes ADO-3289


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
