### PR TITLE
perf(editor): Making sure every card in workflows list has unique render key (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/views/WorkflowsView.vue
+++ b/packages/frontend/editor-ui/src/views/WorkflowsView.vue
@@ -1312,9 +1312,10 @@ const onCreateWorkflowClick = () => {
 				/>
 			</div>
 		</template>
-		<template #item="{ item: data }">
+		<template #item="{ item: data, index }">
 			<FolderCard
 				v-if="(data as FolderResource | WorkflowResource).resourceType === 'folder'"
+				:key="`folder-${index}`"
 				:data="data as FolderResource"
 				:actions="folderCardActions"
 				:read-only="readOnlyEnv || (!hasPermissionToDeleteFolders && !hasPermissionToCreateFolders)"
@@ -1323,6 +1324,7 @@ const onCreateWorkflowClick = () => {
 			/>
 			<WorkflowCard
 				v-else
+				:key="`workflow-${index}`"
 				data-test-id="resources-list-item-workflow"
 				class="mb-2xs"
 				:data="data as WorkflowResource"


### PR DESCRIPTION
## Summary
Passing item index to cards inside workflows list and using it as render key. This fixes the issue where all cards were rendered using the default key (`1`) which is a big vue performance bottleneck.
Now every card has a unique key:
![image](https://github.com/user-attachments/assets/45c49633-aab8-4397-88ee-0c8b2d3fe4b5)


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
