### PR TITLE
feat(API): Match insights summary period with number of days filter in graphs and table

### DIFF
--- a/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
@@ -126,7 +126,10 @@ describe('workflowExecuteAfterHandler', () => {
 		);
 		// expect timestamp to be close to workflow execution start
 		for (const insight of allInsights) {
-			expect(insight.timestamp.getTime() / 1000).toBeCloseTo(now.getTime() / 1000, 0);
+			const timeDiffInSeconds = Math.abs(
+				Math.round(insight.timestamp.getTime() / 1000) - Math.round(now.getTime() / 1000),
+			);
+			expect(timeDiffInSeconds).toBeLessThanOrEqual(1);
 		}
 		if (status === 'success') {
 			expect(allInsights).toContainEqual(

--- a/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
@@ -1232,7 +1232,7 @@ describe('getInsightsSummary', () => {
 
 	test('compacted data are summarized correctly', async () => {
 		// ARRANGE
-		// last 7 days
+		// last 6 days
 		await createCompactedInsightsEvent(workflow, {
 			type: 'success',
 			value: 1,
@@ -1251,7 +1251,7 @@ describe('getInsightsSummary', () => {
 			periodUnit: 'day',
 			periodStart: DateTime.utc(),
 		});
-		// last 14 days
+		// last 12 days
 		await createCompactedInsightsEvent(workflow, {
 			type: 'success',
 			value: 1,
@@ -1264,9 +1264,16 @@ describe('getInsightsSummary', () => {
 			periodUnit: 'day',
 			periodStart: DateTime.utc().minus({ days: 10 }),
 		});
+		//Outside range should not be taken into account
+		await createCompactedInsightsEvent(workflow, {
+			type: 'runtime_ms',
+			value: 123,
+			periodUnit: 'day',
+			periodStart: DateTime.utc().minus({ days: 13 }),
+		});
 
 		// ACT
-		const summary = await insightsService.getInsightsSummary();
+		const summary = await insightsService.getInsightsSummary({ periodLengthInDays: 6 });
 
 		// ASSERT
 		expect(summary).toEqual({
@@ -1289,7 +1296,7 @@ describe('getInsightsSummary', () => {
 		});
 
 		// ACT
-		const summary = await insightsService.getInsightsSummary();
+		const summary = await insightsService.getInsightsSummary({ periodLengthInDays: 7 });
 
 		// ASSERT
 		expect(Object.values(summary).map((v) => v.deviation)).toEqual([null, null, null, null, null]);
@@ -1329,7 +1336,7 @@ describe('getInsightsSummary', () => {
 		});
 
 		// ACT
-		const summary = await insightsService.getInsightsSummary();
+		const summary = await insightsService.getInsightsSummary({ periodLengthInDays: 7 });
 
 		// ASSERT
 		expect(summary).toEqual({

--- a/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
+++ b/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
@@ -252,7 +252,9 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 				: `DATE_SUB(NOW(), INTERVAL ${maxAgeInDays} DAY)`;
 	}
 
-	async getPreviousAndCurrentPeriodTypeAggregates(): Promise<
+	async getPreviousAndCurrentPeriodTypeAggregates({
+		periodLengthInDays,
+	}: { periodLengthInDays: number }): Promise<
 		Array<{
 			period: 'previous' | 'current';
 			type: 0 | 1 | 2 | 3;
@@ -261,9 +263,9 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 	> {
 		const cte = sql`
 			SELECT
-				${this.getAgeLimitQuery(7)} AS current_start,
+				${this.getAgeLimitQuery(periodLengthInDays)} AS current_start,
 				${this.getAgeLimitQuery(0)} AS current_end,
-				${this.getAgeLimitQuery(14)}  AS previous_start
+				${this.getAgeLimitQuery(periodLengthInDays * 2)}  AS previous_start
 		`;
 
 		const rawRows = await this.createQueryBuilder('insights')

--- a/packages/cli/src/modules/insights/insights.controller.ts
+++ b/packages/cli/src/modules/insights/insights.controller.ts
@@ -10,14 +10,16 @@ import { InsightsService } from './insights.service';
 
 @RestController('/insights')
 export class InsightsController {
-	private readonly maxAgeInDaysFilteredInsights = 14;
+	private readonly maxAgeInDaysFilteredInsights = 7;
 
 	constructor(private readonly insightsService: InsightsService) {}
 
 	@Get('/summary')
 	@GlobalScope('insights:list')
 	async getInsightsSummary(): Promise<InsightsSummary> {
-		return await this.insightsService.getInsightsSummary();
+		return await this.insightsService.getInsightsSummary({
+			periodLengthInDays: this.maxAgeInDaysFilteredInsights,
+		});
 	}
 
 	@Get('/by-workflow', { middlewares: [paginationListQueryMiddleware, sortByQueryMiddleware] })

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -348,8 +348,12 @@ export class InsightsService {
 		});
 	}
 
-	async getInsightsSummary(): Promise<InsightsSummary> {
-		const rows = await this.insightsByPeriodRepository.getPreviousAndCurrentPeriodTypeAggregates();
+	async getInsightsSummary({
+		periodLengthInDays,
+	}: { periodLengthInDays: number }): Promise<InsightsSummary> {
+		const rows = await this.insightsByPeriodRepository.getPreviousAndCurrentPeriodTypeAggregates({
+			periodLengthInDays,
+		});
 
 		// Initialize data structures for both periods
 		const data = {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR uses the same `maxAgeInDays` parameter (hardcoded to 7 days for now) to filter the Insights API data summary than the one used to filter the by-workflow and by-time routes to display graph and tables.
Meaning that the summary will still compare the last 7 days with the 7 days before that, but the graph and table will take only the last 7 days of data.
This PR also prepare the work for using a query param for max age in days filtering in the future for all endpoints.
The feature is not in GA yet.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [X] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [X] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
