### PR TITLE
fix(core): Prefer triggers with run data during partial executions

### DIFF
--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -394,7 +394,7 @@ export class WorkflowExecute {
 		}
 
 		// 1. Find the Trigger
-		const trigger = findTriggerForPartialExecution(workflow, destinationNodeName);
+		const trigger = findTriggerForPartialExecution(workflow, destinationNodeName, runData);
 		if (trigger === undefined) {
 			throw new UserError('Connect a trigger to run this node');
 		}


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

The trigger-choosing logic was always preferring triggers based on pinned data and in what order they have been added, but with the addition of the test workflow button per trigger it makes sense to prioritize the trigger that has run data instead.

**before**:

https://github.com/user-attachments/assets/9892633e-fd3a-44a8-b214-172e1de49e89

**after:**:

https://github.com/user-attachments/assets/99411fa4-2b90-4c62-9f6b-f13071483941

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

https://linear.app/n8n/issue/PAY-2756/bug-partial-exec-uses-wrong-trigger#comment-9e57102f

<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
