### PR TITLE
fix(core): Use destination node to select the correct pinned trigger to start from

### DIFF
--- a/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
@@ -433,7 +433,7 @@ describe('WorkflowExecutionService', () => {
 			expect(node).toEqual(webhookNode);
 		});
 
-		it('should favor first webhook node over second webhook node', () => {
+		it('should favor webhook node connected to the destination node', () => {
 			workflow.nodes.push(webhookNode, secondWebhookNode, hackerNewsNode, secondHackerNewsNode);
 			workflow.connections = {
 				...createMainConnection(webhookNode.name, hackerNewsNode.name),

--- a/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
@@ -1,6 +1,13 @@
 import type { User } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
-import type { INode, IWorkflowBase, INodeType, IWorkflowExecuteAdditionalData } from 'n8n-workflow';
+import {
+	NodeConnectionTypes,
+	type IConnections,
+	type INode,
+	type INodeType,
+	type IWorkflowBase,
+	type IWorkflowExecuteAdditionalData,
+} from 'n8n-workflow';
 
 import type { NodeTypes } from '@/node-types';
 import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
@@ -47,6 +54,15 @@ const hackerNewsNode: INode = {
 	name: 'Hacker News',
 	type: 'n8n-nodes-base.hackerNews',
 	id: '55d63bca-bb6c-4568-948f-8ed9aacb1fe9',
+	parameters: {},
+	typeVersion: 1,
+	position: [0, 0],
+};
+
+const secondHackerNewsNode: INode = {
+	name: 'Hacker News 2',
+	type: 'n8n-nodes-base.hackerNews',
+	id: '55d63bca-bb6c-4568-948f-8ed9aacb1fe3',
 	parameters: {},
 	typeVersion: 1,
 	position: [0, 0],
@@ -417,6 +433,23 @@ describe('WorkflowExecutionService', () => {
 			expect(node).toEqual(webhookNode);
 		});
 
+		it('should favor first webhook node over second webhook node', () => {
+			workflow.nodes.push(webhookNode, secondWebhookNode, hackerNewsNode, secondHackerNewsNode);
+			workflow.connections = {
+				...createMainConnection(webhookNode.name, hackerNewsNode.name),
+				...createMainConnection(secondWebhookNode.name, secondHackerNewsNode.name),
+			};
+
+			const node = workflowExecutionService.selectPinnedActivatorStarter(
+				workflow,
+				[],
+				{ ...pinData, [secondWebhookNode.name]: [{ json: { key: 'value' } }] },
+				secondHackerNewsNode.name,
+			);
+
+			expect(node).toEqual(secondWebhookNode);
+		});
+
 		describe('offloading manual executions to workers', () => {
 			test('when receiving no `runData`, should set `runData` to undefined in `executionData`', async () => {
 				const originalEnv = process.env;
@@ -458,3 +491,19 @@ describe('WorkflowExecutionService', () => {
 		});
 	});
 });
+
+function createMainConnection(targetNode: string, sourceNode: string): IConnections {
+	return {
+		[sourceNode]: {
+			[NodeConnectionTypes.Main]: [
+				[
+					{
+						node: targetNode,
+						type: 'main',
+						index: 0,
+					},
+				],
+			],
+		},
+	};
+}


### PR DESCRIPTION
## Summary

If there is a destination node, find the pinned activator that is a parent of the destination node

<img width="674" alt="image" src="https://github.com/user-attachments/assets/ac723479-33a5-4bd3-a65c-b46460f0fa70" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-2347/manual-execution-waits-for-webhook-even-though-data-is-pinned

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
