### PR TITLE
fix(PostBin Node): Update base URL for postbin node

### DIFF
--- a/packages/nodes-base/nodes/PostBin/BinDescription.ts
+++ b/packages/nodes-base/nodes/PostBin/BinDescription.ts
@@ -22,7 +22,7 @@ export const binOperations: INodeProperties[] = [
 				routing: {
 					request: {
 						method: 'POST',
-						url: '/developers/postbin/api/bin',
+						url: '/api/bin',
 					},
 					output: {
 						postReceive: [transformBinResponse],

--- a/packages/nodes-base/nodes/PostBin/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/PostBin/GenericFunctions.ts
@@ -51,7 +51,7 @@ export async function buildBinAPIURL(
 ): Promise<IHttpRequestOptions> {
 	const binId = parseBinId(this);
 	// Assemble the PostBin API URL and put it back to requestOptions
-	requestOptions.url = `/developers/postbin/api/bin/${binId}`;
+	requestOptions.url = `/api/bin/${binId}`;
 
 	return requestOptions;
 }
@@ -69,7 +69,7 @@ export async function buildBinTestURL(
 	const binId = parseBinId(this);
 
 	// Assemble the PostBin API URL and put it back to requestOptions
-	requestOptions.url = `/developers/postbin/${binId}`;
+	requestOptions.url = `/${binId}`;
 	return requestOptions;
 }
 
@@ -86,7 +86,7 @@ export async function buildRequestURL(
 	const reqId = this.getNodeParameter('requestId', 'shift') as string;
 	const binId = parseBinId(this);
 
-	requestOptions.url = `/developers/postbin/api/bin/${binId}/req/${reqId}`;
+	requestOptions.url = `/api/bin/${binId}/req/${reqId}`;
 	return requestOptions;
 }
 
@@ -107,8 +107,8 @@ export async function transformBinResponse(
 				nowIso: new Date(item.json.now as string).toISOString(),
 				expiresTimestamp: item.json.expires,
 				expiresIso: new Date(item.json.expires as string).toISOString(),
-				requestUrl: 'https://www.toptal.com/developers/postbin/' + (item.json.binId as string),
-				viewUrl: 'https://www.toptal.com/developers/postbin/b/' + (item.json.binId as string),
+				requestUrl: 'https://www.postb.in/' + (item.json.binId as string),
+				viewUrl: 'https://www.postb.in/b/' + (item.json.binId as string),
 			}),
 	);
 	return items;

--- a/packages/nodes-base/nodes/PostBin/PostBin.node.ts
+++ b/packages/nodes-base/nodes/PostBin/PostBin.node.ts
@@ -21,7 +21,7 @@ export class PostBin implements INodeType {
 		outputs: [NodeConnectionTypes.Main],
 		credentials: [],
 		requestDefaults: {
-			baseURL: 'https://www.toptal.com',
+			baseURL: 'https://www.postb.in',
 		},
 		properties: [
 			{

--- a/packages/nodes-base/nodes/PostBin/RequestDescription.ts
+++ b/packages/nodes-base/nodes/PostBin/RequestDescription.ts
@@ -22,7 +22,7 @@ export const requestOperations: INodeProperties[] = [
 				routing: {
 					request: {
 						method: 'GET',
-						url: '=/developers/postbin/api/bin/{{$parameter["binId"]}}/req/{{$parameter["requestId"]}}',
+						url: '=/api/bin/{{$parameter["binId"]}}/req/{{$parameter["requestId"]}}',
 					},
 					send: {
 						preSend: [
@@ -40,7 +40,7 @@ export const requestOperations: INodeProperties[] = [
 				routing: {
 					request: {
 						method: 'GET',
-						url: '=/developers/postbin/api/bin/{{$parameter["binId"]}}/req/shift',
+						url: '=/api/bin/{{$parameter["binId"]}}/req/shift',
 					},
 					send: {
 						preSend: [


### PR DESCRIPTION
## Summary

The baseurl used for the postbin node was `https://toptal.com/developers/postbin`. 
This has an existing redirect 
<img width="505" alt="Screenshot 2025-05-13 at 16 48 13" src="https://github.com/user-attachments/assets/ca1d17c2-abf4-4c81-82a2-fdea7499ace4" />

Due to the redirect, POST requests are converted to GET requests and the payload is removed. 
This is causing two functionalities to break

- Create a new bin 
- Send a post request to the bin 

The fix is using the correct base URL

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/issues/11836
ADO-3575

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
