### PR TITLE
feat(Merge Node): Add Telemetry for SQL query (no-changelog)

### DIFF
--- a/packages/workflow/src/TelemetryHelpers.ts
+++ b/packages/workflow/src/TelemetryHelpers.ts
@@ -251,7 +251,7 @@ export function generateNodesGraph(
 		} else if (node.type === MERGE_NODE_TYPE) {
 			nodeItem.operation = node.parameters.mode as string;
 
-			if (options?.isCloudDeployment) {
+			if (options?.isCloudDeployment && node.parameters.mode === 'combineBySql') {
 				nodeItem.sql = node.parameters.query as string;
 			}
 		} else if (node.type === HTTP_REQUEST_NODE_TYPE && node.typeVersion === 1) {

--- a/packages/workflow/src/TelemetryHelpers.ts
+++ b/packages/workflow/src/TelemetryHelpers.ts
@@ -250,6 +250,10 @@ export function generateNodesGraph(
 			nodeItem.agent = (node.parameters.agent as string) ?? 'conversationalAgent';
 		} else if (node.type === MERGE_NODE_TYPE) {
 			nodeItem.operation = node.parameters.mode as string;
+
+			if (options?.isCloudDeployment) {
+				nodeItem.sql = node.parameters.query as string;
+			}
 		} else if (node.type === HTTP_REQUEST_NODE_TYPE && node.typeVersion === 1) {
 			try {
 				nodeItem.domain = new URL(node.parameters.url as string).hostname;

--- a/packages/workflow/test/TelemetryHelpers.test.ts
+++ b/packages/workflow/test/TelemetryHelpers.test.ts
@@ -592,85 +592,126 @@ describe('generateNodesGraph', () => {
 		});
 	});
 
-	test('should return graph with merge v3 node', () => {
-		const workflow: Partial<IWorkflowBase> = {
-			nodes: [
-				{
-					parameters: {
-						mode: 'combineBySql',
-						query: 'SELECT * FROM input1 LEFT JOIN input2 ON input1.name = input2.id',
-					},
-					id: 'b468b603-3e59-4515-b555-90cfebd64d47',
-					name: 'Merge Node V3',
-					type: 'n8n-nodes-base.merge',
-					typeVersion: 3,
-					position: [320, 460],
-				},
-			],
-			connections: {},
-			pinData: {},
-		};
-
-		expect(generateNodesGraph(workflow, nodeTypes)).toEqual({
-			nodeGraph: {
-				node_types: ['n8n-nodes-base.merge'],
-				node_connections: [],
-				nodes: {
-					'0': {
+	it.each([
+		{
+			workflow: {
+				nodes: [
+					{
+						parameters: {
+							mode: 'combineBySql',
+							query: 'SELECT * FROM input1 LEFT JOIN input2 ON input1.name = input2.id',
+						},
 						id: 'b468b603-3e59-4515-b555-90cfebd64d47',
+						name: 'Merge Node V3',
 						type: 'n8n-nodes-base.merge',
-						version: 3,
+						typeVersion: 3,
 						position: [320, 460],
-						operation: 'combineBySql',
 					},
+				],
+				connections: {},
+				pinData: {},
+			} as Partial<IWorkflowBase>,
+			isCloudDeployment: false,
+			expected: {
+				nodeGraph: {
+					node_types: ['n8n-nodes-base.merge'],
+					node_connections: [],
+					nodes: {
+						'0': {
+							id: 'b468b603-3e59-4515-b555-90cfebd64d47',
+							type: 'n8n-nodes-base.merge',
+							version: 3,
+							position: [320, 460],
+							operation: 'combineBySql',
+						},
+					},
+					notes: {},
+					is_pinned: false,
 				},
-				notes: {},
-				is_pinned: false,
+				nameIndices: { 'Merge Node V3': '0' },
+				webhookNodeNames: [],
 			},
-			nameIndices: { 'Merge Node V3': '0' },
-			webhookNodeNames: [],
-		});
-	});
-
-	test('should return graph with sql for merge v3 node on cloud', () => {
-		const workflow: Partial<IWorkflowBase> = {
-			nodes: [
-				{
-					parameters: {
-						mode: 'combineBySql',
-						query: 'SELECT * FROM input1 LEFT JOIN input2 ON input1.name = input2.id',
-					},
-					id: 'b468b603-3e59-4515-b555-90cfebd64d47',
-					name: 'Merge Node V3',
-					type: 'n8n-nodes-base.merge',
-					typeVersion: 3,
-					position: [320, 460],
-				},
-			],
-			connections: {},
-			pinData: {},
-		};
-
-		expect(generateNodesGraph(workflow, nodeTypes, { isCloudDeployment: true })).toEqual({
-			nodeGraph: {
-				node_types: ['n8n-nodes-base.merge'],
-				node_connections: [],
-				nodes: {
-					'0': {
+		},
+		{
+			workflow: {
+				nodes: [
+					{
+						parameters: {
+							mode: 'append',
+						},
 						id: 'b468b603-3e59-4515-b555-90cfebd64d47',
+						name: 'Merge Node V3',
 						type: 'n8n-nodes-base.merge',
-						version: 3,
+						typeVersion: 3,
 						position: [320, 460],
-						operation: 'combineBySql',
-						sql: 'SELECT * FROM input1 LEFT JOIN input2 ON input1.name = input2.id',
 					},
+				],
+				connections: {},
+				pinData: {},
+			} as Partial<IWorkflowBase>,
+			isCloudDeployment: true,
+			expected: {
+				nodeGraph: {
+					node_types: ['n8n-nodes-base.merge'],
+					node_connections: [],
+					nodes: {
+						'0': {
+							id: 'b468b603-3e59-4515-b555-90cfebd64d47',
+							type: 'n8n-nodes-base.merge',
+							version: 3,
+							position: [320, 460],
+							operation: 'append',
+						},
+					},
+					notes: {},
+					is_pinned: false,
 				},
-				notes: {},
-				is_pinned: false,
+				nameIndices: { 'Merge Node V3': '0' },
+				webhookNodeNames: [],
 			},
-			nameIndices: { 'Merge Node V3': '0' },
-			webhookNodeNames: [],
-		});
+		},
+		{
+			workflow: {
+				nodes: [
+					{
+						parameters: {
+							mode: 'combineBySql',
+							query: 'SELECT * FROM input1 LEFT JOIN input2 ON input1.name = input2.id',
+						},
+						id: 'b468b603-3e59-4515-b555-90cfebd64d47',
+						name: 'Merge Node V3',
+						type: 'n8n-nodes-base.merge',
+						typeVersion: 3,
+						position: [320, 460],
+					},
+				],
+				connections: {},
+				pinData: {},
+			} as Partial<IWorkflowBase>,
+			isCloudDeployment: true,
+			expected: {
+				nodeGraph: {
+					node_types: ['n8n-nodes-base.merge'],
+					node_connections: [],
+					nodes: {
+						'0': {
+							id: 'b468b603-3e59-4515-b555-90cfebd64d47',
+							type: 'n8n-nodes-base.merge',
+							version: 3,
+							position: [320, 460],
+							operation: 'combineBySql',
+							sql: 'SELECT * FROM input1 LEFT JOIN input2 ON input1.name = input2.id',
+						},
+					},
+					notes: {},
+					is_pinned: false,
+				},
+				nameIndices: { 'Merge Node V3': '0' },
+				webhookNodeNames: [],
+			},
+		},
+	])('should return graph with merge v3 node', ({ workflow, expected, isCloudDeployment }) => {
+		expect(generateNodesGraph(workflow, nodeTypes, { isCloudDeployment })).toEqual(expected);
 	});
 
 	test('should return graph with http v1 node', () => {

--- a/packages/workflow/test/TelemetryHelpers.test.ts
+++ b/packages/workflow/test/TelemetryHelpers.test.ts
@@ -592,6 +592,87 @@ describe('generateNodesGraph', () => {
 		});
 	});
 
+	test('should return graph with merge v3 node', () => {
+		const workflow: Partial<IWorkflowBase> = {
+			nodes: [
+				{
+					parameters: {
+						mode: 'combineBySql',
+						query: 'SELECT * FROM input1 LEFT JOIN input2 ON input1.name = input2.id',
+					},
+					id: 'b468b603-3e59-4515-b555-90cfebd64d47',
+					name: 'Merge Node V3',
+					type: 'n8n-nodes-base.merge',
+					typeVersion: 3,
+					position: [320, 460],
+				},
+			],
+			connections: {},
+			pinData: {},
+		};
+
+		expect(generateNodesGraph(workflow, nodeTypes)).toEqual({
+			nodeGraph: {
+				node_types: ['n8n-nodes-base.merge'],
+				node_connections: [],
+				nodes: {
+					'0': {
+						id: 'b468b603-3e59-4515-b555-90cfebd64d47',
+						type: 'n8n-nodes-base.merge',
+						version: 3,
+						position: [320, 460],
+						operation: 'combineBySql',
+					},
+				},
+				notes: {},
+				is_pinned: false,
+			},
+			nameIndices: { 'Merge Node V3': '0' },
+			webhookNodeNames: [],
+		});
+	});
+
+	test('should return graph with sql for merge v3 node on cloud', () => {
+		const workflow: Partial<IWorkflowBase> = {
+			nodes: [
+				{
+					parameters: {
+						mode: 'combineBySql',
+						query: 'SELECT * FROM input1 LEFT JOIN input2 ON input1.name = input2.id',
+					},
+					id: 'b468b603-3e59-4515-b555-90cfebd64d47',
+					name: 'Merge Node V3',
+					type: 'n8n-nodes-base.merge',
+					typeVersion: 3,
+					position: [320, 460],
+				},
+			],
+			connections: {},
+			pinData: {},
+		};
+
+		expect(generateNodesGraph(workflow, nodeTypes, { isCloudDeployment: true })).toEqual({
+			nodeGraph: {
+				node_types: ['n8n-nodes-base.merge'],
+				node_connections: [],
+				nodes: {
+					'0': {
+						id: 'b468b603-3e59-4515-b555-90cfebd64d47',
+						type: 'n8n-nodes-base.merge',
+						version: 3,
+						position: [320, 460],
+						operation: 'combineBySql',
+						sql: 'SELECT * FROM input1 LEFT JOIN input2 ON input1.name = input2.id',
+					},
+				},
+				notes: {},
+				is_pinned: false,
+			},
+			nameIndices: { 'Merge Node V3': '0' },
+			webhookNodeNames: [],
+		});
+	});
+
 	test('should return graph with http v1 node', () => {
 		const workflow: Partial<IWorkflowBase> = {
 			nodes: [


### PR DESCRIPTION
## Summary

In order to understand how important [NODE-1606](https://linear.app/n8n/issue/NODE-1606/paired-item-in-merge-sql-operation) is, we are adding telemetry to the SQL of the merge only on Cloud

## Related Linear tickets, Github issues, and Community forum posts

Resolves https://linear.app/n8n/issue/NODE-2478/add-more-merge-node-telemetry

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
