### PR TITLE
fix: Corrects success response code to match handler (no-changelog)

### DIFF
--- a/packages/cli/src/public-api/v1/handlers/variables/spec/paths/variables.id.yml
+++ b/packages/cli/src/public-api/v1/handlers/variables/spec/paths/variables.id.yml
@@ -8,7 +8,7 @@ delete:
   parameters:
     - $ref: '../schemas/parameters/variableId.yml'
   responses:
-    '201':
+    '204':
       description: Operation successful.
     '401':
       $ref: '../../../../shared/spec/responses/unauthorized.yml'


### PR DESCRIPTION
## Summary

This PR corrects the response code for the `deleteVariable` API endpoint. 
As discussed here: https://github.com/n8n-io/n8n/pull/15315/files#r2086387448

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
