### PR TITLE
fix(Summarize Node): Convert v1 split by values to string

### DIFF
--- a/packages/nodes-base/nodes/Transform/Summarize/test/unitTests/__snapshots__/splitData.test.ts.snap
+++ b/packages/nodes-base/nodes/Transform/Summarize/test/unitTests/__snapshots__/splitData.test.ts.snap
@@ -1,5 +1,183 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Test Summarize Node, aggregateAndSplitData should handle multiple split field values containing null when convertKeysToString is false: split-field-with-spaces-array 1`] = `
+[
+  {
+    "pairedItems": [
+      0,
+    ],
+    "returnData": {
+      "Product": "Widget A",
+      "Warehouse": "WH1",
+      "appended_Warehouse": [
+        "WH1",
+      ],
+    },
+  },
+  {
+    "pairedItems": [
+      2,
+    ],
+    "returnData": {
+      "Product": "Widget A",
+      "Warehouse": null,
+      "appended_Warehouse": [
+        null,
+      ],
+    },
+  },
+  {
+    "pairedItems": [
+      1,
+    ],
+    "returnData": {
+      "Product": null,
+      "Warehouse": "WH2",
+      "appended_Warehouse": [
+        "WH2",
+      ],
+    },
+  },
+]
+`;
+
+exports[`Test Summarize Node, aggregateAndSplitData should handle multiple split field values containing null when convertKeysToString is false: split-field-with-spaces-result 1`] = `
+{
+  "fieldName": "Product",
+  "splits": Map {
+    "Widget A" => {
+      "fieldName": "Warehouse",
+      "splits": Map {
+        "WH1" => {
+          "pairedItems": [
+            0,
+          ],
+          "returnData": {
+            "appended_Warehouse": [
+              "WH1",
+            ],
+          },
+        },
+        null => {
+          "pairedItems": [
+            2,
+          ],
+          "returnData": {
+            "appended_Warehouse": [
+              null,
+            ],
+          },
+        },
+      },
+    },
+    null => {
+      "fieldName": "Warehouse",
+      "splits": Map {
+        "WH2" => {
+          "pairedItems": [
+            1,
+          ],
+          "returnData": {
+            "appended_Warehouse": [
+              "WH2",
+            ],
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`Test Summarize Node, aggregateAndSplitData should handle multiple split field values containing null when convertKeysToString is true: split-field-with-spaces-array 1`] = `
+[
+  {
+    "pairedItems": [
+      0,
+    ],
+    "returnData": {
+      "Product": "Widget A",
+      "Warehouse": "WH1",
+      "appended_Warehouse": [
+        "WH1",
+      ],
+    },
+  },
+  {
+    "pairedItems": [
+      2,
+    ],
+    "returnData": {
+      "Product": "Widget A",
+      "Warehouse": "null",
+      "appended_Warehouse": [
+        null,
+      ],
+    },
+  },
+  {
+    "pairedItems": [
+      1,
+    ],
+    "returnData": {
+      "Product": "null",
+      "Warehouse": "WH2",
+      "appended_Warehouse": [
+        "WH2",
+      ],
+    },
+  },
+]
+`;
+
+exports[`Test Summarize Node, aggregateAndSplitData should handle multiple split field values containing null when convertKeysToString is true: split-field-with-spaces-result 1`] = `
+{
+  "fieldName": "Product",
+  "splits": Map {
+    "Widget A" => {
+      "fieldName": "Warehouse",
+      "splits": Map {
+        "WH1" => {
+          "pairedItems": [
+            0,
+          ],
+          "returnData": {
+            "appended_Warehouse": [
+              "WH1",
+            ],
+          },
+        },
+        "null" => {
+          "pairedItems": [
+            2,
+          ],
+          "returnData": {
+            "appended_Warehouse": [
+              null,
+            ],
+          },
+        },
+      },
+    },
+    "null" => {
+      "fieldName": "Warehouse",
+      "splits": Map {
+        "WH2" => {
+          "pairedItems": [
+            1,
+          ],
+          "returnData": {
+            "appended_Warehouse": [
+              "WH2",
+            ],
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
 exports[`Test Summarize Node, aggregateAndSplitData should handle split field values containing spaces when convertKeysToString is not set: split-field-with-spaces-array 1`] = `
 [
   {

--- a/packages/nodes-base/nodes/Transform/Summarize/test/unitTests/splitData.test.ts
+++ b/packages/nodes-base/nodes/Transform/Summarize/test/unitTests/splitData.test.ts
@@ -177,6 +177,96 @@ describe('Test Summarize Node, aggregateAndSplitData', () => {
 		);
 	});
 
+	test('should handle multiple split field values containing null when convertKeysToString is true', () => {
+		const data = [
+			{
+				Product: 'Widget A',
+				Warehouse: 'WH1',
+				Qty: '5',
+				_itemIndex: 0,
+			},
+			{
+				Product: null,
+				Warehouse: 'WH2',
+				Qty: '3',
+				_itemIndex: 1,
+			},
+			{
+				Product: 'Widget A',
+				Warehouse: null,
+				Qty: '2',
+				_itemIndex: 2,
+			},
+		];
+
+		const aggregations: Aggregations = [
+			{
+				aggregation: 'append',
+				field: 'Warehouse',
+				includeEmpty: true,
+			},
+		];
+
+		const result = aggregateAndSplitData({
+			splitKeys: ['Product', 'Warehouse'],
+			inputItems: data,
+			fieldsToSummarize: aggregations,
+			options: { continueIfFieldNotFound: true },
+			getValue: fieldValueGetter(),
+			convertKeysToString: true,
+		});
+
+		expect(result).toMatchSnapshot('split-field-with-spaces-result');
+		expect(flattenAggregationResultToArray(result)).toMatchSnapshot(
+			'split-field-with-spaces-array',
+		);
+	});
+
+	test('should handle multiple split field values containing null when convertKeysToString is false', () => {
+		const data = [
+			{
+				Product: 'Widget A',
+				Warehouse: 'WH1',
+				Qty: '5',
+				_itemIndex: 0,
+			},
+			{
+				Product: null,
+				Warehouse: 'WH2',
+				Qty: '3',
+				_itemIndex: 1,
+			},
+			{
+				Product: 'Widget A',
+				Warehouse: null,
+				Qty: '2',
+				_itemIndex: 2,
+			},
+		];
+
+		const aggregations: Aggregations = [
+			{
+				aggregation: 'append',
+				field: 'Warehouse',
+				includeEmpty: true,
+			},
+		];
+
+		const result = aggregateAndSplitData({
+			splitKeys: ['Product', 'Warehouse'],
+			inputItems: data,
+			fieldsToSummarize: aggregations,
+			options: { continueIfFieldNotFound: true },
+			getValue: fieldValueGetter(),
+			convertKeysToString: false,
+		});
+
+		expect(result).toMatchSnapshot('split-field-with-spaces-result');
+		expect(flattenAggregationResultToArray(result)).toMatchSnapshot(
+			'split-field-with-spaces-array',
+		);
+	});
+
 	describe('with skipEmptySplitFields=true', () => {
 		test('should skip empty split fields', () => {
 			const data = [

--- a/packages/nodes-base/nodes/Transform/Summarize/utils.ts
+++ b/packages/nodes-base/nodes/Transform/Summarize/utils.ts
@@ -252,6 +252,7 @@ export function aggregateAndSplitData({
 				fieldsToSummarize,
 				options,
 				getValue,
+				convertKeysToString,
 			}),
 		]),
 	);


### PR DESCRIPTION
## Summary
This PR fixes a regression in Summarize v1 node, where using multiple split by keys doesn't convert null values to string
the regression was introduced in https://github.com/n8n-io/n8n/pull/14259 and it caused only the first value of spilt by to be converted to string

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-2993/summarize-node-breaking-change-with-fields-to-split-by-param

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
