### PR TITLE
fix(API): Summarize insights from current datetime instead of beginning of the day

### DIFF
--- a/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
+++ b/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
@@ -225,15 +225,15 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 				: dbType === 'postgresdb'
 					? sql`
 								SELECT
-								(CURRENT_DATE - INTERVAL '7 days')::timestamptz AS current_start,
-								CURRENT_DATE::timestamptz AS current_end,
-								(CURRENT_DATE - INTERVAL '14 days')::timestamptz AS previous_start
+								(NOW() - INTERVAL '7 days')::timestamptz AS current_start,
+								NOW()::timestamptz AS current_end,
+								(NOW() - INTERVAL '14 days')::timestamptz AS previous_start
 							`
 					: sql`
 								SELECT
-									DATE_SUB(CURDATE(), INTERVAL 7 DAY) AS current_start,
-									CURDATE() AS current_end,
-									DATE_SUB(CURDATE(), INTERVAL 14 DAY) AS previous_start
+									DATE_SUB(NOW(), INTERVAL 7 DAY) AS current_start,
+									NOW() AS current_end,
+									DATE_SUB(NOW(), INTERVAL 14 DAY) AS previous_start
 							`;
 
 		const rawRows = await this.createQueryBuilder('insights')


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR fixes the SQL query to compute insights summary for postgres and mysql db engines. 
- Before: we computed only insights starting before the start of the day, meaning that the current day insights were not displayed in the overview (so module would take a day to start showing data, even if we had some)
- After: We also take current day insights into account. Insights overview starts showing data as soon as some raw insights have been compacted to hours (1 hour by default)

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [X] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [X] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
