### PR TITLE
chore(core): Parameterize sql queries and escape table names

### DIFF
--- a/packages/@n8n/db/src/repositories/workflow-statistics.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-statistics.repository.ts
@@ -92,7 +92,7 @@ export class WorkflowStatisticsRepository extends Repository<WorkflowStatistics>
 						"rootCount" = ${upsertRootCount},
 						"latestEvent" = CURRENT_TIMESTAMP
 					RETURNING *;`,
-					[isRootExecution ? '1' : '0', eventName, workflowId],
+					[isRootExecution ? 1 : 0, eventName, workflowId],
 				)) as Array<{ count: number }>;
 
 				return queryResult[0].count === 1 ? 'insert' : 'update';
@@ -105,7 +105,7 @@ export class WorkflowStatisticsRepository extends Repository<WorkflowStatistics>
 						count = count + 1,
 						rootCount = ${isRootExecution ? 'rootCount + 1' : 'rootCount'},
 						latestEvent = NOW();`,
-					[isRootExecution ? '1' : '0', eventName, workflowId],
+					[isRootExecution ? 1 : 0, eventName, workflowId],
 				)) as { affectedRows: number };
 
 				// MySQL returns 2 affected rows on update

--- a/packages/@n8n/db/src/repositories/workflow-statistics.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-statistics.repository.ts
@@ -55,59 +55,59 @@ export class WorkflowStatisticsRepository extends Repository<WorkflowStatistics>
 		isRootExecution: boolean,
 	): Promise<StatisticsUpsertResult> {
 		const dbType = this.globalConfig.database.type;
-		const { tableName } = this.metadata;
+		const escapedTableName = this.manager.connection.driver.escape(this.metadata.tableName);
+
 		try {
 			if (dbType === 'sqlite') {
 				await this.query(
-					`INSERT INTO "${tableName}" ("count", "rootCount", "name", "workflowId", "latestEvent")
-					VALUES (1, ${isRootExecution ? '1' : '0'}, "${eventName}", "${workflowId}", CURRENT_TIMESTAMP)
+					`INSERT INTO ${escapedTableName} ("count", "rootCount", "name", "workflowId", "latestEvent")
+					VALUES (1, ?, ?, ?, CURRENT_TIMESTAMP)
 					ON CONFLICT (workflowId, name)
 					DO UPDATE SET
 						count = count + 1,
 						rootCount = ${isRootExecution ? 'rootCount + 1' : 'rootCount'},
 						latestEvent = CURRENT_TIMESTAMP`,
+					[isRootExecution ? 1 : 0, eventName, workflowId],
 				);
+
 				// SQLite does not offer a reliable way to know whether or not an insert or update happened.
 				// We'll use a naive approach in this case. Query again after and it might cause us to miss the
 				// first production execution sometimes due to concurrency, but it's the only way.
 				const counter = await this.findOne({
 					select: ['count'],
-					where: {
-						name: eventName,
-						workflowId,
-					},
+					where: { name: eventName, workflowId },
 				});
 
 				return (counter?.count ?? 0) > 1 ? 'update' : counter?.count === 1 ? 'insert' : 'failed';
 			} else if (dbType === 'postgresdb') {
 				const upsertRootCount = isRootExecution
-					? `"${tableName}"."rootCount" + 1`
-					: `"${tableName}"."rootCount"`;
+					? `${escapedTableName}."rootCount" + 1`
+					: `${escapedTableName}."rootCount"`;
 				const queryResult = (await this.query(
-					`INSERT INTO "${tableName}" ("count", "rootCount", "name", "workflowId", "latestEvent")
-					VALUES (1, ${isRootExecution ? '1' : '0'}, '${eventName}', '${workflowId}', CURRENT_TIMESTAMP)
+					`INSERT INTO ${escapedTableName} ("count", "rootCount", "name", "workflowId", "latestEvent")
+					VALUES (1, $1, $2, $3, CURRENT_TIMESTAMP)
 					ON CONFLICT ("name", "workflowId")
 					DO UPDATE SET
-						"count" = "${tableName}"."count" + 1,
+						"count" = ${escapedTableName}."count" + 1,
 						"rootCount" = ${upsertRootCount},
 						"latestEvent" = CURRENT_TIMESTAMP
 					RETURNING *;`,
-				)) as Array<{
-					count: number;
-				}>;
+					[isRootExecution ? '1' : '0', eventName, workflowId],
+				)) as Array<{ count: number }>;
+
 				return queryResult[0].count === 1 ? 'insert' : 'update';
 			} else {
 				const queryResult = (await this.query(
-					`INSERT INTO \`${tableName}\` (count, rootCount, name, workflowId, latestEvent)
-					VALUES (1, ${isRootExecution ? '1' : '0'}, "${eventName}", "${workflowId}", NOW())
+					`INSERT INTO ${escapedTableName} (count, rootCount, name, workflowId, latestEvent)
+					VALUES (1, ?, ?, ?, NOW())
 					ON DUPLICATE KEY
 					UPDATE
 						count = count + 1,
 						rootCount = ${isRootExecution ? 'rootCount + 1' : 'rootCount'},
 						latestEvent = NOW();`,
-				)) as {
-					affectedRows: number;
-				};
+					[isRootExecution ? '1' : '0', eventName, workflowId],
+				)) as { affectedRows: number };
+
 				// MySQL returns 2 affected rows on update
 				return queryResult.affectedRows === 1 ? 'insert' : 'update';
 			}

--- a/packages/cli/src/services/__tests__/workflow-statistics.service.test.ts
+++ b/packages/cli/src/services/__tests__/workflow-statistics.service.test.ts
@@ -184,7 +184,7 @@ describe('WorkflowStatisticsService', () => {
 				startedAt: new Date(),
 			};
 			const emitSpy = jest.spyOn(Container.get(EventService), 'emit');
-			const updateSettingsSpy = jest.spyOn(Container.get(UserService), 'updateSettings');
+			const updateSettingsSpy = jest.spyOn(userService, 'updateSettings');
 
 			// ACT
 			await workflowStatisticsService.workflowExecutionCompleted(workflow, runData);
@@ -214,7 +214,7 @@ describe('WorkflowStatisticsService', () => {
 				startedAt: new Date(),
 			};
 			const emitSpy = jest.spyOn(Container.get(EventService), 'emit');
-			const updateSettingsSpy = jest.spyOn(Container.get(UserService), 'updateSettings');
+			const updateSettingsSpy = jest.spyOn(userService, 'updateSettings');
 
 			// ACT
 			await workflowStatisticsService.workflowExecutionCompleted(workflow, runData);
@@ -251,7 +251,6 @@ describe('WorkflowStatisticsService', () => {
 		let eventService: EventService;
 		let fakeUser: User;
 		let fakeProject: Project;
-		let fakeWorkflow: IWorkflowDb & WorkflowEntity;
 		let ownershipService: OwnershipService;
 		let entityManager: EntityManager;
 		let userService: UserService;
@@ -260,7 +259,6 @@ describe('WorkflowStatisticsService', () => {
 		beforeAll(() => {
 			fakeUser = mock<User>({ id: 'abcde-fghij' });
 			fakeProject = mock<Project>({ id: '12345-67890', type: 'personal' });
-			fakeWorkflow = mock<IWorkflowDb & WorkflowEntity>({ id: '1' });
 			ownershipService = mockInstance(OwnershipService);
 			userService = mockInstance(UserService);
 			const globalConfig = Container.get(GlobalConfig);

--- a/packages/cli/src/services/__tests__/workflow-statistics.service.test.ts
+++ b/packages/cli/src/services/__tests__/workflow-statistics.service.test.ts
@@ -253,16 +253,16 @@ describe('WorkflowStatisticsService', () => {
 	describe('nodeFetchedData', () => {
 		let workflowStatisticsService: WorkflowStatisticsService;
 		let eventService: EventService;
-		let fakeUser: User;
-		let fakeProject: Project;
+		let user: User;
+		let project: Project;
 		let ownershipService: OwnershipService;
 		let entityManager: EntityManager;
 		let userService: UserService;
 		let workflowStatisticsRepository: WorkflowStatisticsRepository;
 
 		beforeAll(() => {
-			fakeUser = mock<User>({ id: 'abcde-fghij' });
-			fakeProject = mock<Project>({ id: '12345-67890', type: 'personal' });
+			user = mock<User>({ id: 'abcde-fghij' });
+			project = mock<Project>({ id: '12345-67890', type: 'personal' });
 			ownershipService = mockInstance(OwnershipService);
 			userService = mockInstance(UserService);
 			const globalConfig = Container.get(GlobalConfig);
@@ -288,8 +288,8 @@ describe('WorkflowStatisticsService', () => {
 			);
 			globalConfig.diagnostics.enabled = true;
 			config.set('deployment.type', 'n8n-testing');
-			mocked(ownershipService.getWorkflowProjectCached).mockResolvedValue(fakeProject);
-			mocked(ownershipService.getPersonalProjectOwnerCached).mockResolvedValue(fakeUser);
+			mocked(ownershipService.getWorkflowProjectCached).mockResolvedValue(project);
+			mocked(ownershipService.getPersonalProjectOwnerCached).mockResolvedValue(user);
 		});
 
 		afterAll(() => {
@@ -313,8 +313,8 @@ describe('WorkflowStatisticsService', () => {
 			};
 			await workflowStatisticsService.nodeFetchedData(workflowId, node);
 			expect(eventService.emit).toHaveBeenCalledWith('first-workflow-data-loaded', {
-				userId: fakeUser.id,
-				project: fakeProject.id,
+				userId: user.id,
+				project: project.id,
 				workflowId,
 				nodeType: node.type,
 				nodeId: node.id,
@@ -330,7 +330,7 @@ describe('WorkflowStatisticsService', () => {
 
 			expect(eventService.emit).toHaveBeenCalledWith('first-workflow-data-loaded', {
 				userId: '',
-				project: fakeProject.id,
+				project: project.id,
 				workflowId,
 				nodeType: node.type,
 				nodeId: node.id,
@@ -356,8 +356,8 @@ describe('WorkflowStatisticsService', () => {
 			};
 			await workflowStatisticsService.nodeFetchedData(workflowId, node);
 			expect(eventService.emit).toHaveBeenCalledWith('first-workflow-data-loaded', {
-				userId: fakeUser.id,
-				project: fakeProject.id,
+				userId: user.id,
+				project: project.id,
 				workflowId,
 				nodeType: node.type,
 				nodeId: node.id,

--- a/packages/cli/src/services/__tests__/workflow-statistics.service.test.ts
+++ b/packages/cli/src/services/__tests__/workflow-statistics.service.test.ts
@@ -49,6 +49,10 @@ describe('WorkflowStatisticsService', () => {
 			workflow = await createWorkflow({}, user);
 		});
 
+		afterAll(async () => {
+			await testDb.terminate();
+		});
+
 		beforeEach(async () => {
 			jest.restoreAllMocks();
 			await testDb.truncate(['WorkflowStatistics']);

--- a/packages/cli/src/services/__tests__/workflow-statistics.service.test.ts
+++ b/packages/cli/src/services/__tests__/workflow-statistics.service.test.ts
@@ -81,6 +81,7 @@ describe('WorkflowStatisticsService', () => {
 		test.each<WorkflowExecuteMode>(['cli', 'error', 'retry', 'trigger', 'webhook', 'evaluation'])(
 			'should upsert with root executions for execution mode %s',
 			async (mode) => {
+				mockDBCall();
 				// Call the function with a production success result, ensure metrics hook gets called
 				const runData: IRun = {
 					finished: true,
@@ -103,6 +104,7 @@ describe('WorkflowStatisticsService', () => {
 		test.each<WorkflowExecuteMode>(['manual', 'integrated', 'internal'])(
 			'should upsert without root executions for execution mode %s',
 			async (mode) => {
+				mockDBCall();
 				const runData: IRun = {
 					finished: true,
 					status: 'success',
@@ -124,6 +126,7 @@ describe('WorkflowStatisticsService', () => {
 		test.each<ExecutionStatus>(['success', 'crashed', 'error'])(
 			'should upsert with root executions for execution status %s',
 			async (status) => {
+				mockDBCall();
 				const runData: IRun = {
 					finished: true,
 					status,
@@ -145,6 +148,7 @@ describe('WorkflowStatisticsService', () => {
 		test.each<ExecutionStatus>(['canceled', 'new', 'running', 'unknown', 'waiting'])(
 			'should upsert without root executions for execution status %s',
 			async (status) => {
+				mockDBCall();
 				const runData: IRun = {
 					finished: true,
 					status,
@@ -194,6 +198,7 @@ describe('WorkflowStatisticsService', () => {
 		});
 
 		test('should only create metrics for production successes', async () => {
+			mockDBCall();
 			// Call the function with a non production success result, ensure metrics hook is never called
 			const workflow = {
 				id: '1',

--- a/packages/cli/src/services/__tests__/workflow-statistics.service.test.ts
+++ b/packages/cli/src/services/__tests__/workflow-statistics.service.test.ts
@@ -43,7 +43,7 @@ describe('WorkflowStatisticsService', () => {
 			mock<EntityMetadata>({
 				tableName: 'workflow_statistics',
 			}),
-		driver: { escape: jest.fn().mockImplementation((id) => id) },
+		driver: { escape: jest.fn((id) => id) },
 	});
 	Object.assign(entityManager, { connection: dataSource });
 

--- a/packages/cli/src/services/__tests__/workflow-statistics.service.test.ts
+++ b/packages/cli/src/services/__tests__/workflow-statistics.service.test.ts
@@ -78,8 +78,6 @@ describe('WorkflowStatisticsService', () => {
 	};
 
 	describe('workflowExecutionCompleted', () => {
-		const rootCountRegex = /"?rootCount"?\s*=\s*(?:"?\w+"?\.)?"?rootCount"?\s*\+\s*1/;
-
 		test.each<WorkflowExecuteMode>(['cli', 'error', 'retry', 'trigger', 'webhook', 'evaluation'])(
 			'should upsert with root executions for execution mode %s',
 			async (mode) => {

--- a/packages/cli/src/services/__tests__/workflow-statistics.service.test.ts
+++ b/packages/cli/src/services/__tests__/workflow-statistics.service.test.ts
@@ -43,6 +43,7 @@ describe('WorkflowStatisticsService', () => {
 			mock<EntityMetadata>({
 				tableName: 'workflow_statistics',
 			}),
+		driver: { escape: jest.fn().mockImplementation((id) => id) },
 	});
 	Object.assign(entityManager, { connection: dataSource });
 
@@ -92,10 +93,12 @@ describe('WorkflowStatisticsService', () => {
 				};
 
 				await workflowStatisticsService.workflowExecutionCompleted(fakeWorkflow, runData);
-				expect(entityManager.query).toHaveBeenCalledWith(
-					expect.stringMatching(rootCountRegex),
-					undefined,
-				);
+				expect(entityManager.query).toHaveReturnedTimes(1);
+				expect(entityManager.query).toHaveBeenNthCalledWith(1, expect.any(String), [
+					1,
+					expect.any(String),
+					'1',
+				]);
 			},
 		);
 
@@ -111,10 +114,12 @@ describe('WorkflowStatisticsService', () => {
 				};
 
 				await workflowStatisticsService.workflowExecutionCompleted(fakeWorkflow, runData);
-				expect(entityManager.query).toHaveBeenCalledWith(
-					expect.not.stringMatching(rootCountRegex),
-					undefined,
-				);
+				expect(entityManager.query).toHaveReturnedTimes(1);
+				expect(entityManager.query).toHaveBeenNthCalledWith(1, expect.any(String), [
+					0,
+					expect.any(String),
+					'1',
+				]);
 			},
 		);
 
@@ -130,10 +135,12 @@ describe('WorkflowStatisticsService', () => {
 				};
 
 				await workflowStatisticsService.workflowExecutionCompleted(fakeWorkflow, runData);
-				expect(entityManager.query).toHaveBeenCalledWith(
-					expect.stringMatching(rootCountRegex),
-					undefined,
-				);
+				expect(entityManager.query).toHaveReturnedTimes(1);
+				expect(entityManager.query).toHaveBeenNthCalledWith(1, expect.any(String), [
+					1,
+					expect.any(String),
+					'1',
+				]);
 			},
 		);
 
@@ -149,10 +156,12 @@ describe('WorkflowStatisticsService', () => {
 				};
 
 				await workflowStatisticsService.workflowExecutionCompleted(fakeWorkflow, runData);
-				expect(entityManager.query).toHaveBeenCalledWith(
-					expect.not.stringMatching(rootCountRegex),
-					undefined,
-				);
+				expect(entityManager.query).toHaveReturnedTimes(1);
+				expect(entityManager.query).toHaveBeenNthCalledWith(1, expect.any(String), [
+					0,
+					expect.any(String),
+					'1',
+				]);
 			},
 		);
 

--- a/packages/cli/src/services/__tests__/workflow-statistics.service.test.ts
+++ b/packages/cli/src/services/__tests__/workflow-statistics.service.test.ts
@@ -97,6 +97,7 @@ describe('WorkflowStatisticsService', () => {
 					1,
 					expect.any(String),
 					'1',
+					1,
 				]);
 			},
 		);
@@ -119,6 +120,7 @@ describe('WorkflowStatisticsService', () => {
 					0,
 					expect.any(String),
 					'1',
+					0,
 				]);
 			},
 		);
@@ -141,6 +143,7 @@ describe('WorkflowStatisticsService', () => {
 					1,
 					expect.any(String),
 					'1',
+					1,
 				]);
 			},
 		);
@@ -163,6 +166,7 @@ describe('WorkflowStatisticsService', () => {
 					0,
 					expect.any(String),
 					'1',
+					0,
 				]);
 			},
 		);


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Parameterize sql query and escape table name. This is not exploitable, but still good practice to do this.

I also refactored the tests, e.g. updating the titles, making them test the repository (and thus the SQL) instead of mocking it.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2802/critical-sql-injection-in-workflow-statistics-files


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] ~Tests included.~ <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
