### PR TITLE
fix(core): Error in partial execution of vector stores

### DIFF
--- a/packages/core/src/execution-engine/partial-execution-utils/__tests__/rewire-graph.test.ts
+++ b/packages/core/src/execution-engine/partial-execution-utils/__tests__/rewire-graph.test.ts
@@ -93,14 +93,15 @@ describe('rewireGraph()', () => {
 		expect(tool.rewireOutputLogTo).toBe(NodeConnectionTypes.AiTool);
 	});
 
-	it('fails when the tool has no incoming connections', () => {
+	it('should not rewire when the tool has no root', () => {
 		const tool = createNodeData({ name: 'tool', type: 'n8n-nodes-base.ai-tool' });
 		const root = createNodeData({ name: 'root' });
 
 		const graph = new DirectedGraph();
 		graph.addNodes(root, tool);
+		const result = rewireGraph(tool, graph);
 
-		expect(() => rewireGraph(tool, graph)).toThrow();
+		expect(result).toStrictEqual(graph);
 	});
 
 	it('removes the root node from the graph', () => {

--- a/packages/core/src/execution-engine/partial-execution-utils/rewire-graph.ts
+++ b/packages/core/src/execution-engine/partial-execution-utils/rewire-graph.ts
@@ -4,26 +4,28 @@ import { type INode, NodeConnectionTypes } from 'n8n-workflow';
 import { type DirectedGraph } from './directed-graph';
 
 export function rewireGraph(tool: INode, graph: DirectedGraph): DirectedGraph {
-	graph = graph.clone();
-	const children = graph.getChildren(tool);
+	const modifiedGraph = graph.clone();
+	const children = modifiedGraph.getChildren(tool);
 
-	a.ok(children.size > 0, 'Tool must be connected to a root node');
+	if (children.size === 0) {
+		return graph;
+	}
 
 	const rootNode = [...children][0];
 
 	a.ok(rootNode);
 
-	const allIncomingConnection = graph
+	const allIncomingConnection = modifiedGraph
 		.getDirectParentConnections(rootNode)
 		.filter((cn) => cn.type === NodeConnectionTypes.Main);
 
 	tool.rewireOutputLogTo = NodeConnectionTypes.AiTool;
 
 	for (const cn of allIncomingConnection) {
-		graph.addConnection({ from: cn.from, to: tool });
+		modifiedGraph.addConnection({ from: cn.from, to: tool });
 	}
 
-	graph.removeNode(rootNode);
+	modifiedGraph.removeNode(rootNode);
 
-	return graph;
+	return modifiedGraph;
 }


### PR DESCRIPTION
## Summary
Correct behavior when triggering a partial execution of vector stores that are not connected to an agent.

Update rewiring logic to not modify the graph if no root node is present for a tool instead of throwing an error.

## Related Linear tickets, Github issues, and Community forum posts



## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
