### PR TITLE
feat(API): Add day to week compaction for insights dashboard

### DIFF
--- a/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
@@ -579,7 +579,6 @@ describe('compaction', () => {
 		])('$name', async ({ periodStarts, batches }) => {
 			// ARRANGE
 			const insightsService = Container.get(InsightsService);
-			const insightsRawRepository = Container.get(InsightsRawRepository);
 			const insightsByPeriodRepository = Container.get(InsightsByPeriodRepository);
 
 			const project = await createTeamProject();

--- a/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
@@ -607,6 +607,114 @@ describe('compaction', () => {
 				expect(compacted.value).toBe(batches[index]);
 			}
 		});
+
+		test('recent insight periods should not be compacted', async () => {
+			// ARRANGE
+			const insightsService = Container.get(InsightsService);
+
+			const project = await createTeamProject();
+			const workflow = await createWorkflow({}, project);
+			// create before so we can create the raw events in parallel
+			await createMetadata(workflow);
+			await createCompactedInsightsEvent(workflow, {
+				type: 'success',
+				value: 1,
+				periodUnit: 'hour',
+				periodStart: DateTime.utc().minus({ day: 79 }).startOf('hour'),
+			});
+
+			// ACT
+			const compactedRows = await insightsService.compactHourToDay();
+
+			// ASSERT
+			expect(compactedRows).toBe(0);
+		});
+	});
+
+	describe('compactDayToWeek', () => {
+		type TestData = {
+			name: string;
+			periodStarts: DateTime[];
+			batches: number[];
+		};
+
+		test.each<TestData>([
+			{
+				name: 'compact into 2 rows',
+				periodStarts: [
+					// 2000-01-03 is a Monday
+					DateTime.utc(2000, 1, 3, 0, 0),
+					DateTime.utc(2000, 1, 5, 23, 59),
+					DateTime.utc(2000, 1, 11, 1, 0),
+				],
+				batches: [2, 1],
+			},
+			{
+				name: 'compact into 3 rows',
+				periodStarts: [
+					// 2000-01-03 is a Monday
+					DateTime.utc(2000, 1, 3, 0, 0),
+					DateTime.utc(2000, 1, 4, 23, 59),
+					DateTime.utc(2000, 1, 11, 0, 0),
+					DateTime.utc(2000, 1, 12, 23, 59),
+					DateTime.utc(2000, 1, 18, 23, 59),
+				],
+				batches: [2, 2, 1],
+			},
+		])('$name', async ({ periodStarts, batches }) => {
+			// ARRANGE
+			const insightsService = Container.get(InsightsService);
+			const insightsRawRepository = Container.get(InsightsRawRepository);
+			const insightsByPeriodRepository = Container.get(InsightsByPeriodRepository);
+
+			const project = await createTeamProject();
+			const workflow = await createWorkflow({}, project);
+			// create before so we can create the raw events in parallel
+			await createMetadata(workflow);
+			for (const periodStart of periodStarts) {
+				await createCompactedInsightsEvent(workflow, {
+					type: 'success',
+					value: 1,
+					periodUnit: 'day',
+					periodStart,
+				});
+			}
+
+			// ACT
+			const compactedRows = await insightsService.compactDayToWeek();
+
+			// ASSERT
+			expect(compactedRows).toBe(periodStarts.length);
+			await expect(insightsRawRepository.count()).resolves.toBe(0);
+			const allCompacted = await insightsByPeriodRepository.find({ order: { periodStart: 1 } });
+			expect(allCompacted).toHaveLength(batches.length);
+			for (const [index, compacted] of allCompacted.entries()) {
+				expect(compacted.periodStart.getDay()).toBe(1);
+				expect(compacted.value).toBe(batches[index]);
+			}
+		});
+
+		test('recent insight periods should not be compacted', async () => {
+			// ARRANGE
+			const insightsService = Container.get(InsightsService);
+
+			const project = await createTeamProject();
+			const workflow = await createWorkflow({}, project);
+			// create before so we can create the raw events in parallel
+			await createMetadata(workflow);
+			await createCompactedInsightsEvent(workflow, {
+				type: 'success',
+				value: 1,
+				periodUnit: 'day',
+				periodStart: DateTime.utc().minus({ day: 179 }).startOf('day'),
+			});
+
+			// ACT
+			const compactedRows = await insightsService.compactDayToWeek();
+
+			// ASSERT
+			expect(compactedRows).toBe(0);
+		});
 	});
 });
 

