### PR TITLE
ci: Add flaky test workflow for debugging

### DIFF
--- a/.github/workflows/e2e-flaky.yml
+++ b/.github/workflows/e2e-flaky.yml
@@ -1,4 +1,4 @@
-name: Check Flaky E2E Test
+name: Debug Flaky E2E Test
 
 on:
   workflow_dispatch:
@@ -19,7 +19,7 @@ on:
 
 jobs:
   debug-test:
-    runs-on: blacksmith-2vcpu-ubuntu-2204
+    runs-on: blacksmith-4vcpu-ubuntu-2204
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/e2e-flaky.yml
+++ b/.github/workflows/e2e-flaky.yml
@@ -1,0 +1,69 @@
+name: Check Flaky E2E Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      test_name:
+        description: 'The name of the test to filter.'
+        required: true
+        type: string
+      burn_count:
+        description: 'Number of times to run the test.'
+        required: false
+        type: number
+        default: 50
+      branch:
+        description: 'Optional: GitHub branch, tag, or SHA to test. Defaults to the branch selected in UI.'
+        required: false
+        type: string
+
+jobs:
+  debug-test:
+    runs-on: blacksmith-2vcpu-ubuntu-2204
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'pnpm'
+
+      - name: Cache build artifacts
+        id: cache-build-artifacts
+        uses: useblacksmith/cache@v5
+        with:
+          path: |
+            /home/runner/.cache/Cypress
+            ./packages/**/dist
+          key: ${{ github.ref }}-${{ github.sha }}-debug-build
+          restore-keys: |
+            ${{ github.ref }}-debug-build-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build application
+        if: steps.cache-build-artifacts.outputs.cache-hit != 'true'
+        run: pnpm build
+
+      - name: Cypress install
+        if: steps.cache-build-artifacts.outputs.cache-hit != 'true'
+        working-directory: cypress
+        run: pnpm cypress:install
+
+      - name: Run Flaky Debug Command
+        run: pnpm run debug:flaky:e2e "${{ github.event.inputs.test_name }}" ${{ github.event.inputs.burn_count }}
+        env:
+          NODE_OPTIONS: --dns-result-order=ipv4first
+          E2E_TESTS: true
+          SHELL: /bin/sh
+          CYPRESS_NODE_VIEW_VERSION: 2

--- a/cypress/e2e/24-ndv-paired-item.cy.ts
+++ b/cypress/e2e/24-ndv-paired-item.cy.ts
@@ -59,8 +59,7 @@ describe('NDV', () => {
 		ndv.getters.inputTableRow(4).invoke('attr', 'data-test-id').should('equal', 'hovering-item');
 	});
 
-	// eslint-disable-next-line n8n-local-rules/no-skipped-tests
-	it.skip('maps paired input and output items based on selected input node', () => {
+	it('maps paired input and output items based on selected input node', () => {
 		cy.fixture('Test_workflow_5.json').then((data) => {
 			cy.get('body').paste(JSON.stringify(data));
 		});


### PR DESCRIPTION
## Summary

Adding a workflow that will allow running of tests by filter, with a "burn" rate. e.g run the test called "my test" 100 times.
This is useful for testing the flaky rate of a test but also for ensuring we can run the tests as they run in our CI.

Also removing skip status on node test (ran 150 times, no flake)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-754/create-github-ci-workflow-for-debugging-flaky-tests

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
