### PR TITLE
perf(core): Batch raw insights save and add metadata cache

### DIFF
--- a/packages/@n8n/benchmark/scenarios/multiple-webhooks/multiple-webhooks.manifest.json
+++ b/packages/@n8n/benchmark/scenarios/multiple-webhooks/multiple-webhooks.manifest.json
@@ -1,0 +1,20 @@
+{
+	"$schema": "../scenario.schema.json",
+	"name": "MultipleWebhooks",
+	"description": "10 simple webhooks that respond with a 200 status code",
+	"scenarioData": {
+		"workflowFiles": [
+			"multiple-webhooks1.json",
+			"multiple-webhooks2.json",
+			"multiple-webhooks3.json",
+			"multiple-webhooks4.json",
+			"multiple-webhooks5.json",
+			"multiple-webhooks6.json",
+			"multiple-webhooks7.json",
+			"multiple-webhooks8.json",
+			"multiple-webhooks9.json",
+			"multiple-webhooks10.json"
+		]
+	},
+	"scriptPath": "multiple-webhooks.script.js"
+}

--- a/packages/@n8n/benchmark/scenarios/multiple-webhooks/multiple-webhooks.script.js
+++ b/packages/@n8n/benchmark/scenarios/multiple-webhooks/multiple-webhooks.script.js
@@ -1,0 +1,19 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+const apiBaseUrl = __ENV.API_BASE_URL;
+
+export default function () {
+	const urls = Array(10)
+		.fill()
+		.map((_, i) => `${apiBaseUrl}/webhook/multiple-webhook${i + 1}`);
+
+	const res = http.batch(urls);
+
+	for (let i = 0; i < res.length; i++) {
+		// Check if the response status is 200
+		check(res[i], {
+			'is status 200': (r) => r.status === 200,
+		});
+	}
+}

--- a/packages/@n8n/benchmark/scenarios/multiple-webhooks/multiple-webhooks1.json
+++ b/packages/@n8n/benchmark/scenarios/multiple-webhooks/multiple-webhooks1.json
@@ -1,0 +1,25 @@
+{
+	"createdAt": "2024-08-06T12:19:51.268Z",
+	"updatedAt": "2024-08-06T12:20:45.000Z",
+	"name": "Multiple Webhook 1",
+	"active": true,
+	"nodes": [
+		{
+			"parameters": { "path": "multiple-webhook1", "options": {} },
+			"id": "b239bc6c-ea40-438d-bb14-5bce03599685",
+			"name": "Webhook",
+			"type": "n8n-nodes-base.webhook",
+			"typeVersion": 2,
+			"position": [760, 400],
+			"webhookId": "14226baf-ea56-43d7-bc0d-eea841746441"
+		}
+	],
+	"connections": {},
+	"settings": { "executionOrder": "v1" },
+	"staticData": null,
+	"meta": { "templateCredsSetupCompleted": true, "responseMode": "lastNode", "options": {} },
+	"pinData": {},
+	"versionId": "0322386c-ec84-4d38-b895-c206b574f31c",
+	"triggerCount": 1,
+	"tags": []
+}

--- a/packages/@n8n/benchmark/scenarios/multiple-webhooks/multiple-webhooks10.json
+++ b/packages/@n8n/benchmark/scenarios/multiple-webhooks/multiple-webhooks10.json
@@ -1,0 +1,25 @@
+{
+	"createdAt": "2024-08-06T12:19:51.268Z",
+	"updatedAt": "2024-08-06T12:20:45.000Z",
+	"name": "Multiple Webhook 10",
+	"active": true,
+	"nodes": [
+		{
+			"parameters": { "path": "multiple-webhook10", "options": {} },
+			"id": "34ac4500-9a29-4f4f-a604-134aa2cb2889",
+			"name": "Webhook",
+			"type": "n8n-nodes-base.webhook",
+			"typeVersion": 2,
+			"position": [760, 400],
+			"webhookId": "47fe25ac-1376-4ee7-b9de-3fff1d49281c"
+		}
+	],
+	"connections": {},
+	"settings": { "executionOrder": "v1" },
+	"staticData": null,
+	"meta": { "templateCredsSetupCompleted": true, "responseMode": "lastNode", "options": {} },
+	"pinData": {},
+	"versionId": "106d4d2c-49c0-45b8-8421-99cc0c8b1589",
+	"triggerCount": 1,
+	"tags": []
+}

