### PR TITLE
docs: Update Jina AI credential docs link (no-changelog)

### DIFF
--- a/packages/nodes-base/credentials/JinaAiApi.credentials.ts
+++ b/packages/nodes-base/credentials/JinaAiApi.credentials.ts
@@ -10,7 +10,7 @@ export class JinaAiApi implements ICredentialType {
 
 	displayName = 'Jina AI API';
 
-	documentationUrl = 'jinaAi';
+	documentationUrl = 'jinaai';
 
 	properties: INodeProperties[] = [
 		{


### PR DESCRIPTION
## Summary

Updates the docs link in the Jina AI credential to use the correct format (lowercase). The [node itself](https://github.com/n8n-io/n8n/blob/master/packages/nodes-base/nodes/JinaAI/JinaAi.node.json#L9) seems to use the correct docs link, but this does not.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
