### PR TITLE
feat(OpenAI Node): Support gpt-image-1 for image generation

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/image/generate.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/image/generate.operation.ts
@@ -17,15 +17,15 @@ const properties: INodeProperties[] = [
 		description: 'The model to use for image generation',
 		options: [
 			{
-				name: 'DALL-E-2',
+				name: 'DALL·E 2',
 				value: 'dall-e-2',
 			},
 			{
-				name: 'DALL-E-3',
+				name: 'DALL·E 3',
 				value: 'dall-e-3',
 			},
 			{
-				name: 'gpt-image-1',
+				name: 'GPT Image 1',
 				value: 'gpt-image-1',
 			},
 		],
@@ -67,7 +67,7 @@ const properties: INodeProperties[] = [
 			},
 			{
 				displayName: 'Quality',
-				name: 'quality',
+				name: 'dalleQuality',
 				type: 'options',
 				description:
 					'The quality of the image that will be generated, HD creates images with finer details and greater consistency across the image',
@@ -263,8 +263,12 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 		delete options.binaryPropertyOutput;
 	}
 
-	delete options.returnImageUrls;
+	if (options.dalleQuality) {
+		options.quality = options.dalleQuality;
+		delete options.dalleQuality;
+	}
 
+	delete options.returnImageUrls;
 	const body: IDataObject = {
 		prompt,
 		model,

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/image/generate.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/image/generate.operation.ts
@@ -89,6 +89,34 @@ const properties: INodeProperties[] = [
 				default: 'standard',
 			},
 			{
+				displayName: 'Quality',
+				name: 'quality',
+				type: 'options',
+				description:
+					'The quality of the image that will be generated, High creates images with finer details and greater consistency across the image',
+				options: [
+					{
+						name: 'High',
+						value: 'high',
+					},
+					{
+						name: 'Medium',
+						value: 'medium',
+					},
+					{
+						name: 'Low',
+						value: 'low',
+					},
+				],
+				displayOptions: {
+					show: {
+						'/model': ['gpt-image-1'],
+					},
+				},
+				default: 'medium',
+			},
+
+			{
 				displayName: 'Resolution',
 				name: 'size',
 				type: 'options',
@@ -138,6 +166,32 @@ const properties: INodeProperties[] = [
 				},
 				default: '1024x1024',
 			},
+			{
+				displayName: 'Resolution',
+				name: 'size',
+				type: 'options',
+				options: [
+					{
+						name: '1024x1024',
+						value: '1024x1024',
+					},
+					{
+						name: '1024x1536',
+						value: '1024x1536',
+					},
+					{
+						name: '1536x1024',
+						value: '1536x1024',
+					},
+				],
+				displayOptions: {
+					show: {
+						'/model': ['gpt-image-1'],
+					},
+				},
+				default: '1024x1024',
+			},
+
 			{
 				displayName: 'Style',
 				name: 'style',

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/image/generate.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/image/generate.operation.ts
@@ -24,6 +24,10 @@ const properties: INodeProperties[] = [
 				name: 'DALL-E-3',
 				value: 'dall-e-3',
 			},
+			{
+				name: 'gpt-image-1',
+				value: 'gpt-image-1',
+			},
 		],
 	},
 	{
@@ -210,12 +214,11 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 	const body: IDataObject = {
 		prompt,
 		model,
-		response_format,
+		response_format: model !== 'gpt-image-1' ? response_format : undefined, // gpt-image-1 does not support response_format
 		...options,
 	};
 
 	const { data } = await apiRequest.call(this, 'POST', '/images/generations', { body });
-
 	if (response_format === 'url') {
 		return ((data as IDataObject[]) || []).map((entry) => ({
 			json: entry,


### PR DESCRIPTION
## Summary

Support gpt-image-1 for image generation
## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-887/add-support-for-openai-gpt-image-1-image-generation-model

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