--- a/packages/@n8n/benchmark/scenarios/multiple-webhooks/multiple-webhooks2.json
+++ b/packages/@n8n/benchmark/scenarios/multiple-webhooks/multiple-webhooks2.json
@@ -1,0 +1,25 @@
+{
+	"createdAt": "2024-08-06T12:19:51.268Z",
+	"updatedAt": "2024-08-06T12:20:45.000Z",
+	"name": "Multiple Webhook 2",
+	"active": true,
+	"nodes": [
+		{
+			"parameters": { "path": "multiple-webhook2", "options": {} },
+			"id": "c44ce610-086c-45a6-b347-c7b5df5365ed",
+			"name": "Webhook",
+			"type": "n8n-nodes-base.webhook",
+			"typeVersion": 2,
+			"position": [760, 400],
+			"webhookId": "edc1994b-7cde-4aed-b077-fbc7f21b0f48"
+		}
+	],
+	"connections": {},
+	"settings": { "executionOrder": "v1" },
+	"staticData": null,
+	"meta": { "templateCredsSetupCompleted": true, "responseMode": "lastNode", "options": {} },
+	"pinData": {},
+	"versionId": "b4579dbf-d9c5-4b57-8e1f-883d91e8726b",
+	"triggerCount": 1,
+	"tags": []
+}

--- a/packages/@n8n/benchmark/scenarios/multiple-webhooks/multiple-webhooks3.json
+++ b/packages/@n8n/benchmark/scenarios/multiple-webhooks/multiple-webhooks3.json
@@ -1,0 +1,25 @@
+{
+	"createdAt": "2024-08-06T12:19:51.268Z",
+	"updatedAt": "2024-08-06T12:20:45.000Z",
+	"name": "Multiple Webhook 3",
+	"active": true,
+	"nodes": [
+		{
+			"parameters": { "path": "multiple-webhook3", "options": {} },
+			"id": "34ac4500-9a29-4f4f-a604-134aa2cb2889",
+			"name": "Webhook",
+			"type": "n8n-nodes-base.webhook",
+			"typeVersion": 2,
+			"position": [760, 400],
+			"webhookId": "47fe25ac-1376-4ee7-b9de-3fff1d49281c"
+		}
+	],
+	"connections": {},
+	"settings": { "executionOrder": "v1" },
+	"staticData": null,
+	"meta": { "templateCredsSetupCompleted": true, "responseMode": "lastNode", "options": {} },
+	"pinData": {},
+	"versionId": "106d4d2c-49c0-45b8-8421-99cc0c8b1589",
+	"triggerCount": 1,
+	"tags": []
+}

--- a/packages/@n8n/benchmark/scenarios/multiple-webhooks/multiple-webhooks4.json
+++ b/packages/@n8n/benchmark/scenarios/multiple-webhooks/multiple-webhooks4.json
@@ -1,0 +1,25 @@
+{
+	"createdAt": "2024-08-06T12:19:51.268Z",
+	"updatedAt": "2024-08-06T12:20:45.000Z",
+	"name": "Multiple Webhook 4",
+	"active": true,
+	"nodes": [
+		{
+			"parameters": { "path": "multiple-webhook4", "options": {} },
+			"id": "34ac4500-9a29-4f4f-a604-134aa2cb2889",
+			"name": "Webhook",
+			"type": "n8n-nodes-base.webhook",
+			"typeVersion": 2,
+			"position": [760, 400],
+			"webhookId": "47fe25ac-1376-4ee7-b9de-3fff1d49281c"
+		}
+	],
+	"connections": {},
+	"settings": { "executionOrder": "v1" },
+	"staticData": null,
+	"meta": { "templateCredsSetupCompleted": true, "responseMode": "lastNode", "options": {} },
+	"pinData": {},
+	"versionId": "106d4d2c-49c0-45b8-8421-99cc0c8b1589",
+	"triggerCount": 1,
+	"tags": []
+}

