### PR TITLE
fix(core): Allow running webhook servers in multi-main mode

### DIFF
--- a/packages/cli/src/commands/webhook.ts
+++ b/packages/cli/src/commands/webhook.ts
@@ -1,6 +1,5 @@
 import { Container } from '@n8n/di';
 import { Flags } from '@oclif/core';
-import { UserError } from 'n8n-workflow';
 
 import { ActiveExecutions } from '@/active-executions';
 import config from '@/config';
@@ -83,10 +82,6 @@ export class Webhook extends BaseCommand {
 	}
 
 	async run() {
-		if (this.globalConfig.multiMainSetup.enabled) {
-			throw new UserError('Webhook process cannot be started when multi-main setup is enabled.');
-		}
-
 		const { ScalingService } = await import('@/scaling/scaling.service');
 		await Container.get(ScalingService).setupQueue();
 		await this.server.start();


### PR DESCRIPTION
## Summary

When we added multi-main support in n8n, we assumed that webhook servers were only being used as a scaling mechanism, and weren't needed anymore, since we could not scale up the main instances instead.
However, webhook servers have a second role: They can be used to expose only the webhook server to the internet, while keeping the rest of the infrastructure private.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
