### PR TITLE
fix(editor): Allow long links on rendered markdown split to multiple lines

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nMarkdown/Markdown.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMarkdown/Markdown.vue
@@ -289,6 +289,7 @@ input[type='checkbox'] + label {
 
 .sticky {
 	color: var(--color-sticky-font);
+	overflow-wrap: break-word;
 
 	h1,
 	h2,
@@ -360,8 +361,6 @@ input[type='checkbox'] + label {
 	}
 
 	a {
-		word-break: break-word;
-		overflow-wrap: break-word;
 		&:hover {
 			text-decoration: underline;
 		}

--- a/packages/frontend/@n8n/design-system/src/components/N8nMarkdown/Markdown.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMarkdown/Markdown.vue
@@ -360,6 +360,8 @@ input[type='checkbox'] + label {
 	}
 
 	a {
+		word-break: break-word;
+		overflow-wrap: break-word;
 		&:hover {
 			text-decoration: underline;
 		}


### PR DESCRIPTION
## Summary

Before:

![image](https://github.com/user-attachments/assets/939957ce-7268-4ea3-9d1f-eb589b3d02af)

After:

<img width="510" alt="image" src="https://github.com/user-attachments/assets/421b472f-e24c-4557-8905-462272f28586" />

Allow links in rendered markdown to break into multiple lines even if they contain long continuous blocks of text. By default they would only break to multiple lines if there were characters like - or / splitting the links.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3460/bug-no-line-break-on-sticky-note-with-long-link

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
