### PR TITLE
test(core): Relax assertions for testing the maxTeamProjects quota

### DIFF
--- a/packages/cli/test/integration/project.api.test.ts
+++ b/packages/cli/test/integration/project.api.test.ts
@@ -440,7 +440,8 @@ describe('POST /projects/', () => {
 	if (!globalConfig.database.isLegacySqlite) {
 		test('should respect the quota when trying to create multiple projects in parallel (no race conditions)', async () => {
 			expect(await Container.get(ProjectRepository).count({ where: { type: 'team' } })).toBe(0);
-			testServer.license.setQuota('quota:maxTeamProjects', 3);
+			const maxTeamProjects = 0;
+			testServer.license.setQuota('quota:maxTeamProjects', maxTeamProjects);
 			const ownerUser = await createOwner();
 			const ownerAgent = testServer.authAgentFor(ownerUser);
 			await expect(
@@ -456,9 +457,17 @@ describe('POST /projects/', () => {
 				ownerAgent.post('/projects/').send({ name: 'Test Team Project 6' }),
 			]);
 
+			// Some of the calls above will interleave and may fail with a deadlock
+			// error on MySQL (this is not an issue on PG or MariaDB).
+			// That can lead to less projects being created than the quota allows.
+			// So we're only checking here that we didn't create more projects than
+			// are allowed instead of checking for a specific number.
+			// We only want to prevent that this endpoint is exploited. A normal user
+			// using the FE would almost never hit this and if they do they can retry
+			// the action. No need to implement rety logic in the controller.
 			await expect(
 				Container.get(ProjectRepository).count({ where: { type: 'team' } }),
-			).resolves.toBe(3);
+			).resolves.toBeLessThanOrEqual(maxTeamProjects);
 		});
 	}
 });

--- a/packages/cli/test/integration/project.api.test.ts
+++ b/packages/cli/test/integration/project.api.test.ts
@@ -440,7 +440,7 @@ describe('POST /projects/', () => {
 	if (!globalConfig.database.isLegacySqlite) {
 		test('should respect the quota when trying to create multiple projects in parallel (no race conditions)', async () => {
 			expect(await Container.get(ProjectRepository).count({ where: { type: 'team' } })).toBe(0);
-			const maxTeamProjects = 0;
+			const maxTeamProjects = 3;
 			testServer.license.setQuota('quota:maxTeamProjects', maxTeamProjects);
 			const ownerUser = await createOwner();
 			const ownerAgent = testServer.authAgentFor(ownerUser);


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This test failed for MySQL.
This is because we don't retry when we get a deadlock error.
I don't think we need to retry automatically. 
If a user creates a project at the exact same time another user does it, they will get an error and can retry from the FE. 
This is only here to prevent malicious attacks where someone sends hundreds of requests in the same instant. I doubt a real user would ever hit this.

So to fix this I relaxed the assertion. It only checks that we didn't create too many projects, but does not care anymore about the exact number.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
