### PR TITLE
feat(core): Add recover mechanism for pg when pool is unexpectedly full on connection not closed

### DIFF
--- a/packages/cli/src/databases/__tests__/db-connection.test.ts
+++ b/packages/cli/src/databases/__tests__/db-connection.test.ts
@@ -9,6 +9,8 @@ import { DbConnectionTimeoutError } from 'n8n-workflow';
 import { DbConnection } from '@/databases/db-connection';
 import type { DbConnectionOptions } from '@/databases/db-connection-options';
 
+import type { PgRecover } from '../pg-recover';
+
 jest.mock('@n8n/typeorm', () => ({
 	DataSource: jest.fn(),
 	...jest.requireActual('@n8n/typeorm'),
@@ -37,7 +39,12 @@ describe('DbConnection', () => {
 		connectionOptions.getOptions.mockReturnValue(postgresOptions);
 		(DataSource as jest.Mock) = jest.fn().mockImplementation(() => dataSource);
 
-		dbConnection = new DbConnection(errorReporter, connectionOptions, databaseConfig);
+		dbConnection = new DbConnection(
+			errorReporter,
+			connectionOptions,
+			databaseConfig,
+			mock<PgRecover>(),
+		);
 	});
 
 	describe('init', () => {
@@ -187,6 +194,7 @@ describe('DbConnection', () => {
 					mock<DatabaseConfig>({
 						pingIntervalSeconds: 1,
 					}),
+					mock<PgRecover>(),
 				);
 
 				const pingSpy = jest.spyOn(dbConnection as any, 'ping');

--- a/packages/cli/src/databases/db-connection.ts
+++ b/packages/cli/src/databases/db-connection.ts
@@ -50,7 +50,7 @@ export class DbConnection {
 		try {
 			await this.dataSource.initialize();
 			if (this.options.type === 'postgres') {
-				this.pgRecover.initializeRecoverOnError();
+				this.pgRecover.initializeRecoverOnError(this.dataSource);
 			}
 		} catch (e) {
 			let error = ensureError(e);

--- a/packages/cli/src/databases/pg-recover.ts
+++ b/packages/cli/src/databases/pg-recover.ts
@@ -1,0 +1,100 @@
+import { Service } from '@n8n/di';
+import { DataSource } from '@n8n/typeorm';
+import { PostgresDriver } from '@n8n/typeorm/driver/postgres/PostgresDriver';
+import { ErrorReporter, Logger } from 'n8n-core';
+import { ensureError } from 'n8n-workflow';
+import type { Pool, PoolClient } from 'pg';
+
+// Internal structure of pg Pool and Client for connection recovery
+// These are not part of the public API but are needed for advanced recovery
+export interface InternalPoolClient extends PoolClient {
+	_ended?: boolean;
+	_ending?: boolean;
+}
+
+export interface InternalPool extends Pool {
+	_clients?: Array<InternalPoolClient | null>;
+}
+
+@Service()
+export class PgRecover {
+	constructor(
+		private readonly dataSource: DataSource,
+		private readonly errorReporter: ErrorReporter,
+		private readonly logger: Logger,
+	) {}
+
+	initializeRecoverOnError() {
+		const pgDriver = this.dataSource.driver;
+		if (!(pgDriver instanceof PostgresDriver) || !this.dataSource.isInitialized) return;
+
+		const pgPool = pgDriver.master as Pool;
+		pgPool.on('error', async (error) => {
+			this.logger.debug(`Postgres pool error: ${ensureError(error).message}`);
+			// Log the current pool state
+			this.logger.debug(
+				`Recovering connection pool. Total: ${pgPool.totalCount}, Idle: ${pgPool.idleCount}, Waiting: ${pgPool.waitingCount}`,
+			);
+			// Attempt to recover the connection pool
+			const recoveryAttempted = await this.recoverConnectionPool(pgPool);
+			if (recoveryAttempted) {
+				this.logger.debug('Connection pool recovery attempted');
+			} else {
+				this.logger.debug('Failed to recover connection pool');
+			}
+		});
+	}
+
+	/**
+	 * Attempt to recover the connection pool when it's in an unhealthy state
+	 * This method will try to release any stalled connections and create new ones
+	 * @returns True if recovery was attempted, false otherwise
+	 */
+	private async recoverConnectionPool(pgPool: Pool): Promise<boolean> {
+		if (!this.dataSource.isInitialized) {
+			return false;
+		}
+
+		try {
+			// Access the internal pool structure to find stalled connections
+			// Note: This uses internal properties that are not part of the public API
+			// but necessary for our specific use case of recovering from stalled connections
+			const internalPool = pgPool as InternalPool;
+			if (internalPool._clients && Array.isArray(internalPool._clients)) {
+				this.logger.debug('Recovering connection pool...');
+				let releasedCount = 0;
+				const clients = internalPool._clients;
+
+				for (let i = 0; i < clients.length; i++) {
+					const client = clients[i];
+					this.logger.debug(`Checking client at index ${i}: ${client?._ended}`);
+					// Check if the client is in an ended state but still in the pool
+					if (client && (client._ended === true || client._ending === true)) {
+						// Properly release the client instead of just setting it to null
+						this.logger.debug(`Found stalled connection at index ${i}, properly releasing it`);
+						try {
+							// Force release the client (true parameter forces termination)
+							client.release(true);
+						} catch (error) {
+							// If release fails, manually remove it from the pool
+							this.logger.debug(
+								`Failed to release client, removing from pool: ${ensureError(error).message}`,
+							);
+							clients[i] = null;
+						}
+						releasedCount++;
+					}
+				}
+
+				if (releasedCount > 0) {
+					this.errorReporter.info(`Released ${releasedCount} stalled connections from the pool`);
+				}
+			}
+
+			return true;
+		} catch (error) {
+			this.errorReporter.error(`Failed to recover connection pool: ${ensureError(error).message}`);
+			return false;
+		}
+	}
+}

--- a/packages/cli/src/databases/pg-recover.ts
+++ b/packages/cli/src/databases/pg-recover.ts
@@ -1,7 +1,8 @@
+import { Logger } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
 import { DataSource } from '@n8n/typeorm';
 import { PostgresDriver } from '@n8n/typeorm/driver/postgres/PostgresDriver';
-import { ErrorReporter, Logger } from 'n8n-core';
+import { ErrorReporter } from 'n8n-core';
 import { ensureError } from 'n8n-workflow';
 import type { Pool, PoolClient } from 'pg';
 

--- a/packages/cli/src/databases/pg-recover.ts
+++ b/packages/cli/src/databases/pg-recover.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
-import { DataSource } from '@n8n/typeorm';
+import type { DataSource } from '@n8n/typeorm';
 import { PostgresDriver } from '@n8n/typeorm/driver/postgres/PostgresDriver';
 import { ErrorReporter } from 'n8n-core';
 import { ensureError } from 'n8n-workflow';


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
When an underlying tcp error occur on the postgres connection, we can enter a state where the pg-pool (node-postgres driver used by typeorm) do not close the pool connections, but those connections enter a closed state.
The node-postgres community seem to have encountered this issue as well in a hard to reproduce manner. Eg: https://github.com/brianc/node-postgres/issues/2262#issuecomment-2838302908

This impact the connection status, because all pool connections are used, even though not available because closed.
This PR suggest adding a recover mechanism for those connections to try and clean the ended ones on failure.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2834/bug-main-scaling-instance-stalls-its-connection-to-postgres

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
