### PR TITLE
fix: AWS credential signing http request - convert form to body

### DIFF
--- a/packages/nodes-base/credentials/Aws.credentials.ts
+++ b/packages/nodes-base/credentials/Aws.credentials.ts
@@ -476,8 +476,6 @@ export class Aws implements ICredentialType {
 
 		path = endpoint.pathname + endpoint.search;
 
-		// ! Workaround as we still use the IRequestOptions interface which uses uri instead of url
-		// ! To change when we replace the interface with IHttpRequestOptions
 		// ! aws4.sign *must* have the body to sign, but we might have .form instead of .body
 		const requestWithForm = requestOptions as unknown as { form?: Record<string, string> };
 		let bodyContent = body !== '' ? body : undefined;

--- a/packages/nodes-base/credentials/test/Aws.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/Aws.credentials.test.ts
@@ -139,5 +139,44 @@ describe('Aws Credential', () => {
 			expect(result.method).toBe('POST');
 			expect(result.url).toBe('https://iam.amazonaws.com/');
 		});
+
+		it('should handle an IRequestOptions object with form instead of body', async () => {
+			const result = await aws.authenticate({ ...credentials }, {
+				...requestOptions,
+				body: undefined,
+				form: {
+					Action: 'ListUsers',
+					Version: '2010-05-08',
+				},
+				baseURL: '',
+				url: 'https://iam.amazonaws.com',
+				host: 'iam.amazonaws.com',
+				path: '/',
+			} as IHttpRequestOptions);
+
+			expect(mockSign).toHaveBeenCalledWith(
+				{
+					...signOpts,
+					form: {
+						Action: 'ListUsers',
+						Version: '2010-05-08',
+					},
+					body: 'Action=ListUsers&Version=2010-05-08',
+					host: 'iam.amazonaws.com',
+					url: 'https://iam.amazonaws.com',
+					baseURL: '',
+					path: '/',
+					headers: {
+						'content-type': 'application/x-www-form-urlencoded',
+					},
+					// PR #14037 introduces region normalization for global endpoints
+					// This test works with or without the normalization
+					region: expect.stringMatching(/[a-z]{2}-[a-z]+-[0-9]+/),
+				},
+				securityHeaders,
+			);
+			expect(result.method).toBe('POST');
+			expect(result.url).toBe('https://iam.amazonaws.com/');
+		});
 	});
 });


### PR DESCRIPTION
## Summary

The code that signs a request using AWS credentials does not correctly handle objects passed from HTTP Request.

There is an in-progress refactor, as already worked around in #5751 / #8563 regarding the HTTP Request Options types in use. HTTP Request uses IRequestOptions, but AWS Credentials uses IHttpOptions, which is the target for the refactor, and compatible with an AWS Request object, which is what the signing code is expecting.

The problem is that HTTP Request converts or passes form data as a form property of the object. This is safely ignored by the type management and object processing, but it renders the content to sign incomplete. AWS SigV4 expects and requires the body to be part of the signing request (as well as the content-type header), and is ignorant of the form property.

Unless the form data is converted (back) to body content for the signing request, the result will be an incorrect signature that AWS will reject.

This bug can be simply reproduced:
* Use an HTTP Request node
* Set and associate valid AWS credentials
* Set properties:
  * Method: `POST`
  * URL: `https://iam.amazonaws.com`
  * Authentication: `Predefined credential type`
  * Credential Type: `AWS`
  * AWS: `<select valid credential>`
  * Send Query: `false`
  * Send Headers: `false`
  * Send Body: `true`
  * Body Content Type: `Form Urlencoded`
  * Specify Body: `Using single field`
  * Body: `Action=ListUsers&Version=2010-05-08`
 
The resulting error will be:

```
403

{
  "Error": {
    "Code": "SignatureDoesNotMatch",
    "Message": "The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.",
    "Type": "Sender"
  },
  "RequestId": "<request id>"
}
```

This PR adopts the same workaround approach as used previously to take what it is given, and modify it accordingly so that the signing is successful. `form` content is converted to `body` content, and to ensure it is present as required (and with the right normalised lower casing), if the content-type header is not present it is set to application/x-www-form-urlencoded.

## Related Linear tickets, Github issues, and Community forum posts

Relates to #8563 
Relates to #5751
Relates (kinda) to #14037

<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. -- *NOTE*: Bugfix, no docfix to do.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
