### PR TITLE
fix(editor): Ensure no running node when execution finished

### DIFF
--- a/cypress/e2e/24-ndv-paired-item.cy.ts
+++ b/cypress/e2e/24-ndv-paired-item.cy.ts
@@ -290,6 +290,13 @@ describe('NDV', () => {
 		workflowPage.actions.openNode('Switch1');
 		ndv.actions.execute();
 
-		ndv.getters.parameterExpressionPreview('output').should('include.text', '1');
+		ndv.getters.parameterExpressionPreview('output').should('have.text', '1');
+		ndv.getters.inlineExpressionEditorInput().click();
+		ndv.getters.inlineExpressionEditorOutput().should('have.text', '1');
+		ndv.actions.expressionSelectNextItem();
+		ndv.getters.inlineExpressionEditorOutput().should('have.text', '3');
+		ndv.actions.expressionSelectNextItem();
+		ndv.getters.inlineExpressionEditorOutput().should('have.text', '1');
+		ndv.getters.inlineExpressionEditorItemNextButton().should('be.disabled');
 	});
 });

--- a/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/executionFinished.ts
+++ b/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/executionFinished.ts
@@ -21,6 +21,7 @@ import type {
 	ExpressionError,
 	IDataObject,
 	IRunExecutionData,
+	IRunData,
 } from 'n8n-workflow';
 import { codeNodeEditorEventBus, globalLinkActionsEventBus } from '@/event-bus';
 import { h } from 'vue';
@@ -466,6 +467,8 @@ export function setRunExecutionData(
 		runExecutionData.resultData.runData = workflowsStore.getWorkflowRunData;
 	}
 
+	removeRunningTaskData(runExecutionData.resultData.runData);
+
 	workflowsStore.executingNode.length = 0;
 
 	workflowsStore.setWorkflowExecutionData({
@@ -504,4 +507,12 @@ export function setRunExecutionData(
 
 	const lineNumber = runExecutionData.resultData?.error?.lineNumber;
 	codeNodeEditorEventBus.emit('highlightLine', lineNumber ?? 'last');
+}
+
+function removeRunningTaskData(runData: IRunData): void {
+	for (const [nodeName, taskItems] of Object.entries(runData)) {
+		if (taskItems.some((item) => item.executionStatus === 'running')) {
+			runData[nodeName] = taskItems.filter((item) => item.executionStatus !== 'running');
+		}
+	}
 }


### PR DESCRIPTION
## Summary
This PR adds back the code for removing running nodes which was cleaned up in #15060. In fact, there are still cases where `nodeExecuteBefore` event is sent without corresponding `nodeExecuteAfter` so we still need this.

The bug was detected as flakiness of e2e test. The reason why it didn't always fail is that UI shows cached evaluation result momentarily before it shows `[ERROR: Can’t determine which item to use]`. I updated the test to do more assertions so that test will fail if there's a regression in the future.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/ADO-3563/flaky-ndv-can-resolve-expression-with-paired-item-in-multi-input-node


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
