### PR TITLE
fix(core): Fix task runner error report from user-defined function

### DIFF
--- a/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
@@ -1436,4 +1436,42 @@ describe('JsTaskRunner', () => {
 			expect(Duration.fromObject({ hours: 1 }).maliciousKey).toBeUndefined();
 		});
 	});
+
+	describe('stack trace', () => {
+		it('should extract correct line number from user-defined function stack trace', async () => {
+			const runner = createRunnerWithOpts({});
+			const taskId = '1';
+			const task = newTaskState(taskId);
+			const taskSettings: JSExecSettings = {
+				code: 'function my_function() {\n  null.map();\n}\nmy_function();\nreturn []',
+				nodeMode: 'runOnceForAllItems',
+				continueOnFail: false,
+				workflowMode: 'manual',
+			};
+			runner.runningTasks.set(taskId, task);
+
+			const sendSpy = jest.spyOn(runner.ws, 'send').mockImplementation(() => {});
+			jest.spyOn(runner, 'sendOffers').mockImplementation(() => {});
+			jest
+				.spyOn(runner, 'requestData')
+				.mockResolvedValue(newDataRequestResponse([wrapIntoJson({ a: 1 })]));
+
+			await runner.receivedSettings(taskId, taskSettings);
+
+			expect(sendSpy).toHaveBeenCalled();
+			const calledWith = sendSpy.mock.calls[0][0] as string;
+			expect(typeof calledWith).toBe('string');
+			const calledObject = JSON.parse(calledWith);
+			expect(calledObject).toEqual({
+				type: 'runner:taskerror',
+				taskId,
+				error: {
+					stack: expect.any(String),
+					message: expect.stringContaining('Cannot read properties of null'),
+					description: 'TypeError',
+					lineNumber: 2, // from user-defined function
+				},
+			});
+		});
+	});
 });

--- a/packages/@n8n/task-runner/src/js-task-runner/errors/execution-error.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/errors/execution-error.ts
@@ -1,8 +1,6 @@
 import type { ErrorLike } from './error-like';
 import { SerializableError } from './serializable-error';
 
-const VM_WRAPPER_FN_NAME = 'VmCodeWrapper';
-
 export class ExecutionError extends SerializableError {
 	description: string | null = null;
 
@@ -42,8 +40,7 @@ export class ExecutionError extends SerializableError {
 		}
 
 		const messageRow = stackRows.find((line) => line.includes('Error:'));
-		const lineNumberRow = stackRows.find((line) => line.includes(`at ${VM_WRAPPER_FN_NAME} `));
-		const lineNumberDisplay = this.toLineNumberDisplay(lineNumberRow);
+		const lineNumberDisplay = this.toLineNumberDisplay(stackRows);
 
 		if (!messageRow) {
 			this.message = `Unknown error ${lineNumberDisplay}`;
@@ -62,26 +59,34 @@ export class ExecutionError extends SerializableError {
 		this.message = `${errorDetails} ${lineNumberDisplay}`;
 	}
 
-	private toLineNumberDisplay(lineNumberRow?: string) {
-		if (!lineNumberRow) return '';
+	private toLineNumberDisplay(stackRows: string[]) {
+		if (!stackRows || stackRows.length === 0) return '';
 
-		// TODO: This doesn't work if there is a function definition in the code
-		// and the error is thrown from that function.
-
-		const regex = new RegExp(
-			`at ${VM_WRAPPER_FN_NAME} \\(evalmachine\\.<anonymous>:(?<lineNumber>\\d+):`,
+		const userFnLine = stackRows.find(
+			(row) => row.match(/\(evalmachine\.<anonymous>:\d+:\d+\)/) && !row.includes('VmCodeWrapper'),
 		);
-		const errorLineNumberMatch = lineNumberRow.match(regex);
-		if (!errorLineNumberMatch?.groups?.lineNumber) return null;
 
-		const lineNumber = errorLineNumberMatch.groups.lineNumber;
-		if (!lineNumber) return '';
+		if (userFnLine) {
+			const match = userFnLine.match(/evalmachine\.<anonymous>:(\d+):/);
+			if (match) this.lineNumber = Number(match[1]);
+		}
 
-		this.lineNumber = Number(lineNumber);
+		if (this.lineNumber === undefined) {
+			const topLevelLine = stackRows.find(
+				(row) => row.includes('VmCodeWrapper') && row.includes('evalmachine.<anonymous>'),
+			);
+
+			if (topLevelLine) {
+				const match = topLevelLine.match(/evalmachine\.<anonymous>:(\d+):/);
+				if (match) this.lineNumber = Number(match[1]);
+			}
+		}
+
+		if (this.lineNumber === undefined) return '';
 
 		return this.itemIndex === undefined
-			? `[line ${lineNumber}]`
-			: `[line ${lineNumber}, for item ${this.itemIndex}]`;
+			? `[line ${this.lineNumber}]`
+			: `[line ${this.lineNumber}, for item ${this.itemIndex}]`;
 	}
 
 	private toErrorDetailsAndType(messageRow?: string) {


### PR DESCRIPTION
## Summary

On `master` in the task runner we only extract line numbers from the `VmCodeWrapper` stack frame, i.e. we don't consider stack frames from user-defined functions, which may appear earlier in the trace with more specific error locations. This PR fixes this.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2433

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
