### PR TITLE
ci: Configure CI "temporarily" to use longer timeouts (no-changelog)

### DIFF
--- a/cypress/cypress.config.js
+++ b/cypress/cypress.config.js
@@ -2,15 +2,17 @@ const { defineConfig } = require('cypress');
 
 const BASE_URL = 'http://localhost:5678';
 
+const timeOut = process.env.CI === 'true' ? 30_000 : 5_000;
+
 module.exports = defineConfig({
 	projectId: '5hbsdn',
 	retries: {
 		openMode: 0,
 		runMode: 2,
 	},
-	defaultCommandTimeout: 10000,
-	requestTimeout: 12000,
-	numTestsKeptInMemory: 2,
+	defaultCommandTimeout: timeOut,
+	requestTimeout: timeOut,
+	numTestsKeptInMemory: 1,
 	experimentalMemoryManagement: true,
 	e2e: {
 		baseUrl: BASE_URL,


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
