### PR TITLE
fix(editor): Prevent moving non owned workflows to folders

### DIFF
--- a/packages/frontend/editor-ui/src/components/WorkflowCard.vue
+++ b/packages/frontend/editor-ui/src/components/WorkflowCard.vue
@@ -134,7 +134,12 @@ const actions = computed(() => {
 		});
 	}
 
-	if (workflowPermissions.value.update && !props.readOnly && showFolders.value) {
+	if (
+		workflowPermissions.value.update &&
+		showFolders.value &&
+		!props.readOnly &&
+		!isSomeoneElsesWorkflow.value
+	) {
 		items.push({
 			label: locale.baseText('folders.actions.moveToFolder'),
 			value: WORKFLOW_LIST_ITEM_ACTIONS.MOVE_TO_FOLDER,


### PR DESCRIPTION
## Summary
This PR hides `Move to folder` action from the workflow card if the workflow is not owned by the current user. This is temporary until we add a new section that only shows the workflows shared with you.

## Related Linear tickets, Github issues, and Community forum posts
Fixes ADO-3405

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
