### PR TITLE
refactor(core): Decouple insights module from multi-main

### DIFF
--- a/packages/cli/src/commands/base-command.ts
+++ b/packages/cli/src/commands/base-command.ts
@@ -97,8 +97,11 @@ export abstract class BaseCommand extends Command {
 			}
 		}
 
-		Container.get(ModuleRegistry).initializeModules();
-		Container.get(ModuleRegistry).registerMultiMainListeners(Container.get(MultiMainSetup));
+		const moduleRegistry = Container.get(ModuleRegistry);
+
+		moduleRegistry.initializeModules();
+
+		moduleRegistry.registerMultiMainListeners(Container.get(MultiMainSetup));
 	}
 
 	async init(): Promise<void> {

--- a/packages/cli/src/commands/base-command.ts
+++ b/packages/cli/src/commands/base-command.ts
@@ -101,7 +101,9 @@ export abstract class BaseCommand extends Command {
 
 		moduleRegistry.initializeModules();
 
-		moduleRegistry.registerMultiMainListeners(Container.get(MultiMainSetup));
+		if (this.instanceSettings.isMultiMain) {
+			moduleRegistry.registerMultiMainListeners(Container.get(MultiMainSetup));
+		}
 	}
 
 	async init(): Promise<void> {

--- a/packages/cli/src/commands/base-command.ts
+++ b/packages/cli/src/commands/base-command.ts
@@ -39,6 +39,7 @@ import type { ModulePreInit } from '@/modules/modules.config';
 import { ModulesConfig } from '@/modules/modules.config';
 import { NodeTypes } from '@/node-types';
 import { PostHogClient } from '@/posthog';
+import { MultiMainSetup } from '@/scaling/multi-main-setup.ee';
 import { ShutdownService } from '@/shutdown/shutdown.service';
 import { WorkflowHistoryManager } from '@/workflows/workflow-history.ee/workflow-history-manager.ee';
 
@@ -97,6 +98,7 @@ export abstract class BaseCommand extends Command {
 		}
 
 		Container.get(ModuleRegistry).initializeModules();
+		Container.get(ModuleRegistry).registerMultiMainListeners(Container.get(MultiMainSetup));
 	}
 
 	async init(): Promise<void> {

--- a/packages/cli/src/decorators/module.ts
+++ b/packages/cli/src/decorators/module.ts
@@ -1,9 +1,12 @@
 import { Container, Service, type Constructable } from '@n8n/di';
 import type { ExecutionLifecycleHooks } from 'n8n-core';
 
+import type { MultiMainSetup } from '@/scaling/multi-main-setup.ee';
+
 export interface BaseN8nModule {
 	initialize?(): void;
 	registerLifecycleHooks?(hooks: ExecutionLifecycleHooks): void;
+	registerMultiMainListeners?(multiMainSetup: MultiMainSetup): void;
 }
 
 type Module = Constructable<BaseN8nModule>;
@@ -34,6 +37,12 @@ export class ModuleRegistry {
 			if (instance.registerLifecycleHooks) {
 				instance.registerLifecycleHooks(hooks);
 			}
+		}
+	}
+
+	registerMultiMainListeners(multiMainSetup: MultiMainSetup) {
+		for (const ModuleClass of registry.keys()) {
+			Container.get(ModuleClass).registerMultiMainListeners?.(multiMainSetup);
 		}
 	}
 }

--- a/packages/cli/src/modules/insights/__tests__/insights.module.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.module.test.ts
@@ -30,52 +30,34 @@ describe('InsightsModule', () => {
 	describe('backgroundProcess', () => {
 		it('should start background process if instance is main and leader', () => {
 			instanceSettings = mockInstance(InstanceSettings, { instanceType: 'main', isLeader: true });
-			const insightsModule = new InsightsModule(
-				logger,
-				insightsService,
-				instanceSettings,
-				orchestrationService,
-			);
+			const insightsModule = new InsightsModule(logger, insightsService, instanceSettings);
 			insightsModule.initialize();
 			expect(insightsService.startBackgroundProcess).toHaveBeenCalled();
 		});
 
 		it('should not start background process if instance is main but not leader', () => {
 			instanceSettings = mockInstance(InstanceSettings, { instanceType: 'main', isLeader: false });
-			const insightsModule = new InsightsModule(
-				logger,
-				insightsService,
-				instanceSettings,
-				orchestrationService,
-			);
+			const insightsModule = new InsightsModule(logger, insightsService, instanceSettings);
 			insightsModule.initialize();
 			expect(insightsService.startBackgroundProcess).not.toHaveBeenCalled();
 		});
 
 		it('should start background process on leader takeover', () => {
 			instanceSettings = mockInstance(InstanceSettings, { instanceType: 'main', isLeader: false });
-			const insightsModule = new InsightsModule(
-				logger,
-				insightsService,
-				instanceSettings,
-				orchestrationService,
-			);
+			const insightsModule = new InsightsModule(logger, insightsService, instanceSettings);
 			insightsModule.initialize();
 			expect(insightsService.startBackgroundProcess).not.toHaveBeenCalled();
+			insightsModule.registerMultiMainListeners(orchestrationService.multiMainSetup);
 			orchestrationService.multiMainSetup.emit('leader-takeover');
 			expect(insightsService.startBackgroundProcess).toHaveBeenCalled();
 		});
 
 		it('should stop background process on leader stepdown', () => {
 			instanceSettings = mockInstance(InstanceSettings, { instanceType: 'main', isLeader: true });
-			const insightsModule = new InsightsModule(
-				logger,
-				insightsService,
-				instanceSettings,
-				orchestrationService,
-			);
+			const insightsModule = new InsightsModule(logger, insightsService, instanceSettings);
 			insightsModule.initialize();
 			expect(insightsService.stopBackgroundProcess).not.toHaveBeenCalled();
+			insightsModule.registerMultiMainListeners(orchestrationService.multiMainSetup);
 			orchestrationService.multiMainSetup.emit('leader-stepdown');
 			expect(insightsService.stopBackgroundProcess).toHaveBeenCalled();
 		});

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -85,11 +85,15 @@ export class InsightsService {
 	startBackgroundProcess() {
 		this.startCompactionScheduler();
 		this.startFlushingScheduler();
+
+		this.logger.debug('Started compaction and flushing schedulers');
 	}
 
 	stopBackgroundProcess() {
 		this.stopCompactionScheduler();
 		this.stopFlushingScheduler();
+
+		this.logger.debug('Stopped compaction and flushing schedulers');
 	}
 
 	// Initialize regular compaction of insights data


### PR DESCRIPTION
## Summary

This PR decouples the insights module from multi-main, so that when insights becomes a standalone extension, it will import `MultiMainSetup` only as a type, rather than as a runtime dependency.

## Related Linear tickets, Github issues, and Community forum posts

n/a

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
