### PR TITLE
refactor(core): Provide clearer errors on task runner rejection

### DIFF
--- a/packages/@n8n/task-runner/src/task-runner.ts
+++ b/packages/@n8n/task-runner/src/task-runner.ts
@@ -281,7 +281,7 @@ export abstract class TaskRunner extends EventEmitter {
 			this.send({
 				type: 'runner:taskrejected',
 				taskId,
-				reason: 'Offer expired - broker too slow to accept',
+				reason: 'Offer expired - not accepted within validity window',
 			});
 			return;
 		} else {

--- a/packages/@n8n/task-runner/src/task-runner.ts
+++ b/packages/@n8n/task-runner/src/task-runner.ts
@@ -258,17 +258,20 @@ export abstract class TaskRunner extends EventEmitter {
 		request.resolve(nodeTypes);
 	}
 
-	hasOpenTasks() {
+	/**
+	 * Whether the task runner has capacity to accept more tasks.
+	 */
+	hasOpenTaskSlots() {
 		return this.runningTasks.size < this.maxConcurrency;
 	}
 
 	offerAccepted(offerId: string, taskId: string) {
-		if (!this.hasOpenTasks()) {
+		if (!this.hasOpenTaskSlots()) {
 			this.openOffers.delete(offerId);
 			this.send({
 				type: 'runner:taskrejected',
 				taskId,
-				reason: 'No open task slots',
+				reason: 'No open task slots - runner already at capacity',
 			});
 			return;
 		}
@@ -278,7 +281,7 @@ export abstract class TaskRunner extends EventEmitter {
 			this.send({
 				type: 'runner:taskrejected',
 				taskId,
-				reason: 'Offer expired and no open task slots',
+				reason: 'Offer expired - broker too slow to accept',
 			});
 			return;
 		} else {


### PR DESCRIPTION
Error messages when a task runner rejects a task are not entirely clear (and in one case, it is half incorrect).