### PR TITLE
fix(editor): Apply html sanitization in right lifecycle

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nInputLabel/InputLabel.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInputLabel/InputLabel.vue
@@ -74,7 +74,7 @@ const addTargetBlank = (html: string) =>
 						:class="[$style.infoIcon, showTooltip ? $style.visible : $style.hidden]"
 					>
 						<N8nTooltip placement="top" :popper-class="$style.tooltipPopper" :show-after="300">
-							<N8nIcon icon="question-circle" size="small" />
+							<N8nIcon :class="$style.icon" icon="question-circle" size="small" />
 							<template #content>
 								<div v-n8n-html="addTargetBlank(tooltipText)" />
 							</template>
@@ -141,6 +141,10 @@ const addTargetBlank = (html: string) =>
 			}
 		}
 	}
+}
+
+.infoIcon:has(.icon[aria-describedby]) {
+	opacity: 1;
 }
 
 .trailing-content {

--- a/packages/frontend/@n8n/design-system/src/directives/n8n-html.ts
+++ b/packages/frontend/@n8n/design-system/src/directives/n8n-html.ts
@@ -1,5 +1,5 @@
 import sanitize from 'sanitize-html';
-import type { DirectiveBinding, ObjectDirective } from 'vue';
+import type { DirectiveBinding, FunctionDirective } from 'vue';
 
 /**
  * Custom directive `n8nHtml` to replace v-html from Vue to sanitize content.
@@ -28,11 +28,11 @@ const configuredSanitize = (html: string) =>
 		},
 	});
 
-export const n8nHtml: ObjectDirective = {
-	beforeMount(el: HTMLElement, binding: DirectiveBinding<string>) {
+export const n8nHtml: FunctionDirective<HTMLElement, string> = (
+	el: HTMLElement,
+	binding: DirectiveBinding<string>,
+) => {
+	if (binding.value !== binding.oldValue) {
 		el.innerHTML = configuredSanitize(binding.value);
-	},
-	beforeUpdate(el: HTMLElement, binding: DirectiveBinding<string>) {
-		el.innerHTML = configuredSanitize(binding.value);
-	},
+	}
 };


### PR DESCRIPTION
## Summary

Fix: Clicking Links Inside tooltip now works (without having to double click)

Previously, HTML sanitization removed event listeners inside sanitized content, preventing links within tooltips from working.

**Changes**

-  Applied sanitization in mounted and updated using function directive shorthand.
-  Only update innerHTML when content changes to prevent unnecessary re-renders.
- Ensured the info icon remains visible while the tooltip is open.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2353/ndv-tooltip-links-work-only-on-second-click

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
