### PR TITLE
fix(editor): Fix search highlights on node details view table schema

### DIFF
--- a/packages/frontend/editor-ui/src/components/RunDataTable.vue
+++ b/packages/frontend/editor-ui/src/components/RunDataTable.vue
@@ -616,21 +616,22 @@ watch(focusedMappableInput, (curr) => {
 						/>
 						<N8nTree v-else-if="isObject(data)" :node-class="$style.nodeClass" :value="data">
 							<template #label="{ label, path }">
-								<span
+								<TextWithHighlights
+									data-target="mappable"
 									:class="{
 										[$style.hoveringKey]: mappingEnabled && isHovering(path, index2),
 										[$style.draggingKey]: isDraggingKey(path, index2),
 										[$style.dataKey]: true,
 										[$style.mappable]: mappingEnabled,
 									}"
-									data-target="mappable"
+									:content="label || i18n.baseText('runData.unnamedField')"
+									:search="search"
 									:data-name="getCellPathName(path, index2)"
 									:data-value="getCellExpression(path, index2)"
 									:data-depth="path.length"
 									@mouseenter="() => onMouseEnterKey(path, index2)"
 									@mouseleave="onMouseLeaveKey"
-									>{{ label || i18n.baseText('runData.unnamedField') }}</span
-								>
+								/>
 							</template>
 
 							<template #value="{ value }">


### PR DESCRIPTION
## Summary

On NDV's Table schema viewer search highlights didn't work on object property labels, they only worked on object values.

https://github.com/user-attachments/assets/129317d6-dc53-4697-a141-ddd32497c22e

With this fix the labels still remain draggable to expressions like before.

https://github.com/user-attachments/assets/55012259-d131-4e1e-a9df-5296107b31bf

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3265/search-broken-on-schematable-view

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
