### PR TITLE
fix(Wordpress Node): Remove duplicate comment status field in PageDescription.ts (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Wordpress/PageDescription.ts
+++ b/packages/nodes-base/nodes/Wordpress/PageDescription.ts
@@ -249,23 +249,6 @@ export const pageFields: INodeProperties[] = [
 				description: 'The order of the page in relation to other pages',
 			},
 			{
-				displayName: 'Comment Status',
-				name: 'commentStatus',
-				type: 'options',
-				options: [
-					{
-						name: 'Open',
-						value: 'open',
-					},
-					{
-						name: 'Closed',
-						value: 'closed',
-					},
-				],
-				default: 'open',
-				description: 'Whether or not comments are open on the page',
-			},
-			{
 				displayName: 'Featured Media ID',
 				name: 'featuredMediaId',
 				type: 'number',


### PR DESCRIPTION
## Summary
Removed the duplicate comment status field from Create Page area.
<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
N/A
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
