### PR TITLE
feat(API): Only allow instance owners and admins to see overview

### DIFF
--- a/packages/@n8n/permissions/src/constants.ee.ts
+++ b/packages/@n8n/permissions/src/constants.ee.ts
@@ -23,4 +23,5 @@ export const RESOURCES = {
 	workersView: ['manage'] as const,
 	workflow: ['share', 'execute', 'move', ...DEFAULT_OPERATIONS] as const,
 	folder: [...DEFAULT_OPERATIONS] as const,
+	insights: [...DEFAULT_OPERATIONS] as const,
 } as const;

--- a/packages/@n8n/permissions/src/constants.ee.ts
+++ b/packages/@n8n/permissions/src/constants.ee.ts
@@ -23,5 +23,5 @@ export const RESOURCES = {
 	workersView: ['manage'] as const,
 	workflow: ['share', 'execute', 'move', ...DEFAULT_OPERATIONS] as const,
 	folder: [...DEFAULT_OPERATIONS] as const,
-	insights: [...DEFAULT_OPERATIONS] as const,
+	insights: ['list'] as const,
 } as const;

--- a/packages/cli/src/modules/insights/insights.controller.ts
+++ b/packages/cli/src/modules/insights/insights.controller.ts
@@ -11,7 +11,7 @@ export class InsightsController {
 	constructor(private readonly insightsService: InsightsService) {}
 
 	@Get('/summary')
-	@GlobalScope('insights:read')
+	@GlobalScope('insights:list')
 	async getInsightsSummary(): Promise<InsightsSummary> {
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 		return await this.insightsService.getInsightsSummary();

--- a/packages/cli/src/modules/insights/insights.controller.ts
+++ b/packages/cli/src/modules/insights/insights.controller.ts
@@ -2,7 +2,7 @@
 
 import type { InsightsSummary } from '@n8n/api-types';
 
-import { Get, RestController } from '@/decorators';
+import { Get, GlobalScope, RestController } from '@/decorators';
 
 import { InsightsService } from './insights.service';
 
@@ -11,6 +11,7 @@ export class InsightsController {
 	constructor(private readonly insightsService: InsightsService) {}
 
 	@Get('/summary')
+	@GlobalScope('insights:read')
 	async getInsightsSummary(): Promise<InsightsSummary> {
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 		return await this.insightsService.getInsightsSummary();

--- a/packages/cli/src/permissions.ee/global-roles.ts
+++ b/packages/cli/src/permissions.ee/global-roles.ts
@@ -76,10 +76,7 @@ export const GLOBAL_OWNER_SCOPES: Scope[] = [
 	'project:update',
 	'project:delete',
 	'insights:list',
-	'insights:create',
 	'insights:read',
-	'insights:update',
-	'insights:delete',
 ];
 
 export const GLOBAL_ADMIN_SCOPES = GLOBAL_OWNER_SCOPES.concat();

--- a/packages/cli/src/permissions.ee/global-roles.ts
+++ b/packages/cli/src/permissions.ee/global-roles.ts
@@ -75,6 +75,11 @@ export const GLOBAL_OWNER_SCOPES: Scope[] = [
 	'project:read',
 	'project:update',
 	'project:delete',
+	'insights:list',
+	'insights:create',
+	'insights:read',
+	'insights:update',
+	'insights:delete',
 ];
 
 export const GLOBAL_ADMIN_SCOPES = GLOBAL_OWNER_SCOPES.concat();

--- a/packages/cli/src/permissions.ee/global-roles.ts
+++ b/packages/cli/src/permissions.ee/global-roles.ts
@@ -76,7 +76,6 @@ export const GLOBAL_OWNER_SCOPES: Scope[] = [
 	'project:update',
 	'project:delete',
 	'insights:list',
-	'insights:read',
 ];
 
 export const GLOBAL_ADMIN_SCOPES = GLOBAL_OWNER_SCOPES.concat();

--- a/packages/frontend/editor-ui/src/permissions.test.ts
+++ b/packages/frontend/editor-ui/src/permissions.test.ts
@@ -59,6 +59,8 @@ describe('permissions', () => {
 			'workflow:share',
 			'workflow:update',
 			'folder:create',
+			'insights:list',
+			'insights:read',
 		];
 
 		const permissionRecord: PermissionsRecord = {
@@ -119,6 +121,10 @@ describe('permissions', () => {
 			},
 			folder: {
 				create: true,
+			},
+			insights: {
+				list: true,
+				read: true,
 			},
 		};
 

--- a/packages/frontend/editor-ui/src/permissions.test.ts
+++ b/packages/frontend/editor-ui/src/permissions.test.ts
@@ -28,6 +28,7 @@ describe('permissions', () => {
 			workersView: {},
 			workflow: {},
 			folder: {},
+			insights: {},
 		});
 	});
 	it('getResourcePermissions', () => {

--- a/packages/frontend/editor-ui/src/permissions.test.ts
+++ b/packages/frontend/editor-ui/src/permissions.test.ts
@@ -61,7 +61,6 @@ describe('permissions', () => {
 			'workflow:update',
 			'folder:create',
 			'insights:list',
-			'insights:read',
 		];
 
 		const permissionRecord: PermissionsRecord = {

--- a/packages/frontend/editor-ui/src/permissions.test.ts
+++ b/packages/frontend/editor-ui/src/permissions.test.ts
@@ -124,7 +124,6 @@ describe('permissions', () => {
 			},
 			insights: {
 				list: true,
-				read: true,
 			},
 		};
 

--- a/packages/frontend/editor-ui/src/stores/rbac.store.ts
+++ b/packages/frontend/editor-ui/src/stores/rbac.store.ts
@@ -35,6 +35,7 @@ export const useRBACStore = defineStore(STORES.RBAC, () => {
 		saml: {},
 		securityAudit: {},
 		folder: {},
+		insights: {},
 	});
 
 	function addGlobalRole(role: IRole) {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR had permission checking for insights:list scope when querying insights api. The admin and owner roles have this scope

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2583/only-allow-instance-owners-and-admins-to-see-overview

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [X] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [X] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
