### PR TITLE
Postgres Node: Add searchable schema and table selectors

### DIFF
--- a/packages/nodes-base/nodes/Postgres/v2/actions/common.descriptions.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/common.descriptions.ts
@@ -170,6 +170,7 @@ export const schemaRLC: INodeProperties = {
 			type: 'list',
 			typeOptions: {
 				searchListMethod: 'schemaSearch',
+				searchable: true,
 			},
 		},
 		{
@@ -194,6 +195,7 @@ export const tableRLC: INodeProperties = {
 			type: 'list',
 			typeOptions: {
 				searchListMethod: 'tableSearch',
+				searchable: true,
 			},
 		},
 		{

--- a/packages/nodes-base/nodes/Postgres/v2/methods/listSearch.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/methods/listSearch.ts
@@ -3,13 +3,33 @@ import type { ILoadOptionsFunctions, INodeListSearchResult } from 'n8n-workflow'
 import { configurePostgres } from '../../transport';
 import type { PostgresNodeCredentials } from '../helpers/interfaces';
 
-export async function schemaSearch(this: ILoadOptionsFunctions): Promise<INodeListSearchResult> {
+export async function schemaSearch(
+	this: ILoadOptionsFunctions,
+	filter?: string,
+): Promise<INodeListSearchResult> {
 	const credentials = await this.getCredentials<PostgresNodeCredentials>('postgres');
 	const options = { nodeVersion: this.getNode().typeVersion };
 
 	const { db } = await configurePostgres.call(this, credentials, options);
 
 	const response = await db.any('SELECT schema_name FROM information_schema.schemata');
+
+	if (filter) {
+		const filterLower = filter.toLowerCase();
+		const results = [];
+
+		for (const schema of response) {
+			const schemaName = schema.schema_name as string;
+			if (schemaName.toLowerCase().indexOf(filterLower) !== -1) {
+				results.push({
+					name: schemaName,
+					value: schemaName,
+				});
+			}
+		}
+
+		return { results };
+	}
 
 	return {
 		results: response.map((schema) => ({
@@ -18,7 +38,10 @@ export async function schemaSearch(this: ILoadOptionsFunctions): Promise<INodeLi
 		})),
 	};
 }
-export async function tableSearch(this: ILoadOptionsFunctions): Promise<INodeListSearchResult> {
+export async function tableSearch(
+	this: ILoadOptionsFunctions,
+	filter?: string,
+): Promise<INodeListSearchResult> {
 	const credentials = await this.getCredentials<PostgresNodeCredentials>('postgres');
 	const options = { nodeVersion: this.getNode().typeVersion };
 
@@ -32,6 +55,23 @@ export async function tableSearch(this: ILoadOptionsFunctions): Promise<INodeLis
 		'SELECT table_name FROM information_schema.tables WHERE table_schema=$1',
 		[schema],
 	);
+
+	if (filter) {
+		const filterLower = filter.toLowerCase();
+		const results = [];
+
+		for (const table of response) {
+			const tableName = table.table_name as string;
+			if (tableName.toLowerCase().indexOf(filterLower) !== -1) {
+				results.push({
+					name: tableName,
+					value: tableName,
+				});
+			}
+		}
+
+		return { results };
+	}
 
 	return {
 		results: response.map((table) => ({


### PR DESCRIPTION
## Summary

<!--
Add search functionality to schema and table selectors in the Postgres node, similar to Airtable's implementation. This improves usability when working with databases that have many schemas or tables.

Changes:
- Add searchable property to schema and table resource locators
- Implement filter handling in schemaSearch and tableSearch methods
- Use case-insensitive search for better matching
-->