### PR TITLE
fix(core): Don't fail partial execution when an unrelated node is dirty

### DIFF
--- a/packages/core/src/execution-engine/partial-execution-utils/__tests__/directed-graph.test.ts
+++ b/packages/core/src/execution-engine/partial-execution-utils/__tests__/directed-graph.test.ts
@@ -492,4 +492,35 @@ describe('DirectedGraph', () => {
 			expect(graph.hasNode(node.name + 'foo')).toBe(false);
 		});
 	});
+
+	describe('getNodesByNames', () => {
+		test('returns empty Set when no names are provided', () => {
+			// ARRANGE
+			const node1 = createNodeData({ name: 'Node1' });
+			const node2 = createNodeData({ name: 'Node2' });
+			const graph = new DirectedGraph().addNodes(node1, node2);
+
+			// ACT
+			const result = graph.getNodesByNames([]);
+
+			// ASSERT
+			expect(result.size).toBe(0);
+			expect(result).toEqual(new Set());
+		});
+
+		test('returns Set with only nodes that exist in the graph', () => {
+			// ARRANGE
+			const node1 = createNodeData({ name: 'Node1' });
+			const node2 = createNodeData({ name: 'Node2' });
+			const node3 = createNodeData({ name: 'Node3' });
+			const graph = new DirectedGraph().addNodes(node1, node2, node3);
+
+			// ACT
+			const result = graph.getNodesByNames(['Node1', 'Node3', 'Node4']);
+
+			// ASSERT
+			expect(result.size).toBe(2);
+			expect(result).toEqual(new Set([node1, node3]));
+		});
+	});
 });

--- a/packages/core/src/execution-engine/partial-execution-utils/directed-graph.ts
+++ b/packages/core/src/execution-engine/partial-execution-utils/directed-graph.ts
@@ -50,6 +50,25 @@ export class DirectedGraph {
 		return new Map(this.nodes.entries());
 	}
 
+	/**
+	 * Returns a set of nodes whose names match the provided array of names.
+	 *
+	 * Only nodes that exist in the graph will be included in the result.
+	 */
+	getNodesByNames(names: string[]) {
+		const nodes: Set<INode> = new Set();
+
+		for (const name of names) {
+			const node = this.nodes.get(name);
+
+			if (node) {
+				nodes.add(node);
+			}
+		}
+
+		return nodes;
+	}
+
 	getConnections(filter: { to?: INode } = {}) {
 		const filteredCopy: GraphConnection[] = [];
 

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -404,7 +404,7 @@ export class WorkflowExecute {
 		const filteredNodes = graph.getNodes();
 
 		// 3. Find the Start Nodes
-		const dirtyNodes = new Set(workflow.getNodes(dirtyNodeNames));
+		const dirtyNodes = graph.getNodesByNames(dirtyNodeNames);
 		runData = cleanRunData(runData, graph, dirtyNodes);
 		let startNodes = findStartNodes({ graph, trigger, destination, runData, pinData });
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

*before:*

https://github.com/user-attachments/assets/d1b21d9b-6479-4338-9112-1f79049cded3

*after:*

https://github.com/user-attachments/assets/6b5bef18-cc84-43d5-baf5-e6310c5e683c

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2673/partial-executions-fail-if-an-unrelated-node-is-dirty


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
