### PR TITLE
fix(core): Add support for proxy using forward headers

### DIFF
--- a/packages/cli/src/push/__tests__/index.test.ts
+++ b/packages/cli/src/push/__tests__/index.test.ts
@@ -1,5 +1,6 @@
 import type { Application } from 'express';
 import { captor, mock } from 'jest-mock-extended';
+import type { Logger } from 'n8n-core';
 import type { Server, ServerResponse } from 'node:http';
 import type { Socket } from 'node:net';
 import { type WebSocket, Server as WSServer } from 'ws';
@@ -13,7 +14,6 @@ import { WebSocketPush } from '@/push/websocket.push';
 import { mockInstance } from '@test/mocking';
 
 import type { PushConfig } from '../push.config';
-import { Logger } from 'n8n-core';
 
 jest.mock('ws', () => ({
 	Server: jest.fn(),

--- a/packages/cli/src/push/__tests__/index.test.ts
+++ b/packages/cli/src/push/__tests__/index.test.ts
@@ -214,8 +214,26 @@ describe('Push', () => {
 						xForwardedHost: 'example.com',
 					},
 					{
-						name: 'origin matches host',
+						name: 'origin matches forward headers but has different case',
 						origin: 'https://example.com',
+						xForwardedProto: 'https',
+						xForwardedHost: 'EXAMPLE.com',
+					},
+					{
+						name: 'origin matches forward headers but protocol has different case',
+						origin: 'HTTPS://example.com',
+						xForwardedProto: undefined,
+						xForwardedHost: undefined,
+					},
+					{
+						name: 'origin matches host (https)',
+						origin: 'https://example.com',
+						xForwardedProto: undefined,
+						xForwardedHost: undefined,
+					},
+					{
+						name: 'origin matches host (http)',
+						origin: 'http://example.com',
 						xForwardedProto: undefined,
 						xForwardedHost: undefined,
 					},

--- a/packages/cli/src/push/__tests__/index.test.ts
+++ b/packages/cli/src/push/__tests__/index.test.ts
@@ -13,6 +13,7 @@ import { WebSocketPush } from '@/push/websocket.push';
 import { mockInstance } from '@test/mocking';
 
 import type { PushConfig } from '../push.config';
+import { Logger } from 'n8n-core';
 
 jest.mock('ws', () => ({
 	Server: jest.fn(),
@@ -27,12 +28,16 @@ describe('Push', () => {
 	const host = 'example.com';
 	const user = mock<User>({ id: 'user-id' });
 	const config = mock<PushConfig>();
+	const logger = mock<Logger>();
 
 	let push: Push;
 	const sseBackend = mockInstance(SSEPush);
 	const wsBackend = mockInstance(WebSocketPush);
 
-	beforeEach(() => jest.resetAllMocks());
+	beforeEach(() => {
+		jest.resetAllMocks();
+		logger.scoped.mockReturnValue(logger);
+	});
 
 	describe('setupPushServer', () => {
 		const restEndpoint = 'rest';
@@ -44,7 +49,7 @@ describe('Push', () => {
 		describe('sse backend', () => {
 			test('should not create a WebSocket server', () => {
 				config.backend = 'sse';
-				push = new Push(config, mock(), mock(), mock(), mock());
+				push = new Push(config, mock(), logger, mock(), mock());
 
 				push.setupPushServer(restEndpoint, server, app);
 
@@ -61,7 +66,7 @@ describe('Push', () => {
 
 			beforeEach(() => {
 				config.backend = 'websocket';
-				push = new Push(config, mock(), mock(), mock(), mock());
+				push = new Push(config, mock(), logger, mock(), mock());
 				wssSpy.mockReturnValue(wsServer);
 
 				push.setupPushServer(restEndpoint, server, app);
@@ -130,15 +135,61 @@ describe('Push', () => {
 
 			beforeEach(() => {
 				config.backend = backendName;
-				push = new Push(config, mock(), mock(), mock(), mock());
+				push = new Push(config, mock(), logger, mock(), mock());
 				req.ws = backendName === 'sse' ? undefined : ws;
 			});
 
 			describe('should throw on invalid origin', () => {
-				test.each(['https://subdomain.example.com', 'https://123example.com', undefined])(
-					'%s',
-					(origin) => {
+				test.each([
+					{
+						name: 'origin does not match host',
+						origin: 'https://subdomain.example.com',
+						xForwardedProto: undefined,
+						xForwardedHost: undefined,
+					},
+					{
+						name: 'origin does not match host (subdomain)',
+						origin: 'https://123example.com',
+						xForwardedProto: undefined,
+						xForwardedHost: undefined,
+					},
+					{
+						name: 'origin is not defined',
+						origin: undefined,
+						xForwardedProto: undefined,
+						xForwardedHost: undefined,
+					},
+					{
+						name: 'only one of the forward headers is defined',
+						origin: 'https://123example.com',
+						xForwardedProto: 'https',
+						xForwardedHost: undefined,
+					},
+					{
+						name: 'only one of the forward headers is defined',
+						origin: 'https://123example.com',
+						xForwardedProto: undefined,
+						xForwardedHost: '123example.com',
+					},
+					{
+						name: 'protocol mismatch',
+						// correct origin, but forward headers take precedence
+						origin: 'https://example.com',
+						xForwardedProto: 'http',
+						xForwardedHost: host,
+					},
+					{
+						name: 'origin is undefined',
+						origin: undefined,
+						xForwardedProto: undefined,
+						xForwardedHost: undefined,
+					},
+				])(
+					'$name (origin: $origin, x-forwarded-proto: $xForwardedProto, x-forwarded-host: $xForwardedHost)',
+					({ origin, xForwardedProto, xForwardedHost }) => {
 						req.headers.origin = origin;
+						req.headers['x-forwarded-proto'] = xForwardedProto;
+						req.headers['x-forwarded-host'] = xForwardedHost;
 
 						if (backendName === 'sse') {
 							expect(() => push.handleRequest(req, res)).toThrow(
@@ -150,6 +201,41 @@ describe('Push', () => {
 							expect(ws.close).toHaveBeenCalledWith(1008);
 						}
 						expect(backend.add).not.toHaveBeenCalled();
+					},
+				);
+			});
+
+			describe('should not throw on invalid origin if `X-Forwarded-Host` and `X-Forwarded-Proto` are set correctly', () => {
+				test.each([
+					{
+						name: 'origin matches forward headers',
+						origin: 'https://example.com',
+						xForwardedProto: 'https',
+						xForwardedHost: 'example.com',
+					},
+					{
+						name: 'origin matches host',
+						origin: 'https://example.com',
+						xForwardedProto: undefined,
+						xForwardedHost: undefined,
+					},
+				])(
+					'$name (origin: $origin, x-forwarded-proto: $xForwardedProto, x-forwarded-host: $xForwardedHost)',
+					({ origin, xForwardedProto, xForwardedHost }) => {
+						// ARRANGE
+						req.headers.origin = origin;
+						req.headers['x-forwarded-proto'] = xForwardedProto;
+						req.headers['x-forwarded-host'] = xForwardedHost;
+
+						const emitSpy = jest.spyOn(push, 'emit');
+						const connection = backendName === 'sse' ? { req, res } : ws;
+
+						// ACT
+						push.handleRequest(req, res);
+
+						// ASSERT
+						expect(backend.add).toHaveBeenCalledWith(pushRef, user.id, connection);
+						expect(emitSpy).toHaveBeenCalledWith('editorUiConnected', pushRef);
 					},
 				);
 			});

--- a/packages/cli/src/push/index.ts
+++ b/packages/cli/src/push/index.ts
@@ -142,8 +142,8 @@ export class Push extends TypedEmitter<PushEvents> {
 
 		if (!pushRef) {
 			connectionError = 'The query parameter "pushRef" is missing!';
-		} else if (expectedOriginResult.success === false) {
-			this.logger.warn(`Origin header is missing`);
+		} else if (!expectedOriginResult.success) {
+			this.logger.warn('Origin header is missing');
 
 			connectionError = 'Invalid origin!';
 		} else if (inProduction && headers.origin !== expectedOriginResult.expectedOrigin) {

--- a/packages/cli/src/push/index.ts
+++ b/packages/cli/src/push/index.ts
@@ -118,7 +118,7 @@ export class Push extends TypedEmitter<PushEvents> {
 			const host = allForwardHeadersAreDefined ? forwardedHost : headers.host;
 			const proto = allForwardHeadersAreDefined
 				? forwardedProto
-				: headers.origin?.startsWith('https://')
+				: headers.origin?.toLowerCase().startsWith('https://')
 					? 'https'
 					: 'http';
 
@@ -146,7 +146,10 @@ export class Push extends TypedEmitter<PushEvents> {
 			this.logger.warn('Origin header is missing');
 
 			connectionError = 'Invalid origin!';
-		} else if (inProduction && headers.origin !== expectedOriginResult.expectedOrigin) {
+		} else if (
+			inProduction &&
+			headers.origin?.toLowerCase() !== expectedOriginResult.expectedOrigin.toLowerCase()
+		) {
 			this.logger.warn(
 				`Origin header does NOT match the expected origin. (Origin: "${headers.origin}", Expected: "${expectedOriginResult.expectedOrigin}")`,
 				{

--- a/packages/cli/src/push/index.ts
+++ b/packages/cli/src/push/index.ts
@@ -136,8 +136,6 @@ export class Push extends TypedEmitter<PushEvents> {
 			headers,
 		} = req;
 
-		const inProduction = true;
-
 		let connectionError = '';
 
 		const expectedOriginResult = this.constructExpectedOrigin(req);

--- a/packages/cli/src/push/index.ts
+++ b/packages/cli/src/push/index.ts
@@ -123,11 +123,11 @@ export class Push extends TypedEmitter<PushEvents> {
         if (headers.origin === expectedOrigin) {
             this.logger.debug('Origin header matches the expected origin.');
         } else {
-            this.logger.debug(
+            this.logger.error(
                 `Origin header does NOT match the expected origin. (Origin: "${headers.origin}", Expected: "${expectedOrigin}")`,
             );
         }
-		
+
 		if (!pushRef) {
 			connectionError = 'The query parameter "pushRef" is missing!';
 		} else if (


### PR DESCRIPTION
## Summary
This pull request introduces support for proxies in the `Push` class by utilizing `X-Forwarded` headers to determine the expected origin, along with enhanced logging to debug origin-related issues.

### Support for proxies:
* Added logic to prefer `X-Forwarded-Host` and `X-Forwarded-Proto` headers over the standard `Host` and `Origin` headers to compute the `expectedOrigin`. This ensures compatibility when the application is behind a proxy.

### Enhanced logging:
* Introduced detailed debug logs to capture the values of `Host`, `Origin`, `X-Forwarded-Host`, `X-Forwarded-Proto`, and the computed `expectedOrigin`. This helps in identifying mismatches between the `Origin` header and the `expectedOrigin`. 

## Related Linear tickets, Github issues, and Community forum posts

fixes: #14619, #14653

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
