### PR TITLE
Enabled Authentication using header auth in SseTrigger node

### DIFF
--- a/packages/nodes-base/nodes/SseTrigger/SseTrigger.node.ts
+++ b/packages/nodes-base/nodes/SseTrigger/SseTrigger.node.ts
@@ -4,6 +4,7 @@ import type {
 	ITriggerFunctions,
 	INodeType,
 	INodeTypeDescription,
+	IRequestOptions,
 	ITriggerResponse,
 } from 'n8n-workflow';
 import { NodeConnectionTypes, jsonParse } from 'n8n-workflow';
@@ -36,7 +37,34 @@ export class SseTrigger implements INodeType {
 		},
 		inputs: [],
 		outputs: [NodeConnectionTypes.Main],
+		credentials: [
+			{
+				name: 'httpHeaderAuth',
+				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['headerAuth'],
+					},
+				},
+			},
+		],
 		properties: [
+			{
+				displayName: 'Authentication',
+				name: 'authentication',
+				type: 'options',
+				options: [
+					{
+						name: 'None',
+						value: 'none',
+					},
+					{
+						name: 'Header Auth',
+						value: 'headerAuth',
+					},
+				],
+				default: 'none',
+			},
 			{
 				displayName: 'URL',
 				name: 'url',
@@ -51,8 +79,24 @@ export class SseTrigger implements INodeType {
 
 	async trigger(this: ITriggerFunctions): Promise<ITriggerResponse> {
 		const url = this.getNodeParameter('url') as string;
+		let httpHeaderAuth;
+		let requestOptions: IRequestOptions = {};
 
-		const eventSource = new EventSource(url);
+		try {
+			httpHeaderAuth = await this.getCredentials('httpHeaderAuth');
+		} catch (error) {
+			// Do nothing
+		}
+
+		requestOptions = {
+			headers: {},
+		};
+
+		if (httpHeaderAuth !== undefined) {
+			requestOptions.headers![httpHeaderAuth.name as string] = httpHeaderAuth.value;
+		}
+
+		const eventSource = new EventSource(url, { headers: requestOptions.headers });
 
 		eventSource.onmessage = (event) => {
 			const eventData = jsonParse<IDataObject>(event.data as string, {

--- a/packages/nodes-base/nodes/SseTrigger/SseTrigger.node.ts
+++ b/packages/nodes-base/nodes/SseTrigger/SseTrigger.node.ts
@@ -105,6 +105,13 @@ export class SseTrigger implements INodeType {
 			this.emit([this.helpers.returnJsonArray([eventData])]);
 		};
 
+		eventSource.onerror = (event) => {
+			const eventData = jsonParse<IDataObject>(event.data as string, {
+				errorMessage: 'A connection error has occured, please try again',
+			});
+			this.emit([this.helpers.returnJsonArray([eventData])]);
+		};
+
 		async function closeFunction() {
 			eventSource.close();
 		}


### PR DESCRIPTION
## Summary

This pull request enables the header auth field in the SseTrigger Node

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
