### PR TITLE
fix(editor): Fix phantom items for waiting nodes (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/stores/workflows.store.test.ts
+++ b/packages/frontend/editor-ui/src/stores/workflows.store.test.ts
@@ -660,7 +660,7 @@ describe('useWorkflowsStore', () => {
 		});
 
 		it('should replace placeholder task data in waiting nodes correctly', () => {
-			const runWithExistingRunData = executionResponse;
+			const runWithExistingRunData = deepCopy(executionResponse);
 			runWithExistingRunData.data = {
 				resultData: {
 					runData: {
@@ -699,7 +699,7 @@ describe('useWorkflowsStore', () => {
 			workflowsStore.updateNodeExecutionData(successEvent);
 
 			expect(workflowsStore.workflowExecutionData).toEqual({
-				...executionResponse,
+				...runWithExistingRunData,
 				data: {
 					resultData: {
 						runData: {

--- a/packages/frontend/editor-ui/src/stores/workflows.store.test.ts
+++ b/packages/frontend/editor-ui/src/stores/workflows.store.test.ts
@@ -659,6 +659,56 @@ describe('useWorkflowsStore', () => {
 			});
 		});
 
+		it('should replace placeholder task data in waiting nodes correctly', () => {
+			const runWithExistingRunData = executionResponse;
+			runWithExistingRunData.data = {
+				resultData: {
+					runData: {
+						[successEvent.nodeName]: [
+							{
+								hints: [],
+								startTime: 1727867966633,
+								executionIndex: 2,
+								executionTime: 1,
+								source: [],
+								executionStatus: 'waiting',
+								data: {
+									main: [
+										[
+											{
+												json: {},
+												pairedItem: {
+													item: 0,
+												},
+											},
+										],
+									],
+								},
+							},
+						],
+					},
+				},
+			};
+			workflowsStore.setWorkflowExecutionData(runWithExistingRunData);
+
+			workflowsStore.nodesByName[successEvent.nodeName] = mock<INodeUi>({
+				type: 'n8n-nodes-base.manualTrigger',
+			});
+
+			// ACT
+			workflowsStore.updateNodeExecutionData(successEvent);
+
+			expect(workflowsStore.workflowExecutionData).toEqual({
+				...executionResponse,
+				data: {
+					resultData: {
+						runData: {
+							[successEvent.nodeName]: [successEvent.data],
+						},
+					},
+				},
+			});
+		});
 		it('should replace existing placeholder task data in new log view', () => {
 			settingsStore.settings = {
 				logsView: {

--- a/packages/frontend/editor-ui/src/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/stores/workflows.store.ts
@@ -1548,10 +1548,14 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 			const existingRunIndex = tasksData.findIndex(
 				(item) => item.executionIndex === data.executionIndex,
 			);
-			const index = existingRunIndex > -1 ? existingRunIndex : tasksData.length - 1;
+
+			// For waiting nodes always replace the last item as executionIndex will always be different
+			const hasWaitingItems = tasksData.some((it) => it.executionStatus === 'waiting');
+			const index =
+				existingRunIndex > -1 && !hasWaitingItems ? existingRunIndex : tasksData.length - 1;
 			const status = tasksData[index]?.executionStatus ?? 'unknown';
 
-			if ('waiting' === status || (settingsStore.isNewLogsEnabled && 'running' === status)) {
+			if (status === 'waiting' || (settingsStore.isNewLogsEnabled && 'running' === status)) {
 				tasksData.splice(index, 1, data);
 			} else {
 				tasksData.push(data);

--- a/packages/frontend/editor-ui/src/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/stores/workflows.store.ts
@@ -1555,7 +1555,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 				existingRunIndex > -1 && !hasWaitingItems ? existingRunIndex : tasksData.length - 1;
 			const status = tasksData[index]?.executionStatus ?? 'unknown';
 
-			if (status === 'waiting' || (settingsStore.isNewLogsEnabled && 'running' === status)) {
+			if ('waiting' === status || (settingsStore.isNewLogsEnabled && 'running' === status)) {
 				tasksData.splice(index, 1, data);
 			} else {
 				tasksData.push(data);


### PR DESCRIPTION
## Summary
This PR fixes an issue introduced in this commit https://github.com/n8n-io/n8n/commit/ff156930c5f1b75da59bc27b424925a5535cd908 . 
The execution index differs in waiting nodes after execution is picked back up and therefore the update to the tasks data did not find the correct item to replace and just appended the data. 
This will now always replace the last item for nodes with status waiting in their task data.
  
![image](https://github.com/user-attachments/assets/8ed11913-faf1-45fa-ba34-7e8d60a436b5)

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-941/bug-extra-runs-generated-for-form-node-in-a-loop

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
