### PR TITLE
feat(core): Allow specifying Content-Security-Policy-Report-Only

### DIFF
--- a/packages/@n8n/config/src/configs/security.config.ts
+++ b/packages/@n8n/config/src/configs/security.config.ts
@@ -32,4 +32,10 @@ export class SecurityConfig {
 	// TODO: create a new type that parses and validates this string into a strongly-typed object
 	@Env('N8N_CONTENT_SECURITY_POLICY')
 	contentSecurityPolicy: string = '{}';
+
+	/**
+	 * Whether to set the `Content-Security-Policy-Report-Only` header instead of `Content-Security-Policy`.
+	 */
+	@Env('N8N_CONTENT_SECURITY_POLICY_REPORT_ONLY')
+	contentSecurityPolicyReportOnly: boolean = false;
 }

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -272,6 +272,7 @@ describe('GlobalConfig', () => {
 			blockFileAccessToN8nFiles: true,
 			daysAbandonedWorkflow: 90,
 			contentSecurityPolicy: '{}',
+			contentSecurityPolicyReportOnly: false,
 		},
 		executions: {
 			pruneData: true,

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -354,11 +354,13 @@ export class Server extends AbstractServer {
 					errorMessage: 'The contentSecurityPolicy is not valid JSON.',
 				},
 			);
+			const cspReportOnly = Container.get(SecurityConfig).contentSecurityPolicyReportOnly;
 			const securityHeadersMiddleware = helmet({
 				contentSecurityPolicy: isEmpty(cspDirectives)
 					? false
 					: {
 							useDefaults: false,
+							reportOnly: cspReportOnly,
 							directives: {
 								...cspDirectives,
 							},


### PR DESCRIPTION
Adds the environment variable `N8N_CONTENT_SECURITY_POLICY_REPORT_ONLY` to toggle the Helmet.js `reportOnly` switch (see [Helmet docs](https://helmetjs.github.io/#content-security-policy)).

When enabled, `Content-Security-Policy` header is changed into `Content-Security-Policy-Report-Only`, which has the effect of only logging the changes but not enforcing them.

<img width="1767" alt="Screenshot 2025-05-28 at 15 34 13" src="https://github.com/user-attachments/assets/ccf4ef9d-1e8b-493f-aba5-0385deab5510" />
