### PR TITLE
fix(editor): Support 'View Execution' links with multiple branches

### DIFF
--- a/packages/frontend/editor-ui/src/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/components/RunData.vue
@@ -557,12 +557,6 @@ const activeTaskMetadata = computed((): ITaskMetadata | null => {
 	return workflowRunData.value?.[node.value.name]?.[props.runIndex]?.metadata ?? null;
 });
 
-const hasRelatedExecution = computed(() => {
-	return Boolean(
-		activeTaskMetadata.value?.subExecution ?? activeTaskMetadata.value?.parentExecution,
-	);
-});
-
 const hasInputOverwrite = computed((): boolean => {
 	if (!node.value) {
 		return false;

--- a/packages/frontend/editor-ui/src/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/components/RunData.vue
@@ -86,11 +86,11 @@ import {
 } from '@n8n/design-system';
 import { storeToRefs } from 'pinia';
 import { useRoute } from 'vue-router';
-import { useExecutionHelpers } from '@/composables/useExecutionHelpers';
 import { useUIStore } from '@/stores/ui.store';
 import { useSchemaPreviewStore } from '@/stores/schemaPreview.store';
 import { asyncComputed } from '@vueuse/core';
 import { usePostHog } from '@/stores/posthog.store';
+import ViewSubExecution from './ViewSubExecution.vue';
 
 const LazyRunDataTable = defineAsyncComponent(
 	async () => await import('@/components/RunDataTable.vue'),
@@ -200,7 +200,6 @@ const nodeHelpers = useNodeHelpers();
 const externalHooks = useExternalHooks();
 const telemetry = useTelemetry();
 const i18n = useI18n();
-const { trackOpeningRelatedExecution, resolveRelatedExecutionUrl } = useExecutionHelpers();
 
 const node = toRef(props, 'node');
 
@@ -1313,26 +1312,6 @@ function onSearchClear() {
 	document.dispatchEvent(new KeyboardEvent('keyup', { key: '/' }));
 }
 
-function getExecutionLinkLabel(task: ITaskMetadata): string | undefined {
-	if (task.parentExecution) {
-		return i18n.baseText('runData.openParentExecution', {
-			interpolate: { id: task.parentExecution.executionId },
-		});
-	}
-
-	if (task.subExecution) {
-		if (activeTaskMetadata.value?.subExecutionsCount === 1) {
-			return i18n.baseText('runData.openSubExecutionSingle');
-		} else {
-			return i18n.baseText('runData.openSubExecutionWithId', {
-				interpolate: { id: task.subExecution.executionId },
-			});
-		}
-	}
-
-	return;
-}
-
 defineExpose({ enterEditMode });
 </script>
 
@@ -1504,20 +1483,11 @@ defineExpose({ enterEditMode });
 
 				<slot name="run-info"></slot>
 			</div>
-
-			<a
-				v-if="
-					activeTaskMetadata && hasRelatedExecution && !(paneType === 'input' && hasInputOverwrite)
-				"
-				:class="$style.relatedExecutionInfo"
-				data-test-id="related-execution-link"
-				:href="resolveRelatedExecutionUrl(activeTaskMetadata)"
-				target="_blank"
-				@click.stop="trackOpeningRelatedExecution(activeTaskMetadata, displayMode)"
-			>
-				<N8nIcon icon="external-link-alt" size="xsmall" />
-				{{ getExecutionLinkLabel(activeTaskMetadata) }}
-			</a>
+			<ViewSubExecution
+				v-if="activeTaskMetadata && !(paneType === 'input' && hasInputOverwrite)"
+				:task-metadata="activeTaskMetadata"
+				:display-mode="displayMode"
+			/>
 		</div>
 
 		<slot v-if="!displaysMultipleNodes" name="before-data" />
@@ -1544,6 +1514,11 @@ defineExpose({ enterEditMode });
 			data-test-id="branches"
 		>
 			<slot v-if="inputSelectLocation === 'outputs'" name="input-select"></slot>
+			<ViewSubExecution
+				v-if="activeTaskMetadata && !(paneType === 'input' && hasInputOverwrite)"
+				:task-metadata="activeTaskMetadata"
+				:display-mode="displayMode"
+			/>
 
 			<div :class="$style.tabs">
 				<N8nTabs
@@ -1594,20 +1569,11 @@ defineExpose({ enterEditMode });
 					}}
 				</span>
 			</N8nText>
-
-			<a
-				v-if="
-					activeTaskMetadata && hasRelatedExecution && !(paneType === 'input' && hasInputOverwrite)
-				"
-				:class="$style.relatedExecutionInfo"
-				data-test-id="related-execution-link"
-				:href="resolveRelatedExecutionUrl(activeTaskMetadata)"
-				target="_blank"
-				@click.stop="trackOpeningRelatedExecution(activeTaskMetadata, displayMode)"
-			>
-				<N8nIcon icon="external-link-alt" size="xsmall" />
-				{{ getExecutionLinkLabel(activeTaskMetadata) }}
-			</a>
+			<ViewSubExecution
+				v-if="activeTaskMetadata && !(paneType === 'input' && hasInputOverwrite)"
+				:task-metadata="activeTaskMetadata"
+				:display-mode="displayMode"
+			/>
 		</div>
 
 		<div ref="dataContainerRef" :class="$style.dataContainer" data-test-id="ndv-data-container">
@@ -2303,15 +2269,6 @@ defineExpose({ enterEditMode });
 
 .schema {
 	padding: 0 var(--spacing-s);
-}
-
-.relatedExecutionInfo {
-	font-size: var(--font-size-s);
-	margin-left: var(--spacing-3xs);
-
-	svg {
-		padding-bottom: 2px;
-	}
 }
 </style>
 

--- a/packages/frontend/editor-ui/src/components/RunDataAi/RunDataAiContent.vue
+++ b/packages/frontend/editor-ui/src/components/RunDataAi/RunDataAiContent.vue
@@ -105,7 +105,7 @@ const outputError = computed(() => {
 						</n8n-tooltip>
 					</li>
 					<li v-if="runMeta">
-						<ViewSubExecution :task-metadata="runMeta" :display-mode="'ai'" />
+						<ViewSubExecution :task-metadata="runMeta" :display-mode="'ai'" :inline="true" />
 					</li>
 					<li v-if="(consumedTokensSum?.totalTokens ?? 0) > 0" :class="$style.tokensUsage">
 						{{

--- a/packages/frontend/editor-ui/src/components/RunDataAi/RunDataAiContent.vue
+++ b/packages/frontend/editor-ui/src/components/RunDataAi/RunDataAiContent.vue
@@ -6,10 +6,10 @@ import type { INodeTypeDescription, NodeConnectionType, NodeError } from 'n8n-wo
 import { computed } from 'vue';
 import NodeIcon from '@/components/NodeIcon.vue';
 import AiRunContentBlock from './AiRunContentBlock.vue';
-import { useExecutionHelpers } from '@/composables/useExecutionHelpers';
 import { useI18n } from '@/composables/useI18n';
 import { formatTokenUsageCount, getConsumedTokens } from '@/components/RunDataAi/utils';
 import ConsumedTokensDetails from '@/components/ConsumedTokensDetails.vue';
+import ViewSubExecution from '../ViewSubExecution.vue';
 
 interface RunMeta {
 	startTimeMs: number;
@@ -30,7 +30,6 @@ const props = defineProps<{
 const nodeTypesStore = useNodeTypesStore();
 const workflowsStore = useWorkflowsStore();
 
-const { trackOpeningRelatedExecution, resolveRelatedExecutionUrl } = useExecutionHelpers();
 const i18n = useI18n();
 
 const consumedTokensSum = computed(() => {
@@ -105,15 +104,8 @@ const outputError = computed(() => {
 							}}
 						</n8n-tooltip>
 					</li>
-					<li v-if="runMeta?.subExecution">
-						<a
-							:href="resolveRelatedExecutionUrl(runMeta)"
-							target="_blank"
-							@click.stop="trackOpeningRelatedExecution(runMeta, 'ai')"
-						>
-							<N8nIcon icon="external-link-alt" size="xsmall" />
-							{{ i18n.baseText('runData.openSubExecutionSingle') }}
-						</a>
+					<li v-if="runMeta">
+						<ViewSubExecution :task-metadata="runMeta" :display-mode="'ai'" />
 					</li>
 					<li v-if="(consumedTokensSum?.totalTokens ?? 0) > 0" :class="$style.tokensUsage">
 						{{

--- a/packages/frontend/editor-ui/src/components/ViewSubExecution.vue
+++ b/packages/frontend/editor-ui/src/components/ViewSubExecution.vue
@@ -41,7 +41,7 @@ function getExecutionLinkLabel(task: ITaskMetadata): string | undefined {
 <template>
 	<a
 		v-if="hasRelatedExecution"
-		:class="$style.relatedExecutionInfo"
+		:class="{ [$style.relatedExecutionInfo]: displayMode !== 'ai' }"
 		data-test-id="related-execution-link"
 		:href="resolveRelatedExecutionUrl(taskMetadata)"
 		target="_blank"

--- a/packages/frontend/editor-ui/src/components/ViewSubExecution.vue
+++ b/packages/frontend/editor-ui/src/components/ViewSubExecution.vue
@@ -64,7 +64,7 @@ function getExecutionLinkLabel(task: ITaskMetadata): string | undefined {
 	margin-left: var(--spacing-3xs);
 
 	svg {
-		padding-bottom: 2px;
+		padding-bottom: var(--spacing-5xs);
 	}
 }
 </style>

--- a/packages/frontend/editor-ui/src/components/ViewSubExecution.vue
+++ b/packages/frontend/editor-ui/src/components/ViewSubExecution.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import { useExecutionHelpers } from '@/composables/useExecutionHelpers';
+import { useI18n } from '@/composables/useI18n';
+import type { IRunDataDisplayMode } from '@/Interface';
+import type { ITaskMetadata } from 'n8n-workflow';
+import { computed } from 'vue';
+
+const { trackOpeningRelatedExecution, resolveRelatedExecutionUrl } = useExecutionHelpers();
+const i18n = useI18n();
+
+const props = defineProps<{
+	taskMetadata: ITaskMetadata;
+	displayMode: IRunDataDisplayMode;
+}>();
+
+const hasRelatedExecution = computed(() => {
+	return Boolean(props.taskMetadata.subExecution ?? props.taskMetadata.parentExecution);
+});
+
+function getExecutionLinkLabel(task: ITaskMetadata): string | undefined {
+	if (task.parentExecution) {
+		return i18n.baseText('runData.openParentExecution', {
+			interpolate: { id: task.parentExecution.executionId },
+		});
+	}
+
+	if (task.subExecution) {
+		if (props.taskMetadata.subExecutionsCount === 1) {
+			return i18n.baseText('runData.openSubExecutionSingle');
+		} else {
+			return i18n.baseText('runData.openSubExecutionWithId', {
+				interpolate: { id: task.subExecution.executionId },
+			});
+		}
+	}
+
+	return;
+}
+</script>
+
+<template>
+	<a
+		v-if="hasRelatedExecution"
+		:class="$style.relatedExecutionInfo"
+		data-test-id="related-execution-link"
+		:href="resolveRelatedExecutionUrl(taskMetadata)"
+		target="_blank"
+		@click.stop="trackOpeningRelatedExecution(taskMetadata, displayMode)"
+	>
+		<N8nIcon icon="external-link-alt" size="xsmall" />
+		{{ getExecutionLinkLabel(taskMetadata) }}
+	</a>
+</template>
+
+<style lang="scss" module>
+.relatedExecutionInfo {
+	font-size: var(--font-size-s);
+	margin-left: var(--spacing-3xs);
+
+	svg {
+		padding-bottom: 2px;
+	}
+}
+</style>

--- a/packages/frontend/editor-ui/src/components/ViewSubExecution.vue
+++ b/packages/frontend/editor-ui/src/components/ViewSubExecution.vue
@@ -8,10 +8,16 @@ import { computed } from 'vue';
 const { trackOpeningRelatedExecution, resolveRelatedExecutionUrl } = useExecutionHelpers();
 const i18n = useI18n();
 
-const props = defineProps<{
-	taskMetadata: ITaskMetadata;
-	displayMode: IRunDataDisplayMode;
-}>();
+const props = withDefaults(
+	defineProps<{
+		taskMetadata: ITaskMetadata;
+		displayMode: IRunDataDisplayMode;
+		inline?: boolean;
+	}>(),
+	{
+		inline: false,
+	},
+);
 
 const hasRelatedExecution = computed(() => {
 	return Boolean(props.taskMetadata.subExecution ?? props.taskMetadata.parentExecution);
@@ -41,7 +47,7 @@ function getExecutionLinkLabel(task: ITaskMetadata): string | undefined {
 <template>
 	<a
 		v-if="hasRelatedExecution"
-		:class="{ [$style.relatedExecutionInfo]: displayMode !== 'ai' }"
+		:class="{ [$style.relatedExecutionInfo]: !inline }"
 		data-test-id="related-execution-link"
 		:href="resolveRelatedExecutionUrl(taskMetadata)"
 		target="_blank"


### PR DESCRIPTION
## Summary

Since we now have this in a third location I went ahead and refactored it into a component.

Do we have a better place nowadays for these small store-using components?

Testing workflow in linear.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3311/bug-sub-workflow-debugging-doesnt-show-with-multiple-branches


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
