### PR TITLE
fix(editor): Don't flag uiStore as dirty on node selected

### DIFF
--- a/packages/frontend/editor-ui/src/stores/workflows.store.test.ts
+++ b/packages/frontend/editor-ui/src/stores/workflows.store.test.ts
@@ -681,6 +681,57 @@ describe('useWorkflowsStore', () => {
 		});
 	});
 
+	describe('updateNodeAtIndex', () => {
+		describe('updateNodeAtIndex', () => {
+			it.each([
+				{
+					description: 'should update node at given index with provided data',
+					nodeIndex: 0,
+					nodeData: { name: 'Updated Node' },
+					initialNodes: [{ name: 'Original Node' }],
+					expectedNodes: [{ name: 'Updated Node' }],
+					expectedResult: true,
+				},
+				{
+					description: 'should not update node if index is invalid',
+					nodeIndex: -1,
+					nodeData: { name: 'Updated Node' },
+					initialNodes: [{ name: 'Original Node' }],
+					expectedNodes: [{ name: 'Original Node' }],
+					expectedResult: false,
+				},
+				{
+					description: 'should return false if node data is unchanged',
+					nodeIndex: 0,
+					nodeData: { name: 'Original Node' },
+					initialNodes: [{ name: 'Original Node' }],
+					expectedNodes: [{ name: 'Original Node' }],
+					expectedResult: false,
+				},
+				{
+					description: 'should update multiple properties of a node',
+					nodeIndex: 0,
+					nodeData: { name: 'Updated Node', type: 'newType' },
+					initialNodes: [{ name: 'Original Node', type: 'oldType' }],
+					expectedNodes: [{ name: 'Updated Node', type: 'newType' }],
+					expectedResult: true,
+				},
+			])('$description', ({ nodeIndex, nodeData, initialNodes, expectedNodes, expectedResult }) => {
+				workflowsStore.workflow.nodes = initialNodes as unknown as IWorkflowDb['nodes'];
+
+				const result = workflowsStore.updateNodeAtIndex(nodeIndex, nodeData);
+
+				expect(result).toBe(expectedResult);
+				expect(workflowsStore.workflow.nodes).toEqual(expectedNodes);
+			});
+
+			it('should throw error if out of bounds', () => {
+				workflowsStore.workflow.nodes = [];
+				expect(() => workflowsStore.updateNodeAtIndex(0, { name: 'Updated Node' })).toThrowError();
+			});
+		});
+	});
+
 	test.each([
 		// check userVersion behavior
 		[-1, 1, 1], // userVersion -1, use default (1)

--- a/packages/frontend/editor-ui/src/stores/workflows.store.test.ts
+++ b/packages/frontend/editor-ui/src/stores/workflows.store.test.ts
@@ -682,53 +682,51 @@ describe('useWorkflowsStore', () => {
 	});
 
 	describe('updateNodeAtIndex', () => {
-		describe('updateNodeAtIndex', () => {
-			it.each([
-				{
-					description: 'should update node at given index with provided data',
-					nodeIndex: 0,
-					nodeData: { name: 'Updated Node' },
-					initialNodes: [{ name: 'Original Node' }],
-					expectedNodes: [{ name: 'Updated Node' }],
-					expectedResult: true,
-				},
-				{
-					description: 'should not update node if index is invalid',
-					nodeIndex: -1,
-					nodeData: { name: 'Updated Node' },
-					initialNodes: [{ name: 'Original Node' }],
-					expectedNodes: [{ name: 'Original Node' }],
-					expectedResult: false,
-				},
-				{
-					description: 'should return false if node data is unchanged',
-					nodeIndex: 0,
-					nodeData: { name: 'Original Node' },
-					initialNodes: [{ name: 'Original Node' }],
-					expectedNodes: [{ name: 'Original Node' }],
-					expectedResult: false,
-				},
-				{
-					description: 'should update multiple properties of a node',
-					nodeIndex: 0,
-					nodeData: { name: 'Updated Node', type: 'newType' },
-					initialNodes: [{ name: 'Original Node', type: 'oldType' }],
-					expectedNodes: [{ name: 'Updated Node', type: 'newType' }],
-					expectedResult: true,
-				},
-			])('$description', ({ nodeIndex, nodeData, initialNodes, expectedNodes, expectedResult }) => {
-				workflowsStore.workflow.nodes = initialNodes as unknown as IWorkflowDb['nodes'];
+		it.each([
+			{
+				description: 'should update node at given index with provided data',
+				nodeIndex: 0,
+				nodeData: { name: 'Updated Node' },
+				initialNodes: [{ name: 'Original Node' }],
+				expectedNodes: [{ name: 'Updated Node' }],
+				expectedResult: true,
+			},
+			{
+				description: 'should not update node if index is invalid',
+				nodeIndex: -1,
+				nodeData: { name: 'Updated Node' },
+				initialNodes: [{ name: 'Original Node' }],
+				expectedNodes: [{ name: 'Original Node' }],
+				expectedResult: false,
+			},
+			{
+				description: 'should return false if node data is unchanged',
+				nodeIndex: 0,
+				nodeData: { name: 'Original Node' },
+				initialNodes: [{ name: 'Original Node' }],
+				expectedNodes: [{ name: 'Original Node' }],
+				expectedResult: false,
+			},
+			{
+				description: 'should update multiple properties of a node',
+				nodeIndex: 0,
+				nodeData: { name: 'Updated Node', type: 'newType' },
+				initialNodes: [{ name: 'Original Node', type: 'oldType' }],
+				expectedNodes: [{ name: 'Updated Node', type: 'newType' }],
+				expectedResult: true,
+			},
+		])('$description', ({ nodeIndex, nodeData, initialNodes, expectedNodes, expectedResult }) => {
+			workflowsStore.workflow.nodes = initialNodes as unknown as IWorkflowDb['nodes'];
 
-				const result = workflowsStore.updateNodeAtIndex(nodeIndex, nodeData);
+			const result = workflowsStore.updateNodeAtIndex(nodeIndex, nodeData);
 
-				expect(result).toBe(expectedResult);
-				expect(workflowsStore.workflow.nodes).toEqual(expectedNodes);
-			});
+			expect(result).toBe(expectedResult);
+			expect(workflowsStore.workflow.nodes).toEqual(expectedNodes);
+		});
 
-			it('should throw error if out of bounds', () => {
-				workflowsStore.workflow.nodes = [];
-				expect(() => workflowsStore.updateNodeAtIndex(0, { name: 'Updated Node' })).toThrowError();
-			});
+		it('should throw error if out of bounds', () => {
+			workflowsStore.workflow.nodes = [];
+			expect(() => workflowsStore.updateNodeAtIndex(0, { name: 'Updated Node' })).toThrowError();
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/stores/workflows.store.ts
@@ -62,7 +62,7 @@ import {
 	SEND_AND_WAIT_OPERATION,
 	Workflow,
 } from 'n8n-workflow';
-import { findLast } from 'lodash-es';
+import { findLast, pick, isEqual } from 'lodash-es';
 
 import { useRootStore } from '@/stores/root.store';
 import * as workflowsApi from '@/api/workflows';
@@ -1144,9 +1144,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 	function updateNodeAtIndex(nodeIndex: number, nodeData: Partial<INodeUi>): boolean {
 		if (nodeIndex !== -1) {
 			const node = workflow.value.nodes[nodeIndex];
-			const changed = Object.entries(nodeData).some(
-				([key, value]) => !(key in node) || node[key as keyof INodeUi] !== value,
-			);
+			const changed = !isEqual(pick(node, Object.keys(nodeData)), nodeData);
 			Object.assign(node, nodeData);
 			return changed;
 		}

--- a/packages/frontend/editor-ui/src/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/stores/workflows.store.ts
@@ -91,7 +91,6 @@ import { useNodeHelpers } from '@/composables/useNodeHelpers';
 import { useUsersStore } from '@/stores/users.store';
 import { updateCurrentUserSettings } from '@/api/users';
 import { useExecutingNode } from '@/composables/useExecutingNode';
-import _ from 'lodash';
 
 const defaults: Omit<IWorkflowDb, 'id'> & { settings: NonNullable<IWorkflowDb['settings']> } = {
 	name: '',
@@ -329,7 +328,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 	}
 
 	function getNodeById(nodeId: string): INodeUi | undefined {
-		debugger;
 		return workflow.value.nodes.find((node) => node.id === nodeId);
 	}
 
@@ -1146,7 +1144,9 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 	function updateNodeAtIndex(nodeIndex: number, nodeData: Partial<INodeUi>): boolean {
 		if (nodeIndex !== -1) {
 			const node = workflow.value.nodes[nodeIndex];
-			const changed = !_.isEqual(_.pick(node, Object.keys(nodeData)), nodeData);
+			const changed = Object.entries(nodeData).some(
+				([key, value]) => !(key in node) || node[key as keyof INodeUi] !== value,
+			);
 			Object.assign(node, nodeData);
 			return changed;
 		}


### PR DESCRIPTION
## Summary

Only flag the uiStore as dirty if we actually changed the node.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3278/the-save-button-is-activated-even-when-not-needed-eg-by-selecting-a


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
