### PR TITLE
Changed getContext function to handle missing executionData better.

### DIFF
--- a/packages/workflow/src/NodeHelpers.ts
+++ b/packages/workflow/src/NodeHelpers.ts
@@ -569,8 +569,13 @@ export function getContext(
 	node?: INode,
 ): IContextObject {
 	if (runExecutionData.executionData === undefined) {
-		// TODO: Should not happen leave it for test now
-		throw new ApplicationError('`executionData` is not initialized');
+		// Improved error handling: log error and return empty context instead of throwing
+		console.error(
+			'`executionData` is not initialized in runExecutionData. This usually indicates a problem in workflow execution or data passing. Returning empty context to avoid breaking execution.',
+			{ runExecutionData, type, nodeName: node?.name },
+		);
+		// Return empty context object to avoid breaking the workflow
+		return {};
 	}
 
 	let key: string;
@@ -578,7 +583,6 @@ export function getContext(
 		key = 'flow';
 	} else if (type === 'node') {
 		if (node === undefined) {
-			// @TODO: What does this mean?
 			throw new ApplicationError(
 				'The request data of context type "node" the node parameter has to be set!',
 			);


### PR DESCRIPTION
Instead of stopping the program with an error, it now logs a message and returns an empty context. This helps the workflow keep running smoothly and makes it easier to find and fix problems.

**Lines Added**
console.error(...): logs a detailed error message with context to help debugging instead of throwing an error.
return {}: returns an empty context object to prevent the workflow from breaking unexpectedly.
**Lines removed**
throw new ApplicationError(...) statement: caused the workflow to stop.