### PR TITLE
fix(Jira Software Node): Use old endpoints to get all issues on self-hosted instances

### DIFF
--- a/packages/nodes-base/nodes/Jira/Jira.node.ts
+++ b/packages/nodes-base/nodes/Jira/Jira.node.ts
@@ -822,24 +822,43 @@ export class Jira implements INodeType {
 						}
 					}
 					if (returnAll) {
-						responseData = await jiraSoftwareCloudApiRequestAllItems.call(
-							this,
-							'issues',
-							'/api/2/search/jql',
-							'POST',
-							body,
-							{},
-							'token',
-						);
+						if (jiraVersion === 'server' || jiraVersion === 'serverPat') {
+							responseData = await jiraSoftwareCloudApiRequestAllItems.call(
+								this,
+								'issues',
+								'/api/2/search',
+								'POST',
+								body,
+							);
+						} else {
+							responseData = await jiraSoftwareCloudApiRequestAllItems.call(
+								this,
+								'issues',
+								'/api/2/search/jql',
+								'POST',
+								body,
+								{},
+								'token',
+							);
+						}
 					} else {
 						const limit = this.getNodeParameter('limit', i);
 						body.maxResults = limit;
-						responseData = await jiraSoftwareCloudApiRequest.call(
-							this,
-							'/api/2/search/jql',
-							'POST',
-							body,
-						);
+						if (jiraVersion === 'server' || jiraVersion === 'serverPat') {
+							responseData = await jiraSoftwareCloudApiRequest.call(
+								this,
+								'/api/2/search',
+								'POST',
+								body,
+							);
+						} else {
+							responseData = await jiraSoftwareCloudApiRequest.call(
+								this,
+								'/api/2/search/jql',
+								'POST',
+								body,
+							);
+						}
 						responseData = responseData.issues;
 					}
 

--- a/packages/nodes-base/nodes/Jira/__test__/Jira.node.test.ts
+++ b/packages/nodes-base/nodes/Jira/__test__/Jira.node.test.ts
@@ -2,8 +2,8 @@ import type { DeepMockProxy } from 'jest-mock-extended';
 import { mockDeep } from 'jest-mock-extended';
 import type { IExecuteFunctions } from 'n8n-workflow';
 
