### PR TITLE
fix(core): Don't abort import if user already owns credential

### DIFF
--- a/packages/cli/src/commands/import/credentials.ts
+++ b/packages/cli/src/commands/import/credentials.ts
@@ -154,6 +154,11 @@ export class ImportCredentialsCommand extends BaseCommand {
 				continue;
 			}
 
+			// check if credential is already owned by the provided userId
+			if (userId && user?.id === userId) {
+				continue;
+			}
+
 			if (ownerProject.id !== projectId) {
 				const currentOwner =
 					ownerProject.type === 'personal'

--- a/packages/cli/test/integration/commands/credentials.cmd.test.ts
+++ b/packages/cli/test/integration/commands/credentials.cmd.test.ts
@@ -296,6 +296,73 @@ test('`import:credential --projectId ...` should fail if the credential already 
 	});
 });
 
+test('`import:credential --userId ...` should succeed if the credential already exists and is already owned by the user', async () => {
+	//
+	// ARRANGE
+	//
+	const owner = await createOwner();
+	const ownerProject = await getPersonalProject(owner);
+	const member = await createMember();
+	const memberProject = await getPersonalProject(member);
+
+	// import credential the first time, assigning it to the owner
+	await command.run([
+		'--input=./test/integration/commands/import-credentials/credentials.json',
+		`--userId=${owner.id}`,
+	]);
+
+	// making sure the import worked
+	const before = {
+		credentials: await getAllCredentials(),
+		sharings: await getAllSharedCredentials(),
+	};
+	expect(before).toMatchObject({
+		credentials: [expect.objectContaining({ id: '123', name: 'cred-aws-test' })],
+		sharings: [
+			expect.objectContaining({
+				credentialsId: '123',
+				projectId: ownerProject.id,
+				role: 'credential:owner',
+			}),
+		],
+	});
+
+	//
+	// ACT
+	//
+
+	// Import again changing nothing but the name and passing `--userId`
+	await command.run([
+		'--input=./test/integration/commands/import-credentials/credentials-updated.json',
+		`--projectId=${memberProject.id}`,
+	]);
+
+	//
+	// ASSERT
+	//
+	const after = {
+		credentials: await getAllCredentials(),
+		sharings: await getAllSharedCredentials(),
+	};
+
+	expect(after).toMatchObject({
+		credentials: [
+			expect.objectContaining({
+				id: '123',
+				// only the name was updated
+				name: 'cred-aws-prod',
+			}),
+		],
+		sharings: [
+			expect.objectContaining({
+				credentialsId: '123',
+				projectId: memberProject.id,
+				role: 'credential:owner',
+			}),
+		],
+	});
+});
+
 test('`import:credential --projectId ... --userId ...` fails explaining that only one of the options can be used at a time', async () => {
 	await expect(
 		command.run([

--- a/packages/cli/test/integration/commands/credentials.cmd.test.ts
+++ b/packages/cli/test/integration/commands/credentials.cmd.test.ts
@@ -334,7 +334,7 @@ test('`import:credential --userId ...` should succeed if the credential already 
 	// Import again changing nothing but the name and passing `--userId`
 	await command.run([
 		'--input=./test/integration/commands/import-credentials/credentials-updated.json',
-		`--projectId=${memberProject.id}`,
+		`--userId=${owner.id}`,
 	]);
 
 	//
@@ -356,7 +356,7 @@ test('`import:credential --userId ...` should succeed if the credential already 
 		sharings: [
 			expect.objectContaining({
 				credentialsId: '123',
-				projectId: memberProject.id,
+				projectId: ownerProject.id,
 				role: 'credential:owner',
 			}),
 		],


### PR DESCRIPTION
## Summary

When importing credentials the current implementation fails because it tries to prevent re-owning although the user already owns the credential.

```
2025-03-18T14:59:46.742Z | error | An error occurred while importing credentials. See log messages for details. {"file":"credentials.js","function":"catch"}
2025-03-18T14:59:46.742Z | error | The credential with ID "3cJ83Qo5X4LKeEqU" is already owned by the user with the ID "b0910508-69e7-4be3-a76d-0c4ceb16d55a". It can't be re-owned by the user with the ID "b0910508-69e7-4be3-a76d-0c4ceb16d55a". {"file":"credentials.js","function":"catch"}
```

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [n/a] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
