### PR TITLE
feat(core): Implement Insights pruning system

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -27,7 +27,7 @@ import { PubSubHandler } from '@/scaling/pubsub/pubsub-handler';
 import { Subscriber } from '@/scaling/pubsub/subscriber.service';
 import { Server } from '@/server';
 import { OwnershipService } from '@/services/ownership.service';
-import { PruningService } from '@/services/pruning/pruning.service';
+import { ExecutionsPruningService } from '@/services/pruning/executions-pruning.service';
 import { UrlService } from '@/services/url.service';
 import { WaitTracker } from '@/wait-tracker';
 import { WorkflowRunner } from '@/workflow-runner';
@@ -315,7 +315,7 @@ export class Start extends BaseCommand {
 
 		await this.server.start();
 
-		Container.get(PruningService).init();
+		Container.get(ExecutionsPruningService).init();
 
 		if (config.getEnv('executions.mode') === 'regular') {
 			await this.runEnqueuedExecutions();

--- a/packages/cli/src/modules/insights/__tests__/insights-collection.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights-collection.service.test.ts
@@ -6,7 +6,6 @@ import { Container } from '@n8n/di';
 import { In, type EntityManager } from '@n8n/typeorm';
 import { mock } from 'jest-mock-extended';
 import { DateTime } from 'luxon';
-import type { Logger } from 'n8n-core';
 import {
 	createDeferredPromise,
 	type ExecutionStatus,
@@ -402,14 +401,7 @@ describe('workflowExecuteAfterHandler - flushEvents', () => {
 	const sharedWorkflowRepositoryMock: jest.Mocked<SharedWorkflowRepository> = {
 		manager: entityManagerMock,
 	} as unknown as jest.Mocked<SharedWorkflowRepository>;
-	const logger = mock<Logger>({
-		scoped: jest.fn().mockReturnValue(
-			mock<Logger>({
-				error: jest.fn(),
-			}),
-		),
-	});
-
+	const logger = mockLogger();
 	const startedAt = DateTime.utc();
 	const stoppedAt = startedAt.plus({ seconds: 5 });
 	const runData = mock<IRun>({

--- a/packages/cli/src/modules/insights/__tests__/insights-pruning.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights-pruning.service.test.ts
@@ -92,6 +92,7 @@ describe('InsightsPrunningService', () => {
 			expect(pruneSpy).toHaveBeenCalledTimes(1);
 		} finally {
 			jest.useRealTimers();
+			insightsPruningService.stopPruningTimer();
 		}
 	});
 });

--- a/packages/cli/src/modules/insights/__tests__/insights-pruning.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights-pruning.service.test.ts
@@ -1,0 +1,97 @@
+import { Container } from '@n8n/di';
+import { DateTime } from 'luxon';
+
+import { createTeamProject } from '@test-integration/db/projects';
+import { createWorkflow } from '@test-integration/db/workflows';
+import * as testDb from '@test-integration/test-db';
+
+import {
+	createCompactedInsightsEvent,
+	createMetadata,
+} from '../database/entities/__tests__/db-utils';
+import { InsightsByPeriodRepository } from '../database/repositories/insights-by-period.repository';
+import { InsightsPruningService } from '../insights-pruning.service';
+import { InsightsConfig } from '../insights.config';
+
+// Initialize DB once for all tests
+beforeAll(async () => {
+	await testDb.init(['insights']);
+});
+
+describe('InsightsPrunningService', () => {
+	let insightsConfig: InsightsConfig;
+	let insightsByPeriodRepository: InsightsByPeriodRepository;
+	let insightsPruningService: InsightsPruningService;
+	beforeAll(async () => {
+		insightsConfig = Container.get(InsightsConfig);
+		insightsPruningService = Container.get(InsightsPruningService);
+		insightsByPeriodRepository = Container.get(InsightsByPeriodRepository);
+	});
+
+	test('prune old insights', async () => {
+		// ARRANGE
+		insightsConfig.maxAgeDays = 10;
+
+		const project = await createTeamProject();
+		const workflow = await createWorkflow({}, project);
+
+		await createMetadata(workflow);
+
+		const timestamp = DateTime.utc().minus({ days: insightsConfig.maxAgeDays + 1 });
+		await createCompactedInsightsEvent(workflow, {
+			type: 'success',
+			value: 1,
+			periodUnit: 'day',
+			periodStart: timestamp,
+		});
+
+		// ACT
+		await insightsPruningService.pruneInsights();
+
+		// ASSERT
+		expect(await insightsByPeriodRepository.count()).toBe(0);
+	});
+
+	test('prune old insights with recent data', async () => {
+		// ARRANGE
+		insightsConfig.maxAgeDays = 10;
+
+		const project = await createTeamProject();
+		const workflow = await createWorkflow({}, project);
+
+		await createMetadata(workflow);
+
+		const timestamp = DateTime.utc().minus({ days: insightsConfig.maxAgeDays - 1 });
+		await createCompactedInsightsEvent(workflow, {
+			type: 'success',
+			value: 1,
+			periodUnit: 'day',
+			periodStart: timestamp,
+		});
+
+		// ACT
+		await insightsPruningService.pruneInsights();
+
+		// ASSERT
+		expect(await insightsByPeriodRepository.count()).toBe(1);
+	});
+
+	test('startPruningTimer runs pruning on schedule', async () => {
+		jest.useFakeTimers();
+		try {
+			// ARRANGE
+			insightsConfig.pruneCheckIntervalHours = 1; // Set pruning interval to 1 hour
+			insightsPruningService.startPruningTimer();
+			const pruneSpy = jest.spyOn(insightsPruningService, 'pruneInsights');
+
+			// ACT
+			// Advance time by 1 hour and 1 minute
+			jest.advanceTimersByTime(1000 * 60 * 61);
+
+			// ASSERT
+			expect(pruneSpy).toHaveBeenCalledTimes(1);
+		} finally {
+			jest.useRealTimers();
+		}
+	});
+});

--- a/packages/cli/src/modules/insights/__tests__/insights-pruning.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights-pruning.service.test.ts
@@ -28,7 +28,7 @@ describe('InsightsPrunningService', () => {
 		insightsByPeriodRepository = Container.get(InsightsByPeriodRepository);
 	});
 
-	test('prune old insights', async () => {
+	test('old insights get pruned successfully', async () => {
 		// ARRANGE
 		insightsConfig.maxAgeDays = 10;
 
@@ -52,7 +52,7 @@ describe('InsightsPrunningService', () => {
 		expect(await insightsByPeriodRepository.count()).toBe(0);
 	});
 
-	test('prune old insights with recent data', async () => {
+	test('insights newer than maxAgeDays do not get pruned', async () => {
 		// ARRANGE
 		insightsConfig.maxAgeDays = 10;
 

--- a/packages/cli/src/modules/insights/__tests__/insights-pruning.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights-pruning.service.test.ts
@@ -16,12 +16,11 @@ import { InsightsByPeriodRepository } from '../database/repositories/insights-by
 import { InsightsPruningService } from '../insights-pruning.service';
 import { InsightsConfig } from '../insights.config';
 
-// Initialize DB once for all tests
 beforeAll(async () => {
 	await testDb.init();
 });
 
-describe('InsightsPrunningService', () => {
+describe('InsightsPruningService', () => {
 	let insightsConfig: InsightsConfig;
 	let insightsByPeriodRepository: InsightsByPeriodRepository;
 	let insightsPruningService: InsightsPruningService;

--- a/packages/cli/src/modules/insights/__tests__/insights-pruning.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights-pruning.service.test.ts
@@ -20,6 +20,20 @@ beforeAll(async () => {
 	await testDb.init();
 });
 
+beforeEach(async () => {
+	await testDb.truncate([
+		'InsightsRaw',
+		'InsightsByPeriod',
+		'InsightsMetadata',
+		'WorkflowEntity',
+		'Project',
+	]);
+});
+
+afterAll(async () => {
+	await testDb.terminate();
+});
+
 describe('InsightsPruningService', () => {
 	let insightsConfig: InsightsConfig;
 	let insightsByPeriodRepository: InsightsByPeriodRepository;

--- a/packages/cli/src/modules/insights/__tests__/insights.module.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.module.test.ts
@@ -1,8 +1,7 @@
-import { mock } from 'jest-mock-extended';
 import { InstanceSettings } from 'n8n-core';
 import type { Logger } from 'n8n-core';
 
-import { mockInstance } from '@test/mocking';
+import { mockInstance, mockLogger } from '@test/mocking';
 
 import { InsightsModule } from '../insights.module';
 import { InsightsService } from '../insights.service';
@@ -13,13 +12,7 @@ describe('InsightsModule', () => {
 	let instanceSettings: InstanceSettings;
 
 	beforeEach(() => {
-		logger = mock<Logger>({
-			scoped: jest.fn().mockReturnValue(
-				mock<Logger>({
-					error: jest.fn(),
-				}),
-			),
-		});
+		logger = mockLogger();
 		insightsService = mockInstance(InsightsService);
 	});
 

--- a/packages/cli/src/modules/insights/__tests__/insights.module.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.module.test.ts
@@ -21,14 +21,14 @@ describe('InsightsModule', () => {
 			instanceSettings = mockInstance(InstanceSettings, { instanceType: 'main', isLeader: true });
 			const insightsModule = new InsightsModule(logger, insightsService, instanceSettings);
 			insightsModule.initialize();
-			expect(insightsService.startBackgroundProcess).toHaveBeenCalled();
+			expect(insightsService.startTimers).toHaveBeenCalled();
 		});
 
 		it('should not start background process if instance is main but not leader', () => {
 			instanceSettings = mockInstance(InstanceSettings, { instanceType: 'main', isLeader: false });
 			const insightsModule = new InsightsModule(logger, insightsService, instanceSettings);
 			insightsModule.initialize();
-			expect(insightsService.startBackgroundProcess).not.toHaveBeenCalled();
+			expect(insightsService.startTimers).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
@@ -17,7 +17,6 @@ import type { InsightsCollectionService } from '../insights-collection.service';
 import type { InsightsCompactionService } from '../insights-compaction.service';
 import type { InsightsPruningService } from '../insights-pruning.service';
 import { InsightsService } from '../insights.service';
-import { InsightsConfig } from '../insights.config';
 
 // Initialize DB once for all tests
 beforeAll(async () => {
@@ -603,6 +602,7 @@ describe('getMaxAgeInDaysAndGranularity', () => {
 			mock<InsightsByPeriodRepository>(),
 			mock<InsightsCompactionService>(),
 			mock<InsightsCollectionService>(),
+			mock<InsightsPruningService>(),
 			licenseMock,
 		);
 	});
@@ -724,6 +724,10 @@ describe('backgroundProcess', () => {
 		stopPruningTimer: jest.fn(),
 	} as unknown as InsightsPruningService;
 
+	const mockLogger = {
+		debug: jest.fn(),
+	} as unknown as Logger;
+
 	beforeAll(() => {
 		insightsService = new InsightsService(
 			mock<InsightsByPeriodRepository>(),
@@ -731,7 +735,7 @@ describe('backgroundProcess', () => {
 			mockCollectionService,
 			mockPruningService,
 			mock<License>(),
-			mock<Logger>(),
+			mockLogger,
 		);
 	});
 
@@ -743,6 +747,9 @@ describe('backgroundProcess', () => {
 		expect(mockCompactionService.startCompactionTimer).toHaveBeenCalled();
 		expect(mockCollectionService.startFlushingTimer).toHaveBeenCalled();
 		expect(mockPruningService.startPruningTimer).toHaveBeenCalled();
+		expect(mockLogger.debug).toHaveBeenCalledWith(
+			'Started compaction, flushing and pruning schedulers',
+		);
 	});
 
 	test('stopBackgroundProcess stops timers and logs message', () => {
@@ -753,5 +760,8 @@ describe('backgroundProcess', () => {
 		expect(mockCompactionService.stopCompactionTimer).toHaveBeenCalled();
 		expect(mockCollectionService.stopFlushingTimer).toHaveBeenCalled();
 		expect(mockPruningService.stopPruningTimer).toHaveBeenCalled();
+		expect(mockLogger.debug).toHaveBeenCalledWith(
+			'Stopped compaction, flushing and pruning schedulers',
+		);
 	});
 });

--- a/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
@@ -6,7 +6,6 @@ import type { IWorkflowDb } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
 import { DateTime } from 'luxon';
-import type { Logger } from 'n8n-core';
 
 import { mockLogger } from '@test/mocking';
 import { createTeamProject } from '@test-integration/db/projects';
@@ -675,10 +674,10 @@ describe('getMaxAgeInDaysAndGranularity', () => {
 describe('shutdown', () => {
 	let insightsService: InsightsService;
 
-	const mockCollectionService = {
+	const mockCollectionService = mock<InsightsCollectionService>({
 		shutdown: jest.fn().mockResolvedValue(undefined),
 		stopFlushingTimer: jest.fn(),
-	} as unknown as InsightsCollectionService;
+	});
 
 	const mockCompactionService = {
 		stopCompactionTimer: jest.fn(),
@@ -728,13 +727,7 @@ describe('backgroundProcess', () => {
 		stopPruningTimer: jest.fn(),
 	} as unknown as InsightsPruningService;
 
-	const mockedScopedLogger = {
-		debug: jest.fn(),
-	} as unknown as Logger;
-
-	const mockedLogger = mock<Logger>({
-		scoped: jest.fn().mockReturnValue(mockedScopedLogger),
-	});
+	const mockedLogger = mockLogger();
 
 	beforeAll(() => {
 		insightsService = new InsightsService(
@@ -755,9 +748,6 @@ describe('backgroundProcess', () => {
 		expect(mockCompactionService.startCompactionTimer).toHaveBeenCalled();
 		expect(mockCollectionService.startFlushingTimer).toHaveBeenCalled();
 		expect(mockPruningService.startPruningTimer).toHaveBeenCalled();
-		expect(mockedScopedLogger.debug).toHaveBeenCalledWith(
-			'Started compaction, flushing and pruning schedulers',
-		);
 	});
 
 	test('stopBackgroundProcess stops timers and logs message', () => {
@@ -768,8 +758,5 @@ describe('backgroundProcess', () => {
 		expect(mockCompactionService.stopCompactionTimer).toHaveBeenCalled();
 		expect(mockCollectionService.stopFlushingTimer).toHaveBeenCalled();
 		expect(mockPruningService.stopPruningTimer).toHaveBeenCalled();
-		expect(mockedScopedLogger.debug).toHaveBeenCalledWith(
-			'Stopped compaction, flushing and pruning schedulers',
-		);
 	});
 });

--- a/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
@@ -709,7 +709,7 @@ describe('shutdown', () => {
 	});
 });
 
-describe('backgroundProcess', () => {
+describe('timers', () => {
 	let insightsService: InsightsService;
 
 	const mockCollectionService = {
@@ -740,9 +740,9 @@ describe('backgroundProcess', () => {
 		);
 	});
 
-	test('startBackgroundProcess starts timers and logs message', () => {
+	test('startTimers starts timers and logs message', () => {
 		// ACT
-		insightsService.startBackgroundProcess();
+		insightsService.startTimers();
 
 		// ASSERT
 		expect(mockCompactionService.startCompactionTimer).toHaveBeenCalled();
@@ -750,9 +750,9 @@ describe('backgroundProcess', () => {
 		expect(mockPruningService.startPruningTimer).toHaveBeenCalled();
 	});
 
-	test('stopBackgroundProcess stops timers and logs message', () => {
+	test('stopTimers stops timers and logs message', () => {
 		// ACT
-		insightsService.stopBackgroundProcess();
+		insightsService.stopTimers();
 
 		// ASSERT
 		expect(mockCompactionService.stopCompactionTimer).toHaveBeenCalled();

--- a/packages/cli/src/modules/insights/database/entities/__tests__/insights-by-period.test.ts
+++ b/packages/cli/src/modules/insights/database/entities/__tests__/insights-by-period.test.ts
@@ -1,25 +1,5 @@
-import { Container } from '@n8n/di';
-
-import * as testDb from '@test-integration/test-db';
-
-import { InsightsRawRepository } from '../../repositories/insights-raw.repository';
 import { InsightsByPeriod } from '../insights-by-period';
 import type { PeriodUnit, TypeUnit } from '../insights-shared';
-
-let insightsRawRepository: InsightsRawRepository;
-
-beforeAll(async () => {
-	await testDb.init();
-	insightsRawRepository = Container.get(InsightsRawRepository);
-});
-
-beforeEach(async () => {
-	await insightsRawRepository.delete({});
-});
-
-afterAll(async () => {
-	await testDb.terminate();
-});
 
 describe('Insights By Period', () => {
 	test.each(['time_saved_min', 'runtime_ms', 'failure', 'success'] satisfies TypeUnit[])(

--- a/packages/cli/src/modules/insights/database/entities/__tests__/insights-raw.test.ts
+++ b/packages/cli/src/modules/insights/database/entities/__tests__/insights-raw.test.ts
@@ -13,7 +13,7 @@ import type { TypeUnit } from '../insights-shared';
 let insightsRawRepository: InsightsRawRepository;
 
 beforeAll(async () => {
-	await testDb.init(['insights']);
+	await testDb.init();
 	insightsRawRepository = Container.get(InsightsRawRepository);
 });
 

--- a/packages/cli/src/modules/insights/database/entities/__tests__/insights-raw.test.ts
+++ b/packages/cli/src/modules/insights/database/entities/__tests__/insights-raw.test.ts
@@ -13,7 +13,7 @@ import type { TypeUnit } from '../insights-shared';
 let insightsRawRepository: InsightsRawRepository;
 
 beforeAll(async () => {
-	await testDb.init();
+	await testDb.init(['insights']);
 	insightsRawRepository = Container.get(InsightsRawRepository);
 });
 

--- a/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
+++ b/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
@@ -389,12 +389,12 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 		return aggregatedInsightsByTimeParser.parse(rawRows);
 	}
 
-	async pruneOldData(maxAgeInDays: number): Promise<{ affected: number }> {
+	async pruneOldData(maxAgeInDays: number): Promise<{ affected: number | null | undefined }> {
 		const thresholdDate = DateTime.now().minus({ days: maxAgeInDays }).toJSDate();
 		const result = await this.delete({
 			periodStart: LessThan(thresholdDate),
 		});
 
-		return { affected: result.affected ?? 0 };
+		return { affected: result.affected };
 	}
 }

--- a/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
+++ b/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
@@ -1,7 +1,7 @@
 import { GlobalConfig } from '@n8n/config';
 import { Container, Service } from '@n8n/di';
 import type { SelectQueryBuilder } from '@n8n/typeorm';
-import { DataSource, Repository } from '@n8n/typeorm';
+import { DataSource, LessThan, Repository } from '@n8n/typeorm';
 import { DateTime } from 'luxon';
 import { z } from 'zod';
 
@@ -390,10 +390,10 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 	}
 
 	async pruneOldData(maxAgeInDays: number): Promise<{ affected: number }> {
-		const result = await this.createQueryBuilder()
-			.delete()
-			.where(`${this.escapeField('periodStart')} < ${this.getPeriodFilterExpr(maxAgeInDays)}`)
-			.execute();
+		const thresholdDate = DateTime.now().minus({ days: maxAgeInDays }).toJSDate();
+		const result = await this.delete({
+			periodStart: LessThan(thresholdDate),
+		});
 
 		return { affected: result.affected ?? 0 };
 	}

--- a/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
+++ b/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
@@ -1,7 +1,7 @@
 import { GlobalConfig } from '@n8n/config';
 import { Container, Service } from '@n8n/di';
 import type { SelectQueryBuilder } from '@n8n/typeorm';
-import { DataSource, LessThan, Repository } from '@n8n/typeorm';
+import { DataSource, LessThanOrEqual, Repository } from '@n8n/typeorm';
 import { DateTime } from 'luxon';
 import { z } from 'zod';
 
@@ -390,9 +390,9 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 	}
 
 	async pruneOldData(maxAgeInDays: number): Promise<{ affected: number | null | undefined }> {
-		const thresholdDate = DateTime.now().minus({ days: maxAgeInDays }).toJSDate();
+		const thresholdDate = DateTime.now().minus({ days: maxAgeInDays }).startOf('day').toJSDate();
 		const result = await this.delete({
-			periodStart: LessThan(thresholdDate),
+			periodStart: LessThanOrEqual(thresholdDate),
 		});
 
 		return { affected: result.affected };

--- a/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
+++ b/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
@@ -388,4 +388,13 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 
 		return aggregatedInsightsByTimeParser.parse(rawRows);
 	}
+
+	async pruneOldData(maxAgeInDays: number): Promise<{ affected: number }> {
+		const result = await this.createQueryBuilder()
+			.delete()
+			.where(`${this.escapeField('periodStart')} < ${this.getPeriodFilterExpr(maxAgeInDays)}`)
+			.execute();
+
+		return { affected: result.affected ?? 0 };
+	}
 }

--- a/packages/cli/src/modules/insights/insights-pruning.service.ts
+++ b/packages/cli/src/modules/insights/insights-pruning.service.ts
@@ -65,7 +65,10 @@ export class InsightsPruningService {
 		for (let attempt = 1; attempt <= this.maxRetries; attempt++) {
 			try {
 				const result = await this.insightsByPeriodRepository.pruneOldData(this.config.maxAgeDays);
-				this.logger.debug('Deleted insights by period', { count: result.affected });
+				this.logger.debug(
+					'Deleted insights by period',
+					result.affected ? { count: result.affected } : {},
+				);
 				return;
 			} catch (error: unknown) {
 				this.logger.warn(`Prune attempt ${attempt} failed`, { error });

--- a/packages/cli/src/modules/insights/insights-pruning.service.ts
+++ b/packages/cli/src/modules/insights/insights-pruning.service.ts
@@ -1,17 +1,25 @@
 import { Service } from '@n8n/di';
 import { Logger } from 'n8n-core';
 
+import { Time } from '@/constants';
+
 import { InsightsByPeriodRepository } from './database/repositories/insights-by-period.repository';
 import { InsightsConfig } from './insights.config';
 
 @Service()
 export class InsightsPruningService {
-	private pruneInsightsTimer: NodeJS.Timer | undefined;
+	private pruneInsightsTimer: NodeJS.Timeout | undefined;
+
+	private isStopped = false;
+
+	private readonly delayBetweenRetries = Time.seconds.toMilliseconds * 10;
+
+	private readonly maxRetries = 3;
 
 	constructor(
 		private readonly insightsByPeriodRepository: InsightsByPeriodRepository,
 		private readonly config: InsightsConfig,
-		private readonly logger: Logger, // Assuming a logger is injected,
+		private readonly logger: Logger,
 	) {
 		this.logger = this.logger.scoped('insights');
 	}
@@ -25,27 +33,55 @@ export class InsightsPruningService {
 			return;
 		}
 
-		this.stopPruningTimer();
-		this.pruneInsightsTimer = setInterval(
-			async () => await this.pruneInsights(),
-			this.config.pruneCheckIntervalHours * 60 * 60 * 1000,
-		);
+		this.clearPruningTimer();
+		this.isStopped = false;
+		this.scheduleNextPrune();
 		this.logger.debug(`Insights pruning every ${this.config.pruneCheckIntervalHours} hours`);
 	}
 
-	stopPruningTimer() {
+	private clearPruningTimer() {
 		if (this.pruneInsightsTimer !== undefined) {
-			clearInterval(this.pruneInsightsTimer);
+			clearTimeout(this.pruneInsightsTimer);
 			this.pruneInsightsTimer = undefined;
 		}
 	}
 
+	stopPruningTimer() {
+		this.isStopped = true;
+		this.clearPruningTimer();
+		this.logger.debug('Stopped Insights pruning');
+	}
+
+	private scheduleNextPrune() {
+		if (this.isStopped) return;
+
+		this.pruneInsightsTimer = setTimeout(async () => {
+			await this.pruneInsights();
+			this.scheduleNextPrune(); // reschedule after execution
+		}, this.config.pruneCheckIntervalHours * Time.hours.toMilliseconds);
+	}
+
 	async pruneInsights() {
-		try {
-			const result = await this.insightsByPeriodRepository.pruneOldData(this.config.maxAgeDays);
-			this.logger.debug('Hard-deleted insights', { count: result.affected });
-		} catch (error: unknown) {
-			this.logger.error('Error while pruning insights', { error });
+		for (let attempt = 1; attempt <= this.maxRetries; attempt++) {
+			try {
+				const result = await this.insightsByPeriodRepository.pruneOldData(this.config.maxAgeDays);
+				this.logger.debug('Deleted insights by period', { count: result.affected });
+				return;
+			} catch (error: unknown) {
+				this.logger.warn(`Prune attempt ${attempt} failed`, { error });
+
+				if (attempt === this.maxRetries) {
+					this.logger.error('All pruning attempts failed', { error });
+				} else {
+					await this.delay(this.delayBetweenRetries);
+				}
+			}
 		}
+	}
+
+	private async delay(ms: number) {
+		return await new Promise((resolve) => {
+			setTimeout(resolve, ms);
+		});
 	}
 }

--- a/packages/cli/src/modules/insights/insights-pruning.service.ts
+++ b/packages/cli/src/modules/insights/insights-pruning.service.ts
@@ -39,7 +39,11 @@ export class InsightsPruningService {
 	}
 
 	async pruneInsights() {
-		const result = await this.insightsByPeriodRepository.pruneOldData(this.config.maxAgeDays);
-		this.logger.debug('Hard-deleted insights', { count: result.affected });
+		try {
+			const result = await this.insightsByPeriodRepository.pruneOldData(this.config.maxAgeDays);
+			this.logger.debug('Hard-deleted insights', { count: result.affected });
+		} catch (error: unknown) {
+			this.logger.error('Error while pruning insights', { error });
+		}
 	}
 }

--- a/packages/cli/src/modules/insights/insights-pruning.service.ts
+++ b/packages/cli/src/modules/insights/insights-pruning.service.ts
@@ -12,7 +12,9 @@ export class InsightsPruningService {
 		private readonly insightsByPeriodRepository: InsightsByPeriodRepository,
 		private readonly config: InsightsConfig,
 		private readonly logger: Logger, // Assuming a logger is injected,
-	) {}
+	) {
+		this.logger = this.logger.scoped('insights');
+	}
 
 	get isPruningEnabled() {
 		return this.config.maxAgeDays > -1;

--- a/packages/cli/src/modules/insights/insights-pruning.service.ts
+++ b/packages/cli/src/modules/insights/insights-pruning.service.ts
@@ -1,0 +1,45 @@
+import { Service } from '@n8n/di';
+import { Logger } from 'n8n-core';
+
+import { InsightsByPeriodRepository } from './database/repositories/insights-by-period.repository';
+import { InsightsConfig } from './insights.config';
+
+@Service()
+export class InsightsPruningService {
+	private pruneInsightsTimer: NodeJS.Timer | undefined;
+
+	constructor(
+		private readonly insightsByPeriodRepository: InsightsByPeriodRepository,
+		private readonly config: InsightsConfig,
+		private readonly logger: Logger, // Assuming a logger is injected,
+	) {}
+
+	get isPruningEnabled() {
+		return this.config.maxAgeDays > -1;
+	}
+
+	startPruningTimer() {
+		if (!this.isPruningEnabled) {
+			return;
+		}
+
+		this.stopPruningTimer();
+		this.pruneInsightsTimer = setInterval(
+			async () => await this.pruneInsights(),
+			this.config.pruneCheckIntervalHours * 60 * 60 * 1000,
+		);
+		this.logger.debug(`Insights pruning every ${this.config.pruneCheckIntervalHours} hours`);
+	}
+
+	stopPruningTimer() {
+		if (this.pruneInsightsTimer !== undefined) {
+			clearInterval(this.pruneInsightsTimer);
+			this.pruneInsightsTimer = undefined;
+		}
+	}
+
+	async pruneInsights() {
+		const result = await this.insightsByPeriodRepository.pruneOldData(this.config.maxAgeDays);
+		this.logger.debug('Hard-deleted insights', { count: result.affected });
+	}
+}

--- a/packages/cli/src/modules/insights/insights-pruning.service.ts
+++ b/packages/cli/src/modules/insights/insights-pruning.service.ts
@@ -55,9 +55,9 @@ export class InsightsPruningService {
 	private scheduleNextPrune() {
 		if (this.isStopped) return;
 
-		this.pruneInsightsTimer = setTimeout(async () => {
+		this.pruneInsightsTimout = setTimeout(async () => {
 			await this.pruneInsights();
-			this.scheduleNextPrune(); // reschedule after execution
+			this.scheduleNextPrune();
 		}, this.config.pruneCheckIntervalHours * Time.hours.toMilliseconds);
 	}
 
@@ -69,7 +69,6 @@ export class InsightsPruningService {
 					'Deleted insights by period',
 					result.affected ? { count: result.affected } : {},
 				);
-				return;
 			} catch (error: unknown) {
 				this.logger.warn(`Prune attempt ${attempt} failed`, { error });
 

--- a/packages/cli/src/modules/insights/insights-pruning.service.ts
+++ b/packages/cli/src/modules/insights/insights-pruning.service.ts
@@ -1,4 +1,5 @@
 import { Service } from '@n8n/di';
+import { strict } from 'assert';
 import { Logger } from 'n8n-core';
 
 import { Time } from '@/constants';
@@ -10,7 +11,7 @@ import { InsightsConfig } from './insights.config';
 export class InsightsPruningService {
 	private pruneInsightsTimeout: NodeJS.Timeout | undefined;
 
-	private isStopped = false;
+	private isStopped = true;
 
 	private readonly delayOnError = Time.seconds.toMilliseconds;
 
@@ -22,15 +23,8 @@ export class InsightsPruningService {
 		this.logger = this.logger.scoped('insights');
 	}
 
-	get isPruningEnabled() {
-		return this.config.maxAgeDays > -1;
-	}
-
 	startPruningTimer() {
-		if (!this.isPruningEnabled) {
-			return;
-		}
-
+		strict(this.isStopped);
 		this.clearPruningTimer();
 		this.isStopped = false;
 		this.scheduleNextPrune();
@@ -61,6 +55,7 @@ export class InsightsPruningService {
 	}
 
 	async pruneInsights() {
+		this.logger.info('Pruning old insights data');
 		try {
 			const result = await this.insightsByPeriodRepository.pruneOldData(this.config.maxAgeDays);
 			this.logger.debug(

--- a/packages/cli/src/modules/insights/insights.config.ts
+++ b/packages/cli/src/modules/insights/insights.config.ts
@@ -43,4 +43,18 @@ export class InsightsConfig {
 	 */
 	@Env('N8N_INSIGHTS_FLUSH_INTERVAL_SECONDS')
 	flushIntervalSeconds: number = 30;
+
+	/**
+	 * The maximum age in days for all insights data before pruning.
+	 * Default: -1 (no pruning)
+	 */
+	@Env('N8N_INSIGHTS_MAX_AGE_DAYS')
+	maxAgeDays: number = -1;
+
+	/**
+	 * The interval in hours at which the insights data should be checked for pruning.
+	 * Default: 24
+	 */
+	@Env('N8N_INSIGHTS_PRUNE_CHECK_INTERVAL_HOURS')
+	pruneCheckIntervalHours: number = 24;
 }

--- a/packages/cli/src/modules/insights/insights.config.ts
+++ b/packages/cli/src/modules/insights/insights.config.ts
@@ -45,14 +45,14 @@ export class InsightsConfig {
 	flushIntervalSeconds: number = 30;
 
 	/**
-	 * The maximum age in days for all insights data before pruning.
+	 * How old (days) insights data must be to qualify for regular deletion
 	 * Default: -1 (no pruning)
 	 */
 	@Env('N8N_INSIGHTS_MAX_AGE_DAYS')
 	maxAgeDays: number = -1;
 
 	/**
-	 * The interval in hours at which the insights data should be checked for pruning.
+	 * How often (hours) insights data will be checked for regular deletion.
 	 * Default: 24
 	 */
 	@Env('N8N_INSIGHTS_PRUNE_CHECK_INTERVAL_HOURS')

--- a/packages/cli/src/modules/insights/insights.module.ts
+++ b/packages/cli/src/modules/insights/insights.module.ts
@@ -20,17 +20,17 @@ export class InsightsModule implements BaseN8nModule {
 		// We want to initialize the insights background process (schedulers) for the main leader instance
 		// to have only one main instance saving the insights data
 		if (this.instanceSettings.isLeader) {
-			this.insightsService.startBackgroundProcess();
+			this.insightsService.startTimers();
 		}
 	}
 
 	@OnLeaderTakeover()
 	startBackgroundProcess() {
-		this.insightsService.startBackgroundProcess();
+		this.insightsService.startTimers();
 	}
 
 	@OnLeaderStepdown()
 	stopBackgroundProcess() {
-		this.insightsService.stopBackgroundProcess();
+		this.insightsService.stopTimers();
 	}
 }

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -13,7 +13,7 @@ import { NumberToType } from './database/entities/insights-shared';
 import { InsightsByPeriodRepository } from './database/repositories/insights-by-period.repository';
 import { InsightsCollectionService } from './insights-collection.service';
 import { InsightsCompactionService } from './insights-compaction.service';
-import { InsightsConfig } from './insights.config';
+import { InsightsPruningService } from './insights-pruning.service';
 
 const keyRangeToDays: Record<InsightsDateRange['key'], number> = {
 	day: 1,
@@ -27,57 +27,33 @@ const keyRangeToDays: Record<InsightsDateRange['key'], number> = {
 
 @Service()
 export class InsightsService {
-	private pruneInsightsTimer: NodeJS.Timer | undefined;
-
 	constructor(
 		private readonly insightsByPeriodRepository: InsightsByPeriodRepository,
-		private readonly config: InsightsConfig,
 		private readonly compactionService: InsightsCompactionService,
 		private readonly collectionService: InsightsCollectionService,
+		private readonly pruningService: InsightsPruningService,
 		private readonly licenseState: LicenseState,
+		private readonly logger: Logger, // Assuming a logger is injected,
 	) {}
-
-	get isPruningEnabled() {
-		return this.config.maxAgeDays > -1;
-	}
 
 	startBackgroundProcess() {
 		this.compactionService.startCompactionTimer();
 		this.collectionService.startFlushingTimer();
-		this.startPruningScheduling();
+		this.pruningService.startPruningTimer();
+		this.logger.debug('Started compaction, flushing and pruning schedulers');
 	}
 
 	stopBackgroundProcess() {
 		this.compactionService.stopCompactionTimer();
 		this.collectionService.stopFlushingTimer();
-		this.stopPruningScheduling();
-		this.logger.debug('Started compaction, flushing and pruning schedulers');
-	}
-
-	startPruningScheduling() {
-		if (!this.isPruningEnabled) {
-			return;
-		}
-
-		this.stopPruningScheduling();
-		this.pruneInsightsTimer = setInterval(
-			async () => await this.pruneInsights(),
-			this.config.pruneCheckIntervalHours * 60 * 60 * 1000,
-		);
-		this.logger.debug(`Insights pruning every ${this.config.pruneCheckIntervalHours} hours`);
-	}
-
-	stopPruningScheduling() {
-		if (this.pruneInsightsTimer !== undefined) {
-			clearInterval(this.pruneInsightsTimer);
-			this.pruneInsightsTimer = undefined;
-		}
+		this.pruningService.stopPruningTimer();
+		this.logger.debug('Stopped compaction, flushing and pruning schedulers');
 	}
 
 	@OnShutdown()
 	async shutdown() {
 		await this.collectionService.shutdown();
-		this.compactionService.stopCompactionTimer();
+		this.stopBackgroundProcess();
 	}
 
 	async pruneInsights() {

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -6,6 +6,7 @@ import {
 import { LicenseState } from '@n8n/backend-common';
 import { OnShutdown } from '@n8n/decorators';
 import { Service } from '@n8n/di';
+import { Logger } from 'n8n-core';
 import { UserError } from 'n8n-workflow';
 
 import type { PeriodUnit, TypeUnit } from './database/entities/insights-shared';
@@ -33,8 +34,10 @@ export class InsightsService {
 		private readonly collectionService: InsightsCollectionService,
 		private readonly pruningService: InsightsPruningService,
 		private readonly licenseState: LicenseState,
-		private readonly logger: Logger, // Assuming a logger is injected,
-	) {}
+		private readonly logger: Logger,
+	) {
+		this.logger = this.logger.scoped('insights');
+	}
 
 	startBackgroundProcess() {
 		this.compactionService.startCompactionTimer();
@@ -54,11 +57,6 @@ export class InsightsService {
 	async shutdown() {
 		await this.collectionService.shutdown();
 		this.stopBackgroundProcess();
-	}
-
-	async pruneInsights() {
-		const result = await this.insightsByPeriodRepository.pruneOldData(this.config.maxAgeDays);
-		this.logger.debug('Hard-deleted insights', { count: result.affected });
 	}
 
 	async getInsightsSummary({

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -39,14 +39,14 @@ export class InsightsService {
 		this.logger = this.logger.scoped('insights');
 	}
 
-	startBackgroundProcess() {
+	startTimers() {
 		this.compactionService.startCompactionTimer();
 		this.collectionService.startFlushingTimer();
 		this.pruningService.startPruningTimer();
 		this.logger.debug('Started compaction, flushing and pruning schedulers');
 	}
 
-	stopBackgroundProcess() {
+	stopTimers() {
 		this.compactionService.stopCompactionTimer();
 		this.collectionService.stopFlushingTimer();
 		this.pruningService.stopPruningTimer();
@@ -56,7 +56,7 @@ export class InsightsService {
 	@OnShutdown()
 	async shutdown() {
 		await this.collectionService.shutdown();
-		this.stopBackgroundProcess();
+		this.stopTimers();
 	}
 
 	async getInsightsSummary({

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -15,6 +15,7 @@ import { InsightsByPeriodRepository } from './database/repositories/insights-by-
 import { InsightsCollectionService } from './insights-collection.service';
 import { InsightsCompactionService } from './insights-compaction.service';
 import { InsightsPruningService } from './insights-pruning.service';
+import { InsightsConfig } from './insights.config';
 
 const keyRangeToDays: Record<InsightsDateRange['key'], number> = {
 	day: 1,
@@ -34,15 +35,22 @@ export class InsightsService {
 		private readonly collectionService: InsightsCollectionService,
 		private readonly pruningService: InsightsPruningService,
 		private readonly licenseState: LicenseState,
+		private readonly config: InsightsConfig,
 		private readonly logger: Logger,
 	) {
 		this.logger = this.logger.scoped('insights');
 	}
 
+	get isPruningEnabled() {
+		return this.config.maxAgeDays > -1;
+	}
+
 	startTimers() {
 		this.compactionService.startCompactionTimer();
 		this.collectionService.startFlushingTimer();
-		this.pruningService.startPruningTimer();
+		if (this.isPruningEnabled) {
+			this.pruningService.startPruningTimer();
+		}
 		this.logger.debug('Started compaction, flushing and pruning schedulers');
 	}
 

--- a/packages/cli/src/services/pruning/__tests__/executions-pruning.service.test.ts
+++ b/packages/cli/src/services/pruning/__tests__/executions-pruning.service.test.ts
@@ -4,7 +4,7 @@ import type { InstanceSettings } from 'n8n-core';
 
 import { mockLogger } from '@test/mocking';
 
-import { PruningService } from '../pruning.service';
+import { ExecutionsPruningService } from '../executions-pruning.service';
 
 jest.mock('@/db', () => ({
 	connectionState: { migrated: true },
@@ -13,7 +13,7 @@ jest.mock('@/db', () => ({
 describe('PruningService', () => {
 	describe('init', () => {
 		it('should start pruning on main instance that is the leader', () => {
-			const pruningService = new PruningService(
+			const pruningService = new ExecutionsPruningService(
 				mockLogger(),
 				mock<InstanceSettings>({ isLeader: true, isMultiMain: true }),
 				mock(),
@@ -28,7 +28,7 @@ describe('PruningService', () => {
 		});
 
 		it('should not start pruning on main instance that is a follower', () => {
-			const pruningService = new PruningService(
+			const pruningService = new ExecutionsPruningService(
 				mockLogger(),
 				mock<InstanceSettings>({ isLeader: false, isMultiMain: true }),
 				mock(),
@@ -45,7 +45,7 @@ describe('PruningService', () => {
 
 	describe('isEnabled', () => {
 		it('should return `true` based on config if leader main', () => {
-			const pruningService = new PruningService(
+			const pruningService = new ExecutionsPruningService(
 				mockLogger(),
 				mock<InstanceSettings>({ isLeader: true, instanceType: 'main', isMultiMain: true }),
 				mock(),
@@ -57,7 +57,7 @@ describe('PruningService', () => {
 		});
 
 		it('should return `false` based on config if leader main', () => {
-			const pruningService = new PruningService(
+			const pruningService = new ExecutionsPruningService(
 				mockLogger(),
 				mock<InstanceSettings>({ isLeader: true, instanceType: 'main', isMultiMain: true }),
 				mock(),
@@ -69,7 +69,7 @@ describe('PruningService', () => {
 		});
 
 		it('should return `false` if non-main even if config is enabled', () => {
-			const pruningService = new PruningService(
+			const pruningService = new ExecutionsPruningService(
 				mockLogger(),
 				mock<InstanceSettings>({ isLeader: false, instanceType: 'worker', isMultiMain: true }),
 				mock(),
@@ -81,7 +81,7 @@ describe('PruningService', () => {
 		});
 
 		it('should return `false` if follower main even if config is enabled', () => {
-			const pruningService = new PruningService(
+			const pruningService = new ExecutionsPruningService(
 				mockLogger(),
 				mock<InstanceSettings>({
 					isLeader: false,
@@ -100,7 +100,7 @@ describe('PruningService', () => {
 
 	describe('startPruning', () => {
 		it('should not start pruning if service is disabled', () => {
-			const pruningService = new PruningService(
+			const pruningService = new ExecutionsPruningService(
 				mockLogger(),
 				mock<InstanceSettings>({ isLeader: true, instanceType: 'main', isMultiMain: true }),
 				mock(),
@@ -124,7 +124,7 @@ describe('PruningService', () => {
 		});
 
 		it('should start pruning if service is enabled and DB is migrated', () => {
-			const pruningService = new PruningService(
+			const pruningService = new ExecutionsPruningService(
 				mockLogger(),
 				mock<InstanceSettings>({ isLeader: true, instanceType: 'main', isMultiMain: true }),
 				mock(),

--- a/packages/cli/src/services/pruning/executions-pruning.service.ts
+++ b/packages/cli/src/services/pruning/executions-pruning.service.ts
@@ -23,7 +23,7 @@ import { connectionState as dbConnectionState } from '@/db';
  * - Once mostly caught up, hard deletion goes back to the 15m schedule.
  */
 @Service()
-export class PruningService {
+export class ExecutionsPruningService {
 	/** Timer for soft-deleting executions on a rolling basis. */
 	private softDeletionInterval: NodeJS.Timer | undefined;
 

--- a/packages/cli/test/integration/pruning.service.test.ts
+++ b/packages/cli/test/integration/pruning.service.test.ts
@@ -6,7 +6,7 @@ import { BinaryDataService, InstanceSettings } from 'n8n-core';
 import type { ExecutionStatus, IWorkflowBase } from 'n8n-workflow';
 
 import { Time } from '@/constants';
-import { PruningService } from '@/services/pruning/pruning.service';
+import { ExecutionsPruningService } from '@/services/pruning/executions-pruning.service';
 
 import {
 	annotateExecution,
@@ -18,7 +18,7 @@ import * as testDb from './shared/test-db';
 import { mockInstance, mockLogger } from '../shared/mocking';
 
 describe('softDeleteOnPruningCycle()', () => {
-	let pruningService: PruningService;
+	let pruningService: ExecutionsPruningService;
 	const instanceSettings = Container.get(InstanceSettings);
 	instanceSettings.markAsLeader();
 
@@ -31,7 +31,7 @@ describe('softDeleteOnPruningCycle()', () => {
 		await testDb.init();
 
 		executionsConfig = Container.get(ExecutionsConfig);
-		pruningService = new PruningService(
+		pruningService = new ExecutionsPruningService(
 			mockLogger(),
 			instanceSettings,
 			Container.get(ExecutionRepository),


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR adds a pruning mechanism for the insights data, to hard delete insights-by-period data (the table that stores time-aggregated insights data for all workflows and take the most space) every X hours.
There are 2 environment variable to configure this pruning:
`N8N_INSIGHTS_MAX_AGE_DAYS`: the age in days of the data to be pruned
`N8N_INSIGHTS_PRUNE_CHECK_INTERVAL_HOURS`: the interval in hours between each pruning


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2703/implement-pruning-system

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
