### PR TITLE
feat(core): Add TikTok OAuth2 support with hex PKCE challenge

### DIFF
--- a/packages/@n8n/client-oauth2/src/ClientOAuth2.ts
+++ b/packages/@n8n/client-oauth2/src/ClientOAuth2.ts
@@ -35,6 +35,7 @@ export interface ClientOAuth2Options {
 	body?: Record<string, any>;
 	query?: qs.ParsedUrlQuery;
 	ignoreSSLIssues?: boolean;
+	pkceChallengeFormat?: 'base64' | 'hex';
 }
 
 export class ResponseError extends Error {

--- a/packages/@n8n/client-oauth2/src/types.ts
+++ b/packages/@n8n/client-oauth2/src/types.ts
@@ -17,6 +17,7 @@ export interface OAuth2CredentialData {
 		access_token: string;
 		refresh_token?: string;
 	};
+	pkceChallengeFormat?: 'hex' | 'base64';
 }
 
 /**

--- a/packages/nodes-base/credentials/TikTokOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/TikTokOAuth2Api.credentials.ts
@@ -1,0 +1,68 @@
+import { ICredentialType, INodeProperties } from 'n8n-workflow';
+
+const scopes = ['user.info.basic', 'video.publish', 'video.upload'];
+
+export class TikTokOAuth2Api implements ICredentialType {
+	name = 'tikTokOAuth2Api';
+	extends = ['oAuth2Api'];
+	displayName = 'TikTok OAuth2 API';
+	documentationUrl = 'https://developers.tiktok.com/doc/login-kit-web/';
+
+	properties: INodeProperties[] = [
+		{
+			displayName: 'Scope',
+			name: 'scope',
+			type: 'string',
+			default: `${scopes.join(',')}`,
+		},
+		{
+			displayName: 'Grant Type',
+			name: 'grantType',
+			type: 'hidden',
+			default: 'pkce',
+		},
+		{
+			displayName: 'Authorization URL',
+			name: 'authUrl',
+			type: 'hidden',
+			default: 'https://www.tiktok.com/v2/auth/authorize',
+		},
+		{
+			displayName: 'Access Token URL',
+			name: 'accessTokenUrl',
+			type: 'hidden',
+			default: 'https://open.tiktokapis.com/v2/oauth/token/',
+		},
+		{
+			displayName: 'Authentication',
+			name: 'authentication',
+			type: 'hidden',
+			default: 'header',
+		},
+		{
+			displayName: 'Client Key',
+			name: 'clientId',
+			type: 'string',
+			default: '',
+			required: true,
+		},
+		{
+			displayName: 'Auth URI Query Parameters',
+			name: 'authQueryParameters',
+			type: 'hidden',
+			default: '={{"client_key=" + $self.clientId}}',
+		},
+		{
+			displayName: 'Additional Body Properties',
+			name: 'additionalBodyProperties',
+			type: 'hidden',
+			default: `={{'{"client_key":"' + $self.clientId + '", "client_secret":"' + $self.clientSecret + '"}'}}`,
+		},
+		{
+			displayName: 'PKCE Challenge Format',
+			name: 'pkceChallengeFormat',
+			type: 'hidden',
+			default: 'hex',
+		},
+	];
+}

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -354,6 +354,7 @@
       "dist/credentials/TelegramApi.credentials.js",
       "dist/credentials/TheHiveProjectApi.credentials.js",
       "dist/credentials/TheHiveApi.credentials.js",
+      "dist/credentials/TikTokOAuth2Api.credentials.js",
       "dist/credentials/TimescaleDb.credentials.js",
       "dist/credentials/TodoistApi.credentials.js",
       "dist/credentials/TodoistOAuth2Api.credentials.js",


### PR DESCRIPTION
## Summary

This PR adds OAuth2 compatibility for TikTok by introducing support for a custom `code_challenge` format (`hex`) in the OAuth2 credential implementation. TikTok's PKCE flow requires the code challenge to be in `hex` format instead of the default `base64`.

Additionally, a new credential `TikTok OAuth2 API` was created that leverages this functionality, allowing users to authenticate with TikTok's API using the correct PKCE configuration.

### How to test:

* Create a new TikTok OAuth2 credential.
* Confirm the `code_challenge` generated uses `hex` encoding.
* Complete the TikTok OAuth2 flow successfully.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
