### PR TITLE
fix(editor): Fix sticky button disappearing on window resize

### DIFF
--- a/packages/frontend/editor-ui/src/components/Node/NodeCreation.vue
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreation.vue
@@ -88,14 +88,20 @@ function nodeTypeSelected(nodeTypes: string[]) {
 	closeNodeCreator(true);
 }
 
-onMounted(() => {
+function setWrapperRect() {
 	wrapperBoundingRect.value = wrapperRef.value?.getBoundingClientRect();
+}
+
+onMounted(() => {
+	setWrapperRect();
 
 	document.addEventListener('mousemove', onMouseMove);
+	window.addEventListener('resize', setWrapperRect);
 });
 
 onBeforeUnmount(() => {
 	document.removeEventListener('mousemove', onMouseMove);
+	window.removeEventListener('resize', setWrapperRect);
 });
 </script>
 


### PR DESCRIPTION
## Summary

The bug occurred because the component was calculating the wrapper's bounding rectangle only once during initial mounting. When the window was resized, the actual DOM element position would change, but the stored boundary values remained the same. This created a mismatch between where the component "thought" the button was and its actual position, causing the visibility detection to fail after any window resize.

The solution:
- Extracts the boundary calculation logic into a separate `setWrapperRect()` function
- Adds a window resize event listener that recalculates the button's boundary rectangle

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
