### PR TITLE
feat(Airtable node): Support field ids for robust workflows

### DIFF
--- a/packages/nodes-base/nodes/Airtable/test/v2/methods/resourceMapping.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/methods/resourceMapping.test.ts
@@ -1,0 +1,140 @@
+import { get } from 'lodash';
+import type { IGetNodeParameterOptions, ILoadOptionsFunctions } from 'n8n-workflow';
+
+import * as resourceMapping from '../../../v2/methods/resourceMapping';
+import * as transport from '../../../v2/transport';
+
+jest.mock('../../../v2/transport', () => {
+	const originalModule = jest.requireActual('../../../v2/transport');
+	return {
+		...originalModule,
+		apiRequest: jest.fn(async function () {
+			return {
+				tables: [
+					{
+						id: 'tblTestTable',
+						name: 'Test Table',
+						fields: [
+							{
+								id: 'fldName',
+								name: 'Name',
+								type: 'singleLineText',
+							},
+							{
+								id: 'fldEmail',
+								name: 'Email',
+								type: 'email',
+							},
+							{
+								id: 'fldSelect',
+								name: 'Status',
+								type: 'singleSelect',
+								options: {
+									choices: [
+										{
+											id: 'selActive',
+											name: 'Active',
+											color: 'green',
+										},
+										{
+											id: 'selInactive',
+											name: 'Inactive',
+											color: 'red',
+										},
+									],
+								},
+							},
+						],
+					},
+				],
+			};
+		}),
+	};
+});
+
+const nodeParameters = {
+	base: {
+		value: 'appBaseId',
+	},
+	table: {
+		value: 'tblTestTable',
+	},
+};
+
+const mockLoadOptionsFunctions = {
+	getNodeParameter(
+		parameterName: string,
+		fallbackValue: unknown,
+		options?: IGetNodeParameterOptions,
+	) {
+		const parameter = options?.extractValue ? `${parameterName}.value` : parameterName;
+		return get(nodeParameters, parameter, fallbackValue);
+	},
+} as unknown as ILoadOptionsFunctions;
+
+describe('Test Airtable resourceMapping methods', () => {
+	describe('getColumns', () => {
+		it('should return fields with IDs as identifiers, not names', async () => {
+			const result = await resourceMapping.getColumns.call(mockLoadOptionsFunctions);
+
+			// Verify the API was called correctly
+			expect(transport.apiRequest).toHaveBeenCalledWith('GET', 'meta/bases/appBaseId/tables');
+
+			// Verify the returned fields use IDs as identifiers
+			expect(result.fields).toHaveLength(3);
+			expect(result.fields).toMatchObject([
+				{
+					id: 'fldName',
+					displayName: 'Name',
+					type: 'string',
+				},
+				{
+					id: 'fldEmail',
+					displayName: 'Email',
+					type: 'string',
+				},
+				{
+					id: 'fldSelect',
+					displayName: 'Status',
+					type: 'options',
+					options: [
+						{ name: 'Active', value: 'selActive' },
+						{ name: 'Inactive', value: 'selInactive' },
+					],
+				},
+			]);
+		});
+	});
+
+	describe('getColumnsWithRecordId', () => {
+		it('should return fields with IDs as identifiers including record ID field', async () => {
+			const result = await resourceMapping.getColumnsWithRecordId.call(mockLoadOptionsFunctions);
+
+			// Verify the API was called correctly
+			expect(transport.apiRequest).toHaveBeenCalledWith('GET', 'meta/bases/appBaseId/tables');
+
+			// Verify the returned fields include the record ID field
+			expect(result.fields).toHaveLength(4);
+			expect(result.fields).toMatchObject([
+				{
+					id: 'id',
+					displayName: 'id',
+					type: 'string',
+					defaultMatch: true,
+				},
+				{
+					id: 'fldName',
+					displayName: 'Name',
+				},
+				{
+					id: 'fldEmail',
+					displayName: 'Email',
+				},
+				{
+					id: 'fldSelect',
+					displayName: 'Status',
+				},
+			]);
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/base/getSchema.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/base/getSchema.test.ts
@@ -1,15 +1,57 @@
 import { mockDeep } from 'jest-mock-extended';
 import { get } from 'lodash';
-import type { IExecuteFunctions } from 'n8n-workflow';
+import type { IDataObject, IExecuteFunctions } from 'n8n-workflow';
 
 import * as getSchema from '../../../../v2/actions/base/getSchema.operation';
 import * as transport from '../../../../v2/transport';
+import { createMockExecuteFunction } from '../helpers';
 
 jest.mock('../../../../v2/transport', () => {
 	const originalModule = jest.requireActual('../../../../v2/transport');
 	return {
 		...originalModule,
-		apiRequest: jest.fn(async function () {
+		apiRequest: jest.fn(async function (_: string, endpoint: string) {
+			if (endpoint === 'meta/bases/appWithTables/tables') {
+				return {
+					tables: [
+						{
+							id: 'tblTestTable',
+							name: 'Test Table',
+							fields: [
+								{
+									id: 'fldName',
+									name: 'Name',
+									type: 'singleLineText',
+								},
+								{
+									id: 'fldEmail',
+									name: 'Email',
+									type: 'email',
+								},
+								{
+									id: 'fldSelect',
+									name: 'Status',
+									type: 'singleSelect',
+									options: {
+										choices: [
+											{
+												id: 'selActive',
+												name: 'Active',
+												color: 'green',
+											},
+											{
+												id: 'selInactive',
+												name: 'Inactive',
+												color: 'red',
+											},
+										],
+									},
+								},
+							],
+						},
+					],
+				};
+			}
 			return { tables: [] };
 		}),
 	};
@@ -27,10 +69,10 @@ describe('Test AirtableV2, base => getSchema', () => {
 
 		const items = [
 			{
-				json: { id: 'appYobase1' },
+				json: { id: 'appEmptyBase1' },
 			},
 			{
-				json: { id: 'appYobase2' },
+				json: { id: 'appEmptyBase2' },
 			},
 		];
 
@@ -49,7 +91,73 @@ describe('Test AirtableV2, base => getSchema', () => {
 		);
 
 		expect(transport.apiRequest).toBeCalledTimes(2);
-		expect(transport.apiRequest).toHaveBeenCalledWith('GET', 'meta/bases/appYobase1/tables');
-		expect(transport.apiRequest).toHaveBeenCalledWith('GET', 'meta/bases/appYobase2/tables');
+		expect(transport.apiRequest).toHaveBeenCalledWith('GET', 'meta/bases/appEmptyBase1/tables');
+		expect(transport.apiRequest).toHaveBeenCalledWith('GET', 'meta/bases/appEmptyBase2/tables');
+	});
+
+	it('should return schema when base has tables', async () => {
+		const nodeParameters = {
+			resource: 'base',
+			operation: 'getSchema',
+			base: {
+				value: 'appWithTables',
+			},
+		};
+
+		const items = [
+			{
+				json: {},
+			},
+		];
+
+		const result = await getSchema.execute.call(
+			createMockExecuteFunction({
+				...nodeParameters,
+			}),
+			items,
+		);
+
+		// Verify the API was called correctly
+		expect(transport.apiRequest).toHaveBeenCalledWith('GET', 'meta/bases/appWithTables/tables');
+
+		// Verify the returned schema contains the correct field IDs using simplified expect
+		expect(result).toHaveLength(1);
+
+		const table = result[0].json as IDataObject;
+		expect(table).toMatchObject({
+			id: 'tblTestTable',
+			name: 'Test Table',
+			fields: [
+				{
+					id: 'fldName',
+					name: 'Name',
+					type: 'singleLineText',
+				},
+				{
+					id: 'fldEmail',
+					name: 'Email',
+					type: 'email',
+				},
+				{
+					id: 'fldSelect',
+					name: 'Status',
+					type: 'singleSelect',
+					options: {
+						choices: [
+							{
+								id: 'selActive',
+								name: 'Active',
+								color: 'green',
+							},
+							{
+								id: 'selInactive',
+								name: 'Inactive',
+								color: 'red',
+							},
+						],
+					},
+				},
+			],
+		});
 	});
 });

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/record/create.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/record/create.test.ts
@@ -56,6 +56,7 @@ describe('Test AirtableV2, create operation', () => {
 			options: {
 				typecast: true,
 				ignoreFields: 'spam',
+				returnFieldsByFieldId: true,
 			},
 		};
 
@@ -90,6 +91,7 @@ describe('Test AirtableV2, create operation', () => {
 				bar: 'bar 1',
 			},
 			typecast: true,
+			returnFieldsByFieldId: true,
 		});
 		expect(transport.apiRequest).toHaveBeenCalledWith('POST', 'appYoLbase/tblltable', {
 			fields: {
@@ -97,6 +99,7 @@ describe('Test AirtableV2, create operation', () => {
 				bar: 'bar 2',
 			},
 			typecast: true,
+			returnFieldsByFieldId: true,
 		});
 	});
 
@@ -129,7 +132,9 @@ describe('Test AirtableV2, create operation', () => {
 					},
 				],
 			},
-			options: {},
+			options: {
+				returnFieldsByFieldId: false,
+			},
 		};
 
 		const items = [
@@ -152,6 +157,7 @@ describe('Test AirtableV2, create operation', () => {
 				bar: 'bar 1',
 			},
 			typecast: false,
+			returnFieldsByFieldId: false,
 		});
 	});
 });

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/record/get.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/record/get.test.ts
@@ -25,7 +25,9 @@ describe('Test AirtableV2, create operation', () => {
 		const nodeParameters = {
 			operation: 'get',
 			id: 'recXXX',
-			options: {},
+			options: {
+				returnFieldsByFieldId: false,
+			},
 		};
 
 		const items = [
@@ -42,7 +44,12 @@ describe('Test AirtableV2, create operation', () => {
 		);
 
 		expect(transport.apiRequest).toHaveBeenCalledTimes(1);
-		expect(transport.apiRequest).toHaveBeenCalledWith('GET', 'appYoLbase/tblltable/recXXX');
+		expect(transport.apiRequest).toHaveBeenCalledWith(
+			'GET',
+			'appYoLbase/tblltable/recXXX',
+			{},
+			{ returnFieldsByFieldId: false },
+		);
 
 		expect(responce).toEqual([
 			{

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/record/search.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/record/search.test.ts
@@ -58,6 +58,7 @@ describe('Test AirtableV2, search operation', () => {
 					value: 'viwView',
 					mode: 'list',
 				},
+				returnFieldsByFieldId: false,
 			},
 			sort: {
 				property: [
@@ -92,6 +93,7 @@ describe('Test AirtableV2, search operation', () => {
 				filterByFormula: 'foo',
 				sort: [{ direction: 'desc', field: 'bar' }],
 				view: 'viwView',
+				returnFieldsByFieldId: false,
 			},
 		);
 
@@ -114,6 +116,7 @@ describe('Test AirtableV2, search operation', () => {
 			limit: 1,
 			options: {
 				fields: ['foo', 'bar'],
+				returnFieldsByFieldId: false,
 			},
 			sort: {},
 		};
@@ -136,7 +139,12 @@ describe('Test AirtableV2, search operation', () => {
 			'GET',
 			'appYoLbase/tblltable',
 			{},
-			{ fields: ['foo', 'bar'], filterByFormula: 'foo', maxRecords: 1 },
+			{
+				fields: ['foo', 'bar'],
+				filterByFormula: 'foo',
+				maxRecords: 1,
+				returnFieldsByFieldId: false,
+			},
 		);
 
 		expect(result).toHaveLength(1);

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/record/update.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/record/update.test.ts
@@ -45,7 +45,9 @@ describe('Test AirtableV2, update operation', () => {
 				mappingMode: 'autoMapInputData',
 				matchingColumns: ['id'],
 			},
-			options: {},
+			options: {
+				returnFieldsByFieldId: false,
+			},
 		};
 
 		const items = [
@@ -67,7 +69,7 @@ describe('Test AirtableV2, update operation', () => {
 
 		expect(transport.batchUpdate).toHaveBeenCalledWith(
 			'appYoLbase/tblltable',
-			{ typecast: false },
+			{ typecast: false, returnFieldsByFieldId: false },
 			[{ fields: { bar: 'bar 1', foo: 'foo 1' }, id: 'recXXX' }],
 		);
 	});
@@ -79,7 +81,9 @@ describe('Test AirtableV2, update operation', () => {
 				mappingMode: 'autoMapInputData',
 				matchingColumns: ['foo'],
 			},
-			options: {},
+			options: {
+				returnFieldsByFieldId: false,
+			},
 		};
 
 		const items = [
@@ -101,7 +105,7 @@ describe('Test AirtableV2, update operation', () => {
 
 		expect(transport.batchUpdate).toHaveBeenCalledWith(
 			'appYoLbase/tblltable',
-			{ typecast: false },
+			{ typecast: false, returnFieldsByFieldId: false },
 			[{ fields: { bar: 'bar 1', foo: 'foo 1', id: 'recXXX' }, id: 'recXXX' }],
 		);
 	});

--- a/packages/nodes-base/nodes/Airtable/v2/actions/common.descriptions.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/actions/common.descriptions.ts
@@ -193,6 +193,14 @@ export const insertUpdateOptions: INodeProperties[] = [
 				description: 'Comma-separated list of fields in input to ignore when updating',
 			},
 			{
+				displayName: 'Return Fields by Field ID',
+				name: 'returnFieldsByFieldId',
+				type: 'boolean',
+				default: true,
+				description:
+					'Whether to return field values by field ID instead of field name. This is recommended to avoid your integration breaking if you rename Airtable fields.',
+			},
+			{
 				displayName: 'Update All Matches',
 				name: 'updateAllMatches',
 				type: 'boolean',

--- a/packages/nodes-base/nodes/Airtable/v2/actions/record/create.operation.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/actions/record/create.operation.ts
@@ -68,6 +68,10 @@ export async function execute(
 				typecast: options.typecast ? true : false,
 			};
 
+			if (options.returnFieldsByFieldId !== undefined) {
+				body.returnFieldsByFieldId = options.returnFieldsByFieldId as boolean;
+			}
+
 			if (dataMode === 'autoMapInputData') {
 				body.fields = removeIgnored(items[i].json, options.ignoreFields as string);
 			}

--- a/packages/nodes-base/nodes/Airtable/v2/actions/record/get.operation.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/actions/record/get.operation.ts
@@ -44,6 +44,14 @@ const properties: INodeProperties[] = [
 				// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-multi-options
 				description: "The fields of type 'attachment' that should be downloaded",
 			},
+			{
+				displayName: 'Return Fields by Field ID',
+				name: 'returnFieldsByFieldId',
+				type: 'boolean',
+				default: true,
+				description:
+					'Whether to return field values by field ID instead of field name. This is recommended to avoid your integration breaking if you rename Airtable fields.',
+			},
 		],
 	},
 ];
@@ -69,10 +77,14 @@ export async function execute(
 		let id;
 		try {
 			id = this.getNodeParameter('id', i) as string;
+			const options = this.getNodeParameter('options', i, {});
 
-			const responseData = await apiRequest.call(this, 'GET', `${base}/${table}/${id}`);
+			const qs: IDataObject = {};
+			if (options.returnFieldsByFieldId !== undefined) {
+				qs.returnFieldsByFieldId = options.returnFieldsByFieldId as boolean;
+			}
 
-			const options = this.getNodeParameter('options', 0, {});
+			const responseData = await apiRequest.call(this, 'GET', `${base}/${table}/${id}`, {}, qs);
 
 			if (options.downloadFields) {
 				const itemWithAttachments = await downloadRecordAttachments.call(

--- a/packages/nodes-base/nodes/Airtable/v2/actions/record/search.operation.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/actions/record/search.operation.ts
@@ -79,6 +79,14 @@ const properties: INodeProperties[] = [
 				// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-multi-options
 				description: 'The fields you want to include in the output',
 			},
+			{
+				displayName: 'Return Fields by Field ID',
+				name: 'returnFieldsByFieldId',
+				type: 'boolean',
+				default: true,
+				description:
+					'Whether to return field values by field ID instead of field name. This is recommended to avoid your integration breaking if you rename Airtable fields.',
+			},
 			viewRLC,
 		],
 	},
@@ -192,6 +200,10 @@ export async function execute(
 
 			if (options.view) {
 				qs.view = (options.view as IDataObject).value as string;
+			}
+
+			if (options.returnFieldsByFieldId !== undefined) {
+				qs.returnFieldsByFieldId = options.returnFieldsByFieldId as boolean;
 			}
 
 			let responseData;

--- a/packages/nodes-base/nodes/Airtable/v2/actions/record/update.operation.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/actions/record/update.operation.ts
@@ -129,6 +129,10 @@ export async function execute(
 
 			const body: IDataObject = { typecast: options.typecast ? true : false };
 
+			if (options.returnFieldsByFieldId !== undefined) {
+				body.returnFieldsByFieldId = options.returnFieldsByFieldId as boolean;
+			}
+
 			const responseData = await batchUpdate.call(this, endpoint, body, records);
 
 			const executionData = this.helpers.constructExecutionMetaData(

--- a/packages/nodes-base/nodes/Airtable/v2/actions/record/upsert.operation.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/actions/record/upsert.operation.ts
@@ -97,6 +97,10 @@ export async function execute(
 				typecast: options.typecast ? true : false,
 			};
 
+			if (options.returnFieldsByFieldId !== undefined) {
+				body.returnFieldsByFieldId = options.returnFieldsByFieldId as boolean;
+			}
+
 			if (!columnsToMatchOn.includes('id')) {
 				body.performUpsert = { fieldsToMergeOn: columnsToMatchOn };
 			}

--- a/packages/nodes-base/nodes/Airtable/v2/methods/loadOptions.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/methods/loadOptions.ts
@@ -31,7 +31,7 @@ export async function getColumns(this: ILoadOptionsFunctions): Promise<INodeProp
 	for (const field of tableData.fields as IDataObject[]) {
 		result.push({
 			name: field.name as string,
-			value: field.name as string,
+			value: field.id as string,
 			description: `Type: ${field.type}`,
 		});
 	}
@@ -95,7 +95,7 @@ export async function getAttachmentColumns(
 		}
 		result.push({
 			name: field.name as string,
-			value: field.name as string,
+			value: field.id as string,
 			description: `Type: ${field.type}`,
 		});
 	}

--- a/packages/nodes-base/nodes/Airtable/v2/methods/resourceMapping.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/methods/resourceMapping.ts
@@ -89,7 +89,7 @@ export async function getColumns(this: ILoadOptionsFunctions): Promise<ResourceM
 		if (field?.options?.choices) {
 			return (field.options.choices as IDataObject[]).map((choice) => ({
 				name: choice.name,
-				value: choice.name,
+				value: choice.id,
 			})) as INodePropertyOptions[];
 		}
 
@@ -101,7 +101,7 @@ export async function getColumns(this: ILoadOptionsFunctions): Promise<ResourceM
 		const isReadOnly = airtableReadOnlyFields.includes(field.type);
 		const options = constructOptions(field);
 		fields.push({
-			id: field.name,
+			id: field.id,
 			displayName: field.name,
 			required: false,
 			defaultMatch: false,


### PR DESCRIPTION
## Summary

Currently, the node requires field names when creating or updating records, but Airtable’s API uses field IDs. This can cause issues, especially when field names change which results in broken workflows.

A similar functionality for targeting tables by ID instead of table name has been discussed and implemented. This PR implements a similar feature for fields.

To avoid this being a breaking change, nodes accept either field ids or field names (by virtue of the Airtable API allowing these to be interchanged). Nodes continue to output with field names, but with the `returnFieldsByFieldId` option users of this node can opt-in to getting data as fieldIds.

Screenshots:

Without field id output:
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/724d0866-c74e-4fd8-a301-92f58df965f5" />

With field id output:
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/e23131c1-d349-4d53-9191-2c741b498c90" />

Updating a record. Under the hood this now uses field ids, so continues to work even if I edit the column names after saving the n8n configuration:
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/353f7abb-5403-4e0b-ad3b-ddcc1dcd583b" />

Plus this also works with returning the updated data with field ids:
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/80a97aeb-5a37-47aa-a39b-83c903fda44a" />

## Related Linear tickets, Github issues, and Community forum posts

Closes https://github.com/bluedotimpact/bluedot/issues/19

Related:
- https://community.n8n.io/t/airtable-node-target-table-with-table-name-instead-of-id/26067
- https://community.n8n.io/t/airtable-node-target-table-with-table-name-instead-of-id/26067
- https://github.com/n8n-io/n8n/pull/11666
- https://github.com/n8n-io/n8n/pull/13328

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
