### PR TITLE
fix: Ensure diagnostics stay disabled in e2e even when enabled by environment variable

### DIFF
--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -10,18 +10,19 @@ import assert from 'node:assert';
 
 import { inTest, inE2ETests } from '@/constants';
 
+const globalConfig = Container.get(GlobalConfig);
+
 if (inE2ETests) {
-	// Skip loading config from env variables in end-to-end tests
-	process.env.N8N_DIAGNOSTICS_ENABLED = 'false';
-	process.env.N8N_PUBLIC_API_DISABLED = 'true';
+	globalConfig.diagnostics.enabled = false;
+	globalConfig.publicApi.disabled = true;
 	process.env.EXTERNAL_FRONTEND_HOOKS_URLS = '';
 	process.env.N8N_PERSONALIZATION_ENABLED = 'false';
 	process.env.N8N_AI_ENABLED = 'true';
 } else if (inTest) {
-	process.env.N8N_LOG_LEVEL = 'silent';
-	process.env.N8N_PUBLIC_API_DISABLED = 'true';
+	globalConfig.logging.level = 'silent';
+	globalConfig.publicApi.disabled = true;
 	process.env.SKIP_STATISTICS_EVENTS = 'true';
-	process.env.N8N_SECURE_COOKIE = 'false';
+	globalConfig.auth.cookie.secure = false;
 	process.env.N8N_SKIP_AUTH_ON_OAUTH_CALLBACK = 'true';
 }
 
@@ -33,7 +34,6 @@ const config = convict(schema, { args: [] });
 config.getEnv = config.get;
 
 const logger = Container.get(Logger);
-const globalConfig = Container.get(GlobalConfig);
 
 // Load overwrites when not in tests
 if (!inE2ETests && !inTest) {


### PR DESCRIPTION
If the env has `N8N_DIAGNOSTICS_ENABLED=true` then e2e runs will still correctly [set](https://github.com/n8n-io/n8n/blob/6be129c08bd46fb21045f50c57317156527903a0/packages/cli/src/config/index.ts#L15) `N8N_DIAGNOSTICS_ENABLED=false` but  `DiagnosticsConfig.enabled` will end up incorrectly as `true`. This surfaced in #15260.
