### PR TITLE
fix(core): Pick up release version and date from package.json (no-changelog)

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -109,7 +109,6 @@ jobs:
           context: ./docker/images/n8n
           build-args: |
             N8N_VERSION=${{ needs.publish-to-npm.outputs.release }}
-            N8N_RELEASE_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           platforms: linux/amd64,linux/arm64
           provenance: false
           push: true

--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -4,18 +4,15 @@ FROM n8nio/base:${NODE_VERSION}
 ARG N8N_VERSION
 RUN if [ -z "$N8N_VERSION" ] ; then echo "The N8N_VERSION argument is missing!" ; exit 1; fi
 
-ARG N8N_RELEASE_DATE
 LABEL org.opencontainers.image.title="n8n"
 LABEL org.opencontainers.image.description="Workflow Automation Tool"
 LABEL org.opencontainers.image.source="https://github.com/n8n-io/n8n"
 LABEL org.opencontainers.image.url="https://n8n.io"
 LABEL org.opencontainers.image.version=${N8N_VERSION}
-LABEL org.opencontainers.image.created=${N8N_RELEASE_DATE}
 
 ENV N8N_VERSION=${N8N_VERSION}
 ENV NODE_ENV=production
 ENV N8N_RELEASE_TYPE=stable
-ENV N8N_RELEASE_DATE=${N8N_RELEASE_DATE}
 RUN set -eux; \
 	npm install -g --omit=dev n8n@${N8N_VERSION} --ignore-scripts && \
 	npm rebuild --prefix=/usr/local/lib/node_modules/n8n sqlite3 && \

