### PR TITLE
test(editor): Add unit test for TriggerPanel component

### DIFF
--- a/packages/frontend/editor-ui/src/components/TriggerPanel.test.ts
+++ b/packages/frontend/editor-ui/src/components/TriggerPanel.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import TriggerPanel from './TriggerPanel.vue';
+
+// Stubs for child components
+const NodeExecuteButton = {
+	template: '<button data-test-id="trigger-execute-button" />',
+	props: ['nodeName', 'size', 'telemetrySource'],
+};
+const CopyInput = { template: '<div />', props: ['value'] };
+const NodeIcon = { template: '<div />', props: ['nodeType', 'size'] };
+
+// Mock stores and composables
+vi.mock('@/stores/ui.store', () => ({ useUIStore: () => ({ openModal: vi.fn() }) }));
+vi.mock('@/stores/workflows.store', () => ({
+	useWorkflowsStore: () => ({
+		getNodeByName: () => ({ type: 'webhook', parameters: {}, issues: undefined }),
+		isWorkflowRunning: false,
+		isWorkflowActive: false,
+		executionWaitingForWebhook: false,
+		executedNode: null,
+		workflowId: '1',
+	}),
+}));
+vi.mock('@/stores/ndv.store', () => ({ useNDVStore: () => ({ activeNodeName: null }) }));
+vi.mock('@/stores/nodeTypes.store', () => ({
+	useNodeTypesStore: () => ({
+		getNodeType: () => ({ name: 'webhook', webhooks: [{}] }),
+		isTriggerNode: () => true,
+	}),
+}));
+vi.mock('@/composables/useWorkflowHelpers', () => ({
+	useWorkflowHelpers: () => ({
+		getCurrentWorkflow: () => ({ expression: { getSimpleParameterValue: () => false } }),
+		getWebhookExpressionValue: () => 'POST',
+		getWebhookUrl: () => 'https://test.url/webhook',
+	}),
+}));
+vi.mock('@/composables/useI18n', () => ({
+	useI18n: () => ({ baseText: (key: string) => key }),
+}));
+vi.mock('@/composables/useTelemetry', () => ({ useTelemetry: () => ({ track: vi.fn() }) }));
+vi.mock('@/utils/nodeTypesUtils', () => ({ getTriggerNodeServiceName: () => 'Webhook' }));
+vi.mock('@/utils/typeGuards', () => ({ isTriggerPanelObject: () => false }));
+vi.mock('@n8n/utils/event-bus', () => ({ createEventBus: () => ({ emit: vi.fn() }) }));
+vi.mock('vue-router', () => ({ useRouter: () => ({ push: vi.fn() }) }));
+
+describe('TriggerPanel', () => {
+	it('renders the trigger execute button', () => {
+		const wrapper = mount(TriggerPanel, {
+			props: {
+				nodeName: 'Webhook Trigger',
+				pushRef: '',
+			},
+			global: {
+				components: {
+					NodeExecuteButton,
+					CopyInput,
+					NodeIcon,
+				},
+			},
+		});
+		const button = wrapper.find('[data-test-id="trigger-execute-button"]');
+		expect(button.exists()).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

This PR adds a unit test for the `TriggerPanel` component in the Editor UI.  
The test verifies that the trigger execute button is rendered when the component is mounted with the required props and stubbed child components.

**How to test:**  
Run the test suite for the Editor UI package and ensure the new test passes:
```bash
pnpm run test --filter @n8n/editor-ui
```

No user-facing changes. This PR only adds missing test coverage.

## Related Linear tickets, Github issues, and Community forum posts

<!-- No related tickets or issues. -->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)