### PR TITLE
feat: Only show workflows shared with you in the overview page

### DIFF
--- a/packages/cli/src/workflows/workflow-sharing.service.ts
+++ b/packages/cli/src/workflows/workflow-sharing.service.ts
@@ -37,9 +37,7 @@ export class WorkflowSharingService {
 		if (user.hasGlobalScope('workflow:read')) {
 			const sharedWorkflows = await this.sharedWorkflowRepository.find({
 				select: ['workflowId'],
-				where: {
-					...(projectId && { projectId }),
-				},
+				...(projectId && { where: { projectId } }),
 			});
 			return sharedWorkflows.map(({ workflowId }) => workflowId);
 		}

--- a/packages/cli/src/workflows/workflow-sharing.service.ts
+++ b/packages/cli/src/workflows/workflow-sharing.service.ts
@@ -27,6 +27,7 @@ export class WorkflowSharingService {
 	 * scope or roles.
 	 * If `scopes` is passed the roles are inferred. Alternatively `projectRoles`
 	 * and `workflowRoles` can be passed specifically.
+	 * if `projectId` is passed, only workflows where the user is the owner are returned.
 	 *
 	 * Returns all IDs if user has the 'workflow:read' global scope.
 	 */

--- a/packages/cli/src/workflows/workflow-sharing.service.ts
+++ b/packages/cli/src/workflows/workflow-sharing.service.ts
@@ -9,10 +9,9 @@ import type { User } from '@/databases/entities/user';
 import { ProjectRelationRepository } from '@/databases/repositories/project-relation.repository';
 import { SharedWorkflowRepository } from '@/databases/repositories/shared-workflow.repository';
 import { RoleService } from '@/services/role.service';
-import { Project } from '@/databases/entities/project';
 
 export type ShareWorkflowOptions =
-	| { scopes: Scope[]; projectId?: string; workflowRoles?: WorkflowSharingRole[] }
+	| { scopes: Scope[]; projectId?: string }
 	| { projectRoles: ProjectRole[]; workflowRoles: WorkflowSharingRole[]; projectId?: string };
 
 @Service()

--- a/packages/cli/src/workflows/workflow-sharing.service.ts
+++ b/packages/cli/src/workflows/workflow-sharing.service.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/order */
 import type { ProjectRole } from '@n8n/api-types';
 import { Service } from '@n8n/di';
 import type { Scope } from '@n8n/permissions';
@@ -9,8 +10,6 @@ import type { User } from '@/databases/entities/user';
 import { ProjectRelationRepository } from '@/databases/repositories/project-relation.repository';
 import { SharedWorkflowRepository } from '@/databases/repositories/shared-workflow.repository';
 import { RoleService } from '@/services/role.service';
-import { ProjectService } from '@/services/project.service.ee';
-import { ProjectRepository } from '@/databases/repositories/project.repository';
 
 export type ShareWorkflowOptions =
 	| { scopes: Scope[]; projectId?: string }
@@ -22,7 +21,6 @@ export class WorkflowSharingService {
 		private readonly sharedWorkflowRepository: SharedWorkflowRepository,
 		private readonly roleService: RoleService,
 		private readonly projectRelationRepository: ProjectRelationRepository,
-		private readonly projectRepository: ProjectRepository,
 	) {}
 
 	/**

--- a/packages/cli/src/workflows/workflow-sharing.service.ts
+++ b/packages/cli/src/workflows/workflow-sharing.service.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/order */
 import type { ProjectRole } from '@n8n/api-types';
 import { Service } from '@n8n/di';
 import type { Scope } from '@n8n/permissions';

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -37,6 +37,7 @@ import { TagService } from '@/services/tag.service';
 import * as WorkflowHelpers from '@/workflow-helpers';
 
 import { WorkflowHistoryService } from './workflow-history.ee/workflow-history.service.ee';
+import type { ShareWorkflowOptions } from './workflow-sharing.service';
 import { WorkflowSharingService } from './workflow-sharing.service';
 
 @Service()
@@ -72,9 +73,18 @@ export class WorkflowService {
 		let workflows;
 		let workflowsAndFolders: WorkflowFolderUnionFull[] = [];
 
-		const sharedWorkflowIds = await this.workflowSharingService.getSharedWorkflowIds(user, {
+		const sharedWorkflowsOptions: ShareWorkflowOptions = {
 			scopes: ['workflow:read'],
-		});
+		};
+
+		if (typeof options?.filter?.projectId === 'string') {
+			sharedWorkflowsOptions.projectId = options.filter.projectId;
+		}
+
+		const sharedWorkflowIds = await this.workflowSharingService.getSharedWorkflowIds(
+			user,
+			sharedWorkflowsOptions,
+		);
 
 		if (includeFolders) {
 			[workflowsAndFolders, count] = await this.workflowRepository.getWorkflowsAndFoldersWithCount(

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -37,7 +37,6 @@ import { TagService } from '@/services/tag.service';
 import * as WorkflowHelpers from '@/workflow-helpers';
 
 import { WorkflowHistoryService } from './workflow-history.ee/workflow-history.service.ee';
-import type { ShareWorkflowOptions } from './workflow-sharing.service';
 import { WorkflowSharingService } from './workflow-sharing.service';
 
 @Service()
@@ -72,19 +71,24 @@ export class WorkflowService {
 		let count;
 		let workflows;
 		let workflowsAndFolders: WorkflowFolderUnionFull[] = [];
+		let sharedWorkflowIds: string[] = [];
+		let isPersonalProject = false;
 
-		const sharedWorkflowsOptions: ShareWorkflowOptions = {
-			scopes: ['workflow:read'],
-		};
-
-		if (typeof options?.filter?.projectId === 'string') {
-			sharedWorkflowsOptions.projectId = options.filter.projectId;
+		if (options?.filter?.projectId) {
+			const projects = await this.projectService.getProjectRelationsForUser(user);
+			isPersonalProject = !!projects.find(
+				(p) => p.project.id === options.filter?.projectId && p.project.type === 'personal',
+			);
 		}
 
-		const sharedWorkflowIds = await this.workflowSharingService.getSharedWorkflowIds(
-			user,
-			sharedWorkflowsOptions,
-		);
+		if (isPersonalProject) {
+			sharedWorkflowIds =
+				await this.workflowSharingService.getOwnedWorkflowsInPersonalProject(user);
+		} else {
+			sharedWorkflowIds = await this.workflowSharingService.getSharedWorkflowIds(user, {
+				scopes: ['workflow:read'],
+			});
+		}
 
 		if (includeFolders) {
 			[workflowsAndFolders, count] = await this.workflowRepository.getWorkflowsAndFoldersWithCount(

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -961,20 +961,6 @@ describe('GET /workflows', () => {
 			expect(response2.body.data).toHaveLength(1);
 			expect(response2.body.data[0].id).toBe(workflow2.id);
 		});
-
-		test('should return homeProject when filtering workflows by projectId', async () => {
-			const workflow = await createWorkflow({ name: 'First' }, member);
-			const pp = await getPersonalProject(member);
-
-			const response = await authMemberAgent
-				.get('/workflows')
-				.query(`filter={ "projectId": "${pp.id}" }`)
-				.expect(200);
-
-			expect(response.body.data).toHaveLength(1);
-			expect(response.body.data[0].id).toBe(workflow.id);
-			expect(response.body.data[0].homeProject).not.toBeNull();
-		});
 	});
 
 	describe('select', () => {

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -924,14 +924,14 @@ describe('GET /workflows', () => {
 			expect(response1.body.data).toHaveLength(1);
 			expect(response1.body.data[0].id).toBe(workflow.id);
 
-			const response2 = await authOwnerAgent
+			const response2 = await authMemberAgent
 				.get('/workflows')
 				.query('filter={ "projectId": "Non-Existing Project ID" }')
 				.expect(200);
 
 			expect(response2.body.data).toHaveLength(0);
 
-			const response3 = await authOwnerAgent.get('/workflows').query('filter={}').expect(200);
+			const response3 = await authMemberAgent.get('/workflows').query('filter={}').expect(200);
 			expect(response3.body.data).toHaveLength(2);
 		});
 

--- a/packages/frontend/editor-ui/src/components/WorkflowCard.vue
+++ b/packages/frontend/editor-ui/src/components/WorkflowCard.vue
@@ -136,12 +136,7 @@ const actions = computed(() => {
 		});
 	}
 
-	if (
-		workflowPermissions.value.update &&
-		showFolders.value &&
-		!props.readOnly &&
-		!isSomeoneElsesWorkflow.value
-	) {
+	if (workflowPermissions.value.update && showFolders.value && !props.readOnly) {
 		items.push({
 			label: locale.baseText('folders.actions.moveToFolder'),
 			value: WORKFLOW_LIST_ITEM_ACTIONS.MOVE_TO_FOLDER,


### PR DESCRIPTION
## Summary

When a projectId is provided, we now only return workflows where the role is workflow:owner. This change ensures that users only see workflows they own, rather than those shared with them.

In the overview view (where projectId is not sent), users will still see both owned and shared workflows, preserving the current behavior in that context.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3494/owner-should-only-see-workflows-where-he-is-the-owner-in-personal-view

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
