### PR TITLE
feat(Wordpress Node): User Roles support for User

### DIFF
--- a/packages/nodes-base/nodes/Wordpress/UserDescription.ts
+++ b/packages/nodes-base/nodes/Wordpress/UserDescription.ts
@@ -172,6 +172,35 @@ export const userFields: INodeProperties[] = [
 				default: '',
 				description: 'An alphanumeric identifier for the user',
 			},
+			{
+				displayName: 'Roles',
+				name: 'roles',
+				type: 'options',
+				options: [
+					{
+						name: 'Administrator',
+						value: 'administrator',
+					}
+					{
+						name: 'Editor',
+						value: 'editor',
+					}
+					{
+						name: 'Author',
+						value: 'author',
+					}
+					{
+						name: 'Contributor',
+						value: 'contributor',
+					}
+					{
+						name: 'Subscriber',
+						value: 'subscriber',
+					}
+				],
+				default: 'subscriber',
+				description: 'The role for the new user',
+			}
 		],
 	},
 	/* -------------------------------------------------------------------------- */
@@ -276,6 +305,35 @@ export const userFields: INodeProperties[] = [
 				default: '',
 				description: 'An alphanumeric identifier for the user',
 			},
+			{
+				displayName: 'Roles',
+				name: 'roles',
+				type: 'options',
+				options: [
+					{
+						name: 'Administrator',
+						value: 'administrator',
+					}
+					{
+						name: 'Editor',
+						value: 'editor',
+					}
+					{
+						name: 'Author',
+						value: 'author',
+					}
+					{
+						name: 'Contributor',
+						value: 'contributor',
+					}
+					{
+						name: 'Subscriber',
+						value: 'subscriber',
+					}
+				],
+				default: 'subscriber',
+				description: 'Update the role for the existing user',
+			}
 		],
 	},
 	/* -------------------------------------------------------------------------- */

--- a/packages/nodes-base/nodes/Wordpress/UserDescription.ts
+++ b/packages/nodes-base/nodes/Wordpress/UserDescription.ts
@@ -313,7 +313,7 @@ export const userFields: INodeProperties[] = [
 					{
 						name: 'Administrator',
 						value: 'administrator',
-					}
+					},
 					{
 						name: 'Editor',
 						value: 'editor',

--- a/packages/nodes-base/nodes/Wordpress/UserDescription.ts
+++ b/packages/nodes-base/nodes/Wordpress/UserDescription.ts
@@ -175,24 +175,24 @@ export const userFields: INodeProperties[] = [
 			{
 				displayName: 'Roles',
 				name: 'roles',
-				type: 'options',
+				type: 'multiOptions',
 				options: [
 					{
 						name: 'Administrator',
 						value: 'administrator',
-					}
+					},
 					{
 						name: 'Editor',
 						value: 'editor',
-					}
+					},
 					{
 						name: 'Author',
 						value: 'author',
-					}
+					},
 					{
 						name: 'Contributor',
 						value: 'contributor',
-					}
+					},
 					{
 						name: 'Subscriber',
 						value: 'subscriber',
@@ -308,7 +308,7 @@ export const userFields: INodeProperties[] = [
 			{
 				displayName: 'Roles',
 				name: 'roles',
-				type: 'options',
+				type: 'multiOptions',
 				options: [
 					{
 						name: 'Administrator',
@@ -317,15 +317,15 @@ export const userFields: INodeProperties[] = [
 					{
 						name: 'Editor',
 						value: 'editor',
-					}
+					},
 					{
 						name: 'Author',
 						value: 'author',
-					}
+					},
 					{
 						name: 'Contributor',
 						value: 'contributor',
-					}
+					},
 					{
 						name: 'Subscriber',
 						value: 'subscriber',

--- a/packages/nodes-base/nodes/Wordpress/UserInterface.ts
+++ b/packages/nodes-base/nodes/Wordpress/UserInterface.ts
@@ -10,4 +10,5 @@ export interface IUser {
 	url?: string;
 	description?: string;
 	password?: string;
+	roles?: number[];
 }

--- a/packages/nodes-base/nodes/Wordpress/Wordpress.node.ts
+++ b/packages/nodes-base/nodes/Wordpress/Wordpress.node.ts
@@ -511,6 +511,9 @@ export class Wordpress implements INodeType {
 						if (additionalFields.slug) {
 							body.slug = additionalFields.slug as string;
 						}
+						if (additionalFields.roles) {
+							body.roles = additionalFields.roles as number[];
+						}
 						responseData = await wordpressApiRequest.call(this, 'POST', '/users', body);
 					}
 					//https://developer.wordpress.org/rest-api/reference/users/#update-a-user
@@ -549,6 +552,9 @@ export class Wordpress implements INodeType {
 						}
 						if (updateFields.slug) {
 							body.slug = updateFields.slug as string;
+						}
+						if (updateFields.roles) {
+							body.roles = updateFields.roles as number[];
 						}
 						responseData = await wordpressApiRequest.call(this, 'POST', `/users/${userId}`, body);
 					}

--- a/packages/nodes-base/nodes/Wordpress/__tests__/workflow/apiResponses.ts
+++ b/packages/nodes-base/nodes/Wordpress/__tests__/workflow/apiResponses.ts
@@ -565,15 +565,20 @@ export const userCreate = {
 	locale: 'en_GB',
 	nickname: 'new-user',
 	slug: 'new-user',
-	roles: ['subscriber'],
+	roles: ['subscriber', 'contributor'],
 	registered_date: '2025-03-27T19:49:07+00:00',
 	capabilities: {
 		read: true,
 		level_0: true,
+		edit_posts: true,
+		level_1: true,
+		delete_posts: true,
 		subscriber: true,
+		contributor: true,
 	},
 	extra_capabilities: {
 		subscriber: true,
+		contributor: true,
 	},
 	avatar_urls: {
 		'24': 'https://secure.gravatar.com/avatar/6eabaa023affb379ccfd92d522ab0e37?s=24&d=mm&r=g',

--- a/packages/nodes-base/nodes/Wordpress/__tests__/workflow/user/user.test.ts
+++ b/packages/nodes-base/nodes/Wordpress/__tests__/workflow/user/user.test.ts
@@ -15,6 +15,7 @@ describe('Wordpress > User Workflows', () => {
 				last_name: 'Tester',
 				email: 'nathan@domain.com',
 				password: 'fake-password',
+				roles:	['subscriber', 'contributor'],
 			})
 			.reply(200, userCreate);
 		mock.get('/wp-json/wp/v2/users/2').query({ context: 'view' }).reply(200, userGet);
@@ -26,6 +27,7 @@ describe('Wordpress > User Workflows', () => {
 				first_name: 'Name',
 				last_name: 'Change',
 				nickname: 'newuser',
+				roles:	['subscriber'],
 			})
 			.reply(200, userUpdate);
 	});

--- a/packages/nodes-base/nodes/Wordpress/__tests__/workflow/user/user.test.ts
+++ b/packages/nodes-base/nodes/Wordpress/__tests__/workflow/user/user.test.ts
@@ -15,7 +15,7 @@ describe('Wordpress > User Workflows', () => {
 				last_name: 'Tester',
 				email: 'nathan@domain.com',
 				password: 'fake-password',
-				roles:	['subscriber', 'contributor'],
+				roles: ['subscriber', 'contributor'],
 			})
 			.reply(200, userCreate);
 		mock.get('/wp-json/wp/v2/users/2').query({ context: 'view' }).reply(200, userGet);
@@ -27,7 +27,7 @@ describe('Wordpress > User Workflows', () => {
 				first_name: 'Name',
 				last_name: 'Change',
 				nickname: 'newuser',
-				roles:	['subscriber'],
+				roles: ['subscriber'],
 			})
 			.reply(200, userUpdate);
 	});

--- a/packages/nodes-base/nodes/Wordpress/__tests__/workflow/user/user.workflow.json
+++ b/packages/nodes-base/nodes/Wordpress/__tests__/workflow/user/user.workflow.json
@@ -18,7 +18,9 @@
 				"lastName": "Tester",
 				"email": "nathan@domain.com",
 				"password": "fake-password",
-				"additionalFields": {}
+				"additionalFields": {
+					"roles": ["subscriber", "contributor"]
+				}
 			},
 			"type": "n8n-nodes-base.wordpress",
 			"typeVersion": 1,
