### PR TITLE
fix(Jina AI Node): Default value for "Output format" option

### DIFF
--- a/packages/nodes-base/nodes/JinaAI/JinaAi.node.ts
+++ b/packages/nodes-base/nodes/JinaAI/JinaAi.node.ts
@@ -351,7 +351,7 @@ export class JinaAi implements INodeType {
 								value: 'text',
 							},
 						],
-						default: 'json',
+						default: '',
 					},
 					{
 						displayName: 'Site Filter',


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Update the default value of the "Output format" option to the correct value (empty string instead of `json`)

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-3027/jina-ai-node-incorrect-default-value-for-json-output-format-option

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
