### PR TITLE
fix(editor): Fix chat package build warning related to types (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/chat/package.json
+++ b/packages/frontend/@n8n/chat/package.json
@@ -17,14 +17,14 @@
     "storybook": "storybook dev -p 6006 --no-open",
     "build:storybook": "storybook build"
   },
+  "types": "./dist/index.d.ts",
   "main": "./dist/chat.umd.js",
   "module": "./dist/chat.es.js",
-  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/chat.es.js",
-      "require": "./dist/chat.umd.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/chat.umd.js"
     },
     "./style.css": {
       "import": "./dist/style.css",


### PR DESCRIPTION
## Summary

The `types` field needs to be specified first in order to be prioritized by bundlers. Not doing so leads to warning.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
