### PR TITLE
fix(Email Trigger (IMAP) Node): Add Email UID also to email format "resolved"

### DIFF
--- a/packages/nodes-base/nodes/EmailReadImap/v2/utils.ts
+++ b/packages/nodes-base/nodes/EmailReadImap/v2/utils.ts
@@ -117,6 +117,10 @@ export async function getNewEmails(
 				dataPropertyAttachmentsPrefixName,
 			);
 
+			(parsedEmail.json as IDataObject).attributes = {
+				uid: message.attributes.uid,
+			};
+
 			newEmails.push(parsedEmail);
 		}
 	} else if (format === 'simple') {


### PR DESCRIPTION
When returning the email in the format "simple" the UID is added and returned, but not when returned in format "resolved". This commit changes this

## Summary

Its basically the same functionality as in the PR from [https://github.com/n8n-io/n8n/pull/13152](https://github.com/n8n-io/n8n/pull/13152 
)
It only adds the returned UID also when choosing format "resolved"

## Related Linear tickets, Github issues, and Community forum posts


Forum feature request [IMAP Trigger Node - Provide email UIDs](https://community.n8n.io/t/imap-trigger-node-provide-email-uids/75626)
GitHub issue: https://github.com/umanamente/n8n-nodes-imap/issues/42



## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. NO DOCS AVAILABLE IN BASELINE
- [x] Tests included. NO TESTS AVAILABLE IN BASELINE
- [x] PR Labeled with `release/backport` NO NEED
