### PR TITLE
fix(Google Sheets Node): Accommodate special characters when updating row

### DIFF
--- a/packages/nodes-base/nodes/Google/Sheet/test/v2/node/update.test.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/test/v2/node/update.test.ts
@@ -12,6 +12,14 @@ describe('Google Sheet - Update', () => {
 	beforeEach(() => {
 		mockExecuteFunctions = mock<IExecuteFunctions>();
 		mockGoogleSheet = mock<GoogleSheet>();
+
+		mockExecuteFunctions.getNode.mockReturnValueOnce(mock<INode>({ typeVersion: 4.5 }));
+
+		mockGoogleSheet.batchUpdate.mockResolvedValueOnce([]);
+	});
+
+	afterEach(() => {
+		jest.resetAllMocks();
 	});
 
 	it('should update by row_number and not insert it as a new column', async () => {
@@ -29,7 +37,6 @@ describe('Google Sheet - Update', () => {
 			},
 		]);
 
-		mockExecuteFunctions.getNode.mockReturnValueOnce(mock<INode>({ typeVersion: 4.5 }));
 		mockExecuteFunctions.getNodeParameter
 			.mockReturnValueOnce('USER_ENTERED') // valueInputMode
 			.mockReturnValueOnce({}); // options
@@ -57,8 +64,6 @@ describe('Google Sheet - Update', () => {
 				},
 			],
 		});
-
-		mockGoogleSheet.batchUpdate.mockResolvedValueOnce([]);
 
 		await execute.call(mockExecuteFunctions, mockGoogleSheet, 'Sheet1');
 

--- a/packages/nodes-base/nodes/Google/Sheet/test/v2/node/update.test.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/test/v2/node/update.test.ts
@@ -106,4 +106,102 @@ describe('Google Sheet - Update', () => {
 			'USER_ENTERED',
 		);
 	});
+
+	it('should update rows by column values with special character', async () => {
+		mockExecuteFunctions.getInputData.mockReturnValueOnce([
+			{
+				json: {
+					row_number: 3,
+					name: '** δ$% " []',
+					text: 'δ$% " []',
+				},
+				pairedItem: {
+					item: 0,
+					input: undefined,
+				},
+			},
+		]);
+
+		mockExecuteFunctions.getNodeParameter.mockImplementation((parameterName: string) => {
+			const params: { [key: string]: string | object } = {
+				options: {},
+				'options.cellFormat': 'USER_ENTERED',
+				'columns.matchingColumns': ['row_number'],
+				'columns.value': {
+					'ha []': 'kayyyy$',
+					macarena: 'baile',
+					'Real.1': 't&c',
+					'21 "': 'Σ',
+				},
+				dataMode: 'autoMapInputData',
+			};
+			return params[parameterName];
+		});
+
+		mockGoogleSheet.getData.mockResolvedValueOnce([
+			['Real.1', '21 "', 'dfd', 'ha []', 'macarena'],
+			['aye.2', '"book"', 'ee', 'dd', 'dance'],
+			['t&c', 'Σ', 'baz', 'kayyyy$', 'baile'],
+			['fudge.2', '9080', 'live', 'dog', 'brazil'],
+		]);
+
+		mockGoogleSheet.getColumnValues.mockResolvedValueOnce([]);
+
+		mockGoogleSheet.prepareDataForUpdatingByRowNumber.mockReturnValueOnce({
+			updateData: [
+				{
+					range: 'Sheet1!B3',
+					values: [['** δ$% " []']],
+				},
+				{
+					range: 'Sheet1!C3',
+					values: [['δ$% " []']],
+				},
+			],
+		});
+
+		await execute.call(mockExecuteFunctions, mockGoogleSheet, 'Sheet1');
+
+		expect(mockGoogleSheet.getData).toHaveBeenCalledWith('Sheet1', 'FORMATTED_VALUE');
+
+		expect(mockGoogleSheet.getColumnValues).toHaveBeenCalledWith({
+			range: 'Sheet1!A:Z',
+			keyIndex: -1,
+			dataStartRowIndex: 1,
+			valueRenderMode: 'UNFORMATTED_VALUE',
+			sheetData: [
+				['Real.1', '21 "', 'dfd', 'ha []', 'macarena'],
+				['aye.2', '"book"', 'ee', 'dd', 'dance'],
+				['t&c', 'Σ', 'baz', 'kayyyy$', 'baile'],
+				['fudge.2', '9080', 'live', 'dog', 'brazil'],
+			],
+		});
+
+		expect(mockGoogleSheet.prepareDataForUpdatingByRowNumber).toHaveBeenCalledWith(
+			[
+				{
+					'21 "': 'Σ',
+					'Real.1': 't&c',
+					'ha []': 'kayyyy$',
+					macarena: 'baile',
+				},
+			],
+			'Sheet1!A:Z',
+			[['Real.1', '21 "', 'dfd', 'ha []', 'macarena']],
+		);
+
+		expect(mockGoogleSheet.batchUpdate).toHaveBeenCalledWith(
+			[
+				{
+					range: 'Sheet1!B3',
+					values: [['** δ$% " []']],
+				},
+				{
+					range: 'Sheet1!C3',
+					values: [['δ$% " []']],
+				},
+			],
+			'USER_ENTERED',
+		);
+	});
 });

