### PR TITLE
chore(benchmark): Don't enable insights in the default benchmarks

### DIFF
--- a/packages/@n8n/benchmark/scripts/n8n-setups/postgres/docker-compose.yml
+++ b/packages/@n8n/benchmark/scripts/n8n-setups/postgres/docker-compose.yml
@@ -35,6 +35,8 @@ services:
       # Task Runner config
       - N8N_RUNNERS_ENABLED=true
       - N8N_RUNNERS_MODE=internal
+      # Disable Insights
+      - N8N_DISABLED_MODULES=insights
     ports:
       - 5678:5678
     volumes:

--- a/packages/@n8n/benchmark/scripts/n8n-setups/scaling-multi-main/docker-compose.yml
+++ b/packages/@n8n/benchmark/scripts/n8n-setups/scaling-multi-main/docker-compose.yml
@@ -53,6 +53,8 @@ services:
       # Task Runner config
       - N8N_RUNNERS_ENABLED=true
       - N8N_RUNNERS_MODE=internal
+      # Disable Insights
+      - N8N_DISABLED_MODULES=insights
     command: worker
     volumes:
       - ${RUN_DIR}/n8n-worker1:/n8n
@@ -88,6 +90,8 @@ services:
       # Task Runner config
       - N8N_RUNNERS_ENABLED=true
       - N8N_RUNNERS_MODE=internal
+      # Disable Insights
+      - N8N_DISABLED_MODULES=insights
     command: worker
     volumes:
       - ${RUN_DIR}/n8n-worker2:/n8n
@@ -126,6 +130,8 @@ services:
       # Task Runner config
       - N8N_RUNNERS_ENABLED=true
       - N8N_RUNNERS_MODE=internal
+      # Disable Insights
+      - N8N_DISABLED_MODULES=insights
     volumes:
       - ${RUN_DIR}/n8n-main2:/n8n
     depends_on:
@@ -166,6 +172,8 @@ services:
       # Task Runner config
       - N8N_RUNNERS_ENABLED=true
       - N8N_RUNNERS_MODE=internal
+      # Disable Insights
+      - N8N_DISABLED_MODULES=insights
     volumes:
       - ${RUN_DIR}/n8n-main1:/n8n
     depends_on:

--- a/packages/@n8n/benchmark/scripts/n8n-setups/scaling-single-main/docker-compose.yml
+++ b/packages/@n8n/benchmark/scripts/n8n-setups/scaling-single-main/docker-compose.yml
@@ -51,6 +51,8 @@ services:
       # Task Runner config
       - N8N_RUNNERS_ENABLED=true
       - N8N_RUNNERS_MODE=internal
+      # Disable Insights
+      - N8N_DISABLED_MODULES=insights
     command: worker
     volumes:
       - ${RUN_DIR}/n8n-worker1:/n8n
@@ -84,6 +86,8 @@ services:
       # Task Runner config
       - N8N_RUNNERS_ENABLED=true
       - N8N_RUNNERS_MODE=internal
+      # Disable Insights
+      - N8N_DISABLED_MODULES=insights
     command: worker
     volumes:
       - ${RUN_DIR}/n8n-worker2:/n8n
@@ -118,6 +122,8 @@ services:
       # Task Runner config
       - N8N_RUNNERS_ENABLED=true
       - N8N_RUNNERS_MODE=internal
+      # Disable Insights
+      - N8N_DISABLED_MODULES=insights
     ports:
       - 5678:5678
     volumes:

--- a/packages/@n8n/benchmark/scripts/n8n-setups/sqlite-legacy/docker-compose.yml
+++ b/packages/@n8n/benchmark/scripts/n8n-setups/sqlite-legacy/docker-compose.yml
@@ -12,6 +12,8 @@ services:
     environment:
       - N8N_DIAGNOSTICS_ENABLED=false
       - N8N_USER_FOLDER=/n8n
+      # Disable Insights
+      - N8N_DISABLED_MODULES=insights
     ports:
       - 5678:5678
     volumes:

--- a/packages/@n8n/benchmark/scripts/n8n-setups/sqlite/docker-compose.yml
+++ b/packages/@n8n/benchmark/scripts/n8n-setups/sqlite/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       # Task Runner config
       - N8N_RUNNERS_ENABLED=true
       - N8N_RUNNERS_MODE=internal
+      # Disable Insights
+      - N8N_DISABLED_MODULES=insights
     ports:
       - 5678:5678
     volumes:


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

When we enabled insights by default we forgot to disable them in the default benchmark. So we can't compare the performance with and without insights enabled at the moment.
This PR disables insights for the default benchmark.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] ~Tests included.~ <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
