### PR TITLE
Fixed the error that when using s3 storage,  xlsx files will still be read from local

### DIFF
--- a/packages/nodes-base/nodes/SpreadsheetFile/v2/fromFile.operation.ts
+++ b/packages/nodes-base/nodes/SpreadsheetFile/v2/fromFile.operation.ts
@@ -124,18 +124,17 @@ export async function execute(
 				let workbook: WorkBook;
 				const xlsxOptions: ParsingOptions = { raw: options.rawData as boolean };
 				if (options.readAsString) xlsxOptions.type = 'string';
-
+				let binaryDataBuffer: Buffer;
 				if (binaryData.id) {
-					const binaryPath = this.helpers.getBinaryPath(binaryData.id);
-					workbook = xlsxReadFile(binaryPath, xlsxOptions);
+					// 兼容 S3，本地和 buffer 都走 getBinaryDataBuffer
+					binaryDataBuffer = await this.helpers.getBinaryDataBuffer(i, binaryPropertyName);
 				} else {
-					const binaryDataBuffer = Buffer.from(binaryData.data, BINARY_ENCODING);
-					workbook = xlsxRead(
-						options.readAsString ? binaryDataBuffer.toString() : binaryDataBuffer,
-						xlsxOptions,
-					);
+					binaryDataBuffer = Buffer.from(binaryData.data, BINARY_ENCODING);
 				}
-
+				workbook = xlsxRead(
+					options.readAsString ? binaryDataBuffer.toString() : binaryDataBuffer,
+					xlsxOptions,
+				);
 				if (workbook.SheetNames.length === 0) {
 					throw new NodeOperationError(this.getNode(), 'Spreadsheet does not have any sheets!', {
 						itemIndex: i,


### PR DESCRIPTION

## Summary
When using s3 storage, the xlsx file will still be read from the local error。

* Configure binary storage to S3
* Use Form to upload xlsx file
* Use extractFromFile to parse binary files

```
{
  "nodes": [
    {
      "parameters": {
        "formTitle": "test",
        "formDescription": "test",
        "formFields": {
          "values": [
            {
              "fieldLabel": "file",
              "fieldType": "file",
              "multipleFiles": false
            }
          ]
        },
        "options": {}
      },
      "type": "n8n-nodes-base.formTrigger",
      "typeVersion": 2.2,
      "position": [
        120,
        -160
      ],
      "id": "1f7946b9-765b-48b0-a0fc-53610fbcfe23",
      "name": "On form submission",
      "webhookId": "49c8551c-bb06-4505-8bac-095d588dab85"
    },
    {
      "parameters": {
        "operation": "xls",
        "binaryPropertyName": "file",
        "options": {}
      },
      "type": "n8n-nodes-base.extractFromFile",
      "typeVersion": 1,
      "position": [
        500,
        -160
      ],
      "id": "6213d6a7-ae49-4114-870a-01c8d238971c",
      "name": "Extract from File"
    }
  ],
  "connections": {
    "On form submission": {
      "main": [
        [
          {
            "node": "Extract from File",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {},
  "meta": {
    "instanceId": "79382c345468f35913859b8a1f3642892cee8903669bf4def37f72fad2645c44"
  }
}
```

### error message
```
2025-05-06T03:02:16.658Z | info | Worker started execution 56 (job 55) {"scopes":["scaling"],"executionId":"56","jobId":"55","file":"job-processor.js","function":"processJob"}
2025-05-06T03:02:16.661Z | debug | Execution ID 56 is a partial execution. {"executionId":"56","file":"manual-execution.service.js","function":"runManually"}
2025-05-06T03:02:16.663Z | debug | Workflow execution started {"workflowId":"8wPGH3luXma3xt5F","file":"LoggerProxy.js","function":"exports.debug"}
2025-05-06T03:02:16.664Z | debug | Executing hook (hookFunctionsPush) {"executionId":"56","pushRef":"ve1atzlawv","workflowId":"8wPGH3luXma3xt5F","file":"execution-lifecycle-hooks.js"}
2025-05-06T03:02:16.664Z | debug | Start executing node "Extract from File" {"node":"Extract from File","workflowId":"8wPGH3luXma3xt5F","file":"LoggerProxy.js","function":"exports.debug"}
2025-05-06T03:02:16.665Z | debug | Executing hook on node "Extract from File" (hookFunctionsPush) {"executionId":"56","pushRef":"ve1atzlawv","workflowId":"8wPGH3luXma3xt5F","file":"execution-lifecycle-hooks.js"}
2025-05-06T03:02:16.665Z | debug | Running node "Extract from File" started {"node":"Extract from File","workflowId":"8wPGH3luXma3xt5F","file":"LoggerProxy.js","function":"exports.debug"}
2025-05-06T03:02:16.666Z | error | ENOENT: no such file or directory, open 'workflows/8wPGH3luXma3xt5F/executions/temp/binary_data/7b58812b-a2a9-4434-8860-ed101cfd6d9a' {"file":"error-reporter.js","function":"defaultReport"}
```

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
