### PR TITLE
fix(editor): Hide node toolbar on `AddNodes` node type

### DIFF
--- a/packages/frontend/editor-ui/src/components/canvas/elements/nodes/CanvasNode.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/elements/nodes/CanvasNode.vue
@@ -288,6 +288,8 @@ provide(CanvasNodeKey, {
 	eventBus: canvasNodeEventBus,
 });
 
+const hasToolbar = computed(() => props.data.type !== CanvasNodeRenderType.AddNodes);
+
 const showToolbar = computed(() => {
 	const target = contextMenu.target.value;
 	return contextMenu.isOpen && target?.source === 'node-button' && target.nodeId === id.value;
@@ -373,7 +375,7 @@ onBeforeUnmount(() => {
 		</template>
 
 		<CanvasNodeToolbar
-			v-else
+			v-else-if="hasToolbar"
 			data-test-id="canvas-node-toolbar"
 			:read-only="readOnly"
 			:class="$style.canvasNodeToolbar"


### PR DESCRIPTION
## Summary

<img width="335" alt="image" src="https://github.com/user-attachments/assets/4addb072-a548-45f5-8568-a252760eeffd" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-736/nodes-toolbar-showing-up-on-addnodes-node-type

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
