### PR TITLE
fix(editor): Change freeAiCredits success text size

### DIFF
--- a/packages/frontend/editor-ui/src/components/FreeAiCreditsCallout.vue
+++ b/packages/frontend/editor-ui/src/components/FreeAiCreditsCallout.vue
@@ -111,14 +111,14 @@ const onClaimCreditsClicked = async () => {
 			</template>
 		</n8n-callout>
 		<n8n-callout v-else-if="showSuccessCallout" theme="success" icon="check-circle">
-			<n8n-text>
+			<n8n-text size="small">
 				{{
 					i18n.baseText('freeAi.credits.callout.success.title.part1', {
 						interpolate: { credits: settingsStore.aiCreditsQuota },
 					})
 				}}</n8n-text
 			>&nbsp;
-			<n8n-text :bold="true">
+			<n8n-text size="small" bold="true">
 				{{ i18n.baseText('freeAi.credits.callout.success.title.part2') }}</n8n-text
 			>
 		</n8n-callout>


### PR DESCRIPTION
## Summary

Make the success text smaller. Super annoying to test.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3369/bug-freeaicreditscallout-text-size
notion page for test instructions - though I'd advise skipping here, simple change, not worth the effort: https://www.notion.so/n8n/Free-AI-credits-1565b6e0c94f8074b254da8db0fb6219


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
