### PR TITLE
fix(editor): Add type definition for $getWorkflowStaticData to code node

### DIFF
--- a/packages/frontend/editor-ui/src/plugins/codemirror/typescript/worker/type-declarations/n8n.d.ts
+++ b/packages/frontend/editor-ui/src/plugins/codemirror/typescript/worker/type-declarations/n8n.d.ts
@@ -94,6 +94,7 @@ declare global {
 	function $min(...numbers: number[]): number;
 	function $max(...numbers: number[]): number;
 	function $evaluateExpression(expression: string): any;
+	function $getWorkflowStaticData(type: 'global' | 'node'): N8nJson;
 
 	type SomeOtherString = string & NonNullable<unknown>;
 	// @ts-expect-error NodeName is created dynamically


### PR DESCRIPTION
## Summary

<img width="819" alt="image" src="https://github.com/user-attachments/assets/ba13c544-4a22-4de8-a435-0331a8ed1041" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2943/methods-to-get-static-data-are-red-in-the-code-node

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
