### PR TITLE
fix(core): Prioritize workflow execution with existing execution data on worker

### DIFF
--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -170,7 +170,10 @@ export class JobProcessor {
 
 		const { startData, resultData, manualData, isTestWebhook } = execution.data;
 
-		if (['manual', 'evaluation'].includes(execution.mode) && !isTestWebhook) {
+		if (execution.data?.executionData) {
+			workflowExecute = new WorkflowExecute(additionalData, execution.mode, execution.data);
+			workflowRun = workflowExecute.processRunExecutionData(workflow);
+		} else if (['manual', 'evaluation'].includes(execution.mode) && !isTestWebhook) {
 			const data: IWorkflowExecutionDataProcess = {
 				executionMode: execution.mode,
 				workflowData: execution.workflowData,
@@ -211,9 +214,6 @@ export class JobProcessor {
 				}
 				throw error;
 			}
-		} else if (execution.data !== undefined) {
-			workflowExecute = new WorkflowExecute(additionalData, execution.mode, execution.data);
-			workflowRun = workflowExecute.processRunExecutionData(workflow);
 		} else {
 			this.errorReporter.info(`Worker found execution ${executionId} without data`);
 			// Execute all nodes


### PR DESCRIPTION
## Summary

This PR fixes the issue of wait node not working in queue mode and OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS=true on manual execution.
What happens is that the worker re-executes the flow from the manual trigger, and re-executes the wait node, thus leading to an infinite wait / resume / wait / resume / ... loop.

Indeed, manual executions when running in the workers are always "restarted" from the manual execution context: https://github.com/n8n-io/n8n/blob/n8n%401.91.2/packages/cli/src/scaling/job-processor.ts#L173

But wait resume workflow are a special kind of manual executions that need to keep certain execution data to resume properly:
- the `waitTill` is necessary for the execution engine to know to proceed with the wait node directly (and disable it to prevent re-execution)
- the nodeExecutionStack is necessary to start from the wait node directly
See: https://github.com/n8n-io/n8n/blob/n8n%401.91.2/packages/core/src/execution-engine/workflow-execute.ts#L1322

I decided to fix that by applying the same "priority" logic on workflow execution from the job processor than for the runMainProcess (without worker): https://github.com/n8n-io/n8n/blob/n8n%401.91.2/packages/cli/src/workflow-runner.ts#L271
- if there is the necessary existing executionData, just run from that (I check the existence of `execution.data?.executionData` because just `execution.data` is not enough to run from it)
- otherwise, run manually as before

I ran some manual tests, but I'm not 100% sure about the potential regressions with this logic change.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2793/bug-wait-node-cant-wait-for-a-time-more-than-60s-in-the-future-extra

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
