### PR TITLE
ci: Implement reusable workflow for PR job eligibility checks (no-changelog)

### DIFF
--- a/.github/workflows/check-run-eligibility.yml
+++ b/.github/workflows/check-run-eligibility.yml
@@ -1,0 +1,116 @@
+# Determines if conditions are met for running gated jobs on a Pull Request.
+#
+# This workflow checks for:
+# 1. Relevant file changes (based on the `paths_filter_patterns` input).
+# 2. The PR does NOT target an excluded branch (based on the `excluded_target_branch_patterns` input).
+# 3. The PR has been approved by a maintainer (based on the `is_pr_approved_by_maintainer` input).
+#
+# If all these conditions are met, it sets the `conditions_met_for_gated_jobs` output to true.
+# This applies to ALL Pull Requests (internal or from community forks) that are approved
+# and meet the file/branch criteria.
+# It also outputs `is_community_pr` (true if the PR is from a fork) for informational purposes.
+
+name: Check Run Eligibility
+
+on:
+  workflow_call:
+    inputs:
+      pr_base_ref:
+        required: true
+        type: string
+      pr_head_sha:
+        required: true
+        type: string
+      pr_head_repo_full_name:
+        required: true
+        type: string
+      is_pr_approved_by_maintainer:
+        required: true
+        type: boolean
+      paths_filter_patterns:
+        required: false
+        type: string
+        default: |
+          not_ignored:
+            - '!.devcontainer/**'
+            - '!.github/*'
+            - '!.github/scripts/*'
+            - '!.github/workflows/benchmark-*'
+            - '!.github/workflows/check-*'
+            - '!.vscode/**'
+            - '!docker/**'
+            - '!packages/@n8n/benchmark/**'
+            - '!**/*.md'
+      excluded_target_branch_patterns:
+        description: "Newline-separated list of glob patterns for PR target branches on which gated jobs should be SKIPPED. e.g. release/*"
+        required: false
+        type: string
+        default: |
+          release/*
+          master
+
+    outputs:
+      conditions_met_for_gated_jobs:
+        description: "Indicates if pre-conditions are met for running gated jobs."
+        value: ${{ jobs.evaluate_conditions.outputs.run_gated_jobs_decision }}
+      is_community_pr:
+        description: "Boolean indicating if this is a community PR (from a fork)."
+        value: ${{ jobs.evaluate_conditions.outputs.is_community_pr_val }}
+
+jobs:
+  evaluate_conditions:
+    runs-on: ubuntu-latest
+    outputs:
+      run_gated_jobs_decision: ${{ steps.determine_gated_run_logic.outputs.should_run_gated }}
+      is_community_pr_val: ${{ steps.determine_pr_type.outputs.is_community_pr }}
+    steps:
+      - name: Determine PR Type (Fork vs. Internal)
+        id: determine_pr_type
+        run: |
+          if [[ "${{ inputs.pr_head_repo_full_name }}" == "${{ github.repository }}" ]]; then
+            echo "is_community_pr=false" >> $GITHUB_OUTPUT
+          else
+            echo "is_community_pr=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check out current commit
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          ref: ${{ inputs.pr_head_sha }}
+          fetch-depth: 2
+
+      - name: Determine changed files
+        uses: tomi/paths-filter-action@32c62f5ca100c1110406e3477d5b3ecef4666fec # v3.0.2
+        id: changed
+        with:
+          filters: ${{ inputs.paths_filter_patterns }}
+          predicate-quantifier: 'every'
+
+      - name: Determine Gated Jobs Run Logic
+        id: determine_gated_run_logic
+        env:
+          IS_APPROVED_BY_MAINTAINER: ${{ inputs.is_pr_approved_by_maintainer }}
+          RELEVANT_FILES_CHANGED: ${{ steps.changed.outputs.not_ignored == 'true' }}
+          BASE_REF: ${{ inputs.pr_base_ref }}
+          EXCLUDED_PATTERNS: ${{ inputs.excluded_target_branch_patterns }}
+        run: |
+          run_gated="false"
+          target_branch_ok="true"
+
+          if [[ -n "$EXCLUDED_PATTERNS" ]]; then
+            while IFS= read -r pattern; do
+              if [[ -n "$pattern" ]]; then
+                if [[ "$BASE_REF" == $pattern ]]; then
+                  target_branch_ok="false"
+                  break
+                fi
+              fi
+            done <<< "$EXCLUDED_PATTERNS"
+          fi
+
+          if [[ "$RELEVANT_FILES_CHANGED" == "true" && \
+                "$target_branch_ok" == "true" && \
+                "$IS_APPROVED_BY_MAINTAINER" == "true" ]]; then
+            run_gated="true"
+          fi
+          echo "should_run_gated=$run_gated" >> $GITHUB_OUTPUT

--- a/.github/workflows/check-run-eligibility.yml
+++ b/.github/workflows/check-run-eligibility.yml
@@ -1,33 +1,28 @@
-# Determines if conditions are met for running gated jobs on a Pull Request.
+# Determines if conditions are met for running subsequent jobs on a Pull Request.
 #
-# This workflow checks for:
-# 1. Relevant file changes (based on the `paths_filter_patterns` input).
-# 2. The PR does NOT target an excluded branch (based on the `excluded_target_branch_patterns` input).
-# 3. The PR has been approved by a maintainer (based on the `is_pr_approved_by_maintainer` input).
+# !! IMPORTANT !!
+# This workflow RELIES on being called from a parent workflow triggered by
+# a `pull_request` or `pull_request_target` event. It uses `github.event`
+# to access PR details.
 #
-# If all these conditions are met, it sets the `conditions_met_for_gated_jobs` output to true.
-# This applies to ALL Pull Requests (internal or from community forks) that are approved
-# and meet the file/branch criteria.
-# It also outputs `is_community_pr` (true if the PR is from a fork) for informational purposes.
+# It checks if all the following conditions are TRUE:
+# 1. The PR is NOT from a fork (i.e., it's an internal PR).
+# 2. The PR has been approved by a maintainer (`is_pr_approved_by_maintainer`).
+# 3. The PR's source branch does NOT match an excluded pattern.
+# 4. The PR includes relevant file changes (`paths_filter_patterns`).
+#
+# It outputs `should_run` as 'true' if ALL conditions pass, 'false' otherwise.
 
-name: Check Run Eligibility
+name: PR Eligibility Check
 
 on:
   workflow_call:
     inputs:
-      pr_base_ref:
-        required: true
-        type: string
-      pr_head_sha:
-        required: true
-        type: string
-      pr_head_repo_full_name:
-        required: true
-        type: string
       is_pr_approved_by_maintainer:
         required: true
         type: boolean
       paths_filter_patterns:
+        description: "Path filter patterns for 'paths-filter-action'."
         required: false
         type: string
         default: |
@@ -41,8 +36,8 @@ on:
             - '!docker/**'
             - '!packages/@n8n/benchmark/**'
             - '!**/*.md'
