### PR TITLE
feat(core): Implement granularity and date range filtering on insights

### DIFF
--- a/packages/@n8n/api-types/src/dto/insights/list-workflow-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/insights/list-workflow-query.dto.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { Z } from 'zod-class';
 
+import { InsightsDateFilterDto } from './date-filter.dto';
 import { paginationSchema } from '../pagination/pagination.dto';
 
 const VALID_SORT_OPTIONS = [
@@ -30,5 +31,6 @@ const sortByValidator = z
 
 export class ListInsightsWorkflowQueryDto extends Z.class({
 	...paginationSchema,
+	dateRange: InsightsDateFilterDto.shape.dateRange,
 	sortBy: sortByValidator,
 }) {}

--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -29,11 +29,12 @@ export {
 	SOURCE_CONTROL_FILE_TYPE,
 } from './schemas/source-controlled-file.schema';
 
-export type {
-	InsightsSummaryType,
-	InsightsSummaryUnit,
-	InsightsSummary,
-	InsightsByWorkflow,
-	InsightsByTime,
-	InsightsDateRange,
+export {
+	type InsightsSummaryType,
+	type InsightsSummaryUnit,
+	type InsightsSummary,
+	type InsightsByWorkflow,
+	type InsightsByTime,
+	type InsightsDateRange,
+	INSIGHTS_DATE_RANGE_KEYS,
 } from './schemas/insights.schema';

--- a/packages/@n8n/api-types/src/schemas/insights.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/insights.schema.ts
@@ -82,13 +82,21 @@ export const insightsByTimeDataSchemas = {
 		})
 		.strict(),
 } as const;
-
 export const insightsByTimeSchema = z.object(insightsByTimeDataSchemas).strict();
 export type InsightsByTime = z.infer<typeof insightsByTimeSchema>;
 
+export const INSIGHTS_DATE_RANGE_KEYS = [
+	'day',
+	'week',
+	'2weeks',
+	'month',
+	'quarter',
+	'6months',
+	'year',
+] as const;
 export const insightsDateRangeSchema = z
 	.object({
-		key: z.enum(['day', 'week', '2weeks', 'month', 'quarter', '6months', 'year']),
+		key: z.enum(INSIGHTS_DATE_RANGE_KEYS),
 		licensed: z.boolean(),
 		granularity: z.enum(['hour', 'day', 'week']),
 	})

--- a/packages/cli/src/modules/insights/__tests__/insights.controller.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.controller.test.ts
@@ -1,5 +1,7 @@
 import { Container } from '@n8n/di';
+import { mock } from 'jest-mock-extended';
 
+import type { AuthenticatedRequest } from '@/requests';
 import { mockInstance } from '@test/mocking';
 import * as testDb from '@test-integration/test-db';
 
