### PR TITLE
feat(HTTP Request Node): Adds split out field option

### DIFF
--- a/packages/nodes-base/nodes/HttpRequest/V3/Description.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/Description.ts
@@ -901,6 +901,14 @@ export const mainProperties: INodeProperties[] = [
 								description:
 									'Name of the binary property to which to write the data of the read file',
 							},
+							{
+								displayName: 'Field to Split Out',
+								name: 'fieldsToSplitOut',
+								type: 'string',
+								default: '',
+								description:
+									'Name of a field in the response to return as individual items. If the specified field contains an array, each array item will be output as a separate item.',
+							},
 						],
 					},
 				],

--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -1056,7 +1056,7 @@ export class HttpRequestV3 implements INodeType {
 		) {
 			this.addExecutionHints({
 				message:
-					'To split the contents of "data" into separate items for easier processing, set the "Field to Split Out" option or use an additional "Split Out Items" node.',
+					'To split the contents of "data" into separate items for easier processing, set the "Field to Split Out" option or use an additional "Split Out" node.',
 				location: 'outputPane',
 			});
 		}

--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -996,14 +996,67 @@ export class HttpRequestV3 implements INodeType {
 
 		returnItems = returnItems.map(replaceNullValues);
 
-		if (
+		const fieldsToSplitOut = this.getNodeParameter(
+			'options.response.response.fieldsToSplitOut',
+			0,
+			'',
+		) as string;
+
+		if (fieldsToSplitOut && fieldsToSplitOut.trim() !== '') {
+			const newReturnItems: INodeExecutionData[] = [];
+			let fieldFound = false;
+
+			for (const item of returnItems) {
+				if (
+					item.json &&
+					item.json[fieldsToSplitOut] !== undefined &&
+					item.json[fieldsToSplitOut] !== null
+				) {
+					fieldFound = true;
+					const fieldValue = item.json[fieldsToSplitOut];
+
+					if (Array.isArray(fieldValue)) {
+						for (const element of fieldValue) {
+							newReturnItems.push({
+								json: typeof element === 'object' ? element : { value: element },
+								pairedItem: item.pairedItem,
+								binary: item.binary,
+							} as INodeExecutionData);
+						}
+					} else if (typeof fieldValue === 'object') {
+						newReturnItems.push({
+							json: fieldValue,
+							pairedItem: item.pairedItem,
+							binary: item.binary,
+						} as INodeExecutionData);
+					} else {
+						newReturnItems.push({
+							json: { value: fieldValue },
+							pairedItem: item.pairedItem,
+							binary: item.binary,
+						});
+					}
+				} else {
+					newReturnItems.push(item);
+				}
+			}
+
+			returnItems = newReturnItems;
+
+			if (!fieldFound) {
+				this.addExecutionHints({
+					message: `The field "${fieldsToSplitOut}" to split out was not found in the response. Check the field name and response structure.`,
+					location: 'outputPane',
+				});
+			}
+		} else if (
 			returnItems.length === 1 &&
 			returnItems[0].json.data &&
 			Array.isArray(returnItems[0].json.data)
 		) {
 			this.addExecutionHints({
 				message:
-					'To split the contents of ‘data’ into separate items for easier processing, add a ‘Split Out’ node after this one',
+					'To split the contents of "data" into separate items for easier processing, set the "Field to Split Out" option or use an additional "Split Out Items" node.',
 				location: 'outputPane',
 			});
 		}


### PR DESCRIPTION
## Summary

This PR adds a simple `Field to Split Out` option to make it easier for users to return selected data from nested API responses. Instead of requiring a separate `Split Out` node, users can now directly return the items from a specific field from the HTTP response. For more complex splitting a separate `Split Out` node after the HTTP node is still recommended. 

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
