### PR TITLE
feat(core): Add logs for insights flushing and compaction

### DIFF
--- a/packages/cli/src/modules/insights/__tests__/insights-compaction.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights-compaction.service.test.ts
@@ -282,11 +282,11 @@ describe('compaction', () => {
 			const workflow = await createWorkflow({}, project);
 
 			// create 100 more events than the batch size (500)
-			const batchSize = 600;
+			const numberOfEvents = 600;
 
 			let timestamp = DateTime.utc().startOf('hour');
 			const events = Array<{ type: 'success'; value: number; timestamp: DateTime }>();
-			for (let i = 0; i < batchSize; i++) {
+			for (let i = 0; i < numberOfEvents; i++) {
 				events.push({ type: 'success', value: 1, timestamp });
 				timestamp = timestamp.plus({ minute: 1 });
 			}
@@ -296,13 +296,13 @@ describe('compaction', () => {
 			await insightsCompactionService.compactInsights();
 
 			// ASSERT
-			// compaction batch size is 500, so rawToHour should be called 3 times:
-			// 1st call: 500 events, 2nd call: 100 events, and third call that returns nothing
-			expect(rawToHourSpy).toHaveBeenCalledTimes(3);
+			// compaction batch size is 500, so rawToHour should be called 2 times:
+			// 1st call: 500 events, 2nd call: 100 events
+			expect(rawToHourSpy).toHaveBeenCalledTimes(2);
 			await expect(insightsRawRepository.count()).resolves.toBe(0);
 			const allCompacted = await insightsByPeriodRepository.find({ order: { periodStart: 1 } });
 			const accumulatedValues = allCompacted.reduce((acc, event) => acc + event.value, 0);
-			expect(accumulatedValues).toBe(batchSize);
+			expect(accumulatedValues).toBe(numberOfEvents);
 		});
 	});
 

--- a/packages/cli/src/modules/insights/insights-compaction.service.ts
+++ b/packages/cli/src/modules/insights/insights-compaction.service.ts
@@ -44,21 +44,27 @@ export class InsightsCompactionService {
 
 		// Compact raw data to hourly aggregates
 		do {
+			this.logger.debug('Compacting raw data to hourly aggregates');
 			numberOfCompactedRawData = await this.compactRawToHour();
-		} while (numberOfCompactedRawData > 0);
+			this.logger.debug(`Compacted ${numberOfCompactedRawData} raw data to hourly aggregates`);
+		} while (numberOfCompactedRawData === this.insightsConfig.compactionBatchSize);
 
 		let numberOfCompactedHourData: number;
 
 		// Compact hourly data to daily aggregates
 		do {
+			this.logger.debug('Compacting hourly data to daily aggregates');
 			numberOfCompactedHourData = await this.compactHourToDay();
-		} while (numberOfCompactedHourData > 0);
+			this.logger.debug(`Compacted ${numberOfCompactedHourData} hourly data to daily aggregates`);
+		} while (numberOfCompactedHourData === this.insightsConfig.compactionBatchSize);
 
 		let numberOfCompactedDayData: number;
 		// Compact daily data to weekly aggregates
 		do {
+			this.logger.debug('Compacting daily data to weekly aggregates');
 			numberOfCompactedDayData = await this.compactDayToWeek();
-		} while (numberOfCompactedDayData > 0);
+			this.logger.debug(`Compacted ${numberOfCompactedDayData} daily data to weekly aggregates`);
+		} while (numberOfCompactedDayData === this.insightsConfig.compactionBatchSize);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR adds logging lines to insights flushing and compaction, for debug and diagnostic purposes.
The PR also adds a minor optimization on compaction looping, to stop the loop if there is less processed rows than the batch size (meaning that we are on the last batch). This prevents a useless loop run with 0 data on last loop most of the time (optimization does not work if total items to compact is a multiple of the batch size, but that's quite rare).

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

[PAY-2838: Improve logging for debug and diagnostic](https://linear.app/n8n/issue/PAY-2838/improve-logging-for-debug-and-diagnostic)

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included (updated for the optimization). <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
