### PR TITLE
fix(Wait Node): Validate datetime for specific time mode

### DIFF
--- a/packages/nodes-base/nodes/Wait/Wait.node.ts
+++ b/packages/nodes-base/nodes/Wait/Wait.node.ts
@@ -506,7 +506,15 @@ export class Wait extends Webhook {
 			// a number of seconds added to the current timestamp
 			waitTill = new Date(new Date().getTime() + waitAmount);
 		} else {
-			const dateTimeStr = context.getNodeParameter('dateTime', 0) as string;
+			const dateTimeStrRaw = context.getNodeParameter('dateTime', 0);
+			const dateTimeStr =
+				dateTimeStrRaw instanceof Date
+					? dateTimeStrRaw.toISOString()
+					: dateTimeStrRaw instanceof DateTime
+						? dateTimeStrRaw.toISO()
+						: typeof 'string' === dateTimeStrRaw
+							? dateTimeStrRaw
+							: 'invalid';
 
 			if (isNaN(Date.parse(dateTimeStr))) {
 				throw new NodeOperationError(

--- a/packages/nodes-base/nodes/Wait/Wait.node.ts
+++ b/packages/nodes-base/nodes/Wait/Wait.node.ts
@@ -508,9 +508,9 @@ export class Wait extends Webhook {
 		} else {
 			try {
 				const dateTimeStrRaw = context.getNodeParameter('dateTime', 0);
-				const parsedDateTime = tryToParseDateTime(dateTimeStrRaw);
+				const parsedDateTime = tryToParseDateTime(dateTimeStrRaw, context.getTimezone());
 
-				waitTill = parsedDateTime.setZone(context.getTimezone()).toUTC().toJSDate();
+				waitTill = parsedDateTime.toUTC().toJSDate();
 			} catch (e) {
 				throw new NodeOperationError(
 					context.getNode(),

--- a/packages/nodes-base/nodes/Wait/Wait.node.ts
+++ b/packages/nodes-base/nodes/Wait/Wait.node.ts
@@ -1,4 +1,3 @@
-import { DateTime } from 'luxon';
 import type {
 	IExecuteFunctions,
 	INodeExecutionData,
@@ -8,10 +7,11 @@ import type {
 	IWebhookFunctions,
 } from 'n8n-workflow';
 import {
-	NodeOperationError,
 	NodeConnectionTypes,
 	WAIT_INDEFINITELY,
 	FORM_TRIGGER_NODE_TYPE,
+	tryToParseDateTime,
+	NodeOperationError,
 } from 'n8n-workflow';
 
 import { updateDisplayOptions } from '../../utils/utilities';
@@ -506,28 +506,17 @@ export class Wait extends Webhook {
 			// a number of seconds added to the current timestamp
 			waitTill = new Date(new Date().getTime() + waitAmount);
 		} else {
-			const dateTimeStrRaw = context.getNodeParameter('dateTime', 0);
-			const dateTimeStr =
-				dateTimeStrRaw instanceof Date
-					? dateTimeStrRaw.toISOString()
-					: dateTimeStrRaw instanceof DateTime
-						? dateTimeStrRaw.toISO()
-						: typeof 'string' === dateTimeStrRaw
-							? dateTimeStrRaw
-							: 'invalid';
+			try {
+				const dateTimeStrRaw = context.getNodeParameter('dateTime', 0);
+				const parsedDateTime = tryToParseDateTime(dateTimeStrRaw);
 
-			if (isNaN(Date.parse(dateTimeStr))) {
+				waitTill = parsedDateTime.setZone(context.getTimezone()).toUTC().toJSDate();
+			} catch (e) {
 				throw new NodeOperationError(
 					context.getNode(),
 					'[Wait node] Cannot put execution to wait because `dateTime` parameter is not a valid date. Please pick a specific date and time to wait until.',
 				);
 			}
-
-			waitTill = DateTime.fromFormat(dateTimeStr, "yyyy-MM-dd'T'HH:mm:ss", {
-				zone: context.getTimezone(),
-			})
-				.toUTC()
-				.toJSDate();
 		}
 
 		const waitValue = Math.max(waitTill.getTime() - new Date().getTime(), 0);

--- a/packages/nodes-base/nodes/Wait/test/Wait.node.test.ts
+++ b/packages/nodes-base/nodes/Wait/test/Wait.node.test.ts
@@ -1,9 +1,11 @@
+import { mock } from 'jest-mock-extended';
 import { DateTime } from 'luxon';
 import { NodeOperationError, type IExecuteFunctions } from 'n8n-workflow';
 
-import { testWorkflows, getWorkflowFilenames } from '@test/nodes/Helpers';
+import { getWorkflowFilenames, testWorkflows } from '@test/nodes/Helpers';
 
 import { Wait } from '../Wait.node';
+
 const workflows = getWorkflowFilenames(__dirname);
 
 describe('Execute Wait Node', () => {
@@ -20,30 +22,52 @@ describe('Execute Wait Node', () => {
 		jest.useRealTimers();
 	});
 
-	test.each<{ value: Date | DateTime | string; isValid: boolean }>([
+	test.each([
 		{ value: 'invalid_date', isValid: false },
-		{ value: DateTime.now().plus({ days: 1 }).toISO(), isValid: true },
-		{ value: DateTime.now().plus({ days: 1 }).toJSDate(), isValid: true },
-		{ value: DateTime.now().plus({ days: 1 }), isValid: true },
-	])('Test Wait Node with specificTime $value and isValid $isValid', async ({ value, isValid }) => {
-		const waitNode = new Wait();
-		const executeFunctionsMock: IExecuteFunctions = {
-			getNodeParameter: jest.fn().mockImplementation((paramName: string) => {
-				if (paramName === 'resume') return 'specificTime';
-				if (paramName === 'dateTime') return value;
-			}),
-			getTimezone: jest.fn().mockReturnValue('UTC'),
-			putExecutionToWait: jest.fn(),
-			getInputData: jest.fn(),
-			getNode: jest.fn(),
-		} as unknown as IExecuteFunctions;
+		{
+			value: '2025-04-18T10:50:47.560',
+			isValid: true,
+			expectedWaitTill: new Date('2025-04-18T10:50:47.560Z'),
+		},
+		{
+			value: '2025-04-18T10:50:47.560+02:00',
+			isValid: true,
+			expectedWaitTill: new Date('2025-04-18T08:50:47.560Z'),
+		},
+		{
+			value: DateTime.fromISO('2025-04-18T10:50:47.560Z').toJSDate(),
+			isValid: true,
+			expectedWaitTill: new Date('2025-04-18T10:50:47.560Z'),
+		},
+		{
+			value: DateTime.fromISO('2025-04-18T10:50:47.560Z'),
+			isValid: true,
+			expectedWaitTill: new Date('2025-04-18T10:50:47.560Z'),
+		},
+	])(
+		'Test Wait Node with specificTime $value and isValid $isValid',
+		async ({ value, isValid, expectedWaitTill }) => {
+			const putExecutionToWaitSpy = jest.fn();
+			const waitNode = new Wait();
+			const executeFunctionsMock = mock<IExecuteFunctions>({
+				getNodeParameter: jest.fn().mockImplementation((paramName: string) => {
+					if (paramName === 'resume') return 'specificTime';
+					if (paramName === 'dateTime') return value;
+				}),
+				getTimezone: jest.fn().mockReturnValue('UTC'),
+				putExecutionToWait: putExecutionToWaitSpy,
+				getInputData: jest.fn(),
+				getNode: jest.fn(),
+			});
 
-		if (isValid) {
-			await expect(waitNode.execute(executeFunctionsMock)).resolves.not.toThrow();
-		} else {
-			await expect(waitNode.execute(executeFunctionsMock)).rejects.toThrow(NodeOperationError);
-		}
-	});
+			if (isValid) {
+				await expect(waitNode.execute(executeFunctionsMock)).resolves.not.toThrow();
+				expect(putExecutionToWaitSpy).toHaveBeenCalledWith(expectedWaitTill);
+			} else {
+				await expect(waitNode.execute(executeFunctionsMock)).rejects.toThrow(NodeOperationError);
+			}
+		},
+	);
 
 	testWorkflows(workflows);
 });

--- a/packages/nodes-base/nodes/Wait/test/Wait.node.test.ts
+++ b/packages/nodes-base/nodes/Wait/test/Wait.node.test.ts
@@ -1,4 +1,9 @@
+import { DateTime } from 'luxon';
+import { NodeOperationError, type IExecuteFunctions } from 'n8n-workflow';
+
 import { testWorkflows, getWorkflowFilenames } from '@test/nodes/Helpers';
+
+import { Wait } from '../Wait.node';
 const workflows = getWorkflowFilenames(__dirname);
 
 describe('Execute Wait Node', () => {
@@ -13,6 +18,31 @@ describe('Execute Wait Node', () => {
 	afterAll(() => {
 		clearInterval(timer);
 		jest.useRealTimers();
+	});
+
+	test.each<{ value: Date | DateTime | string; isValid: boolean }>([
+		{ value: 'invalid_date', isValid: false },
+		{ value: DateTime.now().plus({ days: 1 }).toISO(), isValid: true },
+		{ value: DateTime.now().plus({ days: 1 }).toJSDate(), isValid: true },
+		{ value: DateTime.now().plus({ days: 1 }), isValid: true },
+	])('Test Wait Node with specificTime $value and isValid $isValid', async ({ value, isValid }) => {
+		const waitNode = new Wait();
+		const executeFunctionsMock: IExecuteFunctions = {
+			getNodeParameter: jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'resume') return 'specificTime';
+				if (paramName === 'dateTime') return value;
+			}),
+			getTimezone: jest.fn().mockReturnValue('UTC'),
+			putExecutionToWait: jest.fn(),
+			getInputData: jest.fn(),
+			getNode: jest.fn(),
+		} as unknown as IExecuteFunctions;
+
+		if (isValid) {
+			await expect(waitNode.execute(executeFunctionsMock)).resolves.not.toThrow();
+		} else {
+			await expect(waitNode.execute(executeFunctionsMock)).rejects.toThrow(NodeOperationError);
+		}
 	});
 
 	testWorkflows(workflows);

--- a/packages/workflow/src/TypeValidation.ts
+++ b/packages/workflow/src/TypeValidation.ts
@@ -1,6 +1,5 @@
 import isObject from 'lodash/isObject';
-import type { Zone } from 'luxon';
-import { DateTime, Settings } from 'luxon';
+import { DateTime } from 'luxon';
 
 import { ApplicationError } from './errors';
 import type {
@@ -68,10 +67,8 @@ export const tryToParseBoolean = (value: unknown): value is boolean => {
 
 export const tryToParseDateTime = (value: unknown, defaultZone?: string): DateTime => {
 	if (DateTime.isDateTime(value) && value.isValid) {
-		// Heuristic: overwrite the zone only if the value zone if the system default
-		// because we consider it not intentional
-		if (defaultZone && value.zone.equals(Settings.defaultZone as Zone))
-			return value.setZone(defaultZone, { keepLocalTime: true });
+		// Ignore the defaultZone if the value is already a DateTime
+		// because DateTime objects already contain the zone information
 		return value;
 	}
 

--- a/packages/workflow/src/TypeValidation.ts
+++ b/packages/workflow/src/TypeValidation.ts
@@ -1,5 +1,6 @@
 import isObject from 'lodash/isObject';
-import { DateTime } from 'luxon';
+import type { Zone } from 'luxon';
+import { DateTime, Settings } from 'luxon';
 
 import { ApplicationError } from './errors';
 import type {
@@ -67,7 +68,10 @@ export const tryToParseBoolean = (value: unknown): value is boolean => {
 
 export const tryToParseDateTime = (value: unknown, defaultZone?: string): DateTime => {
 	if (DateTime.isDateTime(value) && value.isValid) {
-		if (defaultZone) return value.setZone(defaultZone);
+		// Heuristic: overwrite the zone only if the value zone if the system default
+		// because we consider it not intentional
+		if (defaultZone && value.zone.equals(Settings.defaultZone as Zone))
+			return value.setZone(defaultZone, { keepLocalTime: true });
 		return value;
 	}
 

--- a/packages/workflow/src/TypeValidation.ts
+++ b/packages/workflow/src/TypeValidation.ts
@@ -65,13 +65,14 @@ export const tryToParseBoolean = (value: unknown): value is boolean => {
 	});
 };
 
-export const tryToParseDateTime = (value: unknown): DateTime => {
-	if (value instanceof DateTime && value.isValid) {
+export const tryToParseDateTime = (value: unknown, defaultZone?: string): DateTime => {
+	if (DateTime.isDateTime(value) && value.isValid) {
+		if (defaultZone) return value.setZone(defaultZone);
 		return value;
 	}
 
 	if (value instanceof Date) {
-		const fromJSDate = DateTime.fromJSDate(value);
+		const fromJSDate = DateTime.fromJSDate(value, { zone: defaultZone });
 		if (fromJSDate.isValid) {
 			return fromJSDate;
 		}
@@ -80,24 +81,24 @@ export const tryToParseDateTime = (value: unknown): DateTime => {
 	const dateString = String(value).trim();
 
 	// Rely on luxon to parse different date formats
-	const isoDate = DateTime.fromISO(dateString, { setZone: true });
+	const isoDate = DateTime.fromISO(dateString, { zone: defaultZone, setZone: true });
 	if (isoDate.isValid) {
 		return isoDate;
 	}
-	const httpDate = DateTime.fromHTTP(dateString, { setZone: true });
+	const httpDate = DateTime.fromHTTP(dateString, { zone: defaultZone, setZone: true });
 	if (httpDate.isValid) {
 		return httpDate;
 	}
-	const rfc2822Date = DateTime.fromRFC2822(dateString, { setZone: true });
+	const rfc2822Date = DateTime.fromRFC2822(dateString, { zone: defaultZone, setZone: true });
 	if (rfc2822Date.isValid) {
 		return rfc2822Date;
 	}
-	const sqlDate = DateTime.fromSQL(dateString, { setZone: true });
+	const sqlDate = DateTime.fromSQL(dateString, { zone: defaultZone, setZone: true });
 	if (sqlDate.isValid) {
 		return sqlDate;
 	}
 
-	const parsedDateTime = DateTime.fromMillis(Date.parse(dateString));
+	const parsedDateTime = DateTime.fromMillis(Date.parse(dateString), { zone: defaultZone });
 	if (parsedDateTime.isValid) {
 		return parsedDateTime;
 	}

--- a/packages/workflow/test/TypeValidation.test.ts
+++ b/packages/workflow/test/TypeValidation.test.ts
@@ -1,4 +1,4 @@
-import { DateTime, Settings, Zone } from 'luxon';
+import { DateTime, Settings } from 'luxon';
 
 import { getValueDescription, tryToParseDateTime, validateFieldType } from '@/TypeValidation';
 
@@ -299,15 +299,6 @@ describe('Type Validation', () => {
 
 			expect(result.zoneName).toEqual('UTC-4');
 			expect(result.toISO()).toEqual('2025-04-17T06:22:20.000-04:00');
-
-			// if luxon datetime is created with a zone different from settings defaultZone, it should not be changed
-			const resultDatetime = tryToParseDateTime(
-				DateTime.fromObject({ year: 2025, month: 1, day: 1 }, { zone: 'Asia/Tokyo' }),
-				'America/New_York',
-			);
-
-			expect(resultDatetime.zoneName).toEqual('Asia/Tokyo');
-			expect(resultDatetime.toISO()).toEqual('2025-01-01T00:00:00.000+09:00');
 		});
 
 		it('should use defaultZone if timezone is not set', () => {
@@ -315,15 +306,6 @@ describe('Type Validation', () => {
 
 			expect(result.zoneName).toEqual('Europe/Brussels');
 			expect(result.toISO()).toEqual('2025-04-17T06:22:20.000+02:00');
-
-			// if luxon datetime is created with the default settings defaultZone, it should be changed
-			const resultDatetime = tryToParseDateTime(
-				DateTime.fromObject({ year: 2025, month: 1, day: 1 }),
-				'America/New_York',
-			);
-
-			expect(resultDatetime.zoneName).toEqual('America/New_York');
-			expect(resultDatetime.toISO()).toEqual('2025-01-01T00:00:00.000-05:00');
 		});
 
 		it('should use the system timezone when defaultZone arg is not given', () => {
@@ -332,6 +314,17 @@ describe('Type Validation', () => {
 
 			expect(result.zoneName).toEqual('UTC-7');
 			expect(result.toISO()).toEqual('2025-04-17T06:22:20.000-07:00');
+		});
+
+		it('should not impact DateTime zone', () => {
+			const dateTime = DateTime.fromObject(
+				{ year: 2025, month: 1, day: 1 },
+				{ zone: 'Asia/Tokyo' },
+			);
+			const result = tryToParseDateTime(dateTime, 'Europe/Brussels');
+
+			expect(result.zoneName).toEqual('Asia/Tokyo');
+			expect(result.toISO()).toEqual('2025-01-01T00:00:00.000+09:00');
 		});
 	});
 });

--- a/packages/workflow/test/TypeValidation.test.ts
+++ b/packages/workflow/test/TypeValidation.test.ts
@@ -1,4 +1,4 @@
-import { DateTime, Settings } from 'luxon';
+import { DateTime, Settings, Zone } from 'luxon';
 
 import { getValueDescription, tryToParseDateTime, validateFieldType } from '@/TypeValidation';
 
@@ -299,6 +299,15 @@ describe('Type Validation', () => {
 
 			expect(result.zoneName).toEqual('UTC-4');
 			expect(result.toISO()).toEqual('2025-04-17T06:22:20.000-04:00');
+
+			// if luxon datetime is created with a zone different from settings defaultZone, it should not be changed
+			const resultDatetime = tryToParseDateTime(
+				DateTime.fromObject({ year: 2025, month: 1, day: 1 }, { zone: 'Asia/Tokyo' }),
+				'America/New_York',
+			);
+
+			expect(resultDatetime.zoneName).toEqual('Asia/Tokyo');
+			expect(resultDatetime.toISO()).toEqual('2025-01-01T00:00:00.000+09:00');
 		});
 
 		it('should use defaultZone if timezone is not set', () => {
@@ -306,6 +315,15 @@ describe('Type Validation', () => {
 
 			expect(result.zoneName).toEqual('Europe/Brussels');
 			expect(result.toISO()).toEqual('2025-04-17T06:22:20.000+02:00');
+
+			// if luxon datetime is created with the default settings defaultZone, it should be changed
+			const resultDatetime = tryToParseDateTime(
+				DateTime.fromObject({ year: 2025, month: 1, day: 1 }),
+				'America/New_York',
+			);
+
+			expect(resultDatetime.zoneName).toEqual('America/New_York');
+			expect(resultDatetime.toISO()).toEqual('2025-01-01T00:00:00.000-05:00');
 		});
 
 		it('should use the system timezone when defaultZone arg is not given', () => {

--- a/packages/workflow/test/TypeValidation.test.ts
+++ b/packages/workflow/test/TypeValidation.test.ts
@@ -1,6 +1,6 @@
-import { DateTime } from 'luxon';
+import { DateTime, Settings } from 'luxon';
 
-import { getValueDescription, validateFieldType } from '@/TypeValidation';
+import { getValueDescription, tryToParseDateTime, validateFieldType } from '@/TypeValidation';
 
 describe('Type Validation', () => {
 	describe('Dates', () => {
@@ -290,6 +290,30 @@ describe('Type Validation', () => {
 			expect(getValueDescription(undefined)).toBe("'undefined'");
 			expect(getValueDescription([{}])).toBe('array');
 			expect(getValueDescription({})).toBe('object');
+		});
+	});
+
+	describe('tryToParseDateTime', () => {
+		it('should NOT use defaultZone if set', () => {
+			const result = tryToParseDateTime('2025-04-17T06:22:20-04:00', 'Europe/Brussels');
+
+			expect(result.zoneName).toEqual('UTC-4');
+			expect(result.toISO()).toEqual('2025-04-17T06:22:20.000-04:00');
+		});
+
+		it('should use defaultZone if timezone is not set', () => {
+			const result = tryToParseDateTime('2025-04-17T06:22:20', 'Europe/Brussels');
+
+			expect(result.zoneName).toEqual('Europe/Brussels');
+			expect(result.toISO()).toEqual('2025-04-17T06:22:20.000+02:00');
+		});
+
+		it('should use the system timezone when defaultZone arg is not given', () => {
+			Settings.defaultZone = 'UTC-7';
+			const result = tryToParseDateTime('2025-04-17T06:22:20');
+
+			expect(result.zoneName).toEqual('UTC-7');
+			expect(result.toISO()).toEqual('2025-04-17T06:22:20.000-07:00');
 		});
 	});
 });


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
Curently, the wait node accepts invalid date time (using express for instance) when using specificTime resume property. This leads to unclear error on test, and side effect on run (as described in the ticket linked).
This PR proposes to validate that the specific time value can be parsed as a datetime when executing the node.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
https://linear.app/n8n/issue/PAY-2757/scary-fake-excecutions


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
