### PR TITLE
fix(core): Correct NODE_OPTIONS export syntax for custom certificates

### DIFF
--- a/docker/images/n8n/docker-entrypoint.sh
+++ b/docker/images/n8n/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 if [ -d /opt/custom-certificates ]; then
   echo "Trusting custom certificates from /opt/custom-certificates."
-  export NODE_OPTIONS=--use-openssl-ca $NODE_OPTIONS
+  export NODE_OPTIONS="--use-openssl-ca $NODE_OPTIONS"
   export SSL_CERT_DIR=/opt/custom-certificates
   c_rehash /opt/custom-certificates
 fi


### PR DESCRIPTION
## Summary

The docker entrypoint `docker-entrypoint.sh` does not handle using `/opt/custom-certificates` with `NODE_OPTIONS` defined.

When running with both defined:
```bash
Trusting custom certificates from /opt/custom-certificates.
+ '[' -d /opt/custom-certificates ]
+ echo 'Trusting custom certificates from /opt/custom-certificates.'
+ export 'NODE_OPTIONS=--use-openssl-ca' --require global-agent/bootstrap
/docker-entrypoint.sh: export: line 4: --require: bad variable name
```

The fix is to double quote the export
`  export NODE_OPTIONS="--use-openssl-ca $NODE_OPTIONS"`

Which works successfully:
```bash
+ '[' -d /opt/custom-certificates ]
+ echo 'Trusting custom certificates from /opt/custom-certificates.'
+ export 'NODE_OPTIONS=--use-openssl-ca --require global-agent/bootstrap'
+ export 'SSL_CERT_DIR=/opt/custom-certificates'
+ c_rehash /opt/custom-certificates
```

## Related Linear tickets, Github issues, and Community forum posts

[docker-entrypoint.sh startup script has incorrect export statement #10913](https://github.com/n8n-io/n8n/issues/10913)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
