### PR TITLE
fix(editor): Check for when to show the community+ modal for the folder's feature

### DIFF
--- a/packages/frontend/editor-ui/src/views/WorkflowsView.vue
+++ b/packages/frontend/editor-ui/src/views/WorkflowsView.vue
@@ -333,6 +333,10 @@ const canUserRegisterCommunityPlus = computed(
 	() => getResourcePermissions(usersStore.currentUser?.globalScopes).community.register,
 );
 
+const showRegisteredCommunityCTA = computed(
+	() => isSelfHostedDeployment.value && !foldersEnabled.value && canUserRegisterCommunityPlus.value,
+);
+
 /**
  * WATCHERS, STORE SUBSCRIPTIONS AND EVENT BUS HANDLERS
  */
@@ -1044,7 +1048,7 @@ const renameFolder = async (folderId: string) => {
 
 const createFolderInCurrent = async () => {
 	// Show the community plus enrollment modal if the user is self-hosted, and hasn't enabled folders
-	if (isSelfHostedDeployment.value && !foldersEnabled.value && canUserRegisterCommunityPlus.value) {
+	if (showRegisteredCommunityCTA.value) {
 		uiStore.openModalWithData({
 			name: COMMUNITY_PLUS_ENROLLMENT_MODAL,
 			data: { customHeading: i18n.baseText('folders.registeredCommunity.cta.heading') },
@@ -1126,7 +1130,7 @@ const moveWorkflowToFolder = async (payload: {
 	name: string;
 	parentFolderId?: string;
 }) => {
-	if (isSelfHostedDeployment.value && canUserRegisterCommunityPlus.value) {
+	if (showRegisteredCommunityCTA.value) {
 		uiStore.openModalWithData({
 			name: COMMUNITY_PLUS_ENROLLMENT_MODAL,
 			data: { customHeading: i18n.baseText('folders.registeredCommunity.cta.heading') },

--- a/packages/frontend/editor-ui/src/views/WorkflowsView.vue
+++ b/packages/frontend/editor-ui/src/views/WorkflowsView.vue
@@ -327,7 +327,8 @@ const hasFilters = computed(() => {
 	);
 });
 
-const isCommunity = computed(() => usageStore.planName.toLowerCase() === 'community');
+const isSelfHostedDeployment = computed(() => settingsStore.deploymentType === 'default');
+
 const canUserRegisterCommunityPlus = computed(
 	() => getResourcePermissions(usersStore.currentUser?.globalScopes).community.register,
 );
@@ -1043,7 +1044,7 @@ const renameFolder = async (folderId: string) => {
 
 const createFolderInCurrent = async () => {
 	// Show the community plus enrollment modal if the user is in a community plan
-	if (isCommunity.value && canUserRegisterCommunityPlus.value) {
+	if (isSelfHostedDeployment.value && canUserRegisterCommunityPlus.value) {
 		uiStore.openModalWithData({
 			name: COMMUNITY_PLUS_ENROLLMENT_MODAL,
 			data: { customHeading: i18n.baseText('folders.registeredCommunity.cta.heading') },
@@ -1125,7 +1126,7 @@ const moveWorkflowToFolder = async (payload: {
 	name: string;
 	parentFolderId?: string;
 }) => {
-	if (isCommunity.value && canUserRegisterCommunityPlus.value) {
+	if (isSelfHostedDeployment.value && canUserRegisterCommunityPlus.value) {
 		uiStore.openModalWithData({
 			name: COMMUNITY_PLUS_ENROLLMENT_MODAL,
 			data: { customHeading: i18n.baseText('folders.registeredCommunity.cta.heading') },

--- a/packages/frontend/editor-ui/src/views/WorkflowsView.vue
+++ b/packages/frontend/editor-ui/src/views/WorkflowsView.vue
@@ -1043,8 +1043,8 @@ const renameFolder = async (folderId: string) => {
 };
 
 const createFolderInCurrent = async () => {
-	// Show the community plus enrollment modal if the user is in a community plan
-	if (isSelfHostedDeployment.value && canUserRegisterCommunityPlus.value) {
+	// Show the community plus enrollment modal if the user is self-hosted, and hasn't enabled folders
+	if (isSelfHostedDeployment.value && !foldersEnabled.value && canUserRegisterCommunityPlus.value) {
 		uiStore.openModalWithData({
 			name: COMMUNITY_PLUS_ENROLLMENT_MODAL,
 			data: { customHeading: i18n.baseText('folders.registeredCommunity.cta.heading') },


### PR DESCRIPTION
## Summary

We were checking for `usageStore.planName`, which is set with the value from  GET `/license`, to determine if the user is on a self hosted deployment, but no matter what the deployment type is we always return planName as `community`. You can see the check [here](https://github.com/n8n-io/n8n/blob/5bf10cdb4abe364a8f914362fb94841530aa02c9/packages/cli/src/license.ts#L373), that we look for the planName in the license and if not found we default to community. 

Conclusion its that we are likely not setting the planName as a feature in cloud.

Below a prod trailing instance.

![CleanShot 2025-03-24 at 18 20 14@2x](https://github.com/user-attachments/assets/49a891db-7051-41c6-867d-a8bbc7ae318e)

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
