### PR TITLE
fix(editor): Handle Leading Spaces in Workflow Search

### DIFF
--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/NodesListPanel.test.ts
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/NodesListPanel.test.ts
@@ -247,5 +247,21 @@ describe('NodesListPanel', () => {
 			await nextTick();
 			expect(screen.queryAllByTestId('item-iterator-item')).toHaveLength(9);
 		});
+
+		it('should trim search input before emitting update', async () => {
+			renderComponent();
+			await nextTick();
+
+			expect(screen.queryByTestId('node-creator-search-bar')).toBeInTheDocument();
+			await fireEvent.input(screen.getByTestId('node-creator-search-bar'), {
+				target: { value: '    Node 1' },
+			});
+			await nextTick();
+
+			expect(screen.queryAllByTestId('item-iterator-item')).toHaveLength(1);
+			expect(screen.queryByText('Node 1')).toBeInTheDocument();
+
+			expect(screen.getByTestId('node-creator-search-bar')).toHaveValue('Node 1');
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/Panel/SearchBar.vue
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/Panel/SearchBar.vue
@@ -28,7 +28,7 @@ function focus() {
 
 function onInput(event: Event) {
 	const input = event.target as HTMLInputElement;
-	emit('update:modelValue', input.value);
+	emit('update:modelValue', input.value.trim());
 }
 
 function clear() {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

- Fixes an issue where searches with leading spaces (e.g., " Slack", " Linkedin") returned no results.
- Adds test cases to verify search behavior with leading spaces

https://www.loom.com/share/bd2d5907725542fe95631066fb49a70b

## Related Linear tickets, Github issues, and Community forum posts

closes #13885 

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
