### PR TITLE
fix(n8n Form Node): Show Form Complition after Form Complition page

### DIFF
--- a/packages/cli/templates/form-trigger-completion.handlebars
+++ b/packages/cli/templates/form-trigger-completion.handlebars
@@ -157,6 +157,33 @@
 			<a id='redirectUrl' href='{{redirectUrl}}' style='display: none;'></a>
 		{{/if}}
 	<script>
+		let interval = 1000;
+		let timeoutId;
+		const checkExecutionStatus = async () => {
+			if (!interval) return;
+
+			try {
+				const response = await fetch(`${ window.location.href }/n8n-execution-status`);
+				const text = (await response.text()).trim();
+
+				if (text === "form-waiting") {
+					window.location.replace(window.location.href);
+					return;
+				}
+
+				if(["canceled", "crashed", "error", "success", "null" ].includes(text)) {
+					interval = 0;
+					clearTimeout(timeoutId);
+					return;
+				}
+
+				interval = Math.round(interval * 1.1);
+				timeoutId = setTimeout(checkExecutionStatus, interval);
+			} catch (error) {
+				console.error("Error fetching data:", error);
+			}
+		};
+
 		document.addEventListener('DOMContentLoaded', function () {
 			const binary = "{{{responseBinary}}}"
 				?	JSON.parse(decodeURIComponent("{{{responseBinary}}}"))
@@ -210,6 +237,9 @@
 			})
 			.catch(function (error) {
 					console.error('Error:', error);
+			})
+			.finally(() => {
+				timeoutId = setTimeout(checkExecutionStatus, interval);
 			});
 	</script>
 	</body>


### PR DESCRIPTION
## Summary

redirect based on execution status on form completion page

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2570/form-node-second-ending-executed-incorrectly


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
