### PR TITLE
fix: Allow username to be set in Redis chat memory

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryRedisChat/MemoryRedisChat.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryRedisChat/MemoryRedisChat.node.ts
@@ -30,7 +30,7 @@ export class MemoryRedisChat implements INodeType {
 		name: 'memoryRedisChat',
 		icon: 'file:redis.svg',
 		group: ['transform'],
-		version: [1, 1.1, 1.2, 1.3, 1.4],
+		version: [1, 1.1, 1.2, 1.3, 1.4, 1.5],
 		description: 'Stores the chat history in Redis.',
 		defaults: {
 			name: 'Redis Chat Memory',
@@ -132,7 +132,8 @@ export class MemoryRedisChat implements INodeType {
 			},
 			database: credentials.database as number,
 		};
-		if (credentials.user) {
+
+		if (credentials.user && nodeVersion >= 1.5) {
 			redisOptions.username = credentials.user as string;
 		}
 		if (credentials.password) {

--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryRedisChat/MemoryRedisChat.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryRedisChat/MemoryRedisChat.node.ts
@@ -132,7 +132,9 @@ export class MemoryRedisChat implements INodeType {
 			},
 			database: credentials.database as number,
 		};
-
+		if (credentials.user) {
+			redisOptions.username = credentials.user as string;
+		}
 		if (credentials.password) {
 			redisOptions.password = credentials.password as string;
 		}


### PR DESCRIPTION
## Summary
AI Nodes don't seem to use all credential options, This fixes the issue with the Redis chat memory.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/GHC-1197/community-issue-redis-chat-memory-node-uses-always-default-user
Closes #13924


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
