### PR TITLE
fix(core): Restore run data value when offloading to workers

### DIFF
--- a/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
@@ -411,5 +411,44 @@ describe('WorkflowExecutionService', () => {
 
 			expect(node).toEqual(webhookNode);
 		});
+
+		describe('offloading manual executions to workers', () => {});
+		test('when receiving no `runData`, should set `runData` to undefined in `executionData`', async () => {
+			const originalEnv = process.env;
+			process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS = 'true';
+
+			const configMock = { getEnv: jest.fn() };
+			configMock.getEnv.mockReturnValue('queue');
+
+			const workflowRunnerMock = mock<WorkflowRunner>();
+			workflowRunnerMock.run.mockResolvedValue('fake-execution-id');
+
+			const service = new WorkflowExecutionService(
+				mock(),
+				mock(),
+				mock(),
+				mock(),
+				nodeTypes,
+				mock(),
+				workflowRunnerMock,
+				mock(),
+				mock(),
+				mock(),
+			);
+
+			await service.executeManually(
+				{
+					workflowData: mock<IWorkflowBase>({ nodes: [] }),
+					startNodes: [],
+					runData: undefined,
+				},
+				mock<User>({ id: 'user-id' }),
+			);
+
+			const callArgs = workflowRunnerMock.run.mock.calls[0][0];
+			expect(callArgs.executionData?.resultData?.runData).toBeUndefined();
+
+			process.env = originalEnv;
+		});
 	});
 });

--- a/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
@@ -412,43 +412,44 @@ describe('WorkflowExecutionService', () => {
 			expect(node).toEqual(webhookNode);
 		});
 
-		describe('offloading manual executions to workers', () => {});
-		test('when receiving no `runData`, should set `runData` to undefined in `executionData`', async () => {
-			const originalEnv = process.env;
-			process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS = 'true';
+		describe('offloading manual executions to workers', () => {
+			test('when receiving no `runData`, should set `runData` to undefined in `executionData`', async () => {
+				const originalEnv = process.env;
+				process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS = 'true';
 
-			const configMock = { getEnv: jest.fn() };
-			configMock.getEnv.mockReturnValue('queue');
+				const configMock = { getEnv: jest.fn() };
+				configMock.getEnv.mockReturnValue('queue');
 
-			const workflowRunnerMock = mock<WorkflowRunner>();
-			workflowRunnerMock.run.mockResolvedValue('fake-execution-id');
+				const workflowRunnerMock = mock<WorkflowRunner>();
+				workflowRunnerMock.run.mockResolvedValue('fake-execution-id');
 
-			const service = new WorkflowExecutionService(
-				mock(),
-				mock(),
-				mock(),
-				mock(),
-				nodeTypes,
-				mock(),
-				workflowRunnerMock,
-				mock(),
-				mock(),
-				mock(),
-			);
+				const service = new WorkflowExecutionService(
+					mock(),
+					mock(),
+					mock(),
+					mock(),
+					nodeTypes,
+					mock(),
+					workflowRunnerMock,
+					mock(),
+					mock(),
+					mock(),
+				);
 
-			await service.executeManually(
-				{
-					workflowData: mock<IWorkflowBase>({ nodes: [] }),
-					startNodes: [],
-					runData: undefined,
-				},
-				mock<User>({ id: 'user-id' }),
-			);
+				await service.executeManually(
+					{
+						workflowData: mock<IWorkflowBase>({ nodes: [] }),
+						startNodes: [],
+						runData: undefined,
+					},
+					mock<User>({ id: 'user-id' }),
+				);
 
-			const callArgs = workflowRunnerMock.run.mock.calls[0][0];
-			expect(callArgs.executionData?.resultData?.runData).toBeUndefined();
+				const callArgs = workflowRunnerMock.run.mock.calls[0][0];
+				expect(callArgs.executionData?.resultData?.runData).toBeUndefined();
 
-			process.env = originalEnv;
+				process.env = originalEnv;
+			});
 		});
 	});
 });

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -208,7 +208,8 @@ export class WorkflowExecutionService {
 				},
 				resultData: {
 					pinData,
-					runData: runData ?? {},
+					// @ts-expect-error CAT-752
+					runData,
 				},
 				manualData: {
 					userId: data.userId,


### PR DESCRIPTION
## Summary

PR #13194 changed [this line](https://github.com/n8n-io/n8n/pull/13194/files#diff-cac13b5cca91c50a79e5afb3708e8ec76e810966698ce32387be94de6e7c79bbR210) which has started causing `runData` to be persisted as `{}` when it was originally `undefined`, leading to an error `destinationNodeName is required` when manually running a pinned trigger full execution in scaling mode with offloading enabled.

Specifically, when the worker retrieves execution data and calls `ManualExecutionService.runManually` we eventually reach [this check](https://github.com/n8n-io/n8n/blob/9029dace5c682e4b5df4f18f2f51098dce6436e5/packages/cli/src/manual-execution.service.ts#L92) which now compares `{}` to `undefined`. This causes what was meant to be a full execution to now be wrongly diverted into the partial execution path.

This PR restores the original `undefined` value when persisting `runData`. 

Please note PR #13194 also updated the type `WorkflowRequest.ManualRunPayload['runData']` (optional) which now no longer matches `IRunExecutionData['resultData']['runData']` (required). This type update is correct, but updating also the execution data type to match leads to a cascade of type errors in multiple places across packages, as this has been mistyped for a long time. Updating this type will need to be a [dedicated effort](https://linear.app/n8n/issue/CAT-752), hence for now the TS exception.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-2729
https://linear.app/n8n/issue/PAY-2704
https://github.com/n8n-io/n8n/issues/14144

<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
