### PR TITLE
feat(API): Fix generation strategy for mysql/mariadb

### DIFF
--- a/packages/cli/src/databases/dsl/column.ts
+++ b/packages/cli/src/databases/dsl/column.ts
@@ -179,7 +179,7 @@ export class Column {
 
 		if (isGenerated2) {
 			options.isGenerated = true;
-			options.generationStrategy = type === 'uuid' ? 'uuid' : 'identity';
+			options.generationStrategy = type === 'uuid' ? 'uuid' : isMysql ? 'increment' : 'identity';
 		}
 
 		if (isPrimary || isGenerated || isGenerated2) {

--- a/packages/cli/src/databases/entities/abstract-entity.ts
+++ b/packages/cli/src/databases/entities/abstract-entity.ts
@@ -23,8 +23,6 @@ const timestampSyntax = {
 
 export const jsonColumnType = dbType === 'sqlite' ? 'simple-json' : 'json';
 export const datetimeColumnType = dbType === 'postgresdb' ? 'timestamptz' : 'datetime';
-export const datetimeColumnDefault =
-	dbType === 'sqlite' ? () => 'unixepoch()' : () => 'CURRENT_TIMESTAMP';
 
 const tsColumnOptions: ColumnOptions = {
 	precision: 3,

--- a/packages/cli/src/databases/entities/abstract-entity.ts
+++ b/packages/cli/src/databases/entities/abstract-entity.ts
@@ -23,6 +23,8 @@ const timestampSyntax = {
 
 export const jsonColumnType = dbType === 'sqlite' ? 'simple-json' : 'json';
 export const datetimeColumnType = dbType === 'postgresdb' ? 'timestamptz' : 'datetime';
+export const datetimeColumnDefault =
+	dbType === 'sqlite' ? () => 'unixepoch()' : () => 'CURRENT_TIMESTAMP';
 
 const tsColumnOptions: ColumnOptions = {
 	precision: 3,


### PR DESCRIPTION
## Summary

Use increment strategy for mysql on autogeneration because identity is not handled by mariadb


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [X] ~[Docs updated](https://github.com/n8n-io/n8n-docs)~ or follow-up ticket created.
- [X] ~Tests included.~ <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [X] ~PR Labeled with `release/backport`~ (if the PR is an urgent fix that needs to be backported)
