### PR TITLE
fix(SSH node): raise error if remote execution return non-zero exit code. #fix 14921

### DIFF
--- a/packages/nodes-base/nodes/Ssh/Ssh.node.ts
+++ b/packages/nodes-base/nodes/Ssh/Ssh.node.ts
@@ -165,6 +165,19 @@ export class Ssh implements INodeType {
 				required: true,
 			},
 			{
+				displayName: 'Raise Error on Failure',
+				name: 'raise_failure',
+				type: 'boolean',
+				displayOptions: {
+					show: {
+						resource: ['command'],
+						operation: ['execute'],
+					},
+				},
+				default: true,
+				description: 'Whether to throw an error if the command returns a non-zero exit code',
+			},
+			{
 				displayName: 'Operation',
 				name: 'operation',
 				type: 'options',
@@ -371,9 +384,10 @@ export class Ssh implements INodeType {
 								ssh,
 								i,
 							);
+							const raiseFailure = this.getNodeParameter('raise_failure', i, true) as boolean;
 							const result = await ssh.execCommand(command, { cwd });
 
-							if (result.code !== 0) {
+							if (raiseFailure && result.code !== 0) {
 								throw new NodeOperationError(
 									this.getNode(),
 									`Command failed with exit code ${result.code}. stderr: ${result.stderr || 'N/A'}. stdout: ${result.stdout || 'N/A'}`,

--- a/packages/nodes-base/nodes/Ssh/Ssh.node.ts
+++ b/packages/nodes-base/nodes/Ssh/Ssh.node.ts
@@ -371,8 +371,21 @@ export class Ssh implements INodeType {
 								ssh,
 								i,
 							);
+							const result = await ssh.execCommand(command, { cwd });
+
+							if (result.code !== 0) {
+								throw new NodeOperationError(
+									this.getNode(),
+									`Command failed with exit code ${result.code}. stderr: ${result.stderr || 'N/A'}. stdout: ${result.stdout || 'N/A'}`,
+									{
+										itemIndex: i,
+										description: `Exit Code: ${result.code}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`,
+									},
+								);
+							}
+
 							returnItems.push({
-								json: (await ssh.execCommand(command, { cwd })) as unknown as IDataObject,
+								json: result as unknown as IDataObject,
 								pairedItem: {
 									item: i,
 								},


### PR DESCRIPTION
## Summary

Throw error when SSH execution return a non-zero exit code.

Just run SSH node execution with remote command `/bin/true` and `/bin/false`. If exit code is non-zero, an error show up with stdout and/or stderr if available.

## Related Linear tickets, Github issues, and Community forum posts

- #14921

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**