### PR TITLE
fix(editor): Fix GCP icon size for external secrets modal

### DIFF
--- a/packages/frontend/editor-ui/src/components/ExternalSecretsProviderModal.ee.vue
+++ b/packages/frontend/editor-ui/src/components/ExternalSecretsProviderModal.ee.vue
@@ -300,6 +300,11 @@ async function onConnectionStateChange() {
 	flex-direction: row;
 	align-items: center;
 	flex: 1;
+
+	svg {
+		max-width: 28px;
+		max-height: 28px;
+	}
 }
 
 .providerActions {

--- a/packages/frontend/editor-ui/src/components/ExternalSecretsProviderModal.ee.vue
+++ b/packages/frontend/editor-ui/src/components/ExternalSecretsProviderModal.ee.vue
@@ -301,7 +301,8 @@ async function onConnectionStateChange() {
 	align-items: center;
 	flex: 1;
 
-	svg {
+	svg,
+	img {
 		max-width: 28px;
 		max-height: 28px;
 	}


### PR DESCRIPTION
## Summary

<img width="540" alt="Screenshot 2025-03-04 at 13 41 50" src="https://github.com/user-attachments/assets/b60e68e6-a6f6-4fac-9f3d-1bee7cdcf73f" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-8376/community-issue-gcp-secret-manager-icon-size-issue-with-external

Closes https://github.com/n8n-io/n8n/issues/13608

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
