### PR TITLE
fix(core): Allow `$evaluateExpression` to resolve in task runners

### DIFF
--- a/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
@@ -1504,4 +1504,15 @@ describe('JsTaskRunner', () => {
 			});
 		});
 	});
+
+	describe('expressions', () => {
+		it('should evaluate expressions with $evaluateExpression', async () => {
+			const outcome = await executeForAllItems({
+				code: "return { val: $evaluateExpression('{{ 1 + 1 }}') }",
+				inputItems: [],
+			});
+
+			expect(outcome.result).toEqual([wrapIntoJson({ val: 2 })]);
+		});
+	});
 });

--- a/packages/workflow/src/Expression.ts
+++ b/packages/workflow/src/Expression.ts
@@ -49,17 +49,6 @@ setErrorHandler((error: Error) => {
 	if (isExpressionError(error)) throw error;
 });
 
-const AsyncFunction = (async () => {}).constructor as FunctionConstructor;
-
-const fnConstructors = {
-	sync: Function.prototype.constructor,
-
-	async: AsyncFunction.prototype.constructor,
-	mock: () => {
-		throw new ExpressionError('Arbitrary code execution detected');
-	},
-};
-
 export class Expression {
 	constructor(private readonly workflow: Workflow) {}
 
@@ -217,8 +206,6 @@ export class Expression {
 		data.Reflect = {};
 		data.Proxy = {};
 
-		data.constructor = {};
-
 		// Deprecated
 		data.escape = {};
 		data.unescape = {};
@@ -345,10 +332,6 @@ export class Expression {
 		data: IWorkflowDataProxyData,
 	): tmpl.ReturnValue | undefined {
 		try {
-			[Function, AsyncFunction].forEach(({ prototype }) =>
-				Object.defineProperty(prototype, 'constructor', { value: fnConstructors.mock }),
-			);
-
 			return evaluateExpression(expression, data);
 		} catch (error) {
 			if (isExpressionError(error)) throw error;
@@ -362,11 +345,6 @@ export class Expression {
 
 				throw new ApplicationError(match.groups.msg);
 			}
-		} finally {
-			Object.defineProperty(Function.prototype, 'constructor', { value: fnConstructors.sync });
-			Object.defineProperty(AsyncFunction.prototype, 'constructor', {
-				value: fnConstructors.async,
-			});
 		}
 
 		return null;

--- a/packages/workflow/test/Expression.test.ts
+++ b/packages/workflow/test/Expression.test.ts
@@ -165,15 +165,6 @@ for (const evaluator of ['tmpl', 'tournament'] as const) {
 				expect(evaluate('={{Boolean(1)}}')).toEqual(Boolean(1));
 				expect(evaluate('={{Symbol(1).toString()}}')).toEqual(Symbol(1).toString());
 			});
-
-			it('should not able to do arbitrary code execution', () => {
-				const testFn = jest.fn();
-				Object.assign(global, { testFn });
-				expect(() => evaluate("={{ Date['constructor']('testFn()')()}}")).toThrowError(
-					new ExpressionError('Cannot access "constructor" due to security concerns'),
-				);
-				expect(testFn).not.toHaveBeenCalled();
-			});
 		});
 
 		describe('Test all expression value fixtures', () => {


### PR DESCRIPTION
## Summary

When evaluating an expression, we are protecting against arbitrary code execution by [overriding the constructor](https://github.com/n8n-io/n8n/pull/6420/files#diff-1cf60805861f3e7af58ad0a78cddbc00bb1e0e18308564f989477db6ccbc3357) of the `Function` and `AsyncFunction` prototypes. This errors out in the task runner when it needs to run a script containing `$evaluateExpression` because task runners freeze various prototypes for security.

The constructor override predates the task runner - now that users can run Code nodes via task runners, the above workaround is no longer needed and removing it allows `$evaluateExpression` to work in task runners. Any users concerned about security should switch over to task runners, which will become the default on n8n v2.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-757
#14558

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
