### PR TITLE
fix(core): Avoid using structuredClone on node descriptions

### DIFF
--- a/packages/cli/src/load-nodes-and-credentials.ts
+++ b/packages/cli/src/load-nodes-and-credentials.ts
@@ -26,7 +26,7 @@ import type {
 	IVersionedNodeType,
 	INodeProperties,
 } from 'n8n-workflow';
-import { NodeConnectionType, UnexpectedError, UserError } from 'n8n-workflow';
+import { deepCopy, NodeConnectionType, UnexpectedError, UserError } from 'n8n-workflow';
 import path from 'path';
 import picocolors from 'picocolors';
 
@@ -315,12 +315,11 @@ export class LoadNodesAndCredentials {
 			this.types.nodes.filter((nodetype) => nodetype.usableAsTool === true);
 
 		for (const usableNode of usableNodes) {
-			const description: INodeTypeBaseDescription | INodeTypeDescription =
-				structuredClone(usableNode);
+			const description = deepCopy(usableNode);
 			const wrapped = this.convertNodeToAiTool({ description }).description;
 
 			this.types.nodes.push(wrapped);
-			this.known.nodes[wrapped.name] = structuredClone(this.known.nodes[usableNode.name]);
+			this.known.nodes[wrapped.name] = { ...this.known.nodes[usableNode.name] };
 
 			const credentialNames = Object.entries(this.known.credentials)
 				.filter(([_, credential]) => credential?.supportedNodes?.includes(usableNode.name))


### PR DESCRIPTION
## Summary
Sometimes node descriptions can contains non-transferable objects (even though shouldn't), which can lead to `structuredClone` failing.

## Related Linear tickets, Github issues, and Community forum posts

#13806
https://linear.app/n8n/issue/CAT-713
https://community.n8n.io/t/problem-uninstalling-package/84174


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
