### PR TITLE
feat(Think Tool Node): ToolThink, a simple tool to force the AI agent to do some thinking

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolThink/ToolThink.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolThink/ToolThink.node.ts
@@ -1,5 +1,5 @@
 /* eslint-disable n8n-nodes-base/node-dirname-against-convention */
-import { Tool } from '@langchain/core/tools';
+import { DynamicTool } from 'langchain/tools';
 import {
 	NodeConnectionTypes,
 	type INodeType,
@@ -12,31 +12,15 @@ import { logWrapper } from '@utils/logWrapper';
 import { getConnectionHintNoticeField } from '@utils/sharedFields';
 
 // A thinking tool, see https://www.anthropic.com/engineering/claude-think-tool
-interface ThinkToolParams {
-	subject: string;
-}
 
-class ThinkTool extends Tool {
-	static lc_name(): string {
-		return 'ThinkTool';
-	}
-
-	name = 'think';
-
-	description =
-		'Use the tool to think about something. It will not obtain new information or change the database, but just append the thought to the log. Use it when complex reasoning or some cache memory is needed.';
-
-	protected subject: string;
-
-	constructor(params?: ThinkToolParams) {
-		super();
-		this.subject = params?.subject ?? '';
-	}
-
-	async _call(input: string): Promise<string> {
-		return input;
-	}
-}
+const thinkingTool = new DynamicTool({
+	name: 'thinking_tool',
+	description:
+		'Use the tool to think about something. It will not obtain new information or change the database, but just append the thought to the log. Use it when complex reasoning or some cache memory is needed.',
+	func: async (subject: string) => {
+		return subject;
+	},
+});
 
 export class ToolThink implements INodeType {
 	description: INodeTypeDescription = {
@@ -74,7 +58,7 @@ export class ToolThink implements INodeType {
 
 	async supplyData(this: ISupplyDataFunctions): Promise<SupplyData> {
 		return {
-			response: logWrapper(new ThinkTool(), this),
+			response: logWrapper(thinkingTool, this),
 		};
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolThink/ToolThink.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolThink/ToolThink.node.ts
@@ -1,0 +1,80 @@
+/* eslint-disable n8n-nodes-base/node-dirname-against-convention */
+import { Tool } from '@langchain/core/tools';
+import {
+	NodeConnectionTypes,
+	type INodeType,
+	type INodeTypeDescription,
+	type ISupplyDataFunctions,
+	type SupplyData,
+} from 'n8n-workflow';
+
+import { logWrapper } from '@utils/logWrapper';
+import { getConnectionHintNoticeField } from '@utils/sharedFields';
+
+// A thinking tool, see https://www.anthropic.com/engineering/claude-think-tool
+interface ThinkToolParams {
+	subject: string;
+}
+
+class ThinkTool extends Tool {
+	static lc_name(): string {
+		return 'ThinkTool';
+	}
+
+	name = 'think';
+
+	description =
+		'Use the tool to think about something. It will not obtain new information or change the database, but just append the thought to the log. Use it when complex reasoning or some cache memory is needed.';
+
+	protected subject: string;
+
+	constructor(params?: ThinkToolParams) {
+		super();
+		this.subject = params?.subject ?? '';
+	}
+
+	async _call(input: string): Promise<string> {
+		return input;
+	}
+}
+
+export class ToolThink implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Think Tool',
+		name: 'toolThink',
+		icon: 'fa:brain',
+		iconColor: 'black',
+		group: ['transform'],
+		version: 1,
+		description: 'Invite the AI agent to do some thinking',
+		defaults: {
+			name: 'Think',
+		},
+		codex: {
+			categories: ['AI'],
+			subcategories: {
+				AI: ['Tools'],
+				Tools: ['Other Tools'],
+			},
+			resources: {
+				primaryDocumentation: [
+					{
+						url: 'https://docs.n8n.io/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolthink/',
+					},
+				],
+			},
+		},
+		// eslint-disable-next-line n8n-nodes-base/node-class-description-inputs-wrong-regular-node
+		inputs: [],
+		// eslint-disable-next-line n8n-nodes-base/node-class-description-outputs-wrong
+		outputs: [NodeConnectionTypes.AiTool],
+		outputNames: ['Tool'],
+		properties: [getConnectionHintNoticeField([NodeConnectionTypes.AiAgent])],
+	};
+
+	async supplyData(this: ISupplyDataFunctions): Promise<SupplyData> {
+		return {
+			response: logWrapper(new ThinkTool(), this),
+		};
+	}
+}

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolThink/test/ToolThink.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolThink/test/ToolThink.node.test.ts
@@ -1,0 +1,34 @@
+import { mock } from 'jest-mock-extended';
+import { DynamicTool } from 'langchain/tools';
+import type { ISupplyDataFunctions } from 'n8n-workflow';
+
+import { ToolThink } from '../ToolThink.node';
+
+describe('ToolThink', () => {
+	const thinkTool = new ToolThink();
+	const helpers = mock<ISupplyDataFunctions['helpers']>();
+	const executeFunctions = mock<ISupplyDataFunctions>({
+		helpers,
+	});
+	executeFunctions.addInputData.mockReturnValue({ index: 0 });
+	executeFunctions.getNodeParameter.mockImplementation((paramName: string) => {
+		switch (paramName) {
+			case 'description':
+				return 'Tool description';
+			default:
+				return undefined;
+		}
+	});
+
+	describe('Tool response', () => {
+		it('should return the same text as response when receiving a text input', async () => {
+			const { response } = (await thinkTool.supplyData.call(executeFunctions, 0)) as {
+				response: DynamicTool;
+			};
+			expect(response).toBeInstanceOf(DynamicTool);
+			expect(response.description).toEqual('Tool description');
+			const res = (await response.invoke('foo')) as string;
+			expect(res).toEqual('foo');
+		});
+	});
+});

--- a/packages/@n8n/nodes-langchain/package.json
+++ b/packages/@n8n/nodes-langchain/package.json
@@ -103,6 +103,7 @@
       "dist/nodes/tools/ToolCode/ToolCode.node.js",
       "dist/nodes/tools/ToolHttpRequest/ToolHttpRequest.node.js",
       "dist/nodes/tools/ToolSerpApi/ToolSerpApi.node.js",
+      "dist/nodes/tools/ToolThink/ToolThink.node.js",
       "dist/nodes/tools/ToolVectorStore/ToolVectorStore.node.js",
       "dist/nodes/tools/ToolWikipedia/ToolWikipedia.node.js",
       "dist/nodes/tools/ToolWolframAlpha/ToolWolframAlpha.node.js",


### PR DESCRIPTION
## Summary

A simple tool that invites the AI to do some thinking before answering. See  Anthropic's [blog post](https://www.anthropic.com/engineering/claude-think-tool)

## Related Linear tickets, Github issues, and Community forum posts

[Linear ticket](https://linear.app/n8n/issue/AI-826/thinking-tool)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
