### PR TITLE
fix(editor): Fix options parameters that have extra displayName field

### DIFF
--- a/packages/frontend/editor-ui/src/components/ParameterInput.test.ts
+++ b/packages/frontend/editor-ui/src/components/ParameterInput.test.ts
@@ -143,6 +143,52 @@ describe('ParameterInput.vue', () => {
 		expect(emitted('update')).toContainEqual([expect.objectContaining({ value: 'append' })]);
 	});
 
+	test('should render an options parameter even if it has invalid fields (like displayName)', async () => {
+		// Test case based on the Schedule node
+		// type=options parameters shouldn't have a displayName field, but some do
+		const { container, baseElement, emitted } = renderComponent(ParameterInput, {
+			pinia: createTestingPinia(),
+			props: {
+				path: 'operation',
+				parameter: {
+					displayName: 'Trigger at Hour',
+					name: 'triggerAtHour',
+					type: 'options',
+					default: 0,
+					options: [
+						{
+							name: 'Midnight',
+							displayName: 'Midnight',
+							value: 0,
+						},
+						{
+							name: '1am',
+							displayName: '1am',
+							value: 1,
+						},
+					],
+					description: 'The hour of the day to trigger',
+				},
+				modelValue: 0,
+			},
+		});
+		const select = container.querySelector('input') as HTMLInputElement;
+		const selectTrigger = container.querySelector('.select-trigger') as HTMLElement;
+
+		await waitFor(() => expect(select).toHaveValue('Midnight'));
+
+		await userEvent.click(selectTrigger);
+
+		const options = baseElement.querySelectorAll('.list-option');
+		expect(options.length).toEqual(2);
+		expect(options[0].querySelector('.option-headline')).toHaveTextContent('Midnight');
+		expect(options[1].querySelector('.option-headline')).toHaveTextContent('1am');
+
+		await userEvent.click(options[1]);
+
+		expect(emitted('update')).toContainEqual([expect.objectContaining({ value: 1 })]);
+	});
+
 	test('should render a string parameter', async () => {
 		const { container, emitted } = renderComponent(ParameterInput, {
 			pinia: createTestingPinia(),

--- a/packages/frontend/editor-ui/src/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/components/ParameterInput.vue
@@ -23,7 +23,7 @@ import type {
 	IParameterLabel,
 	NodeParameterValueType,
 } from 'n8n-workflow';
-import { CREDENTIAL_EMPTY_VALUE, isINodePropertyOptions, NodeHelpers } from 'n8n-workflow';
+import { CREDENTIAL_EMPTY_VALUE, NodeHelpers } from 'n8n-workflow';
 
 import CodeNodeEditor from '@/components/CodeNodeEditor/CodeNodeEditor.vue';
 import CredentialsSelect from '@/components/CredentialsSelect.vue';
@@ -574,7 +574,7 @@ const shouldCaptureForPosthog = computed(() => {
 function isValidParameterOption(
 	option: INodePropertyOptions | INodeProperties | INodePropertyCollection,
 ): option is INodePropertyOptions {
-	return isINodePropertyOptions(option) && isPresent(option.value) && isPresent(option.name);
+	return 'value' in option && isPresent(option.value) && isPresent(option.name);
 }
 
 function isRemoteParameterOption(option: INodePropertyOptions) {


### PR DESCRIPTION
## Summary

introduced in https://github.com/n8n-io/n8n/pull/13458

Options that had `displayName` were filtered out. This PR fixes that by making the validation less strict.

The `displayName` field shouldn't exist on an option and is not used, but for some nodes it does. We should improve our types to prevent this.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2554/community-issue-after-adding-schedule-trigger-workflow-cant-set-active
fixes https://github.com/n8n-io/n8n/issues/13884
## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
