### PR TITLE
fix(editor): Not all sub node runs are shown in sub execution log (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/components/RunDataAi/utils.ts
+++ b/packages/frontend/editor-ui/src/components/RunDataAi/utils.ts
@@ -358,6 +358,8 @@ function getChildNodes(
 
 	// Get the first level of children
 	const connectedSubNodes = context.workflow.getParentNodes(node.name, 'ALL_NON_MAIN', 1);
+	const isExecutionRoot =
+		treeNode.parent === undefined || treeNode.executionId !== treeNode.parent.executionId;
 
 	return connectedSubNodes.flatMap((subNodeName) =>
 		(context.data.resultData.runData[subNodeName] ?? []).flatMap((t, index) => {
@@ -365,7 +367,7 @@ function getChildNodes(
 			// This prevents showing duplicate executions when a sub-node is connected to multiple parents
 			// Only filter nodes that have source information with valid previousNode references
 			const isMatched =
-				context.depth === 0 && t.source.some((source) => source !== null)
+				isExecutionRoot && t.source.some((source) => source !== null)
 					? t.source.some(
 							(source) =>
 								source?.previousNode === node.name &&


### PR DESCRIPTION
## Summary

This PR fixes the bug where some sub node runs are missing in sub execution log.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/SUG-64/bug-some-sub-node-runs-in-sub-execution-are-missing


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
