### PR TITLE
feat: Cat 720 improve pre merge ci

### DIFF
--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -65,11 +65,9 @@ jobs:
         run: echo "value=sha-$GITHUB_SHA-time-$(date +"%s")" >> $GITHUB_OUTPUT
 
   install:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2204
     needs: ['prepare']
-    container:
-      image: cypress/${{ inputs.run-env }}
-      options: --user 1001
+
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
@@ -83,10 +81,22 @@ jobs:
 
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
+      - name: Cache build artifacts
+        id: cache-build-artifacts
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: |
+            /home/runner/.cache/Cypress
+            /github/home/.pnpm-store
+            ./packages/**/dist
+          key: ${{ github.sha }}:build-artifacts
+
       - name: Install dependencies
+        if: steps.cache-build-artifacts.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Cypress build
+        if: steps.cache-build-artifacts.outputs.cache-hit != 'true'
         uses: cypress-io/github-action@1b70233146622b69e789ccdd4f9452adc638d25a # v6.6.1
         with:
           # Disable running of tests within install job
@@ -95,23 +105,13 @@ jobs:
           build: pnpm build
 
       - name: Cypress install
+        if: steps.cache-build-artifacts.outputs.cache-hit != 'true'
         working-directory: cypress
         run: pnpm cypress:install
 
-      - name: Cache build artifacts
-        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
-        with:
-          path: |
-            /github/home/.cache
-            /github/home/.pnpm-store
-            ./packages/**/dist
-          key: ${{ github.sha }}-e2e
 
   testing:
     runs-on: ubuntu-latest
-    container:
-      image: cypress/${{ inputs.run-env }}
-      options: --user 1001
     needs: ['prepare', 'install']
     strategy:
       fail-fast: false
@@ -133,13 +133,14 @@ jobs:
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
       - name: Restore cached pnpm modules
-        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        id: cache-build-artifacts
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: |
-            /github/home/.cache
+            /home/runner/.cache/Cypress
             /github/home/.pnpm-store
             ./packages/**/dist
-          key: ${{ github.sha }}-e2e
+          key: ${{ github.sha }}:build-artifacts
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/linting-reusable.yml
+++ b/.github/workflows/linting-reusable.yml
@@ -17,9 +17,7 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: blacksmith-2vcpu-ubuntu-2204
-    env:
-      NODE_OPTIONS: '--max-old-space-size=4096'
+    runs-on: blacksmith-4vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:


### PR DESCRIPTION
## Summary

Improves the CI timings for some workflows:
e2e-reusable: 
- Changes the install step to use a blacksmith 4 core runner to increase install time.
- Adds extra cache checks to allow for reruns
linting:
- Increase from 2 core to 4 core CPU for blacksmith,
- Removed max node memory usage as 4 core cpu has extra ram.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-720/ci-improve-pre-merge-ci-time


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
