### PR TITLE
fix(QuickBooks Online Node): Add qty to quickbooks invoice line details

### DIFF
--- a/packages/nodes-base/nodes/QuickBooks/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/QuickBooks/GenericFunctions.ts
@@ -329,9 +329,14 @@ export function processLines(this: IExecuteFunctions, lines: IDataObject[], reso
 					TaxCodeRef: {
 						value: line.TaxCodeRef,
 					},
+					Qty: line.Qty,
 				};
+				if (line.Qty === undefined) {
+					delete (line.SalesItemLineDetail as IDataObject).Qty;
+				}
 				delete line.itemId;
 				delete line.TaxCodeRef;
+				delete line.Qty;
 			}
 		}
 	});

--- a/packages/nodes-base/nodes/QuickBooks/__tests__/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/QuickBooks/__tests__/GenericFunctions.test.ts
@@ -1,0 +1,75 @@
+import type { IExecuteFunctions } from 'n8n-workflow';
+
+import { processLines } from '../GenericFunctions';
+describe('processLines', () => {
+	const mockExecuteFunctions: Partial<IExecuteFunctions> = {
+		getNodeParameter: jest.fn(),
+	};
+
+	test('should process AccountBasedExpenseLineDetail for bill resource', () => {
+		const lines = [{ DetailType: 'AccountBasedExpenseLineDetail', accountId: '123' }];
+
+		const result = processLines.call(mockExecuteFunctions as IExecuteFunctions, lines, 'bill');
+
+		expect(result).toEqual([
+			{
+				DetailType: 'AccountBasedExpenseLineDetail',
+				AccountBasedExpenseLineDetail: { AccountRef: { value: '123' } },
+			},
+		]);
+	});
+
+	test('should process ItemBasedExpenseLineDetail for bill resource', () => {
+		const lines = [{ DetailType: 'ItemBasedExpenseLineDetail', itemId: '456' }];
+
+		const result = processLines.call(mockExecuteFunctions as IExecuteFunctions, lines, 'bill');
+
+		expect(result).toEqual([
+			{
+				DetailType: 'ItemBasedExpenseLineDetail',
+				ItemBasedExpenseLineDetail: { ItemRef: { value: '456' } },
+			},
+		]);
+	});
+
+	test('should process SalesItemLineDetail for estimate resource', () => {
+		const lines = [{ DetailType: 'SalesItemLineDetail', itemId: '789', TaxCodeRef: 'TAX1' }];
+
+		const result = processLines.call(mockExecuteFunctions as IExecuteFunctions, lines, 'estimate');
+
+		expect(result).toEqual([
+			{
+				DetailType: 'SalesItemLineDetail',
+				SalesItemLineDetail: { ItemRef: { value: '789' }, TaxCodeRef: { value: 'TAX1' } },
+			},
+		]);
+	});
+
+	test('should process SalesItemLineDetail for invoice resource with Qty', () => {
+		const lines = [
+			{ DetailType: 'SalesItemLineDetail', itemId: '101', TaxCodeRef: 'TAX2', Qty: 10 },
+		];
+
+		const result = processLines.call(mockExecuteFunctions as IExecuteFunctions, lines, 'invoice');
+
+		expect(result).toEqual([
+			{
+				DetailType: 'SalesItemLineDetail',
+				SalesItemLineDetail: { ItemRef: { value: '101' }, TaxCodeRef: { value: 'TAX2' }, Qty: 10 },
+			},
+		]);
+	});
+
+	test('should process SalesItemLineDetail for invoice resource without Qty', () => {
+		const lines = [{ DetailType: 'SalesItemLineDetail', itemId: '202', TaxCodeRef: 'TAX3' }];
+
+		const result = processLines.call(mockExecuteFunctions as IExecuteFunctions, lines, 'invoice');
+
+		expect(result).toEqual([
+			{
+				DetailType: 'SalesItemLineDetail',
+				SalesItemLineDetail: { ItemRef: { value: '202' }, TaxCodeRef: { value: 'TAX3' } },
+			},
+		]);
+	});
+});

--- a/packages/nodes-base/nodes/QuickBooks/descriptions/Invoice/InvoiceDescription.ts
+++ b/packages/nodes-base/nodes/QuickBooks/descriptions/Invoice/InvoiceDescription.ts
@@ -148,6 +148,13 @@ export const invoiceFields: INodeProperties[] = [
 					loadOptionsMethod: 'getTaxCodeRefs',
 				},
 			},
+			{
+				displayName: 'Quantity',
+				name: 'Qty',
+				description: 'Number of units of the line item',
+				type: 'number',
+				default: 0,
+			},
 		],
 	},
 	{


### PR DESCRIPTION
## Summary

This PR Adds Qty option to create invoice in Quick books

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-2339/community-issue-quickbooks-create-invoice-fails-due-to-quantity-not
Fixes https://github.com/n8n-io/n8n/issues/12956

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
