### PR TITLE
fix(editor): Show `Execute previous Node` panel after disabled node in Schema view

### DIFF
--- a/packages/frontend/editor-ui/src/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/components/RunData.vue
@@ -1906,6 +1906,9 @@ defineExpose({ enterEditMode });
 					</div>
 				</div>
 			</div>
+			<div v-if="!hasNodeRun" :class="$style.center">
+				<slot name="node-not-run"></slot>
+			</div>
 		</div>
 		<div
 			v-if="

--- a/packages/frontend/editor-ui/src/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/components/RunData.vue
@@ -1906,7 +1906,7 @@ defineExpose({ enterEditMode });
 					</div>
 				</div>
 			</div>
-			<div v-if="!hasNodeRun" :class="$style.center">
+			<div v-else-if="!hasNodeRun" :class="$style.center">
 				<slot name="node-not-run"></slot>
 			</div>
 		</div>

--- a/packages/frontend/editor-ui/src/components/__snapshots__/InputPanel.test.ts.snap
+++ b/packages/frontend/editor-ui/src/components/__snapshots__/InputPanel.test.ts.snap
@@ -159,6 +159,7 @@ exports[`InputPanel > should render 1`] = `
       data-v-2e5cd75c=""
     >
       <!---->
+      <!--v-if-->
     </div>
     <!--v-if-->
     <transition-stub

--- a/packages/frontend/editor-ui/src/components/__snapshots__/InputPanel.test.ts.snap
+++ b/packages/frontend/editor-ui/src/components/__snapshots__/InputPanel.test.ts.snap
@@ -159,7 +159,6 @@ exports[`InputPanel > should render 1`] = `
       data-v-2e5cd75c=""
     >
       <!---->
-      <!--v-if-->
     </div>
     <!--v-if-->
     <transition-stub


### PR DESCRIPTION
## Summary

Without this we have a completely empty input panel if viewing an unexecuted node with a disabled input in schema view.

This way we at least show the panel with its hint that the previous node is disabled:

<img width="1175" alt="image" src="https://github.com/user-attachments/assets/49e61a27-bb22-4fff-81ec-17ae62fa0ea1" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3392/bug-input-panel-empty-before-execution-if-previous-node-is-disabled


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
