### PR TITLE
fix(editor): Place duplicated WFs always to correct parent folders

### DIFF
--- a/cypress/composables/folders.ts
+++ b/cypress/composables/folders.ts
@@ -1,4 +1,4 @@
-import { successToast } from '../pages/notifications';
+import { errorToast, successToast } from '../pages/notifications';
 
 /**
  * Getters
@@ -45,6 +45,14 @@ export function getWorkflowCardActionItem(workflowName: string, actionName: stri
 		.then((popperId) => {
 			return cy.get(`#${popperId}`).find(`[data-test-id="action-${actionName}"]`);
 		});
+}
+
+export function getDuplicateWorkflowModal() {
+	return cy.getByTestId('duplicate-modal');
+}
+
+export function getWorkflowMenu() {
+	return cy.getByTestId('workflow-menu');
 }
 
 export function getAddFolderButton() {
@@ -302,6 +310,24 @@ export function renameFolderFromCardActions(folderName: string, newName: string)
 	getFolderCardActionToggle(folderName).click();
 	getFolderCardActionItem(folderName, 'rename').click();
 	renameFolder(newName);
+}
+
+export function duplicateWorkflowFromCardActions(workflowName: string, duplicateName: string) {
+	getWorkflowCardActions(workflowName).click();
+	getWorkflowCardActionItem(workflowName, 'duplicate').click();
+	getDuplicateWorkflowModal().find('input').first().type('{selectall}');
+	getDuplicateWorkflowModal().find('input').first().type(duplicateName);
+	getDuplicateWorkflowModal().find('button').contains('Duplicate').click();
+	errorToast().should('not.exist');
+}
+
+export function duplicateWorkflowFromWorkflowPage(duplicateName: string) {
+	getWorkflowMenu().click();
+	cy.getByTestId('workflow-menu-item-duplicate').click();
+	getDuplicateWorkflowModal().find('input').first().type('{selectall}');
+	getDuplicateWorkflowModal().find('input').first().type(duplicateName);
+	getDuplicateWorkflowModal().find('button').contains('Duplicate').click();
+	errorToast().should('not.exist');
 }
 
 export function deleteEmptyFolderFromCardDropdown(folderName: string) {

--- a/cypress/e2e/49-folders.cy.ts
+++ b/cypress/e2e/49-folders.cy.ts
@@ -16,6 +16,8 @@ import {
 	deleteFolderWithContentsFromListDropdown,
 	dragAndDropToFolder,
 	dragAndDropToProjectRoot,
+	duplicateWorkflowFromCardActions,
+	duplicateWorkflowFromWorkflowPage,
 	getAddResourceDropdown,
 	getCurrentBreadcrumb,
 	getFolderCard,
@@ -535,6 +537,72 @@ describe('Folders', () => {
 			// Card badges with breadcrumbs should be shown
 			getFolderCard('Child Folder').findChildByTestId('card-badge').should('exist');
 			getWorkflowCard('Child - Workflow').findChildByTestId('card-badge').should('exist');
+		});
+	});
+
+	describe('Duplicate workflows', () => {
+		beforeEach(() => {
+			// Prevent the duplicated workflow from opening in a new tab
+			cy.window().then((win) => {
+				cy.stub(win, 'open').as('open');
+			});
+		});
+
+		it('should duplicate workflow within root folder from personal projects', () => {
+			goToPersonalProject();
+			createWorkflowFromProjectHeader(undefined, 'Duplicate Me From Root');
+			goToPersonalProject();
+			duplicateWorkflowFromCardActions('Duplicate Me From Root', 'Duplicate Me From Root (Copy)');
+			getWorkflowCard('Duplicate Me From Root (Copy)').should('exist');
+		});
+
+		it('should duplicate workflow within a folder from personal projects', () => {
+			goToPersonalProject();
+			createFolderFromProjectHeader('Parent folder for duplication');
+			getFolderCard('Parent folder for duplication').click();
+			createWorkflowFromProjectHeader(
+				'Parent folder for duplication',
+				'Duplicate Me From Personal',
+			);
+			goToPersonalProject();
+			getFolderCard('Parent folder for duplication').click();
+			duplicateWorkflowFromCardActions(
+				'Duplicate Me From Personal',
+				'Duplicate Me From Personal (Copy)',
+			);
+			getWorkflowCard('Duplicate Me From Personal (Copy)').should('exist');
+		});
+
+		it('should duplicate workflow within a folder from overview', () => {
+			goToPersonalProject();
+			getFolderCard('Parent folder for duplication').click();
+			createWorkflowFromProjectHeader(
+				'Parent folder for duplication',
+				'Duplicate Me From Overview',
+			);
+			getOverviewMenuItem().click();
+			duplicateWorkflowFromCardActions(
+				'Duplicate Me From Overview',
+				'Duplicate Me From Overview (Copy)',
+			);
+			getWorkflowCard('Duplicate Me From Overview (Copy)').should('exist');
+			goToPersonalProject();
+			getFolderCard('Parent folder for duplication').click();
+			getWorkflowCard('Duplicate Me From Overview (Copy)').should('exist');
+		});
+
+		it('should duplicate workflow within a folder from workflow', () => {
+			goToPersonalProject();
+			createFolderFromProjectHeader('Parent folder for duplication');
+			getFolderCard('Parent folder for duplication').click();
+			createWorkflowFromProjectHeader(
+				'Parent folder for duplication',
+				'Duplicate Me From Workflow',
+			);
+			duplicateWorkflowFromWorkflowPage('Duplicate Me From Workflow (Copy)');
+			goToPersonalProject();
+			getFolderCard('Parent folder for duplication').click();
+			getWorkflowCard('Duplicate Me From Workflow (Copy)').should('exist');
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/components/DuplicateWorkflowDialog.vue
+++ b/packages/frontend/editor-ui/src/components/DuplicateWorkflowDialog.vue
@@ -17,7 +17,13 @@ import { useTelemetry } from '@/composables/useTelemetry';
 const props = defineProps<{
 	modalName: string;
 	isActive: boolean;
-	data: { tags: string[]; id: string; name: string; externalEventBus?: EventBus };
+	data: {
+		tags: string[];
+		id: string;
+		name: string;
+		externalEventBus?: EventBus;
+		parentFolderId?: string;
+	};
 }>();
 
 const router = useRouter();
@@ -72,7 +78,7 @@ const save = async (): Promise<void> => {
 		return;
 	}
 
-	const parentFolderId = router.currentRoute.value.params.folderId as string | undefined;
+	const parentFolderId = props.data.parentFolderId;
 
 	const currentWorkflowId = props.data.id;
 	isSaving.value = true;

--- a/packages/frontend/editor-ui/src/components/MainHeader/WorkflowDetails.vue
+++ b/packages/frontend/editor-ui/src/components/MainHeader/WorkflowDetails.vue
@@ -408,6 +408,7 @@ async function onWorkflowMenuSelect(action: WORKFLOW_MENU_ACTIONS): Promise<void
 					id: props.id,
 					name: props.name,
 					tags: props.tags,
+					parentFolderId: currentFolder?.value?.id,
 				},
 			});
 			break;

--- a/packages/frontend/editor-ui/src/components/WorkflowCard.vue
+++ b/packages/frontend/editor-ui/src/components/WorkflowCard.vue
@@ -220,7 +220,7 @@ async function onAction(action: string) {
 						typeof tag !== 'string' && 'id' in tag ? tag.id : tag,
 					),
 					externalEventBus: props.workflowListEventBus,
-					parentFolderId: router.currentRoute.value.params.folderId as string | undefined,
+					parentFolderId: props.data.parentFolder?.id,
 				},
 			});
 			break;

--- a/packages/frontend/editor-ui/src/components/WorkflowCard.vue
+++ b/packages/frontend/editor-ui/src/components/WorkflowCard.vue
@@ -220,6 +220,7 @@ async function onAction(action: string) {
 						typeof tag !== 'string' && 'id' in tag ? tag.id : tag,
 					),
 					externalEventBus: props.workflowListEventBus,
+					parentFolderId: router.currentRoute.value.params.folderId as string | undefined,
 				},
 			});
 			break;


### PR DESCRIPTION
## Summary

Fix a bug that would cause workflows duplicated on the WF canvas to always be placed in the root parent folder instead of their current parent folder, like when duplicating folders on the workflow list.

To do this, I changed the `DuplicateWorkflowDialog` to get the `parentFolderId` via its props instead of the current route's folder param, as not all routes have folder parameter.

Also fixes the same bug when duplicating a workflow when on the "overview" page, which didn't have route folder param.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/ADO-3402/bug-duplicating-a-wf-should-duplicate-in-same-folder

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