--- a/packages/@n8n/config/src/configs/generic.config.ts
+++ b/packages/@n8n/config/src/configs/generic.config.ts
@@ -9,9 +9,6 @@ export class GenericConfig {
 	@Env('N8N_RELEASE_TYPE')
 	releaseChannel: 'stable' | 'beta' | 'nightly' | 'dev' = 'dev';
 
-	@Env('N8N_RELEASE_DATE')
-	releaseDate?: Date;
-
 	/** Grace period (in seconds) to wait for components to shut down before process exit. */
 	@Env('N8N_GRACEFUL_SHUTDOWN_TIMEOUT')
 	gracefulShutdownTimeout: number = 30;

--- a/packages/@n8n/config/src/configs/sentry.config.ts
+++ b/packages/@n8n/config/src/configs/sentry.config.ts
@@ -11,14 +11,6 @@ export class SentryConfig {
 	frontendDsn: string = '';
 
 	/**
-	 * Version of the n8n instance
-	 *
-	 * @example '1.73.0'
-	 */
-	@Env('N8N_VERSION')
-	n8nVersion: string = '';
-
-	/**
 	 * Environment of the n8n instance.
 	 *
 	 * @example 'production'

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -243,7 +243,6 @@ describe('GlobalConfig', () => {
 		sentry: {
 			backendDsn: '',
 			frontendDsn: '',
-			n8nVersion: '',
 			environment: '',
 			deploymentName: '',
 		},
@@ -326,7 +325,6 @@ describe('GlobalConfig', () => {
 			DB_LOGGING_MAX_EXECUTION_TIME: '0',
 			N8N_METRICS: 'TRUE',
 			N8N_TEMPLATES_ENABLED: '0',
-			N8N_RELEASE_DATE: '2025-02-17T13:54:15Z',
 		};
 		const config = Container.get(GlobalConfig);
 		expect(structuredClone(config)).toEqual({
@@ -357,10 +355,6 @@ describe('GlobalConfig', () => {
 			templates: {
 				...defaultConfig.templates,
 				enabled: false,
-			},
-			generic: {
-				...defaultConfig.generic,
-				releaseDate: new Date('2025-02-17T13:54:15.000Z'),
 			},
 		});
 		expect(mockFs.readFileSync).not.toHaveBeenCalled();
@@ -395,17 +389,6 @@ describe('GlobalConfig', () => {
 		expect(config.database.logging.maxQueryExecutionTime).toEqual(0);
 		expect(consoleWarnMock).toHaveBeenCalledWith(
 			'Invalid number value for DB_LOGGING_MAX_EXECUTION_TIME: abcd',
-		);
-	});
-
-	it('should handle invalid timestamps', () => {
-		process.env = {
-			N8N_RELEASE_DATE: 'abcd',
-		};
-		const config = Container.get(GlobalConfig);
-		expect(config.generic.releaseDate).toBeUndefined();
-		expect(consoleWarnMock).toHaveBeenCalledWith(
-			'Invalid timestamp value for N8N_RELEASE_DATE: abcd',
 		);
 	});
 });

--- a/packages/cli/src/commands/base-command.ts
+++ b/packages/cli/src/commands/base-command.ts
@@ -14,7 +14,13 @@ import { ensureError, sleep, UserError } from 'n8n-workflow';
 
 import type { AbstractServer } from '@/abstract-server';
 import config from '@/config';
-import { LICENSE_FEATURES, inDevelopment, inTest } from '@/constants';
+import {
+	LICENSE_FEATURES,
+	N8N_VERSION,
+	N8N_RELEASE_DATE,
+	inDevelopment,
+	inTest,
+} from '@/constants';
 import * as CrashJournal from '@/crash-journal';
 import * as Db from '@/db';
 import { getDataDeduplicationService } from '@/deduplication';
@@ -63,15 +69,14 @@ export abstract class BaseCommand extends Command {
 	async init(): Promise<void> {
 		this.errorReporter = Container.get(ErrorReporter);
 
-		const { releaseDate } = this.globalConfig.generic;
-		const { backendDsn, n8nVersion, environment, deploymentName } = this.globalConfig.sentry;
+		const { backendDsn, environment, deploymentName } = this.globalConfig.sentry;
 		await this.errorReporter.init({
 			serverType: this.instanceSettings.instanceType,
 			dsn: backendDsn,
 			environment,
-			release: n8nVersion,
+			release: N8N_VERSION,
 			serverName: deploymentName,
-			releaseDate,
+			releaseDate: N8N_RELEASE_DATE,
 		});
 		initExpressionEvaluator();
 

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'fs';
+import { readFileSync, statSync } from 'fs';
 import type { n8n } from 'n8n-core';
 import type { ITaskDataConnections } from 'n8n-workflow';
 import { jsonParse, TRIMMED_TASK_DATA_CONNECTIONS_KEY } from 'n8n-workflow';
@@ -18,17 +18,16 @@ export const TEMPLATES_DIR = join(CLI_DIR, 'templates');
 export const NODES_BASE_DIR = dirname(require.resolve('n8n-nodes-base'));
 export const EDITOR_UI_DIST_DIR = join(dirname(require.resolve('n8n-editor-ui')), 'dist');
 
-export function getN8nPackageJson() {
-	return jsonParse<n8n.PackageJson>(readFileSync(join(CLI_DIR, 'package.json'), 'utf8'));
-}
+const packageJsonPath = join(CLI_DIR, 'package.json');
+const n8nPackageJson = jsonParse<n8n.PackageJson>(readFileSync(packageJsonPath, 'utf8'));
+export const N8N_VERSION = n8nPackageJson.version + (inDevelopment ? '-dev' : '');
+export const N8N_RELEASE_DATE = statSync(packageJsonPath).mtime;
 
 export const STARTING_NODES = [
 	'@n8n/n8n-nodes-langchain.manualChatTrigger',
 	'n8n-nodes-base.start',
 	'n8n-nodes-base.manualTrigger',
 ];
-
-export const N8N_VERSION = getN8nPackageJson().version;
 
 export const NODE_PACKAGE_PREFIX = 'n8n-nodes-';
 

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -20,7 +20,7 @@ export const EDITOR_UI_DIST_DIR = join(dirname(require.resolve('n8n-editor-ui'))
 
 const packageJsonPath = join(CLI_DIR, 'package.json');
 const n8nPackageJson = jsonParse<n8n.PackageJson>(readFileSync(packageJsonPath, 'utf8'));
-export const N8N_VERSION = n8nPackageJson.version + (inDevelopment ? '-dev' : '');
+export const N8N_VERSION = n8nPackageJson.version;
 export const N8N_RELEASE_DATE = statSync(packageJsonPath).mtime;
 
 export const STARTING_NODES = [

--- a/packages/cli/src/security-audit/risk-reporters/instance-risk-reporter.ts
+++ b/packages/cli/src/security-audit/risk-reporters/instance-risk-reporter.ts
@@ -5,7 +5,7 @@ import { InstanceSettings, Logger } from 'n8n-core';
 import type { IWorkflowBase } from 'n8n-workflow';
 
 import config from '@/config';
-import { getN8nPackageJson, inDevelopment } from '@/constants';
+import { inDevelopment, N8N_VERSION } from '@/constants';
 import { isApiEnabled } from '@/public-api';
 import {
 	ENV_VARS_DOCS_URL,
@@ -175,7 +175,7 @@ export class InstanceRiskReporter implements RiskReporter {
 	private async getOutdatedState() {
 		let versions = [];
 
-		const localVersion = getN8nPackageJson().version;
+		const localVersion = N8N_VERSION;
 
 		try {
 			versions = await this.getNextVersions(localVersion).then((v) => this.removeIconData(v));

--- a/packages/cli/test/integration/security-audit/utils.ts
+++ b/packages/cli/test/integration/security-audit/utils.ts
@@ -114,9 +114,8 @@ export const MOCK_PACKAGE: InstalledPackages[] = [
 export function simulateOutdatedInstanceOnce(versionName = MOCK_01110_N8N_VERSION.name) {
 	const baseUrl = Container.get(GlobalConfig).versionNotifications.endpoint + '/';
 
-	jest
-		.spyOn(constants, 'getN8nPackageJson')
-		.mockReturnValueOnce({ name: 'n8n', version: versionName });
+	// @ts-expect-error readonly export
+	constants.N8N_VERSION = versionName;
 
 	nock(baseUrl).get(versionName).reply(200, [MOCK_01110_N8N_VERSION, MOCK_09990_N8N_VERSION]);
 }
@@ -124,9 +123,8 @@ export function simulateOutdatedInstanceOnce(versionName = MOCK_01110_N8N_VERSIO
 export function simulateUpToDateInstance(versionName = MOCK_09990_N8N_VERSION.name) {
 	const baseUrl = Container.get(GlobalConfig).versionNotifications.endpoint + '/';
 
-	jest
-		.spyOn(constants, 'getN8nPackageJson')
-		.mockReturnValueOnce({ name: 'n8n', version: versionName });
+	// @ts-expect-error readonly export
+	constants.N8N_VERSION = versionName;
 
 	nock(baseUrl).persist().get(versionName).reply(200, [MOCK_09990_N8N_VERSION]);
 }


### PR DESCRIPTION
## Summary
In #13323 I added a new env variable `N8N_RELEASE_DATE` to track how old a release it.
Unfortunately since we couldn't test that workflow without creating a release, we did not catch that the shell command in that workflow wasn't executed as I thought it would.
This PR removes some of that setup, and switches to reading the version and release data from the `package.json` for the `cli` package.

## Related Linear tickets, Github issues, and Community forum posts

[CAT-702](https://linear.app/n8n/issue/CAT-702)
Fixes #13661

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
