### PR TITLE
feat(MCP Server Trigger Node): Cleanup session in MCP Server trigger

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpServer.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpServer.ts
@@ -162,7 +162,7 @@ export class McpServer {
 					throw new OperationalError('Require a sessionId for the tool call');
 				}
 
-				const callId = extra.requestId ? `${extra.sessionId}_${extra.requestId}` : extra.sessionId;
+				const callId = `${extra.sessionId}_${extra.requestId}`;
 
 				const requestedTool: Tool | undefined = this.tools.find(
 					(tool) => tool.name === request.params.name,

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
@@ -143,8 +143,9 @@ export class McpTrigger extends Node {
 			}
 			throw error;
 		}
+		const connectedTools = await getConnectedTools(context, true);
 
-		const mcpServer: McpServer = McpServerSingleton.instance(context.logger);
+		const mcpServer: McpServer = McpServerSingleton.instance(connectedTools, context.logger);
 
 		if (webhookName === 'setup') {
 			// Sets up the transport and opens the long-lived connection. This resp
@@ -160,9 +161,8 @@ export class McpTrigger extends Node {
 			// This is the command-channel, and is actually executing the tools. This
 			// sends the response back through the long-lived connection setup in the
 			// 'setup' call
-			const connectedTools = await getConnectedTools(context, true);
 
-			const wasToolCall = await mcpServer.handlePostMessage(req, resp, connectedTools);
+			const wasToolCall = await mcpServer.handlePostMessage(req, resp);
 
 			if (wasToolCall) return { noWebhookResponse: true, workflowData: [[{ json: {} }]] };
 			return { noWebhookResponse: true };

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpServer.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpServer.test.ts
@@ -7,6 +7,7 @@ import { captor, mock } from 'jest-mock-extended';
 import type { CompressionResponse } from '../FlushingSSEServerTransport';
 import { FlushingSSEServerTransport } from '../FlushingSSEServerTransport';
 import { McpServer } from '../McpServer';
+import exp from 'constants';
 
 const sessionId = 'mock-session-id';
 const mockServer = mock<Server>();
@@ -34,11 +35,16 @@ describe('McpServer', () => {
 		jest.clearAllMocks();
 		mockResponse.status.mockReturnThis();
 
-		mcpServer = new McpServer(mock());
+		mcpServer = new McpServer([mockTool], mock());
 	});
 
 	describe('connectTransport', () => {
 		const postUrl = '/post-url';
+
+		it('should set up tools on initialization', () => {
+			// @ts-expect-error private property `tools`
+			expect(mcpServer.tools).toEqual([mockTool]);
+		});
 
 		it('should set up a transport and server', async () => {
 			await mcpServer.connectTransport(postUrl, mockResponse);
@@ -94,7 +100,7 @@ describe('McpServer', () => {
 			);
 
 			// Call the method
-			const result = await mcpServer.handlePostMessage(mockRequest, mockResponse, [mockTool]);
+			const result = await mcpServer.handlePostMessage(mockRequest, mockResponse);
 
 			// Verify that transport's handlePostMessage was called
 			expect(mockTransport.handlePostMessage).toHaveBeenCalledWith(
@@ -136,7 +142,7 @@ describe('McpServer', () => {
 			);
 
 			// Handle first tool call
-			const firstResult = await mcpServer.handlePostMessage(mockRequest, mockResponse, [mockTool]);
+			const firstResult = await mcpServer.handlePostMessage(mockRequest, mockResponse);
 			expect(firstResult).toBe(true);
 			expect(mockTransport.handlePostMessage).toHaveBeenCalledWith(
 				mockRequest,
@@ -155,7 +161,7 @@ describe('McpServer', () => {
 			);
 
 			// Handle second tool call
-			const secondResult = await mcpServer.handlePostMessage(mockRequest, mockResponse, [mockTool]);
+			const secondResult = await mcpServer.handlePostMessage(mockRequest, mockResponse);
 			expect(secondResult).toBe(true);
 
 			// Verify transport's handlePostMessage was called twice
@@ -167,7 +173,7 @@ describe('McpServer', () => {
 
 		it('should return 401 when transport does not exist', async () => {
 			// Call without setting up transport
-			await mcpServer.handlePostMessage(mockRequest, mockResponse, [mockTool]);
+			await mcpServer.handlePostMessage(mockRequest, mockResponse);
 
 			// Verify error status was set
 			expect(mockResponse.status).toHaveBeenCalledWith(401);

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpServer.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpServer.test.ts
@@ -7,7 +7,6 @@ import { captor, mock } from 'jest-mock-extended';
 import type { CompressionResponse } from '../FlushingSSEServerTransport';
 import { FlushingSSEServerTransport } from '../FlushingSSEServerTransport';
 import { McpServer } from '../McpServer';
-import exp from 'constants';
 
 const sessionId = 'mock-session-id';
 const mockServer = mock<Server>();

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpTrigger.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpTrigger.node.test.ts
@@ -64,9 +64,7 @@ describe('McpTrigger Node', () => {
 			const result = await mcpTrigger.webhook(mockContext);
 
 			// Verify that handlePostMessage was called with request, response and tools
-			expect(mockServer.handlePostMessage).toHaveBeenCalledWith(mockRequest, mockResponse, [
-				mockTool,
-			]);
+			expect(mockServer.handlePostMessage).toHaveBeenCalledWith(mockRequest, mockResponse);
 
 			// Verify the returned result when a tool was called
 			expect(result).toEqual({


### PR DESCRIPTION
## Summary
This is a small PR to clean-up the original implementation of the MCP Trigger Server.
Previously tools were saved (and needed to be cleanup) when a new client session was established. Now we setup the tools when the server is initialized.

## Related Linear tickets, Github issues, and Community forum posts

Linear: https://linear.app/n8n/issue/AI-937/clean-mcp-server-trigger

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
