### PR TITLE
fix(core): Fix routing for waiting webhooks and forms

### DIFF
--- a/packages/cli/src/abstract-server.ts
+++ b/packages/cli/src/abstract-server.ts
@@ -193,13 +193,13 @@ export abstract class AbstractServer {
 
 			// Register a handler for waiting forms
 			this.app.all(
-				`/${this.endpointFormWaiting}/:path/{:suffix}`,
+				`/${this.endpointFormWaiting}/:path{/:suffix}`,
 				createWebhookHandlerFor(Container.get(WaitingForms)),
 			);
 
 			// Register a handler for waiting webhooks
 			this.app.all(
-				`/${this.endpointWebhookWaiting}/:path/{:suffix}`,
+				`/${this.endpointWebhookWaiting}/:path{/:suffix}`,
 				createWebhookHandlerFor(Container.get(WaitingWebhooks)),
 			);
 		}

--- a/packages/cli/test/integration/webhooks.test.ts
+++ b/packages/cli/test/integration/webhooks.test.ts
@@ -16,23 +16,31 @@ import { mockInstance } from '@test/mocking';
 let agent: SuperAgentTest;
 
 describe('WebhookServer', () => {
+	const liveWebhooks = mockInstance(LiveWebhooks);
+	const testWebhooks = mockInstance(TestWebhooks);
+	mockInstance(WaitingWebhooks);
+	mockInstance(WaitingForms);
 	mockInstance(ExternalHooks);
+	const globalConfig = Container.get(GlobalConfig);
+
+	const mockResponse = (data = {}, headers = {}, status = 200) => {
+		const response = mock<IWebhookResponseCallbackData>();
+		response.responseCode = status;
+		response.data = data;
+		response.headers = headers;
+		return response;
+	};
+
+	beforeAll(async () => {
+		const server = new WebhookServer();
+		// @ts-expect-error: testWebhooksEnabled is private
+		server.testWebhooksEnabled = true;
+		await server.start();
+		agent = testAgent(server.app);
+	});
 
 	describe('CORS', () => {
 		const corsOrigin = 'https://example.com';
-		const liveWebhooks = mockInstance(LiveWebhooks);
-		const testWebhooks = mockInstance(TestWebhooks);
-		mockInstance(WaitingWebhooks);
-		mockInstance(WaitingForms);
-
-		beforeAll(async () => {
-			const server = new WebhookServer();
-			// @ts-expect-error: testWebhooksEnabled is private
-			server.testWebhooksEnabled = true;
-			await server.start();
-			agent = testAgent(server.app);
-		});
-
 		const tests = [
 			['webhook', liveWebhooks],
 			['webhookTest', testWebhooks],
@@ -43,8 +51,9 @@ describe('WebhookServer', () => {
 
 		for (const [key, manager] of tests) {
 			describe(`for ${key}`, () => {
+				const pathPrefix = globalConfig.endpoints[key];
+
 				it('should handle preflight requests', async () => {
-					const pathPrefix = Container.get(GlobalConfig).endpoints[key];
 					manager.getWebhookMethods.mockResolvedValueOnce(['GET']);
 
 					const response = await agent
@@ -58,7 +67,6 @@ describe('WebhookServer', () => {
 				});
 
 				it('should handle regular requests', async () => {
-					const pathPrefix = Container.get(GlobalConfig).endpoints[key];
 					manager.getWebhookMethods.mockResolvedValueOnce(['GET']);
 					manager.executeWebhook.mockResolvedValueOnce(
 						mockResponse({ test: true }, { key: 'value ' }),
@@ -75,13 +83,5 @@ describe('WebhookServer', () => {
 				});
 			});
 		}
-
-		const mockResponse = (data = {}, headers = {}, status = 200) => {
-			const response = mock<IWebhookResponseCallbackData>();
-			response.responseCode = status;
-			response.data = data;
-			response.headers = headers;
-			return response;
-		};
 	});
 });

--- a/packages/cli/test/integration/webhooks.test.ts
+++ b/packages/cli/test/integration/webhooks.test.ts
@@ -18,7 +18,7 @@ let agent: SuperAgentTest;
 describe('WebhookServer', () => {
 	const liveWebhooks = mockInstance(LiveWebhooks);
 	const testWebhooks = mockInstance(TestWebhooks);
-	mockInstance(WaitingWebhooks);
+	const waitingWebhooks = mockInstance(WaitingWebhooks);
 	mockInstance(WaitingForms);
 	mockInstance(ExternalHooks);
 	const globalConfig = Container.get(GlobalConfig);
@@ -83,5 +83,19 @@ describe('WebhookServer', () => {
 				});
 			});
 		}
+	});
+
+	describe('routing', () => {
+		it('should handle waiting-webhooks', async () => {
+			const pathPrefix = globalConfig.endpoints.webhookWaiting;
+			waitingWebhooks.executeWebhook.mockResolvedValueOnce({
+				noWebhookResponse: false,
+				responseCode: 204,
+			});
+
+			const response = await agent.get(`/${pathPrefix}/12345`);
+
+			expect(response.statusCode).toEqual(204);
+		});
 	});
 });

--- a/packages/cli/test/integration/webhooks.test.ts
+++ b/packages/cli/test/integration/webhooks.test.ts
@@ -85,17 +85,35 @@ describe('WebhookServer', () => {
 		}
 	});
 
-	describe('routing', () => {
-		it('should handle waiting-webhooks', async () => {
-			const pathPrefix = globalConfig.endpoints.webhookWaiting;
-			waitingWebhooks.executeWebhook.mockResolvedValueOnce({
-				noWebhookResponse: false,
-				responseCode: 204,
-			});
+	describe('Routing for Waiting Webhooks', () => {
+		const pathPrefix = globalConfig.endpoints.webhookWaiting;
 
+		waitingWebhooks.executeWebhook.mockImplementation(async (req) => {
+			return {
+				noWebhookResponse: false,
+				responseCode: 200,
+				data: {
+					params: req.params,
+				},
+			};
+		});
+
+		it('should handle URLs without suffix', async () => {
 			const response = await agent.get(`/${pathPrefix}/12345`);
 
-			expect(response.statusCode).toEqual(204);
+			expect(response.statusCode).toEqual(200);
+			expect(response.body).toEqual({
+				params: { path: '12345' },
+			});
+		});
+
+		it('should handle URLs with suffix', async () => {
+			const response = await agent.get(`/${pathPrefix}/12345/suffix`);
+
+			expect(response.statusCode).toEqual(200);
+			expect(response.body).toEqual({
+				params: { path: '12345', suffix: 'suffix' },
+			});
 		});
 	});
 });


### PR DESCRIPTION
## Summary

in #14332 I accidentally broke the routing for waiting webhooks and forms, and due to a lack of routing tests, we did not catch this.
This PR fixes the routing, and adds tests to prevent this regression from happening again.


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
