### PR TITLE
feat: Optimize langchain calls in a batching mode

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/description.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/description.ts
@@ -47,6 +47,29 @@ export const toolsAgentProperties: INodeProperties[] = [
 				description:
 					'Whether or not binary images should be automatically passed through to the agent as image type messages',
 			},
+			{
+				displayName: 'Batch Processing',
+				name: 'batching',
+				type: 'collection',
+				description: 'Batch processing options for rate limiting',
+				default: {},
+				options: [
+					{
+						displayName: 'Batch Size',
+						name: 'batchSize',
+						default: 1,
+						type: 'number',
+						description: 'How many items to process in parallel. This is useful for rate limiting.',
+					},
+					{
+						displayName: 'Delay Between Batches',
+						name: 'delayBetweenBatches',
+						default: 1000,
+						type: 'number',
+						description: 'Delay in milliseconds between batches. This is useful for rate limiting.',
+					},
+				],
+			},
 		],
 	},
 ];

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/description.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/description.ts
@@ -59,7 +59,8 @@ export const toolsAgentProperties: INodeProperties[] = [
 						name: 'batchSize',
 						default: 1,
 						type: 'number',
-						description: 'How many items to process in parallel. This is useful for rate limiting.',
+						description:
+							'How many items to process in parallel. This is useful for rate limiting, but will impact the ordering in the agents log output.',
 					},
 					{
 						displayName: 'Delay Between Batches',

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/description.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/description.ts
@@ -65,7 +65,7 @@ export const toolsAgentProperties: INodeProperties[] = [
 					{
 						displayName: 'Delay Between Batches',
 						name: 'delayBetweenBatches',
-						default: 1000,
+						default: 0,
 						type: 'number',
 						description: 'Delay in milliseconds between batches. This is useful for rate limiting.',
 					},

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/execute.ts
@@ -410,7 +410,10 @@ export async function toolsAgentExecute(this: IExecuteFunctions): Promise<INodeE
 	const outputParser = await getOptionalOutputParser(this);
 	const memory = await getOptionalMemory(this);
 	const tools = await getTools(this, outputParser);
-	const { batchSize, delayBetweenBatches } = this.getNodeParameter('options.batching', 0, {}) as {
+	const { batchSize, delayBetweenBatches } = this.getNodeParameter('options.batching', 0, {
+		batchSize: 1,
+		delayBetweenBatches: 0,
+	}) as {
 		batchSize: number;
 		delayBetweenBatches: number;
 	};

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/execute.ts
@@ -496,6 +496,17 @@ export async function toolsAgentExecute(this: IExecuteFunctions): Promise<INodeE
 		}
 	}
 	(await Promise.allSettled(promises)).forEach((result, index) => {
+		if (result.status === 'rejected') {
+			if (this.continueOnFail()) {
+				returnData.push({
+					json: { error: result.reason as string },
+					pairedItem: { item: index },
+				});
+				return;
+			} else {
+				throw new NodeOperationError(this.getNode(), result.reason);
+			}
+		}
 		const response = result.value;
 		// If memory and outputParser are connected, parse the output.
 		if (memory && outputParser) {

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
@@ -67,13 +67,13 @@ export class ChainLlm implements INodeType {
 		this.logger.debug('Executing Basic LLM Chain');
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
-		const batchSize = this.getNodeParameter('batching.batchSize', 0, 1) as number;
-		const delayBetweenBatches = this.getNodeParameter(
-			'batching.delayBetweenBatches',
-			0,
-			1000,
-		) as number;
-
+		const { batchSize, delayBetweenBatches } = this.getNodeParameter('batching', 0, {
+			batchSize: 100,
+			delayBetweenBatches: 0,
+		}) as {
+			batchSize: number;
+			delayBetweenBatches: number;
+		};
 		// Get output parser if configured
 		const outputParser = await getOptionalOutputParser(this);
 

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/config.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/config.ts
@@ -281,7 +281,7 @@ export const nodeProperties: INodeProperties[] = [
 			{
 				displayName: 'Batch Size',
 				name: 'batchSize',
-				default: 1,
+				default: 100,
 				type: 'number',
 				description:
 					'How many items to process in parallel. This is useful for rate limiting, but will impact the agents log output.',

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/config.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/config.ts
@@ -270,4 +270,29 @@ export const nodeProperties: INodeProperties[] = [
 			},
 		},
 	},
+	{
+		displayName: 'Batch Processing',
+		name: 'batching',
+		type: 'collection',
+		placeholder: 'Add Batch Processing Option',
+		description: 'Batch processing options for rate limiting',
+		default: {},
+		options: [
+			{
+				displayName: 'Batch Size',
+				name: 'batchSize',
+				default: 1,
+				type: 'number',
+				description:
+					'How many items to process in parallel. This is useful for rate limiting, but will impact the agents log output.',
+			},
+			{
+				displayName: 'Delay Between Batches',
+				name: 'delayBetweenBatches',
+				default: 1000,
+				type: 'number',
+				description: 'Delay in milliseconds between batches. This is useful for rate limiting.',
+			},
+		],
+	},
 ];

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/ChainRetrievalQa.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/ChainRetrievalQa.node.ts
@@ -195,7 +195,7 @@ export class ChainRetrievalQa implements INodeType {
 							{
 								displayName: 'Delay Between Batches',
 								name: 'delayBetweenBatches',
-								default: 1000,
+								default: 0,
 								type: 'number',
 								description:
 									'Delay in milliseconds between batches. This is useful for rate limiting.',
@@ -211,7 +211,10 @@ export class ChainRetrievalQa implements INodeType {
 		this.logger.debug('Executing Retrieval QA Chain');
 
 		const items = this.getInputData();
-		const { batchSize, delayBetweenBatches } = this.getNodeParameter('options.batching', 0, {}) as {
+		const { batchSize, delayBetweenBatches } = this.getNodeParameter('options.batching', 0, {
+			batchSize: 100,
+			delayBetweenBatches: 0,
+		}) as {
 			batchSize: number;
 			delayBetweenBatches: number;
 		};

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/ChainRetrievalQa.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/ChainRetrievalQa.node.ts
@@ -187,7 +187,7 @@ export class ChainRetrievalQa implements INodeType {
 							{
 								displayName: 'Batch Size',
 								name: 'batchSize',
-								default: 20,
+								default: 100,
 								type: 'number',
 								description:
 									'How many items to process in parallel. This is useful for rate limiting.',

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/ChainRetrievalQa.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/ChainRetrievalQa.node.ts
@@ -324,16 +324,17 @@ export class ChainRetrievalQa implements INodeType {
 		}
 		(await Promise.allSettled(promises)).forEach((response, index) => {
 			if (response.status === 'rejected') {
+				const error = response.reason;
 				if (this.continueOnFail()) {
-					const metadata = parseErrorMetadata(response.reason);
+					const metadata = parseErrorMetadata(error);
 					returnData.push({
-						json: { error: response.reason.message },
+						json: { error: error.message },
 						pairedItem: { item: index },
 						metadata,
 					});
 					return;
 				} else {
-					throw new NodeOperationError(this.getNode(), response.reason);
+					throw error;
 				}
 			}
 			const output = response.value;

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/test/ChainRetrievalQa.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/test/ChainRetrievalQa.node.test.ts
@@ -8,6 +8,11 @@ import { NodeConnectionTypes, NodeOperationError, UnexpectedError } from 'n8n-wo
 
 import { ChainRetrievalQa } from '../ChainRetrievalQa.node';
 
+jest.mock('n8n-workflow', () => ({
+	...jest.requireActual('n8n-workflow'),
+	sleep: jest.fn(),
+}));
+
 const createExecuteFunctionsMock = (
 	parameters: IDataObject,
 	fakeLlm: BaseLanguageModel,

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/test/ChainRetrievalQa.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/test/ChainRetrievalQa.node.test.ts
@@ -80,7 +80,12 @@ describe('ChainRetrievalQa', () => {
 			const params = {
 				promptType: 'define',
 				text: 'What is the capital of France?',
-				options: {},
+				options: {
+					batching: {
+						batchSize: 1,
+						delayBetweenBatches: 100,
+					},
+				},
 			};
 
 			const result = await node.execute.call(
@@ -114,7 +119,12 @@ describe('ChainRetrievalQa', () => {
 			const params = {
 				promptType: 'define',
 				text: 'What is the capital of France?',
-				options: {},
+				options: {
+					batching: {
+						batchSize: 1,
+						delayBetweenBatches: 100,
+					},
+				},
 			};
 
 			const result = await node.execute.call(
@@ -158,6 +168,10 @@ describe('ChainRetrievalQa', () => {
 				text: 'What is the capital of France?',
 				options: {
 					systemPromptTemplate: customSystemPrompt,
+					batching: {
+						batchSize: 1,
+						delayBetweenBatches: 100,
+					},
 				},
 			};
 
@@ -185,7 +199,12 @@ describe('ChainRetrievalQa', () => {
 			const params = {
 				promptType: 'define',
 				text: undefined, // undefined query
-				options: {},
+				options: {
+					batching: {
+						batchSize: 1,
+						delayBetweenBatches: 100,
+					},
+				},
 			};
 
 			await expect(
@@ -211,7 +230,12 @@ describe('ChainRetrievalQa', () => {
 			const params = {
 				promptType: 'define',
 				text: 'What is the capital of France?',
-				options: {},
+				options: {
+					batching: {
+						batchSize: 1,
+						delayBetweenBatches: 100,
+					},
+				},
 			};
 
 			// Override continueOnFail to return true

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainSummarization/V2/ChainSummarizationV2.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainSummarization/V2/ChainSummarizationV2.node.ts
@@ -316,7 +316,7 @@ export class ChainSummarizationV2 implements INodeType {
 								{
 									displayName: 'Batch Size',
 									name: 'batchSize',
-									default: 20,
+									default: 100,
 									type: 'number',
 									description:
 										'How many items to process in parallel. This is useful for rate limiting.',

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainSummarization/V2/ChainSummarizationV2.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainSummarization/V2/ChainSummarizationV2.node.ts
@@ -1,5 +1,6 @@
 import type { Document } from '@langchain/core/documents';
 import type { BaseLanguageModel } from '@langchain/core/language_models/base';
+import type { ChainValues } from '@langchain/core/utils/types';
 import type { TextSplitter } from '@langchain/textsplitters';
 import { RecursiveCharacterTextSplitter } from '@langchain/textsplitters';
 import { loadSummarizationChain } from 'langchain/chains';
@@ -21,7 +22,6 @@ import { getTracingConfig } from '@utils/tracing';
 
 import { getChainPromptsArgs } from '../helpers';
 import { REFINE_PROMPT_TEMPLATE, DEFAULT_PROMPT_TEMPLATE } from '../prompt';
-import { ChainValues } from '@langchain/core/utils/types';
 
 function getInputs(parameters: IDataObject) {
 	const chunkingMode = parameters?.chunkingMode;
@@ -325,7 +325,7 @@ export class ChainSummarizationV2 implements INodeType {
 								{
 									displayName: 'Delay Between Batches',
 									name: 'delayBetweenBatches',
-									default: 1000,
+									default: 0,
 									type: 'number',
 									description:
 										'Delay in milliseconds between batches. This is useful for rate limiting.',
@@ -350,7 +350,10 @@ export class ChainSummarizationV2 implements INodeType {
 
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
-		const { batchSize, delayBetweenBatches } = this.getNodeParameter('options.batching', 0, {}) as {
+		const { batchSize, delayBetweenBatches } = this.getNodeParameter('options.batching', 0, {
+			batchSize: 100,
+			delayBetweenBatches: 0,
+		}) as {
 			batchSize: number;
 			delayBetweenBatches: number;
 		};

--- a/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/InformationExtractor.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/InformationExtractor.node.ts
@@ -331,14 +331,15 @@ export class InformationExtractor implements INodeType {
 
 			batchResults.forEach((response, index) => {
 				if (response.status === 'rejected') {
+					const error = response.reason as Error;
 					if (this.continueOnFail()) {
 						resultData.push({
 							json: { error: response.reason as string },
-							pairedItem: { item: index },
+							pairedItem: { item: i + index },
 						});
 						return;
 					} else {
-						throw new NodeOperationError(this.getNode(), response.reason);
+						throw new NodeOperationError(this.getNode(), error.message);
 					}
 				}
 				const output = response.value;

--- a/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/InformationExtractor.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/InformationExtractor.node.ts
@@ -330,6 +330,7 @@ export class InformationExtractor implements INodeType {
 						json: { error: response.reason as string },
 						pairedItem: { item: index },
 					});
+					return;
 				} else {
 					throw new NodeOperationError(this.getNode(), response.reason);
 				}

--- a/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/InformationExtractor.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/InformationExtractor.node.ts
@@ -223,7 +223,7 @@ export class InformationExtractor implements INodeType {
 							{
 								displayName: 'Batch Size',
 								name: 'batchSize',
-								default: 1,
+								default: 100,
 								type: 'number',
 								description:
 									'How many items to process in parallel. This is useful for rate limiting, but will impact the agents log output.',

--- a/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/InformationExtractor.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/InformationExtractor.node.ts
@@ -231,7 +231,7 @@ export class InformationExtractor implements INodeType {
 							{
 								displayName: 'Delay Between Batches',
 								name: 'delayBetweenBatches',
-								default: 1000,
+								default: 0,
 								type: 'number',
 								description:
 									'Delay in milliseconds between batches. This is useful for rate limiting.',
@@ -245,7 +245,10 @@ export class InformationExtractor implements INodeType {
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
-		const { batchSize, delayBetweenBatches } = this.getNodeParameter('options.batching', 0, {}) as {
+		const { batchSize, delayBetweenBatches } = this.getNodeParameter('options.batching', 0, {
+			batchSize: 100,
+			delayBetweenBatches: 0,
+		}) as {
 			batchSize: number;
 			delayBetweenBatches: number;
 		};

--- a/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/test/InformationExtraction.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/test/InformationExtraction.node.test.ts
@@ -91,7 +91,12 @@ describe('InformationExtractor', () => {
 						attributes: {
 							attributes: mockPersonAttributes,
 						},
-						options: {},
+						options: {
+							batching: {
+								batchSize: 1,
+								delayBetweenBatches: 100,
+							},
+						},
 						schemaType: 'fromAttributes',
 					},
 					new FakeLLM({ response: formatFakeLlmResponse({ name: 'John', age: 30 }) }),
@@ -111,7 +116,12 @@ describe('InformationExtractor', () => {
 						attributes: {
 							attributes: mockPersonAttributes,
 						},
-						options: {},
+						options: {
+							batching: {
+								batchSize: 1,
+								delayBetweenBatches: 100,
+							},
+						},
 						schemaType: 'fromAttributes',
 					},
 					new FakeLLM({ response: formatFakeLlmResponse({ name: 'John' }) }),
@@ -132,7 +142,12 @@ describe('InformationExtractor', () => {
 							attributes: {
 								attributes: mockPersonAttributesRequired,
 							},
-							options: {},
+							options: {
+								batching: {
+									batchSize: 1,
+									delayBetweenBatches: 100,
+								},
+							},
 							schemaType: 'fromAttributes',
 						},
 						new FakeLLM({ response: formatFakeLlmResponse({ name: 'John' }) }),
@@ -154,7 +169,12 @@ describe('InformationExtractor', () => {
 							attributes: {
 								attributes: mockPersonAttributes,
 							},
-							options: {},
+							options: {
+								batching: {
+									batchSize: 1,
+									delayBetweenBatches: 100,
+								},
+							},
 							schemaType: 'fromAttributes',
 						},
 						new FakeLLM({ response: formatFakeLlmResponse({ name: 'John', age: '30' }) }),
@@ -175,7 +195,12 @@ describe('InformationExtractor', () => {
 						attributes: {
 							attributes: mockPersonAttributesRequired,
 						},
-						options: {},
+						options: {
+							batching: {
+								batchSize: 1,
+								delayBetweenBatches: 100,
+							},
+						},
 						schemaType: 'fromAttributes',
 					},
 					new FakeListChatModel({
@@ -200,7 +225,12 @@ describe('InformationExtractor', () => {
 						attributes: {
 							attributes: mockPersonAttributesRequired,
 						},
-						options: {},
+						options: {
+							batching: {
+								batchSize: 1,
+								delayBetweenBatches: 100,
+							},
+						},
 						schemaType: 'fromAttributes',
 					},
 					new FakeListChatModel({

--- a/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/test/InformationExtraction.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/test/InformationExtraction.node.test.ts
@@ -7,6 +7,11 @@ import { makeZodSchemaFromAttributes } from '../helpers';
 import { InformationExtractor } from '../InformationExtractor.node';
 import type { AttributeDefinition } from '../types';
 
+jest.mock('n8n-workflow', () => ({
+	...jest.requireActual('n8n-workflow'),
+	sleep: jest.fn(),
+}));
+
 const mockPersonAttributes: AttributeDefinition[] = [
 	{
 		name: 'name',

--- a/packages/@n8n/nodes-langchain/nodes/chains/SentimentAnalysis/SentimentAnalysis.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/SentimentAnalysis/SentimentAnalysis.node.ts
@@ -168,7 +168,7 @@ export class SentimentAnalysis implements INodeType {
 		)) as BaseLanguageModel;
 
 		const returnData: INodeExecutionData[][] = [];
-		const promises = [];
+		const promises: Array<Promise<{ sentimentIndex: number; resultItem: INodeExecutionData }>> = [];
 		const { batchSize, delayBetweenBatches } = this.getNodeParameter('options.batching', 0, {}) as {
 			batchSize: number;
 			delayBetweenBatches: number;

--- a/packages/@n8n/nodes-langchain/nodes/chains/SentimentAnalysis/SentimentAnalysis.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/SentimentAnalysis/SentimentAnalysis.node.ts
@@ -180,7 +180,8 @@ export class SentimentAnalysis implements INodeType {
 
 		for (let i = 0; i < items.length; i += batchSize) {
 			const batch = items.slice(i, i + batchSize);
-			const batchPromises = batch.map(async (_item, itemIndex) => {
+			const batchPromises = batch.map(async (_item, batchItemIndex) => {
+				const itemIndex = i + batchItemIndex;
 				const sentimentCategories = this.getNodeParameter(
 					'options.categories',
 					itemIndex,

--- a/packages/@n8n/nodes-langchain/nodes/chains/SentimentAnalysis/SentimentAnalysis.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/SentimentAnalysis/SentimentAnalysis.node.ts
@@ -143,7 +143,7 @@ export class SentimentAnalysis implements INodeType {
 					{
 						displayName: 'Batch Size',
 						name: 'batchSize',
-						default: 20,
+						default: 100,
 						type: 'number',
 						description: 'How many items to process in parallel. This is useful for rate limiting.',
 					},

--- a/packages/@n8n/nodes-langchain/nodes/chains/SentimentAnalysis/SentimentAnalysis.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/SentimentAnalysis/SentimentAnalysis.node.ts
@@ -131,28 +131,30 @@ export class SentimentAnalysis implements INodeType {
 						description:
 							'Whether to enable auto-fixing (may trigger an additional LLM call if output is broken)',
 					},
-				],
-			},
-			{
-				displayName: 'Batch Processing',
-				name: 'batching',
-				type: 'collection',
-				description: 'Batch processing options for rate limiting',
-				default: {},
-				options: [
 					{
-						displayName: 'Batch Size',
-						name: 'batchSize',
-						default: 100,
-						type: 'number',
-						description: 'How many items to process in parallel. This is useful for rate limiting.',
-					},
-					{
-						displayName: 'Delay Between Batches',
-						name: 'delayBetweenBatches',
-						default: 1000,
-						type: 'number',
-						description: 'Delay in milliseconds between batches. This is useful for rate limiting.',
+						displayName: 'Batch Processing',
+						name: 'batching',
+						type: 'collection',
+						description: 'Batch processing options for rate limiting',
+						default: {},
+						options: [
+							{
+								displayName: 'Batch Size',
+								name: 'batchSize',
+								default: 100,
+								type: 'number',
+								description:
+									'How many items to process in parallel. This is useful for rate limiting.',
+							},
+							{
+								displayName: 'Delay Between Batches',
+								name: 'delayBetweenBatches',
+								default: 1000,
+								type: 'number',
+								description:
+									'Delay in milliseconds between batches. This is useful for rate limiting.',
+							},
+						],
 					},
 				],
 			},
@@ -168,17 +170,17 @@ export class SentimentAnalysis implements INodeType {
 		)) as BaseLanguageModel;
 
 		const returnData: INodeExecutionData[][] = [];
-		const promises: Array<Promise<{ sentimentIndex: number; resultItem: INodeExecutionData }>> = [];
 		const { batchSize, delayBetweenBatches } = this.getNodeParameter('options.batching', 0, {}) as {
 			batchSize: number;
 			delayBetweenBatches: number;
 		};
 
-		for (let i = 0; i < items.length; i++) {
-			try {
+		for (let i = 0; i < items.length; i += batchSize) {
+			const batch = items.slice(i, i + batchSize);
+			const batchPromises = batch.map(async (_item, itemIndex) => {
 				const sentimentCategories = this.getNodeParameter(
 					'options.categories',
-					i,
+					itemIndex,
 					DEFAULT_CATEGORIES,
 				) as string;
 
@@ -188,9 +190,13 @@ export class SentimentAnalysis implements INodeType {
 					.filter(Boolean);
 
 				if (categories.length === 0) {
-					throw new NodeOperationError(this.getNode(), 'No sentiment categories provided', {
-						itemIndex: i,
-					});
+					return {
+						result: null,
+						itemIndex,
+						error: new NodeOperationError(this.getNode(), 'No sentiment categories provided', {
+							itemIndex,
+						}),
+					};
 				}
 
 				// Initialize returnData with empty arrays for each category
@@ -198,7 +204,7 @@ export class SentimentAnalysis implements INodeType {
 					returnData.push(...Array.from({ length: categories.length }, () => []));
 				}
 
-				const options = this.getNodeParameter('options', i, {}) as {
+				const options = this.getNodeParameter('options', itemIndex, {}) as {
 					systemPromptTemplate?: string;
 					includeDetailedResults?: boolean;
 					enableAutoFixing?: boolean;
@@ -222,10 +228,10 @@ export class SentimentAnalysis implements INodeType {
 
 				const systemPromptTemplate = SystemMessagePromptTemplate.fromTemplate(
 					`${options.systemPromptTemplate ?? DEFAULT_SYSTEM_PROMPT_TEMPLATE}
-		{format_instructions}`,
+			{format_instructions}`,
 				);
 
-				const input = this.getNodeParameter('inputText', i) as string;
+				const input = this.getNodeParameter('inputText', itemIndex) as string;
 				const inputPrompt = new HumanMessage(input);
 				const messages = [
 					await systemPromptTemplate.format({
@@ -239,82 +245,79 @@ export class SentimentAnalysis implements INodeType {
 				const chain = prompt.pipe(llm).pipe(parser).withConfig(getTracingConfig(this));
 
 				try {
-					promises.push(
-						new Promise((resolve, reject) => {
-							chain
-								.invoke(messages)
-								.then((output) => {
-									const sentimentIndex = categories.findIndex(
-										(s) => s.toLowerCase() === output.sentiment.toLowerCase(),
-									);
+					const output = await chain.invoke(messages);
+					const sentimentIndex = categories.findIndex(
+						(s) => s.toLowerCase() === output.sentiment.toLowerCase(),
+					);
 
-									if (sentimentIndex !== -1) {
-										const resultItem = { ...items[i] };
-										const sentimentAnalysis: IDataObject = {
-											category: output.sentiment,
-										};
-										if (options.includeDetailedResults) {
-											sentimentAnalysis.strength = output.strength;
-											sentimentAnalysis.confidence = output.confidence;
-										}
-										resultItem.json = {
-											...resultItem.json,
-											sentimentAnalysis,
-										};
-										resolve({ sentimentIndex, resultItem });
-									}
-								})
-								.catch((error) => reject(error));
-						}),
-					);
-					if (i % batchSize === 0) {
-						await sleep(delayBetweenBatches);
+					if (sentimentIndex !== -1) {
+						const resultItem = { ...items[itemIndex] };
+						const sentimentAnalysis: IDataObject = {
+							category: output.sentiment,
+						};
+						if (options.includeDetailedResults) {
+							sentimentAnalysis.strength = output.strength;
+							sentimentAnalysis.confidence = output.confidence;
+						}
+						resultItem.json = {
+							...resultItem.json,
+							sentimentAnalysis,
+						};
+
+						return {
+							result: {
+								resultItem,
+								sentimentIndex,
+							},
+							itemIndex,
+						};
 					}
+
+					return {
+						result: {},
+						itemIndex,
+					};
 				} catch (error) {
-					throw new NodeOperationError(
-						this.getNode(),
-						'Error during parsing of LLM output, please check your LLM model and configuration',
-						{
-							itemIndex: i,
-						},
-					);
+					return {
+						result: null,
+						itemIndex,
+						error: new NodeOperationError(
+							this.getNode(),
+							'Error during parsing of LLM output, please check your LLM model and configuration',
+							{
+								itemIndex,
+							},
+						),
+					};
 				}
-			} catch (error) {
-				if (this.continueOnFail()) {
-					const executionErrorData = this.helpers.constructExecutionMetaData(
-						this.helpers.returnJsonArray({ error: error.message }),
-						{ itemData: { item: i } },
-					);
-					returnData[0].push(...executionErrorData);
-					continue;
+			});
+			const batchResults = await Promise.all(batchPromises);
+
+			batchResults.forEach(({ result, itemIndex, error }) => {
+				if (error) {
+					if (this.continueOnFail()) {
+						const executionErrorData = this.helpers.constructExecutionMetaData(
+							this.helpers.returnJsonArray({ error: error.message }),
+							{ itemData: { item: itemIndex } },
+						);
+
+						returnData[0].push(...executionErrorData);
+						return;
+					} else {
+						throw error;
+					}
+				} else if (result.resultItem && result.sentimentIndex) {
+					const sentimentIndex = result.sentimentIndex;
+					const resultItem = result.resultItem;
+					returnData[sentimentIndex].push(resultItem);
 				}
-				throw error;
+			});
+
+			// Add delay between batches if not the last batch
+			if (i + batchSize < items.length && delayBetweenBatches > 0) {
+				await sleep(delayBetweenBatches);
 			}
 		}
-
-		(await Promise.allSettled(promises)).forEach((response, index) => {
-			if (response.status === 'rejected') {
-				if (this.continueOnFail()) {
-					const error = response.reason;
-					const executionErrorData = this.helpers.constructExecutionMetaData(
-						this.helpers.returnJsonArray({ error: error.message }),
-						{ itemData: { item: index } },
-					);
-
-					returnData[0].push(...executionErrorData);
-					return;
-				} else {
-					throw new NodeOperationError(this.getNode(), response.reason);
-				}
-			} else {
-				const output = response.value;
-				const sentimentIndex = output.sentimentIndex;
-				const resultItem = output.resultItem;
-				returnData[sentimentIndex].push(resultItem);
-			}
-			const result = response.value;
-			returnData[result.sentimentIndex].push(result.resultItem);
-		});
 		return returnData;
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/chains/SentimentAnalysis/SentimentAnalysis.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/SentimentAnalysis/SentimentAnalysis.node.ts
@@ -149,7 +149,7 @@ export class SentimentAnalysis implements INodeType {
 							{
 								displayName: 'Delay Between Batches',
 								name: 'delayBetweenBatches',
-								default: 1000,
+								default: 0,
 								type: 'number',
 								description:
 									'Delay in milliseconds between batches. This is useful for rate limiting.',
@@ -170,7 +170,10 @@ export class SentimentAnalysis implements INodeType {
 		)) as BaseLanguageModel;
 
 		const returnData: INodeExecutionData[][] = [];
-		const { batchSize, delayBetweenBatches } = this.getNodeParameter('options.batching', 0, {}) as {
+		const { batchSize, delayBetweenBatches } = this.getNodeParameter('options.batching', 0, {
+			batchSize: 100,
+			delayBetweenBatches: 0,
+		}) as {
 			batchSize: number;
 			delayBetweenBatches: number;
 		};

--- a/packages/@n8n/nodes-langchain/nodes/chains/TextClassifier/TextClassifier.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/TextClassifier/TextClassifier.node.ts
@@ -303,7 +303,6 @@ ${fallbackPrompt}`,
 
 			promises.push(chain.invoke(messages));
 			if (batchSize && itemIdx % batchSize === 0) {
-				console.log('Sleeping');
 				await sleep(delayBetweenBatches);
 			}
 		}

--- a/packages/@n8n/nodes-langchain/nodes/chains/TextClassifier/TextClassifier.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/TextClassifier/TextClassifier.node.ts
@@ -168,7 +168,7 @@ export class TextClassifier implements INodeType {
 							{
 								displayName: 'Batch Size',
 								name: 'batchSize',
-								default: 20,
+								default: 100,
 								type: 'number',
 								description:
 									'How many items to process in parallel. This is useful for rate limiting.',

--- a/packages/@n8n/nodes-langchain/nodes/chains/TextClassifier/TextClassifier.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/TextClassifier/TextClassifier.node.ts
@@ -176,7 +176,7 @@ export class TextClassifier implements INodeType {
 							{
 								displayName: 'Delay Between Batches',
 								name: 'delayBetweenBatches',
-								default: 1000,
+								default: 0,
 								type: 'number',
 								description:
 									'Delay in milliseconds between batches. This is useful for rate limiting.',
@@ -191,8 +191,8 @@ export class TextClassifier implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
 		const { batchSize, delayBetweenBatches } = this.getNodeParameter('options.batching', 0, {
-			batchSize: 20,
-			delayBetweenBatches: 1000,
+			batchSize: 100,
+			delayBetweenBatches: 0,
 		}) as {
 			batchSize: number;
 			delayBetweenBatches: number;


### PR DESCRIPTION
## Summary
Adds batching options for parallel processing instead of awaiting each langchain call.
Implemented for following nodes:
- ToolsAgent
- ChainSummarizationV2
- InformationExtractor
- TextClassifier
- QARetrieval
- SentimentAnalysis

This allows the user to set the batch size and a delay between batches. Items in a batch will be processed simultaneously. Defaults are set according to common API request limits of OpenAI. For the tools agent that processing makes the logs less readable so for this case the default for batch size is 1.

For now this is implementing the same pattern that's on the HTTPRequest node.

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
![image](https://github.com/user-attachments/assets/a129cec5-623a-4069-a51a-417fa8c9bfb1)


## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-792/optimize-langchain-calls-in-a-batching-mode
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
