### PR TITLE
fix(core): Bring back the missing GMT and UTC timezone for workflow settings

### DIFF
--- a/packages/cli/scripts/build.mjs
+++ b/packages/cli/scripts/build.mjs
@@ -65,9 +65,10 @@ function bundleOpenApiSpecs() {
 }
 
 function generateTimezoneData() {
-	const timezones = rawTimeZones.reduce((acc, tz) => {
-		acc[tz.name] = tz.name.replaceAll('_', ' ');
+	const timezones = ['Etc/UTC', 'Etc/GMT', ...rawTimeZones.map((tz) => tz.name)];
+	const data = timezones.sort().reduce((acc, name) => {
+		acc[name] = name.replaceAll('_', ' ');
 		return acc;
 	}, {});
-	writeFileSync(path.resolve(ROOT_DIR, 'dist/timezones.json'), JSON.stringify({ data: timezones }));
+	writeFileSync(path.resolve(ROOT_DIR, 'dist/timezones.json'), JSON.stringify({ data }));
 }


### PR DESCRIPTION
## Summary

These were accidentally removed in https://github.com/n8n-io/n8n/pull/10073

![image](https://github.com/user-attachments/assets/de9cbf42-2d80-46e4-b00e-055e941137b0)


## Related Linear tickets, Github issues, and Community forum posts

https://community.n8n.io/t/default-timezone-issues/51334/13
https://community.n8n.io/t/generic-timezone-value-for-utc-gmt/89077


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
