### PR TITLE
fix(Chat Trigger Node): Don't continue when action is load previous session and option is not set

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
@@ -563,7 +563,7 @@ ${cssVariables}
 				return {
 					webhookResponse: { data: messages },
 				};
-			} else if (options?.loadPreviousSession === 'notSupported') {
+			} else if (!options?.loadPreviousSession || options?.loadPreviousSession === 'notSupported') {
 				// If messages of a previous session should not be loaded, simply return an empty array
 				return {
 					webhookResponse: { data: [] },

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/ChatTrigger.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/ChatTrigger.node.test.ts
@@ -1,0 +1,133 @@
+import { jest } from '@jest/globals';
+import type { Request, Response } from 'express';
+import { mock } from 'jest-mock-extended';
+import type { IWebhookFunctions } from 'n8n-workflow';
+
+import { ChatTrigger } from '../ChatTrigger.node';
+import type { LoadPreviousSessionChatOption } from '../types';
+
+jest.mock('../GenericFunctions', () => ({
+	validateAuth: jest.fn(),
+}));
+
+describe('ChatTrigger Node', () => {
+	const mockContext = mock<IWebhookFunctions>();
+	const mockRequest = mock<Request>();
+	const mockResponse = mock<Response>();
+	let chatTrigger: ChatTrigger;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		chatTrigger = new ChatTrigger();
+
+		mockContext.getRequestObject.mockReturnValue(mockRequest);
+		mockContext.getResponseObject.mockReturnValue(mockResponse);
+		mockContext.getNodeParameter.mockImplementation(
+			(
+				paramName: string,
+				defaultValue?: boolean | string | object,
+			): boolean | string | object | undefined => {
+				if (paramName === 'public') return true;
+				if (paramName === 'mode') return 'hostedChat';
+				if (paramName === 'options') return {};
+				return defaultValue;
+			},
+		);
+		mockContext.getBodyData.mockReturnValue({});
+	});
+
+	describe('webhook method: loadPreviousSession action', () => {
+		beforeEach(() => {
+			mockContext.getBodyData.mockReturnValue({ action: 'loadPreviousSession' });
+		});
+
+		it('should return empty array when loadPreviousSession is undefined', async () => {
+			// Mock options with undefined loadPreviousSession
+			mockContext.getNodeParameter.mockImplementation(
+				(
+					paramName: string,
+					defaultValue?: boolean | string | object,
+				): boolean | string | object | undefined => {
+					if (paramName === 'public') return true;
+					if (paramName === 'mode') return 'hostedChat';
+					if (paramName === 'options') return { loadPreviousSession: undefined };
+					return defaultValue;
+				},
+			);
+
+			// Call the webhook method
+			const result = await chatTrigger.webhook(mockContext);
+
+			// Verify the returned result contains empty data array
+			expect(result).toEqual({
+				webhookResponse: { data: [] },
+			});
+		});
+
+		it('should return empty array when loadPreviousSession is "notSupported"', async () => {
+			// Mock options with notSupported loadPreviousSession
+			mockContext.getNodeParameter.mockImplementation(
+				(
+					paramName: string,
+					defaultValue?: boolean | string | object,
+				): boolean | string | object | undefined => {
+					if (paramName === 'public') return true;
+					if (paramName === 'mode') return 'hostedChat';
+					if (paramName === 'options') return { loadPreviousSession: 'notSupported' };
+					return defaultValue;
+				},
+			);
+
+			// Call the webhook method
+			const result = await chatTrigger.webhook(mockContext);
+
+			// Verify the returned result contains empty data array
+			expect(result).toEqual({
+				webhookResponse: { data: [] },
+			});
+		});
+
+		it('should handle loadPreviousSession="memory" correctly', async () => {
+			// Mock chat history data
+			const mockMessages = [
+				{ toJSON: () => ({ content: 'Message 1' }) },
+				{ toJSON: () => ({ content: 'Message 2' }) },
+			];
+
+			// Mock memory with chat history
+			const mockMemory = {
+				chatHistory: {
+					getMessages: jest.fn().mockReturnValueOnce(mockMessages),
+				},
+			};
+
+			// Mock options with memory loadPreviousSession
+			mockContext.getNodeParameter.mockImplementation(
+				(
+					paramName: string,
+					defaultValue?: boolean | string | object,
+				): boolean | string | object | undefined => {
+					if (paramName === 'public') return true;
+					if (paramName === 'mode') return 'hostedChat';
+					if (paramName === 'options')
+						return { loadPreviousSession: 'memory' as LoadPreviousSessionChatOption };
+					return defaultValue;
+				},
+			);
+
+			// Mock getInputConnectionData to return memory
+			mockContext.getInputConnectionData.mockResolvedValue(mockMemory);
+
+			// Call the webhook method
+			const result = await chatTrigger.webhook(mockContext);
+
+			// Verify the returned result contains messages from memory
+			expect(result).toEqual({
+				webhookResponse: {
+					data: [{ content: 'Message 1' }, { content: 'Message 2' }],
+				},
+			});
+		});
+	});
+});


### PR DESCRIPTION
## Summary

This PR makes sure that whenever there is no value set for `loadPreviousSession`, it works similarly to the `notSupported` option.

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/issues/12791
https://linear.app/n8n/issue/AI-619/community-issue-issue-with-when-chat-message-received-node

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
