### PR TITLE
fix(core): Handle task runner accept timeout error

### DIFF
--- a/packages/cli/src/task-runners/task-broker/__tests__/task-broker.service.test.ts
+++ b/packages/cli/src/task-runners/task-broker/__tests__/task-broker.service.test.ts
@@ -7,7 +7,7 @@ import { Time } from '@/constants';
 import type { TaskRunnerLifecycleEvents } from '@/task-runners/task-runner-lifecycle-events';
 
 import { TaskRejectError } from '../errors/task-reject.error';
-import { TaskRunnerTimeoutError } from '../errors/task-runner-timeout.error';
+import { TaskRunnerExecutionTimeoutError } from '../errors/task-runner-execution-timeout.error';
 import { TaskBroker } from '../task-broker.service';
 import type { TaskOffer, TaskRequest, TaskRunner } from '../task-broker.service';
 
@@ -715,7 +715,7 @@ describe('TaskBroker', () => {
 		});
 	});
 
-	describe('task timeouts', () => {
+	describe('task execution timeouts', () => {
 		let taskBroker: TaskBroker;
 		let config: TaskRunnersConfig;
 		let runnerLifecycleEvents = mock<TaskRunnerLifecycleEvents>();
@@ -879,11 +879,17 @@ describe('TaskBroker', () => {
 			expect(requesterCallback).toHaveBeenCalledWith({
 				type: 'broker:taskerror',
 				taskId,
-				error: expect.any(TaskRunnerTimeoutError),
+				error: expect.any(TaskRunnerExecutionTimeoutError),
 			});
 
 			expect(clearTimeout).toHaveBeenCalled();
 			expect(taskBroker.getTasks().get(taskId)).toBeUndefined();
+		});
+	});
+
+	describe('task runner accept timeout', () => {
+		it('broker should handle timeout when waiting for acknowledgment of offer accept', () => {
+			// @TODO
 		});
 	});
 });

--- a/packages/cli/src/task-runners/task-broker/errors/task-runner-accept-timeout.error.ts
+++ b/packages/cli/src/task-runners/task-broker/errors/task-runner-accept-timeout.error.ts
@@ -1,4 +1,6 @@
-export class TaskRunnerAcceptTimeoutError extends Error {
+import { OperationalError } from 'n8n-workflow';
+
+export class TaskRunnerAcceptTimeoutError extends OperationalError {
 	constructor(taskId: string, runnerId: string) {
 		super(`Runner (${runnerId}) took too long to acknowledge acceptance of task (${taskId})`);
 	}

--- a/packages/cli/src/task-runners/task-broker/errors/task-runner-accept-timeout.error.ts
+++ b/packages/cli/src/task-runners/task-broker/errors/task-runner-accept-timeout.error.ts
@@ -2,6 +2,8 @@ import { OperationalError } from 'n8n-workflow';
 
 export class TaskRunnerAcceptTimeoutError extends OperationalError {
 	constructor(taskId: string, runnerId: string) {
-		super(`Runner (${runnerId}) took too long to acknowledge acceptance of task (${taskId})`);
+		super(`Runner (${runnerId}) took too long to acknowledge acceptance of task (${taskId})`, {
+			level: 'warning',
+		});
 	}
 }

--- a/packages/cli/src/task-runners/task-broker/errors/task-runner-accept-timeout.error.ts
+++ b/packages/cli/src/task-runners/task-broker/errors/task-runner-accept-timeout.error.ts
@@ -1,0 +1,5 @@
+export class TaskRunnerAcceptTimeoutError extends Error {
+	constructor(taskId: string, runnerId: string) {
+		super(`Runner (${runnerId}) took too long to acknowledge acceptance of task (${taskId})`);
+	}
+}

--- a/packages/cli/src/task-runners/task-broker/errors/task-runner-execution-timeout.error.ts
+++ b/packages/cli/src/task-runners/task-broker/errors/task-runner-execution-timeout.error.ts
@@ -1,7 +1,7 @@
 import type { TaskRunnerMode } from '@n8n/config/src/configs/runners.config';
 import { OperationalError } from 'n8n-workflow';
 
-export class TaskRunnerTimeoutError extends OperationalError {
+export class TaskRunnerExecutionTimeoutError extends OperationalError {
 	description: string;
 
 	constructor({


### PR DESCRIPTION
## Summary

Whenever the broker finds a match and sends an accept to a task runner, if the runner for any reason times out when acknowledging the accept, we throw a timeout error in the broker, which sends the task back into matching, but also leads to an unhandled promise rejection. This PR handles it so we prevent rethrowing and simply warn about it, as this is transient and non-actionable to report to Sentry.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-762
https://n8nio.sentry.io/issues/6385397492

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
