### PR TITLE
fix(editor): Remove unneeded onClickOutside handler from context menu (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/components/ContextMenu/ContextMenu.vue
+++ b/packages/frontend/editor-ui/src/components/ContextMenu/ContextMenu.vue
@@ -2,13 +2,11 @@
 import { type ContextMenuAction, useContextMenu } from '@/composables/useContextMenu';
 import { N8nActionDropdown } from '@n8n/design-system';
 import { watch, ref } from 'vue';
-import { onClickOutside } from '@vueuse/core';
 
 const contextMenu = useContextMenu();
 const { position, isOpen, actions, target } = contextMenu;
 const dropdown = ref<InstanceType<typeof N8nActionDropdown>>();
 const emit = defineEmits<{ action: [action: ContextMenuAction, nodeIds: string[]] }>();
-const container = ref<HTMLDivElement>();
 
 watch(
 	isOpen,
@@ -28,27 +26,16 @@ function onActionSelect(item: string) {
 	emit('action', action, contextMenu.targetNodeIds.value);
 }
 
-function closeMenu(event: MouseEvent) {
-	if (event.cancelable) {
-		event.preventDefault();
-	}
-	event.stopPropagation();
-	contextMenu.close();
-}
-
 function onVisibleChange(open: boolean) {
 	if (!open) {
 		contextMenu.close();
 	}
 }
-
-onClickOutside(container, closeMenu);
 </script>
 
 <template>
 	<Teleport v-if="isOpen" to="body">
 		<div
-			ref="container"
 			:class="$style.contextMenu"
 			:style="{
 				left: `${position[0]}px`,


### PR DESCRIPTION
## Summary

preventDefault in this passive event handler throws console errors.

Element UI's dropdown component already closes on click outside, so no need to do this again here

## Related Linear tickets, Github issues, and Community forum posts

fixes  https://github.com/n8n-io/n8n/issues/13844

https://linear.app/n8n/issue/NODE-2541/community-issue-event-listener-error

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
