### PR TITLE
fix(Code Node): Update pyodide sandbox context to fix micropip regressions

### DIFF
--- a/packages/nodes-base/nodes/Code/Pyodide.ts
+++ b/packages/nodes-base/nodes/Code/Pyodide.ts
@@ -14,8 +14,11 @@ export async function LoadPyodide(packageCacheDir: string): Promise<PyodideInter
 			indexURL,
 			packageCacheDir,
 			jsglobals: {
-				Object,
 				console,
+				fetch,
+				AbortController,
+				AbortSignal,
+				Object,
 				XMLHttpRequest,
 			},
 		});


### PR DESCRIPTION
## Summary
Micropip (and the http requests stack) in pyodide [needs](https://github.com/pyodide/pyodide/blob/0.27.5/src/py/pyodide/http.py#L13-L14) these additional globals to work.

This broke in #14356 because we started sandboxing pyodide, but did not allow these additional globals on the sanbox.

## Related Linear tickets, Github issues, and Community forum posts

CAT-777
Fixes #15150

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
