### PR TITLE
fix(editor): Fix insights summary banner empty state on time saved tab

### DIFF
--- a/packages/frontend/editor-ui/src/features/insights/components/InsightsSummary.vue
+++ b/packages/frontend/editor-ui/src/features/insights/components/InsightsSummary.vue
@@ -101,11 +101,9 @@ const trackTabClick = (insightType: keyof InsightsSummary) => {
 								<N8nTooltip placement="bottom">
 									<template #content>
 										<i18n-t keypath="insights.banner.timeSaved.tooltip">
-											<template #link>
-												<a href="#">{{
-													i18n.baseText('insights.banner.timeSaved.tooltip.link.text')
-												}}</a>
-											</template>
+											<template #link>{{
+												i18n.baseText('insights.banner.timeSaved.tooltip.link.text')
+											}}</template>
 										</i18n-t>
 									</template>
 									<N8nIcon :class="$style.icon" icon="info-circle" />
@@ -219,7 +217,7 @@ const trackTabClick = (insightType: keyof InsightsSummary) => {
 						.icon {
 							height: 20px;
 							width: 8px;
-							top: -3px;
+							top: 5px;
 							transform: translateY(0);
 							color: var(--color-text-light);
 						}


### PR DESCRIPTION
## Summary

Insights Summary banner UI fixes

## Related Linear tickets, Github issues, and Community forum posts

PAY-2771

## Review / Merge checklist

- [ ] PR title and summary are descriptive
- [ ] Tests included
- [ ] PR Labeled with `release/backport`
