### PR TITLE
refactor(core): Overhaul community packages installation code

### DIFF
--- a/packages/cli/src/services/__tests__/community-packages.service.test.ts
+++ b/packages/cli/src/services/__tests__/community-packages.service.test.ts
@@ -3,7 +3,7 @@ import { InstalledNodes } from '@n8n/db';
 import { InstalledPackages } from '@n8n/db';
 import axios from 'axios';
 import { exec } from 'child_process';
-import { access as fsAccess, mkdir as fsMkdir } from 'fs/promises';
+import { mkdir as fsMkdir } from 'fs/promises';
 import { mocked } from 'jest-mock';
 import { mock } from 'jest-mock-extended';
 import type { PackageDirectoryLoader } from 'n8n-core';
@@ -128,7 +128,6 @@ describe('CommunityPackagesService', () => {
 
 	describe('executeCommand()', () => {
 		beforeEach(() => {
-			mocked(fsAccess).mockReset();
 			mocked(fsMkdir).mockReset();
 			mocked(exec).mockReset();
 		});
@@ -147,31 +146,17 @@ describe('CommunityPackagesService', () => {
 
 			await communityPackagesService.executeNpmCommand('ls');
 
-			expect(fsAccess).toHaveBeenCalled();
+			expect(fsMkdir).toHaveBeenCalled();
 			expect(exec).toHaveBeenCalled();
-			expect(fsMkdir).toBeCalledTimes(0);
 		});
 
 		test('should make sure folder exists', async () => {
 			mocked(exec).mockImplementation(execMock);
 
 			await communityPackagesService.executeNpmCommand('ls');
-			expect(fsAccess).toHaveBeenCalled();
-			expect(exec).toHaveBeenCalled();
-			expect(fsMkdir).toBeCalledTimes(0);
-		});
 
-		test('should try to create folder if it does not exist', async () => {
-			mocked(exec).mockImplementation(execMock);
-			mocked(fsAccess).mockImplementation(() => {
-				throw new Error('Folder does not exist.');
-			});
-
-			await communityPackagesService.executeNpmCommand('ls');
-
-			expect(fsAccess).toHaveBeenCalled();
-			expect(exec).toHaveBeenCalled();
 			expect(fsMkdir).toHaveBeenCalled();
+			expect(exec).toHaveBeenCalled();
 		});
 
 		test('should throw especial error when package is not found', async () => {
@@ -187,9 +172,8 @@ describe('CommunityPackagesService', () => {
 
 			await expect(call).rejects.toThrowError(RESPONSE_ERROR_MESSAGES.PACKAGE_NOT_FOUND);
 
-			expect(fsAccess).toHaveBeenCalled();
+			expect(fsMkdir).toHaveBeenCalled();
 			expect(exec).toHaveBeenCalled();
-			expect(fsMkdir).toHaveBeenCalledTimes(0);
 		});
 	});
 
@@ -406,7 +390,7 @@ describe('CommunityPackagesService', () => {
 			expect(exec).toHaveBeenCalledTimes(1);
 			expect(exec).toHaveBeenNthCalledWith(
 				1,
-				`npm install ${installedPackage.packageName}@latest --registry=some.random.host`,
+				`npm install ${installedPackage.packageName}@latest --audit=false --fund=false --bin-links=false --install-strategy=shallow --omit=dev --omit=optional --omit=peer --registry=some.random.host`,
 				expect.any(Object),
 				expect.any(Function),
 			);


### PR DESCRIPTION
## Summary

This PR changes how we install community nodes so that
1. We don't do an `npm init` anymore. we [added](https://github.com/n8n-io/n8n/pull/3934) that code to handle issues with versions of node that we haven't supported in a few years now.
2. We don't need to do an `access` check when trying to ensure that the `downloadFolder` exists. it's an unnecessary call that be avoided simply by switch to `mkdir -p`.
3. We use some explicit flags with `npm install` to ensure that
    - we do not install any dev, peer, or optional dependency
    - we so not symlink any `bin` scripts
    - every package is installed in an isolated manner, so that they all get their own copies of their dependencies
    - `audit` and `fund` steps are disabled, to speed up the installation process

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
