### PR TITLE
fix: Folders typo in modal (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/frontend/editor-ui/src/plugins/i18n/locales/en.json
@@ -2954,7 +2954,7 @@
 	"communityPlusModal.features.third.title": "Execution search and tagging",
 	"communityPlusModal.features.third.description": "Search and organize past workflow executions for easier review",
 	"communityPlusModal.features.fourth.title": "Folders",
-	"communityPlusModal.features.fourth.description": "Organize your workflows in a nested folder structrue",
+	"communityPlusModal.features.fourth.description": "Organize your workflows in a nested folder structure",
 	"communityPlusModal.input.email.label": "Enter email to receive your license key",
 	"communityPlusModal.button.skip": "Skip",
 	"communityPlusModal.button.confirm": "Send me a free license key",


### PR DESCRIPTION
## Summary

Fixes typo in modal.

## Related Linear tickets, Github issues, and Community forum posts

Fixes: https://github.com/n8n-io/n8n/issues/15084
Fixes: PAY-2806

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- ~[ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- ~[ ] Tests included.~
- ~[ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
