### PR TITLE
fix(editor): Mark execution as stopped even if fetching execution has failed (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/executionFinished.ts
+++ b/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/executionFinished.ts
@@ -129,6 +129,7 @@ export async function executionFinished(
 		handleExecutionFinishedWithWaitTill(options);
 	} else if (execution.status === 'error' || execution.status === 'canceled') {
 		handleExecutionFinishedWithErrorOrCanceled(execution, runExecutionData, options);
+		workflowsStore.markExecutionAsStopped();
 	} else {
 		handleExecutionFinishedWithOther(successToastAlreadyShown, options);
 	}

--- a/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/executionFinished.ts
+++ b/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/executionFinished.ts
@@ -129,7 +129,6 @@ export async function executionFinished(
 		handleExecutionFinishedWithWaitTill(options);
 	} else if (execution.status === 'error' || execution.status === 'canceled') {
 		handleExecutionFinishedWithErrorOrCanceled(execution, runExecutionData, options);
-		workflowsStore.markExecutionAsStopped();
 	} else {
 		handleExecutionFinishedWithOther(successToastAlreadyShown, options);
 	}

--- a/packages/frontend/editor-ui/src/composables/useRunWorkflow.ts
+++ b/packages/frontend/editor-ui/src/composables/useRunWorkflow.ts
@@ -508,7 +508,7 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 					return false;
 				},
 				250,
-				10,
+				20,
 			);
 
 			if (!markedAsStopped) {

--- a/packages/frontend/editor-ui/src/composables/useRunWorkflow.ts
+++ b/packages/frontend/editor-ui/src/composables/useRunWorkflow.ts
@@ -498,7 +498,7 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 			}
 		} finally {
 			// Wait for websocket event to update the execution status to 'canceled'
-			await retry(
+			const markedAsStopped = await retry(
 				async () => {
 					if (workflowsStore.workflowExecutionData?.status !== 'running') {
 						workflowsStore.markExecutionAsStopped();
@@ -510,6 +510,10 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 				250,
 				10,
 			);
+
+			if (!markedAsStopped) {
+				workflowsStore.markExecutionAsStopped();
+			}
 		}
 	}
 

--- a/packages/frontend/editor-ui/src/composables/useRunWorkflow.ts
+++ b/packages/frontend/editor-ui/src/composables/useRunWorkflow.ts
@@ -17,7 +17,6 @@ import type {
 	IWorkflowBase,
 } from 'n8n-workflow';
 import { NodeConnectionTypes, TelemetryHelpers } from 'n8n-workflow';
-import { retry } from '@n8n/utils/retry';
 
 import { useToast } from '@/composables/useToast';
 import { useNodeHelpers } from '@/composables/useNodeHelpers';
@@ -497,19 +496,7 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 				toast.showError(error, i18n.baseText('nodeView.showError.stopExecution.title'));
 			}
 		} finally {
-			// Wait for websocket event to update the execution status to 'canceled'
-			await retry(
-				async () => {
-					if (workflowsStore.workflowExecutionData?.status !== 'running') {
-						workflowsStore.markExecutionAsStopped();
-						return true;
-					}
-
-					return false;
-				},
-				250,
-				10,
-			);
+			workflowsStore.markExecutionAsStopped();
 		}
 	}
 


### PR DESCRIPTION
## Summary

We're marking the execution as stopped either way if the retry has failed. This fixes the case when the network is very slow or fetching the execution in `executionFinished` has failed.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-864/mark-execution-as-stop-even-if-fetching-execution-has-failed

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
