### PR TITLE
fix(xAI Grok Chat Model Node): Remove stream_options parameter

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatXAiGrok/LmChatXAiGrok.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatXAiGrok/LmChatXAiGrok.node.ts
@@ -238,11 +238,14 @@ export class LmChatXAiGrok implements INodeType {
 			maxRetries: options.maxRetries ?? 2,
 			configuration,
 			callbacks: [new N8nLlmTracing(this)],
-			modelKwargs: options.responseFormat
-				? {
-						response_format: { type: options.responseFormat },
-					}
-				: undefined,
+			modelKwargs: {
+				stream_options: undefined,
+				...(options.responseFormat
+					? {
+							response_format: { type: options.responseFormat },
+						}
+					: undefined),
+			},
 			onFailedAttempt: makeN8nLlmFailedAttemptHandler(this, openAiFailedAttemptHandler),
 		});
 


### PR DESCRIPTION
## Summary

xAI Grok model node uses ChatOpenAI from LangChain as an implementation right now, but xAI API returns an error when stream_options parameter is supplied. This PR disables sending this parameter to the API.

## Related Linear tickets, Github issues, and Community forum posts

- fixes #14483 
- https://linear.app/n8n/issue/AI-851/community-issue-issue-xai-grok-with-ai-agent-node-does-not-work

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
