### PR TITLE
feat(Telegram Trigger Node): Add options to restrict to chat and user IDs

### DIFF
--- a/packages/nodes-base/nodes/Telegram/IEvent.ts
+++ b/packages/nodes-base/nodes/Telegram/IEvent.ts
@@ -10,6 +10,12 @@ interface EventBody {
 	video?: {
 		file_id: string;
 	};
+	chat?: {
+		id: number;
+	};
+	from?: {
+		id: number;
+	};
 }
 
 export interface IEvent {

--- a/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
+++ b/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
@@ -18,8 +18,8 @@ export class TelegramTrigger implements INodeType {
 		name: 'telegramTrigger',
 		icon: 'file:telegram.svg',
 		group: ['trigger'],
-		version: [1, 1.1],
-		defaultVersion: 1.1,
+		version: [1, 1.1, 1.2],
+		defaultVersion: 1.2,
 		subtitle: '=Updates: {{$parameter["updates"].join(", ")}}',
 		description: 'Starts the workflow on a Telegram update',
 		defaults: {
@@ -167,6 +167,32 @@ export class TelegramTrigger implements INodeType {
 						],
 						default: 'large',
 						description: 'The size of the image to be downloaded',
+					},
+					{
+						displayName: 'Restrict to Chat IDs',
+						name: 'chatIds',
+						type: 'string',
+						default: '',
+						description:
+							'The chat IDs to restrict the trigger to. Multiple can be defined separated by comma.',
+						displayOptions: {
+							show: {
+								'@version': [{ _cnd: { gte: 1.1 } }],
+							},
+						},
+					},
+					{
+						displayName: 'Restrict to User IDs',
+						name: 'userIds',
+						type: 'string',
+						default: '',
+						description:
+							'The user IDs to restrict the trigger to. Multiple can be defined separated by comma.',
+						displayOptions: {
+							show: {
+								'@version': [{ _cnd: { gte: 1.1 } }],
+							},
+						},
 					},
 				],
 			},
@@ -330,6 +356,24 @@ export class TelegramTrigger implements INodeType {
 						],
 					],
 				};
+			}
+		}
+
+		if (nodeVersion >= 1.2) {
+			if (additionalFields.chatIds) {
+				const chatIds = additionalFields.chatIds as string;
+				const splitIds = chatIds.split(',').map((chatId) => chatId.trim());
+				if (!splitIds.includes(String(bodyData.message?.chat?.id))) {
+					return {};
+				}
+			}
+
+			if (additionalFields.userIds) {
+				const userIds = additionalFields.userIds as string;
+				const splitIds = userIds.split(',').map((userId) => userId.trim());
+				if (!splitIds.includes(String(bodyData.message?.from?.id))) {
+					return {};
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary
Adds 2 options to the Telegram Trigger node so that triggers can only be executed by specified chat / user IDs, These can be comma separated to include multiple options.

![image](https://github.com/user-attachments/assets/a3a124bc-6a4d-4c2f-85b1-ed7cf7b81813)

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-2610/telegram-trigger-restrict-user-chat-ids

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
