### PR TITLE
fix(editor): Adjust URL on lost change warning Cancel or failed save

### DIFF
--- a/cypress/composables/modals/save-changes-modal.ts
+++ b/cypress/composables/modals/save-changes-modal.ts
@@ -1,3 +1,13 @@
 export function getSaveChangesModal() {
 	return cy.get('.el-overlay').contains('Save changes before leaving?');
 }
+
+// this is the button next to 'Save Changes'
+export function getCancelSaveChangesButton() {
+	return cy.get('.btn--cancel');
+}
+
+// This is the top right 'x'
+export function getCloseSaveChangesButton() {
+	return cy.get('.el-message-box__headerbtn');
+}

--- a/cypress/composables/workflowsPage.ts
+++ b/cypress/composables/workflowsPage.ts
@@ -8,6 +8,8 @@ export function getWorkflowsPageUrl() {
 
 export const getCreateWorkflowButton = () => cy.getByTestId('add-resource-workflow');
 
+export const getNewWorkflowCardButton = () => cy.getByTestId('new-workflow-card');
+
 /**
  * Actions
  */

--- a/cypress/composables/workflowsPage.ts
+++ b/cypress/composables/workflowsPage.ts
@@ -6,6 +6,8 @@ export function getWorkflowsPageUrl() {
 	return '/home/workflows';
 }
 
+export const getCreateWorkflowButton = () => cy.getByTestId('add-resource-workflow');
+
 /**
  * Actions
  */

--- a/cypress/e2e/44-routing.cy.ts
+++ b/cypress/e2e/44-routing.cy.ts
@@ -1,20 +1,16 @@
 import {
-	getCancelSaveChangesButton,
 	getCloseSaveChangesButton,
 	getSaveChangesModal,
 } from '../composables/modals/save-changes-modal';
 import { getHomeButton } from '../composables/projects';
+import { addNodeToCanvas } from '../composables/workflow';
 import {
 	getCreateWorkflowButton,
+	getNewWorkflowCardButton,
 	getWorkflowsPageUrl,
 	visitWorkflowsPage,
 } from '../composables/workflowsPage';
 import { EDIT_FIELDS_SET_NODE_NAME } from '../constants';
-import { WorkflowPage as WorkflowPageClass } from '../pages/workflow';
-import { WorkflowsPage as WorkflowsPageClass } from '../pages/workflows';
-
-const WorkflowsPage = new WorkflowsPageClass();
-const WorkflowPage = new WorkflowPageClass();
 
 describe('Workflows', () => {
 	beforeEach(() => {
@@ -22,12 +18,12 @@ describe('Workflows', () => {
 	});
 
 	it('should ask to save unsaved changes before leaving route', () => {
-		WorkflowsPage.getters.newWorkflowButtonCard().should('be.visible');
-		WorkflowsPage.getters.newWorkflowButtonCard().click();
+		getNewWorkflowCardButton().should('be.visible');
+		getNewWorkflowCardButton().click();
 
 		cy.createFixtureWorkflow('Test_workflow_1.json', 'Empty State Card Workflow');
 
-		WorkflowPage.actions.addNodeToCanvas(EDIT_FIELDS_SET_NODE_NAME);
+		addNodeToCanvas(EDIT_FIELDS_SET_NODE_NAME);
 
 		getHomeButton().click();
 
@@ -38,7 +34,7 @@ describe('Workflows', () => {
 		getCreateWorkflowButton().click();
 
 		cy.createFixtureWorkflow('Test_workflow_1.json', 'Empty State Card Workflow');
-		WorkflowPage.actions.addNodeToCanvas(EDIT_FIELDS_SET_NODE_NAME);
+		addNodeToCanvas(EDIT_FIELDS_SET_NODE_NAME);
 
 		// Here we go back via browser rather than the home button
 		// As this already updates the route

--- a/cypress/e2e/44-routing.cy.ts
+++ b/cypress/e2e/44-routing.cy.ts
@@ -1,4 +1,14 @@
-import { getSaveChangesModal } from '../composables/modals/save-changes-modal';
+import {
+	getCancelSaveChangesButton,
+	getCloseSaveChangesButton,
+	getSaveChangesModal,
+} from '../composables/modals/save-changes-modal';
+import { getHomeButton } from '../composables/projects';
+import {
+	getCreateWorkflowButton,
+	getWorkflowsPageUrl,
+	visitWorkflowsPage,
+} from '../composables/workflowsPage';
 import { EDIT_FIELDS_SET_NODE_NAME } from '../constants';
 import { WorkflowPage as WorkflowPageClass } from '../pages/workflow';
 import { WorkflowsPage as WorkflowsPageClass } from '../pages/workflows';
@@ -8,7 +18,7 @@ const WorkflowPage = new WorkflowPageClass();
 
 describe('Workflows', () => {
 	beforeEach(() => {
-		cy.visit(WorkflowsPage.url);
+		visitWorkflowsPage();
 	});
 
 	it('should ask to save unsaved changes before leaving route', () => {
@@ -19,8 +29,27 @@ describe('Workflows', () => {
 
 		WorkflowPage.actions.addNodeToCanvas(EDIT_FIELDS_SET_NODE_NAME);
 
-		cy.getByTestId('project-home-menu-item').click();
+		getHomeButton().click();
 
 		getSaveChangesModal().should('be.visible');
+	});
+
+	it('should correct route after cancelling saveChangesModal', () => {
+		getCreateWorkflowButton().click();
+
+		cy.createFixtureWorkflow('Test_workflow_1.json', 'Empty State Card Workflow');
+		WorkflowPage.actions.addNodeToCanvas(EDIT_FIELDS_SET_NODE_NAME);
+
+		// Here we go back via browser rather than the home button
+		// As this already updates the route
+		cy.go(-1);
+
+		cy.url().should('include', getWorkflowsPageUrl());
+
+		getSaveChangesModal().should('be.visible');
+		getCloseSaveChangesButton().click();
+
+		// Confirm the url is back to the workflow
+		cy.url().should('include', '/workflow/');
 	});
 });

--- a/cypress/e2e/44-routing.cy.ts
+++ b/cypress/e2e/44-routing.cy.ts
@@ -1,4 +1,5 @@
 import {
+	getCancelSaveChangesButton,
 	getCloseSaveChangesButton,
 	getSaveChangesModal,
 } from '../composables/modals/save-changes-modal';
@@ -27,7 +28,14 @@ describe('Workflows', () => {
 
 		getHomeButton().click();
 
+		// We expect to still be on the workflow route here
+		cy.url().should('include', '/workflow/');
+
 		getSaveChangesModal().should('be.visible');
+		getCancelSaveChangesButton().click();
+
+		// Only now do we switch
+		cy.url().should('include', getWorkflowsPageUrl());
 	});
 
 	it('should correct route after cancelling saveChangesModal', () => {

--- a/packages/frontend/editor-ui/src/composables/useWorkflowHelpers.ts
+++ b/packages/frontend/editor-ui/src/composables/useWorkflowHelpers.ts
@@ -1,6 +1,7 @@
 import {
 	HTTP_REQUEST_NODE_TYPE,
 	MODAL_CANCEL,
+	MODAL_CLOSE,
 	MODAL_CONFIRM,
 	PLACEHOLDER_EMPTY_WORKFLOW_ID,
 	PLACEHOLDER_FILLED_AT_EXECUTION_TIME,
@@ -827,6 +828,12 @@ export function useWorkflowHelpers(options: { router: ReturnType<typeof useRoute
 
 			const workflowDataRequest: IWorkflowDataUpdate = await getWorkflowDataToSave();
 
+			// This can happen if the user has another workflow in the browser history and navigates
+			// via the browser back button, encountering our warning dialog with the new route already set
+			if (workflowDataRequest.id !== currentWorkflow) {
+				throw new Error('Attempted to save a workflow different from the current workflow');
+			}
+
 			if (name) {
 				workflowDataRequest.name = name.trim();
 			}
@@ -1139,18 +1146,24 @@ export function useWorkflowHelpers(options: { router: ReturnType<typeof useRoute
 				const saved = await saveCurrentWorkflow({}, false);
 				if (saved) {
 					await npsSurveyStore.fetchPromptsData();
-				}
-				uiStore.stateIsDirty = false;
-
-				const goToNext = await confirm();
-				if (goToNext) {
-					next();
+					uiStore.stateIsDirty = false;
+					const goToNext = await confirm();
+					if (goToNext) {
+						next();
+					}
+				} else {
+					router.resolve({ name: VIEWS.WORKFLOW, params: { name: workflowsStore.workflow.id } });
+					next(false);
 				}
 			} else if (confirmModal === MODAL_CANCEL) {
 				await cancel();
 
 				uiStore.stateIsDirty = false;
 				next();
+			} else if (confirmModal === MODAL_CLOSE) {
+				// The route may have already changed due to the browser back button, so let's restore it
+				router.resolve({ name: VIEWS.WORKFLOW, params: { name: workflowsStore.workflow.id } });
+				next(false);
 			}
 		} else {
 			next();

--- a/packages/frontend/editor-ui/src/composables/useWorkflowHelpers.ts
+++ b/packages/frontend/editor-ui/src/composables/useWorkflowHelpers.ts
@@ -1141,19 +1141,20 @@ export function useWorkflowHelpers(options: { router: ReturnType<typeof useRoute
 					showClose: true,
 				},
 			);
-
 			if (confirmModal === MODAL_CONFIRM) {
 				const saved = await saveCurrentWorkflow({}, false);
 				if (saved) {
 					await npsSurveyStore.fetchPromptsData();
 					uiStore.stateIsDirty = false;
 					const goToNext = await confirm();
-					if (goToNext) {
-						next();
-					}
+					next(goToNext);
 				} else {
-					router.resolve({ name: VIEWS.WORKFLOW, params: { name: workflowsStore.workflow.id } });
-					next(false);
+					next(
+						router.resolve({
+							name: VIEWS.WORKFLOW,
+							params: { name: workflowsStore.workflow.id },
+						}),
+					);
 				}
 			} else if (confirmModal === MODAL_CANCEL) {
 				await cancel();
@@ -1162,8 +1163,12 @@ export function useWorkflowHelpers(options: { router: ReturnType<typeof useRoute
 				next();
 			} else if (confirmModal === MODAL_CLOSE) {
 				// The route may have already changed due to the browser back button, so let's restore it
-				router.resolve({ name: VIEWS.WORKFLOW, params: { name: workflowsStore.workflow.id } });
-				next(false);
+				next(
+					router.resolve({
+						name: VIEWS.WORKFLOW,
+						params: { name: workflowsStore.workflow.id },
+					}),
+				);
 			}
 		} else {
 			next();


### PR DESCRIPTION
## Summary

Currently our route handling fails to account for cancelling the "did you forget to save?" prompt, especially if the user used the back button to trigger it.
This PR attempts to restore a valid url state for some more common scenarios, and especially to prevent overwriting a different workflow in the history.

Will add (e2e?) tests once I confirmed the approach is sound.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3209/community-issue-workflows-are-overwritten-and-lost-when-switching


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
