### PR TITLE
feat(editor): Enable source environment push button for project admins

### DIFF
--- a/packages/@n8n/permissions/src/roles/scopes/project-scopes.ee.ts
+++ b/packages/@n8n/permissions/src/roles/scopes/project-scopes.ee.ts
@@ -31,6 +31,7 @@ export const REGULAR_PROJECT_ADMIN_SCOPES: Scope[] = [
 	'folder:delete',
 	'folder:list',
 	'folder:move',
+	'sourceControl:push',
 ];
 
 export const PERSONAL_PROJECT_OWNER_SCOPES: Scope[] = [

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -2146,6 +2146,8 @@
 	"settings.sourceControl.sync.prompt.error": "Please enter a commit message",
 	"settings.sourceControl.button.push": "Push",
 	"settings.sourceControl.button.pull": "Pull",
+	"settings.sourceControl.button.pull.forbidden": "Only the instance owner or instance admins can pull changes",
+	"settings.sourceControl.button.push.forbidden": "You can't push changes from a protected instance",
 	"settings.sourceControl.modals.push.title": "Commit and push changes",
 	"settings.sourceControl.modals.push.description": "The following will be committed: ",
 	"settings.sourceControl.modals.push.description.learnMore": "More info",

--- a/packages/frontend/editor-ui/src/components/MainSidebarSourceControl.test.ts
+++ b/packages/frontend/editor-ui/src/components/MainSidebarSourceControl.test.ts
@@ -94,8 +94,33 @@ describe('MainSidebarSourceControl', () => {
 			});
 			expect(getByTestId('main-sidebar-source-control-connected')).toBeInTheDocument();
 			expect(queryByTestId('main-sidebar-source-control-setup')).not.toBeInTheDocument();
-			expect(queryByTestId('main-sidebar-source-control-push')).toBeInTheDocument();
-			expect(queryByTestId('main-sidebar-source-control-pull')).not.toBeInTheDocument();
+
+			const pushButton = queryByTestId('main-sidebar-source-control-push');
+			expect(pushButton).toBeInTheDocument();
+			expect(pushButton).not.toBeDisabled();
+
+			const pullButton = queryByTestId('main-sidebar-source-control-pull');
+			expect(pullButton).toBeInTheDocument();
+			expect(pullButton).toBeDisabled();
+		});
+
+		it('should disable push button if branch is read-only', async () => {
+			vi.spyOn(sourceControlStore, 'preferences', 'get').mockReturnValue({
+				branchName: 'main',
+				branches: [],
+				repositoryUrl: '',
+				branchReadOnly: true,
+				branchColor: '#5296D6',
+				connected: true,
+				publicKey: '',
+			});
+
+			const { getByTestId } = renderComponent({
+				pinia,
+				props: { isCollapsed: false },
+			});
+			const pushButton = getByTestId('main-sidebar-source-control-push');
+			expect(pushButton).toBeDisabled();
 		});
 	});
 
@@ -120,6 +145,32 @@ describe('MainSidebarSourceControl', () => {
 			});
 			expect(getByTestId('main-sidebar-source-control-connected')).toBeInTheDocument();
 			expect(queryByTestId('main-sidebar-source-control-setup')).not.toBeInTheDocument();