--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/update.operation.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/update.operation.ts
@@ -320,7 +320,7 @@ export async function execute(
 			const valueToMatchOn =
 				nodeVersion < 4
 					? (this.getNodeParameter('valueToMatchOn', i, '') as string)
-					: (this.getNodeParameter(`columns.value[${columnsToMatchOn[0]}]`, i, '') as string);
+					: (this.getNodeParameter(`columns.value["${columnsToMatchOn[0]}"]`, i, '') as string);
 
 			if (valueToMatchOn === '') {
 				throw new NodeOperationError(


### PR DESCRIPTION
## Summary

The parameterName doesn't get properly parsed without the additional
quotes when we call the values parameter

Workflow for testing. You do not have to use the same special characters -- just make sure some of the cells have special characters:

```
{
  "nodes": [
    {
      "parameters": {},
      "type": "n8n-nodes-base.manualTrigger",
      "typeVersion": 1,
      "position": [
        0,
        0
      ],
      "id": "c78a115a-5600-4f1e-8740-f3ca9d038d3a",
      "name": "When clicking ‘Test workflow’"
    },
    {
      "parameters": {
        "operation": "update",
        "documentId": {
          "__rl": true,
          "value": "1oqFpPgEPTGDw7BPkp1SfPXq3Cb3Hyr1SROtf-Ec4zvA",
          "mode": "list",
          "cachedResultName": "lol",
          "cachedResultUrl": "https://docs.google.com/spreadsheets/d/1oqFpPgEPTGDw7BPkp1SfPXq3Cb3Hyr1SROtf-Ec4zvA/edit?usp=drivesdk"
        },
        "sheetName": {
          "__rl": true,
          "value": "gid=0",
          "mode": "list",
          "cachedResultName": "Sheet1",
          "cachedResultUrl": "https://docs.google.com/spreadsheets/d/1oqFpPgEPTGDw7BPkp1SfPXq3Cb3Hyr1SROtf-Ec4zvA/edit#gid=0"
        },
        "columns": {
          "mappingMode": "defineBelow",
          "value": {
            "ha []": "kayyyy$",
            "macarena": "baile",
            "Real.1": "t&c",
            "21 \"": "Σ"
          },
          "matchingColumns": [
            "ha []"
          ],
          "schema": [
            {
              "id": "Real.1",
              "displayName": "Real.1",
              "required": false,
              "defaultMatch": false,
              "display": true,
              "type": "string",
              "canBeUsedToMatch": true,
              "removed": false
            },
            {
              "id": "21 \"",
              "displayName": "21 \"",
              "required": false,
              "defaultMatch": false,
              "display": true,
              "type": "string",
              "canBeUsedToMatch": true,
              "removed": false
            },
            {
              "id": "dfd",
              "displayName": "dfd",
              "required": false,
              "defaultMatch": false,
              "display": true,
              "type": "string",
              "canBeUsedToMatch": true,
              "removed": true
            },
            {
              "id": "ha []",
              "displayName": "ha []",
              "required": false,
              "defaultMatch": false,
              "display": true,
              "type": "string",
              "canBeUsedToMatch": true,
              "removed": false
            },
            {
              "id": "macarena",
              "displayName": "macarena",
              "required": false,
              "defaultMatch": false,
              "display": true,
              "type": "string",
              "canBeUsedToMatch": true,
              "removed": false
            },
            {
              "id": "row_number",
              "displayName": "row_number",
              "required": false,
              "defaultMatch": false,
              "display": true,
              "type": "string",
              "canBeUsedToMatch": true,
              "readOnly": true,
              "removed": true
            }
          ],
          "attemptToConvertTypes": false,
          "convertFieldsToString": false
        },
        "options": {}
      },
      "type": "n8n-nodes-base.googleSheets",
      "typeVersion": 4.5,
      "position": [
        220,
        0
      ],
      "id": "342460fd-baef-4514-9d07-7716b4ed3aff",
      "name": "Google Sheets",
      "alwaysOutputData": true,
      "credentials": {
        "googleSheetsOAuth2Api": {
          "id": "5hJuQNmnEpxoehAN",
          "name": "Google Sheets account"
        }
      }
    }
  ],
  "connections": {
    "When clicking ‘Test workflow’": {
      "main": [
        [
          {
            "node": "Google Sheets",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {},
  "meta": {
    "templateCredsSetupCompleted": true,
    "instanceId": "ee90fdf8d57662f949e6c691dc07fa0fd2f66e1eee28ed82ef06658223e67255"
  }
}
```

## Related Linear tickets, Github issues, and Community forum posts

Resolves https://community.n8n.io/t/the-column-to-match-on-parameter-is-required-problem/82132
Resolves https://linear.app/n8n/issue/NODE-2482/community-issue-n8n-nodes-basegooglesheets-column-to-match-on-error
Resolves https://github.com/n8n-io/n8n/issues/13442

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
