### PR TITLE
fix(Google Sheets Node): Return single row in read operation if combine conditions is OR and 'Return only First Matching Row'

### DIFF
--- a/packages/nodes-base/nodes/Google/Sheet/GoogleSheets.node.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/GoogleSheets.node.ts
@@ -11,7 +11,7 @@ export class GoogleSheets extends VersionedNodeType {
 			name: 'googleSheets',
 			icon: 'file:googleSheets.svg',
 			group: ['input', 'output'],
-			defaultVersion: 4.5,
+			defaultVersion: 4.6,
 			subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
 			description: 'Read, update and write data to Google Sheets',
 		};
@@ -26,6 +26,7 @@ export class GoogleSheets extends VersionedNodeType {
 			4.3: new GoogleSheetsV2(baseDescription),
 			4.4: new GoogleSheetsV2(baseDescription),
 			4.5: new GoogleSheetsV2(baseDescription),
+			4.6: new GoogleSheetsV2(baseDescription),
 		};
 
 		super(nodeVersions, baseDescription);

--- a/packages/nodes-base/nodes/Google/Sheet/test/v2/helpers/GoogleSheet.test.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/test/v2/helpers/GoogleSheet.test.ts
@@ -103,14 +103,14 @@ describe('GoogleSheet', () => {
 	});
 
 	describe('lookupValues', () => {
-		it('should find matching rows with OR combination', async () => {
-			const inputData = [
-				['name', 'age', 'city'],
-				['John', '30', 'NY'],
-				['Jane', '25', 'LA'],
-				['Bob', '30', 'SF'],
-			];
+		const inputData = [
+			['name', 'age', 'city'],
+			['John', '30', 'NY'],
+			['Jane', '25', 'LA'],
+			['Bob', '30', 'SF'],
+		];
 
+		it('should find matching rows with OR combination', async () => {
 			const lookupValues = [{ lookupColumn: 'age', lookupValue: '30' }];
 
 			const result = await googleSheet.lookupValues({
@@ -120,6 +120,7 @@ describe('GoogleSheet', () => {
 				lookupValues,
 				returnAllMatches: true,
 				combineFilters: 'OR',
+				nodeVersion: 4.5,
 			});
 
 			expect(result).toEqual([
@@ -128,14 +129,46 @@ describe('GoogleSheet', () => {
 			]);
 		});
 
-		it('should find matching rows with AND combination', async () => {
-			const inputData = [
-				['name', 'age', 'city'],
-				['John', '30', 'NY'],
-				['Jane', '25', 'LA'],
-				['Bob', '30', 'SF'],
+		it('should find matching rows with OR combination and returnAllMatches is falsy at version 4.5', async () => {
+			const lookupValues = [
+				{ lookupColumn: 'age', lookupValue: '30' },
+				{ lookupColumn: 'name', lookupValue: 'Jane' },
 			];
 
+			const result = await googleSheet.lookupValues({
+				inputData,
+				keyRowIndex: 0,
+				dataStartRowIndex: 1,
+				lookupValues,
+				combineFilters: 'OR',
+				nodeVersion: 4.5,
+			});
+
+			expect(result).toEqual([
+				{ name: 'John', age: '30', city: 'NY' },
+				{ name: 'Jane', age: '25', city: 'LA' },
+			]);
+		});
+
+		it('should find matching rows with OR combination and returnAllMatches is falsy at version 4.6', async () => {
+			const lookupValues = [
+				{ lookupColumn: 'age', lookupValue: '30' },
+				{ lookupColumn: 'name', lookupValue: 'Jane' },
+			];
+
+			const result = await googleSheet.lookupValues({
+				inputData,
+				keyRowIndex: 0,
+				dataStartRowIndex: 1,
+				lookupValues,
+				combineFilters: 'OR',
+				nodeVersion: 4.6,
+			});
+
+			expect(result).toEqual([{ name: 'John', age: '30', city: 'NY' }]);
+		});
+
+		it('should find matching rows with AND combination', async () => {
 			const lookupValues = [
 				{ lookupColumn: 'age', lookupValue: '30' },
 				{ lookupColumn: 'city', lookupValue: 'NY' },
@@ -148,21 +181,22 @@ describe('GoogleSheet', () => {
 				lookupValues,
 				returnAllMatches: true,
 				combineFilters: 'AND',
+				nodeVersion: 4.5,
 			});
 
 			expect(result).toEqual([{ name: 'John', age: '30', city: 'NY' }]);
 		});
 
 		it('should throw error for invalid key row', async () => {
-			const inputData = [['name', 'age']];
 			const lookupValues = [{ lookupColumn: 'age', lookupValue: '30' }];
 
 			await expect(
 				googleSheet.lookupValues({
-					inputData,
+					inputData: [['name', 'age']],
 					keyRowIndex: -1,
 					dataStartRowIndex: 1,
 					lookupValues,
+					nodeVersion: 4.5,
 				}),
 			).rejects.toThrow('The key row does not exist');
 		});

--- a/packages/nodes-base/nodes/Google/Sheet/test/v2/utils/utils.test.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/test/v2/utils/utils.test.ts
@@ -335,6 +335,7 @@ describe('Test Google Sheets, lookupValues', () => {
 			],
 			returnAllMatches: true,
 			combineFilters: 'OR',
+			nodeVersion: 4.5,
 		});
 
 		expect(result).toBeDefined();
@@ -397,6 +398,7 @@ describe('Test Google Sheets, lookupValues', () => {
 			],
 			returnAllMatches: true,
 			combineFilters: 'AND',
+			nodeVersion: 4.5,
 		});
 
 		expect(result).toBeDefined();

--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/read.operation.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/read.operation.ts
@@ -268,6 +268,7 @@ export async function execute(
 				lookupValues,
 				returnAllMatches,
 				combineFilters,
+				nodeVersion,
 			});
 		} else {
 			responseData = sheet.structureArrayDataByColumn(inputData, keyRowIndex, dataStartRowIndex);

--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/versionDescription.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/versionDescription.ts
@@ -9,7 +9,7 @@ export const versionDescription: INodeTypeDescription = {
 	name: 'googleSheets',
 	icon: 'file:googleSheets.svg',
 	group: ['input', 'output'],
-	version: [3, 4, 4.1, 4.2, 4.3, 4.4, 4.5],
+	version: [3, 4, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6],
 	subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
 	description: 'Read, update and write data to Google Sheets',
 	defaults: {

--- a/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheet.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheet.ts
@@ -651,12 +651,14 @@ export class GoogleSheet {
 		dataStartRowIndex,
 		lookupValues,
 		returnAllMatches,
+		nodeVersion,
 		combineFilters = 'OR',
 	}: {
 		inputData: string[][];
 		keyRowIndex: number;
 		dataStartRowIndex: number;
 		lookupValues: ILookupValues[];
+		nodeVersion: number;
 		returnAllMatches?: boolean;
 		combineFilters?: 'AND' | 'OR';
 	}): Promise<IDataObject[]> {
@@ -672,7 +674,7 @@ export class GoogleSheet {
 			keys.push(inputData[keyRowIndex][columnIndex] || `col_${columnIndex}`);
 		}
 
-		// Standardise values array, if rows is [[]], map it to [['']] (Keep the columns into consideration)
+		// Standardize values array, if rows is [[]], map it to [['']] (Keep the columns into consideration)
 		for (let rowIndex = 0; rowIndex < inputData?.length; rowIndex++) {
 			if (inputData[rowIndex].length === 0) {
 				for (let i = 0; i < keys.length; i++) {
@@ -718,6 +720,9 @@ export class GoogleSheet {
 						}
 
 						if (returnAllMatches !== true) {
+							if (nodeVersion >= 4.6) {
+								break lookupLoop;
+							}
 							continue lookupLoop;
 						}
 					}


### PR DESCRIPTION
## Summary

Return single row in read operation if combine conditions is OR and 'Return only First Matching Row'

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-2907/community-issue-google-sheets-get-rows-returns-multiple-rows-despite
closes https://github.com/n8n-io/n8n/issues/14901

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
