### PR TITLE
Update LmChatXAiGrok.node.ts

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatXAiGrok/LmChatXAiGrok.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatXAiGrok/LmChatXAiGrok.node.ts
@@ -226,7 +226,11 @@ export class LmChatXAiGrok implements INodeType {
 			topP?: number;
 			responseFormat?: 'text' | 'json_object';
 		};
-
+		
+		if (options.presencePenalty === 0) {
+			delete options.presencePenalty;
+		}
+		
 		const configuration: ClientOptions = {
 			baseURL: credentials.url,
 			httpAgent: getHttpProxyAgent(),


### PR DESCRIPTION
## Summary

This PR fixes the “Argument not supported on this model: presencePenalty” error when using the xAI Grok Chat Model with `grok-3-mini` or `grok-3-mini-fast`. Previously, even when `presencePenalty` was left at its default of `0`, the parameter was still sent in the request body and caused a 400 Bad Request from the xAI API. With this change, we now conditionally remove `presencePenalty` from the options object whenever it remains unset (i.e. equals `0`), preventing the unsupported-argument error and restoring normal Grok mini model usage.

## Related Linear tickets, Github issues, and Community forum posts

* "closes #14581 " — “X-AI Grok Chat Modal report ‘Argument not supported on this model: presencePenalty’”
* Internal Linear ticket: GHC-1556

## Review / Merge checklist

* [ ] PR title and summary are descriptive. ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
* [ ]  [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
* [ ] Code change correctly deletes `options.presencePenalty` when it is `0` (lines 230–233).
* [ ] No presencePenalty is sent unless explicitly set by the user.