### PR TITLE
fix: Update Sentry `rewriteFramesIntegration` prefix (no-changleog)

### DIFF
--- a/packages/frontend/editor-ui/src/plugins/sentry.ts
+++ b/packages/frontend/editor-ui/src/plugins/sentry.ts
@@ -55,6 +55,7 @@ export const SentryPlugin: Plugin = {
 			environment,
 			integrations: [
 				Sentry.rewriteFramesIntegration({
+					prefix: '',
 					root: window.location.origin + '/',
 				}),
 			],


### PR DESCRIPTION
## Summary

Sets an empty string prefix to replace the `app://` prefix.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
