### PR TITLE
fix(Microsoft SQL Node): Fix maximum call stack on execute query

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Sql/MicrosoftSql.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Sql/MicrosoftSql.node.ts
@@ -269,7 +269,7 @@ export class MicrosoftSql implements INodeType {
 						);
 					}
 					const results = await executeSqlQueryAndPrepareResults(pool, rawQuery, i);
-					returnData.push(...results);
+					returnData.concat(results);
 				} catch (error) {
 					if (this.continueOnFail()) {
 						returnData.push({

--- a/packages/nodes-base/nodes/Microsoft/Sql/MicrosoftSql.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Sql/MicrosoftSql.node.ts
@@ -269,7 +269,7 @@ export class MicrosoftSql implements INodeType {
 						);
 					}
 					const results = await executeSqlQueryAndPrepareResults(pool, rawQuery, i);
-					returnData.concat(results);
+					returnData = returnData.concat(results);
 				} catch (error) {
 					if (this.continueOnFail()) {
 						returnData.push({


### PR DESCRIPTION
## Summary
Same as fixes for similar nodes in the past.

Marking as draft until I have set up an MS SQL server to test.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/GHC-1203/community-issue-microsoftsql-node-maximum-call-stack-size-exceeded
closes #13939 


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
