### PR TITLE
fix(core): Resolves response promise for active execution on job finished in queue mode

### DIFF
--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -305,6 +305,7 @@ export class ScalingService {
 					this.activeExecutions.resolveResponsePromise(msg.executionId, decodedResponse);
 					break;
 				case 'job-finished':
+					this.activeExecutions.resolveResponsePromise(msg.executionId, {});
 					this.logger.info(`Execution ${msg.executionId} (job ${jobId}) finished successfully`, {
 						workerId: msg.workerId,
 						executionId: msg.executionId,

--- a/packages/cli/src/webhooks/__tests__/webhook-helpers.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-helpers.test.ts
@@ -64,6 +64,24 @@ describe('autoDetectResponseMode', () => {
 		expect(result).toBe('responseNode');
 	});
 
+	test('should return formPage when start node is FORM_NODE_TYPE and method is POST and there is a following FORM_NODE_TYPE node', () => {
+		const workflowStartNode = mock<INode>({
+			type: FORM_NODE_TYPE,
+			name: 'startNode',
+			parameters: {},
+		});
+		workflow.getChildNodes.mockReturnValue(['childNode']);
+		workflow.nodes.childNode = mock<INode>({
+			type: FORM_NODE_TYPE,
+			parameters: {
+				operation: 'completion',
+			},
+			disabled: false,
+		});
+		const result = autoDetectResponseMode(workflowStartNode, workflow, 'POST');
+		expect(result).toBe('formPage');
+	});
+
 	test('should return undefined when start node is FORM_NODE_TYPE with no other form child nodes', () => {
 		const workflowStartNode = mock<INode>({
 			type: FORM_NODE_TYPE,

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -104,6 +104,7 @@ export function getWorkflowWebhooks(
 	return returnData;
 }
 
+// eslint-disable-next-line complexity
 export function autoDetectResponseMode(
 	workflowStartNode: INode,
 	workflow: Workflow,
@@ -120,6 +121,21 @@ export function autoDetectResponseMode(
 			}
 
 			if ([FORM_NODE_TYPE, WAIT_NODE_TYPE].includes(node.type) && !node.disabled) {
+				return 'formPage';
+			}
+		}
+	}
+
+	// If there are form nodes connected to a current form node we're dealing with a multipage form
+	// and we need to return the formPage response mode when a second page of the form gets submitted
+	// to be able to show potential form errors correctly.
+	if (workflowStartNode.type === FORM_NODE_TYPE && method === 'POST') {
+		const connectedNodes = workflow.getChildNodes(workflowStartNode.name);
+
+		for (const nodeName of connectedNodes) {
+			const node = workflow.nodes[nodeName];
+
+			if (node.type === FORM_NODE_TYPE && !node.disabled) {
 				return 'formPage';
 			}
 		}

--- a/packages/cli/templates/form-trigger.handlebars
+++ b/packages/cli/templates/form-trigger.handlebars
@@ -857,9 +857,7 @@
 					document.querySelector('#submit-btn span').style.display = 'inline-block';
 
 					let postUrl = '';
-					if (window.location.href.includes('form-waiting')) {
-						intervalId = setTimeout(checkExecutionStatus, interval);
-					} else {
+					if (!window.location.href.includes('form-waiting')) {
 						postUrl = window.location.search;
 					}
 
@@ -880,7 +878,8 @@
 
 								if(json?.formWaitingUrl) {
 									formWaitingUrl = json.formWaitingUrl;
-									intervalId = setTimeout(checkExecutionStatus, interval);
+									clearTimeout(timeoutId);
+									timeoutId = setTimeout(checkExecutionStatus, interval);
 									return;
 								}
 
@@ -934,6 +933,12 @@
 						})
 						.catch(function (error) {
 							console.error('Error:', error);
+						})
+						.finally(() => {
+							if (window.location.href.includes('form-waiting')) {
+								clearTimeout(timeoutId);
+								timeoutId = setTimeout(checkExecutionStatus, interval);
+							}
 						});
 				}
 			});


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

On form submission in scaling mode, when the form trigger is followed by a form page, the second form submit "responsePromise" is never resolved, and the form post thus never resolves.
There is currently a workaround setup in the UI for this that fetches the execution data to know whether the job is finished or not, and update the form UI accordingly. But this comes with issues of its own, like this one: https://linear.app/n8n/issue/NODE-2557/form-node-form-shows-success-when-there-was-an-error

What we want to do is resolve the responsePromise when a form is submitted in queue mode, so that form submission properly finishes, and we can adapt the UI workaround to prevent race conditions: https://github.com/n8n-io/n8n/blob/master/packages/cli/templates/form-trigger.handlebars#L861

I need insights to know if resolving the response promise from the job-finished msg is safe enough though.
Also, we noticed that for webhooks (in queue mode), both messages are listened to ('responde-to-webhook' and 'job-finished'), meaning that the promise will be resolved twice. This seems fine but still..

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
