### PR TITLE
feat(API): Add Public API endpoint for updating variables

### DIFF
--- a/packages/@n8n/permissions/src/constants.ee.ts
+++ b/packages/@n8n/permissions/src/constants.ee.ts
@@ -30,7 +30,7 @@ export const RESOURCES = {
 export const API_KEY_RESOURCES = {
 	tag: [...DEFAULT_OPERATIONS] as const,
 	workflow: [...DEFAULT_OPERATIONS, 'move', 'activate', 'deactivate'] as const,
-	variable: ['create', 'delete', 'list'] as const,
+	variable: DEFAULT_OPERATIONS,
 	securityAudit: ['generate'] as const,
 	project: ['create', 'update', 'delete', 'list'] as const,
 	user: ['read', 'list', 'create', 'changeRole', 'delete'] as const,

--- a/packages/cli/src/public-api/v1/handlers/variables/spec/paths/variables.id.yml
+++ b/packages/cli/src/public-api/v1/handlers/variables/spec/paths/variables.id.yml
@@ -8,9 +8,35 @@ delete:
   parameters:
     - $ref: '../schemas/parameters/variableId.yml'
   responses:
-    '204':
+    '201':
       description: Operation successful.
     '401':
       $ref: '../../../../shared/spec/responses/unauthorized.yml'
+    '404':
+      $ref: '../../../../shared/spec/responses/notFound.yml'
+
+put:
+  x-eov-operation-id: updateVariable
+  x-eov-operation-handler: v1/handlers/variables/variables.handler
+  tags:
+    - Variables
+  summary: Update a variable
+  description: Update a variable from your instance.
+  requestBody:
+    description: Payload for variable to update.
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/variable.yml'
+    required: true
+  responses:
+    '204':
+      description: Operation successful.
+    '400':
+      $ref: '../../../../shared/spec/responses/badRequest.yml'
+    '401':
+      $ref: '../../../../shared/spec/responses/unauthorized.yml'
+    '403':
+      $ref: '../../../../shared/spec/responses/forbidden.yml'
     '404':
       $ref: '../../../../shared/spec/responses/notFound.yml'

--- a/packages/cli/src/public-api/v1/handlers/variables/variables.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/variables/variables.handler.ts
@@ -27,6 +27,15 @@ export = {
 			res.status(201).send();
 		},
 	],
+	updateVariable: [
+		isLicensed('feat:variables'),
+		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'variable:update' }),
+		async (req: VariablesRequest.Update, res: Response) => {
+			await Container.get(VariablesController).updateVariable(req);
+
+			res.status(204).send();
+		},
+	],
 	deleteVariable: [
 		isLicensed('feat:variables'),
 		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'variable:delete' }),


### PR DESCRIPTION
## Summary
This PR adds the missing endpoint in the variables public API, to let users fully managed variable through the public API.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
