### PR TITLE
feat(Wordpress Node): Excerpt and Featured Media support for Posts

### DIFF
--- a/packages/nodes-base/nodes/Wordpress/PostDescription.ts
+++ b/packages/nodes-base/nodes/Wordpress/PostDescription.ts
@@ -135,6 +135,20 @@ export const postFields: INodeProperties[] = [
 				description: 'A named status for the post',
 			},
 			{
+				displayName: 'Excerpt',
+				name: 'excerpt',
+				type: 'string',
+				default: '',
+				description: 'The excerpt for the post',
+			},
+			{
+				displayName: 'Featured Media ID',
+				name: 'featuredMediaId',
+				type: 'number',
+				default: '',
+				description: 'The ID of the featured media for the post',
+			},
+			{
 				displayName: 'Comment Status',
 				name: 'commentStatus',
 				type: 'options',
@@ -412,6 +426,20 @@ export const postFields: INodeProperties[] = [
 				],
 				default: 'draft',
 				description: 'A named status for the post',
+			},
+			{
+				displayName: 'Excerpt',
+				name: 'excerpt',
+				type: 'string',
+				default: '',
+				description: 'The excerpt for the post',
+			},
+			{
+				displayName: 'Featured Media ID',
+				name: 'featuredMediaId',
+				type: 'number',
+				default: '',
+				description: 'The ID of the featured media for the post',
 			},
 			{
 				displayName: 'Comment Status',

--- a/packages/nodes-base/nodes/Wordpress/PostInterface.ts
+++ b/packages/nodes-base/nodes/Wordpress/PostInterface.ts
@@ -6,6 +6,8 @@ export interface IPost {
 	slug?: string;
 	password?: string;
 	status?: string;
+	excerpt?: string;
+	featured_media?: number;
 	comment_status?: string;
 	ping_status?: string;
 	format?: string;

--- a/packages/nodes-base/nodes/Wordpress/Wordpress.node.ts
+++ b/packages/nodes-base/nodes/Wordpress/Wordpress.node.ts
@@ -162,6 +162,12 @@ export class Wordpress implements INodeType {
 						if (additionalFields.status) {
 							body.status = additionalFields.status as string;
 						}
+						if (additionalFields.excerpt) {
+							body.excerpt = additionalFields.excerpt as string;
+						}
+						if (additionalFields.featuredMediaId) {
+							body.featured_media = additionalFields.featuredMediaId as number;
+						}
 						if (additionalFields.commentStatus) {
 							body.comment_status = additionalFields.commentStatus as string;
 						}
@@ -213,6 +219,12 @@ export class Wordpress implements INodeType {
 						}
 						if (updateFields.status) {
 							body.status = updateFields.status as string;
+						}
+						if (updateFields.excerpt) {
+							body.excerpt = updateFields.excerpt as string;
+						}
+						if (updateFields.featuredMediaId) {
+							body.featured_media = updateFields.featuredMediaId as number;
 						}
 						if (updateFields.commentStatus) {
 							body.comment_status = updateFields.commentStatus as string;

--- a/packages/nodes-base/nodes/Wordpress/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Wordpress/test/utils.test.ts
@@ -1,0 +1,69 @@
+import type { IExecuteFunctions, ILoadOptionsFunctions } from 'n8n-workflow/src';
+
+import { wordpressApiRequest } from '../GenericFunctions';
+
+describe('wordpressApiRequest', () => {
+	const mockHttpRequestWithAuthentication = jest.fn();
+	const mockContext = {
+		helpers: {
+			requestWithAuthentication: mockHttpRequestWithAuthentication,
+		},
+		getCredentials: jest.fn().mockImplementation(async (type) => {
+			if (type === 'wordpressApi') {
+				return {
+					url: 'https://example.com',
+					username: 'testuser',
+					password: 'testpassword',
+					allowUnauthorizedCerts: false,
+				};
+			}
+			return {};
+		}),
+	} as unknown as IExecuteFunctions | ILoadOptionsFunctions;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should make a POST request with body and return data', async () => {
+		const mockResponse = {
+			id: 123,
+			date: '2023-10-15T14:30:45',
+			date_gmt: '2023-10-15T14:30:45',
+			guid: { rendered: 'https://example.com/test-post' },
+			modified: '2023-10-15T14:30:45',
+			modified_gmt: '2023-10-15T14:30:45',
+			slug: 'my-test-post-title',
+			status: 'publish',
+			type: 'post',
+			link: 'https://example.com/my-test-post-title',
+			title: { rendered: 'My Test Post Title' },
+			content: {
+				rendered: 'This is the full content of the blog post with <b>HTML</b> formatting.',
+			},
+			excerpt: { rendered: 'This is a short excerpt for the post' },
+			featured_media: 42,
+		};
+		mockHttpRequestWithAuthentication.mockResolvedValue(mockResponse);
+
+		const requestBody = {
+			title: 'My Test Post Title',
+			excerpt: 'This is a short excerpt for the post',
+			content: 'This is the full content of the blog post with <b>HTML</b> formatting.',
+			featured_media: 42,
+		};
+
+		const result = await wordpressApiRequest.call(mockContext, 'POST', '/posts', requestBody);
+
+		expect(mockHttpRequestWithAuthentication).toHaveBeenCalledWith(
+			'wordpressApi',
+			expect.objectContaining({
+				method: 'POST',
+				uri: 'https://example.com/wp-json/wp/v2/posts',
+				body: requestBody,
+			}),
+		);
+
+		expect(result).toEqual(mockResponse);
+	});
+});


### PR DESCRIPTION
## Summary

Added support for `excerpt` and `featured_media` fields in the WordPress Node, simplifying the post creation process. Previously, users had to rely on the HTTP Request Node to include these fields when creating or updating posts. This improvement makes the WordPress Node more user-friendly and efficient.
<img width="369" alt="image" src="https://github.com/user-attachments/assets/4618a873-9f10-4164-8144-96acc9725e16" />



## Related Linear tickets, Github issues, and Community forum posts
https://community.n8n.io/t/how-to-create-a-excerpt-for-a-wordpress-post/30366

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
