### PR TITLE
feat(Odoo Node): add custom ressource method execution capabilities

### DIFF
--- a/packages/nodes-base/nodes/Odoo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Odoo/GenericFunctions.ts
@@ -381,6 +381,35 @@ export async function odooDelete(
 	}
 }
 
+export async function odooExecuteMethod(
+	this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions,
+	db: string,
+	userID: number,
+	password: string,
+	resource: string,
+	methodName: string,
+	methodArgs: any[],
+	methodKwargs: object,
+	url: string,
+): Promise<any> {
+	try {
+		const body = {
+			jsonrpc: '2.0',
+			method: 'call',
+			params: {
+				service: serviceJSONRPC,
+				method: 'execute_kw',
+				args: [db, userID, password, resource, methodName, methodArgs, methodKwargs],
+			},
+			id: randomInt(100),
+		};
+		const result = await odooJSONRPCRequest.call(this, body, url);
+		return { id: result };
+	} catch (error) {
+		throw new NodeApiError(this.getNode(), error as JsonObject);
+	}
+}
+
 export async function odooGetUserID(
 	this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions,
 	db: string,

--- a/packages/nodes-base/nodes/Odoo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Odoo/GenericFunctions.ts
@@ -121,7 +121,7 @@ export async function odooJSONRPCRequest(
 			json: true,
 		};
 
-		const response = await this.helpers.request(options);
+		const response = await this.helpers.httpRequest(options);
 		if (response.error) {
 			throw new NodeApiError(this.getNode(), response.error.data as JsonObject, {
 				message: response.error.data.message,

--- a/packages/nodes-base/nodes/Odoo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Odoo/GenericFunctions.ts
@@ -2,9 +2,9 @@ import type {
 	IDataObject,
 	IExecuteFunctions,
 	IHookFunctions,
+	IHttpRequestOptions,
 	ILoadOptionsFunctions,
 	JsonObject,
-	IRequestOptions,
 } from 'n8n-workflow';
 import { NodeApiError, randomInt } from 'n8n-workflow';
 
@@ -108,7 +108,7 @@ export async function odooJSONRPCRequest(
 	url: string,
 ): Promise<IDataObject | IDataObject[]> {
 	try {
-		const options: IRequestOptions = {
+		const options: IHttpRequestOptions = {
 			headers: {
 				'User-Agent': 'n8n',
 				Connection: 'keep-alive',
@@ -117,7 +117,7 @@ export async function odooJSONRPCRequest(
 			},
 			method: 'POST',
 			body,
-			uri: `${url}/jsonrpc`,
+			url: `${url}/jsonrpc`,
 			json: true,
 		};
 

--- a/packages/nodes-base/nodes/Odoo/Odoo.node.ts
+++ b/packages/nodes-base/nodes/Odoo/Odoo.node.ts
@@ -305,6 +305,7 @@ export class Odoo implements INodeType {
 		//                            Main loop
 		//----------------------------------------------------------------------
 
+		// TODO : Refactor this loop to remove duplicate code.
 		for (let i = 0; i < items.length; i++) {
 			try {
 				if (resource === 'contact') {

--- a/packages/nodes-base/nodes/Odoo/Odoo.node.ts
+++ b/packages/nodes-base/nodes/Odoo/Odoo.node.ts
@@ -65,7 +65,7 @@ export class Odoo implements INodeType {
 				displayName: 'Resource',
 				name: 'resource',
 				type: 'options',
-				default: 'contact',
+				default: 'custom',
 				noDataExpression: true,
 				options: [
 					{

--- a/packages/nodes-base/nodes/Odoo/Odoo.node.ts
+++ b/packages/nodes-base/nodes/Odoo/Odoo.node.ts
@@ -1,18 +1,18 @@
 import { capitalCase } from 'change-case';
 import type {
-	IExecuteFunctions,
 	ICredentialsDecrypted,
 	ICredentialTestFunctions,
 	IDataObject,
+	IExecuteFunctions,
+	IHttpRequestOptions,
 	ILoadOptionsFunctions,
 	INodeCredentialTestResult,
 	INodeExecutionData,
 	INodePropertyOptions,
 	INodeType,
 	INodeTypeDescription,
-	IRequestOptions,
 } from 'n8n-workflow';
-import { NodeConnectionType, deepCopy, randomInt } from 'n8n-workflow';
+import { deepCopy, NodeConnectionType, randomInt } from 'n8n-workflow';
 
 import {
 	contactDescription,
@@ -246,7 +246,7 @@ export class Odoo implements INodeType {
 						id: randomInt(100),
 					};
 
-					const options: IRequestOptions = {
+					const options: IHttpRequestOptions = {
 						headers: {
 							'User-Agent': 'n8n',
 							Connection: 'keep-alive',
@@ -255,7 +255,7 @@ export class Odoo implements INodeType {
 						},
 						method: 'POST',
 						body,
-						uri: `${(credentials?.url as string).replace(/\/$/, '')}/jsonrpc`,
+						url: `${(credentials?.url as string).replace(/\/$/, '')}/jsonrpc`,
 						json: true,
 					};
 					const result = await this.helpers.request(options);

--- a/packages/nodes-base/nodes/Odoo/descriptions/CustomResourceDescription.ts
+++ b/packages/nodes-base/nodes/Odoo/descriptions/CustomResourceDescription.ts
@@ -162,7 +162,7 @@ export const customResourceDescription: INodeProperties[] = [
 						name: 'argValue',
 						type: 'string',
 						default: '',
-						// TODO: Add placeholders
+						placeholder: 'Could be a number, a string, an array or a tupple',
 					},
 				],
 			},
@@ -196,14 +196,14 @@ export const customResourceDescription: INodeProperties[] = [
 						name: 'kwargName',
 						type: 'string',
 						default: '',
-						// TODO: Add placeholders
+						placeholder: 'limit',
 					},
 					{
 						displayName: 'Keyword Argument Value',
 						name: 'kwargValue',
 						type: 'string',
 						default: '',
-						// TODO: Add placeholders
+						placeholder: '10',
 					},
 				],
 			},

--- a/packages/nodes-base/nodes/Odoo/descriptions/CustomResourceDescription.ts
+++ b/packages/nodes-base/nodes/Odoo/descriptions/CustomResourceDescription.ts
@@ -42,6 +42,12 @@ export const customResourceOperations: INodeProperties[] = [
 				action: 'Delete an item',
 			},
 			{
+				name: 'Execute a Method',
+				value: 'executeMethod',
+				description: 'Execute a method on a custom resource',
+				action: 'Execute a method',
+			},
+			{
 				name: 'Get',
 				value: 'get',
 				description: 'Get an item',
@@ -104,6 +110,100 @@ export const customResourceDescription: INodeProperties[] = [
 						name: 'fieldValue',
 						type: 'string',
 						default: '',
+					},
+				],
+			},
+		],
+	},
+
+	/* -------------------------------------------------------------------------- */
+	/*                            custom:executeMethod                            */
+	/* -------------------------------------------------------------------------- */
+
+	{
+		displayName: 'Method Name',
+		name: 'methodName',
+		type: 'string',
+		description: 'Choose a method to execute on the custom resource',
+		default: '',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['custom'],
+				operation: ['executeMethod'],
+			},
+		},
+	},
+
+	{
+		displayName: 'Method Arguments',
+		name: 'methodArgs',
+		type: 'fixedCollection',
+		description: 'Arguments to pass to the method',
+		default: {},
+		typeOptions: {
+			multipleValues: true,
+			multipleValueButtonText: 'Add Argument',
+		},
+		placeholder: 'Add Argument',
+		displayOptions: {
+			show: {
+				resource: ['custom'],
+				operation: ['executeMethod'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Argument',
+				name: 'args',
+				values: [
+					{
+						displayName: 'Argument Value',
+						name: 'argValue',
+						type: 'string',
+						default: '',
+						// TODO: Add placeholders
+					},
+				],
+			},
+		],
+	},
+
+	{
+		displayName: 'Method Keyword Arguments',
+		name: 'methodKwargs',
+		type: 'fixedCollection',
+		description: 'Keyword arguments to pass to the method',
+		default: {},
+		typeOptions: {
+			multipleValues: true,
+			multipleValueButtonText: 'Add Keyword Argument',
+		},
+		placeholder: 'Add Keyword Argument',
+		displayOptions: {
+			show: {
+				resource: ['custom'],
+				operation: ['executeMethod'],
+			},
+		},
+		options: [
+			{
+				name: 'kwargs',
+				displayName: 'Keyword Argument',
+				values: [
+					{
+						displayName: 'Keyword Argument Name',
+						name: 'kwargName',
+						type: 'string',
+						default: '',
+						// TODO: Add placeholders
+					},
+					{
+						displayName: 'Keyword Argument Value',
+						name: 'kwargValue',
+						type: 'string',
+						default: '',
+						// TODO: Add placeholders
 					},
 				],
 			},


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Disclaimer : I don't code in TypeScript, so I discovered languages particularities on the go. I tried to fit to the coding style of the current node codebase though, so it should be ok.

### Why was this needed ?

Currently, if someone wanted to let's say post a message to a specific record's chatter, he needed to do it using HTTP Request nodes and using Odoo JsonRPC. 

1. He would first use a HTTP request to login :

```json
{
  "jsonrpc": "2.0",
  "method": "call",
  "params": {
    "service": "common",
    "method": "login", 
    "args": [
      "{{ $('Odoo Json RPC Variable').first().json.DB_NAME }}",
      "{{ $('Odoo Json RPC Variable').first().json.ODOO_LOGIN }}",
      "{{ $('Odoo Json RPC Variable').first().json.ODOO_API_KEY }}"
    ]
  }
}
```

2. And then another one to post the message :

```json
{
  "jsonrpc": "2.0",
  "method": "call",
  "params": {
    "service": "object",
    "method": "execute",
    "args": [
      "{{ $('Odoo Json RPC Variable').first().json.DB_NAME }}",
      "{{ $('Odoo RPC Login').first().json.result }}",
      "{{ $('Odoo Json RPC Variable').first().json.ODOO_API_KEY }}",
      "res.partner",
      "search",
      [["name", "=", "test"]]
    ]
  }
}
```

The issue is that it then **requires to use credentials inside the workflow as the authentification is done inside the json body**. This is unfortunately a security issue to have these in the logs.

### Improvements made and demo

I added the ability to execute a custom method inside a record with the authenticated user capabilities. For instance, he would be able to :

1. Post a message in the chatter :

![image](https://github.com/user-attachments/assets/8f7e1824-bb4f-428a-9aca-7a6385ce0260)

2. Do a custom search (which was already available through the `getAll` capabilities of the node :

![image](https://github.com/user-attachments/assets/d785147e-04f0-4c45-858c-8a64f3271753)

He would also be able to execute method that are executed periodically as part of some kind of automation process or record cleaning, for example.

## Related Linear tickets, Github issues, and Community forum posts

None, this is a personal need that I haven't seen expressed yet here in the form of an issue. I think I remember having read about it in the community forum, though.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->

## Follow up and questions

I will probably update the doc on another follow-up ticket if the feature is approved. 

As for the testing, I think we should discuss the need to keep contact, note and opportunity first.

If we could remove hard coded resources, we would make the node more modulable and remove so many duplicated code parts in the codebase. But before doing so, I would like to verify that it is wanted by the n8n-team.

## Help needed

I do struggle a bit with the last part of the odooExecuteMethod being :

```
const result = await odooJSONRPCRequest.call(this, body, url);
return { id: result };
```

Maybe I should make it even more adaptable, but I am no expert and would benefit from an experienced eye here.