### PR TITLE
fix(MCP Client Tool Node): Stringify tool result

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.test.ts
@@ -57,7 +57,7 @@ describe('McpClientTool', () => {
 			jest.resetAllMocks();
 		});
 
-		it('should return a valid toolkit with usable tools', async () => {
+		it('should return a valid toolkit with usable tools (that returns a string)', async () => {
 			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
 			jest
 				.spyOn(Client.prototype, 'callTool')
@@ -93,7 +93,7 @@ describe('McpClientTool', () => {
 			expect(tools).toHaveLength(2);
 
 			const toolCallResult = await tools[0].invoke({ input: 'foo' });
-			expect(toolCallResult).toEqual([{ type: 'text', text: 'result from tool' }]);
+			expect(toolCallResult).toEqual(JSON.stringify([{ type: 'text', text: 'result from tool' }]));
 		});
 
 		it('should support selecting tools to expose', async () => {

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpServer.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpServer.ts
@@ -120,7 +120,8 @@ export class McpServer {
 					return {
 						name: tool.name,
 						description: tool.description,
-						inputSchema: zodToJsonSchema(tool.schema),
+						// Allow additional properties on tool call input
+						inputSchema: zodToJsonSchema(tool.schema, { removeAdditionalStrategy: 'strict' }),
 					};
 				}),
 			};

--- a/packages/@n8n/nodes-langchain/utils/logWrapper.ts
+++ b/packages/@n8n/nodes-langchain/utils/logWrapper.ts
@@ -395,7 +395,9 @@ export function logWrapper<
 
 						logAiEvent(executeFunctions, 'ai-tool-called', { ...inputData, response });
 						executeFunctions.addOutputData(connectionType, index, [[{ json: { response } }]]);
-						return response;
+
+						if (typeof response === 'string') return response;
+						return JSON.stringify(response);
 					};
 				}
 			}


### PR DESCRIPTION
## Summary

Stringify tool result to be compatible with more AI models

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2843/community-issue-mcp-client-not-working-with-ollama-and-most-of-models
fixes https://github.com/n8n-io/n8n/issues/14548

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
