### PR TITLE
fix(OpenAI Node): Do not report openai RateLimitErrors to Sentry (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/helpers/error-handling.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/helpers/error-handling.test.ts
@@ -1,3 +1,4 @@
+import { OperationalError } from 'n8n-workflow';
 import { RateLimitError } from 'openai';
 import { OpenAIError } from 'openai/error';
 
@@ -41,7 +42,9 @@ describe('error-handling', () => {
 			try {
 				openAiFailedAttemptHandler(error);
 			} catch (e) {
-				expect(e).toBe(error);
+				expect(e).toBeInstanceOf(OperationalError);
+				expect(e.level).toBe('warning');
+				expect(e.cause).toBe(error);
 				expect(e.message).toBe('OpenAI: Rate limit reached');
 			}
 		});

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/helpers/error-handling.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/helpers/error-handling.ts
@@ -1,3 +1,4 @@
+import { OperationalError } from 'n8n-workflow';
 import { RateLimitError } from 'openai';
 import { OpenAIError } from 'openai/error';
 
@@ -20,17 +21,8 @@ export const openAiFailedAttemptHandler = (error: any) => {
 		// If the error is a rate limit error, we want to handle it differently
 		// because OpenAI has multiple different rate limit errors
 		const errorCode = error?.code;
-		if (errorCode) {
-			const customErrorMessage = getCustomErrorMessage(errorCode);
-
-			if (customErrorMessage) {
-				if (error.error) {
-					(error.error as { message: string }).message = customErrorMessage;
-					error.message = customErrorMessage;
-				}
-			}
-		}
-
-		throw error;
+		const errorMessage =
+			getCustomErrorMessage(errorCode ?? 'rate_limit_exceeded') ?? errorMap.rate_limit_exceeded;
+		throw new OperationalError(errorMessage, { cause: error });
 	}
 };


### PR DESCRIPTION
## Summary
When we rethrow `RateLimitError`, they all get reported to Sentry. but there is nothing that we can do with these error reports.
This PR wraps such errors inside an `OperationalError`, which prevents these from being reported to Sentry. 

## Related Linear tickets, Github issues, and Community forum posts

CAT-700
https://n8nio.sentry.io/issues/6136510117

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
