### PR TITLE
fix(Summarize Node): Fix spaces in Fields to Split By values converted to underscores

### DIFF
--- a/packages/nodes-base/nodes/Transform/Summarize/test/unitTests/__snapshots__/splitData.test.ts.snap
+++ b/packages/nodes-base/nodes/Transform/Summarize/test/unitTests/__snapshots__/splitData.test.ts.snap
@@ -118,65 +118,6 @@ exports[`Test Summarize Node, aggregateAndSplitData should handle split field va
 }
 `;
 
-exports[`Test Summarize Node, aggregateAndSplitData should handle split field values containing spaces: split-field-with-spaces-array 1`] = `
-[
-  {
-    "pairedItems": [
-      0,
-      2,
-    ],
-    "returnData": {
-      "Product": "Widget A",
-      "appended_Warehouse": [
-        "WH1",
-        "WH3",
-      ],
-    },
-  },
-  {
-    "pairedItems": [
-      1,
-    ],
-    "returnData": {
-      "Product": "Widget B",
-      "appended_Warehouse": [
-        "WH2",
-      ],
-    },
-  },
-]
-`;
-
-exports[`Test Summarize Node, aggregateAndSplitData should handle split field values containing spaces: split-field-with-spaces-result 1`] = `
-{
-  "fieldName": "Product",
-  "splits": Map {
-    "Widget A" => {
-      "pairedItems": [
-        0,
-        2,
-      ],
-      "returnData": {
-        "appended_Warehouse": [
-          "WH1",
-          "WH3",
-        ],
-      },
-    },
-    "Widget B" => {
-      "pairedItems": [
-        1,
-      ],
-      "returnData": {
-        "appended_Warehouse": [
-          "WH2",
-        ],
-      },
-    },
-  },
-}
-`;
-
 exports[`Test Summarize Node, aggregateAndSplitData should not convert numbers to strings: array 1`] = `
 [
   {

--- a/packages/nodes-base/nodes/Transform/Summarize/test/unitTests/__snapshots__/splitData.test.ts.snap
+++ b/packages/nodes-base/nodes/Transform/Summarize/test/unitTests/__snapshots__/splitData.test.ts.snap
@@ -1,5 +1,182 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Test Summarize Node, aggregateAndSplitData should handle split field values containing spaces when convertKeysToString is not set: split-field-with-spaces-array 1`] = `
+[
+  {
+    "pairedItems": [
+      0,
+      2,
+    ],
+    "returnData": {
+      "Product": "Widget A",
+      "appended_Warehouse": [
+        "WH1",
+        "WH3",
+      ],
+    },
+  },
+  {
+    "pairedItems": [
+      1,
+    ],
+    "returnData": {
+      "Product": "Widget B",
+      "appended_Warehouse": [
+        "WH2",
+      ],
+    },
+  },
+]
+`;
+
+exports[`Test Summarize Node, aggregateAndSplitData should handle split field values containing spaces when convertKeysToString is not set: split-field-with-spaces-result 1`] = `
+{
+  "fieldName": "Product",
+  "splits": Map {
+    "Widget A" => {
+      "pairedItems": [
+        0,
+        2,
+      ],
+      "returnData": {
+        "appended_Warehouse": [
+          "WH1",
+          "WH3",
+        ],
+      },
+    },
+    "Widget B" => {
+      "pairedItems": [
+        1,
+      ],
+      "returnData": {
+        "appended_Warehouse": [
+          "WH2",
+        ],
+      },
+    },
+  },
+}
+`;
+
+exports[`Test Summarize Node, aggregateAndSplitData should handle split field values containing spaces when convertKeysToString is true: split-field-with-spaces-array 1`] = `
+[
+  {
+    "pairedItems": [
+      0,
+      2,
+    ],
+    "returnData": {
+      "Product": "Widget A",
+      "appended_Warehouse": [
+        "WH1",
+        "WH3",
+      ],
+    },
+  },
+  {
+    "pairedItems": [
+      1,
+    ],
+    "returnData": {
+      "Product": "Widget B",
+      "appended_Warehouse": [
+        "WH2",
+      ],
+    },
+  },
+]
+`;
+
+exports[`Test Summarize Node, aggregateAndSplitData should handle split field values containing spaces when convertKeysToString is true: split-field-with-spaces-result 1`] = `
+{
+  "fieldName": "Product",
+  "splits": Map {
+    "Widget A" => {
+      "pairedItems": [
+        0,
+        2,
+      ],
+      "returnData": {
+        "appended_Warehouse": [
+          "WH1",
+          "WH3",
+        ],
+      },
+    },
+    "Widget B" => {
+      "pairedItems": [
+        1,
+      ],
+      "returnData": {
+        "appended_Warehouse": [
+          "WH2",
+        ],
+      },
+    },
+  },
+}
+`;
+
+exports[`Test Summarize Node, aggregateAndSplitData should handle split field values containing spaces: split-field-with-spaces-array 1`] = `
+[
+  {
+    "pairedItems": [
+      0,
+      2,
+    ],
+    "returnData": {
+      "Product": "Widget A",
+      "appended_Warehouse": [
+        "WH1",
+        "WH3",
+      ],
+    },
+  },
+  {
+    "pairedItems": [
+      1,
+    ],
+    "returnData": {
+      "Product": "Widget B",
+      "appended_Warehouse": [
+        "WH2",
+      ],
+    },
+  },
+]
+`;
+
+exports[`Test Summarize Node, aggregateAndSplitData should handle split field values containing spaces: split-field-with-spaces-result 1`] = `
+{
+  "fieldName": "Product",
+  "splits": Map {
+    "Widget A" => {
+      "pairedItems": [
+        0,
+        2,
+      ],
+      "returnData": {
+        "appended_Warehouse": [
+          "WH1",
+          "WH3",
+        ],
+      },
+    },
+    "Widget B" => {
+      "pairedItems": [
+        1,
+      ],
+      "returnData": {
+        "appended_Warehouse": [
+          "WH2",
+        ],
+      },
+    },
+  },
+}
+`;
+
 exports[`Test Summarize Node, aggregateAndSplitData should not convert numbers to strings: array 1`] = `
 [
   {

--- a/packages/nodes-base/nodes/Transform/Summarize/test/unitTests/splitData.test.ts
+++ b/packages/nodes-base/nodes/Transform/Summarize/test/unitTests/splitData.test.ts
@@ -88,6 +88,95 @@ describe('Test Summarize Node, aggregateAndSplitData', () => {
 		expect(flattenAggregationResultToArray(result)).toMatchSnapshot('array');
 	});
 
+	test('should handle split field values containing spaces when convertKeysToString is not set', () => {
+		const data = [
+			{
+				Product: 'Widget A',
+				Warehouse: 'WH1',
+				Qty: '5',
+				_itemIndex: 0,
+			},
+			{
+				Product: 'Widget B',
+				Warehouse: 'WH2',
+				Qty: '3',
+				_itemIndex: 1,
+			},
+			{
+				Product: 'Widget A',
+				Warehouse: 'WH3',
+				Qty: '2',
+				_itemIndex: 2,
+			},
+		];
+
+		const aggregations: Aggregations = [
+			{
+				aggregation: 'append',
+				field: 'Warehouse',
+				includeEmpty: true,
+			},
+		];
+
+		const result = aggregateAndSplitData({
+			splitKeys: ['Product'],
+			inputItems: data,
+			fieldsToSummarize: aggregations,
+			options: { continueIfFieldNotFound: true },
+			getValue: fieldValueGetter(),
+		});
+
+		expect(result).toMatchSnapshot('split-field-with-spaces-result');
+		expect(flattenAggregationResultToArray(result)).toMatchSnapshot(
+			'split-field-with-spaces-array',
+		);
+	});
+
+	test('should handle split field values containing spaces when convertKeysToString is true', () => {
+		const data = [
+			{
+				Product: 'Widget A',
+				Warehouse: 'WH1',
+				Qty: '5',
+				_itemIndex: 0,
+			},
+			{
+				Product: 'Widget B',
+				Warehouse: 'WH2',
+				Qty: '3',
+				_itemIndex: 1,
+			},
+			{
+				Product: 'Widget A',
+				Warehouse: 'WH3',
+				Qty: '2',
+				_itemIndex: 2,
+			},
+		];
+
+		const aggregations: Aggregations = [
+			{
+				aggregation: 'append',
+				field: 'Warehouse',
+				includeEmpty: true,
+			},
+		];
+
+		const result = aggregateAndSplitData({
+			splitKeys: ['Product'],
+			inputItems: data,
+			fieldsToSummarize: aggregations,
+			options: { continueIfFieldNotFound: true },
+			getValue: fieldValueGetter(),
+			convertKeysToString: true,
+		});
+
+		expect(result).toMatchSnapshot('split-field-with-spaces-result');
+		expect(flattenAggregationResultToArray(result)).toMatchSnapshot(
+			'split-field-with-spaces-array',
+		);
+	});
+
 	describe('with skipEmptySplitFields=true', () => {
 		test('should skip empty split fields', () => {
 			const data = [

--- a/packages/nodes-base/nodes/Transform/Summarize/utils.ts
+++ b/packages/nodes-base/nodes/Transform/Summarize/utils.ts
@@ -232,7 +232,7 @@ export function aggregateAndSplitData({
 		}
 
 		if (convertKeysToString) {
-			key = normalizeFieldName(String(key));
+			key = String(key);
 		}
 
 		if (options.skipEmptySplitFields && typeof key !== 'number' && !key) {

--- a/packages/nodes-base/nodes/Transform/Summarize/utils.ts
+++ b/packages/nodes-base/nodes/Transform/Summarize/utils.ts
@@ -225,22 +225,22 @@ export function aggregateAndSplitData({
 
 	const groupedItems = new Map<unknown, IDataObject[]>();
 	for (const item of inputItems) {
-		let key = getValue(item, firstSplitKey);
+		let splitValue = getValue(item, firstSplitKey);
 
-		if (key && typeof key === 'object') {
-			key = JSON.stringify(key);
+		if (splitValue && typeof splitValue === 'object') {
+			splitValue = JSON.stringify(splitValue);
 		}
 
 		if (convertKeysToString) {
-			key = String(key);
+			splitValue = String(splitValue);
 		}
 
-		if (options.skipEmptySplitFields && typeof key !== 'number' && !key) {
+		if (options.skipEmptySplitFields && typeof splitValue !== 'number' && !splitValue) {
 			continue;
 		}
 
-		const group = groupedItems.get(key) ?? [];
-		groupedItems.set(key, group.concat([item]));
+		const group = groupedItems.get(splitValue) ?? [];
+		groupedItems.set(splitValue, group.concat([item]));
 	}
 
 	const splits = new Map(


### PR DESCRIPTION
## Summary
This PR fixes a regression in V1 of Summarize Node where spaces in Fields to Split By values are converted to underscores
issue was introduced in 1.86.0 in https://github.com/n8n-io/n8n/issues/14053 were spaces were removed and then in 1.89.0 in https://github.com/n8n-io/n8n/pull/14528 were spaces were converted to underscores 
## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-2910/bug-summarize-node-spaces-converted-to-underscores-[breaking-change]

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
