### PR TITLE
fix(editor): Correct WF counts on folder with archived filter (no-changelog)

### DIFF
--- a/packages/cli/src/controllers/folder.controller.ts
+++ b/packages/cli/src/controllers/folder.controller.ts
@@ -25,7 +25,6 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { InternalServerError } from '@/errors/response-errors/internal-server.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { AuthenticatedRequest } from '@/requests';
-import type { ListQuery } from '@/requests';
 import { FolderService } from '@/services/folder.service';
 import { EnterpriseWorkflowService } from '@/workflows/workflow.service.ee';
 
@@ -124,10 +123,7 @@ export class ProjectController {
 	) {
 		const { projectId } = req.params;
 
-		const [data, count] = await this.folderService.getManyAndCount(
-			projectId,
-			payload as ListQuery.Options,
-		);
+		const [data, count] = await this.folderService.getManyAndCount(projectId, payload);
 
 		res.json({ count, data });
 	}

--- a/packages/cli/src/databases/repositories/__tests__/folder.repository.test.ts
+++ b/packages/cli/src/databases/repositories/__tests__/folder.repository.test.ts
@@ -242,6 +242,87 @@ describe('FolderRepository', () => {
 				expect(folders[0].parentFolder?.id).toBe(parentFolder.id);
 				expect(folders[0].tags[0].name).toBe('important');
 			});
