### PR TITLE
fix: Close NDV using correct button (no-changelog)

### DIFF
--- a/cypress/e2e/39-projects.cy.ts
+++ b/cypress/e2e/39-projects.cy.ts
@@ -4,6 +4,7 @@ import {
 	clickCreateNewCredential,
 	getNdvContainer,
 	selectResourceLocatorAddResourceItem,
+	getBackToCanvasButton,
 } from '../composables/ndv';
 import * as projects from '../composables/projects';
 import {
@@ -292,6 +293,11 @@ describe('Projects', { disableAutoLogin: true }, () => {
 			cy.signinAsOwner();
 			cy.visit(workflowsPage.url);
 
+			// Stub window.open before adding sub-workflow opens a new tab
+			cy.window().then((win) => {
+				cy.stub(win, 'open').as('windowOpen').returns(null);
+			});
+
 			projects.createProject('Dev');
 			projects.getProjectTabWorkflows().click();
 			workflowsPage.getters.newWorkflowButtonCard().click();
@@ -299,14 +305,10 @@ describe('Projects', { disableAutoLogin: true }, () => {
 			workflowPage.actions.saveWorkflowOnButtonClick();
 			workflowPage.actions.addNodeToCanvas('Execute Workflow', true, true);
 
-			// This mock fails when running with `test:e2e:dev` but works with `test:e2e:ui`,
-			// at least on macOS at version 1.94.0. ¯\_(ツ)_/¯
-			cy.window().then((win) => cy.stub(win, 'open').callsFake((url) => cy.visit(url)));
-
 			selectResourceLocatorAddResourceItem('workflowId', 'Create a');
-			// Need to wait for the trigger node to auto-open after a delay
 			getNdvContainer().should('be.visible');
-			cy.get('body').type('{esc}');
+			getBackToCanvasButton().click();
+
 			workflowPage.actions.addNodeToCanvas(NOTION_NODE_NAME, true, true);
 			clickCreateNewCredential();
 			setCredentialValues({

--- a/cypress/e2e/39-projects.cy.ts
+++ b/cypress/e2e/39-projects.cy.ts
@@ -4,7 +4,7 @@ import {
 	clickCreateNewCredential,
 	getNdvContainer,
 	selectResourceLocatorAddResourceItem,
-	getBackToCanvasButton,
+	clickGetBackToCanvas,
 } from '../composables/ndv';
 import * as projects from '../composables/projects';
 import {
@@ -293,11 +293,6 @@ describe('Projects', { disableAutoLogin: true }, () => {
 			cy.signinAsOwner();
 			cy.visit(workflowsPage.url);
 
-			// Stub window.open before adding sub-workflow opens a new tab
-			cy.window().then((win) => {
-				cy.stub(win, 'open').as('windowOpen').returns(null);
-			});
-
 			projects.createProject('Dev');
 			projects.getProjectTabWorkflows().click();
 			workflowsPage.getters.newWorkflowButtonCard().click();
@@ -305,9 +300,11 @@ describe('Projects', { disableAutoLogin: true }, () => {
 			workflowPage.actions.saveWorkflowOnButtonClick();
 			workflowPage.actions.addNodeToCanvas('Execute Workflow', true, true);
 
+			cy.window().then((win) => cy.stub(win, 'open').callsFake((url) => cy.visit(url)));
+
 			selectResourceLocatorAddResourceItem('workflowId', 'Create a');
 			getNdvContainer().should('be.visible');
-			getBackToCanvasButton().click();
+			clickGetBackToCanvas();
 
 			workflowPage.actions.addNodeToCanvas(NOTION_NODE_NAME, true, true);
 			clickCreateNewCredential();


### PR DESCRIPTION
The test was failing due to how Cypress runs in headless vs non headless mode. Esc not always being registered etc.

## Summary

Fixes the failing project test.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-2815/flaky-ui-projects-when-starting-from-scratch-should-create-sub
Flaky Test Run: https://github.com/n8n-io/n8n/actions/runs/15274055259/job/42956066490 200 passed

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
