### PR TITLE
fix(core): ID quoting in add scopes migration

### DIFF
--- a/packages/cli/src/databases/migrations/common/1742918400000-AddScopesColumnToApiKeys.ts
+++ b/packages/cli/src/databases/migrations/common/1742918400000-AddScopesColumnToApiKeys.ts
@@ -1,12 +1,18 @@
 import type { GlobalRole } from '@n8n/permissions';
 
+import { ApiKey } from '@/databases/entities/api-key';
 import type { MigrationContext, ReversibleMigration } from '@/databases/types';
 import { getApiKeyScopesForRole } from '@/public-api/permissions.ee';
 
 type ApiKeyWithRole = { id: string; role: GlobalRole };
 
 export class AddScopesColumnToApiKeys1742918400000 implements ReversibleMigration {
-	async up({ runQuery, escape, schemaBuilder: { addColumns, column } }: MigrationContext) {
+	async up({
+		runQuery,
+		escape,
+		queryRunner,
+		schemaBuilder: { addColumns, column },
+	}: MigrationContext) {
 		await addColumns('user_api_keys', [column('scopes').json]);
 
 		const userApiKeysTable = escape.tableName('user_api_keys');
@@ -14,18 +20,14 @@ export class AddScopesColumnToApiKeys1742918400000 implements ReversibleMigratio
 		const idColumn = escape.columnName('id');
 		const userIdColumn = escape.columnName('userId');
 		const roleColumn = escape.columnName('role');
-		const scopesColumn = escape.columnName('scopes');
 
 		const apiKeysWithRoles = await runQuery<ApiKeyWithRole[]>(
 			`SELECT ${userApiKeysTable}.${idColumn} AS id, ${userTable}.${roleColumn} AS role FROM ${userApiKeysTable} JOIN ${userTable} ON ${userTable}.${idColumn} = ${userApiKeysTable}.${userIdColumn}`,
 		);
 
 		for (const { id, role } of apiKeysWithRoles) {
-			const scopes = JSON.stringify(getApiKeyScopesForRole(role));
-
-			await runQuery(
-				`UPDATE ${userApiKeysTable} SET ${scopesColumn} = '${scopes}' WHERE ${idColumn} = '${id}'`,
-			);
+			const scopes = getApiKeyScopesForRole(role);
+			await queryRunner.manager.update(ApiKey, { id }, { scopes });
 		}
 	}
 

--- a/packages/cli/src/databases/migrations/common/1742918400000-AddScopesColumnToApiKeys.ts
+++ b/packages/cli/src/databases/migrations/common/1742918400000-AddScopesColumnToApiKeys.ts
@@ -24,7 +24,7 @@ export class AddScopesColumnToApiKeys1742918400000 implements ReversibleMigratio
 			const scopes = JSON.stringify(getApiKeyScopesForRole(role));
 
 			await runQuery(
-				`UPDATE ${userApiKeysTable} SET ${scopesColumn} = '${scopes}' WHERE ${idColumn} = "${id}"`,
+				`UPDATE ${userApiKeysTable} SET ${scopesColumn} = '${scopes}' WHERE ${idColumn} = '${id}'`,
 			);
 		}
 	}


### PR DESCRIPTION
## Summary

I tested it this locally before releasing, so the only things that comes to mind it's that mistakenly:

- I did not an old record before running the migration
- Maybe I had the wrong env variables locally and connected to Sqlite instead.

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/issues/14785

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
