### PR TITLE
fix(editor): Fix partial chat trigger executions

### DIFF
--- a/cypress/composables/workflow.ts
+++ b/cypress/composables/workflow.ts
@@ -182,10 +182,6 @@ export function getZoomToFitButton() {
 	return cy.getByTestId('zoom-to-fit');
 }
 
-export function getClearExecutionDataButton() {
-	return cy.getByTestId('clear-execution-data-button');
-}
-
 /**
  * Actions
  */
@@ -364,5 +360,5 @@ export function clickContextMenuAction(action: string) {
 }
 
 export function clickClearExecutionDataButton() {
-	getClearExecutionDataButton().click();
+	cy.getByTestId('clear-execution-data-button').click();
 }

--- a/cypress/composables/workflow.ts
+++ b/cypress/composables/workflow.ts
@@ -182,6 +182,10 @@ export function getZoomToFitButton() {
 	return cy.getByTestId('zoom-to-fit');
 }
 
+export function getClearExecutionDataButton() {
+	return cy.getByTestId('clear-execution-data-button');
+}
+
 /**
  * Actions
  */
@@ -357,4 +361,8 @@ export function openContextMenu(
 
 export function clickContextMenuAction(action: string) {
 	getContextMenuAction(action).click({ force: true });
+}
+
+export function clickClearExecutionDataButton() {
+	getClearExecutionDataButton().click();
 }

--- a/cypress/e2e/812-AI-partial-execs-broken-when-using-chat-trigger.cy.ts
+++ b/cypress/e2e/812-AI-partial-execs-broken-when-using-chat-trigger.cy.ts
@@ -26,26 +26,30 @@ describe('AI-812-partial-execs-broken-when-using-chat-trigger', () => {
 	afterEach(() => {
 		clearNotifications();
 		clickClearExecutionDataButton();
-		sendManualChatMessage('Test 2');
+		sendManualChatMessage('Test Full Execution');
 		getManualChatMessages().should('have.length', 4);
-		getManualChatMessages().should('contain', 'Set 3');
+		getManualChatMessages().should('contain', 'Set 3 with chatInput: Test Full Execution');
 	});
 
 	it('should do partial execution when using chat trigger and clicking NDV execute node', () => {
 		openNode('Edit Fields1');
 		clickExecuteNode();
 		getManualChatModal().should('exist');
-		sendManualChatMessage('Test');
+		sendManualChatMessage('Test Partial Execution');
+
+		getManualChatMessages().should('have.length', 2);
+		getManualChatMessages().should('contain', 'Test Partial Execution');
+		getManualChatMessages().should('contain', 'Set 2 with chatInput: Test Partial Execution');
 	});
 
 	it('should do partial execution when using chat trigger and context-menu execute node', () => {
 		openContextMenu('Edit Fields');
 		clickContextMenuAction('execute');
 		getManualChatModal().should('exist');
-		sendManualChatMessage('Test');
+		sendManualChatMessage('Test Partial Execution');
 
 		getManualChatMessages().should('have.length', 2);
-		getManualChatMessages().should('contain', 'Test');
-		getManualChatMessages().should('contain', 'Set 1');
+		getManualChatMessages().should('contain', 'Test Partial Execution');
+		getManualChatMessages().should('contain', 'Set 1 with chatInput: Test Partial Execution');
 	});
 });

--- a/cypress/e2e/812-AI-partial-execs-broken-when-using-chat-trigger.cy.ts
+++ b/cypress/e2e/812-AI-partial-execs-broken-when-using-chat-trigger.cy.ts
@@ -1,6 +1,17 @@
-import { getManualChatMessages, getManualChatModal, sendManualChatMessage } from '../composables/modals/chat-modal';
+import {
+	getManualChatMessages,
+	getManualChatModal,
+	sendManualChatMessage,
+} from '../composables/modals/chat-modal';
 import { clickExecuteNode } from '../composables/ndv';
-import { clickZoomToFit, openNode, navigateToNewWorkflowPage, openContextMenu, clickContextMenuAction, clickClearExecutionDataButton } from '../composables/workflow';
+import {
+	clickZoomToFit,
+	openNode,
+	navigateToNewWorkflowPage,
+	openContextMenu,
+	clickContextMenuAction,
+	clickClearExecutionDataButton,
+} from '../composables/workflow';
 import { clearNotifications } from '../pages/notifications';
 
 describe('AI-812-partial-execs-broken-when-using-chat-trigger', () => {

--- a/cypress/e2e/812-AI-partial-execs-broken-when-using-chat-trigger.cy.ts
+++ b/cypress/e2e/812-AI-partial-execs-broken-when-using-chat-trigger.cy.ts
@@ -1,0 +1,40 @@
+import { getManualChatMessages, getManualChatModal, sendManualChatMessage } from '../composables/modals/chat-modal';
+import { clickExecuteNode } from '../composables/ndv';
+import { clickZoomToFit, openNode, navigateToNewWorkflowPage, openContextMenu, clickContextMenuAction, clickClearExecutionDataButton } from '../composables/workflow';
+import { clearNotifications } from '../pages/notifications';
+
+describe('AI-812-partial-execs-broken-when-using-chat-trigger', () => {
+	beforeEach(() => {
+		navigateToNewWorkflowPage();
+		cy.createFixtureWorkflow('Test_chat_partial_execution.json');
+		clearNotifications();
+		clickZoomToFit();
+	});
+
+	// Check if the full execution still behaves as expected after the partial execution tests
+	afterEach(() => {
+		clearNotifications();
+		clickClearExecutionDataButton();
+		sendManualChatMessage('Test 2');
+		getManualChatMessages().should('have.length', 4);
+		getManualChatMessages().should('contain', 'Set 3');
+	});
+
+	it('should do partial execution when using chat trigger and clicking NDV execute node', () => {
+		openNode('Edit Fields1');
+		clickExecuteNode();
+		getManualChatModal().should('exist');
+		sendManualChatMessage('Test');
+	});
+
+	it('should do partial execution when using chat trigger and context-menu execute node', () => {
+		openContextMenu('Edit Fields');
+		clickContextMenuAction('execute');
+		getManualChatModal().should('exist');
+		sendManualChatMessage('Test');
+
+		getManualChatMessages().should('have.length', 2);
+		getManualChatMessages().should('contain', 'Test');
+		getManualChatMessages().should('contain', 'Set 1');
+	});
+});

--- a/cypress/fixtures/Test_chat_partial_execution.json
+++ b/cypress/fixtures/Test_chat_partial_execution.json
@@ -1,0 +1,134 @@
+{
+  "name": "Test_chat_partial_execution",
+  "nodes": [
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "0c345346-8cef-415c-aa1a-3d3941bb4035",
+              "name": "text",
+              "value": "Set 1",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        0,
+        0
+      ],
+      "id": "b3ab0f0d-ba41-4d2d-9511-a57bb1913632",
+      "name": "Edit Fields"
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "9a7bd7af-c3fb-4984-b15a-2f805b66ed02",
+              "name": "text",
+              "value": "Set 2",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        220,
+        0
+      ],
+      "id": "ed8bb10e-aa2b-4527-8860-de2cf71d7b0b",
+      "name": "Edit Fields1"
+    },
+    {
+      "parameters": {
+        "options": {}
+      },
+      "type": "@n8n/n8n-nodes-langchain.chatTrigger",
+      "typeVersion": 1.1,
+      "position": [
+        -220,
+        0
+      ],
+      "id": "ecd39844-b08c-48b9-969b-8e9f5a13baed",
+      "name": "When chat message received",
+      "webhookId": "28da48d8-cef1-4364-b4d6-429212d2e3f6"
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "9a7bd7af-c3fb-4984-b15a-2f805b66ed02",
+              "name": "text",
+              "value": "Set 3",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        440,
+        0
+      ],
+      "id": "9fcec771-c4b4-4a6e-89be-9ff7c8dab0e4",
+      "name": "Edit Fields2"
+    }
+  ],
+  "pinData": {},
+  "connections": {
+    "Edit Fields": {
+      "main": [
+        [
+          {
+            "node": "Edit Fields1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "When chat message received": {
+      "main": [
+        [
+          {
+            "node": "Edit Fields",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Edit Fields1": {
+      "main": [
+        [
+          {
+            "node": "Edit Fields2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "versionId": "70bd8b17-bfdf-404e-a7ce-daa928233f00",
+  "meta": {
+    "instanceId": "27cc9b56542ad45b38725555722c50a1c3fee1670bbb67980558314ee08517c4"
+  },
+  "id": "ugW3t5bryZPt3JNy",
+  "tags": []
+}

--- a/cypress/fixtures/Test_chat_partial_execution.json
+++ b/cypress/fixtures/Test_chat_partial_execution.json
@@ -1,5 +1,4 @@
 {
-  "name": "Test_chat_partial_execution",
   "nodes": [
     {
       "parameters": {
@@ -8,30 +7,7 @@
             {
               "id": "0c345346-8cef-415c-aa1a-3d3941bb4035",
               "name": "text",
-              "value": "Set 1",
-              "type": "string"
-            }
-          ]
-        },
-        "options": {}
-      },
-      "type": "n8n-nodes-base.set",
-      "typeVersion": 3.4,
-      "position": [
-        0,
-        0
-      ],
-      "id": "b3ab0f0d-ba41-4d2d-9511-a57bb1913632",
-      "name": "Edit Fields"
-    },
-    {
-      "parameters": {
-        "assignments": {
-          "assignments": [
-            {
-              "id": "9a7bd7af-c3fb-4984-b15a-2f805b66ed02",
-              "name": "text",
-              "value": "Set 2",
+              "value": "=Set 1 with chatInput: {{ $json.chatInput }}",
               "type": "string"
             }
           ]
@@ -44,22 +20,8 @@
         220,
         0
       ],
-      "id": "ed8bb10e-aa2b-4527-8860-de2cf71d7b0b",
-      "name": "Edit Fields1"
-    },
-    {
-      "parameters": {
-        "options": {}
-      },
-      "type": "@n8n/n8n-nodes-langchain.chatTrigger",
-      "typeVersion": 1.1,
-      "position": [
-        -220,
-        0
-      ],
-      "id": "ecd39844-b08c-48b9-969b-8e9f5a13baed",
-      "name": "When chat message received",
-      "webhookId": "28da48d8-cef1-4364-b4d6-429212d2e3f6"
+      "id": "b1584b5b-c17c-4fd9-9b75-dd61f2c4c20d",
+      "name": "Edit Fields"
     },
     {
       "parameters": {
@@ -68,7 +30,7 @@
             {
               "id": "9a7bd7af-c3fb-4984-b15a-2f805b66ed02",
               "name": "text",
-              "value": "Set 3",
+              "value": "=Set 2 with chatInput: {{ $('When chat message received').item.json.chatInput }}",
               "type": "string"
             }
           ]
@@ -81,28 +43,53 @@
         440,
         0
       ],
-      "id": "9fcec771-c4b4-4a6e-89be-9ff7c8dab0e4",
+      "id": "e9e02219-4b6b-48d1-8d3d-2c850362abf2",
+      "name": "Edit Fields1"
+    },
+    {
+      "parameters": {
+        "options": {}
+      },
+      "type": "@n8n/n8n-nodes-langchain.chatTrigger",
+      "typeVersion": 1.1,
+      "position": [
+        0,
+        0
+      ],
+      "id": "c2dd390e-1360-4d6f-a922-4d295246a886",
+      "name": "When chat message received",
+      "webhookId": "28da48d8-cef1-4364-b4d6-429212d2e3f6"
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "9a7bd7af-c3fb-4984-b15a-2f805b66ed02",
+              "name": "text",
+              "value": "=Set 3 with chatInput: {{ $('When chat message received').item.json.chatInput }}",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        660,
+        0
+      ],
+      "id": "766dba66-a4da-4d84-ad80-ca5579ce91e5",
       "name": "Edit Fields2"
     }
   ],
-  "pinData": {},
   "connections": {
     "Edit Fields": {
       "main": [
         [
           {
             "node": "Edit Fields1",
-            "type": "main",
-            "index": 0
-          }
-        ]
-      ]
-    },
-    "When chat message received": {
-      "main": [
-        [
-          {
-            "node": "Edit Fields",
             "type": "main",
             "index": 0
           }
@@ -119,16 +106,22 @@
           }
         ]
       ]
+    },
+    "When chat message received": {
+      "main": [
+        [
+          {
+            "node": "Edit Fields",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
     }
   },
-  "active": false,
-  "settings": {
-    "executionOrder": "v1"
-  },
-  "versionId": "70bd8b17-bfdf-404e-a7ce-daa928233f00",
+  "pinData": {},
   "meta": {
+    "templateCredsSetupCompleted": true,
     "instanceId": "27cc9b56542ad45b38725555722c50a1c3fee1670bbb67980558314ee08517c4"
-  },
-  "id": "ugW3t5bryZPt3JNy",
-  "tags": []
+  }
 }

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
@@ -573,7 +573,6 @@ ${cssVariables}
 
 		let returnData: INodeExecutionData[];
 		const webhookResponse: IDataObject = { status: 200 };
-
 		if (req.contentType === 'multipart/form-data') {
 			returnData = [await this.handleFormData(ctx)];
 			return {

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
@@ -573,6 +573,7 @@ ${cssVariables}
 
 		let returnData: INodeExecutionData[];
 		const webhookResponse: IDataObject = { status: 200 };
+
 		if (req.contentType === 'multipart/form-data') {
 			returnData = [await this.handleFormData(ctx)];
 			return {

--- a/packages/cli/src/manual-execution.service.ts
+++ b/packages/cli/src/manual-execution.service.ts
@@ -110,7 +110,13 @@ export class ManualExecutionService {
 			// Can execute without webhook so go on
 			const workflowExecute = new WorkflowExecute(additionalData, data.executionMode);
 
-			return workflowExecute.run(workflow, startNode, data.destinationNode, data.pinData);
+			return workflowExecute.run(
+				workflow,
+				startNode,
+				data.destinationNode,
+				data.pinData,
+				data.triggerToStartFrom,
+			);
 		} else {
 			// Partial Execution
 			this.logger.debug(`Execution ID ${executionId} is a partial execution.`, { executionId });

--- a/packages/cli/src/manual-execution.service.ts
+++ b/packages/cli/src/manual-execution.service.ts
@@ -48,7 +48,7 @@ export class ManualExecutionService {
 		executionId: string,
 		pinData?: IPinData,
 	): PCancelable<IRun> {
-		if (data.triggerToStartFrom?.data && data.startNodes) {
+		if (data.triggerToStartFrom?.data && data.startNodes?.length) {
 			this.logger.debug(
 				`Execution ID ${executionId} had triggerToStartFrom. Starting from that trigger.`,
 				{ executionId },

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -40,6 +40,7 @@ import type {
 	IWorkflowIssues,
 	INodeIssues,
 	INodeType,
+	IWorkflowExecutionDataProcess,
 } from 'n8n-workflow';
 import {
 	LoggerProxy as Logger,
@@ -112,6 +113,7 @@ export class WorkflowExecute {
 		startNode?: INode,
 		destinationNode?: string,
 		pinData?: IPinData,
+		triggerToStartFrom?: IWorkflowExecutionDataProcess['triggerToStartFrom'],
 	): PCancelable<IRun> {
 		this.status = 'running';
 
@@ -133,7 +135,7 @@ export class WorkflowExecute {
 		const nodeExecutionStack: IExecuteData[] = [
 			{
 				node: startNode,
-				data: {
+				data: triggerToStartFrom?.data?.data ?? {
 					main: [
 						[
 							{

--- a/packages/frontend/editor-ui/src/composables/useRunWorkflow.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useRunWorkflow.test.ts
@@ -329,6 +329,64 @@ describe('useRunWorkflow({ router })', () => {
 			expect(result).toEqual(mockExecutionResponse);
 		});
 
+		it('should exclude destinationNode from startNodes when provided', async () => {
+			// ARRANGE
+			const mockExecutionResponse = { executionId: '123' };
+			const { runWorkflow } = useRunWorkflow({ router });
+			const dataCaptor = captor<IStartRunData>();
+
+			const parentNodeName = 'parentNode';
+			const destinationNodeName = 'destinationNode';
+
+			// Mock workflow with parent-child relationship
+			const workflow = {
+				name: 'Test Workflow',
+				id: 'workflowId',
+				getParentNodes: vi.fn().mockImplementation((nodeName: string) => {
+					if (nodeName === destinationNodeName) {
+						return [parentNodeName];
+					}
+					return [];
+				}),
+				nodes: {
+					[parentNodeName]: createTestNode({ name: parentNodeName }),
+					[destinationNodeName]: createTestNode({ name: destinationNodeName }),
+				},
+			} as unknown as Workflow;
+
+			vi.mocked(pushConnectionStore).isConnected = true;
+			vi.mocked(workflowsStore).runWorkflow.mockResolvedValue(mockExecutionResponse);
+			vi.mocked(workflowsStore).nodesIssuesExist = false;
+			vi.mocked(workflowHelpers).getCurrentWorkflow.mockReturnValue(workflow);
+			vi.mocked(workflowHelpers).getWorkflowDataToSave.mockResolvedValue({
+				id: 'workflowId',
+				nodes: [],
+			} as unknown as IWorkflowData);
+
+			vi.mocked(workflowsStore).getWorkflowRunData = {
+				[parentNodeName]: [
+					{
+						startTime: 1,
+						executionTime: 0,
+						source: [],
+						data: { main: [[{ json: { test: 'data' } }]] },
+					},
+				],
+			} as unknown as IRunData;
+
+			// ACT
+			await runWorkflow({ destinationNode: destinationNodeName });
+
+			// ASSERT
+			expect(workflowsStore.runWorkflow).toHaveBeenCalledTimes(1);
+			expect(workflowsStore.runWorkflow).toHaveBeenCalledWith(dataCaptor);
+
+			const startNodes = dataCaptor.value.startNodes ?? [];
+			const destinationInStartNodes = startNodes.some((node) => node.name === destinationNodeName);
+
+			expect(destinationInStartNodes).toBe(false);
+		});
+
 		it('should send dirty nodes for partial executions v2', async () => {
 			vi.mocked(settingsStore).partialExecutionVersion = 2;
 			const composable = useRunWorkflow({ router });

--- a/packages/frontend/editor-ui/src/composables/useRunWorkflow.ts
+++ b/packages/frontend/editor-ui/src/composables/useRunWorkflow.ts
@@ -237,8 +237,16 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 						sourceData,
 					};
 				})
-				// If a destination node is specified, we don't want to include it in the start nodes
-				.filter((node) => !options.destinationNode || node.name !== options.destinationNode);
+				// If a destination node is specified and it has chat parent, we don't want to include it in the start nodes
+				.filter((node) => {
+					if (
+						options.destinationNode &&
+						workflowsStore.checkIfNodeHasChatParent(options.destinationNode)
+					) {
+						return node.name !== options.destinationNode;
+					}
+					return true;
+				});
 
 			const singleWebhookTrigger = triggers.find((node) =>
 				SINGLE_WEBHOOK_TRIGGERS.includes(node.type),

--- a/packages/frontend/editor-ui/src/composables/useRunWorkflow.ts
+++ b/packages/frontend/editor-ui/src/composables/useRunWorkflow.ts
@@ -218,24 +218,27 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 			const version = settingsStore.partialExecutionVersion;
 
 			// TODO: this will be redundant once we cleanup the partial execution v1
-			const startNodes: StartNodeData[] = startNodeNames.map((name) => {
-				// Find for each start node the source data
-				let sourceData = get(runData, [name, 0, 'source', 0], null);
-				if (sourceData === null) {
-					const parentNodes = workflow.getParentNodes(name, NodeConnectionTypes.Main, 1);
-					const executeData = workflowHelpers.executeData(
-						parentNodes,
+			const startNodes: StartNodeData[] = startNodeNames
+				.map((name) => {
+					// Find for each start node the source data
+					let sourceData = get(runData, [name, 0, 'source', 0], null);
+					if (sourceData === null) {
+						const parentNodes = workflow.getParentNodes(name, NodeConnectionTypes.Main, 1);
+						const executeData = workflowHelpers.executeData(
+							parentNodes,
+							name,
+							NodeConnectionTypes.Main,
+							0,
+						);
+						sourceData = get(executeData, ['source', NodeConnectionTypes.Main, 0], null);
+					}
+					return {
 						name,
-						NodeConnectionTypes.Main,
-						0,
-					);
-					sourceData = get(executeData, ['source', NodeConnectionTypes.Main, 0], null);
-				}
-				return {
-					name,
-					sourceData,
-				};
-			});
+						sourceData,
+					};
+				})
+				// If a destination node is specified, we don't want to include it in the start nodes
+				.filter((node) => !options.destinationNode || node.name !== options.destinationNode);
 
 			const singleWebhookTrigger = triggers.find((node) =>
 				SINGLE_WEBHOOK_TRIGGERS.includes(node.type),


### PR DESCRIPTION
## Summary

Previously, triggering a partial execution from a node downstream of a Chat Trigger would open the chat modal, but only the Chat Trigger would execute. This PR ensures that the intended execution path is followed by excluding the destination node from startNodes, allowing upstream data to flow correctly.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
