### PR TITLE
fix(ERPNext Node): filters error and add like operator

### DIFF
--- a/packages/nodes-base/nodes/ERPNext/DocumentDescription.ts
+++ b/packages/nodes-base/nodes/ERPNext/DocumentDescription.ts
@@ -182,6 +182,10 @@ export const documentFields: INodeProperties[] = [
 										name: 'IS NOT',
 										value: 'isNot',
 									},
+									{
+										name: 'LIKE',
+										value: 'like',
+									},
 								],
 							},
 							{

--- a/packages/nodes-base/nodes/ERPNext/ERPNext.node.ts
+++ b/packages/nodes-base/nodes/ERPNext/ERPNext.node.ts
@@ -179,7 +179,7 @@ export class ERPNext implements INodeType {
 					if (filters) {
 						qs.filters = JSON.stringify(
 							filters.customProperty.map((filter) => {
-								return [docType, filter.field, toSQL(filter.operator), filter.value];
+								return [filter.field, toSQL(filter.operator), filter.value];
 							}),
 						);
 					}

--- a/packages/nodes-base/nodes/ERPNext/utils.ts
+++ b/packages/nodes-base/nodes/ERPNext/utils.ts
@@ -22,6 +22,7 @@ export const toSQL = (operator: string) => {
 		less: '<',
 		equalsGreater: '>=',
 		equalsLess: '<=',
+		like: 'like',
 	};
 
 	return operators[operator];


### PR DESCRIPTION
## Summary

I'm really sorry, I'm a beginner in Typescript and I don't know how to write test code using jest.
The filter function of the ERPNextNode is not working. I modified some codes and built a docker custom image to confirm that the modified code worked properly.
I tried to write a test case using GPT, but it doesn't work well, so I register PR at least like this.
Once again, I'm sorry that I didn't follow the guidelines.

![image](https://github.com/user-attachments/assets/1b7efda7-5331-4e79-8331-8e7cc17bc5bd)
### ERPNext REST API Documentation

[ERPNext REST API Documentation](https://docs.frappe.io/framework/user/en/guides/integration/rest_api/listing_documents)

### Filter Functionality
The `filter` functionality in ERPNext's REST API does **not require** the `doctype`. This means you can apply various filter conditions without the need to specify a `doctype` when fetching document lists.

### 'LIKE' Operator Added
Additionally, the commonly used **'like'** operator has been added to the API. This allows for more flexible string filtering.

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
