### PR TITLE
feat(core): Enable insights for sqlite legacy

### DIFF
--- a/packages/cli/src/modules/insights/__tests__/insights.pre-init.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.pre-init.test.ts
@@ -15,16 +15,8 @@ describe('InsightsModulePreInit', () => {
 		expect(shouldLoadModule(ctx)).toBe(false);
 	});
 
-	it('should return false if database type is "sqlite" and poolSize is < 1', () => {
-		const ctx: ModulePreInitContext = {
-			instance: mock<InstanceSettings>({ instanceType: 'main' }),
-			database: mock<DatabaseConfig>({ type: 'sqlite', sqlite: { poolSize: 0 } }),
-		};
-		expect(shouldLoadModule(ctx)).toBe(false);
-	});
-
-	it.each(['postgresdb', 'mariadb', 'mysqldb'])(
-		'should return true if instance type is "main" and database is not sqlite',
+	it.each(['postgresdb', 'mariadb', 'mysqldb', 'sqlite'])(
+		'should return true if instance type is "main"',
 		(dbType: 'postgresdb' | 'mysqldb' | 'sqlite' | 'mariadb') => {
 			const ctx: ModulePreInitContext = {
 				instance: mock<InstanceSettings>({ instanceType: 'main' }),
@@ -33,12 +25,4 @@ describe('InsightsModulePreInit', () => {
 			expect(shouldLoadModule(ctx)).toBe(true);
 		},
 	);
-
-	it('should return true if instance type is "main" and sqlite poolSize is >= 1', () => {
-		const ctx: ModulePreInitContext = {
-			instance: mock<InstanceSettings>({ instanceType: 'main' }),
-			database: mock<DatabaseConfig>({ type: 'sqlite', sqlite: { poolSize: 1 } }),
-		};
-		expect(shouldLoadModule(ctx)).toBe(true);
-	});
 });

--- a/packages/cli/src/modules/insights/__tests__/insights.pre-init.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.pre-init.test.ts
@@ -10,7 +10,7 @@ describe('InsightsModulePreInit', () => {
 	it('should return false if instance type is not "main"', () => {
 		const ctx: ModulePreInitContext = {
 			instance: mock<InstanceSettings>({ instanceType: 'worker' }),
-			database: mock<DatabaseConfig>({ type: 'sqlite', sqlite: { poolSize: 10 } }),
+			database: mock<DatabaseConfig>({ type: 'sqlite' }),
 		};
 		expect(shouldLoadModule(ctx)).toBe(false);
 	});

--- a/packages/cli/src/modules/insights/insights.pre-init.ts
+++ b/packages/cli/src/modules/insights/insights.pre-init.ts
@@ -3,7 +3,4 @@ import type { ModulePreInitContext } from '../modules.config';
 export const shouldLoadModule = (ctx: ModulePreInitContext) =>
 	// Only main instance(s) should collect insights
 	// Because main instances are informed of all finished workflow executions, whatever the mode
-	ctx.instance.instanceType === 'main' &&
-	// This is because legacy sqlite (without pool) does not support nested transactions needed for insights
-	// TODO: remove once benchmarks confirm this issue is solved with buffering / flushing mechanism
-	(ctx.database.type !== 'sqlite' || ctx.database.sqlite.poolSize > 0);
+	ctx.instance.instanceType === 'main';


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Before setting up buffering and flushing mechanism to save insights data, we experienced errors on saving insights,  and mismatch between executions and insights data when using legacy SQLite driver (poolSize == 0).
Since buffer / flush has been setup, we could not reproduce this error.
Thus we suggest to enable insights even for legacy SQLite driver

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
