### PR TITLE
feat(Postgres Node): Option to not parse types

### DIFF
--- a/packages/nodes-base/nodes/Postgres/transport/index.ts
+++ b/packages/nodes-base/nodes/Postgres/transport/index.ts
@@ -82,6 +82,12 @@ export async function configurePostgres(
 			});
 		}
 
+		if (options.preservePostgresTypes?.length) {
+			options.preservePostgresTypes.forEach((type) => {
+				pgp.pg.types.setTypeParser(type, (value: string) => value);
+			});
+		}
+
 		if (options.largeNumbersOutput === 'numbers') {
 			pgp.pg.types.setTypeParser(20, (value: string) => {
 				return parseInt(value, 10);

--- a/packages/nodes-base/nodes/Postgres/v2/actions/common.descriptions.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/common.descriptions.ts
@@ -152,6 +152,30 @@ export const optionsCollection: INodeProperties = {
 				},
 			},
 		},
+		{
+			displayName: 'Preserve Postgres Types',
+			name: 'preservePostgresTypes',
+			type: 'multiOptions',
+			default: [],
+			options: [
+				{
+					name: 'DATE',
+					value: 1082,
+				},
+				{
+					name: 'TIMESTAMP',
+					value: 1114,
+				},
+				{
+					name: 'TIMESTAMP WITH TIME ZONE',
+					value: 1184,
+				},
+				{
+					name: 'INTERVAL',
+					value: 1186,
+				},
+			],
+		},
 	],
 };
 

--- a/packages/nodes-base/nodes/Postgres/v2/helpers/interfaces.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/helpers/interfaces.ts
@@ -50,6 +50,7 @@ export type PostgresNodeOptions = {
 	skipOnConflict?: boolean;
 	replaceEmptyStrings?: boolean;
 	treatQueryParametersInSingleQuotesAsText?: boolean;
+	preservePostgresTypes?: number[];
 };
 
 export type PostgresNodeCredentials = {


### PR DESCRIPTION
## Summary

DOES NOT WORK! pg.types is global setting and will affect other nodes

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
