### PR TITLE
fix(core): Detach workflow from parent folder in source project when transferring ownership

### DIFF
--- a/packages/cli/src/workflows/workflow.service.ee.ts
+++ b/packages/cli/src/workflows/workflow.service.ee.ts
@@ -343,6 +343,9 @@ export class EnterpriseWorkflowService {
 			}
 		});
 
+		// 9. detach workflow from parent folder in source project
+		await this.workflowRepository.update({ id: workflow.id }, { parentFolder: null });
+
 		// 9. try to activate it again if it was active
 		if (wasActive) {
 			try {

--- a/packages/cli/test/integration/workflows/workflows.controller.ee.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.ee.test.ts
@@ -14,6 +14,7 @@ import { WorkflowRepository } from '@/databases/repositories/workflow.repository
 import { UserManagementMailer } from '@/user-management/email';
 import type { WorkflowWithSharingsMetaDataAndCredentials } from '@/workflows/workflows.types';
 import { mockInstance } from '@test/mocking';
+import { createFolder } from '@test-integration/db/folders';
 
 import {
 	affixRoleToSaveCredential,
@@ -36,7 +37,6 @@ import type { SaveCredentialFunction } from '../shared/types';
 import type { SuperAgentTest } from '../shared/types';
 import * as utils from '../shared/utils/';
 import { makeWorkflow } from '../shared/utils/';
-import { createFolder } from '@test-integration/db/folders';
 
 let owner: User;
 let admin: User;

--- a/packages/cli/test/integration/workflows/workflows.controller.ee.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.ee.test.ts
@@ -1644,7 +1644,11 @@ describe('PUT /:workflowId/transfer', () => {
 		//
 		expect(response.body).toEqual({});
 
-		const workflowFromDB = await workflowRepository.findOneByOrFail({ id: workflow.id });
+		const workflowFromDB = await workflowRepository.findOneOrFail({
+			where: { id: workflow.id },
+			relations: ['parentFolder'],
+		});
+
 		expect(workflowFromDB.parentFolder).toBeNull();
 	});
 


### PR DESCRIPTION
## Summary

Title self explanatory

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3396/moving-wf-from-inner-folder-to-another-project-makes-it-disappear

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
