### PR TITLE
feat(McpClientTool): Add support for custom authentication method and update tests

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
@@ -72,6 +72,15 @@ export class McpClientTool implements INodeType {
 					},
 				},
 			},
+			{
+				name: 'httpCustomAuth',
+				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['customAuth'],
+					},
+				},
+			},
 		],
 		properties: [
 			getConnectionHintNoticeField([NodeConnectionTypes.AiAgent]),
@@ -94,6 +103,10 @@ export class McpClientTool implements INodeType {
 						value: 'bearerAuth',
 					},
 					{
+						name: 'Custom Auth',
+						value: 'customAuth',
+					},
+					{
 						name: 'Header Auth',
 						value: 'headerAuth',
 					},
@@ -112,7 +125,7 @@ export class McpClientTool implements INodeType {
 				default: '',
 				displayOptions: {
 					show: {
-						authentication: ['headerAuth', 'bearerAuth'],
+						authentication: ['headerAuth', 'bearerAuth', 'customAuth'],
 					},
 				},
 			},

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/types.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/types.ts
@@ -4,4 +4,4 @@ export type McpTool = { name: string; description?: string; inputSchema: JSONSch
 
 export type McpToolIncludeMode = 'all' | 'selected' | 'except';
 
-export type McpAuthenticationOption = 'none' | 'headerAuth' | 'bearerAuth';
+export type McpAuthenticationOption = 'bearerAuth' | 'headerAuth' | 'customAuth' | 'none';

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/utils.ts
@@ -8,7 +8,9 @@ import {
 	createResultOk,
 	type IDataObject,
 	type IExecuteFunctions,
+	type IRequestOptionsSimplified,
 	type Result,
+	jsonParse,
 } from 'n8n-workflow';
 import { type ZodTypeAny } from 'zod';
 
@@ -203,6 +205,18 @@ export async function getAuthHeaders(
 			if (!result) return {};
 
 			return { headers: { Authorization: `Bearer ${result.token}` } };
+		}
+		case 'customAuth': {
+			const httpCustomAuth = await ctx
+				.getCredentials<{ json: string }>('httpCustomAuth')
+				.catch(() => null);
+			if (!httpCustomAuth) return {};
+
+			const customAuth = jsonParse<Pick<IRequestOptionsSimplified, 'headers'>>(
+				(httpCustomAuth.json as string) || '{}',
+				{ errorMessage: 'Invalid Custom Auth JSON' },
+			);
+			return { headers: (customAuth.headers as Record<string, string>) ?? {} };
 		}
 		case 'none':
 		default: {


### PR DESCRIPTION
## Summary

Supporting custom auth for mcp client node

<img width="505" alt="スクリーンショット 2025-04-11 夜10 32 14" src="https://github.com/user-attachments/assets/a50ea856-3330-48d4-b2d9-bd589fe6a2c1" />


<img width="518" alt="スクリーンショット 2025-04-11 夜10 37 36" src="https://github.com/user-attachments/assets/6f8dc6a1-6928-4fd4-8da0-cacb3eb4f3f0" />


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
