### PR TITLE
fix(core): Make sub-workflows with waits return correct data to parents

### DIFF
--- a/packages/cli/src/__tests__/wait-tracker.test.ts
+++ b/packages/cli/src/__tests__/wait-tracker.test.ts
@@ -1,7 +1,7 @@
 import { mock } from 'jest-mock-extended';
 import type { InstanceSettings } from 'n8n-core';
-import type { IRun, IWorkflowBase } from 'n8n-workflow';
-import { createDeferredPromise } from 'n8n-workflow';
+import type { IRun, IWorkflowBase, INode } from 'n8n-workflow';
+import { createDeferredPromise, WAIT_INDEFINITELY } from 'n8n-workflow';
 
 import type { ActiveExecutions } from '@/active-executions';
 import type { Project } from '@/databases/entities/project';
@@ -149,10 +149,11 @@ describe('WaitTracker', () => {
 			);
 		});
 
-		it('should also resume parent execution once sub-workflow finishes', async () => {
+		it('should also resume parent execution once waiting sub-workflow finishes with no data', async () => {
 			const parentExecution = mock<IExecutionResponse>({
 				id: 'parent_execution_id',
 				finished: false,
+				status: 'waiting',
 			});
 			parentExecution.workflowData = mock<IWorkflowBase>({ id: 'parent_workflow_id' });
 			execution.data.parentExecution = {
@@ -189,8 +190,254 @@ describe('WaitTracker', () => {
 				execution.id,
 			);
 
-			postExecutePromise.resolve(mock<IRun>());
+			const subworkflowResults = mock<IRun>({
+				data: {
+					resultData: {
+						runData: {},
+					},
+				},
+			});
+
+			postExecutePromise.resolve(subworkflowResults);
 			await jest.advanceTimersByTimeAsync(100);
+
+			expect(workflowRunner.run).toHaveBeenCalledTimes(2);
+			expect(workflowRunner.run).toHaveBeenNthCalledWith(
+				2,
+				{
+					executionMode: parentExecution.mode,
+					executionData: parentExecution.data,
+					workflowData: parentExecution.workflowData,
+					projectId: project.id,
+					pushRef: parentExecution.data.pushRef,
+				},
+				false,
+				false,
+				parentExecution.id,
+			);
+		});
+
+		it('should resume parent execution with sub-workflow results once waiting sub-workflow finishes with data', async () => {
+			const parentExecution: IExecutionResponse = {
+				id: 'parent_execution_id',
+				finished: false,
+				status: 'waiting',
+				waitTill: WAIT_INDEFINITELY,
+				workflowData: mock<IWorkflowBase>({ id: 'parent_workflow_id' }),
+				customData: {},
+				annotation: {
+					tags: [],
+				},
+				createdAt: new Date(),
+				startedAt: new Date(),
+				mode: 'manual',
+				workflowId: 'parent_workflow_id',
+				data: {
+					resultData: {
+						runData: {
+							'Execute Sub Workflow': [
+								{
+									hints: [],
+									startTime: new Date().getTime(),
+									executionTime: 20,
+									source: [
+										{
+											previousNode: 'Previous Node In Parent Workflow',
+										},
+									],
+									metadata: {
+										subExecution: {
+											executionId: '123',
+											workflowId: 'some random id',
+										},
+										subExecutionsCount: 1,
+									},
+									executionStatus: 'waiting',
+									data: {
+										main: [
+											[
+												{
+													json: {
+														data: 'Input sub workflow wait node received before waiting',
+													},
+													pairedItem: {
+														item: 0,
+													},
+												},
+											],
+										],
+									},
+								},
+							],
+						},
+						lastNodeExecuted: 'Execute Sub Workflow',
+					},
+					executionData: {
+						contextData: mock(),
+						nodeExecutionStack: [
+							{
+								node: mock<INode>({ name: 'Execute Sub Workflow' }),
+								data: {
+									main: [
+										[
+											{
+												json: {
+													data: 'Input received before sub-workflow execution',
+												},
+												pairedItem: {
+													item: 0,
+												},
+											},
+										],
+									],
+								},
+								source: {
+									main: [
+										{
+											previousNode: 'Previous Node In Parent Workflow',
+										},
+									],
+								},
+							},
+						],
+						metadata: {},
+						waitingExecution: {},
+						waitingExecutionSource: {},
+					},
+					parentExecution: undefined,
+				},
+			};
+
+			execution.data.parentExecution = {
+				executionId: parentExecution.id,
+				workflowId: parentExecution.workflowData.id,
+			};
+
+			executionRepository.findSingleExecution
+				.calledWith(parentExecution.id)
+				.mockResolvedValue(parentExecution);
+			executionRepository.updateExistingExecution.mockResolvedValue();
+
+			const postExecutePromise = createDeferredPromise<IRun | undefined>();
+			activeExecutions.getPostExecutePromise
+				.calledWith(execution.id)
+				.mockReturnValue(postExecutePromise.promise);
+
+			await waitTracker.startExecution(execution.id);
+
+			expect(executionRepository.findSingleExecution).toHaveBeenNthCalledWith(1, execution.id, {
+				includeData: true,
+				unflattenData: true,
+			});
+
+			expect(workflowRunner.run).toHaveBeenCalledTimes(1);
+			expect(workflowRunner.run).toHaveBeenNthCalledWith(
+				1,
+				{
+					executionMode: execution.mode,
+					executionData: execution.data,
+					workflowData: execution.workflowData,
+					projectId: project.id,
+					pushRef: execution.data.pushRef,
+				},
+				false,
+				false,
+				execution.id,
+			);
+
+			const subworkflowResults: IRun = {
+				mode: 'manual',
+				startedAt: new Date(),
+				status: 'running',
+				data: {
+					resultData: {
+						runData: {
+							'Test sub-workflow node': [
+								{
+									hints: [],
+									startTime: new Date().getTime(),
+									executionTime: 0,
+									source: [
+										{
+											previousNode: 'Wait on Timer',
+										},
+									],
+									executionStatus: 'success',
+									data: {
+										main: [
+											[
+												{
+													json: {
+														data: 'Test sub-workflow result',
+													},
+													pairedItem: {
+														item: 0,
+													},
+												},
+											],
+										],
+									},
+								},
+							],
+						},
+						lastNodeExecuted: 'Test sub-workflow node',
+					},
+				},
+			};
+
+			postExecutePromise.resolve(subworkflowResults);
+			await jest.advanceTimersByTimeAsync(100);
+
+			expect(executionRepository.updateExistingExecution).toHaveBeenCalledTimes(1);
+			expect(executionRepository.updateExistingExecution).toHaveBeenNthCalledWith(
+				1,
+				parentExecution.id,
+				{
+					data: {
+						...parentExecution.data,
+						executionData: {
+							...parentExecution.data.executionData,
+							nodeExecutionStack: [
+								{
+									...parentExecution.data.executionData!.nodeExecutionStack[0],
+									data: {
+										main: [
+											[
+												{
+													json: {
+														data: 'Test sub-workflow result',
+													},
+													pairedItem: {
+														item: 0,
+													},
+												},
+											],
+										],
+									},
+								},
+							],
+						},
+					},
+				},
+			);
+
+			expect(executionRepository.findSingleExecution).toHaveBeenCalledTimes(3);
+			expect(executionRepository.findSingleExecution).toHaveBeenNthCalledWith(
+				2,
+				parentExecution.id,
+				{
+					includeData: true,
+					unflattenData: true,
+				},
+			);
+			expect(executionRepository.findSingleExecution).toHaveBeenNthCalledWith(
+				3,
+				parentExecution.id,
+				{
+					includeData: true,
+					unflattenData: true,
+				},
+			);
 
 			expect(workflowRunner.run).toHaveBeenCalledTimes(2);
 			expect(workflowRunner.run).toHaveBeenNthCalledWith(

--- a/packages/cli/src/wait-tracker.ts
+++ b/packages/cli/src/wait-tracker.ts
@@ -6,6 +6,7 @@ import { ActiveExecutions } from '@/active-executions';
 import { ExecutionRepository } from '@/databases/repositories/execution.repository';
 import { OrchestrationService } from '@/services/orchestration.service';
 import { OwnershipService } from '@/services/ownership.service';
+import { getDataLastExecutedNodeData } from '@/workflow-helpers';
 import { WorkflowRunner } from '@/workflow-runner';
 
 @Service()
@@ -137,9 +138,58 @@ export class WaitTracker {
 		const { parentExecution } = fullExecutionData.data;
 		if (parentExecution) {
 			// on child execution completion, resume parent execution
-			void this.activeExecutions.getPostExecutePromise(executionId).then(() => {
-				void this.startExecution(parentExecution.executionId);
-			});
+			void this.activeExecutions
+				.getPostExecutePromise(executionId)
+				.then(async (subworkflowResults) => {
+					if (!subworkflowResults) return;
+
+					const lastExecutedNodeData = getDataLastExecutedNodeData(subworkflowResults);
+					if (!lastExecutedNodeData?.data) return;
+
+					try {
+						const parent = await this.executionRepository.findSingleExecution(
+							parentExecution.executionId,
+							{
+								includeData: true,
+								unflattenData: true,
+							},
+						);
+
+						if (!parent || parent.status !== 'waiting') return;
+
+						const parentWithSubWorkflowResults = {
+							data: { ...parent.data },
+						};
+
+						if (
+							!parentWithSubWorkflowResults.data.executionData?.nodeExecutionStack ||
+							parentWithSubWorkflowResults.data.executionData.nodeExecutionStack.length === 0
+						) {
+							return;
+						}
+
+						// Copy the sub workflow result to the parent execution's Execute Workflow node inputs
+						// so that the Execute Workflow node returns the correct data when parent execution is resumed
+						// and the Execute Workflow node is executed again in disabled mode.
+						parentWithSubWorkflowResults.data.executionData.nodeExecutionStack[0].data =
+							lastExecutedNodeData.data;
+
+						await this.executionRepository.updateExistingExecution(
+							parentExecution.executionId,
+							parentWithSubWorkflowResults,
+						);
+					} catch (error: unknown) {
+						this.logger.error('Could not copy sub workflow result to waiting parent execution', {
+							executionId,
+							parentExecutionId: parentExecution.executionId,
+							workflowId,
+							error,
+						});
+					}
+				})
+				.then(() => {
+					void this.startExecution(parentExecution.executionId);
+				});
 		}
 	}
 


### PR DESCRIPTION
## Summary

Executing sub workflows with `Execute Sub Workflow`s in `options.waitForSubWorkflow` mode containing `Wait` nodes or "Human in the Loop" `sendAndWait` nodes would make them return wrong data to the parent workflow once execution resumed after the sub workflow resumed from `waiting` state.

This affected at least:

"Wait" nodes using resume modes
- `webhook`
- `form`
- `specificTime`, if the chosen time is more than 65 seconds away
- `timeInterval`, if the chosen interval is longer than 65 seconds

"Human in the loop" nodes in `sendAndWait` operation mode
- Discord
- Gmail
- Google Chat
- Microsoft Outlook
- Microsoft Teams
- Send Email
- Slack
- Telegram
- Whatsapp Business Cloud

or any other nodes that would call `putExecutionToWait`. When parent workflow execution resumed it never received the final output from the sub workflow, and the input to `Execute Sub Workflow` node was be "returned" from the execution instead (like when `options.waitForSubWorkflow` mode is disabled).

This PR fixes this by copying the output from last node of sub workflow into the input of its parent workflow's waiting node, which should be the `Execute Sub Workflow` node. This works well in `Run once with all items` mode but I now realized that the `Run once with each item` mode behaves differently here and this fix doesn't work for it yet.

The issue can be reproduced with these workflows

[Simple_parent.json](https://github.com/user-attachments/files/19211801/Simple_parent.json)
[Simple_Wait_Webhook_child.json](https://github.com/user-attachments/files/19211802/Simple_Wait_Webhook_child.json)

Note that the wait has to be longer than 65 seconds, but webhook, form and one of the many `sendAndWait` nodes can be used instead.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3297/community-issue-calling-a-sub-workflow-with-a-wait-by-webhook-node
Fixes #13135 

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
