### PR TITLE
fix: Memory node position on insert via plus icon

### DIFF
--- a/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
@@ -1022,6 +1022,12 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 
 				pushOffsets = [100, 0];
 
+				// FIXME: workaround to avoid the clash between memory node connection removal icon and parent node's next input connection icon
+				if (outputTypes.some((output) => output === NodeConnectionTypes.AiMemory)) {
+					pushOffsets = [40, 0];
+				}
+				// end of workaround
+
 				if (
 					outputTypes.length > 0 &&
 					outputTypes.every((outputName) => outputName !== NodeConnectionTypes.Main)


### PR DESCRIPTION
## Summary

For the Memory node the workaround was added, to push it's position right in smaller increments when conflicting with other nodes.

Before:

https://github.com/user-attachments/assets/7d13b06d-70eb-4e3a-980b-b11ab4c2bb81

After:

https://github.com/user-attachments/assets/7278a34b-30a0-4955-a3c2-9be247566b06



## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
