### PR TITLE
fix(core): Find correct start nodes when the first node after that has no run data has pinned data

### DIFF
--- a/packages/core/src/execution-engine/partial-execution-utils/__tests__/find-start-nodes.test.ts
+++ b/packages/core/src/execution-engine/partial-execution-utils/__tests__/find-start-nodes.test.ts
@@ -443,7 +443,49 @@ describe('findStartNodes', () => {
 		expect(startNodes).toContainEqual(node2);
 	});
 
+	describe('pinData', () => {
+		//               PD              ►►
+		// ┌───────┐1   ┌──────────┐0   ┌───────────┐
+		// │trigger├────►pinnedNode├────►destination│
+		// └───────┘    └──────────┘    └───────────┘
+		test('does not stop recursing when the first node that has no run data has pinned data', () => {
+			// ARRANGE
+			const trigger = createNodeData({ name: 'trigger' });
+			const pinnedNode = createNodeData({ name: 'pinnedNode' });
+			const destination = createNodeData({ name: 'destinationNode' });
+			const graph = new DirectedGraph()
+				.addNodes(trigger, destination, pinnedNode)
+				.addConnections({ from: trigger, to: pinnedNode }, { from: pinnedNode, to: destination });
+			const pinData: IPinData = { [pinnedNode.name]: [{ json: { value: 1 } }] };
+			const runData: IRunData = {
+				[trigger.name]: [toITaskData([{ data: { value: 1 } }])],
+			};
+
+			// ACT
+			const startNodes = findStartNodes({
+				graph,
+				trigger,
+				destination,
+				runData,
+				pinData,
+			});
+
+			// ASSERT
+			expect(startNodes.size).toBe(1);
+			expect(startNodes).toContain(destination);
+		});
+	});
+
 	describe('custom loop logic', () => {
+		//                       ►►
+		//             ┌────┐0  ┌─────────┐
+		// ┌───────┐1  │    ├───►afterLoop│
+		// │trigger├─┬─►loop│1  └─────────┘
+		// └───────┘ │ │    ├─┐ ┌──────┐1
+		//           │ └────┘ └─►inLoop├──┐
+		//           │          └──────┘  │
+		//           └────────────────────┘
+		//
 		test('if the last run of loop node has no data (null) on the done output, then the loop is the start node', () => {
 			// ARRANGE
 			const trigger = createNodeData({ name: 'trigger' });
@@ -482,6 +524,15 @@ describe('findStartNodes', () => {
 			expect(startNodes).toContainEqual(loop);
 		});
 
+		//                       ►►
+		//             ┌────┐0  ┌─────────┐
+		// ┌───────┐1  │    ├───►afterLoop│
+		// │trigger├─┬─►loop│1  └─────────┘
+		// └───────┘ │ │    ├─┐ ┌──────┐1
+		//           │ └────┘ └─►inLoop├──┐
+		//           │          └──────┘  │
+		//           └────────────────────┘
+		//
 		test('if the last run of loop node has no data (empty array) on the done output, then the loop is the start  node', () => {
 			// ARRANGE
 			const trigger = createNodeData({ name: 'trigger' });
@@ -527,6 +578,15 @@ describe('findStartNodes', () => {
 			expect(startNodes).toContainEqual(loop);
 		});
 
+		//                       ►►
+		//             ┌────┐1  ┌─────────┐
+		// ┌───────┐1  │    ├───►afterLoop│
+		// │trigger├─┬─►loop│1  └─────────┘
+		// └───────┘ │ │    ├─┐ ┌──────┐1
+		//           │ └────┘ └─►inLoop├──┐
+		//           │          └──────┘  │
+		//           └────────────────────┘
+		//
 		test('if the loop has data on the done output in the last run it does not become a start node', () => {
 			// ARRANGE
 			const trigger = createNodeData({ name: 'trigger' });

--- a/packages/core/src/execution-engine/partial-execution-utils/find-start-nodes.ts
+++ b/packages/core/src/execution-engine/partial-execution-utils/find-start-nodes.ts
@@ -111,7 +111,7 @@ function findStartNodesRecursive(
 		// If the node has multiple outputs, only follow the outputs that have run data.
 		const hasNoRunData =
 			nodeRunData === null || nodeRunData === undefined || nodeRunData.data.length === 0;
-		const hasNoPinnedData = !(pinData[outGoingConnection.from.name] !== undefined);
+		const hasNoPinnedData = pinData[outGoingConnection.from.name] === undefined;
 		if (hasNoRunData && hasNoPinnedData) {
 			continue;
 		}

--- a/packages/core/src/execution-engine/partial-execution-utils/find-start-nodes.ts
+++ b/packages/core/src/execution-engine/partial-execution-utils/find-start-nodes.ts
@@ -111,7 +111,8 @@ function findStartNodesRecursive(
 		// If the node has multiple outputs, only follow the outputs that have run data.
 		const hasNoRunData =
 			nodeRunData === null || nodeRunData === undefined || nodeRunData.data.length === 0;
-		if (hasNoRunData) {
+		const hasNoPinnedData = !(pinData[outGoingConnection.from.name] !== undefined);
+		if (hasNoRunData && hasNoPinnedData) {
 			continue;
 		}
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

The finding start node function would terminate too early when a node has no run data but pinned data.

*before:*

https://github.com/user-attachments/assets/4be94966-95dc-4387-819b-91f5dcd31827


*after:*

https://github.com/user-attachments/assets/7023012a-55a6-4877-ae54-2c1ef0e7c7e0



## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2655/bug-partial-execs-dont-work-across-pinned-nodes


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
