### PR TITLE
fix(editor): Sort start start nodes for manual execution by Y position

### DIFF
--- a/packages/frontend/editor-ui/src/composables/useRunWorkflow.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useRunWorkflow.test.ts
@@ -822,4 +822,37 @@ describe('useRunWorkflow({ router })', () => {
 			await waitFor(() => expect(markStoppedSpy).toHaveBeenCalled());
 		});
 	});
+
+	describe('sortNodesByYPosition()', () => {
+		const getNodeUi = (name: string, position: [number, number]) => {
+			return {
+				name,
+				position,
+				type: 'n8n-nodes-base.test',
+				typeVersion: 1,
+				id: name,
+				parameters: {},
+			};
+		};
+		it('should sort nodes by Y position in ascending order', () => {
+			const { sortNodesByYPosition } = useRunWorkflow({ router });
+
+			const topNode = 'topNode';
+			const middleNode = 'middleNode';
+			const bottomNode = 'bottomNode';
+
+			vi.mocked(workflowsStore.getNodeByName).mockImplementation((name) => {
+				if (name === topNode) return getNodeUi(topNode, [100, 50]);
+				if (name === middleNode) return getNodeUi(middleNode, [200, 200]);
+				if (name === bottomNode) return getNodeUi(bottomNode, [150, 350]);
+				return null;
+			});
+
+			// Test with different order of input nodes
+			const result = sortNodesByYPosition([bottomNode, topNode, middleNode]);
+
+			// Should be sorted by Y position (top to bottom)
+			expect(result).toEqual([topNode, middleNode, bottomNode]);
+		});
+	});
 });

--- a/packages/frontend/editor-ui/src/composables/useRunWorkflow.ts
+++ b/packages/frontend/editor-ui/src/composables/useRunWorkflow.ts
@@ -60,6 +60,20 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 	const executionsStore = useExecutionsStore();
 	const { dirtinessByName } = useNodeDirtiness();
 
+	function sortNodesByYPosition(nodes: string[]) {
+		return [...nodes].sort((a, b) => {
+			const nodeA = workflowsStore.getNodeByName(a)?.position ?? [0, 0];
+			const nodeB = workflowsStore.getNodeByName(b)?.position ?? [0, 0];
+
+			const nodeAYPosition = nodeA[1];
+			const nodeBYPosition = nodeB[1];
+
+			if (nodeAYPosition === nodeBYPosition) return 0;
+
+			return nodeAYPosition > nodeBYPosition ? 1 : -1;
+		});
+	}
+
 	// Starts to execute a workflow on server
 	async function runWorkflowApi(runData: IStartRunData): Promise<IExecutionPushResponse> {
 		if (!pushConnectionStore.isConnected) {
@@ -223,7 +237,7 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 			const version = settingsStore.partialExecutionVersion;
 
 			// TODO: this will be redundant once we cleanup the partial execution v1
-			const startNodes: StartNodeData[] = startNodeNames.map((name) => {
+			const startNodes: StartNodeData[] = sortNodesByYPosition(startNodeNames).map((name) => {
 				// Find for each start node the source data
 				let sourceData = get(runData, [name, 0, 'source', 0], null);
 				if (sourceData === null) {
@@ -519,5 +533,6 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 		runWorkflowApi,
 		stopCurrentExecution,
 		stopWaitingForWebhook,
+		sortNodesByYPosition,
 	};
 }


### PR DESCRIPTION
## Summary


This PR fixes an issue where the order of connecting nodes to chat trigger affects manual workflow execution results. By implementing Y-position sorting for nodes, we ensure consistent execution flow from top to bottom, regardless of connection order.

https://github.com/user-attachments/assets/be818d3a-6057-4e81-8e89-91334975f2d3


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
fixes #15042

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
