### PR TITLE
fix(editor): Fix paired items after renaming a node

### DIFF
--- a/packages/frontend/editor-ui/src/stores/workflows.store.test.ts
+++ b/packages/frontend/editor-ui/src/stores/workflows.store.test.ts
@@ -990,6 +990,90 @@ describe('useWorkflowsStore', () => {
 			);
 		});
 	});
+
+	describe('renameNodeSelectedAndExecution', () => {
+		it('should rename node and update execution data', () => {
+			const nodeName = 'Rename me';
+			const newName = 'Renamed';
+
+			workflowsStore.workflowExecutionData = {
+				data: {
+					resultData: {
+						runData: {
+							"When clicking 'Test workflow'": [
+								{
+									startTime: 1747389900668,
+									executionIndex: 0,
+									source: [],
+									hints: [],
+									executionTime: 1,
+									executionStatus: 'success',
+									data: {},
+								},
+							],
+							[nodeName]: [
+								{
+									startTime: 1747389900670,
+									executionIndex: 2,
+									source: [
+										{
+											previousNode: "When clicking 'Test workflow'",
+										},
+									],
+									hints: [],
+									executionTime: 1,
+									executionStatus: 'success',
+									data: {},
+								},
+							],
+							'Edit Fields': [
+								{
+									startTime: 1747389900671,
+									executionIndex: 3,
+									source: [
+										{
+											previousNode: nodeName,
+										},
+									],
+									hints: [],
+									executionTime: 3,
+									executionStatus: 'success',
+									data: {},
+								},
+							],
+						},
+						pinData: {},
+						lastNodeExecuted: 'Edit Fields',
+					},
+				},
+			} as unknown as IExecutionResponse;
+
+			workflowsStore.addNode({
+				parameters: {},
+				id: '554c7ff4-7ee2-407c-8931-e34234c5056a',
+				name: nodeName,
+				type: 'n8n-nodes-base.set',
+				position: [680, 180],
+				typeVersion: 3.4,
+			});
+
+			workflowsStore.renameNodeSelectedAndExecution({ old: nodeName, new: newName });
+
+			expect(workflowsStore.nodeMetadata[nodeName]).not.toBeDefined();
+			expect(workflowsStore.nodeMetadata[newName]).toEqual({});
+			expect(
+				workflowsStore.workflowExecutionData.data.resultData.runData[nodeName],
+			).not.toBeDefined();
+			expect(workflowsStore.workflowExecutionData.data.resultData.runData[newName]).toBeDefined();
+			expect(
+				workflowsStore.workflowExecutionData.data.resultData.runData['Edit Fields'][0].source,
+			).toEqual([
+				{
+					previousNode: newName,
+				},
+			]);
+		});
+	});
 });
 
 function getMockEditFieldsNode() {

--- a/packages/frontend/editor-ui/src/stores/workflows.store.test.ts
+++ b/packages/frontend/editor-ui/src/stores/workflows.store.test.ts
@@ -1062,11 +1062,11 @@ describe('useWorkflowsStore', () => {
 			expect(workflowsStore.nodeMetadata[nodeName]).not.toBeDefined();
 			expect(workflowsStore.nodeMetadata[newName]).toEqual({});
 			expect(
-				workflowsStore.workflowExecutionData.data.resultData.runData[nodeName],
+				workflowsStore.workflowExecutionData?.data?.resultData.runData[nodeName],
 			).not.toBeDefined();
-			expect(workflowsStore.workflowExecutionData.data.resultData.runData[newName]).toBeDefined();
+			expect(workflowsStore.workflowExecutionData?.data?.resultData.runData[newName]).toBeDefined();
 			expect(
-				workflowsStore.workflowExecutionData.data.resultData.runData['Edit Fields'][0].source,
+				workflowsStore.workflowExecutionData?.data?.resultData.runData['Edit Fields'][0].source,
 			).toEqual([
 				{
 					previousNode: newName,

--- a/packages/frontend/editor-ui/src/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/stores/workflows.store.ts
@@ -1190,10 +1190,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 
 		// If node has any WorkflowResultData rename also that one that the data
 		// does still get displayed also after node got renamed
-		if (
-			workflowExecutionData.value?.data &&
-			workflowExecutionData.value.data.resultData.runData.hasOwnProperty(nameData.old)
-		) {
+		if (workflowExecutionData.value?.data?.resultData.runData[nameData.old]) {
 			workflowExecutionData.value.data.resultData.runData[nameData.new] =
 				workflowExecutionData.value.data.resultData.runData[nameData.old];
 			delete workflowExecutionData.value.data.resultData.runData[nameData.old];

--- a/packages/frontend/editor-ui/src/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/stores/workflows.store.ts
@@ -1219,8 +1219,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		}
 
 		Object.values(workflowExecutionData.value?.data?.resultData.runData ?? {})
-			.map((taskData) => taskData.map((task) => task.source).flat())
-			.flat()
+			.flatMap((taskData) => taskData.map((task) => task.source).flat())
 			.forEach((source) => {
 				if (!source || source.previousNode !== nameData.old) return;
 				source.previousNode = nameData.new;

--- a/packages/frontend/editor-ui/src/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/stores/workflows.store.ts
@@ -1221,9 +1221,8 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		Object.values(workflowExecutionData.value?.data?.resultData.runData ?? {})
 			.map((taskData) => taskData.map((task) => task.source).flat())
 			.flat()
-			.filter((source) => source?.previousNode === nameData.old)
 			.forEach((source) => {
-				if (!source) return;
+				if (!source || source.previousNode !== nameData.old) return;
 				source.previousNode = nameData.new;
 			});
 	}

--- a/packages/frontend/editor-ui/src/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/stores/workflows.store.ts
@@ -1217,6 +1217,15 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 				},
 			};
 		}
+
+		Object.values(workflowExecutionData.value?.data?.resultData.runData ?? {})
+			.map((taskData) => taskData.map((task) => task.source).flat())
+			.flat()
+			.filter((source) => source?.previousNode === nameData.old)
+			.forEach((source) => {
+				if (!source) return;
+				source.previousNode = nameData.new;
+			});
 	}
 
 	function setParentFolder(folder: IWorkflowDb['parentFolder']) {


### PR DESCRIPTION
## Summary

Renaming nodes breaks paired item

## Related Linear tickets, Github issues, and Community forum posts

PAY-2829

## Review / Merge checklist

- [ ] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport`