@@ -30,7 +32,10 @@ describe('InsightsController', () => {
 			insightsByPeriodRepository.getPreviousAndCurrentPeriodTypeAggregates.mockResolvedValue([]);
 
 			// ACT
-			const response = await controller.getInsightsSummary();
+			const response = await controller.getInsightsSummary(
+				mock<AuthenticatedRequest>(),
+				mock<Response>(),
+			);
 
 			// ASSERT
 			expect(response).toEqual({
@@ -52,7 +57,10 @@ describe('InsightsController', () => {
 			]);
 
 			// ACT
-			const response = await controller.getInsightsSummary();
+			const response = await controller.getInsightsSummary(
+				mock<AuthenticatedRequest>(),
+				mock<Response>(),
+			);
 
 			// ASSERT
 			expect(response).toEqual({
@@ -78,7 +86,10 @@ describe('InsightsController', () => {
 			]);
 
 			// ACT
-			const response = await controller.getInsightsSummary();
+			const response = await controller.getInsightsSummary(
+				mock<AuthenticatedRequest>(),
+				mock<Response>(),
+			);
 
 			// ASSERT
 			expect(response).toEqual({

--- a/packages/cli/src/modules/insights/insights.controller.ts
+++ b/packages/cli/src/modules/insights/insights.controller.ts
@@ -1,22 +1,39 @@
-import { ListInsightsWorkflowQueryDto } from '@n8n/api-types';
+import { InsightsDateFilterDto, ListInsightsWorkflowQueryDto } from '@n8n/api-types';
 import type { InsightsSummary, InsightsByTime, InsightsByWorkflow } from '@n8n/api-types';
 import { Get, GlobalScope, Licensed, Query, RestController } from '@n8n/decorators';
+import type { UserError } from 'n8n-workflow';
 
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { AuthenticatedRequest } from '@/requests';
 
 import { InsightsService } from './insights.service';
 
 @RestController('/insights')
 export class InsightsController {
-	private readonly maxAgeInDaysFilteredInsights = 7;
-
 	constructor(private readonly insightsService: InsightsService) {}
+
+	/**
+	 * This method is used to transform the date range from the request payload into a maximum age in days.
+	 * It throws a ForbiddenError if the date range does not match the license insights max history
+	 */
+	private getMaxAgeInDaysAndGranularity(payload: InsightsDateFilterDto) {
+		try {
+			return this.insightsService.getMaxAgeInDaysAndGranularity(payload.dateRange ?? 'week');
+		} catch (error: unknown) {
+			throw new ForbiddenError((error as UserError).message);
+		}
+	}
 
 	@Get('/summary')
 	@GlobalScope('insights:list')
-	async getInsightsSummary(): Promise<InsightsSummary> {
+	async getInsightsSummary(
+		_req: AuthenticatedRequest,
+		_res: Response,
+		@Query payload: InsightsDateFilterDto = { dateRange: 'week' },
+	): Promise<InsightsSummary> {
+		const dateRangeAndMaxAgeInDays = this.getMaxAgeInDaysAndGranularity(payload);
 		return await this.insightsService.getInsightsSummary({
-			periodLengthInDays: this.maxAgeInDaysFilteredInsights,
+			periodLengthInDays: dateRangeAndMaxAgeInDays.maxAgeInDays,
 		});
 	}
 
@@ -28,8 +45,11 @@ export class InsightsController {
 		_res: Response,
 		@Query payload: ListInsightsWorkflowQueryDto,
 	): Promise<InsightsByWorkflow> {
+		const dateRangeAndMaxAgeInDays = this.getMaxAgeInDaysAndGranularity({
+			dateRange: payload.dateRange ?? 'week',
+		});
 		return await this.insightsService.getInsightsByWorkflow({
-			maxAgeInDays: this.maxAgeInDaysFilteredInsights,
+			maxAgeInDays: dateRangeAndMaxAgeInDays.maxAgeInDays,
 			skip: payload.skip,
 			take: payload.take,
 			sortBy: payload.sortBy,
@@ -39,10 +59,15 @@ export class InsightsController {
 	@Get('/by-time')
 	@GlobalScope('insights:list')
 	@Licensed('feat:insights:viewDashboard')
-	async getInsightsByTime(): Promise<InsightsByTime[]> {
+	async getInsightsByTime(
+		_req: AuthenticatedRequest,
+		_res: Response,
+		@Query payload: InsightsDateFilterDto,
+	): Promise<InsightsByTime[]> {
+		const dateRangeAndMaxAgeInDays = this.getMaxAgeInDaysAndGranularity(payload);
 		return await this.insightsService.getInsightsByTime({
-			maxAgeInDays: this.maxAgeInDaysFilteredInsights,
-			periodUnit: 'day',
+			maxAgeInDays: dateRangeAndMaxAgeInDays.maxAgeInDays,
+			periodUnit: dateRangeAndMaxAgeInDays.granularity,
 		});
 	}
 }

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -1,8 +1,8 @@
-import type { InsightsSummary } from '@n8n/api-types';
 import {
-	insightsDateRangeSchema,
+	type InsightsSummary,
 	type InsightsDateRange,
-} from '@n8n/api-types/src/schemas/insights.schema';
+	INSIGHTS_DATE_RANGE_KEYS,
+} from '@n8n/api-types';
 import { OnShutdown } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 import { Logger } from 'n8n-core';
@@ -205,7 +205,7 @@ export class InsightsService {
 				: this.license.getInsightsMaxHistory();
 		const isHourlyDateEnabled = this.license.isInsightsHourlyDataEnabled();
 
-		return insightsDateRangeSchema.shape.key.options.map((key) => ({
+		return INSIGHTS_DATE_RANGE_KEYS.map((key) => ({
 			key,
 			licensed:
 				key === 'day' ? (isHourlyDateEnabled ?? false) : maxHistoryInDays >= keyRangeToDays[key],

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -1,10 +1,13 @@
 import type { InsightsSummary } from '@n8n/api-types';
-import type { InsightsDateRange } from '@n8n/api-types/src/schemas/insights.schema';
+import {
+	insightsDateRangeSchema,
+	type InsightsDateRange,
+} from '@n8n/api-types/src/schemas/insights.schema';
 import { OnShutdown } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 import { Logger } from 'n8n-core';
 import type { ExecutionLifecycleHooks } from 'n8n-core';
-import type { IRun } from 'n8n-workflow';
+import { UserError, type IRun } from 'n8n-workflow';
 
 import { License } from '@/license';
 
@@ -13,6 +16,16 @@ import { NumberToType } from './database/entities/insights-shared';
 import { InsightsByPeriodRepository } from './database/repositories/insights-by-period.repository';
 import { InsightsCollectionService } from './insights-collection.service';
 import { InsightsCompactionService } from './insights-compaction.service';
+
+const keyRangeToDays: Record<InsightsDateRange['key'], number> = {
+	day: 1,
+	week: 7,
+	'2weeks': 14,
+	month: 30,
+	quarter: 90,
+	'6months': 180,
+	year: 365,
+};
 
 @Service()
 export class InsightsService {
@@ -181,6 +194,10 @@ export class InsightsService {
 		});
 	}
 
+	/**
+	 * Returns the available date ranges with their license authorization and time granularity
+	 * when grouped by time.
+	 */
 	getAvailableDateRanges(): InsightsDateRange[] {
 		const maxHistoryInDays =
 			this.license.getInsightsMaxHistory() === -1
@@ -188,13 +205,31 @@ export class InsightsService {
 				: this.license.getInsightsMaxHistory();
 		const isHourlyDateEnabled = this.license.isInsightsHourlyDataEnabled();
 
-		return [
-			{ key: 'day', licensed: isHourlyDateEnabled ?? false, granularity: 'hour' },
-			{ key: 'week', licensed: maxHistoryInDays >= 7, granularity: 'day' },
-			{ key: '2weeks', licensed: maxHistoryInDays >= 14, granularity: 'day' },
-			{ key: 'month', licensed: maxHistoryInDays >= 30, granularity: 'day' },
-			{ key: 'quarter', licensed: maxHistoryInDays >= 90, granularity: 'week' },
-			{ key: 'year', licensed: maxHistoryInDays >= 365, granularity: 'week' },
-		];
+		return insightsDateRangeSchema.shape.key.options.map((key) => ({
+			key,
+			licensed:
+				key === 'day' ? (isHourlyDateEnabled ?? false) : maxHistoryInDays >= keyRangeToDays[key],
+			granularity: key === 'day' ? 'hour' : keyRangeToDays[key] <= 30 ? 'day' : 'week',
+		}));
+	}
+
+	getMaxAgeInDaysAndGranularity(
+		dateRangeKey: InsightsDateRange['key'],
+	): InsightsDateRange & { maxAgeInDays: number } {
+		const availableDateRanges = this.getAvailableDateRanges();
+
+		const dateRange = availableDateRanges.find((range) => range.key === dateRangeKey);
+		if (!dateRange) {
+			// Not supposed to happen if we trust the dateRangeKey type
+			throw new UserError('The selected date range is not available');
+		}
+
+		if (!dateRange.licensed) {
+			throw new UserError(
+				'The selected date range exceeds the maximum history allowed by your license.',
+			);
+		}
+
+		return { ...dateRange, maxAgeInDays: keyRangeToDays[dateRangeKey] };
 	}
 }

--- a/packages/cli/test/integration/insights/insights.api.test.ts
+++ b/packages/cli/test/integration/insights/insights.api.test.ts
@@ -1,3 +1,5 @@
+import type { InsightsDateRange } from '@n8n/api-types';
+
 import { Telemetry } from '@/telemetry';
 import { mockInstance } from '@test/mocking';
 
@@ -11,6 +13,7 @@ let agents: Record<string, SuperAgentTest> = {};
 const testServer = utils.setupTestServer({
 	endpointGroups: ['insights', 'license', 'auth'],
 	enabledFeatures: ['feat:insights:viewSummary', 'feat:insights:viewDashboard'],
+	quotas: { 'quota:insights:maxHistoryDays': 365 },
 });
 
 beforeAll(async () => {
@@ -47,6 +50,54 @@ describe('GET /insights routes return 403 for dashboard routes when summary lice
 			await authAgent.get('/insights/by-workflow').expect(403);
 		},
 	);
+});
+
+describe('GET /insights routes return 403 for insights route with date range outside license limits', () => {
+	beforeAll(() => {
+		testServer.license.setDefaults({ quotas: { 'quota:insights:maxHistoryDays': 3 } });
+	});
+
+	test('Call should throw forbidden for default week insights', async () => {
+		const authAgent = agents.admin;
+		await authAgent.get('/insights/summary').expect(403);
+		await authAgent.get('/insights/by-time').expect(403);
+		await authAgent.get('/insights/by-workflow').expect(403);
+	});
+
+	test('Call should throw forbidden for daily data without viewHourlyData enabled', async () => {
+		const authAgent = agents.admin;
+		await authAgent.get('/insights/summary?dateRange=day').expect(403);
+		await authAgent.get('/insights/by-time?dateRange=day').expect(403);
+		await authAgent.get('/insights/by-workflow?dateRange=day').expect(403);
+	});
+});
+
+describe('GET /insights routes return 200 for insights route with date range inside license limits', () => {
+	beforeAll(() => {
+		testServer.license.setDefaults({
+			features: [
+				'feat:insights:viewSummary',
+				'feat:insights:viewDashboard',
+				'feat:insights:viewHourlyData',
+			],
+			quotas: { 'quota:insights:maxHistoryDays': 365 },
+		});
+	});
+
+	test.each<InsightsDateRange['key']>([
+		'day',
+		'week',
+		'2weeks',
+		'month',
+		'quarter',
+		'6months',
+		'year',
+	])('Call should work for date range %s', async (dateRange) => {
+		const authAgent = agents.admin;
+		await authAgent.get(`/insights/summary?dateRange=${dateRange}`).expect(200);
+		await authAgent.get(`/insights/by-time?dateRange=${dateRange}`).expect(200);
+		await authAgent.get(`/insights/by-workflow?dateRange=${dateRange}`).expect(200);
+	});
 });
 
 describe('GET /insights/by-workflow', () => {

--- a/packages/cli/test/integration/insights/insights.api.test.ts
+++ b/packages/cli/test/integration/insights/insights.api.test.ts
@@ -52,7 +52,7 @@ describe('GET /insights routes return 403 for dashboard routes when summary lice
 	);
 });
 
-describe('GET /insights routes return 403 for insights route with date range outside license limits', () => {
+describe('GET /insights routes return 403 if date range outside license limits', () => {
 	beforeAll(() => {
 		testServer.license.setDefaults({ quotas: { 'quota:insights:maxHistoryDays': 3 } });
 	});
@@ -72,7 +72,7 @@ describe('GET /insights routes return 403 for insights route with date range out
 	});
 });
 
-describe('GET /insights routes return 200 for insights route with date range inside license limits', () => {
+describe('GET /insights routes return 200 if date range inside license limits', () => {
 	beforeAll(() => {
 		testServer.license.setDefaults({
 			features: [


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR adds the possibility to filter insights data by a specific date range (day, week, 2 weeks, month, quarter, 6 months, year). 
To do that, the user can send a `dateRange` query parameter to all insights routes. this query param is validated so that it matches the insights max history quota of the license. 
The `by-time` endpoint also chooses granularity according to the date range (<24 hours = hourly, 7, 14, 30 = days, 3 months +  = weeks) so that it stays relevant on the frontend.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2737/implement-granularity-and-date-range-filtering-on-insights-routes


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
