### PR TITLE
fix(core): License should ignore empty input on onFeatureChange

### DIFF
--- a/packages/cli/src/license.ts
+++ b/packages/cli/src/license.ts
@@ -131,11 +131,18 @@ export class License {
 	}
 
 	async onFeatureChange(_features: TFeatures): Promise<void> {
+		const { isMultiMain, isLeader } = this.instanceSettings;
+
+		if (Object.keys(_features).length === 0) {
+			this.logger.error('Empty license features recieved', { isMultiMain, isLeader });
+			return;
+		}
+
 		this.logger.debug('License feature change detected', _features);
 
 		this.checkIsLicensedForMultiMain(_features);
 
-		if (this.instanceSettings.isMultiMain && !this.instanceSettings.isLeader) {
+		if (isMultiMain && !isLeader) {
 			this.logger
 				.scoped(['scaling', 'multi-main-setup', 'license'])
 				.debug('Instance is not leader, skipping sending of "reload-license" command...');


### PR DESCRIPTION
## Summary

There is likely a race-condition in a multi-main setup of n8n that's causing some instances to receive a `onFeatureChange` call with an empty object `{}` instead if a valid set of features.
This leads to features getting removed even if they are actually still licensed.
Until we manage to narrow down the race-condition, this check ensures that payloads like these are ignored.

https://linear.app/n8n/issue/CAT-714

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
