### PR TITLE
feat(editor): Add toJsonString to string extensions

### DIFF
--- a/packages/workflow/src/Extensions/StringExtensions.ts
+++ b/packages/workflow/src/Extensions/StringExtensions.ts
@@ -159,6 +159,10 @@ function length(value: string): number {
 	return value.length;
 }
 
+export function toJsonString(value: string): string {
+	return JSON.stringify(value);
+}
+
 function removeMarkdown(value: string): string {
 	let output = value;
 	try {
@@ -700,6 +704,23 @@ isNotEmpty.doc = {
 	],
 };
 
+toJsonString.doc = {
+	name: 'toJsonString',
+	description:
+		'Prepares the string to be inserted into a JSON object. Escapes any quotes and special characters (e.g. new lines), and wraps the string in quotes.The same as JavaScript’s JSON.stringify().',
+	section: 'edit',
+	returnType: 'string',
+	docURL:
+		'https://docs.n8n.io/code/builtin/data-transformation-functions/strings/#string-toJsonString',
+	examples: [
+		{
+			example: 'The "best" colours: red\nbrown.toJsonString()',
+			evaluated: '"The \\"best\\" colours: red\\nbrown"',
+		},
+		{ example: 'foo.toJsonString()', evaluated: '"foo"' },
+	],
+};
+
 extractEmail.doc = {
 	name: 'extractEmail',
 	description:
@@ -877,6 +898,7 @@ export const stringExtensions: ExtensionMap = {
 		isUrl,
 		isEmpty,
 		isNotEmpty,
+		toJsonString,
 		extractEmail,
 		extractDomain,
 		extractUrl,

--- a/packages/workflow/test/ExpressionExtensions/StringExtensions.test.ts
+++ b/packages/workflow/test/ExpressionExtensions/StringExtensions.test.ts
@@ -313,6 +313,14 @@ describe('Data Transformation Functions', () => {
 			expect(() => evaluate('={{ "No JSON here".parseJson() }}')).toThrowError('Parsing failed');
 		});
 
+		test('.toJsonString should work on a string', () => {
+			expect(evaluate('={{ "test".toJsonString() }}')).toEqual(JSON.stringify('test'));
+			expect(evaluate('={{ "The \\"best\\" colours: red\\nbrown".toJsonString() }}')).toEqual(
+				JSON.stringify('The "best" colours: red\nbrown'),
+			);
+			expect(evaluate('={{ "".toJsonString() }}')).toEqual(JSON.stringify(''));
+		});
+
 		test('.toBoolean should work on a string', () => {
 			expect(evaluate('={{ "False".toBoolean() }}')).toBe(false);
 			expect(evaluate('={{ "".toBoolean() }}')).toBe(false);


### PR DESCRIPTION
## Summary

Add toJsonString to string extensions

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1624/expressions-add-stringtojsonstring

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
