### PR TITLE
fix(editor): Expand error view to full output panel width

### DIFF
--- a/packages/frontend/editor-ui/src/components/Error/NodeErrorView.vue
+++ b/packages/frontend/editor-ui/src/components/Error/NodeErrorView.vue
@@ -654,7 +654,6 @@ async function onAskAssistantClick() {
 <style lang="scss">
 .node-error-view {
 	&__header {
-		max-width: 960px;
 		margin: 0 auto var(--spacing-s) auto;
 		padding-bottom: var(--spacing-3xs);
 		background-color: var(--color-background-xlight);
@@ -755,7 +754,6 @@ async function onAskAssistantClick() {
 	}
 
 	&__info {
-		max-width: 960px;
 		margin: 0 auto;
 		border: 1px solid var(--color-foreground-base);
 		border-radius: var(--border-radius-large);


### PR DESCRIPTION
## Summary
**Before**:
![image](https://github.com/user-attachments/assets/5c8232c7-756e-47fe-8944-50fab9e1558e)

**After**:
![image](https://github.com/user-attachments/assets/e43e7749-d53f-4280-bc27-7bc36bc05247)


## Related Linear tickets, Github issues, and Community forum posts
Fixes ADO-3228


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
