### PR TITLE
perf(editor): Avoid deep watch on execution result data

### DIFF
--- a/packages/frontend/editor-ui/src/components/CanvasChat/future/composables/useExecutionData.ts
+++ b/packages/frontend/editor-ui/src/components/CanvasChat/future/composables/useExecutionData.ts
@@ -5,7 +5,6 @@ import { Workflow } from 'n8n-workflow';
 import { useWorkflowsStore } from '@/stores/workflows.store';
 import { useNodeHelpers } from '@/composables/useNodeHelpers';
 import { useThrottleFn } from '@vueuse/core';
-import { IN_PROGRESS_EXECUTION_ID } from '@/constants';
 import {
 	createLogEntries,
 	deepToRaw,
@@ -58,13 +57,6 @@ export function useExecutionData() {
 		};
 	});
 	const updateInterval = computed(() => ((execution.value?.tree.length ?? 0) > 10 ? 300 : 0));
-	const runStatusList = computed(() =>
-		workflowsStore.workflowExecutionData?.id === IN_PROGRESS_EXECUTION_ID
-			? Object.values(workflowsStore.workflowExecutionData?.data?.resultData.runData ?? {})
-					.flatMap((tasks) => tasks.map((task) => task.executionStatus ?? ''))
-					.join('|')
-			: '',
-	);
 
 	function resetExecutionData() {
 		execData.value = undefined;
@@ -78,7 +70,7 @@ export function useExecutionData() {
 			() => workflowsStore.workflowExecutionData?.id,
 			() => workflowsStore.workflowExecutionData?.workflowData.id,
 			() => workflowsStore.workflowExecutionData?.status,
-			runStatusList,
+			() => workflowsStore.workflowExecutionResultDataLastUpdate,
 		],
 		useThrottleFn(
 			() => {

--- a/packages/frontend/editor-ui/src/stores/assistant.store.ts
+++ b/packages/frontend/editor-ui/src/stores/assistant.store.ts
@@ -806,11 +806,11 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 	);
 
 	watch(
-		() => workflowsStore.workflowExecutionData?.data?.resultData ?? {},
+		() => workflowsStore.workflowExecutionResultDataLastUpdate,
 		() => {
 			workflowExecutionDataStale.value = true;
 		},
-		{ deep: true, immediate: true },
+		{ immediate: true },
 	);
 
 	return {

--- a/packages/frontend/editor-ui/src/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/stores/workflows.store.ts
@@ -141,6 +141,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 	const activeWorkflowExecution = ref<ExecutionSummary | null>(null);
 	const currentWorkflowExecutions = ref<ExecutionSummary[]>([]);
 	const workflowExecutionData = ref<IExecutionResponse | null>(null);
+	const workflowExecutionResultDataLastUpdate = ref<number>();
 	const workflowExecutionPairedItemMappings = ref<Record<string, Set<string>>>({});
 	const subWorkflowExecutionError = ref<Error | null>(null);
 	const executionWaitingForWebhook = ref(false);
@@ -866,6 +867,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		}
 		workflowExecutionData.value = workflowResultData;
 		workflowExecutionPairedItemMappings.value = getPairedItemsMapping(workflowResultData);
+		workflowExecutionResultDataLastUpdate.value = Date.now();
 	}
 
 	function setWorkflowExecutionRunData(workflowResultData: IRunExecutionData) {
@@ -874,6 +876,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 				...workflowExecutionData.value,
 				data: workflowResultData,
 			};
+			workflowExecutionResultDataLastUpdate.value = Date.now();
 		}
 	}
 
@@ -1497,6 +1500,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 				executionTime: 0,
 				...data.data,
 			});
+			workflowExecutionResultDataLastUpdate.value = Date.now();
 		}
 	}
 
@@ -1544,6 +1548,8 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 			} else {
 				tasksData.push(data);
 			}
+
+			workflowExecutionResultDataLastUpdate.value = Date.now();
 
 			void trackNodeExecution(pushData);
 		}
@@ -1830,6 +1836,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		currentWorkflowExecutions,
 		workflowExecutionData,
 		workflowExecutionPairedItemMappings,
+		workflowExecutionResultDataLastUpdate,
 		activeExecutionId: readonlyActiveExecutionId,
 		previousExecutionId: readonlyPreviousExecutionId,
 		setActiveExecutionId,


### PR DESCRIPTION
## Summary
This PR improves canvas performance while executing a workflow that generates many runs by replacing deep watch on execution response with update timestamp.

The comparison below shows the difference in the main thread work.
For testing, I used a workflow that generates ~300 runs of nodes in a loop [Loop__wait.json](https://github.com/user-attachments/files/20157949/Loop__wait.json)

| Before | After |
|--------|--------|
| <img width="1512" alt="Screenshot 2025-05-12 at 11 02 30" src="https://github.com/user-attachments/assets/ba6adc00-c519-4cf8-9acc-60f2202dc1a3" /> |<img width="1512" alt="Screenshot 2025-05-12 at 11 01 28" src="https://github.com/user-attachments/assets/22f517c4-029e-4340-8e85-15c508b8fef6" /> | 




## Related Linear tickets, Github issues, and Community forum posts



## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
