### PR TITLE
fix(core): Only check for folder changes when `parentFolderId` is present

### DIFF
--- a/packages/cli/src/environments.ee/source-control/source-control-helper.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-helper.ee.ts
@@ -18,7 +18,7 @@ import {
 } from './constants';
 import type { KeyPair } from './types/key-pair';
 import type { KeyPairType } from './types/key-pair-type';
-import { SourceControlWorkflowVersionId } from './types/source-control-workflow-version-id';
+import type { SourceControlWorkflowVersionId } from './types/source-control-workflow-version-id';
 
 export function stringContainsExpression(testString: string): boolean {
 	return /^=.*\{\{.*\}\}/.test(testString);

--- a/packages/cli/src/environments.ee/source-control/source-control-helper.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-helper.ee.ts
@@ -18,6 +18,7 @@ import {
 } from './constants';
 import type { KeyPair } from './types/key-pair';
 import type { KeyPairType } from './types/key-pair-type';
+import { SourceControlWorkflowVersionId } from './types/source-control-workflow-version-id';
 
 export function stringContainsExpression(testString: string): boolean {
 	return /^=.*\{\{.*\}\}/.test(testString);
@@ -203,4 +204,18 @@ export function normalizeAndValidateSourceControlledFilePath(
 	}
 
 	return normalizedPath;
+}
+
+/**
+ * Checks if a workflow has been modified by comparing version IDs and parent folder IDs
+ * between local and remote versions
+ */
+export function isWorkflowModified(
+	local: SourceControlWorkflowVersionId,
+	remote: SourceControlWorkflowVersionId,
+): boolean {
+	return (
+		remote.versionId !== local.versionId ||
+		(remote.parentFolderId !== undefined && remote.parentFolderId !== local.parentFolderId)
+	);
 }

--- a/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
@@ -571,12 +571,16 @@ export class SourceControlService {
 		);
 
 		const wfModifiedInEither: SourceControlWorkflowVersionId[] = [];
+
 		wfLocalVersionIds.forEach((local) => {
 			const mismatchingIds = wfRemoteVersionIds.find(
 				(remote) =>
 					remote.id === local.id &&
-					(remote.versionId !== local.versionId || remote.parentFolderId !== local.parentFolderId),
+					(remote.versionId !== local.versionId ||
+						(remote.parentFolderId !== undefined &&
+							remote.parentFolderId !== local.parentFolderId)),
 			);
+
 			let name = (options?.preferLocalVersion ? local?.name : mismatchingIds?.name) ?? 'Workflow';
 			if (local.name && mismatchingIds?.name && local.name !== mismatchingIds.name) {
 				name = options?.preferLocalVersion

--- a/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
@@ -573,37 +573,37 @@ export class SourceControlService {
 
 		const wfModifiedInEither: SourceControlWorkflowVersionId[] = [];
 
-		wfLocalVersionIds.forEach((local) => {
-			const remoteWorkflowWithSameId = wfRemoteVersionIds.find((remote) => remote.id === local.id);
+		wfLocalVersionIds.forEach((localWorkflow) => {
+			const remoteWorkflowWithSameId = wfRemoteVersionIds.find(
+				(removeWorkflow) => removeWorkflow.id === localWorkflow.id,
+			);
 
 			if (!remoteWorkflowWithSameId) {
 				return;
 			}
 
-			if (isWorkflowModified(local, remoteWorkflowWithSameId)) {
+			if (isWorkflowModified(localWorkflow, remoteWorkflowWithSameId)) {
 				let name =
-					(options?.preferLocalVersion ? local?.name : remoteWorkflowWithSameId?.name) ??
+					(options?.preferLocalVersion ? localWorkflow?.name : remoteWorkflowWithSameId?.name) ??
 					'Workflow';
 				if (
-					local.name &&
+					localWorkflow.name &&
 					remoteWorkflowWithSameId?.name &&
-					local.name !== remoteWorkflowWithSameId.name
+					localWorkflow.name !== remoteWorkflowWithSameId.name
 				) {
 					name = options?.preferLocalVersion
-						? `${local.name} (Remote: ${remoteWorkflowWithSameId.name})`
-						: (name = `${remoteWorkflowWithSameId.name} (Local: ${local.name})`);
+						? `${localWorkflow.name} (Remote: ${remoteWorkflowWithSameId.name})`
+						: (name = `${remoteWorkflowWithSameId.name} (Local: ${localWorkflow.name})`);
 				}
-				if (remoteWorkflowWithSameId) {
-					wfModifiedInEither.push({
-						...local,
-						name,
-						versionId: options.preferLocalVersion
-							? local.versionId
-							: remoteWorkflowWithSameId.versionId,
-						localId: local.versionId,
-						remoteId: remoteWorkflowWithSameId.versionId,
-					});
-				}
+				wfModifiedInEither.push({
+					...localWorkflow,
+					name,
+					versionId: options.preferLocalVersion
+						? localWorkflow.versionId
+						: remoteWorkflowWithSameId.versionId,
+					localId: localWorkflow.versionId,
+					remoteId: remoteWorkflowWithSameId.versionId,
+				});
 			}
 		});
 


### PR DESCRIPTION
## Summary

In the protected branch when pulling for changes and the `parentFolderId` is not present in remote, because user has not pushed to the branch in the non protected instance, do not detect it as a change (workflow modification), and create the workflow in the project root.

This is an edge case and will only happen when you push to the remote repo in a n8n version that does not include folders, then upgrade n8n to a version with folders, and then try to pull the changes in the protected branch.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-2739/workflows-being-detected-as-modified-when-pulling-into-an-environment

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
