### PR TITLE
feat(editor): Support pasting an expression into a number parameter

### DIFF
--- a/packages/frontend/editor-ui/src/components/ParameterInput.test.ts
+++ b/packages/frontend/editor-ui/src/components/ParameterInput.test.ts
@@ -224,39 +224,65 @@ describe('ParameterInput.vue', () => {
 		expect(emitted('update')).toContainEqual([expect.objectContaining({ value: 'foo' })]);
 	});
 
-	test('should correctly handle paste events', async () => {
-		const { container, emitted } = renderComponent({
-			props: {
-				path: 'tag',
-				parameter: {
-					displayName: 'Tag',
-					name: 'tag',
-					type: 'string',
-				},
-				modelValue: '',
-			},
-		});
-		const input = container.querySelector('input') as HTMLInputElement;
-		expect(input).toBeInTheDocument();
-		await userEvent.click(input);
-
-		async function paste(text: string) {
+	describe('paste events', () => {
+		async function paste(input: HTMLInputElement, text: string) {
 			const expression = new DataTransfer();
 			expression.setData('text', text);
 			await userEvent.clear(input);
 			await userEvent.paste(expression);
 		}
 
-		await paste('foo');
-		expect(emitted('update')).toContainEqual([expect.objectContaining({ value: 'foo' })]);
+		test('should handle pasting into a string parameter', async () => {
+			const { container, emitted } = renderComponent({
+				props: {
+					path: 'tag',
+					parameter: {
+						displayName: 'Tag',
+						name: 'tag',
+						type: 'string',
+					},
+					modelValue: '',
+				},
+			});
+			const input = container.querySelector('input') as HTMLInputElement;
+			expect(input).toBeInTheDocument();
+			await userEvent.click(input);
 
-		await paste('={{ $json.foo }}');
-		expect(emitted('update')).toContainEqual([
-			expect.objectContaining({ value: '={{ $json.foo }}' }),
-		]);
+			await paste(input, 'foo');
+			expect(emitted('update')).toContainEqual([expect.objectContaining({ value: 'foo' })]);
 
-		await paste('=flDvzj%y1nP');
-		expect(emitted('update')).toContainEqual([expect.objectContaining({ value: '==flDvzj%y1nP' })]);
+			await paste(input, '={{ $json.foo }}');
+			expect(emitted('update')).toContainEqual([
+				expect.objectContaining({ value: '={{ $json.foo }}' }),
+			]);
+
+			await paste(input, '=flDvzj%y1nP');
+			expect(emitted('update')).toContainEqual([
+				expect.objectContaining({ value: '==flDvzj%y1nP' }),
+			]);
+		});
+
+		test('should handle pasting an expression into a number parameter', async () => {
+			const { container, emitted } = renderComponent({
+				props: {
+					path: 'percentage',
+					parameter: {
+						displayName: 'Percentage',
+						name: 'percentage',
+						type: 'number',
+					},
+					modelValue: 1,
+				},
+			});
+			const input = container.querySelector('input') as HTMLInputElement;
+			expect(input).toBeInTheDocument();
+			await userEvent.click(input);
+
+			await paste(input, '{{ $json.foo }}');
+			expect(emitted('update')).toContainEqual([
+				expect.objectContaining({ value: '={{ $json.foo }}' }),
+			]);
+		});
 	});
 
 	test('should not reset the value of a multi-select with loadOptionsMethod on load', async () => {

--- a/packages/frontend/editor-ui/src/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/components/ParameterInput.vue
@@ -784,6 +784,7 @@ function onPasteNumber(event: ClipboardEvent) {
 	const pastedText = event.clipboardData?.getData('text');
 
 	if (shouldConvertToExpression(pastedText)) {
+		event.preventDefault();
 		valueChanged('=' + pastedText);
 		return;
 	}

--- a/packages/frontend/editor-ui/src/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/components/ParameterInput.vue
@@ -780,6 +780,15 @@ function onPaste(event: ClipboardEvent) {
 	}
 }
 
+function onPasteNumber(event: ClipboardEvent) {
+	const pastedText = event.clipboardData?.getData('text');
+
+	if (shouldConvertToExpression(pastedText)) {
+		valueChanged('=' + pastedText);
+		return;
+	}
+}
+
 function onResourceLocatorDrop(data: string) {
 	emit('drop', data);
 }
@@ -1590,7 +1599,7 @@ onUpdated(async () => {
 				@update:model-value="onUpdateTextInput"
 				@focus="setFocus"
 				@blur="onBlur"
-				@keydown.stop
+				@paste="onPasteNumber"
 			/>
 
 			<CredentialsSelect


### PR DESCRIPTION
## Summary

When pasting a string with expression syntax into a number input (example: `{{ $json.test }}`, switch to expression mode

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2602/number-fields-arent-automatically-turned-to-expressions


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
