### PR TITLE
feat(core): Add insights date ranges option to frontend settings

### DIFF
--- a/packages/@n8n/api-types/src/dto/insights/__tests__/date-filter.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/insights/__tests__/date-filter.dto.test.ts
@@ -1,0 +1,51 @@
+import { InsightsDateFilterDto } from '../date-filter.dto';
+
+describe('InsightsDateFilterDto', () => {
+	describe('Valid requests', () => {
+		test.each([
+			{
+				name: 'empty object (no filters)',
+				request: {},
+				parsedResult: {},
+			},
+			{
+				name: 'valid dateRange',
+				request: {
+					dateRange: 'week', // Using a valid option from the provided list
+				},
+				parsedResult: {
+					dateRange: 'week',
+				},
+			},
+		])('should validate $name', ({ request, parsedResult }) => {
+			const result = InsightsDateFilterDto.safeParse(request);
+			expect(result.success).toBe(true);
+			if (parsedResult) {
+				expect(result.data).toMatchObject(parsedResult);
+			}
+		});
+	});
+
+	describe('Invalid requests', () => {
+		test.each([
+			{
+				name: 'invalid dateRange value',
+				request: {
+					dateRange: 'invalid-value',
+				},
+				expectedErrorPath: ['dateRange'],
+			},
+		])('should fail validation for $name', ({ request, expectedErrorPath }) => {
+			const result = InsightsDateFilterDto.safeParse(request);
+
+			expect(result.success).toBe(false);
+
+			if (expectedErrorPath && !result.success) {
+				if (Array.isArray(expectedErrorPath)) {
+					const errorPaths = result.error.issues[0].path;
+					expect(errorPaths).toContain(expectedErrorPath[0]);
+				}
+			}
+		});
+	});
+});

--- a/packages/@n8n/api-types/src/dto/insights/date-filter.dto.ts
+++ b/packages/@n8n/api-types/src/dto/insights/date-filter.dto.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+import { Z } from 'zod-class';
+
+import { insightsDateRangeSchema } from 'schemas/insights.schema';
+
+const VALID_DATE_RANGE_OPTIONS = insightsDateRangeSchema.shape.key.options;
+
+// Date range parameter validation
+const dateRange = z.enum(VALID_DATE_RANGE_OPTIONS).optional();
+
+export class InsightsDateFilterDto extends Z.class({
+	dateRange,
+}) {}

--- a/packages/@n8n/api-types/src/dto/insights/date-filter.dto.ts
+++ b/packages/@n8n/api-types/src/dto/insights/date-filter.dto.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { Z } from 'zod-class';
 
-import { insightsDateRangeSchema } from 'schemas/insights.schema';
+import { insightsDateRangeSchema } from '../../schemas/insights.schema';
 
 const VALID_DATE_RANGE_OPTIONS = insightsDateRangeSchema.shape.key.options;
 

--- a/packages/@n8n/api-types/src/schemas/__tests__/insights.schema.test.ts
+++ b/packages/@n8n/api-types/src/schemas/__tests__/insights.schema.test.ts
@@ -1,6 +1,7 @@
 import {
 	insightsByTimeSchema,
 	insightsByWorkflowSchema,
+	insightsDateRangeSchema,
 	insightsSummarySchema,
 } from '../insights.schema';
 
@@ -230,6 +231,76 @@ describe('insightsByTimeSchema', () => {
 		},
 	])('should validate $name', ({ value, expected }) => {
 		const result = insightsByTimeSchema.safeParse(value);
+		expect(result.success).toBe(expected);
+	});
+});
+
+describe('insightsDateRangeSchema', () => {
+	test.each([
+		{
+			name: 'valid date range',
+			value: {
+				key: 'day',
+				licensed: true,
+				granularity: 'hour',
+			},
+			expected: true,
+		},
+		{
+			name: 'missing required key',
+			value: {
+				licensed: true,
+				granularity: 'hour',
+			},
+			expected: false,
+		},
+		{
+			name: 'invalid key value',
+			value: {
+				key: 'invalid',
+				licensed: true,
+				granularity: 'hour',
+			},
+			expected: false,
+		},
+		{
+			name: 'missing licensed field',
+			value: {
+				key: 'day',
+				granularity: 'hour',
+			},
+			expected: false,
+		},
+		{
+			name: 'invalid licensed type',
+			value: {
+				key: 'day',
+				licensed: 'true', // Should be a boolean
+				granularity: 'hour',
+			},
+			expected: false,
+		},
+		{
+			name: 'invalid granularity value',
+			value: {
+				key: 'day',
+				licensed: true,
+				granularity: 'invalid',
+			},
+			expected: false,
+		},
+		{
+			name: 'unexpected additional key',
+			value: {
+				key: 'day',
+				licensed: true,
+				granularity: 'hour',
+				extraKey: 'value', // Extra key not allowed
+			},
+			expected: false,
+		},
+	])('should validate $name', ({ value, expected }) => {
+		const result = insightsDateRangeSchema.safeParse(value);
 		expect(result.success).toBe(expected);
 	});
 });

