### PR TITLE
feat(Extract from File Node): Add relax_quote option

### DIFF
--- a/packages/nodes-base/nodes/Files/ExtractFromFile/actions/spreadsheet.operation.ts
+++ b/packages/nodes-base/nodes/Files/ExtractFromFile/actions/spreadsheet.operation.ts
@@ -18,7 +18,9 @@ export const description: INodeProperties[] = fromFile.description
 			newProperty.options = (newProperty.options as INodeProperties[]).map((option) => {
 				let newOption = option;
 				if (
-					['delimiter', 'encoding', 'fromLine', 'maxRowCount', 'enableBOM'].includes(option.name)
+					['delimiter', 'encoding', 'fromLine', 'maxRowCount', 'enableBOM', 'relaxQuotes'].includes(
+						option.name,
+					)
 				) {
 					newOption = { ...option, displayOptions: { show: { '/operation': ['csv'] } } };
 				}

--- a/packages/nodes-base/nodes/SpreadsheetFile/description.ts
+++ b/packages/nodes-base/nodes/SpreadsheetFile/description.ts
@@ -221,7 +221,7 @@ export const fromFileOptions: INodeProperties = {
 			},
 			default: false,
 			description:
-				"Whether to handle unclosed quotes in CSV fields as part of the field's content instead of throwing a parsing error.",
+				"Whether to handle unclosed quotes in CSV fields as part of the field's content instead of throwing a parsing error",
 		},
 		{
 			displayName: 'Header Row',

--- a/packages/nodes-base/nodes/SpreadsheetFile/description.ts
+++ b/packages/nodes-base/nodes/SpreadsheetFile/description.ts
@@ -221,7 +221,7 @@ export const fromFileOptions: INodeProperties = {
 			},
 			default: false,
 			description:
-				"Whether to handle unclosed quotes in CSV fields as part of the field's content, rather than causing a parsing error",
+				"Whether to handle unclosed quotes in CSV fields as part of the field's content instead of throwing a parsing error.",
 		},
 		{
 			displayName: 'Header Row',

--- a/packages/nodes-base/nodes/SpreadsheetFile/description.ts
+++ b/packages/nodes-base/nodes/SpreadsheetFile/description.ts
@@ -211,6 +211,19 @@ export const fromFileOptions: INodeProperties = {
 				'Whether to detect and exclude the byte-order-mark from the CSV Input if present',
 		},
 		{
+			displayName: 'Preserve quotes inside unquoted field',
+			name: 'relaxQuotes',
+			type: 'boolean',
+			displayOptions: {
+				show: {
+					'/fileFormat': ['csv'],
+				},
+			},
+			default: false,
+			description:
+				'Treats unclosed quotes in CSV fields as part of the field\'s content, rather than causing a parsing error.',
+		},
+		{
 			displayName: 'Header Row',
 			name: 'headerRow',
 			type: 'boolean',

--- a/packages/nodes-base/nodes/SpreadsheetFile/description.ts
+++ b/packages/nodes-base/nodes/SpreadsheetFile/description.ts
@@ -211,7 +211,7 @@ export const fromFileOptions: INodeProperties = {
 				'Whether to detect and exclude the byte-order-mark from the CSV Input if present',
 		},
 		{
-			displayName: 'Preserve quotes inside unquoted field',
+			displayName: 'Preserve Quotes',
 			name: 'relaxQuotes',
 			type: 'boolean',
 			displayOptions: {
@@ -221,7 +221,7 @@ export const fromFileOptions: INodeProperties = {
 			},
 			default: false,
 			description:
-				'Treats unclosed quotes in CSV fields as part of the field\'s content, rather than causing a parsing error.',
+				"Whether to handle unclosed quotes in CSV fields as part of the field's content, rather than causing a parsing error",
 		},
 		{
 			displayName: 'Header Row',

--- a/packages/nodes-base/nodes/SpreadsheetFile/v2/fromFile.operation.ts
+++ b/packages/nodes-base/nodes/SpreadsheetFile/v2/fromFile.operation.ts
@@ -95,6 +95,7 @@ export async function execute(
 					bom: options.enableBOM as boolean,
 					to: maxRowCount > -1 ? maxRowCount : undefined,
 					columns: options.headerRow !== false,
+					relax_quotes: options.relaxQuotes as boolean,
 					onRecord: (record) => {
 						if (!options.includeEmptyCells) {
 							record = Object.fromEntries(


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
It does allow quotes in unquotes csv fields.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
relates to #13594

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

Before:
<img width="1100" alt="image" src="https://github.com/user-attachments/assets/e0f93835-7fd9-4261-91ea-6b9fd8db408c" />
```
n8n:dev: [Node] Invalid Opening Quote: a quote is found on field 4 at line 58863, value is "ROOMZ Display EDU SILVER incl. software subscription (1 year "
```

After:
<img width="1063" alt="image" src="https://github.com/user-attachments/assets/8ddf1401-1742-4260-9405-f3cafe1652b9" />
While no error has been seen in the console.

<img width="505" alt="image" src="https://github.com/user-attachments/assets/d142c655-29f6-48a6-8d9c-76079f9e29e2" />
