### PR TITLE
Docs: Update a new contributor graph in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ Additional information about the license model can be found in the [docs](https:
 
 Found a bug 🐛 or have a feature idea ✨? Check our [Contributing Guide](https://github.com/n8n-io/n8n/blob/master/CONTRIBUTING.md) to get started.
 
+<a href="https://openomy.app/github/n8n-io/n8n" target="_blank" rel="noopener noreferrer" style="display: block; width: 100%;" align="center">
+<img src="https://openomy.app/svg?repo=n8n-io/n8n&chart=bubble&latestMonth=3" target="_blank" alt="Contribution Chart" style="display: block; width: 100%;" />
+</a>
+
 ## Join the Team
 
 Want to shape the future of automation? Check out our [job posts](https://n8n.io/careers) and join our team!


### PR DESCRIPTION
Hi n8n-io!

n8n is a vibrant open-source community where its products are loved by thousands of users and developers. As people use it, they contribute by raising issues, engaging in discussions, or directly contributing code, all of which help in continuously improving n8n.

However, GitHub's default contributor list simply enumerates users who have committed code, failing to reflect the broader range of community contributors.

Therefore, we have designed a new chart that showcases active contributors from three perspectives: issues, PRs, and discussions. It can be embedded within the README just like star-history:

<a href="https://openomy.app/github/n8n-io/n8n" target="_blank" rel="noopener noreferrer" style="display: block; width: 100%;" align="center">
<img src="https://openomy.app/svg?repo=n8n-io/n8n&chart=bubble&latestMonth=3" target="_blank" alt="Contribution Chart" style="display: block; width: 100%;" />
</a>

By clicking the image, you can view the specific contributions made by each individual:

<img width="1091" alt="image" src="https://github.com/user-attachments/assets/6a7f827a-51a5-417a-9e64-a30523bb879a" />

Currently, we have received recognition from communities such as [Ant Design](https://github.com/ant-design/ant-design?rgh-link-date=2025-05-27T16%3A01%3A58Z), [element-plus](https://github.com/element-plus/element-plus?rgh-link-date=2025-05-27T16%3A01%3A58Z) and 10+ projects. We aim to introduce this solution to more open-source communities and actively seek feedback for ongoing improvement.

We would greatly appreciate it if you could merge this PR. However, if you feel that the style is not appropriate or you don't like this approach, that's perfectly okay as well!

Thanks for your amazing repo!