### PR TITLE
fix(editor): Delete all connections of nodes with multiple ones when removed from canvas

### DIFF
--- a/packages/frontend/editor-ui/src/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasOperations.test.ts
@@ -2442,8 +2442,6 @@ describe('useCanvasOperations', () => {
 				},
 			};
 
-			workflowsStore.removeConnection = vi.fn();
-
 			workflowsStore.getNodeById = vi.fn().mockImplementation((id) => {
 				if (id === sourceNode.id) return sourceNode;
 				if (id === targetNode.id) return targetNode;
@@ -2454,6 +2452,26 @@ describe('useCanvasOperations', () => {
 				if (name === targetNode.name) return targetNode;
 				return null;
 			});
+
+			workflowsStore.removeConnection = vi
+				.fn()
+				.mockImplementation((data: { connection: IConnection[] }) => {
+					const sourceData = data.connection[0];
+					const destinationData = data.connection[1];
+
+					const connections =
+						workflowsStore.workflow.connections[sourceData.node][sourceData.type][sourceData.index];
+
+					for (const index in connections) {
+						if (
+							connections[+index].node === destinationData.node &&
+							connections[+index].type === destinationData.type &&
+							connections[+index].index === destinationData.index
+						) {
+							connections.splice(parseInt(index, 10), 1);
+						}
+					}
+				});
 
 			deleteConnectionsByNodeId(targetNode.id);
 
@@ -2472,6 +2490,10 @@ describe('useCanvasOperations', () => {
 					{ node: targetNode.name, type: NodeConnectionTypes.Main, index: 1 },
 				],
 			});
+
+			expect(
+				workflowsStore.workflow.connections[sourceNode.name][NodeConnectionTypes.Main][0],
+			).toEqual([]);
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
@@ -109,6 +109,7 @@ import type { CanvasLayoutEvent } from './useCanvasLayout';
 import { chatEventBus } from '@n8n/chat/event-buses';
 import { isChatNode } from '@/components/CanvasChat/utils';
 import { useLogsStore } from '@/stores/logs.store';
+import { cloneDeep } from 'lodash-es';
 
 type AddNodeData = Partial<INodeUi> & {
 	type: string;
@@ -1210,7 +1211,7 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 			historyStore.startRecordingUndo();
 		}
 
-		const connections = deepCopy(workflowsStore.workflow.connections) ?? {};
+		const connections = cloneDeep(workflowsStore.workflow.connections);
 		for (const nodeName of Object.keys(connections)) {
 			const node = workflowsStore.getNodeByName(nodeName);
 			if (!node) {

--- a/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
@@ -1122,7 +1122,7 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 		);
 		for (const nodeName of checkNodes) {
 			const node = workflowsStore.nodesByName[nodeName];
-			if (node.position[0] < sourceNode.position[0]) {
+			if (!node || !sourceNode || node.position[0] < sourceNode.position[0]) {
 				continue;
 			}
 
@@ -1210,7 +1210,7 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 			historyStore.startRecordingUndo();
 		}
 
-		const connections = workflowsStore.workflow.connections;
+		const connections = deepCopy(workflowsStore.workflow.connections) ?? {};
 		for (const nodeName of Object.keys(connections)) {
 			const node = workflowsStore.getNodeByName(nodeName);
 			if (!node) {


### PR DESCRIPTION
## Summary

A bug occurred when deleting all nodes between a trigger node and a target node, and then adding a new node - this caused an error to appear. I added checks to the affected line, but the real issue was with removing nodes that have multiple connections (like "Merge"), after which the `connections` object in the workflow store was still storing some of the deleted connections. The original code changed the length of the node connections array during iteration, causing some connections to be skipped. I fixed this by iterating over a copy of the object, keeping the original intact. I added a test that fails without the fix.

A simple workflow to reproduce this behavior:
```json
{
  "nodes": [
    {
      "parameters": {},
      "type": "n8n-nodes-base.manualTrigger",
      "typeVersion": 1,
      "position": [
        340,
        20
      ],
      "id": "f3326f25-1a87-4ffb-a670-2ca7b325b221",
      "name": "When clicking ‘Execute workflow’"
    },
    {
      "parameters": {},
      "type": "n8n-nodes-base.merge",
      "typeVersion": 3.2,
      "position": [
        880,
        20
      ],
      "id": "513d084c-cb8a-4d92-a7a2-d28bfd668cd2",
      "name": "Merge"
    },
    {
      "parameters": {},
      "type": "n8n-nodes-base.noOp",
      "typeVersion": 1,
      "position": [
        1100,
        20
      ],
      "id": "448d9e52-18dc-4445-8364-245aa041de19",
      "name": "No Operation, do nothing"
    }
  ],
  "connections": {
    "When clicking ‘Execute workflow’": {
      "main": [
        [
          {
            "node": "Merge",
            "type": "main",
            "index": 0
          },
          {
            "node": "Merge",
            "type": "main",
            "index": 1
          }
        ]
      ]
    },
    "Merge": {
      "main": [
        [
          {
            "node": "No Operation, do nothing",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {},
  "meta": {
    "instanceId": "83c3820f830e55a52025face5677a42dc0e7951bd6b7dbb04659e20a97326906"
  }
}
```

How to reproduce the bug:
1. Remove the node "Merge" (you will see that now the trigger is connected to the newly added node)
2. Add a node between the existing two, e.g. "Google BugQuery"
3. You will notice an error "Cannot read properties of undefined (reading 'position')"
4. (*) Check that there is still the node "Merge" inside `workflow.connections` of workflow store.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3595/remove-nodes-then-try-to-add-bigquery-leads-to-cannot-read-properties

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
