### PR TITLE
feat(core): Start listening to IPv6 addresses as well by default

### DIFF
--- a/packages/@n8n/config/src/configs/scaling-mode.config.ts
+++ b/packages/@n8n/config/src/configs/scaling-mode.config.ts
@@ -16,7 +16,7 @@ class HealthConfig {
 
 	/** IP address for worker server to listen on. */
 	@Env('N8N_WORKER_SERVER_ADDRESS')
-	address: string = '0.0.0.0';
+	address: string = '::';
 }
 
 @Config

--- a/packages/@n8n/config/src/index.ts
+++ b/packages/@n8n/config/src/index.ts
@@ -96,7 +96,7 @@ export class GlobalConfig {
 
 	/** IP address n8n should listen on */
 	@Env('N8N_LISTEN_ADDRESS')
-	listen_address: string = '0.0.0.0';
+	listen_address: string = '::';
 
 	/** HTTP Protocol via which n8n can be reached */
 	@Env('N8N_PROTOCOL', protocolSchema)

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -25,7 +25,7 @@ describe('GlobalConfig', () => {
 		path: '/',
 		host: 'localhost',
 		port: 5678,
-		listen_address: '0.0.0.0',
+		listen_address: '::',
 		protocol: 'http',
 		auth: {
 			cookie: {
@@ -196,7 +196,7 @@ describe('GlobalConfig', () => {
 			health: {
 				active: false,
 				port: 5678,
-				address: '0.0.0.0',
+				address: '::',
 			},
 			bull: {
 				redis: {

--- a/packages/cli/src/scaling/__tests__/worker-server.test.ts
+++ b/packages/cli/src/scaling/__tests__/worker-server.test.ts
@@ -48,7 +48,7 @@ describe('WorkerServer', () => {
 	beforeEach(() => {
 		globalConfig = mock<GlobalConfig>({
 			queue: {
-				health: { active: true, port: 5678, address: '0.0.0.0' },
+				health: { active: true, port: 5678, address: '::' },
 			},
 			credentials: {
 				overwrite: { endpoint: '' },

--- a/packages/cli/src/services/__tests__/user.service.test.ts
+++ b/packages/cli/src/services/__tests__/user.service.test.ts
@@ -13,7 +13,7 @@ describe('UserService', () => {
 		host: 'localhost',
 		path: '/',
 		port: 5678,
-		listen_address: '0.0.0.0',
+		listen_address: '::',
 		protocol: 'http',
 	});
 	const urlService = new UrlService(globalConfig);


### PR DESCRIPTION
## Summary

There is no reason for us not to listen to on available interfaces/IPs by default. This PR changes the default listening address from `0.0.0.0` (IPv4) to `::` (IPv6 and IPv4).

This should hopefully be backward-compatible. 
But if any user has issues with this change, we can ask them to explicitly set `N8N_LISTEN_ADDRESS` back to `0.0.0.0`.

![image](https://github.com/user-attachments/assets/6678cb30-f6a7-4e05-a3bb-975d0d9a64af)


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
