### PR TITLE
fix(editor): Fix update panel icon display. Fix title on insights dashboard

### DIFF
--- a/packages/frontend/editor-ui/src/components/UpdatesPanel.vue
+++ b/packages/frontend/editor-ui/src/components/UpdatesPanel.vue
@@ -106,6 +106,7 @@ const i18n = useI18n();
 
 	.link {
 		padding-left: 0px;
+		display: flex;
 	}
 
 	.link:hover {

--- a/packages/frontend/editor-ui/src/features/insights/components/InsightsDashboard.test.ts
+++ b/packages/frontend/editor-ui/src/features/insights/components/InsightsDashboard.test.ts
@@ -21,6 +21,7 @@ describe('InsightsDashboard', () => {
 	it('should render without error', () => {
 		mockedStore(useInsightsStore);
 		expect(() => renderComponent()).not.toThrow();
+		expect(document.title).toBe('Insights - n8n');
 	});
 
 	it('should update the selected time range', async () => {

--- a/packages/frontend/editor-ui/src/features/insights/components/InsightsDashboard.vue
+++ b/packages/frontend/editor-ui/src/features/insights/components/InsightsDashboard.vue
@@ -4,10 +4,11 @@ import { useTelemetry } from '@/composables/useTelemetry';
 import InsightsSummary from '@/features/insights/components/InsightsSummary.vue';
 import { useInsightsStore } from '@/features/insights/insights.store';
 import type { InsightsDateRange, InsightsSummaryType } from '@n8n/api-types';
-import { computed, defineAsyncComponent, ref, watch } from 'vue';
+import { computed, defineAsyncComponent, onMounted, ref, watch } from 'vue';
 import { TELEMETRY_TIME_RANGE, UNLICENSED_TIME_RANGE } from '../insights.constants';
 import InsightsDateRangeSelect from './InsightsDateRangeSelect.vue';
 import InsightsUpgradeModal from './InsightsUpgradeModal.vue';
+import { useDocumentTitle } from '@/composables/useDocumentTitle';
 
 const InsightsPaywall = defineAsyncComponent(
 	async () => await import('@/features/insights/components/InsightsPaywall.vue'),
@@ -116,6 +117,10 @@ watch(
 		immediate: true,
 	},
 );
+
+onMounted(() => {
+	useDocumentTitle().set(i18n.baseText('insights.heading'));
+});
 </script>
 
 <template>

--- a/packages/frontend/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/frontend/editor-ui/src/plugins/i18n/locales/en.json
@@ -3135,6 +3135,7 @@
 	"freeAi.credits.showError.claim.message": "Enable to claim credits",
 	"freeAi.credits.showWarning.workflow.activation.title": "You're using free OpenAI API credits",
 	"freeAi.credits.showWarning.workflow.activation.description": "To make sure your workflow runs smoothly in the future, replace the free OpenAI API credits with your own API key.",
+	"insights.heading": "Insights",
 	"insights.lastNDays": "Last {count} days",
 	"insights.lastNHours": "Last {count} hours",
 	"insights.months": "{count} months",


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Insights dashboard page did not have its own document title, so it kept the title of the previous page opened. 
+ minor css fix on update panel (I know it's unrelated, sorry)

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2862/insights-design-bugs

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
