### PR TITLE
fix(core): Clean run data for dirty nodes properly, including their children

### DIFF
--- a/packages/core/src/execution-engine/partial-execution-utils/clean-run-data.ts
+++ b/packages/core/src/execution-engine/partial-execution-utils/clean-run-data.ts
@@ -4,28 +4,30 @@ import type { DirectedGraph } from './directed-graph';
 
 /**
  * Returns new run data that does not contain data for any node that is a child
- * of any start node.
+ * of any of the passed nodes. This is useful for cleaning run data after start
+ * nodes or dirty nodes.
+ *
  * This does not mutate the `runData` being passed in.
  */
 export function cleanRunData(
 	runData: IRunData,
 	graph: DirectedGraph,
-	startNodes: Set<INode>,
+	nodesToClean: Set<INode>,
 ): IRunData {
 	const newRunData: IRunData = { ...runData };
 
-	for (const startNode of startNodes) {
-		delete newRunData[startNode.name];
+	for (const nodeToClean of nodesToClean) {
+		delete newRunData[nodeToClean.name];
 
-		const children = graph.getChildren(startNode);
-		for (const node of [startNode, ...children]) {
+		const children = graph.getChildren(nodeToClean);
+		for (const node of [nodeToClean, ...children]) {
 			delete newRunData[node.name];
 
 			// Delete runData for subNodes
 			const subNodeConnections = graph.getParentConnections(node);
 			for (const subNodeConnection of subNodeConnections) {
 				// Sub nodes never use the Main connection type, so this filters out
-				// the connection that goes upstream of the startNode.
+				// the connection that goes upstream of the node to clean.
 				if (subNodeConnection.type === NodeConnectionType.Main) {
 					continue;
 				}

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -353,18 +353,6 @@ export class WorkflowExecute {
 			`Could not find a node with the name ${destinationNodeName} in the workflow.`,
 		);
 
-		const dirtyNodes: Set<INode> = new Set();
-		for (const name of dirtyNodeNames) {
-			const node = workflow.getNode(name);
-			if (!node) {
-				console.warn(
-					`Could not find a node with the name ${name} in the workflow. This was passed in as a dirty node name.`,
-				);
-				continue;
-			}
-			dirtyNodes.add(node);
-		}
-
 		let graph = DirectedGraph.fromWorkflow(workflow);
 
 		// Edge Case 1:
@@ -415,6 +403,7 @@ export class WorkflowExecute {
 		const filteredNodes = graph.getNodes();
 
 		// 3. Find the Start Nodes
+		const dirtyNodes = new Set(workflow.getNodes(dirtyNodeNames));
 		runData = cleanRunData(runData, graph, dirtyNodes);
 		let startNodes = findStartNodes({ graph, trigger, destination, runData, pinData });
 

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -50,6 +50,7 @@ import {
 	ExecutionCancelledError,
 	Node,
 	UnexpectedError,
+	UserError,
 } from 'n8n-workflow';
 import PCancelable from 'p-cancelable';
 
@@ -395,7 +396,7 @@ export class WorkflowExecute {
 		// 1. Find the Trigger
 		const trigger = findTriggerForPartialExecution(workflow, destinationNodeName);
 		if (trigger === undefined) {
-			throw new ApplicationError('Connect a trigger to run this node');
+			throw new UserError('Connect a trigger to run this node');
 		}
 
 		// 2. Find the Subgraph

--- a/packages/workflow/src/Workflow.ts
+++ b/packages/workflow/src/Workflow.ts
@@ -290,6 +290,27 @@ export class Workflow {
 	}
 
 	/**
+	 * Returns the nodes with the given names if they exist.
+	 * If a node cannot be found it will be ignored, meaning the returned array
+	 * of nodes can be smaller than the array of names.
+	 */
+	getNodes(nodeNames: string[]): INode[] {
+		const nodes: INode[] = [];
+		for (const name of nodeNames) {
+			const node = this.getNode(name);
+			if (!node) {
+				console.warn(
+					`Could not find a node with the name ${name} in the workflow. This was passed in as a dirty node name.`,
+				);
+				continue;
+			}
+			nodes.push(node);
+		}
+
+		return nodes;
+	}
+
+	/**
 	 * Returns the pinData of the node with the given name if it exists
 	 *
 	 * @param {string} nodeName Name of the node to return the pinData of

--- a/packages/workflow/test/Workflow.test.ts
+++ b/packages/workflow/test/Workflow.test.ts
@@ -344,6 +344,10 @@ describe('Workflow', () => {
 		active: false,
 	});
 
+	beforeEach(() => {
+		jest.restoreAllMocks();
+	});
+
 	describe('renameNodeInParameterValue', () => {
 		describe('for expressions', () => {
 			const tests = [
@@ -2337,6 +2341,67 @@ describe('Workflow', () => {
 			});
 
 			expect(workflow.getStartNode()).toBeUndefined();
+		});
+	});
+
+	describe('getNode', () => {
+		test('should return the node with the given name if it exists', () => {
+			const workflow = SIMPLE_WORKFLOW;
+			const node = workflow.getNode('Start');
+			expect(node).not.toBeNull();
+			expect(node?.name).toBe('Start');
+			expect(node?.type).toBe('test.set');
+			expect(node?.id).toBe('uuid-1');
+		});
+
+		test('should return null if the node does not exist', () => {
+			const nonExistentNode = SIMPLE_WORKFLOW.getNode('NonExistentNode');
+			expect(nonExistentNode).toBeNull();
+		});
+	});
+
+	describe('getNodes', () => {
+		test('should return all requested nodes that exist', () => {
+			const nodes = SIMPLE_WORKFLOW.getNodes(['Start', 'Set', 'Set1']);
+			expect(nodes).toHaveLength(3);
+			expect(nodes[0].name).toBe('Start');
+			expect(nodes[1].name).toBe('Set');
+			expect(nodes[2].name).toBe('Set1');
+		});
+
+		test('should return nodes in the order they were requested', () => {
+			const nodes = SIMPLE_WORKFLOW.getNodes(['Set1', 'Start', 'Set']);
+			expect(nodes).toHaveLength(3);
+			expect(nodes[0].name).toBe('Set1');
+			expect(nodes[1].name).toBe('Start');
+			expect(nodes[2].name).toBe('Set');
+		});
+
+		test('should skip nodes that do not exist and log a warning', () => {
+			// Spy on console.warn
+			const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+			const nodes = SIMPLE_WORKFLOW.getNodes(['Start', 'NonExistentNode', 'Set1']);
+			expect(nodes).toHaveLength(2);
+			expect(nodes[0].name).toBe('Start');
+			expect(nodes[1].name).toBe('Set1');
+			expect(consoleWarnSpy).toHaveBeenCalledWith(
+				expect.stringContaining('Could not find a node with the name NonExistentNode'),
+			);
+		});
+
+		test('should return an empty array if none of the requested nodes exist', () => {
+			// Spy on console.warn
+			const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+			const nodes = SIMPLE_WORKFLOW.getNodes(['NonExistentNode1', 'NonExistentNode2']);
+			expect(nodes).toHaveLength(0);
+			expect(consoleWarnSpy).toHaveBeenCalledTimes(2);
+		});
+
+		test('should handle an empty array of node names', () => {
+			const nodes = SIMPLE_WORKFLOW.getNodes([]);
+			expect(nodes).toHaveLength(0);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This cleans run data of dirty nodes properly, including cleaning the run data of their children. 
If this is not done we miscalculate the start nodes in situations involving nodes with multiple inputs and the graph branching and joining again, this leads to the `waitingExecution` being setup incorrectly and the execution terminating too early.

*before:*

https://github.com/user-attachments/assets/9bb6b53e-cb1f-4b70-882c-3448b45abef7


*after:*

https://github.com/user-attachments/assets/1d2b02fa-ec50-4e78-bf76-2ad26ccd3bdd


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2652/bug-partial-execution-across-merge-node-with-pinned-data


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
