### PR TITLE
fix(editor): Hide evaluation trigger

### DIFF
--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/NodesListPanel.test.ts
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/NodesListPanel.test.ts
@@ -76,7 +76,7 @@ describe('NodesListPanel', () => {
 			await fireEvent.click(container.querySelector('.backButton')!);
 			await nextTick();
 
-			expect(screen.queryAllByTestId('item-iterator-item')).toHaveLength(9);
+			expect(screen.queryAllByTestId('item-iterator-item')).toHaveLength(8);
 		});
 
 		it('should render regular nodes', async () => {

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/viewsData.ts
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/viewsData.ts
@@ -344,6 +344,26 @@ export function AINodesView(_nodes: SimplifiedNodeType[]): NodeView {
 
 export function TriggerView() {
 	const i18n = useI18n();
+	const posthogStore = usePostHog();
+	const isEvaluationVariantEnabled = posthogStore.isVariantEnabled(
+		EVALUATION_TRIGGER.name,
+		EVALUATION_TRIGGER.variant,
+	);
+
+	const evaluationTriggerNode = isEvaluationVariantEnabled
+		? {
+				key: EVALUATION_TRIGGER_NODE_TYPE,
+				type: 'node',
+				category: [CORE_NODES_CATEGORY],
+				properties: {
+					group: [],
+					name: EVALUATION_TRIGGER_NODE_TYPE,
+					displayName: 'Evaluation Trigger',
+					description: 'Run a dataset through your workflow to test performance',
+					icon: 'fa:check-double',
+				},
+			}
+		: null;
 
 	const view: NodeView = {
 		value: TRIGGER_NODE_CREATOR_VIEW,
@@ -437,18 +457,7 @@ export function TriggerView() {
 					icon: 'fa:comments',
 				},
 			},
-			{
-				key: EVALUATION_TRIGGER_NODE_TYPE,
-				type: 'node',
-				category: [CORE_NODES_CATEGORY],
-				properties: {
-					group: [],
-					name: EVALUATION_TRIGGER_NODE_TYPE,
-					displayName: 'Evaluation Trigger',
-					description: 'Run a dataset through your workflow to test performance',
-					icon: 'fa:check-double',
-				},
-			},
+			...(evaluationTriggerNode ? [evaluationTriggerNode] : []),
 			{
 				type: 'subcategory',
 				key: OTHER_TRIGGER_NODES_SUBCATEGORY,


### PR DESCRIPTION
## Summary

Hide evaluation trigger

To enable, run pnpm dev:fe and then in console, paste:

```
localStorage.setItem('N8N_EXPERIMENT_OVERRIDES', '{"031-evaluation-trigger":"variant"}')
```

currently on master: without the feat flag, the eval trigger is seen in Nodes Creator in the TriggerView
what should happen: the eval trigger should only be seen in Nodes Creator w/ the feat flag

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2989/hide-trigger-under-feat-flag-in-trigger-list

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
