### PR TITLE
fix(editor): Open NDV from logs view with correct run index

### DIFF
--- a/packages/frontend/editor-ui/src/Interface.ts
+++ b/packages/frontend/editor-ui/src/Interface.ts
@@ -1563,6 +1563,7 @@ export type InputPanel = {
 };
 
 export type OutputPanel = {
+	run?: number;
 	branch?: number;
 	data: {
 		isEmpty: boolean;

--- a/packages/frontend/editor-ui/src/components/CanvasChat/future/components/LogsOverviewPanel.test.ts
+++ b/packages/frontend/editor-ui/src/components/CanvasChat/future/components/LogsOverviewPanel.test.ts
@@ -115,9 +115,15 @@ describe('LogsOverviewPanel', () => {
 		const rendered = render({ isOpen: true });
 		const aiAgentRow = rendered.getAllByRole('treeitem')[0];
 
+		expect(ndvStore.activeNodeName).toBe(null);
+		expect(ndvStore.output.run).toBe(undefined);
+
 		await fireEvent.click(within(aiAgentRow).getAllByLabelText('Open...')[0]);
 
-		await waitFor(() => expect(ndvStore.activeNodeName).toBe('AI Agent'));
+		await waitFor(() => {
+			expect(ndvStore.activeNodeName).toBe('AI Agent');
+			expect(ndvStore.output.run).toBe(0);
+		});
 	});
 
 	it('should trigger partial execution if the button is clicked', async () => {

--- a/packages/frontend/editor-ui/src/components/CanvasChat/future/components/LogsOverviewPanel.vue
+++ b/packages/frontend/editor-ui/src/components/CanvasChat/future/components/LogsOverviewPanel.vue
@@ -5,7 +5,7 @@ import { useI18n } from '@/composables/useI18n';
 import { useNodeHelpers } from '@/composables/useNodeHelpers';
 import { useWorkflowsStore } from '@/stores/workflows.store';
 import { N8nButton, N8nRadioButtons, N8nText, N8nTooltip } from '@n8n/design-system';
-import { computed } from 'vue';
+import { computed, nextTick } from 'vue';
 import { ElTree, type TreeNode as ElTreeNode } from 'element-plus';
 import {
 	getSubtreeTotalConsumedTokens,
@@ -80,6 +80,8 @@ function handleToggleExpanded(treeNode: ElTreeNode) {
 
 async function handleOpenNdv(treeNode: TreeNode) {
 	ndvStore.setActiveNodeName(treeNode.node);
+
+	await nextTick(() => ndvStore.setOutputRunIndex(treeNode.runIndex));
 }
 
 async function handleTriggerPartialExecution(treeNode: TreeNode) {

--- a/packages/frontend/editor-ui/src/components/NodeDetailsView.vue
+++ b/packages/frontend/editor-ui/src/components/NodeDetailsView.vue
@@ -79,7 +79,7 @@ const { APP_Z_INDEXES } = useStyles();
 const settingsEventBus = createEventBus();
 const redrawRequired = ref(false);
 const runInputIndex = ref(-1);
-const runOutputIndex = ref(-1);
+const runOutputIndex = computed(() => ndvStore.output.run ?? -1);
 const isLinkingEnabled = ref(true);
 const selectedInput = ref<string | undefined>();
 const triggerWaitingWarningEnabled = ref(false);
@@ -476,7 +476,7 @@ const trackLinking = (pane: string) => {
 };
 
 const onLinkRunToInput = () => {
-	runOutputIndex.value = runInputIndex.value;
+	ndvStore.setOutputRunIndex(runInputIndex.value);
 	isLinkingEnabled.value = true;
 	trackLinking('input');
 };
@@ -553,14 +553,14 @@ const trackRunChange = (run: number, pane: string) => {
 };
 
 const onRunOutputIndexChange = (run: number) => {
-	runOutputIndex.value = run;
+	ndvStore.setOutputRunIndex(run);
 	trackRunChange(run, 'output');
 };
 
 const onRunInputIndexChange = (run: number) => {
 	runInputIndex.value = run;
 	if (linked.value) {
-		runOutputIndex.value = run;
+		ndvStore.setOutputRunIndex(run);
 	}
 	trackRunChange(run, 'input');
 };
@@ -622,7 +622,7 @@ watch(
 
 		if (node && node.name !== oldNode?.name && !isActiveStickyNode.value) {
 			runInputIndex.value = -1;
-			runOutputIndex.value = -1;
+			ndvStore.setOutputRunIndex(-1);
 			isLinkingEnabled.value = true;
 			selectedInput.value = undefined;
 			triggerWaitingWarningEnabled.value = false;
@@ -675,7 +675,7 @@ watch(
 );
 
 watch(maxOutputRun, () => {
-	runOutputIndex.value = -1;
+	ndvStore.setOutputRunIndex(-1);
 });
 
 watch(maxInputRun, () => {

--- a/packages/frontend/editor-ui/src/stores/ndv.store.ts
+++ b/packages/frontend/editor-ui/src/stores/ndv.store.ts
@@ -59,6 +59,7 @@ export const useNDVStore = defineStore(STORES.NDV, () => {
 		'schema',
 	);
 	const output = ref<OutputPanel>({
+		run: undefined,
 		branch: undefined,
 		data: {
 			isEmpty: true,
@@ -222,6 +223,10 @@ export const useNDVStore = defineStore(STORES.NDV, () => {
 
 	const setInputRunIndex = (run?: number): void => {
 		input.value.run = run;
+	};
+
+	const setOutputRunIndex = (run?: number): void => {
+		output.value.run = run;
 	};
 
 	const setMainPanelDimensions = (params: {
@@ -407,6 +412,7 @@ export const useNDVStore = defineStore(STORES.NDV, () => {
 		setActiveNodeName,
 		setInputNodeName,
 		setInputRunIndex,
+		setOutputRunIndex,
 		setMainPanelDimensions,
 		setNDVPushRef,
 		resetNDVPushRef,


### PR DESCRIPTION
## Summary
This PR fixes the behavior of opening NDV from the new logs view, where output run index is always set to the last one whereas it should reflect the clicked log entry.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/SUG-39/bug-run-index-in-ndv-does-not-match-the-clicked-log


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
