### PR TITLE
ci: Increase timeout for MariaDB and MySQL tests

### DIFF
--- a/.github/workflows/ci-postgres-mysql.yml
+++ b/.github/workflows/ci-postgres-mysql.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Test MariaDB
         working-directory: packages/cli
-        run: pnpm test:mariadb --testTimeout 30000
+        run: pnpm test:mariadb --testTimeout 60000
 
   mysql:
     name: MySQL (${{ matrix.service-name }})
@@ -166,7 +166,7 @@ jobs:
 
       - name: Test MySQL
         working-directory: packages/cli
-        run: pnpm test:mysql --testTimeout 30000
+        run: pnpm test:mysql --testTimeout 60000
 
   postgres:
     name: Postgres


### PR DESCRIPTION
## Summary

Increase timeout for MariaDB and MySQL tests until we have time to look into a more [permanent solution](https://linear.app/n8n/issue/CAT-765/solve-performance-degradation-in-mariadb-and-mysql-tests).

## Related Linear tickets, Github issues, and Community forum posts

n/a
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
