### PR TITLE
refactor(editor): Remove unused return fields from ui store

### DIFF
--- a/packages/frontend/editor-ui/src/composables/useContextMenu.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useContextMenu.test.ts
@@ -38,7 +38,6 @@ describe('useContextMenu', () => {
 		} as never);
 
 		uiStore = useUIStore();
-		uiStore.selectedNodes = selectedNodes;
 		vi.spyOn(uiStore, 'isReadOnlyView', 'get').mockReturnValue(false);
 
 		workflowsStore = useWorkflowsStore();

--- a/packages/frontend/editor-ui/src/stores/nodeCreator.store.ts
+++ b/packages/frontend/editor-ui/src/stores/nodeCreator.store.ts
@@ -181,11 +181,9 @@ export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, () => {
 			return;
 		}
 
-		const { type, index, mode } = parseCanvasConnectionHandleString(connection.sourceHandle);
+		const { type, mode } = parseCanvasConnectionHandleString(connection.sourceHandle);
 
 		uiStore.lastSelectedNode = sourceNode.name;
-		uiStore.lastSelectedNodeEndpointUuid = connection.sourceHandle ?? null;
-		uiStore.lastSelectedNodeOutputIndex = index;
 
 		if (isVueFlowConnection(connection)) {
 			uiStore.lastInteractedWithNodeConnection = connection;


### PR DESCRIPTION
## Summary

This PR cleans up unused fields from the return object of UI store.

## Related Linear tickets, Github issues, and Community forum posts

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
