### PR TITLE
feat(API): Return null deviation on insights summary if previous period has no data

### DIFF
--- a/packages/@n8n/api-types/src/schemas/insights.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/insights.schema.ts
@@ -15,27 +15,27 @@ export type InsightsSummaryUnit = z.infer<typeof insightsSummaryUnitSchema>;
 export const insightsSummaryDataSchemas = {
 	total: z.object({
 		value: z.number(),
-		deviation: z.number(),
+		deviation: z.union([z.null(), z.number()]),
 		unit: z.literal('count'),
 	}),
 	failed: z.object({
 		value: z.number(),
-		deviation: z.number(),
+		deviation: z.union([z.null(), z.number()]),
 		unit: z.literal('count'),
 	}),
 	failureRate: z.object({
 		value: z.number(),
-		deviation: z.number(),
+		deviation: z.union([z.null(), z.number()]),
 		unit: z.literal('ratio'),
 	}),
 	timeSaved: z.object({
 		value: z.number(),
-		deviation: z.number(),
+		deviation: z.union([z.null(), z.number()]),
 		unit: z.literal('time'),
 	}),
 	averageRunTime: z.object({
 		value: z.number(),
-		deviation: z.number(),
+		deviation: z.union([z.null(), z.number()]),
 		unit: z.literal('time'),
 	}),
 } as const;

--- a/packages/cli/src/modules/insights/__tests__/insights.controller.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.controller.test.ts
@@ -34,15 +34,15 @@ describe('InsightsController', () => {
 
 			// ASSERT
 			expect(response).toEqual({
-				total: { deviation: 0, unit: 'count', value: 0 },
-				failed: { deviation: 0, unit: 'count', value: 0 },
-				failureRate: { deviation: 0, unit: 'ratio', value: 0 },
-				averageRunTime: { deviation: 0, unit: 'time', value: 0 },
-				timeSaved: { deviation: 0, unit: 'time', value: 0 },
+				total: { deviation: null, unit: 'count', value: 0 },
+				failed: { deviation: null, unit: 'count', value: 0 },
+				failureRate: { deviation: null, unit: 'ratio', value: 0 },
+				averageRunTime: { deviation: null, unit: 'time', value: 0 },
+				timeSaved: { deviation: null, unit: 'time', value: 0 },
 			});
 		});
 
