### PR TITLE
feat(editor): Add support for automatic expression switching to RLC

### DIFF
--- a/packages/frontend/editor-ui/src/components/ResourceLocator/ResourceLocator.test.ts
+++ b/packages/frontend/editor-ui/src/components/ResourceLocator/ResourceLocator.test.ts
@@ -237,8 +237,8 @@ describe('ResourceLocator', () => {
 
 		const input = getByTestId('rlc-input');
 		await userEvent.click(input);
-		// '{' is an escape character: '{{{{' === '{{'
 		const expression = new DataTransfer();
+		// '{' is an escape character: '{{{{' === '{{'
 		expression.setData('text', '{{ ');
 		await userEvent.clear(input);
 		await userEvent.paste(expression);
@@ -255,9 +255,7 @@ describe('ResourceLocator', () => {
 	});
 
 	it('can switch between modes', async () => {
-		const { getByTestId, emitted } = renderComponent({
-			props: { modelValue: { ...TEST_MODEL_VALUE, mode: 'id' } },
-		});
+		const { getByTestId, emitted } = renderComponent();
 
 		await userEvent.click(getByTestId('rlc-mode-selector'));
 		await userEvent.click(screen.getByTestId('mode-id'));
@@ -266,7 +264,7 @@ describe('ResourceLocator', () => {
 				{
 					__rl: true,
 					mode: 'id',
-					value: '',
+					value: 'test',
 				},
 			],
 		]);

--- a/packages/frontend/editor-ui/src/components/ResourceLocator/ResourceLocator.test.ts
+++ b/packages/frontend/editor-ui/src/components/ResourceLocator/ResourceLocator.test.ts
@@ -229,4 +229,46 @@ describe('ResourceLocator', () => {
 			expect(queryByTestId('permission-error-link')).not.toBeInTheDocument();
 		});
 	});
+
+	it('switches to expression when user enters "{{ "', async () => {
+		const { getByTestId, emitted } = renderComponent({
+			props: { modelValue: { ...TEST_MODEL_VALUE, value: '', mode: 'id' } },
+		});
+
+		const input = getByTestId('rlc-input');
+		await userEvent.click(input);
+		// '{' is an escape character: '{{{{' === '{{'
+		const expression = new DataTransfer();
+		expression.setData('text', '{{ ');
+		await userEvent.clear(input);
+		await userEvent.paste(expression);
+
+		expect(emitted('update:modelValue')).toEqual([
+			[
+				{
+					__rl: true,
+					mode: 'id',
+					value: '={{  }}',
+				},
+			],
+		]);
+	});
+
+	it('can switch between modes', async () => {
+		const { getByTestId, emitted } = renderComponent({
+			props: { modelValue: { ...TEST_MODEL_VALUE, mode: 'id' } },
+		});
+
+		await userEvent.click(getByTestId('rlc-mode-selector'));
+		await userEvent.click(screen.getByTestId('mode-id'));
+		expect(emitted('update:modelValue')).toEqual([
+			[
+				{
+					__rl: true,
+					mode: 'id',
+					value: '',
+				},
+			],
+		]);
+	});
 });

--- a/packages/frontend/editor-ui/src/components/ResourceLocator/ResourceLocator.vue
+++ b/packages/frontend/editor-ui/src/components/ResourceLocator/ResourceLocator.vue
@@ -54,6 +54,7 @@ import {
 	type FromAIOverride,
 } from '../../utils/fromAIOverrideUtils';
 import { N8nNotice } from '@n8n/design-system';
+import { completeExpressionSyntax } from '@/utils/expressions';
 
 /**
  * Regular expression to check if the error message contains credential-related phrases.
@@ -355,10 +356,12 @@ watch(currentQueryError, (curr, prev) => {
 
 watch(
 	() => props.isValueExpression,
-	(newValue) => {
+	async (newValue) => {
 		if (newValue) {
 			switchFromListMode();
 		}
+		await nextTick();
+		inputRef.value?.focus();
 	},
 );
 
@@ -507,6 +510,7 @@ function getModeLabel(mode: INodePropertyMode): string | null {
 
 function onInputChange(value: NodeParameterValue): void {
 	const params: INodeParameterResourceLocator = { __rl: true, value, mode: selectedMode.value };
+	console.log('===CHANGE===, value');
 	if (isListMode.value) {
 		const resource = currentQueryResults.value.find((result) => result.value === value);
 		if (resource?.name) {
@@ -516,6 +520,8 @@ function onInputChange(value: NodeParameterValue): void {
 		if (resource?.url) {
 			params.cachedResultUrl = resource.url;
 		}
+	} else {
+		params.value = completeExpressionSyntax(value);
 	}
 	emit('update:modelValue', params);
 }

--- a/packages/frontend/editor-ui/src/components/ResourceLocator/ResourceLocator.vue
+++ b/packages/frontend/editor-ui/src/components/ResourceLocator/ResourceLocator.vue
@@ -510,7 +510,6 @@ function getModeLabel(mode: INodePropertyMode): string | null {
 
 function onInputChange(value: NodeParameterValue): void {
 	const params: INodeParameterResourceLocator = { __rl: true, value, mode: selectedMode.value };
-	console.log('===CHANGE===, value');
 	if (isListMode.value) {
 		const resource = currentQueryResults.value.find((result) => result.value === value);
 		if (resource?.name) {


### PR DESCRIPTION
## Summary

When user enters `{{ ` automatically switch to expression mode, maintain focus

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2656/auto-switch-to-expression-not-working-in-resource-locator

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
