### PR TITLE
feat(core): Implement partial execution of tool nodes (no-changelog)

### DIFF
--- a/packages/core/src/execution-engine/partial-execution-utils/__tests__/is-tool.test.ts
+++ b/packages/core/src/execution-engine/partial-execution-utils/__tests__/is-tool.test.ts
@@ -1,0 +1,50 @@
+import { type INode, type INodeTypes, NodeConnectionTypes } from 'n8n-workflow';
+import { isTool } from '../is-tool';
+import { mock } from 'jest-mock-extended';
+
+const mockNode = mock<INode>({ id: '1', type: 'n8n-nodes-base.openAi', typeVersion: 1 });
+const mockNodeTypes = mock<INodeTypes>();
+
+describe('isTool', () => {
+	it('should return true for a node with AiTool output', () => {
+		mockNodeTypes.getByNameAndVersion.mockReturnValue({
+			description: {
+				outputs: [NodeConnectionTypes.AiTool],
+				version: 0,
+				defaults: {
+					name: '',
+					color: '',
+				},
+				inputs: [NodeConnectionTypes.Main],
+				properties: [],
+				displayName: '',
+				name: '',
+				group: [],
+				description: '',
+			},
+		});
+		const result = isTool(mockNode, mockNodeTypes);
+		expect(result).toBe(true);
+	});
+
+	it('returns false for node with no AiTool output', () => {
+		mockNodeTypes.getByNameAndVersion.mockReturnValue({
+			description: {
+				outputs: [NodeConnectionTypes.Main],
+				version: 0,
+				defaults: {
+					name: '',
+					color: '',
+				},
+				inputs: [NodeConnectionTypes.Main],
+				properties: [],
+				displayName: '',
+				name: '',
+				group: [],
+				description: '',
+			},
+		});
+		const result = isTool(mockNode, mockNodeTypes);
+		expect(result).toBe(false);
+	});
+});

--- a/packages/core/src/execution-engine/partial-execution-utils/__tests__/is-tool.test.ts
+++ b/packages/core/src/execution-engine/partial-execution-utils/__tests__/is-tool.test.ts
@@ -1,6 +1,7 @@
-import { type INode, type INodeTypes, NodeConnectionTypes } from 'n8n-workflow';
-import { isTool } from '../is-tool';
 import { mock } from 'jest-mock-extended';
+import { type INode, type INodeTypes, NodeConnectionTypes } from 'n8n-workflow';
+
+import { isTool } from '../is-tool';
 
 const mockNode = mock<INode>({ id: '1', type: 'n8n-nodes-base.openAi', typeVersion: 1 });
 const mockNodeTypes = mock<INodeTypes>();

--- a/packages/core/src/execution-engine/partial-execution-utils/__tests__/rewire-graph.test.ts
+++ b/packages/core/src/execution-engine/partial-execution-utils/__tests__/rewire-graph.test.ts
@@ -1,7 +1,8 @@
 import { NodeConnectionTypes } from 'n8n-workflow';
-import { rewireGraph } from '../rewire-graph';
-import { DirectedGraph } from '../directed-graph';
+
 import { createNodeData } from './helpers';
