### PR TITLE
fix(core): Do not cache dynamic webhooks

### DIFF
--- a/packages/cli/src/webhooks/__tests__/webhook.service.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook.service.test.ts
@@ -360,4 +360,30 @@ describe('WebhookService', () => {
 			expect(nodeType.webhook).toHaveBeenCalled();
 		});
 	});
+
+	describe('findCached()', () => {
+		test('should not cache dynamic webhooks', async () => {
+			const method = 'GET';
+			const webhookId = uuid();
+			const fullPath = `${webhookId}/user/123/posts`;
+			const dynamicWebhook = createWebhook(method, 'user/:id/posts', webhookId, 3);
+
+			webhookRepository.findOneBy.mockResolvedValueOnce(null); // static lookup
+			webhookRepository.findBy.mockResolvedValueOnce([dynamicWebhook]); // dynamic lookup
+
+			const result1 = await webhookService.findWebhook(method, fullPath);
+			expect(result1).toBe(dynamicWebhook);
+
+			expect(cacheService.set).not.toHaveBeenCalled();
+
+			webhookRepository.findOneBy.mockResolvedValueOnce(null);
+			webhookRepository.findBy.mockResolvedValueOnce([dynamicWebhook]);
+
+			const result2 = await webhookService.findWebhook(method, fullPath);
+			expect(result2).toBe(dynamicWebhook);
+
+			expect(webhookRepository.findOneBy).toHaveBeenCalledTimes(2);
+			expect(webhookRepository.findBy).toHaveBeenCalledTimes(2);
+		});
+	});
 });

--- a/packages/cli/src/webhooks/webhook.service.ts
+++ b/packages/cli/src/webhooks/webhook.service.ts
@@ -41,19 +41,18 @@ export class WebhookService {
 	private async findCached(method: Method, path: string) {
 		const cacheKey = `webhook:${method}-${path}`;
 
-		const cachedWebhook = await this.cacheService.get(cacheKey);
+		const cachedStaticWebhook = await this.cacheService.get(cacheKey);
 
-		if (cachedWebhook) return this.webhookRepository.create(cachedWebhook);
+		if (cachedStaticWebhook) return this.webhookRepository.create(cachedStaticWebhook);
 
-		let dbWebhook = await this.findStaticWebhook(method, path);
+		const dbStaticWebhook = await this.findStaticWebhook(method, path);
 
-		if (dbWebhook === null) {
-			dbWebhook = await this.findDynamicWebhook(method, path);
+		if (dbStaticWebhook) {
+			void this.cacheService.set(cacheKey, dbStaticWebhook);
+			return dbStaticWebhook;
 		}
 
-		void this.cacheService.set(cacheKey, dbWebhook);
-
-		return dbWebhook;
+		return await this.findDynamicWebhook(method, path);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR stops caching dynamic webhooks. Dynamic webhooks contain variable path segments that change between requests, so caching is likely to be a miss and lead to bloat. Also, if lookup returns `null` then that `null` result is currently being cached.

## Related Linear tickets, Github issues, and Community forum posts

Related to https://linear.app/n8n/issue/CAT-772 but likely not the root cause.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
