### PR TITLE
feat(GoogleChat): Add message reply option to request parameters

### DIFF
--- a/packages/nodes-base/nodes/Google/Chat/GoogleChat.node.ts
+++ b/packages/nodes-base/nodes/Google/Chat/GoogleChat.node.ts
@@ -403,6 +403,9 @@ export class GoogleChat implements INodeType {
 						if (additionalFields.requestId) {
 							qs.requestId = additionalFields.requestId;
 						}
+						if (additionalFields.messageReplyOption) {
+							qs.messageReplyOption = additionalFields.messageReplyOption;
+						}
 
 						let message: IMessage = {};
 						const jsonParameters = this.getNodeParameter('jsonParameters', i);

--- a/packages/nodes-base/nodes/Google/Chat/descriptions/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Google/Chat/descriptions/MessageDescription.ts
@@ -216,6 +216,14 @@ export const messageFields: INodeProperties[] = [
 				description:
 					'A unique request ID for this message. If a message has already been created in the space with this request ID, the subsequent request will return the existing message and no new message will be created.',
 			},
+			{
+				displayName: 'Message Reply Option',
+				name: 'messageReplyOption',
+				type: 'string',
+				default: '',
+				description:
+					'Optional. Specifies whether a message starts a thread or replies to one. Only supported in named spaces. When responding to user interactions, this field is ignored. For interactions within a thread, the reply is created in the same thread. Otherwise, the reply is created as a new thread.',
+			},
 		],
 	},
 

--- a/packages/nodes-base/nodes/Google/Chat/descriptions/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Google/Chat/descriptions/MessageDescription.ts
@@ -219,10 +219,31 @@ export const messageFields: INodeProperties[] = [
 			{
 				displayName: 'Message Reply Option',
 				name: 'messageReplyOption',
-				type: 'string',
-				default: '',
+				type: 'options',
+				noDataExpression: true,
+				default: 'MESSAGE_REPLY_OPTION_UNSPECIFIED',
 				description:
 					'Optional. Specifies whether a message starts a thread or replies to one. Only supported in named spaces. When responding to user interactions, this field is ignored. For interactions within a thread, the reply is created in the same thread. Otherwise, the reply is created as a new thread.',
+				options: [
+					{
+						name: 'MESSAGE_REPLY_OPTION_UNSPECIFIED',
+						value: 'MESSAGE_REPLY_OPTION_UNSPECIFIED',
+						description:
+							"Default. Starts a new thread. Using this option ignores any thread ID or threadKey that's included.",
+					},
+					{
+						name: 'REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD',
+						value: 'REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD',
+						description:
+							'Creates the message as a reply to the thread specified by thread ID or threadKey. If it fails, the message starts a new thread instead.',
+					},
+					{
+						name: 'REPLY_MESSAGE_OR_FAIL',
+						value: 'REPLY_MESSAGE_OR_FAIL',
+						description:
+							'Creates the message as a reply to the thread specified by thread ID or threadKey. If a new threadKey is used, a new thread is created. If the message creation fails, a NOT_FOUND error is returned instead.',
+					},
+				],
 			},
 		],
 	},


### PR DESCRIPTION
## Summary

This PR adds support for the `messageReplyOption` parameter to the **Google Chat > Create Message** node in the n8n workflow editor.

The `messageReplyOption` field allows developers to specify how the created message should behave when replied to in a threaded conversation. This enables more granular control over thread behaviors such as replying in an existing thread, starting a new thread, or leaving the behavior unspecified.

### How to test

1. Go to the **Google Chat > Create Message** node in n8n.
2. A new optional field `messageReplyOption` should be available under **Additional Fields**.
3. Set this field to one of the supported values: `REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD`, `REPLY_MESSAGE`, or `NEW_THREAD`.
4. Execute the workflow and verify that the message is posted with the correct threading behavior in the target Google Chat space.

No visual UI changes were introduced apart from the additional input field.

## Related Linear tickets, Github issues, and Community forum posts

- Fixes #<issue-number> <!-- Replace with actual issue number if available -->
- Community Forum: [Add `messageReplyOption` to Google Chat node](<insert-link-if-any>)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)