### PR TITLE
fix(n8n Form Trigger Node): Remove relience on getWorkflowStaticData for passing query parameters

### DIFF
--- a/packages/cli/templates/form-trigger.handlebars
+++ b/packages/cli/templates/form-trigger.handlebars
@@ -852,11 +852,14 @@
 					document.querySelector('#submit-btn').style.cursor = 'not-allowed';
 					document.querySelector('#submit-btn span').style.display = 'inline-block';
 
+					let postUrl = '';
 					if (window.location.href.includes('form-waiting')) {
 						intervalId = setTimeout(checkExecutionStatus, interval);
+					} else {
+						postUrl = window.location.search;
 					}
 
-					fetch('', {
+					fetch(postUrl, {
 						method: 'POST',
 						body: formData,
 					})

--- a/packages/nodes-base/nodes/Form/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/utils.test.ts
@@ -746,7 +746,7 @@ describe('prepareFormReturnItem', () => {
 		expect(result.json.formQueryParameters).toBeUndefined();
 	});
 
-	it.only('should include query parameters if present and is trigger node', async () => {
+	it('should include query parameters if present and is trigger node', async () => {
 		mockContext.getRequestObject.mockReturnValue({
 			method: 'POST',
 			query: { param: 'value' },
@@ -757,7 +757,7 @@ describe('prepareFormReturnItem', () => {
 		expect(result.json.formQueryParameters).toEqual({ param: 'value' });
 	});
 
-	it.only('should not include query parameters if empty', async () => {
+	it('should not include query parameters if empty', async () => {
 		mockContext.getRequestObject.mockReturnValue({
 			method: 'POST',
 			query: {},

--- a/packages/nodes-base/nodes/Form/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/utils.test.ts
@@ -1,3 +1,4 @@
+import type { Request } from 'express';
 import { mock } from 'jest-mock-extended';
 import { DateTime } from 'luxon';
 import type {
@@ -603,6 +604,7 @@ jest.mock('luxon', () => ({
 
 describe('prepareFormReturnItem', () => {
 	const mockContext = mock<IWebhookFunctions>({
+		getRequestObject: jest.fn().mockReturnValue({ method: 'GET', query: {} }),
 		nodeHelpers: mock({
 			copyBinaryFile: jest.fn().mockResolvedValue({}),
 		}),
@@ -735,13 +737,35 @@ describe('prepareFormReturnItem', () => {
 		expect(DateTime.now().setZone).toHaveBeenCalledWith('America/New_York');
 	});
 
-	it('should include workflow static data for form trigger node', async () => {
+	it('should not include workflow static data for form trigger node', async () => {
 		const staticData = { queryParam: 'value' };
 		mockContext.getWorkflowStaticData.mockReturnValue(staticData);
 
 		const result = await prepareFormReturnItem(mockContext, [], 'test');
 
-		expect(result.json.formQueryParameters).toEqual(staticData);
+		expect(result.json.formQueryParameters).toBeUndefined();
+	});
+
+	it.only('should include query parameters if present and is trigger node', async () => {
+		mockContext.getRequestObject.mockReturnValue({
+			method: 'POST',
+			query: { param: 'value' },
+		} as unknown as Request);
+
+		const result = await prepareFormReturnItem(mockContext, [], 'test');
+
+		expect(result.json.formQueryParameters).toEqual({ param: 'value' });
+	});
+
+	it.only('should not include query parameters if empty', async () => {
+		mockContext.getRequestObject.mockReturnValue({
+			method: 'POST',
+			query: {},
+		} as unknown as Request);
+
+		const result = await prepareFormReturnItem(mockContext, [], 'test');
+
+		expect(result.json.formQueryParameters).toBeUndefined();
 	});
 
 	it('should return html if field name is set', async () => {

--- a/packages/nodes-base/nodes/Form/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils.ts
@@ -369,12 +369,11 @@ export async function prepareFormReturnItem(
 
 	returnItem.json.formMode = mode;
 
-	const workflowStaticData = context.getWorkflowStaticData('node');
 	if (
-		Object.keys(workflowStaticData || {}).length &&
-		context.getNode().type === FORM_TRIGGER_NODE_TYPE
+		context.getNode().type === FORM_TRIGGER_NODE_TYPE &&
+		Object.keys(context.getRequestObject().query || {}).length
 	) {
-		returnItem.json.formQueryParameters = workflowStaticData;
+		returnItem.json.formQueryParameters = context.getRequestObject().query;
 	}
 
 	return returnItem;
@@ -416,10 +415,6 @@ export function renderForm({
 
 	if (context.getNode().type === FORM_TRIGGER_NODE_TYPE) {
 		query = context.getRequestObject().query as IDataObject;
-		const workflowStaticData = context.getWorkflowStaticData('node');
-		for (const key of Object.keys(query)) {
-			workflowStaticData[key] = query[key];
-		}
 	} else if (context.getNode().type === FORM_NODE_TYPE) {
 		const parentNodes = context.getParentNodes(context.getNode().name);
 		const trigger = parentNodes.find(

--- a/packages/nodes-base/utils/sendAndWait/test/util.test.ts
+++ b/packages/nodes-base/utils/sendAndWait/test/util.test.ts
@@ -341,6 +341,7 @@ describe('Send and Wait utils tests', () => {
 			mockWebhookFunctions.getRequestObject.mockReturnValue({
 				method: 'POST',
 			} as any);
+			mockWebhookFunctions.getNode.mockReturnValue({} as any);
 
 			mockWebhookFunctions.getNodeParameter.mockImplementation((parameterName: string) => {
 				const params: { [key: string]: any } = {


### PR DESCRIPTION
## Summary

Remove relience on getWorkflowStaticData for passing query parameters

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2826/community-issue-n8n-form-formqueryparameters-cached-between-executions
closes https://github.com/n8n-io/n8n/issues/14391

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
