### PR TITLE
fix(editor): Inline expression previews are not displayed in NDV

### DIFF
--- a/cypress/composables/ndv.ts
+++ b/cypress/composables/ndv.ts
@@ -264,3 +264,7 @@ export function populateFixedCollection<T extends readonly string[]>(
 		}
 	}
 }
+
+export function assertInlineExpressionValid() {
+	cy.getByTestId('inline-expression-editor-input').find('.cm-valid-resolvable').should('exist');
+}

--- a/cypress/composables/ndv.ts
+++ b/cypress/composables/ndv.ts
@@ -126,6 +126,10 @@ export function getNodeOutputErrorMessage() {
 	return getOutputPanel().findChildByTestId('node-error-message');
 }
 
+export function getParameterExpressionPreviewValue() {
+	return cy.getByTestId('parameter-expression-preview-value');
+}
+
 /**
  * Actions
  */

--- a/cypress/e2e/9999-SUG-38-inline-expression-preview.cy.ts
+++ b/cypress/e2e/9999-SUG-38-inline-expression-preview.cy.ts
@@ -1,0 +1,20 @@
+import { assertInlineExpressionValid } from '../composables/ndv';
+import {
+	clickZoomToFit,
+	executeWorkflowAndWait,
+	navigateToNewWorkflowPage,
+	openNode,
+	pasteWorkflow,
+} from '../composables/workflow';
+import Workflow from '../fixtures/Test_9999-SUG-38.json';
+
+describe('SUG-38 Inline expression previews are not displayed in NDV', () => {
+	it("should show active inline expression preview in NDV if the node's input data is populated", () => {
+		navigateToNewWorkflowPage();
+		pasteWorkflow(Workflow);
+		clickZoomToFit();
+		executeWorkflowAndWait();
+		openNode('Repro1');
+		assertInlineExpressionValid();
+	});
+});

