### PR TITLE
chore(core): Add test case for getStatus pull case (no-changelog)

### DIFF
--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control.service.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control.service.test.ts
@@ -15,6 +15,7 @@ import { SourceControlService } from '@/environments.ee/source-control/source-co
 import type { SourceControlImportService } from '../source-control-import.service.ee';
 import type { ExportableCredential } from '../types/exportable-credential';
 import type { SourceControlWorkflowVersionId } from '../types/source-control-workflow-version-id';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 
 describe('SourceControlService', () => {
 	const preferencesService = new SourceControlPreferencesService(
@@ -242,6 +243,21 @@ describe('SourceControlService', () => {
 
 			expect(pullResult.find((i) => i.type === 'folders')).toHaveProperty('conflict', true);
 			expect(pushResult.find((i) => i.type === 'folders')).toHaveProperty('conflict', false);
+		});
+
+		it('should throw `ForbiddenError` if direction is pull and user is not allowed to globally pull', async () => {
+			// ARRANGE
+			const user = mock<User>();
+			user.role = 'global:member';
+
+			// ACT
+			await expect(
+				sourceControlService.getStatus(user, {
+					direction: 'pull',
+					verbose: false,
+					preferLocalVersion: false,
+				}),
+			).rejects.toThrowError(ForbiddenError);
 		});
 	});
 });

--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control.service.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control.service.test.ts
@@ -11,11 +11,11 @@ import { InstanceSettings } from 'n8n-core';
 
 import { SourceControlPreferencesService } from '@/environments.ee/source-control/source-control-preferences.service.ee';
 import { SourceControlService } from '@/environments.ee/source-control/source-control.service.ee';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 
 import type { SourceControlImportService } from '../source-control-import.service.ee';
 import type { ExportableCredential } from '../types/exportable-credential';
 import type { SourceControlWorkflowVersionId } from '../types/source-control-workflow-version-id';
-import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 
 describe('SourceControlService', () => {
 	const preferencesService = new SourceControlPreferencesService(


### PR DESCRIPTION
## Summary

This adds a test case for the fix mentioned here: https://github.com/n8n-io/n8n/pull/15597

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-2863/bug-returning-error-instead-of-throwing-in-getstatus-method


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
