### PR TITLE
feat: add project:executor role with workflow execution permissions

### DIFF
--- a/packages/@n8n/db/src/entities/types-db.ts
+++ b/packages/@n8n/db/src/entities/types-db.ts
@@ -329,7 +329,8 @@ export type ProjectRole =
 	| 'project:personalOwner'
 	| 'project:admin'
 	| 'project:editor'
-	| 'project:viewer';
+	| 'project:viewer'
+	| 'project:executor';
 
 export interface IGetExecutionsQueryFilter {
 	id?: FindOperator<string> | string;

--- a/packages/@n8n/permissions/src/__tests__/schemas.test.ts
+++ b/packages/@n8n/permissions/src/__tests__/schemas.test.ts
@@ -57,6 +57,7 @@ describe('projectRoleSchema', () => {
 		{ name: 'valid role: project:admin', value: 'project:admin', expected: true },
 		{ name: 'valid role: project:editor', value: 'project:editor', expected: true },
 		{ name: 'valid role: project:viewer', value: 'project:viewer', expected: true },
+		{ name: 'valid role: project:executor', value: 'project:executor', expected: true },
 		{ name: 'invalid role', value: 'invalid-role', expected: false },
 	])('should validate $name', ({ value, expected }) => {
 		const result = projectRoleSchema.safeParse(value);

--- a/packages/@n8n/permissions/src/roles/all-roles.ts
+++ b/packages/@n8n/permissions/src/roles/all-roles.ts
@@ -15,6 +15,7 @@ const ROLE_NAMES: Record<AllRoleTypes, string> = {
 	'project:admin': 'Project Admin',
 	'project:editor': 'Project Editor',
 	'project:viewer': 'Project Viewer',
+	'project:executor': 'Project Executor',
 	'credential:user': 'Credential User',
 	'credential:owner': 'Credential Owner',
 	'workflow:owner': 'Workflow Owner',

--- a/packages/@n8n/permissions/src/roles/role-maps.ee.ts
+++ b/packages/@n8n/permissions/src/roles/role-maps.ee.ts
@@ -12,6 +12,7 @@ import {
 	PERSONAL_PROJECT_OWNER_SCOPES,
 	PROJECT_EDITOR_SCOPES,
 	PROJECT_VIEWER_SCOPES,
+	PROJECT_EXECUTOR_SCOPES,
 } from './scopes/project-scopes.ee';
 import {
 	WORKFLOW_SHARING_OWNER_SCOPES,
@@ -36,6 +37,7 @@ export const PROJECT_SCOPE_MAP: Record<ProjectRole, Scope[]> = {
 	'project:personalOwner': PERSONAL_PROJECT_OWNER_SCOPES,
 	'project:editor': PROJECT_EDITOR_SCOPES,
 	'project:viewer': PROJECT_VIEWER_SCOPES,
+	'project:executor': PROJECT_EXECUTOR_SCOPES,
 };
 
 export const CREDENTIALS_SHARING_SCOPE_MAP: Record<CredentialSharingRole, Scope[]> = {

--- a/packages/@n8n/permissions/src/roles/scopes/project-scopes.ee.ts
+++ b/packages/@n8n/permissions/src/roles/scopes/project-scopes.ee.ts
@@ -90,3 +90,5 @@ export const PROJECT_VIEWER_SCOPES: Scope[] = [
 	'folder:read',
 	'folder:list',
 ];
+
+export const PROJECT_EXECUTOR_SCOPES: Scope[] = [...PROJECT_VIEWER_SCOPES, 'workflow:execute'];

--- a/packages/@n8n/permissions/src/schemas.ee.ts
+++ b/packages/@n8n/permissions/src/schemas.ee.ts
@@ -12,7 +12,7 @@ export const personalRoleSchema = z.enum([
 	'project:personalOwner', // personalOwner is only used for personal projects
 ]);
 
-export const teamRoleSchema = z.enum(['project:admin', 'project:editor', 'project:viewer']);
+export const teamRoleSchema = z.enum(['project:admin', 'project:editor', 'project:viewer', 'project:executor']);
 
 export const projectRoleSchema = z.enum([...personalRoleSchema.options, ...teamRoleSchema.options]);
 

--- a/packages/@n8n/permissions/src/utilities/__tests__/get-role-scopes.test.ts
+++ b/packages/@n8n/permissions/src/utilities/__tests__/get-role-scopes.test.ts
@@ -1,15 +1,39 @@
 import type { AllRoleTypes, Resource } from '../../types.ee';
 import { getRoleScopes, COMBINED_ROLE_MAP } from '../get-role-scopes.ee';
+import {
+	PROJECT_VIEWER_SCOPES,
+	PROJECT_EXECUTOR_SCOPES,
+} from '../../roles/scopes/project-scopes.ee';
 
 describe('getRoleScopes', () => {
 	describe('role scope retrieval', () => {
-		test.each(['global:owner', 'global:admin', 'project:admin'] satisfies AllRoleTypes[])(
-			'should return scopes for %s',
-			(role) => {
-				const scopes = getRoleScopes(role);
-				expect(scopes).toEqual(COMBINED_ROLE_MAP[role]);
-			},
-		);
+		test.each([
+			'global:owner',
+			'global:admin',
+			'project:admin',
+			// Add other roles as needed or test them specifically
+		] satisfies AllRoleTypes[])('should return scopes for %s from COMBINED_ROLE_MAP', (role) => {
+			const scopes = getRoleScopes(role);
+			expect(scopes).toEqual(COMBINED_ROLE_MAP[role]);
+		});
+
+		test('should return correct scopes for project:viewer', () => {
+			const scopes = getRoleScopes('project:viewer');
+			expect(scopes).toEqual(expect.arrayContaining(PROJECT_VIEWER_SCOPES));
+			expect(scopes.length).toEqual(PROJECT_VIEWER_SCOPES.length);
+		});
+
+		test('should return correct scopes for project:executor', () => {
+			const scopes = getRoleScopes('project:executor');
+			// Check that all viewer scopes are present
+			expect(scopes).toEqual(expect.arrayContaining(PROJECT_VIEWER_SCOPES));
+			// Check that the execute scope is present
+			expect(scopes).toContain('workflow:execute');
+			// Check the total number of scopes to match PROJECT_EXECUTOR_SCOPES
+			expect(scopes.length).toEqual(PROJECT_EXECUTOR_SCOPES.length);
+			// For a more precise check, ensure set equality
+			expect(new Set(scopes)).toEqual(new Set(PROJECT_EXECUTOR_SCOPES));
+		});
 	});
 
 	describe('resource filtering', () => {


### PR DESCRIPTION
- Add new project:executor role that extends project:viewer with workflow:execute scope
- Update ProjectRole type definitions and schema validation
- Add comprehensive test coverage for the new role
- Update role mappings and display names

The project:executor role provides a middle ground between project:viewer (read-only) and project:editor (full edit permissions), allowing users to view project resources and execute workflows without modification rights.

This enhances granular project permissions by providing a dedicated role for users who need to execute workflows but should not have edit access.

Resolves: Enhanced granular project permissions

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
