### PR TITLE
fix(editor): Fix folders UI for different plans (no-changelog)

### DIFF
--- a/cypress/composables/folders.ts
+++ b/cypress/composables/folders.ts
@@ -212,6 +212,11 @@ export function getNewFolderNameInput() {
 export function getNewFolderModalErrorMessage() {
 	return cy.get('.el-message-box__errormsg').filter(':visible');
 }
+
+export function getProjectTab(tabId: string) {
+	return cy.getByTestId('project-tabs').find(`#${tabId}`);
+}
+
 /**
  * Actions
  */

--- a/cypress/e2e/49-folders.cy.ts
+++ b/cypress/e2e/49-folders.cy.ts
@@ -32,6 +32,7 @@ import {
 	getPersonalProjectMenuItem,
 	getProjectEmptyState,
 	getProjectMenuItem,
+	getProjectTab,
 	getVisibleListBreadcrumbs,
 	getWorkflowCard,
 	getWorkflowCardBreadcrumbs,
@@ -217,6 +218,10 @@ describe('Folders', () => {
 			cy.getByTestId('action-folder').should('exist');
 			createFolderFromProjectHeader('Personal Folder');
 			getFolderCards().should('exist');
+			// Create folder option should not be available on credentials tab
+			getProjectTab('ProjectsCredentials').click();
+			getAddResourceDropdown().click();
+			cy.getByTestId('action-folder').should('not.exist');
 		});
 	});
 

--- a/cypress/e2e/49-folders.cy.ts
+++ b/cypress/e2e/49-folders.cy.ts
@@ -64,7 +64,7 @@ describe('Folders', () => {
 	});
 
 	describe('Create and navigate folders', () => {
-		it.only('should create folder from the project header', () => {
+		it('should create folder from the project header', () => {
 			// 1. In project root
 			getPersonalProjectMenuItem().click();
 			createFolderFromProjectHeader('My Folder');

--- a/cypress/e2e/49-folders.cy.ts
+++ b/cypress/e2e/49-folders.cy.ts
@@ -64,13 +64,17 @@ describe('Folders', () => {
 	});
 
 	describe('Create and navigate folders', () => {
-		it('should create folder from the project header', () => {
+		it.only('should create folder from the project header', () => {
+			// 1. In project root
 			getPersonalProjectMenuItem().click();
 			createFolderFromProjectHeader('My Folder');
 			getFolderCards().should('have.length.greaterThan', 0);
 			// Clicking on the success toast should navigate to the folder
 			successToast().find('a').click();
 			getCurrentBreadcrumb().should('contain.text', 'My Folder');
+			// 2. In a folder
+			createFolderFromListHeaderButton('My Folder 2');
+			getFolderCard('My Folder 2').should('exist');
 		});
 
 		it('should not allow illegal folder names', () => {

--- a/packages/frontend/editor-ui/src/components/Projects/ProjectHeader.vue
+++ b/packages/frontend/editor-ui/src/components/Projects/ProjectHeader.vue
@@ -61,7 +61,10 @@ const showSettings = computed(
 const homeProject = computed(() => projectsStore.currentProject ?? projectsStore.personalProject);
 
 const showFolders = computed(() => {
-	return settingsStore.isFoldersFeatureEnabled && route.name == VIEWS.PROJECTS_WORKFLOWS;
+	return (
+		settingsStore.isFoldersFeatureEnabled &&
+		[VIEWS.PROJECTS_WORKFLOWS, VIEWS.PROJECTS_FOLDERS].includes(route.name as VIEWS)
+	);
 });
 
 const ACTION_TYPES = {

--- a/packages/frontend/editor-ui/src/components/Projects/ProjectHeader.vue
+++ b/packages/frontend/editor-ui/src/components/Projects/ProjectHeader.vue
@@ -61,7 +61,7 @@ const showSettings = computed(
 const homeProject = computed(() => projectsStore.currentProject ?? projectsStore.personalProject);
 
 const showFolders = computed(() => {
-	return settingsStore.isFoldersFeatureEnabled && route.name !== VIEWS.WORKFLOWS;
+	return settingsStore.isFoldersFeatureEnabled && route.name == VIEWS.PROJECTS_WORKFLOWS;
 });
 
 const ACTION_TYPES = {

--- a/packages/frontend/editor-ui/src/views/WorkflowsView.vue
+++ b/packages/frontend/editor-ui/src/views/WorkflowsView.vue
@@ -1231,13 +1231,13 @@ const onCreateWorkflowClick = () => {
 				/>
 			</ProjectHeader>
 		</template>
-		<template v-if="foldersEnabled" #add-button>
+		<template v-if="foldersEnabled || showRegisteredCommunityCTA" #add-button>
 			<N8nTooltip
 				placement="top"
 				:disabled="!(isOverviewPage || (!readOnlyEnv && hasPermissionToCreateFolders))"
 			>
 				<template #content>
-					<span v-if="isOverviewPage">
+					<span v-if="isOverviewPage && !showRegisteredCommunityCTA">
 						<span v-if="teamProjectsEnabled">
 							{{ i18n.baseText('folders.add.overview.withProjects.message') }}
 						</span>
@@ -1245,7 +1245,7 @@ const onCreateWorkflowClick = () => {
 							{{ i18n.baseText('folders.add.overview.community.message') }}
 						</span>
 					</span>
-					<span v-else-if="!readOnlyEnv && hasPermissionToCreateFolders">
+					<span v-else>
 						{{
 							currentParentName
 								? i18n.baseText('folders.add.to.parent.message', {
@@ -1261,7 +1261,7 @@ const onCreateWorkflowClick = () => {
 					type="tertiary"
 					data-test-id="add-folder-button"
 					:class="$style['add-folder-button']"
-					:disabled="readOnlyEnv || !hasPermissionToCreateFolders"
+					:disabled="!showRegisteredCommunityCTA && (readOnlyEnv || !hasPermissionToCreateFolders)"
 					@click="createFolderInCurrent"
 				/>
 			</N8nTooltip>


### PR DESCRIPTION
## Summary
1. Showing `Create Folder` option from project header only in `Workflows` tab
2. Showing `Create Folder` button that opens register CTA in overview for community plan 

## How to test:
1. Test locally with community license: `Create folder` button should be in the overview page next to filters and should show register modal
2. Switch to registered community (or [other license](https://www.notion.so/n8n/Manual-Testing-b46e9bd44b7c49dcb2fdb88108f8ca83?pvs=4#38c868a72de249879a3c31d8e97e3583) with feature enabled): Button should be there and work as expected


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
