### PR TITLE
ci: Adding jest config to turbo cache (no-changelog)

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -72,7 +72,8 @@
 				"n8n-core#test",
 				"n8n#test"
 			],
-			"outputs": ["coverage/**"]
+			"outputs": ["coverage/**"],
+			"inputs": ["jest.config.js"]
 		},
 		"test:frontend": {
 			"dependsOn": [
@@ -82,7 +83,8 @@
 				"@n8n/design-system#test",
 				"n8n-editor-ui#test"
 			],
-			"outputs": ["coverage/**"]
+			"outputs": ["coverage/**"],
+			"inputs": ["jest.config.js"]
 		},
 		"test:nodes": {
 			"dependsOn": [
@@ -90,7 +92,8 @@
 				"@n8n/n8n-nodes-langchain#test",
 				"@n8n/json-schema-to-zod#test"
 			],
-			"outputs": ["coverage/**"]
+			"outputs": ["coverage/**"],
+			"inputs": ["jest.config.js"]
 		},
 		"test": {},
 		"watch": {


### PR DESCRIPTION
Changes to how we run our tests should reset the cache for running tests. If we don't reset the cache we can break testing when changes are made.

## Summary

Resets the turbo cache when changes are detected in our Jest config. This will ensure the tests will be run when they are changed.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-729/ci-add-jest-config-to-turbo-cache

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
