### PR TITLE
fix: Disable autocomplete expression for specialized editor types

### DIFF
--- a/packages/frontend/editor-ui/src/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/components/ParameterInput.vue
@@ -68,7 +68,7 @@ import { createEventBus } from '@n8n/utils/event-bus';
 import { useRouter } from 'vue-router';
 import { useElementSize } from '@vueuse/core';
 import { captureMessage } from '@sentry/vue';
-import { completeExpressionSyntax, isStringWithExpressionSyntax } from '@/utils/expressions';
+import { completeExpressionSyntax, shouldConvertToExpression } from '@/utils/expressions';
 import { isPresent } from '@/utils/typesUtils';
 import CssEditor from './CssEditor/CssEditor.vue';
 
@@ -853,7 +853,13 @@ function valueChanged(value: NodeParameterValueType | {} | Date) {
 		return;
 	}
 
-	if (!oldValue && oldValue !== undefined && isStringWithExpressionSyntax(value)) {
+	const isSpecializedEditor = props.parameter.typeOptions?.editor !== undefined;
+
+	if (
+		!oldValue &&
+		oldValue !== undefined &&
+		shouldConvertToExpression(value, isSpecializedEditor)
+	) {
 		// if empty old value and updated value has an expression, add '=' prefix to switch to expression mode
 		value = '=' + value;
 	}
@@ -862,7 +868,7 @@ function valueChanged(value: NodeParameterValueType | {} | Date) {
 		activeCredentialType.value = value as string;
 	}
 
-	value = completeExpressionSyntax(value);
+	value = completeExpressionSyntax(value, isSpecializedEditor);
 
 	if (value instanceof Date) {
 		value = value.toISOString();

--- a/packages/frontend/editor-ui/src/utils/expressions.test.ts
+++ b/packages/frontend/editor-ui/src/utils/expressions.test.ts
@@ -1,7 +1,7 @@
 import { ExpressionError } from 'n8n-workflow';
 import {
 	completeExpressionSyntax,
-	isStringWithExpressionSyntax,
+	shouldConvertToExpression,
 	removeExpressionPrefix,
 	stringifyExpressionResult,
 	unwrapExpression,
@@ -79,25 +79,33 @@ describe('Utils: Expressions', () => {
 			expect(completeExpressionSyntax(true)).toBe(true);
 			expect(completeExpressionSyntax(null)).toBe(null);
 		});
+
+		it('should return unchanged value if special editor type', () => {
+			expect(completeExpressionSyntax('test {{ ', true)).toBe('test {{ ');
+		});
 	});
 
-	describe('isStringWithExpressionSyntax', () => {
+	describe('shouldConvertToExpression', () => {
 		it('should return true for strings with expression syntax', () => {
-			expect(isStringWithExpressionSyntax('test {{ value }}')).toBe(true);
+			expect(shouldConvertToExpression('test {{ value }}')).toBe(true);
 		});
 
 		it('should return false for strings without expression syntax', () => {
-			expect(isStringWithExpressionSyntax('just a string')).toBe(false);
+			expect(shouldConvertToExpression('just a string')).toBe(false);
 		});
 
 		it('should return false for strings starting with "="', () => {
-			expect(isStringWithExpressionSyntax('=expression {{ value }}')).toBe(false);
+			expect(shouldConvertToExpression('=expression {{ value }}')).toBe(false);
 		});
 
 		it('should return false for non-string values', () => {
-			expect(isStringWithExpressionSyntax(123)).toBe(false);
-			expect(isStringWithExpressionSyntax(true)).toBe(false);
-			expect(isStringWithExpressionSyntax(null)).toBe(false);
+			expect(shouldConvertToExpression(123)).toBe(false);
+			expect(shouldConvertToExpression(true)).toBe(false);
+			expect(shouldConvertToExpression(null)).toBe(false);
+		});
+
+		it('should return false if special editor type', () => {
+			expect(shouldConvertToExpression('test {{ value }}', true)).toBe(false);
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/utils/expressions.ts
+++ b/packages/frontend/editor-ui/src/utils/expressions.ts
@@ -140,7 +140,8 @@ export const stringifyExpressionResult = (
 	return typeof result.result === 'string' ? result.result : String(result.result);
 };
 
-export const completeExpressionSyntax = <T>(value: T) => {
+export const completeExpressionSyntax = <T>(value: T, isSpecializedEditor = false) => {
+	if (isSpecializedEditor) return value;
 	if (typeof value === 'string' && !value.startsWith('=')) {
 		if (value.endsWith('{{ ')) return '=' + value + ' }}';
 		if (value.endsWith('{{$')) return '=' + value.slice(0, -1) + ' $ }}';
@@ -149,7 +150,8 @@ export const completeExpressionSyntax = <T>(value: T) => {
 	return value;
 };
 
-export const isStringWithExpressionSyntax = <T>(value: T): boolean => {
+export const shouldConvertToExpression = <T>(value: T, isSpecializedEditor = false): boolean => {
+	if (isSpecializedEditor) return false;
 	return (
 		typeof value === 'string' &&
 		!value.startsWith('=') &&


### PR DESCRIPTION
## Summary

fix for issues where additional = inserted, e.g. sqlEditor

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2569/community-issue-on-fast-typing-or-pasting-a-=-will-be-inserted-in-the
closes https://github.com/n8n-io/n8n/issues/13950


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
