### PR TITLE
feat: Allow custom scopes for Entra credential

### DIFF
--- a/packages/nodes-base/credentials/MicrosoftEntraOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftEntraOAuth2Api.credentials.ts
@@ -1,5 +1,19 @@
 import type { ICredentialType, INodeProperties } from 'n8n-workflow';
 
+const defaultScopes = [
+	'openid',
+	'offline_access',
+	'AccessReview.ReadWrite.All',
+	'Directory.ReadWrite.All',
+	'NetworkAccessPolicy.ReadWrite.All',
+	'DelegatedAdminRelationship.ReadWrite.All',
+	'EntitlementManagement.ReadWrite.All',
+	'User.ReadWrite.All',
+	'Directory.AccessAsUser.All',
+	'Sites.FullControl.All',
+	'GroupMember.ReadWrite.All',
+];
+
 export class MicrosoftEntraOAuth2Api implements ICredentialType {
 	name = 'microsoftEntraOAuth2Api';
 
@@ -11,12 +25,43 @@ export class MicrosoftEntraOAuth2Api implements ICredentialType {
 
 	properties: INodeProperties[] = [
 		{
+			displayName: 'Custom Scopes',
+			name: 'customScopes',
+			type: 'boolean',
+			default: false,
+			description: 'Define custom scopes',
+		},
+		{
+			displayName:
+				'The default scopes needed for the node to work are already set, If you change these the node may not function correctly.',
+			name: 'customScopesNotice',
+			type: 'notice',
+			default: '',
+			displayOptions: {
+				show: {
+					customScopes: [true],
+				},
+			},
+		},
+		{
+			displayName: 'Enabled Scopes',
+			name: 'enabledScopes',
+			type: 'string',
+			displayOptions: {
+				show: {
+					customScopes: [true],
+				},
+			},
+			default: defaultScopes.join(' '),
+			description: 'Scopes that should be enabled',
+		},
+		{
 			displayName: 'Scope',
 			name: 'scope',
 			type: 'hidden',
 			// Sites.FullControl.All required to update user specific properties https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1316
 			default:
-				'openid offline_access AccessReview.ReadWrite.All Directory.ReadWrite.All NetworkAccessPolicy.ReadWrite.All DelegatedAdminRelationship.ReadWrite.All EntitlementManagement.ReadWrite.All User.ReadWrite.All Directory.AccessAsUser.All Sites.FullControl.All GroupMember.ReadWrite.All',
+				'={{$self["customScopes"] ? $self["enabledScopes"] : "' + defaultScopes.join(' ') + '"}}',
 		},
 	];
 }


### PR DESCRIPTION
## Summary
This updates the Entra credential to allow custom scopes, Due to how the scopes are loading I had to make a second input field as just changing the display option for the normal scopes field didn't allow the scopes to be changed.

![image](https://github.com/user-attachments/assets/fe1c5162-3982-4742-85c7-b83a31a22444)


## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-2399/digital-boss-microsoft-entra-id#comment-23c193b5


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
