### PR TITLE
BigQuery Node: Prevent infinite loop in BigQuery executeQuery with contin…

### DIFF
--- a/packages/nodes-base/nodes/Google/BigQuery/v2/actions/database/executeQuery.operation.ts
+++ b/packages/nodes-base/nodes/Google/BigQuery/v2/actions/database/executeQuery.operation.ts
@@ -361,6 +361,8 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 				}
 			} catch (error) {
 				if (this.continueOnFail()) {
+					completedJobs.push(job.jobId); //FIX: Mark errored job as completed
+
 					const executionErrorData = this.helpers.constructExecutionMetaData(
 						this.helpers.returnJsonArray({ error: error.message }),
 						{ itemData: { item: job.i } },


### PR DESCRIPTION
## Summary

This PR fixes a bug in the BigQuery executeQuery node that caused an infinite loop when:

- A query job was queued (e.g. using wildcard tables),
- The job failed with an error,
- The “Continue On Fail” option was enabled.

The root cause was that errored jobs were not removed from the polling queue, resulting in an endless while loop. This fix ensures such jobs are added to the completedJobs array, allowing the loop to exit cleanly.

How to test:

1. Configure a BigQuery node with a query that triggers a queued job (e.g. using * in table names).
2. Enable "Continue On Fail".
3. Provide an intentionally invalid query that results in a job-level error.
4. Observe that the node no longer gets stuck and the error is handled properly.

## Related Linear tickets, Github issues, and Community forum posts

Closes  #15272

<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
