### PR TITLE
fix(core): Reschedule Insights flushing after skipping for empty buffer

### DIFF
--- a/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
@@ -544,6 +544,29 @@ describe('workflowExecuteAfterHandler - flushEvents', () => {
 		}
 	});
 
+	test('reschedule flush on no buffered insights', async () => {
+		// ARRANGE
+		jest.useFakeTimers();
+		trxMock.insert.mockClear();
+		insightsService.startBackgroundProcess();
+		const flushEventsSpy = jest.spyOn(insightsService, 'flushEvents');
+
+		try {
+			// ACT
+			await jest.advanceTimersByTimeAsync(31 * 1000);
+
+			// ASSERT
+			expect(flushEventsSpy).toHaveBeenCalledTimes(1);
+			expect(trxMock.insert).not.toHaveBeenCalled();
+
+			// ACT
+			await jest.advanceTimersByTimeAsync(31 * 1000);
+			expect(flushEventsSpy).toHaveBeenCalledTimes(2);
+		} finally {
+			jest.useRealTimers();
+		}
+	});
+
 	test('flushes events to the database on shutdown', async () => {
 		// ARRANGE
 		trxMock.insert.mockClear();

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -259,6 +259,8 @@ export class InsightsService {
 	async flushEvents() {
 		// Prevent flushing if there are no events to flush
 		if (this.bufferedInsights.size === 0) {
+			// reschedule the timer to flush again
+			this.startFlushingScheduler();
 			return;
 		}
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Fixes an issue spotted on test instances: if there is no buffered insights on first flushing timer tick, then the flushing timer does not get re-scheduled.
This is especially problematic for new instances (that will have no buffer on first flush timer tick - 30s -, because no active workflows

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
