### PR TITLE
fix(editor): Add `rewriteFramesIntegration` to sentry (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/plugins/sentry.ts
+++ b/packages/frontend/editor-ui/src/plugins/sentry.ts
@@ -15,7 +15,6 @@ const ignoredErrors = [
 ] as const;
 
 export function beforeSend(event: Sentry.ErrorEvent, { originalException }: Sentry.EventHint) {
-	console.log({ event });
 	if (
 		!originalException ||
 		ignoredErrors.some((entry) => {

--- a/packages/frontend/editor-ui/src/plugins/sentry.ts
+++ b/packages/frontend/editor-ui/src/plugins/sentry.ts
@@ -15,6 +15,7 @@ const ignoredErrors = [
 ] as const;
 
 export function beforeSend(event: Sentry.ErrorEvent, { originalException }: Sentry.EventHint) {
+	console.log({ event });
 	if (
 		!originalException ||
 		ignoredErrors.some((entry) => {
@@ -53,6 +54,11 @@ export const SentryPlugin: Plugin = {
 			dsn,
 			release,
 			environment,
+			integrations: [
+				Sentry.rewriteFramesIntegration({
+					root: window.location.origin + '/',
+				}),
+			],
 			beforeSend,
 		});
 


### PR DESCRIPTION
## Summary

Sentry is unable to match sourcemaps to source files because the file path contains different domain names. This should hopefully fix it.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-699/enable-sourcemaps-for-production-build

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
