### PR TITLE
fix(Respond to Webhook Node): Disable expressions in Respond With

### DIFF
--- a/packages/nodes-base/nodes/RespondToWebhook/RespondToWebhook.node.ts
+++ b/packages/nodes-base/nodes/RespondToWebhook/RespondToWebhook.node.ts
@@ -6,6 +6,7 @@ import type {
 	IN8nHttpFullResponse,
 	IN8nHttpResponse,
 	INodeExecutionData,
+	INodeProperties,
 	INodeType,
 	INodeTypeDescription,
 } from 'n8n-workflow';
@@ -23,13 +24,63 @@ import type { Readable } from 'stream';
 
 import { formatPrivateKey, generatePairedItemData } from '../../utils/utilities';
 
+const respondWithProperty: INodeProperties = {
+	displayName: 'Respond With',
+	name: 'respondWith',
+	type: 'options',
+	options: [
+		{
+			name: 'All Incoming Items',
+			value: 'allIncomingItems',
+			description: 'Respond with all input JSON items',
+		},
+		{
+			name: 'Binary File',
+			value: 'binary',
+			description: 'Respond with incoming file binary data',
+		},
+		{
+			name: 'First Incoming Item',
+			value: 'firstIncomingItem',
+			description: 'Respond with the first input JSON item',
+		},
+		{
+			name: 'JSON',
+			value: 'json',
+			description: 'Respond with a custom JSON body',
+		},
+		{
+			name: 'JWT Token',
+			value: 'jwt',
+			description: 'Respond with a JWT token',
+		},
+		{
+			name: 'No Data',
+			value: 'noData',
+			description: 'Respond with an empty body',
+		},
+		{
+			name: 'Redirect',
+			value: 'redirect',
+			description: 'Respond with a redirect to a given URL',
+		},
+		{
+			name: 'Text',
+			value: 'text',
+			description: 'Respond with a simple text message body',
+		},
+	],
+	default: 'firstIncomingItem',
+	description: 'The data that should be returned',
+};
+
 export class RespondToWebhook implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'Respond to Webhook',
 		icon: { light: 'file:webhook.svg', dark: 'file:webhook.dark.svg' },
 		name: 'respondToWebhook',
 		group: ['transform'],
-		version: [1, 1.1],
+		version: [1, 1.1, 1.2],
 		description: 'Returns data for Webhook',
 		defaults: {
 			name: 'Respond to Webhook',
@@ -56,54 +107,13 @@ export class RespondToWebhook implements INodeType {
 				default: '',
 			},
 			{
-				displayName: 'Respond With',
-				name: 'respondWith',
-				type: 'options',
+				...respondWithProperty,
+				displayOptions: { show: { '@version': [1, 1.1] } },
+			},
+			{
+				...respondWithProperty,
 				noDataExpression: true,
-				options: [
-					{
-						name: 'All Incoming Items',
-						value: 'allIncomingItems',
-						description: 'Respond with all input JSON items',
-					},
-					{
-						name: 'Binary File',
-						value: 'binary',
-						description: 'Respond with incoming file binary data',
-					},
-					{
-						name: 'First Incoming Item',
-						value: 'firstIncomingItem',
-						description: 'Respond with the first input JSON item',
-					},
-					{
-						name: 'JSON',
-						value: 'json',
-						description: 'Respond with a custom JSON body',
-					},
-					{
-						name: 'JWT Token',
-						value: 'jwt',
-						description: 'Respond with a JWT token',
-					},
-					{
-						name: 'No Data',
-						value: 'noData',
-						description: 'Respond with an empty body',
-					},
-					{
-						name: 'Redirect',
-						value: 'redirect',
-						description: 'Respond with a redirect to a given URL',
-					},
-					{
-						name: 'Text',
-						value: 'text',
-						description: 'Respond with a simple text message body',
-					},
-				],
-				default: 'firstIncomingItem',
-				description: 'The data that should be returned',
+				displayOptions: { show: { '@version': [{ _cnd: { gte: 1.2 } }] } },
 			},
 			{
 				displayName: 'Credentials',

--- a/packages/nodes-base/nodes/RespondToWebhook/RespondToWebhook.node.ts
+++ b/packages/nodes-base/nodes/RespondToWebhook/RespondToWebhook.node.ts
@@ -59,6 +59,7 @@ export class RespondToWebhook implements INodeType {
 				displayName: 'Respond With',
 				name: 'respondWith',
 				type: 'options',
+				noDataExpression: true,
 				options: [
 					{
 						name: 'All Incoming Items',


### PR DESCRIPTION
## Summary

Respond With should not allow to set expression

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2649/respond-to-webhook-respond-with-expression

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
