### PR TITLE
feat(core): Improve nodeNameToToolName special characters normalization

### DIFF
--- a/packages/@n8n/nodes-langchain/utils/helpers.ts
+++ b/packages/@n8n/nodes-langchain/utils/helpers.ts
@@ -251,6 +251,10 @@ export function unwrapNestedOutput(output: Record<string, unknown>): Record<stri
 	return output;
 }
 
+/**
+ * Converts a node name to a valid tool name by replacing special characters with underscores
+ * and collapsing consecutive underscores into a single one.
+ */
 export function nodeNameToToolName(node: INode): string {
-	return node.name.replace(/ /g, '_');
+	return node.name.replace(/[\s.?!=+#@&*()[\]{}:;,<>\/\\'"^%$]/g, '_').replace(/_+/g, '_');
 }

--- a/packages/@n8n/nodes-langchain/utils/tests/helpers.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/tests/helpers.test.ts
@@ -5,8 +5,61 @@ import { NodeOperationError } from 'n8n-workflow';
 import type { ISupplyDataFunctions, IExecuteFunctions, INode } from 'n8n-workflow';
 import { z } from 'zod';
 
-import { escapeSingleCurlyBrackets, getConnectedTools, unwrapNestedOutput } from '../helpers';
+import {
+	escapeSingleCurlyBrackets,
+	getConnectedTools,
+	nodeNameToToolName,
+	unwrapNestedOutput,
+} from '../helpers';
 import { N8nTool } from '../N8nTool';
+
+describe('nodeNameToToolName', () => {
+	const getNodeWithName = (name: string): INode => ({
+		id: 'test-node',
+		name,
+		type: 'test',
+		typeVersion: 1,
+		position: [0, 0] as [number, number],
+		parameters: {},
+	});
+	it('should replace spaces with underscores', () => {
+		expect(nodeNameToToolName(getNodeWithName('Test Node'))).toBe('Test_Node');
+	});
+
+	it('should replace dots with underscores', () => {
+		expect(nodeNameToToolName(getNodeWithName('Test.Node'))).toBe('Test_Node');
+	});
+
+	it('should replace question marks with underscores', () => {
+		expect(nodeNameToToolName(getNodeWithName('Test?Node'))).toBe('Test_Node');
+	});
+
+	it('should replace exclamation marks with underscores', () => {
+		expect(nodeNameToToolName(getNodeWithName('Test!Node'))).toBe('Test_Node');
+	});
+
+	it('should replace equals signs with underscores', () => {
+		expect(nodeNameToToolName(getNodeWithName('Test=Node'))).toBe('Test_Node');
+	});
+
+	it('should replace multiple special characters with underscores', () => {
+		expect(nodeNameToToolName(getNodeWithName('Test.Node?With!Special=Chars'))).toBe(
+			'Test_Node_With_Special_Chars',
+		);
+	});
+
+	it('should handle names that already have underscores', () => {
+		expect(nodeNameToToolName(getNodeWithName('Test_Node'))).toBe('Test_Node');
+	});
+
+	it('should handle names with consecutive special characters', () => {
+		expect(nodeNameToToolName(getNodeWithName('Test..!!??==Node'))).toBe('Test_Node');
+	});
+
+	it('should replace various special characters with underscores', () => {
+		expect(nodeNameToToolName(getNodeWithName('Test#+*()[]{}:;,<>/\\\'"%$Node'))).toBe('Test_Node');
+	});
+});
 
 describe('escapeSingleCurlyBrackets', () => {
 	it('should return undefined when input is undefined', () => {
@@ -166,7 +219,7 @@ describe('getConnectedTools', () => {
 			name: 'Test Node',
 			type: 'test',
 			typeVersion: 1,
-			position: [0, 0],
+			position: [0, 0] as [number, number],
 			parameters: {},
 		};
 

--- a/packages/core/src/execution-engine/node-execution-context/utils/create-node-as-tool.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/create-node-as-tool.ts
@@ -108,8 +108,13 @@ function makeDescription(node: INode, nodeType: INodeType): string {
 	return (node.parameters.toolDescription as string) ?? nodeType.description.description;
 }
 
+/**
+ * Converts a node name to a valid tool name by replacing special characters with underscores
+ * and collapsing consecutive underscores into a single one.
+ * This method is copied from `packages/@n8n/nodes-langchain/utils/helpers.ts`.
+ */
 export function nodeNameToToolName(node: INode): string {
-	return node.name.replace(/ /g, '_');
+	return node.name.replace(/[\s.?!=+#@&*()[\]{}:;,<>\/\\'"^%$]/g, '_').replace(/_+/g, '_');
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR improves how node names are converted to tool names by handling a wider range of special characters. The enhanced `nodeNameToToolName` function:

- Replaces all potentially problematic special characters with underscores
- Collapses consecutive special characters into a single underscore

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
