### PR TITLE
feat(Node Telegram) : Add missing message_thread_id for sendChatAction

### DIFF
--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -1515,6 +1515,7 @@ export class Telegram implements INodeType {
 							'editMessageText',
 							'sendAnimation',
 							'sendAudio',
+							'sendChatAction',
 							'sendDocument',
 							'sendLocation',
 							'sendMessage',
@@ -1998,6 +1999,8 @@ export class Telegram implements INodeType {
 
 						body.chat_id = this.getNodeParameter('chatId', i) as string;
 						body.action = this.getNodeParameter('action', i) as string;
+						// Add additional fields and replyMarkup
+						addAdditionalFields.call(this, body, i);
 					} else if (operation === 'sendDocument') {
 						// ----------------------------------
 						//         message:sendDocument


### PR DESCRIPTION
## Summary

Since Telegram API webhook support message_thread_id but currently at our sendChatAction don't have message_thread_id as additionalFields 

Without this field we can't send typing for topic (thread) in supergroup

N8N Dashboard : 

<img width="494" alt="image" src="https://github.com/user-attachments/assets/d92735ae-1431-4cd5-b41f-da5d2bfc9d2d" />


Telegram Docs: 

<img width="826" alt="image" src="https://github.com/user-attachments/assets/5d164fec-f20f-49f4-b205-44d30b1c60ff" />


https://core.telegram.org/bots/api#sendchataction



<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
