### PR TITLE
fix(RabbitMQ Node): Support routing key per item instead of using the first item's

### DIFF
--- a/packages/nodes-base/nodes/RabbitMQ/RabbitMQ.node.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/RabbitMQ.node.ts
@@ -466,7 +466,6 @@ export class RabbitMQ implements INodeType {
 				await channel.connection.close();
 			} else if (mode === 'exchange') {
 				const exchange = this.getNodeParameter('exchange', 0) as string;
-				const routingKey = this.getNodeParameter('routingKey', 0) as string;
 
 				const options = this.getNodeParameter('options', 0, {}) as Options;
 
@@ -478,6 +477,8 @@ export class RabbitMQ implements INodeType {
 
 				const exchangePromises = [];
 				for (let i = 0; i < items.length; i++) {
+					const routingKey = this.getNodeParameter('routingKey', i) as string;
+
 					if (sendInputData) {
 						message = JSON.stringify(items[i].json);
 					} else {

--- a/packages/nodes-base/nodes/RabbitMQ/test/RabbitMQ.node.test.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/test/RabbitMQ.node.test.ts
@@ -1,0 +1,68 @@
+import type { Channel } from 'amqplib';
+import { mock } from 'jest-mock-extended';
+import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+
+import * as GenericFunctions from '../GenericFunctions';
+import { RabbitMQ } from '../RabbitMQ.node';
+
+describe('RabbitMQ Node', () => {
+	const mockChannel = mock<Channel>({
+		publish: jest.fn().mockReturnValue(true),
+		close: jest.fn(),
+		connection: mock({ close: jest.fn() }),
+	});
+	const context = mock<IExecuteFunctions>();
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should use per-item routingKey when publishing to exchange', async () => {
+		const items: INodeExecutionData[] = [
+			{ json: { message: 'msg1' } },
+			{ json: { message: 'msg2' } },
+		];
+
+		// Mock getInputData() to return multiple items
+		context.getInputData.mockReturnValue(items);
+
+		// Mock parameters per item
+		context.getNodeParameter.mockImplementation((paramName, itemIndex) => {
+			const params: Record<string, string | boolean | object> = {
+				mode: 'exchange',
+				operation: 'sendMessage',
+				exchange: 'test-exchange',
+				exchangeType: 'topic',
+				routingKey: ['key.1', 'key.2'][itemIndex],
+				sendInputData: true,
+				options: {},
+			};
+			return params[paramName];
+		});
+
+		// Override the actual exchange connection to return the mock channel
+		const node = new RabbitMQ();
+
+		jest
+			.spyOn(GenericFunctions, 'rabbitmqConnectExchange')
+			.mockImplementation(async () => mockChannel);
+
+		// Run node
+		await node.execute.call(context);
+
+		// Assert publish was called with correct routing keys
+		expect(mockChannel.publish).toHaveBeenCalledTimes(2);
+		expect(mockChannel.publish).toHaveBeenCalledWith(
+			'test-exchange',
+			'key.1',
+			expect.any(Buffer),
+			expect.any(Object),
+		);
+		expect(mockChannel.publish).toHaveBeenCalledWith(
+			'test-exchange',
+			'key.2',
+			expect.any(Buffer),
+			expect.any(Object),
+		);
+	});
+});


### PR DESCRIPTION
## Summary

When using routing key in rabbitmq node, it uses the first item's routing key for all items, but sometimes you need to set routing key per item, eg:  `events.{{$json.domain}}.{{$json.model}}.{{$json.item_type}}`

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
