### PR TITLE
feat(Matrix Node): Add audio and video media types

### DIFF
--- a/packages/nodes-base/nodes/Matrix/MediaDescription.ts
+++ b/packages/nodes-base/nodes/Matrix/MediaDescription.ts
@@ -81,6 +81,16 @@ export const mediaFields: INodeProperties[] = [
 				value: 'image',
 				description: 'Image media type',
 			},
+			{
+				name: 'Audio',
+				value: 'audio',
+				description: 'Audio media type',
+			},
+			{
+				name: 'Video',
+				value: 'video',
+				description: 'Video media type',
+			},
 		],
 		description: 'Type of file being uploaded',
 		placeholder: 'mxc://matrix.org/uploaded-media-uri',


### PR DESCRIPTION
## Summary

This adds the Audio and Video [message types](https://spec.matrix.org/latest/client-server-api/#mroommessage-msgtypes) to the Matrix Media upload.
Image and File were already there. This really is just more of the same.
It just allows Matrix clients to be more specific in how they deal with the uploaded media.

![image](https://github.com/user-attachments/assets/fdf988ec-2d00-4a35-83a8-eaa5bb33e91c)

My use case is uploading a voicemail wav file from a PBX.
All I had was the plain File option. You then have to download the file from the Matrix client, to open it somewhere else.
![image](https://github.com/user-attachments/assets/6db0a549-1601-47c0-8ded-56a65b2fcc39)
With the Audio option you can play the file in the client itself.
![image](https://github.com/user-attachments/assets/844d584e-145d-4780-a520-0ee62a0cebf2)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
