### PR TITLE
refactor(editor): Refactor height adjustment method to use ref (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/chat/src/components/Input.vue
+++ b/packages/frontend/@n8n/chat/src/components/Input.vue
@@ -89,7 +89,7 @@ onMounted(() => {
 		resizeObserver.value = new ResizeObserver((entries) => {
 			for (const entry of entries) {
 				if (entry.target === chatTextArea.value) {
-					adjustHeight({ target: chatTextArea.value } as unknown as Event);
+					adjustTextAreaHeight();
 				}
 			}
 		});
@@ -149,7 +149,7 @@ async function onSubmitKeydown(event: KeyboardEvent) {
 	}
 
 	await onSubmit(event);
-	adjustHeight({ target: chatTextArea.value } as unknown as Event);
+	adjustTextAreaHeight();
 }
 
 function onFileRemove(file: File) {
@@ -181,8 +181,9 @@ function onOpenFileDialog() {
 	openFileDialog({ accept: unref(allowedFileTypes) });
 }
 
-function adjustHeight(event: Event) {
-	const textarea = event.target as HTMLTextAreaElement;
+function adjustTextAreaHeight() {
+	const textarea = chatTextArea.value;
+	if (!textarea) return;
 	// Set to content minimum to get the right scrollHeight
 	textarea.style.height = 'var(--chat--textarea--height)';
 	// Get the new height, with a small buffer for padding
@@ -204,9 +205,9 @@ function adjustHeight(event: Event) {
 				:disabled="isInputDisabled"
 				:placeholder="t(props.placeholder)"
 				@keydown.enter="onSubmitKeydown"
-				@input="adjustHeight"
-				@mousedown="adjustHeight"
-				@focus="adjustHeight"
+				@input="adjustTextAreaHeight"
+				@mousedown="adjustTextAreaHeight"
+				@focus="adjustTextAreaHeight"
 			/>
 
 			<div class="chat-inputs-controls">


### PR DESCRIPTION
## Summary

Use ref value when calculating chat text-area height instead of passed event

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
