### PR TITLE
fix: Support relative tsconfig paths on multiple levels in jest config (no-changelog)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
-const { compilerOptions } = require('./tsconfig.json');
+const { pathsToModuleNameMapper } = require('ts-jest')
+const { compilerOptions } = require('get-tsconfig').getTsconfig().config;
 
 /** @type {import('ts-jest').TsJestGlobalOptions} */
 const tsJestOptions = {
@@ -10,7 +11,6 @@ const tsJestOptions = {
 	},
 };
 
-const { baseUrl, paths } = require('get-tsconfig').getTsconfig().config?.compilerOptions;
 
 const isCoverageEnabled = process.env.COVERAGE_ENABLED === 'true';
 
@@ -24,15 +24,7 @@ const config = {
 		'^.+\\.ts$': ['ts-jest', tsJestOptions],
 	},
 	// This resolve the path mappings from the tsconfig relative to each jest.config.js
-	moduleNameMapper: Object.entries(paths || {}).reduce((acc, [path, [mapping]]) => {
-		path = `^${path.replace(/\/\*$/, '/(.*)$')}`;
-		mapping = mapping.replace(/^\.?\.\/(?:(.*)\/)?\*$/, '$1');
-		mapping = mapping ? `/${mapping}` : '';
-		acc[path] = mapping.startsWith('/test')
-			? '<rootDir>' + mapping + '/$1'
-			: '<rootDir>' + (baseUrl ? `/${baseUrl.replace(/^\.\//, '')}` : '') + mapping + '/$1';
-		return acc;
-	}, {}),
+	moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, { prefix: `<rootDir>${compilerOptions.baseUrl ? `/${compilerOptions.baseUrl}` : ''}` }),
 	setupFilesAfterEnv: ['jest-expect-message'],
 	collectCoverage: isCoverageEnabled,
 	coverageReporters: ['text-summary', 'lcov', 'html-spa'],

--- a/jest.config.js
+++ b/jest.config.js
@@ -24,7 +24,7 @@ const config = {
 		'^.+\\.ts$': ['ts-jest', tsJestOptions],
 	},
 	// This resolve the path mappings from the tsconfig relative to each jest.config.js
-	moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, { prefix: `<rootDir>${compilerOptions.baseUrl ? `/${compilerOptions.baseUrl}` : ''}` }),
+	moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, { prefix: `<rootDir>${compilerOptions.baseUrl ? `/${compilerOptions.baseUrl.replace(/^\.\//, '')}` : ''}` }),
 	setupFilesAfterEnv: ['jest-expect-message'],
 	collectCoverage: isCoverageEnabled,
 	coverageReporters: ['text-summary', 'lcov', 'html-spa'],


### PR DESCRIPTION
## Summary

The current in-house implementation of the `moduleNameMapper` only supports `./` and `../` in `tsconfig.compilerOptions.paths`. 

This PR makes use of the `pathsToModuleNameMapper` provided by `ts-jest` for mapping.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
