### PR TITLE
fix(HTTP Request Node): Add support for Bearer Auth in HttpRequest node

### DIFF
--- a/packages/@n8n/nodes-langchain/.eslintrc.js
+++ b/packages/@n8n/nodes-langchain/.eslintrc.js
@@ -151,6 +151,7 @@ module.exports = {
 			files: ['**/*.test.ts', '**/test/**/*.ts'],
 			rules: {
 				'import/no-extraneous-dependencies': 'off',
+				'n8n-nodes-base/node-filename-against-convention': 'off',
 			},
 		},
 	],

--- a/packages/nodes-base/.eslintrc.js
+++ b/packages/nodes-base/.eslintrc.js
@@ -153,6 +153,7 @@ module.exports = {
 			files: ['**/*.test.ts', '**/test/**/*.ts'],
 			rules: {
 				'import/no-extraneous-dependencies': 'off',
+				'n8n-nodes-base/node-filename-against-convention': 'off',
 			},
 		},
 	],

--- a/packages/nodes-base/nodes/EmailReadImap/test/v2/EmailReadImapV2.node.test.ts
+++ b/packages/nodes-base/nodes/EmailReadImap/test/v2/EmailReadImapV2.node.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable n8n-nodes-base/node-filename-against-convention */
 import { mock } from 'jest-mock-extended';
 import { type INodeTypeBaseDescription, type ITriggerFunctions } from 'n8n-workflow';
 

--- a/packages/nodes-base/nodes/GraphQL/test/GraphQL.node.test.ts
+++ b/packages/nodes-base/nodes/GraphQL/test/GraphQL.node.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable n8n-nodes-base/node-filename-against-convention */
 import { NodeTestHarness } from '@nodes-testing/node-test-harness';
 import nock from 'nock';
 

--- a/packages/nodes-base/nodes/HttpRequest/V2/HttpRequestV2.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V2/HttpRequestV2.node.ts
@@ -640,6 +640,7 @@ export class HttpRequestV2 implements INodeType {
 		} catch {}
 
 		let httpBasicAuth;
+		let httpBearerAuth;
 		let httpDigestAuth;
 		let httpHeaderAuth;
 		let httpQueryAuth;
@@ -653,6 +654,10 @@ export class HttpRequestV2 implements INodeType {
 			if (genericAuthType === 'httpBasicAuth') {
 				try {
 					httpBasicAuth = await this.getCredentials('httpBasicAuth');
+				} catch {}
+			} else if (genericAuthType === 'httpBearerAuth') {
+				try {
+					httpBearerAuth = await this.getCredentials('httpBearerAuth');
 				} catch {}
 			} else if (genericAuthType === 'httpDigestAuth') {
 				try {
@@ -958,6 +963,11 @@ export class HttpRequestV2 implements INodeType {
 					pass: httpBasicAuth.password as string,
 				};
 				authDataKeys.auth = ['pass'];
+			}
+			if (httpBearerAuth !== undefined) {
+				requestOptions.headers = requestOptions.headers ?? {};
+				requestOptions.headers.Authorization = `Bearer ${String(httpBearerAuth.token)}`;
+				authDataKeys.headers = ['Authorization'];
 			}
 			if (httpHeaderAuth !== undefined) {
 				requestOptions.headers![httpHeaderAuth.name as string] = httpHeaderAuth.value;

--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -100,6 +100,7 @@ export class HttpRequestV3 implements INodeType {
 		} catch {}
 
 		let httpBasicAuth;
+		let httpBearerAuth;
 		let httpDigestAuth;
 		let httpHeaderAuth;
 		let httpQueryAuth;
@@ -156,6 +157,8 @@ export class HttpRequestV3 implements INodeType {
 
 					if (genericCredentialType === 'httpBasicAuth') {
 						httpBasicAuth = await this.getCredentials('httpBasicAuth', itemIndex);
+					} else if (genericCredentialType === 'httpBearerAuth') {
+						httpBearerAuth = await this.getCredentials('httpBearerAuth', itemIndex);
 					} else if (genericCredentialType === 'httpDigestAuth') {
 						httpDigestAuth = await this.getCredentials('httpDigestAuth', itemIndex);
 					} else if (genericCredentialType === 'httpHeaderAuth') {
@@ -495,6 +498,11 @@ export class HttpRequestV3 implements INodeType {
 						pass: httpBasicAuth.password as string,
 					};
 					authDataKeys.auth = ['pass'];
+				}
+				if (httpBearerAuth !== undefined) {
+					requestOptions.headers = requestOptions.headers ?? {};
+					requestOptions.headers.Authorization = `Bearer ${String(httpBearerAuth.token)}`;
+					authDataKeys.headers = ['Authorization'];
 				}
 				if (httpHeaderAuth !== undefined) {
 					requestOptions.headers![httpHeaderAuth.name as string] = httpHeaderAuth.value;

--- a/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequestV2.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequestV2.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable n8n-nodes-base/node-filename-against-convention */
 import type { IExecuteFunctions, INodeTypeBaseDescription } from 'n8n-workflow';
 
 import { HttpRequestV2 } from '../../V2/HttpRequestV2.node';

--- a/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequestV3.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequestV3.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable n8n-nodes-base/node-filename-against-convention */
 import type { IExecuteFunctions, INodeTypeBaseDescription } from 'n8n-workflow';
 
 import { HttpRequestV3 } from '../../V3/HttpRequestV3.node';

--- a/packages/nodes-base/nodes/N8nTrigger/test/trigger.test.ts
+++ b/packages/nodes-base/nodes/N8nTrigger/test/trigger.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable n8n-nodes-base/node-filename-against-convention */
 import { N8nTrigger } from '../N8nTrigger.node';
 
 describe('N8nTrigger', () => {

--- a/packages/nodes-base/nodes/Transform/RemoveDuplicates/v2/test/RemoveDuplicates.test.ts
+++ b/packages/nodes-base/nodes/Transform/RemoveDuplicates/v2/test/RemoveDuplicates.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable n8n-nodes-base/node-filename-against-convention */
 import { mock } from 'jest-mock-extended';
 import type { IExecuteFunctions, INodeExecutionData, INodeTypeBaseDescription } from 'n8n-workflow';
 


### PR DESCRIPTION
## Summary

This PR adds supports for HttpBearerAuth to HttpRequest Node >= V2
It also updates the linter rules to exclude test files from nodes file naming convention

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2909/community-issue-401-unauthorized-no-authorization-token-provided-error
fixes https://github.com/n8n-io/n8n/issues/14615

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
