### PR TITLE
feat(core): Allow moving workflow to project root (no-changelog)

### DIFF
--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -9,7 +9,7 @@ import type { QueryDeepPartialEntity } from '@n8n/typeorm/query-builder/QueryPar
 import omit from 'lodash/omit';
 import pick from 'lodash/pick';
 import { BinaryDataService, Logger } from 'n8n-core';
-import { NodeApiError } from 'n8n-workflow';
+import { NodeApiError, PROJECT_ROOT } from 'n8n-workflow';
 import { v4 as uuid } from 'uuid';
 
 import { ActiveWorkflowManager } from '@/active-workflow-manager';
@@ -281,8 +281,10 @@ export class WorkflowService {
 
 		if (parentFolderId) {
 			const project = await this.sharedWorkflowRepository.getWorkflowOwningProject(workflow.id);
-			await this.folderService.findFolderInProjectOrFail(parentFolderId, project?.id ?? '');
-			updatePayload.parentFolder = { id: parentFolderId };
+			if (parentFolderId !== PROJECT_ROOT) {
+				await this.folderService.findFolderInProjectOrFail(parentFolderId, project?.id ?? '');
+			}
+			updatePayload.parentFolder = parentFolderId === PROJECT_ROOT ? null : { id: parentFolderId };
 		}
 
 		await this.workflowRepository.update(workflowId, updatePayload);


### PR DESCRIPTION
## Summary

Title self explanatory.

## Related Linear tickets, Github issues, and Community forum posts

https://www.notion.so/n8n/There-is-no-way-to-move-a-workflow-from-a-folder-to-the-root-directory-no-parent-folder-1bb5b6e0c94f804f81d0c7dffab7bbc1?pvs=4

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
