### PR TITLE
fix: Allow saved credentials types of up to 128 characters instead of 32

### DIFF
--- a/packages/@n8n/api-types/src/dto/credentials/__tests__/create-credential.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/__tests__/create-credential.dto.test.ts
@@ -34,6 +34,17 @@ describe('CreateCredentialDto', () => {
 					},
 				},
 			},
+			{
+				name: 'longer type',
+				request: {
+					name: 'LinkedIn Community Management OAuth2 API',
+					type: 'linkedInCommunityManagementOAuth2Api',
+					data: {
+						clientId: '123',
+						clientSecret: 'secret',
+					},
+				},
+			},
 		])('should validate $name', ({ request }) => {
 			const result = CreateCredentialDto.safeParse(request);
 			expect(result.success).toBe(true);

--- a/packages/@n8n/api-types/src/dto/credentials/__tests__/create-credential.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/__tests__/create-credential.dto.test.ts
@@ -121,7 +121,7 @@ describe('CreateCredentialDto', () => {
 				name: 'type too long',
 				request: {
 					name: 'My API Credentials',
-					type: 'a'.repeat(33),
+					type: 'a'.repeat(65),
 					data: {},
 				},
 				expectedErrorPath: ['type'],

--- a/packages/@n8n/api-types/src/dto/credentials/__tests__/create-credential.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/__tests__/create-credential.dto.test.ts
@@ -121,7 +121,7 @@ describe('CreateCredentialDto', () => {
 				name: 'type too long',
 				request: {
 					name: 'My API Credentials',
-					type: 'a'.repeat(65),
+					type: 'a'.repeat(129),
 					data: {},
 				},
 				expectedErrorPath: ['type'],

--- a/packages/@n8n/api-types/src/dto/credentials/create-credential.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/create-credential.dto.ts
@@ -3,7 +3,7 @@ import { Z } from 'zod-class';
 
 export class CreateCredentialDto extends Z.class({
 	name: z.string().min(1).max(128),
-	type: z.string().min(1).max(64),
+	type: z.string().min(1).max(128),
 	data: z.record(z.string(), z.unknown()),
 	projectId: z.string().optional(),
 }) {}

--- a/packages/@n8n/api-types/src/dto/credentials/create-credential.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/create-credential.dto.ts
@@ -3,7 +3,7 @@ import { Z } from 'zod-class';
 
 export class CreateCredentialDto extends Z.class({
 	name: z.string().min(1).max(128),
-	type: z.string().min(1).max(32),
+	type: z.string().min(1).max(64),
 	data: z.record(z.string(), z.unknown()),
 	projectId: z.string().optional(),
 }) {}


### PR DESCRIPTION
## Summary
We set a limit of 32 characters for credential types but we already exceed that limit, This increases it to 64 characters.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-2560/linkedin-updated-the-max-length-of-their-client-secrets-to-50-but-we
https://community.n8n.io/t/linkedin-api-client-secret-32-character-limit-but-its-33-characters-long/86953/6


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
