### PR TITLE
feat(editor): Show different text when only archived filter is on (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/components/layouts/ResourcesListLayout.test.ts
+++ b/packages/frontend/editor-ui/src/components/layouts/ResourcesListLayout.test.ts
@@ -151,4 +151,50 @@ describe('ResourcesListLayout', () => {
 		expect(emitted()['update:pagination-and-sort']).toBeTruthy();
 		expect(emitted()['update:pagination-and-sort'].pop()).toEqual([TEST_LOCAL_STORAGE_VALUES]);
 	});
+
+	it('should display info text if filters are applied', async () => {
+		const { getByTestId } = renderComponent({
+			props: {
+				resources: TEST_WORKFLOWS,
+				type: 'list-paginated',
+				showFiltersDropdown: true,
+				filters: {
+					search: '',
+					homeProject: '',
+					showArchived: true,
+					testFilter: true,
+				},
+			},
+		});
+
+		await waitAllPromises();
+		expect(getByTestId('resources-list-filters-applied-info')).toBeInTheDocument();
+		expect(getByTestId('workflows-filter-reset')).toBeInTheDocument();
+		expect(getByTestId('resources-list-filters-applied-info').textContent).toContain(
+			'Some workflows may be hidden since filters are applied.',
+		);
+	});
+
+	it('should display different info text if all applied filters display more results', async () => {
+		const { getByTestId } = renderComponent({
+			props: {
+				resources: TEST_WORKFLOWS,
+				type: 'list-paginated',
+				showFiltersDropdown: true,
+				filters: {
+					search: '',
+					homeProject: '',
+					tags: [],
+					showArchived: true,
+				},
+			},
+		});
+
+		await waitAllPromises();
+		expect(getByTestId('resources-list-filters-applied-info')).toBeInTheDocument();
+		expect(getByTestId('workflows-filter-reset')).toBeInTheDocument();
+		expect(getByTestId('resources-list-filters-applied-info').textContent).toContain(
+			'Filters are applied.',
+		);
+	});
 });

--- a/packages/frontend/editor-ui/src/components/layouts/ResourcesListLayout.vue
+++ b/packages/frontend/editor-ui/src/components/layouts/ResourcesListLayout.vue
@@ -337,20 +337,32 @@ const focusSearchInput = () => {
 	}
 };
 
