### PR TITLE
fix(editor): Display form errors when there are multiple form pages

### DIFF
--- a/packages/cli/src/webhooks/__tests__/webhook-helpers.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-helpers.test.ts
@@ -64,6 +64,24 @@ describe('autoDetectResponseMode', () => {
 		expect(result).toBe('responseNode');
 	});
 
+	test('should return formPage when start node is FORM_NODE_TYPE and method is POST and there is a following FORM_NODE_TYPE node', () => {
+		const workflowStartNode = mock<INode>({
+			type: FORM_NODE_TYPE,
+			name: 'startNode',
+			parameters: {},
+		});
+		workflow.getChildNodes.mockReturnValue(['childNode']);
+		workflow.nodes.childNode = mock<INode>({
+			type: FORM_NODE_TYPE,
+			parameters: {
+				operation: 'completion',
+			},
+			disabled: false,
+		});
+		const result = autoDetectResponseMode(workflowStartNode, workflow, 'POST');
+		expect(result).toBe('formPage');
+	});
+
 	test('should return undefined when start node is FORM_NODE_TYPE with no other form child nodes', () => {
 		const workflowStartNode = mock<INode>({
 			type: FORM_NODE_TYPE,

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -104,6 +104,7 @@ export function getWorkflowWebhooks(
 	return returnData;
 }
 
+// eslint-disable-next-line complexity
 export function autoDetectResponseMode(
 	workflowStartNode: INode,
 	workflow: Workflow,
@@ -120,6 +121,21 @@ export function autoDetectResponseMode(
 			}
 
 			if ([FORM_NODE_TYPE, WAIT_NODE_TYPE].includes(node.type) && !node.disabled) {
+				return 'formPage';
+			}
+		}
+	}
+
+	// If there are form nodes connected to a current form node we're dealing with a multipage form
+	// and we need to return the formPage response mode when a second page of the form gets submitted
+	// to be able to show potential form errors correctly.
+	if (workflowStartNode.type === FORM_NODE_TYPE && method === 'POST') {
+		const connectedNodes = workflow.getChildNodes(workflowStartNode.name);
+
+		for (const nodeName of connectedNodes) {
+			const node = workflow.nodes[nodeName];
+
+			if (node.type === FORM_NODE_TYPE && !node.disabled) {
 				return 'formPage';
 			}
 		}

--- a/packages/cli/templates/form-trigger.handlebars
+++ b/packages/cli/templates/form-trigger.handlebars
@@ -857,9 +857,7 @@
 					document.querySelector('#submit-btn span').style.display = 'inline-block';
 
 					let postUrl = '';
-					if (window.location.href.includes('form-waiting')) {
-						intervalId = setTimeout(checkExecutionStatus, interval);
-					} else {
+					if (!window.location.href.includes('form-waiting')) {
 						postUrl = window.location.search;
 					}
 
@@ -880,7 +878,8 @@
 
 								if(json?.formWaitingUrl) {
 									formWaitingUrl = json.formWaitingUrl;
-									intervalId = setTimeout(checkExecutionStatus, interval);
+									clearTimeout(timeoutId);
+									timeoutId = setTimeout(checkExecutionStatus, interval);
 									return;
 								}
 
@@ -934,6 +933,12 @@
 						})
 						.catch(function (error) {
 							console.error('Error:', error);
+						})
+						.finally(() => {
+							if (window.location.href.includes('form-waiting')) {
+								clearTimeout(timeoutId);
+								timeoutId = setTimeout(checkExecutionStatus, interval);
+							}
 						});
 				}
 			});


### PR DESCRIPTION
## Summary

If a form has multiple pages and an error happens between the pages and the end of the form the form wouldn't show any errors, and the user submitting the form wouldn't know that something went wrong.

This could happen with a simple setup like this

![image](https://github.com/user-attachments/assets/56b67bc7-1852-449b-854a-88f9ee3d49fd)

[form-error.json](https://github.com/user-attachments/files/20410859/form-error.json)

where the form fails between the second page and form end (or between first and second pages with no form end, same thing happens).

There was another problem with queue mode and forms that had been previously circumvented by making the UI poll for the form state,  but there were some problems in that implementation.

This PR fixes this by checking at `autoDetectResponseMode` if the current node is a form node, not just form trigger node and seeing if its connected to other following form (end) nodes, and staying in `formPage` mode if so.

Second part of the fix is not prematurely running the `checkExecutionStatus` checks, which lead to problems if form submission lasted for more than 1000ms. Moving that to only happen once the form has been submitted fixes that, and while at that fix the clearing of the interval (using wrong variable).

This fix requires PR https://github.com/n8n-io/n8n/pull/15643 to work in queue mode, which fixes form submission never responding in that mode.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
