### PR TITLE
build: Prettify schema.json using the correct config

### DIFF
--- a/packages/@n8n/extension-sdk/schema.json
+++ b/packages/@n8n/extension-sdk/schema.json
@@ -1,68 +1,29 @@
 {
 	"type": "object",
 	"properties": {
-		"name": {
-			"type": "string"
-		},
-		"displayName": {
-			"type": "string"
-		},
-		"description": {
-			"type": "string"
-		},
-		"publisher": {
-			"type": "string"
-		},
-		"version": {
-			"type": "string"
-		},
-		"categories": {
-			"type": "array",
-			"items": {
-				"type": "string"
-			}
-		},
+		"name": { "type": "string" },
+		"displayName": { "type": "string" },
+		"description": { "type": "string" },
+		"publisher": { "type": "string" },
+		"version": { "type": "string" },
+		"categories": { "type": "array", "items": { "type": "string" } },
 		"entry": {
 			"type": "object",
-			"properties": {
-				"backend": {
-					"type": "string"
-				},
-				"frontend": {
-					"type": "string"
-				}
-			},
+			"properties": { "backend": { "type": "string" }, "frontend": { "type": "string" } },
 			"required": ["backend", "frontend"],
 			"additionalProperties": false
 		},
-		"minSDKVersion": {
-			"type": "string"
-		},
+		"minSDKVersion": { "type": "string" },
 		"permissions": {
 			"type": "object",
 			"properties": {
-				"frontend": {
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				},
-				"backend": {
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				}
+				"frontend": { "type": "array", "items": { "type": "string" } },
+				"backend": { "type": "array", "items": { "type": "string" } }
 			},
 			"required": ["frontend", "backend"],
 			"additionalProperties": false
 		},
-		"events": {
-			"type": "array",
-			"items": {
-				"type": "string"
-			}
-		},
+		"events": { "type": "array", "items": { "type": "string" } },
 		"extends": {
 			"type": "object",
 			"properties": {
@@ -71,11 +32,7 @@
 					"properties": {
 						"workflows": {
 							"type": "object",
-							"properties": {
-								"header": {
-									"type": "string"
-								}
-							},
+							"properties": { "header": { "type": "string" } },
 							"required": ["header"],
 							"additionalProperties": false
 						}

--- a/packages/@n8n/extension-sdk/scripts/create-json-schema.ts
+++ b/packages/@n8n/extension-sdk/scripts/create-json-schema.ts
@@ -3,7 +3,7 @@ import { zodToJsonSchema } from 'zod-to-json-schema';
 import { writeFile } from 'fs/promises';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
-import { format } from 'prettier';
+import { format, resolveConfig } from 'prettier';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = resolve(__dirname, '..');
@@ -15,7 +15,8 @@ const jsonSchema = zodToJsonSchema(extensionManifestSchema, {
 
 (async () => {
 	const filepath = 'schema.json';
-	const schema = JSON.stringify(jsonSchema, null, 2);
-	const formattedSchema = await format(schema, { filepath: filepath });
+	const schema = JSON.stringify(jsonSchema);
+	const config = await resolveConfig(filepath);
+	const formattedSchema = await format(schema, { ...config, filepath });
 	await writeFile(resolve(rootDir, filepath), formattedSchema);
 })();


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Follow up for https://github.com/n8n-io/n8n/pull/15600
That PR was not using the correct config. By default `format` uses the default config, not the one in the repository. That leads to the editor and the `pnpm build` formatting differently.
This PR fixes this.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] ~Tests included.~ <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
