### PR TITLE
fix(n8n Form Trigger Node): Add back the query selector for multiselect

### DIFF
--- a/packages/cli/templates/form-trigger.handlebars
+++ b/packages/cli/templates/form-trigger.handlebars
@@ -859,7 +859,10 @@
 							}
 						}
 					}
-
+					document.querySelectorAll('.multiselect').forEach((multiselect) => {
+ 						const selectedValues = getSelectedValues(multiselect);
+ 						formData.append(multiselect.id, JSON.stringify(selectedValues));
+ 					});
 					document.querySelector('#submit-btn').disabled = true;
 					document.querySelector('#submit-btn').style.cursor = 'not-allowed';
 					document.querySelector('#submit-btn span').style.display = 'inline-block';


### PR DESCRIPTION
## Summary

This resolves a bug which was introduced in #13506 which was not allowing drop downs to be included in the result

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2556/community-issue-%5Bbug%5D-dropdown-list-multi-choice-on-node-form-not

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
