### PR TITLE
fix(core): Make the Insights by time datetime parsing more robust

### DIFF
--- a/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
+++ b/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
@@ -41,13 +41,19 @@ const aggregatedInsightsByWorkflowParser = z
 
 const aggregatedInsightsByTimeParser = z
 	.object({
-		periodStart: z
-			.union([z.date(), z.string()])
-			.transform((value) =>
-				value instanceof Date
-					? value.toISOString()
-					: DateTime.fromSQL(value.toString(), { zone: 'utc' }).toISO(),
-			),
+		periodStart: z.union([z.date(), z.string()]).transform((value) => {
+			if (value instanceof Date) {
+				return value.toISOString();
+			}
+
+			const parsedDatetime = DateTime.fromSQL(value.toString(), { zone: 'utc' });
+			if (parsedDatetime.isValid) {
+				return parsedDatetime.toISO();
+			}
+
+			// fallback on native date parsing
+			return new Date(value).toISOString();
+		}),
 		runTime: z.union([z.number(), z.string()]).transform((value) => Number(value)),
 		succeeded: z.union([z.number(), z.string()]).transform((value) => Number(value)),
 		failed: z.union([z.number(), z.string()]).transform((value) => Number(value)),
@@ -381,7 +387,7 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 			])
 			.innerJoin('date_range', 'date_range', '1=1')
 			.where(`${this.escapeField('periodStart')} >= date_range.start_date`)
-			.addGroupBy(this.getPeriodStartExpr(periodUnit))
+			.groupBy(this.getPeriodStartExpr(periodUnit))
 			.orderBy(this.getPeriodStartExpr(periodUnit), 'ASC');
 
 		const rawRows = await rawRowsQuery.getRawMany();


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
Depending on db server setup and configuration (like this one: https://github.com/n8n-io/n8n/blob/master/packages/nodes-base/nodes/Postgres/transport/index.ts#L73), querying timestampz can return either a js date or a string from the db. 
This PR handles the different types when querying the insights by time (periodStart field) so both types are parsed the same way.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
https://linear.app/n8n/issue/PAY-2832/insights-dashboard-date-issue-on-graph-on-internal

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
