### PR TITLE
chore: Upgrade pdfjs-dist (no-changelog)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -21,7 +21,15 @@ const config = {
 	testPathIgnorePatterns: ['/dist/', '/node_modules/'],
 	transform: {
 		'^.+\\.ts$': ['ts-jest', tsJestOptions],
+		'node_modules/pdfjs-dist/.+\\.mjs$': [
+			'babel-jest',
+			{
+				presets: ['@babel/preset-env'],
+				plugins: ['babel-plugin-transform-import-meta'],
+			},
+		],
 	},
+	transformIgnorePatterns: ['/dist/', '/node_modules/(?!.*pdfjs-dist/)'],
 	// This resolve the path mappings from the tsconfig relative to each jest.config.js
 	moduleNameMapper: compilerOptions?.paths
 		? pathsToModuleNameMapper(compilerOptions.paths, {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@types/jest": "^29.5.3",
     "@types/node": "*",
     "@types/supertest": "^6.0.3",
+    "babel-plugin-transform-import-meta": "^2.3.2",
     "cross-env": "^7.0.3",
     "jest": "^29.6.2",
     "jest-environment-jsdom": "^29.6.2",
@@ -94,6 +95,7 @@
     },
     "patchedDependencies": {
       "bull@4.16.4": "patches/bull@4.16.4.patch",
+      "pdfjs-dist@5.3.31": "patches/pdfjs-dist@5.3.31.patch",
       "pkce-challenge@5.0.0": "patches/pkce-challenge@5.0.0.patch",
       "@types/express-serve-static-core@5.0.6": "patches/@types__express-serve-static-core@5.0.6.patch",
       "@types/ws@8.18.1": "patches/@types__ws@8.18.1.patch",

--- a/packages/nodes-base/nodes/ReadPdf/test/ReadPDF-encrypted.workflow.json
+++ b/packages/nodes-base/nodes/ReadPdf/test/ReadPDF-encrypted.workflow.json
@@ -57,7 +57,7 @@
 						"Title": "sample"
 					},
 					"text": "N8N\nSample PDF\nLorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor\ninvidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et\njusto duo dolores et ea rebum.",
-					"version": "2.16.105"
+					"version": "5.3.31"
 				}
 			}
 		]

--- a/packages/nodes-base/nodes/ReadPdf/test/ReadPDF.workflow.json
+++ b/packages/nodes-base/nodes/ReadPdf/test/ReadPDF.workflow.json
@@ -54,7 +54,7 @@
 						"ModDate": "D:20230210122750Z"
 					},
 					"text": "N8N\nSample PDF\nLorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor\ninvidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et\njusto duo dolores et ea rebum.",
-					"version": "2.16.105"
+					"version": "5.3.31"
 				}
 			}
 		]

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -924,7 +924,7 @@
     "node-ssh": "13.2.0",
     "nodemailer": "6.9.9",
     "otpauth": "9.1.1",
-    "pdfjs-dist": "2.16.105",
+    "pdfjs-dist": "5.3.31",
     "pg": "8.12.0",
     "pg-promise": "11.9.1",
     "promise-ftp": "1.3.5",

