### PR TITLE
fix(n8n Evaluation Trigger Node): Fix tweaks

### DIFF
--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/viewsData.ts
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/viewsData.ts
@@ -358,7 +358,7 @@ export function TriggerView() {
 				properties: {
 					group: [],
 					name: EVALUATION_TRIGGER_NODE_TYPE,
-					displayName: 'Evaluation Trigger',
+					displayName: 'When running evaluation',
 					description: 'Run a dataset through your workflow to test performance',
 					icon: 'fa:check-double',
 				},

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/viewsData.ts
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/viewsData.ts
@@ -139,6 +139,32 @@ function getAiNodesBySubcategory(nodes: INodeTypeDescription[], subcategory: str
 		.sort((a, b) => a.properties.displayName.localeCompare(b.properties.displayName));
 }
 
+function getEvaluationNode(
+	nodeTypesStore: ReturnType<typeof useNodeTypesStore>,
+	isEvaluationVariantEnabled: boolean,
+) {
+	const evaluationNodeStore = nodeTypesStore.getNodeType('n8n-nodes-base.evaluation');
+
+	if (!isEvaluationVariantEnabled || !evaluationNodeStore) {
+		return [];
+	}
+
+	const evaluationNode = getNodeView(evaluationNodeStore);
+
+	return [
+		{
+			...evaluationNode,
+			properties: {
+				...evaluationNode.properties,
+				defaults: {
+					name: 'Evaluation',
+					color: '#c3c9d5',
+				},
+			},
+		},
+	];
+}
+
 export function AIView(_nodes: SimplifiedNodeType[]): NodeView {
 	const i18n = useI18n();
 	const nodeTypesStore = useNodeTypesStore();
@@ -150,9 +176,7 @@ export function AIView(_nodes: SimplifiedNodeType[]): NodeView {
 		EVALUATION_TRIGGER.variant,
 	);
 
-	const evaluationNodeStore = nodeTypesStore.getNodeType('n8n-nodes-base.evaluation');
-	const evaluationNode =
-		isEvaluationVariantEnabled && evaluationNodeStore ? [getNodeView(evaluationNodeStore)] : [];
+	const evaluationNode = getEvaluationNode(nodeTypesStore, isEvaluationVariantEnabled);
 
 	const chainNodes = getAiNodesBySubcategory(nodeTypesStore.allLatestNodeTypes, AI_CATEGORY_CHAINS);
 	const agentNodes = getAiNodesBySubcategory(nodeTypesStore.allLatestNodeTypes, AI_CATEGORY_AGENTS);
@@ -361,6 +385,10 @@ export function TriggerView() {
 					displayName: 'When running evaluation',
 					description: 'Run a dataset through your workflow to test performance',
 					icon: 'fa:check-double',
+					defaults: {
+						name: 'Evaluation',
+						color: '#c3c9d5',
+					},
 				},
 			}
 		: null;

--- a/packages/frontend/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/frontend/editor-ui/src/plugins/i18n/locales/en.json
@@ -1299,7 +1299,7 @@
 	"nodeCreator.triggerHelperPanel.whatHappensNext": "What happens next?",
 	"nodeCreator.triggerHelperPanel.selectATrigger": "What triggers this workflow?",
 	"nodeCreator.triggerHelperPanel.selectATriggerDescription": "A trigger is a step that starts your workflow",
-	"nodeCreator.triggerHelperPanel.workflowTriggerDisplayName": "When Executed by Another Workflow",
+	"nodeCreator.triggerHelperPanel.workflowTriggerDisplayName": "When executed by another workflow",
 	"nodeCreator.triggerHelperPanel.workflowTriggerDescription": "Runs the flow when called by the Execute Workflow node from a different workflow",
 	"nodeCreator.aiPanel.aiNodes": "AI Nodes",
 	"nodeCreator.aiPanel.aiOtherNodes": "Other AI Nodes",

--- a/packages/nodes-base/nodes/Evaluation/Evaluation/Description.node.ts
+++ b/packages/nodes-base/nodes/Evaluation/Evaluation/Description.node.ts
@@ -11,6 +11,7 @@ export const setOutputProperties: INodeProperties[] = [
 	},
 	{
 		...document,
+		displayName: 'Document Containing Dataset',
 		displayOptions: {
 			show: {
 				operation: ['setOutputs'],
@@ -19,6 +20,7 @@ export const setOutputProperties: INodeProperties[] = [
 	},
 	{
 		...sheet,
+		displayName: 'Sheet Containing Dataset',
 		displayOptions: {
 			show: {
 				operation: ['setOutputs'],

--- a/packages/nodes-base/nodes/Evaluation/Evaluation/Evaluation.node.ee.ts
+++ b/packages/nodes-base/nodes/Evaluation/Evaluation/Evaluation.node.ee.ts
@@ -32,6 +32,9 @@ export class Evaluation implements INodeType {
 		},
 		inputs: [NodeConnectionTypes.Main],
 		outputs: `={{(${setOutputs})($parameter)}}`,
+		codex: {
+			alias: ['Test', 'Metrics', 'Evals', 'Set Output', 'Set Metrics'],
+		},
 		credentials: [
 			{
 				name: 'googleApi',

--- a/packages/nodes-base/nodes/Evaluation/EvaluationTrigger/EvaluationTrigger.node.ee.ts
+++ b/packages/nodes-base/nodes/Evaluation/EvaluationTrigger/EvaluationTrigger.node.ee.ts
@@ -76,6 +76,9 @@ export class EvaluationTrigger implements INodeType {
 			},
 			readFilter,
 		],
+		codex: {
+			alias: ['Test', 'Metrics', 'Evals', 'Set Output', 'Set Metrics'],
+		},
 		credentials: [
 			{
 				name: 'googleApi',

--- a/packages/nodes-base/nodes/Evaluation/EvaluationTrigger/EvaluationTrigger.node.ee.ts
+++ b/packages/nodes-base/nodes/Evaluation/EvaluationTrigger/EvaluationTrigger.node.ee.ts
@@ -54,9 +54,10 @@ export class EvaluationTrigger implements INodeType {
 			authentication,
 			{
 				...document,
+				displayName: 'Document Containing Dataset',
 				hint: 'Example dataset format <a href="https://docs.google.com/spreadsheets/d/1vD_IdeFUg7sHsK9okL6Doy1rGOkWTnPJV3Dro4FBUsY/edit?gid=0#gid=0">here</a>',
 			},
-			sheet,
+			{ ...sheet, displayName: 'Sheet Containing Dataset' },
 			{
 				displayName: 'Limit Rows',
 				name: 'limitRows',

--- a/packages/nodes-base/nodes/Evaluation/test/Evaluation.node.test.ts
+++ b/packages/nodes-base/nodes/Evaluation/test/Evaluation.node.test.ts
@@ -127,7 +127,7 @@ describe('Test Evaluation', () => {
 
 			const result = await new Evaluation().execute.call(mockExecuteFunctions);
 
-			expect(result).toEqual([{}]);
+			expect(result).toEqual([[{ json: {} }]]);
 
 			expect(GoogleSheet.prototype.updateRows).not.toBeCalled();
 

--- a/packages/nodes-base/nodes/Evaluation/test/Evaluation.node.test.ts
+++ b/packages/nodes-base/nodes/Evaluation/test/Evaluation.node.test.ts
@@ -127,7 +127,7 @@ describe('Test Evaluation', () => {
 
 			const result = await new Evaluation().execute.call(mockExecuteFunctions);
 
-			expect(result).toEqual([]);
+			expect(result).toEqual([{}]);
 
 			expect(GoogleSheet.prototype.updateRows).not.toBeCalled();
 

--- a/packages/nodes-base/nodes/Evaluation/utils/evaluationUtils.ts
+++ b/packages/nodes-base/nodes/Evaluation/utils/evaluationUtils.ts
@@ -107,12 +107,6 @@ export async function setMetrics(this: IExecuteFunctions): Promise<INodeExecutio
 				const assignmentValue =
 					typeof assignment.value === 'number' ? assignment.value : Number(assignment.value);
 
-				if (!assignment.name || isNaN(assignmentValue)) {
-					throw new NodeOperationError(this.getNode(), 'Metric name missing', {
-						description: 'Make sure each metric you define has a name',
-					});
-				}
-
 				if (isNaN(assignmentValue)) {
 					throw new NodeOperationError(
 						this.getNode(),
@@ -121,6 +115,12 @@ export async function setMetrics(this: IExecuteFunctions): Promise<INodeExecutio
 							description: `It’s currently '${assignment.value}'. Metrics must be numeric.`,
 						},
 					);
+				}
+
+				if (!assignment.name || isNaN(assignmentValue)) {
+					throw new NodeOperationError(this.getNode(), 'Metric name missing', {
+						description: 'Make sure each metric you define has a name',
+					});
 				}
 
 				const { name, value } = validateEntry(

--- a/packages/nodes-base/nodes/Evaluation/utils/evaluationUtils.ts
+++ b/packages/nodes-base/nodes/Evaluation/utils/evaluationUtils.ts
@@ -25,7 +25,7 @@ export async function setOutput(this: IExecuteFunctions): Promise<INodeExecution
 			message: "No outputs were set since the execution didn't start from an evaluation trigger",
 			location: 'outputPane',
 		});
-		return [];
+		return [this.getInputData()];
 	}
 
 	const outputFields = this.getNodeParameter('outputs.values', 0, []) as Array<{


### PR DESCRIPTION
## Summary

Fix more tweaks for Evaluation node

To enable, run pnpm dev:fe and then in console, paste:

```
localStorage.setItem('N8N_EXPERIMENT_OVERRIDES', '{"031-evaluation-trigger":"variant"}')
```
## Related Linear tickets, Github issues, and Community forum posts

Resolves [NODE-2991: tweaks eval node](https://linear.app/n8n/issue/NODE-2991/tweaks-eval-node)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
