### PR TITLE
fix(core): Fix using secrets for credentials on oauth callback

### DIFF
--- a/packages/cli/src/controllers/oauth/__tests__/oauth1-credential.controller.test.ts
+++ b/packages/cli/src/controllers/oauth/__tests__/oauth1-credential.controller.test.ts
@@ -86,7 +86,7 @@ describe('OAuth1CredentialController', () => {
 			jest.spyOn(Csrf.prototype, 'create').mockReturnValueOnce('token');
 			sharedCredentialsRepository.findCredentialForUser.mockResolvedValueOnce(credential);
 			credentialsHelper.getDecrypted.mockResolvedValueOnce({});
-			credentialsHelper.applyDefaultsAndOverwrites.mockReturnValueOnce({
+			credentialsHelper.applyDefaultsAndOverwrites.mockResolvedValue({
 				requestTokenUrl: 'https://example.domain/oauth/request_token',
 				authUrl: 'https://example.domain/oauth/authorize',
 				accessTokenUrl: 'https://example.domain/oauth/access_token',
@@ -223,7 +223,7 @@ describe('OAuth1CredentialController', () => {
 		it('should exchange the code for a valid token, and save it to DB', async () => {
 			credentialsRepository.findOneBy.mockResolvedValue(credential);
 			credentialsHelper.getDecrypted.mockResolvedValue({ csrfSecret });
-			credentialsHelper.applyDefaultsAndOverwrites.mockReturnValueOnce({
+			credentialsHelper.applyDefaultsAndOverwrites.mockResolvedValue({
 				requestTokenUrl: 'https://example.domain/oauth/request_token',
 				accessTokenUrl: 'https://example.domain/oauth/access_token',
 				signatureMethod: 'HMAC-SHA1',

--- a/packages/cli/src/controllers/oauth/__tests__/oauth1-credential.controller.test.ts
+++ b/packages/cli/src/controllers/oauth/__tests__/oauth1-credential.controller.test.ts
@@ -223,7 +223,7 @@ describe('OAuth1CredentialController', () => {
 		it('should exchange the code for a valid token, and save it to DB', async () => {
 			credentialsRepository.findOneBy.mockResolvedValue(credential);
 			credentialsHelper.getDecrypted.mockResolvedValue({ csrfSecret });
-			credentialsHelper.applyDefaultsAndOverwrites.mockResolvedValue({
+			credentialsHelper.applyDefaultsAndOverwrites.mockResolvedValueOnce({
 				requestTokenUrl: 'https://example.domain/oauth/request_token',
 				accessTokenUrl: 'https://example.domain/oauth/access_token',
 				signatureMethod: 'HMAC-SHA1',

--- a/packages/cli/src/controllers/oauth/__tests__/oauth1-credential.controller.test.ts
+++ b/packages/cli/src/controllers/oauth/__tests__/oauth1-credential.controller.test.ts
@@ -86,7 +86,7 @@ describe('OAuth1CredentialController', () => {
 			jest.spyOn(Csrf.prototype, 'create').mockReturnValueOnce('token');
 			sharedCredentialsRepository.findCredentialForUser.mockResolvedValueOnce(credential);
 			credentialsHelper.getDecrypted.mockResolvedValueOnce({});
-			credentialsHelper.applyDefaultsAndOverwrites.mockResolvedValue({
+			credentialsHelper.applyDefaultsAndOverwrites.mockResolvedValueOnce({
 				requestTokenUrl: 'https://example.domain/oauth/request_token',
 				authUrl: 'https://example.domain/oauth/authorize',
 				accessTokenUrl: 'https://example.domain/oauth/access_token',

--- a/packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts
+++ b/packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts
@@ -64,7 +64,7 @@ describe('OAuth2CredentialController', () => {
 		jest.setSystemTime(new Date(timestamp));
 		jest.clearAllMocks();
 
-		credentialsHelper.applyDefaultsAndOverwrites.mockReturnValue({
+		credentialsHelper.applyDefaultsAndOverwrites.mockResolvedValue({
 			clientId: 'test-client-id',
 			clientSecret: 'oauth-secret',
 			authUrl: 'https://example.domain/o/oauth2/v2/auth',
@@ -356,18 +356,6 @@ describe('OAuth2CredentialController', () => {
 				}),
 			]);
 			const dataCaptor = captor();
-			// check that credentialsHelper.applyDefaultsAndOverwrites is called with the canUseSecrets true
-			expect(credentialsHelper.applyDefaultsAndOverwrites).toHaveBeenCalledWith(
-				additionalData,
-				expect.objectContaining({
-					oauthTokenData: CREDENTIAL_BLANKING_VALUE,
-				}),
-				credential.type,
-				'internal',
-				undefined,
-				undefined,
-				true,
-			);
 			expect(credentialsRepository.update).toHaveBeenCalledWith(
 				'1',
 				expect.objectContaining({

--- a/packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts
+++ b/packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts
@@ -70,7 +70,6 @@ describe('OAuth2CredentialController', () => {
 			authUrl: 'https://example.domain/o/oauth2/v2/auth',
 			accessTokenUrl: 'https://example.domain/token',
 		});
-		credentialsHelper.credentialCanUseExternalSecrets.mockResolvedValue(true);
 	});
 
 	describe('getAuthUri', () => {

--- a/packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts
+++ b/packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts
@@ -70,6 +70,7 @@ describe('OAuth2CredentialController', () => {
 			authUrl: 'https://example.domain/o/oauth2/v2/auth',
 			accessTokenUrl: 'https://example.domain/token',
 		});
+		credentialsHelper.credentialCanUseExternalSecrets.mockResolvedValue(true);
 	});
 
 	describe('getAuthUri', () => {
@@ -355,6 +356,18 @@ describe('OAuth2CredentialController', () => {
 				}),
 			]);
 			const dataCaptor = captor();
+			// check that credentialsHelper.applyDefaultsAndOverwrites is called with the canUseSecrets true
+			expect(credentialsHelper.applyDefaultsAndOverwrites).toHaveBeenCalledWith(
+				additionalData,
+				expect.objectContaining({
+					oauthTokenData: CREDENTIAL_BLANKING_VALUE,
+				}),
+				credential.type,
+				'internal',
+				undefined,
+				undefined,
+				true,
+			);
 			expect(credentialsRepository.update).toHaveBeenCalledWith(
 				'1',
 				expect.objectContaining({

--- a/packages/cli/src/controllers/oauth/abstract-oauth.controller.ts
+++ b/packages/cli/src/controllers/oauth/abstract-oauth.controller.ts
@@ -125,12 +125,16 @@ export abstract class AbstractOAuthController {
 		credential: ICredentialsDb,
 		decryptedData: ICredentialDataDecryptedObject,
 		additionalData: IWorkflowExecuteAdditionalData,
+		canUseSecrets: boolean = false,
 	) {
 		return this.credentialsHelper.applyDefaultsAndOverwrites(
 			additionalData,
 			decryptedData,
 			credential.type,
 			'internal',
+			undefined,
+			undefined,
+			canUseSecrets,
 		) as unknown as T;
 	}
 
@@ -209,10 +213,13 @@ export abstract class AbstractOAuthController {
 			credential,
 			additionalData,
 		);
+
+		const canUseSecrets = await this.credentialsHelper.credentialCanUseExternalSecrets(credential);
 		const oauthCredentials = this.applyDefaultsAndOverwrites<T>(
 			credential,
 			decryptedDataOriginal,
 			additionalData,
+			canUseSecrets,
 		);
 
 		if (!this.verifyCsrfState(decryptedDataOriginal, state)) {

--- a/packages/cli/src/controllers/oauth/abstract-oauth.controller.ts
+++ b/packages/cli/src/controllers/oauth/abstract-oauth.controller.ts
@@ -121,21 +121,20 @@ export abstract class AbstractOAuthController {
 		);
 	}
 
-	protected applyDefaultsAndOverwrites<T>(
+	protected async applyDefaultsAndOverwrites<T>(
 		credential: ICredentialsDb,
 		decryptedData: ICredentialDataDecryptedObject,
 		additionalData: IWorkflowExecuteAdditionalData,
-		canUseSecrets: boolean = false,
 	) {
-		return this.credentialsHelper.applyDefaultsAndOverwrites(
+		return (await this.credentialsHelper.applyDefaultsAndOverwrites(
 			additionalData,
 			decryptedData,
+			credential,
 			credential.type,
 			'internal',
 			undefined,
 			undefined,
-			canUseSecrets,
-		) as unknown as T;
+		)) as unknown as T;
 	}
 
 	protected async encryptAndSaveData(
@@ -214,12 +213,10 @@ export abstract class AbstractOAuthController {
 			additionalData,
 		);
 
-		const canUseSecrets = await this.credentialsHelper.credentialCanUseExternalSecrets(credential);
-		const oauthCredentials = this.applyDefaultsAndOverwrites<T>(
+		const oauthCredentials = await this.applyDefaultsAndOverwrites<T>(
 			credential,
 			decryptedDataOriginal,
 			additionalData,
-			canUseSecrets,
 		);
 
 		if (!this.verifyCsrfState(decryptedDataOriginal, state)) {

--- a/packages/cli/src/controllers/oauth/oauth1-credential.controller.ts
+++ b/packages/cli/src/controllers/oauth/oauth1-credential.controller.ts
@@ -36,7 +36,7 @@ export class OAuth1CredentialController extends AbstractOAuthController {
 		const credential = await this.getCredential(req);
 		const additionalData = await this.getAdditionalData();
 		const decryptedDataOriginal = await this.getDecryptedDataForAuthUri(credential, additionalData);
-		const oauthCredentials = this.applyDefaultsAndOverwrites<OAuth1CredentialData>(
+		const oauthCredentials = await this.applyDefaultsAndOverwrites<OAuth1CredentialData>(
 			credential,
 			decryptedDataOriginal,
 			additionalData,

--- a/packages/cli/src/controllers/oauth/oauth2-credential.controller.ts
+++ b/packages/cli/src/controllers/oauth/oauth2-credential.controller.ts
@@ -37,7 +37,7 @@ export class OAuth2CredentialController extends AbstractOAuthController {
 			delete decryptedDataOriginal.scope;
 		}
 
-		const oauthCredentials = this.applyDefaultsAndOverwrites<OAuth2CredentialData>(
+		const oauthCredentials = await this.applyDefaultsAndOverwrites<OAuth2CredentialData>(
 			credential,
 			decryptedDataOriginal,
 			additionalData,

--- a/packages/cli/src/credentials-helper.ts
+++ b/packages/cli/src/credentials-helper.ts
@@ -331,31 +331,29 @@ export class CredentialsHelper extends ICredentialsHelper {
 
 		await additionalData?.secretsHelpers?.waitForInit();
 
-		const canUseSecrets = await this.credentialCanUseExternalSecrets(nodeCredentials);
-
-		return this.applyDefaultsAndOverwrites(
+		return await this.applyDefaultsAndOverwrites(
 			additionalData,
 			decryptedDataOriginal,
+			nodeCredentials,
 			type,
 			mode,
 			executeData,
 			expressionResolveValues,
-			canUseSecrets,
 		);
 	}
 
 	/**
 	 * Applies credential default data and overwrites
 	 */
-	applyDefaultsAndOverwrites(
+	async applyDefaultsAndOverwrites(
 		additionalData: IWorkflowExecuteAdditionalData,
 		decryptedDataOriginal: ICredentialDataDecryptedObject,
+		credential: INodeCredentialsDetails,
 		type: string,
 		mode: WorkflowExecuteMode,
 		executeData?: IExecuteData,
 		expressionResolveValues?: ICredentialsExpressionResolveValues,
-		canUseSecrets?: boolean,
-	): ICredentialDataDecryptedObject {
+	): Promise<ICredentialDataDecryptedObject> {
 		const credentialsProperties = this.getCredentialsProperties(type);
 
 		// Load and apply the credentials overwrites if any exist
@@ -380,8 +378,9 @@ export class CredentialsHelper extends ICredentialsHelper {
 			decryptedData.oauthTokenData = decryptedDataOriginal.oauthTokenData;
 		}
 
+		const canUseExternalSecrets = await this.credentialCanUseExternalSecrets(credential);
 		const additionalKeys = getAdditionalKeys(additionalData, mode, null, {
-			secretsEnabled: canUseSecrets,
+			secretsEnabled: canUseExternalSecrets,
 		});
 
 		if (expressionResolveValues) {

--- a/packages/cli/src/services/credentials-tester.service.ts
+++ b/packages/cli/src/services/credentials-tester.service.ts
@@ -187,14 +187,14 @@ export class CredentialsTester {
 		if (credentialsDecrypted.data) {
 			try {
 				const additionalData = await WorkflowExecuteAdditionalData.getBase(userId);
-				credentialsDecrypted.data = this.credentialsHelper.applyDefaultsAndOverwrites(
+				credentialsDecrypted.data = await this.credentialsHelper.applyDefaultsAndOverwrites(
 					additionalData,
 					credentialsDecrypted.data,
+					credentialsDecrypted,
 					credentialType,
 					'internal' as WorkflowExecuteMode,
 					undefined,
 					undefined,
-					await this.credentialsHelper.credentialCanUseExternalSecrets(credentialsDecrypted),
 				);
 			} catch (error) {
 				this.logger.debug('Credential test failed', error);

--- a/packages/cli/test/integration/controllers/oauth/oauth2.api.test.ts
+++ b/packages/cli/test/integration/controllers/oauth/oauth2.api.test.ts
@@ -28,7 +28,7 @@ describe('OAuth2 API', () => {
 		authQueryParameters: 'access_type=offline',
 	};
 
-	CredentialsHelper.prototype.applyDefaultsAndOverwrites = (_, decryptedDataOriginal) =>
+	CredentialsHelper.prototype.applyDefaultsAndOverwrites = async (_, decryptedDataOriginal) =>
 		decryptedDataOriginal;
 
 	beforeAll(async () => {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
This PR ensures that the canUseSecrets flag is properly passed to applyDefaultsAndOverwrites during the OAuth callback flow. This allows credentials to correctly use external secrets when available (which did not work since https://github.com/n8n-io/n8n/pull/13110)

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2744/oauth2-secrets-bug-is-back
https://support.n8n.io/#ticket/zoom/16592

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
