### PR TITLE
fix(editor): Account for `$evaluateExpression` in Codemirror

### DIFF
--- a/packages/frontend/editor-ui/src/plugins/codemirror/typescript/worker/type-declarations/n8n.d.ts
+++ b/packages/frontend/editor-ui/src/plugins/codemirror/typescript/worker/type-declarations/n8n.d.ts
@@ -93,6 +93,7 @@ declare global {
 	function $ifEmpty<V, E>(value: V, valueIfEmpty: E): V | E;
 	function $min(...numbers: number[]): number;
 	function $max(...numbers: number[]): number;
+	function $evaluateExpression(expression: string): any;
 
 	type SomeOtherString = string & NonNullable<unknown>;
 	// @ts-expect-error NodeName is created dynamically


### PR DESCRIPTION
`$evaluateExpression` in a Code node is currently [underlined in red as an error](https://n8nio.slack.com/archives/C03594NKD7W/p1744711639382329) but it works and resolves fine, so users relying on it should be able to see its typings and completions. 

If we ever want to remove this, e.g. in v2, then we should follow the deprecation procedure.