### PR TITLE
fix(editor): Disable deactivated node execution

### DIFF
--- a/packages/frontend/editor-ui/src/components/NodeExecuteButton.test.ts
+++ b/packages/frontend/editor-ui/src/components/NodeExecuteButton.test.ts
@@ -1,14 +1,20 @@
 import { reactive } from 'vue';
 import { createTestingPinia } from '@pinia/testing';
+import { useRouter } from 'vue-router';
 import userEvent from '@testing-library/user-event';
 import { createComponentRenderer } from '@/__tests__/render';
 import { type MockedStore, mockedStore } from '@/__tests__/utils';
-import { mockNode } from '@/__tests__/mocks';
-import { CODE_NODE_TYPE } from '@/constants';
+import { mockNode, mockNodeTypeDescription } from '@/__tests__/mocks';
+import { nodeViewEventBus } from '@/event-bus';
+import { CHAT_TRIGGER_NODE_TYPE, SET_NODE_TYPE } from '@/constants';
 import NodeExecuteButton from '@/components/NodeExecuteButton.vue';
 import { useWorkflowsStore } from '@/stores/workflows.store';
 import { useUIStore } from '@/stores/ui.store';
 import { useNodeTypesStore } from '@/stores/nodeTypes.store';
+import { useNDVStore } from '@/stores/ndv.store';
+import { useExecutionsStore } from '@/stores/executions.store';
+import { useRunWorkflow } from '@/composables/useRunWorkflow';
+import { useExternalHooks } from '@/composables/useExternalHooks';
 
 vi.mock('vue-router', () => ({
 	useRouter: () => ({}),
@@ -16,44 +22,65 @@ vi.mock('vue-router', () => ({
 	RouterLink: vi.fn(),
 }));
 
+vi.mock('@/composables/useRunWorkflow', () => ({
+	useRunWorkflow: () => ({
+		runWorkflow: vi.fn(),
+		stopCurrentExecution: vi.fn(),
+	}),
+}));
+
+vi.mock('@/composables/useExternalHooks', () => ({
+	useExternalHooks: () => ({
+		run: vi.fn(),
+	}),
+}));
+
 let renderComponent: ReturnType<typeof createComponentRenderer>;
 let workflowsStore: MockedStore<typeof useWorkflowsStore>;
 let uiStore: MockedStore<typeof useUIStore>;
 let nodeTypesStore: MockedStore<typeof useNodeTypesStore>;
+let ndvStore: MockedStore<typeof useNDVStore>;
+let executionsStore: MockedStore<typeof useExecutionsStore>;
+
+let runWorkflow: ReturnType<typeof useRunWorkflow>;
+let externalHooks: ReturnType<typeof useExternalHooks>;
+
+const nodeViewEventBusEmitSpy = vi.spyOn(nodeViewEventBus, 'emit');
 
 describe('NodeExecuteButton', () => {
 	beforeEach(() => {
+		vi.clearAllMocks();
+
 		renderComponent = createComponentRenderer(NodeExecuteButton, {
 			pinia: createTestingPinia(),
+			props: {
+				nodeName: 'test-node',
+				telemetrySource: 'test-source',
+			},
 		});
 
 		workflowsStore = mockedStore(useWorkflowsStore);
 		uiStore = mockedStore(useUIStore);
 		nodeTypesStore = mockedStore(useNodeTypesStore);
+		ndvStore = mockedStore(useNDVStore);
+		executionsStore = mockedStore(useExecutionsStore);
+
+		runWorkflow = useRunWorkflow({ router: useRouter() });
+		externalHooks = useExternalHooks();
+
+		workflowsStore.workflowId = 'abc123';
 	});
 
 	it('renders without error', () => {
-		expect(() =>
-			renderComponent({
-				props: {
-					nodeName: 'test',
-					telemetrySource: 'test',
-				},
-			}),
-		).not.toThrow();
+		expect(() => renderComponent()).not.toThrow();
 	});
 
 	it('should be disabled if the node is disabled and show tooltip', async () => {
 		workflowsStore.getNodeByName.mockReturnValue(
-			mockNode({ name: 'test', type: CODE_NODE_TYPE, disabled: true }),
+			mockNode({ name: 'test', type: SET_NODE_TYPE, disabled: true }),
 		);
 
-		const { getByRole, queryByRole } = renderComponent({
-			props: {
-				nodeName: 'test',
-				telemetrySource: 'test',
-			},
-		});
+		const { getByRole, queryByRole } = renderComponent();
 
 		const button = getByRole('button');
 		expect(button).toBeDisabled();
@@ -67,14 +94,11 @@ describe('NodeExecuteButton', () => {
 	it('should be disabled when workflow is running but node is not executing', async () => {
 		uiStore.isActionActive.workflowRunning = true;
 		workflowsStore.isNodeExecuting.mockReturnValue(false);
-		workflowsStore.getNodeByName.mockReturnValue(mockNode({ name: 'test', type: CODE_NODE_TYPE }));
+		workflowsStore.getNodeByName.mockReturnValue(
+			mockNode({ name: 'test-node', type: SET_NODE_TYPE }),
+		);
 
-		const { getByRole, queryByRole } = renderComponent({
-			props: {
-				nodeName: 'test',
-				telemetrySource: 'test',
-			},
-		});
+		const { getByRole, queryByRole } = renderComponent();
 
 		const button = getByRole('button');
 		expect(button).toBeDisabled();
@@ -90,20 +114,94 @@ describe('NodeExecuteButton', () => {
 		workflowsStore.getNodeByName.mockReturnValue(
 			mockNode({
 				name: 'test',
-				type: CODE_NODE_TYPE,
+				type: SET_NODE_TYPE,
 				issues: {
 					typeUnknown: true,
 				},
 			}),
 		);
 
-		const { getByRole } = renderComponent({
-			props: {
-				nodeName: 'test',
-				telemetrySource: 'test',
-			},
-		});
+		const { getByRole } = renderComponent();
 
 		expect(getByRole('button')).toBeDisabled();
+	});
+
+	it('stops webhook when clicking button while listening for events', async () => {
+		workflowsStore.executionWaitingForWebhook = true;
+		nodeTypesStore.isTriggerNode = () => true;
+		workflowsStore.getNodeByName.mockReturnValue(
+			mockNode({ name: 'test-node', type: SET_NODE_TYPE }),
+		);
+
+		const { getByRole } = renderComponent();
+
+		await userEvent.click(getByRole('button'));
+
+		expect(workflowsStore.removeTestWebhook).toHaveBeenCalledWith('abc123');
+	});
+
+	it('stops execution when clicking button while workflow is running', async () => {
+		uiStore.isActionActive.workflowRunning = true;
+		nodeTypesStore.isTriggerNode = () => true;
+		workflowsStore.activeExecutionId = 'test-execution-id';
+		workflowsStore.isNodeExecuting.mockReturnValue(true);
+		workflowsStore.getNodeByName.mockReturnValue(
+			mockNode({ name: 'test-node', type: SET_NODE_TYPE }),
+		);
+
+		const { getByRole, emitted } = renderComponent();
+
+		await userEvent.click(getByRole('button'));
+
+		expect(executionsStore.stopCurrentExecution).toHaveBeenCalledWith('test-execution-id');
+		expect(emitted().stopExecution).toBeTruthy();
+	});
+
+	it('runs workflow when clicking button normally', async () => {
+		workflowsStore.getNodeByName.mockReturnValue(
+			mockNode({ name: 'test-node', type: SET_NODE_TYPE }),
+		);
+		nodeTypesStore.getNodeType = () => mockNodeTypeDescription();
+
+		const { getByRole, emitted } = renderComponent();
+
+		await userEvent.click(getByRole('button'));
+
+		expect(externalHooks.run).toHaveBeenCalledWith('nodeExecuteButton.onClick', expect.any(Object));
+		expect(runWorkflow.runWorkflow).toHaveBeenCalledWith({
+			destinationNode: 'test-node',
+			source: 'RunData.ExecuteNodeButton',
+		});
+		expect(emitted().execute).toBeTruthy();
+	});
+
+	it('opens chat when clicking button for chat node', async () => {
+		workflowsStore.getNodeByName.mockReturnValue(
+			mockNode({ name: 'test-node', type: SET_NODE_TYPE }),
+		);
+		nodeTypesStore.getNodeType = () => mockNodeTypeDescription({ name: CHAT_TRIGGER_NODE_TYPE });
+
+		const { getByRole } = renderComponent();
+
+		await userEvent.click(getByRole('button'));
+
+		expect(ndvStore.setActiveNodeName).toHaveBeenCalledWith(null);
+		expect(workflowsStore.chatPartialExecutionDestinationNode).toBe('test-node');
+		expect(nodeViewEventBusEmitSpy).toHaveBeenCalledWith('openChat');
+	});
+
+	it('opens chat when clicking button for chat child node', async () => {
+		workflowsStore.getNodeByName.mockReturnValue(
+			mockNode({ name: 'test-node', type: SET_NODE_TYPE }),
+		);
+		workflowsStore.checkIfNodeHasChatParent.mockReturnValue(true);
+
+		const { getByRole } = renderComponent();
+
+		await userEvent.click(getByRole('button'));
+
+		expect(ndvStore.setActiveNodeName).toHaveBeenCalledWith(null);
+		expect(workflowsStore.chatPartialExecutionDestinationNode).toBe('test-node');
+		expect(nodeViewEventBusEmitSpy).toHaveBeenCalledWith('openChat');
 	});
 });

--- a/packages/frontend/editor-ui/src/components/NodeExecuteButton.test.ts
+++ b/packages/frontend/editor-ui/src/components/NodeExecuteButton.test.ts
@@ -1,0 +1,109 @@
+import { reactive } from 'vue';
+import { createTestingPinia } from '@pinia/testing';
+import userEvent from '@testing-library/user-event';
+import { createComponentRenderer } from '@/__tests__/render';
+import { type MockedStore, mockedStore } from '@/__tests__/utils';
+import { mockNode } from '@/__tests__/mocks';
+import { CODE_NODE_TYPE } from '@/constants';
+import NodeExecuteButton from '@/components/NodeExecuteButton.vue';
+import { useWorkflowsStore } from '@/stores/workflows.store';
+import { useUIStore } from '@/stores/ui.store';
+import { useNodeTypesStore } from '@/stores/nodeTypes.store';
+
+vi.mock('vue-router', () => ({
+	useRouter: () => ({}),
+	useRoute: () => reactive({}),
+	RouterLink: vi.fn(),
+}));
+
+let renderComponent: ReturnType<typeof createComponentRenderer>;
+let workflowsStore: MockedStore<typeof useWorkflowsStore>;
+let uiStore: MockedStore<typeof useUIStore>;
+let nodeTypesStore: MockedStore<typeof useNodeTypesStore>;
+
+describe('NodeExecuteButton', () => {
+	beforeEach(() => {
+		renderComponent = createComponentRenderer(NodeExecuteButton, {
+			pinia: createTestingPinia(),
+		});
+
+		workflowsStore = mockedStore(useWorkflowsStore);
+		uiStore = mockedStore(useUIStore);
+		nodeTypesStore = mockedStore(useNodeTypesStore);
+	});
+
+	it('renders without error', () => {
+		expect(() =>
+			renderComponent({
+				props: {
+					nodeName: 'test',
+					telemetrySource: 'test',
+				},
+			}),
+		).not.toThrow();
+	});
+
+	it('should be disabled if the node is disabled and show tooltip', async () => {
+		workflowsStore.getNodeByName.mockReturnValue(
+			mockNode({ name: 'test', type: CODE_NODE_TYPE, disabled: true }),
+		);
+
+		const { getByRole, queryByRole } = renderComponent({
+			props: {
+				nodeName: 'test',
+				telemetrySource: 'test',
+			},
+		});
+
+		const button = getByRole('button');
+		expect(button).toBeDisabled();
+		expect(queryByRole('tooltip')).not.toBeInTheDocument();
+
+		await userEvent.hover(button);
+		expect(getByRole('tooltip')).toBeVisible();
+		expect(getByRole('tooltip')).toHaveTextContent('Enable node to execute');
+	});
+
+	it('should be disabled when workflow is running but node is not executing', async () => {
+		uiStore.isActionActive.workflowRunning = true;
+		workflowsStore.isNodeExecuting.mockReturnValue(false);
+		workflowsStore.getNodeByName.mockReturnValue(mockNode({ name: 'test', type: CODE_NODE_TYPE }));
+
+		const { getByRole, queryByRole } = renderComponent({
+			props: {
+				nodeName: 'test',
+				telemetrySource: 'test',
+			},
+		});
+
+		const button = getByRole('button');
+		expect(button).toBeDisabled();
+		expect(queryByRole('tooltip')).not.toBeInTheDocument();
+
+		await userEvent.hover(button);
+		expect(getByRole('tooltip')).toBeVisible();
+		expect(getByRole('tooltip')).toHaveTextContent('Workflow is already running');
+	});
+
+	it('disables button when trigger node has issues', async () => {
+		nodeTypesStore.isTriggerNode = () => true;
+		workflowsStore.getNodeByName.mockReturnValue(
+			mockNode({
+				name: 'test',
+				type: CODE_NODE_TYPE,
+				issues: {
+					typeUnknown: true,
+				},
+			}),
+		);
+
+		const { getByRole } = renderComponent({
+			props: {
+				nodeName: 'test',
+				telemetrySource: 'test',
+			},
+		});
+
+		expect(getByRole('button')).toBeDisabled();
+	});
+});

--- a/packages/frontend/editor-ui/src/components/NodeExecuteButton.test.ts
+++ b/packages/frontend/editor-ui/src/components/NodeExecuteButton.test.ts
@@ -12,7 +12,6 @@ import { useWorkflowsStore } from '@/stores/workflows.store';
 import { useUIStore } from '@/stores/ui.store';
 import { useNodeTypesStore } from '@/stores/nodeTypes.store';
 import { useNDVStore } from '@/stores/ndv.store';
-import { useExecutionsStore } from '@/stores/executions.store';
 import { useRunWorkflow } from '@/composables/useRunWorkflow';
 import { useExternalHooks } from '@/composables/useExternalHooks';
 
@@ -40,7 +39,6 @@ let workflowsStore: MockedStore<typeof useWorkflowsStore>;
 let uiStore: MockedStore<typeof useUIStore>;
 let nodeTypesStore: MockedStore<typeof useNodeTypesStore>;
 let ndvStore: MockedStore<typeof useNDVStore>;
-let executionsStore: MockedStore<typeof useExecutionsStore>;
 
 let runWorkflow: ReturnType<typeof useRunWorkflow>;
 let externalHooks: ReturnType<typeof useExternalHooks>;
@@ -63,7 +61,6 @@ describe('NodeExecuteButton', () => {
 		uiStore = mockedStore(useUIStore);
 		nodeTypesStore = mockedStore(useNodeTypesStore);
 		ndvStore = mockedStore(useNDVStore);
-		executionsStore = mockedStore(useExecutionsStore);
 
 		runWorkflow = useRunWorkflow({ router: useRouter() });
 		externalHooks = useExternalHooks();
@@ -153,7 +150,7 @@ describe('NodeExecuteButton', () => {
 
 		await userEvent.click(getByRole('button'));
 
-		expect(executionsStore.stopCurrentExecution).toHaveBeenCalledWith('test-execution-id');
+		expect(runWorkflow.stopCurrentExecution).toHaveBeenCalledWith('test-execution-id');
 		expect(emitted().stopExecution).toBeTruthy();
 	});
 

--- a/packages/frontend/editor-ui/src/components/NodeExecuteButton.test.ts
+++ b/packages/frontend/editor-ui/src/components/NodeExecuteButton.test.ts
@@ -221,6 +221,7 @@ describe('NodeExecuteButton', () => {
 		expect(queryByRole('tooltip')).not.toBeInTheDocument();
 
 		await userEvent.hover(button);
+
 		expect(getByRole('tooltip')).toBeVisible();
 		expect(getByRole('tooltip')).toHaveTextContent('Enable node to execute');
 	});
@@ -239,6 +240,7 @@ describe('NodeExecuteButton', () => {
 		expect(queryByRole('tooltip')).not.toBeInTheDocument();
 
 		await userEvent.hover(button);
+
 		expect(getByRole('tooltip')).toBeVisible();
 		expect(getByRole('tooltip')).toHaveTextContent('Workflow is already running');
 	});
@@ -371,6 +373,7 @@ describe('NodeExecuteButton', () => {
 		const { getByRole, emitted } = renderComponent();
 
 		await userEvent.click(getByRole('button'));
+
 		expect(generateCodeForAiTransformSpy).toHaveBeenCalledTimes(1);
 		expect(toast.showMessage).toHaveBeenCalledTimes(1);
 		expect(emitted().valueChanged).toEqual([

--- a/packages/frontend/editor-ui/src/components/NodeExecuteButton.vue
+++ b/packages/frontend/editor-ui/src/components/NodeExecuteButton.vue
@@ -85,7 +85,7 @@ const nodeType = computed((): INodeTypeDescription | null => {
 });
 
 const isNodeRunning = computed(() => {
-	if (!uiStore.isActionActive['workflowRunning'] || codeGenerationInProgress.value) return false;
+	if (!uiStore.isActionActive.workflowRunning || codeGenerationInProgress.value) return false;
 	const triggeredNode = workflowsStore.executedNode;
 	return (
 		workflowsStore.isNodeExecuting(node.value?.name ?? '') || triggeredNode === node.value?.name

--- a/packages/frontend/editor-ui/src/components/NodeExecuteButton.vue
+++ b/packages/frontend/editor-ui/src/components/NodeExecuteButton.vue
@@ -26,7 +26,7 @@ import { useUIStore } from '@/stores/ui.store';
 import { useRouter } from 'vue-router';
 import { useI18n } from '@/composables/useI18n';
 import { useTelemetry } from '@/composables/useTelemetry';
-import { type IUpdateInformation } from '../Interface';
+import { type IUpdateInformation } from '@/Interface';
 import { generateCodeForAiTransform } from '@/components/ButtonParameter/utils';
 
 const NODE_TEST_STEP_POPUP_COUNT_KEY = 'N8N_NODE_TEST_STEP_POPUP_COUNT';
@@ -367,28 +367,21 @@ async function onClick() {
 </script>
 
 <template>
-	<div>
-		<n8n-tooltip placement="right" :disabled="!tooltipText">
-			<template #content>
-				<div>{{ tooltipText }}</div>
-			</template>
-			<div>
-				<n8n-button
-					v-bind="$attrs"
-					:loading="isLoading"
-					:disabled="disabled || !!disabledHint"
-					:label="buttonLabel"
-					:type="type"
-					:size="size"
-					:icon="buttonIcon"
-					:transparent-background="transparent"
-					:title="
-						!isTriggerNode && !tooltipText ? i18n.baseText('ndv.execute.testNode.description') : ''
-					"
-					@mouseover="onMouseOver"
-					@click="onClick"
-				/>
-			</div>
-		</n8n-tooltip>
-	</div>
+	<N8nTooltip placement="right" :disabled="!tooltipText" :content="tooltipText">
+		<N8nButton
+			v-bind="$attrs"
+			:loading="isLoading"
+			:disabled="disabled || !!disabledHint"
+			:label="buttonLabel"
+			:type="type"
+			:size="size"
+			:icon="buttonIcon"
+			:transparent-background="transparent"
+			:title="
+				!isTriggerNode && !tooltipText ? i18n.baseText('ndv.execute.testNode.description') : ''
+			"
+			@mouseover="onMouseOver"
+			@click="onClick"
+		/>
+	</N8nTooltip>
 </template>

--- a/packages/frontend/editor-ui/src/components/NodeExecuteButton.vue
+++ b/packages/frontend/editor-ui/src/components/NodeExecuteButton.vue
@@ -155,7 +155,7 @@ const disabledHint = computed(() => {
 		return i18n.baseText('ndv.execute.generatingCode');
 	}
 
-	if (isTriggerNode.value && node?.value?.disabled) {
+	if (node?.value?.disabled) {
 		return i18n.baseText('ndv.execute.nodeIsDisabled');
 	}
 

--- a/packages/frontend/editor-ui/src/components/canvas/elements/nodes/CanvasNodeToolbar.test.ts
+++ b/packages/frontend/editor-ui/src/components/canvas/elements/nodes/CanvasNodeToolbar.test.ts
@@ -1,4 +1,5 @@
-import { fireEvent, waitFor } from '@testing-library/vue';
+import { waitFor } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
 import CanvasNodeToolbar from '@/components/canvas/elements/nodes/CanvasNodeToolbar.vue';
 import { createComponentRenderer } from '@/__tests__/render';
 import { createCanvasNodeProvide, createCanvasProvide } from '@/__tests__/data';
@@ -35,6 +36,29 @@ describe('CanvasNodeToolbar', () => {
 		expect(getByTestId('execute-node-button')).toBeDisabled();
 	});
 
+	it('should render disabled execute node button when node is deactivated', async () => {
+		const { getByTestId, getByRole } = renderComponent({
+			global: {
+				provide: {
+					...createCanvasNodeProvide({
+						data: {
+							disabled: true,
+						},
+					}),
+					...createCanvasProvide(),
+				},
+			},
+		});
+
+		const button = getByTestId('execute-node-button');
+		expect(button).toBeDisabled();
+
+		await userEvent.hover(button);
+
+		expect(getByRole('tooltip')).toBeVisible();
+		expect(getByRole('tooltip')).toHaveTextContent("This node is deactivated and can't be run");
+	});
+
 	it('should not render execute node button when renderType is configuration', async () => {
 		const { queryByTestId } = renderComponent({
 			global: {
@@ -65,7 +89,7 @@ describe('CanvasNodeToolbar', () => {
 			},
 		});
 
-		await fireEvent.click(getByTestId('execute-node-button'));
+		await userEvent.click(getByTestId('execute-node-button'));
 
 		expect(emitted('run')[0]).toEqual([]);
 	});
@@ -80,7 +104,7 @@ describe('CanvasNodeToolbar', () => {
 			},
 		});
 
-		await fireEvent.click(getByTestId('disable-node-button'));
+		await userEvent.click(getByTestId('disable-node-button'));
 
 		expect(emitted('toggle')[0]).toEqual([]);
 	});
@@ -95,7 +119,7 @@ describe('CanvasNodeToolbar', () => {
 			},
 		});
 
-		await fireEvent.click(getByTestId('delete-node-button'));
+		await userEvent.click(getByTestId('delete-node-button'));
 
 		expect(emitted('delete')[0]).toEqual([]);
 	});
@@ -110,7 +134,7 @@ describe('CanvasNodeToolbar', () => {
 			},
 		});
 
-		await fireEvent.click(getByTestId('overflow-node-button'));
+		await userEvent.click(getByTestId('overflow-node-button'));
 
 		expect(emitted('open:contextmenu')[0]).toEqual([expect.any(MouseEvent)]);
 	});
@@ -132,8 +156,8 @@ describe('CanvasNodeToolbar', () => {
 			},
 		});
 
-		await fireEvent.click(getByTestId('change-sticky-color'));
-		await fireEvent.click(getAllByTestId('color')[0]);
+		await userEvent.click(getByTestId('change-sticky-color'));
+		await userEvent.click(getAllByTestId('color')[0]);
 
 		expect(emitted('update')[0]).toEqual([{ color: 1 }]);
 	});
@@ -150,7 +174,7 @@ describe('CanvasNodeToolbar', () => {
 
 		const toolbar = getByTestId('canvas-node-toolbar');
 
-		await fireEvent.mouseEnter(toolbar);
+		await userEvent.hover(toolbar);
 
 		expect(toolbar).toHaveClass('forceVisible');
 	});
@@ -174,7 +198,7 @@ describe('CanvasNodeToolbar', () => {
 
 		const toolbar = getByTestId('canvas-node-toolbar');
 
-		await fireEvent.click(getByTestId('change-sticky-color'));
+		await userEvent.click(getByTestId('change-sticky-color'));
 
 		await waitFor(() => expect(toolbar).toHaveClass('forceVisible'));
 	});

--- a/packages/frontend/editor-ui/src/components/canvas/elements/nodes/CanvasNodeToolbar.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/elements/nodes/CanvasNodeToolbar.vue
@@ -94,17 +94,23 @@ function onMouseLeave() {
 		@mouseleave="onMouseLeave"
 	>
 		<div :class="$style.canvasNodeToolbarItems">
-			<N8nIconButton
-				v-if="isExecuteNodeVisible"
-				data-test-id="execute-node-button"
-				type="tertiary"
-				text
-				size="small"
-				icon="play"
-				:disabled="isExecuting"
-				:title="i18n.baseText('node.testStep')"
-				@click="executeNode"
-			/>
+			<N8nTooltip
+				placement="top"
+				:disabled="!isDisabled"
+				:content="i18n.baseText('ndv.execute.deactivated')"
+			>
+				<N8nIconButton
+					v-if="isExecuteNodeVisible"
+					data-test-id="execute-node-button"
+					type="tertiary"
+					text
+					size="small"
+					icon="play"
+					:disabled="isExecuting || isDisabled"
+					:title="i18n.baseText('node.testStep')"
+					@click="executeNode"
+				/>
+			</N8nTooltip>
 			<N8nIconButton
 				v-if="isDisableNodeVisible"
 				data-test-id="disable-node-button"

--- a/packages/frontend/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/frontend/editor-ui/src/plugins/i18n/locales/en.json
@@ -976,6 +976,7 @@
 	"ndv.execute.requiredFieldsMissing": "Complete required fields first",
 	"ndv.execute.stopWaitingForWebhook.error": "Problem deleting test webhook",
 	"ndv.execute.workflowAlreadyRunning": "Workflow is already running",
+	"ndv.execute.deactivated": "This node is deactivated and can't be run",
 	"ndv.featureRequest": "I wish this node would...",
 	"ndv.input": "Input",
 	"ndv.input.nodeDistance": "{count} node back | {count} nodes back",


### PR DESCRIPTION
## Summary

Prevent deactivated node execution as they're not executed either when the workflow gets executed.
A deactivated node needs to be activated before being executed individually.

## Related Linear tickets, Github issues, and Community forum posts

PAY-2620


## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport`
