### PR TITLE
fix(editor): Make styling of search labels inline

### DIFF
--- a/packages/frontend/editor-ui/src/components/CodeNodeEditor/theme.ts
+++ b/packages/frontend/editor-ui/src/components/CodeNodeEditor/theme.ts
@@ -246,6 +246,7 @@ export const codeEditorTheme = ({ isReadOnly, minHeight, maxHeight, rows }: Them
 		},
 		'.cm-panel.cm-search label': {
 			fontSize: '90%',
+			display: 'inline',
 		},
 		'.cm-button': {
 			outline: 'none',


### PR DESCRIPTION
## Summary

Make styling of search labels inline. Reverts to old design.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2525/code-node-search-styling-messed-up

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
