### PR TITLE
ci: Fix flaky 45-ai test (no-changelog)

### DIFF
--- a/cypress/README.md
+++ b/cypress/README.md
@@ -13,16 +13,16 @@ pnpm run debug:flaky:e2e -- <grep_filter> <burn_count>
 
 **Examples:**
 
-1.  **Run all tests tagged with `@CAT-726` ten times:**
+1.  **Run all tests tagged with `CAT-726` ten times:**
 
     ```bash
-    pnpm run debug:flaky:e2e -- @CAT-726 10
+    pnpm run debug:flaky:e2e CAT-726 10
     ```
 
 2.  **Run all tests containing "login" five times (default burn count):**
 
     ```bash
-    pnpm run debug:flaky:e2e -- login
+    pnpm run debug:flaky:e2e login
     ```
 
 3.  **Run all tests five times (default grep and burn count):**

--- a/cypress/e2e/45-ai-assistant.cy.ts
+++ b/cypress/e2e/45-ai-assistant.cy.ts
@@ -49,6 +49,7 @@ describe('AI Assistant::enabled', () => {
 	it('should resize assistant chat up', () => {
 		aiAssistant.getters.askAssistantFloatingButton().click();
 		aiAssistant.getters.askAssistantSidebarResizer().should('be.visible');
+		aiAssistant.getters.askAssistantChat().should('be.visible');
 		aiAssistant.getters.askAssistantChat().then((element) => {
 			const { width, left } = element[0].getBoundingClientRect();
 			cy.drag(aiAssistant.getters.askAssistantSidebarResizer(), [left - 10, 0], {
@@ -65,6 +66,7 @@ describe('AI Assistant::enabled', () => {
 	it('should resize assistant chat down', () => {
 		aiAssistant.getters.askAssistantFloatingButton().click();
 		aiAssistant.getters.askAssistantSidebarResizer().should('be.visible');
+		aiAssistant.getters.askAssistantChat().should('be.visible');
 		aiAssistant.getters.askAssistantChat().then((element) => {
 			const { width, left } = element[0].getBoundingClientRect();
 			cy.drag(aiAssistant.getters.askAssistantSidebarResizer(), [left + 10, 0], {


### PR DESCRIPTION
## Summary

This test fixes the flaky AI assistant chat test.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-739/flaky-e2e-investigate-and-fix-45-ai-assistant

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