-      excluded_target_branch_patterns:
-        description: "Newline-separated list of glob patterns for PR target branches on which gated jobs should be SKIPPED. e.g. release/*"
+      excluded_source_branch_patterns:
+        description: "Newline-separated list of glob patterns for source branches to EXCLUDE."
         required: false
         type: string
         default: |
@@ -50,34 +45,20 @@ on:
           master
 
     outputs:
-      conditions_met_for_gated_jobs:
-        description: "Indicates if pre-conditions are met for running gated jobs."
-        value: ${{ jobs.evaluate_conditions.outputs.run_gated_jobs_decision }}
-      is_community_pr:
-        description: "Boolean indicating if this is a community PR (from a fork)."
-        value: ${{ jobs.evaluate_conditions.outputs.is_community_pr_val }}
+      should_run:
+        description: "Outputs 'true' if all eligibility checks pass, otherwise 'false'."
+        value: ${{ jobs.evaluate_conditions.outputs.run_decision }}
 
 jobs:
   evaluate_conditions:
     runs-on: ubuntu-latest
     outputs:
-      run_gated_jobs_decision: ${{ steps.determine_gated_run_logic.outputs.should_run_gated }}
-      is_community_pr_val: ${{ steps.determine_pr_type.outputs.is_community_pr }}
+      run_decision: ${{ steps.evaluate.outputs.should_run }}
     steps:
