### PR TITLE
fix(editor): Fix updating of canvas node issue when credential is set-up

### DIFF
--- a/cypress/composables/credentialsComposables.ts
+++ b/cypress/composables/credentialsComposables.ts
@@ -1,3 +1,7 @@
+export function getCredentialsPageUrl() {
+	return '/home/credentials';
+}
+
 export const verifyCredentialsListPageIsLoaded = () => {
 	cy.get('[data-test-id="resources-list-wrapper"], [data-test-id="empty-resources-list"]').should(
 		'be.visible',
@@ -8,3 +12,92 @@ export const loadCredentialsPage = (credentialsPageUrl: string) => {
 	cy.visit(credentialsPageUrl);
 	verifyCredentialsListPageIsLoaded();
 };
+
+/**
+ * Getters - Page
+ */
+
+export function getEmptyListCreateCredentialButton() {
+	return cy.getByTestId('empty-resources-list').find('button');
+}
+
+export function getCredentialCards() {
+	return cy.getByTestId('resources-list-item');
+}
+
+/**
+ * Getters - Modal
+ */
+
+export function getNewCredentialModal() {
+	return cy.getByTestId('selectCredential-modal', { timeout: 5000 });
+}
+
+export function getNewCredentialTypeSelect() {
+	return cy.getByTestId('new-credential-type-select');
+}
+
+export function getNewCredentialTypeOption(credentialType: string) {
+	return cy.getByTestId('new-credential-type-select-option').contains(credentialType);
+}
+
+export function getNewCredentialTypeButton() {
+	return cy.getByTestId('new-credential-type-button');
+}
+
+export function getCredentialConnectionParameterInputs() {
+	return cy.getByTestId('credential-connection-parameter');
+}
+
+export function getConnectionParameter(fieldName: string) {
+	return getCredentialConnectionParameterInputs().find(`:contains('${fieldName}') .n8n-input input`);
+}
+
+export function getCredentialSaveButton() {
+	return cy.getByTestId('credential-save-button', { timeout: 5000 });
+}
+
+/**
+ * Actions - Modal
+ */
+
+export function setCredentialName(name: string) {
+	cy.getByTestId('credential-name').click();
+	cy.getByTestId('credential-name').find('input').clear()
+	cy.getByTestId('credential-name').type(name);
+}
+export function saveCredential() {
+	getCredentialSaveButton()
+		.click({ force: true })
+		.within(() => {
+			cy.get('button').should('not.exist');
+		});
+	getCredentialSaveButton().should('have.text', 'Saved');
+}
+export function saveCredentialWithWait() {
+	cy.intercept('POST', '/rest/credentials').as('saveCredential');
+	saveCredential();
+	cy.wait('@saveCredential');
+	getCredentialSaveButton().should('contain.text', 'Saved');
+}
+
+export function closeNewCredentialModal() {
+	getNewCredentialModal().find('.el-dialog__close').first().click();
+}
+
+export function createNewCredential(type: string, name: string, parameter: string, parameterValue: string, closeModal = true) {
+	getEmptyListCreateCredentialButton().click();
+
+	getNewCredentialModal().should('be.visible');
+	getNewCredentialTypeSelect().should('be.visible');
+	getNewCredentialTypeOption(type).click();
+
+	getNewCredentialTypeButton().click();
+	getConnectionParameter(parameter).type(parameterValue);
+
+	setCredentialName(name);
+	saveCredential();
+	if (closeModal) {
+		close();
+	}
+}

--- a/cypress/composables/credentialsComposables.ts
+++ b/cypress/composables/credentialsComposables.ts
@@ -54,7 +54,9 @@ export function getCredentialConnectionParameterInputs() {
 }
 
 export function getConnectionParameter(fieldName: string) {
-	return getCredentialConnectionParameterInputs().find(`:contains('${fieldName}') .n8n-input input`);
+	return getCredentialConnectionParameterInputs().find(
+		`:contains('${fieldName}') .n8n-input input`,
+	);
 }
 
 export function getCredentialSaveButton() {
@@ -67,7 +69,7 @@ export function getCredentialSaveButton() {
 
 export function setCredentialName(name: string) {
 	cy.getByTestId('credential-name').click();
-	cy.getByTestId('credential-name').find('input').clear()
+	cy.getByTestId('credential-name').find('input').clear();
 	cy.getByTestId('credential-name').type(name);
 }
 export function saveCredential() {
@@ -89,7 +91,13 @@ export function closeNewCredentialModal() {
 	getNewCredentialModal().find('.el-dialog__close').first().click();
 }
 
-export function createNewCredential(type: string, name: string, parameter: string, parameterValue: string, closeModal = true) {
+export function createNewCredential(
+	type: string,
+	name: string,
+	parameter: string,
+	parameterValue: string,
+	closeModal = true,
+) {
 	getEmptyListCreateCredentialButton().click();
 
 	getNewCredentialModal().should('be.visible');

--- a/cypress/composables/credentialsComposables.ts
+++ b/cypress/composables/credentialsComposables.ts
@@ -33,6 +33,10 @@ export function getNewCredentialModal() {
 	return cy.getByTestId('selectCredential-modal', { timeout: 5000 });
 }
 
+export function getEditCredentialModal() {
+	return cy.getByTestId('editCredential-modal', { timeout: 5000 });
+}
+
 export function getNewCredentialTypeSelect() {
 	return cy.getByTestId('new-credential-type-select');
 }
@@ -98,6 +102,6 @@ export function createNewCredential(type: string, name: string, parameter: strin
 	setCredentialName(name);
 	saveCredential();
 	if (closeModal) {
-		close();
+		getEditCredentialModal().find('.el-dialog__close').first().click();
 	}
 }

--- a/cypress/composables/workflow.ts
+++ b/cypress/composables/workflow.ts
@@ -188,6 +188,13 @@ export function getZoomToFitButton() {
 	return cy.getByTestId('zoom-to-fit');
 }
 
+export function getNodeIssuesByName(nodeName: string) {
+	return getCanvasNodes()
+		.filter(`:contains(${nodeName})`)
+		.should('have.length.greaterThan', 0)
+		.findChildByTestId('node-issues');
+}
+
 /**
  * Actions
  */

--- a/cypress/e2e/716-AI-bug-correctly-set-up-agent-model-shows-error.cy.ts
+++ b/cypress/e2e/716-AI-bug-correctly-set-up-agent-model-shows-error.cy.ts
@@ -1,0 +1,23 @@
+import { createNewCredential, getCredentialsPageUrl } from "../composables/credentialsComposables";
+import { addLanguageModelNodeToParent, addNodeToCanvas, getNodeIssuesByName } from "../composables/workflow";
+import { AGENT_NODE_NAME, AI_LANGUAGE_MODEL_OPENAI_CHAT_MODEL_NODE_NAME } from "../constants";
+
+describe('AI-716 Correctly set up agent model shows error', () => {
+	beforeEach(() => {
+		cy.visit(getCredentialsPageUrl());
+		createNewCredential('OpenAi', 'OpenAI Account', 'API Key', 'sk-123', true)
+		cy.visit('/workflow/new');
+	});
+
+	it('should not show error when adding a sub-node with credential set-up', () => {
+		addNodeToCanvas('AI Agent');
+		addLanguageModelNodeToParent(
+			AI_LANGUAGE_MODEL_OPENAI_CHAT_MODEL_NODE_NAME,
+			AGENT_NODE_NAME,
+			true,
+		);
+		cy.get('body').type('{esc}');
+
+		getNodeIssuesByName(AI_LANGUAGE_MODEL_OPENAI_CHAT_MODEL_NODE_NAME).should('have.length', 0);
+	})
+})

--- a/cypress/e2e/716-AI-bug-correctly-set-up-agent-model-shows-error.cy.ts
+++ b/cypress/e2e/716-AI-bug-correctly-set-up-agent-model-shows-error.cy.ts
@@ -1,11 +1,15 @@
-import { createNewCredential, getCredentialsPageUrl } from "../composables/credentialsComposables";
-import { addLanguageModelNodeToParent, addNodeToCanvas, getNodeIssuesByName } from "../composables/workflow";
-import { AGENT_NODE_NAME, AI_LANGUAGE_MODEL_OPENAI_CHAT_MODEL_NODE_NAME } from "../constants";
+import { createNewCredential, getCredentialsPageUrl } from '../composables/credentialsComposables';
+import {
+	addLanguageModelNodeToParent,
+	addNodeToCanvas,
+	getNodeIssuesByName,
+} from '../composables/workflow';
+import { AGENT_NODE_NAME, AI_LANGUAGE_MODEL_OPENAI_CHAT_MODEL_NODE_NAME } from '../constants';
 
 describe('AI-716 Correctly set up agent model shows error', () => {
 	beforeEach(() => {
 		cy.visit(getCredentialsPageUrl());
-		createNewCredential('OpenAi', 'OpenAI Account', 'API Key', 'sk-123', true)
+		createNewCredential('OpenAi', 'OpenAI Account', 'API Key', 'sk-123', true);
 		cy.visit('/workflow/new');
 	});
 
@@ -19,5 +23,5 @@ describe('AI-716 Correctly set up agent model shows error', () => {
 		cy.get('body').type('{esc}');
 
 		getNodeIssuesByName(AI_LANGUAGE_MODEL_OPENAI_CHAT_MODEL_NODE_NAME).should('have.length', 0);
-	})
-})
+	});
+});

--- a/packages/frontend/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/Canvas.vue
@@ -28,6 +28,7 @@ import type {
 	GraphNode,
 	NodeDragEvent,
 	NodeMouseEvent,
+	NodeProps,
 	XYPosition,
 } from '@vue-flow/core';
 import { MarkerType, PanelPosition, useVueFlow, VueFlow } from '@vue-flow/core';
@@ -583,6 +584,17 @@ function onPaneMoveEnd() {
 	isPaneMoving.value = false;
 }
 
+// #AI-716: Due to a bug in vue-flow reactivity, the node data is not updated when the node is added
+// resulting in outdated data. This function is a workaround to get the latest node data.
+function getNodeData<T extends NodeProps>(nodeProps: T): T {
+	const nodeData = props.nodes.find((node) => node.id === nodeProps.id);
+
+	return {
+		...nodeProps,
+		...nodeData,
+	};
+}
+
 /**
  * Context menu
  */
@@ -811,7 +823,7 @@ provide(CanvasKey, {
 		<template #node-canvas-node="nodeProps">
 			<slot name="node" v-bind="{ nodeProps }">
 				<Node
-					v-bind="nodeProps"
+					v-bind="getNodeData(nodeProps)"
 					:read-only="readOnly"
 					:event-bus="eventBus"
 					:hovered="nodesHoveredById[nodeProps.id]"


### PR DESCRIPTION
## Summary

- Fixed reactivity bug in Canvas.vue that was showing errors when properly configured
- Added new Cypress test to verify fix for issue where connected language model nodes showed errors despite having valid credentials
- Migrated credential-related Cypress helpers to functional composables 


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
