### PR TITLE
fix: Push tidy up telemetry events to posthog (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasOperations.test.ts
@@ -527,11 +527,15 @@ describe('useCanvasOperations', () => {
 			const { tidyUp } = useCanvasOperations({ router });
 			tidyUp(event);
 
-			expect(useTelemetry().track).toHaveBeenCalledWith('User tidied up canvas', {
-				nodes_count: 2,
-				source: 'canvas-button',
-				target: 'all',
-			});
+			expect(useTelemetry().track).toHaveBeenCalledWith(
+				'User tidied up canvas',
+				{
+					nodes_count: 2,
+					source: 'canvas-button',
+					target: 'all',
+				},
+				{ withPostHog: true },
+			);
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
@@ -175,11 +175,15 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 	}
 
 	function trackTidyUp({ result, source, target }: CanvasLayoutEvent) {
-		telemetry.track('User tidied up canvas', {
-			source,
-			target,
-			nodes_count: result.nodes.length,
-		});
+		telemetry.track(
+			'User tidied up canvas',
+			{
+				source,
+				target,
+				nodes_count: result.nodes.length,
+			},
+			{ withPostHog: true },
+		);
 	}
 
 	function updateNodesPosition(


### PR DESCRIPTION
## Summary

Push tidy up telemetry events to posthog

https://linear.app/n8n/issue/NODE-2494/add-telemetry-to-tidy-up#comment-c741acb6

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
