### PR TITLE
fix(core): Use manual tool description if neither resources or operations exist 

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/create-node-as-tool.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/create-node-as-tool.test.ts
@@ -68,6 +68,15 @@ describe('createNodeAsTool', () => {
 
 			expect(tool.description).toBe('Custom tool description');
 		});
+
+		it('should use toolDescription when descriptionType is absent', () => {
+			delete node.parameters.descriptionType;
+			node.parameters.toolDescription = 'Another custom tool description';
+
+			const tool = createNodeAsTool(options).response;
+
+			expect(tool.description).toBe('Another custom tool description');
+		});
 	});
 
 	describe('Schema Creation and Parameter Handling', () => {

--- a/packages/core/src/execution-engine/node-execution-context/utils/create-node-as-tool.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/create-node-as-tool.ts
@@ -103,11 +103,9 @@ function makeDescription(node: INode, nodeType: INodeType): string {
 		return description.trim();
 	}
 
-	// This is the custom description the user may provide if descriptionType
-	// is `manual` or not included in the node's properties
-	const explicitDescription = node.parameters.toolDescription as string;
-
-	return explicitDescription ?? nodeType.description.description;
+	// Users can define custom descriptions when `descriptionType` is manual or not included
+	// in the node's properties, e.g. when the node has neither `operation` or `resource`
+	return (node.parameters.toolDescription as string) ?? nodeType.description.description;
 }
 
 export function nodeNameToToolName(node: INode): string {

--- a/packages/core/src/execution-engine/node-execution-context/utils/create-node-as-tool.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/create-node-as-tool.ts
@@ -90,7 +90,9 @@ function getSchema(node: INode) {
  * @returns A string description for the node.
  */
 function makeDescription(node: INode, nodeType: INodeType): string {
-	const manualDescription = node.parameters.toolDescription as string;
+	// This is the custom description the user may provide if descriptionType
+	// is `manual` or not included in the node's properties
+	const explicitDescription = node.parameters.toolDescription as string;
 
 	if (node.parameters.descriptionType === 'auto') {
 		const resource = node.parameters.resource as string;
@@ -105,9 +107,7 @@ function makeDescription(node: INode, nodeType: INodeType): string {
 		return description.trim();
 	}
 
-	// This covers both cases where either descriptionType is `manual` or
-	// we only have the `toolDescription` field
-	return manualDescription ?? nodeType.description.description;
+	return explicitDescription ?? nodeType.description.description;
 }
 
 export function nodeNameToToolName(node: INode): string {

--- a/packages/core/src/execution-engine/node-execution-context/utils/create-node-as-tool.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/create-node-as-tool.ts
@@ -90,10 +90,6 @@ function getSchema(node: INode) {
  * @returns A string description for the node.
  */
 function makeDescription(node: INode, nodeType: INodeType): string {
-	// This is the custom description the user may provide if descriptionType
-	// is `manual` or not included in the node's properties
-	const explicitDescription = node.parameters.toolDescription as string;
-
 	if (node.parameters.descriptionType === 'auto') {
 		const resource = node.parameters.resource as string;
 		const operation = node.parameters.operation as string;
@@ -106,6 +102,10 @@ function makeDescription(node: INode, nodeType: INodeType): string {
 		}
 		return description.trim();
 	}
+
+	// This is the custom description the user may provide if descriptionType
+	// is `manual` or not included in the node's properties
+	const explicitDescription = node.parameters.toolDescription as string;
 
 	return explicitDescription ?? nodeType.description.description;
 }

--- a/packages/core/src/execution-engine/node-execution-context/utils/create-node-as-tool.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/create-node-as-tool.ts
@@ -104,11 +104,10 @@ function makeDescription(node: INode, nodeType: INodeType): string {
 		}
 		return description.trim();
 	}
-	if (node.parameters.descriptionType === 'manual') {
-		return manualDescription ?? nodeType.description.description;
-	}
 
-	return nodeType.description.description;
+	// This covers both cases where either descriptionType is `manual` or
+	// we only have the `toolDescription` field
+	return manualDescription ?? nodeType.description.description;
 }
 
 export function nodeNameToToolName(node: INode): string {


### PR DESCRIPTION
## Summary

In https://github.com/n8n-io/n8n/blob/54dcdedecedb0a480caa17f8d6f0447535a2995a/packages/cli/src/load-nodes-and-credentials.ts#L499 we only add the `descriptionType` field if we have either resources or operations, meaning that we ignored custom toolDescriptions if neither was present.

Should backport to 1.90 and 1.91.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3538/community-issue-mcp-server-doesnt-pass-on-http-node-descriptions
#15007 


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
