### PR TITLE
fix(core): Gracefully handle missing tasks metadata

### DIFF
--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -462,10 +462,15 @@ export class WorkflowExecute {
 			let metaRunData: ITaskMetadata;
 			for (const nodeName of Object.keys(metadata)) {
 				for ([index, metaRunData] of metadata[nodeName].entries()) {
-					runData[nodeName][index].metadata = {
-						...(runData[nodeName][index].metadata ?? {}),
-						...metaRunData,
-					};
+					const taskData = runData[nodeName]?.[index];
+					if (taskData) {
+						taskData.metadata = { ...taskData.metadata, ...metaRunData };
+					} else {
+						Container.get(ErrorReporter).error(
+							new UnexpectedError('Taskdata missing at the end of an execution'),
+							{ extra: { nodeName, index } },
+						);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
Sometimes a error in a node-execution is thrown before `resultData.runData` contains any data for the node at that particular runIndex. This leads to `runData[nodeName][index]` being undefined. Until we fix the types, and have tests covering this code, this PR "temporarily" updates `moveNodeMetadata` to gracefully handle this scenario, to prevent executions from getting stuck forever.
This is not a real fix, but is meant to unblock customers while we change execution lifecycle code to ensure that task-data is always present in the parts of the code where the types suggest so.   

## Related Linear tickets, Github issues, and Community forum posts

CAT-696
Fixes https://github.com/n8n-io/n8n/issues/13138


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
