### PR TITLE
feat(SendGrid Node): Add option to specify "reply to" email addresses

### DIFF
--- a/packages/nodes-base/nodes/SendGrid/MailDescription.ts
+++ b/packages/nodes-base/nodes/SendGrid/MailDescription.ts
@@ -252,6 +252,15 @@ export const mailFields: INodeProperties[] = [
 				description: 'The IP Pool that you would like to send this email from',
 			},
 			{
+				displayName: 'Reply-To Email',
+				name: 'replyToEmail',
+				type: 'string',
+				default: '',
+				placeholder: 'reply@domain.com',
+				description:
+					'Comma-separated list of email addresses that will appear in the reply-to field of the email',
+			},
+			{
 				displayName: 'Headers',
 				name: 'headers',
 				placeholder: 'Add Header',
@@ -306,6 +315,7 @@ export type SendMailBody = {
 	}>;
 	ip_pool_name?: string;
 	from: EmailName;
+	reply_to_list?: EmailName[];
 	template_id?: string;
 	content?: Array<{
 		type: string;

--- a/packages/nodes-base/nodes/SendGrid/SendGrid.node.ts
+++ b/packages/nodes-base/nodes/SendGrid/SendGrid.node.ts
@@ -524,6 +524,7 @@ export class SendGrid implements INodeType {
 							attachments,
 							categories,
 							ipPoolName,
+							replyToEmail,
 						} = this.getNodeParameter('additionalFields', i) as {
 							bccEmail: string;
 							ccEmail: string;
@@ -533,6 +534,7 @@ export class SendGrid implements INodeType {
 							attachments: string;
 							categories: string;
 							ipPoolName: string;
+							replyToEmail: string;
 						};
 
 						const body: SendMailBody = {
@@ -628,6 +630,12 @@ export class SendGrid implements INodeType {
 
 						if (sendAt) {
 							body.personalizations[0].send_at = moment.tz(sendAt, timezone).unix();
+						}
+
+						if (replyToEmail) {
+							body.reply_to_list = replyToEmail
+								.split(',')
+								.map((entry) => ({ email: entry.trim() }));
 						}
 
 						const data = await sendGridApiRequest.call(this, '/mail/send', 'POST', body, qs, {

--- a/packages/nodes-base/nodes/SendGrid/test/SendGrid.node.test.ts
+++ b/packages/nodes-base/nodes/SendGrid/test/SendGrid.node.test.ts
@@ -1,0 +1,30 @@
+/* eslint-disable n8n-nodes-base/node-param-display-name-miscased */
+import nock from 'nock';
+
+import { testWorkflows } from '@test/nodes/Helpers';
+
+describe('Test SendGrid Node', () => {
+	beforeAll(() => {
+		nock.disableNetConnect();
+	});
+
+	describe('Mail', () => {
+		const sendgridNock = nock('https://api.sendgrid.com/v3');
+
+		beforeAll(() => {
+			sendgridNock
+				.post(
+					'/mail/send',
+					(body: { reply_to_list?: [{ email: string }] }) =>
+						body?.reply_to_list?.[0]?.email === 'test-reply-to@n8n.io',
+				)
+				.reply(202);
+		});
+
+		testWorkflows(['nodes/SendGrid/test/mail.workflow.json']);
+
+		it('should make the correct network calls', () => {
+			sendgridNock.done();
+		});
+	});
+});

--- a/packages/nodes-base/nodes/SendGrid/test/mail.workflow.json
+++ b/packages/nodes-base/nodes/SendGrid/test/mail.workflow.json
@@ -1,0 +1,62 @@
+{
+	"name": "mail",
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0],
+			"id": "0b4c0843-6007-4687-8e91-cf3b97cb0734",
+			"name": "When clicking ‘Test workflow’"
+		},
+		{
+			"parameters": {
+				"resource": "mail",
+				"fromEmail": "test@n8n.io",
+				"fromName": "Test Sender",
+				"toEmail": "test@n8n.io",
+				"subject": "Test Subject",
+				"contentValue": "Test Message",
+				"additionalFields": {
+					"replyToEmail": "test-reply-to@n8n.io"
+				}
+			},
+			"type": "n8n-nodes-base.sendGrid",
+			"typeVersion": 1,
+			"position": [220, 0],
+			"id": "69ea4501-a90d-4067-b9f7-a7b7f2b79a96",
+			"name": "SendGrid",
+			"credentials": {
+				"sendGridApi": {
+					"id": "3D7B6nvmzW0SZkjG",
+					"name": "SendGrid account"
+				}
+			}
+		}
+	],
+	"pinData": {},
+	"connections": {
+		"When clicking ‘Test workflow’": {
+			"main": [
+				[
+					{
+						"node": "SendGrid",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "7e4ed87a-64b8-4248-b78f-e2db21f1f603",
+	"meta": {
+		"templateCredsSetupCompleted": true,
+		"instanceId": "35e7acdc2e5caa3b0a5fca77da6cc9361ca88ba3e6f6b97ecd8a8cf35cb2ea85"
+	},
+	"id": "YdfKbNlA37FExwxC",
+	"tags": []
+}


### PR DESCRIPTION
## Summary

Add an ability to specify email address(es) to which replies will be sent.

## Related Linear tickets, Github issues, and Community forum posts

https://community.n8n.io/t/add-reply-to-reply-to-list-field-on-sendgrid-node/14684

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
