### PR TITLE
chore(benchmark): Increase benchmark vm disk size from 16 to 32

### DIFF
--- a/packages/@n8n/benchmark/infra/modules/benchmark-vm/vm.tf
+++ b/packages/@n8n/benchmark/infra/modules/benchmark-vm/vm.tf
@@ -74,7 +74,7 @@ resource "azurerm_managed_disk" "data" {
   resource_group_name  = var.resource_group_name
   storage_account_type = "PremiumV2_LRS"
   create_option        = "Empty"
-  disk_size_gb         = "16"
+  disk_size_gb         = "32"
   zone                 = 1
 
   tags = var.tags


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
We noticed some errors linked with the benchmark VM disk being full when turning on insights module and running sqlite benchmarks: https://github.com/n8n-io/n8n/actions/runs/14347382239/job/40219643621
This is because insights module fills a new insights_raw table with execution insights for each execution, thus adding non negligible amount of data.
The benchmarks sometimes run fine though, meaning that the size of the sqlite data is not out of control but just increased too much for the disk size (16gb for now).
We decided to increase the disk size from 16gb to 32gb for now, and monitor the storage usage of the insights module.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [X] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [X] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
