### PR TITLE
chore(core): Show error message for unsupported SAML bindings

### DIFF
--- a/packages/cli/src/sso.ee/saml/errors/invalid-saml-metadata.error.ts
+++ b/packages/cli/src/sso.ee/saml/errors/invalid-saml-metadata.error.ts
@@ -1,7 +1,7 @@
 import { UserError } from 'n8n-workflow';
 
 export class InvalidSamlMetadataError extends UserError {
-	constructor() {
-		super('Invalid SAML metadata');
+	constructor(detail: string = '') {
+		super(`Invalid SAML metadata${detail ? ': ' + detail : ''}`);
 	}
 }

--- a/packages/cli/src/sso.ee/saml/saml.service.ee.ts
+++ b/packages/cli/src/sso.ee/saml/saml.service.ee.ts
@@ -7,7 +7,7 @@ import type express from 'express';
 import https from 'https';
 import { Logger } from 'n8n-core';
 import { jsonParse, UnexpectedError } from 'n8n-workflow';
-import { Constants, type IdentityProviderInstance, type ServiceProviderInstance } from 'samlify';
+import { type IdentityProviderInstance, type ServiceProviderInstance } from 'samlify';
 import type { BindingContext, PostBindingContext } from 'samlify/types/src/entity';
 
 import { AuthError } from '@/errors/response-errors/auth.error';

--- a/packages/cli/src/sso.ee/saml/saml.service.ee.ts
+++ b/packages/cli/src/sso.ee/saml/saml.service.ee.ts
@@ -135,6 +135,11 @@ export class SamlService {
 			});
 		}
 
+		const binding = this.identityProviderInstance.entityMeta.getSingleSignOnService('redirect');
+		if (typeof binding !== 'string') {
+			throw new InvalidSamlMetadataError('only SAML redirect binding is supported.');
+		}
+
 		return this.identityProviderInstance;
 	}
 

--- a/packages/cli/src/sso.ee/saml/saml.service.ee.ts
+++ b/packages/cli/src/sso.ee/saml/saml.service.ee.ts
@@ -7,7 +7,7 @@ import type express from 'express';
 import https from 'https';
 import { Logger } from 'n8n-core';
 import { jsonParse, UnexpectedError } from 'n8n-workflow';
-import type { IdentityProviderInstance, ServiceProviderInstance } from 'samlify';
+import { Constants, type IdentityProviderInstance, type ServiceProviderInstance } from 'samlify';
 import type { BindingContext, PostBindingContext } from 'samlify/types/src/entity';
 
 import { AuthError } from '@/errors/response-errors/auth.error';
@@ -135,10 +135,7 @@ export class SamlService {
 			});
 		}
 
-		const binding = this.identityProviderInstance.entityMeta.getSingleSignOnService('redirect');
-		if (typeof binding !== 'string') {
-			throw new InvalidSamlMetadataError('only SAML redirect binding is supported.');
-		}
+		this.validator.validateIdentiyProvider(this.identityProviderInstance);
 
 		return this.identityProviderInstance;
 	}


### PR DESCRIPTION
## Summary

SAML can support different binding methods. We only support redirect binding at this moment, this shows a message to the user in case no redirect binding option is found the SAML metadata.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-2840/sso-configuration-issue-in-version-192


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
