### PR TITLE
feat(MCP Client Tool Node): Add support for HTTP Streamable Transport

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
@@ -11,7 +11,7 @@ import { logWrapper } from '@utils/logWrapper';
 import { getConnectionHintNoticeField } from '@utils/sharedFields';
 
 import { getTools } from './loadOptions';
-import type { McpAuthenticationOption, McpToolIncludeMode } from './types';
+import type { McpServerTransport, McpAuthenticationOption, McpToolIncludeMode } from './types';
 import {
 	connectMcpClient,
 	createCallTool,
@@ -76,13 +76,30 @@ export class McpClientTool implements INodeType {
 		properties: [
 			getConnectionHintNoticeField([NodeConnectionTypes.AiAgent]),
 			{
-				displayName: 'SSE Endpoint',
-				name: 'sseEndpoint',
+				displayName: 'Endpoint',
+				name: 'endpointUrl',
 				type: 'string',
-				description: 'SSE Endpoint of your MCP server',
-				placeholder: 'e.g. https://my-mcp-server.ai/sse',
+				description: 'Endpoint of your MCP server',
+				placeholder: 'e.g. https://my-mcp-server.ai/mcp',
 				default: '',
 				required: true,
+			},
+			{
+				displayName: 'Server Transport',
+				name: 'serverTransport',
+				type: 'options',
+				options: [
+					{
+						name: 'Server Sent Events (deprecated)',
+						value: 'sse',
+					},
+					{
+						name: 'HTTP Streamable',
+						value: 'httpStreamable',
+					},
+				],
+				default: 'sse',
+				description: 'The transport used by your endpoint',
 			},
 			{
 				displayName: 'Authentication',
@@ -103,7 +120,7 @@ export class McpClientTool implements INodeType {
 					},
 				],
 				default: 'none',
-				description: 'The way to authenticate with your SSE endpoint',
+				description: 'The way to authenticate with your endpoint',
 			},
 			{
 				displayName: 'Credentials',
@@ -187,11 +204,16 @@ export class McpClientTool implements INodeType {
 			'authentication',
 			itemIndex,
 		) as McpAuthenticationOption;
-		const sseEndpoint = this.getNodeParameter('sseEndpoint', itemIndex) as string;
+		const serverTransport = this.getNodeParameter(
+			'serverTransport',
+			itemIndex,
+		) as McpServerTransport;
+		const endpointUrl = this.getNodeParameter('endpointUrl', itemIndex) as string;
 		const node = this.getNode();
 		const { headers } = await getAuthHeaders(this, authentication);
 		const client = await connectMcpClient({
-			sseEndpoint,
+			serverTransport,
+			endpointUrl,
 			headers,
 			name: node.type,
 			version: node.typeVersion,

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
@@ -31,7 +31,7 @@ export class McpClientTool implements INodeType {
 			dark: 'file:../mcp.dark.svg',
 		},
 		group: ['output'],
-		version: 1,
+		version: [1, 1.1],
 		description: 'Connect tools from an MCP Server',
 		defaults: {
 			name: 'MCP Client',
@@ -76,6 +76,20 @@ export class McpClientTool implements INodeType {
 		properties: [
 			getConnectionHintNoticeField([NodeConnectionTypes.AiAgent]),
 			{
+				displayName: 'SSE Endpoint',
+				name: 'sseEndpoint',
+				type: 'string',
+				description: 'SSE Endpoint of your MCP server',
+				placeholder: 'e.g. https://my-mcp-server.ai/sse',
+				default: '',
+				required: true,
+				displayOptions: {
+					show: {
+						'@version': [1],
+					},
+				},
+			},
+			{
 				displayName: 'Endpoint',
 				name: 'endpointUrl',
 				type: 'string',
@@ -83,6 +97,11 @@ export class McpClientTool implements INodeType {
 				placeholder: 'e.g. https://my-mcp-server.ai/mcp',
 				default: '',
 				required: true,
+				displayOptions: {
+					show: {
+						'@version': [{ _cnd: { gte: 1.1 } }],
+					},
+				},
 			},
 			{
 				displayName: 'Server Transport',
@@ -100,6 +119,11 @@ export class McpClientTool implements INodeType {
 				],
 				default: 'sse',
 				description: 'The transport used by your endpoint',
+				displayOptions: {
+					show: {
+						'@version': [{ _cnd: { gte: 1.1 } }],
+					},
+				},
 			},
 			{
 				displayName: 'Authentication',
@@ -204,12 +228,18 @@ export class McpClientTool implements INodeType {
 			'authentication',
 			itemIndex,
 		) as McpAuthenticationOption;
-		const serverTransport = this.getNodeParameter(
-			'serverTransport',
-			itemIndex,
-		) as McpServerTransport;
-		const endpointUrl = this.getNodeParameter('endpointUrl', itemIndex) as string;
 		const node = this.getNode();
+
+		let serverTransport: McpServerTransport;
+		let endpointUrl: string;
+		if (node.typeVersion == 1) {
+			serverTransport = 'sse';
+			endpointUrl = this.getNodeParameter('sseEndpoint', itemIndex) as string;
+		} else {
+			serverTransport = this.getNodeParameter('serverTransport', itemIndex) as McpServerTransport;
+			endpointUrl = this.getNodeParameter('endpointUrl', itemIndex) as string;
+		}
+
 		const { headers } = await getAuthHeaders(this, authentication);
 		const client = await connectMcpClient({
 			serverTransport,

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
@@ -109,7 +109,7 @@ export class McpClientTool implements INodeType {
 				type: 'options',
 				options: [
 					{
-						name: 'Server Sent Events (deprecated)',
+						name: 'Server Sent Events (Deprecated)',
 						value: 'sse',
 					},
 					{
@@ -232,7 +232,7 @@ export class McpClientTool implements INodeType {
 
 		let serverTransport: McpServerTransport;
 		let endpointUrl: string;
-		if (node.typeVersion == 1) {
+		if (node.typeVersion === 1) {
 			serverTransport = 'sse';
 			endpointUrl = this.getNodeParameter('sseEndpoint', itemIndex) as string;
 		} else {

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/loadOptions.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/loadOptions.ts
@@ -4,16 +4,25 @@ import {
 	NodeOperationError,
 } from 'n8n-workflow';
 
-import type { McpAuthenticationOption } from './types';
+import type { McpAuthenticationOption, McpServerTransport } from './types';
 import { connectMcpClient, getAllTools, getAuthHeaders } from './utils';
 
 export async function getTools(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 	const authentication = this.getNodeParameter('authentication') as McpAuthenticationOption;
-	const sseEndpoint = this.getNodeParameter('sseEndpoint') as string;
 	const node = this.getNode();
+	let serverTransport: McpServerTransport;
+	let endpointUrl: string;
+	if (node.typeVersion == 1) {
+		serverTransport = 'sse';
+		endpointUrl = this.getNodeParameter('sseEndpoint') as string;
+	} else {
+		serverTransport = this.getNodeParameter('serverTransport') as McpServerTransport;
+		endpointUrl = this.getNodeParameter('endpointUrl') as string;
+	}
 	const { headers } = await getAuthHeaders(this, authentication);
 	const client = await connectMcpClient({
-		sseEndpoint,
+		serverTransport,
+		endpointUrl,
 		headers,
 		name: node.type,
 		version: node.typeVersion,

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/loadOptions.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/loadOptions.ts
@@ -12,7 +12,7 @@ export async function getTools(this: ILoadOptionsFunctions): Promise<INodeProper
 	const node = this.getNode();
 	let serverTransport: McpServerTransport;
 	let endpointUrl: string;
-	if (node.typeVersion == 1) {
+	if (node.typeVersion === 1) {
 		serverTransport = 'sse';
 		endpointUrl = this.getNodeParameter('sseEndpoint') as string;
 	} else {

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/types.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/types.ts
@@ -2,6 +2,8 @@ import type { JSONSchema7 } from 'json-schema';
 
 export type McpTool = { name: string; description?: string; inputSchema: JSONSchema7 };
 
+export type McpServerTransport = 'sse' | 'httpStreamable';
+
 export type McpToolIncludeMode = 'all' | 'selected' | 'except';
 
 export type McpAuthenticationOption = 'none' | 'headerAuth' | 'bearerAuth';

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/utils.ts
@@ -176,10 +176,8 @@ export async function connectMcpClient({
 				requestInit: { headers },
 			});
 			await client.connect(transport);
-			console.log('Connected using Streamable HTTP transport');
 		} catch (error) {
 			// If that fails with a 4xx error, try the older SSE transport
-			console.log('Streamable HTTP connection failed, falling back to SSE transport');
 			const sseTransport = new SSEClientTransport(endpoint.result, {
 				eventSourceInit: {
 					fetch: async (url, init) =>
@@ -194,7 +192,6 @@ export async function connectMcpClient({
 				requestInit: { headers },
 			});
 			await client.connect(sseTransport);
-			console.log('Connected using SSE transport');
 		}
 		return createResultOk(client);
 	} catch (error) {

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/utils.ts
@@ -180,6 +180,7 @@ export async function connectMcpClient({
 				requestInit: { headers },
 			});
 			await client.connect(transport);
+			return createResultOk(client);
 		} catch (error) {
 			return createResultError({ type: 'connection', error });
 		}

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/utils.ts
@@ -167,16 +167,6 @@ export async function connectMcpClient({
 	if (serverTransport === 'httpStreamable') {
 		try {
 			const transport = new StreamableHTTPClientTransport(endpoint.result, {
-				eventSourceInit: {
-					fetch: async (url, init) =>
-						await fetch(url, {
-							...init,
-							headers: {
-								...headers,
-								Accept: 'text/event-stream',
-							},
-						}),
-				},
 				requestInit: { headers },
 			});
 			await client.connect(transport);


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR adds support for the now recommended HTTP Streamable Transport for the MCP Protocol.

It also keeps the compatibility with the deprecated SSE transport, in order to not break existing instances.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
