### PR TITLE
fix: Bring back TidyUp button's icon and fix Easy AI button size

### DIFF
--- a/packages/frontend/editor-ui/src/components/ParameterInputOverrides/FromAiOverrideButton.vue
+++ b/packages/frontend/editor-ui/src/components/ParameterInputOverrides/FromAiOverrideButton.vue
@@ -21,6 +21,7 @@ const emit = defineEmits<{
 			@click="emit('click')"
 		>
 			<span>
+				<!-- The span wrapping the icon centers it due to reliance on legacy behavior -->
 				<AiStarsIcon size="large" />
 			</span>
 		</N8nButton>

--- a/packages/frontend/editor-ui/src/components/ParameterInputOverrides/FromAiOverrideButton.vue
+++ b/packages/frontend/editor-ui/src/components/ParameterInputOverrides/FromAiOverrideButton.vue
@@ -20,7 +20,9 @@ const emit = defineEmits<{
 			data-test-id="from-ai-override-button"
 			@click="emit('click')"
 		>
-			<AiStarsIcon size="large" />
+			<span>
+				<AiStarsIcon size="large" />
+			</span>
 		</N8nButton>
 	</N8nTooltip>
 </template>
@@ -34,8 +36,6 @@ const emit = defineEmits<{
 	width: 30px;
 	background-color: var(--color-foreground-base);
 	color: var(--color-foreground-xdark);
-	padding-left: 0;
-	padding-right: 0;
 
 	&:hover {
 		color: var(--color-foreground-xdark);

--- a/packages/frontend/editor-ui/src/components/ParameterInputOverrides/FromAiOverrideButton.vue
+++ b/packages/frontend/editor-ui/src/components/ParameterInputOverrides/FromAiOverrideButton.vue
@@ -34,6 +34,8 @@ const emit = defineEmits<{
 	width: 30px;
 	background-color: var(--color-foreground-base);
 	color: var(--color-foreground-xdark);
+	padding-left: 0;
+	padding-right: 0;
 
 	&:hover {
 		color: var(--color-foreground-xdark);

--- a/packages/frontend/editor-ui/src/components/canvas/elements/buttons/CanvasControlButtons.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/elements/buttons/CanvasControlButtons.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { Controls } from '@vue-flow/controls';
 import KeyboardShortcutTooltip from '@/components/KeyboardShortcutTooltip.vue';
 import TidyUpIcon from '@/components/TidyUpIcon.vue';
-import { computed } from 'vue';
 import { useI18n } from '@/composables/useI18n';
+import { Controls } from '@vue-flow/controls';
+import { computed } from 'vue';
 
 const props = withDefaults(
 	defineProps<{
@@ -114,9 +114,8 @@ function onTidyUp() {
 
 <style module lang="scss">
 .iconButton {
-	display: flex;
-	align-items: center;
-	justify-content: center;
+	padding-left: 0;
+	padding-right: 0;
 
 	svg {
 		width: 16px;


### PR DESCRIPTION
## Summary

![image](https://github.com/user-attachments/assets/582584bf-9ead-48dd-9626-9f0d9473eaae)

Remove button padding, so the svg is within bounds

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

fixes #14805
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