--- a/packages/@n8n/api-types/src/schemas/insights.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/insights.schema.ts
@@ -85,3 +85,12 @@ export const insightsByTimeDataSchemas = {
 
 export const insightsByTimeSchema = z.object(insightsByTimeDataSchemas).strict();
 export type InsightsByTime = z.infer<typeof insightsByTimeSchema>;
+
+export const insightsDateRangeSchema = z
+	.object({
+		key: z.enum(['day', 'week', '2weeks', 'month', 'quarter', 'year']),
+		licensed: z.boolean(),
+		granularity: z.enum(['hour', 'day', 'week']),
+	})
+	.strict();
+export type InsightsDateRange = z.infer<typeof insightsDateRangeSchema>;

--- a/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
@@ -1,14 +1,20 @@
 import { Container } from '@n8n/di';
+import { mock } from 'jest-mock-extended';
 import { DateTime } from 'luxon';
+import type { Logger } from 'n8n-core';
 
 import type { Project } from '@/databases/entities/project';
 import type { WorkflowEntity } from '@/databases/entities/workflow-entity';
 import type { IWorkflowDb } from '@/interfaces';
+import type { License } from '@/license';
 import { createTeamProject } from '@test-integration/db/projects';
 import { createWorkflow } from '@test-integration/db/workflows';
 import * as testDb from '@test-integration/test-db';
 
 import { createCompactedInsightsEvent } from '../database/entities/__tests__/db-utils';
+import type { InsightsByPeriodRepository } from '../database/repositories/insights-by-period.repository';
+import type { InsightsCollectionService } from '../insights-collection.service';
+import type { InsightsCompactionService } from '../insights-compaction.service';
 import { InsightsService } from '../insights.service';
 
 // Initialize DB once for all tests
@@ -481,5 +487,85 @@ describe('getInsightsByTime', () => {
 			averageRunTime: 0,
 			timeSaved: 0,
 		});
+	});
+});
+
+describe('getAvailableDateRanges', () => {
+	let insightsService: InsightsService;
+	let licenseMock: jest.Mocked<License>;
+
+	beforeAll(() => {
+		licenseMock = mock<License>();
+		insightsService = new InsightsService(
+			mock<InsightsByPeriodRepository>(),
+			mock<InsightsCompactionService>(),
+			mock<InsightsCollectionService>(),
+			licenseMock,
+			mock<Logger>(),
+		);
+	});
+
+	test('returns correct ranges when hourly data is enabled and max history is 365 days', () => {
+		licenseMock.getInsightsMaxHistory.mockReturnValue(365);
+		licenseMock.isInsightsHourlyDataEnabled.mockReturnValue(true);
+
+		const result = insightsService.getAvailableDateRanges();
+
+		expect(result).toEqual([
+			{ key: 'day', licensed: true, granularity: 'hour' },
+			{ key: 'week', licensed: true, granularity: 'day' },
+			{ key: '2weeks', licensed: true, granularity: 'day' },
+			{ key: 'month', licensed: true, granularity: 'day' },
+			{ key: 'quarter', licensed: true, granularity: 'week' },
+			{ key: 'year', licensed: true, granularity: 'week' },
+		]);
+	});
+
+	test('returns correct ranges when hourly data is disabled and max history is 30 days', () => {
+		licenseMock.getInsightsMaxHistory.mockReturnValue(30);
+		licenseMock.isInsightsHourlyDataEnabled.mockReturnValue(false);
+
+		const result = insightsService.getAvailableDateRanges();
+
+		expect(result).toEqual([
+			{ key: 'day', licensed: false, granularity: 'hour' },
+			{ key: 'week', licensed: true, granularity: 'day' },
+			{ key: '2weeks', licensed: true, granularity: 'day' },
+			{ key: 'month', licensed: true, granularity: 'day' },
+			{ key: 'quarter', licensed: false, granularity: 'week' },
+			{ key: 'year', licensed: false, granularity: 'week' },
+		]);
+	});
+
+	test('returns correct ranges when max history is less than 7 days', () => {
+		licenseMock.getInsightsMaxHistory.mockReturnValue(5);
+		licenseMock.isInsightsHourlyDataEnabled.mockReturnValue(false);
+
+		const result = insightsService.getAvailableDateRanges();
+
+		expect(result).toEqual([
+			{ key: 'day', licensed: false, granularity: 'hour' },
+			{ key: 'week', licensed: false, granularity: 'day' },
+			{ key: '2weeks', licensed: false, granularity: 'day' },
+			{ key: 'month', licensed: false, granularity: 'day' },
+			{ key: 'quarter', licensed: false, granularity: 'week' },
+			{ key: 'year', licensed: false, granularity: 'week' },
+		]);
+	});
+
+	test('returns correct ranges when max history is 90 days and hourly data is enabled', () => {
+		licenseMock.getInsightsMaxHistory.mockReturnValue(90);
+		licenseMock.isInsightsHourlyDataEnabled.mockReturnValue(true);
+
+		const result = insightsService.getAvailableDateRanges();
+
+		expect(result).toEqual([
+			{ key: 'day', licensed: true, granularity: 'hour' },
+			{ key: 'week', licensed: true, granularity: 'day' },
+			{ key: '2weeks', licensed: true, granularity: 'day' },
+			{ key: 'month', licensed: true, granularity: 'day' },
+			{ key: 'quarter', licensed: true, granularity: 'week' },
+			{ key: 'year', licensed: false, granularity: 'week' },
+		]);
 	});
 });

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -1,10 +1,12 @@
 import type { InsightsSummary } from '@n8n/api-types';
