### PR TITLE
fix(editor): Fix how deviation percentage is calculated in Insights summary

### DIFF
--- a/packages/frontend/editor-ui/src/features/insights/insights.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/insights/insights.utils.test.ts
@@ -71,8 +71,8 @@ describe('Insights Transformers', () => {
 	describe('transformInsightsDeviation', () => {
 		describe('for total and failed types', () => {
 			it('should calculate percentage deviation', () => {
-				expect(transformInsightsDeviation.total(100, 10)).toBe(10);
-				expect(transformInsightsDeviation.failed(50, 5)).toBe(10);
+				expect(transformInsightsDeviation.total(110, 10)).toBe(10);
+				expect(transformInsightsDeviation.failed(55, 5)).toBe(10);
 			});
 
 			it('should return 0 if value and deviation are 0', () => {
@@ -80,9 +80,9 @@ describe('Insights Transformers', () => {
 				expect(transformInsightsDeviation.failed(0, 0)).toBe(0);
 			});
 
-			it('should return Infinity if value is 0 and deviation is not 0', () => {
-				expect(transformInsightsDeviation.total(0, 10)).toBe(Infinity);
-				expect(transformInsightsDeviation.failed(0, 5)).toBe(Infinity);
+			it('should return Infinity if value equals deviation (and thus previous value is 0)', () => {
+				expect(transformInsightsDeviation.total(10, 10)).toBe(Infinity);
+				expect(transformInsightsDeviation.failed(5, 5)).toBe(Infinity);
 			});
 
 			it('should return 0 if deviation is 0 and value is not 0', () => {
@@ -122,7 +122,7 @@ describe('Insights Transformers', () => {
 		it('should correctly transform InsightsSummary data and respect INSIGHTS_SUMMARY_ORDER', () => {
 			const summaryData: InsightsSummary = {
 				timeSaved: { value: 1200, deviation: 120, unit: 'minute' },
-				total: { value: 100, deviation: 10, unit: 'count' },
+				total: { value: 110, deviation: 10, unit: 'count' },
 				failureRate: { value: 0.05, deviation: 0.01, unit: 'ratio' },
 				averageRunTime: { value: 5000, deviation: 1000, unit: 'millisecond' },
 				failed: { value: 5, deviation: 1, unit: 'count' },
@@ -131,7 +131,7 @@ describe('Insights Transformers', () => {
 			const expectedOutput = [
 				{
 					id: 'total',
-					value: 100,
+					value: 110,
 					deviation: 10,
 					deviationUnit: '%',
 					unit: '',
@@ -139,7 +139,7 @@ describe('Insights Transformers', () => {
 				{
 					id: 'failed',
 					value: 5,
-					deviation: 20,
+					deviation: 25,
 					deviationUnit: '%',
 					unit: '',
 				},
@@ -176,7 +176,7 @@ describe('Insights Transformers', () => {
 				'averageRunTime',
 			]);
 
-			expect(INSIGHTS_UNIT_MAPPING.total).toHaveBeenCalledWith(100);
+			expect(INSIGHTS_UNIT_MAPPING.total).toHaveBeenCalledWith(110);
 			expect(INSIGHTS_DEVIATION_UNIT_MAPPING.total).toHaveBeenCalledWith(10);
 			expect(INSIGHTS_UNIT_MAPPING.failed).toHaveBeenCalledWith(5);
 			expect(INSIGHTS_DEVIATION_UNIT_MAPPING.failed).toHaveBeenCalledWith(1);
@@ -208,7 +208,7 @@ describe('Insights Transformers', () => {
 				{
 					id: 'failed',
 					value: 5,
-					deviation: 20,
+					deviation: 25,
 					deviationUnit: '%',
 					unit: '',
 				},

--- a/packages/frontend/editor-ui/src/features/insights/insights.utils.ts
+++ b/packages/frontend/editor-ui/src/features/insights/insights.utils.ts
@@ -19,14 +19,16 @@ export const transformInsightsValues: Record<InsightsSummaryType, (value: number
 	failureRate: transformInsightsFailureRate,
 };
 
+const getPreviousValue = (value: number, deviation: number): number => value - deviation;
+
 export const transformInsightsDeviation: Record<
 	InsightsSummaryType,
 	(value: number, deviation: number) => number
 > = {
 	total: (value: number, deviation: number) =>
-		value === 0 && deviation === 0 ? 0 : (deviation / value) * 100,
+		value === 0 && deviation === 0 ? 0 : (deviation / getPreviousValue(value, deviation)) * 100,
 	failed: (value: number, deviation: number) =>
-		value === 0 && deviation === 0 ? 0 : (deviation / value) * 100,
+		value === 0 && deviation === 0 ? 0 : (deviation / getPreviousValue(value, deviation)) * 100,
 	timeSaved: (_: number, deviation: number) => transformInsightsTimeSaved(deviation),
 	averageRunTime: (_: number, deviation: number) => transformInsightsAverageRunTime(deviation),
 	failureRate: (_: number, deviation: number) => transformInsightsFailureRate(deviation),


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR fixes the way the percentage is calculated on the frontend for the total and failed production execution Insights in the summary banner. 
Previously, the percentage was computed compared to the current value (deviation / currentValue). This PR fixes it by computing the percentage like this: (deviation / previousValue)

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2850/issues-with-how-the-deviation-is-calculated

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