+
+			const pushButton = queryByTestId('main-sidebar-source-control-push');
+			expect(pushButton).toBeInTheDocument();
+			expect(pushButton).not.toBeDisabled();
+
+			const pullButton = queryByTestId('main-sidebar-source-control-pull');
+			expect(pullButton).toBeInTheDocument();
+			expect(pullButton).not.toBeDisabled();
+		});
+
+		it('should disable push button if branch is read-only', async () => {
+			vi.spyOn(sourceControlStore, 'preferences', 'get').mockReturnValue({
+				branchName: 'main',
+				branches: [],
+				repositoryUrl: '',
+				branchReadOnly: true,
+				branchColor: '#5296D6',
+				connected: true,
+				publicKey: '',
+			});
+			const { getByTestId } = renderComponent({
+				pinia,
+				props: { isCollapsed: false },
+			});
+			const pushButton = getByTestId('main-sidebar-source-control-push');
+			expect(pushButton).toBeDisabled();
 		});
 
 		it('should show toast error if pull response http status code is not 409', async () => {

--- a/packages/frontend/editor-ui/src/components/MainSidebarSourceControl.vue
+++ b/packages/frontend/editor-ui/src/components/MainSidebarSourceControl.vue
@@ -3,6 +3,7 @@ import { computed, ref } from 'vue';
 import { createEventBus } from '@n8n/utils/event-bus';
 import { useI18n } from '@n8n/i18n';
 import { hasPermission } from '@/utils/rbac/permissions';
+import { getResourcePermissions } from '@/permissions';
 import { useToast } from '@/composables/useToast';
 import { useLoadingService } from '@/composables/useLoadingService';
 import { useUIStore } from '@/stores/ui.store';
@@ -10,6 +11,7 @@ import { useSourceControlStore } from '@/stores/sourceControl.store';
 import { SOURCE_CONTROL_PULL_MODAL_KEY, SOURCE_CONTROL_PUSH_MODAL_KEY } from '@/constants';
 import { sourceControlEventBus } from '@/event-bus/source-control';
 import { notifyUserAboutPullWorkFolderOutcome } from '@/utils/sourceControlUtils';
+import { useProjectsStore } from '@/stores/projects.store';
 
 defineProps<{
 	isCollapsed: boolean;
@@ -22,6 +24,7 @@ const responseStatuses = {
 const loadingService = useLoadingService();
 const uiStore = useUIStore();
 const sourceControlStore = useSourceControlStore();
+const projectStore = useProjectsStore();
 const toast = useToast();
 const i18n = useI18n();
 
@@ -31,10 +34,26 @@ const tooltipOpenDelay = ref(300);
 const currentBranch = computed(() => {
 	return sourceControlStore.preferences.branchName;
 });
+
+// Check if the user has permission to push at least one project
+const hasProjectPushScope = computed(() => {
+	return (
+		hasPermission(['rbac'], { rbac: { scope: 'sourceControl:push' } }) ||
+		projectStore.myProjects.some(
+			(project) =>
+				project.type === 'team' && getResourcePermissions(project?.scopes)?.sourceControl?.push,
+		)
+	);
+});
+
+const hasPullPermission = computed(() => {
+	return hasPermission(['rbac'], { rbac: { scope: 'sourceControl:pull' } });
+});
+
 const sourceControlAvailable = computed(
 	() =>
 		sourceControlStore.isEnterpriseSourceControlEnabled &&
-		hasPermission(['rbac'], { rbac: { scope: 'sourceControl:manage' } }),
+		(hasPullPermission.value || hasProjectPushScope.value),
 );
 
 async function pushWorkfolder() {
@@ -113,7 +132,12 @@ async function pullWorkfolder() {
 				{{ currentBranch }}
 			</span>
 			<div :class="{ 'pt-xs': !isCollapsed }">
-				<n8n-tooltip :disabled="!isCollapsed" :show-after="tooltipOpenDelay" placement="right">
+				<n8n-tooltip
+					v-if="hasPullPermission"
+					:disabled="!isCollapsed"
+					:show-after="tooltipOpenDelay"
+					placement="right"
+				>
 					<template #content>
 						<div>
 							{{ i18n.baseText('settings.sourceControl.button.pull') }}
@@ -124,6 +148,7 @@ async function pullWorkfolder() {
 							'mr-2xs': !isCollapsed,
 							'mb-2xs': isCollapsed && !sourceControlStore.preferences.branchReadOnly,
 						}"
+						data-test-id="main-sidebar-source-control-pull"
 						icon="arrow-down"
 						type="tertiary"
 						size="mini"
@@ -133,7 +158,7 @@ async function pullWorkfolder() {
 					/>
 				</n8n-tooltip>
 				<n8n-tooltip
-					v-if="!sourceControlStore.preferences.branchReadOnly"
+					v-if="!sourceControlStore.preferences.branchReadOnly && hasProjectPushScope"
 					:disabled="!isCollapsed"
 					:show-after="tooltipOpenDelay"
 					placement="right"
@@ -146,6 +171,7 @@ async function pullWorkfolder() {
 					<n8n-button
 						:square="isCollapsed"
 						:label="isCollapsed ? '' : i18n.baseText('settings.sourceControl.button.push')"
+						data-test-id="main-sidebar-source-control-push"
 						icon="arrow-up"
 						type="tertiary"
 						size="mini"


### PR DESCRIPTION
### :warning: Should not be merged before this ticket is done: https://linear.app/n8n/issue/PAY-2826/validate-when-attempting-to-commit-from-modal-what-a-user-has-access

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
Currently, only instance owners and admins can see the push / pull button in the source control section of the side menu.
We want to enable project admins to push (not pull) to instances the changes related to the resources they have access to (workflows, credentials, tags, folder of the project they are admin of).
This PR does 2 things:
- it show the souce control section of the side menu for project admins, with disabled pull button with tooltip to show why pull is disabled
- it also displays the push button even if the instance is protected, with a tooltip explaning why

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
https://linear.app/n8n/issue/PAY-2824/show-push-button-for-project-admins#comment-c702d776

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
