### PR TITLE
fix(core): Error when multiple nodes return items with multiple paired items

### DIFF
--- a/packages/workflow/src/WorkflowDataProxy.ts
+++ b/packages/workflow/src/WorkflowDataProxy.ts
@@ -900,7 +900,7 @@ export class WorkflowDataProxy {
 								return null;
 							}
 						})
-						.filter((result) => result !== null);
+						.filter((result) => result !== null && result !== undefined);
 
 					if (results.length !== 1) {
 						// Check if the results are all the same


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Fix an error related to paired items that occurred whenever the workflow has multiple nodes that each return multiple paired items for each output item (e.g. an Aggregate node that comes before a Merge node) 

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-2254/summarize-node-returns-multiple-paired-items-per-item

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