-      - name: Determine PR Type (Fork vs. Internal)
-        id: determine_pr_type
-        run: |
-          if [[ "${{ inputs.pr_head_repo_full_name }}" == "${{ github.repository }}" ]]; then
-            echo "is_community_pr=false" >> $GITHUB_OUTPUT
-          else
-            echo "is_community_pr=true" >> $GITHUB_OUTPUT
-          fi
-
       - name: Check out current commit
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          ref: ${{ inputs.pr_head_sha }}
-          fetch-depth: 2
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Determine changed files
         uses: tomi/paths-filter-action@32c62f5ca100c1110406e3477d5b3ecef4666fec # v3.0.2
@@ -86,31 +67,43 @@ jobs:
           filters: ${{ inputs.paths_filter_patterns }}
           predicate-quantifier: 'every'
 
-      - name: Determine Gated Jobs Run Logic
-        id: determine_gated_run_logic
+      - name: Evaluate Conditions & Set Output
+        id: evaluate
         env:
-          IS_APPROVED_BY_MAINTAINER: ${{ inputs.is_pr_approved_by_maintainer }}
-          RELEVANT_FILES_CHANGED: ${{ steps.changed.outputs.not_ignored == 'true' }}
-          BASE_REF: ${{ inputs.pr_base_ref }}
-          EXCLUDED_PATTERNS: ${{ inputs.excluded_target_branch_patterns }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+          IS_APPROVED: ${{ inputs.is_pr_approved_by_maintainer }}
+          FILES_CHANGED: ${{ steps.changed.outputs.not_ignored == 'true' }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          EXCLUDED_PATTERNS: ${{ inputs.excluded_source_branch_patterns }}
         run: |
-          run_gated="false"
-          target_branch_ok="true"
-
-          if [[ -n "$EXCLUDED_PATTERNS" ]]; then
-            while IFS= read -r pattern; do
-              if [[ -n "$pattern" ]]; then
-                if [[ "$BASE_REF" == $pattern ]]; then
-                  target_branch_ok="false"
-                  break
-                fi
-              fi
-            done <<< "$EXCLUDED_PATTERNS"
+          if [[ "$IS_FORK" == "true" ]]; then
+            is_community="true"
+          else
+            is_community="false"
           fi
 
-          if [[ "$RELEVANT_FILES_CHANGED" == "true" && \
-                "$target_branch_ok" == "true" && \
-                "$IS_APPROVED_BY_MAINTAINER" == "true" ]]; then
-            run_gated="true"
+          source_branch_excluded="false"
+          while IFS= read -r pattern; do
+            if [[ -n "$pattern" && "$HEAD_REF" == $pattern ]]; then
+                source_branch_excluded="true"
+                break
+            fi
+          done <<< "$EXCLUDED_PATTERNS"
+
+          echo "--- Checking Conditions ---"
+          echo "Is NOT Community PR: $([[ "$is_community" == "false" ]] && echo true || echo false)"
+          echo "Files Changed: $FILES_CHANGED"
+          echo "Source Branch Excluded: $source_branch_excluded"
+          echo "Is Approved: $IS_APPROVED"
+          echo "-------------------------"
+
+          if [[ "$is_community" == "false" && \
+                "$FILES_CHANGED" == "true" && \
+                "$source_branch_excluded" == "false" && \
+                "$IS_APPROVED" == "true" ]]; then
+            echo "Decision: Conditions met. Setting should_run=true."
+            echo "should_run=true" >> $GITHUB_OUTPUT
+          else
+            echo "Decision: Conditions not met. Setting should_run=false."
+            echo "should_run=false" >> $GITHUB_OUTPUT
           fi
-          echo "should_run_gated=$run_gated" >> $GITHUB_OUTPUT

--- a/.github/workflows/e2e-tests-pr.yml
+++ b/.github/workflows/e2e-tests-pr.yml
@@ -10,11 +10,11 @@ concurrency:
 
 jobs:
   eligibility_check:
-      name: Check Eligibility for Test Run
-      if: github.event.review.state == 'approved'
-      uses: ./.github/workflows/check-run-eligibility.yml
-      with:
-        is_pr_approved_by_maintainer: true
+    name: Check Eligibility for Test Run
+    if: github.event.review.state == 'approved'
+    uses: ./.github/workflows/check-run-eligibility.yml
+    with:
+      is_pr_approved_by_maintainer: true
 
   run-e2e-tests:
     name: E2E [Electron/Node 18]
@@ -28,7 +28,7 @@ jobs:
       CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
 
   post-e2e-tests:
-    name: E2E - Summary & Status
+    name: E2E [Electron/Node 18] - Checks
     runs-on: ubuntu-latest
     needs: [eligibility_check, run-e2e-tests]
     if: always() && needs.eligibility_check.result != 'skipped'

--- a/.github/workflows/e2e-tests-pr.yml
+++ b/.github/workflows/e2e-tests-pr.yml
@@ -10,20 +10,17 @@ concurrency:
 
 jobs:
   eligibility_check:
-    name: Check Run Eligibility
-    uses: ./.github/workflows/check-run-eligibility.yml
-    if: github.event.review.state == 'approved'
-    with:
-      pr_base_ref: ${{ github.event.pull_request.base.ref }}
-      pr_head_sha: ${{ github.event.pull_request.head.sha }}
-      pr_head_repo_full_name: ${{ github.event.pull_request.head.repo.full_name }}
-      is_pr_approved_by_maintainer: ${{ github.event.review.state == 'approved' }}
+      name: Check Eligibility for Test Run
+      if: github.event.review.state == 'approved'
+      uses: ./.github/workflows/check-run-eligibility.yml
+      with:
+        is_pr_approved_by_maintainer: true
 
   run-e2e-tests:
     name: E2E [Electron/Node 18]
     uses: ./.github/workflows/e2e-reusable.yml
     needs: [eligibility_check]
-    if: ${{ needs.eligibility_check.result != 'skipped' && needs.eligibility_check.outputs.should_run == 'true' }}
+    if: needs.eligibility_check.outputs.should_run == 'true'
     with:
       pr_number: ${{ github.event.pull_request.number }}
       user: ${{ github.event.pull_request.user.login || 'PR User' }}

--- a/.github/workflows/e2e-tests-pr.yml
+++ b/.github/workflows/e2e-tests-pr.yml
@@ -9,46 +9,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  get-metadata:
-    name: Get Metadata
+  eligibility_check:
+    name: Check Run Eligibility
     runs-on: ubuntu-latest
     if: github.event.review.state == 'approved'
-    steps:
-      - name: Check out current commit
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 2
-
-      - name: Determine changed files
-        uses: tomi/paths-filter-action@32c62f5ca100c1110406e3477d5b3ecef4666fec # v3.0.2
-        id: changed
-        with:
-          filters: |
-            not_ignored:
-              - '!.devcontainer/**'
-              - '!.github/*'
-              - '!.github/scripts/*'
-              - '!.github/workflows/benchmark-*'
-              - '!.github/workflows/check-*'
-              - '!.vscode/**'
-              - '!docker/**'
-              - '!packages/@n8n/benchmark/**'
-              - '!**/*.md'
-          predicate-quantifier: 'every'
-
     outputs:
-      # The workflow should run when:
-      # - It has changes to files that are not ignored
-      # - It is not a community PR
-      # - It is targeting master or a release branch
-      should_run: ${{ steps.changed.outputs.not_ignored == 'true' && !contains(github.event.pull_request.labels.*.name, 'community') && (github.event.pull_request.base.ref == 'master' || startsWith(github.event.pull_request.base.ref, 'release/')) }}
+      should_run: ${{ steps.reusable_eligibility_check.outputs.conditions_met_for_gated_jobs }}
+      is_community_pr: ${{ steps.reusable_eligibility_check.outputs.is_community_pr }}
+    steps:
+      - name: Call Reusable Eligibility Check
+        id: reusable_eligibility_check
+        uses: ./.github/workflows/check-run-eligibility.yml
+        with:
+          pr_base_ref: ${{ github.event.pull_request.base.ref }}
+          pr_head_sha: ${{ github.event.pull_request.head.sha }}
+          pr_head_repo_full_name: ${{ github.event.pull_request.head.repo.full_name }}
+          is_pr_approved_by_maintainer: ${{ github.event.review.state == 'approved' }}
 
   run-e2e-tests:
     name: E2E [Electron/Node 18]
     uses: ./.github/workflows/e2e-reusable.yml
-    needs: [get-metadata]
-    if: ${{ github.event.review.state == 'approved' && needs.get-metadata.outputs.should_run == 'true' }}
+    needs: [eligibility_check]
+    if: ${{ needs.eligibility_check.result != 'skipped' && needs.eligibility_check.outputs.should_run == 'true' }}
     with:
       pr_number: ${{ github.event.pull_request.number }}
       user: ${{ github.event.pull_request.user.login || 'PR User' }}
@@ -56,33 +38,52 @@ jobs:
       CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
 
   post-e2e-tests:
+    name: E2E - Summary & Status
     runs-on: ubuntu-latest
-    name: E2E [Electron/Node 18] - Checks
-    needs: [get-metadata, run-e2e-tests]
-    if: always()
+    needs: [eligibility_check, run-e2e-tests]
+    if: always() && needs.eligibility_check.result != 'skipped'
     steps:
-      - name: E2E success comment
-        if: ${{ needs.get-metadata.outputs.should_run == 'true' && needs.run-e2e-tests.outputs.tests_passed == 'true' }}
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+      - name: Determine Outcome and Comment Message
+        id: determine_outcome
+        run: |
+          JOB_OUTCOME="success"
+          COMMENT_BODY=""
+          SHOULD_POST_COMMENT="false"
+
+          if [[ "${{ needs.eligibility_check.outputs.should_run }}" == "false" ]]; then
+            COMMENT_BODY="ℹ️ E2E tests were not run for this PR based on the eligibility criteria."
+            SHOULD_POST_COMMENT="true"
+            JOB_OUTCOME="success"
+          elif [[ "${{ needs.run-e2e-tests.result }}" == "success" ]]; then
+            COMMENT_BODY=":white_check_mark: All Cypress E2E specs passed"
+            SHOULD_POST_COMMENT="true"
+            JOB_OUTCOME="success"
+          elif [[ "${{ needs.run-e2e-tests.result }}" == "failure" ]]; then
+            COMMENT_BODY=":warning: Some Cypress E2E specs are failing, please fix them before merging"
+            SHOULD_POST_COMMENT="true"
+            JOB_OUTCOME="failure"
+          else
+            COMMENT_BODY="ℹ️ E2E tests were scheduled but did not complete as expected (Result: ${{ needs.run-e2e-tests.result }})."
+            SHOULD_POST_COMMENT="true"
+            JOB_OUTCOME="failure"
+          fi
+
+          echo "comment_body=$COMMENT_BODY" >> $GITHUB_OUTPUT
+          echo "should_post_comment=$SHOULD_POST_COMMENT" >> $GITHUB_OUTPUT
+          echo "job_outcome=$JOB_OUTCOME" >> $GITHUB_OUTPUT
+
+      - name: Create or Update PR Comment
+        if: steps.determine_outcome.outputs.should_post_comment == 'true'
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            :white_check_mark: All Cypress E2E specs passed
+          body: ${{ steps.determine_outcome.outputs.comment_body }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: E2E fail comment
-        if: needs.run-e2e-tests.result == 'failure'
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            :warning: Some Cypress E2E specs are failing, please fix them before merging
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Success job if community PR
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'community') }}
-        run: exit 0
-
-      - name: Fail job if run-e2e-tests failed
-        if: ${{ (github.event.review.state != 'approved' && github.event.review.state != 'commented') || needs.run-e2e-tests.result == 'failure' }}
-        run: exit 1
+      - name: Finalize Job Status
+        run: |
+          if [[ "${{ steps.determine_outcome.outputs.job_outcome }}" == "failure" ]]; then
+            exit 1
+          else
+            exit 0
+          fi

