### PR TITLE
fix: Add Exact Match Option for NDV (no-changelog)

### DIFF
--- a/cypress/composables/ndv.ts
+++ b/cypress/composables/ndv.ts
@@ -36,6 +36,10 @@ export function getInputSelect() {
 	return cy.getByTestId('ndv-input-select').find('input');
 }
 
+export function getInputLinkRun() {
+	return getInputPanel().findChildByTestId('link-run');
+}
+
 export function getMainPanel() {
 	return cy.getByTestId('node-parameters');
 }
@@ -66,6 +70,10 @@ export function getInputTableRows() {
 
 export function getInputTbodyCell(row: number, col: number) {
 	return getInputTableRows().eq(row).find('td').eq(col);
+}
+
+export function getInputRunSelector() {
+	return getInputPanel().findChildByTestId('run-selector');
 }
 
 export function getOutputPanelDataContainer() {
@@ -328,4 +336,8 @@ export function resetHoverState() {
 
 export function setInputDisplayMode(mode: 'Schema' | 'Table' | 'JSON' | 'Binary') {
 	getInputPanel().findChildByTestId('ndv-run-data-display-mode').contains(mode).click();
+}
+
+export function toggleInputRunLinking() {
+	getInputLinkRun().click();
 }

--- a/cypress/composables/ndv.ts
+++ b/cypress/composables/ndv.ts
@@ -76,6 +76,10 @@ export function getInputRunSelector() {
 	return getInputPanel().findChildByTestId('run-selector');
 }
 
+export function getInputPanelItemsCount() {
+	return getInputPanel().getByTestId('ndv-items-count');
+}
+
 export function getOutputPanelDataContainer() {
 	return getOutputPanel().findChildByTestId('ndv-data-container');
 }

--- a/cypress/composables/workflow.ts
+++ b/cypress/composables/workflow.ts
@@ -218,12 +218,13 @@ export function addNodeToCanvas(
 	});
 
 	if (!preventNdvClose) {
-		cy.get('body').type('{esc}');
+		clickGetBackToCanvas();
 	}
 }
 
 export function navigateToNewWorkflowPage(preventNodeViewUnload = true) {
 	cy.visit(ROUTES.NEW_WORKFLOW_PAGE);
+	cy.getByTestId('node-creator-plus-button').should('be.visible');
 	cy.waitForLoad();
 	cy.window().then((win) => {
 		win.preventNodeViewBeforeUnload = preventNodeViewUnload;

--- a/cypress/composables/workflow.ts
+++ b/cypress/composables/workflow.ts
@@ -179,31 +179,47 @@ export function executeWorkflowAndWait(waitForSuccessBannerToDisappear = true) {
 	}
 }
 
+/**
+ * @param nodeDisplayName - The name of the node to add to the canvas
+ * @param plusButtonClick - Whether to click the plus button to open the node creator
+ * @param preventNdvClose - Whether to prevent the Ndv from closing
+ * @param action - The action to select in the node creator
+ * @param useExactMatch - Whether to use an exact match for the node name will use selector instead of enter key
+ */
 export function addNodeToCanvas(
 	nodeDisplayName: string,
 	plusButtonClick = true,
 	preventNdvClose?: boolean,
 	action?: string,
+	useExactMatch = false,
 ) {
 	if (plusButtonClick) {
 		getNodeCreatorPlusButton().click();
 	}
 
 	getNodeCreatorSearchBar().type(nodeDisplayName);
-	getNodeCreatorSearchBar().type('{enter}');
+
+	if (useExactMatch) {
+		cy.getByTestId('node-creator-item-name').contains(nodeDisplayName).click();
+	} else {
+		getNodeCreatorSearchBar().type('{enter}');
+	}
+
 	cy.wait(500);
+
 	cy.get('body').then((body) => {
 		if (body.find('[data-test-id=node-creator]').length > 0) {
 			if (action) {
 				cy.contains(action).click();
 			} else {
-				// Select the first action
 				cy.get('[data-keyboard-nav-type="action"]').eq(0).click();
 			}
 		}
 	});
 
-	if (!preventNdvClose) cy.get('body').type('{esc}');
+	if (!preventNdvClose) {
+		cy.get('body').type('{esc}');
+	}
 }
 
 export function navigateToNewWorkflowPage(preventNodeViewUnload = true) {

--- a/cypress/composables/workflow.ts
+++ b/cypress/composables/workflow.ts
@@ -218,7 +218,7 @@ export function addNodeToCanvas(
 	});
 
 	if (!preventNdvClose) {
-		clickGetBackToCanvas();
+		cy.get('body').type('{esc}');
 	}
 }
 

--- a/cypress/e2e/233-AI-switch-to-logs-on-error.cy.ts
+++ b/cypress/e2e/233-AI-switch-to-logs-on-error.cy.ts
@@ -139,7 +139,7 @@ function createRunDataWithError(inputMessage: string) {
 function setupTestWorkflow(chatTrigger: boolean = false) {
 	// Setup test workflow with AI Agent, Postgres Memory Node (source of error), Calculator Tool, and OpenAI Chat Model
 	if (chatTrigger) {
-		addNodeToCanvas(MANUAL_CHAT_TRIGGER_NODE_NAME, true);
+		addNodeToCanvas(MANUAL_CHAT_TRIGGER_NODE_NAME, true, false, undefined, true);
 	} else {
 		addNodeToCanvas(MANUAL_TRIGGER_NODE_NAME, true);
 	}

--- a/cypress/e2e/30-langchain.cy.ts
+++ b/cypress/e2e/30-langchain.cy.ts
@@ -21,6 +21,7 @@ import {
 	sendManualChatMessage,
 } from '../composables/modals/chat-modal';
 import { setCredentialValues } from '../composables/modals/credential-modal';
+import * as ndv from '../composables/ndv';
 import {
 	clickCreateNewCredential,
 	clickExecuteNode,
@@ -44,7 +45,7 @@ import {
 	disableNode,
 	getExecuteWorkflowButton,
 } from '../composables/workflow';
-import { NDV, WorkflowPage } from '../pages';
+import { WorkflowPage } from '../pages';
 import { createMockNodeExecutionData, runMockWorkflowExecution } from '../utils';
 
 describe('Langchain Integration', () => {
@@ -370,9 +371,8 @@ describe('Langchain Integration', () => {
 		getNodes().should('have.length', 3);
 	});
 
-	it('should render runItems for sub-nodes and allow switching between them', () => {
+	it.only('should render runItems for sub-nodes and allow switching between them', () => {
 		const workflowPage = new WorkflowPage();
-		const ndv = new NDV();
 
 		cy.visit(workflowPage.url);
 		cy.createFixtureWorkflow('In_memory_vector_store_fake_embeddings.json');
@@ -382,44 +382,42 @@ describe('Langchain Integration', () => {
 		workflowPage.actions.executeNode('Populate VS');
 
 		const assertInputOutputText = (text: string, assertion: 'exist' | 'not.exist') => {
-			ndv.getters.outputPanel().contains(text).should(assertion);
-			ndv.getters.inputPanel().contains(text).should(assertion);
+			ndv.getOutputPanel().contains(text).should(assertion);
+			ndv.getOutputPanel().contains(text).should(assertion);
 		};
 
 		workflowPage.actions.openNode('Character Text Splitter');
-		ndv.getters.inputPanel().should('exist');
-		ndv.getters.outputPanel().should('exist');
-		ndv.getters.outputRunSelector().should('exist');
-		ndv.getters.inputRunSelector().should('exist');
-		ndv.getters.inputRunSelector().find('input').should('include.value', '3 of 3');
-		ndv.getters.outputRunSelector().find('input').should('include.value', '3 of 3');
+		ndv.getOutputRunSelector().should('exist');
+		ndv.getInputRunSelector().should('exist');
+		ndv.getInputRunSelector().find('input').should('include.value', '3 of 3');
+		ndv.getOutputRunSelector().find('input').should('include.value', '3 of 3');
 		assertInputOutputText('Kyiv', 'exist');
 		assertInputOutputText('Berlin', 'not.exist');
 		assertInputOutputText('Prague', 'not.exist');
 
-		ndv.actions.changeOutputRunSelector('2 of 3');
+		ndv.changeOutputRunSelector('2 of 3');
 		assertInputOutputText('Berlin', 'exist');
 		assertInputOutputText('Kyiv', 'not.exist');
 		assertInputOutputText('Prague', 'not.exist');
 
-		ndv.actions.changeOutputRunSelector('1 of 3');
+		ndv.changeOutputRunSelector('1 of 3');
 		assertInputOutputText('Prague', 'exist');
 		assertInputOutputText('Berlin', 'not.exist');
 		assertInputOutputText('Kyiv', 'not.exist');
 
-		ndv.actions.toggleInputRunLinking();
-		ndv.actions.changeOutputRunSelector('2 of 3');
-		ndv.getters.inputRunSelector().find('input').should('include.value', '1 of 3');
-		ndv.getters.outputRunSelector().find('input').should('include.value', '2 of 3');
-		ndv.getters.inputPanel().contains('Prague').should('exist');
-		ndv.getters.inputPanel().contains('Berlin').should('not.exist');
+		ndv.toggleInputRunLinking();
+		ndv.changeOutputRunSelector('2 of 3');
+		ndv.getInputRunSelector().find('input').should('include.value', '1 of 3');
+		ndv.getOutputRunSelector().find('input').should('include.value', '2 of 3');
+		ndv.getInputPanel().contains('Prague').should('exist');
+		ndv.getInputPanel().contains('Berlin').should('not.exist');
 
-		ndv.getters.outputPanel().contains('Berlin').should('exist');
-		ndv.getters.outputPanel().contains('Prague').should('not.exist');
+		ndv.getOutputPanel().contains('Berlin').should('exist');
+		ndv.getOutputPanel().contains('Prague').should('not.exist');
 
-		ndv.actions.toggleInputRunLinking();
-		ndv.getters.inputRunSelector().find('input').should('include.value', '1 of 3');
-		ndv.getters.outputRunSelector().find('input').should('include.value', '1 of 3');
+		ndv.toggleInputRunLinking();
+		ndv.getInputRunSelector().find('input').should('include.value', '1 of 3');
+		ndv.getOutputRunSelector().find('input').should('include.value', '1 of 3');
 		assertInputOutputText('Prague', 'exist');
 		assertInputOutputText('Berlin', 'not.exist');
 		assertInputOutputText('Kyiv', 'not.exist');
@@ -525,7 +523,6 @@ describe('Langchain Integration', () => {
 
 	it('should execute up to Node 1 when using partial execution', () => {
 		const workflowPage = new WorkflowPage();
-		const ndv = new NDV();
 
 		cy.visit(workflowPage.url);
 		cy.createFixtureWorkflow('Test_workflow_chat_partial_execution.json');
@@ -533,7 +530,7 @@ describe('Langchain Integration', () => {
 
 		getManualChatModal().find('main').should('not.exist');
 		openNode('Node 1');
-		ndv.actions.execute();
+		ndv.clickExecuteNode();
 
 		getManualChatModal().find('main').should('exist');
 		sendManualChatMessage('Test');

--- a/cypress/e2e/30-langchain.cy.ts
+++ b/cypress/e2e/30-langchain.cy.ts
@@ -29,6 +29,8 @@ import {
 	getRunDataInfoCallout,
 	getOutputPanelTable,
 	checkParameterCheckboxInputByName,
+	getOutputPanelItemsCount,
+	getInputPanelItemsCount,
 } from '../composables/ndv';
 import * as workflow from '../composables/workflow';
 import {
@@ -389,6 +391,10 @@ describe('Langchain Integration', () => {
 		};
 
 		workflowPage.actions.openNode('Character Text Splitter');
+
+		// Wait for the input panel to switch to Debugging mode
+		ndv.getInputPanelItemsCount().should('not.exist');
+
 		ndv.getOutputRunSelector().should('exist');
 		ndv.getInputRunSelector().should('exist');
 		ndv.getInputRunSelector().find('input').should('include.value', '3 of 3');

--- a/cypress/e2e/30-langchain.cy.ts
+++ b/cypress/e2e/30-langchain.cy.ts
@@ -370,7 +370,8 @@ describe('Langchain Integration', () => {
 		getNodes().should('have.length', 3);
 	});
 
-	it('should render runItems for sub-nodes and allow switching between them', () => {
+	// eslint-disable-next-line n8n-local-rules/no-skipped-tests
+	it.skip('should render runItems for sub-nodes and allow switching between them', () => {
 		const workflowPage = new WorkflowPage();
 		const ndv = new NDV();
 

--- a/cypress/e2e/30-langchain.cy.ts
+++ b/cypress/e2e/30-langchain.cy.ts
@@ -372,8 +372,7 @@ describe('Langchain Integration', () => {
 		getNodes().should('have.length', 3);
 	});
 
-	// eslint-disable-next-line n8n-local-rules/no-skipped-tests
-	it.skip('should render runItems for sub-nodes and allow switching between them', () => {
+	it('should render runItems for sub-nodes and allow switching between them', () => {
 		const workflowPage = new WorkflowPage();
 
 		cy.visit(workflowPage.url);

--- a/cypress/e2e/30-langchain.cy.ts
+++ b/cypress/e2e/30-langchain.cy.ts
@@ -132,7 +132,7 @@ describe('Langchain Integration', () => {
 	});
 
 	it('should be able to open and execute Basic LLM Chain node', () => {
-		addNodeToCanvas(MANUAL_CHAT_TRIGGER_NODE_NAME, true);
+		addNodeToCanvas(MANUAL_CHAT_TRIGGER_NODE_NAME, true, false, undefined, true);
 		addNodeToCanvas(BASIC_LLM_CHAIN_NODE_NAME, true);
 
 		addLanguageModelNodeToParent(
@@ -171,7 +171,7 @@ describe('Langchain Integration', () => {
 	});
 
 	it('should be able to open and execute Agent node', () => {
-		addNodeToCanvas(MANUAL_CHAT_TRIGGER_NODE_NAME, true);
+		addNodeToCanvas(MANUAL_CHAT_TRIGGER_NODE_NAME, true, false, undefined, true);
 		addNodeToCanvas(AGENT_NODE_NAME, true);
 
 		addLanguageModelNodeToParent(
@@ -211,7 +211,7 @@ describe('Langchain Integration', () => {
 	});
 
 	it('should add and use Manual Chat Trigger node together with Agent node', () => {
-		addNodeToCanvas(MANUAL_CHAT_TRIGGER_NODE_NAME, true);
+		addNodeToCanvas(MANUAL_CHAT_TRIGGER_NODE_NAME, true, false, undefined, true);
 		addNodeToCanvas(AGENT_NODE_NAME, true);
 
 		addLanguageModelNodeToParent(
@@ -362,7 +362,7 @@ describe('Langchain Integration', () => {
 		getNodes().should('have.length', 3);
 	});
 	it('should not auto-add nodes if ChatTrigger is already present', () => {
-		addNodeToCanvas(MANUAL_CHAT_TRIGGER_NODE_NAME, true);
+		addNodeToCanvas(MANUAL_CHAT_TRIGGER_NODE_NAME, true, false, undefined, true);
 		addNodeToCanvas(AGENT_NODE_NAME, true);
 
 		addNodeToCanvas(AI_LANGUAGE_MODEL_OPENAI_CHAT_MODEL_NODE_NAME, true);
@@ -424,7 +424,7 @@ describe('Langchain Integration', () => {
 	});
 
 	it('should show tool info notice if no existing tools were used during execution', () => {
-		addNodeToCanvas(MANUAL_CHAT_TRIGGER_NODE_NAME, true);
+		addNodeToCanvas(MANUAL_CHAT_TRIGGER_NODE_NAME, true, false, undefined, true);
 		addNodeToCanvas(AGENT_NODE_NAME, true);
 
 		addLanguageModelNodeToParent(
@@ -469,7 +469,7 @@ describe('Langchain Integration', () => {
 	});
 
 	it('should not show tool info notice if tools were used during execution', () => {
-		addNodeToCanvas(MANUAL_CHAT_TRIGGER_NODE_NAME, true);
+		addNodeToCanvas(MANUAL_CHAT_TRIGGER_NODE_NAME, true, false, undefined, true);
 		addNodeToCanvas(AGENT_NODE_NAME, true, true);
 		getRunDataInfoCallout().should('not.exist');
 		clickGetBackToCanvas();

--- a/cypress/e2e/30-langchain.cy.ts
+++ b/cypress/e2e/30-langchain.cy.ts
@@ -371,7 +371,7 @@ describe('Langchain Integration', () => {
 		getNodes().should('have.length', 3);
 	});
 
-	it.only('should render runItems for sub-nodes and allow switching between them', () => {
+	it('should render runItems for sub-nodes and allow switching between them', () => {
 		const workflowPage = new WorkflowPage();
 
 		cy.visit(workflowPage.url);

--- a/cypress/e2e/30-langchain.cy.ts
+++ b/cypress/e2e/30-langchain.cy.ts
@@ -29,8 +29,6 @@ import {
 	getRunDataInfoCallout,
 	getOutputPanelTable,
 	checkParameterCheckboxInputByName,
-	getOutputPanelItemsCount,
-	getInputPanelItemsCount,
 } from '../composables/ndv';
 import * as workflow from '../composables/workflow';
 import {

--- a/cypress/e2e/30-langchain.cy.ts
+++ b/cypress/e2e/30-langchain.cy.ts
@@ -30,6 +30,7 @@ import {
 	getOutputPanelTable,
 	checkParameterCheckboxInputByName,
 } from '../composables/ndv';
+import * as workflow from '../composables/workflow';
 import {
 	addLanguageModelNodeToParent,
 	addMemoryNodeToParent,
@@ -380,6 +381,7 @@ describe('Langchain Integration', () => {
 		workflowPage.actions.deselectAll();
 
 		workflowPage.actions.executeNode('Populate VS');
+		workflow.getNodesWithSpinner().should('not.exist');
 
 		const assertInputOutputText = (text: string, assertion: 'exist' | 'not.exist') => {
 			ndv.getOutputPanel().contains(text).should(assertion);

--- a/cypress/e2e/30-langchain.cy.ts
+++ b/cypress/e2e/30-langchain.cy.ts
@@ -387,6 +387,8 @@ describe('Langchain Integration', () => {
 		};
 
 		workflowPage.actions.openNode('Character Text Splitter');
+		ndv.getters.inputPanel().should('exist');
+		ndv.getters.outputPanel().should('exist');
 		ndv.getters.outputRunSelector().should('exist');
 		ndv.getters.inputRunSelector().should('exist');
 		ndv.getters.inputRunSelector().find('input').should('include.value', '3 of 3');

--- a/cypress/e2e/4-node-creator.cy.ts
+++ b/cypress/e2e/4-node-creator.cy.ts
@@ -548,7 +548,7 @@ describe('Node Creator', () => {
 	});
 
 	it('should add node directly for sub-connection as tool', () => {
-		addNodeToCanvas(MANUAL_CHAT_TRIGGER_NODE_NAME, true);
+		addNodeToCanvas(MANUAL_CHAT_TRIGGER_NODE_NAME, true, false, undefined, true);
 		addNodeToCanvas(AGENT_NODE_NAME, true, true);
 		clickGetBackToCanvas();
 

--- a/cypress/e2e/48-subworkflow-inputs.cy.ts
+++ b/cypress/e2e/48-subworkflow-inputs.cy.ts
@@ -70,7 +70,7 @@ describe('Sub-workflow creation and typed usage', () => {
 		// NAVIGATE TO CHILD WORKFLOW
 		// **************************
 		// Close NDV before opening the node creator
-		cy.get('body').type('{esc}');
+		clickGetBackToCanvas();
 		openNode('When Executed by Another Workflow');
 	});
 


### PR DESCRIPTION
Allows to add a node by exact name match, and not just search + enter key
Also includes the changes needed for https://linear.app/n8n/issue/AI-979/flaky-ui-langchain-integration-should-render-runitems-for-sub-nodes

## Summary

This will fix the tests which are now failing due to the node not being the first in the list.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-979/flaky-ui-langchain-integration-should-render-runitems-for-sub-nodes


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