--- a/packages/@n8n/benchmark/scenarios/multiple-webhooks/multiple-webhooks5.json
+++ b/packages/@n8n/benchmark/scenarios/multiple-webhooks/multiple-webhooks5.json
@@ -1,0 +1,25 @@
+{
+	"createdAt": "2024-08-06T12:19:51.268Z",
+	"updatedAt": "2024-08-06T12:20:45.000Z",
+	"name": "Multiple Webhook 5",
+	"active": true,
+	"nodes": [
+		{
+			"parameters": { "path": "multiple-webhook5", "options": {} },
+			"id": "34ac4500-9a29-4f4f-a604-134aa2cb2889",
+			"name": "Webhook",
+			"type": "n8n-nodes-base.webhook",
+			"typeVersion": 2,
+			"position": [760, 400],
+			"webhookId": "47fe25ac-1376-4ee7-b9de-3fff1d49281c"
+		}
+	],
+	"connections": {},
+	"settings": { "executionOrder": "v1" },
+	"staticData": null,
+	"meta": { "templateCredsSetupCompleted": true, "responseMode": "lastNode", "options": {} },
+	"pinData": {},
+	"versionId": "106d4d2c-49c0-45b8-8421-99cc0c8b1589",
+	"triggerCount": 1,
+	"tags": []
+}

--- a/packages/@n8n/benchmark/scenarios/multiple-webhooks/multiple-webhooks6.json
+++ b/packages/@n8n/benchmark/scenarios/multiple-webhooks/multiple-webhooks6.json
@@ -1,0 +1,25 @@
+{
+	"createdAt": "2024-08-06T12:19:51.268Z",
+	"updatedAt": "2024-08-06T12:20:45.000Z",
+	"name": "Multiple Webhook 6",
+	"active": true,
+	"nodes": [
+		{
+			"parameters": { "path": "multiple-webhook6", "options": {} },
+			"id": "34ac4500-9a29-4f4f-a604-134aa2cb2889",
+			"name": "Webhook",
+			"type": "n8n-nodes-base.webhook",
+			"typeVersion": 2,
+			"position": [760, 400],
+			"webhookId": "47fe25ac-1376-4ee7-b9de-3fff1d49281c"
+		}
+	],
+	"connections": {},
+	"settings": { "executionOrder": "v1" },
+	"staticData": null,
+	"meta": { "templateCredsSetupCompleted": true, "responseMode": "lastNode", "options": {} },
+	"pinData": {},
+	"versionId": "106d4d2c-49c0-45b8-8421-99cc0c8b1589",
+	"triggerCount": 1,
+	"tags": []
+}

--- a/packages/@n8n/benchmark/scenarios/multiple-webhooks/multiple-webhooks7.json
+++ b/packages/@n8n/benchmark/scenarios/multiple-webhooks/multiple-webhooks7.json
@@ -1,0 +1,25 @@
+{
+	"createdAt": "2024-08-06T12:19:51.268Z",
+	"updatedAt": "2024-08-06T12:20:45.000Z",
+	"name": "Multiple Webhook 7",
+	"active": true,
+	"nodes": [
+		{
+			"parameters": { "path": "multiple-webhook7", "options": {} },
+			"id": "34ac4500-9a29-4f4f-a604-134aa2cb2889",
+			"name": "Webhook",
+			"type": "n8n-nodes-base.webhook",
+			"typeVersion": 2,
+			"position": [760, 400],
+			"webhookId": "47fe25ac-1376-4ee7-b9de-3fff1d49281c"
+		}
+	],
+	"connections": {},
+	"settings": { "executionOrder": "v1" },
+	"staticData": null,
+	"meta": { "templateCredsSetupCompleted": true, "responseMode": "lastNode", "options": {} },
+	"pinData": {},
+	"versionId": "106d4d2c-49c0-45b8-8421-99cc0c8b1589",
+	"triggerCount": 1,
+	"tags": []
+}

--- a/packages/@n8n/benchmark/scenarios/multiple-webhooks/multiple-webhooks8.json
+++ b/packages/@n8n/benchmark/scenarios/multiple-webhooks/multiple-webhooks8.json
@@ -1,0 +1,25 @@
+{
+	"createdAt": "2024-08-06T12:19:51.268Z",
+	"updatedAt": "2024-08-06T12:20:45.000Z",
+	"name": "Multiple Webhook 8",
+	"active": true,
+	"nodes": [
+		{
+			"parameters": { "path": "multiple-webhook8", "options": {} },
+			"id": "34ac4500-9a29-4f4f-a604-134aa2cb2889",
+			"name": "Webhook",
+			"type": "n8n-nodes-base.webhook",
+			"typeVersion": 2,
+			"position": [760, 400],
+			"webhookId": "47fe25ac-1376-4ee7-b9de-3fff1d49281c"
+		}
+	],
+	"connections": {},
+	"settings": { "executionOrder": "v1" },
+	"staticData": null,
+	"meta": { "templateCredsSetupCompleted": true, "responseMode": "lastNode", "options": {} },
+	"pinData": {},
+	"versionId": "106d4d2c-49c0-45b8-8421-99cc0c8b1589",
+	"triggerCount": 1,
+	"tags": []
+}