--- a/.github/workflows/e2e-tests-pr.yml
+++ b/.github/workflows/e2e-tests-pr.yml
@@ -11,20 +11,13 @@ concurrency:
 jobs:
   eligibility_check:
     name: Check Run Eligibility
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/check-run-eligibility.yml
     if: github.event.review.state == 'approved'
-    outputs:
-      should_run: ${{ steps.reusable_eligibility_check.outputs.conditions_met_for_gated_jobs }}
-      is_community_pr: ${{ steps.reusable_eligibility_check.outputs.is_community_pr }}
-    steps:
-      - name: Call Reusable Eligibility Check
-        id: reusable_eligibility_check
-        uses: ./.github/workflows/check-run-eligibility.yml
-        with:
-          pr_base_ref: ${{ github.event.pull_request.base.ref }}
-          pr_head_sha: ${{ github.event.pull_request.head.sha }}
-          pr_head_repo_full_name: ${{ github.event.pull_request.head.repo.full_name }}
-          is_pr_approved_by_maintainer: ${{ github.event.review.state == 'approved' }}
+    with:
+      pr_base_ref: ${{ github.event.pull_request.base.ref }}
+      pr_head_sha: ${{ github.event.pull_request.head.sha }}
+      pr_head_repo_full_name: ${{ github.event.pull_request.head.repo.full_name }}
+      is_pr_approved_by_maintainer: ${{ github.event.review.state == 'approved' }}
 
   run-e2e-tests:
     name: E2E [Electron/Node 18]