-import * as GenericFunctions from '../../GenericFunctions';
-import { Jira } from '../../Jira.node';
+import * as GenericFunctions from '../GenericFunctions';
+import { Jira } from '../Jira.node';
 
 jest.mock('../../GenericFunctions', () => ({
 	jiraSoftwareCloudApiRequest: jest.fn().mockResolvedValue({ issues: [] }),

--- a/packages/nodes-base/nodes/Jira/__test__/Jira.node.test.ts
+++ b/packages/nodes-base/nodes/Jira/__test__/Jira.node.test.ts
@@ -152,7 +152,7 @@ describe('Jira Node', () => {
 			);
 		});
 
-		it('should call old endpoint for the self-hosted version with return all = false', async () => {
+		it('should call new endpoint for the cloud version with return all = true', async () => {
 			executeFunctionsMock.getNodeParameter.mockImplementation((parameterName: string) => {
 				switch (parameterName) {
 					case 'resource':
@@ -160,36 +160,7 @@ describe('Jira Node', () => {
 					case 'operation':
 						return 'getAll';
 					case 'jiraVersion':
-						return 'server';
-					case 'returnAll':
-						return false;
-					case 'limit':
-						return 10;
-					case 'options':
-						return {};
-					default:
-						return null;
-				}
-			});
-
-			await jiraNode.execute.call(executeFunctionsMock);
-
-			expect(jiraSoftwareCloudApiRequestMock).toHaveBeenCalledWith(
-				'/api/2/search',
-				'POST',
-				expect.anything(),
-			);
-		});
-
-		it('should call old endpoint for the self-hosted version with return all = true', async () => {
-			executeFunctionsMock.getNodeParameter.mockImplementation((parameterName: string) => {
-				switch (parameterName) {
-					case 'resource':
-						return 'issue';
-					case 'operation':
-						return 'getAll';
-					case 'jiraVersion':
-						return 'server';
+						return 'cloud';
 					case 'returnAll':
 						return true;
 					case 'options':
@@ -203,10 +174,75 @@ describe('Jira Node', () => {
 
 			expect(jiraSoftwareCloudApiRequestAllItems).toHaveBeenCalledWith(
 				'issues',
-				'/api/2/search',
+				'/api/2/search/jql',
 				'POST',
 				expect.anything(),
+				{},
+				'token',
 			);
 		});
+
+		it.each([['server'], ['serverPat']])(
+			'should call old endpoint for the self-hosted version with return all = false',
+			async (jiraVersion: string) => {
+				executeFunctionsMock.getNodeParameter.mockImplementation((parameterName: string) => {
+					switch (parameterName) {
+						case 'resource':
+							return 'issue';
+						case 'operation':
+							return 'getAll';
+						case 'jiraVersion':
+							return jiraVersion;
+						case 'returnAll':
+							return false;
+						case 'limit':
+							return 10;
+						case 'options':
+							return {};
+						default:
+							return null;
+					}
+				});
+
+				await jiraNode.execute.call(executeFunctionsMock);
+
+				expect(jiraSoftwareCloudApiRequestMock).toHaveBeenCalledWith(
+					'/api/2/search',
+					'POST',
+					expect.anything(),
+				);
+			},
+		);
+
+		it.each([['server'], ['serverPat']])(
+			'should call old endpoint for the self-hosted version with return all = true',
+			async (jiraVersion: string) => {
+				executeFunctionsMock.getNodeParameter.mockImplementation((parameterName: string) => {
+					switch (parameterName) {
+						case 'resource':
+							return 'issue';
+						case 'operation':
+							return 'getAll';
+						case 'jiraVersion':
+							return jiraVersion;
+						case 'returnAll':
+							return true;
+						case 'options':
+							return {};
+						default:
+							return null;
+					}
+				});
+
+				await jiraNode.execute.call(executeFunctionsMock);
+
+				expect(jiraSoftwareCloudApiRequestAllItems).toHaveBeenCalledWith(
+					'issues',
+					'/api/2/search',
+					'POST',
+					expect.anything(),
+				);
+			},
+		);
 	});
 });

--- a/packages/nodes-base/nodes/Jira/__test__/Jira.node.test.ts
+++ b/packages/nodes-base/nodes/Jira/__test__/Jira.node.test.ts
@@ -5,7 +5,7 @@ import type { IExecuteFunctions } from 'n8n-workflow';
 import * as GenericFunctions from '../GenericFunctions';
 import { Jira } from '../Jira.node';
 
-jest.mock('../../GenericFunctions', () => ({
+jest.mock('../GenericFunctions', () => ({
 	jiraSoftwareCloudApiRequest: jest.fn().mockResolvedValue({ issues: [] }),
 	jiraSoftwareCloudApiRequestAllItems: jest.fn().mockResolvedValue([]),
 }));

--- a/packages/nodes-base/nodes/Jira/test/node/Jira.node.test.ts
+++ b/packages/nodes-base/nodes/Jira/test/node/Jira.node.test.ts
@@ -7,9 +7,12 @@ import { Jira } from '../../Jira.node';
 
 jest.mock('../../GenericFunctions', () => ({
 	jiraSoftwareCloudApiRequest: jest.fn().mockResolvedValue({ issues: [] }),
+	jiraSoftwareCloudApiRequestAllItems: jest.fn().mockResolvedValue([]),
 }));
 
 const jiraSoftwareCloudApiRequestMock = GenericFunctions.jiraSoftwareCloudApiRequest as jest.Mock;
+const jiraSoftwareCloudApiRequestAllItems =
+	GenericFunctions.jiraSoftwareCloudApiRequestAllItems as jest.Mock;
 
 describe('Jira Node', () => {
 	let jiraNode: Jira;
@@ -146,6 +149,63 @@ describe('Jira Node', () => {
 				expect.objectContaining({
 					jql: 'project = TEST',
 				}),
+			);
+		});
+
+		it('should call old endpoint for the self-hosted version with return all = false', async () => {
+			executeFunctionsMock.getNodeParameter.mockImplementation((parameterName: string) => {
+				switch (parameterName) {
+					case 'resource':
+						return 'issue';
+					case 'operation':
+						return 'getAll';
+					case 'jiraVersion':
+						return 'server';
+					case 'returnAll':
+						return false;
+					case 'limit':
+						return 10;
+					case 'options':
+						return {};
+					default:
+						return null;
+				}
+			});
+
+			await jiraNode.execute.call(executeFunctionsMock);
+
+			expect(jiraSoftwareCloudApiRequestMock).toHaveBeenCalledWith(
+				'/api/2/search',
+				'POST',
+				expect.anything(),
+			);
+		});
+
+		it('should call old endpoint for the self-hosted version with return all = true', async () => {
+			executeFunctionsMock.getNodeParameter.mockImplementation((parameterName: string) => {
+				switch (parameterName) {
+					case 'resource':
+						return 'issue';
+					case 'operation':
+						return 'getAll';
+					case 'jiraVersion':
+						return 'server';
+					case 'returnAll':
+						return true;
+					case 'options':
+						return {};
+					default:
+						return null;
+				}
+			});
+
+			await jiraNode.execute.call(executeFunctionsMock);
+
+			expect(jiraSoftwareCloudApiRequestAllItems).toHaveBeenCalledWith(
+				'issues',
+				'/api/2/search',
+				'POST',
+				expect.anything(),
 			);
 		});
 	});


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Update the Jira node to call old endpoints to get all issues, if the user is using self-hosted Jira version. These endpoints are supposed to be deprecated on cloud, which was addressed in #14821, however, the new endpoints do not exist on self-hosted, so this PR addresses that

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-2969/community-issue-jira-node-returns-404-in-v1922-but-works-in-v1902
Closes #15376

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
