### PR TITLE
feat: Optional session key management injection for @n8n/chat

### DIFF
--- a/packages/frontend/@n8n/chat/README.md
+++ b/packages/frontend/@n8n/chat/README.md
@@ -200,6 +200,16 @@ createChat({
 - **Default**: `''`
 - **Description**: A comma-separated list of allowed MIME types for file uploads. Only applicable if `allowFileUploads` is set to `true`. If left empty, all file types are allowed. For example: `'image/*,application/pdf'`.
 
+### `sessionKeySource`
+- **Type**: `() => string`
+- **Default**: `undefined`
+- **Description**: A function that returns a custom session key to be used for the chat session. If not provided, the session key will be retrieved from localStorage or generated using UUID.
+
+### `onSessionKeyLoaded`
+- **Type**: `(sessionKey: string) => void`
+- **Default**: `undefined`
+- **Description**: A callback function that is called when a session key is loaded. The session key is passed as an argument to the callback.
+
 ## Customization
 The Chat window is entirely customizable using CSS variables.
 

--- a/packages/frontend/@n8n/chat/src/plugins/chat.ts
+++ b/packages/frontend/@n8n/chat/src/plugins/chat.ts
@@ -78,7 +78,8 @@ export const ChatPlugin: Plugin<ChatOptions> = {
 				return;
 			}
 
-			const sessionId = localStorage.getItem(localStorageSessionIdKey) ?? uuidv4();
+			const sessionId =
+				options.sessionKeySouce?.() ?? localStorage.getItem(localStorageSessionIdKey) ?? uuidv4();
 			const previousMessagesResponse = await api.loadPreviousSession(sessionId, options);
 			const timestamp = new Date().toISOString();
 
@@ -93,6 +94,7 @@ export const ChatPlugin: Plugin<ChatOptions> = {
 				currentSessionId.value = sessionId;
 			}
 
+			options.onSessionKeyLoaded?.(sessionId);
 			return sessionId;
 		}
 

--- a/packages/frontend/@n8n/chat/src/types/options.ts
+++ b/packages/frontend/@n8n/chat/src/types/options.ts
@@ -33,4 +33,6 @@ export interface ChatOptions {
 	disabled?: Ref<boolean>;
 	allowFileUploads?: Ref<boolean> | boolean;
 	allowedFilesMimeTypes?: Ref<string> | string;
+	sessionKeySouce?: () => string;
+	onSessionKeyLoaded?: (sessionKey: string) => void;
 }


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Added custom session key management capabilities to the @n8n/chat component. This enhancement allows developers to provide their own session key source and receive notifications when session keys are loaded.

**New Features**
- Added `sessionKeySource` option that lets developers inject custom session keys instead of using the default localStorage/UUID approach.
- Added `onSessionKeyLoaded` callback that notifies when a session key is loaded, providing the key as an argument.
- Updated documentation with detailed descriptions of the new options.

**Refactors**
- Modified session key retrieval logic to prioritize custom source when available.

<!-- End of auto-generated description by mrge. -->

