### PR TITLE
fix(GitHub Node): Fix workflow resource locator

### DIFF
--- a/packages/nodes-base/nodes/Github/Github.node.ts
+++ b/packages/nodes-base/nodes/Github/Github.node.ts
@@ -457,7 +457,7 @@ export class Github implements INodeType {
 				required: true,
 				modes: [
 					{
-						displayName: 'Workflow',
+						displayName: 'From List',
 						name: 'list',
 						type: 'list',
 						placeholder: 'Select a workflow...',
@@ -478,6 +478,21 @@ export class Github implements INodeType {
 								properties: {
 									regex: '\\d+',
 									errorMessage: 'Not a valid Github Workflow ID',
+								},
+							},
+						],
+					},
+					{
+						displayName: 'By File Name',
+						name: 'filename',
+						type: 'string',
+						placeholder: 'e.g. main.yaml or main.yml',
+						validation: [
+							{
+								type: 'regex',
+								properties: {
+									regex: '[a-zA-Z0-9_-]+.(yaml|yml)',
+									errorMessage: 'Not a valid Github Workflow File Name',
 								},
 							},
 						],
@@ -2501,7 +2516,9 @@ export class Github implements INodeType {
 
 						requestMethod = 'POST';
 
-						const workflowId = this.getNodeParameter('workflowId', i) as string;
+						const workflowId = this.getNodeParameter('workflowId', i, undefined, {
+							extractValue: true,
+						}) as string;
 
 						endpoint = `/repos/${owner}/${repository}/actions/workflows/${workflowId}/dispatches`;
 						body.ref = this.getNodeParameter('ref', i) as string;

--- a/packages/nodes-base/nodes/Github/Github.node.ts
+++ b/packages/nodes-base/nodes/Github/Github.node.ts
@@ -463,8 +463,6 @@ export class Github implements INodeType {
 						placeholder: 'Select a workflow...',
 						typeOptions: {
 							searchListMethod: 'getWorkflows',
-							searchable: true,
-							searchFilterRequired: true,
 						},
 					},
 					{

--- a/packages/nodes-base/nodes/Github/__tests__/Github.node.test.ts
+++ b/packages/nodes-base/nodes/Github/__tests__/Github.node.test.ts
@@ -1,0 +1,91 @@
+import nock from 'nock';
+
+import { getWorkflowFilenames, initBinaryDataService, testWorkflows } from '@test/nodes/Helpers';
+
+const workflows = getWorkflowFilenames(__dirname);
+
+describe('Test Github Node', () => {
+	describe('Workflow Dispatch', () => {
+		const now = 1683028800000;
+		const owner = 'testOwner';
+		const repository = 'testRepository';
+		const workflowId = 147025216;
+		const usersResponse = {
+			total_count: 12,
+			items: [
+				{
+					login: 'testOwner',
+					id: 1,
+				},
+			],
+		};
+		const repositoriesResponse = {
+			total_count: 40,
+			items: [
+				{
+					id: 3081286,
+					name: 'testRepository',
+				},
+			],
+		};
+		const workflowsResponse = {
+			total_count: 2,
+			workflows: [
+				{
+					id: workflowId,
+					node_id: 'MDg6V29ya2Zsb3cxNjEzMzU=',
+					name: 'CI',
+					path: '.github/workflows/blank.yaml',
+					state: 'active',
+					created_at: '2020-01-08T23:48:37.000-08:00',
+					updated_at: '2020-01-08T23:50:21.000-08:00',
+					url: 'https://api.github.com/repos/octo-org/octo-repo/actions/workflows/161335',
+					html_url: 'https://github.com/octo-org/octo-repo/blob/master/.github/workflows/161335',
+					badge_url: 'https://github.com/octo-org/octo-repo/workflows/CI/badge.svg',
+				},
+				{
+					id: 269289,
+					node_id: 'MDE4OldvcmtmbG93IFNlY29uZGFyeTI2OTI4OQ==',
+					name: 'Linter',
+					path: '.github/workflows/linter.yaml',
+					state: 'active',
+					created_at: '2020-01-08T23:48:37.000-08:00',
+					updated_at: '2020-01-08T23:50:21.000-08:00',
+					url: 'https://api.github.com/repos/octo-org/octo-repo/actions/workflows/269289',
+					html_url: 'https://github.com/octo-org/octo-repo/blob/master/.github/workflows/269289',
+					badge_url: 'https://github.com/octo-org/octo-repo/workflows/Linter/badge.svg',
+				},
+			],
+		};
+
+		beforeAll(async () => {
+			jest.useFakeTimers({ doNotFake: ['nextTick'], now });
+			await initBinaryDataService();
+		});
+		beforeEach(async () => {
+			const baseUrl = 'https://api.github.com';
+			nock.cleanAll();
+			nock(baseUrl)
+				.persist()
+				.defaultReplyHeaders({ 'Content-Type': 'application/json' })
+				.get('/search/users')
+				.query(true)
+				.reply(200, usersResponse)
+				.get('/search/repositories')
+				.query(true)
+				.reply(200, repositoriesResponse)
+				.get(`/repos/${owner}/${repository}/actions/workflows`)
+				.reply(200, workflowsResponse)
+				.post(`/repos/${owner}/${repository}/actions/workflows/${workflowId}/dispatches`, {
+					ref: 'main',
+					inputs: {},
+				})
+				.reply(200, {});
+		});
+
+		afterEach(() => {
+			nock.cleanAll();
+		});
+		testWorkflows(workflows);
+	});
+});

--- a/packages/nodes-base/nodes/Github/__tests__/GithubTestWorkflow.json
+++ b/packages/nodes-base/nodes/Github/__tests__/GithubTestWorkflow.json
@@ -1,0 +1,86 @@
+{
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [-300, 260],
+			"id": "b14bf20f-78b0-490a-bbc6-d02b1af4c03c",
+			"name": "When clicking ‘Test workflow’"
+		},
+		{
+			"parameters": {
+				"resource": "workflow",
+				"workflowId": {
+					"__rl": true,
+					"value": 147025216,
+					"mode": "list",
+					"cachedResultName": "CI"
+				},
+				"owner": {
+					"__rl": true,
+					"value": "testOwner",
+					"mode": "name"
+				},
+				"repository": {
+					"__rl": true,
+					"value": "testRepository",
+					"mode": "name"
+				}
+			},
+			"type": "n8n-nodes-base.github",
+			"typeVersion": 1,
+			"position": [-80, 260],
+			"id": "061752c9-507c-4b27-ba18-47b21d487aed",
+			"name": "GitHub",
+			"credentials": {
+				"githubApi": {
+					"id": "1",
+					"name": "GitHub account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [120, 260],
+			"id": "3bc54e8f-eeba-496d-a95f-bb8927eff671",
+			"name": "No Operation, do nothing"
+		}
+	],
+	"connections": {
+		"When clicking ‘Test workflow’": {
+			"main": [
+				[
+					{
+						"node": "GitHub",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"GitHub": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {}
+			}
+		]
+	},
+	"meta": {
+		"instanceId": "27cc9b56542ad45b38725555722c50a1c3fee1670bbb67980558314ee08517c4"
+	}
+}


### PR DESCRIPTION
## Summary
This PR fixes the workflow resource locator and add an option to use workflow file name

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2434/github-node-validation-for-dispatch-operations-workflowid-is-wrong

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