--- a/.github/workflows/test-workflows-pr-approved.yml
+++ b/.github/workflows/test-workflows-pr-approved.yml
@@ -6,12 +6,25 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
-  run_workflow_tests_after_approval:
-    name: Run Tests on Approved PR
+  eligibility_check:
+    name: Check Eligibility for Test Run
     if: github.event.review.state == 'approved'
+    uses: ./.github/workflows/check-run-eligibility.yml
+    with:
+      pr_base_ref: ${{ github.event.pull_request.base.ref }}
+      pr_head_sha: ${{ github.event.pull_request.head.sha }}
+      pr_head_repo_full_name: ${{ github.event.pull_request.head.repo.full_name }}
+      is_pr_approved_by_maintainer: ${{ github.event.review.state == 'approved' }}
+
+  run_workflow_tests:
+    name: Run Tests on Approved Internal PR
+    needs: [eligibility_check]
+    if: >
+      needs.eligibility_check.result != 'skipped' &&
+      needs.eligibility_check.outputs.conditions_met_for_gated_jobs == 'true' &&
+      needs.eligibility_check.outputs.is_community_pr == 'false'
     uses: ./.github/workflows/test-workflows-callable.yml
     with:
       git_ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/test-workflows-pr-approved.yml
+++ b/.github/workflows/test-workflows-pr-approved.yml
@@ -13,15 +13,12 @@ jobs:
     if: github.event.review.state == 'approved'
     uses: ./.github/workflows/check-run-eligibility.yml
     with:
