### PR TITLE
feat(Postgres Node): Add support for connecting with SSL certificates

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/other/handlers/postgres.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/other/handlers/postgres.test.ts
@@ -60,53 +60,6 @@ describe('Postgres SSL settings', () => {
 		});
 	});
 
-	test('ssl is allow + allowUnauthorizedCerts is false', async () => {
-		const context = mock<IExecuteFunctions>({
-			getCredentials: jest.fn().mockReturnValue({
-				...credentials,
-				ssl: 'allow',
-				allowUnauthorizedCerts: false,
-			}),
-		});
-
-		const dataSource = await getPostgresDataSource.call(context);
-
-		expect(dataSource.options).toMatchObject({
-			ssl: true,
-		});
-	});
-
-	test('ssl is allow + allowUnauthorizedCerts is true', async () => {
-		const context = mock<IExecuteFunctions>({
-			getCredentials: jest.fn().mockReturnValue({
-				...credentials,
-				ssl: 'allow',
-				allowUnauthorizedCerts: true,
-			}),
-		});
-
-		const dataSource = await getPostgresDataSource.call(context);
-
-		expect(dataSource.options).toMatchObject({
-			ssl: { rejectUnauthorized: false },
-		});
-	});
-
-	test('ssl is allow + allowUnauthorizedCerts is undefined', async () => {
-		const context = mock<IExecuteFunctions>({
-			getCredentials: jest.fn().mockReturnValue({
-				...credentials,
-				ssl: 'allow',
-			}),
-		});
-
-		const dataSource = await getPostgresDataSource.call(context);
-
-		expect(dataSource.options).toMatchObject({
-			ssl: true,
-		});
-	});
-
 	test('ssl is require + allowUnauthorizedCerts is false', async () => {
 		const context = mock<IExecuteFunctions>({
 			getCredentials: jest.fn().mockReturnValue({

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/other/handlers/postgres.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/other/handlers/postgres.ts
@@ -27,6 +27,10 @@ export async function getPostgresDataSource(this: IExecuteFunctions): Promise<Da
 		if (allowUnauthorizedCerts === true) {
 			ssl.rejectUnauthorized = false;
 		}
+		if (credentials.ssl === 'verify-ca') {
+			// @ts-expect-error this option is available for tls.connect but not on the TLSSocket constructor. typeorm has incorrectly typed as options for the latter.
+			ssl.checkServerIdentity = (_hostname: string, _cert: unknown) => undefined;
+		}
 	}
 
 	return new DataSource({

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/other/handlers/postgres.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/other/handlers/postgres.ts
@@ -13,7 +13,7 @@ export async function getPostgresDataSource(this: IExecuteFunctions): Promise<Da
 	if (ssl) {
 		ssl = {};
 
-		const { caCert, clientCert, clientKey, allowUnauthorizedCerts } =
+		const { caCert, clientCert, clientKey, allowUnauthorizedCerts, servername } =
 			credentials as PostgresNodeSSLOptions;
 		if (caCert) {
 			ssl.ca = caCert;
@@ -27,9 +27,9 @@ export async function getPostgresDataSource(this: IExecuteFunctions): Promise<Da
 		if (allowUnauthorizedCerts === true) {
 			ssl.rejectUnauthorized = false;
 		}
-		if (credentials.ssl === 'verify-ca') {
+		if (servername) {
 			// @ts-expect-error this option is available for tls.connect but not on the TLSSocket constructor. typeorm has incorrectly typed as options for the latter.
-			ssl.checkServerIdentity = (_hostname: string, _cert: unknown) => undefined;
+			ssl.servername = servername;
 		}
 	}
 

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/other/handlers/postgres.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/other/handlers/postgres.ts
@@ -11,24 +11,28 @@ export async function getPostgresDataSource(this: IExecuteFunctions): Promise<Da
 
 	let ssl: ConnectionOptions | boolean = !['disable', undefined].includes(credentials.ssl);
 	if (ssl) {
-		ssl = {};
+		const sslOpts: ConnectionOptions = {};
 
 		const { caCert, clientCert, clientKey, allowUnauthorizedCerts, servername } =
 			credentials as PostgresNodeSSLOptions;
 		if (caCert) {
-			ssl.ca = caCert;
+			sslOpts.ca = caCert;
 		}
 		if (clientCert) {
-			ssl.cert = clientCert;
+			sslOpts.cert = clientCert;
 		}
 		if (clientKey) {
-			ssl.key = clientKey;
+			sslOpts.key = clientKey;
 		}
 		if (allowUnauthorizedCerts === true) {
-			ssl.rejectUnauthorized = false;
+			sslOpts.rejectUnauthorized = false;
 		}
 		if (servername) {
-			ssl.servername = servername;
+			sslOpts.servername = servername;
+		}
+
+		if (Object.keys(sslOpts).length > 0) {
+			ssl = sslOpts;
 		}
 	}
 

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/other/handlers/postgres.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/other/handlers/postgres.ts
@@ -4,12 +4,12 @@ import type {
 	PostgresNodeSSLOptions,
 } from 'n8n-nodes-base/dist/nodes/Postgres/v2/helpers/interfaces';
 import { type IExecuteFunctions } from 'n8n-workflow';
-import type { TlsOptions } from 'tls';
+import { type TlsOptions, type ConnectionOptions } from 'tls';
 
 export async function getPostgresDataSource(this: IExecuteFunctions): Promise<DataSource> {
 	const credentials = await this.getCredentials<PostgresNodeCredentials>('postgres');
 
-	let ssl: TlsOptions | boolean = !['disable', undefined].includes(credentials.ssl);
+	let ssl: ConnectionOptions | boolean = !['disable', undefined].includes(credentials.ssl);
 	if (ssl) {
 		ssl = {};
 
@@ -28,7 +28,6 @@ export async function getPostgresDataSource(this: IExecuteFunctions): Promise<Da
 			ssl.rejectUnauthorized = false;
 		}
 		if (servername) {
-			// @ts-expect-error this option is available for tls.connect but not on the TLSSocket constructor. typeorm has incorrectly typed as options for the latter.
 			ssl.servername = servername;
 		}
 	}
@@ -40,6 +39,7 @@ export async function getPostgresDataSource(this: IExecuteFunctions): Promise<Da
 		username: credentials.user,
 		password: credentials.password,
 		database: credentials.database,
-		ssl,
+		// typeorm incorrectly types this for the TLSSocket constructor options instead of tls.connect options
+		ssl: ssl as boolean | TlsOptions,
 	});
 }

--- a/packages/nodes-base/credentials/Postgres.credentials.ts
+++ b/packages/nodes-base/credentials/Postgres.credentials.ts
@@ -71,11 +71,66 @@ export class Postgres implements ICredentialType {
 					value: 'disable',
 				},
 				{
+					name: 'Prefer',
+					value: 'prefer',
+				},
+				{
 					name: 'Require',
 					value: 'require',
 				},
+				{
+					name: 'Verify CA Only',
+					value: 'verify-ca',
+				},
+				{
+					name: 'Verify Full Chain',
+					value: 'verify-ful',
+				},
 			],
 			default: 'disable',
+		},
+		{
+			displayName: 'CA Certificate',
+			name: 'caCert',
+			type: 'string',
+			typeOptions: {
+				alwaysOpenEditWindow: true,
+			},
+			displayOptions: {
+				show: {
+					ssl: [true],
+				},
+			},
+			default: '',
+		},
+		{
+			displayName: 'Client Certificate',
+			name: 'clientCert',
+			type: 'string',
+			typeOptions: {
+				alwaysOpenEditWindow: true,
+			},
+			displayOptions: {
+				show: {
+					ssl: [true],
+				},
+			},
+			default: '',
+		},
+		{
+			displayName: 'Client Key',
+			name: 'clientKey',
+			type: 'string',
+			typeOptions: {
+				alwaysOpenEditWindow: true,
+				password: true,
+			},
+			displayOptions: {
+				show: {
+					ssl: [true],
+				},
+			},
+			default: '',
 		},
 		{
 			displayName: 'Port',

--- a/packages/nodes-base/credentials/Postgres.credentials.ts
+++ b/packages/nodes-base/credentials/Postgres.credentials.ts
@@ -63,10 +63,6 @@ export class Postgres implements ICredentialType {
 			},
 			options: [
 				{
-					name: 'Allow',
-					value: 'allow',
-				},
-				{
 					name: 'Disable',
 					value: 'disable',
 				},

--- a/packages/nodes-base/credentials/Postgres.credentials.ts
+++ b/packages/nodes-base/credentials/Postgres.credentials.ts
@@ -71,23 +71,22 @@ export class Postgres implements ICredentialType {
 					value: 'disable',
 				},
 				{
-					name: 'Prefer',
-					value: 'prefer',
-				},
-				{
 					name: 'Require',
 					value: 'require',
 				},
-				{
-					name: 'Verify CA Only',
-					value: 'verify-ca',
-				},
-				{
-					name: 'Verify Full Chain',
-					value: 'verify-ful',
-				},
 			],
 			default: 'disable',
+		},
+		{
+			displayName: 'Server name override for SSL',
+			name: 'servername',
+			type: 'string',
+			displayOptions: {
+				show: {
+					ssl: [true],
+				},
+			},
+			default: '',
 		},
 		{
 			displayName: 'CA Certificate',

--- a/packages/nodes-base/credentials/Postgres.credentials.ts
+++ b/packages/nodes-base/credentials/Postgres.credentials.ts
@@ -79,7 +79,7 @@ export class Postgres implements ICredentialType {
 			type: 'string',
 			default: '',
 			description:
-				'Override the server name used to verify the certificate. Use this whent he host is an IP but has a certificate from a recognized CA.',
+				'Override the server name used to verify the certificate. Use this when the host is an IP but has a certificate from a recognized CA.',
 			displayOptions: {
 				show: {
 					ssl: ['require'],

--- a/packages/nodes-base/credentials/Postgres.credentials.ts
+++ b/packages/nodes-base/credentials/Postgres.credentials.ts
@@ -46,21 +46,9 @@ export class Postgres implements ICredentialType {
 				'Make sure this value times the number of workers you have is lower than the maximum number of connections your postgres instance allows.',
 		},
 		{
-			displayName: 'Ignore SSL Issues (Insecure)',
-			name: 'allowUnauthorizedCerts',
-			type: 'boolean',
-			default: false,
-			description: 'Whether to connect even if SSL certificate validation is not possible',
-		},
-		{
 			displayName: 'SSL',
 			name: 'ssl',
 			type: 'options',
-			displayOptions: {
-				show: {
-					allowUnauthorizedCerts: [false],
-				},
-			},
 			options: [
 				{
 					name: 'Disable',
@@ -74,58 +62,77 @@ export class Postgres implements ICredentialType {
 			default: 'disable',
 		},
 		{
+			displayName: 'Ignore SSL Issues (Insecure)',
+			name: 'allowUnauthorizedCerts',
+			type: 'boolean',
+			default: false,
+			description: 'Whether to connect even if SSL certificate validation is not possible.',
+			displayOptions: {
+				show: {
+					ssl: ['require'],
+				},
+			},
+		},
+		{
 			displayName: 'Server name override for SSL',
 			name: 'servername',
 			type: 'string',
+			default: '',
+			description:
+				'Override the server name used to verify the certificate. Use this whent he host is an IP but has a certificate from a recognized CA.',
 			displayOptions: {
 				show: {
-					ssl: [true],
+					ssl: ['require'],
 				},
 			},
-			default: '',
 		},
 		{
 			displayName: 'CA Certificate',
 			name: 'caCert',
 			type: 'string',
+			default: '',
+			description:
+				'Certificate for the CA root that should be used to verify the server certificate. By default, all system roots are used.',
 			typeOptions: {
 				alwaysOpenEditWindow: true,
 			},
 			displayOptions: {
 				show: {
-					ssl: [true],
+					ssl: ['require'],
 				},
 			},
-			default: '',
 		},
 		{
 			displayName: 'Client Certificate',
 			name: 'clientCert',
 			type: 'string',
+			default: '',
+			description:
+				'Client certificate to provide to the server, in case the server requires client certificates.',
 			typeOptions: {
 				alwaysOpenEditWindow: true,
 			},
 			displayOptions: {
 				show: {
-					ssl: [true],
+					ssl: ['require'],
 				},
 			},
-			default: '',
 		},
 		{
 			displayName: 'Client Key',
 			name: 'clientKey',
 			type: 'string',
+			default: '',
+			description: 'Client key corresponding to the client certificate',
 			typeOptions: {
 				alwaysOpenEditWindow: true,
 				password: true,
 			},
 			displayOptions: {
 				show: {
-					ssl: [true],
+					ssl: ['require'],
 				},
 			},
-			default: '',
 		},
 		{
 			displayName: 'Port',

--- a/packages/nodes-base/nodes/Postgres/test/transport/index.test.ts
+++ b/packages/nodes-base/nodes/Postgres/test/transport/index.test.ts
@@ -1,0 +1,224 @@
+import { mock, mockFn } from 'jest-mock-extended';
+import { type ICredentialTestFunctions } from 'n8n-workflow';
+import pgPromise from 'pg-promise';
+
+import { ConnectionPoolManager } from '@utils/connection-pool-manager';
+
+import { configurePostgres } from '../../transport';
+
+jest.mock('pg-promise');
+jest.mock('@utils/connection-pool-manager');
+
+const mockConfigurePostgres = (): jest.MockedFunction<pgPromise.IMain> => {
+	const ConnectionPoolManagerStatic = ConnectionPoolManager as jest.Mocked<
+		typeof ConnectionPoolManager
+	>;
+	const poolManager = mock<ConnectionPoolManager>();
+	ConnectionPoolManagerStatic.getInstance.mockReturnValue(poolManager as any);
+	poolManager.getConnection.mockImplementation(async (options) => {
+		return await options.fallBackHandler();
+	});
+
+	const pgp = mockFn<pgPromise.IMain>();
+	(pgPromise as jest.MockedFunction<typeof pgPromise>).mockReturnValue(pgp);
+	return pgp;
+};
+
+describe('configurePostgres', () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
+	it('calls pg-promise with ssl false when disabled', async () => {
+		const pgp = mockConfigurePostgres();
+
+		await configurePostgres.call(mock<ICredentialTestFunctions>(), {
+			host: 'db.localhost',
+			port: 2345,
+			database: 'defaultdb',
+			user: 'postgres',
+			password: 'sergtsop',
+			maxConnections: 100,
+			ssl: 'disable',
+			sshTunnel: false,
+		});
+
+		expect(pgp.mock.calls).toEqual([
+			[
+				{
+					host: 'db.localhost',
+					port: 2345,
+					database: 'defaultdb',
+					user: 'postgres',
+					password: 'sergtsop',
+					keepAlive: true,
+					max: 100,
+					ssl: false,
+				},
+			],
+		]);
+	});
+
+	it('calls pg-promise with ssl enabled when required', async () => {
+		const pgp = mockConfigurePostgres();
+
+		await configurePostgres.call(mock<ICredentialTestFunctions>(), {
+			host: 'db.localhost',
+			port: 2345,
+			database: 'defaultdb',
+			user: 'postgres',
+			password: 'sergtsop',
+			maxConnections: 100,
+			ssl: 'require',
+			sshTunnel: false,
+		});
+
+		expect(pgp.mock.calls).toEqual([
+			[
+				{
+					host: 'db.localhost',
+					port: 2345,
+					database: 'defaultdb',
+					user: 'postgres',
+					password: 'sergtsop',
+					keepAlive: true,
+					max: 100,
+					ssl: true,
+				},
+			],
+		]);
+	});
+
+	it('calls pg-promise with ssl enabled when set to unknown value', async () => {
+		const pgp = mockConfigurePostgres();
+
+		await configurePostgres.call(mock<ICredentialTestFunctions>(), {
+			host: 'db.localhost',
+			port: 2345,
+			database: 'defaultdb',
+			user: 'postgres',
+			password: 'sergtsop',
+			maxConnections: 100,
+			ssl: 'allow' as 'require',
+			sshTunnel: false,
+		});
+
+		expect(pgp.mock.calls).toEqual([
+			[
+				{
+					host: 'db.localhost',
+					port: 2345,
+					database: 'defaultdb',
+					user: 'postgres',
+					password: 'sergtsop',
+					keepAlive: true,
+					max: 100,
+					ssl: true,
+				},
+			],
+		]);
+	});
+
+	it('calls pg-promise with ssl ignoring verification errors when configured', async () => {
+		const pgp = mockConfigurePostgres();
+
+		await configurePostgres.call(mock<ICredentialTestFunctions>(), {
+			host: 'db.localhost',
+			port: 2345,
+			database: 'defaultdb',
+			user: 'postgres',
+			password: 'sergtsop',
+			maxConnections: 100,
+			ssl: 'require',
+			allowUnauthorizedCerts: true,
+			sshTunnel: false,
+		});
+
+		expect(pgp.mock.calls).toEqual([
+			[
+				{
+					host: 'db.localhost',
+					port: 2345,
+					database: 'defaultdb',
+					user: 'postgres',
+					password: 'sergtsop',
+					keepAlive: true,
+					max: 100,
+					ssl: {
+						rejectUnauthorized: false,
+					},
+				},
+			],
+		]);
+	});
+
+	it('calls pg-promise with ssl server certificate options', async () => {
+		const pgp = mockConfigurePostgres();
+
+		await configurePostgres.call(mock<ICredentialTestFunctions>(), {
+			host: 'db.localhost',
+			port: 2345,
+			database: 'defaultdb',
+			user: 'postgres',
+			password: 'sergtsop',
+			maxConnections: 100,
+			ssl: 'require',
+			servername: 'other-server-name',
+			caCert: 'ca-cert',
+			sshTunnel: false,
+		});
+
+		expect(pgp.mock.calls).toEqual([
+			[
+				{
+					host: 'db.localhost',
+					port: 2345,
+					database: 'defaultdb',
+					user: 'postgres',
+					password: 'sergtsop',
+					keepAlive: true,
+					max: 100,
+					ssl: {
+						servername: 'other-server-name',
+						ca: 'ca-cert',
+					},
+				},
+			],
+		]);
+	});
+
+	it('calls pg-promise with ssl client certificate options', async () => {
+		const pgp = mockConfigurePostgres();
+
+		await configurePostgres.call(mock<ICredentialTestFunctions>(), {
+			host: 'db.localhost',
+			port: 2345,
+			database: 'defaultdb',
+			user: 'postgres',
+			password: 'sergtsop',
+			maxConnections: 100,
+			ssl: 'require',
+			clientCert: 'client-cert',
+			clientKey: 'client-key',
+			sshTunnel: false,
+		});
+
+		expect(pgp.mock.calls).toEqual([
+			[
+				{
+					host: 'db.localhost',
+					port: 2345,
+					database: 'defaultdb',
+					user: 'postgres',
+					password: 'sergtsop',
+					keepAlive: true,
+					max: 100,
+					ssl: {
+						cert: 'client-cert',
+						key: 'client-key',
+					},
+				},
+			],
+		]);
+	});
+});

--- a/packages/nodes-base/nodes/Postgres/transport/index.ts
+++ b/packages/nodes-base/nodes/Postgres/transport/index.ts
@@ -41,12 +41,11 @@ const getPostgresConfig = (
 		dbConfig.keepAliveInitialDelayMillis = options.delayClosingIdleConnection * 1000;
 	}
 
-	// @ts-expect-error parameters unrecognized by pg-connection-string are preserved
-	dbConfig.sslmode = credentials.ssl || 'disable';
+	dbConfig.ssl = false;
 	if (credentials.ssl && credentials.ssl !== 'disable') {
 		dbConfig.ssl = {};
 
-		const { caCert, clientCert, clientKey, allowUnauthorizedCerts } =
+		const { caCert, clientCert, clientKey, allowUnauthorizedCerts, servername } =
 			credentials as PostgresNodeSSLOptions;
 		if (caCert) {
 			dbConfig.ssl.ca = caCert;
@@ -60,8 +59,9 @@ const getPostgresConfig = (
 		if (allowUnauthorizedCerts === true) {
 			dbConfig.ssl.rejectUnauthorized = false;
 		}
-		if (credentials.ssl === 'verify-ca') {
-			dbConfig.ssl.checkServerIdentity = (_hostname: string, _cert: unknown) => undefined;
+		if (servername) {
+			// @ts-expect-error the ISSLConfig type is an incomplete subset of tls.ConnectOptions
+			dbConfig.ssl.servername = servername;
 		}
 	}
 

--- a/packages/nodes-base/nodes/Postgres/transport/index.ts
+++ b/packages/nodes-base/nodes/Postgres/transport/index.ts
@@ -60,6 +60,9 @@ const getPostgresConfig = (
 		if (allowUnauthorizedCerts === true) {
 			dbConfig.ssl.rejectUnauthorized = false;
 		}
+		if (credentials.ssl === 'verify-ca') {
+			dbConfig.ssl.checkServerIdentity = (_hostname: string, _cert: unknown) => undefined;
+		}
 	}
 
 	return dbConfig;

--- a/packages/nodes-base/nodes/Postgres/v2/helpers/interfaces.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/helpers/interfaces.ts
@@ -28,6 +28,7 @@ export type EnumInfo = {
 export type PgpClient = pgPromise.IMain<{}, pg.IClient>;
 export type PgpDatabase = pgPromise.IDatabase<{}, pg.IClient>;
 export type PgpConnectionParameters = pg.IConnectionParameters<pg.IClient>;
+export type PgpSSLConfig = pg.ISSLConfig;
 export type PgpConnection = pgPromise.IConnected<{}, pg.IClient>;
 export type ConnectionsData = { db: PgpDatabase; pgp: PgpClient };
 

--- a/packages/nodes-base/nodes/Postgres/v2/helpers/interfaces.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/helpers/interfaces.ts
@@ -62,7 +62,7 @@ export type PostgresNodeCredentials = {
 } & (
 	| { ssl?: 'disable' }
 	| ({
-			ssl: 'allow' | 'require';
+			ssl: 'require';
 	  } & PostgresNodeSSLOptions)
 ) &
 	(
@@ -74,8 +74,8 @@ export type PostgresNodeCredentials = {
 
 export type PostgresNodeSSLOptions = {
 	allowUnauthorizedCerts?: boolean;
-	servername: string;
-	caCert: string;
-	clientCert: string;
-	clientKey: string;
+	servername?: string;
+	caCert?: string;
+	clientCert?: string;
+	clientKey?: string;
 };

--- a/packages/nodes-base/nodes/Postgres/v2/helpers/interfaces.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/helpers/interfaces.ts
@@ -59,11 +59,22 @@ export type PostgresNodeCredentials = {
 	user: string;
 	password: string;
 	maxConnections: number;
-	allowUnauthorizedCerts?: boolean;
-	ssl?: 'disable' | 'allow' | 'require' | 'verify' | 'verify-full';
 } & (
-	| { sshTunnel: false }
+	| { ssl?: 'disable' }
 	| ({
-			sshTunnel: true;
-	  } & SSHCredentials)
-);
+			ssl: 'allow' | 'prefer' | 'require' | 'verify-ca' | 'verify-full';
+	  } & PostgresNodeSSLOptions)
+) &
+	(
+		| { sshTunnel: false }
+		| ({
+				sshTunnel: true;
+		  } & SSHCredentials)
+	);
+
+export type PostgresNodeSSLOptions = {
+	allowUnauthorizedCerts?: boolean;
+	caCert: string;
+	clientCert: string;
+	clientKey: string;
+};

--- a/packages/nodes-base/nodes/Postgres/v2/helpers/interfaces.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/helpers/interfaces.ts
@@ -62,7 +62,7 @@ export type PostgresNodeCredentials = {
 } & (
 	| { ssl?: 'disable' }
 	| ({
-			ssl: 'allow' | 'prefer' | 'require' | 'verify-ca' | 'verify-full';
+			ssl: 'allow' | 'require';
 	  } & PostgresNodeSSLOptions)
 ) &
 	(
@@ -74,6 +74,7 @@ export type PostgresNodeCredentials = {
 
 export type PostgresNodeSSLOptions = {
 	allowUnauthorizedCerts?: boolean;
+	servername: string;
 	caCert: string;
 	clientCert: string;
 	clientKey: string;


### PR DESCRIPTION
## Summary

Add options for configuring Postgres connections with server and client certificates, and overriding the server name used to verify the server certificate.

Server certificates are required for some Postgres setups, e.g. the standard setup in Google Cloud SQL, where every instance has its own CA. The server certificate can only be verified by clients having the certificate for the CA, and the client must handle the fact that the host is an IP, and so the certificate name will not match the host.

For the last part, common postgres clients have a `verify-ca` mode, in which the certificate must be signed by the CA, but the certificate subject is not checked against the server name. This is quite complex to implement through all the layers of configuration happening in node-postgres packages, and seems quite lax as any certificate from a valid CA will do, and so the alternative provided in this change is to explicitly override the server name used to verify the certificate.

Client certificates can also be used for additional security, so that even when the database IP is reachable from many addresses on the public internet, only clients with a recognized key can connect. This is a security hardening option also available in Google Cloud SQL.

## Related Linear tickets, Github issues, and Community forum posts

https://community.n8n.io/t/connect-to-gcp-cloud-sql-postgres/91918

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
