### PR TITLE
feat(Postgres Node): Include old (row before update) to the event

### DIFF
--- a/packages/nodes-base/nodes/Postgres/PostgresTrigger.node.ts
+++ b/packages/nodes-base/nodes/Postgres/PostgresTrigger.node.ts
@@ -260,7 +260,11 @@ export class PostgresTrigger implements INodeType {
 		const onNotification = async (data: IDataObject) => {
 			if (data.payload) {
 				try {
-					data.payload = JSON.parse(data.payload as string) as IDataObject;
+					const parsed = JSON.parse(data.payload as string) as IDataObject;
+					data.payload = parsed.new;
+					if ('old' in parsed) {
+						data.oldPayload = parsed.old;
+					}
 				} catch (error) {}
 			}
 			this.emit([this.helpers.returnJsonArray([data])]);


### PR DESCRIPTION
## Summary

<img width="1373" alt="Screenshot 2025-04-09 at 22 03 29" src="https://github.com/user-attachments/assets/d3e0391b-0ea6-428e-b76f-638c9f2e6e0b" />

Adds "payloadOld" to Postgres Trigger to make it possible to compare row changes.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] ~~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~~ There is no mention about event result structure, so can't update anything.
- [ ] ~~Tests included.~~ There are no tests for Postgres Trigger anyway
