### PR TITLE
fix(Code Node): Ensure 'Generate Code' works with empty input object 

### DIFF
--- a/cypress/e2e/6-code-node.cy.ts
+++ b/cypress/e2e/6-code-node.cy.ts
@@ -167,8 +167,9 @@ return []
 				const askAiReq = cy.wait('@ask-ai');
 
 				askAiReq.its('request.body').should('have.keys', ['question', 'context', 'forNode']);
-
-				askAiReq.its('context').should('have.keys', ['schema', 'ndvPushRef', 'pushRef']);
+				askAiReq
+					.its('context')
+					.should('have.keys', ['schema', 'ndvPushRef', 'pushRef', 'inputSchema']);
 
 				cy.contains('Code generation completed').should('be.visible');
 				cy.getByTestId('code-node-tab-code').should('contain.text', 'console.log("Hello World")');

--- a/packages/frontend/editor-ui/src/components/CodeNodeEditor/AskAI/AskAI.vue
+++ b/packages/frontend/editor-ui/src/components/CodeNodeEditor/AskAI/AskAI.vue
@@ -106,7 +106,11 @@ function getSchemas() {
 		})
 		.filter((node) => node.schema?.value.length > 0);
 
-	const inputSchema = parentNodesSchemas.shift();
+	// Account for empty objects
+	const inputSchema = parentNodesSchemas.shift() ?? {
+		nodeName: parentNodesNames[0] ?? '',
+		schema: { path: '', type: 'undefined', value: '' },
+	};
 
 	return {
 		parentNodesNames,
@@ -161,7 +165,7 @@ async function onSubmit() {
 		question: prompt.value,
 		context: {
 			schema: schemas.parentNodesSchemas,
-			inputSchema: schemas.inputSchema!,
+			inputSchema: schemas.inputSchema,
 			ndvPushRef: useNDVStore().pushRef,
 			pushRef: rootStore.pushRef,
 		},


### PR DESCRIPTION
## Summary

Provide a fallback value rather than passing through undefined if the input object is empty.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3298/bug-code-node-ai-generation-fails-if-input-data-exists-but-is-empty


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
