### PR TITLE
fix(editor): Disable Drag and Drop for ResourceMapper 'attemptToConvertTypes' switch

### DIFF
--- a/packages/frontend/editor-ui/src/components/ResourceMapper/ResourceMapper.vue
+++ b/packages/frontend/editor-ui/src/components/ResourceMapper/ResourceMapper.vue
@@ -665,6 +665,7 @@ defineExpose({
 					displayName: locale.baseText('resourceMapper.attemptToConvertTypes.displayName'),
 					default: false,
 					description: locale.baseText('resourceMapper.attemptToConvertTypes.description'),
+					noDataExpression: true,
 				}"
 				:path="props.path + '.attemptToConvertTypes'"
 				:value="state.paramValue.attemptToConvertTypes"


### PR DESCRIPTION
## Summary

The lack of the attribute caused drag n drop to be enabled.

No matter the expression it always functioned as `true`, so this wasn't operational and I don't mind technically breaking it. Also confirmed existing use cases automatically are removed thanks to existing infrastructure

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3381/dragging-schema-to-node-ui-changes-button-type

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
