### PR TITLE
fix(editor): Fix expanding schema items with same names on NDV

### DIFF
--- a/packages/frontend/editor-ui/src/composables/useDataSchema.ts
+++ b/packages/frontend/editor-ui/src/composables/useDataSchema.ts
@@ -380,7 +380,7 @@ export const useFlattenSchema = () => {
 
 		const expression = `{{ ${expressionPrefix ? expressionPrefix + schema.path : schema.path.slice(1)} }}`;
 
-		const id = expression;
+		const id = `${nodeName}-${expression}`;
 
 		if (Array.isArray(schema.value)) {
 			const items: Renders[] = [];


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/4b04af3b-c74d-4a0a-aec2-f623c5b9a473

This PR fixes expanding the items on NDV schema view if there are multiple inputs to the node containing a field with the same name. Prior to this PR this was broken, as the DynamicScroller component we use expects unique IDs on each item, and the expression on both of these items is the same (`{{ $json.test }}` here in this example).

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/ADO-3426/duplicate-key-name-disappears-in-node-input-panel

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
