### PR TITLE
fix(Google Sheets Node): Improve error message when row_number is null or undefined

### DIFF
--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/update.operation.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/update.operation.ts
@@ -1,5 +1,5 @@
 import type { IExecuteFunctions, IDataObject, INodeExecutionData } from 'n8n-workflow';
-import { NodeOperationError } from 'n8n-workflow';
+import { NodeOperationError, UserError } from 'n8n-workflow';
 
 import { cellFormat, handlingExtraData, locationDefine } from './commonDescription';
 import type { GoogleSheet } from '../../helpers/GoogleSheet';
@@ -369,6 +369,15 @@ export async function execute(
 				}
 				// Setting empty values to empty string so that they are not ignored by the API
 				Object.keys(mappingValues).forEach((key) => {
+					if (
+						(key === 'row_number' && mappingValues[key] === null) ||
+						mappingValues[key] === undefined
+					) {
+						throw new UserError(
+							'Column to match on (row_number) is not defined. Since the field is used to determine the row to update, it needs to have a value set.',
+						);
+					}
+
 					if (mappingValues[key] === undefined || mappingValues[key] === null) {
 						mappingValues[key] = '';
 					}

--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/update.operation.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/update.operation.ts
@@ -370,8 +370,8 @@ export async function execute(
 				// Setting empty values to empty string so that they are not ignored by the API
 				Object.keys(mappingValues).forEach((key) => {
 					if (
-						(key === 'row_number' && mappingValues[key] === null) ||
-						mappingValues[key] === undefined
+						key === 'row_number' &&
+						(mappingValues[key] === null || mappingValues[key] === undefined)
 					) {
 						throw new UserError(
 							'Column to match on (row_number) is not defined. Since the field is used to determine the row to update, it needs to have a value set.',


### PR DESCRIPTION
## Summary

If row_number is null or undefined, we display a more helpful error message

## Related Linear tickets, Github issues, and Community forum posts

Resolves https://linear.app/n8n/issue/NODE-1592/google-sheetsrmc-improve-error-when-field-to-match-on-is-null

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
