### PR TITLE
fix(Basic LLM Chain Node): Prevent stringifying of structured output on previous versions

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
@@ -116,10 +116,13 @@ export class ChainLlm implements INodeType {
 					messages,
 				});
 
+				// If the node version is 1.6(and LLM is using `response_format: json_object`) or higher or an output parser is configured,
+				//  we unwrap the response and return the object directly as JSON
+				const shouldUnwrapObjects = this.getNode().typeVersion >= 1.6 || !!outputParser;
 				// Process each response and add to return data
 				responses.forEach((response) => {
 					returnData.push({
-						json: formatResponse(response, this.getNode().typeVersion),
+						json: formatResponse(response, shouldUnwrapObjects),
 					});
 				});
 			} catch (error) {

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/chainExecutor.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/chainExecutor.ts
@@ -9,6 +9,21 @@ import { getTracingConfig } from '@utils/tracing';
 import { createPromptTemplate } from './promptUtils';
 import type { ChainExecutionParams } from './types';
 
+export class NaiveJsonOutputParser<
+	T extends Record<string, any> = Record<string, any>,
+> extends JsonOutputParser<T> {
+	async parse(text: string): Promise<T> {
+		// First try direct JSON parsing
+		try {
+			const directParsed = JSON.parse(text);
+			return directParsed as T;
+		} catch (e) {
+			// If fails, fall back to JsonOutputParser parser
+			return super.parse(text);
+		}
+	}
+}
+
 /**
  * Type guard to check if the LLM has a modelKwargs property(OpenAI)
  */
@@ -39,11 +54,11 @@ export function getOutputParserForLLM(
 	llm: BaseLanguageModel,
 ): BaseLLMOutputParser<string | Record<string, unknown>> {
 	if (isModelWithResponseFormat(llm) && llm.modelKwargs?.response_format?.type === 'json_object') {
-		return new JsonOutputParser();
+		return new NaiveJsonOutputParser();
 	}
 
 	if (isModelWithFormat(llm) && llm.format === 'json') {
-		return new JsonOutputParser();
+		return new NaiveJsonOutputParser();
 	}
 
 	return new StringOutputParser();

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/chainExecutor.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/chainExecutor.ts
@@ -19,7 +19,7 @@ export class NaiveJsonOutputParser<
 			return directParsed as T;
 		} catch (e) {
 			// If fails, fall back to JsonOutputParser parser
-			return super.parse(text);
+			return await super.parse(text);
 		}
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/responseFormatter.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/responseFormatter.ts
@@ -3,7 +3,7 @@ import type { IDataObject } from 'n8n-workflow';
 /**
  * Formats the response from the LLM chain into a consistent structure
  */
-export function formatResponse(response: unknown, version: number): IDataObject {
+export function formatResponse(response: unknown, returnUnwrappedObject: boolean): IDataObject {
 	if (typeof response === 'string') {
 		return {
 			text: response.trim(),
@@ -17,10 +17,12 @@ export function formatResponse(response: unknown, version: number): IDataObject 
 	}
 
 	if (response instanceof Object) {
-		if (version >= 1.6) {
+		if (returnUnwrappedObject) {
 			return response as IDataObject;
 		}
 
+		// If the response is an object and we are not unwrapping it, we need to stringify it
+		// to be backwards compatible with older versions of the chain(< 1.6)
 		return {
 			text: JSON.stringify(response),
 		};

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/responseFormatter.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/responseFormatter.test.ts
@@ -3,14 +3,14 @@ import { formatResponse } from '../methods/responseFormatter';
 describe('responseFormatter', () => {
 	describe('formatResponse', () => {
 		it('should format string responses', () => {
-			const result = formatResponse('Test response', 1.6);
+			const result = formatResponse('Test response', true);
 			expect(result).toEqual({
 				text: 'Test response',
 			});
 		});
 
 		it('should trim string responses', () => {
-			const result = formatResponse('  Test response with whitespace   ', 1.6);
+			const result = formatResponse('  Test response with whitespace   ', true);
 			expect(result).toEqual({
 				text: 'Test response with whitespace',
 			});
@@ -18,23 +18,69 @@ describe('responseFormatter', () => {
 
 		it('should handle array responses', () => {
 			const testArray = [{ item: 1 }, { item: 2 }];
-			const result = formatResponse(testArray, 1.6);
+			const result = formatResponse(testArray, true);
 			expect(result).toEqual({ data: testArray });
 		});
 
-		it('should handle object responses', () => {
+		it('should handle object responses when unwrapping is enabled', () => {
 			const testObject = { key: 'value', nested: { key: 'value' } };
-			const result = formatResponse(testObject, 1.6);
+			const result = formatResponse(testObject, true);
 			expect(result).toEqual(testObject);
+		});
+
+		it('should stringify object responses when unwrapping is disabled', () => {
+			const testObject = { key: 'value', nested: { key: 'value' } };
+			const result = formatResponse(testObject, false);
+			expect(result).toEqual({
+				text: JSON.stringify(testObject),
+			});
 		});
 
 		it('should handle primitive non-string responses', () => {
 			const testNumber = 42;
-			const result = formatResponse(testNumber, 1.6);
+			const result = formatResponse(testNumber, true);
 			expect(result).toEqual({
 				response: {
 					text: 42,
 				},
+			});
+		});
+
+		it('should handle complex object structures when unwrapping is enabled', () => {
+			const complexObject = {
+				person: {
+					name: 'John',
+					age: 30,
+					address: {
+						street: '123 Main St',
+						city: 'Anytown',
+					},
+				},
+				items: [1, 2, 3],
+				active: true,
+			};
+
+			const result = formatResponse(complexObject, true);
+			expect(result).toEqual(complexObject);
+		});
+
+		it('should stringify complex object structures when unwrapping is disabled', () => {
+			const complexObject = {
+				person: {
+					name: 'John',
+					age: 30,
+					address: {
+						street: '123 Main St',
+						city: 'Anytown',
+					},
+				},
+				items: [1, 2, 3],
+				active: true,
+			};
+
+			const result = formatResponse(complexObject, false);
+			expect(result).toEqual({
+				text: JSON.stringify(complexObject),
 			});
 		});
 	});


### PR DESCRIPTION
## Summary

#14183 broke output of structured output parsers in Basic LLM Chain by incorrectly stringifying it for versions < 1.6. This PR addresses it by skipping objects wrapping if output parser is defined and on versions >= 1.6.

It also attempts fixing an issue with markdown in JSON and `executeSimpleChain` output branch(so when using LLM with `response_format: json_object`) by first trying to do `JSON.parse` before passing it to Langchain JsonOutputParser parser.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
