### PR TITLE
fix(editor): Memory getting rendered in chat on workflow load

### DIFF
--- a/packages/frontend/editor-ui/src/components/CanvasChat/CanvasChat.test.ts
+++ b/packages/frontend/editor-ui/src/components/CanvasChat/CanvasChat.test.ts
@@ -315,12 +315,15 @@ describe('CanvasChat', () => {
 		];
 
 		beforeEach(() => {
-			vi.spyOn(useChatMessaging, 'useChatMessaging').mockReturnValue({
-				getChatMessages: vi.fn().mockReturnValue(mockMessages),
-				sendMessage: vi.fn(),
-				extractResponseMessage: vi.fn(),
-				previousMessageIndex: ref(0),
-				isLoading: computed(() => false),
+			vi.spyOn(useChatMessaging, 'useChatMessaging').mockImplementation(({ messages }) => {
+				messages.value.push(...mockMessages);
+
+				return {
+					sendMessage: vi.fn(),
+					extractResponseMessage: vi.fn(),
+					previousMessageIndex: ref(0),
+					isLoading: computed(() => false),
+				};
 			});
 		});
 
@@ -381,7 +384,6 @@ describe('CanvasChat', () => {
 	describe('file handling', () => {
 		beforeEach(() => {
 			vi.spyOn(useChatMessaging, 'useChatMessaging').mockReturnValue({
-				getChatMessages: vi.fn().mockReturnValue([]),
 				sendMessage: vi.fn(),
 				extractResponseMessage: vi.fn(),
 				previousMessageIndex: ref(0),
@@ -478,12 +480,15 @@ describe('CanvasChat', () => {
 					createdAt: new Date().toISOString(),
 				},
 			];
-			vi.spyOn(useChatMessaging, 'useChatMessaging').mockReturnValue({
-				getChatMessages: vi.fn().mockReturnValue(mockMessages),
-				sendMessage: sendMessageSpy,
-				extractResponseMessage: vi.fn(),
-				previousMessageIndex: ref(0),
-				isLoading: computed(() => false),
+			vi.spyOn(useChatMessaging, 'useChatMessaging').mockImplementation(({ messages }) => {
+				messages.value.push(...mockMessages);
+
+				return {
+					sendMessage: sendMessageSpy,
+					extractResponseMessage: vi.fn(),
+					previousMessageIndex: ref(0),
+					isLoading: computed(() => false),
+				};
 			});
 			workflowsStore.messages = mockMessages;
 		});
@@ -582,24 +587,6 @@ describe('CanvasChat', () => {
 			await userEvent.type(input, 'Line 2');
 
 			expect(input).toHaveValue('Line 1\nLine 2');
-		});
-	});
-
-	describe('chat synchronization', () => {
-		it('should load initial chat history when first opening panel', async () => {
-			const getChatMessagesSpy = vi.fn().mockReturnValue(['Previous message']);
-			vi.spyOn(useChatMessaging, 'useChatMessaging').mockReturnValue({
-				...vi.fn()(),
-				getChatMessages: getChatMessagesSpy,
-			});
-
-			workflowsStore.chatPanelState = LOGS_PANEL_STATE.CLOSED;
-			const { rerender } = renderComponent();
-
-			workflowsStore.chatPanelState = LOGS_PANEL_STATE.ATTACHED;
-			await rerender({});
-
-			expect(getChatMessagesSpy).toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/components/CanvasChat/composables/useChatMessaging.ts
+++ b/packages/frontend/editor-ui/src/components/CanvasChat/composables/useChatMessaging.ts
@@ -10,7 +10,6 @@ import type {
 	IDataObject,
 	IBinaryData,
 	BinaryFileType,
-	Workflow,
 	IRunExecutionData,
 } from 'n8n-workflow';
 import { useToast } from '@/composables/useToast';
@@ -29,12 +28,9 @@ export type RunWorkflowChatPayload = {
 };
 export interface ChatMessagingDependencies {
 	chatTrigger: Ref<INodeUi | null>;
-	connectedNode: Ref<INodeUi | null>;
 	messages: Ref<ChatMessage[]>;
 	sessionId: Ref<string>;
-	workflow: ComputedRef<Workflow>;
 	executionResultData: ComputedRef<IRunExecutionData['resultData'] | undefined>;
-	getWorkflowResultDataByNodeName: (nodeName: string) => ITaskData[] | null;
 	onRunChatWorkflow: (
 		payload: RunWorkflowChatPayload,
 	) => Promise<IExecutionPushResponse | undefined>;
@@ -42,12 +38,9 @@ export interface ChatMessagingDependencies {
 
 export function useChatMessaging({
 	chatTrigger,
-	connectedNode,
 	messages,
 	sessionId,
-	workflow,
 	executionResultData,
-	getWorkflowResultDataByNodeName,
 	onRunChatWorkflow,
 }: ChatMessagingDependencies) {
 	const locale = useI18n();

--- a/packages/frontend/editor-ui/src/components/CanvasChat/composables/useChatState.ts
+++ b/packages/frontend/editor-ui/src/components/CanvasChat/composables/useChatState.ts
@@ -60,7 +60,7 @@ export function useChatState(isDisabled: Ref<boolean>, onWindowResize: () => voi
 		getNodeType: nodeTypesStore.getNodeType,
 	});
 
-	const { sendMessage, getChatMessages, isLoading } = useChatMessaging({
+	const { sendMessage, isLoading } = useChatMessaging({
 		chatTrigger: chatTriggerNode,
 		connectedNode,
 		messages,
@@ -133,10 +133,6 @@ export function useChatState(isDisabled: Ref<boolean>, onWindowResize: () => voi
 			if (state !== LOGS_PANEL_STATE.CLOSED) {
 				setChatTriggerNode();
 				setConnectedNode();
-
-				if (messages.value.length === 0) {
-					messages.value = getChatMessages();
-				}
 
 				setTimeout(() => {
 					onWindowResize();

--- a/packages/frontend/editor-ui/src/components/CanvasChat/composables/useChatState.ts
+++ b/packages/frontend/editor-ui/src/components/CanvasChat/composables/useChatState.ts
@@ -62,12 +62,9 @@ export function useChatState(isDisabled: Ref<boolean>, onWindowResize: () => voi
 
 	const { sendMessage, isLoading } = useChatMessaging({
 		chatTrigger: chatTriggerNode,
-		connectedNode,
 		messages,
 		sessionId: currentSessionId,
-		workflow,
 		executionResultData: computed(() => workflowsStore.getWorkflowExecution?.data?.resultData),
-		getWorkflowResultDataByNodeName: workflowsStore.getWorkflowResultDataByNodeName,
 		onRunChatWorkflow,
 	});
 


### PR DESCRIPTION
## Summary
This PR removes the logic for restoring chat history from memory store node, as it causes messages from previously opened workflow to appear in the chat history, whether it's the same workflow or not.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/SUG-35/bug-memory-getting-rendered-in-chat-on-workflow-load


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
