### PR TITLE
fix(Postgres Node): Fix inserting `null` or `undefined` in `type=json` columns

### DIFF
--- a/packages/nodes-base/nodes/Postgres/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/helpers/utils.ts
@@ -414,7 +414,10 @@ export function convertValuesToJsonWithPgp(
 	values: IDataObject,
 ) {
 	schema
-		.filter(({ data_type }: { data_type: string }) => data_type === 'json')
+		.filter(
+			({ data_type, column_name }) =>
+				data_type === 'json' && values[column_name] !== null && values[column_name] !== undefined,
+		)
 		.forEach(({ column_name }) => {
 			values[column_name] = pgp.as.json(values[column_name], true);
 		});


### PR DESCRIPTION
## Summary

When inserting or updating a row in postgres with a column of type json, users are unable to insert null or undefined. This was possible in earlier versions.

Error:
> Values null/undefined cannot be used as raw text

This was broken in [this PR](https://github.com/n8n-io/n8n/pull/12452) in [n8n@1.74.0](https://github.com/n8n-io/n8n/releases/tag/n8n%401.74.0)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2864/cannot-insert-null-or-undefined-into-postrgres-json-columns
related to #13490

https://community.n8n.io/t/postgres-node-issuse-after-update/72421

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
