### PR TITLE
refactor(core): Do not report Unrecognized node/credential type errors to Sentry (no-changelog)

### DIFF
--- a/packages/core/src/errors/error-reporter.ts
+++ b/packages/core/src/errors/error-reporter.ts
@@ -190,7 +190,7 @@ export class ErrorReporter {
 			'cause' in originalException &&
 			originalException.cause instanceof Error &&
 			'level' in originalException.cause &&
-			originalException.cause.level === 'warning'
+			(originalException.cause.level === 'warning' || originalException.cause.level === 'info')
 		) {
 			// handle underlying errors propagating from dependencies like ai-assistant-sdk
 			return null;

--- a/packages/core/src/errors/unrecognized-credential-type.error.ts
+++ b/packages/core/src/errors/unrecognized-credential-type.error.ts
@@ -1,8 +1,6 @@
-import { ApplicationError } from 'n8n-workflow';
+import { UserError } from 'n8n-workflow';
 
-export class UnrecognizedCredentialTypeError extends ApplicationError {
-	severity = 'warning';
-
+export class UnrecognizedCredentialTypeError extends UserError {
 	constructor(credentialType: string) {
 		super(`Unrecognized credential type: ${credentialType}`);
 	}

--- a/packages/core/src/errors/unrecognized-node-type.error.ts
+++ b/packages/core/src/errors/unrecognized-node-type.error.ts
@@ -1,8 +1,6 @@
-import { ApplicationError } from 'n8n-workflow';
+import { UserError } from 'n8n-workflow';
 
-export class UnrecognizedNodeTypeError extends ApplicationError {
-	severity = 'warning';
-
+export class UnrecognizedNodeTypeError extends UserError {
 	constructor(packageName: string, nodeType: string) {
 		super(`Unrecognized node type: ${packageName}.${nodeType}`);
 	}


### PR DESCRIPTION
## Summary
These errors aren't actionable, therefore we can avoid sending these to Sentry.

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.sentry.io/issues/6240038207
https://linear.app/n8n/issue/CAT-711


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
