### PR TITLE
feat(editor): Add telemetry event for tidy up feature (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/Canvas.vue
@@ -873,6 +873,7 @@ provide(CanvasKey, {
 			:position="controlsPosition"
 			:show-interactive="false"
 			:zoom="viewport.zoom"
+			:read-only="readOnly"
 			@zoom-to-fit="onFitView"
 			@zoom-in="onZoomIn"
 			@zoom-out="onZoomOut"

--- a/packages/frontend/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/Canvas.vue
@@ -47,7 +47,11 @@ import CanvasBackground from './elements/background/CanvasBackground.vue';
 import { useCanvasTraversal } from '@/composables/useCanvasTraversal';
 import { NodeConnectionType } from 'n8n-workflow';
 import { useCanvasNodeHover } from '@/composables/useCanvasNodeHover';
-import { useCanvasLayout } from '@/composables/useCanvasLayout';
+import {
+	type CanvasLayoutEvent,
+	type CanvasLayoutSource,
+	useCanvasLayout,
+} from '@/composables/useCanvasLayout';
 
 const $style = useCssModule();
 
@@ -90,6 +94,7 @@ const emit = defineEmits<{
 	'save:workflow': [];
 	'create:workflow': [];
 	'drag-and-drop': [position: XYPosition, event: DragEvent];
+	'tidy-up': [CanvasLayoutEvent];
 }>();
 
 const props = withDefaults(
@@ -290,7 +295,7 @@ const keyMap = computed(() => {
 		ctrl_alt_n: () => emit('create:workflow'),
 		ctrl_enter: () => emit('run:workflow'),
 		ctrl_s: () => emit('save:workflow'),
-		shift_alt_t: onTidyUp,
+		shift_alt_t: async () => await onTidyUp('keyboard-shortcut'),
 	};
 	return fullKeymap;
 });
@@ -635,15 +640,16 @@ async function onContextMenuAction(action: ContextMenuAction, nodeIds: string[])
 		case 'change_color':
 			return props.eventBus.emit('nodes:action', { ids: nodeIds, action: 'update:sticky:color' });
 		case 'tidy_up':
-			return await onTidyUp();
+			return await onTidyUp('context-menu');
 	}
 }
 
-async function onTidyUp() {
+async function onTidyUp(source: CanvasLayoutSource) {
 	const applyOnSelection = selectedNodes.value.length > 1;
-	const { nodes } = layout(applyOnSelection ? 'selection' : 'all');
+	const target = applyOnSelection ? 'selection' : 'all';
+	const result = layout(target);
 
-	onUpdateNodesPosition(nodes.map((node) => ({ id: node.id, position: { x: node.x, y: node.y } })));
+	emit('tidy-up', { result, target, source });
 
 	if (!applyOnSelection) {
 		await nextTick();
@@ -871,7 +877,7 @@ provide(CanvasKey, {
 			@zoom-in="onZoomIn"
 			@zoom-out="onZoomOut"
 			@reset-zoom="onResetZoom"
-			@tidy-up="onTidyUp"
+			@tidy-up="onTidyUp('canvas-button')"
 		/>
 
 		<Suspense>

--- a/packages/frontend/editor-ui/src/components/canvas/elements/buttons/CanvasControlButtons.test.ts
+++ b/packages/frontend/editor-ui/src/components/canvas/elements/buttons/CanvasControlButtons.test.ts
@@ -16,6 +16,7 @@ describe('CanvasControlButtons', () => {
 		expect(wrapper.getByTestId('zoom-in-button')).toBeVisible();
 		expect(wrapper.getByTestId('zoom-out-button')).toBeVisible();
 		expect(wrapper.getByTestId('zoom-to-fit')).toBeVisible();
+		expect(wrapper.getByTestId('tidy-up-button')).toBeVisible();
 
 		expect(wrapper.html()).toMatchSnapshot();
 	});
@@ -28,5 +29,25 @@ describe('CanvasControlButtons', () => {
 		});
 
 		expect(wrapper.getByTestId('reset-zoom-button')).toBeVisible();
+	});
+
+	it('should hide the reset zoom button when zoom is equal to 1', () => {
+		const wrapper = renderComponent({
+			props: {
+				zoom: 1,
+			},
+		});
+
+		expect(wrapper.queryByTestId('reset-zoom-button')).not.toBeInTheDocument();
+	});
+
+	it('should hide the tidy up button when canvas is read-only', () => {
+		const wrapper = renderComponent({
+			props: {
+				readOnly: true,
+			},
+		});
+
+		expect(wrapper.queryByTestId('tidy-up-button')).not.toBeInTheDocument();
 	});
 });

--- a/packages/frontend/editor-ui/src/components/canvas/elements/buttons/CanvasControlButtons.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/elements/buttons/CanvasControlButtons.vue
@@ -8,9 +8,11 @@ import { useI18n } from '@/composables/useI18n';
 const props = withDefaults(
 	defineProps<{
 		zoom?: number;
+		readOnly?: boolean;
 	}>(),
 	{
 		zoom: 1,
+		readOnly: false,
 	},
 );
 
@@ -92,6 +94,7 @@ function onTidyUp() {
 			/>
 		</KeyboardShortcutTooltip>
 		<KeyboardShortcutTooltip
+			v-if="!readOnly"
 			:label="i18n.baseText('nodeView.tidyUp')"
 			:shortcut="{ shiftKey: true, altKey: true, keys: ['T'] }"
 		>

--- a/packages/frontend/editor-ui/src/composables/useCanvasLayout.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasLayout.test.ts
@@ -2,13 +2,13 @@ import { useVueFlow, type GraphNode, type VueFlowStore } from '@vue-flow/core';
 import { ref } from 'vue';
 import { createCanvasGraphEdge, createCanvasGraphNode } from '../__tests__/data';
 import { CanvasNodeRenderType, type CanvasNodeData } from '../types';
-import { useCanvasLayout, type LayoutResult } from './useCanvasLayout';
+import { useCanvasLayout, type CanvasLayoutResult } from './useCanvasLayout';
 import { STICKY_NODE_TYPE } from '../constants';
 import { GRID_SIZE } from '../utils/nodeViewUtils';
 
 vi.mock('@vue-flow/core');
 
-function matchesGrid(result: LayoutResult) {
+function matchesGrid(result: CanvasLayoutResult) {
 	return result.nodes.every((node) => node.x % GRID_SIZE === 0 && node.y % GRID_SIZE === 0);
 }
 

--- a/packages/frontend/editor-ui/src/composables/useCanvasLayout.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasLayout.ts
@@ -13,6 +13,7 @@ import { GRID_SIZE, NODE_SIZE } from '../utils/nodeViewUtils';
 
 export type CanvasLayoutOptions = { id?: string };
 export type CanvasLayoutTarget = 'selection' | 'all';
+export type CanvasLayoutSource = 'keyboard-shortcut' | 'canvas-button' | 'context-menu';
 export type CanvasLayoutTargetData = {
 	nodes: Array<GraphNode<CanvasNodeData>>;
 	edges: CanvasConnection[];
@@ -25,7 +26,13 @@ export type NodeLayoutResult = {
 	width?: number;
 	height?: number;
 };
-export type LayoutResult = { boundingBox: BoundingBox; nodes: NodeLayoutResult[] };
+export type CanvasLayoutResult = { boundingBox: BoundingBox; nodes: NodeLayoutResult[] };
+
+export type CanvasLayoutEvent = {
+	result: CanvasLayoutResult;
+	source: CanvasLayoutSource;
+	target: CanvasLayoutTarget;
+};
 
 export type CanvasNodeDictionary = Record<string, GraphNode<CanvasNodeData>>;
 
@@ -300,7 +307,7 @@ export function useCanvasLayout({ id: canvasId }: CanvasLayoutOptions = {}) {
 			]);
 	}
 
-	function layout(target: CanvasLayoutTarget): LayoutResult {
+	function layout(target: CanvasLayoutTarget): CanvasLayoutResult {
 		const { nodes, edges } = getTargetData(target);
 
 		const nonStickyNodes = nodes

--- a/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
@@ -99,6 +99,7 @@ import { useClipboard } from '@/composables/useClipboard';
 import { useUniqueNodeName } from '@/composables/useUniqueNodeName';
 import { isPresent } from '../utils/typesUtils';
 import { useProjectsStore } from '@/stores/projects.store';
+import type { CanvasLayoutEvent } from './useCanvasLayout';
 
 type AddNodeData = Partial<INodeUi> & {
 	type: string;
@@ -163,6 +164,22 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 	/**
 	 * Node operations
 	 */
+
+	function tidyUp({ result, source, target }: CanvasLayoutEvent) {
+		updateNodesPosition(
+			result.nodes.map(({ id, x, y }) => ({ id, position: { x, y } })),
+			{ trackBulk: true, trackHistory: true },
+		);
+		trackTidyUp({ result, source, target });
+	}
+
+	function trackTidyUp({ result, source, target }: CanvasLayoutEvent) {
+		telemetry.track('User tidied up canvas', {
+			source,
+			target,
+			nodes_count: result.nodes.length,
+		});
+	}
 
 	function updateNodesPosition(
 		events: CanvasNodeMoveEvent[],
@@ -1995,6 +2012,7 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 		revertAddNode,
 		updateNodesPosition,
 		updateNodePosition,
+		tidyUp,
 		revertUpdateNodePosition,
 		setNodeActive,
 		setNodeActiveByName,

--- a/packages/frontend/editor-ui/src/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/views/NodeView.vue
@@ -112,6 +112,7 @@ import NodeViewUnfinishedWorkflowMessage from '@/components/NodeViewUnfinishedWo
 import { createCanvasConnectionHandleString } from '@/utils/canvasUtils';
 import { isValidNodeConnectionType } from '@/utils/typeGuards';
 import { getEasyAiWorkflowJson } from '@/utils/easyAiWorkflowUtils';
+import type { CanvasLayoutEvent } from '@/composables/useCanvasLayout';
 
 defineOptions({
 	name: 'NodeView',
@@ -175,6 +176,7 @@ const { runWorkflow, runEntireWorkflow, stopCurrentExecution, stopWaitingForWebh
 const {
 	updateNodePosition,
 	updateNodesPosition,
+	tidyUp,
 	revertUpdateNodePosition,
 	renameNode,
 	revertRenameNode,
@@ -579,6 +581,10 @@ const allTriggerNodesDisabled = computed(() => {
 	const disabledTriggerNodes = triggerNodes.value.filter((node) => node.disabled);
 	return disabledTriggerNodes.length === triggerNodes.value.length;
 });
+
+function onTidyUp(event: CanvasLayoutEvent) {
+	tidyUp(event);
+}
 
 function onUpdateNodesPosition(events: CanvasNodeMoveEvent[]) {
 	updateNodesPosition(events, { trackHistory: true });
@@ -1769,6 +1775,7 @@ onBeforeUnmount(() => {
 		@create:workflow="onCreateWorkflow"
 		@viewport-change="onViewportChange"
 		@drag-and-drop="onDragAndDrop"
+		@tidy-up="onTidyUp"
 	>
 		<Suspense>
 			<LazySetupWorkflowCredentialsButton :class="$style.setupCredentialsButtonWrapper" />


### PR DESCRIPTION
## Summary

Add telemetry event "User tidied up workflow" with attributes: `source`, `target` and `nodes_count`

Also hid the tidy up button when the canvas is read-only (for example on the executions page)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2494/add-telemetry-to-tidy-up

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
