### PR TITLE
fix(cli): Fix shouldEnqueue in execution cli mode

### DIFF
--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -156,9 +156,10 @@ export class WorkflowRunner {
 
 		// @TODO: Reduce to true branch once feature is stable
 		const shouldEnqueue =
-			process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS === 'true'
+			data.executionMode !== 'cli' &&
+			(process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS === 'true'
 				? this.executionsMode === 'queue'
-				: this.executionsMode === 'queue' && data.executionMode !== 'manual';
+				: this.executionsMode === 'queue' && data.executionMode !== 'manual');
 
 		if (shouldEnqueue) {
 			await this.enqueueExecution(executionId, data, loadStaticData, realtime);


### PR DESCRIPTION
## Summary
When running `n8n execute` in queue mode, an error occurs.
<img width="1439" alt="Screenshot 2025-04-03 at 03 35 01" src="https://github.com/user-attachments/assets/8bd5847c-c320-4836-b71b-f1f9804b0a0f" />

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
- https://community.n8n.io/t/execute-command-raises-cannot-read-properties-of-undefined-reading-add/91035/5

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
