### PR TITLE
feat(API): Add the list of enabled modules in the frontend settings

### DIFF
--- a/packages/@n8n/api-types/src/frontend-settings.ts
+++ b/packages/@n8n/api-types/src/frontend-settings.ts
@@ -181,4 +181,7 @@ export interface FrontendSettings {
 	partialExecution: {
 		version: 1 | 2;
 	};
+	modules: {
+		enabled: Array<'insights'>;
+	};
 }

--- a/packages/cli/src/modules/modules.config.ts
+++ b/packages/cli/src/modules/modules.config.ts
@@ -2,7 +2,7 @@ import { CommaSeperatedStringArray, Config, Env } from '@n8n/config';
 import { UnexpectedError } from 'n8n-workflow';
 
 const moduleNames = ['insights'] as const;
-type ModuleName = (typeof moduleNames)[number];
+export type ModuleName = (typeof moduleNames)[number];
 
 class Modules extends CommaSeperatedStringArray<ModuleName> {
 	constructor(str: string) {

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -15,6 +15,7 @@ import { CredentialsOverwrites } from '@/credentials-overwrites';
 import { getLdapLoginLabel } from '@/ldap.ee/helpers.ee';
 import { License } from '@/license';
 import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
+import { ModulesConfig } from '@/modules/modules.config';
 import { isApiEnabled } from '@/public-api';
 import type { CommunityPackagesService } from '@/services/community-packages.service';
 import { getSamlLoginLabel } from '@/sso.ee/saml/saml-helpers';
@@ -44,6 +45,7 @@ export class FrontendService {
 		private readonly instanceSettings: InstanceSettings,
 		private readonly urlService: UrlService,
 		private readonly securityConfig: SecurityConfig,
+		private readonly modulesConfig: ModulesConfig,
 	) {
 		loadNodesAndCredentials.addPostProcessor(async () => await this.generateTypes());
 		void this.generateTypes();
@@ -234,6 +236,9 @@ export class FrontendService {
 			partialExecution: this.globalConfig.partialExecutions,
 			folders: {
 				enabled: false,
+			},
+			modules: {
+				enabled: this.modulesConfig.modules,
 			},
 		};
 	}

--- a/packages/frontend/editor-ui/src/__tests__/defaults.ts
+++ b/packages/frontend/editor-ui/src/__tests__/defaults.ts
@@ -141,4 +141,7 @@ export const defaultSettings: FrontendSettings = {
 	folders: {
 		enabled: false,
 	},
+	modules: {
+		enabled: [],
+	},
 };


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Provide the frontend the list of all modules that have been enabled (for now only insights module), so that the front end can toggle the display of the insights overview

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2706/provide-list-of-enabled-modules-to-the-front

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [X] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [X] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
