### PR TITLE
fix(editor): Highlight the suggested data type with bold in the Filter node

### DIFF
--- a/packages/frontend/editor-ui/src/components/FilterConditions/OperatorSelect.vue
+++ b/packages/frontend/editor-ui/src/components/FilterConditions/OperatorSelect.vue
@@ -136,7 +136,6 @@ function onGroupSelect(group: string) {
 	align-items: center;
 	justify-content: space-between;
 	font-size: var(--font-size-s);
-	font-weight: var(--font-weight-bold);
 	line-height: var(--font-line-height-regular);
 	color: var(--color-text-dark);
 	padding: var(--spacing-2xs) var(--spacing-s);


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Update styles in the Filter node operator select, so that only the datatype of the selected field is highlighted with bold, not all of them

Before:
![1](https://github.com/user-attachments/assets/2b3b48ce-ba60-498d-ac31-fd86b47618b9)

After (`foo` is a `number'):
![2](https://github.com/user-attachments/assets/7d12ca46-a08b-4582-8e0b-bbdaac0f6896)

After (`foo` is a `boolean`):
![3](https://github.com/user-attachments/assets/3f15f1d0-b6a8-48e3-934c-ea8583e6e8c0)

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

[https://linear.app/n8n/issue/NODE-2617/bug-filter-component-type-bolding-is-broken](https://linear.app/n8n/issue/NODE-2617/bug-filter-component-type-bolding-is-broken)

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