--- a/packages/nodes-base/utils/binary.ts
+++ b/packages/nodes-base/utils/binary.ts
@@ -2,8 +2,7 @@ import iconv from 'iconv-lite';
 import get from 'lodash/get';
 import type { IBinaryData, IDataObject, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 import { NodeOperationError, BINARY_ENCODING } from 'n8n-workflow';
-import { getDocument as readPDF, version as pdfJsVersion } from 'pdfjs-dist';
-import type { DocumentInitParameters } from 'pdfjs-dist/types/src/display/api';
+import type { TextContent as PdfTextContent } from 'pdfjs-dist/types/src/display/api';
 import type { WorkBook, WritingOptions } from 'xlsx';
 import { utils as xlsxUtils, write as xlsxWrite } from 'xlsx';
 
@@ -29,10 +28,6 @@ export type JsonToBinaryOptions = {
 	itemIndex?: number;
 	format?: boolean;
 };
-
-type PdfDocument = Awaited<ReturnType<Awaited<typeof readPDF>>['promise']>;
-type PdfPage = Awaited<ReturnType<Awaited<PdfDocument['getPage']>>>;
-type PdfTextContent = Awaited<ReturnType<PdfPage['getTextContent']>>;
 
 export async function convertJsonToSpreadsheetBinary(
 	this: IExecuteFunctions,
@@ -162,17 +157,22 @@ export async function extractDataFromPDF(
 ) {
 	const binaryData = this.helpers.assertBinaryData(itemIndex, binaryPropertyName);
 
-	const params: DocumentInitParameters = { password, isEvalSupported: false };
-
+	let buffer: Buffer;
 	if (binaryData.id) {
-		params.data = await this.helpers.binaryToBuffer(
-			await this.helpers.getBinaryStream(binaryData.id),
-		);
+		const stream = await this.helpers.getBinaryStream(binaryData.id);
+		buffer = await this.helpers.binaryToBuffer(stream);
 	} else {
-		params.data = Buffer.from(binaryData.data, BINARY_ENCODING).buffer;
+		buffer = Buffer.from(binaryData.data, BINARY_ENCODING);
 	}
 
-	const document = await readPDF(params).promise;
+	const { getDocument: readPDF, version: pdfJsVersion } = await import(
+		'pdfjs-dist/legacy/build/pdf.mjs'
+	);
+	const document = await readPDF({
+		password,
+		isEvalSupported: false,
+		data: new Uint8Array(buffer),
+	}).promise;
 	const { info, metadata } = await document
 		.getMetadata()
 		.catch(() => ({ info: null, metadata: null }));
@@ -196,7 +196,7 @@ export async function extractDataFromPDF(
 		numpages: document.numPages,
 		numrender: document.numPages,
 		info,
-		metadata: metadata?.getAll(),
+		metadata: (metadata && Object.fromEntries([...metadata])) ?? undefined,
 		text,
 		version: pdfJsVersion,
 	};

--- a/patches/pdfjs-dist@5.3.31.patch
+++ b/patches/pdfjs-dist@5.3.31.patch
@@ -1,0 +1,27 @@
+diff --git a/legacy/build/pdf.mjs b/legacy/build/pdf.mjs
+index 1a373ea986beef21076d30438235d180a0487c20..9d584f4fcc13f0b86e57160570c530e5ac794638 100644
+--- a/legacy/build/pdf.mjs
++++ b/legacy/build/pdf.mjs
+@@ -12060,9 +12060,9 @@ class DOMWasmFactory extends BaseWasmFactory {
+ if (isNodeJS) {
+   let canvas;
+   try {
+-    const require = process.getBuiltinModule("module").createRequire(import.meta.url);
++    const _require = process.getBuiltinModule("module").createRequire(import.meta.url);
+     try {
+-      canvas = require("@napi-rs/canvas");
++      canvas = _require("@napi-rs/canvas");
+     } catch (ex) {
+       warn(`Cannot load "@napi-rs/canvas" package: "${ex}".`);
+     }
+@@ -12106,8 +12106,8 @@ async function node_utils_fetchData(url) {
+ class NodeFilterFactory extends BaseFilterFactory {}
+ class NodeCanvasFactory extends BaseCanvasFactory {
+   _createCanvas(width, height) {
+-    const require = process.getBuiltinModule("module").createRequire(import.meta.url);
+-    const canvas = require("@napi-rs/canvas");
++    const _require = process.getBuiltinModule("module").createRequire(import.meta.url);
++    const canvas = _require("@napi-rs/canvas");
+     return canvas.createCanvas(width, height);
+   }
+ }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,9 @@ patchedDependencies:
   eslint-plugin-n8n-local-rules:
     hash: e0fd59254ab02473c6940fa25fcc8102ebc7d371c015ec53333a43f48af33cc2
     path: patches/eslint-plugin-n8n-local-rules.patch
+  pdfjs-dist@5.3.31:
+    hash: 421253c8e411cdaef58ba96d2bb44ae0784e1b3e446f5caca50710daa1fa5dcd
+    path: patches/pdfjs-dist@5.3.31.patch
   pkce-challenge@5.0.0:
     hash: 651e785d0b7bbf5be9210e1e895c39a16dc3ce8a5a3843b4819565fb6e175b90
     path: patches/pkce-challenge@5.0.0.patch
@@ -224,6 +227,9 @@ importers:
       '@types/supertest':
         specifier: ^6.0.3
         version: 6.0.3
+      babel-plugin-transform-import-meta:
+        specifier: ^2.3.2
+        version: 2.3.3(@babel/core@7.26.10)
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -2500,8 +2506,8 @@ importers:
         specifier: 9.1.1
         version: 9.1.1
       pdfjs-dist:
-        specifier: 2.16.105
-        version: 2.16.105
+        specifier: 5.3.31
+        version: 5.3.31(patch_hash=421253c8e411cdaef58ba96d2bb44ae0784e1b3e446f5caca50710daa1fa5dcd)
       pg:
         specifier: 8.12.0
         version: 8.12.0
@@ -5120,6 +5126,70 @@ packages:
   '@n8n_io/riot-tmpl@4.0.1':
     resolution: {integrity: sha512-/zdRbEfTFjsm1NqnpPQHgZTkTdbp5v3VUxGeMA9098sps8jRCTraQkc3AQstJgHUm7ylBXJcIVhnVeLUMWAfwQ==}
 
+  '@napi-rs/canvas-android-arm64@0.1.70':
+    resolution: {integrity: sha512-I/YOuQ0wbkVYxVaYtCgN42WKTYxNqFA0gTcTrHIGG1jfpDSyZWII/uHcjOo4nzd19io6Y4+/BqP8E5hJgf9OmQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@0.1.70':
+    resolution: {integrity: sha512-4pPGyXetHIHkw2TOJHujt3mkCP8LdDu8+CT15ld9Id39c752RcI0amDHSuMLMQfAjvusA9B5kKxazwjMGjEJpQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@0.1.70':
+    resolution: {integrity: sha512-+2N6Os9LbkmDMHL+raknrUcLQhsXzc5CSXRbXws9C3pv/mjHRVszQ9dhFUUe9FjfPhCJznO6USVdwOtu7pOrzQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.70':
+    resolution: {integrity: sha512-QjscX9OaKq/990sVhSMj581xuqLgiaPVMjjYvWaCmAJRkNQ004QfoSMEm3FoTqM4DRoquP8jvuEXScVJsc1rqQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.70':
+    resolution: {integrity: sha512-LNakMOwwqwiHIwMpnMAbFRczQMQ7TkkMyATqFCOtUJNlE6LPP/QiUj/mlFrNbUn/hctqShJ60gWEb52ZTALbVw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.70':
+    resolution: {integrity: sha512-wBTOllEYNfJCHOdZj9v8gLzZ4oY3oyPX8MSRvaxPm/s7RfEXxCyZ8OhJ5xAyicsDdbE5YBZqdmaaeP5+xKxvtg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.70':
+    resolution: {integrity: sha512-GVUUPC8TuuFqHip0rxHkUqArQnlzmlXmTEBuXAWdgCv85zTCFH8nOHk/YCF5yo0Z2eOm8nOi90aWs0leJ4OE5Q==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.70':
+    resolution: {integrity: sha512-/kvUa2lZRwGNyfznSn5t1ShWJnr/m5acSlhTV3eXECafObjl0VBuA1HJw0QrilLpb4Fe0VLywkpD1NsMoVDROQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.70':
+    resolution: {integrity: sha512-aqlv8MLpycoMKRmds7JWCfVwNf1fiZxaU7JwJs9/ExjTD8lX2KjsO7CTeAj5Cl4aEuzxUWbJPUUE2Qu9cZ1vfg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.70':
+    resolution: {integrity: sha512-Q9QU3WIpwBTVHk4cPfBjGHGU4U0llQYRXgJtFtYqqGNEOKVN4OT6PQ+ve63xwIPODMpZ0HHyj/KLGc9CWc3EtQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@0.1.70':
+    resolution: {integrity: sha512-nD6NGa4JbNYSZYsTnLGrqe9Kn/lCkA4ybXt8sx5ojDqZjr2i0TWAHxx/vhgfjX+i3hCdKWufxYwi7CfXqtITSA==}
+    engines: {node: '>= 10'}
+
   '@ngneat/falso@7.4.0':
     resolution: {integrity: sha512-7MzPP0YGNHDrohf/epmz6SVIjHGhKyHbh0bm+iZ1z/7KVW4xZi9Dx6Tl9NMPy6a4lWh/t3WXSsCGkgkuJ/eroQ==}
 
@@ -7466,6 +7536,11 @@ packages:
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
 
+  babel-plugin-transform-import-meta@2.3.3:
+    resolution: {integrity: sha512-bbh30qz1m6ZU1ybJoNOhA2zaDvmeXMnGNBMVMDOJ1Fni4+wMBoy/j7MTRVmqAUCIcy54/rEnr9VEBsfcgbpm3Q==}
+    peerDependencies:
+      '@babel/core': ^7.10.0
+
   babel-preset-current-node-syntax@1.0.1:
     resolution: {integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==}
     peerDependencies:
@@ -8520,10 +8595,6 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
-
-  dommatrix@1.0.3:
-    resolution: {integrity: sha512-l32Xp/TLgWb8ReqbVJAFIvXmY7go4nTxxlWiAFyhoQw9RKEOHBZNnyGvJWqDVSPmq3Y9HlM4npqF/T6VMOXhww==}
-    deprecated: dommatrix is no longer maintained. Please use @thednp/dommatrix.
 
   dompurify@3.1.7:
     resolution: {integrity: sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==}
@@ -11769,13 +11840,9 @@ packages:
     resolution: {integrity: sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==}
     engines: {node: '>=6.8.1'}
 
-  pdfjs-dist@2.16.105:
-    resolution: {integrity: sha512-J4dn41spsAwUxCpEoVf6GVoz908IAA3mYiLmNxg8J9kfRXc2jxpbUepcP0ocp0alVNLFthTAM8DZ1RaHh8sU0A==}
-    peerDependencies:
-      worker-loader: ^3.0.8
-    peerDependenciesMeta:
-      worker-loader:
-        optional: true
+  pdfjs-dist@5.3.31:
+    resolution: {integrity: sha512-EhPdIjNX0fcdwYQO+e3BAAJPXt+XI29TZWC7COhIXs/K0JHcUt1Gdz1ITpebTwVMFiLsukdUZ3u0oTO7jij+VA==}
+    engines: {node: '>=20.16.0 || >=22.3.0'}
 
   peberminta@0.9.0:
     resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
@@ -17737,6 +17804,50 @@ snapshots:
     dependencies:
       eslint-config-riot: 1.0.0
 
+  '@napi-rs/canvas-android-arm64@0.1.70':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@0.1.70':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@0.1.70':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.70':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.70':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.70':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.70':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.70':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.70':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.70':
+    optional: true
+
+  '@napi-rs/canvas@0.1.70':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 0.1.70
+      '@napi-rs/canvas-darwin-arm64': 0.1.70
+      '@napi-rs/canvas-darwin-x64': 0.1.70
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.70
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.70
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.70
+      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.70
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.70
+      '@napi-rs/canvas-linux-x64-musl': 0.1.70
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.70
+    optional: true
+
   '@ngneat/falso@7.4.0':
     dependencies:
       seedrandom: 3.0.5
@@ -20805,6 +20916,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-plugin-transform-import-meta@2.3.3(@babel/core@7.26.10):
+    dependencies:
+      '@babel/core': 7.26.10
+      '@babel/template': 7.26.9
+      tslib: 2.8.1
+
   babel-preset-current-node-syntax@1.0.1(@babel/core@7.26.10):
     dependencies:
       '@babel/core': 7.26.10
@@ -21956,8 +22073,6 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
-
-  dommatrix@1.0.3: {}
 
   dompurify@3.1.7: {}
 
@@ -26124,10 +26239,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  pdfjs-dist@2.16.105:
-    dependencies:
-      dommatrix: 1.0.3
-      web-streams-polyfill: 3.2.1
+  pdfjs-dist@5.3.31(patch_hash=421253c8e411cdaef58ba96d2bb44ae0784e1b3e446f5caca50710daa1fa5dcd):
+    optionalDependencies:
+      '@napi-rs/canvas': 0.1.70
 
   peberminta@0.9.0: {}
 


### PR DESCRIPTION
## Summary

Attempting to do this again. The node already works, but the tests are broken because of the new versions of this package containing ESM code even in the `legacy` builds.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
