### PR TITLE
fix(Code Node): Use an explicit `indexURL` to load the pyodide runtime

### DIFF
--- a/packages/nodes-base/nodes/Code/Pyodide.ts
+++ b/packages/nodes-base/nodes/Code/Pyodide.ts
@@ -1,3 +1,4 @@
+import { dirname } from 'node:path';
 import type { PyodideInterface } from 'pyodide';
 
 let pyodideInstance: PyodideInterface | undefined;
@@ -5,7 +6,8 @@ let pyodideInstance: PyodideInterface | undefined;
 export async function LoadPyodide(packageCacheDir: string): Promise<PyodideInterface> {
 	if (pyodideInstance === undefined) {
 		const { loadPyodide } = await import('pyodide');
-		pyodideInstance = await loadPyodide({ packageCacheDir });
+		const indexURL = dirname(require.resolve('pyodide'));
+		pyodideInstance = await loadPyodide({ indexURL, packageCacheDir });
 
 		await pyodideInstance.runPythonAsync(`
 from _pyodide_core import jsproxy_typedict


### PR DESCRIPTION
## Summary

It's not clear why, but since the last release pyodide is trying to load it's WASM runtime from an invalid path.
This PR switched the pyodide setup to use an explicit (and absolute) path, to make python codes work again. 

## Related Linear tickets, Github issues, and Community forum posts

Fixes #14479
NODE-2830

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
