### PR TITLE
fix(Slack Trigger Node): Fix issue with new user event not correctly working

### DIFF
--- a/packages/nodes-base/nodes/Slack/SlackTrigger.node.ts
+++ b/packages/nodes-base/nodes/Slack/SlackTrigger.node.ts
@@ -320,7 +320,7 @@ export class SlackTrigger implements INodeType {
 		const options = this.getNodeParameter('options', {}) as IDataObject;
 		const binaryData: IBinaryKeyData = {};
 		const watchWorkspace = this.getNodeParameter('watchWorkspace', false) as boolean;
-
+		let eventChannel: string = '';
 		// Check if the request is a challenge request
 		if (req.body.type === 'url_verification') {
 			const res = this.getResponseObject();
@@ -342,14 +342,17 @@ export class SlackTrigger implements INodeType {
 			return {};
 		}
 
-		const eventChannel = req.body.event.channel ?? req.body.event.item.channel;
+		if (eventType !== 'team_join') {
+			eventChannel = req.body.event.channel ?? req.body.event.item.channel;
 
-		// Check for single channel
-		if (!watchWorkspace) {
-			if (
-				eventChannel !== (this.getNodeParameter('channelId', {}, { extractValue: true }) as string)
-			) {
-				return {};
+			// Check for single channel
+			if (!watchWorkspace) {
+				if (
+					eventChannel !==
+					(this.getNodeParameter('channelId', {}, { extractValue: true }) as string)
+				) {
+					return {};
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary
When using New User in the Slack trigger we were not skipping over the single channel checks which do not apply to this event type.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-2606/slack-trigger-ignore-eventchannel-on-team-join
https://community.n8n.io/t/slack-trigger-throwing-error-when-new-user-is-created-cannot-read-properties-of-undefined-reading-channel/92005


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