+const isFilterApplied = (key: string) => {
+	if (key === 'search') return false;
+
+	if (typeof props.filters[key] === 'boolean') {
+		return props.filters[key];
+	}
+
+	if (Array.isArray(props.filters[key])) {
+		return props.filters[key].length > 0;
+	}
+
+	return props.filters[key] !== '';
+};
+
+const hasOnlyShowArchivedFilter = computed(() => {
+	const activeFilters = filterKeys.value.filter(isFilterApplied);
+
+	if (activeFilters.length !== 1) {
+		return false;
+	}
+
+	return activeFilters[0] === 'showArchived';
+});
+
 const hasAppliedFilters = (): boolean => {
-	return !!filterKeys.value.find((key) => {
-		if (key === 'search') return false;
-
-		if (typeof props.filters[key] === 'boolean') {
-			return props.filters[key];
-		}
-
-		if (Array.isArray(props.filters[key])) {
-			return props.filters[key].length > 0;
-		}
-
-		return props.filters[key] !== '';
-	});
+	return !!filterKeys.value.find(isFilterApplied);
 };
 
 const setRowsPerPage = async (numberOfRowsPerPage: number) => {
@@ -672,7 +684,11 @@ defineExpose({
 
 					<div v-if="showFiltersDropdown" v-show="hasFilters" class="mt-xs">
 						<n8n-info-tip :bold="false">
-							{{ i18n.baseText(`${resourceKey}.filters.active` as BaseTextKey) }}
+							{{
+								hasOnlyShowArchivedFilter
+									? i18n.baseText(`${resourceKey}.filters.active.onlyShowArchived` as BaseTextKey)
+									: i18n.baseText(`${resourceKey}.filters.active` as BaseTextKey)
+							}}
 							<n8n-link data-test-id="workflows-filter-reset" size="small" @click="resetFilters">
 								{{ i18n.baseText(`${resourceKey}.filters.active.reset` as BaseTextKey) }}
 							</n8n-link>

--- a/packages/frontend/editor-ui/src/components/layouts/ResourcesListLayout.vue
+++ b/packages/frontend/editor-ui/src/components/layouts/ResourcesListLayout.vue
@@ -337,7 +337,7 @@ const focusSearchInput = () => {
 	}
 };
 
-const isFilterApplied = (key: string) => {
+const isFilterApplied = (key: string): boolean => {
 	if (key === 'search') return false;
 
 	if (typeof props.filters[key] === 'boolean') {
@@ -351,14 +351,14 @@ const isFilterApplied = (key: string) => {
 	return props.filters[key] !== '';
 };
 
-const hasOnlyShowArchivedFilter = computed(() => {
+const hasOnlyFiltersThatShowMoreResults = computed(() => {
 	const activeFilters = filterKeys.value.filter(isFilterApplied);
 
-	if (activeFilters.length !== 1) {
-		return false;
-	}
+	const filtersThatShowMoreResults = ['showArchived'];
 
-	return activeFilters[0] === 'showArchived';
+	return activeFilters.every((filter) => {
+		return filtersThatShowMoreResults.includes(filter);
+	});
 });
 
 const hasAppliedFilters = (): boolean => {
@@ -685,8 +685,8 @@ defineExpose({
 					<div v-if="showFiltersDropdown" v-show="hasFilters" class="mt-xs">
 						<n8n-info-tip :bold="false">
 							{{
-								hasOnlyShowArchivedFilter
-									? i18n.baseText(`${resourceKey}.filters.active.onlyShowArchived` as BaseTextKey)
+								hasOnlyFiltersThatShowMoreResults
+									? i18n.baseText(`${resourceKey}.filters.active.shortText` as BaseTextKey)
 									: i18n.baseText(`${resourceKey}.filters.active` as BaseTextKey)
 							}}
 							<n8n-link data-test-id="workflows-filter-reset" size="small" @click="resetFilters">

--- a/packages/frontend/editor-ui/src/components/layouts/ResourcesListLayout.vue
+++ b/packages/frontend/editor-ui/src/components/layouts/ResourcesListLayout.vue
@@ -682,7 +682,12 @@ defineExpose({
 
 					<slot name="callout"></slot>
 
-					<div v-if="showFiltersDropdown" v-show="hasFilters" class="mt-xs">
+					<div
+						v-if="showFiltersDropdown"
+						v-show="hasFilters"
+						class="mt-xs"
+						data-test-id="resources-list-filters-applied-info"
+					>
 						<n8n-info-tip :bold="false">
 							{{
 								hasOnlyFiltersThatShowMoreResults

--- a/packages/frontend/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/frontend/editor-ui/src/plugins/i18n/locales/en.json
@@ -2498,7 +2498,7 @@
 	"workflows.filters.apply": "Apply filters",
 	"workflows.filters.reset": "Reset all",
 	"workflows.filters.active": "Some workflows may be hidden since filters are applied.",
-	"workflows.filters.active.onlyShowArchived": "Filters are applied.",
+	"workflows.filters.active.shortText": "Filters are applied.",
 	"workflows.filters.active.reset": "Remove filters",
 	"workflows.sort.lastUpdated": "Sort by last updated",
 	"workflows.sort.lastCreated": "Sort by last created",

--- a/packages/frontend/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/frontend/editor-ui/src/plugins/i18n/locales/en.json
@@ -2498,6 +2498,7 @@
 	"workflows.filters.apply": "Apply filters",
 	"workflows.filters.reset": "Reset all",
 	"workflows.filters.active": "Some workflows may be hidden since filters are applied.",
+	"workflows.filters.active.onlyShowArchived": "Filters are applied.",
 	"workflows.filters.active.reset": "Remove filters",
 	"workflows.sort.lastUpdated": "Sort by last updated",
 	"workflows.sort.lastCreated": "Sort by last created",


### PR DESCRIPTION
## Summary

<img width="502" alt="image" src="https://github.com/user-attachments/assets/b2393ff2-0609-461e-bd9e-8bf38fc5084a" />

Show a different warning text about applied filters if the only active filter is the "Show archived" filter, which doesn't hide workflows but makes more workflows visible.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3552/feature-fixing-feedback-issues

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