--- a/packages/@n8n/benchmark/scenarios/multiple-webhooks/multiple-webhooks9.json
+++ b/packages/@n8n/benchmark/scenarios/multiple-webhooks/multiple-webhooks9.json
@@ -1,0 +1,25 @@
+{
+	"createdAt": "2024-08-06T12:19:51.268Z",
+	"updatedAt": "2024-08-06T12:20:45.000Z",
+	"name": "Multiple Webhook 9",
+	"active": true,
+	"nodes": [
+		{
+			"parameters": { "path": "multiple-webhook9", "options": {} },
+			"id": "34ac4500-9a29-4f4f-a604-134aa2cb2889",
+			"name": "Webhook",
+			"type": "n8n-nodes-base.webhook",
+			"typeVersion": 2,
+			"position": [760, 400],
+			"webhookId": "47fe25ac-1376-4ee7-b9de-3fff1d49281c"
+		}
+	],
+	"connections": {},
+	"settings": { "executionOrder": "v1" },
+	"staticData": null,
+	"meta": { "templateCredsSetupCompleted": true, "responseMode": "lastNode", "options": {} },
+	"pinData": {},
+	"versionId": "106d4d2c-49c0-45b8-8421-99cc0c8b1589",
+	"triggerCount": 1,
+	"tags": []
+}

--- a/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
@@ -2,7 +2,7 @@ import { Container } from '@n8n/di';
 import { In, type EntityManager } from '@n8n/typeorm';
 import { mock } from 'jest-mock-extended';
 import { DateTime } from 'luxon';
-import type { ExecutionLifecycleHooks } from 'n8n-core';
+import { Logger, type ExecutionLifecycleHooks } from 'n8n-core';
 import type { ExecutionStatus, IRun, WorkflowExecuteMode } from 'n8n-workflow';
 
 import type { Project } from '@/databases/entities/project';
@@ -12,6 +12,7 @@ import type { IWorkflowDb } from '@/interfaces';
 import type { TypeUnit } from '@/modules/insights/database/entities/insights-shared';
 import { InsightsMetadataRepository } from '@/modules/insights/database/repositories/insights-metadata.repository';
 import { InsightsRawRepository } from '@/modules/insights/database/repositories/insights-raw.repository';
+import { mockInstance } from '@test/mocking';
 import { createTeamProject } from '@test-integration/db/projects';
 import { createWorkflow } from '@test-integration/db/workflows';
 import * as testDb from '@test-integration/test-db';
@@ -269,6 +270,7 @@ describe('workflowExecuteAfterHandler', () => {
 				sharedWorkflowRepositoryMock,
 				Container.get(InsightsByPeriodRepository),
 				insightsRawRepository,
+				mockInstance(Logger),
 			);
 		});
 
