### PR TITLE
fix(core): Ensure frontend sentry releases also follow semver

### DIFF
--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -259,7 +259,7 @@ export class Server extends AbstractServer {
 						dsn: this.globalConfig.sentry.frontendDsn,
 						environment: process.env.ENVIRONMENT || 'development',
 						serverName: process.env.DEPLOYMENT_NAME,
-						release: N8N_VERSION,
+						release: `n8n@${N8N_VERSION}`,
 					}),
 				);
 				res.end();


### PR DESCRIPTION
## Summary

In #13907, I forgot to update the frontend setup.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
