### PR TITLE
feat(core): Don't store insights for sub workflow executions

### DIFF
--- a/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
@@ -153,30 +153,31 @@ describe('workflowExecuteAfterHandler', () => {
 		expect(allInsights).toHaveLength(0);
 	});
 
-	test.each<{ mode: WorkflowExecuteMode }>([{ mode: 'internal' }, { mode: 'manual' }])(
-		'does not store events for executions with the mode `$mode`',
-		async ({ mode }) => {
-			// ARRANGE
-			const ctx = mock<ExecutionLifecycleHooks>({ workflowData: workflow });
-			const startedAt = DateTime.utc();
-			const stoppedAt = startedAt.plus({ seconds: 5 });
-			const run = mock<IRun>({
-				mode,
-				status: 'success',
-				startedAt: startedAt.toJSDate(),
-				stoppedAt: stoppedAt.toJSDate(),
-			});
+	test.each<{ mode: WorkflowExecuteMode }>([
+		{ mode: 'internal' },
+		{ mode: 'manual' },
+		{ mode: 'integrated' },
+	])('does not store events for executions with the mode `$mode`', async ({ mode }) => {
+		// ARRANGE
+		const ctx = mock<ExecutionLifecycleHooks>({ workflowData: workflow });
+		const startedAt = DateTime.utc();
+		const stoppedAt = startedAt.plus({ seconds: 5 });
+		const run = mock<IRun>({
+			mode,
+			status: 'success',
+			startedAt: startedAt.toJSDate(),
+			stoppedAt: stoppedAt.toJSDate(),
+		});
 
-			// ACT
-			await insightsService.workflowExecuteAfterHandler(ctx, run);
+		// ACT
+		await insightsService.workflowExecuteAfterHandler(ctx, run);
 
-			// ASSERT
-			const metadata = await insightsMetadataRepository.findOneBy({ workflowId: workflow.id });
-			const allInsights = await insightsRawRepository.find();
-			expect(metadata).toBeNull();
-			expect(allInsights).toHaveLength(0);
-		},
-	);
+		// ASSERT
+		const metadata = await insightsMetadataRepository.findOneBy({ workflowId: workflow.id });
+		const allInsights = await insightsRawRepository.find();
+		expect(metadata).toBeNull();
+		expect(allInsights).toHaveLength(0);
+	});
 
 	test.each<{ mode: WorkflowExecuteMode }>([
 		{ mode: 'evaluation' },
@@ -185,7 +186,6 @@ describe('workflowExecuteAfterHandler', () => {
 		{ mode: 'retry' },
 		{ mode: 'trigger' },
 		{ mode: 'webhook' },
-		{ mode: 'integrated' },
 	])('stores events for executions with the mode `$mode`', async ({ mode }) => {
 		// ARRANGE
 		const ctx = mock<ExecutionLifecycleHooks>({ workflowData: workflow });

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -45,7 +45,9 @@ const shouldSkipMode: Record<WorkflowExecuteMode, boolean> = {
 	// sub workflows
 	integrated: true,
 
+	// error workflows
 	internal: true,
+
 	manual: true,
 };
 

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -37,11 +37,13 @@ const shouldSkipStatus: Record<ExecutionStatus, boolean> = {
 const shouldSkipMode: Record<WorkflowExecuteMode, boolean> = {
 	cli: false,
 	error: false,
-	integrated: false,
 	retry: false,
 	trigger: false,
 	webhook: false,
 	evaluation: false,
+
+	// sub workflows
+	integrated: true,
 
 	internal: true,
 	manual: true,


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

We don't want sub workflows to be counted in the insights dashboard or overview. That is to make the numbers match the limits in the license more closely.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