@@ -424,6 +426,7 @@ describe('workflowExecuteAfterHandler', () => {
 				sharedWorkflowRepositoryMock,
 				Container.get(InsightsByPeriodRepository),
 				insightsRawRepository,
+				mockInstance(Logger),
 			);
 
 			trxMock.find = jest.fn().mockResolvedValue([

--- a/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
@@ -613,10 +613,7 @@ describe('workflowExecuteAfterHandler - flushEvents', () => {
 		const ctx = mock<ExecutionLifecycleHooks>({ workflowData: workflow });
 
 		// Flush will hang until we manually resolve it
-		let flushResolve: () => void;
-		const flushPromise = new Promise<void>((resolve) => {
-			flushResolve = resolve;
-		});
+		const { resolve: flushResolve, promise: flushPromise } = createDeferredPromise();
 
 		// First flush will "hang" (simulate long save)
 		trxMock.insert.mockImplementationOnce(async () => {

--- a/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
@@ -4,7 +4,12 @@ import { mock } from 'jest-mock-extended';
 import { DateTime } from 'luxon';
 import type { Logger } from 'n8n-core';
 import { type ExecutionLifecycleHooks } from 'n8n-core';
-import type { ExecutionStatus, IRun, WorkflowExecuteMode } from 'n8n-workflow';
+import {
+	createDeferredPromise,
+	type ExecutionStatus,
+	type IRun,
+	type WorkflowExecuteMode,
+} from 'n8n-workflow';
 
 import type { Project } from '@/databases/entities/project';
 import type { WorkflowEntity } from '@/databases/entities/workflow-entity';
@@ -643,7 +648,7 @@ describe('workflowExecuteAfterHandler - flushEvents', () => {
 
 		// ACT
 		// Now resolve the hanging flush and await shutdown
-		flushResolve!();
+		flushResolve();
 		await shutdownPromise;
 
 		// ASSERT

--- a/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
@@ -94,7 +94,7 @@ describe('workflowExecuteAfterHandler', () => {
 		});
 
 		// ACT
-		const now = new Date();
+		const now = DateTime.utc().toJSDate();
 		await insightsService.workflowExecuteAfterHandler(ctx, run);
 		await insightsService.flushEvents();
 

--- a/packages/cli/src/modules/insights/insights.config.ts
+++ b/packages/cli/src/modules/insights/insights.config.ts
@@ -35,7 +35,7 @@ export class InsightsConfig {
 	 * Default: 100
 	 */
 	@Env('N8N_INSIGHTS_FLUSH_BATCH_SIZE')
-	flushBatchSize: number = 100;
+	flushBatchSize: number = 1000;
 
 	/**
 	 * The interval in seconds at which the insights data should be flushed to the database.

--- a/packages/cli/src/modules/insights/insights.config.ts
+++ b/packages/cli/src/modules/insights/insights.config.ts
@@ -29,4 +29,18 @@ export class InsightsConfig {
 	 */
 	@Env('N8N_INSIGHTS_COMPACTION_DAILY_TO_WEEKLY_THRESHOLD_DAYS')
 	compactionDailyToWeeklyThresholdDays: number = 180;
+
+	/**
+	 * The maximum number of insights data to keep in the buffer before flushing.
+	 * Default: 100
+	 */
+	@Env('N8N_INSIGHTS_FLUSH_BATCH_SIZE')
+	flushBatchSize: number = 100;
+
+	/**
+	 * The interval in seconds at which the insights data should be flushed to the database.
+	 * Default: 30
+	 */
+	@Env('N8N_INSIGHTS_FLUSH_INTERVAL_SECONDS')
+	flushIntervalSeconds: number = 30;
 }

--- a/packages/cli/src/modules/insights/insights.config.ts
+++ b/packages/cli/src/modules/insights/insights.config.ts
@@ -32,7 +32,7 @@ export class InsightsConfig {
 
 	/**
 	 * The maximum number of insights data to keep in the buffer before flushing.
-	 * Default: 100
+	 * Default: 1000
 	 */
 	@Env('N8N_INSIGHTS_FLUSH_BATCH_SIZE')
 	flushBatchSize: number = 1000;

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -123,13 +123,14 @@ export class InsightsService {
 				);
 			}
 
+			const events: InsightsRaw[] = [];
 			// success or failure event
 			{
 				const event = new InsightsRaw();
 				event.metaId = metadata.metaId;
 				event.type = status;
 				event.value = 1;
-				await trx.insert(InsightsRaw, event);
+				events.push(event);
 			}
 
 			// run time event
@@ -139,7 +140,7 @@ export class InsightsService {
 				event.metaId = metadata.metaId;
 				event.type = 'runtime_ms';
 				event.value = value;
-				await trx.insert(InsightsRaw, event);
+				events.push(event);
 			}
 
 			// time saved event
@@ -148,8 +149,10 @@ export class InsightsService {
 				event.metaId = metadata.metaId;
 				event.type = 'time_saved_min';
 				event.value = ctx.workflowData.settings.timeSavedPerExecution;
-				await trx.insert(InsightsRaw, event);
+				events.push(event);
 			}
+
+			await trx.insert(InsightsRaw, events);
 		});
 	}
 

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -3,7 +3,12 @@ import { Container, Service } from '@n8n/di';
 import { In } from '@n8n/typeorm';
 import { Logger } from 'n8n-core';
 import type { ExecutionLifecycleHooks } from 'n8n-core';
-import { type ExecutionStatus, type IRun, type WorkflowExecuteMode } from 'n8n-workflow';
+import {
+	UnexpectedError,
+	type ExecutionStatus,
+	type IRun,
+	type WorkflowExecuteMode,
+} from 'n8n-workflow';
 
 import { SharedWorkflow } from '@/databases/entities/shared-workflow';
 import { SharedWorkflowRepository } from '@/databases/repositories/shared-workflow.repository';
@@ -88,6 +93,7 @@ export class InsightsService {
 	}
 
 	scheduleFlushing() {
+		this.isAsynchronouslySavingInsights = true;
 		this.disposeFlushing();
 		this.flushInsightsRawBufferTimer = setTimeout(
 			async () => await this.flushEvents(),
@@ -178,71 +184,65 @@ export class InsightsService {
 			workflowIdNames.set(event.workflowId, event.workflowName);
 		}
 
-		// Save the current cached metadata to restore it in case of an error
-		const oldCachedMetadata = new Map(this.cachedMetadata);
-
-		await this.sharedWorkflowRepository.manager
-			.transaction(async (trx) => {
-				const sharedWorkflows = await trx.find(SharedWorkflow, {
-					where: { workflowId: In([...workflowIdNames.keys()]), role: 'workflow:owner' },
-					relations: { project: true },
-				});
-
-				// Upsert metadata for the workflows that are not already in the cache or have
-				// different project or workflow names
-				const metadataToUpsert = sharedWorkflows.reduce((acc, workflow) => {
-					const cachedMetadata = this.cachedMetadata.get(workflow.workflowId);
-					if (
-						!cachedMetadata ||
-						cachedMetadata.projectId !== workflow.projectId ||
-						cachedMetadata.projectName !== workflow.project.name ||
-						cachedMetadata.workflowName !== workflowIdNames.get(workflow.workflowId)
-					) {
-						const metadata = new InsightsMetadata();
-						metadata.projectId = workflow.projectId;
-						metadata.projectName = workflow.project.name;
-						metadata.workflowId = workflow.workflowId;
-						metadata.workflowName = workflowIdNames.get(workflow.workflowId)!;
-
-						// Update the cache with the new metadata
-						this.cachedMetadata.set(metadata.workflowId, metadata);
-						acc.push(metadata);
-					}
-					return acc;
-				}, [] as InsightsMetadata[]);
-
-				await trx.upsert(InsightsMetadata, metadataToUpsert, ['workflowId']);
-
-				const events: InsightsRaw[] = [];
-				for (const event of insightsRawToInsertBuffer) {
-					const insight = new InsightsRaw();
-					const metadata = this.cachedMetadata.get(event.workflowId);
-					if (!metadata) {
-						// could not find shared workflow for this insight
-						continue;
-					}
-					insight.metaId = metadata.metaId;
-					insight.type = event.type;
-					insight.value = event.value;
-
-					events.push(insight);
-				}
-
-				await trx.insert(InsightsRaw, events);
-			})
-			.catch((e) => {
-				this.logger.error('Error while saving insights metadata and raw data', { error: e });
-
-				// If there was an error, reset the cached metadata to the old one
-				this.cachedMetadata.clear();
-				oldCachedMetadata.forEach((value, key) => {
-					this.cachedMetadata.set(key, value);
-				});
+		await this.sharedWorkflowRepository.manager.transaction(async (trx) => {
+			const sharedWorkflows = await trx.find(SharedWorkflow, {
+				where: { workflowId: In([...workflowIdNames.keys()]), role: 'workflow:owner' },
+				relations: { project: true },
 			});
+
+			// Upsert metadata for the workflows that are not already in the cache or have
+			// different project or workflow names
+			const metadataToUpsert = sharedWorkflows.reduce((acc, workflow) => {
+				const cachedMetadata = this.cachedMetadata.get(workflow.workflowId);
+				if (
+					!cachedMetadata ||
+					cachedMetadata.projectId !== workflow.projectId ||
+					cachedMetadata.projectName !== workflow.project.name ||
+					cachedMetadata.workflowName !== workflowIdNames.get(workflow.workflowId)
+				) {
+					const metadata = new InsightsMetadata();
+					metadata.projectId = workflow.projectId;
+					metadata.projectName = workflow.project.name;
+					metadata.workflowId = workflow.workflowId;
+					metadata.workflowName = workflowIdNames.get(workflow.workflowId)!;
+
+					acc.push(metadata);
+				}
+				return acc;
+			}, [] as InsightsMetadata[]);
+
+			await trx.upsert(InsightsMetadata, metadataToUpsert, ['workflowId']);
+
+			const upsertMetadata = await trx.findBy(InsightsMetadata, {
+				workflowId: In(metadataToUpsert.map((m) => m.workflowId)),
+			});
+			for (const metadata of upsertMetadata) {
+				this.cachedMetadata.set(metadata.workflowId, metadata);
+			}
+
+			const events: InsightsRaw[] = [];
+			for (const event of insightsRawToInsertBuffer) {
+				const insight = new InsightsRaw();
+				const metadata = this.cachedMetadata.get(event.workflowId);
+				if (!metadata) {
+					// could not find shared workflow for this insight (not supposed to happen)
+					throw new UnexpectedError(
+						`Could not find shared workflow for insight with workflowId ${event.workflowId}`,
+					);
+				}
+				insight.metaId = metadata.metaId;
+				insight.type = event.type;
+				insight.value = event.value;
+
+				events.push(insight);
+			}
+
+			await trx.insert(InsightsRaw, events);
+		});
 	}
 
 	async flushEvents() {
-		// Prevent flushing if we are already flushing or if there are no events to flush
+		// Prevent flushing if there are no events to flush and we are not forcing it
 		if (this.bufferedInsights.size === 0) {
 			return;
 		}

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -76,7 +76,7 @@ export class InsightsService {
 		private readonly insightsRawRepository: InsightsRawRepository,
 		private readonly logger: Logger,
 	) {
-		this.logger.scoped('insights');
+		this.logger = this.logger.scoped('insights');
 		this.initializeCompaction();
 		this.scheduleFlushing();
 	}

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -1,6 +1,7 @@
 import type { InsightsSummary } from '@n8n/api-types';
 import { Container, Service } from '@n8n/di';
 import { In } from '@n8n/typeorm';
+import { DateTime } from 'luxon';
 import { Logger } from 'n8n-core';
 import type { ExecutionLifecycleHooks } from 'n8n-core';
 import {
@@ -141,8 +142,9 @@ export class InsightsService {
 		const commonWorkflowData = {
 			workflowId: ctx.workflowData.id,
 			workflowName: ctx.workflowData.name,
-			timestamp: new Date(),
+			timestamp: DateTime.utc().toJSDate(),
 		};
+
 		// success or failure event
 		this.bufferedInsights.add({
 			...commonWorkflowData,

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -53,7 +53,7 @@ const shouldSkipMode: Record<WorkflowExecuteMode, boolean> = {
 	manual: true,
 };
 
-type BufferedInsight = Pick<InsightsRaw, 'type' | 'value'> & {
+type BufferedInsight = Pick<InsightsRaw, 'type' | 'value' | 'timestamp'> & {
 	workflowId: string;
 	workflowName: string;
 };
@@ -141,6 +141,7 @@ export class InsightsService {
 		const commonWorkflowData = {
 			workflowId: ctx.workflowData.id,
 			workflowName: ctx.workflowData.name,
+			timestamp: new Date(),
 		};
 		// success or failure event
 		this.bufferedInsights.add({
@@ -236,6 +237,7 @@ export class InsightsService {
 				insight.metaId = metadata.metaId;
 				insight.type = event.type;
 				insight.value = event.value;
+				insight.timestamp = event.timestamp;
 
 				events.push(insight);
 			}


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
Adds two performance improvements when saving insights after workflow execution:
- batch all raw insights into one insert call
- implement buffer / flush mechanism to save all insights in a buffer, flushing it regularly and if it reaches a size limit
- saves existing workflow metadata into memory cache to prevent upserting and finding it

The metadata memory cache will contain all already executed workflow metadata, and is updated if the metadata changes (workflow name, project id, project name).

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2717/implement-insights-raw-batch-insert

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [X] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [X] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
