### PR TITLE
test: Update e2e test that fails with the new log view (no-changelog)

### DIFF
--- a/cypress/e2e/30-langchain.cy.ts
+++ b/cypress/e2e/30-langchain.cy.ts
@@ -454,11 +454,11 @@ describe('Langchain Integration', () => {
 		cy.createFixtureWorkflow('Test_workflow_chat_partial_execution.json');
 		workflowPage.actions.zoomToFit();
 
-		getManualChatModal().should('not.exist');
+		getManualChatModal().find('main').should('not.exist');
 		openNode('Node 1');
 		ndv.actions.execute();
 
-		getManualChatModal().should('exist');
+		getManualChatModal().find('main').should('exist');
 		sendManualChatMessage('Test');
 
 		getManualChatMessages().should('contain', 'this_my_field_1');


### PR DESCRIPTION
## Summary
This PR updates an e2e test case that started to fail after #15202

## Related Linear tickets, Github issues, and Community forum posts



## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
