### PR TITLE
feat(core): Scope getStatus for environments for project admin role

### DIFF
--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control-import.service.ee.test.ts
@@ -1,4 +1,4 @@
-import { Project, ProjectRepository, User, WorkflowEntity } from '@n8n/db';
+import { Project, type ProjectRepository, User, WorkflowEntity } from '@n8n/db';
 import type { FolderRepository } from '@n8n/db';
 import type { WorkflowRepository } from '@n8n/db';
 import * as fastGlob from 'fast-glob';

--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control-import.service.ee.test.ts
@@ -103,7 +103,7 @@ describe('SourceControlImportService', () => {
 
 			fsReadFile.mockResolvedValue(JSON.stringify(mockCredentialData));
 
-			const result = await service.getRemoteCredentialsFromFiles();
+			const result = await service.getRemoteCredentialsFromFiles(globalAdminContext);
 
 			expect(result).toHaveLength(1);
 			expect(result[0]).toEqual(
@@ -119,7 +119,7 @@ describe('SourceControlImportService', () => {
 			globMock.mockResolvedValue(['/mock/invalid.json']);
 			fsReadFile.mockResolvedValue('{}');
 
-			const result = await service.getRemoteCredentialsFromFiles();
+			const result = await service.getRemoteCredentialsFromFiles(globalAdminContext);
 
 			expect(result).toHaveLength(0);
 		});

--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control-import.service.ee.test.ts
@@ -7,6 +7,7 @@ import { type InstanceSettings } from 'n8n-core';
 import fsp from 'node:fs/promises';
 
 import { SourceControlImportService } from '../source-control-import.service.ee';
+import type { SourceControlScopedService } from '../source-control-scoped.service';
 import type { ExportableFolder } from '../types/exportable-folders';
 import { SourceControlContext } from '../types/source-control-context';
 
@@ -28,6 +29,7 @@ describe('SourceControlImportService', () => {
 	const workflowRepository = mock<WorkflowRepository>();
 	const folderRepository = mock<FolderRepository>();
 	const projectRepository = mock<ProjectRepository>();
+	const sourceControlScopedService = mock<SourceControlScopedService>();
 	const service = new SourceControlImportService(
 		mock(),
 		mock(),
@@ -47,6 +49,7 @@ describe('SourceControlImportService', () => {
 		mock(),
 		folderRepository,
 		mock<InstanceSettings>({ n8nFolder: '/mock/n8n' }),
+		sourceControlScopedService,
 	);
 
 	const globMock = fastGlob.default as unknown as jest.Mock<Promise<string[]>, string[]>;
@@ -297,7 +300,7 @@ describe('SourceControlImportService', () => {
 				],
 			};
 
-			projectRepository.find.mockResolvedValue([
+			sourceControlScopedService.getAdminProjectsFromContext.mockResolvedValue([
 				Object.assign(new Project(), {
 					id: 'project1',
 				}),

--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control-import.service.ee.test.ts
@@ -1,4 +1,4 @@
-import type { WorkflowEntity } from '@n8n/db';
+import { User, type WorkflowEntity } from '@n8n/db';
 import type { FolderRepository } from '@n8n/db';
 import type { WorkflowRepository } from '@n8n/db';
 import * as fastGlob from 'fast-glob';
@@ -8,8 +8,15 @@ import fsp from 'node:fs/promises';
 
 import { SourceControlImportService } from '../source-control-import.service.ee';
 import type { ExportableFolder } from '../types/exportable-folders';
+import type { SourceControlContext } from '../types/source-control-context';
 
 jest.mock('fast-glob');
+
+const globalAdminContext: SourceControlContext = {
+	user: Object.assign(new User(), {
+		role: 'global:admin',
+	}),
+};
 
 describe('SourceControlImportService', () => {
 	const workflowRepository = mock<WorkflowRepository>();
@@ -53,7 +60,7 @@ describe('SourceControlImportService', () => {
 
 			fsReadFile.mockResolvedValue(JSON.stringify(mockWorkflowData));
 
-			const result = await service.getRemoteVersionIdsFromFiles();
+			const result = await service.getRemoteVersionIdsFromFiles(globalAdminContext);
 			expect(fsReadFile).toHaveBeenCalledWith(mockWorkflowFile, { encoding: 'utf8' });
 
 			expect(result).toHaveLength(1);
@@ -71,7 +78,7 @@ describe('SourceControlImportService', () => {
 
 			fsReadFile.mockResolvedValue('{}');
 
-			const result = await service.getRemoteVersionIdsFromFiles();
+			const result = await service.getRemoteVersionIdsFromFiles(globalAdminContext);
 
 			expect(result).toHaveLength(0);
 		});
@@ -215,7 +222,7 @@ describe('SourceControlImportService', () => {
 
 			workflowRepository.find.mockResolvedValue(mockWorkflows);
 
-			const result = await service.getLocalVersionIdsFromDb();
+			const result = await service.getLocalVersionIdsFromDb(globalAdminContext);
 
 			expect(result[0].updatedAt).toBe(now.toISOString());
 		});

--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control-import.service.ee.test.ts
@@ -8,21 +8,21 @@ import fsp from 'node:fs/promises';
 
 import { SourceControlImportService } from '../source-control-import.service.ee';
 import type { ExportableFolder } from '../types/exportable-folders';
-import type { SourceControlContext } from '../types/source-control-context';
+import { SourceControlContext } from '../types/source-control-context';
 
 jest.mock('fast-glob');
 
-const globalAdminContext: SourceControlContext = {
-	user: Object.assign(new User(), {
+const globalAdminContext = new SourceControlContext(
+	Object.assign(new User(), {
 		role: 'global:admin',
 	}),
-};
+);
 
-const globalMemberContext: SourceControlContext = {
-	user: Object.assign(new User(), {
+const globalMemberContext = new SourceControlContext(
+	Object.assign(new User(), {
 		role: 'global:member',
 	}),
-};
+);
 
 describe('SourceControlImportService', () => {
 	const workflowRepository = mock<WorkflowRepository>();

--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control.service.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control.service.test.ts
@@ -141,6 +141,7 @@ describe('SourceControlService', () => {
 		it('conflict depends on the value of `direction`', async () => {
 			// ARRANGE
 			const user = mock<User>();
+			user.role = 'global:admin';
 
 			// Define a credential that does only exist locally.
 			// Pulling this would delete it so it should be marked as a conflict.

--- a/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
@@ -50,11 +50,11 @@ import {
 import { getCredentialExportPath, getWorkflowExportPath } from './source-control-helper.ee';
 import type { ExportableCredential } from './types/exportable-credential';
 import type { ExportableFolder } from './types/exportable-folders';
+import type { ExportableTags } from './types/exportable-tags';
 import type { ResourceOwner } from './types/resource-owner';
 import type { SourceControlContext } from './types/source-control-context';
 import type { SourceControlWorkflowVersionId } from './types/source-control-workflow-version-id';
 import { VariablesService } from '../variables/variables.service.ee';
-import { ExportableTags } from './types/exportable-tags';
 
 @Service()
 export class SourceControlImportService {

--- a/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
@@ -1,5 +1,5 @@
 import type { SourceControlledFile } from '@n8n/api-types';
-import {
+import type {
 	Variables,
 	Project,
 	TagEntity,
@@ -24,7 +24,7 @@ import {
 } from '@n8n/db';
 import { Service } from '@n8n/di';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
-import { FindOptionsWhere, In } from '@n8n/typeorm';
+import { type FindOptionsWhere, In } from '@n8n/typeorm';
 import glob from 'fast-glob';
 import { Credentials, ErrorReporter, InstanceSettings, Logger } from 'n8n-core';
 import { jsonParse, ensureError, UserError, UnexpectedError } from 'n8n-workflow';
@@ -54,6 +54,7 @@ import type { ResourceOwner } from './types/resource-owner';
 import type { SourceControlContext } from './types/source-control-context';
 import type { SourceControlWorkflowVersionId } from './types/source-control-workflow-version-id';
 import { VariablesService } from '../variables/variables.service.ee';
+import { ExportableTags } from './types/exportable-tags';
 
 @Service()
 export class SourceControlImportService {
@@ -439,17 +440,14 @@ export class SourceControlImportService {
 		};
 	}
 
-	async getRemoteTagsAndMappingsFromFile(context: SourceControlContext): Promise<{
-		tags: TagEntity[];
-		mappings: WorkflowTagMapping[];
-	}> {
+	async getRemoteTagsAndMappingsFromFile(context: SourceControlContext): Promise<ExportableTags> {
 		const tagsFile = await glob(SOURCE_CONTROL_TAGS_EXPORT_FILE, {
 			cwd: this.gitFolder,
 			absolute: true,
 		});
 		if (tagsFile.length > 0) {
 			this.logger.debug(`Importing tags from file ${tagsFile[0]}`);
-			const mappedTags = jsonParse<{ tags: TagEntity[]; mappings: WorkflowTagMapping[] }>(
+			const mappedTags = jsonParse<ExportableTags>(
 				await fsReadFile(tagsFile[0], { encoding: 'utf8' }),
 				{ fallbackValue: { tags: [], mappings: [] } },
 			);

--- a/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
@@ -105,18 +105,17 @@ export class SourceControlImportService {
 
 		const remoteWorkflowFilesParsed = remoteWorkflowsRead
 			.filter((remote) => {
-				return remote?.id;
-			})
-			.filter((remote) => {
-				if (Array.isArray(accessibleProjects) && remote.owner.type === 'team') {
-					const teamId = remote.owner.teamId;
-					if (!accessibleProjects.some((project) => project.id === teamId)) {
-						// The workflow `remote` does not belong to a project, that the context has access to
-						return false;
-					}
-				} else if (Array.isArray(accessibleProjects) && remote.owner.type === 'personal') {
-					// When filters apply, we don't support personal projects
+				if (!remote?.id) {
 					return false;
+				}
+				if (Array.isArray(accessibleProjects)) {
+					const owner = remote.owner;
+					// The workflow `remote` belongs not to a project, that the context has access to
+					return (
+						typeof owner === 'object' &&
+						owner?.type === 'team' &&
+						accessibleProjects.some((project) => project.id === owner.teamId)
+					);
 				}
 				return true;
 			})
@@ -238,26 +237,17 @@ export class SourceControlImportService {
 
 		const remoteCredentialFilesParsed = remoteCredentialFilesRead
 			.filter((remote) => {
-				return remote?.id;
-			})
-			.filter((remote) => {
-				if (
-					Array.isArray(accessibleProjects) &&
-					typeof remote.ownedBy === 'object' &&
-					remote.ownedBy?.type === 'team'
-				) {
-					const projectId = remote.ownedBy?.teamId;
-					if (!accessibleProjects.some((project) => project.id === projectId)) {
-						// The credential `remote` belongs not to a project, that the context has access to
-						return false;
-					}
-				} else if (
-					Array.isArray(accessibleProjects) &&
-					typeof remote.ownedBy === 'object' &&
-					remote.ownedBy?.type === 'personal'
-				) {
-					// When filters apply, we don't support personal projects
+				if (!remote?.id) {
 					return false;
+				}
+				if (Array.isArray(accessibleProjects)) {
+					const owner = remote.ownedBy;
+					// The credential `remote` belongs not to a project, that the context has access to
+					return (
+						typeof owner === 'object' &&
+						owner?.type === 'team' &&
+						accessibleProjects.some((project) => project.id === owner.teamId)
+					);
 				}
 				return true;
 			})

--- a/packages/cli/src/environments.ee/source-control/source-control-scoped.service.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-scoped.service.ts
@@ -1,0 +1,138 @@
+import {
+	type CredentialsEntity,
+	type Folder,
+	type Project,
+	ProjectRepository,
+	type WorkflowEntity,
+	WorkflowRepository,
+	type WorkflowTagMapping,
+} from '@n8n/db';
+import { Service } from '@n8n/di';
+import type { FindOptionsWhere } from '@n8n/typeorm';
+
+import type { SourceControlContext } from './types/source-control-context';
+
+@Service()
+export class SourceControlScopedService {
+	constructor(
+		private readonly projectRepository: ProjectRepository,
+		private readonly workflowRepository: WorkflowRepository,
+	) {}
+
+	async getAdminProjectsFromContext(context: SourceControlContext): Promise<Project[] | undefined> {
+		if (context.accessToAllProjects()) {
+			// In case the user is a global admin or owner, we don't need a filter
+			return;
+		}
+
+		return await this.projectRepository.find({
+			relations: {
+				projectRelations: true,
+			},
+			select: {
+				id: true,
+				name: true,
+			},
+			where: this.getAdminProjectsByContextFilter(context),
+		});
+	}
+
+	async getWorkflowsInAdminProjectsFromContext(
+		context: SourceControlContext,
+	): Promise<WorkflowEntity[] | undefined> {
+		if (context.accessToAllProjects()) {
+			// In case the user is a global admin or owner, we don't need a filter
+			return;
+		}
+
+		return await this.workflowRepository.find({
+			select: {
+				id: true,
+			},
+			where: this.getWorkflowsInAdminProjectsFromContextFilter(context),
+		});
+	}
+
+	getAdminProjectsByContextFilter(
+		context: SourceControlContext,
+	): FindOptionsWhere<Project> | undefined {
+		if (context.accessToAllProjects()) {
+			// In case the user is a global admin or owner, we don't need a filter
+			return;
+		}
+
+		return {
+			type: 'team',
+			projectRelations: {
+				role: 'project:admin',
+				userId: context.user.id,
+			},
+		};
+	}
+
+	getFoldersInAdminProjectsFromContextFilter(
+		context: SourceControlContext,
+	): FindOptionsWhere<Folder> | undefined {
+		if (context.accessToAllProjects()) {
+			// In case the user is a global admin or owner, we don't need a filter
+			return;
+		}
+
+		// We build a filter to only select folder, that belong to a team project
+		// that the user is an admin off
+		return {
+			homeProject: this.getAdminProjectsByContextFilter(context),
+		};
+	}
+
+	getWorkflowsInAdminProjectsFromContextFilter(
+		context: SourceControlContext,
+	): FindOptionsWhere<WorkflowEntity> | undefined {
+		if (context.accessToAllProjects()) {
+			// In case the user is a global admin or owner, we don't need a filter
+			return;
+		}
+
+		// We build a filter to only select workflows, that belong to a team project
+		// that the user is an admin off
+		return {
+			shared: {
+				role: 'workflow:owner',
+				project: this.getAdminProjectsByContextFilter(context),
+			},
+		};
+	}
+
+	getCredentialsInAdminProjectsFromContextFilter(
+		context: SourceControlContext,
+	): FindOptionsWhere<CredentialsEntity> | undefined {
+		if (context.accessToAllProjects()) {
+			// In case the user is a global admin or owner, we don't need a filter
+			return;
+		}
+
+		// We build a filter to only select workflows, that belong to a team project
+		// that the user is an admin off
+		return {
+			shared: {
+				role: 'credential:owner',
+				project: this.getAdminProjectsByContextFilter(context),
+			},
+		};
+	}
+
+	getWorkflowTagMappingInAdminProjectsFromContextFilter(
+		context: SourceControlContext,
+	): FindOptionsWhere<WorkflowTagMapping> | undefined {
+		if (context.accessToAllProjects()) {
+			// In case the user is a global admin or owner, we don't need a filter
+			return;
+		}
+
+		// We build a filter to only select workflows, that belong to a team project
+		// that the user is an admin off
+		return {
+			workflows: this.getWorkflowsInAdminProjectsFromContextFilter(context),
+		};
+	}
+}

--- a/packages/cli/src/environments.ee/source-control/source-control-scoped.service.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-scoped.service.ts
@@ -8,6 +8,7 @@ import {
 	type WorkflowTagMapping,
 } from '@n8n/db';
 import { Service } from '@n8n/di';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import type { FindOptionsWhere } from '@n8n/typeorm';
 
 import type { SourceControlContext } from './types/source-control-context';

--- a/packages/cli/src/environments.ee/source-control/source-control-scoped.service.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-scoped.service.ts
@@ -21,7 +21,7 @@ export class SourceControlScopedService {
 	) {}
 
 	async getAdminProjectsFromContext(context: SourceControlContext): Promise<Project[] | undefined> {
-		if (context.accessToAllProjects()) {
+		if (context.hasAccessToAllProjects()) {
 			// In case the user is a global admin or owner, we don't need a filter
 			return;
 		}
@@ -41,7 +41,7 @@ export class SourceControlScopedService {
 	async getWorkflowsInAdminProjectsFromContext(
 		context: SourceControlContext,
 	): Promise<WorkflowEntity[] | undefined> {
-		if (context.accessToAllProjects()) {
+		if (context.hasAccessToAllProjects()) {
 			// In case the user is a global admin or owner, we don't need a filter
 			return;
 		}
@@ -57,7 +57,7 @@ export class SourceControlScopedService {
 	getAdminProjectsByContextFilter(
 		context: SourceControlContext,
 	): FindOptionsWhere<Project> | undefined {
-		if (context.accessToAllProjects()) {
+		if (context.hasAccessToAllProjects()) {
 			// In case the user is a global admin or owner, we don't need a filter
 			return;
 		}
@@ -74,7 +74,7 @@ export class SourceControlScopedService {
 	getFoldersInAdminProjectsFromContextFilter(
 		context: SourceControlContext,
 	): FindOptionsWhere<Folder> | undefined {
-		if (context.accessToAllProjects()) {
+		if (context.hasAccessToAllProjects()) {
 			// In case the user is a global admin or owner, we don't need a filter
 			return;
 		}
@@ -89,7 +89,7 @@ export class SourceControlScopedService {
 	getWorkflowsInAdminProjectsFromContextFilter(
 		context: SourceControlContext,
 	): FindOptionsWhere<WorkflowEntity> | undefined {
-		if (context.accessToAllProjects()) {
+		if (context.hasAccessToAllProjects()) {
 			// In case the user is a global admin or owner, we don't need a filter
 			return;
 		}
@@ -107,7 +107,7 @@ export class SourceControlScopedService {
 	getCredentialsInAdminProjectsFromContextFilter(
 		context: SourceControlContext,
 	): FindOptionsWhere<CredentialsEntity> | undefined {
-		if (context.accessToAllProjects()) {
+		if (context.hasAccessToAllProjects()) {
 			// In case the user is a global admin or owner, we don't need a filter
 			return;
 		}
@@ -125,7 +125,7 @@ export class SourceControlScopedService {
 	getWorkflowTagMappingInAdminProjectsFromContextFilter(
 		context: SourceControlContext,
 	): FindOptionsWhere<WorkflowTagMapping> | undefined {
-		if (context.accessToAllProjects()) {
+		if (context.hasAccessToAllProjects()) {
 			// In case the user is a global admin or owner, we don't need a filter
 			return;
 		}

--- a/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
@@ -41,6 +41,7 @@ import type { ImportResult } from './types/import-result';
 import type { SourceControlGetStatus } from './types/source-control-get-status';
 import type { SourceControlPreferences } from './types/source-control-preferences';
 import type { SourceControlWorkflowVersionId } from './types/source-control-workflow-version-id';
+import { SourceControlContext } from './types/source-control-context';
 
 @Service()
 export class SourceControlService {
@@ -486,13 +487,17 @@ export class SourceControlService {
 		// fetch and reset hard first
 		await this.resetWorkfolder();
 
+		const context: SourceControlContext = {
+			user,
+		};
+
 		const {
 			wfRemoteVersionIds,
 			wfLocalVersionIds,
 			wfMissingInLocal,
 			wfMissingInRemote,
 			wfModifiedInEither,
-		} = await this.getStatusWorkflows(options, sourceControlledFiles);
+		} = await this.getStatusWorkflows(options, context, sourceControlledFiles);
 
 		const { credMissingInLocal, credMissingInRemote, credModifiedInEither } =
 			await this.getStatusCredentials(options, sourceControlledFiles);
@@ -555,10 +560,13 @@ export class SourceControlService {
 
 	private async getStatusWorkflows(
 		options: SourceControlGetStatus,
+		context: SourceControlContext,
 		sourceControlledFiles: SourceControlledFile[],
 	) {
-		const wfRemoteVersionIds = await this.sourceControlImportService.getRemoteVersionIdsFromFiles();
-		const wfLocalVersionIds = await this.sourceControlImportService.getLocalVersionIdsFromDb();
+		const wfRemoteVersionIds =
+			await this.sourceControlImportService.getRemoteVersionIdsFromFiles(context);
+		const wfLocalVersionIds =
+			await this.sourceControlImportService.getLocalVersionIdsFromDb(context);
 
 		const wfMissingInLocal = wfRemoteVersionIds.filter(
 			(remote) => wfLocalVersionIds.findIndex((local) => local.id === remote.id) === -1,

--- a/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
@@ -3,8 +3,8 @@ import type {
 	PushWorkFolderRequestDto,
 	SourceControlledFile,
 } from '@n8n/api-types';
-import { Variables, TagEntity, User } from '@n8n/db';
-import { FolderRepository, TagRepository } from '@n8n/db';
+import type { Variables, TagEntity } from '@n8n/db';
+import { FolderRepository, TagRepository, User } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { writeFileSync } from 'fs';
 import { Logger } from 'n8n-core';
@@ -38,10 +38,10 @@ import { SourceControlPreferencesService } from './source-control-preferences.se
 import type { ExportableCredential } from './types/exportable-credential';
 import type { ExportableFolder } from './types/exportable-folders';
 import type { ImportResult } from './types/import-result';
+import type { SourceControlContext } from './types/source-control-context';
 import type { SourceControlGetStatus } from './types/source-control-get-status';
 import type { SourceControlPreferences } from './types/source-control-preferences';
 import type { SourceControlWorkflowVersionId } from './types/source-control-workflow-version-id';
-import { SourceControlContext } from './types/source-control-context';
 
 const GlobalAccessContext: SourceControlContext = {
 	user: Object.assign(new User(), {
@@ -680,8 +680,9 @@ export class SourceControlService {
 		context: SourceControlContext,
 		sourceControlledFiles: SourceControlledFile[],
 	) {
-		const credRemoteIds = await this.sourceControlImportService.getRemoteCredentialsFromFiles();
-		const credLocalIds = await this.sourceControlImportService.getLocalCredentialsFromDb();
+		const credRemoteIds =
+			await this.sourceControlImportService.getRemoteCredentialsFromFiles(context);
+		const credLocalIds = await this.sourceControlImportService.getLocalCredentialsFromDb(context);
 
 		const credMissingInLocal = credRemoteIds.filter(
 			(remote) => credLocalIds.findIndex((local) => local.id === remote.id) === -1,

--- a/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
@@ -43,12 +43,6 @@ import type { SourceControlGetStatus } from './types/source-control-get-status';
 import type { SourceControlPreferences } from './types/source-control-preferences';
 import type { SourceControlWorkflowVersionId } from './types/source-control-workflow-version-id';
 
-const GlobalAccessContext: SourceControlContext = {
-	user: Object.assign(new User(), {
-		role: 'global:admin',
-	}),
-};
-
 @Service()
 export class SourceControlService {
 	/** Path to SSH private key in filesystem. */

--- a/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
@@ -487,12 +487,9 @@ export class SourceControlService {
 	async getStatus(user: User, options: SourceControlGetStatus) {
 		await this.sanityCheck();
 
-		// TODO: check for a better query based on the scopes
-		if (
-			options.direction === 'pull' &&
-			user.role !== 'global:admin' &&
-			user.role !== 'global:owner'
-		) {
+		const context = new SourceControlContext(user);
+
+		if (options.direction === 'pull' && !context.accessToAllProjects()) {
 			// A pull is only allowed by global admins or owners
 			return [];
 		}
@@ -501,8 +498,6 @@ export class SourceControlService {
 
 		// fetch and reset hard first
 		await this.resetWorkfolder();
-
-		const context = new SourceControlContext(user);
 
 		const {
 			wfRemoteVersionIds,

--- a/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
@@ -11,6 +11,7 @@ import {
 	type User,
 } from '@n8n/db';
 import { Service } from '@n8n/di';
+import { hasGlobalScope } from '@n8n/permissions';
 import { writeFileSync } from 'fs';
 import { Logger } from 'n8n-core';
 import { UnexpectedError, UserError } from 'n8n-workflow';
@@ -18,6 +19,7 @@ import path from 'path';
 import type { PushResult } from 'simple-git';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { EventService } from '@/events/event.service';
 
 import {
@@ -47,8 +49,6 @@ import { SourceControlContext } from './types/source-control-context';
 import type { SourceControlGetStatus } from './types/source-control-get-status';
 import type { SourceControlPreferences } from './types/source-control-preferences';
 import type { SourceControlWorkflowVersionId } from './types/source-control-workflow-version-id';
-import { hasGlobalScope } from '@n8n/permissions';
-import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 
 @Service()
 export class SourceControlService {

--- a/packages/cli/src/environments.ee/source-control/types/exportable-tags.ts
+++ b/packages/cli/src/environments.ee/source-control/types/exportable-tags.ts
@@ -1,0 +1,3 @@
+import type { TagEntity, WorkflowTagMapping } from '@n8n/db';
+
+export type ExportableTags = { tags: TagEntity[]; mappings: WorkflowTagMapping[] };

--- a/packages/cli/src/environments.ee/source-control/types/source-control-context.ts
+++ b/packages/cli/src/environments.ee/source-control/types/source-control-context.ts
@@ -1,5 +1,14 @@
 import type { User } from '@n8n/db';
+import { hasGlobalScope } from '@n8n/permissions';
 
-export interface SourceControlContext {
-	user: User;
+export class SourceControlContext {
+	constructor(private readonly userInternal: User) {}
+
+	get user() {
+		return this.userInternal;
+	}
+
+	accessToAllProjects() {
+		return hasGlobalScope(this.userInternal, 'project:read');
+	}
 }

--- a/packages/cli/src/environments.ee/source-control/types/source-control-context.ts
+++ b/packages/cli/src/environments.ee/source-control/types/source-control-context.ts
@@ -1,13 +1,5 @@
-import type {
-	CredentialsEntity,
-	Folder,
-	Project,
-	User,
-	WorkflowEntity,
-	WorkflowTagMapping,
-} from '@n8n/db';
+import type { User } from '@n8n/db';
 import { hasGlobalScope } from '@n8n/permissions';
-import type { FindOptionsWhere } from '@n8n/typeorm';
 
 export class SourceControlContext {
 	constructor(private readonly userInternal: User) {}

--- a/packages/cli/src/environments.ee/source-control/types/source-control-context.ts
+++ b/packages/cli/src/environments.ee/source-control/types/source-control-context.ts
@@ -1,5 +1,13 @@
-import type { User } from '@n8n/db';
+import type {
+	CredentialsEntity,
+	Folder,
+	Project,
+	User,
+	WorkflowEntity,
+	WorkflowTagMapping,
+} from '@n8n/db';
 import { hasGlobalScope } from '@n8n/permissions';
+import type { FindOptionsWhere } from '@n8n/typeorm';
 
 export class SourceControlContext {
 	constructor(private readonly userInternal: User) {}

--- a/packages/cli/src/environments.ee/source-control/types/source-control-context.ts
+++ b/packages/cli/src/environments.ee/source-control/types/source-control-context.ts
@@ -1,0 +1,5 @@
+import type { User } from '@n8n/db';
+
+export interface SourceControlContext {
+	user: User;
+}

--- a/packages/cli/src/environments.ee/source-control/types/source-control-context.ts
+++ b/packages/cli/src/environments.ee/source-control/types/source-control-context.ts
@@ -8,7 +8,7 @@ export class SourceControlContext {
 		return this.userInternal;
 	}
 
-	accessToAllProjects() {
-		return hasGlobalScope(this.userInternal, 'project:read');
+	hasAccessToAllProjects() {
+		return hasGlobalScope(this.userInternal, 'project:update');
 	}
 }

--- a/packages/cli/src/interfaces.ts
+++ b/packages/cli/src/interfaces.ts
@@ -48,10 +48,16 @@ export interface IWorkflowResponse extends IWorkflowBase {
 
 export interface IWorkflowToImport
 	extends Omit<IWorkflowBase, 'staticData' | 'pinData' | 'createdAt' | 'updatedAt'> {
-	owner: {
-		type: 'personal';
-		personalEmail: string;
-	};
+	owner:
+		| {
+				type: 'personal';
+				personalEmail: string;
+		  }
+		| {
+				type: 'team';
+				teamId: string;
+				teamName: string;
+		  };
 	parentFolderId: string | null;
 }
 

--- a/packages/cli/test/integration/environments/source-control-import.service.test.ts
+++ b/packages/cli/test/integration/environments/source-control-import.service.test.ts
@@ -899,8 +899,6 @@ describe('SourceControlImportService', () => {
 				user: teamAdmin,
 			});
 
-			console.log('Result', result);
-
 			expect(new Set(result.tags.map((r) => r.id))).toEqual(
 				new Set(mockTagData.tags.map((t) => t.id)),
 			);

--- a/packages/cli/test/integration/environments/source-control-import.service.test.ts
+++ b/packages/cli/test/integration/environments/source-control-import.service.test.ts
@@ -25,6 +25,7 @@ import { nanoid } from 'nanoid';
 import fsp from 'node:fs/promises';
 
 import { SourceControlImportService } from '@/environments.ee/source-control/source-control-import.service.ee';
+import { SourceControlScopedService } from '@/environments.ee/source-control/source-control-scoped.service';
 import type { ExportableCredential } from '@/environments.ee/source-control/types/exportable-credential';
 import { SourceControlContext } from '@/environments.ee/source-control/types/source-control-context';
 import type { IWorkflowToImport } from '@/interfaces';
@@ -51,6 +52,7 @@ describe('SourceControlImportService', () => {
 	let workflowRepository: WorkflowRepository;
 	let tagRepository: TagRepository;
 	let workflowTagMappingRepository: WorkflowTagMappingRepository;
+	let sourceControlScopedService: SourceControlScopedService;
 
 	const cipher = mockInstance(Cipher);
 
@@ -65,6 +67,7 @@ describe('SourceControlImportService', () => {
 		workflowRepository = Container.get(WorkflowRepository);
 		tagRepository = Container.get(TagRepository);
 		workflowTagMappingRepository = Container.get(WorkflowTagMappingRepository);
+		sourceControlScopedService = Container.get(SourceControlScopedService);
 		service = new SourceControlImportService(
 			mock(),
 			mock(),
@@ -84,6 +87,7 @@ describe('SourceControlImportService', () => {
 			mock(),
 			folderRepository,
 			mock<InstanceSettings>({ n8nFolder: '/some-path' }),
+			sourceControlScopedService,
 		);
 	});
 

--- a/packages/cli/test/integration/environments/source-control-import.service.test.ts
+++ b/packages/cli/test/integration/environments/source-control-import.service.test.ts
@@ -1,10 +1,18 @@
 import type { SourceControlledFile } from '@n8n/api-types';
-import { CredentialsRepository, Project, User, WorkflowEntity, WorkflowRepository } from '@n8n/db';
+import {
+	CredentialsEntity,
+	CredentialsRepository,
+	Project,
+	User,
+	WorkflowEntity,
+	WorkflowRepository,
+} from '@n8n/db';
 import { FolderRepository } from '@n8n/db';
 import { ProjectRepository } from '@n8n/db';
 import { SharedCredentialsRepository } from '@n8n/db';
 import { UserRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
+import * as fastGlob from 'fast-glob';
 import { mock } from 'jest-mock-extended';
 import { Cipher } from 'n8n-core';
 import type { InstanceSettings } from 'n8n-core';
@@ -16,12 +24,16 @@ import { SourceControlImportService } from '@/environments.ee/source-control/sou
 import type { ExportableCredential } from '@/environments.ee/source-control/types/exportable-credential';
 
 import { mockInstance } from '../../shared/mocking';
-import { saveCredential } from '../shared/db/credentials';
+import { createCredentials, saveCredential } from '../shared/db/credentials';
 import { createTeamProject, getPersonalProject, linkUserToProject } from '../shared/db/projects';
-import { createMember, getGlobalOwner } from '../shared/db/users';
+import { createAdmin, createMember, createOwner, getGlobalOwner } from '../shared/db/users';
 import { createWorkflow } from '../shared/db/workflows';
 import { randomCredentialPayload } from '../shared/random';
 import * as testDb from '../shared/test-db';
+import { IWorkflowToImport } from '@/interfaces';
+import { SourceControlContext } from '@/environments.ee/source-control/types/source-control-context';
+
+jest.mock('fast-glob');
 
 describe('SourceControlImportService', () => {
 	let credentialsRepository: CredentialsRepository;
@@ -77,6 +89,183 @@ describe('SourceControlImportService', () => {
 
 	describe('getLocalFoldersAndMappingsFromDb()', () => {
 		// TODO: make test cases for folders from DB!
+	});
+
+	describe('getRemoteVersionIdsFromFiles()', () => {
+		const mockWorkflow1File = '/mock/workflow1.json';
+		const mockWorkflow2File = '/mock/workflow2.json';
+		const mockWorkflow3File = '/mock/workflow3.json';
+		const mockWorkflow4File = '/mock/workflow4.json';
+		const mockWorkflow5File = '/mock/workflow5.json';
+
+		const mockWorkflow1Data: Partial<IWorkflowToImport> = {
+			id: 'workflow1',
+			versionId: 'v1',
+			name: 'Test Workflow',
+			owner: {
+				type: 'personal',
+				personalEmail: 'someuser@example.com',
+			},
+		};
+		const mockWorkflow2Data: Partial<IWorkflowToImport> = {
+			id: 'workflow2',
+			versionId: 'v1',
+			name: 'Test Workflow',
+			owner: {
+				type: 'team',
+				teamId: 'team1',
+				teamName: 'Team 1',
+			},
+		};
+		const mockWorkflow3Data: Partial<IWorkflowToImport> = {
+			id: 'workflow3',
+			versionId: 'v1',
+			name: 'Test Workflow',
+			owner: {
+				type: 'team',
+				teamId: 'team2',
+				teamName: 'Team 2',
+			},
+		};
+		const mockWorkflow4Data: Partial<IWorkflowToImport> = {
+			id: 'workflow4',
+			versionId: 'v1',
+			name: 'Test Workflow',
+			owner: {
+				type: 'personal',
+				personalEmail: 'someotheruser@example.com',
+			},
+		};
+		const mockWorkflow5Data: Partial<IWorkflowToImport> = {
+			id: 'workflow5',
+			versionId: 'v1',
+			name: 'Test Workflow',
+			owner: {
+				type: 'team',
+				teamId: 'team1',
+				teamName: 'Team 1',
+			},
+		};
+
+		const globMock = fastGlob.default as unknown as jest.Mock<Promise<string[]>, string[]>;
+		const fsReadFile = jest.spyOn(fsp, 'readFile');
+
+		let globalAdmin: User;
+		let globalOwner: User;
+		let globalMember: User;
+		let teamAdmin: User;
+		let team1: Project;
+
+		beforeAll(async () => {
+			[globalAdmin, globalOwner, globalMember, teamAdmin] = await Promise.all([
+				createAdmin(),
+				createOwner(),
+				createMember(),
+				createMember(),
+			]);
+
+			team1 = await createTeamProject('Team 1', teamAdmin);
+		});
+
+		beforeEach(async () => {
+			globMock.mockImplementation(async () => [
+				mockWorkflow1File,
+				mockWorkflow2File,
+				mockWorkflow3File,
+				mockWorkflow4File,
+				mockWorkflow5File,
+			]);
+
+			fsReadFile.mockImplementation(async (path) => {
+				switch (path) {
+					case mockWorkflow1File:
+						return JSON.stringify({
+							...mockWorkflow1Data,
+							owner: {
+								type: 'personal',
+								personalEmail: teamAdmin.email,
+							},
+						});
+					case mockWorkflow2File:
+						return JSON.stringify({
+							...mockWorkflow2Data,
+							owner: {
+								type: 'team',
+								teamId: team1.id,
+								teamName: team1.name,
+							},
+						});
+					case mockWorkflow3File:
+						return JSON.stringify(mockWorkflow3Data);
+					case mockWorkflow4File:
+						return JSON.stringify(mockWorkflow4Data);
+					case mockWorkflow5File:
+						return JSON.stringify({
+							...mockWorkflow5Data,
+							owner: {
+								type: 'team',
+								teamId: team1.id,
+								teamName: team1.name,
+							},
+						});
+				}
+				throw new Error(`Trying to access invalid file in test: ${path}`);
+			});
+		});
+
+		it('should show all remote workflows for instance admins', async () => {
+			const result = await service.getRemoteVersionIdsFromFiles({
+				user: globalAdmin,
+			});
+
+			expect(new Set(result.map((r) => r.id))).toEqual(
+				new Set(
+					[
+						mockWorkflow1Data,
+						mockWorkflow2Data,
+						mockWorkflow3Data,
+						mockWorkflow4Data,
+						mockWorkflow5Data,
+					].map((r) => r.id),
+				),
+			);
+		});
+
+		it('should show all remote workflows for instance owners', async () => {
+			const result = await service.getRemoteVersionIdsFromFiles({
+				user: globalOwner,
+			});
+
+			expect(new Set(result.map((r) => r.id))).toEqual(
+				new Set(
+					[
+						mockWorkflow1Data,
+						mockWorkflow2Data,
+						mockWorkflow3Data,
+						mockWorkflow4Data,
+						mockWorkflow5Data,
+					].map((r) => r.id),
+				),
+			);
+		});
+
+		it('should return no remote workflows for instance members', async () => {
+			const result = await service.getRemoteVersionIdsFromFiles({
+				user: globalMember,
+			});
+
+			expect(result).toBeEmptyArray();
+		});
+
+		it('should return only remote workflows that belong to team project', async () => {
+			const result = await service.getRemoteVersionIdsFromFiles({
+				user: teamAdmin,
+			});
+
+			expect(new Set(result.map((r) => r.id))).toEqual(
+				new Set([mockWorkflow2Data, mockWorkflow5Data].map((r) => r.id)),
+			);
+		});
 	});
 
 	describe('getLocalVersionIdsFromDb()', () => {
@@ -172,7 +361,292 @@ describe('SourceControlImportService', () => {
 					user: projectMember,
 				});
 
-				expect(new Set(versions.map((v) => v.id))).toEqual(new Set([]));
+				expect(versions).toBeEmptyArray();
+			});
+		});
+	});
+
+	describe('getRemoteCredentialsFromFiles()', () => {
+		const mockCredential1File = '/mock/credential1.json';
+		const mockCredential2File = '/mock/credential2.json';
+		const mockCredential3File = '/mock/credential3.json';
+		const mockCredential4File = '/mock/credential4.json';
+		const mockCredential5File = '/mock/credential5.json';
+
+		const mockCredential1Data: Partial<ExportableCredential> = {
+			id: 'credentials1',
+			name: 'Test Workflow',
+			ownedBy: {
+				type: 'personal',
+				personalEmail: 'someuser@example.com',
+			},
+		};
+		const mockCredential2Data: Partial<ExportableCredential> = {
+			id: 'credentials2',
+			name: 'Test Workflow',
+			ownedBy: {
+				type: 'team',
+				teamId: 'team1',
+				teamName: 'Team 1',
+			},
+		};
+		const mockCredential3Data: Partial<ExportableCredential> = {
+			id: 'credentials3',
+			name: 'Test Workflow',
+			ownedBy: {
+				type: 'team',
+				teamId: 'team2',
+				teamName: 'Team 2',
+			},
+		};
+		const mockCredential4Data: Partial<ExportableCredential> = {
+			id: 'credentials4',
+			name: 'Test Workflow',
+			ownedBy: {
+				type: 'personal',
+				personalEmail: 'someotheruser@example.com',
+			},
+		};
+		const mockCredential5Data: Partial<ExportableCredential> = {
+			id: 'credentials5',
+			name: 'Test Workflow',
+			ownedBy: {
+				type: 'team',
+				teamId: 'team1',
+				teamName: 'Team 1',
+			},
+		};
+
+		const globMock = fastGlob.default as unknown as jest.Mock<Promise<string[]>, string[]>;
+		const fsReadFile = jest.spyOn(fsp, 'readFile');
+
+		let globalAdmin: User;
+		let globalOwner: User;
+		let globalMember: User;
+		let teamAdmin: User;
+		let team1: Project;
+
+		beforeAll(async () => {
+			[globalAdmin, globalOwner, globalMember, teamAdmin] = await Promise.all([
+				createAdmin(),
+				createOwner(),
+				createMember(),
+				createMember(),
+			]);
+
+			team1 = await createTeamProject('Team 1', teamAdmin);
+		});
+
+		beforeEach(async () => {
+			globMock.mockImplementation(async () => [
+				mockCredential1File,
+				mockCredential2File,
+				mockCredential3File,
+				mockCredential4File,
+				mockCredential5File,
+			]);
+
+			fsReadFile.mockImplementation(async (path) => {
+				switch (path) {
+					case mockCredential1File:
+						return JSON.stringify({
+							...mockCredential1Data,
+							ownedBy: {
+								type: 'personal',
+								personalEmail: teamAdmin.email,
+							},
+						});
+					case mockCredential2File:
+						return JSON.stringify({
+							...mockCredential2Data,
+							ownedBy: {
+								type: 'team',
+								teamId: team1.id,
+								teamName: team1.name,
+							},
+						});
+					case mockCredential3File:
+						return JSON.stringify(mockCredential3Data);
+					case mockCredential4File:
+						return JSON.stringify(mockCredential4Data);
+					case mockCredential5File:
+						return JSON.stringify({
+							...mockCredential5Data,
+							ownedBy: {
+								type: 'team',
+								teamId: team1.id,
+								teamName: team1.name,
+							},
+						});
+				}
+				throw new Error(`Trying to access invalid file in test: ${path}`);
+			});
+		});
+
+		it('should show all remote credentials for instance admins', async () => {
+			const result = await service.getRemoteCredentialsFromFiles({
+				user: globalAdmin,
+			});
+
+			expect(new Set(result.map((r) => r.id))).toEqual(
+				new Set(
+					[
+						mockCredential1Data,
+						mockCredential2Data,
+						mockCredential3Data,
+						mockCredential4Data,
+						mockCredential5Data,
+					].map((r) => r.id),
+				),
+			);
+		});
+
+		it('should show all remote credentials for instance owners', async () => {
+			const result = await service.getRemoteCredentialsFromFiles({
+				user: globalOwner,
+			});
+
+			expect(new Set(result.map((r) => r.id))).toEqual(
+				new Set(
+					[
+						mockCredential1Data,
+						mockCredential2Data,
+						mockCredential3Data,
+						mockCredential4Data,
+						mockCredential5Data,
+					].map((r) => r.id),
+				),
+			);
+		});
+
+		it('should return no remote credentials for instance members', async () => {
+			const result = await service.getRemoteCredentialsFromFiles({
+				user: globalMember,
+			});
+
+			expect(result).toBeEmptyArray();
+		});
+
+		it('should return only remote credentials that belong to team project', async () => {
+			const result = await service.getRemoteCredentialsFromFiles({
+				user: teamAdmin,
+			});
+
+			expect(new Set(result.map((r) => r.id))).toEqual(
+				new Set([mockCredential2Data, mockCredential5Data].map((r) => r.id)),
+			);
+		});
+	});
+
+	describe('getLocalCredentialsFromDb', () => {
+		let instanceOwner: User;
+		let projectAdmin: User;
+		let projectMember: User;
+		let teamProjectA: Project;
+		let teamProjectB: Project;
+		let teamACredentials: CredentialsEntity[];
+		let teamBCredentials: CredentialsEntity[];
+
+		beforeAll(async () => {
+			[instanceOwner, projectAdmin, projectMember, teamProjectA, teamProjectB] = await Promise.all([
+				getGlobalOwner(),
+				createMember(),
+				createMember(),
+				createTeamProject(),
+				createTeamProject(),
+			]);
+
+			await linkUserToProject(projectAdmin, teamProjectA, 'project:admin');
+			await linkUserToProject(projectMember, teamProjectA, 'project:editor');
+			await linkUserToProject(projectAdmin, teamProjectB, 'project:editor');
+			await linkUserToProject(projectMember, teamProjectB, 'project:editor');
+
+			teamACredentials = await Promise.all([
+				await createCredentials(
+					{
+						name: 'credential1',
+						data: '',
+						type: 'test',
+					},
+					teamProjectA,
+				),
+				await createCredentials(
+					{
+						name: 'credential2',
+						data: '',
+						type: 'test',
+					},
+					teamProjectA,
+				),
+				await createCredentials(
+					{
+						name: 'credential3',
+						data: '',
+						type: 'test',
+					},
+					teamProjectA,
+				),
+			]);
+
+			teamBCredentials = await Promise.all([
+				await createCredentials(
+					{
+						name: 'credential4',
+						data: '',
+						type: 'test',
+					},
+					teamProjectB,
+				),
+				await createCredentials(
+					{
+						name: 'credential5',
+						data: '',
+						type: 'test',
+					},
+					teamProjectB,
+				),
+				await createCredentials(
+					{
+						name: 'credential6',
+						data: '',
+						type: 'test',
+					},
+					teamProjectB,
+				),
+			]);
+		});
+
+		describe('if user is an instance owner', () => {
+			it('should get all available credentials on the instance', async () => {
+				let versions = await service.getLocalCredentialsFromDb({
+					user: instanceOwner,
+				});
+
+				expect(new Set(versions.map((v) => v.id))).toEqual(
+					new Set([...teamACredentials.map((w) => w.id), ...teamBCredentials.map((w) => w.id)]),
+				);
+			});
+		});
+
+		describe('if user is a project admin of a team project', () => {
+			it.only('should only get all available credentials from the team project', async () => {
+				let versions = await service.getLocalCredentialsFromDb({
+					user: projectAdmin,
+				});
+
+				expect(new Set(versions.map((v) => v.id))).toEqual(
+					new Set([...teamACredentials.map((w) => w.id)]),
+				);
+			});
+		});
+
+		describe('if user is a project member of a team project', () => {
+			it('should not get any workflows', async () => {
+				let versions = await service.getLocalCredentialsFromDb({
+					user: projectMember,
+				});
+
+				expect(versions).toBeEmptyArray();
 			});
 		});
 	});

--- a/packages/cli/test/integration/environments/source-control-import.service.test.ts
+++ b/packages/cli/test/integration/environments/source-control-import.service.test.ts
@@ -26,6 +26,7 @@ import fsp from 'node:fs/promises';
 
 import { SourceControlImportService } from '@/environments.ee/source-control/source-control-import.service.ee';
 import type { ExportableCredential } from '@/environments.ee/source-control/types/exportable-credential';
+import { SourceControlContext } from '@/environments.ee/source-control/types/source-control-context';
 import type { IWorkflowToImport } from '@/interfaces';
 import { createFolder } from '@test-integration/db/folders';
 import { assignTagToWorkflow, createTag } from '@test-integration/db/tags';
@@ -219,9 +220,9 @@ describe('SourceControlImportService', () => {
 		});
 
 		it('should show all remote workflows for instance admins', async () => {
-			const result = await service.getRemoteVersionIdsFromFiles({
-				user: globalAdmin,
-			});
+			const result = await service.getRemoteVersionIdsFromFiles(
+				new SourceControlContext(globalAdmin),
+			);
 
 			expect(new Set(result.map((r) => r.id))).toEqual(
 				new Set(
@@ -237,9 +238,9 @@ describe('SourceControlImportService', () => {
 		});
 
 		it('should show all remote workflows for instance owners', async () => {
-			const result = await service.getRemoteVersionIdsFromFiles({
-				user: globalOwner,
-			});
+			const result = await service.getRemoteVersionIdsFromFiles(
+				new SourceControlContext(globalOwner),
+			);
 
 			expect(new Set(result.map((r) => r.id))).toEqual(
 				new Set(
@@ -255,17 +256,17 @@ describe('SourceControlImportService', () => {
 		});
 
 		it('should return no remote workflows for instance members', async () => {
-			const result = await service.getRemoteVersionIdsFromFiles({
-				user: globalMember,
-			});
+			const result = await service.getRemoteVersionIdsFromFiles(
+				new SourceControlContext(globalMember),
+			);
 
 			expect(result).toBeEmptyArray();
 		});
 
 		it('should return only remote workflows that belong to team project', async () => {
-			const result = await service.getRemoteVersionIdsFromFiles({
-				user: teamAdmin,
-			});
+			const result = await service.getRemoteVersionIdsFromFiles(
+				new SourceControlContext(teamAdmin),
+			);
 
 			expect(new Set(result.map((r) => r.id))).toEqual(
 				new Set([mockWorkflow2Data, mockWorkflow5Data].map((r) => r.id)),
@@ -332,9 +333,9 @@ describe('SourceControlImportService', () => {
 
 		describe('if user is an instance owner', () => {
 			it('should get all available workflows on the instance', async () => {
-				let versions = await service.getLocalVersionIdsFromDb({
-					user: instanceOwner,
-				});
+				let versions = await service.getLocalVersionIdsFromDb(
+					new SourceControlContext(instanceOwner),
+				);
 
 				expect(new Set(versions.map((v) => v.id))).toEqual(
 					new Set([
@@ -350,9 +351,9 @@ describe('SourceControlImportService', () => {
 
 		describe('if user is a project admin of a team project', () => {
 			it('should only get all available workflows from the team project', async () => {
-				let versions = await service.getLocalVersionIdsFromDb({
-					user: projectAdmin,
-				});
+				let versions = await service.getLocalVersionIdsFromDb(
+					new SourceControlContext(projectAdmin),
+				);
 
 				expect(new Set(versions.map((v) => v.id))).toEqual(
 					new Set([...teamAWorkflows.map((w) => w.id)]),
@@ -362,9 +363,9 @@ describe('SourceControlImportService', () => {
 
 		describe('if user is a project member of a team project', () => {
 			it('should not get any workflows', async () => {
-				let versions = await service.getLocalVersionIdsFromDb({
-					user: projectMember,
-				});
+				let versions = await service.getLocalVersionIdsFromDb(
+					new SourceControlContext(projectMember),
+				);
 
 				expect(versions).toBeEmptyArray();
 			});
@@ -489,9 +490,9 @@ describe('SourceControlImportService', () => {
 		});
 
 		it('should show all remote credentials for instance admins', async () => {
-			const result = await service.getRemoteCredentialsFromFiles({
-				user: globalAdmin,
-			});
+			const result = await service.getRemoteCredentialsFromFiles(
+				new SourceControlContext(globalAdmin),
+			);
 
 			expect(new Set(result.map((r) => r.id))).toEqual(
 				new Set(
@@ -507,9 +508,9 @@ describe('SourceControlImportService', () => {
 		});
 
 		it('should show all remote credentials for instance owners', async () => {
-			const result = await service.getRemoteCredentialsFromFiles({
-				user: globalOwner,
-			});
+			const result = await service.getRemoteCredentialsFromFiles(
+				new SourceControlContext(globalOwner),
+			);
 
 			expect(new Set(result.map((r) => r.id))).toEqual(
 				new Set(
@@ -525,17 +526,17 @@ describe('SourceControlImportService', () => {
 		});
 
 		it('should return no remote credentials for instance members', async () => {
-			const result = await service.getRemoteCredentialsFromFiles({
-				user: globalMember,
-			});
+			const result = await service.getRemoteCredentialsFromFiles(
+				new SourceControlContext(globalMember),
+			);
 
 			expect(result).toBeEmptyArray();
 		});
 
 		it('should return only remote credentials that belong to team project', async () => {
-			const result = await service.getRemoteCredentialsFromFiles({
-				user: teamAdmin,
-			});
+			const result = await service.getRemoteCredentialsFromFiles(
+				new SourceControlContext(teamAdmin),
+			);
 
 			expect(new Set(result.map((r) => r.id))).toEqual(
 				new Set([mockCredential2Data, mockCredential5Data].map((r) => r.id)),
@@ -622,9 +623,9 @@ describe('SourceControlImportService', () => {
 		});
 
 		it('should get all available credentials on the instance, for an instance owner', async () => {
-			let versions = await service.getLocalCredentialsFromDb({
-				user: instanceOwner,
-			});
+			let versions = await service.getLocalCredentialsFromDb(
+				new SourceControlContext(instanceOwner),
+			);
 
 			expect(new Set(versions.map((v) => v.id))).toEqual(
 				new Set([...teamACredentials.map((w) => w.id), ...teamBCredentials.map((w) => w.id)]),
@@ -632,9 +633,9 @@ describe('SourceControlImportService', () => {
 		});
 
 		it('should only get all available credentials from the team project, for a project admin', async () => {
-			let versions = await service.getLocalCredentialsFromDb({
-				user: projectAdmin,
-			});
+			let versions = await service.getLocalCredentialsFromDb(
+				new SourceControlContext(projectAdmin),
+			);
 
 			expect(new Set(versions.map((v) => v.id))).toEqual(
 				new Set([...teamACredentials.map((w) => w.id)]),
@@ -642,9 +643,9 @@ describe('SourceControlImportService', () => {
 		});
 
 		it('should not get any workflows, for a project member', async () => {
-			let versions = await service.getLocalCredentialsFromDb({
-				user: projectMember,
-			});
+			let versions = await service.getLocalCredentialsFromDb(
+				new SourceControlContext(projectMember),
+			);
 
 			expect(versions).toBeEmptyArray();
 		});
@@ -706,9 +707,9 @@ describe('SourceControlImportService', () => {
 		});
 
 		it('should get all available folders on the instance, for an instance owner', async () => {
-			let folders = await service.getLocalFoldersAndMappingsFromDb({
-				user: instanceOwner,
-			});
+			let folders = await service.getLocalFoldersAndMappingsFromDb(
+				new SourceControlContext(instanceOwner),
+			);
 
 			expect(new Set(folders.folders.map((v) => v.id))).toEqual(
 				new Set([...foldersProjectA.map((w) => w.id), ...foldersProjectB.map((w) => w.id)]),
@@ -716,9 +717,9 @@ describe('SourceControlImportService', () => {
 		});
 
 		it('should only get all available folders from the team project, for a project admin', async () => {
-			let versions = await service.getLocalFoldersAndMappingsFromDb({
-				user: projectAdmin,
-			});
+			let versions = await service.getLocalFoldersAndMappingsFromDb(
+				new SourceControlContext(projectAdmin),
+			);
 
 			expect(new Set(versions.folders.map((v) => v.id))).toEqual(
 				new Set([...foldersProjectA.map((w) => w.id)]),
@@ -726,9 +727,9 @@ describe('SourceControlImportService', () => {
 		});
 
 		it('should not get any folders, for a project member', async () => {
-			let versions = await service.getLocalFoldersAndMappingsFromDb({
-				user: projectMember,
-			});
+			let versions = await service.getLocalFoldersAndMappingsFromDb(
+				new SourceControlContext(projectMember),
+			);
 
 			expect(versions.folders).toBeEmptyArray();
 		});
@@ -859,9 +860,9 @@ describe('SourceControlImportService', () => {
 		beforeEach(async () => {});
 
 		it('should show all remote tags and all remote mappings for instance admins', async () => {
-			const result = await service.getRemoteTagsAndMappingsFromFile({
-				user: globalAdmin,
-			});
+			const result = await service.getRemoteTagsAndMappingsFromFile(
+				new SourceControlContext(globalAdmin),
+			);
 
 			expect(new Set(result.tags.map((r) => r.id))).toEqual(
 				new Set(mockTagData.tags.map((t) => t.id)),
@@ -870,9 +871,9 @@ describe('SourceControlImportService', () => {
 		});
 
 		it('should show all remote tags and all remote mappings for instance owners', async () => {
-			const result = await service.getRemoteTagsAndMappingsFromFile({
-				user: globalOwner,
-			});
+			const result = await service.getRemoteTagsAndMappingsFromFile(
+				new SourceControlContext(globalOwner),
+			);
 
 			expect(new Set(result.tags.map((r) => r.id))).toEqual(
 				new Set(mockTagData.tags.map((t) => t.id)),
@@ -881,9 +882,9 @@ describe('SourceControlImportService', () => {
 		});
 
 		it('should return all remote tags and no remote mappings for instance members', async () => {
-			const result = await service.getRemoteTagsAndMappingsFromFile({
-				user: globalMember,
-			});
+			const result = await service.getRemoteTagsAndMappingsFromFile(
+				new SourceControlContext(globalMember),
+			);
 
 			expect(new Set(result.tags.map((r) => r.id))).toEqual(
 				new Set(mockTagData.tags.map((t) => t.id)),
@@ -892,9 +893,9 @@ describe('SourceControlImportService', () => {
 		});
 
 		it('should return all remote tags and only remote mappings for in scope team for team admin', async () => {
-			const result = await service.getRemoteTagsAndMappingsFromFile({
-				user: teamAdmin,
-			});
+			const result = await service.getRemoteTagsAndMappingsFromFile(
+				new SourceControlContext(teamAdmin),
+			);
 
 			expect(new Set(result.tags.map((r) => r.id))).toEqual(
 				new Set(mockTagData.tags.map((t) => t.id)),
@@ -1009,9 +1010,9 @@ describe('SourceControlImportService', () => {
 		});
 
 		it('should get all available tags and mappings on the instance, for an instance owner', async () => {
-			let result = await service.getLocalTagsAndMappingsFromDb({
-				user: instanceOwner,
-			});
+			let result = await service.getLocalTagsAndMappingsFromDb(
+				new SourceControlContext(instanceOwner),
+			);
 
 			expect(new Set(result.tags.map((v) => v.id))).toEqual(new Set([...tags.map((w) => w.id)]));
 			expect(
@@ -1030,9 +1031,9 @@ describe('SourceControlImportService', () => {
 		});
 
 		it('should only get all available tags and only mappings from the team project, for a project admin', async () => {
-			let result = await service.getLocalTagsAndMappingsFromDb({
-				user: projectAdmin,
-			});
+			let result = await service.getLocalTagsAndMappingsFromDb(
+				new SourceControlContext(projectAdmin),
+			);
 
 			expect(new Set(result.tags.map((v) => v.id))).toEqual(new Set([...tags.map((w) => w.id)]));
 
@@ -1054,9 +1055,9 @@ describe('SourceControlImportService', () => {
 		});
 
 		it('should get all available tags but no mappings, for a project member', async () => {
-			let result = await service.getLocalTagsAndMappingsFromDb({
-				user: projectMember,
-			});
+			let result = await service.getLocalTagsAndMappingsFromDb(
+				new SourceControlContext(projectMember),
+			);
 
 			expect(new Set(result.tags.map((v) => v.id))).toEqual(new Set([...tags.map((w) => w.id)]));
 

--- a/packages/cli/test/integration/environments/source-control-import.service.test.ts
+++ b/packages/cli/test/integration/environments/source-control-import.service.test.ts
@@ -1,13 +1,13 @@
 import type { SourceControlledFile } from '@n8n/api-types';
 import {
-	CredentialsEntity,
+	type CredentialsEntity,
 	CredentialsRepository,
-	Folder,
-	Project,
-	TagEntity,
+	type Folder,
+	type Project,
+	type TagEntity,
 	TagRepository,
-	User,
-	WorkflowEntity,
+	type User,
+	type WorkflowEntity,
 	WorkflowRepository,
 	WorkflowTagMappingRepository,
 } from '@n8n/db';
@@ -26,6 +26,9 @@ import fsp from 'node:fs/promises';
 
 import { SourceControlImportService } from '@/environments.ee/source-control/source-control-import.service.ee';
 import type { ExportableCredential } from '@/environments.ee/source-control/types/exportable-credential';
+import type { IWorkflowToImport } from '@/interfaces';
+import { createFolder } from '@test-integration/db/folders';
+import { assignTagToWorkflow, createTag } from '@test-integration/db/tags';
 
 import { mockInstance } from '../../shared/mocking';
 import { createCredentials, saveCredential } from '../shared/db/credentials';
@@ -34,11 +37,6 @@ import { createAdmin, createMember, createOwner, getGlobalOwner } from '../share
 import { createWorkflow } from '../shared/db/workflows';
 import { randomCredentialPayload } from '../shared/random';
 import * as testDb from '../shared/test-db';
-import { IWorkflowToImport } from '@/interfaces';
-import { SourceControlContext } from '@/environments.ee/source-control/types/source-control-context';
-import { createFolder } from '@test-integration/db/folders';
-import { assignTagToWorkflow, createTag } from '@test-integration/db/tags';
-import { ExportableTags } from '@/environments.ee/source-control/types/exportable-tags';
 
 jest.mock('fast-glob');
 
@@ -791,7 +789,6 @@ describe('SourceControlImportService', () => {
 		let team1: Project;
 		let team2: Project;
 		let workflowTeam1: WorkflowEntity[];
-		let workflowTeam2: WorkflowEntity[];
 
 		beforeEach(async () => {
 			[globalAdmin, globalOwner, globalMember, teamAdmin] = await Promise.all([
@@ -834,7 +831,7 @@ describe('SourceControlImportService', () => {
 				),
 			]);
 
-			workflowTeam2 = await Promise.all([
+			await Promise.all([
 				await createWorkflow(
 					{
 						id: 'wf4',

--- a/packages/cli/test/integration/environments/source-control.api.test.ts
+++ b/packages/cli/test/integration/environments/source-control.api.test.ts
@@ -13,6 +13,7 @@ import * as utils from '../shared/utils';
 
 let authOwnerAgent: SuperAgentTest;
 let owner: User;
+
 mockInstance(Telemetry);
 
 const testServer = utils.setupTestServer({

--- a/packages/cli/test/integration/environments/source-control.service.test.ts
+++ b/packages/cli/test/integration/environments/source-control.service.test.ts
@@ -681,6 +681,7 @@ describe('SourceControlService', () => {
 							projectAdminScope.workflows[1],
 							projectAScope.workflows[0],
 							projectBScope.workflows[0],
+							movedOutOfScopeWorkflow,
 						]
 							.map((wf) => wf.id)
 							.some((id) => wf.id === id);
@@ -694,7 +695,7 @@ describe('SourceControlService', () => {
 
 					// The created workflows‚
 					expect(new Set(deletedWorkflows.map((wf) => wf.id))).toEqual(
-						new Set([deletedInScopeWorkflow.id, movedOutOfScopeWorkflow.id]),
+						new Set([deletedInScopeWorkflow.id]),
 					);
 
 					const newWorkflows = result.filter(

--- a/packages/cli/test/integration/environments/source-control.service.test.ts
+++ b/packages/cli/test/integration/environments/source-control.service.test.ts
@@ -1,0 +1,776 @@
+import {
+	CredentialsEntity,
+	type Folder,
+	Project,
+	type TagEntity,
+	type User,
+	WorkflowEntity,
+} from '@n8n/db';
+import { Container } from '@n8n/di';
+import * as fastGlob from 'fast-glob';
+import fsp from 'node:fs/promises';
+
+import {
+	SOURCE_CONTROL_CREDENTIAL_EXPORT_FOLDER,
+	SOURCE_CONTROL_FOLDERS_EXPORT_FILE,
+	SOURCE_CONTROL_TAGS_EXPORT_FILE,
+	SOURCE_CONTROL_WORKFLOW_EXPORT_FOLDER,
+} from '@/environments.ee/source-control/constants';
+import { SourceControlPreferencesService } from '@/environments.ee/source-control/source-control-preferences.service.ee';
+import { SourceControlService } from '@/environments.ee/source-control/source-control.service.ee';
+import type { ExportableCredential } from '@/environments.ee/source-control/types/exportable-credential';
+import type { ExportableFolder } from '@/environments.ee/source-control/types/exportable-folders';
+import type { ExportableWorkflow } from '@/environments.ee/source-control/types/exportable-workflow';
+import type { ResourceOwner } from '@/environments.ee/source-control/types/resource-owner';
+import { createCredentials } from '@test-integration/db/credentials';
+import { createFolder } from '@test-integration/db/folders';
+import { createTeamProject } from '@test-integration/db/projects';
+import { assignTagToWorkflow, createTag } from '@test-integration/db/tags';
+import { createUser } from '@test-integration/db/users';
+import { createWorkflow } from '@test-integration/db/workflows';
+
+import * as testDb from '../shared/test-db';
+
+jest.mock('fast-glob');
+
+type Scope = {
+	workflows: WorkflowEntity[];
+	credentials: CredentialsEntity[];
+	folders: Folder[];
+};
+
+let sourceControlPreferencesService: SourceControlPreferencesService;
+
+function toExportableFolder(folder: Folder): ExportableFolder {
+	return {
+		id: folder.id,
+		name: folder.name,
+		homeProjectId: folder.homeProject.id,
+		parentFolderId: folder.parentFolderId,
+		createdAt: folder.createdAt.toISOString(),
+		updatedAt: folder.updatedAt.toISOString(),
+	};
+}
+
+function toExportableCredential(
+	cred: CredentialsEntity,
+	owner: Project | User,
+): ExportableCredential {
+	let resourceOwner: ResourceOwner;
+
+	if (owner instanceof Project) {
+		resourceOwner = {
+			type: 'team',
+			teamId: owner.id,
+			teamName: owner.name,
+		};
+	} else {
+		resourceOwner = {
+			type: 'personal',
+			personalEmail: owner.email,
+		};
+	}
+
+	return {
+		id: cred.id,
+		data: {},
+		name: cred.name,
+		type: cred.type,
+		ownedBy: resourceOwner,
+	};
+}
+
+function toExportableWorkflow(
+	wf: WorkflowEntity,
+	owner: Project | User,
+	versionId?: string,
+): ExportableWorkflow {
+	let resourceOwner: ResourceOwner;
+
+	if (owner instanceof Project) {
+		resourceOwner = {
+			type: 'team',
+			teamId: owner.id,
+			teamName: owner.name,
+		};
+	} else {
+		resourceOwner = {
+			type: 'personal',
+			personalEmail: owner.email,
+		};
+	}
+
+	return {
+		id: wf.id,
+		name: wf.name,
+		connections: wf.connections,
+		isArchived: wf.isArchived,
+		nodes: wf.nodes,
+		owner: resourceOwner,
+		triggerCount: wf.triggerCount,
+		parentFolderId: null,
+		versionId: versionId ?? wf.versionId,
+	};
+}
+
+describe('SourceControlService', () => {
+	beforeAll(async () => {
+		await testDb.init();
+
+		sourceControlPreferencesService = Container.get(SourceControlPreferencesService);
+		await sourceControlPreferencesService.setPreferences({
+			connected: true,
+			keyGeneratorType: 'rsa',
+		});
+	});
+
+	afterAll(async () => {
+		await testDb.terminate();
+	});
+
+	describe('getStatus', () => {
+		/*
+			Test scenarios (push):
+				1. 	globalAdmin
+						sees everything, workflows in different projects, credentials in different projects, tags and mappings in different projects, folders in different projects
+				2. 	globalOwner
+						same as global Admin
+				3.  globalMember
+						sees nothing ...
+				4. 	projectAdmin (global member)
+						sees workflows in his team projects only, credentials in his team projects only, same for mappings and folders, sees all tags
+				5.  projectMember
+						sees nothing
+
+			Test scenarios (pull):
+				TBD!
+		*/
+
+		let globalAdmin: User;
+		let globalOwner: User;
+		let globalMember: User;
+		let projectAdmin: User;
+
+		let projectA: Project;
+		let projectB: Project;
+
+		let globalAdminScope: Scope;
+		let globalOwnerScope: Scope;
+		let globalMemberScope: Scope;
+		let projectAdminScope: Scope;
+		let projectAScope: Scope;
+		let projectBScope: Scope;
+
+		let allWorkflows: WorkflowEntity[];
+		let tags: TagEntity[];
+		let gitFiles: Record<string, unknown>;
+
+		let movedOutOfScopeWorkflow: WorkflowEntity;
+		let movedIntoScopeWorkflow: WorkflowEntity;
+
+		let deletedOutOfScopeWorkflow: WorkflowEntity;
+		let deletedInScopeWorkflow: WorkflowEntity;
+
+		let movedOutOfScopeCredential: CredentialsEntity;
+		let movedIntoScopeCredential: CredentialsEntity;
+
+		let deletedOutOfScopeCredential: CredentialsEntity;
+		let deletedInScopeCredential: CredentialsEntity;
+
+		let service: SourceControlService;
+
+		const globMock = fastGlob.default as unknown as jest.Mock<
+			Promise<string[]>,
+			[fastGlob.Pattern | fastGlob.Pattern[], fastGlob.Options]
+		>;
+		const fsReadFile = jest.spyOn(fsp, 'readFile');
+
+		beforeAll(async () => {
+			/*
+				Set up test conditions:
+				4 users:
+					globalAdmin
+					globalOwner
+					globalMember
+					projectAdmin
+
+				2 Team projects:
+					ProjectA (admin == projectAdmin)
+					ProjectB
+
+				2 Workflows per Team and User
+				2 Credentials per Team
+				3 Tags
+				Mappings to all workflows
+				for each project 3 folders 2 top level, 1 child
+
+				1. Workflow moved in git to other project
+			*/
+
+			[globalAdmin, globalOwner, globalMember, projectAdmin] = await Promise.all([
+				await createUser({ role: 'global:admin' }),
+				await createUser({ role: 'global:owner' }),
+				await createUser({ role: 'global:member' }),
+				await createUser({ role: 'global:member' }),
+			]);
+
+			[projectA, projectB] = await Promise.all([
+				createTeamProject('ProjectA', projectAdmin),
+				createTeamProject('ProjectB'),
+			]);
+
+			let [
+				globalAdminWorkflows,
+				globalOwnerWorkflows,
+				globalMemberWorkflows,
+				projectAdminWorkflows,
+				projectAWorkflows,
+				projectBWorkflows,
+			] = await Promise.all(
+				[globalAdmin, globalOwner, globalMember, projectAdmin, projectA, projectB].map(
+					async (owner) => [
+						await createWorkflow(
+							{
+								name: `${owner.id}-WFA`,
+							},
+							owner,
+						),
+						await createWorkflow(
+							{
+								name: `${owner.id}-WFB`,
+							},
+							owner,
+						),
+					],
+				),
+			);
+
+			allWorkflows = [
+				...globalAdminWorkflows,
+				...globalOwnerWorkflows,
+				...globalMemberWorkflows,
+				...projectAdminWorkflows,
+				...projectAWorkflows,
+				...projectBWorkflows,
+			];
+
+			deletedOutOfScopeWorkflow = Object.assign(new WorkflowEntity(), {
+				id: 'deletedOutOfScope',
+				name: 'deletedOutOfScope',
+			});
+
+			deletedInScopeWorkflow = Object.assign(new WorkflowEntity(), {
+				id: 'deletedInScope',
+				name: 'deletedInScope',
+			});
+
+			deletedInScopeCredential = Object.assign(new CredentialsEntity(), {
+				id: 'deletedInScope',
+				name: 'deletedInScope',
+				data: '',
+				type: '',
+			});
+
+			deletedOutOfScopeCredential = Object.assign(new CredentialsEntity(), {
+				id: 'deletedOutOfScope',
+				name: 'deletedOutOfScope',
+				data: '',
+				type: '',
+			});
+
+			[
+				movedOutOfScopeCredential,
+				movedIntoScopeCredential,
+				movedOutOfScopeWorkflow,
+				movedIntoScopeWorkflow,
+			] = await Promise.all([
+				await createCredentials(
+					{
+						name: 'OutOfScope',
+						data: '',
+						type: '',
+					},
+					projectB,
+				),
+				await createCredentials(
+					{
+						name: 'IntoScope',
+						data: '',
+						type: '',
+					},
+					projectA,
+				),
+				await createWorkflow(
+					{
+						name: 'OutOfScope',
+					},
+					projectB,
+				),
+				await createWorkflow(
+					{
+						name: 'IntoScope',
+					},
+					projectA,
+				),
+			]);
+
+			let [projectACredentials, projectBCredentials] = await Promise.all(
+				[projectA, projectB].map(async (project) => [
+					await createCredentials(
+						{
+							name: `${project.name}-CredA`,
+							data: '',
+							type: '',
+						},
+						project,
+					),
+					await createCredentials(
+						{
+							name: `${project.name}-CredB‚`,
+							data: '',
+							type: '',
+						},
+						project,
+					),
+				]),
+			);
+
+			tags = await Promise.all([
+				createTag({
+					name: 'testTag1',
+				}),
+				createTag({
+					name: 'testTag2',
+				}),
+				createTag({
+					name: 'testTag3',
+				}),
+			]);
+
+			await Promise.all(
+				tags.map(async (tag) => {
+					await Promise.all(
+						allWorkflows.map(async (workflow) => {
+							await assignTagToWorkflow(tag, workflow);
+						}),
+					);
+				}),
+			);
+
+			let [projectAFolders, projectBFolders] = await Promise.all(
+				[projectA, projectB].map(async (project) => {
+					const parent = await createFolder(project, {
+						name: `${project.name}-FolderA`,
+					});
+
+					return [
+						parent,
+						await createFolder(project, {
+							name: `${project.name}-FolderB`,
+						}),
+						await createFolder(project, {
+							name: `${project.name}-FolderA.1`,
+							parentFolder: parent,
+						}),
+					];
+				}),
+			);
+
+			globalAdminScope = {
+				credentials: [],
+				workflows: globalAdminWorkflows,
+				folders: [],
+			};
+
+			globalOwnerScope = {
+				credentials: [],
+				workflows: globalOwnerWorkflows,
+				folders: [],
+			};
+
+			globalMemberScope = {
+				credentials: [],
+				workflows: globalMemberWorkflows,
+				folders: [],
+			};
+
+			projectAdminScope = {
+				credentials: [],
+				workflows: projectAdminWorkflows,
+				folders: [],
+			};
+
+			projectAScope = {
+				credentials: projectACredentials,
+				folders: projectAFolders,
+				workflows: projectAWorkflows,
+			};
+
+			projectBScope = {
+				credentials: projectBCredentials,
+				folders: projectBFolders,
+				workflows: projectBWorkflows,
+			};
+
+			service = Container.get(SourceControlService);
+
+			// Skip actual git operations
+			service.sanityCheck = async () => {};
+			service.resetWorkfolder = async () => undefined;
+
+			// Git mocking
+			gitFiles = {
+				'workflows/deletedOutOfScope.json': toExportableWorkflow(
+					deletedOutOfScopeWorkflow,
+					projectB,
+				),
+				'workflows/deletedInScope.json': toExportableWorkflow(deletedInScopeWorkflow, projectA),
+				'workflows/globalAdminWFA.json': toExportableWorkflow(globalAdminWorkflows[0], globalAdmin),
+				'workflows/globalOwnerWFA.json': toExportableWorkflow(globalOwnerWorkflows[0], globalOwner),
+				'workflows/globalMemberWFA.json': toExportableWorkflow(
+					globalMemberWorkflows[0],
+					globalMember,
+				),
+				'workflows/projectAdminWFA.json': toExportableWorkflow(
+					projectAdminWorkflows[0],
+					projectAdmin,
+				),
+				'workflows/projectAWFA.json': toExportableWorkflow(projectAWorkflows[0], projectA),
+				'workflows/projectBWFA.json': toExportableWorkflow(projectBWorkflows[0], projectB),
+				'workflows/outofscope.json': toExportableWorkflow(
+					movedOutOfScopeWorkflow,
+					projectA,
+					'otherID',
+				),
+				'workflows/intoscope.json': toExportableWorkflow(
+					movedIntoScopeWorkflow,
+					projectB,
+					'otherID',
+				),
+				'credential_stubs/AcredA.json': toExportableCredential(projectACredentials[0], projectA),
+				'credential_stubs/BcredA.json': toExportableCredential(projectBCredentials[0], projectB),
+				'credential_stubs/movedOutOfScopeCred.json': toExportableCredential(
+					movedOutOfScopeCredential,
+					projectB,
+				),
+				'credential_stubs/movedIntoScopeCred.json': toExportableCredential(
+					movedIntoScopeCredential,
+					projectA,
+				),
+				'credential_stubs/deletedOutOfScopeCred.json': toExportableCredential(
+					deletedOutOfScopeCredential,
+					projectB,
+				),
+				'credential_stubs/deletedIntoScopeCred.json': toExportableCredential(
+					deletedInScopeCredential,
+					projectA,
+				),
+				'folders.json': {
+					folders: [toExportableFolder(projectAFolders[0]), toExportableFolder(projectBFolders[0])],
+				},
+				'tags.json': {
+					tags: tags.map((t) => {
+						return {
+							id: t.id,
+							name: t.name,
+						};
+					}),
+					mappings: [
+						...globalAdminWorkflows.map((m) => {
+							return {
+								workflowId: m.id,
+								tagId: tags[0].id,
+							};
+						}),
+					],
+				},
+			};
+
+			globMock.mockImplementation(async (path, opts) => {
+				if (opts.cwd?.endsWith(SOURCE_CONTROL_WORKFLOW_EXPORT_FOLDER)) {
+					// asking for workflows
+					return Object.keys(gitFiles).filter((file) =>
+						file.startsWith(SOURCE_CONTROL_WORKFLOW_EXPORT_FOLDER),
+					);
+				} else if (opts.cwd?.endsWith(SOURCE_CONTROL_CREDENTIAL_EXPORT_FOLDER)) {
+					// asking for credentials
+					return Object.keys(gitFiles).filter((file) =>
+						file.startsWith(SOURCE_CONTROL_CREDENTIAL_EXPORT_FOLDER),
+					);
+				} else if (path === SOURCE_CONTROL_FOLDERS_EXPORT_FILE) {
+					// asking for folders
+					return ['folders.json'];
+				} else if (path === SOURCE_CONTROL_TAGS_EXPORT_FILE) {
+					// asking for folders
+					return ['tags.json'];
+				}
+
+				return [];
+			});
+
+			fsReadFile.mockImplementation(async (path: string) => {
+				return JSON.stringify(gitFiles[path]);
+			});
+		});
+
+		describe('direction: push', () => {
+			describe('global:admin user', () => {
+				it('should see all workflows', async () => {
+					let result = await service.getStatus(globalAdmin, {
+						direction: 'push',
+						preferLocalVersion: true,
+						verbose: false,
+					});
+
+					expect(Array.isArray(result)).toBe(true);
+
+					if (!Array.isArray(result)) {
+						throw new Error('Cannot reach this, only needed as type guard');
+					}
+
+					// not existing in get status response
+					const notExisting = result.filter((wf) => {
+						return [
+							globalAdminScope.workflows[0],
+							globalOwnerScope.workflows[0],
+							globalMemberScope.workflows[0],
+							projectAdminScope.workflows[0],
+							projectAScope.workflows[0],
+							projectBScope.workflows[0],
+						]
+							.map((wf) => wf.id)
+							.some((id) => wf.id === id);
+					});
+
+					expect(notExisting).toBeEmptyArray();
+
+					const deletedWorkflows = result.filter(
+						(r) => r.type === 'workflow' && r.status === 'deleted',
+					);
+
+					// The created workflows‚
+					expect(new Set(deletedWorkflows.map((wf) => wf.id))).toEqual(
+						new Set([deletedOutOfScopeWorkflow.id, deletedInScopeWorkflow.id]),
+					);
+
+					const newWorkflows = result.filter(
+						(r) => r.type === 'workflow' && r.status === 'created',
+					);
+
+					// The created workflows‚
+					expect(new Set(newWorkflows.map((wf) => wf.id))).toEqual(
+						new Set([
+							globalAdminScope.workflows[1].id,
+							globalOwnerScope.workflows[1].id,
+							globalMemberScope.workflows[1].id,
+							projectAdminScope.workflows[1].id,
+							projectAScope.workflows[1].id,
+							projectBScope.workflows[1].id,
+						]),
+					);
+
+					const modifiedWorkflows = result.filter(
+						(r) => r.type === 'workflow' && r.status === 'modified',
+					);
+
+					// The modified workflows‚
+					expect(new Set(modifiedWorkflows.map((wf) => wf.id))).toEqual(
+						new Set([movedOutOfScopeWorkflow.id, movedIntoScopeWorkflow.id]),
+					);
+				});
+
+				it('should see all credentials', async () => {
+					let result = await service.getStatus(globalAdmin, {
+						direction: 'push',
+						preferLocalVersion: true,
+						verbose: false,
+					});
+
+					expect(Array.isArray(result)).toBe(true);
+
+					if (!Array.isArray(result)) {
+						throw new Error('Cannot reach this, only needed as type guard');
+					}
+
+					const newCredentials = result.filter(
+						(r) => r.type === 'credential' && r.status === 'created',
+					);
+					const deletedCredentials = result.filter(
+						(r) => r.type === 'credential' && r.status === 'deleted',
+					);
+					const modifiedCredentials = result.filter(
+						(r) => r.type === 'credential' && r.status === 'modified',
+					);
+
+					expect(new Set(newCredentials.map((c) => c.id))).toEqual(
+						new Set([projectAScope.credentials[1].id, projectBScope.credentials[1].id]),
+					);
+
+					expect(new Set(deletedCredentials.map((c) => c.id))).toEqual(
+						new Set([deletedInScopeCredential.id, deletedOutOfScopeCredential.id]),
+					);
+
+					expect(modifiedCredentials).toBeEmptyArray();
+
+					// Make sure we checked all credential entries!
+					expect(result.filter((r) => r.type === 'credential')).toHaveLength(4);
+				});
+
+				it('should see all folder', async () => {
+					let result = await service.getStatus(globalAdmin, {
+						direction: 'push',
+						preferLocalVersion: true,
+						verbose: false,
+					});
+
+					expect(Array.isArray(result)).toBe(true);
+
+					if (!Array.isArray(result)) {
+						throw new Error('Cannot reach this, only needed as type guard');
+					}
+
+					const folders = result.filter((r) => r.type === 'folders');
+
+					expect(new Set(folders.map((f) => f.id))).toEqual(
+						new Set([
+							projectAScope.folders[1].id,
+							projectAScope.folders[2].id,
+							projectBScope.folders[1].id,
+							projectBScope.folders[2].id,
+						]),
+					);
+				});
+			});
+
+			describe('global:member user', () => {
+				it('should see nothing', async () => {
+					let result = await service.getStatus(globalMember, {
+						direction: 'push',
+						preferLocalVersion: true,
+						verbose: false,
+					});
+
+					expect(result).toBeEmptyArray();
+				});
+			});
+
+			describe('project:Admin user', () => {
+				it('should see only workflows in correct scope', async () => {
+					let result = await service.getStatus(projectAdmin, {
+						direction: 'push',
+						preferLocalVersion: true,
+						verbose: false,
+					});
+
+					expect(Array.isArray(result)).toBe(true);
+
+					if (!Array.isArray(result)) {
+						throw new Error('Cannot reach this, only needed as type guard');
+					}
+
+					// not existing in get status response
+					const notExisting = result.filter((wf) => {
+						return [
+							globalAdminScope.workflows[0],
+							globalOwnerScope.workflows[0],
+							globalMemberScope.workflows[0],
+							projectAdminScope.workflows[0],
+							globalAdminScope.workflows[1],
+							globalOwnerScope.workflows[1],
+							globalMemberScope.workflows[1],
+							projectAdminScope.workflows[1],
+							projectAScope.workflows[0],
+							projectBScope.workflows[0],
+						]
+							.map((wf) => wf.id)
+							.some((id) => wf.id === id);
+					});
+
+					expect(notExisting).toBeEmptyArray();
+
+					const deletedWorkflows = result.filter(
+						(r) => r.type === 'workflow' && r.status === 'deleted',
+					);
+
+					// The created workflows‚
+					expect(new Set(deletedWorkflows.map((wf) => wf.id))).toEqual(
+						new Set([deletedInScopeWorkflow.id, movedOutOfScopeWorkflow.id]),
+					);
+
+					const newWorkflows = result.filter(
+						(r) => r.type === 'workflow' && r.status === 'created',
+					);
+
+					// The created workflows‚
+					expect(new Set(newWorkflows.map((wf) => wf.id))).toEqual(
+						new Set([projectAScope.workflows[1].id, movedIntoScopeWorkflow.id]),
+					);
+
+					const modifiedWorkflows = result.filter(
+						(r) => r.type === 'workflow' && r.status === 'modified',
+					);
+
+					// No modified workflows‚
+					expect(modifiedWorkflows).toBeEmptyArray();
+				});
+
+				it('should see only credentials in correct scope', async () => {
+					let result = await service.getStatus(projectAdmin, {
+						direction: 'push',
+						preferLocalVersion: true,
+						verbose: false,
+					});
+
+					expect(Array.isArray(result)).toBe(true);
+
+					if (!Array.isArray(result)) {
+						throw new Error('Cannot reach this, only needed as type guard');
+					}
+
+					const newCredentials = result.filter(
+						(r) => r.type === 'credential' && r.status === 'created',
+					);
+					const deletedCredentials = result.filter(
+						(r) => r.type === 'credential' && r.status === 'deleted',
+					);
+					const modifiedCredentials = result.filter(
+						(r) => r.type === 'credential' && r.status === 'modified',
+					);
+
+					expect(new Set(newCredentials.map((c) => c.id))).toEqual(
+						new Set([projectAScope.credentials[1].id]),
+					);
+
+					expect(new Set(deletedCredentials.map((c) => c.id))).toEqual(
+						new Set([deletedInScopeCredential.id]),
+					);
+
+					expect(modifiedCredentials).toBeEmptyArray();
+
+					// Make sure we checked all credential entries!
+					expect(result.filter((r) => r.type === 'credential')).toHaveLength(2);
+				});
+
+				it('should see only folders in correct scope', async () => {
+					let result = await service.getStatus(projectAdmin, {
+						direction: 'push',
+						preferLocalVersion: true,
+						verbose: false,
+					});
+
+					expect(Array.isArray(result)).toBe(true);
+
+					if (!Array.isArray(result)) {
+						throw new Error('Cannot reach this, only needed as type guard');
+					}
+
+					const folders = result.filter((r) => r.type === 'folders');
+
+					expect(new Set(folders.map((f) => f.id))).toEqual(
+						new Set([projectAScope.folders[1].id, projectAScope.folders[2].id]),
+					);
+				});
+			});
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Changes the behavior of the getStatus endpoint to scope available changes in environments to only resources
project admins have access to. 

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-2822/adapt-getstatus-endpoint-to-support-scoping-to-project-admins

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
