### PR TITLE
perf(editor): Prevent excessive fetch requests from workflows list (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/views/WorkflowsView.vue
+++ b/packages/frontend/editor-ui/src/views/WorkflowsView.vue
@@ -351,6 +351,13 @@ sourceControlStore.$onAction(({ name, after }) => {
 	after(async () => await initialize());
 });
 
+const onWorkflowDeleted = async () => {
+	await Promise.all([
+		fetchWorkflows(),
+		foldersStore.fetchTotalWorkflowsAndFoldersCount(route.params.projectId as string | undefined),
+	]);
+};
+
 const onFolderDeleted = async (payload: {
 	folderId: string;
 	workflowCount: number;
@@ -359,6 +366,9 @@ const onFolderDeleted = async (payload: {
 	const folderInfo = foldersStore.getCachedFolder(payload.folderId);
 	foldersStore.deleteFoldersFromCache([payload.folderId, folderInfo?.parentFolder ?? '']);
 	// If the deleted folder is the current folder, navigate to the parent folder
+	await foldersStore.fetchTotalWorkflowsAndFoldersCount(
+		route.params.projectId as string | undefined,
+	);
 
 	if (currentFolderId.value === payload.folderId) {
 		void router.push({
@@ -1303,7 +1313,7 @@ const onCreateWorkflowClick = () => {
 				:workflow-list-event-bus="workflowListEventBus"
 				:read-only="readOnlyEnv"
 				@click:tag="onClickTag"
-				@workflow:deleted="fetchWorkflows"
+				@workflow:deleted="onWorkflowDeleted"
 				@workflow:moved="fetchWorkflows"
 				@workflow:duplicated="fetchWorkflows"
 				@workflow:active-toggle="onWorkflowActiveToggle"

--- a/packages/frontend/editor-ui/src/views/WorkflowsView.vue
+++ b/packages/frontend/editor-ui/src/views/WorkflowsView.vue
@@ -62,6 +62,9 @@ import { useFoldersStore } from '@/stores/folders.store';
 import { useFolders } from '@/composables/useFolders';
 import { useUsageStore } from '@/stores/usage.store';
 
+const SEARCH_DEBOUNCE_TIME = 300;
+const FILTERS_DEBOUNCE_TIME = 100;
+
 interface Filters extends BaseFilters {
 	status: string | boolean;
 	tags: string[];
@@ -410,6 +413,7 @@ const initialize = async () => {
 		fetchWorkflows(),
 		workflowsStore.fetchActiveWorkflows(),
 		usageStore.getLicenseInfo(),
+		foldersStore.fetchTotalWorkflowsAndFoldersCount(route.params.projectId as string | undefined),
 	]);
 	breadcrumbsLoading.value = false;
 	workflowsAndFolders.value = resourcesPage;
@@ -428,6 +432,7 @@ const fetchWorkflows = async () => {
 	const delayedLoading = debounce(() => {
 		loading.value = true;
 	}, 300);
+
 	const routeProjectId = route.params?.projectId as string | undefined;
 	const homeProjectFilter = filters.value.homeProject || undefined;
 	const parentFolder = (route.params?.folderId as string) || undefined;
@@ -473,8 +478,6 @@ const fetchWorkflows = async () => {
 			breadcrumbsLoading.value = false;
 		}
 
-		await foldersStore.fetchTotalWorkflowsAndFoldersCount(routeProjectId);
-
 		workflowsAndFolders.value = fetchedResources;
 		return fetchedResources;
 	} catch (error) {
@@ -507,14 +510,14 @@ const onSortUpdated = async (sort: string) => {
 const onFiltersUpdated = async () => {
 	currentPage.value = 1;
 	saveFiltersOnQueryString();
-	await callDebounced(fetchWorkflows, { debounceTime: 100, trailing: true });
+	await callDebounced(fetchWorkflows, { debounceTime: FILTERS_DEBOUNCE_TIME, trailing: true });
 };
 
 const onSearchUpdated = async (search: string) => {
 	currentPage.value = 1;
 	saveFiltersOnQueryString();
 	if (search) {
-		await callDebounced(fetchWorkflows, { debounceTime: 100, trailing: true });
+		await callDebounced(fetchWorkflows, { debounceTime: SEARCH_DEBOUNCE_TIME, trailing: true });
 	} else {
 		// No need to debounce when clearing search
 		await fetchWorkflows();
@@ -523,12 +526,12 @@ const onSearchUpdated = async (search: string) => {
 
 const setCurrentPage = async (page: number) => {
 	currentPage.value = page;
-	await callDebounced(fetchWorkflows, { debounceTime: 100, trailing: true });
+	await callDebounced(fetchWorkflows, { debounceTime: FILTERS_DEBOUNCE_TIME, trailing: true });
 };
 
 const setPageSize = async (size: number) => {
 	pageSize.value = size;
-	await callDebounced(fetchWorkflows, { debounceTime: 100, trailing: true });
+	await callDebounced(fetchWorkflows, { debounceTime: FILTERS_DEBOUNCE_TIME, trailing: true });
 };
 
 const onClickTag = async (tagId: string) => {


### PR DESCRIPTION
## Summary
Preventing excessive calls to workflows end-point by:
1. Increasing search debounce timeout (`100ms` is too short even for regular typing)
2. Fetching total number of workflows and folders only when the component initializes. We need this info for paginated lists so we show empty state only when there are no resources in the database but this needs to be fetched only once, not with every page

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
