### PR TITLE
feat(core): Check license config for insights max retention

### DIFF
--- a/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
@@ -733,6 +733,7 @@ describe('timers', () => {
 	const mockPruningService = mock<InsightsPruningService>({
 		startPruningTimer: jest.fn(),
 		stopPruningTimer: jest.fn(),
+		isPruningEnabled: false,
 	});
 
 	const mockedLogger = mockLogger();
@@ -764,6 +765,7 @@ describe('timers', () => {
 	test('startTimers starts pruning timer', () => {
 		// ARRANGE
 		mockedConfig.maxAgeDays = 30;
+		Object.defineProperty(mockPruningService, 'isPruningEnabled', { value: true });
 
 		// ACT
 		insightsService.startTimers();

--- a/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
@@ -512,7 +512,6 @@ describe('getAvailableDateRanges', () => {
 			mock<InsightsCollectionService>(),
 			mock<InsightsPruningService>(),
 			licenseMock,
-			mock<InsightsConfig>(),
 			mockLogger(),
 		);
 	});
@@ -615,7 +614,6 @@ describe('getMaxAgeInDaysAndGranularity', () => {
 			mock<InsightsCollectionService>(),
 			mock<InsightsPruningService>(),
 			licenseMock,
-			mock<InsightsConfig>(),
 			mockLogger(),
 		);
 	});
@@ -704,7 +702,6 @@ describe('shutdown', () => {
 			mockCollectionService,
 			mockPruningService,
 			mock<LicenseState>(),
-			mock<InsightsConfig>(),
 			mockLogger(),
 		);
 	});
@@ -750,7 +747,6 @@ describe('timers', () => {
 			mockCollectionService,
 			mockPruningService,
 			mock<LicenseState>(),
-			mockedConfig,
 			mockedLogger,
 		);
 	});

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -15,7 +15,6 @@ import { InsightsByPeriodRepository } from './database/repositories/insights-by-
 import { InsightsCollectionService } from './insights-collection.service';
 import { InsightsCompactionService } from './insights-compaction.service';
 import { InsightsPruningService } from './insights-pruning.service';
-import { InsightsConfig } from './insights.config';
 
 const keyRangeToDays: Record<InsightsDateRange['key'], number> = {
 	day: 1,
@@ -35,20 +34,15 @@ export class InsightsService {
 		private readonly collectionService: InsightsCollectionService,
 		private readonly pruningService: InsightsPruningService,
 		private readonly licenseState: LicenseState,
-		private readonly config: InsightsConfig,
 		private readonly logger: Logger,
 	) {
 		this.logger = this.logger.scoped('insights');
 	}
 
-	get isPruningEnabled() {
-		return this.config.maxAgeDays > -1;
-	}
-
 	startTimers() {
 		this.compactionService.startCompactionTimer();
 		this.collectionService.startFlushingTimer();
-		if (this.isPruningEnabled) {
+		if (this.pruningService.isPruningEnabled) {
 			this.pruningService.startPruningTimer();
 		}
 		this.logger.debug('Started compaction, flushing and pruning schedulers');


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
Right now, the insights max retention in days rely on the environment variable (mapped to config) only
This PR take the license quotas into account as well.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2703/implement-pruning-system


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
