### PR TITLE
fix(Code Node): Forbid selected module import in python 

### DIFF
--- a/packages/nodes-base/nodes/Code/PythonSandbox.ts
+++ b/packages/nodes-base/nodes/Code/PythonSandbox.ts
@@ -4,6 +4,7 @@ import type { PyDict } from 'pyodide/ffi';
 import { LoadPyodide } from './Pyodide';
 import type { SandboxContext } from './Sandbox';
 import { Sandbox } from './Sandbox';
+import { checkPythonCodeImports } from './utils';
 
 type PythonSandboxContext = {
 	[K in keyof SandboxContext as K extends `$${infer I}` ? `_${I}` : K]: SandboxContext[K];
@@ -53,6 +54,8 @@ export class PythonSandbox extends Sandbox {
 	}
 
 	private async runCodeInPython<T>() {
+		checkPythonCodeImports(this.pythonCode);
+
 		const packageCacheDir = this.helpers.getStoragePath();
 		const pyodide = await LoadPyodide(packageCacheDir);
 


### PR DESCRIPTION
## Summary

do not allow module import(os)

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-3032/remote-code-execution-via-python-code-node

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
