### PR TITLE
fix(editor): Match nodes for autocomplete

### DIFF
--- a/packages/frontend/editor-ui/src/plugins/codemirror/typescript/client/completions.ts
+++ b/packages/frontend/editor-ui/src/plugins/codemirror/typescript/client/completions.ts
@@ -52,13 +52,6 @@ export const typescriptCompletionSource: CompletionSource = async (context) => {
 	if (isGlobal) {
 		options = options
 			.flatMap((opt) => {
-				let word = context.matchBefore(START_CHARACTERS_REGEX);
-				if (!word?.text) {
-					word = context.matchBefore(/[\"\'].*/);
-				}
-				if (!word?.text) {
-					word = context.matchBefore(/[\$\w]+/);
-				}
 				if (opt.label === '$()') {
 					return [
 						opt,

--- a/packages/frontend/editor-ui/src/plugins/codemirror/typescript/client/completions.ts
+++ b/packages/frontend/editor-ui/src/plugins/codemirror/typescript/client/completions.ts
@@ -1,5 +1,6 @@
 import { escapeMappingString } from '@/utils/mappingUtils';
 import {
+	type CompletionContext,
 	insertCompletionText,
 	pickedCompletion,
 	type Completion,
@@ -16,16 +17,21 @@ import { blockCommentSnippet, snippets } from './snippets';
 const START_CHARACTERS = ['"', "'", '(', '.', '@'];
 const START_CHARACTERS_REGEX = /[\.\(\'\"\@]/;
 
-export const typescriptCompletionSource: CompletionSource = async (context) => {
-	const { worker } = context.state.facet(typescriptWorkerFacet);
-
+export const matchText = (context: CompletionContext) => {
 	let word = context.matchBefore(START_CHARACTERS_REGEX);
-	if (!word?.text) {
-		word = context.matchBefore(/[\"\'].*/);
-	}
 	if (!word?.text) {
 		word = context.matchBefore(/[\$\w]+/);
 	}
+	if (!word?.text) {
+		word = context.matchBefore(/[\"\'].*/);
+	}
+	return word;
+};
+
+export const typescriptCompletionSource: CompletionSource = async (context) => {
+	const { worker } = context.state.facet(typescriptWorkerFacet);
+
+	const word = matchText(context);
 
 	const blockComment = context.matchBefore(/\/\*?\*?/);
 	if (blockComment) {
@@ -46,7 +52,14 @@ export const typescriptCompletionSource: CompletionSource = async (context) => {
 	if (isGlobal) {
 		options = options
 			.flatMap((opt) => {
-				if (opt.label === '$') {
+				let word = context.matchBefore(START_CHARACTERS_REGEX);
+				if (!word?.text) {
+					word = context.matchBefore(/[\"\'].*/);
+				}
+				if (!word?.text) {
+					word = context.matchBefore(/[\$\w]+/);
+				}
+				if (opt.label === '$()') {
 					return [
 						opt,
 						...autocompletableNodeNames().map((name) => ({

--- a/packages/frontend/editor-ui/src/plugins/codemirror/typescript/client/tests/completions.test.ts
+++ b/packages/frontend/editor-ui/src/plugins/codemirror/typescript/client/tests/completions.test.ts
@@ -1,0 +1,39 @@
+import { matchText } from '../completions';
+import { CompletionContext } from '@codemirror/autocomplete';
+import { EditorState } from '@codemirror/state';
+import { n8nLang } from '@/plugins/codemirror/n8nLang';
+
+describe('matchText', () => {
+	afterEach(() => {
+		vi.resetAllMocks();
+	});
+
+	it('should match on previous nodes', () => {
+		const previousNodes = [
+			{ doc: '$(|)', expected: '(' },
+			{ doc: '$("|', expected: '"' },
+			{ doc: "$('|", expected: "'" },
+			{ doc: '$(""|', expected: '"' },
+			{ doc: "$('|", expected: "'" },
+			{ doc: '$("|")', expected: '"' },
+			{ doc: "$('|')", expected: "'" },
+			{ doc: '$("|)', expected: '"' },
+			{ doc: '$("No|")', expected: 'No' },
+			{ doc: "$('No|')", expected: 'No' },
+			{ doc: '$("N|")', expected: 'N' },
+			{ doc: "$('N|')", expected: 'N' },
+		];
+
+		previousNodes.forEach((node) => {
+			const cursorPosition = node.doc.indexOf('|');
+			const state = EditorState.create({
+				doc: node.doc.replace('|', ''),
+				selection: { anchor: cursorPosition },
+				extensions: [n8nLang()],
+			});
+			const context = new CompletionContext(state, cursorPosition, false);
+
+			expect(matchText(context)?.text).toEqual(node.expected);
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/plugins/codemirror/typescript/client/tests/completions.test.ts
+++ b/packages/frontend/editor-ui/src/plugins/codemirror/typescript/client/tests/completions.test.ts
@@ -8,32 +8,28 @@ describe('matchText', () => {
 		vi.resetAllMocks();
 	});
 
-	it('should match on previous nodes', () => {
-		const previousNodes = [
-			{ doc: '$(|)', expected: '(' },
-			{ doc: '$("|', expected: '"' },
-			{ doc: "$('|", expected: "'" },
-			{ doc: '$(""|', expected: '"' },
-			{ doc: "$('|", expected: "'" },
-			{ doc: '$("|")', expected: '"' },
-			{ doc: "$('|')", expected: "'" },
-			{ doc: '$("|)', expected: '"' },
-			{ doc: '$("No|")', expected: 'No' },
-			{ doc: "$('No|')", expected: 'No' },
-			{ doc: '$("N|")', expected: 'N' },
-			{ doc: "$('N|')", expected: 'N' },
-		];
-
-		previousNodes.forEach((node) => {
-			const cursorPosition = node.doc.indexOf('|');
-			const state = EditorState.create({
-				doc: node.doc.replace('|', ''),
-				selection: { anchor: cursorPosition },
-				extensions: [n8nLang()],
-			});
-			const context = new CompletionContext(state, cursorPosition, false);
-
-			expect(matchText(context)?.text).toEqual(node.expected);
+	it.each([
+		{ node: '$(|)', expected: '(' },
+		{ node: '$("|', expected: '"' },
+		{ node: "$('|", expected: "'" },
+		{ node: '$(""|', expected: '"' },
+		{ node: "$('|", expected: "'" },
+		{ node: '$("|")', expected: '"' },
+		{ node: "$('|')", expected: "'" },
+		{ node: '$("|)', expected: '"' },
+		{ node: '$("No|")', expected: 'No' },
+		{ node: "$('No|')", expected: 'No' },
+		{ node: '$("N|")', expected: 'N' },
+		{ node: "$('N|')", expected: 'N' },
+	])('should match on previous node: $node', ({ node, expected }) => {
+		const cursorPosition = node.indexOf('|');
+		const state = EditorState.create({
+			doc: node.replace('|', ''),
+			selection: { anchor: cursorPosition },
+			extensions: [n8nLang()],
 		});
+		const context = new CompletionContext(state, cursorPosition, false);
+
+		expect(matchText(context)?.text).toEqual(expected);
 	});
 });


### PR DESCRIPTION
## Summary

Properly autocompletes for previous nodes when using `$(...)`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2450/code-node-auto-complete-messes-up-with-dollar-helper

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
