### PR TITLE
fix(HubSpot Trigger Node): Fix issue with conversationId not being set

### DIFF
--- a/packages/nodes-base/nodes/Hubspot/HubspotTrigger.node.ts
+++ b/packages/nodes-base/nodes/Hubspot/HubspotTrigger.node.ts
@@ -448,6 +448,9 @@ export class HubspotTrigger implements INodeType {
 			if (subscriptionType.includes('ticket')) {
 				bodyData[i].ticketId = bodyData[i].objectId;
 			}
+			if (subscriptionType.includes('conversation')) {
+				bodyData[i].conversationId = bodyData[i].objectId;
+			}
 			delete bodyData[i].objectId;
 		}
 		return {


### PR DESCRIPTION
## Summary
When using the HubSpot trigger node with the event `conversation.created`, the objectId is being filtered out.

This PR maps the objectId to a new property, conversationId, when the subscription type includes "conversation".

<img width="900" alt="Screenshot 2025-04-23 at 13 44 12" src="https://github.com/user-attachments/assets/a1e5b4df-8523-4e09-ac9f-539a5f319693" />

The payload from Hubspot:

<img width="516" alt="Screenshot 2025-04-23 at 13 45 49" src="https://github.com/user-attachments/assets/0c5da135-3027-4d7a-a547-992978018334" />


## Related Linear tickets, Github issues, and Community forum posts
#9403 
