### PR TITLE
fix(core): Ensure sentry releases follow semver (no-changelog)

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -160,7 +160,7 @@ jobs:
         continue-on-error: true
         with:
           projects: ${{ secrets.SENTRY_FRONTEND_PROJECT }}
-          version: ${{ needs.publish-to-npm.outputs.release }}
+          version: n8n@${{ needs.publish-to-npm.outputs.release }}
           sourcemaps: packages/frontend/editor-ui/dist
 
       - name: Create a backend release
@@ -168,7 +168,7 @@ jobs:
         continue-on-error: true
         with:
           projects: ${{ secrets.SENTRY_BACKEND_PROJECT }}
-          version: ${{ needs.publish-to-npm.outputs.release }}
+          version: n8n@${{ needs.publish-to-npm.outputs.release }}
           sourcemaps: packages/cli/dist packages/core/dist packages/nodes-base/dist packages/@n8n/n8n-nodes-langchain/dist
 
       - name: Create a task runner release
@@ -176,7 +176,7 @@ jobs:
         continue-on-error: true
         with:
           projects: ${{ secrets.SENTRY_TASK_RUNNER_PROJECT }}
-          version: ${{ needs.publish-to-npm.outputs.release }}
+          version: n8n@${{ needs.publish-to-npm.outputs.release }}
           sourcemaps: packages/core/dist packages/workflow/dist packages/@n8n/task-runner/dist
 
   trigger-release-note:

--- a/packages/@n8n/task-runner/src/__tests__/task-runner-sentry.test.ts
+++ b/packages/@n8n/task-runner/src/__tests__/task-runner-sentry.test.ts
@@ -5,6 +5,12 @@ import type { ErrorReporter } from 'n8n-core';
 import { TaskRunnerSentry } from '../task-runner-sentry';
 
 describe('TaskRunnerSentry', () => {
+	const commonConfig = {
+		n8nVersion: '1.0.0',
+		environment: 'local',
+		deploymentName: 'test',
+	};
+
 	afterEach(() => {
 		jest.resetAllMocks();
 	});
@@ -12,10 +18,8 @@ describe('TaskRunnerSentry', () => {
 	describe('filterOutUserCodeErrors', () => {
 		const sentry = new TaskRunnerSentry(
 			{
+				...commonConfig,
 				dsn: 'https://sentry.io/123',
-				n8nVersion: '1.0.0',
-				environment: 'local',
-				deploymentName: 'test',
 			},
 			mock(),
 		);
@@ -103,10 +107,8 @@ describe('TaskRunnerSentry', () => {
 		it('should not configure sentry if dsn is not set', async () => {
 			const sentry = new TaskRunnerSentry(
 				{
+					...commonConfig,
 					dsn: '',
-					n8nVersion: '1.0.0',
-					environment: 'local',
-					deploymentName: 'test',
 				},
 				mockErrorReporter,
 			);
@@ -119,10 +121,8 @@ describe('TaskRunnerSentry', () => {
 		it('should configure sentry if dsn is set', async () => {
 			const sentry = new TaskRunnerSentry(
 				{
+					...commonConfig,
 					dsn: 'https://sentry.io/123',
-					n8nVersion: '1.0.0',
-					environment: 'local',
-					deploymentName: 'test',
 				},
 				mockErrorReporter,
 			);
@@ -132,7 +132,7 @@ describe('TaskRunnerSentry', () => {
 			expect(mockErrorReporter.init).toHaveBeenCalledWith({
 				dsn: 'https://sentry.io/123',
 				beforeSendFilter: sentry.filterOutUserCodeErrors,
-				release: '1.0.0',
+				release: 'n8n@1.0.0',
 				environment: 'local',
 				serverName: 'test',
 				serverType: 'task_runner',
@@ -146,10 +146,8 @@ describe('TaskRunnerSentry', () => {
 		it('should not shutdown sentry if dsn is not set', async () => {
 			const sentry = new TaskRunnerSentry(
 				{
+					...commonConfig,
 					dsn: '',
-					n8nVersion: '1.0.0',
-					environment: 'local',
-					deploymentName: 'test',
 				},
 				mockErrorReporter,
 			);
@@ -162,10 +160,8 @@ describe('TaskRunnerSentry', () => {
 		it('should shutdown sentry if dsn is set', async () => {
 			const sentry = new TaskRunnerSentry(
 				{
+					...commonConfig,
 					dsn: 'https://sentry.io/123',
-					n8nVersion: '1.0.0',
-					environment: 'local',
-					deploymentName: 'test',
 				},
 				mockErrorReporter,
 			);

--- a/packages/@n8n/task-runner/src/task-runner-sentry.ts
+++ b/packages/@n8n/task-runner/src/task-runner-sentry.ts
@@ -22,7 +22,7 @@ export class TaskRunnerSentry {
 		await this.errorReporter.init({
 			serverType: 'task_runner',
 			dsn,
-			release: n8nVersion,
+			release: `n8n@${n8nVersion}`,
 			environment,
 			serverName: deploymentName,
 			beforeSendFilter: this.filterOutUserCodeErrors,

--- a/packages/cli/src/commands/base-command.ts
+++ b/packages/cli/src/commands/base-command.ts
@@ -74,7 +74,7 @@ export abstract class BaseCommand extends Command {
 			serverType: this.instanceSettings.instanceType,
 			dsn: backendDsn,
 			environment,
-			release: N8N_VERSION,
+			release: `n8n@${N8N_VERSION}`,
 			serverName: deploymentName,
 			releaseDate: N8N_RELEASE_DATE,
 		});


### PR DESCRIPTION
## Summary

According to [Sentry docs](https://docs.sentry.io/platforms/javascript/configuration/releases/#bind-the-version), the release version needs to include a package name as well to be marked as semver.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
