### PR TITLE
feat(Calendly Trigger Node): Deprecation notice for apiKey authentication

### DIFF
--- a/packages/nodes-base/nodes/Calendly/CalendlyTrigger.node.ts
+++ b/packages/nodes-base/nodes/Calendly/CalendlyTrigger.node.ts
@@ -70,6 +70,18 @@ export class CalendlyTrigger implements INodeType {
 				default: 'apiKey',
 			},
 			{
+				displayName:
+					'Action required: Calendly will discontinue API Key authentication on May 31, 2025. Update node to use OAuth2 authentication now to ensure your workflows continue to work.',
+				name: 'deprecationNotice',
+				type: 'notice',
+				default: '',
+				displayOptions: {
+					show: {
+						authentication: ['apiKey'],
+					},
+				},
+			},
+			{
 				displayName: 'Scope',
 				name: 'scope',
 				type: 'options',


### PR DESCRIPTION
## Summary

Calendly planning to deprecate API v1(apiKey authentication) in May 2025.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2571/blackcloak-calendly-node-fully-migrate-to-api-v2-before-end-of-may


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
