### PR TITLE
fix: Fix issue with Qdrant not always connecting

### DIFF
--- a/packages/@n8n/nodes-langchain/credentials/QdrantApi.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/QdrantApi.credentials.ts
@@ -42,9 +42,7 @@ export class QdrantApi implements ICredentialType {
 	test: ICredentialTestRequest = {
 		request: {
 			baseURL: '={{$credentials.qdrantUrl}}',
-			headers: {
-				accept: 'application/json; charset=utf-8',
-			},
+			url: '/collections',
 		},
 	};
 }

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreQdrant/Qdrant.utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreQdrant/Qdrant.utils.ts
@@ -1,0 +1,39 @@
+import { QdrantClient } from '@qdrant/js-client-rest';
+import { UserError } from 'n8n-workflow';
+
+export type QdrantCredential = {
+	qdrantUrl: string;
+	apiKey: string;
+};
+
+function parseQdrantUrl(url: string): { protocol: string; host: string; port: number } {
+	try {
+		const parsedUrl = new URL(url);
+		return {
+			protocol: parsedUrl.protocol,
+			host: parsedUrl.hostname,
+			port: parsedUrl.port
+				? parseInt(parsedUrl.port, 10)
+				: parsedUrl.protocol === 'https:'
+					? 443
+					: 80,
+		};
+	} catch (error) {
+		throw new UserError(
+			`Invalid Qdrant URL: ${url}. Please provide a valid URL with protocol (http/https)`,
+		);
+	}
+}
+
+export function createQdrantClient(credentials: QdrantCredential): QdrantClient {
+	const { protocol, host, port } = parseQdrantUrl(credentials.qdrantUrl);
+
+	const qdrantClient = new QdrantClient({
+		url: host,
+		apiKey: credentials.apiKey,
+		https: protocol === 'https:',
+		port,
+	});
+
+	return qdrantClient;
+}

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreQdrant/Qdrant.utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreQdrant/Qdrant.utils.ts
@@ -29,7 +29,7 @@ export function createQdrantClient(credentials: QdrantCredential): QdrantClient 
 	const { protocol, host, port } = parseQdrantUrl(credentials.qdrantUrl);
 
 	const qdrantClient = new QdrantClient({
-		url: host,
+		host,
 		apiKey: credentials.apiKey,
 		https: protocol === 'https:',
 		port,

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreQdrant/VectorStoreQdrant.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreQdrant/VectorStoreQdrant.node.ts
@@ -2,9 +2,10 @@ import type { Callbacks } from '@langchain/core/callbacks/manager';
 import type { Embeddings } from '@langchain/core/embeddings';
 import type { QdrantLibArgs } from '@langchain/qdrant';
 import { QdrantVectorStore } from '@langchain/qdrant';
-import type { Schemas as QdrantSchemas } from '@qdrant/js-client-rest';
+import { type Schemas as QdrantSchemas } from '@qdrant/js-client-rest';
 import type { IDataObject, INodeProperties } from 'n8n-workflow';
 
+import { createQdrantClient, type QdrantCredential } from './Qdrant.utils';
 import { createVectorStoreNode } from '../shared/createVectorStoreNode/createVectorStoreNode';
 import { qdrantCollectionsSearch } from '../shared/createVectorStoreNode/methods/listSearch';
 import { qdrantCollectionRLC } from '../shared/descriptions';
@@ -106,9 +107,10 @@ export class VectorStoreQdrant extends createVectorStoreNode<ExtendedQdrantVecto
 
 		const credentials = await context.getCredentials('qdrantApi');
 
+		const client = createQdrantClient(credentials as QdrantCredential);
+
 		const config: QdrantLibArgs = {
-			url: credentials.qdrantUrl as string,
-			apiKey: credentials.apiKey as string,
+			client,
 			collectionName: collection,
 		};
 
@@ -126,9 +128,10 @@ export class VectorStoreQdrant extends createVectorStoreNode<ExtendedQdrantVecto
 		};
 		const credentials = await context.getCredentials('qdrantApi');
 
+		const client = createQdrantClient(credentials as QdrantCredential);
+
 		const config: QdrantLibArgs = {
-			url: credentials.qdrantUrl as string,
-			apiKey: credentials.apiKey as string,
+			client,
 			collectionName,
 			collectionConfig,
 		};

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/methods/listSearch.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/methods/listSearch.ts
@@ -1,7 +1,9 @@
 import { Pinecone } from '@pinecone-database/pinecone';
-import { QdrantClient } from '@qdrant/js-client-rest';
 import { MilvusClient } from '@zilliz/milvus2-sdk-node';
 import { ApplicationError, type IDataObject, type ILoadOptionsFunctions } from 'n8n-workflow';
+
+import type { QdrantCredentials } from '../../../VectorStoreQdrant/Qdrant.utils';
+import { createQdrantClient } from '../../../VectorStoreQdrant/Qdrant.utils';
 
 export async function pineconeIndexSearch(this: ILoadOptionsFunctions) {
 	const credentials = await this.getCredentials('pineconeApi');
@@ -54,10 +56,7 @@ export async function supabaseTableNameSearch(this: ILoadOptionsFunctions) {
 export async function qdrantCollectionsSearch(this: ILoadOptionsFunctions) {
 	const credentials = await this.getCredentials('qdrantApi');
 
-	const client = new QdrantClient({
-		url: credentials.qdrantUrl as string,
-		apiKey: credentials.apiKey as string,
-	});
+	const client = createQdrantClient(credentials as QdrantCredentials);
 
 	const response = await client.getCollections();
 

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/methods/listSearch.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/methods/listSearch.ts
@@ -2,7 +2,7 @@ import { Pinecone } from '@pinecone-database/pinecone';
 import { MilvusClient } from '@zilliz/milvus2-sdk-node';
 import { ApplicationError, type IDataObject, type ILoadOptionsFunctions } from 'n8n-workflow';
 
-import type { QdrantCredentials } from '../../../VectorStoreQdrant/Qdrant.utils';
+import type { QdrantCredential } from '../../../VectorStoreQdrant/Qdrant.utils';
 import { createQdrantClient } from '../../../VectorStoreQdrant/Qdrant.utils';
 
 export async function pineconeIndexSearch(this: ILoadOptionsFunctions) {
@@ -56,7 +56,7 @@ export async function supabaseTableNameSearch(this: ILoadOptionsFunctions) {
 export async function qdrantCollectionsSearch(this: ILoadOptionsFunctions) {
 	const credentials = await this.getCredentials('qdrantApi');
 
-	const client = createQdrantClient(credentials as QdrantCredentials);
+	const client = createQdrantClient(credentials as QdrantCredential);
 
 	const response = await client.getCollections();
 


### PR DESCRIPTION
## Summary
We were not testing an endpoint that needed authentication, This also fixes the issue with the qdrant connection not using https or custom ports in some scenarios.

**Incorrect Credential or URL**
![image](https://github.com/user-attachments/assets/69c40343-d432-454f-b273-de559d73490d)

**Correct Credential / URL**
![image](https://github.com/user-attachments/assets/523b54f3-51b7-4fd3-9512-f1aefc0f5b7a)


## Related Linear tickets, Github issues, and Community forum posts
https://community.n8n.io/t/cannot-access-selfhosted-qdrant-vector-store/63070
https://linear.app/n8n/issue/AI-830/qdrant-doesnt-support-https-or-non-default-port

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
