### PR TITLE
fix(editor): Adjust MappingFields parameterInput width to account for delete button (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/components/ResourceMapper/MappingFields.vue
+++ b/packages/frontend/editor-ui/src/components/ResourceMapper/MappingFields.vue
@@ -449,7 +449,7 @@ defineExpose({
 	padding: 0 0 0 var(--spacing-s);
 
 	.parameterInput {
-		width: 100%;
+		width: calc(100% - var(--delete-option-width));
 	}
 
 	.parameterInput:first-child {


### PR DESCRIPTION
## Summary

Before:
<img width="225" alt="image" src="https://github.com/user-attachments/assets/121bc4b6-4d08-4ccf-89db-7f6b0c102ebf" />


After:
<img width="225" alt="image" src="https://github.com/user-attachments/assets/5d5dbcbf-9116-4ead-9818-977e2b23ef44" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3283/bug-fromai-override-in-workflowinputs-does-not-respect-component-width


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
