### PR TITLE
refactor(core): Simplify worker execution path

### DIFF
--- a/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
@@ -53,7 +53,6 @@ describe('JobProcessor', () => {
 		);
 		const jobProcessor = new JobProcessor(
 			logger,
-			mock(),
 			executionRepository,
 			mock(),
 			mock(),
@@ -75,7 +74,6 @@ describe('JobProcessor', () => {
 					mode,
 					workflowData: { nodes: [] },
 					data: mock<IRunExecutionData>({
-						isTestWebhook: false,
 						executionData: undefined,
 					}),
 				}),
@@ -84,7 +82,6 @@ describe('JobProcessor', () => {
 			const manualExecutionService = mock<ManualExecutionService>();
 			const jobProcessor = new JobProcessor(
 				logger,
-				mock(),
 				executionRepository,
 				mock(),
 				mock(),
@@ -105,7 +102,6 @@ describe('JobProcessor', () => {
 			mode: 'manual',
 			workflowData: { nodes: [], pinData },
 			data: mock<IRunExecutionData>({
-				isTestWebhook: false,
 				resultData: {
 					runData: {
 						trigger: [mock<ITaskData>({ executionIndex: 1 })],
@@ -124,7 +120,6 @@ describe('JobProcessor', () => {
 		const manualExecutionService = mock<ManualExecutionService>();
 		const jobProcessor = new JobProcessor(
 			logger,
-			mock(),
 			executionRepository,
 			mock(),
 			mock(),
@@ -164,7 +159,6 @@ describe('JobProcessor', () => {
 
 			const executionRepository = mock<ExecutionRepository>();
 			const executionData = mock<IRunExecutionData>({
-				isTestWebhook: false,
 				startData: undefined,
 				executionData: {
 					nodeExecutionStack: [
@@ -188,7 +182,6 @@ describe('JobProcessor', () => {
 			const manualExecutionService = mock<ManualExecutionService>();
 			const jobProcessor = new JobProcessor(
 				logger,
-				mock(),
 				executionRepository,
 				mock(),
 				mock(),

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -1,13 +1,7 @@
 import type { RunningJobSummary } from '@n8n/api-types';
 import { ExecutionRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
-import {
-	WorkflowHasIssuesError,
-	InstanceSettings,
-	WorkflowExecute,
-	ErrorReporter,
-	Logger,
-} from 'n8n-core';
+import { WorkflowHasIssuesError, InstanceSettings, WorkflowExecute, Logger } from 'n8n-core';
 import type {
 	ExecutionStatus,
 	IExecuteResponsePromiseData,
@@ -42,7 +36,6 @@ export class JobProcessor {
 
 	constructor(
 		private readonly logger: Logger,
-		private readonly errorReporter: ErrorReporter,
 		private readonly executionRepository: ExecutionRepository,
 		private readonly workflowRepository: WorkflowRepository,
 		private readonly nodeTypes: NodeTypes,
@@ -168,12 +161,12 @@ export class JobProcessor {
 		let workflowExecute: WorkflowExecute;
 		let workflowRun: PCancelable<IRun>;
 
-		const { startData, resultData, manualData, isTestWebhook } = execution.data;
+		const { startData, resultData, manualData } = execution.data;
 
 		if (execution.data?.executionData) {
 			workflowExecute = new WorkflowExecute(additionalData, execution.mode, execution.data);
 			workflowRun = workflowExecute.processRunExecutionData(workflow);
-		} else if (['manual', 'evaluation'].includes(execution.mode) && !isTestWebhook) {
+		} else {
 			const data: IWorkflowExecutionDataProcess = {
 				executionMode: execution.mode,
 				workflowData: execution.workflowData,
@@ -214,12 +207,6 @@ export class JobProcessor {
 				}
 				throw error;
 			}
-		} else {
-			this.errorReporter.info(`Worker found execution ${executionId} without data`);
-			// Execute all nodes
-			// Can execute without webhook so go on
-			workflowExecute = new WorkflowExecute(additionalData, execution.mode);
-			workflowRun = workflowExecute.run(workflow);
 		}
 
 		const runningJob: RunningJob = {

--- a/packages/cli/src/webhooks/__tests__/waiting-forms.test.ts
+++ b/packages/cli/src/webhooks/__tests__/waiting-forms.test.ts
@@ -200,27 +200,6 @@ describe('WaitingForms', () => {
 			expect(result).toBe('Form2');
 		});
 
-		it('should mark as test form webhook when execution mode is manual', async () => {
-			jest
-				// @ts-expect-error Protected method
-				.spyOn(waitingForms, 'getWebhookExecutionData')
-				// @ts-expect-error Protected method
-				.mockResolvedValue(mock<IWebhookResponseCallbackData>());
-
-			const execution = mock<IExecutionResponse>({
-				finished: false,
-				mode: 'manual',
-				data: {
-					resultData: { lastNodeExecuted: 'someNode', error: undefined },
-				},
-			});
-			executionRepository.findSingleExecution.mockResolvedValue(execution);
-
-			await waitingForms.executeWebhook(mock<WaitingWebhookRequest>(), mock<express.Response>());
-
-			expect(execution.data.isTestWebhook).toBe(true);
-		});
-
 		it('should return status of execution if suffix is WAITING_FORMS_EXECUTION_STATUS', async () => {
 			const execution = mock<IExecutionResponse>({
 				status: 'success',

--- a/packages/cli/src/webhooks/__tests__/waiting-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/waiting-webhooks.test.ts
@@ -6,7 +6,7 @@ import { mock } from 'jest-mock-extended';
 import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { WaitingWebhooks } from '@/webhooks/waiting-webhooks';
-import type { IWebhookResponseCallbackData, WaitingWebhookRequest } from '@/webhooks/webhook.types';
+import type { WaitingWebhookRequest } from '@/webhooks/webhook.types';
 
 describe('WaitingWebhooks', () => {
 	const executionRepository = mock<ExecutionRepository>();
@@ -78,26 +78,5 @@ describe('WaitingWebhooks', () => {
 		 * Assert
 		 */
 		await expect(promise).rejects.toThrowError(ConflictError);
-	});
-
-	it('should mark as test webhook when execution mode is manual', async () => {
-		jest
-			// @ts-expect-error Protected method
-			.spyOn(waitingWebhooks, 'getWebhookExecutionData')
-			// @ts-expect-error Protected method
-			.mockResolvedValue(mock<IWebhookResponseCallbackData>());
-
-		const execution = mock<IExecutionResponse>({
-			finished: false,
-			mode: 'manual',
-			data: {
-				resultData: { lastNodeExecuted: 'someNode', error: undefined },
-			},
-		});
-		executionRepository.findSingleExecution.mockResolvedValue(execution);
-
-		await waitingWebhooks.executeWebhook(mock<WaitingWebhookRequest>(), mock<express.Response>());
-
-		expect(execution.data.isTestWebhook).toBe(true);
 	});
 });

--- a/packages/cli/src/webhooks/waiting-forms.ts
+++ b/packages/cli/src/webhooks/waiting-forms.ts
@@ -137,12 +137,6 @@ export class WaitingForms extends WaitingWebhooks {
 			}
 		}
 
-		/**
-		 * A manual execution resumed by a webhook call needs to be marked as such
-		 * so workers in scaling mode reuse the existing execution data.
-		 */
-		if (execution.mode === 'manual') execution.data.isTestWebhook = true;
-
 		return await this.getWebhookExecutionData({
 			execution,
 			req,

--- a/packages/cli/src/webhooks/waiting-webhooks.ts
+++ b/packages/cli/src/webhooks/waiting-webhooks.ts
@@ -121,12 +121,6 @@ export class WaitingWebhooks implements IWebhookManager {
 
 		const lastNodeExecuted = execution.data.resultData.lastNodeExecuted as string;
 
-		/**
-		 * A manual execution resumed by a webhook call needs to be marked as such
-		 * so workers in scaling mode reuse the existing execution data.
-		 */
-		if (execution.mode === 'manual') execution.data.isTestWebhook = true;
-
 		return await this.getWebhookExecutionData({
 			execution,
 			req,

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -44,11 +44,9 @@ import {
 	UnexpectedError,
 	WAIT_NODE_TYPE,
 } from 'n8n-workflow';
-import assert from 'node:assert';
 import { finished } from 'stream/promises';
 
 import { ActiveExecutions } from '@/active-executions';
-import config from '@/config';
 import { MCP_TRIGGER_NODE_TYPE } from '@/constants';
 import { InternalServerError } from '@/errors/response-errors/internal-server.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
@@ -636,15 +634,6 @@ export async function executeWebhook(
 				executionId,
 				workflow,
 			);
-		}
-
-		if (
-			config.getEnv('executions.mode') === 'queue' &&
-			process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS === 'true' &&
-			runData.executionMode === 'manual'
-		) {
-			assert(runData.executionData);
-			runData.executionData.isTestWebhook = true;
 		}
 
 		// Start now to run the workflow

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -2162,9 +2162,6 @@ export interface IRunExecutionData {
 	waitTill?: Date;
 	pushRef?: string;
 
-	/** Whether this execution was started by a test webhook call. */
-	isTestWebhook?: boolean;
-
 	/** Data needed for a worker to run a manual execution. */
 	manualData?: Pick<
 		IWorkflowExecutionDataProcess,


### PR DESCRIPTION
## Summary

Move towards unifying the worker's execution routing logic with [that of main](https://github.com/n8n-io/n8n/blob/33030eae7d7f3ee81fc3273751f986fe40102fae/packages/cli/src/workflow-runner.ts#L272-L290) in regular mode.

- Remove execution mode check for `manual` or `evaluation`
- Remove now unneeded `isTestWebhook` flag
- Remove legacy execution branch flagged in #11298 (no Sentry reports)

Tested manually:
- Wait node with >65s wait
- Wait node with webhook
- Webhook with and without pindata
- `Testing` section at #11284

## Related Linear tickets, Github issues, and Community forum posts

n/a


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
