### PR TITLE
fix(core): Load config early to fix `N8N_CONFIG_FILES`

### DIFF
--- a/packages/cli/bin/n8n
+++ b/packages/cli/bin/n8n
@@ -48,6 +48,11 @@ if (process.env.E2E_TESTS !== 'true') {
 	require('dotenv').config();
 }
 
+// Load config early to ensure `N8N_CONFIG_FILES` values are populated into `GlobalConfig`
+// _before_ typeorm entities in `@n8n/db` are loaded, as typeorm entity decorators rely on
+// `GlobalConfig.database.type` to decide on column types and timestamp syntax.
+require('../dist/config');
+
 if (process.env.NODEJS_PREFER_IPV4 === 'true') {
 	require('dns').setDefaultResultOrder('ipv4first');
 }


### PR DESCRIPTION
## Summary

The move to `@n8n/db` altered module loading order, so now the `typeorm` decorators in `packages/@n8n/db/src/entities/abstract-entity.ts` are being evaluated before `packages/cli/src/config/index.ts`. Specifically, those decorators are reading `GlobalConfig.database.type` _before_ we've loaded `database.type` from the file specified by `N8N_CONFIG_FILES`, leading those decorators to stay with the default value `sqlite` and so wrongly choose column types and timestamp syntax when the database type is not `sqlite` when set via `N8N_CONFIG_FILES`.

```
Data type "datetime" in "AnnotationTagEntity.createdAt" is not supported by "postgres" database.
```

This PR loads the config early to have all values ready in time for the `typeorm` decorators. `N8N_CONFIG_FILES` is deprecated and will be removed in v2, but it's still in use.

## Related Linear tickets, Github issues, and Community forum posts

Context: https://n8nio.slack.com/archives/C069HS026UF/p1747239330177629

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
