### PR TITLE
fix(core): Don't allow creating more projects than allowed by exploiting a race condition

### DIFF
--- a/packages/@n8n/config/src/configs/__tests__/database.config.test.ts
+++ b/packages/@n8n/config/src/configs/__tests__/database.config.test.ts
@@ -1,22 +1,11 @@
 import { Container } from '@n8n/di';
-import fs from 'fs';
-import { mock } from 'jest-mock-extended';
 
 import { DatabaseConfig } from '../database.config';
-
-jest.mock('fs');
-const mockFs = mock<typeof fs>();
-fs.readFileSync = mockFs.readFileSync;
 
 describe('DatabaseConfig', () => {
 	beforeEach(() => {
 		Container.reset();
 		jest.clearAllMocks();
-	});
-
-	const originalEnv = process.env;
-	afterEach(() => {
-		process.env = originalEnv;
 	});
 
 	test.each(['mariadb', 'mysqldb', 'postgresdb'] satisfies Array<DatabaseConfig['type']>)(

--- a/packages/@n8n/config/src/configs/__tests__/database.config.test.ts
+++ b/packages/@n8n/config/src/configs/__tests__/database.config.test.ts
@@ -1,0 +1,45 @@
+import { Container } from '@n8n/di';
+import fs from 'fs';
+import { mock } from 'jest-mock-extended';
+
+import { DatabaseConfig } from '../database.config';
+
+jest.mock('fs');
+const mockFs = mock<typeof fs>();
+fs.readFileSync = mockFs.readFileSync;
+
+describe('DatabaseConfig', () => {
+	beforeEach(() => {
+		Container.reset();
+		jest.clearAllMocks();
+	});
+
+	const originalEnv = process.env;
+	afterEach(() => {
+		process.env = originalEnv;
+	});
+
+	test.each(['mariadb', 'mysqldb', 'postgresdb'] satisfies Array<DatabaseConfig['type']>)(
+		'`isLegacySqlite` returns false if dbType is `%s`',
+		(dbType) => {
+			const databaseConfig = Container.get(DatabaseConfig);
+			databaseConfig.sqlite.poolSize = 0;
+			databaseConfig.type = dbType;
+			expect(databaseConfig.isLegacySqlite).toBe(false);
+		},
+	);
+
+	test('`isLegacySqlite` returns false if dbType is `sqlite` and `poolSize` > 0', () => {
+		const databaseConfig = Container.get(DatabaseConfig);
+		databaseConfig.sqlite.poolSize = 1;
+		databaseConfig.type = 'sqlite';
+		expect(databaseConfig.isLegacySqlite).toBe(false);
+	});
+
+	test('`isLegacySqlite` returns true if dbType is `sqlite` and `poolSize` is 0', () => {
+		const databaseConfig = Container.get(DatabaseConfig);
+		databaseConfig.sqlite.poolSize = 0;
+		databaseConfig.type = 'sqlite';
+		expect(databaseConfig.isLegacySqlite).toBe(true);
+	});
+});

--- a/packages/@n8n/config/src/configs/__tests__/database.config.test.ts
+++ b/packages/@n8n/config/src/configs/__tests__/database.config.test.ts
@@ -8,6 +8,11 @@ describe('DatabaseConfig', () => {
 		jest.clearAllMocks();
 	});
 
+	test('`isLegacySqlite` defaults to true', () => {
+		const databaseConfig = Container.get(DatabaseConfig);
+		expect(databaseConfig.isLegacySqlite).toBe(true);
+	});
+
 	test.each(['mariadb', 'mysqldb', 'postgresdb'] satisfies Array<DatabaseConfig['type']>)(
 		'`isLegacySqlite` returns false if dbType is `%s`',
 		(dbType) => {

--- a/packages/@n8n/config/src/configs/database.config.ts
+++ b/packages/@n8n/config/src/configs/database.config.ts
@@ -145,6 +145,10 @@ export class DatabaseConfig {
 	@Env('DB_TYPE', dbTypeSchema)
 	type: DbType = 'sqlite';
 
+	get isLegacySqlite() {
+		return this.type === 'sqlite' && this.sqlite.poolSize === 0;
+	}
+
 	/** Prefix for table names */
 	@Env('DB_TABLE_PREFIX')
 	tablePrefix: string = '';

--- a/packages/@n8n/config/src/configs/database.config.ts
+++ b/packages/@n8n/config/src/configs/database.config.ts
@@ -145,6 +145,11 @@ export class DatabaseConfig {
 	@Env('DB_TYPE', dbTypeSchema)
 	type: DbType = 'sqlite';
 
+	/**
+	 * Is true if the default sqlite data source of TypeORM is used, as opposed
+	 * to any other (e.g. postgres)
+	 * This also returns false if n8n's new pooled sqlite data source is used.
+	 */
 	get isLegacySqlite() {
 		return this.type === 'sqlite' && this.sqlite.poolSize === 0;
 	}

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -71,6 +71,7 @@ describe('GlobalConfig', () => {
 			},
 			tablePrefix: '',
 			type: 'sqlite',
+			isLegacySqlite: true,
 		},
 		credentials: {
 			defaultName: 'My credentials',

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -311,7 +311,7 @@ describe('GlobalConfig', () => {
 		process.env = {};
 		const config = Container.get(GlobalConfig);
 		// Makes sure the objects are structurally equal while respecting getters,
-		// which `toEqual` and `toEqual` does not do.
+		// which `toEqual` and `toBe` does not do.
 		expect(defaultConfig).toMatchObject(config);
 		expect(config).toMatchObject(defaultConfig);
 		expect(mockFs.readFileSync).not.toHaveBeenCalled();
@@ -380,7 +380,7 @@ describe('GlobalConfig', () => {
 			},
 		};
 		// Makes sure the objects are structurally equal while respecting getters,
-		// which `toEqual` and `toEqual` does not do.
+		// which `toEqual` and `toBe` does not do.
 		expect(config).toMatchObject(expected);
 		expect(expected).toMatchObject(config);
 		expect(mockFs.readFileSync).toHaveBeenCalled();

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -310,7 +310,10 @@ describe('GlobalConfig', () => {
 	it('should use all default values when no env variables are defined', () => {
 		process.env = {};
 		const config = Container.get(GlobalConfig);
-		expect(structuredClone(config)).toEqual(defaultConfig);
+		// Makes sure the objects are structurally equal while respecting getters,
+		// which `toEqual` and `toEqual` does not do.
+		expect(defaultConfig).toMatchObject(config);
+		expect(config).toMatchObject(defaultConfig);
 		expect(mockFs.readFileSync).not.toHaveBeenCalled();
 	});
 
@@ -366,7 +369,7 @@ describe('GlobalConfig', () => {
 		mockFs.readFileSync.calledWith(passwordFile, 'utf8').mockReturnValueOnce('password-from-file');
 
 		const config = Container.get(GlobalConfig);
-		expect(structuredClone(config)).toEqual({
+		const expected = {
 			...defaultConfig,
 			database: {
 				...defaultConfig.database,
@@ -375,7 +378,11 @@ describe('GlobalConfig', () => {
 					password: 'password-from-file',
 				},
 			},
-		});
+		};
+		// Makes sure the objects are structurally equal while respecting getters,
+		// which `toEqual` and `toEqual` does not do.
+		expect(config).toMatchObject(expected);
+		expect(expected).toMatchObject(config);
 		expect(mockFs.readFileSync).toHaveBeenCalled();
 	});
 

--- a/packages/@n8n/config/tsconfig.build.json
+++ b/packages/@n8n/config/tsconfig.build.json
@@ -7,5 +7,5 @@
 		"tsBuildInfoFile": "dist/build.tsbuildinfo"
 	},
 	"include": ["src/**/*.ts"],
-	"exclude": ["test/**"]
+	"exclude": ["test/**", "src/**/__tests__/**"]
 }

--- a/packages/cli/src/services/project.service.ee.ts
+++ b/packages/cli/src/services/project.service.ee.ts
@@ -189,9 +189,8 @@ export class ProjectService {
 		trx: EntityManager,
 	) {
 		const limit = this.licenseState.getMaxTeamProjects();
-
-		const teamProjectCount = await trx.count(Project, { where: { type: 'team' } });
 		if (limit !== UNLIMITED_LICENSE_QUOTA) {
+			const teamProjectCount = await trx.count(Project, { where: { type: 'team' } });
 			if (limit <= teamProjectCount) {
 				throw new TeamProjectOverQuotaError(limit);
 			}

--- a/packages/cli/src/services/project.service.ee.ts
+++ b/packages/cli/src/services/project.service.ee.ts
@@ -1,4 +1,5 @@
 import type { CreateProjectDto, ProjectType, UpdateProjectDto } from '@n8n/api-types';
+import { GlobalConfig } from '@n8n/config';
 import { UNLIMITED_LICENSE_QUOTA } from '@n8n/constants';
 import type { User } from '@n8n/db';
 import {
@@ -47,6 +48,7 @@ export class ProjectService {
 		private readonly sharedCredentialsRepository: SharedCredentialsRepository,
 		private readonly cacheService: CacheService,
 		private readonly license: License,
+		private readonly globalConfig: GlobalConfig,
 	) {}
 
 	private get workflowService() {
@@ -181,23 +183,51 @@ export class ProjectService {
 		return await this.projectRelationRepository.getPersonalProjectOwners(projectIds);
 	}
 
-	async createTeamProject(adminUser: User, data: CreateProjectDto): Promise<Project> {
+	private async createTeamProjectWithEntityManager(
+		adminUser: User,
+		data: CreateProjectDto,
+		trx: EntityManager,
+	) {
+		// TODO: use LicenseState instead
 		const limit = this.license.getTeamProjectLimit();
-		if (
-			limit !== UNLIMITED_LICENSE_QUOTA &&
-			limit <= (await this.projectRepository.count({ where: { type: 'team' } }))
-		) {
-			throw new TeamProjectOverQuotaError(limit);
+
+		const teamProjectCount = await trx.count(Project, { where: { type: 'team' } });
+		if (limit !== UNLIMITED_LICENSE_QUOTA) {
+			if (limit <= teamProjectCount) {
+				throw new TeamProjectOverQuotaError(limit);
+			}
 		}
 
-		const project = await this.projectRepository.save(
+		const project = await trx.save(
+			Project,
 			this.projectRepository.create({ ...data, type: 'team' }),
 		);
 
 		// Link admin
-		await this.addUser(project.id, adminUser.id, 'project:admin');
+		await this.addUser(project.id, adminUser.id, 'project:admin', trx);
 
 		return project;
+	}
+
+	async createTeamProject(adminUser: User, data: CreateProjectDto): Promise<Project> {
+		if (
+			this.globalConfig.database.type === 'sqlite' &&
+			this.globalConfig.database.sqlite.poolSize === 0
+		) {
+			// Using transaction in the sqlite legacy driver can cause data loss, so
+			// we avoid this here.
+			return await this.createTeamProjectWithEntityManager(
+				adminUser,
+				data,
+				this.projectRepository.manager,
+			);
+		} else {
+			// This needs to be SERIALIZABLE otherwise the count would not block a
+			// concurrent transaction and we could insert multiple projects.
+			return await this.projectRepository.manager.transaction('SERIALIZABLE', async (trx) => {
+				return await this.createTeamProjectWithEntityManager(adminUser, data, trx);
+			});
+		}
 	}
 
 	async updateProject(
@@ -326,8 +356,9 @@ export class ProjectService {
 		});
 	}
 
-	async addUser(projectId: string, userId: string, role: ProjectRole) {
-		return await this.projectRelationRepository.save({
+	async addUser(projectId: string, userId: string, role: ProjectRole, trx?: EntityManager) {
+		trx = trx ?? this.projectRelationRepository.manager;
+		return await trx.save(ProjectRelation, {
 			projectId,
 			userId,
 			role,

--- a/packages/cli/src/services/project.service.ee.ts
+++ b/packages/cli/src/services/project.service.ee.ts
@@ -208,10 +208,7 @@ export class ProjectService {
 	}
 
 	async createTeamProject(adminUser: User, data: CreateProjectDto): Promise<Project> {
-		if (
-			this.globalConfig.database.type === 'sqlite' &&
-			this.globalConfig.database.sqlite.poolSize === 0
-		) {
+		if (this.globalConfig.database.isLegacySqlite) {
 			// Using transaction in the sqlite legacy driver can cause data loss, so
 			// we avoid this here.
 			return await this.createTeamProjectWithEntityManager(

--- a/packages/cli/test/integration/project.api.test.ts
+++ b/packages/cli/test/integration/project.api.test.ts
@@ -440,7 +440,7 @@ describe('POST /projects/', () => {
 	if (!globalConfig.database.isLegacySqlite) {
 		test('should respect the quota when trying to create multiple projects in parallel (no race conditions)', async () => {
 			expect(await Container.get(ProjectRepository).count({ where: { type: 'team' } })).toBe(0);
-			testServer.license.setQuota('quota:maxTeamProjects', 1);
+			testServer.license.setQuota('quota:maxTeamProjects', 3);
 			const ownerUser = await createOwner();
 			const ownerAgent = testServer.authAgentFor(ownerUser);
 			expect(await Container.get(ProjectRepository).count({ where: { type: 'team' } })).toBe(0);
@@ -454,7 +454,7 @@ describe('POST /projects/', () => {
 				ownerAgent.post('/projects/').send({ name: 'Test Team Project 6' }),
 			]);
 
-			expect(await Container.get(ProjectRepository).count({ where: { type: 'team' } })).toBe(1);
+			expect(await Container.get(ProjectRepository).count({ where: { type: 'team' } })).toBe(3);
 		});
 	}
 });

--- a/packages/cli/test/integration/project.api.test.ts
+++ b/packages/cli/test/integration/project.api.test.ts
@@ -443,7 +443,9 @@ describe('POST /projects/', () => {
 			testServer.license.setQuota('quota:maxTeamProjects', 3);
 			const ownerUser = await createOwner();
 			const ownerAgent = testServer.authAgentFor(ownerUser);
-			expect(await Container.get(ProjectRepository).count({ where: { type: 'team' } })).toBe(0);
+			await expect(
+				Container.get(ProjectRepository).count({ where: { type: 'team' } }),
+			).resolves.toBe(0);
 
 			await Promise.all([
 				ownerAgent.post('/projects/').send({ name: 'Test Team Project 1' }),
@@ -454,7 +456,9 @@ describe('POST /projects/', () => {
 				ownerAgent.post('/projects/').send({ name: 'Test Team Project 6' }),
 			]);
 
-			expect(await Container.get(ProjectRepository).count({ where: { type: 'team' } })).toBe(3);
+			await expect(
+				Container.get(ProjectRepository).count({ where: { type: 'team' } }),
+			).resolves.toBe(3);
 		});
 	}
 });

--- a/packages/cli/test/integration/project.api.test.ts
+++ b/packages/cli/test/integration/project.api.test.ts
@@ -432,6 +432,25 @@ describe('POST /projects/', () => {
 
 		expect(await Container.get(ProjectRepository).count({ where: { type: 'team' } })).toBe(2);
 	});
+
+	test('should respect the quota when trying to create multiple projects in parallel (no race conditions)', async () => {
+		expect(await Container.get(ProjectRepository).count({ where: { type: 'team' } })).toBe(0);
+		testServer.license.setQuota('quota:maxTeamProjects', 1);
+		const ownerUser = await createOwner();
+		const ownerAgent = testServer.authAgentFor(ownerUser);
+		expect(await Container.get(ProjectRepository).count({ where: { type: 'team' } })).toBe(0);
+
+		await Promise.all([
+			ownerAgent.post('/projects/').send({ name: 'Test Team Project 1' }),
+			ownerAgent.post('/projects/').send({ name: 'Test Team Project 2' }),
+			ownerAgent.post('/projects/').send({ name: 'Test Team Project 3' }),
+			ownerAgent.post('/projects/').send({ name: 'Test Team Project 4' }),
+			ownerAgent.post('/projects/').send({ name: 'Test Team Project 5' }),
+			ownerAgent.post('/projects/').send({ name: 'Test Team Project 6' }),
+		]);
+
+		expect(await Container.get(ProjectRepository).count({ where: { type: 'team' } })).toBe(1);
+	});
 });
 
 describe('PATCH /projects/:projectId', () => {

--- a/packages/cli/test/integration/project.api.test.ts
+++ b/packages/cli/test/integration/project.api.test.ts
@@ -1,5 +1,6 @@
+import { GlobalConfig } from '@n8n/config';
 import type { Project } from '@n8n/db';
-import { FolderRepository } from '@n8n/db';
+import { dbType, FolderRepository } from '@n8n/db';
 import { ProjectRelationRepository } from '@n8n/db';
 import { ProjectRepository } from '@n8n/db';
 import { SharedCredentialsRepository } from '@n8n/db';
@@ -434,6 +435,13 @@ describe('POST /projects/', () => {
 	});
 
 	test('should respect the quota when trying to create multiple projects in parallel (no race conditions)', async () => {
+		const globalConfig = Container.get(GlobalConfig);
+		// Preventing this relies on transactions and we can't use them with the
+		// sqlite legacy driver due to data loss risks.
+		if (dbType === 'sqlite' && globalConfig.database.sqlite.poolSize === 0) {
+			return expect(1).toBe(1);
+		}
+
 		expect(await Container.get(ProjectRepository).count({ where: { type: 'team' } })).toBe(0);
 		testServer.license.setQuota('quota:maxTeamProjects', 1);
 		const ownerUser = await createOwner();

--- a/packages/cli/test/integration/workflows/workflow-sharing.service.test.ts
+++ b/packages/cli/test/integration/workflows/workflow-sharing.service.test.ts
@@ -1,13 +1,13 @@
+import { LicenseState } from '@n8n/backend-common';
 import type { User } from '@n8n/db';
 import { Container } from '@n8n/di';
+import { mock } from 'jest-mock-extended';
 
-import { License } from '@/license';
 import { ProjectService } from '@/services/project.service.ee';
 import { WorkflowSharingService } from '@/workflows/workflow-sharing.service';
 
 import { createUser } from '../shared/db/users';
 import { createWorkflow, shareWorkflowWithUsers } from '../shared/db/workflows';
-import { LicenseMocker } from '../shared/license';
 import * as testDb from '../shared/test-db';
 
 let owner: User;
@@ -21,11 +21,10 @@ beforeAll(async () => {
 	owner = await createUser({ role: 'global:owner' });
 	member = await createUser({ role: 'global:member' });
 	anotherMember = await createUser({ role: 'global:member' });
-	let license: LicenseMocker;
-	license = new LicenseMocker();
-	license.mock(Container.get(License));
-	license.enable('feat:sharing');
-	license.setQuota('quota:maxTeamProjects', -1);
+	const licenseMock = mock<LicenseState>();
+	licenseMock.isSharingLicensed.mockReturnValue(true);
+	licenseMock.getMaxTeamProjects.mockReturnValue(-1);
+	Container.set(LicenseState, licenseMock);
 	workflowSharingService = Container.get(WorkflowSharingService);
 	projectService = Container.get(ProjectService);
 });


### PR DESCRIPTION

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This fixes a race condition that allows creating more projects than the license allows.
This is fixed by using a serializable transaction.
This does not fix it for the legacy sqlite driver, since the driver does not work well with transactions (can lead to data loss). This is not an issue though since that this driver is only used by the community edition and that edition does not allow creating team projects at all.

Additionally it refactors the ProjectService to use LicenseState instead of License.


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
https://linear.app/n8n/issue/PAY-2725/411-race-condition-multiple-projects


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
