### PR TITLE
feat: Add nested search in folders

### DIFF
--- a/cypress/e2e/49-folders.cy.ts
+++ b/cypress/e2e/49-folders.cy.ts
@@ -490,9 +490,9 @@ describe('Folders', () => {
 		});
 	});
 
-	describe('Workflow card breadcrumbs', () => {
-		it('should correctly show workflow card breadcrumbs', () => {
-			createNewProject('Test workflow breadcrumbs', { openAfterCreate: true });
+	describe('Card breadcrumbs', () => {
+		it('should correctly show workflow card breadcrumbs in overview page', () => {
+			createNewProject('Test card breadcrumbs', { openAfterCreate: true });
 			createFolderFromProjectHeader('Parent Folder');
 			createFolderInsideFolder('Child Folder', 'Parent Folder');
 			getFolderCard('Child Folder').click();
@@ -508,8 +508,31 @@ describe('Folders', () => {
 			cy.get('[role=tooltip]').should('exist');
 			cy.get('[role=tooltip]').should(
 				'contain.text',
-				'est workflow breadcrumbs / Parent Folder / Child Folder / Child Folder 2',
+				'Test card breadcrumbs / Parent Folder / Child Folder / Child Folder 2',
 			);
+		});
+
+		it('should correctly toggle folder and workflow card breadcrumbs in projects and folders', () => {
+			createNewProject('Test nested search', { openAfterCreate: true });
+			createFolderFromProjectHeader('Parent Folder');
+			getFolderCard('Parent Folder').click();
+			createWorkflowFromEmptyState('Child - Workflow');
+			getProjectMenuItem('Test nested search').click();
+			createFolderInsideFolder('Child Folder', 'Parent Folder');
+			// Should not show breadcrumbs in the folder if there is no search term
+			cy.getByTestId('card-badge').should('not.exist');
+			// Back to project root
+			getHomeProjectBreadcrumb().click();
+			// Should not show breadcrumbs in the project if there is no search term
+			cy.getByTestId('card-badge').should('not.exist');
+			// Search for something
+			cy.getByTestId('resources-list-search').type('child', { delay: 20 });
+			// Both folder and workflow from child folder should be in the results - nested search works
+			getFolderCards().should('have.length', 1);
+			getWorkflowCards().should('have.length', 1);
+			// Card badges with breadcrumbs should be shown
+			getFolderCard('Child Folder').findChildByTestId('card-badge').should('exist');
+			getWorkflowCard('Child - Workflow').findChildByTestId('card-badge').should('exist');
 		});
 	});
 });

--- a/packages/cli/src/databases/entities/folder.ts
+++ b/packages/cli/src/databases/entities/folder.ts
@@ -23,6 +23,9 @@ export class Folder extends WithTimestampsAndStringId {
 	@Column()
 	name: string;
 
+	@Column({ nullable: true, select: false })
+	parentFolderId: string | null;
+
 	@ManyToOne(() => Folder, { nullable: true, onDelete: 'CASCADE' })
 	@JoinColumn({ name: 'parentFolderId' })
 	parentFolder: Folder | null;

--- a/packages/cli/src/databases/repositories/__tests__/folder.repository.test.ts
+++ b/packages/cli/src/databases/repositories/__tests__/folder.repository.test.ts
@@ -345,6 +345,7 @@ describe('FolderRepository', () => {
 				expect(childFolder?.parentFolder).toEqual({
 					id: expect.any(String),
 					name: 'Parent Folder',
+					parentFolderId: null,
 				});
 			});
 

--- a/packages/cli/src/databases/repositories/folder.repository.ts
+++ b/packages/cli/src/databases/repositories/folder.repository.ts
@@ -125,7 +125,7 @@ export class FolderRepository extends Repository<FolderWithWorkflowAndSubFolderC
 	}
 
 	private getParentFolderFields(alias: string): string[] {
-		return [`${alias}.id`, `${alias}.name`];
+		return [`${alias}.id`, `${alias}.name`, `${alias}.parentFolderId`];
 	}
 
 	private applyFilters(

--- a/packages/cli/src/databases/repositories/folder.repository.ts
+++ b/packages/cli/src/databases/repositories/folder.repository.ts
@@ -343,9 +343,8 @@ export class FolderRepository extends Repository<FolderWithWorkflowAndSubFolderC
 	 */
 	async getAllFolderIdsInHierarchy(parentFolderId: string, projectId?: string): Promise<string[]> {
 		// Start with direct children as the base case
-		const baseQuery = this.createQueryBuilder()
+		const baseQuery = this.createQueryBuilder('f')
 			.select('f.id', 'id')
-			.from('folder', 'f')
 			.where('f.parentFolderId = :parentFolderId', { parentFolderId });
 
 		// Add project filter if provided
@@ -354,9 +353,8 @@ export class FolderRepository extends Repository<FolderWithWorkflowAndSubFolderC
 		}
 
 		// Create the recursive query for descendants
-		const recursiveQuery = this.createQueryBuilder()
+		const recursiveQuery = this.createQueryBuilder('child')
 			.select('child.id', 'id')
-			.from('folder', 'child')
 			.innerJoin('folder_tree', 'parent', 'child.parentFolderId = parent.id');
 
 		// Add project filter if provided

--- a/packages/cli/src/databases/repositories/workflow.repository.ts
+++ b/packages/cli/src/databases/repositories/workflow.repository.ts
@@ -544,7 +544,11 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 		const isParentFolderIncluded = isDefaultSelect || select?.parentFolder;
 
 		if (isParentFolderIncluded) {
-			qb.leftJoinAndSelect('workflow.parentFolder', 'parentFolder');
+			qb.leftJoin('workflow.parentFolder', 'parentFolder').addSelect([
+				'parentFolder.id',
+				'parentFolder.name',
+				'parentFolder.parentFolderId',
+			]);
 		}
 
 		if (areTagsEnabled && areTagsRequested) {

--- a/packages/cli/src/databases/repositories/workflow.repository.ts
+++ b/packages/cli/src/databases/repositories/workflow.repository.ts
@@ -269,7 +269,7 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 			typeof options.filter?.parentFolderId === 'string' &&
 			options.filter.parentFolderId !== PROJECT_ROOT &&
 			typeof options.filter?.projectId === 'string' &&
-			typeof options.filter.name === 'string'
+			(options.filter.name || options.filter.tags || options.filter.active)
 		) {
 			const folderIds = await this.folderRepository.getAllFolderIdsInHierarchy(
 				options.filter.parentFolderId,

--- a/packages/cli/src/databases/repositories/workflow.repository.ts
+++ b/packages/cli/src/databases/repositories/workflow.repository.ts
@@ -269,7 +269,7 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 			typeof options.filter?.parentFolderId === 'string' &&
 			options.filter.parentFolderId !== PROJECT_ROOT &&
 			typeof options.filter?.projectId === 'string' &&
-			(options.filter.name || options.filter.tags || options.filter.active)
+			options.filter.name
 		) {
 			const folderIds = await this.folderRepository.getAllFolderIdsInHierarchy(
 				options.filter.parentFolderId,

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -1056,8 +1056,7 @@ describe('GET /workflows', () => {
 						parentFolder: {
 							id: folder.id,
 							name: folder.name,
-							createdAt: expect.any(String),
-							updatedAt: expect.any(String),
+							parentFolderId: null,
 						},
 					},
 					{

--- a/packages/frontend/editor-ui/src/Interface.ts
+++ b/packages/frontend/editor-ui/src/Interface.ts
@@ -346,6 +346,7 @@ export type FolderShortInfo = {
 	id: string;
 	name: string;
 	parentFolder?: string;
+	parentFolderId?: string | null;
 };
 
 export type BaseFolderItem = BaseResource & {

--- a/packages/frontend/editor-ui/src/components/WorkflowCard.test.ts
+++ b/packages/frontend/editor-ui/src/components/WorkflowCard.test.ts
@@ -118,7 +118,9 @@ describe('WorkflowCard', () => {
 				name: projectName,
 			},
 		});
-		const { getByRole, getByTestId } = renderComponent({ props: { data } });
+		const { getByRole, getByTestId } = renderComponent({
+			props: { data, showOwnershipBadge: true },
+		});
 
 		const heading = getByRole('heading');
 		const badge = getByTestId('card-badge');
@@ -134,7 +136,9 @@ describe('WorkflowCard', () => {
 				name: projectName,
 			},
 		});
-		const { getByRole, getByTestId } = renderComponent({ props: { data } });
+		const { getByRole, getByTestId } = renderComponent({
+			props: { data, showOwnershipBadge: true },
+		});
 
 		const heading = getByRole('heading');
 		const badge = getByTestId('card-badge');

--- a/packages/frontend/editor-ui/src/components/WorkflowCard.vue
+++ b/packages/frontend/editor-ui/src/components/WorkflowCard.vue
@@ -44,10 +44,12 @@ const props = withDefaults(
 		data: WorkflowResource;
 		readOnly?: boolean;
 		workflowListEventBus?: EventBus;
+		showOwnershipBadge?: boolean;
 	}>(),
 	{
 		readOnly: false,
 		workflowListEventBus: undefined,
+		showOwnershipBadge: false,
 	},
 );
 
@@ -74,18 +76,18 @@ const projectsStore = useProjectsStore();
 const foldersStore = useFoldersStore();
 
 const hiddenBreadcrumbsItemsAsync = ref<Promise<PathItem[]>>(new Promise(() => {}));
+const cachedHiddenBreadcrumbsItems = ref<PathItem[]>([]);
 
 const resourceTypeLabel = computed(() => locale.baseText('generic.workflow').toLowerCase());
 const currentUser = computed(() => usersStore.currentUser ?? ({} as IUser));
 const workflowPermissions = computed(() => getResourcePermissions(props.data.scopes).workflow);
-const isOverviewPage = computed(() => route.name === VIEWS.WORKFLOWS);
 
 const showFolders = computed(() => {
 	return settingsStore.isFoldersFeatureEnabled && route.name !== VIEWS.WORKFLOWS;
 });
 
 const showCardBreadcrumbs = computed(() => {
-	return isOverviewPage.value && !isSomeoneElsesWorkflow.value && cardBreadcrumbs.value.length;
+	return props.showOwnershipBadge && !isSomeoneElsesWorkflow.value && cardBreadcrumbs.value.length;
 });
 
 const projectName = computed(() => {
@@ -284,10 +286,16 @@ const fetchHiddenBreadCrumbsItems = async () => {
 	if (!props.data.homeProject?.id || !projectName.value || !props.data.parentFolder) {
 		hiddenBreadcrumbsItemsAsync.value = Promise.resolve([]);
 	} else {
-		hiddenBreadcrumbsItemsAsync.value = foldersStore.getHiddenBreadcrumbsItems(
+		if (cachedHiddenBreadcrumbsItems.value.length) {
+			hiddenBreadcrumbsItemsAsync.value = Promise.resolve(cachedHiddenBreadcrumbsItems.value);
+			return;
+		}
+		const loadedItem = foldersStore.getHiddenBreadcrumbsItems(
 			{ id: props.data.homeProject.id, name: projectName.value },
 			props.data.parentFolder.id,
 		);
+		hiddenBreadcrumbsItemsAsync.value = loadedItem;
+		cachedHiddenBreadcrumbsItems.value = await loadedItem;
 	}
 };
 
@@ -351,6 +359,7 @@ const onBreadcrumbItemClick = async (item: PathItem) => {
 		<template #append>
 			<div :class="$style.cardActions" @click.stop>
 				<ProjectCardBadge
+					v-if="showOwnershipBadge"
 					:class="{ [$style.cardBadge]: true, [$style['with-breadcrumbs']]: showCardBreadcrumbs }"
 					:resource="data"
 					:resource-type="ResourceType.Workflow"
@@ -361,8 +370,10 @@ const onBreadcrumbItemClick = async (item: PathItem) => {
 					<div v-if="showCardBreadcrumbs" :class="$style.breadcrumbs">
 						<n8n-breadcrumbs
 							:items="cardBreadcrumbs"
-							:hidden-items="hiddenBreadcrumbsItemsAsync"
-							:path-truncated="true"
+							:hidden-items="
+								data.parentFolder?.parentFolderId !== null ? hiddenBreadcrumbsItemsAsync : undefined
+							"
+							:path-truncated="data.parentFolder?.parentFolderId !== null"
 							:highlight-last-item="false"
 							hidden-items-trigger="hover"
 							theme="small"

--- a/packages/frontend/editor-ui/src/components/layouts/ResourcesListLayout.vue
+++ b/packages/frontend/editor-ui/src/components/layouts/ResourcesListLayout.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, nextTick, ref, onMounted, watch } from 'vue';
+import { computed, nextTick, ref, onMounted, watch, onBeforeUnmount } from 'vue';
 
 import { type ProjectSharingData } from '@/types/projects.types';
 import PageViewLayout from '@/components/layouts/PageViewLayout.vue';
@@ -320,9 +320,22 @@ onMounted(async () => {
 	if (hasAppliedFilters()) {
 		hasFilters.value = true;
 	}
+
+	window.addEventListener('keydown', captureSearchHotKey);
+});
+
+onBeforeUnmount(() => {
+	window.removeEventListener('keydown', captureSearchHotKey);
 });
 
 //methods
+const captureSearchHotKey = (e: KeyboardEvent) => {
+	if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
+		e.preventDefault();
+		focusSearchInput();
+	}
+};
+
 const focusSearchInput = () => {
 	if (search.value) {
 		search.value.focus();

--- a/packages/frontend/editor-ui/src/views/WorkflowsView.vue
+++ b/packages/frontend/editor-ui/src/views/WorkflowsView.vue
@@ -133,6 +133,8 @@ const currentSort = ref('updatedAt:desc');
 
 const currentFolderId = ref<string | null>(null);
 
+const showCardsBadge = ref(false);
+
 /**
  * Folder actions
  * These can appear on the list header, and then they are applied to current folder
@@ -353,6 +355,7 @@ watch(
 	() => route.params?.folderId,
 	async (newVal) => {
 		currentFolderId.value = newVal as string;
+		filters.value.search = '';
 		await fetchWorkflows();
 	},
 );
@@ -502,6 +505,10 @@ const fetchWorkflows = async () => {
 		}
 
 		workflowsAndFolders.value = fetchedResources;
+
+		// Toggle ownership cards visibility only after we have fetched the workflows
+		showCardsBadge.value = isOverviewPage.value || filters.value.search !== '';
+
 		return fetchedResources;
 	} catch (error) {
 		toast.showError(error, i18n.baseText('workflows.list.error.fetching'));
@@ -1323,6 +1330,7 @@ const onCreateWorkflowClick = () => {
 				:actions="folderCardActions"
 				:read-only="readOnlyEnv || (!hasPermissionToDeleteFolders && !hasPermissionToCreateFolders)"
 				:personal-project="projectsStore.personalProject"
+				:show-ownership-badge="showCardsBadge"
 				class="mb-2xs"
 				@action="onFolderCardAction"
 			/>
@@ -1334,6 +1342,7 @@ const onCreateWorkflowClick = () => {
 				:data="data as WorkflowResource"
 				:workflow-list-event-bus="workflowListEventBus"
 				:read-only="readOnlyEnv"
+				:show-ownership-badge="showCardsBadge"
 				@click:tag="onClickTag"
 				@workflow:deleted="onWorkflowDeleted"
 				@workflow:moved="fetchWorkflows"

--- a/packages/frontend/editor-ui/src/views/WorkflowsView.vue
+++ b/packages/frontend/editor-ui/src/views/WorkflowsView.vue
@@ -478,7 +478,9 @@ const fetchWorkflows = async () => {
 				name: filters.value.search || undefined,
 				active: activeFilter,
 				tags: tags.length ? tags : undefined,
-				parentFolderId: parentFolder ?? (isOverviewPage.value ? undefined : '0'), // Sending 0 will only show one level of folders
+				parentFolderId:
+					parentFolder ??
+					(isOverviewPage.value ? undefined : filters?.value.search ? undefined : '0'), // Sending 0 will only show one level of folders
 			},
 			fetchFolders,
 		);

--- a/packages/frontend/editor-ui/src/views/WorkflowsView.vue
+++ b/packages/frontend/editor-ui/src/views/WorkflowsView.vue
@@ -64,6 +64,8 @@ import { useUsageStore } from '@/stores/usage.store';
 import { useInsightsStore } from '@/features/insights/insights.store';
 import InsightsSummary from '@/features/insights/components/InsightsSummary.vue';
 import { useOverview } from '@/composables/useOverview';
+import { PROJECT_ROOT } from 'n8n-workflow';
+import { should } from 'vitest';
 
 const SEARCH_DEBOUNCE_TIME = 300;
 const FILTERS_DEBOUNCE_TIME = 100;
@@ -468,6 +470,12 @@ const fetchWorkflows = async () => {
 	// Only fetch folders if showFolders is enabled and there are not tags or active filter applied
 	const fetchFolders = showFolders.value && !tags.length && activeFilter === undefined;
 
+	const areFiltersApplied =
+		filters.value.search ||
+		filters.value.status !== StatusFilter.ALL ||
+		filters.value.homeProject ||
+		tags.length;
+
 	try {
 		const fetchedResources = await workflowsStore.fetchWorkflowsPage(
 			routeProjectId ?? homeProjectFilter,
@@ -480,7 +488,7 @@ const fetchWorkflows = async () => {
 				tags: tags.length ? tags : undefined,
 				parentFolderId:
 					parentFolder ??
-					(isOverviewPage.value ? undefined : filters?.value.search ? undefined : '0'), // Sending 0 will only show one level of folders
+					(isOverviewPage.value ? undefined : areFiltersApplied ? undefined : PROJECT_ROOT),
 			},
 			fetchFolders,
 		);

--- a/packages/frontend/editor-ui/src/views/WorkflowsView.vue
+++ b/packages/frontend/editor-ui/src/views/WorkflowsView.vue
@@ -469,12 +469,6 @@ const fetchWorkflows = async () => {
 	// Only fetch folders if showFolders is enabled and there are not tags or active filter applied
 	const fetchFolders = showFolders.value && !tags.length && activeFilter === undefined;
 
-	const areFiltersApplied =
-		filters.value.search ||
-		filters.value.status !== StatusFilter.ALL ||
-		filters.value.homeProject ||
-		tags.length;
-
 	try {
 		const fetchedResources = await workflowsStore.fetchWorkflowsPage(
 			routeProjectId ?? homeProjectFilter,
@@ -487,7 +481,7 @@ const fetchWorkflows = async () => {
 				tags: tags.length ? tags : undefined,
 				parentFolderId:
 					parentFolder ??
-					(isOverviewPage.value ? undefined : areFiltersApplied ? undefined : PROJECT_ROOT),
+					(isOverviewPage.value ? undefined : filters?.value.search ? undefined : PROJECT_ROOT), // Sending 0 will only show one level of folders
 			},
 			fetchFolders,
 		);

--- a/packages/frontend/editor-ui/src/views/WorkflowsView.vue
+++ b/packages/frontend/editor-ui/src/views/WorkflowsView.vue
@@ -65,7 +65,6 @@ import { useInsightsStore } from '@/features/insights/insights.store';
 import InsightsSummary from '@/features/insights/components/InsightsSummary.vue';
 import { useOverview } from '@/composables/useOverview';
 import { PROJECT_ROOT } from 'n8n-workflow';
-import { should } from 'vitest';
 
 const SEARCH_DEBOUNCE_TIME = 300;
 const FILTERS_DEBOUNCE_TIME = 100;


### PR DESCRIPTION
## Summary

Previously, searching within folders only considered records that were direct children of the current level. With this update, the search now includes all descendant records of the current level, when a filter is applied. Navigation behavior remains unchanged.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3382/[be]-feature-nested-search-in-folders

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
