### PR TITLE
fix(API): Insights - round failure rate to 3 decimals

### DIFF
--- a/packages/cli/src/modules/insights/__tests__/insights.controller.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.controller.test.ts
@@ -58,7 +58,7 @@ describe('InsightsController', () => {
 			expect(response).toEqual({
 				total: { deviation: null, unit: 'count', value: 30 },
 				failed: { deviation: null, unit: 'count', value: 10 },
-				failureRate: { deviation: null, unit: 'ratio', value: 0.33 },
+				failureRate: { deviation: null, unit: 'ratio', value: 0.333 },
 				averageRunTime: { deviation: null, unit: 'time', value: 10 },
 				timeSaved: { deviation: null, unit: 'time', value: 10 },
 			});
@@ -84,7 +84,7 @@ describe('InsightsController', () => {
 			expect(response).toEqual({
 				total: { deviation: 10, unit: 'count', value: 30 },
 				failed: { deviation: 6, unit: 'count', value: 10 },
-				failureRate: { deviation: 0.33 - 0.2, unit: 'ratio', value: 0.33 },
+				failureRate: { deviation: 0.333 - 0.2, unit: 'ratio', value: 0.333 },
 				averageRunTime: { deviation: 300 / 30 - 40 / 20, unit: 'time', value: 10 },
 				timeSaved: { deviation: 5, unit: 'time', value: 10 },
 			});

--- a/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
@@ -754,7 +754,7 @@ describe('getInsightsSummary', () => {
 		});
 		await createCompactedInsightsEvent(workflow, {
 			type: 'failure',
-			value: 2,
+			value: 1,
 			periodUnit: 'day',
 			periodStart: DateTime.utc(),
 		});
@@ -778,10 +778,10 @@ describe('getInsightsSummary', () => {
 		// ASSERT
 		expect(summary).toEqual({
 			averageRunTime: { deviation: -123, unit: 'time', value: 0 },
-			failed: { deviation: 2, unit: 'count', value: 2 },
-			failureRate: { deviation: 0.5, unit: 'ratio', value: 0.5 },
+			failed: { deviation: 1, unit: 'count', value: 1 },
+			failureRate: { deviation: 0.333, unit: 'ratio', value: 0.333 },
 			timeSaved: { deviation: 0, unit: 'time', value: 0 },
-			total: { deviation: 3, unit: 'count', value: 4 },
+			total: { deviation: 2, unit: 'count', value: 3 },
 		});
 	});
 

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -250,9 +250,9 @@ export class InsightsService {
 		const previousTotal = previousSuccesses + previousFailures;
 
 		const currentFailureRate =
-			currentTotal > 0 ? Math.round((currentFailures / currentTotal) * 100) / 100 : 0;
+			currentTotal > 0 ? Math.round((currentFailures / currentTotal) * 1000) / 1000 : 0;
 		const previousFailureRate =
-			previousTotal > 0 ? Math.round((previousFailures / previousTotal) * 100) / 100 : 0;
+			previousTotal > 0 ? Math.round((previousFailures / previousTotal) * 1000) / 1000 : 0;
 
 		const currentTotalRuntime = getValueByType('current', 'runtime_ms') ?? 0;
 		const previousTotalRuntime = getValueByType('previous', 'runtime_ms') ?? 0;


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
For now, failure rates (and deviations) are rounded to 2 decimals, meaning that the percentage is rounded to nearest integer.

This PR changes it so that the percentage has 1 decimal (so make the failure rate with 3 decimals)

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2718/display-failure-rates-percentage-with-1-decimals

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [X] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [X] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
