### PR TITLE
fix(core): Manual execution defaults to Manual trigger

### DIFF
--- a/packages/cli/src/__tests__/manual-execution.service.test.ts
+++ b/packages/cli/src/__tests__/manual-execution.service.test.ts
@@ -1,7 +1,7 @@
 import { mock } from 'jest-mock-extended';
 import * as core from 'n8n-core';
 import { DirectedGraph, recreateNodeExecutionStack, WorkflowExecute } from 'n8n-core';
-import {
+import type {
 	Workflow,
 	IWorkflowExecutionDataProcess,
 	IWorkflowExecuteAdditionalData,

--- a/packages/cli/src/__tests__/manual-execution.service.test.ts
+++ b/packages/cli/src/__tests__/manual-execution.service.test.ts
@@ -34,6 +34,9 @@ describe('ManualExecutionService', () => {
 						name: nodeName,
 					};
 				},
+				getTriggerNodes() {
+					return [];
+				},
 			} as unknown as Workflow;
 			const executionStartNode = manualExecutionService.getExecutionStartNode(data, workflow);
 			expect(executionStartNode).toBeUndefined();
@@ -56,6 +59,9 @@ describe('ManualExecutionService', () => {
 					}
 					return undefined;
 				},
+				getTriggerNodes() {
+					return [];
+				},
 			} as unknown as Workflow;
 			const executionStartNode = manualExecutionService.getExecutionStartNode(data, workflow);
 			expect(executionStartNode).toEqual({
@@ -77,11 +83,42 @@ describe('ManualExecutionService', () => {
 						name: nodeName,
 					};
 				},
+				getTriggerNodes() {
+					return [];
+				},
 			} as unknown as Workflow;
 			const executionStartNode = manualExecutionService.getExecutionStartNode(data, workflow);
 			expect(executionStartNode).toEqual({
 				name: 'node3',
 			});
+		});
+
+		it('should default to The manual trigger', () => {
+			const data = {
+				pinData: {},
+				startNodes: [],
+			} as unknown as IWorkflowExecutionDataProcess;
+			const manualTrigger = {
+				type: 'n8n-nodes-base.manualTrigger',
+				name: 'When clicking ‘Test workflow’',
+			};
+
+			const workflow = {
+				getNode() {
+					return undefined;
+				},
+				getTriggerNodes() {
+					return [
+						{
+							type: 'n8n-nodes-base.scheduleTrigger',
+							name: 'Wed 12:00',
+						},
+						manualTrigger,
+					];
+				},
+			} as unknown as Workflow;
+			const executionStartNode = manualExecutionService.getExecutionStartNode(data, workflow);
+			expect(executionStartNode?.name).toBe(manualTrigger.name);
 		});
 	});
 