-		it('should return the insights summary with deviation = current if insights exist only for current period', async () => {
+		it('should return the insights summary with null deviation if insights exist only for current period', async () => {
 			// ARRANGE
 			insightsByPeriodRepository.getPreviousAndCurrentPeriodTypeAggregates.mockResolvedValue([
 				{ period: 'current', type: TypeToNumber.success, total_value: 20 },
@@ -56,11 +56,11 @@ describe('InsightsController', () => {
 
 			// ASSERT
 			expect(response).toEqual({
-				total: { deviation: 30, unit: 'count', value: 30 },
-				failed: { deviation: 10, unit: 'count', value: 10 },
-				failureRate: { deviation: 0.33, unit: 'ratio', value: 0.33 },
-				averageRunTime: { deviation: 10, unit: 'time', value: 10 },
-				timeSaved: { deviation: 10, unit: 'time', value: 10 },
+				total: { deviation: null, unit: 'count', value: 30 },
+				failed: { deviation: null, unit: 'count', value: 10 },
+				failureRate: { deviation: null, unit: 'ratio', value: 0.33 },
+				averageRunTime: { deviation: null, unit: 'time', value: 10 },
+				timeSaved: { deviation: null, unit: 'time', value: 10 },
 			});
 		});
 

--- a/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
@@ -673,4 +673,21 @@ describe('getInsightsSummary', () => {
 			total: { deviation: 3, unit: 'count', value: 4 },
 		});
 	});
+
+	test('no data for previous period should return null deviation', async () => {
+		// ARRANGE
+		// last 7 days
+		await createCompactedInsightsEvent(workflow, {
+			type: 'success',
+			value: 1,
+			periodUnit: 'day',
+			periodStart: DateTime.utc(),
+		});
+
+		// ACT
+		const summary = await insightsService.getInsightsSummary();
+
+		// ASSERT
+		expect(Object.values(summary).map((v) => v.deviation)).toEqual([null, null, null, null, null]);
+	});
 });

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -241,32 +241,36 @@ export class InsightsService {
 		const currentTimeSaved = getValueByType('current', 'time_saved_min');
 		const previousTimeSaved = getValueByType('previous', 'time_saved_min');
 
+		// If the previous period has no executions, we discard deviation
+		const getDeviation = (current: number, previous: number) =>
+			previousTotal === 0 ? null : current - previous;
+
 		// Return the formatted result
 		const result: InsightsSummary = {
 			averageRunTime: {
 				value: currentAvgRuntime,
 				unit: 'time',
-				deviation: currentAvgRuntime - previousAvgRuntime,
+				deviation: getDeviation(currentAvgRuntime, previousAvgRuntime),
 			},
 			failed: {
 				value: currentFailures,
 				unit: 'count',
-				deviation: currentFailures - previousFailures,
+				deviation: getDeviation(currentFailures, previousFailures),
 			},
 			failureRate: {
 				value: currentFailureRate,
 				unit: 'ratio',
-				deviation: currentFailureRate - previousFailureRate,
+				deviation: getDeviation(currentFailureRate, previousFailureRate),
 			},
 			timeSaved: {
 				value: currentTimeSaved,
 				unit: 'time',
-				deviation: currentTimeSaved - previousTimeSaved,
+				deviation: getDeviation(currentTimeSaved, previousTimeSaved),
 			},
 			total: {
 				value: currentTotal,
 				unit: 'count',
-				deviation: currentTotal - previousTotal,
+				deviation: getDeviation(currentTotal, previousTotal),
 			},
 		};
 

--- a/packages/frontend/editor-ui/src/features/insights/components/InsightsSummary.test.ts
+++ b/packages/frontend/editor-ui/src/features/insights/components/InsightsSummary.test.ts
@@ -44,6 +44,15 @@ describe('InsightsSummary', () => {
 				{ id: 'averageRunTime', value: 2.5, deviation: 0.5, unit: 's' },
 			],
 		],
+		[
+			[
+				{ id: 'total', value: 525, deviation: null, unit: '' },
+				{ id: 'failed', value: 14, deviation: null, unit: '' },
+				{ id: 'failureRate', value: 1.9, deviation: null, unit: '%' },
+				{ id: 'timeSaved', value: 55.55555555555556, deviation: null, unit: 'h' },
+				{ id: 'averageRunTime', value: 2.5, deviation: null, unit: 's' },
+			],
+		],
 	])('should render the summary correctly', (summary) => {
 		const { html } = renderComponent({
 			props: {

--- a/packages/frontend/editor-ui/src/features/insights/components/InsightsSummary.vue
+++ b/packages/frontend/editor-ui/src/features/insights/components/InsightsSummary.vue
@@ -76,7 +76,7 @@ const getImpactStyle = (id: keyof InsightsSummary, value: number) => {
 						<em
 							>{{ smartDecimal(value) }} <i>{{ unit }}</i></em
 						>
-						<small :class="getImpactStyle(id, deviation)">
+						<small v-if="deviation !== null" :class="getImpactStyle(id, deviation)">
 							<N8nIcon
 								:class="[$style.icon, getImpactStyle(id, deviation)]"
 								:icon="deviation === 0 ? 'caret-right' : deviation > 0 ? 'caret-up' : 'caret-down'"

--- a/packages/frontend/editor-ui/src/features/insights/components/__snapshots__/InsightsSummary.test.ts.snap
+++ b/packages/frontend/editor-ui/src/features/insights/components/__snapshots__/InsightsSummary.test.ts.snap
@@ -73,3 +73,26 @@ exports[`InsightsSummary > should render the summary correctly 4`] = `
   </ul>
 </div>"
 `;
+
+exports[`InsightsSummary > should render the summary correctly 5`] = `
+"<div class="insights">
+  <h3 class="n8n-heading text-light size-small bold mb-xs mb-xs">Production executions for the last 7 days</h3>
+  <ul data-test-id="insights-summary-tabs">
+    <li data-test-id="insights-summary-tab-total">
+      <p><strong>Total</strong><span><em>525 <i></i></em><!--v-if--></span></p>
+    </li>
+    <li data-test-id="insights-summary-tab-failed">
+      <p><strong>Failed</strong><span><em>14 <i></i></em><!--v-if--></span></p>
+    </li>
+    <li data-test-id="insights-summary-tab-failureRate">
+      <p><strong>Failure rate</strong><span><em>1.9 <i>%</i></em><!--v-if--></span></p>
+    </li>
+    <li data-test-id="insights-summary-tab-timeSaved">
+      <p><strong>Time saved</strong><span><em>55.56 <i>h</i></em><!--v-if--></span></p>
+    </li>
+    <li data-test-id="insights-summary-tab-averageRunTime">
+      <p><strong>Avg. run time</strong><span><em>2.5 <i>s</i></em><!--v-if--></span></p>
+    </li>
+  </ul>
+</div>"
+`;

--- a/packages/frontend/editor-ui/src/features/insights/insights.types.ts
+++ b/packages/frontend/editor-ui/src/features/insights/insights.types.ts
@@ -7,7 +7,7 @@ export type InsightsSummaryDisplay = Array<
 		[K in keyof InsightsDisplayUnits]: {
 			id: K;
 			value: number;
-			deviation: number;
+			deviation: number | null;
 			unit: InsightsDisplayUnits[K];
 		};
 	}[keyof InsightsDisplayUnits]

--- a/packages/frontend/editor-ui/src/features/insights/insights.utils.ts
+++ b/packages/frontend/editor-ui/src/features/insights/insights.utils.ts
@@ -16,7 +16,9 @@ export const transformInsightsSummary = (data: InsightsSummary | null): Insights
 		? INSIGHTS_SUMMARY_ORDER.map((key) => ({
 				id: key,
 				value: transformInsightsValues[key]?.(data[key].value) ?? data[key].value,
-				deviation: transformInsightsValues[key]?.(data[key].deviation) ?? data[key].deviation,
+				deviation: data[key].deviation
+					? (transformInsightsValues[key]?.(data[key].deviation) ?? data[key].deviation)
+					: null,
 				unit: INSIGHTS_UNIT_MAPPING[key],
 			}))
 		: [];


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR changes the deviation returned from the Insights summary API route and front component, when the previous period has no workflow executions (thus no insights).
- Before: the deviation equaled the value of the current period 
- After: the deviation is null, and the front hides it

![image](https://github.com/user-attachments/assets/a654ae8b-1919-4b74-8fb9-935dc9217009)

Why : the main reason the previous period have no executions is that the insights module have just been enabled (version update or new install) and has not collected any executions yet (even though there could have some for the previous period). In that case, it seems weird to show a deviation which the user would consider incorrect.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2705/fix-deviation-when-no-data-on-previous-period

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [X] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [X] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
