### PR TITLE
Adding a missing word from the Tooltip

### DIFF
--- a/packages/frontend/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/frontend/editor-ui/src/plugins/i18n/locales/en.json
@@ -2330,7 +2330,7 @@
 	"workflowSettings.defaultTimezoneNotValid": "Default Timezone not valid",
 	"workflowSettings.errorWorkflow": "Error Workflow",
 	"workflowSettings.executionOrder": "Execution Order",
-	"workflowSettings.helpTexts.errorWorkflow": "A second workflow to run if the current one fails.<br />The second workflow should an 'Error Trigger' node.",
+	"workflowSettings.helpTexts.errorWorkflow": "A second workflow to run if the current one fails.<br />The second workflow should have an 'Error Trigger' node.",
 	"workflowSettings.helpTexts.executionTimeout": "How long the workflow should wait before timing out",
 	"workflowSettings.helpTexts.executionTimeoutToggle": "Whether to cancel workflow execution after a defined time",
 	"workflowSettings.helpTexts.saveDataErrorExecution": "Whether to save data of executions that fail",


### PR DESCRIPTION
## Summary

The tool tip had a missing word, added the missing word.
Error: 
* `The second workflow should an 'Error Trigger' node.`

Fix: 
* `The second workflow should have an 'Error Trigger' node.`

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
