### PR TITLE
feat(API): Implement BE api for insights data

### DIFF
--- a/packages/@n8n/api-types/src/schemas/insights.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/insights.schema.ts
@@ -49,9 +49,9 @@ export const insightsByWorkflowDataSchemas = {
 		z
 			.object({
 				workflowId: z.string(),
-				workflowName: z.string().optional(),
-				projectId: z.string().optional(),
-				projectName: z.string().optional(),
+				workflowName: z.string(),
+				projectId: z.string(),
+				projectName: z.string(),
 				total: z.number(),
 				succeeded: z.number(),
 				failed: z.number(),

--- a/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
@@ -903,6 +903,14 @@ describe('getInsightsByWorkflow', () => {
 				periodUnit: 'day',
 				periodStart: DateTime.utc().minus({ days: 10 }),
 			});
+			// Out of date range insight (should not be included)
+			// 14 days and 1 minute ago
+			await createCompactedInsightsEvent(workflow, {
+				type: 'success',
+				value: 1,
+				periodUnit: 'day',
+				periodStart: DateTime.utc().minus({ days: 14, minutes: 1 }),
+			});
 		}
 
 		// ACT
@@ -1085,6 +1093,14 @@ describe('getInsightsByTime', () => {
 				value: workflow === workflow1 ? 10 : 20,
 				periodUnit: 'day',
 				periodStart: DateTime.utc().minus({ days: 10 }),
+			});
+			/// Out of date range insight (should not be included)
+			// 14 days ago start of the day and minus 1 minute
+			await createCompactedInsightsEvent(workflow, {
+				type: 'success',
+				value: 1,
+				periodUnit: 'day',
+				periodStart: DateTime.utc().startOf('day').minus({ days: 14, minutes: 1 }),
 			});
 		}
 

--- a/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
@@ -1036,7 +1036,7 @@ describe('getInsightsByTime', () => {
 	});
 
 	test('returns empty array when no insights exist', async () => {
-		const byTime = await insightsService.getInsightsByTime(14);
+		const byTime = await insightsService.getInsightsByTime({ maxAgeInDays: 14, periodUnit: 'day' });
 		expect(byTime).toEqual([]);
 	});
 
@@ -1048,7 +1048,7 @@ describe('getInsightsByTime', () => {
 			periodStart: DateTime.utc().minus({ days: 30 }),
 		});
 
-		const byTime = await insightsService.getInsightsByTime(14);
+		const byTime = await insightsService.getInsightsByTime({ maxAgeInDays: 14, periodUnit: 'day' });
 		expect(byTime).toEqual([]);
 	});
 
@@ -1061,10 +1061,11 @@ describe('getInsightsByTime', () => {
 				periodUnit: 'day',
 				periodStart: DateTime.utc(),
 			});
