### PR TITLE
feat(core): Allow logging JSON to stdout

### DIFF
--- a/packages/@n8n/backend-common/src/logging/__tests__/logger.test.ts
+++ b/packages/@n8n/backend-common/src/logging/__tests__/logger.test.ts
@@ -37,6 +37,152 @@ describe('Logger', () => {
 		});
 	});
 
+	describe('formats', () => {
+		afterEach(() => {
+			jest.resetAllMocks();
+		});
+
+		test('log text, if `config.logging.format` is set to `default`', () => {
+			// ARRANGE
+			const stdoutSpy = jest.spyOn(process.stdout, 'write').mockReturnValue(true);
+			const globalConfig = mock<GlobalConfig>({
+				logging: {
+					format: 'default',
+					level: 'info',
+					outputs: ['console'],
+					scopes: [],
+				},
+			});
+			const logger = new Logger(globalConfig, mock<InstanceSettingsConfig>());
+			const testMessage = 'Test Message';
+			const testMetadata = { test: 1 };
+
+			// ACT
+			logger.info(testMessage, testMetadata);
+
+			// ASSERT
+			expect(stdoutSpy).toHaveBeenCalledTimes(1);
+
+			const output = stdoutSpy.mock.lastCall?.[0];
+			if (typeof output !== 'string') {
+				fail(`expected 'output' to be of type 'string', got ${typeof output}`);
+			}
+
+			expect(output).toEqual(`${testMessage}\n`);
+		});
+
+		test('log json, if `config.logging.format` is set to `json`', () => {
+			// ARRANGE
+			const stdoutSpy = jest.spyOn(process.stdout, 'write').mockReturnValue(true);
+			const globalConfig = mock<GlobalConfig>({
+				logging: {
+					format: 'json',
+					level: 'info',
+					outputs: ['console'],
+					scopes: [],
+				},
+			});
+			const logger = new Logger(globalConfig, mock<InstanceSettingsConfig>());
+			const testMessage = 'Test Message';
+			const testMetadata = { test: 1 };
+
+			// ACT
+			logger.info(testMessage, testMetadata);
+
+			// ASSERT
+			expect(stdoutSpy).toHaveBeenCalledTimes(1);
+			const output = stdoutSpy.mock.lastCall?.[0];
+			if (typeof output !== 'string') {
+				fail(`expected 'output' to be of type 'string', got ${typeof output}`);
+			}
+
+			expect(() => JSON.parse(output)).not.toThrow();
+			const parsedOutput = JSON.parse(output);
+
+			expect(parsedOutput).toMatchObject({
+				message: testMessage,
+				level: 'info',
+				metadata: {
+					...testMetadata,
+					timestamp: expect.any(String),
+				},
+			});
+		});
+
+		test('apply scope filters, if `config.logging.format` is set to `json`', () => {
+			// ARRANGE
+			const stdoutSpy = jest.spyOn(process.stdout, 'write').mockReturnValue(true);
+			const globalConfig = mock<GlobalConfig>({
+				logging: {
+					format: 'json',
+					level: 'info',
+					outputs: ['console'],
+					scopes: ['push'],
+				},
+			});
+			const logger = new Logger(globalConfig, mock<InstanceSettingsConfig>());
+			const redisLogger = logger.scoped('redis');
+			const pushLogger = logger.scoped('push');
+			const testMessage = 'Test Message';
+			const testMetadata = { test: 1 };
+
+			// ACT
+			redisLogger.info(testMessage, testMetadata);
+			pushLogger.info(testMessage, testMetadata);
+
+			// ASSERT
+			expect(stdoutSpy).toHaveBeenCalledTimes(1);
+		});
+
+		test('log errors in metadata with stack trace, if `config.logging.format` is set to `json`', () => {
+			// ARRANGE
+			const stdoutSpy = jest.spyOn(process.stdout, 'write').mockReturnValue(true);
+			const globalConfig = mock<GlobalConfig>({
+				logging: {
+					format: 'json',
+					level: 'info',
+					outputs: ['console'],
+					scopes: [],
+				},
+			});
+			const logger = new Logger(globalConfig, mock<InstanceSettingsConfig>());
+			const testMessage = 'Test Message';
+			const parentError = new Error('Parent', { cause: 'just a string' });
+			const testError = new Error('Test', { cause: parentError });
+			const testMetadata = { error: testError };
+
+			// ACT
+			logger.info(testMessage, testMetadata);
+
+			// ASSERT
+			expect(stdoutSpy).toHaveBeenCalledTimes(1);
+			const output = stdoutSpy.mock.lastCall?.[0];
+			if (typeof output !== 'string') {
+				fail(`expected 'output' to be of type 'string', got ${typeof output}`);
+			}
+
+			expect(() => JSON.parse(output)).not.toThrow();
+			const parsedOutput = JSON.parse(output);
+
+			expect(parsedOutput).toMatchObject({
+				message: testMessage,
+				metadata: {
+					error: {
+						name: testError.name,
+						message: testError.message,
+						stack: testError.stack,
+						cause: {
+							name: parentError.name,
+							message: parentError.message,
+							stack: parentError.stack,
+							cause: parentError.cause,
+						},
+					},
+				},
+			});
+		});
+	});
+
 	describe('transports', () => {
 		afterEach(() => {
 			jest.restoreAllMocks();

--- a/packages/@n8n/backend-common/src/logging/__tests__/logger.test.ts
+++ b/packages/@n8n/backend-common/src/logging/__tests__/logger.test.ts
@@ -42,12 +42,12 @@ describe('Logger', () => {
 			jest.resetAllMocks();
 		});
 
-		test('log text, if `config.logging.format` is set to `default`', () => {
+		test('log text, if `config.logging.format` is set to `text`', () => {
 			// ARRANGE
 			const stdoutSpy = jest.spyOn(process.stdout, 'write').mockReturnValue(true);
 			const globalConfig = mock<GlobalConfig>({
 				logging: {
-					format: 'default',
+					format: 'text',
 					level: 'info',
 					outputs: ['console'],
 					scopes: [],

--- a/packages/@n8n/backend-common/src/logging/logger.ts
+++ b/packages/@n8n/backend-common/src/logging/logger.ts
@@ -83,14 +83,22 @@ export class Logger implements LoggerType {
 
 	private detailedErrorStringify(
 		error: unknown,
+		seen: Set<unknown> = new Set(),
 	): { name: string; message: string; stack?: string; cause: unknown } | string {
 		if (!(error instanceof Error)) return String(error);
+
+		// prevent infinite recursion
+		let cause: unknown;
+		if (error.cause && !seen.has(error.cause)) {
+			seen.add(error.cause);
+			cause = this.detailedErrorStringify(error.cause, seen);
+		}
 
 		return {
 			name: error.name,
 			message: error.message,
 			stack: error.stack,
-			cause: error.cause ? this.detailedErrorStringify(error.cause) : undefined,
+			cause,
 		};
 	}
 

--- a/packages/@n8n/backend-common/src/logging/logger.ts
+++ b/packages/@n8n/backend-common/src/logging/logger.ts
@@ -132,6 +132,7 @@ export class Logger implements LoggerType {
 			winston.format.timestamp(),
 			winston.format.metadata(),
 			winston.format.json(),
+			this.scopeFilter(),
 		);
 	}
 

--- a/packages/@n8n/backend-common/src/logging/logger.ts
+++ b/packages/@n8n/backend-common/src/logging/logger.ts
@@ -127,14 +127,18 @@ export class Logger implements LoggerType {
 		}
 	}
 
+	private jsonConsoleFormat() {
+		return winston.format.combine(
+			winston.format.timestamp(),
+			winston.format.metadata(),
+			winston.format.json(),
+		);
+	}
+
 	private setConsoleTransport() {
 		const format =
 			this.globalConfig.logging.format === 'json'
-				? winston.format.combine(
-						winston.format.timestamp(),
-						winston.format.metadata(),
-						winston.format.json(),
-					)
+				? this.jsonConsoleFormat()
 				: this.level === 'debug' && inDevelopment
 					? this.debugDevConsoleFormat()
 					: this.level === 'debug' && inProduction
@@ -215,12 +219,6 @@ export class Logger implements LoggerType {
 	}
 
 	private setFileTransport() {
-		const format = winston.format.combine(
-			winston.format.timestamp(),
-			winston.format.metadata(),
-			winston.format.json(),
-		);
-
 		const filename = path.isAbsolute(this.globalConfig.logging.file.location)
 			? this.globalConfig.logging.file.location
 			: path.join(this.instanceSettingsConfig.n8nFolder, this.globalConfig.logging.file.location);
@@ -230,7 +228,7 @@ export class Logger implements LoggerType {
 		this.internalLogger.add(
 			new winston.transports.File({
 				filename,
-				format,
+				format: this.jsonConsoleFormat(),
 				maxsize: fileSizeMax * 1_048_576, // config * 1 MiB in bytes
 				maxFiles: fileCountMax,
 			}),

--- a/packages/@n8n/backend-common/src/logging/logger.ts
+++ b/packages/@n8n/backend-common/src/logging/logger.ts
@@ -109,11 +109,17 @@ export class Logger implements LoggerType {
 
 	private setConsoleTransport() {
 		const format =
-			this.level === 'debug' && inDevelopment
-				? this.debugDevConsoleFormat()
-				: this.level === 'debug' && inProduction
-					? this.debugProdConsoleFormat()
-					: winston.format.printf(({ message }: { message: string }) => message);
+			this.globalConfig.logging.format === 'json'
+				? winston.format.combine(
+						winston.format.timestamp(),
+						winston.format.metadata(),
+						winston.format.json(),
+					)
+				: this.level === 'debug' && inDevelopment
+					? this.debugDevConsoleFormat()
+					: this.level === 'debug' && inProduction
+						? this.debugProdConsoleFormat()
+						: winston.format.printf(({ message }: { message: string }) => message);
 
 		this.internalLogger.add(new winston.transports.Console({ format }));
 	}

--- a/packages/@n8n/backend-common/src/logging/logger.ts
+++ b/packages/@n8n/backend-common/src/logging/logger.ts
@@ -144,15 +144,20 @@ export class Logger implements LoggerType {
 		);
 	}
 
+	private pickConsoleTransportFormat() {
+		if (this.globalConfig.logging.format === 'json') {
+			return this.jsonConsoleFormat();
+		} else if (this.level === 'debug' && inDevelopment) {
+			return this.debugDevConsoleFormat();
+		} else if (this.level === 'debug' && inProduction) {
+			return this.debugProdConsoleFormat();
+		} else {
+			return winston.format.printf(({ message }: { message: string }) => message);
+		}
+	}
+
 	private setConsoleTransport() {
-		const format =
-			this.globalConfig.logging.format === 'json'
-				? this.jsonConsoleFormat()
-				: this.level === 'debug' && inDevelopment
-					? this.debugDevConsoleFormat()
-					: this.level === 'debug' && inProduction
-						? this.debugProdConsoleFormat()
-						: winston.format.printf(({ message }: { message: string }) => message);
+		const format = this.pickConsoleTransportFormat();
 
 		this.internalLogger.add(new winston.transports.Console({ format }));
 	}

--- a/packages/@n8n/backend-common/src/logging/logger.ts
+++ b/packages/@n8n/backend-common/src/logging/logger.ts
@@ -81,7 +81,7 @@ export class Logger implements LoggerType {
 		return scopedLogger;
 	}
 
-	private detailedErrorStringify(
+	private serializeError(
 		error: unknown,
 		seen: Set<unknown> = new Set(),
 	): { name: string; message: string; stack?: string; cause: unknown } | string {
@@ -91,7 +91,7 @@ export class Logger implements LoggerType {
 		let cause: unknown;
 		if (error.cause && !seen.has(error.cause)) {
 			seen.add(error.cause);
-			cause = this.detailedErrorStringify(error.cause, seen);
+			cause = this.serializeError(error.cause, seen);
 		}
 
 		return {
@@ -116,7 +116,7 @@ export class Logger implements LoggerType {
 		for (const key of Object.keys(metadata)) {
 			const value = metadata[key];
 			if (value instanceof Error) {
-				metadata[key] = this.detailedErrorStringify(value);
+				metadata[key] = this.serializeError(value);
 			}
 		}
 

--- a/packages/@n8n/config/src/configs/logging.config.ts
+++ b/packages/@n8n/config/src/configs/logging.config.ts
@@ -67,7 +67,7 @@ export class LoggingConfig {
 	outputs: CommaSeparatedStringArray<'console' | 'file'> = ['console'];
 
 	@Env('N8N_LOG_FORMAT')
-	format: 'default' | 'json';
+	format: 'default' | 'json' = 'default';
 
 	@Nested
 	file: FileLoggingConfig;

--- a/packages/@n8n/config/src/configs/logging.config.ts
+++ b/packages/@n8n/config/src/configs/logging.config.ts
@@ -74,7 +74,7 @@ export class LoggingConfig {
 	 * monitoring as well as debugging.
 	 */
 	@Env('N8N_LOG_FORMAT')
-	format: 'default' | 'json' = 'default';
+	format: 'text' | 'json' = 'text';
 
 	@Nested
 	file: FileLoggingConfig;

--- a/packages/@n8n/config/src/configs/logging.config.ts
+++ b/packages/@n8n/config/src/configs/logging.config.ts
@@ -66,6 +66,13 @@ export class LoggingConfig {
 	@Env('N8N_LOG_OUTPUT')
 	outputs: CommaSeparatedStringArray<'console' | 'file'> = ['console'];
 
+	/**
+	 * What format the logs should have.
+	 * `text` is only printing the human readable messages.
+	 * `json` is printing one JSON object per line containing the message, level,
+	 * timestamp and all the metadata. This is very useful for production
+	 * monitoring as well as debugging.
+	 */
 	@Env('N8N_LOG_FORMAT')
 	format: 'default' | 'json' = 'default';
 

--- a/packages/@n8n/config/src/configs/logging.config.ts
+++ b/packages/@n8n/config/src/configs/logging.config.ts
@@ -66,6 +66,9 @@ export class LoggingConfig {
 	@Env('N8N_LOG_OUTPUT')
 	outputs: CommaSeparatedStringArray<'console' | 'file'> = ['console'];
 
+	@Env('N8N_LOG_FORMAT')
+	format: 'default' | 'json';
+
 	@Nested
 	file: FileLoggingConfig;
 

--- a/packages/@n8n/config/src/configs/logging.config.ts
+++ b/packages/@n8n/config/src/configs/logging.config.ts
@@ -70,8 +70,7 @@ export class LoggingConfig {
 	 * What format the logs should have.
 	 * `text` is only printing the human readable messages.
 	 * `json` is printing one JSON object per line containing the message, level,
-	 * timestamp and all the metadata. This is very useful for production
-	 * monitoring as well as debugging.
+	 * timestamp and all the metadata.
 	 */
 	@Env('N8N_LOG_FORMAT')
 	format: 'text' | 'json' = 'text';

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -241,7 +241,7 @@ describe('GlobalConfig', () => {
 		},
 		logging: {
 			level: 'info',
-			format: 'default',
+			format: 'text',
 			outputs: ['console'],
 			file: {
 				fileCountMax: 100,

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -241,6 +241,7 @@ describe('GlobalConfig', () => {
 		},
 		logging: {
 			level: 'info',
+			format: 'default',
 			outputs: ['console'],
 			file: {
 				fileCountMax: 100,

--- a/packages/cli/src/active-workflow-manager.ts
+++ b/packages/cli/src/active-workflow-manager.ts
@@ -425,9 +425,7 @@ export class ActiveWorkflowManager {
 		if (dbWorkflowIds.length === 0) return;
 
 		if (this.instanceSettings.isLeader) {
-			this.logger.info(' ================================');
-			this.logger.info('   Start Active Workflows:');
-			this.logger.info(' ================================');
+			this.logger.info('Start Active Workflows:');
 		}
 
 		const batches = chunk(dbWorkflowIds, this.workflowsConfig.activationBatchSize);
@@ -456,23 +454,18 @@ export class ActiveWorkflowManager {
 			});
 
 			if (added.webhooks || added.triggersAndPollers) {
-				this.logger.info(`   - ${formatWorkflow(dbWorkflow)})`);
-				this.logger.info('     => Started');
-				this.logger.debug(`Activated workflow ${formatWorkflow(dbWorkflow)}`, {
+				this.logger.info(`Activated workflow ${formatWorkflow(dbWorkflow)}`, {
 					workflowName: dbWorkflow.name,
 					workflowId: dbWorkflow.id,
 				});
 			}
 		} catch (error) {
 			this.errorReporter.error(error);
-			this.logger.info(
-				`     => ERROR: Workflow ${formatWorkflow(dbWorkflow)} could not be activated on first try, keep on trying if not an auth issue`,
-			);
-
-			this.logger.info(`               ${error.message}`);
 			this.logger.error(
 				`Issue on initial workflow activation try of ${formatWorkflow(dbWorkflow)} (startup)`,
 				{
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+					error,
 					workflowName: dbWorkflow.name,
 					workflowId: dbWorkflow.id,
 				},
@@ -723,10 +716,12 @@ export class ActiveWorkflowManager {
 				}
 
 				this.logger.info(
-					` -> Activation of workflow "${workflowName}" (${workflowId}) did fail with error: "${
+					`Activation of workflow "${workflowName}" (${workflowId}) did fail with error: "${
 						error.message as string
 					}" | retry in ${Math.floor(lastTimeout / 1000)} seconds`,
 					{
+						// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+						error,
 						workflowId,
 						workflowName,
 					},
@@ -736,13 +731,10 @@ export class ActiveWorkflowManager {
 				this.queuedActivations[workflowId].timeout = setTimeout(retryFunction, lastTimeout);
 				return;
 			}
-			this.logger.info(
-				` -> Activation of workflow "${workflowName}" (${workflowId}) was successful!`,
-				{
-					workflowId,
-					workflowName,
-				},
-			);
+			this.logger.info(`Activation of workflow "${workflowName}" (${workflowId}) was successful!`, {
+				workflowId,
+				workflowName,
+			});
 		};
 
 		// Just to be sure that there is not chance that for any reason

--- a/packages/core/src/instance-settings/instance-settings.ts
+++ b/packages/core/src/instance-settings/instance-settings.ts
@@ -186,7 +186,7 @@ export class InstanceSettings {
 				errorMessage: `Error parsing n8n-config file "${this.settingsFile}". It does not seem to be valid JSON.`,
 			});
 
-			if (!inTest) console.info(`User settings loaded from: ${this.settingsFile}`);
+			if (!inTest) this.logger.info(`User settings loaded from: ${this.settingsFile}`);
 
 			const { encryptionKey, tunnelSubdomain } = settings;
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

- **allow logging json to the console**
- **allow logging errors**

Before this we would always log text to stdout, which is sub-optimal for production use cases because we loose all of the metadata that log ingestion systems could use:
- there is no log level apart from error and info
- all metadata is lost (unless they are inlined in the message, e.g. workflow and execution IDs)
- especially error stack traces are lost 

This PR adds a new environment variable to change the log's output format `N8N_LOG_FORMAT`. It can be set to `default` and `json` and defaults to `default`, which is the current text based output.


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
https://linear.app/n8n/issue/PAY-2779/allow-logging-json-to-stdout


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs/pull/3215) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
