### PR TITLE
refactor(core): Remove last license runtime check

### DIFF
--- a/packages/cli/src/license.ts
+++ b/packages/cli/src/license.ts
@@ -106,9 +106,6 @@ export class License implements LicenseProvider {
 
 			await this.manager.initialize();
 
-			const features = this.manager.getFeatures();
-			this.checkIsLicensedForMultiMain(features);
-
 			this.logger.debug('License initialized');
 		} catch (error: unknown) {
 			if (error instanceof Error) {
@@ -141,8 +138,6 @@ export class License implements LicenseProvider {
 		}
 
 		this.logger.debug('License feature change detected', _features);
-
-		this.checkIsLicensedForMultiMain(_features);
 
 		if (isMultiMain && !isLeader) {
 			this.logger
@@ -429,30 +424,6 @@ export class License implements LicenseProvider {
 	/** @deprecated Use `LicenseState` instead. */
 	isWithinUsersLimit() {
 		return this.getUsersLimit() === UNLIMITED_LICENSE_QUOTA;
-	}
-
-	/**
-	 * Ensures that the instance is licensed for multi-main setup if multi-main mode is enabled
-	 */
-	private checkIsLicensedForMultiMain(features: TFeatures) {
-		const isMultiMainEnabled =
-			config.getEnv('executions.mode') === 'queue' && this.globalConfig.multiMainSetup.enabled;
-		if (!isMultiMainEnabled) {
-			return;
-		}
-
-		const isMultiMainLicensed =
-			(features[LICENSE_FEATURES.MULTIPLE_MAIN_INSTANCES] as boolean | undefined) ?? false;
-
-		this.instanceSettings.setMultiMainLicensed(isMultiMainLicensed);
-
-		if (!isMultiMainLicensed) {
-			this.logger
-				.scoped(['scaling', 'multi-main-setup', 'license'])
-				.debug(
-					'License changed with no support for multi-main setup - no new followers will be allowed to init. To restore multi-main setup, please upgrade to a license that supports this feature.',
-				);
-		}
 	}
 
 	@OnLeaderTakeover()


### PR DESCRIPTION
## Summary

As discussed before, `onFeatureChange` is [unnecessary complexity](https://n8nio.slack.com/archives/C035KBDA917/p1740566157792319?thread_ts=1740565893.290659&cid=C035KBDA917) where we pay the price of state management only to have a way to prevent users whose license expires at runtime from benefiting from multi-main until their next restart. This complexity is not worth it and removal here follows the same reasoning as for [removing the S3 license runtime check](https://github.com/n8n-io/n8n/pull/13532/files#diff-6214891477a43f04e46fe559080efdfba4e6aa8cc345dc5ecc906820af9a9234L109).

This is the first part of simplifying license state management in scaling mode. Next we'll add an `onLicenseRenewed` callback to the SDK and then do away with `onFeatureChange` altogether.

## Related Linear tickets, Github issues, and Community forum posts

Related: https://linear.app/n8n/issue/PAY-2761


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
