### PR TITLE
feat(core): Make runtime prototype mutation protection configurable for task runner

### DIFF
--- a/packages/@n8n/task-runner/src/config/js-runner-config.ts
+++ b/packages/@n8n/task-runner/src/config/js-runner-config.ts
@@ -7,4 +7,14 @@ export class JsRunnerConfig {
 
 	@Env('NODE_FUNCTION_ALLOW_EXTERNAL')
 	allowedExternalModules: string = '';
+
+	/**
+	 * Whether to allow prototype mutation for external libraries. Set to `false`
+	 * to allow modules that rely on runtime prototype mutation, e.g. `puppeteer`,
+	 * at the cost of security.
+	 *
+	 * @default false
+	 */
+	@Env('N8N_RUNNERS_ALLOW_PROTOTYPE_MUTATION')
+	allowPrototypeMutation: boolean = false;
 }

--- a/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
@@ -1435,6 +1435,31 @@ describe('JsTaskRunner', () => {
 			// @ts-expect-error Non-existing property
 			expect(Duration.fromObject({ hours: 1 }).maliciousKey).toBeUndefined();
 		});
+
+		it('should allow prototype mutation when `allowPrototypeMutation` is true', async () => {
+			const runner = createRunnerWithOpts({
+				allowPrototypeMutation: true,
+			});
+
+			const outcome = await executeForAllItems({
+				code: `
+					const obj = {};
+
+					Object.prototype.maliciousProperty = 'compromised';
+
+					return [{ json: {
+						prototypeMutated: obj.maliciousProperty === 'compromised'
+					}}];
+				`,
+				inputItems: [{ a: 1 }],
+				runner,
+			});
+
+			expect(outcome.result).toEqual([wrapIntoJson({ prototypeMutated: true })]);
+
+			// @ts-expect-error Non-existing property
+			delete Object.prototype.maliciousProperty;
+		});
 	});
 
 	describe('stack trace', () => {

--- a/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
@@ -30,6 +30,11 @@ import {
 jest.mock('ws');
 
 const defaultConfig = new MainConfig();
+defaultConfig.jsRunnerConfig ??= {
+	allowedBuiltInModules: '',
+	allowedExternalModules: '',
+	allowPrototypeMutation: true, // needed for jest
+};
 
 describe('JsTaskRunner', () => {
 	const createRunnerWithOpts = (

--- a/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
@@ -117,10 +117,13 @@ export class JsTaskRunner extends TaskRunner {
 			allowedExternalModules,
 		});
 
-		this.preventPrototypePollution(allowedExternalModules);
+		this.preventPrototypePollution(allowedExternalModules, jsRunnerConfig.allowPrototypeMutation);
 	}
 
-	private preventPrototypePollution(allowedExternalModules: Set<string> | '*') {
+	private preventPrototypePollution(
+		allowedExternalModules: Set<string> | '*',
+		allowPrototypeMutation: boolean,
+	) {
 		if (allowedExternalModules instanceof Set) {
 			// This is a workaround to enable the allowed external libraries to mutate
 			// prototypes directly. For example momentjs overrides .toString() directly
@@ -133,7 +136,7 @@ export class JsTaskRunner extends TaskRunner {
 		}
 
 		// Freeze globals, except for Jest
-		if (process.env.NODE_ENV !== 'test') {
+		if (!allowPrototypeMutation && process.env.NODE_ENV !== 'test') {
 			Object.getOwnPropertyNames(globalThis)
 				// @ts-expect-error globalThis does not have string in index signature
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access

--- a/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
@@ -135,8 +135,8 @@ export class JsTaskRunner extends TaskRunner {
 			}
 		}
 
-		// Freeze globals, except for Jest
-		if (!allowPrototypeMutation && process.env.NODE_ENV !== 'test') {
+		// Freeze globals if needed
+		if (!allowPrototypeMutation) {
 			Object.getOwnPropertyNames(globalThis)
 				// @ts-expect-error globalThis does not have string in index signature
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access


### PR DESCRIPTION
## Summary

Some JS libs are incompatible with the task runner's runtime prototype mutation protection, e.g.  `rxjs` in `puppeteer`. This PR adds an escape hatch for users willing to trade security for functionality.

Context: https://n8nio.slack.com/archives/C069HS026UF/p1743676389224379


## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/issues/14211
https://linear.app/n8n/issue/CAT-732

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
