### PR TITLE
fix(core): Fix OAuth1 callback token request

### DIFF
--- a/packages/cli/src/controllers/oauth/__tests__/oauth1-credential.controller.test.ts
+++ b/packages/cli/src/controllers/oauth/__tests__/oauth1-credential.controller.test.ts
@@ -230,7 +230,8 @@ describe('OAuth1CredentialController', () => {
 			});
 			jest.spyOn(Csrf.prototype, 'verify').mockReturnValueOnce(true);
 			nock('https://example.domain')
-				.post('/oauth/access_token', {
+				.post('/oauth/access_token')
+				.query({
 					oauth_token: 'token',
 					oauth_verifier: 'verifier',
 				})

--- a/packages/cli/src/controllers/oauth/__tests__/oauth1-credential.controller.test.ts
+++ b/packages/cli/src/controllers/oauth/__tests__/oauth1-credential.controller.test.ts
@@ -230,16 +230,11 @@ describe('OAuth1CredentialController', () => {
 			});
 			jest.spyOn(Csrf.prototype, 'verify').mockReturnValueOnce(true);
 			nock('https://example.domain')
-				.post('/oauth/access_token')
-				.query({
-					oauth_token: 'token',
-					oauth_verifier: 'verifier',
-				})
+				.post('/oauth/access_token', 'oauth_token=token&oauth_verifier=verifier')
 				.once()
 				.reply(200, 'access_token=new_token');
 
 			await controller.handleCallback(req, res);
-
 			const dataCaptor = captor();
 			expect(credentialsRepository.update).toHaveBeenCalledWith(
 				'1',

--- a/packages/cli/src/controllers/oauth/oauth1-credential.controller.ts
+++ b/packages/cli/src/controllers/oauth/oauth1-credential.controller.ts
@@ -118,11 +118,12 @@ export class OAuth1CredentialController extends AbstractOAuthController {
 			const [credential, _, oauthCredentials] =
 				await this.resolveCredential<OAuth1CredentialData>(req);
 
-			const oauthToken = await axios.request<string>({
-				method: 'POST',
-				url: oauthCredentials.accessTokenUrl,
-				params: { oauth_token, oauth_verifier },
-			});
+			// Form URL encoded body https://datatracker.ietf.org/doc/html/rfc5849#section-3.5.2
+			const oauthToken = await axios.post<string>(
+				oauthCredentials.accessTokenUrl,
+				{ oauth_token, oauth_verifier },
+				{ headers: { 'content-type': 'application/x-www-form-urlencoded' } },
+			);
 
 			// Response comes as x-www-form-urlencoded string so convert it to JSON
 

--- a/packages/cli/src/controllers/oauth/oauth1-credential.controller.ts
+++ b/packages/cli/src/controllers/oauth/oauth1-credential.controller.ts
@@ -118,9 +118,10 @@ export class OAuth1CredentialController extends AbstractOAuthController {
 			const [credential, _, oauthCredentials] =
 				await this.resolveCredential<OAuth1CredentialData>(req);
 
-			const oauthToken = await axios.post<string>(oauthCredentials.accessTokenUrl, {
-				oauth_token,
-				oauth_verifier,
+			const oauthToken = await axios.request<string>({
+				method: 'POST',
+				url: oauthCredentials.accessTokenUrl,
+				params: { oauth_token, oauth_verifier },
 			});
 
 			// Response comes as x-www-form-urlencoded string so convert it to JSON


### PR DESCRIPTION
## Summary

Since https://github.com/n8n-io/n8n/pull/11593 (1.69.0) our OAuth1 callback endpoint makes `access_token` requests with an HTTP Body in JSON. However according to [OAuth1 spec](https://datatracker.ietf.org/doc/html/rfc5849#section-3.5.2) it should be `application/x-www-form-urlencoded`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2145/community-issue-x-oauth-api-fails-with-error-401

fixes https://github.com/n8n-io/n8n/issues/12114

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
