### PR TITLE
fix(editor): Fix workflow-builder feedback tracking (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/components/AskAssistant/Agent/AskAssistantBuild.test.ts
+++ b/packages/frontend/editor-ui/src/components/AskAssistant/Agent/AskAssistantBuild.test.ts
@@ -33,6 +33,7 @@ vi.mock('@/composables/useI18n', () => ({
 	}),
 }));
 
+const workflowPrompt = 'Create a workflow';
 describe('AskAssistantBuild', () => {
 	const sessionId = faker.string.uuid();
 	const renderComponent = createComponentRenderer(AskAssistantBuild);
@@ -48,7 +49,7 @@ describe('AskAssistantBuild', () => {
 					currentSessionId: sessionId,
 					streaming: false,
 					assistantThinkingMessage: undefined,
-					workflowPrompt: 'Create a workflow',
+					workflowPrompt,
 				},
 			},
 		});
@@ -61,6 +62,7 @@ describe('AskAssistantBuild', () => {
 		builderStore.resetBuilderChat = vi.fn();
 		builderStore.addAssistantMessages = vi.fn();
 		builderStore.$onAction = vi.fn().mockReturnValue(vi.fn());
+		builderStore.workflowPrompt = workflowPrompt;
 	});
 
 	describe('rendering', () => {
@@ -99,6 +101,7 @@ describe('AskAssistantBuild', () => {
 	});
 
 	describe('feedback handling', () => {
+		const workflowJson = '{"nodes": [], "connections": {}}';
 		beforeEach(() => {
 			builderStore.chatMessages = [
 				{
@@ -106,7 +109,7 @@ describe('AskAssistantBuild', () => {
 					role: 'assistant',
 					type: 'workflow-generated',
 					read: true,
-					codeSnippet: '{}',
+					codeSnippet: workflowJson,
 				},
 				{
 					id: faker.string.uuid(),
@@ -128,8 +131,9 @@ describe('AskAssistantBuild', () => {
 			await flushPromises();
 
 			expect(trackMock).toHaveBeenCalledWith('User rated workflow generation', {
-				chat_session_id: sessionId,
 				helpful: true,
+				prompt: 'Create a workflow',
+				workflow_json: workflowJson,
 			});
 		});
 
@@ -143,8 +147,9 @@ describe('AskAssistantBuild', () => {
 			await flushPromises();
 
 			expect(trackMock).toHaveBeenCalledWith('User rated workflow generation', {
-				chat_session_id: sessionId,
 				helpful: false,
+				prompt: 'Create a workflow',
+				workflow_json: workflowJson,
 			});
 		});
 
@@ -171,8 +176,9 @@ describe('AskAssistantBuild', () => {
 			expect(trackMock).toHaveBeenCalledWith(
 				'User submitted workflow generation feedback',
 				expect.objectContaining({
-					chat_session_id: sessionId,
 					feedback: feedbackText,
+					prompt: 'Create a workflow',
+					workflow_json: workflowJson,
 				}),
 			);
 		});

--- a/packages/frontend/editor-ui/src/components/AskAssistant/Agent/AskAssistantBuild.vue
+++ b/packages/frontend/editor-ui/src/components/AskAssistant/Agent/AskAssistantBuild.vue
@@ -20,7 +20,7 @@ const telemetry = useTelemetry();
 const i18n = useI18n();
 const helpful = ref(false);
 const generationStartTime = ref(0);
-const generatedWorkflow = ref<IWorkflowDataUpdate | undefined>();
+
 const user = computed(() => ({
 	firstName: usersStore.currentUser?.firstName ?? '',
 	lastName: usersStore.currentUser?.lastName ?? '',
@@ -111,7 +111,6 @@ function onNewWorkflow() {
 	builderStore.resetBuilderChat();
 	workflowGenerated.value = false;
 	helpful.value = false;
-	generatedWorkflow.value = undefined;
 	generationStartTime.value = new Date().getTime();
 }
 


### PR DESCRIPTION
## Summary

This PR updates the telemetry tracking for workflow generation to include more context:

1. Adds workflow JSON data to all workflow rating events
2. Adds the prompt to all workflow feedback telemetry
3. Removes chat_session_id from telemetry events (not used in the builder yet)

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
