### PR TITLE
fix(editor): Support pasting values that start with `=`

### DIFF
--- a/packages/frontend/editor-ui/src/__tests__/setup.ts
+++ b/packages/frontend/editor-ui/src/__tests__/setup.ts
@@ -82,7 +82,22 @@ class Worker {
 	terminate = vi.fn();
 }
 
+class DataTransfer {
+	private data: Record<string, unknown> = {};
+
+	setData = vi.fn((type, data) => {
+		this.data[type] = data;
+	});
+
+	getData = vi.fn((type) => this.data[type] ?? null);
+}
+
 Object.defineProperty(window, 'Worker', {
 	writable: true,
 	value: Worker,
+});
+
+Object.defineProperty(window, 'DataTransfer', {
+	writable: true,
+	value: DataTransfer,
 });

--- a/packages/frontend/editor-ui/src/__tests__/setup.ts
+++ b/packages/frontend/editor-ui/src/__tests__/setup.ts
@@ -85,11 +85,14 @@ class Worker {
 class DataTransfer {
 	private data: Record<string, unknown> = {};
 
-	setData = vi.fn((type, data) => {
+	setData = vi.fn((type: string, data) => {
 		this.data[type] = data;
 	});
 
-	getData = vi.fn((type) => this.data[type] ?? null);
+	getData = vi.fn((type) => {
+		if (type.startsWith('text')) type = 'text';
+		return this.data[type] ?? null;
+	});
 }
 
 Object.defineProperty(window, 'Worker', {

--- a/packages/frontend/editor-ui/src/components/ParameterInput.test.ts
+++ b/packages/frontend/editor-ui/src/components/ParameterInput.test.ts
@@ -164,6 +164,42 @@ describe('ParameterInput.vue', () => {
 		expect(emitted('update')).toContainEqual([expect.objectContaining({ value: 'foo' })]);
 	});
 
+	test('should correctly handle paste events', async () => {
+		const { container, emitted } = renderComponent(ParameterInput, {
+			pinia: createTestingPinia(),
+			props: {
+				path: 'tag',
+				parameter: {
+					displayName: 'Tag',
+					name: 'tag',
+					type: 'string',
+				},
+				modelValue: '',
+			},
+		});
+		const input = container.querySelector('input') as HTMLInputElement;
+		expect(input).toBeInTheDocument();
+		await userEvent.click(input);
+
+		async function paste(text: string) {
+			const expression = new DataTransfer();
+			expression.setData('text', text);
+			await userEvent.clear(input);
+			await userEvent.paste(expression);
+		}
+
+		await paste('foo');
+		expect(emitted('update')).toContainEqual([expect.objectContaining({ value: 'foo' })]);
+
+		await paste('={{ $json.foo }}');
+		expect(emitted('update')).toContainEqual([
+			expect.objectContaining({ value: '={{ $json.foo }}' }),
+		]);
+
+		await paste('=flDvzj%y1nP');
+		expect(emitted('update')).toContainEqual([expect.objectContaining({ value: '==flDvzj%y1nP' })]);
+	});
+
 	test('should not reset the value of a multi-select with loadOptionsMethod on load', async () => {
 		mockNodeTypesState.getNodeParameterOptions = vi.fn(async () => [
 			{ name: 'ID', value: 'id' },


### PR DESCRIPTION
## Summary

In n8n, a string value that starts with `=` is treated as an expression.
Pasting any string that begins with `=` automatically switches the input to expression mode.

This PR adds an extra `=` at the beginning to keep the original value unchanged

**After pasting `=test123`**

<img width="971" alt="image" src="https://github.com/user-attachments/assets/1332b334-6493-4ad9-b38c-45143af947d7" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2402/community-issue-imap-credential-cannot-start-with-=-equals
fixes #13201

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
