### PR TITLE
refactor(core): Add strong typing for `INodeTypeBaseDescription['group']` (no-changelog)

### DIFF
--- a/packages/cli/src/__tests__/load-nodes-and-credentials.test.ts
+++ b/packages/cli/src/__tests__/load-nodes-and-credentials.test.ts
@@ -47,7 +47,7 @@ describe('LoadNodesAndCredentials', () => {
 				description: {
 					displayName: 'Test Node',
 					name: 'testNode',
-					group: ['test'],
+					group: ['input'],
 					description: 'A test node',
 					version: 1,
 					defaults: {},

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/__tests__/utils.ts
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/__tests__/utils.ts
@@ -20,7 +20,7 @@ export const mockSimplifiedNodeType = (
 	name: 'sampleName',
 	icon: 'fa:sampleIcon',
 	iconUrl: 'https://example.com/icon.png',
-	group: ['group1', 'group2'],
+	group: ['input', 'output'],
 	description: 'Sample description',
 	codex: {
 		categories: ['category1', 'category2'],

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/composables/useActionsGeneration.ts
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/composables/useActionsGeneration.ts
@@ -255,7 +255,7 @@ function resourceCategories(nodeTypeDescription: INodeTypeDescription): ActionTy
 							},
 							displayName,
 							group: ['trigger'],
-						};
+						} as ActionTypeDescription;
 					},
 				);
 

--- a/packages/frontend/editor-ui/src/composables/useUniqueNodeName.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useUniqueNodeName.test.ts
@@ -60,7 +60,7 @@ describe('useUniqueNodeName', () => {
 				version: 1,
 				inputs: [],
 				outputs: [],
-				group: [''],
+				group: ['input'],
 				properties: [],
 				defaults: {
 					name: 'S3',

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -1699,6 +1699,8 @@ export type IconRef = `fa:${string}` | `node:${string}.${string}`;
 export type IconFile = `file:${string}.png` | `file:${string}.svg`;
 export type Icon = IconRef | Themed<IconFile>;
 
+type NodeGroupType = 'input' | 'output' | 'organization' | 'schedule' | 'transform' | 'trigger';
+
 export interface INodeTypeBaseDescription {
 	displayName: string;
 	name: string;
@@ -1706,7 +1708,7 @@ export interface INodeTypeBaseDescription {
 	iconColor?: ThemeIconColor;
 	iconUrl?: Themed<string>;
 	badgeIconUrl?: Themed<string>;
-	group: string[];
+	group: NodeGroupType[];
 	description: string;
 	documentationUrl?: string;
 	subtitle?: string;


### PR DESCRIPTION
## Summary
While debugging some code I noticed that `INodeTypeBaseDescription['group']` wasn't strongly types. This PR fixes that.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
