### PR TITLE
fix(core): Fix sorting of executions not working on postgres and mysql

### DIFF
--- a/packages/cli/test/integration/execution.repository.test.ts
+++ b/packages/cli/test/integration/execution.repository.test.ts
@@ -1,5 +1,6 @@
 import { ExecutionRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
+import { DateTime } from 'luxon';
 
 import { createExecution } from '@test-integration/db/executions';
 import { createWorkflow } from '@test-integration/db/workflows';
@@ -23,12 +24,30 @@ describe('UserRepository', () => {
 	});
 
 	describe('findManyByRangeQuery', () => {
-		// eslint-disable-next-line n8n-local-rules/no-skipped-tests
-		test.skip('sort by `createdAt` if `startedAt` is null', async () => {
+		test('sort by `createdAt` if `startedAt` is null', async () => {
+			const now = DateTime.utc();
 			const workflow = await createWorkflow();
-			const execution1 = await createExecution({}, workflow);
-			const execution2 = await createExecution({ startedAt: null }, workflow);
-			const execution3 = await createExecution({}, workflow);
+			const execution1 = await createExecution(
+				{
+					createdAt: now.plus({ minute: 1 }).toJSDate(),
+					startedAt: now.plus({ minute: 1 }).toJSDate(),
+				},
+				workflow,
+			);
+			const execution2 = await createExecution(
+				{
+					createdAt: now.plus({ minute: 2 }).toJSDate(),
+					startedAt: null,
+				},
+				workflow,
+			);
+			const execution3 = await createExecution(
+				{
+					createdAt: now.plus({ minute: 3 }).toJSDate(),
+					startedAt: now.plus({ minute: 3 }).toJSDate(),
+				},
+				workflow,
+			);
 
 			const executions = await executionRepository.findManyByRangeQuery({
 				workflowId: workflow.id,

--- a/packages/cli/test/integration/shared/db/executions.ts
+++ b/packages/cli/test/integration/shared/db/executions.ts
@@ -32,13 +32,23 @@ export async function createExecution(
 	>,
 	workflow: IWorkflowBase,
 ) {
-	const { data, finished, mode, startedAt, stoppedAt, waitTill, status, deletedAt, metadata } =
-		attributes;
+	const {
+		data,
+		finished,
+		mode,
+		startedAt,
+		stoppedAt,
+		waitTill,
+		status,
+		deletedAt,
+		metadata,
+		createdAt,
+	} = attributes;
 
 	const execution = await Container.get(ExecutionRepository).save({
 		finished: finished ?? true,
 		mode: mode ?? 'manual',
-		createdAt: new Date(),
+		createdAt: createdAt ?? new Date(),
 		startedAt: startedAt === undefined ? new Date() : startedAt,
 		...(workflow !== undefined && { workflowId: workflow.id }),
 		stoppedAt: stoppedAt ?? new Date(),


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

The sort oder is not guaranteed when joining tables. In this particular case the sort order was ignored by postgres and mysql. They returned the executions in order they where created after joining. 

This probably broke with the introduction of execution curation for evaluations.
This went unnoticed because the FE probably sorts the incoming data again in the executions list.

This PR fixes this by adding the same `ORDER BY` that is used in the sub query to the final query after the joins.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
