### PR TITLE
feat(core): Validate commit content for project admin role

### DIFF
--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control-export.service.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control-export.service.test.ts
@@ -1,5 +1,6 @@
 import type { SourceControlledFile } from '@n8n/api-types';
-import { User, type SharedCredentials } from '@n8n/db';
+import { User } from '@n8n/db';
+import type { SharedCredentials } from '@n8n/db';
 import type { SharedWorkflow } from '@n8n/db';
 import type { FolderRepository } from '@n8n/db';
 import type { TagRepository } from '@n8n/db';
@@ -17,13 +18,13 @@ import { SourceControlExportService } from '../source-control-export.service.ee'
 import type { SourceControlScopedService } from '../source-control-scoped.service';
 import { SourceControlContext } from '../types/source-control-context';
 
-const globalAdminContext = new SourceControlContext(
-	Object.assign(new User(), {
-		role: 'global:admin',
-	}),
-);
-
 describe('SourceControlExportService', () => {
+	const globalAdminContext = new SourceControlContext(
+		Object.assign(new User(), {
+			role: 'global:admin',
+		}),
+	);
+
 	const cipher = Container.get(Cipher);
 	const sharedCredentialsRepository = mock<SharedCredentialsRepository>();
 	const sharedWorkflowRepository = mock<SharedWorkflowRepository>();

--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control-export.service.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control-export.service.test.ts
@@ -1,5 +1,5 @@
 import type { SourceControlledFile } from '@n8n/api-types';
-import type { SharedCredentials } from '@n8n/db';
+import { User, type SharedCredentials } from '@n8n/db';
 import type { SharedWorkflow } from '@n8n/db';
 import type { FolderRepository } from '@n8n/db';
 import type { TagRepository } from '@n8n/db';
@@ -14,6 +14,20 @@ import fsp from 'node:fs/promises';
 
 import type { VariablesService } from '../../variables/variables.service.ee';
 import { SourceControlExportService } from '../source-control-export.service.ee';
+import type { SourceControlScopedService } from '../source-control-scoped.service';
+import { SourceControlContext } from '../types/source-control-context';
+
+const globalAdminContext = new SourceControlContext(
+	Object.assign(new User(), {
+		role: 'global:admin',
+	}),
+);
+
+const globalMemberContext = new SourceControlContext(
+	Object.assign(new User(), {
+		role: 'global:member',
+	}),
+);
 
 describe('SourceControlExportService', () => {
 	const cipher = Container.get(Cipher);
@@ -24,6 +38,7 @@ describe('SourceControlExportService', () => {
 	const workflowTagMappingRepository = mock<WorkflowTagMappingRepository>();
 	const variablesService = mock<VariablesService>();
 	const folderRepository = mock<FolderRepository>();
+	const sourceControlScopedService = mock<SourceControlScopedService>();
 
 	const service = new SourceControlExportService(
 		mock(),
@@ -34,6 +49,7 @@ describe('SourceControlExportService', () => {
 		workflowRepository,
 		workflowTagMappingRepository,
 		folderRepository,
+		sourceControlScopedService,
 		mock<InstanceSettings>({ n8nFolder: '/mock/n8n' }),
 	);
 
@@ -172,7 +188,7 @@ describe('SourceControlExportService', () => {
 			workflowTagMappingRepository.find.mockResolvedValue([mock()]);
 
 			// Act
-			const result = await service.exportTagsToWorkFolder();
+			const result = await service.exportTagsToWorkFolder(globalAdminContext);
 
 			// Assert
 			expect(result.count).toBe(1);
@@ -184,7 +200,7 @@ describe('SourceControlExportService', () => {
 			tagRepository.find.mockResolvedValue([]);
 
 			// Act
-			const result = await service.exportTagsToWorkFolder();
+			const result = await service.exportTagsToWorkFolder(globalAdminContext);
 
 			// Assert
 			expect(result.count).toBe(0);
@@ -201,7 +217,7 @@ describe('SourceControlExportService', () => {
 			workflowRepository.find.mockResolvedValue([mock()]);
 
 			// Act
-			const result = await service.exportFoldersToWorkFolder();
+			const result = await service.exportFoldersToWorkFolder(globalAdminContext);
 
 			// Assert
 			expect(result.count).toBe(1);
@@ -213,7 +229,7 @@ describe('SourceControlExportService', () => {
 			folderRepository.find.mockResolvedValue([]);
 
 			// Act
-			const result = await service.exportFoldersToWorkFolder();
+			const result = await service.exportFoldersToWorkFolder(globalAdminContext);
 
 			// Assert
 			expect(result.count).toBe(0);

--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control-export.service.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control-export.service.test.ts
@@ -23,12 +23,6 @@ const globalAdminContext = new SourceControlContext(
 	}),
 );
 
-const globalMemberContext = new SourceControlContext(
-	Object.assign(new User(), {
-		role: 'global:member',
-	}),
-);
-
 describe('SourceControlExportService', () => {
 	const cipher = Container.get(Cipher);
 	const sharedCredentialsRepository = mock<SharedCredentialsRepository>();

--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control.controller.ee.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control.controller.ee.test.ts
@@ -31,6 +31,7 @@ describe('SourceControlController', () => {
 		controller = new SourceControlController(
 			sourceControlService,
 			sourceControlPreferencesService,
+			mock(),
 			eventService,
 		);
 	});

--- a/packages/cli/src/environments.ee/source-control/source-control-export.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-export.service.ee.ts
@@ -256,14 +256,14 @@ export class SourceControlExportService {
 
 			// keep all folders that are not accessible by the current user
 			// if allowedProjects is undefined, all folders are accessible by the current user
-			const newFolders =
+			const foldersToKeepUnchanged =
 				allowedProjects === undefined
 					? []
 					: existingFolders.folders.filter((folder) => {
 							return !allowedProjects.some((project) => project.id === folder.homeProjectId);
 						});
 
-			newFolders.push(
+			const newFolders = foldersToKeepUnchanged.concat(
 				...folders.map((f) => ({
 					id: f.id,
 					name: f.name,

--- a/packages/cli/src/environments.ee/source-control/source-control-export.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-export.service.ee.ts
@@ -1,6 +1,6 @@
 import type { SourceControlledFile } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
-import type { IWorkflowDb, TagEntity, WorkflowTagMapping } from '@n8n/db';
+import type { IWorkflowDb } from '@n8n/db';
 import {
 	FolderRepository,
 	TagRepository,
@@ -252,31 +252,14 @@ export class SourceControlExportService {
 
 			const fileName = getFoldersPath(this.gitFolder);
 
-			let existingFolders: {
-				folders: Array<{
-					id: string;
-					name: string;
-					parentFolderId: null | string;
-					homeProjectId: string;
-					createdAt: string;
-					updatedAt: string;
-				}>;
-			} = {
-				folders: [],
-			};
-
-			try {
-				existingFolders = await readFoldersFromSourceControlFile(fileName);
-			} catch (error) {
-				this.logger.info('Failed to read folders file from git', error);
-			}
+			const existingFolders = await readFoldersFromSourceControlFile(fileName);
 
 			// keep all folders that are not accessible by the current user
 			// if allowedProjects is undefined, all folders are accessible by the current user
 			const newFolders =
 				allowedProjects === undefined
 					? []
-					: (existingFolders.folders || []).filter((folder) => {
+					: existingFolders.folders.filter((folder) => {
 							return !allowedProjects.some((project) => project.id === folder.homeProjectId);
 						});
 
@@ -339,24 +322,14 @@ export class SourceControlExportService {
 					this.sourceControlScopedService.getWorkflowsInAdminProjectsFromContextFilter(context),
 			});
 			const fileName = path.join(this.gitFolder, SOURCE_CONTROL_TAGS_EXPORT_FILE);
-			let existingTagsAndMapping: {
-				tags: TagEntity[];
-				mappings: WorkflowTagMapping[];
-			} = { tags: [], mappings: [] };
-			try {
-				// read the existing git file
-				existingTagsAndMapping = await readTagAndMappingsFromSourceControlFile(fileName);
-			} catch (error) {
-				this.logger.info('Failed to read tags file', error);
-			}
+			const existingTagsAndMapping = await readTagAndMappingsFromSourceControlFile(fileName);
 
 			// keep all mappings that are not accessible by the current user
-			const mappingsToKeep =
-				(existingTagsAndMapping?.mappings || []).filter((mapping) => {
-					return !allowedWorkflows.some(
-						(allowedWorkflow) => allowedWorkflow.id === mapping.workflowId,
-					);
-				}) ?? [];
+			const mappingsToKeep = existingTagsAndMapping.mappings.filter((mapping) => {
+				return !allowedWorkflows.some(
+					(allowedWorkflow) => allowedWorkflow.id === mapping.workflowId,
+				);
+			});
 
 			await fsWriteFile(
 				fileName,
@@ -364,7 +337,7 @@ export class SourceControlExportService {
 					{
 						// overwrite all tags
 						tags: tags.map((tag) => ({ id: tag.id, name: tag.name })),
-						mappings: (mappingsToKeep || []).concat(mappingsOfAllowedWorkflows),
+						mappings: mappingsToKeep.concat(mappingsOfAllowedWorkflows),
 					},
 					null,
 					2,

--- a/packages/cli/src/environments.ee/source-control/source-control-export.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-export.service.ee.ts
@@ -31,6 +31,7 @@ import {
 	getFoldersPath,
 	getVariablesPath,
 	getWorkflowExportPath,
+	readTagAndMappingsFromSourceControlFile,
 	sourceControlFoldersExistCheck,
 	stringContainsExpression,
 } from './source-control-helper.ee';
@@ -39,6 +40,8 @@ import type { ExportableCredential } from './types/exportable-credential';
 import type { ExportableWorkflow } from './types/exportable-workflow';
 import type { ResourceOwner } from './types/resource-owner';
 import { VariablesService } from '../variables/variables.service.ee';
+import { SourceControlContext } from './types/source-control-context';
+import { SourceControlScopedService } from './source-control-scoped.service';
 
 @Service()
 export class SourceControlExportService {
@@ -57,6 +60,7 @@ export class SourceControlExportService {
 		private readonly workflowRepository: WorkflowRepository,
 		private readonly workflowTagMappingRepository: WorkflowTagMappingRepository,
 		private readonly folderRepository: FolderRepository,
+		private readonly sourceControlScopedService: SourceControlScopedService,
 		instanceSettings: InstanceSettings,
 	) {
 		this.gitFolder = path.join(instanceSettings.n8nFolder, SOURCE_CONTROL_GIT_FOLDER);
@@ -214,7 +218,7 @@ export class SourceControlExportService {
 		}
 	}
 
-	async exportFoldersToWorkFolder(): Promise<ExportResult> {
+	async exportFoldersToWorkFolder(context: SourceControlContext): Promise<ExportResult> {
 		try {
 			sourceControlFoldersExistCheck([this.gitFolder]);
 			const folders = await this.folderRepository.find({
@@ -274,7 +278,7 @@ export class SourceControlExportService {
 		}
 	}
 
-	async exportTagsToWorkFolder(): Promise<ExportResult> {
+	async exportTagsToWorkFolder(context: SourceControlContext): Promise<ExportResult> {
 		try {
 			sourceControlFoldersExistCheck([this.gitFolder]);
 			const tags = await this.tagRepository.find();
@@ -286,14 +290,34 @@ export class SourceControlExportService {
 					files: [],
 				};
 			}
-			const mappings = await this.workflowTagMappingRepository.find();
+			const mappings = await this.workflowTagMappingRepository.find({
+				where:
+					this.sourceControlScopedService.getWorkflowTagMappingInAdminProjectsFromContextFilter(
+						context,
+					),
+			});
+			const allowedWorkflows = await this.workflowRepository.find({
+				where:
+					this.sourceControlScopedService.getWorkflowsInAdminProjectsFromContextFilter(context),
+			});
 			const fileName = path.join(this.gitFolder, SOURCE_CONTROL_TAGS_EXPORT_FILE);
+			// read the existing git file
+			const existingTagsAndMapping = await readTagAndMappingsFromSourceControlFile(fileName);
+			// keep all mappings that are not accessible by the current user
+			const newMappings = existingTagsAndMapping.mappings.filter((mapping) => {
+				return !allowedWorkflows.some(
+					(allowedWorkflow) => allowedWorkflow.id === mapping.workflowId,
+				);
+			});
+			// add mappings the user has access too
+			newMappings.push(...mappings);
 			await fsWriteFile(
 				fileName,
 				JSON.stringify(
 					{
+						// overwrite all tags
 						tags: tags.map((tag) => ({ id: tag.id, name: tag.name })),
-						mappings,
+						mappings: newMappings,
 					},
 					null,
 					2,

--- a/packages/cli/src/environments.ee/source-control/source-control-helper.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-helper.ee.ts
@@ -59,6 +59,28 @@ export async function readTagAndMappingsFromSourceControlFile(file: string): Pro
 	);
 }
 
+export async function readFoldersFromSourceControlFile(file: string): Promise<{
+	folders: Array<{
+		id: string;
+		name: string;
+		parentFolderId: null | string;
+		homeProjectId: string;
+		createdAt: string;
+		updatedAt: string;
+	}>;
+}> {
+	return jsonParse<{
+		folders: Array<{
+			id: string;
+			name: string;
+			parentFolderId: null | string;
+			homeProjectId: string;
+			createdAt: string;
+			updatedAt: string;
+		}>;
+	}>(await fsReadFile(file, { encoding: 'utf8' }), { fallbackValue: { folders: [] } });
+}
+
 export function sourceControlFoldersExistCheck(
 	folders: string[],
 	createIfNotExists = true,

--- a/packages/cli/src/environments.ee/source-control/source-control-helper.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-helper.ee.ts
@@ -1,10 +1,12 @@
 import type { SourceControlledFile } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
+import type { TagEntity, WorkflowTagMapping } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { generateKeyPairSync } from 'crypto';
 import { constants as fsConstants, mkdirSync, accessSync } from 'fs';
-import { UserError } from 'n8n-workflow';
+import { jsonParse, UserError } from 'n8n-workflow';
 import { ok } from 'node:assert/strict';
+import { readFile as fsReadFile } from 'node:fs/promises';
 import path from 'path';
 
 import { License } from '@/license';
@@ -45,6 +47,16 @@ export function getTagsPath(gitFolder: string): string {
 
 export function getFoldersPath(gitFolder: string): string {
 	return path.join(gitFolder, SOURCE_CONTROL_FOLDERS_EXPORT_FILE);
+}
+
+export async function readTagAndMappingsFromSourceControlFile(file: string): Promise<{
+	tags: TagEntity[];
+	mappings: WorkflowTagMapping[];
+}> {
+	return jsonParse<{ tags: TagEntity[]; mappings: WorkflowTagMapping[] }>(
+		await fsReadFile(file, { encoding: 'utf8' }),
+		{ fallbackValue: { tags: [], mappings: [] } },
+	);
 }
 
 export function sourceControlFoldersExistCheck(

--- a/packages/cli/src/environments.ee/source-control/source-control-helper.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-helper.ee.ts
@@ -22,8 +22,6 @@ import type { ExportedFolders } from './types/exportable-folders';
 import type { KeyPair } from './types/key-pair';
 import type { KeyPairType } from './types/key-pair-type';
 import type { SourceControlWorkflowVersionId } from './types/source-control-workflow-version-id';
-import { AuthenticatedRequest } from '@/requests';
-import { hasGlobalScope } from '@n8n/permissions';
 
 export function stringContainsExpression(testString: string): boolean {
 	return /^=.*\{\{.*\}\}/.test(testString);

--- a/packages/cli/src/environments.ee/source-control/source-control-helper.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-helper.ee.ts
@@ -18,9 +18,12 @@ import {
 	SOURCE_CONTROL_TAGS_EXPORT_FILE,
 	SOURCE_CONTROL_VARIABLES_EXPORT_FILE,
 } from './constants';
+import type { ExportedFolders } from './types/exportable-folders';
 import type { KeyPair } from './types/key-pair';
 import type { KeyPairType } from './types/key-pair-type';
 import type { SourceControlWorkflowVersionId } from './types/source-control-workflow-version-id';
+import { AuthenticatedRequest } from '@/requests';
+import { hasGlobalScope } from '@n8n/permissions';
 
 export function stringContainsExpression(testString: string): boolean {
 	return /^=.*\{\{.*\}\}/.test(testString);
@@ -59,26 +62,10 @@ export async function readTagAndMappingsFromSourceControlFile(file: string): Pro
 	);
 }
 
-export async function readFoldersFromSourceControlFile(file: string): Promise<{
-	folders: Array<{
-		id: string;
-		name: string;
-		parentFolderId: null | string;
-		homeProjectId: string;
-		createdAt: string;
-		updatedAt: string;
-	}>;
-}> {
-	return jsonParse<{
-		folders: Array<{
-			id: string;
-			name: string;
-			parentFolderId: null | string;
-			homeProjectId: string;
-			createdAt: string;
-			updatedAt: string;
-		}>;
-	}>(await fsReadFile(file, { encoding: 'utf8' }), { fallbackValue: { folders: [] } });
+export async function readFoldersFromSourceControlFile(file: string): Promise<ExportedFolders> {
+	return jsonParse<ExportedFolders>(await fsReadFile(file, { encoding: 'utf8' }), {
+		fallbackValue: { folders: [] },
+	});
 }
 
 export function sourceControlFoldersExistCheck(

--- a/packages/cli/src/environments.ee/source-control/source-control-scoped.service.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-scoped.service.ts
@@ -73,10 +73,10 @@ export class SourceControlScopedService {
 
 	getFoldersInAdminProjectsFromContextFilter(
 		context: SourceControlContext,
-	): FindOptionsWhere<Folder> | undefined {
+	): FindOptionsWhere<Folder> {
 		if (context.hasAccessToAllProjects()) {
 			// In case the user is a global admin or owner, we don't need a filter
-			return;
+			return {};
 		}
 
 		// We build a filter to only select folder, that belong to a team project
@@ -88,10 +88,10 @@ export class SourceControlScopedService {
 
 	getWorkflowsInAdminProjectsFromContextFilter(
 		context: SourceControlContext,
-	): FindOptionsWhere<WorkflowEntity> | undefined {
+	): FindOptionsWhere<WorkflowEntity> {
 		if (context.hasAccessToAllProjects()) {
 			// In case the user is a global admin or owner, we don't need a filter
-			return;
+			return {};
 		}
 
 		// We build a filter to only select workflows, that belong to a team project
@@ -106,10 +106,10 @@ export class SourceControlScopedService {
 
 	getCredentialsInAdminProjectsFromContextFilter(
 		context: SourceControlContext,
-	): FindOptionsWhere<CredentialsEntity> | undefined {
+	): FindOptionsWhere<CredentialsEntity> {
 		if (context.hasAccessToAllProjects()) {
 			// In case the user is a global admin or owner, we don't need a filter
-			return;
+			return {};
 		}
 
 		// We build a filter to only select workflows, that belong to a team project
@@ -124,10 +124,10 @@ export class SourceControlScopedService {
 
 	getWorkflowTagMappingInAdminProjectsFromContextFilter(
 		context: SourceControlContext,
-	): FindOptionsWhere<WorkflowTagMapping> | undefined {
+	): FindOptionsWhere<WorkflowTagMapping> {
 		if (context.hasAccessToAllProjects()) {
 			// In case the user is a global admin or owner, we don't need a filter
-			return;
+			return {};
 		}
 
 		// We build a filter to only select workflows, that belong to a team project

--- a/packages/cli/src/environments.ee/source-control/source-control-scoped.service.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-scoped.service.ts
@@ -32,11 +32,9 @@ export class SourceControlScopedService {
 		const ctx = new SourceControlContext(req.user);
 		const projectsWithAdminAccess = await this.getAdminProjectsFromContext(ctx);
 
-		if (Array.isArray(projectsWithAdminAccess) && projectsWithAdminAccess.length > 0) {
-			return;
+		if (projectsWithAdminAccess?.length === 0) {
+			throw new ForbiddenError('You are not allowed to push changes');
 		}
-
-		throw new ForbiddenError('You are not allowed to push changes');
 	}
 
 	async getAdminProjectsFromContext(context: SourceControlContext): Promise<Project[] | undefined> {

--- a/packages/cli/src/environments.ee/source-control/source-control.controller.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control.controller.ee.ts
@@ -15,6 +15,7 @@ import {
 } from './middleware/source-control-enabled-middleware.ee';
 import { getRepoType } from './source-control-helper.ee';
 import { SourceControlPreferencesService } from './source-control-preferences.service.ee';
+import { SourceControlScopedService } from './source-control-scoped.service';
 import { SourceControlService } from './source-control.service.ee';
 import type { ImportResult } from './types/import-result';
 import { SourceControlRequest } from './types/requests';
@@ -26,6 +27,7 @@ export class SourceControlController {
 	constructor(
 		private readonly sourceControlService: SourceControlService,
 		private readonly sourceControlPreferencesService: SourceControlPreferencesService,
+		private readonly sourceControlScopedService: SourceControlScopedService,
 		private readonly eventService: EventService,
 	) {}
 
@@ -164,12 +166,13 @@ export class SourceControlController {
 	}
 
 	@Post('/push-workfolder', { middlewares: [sourceControlLicensedAndEnabledMiddleware] })
-	// @GlobalScope('sourceControl:push')
 	async pushWorkfolder(
 		req: AuthenticatedRequest,
 		res: express.Response,
 		@Body payload: PushWorkFolderRequestDto,
 	): Promise<SourceControlledFile[]> {
+		await this.sourceControlScopedService.ensureIsAllowedToPush(req);
+
 		try {
 			await this.sourceControlService.setGitUserDetails(
 				`${req.user.firstName} ${req.user.lastName}`,

--- a/packages/cli/src/environments.ee/source-control/source-control.controller.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control.controller.ee.ts
@@ -20,6 +20,7 @@ import type { ImportResult } from './types/import-result';
 import { SourceControlRequest } from './types/requests';
 import { SourceControlGetStatus } from './types/source-control-get-status';
 import type { SourceControlPreferences } from './types/source-control-preferences';
+import { hasGlobalScope } from '@n8n/permissions';
 
 @RestController('/source-control')
 export class SourceControlController {
@@ -164,7 +165,7 @@ export class SourceControlController {
 	}
 
 	@Post('/push-workfolder', { middlewares: [sourceControlLicensedAndEnabledMiddleware] })
-	@GlobalScope('sourceControl:push')
+	// @GlobalScope('sourceControl:push')
 	async pushWorkfolder(
 		req: AuthenticatedRequest,
 		res: express.Response,

--- a/packages/cli/src/environments.ee/source-control/source-control.controller.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control.controller.ee.ts
@@ -20,7 +20,6 @@ import type { ImportResult } from './types/import-result';
 import { SourceControlRequest } from './types/requests';
 import { SourceControlGetStatus } from './types/source-control-get-status';
 import type { SourceControlPreferences } from './types/source-control-preferences';
-import { hasGlobalScope } from '@n8n/permissions';
 
 @RestController('/source-control')
 export class SourceControlController {

--- a/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
@@ -265,7 +265,7 @@ export class SourceControlService {
 			if (
 				statusResult.some((requested) => {
 					return !allowedResources.some((allowed) => {
-						return allowed.id === requested.id && allowed.type === requested.id;
+						return allowed.id === requested.id && allowed.type === requested.type;
 					});
 				})
 			) {

--- a/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
@@ -325,16 +325,12 @@ export class SourceControlService {
 		const tagChanges = filesToPush.find((e) => e.type === 'tags');
 		if (tagChanges) {
 			filesToBePushed.add(tagChanges.file);
-			// TODO: For tags we need to change the implementation to
-			// only update mappings, that are available to the user
 			await this.sourceControlExportService.exportTagsToWorkFolder(context);
 		}
 
 		const folderChanges = filesToPush.find((e) => e.type === 'folders');
 		if (folderChanges) {
 			filesToBePushed.add(folderChanges.file);
-			// TODO: For folders we need to change the implementation to
-			// only update folders, that are available to the user
 			await this.sourceControlExportService.exportFoldersToWorkFolder(context);
 		}
 

--- a/packages/cli/src/environments.ee/source-control/types/exportable-folders.ts
+++ b/packages/cli/src/environments.ee/source-control/types/exportable-folders.ts
@@ -6,3 +6,7 @@ export type ExportableFolder = {
 	createdAt: string;
 	updatedAt: string;
 };
+
+export type ExportedFolders = {
+	folders: ExportableFolder[];
+};

--- a/packages/cli/test/integration/environments/source-control.service.test.ts
+++ b/packages/cli/test/integration/environments/source-control.service.test.ts
@@ -13,7 +13,6 @@ import { Container } from '@n8n/di';
 import * as fastGlob from 'fast-glob';
 import { mock } from 'jest-mock-extended';
 import { Cipher } from 'n8n-core';
-import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import { basename, isAbsolute } from 'node:path';
 
@@ -186,7 +185,6 @@ describe('SourceControlService', () => {
 	>;
 	const fsReadFile = jest.spyOn(fsp, 'readFile');
 	const fsWriteFile = jest.spyOn(fsp, 'writeFile');
-	const fsRmSync = jest.spyOn(fs, 'rmSync');
 
 	beforeAll(async () => {
 		await testDb.init();

--- a/packages/cli/test/integration/environments/source-control.service.test.ts
+++ b/packages/cli/test/integration/environments/source-control.service.test.ts
@@ -875,6 +875,7 @@ describe('SourceControlService', () => {
 				expect(workflowFiles).toHaveLength(8);
 				expect(credentialFiles).toHaveLength(2);
 
+				expect(gitService.push).toBeCalled();
 				expect(fsWriteFile).toBeCalledTimes(workflowFiles.length + credentialFiles.length + 2); // folders + tags
 				expect(Object.keys(updatedFiles)).toEqual(expect.arrayContaining(workflowFiles));
 				expect(Object.keys(updatedFiles)).toEqual(expect.arrayContaining(credentialFiles));
@@ -981,7 +982,8 @@ describe('SourceControlService', () => {
 				})) as SourceControlledFile[];
 
 				const workflowOutOfScope = allChanges.find(
-					(wf) => !projectAdminScope.workflows.some((w) => w.id === wf.id),
+					(wf) =>
+						wf.type === 'workflow' && !projectAdminScope.workflows.some((w) => w.id === wf.id),
 				);
 
 				await expect(

--- a/packages/cli/test/integration/shared/db/tags.ts
+++ b/packages/cli/test/integration/shared/db/tags.ts
@@ -26,6 +26,12 @@ export async function createTag(attributes: Partial<TagEntity> = {}, workflow?: 
 	return tag;
 }
 
+export async function updateTag(tag: TagEntity, attributes: Partial<TagEntity>) {
+	const tagRepository = Container.get(TagRepository);
+	const updatedTag = tagRepository.merge(tag, attributes);
+	return await tagRepository.save(updatedTag);
+}
+
 export async function assignTagToWorkflow(tag: TagEntity, workflow: WorkflowEntity) {
 	const mappingRepository = Container.get(WorkflowTagMappingRepository);
 


### PR DESCRIPTION
## Summary

Validates resources that are pushed to git, when none instance admins try to push changes. 

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-2826/validate-when-attempting-to-commit-from-modal-what-a-user-has-access

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
