### PR TITLE
feat(MCP Server Trigger Node): Cleanup MCP server management, use sanitized trigger node's name as name for the MCP server

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpServer.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpServer.ts
@@ -52,7 +52,15 @@ function getRequestId(body: string): string | undefined {
 	}
 }
 
+/**
+ * This singleton is shared across the instance, making sure it is the one
+ * keeping account of MCP servers.
+ * It needs to stay in memory to keep track of the long-lived connections.
+ * It requires a logger at first creation to set everything up.
+ */
 export class McpServerManager {
+	static #instance: McpServerManager;
+
 	servers: { [sessionId: string]: Server } = {};
 
 	transports: { [sessionId: string]: FlushingSSEServerTransport } = {};
@@ -63,9 +71,18 @@ export class McpServerManager {
 
 	logger: Logger;
 
-	constructor(logger: Logger) {
+	private constructor(logger: Logger) {
 		this.logger = logger;
 		this.logger.debug('MCP Server created');
+	}
+
+	static instance(logger: Logger): McpServerManager {
+		if (!McpServerManager.#instance) {
+			McpServerManager.#instance = new McpServerManager(logger);
+			logger.debug('Created singleton MCP manager');
+		}
+
+		return McpServerManager.#instance;
 	}
 
 	async createServerAndTransport(
@@ -208,33 +225,5 @@ export class McpServerManager {
 		server.onerror = (error: unknown) => {
 			this.logger.error(`MCP Error: ${error}`);
 		};
-	}
-}
-
-/**
- * This singleton is shared across the instance, making sure we only have one server to worry about.
- * It needs to stay in memory to keep track of the long-lived connections.
- * It requires a logger at first creation to set everything up.
- */
-export class McpServerSingleton {
-	static #instance: McpServerSingleton;
-
-	private _serverData: McpServerManager;
-
-	private constructor(logger: Logger) {
-		this._serverData = new McpServerManager(logger);
-	}
-
-	static instance(logger: Logger): McpServerManager {
-		if (!McpServerSingleton.#instance) {
-			McpServerSingleton.#instance = new McpServerSingleton(logger);
-			logger.debug('Created singleton for MCP Servers');
-		}
-
-		return McpServerSingleton.#instance.serverData;
-	}
-
-	get serverData() {
-		return this._serverData;
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpServer.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpServer.ts
@@ -52,6 +52,8 @@ function getRequestId(body: string): string | undefined {
 }
 
 export class McpServer {
+	serverName: string;
+
 	servers: { [sessionId: string]: Server } = {};
 
 	transports: { [sessionId: string]: FlushingSSEServerTransport } = {};
@@ -62,9 +64,10 @@ export class McpServer {
 
 	private resolveFunctions: { [callId: string]: CallableFunction } = {};
 
-	constructor(logger: Logger) {
+	constructor(serverName: string, logger: Logger) {
+		this.serverName = serverName;
 		this.logger = logger;
-		this.logger.debug('MCP Server created');
+		this.logger.debug(`MCP Server "${serverName}" created`);
 	}
 
 	async connectTransport(postUrl: string, resp: CompressionResponse): Promise<void> {
@@ -126,7 +129,7 @@ export class McpServer {
 	setUpServer(): Server {
 		const server = new Server(
 			{
-				name: 'n8n-mcp-server',
+				name: this.serverName,
 				version: '0.1.0',
 			},
 			{
@@ -217,13 +220,13 @@ export class McpServerSingleton {
 
 	private _serverData: McpServer;
 
-	private constructor(logger: Logger) {
-		this._serverData = new McpServer(logger);
+	private constructor(serverName: string, logger: Logger) {
+		this._serverData = new McpServer(serverName, logger);
 	}
 
-	static instance(logger: Logger): McpServer {
+	static instance(serverName: string, logger: Logger): McpServer {
 		if (!McpServerSingleton.#instance) {
-			McpServerSingleton.#instance = new McpServerSingleton(logger);
+			McpServerSingleton.#instance = new McpServerSingleton(serverName, logger);
 			logger.debug('Created singleton for MCP Servers');
 		}
 

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
@@ -6,8 +6,7 @@ import { NodeConnectionTypes, Node } from 'n8n-workflow';
 import { getConnectedTools, nodeNameToToolName } from '@utils/helpers';
 
 import type { CompressionResponse } from './FlushingSSEServerTransport';
-import { McpServerSingleton } from './McpServer';
-import type { McpServerManager } from './McpServer';
+import { McpServerManager } from './McpServer';
 
 const MCP_SSE_SETUP_PATH = 'sse';
 const MCP_SSE_MESSAGES_PATH = 'messages';
@@ -147,7 +146,7 @@ export class McpTrigger extends Node {
 		// Get a url/tool friendly name for the server, based on the node name
 		const serverName = node.typeVersion > 1 ? nodeNameToToolName(node) : 'n8n-mcp-server';
 
-		const mcpServerManager: McpServerManager = McpServerSingleton.instance(context.logger);
+		const mcpServerManager: McpServerManager = McpServerManager.instance(context.logger);
 
 		if (webhookName === 'setup') {
 			// Sets up the transport and opens the long-lived connection. This resp

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
@@ -7,7 +7,7 @@ import { getConnectedTools, nodeNameToToolName } from '@utils/helpers';
 
 import type { CompressionResponse } from './FlushingSSEServerTransport';
 import { McpServerSingleton } from './McpServer';
-import type { McpServer } from './McpServer';
+import type { McpServerManager } from './McpServer';
 
 const MCP_SSE_SETUP_PATH = 'sse';
 const MCP_SSE_MESSAGES_PATH = 'messages';
@@ -147,7 +147,7 @@ export class McpTrigger extends Node {
 		// Get a url/tool friendly name for the server, based on the node name
 		const serverName = node.typeVersion > 1 ? nodeNameToToolName(node) : 'n8n-mcp-server';
 
-		const mcpServer: McpServer = McpServerSingleton.instance(context.logger);
+		const mcpServerManager: McpServerManager = McpServerSingleton.instance(context.logger);
 
 		if (webhookName === 'setup') {
 			// Sets up the transport and opens the long-lived connection. This resp
@@ -156,7 +156,7 @@ export class McpTrigger extends Node {
 				new RegExp(`/${MCP_SSE_SETUP_PATH}$`),
 				`/${MCP_SSE_MESSAGES_PATH}`,
 			);
-			await mcpServer.connectTransport(serverName, postUrl, resp);
+			await mcpServerManager.createServerAndTransport(serverName, postUrl, resp);
 
 			return { noWebhookResponse: true };
 		} else if (webhookName === 'default') {
@@ -165,7 +165,7 @@ export class McpTrigger extends Node {
 			// 'setup' call
 			const connectedTools = await getConnectedTools(context, true);
 
-			const wasToolCall = await mcpServer.handlePostMessage(req, resp, connectedTools);
+			const wasToolCall = await mcpServerManager.handlePostMessage(req, resp, connectedTools);
 
 			if (wasToolCall) return { noWebhookResponse: true, workflowData: [[{ json: {} }]] };
 			return { noWebhookResponse: true };

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
@@ -147,7 +147,7 @@ export class McpTrigger extends Node {
 		// Get a url/tool friendly name for the server, based on the node name
 		const serverName = node.typeVersion > 1 ? nodeNameToToolName(node) : 'n8n-mcp-server';
 
-		const mcpServer: McpServer = McpServerSingleton.instance(serverName, context.logger);
+		const mcpServer: McpServer = McpServerSingleton.instance(context.logger);
 
 		if (webhookName === 'setup') {
 			// Sets up the transport and opens the long-lived connection. This resp
@@ -156,7 +156,7 @@ export class McpTrigger extends Node {
 				new RegExp(`/${MCP_SSE_SETUP_PATH}$`),
 				`/${MCP_SSE_MESSAGES_PATH}`,
 			);
-			await mcpServer.connectTransport(postUrl, resp);
+			await mcpServer.connectTransport(serverName, postUrl, resp);
 
 			return { noWebhookResponse: true };
 		} else if (webhookName === 'default') {

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
@@ -21,7 +21,7 @@ export class McpTrigger extends Node {
 			dark: 'file:../mcp.dark.svg',
 		},
 		group: ['trigger'],
-		version: 1,
+		version: [1, 1.1],
 		description: 'Expose n8n tools as an MCP Server endpoint',
 		activationMessage: 'You can now connect your MCP Clients to the SSE URL.',
 		defaults: {
@@ -143,8 +143,9 @@ export class McpTrigger extends Node {
 			}
 			throw error;
 		}
+		const node = context.getNode();
 		// Get a url/tool friendly name for the server, based on the node name
-		const serverName = nodeNameToToolName(context.getNode());
+		const serverName = node.typeVersion > 1 ? nodeNameToToolName(node) : 'n8n-mcp-server';
 
 		const mcpServer: McpServer = McpServerSingleton.instance(serverName, context.logger);
 

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
@@ -143,8 +143,8 @@ export class McpTrigger extends Node {
 			}
 			throw error;
 		}
-
-		const mcpServer: McpServer = McpServerSingleton.instance(context.logger);
+		const serverName = context.getNode().name;
+		const mcpServer: McpServer = McpServerSingleton.instance(serverName, context.logger);
 
 		if (webhookName === 'setup') {
 			// Sets up the transport and opens the long-lived connection. This resp

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
@@ -3,7 +3,7 @@ import { validateWebhookAuthentication } from 'n8n-nodes-base/dist/nodes/Webhook
 import type { INodeTypeDescription, IWebhookFunctions, IWebhookResponseData } from 'n8n-workflow';
 import { NodeConnectionTypes, Node } from 'n8n-workflow';
 
-import { getConnectedTools } from '@utils/helpers';
+import { getConnectedTools, nodeNameToToolName } from '@utils/helpers';
 
 import type { CompressionResponse } from './FlushingSSEServerTransport';
 import { McpServerSingleton } from './McpServer';
@@ -143,7 +143,9 @@ export class McpTrigger extends Node {
 			}
 			throw error;
 		}
-		const serverName = context.getNode().name;
+		// Get a url/tool friendly name for the server, based on the node name
+		const serverName = nodeNameToToolName(context.getNode());
+
 		const mcpServer: McpServer = McpServerSingleton.instance(serverName, context.logger);
 
 		if (webhookName === 'setup') {

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpServer.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpServer.test.ts
@@ -6,7 +6,7 @@ import { captor, mock } from 'jest-mock-extended';
 
 import type { CompressionResponse } from '../FlushingSSEServerTransport';
 import { FlushingSSEServerTransport } from '../FlushingSSEServerTransport';
-import { McpServer } from '../McpServer';
+import { McpServerManager } from '../McpServer';
 
 const sessionId = 'mock-session-id';
 const mockServer = mock<Server>();
@@ -28,20 +28,20 @@ describe('McpServer', () => {
 	const mockResponse = mock<CompressionResponse>();
 	const mockTool = mock<Tool>({ name: 'mockTool' });
 
-	let mcpServer: McpServer;
+	let mcpServer: McpServerManager;
 
 	beforeEach(() => {
 		jest.clearAllMocks();
 		mockResponse.status.mockReturnThis();
 
-		mcpServer = new McpServer(mock());
+		mcpServer = new McpServerManager(mock());
 	});
 
 	describe('connectTransport', () => {
 		const postUrl = '/post-url';
 
 		it('should set up a transport and server', async () => {
-			await mcpServer.connectTransport('mcpServer', postUrl, mockResponse);
+			await mcpServer.createServerAndTransport('mcpServer', postUrl, mockResponse);
 
 			// Check that FlushingSSEServerTransport was initialized with correct params
 			expect(FlushingSSEServerTransport).toHaveBeenCalledWith(postUrl, mockResponse);
@@ -61,7 +61,7 @@ describe('McpServer', () => {
 		});
 
 		it('should set up close handler that cleans up resources', async () => {
-			await mcpServer.connectTransport('mcpServer', postUrl, mockResponse);
+			await mcpServer.createServerAndTransport('mcpServer', postUrl, mockResponse);
 
 			// Get the close callback and execute it
 			const closeCallbackCaptor = captor<() => Promise<void>>();

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpServer.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpServer.test.ts
@@ -34,11 +34,15 @@ describe('McpServer', () => {
 		jest.clearAllMocks();
 		mockResponse.status.mockReturnThis();
 
-		mcpServer = new McpServer(mock());
+		mcpServer = new McpServer('mcpServer', mock());
 	});
 
 	describe('connectTransport', () => {
 		const postUrl = '/post-url';
+
+		it('should set up the server name on initialization', () => {
+			expect(mcpServer.serverName).toEqual('mcpServer');
+		});
 
 		it('should set up a transport and server', async () => {
 			await mcpServer.connectTransport(postUrl, mockResponse);

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpServer.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpServer.test.ts
@@ -34,18 +34,14 @@ describe('McpServer', () => {
 		jest.clearAllMocks();
 		mockResponse.status.mockReturnThis();
 
-		mcpServer = new McpServer('mcpServer', mock());
+		mcpServer = new McpServer(mock());
 	});
 
 	describe('connectTransport', () => {
 		const postUrl = '/post-url';
 
-		it('should set up the server name on initialization', () => {
-			expect(mcpServer.serverName).toEqual('mcpServer');
-		});
-
 		it('should set up a transport and server', async () => {
-			await mcpServer.connectTransport(postUrl, mockResponse);
+			await mcpServer.connectTransport('mcpServer', postUrl, mockResponse);
 
 			// Check that FlushingSSEServerTransport was initialized with correct params
 			expect(FlushingSSEServerTransport).toHaveBeenCalledWith(postUrl, mockResponse);
@@ -65,7 +61,7 @@ describe('McpServer', () => {
 		});
 
 		it('should set up close handler that cleans up resources', async () => {
-			await mcpServer.connectTransport(postUrl, mockResponse);
+			await mcpServer.connectTransport('mcpServer', postUrl, mockResponse);
 
 			// Get the close callback and execute it
 			const closeCallbackCaptor = captor<() => Promise<void>>();

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpServer.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpServer.test.ts
@@ -28,20 +28,18 @@ describe('McpServer', () => {
 	const mockResponse = mock<CompressionResponse>();
 	const mockTool = mock<Tool>({ name: 'mockTool' });
 
-	let mcpServer: McpServerManager;
+	const mcpServerManager = McpServerManager.instance(mock());
 
 	beforeEach(() => {
 		jest.clearAllMocks();
 		mockResponse.status.mockReturnThis();
-
-		mcpServer = new McpServerManager(mock());
 	});
 
 	describe('connectTransport', () => {
 		const postUrl = '/post-url';
 
 		it('should set up a transport and server', async () => {
-			await mcpServer.createServerAndTransport('mcpServer', postUrl, mockResponse);
+			await mcpServerManager.createServerAndTransport('mcpServer', postUrl, mockResponse);
 
 			// Check that FlushingSSEServerTransport was initialized with correct params
 			expect(FlushingSSEServerTransport).toHaveBeenCalledWith(postUrl, mockResponse);
@@ -50,18 +48,18 @@ describe('McpServer', () => {
 			expect(Server).toHaveBeenCalled();
 
 			// Check that transport and server are stored
-			expect(mcpServer.transports[sessionId]).toBeDefined();
-			expect(mcpServer.servers[sessionId]).toBeDefined();
+			expect(mcpServerManager.transports[sessionId]).toBeDefined();
+			expect(mcpServerManager.servers[sessionId]).toBeDefined();
 
 			// Check that connect was called on the server
-			expect(mcpServer.servers[sessionId].connect).toHaveBeenCalled();
+			expect(mcpServerManager.servers[sessionId].connect).toHaveBeenCalled();
 
 			// Check that flush was called if available
 			expect(mockResponse.flush).toHaveBeenCalled();
 		});
 
 		it('should set up close handler that cleans up resources', async () => {
-			await mcpServer.createServerAndTransport('mcpServer', postUrl, mockResponse);
+			await mcpServerManager.createServerAndTransport('mcpServer', postUrl, mockResponse);
 
 			// Get the close callback and execute it
 			const closeCallbackCaptor = captor<() => Promise<void>>();
@@ -69,8 +67,8 @@ describe('McpServer', () => {
 			await closeCallbackCaptor.value();
 
 			// Check that resources were cleaned up
-			expect(mcpServer.transports[sessionId]).toBeUndefined();
-			expect(mcpServer.servers[sessionId]).toBeUndefined();
+			expect(mcpServerManager.transports[sessionId]).toBeUndefined();
+			expect(mcpServerManager.servers[sessionId]).toBeUndefined();
 		});
 	});
 
@@ -78,11 +76,11 @@ describe('McpServer', () => {
 		it('should call transport.handlePostMessage when transport exists', async () => {
 			mockTransport.handlePostMessage.mockImplementation(async () => {
 				// @ts-expect-error private property `resolveFunctions`
-				mcpServer.resolveFunctions[`${sessionId}_123`]();
+				mcpServerManager.resolveFunctions[`${sessionId}_123`]();
 			});
 
 			// Add the transport directly
-			mcpServer.transports[sessionId] = mockTransport;
+			mcpServerManager.transports[sessionId] = mockTransport;
 
 			mockRequest.rawBody = Buffer.from(
 				JSON.stringify({
@@ -94,7 +92,9 @@ describe('McpServer', () => {
 			);
 
 			// Call the method
-			const result = await mcpServer.handlePostMessage(mockRequest, mockResponse, [mockTool]);
+			const result = await mcpServerManager.handlePostMessage(mockRequest, mockResponse, [
+				mockTool,
+			]);
 
 			// Verify that transport's handlePostMessage was called
 			expect(mockTransport.handlePostMessage).toHaveBeenCalledWith(
@@ -119,11 +119,11 @@ describe('McpServer', () => {
 					? `${sessionId}_${firstId}`
 					: `${sessionId}_${secondId}`;
 				// @ts-expect-error private property `resolveFunctions`
-				mcpServer.resolveFunctions[requestKey]();
+				mcpServerManager.resolveFunctions[requestKey]();
 			});
 
 			// Add the transport directly
-			mcpServer.transports[sessionId] = mockTransport;
+			mcpServerManager.transports[sessionId] = mockTransport;
 
 			// First tool call
 			mockRequest.rawBody = Buffer.from(
@@ -136,7 +136,9 @@ describe('McpServer', () => {
 			);
 
 			// Handle first tool call
-			const firstResult = await mcpServer.handlePostMessage(mockRequest, mockResponse, [mockTool]);
+			const firstResult = await mcpServerManager.handlePostMessage(mockRequest, mockResponse, [
+				mockTool,
+			]);
 			expect(firstResult).toBe(true);
 			expect(mockTransport.handlePostMessage).toHaveBeenCalledWith(
 				mockRequest,
@@ -155,7 +157,9 @@ describe('McpServer', () => {
 			);
 
 			// Handle second tool call
-			const secondResult = await mcpServer.handlePostMessage(mockRequest, mockResponse, [mockTool]);
+			const secondResult = await mcpServerManager.handlePostMessage(mockRequest, mockResponse, [
+				mockTool,
+			]);
 			expect(secondResult).toBe(true);
 
 			// Verify transport's handlePostMessage was called twice
@@ -166,8 +170,22 @@ describe('McpServer', () => {
 		});
 
 		it('should return 401 when transport does not exist', async () => {
-			// Call without setting up transport
-			await mcpServer.handlePostMessage(mockRequest, mockResponse, [mockTool]);
+			// Set up request with rawBody and ensure sessionId is properly set
+			const testRequest = mock<Request>({
+				query: { sessionId: 'non-existent-session' },
+				path: '/sse',
+			});
+			testRequest.rawBody = Buffer.from(
+				JSON.stringify({
+					jsonrpc: '2.0',
+					method: 'tools/call',
+					id: 123,
+					params: { name: 'mockTool' },
+				}),
+			);
+
+			// Call without setting up transport for this sessionId
+			await mcpServerManager.handlePostMessage(testRequest, mockResponse, [mockTool]);
 
 			// Verify error status was set
 			expect(mockResponse.status).toHaveBeenCalledWith(401);

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpTrigger.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpTrigger.node.test.ts
@@ -6,13 +6,13 @@ import type { INode, IWebhookFunctions } from 'n8n-workflow';
 
 import * as helpers from '@utils/helpers';
 
-import type { McpServer } from '../McpServer';
+import type { McpServerManager } from '../McpServer';
 import { McpTrigger } from '../McpTrigger.node';
 
 const mockTool = mock<Tool>({ name: 'mockTool' });
 jest.spyOn(helpers, 'getConnectedTools').mockResolvedValue([mockTool]);
 
-const mockServer = mock<McpServer>();
+const mockServer = mock<McpServerManager>();
 jest.mock('../McpServer', () => ({
 	McpServerSingleton: {
 		instance: jest.fn().mockImplementation(() => mockServer),
@@ -47,7 +47,7 @@ describe('McpTrigger Node', () => {
 			const result = await mcpTrigger.webhook(mockContext);
 
 			// Verify that the connectTransport method was called with correct URL
-			expect(mockServer.connectTransport).toHaveBeenCalledWith(
+			expect(mockServer.createServerAndTransport).toHaveBeenCalledWith(
 				'McpTrigger',
 				'/custom-path/messages',
 				mockResponse,
@@ -105,7 +105,7 @@ describe('McpTrigger Node', () => {
 			await mcpTrigger.webhook(mockContext);
 
 			// Verify that connectTransport was called with the sanitized server name
-			expect(mockServer.connectTransport).toHaveBeenCalledWith(
+			expect(mockServer.createServerAndTransport).toHaveBeenCalledWith(
 				'My_custom_MCP_server_',
 				'/custom-path/messages',
 				mockResponse,
@@ -123,7 +123,7 @@ describe('McpTrigger Node', () => {
 			await mcpTrigger.webhook(mockContext);
 
 			// Verify that connectTransport was called with the default server name
-			expect(mockServer.connectTransport).toHaveBeenCalledWith(
+			expect(mockServer.createServerAndTransport).toHaveBeenCalledWith(
 				'n8n-mcp-server',
 				'/custom-path/messages',
 				mockResponse,

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpTrigger.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpTrigger.node.test.ts
@@ -12,10 +12,10 @@ import { McpTrigger } from '../McpTrigger.node';
 const mockTool = mock<Tool>({ name: 'mockTool' });
 jest.spyOn(helpers, 'getConnectedTools').mockResolvedValue([mockTool]);
 
-const mockServer = mock<McpServerManager>();
+const mockServerManager = mock<McpServerManager>();
 jest.mock('../McpServer', () => ({
-	McpServerSingleton: {
-		instance: jest.fn().mockImplementation(() => mockServer),
+	McpServerManager: {
+		instance: jest.fn().mockImplementation(() => mockServerManager),
 	},
 }));
 
@@ -47,7 +47,7 @@ describe('McpTrigger Node', () => {
 			const result = await mcpTrigger.webhook(mockContext);
 
 			// Verify that the connectTransport method was called with correct URL
-			expect(mockServer.createServerAndTransport).toHaveBeenCalledWith(
+			expect(mockServerManager.createServerAndTransport).toHaveBeenCalledWith(
 				'McpTrigger',
 				'/custom-path/messages',
 				mockResponse,
@@ -62,13 +62,13 @@ describe('McpTrigger Node', () => {
 			mockContext.getWebhookName.mockReturnValue('default');
 
 			// Mock that the server executes a tool and returns true
-			mockServer.handlePostMessage.mockResolvedValueOnce(true);
+			mockServerManager.handlePostMessage.mockResolvedValueOnce(true);
 
 			// Call the webhook method
 			const result = await mcpTrigger.webhook(mockContext);
 
 			// Verify that handlePostMessage was called with request, response and tools
-			expect(mockServer.handlePostMessage).toHaveBeenCalledWith(mockRequest, mockResponse, [
+			expect(mockServerManager.handlePostMessage).toHaveBeenCalledWith(mockRequest, mockResponse, [
 				mockTool,
 			]);
 
@@ -84,7 +84,7 @@ describe('McpTrigger Node', () => {
 			mockContext.getWebhookName.mockReturnValue('default');
 
 			// Mock that the server doesn't execute a tool and returns false
-			mockServer.handlePostMessage.mockResolvedValueOnce(false);
+			mockServerManager.handlePostMessage.mockResolvedValueOnce(false);
 
 			// Call the webhook method
 			const result = await mcpTrigger.webhook(mockContext);
@@ -105,7 +105,7 @@ describe('McpTrigger Node', () => {
 			await mcpTrigger.webhook(mockContext);
 
 			// Verify that connectTransport was called with the sanitized server name
-			expect(mockServer.createServerAndTransport).toHaveBeenCalledWith(
+			expect(mockServerManager.createServerAndTransport).toHaveBeenCalledWith(
 				'My_custom_MCP_server_',
 				'/custom-path/messages',
 				mockResponse,
@@ -123,7 +123,7 @@ describe('McpTrigger Node', () => {
 			await mcpTrigger.webhook(mockContext);
 
 			// Verify that connectTransport was called with the default server name
-			expect(mockServer.createServerAndTransport).toHaveBeenCalledWith(
+			expect(mockServerManager.createServerAndTransport).toHaveBeenCalledWith(
 				'n8n-mcp-server',
 				'/custom-path/messages',
 				mockResponse,

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpTrigger.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpTrigger.node.test.ts
@@ -7,7 +7,6 @@ import type { INode, IWebhookFunctions } from 'n8n-workflow';
 import * as helpers from '@utils/helpers';
 
 import type { McpServer } from '../McpServer';
-import { McpServerSingleton } from '../McpServer';
 import { McpTrigger } from '../McpTrigger.node';
 
 const mockTool = mock<Tool>({ name: 'mockTool' });
@@ -49,6 +48,7 @@ describe('McpTrigger Node', () => {
 
 			// Verify that the connectTransport method was called with correct URL
 			expect(mockServer.connectTransport).toHaveBeenCalledWith(
+				'McpTrigger',
 				'/custom-path/messages',
 				mockResponse,
 			);
@@ -104,17 +104,17 @@ describe('McpTrigger Node', () => {
 			// Call the webhook method
 			await mcpTrigger.webhook(mockContext);
 
-			// Verify that McpServerSingleton.instance was called with sanitized server name
-			expect(McpServerSingleton.instance).toHaveBeenCalledWith(
+			// Verify that connectTransport was called with the sanitized server name
+			expect(mockServer.connectTransport).toHaveBeenCalledWith(
 				'My_custom_MCP_server_',
-				mockContext.logger,
+				'/custom-path/messages',
+				mockResponse,
 			);
 		});
 
 		it('should use default server name for version 1', async () => {
 			// Configure node with version 1
 			mockContext.getNode.mockReturnValue({
-				name: 'My Custom MCP Server!',
 				typeVersion: 1,
 			} as INode);
 			mockContext.getWebhookName.mockReturnValue('setup');
@@ -122,10 +122,11 @@ describe('McpTrigger Node', () => {
 			// Call the webhook method
 			await mcpTrigger.webhook(mockContext);
 
-			// Verify that McpServerSingleton.instance was called with default name
-			expect(McpServerSingleton.instance).toHaveBeenCalledWith(
+			// Verify that connectTransport was called with the default server name
+			expect(mockServer.connectTransport).toHaveBeenCalledWith(
 				'n8n-mcp-server',
-				mockContext.logger,
+				'/custom-path/messages',
+				mockResponse,
 			);
 		});
 	});


### PR DESCRIPTION
## Summary


* Currently MCP servers use the static name 'n8n-mcp-server' causing problem when multiple proxies proxy the server.
In this PR, when the MCP server is setup we use the MCP Trigger node's name as the name of the server.
The node's version is incremented to `1.1` from which these changes apply.
* Cleaned up the MCP server implementation. We now use an `McpServerManager` which is responsible for creating and keeping account of MCP servers & transports.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-883/community-issue-mcp-servers-all-use-the-same-server-name
https://linear.app/n8n/issue/AI-937/clean-mcp-server-trigger
Closes #14724 

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
