### PR TITLE
chore(Azure OpenAI Chat Model Node): Bump the default apiVersion to 2025-03-01-preview

### DIFF
--- a/packages/@n8n/nodes-langchain/credentials/AzureEntraCognitiveServicesOAuth2Api.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/AzureEntraCognitiveServicesOAuth2Api.credentials.ts
@@ -31,7 +31,7 @@ export class AzureEntraCognitiveServicesOAuth2Api implements ICredentialType {
 			name: 'apiVersion',
 			type: 'string',
 			required: true,
-			default: '2024-12-01-preview',
+			default: '2025-03-01-preview',
 		},
 		{
 			displayName: 'Endpoint',

--- a/packages/@n8n/nodes-langchain/credentials/AzureOpenAiApi.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/AzureOpenAiApi.credentials.ts
@@ -28,7 +28,7 @@ export class AzureOpenAiApi implements ICredentialType {
 			name: 'apiVersion',
 			type: 'string',
 			required: true,
-			default: '2023-07-01-preview',
+			default: '2025-03-01-preview',
 		},
 		{
 			displayName: 'Endpoint',


### PR DESCRIPTION
## Summary

Update Azure OpenAI credentials to use more recent `apiVersion` as default.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
closes #15077


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
