### PR TITLE
feat(core): Allow transferring folder to project root with delete operation (no-changelog)

### DIFF
--- a/packages/cli/src/databases/repositories/workflow.repository.ts
+++ b/packages/cli/src/databases/repositories/workflow.repository.ts
@@ -619,9 +619,12 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 			WorkflowEntity,
 			{ parentFolder: { id: fromFolderId } },
 			{
-				parentFolder: {
-					id: toFolderId,
-				},
+				parentFolder:
+					toFolderId === PROJECT_ROOT
+						? null
+						: {
+								id: toFolderId,
+							},
 			},
 		);
 	}

--- a/packages/cli/src/services/folder.service.ts
+++ b/packages/cli/src/services/folder.service.ts
@@ -138,7 +138,9 @@ export class FolderService {
 			throw new UserError('Cannot transfer folder contents to the folder being deleted');
 		}
 
-		await this.findFolderInProjectOrFail(transferToFolderId, projectId);
+		if (transferToFolderId !== PROJECT_ROOT) {
+			await this.findFolderInProjectOrFail(transferToFolderId, projectId);
+		}
 
 		return await this.folderRepository.manager.transaction(async (tx) => {
 			await this.folderRepository.moveAllToFolder(folderId, transferToFolderId, tx);

--- a/packages/cli/test/integration/folder/folder.controller.test.ts
+++ b/packages/cli/test/integration/folder/folder.controller.test.ts
@@ -885,30 +885,6 @@ describe('DELETE /projects/:projectId/folders/:folderId', () => {
 		expect(folderInDb).toBeDefined();
 	});
 
-	test('should not allow transferring contents to the same folder being deleted', async () => {
-		const project = await createTeamProject('test', owner);
-		const folder = await createFolder(project, { name: 'Folder To Delete' });
-
-		await createWorkflow({ parentFolder: folder }, owner);
-
-		const payload = {
-			transferToFolderId: folder.id, // Try to transfer contents to the same folder
-		};
-
-		const response = await authOwnerAgent
-			.delete(`/projects/${project.id}/folders/${folder.id}`)
-			.query(payload)
-			.expect(400);
-
-		expect(response.body.message).toContain(
-			'Cannot transfer folder contents to the folder being deleted',
-		);
-
-		// Verify the folder still exists
-		const folderInDb = await folderRepository.findOneBy({ id: folder.id });
-		expect(folderInDb).toBeDefined();
-	});
-
 	test('should transfer folder contents to project root when transferToFolderId is "0"', async () => {
 		const project = await createTeamProject('test', owner);
 		const sourceFolder = await createFolder(project, { name: 'Source' });

--- a/packages/cli/test/integration/folder/folder.controller.test.ts
+++ b/packages/cli/test/integration/folder/folder.controller.test.ts
@@ -1,5 +1,6 @@
 import { Container } from '@n8n/di';
 import { DateTime } from 'luxon';
+import { PROJECT_ROOT } from 'n8n-workflow';
 
 import type { Project } from '@/databases/entities/project';
 import type { User } from '@/databases/entities/user';
@@ -562,7 +563,7 @@ describe('PATCH /projects/:projectId/folders/:folderId', () => {
 		expect(folder?.parentFolder?.id).toBe(parentFolder.id);
 
 		const payload = {
-			parentFolderId: '0',
+			parentFolderId: PROJECT_ROOT,
 		};
 
 		await authOwnerAgent
@@ -883,6 +884,82 @@ describe('DELETE /projects/:projectId/folders/:folderId', () => {
 		const folderInDb = await folderRepository.findOneBy({ id: folder.id });
 		expect(folderInDb).toBeDefined();
 	});
+
+	test('should not allow transferring contents to the same folder being deleted', async () => {
+		const project = await createTeamProject('test', owner);
+		const folder = await createFolder(project, { name: 'Folder To Delete' });
+
+		await createWorkflow({ parentFolder: folder }, owner);
+
+		const payload = {
+			transferToFolderId: folder.id, // Try to transfer contents to the same folder
+		};
+
+		const response = await authOwnerAgent
+			.delete(`/projects/${project.id}/folders/${folder.id}`)
+			.query(payload)
+			.expect(400);
+
+		expect(response.body.message).toContain(
+			'Cannot transfer folder contents to the folder being deleted',
+		);
+
+		// Verify the folder still exists
+		const folderInDb = await folderRepository.findOneBy({ id: folder.id });
+		expect(folderInDb).toBeDefined();
+	});
+
+	test('should transfer folder contents to project root when transferToFolderId is "0"', async () => {
+		const project = await createTeamProject('test', owner);
+		const sourceFolder = await createFolder(project, { name: 'Source' });
+		await createFolder(project, { name: 'Target' });
+		const childFolder = await createFolder(project, {
+			name: 'Child',
+			parentFolder: sourceFolder,
+		});
+
+		const workflow1 = await createWorkflow({ parentFolder: sourceFolder }, owner);
+
+		const workflow2 = await createWorkflow({ parentFolder: childFolder }, owner);
+
+		const payload = {
+			transferToFolderId: PROJECT_ROOT,
+		};
+
+		await authOwnerAgent
+			.delete(`/projects/${project.id}/folders/${sourceFolder.id}`)
+			.query(payload)
+			.expect(200);
+
+		const sourceFolderInDb = await folderRepository.findOne({
+			where: { id: sourceFolder.id },
+			relations: ['parentFolder'],
+		});
+		const childFolderInDb = await folderRepository.findOne({
+			where: { id: childFolder.id },
+			relations: ['parentFolder'],
+		});
+
+		// Check folders
+		expect(sourceFolderInDb).toBeNull();
+		expect(childFolderInDb).toBeDefined();
+		expect(childFolderInDb?.parentFolder).toBe(null);
+
+		// Check workflows
+		const workflow1InDb = await workflowRepository.findOne({
+			where: { id: workflow1.id },
+			relations: ['parentFolder'],
+		});
+		expect(workflow1InDb).toBeDefined();
+		expect(workflow1InDb?.parentFolder).toBe(null);
+
+		const workflow2InDb = await workflowRepository.findOne({
+			where: { id: workflow2.id },
+			relations: ['parentFolder'],
+		});
+		expect(workflow2InDb).toBeDefined();
+		expect(workflow2InDb?.parentFolder?.id).toBe(childFolder.id);
+	});
 });
 
 describe('GET /projects/:projectId/folders', () => {
@@ -968,7 +1045,7 @@ describe('GET /projects/:projectId/folders', () => {
 
 		const response = await authOwnerAgent
 			.get(`/projects/${ownerProject.id}/folders`)
-			.query({ filter: '{ "parentFolderId": "0" }' })
+			.query({ filter: `{ "parentFolderId": "${PROJECT_ROOT}" }` })
 			.expect(200);
 
 		expect(response.body.count).toBe(3);


### PR DESCRIPTION
## Summary

Title self explanatory.

## Related Linear tickets, Github issues, and Community forum posts

https://www.notion.so/n8n/There-is-no-way-to-move-a-workflow-from-a-folder-to-the-root-directory-no-parent-folder-1bb5b6e0c94f804f81d0c7dffab7bbc1?pvs=4

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