+
+			describe('workflowCount', () => {
+				let testFolder: Folder;
+
+				beforeEach(async () => {
+					const parentFolder = await createFolder(project, { name: 'Parent' });
+					testFolder = await createFolder(project, { name: 'Test Folder', parentFolder });
+
+					await createWorkflow({ parentFolder: testFolder, isArchived: false });
+					await createWorkflow({ parentFolder: testFolder, isArchived: false });
+					await createWorkflow({ parentFolder: testFolder, isArchived: true });
+					await createWorkflow({ parentFolder: testFolder, isArchived: true });
+					await createWorkflow({ parentFolder: testFolder, isArchived: true });
+				});
+
+				it('should include archived workflows in the workflow count by default', async () => {
+					const [folders] = await folderRepository.getManyAndCount({
+						select: { workflowCount: true },
+					});
+
+					expect(folders).toHaveLength(2);
+					expect(folders).toEqual(
+						expect.arrayContaining([
+							expect.objectContaining({
+								id: testFolder.id,
+								workflowCount: 5,
+							}),
+							expect.objectContaining({
+								id: testFolder.parentFolderId,
+								workflowCount: 0,
+							}),
+						]),
+					);
+				});
+
+				it('should include only archived workflows in the workflow count if filtered', async () => {
+					const [folders] = await folderRepository.getManyAndCount(
+						{
+							select: { workflowCount: true },
+						},
+						true,
+					);
+
+					expect(folders).toHaveLength(2);
+					expect(folders).toEqual(
+						expect.arrayContaining([
+							expect.objectContaining({
+								id: testFolder.id,
+								workflowCount: 3,
+							}),
+							expect.objectContaining({
+								id: testFolder.parentFolderId,
+								workflowCount: 0,
+							}),
+						]),
+					);
+				});
+
+				it('should return only unarchived workflows in the workflow count if filtered', async () => {
+					const [folders] = await folderRepository.getManyAndCount(
+						{
+							select: { workflowCount: true },
+						},
+						false,
+					);
+
+					expect(folders).toHaveLength(2);
+					expect(folders).toEqual(
+						expect.arrayContaining([
+							expect.objectContaining({
+								id: testFolder.id,
+								workflowCount: 2,
+							}),
+							expect.objectContaining({
+								id: testFolder.parentFolderId,
+								workflowCount: 0,
+							}),
+						]),
+					);
+				});
+			});
 		});
 
 		describe('select', () => {

--- a/packages/cli/src/databases/repositories/__tests__/folder.repository.test.ts
+++ b/packages/cli/src/databases/repositories/__tests__/folder.repository.test.ts
@@ -278,12 +278,10 @@ describe('FolderRepository', () => {
 				});
 
 				it('should include only archived workflows in the workflow count if filtered', async () => {
-					const [folders] = await folderRepository.getManyAndCount(
-						{
-							select: { workflowCount: true },
-						},
-						true,
-					);
+					const [folders] = await folderRepository.getManyAndCount({
+						select: { workflowCount: true },
+						filter: { isArchived: true },
+					});
 
 					expect(folders).toHaveLength(2);
 					expect(folders).toEqual(
@@ -301,12 +299,10 @@ describe('FolderRepository', () => {
 				});
 
 				it('should return only unarchived workflows in the workflow count if filtered', async () => {
-					const [folders] = await folderRepository.getManyAndCount(
-						{
-							select: { workflowCount: true },
-						},
-						false,
-					);
+					const [folders] = await folderRepository.getManyAndCount({
+						select: { workflowCount: true },
+						filter: { isArchived: false },
+					});
 
 					expect(folders).toHaveLength(2);
 					expect(folders).toEqual(

--- a/packages/cli/src/databases/repositories/workflow.repository.ts
+++ b/packages/cli/src/databases/repositories/workflow.repository.ts
@@ -287,10 +287,10 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 			this.getWorkflowsAndFoldersCount(workflowIds, options),
 		]);
 
-		const isArchivedFilter =
+		const isArchived =
 			typeof options.filter?.isArchived === 'boolean' ? options.filter.isArchived : undefined;
 
-		const { workflows, folders } = await this.fetchExtraData(workflowsAndFolders, isArchivedFilter);
+		const { workflows, folders } = await this.fetchExtraData(workflowsAndFolders, isArchived);
 
 		const enrichedWorkflowsAndFolders = this.enrichDataWithExtras(workflowsAndFolders, {
 			workflows,
@@ -312,14 +312,14 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 
 	private async fetchExtraData(
 		workflowsAndFolders: WorkflowFolderUnionRow[],
-		isArchivedFilter?: boolean,
+		isArchived?: boolean,
 	) {
 		const workflowIds = this.getWorkflowsIds(workflowsAndFolders);
 		const folderIds = this.getFolderIds(workflowsAndFolders);
 
 		const [workflows, folders] = await Promise.all([
 			this.getMany(workflowIds),
-			this.folderRepository.getMany({ filter: { folderIds } }, isArchivedFilter),
+			this.folderRepository.getMany({ filter: { folderIds, isArchived } }),
 		]);
 
 		return { workflows, folders };

--- a/packages/cli/src/databases/repositories/workflow.repository.ts
+++ b/packages/cli/src/databases/repositories/workflow.repository.ts
@@ -287,7 +287,10 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 			this.getWorkflowsAndFoldersCount(workflowIds, options),
 		]);
 
-		const { workflows, folders } = await this.fetchExtraData(workflowsAndFolders);
+		const isArchivedFilter =
+			typeof options.filter?.isArchived === 'boolean' ? options.filter.isArchived : undefined;
+
+		const { workflows, folders } = await this.fetchExtraData(workflowsAndFolders, isArchivedFilter);
 
 		const enrichedWorkflowsAndFolders = this.enrichDataWithExtras(workflowsAndFolders, {
 			workflows,
@@ -307,13 +310,16 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 			.map((item) => item.id);
 	}
 
-	private async fetchExtraData(workflowsAndFolders: WorkflowFolderUnionRow[]) {
+	private async fetchExtraData(
+		workflowsAndFolders: WorkflowFolderUnionRow[],
+		isArchivedFilter?: boolean,
+	) {
 		const workflowIds = this.getWorkflowsIds(workflowsAndFolders);
 		const folderIds = this.getFolderIds(workflowsAndFolders);
 
 		const [workflows, folders] = await Promise.all([
 			this.getMany(workflowIds),
-			this.folderRepository.getMany({ filter: { folderIds } }),
+			this.folderRepository.getMany({ filter: { folderIds } }, isArchivedFilter),
 		]);
 
 		return { workflows, folders };

--- a/packages/cli/src/services/folder.service.ts
+++ b/packages/cli/src/services/folder.service.ts
@@ -192,7 +192,6 @@ export class FolderService {
 	async getFolderAndWorkflowCount(
 		folderId: string,
 		projectId: string,
-		includeArchivedWorkflowsInCount = false,
 	): Promise<{ totalSubFolders: number; totalWorkflows: number }> {
 		await this.findFolderInProjectOrFail(folderId, projectId);
 
@@ -227,7 +226,7 @@ export class FolderService {
 		const workflowCountQuery = this.workflowRepository
 			.createQueryBuilder('workflow')
 			.select('COUNT(workflow.id)', 'count')
-			.where('workflow.isArchived = :isArchived', { isArchived: includeArchivedWorkflowsInCount })
+			.where('workflow.isArchived = :isArchived', { isArchived: false })
 			.andWhere((qb) => {
 				const folderQuery = qb.subQuery().from('folder_path', 'fp').select('fp.id').getQuery();
 				return `workflow.parentFolderId IN ${folderQuery}`;

--- a/packages/cli/src/services/folder.service.ts
+++ b/packages/cli/src/services/folder.service.ts
@@ -253,12 +253,8 @@ export class FolderService {
 		};
 	}
 
-	async getManyAndCount(
-		projectId: string,
-		options: ListQuery.Options,
-		includeArchivedWorkflowsInCount = false,
-	) {
-		options.filter = { ...options.filter, projectId };
-		return await this.folderRepository.getManyAndCount(options, includeArchivedWorkflowsInCount);
+	async getManyAndCount(projectId: string, options: ListQuery.Options) {
+		options.filter = { ...options.filter, projectId, isArchived: false };
+		return await this.folderRepository.getManyAndCount(options);
 	}
 }

--- a/packages/cli/test/integration/folder/folder.controller.test.ts
+++ b/packages/cli/test/integration/folder/folder.controller.test.ts
@@ -1307,6 +1307,23 @@ describe('GET /projects/:projectId/folders', () => {
 			['Owner Folder 1', 'Owner Folder 2'].sort(),
 		);
 	});
+
+	test('should include workflow count', async () => {
+		const folder = await createFolder(ownerProject, { name: 'Test Folder' });
+		await createWorkflow({ parentFolder: folder, isArchived: false }, ownerProject);
+		await createWorkflow({ parentFolder: folder, isArchived: false }, ownerProject);
+		// Not included in the count
+		await createWorkflow({ parentFolder: folder, isArchived: true }, ownerProject);
+
+		const response = await authOwnerAgent
+			.get(`/projects/${ownerProject.id}/folders`)
+			.query({ filter: '{ "name": "test" }' })
+			.expect(200);
+
+		expect(response.body.count).toBe(1);
+		expect(response.body.data).toHaveLength(1);
+		expect(response.body.data[0].workflowCount).toEqual(2);
+	});
 });
 
 describe('GET /projects/:projectId/folders/content', () => {
@@ -1358,6 +1375,11 @@ describe('GET /projects/:projectId/folders/content', () => {
 		await createWorkflow({ parentFolder: personalFolder1 }, ownerProject);
 		await createWorkflow({ parentFolder: personalProjectSubfolder1 }, ownerProject);
 		await createWorkflow({ parentFolder: personalProjectSubfolder2 }, ownerProject);
+		// Not included in the count
+		await createWorkflow(
+			{ parentFolder: personalProjectSubfolder2, isArchived: true },
+			ownerProject,
+		);
 
 		const response = await authOwnerAgent
 			.get(`/projects/${ownerProject.id}/folders/${personalFolder1.id}/content`)


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/57ebfe7d-eff9-43d8-8a17-593cb77cbce0

Show correct workflow counts on folders based on the user's current isArchived status filter.

Folder endpoints don't accept this parameter currently, but the support is there in the folder repository if we later need to add support for this, this doesn't seem to appear too visibly to the user currently.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3552/feature-fixing-feedback-issues

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->

