### PR TITLE
fix(core): Don't create additional `nodeExecuteBefore` message

### DIFF
--- a/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
@@ -191,6 +191,82 @@ describe('WorkflowExecute', () => {
 		}
 	});
 
+	describe('v1 hook order', () => {
+		const executionMode = 'manual';
+		const nodeTypes = Helpers.NodeTypes();
+
+		test("don't run hooks for siblings of the destination node", async () => {
+			// ARRANGE
+			const trigger = createNodeData({ name: 'trigger', type: 'n8n-nodes-base.manualTrigger' });
+			const node1 = createNodeData({ name: 'node1' });
+			const node2 = createNodeData({ name: 'node2' });
+			const workflowInstance = new DirectedGraph()
+				.addNodes(trigger, node1, node2)
+				.addConnections({ from: trigger, to: node1 }, { from: trigger, to: node2 })
+				.toWorkflow({ name: '', active: false, nodeTypes, settings: { executionOrder: 'v1' } });
+
+			const additionalData = Helpers.WorkflowExecuteAdditionalData(createDeferredPromise<IRun>());
+			const runHookSpy = jest.spyOn(additionalData.hooks!, 'runHook');
+
+			const workflowExecute = new WorkflowExecute(additionalData, executionMode);
+
+			// ACT
+			await workflowExecute.run(workflowInstance, trigger, 'node1');
+
+			// ASSERT
+			const workflowHooks = runHookSpy.mock.calls.filter(
+				(call) => call[0] === 'workflowExecuteBefore' || call[0] === 'workflowExecuteAfter',
+			);
+			const nodeHooks = runHookSpy.mock.calls.filter(
+				(call) => call[0] === 'nodeExecuteBefore' || call[0] === 'nodeExecuteAfter',
+			);
+
+			expect(workflowHooks.map((hook) => hook[0])).toEqual([
+				'workflowExecuteBefore',
+				'workflowExecuteAfter',
+			]);
+
+			expect(nodeHooks.map((hook) => ({ name: hook[0], node: hook[1][0] }))).toEqual([
+				{ name: 'nodeExecuteBefore', node: 'trigger' },
+				{ name: 'nodeExecuteAfter', node: 'trigger' },
+				{ name: 'nodeExecuteBefore', node: 'node1' },
+				{ name: 'nodeExecuteAfter', node: 'node1' },
+			]);
+		});
+
+		test("don't run hooks if a node does not have input data", async () => {
+			// ARRANGE
+			const trigger = createNodeData({ name: 'trigger', type: 'n8n-nodes-base.manualTrigger' });
+			const workflowInstance = new DirectedGraph()
+				.addNodes(trigger)
+				.toWorkflow({ name: '', active: false, nodeTypes, settings: { executionOrder: 'v1' } });
+
+			const additionalData = Helpers.WorkflowExecuteAdditionalData(createDeferredPromise<IRun>());
+			const runHookSpy = jest.spyOn(additionalData.hooks!, 'runHook');
+
+			const workflowExecute = new WorkflowExecute(additionalData, executionMode);
+			jest.spyOn(workflowExecute, 'ensureInputData').mockReturnValue(false);
+
+			// ACT
+			await workflowExecute.run(workflowInstance, trigger);
+
+			// ASSERT
+			const workflowHooks = runHookSpy.mock.calls.filter(
+				(call) => call[0] === 'workflowExecuteBefore' || call[0] === 'workflowExecuteAfter',
+			);
+			const nodeHooks = runHookSpy.mock.calls.filter(
+				(call) => call[0] === 'nodeExecuteBefore' || call[0] === 'nodeExecuteAfter',
+			);
+
+			expect(workflowHooks.map((hook) => hook[0])).toEqual([
+				'workflowExecuteBefore',
+				'workflowExecuteAfter',
+			]);
+
+			expect(nodeHooks).toHaveLength(0);
+		});
+	});
+
 	//run tests on json files from specified directory, default 'workflows'
 	//workflows must have pinned data that would be used to test output after execution
 	describe('run test workflows', () => {

--- a/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
@@ -191,8 +191,9 @@ describe('WorkflowExecute', () => {
 		}
 	});
 
-	describe('v1 hook order', () => {
+	describe('v0 hook order', () => {
 		const executionMode = 'manual';
+		const executionOrder = 'v0';
 		const nodeTypes = Helpers.NodeTypes();
 
 		test("don't run hooks for siblings of the destination node", async () => {
@@ -203,7 +204,7 @@ describe('WorkflowExecute', () => {
 			const workflowInstance = new DirectedGraph()
 				.addNodes(trigger, node1, node2)
 				.addConnections({ from: trigger, to: node1 }, { from: trigger, to: node2 })
-				.toWorkflow({ name: '', active: false, nodeTypes, settings: { executionOrder: 'v1' } });
+				.toWorkflow({ name: '', active: false, nodeTypes, settings: { executionOrder } });
 
 			const additionalData = Helpers.WorkflowExecuteAdditionalData(createDeferredPromise<IRun>());
 			const runHookSpy = jest.spyOn(additionalData.hooks!, 'runHook');
@@ -239,7 +240,84 @@ describe('WorkflowExecute', () => {
 			const trigger = createNodeData({ name: 'trigger', type: 'n8n-nodes-base.manualTrigger' });
 			const workflowInstance = new DirectedGraph()
 				.addNodes(trigger)
-				.toWorkflow({ name: '', active: false, nodeTypes, settings: { executionOrder: 'v1' } });
+				.toWorkflow({ name: '', active: false, nodeTypes, settings: { executionOrder } });
+
+			const additionalData = Helpers.WorkflowExecuteAdditionalData(createDeferredPromise<IRun>());
+			const runHookSpy = jest.spyOn(additionalData.hooks!, 'runHook');
+
+			const workflowExecute = new WorkflowExecute(additionalData, executionMode);
+			jest.spyOn(workflowExecute, 'ensureInputData').mockReturnValue(false);
+
+			// ACT
+			await workflowExecute.run(workflowInstance, trigger);
+
+			// ASSERT
+			const workflowHooks = runHookSpy.mock.calls.filter(
+				(call) => call[0] === 'workflowExecuteBefore' || call[0] === 'workflowExecuteAfter',
+			);
+			const nodeHooks = runHookSpy.mock.calls.filter(
+				(call) => call[0] === 'nodeExecuteBefore' || call[0] === 'nodeExecuteAfter',
+			);
+
+			expect(workflowHooks.map((hook) => hook[0])).toEqual([
+				'workflowExecuteBefore',
+				'workflowExecuteAfter',
+			]);
+
+			expect(nodeHooks).toHaveLength(0);
+		});
+	});
+
+	describe('v1 hook order', () => {
+		const executionMode = 'manual';
+		const executionOrder = 'v1';
+		const nodeTypes = Helpers.NodeTypes();
+
+		test("don't run hooks for siblings of the destination node", async () => {
+			// ARRANGE
+			const trigger = createNodeData({ name: 'trigger', type: 'n8n-nodes-base.manualTrigger' });
+			const node1 = createNodeData({ name: 'node1' });
+			const node2 = createNodeData({ name: 'node2' });
+			const workflowInstance = new DirectedGraph()
+				.addNodes(trigger, node1, node2)
+				.addConnections({ from: trigger, to: node1 }, { from: trigger, to: node2 })
+				.toWorkflow({ name: '', active: false, nodeTypes, settings: { executionOrder } });
+
+			const additionalData = Helpers.WorkflowExecuteAdditionalData(createDeferredPromise<IRun>());
+			const runHookSpy = jest.spyOn(additionalData.hooks!, 'runHook');
+
+			const workflowExecute = new WorkflowExecute(additionalData, executionMode);
+
+			// ACT
+			await workflowExecute.run(workflowInstance, trigger, 'node1');
+
+			// ASSERT
+			const workflowHooks = runHookSpy.mock.calls.filter(
+				(call) => call[0] === 'workflowExecuteBefore' || call[0] === 'workflowExecuteAfter',
+			);
+			const nodeHooks = runHookSpy.mock.calls.filter(
+				(call) => call[0] === 'nodeExecuteBefore' || call[0] === 'nodeExecuteAfter',
+			);
+
+			expect(workflowHooks.map((hook) => hook[0])).toEqual([
+				'workflowExecuteBefore',
+				'workflowExecuteAfter',
+			]);
+
+			expect(nodeHooks.map((hook) => ({ name: hook[0], node: hook[1][0] }))).toEqual([
+				{ name: 'nodeExecuteBefore', node: 'trigger' },
+				{ name: 'nodeExecuteAfter', node: 'trigger' },
+				{ name: 'nodeExecuteBefore', node: 'node1' },
+				{ name: 'nodeExecuteAfter', node: 'node1' },
+			]);
+		});
+
+		test("don't run hooks if a node does not have input data", async () => {
+			// ARRANGE
+			const trigger = createNodeData({ name: 'trigger', type: 'n8n-nodes-base.manualTrigger' });
+			const workflowInstance = new DirectedGraph()
+				.addNodes(trigger)
+				.toWorkflow({ name: '', active: false, nodeTypes, settings: { executionOrder } });
 
 			const additionalData = Helpers.WorkflowExecuteAdditionalData(createDeferredPromise<IRun>());
 			const runHookSpy = jest.spyOn(additionalData.hooks!, 'runHook');

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -1429,16 +1429,13 @@ export class WorkflowExecute {
 						node: executionNode.name,
 						workflowId: workflow.id,
 					});
-					await hooks.runHook('nodeExecuteBefore', [executionNode.name, taskStartedData]);
 
 					// Get the index of the current run
 					runIndex = 0;
 					if (this.runExecutionData.resultData.runData.hasOwnProperty(executionNode.name)) {
 						runIndex = this.runExecutionData.resultData.runData[executionNode.name].length;
 					}
-
 					currentExecutionTry = `${executionNode.name}:${runIndex}`;
-
 					if (currentExecutionTry === lastExecutionTry) {
 						throw new ApplicationError(
 							'Stopped execution because it seems to be in an endless loop',
@@ -1461,6 +1458,7 @@ export class WorkflowExecute {
 						continue executionLoop;
 					}
 
+					await hooks.runHook('nodeExecuteBefore', [executionNode.name, taskStartedData]);
 					let maxTries = 1;
 					if (executionData.node.retryOnFail === true) {
 						// TODO: Remove the hardcoded default-values here and also in NodeSettings.vue

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -1425,11 +1425,6 @@ export class WorkflowExecute {
 					}
 					executionData.data = newTaskDataConnections;
 
-					Logger.debug(`Start processing node "${executionNode.name}"`, {
-						node: executionNode.name,
-						workflowId: workflow.id,
-					});
-
 					// Get the index of the current run
 					runIndex = 0;
 					if (this.runExecutionData.resultData.runData.hasOwnProperty(executionNode.name)) {
@@ -1458,6 +1453,10 @@ export class WorkflowExecute {
 						continue executionLoop;
 					}
 
+					Logger.debug(`Start executing node "${executionNode.name}"`, {
+						node: executionNode.name,
+						workflowId: workflow.id,
+					});
 					await hooks.runHook('nodeExecuteBefore', [executionNode.name, taskStartedData]);
 					let maxTries = 1;
 					if (executionData.node.retryOnFail === true) {

--- a/packages/core/test/helpers/index.ts
+++ b/packages/core/test/helpers/index.ts
@@ -54,7 +54,15 @@ export function WorkflowExecuteAdditionalData(
 ): IWorkflowExecuteAdditionalData {
 	const hooks = new ExecutionLifecycleHooks('trigger', '1', mock());
 	hooks.addHandler('workflowExecuteAfter', (fullRunData) => waitPromise.resolve(fullRunData));
-	return mock<IWorkflowExecuteAdditionalData>({ hooks, currentNodeExecutionIndex: 0 });
+	return mock<IWorkflowExecuteAdditionalData>({
+		hooks,
+		currentNodeExecutionIndex: 0,
+		// Not setting this to undefined would set it to a mock which would trigger
+		// conditions in the WorkflowExecute which only check if a property exists,
+		// e.g. `if (!this.additionalData.restartExecutionId)`. This would for
+		// example skip running the `workflowExecuteBefore` hook in the tests.
+		restartExecutionId: undefined,
+	});
 }
 
 const preparePinData = (pinData: IDataObject) => {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

We were running the `nodeExecuteBefore` hook before checking some conditions that would skip running the node.
This PR only runs the `nodeExecuteBefore` hook if the node has input data and the destination node hasn't been reached already.

*before:*

https://github.com/user-attachments/assets/9dc0573d-f3c9-4e39-86b5-fa7df8ca36d6

*after:*

https://github.com/user-attachments/assets/055347dd-52de-4e67-917d-4c7ec1b258ed

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2762/bug-partial-execution-generates-suspicious-nodeexecutebefore-event


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] ~Tests included.~ <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
