### PR TITLE
fix(editor): Remove withDefaults import warning during dev and build (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/components/InlineNameEdit.vue
+++ b/packages/frontend/editor-ui/src/components/InlineNameEdit.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { nextTick, ref, withDefaults } from 'vue';
+import { nextTick, ref } from 'vue';
 import { useToast } from '@/composables/useToast';
 import { onClickOutside } from '@vueuse/core';
 


### PR DESCRIPTION
## Summary

The `withDefaults` macro doesn't need to be imported and leads to warning.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
