### PR TITLE
fix(editor): Fix opening 'Schema' view by default after opening binary nodes

### DIFF
--- a/packages/frontend/editor-ui/src/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/components/RunData.vue
@@ -1171,7 +1171,7 @@ function init() {
 	} else if (displayMode.value === 'binary') {
 		ndvStore.setPanelDisplayMode({
 			pane: props.paneType,
-			mode: 'table',
+			mode: 'schema',
 		});
 	}
 }


### PR DESCRIPTION
## Summary

The default RunData NDV tab to open should be `schema` on non binary nodes, even after a binary node has been opened. If user opened a node with binary inputs the default would switch to `table`, and this PR changes that back to `schema`.

https://github.com/user-attachments/assets/7f3b168c-017c-40ff-b06c-b9378633041c


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3220/schema-view-opening-a-ndv-with-binary-inputs-changes-the-default-view

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
