### PR TITLE
ci: Separate caching for ui tests (no-changelog)

### DIFF
--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -89,7 +89,7 @@ jobs:
             /home/runner/.cache/Cypress
             /github/home/.pnpm-store
             ./packages/**/dist
-          key: ${{ github.sha }}-base:build
+          key: ${{ github.sha }}-ui
 
       - name: Install dependencies
         if: steps.cache-build-artifacts.outputs.cache-hit != 'true'
@@ -139,7 +139,7 @@ jobs:
             /home/runner/.cache/Cypress
             /github/home/.pnpm-store
             ./packages/**/dist
-          key: ${{ github.sha }}-base:build
+          key: ${{ github.sha }}-ui
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

This reverts to using a separate cache for the unit tests and e2e ui tests. There are different paths used between both, with Cypress binaries not included.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-734/ci-caching-issues

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
