### PR TITLE
fix(core): Load insights module on webhook instance to save insights on webhook workflows

### DIFF
--- a/packages/cli/src/modules/insights/__tests__/insights.pre-init.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.pre-init.test.ts
@@ -1,22 +1,25 @@
 import { mock } from 'jest-mock-extended';
-import type { InstanceSettings } from 'n8n-core';
+import type { InstanceSettings, InstanceType } from 'n8n-core';
 
 import type { ModulePreInitContext } from '@/modules/modules.config';
 
 import { shouldLoadModule } from '../insights.pre-init';
 
 describe('InsightsModulePreInit', () => {
-	it('should return false if instance type is not "main"', () => {
+	it('should return false if instance type is worker', () => {
 		const ctx: ModulePreInitContext = {
 			instance: mock<InstanceSettings>({ instanceType: 'worker' }),
 		};
 		expect(shouldLoadModule(ctx)).toBe(false);
 	});
 
-	it('should return true if instance type is "main"', () => {
-		const ctx: ModulePreInitContext = {
-			instance: mock<InstanceSettings>({ instanceType: 'main' }),
-		};
-		expect(shouldLoadModule(ctx)).toBe(true);
-	});
+	it.each<InstanceType>(['main', 'webhook'])(
+		'should return true if instance type is "%s"',
+		(instanceType) => {
+			const ctx: ModulePreInitContext = {
+				instance: mock<InstanceSettings>({ instanceType }),
+			};
+			expect(shouldLoadModule(ctx)).toBe(true);
+		},
+	);
 });

--- a/packages/cli/src/modules/insights/insights.pre-init.ts
+++ b/packages/cli/src/modules/insights/insights.pre-init.ts
@@ -1,6 +1,6 @@
 import type { ModulePreInitContext } from '../modules.config';
 
 export const shouldLoadModule = (ctx: ModulePreInitContext) =>
-	// Only main instance(s) should collect insights
-	// Because main instances are informed of all finished workflow executions, whatever the mode
-	ctx.instance.instanceType === 'main';
+	// Only main and webhook instance(s) should collect insights
+	// Because main and webhooks instances are the ones informed of all finished workflow executions, whatever the mode
+	ctx.instance.instanceType === 'main' || ctx.instance.instanceType === 'webhook';


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Currently, only main instances load the insights module and listen to `workflowExecuteAfter` hook. 
The problem is, when using webhook servers, those webhook instances listen to webhooks, enqueue the job, asynchronously waits for it to finish and run the `workflowExecuteAfter` hook. The main instance never run the hooks, and thus the insights module never catches the workflow execution to save the insights data.

So in the current state of how the webhook instance work, we need to load the insights module on webhook instances for webhook triggered workflow to save insights.

I tested this with webhook triggered workflow, as well as workflow with a wait node that resumes on webhook call (although in that case, wait resuming is fired by the main instance, which then catches the job success, so it was already working before this PR).

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2833/investigate-why-musixmatch-are-not-seeing-any-insights-in-the-bd

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
