### PR TITLE
fix(editor): Improve sub-workflow debugging for more node error types

### DIFF
--- a/packages/cli/src/utils/object-to-error.ts
+++ b/packages/cli/src/utils/object-to-error.ts
@@ -2,7 +2,10 @@ import { isObjectLiteral } from 'n8n-core';
 import { NodeOperationError } from 'n8n-workflow';
 import type { Workflow } from 'n8n-workflow';
 
-const transientErrorProperties = ['description', 'stack', 'executionId', 'workflowId'];
+/**
+ * Optional properties that should be propagated from an error object to the new Error instance.
+ */
+const errorProperties = ['description', 'stack', 'executionId', 'workflowId'];
 
 export function objectToError(errorObject: unknown, workflow: Workflow): Error {
 	// TODO: Expand with other error types
@@ -36,8 +39,9 @@ export function objectToError(errorObject: unknown, workflow: Workflow): Error {
 			error = new Error(errorObject.message);
 		}
 
-		for (const field of transientErrorProperties) {
-			if (field in errorObject) {
+		for (const field of errorProperties) {
+			if (field in errorObject && errorObject[field]) {
+				// Not all errors contain these properties
 				(error as unknown as Record<string, unknown>)[field] = errorObject[field];
 			}
 		}

--- a/packages/workflow/src/MetadataUtils.ts
+++ b/packages/workflow/src/MetadataUtils.ts
@@ -27,5 +27,8 @@ export function parseErrorMetadata(error: unknown): ISubWorkflowMetadata | undef
 	if (hasKey(error, 'errorResponse')) {
 		return parseErrorResponseWorkflowMetadata(error.errorResponse);
 	}
-	return undefined;
+
+	// This accounts for cases where the backend attaches the properties on plain errors
+	// e.g. from custom nodes throwing literal `Error` or `ApplicationError` objects directly
+	return parseErrorResponseWorkflowMetadata(error);
 }

--- a/packages/workflow/test/MetadataUtils.test.ts
+++ b/packages/workflow/test/MetadataUtils.test.ts
@@ -2,10 +2,36 @@ import { parseErrorMetadata } from '@/MetadataUtils';
 
 describe('MetadataUtils', () => {
 	describe('parseMetadataFromError', () => {
-		it('should return undefined if error does not have response', () => {
+		const expectedMetadata = {
+			subExecution: {
+				executionId: '123',
+				workflowId: '456',
+			},
+			subExecutionsCount: 1,
+		};
+
+		it('should return undefined if error does not have response or both keys on the object', () => {
 			const error = { message: 'An error occurred' };
 			const result = parseErrorMetadata(error);
 			expect(result).toBeUndefined();
+		});
+
+		it('should return undefined if errorResponse only has workflowId key', () => {
+			const error = { errorResponse: { executionId: '123' } };
+			const result = parseErrorMetadata(error);
+			expect(result).toBeUndefined();
+		});
+
+		it('should return undefined if error only has executionId key', () => {
+			const error = { executionId: '123' };
+			const result = parseErrorMetadata(error);
+			expect(result).toBeUndefined();
+		});
+
+		it('should support executionId and workflowId key directly on the error object', () => {
+			const error = { executionId: '123', workflowId: '456' };
+			const result = parseErrorMetadata(error);
+			expect(result).toEqual(expectedMetadata);
 		});
 
 		it('should return undefined if error response does not have subworkflow data', () => {
@@ -16,13 +42,6 @@ describe('MetadataUtils', () => {
 
 		it('should return metadata if error response has subworkflow data', () => {
 			const error = { errorResponse: { executionId: '123', workflowId: '456' } };
-			const expectedMetadata = {
-				subExecution: {
-					executionId: '123',
-					workflowId: '456',
-				},
-				subExecutionsCount: 1,
-			};
 			const result = parseErrorMetadata(error);
 			expect(result).toEqual(expectedMetadata);
 		});


### PR DESCRIPTION
## Summary

If e.g. a `DebugHelper`, or a hypothetical custom node, throws an `ApplicationError` it erases the sub-workflow debugging properties because there is no node associated with the object. 

From a quick look, 25 nodes throw `ApplicationErrors` (though some may be on old versions).

Not really happy with this fix and open to suggestions. Note that the `errorObject instanceof Error` check is always false since both call sites pass a plain object.
Very open to moving the two properties `executionId` and `workflowId` elsewhere if there's a better place.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3315/bug-error-to-sub-workflow-not-linking


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
