### PR TITLE
fix(HTTP Request Tool Node): Fix OAuth2 requests

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/utils.ts
@@ -92,7 +92,7 @@ const genericCredentialRequest = async (ctx: ISupplyDataFunctions, itemIndex: nu
 
 	if (genericType === 'oAuth2Api') {
 		return async (options: IHttpRequestOptions) => {
-			return await ctx.helpers.requestOAuth2.call(ctx, 'oAuth1Api', options, {
+			return await ctx.helpers.requestOAuth2.call(ctx, 'oAuth2Api', options, {
 				tokenType: 'Bearer',
 			});
 		};
@@ -777,7 +777,7 @@ export const configureToolFunction = (
 						throw new NodeOperationError(ctx.getNode(), 'Binary data is not supported');
 					}
 
-					response = optimizeResponse(fullResponse.body);
+					response = optimizeResponse(fullResponse.body ?? fullResponse);
 				} catch (error) {
 					response = `There was an error: "${error.message}"`;
 				}


### PR DESCRIPTION
## Summary

This PR addresses two issues in the HTTP tool:

1. OAuth2 Credential Handling:
Fixed a typo in the genericCredentialRequest function where oAuth1Api was mistakenly used instead of oAuth2Api. This caused OAuth2 credentials to fail during authenticated requests.

2. Response Fallback:
Updated response handling logic to account for cases where fullResponse.body might be undefined. We now safely fall back to using fullResponse directly when calling optimizeResponse.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
- fixes #11025
- https://community.n8n.io/t/credential-not-found-when-working-with-ai-agent-http-node-as-tool/66097

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
