### PR TITLE
fix(core): Handle infinite max history for insights date range

### DIFF
--- a/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
@@ -505,6 +505,22 @@ describe('getAvailableDateRanges', () => {
 		);
 	});
 
+	test('returns correct ranges when hourly data is enabled and max history is unlimited', () => {
+		licenseMock.getInsightsMaxHistory.mockReturnValue(-1);
+		licenseMock.isInsightsHourlyDataEnabled.mockReturnValue(true);
+
+		const result = insightsService.getAvailableDateRanges();
+
+		expect(result).toEqual([
+			{ key: 'day', licensed: true, granularity: 'hour' },
+			{ key: 'week', licensed: true, granularity: 'day' },
+			{ key: '2weeks', licensed: true, granularity: 'day' },
+			{ key: 'month', licensed: true, granularity: 'day' },
+			{ key: 'quarter', licensed: true, granularity: 'week' },
+			{ key: 'year', licensed: true, granularity: 'week' },
+		]);
+	});
+
 	test('returns correct ranges when hourly data is enabled and max history is 365 days', () => {
 		licenseMock.getInsightsMaxHistory.mockReturnValue(365);
 		licenseMock.isInsightsHourlyDataEnabled.mockReturnValue(true);

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -182,7 +182,10 @@ export class InsightsService {
 	}
 
 	getAvailableDateRanges(): InsightsDateRange[] {
-		const maxHistoryInDays = this.license.getInsightsMaxHistory();
+		const maxHistoryInDays =
+			this.license.getInsightsMaxHistory() === -1
+				? Number.MAX_SAFE_INTEGER
+				: this.license.getInsightsMaxHistory();
 		const isHourlyDateEnabled = this.license.isInsightsHourlyDataEnabled();
 
 		return [


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR handle the special case when the license allow infinite max history for insights data. Before the fix, the date range would have only 'day' enabled (because the max history == -1 was handle literally). After the fix, max history == -1 is handles correctly (returning all the possible date ranges)

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2737/implement-granularity-and-date-range-filtering-on-insights-routes

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
