### PR TITLE
Feat: allow overriding base URL for Anthropic credentials

### DIFF
--- a/packages/@n8n/nodes-langchain/credentials/AnthropicApi.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/AnthropicApi.credentials.ts
@@ -21,6 +21,13 @@ export class AnthropicApi implements ICredentialType {
 			required: true,
 			default: '',
 		},
+		{
+			displayName: 'Base URL',
+			name: 'url',
+			type: 'string',
+			default: 'https://api.anthropic.com',
+			description: 'Override the default base URL for the API',
+		},
 	];
 
 	authenticate: IAuthenticateGeneric = {
@@ -34,7 +41,7 @@ export class AnthropicApi implements ICredentialType {
 
 	test: ICredentialTestRequest = {
 		request: {
-			baseURL: 'https://api.anthropic.com',
+			baseURL: '={{$credentials?.url}}',
 			url: '/v1/messages',
 			method: 'POST',
 			headers: {


### PR DESCRIPTION
## Summary

This PR updates the `AnthropicApi` credential type to support overriding the default base URL (`https://api.anthropic.com`). This change mirrors the existing flexibility of the `OpenAiApi` credential, allowing users to specify a custom endpoint.

This is particularly useful for testing against mock environments or using enterprise proxies.

### How to test
1. Go to **Credentials** > **Anthropic** in n8n.
2. Enter a custom Base URL (e.g., pointing to a mock server).
3. Use the “Test” button to verify that the test request is sent to the provided endpoint.

No visual changes in the UI other than the added field.

---

## Related Linear tickets, Github issues, and Community forum posts

N/A – improvement identified internally for consistency with existing OpenAI credential functionality.

---

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([[conventions](https://chatgpt.com/blob/master/.github/pull_request_title_conventions.md)](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [[Docs updated](https://github.com/n8n-io/n8n-docs)](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

---

Let me know if there's a Linear ticket you want to include or if you want help writing a test for this.