+import { DirectedGraph } from '../directed-graph';
+import { rewireGraph } from '../rewire-graph';
 
 describe('rewireGraph()', () => {
 	it('rewires a simple graph with a tool node', () => {

--- a/packages/core/src/execution-engine/partial-execution-utils/__tests__/rewire-graph.test.ts
+++ b/packages/core/src/execution-engine/partial-execution-utils/__tests__/rewire-graph.test.ts
@@ -1,0 +1,117 @@
+import { NodeConnectionTypes } from 'n8n-workflow';
+import { rewireGraph } from '../rewire-graph';
+import { DirectedGraph } from '../directed-graph';
+import { createNodeData } from './helpers';
+
+describe('rewireGraph()', () => {
+	it('rewires a simple graph with a tool node', () => {
+		const tool = createNodeData({ name: 'tool', type: 'n8n-nodes-base.ai-tool' });
+		const root = createNodeData({ name: 'root' });
+		const trigger = createNodeData({ name: 'trigger' });
+
+		const graph = new DirectedGraph();
+		graph.addNodes(trigger, root, tool);
+		graph.addConnections(
+			{ from: trigger, to: root, type: NodeConnectionTypes.Main },
+			{ from: tool, to: root, type: NodeConnectionTypes.AiTool },
+		);
+
+		const rewiredGraph = rewireGraph(tool, graph);
+
+		const toolConnections = rewiredGraph.getDirectParentConnections(tool);
+		expect(toolConnections).toHaveLength(1);
+		expect(toolConnections[0].from.name).toBe('trigger');
+		expect(toolConnections[0].type).toBe(NodeConnectionTypes.Main);
+
+		expect(rewiredGraph.hasNode(root.name)).toBe(false);
+	});
+
+	it('rewires all incoming connections of the root node to the tool', () => {
+		const tool = createNodeData({ name: 'tool', type: 'n8n-nodes-base.ai-tool' });
+		const root = createNodeData({ name: 'root' });
+		const trigger = createNodeData({ name: 'trigger' });
+		const secondNode = createNodeData({ name: 'secondNode' });
+		const thirdNode = createNodeData({ name: 'thirdNode' });
+
+		const graph = new DirectedGraph();
+		graph.addNodes(trigger, root, tool, secondNode, thirdNode);
+		graph.addConnections(
+			{ from: trigger, to: secondNode, type: NodeConnectionTypes.Main },
+			{ from: trigger, to: thirdNode, type: NodeConnectionTypes.Main },
+			{ from: tool, to: root, type: NodeConnectionTypes.AiTool },
+			{ from: secondNode, to: root, type: NodeConnectionTypes.Main },
+			{ from: thirdNode, to: root, type: NodeConnectionTypes.Main },
+		);
+
+		const rewiredGraph = rewireGraph(tool, graph);
+
+		const toolConnections = rewiredGraph.getDirectParentConnections(tool);
+		expect(toolConnections).toHaveLength(2);
+		expect(toolConnections.map((cn) => cn.from.name).sort()).toEqual(
+			['secondNode', 'thirdNode'].sort(),
+		);
+	});
+
+	it('ignores non-main connections when rewiring', () => {
+		const tool = createNodeData({ name: 'tool', type: 'n8n-nodes-base.ai-tool' });
+		const root = createNodeData({ name: 'root' });
+		const parent = createNodeData({ name: 'parent' });
+		const trigger = createNodeData({ name: 'trigger' });
+		const child = createNodeData({ name: 'child' });
+
+		const graph = new DirectedGraph();
+		graph.addNodes(trigger, root, tool, parent, child);
+		graph.addConnections(
+			{ from: trigger, to: root, type: NodeConnectionTypes.Main },
+			{ from: parent, to: root, type: NodeConnectionTypes.AiLanguageModel },
+			{ from: child, to: root, type: NodeConnectionTypes.AiTool },
+			{ from: tool, to: root, type: NodeConnectionTypes.AiTool },
+		);
+
+		const rewiredGraph = rewireGraph(tool, graph);
+
+		const toolConnections = rewiredGraph.getDirectParentConnections(tool);
+		expect(toolConnections).toHaveLength(1);
+		expect(toolConnections[0].type).toBe(NodeConnectionTypes.Main);
+	});
+
+	it('sets rewireOutputLogTo to AiTool on the tool node', () => {
+		const tool = createNodeData({ name: 'tool', type: 'n8n-nodes-base.ai-tool' });
+		const trigger = createNodeData({ name: 'trigger' });
+		const root = createNodeData({ name: 'root' });
+
+		const graph = new DirectedGraph();
+		graph.addNodes(trigger, root, tool);
+		graph.addConnections(
+			{ from: trigger, to: root, type: NodeConnectionTypes.Main },
+			{ from: tool, to: root, type: NodeConnectionTypes.AiTool },
+		);
+
+		rewireGraph(tool, graph);
+
+		expect(tool.rewireOutputLogTo).toBe(NodeConnectionTypes.AiTool);
+	});
+
+	it('fails when the tool has no incoming connections', () => {
+		const tool = createNodeData({ name: 'tool', type: 'n8n-nodes-base.ai-tool' });
+		const root = createNodeData({ name: 'root' });
+
+		const graph = new DirectedGraph();
+		graph.addNodes(root, tool);
+
+		expect(() => rewireGraph(tool, graph)).toThrow();
+	});
+
+	it('removes the root node from the graph', () => {
+		const tool = createNodeData({ name: 'tool', type: 'n8n-nodes-base.ai-tool' });
+		const root = createNodeData({ name: 'root' });
+
+		const graph = new DirectedGraph();
+		graph.addNodes(root, tool);
+		graph.addConnections({ from: tool, to: root, type: NodeConnectionTypes.AiTool });
+
+		const rewiredGraph = rewireGraph(tool, graph);
+
+		expect(rewiredGraph.hasNode(root.name)).toBe(false);
+	});
+});

--- a/packages/core/src/execution-engine/partial-execution-utils/index.ts
+++ b/packages/core/src/execution-engine/partial-execution-utils/index.ts
@@ -6,3 +6,5 @@ export { recreateNodeExecutionStack } from './recreate-node-execution-stack';
 export { cleanRunData } from './clean-run-data';
 export { handleCycles } from './handle-cycles';
 export { filterDisabledNodes } from './filter-disabled-nodes';
+export { isTool } from './is-tool';
+export { rewireGraph } from './rewire-graph';

--- a/packages/core/src/execution-engine/partial-execution-utils/is-tool.ts
+++ b/packages/core/src/execution-engine/partial-execution-utils/is-tool.ts
@@ -1,0 +1,6 @@
+import { type INode, type INodeTypes, NodeConnectionTypes } from 'n8n-workflow';
+
+export function isTool(node: INode, nodeTypes: INodeTypes) {
+	const type = nodeTypes.getByNameAndVersion(node.type, node.typeVersion);
+	return type.description.outputs.includes(NodeConnectionTypes.AiTool);
+}

--- a/packages/core/src/execution-engine/partial-execution-utils/rewire-graph.ts
+++ b/packages/core/src/execution-engine/partial-execution-utils/rewire-graph.ts
@@ -1,0 +1,26 @@
+import * as a from 'assert/strict';
+import { type INode, NodeConnectionTypes } from 'n8n-workflow';
+
+import { type DirectedGraph } from './directed-graph';
+
+export function rewireGraph(tool: INode, graph: DirectedGraph): DirectedGraph {
+	graph = graph.clone();
+	const children = graph.getChildren(tool);
+	const rootNode = [...children][0];
+
+	a.ok(rootNode);
+
+	const allIncomingConnection = graph
+		.getDirectParentConnections(rootNode)
+		.filter((cn) => cn.type === NodeConnectionTypes.Main);
+
+	tool.rewireOutputLogTo = NodeConnectionTypes.AiTool;
+
+	for (const cn of allIncomingConnection) {
+		graph.addConnection({ from: cn.from, to: tool });
+	}
+
+	graph.removeNode(rootNode);
+
+	return graph;
+}

--- a/packages/core/src/execution-engine/partial-execution-utils/rewire-graph.ts
+++ b/packages/core/src/execution-engine/partial-execution-utils/rewire-graph.ts
@@ -6,6 +6,9 @@ import { type DirectedGraph } from './directed-graph';
 export function rewireGraph(tool: INode, graph: DirectedGraph): DirectedGraph {
 	graph = graph.clone();
 	const children = graph.getChildren(tool);
+
+	a.ok(children.size > 0, 'Tool must be connected to a root node');
+
 	const rootNode = [...children][0];
 
 	a.ok(rootNode);

--- a/packages/core/test/helpers/constants.ts
+++ b/packages/core/test/helpers/constants.ts
@@ -43,6 +43,25 @@ export const predefinedNodesTypes: INodeTypeData = {
 		type: new SplitInBatches(),
 		sourcePath: '',
 	},
+	'n8n-nodes-base.toolTest': {
+		sourcePath: '',
+		type: {
+			description: {
+				displayName: 'Test tool',
+				name: 'toolTest',
+				group: ['transform'],
+				version: 1,
+				description: 'Test tool',
+				inputs: [],
+				defaults: {
+					name: 'Test Tool',
+					color: '#0000FF',
+				},
+				outputs: [NodeConnectionTypes.AiTool],
+				properties: [],
+			},
+		},
+	},
 	'n8n-nodes-base.versionTest': {
 		sourcePath: '',
 		type: {

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -1135,6 +1135,7 @@ export interface INode {
 	credentials?: INodeCredentials;
 	webhookId?: string;
 	extendsCredential?: string;
+	rewireOutputLogTo?: NodeConnectionType;
 }
 
 export interface IPinData {


### PR DESCRIPTION
## Summary
Implement partial execution of tool nodes limited to nodes-as-tools for now. 

Backend part of PR [#14938](https://github.com/n8n-io/n8n/pull/14938)

The backend rewires the execution graph to elevate the tool node to the position of its parent (the agent).
After execution the result data gets rewired back to the tool output instead of the Main output.

- Add helper to recognize a tool node
- Add helper to rewire a tool node in the graph
- Rewire graph on partial executions with tool node as destination
- Rewire graph on full execution with a tool node as destination
- Rewire output log if necessary after successful execution

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-858/implement-partial-execution-of-tools-in-frontend
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
