### PR TITLE
chore: Fix flaky UI test for projects (no-changelog)

### DIFF
--- a/cypress/e2e/39-projects.cy.ts
+++ b/cypress/e2e/39-projects.cy.ts
@@ -301,12 +301,18 @@ describe('Projects', { disableAutoLogin: true }, () => {
 
 			// This mock fails when running with `test:e2e:dev` but works with `test:e2e:ui`,
 			// at least on macOS at version 1.94.0. ¯\_(ツ)_/¯
-			cy.window().then((win) => cy.stub(win, 'open').callsFake((url) => cy.visit(url)));
+			let openedUrl = '';
+			cy.window().then((win) => cy.stub(win, 'open').callsFake((url) => (openedUrl = url)));
 
 			selectResourceLocatorAddResourceItem('workflowId', 'Create a');
-			// Need to wait for the trigger node to auto-open after a delay
-			getNdvContainer().should('be.visible');
-			cy.get('body').type('{esc}');
+			cy.then(() =>
+				cy.visit(openedUrl).then(() => {
+					// Need to wait for the trigger node to auto-open after a delay
+					cy.get('[data-test-id="ndv-modal"]', { timeout: 10000 }).should('be.visible');
+					cy.get('body').type('{esc}');
+					cy.get('[data-test-id="ndv-modal"]').should('not.exist');
+				}),
+			);
 			workflowPage.actions.addNodeToCanvas(NOTION_NODE_NAME, true, true);
 			clickCreateNewCredential();
 			setCredentialValues({


### PR DESCRIPTION
## Summary
This PR Fixes the UI flaky test for [this](https://cloud.cypress.io/projects/5hbsdn/analytics/flaky-tests/1b1ff40b-7998-7393-7c33-a871d7529578-31b95ef1-c835-3185-cbf3-743a47d47a42?branches=%5B%5D&browsers=%5B%5D&chartRangeMostCommonErrors=%5B%5D&chartRangeSlowestTests=%5B%5D&chartRangeTopFailures=%5B%5D&committers=%5B%5D&cypressVersions=%5B%5D&flaky=%5B%5D&operatingSystems=%5B%5D&runGroups=%5B%5D&specFiles=%5B%5D&status=%5B%7B%22label%22%3A%22Passed%22%2C%22value%22%3A%22PASSED%22%7D%2C%7B%22label%22%3A%22Failed%22%2C%22value%22%3A%22FAILED%22%7D%5D&tags=%5B%5D&tagsMatch=ANY&timeInterval=WEEK&timeRange=%7B%22startDate%22%3A%222025-05-05%22%2C%22endDate%22%3A%222025-05-12%22%7D&viewBy=TEST_CASE)
for same reason NDV for Execute workflow Node opens while the notion node is being added which causes the test to fail sometimes
## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/PAY-2815/flaky-ui-projects-when-starting-from-scratch-should-create-sub


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
