### PR TITLE
fix(core): Fall back to regular mode for `execute` and `executeBatch` commands

### DIFF
--- a/packages/cli/src/commands/execute-batch.ts
+++ b/packages/cli/src/commands/execute-batch.ts
@@ -17,6 +17,7 @@ import { findCliWorkflowStart } from '@/utils';
 import { WorkflowRunner } from '@/workflow-runner';
 
 import { BaseCommand } from './base-command';
+import config from '../config';
 import type {
 	IExecutionResult,
 	INodeSpecialCase,
@@ -609,6 +610,13 @@ export class ExecuteBatch extends BaseCommand {
 			}
 		});
 
+		const workflowRunner = Container.get(WorkflowRunner);
+
+		if (config.getEnv('executions.mode') === 'queue') {
+			this.logger.warn('`executeBatch` does not support queue mode. Falling back to regular mode.');
+			workflowRunner.setExecutionMode('regular');
+		}
+
 		return await new Promise(async (resolve) => {
 			let gotCancel = false;
 
@@ -630,7 +638,7 @@ export class ExecuteBatch extends BaseCommand {
 					userId: ExecuteBatch.instanceOwner.id,
 				};
 
-				const executionId = await Container.get(WorkflowRunner).run(runData);
+				const executionId = await workflowRunner.run(runData);
 
 				const activeExecutions = Container.get(ActiveExecutions);
 				const data = await activeExecutions.getPostExecutePromise(executionId);

--- a/packages/cli/src/commands/execute.ts
+++ b/packages/cli/src/commands/execute.ts
@@ -10,6 +10,7 @@ import { findCliWorkflowStart, isWorkflowIdValid } from '@/utils';
 import { WorkflowRunner } from '@/workflow-runner';
 
 import { BaseCommand } from './base-command';
+import config from '../config';
 
 export class Execute extends BaseCommand {
 	static description = '\nExecutes a given workflow';
@@ -81,7 +82,16 @@ export class Execute extends BaseCommand {
 			userId: user.id,
 		};
 
-		const executionId = await Container.get(WorkflowRunner).run(runData);
+		const workflowRunner = Container.get(WorkflowRunner);
+
+		if (config.getEnv('executions.mode') === 'queue') {
+			this.logger.warn(
+				'CLI command `execute` does not support queue mode. Falling back to regular mode.',
+			);
+			workflowRunner.setExecutionMode('regular');
+		}
+
+		const executionId = await workflowRunner.run(runData);
 
 		const activeExecutions = Container.get(ActiveExecutions);
 		const data = await activeExecutions.getPostExecutePromise(executionId);

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -55,6 +55,10 @@ export class WorkflowRunner {
 		private readonly executionDataService: ExecutionDataService,
 	) {}
 
+	setExecutionMode(mode: 'regular' | 'queue') {
+		this.executionsMode = mode;
+	}
+
 	/** The process did error */
 	async processError(
 		error: ExecutionError | ExecutionNotFoundError,


### PR DESCRIPTION
## Summary

CLI commands `execute` and `executeBatch` were never made to work with queue mode. Until this is supported, we should fall back to regular mode.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-744


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
