### PR TITLE
fix(Execute Workflow Trigger Node): Show helpful error message when passing array to JSON Example

### DIFF
--- a/packages/nodes-base/utils/workflowInputsResourceMapping/GenericFunctions.ts
+++ b/packages/nodes-base/utils/workflowInputsResourceMapping/GenericFunctions.ts
@@ -27,6 +27,18 @@ import {
 const SUPPORTED_TYPES = TYPE_OPTIONS.map((x) => x.value);
 
 function parseJsonSchema(schema: JSONSchema7): FieldValueOption[] | string {
+	if (schema.type !== 'object') {
+		if (schema.type === undefined) {
+			return 'Invalid JSON schema. Missing key `type` in schema';
+		}
+
+		if (Array.isArray(schema.type)) {
+			return `Invalid JSON schema type. Only object type is supported, but got an array of types: ${schema.type.join(', ')}`;
+		}
+
+		return `Invalid JSON schema type. Only object type is supported, but got ${schema.type}`;
+	}
+
 	if (!schema?.properties) {
 		return 'Invalid JSON schema. Missing key `properties` in schema';
 	}


### PR DESCRIPTION
## Summary

Now a correct error message is shown when passing an array in Example mode of Execute Workflow Trigger:

![image](https://github.com/user-attachments/assets/e46ffe4f-ddb8-4721-b5bd-9c5632a4277a)


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3570/bug-bad-error-message-when-passing-array-to-workflow-trigger-in

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
