### PR TITLE
ci: Timing test for blacksmith in e2e (no-changelog)

### DIFF
--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -83,13 +83,13 @@ jobs:
 
       - name: Cache build artifacts
         id: cache-build-artifacts
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        uses: useblacksmith/cache@c5fe29eb0efdf1cf4186b9f7fcbbcbc0cf025662 # v5
         with:
           path: |
             /home/runner/.cache/Cypress
             /github/home/.pnpm-store
             ./packages/**/dist
-          key: ${{ github.sha }}:build-artifacts
+          key: ${{ github.sha }}-base:build
 
       - name: Install dependencies
         if: steps.cache-build-artifacts.outputs.cache-hit != 'true'
@@ -111,7 +111,7 @@ jobs:
 
 
   testing:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     needs: ['prepare', 'install']
     strategy:
       fail-fast: false
@@ -134,13 +134,13 @@ jobs:
 
       - name: Restore cached pnpm modules
         id: cache-build-artifacts
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        uses: useblacksmith/cache@c5fe29eb0efdf1cf4186b9f7fcbbcbc0cf025662 # v5
         with:
           path: |
             /home/runner/.cache/Cypress
             /github/home/.pnpm-store
             ./packages/**/dist
-          key: ${{ github.sha }}:build-artifacts
+          key: ${{ github.sha }}-base:build
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/units-tests-reusable.yml
+++ b/.github/workflows/units-tests-reusable.yml
@@ -38,7 +38,7 @@ on:
 jobs:
   unit-test:
     name: Unit tests
-    runs-on: blacksmith-2vcpu-ubuntu-2204
+    runs-on: blacksmith-4vcpu-ubuntu-2204
     env:
       TURBO_FORCE: ${{ inputs.ignoreTurboCache }}
       COVERAGE_ENABLED: ${{ inputs.collectCoverage }}


### PR DESCRIPTION
## Summary

Switches the e2e tests to use the Blacksmith runners.
Also reuses the earlier cache built by the unit tests.

Changes the unit tests to use a 4 core blacksmith runner

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-724/ci-improve-ci-timings-part-2

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
