### PR TITLE
fix(Airtable Node): Table RLC should depend on Base RLC

### DIFF
--- a/packages/nodes-base/nodes/Airtable/v2/actions/common.descriptions.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/actions/common.descriptions.ts
@@ -61,6 +61,9 @@ export const tableRLC: INodeProperties = {
 	type: 'resourceLocator',
 	default: { mode: 'list', value: '' },
 	required: true,
+	typeOptions: {
+		loadOptionsDependsOn: ['base.value'],
+	},
 	modes: [
 		{
 			displayName: 'From List',


### PR DESCRIPTION
## Summary

added `loadOptionsDependsOn` to table `RLC`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2121/community-issue-airtable-nodes-fail-if-table-name-is-switched-work
closes  https://github.com/n8n-io/n8n/issues/12046


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
