### PR TITLE
fix: Add type shims to core package for nodes-base imports (no-changelog)

### DIFF
--- a/packages/core/test/shims.d.ts
+++ b/packages/core/test/shims.d.ts
@@ -1,0 +1,1 @@
+declare module '../../../nodes-base/dist/nodes/*';


### PR DESCRIPTION
## Summary

Fixes `typecheck` issue introduced by https://github.com/n8n-io/n8n/pull/14192

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
