### PR TITLE
fix(AI Agent Node): Prevent adding empty binary message

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/execute.ts
@@ -365,7 +365,11 @@ export async function prepareMessages(
 	const hasBinaryData = ctx.getInputData()?.[itemIndex]?.binary !== undefined;
 	if (hasBinaryData && options.passthroughBinaryImages) {
 		const binaryMessage = await extractBinaryMessages(ctx, itemIndex);
-		messages.push(binaryMessage);
+		if (binaryMessage.content.length !== 0) {
+			messages.push(binaryMessage);
+		} else {
+			ctx.logger.debug('Not attaching binary message, since its content was empty');
+		}
 	}
 
 	// We add the agent scratchpad last, so that the agent will not run in loops

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent.test.ts
@@ -233,6 +233,33 @@ describe('prepareMessages', () => {
 		expect(hasHumanMessage).toBe(false);
 	});
 
+	it('should not include a binary message if no image data is present', async () => {
+		const fakeItem = {
+			json: {},
+			binary: {
+				img1: {
+					mimeType: 'application/pdf',
+					data: 'data:application/pdf;base64,sampledata',
+				},
+			},
+		};
+		mockContext.getInputData.mockReturnValue([fakeItem]);
+		mockContext.logger = {
+			debug: jest.fn(),
+			info: jest.fn(),
+			warn: jest.fn(),
+			error: jest.fn(),
+		};
+
+		const messages = await prepareMessages(mockContext, 0, {
+			systemMessage: 'Test system',
+			passthroughBinaryImages: true,
+		});
+		const hasHumanMessage = messages.some((m) => m instanceof HumanMessage);
+		expect(hasHumanMessage).toBe(false);
+		expect(mockContext.logger.debug).toHaveBeenCalledTimes(1);
+	});
+
 	it('should not include system_message in prompt templates if not provided after version 1.9', async () => {
 		const fakeItem = { json: {} };
 		const mockNode = mock<INode>();


### PR DESCRIPTION
## Summary

When passing in binary data to the agent, that is *not* an image, the resulting binary message will have an empty content member. This does not play nice with some models (especially Gemini). This should make sure that empty messages will not be added through the binary data mechanism.

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/issues/12109
https://github.com/n8n-io/n8n/issues/14023
https://linear.app/n8n/issue/AI-511/community-issue-gemini-tools-agent-not-working

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