@@ -230,6 +267,7 @@ describe('ManualExecutionService', () => {
 
 			const workflow = mock<Workflow>({
 				getNode: jest.fn().mockReturnValue(null),
+				getTriggerNodes: jest.fn().mockReturnValue([]),
 			});
 
 			const additionalData = mock<IWorkflowExecuteAdditionalData>();

--- a/packages/cli/src/manual-execution.service.ts
+++ b/packages/cli/src/manual-execution.service.ts
@@ -9,6 +9,7 @@ import {
 	isTool,
 	rewireGraph,
 } from 'n8n-core';
+import { MANUAL_TRIGGER_NODE_TYPE } from 'n8n-workflow';
 import type {
 	IPinData,
 	IRun,
@@ -39,7 +40,15 @@ export class ManualExecutionService {
 			startNode = workflow.getNode(data.startNodes[0].name) ?? undefined;
 		}
 
-		return startNode;
+		if (startNode) {
+			return startNode;
+		}
+
+		const manualTrigger = workflow
+			.getTriggerNodes()
+			.find((node) => node.type === MANUAL_TRIGGER_NODE_TYPE);
+
+		return manualTrigger;
 	}
 
 	// eslint-disable-next-line @typescript-eslint/promise-function-async

--- a/packages/core/src/execution-engine/partial-execution-utils/__tests__/find-trigger-for-partial-execution.test.ts
+++ b/packages/core/src/execution-engine/partial-execution-utils/__tests__/find-trigger-for-partial-execution.test.ts
@@ -24,12 +24,9 @@ describe('findTriggerForPartialExecution', () => {
 	const disabledTriggerNode = createNode('DisabledTrigger', 'n8n-nodes-base.manualTrigger', true);
 	const pinnedTrigger = createNode('PinnedTrigger', 'n8n-nodes-base.manualTrigger');
 	const setNode = createNode('Set', 'n8n-nodes-base.set');
-	const setNode1 = createNode('Set1', 'n8n-nodes-base.set');
 	const noOpNode = createNode('No Operation', 'n8n-nodes-base.noOp');
 	const webhookNode = createNode('Webhook', 'n8n-nodes-base.webhook');
 	const webhookNode1 = createNode('Webhook1', 'n8n-nodes-base.webhook');
-	const scheduleTrigger = createNode('Wed 12:00', 'n8n-nodes-base.scheduleTrigger');
-	const scheduleTrigger1 = createNode('Sun 12:00', 'n8n-nodes-base.scheduleTrigger');
 
 	beforeEach(() => {
 		nodeTypes.getByNameAndVersion.mockImplementation((type) => {
@@ -110,17 +107,6 @@ describe('findTriggerForPartialExecution', () => {
 					{ from: manualTriggerNode, to: setNode },
 				],
 				destinationNodeName: setNode.name,
-				expectedTrigger: manualTriggerNode,
-			},
-			{
-				description: 'should prioritize manual trigger',
-				nodes: [scheduleTrigger, scheduleTrigger1, manualTriggerNode, setNode, setNode1],
-				connections: [
-					{ from: scheduleTrigger, to: setNode },
-					{ from: manualTriggerNode, to: setNode1 },
-					{ from: scheduleTrigger1, to: setNode1 },
-				],
-				destinationNodeName: setNode1.name,
 				expectedTrigger: manualTriggerNode,
 			},
 		],

--- a/packages/core/src/execution-engine/partial-execution-utils/__tests__/find-trigger-for-partial-execution.test.ts
+++ b/packages/core/src/execution-engine/partial-execution-utils/__tests__/find-trigger-for-partial-execution.test.ts
@@ -24,9 +24,12 @@ describe('findTriggerForPartialExecution', () => {
 	const disabledTriggerNode = createNode('DisabledTrigger', 'n8n-nodes-base.manualTrigger', true);
 	const pinnedTrigger = createNode('PinnedTrigger', 'n8n-nodes-base.manualTrigger');
 	const setNode = createNode('Set', 'n8n-nodes-base.set');
+	const setNode1 = createNode('Set1', 'n8n-nodes-base.set');
 	const noOpNode = createNode('No Operation', 'n8n-nodes-base.noOp');
 	const webhookNode = createNode('Webhook', 'n8n-nodes-base.webhook');
 	const webhookNode1 = createNode('Webhook1', 'n8n-nodes-base.webhook');
+	const scheduleTrigger = createNode('Wed 12:00', 'n8n-nodes-base.scheduleTrigger');
+	const scheduleTrigger1 = createNode('Sun 12:00', 'n8n-nodes-base.scheduleTrigger');
 
 	beforeEach(() => {
 		nodeTypes.getByNameAndVersion.mockImplementation((type) => {
@@ -107,6 +110,17 @@ describe('findTriggerForPartialExecution', () => {
 					{ from: manualTriggerNode, to: setNode },
 				],
 				destinationNodeName: setNode.name,
+				expectedTrigger: manualTriggerNode,
+			},
+			{
+				description: 'should prioritize manual trigger',
+				nodes: [scheduleTrigger, scheduleTrigger1, manualTriggerNode, setNode, setNode1],
+				connections: [
+					{ from: scheduleTrigger, to: setNode },
+					{ from: manualTriggerNode, to: setNode1 },
+					{ from: scheduleTrigger1, to: setNode1 },
+				],
+				destinationNodeName: setNode1.name,
 				expectedTrigger: manualTriggerNode,
 			},
 		],


### PR DESCRIPTION
## Summary


When clicking the "Test Workflow" button. The execution path was incorrect.

Now it defaults to the Manual trigger as the execution starting point.

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/34394d29-961b-4121-a58d-5d560b1f42e4) | ![image](https://github.com/user-attachments/assets/b88b430f-d960-4f1b-a0cf-dc13b02001db) |

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-2800/bug-test-workflow-button-triggers-wrong-node
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
