### PR TITLE
ci: Skip test until behavior is clarified (no-changelog)

### DIFF
--- a/cypress/e2e/24-ndv-paired-item.cy.ts
+++ b/cypress/e2e/24-ndv-paired-item.cy.ts
@@ -59,7 +59,8 @@ describe('NDV', () => {
 		ndv.getters.inputTableRow(4).invoke('attr', 'data-test-id').should('equal', 'hovering-item');
 	});
 
-	it('maps paired input and output items based on selected input node', () => {
+	// eslint-disable-next-line n8n-local-rules/no-skipped-tests
+	it.skip('maps paired input and output items based on selected input node', () => {
 		cy.fixture('Test_workflow_5.json').then((data) => {
 			cy.get('body').paste(JSON.stringify(data));
 		});


### PR DESCRIPTION
## Summary

This skips the ndv test until the behaviour on node outputs is clarified.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-750/failing-e2e-disable-24-ndv-until-bug-is-resolved

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
