### PR TITLE
fix(editor): Switch schema preview feature flag to multivariant (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/components/RunData.vue
@@ -574,7 +574,10 @@ const isSchemaPreviewEnabled = computed(
 		!(nodeType.value?.codex?.categories ?? []).some(
 			(category) => category === CORE_NODES_CATEGORY,
 		) &&
-		posthogStore.isFeatureEnabled(SCHEMA_PREVIEW_EXPERIMENT),
+		posthogStore.isVariantEnabled(
+			SCHEMA_PREVIEW_EXPERIMENT.name,
+			SCHEMA_PREVIEW_EXPERIMENT.variant,
+		),
 );
 
 const hasPreviewSchema = asyncComputed(async () => {

--- a/packages/frontend/editor-ui/src/components/VirtualSchema.test.ts
+++ b/packages/frontend/editor-ui/src/components/VirtualSchema.test.ts
@@ -484,7 +484,7 @@ describe('VirtualSchema.vue', () => {
 			const trackSpy = vi.spyOn(telemetry, 'track');
 			const posthogStore = usePostHog();
 
-			vi.spyOn(posthogStore, 'isFeatureEnabled').mockReturnValue(true);
+			vi.spyOn(posthogStore, 'isVariantEnabled').mockReturnValue(true);
 			const schemaPreviewStore = useSchemaPreviewStore();
 			vi.spyOn(schemaPreviewStore, 'getSchemaPreview').mockResolvedValue(
 				createResultOk({
@@ -562,7 +562,7 @@ describe('VirtualSchema.vue', () => {
 			data: [],
 		});
 		const posthogStore = usePostHog();
-		vi.spyOn(posthogStore, 'isFeatureEnabled').mockReturnValue(true);
+		vi.spyOn(posthogStore, 'isVariantEnabled').mockReturnValue(true);
 		const schemaPreviewStore = useSchemaPreviewStore();
 		vi.spyOn(schemaPreviewStore, 'getSchemaPreview').mockResolvedValue(
 			createResultOk({

--- a/packages/frontend/editor-ui/src/components/VirtualSchema.vue
+++ b/packages/frontend/editor-ui/src/components/VirtualSchema.vue
@@ -130,7 +130,7 @@ const getNodeSchema = async (fullNode: INodeUi, connectedNode: IConnectedNode) =
 };
 
 const isSchemaPreviewEnabled = computed(() =>
-	posthogStore.isFeatureEnabled(SCHEMA_PREVIEW_EXPERIMENT),
+	posthogStore.isVariantEnabled(SCHEMA_PREVIEW_EXPERIMENT.name, SCHEMA_PREVIEW_EXPERIMENT.variant),
 );
 
 const nodeSchema = asyncComputed(async () => {

--- a/packages/frontend/editor-ui/src/constants.ts
+++ b/packages/frontend/editor-ui/src/constants.ts
@@ -727,6 +727,12 @@ export const AI_CREDITS_EXPERIMENT = {
 	variant: 'variant',
 };
 
+export const SCHEMA_PREVIEW_EXPERIMENT = {
+	name: '028_schema_preview',
+	control: 'control',
+	variant: 'variant',
+};
+
 export const EXPERIMENTS_TO_TRACK = [
 	TEMPLATE_CREDENTIAL_SETUP_EXPERIMENT,
 	CANVAS_AUTO_ADD_MANUAL_TRIGGER_EXPERIMENT.name,
@@ -734,10 +740,10 @@ export const EXPERIMENTS_TO_TRACK = [
 	CREDENTIAL_DOCS_EXPERIMENT.name,
 	EASY_AI_WORKFLOW_EXPERIMENT.name,
 	AI_CREDITS_EXPERIMENT.name,
+	SCHEMA_PREVIEW_EXPERIMENT.name,
 ];
 
 export const WORKFLOW_EVALUATION_EXPERIMENT = '025_workflow_evaluation';
-export const SCHEMA_PREVIEW_EXPERIMENT = '028_schema_preview';
 
 export const MFA_FORM = {
 	MFA_TOKEN: 'MFA_TOKEN',


### PR DESCRIPTION
## Summary

Switch `028_schema_preview` from feature toggle (boolean) to multi variant

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2558/update-schema-preview-feature-flag-to-multiple-variants

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
