### PR TITLE
feat: Set up Kafka SchemaRegistry auth for Kafka and KafkaTrigger nodes

### DIFF
--- a/packages/nodes-base/nodes/Kafka/Kafka.node.ts
+++ b/packages/nodes-base/nodes/Kafka/Kafka.node.ts
@@ -93,6 +93,35 @@ export class Kafka implements INodeType {
 				description: 'URL of the schema registry',
 			},
 			{
+				displayName: 'Schema Registry Auth Username',
+				name: 'schemaRegistryUsername',
+				type: 'string',
+				default: '',
+				placeholder: 'username',
+				description: 'Username for HTTP Basic Auth to access the Schema Registry (optional)',
+				displayOptions: {
+					show: {
+						useSchemaRegistry: [true],
+					},
+				},
+			},
+			{
+				displayName: 'Schema Registry Auth Password',
+				name: 'schemaRegistryPassword',
+				type: 'string',
+				typeOptions: {
+					password: true,
+				},
+				default: '',
+				placeholder: 'password',
+				description: 'Password for HTTP Basic Auth to access the Schema Registry (optional)',
+				displayOptions: {
+					show: {
+						useSchemaRegistry: [true],
+					},
+				},
+			},
+			{
 				displayName: 'Use Key',
 				name: 'useKey',
 				type: 'boolean',
@@ -330,9 +359,28 @@ export class Kafka implements INodeType {
 				if (useSchemaRegistry) {
 					try {
 						const schemaRegistryUrl = this.getNodeParameter('schemaRegistryUrl', 0) as string;
+						const schemaRegistryUsername = this.getNodeParameter(
+							'schemaRegistryUsername',
+							0,
+						) as string;
+						const schemaRegistryPassword = this.getNodeParameter(
+							'schemaRegistryPassword',
+							0,
+						) as string;
 						const eventName = this.getNodeParameter('eventName', 0) as string;
 
-						const registry = new SchemaRegistry({ host: schemaRegistryUrl });
+						let registry: SchemaRegistry;
+						if (schemaRegistryUsername && schemaRegistryPassword) {
+							registry = new SchemaRegistry({
+								host: schemaRegistryUrl,
+								auth: {
+									username: schemaRegistryUsername,
+									password: schemaRegistryPassword,
+								},
+							});
+						} else {
+							registry = new SchemaRegistry({ host: schemaRegistryUrl });
+						}
 						const id = await registry.getLatestSchemaId(eventName);
 
 						message = await registry.encode(id, JSON.parse(message));

--- a/packages/nodes-base/nodes/Kafka/Kafka.node.ts
+++ b/packages/nodes-base/nodes/Kafka/Kafka.node.ts
@@ -370,7 +370,7 @@ export class Kafka implements INodeType {
 						const eventName = this.getNodeParameter('eventName', 0) as string;
 
 						let registry: SchemaRegistry;
-						if (schemaRegistryUsername && schemaRegistryPassword) {
+						if (schemaRegistryUsername || schemaRegistryPassword) {
 							registry = new SchemaRegistry({
 								host: schemaRegistryUrl,
 								auth: {

--- a/packages/nodes-base/nodes/Kafka/Kafka.node.ts
+++ b/packages/nodes-base/nodes/Kafka/Kafka.node.ts
@@ -370,7 +370,7 @@ export class Kafka implements INodeType {
 						const eventName = this.getNodeParameter('eventName', 0) as string;
 
 						let registry: SchemaRegistry;
-						if (schemaRegistryUsername || schemaRegistryPassword) {
+						if (schemaRegistryUsername && schemaRegistryPassword) {
 							registry = new SchemaRegistry({
 								host: schemaRegistryUrl,
 								auth: {

--- a/packages/nodes-base/nodes/Kafka/KafkaTrigger.node.ts
+++ b/packages/nodes-base/nodes/Kafka/KafkaTrigger.node.ts
@@ -291,7 +291,7 @@ export class KafkaTrigger implements INodeType {
 					if (useSchemaRegistry) {
 						try {
 							let registry: SchemaRegistry;
-							if (schemaRegistryUsername || schemaRegistryPassword) {
+							if (schemaRegistryUsername && schemaRegistryPassword) {
 								registry = new SchemaRegistry({
 									host: schemaRegistryUrl,
 									auth: {

--- a/packages/nodes-base/nodes/Kafka/test/Kafka.node.test.ts
+++ b/packages/nodes-base/nodes/Kafka/test/Kafka.node.test.ts
@@ -128,6 +128,14 @@ describe('Kafka Node', () => {
 		});
 	});
 
+	test('should get latest schema ID from SchemaRegistry', () => {
+		expect(mockRegistryGetLatestSchemaId).toHaveBeenCalledTimes(4);
+		expect(mockRegistryGetLatestSchemaId).toHaveBeenNthCalledWith(1, 'test-event-name');
+		expect(mockRegistryGetLatestSchemaId).toHaveBeenNthCalledWith(2, 'test-event-name');
+		expect(mockRegistryGetLatestSchemaId).toHaveBeenNthCalledWith(3, 'test-event-name');
+		expect(mockRegistryGetLatestSchemaId).toHaveBeenNthCalledWith(4, 'test-event-name');
+	});
+
 	test('should encode messages with SchemaRegistry', () => {
 		expect(mockRegistryEncode).toHaveBeenCalledTimes(4);
 		expect(mockRegistryEncode).toHaveBeenNthCalledWith(1, 1, { foo: 'bar' });

--- a/packages/nodes-base/nodes/Kafka/test/workflow.json
+++ b/packages/nodes-base/nodes/Kafka/test/workflow.json
@@ -1,134 +1,187 @@
 {
-	"name": "Kafka test",
-	"nodes": [
-		{
-			"parameters": {},
-			"type": "n8n-nodes-base.manualTrigger",
-			"typeVersion": 1,
-			"position": [0, -100],
-			"id": "d0594d58-ebb3-4dc0-a241-3f2531212fd7",
-			"name": "When clicking ‘Execute workflow’"
-		},
-		{
-			"parameters": {
-				"topic": "test-topic",
-				"useKey": true,
-				"key": "messageKey",
-				"headersUi": {
-					"headerValues": [
-						{
-							"key": "header",
-							"value": "value"
-						}
-					]
-				},
-				"options": {
-					"acks": true,
-					"compression": true,
-					"timeout": 1000
-				}
-			},
-			"type": "n8n-nodes-base.kafka",
-			"typeVersion": 1,
-			"position": [440, -200],
-			"id": "f29d6af7-9ded-421a-8ada-cea80eac9464",
-			"name": "Send Input Data",
-			"credentials": {
-				"kafka": {
-					"id": "JJBjHkOrIfcj91EX",
-					"name": "Kafka account"
-				}
-			}
-		},
-		{
-			"parameters": {
-				"topic": "test-topic",
-				"sendInputData": false,
-				"message": "={{ JSON.stringify({foo: 'bar'}) }}",
-				"jsonParameters": true,
-				"useSchemaRegistry": true,
-				"schemaRegistryUrl": "https://test-kafka-registry.local",
-				"eventName": "test-event-name",
-				"headerParametersJson": "{\n  \"headerKey\": \"headerValue\"\n}",
-				"options": {}
-			},
-			"type": "n8n-nodes-base.kafka",
-			"typeVersion": 1,
-			"position": [440, 0],
-			"id": "d851834f-6b97-445d-8e69-cc2e873bdf80",
-			"name": "Schema Registry",
-			"credentials": {
-				"kafka": {
-					"id": "JJBjHkOrIfcj91EX",
-					"name": "Kafka account"
-				}
-			}
-		},
-		{
-			"parameters": {
-				"jsCode": "return [\n  {\n    \"name\": \"First item\",\n    \"code\": 1\n  },\n  {\n    \"name\": \"Second item\",\n    \"code\": 2\n  }\n]"
-			},
-			"type": "n8n-nodes-base.code",
-			"typeVersion": 2,
-			"position": [220, -100],
-			"id": "50ce815c-cf9a-4d83-8739-c95f9c3d7ec6",
-			"name": "Test Data"
-		}
-	],
-	"pinData": {
-		"Send Input Data": [
-			{
-				"json": {
-					"success": true
-				}
-			}
-		],
-		"Schema Registry": [
-			{
-				"json": {
-					"success": true
-				}
-			}
-		]
-	},
-	"connections": {
-		"When clicking ‘Execute workflow’": {
-			"main": [
-				[
-					{
-						"node": "Test Data",
-						"type": "main",
-						"index": 0
-					}
-				]
-			]
-		},
-		"Test Data": {
-			"main": [
-				[
-					{
-						"node": "Schema Registry",
-						"type": "main",
-						"index": 0
-					},
-					{
-						"node": "Send Input Data",
-						"type": "main",
-						"index": 0
-					}
-				]
-			]
-		}
-	},
-	"active": false,
-	"settings": {
-		"executionOrder": "v1"
-	},
-	"versionId": "be4cbb16-225f-41ed-b897-895aaa34ea34",
-	"meta": {
-		"templateCredsSetupCompleted": true,
-		"instanceId": "27cc9b56542ad45b38725555722c50a1c3fee1670bbb67980558314ee08517c4"
-	},
-	"id": "r7XhZVcfhaGvCbgE",
-	"tags": []
+  "name": "Kafka test",
+  "nodes": [
+    {
+      "parameters": {},
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        0,
+        -100
+      ],
+      "id": "d0594d58-ebb3-4dc0-a241-3f2531212fd7",
+      "name": "When clicking ‘Execute workflow’"
+    },
+    {
+      "parameters": {
+        "topic": "test-topic",
+        "useKey": true,
+        "key": "messageKey",
+        "headersUi": {
+          "headerValues": [
+            {
+              "key": "header",
+              "value": "value"
+            }
+          ]
+        },
+        "options": {
+          "acks": true,
+          "compression": true,
+          "timeout": 1000
+        }
+      },
+      "type": "n8n-nodes-base.kafka",
+      "typeVersion": 1,
+      "position": [
+        -500,
+        40
+      ],
+      "id": "9743513a-fcd1-46f3-9bcd-445d2d1e4652",
+      "name": "Send Input Data",
+      "credentials": {
+        "kafka": {
+          "id": "JJBjHkOrIfcj91EX",
+          "name": "Kafka account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "topic": "test-topic",
+        "sendInputData": false,
+        "message": "={{ JSON.stringify({foo: 'bar'}) }}",
+        "jsonParameters": true,
+        "useSchemaRegistry": true,
+        "schemaRegistryUrl": "https://test-kafka-registry.local",
+        "eventName": "test-event-name",
+        "headerParametersJson": "{\n  \"headerKey\": \"headerValue\"\n}",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.kafka",
+      "typeVersion": 1,
+      "position": [
+        -500,
+        240
+      ],
+      "id": "f124b387-82f2-4670-bcbf-fc6f325927f1",
+      "name": "Schema Registry",
+      "credentials": {
+        "kafka": {
+          "id": "JJBjHkOrIfcj91EX",
+          "name": "Kafka account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "return [\n  {\n    \"name\": \"First item\",\n    \"code\": 1\n  },\n  {\n    \"name\": \"Second item\",\n    \"code\": 2\n  }\n]"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -720,
+        240
+      ],
+      "id": "220b83e3-c9d2-4215-bb3a-a19106e63159",
+      "name": "Test Data"
+    },
+    {
+      "parameters": {
+        "topic": "test-topic",
+        "sendInputData": false,
+        "message": "={{ JSON.stringify({foo: 'bar'}) }}",
+        "jsonParameters": true,
+        "useSchemaRegistry": true,
+        "schemaRegistryUrl": "https://test-kafka-registry.local",
+        "schemaRegistryUsername": "abc",
+        "schemaRegistryPassword": "supersecretkey",
+        "eventName": "test-event-name",
+        "headerParametersJson": "{\n  \"headerKey\": \"headerValue\"\n}",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.kafka",
+      "typeVersion": 1,
+      "position": [
+        -500,
+        440
+      ],
+      "id": "2ea52b64-3cf6-4ba1-9fbb-ddc1b0db05e7",
+      "name": "Schema Registry with auth",
+      "credentials": {
+        "kafka": {
+          "id": "JJBjHkOrIfcj91EX",
+          "name": "Kafka account"
+        }
+      }
+    }
+  ],
+  "pinData": {
+    "Send Input Data": [
+      {
+        "json": {
+          "success": true
+        }
+      }
+    ],
+    "Schema Registry": [
+      {
+        "json": {
+          "success": true
+        }
+      }
+    ],
+    "Schema Registry with auth": [
+      {
+        "json": {
+          "success": true
+        }
+      }
+    ]
+  },
+  "connections": {
+    "When clicking ‘Execute workflow’": {
+      "main": [
+        [
+          {
+            "node": "Test Data",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Test Data": {
+      "main": [
+        [
+          {
+            "node": "Schema Registry",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Send Input Data",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Schema Registry with auth",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "versionId": "be4cbb16-225f-41ed-b897-895aaa34ea34",
+  "meta": {
+    "templateCredsSetupCompleted": true,
+    "instanceId": "27cc9b56542ad45b38725555722c50a1c3fee1670bbb67980558314ee08517c4"
+  },
+  "id": "r7XhZVcfhaGvCbgE",
+  "tags": []
 }


### PR DESCRIPTION
## Summary

This MR implements basic auth on the Kafka Node and KafkaTrigger Node

Both fields are optional and shown only when "user schema registry " is activated 

Node 
<img width="880" alt="image" src="https://github.com/user-attachments/assets/9954e510-5903-4cd5-869b-43bb5dd8fcb2" />

Trigger
<img width="561" alt="image" src="https://github.com/user-attachments/assets/96f2ce60-91b8-4a84-bd3e-b843a494a2d9" />


## Related Linear tickets, Github issues, and Community forum posts

closes https://community.n8n.io/t/kafka-node-allow-to-pass-auth-options-to-registry-config/105056

Based on https://kafkajs.github.io/confluent-schema-registry/docs/usage/

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
