### PR TITLE
feat(editor): Show informative message in NDV when AI tools have no parameters

### DIFF
--- a/packages/frontend/editor-ui/src/components/NodeCredentials.test.ts
+++ b/packages/frontend/editor-ui/src/components/NodeCredentials.test.ts
@@ -55,7 +55,7 @@ const openAiNode: INodeUi = {
 
 describe('NodeCredentials', () => {
 	const defaultRenderOptions: RenderOptions = {
-		pinia: createTestingPinia(),
+		pinia: createTestingPinia({ stubActions: false }),
 		props: {
 			overrideCredType: 'openAiApi',
 			node: httpNode,

--- a/packages/frontend/editor-ui/src/components/NodeCredentials.vue
+++ b/packages/frontend/editor-ui/src/components/NodeCredentials.vue
@@ -85,31 +85,21 @@ const filter = ref('');
 const listeningForAuthChange = ref(false);
 const selectRefs = ref<Array<InstanceType<typeof N8nSelect>>>([]);
 
+const credentialTypesNodeDescriptions = computed(() =>
+	credentialsStore.getCredentialTypesNodeDescriptions(props.overrideCredType, nodeType.value),
+);
+
 const credentialTypesNode = computed(() =>
-	credentialTypesNodeDescription.value.map(
+	credentialTypesNodeDescriptions.value.map(
 		(credentialTypeDescription) => credentialTypeDescription.name,
 	),
 );
 
 const credentialTypesNodeDescriptionDisplayed = computed(() =>
-	credentialTypesNodeDescription.value
+	credentialTypesNodeDescriptions.value
 		.filter((credentialTypeDescription) => displayCredentials(credentialTypeDescription))
 		.map((type) => ({ type, options: getCredentialOptions(getAllRelatedCredentialTypes(type)) })),
 );
-const credentialTypesNodeDescription = computed(() => {
-	if (typeof props.overrideCredType !== 'string') return [];
-
-	const credType = credentialsStore.getCredentialTypeByName(props.overrideCredType);
-
-	if (credType) return [credType];
-
-	const activeNodeType = nodeType.value;
-	if (activeNodeType?.credentials) {
-		return activeNodeType.credentials;
-	}
-
-	return [];
-});
 
 const credentialTypeNames = computed(() => {
 	const returnData: Record<string, string> = {};

--- a/packages/frontend/editor-ui/src/components/NodeSettings.vue
+++ b/packages/frontend/editor-ui/src/components/NodeSettings.vue
@@ -205,6 +205,7 @@ const parameters = computed(() => {
 const parametersSetting = computed(() => parameters.value.filter((item) => item.isNodeSetting));
 
 const parametersNoneSetting = computed(() =>
+	// The connection hint notice is visually hidden via CSS in NodeDetails.vue when the node has output connections
 	parameters.value.filter((item) => !item.isNodeSetting),
 );
 

--- a/packages/frontend/editor-ui/src/components/NodeSettings.vue
+++ b/packages/frontend/editor-ui/src/components/NodeSettings.vue
@@ -6,6 +6,7 @@ import type {
 	INodeProperties,
 	NodeConnectionType,
 	NodeParameterValue,
+	INodeCredentialDescription,
 } from 'n8n-workflow';
 import {
 	NodeHelpers,
@@ -205,6 +206,20 @@ const parametersSetting = computed(() => parameters.value.filter((item) => item.
 
 const parametersNoneSetting = computed(() =>
 	parameters.value.filter((item) => !item.isNodeSetting),
+);
+
+const isDisplayingCredentials = computed(
+	() =>
+		credentialsStore
+			.getCredentialTypesNodeDescriptions('', props.nodeType)
+			.filter((credentialTypeDescription) => displayCredentials(credentialTypeDescription)).length >
+		0,
+);
+
+const showNoParametersNotice = computed(
+	() =>
+		!isDisplayingCredentials.value &&
+		parametersNoneSetting.value.filter((item) => item.type !== 'notice').length === 0,
 );
 
 const outputPanelEditMode = computed(() => ndvStore.outputPanelEditMode);
@@ -957,6 +972,18 @@ onBeforeUnmount(() => {
 	importCurlEventBus.off('setHttpNodeParameters', setHttpNodeParameters);
 	ndvEventBus.off('updateParameterValue', valueChanged);
 });
+
+function displayCredentials(credentialTypeDescription: INodeCredentialDescription): boolean {
+	if (credentialTypeDescription.displayOptions === undefined) {
+		// If it is not defined no need to do a proper check
+		return true;
+	}
+
+	return (
+		!!node.value &&
+		nodeHelpers.displayParameter(node.value.parameters, credentialTypeDescription, '', node.value)
+	);
+}
 </script>
 
 <template>
@@ -1077,7 +1104,7 @@ onBeforeUnmount(() => {
 						@blur="onParameterBlur"
 					/>
 				</ParameterInputList>
-				<div v-if="parametersNoneSetting.length === 0" class="no-parameters">
+				<div v-if="showNoParametersNotice" class="no-parameters">
 					<n8n-text>
 						{{ i18n.baseText('nodeSettings.thisNodeDoesNotHaveAnyParameters') }}
 					</n8n-text>

--- a/packages/frontend/editor-ui/src/stores/credentials.store.ts
+++ b/packages/frontend/editor-ui/src/stores/credentials.store.ts
@@ -20,7 +20,10 @@ import { isEmpty, isPresent } from '@/utils/typesUtils';
 import type {
 	ICredentialsDecrypted,
 	ICredentialType,
+	INodeCredentialDescription,
 	INodeCredentialTestResult,
+	INodeTypeDescription,
+	NodeParameterValueType,
 } from 'n8n-workflow';
 import { defineStore } from 'pinia';
 import { computed, ref } from 'vue';
@@ -298,6 +301,19 @@ export const useCredentialsStore = defineStore(STORES.CREDENTIALS, () => {
 		return await credentialsApi.getCredentialData(rootStore.restApiContext, id);
 	};
 
+	const getCredentialTypesNodeDescriptions: (
+		overrideCredType: NodeParameterValueType,
+		nodeType: INodeTypeDescription | null,
+	) => INodeCredentialDescription[] = (overrideCredType, nodeType) => {
+		if (typeof overrideCredType !== 'string') return [];
+
+		const credType = getCredentialTypeByName.value(overrideCredType);
+
+		if (credType) return [credType];
+
+		return nodeType?.credentials ? nodeType.credentials : [];
+	};
+
 	const createNewCredential = async (
 		data: ICredentialsDecrypted,
 		projectId?: string,
@@ -444,6 +460,7 @@ export const useCredentialsStore = defineStore(STORES.CREDENTIALS, () => {
 		createNewCredential,
 		updateCredential,
 		getCredentialData,
+		getCredentialTypesNodeDescriptions,
 		oAuth1Authorize,
 		oAuth2Authorize,
 		getNewCredentialName,


### PR DESCRIPTION
## Summary

When opening Node settings for the node without node settings parameters, if the node already has parameters of type `notice`, the message "This node does not have any parameters" (i.e. the _no-parameter notice_) is not shown.

Changes in this PR:
- Exclude `notice`-type parameters when determining whether to show the _no-parameter notice_.
- Hide the _no-parameter notice_ if credentials are displayed.
- Move getting credential type nodes descriptions from `NodeCredentials` to `Credentials` store to be able to determine whether credentials are displayed in two different components.
- Stop mocking actions for `NodeCredentials` component (as it is now moved to the store).

Examples of affected nodes: Calculator, Wikipedia, Wolfram Alpha.

This is how it looks now for a Calculator not connected to an AI Agent:
<img width="383" alt="image" src="https://github.com/user-attachments/assets/4278f7ad-91b0-43cd-922d-a9c0e757a705" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3436/add-informative-message-to-ndv-when-tools-have-no-parameters

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
