### PR TITLE
test(nodes-loader): add test for missing method in isolated class

### DIFF
--- a/packages/core/src/nodes-loader/__tests__/load-class-in-isolation.test.ts
+++ b/packages/core/src/nodes-loader/__tests__/load-class-in-isolation.test.ts
@@ -56,4 +56,17 @@ describe('loadClassInIsolation', () => {
 
 		expect(() => loadClassInIsolation(filePath, className)).toThrow('Script execution failed');
 	});
+
+	it('should throw if the loaded class does not have the requested method', () => {
+		// Mock a class without getValue
+		class IncompleteClass {}
+		runInContext.mockImplementationOnce(() => new IncompleteClass());
+
+		const instance = loadClassInIsolation(filePath, className);
+
+		expect(() => {
+			// @ts-expect-error
+			instance.getValue();
+		}).toThrow();
+	});
 });


### PR DESCRIPTION
Add test case to verify that loadClassInIsolation properly handles instances where the loaded class does not implement the expected method. This improves test coverage for error handling in dynamic class loading.

## Summary

This PR adds a new test case to `load-class-in-isolation.test.ts` that verifies the behavior of `loadClassInIsolation` when it encounters a class that doesn't implement an expected method. This is an important edge case for dynamic class loading that wasn't previously covered by tests.

The test:
- Mocks a class without the expected `getValue` method
- Verifies that attempting to call the missing method throws an error
- Follows the existing test patterns and coding style

To test:
1. Run the specific test:
```bash
pnpm test packages/core/src/nodes-loader/__tests__/load-class-in-isolation.test.ts
```
2. Verify that all tests in the file pass:
```bash
pnpm test packages/core/src/nodes-loader/__tests__/load-class-in-isolation.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

<!-- No related issues -->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
