### PR TITLE
fix(editor): Render credential-only nodes when loading from the backend

### DIFF
--- a/packages/frontend/editor-ui/src/stores/workflows.store.test.ts
+++ b/packages/frontend/editor-ui/src/stores/workflows.store.test.ts
@@ -12,7 +12,13 @@ import type { IExecutionResponse, INodeUi, IWorkflowDb, IWorkflowSettings } from
 import { useNodeTypesStore } from '@/stores/nodeTypes.store';
 
 import { SEND_AND_WAIT_OPERATION } from 'n8n-workflow';
-import type { IPinData, ExecutionSummary, IConnection, INodeExecutionData } from 'n8n-workflow';
+import type {
+	IPinData,
+	ExecutionSummary,
+	IConnection,
+	INodeExecutionData,
+	INode,
+} from 'n8n-workflow';
 import { stringSizeInBytes } from '@/utils/typesUtils';
 import { dataPinningEventBus } from '@/event-bus';
 import { useUIStore } from '@/stores/ui.store';
@@ -678,6 +684,34 @@ describe('useWorkflowsStore', () => {
 
 			expect(workflowsStore.workflow.nodes[0].position).toStrictEqual([0, 0]);
 			expect(workflowsStore.nodeMetadata[nodeName].parametersLastUpdatedAt).toBe(undefined);
+		});
+	});
+
+	describe('setNodes()', () => {
+		it('should transform credential-only nodes', () => {
+			const setNodeId = '1';
+			const credentialOnlyNodeId = '2';
+			workflowsStore.setNodes([
+				mock<INode>({
+					id: setNodeId,
+					name: 'Edit Fields',
+					type: 'n8n-nodes-base.set',
+				}),
+				mock<INode>({
+					id: credentialOnlyNodeId,
+					name: 'AlienVault Request',
+					type: 'n8n-nodes-base.httpRequest',
+					extendsCredential: 'alienVaultApi',
+				}),
+			]);
+
+			expect(workflowsStore.workflow.nodes[0].id).toEqual(setNodeId);
+			expect(workflowsStore.workflow.nodes[1].id).toEqual(credentialOnlyNodeId);
+			expect(workflowsStore.workflow.nodes[1].type).toEqual('n8n-creds-base.alienVaultApi');
+			expect(workflowsStore.nodeMetadata).toEqual({
+				'AlienVault Request': { pristine: true },
+				'Edit Fields': { pristine: true },
+			});
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/stores/workflows.store.ts
@@ -1117,6 +1117,10 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 				nodeHelpers.assignNodeId(node);
 			}
 
+			if (node.extendsCredential) {
+				node.type = getCredentialOnlyNodeTypeName(node.extendsCredential);
+			}
+
 			if (!nodeMetadata.value[node.name]) {
 				nodeMetadata.value[node.name] = { pristine: true };
 			}
@@ -1181,10 +1185,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 			// All nodes have to have a name
 			// TODO: Check if there is an error or whatever that is supposed to be returned
 			return;
-		}
-
-		if (nodeData.extendsCredential) {
-			nodeData.type = getCredentialOnlyNodeTypeName(nodeData.extendsCredential);
 		}
 
 		workflow.value.nodes.push(nodeData);


### PR DESCRIPTION
## Summary

Credential-only nodes would be displayed as normal HTTP request nodes after refresh.

This PR fixes that issue by transforming the node `type` when storing the nodes in the workflow store.

<img width="382" alt="image" src="https://github.com/user-attachments/assets/44912b6e-c7ee-43d4-ba1f-b2e43bb5f7d4" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2248/credential-only-nodes-become-http-request-nodes


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
