### PR TITLE
fix(API): Fix ratio tests on insights by workflow

### DIFF
--- a/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
@@ -1430,27 +1430,27 @@ describe('getInsightsByWorkflow', () => {
 			projectId: project.id,
 			projectName: project.name,
 			total: 7,
-			failureRate: 2 / 7,
 			failed: 2,
 			runTime: 123,
 			succeeded: 5,
 			timeSaved: 0,
-			averageRunTime: 123 / 7,
 		});
+		expect(byWorkflow.data[0].failureRate).toBeCloseTo(2 / 7);
+		expect(byWorkflow.data[0].averageRunTime).toBeCloseTo(123 / 7);
 
-		expect(byWorkflow.data[1]).toEqual({
+		expect(byWorkflow.data[1]).toMatchObject({
 			workflowId: workflow1.id,
 			workflowName: workflow1.name,
 			projectId: project.id,
 			projectName: project.name,
 			total: 6,
-			failureRate: 2 / 6,
 			failed: 2,
 			runTime: 123,
 			succeeded: 4,
 			timeSaved: 0,
-			averageRunTime: 123 / 6,
 		});
+		expect(byWorkflow.data[1].failureRate).toBeCloseTo(2 / 6);
+		expect(byWorkflow.data[1].averageRunTime).toBeCloseTo(123 / 6);
 	});
 
 	test('compacted data are grouped by workflow correctly with sorting', async () => {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Fix insights module tests when comparing failure rate ratios with different precision for mysql/mariadb and other engines.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [X] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
