### PR TITLE
fix(HubSpot Node): Include item index in error messages

### DIFF
--- a/packages/nodes-base/nodes/Hubspot/V2/HubspotV2.node.ts
+++ b/packages/nodes-base/nodes/Hubspot/V2/HubspotV2.node.ts
@@ -1671,7 +1671,11 @@ export class HubspotV2 implements INodeType {
 								}
 								//@ts-ignore
 								if (body.filterGroups.length > 3) {
-									throw new NodeOperationError(this.getNode(), 'You can only have 3 filter groups');
+									throw new NodeOperationError(
+										this.getNode(),
+										'You can only have 3 filter groups',
+										{ itemIndex: i },
+									);
 								}
 							}
 
@@ -2566,7 +2570,11 @@ export class HubspotV2 implements INodeType {
 								}
 								//@ts-ignore
 								if (body.filterGroups.length > 3) {
-									throw new NodeOperationError(this.getNode(), 'You can only have 3 filter groups');
+									throw new NodeOperationError(
+										this.getNode(),
+										'You can only have 3 filter groups',
+										{ itemIndex: i },
+									);
 								}
 							}
 

--- a/packages/nodes-base/nodes/Hubspot/__test__/Hubspot.node.test.ts
+++ b/packages/nodes-base/nodes/Hubspot/__test__/Hubspot.node.test.ts
@@ -7,6 +7,8 @@ import companies from './fixtures/companies.json';
 import companiesSearchResult from './fixtures/companies_search_result.json';
 import contacts from './fixtures/contacts.json';
 import contactsSearchResult from './fixtures/contacts_search_result.json';
