### PR TITLE
feat(HTTP Request Node): Replace custom httpRequest tool with tool version of standalone HttpRequest Node

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/ToolHttpRequest.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/ToolHttpRequest.node.ts
@@ -63,6 +63,8 @@ export class ToolHttpRequest implements INodeType {
 				],
 			},
 		},
+		// Replaced by a `usableAsTool` version of the standalone HttpRequest node
+		hidden: true,
 		// eslint-disable-next-line n8n-nodes-base/node-class-description-inputs-wrong-regular-node
 		inputs: [],
 		// eslint-disable-next-line n8n-nodes-base/node-class-description-outputs-wrong

--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -71,6 +71,15 @@ export class HttpRequestV3 implements INodeType {
 					},
 				},
 			],
+			usableAsTool: {
+				replacements: {
+					codex: {
+						subcategories: {
+							Tools: ['Recommended Tools'],
+						},
+					},
+				},
+			},
 			properties: mainProperties,
 		};
 	}

--- a/packages/nodes-base/nodes/HttpRequest/shared/optimizeResponse.ts
+++ b/packages/nodes-base/nodes/HttpRequest/shared/optimizeResponse.ts
@@ -151,7 +151,18 @@ const jsonOptimizer = (ctx: IExecuteFunctions, itemIndex: number): ResponseOptim
 
 		if (!Array.isArray(responseData)) {
 			if (dataField) {
+				if (!responseData.hasOwnProperty(dataField)) {
+					throw new NodeOperationError(
+						ctx.getNode(),
+						`Target field "${dataField}" not found in response`,
+						{
+							itemIndex,
+						},
+					);
+				}
+
 				const data = responseData[dataField] as IDataObject | IDataObject[];
+
 				if (Array.isArray(data)) {
 					responseData = data;
 				} else {

--- a/packages/nodes-base/nodes/HttpRequest/shared/optimizeResponse.ts
+++ b/packages/nodes-base/nodes/HttpRequest/shared/optimizeResponse.ts
@@ -151,7 +151,7 @@ const jsonOptimizer = (ctx: IExecuteFunctions, itemIndex: number): ResponseOptim
 
 		if (!Array.isArray(responseData)) {
 			if (dataField) {
-				if (!responseData.hasOwnProperty(dataField)) {
+				if (!Object.prototype.hasOwnProperty.call(responseData, dataField)) {
 					throw new NodeOperationError(
 						ctx.getNode(),
 						`Target field "${dataField}" not found in response`,

--- a/packages/nodes-base/nodes/HttpRequest/shared/optimizeResponse.ts
+++ b/packages/nodes-base/nodes/HttpRequest/shared/optimizeResponse.ts
@@ -154,9 +154,10 @@ const jsonOptimizer = (ctx: IExecuteFunctions, itemIndex: number): ResponseOptim
 				if (!Object.prototype.hasOwnProperty.call(responseData, dataField)) {
 					throw new NodeOperationError(
 						ctx.getNode(),
-						`Target field "${dataField}" not found in response`,
+						`Target field "${dataField}" not found in response.`,
 						{
 							itemIndex,
+							description: `The response contained these fields: [${Object.keys(responseData).join(', ')}]`,
 						},
 					);
 				}


### PR DESCRIPTION
## Summary

Replace the existing tool with a `usableAsTool` version of the standalone node.

Also include a quick fix when the JSON optimization has a non-existing field. The custom tool would previously return `null` in these cases, but I feel an explicit error is preferred. Happy to match existing behavior though.

With the change we get back this error if the key is missing:

<img width="1096" alt="image" src="https://github.com/user-attachments/assets/56cf60fc-734b-4412-a0d8-2ca11620179d" />

rather than succeeding and returning `[null]` as the previous custom tool did.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3304/feature-port-optimizeresponse-to-standalone-httprequest-node


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
