### PR TITLE
fix(editor): Allow pinned data for Code node AI generation

### DIFF
--- a/packages/frontend/editor-ui/src/components/CodeNodeEditor/AskAI/AskAI.vue
+++ b/packages/frontend/editor-ui/src/components/CodeNodeEditor/AskAI/AskAI.vue
@@ -54,7 +54,9 @@ const isSubmitEnabled = computed(() => {
 		hasExecutionData.value
 	);
 });
-const hasExecutionData = computed(() => (useNDVStore().ndvInputData || []).length > 0);
+const hasExecutionData = computed(
+	() => (useNDVStore().ndvInputDataWithPinnedData || []).length > 0,
+);
 const loadingString = computed(() =>
 	i18n.baseText(`codeNodeEditor.askAi.loadingPhrase${loadingPhraseIndex.value}` as BaseTextKey),
 );
@@ -71,7 +73,7 @@ function getErrorMessageByStatusCode(statusCode: number) {
 		429: i18n.baseText('codeNodeEditor.askAi.generationFailedRate'),
 		500: i18n.baseText('codeNodeEditor.askAi.generationFailedUnknown'),
 	};
-
+	console.log(statusCode);
 	return errorMessages[statusCode] || i18n.baseText('codeNodeEditor.askAi.generationFailedUnknown');
 }
 

--- a/packages/frontend/editor-ui/src/components/CodeNodeEditor/AskAI/AskAI.vue
+++ b/packages/frontend/editor-ui/src/components/CodeNodeEditor/AskAI/AskAI.vue
@@ -73,6 +73,7 @@ function getErrorMessageByStatusCode(statusCode: number) {
 		429: i18n.baseText('codeNodeEditor.askAi.generationFailedRate'),
 		500: i18n.baseText('codeNodeEditor.askAi.generationFailedUnknown'),
 	};
+
 	return errorMessages[statusCode] || i18n.baseText('codeNodeEditor.askAi.generationFailedUnknown');
 }
 

--- a/packages/frontend/editor-ui/src/components/CodeNodeEditor/AskAI/AskAI.vue
+++ b/packages/frontend/editor-ui/src/components/CodeNodeEditor/AskAI/AskAI.vue
@@ -73,7 +73,6 @@ function getErrorMessageByStatusCode(statusCode: number) {
 		429: i18n.baseText('codeNodeEditor.askAi.generationFailedRate'),
 		500: i18n.baseText('codeNodeEditor.askAi.generationFailedUnknown'),
 	};
-	console.log(statusCode);
 	return errorMessages[statusCode] || i18n.baseText('codeNodeEditor.askAi.generationFailedUnknown');
 }
 


### PR DESCRIPTION
## Summary

Consider pinned data when determining the state. Note that the actual implementation already supports pinned data https://github.com/n8n-io/n8n/blob/f5743176e57106f5ef626251ed53a4ef9813746f/packages/frontend/editor-ui/src/components/CodeNodeEditor/AskAI/AskAI.vue#L98


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3235/bug-generate-code-does-not-work-with-pinned-data


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
