### PR TITLE
feat: Resolve `parentFolder` when retrieving workflow

### DIFF
--- a/packages/cli/src/databases/entities/folder.ts
+++ b/packages/cli/src/databases/entities/folder.ts
@@ -23,7 +23,7 @@ export class Folder extends WithTimestampsAndStringId {
 	@Column()
 	name: string;
 
-	@Column({ nullable: true, select: false })
+	@Column({ nullable: true })
 	parentFolderId: string | null;
 
 	@ManyToOne(() => Folder, { nullable: true, onDelete: 'CASCADE' })

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -296,7 +296,7 @@ export class WorkflowsController {
 				workflowId,
 				req.user,
 				['workflow:read'],
-				{ includeTags: !this.globalConfig.tags.disabled },
+				{ includeTags: !this.globalConfig.tags.disabled, includeParentFolder: true },
 			);
 
 			if (!workflow) {

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -513,6 +513,55 @@ describe('GET /workflows/:workflowId', () => {
 			tags: [expect.objectContaining({ id: tag.id, name: tag.name })],
 		});
 	});
+
+	test.only('should return parent folder', async () => {
+		const personalProject = await projectRepository.getPersonalProjectForUserOrFail(owner.id);
+
+		const folder1 = await createFolder(personalProject, { name: 'Folder 1' });
+
+		const folder2 = await createFolder(personalProject, {
+			name: 'Folder 2',
+			parentFolder: folder1,
+		});
+
+		const workflow1 = await createWorkflow({ parentFolder: folder2 }, owner);
+
+		const workflow2 = await createWorkflow({}, owner);
+
+		const workflow3 = await createWorkflow({ parentFolder: folder1 }, owner);
+
+		const workflowInNestedFolderWithGrantParent = await authOwnerAgent
+			.get(`/workflows/${workflow1.id}`)
+			.expect(200);
+
+		expect(workflowInNestedFolderWithGrantParent.body.data).toMatchObject({
+			parentFolder: expect.objectContaining({
+				id: folder2.id,
+				name: folder2.name,
+				parentFolderId: folder1.id,
+			}),
+		});
+
+		const workflowInProjectRoot = await authOwnerAgent
+			.get(`/workflows/${workflow2.id}`)
+			.expect(200);
+
+		expect(workflowInProjectRoot.body.data).toMatchObject({
+			parentFolder: null,
+		});
+
+		const workflowInNestedFolder = await authOwnerAgent
+			.get(`/workflows/${workflow3.id}`)
+			.expect(200);
+
+		expect(workflowInNestedFolder.body.data).toMatchObject({
+			parentFolder: expect.objectContaining({
+				id: folder1.id,
+				name: folder1.name,
+				parentFolderId: null,
+			}),
+		});
+	});
 });
 
 describe('GET /workflows', () => {

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -514,7 +514,7 @@ describe('GET /workflows/:workflowId', () => {
 		});
 	});
 
-	test.only('should return parent folder', async () => {
+	test('should return parent folder', async () => {
 		const personalProject = await projectRepository.getPersonalProjectForUserOrFail(owner.id);
 
 		const folder1 = await createFolder(personalProject, { name: 'Folder 1' });


### PR DESCRIPTION
## Summary

Title self explanatory.  Needed to be able to add the folder breadcrumbs in the workflow editor

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3465/update-endpoint-that-return-workflow-to-also-include-the-folder

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
