### PR TITLE
fix(ReadWriteFile): Add binary property reference to JSON output

### DIFF
--- a/packages/nodes-base/nodes/Files/ReadWriteFile/actions/read.operation.ts
+++ b/packages/nodes-base/nodes/Files/ReadWriteFile/actions/read.operation.ts
@@ -127,6 +127,7 @@ export async function execute(this: IExecuteFunctions, items: INodeExecutionData
 						directory: binaryData.directory,
 						fileExtension: binaryData.fileExtension,
 						fileSize: binaryData.fileSize,
+						binaryProperty: dataPropertyName,
 					},
 					pairedItem: {
 						item: itemIndex,


### PR DESCRIPTION
## Summary
When using the "Put Output File in Field" option in the Read/Write Files from Disk node, the binary data was not visible in the output. This PR adds a `binaryProperty` field to the JSON output, which references the field containing the binary data, making it accessible in the output.

This fixes an issue where users couldn't see or access binary data when using the "Put Output File in Field" option, despite the binary data being properly stored internally.

## Related Linear tickets, Github issues, and Community forum posts
Fixes #14271
Related to internal ticket GHC-1391