+import type { InsightsDateRange } from '@n8n/api-types/src/schemas/insights.schema';
 import { Service } from '@n8n/di';
 import { Logger } from 'n8n-core';
 import type { ExecutionLifecycleHooks } from 'n8n-core';
 import type { IRun } from 'n8n-workflow';
 
 import { OnShutdown } from '@/decorators/on-shutdown';
+import { License } from '@/license';
 
 import type { PeriodUnit, TypeUnit } from './database/entities/insights-shared';
 import { NumberToType } from './database/entities/insights-shared';
@@ -18,7 +20,8 @@ export class InsightsService {
 		private readonly insightsByPeriodRepository: InsightsByPeriodRepository,
 		private readonly compactionService: InsightsCompactionService,
 		private readonly collectionService: InsightsCollectionService,
-		private readonly logger: Logger, // Assuming a logger is injected
+		private readonly license: License,
+		private readonly logger: Logger,
 	) {}
 
 	startBackgroundProcess() {
@@ -176,5 +179,19 @@ export class InsightsService {
 				},
 			};
 		});
+	}
+
+	getAvailableDateRanges(): InsightsDateRange[] {
+		const maxHistoryInDays = this.license.getInsightsMaxHistory();
+		const isHourlyDateEnabled = this.license.isInsightsHourlyDataEnabled();
+
+		return [
+			{ key: 'day', licensed: isHourlyDateEnabled ?? false, granularity: 'hour' },
+			{ key: 'week', licensed: maxHistoryInDays >= 7, granularity: 'day' },
+			{ key: '2weeks', licensed: maxHistoryInDays >= 14, granularity: 'day' },
+			{ key: 'month', licensed: maxHistoryInDays >= 30, granularity: 'day' },
+			{ key: 'quarter', licensed: maxHistoryInDays >= 90, granularity: 'week' },
+			{ key: 'year', licensed: maxHistoryInDays >= 365, granularity: 'week' },
+		];
 	}
 }

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -15,6 +15,7 @@ import { CredentialsOverwrites } from '@/credentials-overwrites';
 import { getLdapLoginLabel } from '@/ldap.ee/helpers.ee';
 import { License } from '@/license';
 import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
+import { InsightsService } from '@/modules/insights/insights.service';
 import { ModulesConfig } from '@/modules/modules.config';
 import { isApiEnabled } from '@/public-api';
 import { PushConfig } from '@/push/push.config';
@@ -49,6 +50,7 @@ export class FrontendService {
 		private readonly modulesConfig: ModulesConfig,
 		private readonly pushConfig: PushConfig,
 		private readonly binaryDataConfig: BinaryDataConfig,
+		private readonly insightsService: InsightsService,
 	) {
 		loadNodesAndCredentials.addPostProcessor(async () => await this.generateTypes());
 		void this.generateTypes();
@@ -372,6 +374,7 @@ export class FrontendService {
 			enabled: this.modulesConfig.loadedModules.has('insights'),
 			summary: this.license.isInsightsSummaryEnabled(),
 			dashboard: this.license.isInsightsDashboardEnabled(),
+			dateRanges: this.insightsService.getAvailableDateRanges(),
 		});
 
 		this.settings.mfa.enabled = config.get('mfa.enabled');


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR adds a `dateRange` array to the `insights` object in the frontend settings. it contains all the possible date range filters to see the insights for. Each range has a "key" (unique code of the date range), whether it's available for the instance license, and the granularity to display the time data for that date range.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2734/expose-insights-filtering-that-is-available-from-license-to-fe

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