-      pr_base_ref: ${{ github.event.pull_request.base.ref }}
-      pr_head_sha: ${{ github.event.pull_request.head.sha }}
-      pr_head_repo_full_name: ${{ github.event.pull_request.head.repo.full_name }}
-      is_pr_approved_by_maintainer: ${{ github.event.review.state == 'approved' }}
+      is_pr_approved_by_maintainer: true
 
   run_workflow_tests:
     name: Run Tests on Approved Internal PR
     needs: [eligibility_check]
-    if: ${{ needs.eligibility_check.result != 'skipped' && needs.eligibility_check.outputs.conditions_met_for_gated_jobs == 'true' && needs.eligibility_check.outputs.is_community_pr == 'false' }}
+    if: needs.eligibility_check.outputs.should_run == 'true'
     uses: ./.github/workflows/test-workflows-callable.yml
     with:
       git_ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/test-workflows-pr-approved.yml
+++ b/.github/workflows/test-workflows-pr-approved.yml
@@ -21,10 +21,7 @@ jobs:
   run_workflow_tests:
     name: Run Tests on Approved Internal PR
     needs: [eligibility_check]
-    if: >
-      needs.eligibility_check.result != 'skipped' &&
-      needs.eligibility_check.outputs.conditions_met_for_gated_jobs == 'true' &&
-      needs.eligibility_check.outputs.is_community_pr == 'false'
+    if: ${{ needs.eligibility_check.result != 'skipped' && needs.eligibility_check.outputs.conditions_met_for_gated_jobs == 'true' && needs.eligibility_check.outputs.is_community_pr == 'false' }}
     uses: ./.github/workflows/test-workflows-callable.yml
     with:
       git_ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
Introduces a reusable workflow (`check-run-eligibility.yml`) to standardize the logic for determining if PR-triggered jobs should run.

Integrated this new eligibility check into:
- `PR E2E` workflow (replacing the `get-metadata` job)
- `Test Workflows on PR Approval` workflow

## Summary

https://linear.app/n8n/issue/CAT-851/ci-reuse-gated-pr-checks-for-workflow-tests

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
