### PR TITLE
ci: Change to get the ref once without need for additional checkout (no-changelog)

### DIFF
--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -64,20 +64,19 @@ jobs:
         # "sha-5d3fe...35d3-time-1620841214"
         run: echo "value=sha-$GITHUB_SHA-time-$(date +"%s")" >> $GITHUB_OUTPUT
 
+      - name: Calculate Git Ref 🤔
+        id: calculate_ref
+        # if pr_number is provided, use it, otherwise use the branch
+        run: echo "value=${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || inputs.branch }}" >> $GITHUB_OUTPUT
+
   install:
     runs-on: blacksmith-4vcpu-ubuntu-2204
     needs: ['prepare']
 
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ inputs.branch }}
-
-      - name: Checkout PR
-        if: ${{ inputs.pr_number }}
-        run: |
-          git fetch origin pull/${{ inputs.pr_number }}/head
-          git checkout FETCH_HEAD
+          ref: ${{ steps.calculate_ref.outputs.value }}
 
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
@@ -119,15 +118,9 @@ jobs:
         # running the same tests multiple times
         containers: ${{ fromJSON( inputs.spec == 'e2e/*' && inputs.containers || '[1]' ) }}
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ inputs.branch }}
-
-      - name: Checkout PR
-        if: ${{ inputs.pr_number }}
-        run: |
-          git fetch origin pull/${{ inputs.pr_number }}/head
-          git checkout FETCH_HEAD
+          ref: ${{ steps.calculate_ref.outputs.value }}
 
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 

--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -66,9 +66,12 @@ jobs:
 
       - name: Calculate Git Ref 🤔
         id: calculate_ref
-        # if pr_number is provided, use it, otherwise use the branch
-        run: echo "value=${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || inputs.branch }}" >> $GITHUB_OUTPUT
-
+        run: |
+          if [ -n "${{ inputs.pr_number }}" ]; then
+            echo "value=refs/pull/${{ inputs.pr_number }}/head" >> $GITHUB_OUTPUT
+          else
+            echo "value=${{ inputs.branch }}" >> $GITHUB_OUTPUT
+          fi
   install:
     runs-on: blacksmith-4vcpu-ubuntu-2204
     needs: ['prepare']


### PR DESCRIPTION
This should help when we checkout but don't have the PR commit due to fetch depth

## Summary

We are seeing issues of commits not being found in the e2e tests. This could be due to us using shallow clone in our initial checkout then trying to get a branch/pr that's not in the git commit history.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-751/ci-improve-e2e-reusable-checkout

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
