### PR TITLE
feat(core): Add a new option to customize SSH tunnel idle timeout

### DIFF
--- a/packages/core/src/execution-engine/__tests__/ssh-clients-manager.test.ts
+++ b/packages/core/src/execution-engine/__tests__/ssh-clients-manager.test.ts
@@ -1,9 +1,11 @@
+import { mock } from 'jest-mock-extended';
 import type { SSHCredentials } from 'n8n-workflow';
 import { Client } from 'ssh2';
 
 import { SSHClientsManager } from '../ssh-clients-manager';
 
 describe('SSHClientsManager', () => {
+	const idleTimeout = 5 * 60;
 	const credentials: SSHCredentials = {
 		sshAuthenticateWith: 'password',
 		sshHost: 'example.com',
@@ -20,7 +22,7 @@ describe('SSHClientsManager', () => {
 		jest.clearAllMocks();
 		jest.useFakeTimers();
 
-		sshClientsManager = new SSHClientsManager();
+		sshClientsManager = new SSHClientsManager(mock({ idleTimeout }));
 		connectSpy.mockImplementation(function (this: Client) {
 			this.emit('ready');
 			return this;
@@ -59,7 +61,7 @@ describe('SSHClientsManager', () => {
 		await sshClientsManager.getClient({ ...credentials, sshHost: 'host2' });
 		await sshClientsManager.getClient({ ...credentials, sshHost: 'host3' });
 
-		jest.advanceTimersByTime(6 * 60 * 1000);
+		jest.advanceTimersByTime((idleTimeout + 1) * 1000);
 		sshClientsManager.cleanupStaleConnections();
 
 		expect(endSpy).toHaveBeenCalledTimes(3);


### PR DESCRIPTION
## Summary
Some users have DB queries that take longer than the underlying SSH tunnel is allowed to be open for. This breaks the executions for such workflows.

This PR let's n8n instances customize the SSH tunnel idle timeout to prevent tunnels from being prematurely closed.
 
## Related Linear tickets, Github issues, and Community forum posts

https://community.n8n.io/t/error-using-postgres-chat-memory-and-supabase-for-ai-tools-agent/70792/28?u=netroy


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
