### PR TITLE
fix(chat): Extract text output of the QA node in hosted chat

### DIFF
--- a/packages/frontend/@n8n/chat/src/plugins/chat.ts
+++ b/packages/frontend/@n8n/chat/src/plugins/chat.ts
@@ -48,7 +48,11 @@ export const ChatPlugin: Plugin<ChatOptions> = {
 				options,
 			);
 
-			let textMessage = sendMessageResponse.output ?? sendMessageResponse.text ?? '';
+			let textMessage =
+				sendMessageResponse.output ??
+				sendMessageResponse.text ??
+				sendMessageResponse.response?.text ?? // For QA chains
+				'';
 
 			if (textMessage === '' && Object.keys(sendMessageResponse).length > 0) {
 				try {

--- a/packages/frontend/@n8n/chat/src/types/webhook.ts
+++ b/packages/frontend/@n8n/chat/src/types/webhook.ts
@@ -15,4 +15,7 @@ export interface LoadPreviousSessionResponse {
 export interface SendMessageResponse {
 	output?: string;
 	text?: string;
+	response?: {
+		text?: string;
+	};
 }


### PR DESCRIPTION
## Summary

The QA Chain Node returns a data structure different from other chains or agents. This leads to hosted chat showing JSON instead of the plain text. This PR adds a check for the QA node's format before the JSON fallback.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-355/bug-chat-response-in-json-instead-of-text-when-using-question-and
- https://github.com/n8n-io/n8n/issues/10446
- https://community.n8n.io/t/parsing-error-during-chat-session/53906
- https://community.n8n.io/t/n8n-io-hosted-chat-displays-json-in-the-output/54269

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
