### PR TITLE
ci: Fix code coverage for nodes-base (no-changelog)

### DIFF
--- a/packages/nodes-base/test/nodes/load-nodes-and-credentials.ts
+++ b/packages/nodes-base/test/nodes/load-nodes-and-credentials.ts
@@ -6,7 +6,14 @@ import type {
 	IVersionedNodeType,
 	KnownNodesAndCredentials,
 	LoadedClass,
+	LoadingDetails,
 } from 'n8n-workflow';
+
+/** This rewrites the nodes/credentials source path to load the typescript code instead of the compiled javascript code */
+const fixSourcePath = (loadInfo: LoadingDetails) => {
+	if (!loadInfo) return;
+	loadInfo.sourcePath = loadInfo.sourcePath.replace(/^dist\//, './').replace(/\.js$/, '.ts');
+};
 
 @Service()
 export class LoadNodesAndCredentials {
@@ -29,11 +36,13 @@ export class LoadNodesAndCredentials {
 	}
 
 	getCredential(credentialType: string): LoadedClass<ICredentialType> {
+		fixSourcePath(this.known.credentials[credentialType]);
 		return this.loader.getCredential(credentialType);
 	}
 
 	getNode(fullNodeType: string): LoadedClass<INodeType | IVersionedNodeType> {
 		const nodeType = fullNodeType.split('.')[1];
+		fixSourcePath(this.known.nodes[nodeType]);
 		return this.loader.getNode(nodeType);
 	}
 }


### PR DESCRIPTION
## Summary

#14303 broke code coverage for nodes because we started loading the nodes and credentials from the `dist` folder, which is not included in `collectCoverageFrom` in jest setup.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
