### PR TITLE
fix(YouTube Node): Fix small typo (no-changelog) 

### DIFF
--- a/packages/nodes-base/nodes/Google/YouTube/PlaylistDescription.ts
+++ b/packages/nodes-base/nodes/Google/YouTube/PlaylistDescription.ts
@@ -112,7 +112,7 @@ export const playlistFields: INodeProperties[] = [
 				type: 'string',
 				default: '',
 				description:
-					'Keyword tags associated with the playlist. Mulplie can be defined separated by comma.',
+					'Keyword tags associated with the playlist. Multiple can be defined separated by comma.',
 			},
 			{
 				displayName: 'Default Language Name or ID',
@@ -512,7 +512,7 @@ export const playlistFields: INodeProperties[] = [
 				type: 'string',
 				default: '',
 				description:
-					'Keyword tags associated with the playlist. Mulplie can be defined separated by comma.',
+					'Keyword tags associated with the playlist. Multiple can be defined separated by comma.',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Google/YouTube/VideoDescription.ts
+++ b/packages/nodes-base/nodes/Google/YouTube/VideoDescription.ts
@@ -241,7 +241,7 @@ export const videoFields: INodeProperties[] = [
 				type: 'string',
 				default: '',
 				description:
-					'Keyword tags associated with the playlist. Mulplie can be defined separated by comma.',
+					'Keyword tags associated with the playlist. Multiple can be defined separated by comma.',
 			},
 		],
 	},
@@ -819,7 +819,7 @@ export const videoFields: INodeProperties[] = [
 				type: 'string',
 				default: '',
 				description:
-					'Keyword tags associated with the playlist. Mulplie can be defined separated by comma.',
+					'Keyword tags associated with the playlist. Multiple can be defined separated by comma.',
 			},
 		],
 	},


### PR DESCRIPTION
Fixes small typo in YouTube tagging tooltip. 
Changes "Mulplie" to "Multiple"
