### PR TITLE
fix(Basic LLM Chain Node): Use JSON parsing for Claude 3.7 with thinking enabled

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/chainExecutor.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/chainExecutor.ts
@@ -38,6 +38,18 @@ export function isModelWithResponseFormat(
 	);
 }
 
+export function isModelInThinkingMode(
+	llm: BaseLanguageModel,
+): llm is BaseLanguageModel & { lc_kwargs: { invocationKwargs: { thinking: { type: string } } } } {
+	return (
+		'lc_kwargs' in llm &&
+		'invocationKwargs' in llm.lc_kwargs &&
+		typeof llm.lc_kwargs.invocationKwargs === 'object' &&
+		'thinking' in llm.lc_kwargs.invocationKwargs &&
+		llm.lc_kwargs.invocationKwargs.thinking.type === 'enabled'
+	);
+}
+
 /**
  * Type guard to check if the LLM has a format property(Ollama)
  */
@@ -58,6 +70,10 @@ export function getOutputParserForLLM(
 	}
 
 	if (isModelWithFormat(llm) && llm.format === 'json') {
+		return new NaiveJsonOutputParser();
+	}
+
+	if (isModelInThinkingMode(llm)) {
 		return new NaiveJsonOutputParser();
 	}
 

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/chainExecutor.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/chainExecutor.test.ts
@@ -62,6 +62,20 @@ describe('chainExecutor', () => {
 			const parser = chainExecutor.getOutputParserForLLM(regularModel);
 			expect(parser).toBeInstanceOf(StringOutputParser);
 		});
+
+		it('should resurn NaiveJsonOutputParser for Anthropic models in thinking mode', () => {
+			const model = {
+				lc_kwargs: {
+					invocationKwargs: {
+						thinking: {
+							type: 'enabled',
+						},
+					},
+				},
+			};
+			const parser = chainExecutor.getOutputParserForLLM(model as unknown as BaseChatModel);
+			expect(parser).toBeInstanceOf(NaiveJsonOutputParser);
+		});
 	});
 
 	describe('NaiveJsonOutputParser', () => {

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/chainExecutor.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/chainExecutor.test.ts
@@ -63,7 +63,7 @@ describe('chainExecutor', () => {
 			expect(parser).toBeInstanceOf(StringOutputParser);
 		});
 
-		it('should resurn NaiveJsonOutputParser for Anthropic models in thinking mode', () => {
+		it('should return NaiveJsonOutputParser for Anthropic models in thinking mode', () => {
 			const model = {
 				lc_kwargs: {
 					invocationKwargs: {


### PR DESCRIPTION
## Summary
Fixes an issue with using Anthropic Claude 3.7 in thinking mode. In thinking mode the model returns json which fails to be parsed by the default StringOutputParser. 
This PR adds logic to return the appropriate parser if the model is setup in thinking mode.

![Screenshot 2025-05-14 at 11 05 11](https://github.com/user-attachments/assets/ca1f3ae3-7a84-4cee-a65b-1f935b60cf65)



## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-835/community-issue-claude-37-basic-llm-thinking-mode-cannot-coerce
fixes #14374


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
