### PR TITLE
feat(FacebookTriggerNode): Add page's message webhook trigger

### DIFF
--- a/packages/nodes-base/nodes/Facebook/FacebookTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Facebook/FacebookTrigger.node.test.ts
@@ -1,0 +1,82 @@
+import { testWebhookTriggerNode } from '@test/nodes/TriggerHelpers';
+import { FacebookTrigger } from './FacebookTrigger.node';
+import type { IDataObject } from 'n8n-workflow';
+import { returnJsonArray } from 'n8n-core';
+
+describe('FacebookTrigger', () => {
+	beforeAll(() => {
+		jest.resetAllMocks();
+	});
+
+	it('should validate webhook setup request', async () => {
+		const verifyToken = 'test-verify-token';
+		const challenge = 'test-challenge';
+
+		const { responseData } = await testWebhookTriggerNode(FacebookTrigger, {
+			webhookName: 'setup',
+			node: {
+				parameters: {
+					appId: '123456789',
+					object: 'page',
+					verifyToken,
+				},
+			},
+			request: {
+				query: {
+					'hub.mode': 'subscribe',
+					'hub.verify_token': verifyToken,
+					'hub.challenge': challenge,
+				},
+			},
+			credential: {
+				facebookGraphAppApi: {
+					appSecret: 'appSecret',
+					accessToken: 'accessToken',
+				},
+			},
+		});
+
+		expect(responseData).toEqual({
+			noWebhookResponse: true,
+		});
+	});
+
+	it("should process webhook page's message events", async () => {
+		const mockEvent: IDataObject = {
+			object: 'page',
+			entry: [
+				{
+					id: '123456789',
+					time: 1625097600,
+					changes: [
+						{
+							field: 'feed',
+							value: {
+								post_id: '123_456',
+								message: 'Test post',
+							},
+						},
+					],
+				},
+			],
+		};
+
+		const { responseData } = await testWebhookTriggerNode(FacebookTrigger, {
+			webhookName: 'default',
+			node: {
+				parameters: {
+					appId: '123456789',
+					object: 'page',
+				},
+			},
+			bodyData: mockEvent,
+			credential: {
+				facebookGraphAppApi: {
+					appSecret: '',
+				},
+			},
+		});
+
+		expect(responseData?.workflowData).toEqual([returnJsonArray(mockEvent.entry as IDataObject)]);
+	});
+});

--- a/packages/nodes-base/nodes/Facebook/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Facebook/GenericFunctions.ts
@@ -164,6 +164,10 @@ export function getFields(object: string) {
 				description: "Describes changes to a page's Name profile field.",
 			},
 			{
+				value: 'messages',
+				description: "Webhooks for page's messages",
+			},
+			{
 				value: 'page_about_story',
 			},
 			{


### PR DESCRIPTION
## Summary

Add Facebook page's message webhook trigger for FacebookTrigger Node

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://community.n8n.io/t/get-and-respond-to-facebook-messages/43137

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
