### PR TITLE
fix(core): Remove Python code node memory leak using Workers

### DIFF
--- a/packages/nodes-base/nodes/Code/Pyodide.ts
+++ b/packages/nodes-base/nodes/Code/Pyodide.ts
@@ -3,15 +3,13 @@ import type { PyodideInterface } from 'pyodide';
 let pyodideInstance: PyodideInterface | undefined;
 
 export async function LoadPyodide(packageCacheDir: string): Promise<PyodideInterface> {
-	if (pyodideInstance === undefined) {
-		const { loadPyodide } = await import('pyodide');
-		pyodideInstance = await loadPyodide({ packageCacheDir });
+	const { loadPyodide } = await import('pyodide');
+	pyodideInstance = await loadPyodide({ packageCacheDir });
 
-		await pyodideInstance.runPythonAsync(`
+	await pyodideInstance.runPythonAsync(`
 from _pyodide_core import jsproxy_typedict
 from js import Object
 `);
-	}
 
 	return pyodideInstance;
 }

--- a/packages/nodes-base/nodes/Code/PythonSandbox.ts
+++ b/packages/nodes-base/nodes/Code/PythonSandbox.ts
@@ -55,7 +55,6 @@ export class PythonSandbox extends Sandbox {
 
 	private async runCodeInPython<T>() {
 		const workerFilePath = await this.createWorkerFile();
-		console.log(workerFilePath);
 
 		try {
 			return await this.executePythonInWorker<T>(workerFilePath);

--- a/packages/nodes-base/nodes/Code/PythonSandbox.ts
+++ b/packages/nodes-base/nodes/Code/PythonSandbox.ts
@@ -1,7 +1,8 @@
+import * as fs from 'fs';
 import { ApplicationError, type IExecuteFunctions, type INodeExecutionData } from 'n8n-workflow';
-import type { PyDict } from 'pyodide/ffi';
+import * as path from 'path';
+import { Worker } from 'worker_threads';
 
-import { LoadPyodide } from './Pyodide';
 import type { SandboxContext } from './Sandbox';
 import { Sandbox } from './Sandbox';
 
@@ -53,46 +54,174 @@ export class PythonSandbox extends Sandbox {
 	}
 
 	private async runCodeInPython<T>() {
-		const packageCacheDir = this.helpers.getStoragePath();
-		const pyodide = await LoadPyodide(packageCacheDir);
+		const workerFilePath = await this.createWorkerFile();
+		console.log(workerFilePath);
 
-		let executionResult;
 		try {
-			await pyodide.runPythonAsync('jsproxy_typedict[0] = type(Object.new().as_object_map())');
-
-			await pyodide.loadPackagesFromImports(this.pythonCode);
-
-			const dict = pyodide.globals.get('dict');
-			const globalsDict: PyDict = dict();
-			for (const key of Object.keys(this.context)) {
-				if ((key === '_env' && envAccessBlocked) || key === '_node') continue;
-				const value = this.context[key];
-				globalsDict.set(key, value);
-			}
-
-			pyodide.setStdout({ batched: (str) => this.emit('output', str) });
-
-			const runCode = `
-async def __main():
-${this.pythonCode
-	.split('\n')
-	.map((line) => '  ' + line)
-	.join('\n')}
-await __main()`;
-			executionResult = await pyodide.runPythonAsync(runCode, { globals: globalsDict });
-			globalsDict.destroy();
+			return await this.executePythonInWorker<T>(workerFilePath);
 		} catch (error) {
 			throw this.getPrettyError(error as PyodideError);
+		} finally {
+			// Clean up the temporary worker file
+			try {
+				fs.unlinkSync(workerFilePath);
+			} catch (e) {
+				console.error('Failed to delete temporary worker file:', e);
+			}
+		}
+	}
+
+	/**
+	 * Creates a temporary worker file for Python code execution
+	 */
+	private async createWorkerFile(): Promise<string> {
+		const packageCacheDir = this.helpers.getStoragePath();
+		const tempDir = path.join(packageCacheDir, 'workers');
+
+		if (!fs.existsSync(tempDir)) {
+			fs.mkdirSync(tempDir, { recursive: true });
 		}
 
-		if (executionResult?.toJs) {
-			return executionResult.toJs({
-				dict_converter: Object.fromEntries,
-				create_proxies: false,
-			}) as T;
-		}
+		const workerFilePath = path.join(tempDir, `python-worker-${Date.now()}.js`);
 
-		return executionResult as T;
+		fs.writeFileSync(workerFilePath, this.generateWorkerCode());
+
+		return workerFilePath;
+	}
+
+	/**
+	 * Generates the worker thread code for Python execution
+	 */
+	private generateWorkerCode(): string {
+		return `
+			const { parentPort, workerData } = require('worker_threads');
+			const { pythonCode, context, packageCacheDir } = workerData;
+
+			async function runPython() {
+				try {
+					const { LoadPyodide } = require('${path.resolve(__dirname, './Pyodide.js')}');
+					const pyodide = await LoadPyodide(packageCacheDir);
+
+					await pyodide.runPythonAsync('jsproxy_typedict[0] = type(Object.new().as_object_map())');
+					await pyodide.loadPackagesFromImports(pythonCode);
+
+					const globalsDict = pyodide.globals.get('dict')();
+					for (const [key, value] of Object.entries(context)) {
+						if ((key === '_env' && ${envAccessBlocked}) || key === '_node') continue;
+						globalsDict.set(key, value);
+					}
+
+					const indentedCode = pythonCode.split('\\n').map(line => '  ' + line).join('\\n');
+					const result = await pyodide.runPythonAsync(
+						\`async def __main():\n\${indentedCode}\nawait __main()\`,
+						{ globals: globalsDict }
+					);
+
+					const jsResult = result?.toJs ?
+						result.toJs({ dict_converter: Object.fromEntries, create_proxies: false }) :
+						result;
+					// Clean up
+					globalsDict.destroy();
+
+					// Send result back to main thread
+					parentPort.postMessage({ success: true, result: jsResult });
+				} catch (error) {
+					// Send error back to main thread
+					parentPort.postMessage({
+						success: false,
+						error: error.message,
+						type: error.type || 'Error'
+					});
+				}
+			}
+
+			runPython();
+		`;
+	}
+
+	private async executePythonInWorker<T>(workerFilePath: string): Promise<T> {
+		return await new Promise((resolve, reject) => {
+			try {
+				function sanitizeForWorker(input: any, seen = new WeakMap()) {
+					if (typeof input !== 'object' || input === null) {
+						if (typeof input === 'function' || typeof input === 'symbol') {
+							return undefined;
+						}
+						return input;
+					}
+
+					// Handle circular references: if we've seen this object, return the same reference
+					if (seen.has(input)) {
+						return seen.get(input);
+					}
+
+					let output: any;
+
+					if (Array.isArray(input)) {
+						output = [];
+						// Mark the object as seen before recursing
+						seen.set(input, output);
+						for (const item of input) {
+							const sanitizedItem = sanitizeForWorker(item, seen);
+							if (sanitizedItem !== undefined) {
+								output.push(sanitizedItem);
+							}
+						}
+						return output;
+					}
+
+					output = {};
+					seen.set(input, output);
+					for (const key in input) {
+						if (Object.prototype.hasOwnProperty.call(input, key)) {
+							const value = input[key];
+							// If the value is non-cloneable, skip it
+							if (typeof value === 'function' || typeof value === 'symbol') {
+								continue;
+							}
+							const sanitizedValue = sanitizeForWorker(value, seen);
+							if (sanitizedValue !== undefined) {
+								output[key] = sanitizedValue;
+							}
+						}
+					}
+
+					return output;
+				}
+
+				const worker = new Worker(workerFilePath, {
+					workerData: {
+						pythonCode: this.pythonCode,
+						context: sanitizeForWorker(this.context),
+						packageCacheDir: this.helpers.getStoragePath(),
+					},
+				});
+
+				console.log('before on message');
+				worker.on('message', (data) => {
+					console.log('on message', data);
+					if (data.success) {
+						resolve(data.result as T);
+					} else {
+						const error = new Error(data.error);
+						(error as PyodideError).type = data.type;
+						reject(error);
+					}
+				});
+
+				worker.on('error', (error) => {
+					reject(error);
+				});
+
+				worker.on('exit', (code) => {
+					if (code !== 0 && code !== null) {
+						reject(new Error(`Worker stopped with exit code ${code}`));
+					}
+				});
+			} catch (error) {
+				reject(error);
+			}
+		});
 	}
 
 	private getPrettyError(error: PyodideError): Error {

--- a/packages/nodes-base/nodes/Code/test/PythonSandbox.test.ts
+++ b/packages/nodes-base/nodes/Code/test/PythonSandbox.test.ts
@@ -1,0 +1,301 @@
+import * as fs from 'fs';
+import type { IExecuteFunctions } from 'n8n-workflow';
+import * as path from 'path';
+import { Worker } from 'worker_threads';
+
+import { PythonSandbox } from '../PythonSandbox';
+
+jest.mock('fs');
+jest.mock('worker_threads');
+
+describe('PythonSandbox', () => {
+  let sandbox: PythonSandbox;
+  let mockHelpers: IExecuteFunctions['helpers'];
+  let mockWorker: { on: jest.Mock; postMessage: jest.Mock };
+
+  const mockStoragePath = '/mock/storage/path';
+  const mockPythonCode = 'print("Hello World")';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Mock helpers
+    mockHelpers = {
+      getStoragePath: jest.fn().mockReturnValue(mockStoragePath),
+    } as unknown as IExecuteFunctions['helpers'];
+
+    // Mock fs functions
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    (fs.mkdirSync as jest.Mock).mockImplementation(() => undefined);
+    (fs.writeFileSync as jest.Mock).mockImplementation(() => undefined);
+    (fs.unlinkSync as jest.Mock).mockImplementation(() => undefined);
+
+    // Mock Worker
+    mockWorker = {
+      on: jest.fn(),
+      postMessage: jest.fn(),
+    };
+
+    (Worker as unknown as jest.Mock).mockImplementation(() => mockWorker);
+
+    // Setup default worker behavior
+    mockWorker.on.mockImplementation((event, callback) => {
+      if (event === 'message') {
+        callback({ success: true, result: {} });
+      }
+      return mockWorker;
+    });
+
+    // Create sandbox instance
+    sandbox = new PythonSandbox({} as any, mockPythonCode, mockHelpers);
+  });
+
+  describe('worker file management', () => {
+    it('should create worker file in the correct directory', async () => {
+      // Mock Date.now() to get consistent file names
+      const mockTimestamp = 1234567890;
+      jest.spyOn(Date, 'now').mockReturnValue(mockTimestamp);
+
+      // Access the private method
+      const createWorkerFile = (sandbox as any).createWorkerFile.bind(sandbox);
+      const workerFilePath = await createWorkerFile();
+
+      // Assertions
+      const expectedPath = path.join(mockStoragePath, 'workers', `python-worker-${mockTimestamp}.js`);
+      expect(workerFilePath).toBe(expectedPath);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(expectedPath, expect.any(String));
+    });
+
+    it('should create the workers directory if it does not exist', async () => {
+      // Setup
+      (fs.existsSync as jest.Mock).mockReturnValue(false);
+
+      // Execute
+      const createWorkerFile = (sandbox as any).createWorkerFile.bind(sandbox);
+      await createWorkerFile();
+
+      // Assert
+      expect(fs.mkdirSync).toHaveBeenCalledWith(
+        path.join(mockStoragePath, 'workers'),
+        { recursive: true }
+      );
+    });
+
+    it('should generate worker code with correct absolute paths', async () => {
+      // Execute
+      const generateWorkerCode = (sandbox as any).generateWorkerCode.bind(sandbox);
+      const workerCode = generateWorkerCode();
+
+      // Assert
+      const pyodidePath = path.resolve(__dirname, '../Pyodide.js');
+      expect(workerCode).toContain(`require('${pyodidePath}')`);
+    });
+
+    it('should clean up worker file after execution', async () => {
+      // Setup
+      jest.spyOn(sandbox as any, 'executePythonInWorker').mockResolvedValue({});
+
+      // Execute
+      const runCodeInPython = (sandbox as any).runCodeInPython.bind(sandbox);
+      await runCodeInPython();
+
+      // Assert
+      expect(fs.unlinkSync).toHaveBeenCalled();
+    });
+  });
+
+  describe('worker communication', () => {
+    it('should pass the correct packageCacheDir to the worker', async () => {
+      // Setup a spy to capture worker options
+      let capturedOptions: any;
+      (Worker as unknown as jest.Mock).mockImplementation((_, options) => {
+        capturedOptions = options;
+        return mockWorker;
+      });
+
+      // Execute
+      const executePythonInWorker = (sandbox as any).executePythonInWorker.bind(sandbox);
+      await executePythonInWorker('/mock/worker/file.js');
+
+      // Assert
+      expect(capturedOptions.workerData.packageCacheDir).toBe(mockStoragePath);
+    });
+
+    it('should handle worker exit with non-zero code as error', async () => {
+      // Setup worker to emit exit event with error code
+      mockWorker.on.mockImplementation((event, callback) => {
+        if (event === 'exit') {
+          callback(1); // Non-zero exit code
+        }
+        return mockWorker;
+      });
+
+      // Execute and assert
+      const executePythonInWorker = (sandbox as any).executePythonInWorker.bind(sandbox);
+      await expect(executePythonInWorker('/mock/worker/file.js')).rejects.toThrow('Worker stopped with exit code 1');
+    });
+  });
+
+  describe('Python code execution', () => {
+    it('should execute code and return the result', async () => {
+      // Setup worker to return a specific result
+      mockWorker.on.mockImplementation((event, callback) => {
+        if (event === 'message') {
+          callback({ success: true, result: { hello: 'world' } });
+        }
+        return mockWorker;
+      });
+
+      // Create sandbox with specific Python code
+      const pythonCode = 'result = {"hello": "world"}\nreturn result';
+      const testSandbox = new PythonSandbox({} as any, pythonCode, mockHelpers);
+
+      // Execute and assert
+      const result = await testSandbox.runCode();
+      expect(result).toEqual({ hello: 'world' });
+
+      // Verify worker was created with correct code
+      expect(Worker).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          workerData: expect.objectContaining({ pythonCode })
+        })
+      );
+    });
+
+    it('should propagate Python execution errors', async () => {
+      // Setup worker to return an error
+      mockWorker.on.mockImplementation((event, callback) => {
+        if (event === 'message') {
+          callback({
+            success: false,
+            error: 'NameError: name "undefined_variable" is not defined',
+            type: 'NameError'
+          });
+        }
+        return mockWorker;
+      });
+
+      // Execute and assert
+      await expect(sandbox.runCode()).rejects.toThrow();
+    });
+
+    it('should format Python errors for better readability', async () => {
+      // Setup
+      const error = new Error('Python Error: NameError: name is not defined');
+      (error as any).type = 'NameError';
+
+      // Execute
+      const getPrettyError = (sandbox as any).getPrettyError.bind(sandbox);
+      const prettyError = getPrettyError(error);
+
+      // Assert
+      expect(prettyError.message).toContain('NameError');
+    });
+  });
+
+  describe('context handling', () => {
+    it('should convert $ prefixed variables to _ prefixed for Python compatibility', () => {
+      // Setup context with $ prefixed variables
+      const context = {
+        $input: { item: { json: {} } },
+        $json: { data: 123 }
+      };
+
+      // Create sandbox with this context
+      const testSandbox = new PythonSandbox(context as any, mockPythonCode, mockHelpers);
+
+      // Access the private context property
+      const pythonContext = (testSandbox as any).context;
+
+      // Assert
+      expect(pythonContext).toHaveProperty('_input');
+      expect(pythonContext).toHaveProperty('_json');
+      expect(pythonContext).not.toHaveProperty('$input');
+      expect(pythonContext).not.toHaveProperty('$json');
+    });
+
+    it('should pass sanitized context to the worker', async () => {
+      // Setup
+      let capturedWorkerData: any;
+      (Worker as unknown as jest.Mock).mockImplementation((_, options) => {
+        capturedWorkerData = options.workerData;
+        return mockWorker;
+      });
+
+      // Create context with test data
+      const testContext = {
+        $input: { item: { json: { testData: 123 } } },
+        $json: { testData: 123 }
+      };
+
+      // Create sandbox with this context
+      const testSandbox = new PythonSandbox(testContext as any, mockPythonCode, mockHelpers);
+
+      // Execute
+      await testSandbox.runCode();
+
+      // Assert
+      expect(capturedWorkerData.context).toHaveProperty('_json');
+      expect(capturedWorkerData.context._json).toHaveProperty('testData', 123);
+    });
+
+    it('should handle circular references in context', async () => {
+      // Setup
+      let capturedWorkerData: any;
+      (Worker as unknown as jest.Mock).mockImplementation((_, options) => {
+        capturedWorkerData = options.workerData;
+        return mockWorker;
+      });
+
+      // Create circular reference
+      const circularObj: any = { name: 'circular' };
+      circularObj.self = circularObj;
+
+      const testContext = {
+        $input: { item: { json: { circular: circularObj } } }
+      };
+
+      // Create sandbox and execute
+      const testSandbox = new PythonSandbox(testContext as any, mockPythonCode, mockHelpers);
+      await testSandbox.runCode();
+
+      // Assert
+      expect(capturedWorkerData.context._input.item.json.circular).toBeDefined();
+      expect(capturedWorkerData.context._input.item.json.circular.name).toBe('circular');
+      expect(capturedWorkerData.context._input.item.json.circular.self).toBeDefined();
+    });
+
+    it('should filter out non-serializable values from context', async () => {
+      // Setup
+      let capturedWorkerData: any;
+      (Worker as unknown as jest.Mock).mockImplementation((_, options) => {
+        capturedWorkerData = options.workerData;
+        return mockWorker;
+      });
+
+      // Create context with function and symbol
+      const testContext = {
+        $input: {
+          item: {
+            json: {
+              fn: () => console.log('test'),
+              sym: Symbol('test'),
+              valid: 'data'
+            }
+          }
+        }
+      };
+
+      // Create sandbox and execute
+      const testSandbox = new PythonSandbox(testContext as any, mockPythonCode, mockHelpers);
+      await testSandbox.runCode();
+
+      // Assert
+      expect(capturedWorkerData.context._input.item.json.valid).toBe('data');
+      expect(capturedWorkerData.context._input.item.json.fn).toBeUndefined();
+      expect(capturedWorkerData.context._input.item.json.sym).toBeUndefined();
+    });
+  });
+
+});


### PR DESCRIPTION
## Summary

This PR addresses issue #7939 where users report significant memory growth when using Python in Code nodes. The solution implements a Worker approach that completely resolves the memory leak pattern.

Memory usage comparison charts: https://n8n-memory-git-master-nikitas-projects-2b098508.vercel.app/

![CleanShot 2025-03-03 at 23 50 00@2x](https://github.com/user-attachments/assets/15995830-766b-48d1-8654-2d908c06efe4)
![CleanShot 2025-03-03 at 23 50 03@2x](https://github.com/user-attachments/assets/36869c71-92df-4030-9c9d-d91547511065)
![CleanShot 2025-03-04 at 00 07 51@2x](https://github.com/user-attachments/assets/9a197bdc-4975-41a1-8bb1-43c9011dd233)

## Problem

Users have documented persistent memory growth issues when running Python code nodes:

- Memory increases with each execution and never fully recovers
- Baseline memory usage continually grows over time
- Eventually leads to high memory consumption and OOM errors

Looking at the memory charts from my testing, the pattern is clear - our current implementation shows steadily increasing memory usage that never fully recovers. This matches exactly what users have reported in issue #7939, where memory grows from around 200MB to over 1GB and continues climbing with each Python execution.

## Investigations

The root cause is in how Pyodide (our Python-in-browser implementation) manages memory:
When Python code executes through Pyodide, it creates WebAssembly memory allocations that aren't fully released afterward. Even when JavaScript references are cleared and Python's garbage collector runs, portions of this WASM heap remain allocated.

## Solutions Tested

I tested three approaches:

1. **Removing the singleton pattern**: This helped somewhat by creating a fresh Pyodide instance each time, but still left significant memory unreleased.
2. **Manual cleanup** with sys.modules.clear() and gc.collect(): This provided minor improvements but couldn't reach all the memory being held.
3. **Worker implementation**: This completely solved the issue by isolating each execution in its own worker thread and terminating it afterward.

The charts clearly show that both removing the singleton and using Workers address the memory growth, but the Worker approach is significantly more effective at reclaiming memory: https://n8n-memory-git-master-nikitas-projects-2b098508.vercel.app/

The workflow used was two python scripts executed one after the other every 20 seconds for ~10-15 minutes then turned off for ~10 minutes.

```
my_list = [0] * 1000000
return {"a": my_list}
```
![CleanShot 2025-03-04 at 00 05 04@2x](https://github.com/user-attachments/assets/cb16ad8a-ea46-4052-91ff-d249435652c4)
![CleanShot 2025-03-04 at 00 07 03@2x](https://github.com/user-attachments/assets/3abc9347-9b8d-4ae0-8bd4-2f6d0c716d6e)
![CleanShot 2025-03-04 at 00 05 17@2x](https://github.com/user-attachments/assets/dcdd4cbd-705c-47e6-a542-23d553efcc6b)

## Why Workers Work Better

The Worker solution is superior because terminating a worker forces the browser to reclaim all resources associated with it, including the WebAssembly heap that normal garbage collection can't reach. This creates a complete reset between executions without relying on Pyodide's internal cleanup mechanisms.

This implementation should resolve the frustrating experience users like @pablorq and @merlinxcy have reported where their n8n instances continuously consume more memory until they're forced to restart.

The implementation creates a new worker for each Python execution:

1. Launch worker with Pyodide environment
2. Send Python code and context to worker
3. Receive results from worker
4. Terminate worker completely, releasing all memory

## Implementation Tradeoffs

This implementation creates some tradeoffs worth mentioning:

1. Performance overhead: Creating a worker and initializing a new Pyodide environment for each execution adds <~150ms latency compared to reusing an existing instance depending on machine. This is typically negligible for most workflows, especially considering Python code execution itself is usually the more time-consuming part.

2. Resource usage: Each worker temporarily increases memory usage by approximately 40-60MB during initialization, though these resources are completely released afterward. This temporary spike is far preferable to the permanent memory growth pattern we were seeing.

However, these tradeoffs are well justified given:

- The complete resolution of memory leaks
- Prevention of OOM crashes in production systems 
- More consistent performance over time
- Elimination of need for periodic restarts

In testing, the initialization overhead proved to be a worthwhile tradeoff for the stability benefits. For most Python Code node use cases, the slight performance impact will be negligible compared to the benefits of reliable memory management.

## Future Optimizations

While this implementation completely solves the memory leak issue, there are potential optimizations we could explore in the future:

1. **Worker pooling**: If Python execution becomes performance-critical, we could implement a small pool of workers that are reused for a limited number of executions before being recycled. This would balance memory management with startup performance.

2. **Selective serialization**: We could optimize the data passing between the main thread and worker by implementing smarter serialization that only includes the minimum required context.

These optimizations aren't necessary for the current fix but represent potential future enhancements if needed.

## Related Linear tickets, Github issues, and Community forum posts

Fixes: https://github.com/n8n-io/n8n/issues/7939

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
