### PR TITLE
chore: Remove AI assistant experiment's feature flag. (no-chanelog)

### DIFF
--- a/cypress/pages/features/ai-assistant.ts
+++ b/cypress/pages/features/ai-assistant.ts
@@ -1,12 +1,4 @@
-import { overrideFeatureFlag } from '../../composables/featureFlags';
 import { BasePage } from '../base';
-
-const AI_ASSISTANT_FEATURE = {
-	name: 'aiAssistant',
-	experimentName: '021_ai_debug_helper',
-	enabledFor: 'variant',
-	disabledFor: 'control',
-};
 
 /**
  * @deprecated Use functional composables from @composables instead.
@@ -49,12 +41,10 @@ export class AIAssistant extends BasePage {
 
 	actions = {
 		enableAssistant: () => {
-			overrideFeatureFlag(AI_ASSISTANT_FEATURE.experimentName, AI_ASSISTANT_FEATURE.enabledFor);
-			cy.enableFeature(AI_ASSISTANT_FEATURE.name);
+			cy.enableFeature('aiAssistant');
 		},
 		disableAssistant: () => {
-			overrideFeatureFlag(AI_ASSISTANT_FEATURE.experimentName, AI_ASSISTANT_FEATURE.disabledFor);
-			cy.disableFeature(AI_ASSISTANT_FEATURE.name);
+			cy.disableFeature('aiAssistant');
 		},
 		sendMessage: (message: string) => {
 			this.getters.chatInput().type(message).type('{enter}');

--- a/packages/frontend/editor-ui/src/constants.ts
+++ b/packages/frontend/editor-ui/src/constants.ts
@@ -730,12 +730,6 @@ export const CANVAS_AUTO_ADD_MANUAL_TRIGGER_EXPERIMENT = {
 	variant: 'variant',
 };
 
-export const AI_ASSISTANT_EXPERIMENT = {
-	name: '021_ai_debug_helper',
-	control: 'control',
-	variant: 'variant',
-};
-
 export const CREDENTIAL_DOCS_EXPERIMENT = {
 	name: '024_credential_docs',
 	control: 'control',
@@ -763,7 +757,6 @@ export const SCHEMA_PREVIEW_EXPERIMENT = {
 export const EXPERIMENTS_TO_TRACK = [
 	TEMPLATE_CREDENTIAL_SETUP_EXPERIMENT,
 	CANVAS_AUTO_ADD_MANUAL_TRIGGER_EXPERIMENT.name,
-	AI_ASSISTANT_EXPERIMENT.name,
 	CREDENTIAL_DOCS_EXPERIMENT.name,
 	EASY_AI_WORKFLOW_EXPERIMENT.name,
 	AI_CREDITS_EXPERIMENT.name,

--- a/packages/frontend/editor-ui/src/stores/assistant.store.test.ts
+++ b/packages/frontend/editor-ui/src/stores/assistant.store.test.ts
@@ -13,7 +13,7 @@ import { useSettingsStore } from '@/stores/settings.store';
 import { defaultSettings } from '../__tests__/defaults';
 import { merge } from 'lodash-es';
 import { DEFAULT_POSTHOG_SETTINGS } from './posthog.test';
-import { AI_ASSISTANT_EXPERIMENT, VIEWS } from '@/constants';
+import { VIEWS } from '@/constants';
 import { reactive } from 'vue';
 import * as chatAPI from '@/api/ai';
 import * as telemetryModule from '@/composables/useTelemetry';
@@ -54,12 +54,6 @@ vi.mock('vue-router', () => ({
 	useRouter: vi.fn(),
 	RouterLink: vi.fn(),
 }));
-
-const mockPostHogVariant = (variant: 'variant' | 'control') => {
-	posthogStore.overrides = {
-		[AI_ASSISTANT_EXPERIMENT.name]: variant,
-	};
-};
 
 describe('AI Assistant store', () => {
 	beforeEach(() => {
@@ -281,20 +275,9 @@ describe('AI Assistant store', () => {
 		expect(assistantStore.currentSessionId).toBeUndefined();
 	});
 
-	it('should not show assistant for control experiment group', () => {
-		const assistantStore = useAssistantStore();
-
-		mockPostHogVariant('control');
-		setAssistantEnabled(true);
-		expect(assistantStore.isAssistantEnabled).toBe(false);
-		expect(assistantStore.canShowAssistant).toBe(false);
-		expect(assistantStore.canShowAssistantButtonsOnCanvas).toBe(false);
-	});
-
 	it('should not show assistant if disabled in settings', () => {
 		const assistantStore = useAssistantStore();
 
-		mockPostHogVariant('variant');
 		setAssistantEnabled(false);
 		expect(assistantStore.isAssistantEnabled).toBe(false);
 		expect(assistantStore.canShowAssistant).toBe(false);
@@ -305,7 +288,6 @@ describe('AI Assistant store', () => {
 		const assistantStore = useAssistantStore();
 
 		setAssistantEnabled(true);
-		mockPostHogVariant('variant');
 		expect(assistantStore.isAssistantEnabled).toBe(true);
 		expect(assistantStore.canShowAssistant).toBe(true);
 		expect(assistantStore.canShowAssistantButtonsOnCanvas).toBe(true);
@@ -316,7 +298,6 @@ describe('AI Assistant store', () => {
 		const assistantStore = useAssistantStore();
 
 		setAssistantEnabled(true);
-		mockPostHogVariant('variant');
 		expect(assistantStore.isAssistantEnabled).toBe(true);
 		expect(assistantStore.canShowAssistant).toBe(false);
 		expect(assistantStore.canShowAssistantButtonsOnCanvas).toBe(false);
@@ -328,7 +309,6 @@ describe('AI Assistant store', () => {
 			const assistantStore = useAssistantStore();
 
 			setAssistantEnabled(true);
-			mockPostHogVariant('variant');
 			expect(assistantStore.isAssistantEnabled).toBe(true);
 			expect(assistantStore.canShowAssistant).toBe(true);
 			expect(assistantStore.canShowAssistantButtonsOnCanvas).toBe(false);

--- a/packages/frontend/editor-ui/src/stores/assistant.store.ts
+++ b/packages/frontend/editor-ui/src/stores/assistant.store.ts
@@ -3,7 +3,6 @@ import {
 	VIEWS,
 	EDITABLE_CANVAS_VIEWS,
 	STORES,
-	AI_ASSISTANT_EXPERIMENT,
 	PLACEHOLDER_EMPTY_WORKFLOW_ID,
 	CREDENTIAL_EDIT_MODAL_KEY,
 } from '@/constants';
@@ -23,7 +22,6 @@ import { deepCopy } from 'n8n-workflow';
 import { ndvEventBus, codeNodeEditorEventBus } from '@/event-bus';
 import { useNDVStore } from './ndv.store';
 import type { IUpdateInformation } from '@/Interface';
-import { usePostHog } from './posthog.store';
 import { useI18n } from '@/composables/useI18n';
 import { useTelemetry } from '@/composables/useTelemetry';
 import { useToast } from '@/composables/useToast';
@@ -60,7 +58,6 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 	const route = useRoute();
 	const streaming = ref<boolean>();
 	const ndvStore = useNDVStore();
-	const { getVariant } = usePostHog();
 	const locale = useI18n();
 	const telemetry = useTelemetry();
 	const assistantHelpers = useAIAssistantHelpers();
@@ -89,10 +86,6 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 	const workflowDataStale = ref<boolean>(true);
 	const workflowExecutionDataStale = ref<boolean>(true);
 
-	const isExperimentEnabled = computed(
-		() => getVariant(AI_ASSISTANT_EXPERIMENT.name) === AI_ASSISTANT_EXPERIMENT.variant,
-	);
-
 	const assistantMessages = computed(() =>
 		chatMessages.value.filter((msg) => msg.role === 'assistant'),
 	);
@@ -110,9 +103,7 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 
 	const isAssistantOpen = computed(() => canShowAssistant.value && chatWindowOpen.value);
 
-	const isAssistantEnabled = computed(
-		() => isExperimentEnabled.value && settings.isAiAssistantEnabled,
-	);
+	const isAssistantEnabled = computed(() => settings.isAiAssistantEnabled);
 
 	const canShowAssistant = computed(
 		() => isAssistantEnabled.value && ENABLED_VIEWS.includes(route.name as VIEWS),


### PR DESCRIPTION
## Summary

Clean up `021_ai_debug_helper` experiment's feature flag and make it enabled by default. Stop tracking the experiment as it has matured and it has been enabled for all users already.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-2395/feature-cleanup-old-experiments

Related PR: https://github.com/n8n-io/n8n/pull/14429

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