+			// Check that hourly data is grouped together with the previous daily data
 			await createCompactedInsightsEvent(workflow, {
 				type: 'failure',
 				value: 2,
-				periodUnit: 'day',
+				periodUnit: 'hour',
 				periodStart: DateTime.utc(),
 			});
 			await createCompactedInsightsEvent(workflow, {
@@ -1088,7 +1089,7 @@ describe('getInsightsByTime', () => {
 		}
 
 		// ACT
-		const byTime = await insightsService.getInsightsByTime(14);
+		const byTime = await insightsService.getInsightsByTime({ maxAgeInDays: 14, periodUnit: 'day' });
 
 		// ASSERT
 		expect(byTime).toHaveLength(3);

--- a/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
@@ -852,6 +852,173 @@ describe('getInsightsSummary', () => {
 
 describe('getInsightsByWorkflow', () => {
 	let insightsService: InsightsService;
+	beforeAll(async () => {
+		insightsService = Container.get(InsightsService);
+	});
+
+	let project: Project;
+	let workflow1: IWorkflowDb & WorkflowEntity;
+	let workflow2: IWorkflowDb & WorkflowEntity;
+	let workflow3: IWorkflowDb & WorkflowEntity;
+
+	beforeEach(async () => {
+		await truncateAll();
+
+		project = await createTeamProject();
+		workflow1 = await createWorkflow({}, project);
+		workflow2 = await createWorkflow({}, project);
+		workflow3 = await createWorkflow({}, project);
+	});
+
+	test('compacted data are are grouped by workflow correctly', async () => {
+		// ARRANGE
+		for (const workflow of [workflow1, workflow2]) {
+			await createCompactedInsightsEvent(workflow, {
+				type: 'success',
+				value: workflow === workflow1 ? 1 : 2,
+				periodUnit: 'day',
+				periodStart: DateTime.utc(),
+			});
+			await createCompactedInsightsEvent(workflow, {
+				type: 'success',
+				value: 1,
+				periodUnit: 'day',
+				periodStart: DateTime.utc().minus({ day: 2 }),
+			});
+			await createCompactedInsightsEvent(workflow, {
+				type: 'failure',
+				value: 2,
+				periodUnit: 'day',
+				periodStart: DateTime.utc(),
+			});
+			// last 14 days
+			await createCompactedInsightsEvent(workflow, {
+				type: 'success',
+				value: 1,
+				periodUnit: 'day',
+				periodStart: DateTime.utc().minus({ days: 10 }),
+			});
+			await createCompactedInsightsEvent(workflow, {
+				type: 'runtime_ms',
+				value: 123,
+				periodUnit: 'day',
+				periodStart: DateTime.utc().minus({ days: 10 }),
+			});
+		}
+
+		// ACT
+		const byWorkflow = await insightsService.getInsightsByWorkflow({
+			nbDays: 14,
+		});
+
+		// ASSERT
+		expect(byWorkflow.count).toEqual(2);
+		expect(byWorkflow.data).toHaveLength(2);
+
+		// expect first workflow to be workflow 2, because it has a bigger total (default sorting)
+		expect(byWorkflow.data[0]).toEqual({
+			workflowId: workflow2.id,
+			workflowName: workflow2.name,
+			projectId: project.id,
+			projectName: project.name,
+			total: 6,
+			failureRate: 2 / 6,
+			failed: 2,
+			runTime: 123,
+			succeeded: 4,
+			timeSaved: 0,
+			averageRunTime: 123 / 6,
+		});
+
+		expect(byWorkflow.data[1]).toEqual({
+			workflowId: workflow1.id,
+			workflowName: workflow1.name,
+			projectId: project.id,
+			projectName: project.name,
+			total: 5,
+			failureRate: 2 / 5,
+			failed: 2,
+			runTime: 123,
+			succeeded: 3,
+			timeSaved: 0,
+			averageRunTime: 123 / 5,
+		});
+	});
+
+	test('compacted data are grouped by workflow correctly with sorting', async () => {
+		// ARRANGE
+		for (const workflow of [workflow1, workflow2]) {
+			await createCompactedInsightsEvent(workflow, {
+				type: 'success',
+				value: workflow === workflow1 ? 1 : 2,
+				periodUnit: 'day',
+				periodStart: DateTime.utc(),
+			});
+			await createCompactedInsightsEvent(workflow, {
+				type: 'failure',
+				value: 2,
+				periodUnit: 'day',
+				periodStart: DateTime.utc(),
+			});
+			await createCompactedInsightsEvent(workflow, {
+				type: 'runtime_ms',
+				value: workflow === workflow1 ? 2 : 1,
+				periodUnit: 'day',
+				periodStart: DateTime.utc().minus({ days: 10 }),
+			});
+		}
+
+		// ACT
+		const byWorkflow = await insightsService.getInsightsByWorkflow({
+			nbDays: 14,
+			sortBy: 'runTime:desc',
+		});
+
+		// ASSERT
+		expect(byWorkflow.count).toEqual(2);
+		expect(byWorkflow.data).toHaveLength(2);
+		expect(byWorkflow.data[0].workflowId).toEqual(workflow1.id);
+	});
+
+	test('compacted data are grouped by workflow correctly with pagination', async () => {
+		// ARRANGE
+		for (const workflow of [workflow1, workflow2, workflow3]) {
+			await createCompactedInsightsEvent(workflow, {
+				type: 'success',
+				value: workflow === workflow1 ? 1 : workflow === workflow2 ? 2 : 3,
+				periodUnit: 'day',
+				periodStart: DateTime.utc(),
+			});
+		}
+
+		// ACT
+		const byWorkflow = await insightsService.getInsightsByWorkflow({
+			nbDays: 14,
+			sortBy: 'succeeded:desc',
+			skip: 1,
+			take: 1,
+		});
+
+		// ASSERT
+		expect(byWorkflow.count).toEqual(3);
+		expect(byWorkflow.data).toHaveLength(1);
+		expect(byWorkflow.data[0].workflowId).toEqual(workflow2.id);
+	});
+
+	test('compacted data are grouped by workflow correctly even with 0 data (check division by 0)', async () => {
+		// ACT
+		const byWorkflow = await insightsService.getInsightsByWorkflow({
+			nbDays: 14,
+		});
+
+		// ASSERT
+		expect(byWorkflow.count).toEqual(0);
+		expect(byWorkflow.data).toHaveLength(0);
+	});
+});
+
+describe('getInsightsByWorkflow', () => {
+	let insightsService: InsightsService;
 	let insightsRawRepository: InsightsRawRepository;
 	let insightsByPeriodRepository: InsightsByPeriodRepository;
 	let insightsMetadataRepository: InsightsMetadataRepository;

--- a/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
@@ -848,191 +848,281 @@ describe('getInsightsSummary', () => {
 			total: { deviation: -1, unit: 'count', value: 4 },
 		});
 	});
+});
 
-	describe('getInsightsByWorkflow', () => {
-		let insightsService: InsightsService;
-		beforeAll(async () => {
-			insightsService = Container.get(InsightsService);
+describe('getInsightsByWorkflow', () => {
+	let insightsService: InsightsService;
+	beforeAll(async () => {
+		insightsService = Container.get(InsightsService);
+	});
+
+	let project: Project;
+	let workflow1: IWorkflowDb & WorkflowEntity;
+	let workflow2: IWorkflowDb & WorkflowEntity;
+	let workflow3: IWorkflowDb & WorkflowEntity;
+
+	beforeEach(async () => {
+		await truncateAll();
+
+		project = await createTeamProject();
+		workflow1 = await createWorkflow({}, project);
+		workflow2 = await createWorkflow({}, project);
+		workflow3 = await createWorkflow({}, project);
+	});
+
+	test('compacted data are are grouped by workflow correctly', async () => {
+		// ARRANGE
+		for (const workflow of [workflow1, workflow2]) {
+			await createCompactedInsightsEvent(workflow, {
+				type: 'success',
+				value: workflow === workflow1 ? 1 : 2,
+				periodUnit: 'day',
+				periodStart: DateTime.utc(),
+			});
+			await createCompactedInsightsEvent(workflow, {
+				type: 'success',
+				value: 1,
+				periodUnit: 'day',
+				periodStart: DateTime.utc().minus({ day: 2 }),
+			});
+			await createCompactedInsightsEvent(workflow, {
+				type: 'failure',
+				value: 2,
+				periodUnit: 'day',
+				periodStart: DateTime.utc(),
+			});
+			// last 14 days
+			await createCompactedInsightsEvent(workflow, {
+				type: 'success',
+				value: 1,
+				periodUnit: 'day',
+				periodStart: DateTime.utc().minus({ days: 10 }),
+			});
+			await createCompactedInsightsEvent(workflow, {
+				type: 'runtime_ms',
+				value: 123,
+				periodUnit: 'day',
+				periodStart: DateTime.utc().minus({ days: 10 }),
+			});
+		}
+
+		// ACT
+		const byWorkflow = await insightsService.getInsightsByWorkflow({
+			nbDays: 14,
 		});
 
-		let project: Project;
-		let workflow1: IWorkflowDb & WorkflowEntity;
-		let workflow2: IWorkflowDb & WorkflowEntity;
+		// ASSERT
+		expect(byWorkflow.count).toEqual(2);
+		expect(byWorkflow.data).toHaveLength(2);
 
-		beforeEach(async () => {
-			await truncateAll();
-
-			project = await createTeamProject();
-			workflow1 = await createWorkflow({}, project);
-			workflow2 = await createWorkflow({}, project);
+		// expect first workflow to be workflow 2, because it has a bigger total (default sorting)
+		expect(byWorkflow.data[0]).toEqual({
+			workflowId: workflow2.id,
+			workflowName: workflow2.name,
+			projectId: project.id,
+			projectName: project.name,
+			total: 6,
+			failureRate: 2 / 6,
+			failed: 2,
+			runTime: 123,
+			succeeded: 4,
+			timeSaved: 0,
+			averageRunTime: 123 / 6,
 		});
 
-		test('compacted data are are grouped by workflow correctly', async () => {
-			// ARRANGE
-			for (const workflow of [workflow1, workflow2]) {
-				await createCompactedInsightsEvent(workflow, {
-					type: 'success',
-					value: workflow === workflow1 ? 1 : 2,
-					periodUnit: 'day',
-					periodStart: DateTime.utc(),
-				});
-				await createCompactedInsightsEvent(workflow, {
-					type: 'success',
-					value: 1,
-					periodUnit: 'day',
-					periodStart: DateTime.utc().minus({ day: 2 }),
-				});
-				await createCompactedInsightsEvent(workflow, {
-					type: 'failure',
-					value: 2,
-					periodUnit: 'day',
-					periodStart: DateTime.utc(),
-				});
-				// last 14 days
-				await createCompactedInsightsEvent(workflow, {
-					type: 'success',
-					value: 1,
-					periodUnit: 'day',
-					periodStart: DateTime.utc().minus({ days: 10 }),
-				});
-				await createCompactedInsightsEvent(workflow, {
-					type: 'runtime_ms',
-					value: 123,
-					periodUnit: 'day',
-					periodStart: DateTime.utc().minus({ days: 10 }),
-				});
-			}
-
-			// ACT
-			const byWorkflow = await insightsService.getInsightsByWorkflow({
-				nbDays: 14,
-			});
-
-			// ASSERT
-			expect(byWorkflow.count).toEqual(2);
-			expect(byWorkflow.data).toHaveLength(2);
-
-			// expect first workflow to be workflow 2, because it has a bigger total (default sorting)
-			expect(byWorkflow.data[0]).toEqual({
-				workflowId: workflow2.id,
-				workflowName: workflow2.name,
-				projectId: project.id,
-				projectName: project.name,
-				total: 6,
-				failureRate: 2 / 6,
-				failed: 2,
-				runTime: 123,
-				succeeded: 4,
-				timeSaved: 0,
-				averageRunTime: 123 / 6,
-			});
-
-			expect(byWorkflow.data[1]).toEqual({
-				workflowId: workflow1.id,
-				workflowName: workflow1.name,
-				projectId: project.id,
-				projectName: project.name,
-				total: 5,
-				failureRate: 2 / 5,
-				failed: 2,
-				runTime: 123,
-				succeeded: 3,
-				timeSaved: 0,
-				averageRunTime: 123 / 5,
-			});
+		expect(byWorkflow.data[1]).toEqual({
+			workflowId: workflow1.id,
+			workflowName: workflow1.name,
+			projectId: project.id,
+			projectName: project.name,
+			total: 5,
+			failureRate: 2 / 5,
+			failed: 2,
+			runTime: 123,
+			succeeded: 3,
+			timeSaved: 0,
+			averageRunTime: 123 / 5,
 		});
 	});
 
-	describe('getInsightsByTime', () => {
-		let insightsService: InsightsService;
-		beforeAll(async () => {
-			insightsService = Container.get(InsightsService);
+	test('compacted data are grouped by workflow correctly with sorting', async () => {
+		// ARRANGE
+		for (const workflow of [workflow1, workflow2]) {
+			await createCompactedInsightsEvent(workflow, {
+				type: 'success',
+				value: workflow === workflow1 ? 1 : 2,
+				periodUnit: 'day',
+				periodStart: DateTime.utc(),
+			});
+			await createCompactedInsightsEvent(workflow, {
+				type: 'failure',
+				value: 2,
+				periodUnit: 'day',
+				periodStart: DateTime.utc(),
+			});
+			await createCompactedInsightsEvent(workflow, {
+				type: 'runtime_ms',
+				value: workflow === workflow1 ? 2 : 1,
+				periodUnit: 'day',
+				periodStart: DateTime.utc().minus({ days: 10 }),
+			});
+		}
+
+		// ACT
+		const byWorkflow = await insightsService.getInsightsByWorkflow({
+			nbDays: 14,
+			sortBy: 'runTime:desc',
 		});
 
-		let project: Project;
-		let workflow1: IWorkflowDb & WorkflowEntity;
-		let workflow2: IWorkflowDb & WorkflowEntity;
+		// ASSERT
+		expect(byWorkflow.count).toEqual(2);
+		expect(byWorkflow.data).toHaveLength(2);
+		expect(byWorkflow.data[0].workflowId).toEqual(workflow1.id);
+	});
 
-		beforeEach(async () => {
-			await truncateAll();
+	test('compacted data are grouped by workflow correctly with pagination', async () => {
+		// ARRANGE
+		for (const workflow of [workflow1, workflow2, workflow3]) {
+			await createCompactedInsightsEvent(workflow, {
+				type: 'success',
+				value: workflow === workflow1 ? 1 : workflow === workflow2 ? 2 : 3,
+				periodUnit: 'day',
+				periodStart: DateTime.utc(),
+			});
+		}
 
-			project = await createTeamProject();
-			workflow1 = await createWorkflow({}, project);
-			workflow2 = await createWorkflow({}, project);
+		// ACT
+		const byWorkflow = await insightsService.getInsightsByWorkflow({
+			nbDays: 14,
+			sortBy: 'succeeded:desc',
+			skip: 1,
+			take: 1,
 		});
 
-		test('compacted data are are grouped by time correctly', async () => {
-			// ARRANGE
-			for (const workflow of [workflow1, workflow2]) {
-				await createCompactedInsightsEvent(workflow, {
-					type: 'success',
-					value: workflow === workflow1 ? 1 : 2,
-					periodUnit: 'day',
-					periodStart: DateTime.utc(),
-				});
-				await createCompactedInsightsEvent(workflow, {
-					type: 'failure',
-					value: 2,
-					periodUnit: 'day',
-					periodStart: DateTime.utc(),
-				});
-				await createCompactedInsightsEvent(workflow, {
-					type: 'success',
-					value: 1,
-					periodUnit: 'day',
-					periodStart: DateTime.utc().minus({ day: 2 }),
-				});
-				await createCompactedInsightsEvent(workflow, {
-					type: 'success',
-					value: 1,
-					periodUnit: 'day',
-					periodStart: DateTime.utc().minus({ days: 10 }),
-				});
-				await createCompactedInsightsEvent(workflow, {
-					type: 'runtime_ms',
-					value: workflow === workflow1 ? 10 : 20,
-					periodUnit: 'day',
-					periodStart: DateTime.utc().minus({ days: 10 }),
-				});
-			}
+		// ASSERT
+		expect(byWorkflow.count).toEqual(3);
+		expect(byWorkflow.data).toHaveLength(1);
+		expect(byWorkflow.data[0].workflowId).toEqual(workflow2.id);
+	});
 
-			// ACT
-			const byTime = await insightsService.getInsightsByTime(14);
+	test('compacted data are grouped by workflow correctly even with 0 data (check division by 0)', async () => {
+		// ACT
+		const byWorkflow = await insightsService.getInsightsByWorkflow({
+			nbDays: 14,
+		});
 
-			// ASSERT
-			expect(byTime).toHaveLength(3);
+		// ASSERT
+		expect(byWorkflow.count).toEqual(0);
+		expect(byWorkflow.data).toHaveLength(0);
+	});
+});
 
-			// expect date to be sorted by oldest first
-			expect(byTime[0].date).toEqual(DateTime.utc().minus({ days: 10 }).startOf('day').toISO());
-			expect(byTime[1].date).toEqual(DateTime.utc().minus({ days: 2 }).startOf('day').toISO());
-			expect(byTime[2].date).toEqual(DateTime.utc().startOf('day').toISO());
+describe('getInsightsByTime', () => {
+	let insightsService: InsightsService;
+	beforeAll(async () => {
+		insightsService = Container.get(InsightsService);
+	});
 
-			expect(byTime[0].values).toEqual({
-				total: 2,
-				succeeded: 2,
-				failed: 0,
-				failureRate: 0,
-				averageRunTime: 15,
-				timeSaved: 0,
+	let project: Project;
+	let workflow1: IWorkflowDb & WorkflowEntity;
+	let workflow2: IWorkflowDb & WorkflowEntity;
+
+	beforeEach(async () => {
+		await truncateAll();
+
+		project = await createTeamProject();
+		workflow1 = await createWorkflow({}, project);
+		workflow2 = await createWorkflow({}, project);
+	});
+
+	test('returns empty array when no insights exist', async () => {
+		const byTime = await insightsService.getInsightsByTime(14);
+		expect(byTime).toEqual([]);
+	});
+
+	test('returns empty array when no insights in the time range exists', async () => {
+		await createCompactedInsightsEvent(workflow1, {
+			type: 'success',
+			value: 2,
+			periodUnit: 'day',
+			periodStart: DateTime.utc().minus({ days: 30 }),
+		});
+
+		const byTime = await insightsService.getInsightsByTime(14);
+		expect(byTime).toEqual([]);
+	});
+
+	test('compacted data are are grouped by time correctly', async () => {
+		// ARRANGE
+		for (const workflow of [workflow1, workflow2]) {
+			await createCompactedInsightsEvent(workflow, {
+				type: 'success',
+				value: workflow === workflow1 ? 1 : 2,
+				periodUnit: 'day',
+				periodStart: DateTime.utc(),
 			});
-
-			expect(byTime[1].values).toEqual({
-				total: 2,
-				succeeded: 2,
-				failed: 0,
-				failureRate: 0,
-				averageRunTime: 0,
-				timeSaved: 0,
+			await createCompactedInsightsEvent(workflow, {
+				type: 'failure',
+				value: 2,
+				periodUnit: 'day',
+				periodStart: DateTime.utc(),
 			});
-
-			expect(byTime[2].values).toEqual({
-				total: 7,
-				succeeded: 3,
-				failed: 4,
-				failureRate: 4 / 7,
-				averageRunTime: 0,
-				timeSaved: 0,
+			await createCompactedInsightsEvent(workflow, {
+				type: 'success',
+				value: 1,
+				periodUnit: 'day',
+				periodStart: DateTime.utc().minus({ day: 2 }),
 			});
+			await createCompactedInsightsEvent(workflow, {
+				type: 'success',
+				value: 1,
+				periodUnit: 'day',
+				periodStart: DateTime.utc().minus({ days: 10 }),
+			});
+			await createCompactedInsightsEvent(workflow, {
+				type: 'runtime_ms',
+				value: workflow === workflow1 ? 10 : 20,
+				periodUnit: 'day',
+				periodStart: DateTime.utc().minus({ days: 10 }),
+			});
+		}
+
+		// ACT
+		const byTime = await insightsService.getInsightsByTime(14);
+
+		// ASSERT
+		expect(byTime).toHaveLength(3);
+
+		// expect date to be sorted by oldest first
+		expect(byTime[0].date).toEqual(DateTime.utc().minus({ days: 10 }).startOf('day').toISO());
+		expect(byTime[1].date).toEqual(DateTime.utc().minus({ days: 2 }).startOf('day').toISO());
+		expect(byTime[2].date).toEqual(DateTime.utc().startOf('day').toISO());
+
+		expect(byTime[0].values).toEqual({
+			total: 2,
+			succeeded: 2,
+			failed: 0,
+			failureRate: 0,
+			averageRunTime: 15,
+			timeSaved: 0,
+		});
+
+		expect(byTime[1].values).toEqual({
+			total: 2,
+			succeeded: 2,
+			failed: 0,
+			failureRate: 0,
+			averageRunTime: 0,
+			timeSaved: 0,
+		});
+
+		expect(byTime[2].values).toEqual({
+			total: 7,
+			succeeded: 3,
+			failed: 4,
+			failureRate: 4 / 7,
+			averageRunTime: 0,
+			timeSaved: 0,
 		});
 	});
 });

--- a/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
@@ -916,19 +916,20 @@ describe('getInsightsByWorkflow', () => {
 		expect(byWorkflow.data).toHaveLength(2);
 
 		// expect first workflow to be workflow 2, because it has a bigger total (default sorting)
-		expect(byWorkflow.data[0]).toEqual({
+		expect(byWorkflow.data[0]).toMatchObject({
 			workflowId: workflow2.id,
 			workflowName: workflow2.name,
 			projectId: project.id,
 			projectName: project.name,
 			total: 6,
-			failureRate: 2 / 6,
 			failed: 2,
 			runTime: 123,
 			succeeded: 4,
 			timeSaved: 0,
 			averageRunTime: 123 / 6,
 		});
+		// Expect rates to be close to js rate because db engines have different precision
+		expect(byWorkflow.data[0].failureRate).toBeCloseTo(2 / 6);
 
 		expect(byWorkflow.data[1]).toEqual({
 			workflowId: workflow1.id,

--- a/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
@@ -858,7 +858,6 @@ describe('getInsightsSummary', () => {
 		let project: Project;
 		let workflow1: IWorkflowDb & WorkflowEntity;
 		let workflow2: IWorkflowDb & WorkflowEntity;
-		let workflow3: IWorkflowDb & WorkflowEntity;
 
 		beforeEach(async () => {
 			await truncateAll();
@@ -866,7 +865,6 @@ describe('getInsightsSummary', () => {
 			project = await createTeamProject();
 			workflow1 = await createWorkflow({}, project);
 			workflow2 = await createWorkflow({}, project);
-			workflow3 = await createWorkflow({}, project);
 		});
 
 		test('compacted data are are grouped by workflow correctly', async () => {
@@ -954,7 +952,6 @@ describe('getInsightsSummary', () => {
 		let project: Project;
 		let workflow1: IWorkflowDb & WorkflowEntity;
 		let workflow2: IWorkflowDb & WorkflowEntity;
-		let workflow3: IWorkflowDb & WorkflowEntity;
 
 		beforeEach(async () => {
 			await truncateAll();
@@ -962,7 +959,6 @@ describe('getInsightsSummary', () => {
 			project = await createTeamProject();
 			workflow1 = await createWorkflow({}, project);
 			workflow2 = await createWorkflow({}, project);
-			workflow3 = await createWorkflow({}, project);
 		});
 
 		test('compacted data are are grouped by time correctly', async () => {

--- a/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
@@ -23,22 +23,19 @@ import {
 import { InsightsByPeriodRepository } from '../database/repositories/insights-by-period.repository';
 import { InsightsService } from '../insights.service';
 
-async function truncateAll() {
-	const insightsRawRepository = Container.get(InsightsRawRepository);
-	const insightsMetadataRepository = Container.get(InsightsMetadataRepository);
-	const insightsByPeriodRepository = Container.get(InsightsByPeriodRepository);
-	for (const repo of [
-		insightsRawRepository,
-		insightsMetadataRepository,
-		insightsByPeriodRepository,
-	]) {
-		await repo.delete({});
-	}
-}
-
 // Initialize DB once for all tests
 beforeAll(async () => {
-	await testDb.init();
+	await testDb.init(['insights']);
+});
+
+beforeEach(async () => {
+	await testDb.truncate([
+		'InsightsRaw',
+		'InsightsByPeriod',
+		'InsightsMetadata',
+		'Workflow',
+		'Project',
+	]);
 });
 
 // Terminate DB once after all tests complete
@@ -60,8 +57,6 @@ describe('workflowExecuteAfterHandler', () => {
 	let workflow: IWorkflowDb & WorkflowEntity;
 
 	beforeEach(async () => {
-		await truncateAll();
-
 		project = await createTeamProject();
 		workflow = await createWorkflow(
 			{
@@ -261,10 +256,6 @@ describe('workflowExecuteAfterHandler', () => {
 });
 
 describe('compaction', () => {
-	beforeEach(async () => {
-		await truncateAll();
-	});
-
 	describe('compactRawToHour', () => {
 		type TestData = {
 			name: string;
@@ -731,8 +722,6 @@ describe('getInsightsSummary', () => {
 	let workflow: IWorkflowDb & WorkflowEntity;
 
 	beforeEach(async () => {
-		await truncateAll();
-
 		project = await createTeamProject();
 		workflow = await createWorkflow({}, project);
 	});
@@ -861,8 +850,6 @@ describe('getInsightsByWorkflow', () => {
 	let workflow3: IWorkflowDb & WorkflowEntity;
 
 	beforeEach(async () => {
-		await truncateAll();
-
 		project = await createTeamProject();
 		workflow1 = await createWorkflow({}, project);
 		workflow2 = await createWorkflow({}, project);
@@ -1045,8 +1032,6 @@ describe('getInsightsByTime', () => {
 	let workflow2: IWorkflowDb & WorkflowEntity;
 
 	beforeEach(async () => {
-		await truncateAll();
-
 		project = await createTeamProject();
 		workflow1 = await createWorkflow({}, project);
 		workflow2 = await createWorkflow({}, project);

--- a/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
@@ -892,7 +892,7 @@ describe('getInsightsByWorkflow', () => {
 			});
 
 			// Barely in range insight (should be included)
-			// 14 days ago start of the day
+			// 1 hour before 14 days ago
 			await createCompactedInsightsEvent(workflow, {
 				type: 'success',
 				value: 1,
@@ -901,7 +901,7 @@ describe('getInsightsByWorkflow', () => {
 			});
 
 			// Out of date range insight (should not be included)
-			// 14 days and 1 minute ago
+			// 14 days ago
 			await createCompactedInsightsEvent(workflow, {
 				type: 'success',
 				value: 1,
@@ -1090,7 +1090,7 @@ describe('getInsightsByTime', () => {
 			});
 
 			// Barely in range insight (should be included)
-			// 14 days ago start of the day
+			// 1 hour before 14 days ago
 			await createCompactedInsightsEvent(workflow, {
 				type: workflow === workflow1 ? 'success' : 'failure',
 				value: 1,
@@ -1099,7 +1099,7 @@ describe('getInsightsByTime', () => {
 			});
 
 			// Out of date range insight (should not be included)
-			// 14 days ago start of the day and minus 1 minute
+			// 14 days ago
 			await createCompactedInsightsEvent(workflow, {
 				type: 'success',
 				value: 1,

--- a/packages/cli/src/modules/insights/database/entities/insights-by-period.ts
+++ b/packages/cli/src/modules/insights/database/entities/insights-by-period.ts
@@ -1,6 +1,14 @@
-import { BaseEntity, Column, Entity, PrimaryGeneratedColumn } from '@n8n/typeorm';
+import {
+	BaseEntity,
+	Column,
+	Entity,
+	JoinColumn,
+	OneToOne,
+	PrimaryGeneratedColumn,
+} from '@n8n/typeorm';
 import { UnexpectedError } from 'n8n-workflow';
 
+import { InsightsMetadata } from './insights-metadata';
 import type { PeriodUnit } from './insights-shared';
 import {
 	isValidPeriodNumber,
@@ -19,6 +27,10 @@ export class InsightsByPeriod extends BaseEntity {
 
 	@Column()
 	metaId: number;
+
+	@OneToOne(() => InsightsMetadata)
+	@JoinColumn({ name: 'metaId' })
+	metadata: InsightsMetadata;
 
 	@Column({ name: 'type', type: 'int' })
 	private type_: number;

--- a/packages/cli/src/modules/insights/database/entities/insights-by-period.ts
+++ b/packages/cli/src/modules/insights/database/entities/insights-by-period.ts
@@ -3,7 +3,7 @@ import {
 	Column,
 	Entity,
 	JoinColumn,
-	OneToOne,
+	ManyToOne,
 	PrimaryGeneratedColumn,
 } from '@n8n/typeorm';
 import { UnexpectedError } from 'n8n-workflow';
@@ -28,7 +28,7 @@ export class InsightsByPeriod extends BaseEntity {
 	@Column()
 	metaId: number;
 
-	@OneToOne(() => InsightsMetadata)
+	@ManyToOne(() => InsightsMetadata)
 	@JoinColumn({ name: 'metaId' })
 	metadata: InsightsMetadata;
 

--- a/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
+++ b/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
@@ -52,7 +52,7 @@ const aggregatedInsightsByWorkflowParser = z
 
 const aggregatedInsightsByTimeParser = z
 	.object({
-		periodStart: z.string(),
+		periodStart: z.union([z.date(), z.string()]),
 		runTime: z.union([z.number(), z.string()]),
 		succeeded: z.union([z.number(), z.string()]),
 		failed: z.union([z.number(), z.string()]),
@@ -361,9 +361,7 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 		return { count, rows: aggregatedInsightsByWorkflowParser.parse(rawRows) };
 	}
 
-	// TODO: add return type once rebased on master and InsightsByTimeAndType is
-	// available
-	// TODO: add tests
+	// TODO: add more tests
 	async getInsightsByTime(nbDays: number) {
 		const dateSubQuery =
 			dbType === 'sqlite'

--- a/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
+++ b/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
 import { sql } from '@/utils/sql';
 
 import { InsightsByPeriod } from '../entities/insights-by-period';
-import type { PeriodUnit, TypeUnit } from '../entities/insights-shared';
+import type { PeriodUnit } from '../entities/insights-shared';
 import { PeriodUnitToNumber, TypeToNumber } from '../entities/insights-shared';
 
 const dbType = Container.get(GlobalConfig).database.type;
@@ -353,7 +353,7 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 	// TODO: add return type once rebased on master and InsightsByTimeAndType is
 	// available
 	// TODO: add tests
-	async getInsightsByTime(nbDays: number, types: TypeUnit[]) {
+	async getInsightsByTime(nbDays: number) {
 		const dateSubQuery =
 			dbType === 'sqlite'
 				? `datetime('now', '-${nbDays} days')`
@@ -370,7 +370,6 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 				`SUM(CASE WHEN insights.type = ${TypeToNumber.time_saved_min} THEN value ELSE 0 END) AS "timeSaved"`,
 			])
 			.where(`insights.periodStart >= ${dateSubQuery}`)
-			.andWhere('insights.type IN (:...types)', { types: types.map((t) => TypeToNumber[t]) })
 			.addGroupBy('insights.periodStart') // TODO: group by specific time scale (start with day)
 			.orderBy('insights.periodStart', 'ASC')
 			.getRawMany();

--- a/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
+++ b/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
@@ -363,7 +363,7 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 					? `CURRENT_DATE - INTERVAL '${nbDays} days'`
 					: `DATE_SUB(CURDATE(), INTERVAL ${nbDays} DAY)`;
 
-		const rawRows = await this.createQueryBuilder('insights')
+		const rawRowsQuery = this.createQueryBuilder('insights')
 			.select([
 				'insights.periodStart AS "periodStart"',
 				`SUM(CASE WHEN insights.type = ${TypeToNumber.runtime_ms} THEN value ELSE 0 END) AS "runTime"`,
@@ -373,8 +373,9 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 			])
 			.where(`insights.periodStart >= ${dateSubQuery}`)
 			.addGroupBy('insights.periodStart') // TODO: group by specific time scale (start with day)
-			.orderBy('insights.periodStart', 'ASC')
-			.getRawMany();
+			.orderBy('insights.periodStart', 'ASC');
+
+		const rawRows = await rawRowsQuery.getRawMany();
 
 		return aggregatedInsightsByTimeParser.parse(rawRows);
 	}

--- a/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
+++ b/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
@@ -309,8 +309,8 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 			dbType === 'sqlite'
 				? `datetime('now', '-${nbDays} days')`
 				: dbType === 'postgresdb'
-					? `CURRENT_DATE - INTERVAL '${nbDays} days'`
-					: `DATE_SUB(CURDATE(), INTERVAL ${nbDays} DAY)`;
+					? `NOW() - INTERVAL '${nbDays} days'`
+					: `DATE_SUB(NOW(), INTERVAL ${nbDays} DAY)`;
 
 		const [sortField, sortOrder] = this.parseSortingParams(sortBy);
 		const sumOfExecutions = sql`SUM(CASE WHEN insights.type IN (${TypeToNumber.success.toString()}, ${TypeToNumber.failure.toString()}) THEN value ELSE 0 END)`;

--- a/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
+++ b/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
@@ -341,7 +341,7 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 			.addGroupBy('metadata.workflowName')
 			.addGroupBy('metadata.projectId')
 			.addGroupBy('metadata.projectName')
-			.orderBy(`"${sortField}"`, sortOrder);
+			.orderBy(this.escapeField(sortField), sortOrder);
 
 		const count = (await rawRowsQuery.getRawMany()).length;
 		const rawRows = await rawRowsQuery.offset(skip).limit(take).getRawMany();
@@ -349,7 +349,6 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 		return { count, rows: aggregatedInsightsByWorkflowParser.parse(rawRows) };
 	}
 
-	// TODO: add more tests
 	async getInsightsByTime(nbDays: number) {
 		const dateSubQuery =
 			dbType === 'sqlite'

--- a/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
+++ b/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
@@ -12,18 +12,6 @@ import { PeriodUnitToNumber, TypeToNumber } from '../entities/insights-shared';
 
 const dbType = Container.get(GlobalConfig).database.type;
 
-export const insightsByWorkflowSortingFields = [
-	'total',
-	'succeeded',
-	'failed',
-	'timeSaved',
-	'runTime',
-	'averageRunTime',
-];
-
-export type InsightByWorkflowSortBy =
-	`${(typeof insightsByWorkflowSortingFields)[number]}:${'asc' | 'desc'}`;
-
 const summaryParser = z
 	.object({
 		period: z.enum(['previous', 'current']),
@@ -315,7 +303,7 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 		nbDays: number;
 		skip?: number;
 		take?: number;
-		sortBy?: InsightByWorkflowSortBy;
+		sortBy?: string;
 	}) {
 		const dateSubQuery =
 			dbType === 'sqlite'

--- a/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
+++ b/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
@@ -313,7 +313,7 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 					: `DATE_SUB(CURDATE(), INTERVAL ${nbDays} DAY)`;
 
 		const [sortField, sortOrder] = this.parseSortingParams(sortBy);
-		const sumOfExecutions = sql`CAST(SUM(CASE WHEN insights.type IN (${TypeToNumber.success.toString()}, ${TypeToNumber.failure.toString()}) THEN value ELSE 0 END) as FLOAT)`;
+		const sumOfExecutions = sql`SUM(CASE WHEN insights.type IN (${TypeToNumber.success.toString()}, ${TypeToNumber.failure.toString()}) THEN value ELSE 0 END)`;
 
 		const rawRowsQuery = this.createQueryBuilder('insights')
 			.select([
@@ -326,13 +326,13 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 				`SUM(CASE WHEN insights.type IN (${TypeToNumber.success}, ${TypeToNumber.failure}) THEN value ELSE 0 END) AS "total"`,
 				sql`CASE
 								WHEN ${sumOfExecutions} = 0 THEN 0
-								ELSE SUM(CASE WHEN insights.type = ${TypeToNumber.failure.toString()} THEN value ELSE 0 END) / ${sumOfExecutions}
+								ELSE 1.0 * SUM(CASE WHEN insights.type = ${TypeToNumber.failure.toString()} THEN value ELSE 0 END) / ${sumOfExecutions}
 							END AS "failureRate"`,
 				`SUM(CASE WHEN insights.type = ${TypeToNumber.runtime_ms} THEN value ELSE 0 END) AS "runTime"`,
 				`SUM(CASE WHEN insights.type = ${TypeToNumber.time_saved_min} THEN value ELSE 0 END) AS "timeSaved"`,
 				sql`CASE
 								WHEN ${sumOfExecutions} = 0	THEN 0
-								ELSE SUM(CASE WHEN insights.type = ${TypeToNumber.runtime_ms.toString()} THEN value ELSE 0 END) / ${sumOfExecutions}
+								ELSE 1.0 * SUM(CASE WHEN insights.type = ${TypeToNumber.runtime_ms.toString()} THEN value ELSE 0 END) / ${sumOfExecutions}
 							END AS "averageRunTime"`,
 			])
 			.innerJoin('insights.metadata', 'metadata')

--- a/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
+++ b/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
@@ -362,7 +362,7 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 	}: { maxAgeInDays: number; periodUnit: PeriodUnit }) {
 		const dateSubQuery =
 			dbType === 'sqlite'
-				? `datetime('now', '-${maxAgeInDays} days')`
+				? `date('now', '-${maxAgeInDays} days')`
 				: dbType === 'postgresdb'
 					? `CURRENT_DATE - INTERVAL '${maxAgeInDays} days'`
 					: `DATE_SUB(CURDATE(), INTERVAL ${maxAgeInDays} DAY)`;

--- a/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
+++ b/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
@@ -12,8 +12,17 @@ import { PeriodUnitToNumber, TypeToNumber } from '../entities/insights-shared';
 
 const dbType = Container.get(GlobalConfig).database.type;
 
+export const insightsByWorkflowSortingFields = [
+	'total',
+	'succeeded',
+	'failed',
+	'timeSaved',
+	'runTime',
+	'averageRunTime',
+];
+
 export type InsightByWorkflowSortBy =
-	`${'total' | 'succeeded' | 'failed' | 'timeSaved' | 'runTime' | 'averageRunTime'}:${'asc' | 'desc'}`;
+	`${(typeof insightsByWorkflowSortingFields)[number]}:${'asc' | 'desc'}`;
 
 const summaryParser = z
 	.object({

--- a/packages/cli/src/modules/insights/insights.controller.ts
+++ b/packages/cli/src/modules/insights/insights.controller.ts
@@ -1,17 +1,16 @@
 import type { InsightsSummary } from '@n8n/api-types';
+import { ListInsightsWorkflowQueryDto } from '@n8n/api-types';
 import type {
 	InsightsByTime,
 	InsightsByWorkflow,
 } from '@n8n/api-types/src/schemas/insights.schema';
 
-import { Get, GlobalScope, RestController } from '@/decorators';
+import { Get, GlobalScope, Query, RestController } from '@/decorators';
 import { paginationListQueryMiddleware } from '@/middlewares/list-query/pagination';
 import { sortByQueryMiddleware } from '@/middlewares/list-query/sort-by';
-import { ListQuery } from '@/requests';
+import { AuthenticatedRequest } from '@/requests';
 
 import { InsightsService } from './insights.service';
-import type { InsightByWorkflowSortBy } from './repositories/insights-by-period.repository';
-import { insightsByWorkflowSortingFields } from './repositories/insights-by-period.repository';
 
 @RestController('/insights')
 export class InsightsController {
@@ -26,23 +25,16 @@ export class InsightsController {
 	// TODO: api test for this
 	@Get('/by-workflow', { middlewares: [paginationListQueryMiddleware, sortByQueryMiddleware] })
 	@GlobalScope('insights:list')
-	async getInsightsByWorkflow(req: ListQuery.Options): Promise<InsightsByWorkflow> {
-		let sortBy: InsightByWorkflowSortBy = 'total:asc'; // Provide a default value
-		if (req.sortBy) {
-			const sortByInfo = req.sortBy.split(':');
-			if (
-				insightsByWorkflowSortingFields.includes(sortByInfo[0]) &&
-				['asc', 'desc'].includes(sortByInfo[1])
-			) {
-				sortBy = req.sortBy as InsightByWorkflowSortBy;
-			}
-		}
-
+	async getInsightsByWorkflow(
+		_req: AuthenticatedRequest,
+		_res: Response,
+		@Query payload: ListInsightsWorkflowQueryDto,
+	): Promise<InsightsByWorkflow> {
 		return await this.insightsService.getInsightsByWorkflow({
 			nbDays: 14, // TODO: extract into proper constant
-			skip: req.skip,
-			take: req.take,
-			sortBy,
+			skip: payload.skip,
+			take: payload.take,
+			sortBy: payload.sortBy,
 		});
 	}
 

--- a/packages/cli/src/modules/insights/insights.controller.ts
+++ b/packages/cli/src/modules/insights/insights.controller.ts
@@ -1,4 +1,8 @@
 import type { InsightsSummary } from '@n8n/api-types';
+import type {
+	InsightsByTime,
+	InsightsByWorkflow,
+} from '@n8n/api-types/src/schemas/insights.schema';
 
 import { Get, GlobalScope, RestController } from '@/decorators';
 import { paginationListQueryMiddleware } from '@/middlewares/list-query/pagination';
@@ -20,7 +24,8 @@ export class InsightsController {
 	// TODO: api test for this
 	// TODO: use proper response type once defined
 	@Get('/by-workflow', { middlewares: [paginationListQueryMiddleware, sortByQueryMiddleware] })
-	async getInsightsByWorkflow(req: ListQuery.Options) {
+	@GlobalScope('insights:list')
+	async getInsightsByWorkflow(req: ListQuery.Options): Promise<InsightsByWorkflow> {
 		return await this.insightsService.getInsightsByWorkflow({
 			nbDays: 14, // TODO: extract into proper constant
 			skip: req.skip,
@@ -32,7 +37,8 @@ export class InsightsController {
 	// TODO: api test for this
 	// TODO: use proper response type once defined
 	@Get('/by-time', { middlewares: [paginationListQueryMiddleware, sortByQueryMiddleware] })
-	async getInsightsByTime() {
+	@GlobalScope('insights:list')
+	async getInsightsByTime(): Promise<InsightsByTime[]> {
 		return await this.insightsService.getInsightsByTime(14);
 	}
 }

--- a/packages/cli/src/modules/insights/insights.controller.ts
+++ b/packages/cli/src/modules/insights/insights.controller.ts
@@ -22,7 +22,6 @@ export class InsightsController {
 	}
 
 	// TODO: api test for this
-	// TODO: use proper response type once defined
 	@Get('/by-workflow', { middlewares: [paginationListQueryMiddleware, sortByQueryMiddleware] })
 	@GlobalScope('insights:list')
 	async getInsightsByWorkflow(req: ListQuery.Options): Promise<InsightsByWorkflow> {
@@ -35,7 +34,6 @@ export class InsightsController {
 	}
 
 	// TODO: api test for this
-	// TODO: use proper response type once defined
 	@Get('/by-time', { middlewares: [paginationListQueryMiddleware, sortByQueryMiddleware] })
 	@GlobalScope('insights:list')
 	async getInsightsByTime(): Promise<InsightsByTime[]> {

--- a/packages/cli/src/modules/insights/insights.controller.ts
+++ b/packages/cli/src/modules/insights/insights.controller.ts
@@ -1,6 +1,9 @@
 import type { InsightsSummary } from '@n8n/api-types';
 
 import { Get, GlobalScope, RestController } from '@/decorators';
+import { paginationListQueryMiddleware } from '@/middlewares/list-query/pagination';
+import { sortByQueryMiddleware } from '@/middlewares/list-query/sort-by';
+import { ListQuery } from '@/requests';
 
 import { InsightsService } from './insights.service';
 
@@ -12,5 +15,21 @@ export class InsightsController {
 	@GlobalScope('insights:list')
 	async getInsightsSummary(): Promise<InsightsSummary> {
 		return await this.insightsService.getInsightsSummary();
+	}
+
+	// TODO: api test for this
+	// TODO: use proper response type once defined
+	@Get('/by-workflow', { middlewares: [paginationListQueryMiddleware, sortByQueryMiddleware] })
+	async getInsightsByWorkflow(req: ListQuery.Options): Promise<{
+		count: number;
+		data: any[];
+	}> {
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+		return await this.insightsService.getInsightsByWorkflow({
+			nbDays: 14, // TODO: extract into proper constant
+			skip: req.skip,
+			take: req.take,
+			sortBy: req.sortBy,
+		});
 	}
 }

--- a/packages/cli/src/modules/insights/insights.controller.ts
+++ b/packages/cli/src/modules/insights/insights.controller.ts
@@ -20,16 +20,19 @@ export class InsightsController {
 	// TODO: api test for this
 	// TODO: use proper response type once defined
 	@Get('/by-workflow', { middlewares: [paginationListQueryMiddleware, sortByQueryMiddleware] })
-	async getInsightsByWorkflow(req: ListQuery.Options): Promise<{
-		count: number;
-		data: any[];
-	}> {
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+	async getInsightsByWorkflow(req: ListQuery.Options) {
 		return await this.insightsService.getInsightsByWorkflow({
 			nbDays: 14, // TODO: extract into proper constant
 			skip: req.skip,
 			take: req.take,
 			sortBy: req.sortBy,
 		});
+	}
+
+	// TODO: api test for this
+	// TODO: use proper response type once defined
+	@Get('/by-time', { middlewares: [paginationListQueryMiddleware, sortByQueryMiddleware] })
+	async getInsightsByTime() {
+		return await this.insightsService.getInsightsByTime(14);
 	}
 }

--- a/packages/cli/src/modules/insights/insights.controller.ts
+++ b/packages/cli/src/modules/insights/insights.controller.ts
@@ -14,6 +14,8 @@ import { InsightsService } from './insights.service';
 
 @RestController('/insights')
 export class InsightsController {
+	private readonly nbDaysFilteredInsights = 14;
+
 	constructor(private readonly insightsService: InsightsService) {}
 
 	@Get('/summary')
@@ -22,7 +24,6 @@ export class InsightsController {
 		return await this.insightsService.getInsightsSummary();
 	}
 
-	// TODO: api test for this
 	@Get('/by-workflow', { middlewares: [paginationListQueryMiddleware, sortByQueryMiddleware] })
 	@GlobalScope('insights:list')
 	async getInsightsByWorkflow(
@@ -31,7 +32,7 @@ export class InsightsController {
 		@Query payload: ListInsightsWorkflowQueryDto,
 	): Promise<InsightsByWorkflow> {
 		return await this.insightsService.getInsightsByWorkflow({
-			nbDays: 14, // TODO: extract into proper constant
+			nbDays: this.nbDaysFilteredInsights,
 			skip: payload.skip,
 			take: payload.take,
 			sortBy: payload.sortBy,
@@ -41,6 +42,6 @@ export class InsightsController {
 	@Get('/by-time')
 	@GlobalScope('insights:list')
 	async getInsightsByTime(): Promise<InsightsByTime[]> {
-		return await this.insightsService.getInsightsByTime(14);
+		return await this.insightsService.getInsightsByTime(this.nbDaysFilteredInsights);
 	}
 }

--- a/packages/cli/src/modules/insights/insights.controller.ts
+++ b/packages/cli/src/modules/insights/insights.controller.ts
@@ -1,9 +1,5 @@
-import type { InsightsSummary } from '@n8n/api-types';
 import { ListInsightsWorkflowQueryDto } from '@n8n/api-types';
-import type {
-	InsightsByTime,
-	InsightsByWorkflow,
-} from '@n8n/api-types/src/schemas/insights.schema';
+import type { InsightsSummary, InsightsByTime, InsightsByWorkflow } from '@n8n/api-types';
 
 import { Get, GlobalScope, Query, RestController } from '@/decorators';
 import { paginationListQueryMiddleware } from '@/middlewares/list-query/pagination';

--- a/packages/cli/src/modules/insights/insights.controller.ts
+++ b/packages/cli/src/modules/insights/insights.controller.ts
@@ -10,7 +10,7 @@ import { InsightsService } from './insights.service';
 
 @RestController('/insights')
 export class InsightsController {
-	private readonly nbDaysFilteredInsights = 14;
+	private readonly maxAgeInDaysFilteredInsights = 14;
 
 	constructor(private readonly insightsService: InsightsService) {}
 
@@ -28,7 +28,7 @@ export class InsightsController {
 		@Query payload: ListInsightsWorkflowQueryDto,
 	): Promise<InsightsByWorkflow> {
 		return await this.insightsService.getInsightsByWorkflow({
-			nbDays: this.nbDaysFilteredInsights,
+			maxAgeInDays: this.maxAgeInDaysFilteredInsights,
 			skip: payload.skip,
 			take: payload.take,
 			sortBy: payload.sortBy,
@@ -38,6 +38,6 @@ export class InsightsController {
 	@Get('/by-time')
 	@GlobalScope('insights:list')
 	async getInsightsByTime(): Promise<InsightsByTime[]> {
-		return await this.insightsService.getInsightsByTime(this.nbDaysFilteredInsights);
+		return await this.insightsService.getInsightsByTime(this.maxAgeInDaysFilteredInsights);
 	}
 }

--- a/packages/cli/src/modules/insights/insights.controller.ts
+++ b/packages/cli/src/modules/insights/insights.controller.ts
@@ -38,6 +38,9 @@ export class InsightsController {
 	@Get('/by-time')
 	@GlobalScope('insights:list')
 	async getInsightsByTime(): Promise<InsightsByTime[]> {
-		return await this.insightsService.getInsightsByTime(this.maxAgeInDaysFilteredInsights);
+		return await this.insightsService.getInsightsByTime({
+			maxAgeInDays: this.maxAgeInDaysFilteredInsights,
+			periodUnit: 'day',
+		});
 	}
 }

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -320,21 +320,19 @@ export class InsightsService {
 			sortBy,
 		});
 
-		const data = rows.map((r) => {
-			return {
-				workflowId: r.workflowId,
-				workflowName: r.workflowName,
-				projectId: r.projectId,
-				projectName: r.projectName,
-				total: Number(r.total),
-				failed: Number(r.failed),
-				succeeded: Number(r.succeeded),
-				failureRate: Number(r.failureRate),
-				runTime: Number(r.runTime),
-				averageRunTime: Number(r.averageRunTime),
-				timeSaved: Number(r.timeSaved),
-			};
-		});
+		const data = rows.map((r) => ({
+			workflowId: r.workflowId,
+			workflowName: r.workflowName,
+			projectId: r.projectId,
+			projectName: r.projectName,
+			total: Number(r.total),
+			failed: Number(r.failed),
+			succeeded: Number(r.succeeded),
+			failureRate: Number(r.failureRate),
+			runTime: Number(r.runTime),
+			averageRunTime: Number(r.averageRunTime),
+			timeSaved: Number(r.timeSaved),
+		}));
 
 		return {
 			count,

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -14,7 +14,7 @@ import { OnShutdown } from '@/decorators/on-shutdown';
 import { InsightsMetadata } from '@/modules/insights/database/entities/insights-metadata';
 import { InsightsRaw } from '@/modules/insights/database/entities/insights-raw';
 
-import type { TypeUnit } from './database/entities/insights-shared';
+import type { PeriodUnit, TypeUnit } from './database/entities/insights-shared';
 import { NumberToType } from './database/entities/insights-shared';
 import { InsightsByPeriodRepository } from './database/repositories/insights-by-period.repository';
 import { InsightsRawRepository } from './database/repositories/insights-raw.repository';
@@ -325,8 +325,14 @@ export class InsightsService {
 		};
 	}
 
-	async getInsightsByTime(nbDays: number) {
-		const rows = await this.insightsByPeriodRepository.getInsightsByTime(nbDays);
+	async getInsightsByTime({
+		maxAgeInDays,
+		periodUnit,
+	}: { maxAgeInDays: number; periodUnit: PeriodUnit }) {
+		const rows = await this.insightsByPeriodRepository.getInsightsByTime({
+			maxAgeInDays,
+			periodUnit,
+		});
 
 		return rows.map((r) => {
 			const total = r.succeeded + r.failed;

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -1,5 +1,6 @@
 import type { InsightsSummary } from '@n8n/api-types';
 import { Container, Service } from '@n8n/di';
+import { DateTime } from 'luxon';
 import type { ExecutionLifecycleHooks } from 'n8n-core';
 import {
 	UnexpectedError,
@@ -346,7 +347,7 @@ export class InsightsService {
 
 		return rows.map((r) => {
 			return {
-				date: r.periodStart,
+				date: DateTime.fromSQL(r.periodStart, { zone: 'utc' }).toISO(),
 				values: {
 					total: Number(r.succeeded) + Number(r.failed),
 					succeeded: Number(r.succeeded),

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -311,7 +311,7 @@ export class InsightsService {
 		nbDays: number;
 		skip?: number;
 		take?: number;
-		sortBy?: InsightByWorkflowSortBy;
+		sortBy?: string;
 	}) {
 		const { count, rows } = await this.insightsByPeriodRepository.getInsightsByWorkflow({
 			nbDays,

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -310,7 +310,7 @@ export class InsightsService {
 		nbDays: number;
 		skip?: number;
 		take?: number;
-		sortBy?: string;
+		sortBy?: InsightByWorkflowSortBy;
 	}) {
 		const { count, rows } = await this.insightsByPeriodRepository.getInsightsByWorkflow({
 			nbDays,

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -346,14 +346,18 @@ export class InsightsService {
 		const rows = await this.insightsByPeriodRepository.getInsightsByTime(nbDays);
 
 		return rows.map((r) => {
+			const total = Number(r.succeeded) + Number(r.failed);
 			return {
-				date: DateTime.fromSQL(r.periodStart, { zone: 'utc' }).toISO(),
+				date:
+					r.periodStart instanceof Date
+						? r.periodStart.toISOString()
+						: DateTime.fromSQL(r.periodStart.toString(), { zone: 'utc' }).toISO(),
 				values: {
-					total: Number(r.succeeded) + Number(r.failed),
+					total,
 					succeeded: Number(r.succeeded),
 					failed: Number(r.failed),
-					failureRate: Number(r.failed) / (Number(r.succeeded) + Number(r.failed)),
-					averageRunTime: Number(r.runTime) / (Number(r.succeeded) + Number(r.failed)),
+					failureRate: Number(r.failed) / total,
+					averageRunTime: Number(r.runTime) / total,
 					timeSaved: Number(r.timeSaved),
 				},
 			};

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -301,8 +301,6 @@ export class InsightsService {
 		return result;
 	}
 
-	// TODO: add return type once rebased on master and InsightsByWorkflow is
-	// available
 	async getInsightsByWorkflow({
 		nbDays,
 		skip = 0,
@@ -313,7 +311,7 @@ export class InsightsService {
 		skip?: number;
 		take?: number;
 		sortBy?: string;
-	}): Promise<{ count: number; data: any[] }> {
+	}) {
 		const { count, rows } = await this.insightsByPeriodRepository.getInsightsByWorkflow({
 			nbDays,
 			skip,
@@ -343,11 +341,8 @@ export class InsightsService {
 		};
 	}
 
-	// TODO: add return type once rebased on master and InsightsByTimeAndType is
-	// available
-	// TODO: add tests
-	async getInsightsByTime(nbDays: number, types: TypeUnit[]) {
-		const rows = await this.insightsByPeriodRepository.getInsightsByTime(nbDays, types);
+	async getInsightsByTime(nbDays: number) {
+		const rows = await this.insightsByPeriodRepository.getInsightsByTime(nbDays);
 
 		return rows.map((r) => {
 			return {

--- a/packages/cli/test/integration/insights/insights.api.test.ts
+++ b/packages/cli/test/integration/insights/insights.api.test.ts
@@ -1,0 +1,46 @@
+import { Container } from '@n8n/di';
+
+import type { User } from '@/databases/entities/user';
+import { InsightsService } from '@/modules/insights/insights.service';
+import { Telemetry } from '@/telemetry';
+import { mockInstance } from '@test/mocking';
+
+import { createUser } from '../shared/db/users';
+import type { SuperAgentTest } from '../shared/types';
+import * as utils from '../shared/utils';
+
+let authOwnerAgent: SuperAgentTest;
+let authMemberAgent: SuperAgentTest;
+let owner: User;
+let member: User;
+mockInstance(Telemetry);
+
+const testServer = utils.setupTestServer({
+	endpointGroups: ['insights', 'license', 'auth'],
+	enabledFeatures: [],
+});
+
+let insightsService: InsightsService;
+
+beforeAll(async () => {
+	owner = await createUser({ role: 'global:owner' });
+	member = await createUser({ role: 'global:member' });
+	authOwnerAgent = testServer.authAgentFor(owner);
+	authMemberAgent = testServer.authAgentFor(member);
+
+	insightsService = Container.get(InsightsService);
+});
+
+describe('GET /insights/summary', () => {
+	test('Call should work and return empty summary for owner user', async () => {
+		await authOwnerAgent.get('/insights/summary').expect(200);
+		await authOwnerAgent.get('/insights/by-time').expect(200);
+		await authOwnerAgent.get('/insights/by-workflow').expect(200);
+	});
+
+	test('Call should return forbidden and return empty summary for member user', async () => {
+		await authMemberAgent.get('/insights/summary').expect(403);
+		await authMemberAgent.get('/insights/by-time').expect(403);
+		await authMemberAgent.get('/insights/by-workflow').expect(403);
+	});
+});

--- a/packages/cli/test/integration/insights/insights.api.test.ts
+++ b/packages/cli/test/integration/insights/insights.api.test.ts
@@ -7,10 +7,12 @@ import type { SuperAgentTest } from '../shared/types';
 import * as utils from '../shared/utils';
 
 let authOwnerAgent: SuperAgentTest;
-let authMemberAgent: SuperAgentTest;
 let owner: User;
+let admin: User;
 let member: User;
 mockInstance(Telemetry);
+
+let agents: Record<string, SuperAgentTest> = {};
 
 const testServer = utils.setupTestServer({
 	endpointGroups: ['insights', 'license', 'auth'],
@@ -19,21 +21,58 @@ const testServer = utils.setupTestServer({
 
 beforeAll(async () => {
 	owner = await createUser({ role: 'global:owner' });
+	admin = await createUser({ role: 'global:admin' });
 	member = await createUser({ role: 'global:member' });
 	authOwnerAgent = testServer.authAgentFor(owner);
-	authMemberAgent = testServer.authAgentFor(member);
+	agents.owner = authOwnerAgent;
+	agents.admin = testServer.authAgentFor(admin);
+	agents.member = testServer.authAgentFor(member);
 });
 
-describe('GET /insights/summary', () => {
-	test('Call should work and return empty summary for owner user', async () => {
-		await authOwnerAgent.get('/insights/summary').expect(200);
-		await authOwnerAgent.get('/insights/by-time').expect(200);
-		await authOwnerAgent.get('/insights/by-workflow').expect(200);
+describe('GET /insights routes work for owner and admins', () => {
+	test.each(['owner', 'member', 'admin'])(
+		'Call should work and return empty summary for user %s',
+		async (agentName: string) => {
+			const authAgent = agents[agentName];
+			await authAgent.get('/insights/summary').expect(agentName === 'member' ? 403 : 200);
+			await authAgent.get('/insights/by-time').expect(agentName === 'member' ? 403 : 200);
+			await authAgent.get('/insights/by-workflow').expect(agentName === 'member' ? 403 : 200);
+		},
+	);
+});
+
+describe('GET /insights/by-worklow', () => {
+	test('Call should work with valid query parameters', async () => {
+		await authOwnerAgent
+			.get('/insights/by-workflow')
+			.query({ skip: '10', take: '20', sortBy: 'total:desc' })
+			.expect(200);
 	});
 
-	test('Call should return forbidden and return empty summary for member user', async () => {
-		await authMemberAgent.get('/insights/summary').expect(403);
-		await authMemberAgent.get('/insights/by-time').expect(403);
-		await authMemberAgent.get('/insights/by-workflow').expect(403);
+	test.each<{ skip: string; take?: string; sortBy?: string }>([
+		{
+			skip: 'not_a_number',
+			take: '20',
+		},
+		{
+			skip: '1',
+			take: 'not_a_number',
+		},
+	])(
+		'Call should return internal server error with invalid pagination query parameters',
+		async (queryParams) => {
+			await authOwnerAgent.get('/insights/by-workflow').query(queryParams).expect(500);
+		},
+	);
+
+	test('Call should return bad request with invalid sortby query parameters', async () => {
+		await authOwnerAgent
+			.get('/insights/by-workflow')
+			.query({
+				skip: '1',
+				take: '20',
+				sortBy: 'not_a_sortby',
+			})
+			.expect(400);
 	});
 });

--- a/packages/cli/test/integration/insights/insights.api.test.ts
+++ b/packages/cli/test/integration/insights/insights.api.test.ts
@@ -1,7 +1,4 @@
-import { Container } from '@n8n/di';
-
 import type { User } from '@/databases/entities/user';
-import { InsightsService } from '@/modules/insights/insights.service';
 import { Telemetry } from '@/telemetry';
 import { mockInstance } from '@test/mocking';
 
@@ -20,15 +17,11 @@ const testServer = utils.setupTestServer({
 	enabledFeatures: [],
 });
 
-let insightsService: InsightsService;
-
 beforeAll(async () => {
 	owner = await createUser({ role: 'global:owner' });
 	member = await createUser({ role: 'global:member' });
 	authOwnerAgent = testServer.authAgentFor(owner);
 	authMemberAgent = testServer.authAgentFor(member);
-
-	insightsService = Container.get(InsightsService);
 });
 
 describe('GET /insights/summary', () => {

--- a/packages/cli/test/integration/shared/types.ts
+++ b/packages/cli/test/integration/shared/types.ts
@@ -44,7 +44,8 @@ type EndpointGroup =
 	| 'apiKeys'
 	| 'evaluation'
 	| 'ai'
-	| 'folder';
+	| 'folder'
+	| 'insights';
 
 export interface SetupProps {
 	endpointGroups?: EndpointGroup[];

--- a/packages/cli/test/integration/shared/utils/test-server.ts
+++ b/packages/cli/test/integration/shared/utils/test-server.ts
@@ -290,6 +290,9 @@ export const setupTestServer = ({
 
 					case 'folder':
 						await import('@/controllers/folder.controller');
+
+					case 'insights':
+						await import('@/modules/insights/insights.controller');
 				}
 			}
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR adds insight routes to get aggregated insights by workflow (to display in the dashboard workflow table) and by time (to display a graph by metric).

The routes:
- Insights by time:
  - url: `/rest/insights/by-time`
  - response data: 
```json
{
    "data": [
        {
            "date": "2025-03-24T15:00:00.000Z",
            "values": {
                "total": 119,
                "succeeded": 33,
                "failed": 86,
                "failureRate": 0.7226890756302521,
                "averageRunTime": 1953.2268907563025,
                "timeSaved": 0
            }
        }
    ]
}
```

- Insights by workflow:
  - url: `/rest/insights/by-workflow?skip=0&take=10&sortBy=total:desc`
  - response data: 
```json
{
    "data": {
        "count": 3,
        "data": [
            {
                "workflowId": "UALXgdaoGD8x4Nev",
                "workflowName": "My workflow 3",
                "projectId": "EDlV2htxVd2oSfnZ",
                "projectName": "test n8n <test@n8n.io>",
                "total": 7608,
                "failed": 5755,
                "succeeded": 1853,
                "failureRate": 0.756440588853838,
                "runTime": 12729089,
                "averageRunTime": 1673.1189537329128,
                "timeSaved": 9030
            }
        ]
    }
}
```

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2584/implement-be-api-for-insights-data

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [X] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [X] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
