### PR TITLE
feat(X): Allow custom scopes for X (Twitter) credential

### DIFF
--- a/packages/nodes-base/credentials/TwitterOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/TwitterOAuth2Api.credentials.ts
@@ -52,10 +52,42 @@ export class TwitterOAuth2Api implements ICredentialType {
 			default: 'https://api.twitter.com/2/oauth2/token',
 		},
 		{
+			displayName: 'Custom Scopes',
+			name: 'customScopes',
+			type: 'boolean',
+			default: false,
+			description: 'Define custom scopes',
+		},
+		{
+			displayName:
+				'The default scopes needed for the node to work are already set, If you change these the node may not function correctly.',
+			name: 'customScopesNotice',
+			type: 'notice',
+			default: '',
+			displayOptions: {
+				show: {
+					customScopes: [true],
+				},
+			},
+		},
+		{
+			displayName: 'Enabled Scopes',
+			name: 'enabledScopes',
+			type: 'string',
+			displayOptions: {
+				show: {
+					customScopes: [true],
+				},
+			},
+			default: scopes.join(' '),
+			description: 'Scopes that should be enabled',
+		},
+		{
 			displayName: 'Scope',
 			name: 'scope',
 			type: 'hidden',
-			default: `${scopes.join(' ')}`,
+			default:
+				'={{$self["customScopes"] ? $self["enabledScopes"] : "' + scopes.join(' ') + '"}}',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Added the `media.write` scope to the X OAuth2 API credential type. This scope is necessary to support media upload capabilities when using the Twitter/X HTTP Request node with endpoints like '/2/media/upload'. Without this scope, users would be unable to upload images, videos, and other media content through the API.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
- https://devcommunity.x.com/t/how-to-upload-media-to-twitter-api-v2-using-oauth-2-0/238518
- https://docs.x.com/resources/fundamentals/authentication/oauth-2-0/authorization-code#confidential-clients:~:text=Bookmarks%20from%20Tweets.-,media.write,-Upload%20media.
- https://community.n8n.io/t/solved-post-media-to-x-twitter-via-api/90997
- https://community.n8n.io/t/x-formerly-twitter-predefined-and-generic-credentials-scopes/77195
- https://community.n8n.io/t/x-twitter-oauth1-needed-to-post-images-with-the-x-api/77343/2

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
