### PR TITLE
ci: Generate jest-junit reports only on CI (no-changelog)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ CHANGELOG-*.md
 *.mdx
 build-storybook.log
 *.junit.xml
+junit.xml

--- a/jest.config.js
+++ b/jest.config.js
@@ -32,11 +32,11 @@ const config = {
 	collectCoverage: isCoverageEnabled,
 	coverageReporters: ['text-summary', 'lcov', 'html-spa'],
 	collectCoverageFrom: ['src/**/*.ts'],
-	reporters: ['default', 'jest-junit'],
 	workerIdleMemoryLimit: '1MB',
 };
 
 if (process.env.CI === 'true') {
+	confif.reporters = ['default', 'jest-junit'];
 	config.coverageReporters = ['cobertura'];
 }
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -36,7 +36,7 @@ const config = {
 };
 
 if (process.env.CI === 'true') {
-	confif.reporters = ['default', 'jest-junit'];
+	config.reporters = ['default', 'jest-junit'];
 	config.coverageReporters = ['cobertura'];
 }
 


### PR DESCRIPTION
## Summary
We added these test reports in #14410, and that started generating these even when running tests locally.
This PR changes the setup to generate these reports only on the CI.



## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
