### PR TITLE
chore: Add missing project reference from `core` to `@n8n/decorators`

### DIFF
--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -19,6 +19,7 @@
 	"include": ["src/**/*.ts", "test/**/*.ts"],
 	"references": [
 		{ "path": "../workflow/tsconfig.build.json" },
+		{ "path": "../@n8n/decorators/tsconfig.build.json" },
 		{ "path": "../@n8n/config/tsconfig.build.json" },
 		{ "path": "../@n8n/di/tsconfig.build.json" },
 		{ "path": "../@n8n/client-oauth2/tsconfig.build.json" }


### PR DESCRIPTION
Per title