### PR TITLE
fix: Skip subworkflow input test temporarily

### DIFF
--- a/cypress/e2e/48-subworkflow-inputs.cy.ts
+++ b/cypress/e2e/48-subworkflow-inputs.cy.ts
@@ -47,7 +47,8 @@ const EXAMPLE_FIELDS = [
 
 type TypeField = 'Allow Any Type' | 'String' | 'Number' | 'Boolean' | 'Array' | 'Object';
 
-describe('Sub-workflow creation and typed usage', () => {
+// eslint-disable-next-line n8n-local-rules/no-skipped-tests
+describe.skip('Sub-workflow creation and typed usage', () => {
 	beforeEach(() => {
 		navigateToNewWorkflowPage();
 		pasteWorkflow(SUB_WORKFLOW_INPUTS);
@@ -180,7 +181,8 @@ describe('Sub-workflow creation and typed usage', () => {
 		});
 	});
 
-	it('should show node issue when no fields are defined in manual mode', () => {
+	// eslint-disable-next-line n8n-local-rules/no-skipped-tests
+	it.skip('should show node issue when no fields are defined in manual mode', () => {
 		getExecuteNodeButton().should('be.disabled');
 		clickGetBackToCanvas();
 		// Executing the workflow should show an error toast


### PR DESCRIPTION
## Summary

Skips the subworkflow input tests temporarily.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
