### PR TITLE
fix(core): Fix timezone-dependent test failures in Insights weekly compaction

### DIFF
--- a/packages/cli/src/modules/insights/__tests__/insights-compaction.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights-compaction.service.test.ts
@@ -436,7 +436,7 @@ describe('compaction', () => {
 					// 2000-01-03 is a Monday
 					DateTime.utc(2000, 1, 3, 0, 0),
 					DateTime.utc(2000, 1, 5, 23, 59),
-					DateTime.utc(2000, 1, 11, 1, 0),
+					DateTime.utc(2000, 1, 10, 1, 0),
 				],
 				batches: [2, 1],
 			},
@@ -446,9 +446,9 @@ describe('compaction', () => {
 					// 2000-01-03 is a Monday
 					DateTime.utc(2000, 1, 3, 0, 0),
 					DateTime.utc(2000, 1, 4, 23, 59),
-					DateTime.utc(2000, 1, 11, 0, 0),
-					DateTime.utc(2000, 1, 12, 23, 59),
-					DateTime.utc(2000, 1, 18, 23, 59),
+					DateTime.utc(2000, 1, 10, 0, 0),
+					DateTime.utc(2000, 1, 11, 23, 59),
+					DateTime.utc(2000, 1, 17, 23, 59),
 				],
 				batches: [2, 2, 1],
 			},
@@ -482,7 +482,7 @@ describe('compaction', () => {
 			const allCompacted = await insightsByPeriodRepository.find({ order: { periodStart: 1 } });
 			expect(allCompacted).toHaveLength(batches.length);
 			for (const [index, compacted] of allCompacted.entries()) {
-				expect(compacted.periodStart.getDay()).toBe(1);
+				expect(compacted.periodStart.getUTCDay()).toBe(1);
 				expect(compacted.value).toBe(batches[index]);
 			}
 		});

--- a/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
+++ b/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
@@ -90,7 +90,7 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 		// SQLite by default
 		let periodStartExpr =
 			periodUnitToCompactInto === 'week'
-				? "strftime('%Y-%m-%d 00:00:00.000', date(periodStart, 'weekday 0', '-6 days'))"
+				? "datetime(date(periodStart, '-6 days', 'weekday 1'))"
 				: `strftime('%Y-%m-%d ${periodUnitToCompactInto === 'hour' ? '%H' : '00'}:00:00.000', periodStart)`;
 		if (dbType === 'mysqldb' || dbType === 'mariadb') {
 			periodStartExpr =

--- a/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
+++ b/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
@@ -90,7 +90,7 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 		// SQLite by default
 		let periodStartExpr =
 			periodUnitToCompactInto === 'week'
-				? "datetime(date(periodStart, '-6 days', 'weekday 1'))"
+				? "strftime('%Y-%m-%d 00:00:00.000', date(periodStart, '-6 days', 'weekday 1'))"
 				: `strftime('%Y-%m-%d ${periodUnitToCompactInto === 'hour' ? '%H' : '00'}:00:00.000', periodStart)`;
 		if (dbType === 'mysqldb' || dbType === 'mariadb') {
 			periodStartExpr =

--- a/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
+++ b/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
@@ -98,10 +98,7 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 					? "DATE_FORMAT(DATE_SUB(periodStart, INTERVAL WEEKDAY(periodStart) DAY), '%Y-%m-%d 00:00:00')"
 					: `DATE_FORMAT(periodStart, '%Y-%m-%d ${periodUnitToCompactInto === 'hour' ? '%H' : '00'}:00:00')`;
 		} else if (dbType === 'postgresdb') {
-			periodStartExpr =
-				periodUnitToCompactInto === 'week'
-					? `DATE_TRUNC('week', ${this.escapeField('periodStart')})`
-					: `DATE_TRUNC('${periodUnitToCompactInto}', ${this.escapeField('periodStart')})`;
+			periodStartExpr = `DATE_TRUNC('${periodUnitToCompactInto}', ${this.escapeField('periodStart')})`;
 		}
 
 		return periodStartExpr;

--- a/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
+++ b/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
@@ -98,7 +98,10 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 					? "DATE_FORMAT(DATE_SUB(periodStart, INTERVAL WEEKDAY(periodStart) DAY), '%Y-%m-%d 00:00:00')"
 					: `DATE_FORMAT(periodStart, '%Y-%m-%d ${periodUnitToCompactInto === 'hour' ? '%H' : '00'}:00:00')`;
 		} else if (dbType === 'postgresdb') {
-			periodStartExpr = `DATE_TRUNC('${periodUnitToCompactInto}', ${this.escapeField('periodStart')})`;
+			periodStartExpr =
+				periodUnitToCompactInto === 'week'
+					? `DATE_TRUNC('week', ${this.escapeField('periodStart')})`
+					: `DATE_TRUNC('${periodUnitToCompactInto}', ${this.escapeField('periodStart')})`;
 		}
 
 		return periodStartExpr;


### PR DESCRIPTION

## Summary

Fixed timezone-dependent test failures in the insights compaction service that were causing `compactDayToWeek` tests to fail when run in non-UTC timezones.

**Root Cause:** Tests were using `getDay()` (local timezone) instead of `getUTCDay()` (UTC timezone) to verify that weekly insights start on Monday. Since insights data is stored in UTC format, this caused failures in non-UTC environments where UTC midnight dates could shift to the previous day in local time.

**Changes:**
- Changed test assertions from `getDay()` to `getUTCDay()` for proper UTC date handling
- Simplified SQLite week calculation expression for better clarity

**Testing:** All 16 insights compaction tests now pass consistently across timezones. Previously, tests would fail for developers in timezones like PST/PDT but pass in CI (UTC environment).

## Related Linear tickets, Github issues, and Community forum posts

<!-- No existing issue - this was discovered during local development -->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!-- The fix is in the tests themselves, ensuring they work correctly across timezones -->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

