### PR TITLE
chore(core): Switch `import/no-cycle` to `error` level

### DIFF
--- a/packages/@n8n/eslint-config/base.js
+++ b/packages/@n8n/eslint-config/base.js
@@ -486,7 +486,6 @@ const config = (module.exports = {
 				'@typescript-eslint/restrict-template-expressions': 'off',
 				'@typescript-eslint/unbound-method': 'off',
 				'id-denylist': 'off',
-				'import/no-cycle': 'off',
 				'import/no-default-export': 'off',
 				'import/no-extraneous-dependencies': 'off',
 				'n8n-local-rules/no-uncaught-json-parse': 'off',

--- a/packages/@n8n/json-schema-to-zod/.eslintrc.js
+++ b/packages/@n8n/json-schema-to-zod/.eslintrc.js
@@ -13,7 +13,6 @@ module.exports = {
 	rules: {
 		'unicorn/filename-case': ['error', { case: 'kebabCase' }],
 		'@typescript-eslint/no-duplicate-imports': 'off',
-		'import/no-cycle': 'off',
 		'n8n-local-rules/no-plain-errors': 'off',
 
 		complexity: 'error',

--- a/packages/@n8n/json-schema-to-zod/.eslintrc.js
+++ b/packages/@n8n/json-schema-to-zod/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
 	rules: {
 		'unicorn/filename-case': ['error', { case: 'kebabCase' }],
 		'@typescript-eslint/no-duplicate-imports': 'off',
+		'import/no-cycle': 'off',
 		'n8n-local-rules/no-plain-errors': 'off',
 
 		complexity: 'error',

--- a/packages/cli/.eslintrc.js
+++ b/packages/cli/.eslintrc.js
@@ -27,7 +27,6 @@ module.exports = {
 		complexity: 'error',
 
 		// TODO: Remove this
-		'import/no-cycle': 'warn',
 		'import/extensions': 'warn',
 		'@typescript-eslint/ban-ts-comment': ['warn', { 'ts-ignore': true }],
 		'@typescript-eslint/no-explicit-any': 'warn',

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -37,6 +37,7 @@ import { userHasScopes } from '@/permissions.ee/check-access';
 import type { CredentialRequest, ListQuery } from '@/requests';
 import { CredentialsTester } from '@/services/credentials-tester.service';
 import { OwnershipService } from '@/services/ownership.service';
+// eslint-disable-next-line import/no-cycle
 import { ProjectService } from '@/services/project.service.ee';
 import { RoleService } from '@/services/role.service';
 

--- a/packages/cli/src/execution-lifecycle/execute-error-workflow.ts
+++ b/packages/cli/src/execution-lifecycle/execute-error-workflow.ts
@@ -6,6 +6,7 @@ import type { IRun, IWorkflowBase, WorkflowExecuteMode } from 'n8n-workflow';
 import type { IWorkflowErrorData } from '@/interfaces';
 import { OwnershipService } from '@/services/ownership.service';
 import { UrlService } from '@/services/url.service';
+// eslint-disable-next-line import/no-cycle
 import { WorkflowExecutionService } from '@/workflows/workflow-execution.service';
 
 /**

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -16,6 +16,7 @@ import { WorkflowStatisticsService } from '@/services/workflow-statistics.servic
 import { isWorkflowIdValid } from '@/utils';
 import { WorkflowStaticDataService } from '@/workflows/workflow-static-data.service';
 
+// eslint-disable-next-line import/no-cycle
 import { executeErrorWorkflow } from './execute-error-workflow';
 import { restoreBinaryDataId } from './restore-binary-data-id';
 import { saveExecutionProgress } from './save-execution-progress';

--- a/packages/cli/src/services/folder.service.ts
+++ b/packages/cli/src/services/folder.service.ts
@@ -12,6 +12,7 @@ import { UserError, PROJECT_ROOT } from 'n8n-workflow';
 
 import { FolderNotFoundError } from '@/errors/folder-not-found.error';
 import type { ListQuery } from '@/requests';
+// eslint-disable-next-line import/no-cycle
 import { WorkflowService } from '@/workflows/workflow.service';
 
 export interface SimpleFolderNode {

--- a/packages/cli/src/services/project.service.ee.ts
+++ b/packages/cli/src/services/project.service.ee.ts
@@ -50,12 +50,14 @@ export class ProjectService {
 	) {}
 
 	private get workflowService() {
+		// eslint-disable-next-line import/no-cycle
 		return import('@/workflows/workflow.service').then(({ WorkflowService }) =>
 			Container.get(WorkflowService),
 		);
 	}
 
 	private get credentialsService() {
+		// eslint-disable-next-line import/no-cycle
 		return import('@/credentials/credentials.service').then(({ CredentialsService }) =>
 			Container.get(CredentialsService),
 		);

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -35,6 +35,7 @@ import { ActiveExecutions } from '@/active-executions';
 import { CredentialsHelper } from '@/credentials-helper';
 import { EventService } from '@/events/event.service';
 import type { AiEventMap, AiEventPayload } from '@/events/maps/ai.event-map';
+// eslint-disable-next-line import/no-cycle
 import { getLifecycleHooksForSubExecutions } from '@/execution-lifecycle/execution-lifecycle-hooks';
 import { ExecutionDataService } from '@/executions/execution-data.service';
 import {

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -22,6 +22,7 @@ import { ActiveExecutions } from '@/active-executions';
 import config from '@/config';
 import { ExecutionNotFoundError } from '@/errors/execution-not-found-error';
 import { MaxStalledCountError } from '@/errors/max-stalled-count.error';
+// eslint-disable-next-line import/no-cycle
 import {
 	getLifecycleHooksForRegularMain,
 	getLifecycleHooksForScalingWorker,

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -32,6 +32,7 @@ import { validateEntity } from '@/generic-helpers';
 import type { ListQuery } from '@/requests';
 import { hasSharing } from '@/requests';
 import { OwnershipService } from '@/services/ownership.service';
+// eslint-disable-next-line import/no-cycle
 import { ProjectService } from '@/services/project.service.ee';
 import { RoleService } from '@/services/role.service';
 import { TagService } from '@/services/tag.service';


### PR DESCRIPTION
## Summary

We continue to add dependency cycles like very recently [here](https://github.com/n8n-io/n8n/blob/027a479172351b0af8b2e596eb4f3e9a76859437/packages/cli/src/services/folder.service.ts#L15) - switching `import/no-cycle` to `error` level in hopes this will prevent (or slow down) the growth of cycles.

```
/Users/ivov/Development/n8n/packages/cli/src/credentials/credentials.service.ts
  40:1  error  Dependency cycle detected  import/no-cycle

/Users/ivov/Development/n8n/packages/cli/src/execution-lifecycle/execute-error-workflow.ts
  9:1  error  Dependency cycle via @/workflow-execute-additional-data:27=>@/execution-lifecycle/execution-lifecycle-hooks:38  import/no-cycle

/Users/ivov/Development/n8n/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
  19:1  error  Dependency cycle via @/workflows/workflow-execution.service:9=>@/workflow-execute-additional-data:27  import/no-cycle

/Users/ivov/Development/n8n/packages/cli/src/services/folder.service.ts
  15:1  error  Dependency cycle via @/services/project.service.ee:35  import/no-cycle

/Users/ivov/Development/n8n/packages/cli/src/services/project.service.ee.ts
  53:10  error  Dependency cycle detected  import/no-cycle
  59:10  error  Dependency cycle detected  import/no-cycle

/Users/ivov/Development/n8n/packages/cli/src/workflow-execute-additional-data.ts
  38:1  error  Dependency cycle via ./execute-error-workflow:19=>@/workflows/workflow-execution.service:9  import/no-cycle

/Users/ivov/Development/n8n/packages/cli/src/workflow-runner.ts
  25:1  error  Dependency cycle via ./execute-error-workflow:19=>@/workflows/workflow-execution.service:9  import/no-cycle

/Users/ivov/Development/n8n/packages/cli/src/workflows/workflow.service.ts
  35:1  error  Dependency cycle detected  import/no-cycle

```

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
n/a

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
