### PR TITLE
fix(core): Add mechanism to prevent concurrent compaction on Insights

### DIFF
--- a/packages/cli/src/modules/insights/__tests__/insights-compaction.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights-compaction.service.test.ts
@@ -320,21 +320,21 @@ if (dbType === 'sqlite' && !globalConfig.database.sqlite.poolSize) {
 
 		describe('compactionSchedule', () => {
 			test('compaction is running on schedule', async () => {
+				// ARRANGE
 				jest.useFakeTimers();
-				try {
-					// ARRANGE
-					const insightsCompactionService = new InsightsCompactionService(
-						mock<InsightsByPeriodRepository>(),
-						mock<InsightsRawRepository>(),
-						mock<InsightsConfig>({
-							compactionIntervalMinutes: 60,
-						}),
-						mockLogger(),
-					);
-					insightsCompactionService.startCompactionTimer();
+				const insightsCompactionService = new InsightsCompactionService(
+					mock<InsightsByPeriodRepository>(),
+					mock<InsightsRawRepository>(),
+					mock<InsightsConfig>({
+						compactionIntervalMinutes: 60,
+					}),
+					mockLogger(),
+				);
+				// spy on the compactInsights method to check if it's called
+				const compactInsightsSpy = jest.spyOn(insightsCompactionService, 'compactInsights');
 
-					// spy on the compactInsights method to check if it's called
-					const compactInsightsSpy = jest.spyOn(insightsCompactionService, 'compactInsights');
+				try {
+					insightsCompactionService.startCompactionTimer();
 
 					// ACT
 					// advance by 1 hour and 1 minute
@@ -343,6 +343,7 @@ if (dbType === 'sqlite' && !globalConfig.database.sqlite.poolSize) {
 					// ASSERT
 					expect(compactInsightsSpy).toHaveBeenCalledTimes(1);
 				} finally {
+					insightsCompactionService.stopCompactionTimer();
 					jest.useRealTimers();
 				}
 			});

--- a/packages/cli/src/modules/insights/__tests__/insights-compaction.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights-compaction.service.test.ts
@@ -1,5 +1,6 @@
 import { GlobalConfig } from '@n8n/config';
 import { Container } from '@n8n/di';
+import { mock } from 'jest-mock-extended';
 import { DateTime } from 'luxon';
 
 import { InsightsRawRepository } from '@/modules/insights/database/repositories/insights-raw.repository';
@@ -45,6 +46,7 @@ if (dbType === 'sqlite' && !globalConfig.database.sqlite.poolSize) {
 	afterAll(async () => {
 		await testDb.terminate();
 	});
+
 	describe('compaction', () => {
 		describe('compactRawToHour', () => {
 			type TestData = {
@@ -320,7 +322,13 @@ if (dbType === 'sqlite' && !globalConfig.database.sqlite.poolSize) {
 				jest.useFakeTimers();
 				try {
 					// ARRANGE
-					const insightsCompactionService = Container.get(InsightsCompactionService);
+					const insightsCompactionService = new InsightsCompactionService(
+						mock<InsightsByPeriodRepository>(),
+						mock<InsightsRawRepository>(),
+						mock<InsightsConfig>({
+							compactionIntervalMinutes: 60,
+						}),
+					);
 					insightsCompactionService.startCompactionTimer();
 
 					// spy on the compactInsights method to check if it's called
@@ -592,6 +600,55 @@ if (dbType === 'sqlite' && !globalConfig.database.sqlite.poolSize) {
 				expect(weeklyInsights[0].periodStart.toISOString()).toEqual(
 					beyondThresholdTimestamp.startOf('week').toISO(),
 				);
+			});
+		});
+
+		describe('Avoid deadlock error', () => {
+			let defaultBatchSize: number;
+			beforeAll(() => {
+				// Store the original config value
+				const insightsConfig = Container.get(InsightsConfig);
+				defaultBatchSize = insightsConfig.compactionBatchSize;
+
+				// Set a smaller batch size to trigger the deadlock error
+				insightsConfig.compactionBatchSize = 3;
+			});
+
+			afterAll(() => {
+				// Reset the config to its original state
+				const insightsConfig = Container.get(InsightsConfig);
+				insightsConfig.compactionBatchSize = defaultBatchSize;
+			});
+
+			test('should not throw deadlock error on concurrent compaction', async () => {
+				// ARRANGE
+				const insightsCompactionService = Container.get(InsightsCompactionService);
+				const insightsByPeriodRepository = Container.get(InsightsByPeriodRepository);
+				const transactionSpy = jest.spyOn(insightsByPeriodRepository.manager, 'transaction');
+				const project = await createTeamProject();
+				const workflow = await createWorkflow({}, project);
+				await createMetadata(workflow);
+
+				// Create test data
+				const promises = [];
+				for (let i = 0; i < 100; i++) {
+					await createCompactedInsightsEvent(workflow, {
+						type: 'success',
+						value: 1,
+						periodUnit: 'hour',
+						periodStart: DateTime.now().minus({ day: 91, hour: i + 1 }),
+					});
+				}
+
+				// ACT
+				for (let i = 0; i < 10; i++) {
+					promises.push(insightsCompactionService.compactHourToDay());
+				}
+
+				// ASSERT
+				// await all promises concurrently
+				await expect(Promise.all(promises)).resolves.toBeDefined();
+				expect(transactionSpy).toHaveBeenCalledTimes(1);
 			});
 		});
 	});


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

We noticed transaction deadlock errors on MySQL when running compaction tests:
https://github.com/n8n-io/n8n/actions/runs/14703272604/job/41257984393#step:9:4475

This is due to multiple compaction process running at the same time, and requesting locks to same table for updating and deleting rows.
This PR ensures only one compaction process is running at the same time

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
