### PR TITLE
fix(AI Agent Node): Fix tool calling when tools run in a loop

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/ToolWorkflowV2.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/ToolWorkflowV2.node.ts
@@ -39,6 +39,7 @@ export class ToolWorkflowV2 implements INodeType {
 		const description = this.getNodeParameter('description', itemIndex) as string;
 
 		const tool = await workflowToolService.createTool({
+			ctx: this,
 			name,
 			description,
 			itemIndex,

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/ToolWorkflowV2.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/ToolWorkflowV2.test.ts
@@ -13,6 +13,10 @@ import { WorkflowToolService } from './utils/WorkflowToolService';
 
 // Mock ISupplyDataFunctions interface
 function createMockContext(overrides?: Partial<ISupplyDataFunctions>): ISupplyDataFunctions {
+	let runIndex = 0;
+	const getRunDataLength = jest.fn(() => {
+		return runIndex++;
+	});
 	return {
 		runIndex: 0,
 		getNodeParameter: jest.fn(),
@@ -26,6 +30,7 @@ function createMockContext(overrides?: Partial<ISupplyDataFunctions>): ISupplyDa
 		getInputData: jest.fn(),
 		getMode: jest.fn(),
 		getRestApiUrl: jest.fn(),
+		getRunDataLength,
 		getTimezone: jest.fn(),
 		getWorkflow: jest.fn(),
 		getWorkflowStaticData: jest.fn(),
@@ -56,6 +61,7 @@ describe('WorkflowTool::WorkflowToolService', () => {
 	describe('createTool', () => {
 		it('should create a basic dynamic tool when schema is not used', async () => {
 			const toolParams = {
+				ctx: context,
 				name: 'TestTool',
 				description: 'Test Description',
 				itemIndex: 0,
@@ -70,6 +76,7 @@ describe('WorkflowTool::WorkflowToolService', () => {
 
 		it('should create a tool that can handle successful execution', async () => {
 			const toolParams = {
+				ctx: context,
 				name: 'TestTool',
 				description: 'Test Description',
 				itemIndex: 0,
@@ -112,6 +119,7 @@ describe('WorkflowTool::WorkflowToolService', () => {
 
 		it('should handle errors during tool execution', async () => {
 			const toolParams = {
+				ctx: context,
 				name: 'TestTool',
 				description: 'Test Description',
 				itemIndex: 0,

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/ToolWorkflowV2.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/ToolWorkflowV2.test.ts
@@ -14,7 +14,7 @@ import { WorkflowToolService } from './utils/WorkflowToolService';
 // Mock ISupplyDataFunctions interface
 function createMockContext(overrides?: Partial<ISupplyDataFunctions>): ISupplyDataFunctions {
 	let runIndex = 0;
-	const getLatestRunIndex = jest.fn(() => {
+	const nextRunIndex = jest.fn(() => {
 		return runIndex++;
 	});
 	return {
@@ -30,7 +30,7 @@ function createMockContext(overrides?: Partial<ISupplyDataFunctions>): ISupplyDa
 		getInputData: jest.fn(),
 		getMode: jest.fn(),
 		getRestApiUrl: jest.fn(),
-		getLatestRunIndex,
+		nextRunIndex,
 		getTimezone: jest.fn(),
 		getWorkflow: jest.fn(),
 		getWorkflowStaticData: jest.fn(),

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/ToolWorkflowV2.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/ToolWorkflowV2.test.ts
@@ -14,7 +14,7 @@ import { WorkflowToolService } from './utils/WorkflowToolService';
 // Mock ISupplyDataFunctions interface
 function createMockContext(overrides?: Partial<ISupplyDataFunctions>): ISupplyDataFunctions {
 	let runIndex = 0;
-	const getRunDataLength = jest.fn(() => {
+	const getLatestRunIndex = jest.fn(() => {
 		return runIndex++;
 	});
 	return {
@@ -30,7 +30,7 @@ function createMockContext(overrides?: Partial<ISupplyDataFunctions>): ISupplyDa
 		getInputData: jest.fn(),
 		getMode: jest.fn(),
 		getRestApiUrl: jest.fn(),
-		getRunDataLength,
+		getLatestRunIndex,
 		getTimezone: jest.fn(),
 		getWorkflow: jest.fn(),
 		getWorkflowStaticData: jest.fn(),

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/ToolWorkflowV2.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/ToolWorkflowV2.test.ts
@@ -14,7 +14,7 @@ import { WorkflowToolService } from './utils/WorkflowToolService';
 // Mock ISupplyDataFunctions interface
 function createMockContext(overrides?: Partial<ISupplyDataFunctions>): ISupplyDataFunctions {
 	let runIndex = 0;
-	const nextRunIndex = jest.fn(() => {
+	const getNextRunIndex = jest.fn(() => {
 		return runIndex++;
 	});
 	return {
@@ -30,7 +30,7 @@ function createMockContext(overrides?: Partial<ISupplyDataFunctions>): ISupplyDa
 		getInputData: jest.fn(),
 		getMode: jest.fn(),
 		getRestApiUrl: jest.fn(),
-		nextRunIndex,
+		getNextRunIndex,
 		getTimezone: jest.fn(),
 		getWorkflow: jest.fn(),
 		getWorkflowStaticData: jest.fn(),

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/utils/WorkflowToolService.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/utils/WorkflowToolService.ts
@@ -70,8 +70,6 @@ export class WorkflowToolService {
 		description: string;
 		itemIndex: number;
 	}): Promise<DynamicTool | DynamicStructuredTool> {
-		console.log('node', ctx.getNode());
-		console.log('runDataLength', ctx.getRunDataLength());
 		// Handler for the tool execution, will be called when the tool is executed
 		// This function will execute the sub-workflow and return the response
 		const toolHandler = async (
@@ -79,7 +77,6 @@ export class WorkflowToolService {
 			runManager?: CallbackManagerForToolRun,
 		): Promise<IDataObject | IDataObject[] | string> => {
 			const localRunIndex: number = ctx.getRunDataLength();
-			console.log(`runIndex: ${localRunIndex}`);
 			// We need to clone the context here to handle runIndex correctly
 			// Otherwise the runIndex will be shared between different executions
 			// Causing incorrect data to be passed to the sub-workflow and via $fromAI

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/utils/WorkflowToolService.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/utils/WorkflowToolService.ts
@@ -60,22 +60,26 @@ export class WorkflowToolService {
 
 	// Creates the tool based on the provided parameters
 	async createTool({
+		ctx,
 		name,
 		description,
 		itemIndex,
 	}: {
+		ctx: ISupplyDataFunctions;
 		name: string;
 		description: string;
 		itemIndex: number;
 	}): Promise<DynamicTool | DynamicStructuredTool> {
-		let runIndex = 0;
+		console.log('node', ctx.getNode());
+		console.log('runDataLength', ctx.getRunDataLength());
 		// Handler for the tool execution, will be called when the tool is executed
 		// This function will execute the sub-workflow and return the response
 		const toolHandler = async (
 			query: string | IDataObject,
 			runManager?: CallbackManagerForToolRun,
 		): Promise<IDataObject | IDataObject[] | string> => {
-			const localRunIndex = runIndex++;
+			const localRunIndex: number = ctx.getRunDataLength();
+			console.log(`runIndex: ${localRunIndex}`);
 			// We need to clone the context here to handle runIndex correctly
 			// Otherwise the runIndex will be shared between different executions
 			// Causing incorrect data to be passed to the sub-workflow and via $fromAI
@@ -319,6 +323,8 @@ export class WorkflowToolService {
 			jsonData = currentWorkflowInputs[itemIndex].json;
 		}
 
+		console.log(jsonData);
+
 		const newItem = await manual.execute.call(
 			context,
 			{ json: jsonData },
@@ -327,6 +333,7 @@ export class WorkflowToolService {
 			rawData,
 			context.getNode(),
 		);
+		console.log('new item:', newItem);
 
 		return [newItem] as INodeExecutionData[];
 	}

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/utils/WorkflowToolService.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/utils/WorkflowToolService.ts
@@ -72,16 +72,17 @@ export class WorkflowToolService {
 	}): Promise<DynamicTool | DynamicStructuredTool> {
 		// Handler for the tool execution, will be called when the tool is executed
 		// This function will execute the sub-workflow and return the response
+		let toolRunIndex: number = ctx.nextRunIndex() - 1;
 		const toolHandler = async (
 			query: string | IDataObject,
 			runManager?: CallbackManagerForToolRun,
 		): Promise<IDataObject | IDataObject[] | string> => {
-			const localRunIndex: number = ctx.getLatestRunIndex();
+			toolRunIndex++;
 			// We need to clone the context here to handle runIndex correctly
 			// Otherwise the runIndex will be shared between different executions
 			// Causing incorrect data to be passed to the sub-workflow and via $fromAI
 			const context = this.baseContext.cloneWith({
-				runIndex: localRunIndex,
+				runIndex: toolRunIndex,
 				inputData: [[{ json: { query } }]],
 			});
 
@@ -115,7 +116,7 @@ export class WorkflowToolService {
 
 				void context.addOutputData(
 					NodeConnectionTypes.AiTool,
-					localRunIndex,
+					toolRunIndex,
 					[responseData],
 					metadata,
 				);
@@ -128,7 +129,7 @@ export class WorkflowToolService {
 				const metadata = parseErrorMetadata(error);
 				void context.addOutputData(
 					NodeConnectionTypes.AiTool,
-					localRunIndex,
+					toolRunIndex,
 					executionError,
 					metadata,
 				);

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/utils/WorkflowToolService.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/utils/WorkflowToolService.ts
@@ -76,7 +76,7 @@ export class WorkflowToolService {
 			query: string | IDataObject,
 			runManager?: CallbackManagerForToolRun,
 		): Promise<IDataObject | IDataObject[] | string> => {
-			const localRunIndex: number = ctx.getRunDataLength();
+			const localRunIndex: number = ctx.getLatestRunIndex();
 			// We need to clone the context here to handle runIndex correctly
 			// Otherwise the runIndex will be shared between different executions
 			// Causing incorrect data to be passed to the sub-workflow and via $fromAI

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/utils/WorkflowToolService.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/utils/WorkflowToolService.ts
@@ -320,8 +320,6 @@ export class WorkflowToolService {
 			jsonData = currentWorkflowInputs[itemIndex].json;
 		}
 
-		console.log(jsonData);
-
 		const newItem = await manual.execute.call(
 			context,
 			{ json: jsonData },
@@ -330,7 +328,6 @@ export class WorkflowToolService {
 			rawData,
 			context.getNode(),
 		);
-		console.log('new item:', newItem);
 
 		return [newItem] as INodeExecutionData[];
 	}

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/supply-data-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/supply-data-context.test.ts
@@ -188,9 +188,9 @@ describe('SupplyDataContext', () => {
 		});
 	});
 
-	describe('getLatestRunIndex', () => {
+	describe('nextRunIndex', () => {
 		it('should return 0 as the default latest run index', () => {
-			const latestRunIndex = supplyDataContext.getLatestRunIndex();
+			const latestRunIndex = supplyDataContext.nextRunIndex();
 			expect(latestRunIndex).toBe(0);
 		});
 
@@ -214,7 +214,7 @@ describe('SupplyDataContext', () => {
 				abortSignal,
 			);
 
-			const latestRunIndex = supplyDataContext.getLatestRunIndex();
+			const latestRunIndex = supplyDataContext.nextRunIndex();
 
 			expect(latestRunIndex).toBe(2);
 		});

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/supply-data-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/supply-data-context.test.ts
@@ -15,6 +15,7 @@ import type {
 	ICredentialDataDecryptedObject,
 	NodeConnectionType,
 } from 'n8n-workflow';
+import type { IRunData } from 'n8n-workflow';
 import { ApplicationError, NodeConnectionTypes } from 'n8n-workflow';
 
 import { describeCommonTests } from './shared-tests';
@@ -184,6 +185,38 @@ describe('SupplyDataContext', () => {
 			const clone = supplyDataContext.cloneWith({ runIndex: 12, inputData: [[{ json: {} }]] });
 			expect(clone.runIndex).toBe(12);
 			expect(clone).not.toBe(supplyDataContext);
+		});
+	});
+
+	describe('getLatestRunIndex', () => {
+		it('should return 0 as the default latest run index', () => {
+			const latestRunIndex = supplyDataContext.getLatestRunIndex();
+			expect(latestRunIndex).toBe(0);
+		});
+
+		it('should return the length of the run execution data for the node', () => {
+			const runData = mock<IRunData>();
+			const runExecutionData = mock<IRunExecutionData>({
+				resultData: { runData: { [node.name]: [runData, runData] } },
+			});
+			const supplyDataContext = new SupplyDataContext(
+				workflow,
+				node,
+				additionalData,
+				mode,
+				runExecutionData,
+				runIndex,
+				connectionInputData,
+				inputData,
+				connectionType,
+				executeData,
+				[closeFn],
+				abortSignal,
+			);
+
+			const latestRunIndex = supplyDataContext.getLatestRunIndex();
+
+			expect(latestRunIndex).toBe(2);
 		});
 	});
 });

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/supply-data-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/supply-data-context.test.ts
@@ -188,9 +188,9 @@ describe('SupplyDataContext', () => {
 		});
 	});
 
-	describe('nextRunIndex', () => {
+	describe('getNextRunIndex', () => {
 		it('should return 0 as the default latest run index', () => {
-			const latestRunIndex = supplyDataContext.nextRunIndex();
+			const latestRunIndex = supplyDataContext.getNextRunIndex();
 			expect(latestRunIndex).toBe(0);
 		});
 
@@ -214,7 +214,7 @@ describe('SupplyDataContext', () => {
 				abortSignal,
 			);
 
-			const latestRunIndex = supplyDataContext.nextRunIndex();
+			const latestRunIndex = supplyDataContext.getNextRunIndex();
 
 			expect(latestRunIndex).toBe(2);
 		});

--- a/packages/core/src/execution-engine/node-execution-context/execute-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/execute-context.ts
@@ -200,6 +200,10 @@ export class ExecuteContext extends BaseExecuteContext implements IExecuteFuncti
 		await this.additionalData.hooks?.runHook('sendResponse', [response]);
 	}
 
+	getRunDataLength(): number {
+		throw new ApplicationError('getRunDataLength should not be called on IExecuteFunctions');
+	}
+
 	/** @deprecated use ISupplyDataFunctions.addInputData */
 	addInputData(): { index: number } {
 		throw new ApplicationError('addInputData should not be called on IExecuteFunctions');

--- a/packages/core/src/execution-engine/node-execution-context/execute-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/execute-context.ts
@@ -200,8 +200,8 @@ export class ExecuteContext extends BaseExecuteContext implements IExecuteFuncti
 		await this.additionalData.hooks?.runHook('sendResponse', [response]);
 	}
 
-	getRunDataLength(): number {
-		throw new ApplicationError('getRunDataLength should not be called on IExecuteFunctions');
+	getLatestRunIndex(): number {
+		throw new ApplicationError('getLatestRunIndex should not be called on IExecuteFunctions');
 	}
 
 	/** @deprecated use ISupplyDataFunctions.addInputData */

--- a/packages/core/src/execution-engine/node-execution-context/execute-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/execute-context.ts
@@ -200,8 +200,8 @@ export class ExecuteContext extends BaseExecuteContext implements IExecuteFuncti
 		await this.additionalData.hooks?.runHook('sendResponse', [response]);
 	}
 
-	getLatestRunIndex(): number {
-		throw new ApplicationError('getLatestRunIndex should not be called on IExecuteFunctions');
+	nextRunIndex(): number {
+		throw new ApplicationError('nextRunIndex should not be called on IExecuteFunctions');
 	}
 
 	/** @deprecated use ISupplyDataFunctions.addInputData */

--- a/packages/core/src/execution-engine/node-execution-context/execute-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/execute-context.ts
@@ -200,8 +200,8 @@ export class ExecuteContext extends BaseExecuteContext implements IExecuteFuncti
 		await this.additionalData.hooks?.runHook('sendResponse', [response]);
 	}
 
-	nextRunIndex(): number {
-		throw new ApplicationError('nextRunIndex should not be called on IExecuteFunctions');
+	getNextRunIndex(): number {
+		throw new ApplicationError('getNextRunIndex should not be called on IExecuteFunctions');
 	}
 
 	/** @deprecated use ISupplyDataFunctions.addInputData */

--- a/packages/core/src/execution-engine/node-execution-context/execute-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/execute-context.ts
@@ -200,10 +200,6 @@ export class ExecuteContext extends BaseExecuteContext implements IExecuteFuncti
 		await this.additionalData.hooks?.runHook('sendResponse', [response]);
 	}
 
-	getNextRunIndex(): number {
-		throw new ApplicationError('getNextRunIndex should not be called on IExecuteFunctions');
-	}
-
 	/** @deprecated use ISupplyDataFunctions.addInputData */
 	addInputData(): { index: number } {
 		throw new ApplicationError('addInputData should not be called on IExecuteFunctions');

--- a/packages/core/src/execution-engine/node-execution-context/supply-data-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/supply-data-context.ts
@@ -167,16 +167,21 @@ export class SupplyDataContext extends BaseExecuteContext implements ISupplyData
 		return super.getInputItems(inputIndex, connectionType) ?? [];
 	}
 
+	getRunDataLength(): number {
+		const nodeName = this.node.name;
+		if (this.runExecutionData.resultData.runData.hasOwnProperty(nodeName)) {
+			return this.runExecutionData.resultData.runData[nodeName].length;
+		}
+		return 0;
+	}
+
 	/** @deprecated create a context object with inputData for every runIndex */
 	addInputData(
 		connectionType: AINodeConnectionType,
 		data: INodeExecutionData[][],
 	): { index: number } {
 		const nodeName = this.node.name;
-		let currentNodeRunIndex = 0;
-		if (this.runExecutionData.resultData.runData.hasOwnProperty(nodeName)) {
-			currentNodeRunIndex = this.runExecutionData.resultData.runData[nodeName].length;
-		}
+		const currentNodeRunIndex = this.getRunDataLength();
 
 		this.addExecutionDataFunctions(
 			'input',

--- a/packages/core/src/execution-engine/node-execution-context/supply-data-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/supply-data-context.ts
@@ -169,10 +169,7 @@ export class SupplyDataContext extends BaseExecuteContext implements ISupplyData
 
 	getRunDataLength(): number {
 		const nodeName = this.node.name;
-		if (this.runExecutionData.resultData.runData.hasOwnProperty(nodeName)) {
-			return this.runExecutionData.resultData.runData[nodeName].length;
-		}
-		return 0;
+		return this.runExecutionData.resultData.runData[nodeName]?.length ?? 0;
 	}
 
 	/** @deprecated create a context object with inputData for every runIndex */

--- a/packages/core/src/execution-engine/node-execution-context/supply-data-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/supply-data-context.ts
@@ -167,7 +167,7 @@ export class SupplyDataContext extends BaseExecuteContext implements ISupplyData
 		return super.getInputItems(inputIndex, connectionType) ?? [];
 	}
 
-	getRunDataLength(): number {
+	getLatestRunIndex(): number {
 		const nodeName = this.node.name;
 		return this.runExecutionData.resultData.runData[nodeName]?.length ?? 0;
 	}
@@ -178,7 +178,7 @@ export class SupplyDataContext extends BaseExecuteContext implements ISupplyData
 		data: INodeExecutionData[][],
 	): { index: number } {
 		const nodeName = this.node.name;
-		const currentNodeRunIndex = this.getRunDataLength();
+		const currentNodeRunIndex = this.getLatestRunIndex();
 
 		this.addExecutionDataFunctions(
 			'input',

--- a/packages/core/src/execution-engine/node-execution-context/supply-data-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/supply-data-context.ts
@@ -167,7 +167,7 @@ export class SupplyDataContext extends BaseExecuteContext implements ISupplyData
 		return super.getInputItems(inputIndex, connectionType) ?? [];
 	}
 
-	nextRunIndex(): number {
+	getNextRunIndex(): number {
 		const nodeName = this.node.name;
 		return this.runExecutionData.resultData.runData[nodeName]?.length ?? 0;
 	}
@@ -178,7 +178,7 @@ export class SupplyDataContext extends BaseExecuteContext implements ISupplyData
 		data: INodeExecutionData[][],
 	): { index: number } {
 		const nodeName = this.node.name;
-		const currentNodeRunIndex = this.nextRunIndex();
+		const currentNodeRunIndex = this.getNextRunIndex();
 
 		this.addExecutionDataFunctions(
 			'input',

--- a/packages/core/src/execution-engine/node-execution-context/supply-data-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/supply-data-context.ts
@@ -167,7 +167,7 @@ export class SupplyDataContext extends BaseExecuteContext implements ISupplyData
 		return super.getInputItems(inputIndex, connectionType) ?? [];
 	}
 
-	getLatestRunIndex(): number {
+	nextRunIndex(): number {
 		const nodeName = this.node.name;
 		return this.runExecutionData.resultData.runData[nodeName]?.length ?? 0;
 	}
@@ -178,7 +178,7 @@ export class SupplyDataContext extends BaseExecuteContext implements ISupplyData
 		data: INodeExecutionData[][],
 	): { index: number } {
 		const nodeName = this.node.name;
-		const currentNodeRunIndex = this.getLatestRunIndex();
+		const currentNodeRunIndex = this.nextRunIndex();
 
 		this.addExecutionDataFunctions(
 			'input',

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-input-connection-data.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-input-connection-data.test.ts
@@ -383,7 +383,9 @@ describe('makeHandleToolInvocation', () => {
 		jest.clearAllMocks();
 	});
 	it('should return stringified results when execution is successful', async () => {
-		const mockContext = mock<IExecuteFunctions>();
+		const mockContext = mock<IExecuteFunctions>({
+			getRunDataLength: jest.fn().mockReturnValue(0),
+		});
 		contextFactory.mockReturnValue(mockContext);
 
 		const mockResult = [[{ json: { result: 'success' } }]];
@@ -403,7 +405,9 @@ describe('makeHandleToolInvocation', () => {
 	});
 
 	it('should handle binary data and return a warning message', async () => {
-		const mockContext = mock<IExecuteFunctions>();
+		const mockContext = mock<IExecuteFunctions>({
+			getRunDataLength: jest.fn().mockReturnValue(0),
+		});
 		contextFactory.mockReturnValue(mockContext);
 
 		const mockResult = [[{ json: {}, binary: { file: 'data' } }]];
@@ -434,6 +438,7 @@ describe('makeHandleToolInvocation', () => {
 	it('should continue if json and binary data exist', async () => {
 		const warnFn = jest.fn();
 		const mockContext = mock<IExecuteFunctions>({
+			getRunDataLength: jest.fn().mockReturnValue(0),
 			logger: {
 				warn: warnFn,
 			},
@@ -464,7 +469,9 @@ describe('makeHandleToolInvocation', () => {
 	});
 
 	it('should handle execution errors and return an error message', async () => {
-		const mockContext = mock<IExecuteFunctions>();
+		const mockContext = mock<IExecuteFunctions>({
+			getRunDataLength: jest.fn().mockReturnValue(0),
+		});
 		contextFactory.mockReturnValue(mockContext);
 
 		const error = new Error('Execution failed');

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-input-connection-data.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-input-connection-data.test.ts
@@ -393,7 +393,7 @@ describe('makeHandleToolInvocation', () => {
 	});
 	it('should return stringified results when execution is successful', async () => {
 		const mockContext = mock<IExecuteFunctions>({
-			nextRunIndex: jest.fn().mockReturnValue(0),
+			getNextRunIndex: jest.fn().mockReturnValue(0),
 		});
 		contextFactory.mockReturnValue(mockContext);
 
@@ -416,7 +416,7 @@ describe('makeHandleToolInvocation', () => {
 
 	it('should handle binary data and return a warning message', async () => {
 		const mockContext = mock<IExecuteFunctions>({
-			nextRunIndex: jest.fn().mockReturnValue(0),
+			getNextRunIndex: jest.fn().mockReturnValue(0),
 		});
 		contextFactory.mockReturnValue(mockContext);
 		const mockResult = [[{ json: {}, binary: { file: 'data' } }]];
@@ -448,7 +448,7 @@ describe('makeHandleToolInvocation', () => {
 	it('should continue if json and binary data exist', async () => {
 		const warnFn = jest.fn();
 		const mockContext = mock<IExecuteFunctions>({
-			nextRunIndex: jest.fn().mockReturnValue(0),
+			getNextRunIndex: jest.fn().mockReturnValue(0),
 			logger: {
 				warn: warnFn,
 			},
@@ -480,7 +480,7 @@ describe('makeHandleToolInvocation', () => {
 
 	it('should handle execution errors and return an error message', async () => {
 		const mockContext = mock<IExecuteFunctions>({
-			nextRunIndex: jest.fn().mockReturnValue(0),
+			getNextRunIndex: jest.fn().mockReturnValue(0),
 		});
 		contextFactory.mockReturnValue(mockContext);
 		const error = new Error('Execution failed');

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-input-connection-data.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-input-connection-data.test.ts
@@ -393,7 +393,7 @@ describe('makeHandleToolInvocation', () => {
 	});
 	it('should return stringified results when execution is successful', async () => {
 		const mockContext = mock<IExecuteFunctions>({
-			getLatestRunIndex: jest.fn().mockReturnValue(0),
+			nextRunIndex: jest.fn().mockReturnValue(0),
 		});
 		contextFactory.mockReturnValue(mockContext);
 
@@ -416,7 +416,7 @@ describe('makeHandleToolInvocation', () => {
 
 	it('should handle binary data and return a warning message', async () => {
 		const mockContext = mock<IExecuteFunctions>({
-			getLatestRunIndex: jest.fn().mockReturnValue(0),
+			nextRunIndex: jest.fn().mockReturnValue(0),
 		});
 		contextFactory.mockReturnValue(mockContext);
 		const mockResult = [[{ json: {}, binary: { file: 'data' } }]];
@@ -448,7 +448,7 @@ describe('makeHandleToolInvocation', () => {
 	it('should continue if json and binary data exist', async () => {
 		const warnFn = jest.fn();
 		const mockContext = mock<IExecuteFunctions>({
-			getLatestRunIndex: jest.fn().mockReturnValue(0),
+			nextRunIndex: jest.fn().mockReturnValue(0),
 			logger: {
 				warn: warnFn,
 			},
@@ -480,7 +480,7 @@ describe('makeHandleToolInvocation', () => {
 
 	it('should handle execution errors and return an error message', async () => {
 		const mockContext = mock<IExecuteFunctions>({
-			getLatestRunIndex: jest.fn().mockReturnValue(0),
+			nextRunIndex: jest.fn().mockReturnValue(0),
 		});
 		contextFactory.mockReturnValue(mockContext);
 		const error = new Error('Execution failed');

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-input-connection-data.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-input-connection-data.test.ts
@@ -13,7 +13,8 @@ import type {
 	IExecuteFunctions,
 	IRunData,
 } from 'n8n-workflow';
-import { ITaskData, NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
+import type { ITaskData } from 'n8n-workflow';
+import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 
 import { ExecuteContext } from '../../execute-context';
 import { makeHandleToolInvocation } from '../get-input-connection-data';

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-input-connection-data.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-input-connection-data.test.ts
@@ -391,10 +391,9 @@ describe('makeHandleToolInvocation', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 	});
+
 	it('should return stringified results when execution is successful', async () => {
-		const mockContext = mock<IExecuteFunctions>({
-			getNextRunIndex: jest.fn().mockReturnValue(0),
-		});
+		const mockContext = mock<IExecuteFunctions>();
 		contextFactory.mockReturnValue(mockContext);
 
 		const mockResult = [[{ json: { result: 'success' } }]];
@@ -415,9 +414,7 @@ describe('makeHandleToolInvocation', () => {
 	});
 
 	it('should handle binary data and return a warning message', async () => {
-		const mockContext = mock<IExecuteFunctions>({
-			getNextRunIndex: jest.fn().mockReturnValue(0),
-		});
+		const mockContext = mock<IExecuteFunctions>();
 		contextFactory.mockReturnValue(mockContext);
 		const mockResult = [[{ json: {}, binary: { file: 'data' } }]];
 		execute.mockResolvedValueOnce(mockResult);
@@ -448,7 +445,6 @@ describe('makeHandleToolInvocation', () => {
 	it('should continue if json and binary data exist', async () => {
 		const warnFn = jest.fn();
 		const mockContext = mock<IExecuteFunctions>({
-			getNextRunIndex: jest.fn().mockReturnValue(0),
 			logger: {
 				warn: warnFn,
 			},
@@ -479,9 +475,7 @@ describe('makeHandleToolInvocation', () => {
 	});
 
 	it('should handle execution errors and return an error message', async () => {
-		const mockContext = mock<IExecuteFunctions>({
-			getNextRunIndex: jest.fn().mockReturnValue(0),
-		});
+		const mockContext = mock<IExecuteFunctions>();
 		contextFactory.mockReturnValue(mockContext);
 		const error = new Error('Execution failed');
 		execute.mockRejectedValueOnce(error);

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-input-connection-data.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-input-connection-data.test.ts
@@ -392,7 +392,7 @@ describe('makeHandleToolInvocation', () => {
 	});
 	it('should return stringified results when execution is successful', async () => {
 		const mockContext = mock<IExecuteFunctions>({
-			getRunDataLength: jest.fn().mockReturnValue(0),
+			getLatestRunIndex: jest.fn().mockReturnValue(0),
 		});
 		contextFactory.mockReturnValue(mockContext);
 
@@ -415,7 +415,7 @@ describe('makeHandleToolInvocation', () => {
 
 	it('should handle binary data and return a warning message', async () => {
 		const mockContext = mock<IExecuteFunctions>({
-			getRunDataLength: jest.fn().mockReturnValue(0),
+			getLatestRunIndex: jest.fn().mockReturnValue(0),
 		});
 		contextFactory.mockReturnValue(mockContext);
 		const mockResult = [[{ json: {}, binary: { file: 'data' } }]];
@@ -447,7 +447,7 @@ describe('makeHandleToolInvocation', () => {
 	it('should continue if json and binary data exist', async () => {
 		const warnFn = jest.fn();
 		const mockContext = mock<IExecuteFunctions>({
-			getRunDataLength: jest.fn().mockReturnValue(0),
+			getLatestRunIndex: jest.fn().mockReturnValue(0),
 			logger: {
 				warn: warnFn,
 			},
@@ -479,7 +479,7 @@ describe('makeHandleToolInvocation', () => {
 
 	it('should handle execution errors and return an error message', async () => {
 		const mockContext = mock<IExecuteFunctions>({
-			getRunDataLength: jest.fn().mockReturnValue(0),
+			getLatestRunIndex: jest.fn().mockReturnValue(0),
 		});
 		contextFactory.mockReturnValue(mockContext);
 		const error = new Error('Execution failed');

--- a/packages/core/src/execution-engine/node-execution-context/utils/get-input-connection-data.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/get-input-connection-data.ts
@@ -39,8 +39,12 @@ export function makeHandleToolInvocation(
 	 */
 	let toolRunIndex = 0;
 	return async (toolArgs: IDataObject) => {
-		const runIndex = toolRunIndex++;
-		const context = contextFactory(runIndex);
+		let runIndex = toolRunIndex++;
+		let context = contextFactory(runIndex);
+		if (context.getRunDataLength() !== runIndex) {
+			runIndex = context.getRunDataLength();
+			context = contextFactory(runIndex);
+		}
 		context.addInputData(NodeConnectionTypes.AiTool, [[{ json: toolArgs }]]);
 
 		try {

--- a/packages/core/src/execution-engine/node-execution-context/utils/get-input-connection-data.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/get-input-connection-data.ts
@@ -28,7 +28,7 @@ import type { ExecuteContext, WebhookContext } from '../../node-execution-contex
 // eslint-disable-next-line import/no-cycle
 import { SupplyDataContext } from '../../node-execution-context/supply-data-context';
 
-function nextRunIndex(runExecutionData: IRunExecutionData, nodeName: string) {
+function getNextRunIndex(runExecutionData: IRunExecutionData, nodeName: string) {
 	return runExecutionData.resultData.runData[nodeName]?.length ?? 0;
 }
 
@@ -42,9 +42,14 @@ export function makeHandleToolInvocation(
 	 * This keeps track of how many times this specific AI tool node has been invoked.
 	 * It is incremented on every invocation of the tool to keep the output of each invocation separate from each other.
 	 */
+	// We get the runIndex from the context to handle multiple executions
+	// of the same tool when the tool is used in a loop or in a parallel execution.
+	let runIndex = getNextRunIndex(runExecutionData, node.name);
+
 	return async (toolArgs: IDataObject) => {
-		const runIndex = nextRunIndex(runExecutionData, node.name);
-		const context = contextFactory(runIndex);
+		// Increment the runIndex for the next invocation
+		const localRunIndex = runIndex++;
+		const context = contextFactory(localRunIndex);
 		context.addInputData(NodeConnectionTypes.AiTool, [[{ json: toolArgs }]]);
 
 		try {
@@ -68,13 +73,13 @@ export function makeHandleToolInvocation(
 			}
 
 			// Add output data to the context
-			context.addOutputData(NodeConnectionTypes.AiTool, runIndex, [[{ json: { response } }]]);
+			context.addOutputData(NodeConnectionTypes.AiTool, localRunIndex, [[{ json: { response } }]]);
 
 			// Return the stringified results
 			return JSON.stringify(response);
 		} catch (error) {
 			const nodeError = new NodeOperationError(node, error as Error);
-			context.addOutputData(NodeConnectionTypes.AiTool, runIndex, nodeError);
+			context.addOutputData(NodeConnectionTypes.AiTool, localRunIndex, nodeError);
 			return 'Error during node execution: ' + (nodeError.description ?? nodeError.message);
 		}
 	};

--- a/packages/core/src/execution-engine/node-execution-context/utils/get-input-connection-data.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/get-input-connection-data.ts
@@ -28,7 +28,7 @@ import type { ExecuteContext, WebhookContext } from '../../node-execution-contex
 // eslint-disable-next-line import/no-cycle
 import { SupplyDataContext } from '../../node-execution-context/supply-data-context';
 
-function getLatestRunIndex(runExecutionData: IRunExecutionData, nodeName: string) {
+function nextRunIndex(runExecutionData: IRunExecutionData, nodeName: string) {
 	return runExecutionData.resultData.runData[nodeName]?.length ?? 0;
 }
 
@@ -43,7 +43,7 @@ export function makeHandleToolInvocation(
 	 * It is incremented on every invocation of the tool to keep the output of each invocation separate from each other.
 	 */
 	return async (toolArgs: IDataObject) => {
-		const runIndex = getLatestRunIndex(runExecutionData, node.name);
+		const runIndex = nextRunIndex(runExecutionData, node.name);
 		const context = contextFactory(runIndex);
 		context.addInputData(NodeConnectionTypes.AiTool, [[{ json: toolArgs }]]);
 

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -912,6 +912,7 @@ export type IExecuteFunctions = ExecuteFunctions.GetNodeParameterFn &
 			itemIndex: number,
 			inputIndex?: number,
 		): Promise<unknown>;
+		getRunDataLength(): number;
 		getInputData(inputIndex?: number, connectionType?: NodeConnectionType): INodeExecutionData[];
 		getNodeInputs(): INodeInputConfiguration[];
 		getNodeOutputs(): INodeOutputConfiguration[];
@@ -987,6 +988,7 @@ export type ISupplyDataFunctions = ExecuteFunctions.GetNodeParameterFn &
 		| 'addOutputData'
 		| 'getInputConnectionData'
 		| 'getInputData'
+		| 'getRunDataLength'
 		| 'getNodeOutputs'
 		| 'executeWorkflow'
 		| 'sendMessageToUI'

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -912,7 +912,7 @@ export type IExecuteFunctions = ExecuteFunctions.GetNodeParameterFn &
 			itemIndex: number,
 			inputIndex?: number,
 		): Promise<unknown>;
-		getRunDataLength(): number;
+		getLatestRunIndex(): number;
 		getInputData(inputIndex?: number, connectionType?: NodeConnectionType): INodeExecutionData[];
 		getNodeInputs(): INodeInputConfiguration[];
 		getNodeOutputs(): INodeOutputConfiguration[];
@@ -988,7 +988,7 @@ export type ISupplyDataFunctions = ExecuteFunctions.GetNodeParameterFn &
 		| 'addOutputData'
 		| 'getInputConnectionData'
 		| 'getInputData'
-		| 'getRunDataLength'
+		| 'getLatestRunIndex'
 		| 'getNodeOutputs'
 		| 'executeWorkflow'
 		| 'sendMessageToUI'

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -912,7 +912,6 @@ export type IExecuteFunctions = ExecuteFunctions.GetNodeParameterFn &
 			itemIndex: number,
 			inputIndex?: number,
 		): Promise<unknown>;
-		getNextRunIndex(): number;
 		getInputData(inputIndex?: number, connectionType?: NodeConnectionType): INodeExecutionData[];
 		getNodeInputs(): INodeInputConfiguration[];
 		getNodeOutputs(): INodeOutputConfiguration[];
@@ -988,12 +987,12 @@ export type ISupplyDataFunctions = ExecuteFunctions.GetNodeParameterFn &
 		| 'addOutputData'
 		| 'getInputConnectionData'
 		| 'getInputData'
-		| 'getNextRunIndex'
 		| 'getNodeOutputs'
 		| 'executeWorkflow'
 		| 'sendMessageToUI'
 		| 'helpers'
 	> & {
+		getNextRunIndex(): number;
 		continueOnFail(): boolean;
 		evaluateExpression(expression: string, itemIndex: number): NodeParameterValueType;
 		getWorkflowDataProxy(itemIndex: number): IWorkflowDataProxyData;

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -912,7 +912,7 @@ export type IExecuteFunctions = ExecuteFunctions.GetNodeParameterFn &
 			itemIndex: number,
 			inputIndex?: number,
 		): Promise<unknown>;
-		nextRunIndex(): number;
+		getNextRunIndex(): number;
 		getInputData(inputIndex?: number, connectionType?: NodeConnectionType): INodeExecutionData[];
 		getNodeInputs(): INodeInputConfiguration[];
 		getNodeOutputs(): INodeOutputConfiguration[];
@@ -988,7 +988,7 @@ export type ISupplyDataFunctions = ExecuteFunctions.GetNodeParameterFn &
 		| 'addOutputData'
 		| 'getInputConnectionData'
 		| 'getInputData'
-		| 'nextRunIndex'
+		| 'getNextRunIndex'
 		| 'getNodeOutputs'
 		| 'executeWorkflow'
 		| 'sendMessageToUI'

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -912,7 +912,7 @@ export type IExecuteFunctions = ExecuteFunctions.GetNodeParameterFn &
 			itemIndex: number,
 			inputIndex?: number,
 		): Promise<unknown>;
-		getLatestRunIndex(): number;
+		nextRunIndex(): number;
 		getInputData(inputIndex?: number, connectionType?: NodeConnectionType): INodeExecutionData[];
 		getNodeInputs(): INodeInputConfiguration[];
 		getNodeOutputs(): INodeOutputConfiguration[];
@@ -988,7 +988,7 @@ export type ISupplyDataFunctions = ExecuteFunctions.GetNodeParameterFn &
 		| 'addOutputData'
 		| 'getInputConnectionData'
 		| 'getInputData'
-		| 'getLatestRunIndex'
+		| 'nextRunIndex'
 		| 'getNodeOutputs'
 		| 'executeWorkflow'
 		| 'sendMessageToUI'


### PR DESCRIPTION
## Summary

This PR fixes a long-standing issue of tools executed from an AI agent inside a loop (or with multiple invocations) always being passed the first item of the loop as args.

A workflow from @OlegIvaniv that covers related use cases is attached below:
[Agent_in_the_loop_Oleg.json](https://github.com/user-attachments/files/20119968/Agent_in_the_loop_Oleg.json)

Once this PR is merged the workflow should be included in the workflow tests.

## Related Linear tickets, Github issues, and Community forum posts

Closes #14032 
Resolves https://linear.app/n8n/issue/AI-917/community-issue-agent-in-the-loop
Resolves https://linear.app/n8n/issue/AI-927/bug-ai-agent-tool-logs-not-ordered-correctly-in-loops

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
