### PR TITLE
feat(core): Add config to override default database ping interval and default idle connection timeout

### DIFF
--- a/packages/@n8n/config/src/configs/database.config.ts
+++ b/packages/@n8n/config/src/configs/database.config.ts
@@ -84,6 +84,10 @@ class PostgresConfig {
 	@Env('DB_POSTGRESDB_CONNECTION_TIMEOUT')
 	connectionTimeoutMs: number = 20_000;
 
+	/** Postgres idle connection timeout (ms) */
+	@Env('DB_POSTGRESDB_IDLE_CONNECTION_TIMEOUT')
+	idleTimeoutMs: number = 30_000;
+
 	@Nested
 	ssl: PostgresSSLConfig;
 }
@@ -157,6 +161,12 @@ export class DatabaseConfig {
 	/** Prefix for table names */
 	@Env('DB_TABLE_PREFIX')
 	tablePrefix: string = '';
+
+	/**
+	 * The interval in seconds to ping the database to check if the connection is still alive.
+	 */
+	@Env('DB_PING_INTERVAL_SECONDS')
+	pingIntervalSeconds: number = 2;
 
 	@Nested
 	logging: LoggingConfig;

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -62,6 +62,7 @@ describe('GlobalConfig', () => {
 					rejectUnauthorized: true,
 				},
 				user: 'postgres',
+				idleTimeoutMs: 30_000,
 			},
 			sqlite: {
 				database: 'database.sqlite',
@@ -72,6 +73,7 @@ describe('GlobalConfig', () => {
 			tablePrefix: '',
 			type: 'sqlite',
 			isLegacySqlite: true,
+			pingIntervalSeconds: 2,
 		},
 		credentials: {
 			defaultName: 'My credentials',
@@ -322,7 +324,9 @@ describe('GlobalConfig', () => {
 		process.env = {
 			DB_POSTGRESDB_HOST: 'some-host',
 			DB_POSTGRESDB_USER: 'n8n',
+			DB_POSTGRESDB_IDLE_CONNECTION_TIMEOUT: '10000',
 			DB_TABLE_PREFIX: 'test_',
+			DB_PING_INTERVAL_SECONDS: '2',
 			NODES_INCLUDE: '["n8n-nodes-base.hackerNews"]',
 			DB_LOGGING_MAX_EXECUTION_TIME: '0',
 			N8N_METRICS: 'TRUE',
@@ -338,10 +342,12 @@ describe('GlobalConfig', () => {
 					...defaultConfig.database.postgresdb,
 					host: 'some-host',
 					user: 'n8n',
+					idleTimeoutMs: 10_000,
 				},
 				sqlite: defaultConfig.database.sqlite,
 				tablePrefix: 'test_',
 				type: 'sqlite',
+				pingIntervalSeconds: 2,
 			},
 			endpoints: {
 				...defaultConfig.endpoints,

--- a/packages/cli/src/databases/__tests__/db-connection-options.test.ts
+++ b/packages/cli/src/databases/__tests__/db-connection-options.test.ts
@@ -102,6 +102,7 @@ describe('DbConnectionOptions', () => {
 						key: '',
 						rejectUnauthorized: true,
 					},
+					idleTimeoutMs: 30000,
 				};
 			});
 
@@ -121,6 +122,9 @@ describe('DbConnectionOptions', () => {
 					migrations: postgresMigrations,
 					connectTimeoutMS: 20000,
 					ssl: false,
+					extra: {
+						idleTimeoutMillis: 30000,
+					},
 				});
 			});
 

--- a/packages/cli/src/databases/__tests__/db-connection.test.ts
+++ b/packages/cli/src/databases/__tests__/db-connection.test.ts
@@ -1,3 +1,4 @@
+import type { DatabaseConfig } from '@n8n/config';
 import type { Migration } from '@n8n/db';
 import * as migrationHelper from '@n8n/db';
 import { DataSource, type DataSourceOptions } from '@n8n/typeorm';
@@ -17,6 +18,7 @@ describe('DbConnection', () => {
 	let dbConnection: DbConnection;
 	const migrations = [{ name: 'TestMigration1' }, { name: 'TestMigration2' }] as Migration[];
 	const errorReporter = mock<ErrorReporter>();
+	const databaseConfig = mock<DatabaseConfig>();
 	const dataSource = mockDeep<DataSource>({ options: { migrations } });
 	const connectionOptions = mockDeep<DbConnectionOptions>();
 	const postgresOptions: DataSourceOptions = {
@@ -35,7 +37,7 @@ describe('DbConnection', () => {
 		connectionOptions.getOptions.mockReturnValue(postgresOptions);
 		(DataSource as jest.Mock) = jest.fn().mockImplementation(() => dataSource);
 
-		dbConnection = new DbConnection(errorReporter, connectionOptions);
+		dbConnection = new DbConnection(errorReporter, connectionOptions, databaseConfig);
 	});
 
 	describe('init', () => {
@@ -173,6 +175,30 @@ describe('DbConnection', () => {
 			await dbConnection.ping();
 
 			expect(dataSource.query).not.toHaveBeenCalled();
+		});
+
+		it('should execute ping on schedule', async () => {
+			jest.useFakeTimers();
+			try {
+				// ARRANGE
+				dbConnection = new DbConnection(
+					errorReporter,
+					connectionOptions,
+					mock<DatabaseConfig>({
+						pingIntervalSeconds: 1,
+					}),
+				);
+
+				const pingSpy = jest.spyOn(dbConnection as any, 'ping');
+
+				// @ts-expect-error private property
+				dbConnection.scheduleNextPing();
+				jest.advanceTimersByTime(1000);
+
+				expect(pingSpy).toHaveBeenCalled();
+			} finally {
+				jest.useRealTimers();
+			}
 		});
 	});
 });

--- a/packages/cli/src/databases/db-connection-options.ts
+++ b/packages/cli/src/databases/db-connection-options.ts
@@ -131,6 +131,9 @@ export class DbConnectionOptions {
 			migrations: postgresMigrations,
 			connectTimeoutMS: postgresConfig.connectionTimeoutMs,
 			ssl,
+			extra: {
+				idleTimeoutMillis: postgresConfig.idleTimeoutMs,
+			},
 		};
 	}
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

When using postgres or mysql/mariadb as database, typeorm uses a connection pool. When the dabatase password for the current user changes (password rotation for instance), the db-connection ping function that checks the liveness of the db will most likely re-use an existing connection from the pool, that is kept and not refresh when user db password changes. Thus the ping will succeeded, and n8n will still be up even though new connection from the pool will fail.

To fix that, I suggest to offer the possibility to change the database ping interval as well as the idle connection timeout for a connection in the pool.

That way, a user could setup the idle connection timeout to be less than the ping connection timeout, so that a new connection is created for each ping, thus re-validating the credentials.

We should see later if we want this behavior (each ping connection to be new) to be by default.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2846/community-issue-endpoint-healthzreadiness-returning-statusok-even-when
https://github.com/n8n-io/n8n/issues/15480

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