@@ -107,7 +109,8 @@
 					"name": "Name Change",
 					"firstName": "Name",
 					"lastName": "Change",
-					"nickname": "newuser"
+					"nickname": "newuser",
+					"roles": ["subscriber"]
 				}
 			},
 			"type": "n8n-nodes-base.wordpress",
@@ -147,15 +150,20 @@
 					"locale": "en_GB",
 					"nickname": "new-user",
 					"slug": "new-user",
-					"roles": ["subscriber"],
+					"roles": ["subscriber", "contributor"],
 					"registered_date": "2025-03-27T19:49:07+00:00",
 					"capabilities": {
 						"read": true,
 						"level_0": true,
-						"subscriber": true
+						"edit_posts": true,
+						"level_1": true,
+						"delete_posts": true,
+						"subscriber": true,
+						"contributor": true
 					},
 					"extra_capabilities": {
-						"subscriber": true
+						"subscriber": true,
+						"contributor": true
 					},
 					"avatar_urls": {
 						"24": "https://secure.gravatar.com/avatar/6eabaa023affb379ccfd92d522ab0e37?s=24&d=mm&r=g",

--- a/packages/nodes-base/nodes/Wordpress/__tests__/workflow/user/user.workflow.json
+++ b/packages/nodes-base/nodes/Wordpress/__tests__/workflow/user/user.workflow.json
@@ -200,6 +200,7 @@
 					"description": "",
 					"link": "https://myblog.com/author/new-user/",
 					"slug": "new-user",
+					"roles": ["subscriber", "contributor"],
 					"avatar_urls": {
 						"24": "https://secure.gravatar.com/avatar/6eabaa023affb379ccfd92d522ab0e37?s=24&d=mm&r=g",
 						"48": "https://secure.gravatar.com/avatar/6eabaa023affb379ccfd92d522ab0e37?s=48&d=mm&r=g",
@@ -233,6 +234,7 @@
 					"description": "",
 					"link": "https://myblog.com/author/nodeqa/",
 					"slug": "nodeqa",
+					"roles": ["administrator"],
 					"avatar_urls": {
 						"24": "https://secure.gravatar.com/avatar/de2d127be16acfb3d435ff80b5e13687?s=24&d=mm&r=g",
 						"48": "https://secure.gravatar.com/avatar/de2d127be16acfb3d435ff80b5e13687?s=48&d=mm&r=g",


### PR DESCRIPTION
## Summary
Added support for User Role field in the Wordpress node. When creating new User can select the role for the user from the field. Also can update the role for existing user from the update field.
<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
N/A
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
