### PR TITLE
fix(OpenAI Node): Hide the option to return URL for gpt-image-1 model

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/image/generate.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/image/generate.operation.ts
@@ -221,6 +221,11 @@ const properties: INodeProperties[] = [
 				type: 'boolean',
 				default: false,
 				description: 'Whether to return image URL(s) instead of binary file(s)',
+				displayOptions: {
+					hide: {
+						'/model': ['gpt-image-1'],
+					},
+				},
 			},
 			{
 				displayName: 'Put Output in Field',


### PR DESCRIPTION
## Summary

The `gpt-image-1` model doesn't support the response type `URL`, so we now hide the option for this model.

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-935/community-issue-openai-node-issues-with-gpt-image-1-model-parameters
https://github.com/n8n-io/n8n/issues/15275
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
