### PR TITLE
fix(editor): Update canvas edge toolbar hit area (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/components/canvas/elements/edges/CanvasEdgeToolbar.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/elements/edges/CanvasEdgeToolbar.vue
@@ -63,7 +63,7 @@ function onDelete() {
 	align-items: center;
 	gap: var(--spacing-2xs);
 	pointer-events: all;
-	padding: var(--spacing-l);
+	padding: var(--spacing-2xs);
 }
 </style>
 


### PR DESCRIPTION
## Summary

Fixes recently introduced CanvasEdgeToolbar hit area bug

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-785/canvas-dragging-extra-output-connector-doesnt-work-if-nodes-are-too

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