+import deals from './fixtures/deals.json';
+import dealsSearchResult from './fixtures/deals_search_result.json';
 
 describe('Hubspot Node', () => {
 	nock.disableNetConnect();
@@ -209,6 +211,53 @@ describe('Hubspot Node', () => {
 		});
 
 		testWorkflows(['nodes/Hubspot/__test__/contacts.workflow.json']);
+
+		it('should make the correct network calls', () => {
+			hubspotNock.done();
+		});
+	});
+
+	describe('deals', () => {
+		beforeAll(() => {
+			hubspotNock
+				.delete('/deals/v1/deal/123', {})
+				.reply(200, deals.deals[0])
+				.post('/deals/v1/deal', {
+					properties: [
+						{ name: 'dealstage', value: 'test stage name' },
+						{ name: 'dealname', value: 'Test Deal' },
+						{ name: 'closedate', value: 1744848000000 },
+						{ name: 'amount', value: '100' },
+						{ name: 'pipeline', value: 'test pipeline name' },
+						{ name: 'description', value: 'Test Deal Desc' },
+						{ name: 'test_custom_prop_name', value: 'test custom prop value' },
+					],
+					associations: {},
+				})
+				.reply(200, deals.deals[0])
+				.put('/deals/v1/deal/123')
+				.reply(200, deals.deals[0])
+				.get('/deals/v1/deal/paged?includeAssociations=true&limit=2')
+				.reply(200, deals)
+				.get(
+					'/deals/v1/deal/recent/created?since=1745193600000&includePropertyVersions=true&count=2',
+				)
+				.reply(200, { results: deals.deals })
+				.get('/deals/v1/deal/123')
+				.reply(200, deals.deals[0])
+				.post('/crm/v3/objects/deals/search', {
+					sorts: [{ propertyName: 'createdate', direction: 'ASCENDING' }],
+					filterGroups: [
+						{ filters: [{ propertyName: 'name', operator: 'EQ', value: 'Test Deal Name' }] },
+					],
+					direction: 'ASCENDING',
+					sortBy: 'createdate',
+					limit: 2,
+				})
+				.reply(200, dealsSearchResult);
+		});
+
+		testWorkflows(['nodes/Hubspot/__test__/deals.workflow.json']);
 
 		it('should make the correct network calls', () => {
 			hubspotNock.done();

--- a/packages/nodes-base/nodes/Hubspot/__test__/Hubspot.node.test.ts
+++ b/packages/nodes-base/nodes/Hubspot/__test__/Hubspot.node.test.ts
@@ -1,0 +1,217 @@
+/* eslint-disable n8n-nodes-base/node-param-display-name-miscased */
+import nock from 'nock';
+
+import { testWorkflows } from '@test/nodes/Helpers';
+
+import companies from './fixtures/companies.json';
+import companiesSearchResult from './fixtures/companies_search_result.json';
+import contacts from './fixtures/contacts.json';
+import contactsSearchResult from './fixtures/contacts_search_result.json';
+
+describe('Hubspot Node', () => {
+	nock.disableNetConnect();
+
+	const hubspotNock = nock('https://api.hubapi.com');
+
+	describe('companies', () => {
+		beforeAll(() => {
+			hubspotNock
+				.delete('/crm/v3/objects/companies/123', {})
+				.reply(200, companies.companies[0])
+				.post('/companies/v2/companies', {
+					properties: [
+						{
+							name: 'name',
+							value: 'test',
+						},
+						{
+							name: 'about_us',
+							value: 'test about us',
+						},
+						{
+							name: 'annualrevenue',
+							value: '123',
+						},
+						{
+							name: 'city',
+							value: 'Gent',
+						},
+						{
+							name: 'closedate',
+							value: 1744848000000,
+						},
+						{
+							name: 'domain',
+							value: 'example.com',
+						},
+						{
+							name: 'hubspot_owner_id',
+							value: '123',
+						},
+						{
+							name: 'country',
+							value: 'Belgium',
+						},
+						{
+							name: 'description',
+							value: 'test description',
+						},
+						{
+							name: 'is_public',
+							value: true,
+						},
+						{
+							name: 'zip',
+							value: '9000',
+						},
+						{
+							name: 'twitterhandle',
+							value: 'x',
+						},
+						{
+							name: 'website',
+							value: 'example.com',
+						},
+						{
+							name: 'founded_year',
+							value: '2000',
+						},
+						{
+							name: 'test_custom_prop_name',
+							value: 'test custom prop value',
+						},
+					],
+				})
+				.reply(200, companies.companies[0])
+				.put('/companies/v2/companies/123', {
+					properties: [
+						{
+							name: 'about_us',
+							value: 'test about us',
+						},
+						{
+							name: 'city',
+							value: 'Gent',
+						},
+					],
+				})
+				.reply(200, companies.companies[0])
+				.post('/companies/v2/domains/n8n.io/companies', { requestOptions: {}, limit: 100 })
+				.reply(200, companiesSearchResult)
+				.get('/companies/v2/companies/paged')
+				.query(
+					'properties=name&properties=description&properties=country&propertyMode=value_and_history&limit=2',
+				)
+				.reply(200, companies)
+				.get('/companies/v2/companies/recent/modified')
+				.query('since=1744243200000&count=2')
+				.reply(200, { results: companies.companies })
+				.get('/companies/v2/companies/123')
+				.reply(200, companies.companies[0]);
+		});
+
+		testWorkflows(['nodes/Hubspot/__test__/companies.workflow.json']);
+
+		it('should make the correct network calls', () => {
+			hubspotNock.done();
+		});
+	});
+
+	describe('contacts', () => {
+		beforeAll(() => {
+			hubspotNock
+				.delete('/contacts/v1/contact/vid/123', {})
+				.reply(200, contacts.contacts[0])
+				.post('/contacts/v1/contact/createOrUpdate/email/elias@n8n.io', {
+					properties: [
+						{
+							property: 'annualrevenue',
+							value: '123',
+						},
+						{
+							property: 'city',
+							value: 'Gent',
+						},
+						{
+							property: 'closedate',
+							value: 1744848000000,
+						},
+						{
+							property: 'firstname',
+							value: 'Elias',
+						},
+						{
+							property: 'zip',
+							value: '9000',
+						},
+						{
+							property: 'website',
+							value: 'example.com',
+						},
+						{
+							property: 'work_email',
+							value: 'elias@n8n.io',
+						},
+						{
+							property: 'test_custom_prop_name',
+							value: 'test custom prop value',
+						},
+					],
+				})
+				.reply(200, contacts.contacts[0])
+				.put('/crm-associations/v1/associations/create-batch')
+				.reply(200, {})
+				.post('/crm/v3/objects/contacts/search', {
+					sorts: [
+						{
+							propertyName: 'createdate',
+							direction: 'ASCENDING',
+						},
+					],
+					filterGroups: [
+						{
+							filters: [
+								{
+									propertyName: 'firstname',
+									operator: 'EQ',
+									value: 'Elias',
+								},
+								{
+									propertyName: 'lastname',
+									operator: 'EQ',
+									value: 'Meire',
+								},
+							],
+						},
+						{
+							filters: [
+								{
+									propertyName: 'email',
+									operator: 'CONTAINS_TOKEN',
+									value: 'n8n.io',
+								},
+							],
+						},
+					],
+					direction: 'ASCENDING',
+					limit: 2,
+				})
+				.reply(200, contactsSearchResult)
+				.get('/contacts/v1/lists/all/contacts/all?count=2')
+				.reply(200, contacts)
+				.get('/contacts/v1/lists/recently_updated/contacts/recent?count=2')
+				.reply(200, contacts)
+				.get('/contacts/v1/contact/vid/204727/profile')
+				.reply(200, contacts.contacts[0])
+				.get('/contacts/v1/contact/vid/123/profile')
+				.query('formSubmissionMode=newest&showListMemberships=true')
+				.reply(200, contacts.contacts[0]);
+		});
+
+		testWorkflows(['nodes/Hubspot/__test__/contacts.workflow.json']);
+
+		it('should make the correct network calls', () => {
+			hubspotNock.done();
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Hubspot/__test__/companies.workflow.json
+++ b/packages/nodes-base/nodes/Hubspot/__test__/companies.workflow.json
@@ -1,0 +1,734 @@
+{
+	"name": "Hubspot Companies",
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [-400, 480],
+			"id": "b126b31f-c64f-472f-98ed-6ab9f0eb4e52",
+			"name": "When clicking ‘Test workflow’"
+		},
+		{
+			"parameters": {
+				"resource": "company",
+				"operation": "delete",
+				"companyId": {
+					"__rl": true,
+					"value": "123",
+					"mode": "id"
+				}
+			},
+			"type": "n8n-nodes-base.hubspot",
+			"typeVersion": 2.1,
+			"position": [-180, -120],
+			"id": "7262d6df-23f4-425e-94c2-6ce67d1bc138",
+			"name": "HubSpot - Company - Delete",
+			"credentials": {
+				"hubspotApi": {
+					"id": "EDJsHUkhqof5gr15",
+					"name": "HubSpot account"
+				}
+			}
+		},
+		{
+			"parameters": {
+				"resource": "company",
+				"name": "test",
+				"additionalFields": {
+					"aboutUs": "test about us",
+					"annualRevenue": 123,
+					"city": "Gent",
+					"closeDate": "2025-04-17T00:00:00",
+					"companyDomainName": "example.com",
+					"companyOwner": "=123",
+					"countryRegion": "Belgium",
+					"customPropertiesUi": {
+						"customPropertiesValues": [
+							{
+								"property": "=test_custom_prop_name",
+								"value": "test custom prop value"
+							}
+						]
+					},
+					"description": "test description",
+					"isPublic": true,
+					"postalCode": "9000",
+					"twitterHandle": "x",
+					"websiteUrl": "example.com",
+					"yearFounded": "2000"
+				}
+			},
+			"type": "n8n-nodes-base.hubspot",
+			"typeVersion": 2.1,
+			"position": [-180, 80],
+			"id": "2827f172-451b-4bab-bd91-36a2d0bc7013",
+			"name": "HubSpot - Company - Create",
+			"credentials": {
+				"hubspotApi": {
+					"id": "EDJsHUkhqof5gr15",
+					"name": "HubSpot account"
+				}
+			}
+		},
+		{
+			"parameters": {
+				"resource": "company",
+				"operation": "get",
+				"companyId": {
+					"__rl": true,
+					"value": "123",
+					"mode": "id"
+				},
+				"additionalFields": {}
+			},
+			"type": "n8n-nodes-base.hubspot",
+			"typeVersion": 2.1,
+			"position": [-180, 480],
+			"id": "efbb6c5a-5061-4c6f-82a3-ae388f9e7690",
+			"name": "HubSpot - Company - Get",
+			"credentials": {
+				"hubspotApi": {
+					"id": "EDJsHUkhqof5gr15",
+					"name": "HubSpot account"
+				}
+			}
+		},
+		{
+			"parameters": {
+				"resource": "company",
+				"operation": "getAll",
+				"limit": 2,
+				"options": {
+					"includeMergeAudits": true,
+					"propertiesCollection": {
+						"propertiesValues": {
+							"properties": "={{ ['name', 'description', 'country'] }}"
+						}
+					}
+				}
+			},
+			"type": "n8n-nodes-base.hubspot",
+			"typeVersion": 2.1,
+			"position": [-180, 680],
+			"id": "dc51cf19-947d-41d6-b2d2-908796039dc6",
+			"name": "HubSpot - Company - Get Many",
+			"credentials": {
+				"hubspotApi": {
+					"id": "EDJsHUkhqof5gr15",
+					"name": "HubSpot account"
+				}
+			}
+		},
+		{
+			"parameters": {
+				"resource": "company",
+				"operation": "getRecentlyCreatedUpdated",
+				"limit": 2,
+				"additionalFields": {
+					"since": "2025-04-10T00:00:00"
+				}
+			},
+			"type": "n8n-nodes-base.hubspot",
+			"typeVersion": 2.1,
+			"position": [-180, 880],
+			"id": "af703bd7-ec3f-426e-a903-96d67410ee44",
+			"name": "HubSpot - Company - Get Recently Updated",
+			"credentials": {
+				"hubspotApi": {
+					"id": "EDJsHUkhqof5gr15",
+					"name": "HubSpot account"
+				}
+			}
+		},
+		{
+			"parameters": {
+				"resource": "company",
+				"operation": "searchByDomain",
+				"domain": "n8n.io",
+				"options": {}
+			},
+			"type": "n8n-nodes-base.hubspot",
+			"typeVersion": 2.1,
+			"position": [-180, 1080],
+			"id": "43db81bf-9f5f-4458-bd8f-c36c7162e53b",
+			"name": "HubSpot - Company - Search",
+			"credentials": {
+				"hubspotApi": {
+					"id": "EDJsHUkhqof5gr15",
+					"name": "HubSpot account"
+				}
+			}
+		},
+		{
+			"parameters": {
+				"resource": "company",
+				"operation": "update",
+				"companyId": {
+					"__rl": true,
+					"value": "=123",
+					"mode": "id"
+				},
+				"updateFields": {
+					"aboutUs": "test about us",
+					"city": "Gent"
+				}
+			},
+			"type": "n8n-nodes-base.hubspot",
+			"typeVersion": 2.1,
+			"position": [-180, 280],
+			"id": "6c5c0be3-53ad-4eae-a535-6b19448fefb6",
+			"name": "HubSpot - Company - Update",
+			"credentials": {
+				"hubspotApi": {
+					"id": "EDJsHUkhqof5gr15",
+					"name": "HubSpot account"
+				}
+			}
+		}
+	],
+	"pinData": {
+		"HubSpot - Company - Create": [
+			{
+				"json": {
+					"additionalDomains": [],
+					"companyId": 115200636,
+					"isDeleted": false,
+					"portalId": 62515,
+					"properties": {
+						"name": {
+							"source": "BIDEN",
+							"sourceId": "name",
+							"timestamp": 1464484587592,
+							"value": "Example Company",
+							"versions": [
+								{
+									"name": "name",
+									"source": "BIDEN",
+									"sourceId": "name",
+									"sourceVid": [],
+									"timestamp": 1464484587592,
+									"value": "Example Company"
+								}
+							]
+						},
+						"website": {
+							"source": "COMPANIES",
+							"sourceId": null,
+							"timestamp": 1457513066540,
+							"value": "example.com",
+							"versions": [
+								{
+									"name": "website",
+									"source": "COMPANIES",
+									"sourceVid": [],
+									"timestamp": 1457513066540,
+									"value": "example.com"
+								}
+							]
+						}
+					}
+				}
+			}
+		],
+		"HubSpot - Company - Delete": [
+			{
+				"json": {
+					"additionalDomains": [],
+					"companyId": 115200636,
+					"isDeleted": false,
+					"portalId": 62515,
+					"properties": {
+						"name": {
+							"source": "BIDEN",
+							"sourceId": "name",
+							"timestamp": 1464484587592,
+							"value": "Example Company",
+							"versions": [
+								{
+									"name": "name",
+									"source": "BIDEN",
+									"sourceId": "name",
+									"sourceVid": [],
+									"timestamp": 1464484587592,
+									"value": "Example Company"
+								}
+							]
+						},
+						"website": {
+							"source": "COMPANIES",
+							"sourceId": null,
+							"timestamp": 1457513066540,
+							"value": "example.com",
+							"versions": [
+								{
+									"name": "website",
+									"source": "COMPANIES",
+									"sourceVid": [],
+									"timestamp": 1457513066540,
+									"value": "example.com"
+								}
+							]
+						}
+					}
+				}
+			}
+		],
+		"HubSpot - Company - Update": [
+			{
+				"json": {
+					"additionalDomains": [],
+					"companyId": 115200636,
+					"isDeleted": false,
+					"portalId": 62515,
+					"properties": {
+						"name": {
+							"source": "BIDEN",
+							"sourceId": "name",
+							"timestamp": 1464484587592,
+							"value": "Example Company",
+							"versions": [
+								{
+									"name": "name",
+									"source": "BIDEN",
+									"sourceId": "name",
+									"sourceVid": [],
+									"timestamp": 1464484587592,
+									"value": "Example Company"
+								}
+							]
+						},
+						"website": {
+							"source": "COMPANIES",
+							"sourceId": null,
+							"timestamp": 1457513066540,
+							"value": "example.com",
+							"versions": [
+								{
+									"name": "website",
+									"source": "COMPANIES",
+									"sourceVid": [],
+									"timestamp": 1457513066540,
+									"value": "example.com"
+								}
+							]
+						}
+					}
+				}
+			}
+		],
+		"HubSpot - Company - Get": [
+			{
+				"json": {
+					"additionalDomains": [],
+					"companyId": 115200636,
+					"isDeleted": false,
+					"portalId": 62515,
+					"properties": {
+						"name": {
+							"source": "BIDEN",
+							"sourceId": "name",
+							"timestamp": 1464484587592,
+							"value": "Example Company",
+							"versions": [
+								{
+									"name": "name",
+									"source": "BIDEN",
+									"sourceId": "name",
+									"sourceVid": [],
+									"timestamp": 1464484587592,
+									"value": "Example Company"
+								}
+							]
+						},
+						"website": {
+							"source": "COMPANIES",
+							"sourceId": null,
+							"timestamp": 1457513066540,
+							"value": "example.com",
+							"versions": [
+								{
+									"name": "website",
+									"source": "COMPANIES",
+									"sourceVid": [],
+									"timestamp": 1457513066540,
+									"value": "example.com"
+								}
+							]
+						}
+					}
+				}
+			}
+		],
+		"HubSpot - Company - Get Many": [
+			{
+				"json": {
+					"additionalDomains": [],
+					"companyId": 115200636,
+					"isDeleted": false,
+					"portalId": 62515,
+					"properties": {
+						"name": {
+							"source": "BIDEN",
+							"sourceId": "name",
+							"timestamp": 1464484587592,
+							"value": "Example Company",
+							"versions": [
+								{
+									"name": "name",
+									"source": "BIDEN",
+									"sourceId": "name",
+									"sourceVid": [],
+									"timestamp": 1464484587592,
+									"value": "Example Company"
+								}
+							]
+						},
+						"website": {
+							"source": "COMPANIES",
+							"sourceId": null,
+							"timestamp": 1457513066540,
+							"value": "example.com",
+							"versions": [
+								{
+									"name": "website",
+									"source": "COMPANIES",
+									"sourceVid": [],
+									"timestamp": 1457513066540,
+									"value": "example.com"
+								}
+							]
+						}
+					}
+				}
+			},
+			{
+				"json": {
+					"additionalDomains": [],
+					"companyId": 115279791,
+					"isDeleted": false,
+					"portalId": 62515,
+					"properties": {
+						"name": {
+							"source": "BIDEN",
+							"sourceId": "name",
+							"timestamp": 1468832771769,
+							"value": "Test Company",
+							"versions": [
+								{
+									"name": "name",
+									"source": "BIDEN",
+									"sourceId": "name",
+									"sourceVid": [],
+									"timestamp": 1468832771769,
+									"value": "Test Company"
+								}
+							]
+						},
+						"website": {
+							"source": "COMPANIES",
+							"sourceId": null,
+							"timestamp": 1457535205549,
+							"value": "test.com",
+							"versions": [
+								{
+									"name": "website",
+									"source": "COMPANIES",
+									"sourceVid": [],
+									"timestamp": 1457535205549,
+									"value": "test.com"
+								}
+							]
+						}
+					}
+				}
+			}
+		],
+		"HubSpot - Company - Search": [
+			{
+				"json": {
+					"additionalDomains": [],
+					"companyId": 184896670,
+					"isDeleted": false,
+					"mergeAudits": [],
+					"portalId": 62515,
+					"properties": {
+						"createdate": {
+							"source": "API",
+							"sourceId": null,
+							"timestamp": 1457708103847,
+							"value": "1457708103847",
+							"versions": [
+								{
+									"name": "createdate",
+									"source": "API",
+									"sourceVid": [],
+									"timestamp": 1457708103847,
+									"value": "1457708103847"
+								}
+							]
+						},
+						"domain": {
+							"source": "COMPANIES",
+							"sourceId": null,
+							"timestamp": 1457708103847,
+							"value": "hubspot.com",
+							"versions": [
+								{
+									"name": "domain",
+									"source": "COMPANIES",
+									"sourceVid": [],
+									"timestamp": 1457708103847,
+									"value": "hubspot.com"
+								}
+							]
+						},
+						"hs_lastmodifieddate": {
+							"source": "CALCULATED",
+							"sourceId": null,
+							"timestamp": 1502872954691,
+							"value": "1502872954691",
+							"versions": [
+								{
+									"name": "hs_lastmodifieddate",
+									"source": "CALCULATED",
+									"sourceVid": [],
+									"timestamp": 1502872954691,
+									"value": "1502872954691"
+								}
+							]
+						},
+						"name": {
+							"source": "BIDEN",
+							"sourceId": "name",
+							"timestamp": 1457708103906,
+							"value": "Hubspot, Inc.",
+							"versions": [
+								{
+									"name": "name",
+									"source": "BIDEN",
+									"sourceId": "name",
+									"sourceVid": [],
+									"timestamp": 1457708103906,
+									"value": "Hubspot, Inc."
+								}
+							]
+						}
+					},
+					"stateChanges": []
+				}
+			},
+			{
+				"json": {
+					"additionalDomains": [],
+					"companyId": 418736767,
+					"isDeleted": false,
+					"mergeAudits": [],
+					"portalId": 62515,
+					"properties": {
+						"createdate": {
+							"source": "API",
+							"sourceId": "API",
+							"timestamp": 1490280388204,
+							"value": "1490280388204",
+							"versions": [
+								{
+									"name": "createdate",
+									"source": "API",
+									"sourceId": "API",
+									"sourceVid": [],
+									"timestamp": 1490280388204,
+									"value": "1490280388204"
+								}
+							]
+						},
+						"domain": {
+							"source": "API",
+							"sourceId": null,
+							"timestamp": 1490280388204,
+							"value": "hubspot.com",
+							"versions": [
+								{
+									"name": "domain",
+									"source": "API",
+									"sourceVid": [],
+									"timestamp": 1490280388204,
+									"value": "hubspot.com"
+								}
+							]
+						},
+						"hs_lastmodifieddate": {
+							"source": "CALCULATED",
+							"sourceId": null,
+							"timestamp": 1498644245669,
+							"value": "1498644245669",
+							"versions": [
+								{
+									"name": "hs_lastmodifieddate",
+									"source": "CALCULATED",
+									"sourceVid": [],
+									"timestamp": 1498644245669,
+									"value": "1498644245669"
+								}
+							]
+						},
+						"name": {
+							"source": "API",
+							"sourceId": null,
+							"timestamp": 1490280388204,
+							"value": "qweqwe2323",
+							"versions": [
+								{
+									"name": "name",
+									"source": "API",
+									"sourceVid": [],
+									"timestamp": 1490280388204,
+									"value": "qweqwe2323"
+								}
+							]
+						}
+					},
+					"stateChanges": []
+				}
+			}
+		],
+		"HubSpot - Company - Get Recently Updated": [
+			{
+				"json": {
+					"additionalDomains": [],
+					"companyId": 115200636,
+					"isDeleted": false,
+					"portalId": 62515,
+					"properties": {
+						"name": {
+							"source": "BIDEN",
+							"sourceId": "name",
+							"timestamp": 1464484587592,
+							"value": "Example Company",
+							"versions": [
+								{
+									"name": "name",
+									"source": "BIDEN",
+									"sourceId": "name",
+									"sourceVid": [],
+									"timestamp": 1464484587592,
+									"value": "Example Company"
+								}
+							]
+						},
+						"website": {
+							"source": "COMPANIES",
+							"sourceId": null,
+							"timestamp": 1457513066540,
+							"value": "example.com",
+							"versions": [
+								{
+									"name": "website",
+									"source": "COMPANIES",
+									"sourceVid": [],
+									"timestamp": 1457513066540,
+									"value": "example.com"
+								}
+							]
+						}
+					}
+				}
+			},
+			{
+				"json": {
+					"additionalDomains": [],
+					"companyId": 115279791,
+					"isDeleted": false,
+					"portalId": 62515,
+					"properties": {
+						"name": {
+							"source": "BIDEN",
+							"sourceId": "name",
+							"timestamp": 1468832771769,
+							"value": "Test Company",
+							"versions": [
+								{
+									"name": "name",
+									"source": "BIDEN",
+									"sourceId": "name",
+									"sourceVid": [],
+									"timestamp": 1468832771769,
+									"value": "Test Company"
+								}
+							]
+						},
+						"website": {
+							"source": "COMPANIES",
+							"sourceId": null,
+							"timestamp": 1457535205549,
+							"value": "test.com",
+							"versions": [
+								{
+									"name": "website",
+									"source": "COMPANIES",
+									"sourceVid": [],
+									"timestamp": 1457535205549,
+									"value": "test.com"
+								}
+							]
+						}
+					}
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking ‘Test workflow’": {
+			"main": [
+				[
+					{
+						"node": "HubSpot - Company - Create",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "HubSpot - Company - Delete",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "HubSpot - Company - Get",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "HubSpot - Company - Get Many",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "HubSpot - Company - Get Recently Updated",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "HubSpot - Company - Search",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "HubSpot - Company - Update",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "9acf7d60-9b18-46f4-8a3e-6edd75806535",
+	"meta": {
+		"templateCredsSetupCompleted": true,
+		"instanceId": "27cc9b56542ad45b38725555722c50a1c3fee1670bbb67980558314ee08517c4"
+	},
+	"id": "CYeIbFIs8qLoLvBe",
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Hubspot/__test__/contacts.workflow.json
+++ b/packages/nodes-base/nodes/Hubspot/__test__/contacts.workflow.json
@@ -1,0 +1,597 @@
+{
+	"name": "Hubspot contacts",
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [-220, 500],
+			"id": "660a58a4-9e3c-4d66-908c-26f4d99daff1",
+			"name": "When clicking ‘Test workflow’"
+		},
+		{
+			"parameters": {
+				"operation": "get",
+				"contactId": {
+					"__rl": true,
+					"value": "123",
+					"mode": "id"
+				},
+				"additionalFields": {
+					"formSubmissionMode": "newest",
+					"listMemberships": true
+				}
+			},
+			"type": "n8n-nodes-base.hubspot",
+			"typeVersion": 2.1,
+			"position": [0, 400],
+			"id": "c8a9eacd-7b90-4c7e-9a01-6d417c8595de",
+			"name": "HubSpot - Company - Get",
+			"credentials": {
+				"hubspotApi": {
+					"id": "EDJsHUkhqof5gr15",
+					"name": "HubSpot account"
+				}
+			}
+		},
+		{
+			"parameters": {
+				"operation": "delete",
+				"contactId": {
+					"__rl": true,
+					"value": "123",
+					"mode": "id"
+				}
+			},
+			"type": "n8n-nodes-base.hubspot",
+			"typeVersion": 2.1,
+			"position": [0, 0],
+			"id": "f580a3eb-ac70-4838-8229-f4b1a9c0fe31",
+			"name": "HubSpot - Contact - Delete",
+			"credentials": {
+				"hubspotApi": {
+					"id": "EDJsHUkhqof5gr15",
+					"name": "HubSpot account"
+				}
+			}
+		},
+		{
+			"parameters": {
+				"email": "elias@n8n.io",
+				"additionalFields": {
+					"annualRevenue": 123,
+					"associatedCompanyId": "=123",
+					"city": "Gent",
+					"closeDate": "2025-04-17T00:00:00",
+					"customPropertiesUi": {
+						"customPropertiesValues": [
+							{
+								"property": "=test_custom_prop_name",
+								"value": "test custom prop value"
+							}
+						]
+					},
+					"firstName": "Elias",
+					"postalCode": "9000",
+					"websiteUrl": "example.com",
+					"workEmail": "elias@n8n.io"
+				},
+				"options": {}
+			},
+			"type": "n8n-nodes-base.hubspot",
+			"typeVersion": 2.1,
+			"position": [0, 200],
+			"id": "6d013a2d-284b-44e3-b1ab-6cd980058d78",
+			"name": "HubSpot - Contact - Create",
+			"credentials": {
+				"hubspotApi": {
+					"id": "EDJsHUkhqof5gr15",
+					"name": "HubSpot account"
+				}
+			}
+		},
+		{
+			"parameters": {
+				"operation": "getAll",
+				"limit": 2,
+				"additionalFields": {}
+			},
+			"type": "n8n-nodes-base.hubspot",
+			"typeVersion": 2.1,
+			"position": [0, 600],
+			"id": "be09f310-c593-41ae-b79c-b44661918e8f",
+			"name": "HubSpot - Contact - Get Many",
+			"credentials": {
+				"hubspotApi": {
+					"id": "EDJsHUkhqof5gr15",
+					"name": "HubSpot account"
+				}
+			}
+		},
+		{
+			"parameters": {
+				"operation": "getRecentlyCreatedUpdated",
+				"limit": 2,
+				"additionalFields": {}
+			},
+			"type": "n8n-nodes-base.hubspot",
+			"typeVersion": 2.1,
+			"position": [0, 800],
+			"id": "95b4d7da-612b-4159-b283-36d55d0b6cce",
+			"name": "HubSpot - Contact - Get Recently Updated",
+			"credentials": {
+				"hubspotApi": {
+					"id": "EDJsHUkhqof5gr15",
+					"name": "HubSpot account"
+				}
+			}
+		},
+		{
+			"parameters": {
+				"operation": "search",
+				"limit": 2,
+				"filterGroupsUi": {
+					"filterGroupsValues": [
+						{
+							"filtersUi": {
+								"filterValues": [
+									{
+										"propertyName": "=firstname",
+										"value": "Elias"
+									},
+									{
+										"propertyName": "=lastname",
+										"value": "Meire"
+									}
+								]
+							}
+						},
+						{
+							"filtersUi": {
+								"filterValues": [
+									{
+										"propertyName": "=email",
+										"operator": "CONTAINS_TOKEN",
+										"value": "n8n.io"
+									}
+								]
+							}
+						}
+					]
+				},
+				"additionalFields": {
+					"direction": "ASCENDING"
+				}
+			},
+			"type": "n8n-nodes-base.hubspot",
+			"typeVersion": 2.1,
+			"position": [0, 1000],
+			"id": "68f5e362-b554-48fd-8b1b-982940dd6e7a",
+			"name": "HubSpot - Contact - Search",
+			"credentials": {
+				"hubspotApi": {
+					"id": "EDJsHUkhqof5gr15",
+					"name": "HubSpot account"
+				}
+			}
+		}
+	],
+	"pinData": {
+		"HubSpot - Company - Get": [
+			{
+				"json": {
+					"addedAt": 1390574181854,
+					"canonical-vid": 204727,
+					"form-submissions": [],
+					"identity-profiles": [
+						{
+							"deleted-changed-timestamp": 0,
+							"identities": [
+								{
+									"timestamp": 1390574181878,
+									"type": "LEAD_GUID",
+									"value": "f9d728f1-dff1-49b0-9caa-247dbdf5b8b7"
+								},
+								{
+									"timestamp": 1476768116137,
+									"type": "EMAIL",
+									"value": "mgnew-email@hubspot.com"
+								}
+							],
+							"saved-at-timestamp": 1476768116149,
+							"vid": 204727
+						}
+					],
+					"is-contact": true,
+					"merge-audits": [],
+					"merged-vids": [],
+					"portal-id": 62515,
+					"properties": {
+						"company": {
+							"value": ""
+						},
+						"firstname": {
+							"value": "Bob"
+						},
+						"lastmodifieddate": {
+							"value": "1483461406481"
+						},
+						"lastname": {
+							"value": "Record"
+						}
+					},
+					"vid": 204727
+				}
+			}
+		],
+		"HubSpot - Contact - Delete": [
+			{
+				"json": {
+					"addedAt": 1390574181854,
+					"canonical-vid": 204727,
+					"form-submissions": [],
+					"identity-profiles": [
+						{
+							"deleted-changed-timestamp": 0,
+							"identities": [
+								{
+									"timestamp": 1390574181878,
+									"type": "LEAD_GUID",
+									"value": "f9d728f1-dff1-49b0-9caa-247dbdf5b8b7"
+								},
+								{
+									"timestamp": 1476768116137,
+									"type": "EMAIL",
+									"value": "mgnew-email@hubspot.com"
+								}
+							],
+							"saved-at-timestamp": 1476768116149,
+							"vid": 204727
+						}
+					],
+					"is-contact": true,
+					"merge-audits": [],
+					"merged-vids": [],
+					"portal-id": 62515,
+					"properties": {
+						"company": {
+							"value": ""
+						},
+						"firstname": {
+							"value": "Bob"
+						},
+						"lastmodifieddate": {
+							"value": "1483461406481"
+						},
+						"lastname": {
+							"value": "Record"
+						}
+					},
+					"vid": 204727
+				}
+			}
+		],
+		"HubSpot - Contact - Create": [
+			{
+				"json": {
+					"addedAt": 1390574181854,
+					"canonical-vid": 204727,
+					"form-submissions": [],
+					"identity-profiles": [
+						{
+							"deleted-changed-timestamp": 0,
+							"identities": [
+								{
+									"timestamp": 1390574181878,
+									"type": "LEAD_GUID",
+									"value": "f9d728f1-dff1-49b0-9caa-247dbdf5b8b7"
+								},
+								{
+									"timestamp": 1476768116137,
+									"type": "EMAIL",
+									"value": "mgnew-email@hubspot.com"
+								}
+							],
+							"saved-at-timestamp": 1476768116149,
+							"vid": 204727
+						}
+					],
+					"is-contact": true,
+					"merge-audits": [],
+					"merged-vids": [],
+					"portal-id": 62515,
+					"properties": {
+						"company": {
+							"value": ""
+						},
+						"firstname": {
+							"value": "Bob"
+						},
+						"lastmodifieddate": {
+							"value": "1483461406481"
+						},
+						"lastname": {
+							"value": "Record"
+						}
+					},
+					"vid": 204727
+				}
+			}
+		],
+		"HubSpot - Contact - Get Many": [
+			{
+				"json": {
+					"addedAt": 1390574181854,
+					"canonical-vid": 204727,
+					"form-submissions": [],
+					"identity-profiles": [
+						{
+							"deleted-changed-timestamp": 0,
+							"identities": [
+								{
+									"timestamp": 1390574181878,
+									"type": "LEAD_GUID",
+									"value": "f9d728f1-dff1-49b0-9caa-247dbdf5b8b7"
+								},
+								{
+									"timestamp": 1476768116137,
+									"type": "EMAIL",
+									"value": "mgnew-email@hubspot.com"
+								}
+							],
+							"saved-at-timestamp": 1476768116149,
+							"vid": 204727
+						}
+					],
+					"is-contact": true,
+					"merge-audits": [],
+					"merged-vids": [],
+					"portal-id": 62515,
+					"properties": {
+						"company": {
+							"value": ""
+						},
+						"firstname": {
+							"value": "Bob"
+						},
+						"lastmodifieddate": {
+							"value": "1483461406481"
+						},
+						"lastname": {
+							"value": "Record"
+						}
+					},
+					"vid": 204727
+				}
+			},
+			{
+				"json": {
+					"addedAt": 1392643921079,
+					"canonical-vid": 207303,
+					"form-submissions": [],
+					"identity-profiles": [
+						{
+							"deleted-changed-timestamp": 0,
+							"identities": [
+								{
+									"timestamp": 1392643921079,
+									"type": "EMAIL",
+									"value": "email_0be34aebe5@abctest.com"
+								},
+								{
+									"timestamp": 1392643921082,
+									"type": "LEAD_GUID",
+									"value": "058378c6-9513-43e1-a13a-43a98d47aa22"
+								}
+							],
+							"saved-at-timestamp": 1392643921090,
+							"vid": 207303
+						}
+					],
+					"is-contact": true,
+					"merge-audits": [],
+					"merged-vids": [],
+					"portal-id": 62515,
+					"properties": {
+						"firstname": {
+							"value": "Ff_FirstName_0"
+						},
+						"lastmodifieddate": {
+							"value": "1479148429488"
+						},
+						"lastname": {
+							"value": "Ff_LastName_0"
+						}
+					},
+					"vid": 207303
+				}
+			}
+		],
+		"HubSpot - Contact - Get Recently Updated": [
+			{
+				"json": {
+					"addedAt": 1390574181854,
+					"canonical-vid": 204727,
+					"form-submissions": [],
+					"identity-profiles": [
+						{
+							"deleted-changed-timestamp": 0,
+							"identities": [
+								{
+									"timestamp": 1390574181878,
+									"type": "LEAD_GUID",
+									"value": "f9d728f1-dff1-49b0-9caa-247dbdf5b8b7"
+								},
+								{
+									"timestamp": 1476768116137,
+									"type": "EMAIL",
+									"value": "mgnew-email@hubspot.com"
+								}
+							],
+							"saved-at-timestamp": 1476768116149,
+							"vid": 204727
+						}
+					],
+					"is-contact": true,
+					"merge-audits": [],
+					"merged-vids": [],
+					"portal-id": 62515,
+					"properties": {
+						"company": {
+							"value": ""
+						},
+						"firstname": {
+							"value": "Bob"
+						},
+						"lastmodifieddate": {
+							"value": "1483461406481"
+						},
+						"lastname": {
+							"value": "Record"
+						}
+					},
+					"vid": 204727
+				}
+			},
+			{
+				"json": {
+					"addedAt": 1392643921079,
+					"canonical-vid": 207303,
+					"form-submissions": [],
+					"identity-profiles": [
+						{
+							"deleted-changed-timestamp": 0,
+							"identities": [
+								{
+									"timestamp": 1392643921079,
+									"type": "EMAIL",
+									"value": "email_0be34aebe5@abctest.com"
+								},
+								{
+									"timestamp": 1392643921082,
+									"type": "LEAD_GUID",
+									"value": "058378c6-9513-43e1-a13a-43a98d47aa22"
+								}
+							],
+							"saved-at-timestamp": 1392643921090,
+							"vid": 207303
+						}
+					],
+					"is-contact": true,
+					"merge-audits": [],
+					"merged-vids": [],
+					"portal-id": 62515,
+					"properties": {
+						"firstname": {
+							"value": "Ff_FirstName_0"
+						},
+						"lastmodifieddate": {
+							"value": "1479148429488"
+						},
+						"lastname": {
+							"value": "Ff_LastName_0"
+						}
+					},
+					"vid": 207303
+				}
+			}
+		],
+		"HubSpot - Contact - Search": [
+			{
+				"json": {
+					"archived": false,
+					"archivedAt": "2025-04-16T18:54:48.554Z",
+					"createdAt": "2025-04-16T18:54:48.554Z",
+					"id": "512",
+					"objectWriteTraceId": "string",
+					"properties": {
+						"email": "mark.s@lumon.industries",
+						"firstname": "Mark",
+						"lastname": "S."
+					},
+					"propertiesWithHistory": {
+						"additionalProp1": [
+							{
+								"sourceId": "string",
+								"sourceLabel": "string",
+								"sourceType": "string",
+								"timestamp": "2025-04-16T18:54:48.554Z",
+								"updatedByUserId": 0,
+								"value": "string"
+							}
+						],
+						"additionalProp2": [
+							{
+								"sourceId": "string",
+								"sourceLabel": "string",
+								"sourceType": "string",
+								"timestamp": "2025-04-16T18:54:48.554Z",
+								"updatedByUserId": 0,
+								"value": "string"
+							}
+						],
+						"additionalProp3": [
+							{
+								"sourceId": "string",
+								"sourceLabel": "string",
+								"sourceType": "string",
+								"timestamp": "2025-04-16T18:54:48.554Z",
+								"updatedByUserId": 0,
+								"value": "string"
+							}
+						]
+					},
+					"updatedAt": "2025-04-16T18:54:48.554Z"
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking ‘Test workflow’": {
+			"main": [
+				[
+					{
+						"node": "HubSpot - Contact - Create",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "HubSpot - Contact - Delete",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "HubSpot - Company - Get",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "HubSpot - Contact - Get Many",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "HubSpot - Contact - Get Recently Updated",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "HubSpot - Contact - Search",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "73e9b678-aa88-4d45-9095-285f742173ba",
+	"meta": {
+		"instanceId": "27cc9b56542ad45b38725555722c50a1c3fee1670bbb67980558314ee08517c4"
+	},
+	"id": "0okjdr441aloqrhb",
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Hubspot/__test__/contacts.workflow.json
+++ b/packages/nodes-base/nodes/Hubspot/__test__/contacts.workflow.json
@@ -26,7 +26,7 @@
 			"typeVersion": 2.1,
 			"position": [0, 400],
 			"id": "c8a9eacd-7b90-4c7e-9a01-6d417c8595de",
-			"name": "HubSpot - Company - Get",
+			"name": "HubSpot - Contact - Get",
 			"credentials": {
 				"hubspotApi": {
 					"id": "EDJsHUkhqof5gr15",
@@ -177,7 +177,7 @@
 		}
 	],
 	"pinData": {
-		"HubSpot - Company - Get": [
+		"HubSpot - Contact - Get": [
 			{
 				"json": {
 					"addedAt": 1390574181854,
@@ -561,7 +561,7 @@
 						"index": 0
 					},
 					{
-						"node": "HubSpot - Company - Get",
+						"node": "HubSpot - Contact - Get",
 						"type": "main",
 						"index": 0
 					},

--- a/packages/nodes-base/nodes/Hubspot/__test__/deals.workflow.json
+++ b/packages/nodes-base/nodes/Hubspot/__test__/deals.workflow.json
@@ -1,0 +1,676 @@
+{
+	"name": "Hubspot deals",
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [-220, 600],
+			"id": "4d956443-f695-467e-8ab4-3500914bb1dc",
+			"name": "When clicking ‘Test workflow’"
+		},
+		{
+			"parameters": {
+				"resource": "deal",
+				"operation": "delete",
+				"dealId": {
+					"__rl": true,
+					"value": "123",
+					"mode": "id"
+				}
+			},
+			"type": "n8n-nodes-base.hubspot",
+			"typeVersion": 2.1,
+			"position": [0, 0],
+			"id": "c7db8b4e-7ceb-4070-8559-4daf1b23e63a",
+			"name": "HubSpot - Deal - Delete",
+			"credentials": {
+				"hubspotApi": {
+					"id": "EDJsHUkhqof5gr15",
+					"name": "HubSpot account"
+				}
+			}
+		},
+		{
+			"parameters": {
+				"resource": "deal",
+				"stage": "=test stage name",
+				"additionalFields": {
+					"amount": "100",
+					"closeDate": "2025-04-17T00:00:00",
+					"customPropertiesUi": {
+						"customPropertiesValues": [
+							{
+								"property": "=test_custom_prop_name",
+								"value": "test custom prop value"
+							}
+						]
+					},
+					"description": "Test Deal Desc",
+					"dealName": "Test Deal",
+					"pipeline": "=test pipeline name"
+				}
+			},
+			"type": "n8n-nodes-base.hubspot",
+			"typeVersion": 2.1,
+			"position": [0, 400],
+			"id": "9abda6ab-bd8c-4e9e-9e9c-178f6241c7df",
+			"name": "HubSpot - Deal - Create",
+			"credentials": {
+				"hubspotApi": {
+					"id": "EDJsHUkhqof5gr15",
+					"name": "HubSpot account"
+				}
+			}
+		},
+		{
+			"parameters": {
+				"resource": "deal",
+				"operation": "update",
+				"dealId": {
+					"__rl": true,
+					"value": "123",
+					"mode": "id"
+				},
+				"updateFields": {
+					"closeDate": "2025-04-22T00:00:00",
+					"dealName": "New Name",
+					"dealOwner": {
+						"__rl": true,
+						"value": "123",
+						"mode": "id"
+					},
+					"stage": "=1234",
+					"pipeline": "123"
+				}
+			},
+			"type": "n8n-nodes-base.hubspot",
+			"typeVersion": 2.1,
+			"position": [0, 200],
+			"id": "92854c9b-16d8-44e0-adba-2a4296476a02",
+			"name": "HubSpot - Deal - Update",
+			"credentials": {
+				"hubspotApi": {
+					"id": "EDJsHUkhqof5gr15",
+					"name": "HubSpot account"
+				}
+			}
+		},
+		{
+			"parameters": {
+				"resource": "deal",
+				"operation": "get",
+				"dealId": {
+					"__rl": true,
+					"value": "123",
+					"mode": "id"
+				},
+				"filters": {
+					"includePropertyVersions": true
+				}
+			},
+			"type": "n8n-nodes-base.hubspot",
+			"typeVersion": 2.1,
+			"position": [0, 600],
+			"id": "3566fc17-93d8-4b89-8864-a26ea2f4de51",
+			"name": "HubSpot - Deal - Get",
+			"credentials": {
+				"hubspotApi": {
+					"id": "EDJsHUkhqof5gr15",
+					"name": "HubSpot account"
+				}
+			}
+		},
+		{
+			"parameters": {
+				"resource": "deal",
+				"operation": "getAll",
+				"limit": 2,
+				"filters": {
+					"includeAssociations": true
+				}
+			},
+			"type": "n8n-nodes-base.hubspot",
+			"typeVersion": 2.1,
+			"position": [0, 800],
+			"id": "d0f5d2be-8369-494e-8526-452e6b2a51dc",
+			"name": "HubSpot - Deal - Get Many",
+			"credentials": {
+				"hubspotApi": {
+					"id": "EDJsHUkhqof5gr15",
+					"name": "HubSpot account"
+				}
+			}
+		},
+		{
+			"parameters": {
+				"resource": "deal",
+				"operation": "getRecentlyCreatedUpdated",
+				"limit": 2,
+				"filters": {
+					"since": "2025-04-21T00:00:00",
+					"includePropertyVersions": true
+				}
+			},
+			"type": "n8n-nodes-base.hubspot",
+			"typeVersion": 2.1,
+			"position": [0, 1000],
+			"id": "4ac5aae3-0192-40bf-83d8-d36fadc19a57",
+			"name": "HubSpot - Deal - Get Recently Updated",
+			"credentials": {
+				"hubspotApi": {
+					"id": "EDJsHUkhqof5gr15",
+					"name": "HubSpot account"
+				}
+			}
+		},
+		{
+			"parameters": {
+				"resource": "deal",
+				"operation": "search",
+				"limit": 2,
+				"filterGroupsUi": {
+					"filterGroupsValues": [
+						{
+							"filtersUi": {
+								"filterValues": [
+									{
+										"propertyName": "=name",
+										"value": "Test Deal Name"
+									}
+								]
+							}
+						}
+					]
+				},
+				"additionalFields": {
+					"direction": "ASCENDING",
+					"sortBy": "=createdate"
+				}
+			},
+			"type": "n8n-nodes-base.hubspot",
+			"typeVersion": 2.1,
+			"position": [0, 1200],
+			"id": "a6011494-27f9-4f09-bd30-f509f6438232",
+			"name": "HubSpot - Deal - Search",
+			"credentials": {
+				"hubspotApi": {
+					"id": "EDJsHUkhqof5gr15",
+					"name": "HubSpot account"
+				}
+			}
+		}
+	],
+	"pinData": {
+		"HubSpot - Deal - Delete": [
+			{
+				"json": {
+					"associations": {
+						"associatedCompanyIds": [237892],
+						"associatedDealIds": [],
+						"associatedVids": [393873, 734934]
+					},
+					"dealId": 18039629,
+					"imports": [],
+					"isDeleted": false,
+					"portalId": 62515,
+					"properties": {
+						"dealname": {
+							"source": "API",
+							"sourceId": null,
+							"timestamp": 1457040864519,
+							"value": "Company",
+							"versions": [
+								{
+									"name": "dealname",
+									"source": "API",
+									"sourceVid": [],
+									"timestamp": 1457040864519,
+									"value": "Company Name"
+								}
+							]
+						},
+						"num_associated_contacts": {
+							"source": "CALCULATED",
+							"sourceId": null,
+							"timestamp": 0,
+							"value": "2",
+							"versions": [
+								{
+									"name": "num_associated_contacts",
+									"source": "CALCULATED",
+									"sourceVid": [],
+									"value": "2"
+								}
+							]
+						}
+					}
+				}
+			}
+		],
+		"HubSpot - Deal - Create": [
+			{
+				"json": {
+					"associations": {
+						"associatedCompanyIds": [237892],
+						"associatedDealIds": [],
+						"associatedVids": [393873, 734934]
+					},
+					"dealId": 18039629,
+					"imports": [],
+					"isDeleted": false,
+					"portalId": 62515,
+					"properties": {
+						"dealname": {
+							"source": "API",
+							"sourceId": null,
+							"timestamp": 1457040864519,
+							"value": "Company",
+							"versions": [
+								{
+									"name": "dealname",
+									"source": "API",
+									"sourceVid": [],
+									"timestamp": 1457040864519,
+									"value": "Company Name"
+								}
+							]
+						},
+						"num_associated_contacts": {
+							"source": "CALCULATED",
+							"sourceId": null,
+							"timestamp": 0,
+							"value": "2",
+							"versions": [
+								{
+									"name": "num_associated_contacts",
+									"source": "CALCULATED",
+									"sourceVid": [],
+									"value": "2"
+								}
+							]
+						}
+					}
+				}
+			}
+		],
+		"HubSpot - Deal - Update": [
+			{
+				"json": {
+					"associations": {
+						"associatedCompanyIds": [237892],
+						"associatedDealIds": [],
+						"associatedVids": [393873, 734934]
+					},
+					"dealId": 18039629,
+					"imports": [],
+					"isDeleted": false,
+					"portalId": 62515,
+					"properties": {
+						"dealname": {
+							"source": "API",
+							"sourceId": null,
+							"timestamp": 1457040864519,
+							"value": "Company",
+							"versions": [
+								{
+									"name": "dealname",
+									"source": "API",
+									"sourceVid": [],
+									"timestamp": 1457040864519,
+									"value": "Company Name"
+								}
+							]
+						},
+						"num_associated_contacts": {
+							"source": "CALCULATED",
+							"sourceId": null,
+							"timestamp": 0,
+							"value": "2",
+							"versions": [
+								{
+									"name": "num_associated_contacts",
+									"source": "CALCULATED",
+									"sourceVid": [],
+									"value": "2"
+								}
+							]
+						}
+					}
+				}
+			}
+		],
+		"HubSpot - Deal - Get": [
+			{
+				"json": {
+					"associations": {
+						"associatedCompanyIds": [237892],
+						"associatedDealIds": [],
+						"associatedVids": [393873, 734934]
+					},
+					"dealId": 18039629,
+					"imports": [],
+					"isDeleted": false,
+					"portalId": 62515,
+					"properties": {
+						"dealname": {
+							"source": "API",
+							"sourceId": null,
+							"timestamp": 1457040864519,
+							"value": "Company",
+							"versions": [
+								{
+									"name": "dealname",
+									"source": "API",
+									"sourceVid": [],
+									"timestamp": 1457040864519,
+									"value": "Company Name"
+								}
+							]
+						},
+						"num_associated_contacts": {
+							"source": "CALCULATED",
+							"sourceId": null,
+							"timestamp": 0,
+							"value": "2",
+							"versions": [
+								{
+									"name": "num_associated_contacts",
+									"source": "CALCULATED",
+									"sourceVid": [],
+									"value": "2"
+								}
+							]
+						}
+					}
+				}
+			}
+		],
+		"HubSpot - Deal - Get Many": [
+			{
+				"json": {
+					"associations": {
+						"associatedCompanyIds": [237892],
+						"associatedDealIds": [],
+						"associatedVids": [393873, 734934]
+					},
+					"dealId": 18039629,
+					"imports": [],
+					"isDeleted": false,
+					"portalId": 62515,
+					"properties": {
+						"dealname": {
+							"source": "API",
+							"sourceId": null,
+							"timestamp": 1457040864519,
+							"value": "Company",
+							"versions": [
+								{
+									"name": "dealname",
+									"source": "API",
+									"sourceVid": [],
+									"timestamp": 1457040864519,
+									"value": "Company Name"
+								}
+							]
+						},
+						"num_associated_contacts": {
+							"source": "CALCULATED",
+							"sourceId": null,
+							"timestamp": 0,
+							"value": "2",
+							"versions": [
+								{
+									"name": "num_associated_contacts",
+									"source": "CALCULATED",
+									"sourceVid": [],
+									"value": "2"
+								}
+							]
+						}
+					}
+				}
+			},
+			{
+				"json": {
+					"associations": {
+						"associatedCompanyIds": [],
+						"associatedDealIds": [],
+						"associatedVids": []
+					},
+					"dealId": 18040854,
+					"imports": [],
+					"isDeleted": false,
+					"portalId": 62515,
+					"properties": {
+						"dealname": {
+							"source": "API",
+							"sourceId": null,
+							"timestamp": 1457042290572,
+							"value": "5678",
+							"versions": [
+								{
+									"name": "dealname",
+									"source": "API",
+									"sourceVid": [],
+									"timestamp": 1457042290572,
+									"value": "5678"
+								}
+							]
+						},
+						"num_associated_contacts": {
+							"source": "CALCULATED",
+							"sourceId": null,
+							"timestamp": 0,
+							"value": "0",
+							"versions": [
+								{
+									"name": "num_associated_contacts",
+									"source": "CALCULATED",
+									"sourceVid": [],
+									"value": "0"
+								}
+							]
+						}
+					}
+				}
+			}
+		],
+		"HubSpot - Deal - Get Recently Updated": [
+			{
+				"json": {
+					"associations": {
+						"associatedCompanyIds": [237892],
+						"associatedDealIds": [],
+						"associatedVids": [393873, 734934]
+					},
+					"dealId": 18039629,
+					"imports": [],
+					"isDeleted": false,
+					"portalId": 62515,
+					"properties": {
+						"dealname": {
+							"source": "API",
+							"sourceId": null,
+							"timestamp": 1457040864519,
+							"value": "Company",
+							"versions": [
+								{
+									"name": "dealname",
+									"source": "API",
+									"sourceVid": [],
+									"timestamp": 1457040864519,
+									"value": "Company Name"
+								}
+							]
+						},
+						"num_associated_contacts": {
+							"source": "CALCULATED",
+							"sourceId": null,
+							"timestamp": 0,
+							"value": "2",
+							"versions": [
+								{
+									"name": "num_associated_contacts",
+									"source": "CALCULATED",
+									"sourceVid": [],
+									"value": "2"
+								}
+							]
+						}
+					}
+				}
+			},
+			{
+				"json": {
+					"associations": {
+						"associatedCompanyIds": [],
+						"associatedDealIds": [],
+						"associatedVids": []
+					},
+					"dealId": 18040854,
+					"imports": [],
+					"isDeleted": false,
+					"portalId": 62515,
+					"properties": {
+						"dealname": {
+							"source": "API",
+							"sourceId": null,
+							"timestamp": 1457042290572,
+							"value": "5678",
+							"versions": [
+								{
+									"name": "dealname",
+									"source": "API",
+									"sourceVid": [],
+									"timestamp": 1457042290572,
+									"value": "5678"
+								}
+							]
+						},
+						"num_associated_contacts": {
+							"source": "CALCULATED",
+							"sourceId": null,
+							"timestamp": 0,
+							"value": "0",
+							"versions": [
+								{
+									"name": "num_associated_contacts",
+									"source": "CALCULATED",
+									"sourceVid": [],
+									"value": "0"
+								}
+							]
+						}
+					}
+				}
+			}
+		],
+		"HubSpot - Deal - Search": [
+			{
+				"json": {
+					"archived": false,
+					"archivedAt": "2025-04-17T07:56:45.039Z",
+					"createdAt": "2025-04-17T07:56:45.039Z",
+					"id": "512",
+					"objectWriteTraceId": "string",
+					"properties": {
+						"property_checkbox": "false",
+						"property_date": "1572480000000",
+						"property_dropdown": "choice_b",
+						"property_multiple_checkboxes": "chocolate;strawberry",
+						"property_number": "17",
+						"property_radio": "option_1",
+						"property_string": "value"
+					},
+					"propertiesWithHistory": {
+						"additionalProp1": [
+							{
+								"sourceId": "string",
+								"sourceLabel": "string",
+								"sourceType": "string",
+								"timestamp": "2025-04-17T07:56:45.039Z",
+								"updatedByUserId": 0,
+								"value": "string"
+							}
+						],
+						"additionalProp2": [
+							{
+								"sourceId": "string",
+								"sourceLabel": "string",
+								"sourceType": "string",
+								"timestamp": "2025-04-17T07:56:45.039Z",
+								"updatedByUserId": 0,
+								"value": "string"
+							}
+						],
+						"additionalProp3": [
+							{
+								"sourceId": "string",
+								"sourceLabel": "string",
+								"sourceType": "string",
+								"timestamp": "2025-04-17T07:56:45.039Z",
+								"updatedByUserId": 0,
+								"value": "string"
+							}
+						]
+					},
+					"updatedAt": "2025-04-17T07:56:45.039Z"
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking ‘Test workflow’": {
+			"main": [
+				[
+					{
+						"node": "HubSpot - Deal - Create",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "HubSpot - Deal - Delete",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "HubSpot - Deal - Get",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "HubSpot - Deal - Get Many",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "HubSpot - Deal - Get Recently Updated",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "HubSpot - Deal - Search",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "HubSpot - Deal - Update",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "f124628e-1023-457a-92df-c9afd1a8b0e7",
+	"meta": {
+		"instanceId": "27cc9b56542ad45b38725555722c50a1c3fee1670bbb67980558314ee08517c4"
+	},
+	"id": "dsIoAai3PXpPeSDT",
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Hubspot/__test__/fixtures/companies.json
+++ b/packages/nodes-base/nodes/Hubspot/__test__/fixtures/companies.json
@@ -1,0 +1,84 @@
+{
+	"companies": [
+		{
+			"portalId": 62515,
+			"additionalDomains": [],
+			"properties": {
+				"website": {
+					"sourceId": null,
+					"timestamp": 1457513066540,
+					"versions": [
+						{
+							"timestamp": 1457513066540,
+							"sourceVid": [],
+							"name": "website",
+							"value": "example.com",
+							"source": "COMPANIES"
+						}
+					],
+					"value": "example.com",
+					"source": "COMPANIES"
+				},
+				"name": {
+					"sourceId": "name",
+					"timestamp": 1464484587592,
+					"versions": [
+						{
+							"name": "name",
+							"sourceId": "name",
+							"timestamp": 1464484587592,
+							"value": "Example Company",
+							"source": "BIDEN",
+							"sourceVid": []
+						}
+					],
+					"value": "Example Company",
+					"source": "BIDEN"
+				}
+			},
+			"isDeleted": false,
+			"companyId": 115200636
+		},
+		{
+			"portalId": 62515,
+			"additionalDomains": [],
+			"properties": {
+				"website": {
+					"sourceId": null,
+					"timestamp": 1457535205549,
+					"versions": [
+						{
+							"timestamp": 1457535205549,
+							"sourceVid": [],
+							"name": "website",
+							"value": "test.com",
+							"source": "COMPANIES"
+						}
+					],
+					"value": "test.com",
+					"source": "COMPANIES"
+				},
+				"name": {
+					"sourceId": "name",
+					"timestamp": 1468832771769,
+					"versions": [
+						{
+							"name": "name",
+							"sourceId": "name",
+							"timestamp": 1468832771769,
+							"value": "Test Company",
+							"source": "BIDEN",
+							"sourceVid": []
+						}
+					],
+					"value": "Test Company",
+					"source": "BIDEN"
+				}
+			},
+			"isDeleted": false,
+			"companyId": 115279791
+		}
+	],
+	"has-more": false,
+	"offset": 115279791
+}

--- a/packages/nodes-base/nodes/Hubspot/__test__/fixtures/companies_search_result.json
+++ b/packages/nodes-base/nodes/Hubspot/__test__/fixtures/companies_search_result.json
@@ -1,0 +1,151 @@
+{
+	"results": [
+		{
+			"portalId": 62515,
+			"companyId": 184896670,
+			"isDeleted": false,
+			"properties": {
+				"hs_lastmodifieddate": {
+					"value": "1502872954691",
+					"timestamp": 1502872954691,
+					"source": "CALCULATED",
+					"sourceId": null,
+					"versions": [
+						{
+							"name": "hs_lastmodifieddate",
+							"value": "1502872954691",
+							"timestamp": 1502872954691,
+							"source": "CALCULATED",
+							"sourceVid": []
+						}
+					]
+				},
+				"domain": {
+					"value": "hubspot.com",
+					"timestamp": 1457708103847,
+					"source": "COMPANIES",
+					"sourceId": null,
+					"versions": [
+						{
+							"name": "domain",
+							"value": "hubspot.com",
+							"timestamp": 1457708103847,
+							"source": "COMPANIES",
+							"sourceVid": []
+						}
+					]
+				},
+				"name": {
+					"value": "Hubspot, Inc.",
+					"timestamp": 1457708103906,
+					"source": "BIDEN",
+					"sourceId": "name",
+					"versions": [
+						{
+							"name": "name",
+							"value": "Hubspot, Inc.",
+							"timestamp": 1457708103906,
+							"sourceId": "name",
+							"source": "BIDEN",
+							"sourceVid": []
+						}
+					]
+				},
+				"createdate": {
+					"value": "1457708103847",
+					"timestamp": 1457708103847,
+					"source": "API",
+					"sourceId": null,
+					"versions": [
+						{
+							"name": "createdate",
+							"value": "1457708103847",
+							"timestamp": 1457708103847,
+							"source": "API",
+							"sourceVid": []
+						}
+					]
+				}
+			},
+			"additionalDomains": [],
+			"stateChanges": [],
+			"mergeAudits": []
+		},
+		{
+			"portalId": 62515,
+			"companyId": 418736767,
+			"isDeleted": false,
+			"properties": {
+				"hs_lastmodifieddate": {
+					"value": "1498644245669",
+					"timestamp": 1498644245669,
+					"source": "CALCULATED",
+					"sourceId": null,
+					"versions": [
+						{
+							"name": "hs_lastmodifieddate",
+							"value": "1498644245669",
+							"timestamp": 1498644245669,
+							"source": "CALCULATED",
+							"sourceVid": []
+						}
+					]
+				},
+				"domain": {
+					"value": "hubspot.com",
+					"timestamp": 1490280388204,
+					"source": "API",
+					"sourceId": null,
+					"versions": [
+						{
+							"name": "domain",
+							"value": "hubspot.com",
+							"timestamp": 1490280388204,
+							"source": "API",
+							"sourceVid": []
+						}
+					]
+				},
+				"name": {
+					"value": "qweqwe2323",
+					"timestamp": 1490280388204,
+					"source": "API",
+					"sourceId": null,
+					"versions": [
+						{
+							"name": "name",
+							"value": "qweqwe2323",
+							"timestamp": 1490280388204,
+							"source": "API",
+							"sourceVid": []
+						}
+					]
+				},
+				"createdate": {
+					"value": "1490280388204",
+					"timestamp": 1490280388204,
+					"source": "API",
+					"sourceId": "API",
+					"versions": [
+						{
+							"name": "createdate",
+							"value": "1490280388204",
+							"timestamp": 1490280388204,
+							"sourceId": "API",
+							"source": "API",
+							"sourceVid": []
+						}
+					]
+				}
+			},
+			"additionalDomains": [],
+			"stateChanges": [],
+			"mergeAudits": []
+		}
+	],
+	"hasMore": true,
+	"offset": {
+		"companyId": 418736767,
+		"isPrimary": true
+	}
+}

--- a/packages/nodes-base/nodes/Hubspot/__test__/fixtures/contacts.json
+++ b/packages/nodes-base/nodes/Hubspot/__test__/fixtures/contacts.json
@@ -1,0 +1,89 @@
+{
+	"contacts": [
+		{
+			"addedAt": 1390574181854,
+			"vid": 204727,
+			"canonical-vid": 204727,
+			"merged-vids": [],
+			"portal-id": 62515,
+			"is-contact": true,
+			"properties": {
+				"firstname": {
+					"value": "Bob"
+				},
+				"lastmodifieddate": {
+					"value": "1483461406481"
+				},
+				"company": {
+					"value": ""
+				},
+				"lastname": {
+					"value": "Record"
+				}
+			},
+			"form-submissions": [],
+			"identity-profiles": [
+				{
+					"vid": 204727,
+					"saved-at-timestamp": 1476768116149,
+					"deleted-changed-timestamp": 0,
+					"identities": [
+						{
+							"type": "LEAD_GUID",
+							"value": "f9d728f1-dff1-49b0-9caa-247dbdf5b8b7",
+							"timestamp": 1390574181878
+						},
+						{
+							"type": "EMAIL",
+							"value": "mgnew-email@hubspot.com",
+							"timestamp": 1476768116137
+						}
+					]
+				}
+			],
+			"merge-audits": []
+		},
+		{
+			"addedAt": 1392643921079,
+			"vid": 207303,
+			"canonical-vid": 207303,
+			"merged-vids": [],
+			"portal-id": 62515,
+			"is-contact": true,
+			"properties": {
+				"firstname": {
+					"value": "Ff_FirstName_0"
+				},
+				"lastmodifieddate": {
+					"value": "1479148429488"
+				},
+				"lastname": {
+					"value": "Ff_LastName_0"
+				}
+			},
+			"form-submissions": [],
+			"identity-profiles": [
+				{
+					"vid": 207303,
+					"saved-at-timestamp": 1392643921090,
+					"deleted-changed-timestamp": 0,
+					"identities": [
+						{
+							"type": "EMAIL",
+							"value": "email_0be34aebe5@abctest.com",
+							"timestamp": 1392643921079
+						},
+						{
+							"type": "LEAD_GUID",
+							"value": "058378c6-9513-43e1-a13a-43a98d47aa22",
+							"timestamp": 1392643921082
+						}
+					]
+				}
+			],
+			"merge-audits": []
+		}
+	],
+	"has-more": false,
+	"vid-offset": 207303
+}

--- a/packages/nodes-base/nodes/Hubspot/__test__/fixtures/contacts_search_result.json
+++ b/packages/nodes-base/nodes/Hubspot/__test__/fixtures/contacts_search_result.json
@@ -1,0 +1,56 @@
+{
+	"total": 0,
+	"paging": {
+		"next": {
+			"link": "?after=NTI1Cg%3D%3D",
+			"after": "NTI1Cg%3D%3D"
+		}
+	},
+	"results": [
+		{
+			"createdAt": "2025-04-16T18:54:48.554Z",
+			"archived": false,
+			"archivedAt": "2025-04-16T18:54:48.554Z",
+			"propertiesWithHistory": {
+				"additionalProp1": [
+					{
+						"sourceId": "string",
+						"sourceType": "string",
+						"sourceLabel": "string",
+						"updatedByUserId": 0,
+						"value": "string",
+						"timestamp": "2025-04-16T18:54:48.554Z"
+					}
+				],
+				"additionalProp2": [
+					{
+						"sourceId": "string",
+						"sourceType": "string",
+						"sourceLabel": "string",
+						"updatedByUserId": 0,
+						"value": "string",
+						"timestamp": "2025-04-16T18:54:48.554Z"
+					}
+				],
+				"additionalProp3": [
+					{
+						"sourceId": "string",
+						"sourceType": "string",
+						"sourceLabel": "string",
+						"updatedByUserId": 0,
+						"value": "string",
+						"timestamp": "2025-04-16T18:54:48.554Z"
+					}
+				]
+			},
+			"id": "512",
+			"objectWriteTraceId": "string",
+			"properties": {
+				"email": "mark.s@lumon.industries",
+				"lastname": "S.",
+				"firstname": "Mark"
+			},
+			"updatedAt": "2025-04-16T18:54:48.554Z"
+		}
+	]
+}

--- a/packages/nodes-base/nodes/Hubspot/__test__/fixtures/deals.json
+++ b/packages/nodes-base/nodes/Hubspot/__test__/fixtures/deals.json
@@ -1,0 +1,90 @@
+{
+	"deals": [
+		{
+			"portalId": 62515,
+			"dealId": 18039629,
+			"isDeleted": false,
+			"associations": {
+				"associatedVids": [393873, 734934],
+				"associatedCompanyIds": [237892],
+				"associatedDealIds": []
+			},
+			"properties": {
+				"dealname": {
+					"value": "Company",
+					"timestamp": 1457040864519,
+					"source": "API",
+					"sourceId": null,
+					"versions": [
+						{
+							"name": "dealname",
+							"value": "Company Name",
+							"timestamp": 1457040864519,
+							"source": "API",
+							"sourceVid": []
+						}
+					]
+				},
+				"num_associated_contacts": {
+					"value": "2",
+					"timestamp": 0,
+					"source": "CALCULATED",
+					"sourceId": null,
+					"versions": [
+						{
+							"name": "num_associated_contacts",
+							"value": "2",
+							"source": "CALCULATED",
+							"sourceVid": []
+						}
+					]
+				}
+			},
+			"imports": []
+		},
+		{
+			"portalId": 62515,
+			"dealId": 18040854,
+			"isDeleted": false,
+			"associations": {
+				"associatedVids": [],
+				"associatedCompanyIds": [],
+				"associatedDealIds": []
+			},
+			"properties": {
+				"dealname": {
+					"value": "5678",
+					"timestamp": 1457042290572,
+					"source": "API",
+					"sourceId": null,
+					"versions": [
+						{
+							"name": "dealname",
+							"value": "5678",
+							"timestamp": 1457042290572,
+							"source": "API",
+							"sourceVid": []
+						}
+					]
+				},
+				"num_associated_contacts": {
+					"value": "0",
+					"timestamp": 0,
+					"source": "CALCULATED",
+					"sourceId": null,
+					"versions": [
+						{
+							"name": "num_associated_contacts",
+							"value": "0",
+							"source": "CALCULATED",
+							"sourceVid": []
+						}
+					]
+				}
+			},
+			"imports": []
+		}
+	],
+	"hasMore": false,
+	"offset": 18040854
+}

--- a/packages/nodes-base/nodes/Hubspot/__test__/fixtures/deals_search_result.json
+++ b/packages/nodes-base/nodes/Hubspot/__test__/fixtures/deals_search_result.json
@@ -1,0 +1,60 @@
+{
+	"total": 0,
+	"paging": {
+		"next": {
+			"link": "?after=NTI1Cg%3D%3D",
+			"after": "NTI1Cg%3D%3D"
+		}
+	},
+	"results": [
+		{
+			"createdAt": "2025-04-17T07:56:45.039Z",
+			"archived": false,
+			"archivedAt": "2025-04-17T07:56:45.039Z",
+			"propertiesWithHistory": {
+				"additionalProp1": [
+					{
+						"sourceId": "string",
+						"sourceType": "string",
+						"sourceLabel": "string",
+						"updatedByUserId": 0,
+						"value": "string",
+						"timestamp": "2025-04-17T07:56:45.039Z"
+					}
+				],
+				"additionalProp2": [
+					{
+						"sourceId": "string",
+						"sourceType": "string",
+						"sourceLabel": "string",
+						"updatedByUserId": 0,
+						"value": "string",
+						"timestamp": "2025-04-17T07:56:45.039Z"
+					}
+				],
+				"additionalProp3": [
+					{
+						"sourceId": "string",
+						"sourceType": "string",
+						"sourceLabel": "string",
+						"updatedByUserId": 0,
+						"value": "string",
+						"timestamp": "2025-04-17T07:56:45.039Z"
+					}
+				]
+			},
+			"id": "512",
+			"objectWriteTraceId": "string",
+			"properties": {
+				"property_date": "1572480000000",
+				"property_radio": "option_1",
+				"property_number": "17",
+				"property_string": "value",
+				"property_checkbox": "false",
+				"property_dropdown": "choice_b",
+				"property_multiple_checkboxes": "chocolate;strawberry"
+			},
+			"updatedAt": "2025-04-17T07:56:45.039Z"
+		}
+	]
+}


### PR DESCRIPTION
## Summary

- Include item index in error messages
- Add test coverage to HubSpot node (contacts,companies,deals)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1213/hubspot-output-error-item-index

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
