### PR TITLE
ci: Use composable for credential page load (no-changelog)

### DIFF
--- a/cypress/composables/credentialsComposables.ts
+++ b/cypress/composables/credentialsComposables.ts
@@ -4,7 +4,7 @@ export const verifyCredentialsListPageIsLoaded = () => {
 	);
 };
 
-export const navigateToCredentialsPageAndWaitForLoad = (credentialsPageUrl: string) => {
+export const loadCredentialsPage = (credentialsPageUrl: string) => {
 	cy.visit(credentialsPageUrl);
 	verifyCredentialsListPageIsLoaded();
 };

--- a/cypress/e2e/17-sharing.cy.ts
+++ b/cypress/e2e/17-sharing.cy.ts
@@ -39,7 +39,7 @@ describe('Sharing', { disableAutoLogin: true }, () => {
 	it('should create C1, W1, W2, share W1 with U3, as U2', () => {
 		cy.signinAsMember(0);
 
-		credentialsComposables.navigateToCredentialsPageAndWaitForLoad(credentialsPage.url);
+		credentialsComposables.loadCredentialsPage(credentialsPage.url);
 		credentialsPage.getters.emptyListCreateCredentialButton().click();
 		credentialsModal.getters.newCredentialTypeOption('Notion API').click();
 		credentialsModal.getters.newCredentialTypeButton().click();
@@ -72,7 +72,7 @@ describe('Sharing', { disableAutoLogin: true }, () => {
 	it('should create C2, share C2 with U1 and U2, as U3', () => {
 		cy.signinAsMember(1);
 
-		credentialsComposables.navigateToCredentialsPageAndWaitForLoad(credentialsPage.url);
+		credentialsComposables.loadCredentialsPage(credentialsPage.url);
 		credentialsPage.getters.emptyListCreateCredentialButton().click();
 		credentialsModal.getters.newCredentialTypeOption('Airtable Personal Access Token API').click();
 		credentialsModal.getters.newCredentialTypeButton().click();
@@ -153,7 +153,7 @@ describe('Sharing', { disableAutoLogin: true }, () => {
 	it('should automatically test C2 when opened by U2 sharee', () => {
 		cy.signinAsMember(0);
 
-		credentialsComposables.navigateToCredentialsPageAndWaitForLoad(credentialsPage.url);
+		credentialsComposables.loadCredentialsPage(credentialsPage.url);
 		credentialsPage.getters.credentialCard('Credential C2').click();
 		credentialsModal.getters.testSuccessTag().should('be.visible');
 	});
@@ -161,7 +161,7 @@ describe('Sharing', { disableAutoLogin: true }, () => {
 	it('should work for admin role on credentials created by others (also can share it with themselves)', () => {
 		cy.signinAsMember(0);
 
-		credentialsComposables.navigateToCredentialsPageAndWaitForLoad(credentialsPage.url);
+		credentialsComposables.loadCredentialsPage(credentialsPage.url);
 		credentialsPage.getters.createCredentialButton().click();
 		credentialsModal.getters.newCredentialTypeOption('Notion API').click();
 		credentialsModal.getters.newCredentialTypeButton().click({ force: true });
@@ -172,7 +172,7 @@ describe('Sharing', { disableAutoLogin: true }, () => {
 
 		cy.signout();
 		cy.signinAsAdmin();
-		credentialsComposables.navigateToCredentialsPageAndWaitForLoad(credentialsPage.url);
+		credentialsComposables.loadCredentialsPage(credentialsPage.url);
 		credentialsPage.getters.credentialCard('Credential C3').click();
 		credentialsModal.getters.testSuccessTag().should('be.visible');
 		cy.get('input').should('not.have.length');
@@ -274,7 +274,7 @@ describe('Credential Usage in Cross Shared Workflows', () => {
 		cy.changeQuota('maxTeamProjects', -1);
 		cy.reload();
 		cy.signinAsOwner();
-		credentialsComposables.navigateToCredentialsPageAndWaitForLoad(credentialsPage.url);
+		credentialsComposables.loadCredentialsPage(credentialsPage.url);
 	});
 
 	it('should only show credentials from the same team project', () => {
@@ -318,7 +318,7 @@ describe('Credential Usage in Cross Shared Workflows', () => {
 
 		// As the member, create a new notion credential and a workflow
 		cy.signinAsMember();
-		credentialsComposables.navigateToCredentialsPageAndWaitForLoad(credentialsPage.url);
+		credentialsComposables.loadCredentialsPage(credentialsPage.url);
 		credentialsPage.getters.createCredentialButton().click();
 		credentialsModal.actions.createNewCredential('Notion API');
 		cy.visit(workflowsPage.url);
@@ -347,7 +347,7 @@ describe('Credential Usage in Cross Shared Workflows', () => {
 
 		// As the member, create a new notion credential
 		cy.signinAsMember();
-		credentialsComposables.navigateToCredentialsPageAndWaitForLoad(credentialsPage.url);
+		credentialsComposables.loadCredentialsPage(credentialsPage.url);
 		credentialsPage.getters.emptyListCreateCredentialButton().click();
 		credentialsModal.actions.createNewCredential('Notion API');
 		cy.visit(workflowsPage.url);
@@ -364,20 +364,20 @@ describe('Credential Usage in Cross Shared Workflows', () => {
 
 		// As member 1, create a new notion credential. This should not show up.
 		cy.signinAsMember(1);
-		credentialsComposables.navigateToCredentialsPageAndWaitForLoad(credentialsPage.url);
+		credentialsComposables.loadCredentialsPage(credentialsPage.url);
 		credentialsPage.getters.emptyListCreateCredentialButton().click();
 		credentialsModal.actions.createNewCredential('Notion API');
 
 		// As admin, create a new notion credential. This should show up.
 		cy.signinAsAdmin();
-		credentialsComposables.navigateToCredentialsPageAndWaitForLoad(credentialsPage.url);
+		credentialsComposables.loadCredentialsPage(credentialsPage.url);
 		credentialsPage.getters.createCredentialButton().click();
 		credentialsModal.actions.createNewCredential('Notion API');
 
 		// As member 0, create a new notion credential and a workflow and share it
 		// with the global owner and the admin.
 		cy.signinAsMember();
-		credentialsComposables.navigateToCredentialsPageAndWaitForLoad(credentialsPage.url);
+		credentialsComposables.loadCredentialsPage(credentialsPage.url);
 		credentialsPage.getters.emptyListCreateCredentialButton().click();
 		credentialsModal.actions.createNewCredential('Notion API');
 		cy.visit(workflowsPage.url);
@@ -391,7 +391,7 @@ describe('Credential Usage in Cross Shared Workflows', () => {
 		// As the global owner, create a new notion credential and open the shared
 		// workflow
 		cy.signinAsOwner();
-		credentialsComposables.navigateToCredentialsPageAndWaitForLoad(credentialsPage.url);
+		credentialsComposables.loadCredentialsPage(credentialsPage.url);
 
 		credentialsPage.getters.createCredentialButton().click();
 		credentialsModal.actions.createNewCredential('Notion API');
@@ -407,7 +407,7 @@ describe('Credential Usage in Cross Shared Workflows', () => {
 	it('should show all personal credentials if the global owner owns the workflow', () => {
 		// As member 0, create a new notion credential.
 		cy.signinAsMember();
-		credentialsComposables.navigateToCredentialsPageAndWaitForLoad(credentialsPage.url);
+		credentialsComposables.loadCredentialsPage(credentialsPage.url);
 		credentialsPage.getters.emptyListCreateCredentialButton().click();
 		credentialsModal.actions.createNewCredential('Notion API');
 

--- a/cypress/e2e/2-credentials.cy.ts
+++ b/cypress/e2e/2-credentials.cy.ts
@@ -1,5 +1,6 @@
 import { type ICredentialType } from 'n8n-workflow';
 
+import * as credentialsComposables from '../composables/credentialsComposables';
 import { getCredentialSaveButton, saveCredential } from '../composables/modals/credential-modal';
 import {
 	AGENT_NODE_NAME,
@@ -45,7 +46,7 @@ function deleteSelectedCredential() {
 
 describe('Credentials', () => {
 	beforeEach(() => {
-		cy.visit(credentialsPage.url);
+		credentialsComposables.navigateToCredentialsPageAndWaitForLoad(credentialsPage.url);
 	});
 
 	it('should create a new credential using empty state', () => {

--- a/cypress/e2e/2-credentials.cy.ts
+++ b/cypress/e2e/2-credentials.cy.ts
@@ -46,7 +46,7 @@ function deleteSelectedCredential() {
 
 describe('Credentials', () => {
 	beforeEach(() => {
-		credentialsComposables.navigateToCredentialsPageAndWaitForLoad(credentialsPage.url);
+		credentialsComposables.loadCredentialsPage(credentialsPage.url);
 	});
 
 	it('should create a new credential using empty state', () => {


### PR DESCRIPTION
## Summary

Credentials test switches to using credential page load composable

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-730/flaky-2-credential-flaky-test-investigate

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
