### PR TITLE
ci: Skip 'can resolve expression with paired item in multi-input node' test

### DIFF
--- a/cypress/e2e/24-ndv-paired-item.cy.ts
+++ b/cypress/e2e/24-ndv-paired-item.cy.ts
@@ -239,7 +239,8 @@ describe('NDV', () => {
 		// ndv.getters.outputHoveringItem().should('not.exist');
 	});
 
-	it('can resolve expression with paired item in multi-input node', () => {
+	// https://linear.app/n8n/issue/ADO-3563/flaky-ndv-can-resolve-expression-with-paired-item-in-multi-input-node
+	it.skip('can resolve expression with paired item in multi-input node', () => {
 		cy.fixture('expression_with_paired_item_in_multi_input_node.json').then((data) => {
 			cy.get('body').paste(JSON.stringify(data));
 		});

--- a/cypress/e2e/24-ndv-paired-item.cy.ts
+++ b/cypress/e2e/24-ndv-paired-item.cy.ts
@@ -240,6 +240,7 @@ describe('NDV', () => {
 	});
 
 	// https://linear.app/n8n/issue/ADO-3563/flaky-ndv-can-resolve-expression-with-paired-item-in-multi-input-node
+	// eslint-disable-next-line n8n-local-rules/no-skipped-tests
 	it.skip('can resolve expression with paired item in multi-input node', () => {
 		cy.fixture('expression_with_paired_item_in_multi_input_node.json').then((data) => {
 			cy.get('body').paste(JSON.stringify(data));


### PR DESCRIPTION
## Summary

Disable this flaky test

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3566/skip-flaky-test-can-resolve-expression-with-paired-item-in-multi-input


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
