### PR TITLE
fix: Fix issue with open router credential test

### DIFF
--- a/packages/@n8n/nodes-langchain/credentials/OpenRouterApi.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/OpenRouterApi.credentials.ts
@@ -41,7 +41,7 @@ export class OpenRouterApi implements ICredentialType {
 	test: ICredentialTestRequest = {
 		request: {
 			baseURL: '={{ $credentials.url }}',
-			url: '/models',
+			url: '/key',
 		},
 	};
 }


### PR DESCRIPTION
## Summary
This PR updates the credential test URL as we were previously using the /models endpoint which doesn't require auth.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-838/openrouter-cred-test-fix
closes #14432

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
