### PR TITLE
fix(editor): Issue with context menu disabling most options when importing template

### DIFF
--- a/packages/frontend/editor-ui/src/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasOperations.test.ts
@@ -3002,7 +3002,7 @@ describe('useCanvasOperations', () => {
 				disabled: false,
 			});
 			expect(workflowsStore.setNodePristine).toHaveBeenCalledWith(nodeB.name, true);
-			expect(workflowsStore.getNewWorkflowData).toHaveBeenCalledWith(
+			expect(workflowsStore.getNewWorkflowDataAndMakeShareable).toHaveBeenCalledWith(
 				templateName,
 				projectsStore.currentProjectId,
 			);

--- a/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
@@ -2005,6 +2005,7 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 		await addNodes(convertedNodes ?? []);
 		await workflowsStore.getNewWorkflowData(name, projectsStore.currentProjectId);
 		workflowsStore.addToWorkflowMetadata({ templateId: `${id}` });
+		workflowsStore.makeNewWorkflowShareable();
 	}
 
 	return {

--- a/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
@@ -2003,9 +2003,8 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 			workflowsStore.setConnections(workflow.connections);
 		}
 		await addNodes(convertedNodes ?? []);
-		await workflowsStore.getNewWorkflowData(name, projectsStore.currentProjectId);
+		await workflowsStore.getNewWorkflowDataAndMakeShareable(name, projectsStore.currentProjectId);
 		workflowsStore.addToWorkflowMetadata({ templateId: `${id}` });
-		workflowsStore.makeNewWorkflowShareable();
 	}
 
 	return {

--- a/packages/frontend/editor-ui/src/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/stores/workflows.store.ts
@@ -630,6 +630,16 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		return workflowData;
 	}
 
+	async function getNewWorkflowDataAndMakeShareable(
+		name?: string,
+		projectId?: string,
+		parentFolderId?: string,
+	): Promise<INewWorkflowData> {
+		const workflowData = await getNewWorkflowData(name, projectId, parentFolderId);
+		makeNewWorkflowShareable();
+		return workflowData;
+	}
+
 	function makeNewWorkflowShareable() {
 		const { currentProject, personalProject } = useProjectsStore();
 		const homeProject = currentProject ?? personalProject ?? {};
@@ -1961,6 +1971,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		markExecutionAsStopped,
 		findNodeByPartialId,
 		getPartialIdForNode,
+		getNewWorkflowDataAndMakeShareable,
 		totalWorkflowCount,
 	};
 });

--- a/packages/frontend/editor-ui/src/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/views/NodeView.vue
@@ -380,12 +380,11 @@ async function initializeWorkspaceForNewWorkflow() {
 
 	const parentFolderId = route.query.parentFolderId as string | undefined;
 
-	await workflowsStore.getNewWorkflowData(
+	await workflowsStore.getNewWorkflowDataAndMakeShareable(
 		undefined,
 		projectsStore.currentProjectId,
 		parentFolderId,
 	);
-	workflowsStore.makeNewWorkflowShareable();
 
 	if (projectsStore.currentProjectId) {
 		await fetchAndSetProject(projectsStore.currentProjectId);


### PR DESCRIPTION
## Summary

When creating a new workflow from a template, right-clicking on nodes shows most context menu options disabled. This issue occurs specifically in the following flow:

1. User clicks "get started with n8n cloud" → redirected to `https://app.n8n.cloud/register?templateId=1747`
2. After redirection to user instance at `https://[instance].app.n8n.cloud/templates/1747/setup`
3. For templates without credential requirements → redirects to `https://[instance].app.n8n.cloud/workflow/new?templateId=1750`
4. When the workflow renders, right-clicking on node shows most context menu options disabled

### Root Cause
The `ContextMenu.vue` component relies on the `useContextMenu()` composable, which uses the `isReadOnly` computed property to determine which options are enabled:

```typescript
const  isReadOnly = computed(
    () =>
        sourceControlStore.preferences.branchReadOnly ||
        uiStore.isReadOnlyView ||
        !workflowPermissions.value.update ||
        workflowsStore.workflow.isArchived,
);
```

When creating a workflow from a template, we weren't making the workflow shareable (basically adding all scopes for the role), causing `!workflowPermissions.value.update` to return true, which disabled most context menu actions.

### Solution

Created a new combined method `getNewWorkflowDataAndMakeShareable` that combines getting new workflow data and making it shareable, as these two are frequently used together.

### Testing

1. Import a template by going to `http://localhost:8080/templates/1747/setup`. Template ID does't matter as long as it's a valid one.
2. Right-click on any node in the workflow.
3. Verify that context menu options are properly enabled.
4. Test various context menu actions to ensure they function correctly.
5. Verify manually created workflows still function as expected.

### Before:

![CleanShot 2025-05-07 at 13 29 25](https://github.com/user-attachments/assets/54f7cff4-0f86-4161-b473-c6291318fb6e)

### Now:

![CleanShot 2025-05-07 at 13 27 21](https://github.com/user-attachments/assets/997dd293-ffaa-42a1-a129-3585eab43dba)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3551/copying-a-template-from-the-library-disables-some-canvas-menu-items

<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
