### PR TITLE
fix(editor): Update registered community CTA (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/components/CommunityPlusEnrollmentModal.vue
+++ b/packages/frontend/editor-ui/src/components/CommunityPlusEnrollmentModal.vue
@@ -139,7 +139,7 @@ const confirm = async () => {
 		</template>
 		<template #footer>
 			<div :class="$style.notice">
-				<N8nText tag="span">
+				<N8nText size="small" tag="span">
 					{{ i18n.baseText('communityPlusModal.notice') }}
 					<a :href="COMMUNITY_PLUS_DOCS_URL" target="_blank">
 						{{ i18n.baseText('generic.moreInfo') }}

--- a/packages/frontend/editor-ui/src/components/CommunityPlusEnrollmentModal.vue
+++ b/packages/frontend/editor-ui/src/components/CommunityPlusEnrollmentModal.vue
@@ -139,7 +139,7 @@ const confirm = async () => {
 		</template>
 		<template #footer>
 			<div :class="$style.notice">
-				<N8nText size="small" tag="span">
+				<N8nText size="xsmall" tag="span">
 					{{ i18n.baseText('communityPlusModal.notice') }}
 					<a :href="COMMUNITY_PLUS_DOCS_URL" target="_blank">
 						{{ i18n.baseText('generic.moreInfo') }}

--- a/packages/frontend/editor-ui/src/components/CommunityPlusEnrollmentModal.vue
+++ b/packages/frontend/editor-ui/src/components/CommunityPlusEnrollmentModal.vue
@@ -3,7 +3,7 @@ import { ref } from 'vue';
 import { createEventBus } from '@n8n/utils/event-bus';
 import type { Validatable, IValidator } from '@n8n/design-system';
 import { N8nFormInput } from '@n8n/design-system';
-import { VALID_EMAIL_REGEX } from '@/constants';
+import { VALID_EMAIL_REGEX, COMMUNITY_PLUS_DOCS_URL } from '@/constants';
 import Modal from '@/components/Modal.vue';
 import { useI18n } from '@/composables/useI18n';
 import { useToast } from '@/composables/useToast';
@@ -86,9 +86,6 @@ const confirm = async () => {
 	>
 		<template #content>
 			<div>
-				<p :class="$style.top">
-					<N8nBadge>{{ i18n.baseText('communityPlusModal.badge') }}</N8nBadge>
-				</p>
 				<N8nText tag="h1" align="center" size="xlarge" class="mb-m">{{
 					data?.customHeading ?? i18n.baseText('communityPlusModal.title')
 				}}</N8nText>
@@ -141,6 +138,14 @@ const confirm = async () => {
 			</div>
 		</template>
 		<template #footer>
+			<div :class="$style.notice">
+				<N8nText tag="span">
+					{{ i18n.baseText('communityPlusModal.notice') }}
+					<a :href="COMMUNITY_PLUS_DOCS_URL" target="_blank">
+						{{ i18n.baseText('generic.moreInfo') }}
+					</a>
+				</N8nText>
+			</div>
 			<div :class="$style.buttons">
 				<N8nButton :class="$style.skip" type="secondary" text @click="closeModal">{{
 					i18n.baseText('communityPlusModal.button.skip')
@@ -154,10 +159,8 @@ const confirm = async () => {
 </template>
 
 <style lang="scss" module>
-.top {
-	display: flex;
-	justify-content: center;
-	margin: 0 0 var(--spacing-s);
+.notice {
+	margin-bottom: var(--spacing-l);
 }
 
 .features {

--- a/packages/frontend/editor-ui/src/constants.ts
+++ b/packages/frontend/editor-ui/src/constants.ts
@@ -470,6 +470,8 @@ export const LOCAL_STORAGE_NDV_INPUT_PANEL_DISPLAY_MODE = 'N8N_NDV_INPUT_PANEL_D
 export const LOCAL_STORAGE_NDV_OUTPUT_PANEL_DISPLAY_MODE = 'N8N_NDV_OUTPUT_PANEL_DISPLAY_MODE';
 export const LOCAL_STORAGE_LOGS_2025_SPRING = 'N8N_LOGS_2025_SPRING';
 export const BASE_NODE_SURVEY_URL = 'https://n8n-community.typeform.com/to/BvmzxqYv#nodename=';
+export const COMMUNITY_PLUS_DOCS_URL =
+	'https://docs.n8n.io/hosting/community-edition-features/#registered-community-edition';
 
 export const HIRING_BANNER = `
                                                                     //////

--- a/packages/frontend/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/frontend/editor-ui/src/plugins/i18n/locales/en.json
@@ -2909,6 +2909,7 @@
 	"communityPlusModal.input.email.label": "Enter email to receive your license key",
 	"communityPlusModal.button.skip": "Skip",
 	"communityPlusModal.button.confirm": "Send me a free license key",
+	"communityPlusModal.notice": "Included features may change, but once unlocked, you'll keep them forever.",
 	"executeWorkflowTrigger.createNewSubworkflow": "Create a Sub-Workflow in {projectName}",
 	"executeWorkflowTrigger.createNewSubworkflow.noProject": "Create a New Sub-Workflow",
 	"testDefinition.edit.descriptionPlaceholder": "Enter test description",


### PR DESCRIPTION
## Summary
Removing `Limited time offer` badge from the registered community modal and adding more info with links to docs.

![image](https://github.com/user-attachments/assets/4d0d1b8a-0de1-44b8-a479-188abf37f5f0)


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
