### PR TITLE
fix: Flaky e2e test in 30-langchain (no-changelog)

### DIFF
--- a/cypress/composables/ndv.ts
+++ b/cypress/composables/ndv.ts
@@ -73,7 +73,7 @@ export function getInputTbodyCell(row: number, col: number) {
 }
 
 export function getInputRunSelector() {
-	return getInputPanel().findChildByTestId('run-selector');
+	return cy.get('[data-test-id="ndv-input-panel"] [data-test-id="run-selector"]');
 }
 
 export function getInputPanelItemsCount() {
@@ -105,7 +105,7 @@ export function getOutputTbodyCell(row: number, col: number) {
 }
 
 export function getOutputRunSelector() {
-	return getOutputPanel().findChildByTestId('run-selector');
+	return cy.get('[data-test-id="output-panel"] [data-test-id="run-selector"]');
 }
 
 export function getOutputRunSelectorInput() {

--- a/cypress/e2e/30-langchain.cy.ts
+++ b/cypress/e2e/30-langchain.cy.ts
@@ -372,7 +372,7 @@ describe('Langchain Integration', () => {
 		getNodes().should('have.length', 3);
 	});
 
-	it('should render runItems for sub-nodes and allow switching between them', () => {
+	it.only('should render runItems for sub-nodes and allow switching between them', () => {
 		const workflowPage = new WorkflowPage();
 
 		cy.visit(workflowPage.url);

--- a/cypress/e2e/30-langchain.cy.ts
+++ b/cypress/e2e/30-langchain.cy.ts
@@ -372,7 +372,7 @@ describe('Langchain Integration', () => {
 		getNodes().should('have.length', 3);
 	});
 
-	it('should render runItems for sub-nodes and allow switching between them', () => {
+	it.only('should render runItems for sub-nodes and allow switching between them', () => {
 		const workflowPage = new WorkflowPage();
 
 		cy.visit(workflowPage.url);
@@ -381,7 +381,7 @@ describe('Langchain Integration', () => {
 		workflowPage.actions.deselectAll();
 
 		workflowPage.actions.executeNode('Populate VS');
-		workflow.getNodesWithSpinner().should('not.exist');
+		workflow.waitForSuccessBannerToAppear();
 
 		const assertInputOutputText = (text: string, assertion: 'exist' | 'not.exist') => {
 			ndv.getOutputPanel().contains(text).should(assertion);

--- a/cypress/e2e/30-langchain.cy.ts
+++ b/cypress/e2e/30-langchain.cy.ts
@@ -390,9 +390,6 @@ describe('Langchain Integration', () => {
 
 		workflowPage.actions.openNode('Character Text Splitter');
 
-		// Wait for the input panel to switch to Debugging mode
-		ndv.getInputPanelItemsCount().should('not.exist');
-
 		ndv.getOutputRunSelector().should('exist');
 		ndv.getInputRunSelector().should('exist');
 		ndv.getInputRunSelector().find('input').should('include.value', '3 of 3');

--- a/cypress/e2e/30-langchain.cy.ts
+++ b/cypress/e2e/30-langchain.cy.ts
@@ -372,7 +372,7 @@ describe('Langchain Integration', () => {
 		getNodes().should('have.length', 3);
 	});
 
-	it.only('should render runItems for sub-nodes and allow switching between them', () => {
+	it('should render runItems for sub-nodes and allow switching between them', () => {
 		const workflowPage = new WorkflowPage();
 
 		cy.visit(workflowPage.url);

--- a/cypress/e2e/30-langchain.cy.ts
+++ b/cypress/e2e/30-langchain.cy.ts
@@ -29,8 +29,6 @@ import {
 	getRunDataInfoCallout,
 	getOutputPanelTable,
 	checkParameterCheckboxInputByName,
-	getOutputPanelItemsCount,
-	getInputPanelItemsCount,
 } from '../composables/ndv';
 import * as workflow from '../composables/workflow';
 import {

--- a/cypress/e2e/30-langchain.cy.ts
+++ b/cypress/e2e/30-langchain.cy.ts
@@ -29,6 +29,8 @@ import {
 	getRunDataInfoCallout,
 	getOutputPanelTable,
 	checkParameterCheckboxInputByName,
+	getOutputPanelItemsCount,
+	getInputPanelItemsCount,
 } from '../composables/ndv';
 import * as workflow from '../composables/workflow';
 import {


### PR DESCRIPTION
## Summary

This PR fixes flaky test `should render runItems for sub-nodes and allow switching between them`.
Key changes:
- waiting until node execution completes before opening NDV
- chained cypress element getters were replaced by a single selector for input run selectors


## Related Linear tickets, Github issues, and Community forum posts

- https://github.com/n8n-io/n8n/actions/runs/15325389103/job/43118476117
- https://linear.app/n8n/issue/AI-979/flaky-ui-langchain-integration-should-render-runitems-for-sub-nodes


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
