### PR TITLE
feat(core): Add endpoint for querying credentials used in workflows

### DIFF
--- a/packages/cli/src/controllers/folder.controller.ts
+++ b/packages/cli/src/controllers/folder.controller.ts
@@ -72,6 +72,29 @@ export class ProjectController {
 		}
 	}
 
+	@Get('/:folderId/credentials')
+	@ProjectScope('folder:read')
+	async getFolderUsedCredentials(
+		req: AuthenticatedRequest<{ projectId: string; folderId: string }>,
+		_res: Response,
+	) {
+		const { projectId, folderId } = req.params;
+
+		try {
+			const credentials = await this.enterpriseWorkflowService.getFolderUsedCredentials(
+				req.user,
+				folderId,
+				projectId,
+			);
+			return credentials;
+		} catch (e) {
+			if (e instanceof FolderNotFoundError) {
+				throw new NotFoundError(e.message);
+			}
+			throw new InternalServerError(undefined, e);
+		}
+	}
+
 	@Patch('/:folderId')
 	@ProjectScope('folder:update')
 	async updateFolder(

--- a/packages/cli/src/workflows/workflow-finder.service.ts
+++ b/packages/cli/src/workflows/workflow-finder.service.ts
@@ -1,5 +1,5 @@
 import type { SharedWorkflow, User } from '@n8n/db';
-import { SharedWorkflowRepository } from '@n8n/db';
+import { SharedWorkflowRepository, FolderRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { hasGlobalScope, rolesWithScope, type Scope } from '@n8n/permissions';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
@@ -9,7 +9,10 @@ import { In } from '@n8n/typeorm';
 
 @Service()
 export class WorkflowFinderService {
-	constructor(private readonly sharedWorkflowRepository: SharedWorkflowRepository) {}
+	constructor(
+		private readonly sharedWorkflowRepository: SharedWorkflowRepository,
+		private readonly folderRepository: FolderRepository,
+	) {}
 
 	async findWorkflowForUser(
 		workflowId: string,
@@ -52,8 +55,27 @@ export class WorkflowFinderService {
 		return sharedWorkflow.workflow;
 	}
 
-	async findAllWorkflowsForUser(user: User, scopes: Scope[]) {
+	async findAllWorkflowsForUser(
+		user: User,
+		scopes: Scope[],
+		folderId?: string,
+		projectId?: string,
+	) {
 		let where: FindOptionsWhere<SharedWorkflow> = {};
+
+		if (folderId) {
+			const subFolderIds = await this.folderRepository.getAllFolderIdsInHierarchy(
+				folderId,
+				projectId,
+			);
+
+			where = {
+				...where,
+				workflow: {
+					parentFolder: In([folderId, ...subFolderIds]),
+				},
+			};
+		}
 
 		if (!hasGlobalScope(user, scopes, { mode: 'allOf' })) {
 			const projectRoles = rolesWithScope('project', scopes);
@@ -63,6 +85,7 @@ export class WorkflowFinderService {
 				...where,
 				role: In(workflowRoles),
 				project: {
+					...(projectId && { id: projectId }),
 					projectRelations: {
 						role: In(projectRoles),
 						userId: user.id,

--- a/packages/cli/test/integration/folder/folder.controller.test.ts
+++ b/packages/cli/test/integration/folder/folder.controller.test.ts
@@ -341,7 +341,7 @@ describe('GET /projects/:projectId/folders/:folderId/credentials', () => {
 			.expect(403);
 	});
 
-	test('should all used credentials from workflows within the folder and subfolders', async () => {
+	test('should get all used credentials from workflows within the folder and subfolders', async () => {
 		const project = await createTeamProject('test', owner);
 		const rootFolder = await createFolder(project, { name: 'Root' });
 

--- a/packages/cli/test/integration/folder/folder.controller.test.ts
+++ b/packages/cli/test/integration/folder/folder.controller.test.ts
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker';
 import type { Project, ProjectRole } from '@n8n/db';
 import type { User } from '@n8n/db';
 import { FolderRepository } from '@n8n/db';
@@ -10,6 +11,7 @@ import { ApplicationError, PROJECT_ROOT } from 'n8n-workflow';
 import { ActiveWorkflowManager } from '@/active-workflow-manager';
 import { mockInstance } from '@test/mocking';
 import {
+	createCredentials,
 	getCredentialSharings,
 	saveCredential,
 	shareCredentialWithProjects,
@@ -300,6 +302,111 @@ describe('GET /projects/:projectId/folders/:folderId/tree', () => {
 							]),
 						}),
 					]),
+				}),
+			]),
+		);
+	});
+});
+
+describe('GET /projects/:projectId/folders/:folderId/credentials', () => {
+	test('should not get folder credentials when project does not exist', async () => {
+		await authOwnerAgent
+			.get('/projects/non-existing-id/folders/some-folder-id/credentials')
+			.expect(403);
+	});
+
+	test('should not get folder credentials when folder does not exist', async () => {
+		const project = await createTeamProject('test project', owner);
+
+		await authOwnerAgent
+			.get(`/projects/${project.id}/folders/non-existing-folder/credentials`)
+			.expect(404);
+	});
+
+	test('should not get folder credentials if user has no access to project', async () => {
+		const project = await createTeamProject('test project', owner);
+		const folder = await createFolder(project);
+
+		await authMemberAgent
+			.get(`/projects/${project.id}/folders/${folder.id}/credentials`)
+			.expect(403);
+	});
+
+	test("should not allow getting folder credentials from another user's personal project", async () => {
+		const ownerPersonalProject = await projectRepository.getPersonalProjectForUserOrFail(owner.id);
+		const folder = await createFolder(ownerPersonalProject);
+
+		await authMemberAgent
+			.get(`/projects/${ownerPersonalProject.id}/folders/${folder.id}/credentials`)
+			.expect(403);
+	});
+
+	test('should all used credentials from workflows within the folder and subfolders', async () => {
+		const project = await createTeamProject('test', owner);
+		const rootFolder = await createFolder(project, { name: 'Root' });
+
+		const childFolder1 = await createFolder(project, {
+			name: 'Child 1',
+			parentFolder: rootFolder,
+		});
+
+		await createFolder(project, {
+			name: 'Child 2',
+			parentFolder: rootFolder,
+		});
+
+		const grandchildFolder = await createFolder(project, {
+			name: 'Grandchild',
+			parentFolder: childFolder1,
+		});
+
+		for (const folder of [rootFolder, childFolder1, grandchildFolder]) {
+			const credential = await createCredentials(
+				{
+					name: `Test credential ${folder.name}`,
+					data: '',
+					type: 'test',
+				},
+				project,
+			);
+
+			await createWorkflow(
+				{
+					name: 'Test Workflow',
+					parentFolder: folder,
+					active: false,
+					nodes: [
+						{
+							parameters: {},
+							type: '@n8n/n8n-nodes-langchain.lmChatOpenAi',
+							typeVersion: 1.2,
+							position: [0, 0],
+							id: faker.string.uuid(),
+							name: 'OpenAI Chat Model',
+							credentials: {
+								openAiApi: {
+									id: credential.id,
+									name: credential.name,
+								},
+							},
+						},
+					],
+				},
+				owner,
+			);
+		}
+
+		const response = await authOwnerAgent
+			.get(`/projects/${project.id}/folders/${childFolder1.id}/credentials`)
+			.expect(200);
+
+		expect(response.body.data).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					name: expect.stringContaining('Test credential Child 1'),
+				}),
+				expect.objectContaining({
+					name: expect.stringContaining('Test credential Grandchild'),
 				}),
 			]),
 		);


### PR DESCRIPTION
## Summary

We are missing an endpoint that can be used to query which credentials are used by workflows within a folder and its subfolders. Doing this without a dedicated endpoint on the UI is inefficient as we would have to first resolve the folder tree and then fetch every workflow one by one, and this could be _many_ requests.

Instead lets add an endpoint on the backend that does this there, returning a list of unique credentials used in workflows. This is the same data that has been previously exposed as `usedCredentials` data on single workflow requests, and what the workflow sharing modal uses already to be able to display which credentials should be also shared when transferring ownership of a workflow.

Now, with this endpoint doing the same when moving a folder becomes possible, listing all credentials used by workflows within that folder.

<img width="512" alt="image" src="https://github.com/user-attachments/assets/a6ae426d-3570-4fe5-9dcc-7493698d0966" />

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/ADO-3161/fe-combine-change-owner-and-move-to-folder-modals

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
