### PR TITLE
feat: Add nodeAsTool description overrides for tool version (no-changelog)

### DIFF
--- a/packages/cli/src/__tests__/load-nodes-and-credentials.test.ts
+++ b/packages/cli/src/__tests__/load-nodes-and-credentials.test.ts
@@ -194,6 +194,30 @@ describe('LoadNodesAndCredentials', () => {
 			});
 		});
 
+		it('should handle nodes with existing codex with tool subcategory overwrite', () => {
+			fullNodeWrapper.description.codex = {
+				categories: ['AI'],
+				subcategories: {
+					AI: ['Tools'],
+					Tools: ['Recommended'],
+				},
+				resources: {
+					primaryDocumentation: [{ url: 'https://example.com' }],
+				},
+			};
+			const result = instance.convertNodeToAiTool(fullNodeWrapper);
+			expect(result.description.codex).toEqual({
+				categories: ['AI'],
+				subcategories: {
+					AI: ['Tools'],
+					Tools: ['Recommended'],
+				},
+				resources: {
+					primaryDocumentation: [{ url: 'https://example.com' }],
+				},
+			});
+		});
+
 		it('should handle nodes with very long names', () => {
 			fullNodeWrapper.description.name = 'veryLongNodeNameThatExceedsNormalLimits'.repeat(10);
 			fullNodeWrapper.description.displayName =

--- a/packages/cli/src/load-nodes-and-credentials.ts
+++ b/packages/cli/src/load-nodes-and-credentials.ts
@@ -312,10 +312,16 @@ export class LoadNodesAndCredentials {
 	 */
 	createAiTools() {
 		const usableNodes: Array<INodeTypeBaseDescription | INodeTypeDescription> =
-			this.types.nodes.filter((nodetype) => nodetype.usableAsTool === true);
+			this.types.nodes.filter((nodeType) => nodeType.usableAsTool);
 
 		for (const usableNode of usableNodes) {
-			const description = deepCopy(usableNode);
+			const description =
+				typeof usableNode.usableAsTool === 'object'
+					? ({
+							...deepCopy(usableNode),
+							...usableNode.usableAsTool?.replacements,
+						} as INodeTypeBaseDescription)
+					: deepCopy(usableNode);
 			const wrapped = this.convertNodeToAiTool({ description }).description;
 
 			this.types.nodes.push(wrapped);
@@ -505,7 +511,7 @@ export class LoadNodesAndCredentials {
 			categories: ['AI'],
 			subcategories: {
 				AI: ['Tools'],
-				Tools: ['Other Tools'],
+				Tools: item.description.codex?.subcategories?.Tools ?? ['Other Tools'],
 			},
 			resources,
 		};

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -1724,15 +1724,17 @@ export interface INodeTypeBaseDescription {
 	 * Whether the node will be wrapped for tool-use by AI Agents,
 	 * optionally with merged or replaced parts of the description
 	 */
-	usableAsTool?: true | AsToolDescription;
+	usableAsTool?: true | UsableAsToolDescription;
 }
 
 /**
- * NodeDescription props that are replaced if the node is used as a tool
+ * NodeDescription entries that replace the base node entries when
+ * the node is used as a tool
  *
- * Note that the codex is hardcoded and may need adjustment in the implementation
+ * Note that the new codex is hardcoded and may not behave as expected
+ * without additional changes to the implementation.
  */
-export type AsToolDescription = {
+export type UsableAsToolDescription = {
 	replacements?: Partial<Omit<INodeTypeBaseDescription, 'usableAsTool'>>;
 };
 

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -1722,7 +1722,7 @@ export interface INodeTypeBaseDescription {
 
 	/**
 	 * Whether the node will be wrapped for tool-use by AI Agents,
-	 * optionally with merged or replaced parts of the description
+	 * optionally replacing provided parts of the description
 	 */
 	usableAsTool?: true | UsableAsToolDescription;
 }

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -1721,10 +1721,20 @@ export interface INodeTypeBaseDescription {
 	hidden?: true;
 
 	/**
-	 * Whether the node will be wrapped for tool-use by AI Agents
+	 * Whether the node will be wrapped for tool-use by AI Agents,
+	 * optionally with merged or replaced parts of the description
 	 */
-	usableAsTool?: true;
+	usableAsTool?: true | AsToolDescription;
 }
+
+/**
+ * NodeDescription props that are replaced if the node is used as a tool
+ *
+ * Note that the codex is hardcoded and may need adjustment in the implementation
+ */
+export type AsToolDescription = {
+	replacements?: Partial<Omit<INodeTypeBaseDescription, 'usableAsTool'>>;
+};
 
 export interface INodePropertyRouting {
 	operations?: IN8nRequestOperations; // Should be changed, does not sound right


### PR DESCRIPTION
## Summary

Introduce an object value variant on `usableAsTool` to allow overwriting parts of the description for the tool version only.

I added a `replacement` key indirection in case we want other related options in the future, as otherwise we'd need to introduce yet another top-level key if the time comes.

I'm open to adding a new property instead, though I'm struggling with both a better name and don't feel great about supporting two properties that both create a tool moving forward. Renaming the existing key might be another option?

The concrete use case here is that the planned `usableAsTool` replacement of the current httpRequest tool should still show up in `Recommended Tools`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3310/feature-extend-usableastool-to-support-custom-properties


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
