### PR TITLE
docs: Update doc links in azure cosmos db (no-changelog)

### DIFF
--- a/packages/nodes-base/credentials/MicrosoftAzureCosmosDbSharedKeyApi.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftAzureCosmosDbSharedKeyApi.credentials.ts
@@ -20,7 +20,7 @@ export class MicrosoftAzureCosmosDbSharedKeyApi implements ICredentialType {
 
 	displayName = 'Microsoft Azure Cosmos DB API';
 
-	documentationUrl = 'microsoftAzureCosmosdb';
+	documentationUrl = 'azurecosmosdb';
 
 	properties: INodeProperties[] = [
 		{

--- a/packages/nodes-base/nodes/Microsoft/AzureCosmosDb/AzureCosmosDb.node.json
+++ b/packages/nodes-base/nodes/Microsoft/AzureCosmosDb/AzureCosmosDb.node.json
@@ -6,12 +6,12 @@
 	"resources": {
 		"credentialDocumentation": [
 			{
-				"url": "https://docs.n8n.io/integrations/builtin/credentials/microsoft/"
+				"url": "https://docs.n8n.io/integrations/builtin/credentials/azurecosmosdb/"
 			}
 		],
 		"primaryDocumentation": [
 			{
-				"url": "https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.azureCosmosDb/"
+				"url": "https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.azurecosmosdb/"
 			}
 		]
 	}


### PR DESCRIPTION
## Summary

Changes the links in the Azure Cosmos DB node and credential to point to the expected URLs. The previous targets didn't follow the path format we use in docs.

The docs are not yet merged, but the PR is [available here](https://github.com/n8n-io/n8n-docs/pull/3138).

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
