### PR TITLE
feat: Implement multipart upload for generic S3 node

### DIFF
--- a/packages/nodes-base/nodes/S3/__tests__/S3.multipartUpload.test.json
+++ b/packages/nodes-base/nodes/S3/__tests__/S3.multipartUpload.test.json
@@ -1,0 +1,54 @@
+{
+  "meta": {
+    "templateCredsSetupCompleted": true,
+    "instanceId": "testInstance"
+  },
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        240,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "resource": "file",
+        "operation": "upload",
+        "bucketName": "test-bucket",
+        "fileName": "large-test-file.bin",
+        "binaryData": true,
+        "binaryPropertyName": "data"
+      },
+      "name": "S3",
+      "type": "n8n-nodes-base.s3",
+      "typeVersion": 1,
+      "position": [
+        460,
+        300
+      ],
+      "credentials": {
+        "s3": {
+          "id": "s3-test-account",
+          "name": "S3 test account"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "S3",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Refactors the generic S3 node to support uploading files larger than 2GB by implementing multipart S3 uploads.

Key changes include:
- Added helper functions to `packages/nodes-base/nodes/S3/GenericFunctions.ts` for:
    - `s3CreateMultipartUpload`: Initiates a multipart upload.
    - `s3UploadPart`: Uploads individual file parts.
    - `s3CompleteMultipartUpload`: Completes the multipart upload.
    - `s3AbortMultipartUpload`: Aborts a multipart upload in case of errors.
- Modified `packages/nodes-base/nodes/S3/S3.node.ts`:
    - The `upload` operation now uses the new multipart functions when handling streamable binary data (`binaryData.id` is present).
    - It reads the file in chunks (`UPLOAD_CHUNK_SIZE` of 5MB) and uploads them sequentially.
    - Includes error handling to abort the multipart upload if any step fails.
    - The existing logic for non-streamable binary files and text-based uploads is preserved.
- Added new tests:
    - A workflow test (`S3.multipartUpload.test.json`) for large file uploads.
    - Unit tests in `GenericFunctions.test.ts` for the new multipart helper functions.

This change allows the generic S3 node to handle large file uploads efficiently without requiring the entire file to be loaded into memory, addressing the previous >2GB limitation.

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