--- a/cypress/e2e/9999-SUG-38-inline-expression-preview.cy.ts
+++ b/cypress/e2e/9999-SUG-38-inline-expression-preview.cy.ts
@@ -1,4 +1,7 @@
-import { assertInlineExpressionValid } from '../composables/ndv';
+import {
+	assertInlineExpressionValid,
+	getParameterExpressionPreviewValue,
+} from '../composables/ndv';
 import {
 	clickZoomToFit,
 	executeWorkflowAndWait,
@@ -9,12 +12,13 @@ import {
 import Workflow from '../fixtures/Test_9999-SUG-38.json';
 
 describe('SUG-38 Inline expression previews are not displayed in NDV', () => {
-	it("should show active inline expression preview in NDV if the node's input data is populated", () => {
+	it("should show resolved inline expression preview in NDV if the node's input data is populated", () => {
 		navigateToNewWorkflowPage();
 		pasteWorkflow(Workflow);
 		clickZoomToFit();
 		executeWorkflowAndWait();
 		openNode('Repro1');
 		assertInlineExpressionValid();
+		getParameterExpressionPreviewValue().should('have.text', 'hello there');
 	});
 });

--- a/cypress/fixtures/Test_9999-SUG-38.json
+++ b/cypress/fixtures/Test_9999-SUG-38.json
@@ -1,0 +1,80 @@
+{
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [-240, 180],
+			"id": "cd9b8124-567e-43d9-b4d1-638b111cd049",
+			"name": "When clicking ‘Test workflow’"
+		},
+		{
+			"parameters": {
+				"assignments": {
+					"assignments": [
+						{
+							"id": "3a40d9f2-0eed-4a92-9287-9d6ec9ce90e8",
+							"name": "message",
+							"value": "hello there",
+							"type": "string"
+						}
+					]
+				},
+				"options": {}
+			},
+			"type": "n8n-nodes-base.set",
+			"typeVersion": 3.4,
+			"position": [-20, 180],
+			"id": "6e58ae14-4851-4e9d-9465-4155b6e2f278",
+			"name": "Edit Fields1"
+		},
+		{
+			"parameters": {
+				"assignments": {
+					"assignments": [
+						{
+							"id": "9e957377-c5f2-4254-89d8-334d32a8cfb6",
+							"name": "test",
+							"value": "={{ $json.message }}",
+							"type": "string"
+						}
+					]
+				},
+				"options": {}
+			},
+			"type": "n8n-nodes-base.set",
+			"typeVersion": 3.4,
+			"position": [200, 180],
+			"id": "c4e9d792-51e9-4296-ba66-afac3cf378dd",
+			"name": "Repro1"
+		}
+	],
+	"connections": {
+		"When clicking ‘Test workflow’": {
+			"main": [
+				[
+					{
+						"node": "Edit Fields1",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Edit Fields1": {
+			"main": [
+				[
+					{
+						"node": "Repro1",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"pinData": {},
+	"meta": {
+		"instanceId": "cdc3bfdf3e6244f221ab6e71b2115a631406ae45a034bfca5e9731cf64f4eb64"
+	}
+}

--- a/packages/frontend/editor-ui/src/Interface.ts
+++ b/packages/frontend/editor-ui/src/Interface.ts
@@ -1547,7 +1547,7 @@ export interface IN8nPromptResponse {
 
 export type InputPanel = {
 	nodeName?: string;
-	run: number;
+	run?: number;
 	branch?: number;
 	data: {
 		isEmpty: boolean;
@@ -1555,7 +1555,6 @@ export type InputPanel = {
 };
 
 export type OutputPanel = {
-	run: number;
 	branch?: number;
 	data: {
 		isEmpty: boolean;

--- a/packages/frontend/editor-ui/src/components/CanvasChat/future/components/LogsOverviewPanel.vue
+++ b/packages/frontend/editor-ui/src/components/CanvasChat/future/components/LogsOverviewPanel.vue
@@ -5,7 +5,7 @@ import { useI18n } from '@/composables/useI18n';
 import { useNodeHelpers } from '@/composables/useNodeHelpers';
 import { useWorkflowsStore } from '@/stores/workflows.store';
 import { N8nButton, N8nRadioButtons, N8nText, N8nTooltip } from '@n8n/design-system';
-import { computed, nextTick } from 'vue';
+import { computed } from 'vue';
 import { ElTree, type TreeNode as ElTreeNode } from 'element-plus';
 import {
 	createAiData,
@@ -115,9 +115,6 @@ function handleToggleExpanded(treeNode: ElTreeNode) {
 
 async function handleOpenNdv(treeNode: TreeNode) {
 	ndvStore.setActiveNodeName(treeNode.node);
-
-	// HACK: defer setting the output run index to not be overridden by other effects
-	await nextTick(() => ndvStore.setOutputRunIndex(treeNode.runIndex));
 }
 
 async function handleTriggerPartialExecution(treeNode: TreeNode) {

--- a/packages/frontend/editor-ui/src/stores/ndv.store.ts
+++ b/packages/frontend/editor-ui/src/stores/ndv.store.ts
@@ -38,7 +38,6 @@ export const useNDVStore = defineStore(STORES.NDV, () => {
 	const localStorageAutoCompleteIsOnboarded = useStorage(LOCAL_STORAGE_AUTOCOMPLETE_IS_ONBOARDED);
 
 	const activeNodeName = ref<string | null>(null);
-	const isRunIndexLinkingEnabled = ref(true);
 	const mainPanelDimensions = ref<MainPanelDimensions>({
 		unknown: { ...DEFAULT_MAIN_PANEL_DIMENSIONS },
 		regular: { ...DEFAULT_MAIN_PANEL_DIMENSIONS },
@@ -49,7 +48,7 @@ export const useNDVStore = defineStore(STORES.NDV, () => {
 	const pushRef = ref('');
 	const input = ref<InputPanel>({
 		nodeName: undefined,
-		run: -1,
+		run: undefined,
 		branch: undefined,
 		data: {
 			isEmpty: true,
@@ -60,7 +59,6 @@ export const useNDVStore = defineStore(STORES.NDV, () => {
 		'schema',
 	);
 	const output = ref<OutputPanel>({
-		run: -1,
 		branch: undefined,
 		data: {
 			isEmpty: true,
@@ -215,36 +213,15 @@ export const useNDVStore = defineStore(STORES.NDV, () => {
 	const isNDVOpen = computed(() => activeNodeName.value !== null);
 
 	const setActiveNodeName = (nodeName: string | null): void => {
-		if (nodeName === activeNodeName.value) {
-			return;
-		}
-
 		activeNodeName.value = nodeName;
-
-		// Reset run index
-		input.value.run = -1;
-		output.value.run = -1;
-		isRunIndexLinkingEnabled.value = true;
 	};
 
 	const setInputNodeName = (nodeName: string | undefined): void => {
 		input.value.nodeName = nodeName;
 	};
 
-	const setInputRunIndex = (run: number = -1): void => {
+	const setInputRunIndex = (run?: number): void => {
 		input.value.run = run;
-
-		if (isRunIndexLinkingEnabled.value) {
-			setOutputRunIndex(run);
-		}
-	};
-
-	const setOutputRunIndex = (run: number = -1): void => {
-		output.value.run = run;
-	};
-
-	const setRunIndexLinkingEnabled = (value: boolean): void => {
-		isRunIndexLinkingEnabled.value = value;
 	};
 
 	const setMainPanelDimensions = (params: {
@@ -427,12 +404,9 @@ export const useNDVStore = defineStore(STORES.NDV, () => {
 		expressionOutputItemIndex,
 		isTableHoverOnboarded,
 		mainPanelDimensions,
-		isRunIndexLinkingEnabled,
 		setActiveNodeName,
 		setInputNodeName,
 		setInputRunIndex,
-		setOutputRunIndex,
-		setRunIndexLinkingEnabled,
 		setMainPanelDimensions,
 		setNDVPushRef,
 		resetNDVPushRef,


### PR DESCRIPTION
## Summary
This PR fixes the bug introduced in #14386 by reverting changes made in NDV store and NodeDetailsView.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/SUG-38/expression-previews-inline-expression-previews-are-not-displayed-in


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
