### PR TITLE
feat(editor): Display archived tag on WorkflowHistory (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/views/WorkflowHistory.test.ts
+++ b/packages/frontend/editor-ui/src/views/WorkflowHistory.test.ts
@@ -1,4 +1,5 @@
 import type { MockInstance } from 'vitest';
+import { flushPromises } from '@vue/test-utils';
 import { createTestingPinia } from '@pinia/testing';
 import { waitFor, within } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
@@ -228,5 +229,37 @@ describe('WorkflowHistory', () => {
 				workflow_id: workflowId,
 			});
 		});
+	});
+
+	it('should display archived tag on header if workflow is archived', async () => {
+		vi.spyOn(workflowsStore, 'fetchWorkflow').mockResolvedValue({
+			id: workflowId,
+			name: 'Test Workflow',
+			isArchived: true,
+		} as IWorkflowDb);
+
+		route.params.workflowId = workflowId;
+
+		const { container, getByTestId } = renderComponent({ pinia });
+		await flushPromises();
+
+		expect(getByTestId('workflow-archived-tag')).toBeInTheDocument();
+		expect(container.textContent).toContain('Test Workflow');
+	});
+
+	it('should not display archived tag on header if workflow is not archived', async () => {
+		vi.spyOn(workflowsStore, 'fetchWorkflow').mockResolvedValue({
+			id: workflowId,
+			name: 'Test Workflow',
+			isArchived: false,
+		} as IWorkflowDb);
+
+		route.params.workflowId = workflowId;
+
+		const { queryByTestId, container } = renderComponent({ pinia });
+		await flushPromises();
+
+		expect(queryByTestId('workflow-archived-tag')).not.toBeInTheDocument();
+		expect(container.textContent).toContain('Test Workflow');
 	});
 });

--- a/packages/frontend/editor-ui/src/views/WorkflowHistory.vue
+++ b/packages/frontend/editor-ui/src/views/WorkflowHistory.vue
@@ -329,9 +329,16 @@ watchEffect(async () => {
 </script>
 <template>
 	<div :class="$style.view">
-		<n8n-heading :class="$style.header" tag="h2" size="medium">
-			{{ activeWorkflow?.name }}
-		</n8n-heading>
+		<div :class="$style.header">
+			<n8n-heading tag="h2" size="medium">
+				{{ activeWorkflow?.name }}
+			</n8n-heading>
+			<span v-if="activeWorkflow?.isArchived">
+				<N8nBadge class="ml-s" theme="tertiary" bold data-test-id="workflow-archived-tag">
+					{{ i18n.baseText('workflows.item.archived') }}
+				</N8nBadge>
+			</span>
+		</div>
 		<div :class="$style.corner">
 			<n8n-heading tag="h2" size="medium" bold>
 				{{ i18n.baseText('workflowHistory.title') }}


### PR DESCRIPTION
## Summary

<img width="1779" alt="Screenshot 2025-05-08 at 15 27 01" src="https://github.com/user-attachments/assets/43479e5a-9daa-47e1-9f70-0e7ffc8c9c97" />

Show Archived tag on the WorkflowHistory page if the active workflow is currently archived. We don't keep workflow archive status in history (at least for now), only the status of the workflow currently matters here.

Users are able to restore workflows that are archived, but that's outside the scope of this PR.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3552/feature-fixing-feedback-issues

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
