### PR TITLE
fix(editor): Restrict what binary-data types can be viewed in the UI

### DIFF
--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -12,6 +12,7 @@ export { createHeartbeatMessage, heartbeatMessageSchema } from './push/heartbeat
 export type { SendWorkerStatusMessage } from './push/worker';
 
 export type { BannerName } from './schemas/bannerName.schema';
+export { ViewableMimeTypes } from './schemas/binaryData.schema';
 export { passwordSchema } from './schemas/password.schema';
 
 export type {

--- a/packages/@n8n/api-types/src/schemas/binaryData.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/binaryData.schema.ts
@@ -1,0 +1,32 @@
+/**
+ * List of MIME types that are considered safe to be viewed directly in a browser.
+ *
+ * Explicitly excluded from this list:
+ * - 'text/html': Excluded due to high XSS risks, as HTML can execute arbitrary JavaScript
+ * - 'image/svg+xml': Excluded because SVG can contain embedded JavaScript that might execute in certain contexts
+ * - 'application/pdf': Excluded due to potential arbitrary code-execution vulnerabilities in PDF rendering engines
+ */
+export const ViewableMimeTypes = [
+	'application/json',
+
+	'audio/mpeg',
+	'audio/ogg',
+	'audio/wav',
+
+	'image/bmp',
+	'image/gif',
+	'image/jpeg',
+	'image/jpg',
+	'image/png',
+	'image/tiff',
+	'image/webp',
+
+	'text/css',
+	'text/csv',
+	'text/markdown',
+	'text/plain',
+
+	'video/mp4',
+	'video/ogg',
+	'video/webm',
+];

--- a/packages/cli/src/controllers/__tests__/binary-data.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/binary-data.controller.test.ts
@@ -121,12 +121,12 @@ describe('BinaryDataController', () => {
 			expect(response.setHeader).not.toHaveBeenCalled();
 		});
 
-		it('should allow viewing of jpeg files', async () => {
+		it('should allow viewing of jpeg files, and handle mime-type casing', async () => {
 			const query = {
 				id: 'filesystem:123',
 				action: 'view',
 				fileName: 'test.jpg',
-				mimeType: 'image/jpeg',
+				mimeType: 'image/Jpeg',
 			} as BinaryDataQueryDto;
 
 			binaryDataService.getAsStream.mockResolvedValue(mock());

--- a/packages/cli/src/controllers/__tests__/binary-data.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/binary-data.controller.test.ts
@@ -39,7 +39,11 @@ describe('BinaryDataController', () => {
 		});
 
 		it('should return 404 if file is not found', async () => {
-			const query = { id: 'filesystem:123', action: 'view' } as BinaryDataQueryDto;
+			const query = {
+				id: 'filesystem:123',
+				action: 'view',
+				mimeType: 'image/jpeg',
+			} as BinaryDataQueryDto;
 			binaryDataService.getAsStream.mockRejectedValue(new FileNotFoundError('File not found'));
 
 			await controller.get(request, response, query);
@@ -60,7 +64,7 @@ describe('BinaryDataController', () => {
 
 			await controller.get(request, response, query);
 
-			expect(binaryDataService.getMetadata).not.toHaveBeenCalled();
+			expect(binaryDataService.getMetadata).toHaveBeenCalledWith(query.id);
 			expect(response.setHeader).toHaveBeenCalledWith('Content-Type', 'text/plain');
 			expect(response.setHeader).not.toHaveBeenCalledWith('Content-Length');
 			expect(response.setHeader).not.toHaveBeenCalledWith('Content-Disposition');
@@ -101,7 +105,7 @@ describe('BinaryDataController', () => {
 			);
 		});
 
-		it('should set Content-Security-Policy for HTML in view mode', async () => {
+		it('should not allow viewing of html files', async () => {
 			const query = {
 				id: 'filesystem:123',
 				action: 'view',
@@ -113,26 +117,32 @@ describe('BinaryDataController', () => {
 
 			await controller.get(request, response, query);
 
-			expect(response.header).toHaveBeenCalledWith('Content-Security-Policy', 'sandbox');
+			expect(response.status).toHaveBeenCalledWith(400);
+			expect(response.setHeader).not.toHaveBeenCalled();
 		});
 
-		it('should not set Content-Security-Policy for HTML in download mode', async () => {
+		it('should allow viewing of jpeg files', async () => {
 			const query = {
 				id: 'filesystem:123',
-				action: 'download',
-				fileName: 'test.html',
-				mimeType: 'text/html',
+				action: 'view',
+				fileName: 'test.jpg',
+				mimeType: 'image/jpeg',
 			} as BinaryDataQueryDto;
 
 			binaryDataService.getAsStream.mockResolvedValue(mock());
 
 			await controller.get(request, response, query);
 
-			expect(response.header).not.toHaveBeenCalledWith('Content-Security-Policy', 'sandbox');
+			expect(response.status).not.toHaveBeenCalledWith(400);
+			expect(response.setHeader).toHaveBeenCalledWith('Content-Type', query.mimeType);
 		});
 
 		it('should return the file stream on success', async () => {
-			const query = { id: 'filesystem:123', action: 'view' } as BinaryDataQueryDto;
+			const query = {
+				id: 'filesystem:123',
+				action: 'view',
+				mimeType: 'image/jpeg',
+			} as BinaryDataQueryDto;
 
 			const stream = mock<Readable>();
 			binaryDataService.getAsStream.mockResolvedValue(stream);

--- a/packages/cli/src/controllers/binary-data.controller.ts
+++ b/packages/cli/src/controllers/binary-data.controller.ts
@@ -64,14 +64,12 @@ export class BinaryDataController {
 		fileName?: string,
 		mimeType?: string,
 	) {
-		if (!fileName || !mimeType) {
-			try {
-				const metadata = await this.binaryDataService.getMetadata(binaryDataId);
-				fileName = metadata.fileName;
-				mimeType = metadata.mimeType;
-				res.setHeader('Content-Length', metadata.fileSize);
-			} catch {}
-		}
+		try {
+			const metadata = await this.binaryDataService.getMetadata(binaryDataId);
+			fileName = metadata.fileName ?? fileName;
+			mimeType = metadata.mimeType ?? mimeType;
+			res.setHeader('Content-Length', metadata.fileSize);
+		} catch {}
 
 		if (mimeType) {
 			res.setHeader('Content-Type', mimeType);

--- a/packages/cli/src/controllers/binary-data.controller.ts
+++ b/packages/cli/src/controllers/binary-data.controller.ts
@@ -1,4 +1,4 @@
-import { BinaryDataQueryDto, BinaryDataSignedQueryDto } from '@n8n/api-types';
+import { BinaryDataQueryDto, BinaryDataSignedQueryDto, ViewableMimeTypes } from '@n8n/api-types';
 import { Request, Response } from 'express';
 import { JsonWebTokenError } from 'jsonwebtoken';
 import { BinaryDataService, FileNotFoundError, isValidNonDefaultMode } from 'n8n-core';
@@ -75,11 +75,10 @@ export class BinaryDataController {
 
 		if (mimeType) {
 			res.setHeader('Content-Type', mimeType);
+		}
 
-			// Sandbox html files when viewed in a browser
-			if (mimeType.includes('html') && action === 'view') {
-				res.header('Content-Security-Policy', 'sandbox');
-			}
+		if (action === 'view' && (!mimeType || !ViewableMimeTypes.includes(mimeType))) {
+			throw new BadRequestError('Content not viewable');
 		}
 
 		if (action === 'download' && fileName) {

--- a/packages/cli/src/controllers/binary-data.controller.ts
+++ b/packages/cli/src/controllers/binary-data.controller.ts
@@ -71,12 +71,12 @@ export class BinaryDataController {
 			res.setHeader('Content-Length', metadata.fileSize);
 		} catch {}
 
-		if (mimeType) {
-			res.setHeader('Content-Type', mimeType);
-		}
-
 		if (action === 'view' && (!mimeType || !ViewableMimeTypes.includes(mimeType))) {
 			throw new BadRequestError('Content not viewable');
+		}
+
+		if (mimeType) {
+			res.setHeader('Content-Type', mimeType);
 		}
 
 		if (action === 'download' && fileName) {

--- a/packages/cli/src/controllers/binary-data.controller.ts
+++ b/packages/cli/src/controllers/binary-data.controller.ts
@@ -71,7 +71,7 @@ export class BinaryDataController {
 			res.setHeader('Content-Length', metadata.fileSize);
 		} catch {}
 
-		if (action === 'view' && (!mimeType || !ViewableMimeTypes.includes(mimeType))) {
+		if (action === 'view' && (!mimeType || !ViewableMimeTypes.includes(mimeType.toLowerCase()))) {
 			throw new BadRequestError('Content not viewable');
 		}
 

--- a/packages/frontend/editor-ui/src/components/RunData.test.ts
+++ b/packages/frontend/editor-ui/src/components/RunData.test.ts
@@ -117,8 +117,8 @@ describe('RunData', () => {
 		expect(getByText('Json data 1')).toBeInTheDocument();
 	});
 
-	it('should render view and download buttons for PDFs', async () => {
-		const { getByTestId } = render({
+	it('should render only download buttons for PDFs', async () => {
+		const { getByTestId, queryByTestId } = render({
 			defaultRunItems: [
 				{
 					json: {},
@@ -127,6 +127,31 @@ describe('RunData', () => {
 							fileName: 'test.pdf',
 							fileType: 'pdf',
 							mimeType: 'application/pdf',
+							data: '',
+						},
+					},
+				},
+			],
+			displayMode: 'binary',
+		});
+
+		await waitFor(() => {
+			expect(queryByTestId('ndv-view-binary-data')).not.toBeInTheDocument();
+			expect(getByTestId('ndv-download-binary-data')).toBeInTheDocument();
+			expect(getByTestId('ndv-binary-data_0')).toBeInTheDocument();
+		});
+	});
+
+	it('should render view and download buttons for JPEGs', async () => {
+		const { getByTestId } = render({
+			defaultRunItems: [
+				{
+					json: {},
+					binary: {
+						data: {
+							fileName: 'test.jpg',
+							fileType: 'image',
+							mimeType: 'image/jpeg',
 							data: '',
 						},
 					},

--- a/packages/frontend/editor-ui/src/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/components/RunData.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ViewableMimeTypes } from '@n8n/api-types';
 import { useStorage } from '@/composables/useStorage';
 import { saveAs } from 'file-saver';
 import type {
@@ -1182,10 +1183,8 @@ function closeBinaryDataDisplay() {
 }
 
 function isViewable(index: number, key: string | number): boolean {
-	const { fileType } = binaryData.value[index][key];
-	return (
-		!!fileType && ['image', 'audio', 'video', 'text', 'json', 'pdf', 'html'].includes(fileType)
-	);
+	const { mimeType } = binaryData.value[index][key];
+	return ViewableMimeTypes.includes(mimeType);
 }
 
 function isDownloadable(index: number, key: string | number): boolean {


### PR DESCRIPTION
## Summary
We tried preventing XSS from viewable binary-data in #14350, but that doesn't seem to always work.
So, now are maintaining an explicit allow-list of mime-types that we permit as viewable in the UI.

## Related Linear tickets, Github issues, and Community forum posts
[SEC-244](https://linear.app/n8n/issue/SEC-244)


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
