### PR TITLE
fix(core): Allow strings starting with numbers in alphanumeric string validator

### DIFF
--- a/packages/workflow/src/TypeValidation.ts
+++ b/packages/workflow/src/TypeValidation.ts
@@ -35,7 +35,7 @@ export const tryToParseString = (value: unknown): string => {
 };
 export const tryToParseAlphanumericString = (value: unknown): string => {
 	const parsed = tryToParseString(value);
-	const regex = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+	const regex = /^[a-zA-Z0-9_]+$/;
 	if (!regex.test(parsed)) {
 		throw new ApplicationError('Value is not a valid alphanumeric string', { extra: { value } });
 	}

--- a/packages/workflow/src/TypeValidation.ts
+++ b/packages/workflow/src/TypeValidation.ts
@@ -35,7 +35,9 @@ export const tryToParseString = (value: unknown): string => {
 };
 export const tryToParseAlphanumericString = (value: unknown): string => {
 	const parsed = tryToParseString(value);
-	const regex = /^[a-zA-Z0-9_]+$/;
+	// We do not allow special characters, only letters, numbers and underscore
+	// Numbers not allowed as the first character
+	const regex = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 	if (!regex.test(parsed)) {
 		throw new ApplicationError('Value is not a valid alphanumeric string', { extra: { value } });
 	}

--- a/packages/workflow/test/TypeValidation.test.ts
+++ b/packages/workflow/test/TypeValidation.test.ts
@@ -3,6 +3,36 @@ import { DateTime, Settings } from 'luxon';
 import { getValueDescription, tryToParseDateTime, validateFieldType } from '@/TypeValidation';
 
 describe('Type Validation', () => {
+	describe('tryToParseAlphanumericString', () => {
+		it('should validate and parse alphanumeric strings', () => {
+			const VALID_STRINGS = ['abc123', 'ABC123', 'abc_123', '_abc123', '123abc', 'abcABC123_'];
+
+			VALID_STRINGS.forEach((value) => {
+				expect(validateFieldType('test', value, 'string-alphanumeric')).toEqual({
+					valid: true,
+					newValue: value,
+				});
+			});
+
+			const INVALID_STRINGS = [
+				'abc-123',
+				'abc 123',
+				'abc@123',
+				'abc#123',
+				'abc.123',
+				'abc$123',
+				'abc&123',
+				'abc!123',
+				'abc(123)',
+				'bπc123',
+				'πι',
+			];
+
+			INVALID_STRINGS.forEach((value) => {
+				expect(validateFieldType('test', value, 'string-alphanumeric').valid).toBe(false);
+			});
+		});
+	});
 	describe('Dates', () => {
 		test('should validate and cast ISO dates', () => {
 			const VALID_ISO_DATES = [

--- a/packages/workflow/test/TypeValidation.test.ts
+++ b/packages/workflow/test/TypeValidation.test.ts
@@ -3,17 +3,18 @@ import { DateTime, Settings } from 'luxon';
 import { getValueDescription, tryToParseDateTime, validateFieldType } from '@/TypeValidation';
 
 describe('Type Validation', () => {
-	describe('tryToParseAlphanumericString', () => {
-		it('should validate and parse alphanumeric strings', () => {
-			const VALID_STRINGS = ['abc123', 'ABC123', 'abc_123', '_abc123', '123abc', 'abcABC123_'];
-
-			VALID_STRINGS.forEach((value) => {
-				expect(validateFieldType('test', value, 'string-alphanumeric')).toEqual({
+	describe('string-alphanumeric', () => {
+		test('should validate and parse alphanumeric strings, not starting with a number', () => {
+			const VALID_STRINGS = ['abc123', 'ABC123', 'abc_123', '_abc123', 'abcABC123_'];
+			VALID_STRINGS.forEach((value) =>
+				expect(validateFieldType('string', value, 'string-alphanumeric')).toEqual({
 					valid: true,
 					newValue: value,
-				});
-			});
+				}),
+			);
+		});
 
+		test('should not validate non-alphanumeric strings, or starting with a number', () => {
 			const INVALID_STRINGS = [
 				'abc-123',
 				'abc 123',
@@ -26,11 +27,12 @@ describe('Type Validation', () => {
 				'abc(123)',
 				'bπc123',
 				'πι',
+				'123abc', // Cannot start with number
+				'456_abc', // Cannot start with number
 			];
-
-			INVALID_STRINGS.forEach((value) => {
-				expect(validateFieldType('test', value, 'string-alphanumeric').valid).toBe(false);
-			});
+			INVALID_STRINGS.forEach((value) =>
+				expect(validateFieldType('string', value, 'string-alphanumeric').valid).toBe(false),
+			);
 		});
 	});
 	describe('Dates', () => {


### PR DESCRIPTION
## Summary

Changed `tryToParseAlphanumericString` to accept numbers as the first character. 
Added tests for the parser.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-825/community-issue-execute-workflow-as-tool-does-not-allow-number

Closes #14295

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
