### PR TITLE
fix: Workflow deactivation error should not block deactivation (no-changelog)

### DIFF
--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -54,6 +54,7 @@ import {
 	UnexpectedError,
 	UserError,
 	OperationalError,
+	TriggerCloseError,
 } from 'n8n-workflow';
 import PCancelable from 'p-cancelable';
 
@@ -1572,7 +1573,14 @@ export class WorkflowExecute {
 								if (runNodeData.closeFunction) {
 									// Explanation why we do this can be found in n8n-workflow/Workflow.ts -> runNode
 
-									closeFunction = runNodeData.closeFunction();
+									try {
+										closeFunction = runNodeData.closeFunction();
+									} catch (error) {
+										throw new TriggerCloseError(executionNode, {
+											cause: error as Error,
+											level: 'warning',
+										});
+									}
 								}
 							}
 


### PR DESCRIPTION
## Summary
This PR fixes Trigger nodes so that workflow deactivation error does not block deactivation, by throwing TriggerCloseError

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1699/workflow-deactivation-error-should-not-block-deactivation

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)