### PR TITLE
fix(Box Node): Correct typo in options name 'contet_types' to 'content_types' 

### DIFF
--- a/packages/nodes-base/nodes/Box/FileDescription.ts
+++ b/packages/nodes-base/nodes/Box/FileDescription.ts
@@ -278,7 +278,7 @@ export const fileFields: INodeProperties[] = [
 		options: [
 			{
 				displayName: 'Content Types',
-				name: 'contet_types',
+				name: 'content_types',
 				type: 'string',
 				default: '',
 				description:


### PR DESCRIPTION
## Summary

This PR fixes a typo in Box node.

The typo is: 'contet _types'

Fix: change the name to 'content_types'

A changelog of this fix is added. 

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [ x ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