--- a/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
@@ -600,7 +600,10 @@ describe('compaction', () => {
 
 			// ASSERT
 			expect(compactedRows).toBe(periodStarts.length);
-			await expect(insightsRawRepository.count()).resolves.toBe(0);
+			const hourInsights = (await insightsByPeriodRepository.find()).filter(
+				(insight) => insight.periodUnit !== 'day',
+			);
+			expect(hourInsights).toBeEmptyArray();
 			const allCompacted = await insightsByPeriodRepository.find({ order: { periodStart: 1 } });
 			expect(allCompacted).toHaveLength(batches.length);
 			for (const [index, compacted] of allCompacted.entries()) {
@@ -684,10 +687,10 @@ describe('compaction', () => {
 
 			// ASSERT
 			expect(compactedRows).toBe(periodStarts.length);
-			const hourInsights = (await insightsByPeriodRepository.find()).filter(
-				(insight) => insight.periodUnit === 'hour',
+			const hourAndDayInsights = (await insightsByPeriodRepository.find()).filter(
+				(insight) => insight.periodUnit !== 'week',
 			);
-			expect(hourInsights).toBeEmptyArray();
+			expect(hourAndDayInsights).toBeEmptyArray();
 			const allCompacted = await insightsByPeriodRepository.find({ order: { periodStart: 1 } });
 			expect(allCompacted).toHaveLength(batches.length);
 			for (const [index, compacted] of allCompacted.entries()) {

--- a/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
+++ b/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
@@ -32,7 +32,9 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 	}
 
 	private getPeriodFilterExpr(periodUnit: PeriodUnit) {
+		// filter out data older than 90 days for hourly insights and 180 days for daily
 		const daysAgo = periodUnit === 'hour' ? 90 : 180;
+
 		// Database-specific period start expression to filter out data to compact by days matching the periodUnit
 		let periodStartExpr = `date('now', '-${daysAgo} days')`;
 		if (dbType === 'postgresdb') {
@@ -101,7 +103,7 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 	async compactSourceDataIntoInsightPeriod({
 		sourceBatchQuery, // Query to get batch source data. Must return those fields: 'id', 'metaId', 'type', 'periodStart', 'value'
 		sourceTableName = this.metadata.tableName, // Repository references for table operations
-		periodUnit,
+		periodUnit, // the new period unit to compact the data into
 	}: {
 		sourceBatchQuery: string;
 		sourceTableName?: string;

--- a/packages/cli/src/modules/insights/database/repositories/insights-raw.repository.ts
+++ b/packages/cli/src/modules/insights/database/repositories/insights-raw.repository.ts
@@ -11,7 +11,14 @@ export class InsightsRawRepository extends Repository<InsightsRaw> {
 
 	getRawInsightsBatchQuery(compactionBatchSize: number) {
 		// Build the query to gather raw insights data for the batch
-		const batchQuery = this.createQueryBuilder()
+		const batchQuery = this.manager
+			.createQueryBuilder<{
+				id: number;
+				metaId: number;
+				type: string;
+				value: number;
+				periodStart: Date;
+			}>(InsightsRaw, 'insightsRaw')
 			.select(
 				['id', 'metaId', 'type', 'value'].map((fieldName) =>
 					this.manager.connection.driver.escape(fieldName),
@@ -20,6 +27,7 @@ export class InsightsRawRepository extends Repository<InsightsRaw> {
 			.addSelect('timestamp', 'periodStart')
 			.orderBy('timestamp', 'ASC')
 			.limit(compactionBatchSize);
+
 		return batchQuery;
 	}
 }

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -168,7 +168,7 @@ export class InsightsService {
 		// Compact daily data to weekly aggregates
 		do {
 			numberOfCompactedDayData = await this.compactDayToWeek();
-		} while (numberOfCompactedHourData > 0);
+		} while (numberOfCompactedDayData > 0);
 	}
 
 	// Compacts raw data to hourly aggregates

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -195,7 +195,7 @@ export class InsightsService {
 		const batchQuery = this.insightsByPeriodRepository.getPeriodInsightsBatchQuery({
 			periodUnitToCompactFrom: 'hour',
 			compactionBatchSize: config.compactionBatchSize,
-			nbDaysAgo: this.maxAgeInDaysForHourlyData,
+			maxAgeInDays: this.maxAgeInDaysForHourlyData,
 		});
 
 		return await this.insightsByPeriodRepository.compactSourceDataIntoInsightPeriod({
@@ -210,7 +210,7 @@ export class InsightsService {
 		const batchQuery = this.insightsByPeriodRepository.getPeriodInsightsBatchQuery({
 			periodUnitToCompactFrom: 'day',
 			compactionBatchSize: config.compactionBatchSize,
-			nbDaysAgo: this.maxAgeInDaysForDailyData,
+			maxAgeInDays: this.maxAgeInDaysForDailyData,
 		});
 
 		return await this.insightsByPeriodRepository.compactSourceDataIntoInsightPeriod({

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -163,6 +163,12 @@ export class InsightsService {
 		do {
 			numberOfCompactedHourData = await this.compactHourToDay();
 		} while (numberOfCompactedHourData > 0);
+
+		let numberOfCompactedDayData: number;
+		// Compact daily data to weekly aggregates
+		do {
+			numberOfCompactedDayData = await this.compactDayToWeek();
+		} while (numberOfCompactedHourData > 0);
 	}
 
 	// Compacts raw data to hourly aggregates
@@ -193,8 +199,20 @@ export class InsightsService {
 		});
 	}
 
-	// TODO: add return type once rebased on master and InsightsSummary is
-	// available
+	// Compacts daily data to weekly aggregates
+	async compactDayToWeek() {
+		// get hour data query for batching
+		const batchQuery = this.insightsByPeriodRepository.getPeriodInsightsBatchQuery(
+			'day',
+			config.compactionBatchSize,
+		);
+
+		return await this.insightsByPeriodRepository.compactSourceDataIntoInsightPeriod({
+			sourceBatchQuery: batchQuery.getSql(),
+			periodUnit: 'week',
+		});
+	}
+
 	async getInsightsSummary(): Promise<InsightsSummary> {
 		const rows = await this.insightsByPeriodRepository.getPreviousAndCurrentPeriodTypeAggregates();
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR adds a new layer of compaction of the insights data, transforming the hourly insights into aggregated weekly ones. This is to prevent insights data storage size to grow linearly with time.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2699/day-to-week-compaction

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [X] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [X] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
