### PR TITLE
ci: Enforce codecov checks for node components (no-changelog)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,12 +7,7 @@ coverage:
     patch: false
     project:
       default:
-        threshold: 0.5%
-      nodes:
-        target: 80%
-        threshold: 0.5%
-        paths:
-          - packages/nodes-base/**
+        threshold: 0.5
 
 github_checks:
   annotations: false
@@ -61,6 +56,12 @@ component_management:
         - packages/nodes-base/**
         - packages/@n8n/json-schema-to-zod/**
         - packages/@n8n/nodes-langchain/**
+      statuses:
+        - type: project
+          target: auto
+          threshold: 0% # Enforce: Coverage must not decrease
+
+
 
 ignore:
   - (?s:.*/[^\/]*\.spec\.ts.*)\Z


### PR DESCRIPTION
This will stop any nodes components from being committed if they decrease the overall code coverage for the nodes components.

## Summary

https://linear.app/n8n/issue/CAT-856/nodes-enforce-code-coverage-checks

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
