### PR TITLE
fix(Basic LLM Chain Node): Prevent incorrect wrapping of output

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
@@ -34,7 +34,7 @@ export class ChainLlm implements INodeType {
 		icon: 'fa:link',
 		iconColor: 'black',
 		group: ['transform'],
-		version: [1, 1.1, 1.2, 1.3, 1.4, 1.5],
+		version: [1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6],
 		description: 'A simple chain to prompt a large language model',
 		defaults: {
 			name: 'Basic LLM Chain',
@@ -119,7 +119,7 @@ export class ChainLlm implements INodeType {
 				// Process each response and add to return data
 				responses.forEach((response) => {
 					returnData.push({
-						json: formatResponse(response),
+						json: formatResponse(response, this.getNode().typeVersion),
 					});
 				});
 			} catch (error) {

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/chainExecutor.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/chainExecutor.ts
@@ -1,5 +1,6 @@
 import type { BaseLanguageModel } from '@langchain/core/language_models/base';
-import { StringOutputParser } from '@langchain/core/output_parsers';
+import type { BaseLLMOutputParser } from '@langchain/core/output_parsers';
+import { JsonOutputParser, StringOutputParser } from '@langchain/core/output_parsers';
 import type { ChatPromptTemplate, PromptTemplate } from '@langchain/core/prompts';
 import type { IExecuteFunctions } from 'n8n-workflow';
 
@@ -7,6 +8,41 @@ import { getTracingConfig } from '@utils/tracing';
 
 import { createPromptTemplate } from './promptUtils';
 import type { ChainExecutionParams } from './types';
+
+/**
+ * Type guard to check if the LLM has a modelKwargs property(OpenAI)
+ */
+export function isModelWithResponseFormat(
+	llm: BaseLanguageModel,
+): llm is BaseLanguageModel & { modelKwargs: { response_format: { type: string } } } {
+	return 'modelKwargs' in llm && !!llm.modelKwargs && typeof llm.modelKwargs === 'object';
+}
+
+/**
+ * Type guard to check if the LLM has a format property(Ollama)
+ */
+export function isModelWithFormat(
+	llm: BaseLanguageModel,
+): llm is BaseLanguageModel & { format: string } {
+	return 'format' in llm && typeof llm.format !== 'undefined';
+}
+
+/**
+ * Determines if an LLM is configured to output JSON and returns the appropriate output parser
+ */
+export function getOutputParserForLLM(
+	llm: BaseLanguageModel,
+): BaseLLMOutputParser<string | Record<string, unknown>> {
+	if (isModelWithResponseFormat(llm) && llm.modelKwargs?.response_format?.type === 'json_object') {
+		return new JsonOutputParser();
+	}
+
+	if (isModelWithFormat(llm) && llm.format === 'json') {
+		return new JsonOutputParser();
+	}
+
+	return new StringOutputParser();
+}
 
 /**
  * Creates a simple chain for LLMs without output parsers
@@ -21,11 +57,10 @@ async function executeSimpleChain({
 	llm: BaseLanguageModel;
 	query: string;
 	prompt: ChatPromptTemplate | PromptTemplate;
-}): Promise<string[]> {
-	const chain = prompt
-		.pipe(llm)
-		.pipe(new StringOutputParser())
-		.withConfig(getTracingConfig(context));
+}) {
+	const outputParser = getOutputParserForLLM(llm);
+
+	const chain = prompt.pipe(llm).pipe(outputParser).withConfig(getTracingConfig(context));
 
 	// Execute the chain
 	const response = await chain.invoke({

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/chainExecutor.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/chainExecutor.ts
@@ -15,7 +15,12 @@ import type { ChainExecutionParams } from './types';
 export function isModelWithResponseFormat(
 	llm: BaseLanguageModel,
 ): llm is BaseLanguageModel & { modelKwargs: { response_format: { type: string } } } {
-	return 'modelKwargs' in llm && !!llm.modelKwargs && typeof llm.modelKwargs === 'object';
+	return (
+		'modelKwargs' in llm &&
+		!!llm.modelKwargs &&
+		typeof llm.modelKwargs === 'object' &&
+		'response_format' in llm.modelKwargs
+	);
 }
 
 /**

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/responseFormatter.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/responseFormatter.ts
@@ -3,12 +3,10 @@ import type { IDataObject } from 'n8n-workflow';
 /**
  * Formats the response from the LLM chain into a consistent structure
  */
-export function formatResponse(response: unknown): IDataObject {
+export function formatResponse(response: unknown, version: number): IDataObject {
 	if (typeof response === 'string') {
 		return {
-			response: {
-				text: response.trim(),
-			},
+			text: response.trim(),
 		};
 	}
 
@@ -19,7 +17,13 @@ export function formatResponse(response: unknown): IDataObject {
 	}
 
 	if (response instanceof Object) {
-		return response as IDataObject;
+		if (version >= 1.6) {
+			return response as IDataObject;
+		}
+
+		return {
+			text: JSON.stringify(response),
+		};
 	}
 
 	return {

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/chainExecutor.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/chainExecutor.test.ts
@@ -1,4 +1,5 @@
-import { StringOutputParser } from '@langchain/core/output_parsers';
+import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
+import { JsonOutputParser, StringOutputParser } from '@langchain/core/output_parsers';
 import { ChatPromptTemplate, PromptTemplate } from '@langchain/core/prompts';
 import { FakeLLM, FakeChatModel } from '@langchain/core/utils/testing';
 import { mock } from 'jest-mock-extended';
@@ -8,6 +9,7 @@ import type { N8nOutputParser } from '@utils/output_parsers/N8nOutputParser';
 import * as tracing from '@utils/tracing';
 
 import { executeChain } from '../methods/chainExecutor';
+import * as chainExecutor from '../methods/chainExecutor';
 import * as promptUtils from '../methods/promptUtils';
 
 jest.mock('@utils/tracing', () => ({
@@ -25,6 +27,41 @@ describe('chainExecutor', () => {
 		mockContext = mock<IExecuteFunctions>();
 		mockContext.getExecutionCancelSignal = jest.fn().mockReturnValue(undefined);
 		jest.clearAllMocks();
+	});
+
+	describe('getOutputParserForLLM', () => {
+		it('should return JsonOutputParser for OpenAI-like models with json_object response format', () => {
+			const openAILikeModel = {
+				modelKwargs: {
+					response_format: {
+						type: 'json_object',
+					},
+				},
+			};
+
+			const parser = chainExecutor.getOutputParserForLLM(
+				openAILikeModel as unknown as BaseChatModel,
+			);
+			expect(parser).toBeInstanceOf(JsonOutputParser);
+		});
+
+		it('should return JsonOutputParser for Ollama models with json format', () => {
+			const ollamaLikeModel = {
+				format: 'json',
+			};
+
+			const parser = chainExecutor.getOutputParserForLLM(
+				ollamaLikeModel as unknown as BaseChatModel,
+			);
+			expect(parser).toBeInstanceOf(JsonOutputParser);
+		});
+
+		it('should return StringOutputParser for models without JSON format settings', () => {
+			const regularModel = new FakeLLM({});
+
+			const parser = chainExecutor.getOutputParserForLLM(regularModel);
+			expect(parser).toBeInstanceOf(StringOutputParser);
+		});
 	});
 
 	describe('executeChain', () => {
@@ -218,6 +255,78 @@ describe('chainExecutor', () => {
 			});
 
 			expect(result).toEqual(['Test chat response']);
+		});
+
+		it('should use JsonOutputParser for OpenAI models with json_object response format', async () => {
+			const fakeOpenAIModel = new FakeChatModel({});
+			(
+				fakeOpenAIModel as unknown as { modelKwargs: { response_format: { type: string } } }
+			).modelKwargs = {
+				response_format: { type: 'json_object' },
+			};
+
+			const mockPromptTemplate = new PromptTemplate({
+				template: '{query}',
+				inputVariables: ['query'],
+			});
+
+			const mockChain = {
+				invoke: jest.fn().mockResolvedValue('{"result": "json data"}'),
+			};
+
+			const withConfigMock = jest.fn().mockReturnValue(mockChain);
+			const pipeOutputParserMock = jest.fn().mockReturnValue({
+				withConfig: withConfigMock,
+			});
+
+			mockPromptTemplate.pipe = jest.fn().mockReturnValue({
+				pipe: pipeOutputParserMock,
+			});
+
+			(promptUtils.createPromptTemplate as jest.Mock).mockResolvedValue(mockPromptTemplate);
+
+			await executeChain({
+				context: mockContext,
+				itemIndex: 0,
+				query: 'Hello',
+				llm: fakeOpenAIModel,
+			});
+
+			expect(pipeOutputParserMock).toHaveBeenCalledWith(expect.any(JsonOutputParser));
+		});
+
+		it('should use JsonOutputParser for Ollama models with json format', async () => {
+			const fakeOllamaModel = new FakeChatModel({});
+			(fakeOllamaModel as unknown as { format: string }).format = 'json';
+
+			const mockPromptTemplate = new PromptTemplate({
+				template: '{query}',
+				inputVariables: ['query'],
+			});
+
+			const mockChain = {
+				invoke: jest.fn().mockResolvedValue('{"result": "json data"}'),
+			};
+
+			const withConfigMock = jest.fn().mockReturnValue(mockChain);
+			const pipeOutputParserMock = jest.fn().mockReturnValue({
+				withConfig: withConfigMock,
+			});
+
+			mockPromptTemplate.pipe = jest.fn().mockReturnValue({
+				pipe: pipeOutputParserMock,
+			});
+
+			(promptUtils.createPromptTemplate as jest.Mock).mockResolvedValue(mockPromptTemplate);
+
+			await executeChain({
+				context: mockContext,
+				itemIndex: 0,
+				query: 'Hello',
+				llm: fakeOllamaModel,
+			});
+
+			expect(pipeOutputParserMock).toHaveBeenCalledWith(expect.any(JsonOutputParser));
 		});
 	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/responseFormatter.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/responseFormatter.test.ts
@@ -5,36 +5,32 @@ describe('responseFormatter', () => {
 		it('should format string responses', () => {
 			const result = formatResponse('Test response');
 			expect(result).toEqual({
-				response: {
-					text: 'Test response',
-				},
+				text: 'Test response',
 			});
 		});
 
 		it('should trim string responses', () => {
-			const result = formatResponse('  Test response with whitespace   ');
+			const result = formatResponse('  Test response with whitespace   ', 1.6);
 			expect(result).toEqual({
-				response: {
-					text: 'Test response with whitespace',
-				},
+				text: 'Test response with whitespace',
 			});
 		});
 
 		it('should handle array responses', () => {
 			const testArray = [{ item: 1 }, { item: 2 }];
-			const result = formatResponse(testArray);
+			const result = formatResponse(testArray, 1.6);
 			expect(result).toEqual({ data: testArray });
 		});
 
 		it('should handle object responses', () => {
 			const testObject = { key: 'value', nested: { key: 'value' } };
-			const result = formatResponse(testObject);
+			const result = formatResponse(testObject, 1.6);
 			expect(result).toEqual(testObject);
 		});
 
 		it('should handle primitive non-string responses', () => {
 			const testNumber = 42;
-			const result = formatResponse(testNumber);
+			const result = formatResponse(testNumber, 1.6);
 			expect(result).toEqual({
 				response: {
 					text: 42,

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/responseFormatter.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/responseFormatter.test.ts
@@ -3,7 +3,7 @@ import { formatResponse } from '../methods/responseFormatter';
 describe('responseFormatter', () => {
 	describe('formatResponse', () => {
 		it('should format string responses', () => {
-			const result = formatResponse('Test response');
+			const result = formatResponse('Test response', 1.6);
 			expect(result).toEqual({
 				text: 'Test response',
 			});


### PR DESCRIPTION
## Summary

In the recent refactoring of the Basic LLM Chain (#13850), the output was inadvertently wrapped within an extra `response` object, breaking compatibility for workflows relying on the original node output structure.

This PR addresses this issue by:

- Removing the additional `response` wrapping, restoring the original output structure.
- Introducing improved JSON parsing capabilities for version 1.6+, enabling direct return of parsed JSON objects rather than stringified JSON strings.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
