### PR TITLE
fix(Execute Sub-workflow Node): Multiple outpust handling

### DIFF
--- a/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow/ExecuteWorkflow.node.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow/ExecuteWorkflow.node.ts
@@ -318,7 +318,7 @@ export class ExecuteWorkflow implements INodeType {
 								},
 							},
 						);
-						const workflowResult = executionResult.data as INodeExecutionData[][];
+						const workflowResult = (executionResult.data as INodeExecutionData[][]) ?? [];
 
 						for (const [outputIndex, outputData] of workflowResult.entries()) {
 							for (const item of outputData) {
@@ -367,11 +367,11 @@ export class ExecuteWorkflow implements INodeType {
 					}
 				} catch (error) {
 					if (this.continueOnFail()) {
-						if (returnData[i] === undefined) {
-							returnData[i] = [];
+						if (returnData[0] === undefined) {
+							returnData[0] = [];
 						}
 						const metadata = parseErrorMetadata(error);
-						returnData[i].push({
+						returnData[0].push({
 							json: { error: error.message },
 							pairedItem: { item: i },
 							metadata,
@@ -425,7 +425,7 @@ export class ExecuteWorkflow implements INodeType {
 					return [items];
 				}
 
-				const workflowResult = executionResult.data as INodeExecutionData[][];
+				const workflowResult = (executionResult.data as INodeExecutionData[][]) ?? [];
 
 				const fallbackPairedItemData = generatePairedItemData(items.length);
 

--- a/packages/nodes-base/nodes/Set/v2/manual.mode.ts
+++ b/packages/nodes-base/nodes/Set/v2/manual.mode.ts
@@ -251,7 +251,7 @@ export async function execute(
 		return composeReturnItem.call(this, i, item, newData, options, node.typeVersion);
 	} catch (error) {
 		if (this.continueOnFail()) {
-			return { json: { error: (error as Error).message, pairedItem: { item: i } } };
+			return { json: { error: (error as Error).message }, pairedItem: { item: i } };
 		}
 		throw new NodeOperationError(this.getNode(), error as Error, {
 			itemIndex: i,


### PR DESCRIPTION
## Summary

...

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3588/community-issue-subworkflow-execution-wrongfully-ending-in-error
closes https://github.com/n8n-io/n8n/issues/14597

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
