### PR TITLE
docs: Fix image example links in "Chat" README.md

### DIFF
--- a/packages/frontend/@n8n/chat/README.md
+++ b/packages/frontend/@n8n/chat/README.md
@@ -2,10 +2,10 @@
 This is an embeddable Chat widget for n8n. It allows the execution of AI-Powered Workflows through a Chat window.
 
 **Windowed Example**
-![n8n Chat Windowed](https://raw.githubusercontent.com/n8n-io/n8n/master/packages/%40n8n/chat/resources/images/windowed.png)
+![n8n Chat Windowed](https://raw.githubusercontent.com/n8n-io/n8n/master/packages/frontend/%40n8n/chat/resources/images/windowed.png)
 
 **Fullscreen Example**
-![n8n Chat Fullscreen](https://raw.githubusercontent.com/n8n-io/n8n/master/packages/%40n8n/chat/resources/images/fullscreen.png)
+![n8n Chat Fullscreen](https://raw.githubusercontent.com/n8n-io/n8n/master/packages/frontend/%40n8n/chat/resources/images/fullscreen.png)
 
 ## Prerequisites
 Create a n8n workflow which you want to execute via chat. The workflow has to be triggered using a **Chat Trigger** node.


### PR DESCRIPTION
Windowed and Fullscreen image examples in the master branch now get the images from the right link

Old: https://raw.githubusercontent.com/n8n-io/n8n/master/packages/%40n8n/chat/resources/images/windowed.png
![Current](https://github.com/user-attachments/assets/7d8a14e1-121a-458d-babc-49628b706e34)



New: https://raw.githubusercontent.com/n8n-io/n8n/master/packages/frontend/%40n8n/chat/resources/images/windowed.png
![Updated](https://github.com/user-attachments/assets/46293b0e-03f7-41fa-9658-78ecee37be6b)
