### PR TITLE
fix(editor): Increase hover delay and hit area for canvas toolbar edge

### DIFF
--- a/packages/frontend/editor-ui/src/components/canvas/elements/edges/CanvasEdge.test.ts
+++ b/packages/frontend/editor-ui/src/components/canvas/elements/edges/CanvasEdge.test.ts
@@ -90,7 +90,7 @@ describe('CanvasEdge', () => {
 		await user.unhover(getByTestId('edge-label'));
 		expect(getByTestId('canvas-edge-toolbar')).toBeInTheDocument();
 
-		await vi.advanceTimersByTimeAsync(300);
+		await vi.advanceTimersByTimeAsync(600);
 
 		expect(queryByTestId('canvas-edge-toolbar')).not.toBeInTheDocument();
 	});

--- a/packages/frontend/editor-ui/src/components/canvas/elements/edges/CanvasEdge.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/elements/edges/CanvasEdge.vue
@@ -35,7 +35,7 @@ const connectionType = computed(() =>
 
 const delayedHovered = ref(props.hovered);
 const delayedHoveredSetTimeoutRef = ref<NodeJS.Timeout | null>(null);
-const delayedHoveredTimeout = 300;
+const delayedHoveredTimeout = 600;
 
 watch(
 	() => props.hovered,

--- a/packages/frontend/editor-ui/src/components/canvas/elements/edges/CanvasEdgeToolbar.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/elements/edges/CanvasEdgeToolbar.vue
@@ -63,6 +63,7 @@ function onDelete() {
 	align-items: center;
 	gap: var(--spacing-2xs);
 	pointer-events: all;
+	padding: var(--spacing-l);
 }
 </style>
 


### PR DESCRIPTION
## Summary

The 'add' and 'delete' buttons weren't reliably appearing when hovering over connectors, particularly on sloped connectors. To fix this we:

- Increase hover detection timeout from 300ms to 600ms to provide more stable button visibility
- Add padding to the connector toolbar to create a larger hit area for mouse interaction

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
