### PR TITLE
fix(AI Agent Node): Allow removal of system message

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/Agent.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/Agent.node.ts
@@ -263,7 +263,7 @@ export class Agent implements INodeType {
 		icon: 'fa:robot',
 		iconColor: 'black',
 		group: ['transform'],
-		version: [1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8],
+		version: [1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9],
 		description: 'Generates an action plan and executes it. Can use external tools.',
 		subtitle:
 			"={{ {	toolsAgent: 'Tools Agent', conversationalAgent: 'Conversational Agent', openAiFunctionsAgent: 'OpenAI Functions Agent', reActAgent: 'ReAct Agent', sqlAgent: 'SQL Agent', planAndExecuteAgent: 'Plan and Execute Agent' }[$parameter.agent] }}",

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/execute.ts
@@ -353,7 +353,7 @@ export async function prepareMessages(
 	if (useSystemMessage) {
 		messages.push([
 			'system',
-			`{system_message}${options.outputParser ? '{formatting_instructions}' : ''}`,
+			`{system_message}${options.outputParser ? '\n\n{formatting_instructions}' : ''}`,
 		]);
 	} else if (options.outputParser) {
 		messages.push(['system', '{formatting_instructions}']);

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/execute.ts
@@ -346,15 +346,18 @@ export async function prepareMessages(
 		outputParser?: N8nOutputParser;
 	},
 ): Promise<BaseMessagePromptTemplateLike[]> {
-	const messages: BaseMessagePromptTemplateLike[] =
-		(options.systemMessage ?? ctx.getNode().typeVersion < 1.9)
-			? [
-					[
-						'system',
-						`{system_message}${options.outputParser ? '\n\n{formatting_instructions}' : ''}`,
-					],
-				]
-			: [];
+	const useLegacySystemMessage = options.systemMessage ?? ctx.getNode().typeVersion < 1.9;
+
+	const messages: BaseMessagePromptTemplateLike[] = [];
+
+	if (useLegacySystemMessage) {
+		messages.push([
+			'system',
+			`{system_message}${options.outputParser ? '{formatting_instructions}' : ''}`,
+		]);
+	} else if (options.outputParser) {
+		messages.push(['system', '{formatting_instructions}']);
+	}
 
 	messages.push(['placeholder', '{chat_history}'], ['human', '{input}']);
 

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/execute.ts
@@ -346,11 +346,11 @@ export async function prepareMessages(
 		outputParser?: N8nOutputParser;
 	},
 ): Promise<BaseMessagePromptTemplateLike[]> {
-	const useLegacySystemMessage = options.systemMessage ?? ctx.getNode().typeVersion < 1.9;
+	const useSystemMessage = options.systemMessage ?? ctx.getNode().typeVersion < 1.9;
 
 	const messages: BaseMessagePromptTemplateLike[] = [];
 
-	if (useLegacySystemMessage) {
+	if (useSystemMessage) {
 		messages.push([
 			'system',
 			`{system_message}${options.outputParser ? '{formatting_instructions}' : ''}`,

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/execute.ts
@@ -346,11 +346,17 @@ export async function prepareMessages(
 		outputParser?: N8nOutputParser;
 	},
 ): Promise<BaseMessagePromptTemplateLike[]> {
-	const messages: BaseMessagePromptTemplateLike[] = [
-		['system', `{system_message}${options.outputParser ? '\n\n{formatting_instructions}' : ''}`],
-		['placeholder', '{chat_history}'],
-		['human', '{input}'],
-	];
+	const messages: BaseMessagePromptTemplateLike[] =
+		(options.systemMessage ?? ctx.getNode().typeVersion < 1.9)
+			? [
+					[
+						'system',
+						`{system_message}${options.outputParser ? '\n\n{formatting_instructions}' : ''}`,
+					],
+				]
+			: [];
+
+	messages.push(['placeholder', '{chat_history}'], ['human', '{input}']);
 
 	// If there is binary data and the node option permits it, add a binary message
 	const hasBinaryData = ctx.getInputData()?.[itemIndex]?.binary !== undefined;

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent.test.ts
@@ -281,7 +281,7 @@ describe('prepareMessages', () => {
 		});
 
 		expect(messages.length).toBe(4);
-		expect(messages).toContainEqual(['system', '{system_message}{formatting_instructions}']);
+		expect(messages).toContainEqual(['system', '{system_message}\n\n{formatting_instructions}']);
 	});
 
 	it('should add formatting instructions when omitting system message after version 1.9', async () => {

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent.test.ts
@@ -269,16 +269,31 @@ describe('prepareMessages', () => {
 		expect(messages).toContainEqual(['system', '{system_message}']);
 	});
 
-	it('should include system_message in prompt templates if provided before version 1.9', async () => {
+	it('should include system_message with formatting_instructions in prompt templates if provided before version 1.9', async () => {
 		const fakeItem = { json: {} };
 		const ctx = createFakeExecuteFunctions({
 			getInputData: jest.fn().mockReturnValue([fakeItem]),
 		});
 		ctx.getNode().typeVersion = 1.8;
-		const messages = await prepareMessages(ctx, 0, { systemMessage: 'Hello' });
+		const messages = await prepareMessages(ctx, 0, {
+			systemMessage: 'Hello',
+			outputParser: mock<N8nOutputParser>(),
+		});
 
 		expect(messages.length).toBe(4);
-		expect(messages).toContainEqual(['system', '{system_message}']);
+		expect(messages).toContainEqual(['system', '{system_message}{formatting_instructions}']);
+	});
+
+	it('should add formatting instructions when omitting system message after version 1.9', async () => {
+		const fakeItem = { json: {} };
+		const ctx = createFakeExecuteFunctions({
+			getInputData: jest.fn().mockReturnValue([fakeItem]),
+		});
+		ctx.getNode().typeVersion = 1.9;
+		const messages = await prepareMessages(ctx, 0, { outputParser: mock<N8nOutputParser>() });
+
+		expect(messages.length).toBe(4);
+		expect(messages).toContainEqual(['system', '{formatting_instructions}']);
 	});
 });
 

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent.test.ts
@@ -232,6 +232,54 @@ describe('prepareMessages', () => {
 		const hasHumanMessage = messages.some((m) => m instanceof HumanMessage);
 		expect(hasHumanMessage).toBe(false);
 	});
+
+	it('should not include system_message in prompt templates if not provided after version 1.9', async () => {
+		const fakeItem = { json: {} };
+		const ctx = createFakeExecuteFunctions({
+			getInputData: jest.fn().mockReturnValue([fakeItem]),
+		});
+		ctx.getNode().typeVersion = 1.9;
+		const messages = await prepareMessages(ctx, 0, {});
+
+		expect(messages.length).toBe(3);
+		expect(messages).not.toContainEqual(['system', '{system_message}']);
+	});
+
+	it('should include system_message in prompt templates if provided after version 1.9', async () => {
+		const fakeItem = { json: {} };
+		const ctx = createFakeExecuteFunctions({
+			getInputData: jest.fn().mockReturnValue([fakeItem]),
+		});
+		ctx.getNode().typeVersion = 1.9;
+		const messages = await prepareMessages(ctx, 0, { systemMessage: 'Hello' });
+
+		expect(messages.length).toBe(4);
+		expect(messages).toContainEqual(['system', '{system_message}']);
+	});
+
+	it('should include system_message in prompt templates if not provided before version 1.9', async () => {
+		const fakeItem = { json: {} };
+		const ctx = createFakeExecuteFunctions({
+			getInputData: jest.fn().mockReturnValue([fakeItem]),
+		});
+		ctx.getNode().typeVersion = 1.8;
+		const messages = await prepareMessages(ctx, 0, {});
+
+		expect(messages.length).toBe(4);
+		expect(messages).toContainEqual(['system', '{system_message}']);
+	});
+
+	it('should include system_message in prompt templates if provided before version 1.9', async () => {
+		const fakeItem = { json: {} };
+		const ctx = createFakeExecuteFunctions({
+			getInputData: jest.fn().mockReturnValue([fakeItem]),
+		});
+		ctx.getNode().typeVersion = 1.8;
+		const messages = await prepareMessages(ctx, 0, { systemMessage: 'Hello' });
+
+		expect(messages.length).toBe(4);
+		expect(messages).toContainEqual(['system', '{system_message}']);
+	});
 });
 
 describe('preparePrompt', () => {

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent.test.ts
@@ -6,7 +6,7 @@ import { Buffer } from 'buffer';
 import { mock } from 'jest-mock-extended';
 import type { ToolsAgentAction } from 'langchain/dist/agents/tool_calling/output_parser';
 import type { Tool } from 'langchain/tools';
-import type { IExecuteFunctions } from 'n8n-workflow';
+import type { IExecuteFunctions, INode } from 'n8n-workflow';
 import { NodeOperationError, BINARY_ENCODING, NodeConnectionTypes } from 'n8n-workflow';
 import type { ZodType } from 'zod';
 import { z } from 'zod';
@@ -235,11 +235,11 @@ describe('prepareMessages', () => {
 
 	it('should not include system_message in prompt templates if not provided after version 1.9', async () => {
 		const fakeItem = { json: {} };
-		const ctx = createFakeExecuteFunctions({
-			getInputData: jest.fn().mockReturnValue([fakeItem]),
-		});
-		ctx.getNode().typeVersion = 1.9;
-		const messages = await prepareMessages(ctx, 0, {});
+		const mockNode = mock<INode>();
+		mockNode.typeVersion = 1.9;
+		mockContext.getInputData.mockReturnValue([fakeItem]);
+		mockContext.getNode.mockReturnValue(mockNode);
+		const messages = await prepareMessages(mockContext, 0, {});
 
 		expect(messages.length).toBe(3);
 		expect(messages).not.toContainEqual(['system', '{system_message}']);
@@ -247,11 +247,12 @@ describe('prepareMessages', () => {
 
 	it('should include system_message in prompt templates if provided after version 1.9', async () => {
 		const fakeItem = { json: {} };
-		const ctx = createFakeExecuteFunctions({
-			getInputData: jest.fn().mockReturnValue([fakeItem]),
-		});
-		ctx.getNode().typeVersion = 1.9;
-		const messages = await prepareMessages(ctx, 0, { systemMessage: 'Hello' });
+		const mockNode = mock<INode>();
+		mockNode.typeVersion = 1.9;
+		mockContext.getInputData.mockReturnValue([fakeItem]);
+		mockContext.getNode.mockReturnValue(mockNode);
+
+		const messages = await prepareMessages(mockContext, 0, { systemMessage: 'Hello' });
 
 		expect(messages.length).toBe(4);
 		expect(messages).toContainEqual(['system', '{system_message}']);
@@ -259,11 +260,12 @@ describe('prepareMessages', () => {
 
 	it('should include system_message in prompt templates if not provided before version 1.9', async () => {
 		const fakeItem = { json: {} };
-		const ctx = createFakeExecuteFunctions({
-			getInputData: jest.fn().mockReturnValue([fakeItem]),
-		});
-		ctx.getNode().typeVersion = 1.8;
-		const messages = await prepareMessages(ctx, 0, {});
+		const mockNode = mock<INode>();
+		mockNode.typeVersion = 1.8;
+		mockContext.getInputData.mockReturnValue([fakeItem]);
+		mockContext.getNode.mockReturnValue(mockNode);
+
+		const messages = await prepareMessages(mockContext, 0, {});
 
 		expect(messages.length).toBe(4);
 		expect(messages).toContainEqual(['system', '{system_message}']);
@@ -271,11 +273,12 @@ describe('prepareMessages', () => {
 
 	it('should include system_message with formatting_instructions in prompt templates if provided before version 1.9', async () => {
 		const fakeItem = { json: {} };
-		const ctx = createFakeExecuteFunctions({
-			getInputData: jest.fn().mockReturnValue([fakeItem]),
-		});
-		ctx.getNode().typeVersion = 1.8;
-		const messages = await prepareMessages(ctx, 0, {
+		const mockNode = mock<INode>();
+		mockNode.typeVersion = 1.8;
+		mockContext.getInputData.mockReturnValue([fakeItem]);
+		mockContext.getNode.mockReturnValue(mockNode);
+
+		const messages = await prepareMessages(mockContext, 0, {
 			systemMessage: 'Hello',
 			outputParser: mock<N8nOutputParser>(),
 		});
@@ -286,11 +289,14 @@ describe('prepareMessages', () => {
 
 	it('should add formatting instructions when omitting system message after version 1.9', async () => {
 		const fakeItem = { json: {} };
-		const ctx = createFakeExecuteFunctions({
-			getInputData: jest.fn().mockReturnValue([fakeItem]),
+		const mockNode = mock<INode>();
+		mockNode.typeVersion = 1.9;
+		mockContext.getInputData.mockReturnValue([fakeItem]);
+		mockContext.getNode.mockReturnValue(mockNode);
+
+		const messages = await prepareMessages(mockContext, 0, {
+			outputParser: mock<N8nOutputParser>(),
 		});
-		ctx.getNode().typeVersion = 1.9;
-		const messages = await prepareMessages(ctx, 0, { outputParser: mock<N8nOutputParser>() });
 
 		expect(messages.length).toBe(4);
 		expect(messages).toContainEqual(['system', '{formatting_instructions}']);


### PR DESCRIPTION
## Summary
Removes the default system message that is passed when using ToolsAgent if no system message was setup by the user. Only happens for newest node version.
This should prevent blocking models like o1-mini that don't support system messages.
<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
fixes #13710 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
