### PR TITLE
fix(API): Include waiting executions in public

### DIFF
--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -381,7 +381,7 @@ export class ExecutionService {
 	 * control, "current" means executions enqueued to start and running.
 	 */
 	async findLatestCurrentAndCompleted(query: ExecutionSummaries.RangeQuery) {
-		const currentStatuses: ExecutionStatus[] = ['new', 'running'];
+		const currentStatuses: ExecutionStatus[] = ['new', 'running', 'waiting'];
 
 		const completedStatuses = ExecutionStatusList.filter((s) => !currentStatuses.includes(s));
 

--- a/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts
@@ -111,8 +111,10 @@ export = {
 			}
 
 			// get running workflows so we exclude them from the result
+			// but keep waiting executions as they should be visible in the API
 			const runningExecutionsIds = Container.get(ActiveExecutions)
 				.getActiveExecutions()
+				.filter(({ status }) => status !== 'waiting')
 				.map(({ id }) => id);
 
 			const filters = {


### PR DESCRIPTION
  API results

  The public API was incorrectly excluding waiting executions from
   results
  by treating them as 'running' executions. This fix ensures
  waiting
  executions appear in /api/v1/executions responses while still
  excluding
  truly running executions.

  - Filter out only non-waiting active executions in public API handler
  - Include 'waiting' status in currentStatuses for consistency
  - Add integration test for waiting executions handling

## Related Linear tickets, Github issues, and Community forum posts

Fixes [#14237](https://github.com/n8n-io/n8n/issues/14237)
  

## Summary
Fixes issue where the public API endpoint `/api/v1/executions`
  was not returning executions with "waiting" status.
![image](https://github.com/user-attachments/assets/236c085a-cd2f-44e8-9910-9ed1d7e57b27)

## Root Cause

  The public API handler was excluding ALL active executions
  (including waiting ones) from results by calling
  `getActiveExecutions()` and excluding those IDs. This was
  intended to hide truly running executions, but waiting
  executions should be visible as they are paused and waiting for
  external input.

## Changes

  1. **Primary Fix**: Modified public API handler to filter out
  only non-waiting active executions
  2. **Consistency Fix**: Updated internal execution service to
  include waiting executions as "current" status
  3. **Test Coverage**: Added integration test to verify waiting
  executions are properly handled

## Testing

  - [x] Added integration test `should treat waiting executions as
   current, not completed`
  - [x] Verified fix works in Docker environment
  - [x] All existing tests pass



