### PR TITLE
fix: Unit test fails due to missing document (no-changelog)

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,8 @@
       "@types/ws@8.5.4": "patches/@types__ws@8.5.4.patch",
       "@types/uuencode@0.0.3": "patches/@types__uuencode@0.0.3.patch",
       "vue-tsc@2.2.8": "patches/vue-tsc@2.2.8.patch",
-      "eslint-plugin-n8n-local-rules": "patches/eslint-plugin-n8n-local-rules.patch"
+      "eslint-plugin-n8n-local-rules": "patches/eslint-plugin-n8n-local-rules.patch",
+      "element-plus@2.4.3": "patches/element-plus@2.4.3.patch"
     }
   }
 }

--- a/patches/element-plus@2.4.3.patch
+++ b/patches/element-plus@2.4.3.patch
@@ -1,0 +1,26 @@
+diff --git a/es/hooks/use-lockscreen/index.mjs b/es/hooks/use-lockscreen/index.mjs
+index 482516a6c59f8dcf0caba62b7482f63f126c2280..ad3a62f956fe5672c318273aa69dfcf2576b3783 100644
+--- a/es/hooks/use-lockscreen/index.mjs
++++ b/es/hooks/use-lockscreen/index.mjs
+@@ -20,6 +20,8 @@ const useLockscreen = (trigger, options = {}) => {
+   let withoutHiddenClass = false;
+   let bodyWidth = "0";
+   const cleanup = () => {
++		// Cherry-pick from https://github.com/element-plus/element-plus/pull/18445
++    if (typeof document === 'undefined') return
+     setTimeout(() => {
+       removeClass(document == null ? void 0 : document.body, hiddenCls.value);
+       if (withoutHiddenClass && document) {
+diff --git a/lib/hooks/use-lockscreen/index.js b/lib/hooks/use-lockscreen/index.js
+index ce7bd581a57cd0d7e834c42a954b48d148578ef5..42fcc50bc15a12ab8466a1294c5af2e65384d5ac 100644
+--- a/lib/hooks/use-lockscreen/index.js
++++ b/lib/hooks/use-lockscreen/index.js
+@@ -24,6 +24,8 @@ const useLockscreen = (trigger, options = {}) => {
+   let withoutHiddenClass = false;
+   let bodyWidth = "0";
+   const cleanup = () => {
++		// Cherry-pick from https://github.com/element-plus/element-plus/pull/18445
++    if (typeof document === 'undefined') return
+     setTimeout(() => {
+       style.removeClass(document == null ? void 0 : document.body, hiddenCls.value);
+       if (withoutHiddenClass && document) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,9 @@ patchedDependencies:
   bull@4.12.1:
     hash: 4b8aae78debc54697a9106a44b1a949089d4facfeee057883e32116ab8c80f68
     path: patches/bull@4.12.1.patch
+  element-plus@2.4.3:
+    hash: fe650d17e32d13a07f54411f2ee552a8faeae20d92ef5e5a23424d590ba4a382
+    path: patches/element-plus@2.4.3.patch
   eslint-plugin-n8n-local-rules:
     hash: e0fd59254ab02473c6940fa25fcc8102ebc7d371c015ec53333a43f48af33cc2
     path: patches/eslint-plugin-n8n-local-rules.patch
@@ -1547,7 +1550,7 @@ importers:
         version: 10.11.0(vue@3.5.13(typescript@5.8.2))
       element-plus:
         specifier: catalog:frontend
-        version: 2.4.3(vue@3.5.13(typescript@5.8.2))
+        version: 2.4.3(patch_hash=fe650d17e32d13a07f54411f2ee552a8faeae20d92ef5e5a23424d590ba4a382)(vue@3.5.13(typescript@5.8.2))
       is-emoji-supported:
         specifier: ^0.0.5
         version: 0.0.5
@@ -1791,7 +1794,7 @@ importers:
         version: 3.0.3
       element-plus:
         specifier: catalog:frontend
-        version: 2.4.3(vue@3.5.13(typescript@5.8.2))
+        version: 2.4.3(patch_hash=fe650d17e32d13a07f54411f2ee552a8faeae20d92ef5e5a23424d590ba4a382)(vue@3.5.13(typescript@5.8.2))
       email-providers:
         specifier: ^2.0.1
         version: 2.0.1
@@ -21398,7 +21401,7 @@ snapshots:
 
   electron-to-chromium@1.5.114: {}
 
-  element-plus@2.4.3(vue@3.5.13(typescript@5.8.2)):
+  element-plus@2.4.3(patch_hash=fe650d17e32d13a07f54411f2ee552a8faeae20d92ef5e5a23424d590ba4a382)(vue@3.5.13(typescript@5.8.2)):
     dependencies:
       '@ctrl/tinycolor': 3.6.0
       '@element-plus/icons-vue': 2.3.1(vue@3.5.13(typescript@5.8.2))


### PR DESCRIPTION
## Summary

This PR fixes a unit test failure with uncaught exception below in CI that happens occasionally.
```
⎯⎯⎯⎯⎯ Uncaught Exception ⎯⎯⎯⎯⎯
ReferenceError: document is not defined
 ❯ Timeout._onTimeout ../../../node_modules/.pnpm/element-plus@2.4.3_vue@3.5.13_typescript@5.8.2_/packages/hooks/use-lockscreen/index.ts:27:19
 ❯ listOnTimeout node:internal/timers:581:17
 ❯ processTimers node:internal/timers:519:7

This error originated in "src/components/ChangePasswordModal.test.ts" test file. It doesn't mean the error was thrown inside the file itself, but while it was running.
This error was caught after test environment was torn down. Make sure to cancel any running tasks before test finishes:
- cancel timeouts using clearTimeout and clearInterval
- wait for promises to resolve using the await keyword
```

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
