### PR TITLE
NocoDB node updates

### DIFF
--- a/packages/nodes-base/nodes/NocoDB/NocoDB.node.ts
+++ b/packages/nodes-base/nodes/NocoDB/NocoDB.node.ts
@@ -427,11 +427,6 @@ export class NocoDB implements INodeType {
 					}
 				} else if (version === 3) {
 					endPoint = `/api/v2/tables/${table}/records`;
-
-					primaryKey = this.getNodeParameter('primaryKey', 0) as string;
-					if (primaryKey === 'custom') {
-						primaryKey = this.getNodeParameter('customPrimaryKey', 0) as string;
-					}
 				}
 
 				const body: IDataObject[] = [];

--- a/packages/nodes-base/nodes/NocoDB/NocoDB.node.ts
+++ b/packages/nodes-base/nodes/NocoDB/NocoDB.node.ts
@@ -850,8 +850,9 @@ export class NocoDB implements INodeType {
 				} catch (error) {
 					if (this.continueOnFail()) {
 						returnData.push({ error: error.toString() });
+					} else {
+						throw new NodeApiError(this.getNode(), error as JsonObject);
 					}
-					throw new NodeApiError(this.getNode(), error as JsonObject);
 				}
 			}
 
@@ -875,8 +876,9 @@ export class NocoDB implements INodeType {
 				} catch (error) {
 					if (this.continueOnFail()) {
 						returnData.push({ error: error.toString() });
+					} else {
+						throw new NodeApiError(this.getNode(), error as JsonObject);
 					}
-					throw new NodeApiError(this.getNode(), error as JsonObject);
 				}
 			}
 

--- a/packages/nodes-base/nodes/NocoDB/NocoDB.node.ts
+++ b/packages/nodes-base/nodes/NocoDB/NocoDB.node.ts
@@ -502,6 +502,10 @@ export class NocoDB implements INodeType {
 							qs.fields = (qs.fields as IDataObject[]).join(',');
 						}
 
+						if (qs.shuffle) {
+							qs.shuffle = Number(qs.shuffle);
+						}
+
 						if (returnAll) {
 							responseData = await apiRequestAllItems.call(this, requestMethod, endPoint, {}, qs);
 						} else {

--- a/packages/nodes-base/nodes/NocoDB/NocoDB.node.ts
+++ b/packages/nodes-base/nodes/NocoDB/NocoDB.node.ts
@@ -562,6 +562,12 @@ export class NocoDB implements INodeType {
 							endPoint = `/api/v2/tables/${table}/records/${id}`;
 						}
 
+						qs = this.getNodeParameter('options', i, {});
+
+						if (qs.fields) {
+							qs.fields = (qs.fields as IDataObject[]).join(',');
+						}
+
 						responseData = await apiRequest.call(this, requestMethod, endPoint, {}, qs);
 
 						if (version === 2) {

--- a/packages/nodes-base/nodes/NocoDB/OperationDescription.ts
+++ b/packages/nodes-base/nodes/NocoDB/OperationDescription.ts
@@ -171,10 +171,36 @@ export const operationFields: INodeProperties[] = [
 			},
 		},
 	},
+	{
+		displayName: 'Download Attachments',
+		name: 'downloadAttachments',
+		type: 'boolean',
+		displayOptions: {
+			show: {
+				operation: ['get', 'getAll'],
+			},
+		},
+		default: false,
+		description: "Whether the attachment fields define in 'Download Fields' will be downloaded",
+	},
+	{
+		displayName: 'Download Fields',
+		name: 'downloadFieldNames',
+		type: 'string',
+		required: true,
+		displayOptions: {
+			show: {
+				operation: ['get', 'getAll'],
+				downloadAttachments: [true],
+			},
+		},
+		default: '',
+		description:
+			"Name of the fields of type 'attachment' that should be downloaded. Multiple ones can be defined separated by comma. Case sensitive.",
+	},
 	// ----------------------------------
 	//         delete
 	// ----------------------------------
-
 	// ----------------------------------
 	//         getAll
 	// ----------------------------------
@@ -206,33 +232,6 @@ export const operationFields: INodeProperties[] = [
 		},
 		default: 50,
 		description: 'Max number of results to return',
-	},
-	{
-		displayName: 'Download Attachments',
-		name: 'downloadAttachments',
-		type: 'boolean',
-		displayOptions: {
-			show: {
-				operation: ['getAll'],
-			},
-		},
-		default: false,
-		description: "Whether the attachment fields define in 'Download Fields' will be downloaded",
-	},
-	{
-		displayName: 'Download Fields',
-		name: 'downloadFieldNames',
-		type: 'string',
-		required: true,
-		displayOptions: {
-			show: {
-				operation: ['getAll'],
-				downloadAttachments: [true],
-			},
-		},
-		default: '',
-		description:
-			"Name of the fields of type 'attachment' that should be downloaded. Multiple ones can be defined separated by comma. Case sensitive.",
 	},
 	{
 		displayName: 'Options',
@@ -327,33 +326,6 @@ export const operationFields: INodeProperties[] = [
 	// ----------------------------------
 	//         get
 	// ----------------------------------
-	{
-		displayName: 'Download Attachments',
-		name: 'downloadAttachments',
-		type: 'boolean',
-		displayOptions: {
-			show: {
-				operation: ['get'],
-			},
-		},
-		default: false,
-		description: "Whether the attachment fields define in 'Download Fields' will be downloaded",
-	},
-	{
-		displayName: 'Download Fields',
-		name: 'downloadFieldNames',
-		type: 'string',
-		required: true,
-		displayOptions: {
-			show: {
-				operation: ['get'],
-				downloadAttachments: [true],
-			},
-		},
-		default: '',
-		description:
-			"Name of the fields of type 'attachment' that should be downloaded. Multiple ones can be defined separated by comma. Case sensitive.",
-	},
 	// ----------------------------------
 	//         update
 	// ----------------------------------

--- a/packages/nodes-base/nodes/NocoDB/OperationDescription.ts
+++ b/packages/nodes-base/nodes/NocoDB/OperationDescription.ts
@@ -326,6 +326,32 @@ export const operationFields: INodeProperties[] = [
 	// ----------------------------------
 	//         get
 	// ----------------------------------
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		displayOptions: {
+			show: {
+				operation: ['get'],
+			},
+		},
+		default: {},
+		placeholder: 'Add option',
+		options: [
+			{
+				displayName: 'Fields',
+				name: 'fields',
+				type: 'string',
+				typeOptions: {
+					multipleValues: true,
+					multipleValueButtonText: 'Add Field',
+				},
+				default: [],
+				placeholder: 'Name',
+				description: 'The select fields of the returned row',
+			},
+		],
+	},
 	// ----------------------------------
 	//         update
 	// ----------------------------------

--- a/packages/nodes-base/nodes/NocoDB/OperationDescription.ts
+++ b/packages/nodes-base/nodes/NocoDB/OperationDescription.ts
@@ -320,6 +320,7 @@ export const operationFields: INodeProperties[] = [
 				default: '',
 				placeholder: '(name,like,example%)~or(name,eq,test)',
 				description: 'A formula used to filter rows',
+				hint: 'Check official documentation for <a href="https://nocodb.com/docs/product-docs/developer-resources/rest-apis/overview" target="_blank" rel="noreferrer">supported operators</a>.',
 			},
 			{
 				displayName: 'Shuffle',

--- a/packages/nodes-base/nodes/NocoDB/OperationDescription.ts
+++ b/packages/nodes-base/nodes/NocoDB/OperationDescription.ts
@@ -321,6 +321,13 @@ export const operationFields: INodeProperties[] = [
 				placeholder: '(name,like,example%)~or(name,eq,test)',
 				description: 'A formula used to filter rows',
 			},
+			{
+				displayName: 'Shuffle',
+				name: 'shuffle',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to shuffle the results',
+			},
 		],
 	},
 	// ----------------------------------

--- a/packages/nodes-base/nodes/NocoDB/OperationDescription.ts
+++ b/packages/nodes-base/nodes/NocoDB/OperationDescription.ts
@@ -12,6 +12,7 @@ export const operationFields: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				version: [3],
+				resource: ['row', 'link'],
 			},
 		},
 		description:
@@ -28,6 +29,7 @@ export const operationFields: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				version: [3],
+				resource: ['row', 'link'],
 			},
 		},
 		required: true,
@@ -46,6 +48,7 @@ export const operationFields: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				version: [1],
+				resource: ['row'],
 			},
 		},
 		required: true,
@@ -59,6 +62,7 @@ export const operationFields: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				version: [2],
+				resource: ['row'],
 			},
 		},
 		required: true,
@@ -76,6 +80,7 @@ export const operationFields: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				version: [2, 3],
+				resource: ['row', 'link'],
 			},
 		},
 		required: true,
@@ -94,6 +99,7 @@ export const operationFields: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				version: [1],
+				resource: ['row'],
 			},
 		},
 		required: true,
@@ -127,6 +133,7 @@ export const operationFields: INodeProperties[] = [
 			show: {
 				version: [1, 2],
 				operation: ['delete', 'update'],
+				resource: ['row'],
 			},
 		},
 	},
@@ -140,6 +147,7 @@ export const operationFields: INodeProperties[] = [
 				version: [1, 2],
 				operation: ['delete', 'update'],
 				primaryKey: ['custom'],
+				resource: ['row'],
 			},
 		},
 	},
@@ -154,6 +162,7 @@ export const operationFields: INodeProperties[] = [
 			show: {
 				version: [1, 2],
 				operation: ['delete', 'get', 'update'],
+				resource: ['row'],
 			},
 		},
 	},
@@ -168,6 +177,7 @@ export const operationFields: INodeProperties[] = [
 			show: {
 				version: [3],
 				operation: ['delete', 'get'],
+				resource: ['row'],
 			},
 		},
 	},
@@ -178,6 +188,7 @@ export const operationFields: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				operation: ['get', 'getAll'],
+				resource: ['row'],
 			},
 		},
 		default: false,
@@ -192,6 +203,7 @@ export const operationFields: INodeProperties[] = [
 			show: {
 				operation: ['get', 'getAll'],
 				downloadAttachments: [true],
+				resource: ['row'],
 			},
 		},
 		default: '',
@@ -199,11 +211,89 @@ export const operationFields: INodeProperties[] = [
 			"Name of the fields of type 'attachment' that should be downloaded. Multiple ones can be defined separated by comma. Case sensitive.",
 	},
 	// ----------------------------------
-	//         delete
+	//         Link: Shared
 	// ----------------------------------
+	{
+		displayName: 'Field Name or ID',
+		name: 'field',
+		type: 'options',
+		default: '',
+		displayOptions: {
+			show: {
+				version: [3],
+				resource: ['link'],
+			},
+		},
+		required: true,
+		description:
+			'The link field to operate on. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+		typeOptions: {
+			loadOptionsDependsOn: ['projectId', 'table'],
+			loadOptionsMethod: 'getLinkFields',
+		},
+	},
+	{
+		displayName: 'Table Row ID',
+		name: 'id',
+		type: 'string',
+		default: '',
+		required: true,
+		description: 'The value of the source table row ID field',
+		displayOptions: {
+			show: {
+				version: [3],
+				resource: ['link'],
+			},
+		},
+	},
+	{
+		displayName: 'Link IDs',
+		name: 'links',
+		type: 'string',
+		default: '',
+		required: true,
+		description:
+			'The value of the target table row ID field (multiple can be defined separated by comma)',
+		displayOptions: {
+			show: {
+				version: [3],
+				operation: ['add', 'delete'],
+				resource: ['link'],
+			},
+		},
+	},
 	// ----------------------------------
-	//         getAll
+	//         Link: getAll
 	// ----------------------------------
+	{
+		displayName: 'Download Attachments',
+		name: 'downloadAttachments',
+		type: 'boolean',
+		displayOptions: {
+			show: {
+				operation: ['getAll'],
+				resource: ['link'],
+			},
+		},
+		default: false,
+		description: "Whether the attachment fields define in 'Download Fields' will be downloaded",
+	},
+	{
+		displayName: 'Download Fields',
+		name: 'downloadFieldNames',
+		type: 'string',
+		required: true,
+		displayOptions: {
+			show: {
+				operation: ['getAll'],
+				downloadAttachments: [true],
+				resource: ['link'],
+			},
+		},
+		default: '',
+		description:
+			"Name of the fields of type 'attachment' that should be downloaded. Multiple ones can be defined separated by comma. Case sensitive.",
+	},
 	{
 		displayName: 'Return All',
 		name: 'returnAll',
@@ -211,6 +301,7 @@ export const operationFields: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				operation: ['getAll'],
+				resource: ['link'],
 			},
 		},
 		default: false,
@@ -224,6 +315,7 @@ export const operationFields: INodeProperties[] = [
 			show: {
 				operation: ['getAll'],
 				returnAll: [false],
+				resource: ['link'],
 			},
 		},
 		typeOptions: {
@@ -240,6 +332,132 @@ export const operationFields: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				operation: ['getAll'],
+				resource: ['link'],
+			},
+		},
+		default: {},
+		placeholder: 'Add option',
+		options: [
+			{
+				displayName: 'Fields',
+				name: 'fields',
+				type: 'string',
+				typeOptions: {
+					multipleValues: true,
+					multipleValueButtonText: 'Add Field',
+				},
+				default: [],
+				placeholder: 'Name',
+				description: 'The select fields of the returned rows',
+			},
+			{
+				displayName: 'Sort',
+				name: 'sort',
+				placeholder: 'Add Sort Rule',
+				description: 'The sorting rules for the returned rows',
+				type: 'fixedCollection',
+				typeOptions: {
+					multipleValues: true,
+				},
+				default: {},
+				options: [
+					{
+						name: 'property',
+						displayName: 'Property',
+						values: [
+							{
+								displayName: 'Field',
+								name: 'field',
+								type: 'string',
+								default: '',
+								description: 'Name of the field to sort on',
+							},
+							{
+								displayName: 'Direction',
+								name: 'direction',
+								type: 'options',
+								options: [
+									{
+										name: 'ASC',
+										value: 'asc',
+										description: 'Sort in ascending order (small -> large)',
+									},
+									{
+										name: 'DESC',
+										value: 'desc',
+										description: 'Sort in descending order (large -> small)',
+									},
+								],
+								default: 'asc',
+								description: 'The sort direction',
+							},
+						],
+					},
+				],
+			},
+			{
+				displayName: 'Filter By Formula',
+				name: 'where',
+				type: 'string',
+				default: '',
+				placeholder: '(name,like,example%)~or(name,eq,test)',
+				description: 'A formula used to filter rows',
+				hint: 'Check official documentation for <a href="https://nocodb.com/docs/product-docs/developer-resources/rest-apis/overview" target="_blank" rel="noreferrer">supported operators</a>.',
+			},
+			{
+				displayName: 'Offset',
+				name: 'offset',
+				type: 'number',
+				default: '',
+				description: 'The number of rows to skip from the beginning',
+			},
+		],
+	},
+	// ----------------------------------
+	//         Row: delete
+	// ----------------------------------
+	// ----------------------------------
+	//         Row: getAll
+	// ----------------------------------
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		displayOptions: {
+			show: {
+				operation: ['getAll'],
+				resource: ['row'],
+			},
+		},
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		displayOptions: {
+			show: {
+				operation: ['getAll'],
+				returnAll: [false],
+				resource: ['row'],
+			},
+		},
+		typeOptions: {
+			minValue: 1,
+			maxValue: 100,
+		},
+		default: 50,
+		description: 'Max number of results to return',
+	},
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		displayOptions: {
+			show: {
+				operation: ['getAll'],
+				resource: ['row'],
 			},
 		},
 		default: {},
@@ -339,7 +557,7 @@ export const operationFields: INodeProperties[] = [
 		],
 	},
 	// ----------------------------------
-	//         get
+	//         Row: get
 	// ----------------------------------
 	{
 		displayName: 'Options',
@@ -348,6 +566,7 @@ export const operationFields: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				operation: ['get'],
+				resource: ['row'],
 			},
 		},
 		default: {},
@@ -368,10 +587,10 @@ export const operationFields: INodeProperties[] = [
 		],
 	},
 	// ----------------------------------
-	//         update
+	//         Row: update
 	// ----------------------------------
 	// ----------------------------------
-	//         Shared
+	//         Row: Shared
 	// ----------------------------------
 	{
 		displayName: 'Data to Send',
@@ -392,6 +611,7 @@ export const operationFields: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				operation: ['create', 'update'],
+				resource: ['row'],
 			},
 		},
 		default: 'defineBelow',
@@ -406,6 +626,7 @@ export const operationFields: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				dataToSend: ['autoMapInputData'],
+				resource: ['row'],
 			},
 		},
 	},
@@ -418,6 +639,7 @@ export const operationFields: INodeProperties[] = [
 			show: {
 				operation: ['update'],
 				version: [3],
+				resource: ['row'],
 			},
 		},
 	},
@@ -429,6 +651,7 @@ export const operationFields: INodeProperties[] = [
 			show: {
 				operation: ['create', 'update'],
 				dataToSend: ['autoMapInputData'],
+				resource: ['row'],
 			},
 		},
 		default: '',
@@ -449,6 +672,7 @@ export const operationFields: INodeProperties[] = [
 			show: {
 				operation: ['create', 'update'],
 				dataToSend: ['defineBelow'],
+				resource: ['row'],
 			},
 		},
 		default: {},

--- a/packages/nodes-base/nodes/NocoDB/OperationDescription.ts
+++ b/packages/nodes-base/nodes/NocoDB/OperationDescription.ts
@@ -131,37 +131,6 @@ export const operationFields: INodeProperties[] = [
 		},
 	},
 	{
-		displayName: 'Primary Key Type',
-		name: 'primaryKey',
-		type: 'options',
-		default: 'id',
-		options: [
-			{
-				name: 'Default',
-				value: 'id',
-				description:
-					'Default, added when table was created from UI by those options: Create new table / Import from Excel / Import from CSV',
-			},
-			{
-				name: 'Imported From Airtable',
-				value: 'ncRecordId',
-				description: 'Select if table was imported from Airtable',
-			},
-			{
-				name: 'Custom',
-				value: 'custom',
-				description:
-					'When connecting to existing external database as existing primary key field is retained as is, enter the name of the primary key field below',
-			},
-		],
-		displayOptions: {
-			show: {
-				version: [3],
-				operation: ['delete'],
-			},
-		},
-	},
-	{
 		displayName: 'Field Name',
 		name: 'customPrimaryKey',
 		type: 'string',
@@ -170,19 +139,6 @@ export const operationFields: INodeProperties[] = [
 			show: {
 				version: [1, 2],
 				operation: ['delete', 'update'],
-				primaryKey: ['custom'],
-			},
-		},
-	},
-	{
-		displayName: 'Field Name',
-		name: 'customPrimaryKey',
-		type: 'string',
-		default: '',
-		displayOptions: {
-			show: {
-				version: [3],
-				operation: ['delete'],
 				primaryKey: ['custom'],
 			},
 		},

--- a/packages/nodes-base/nodes/NocoDB/OperationDescription.ts
+++ b/packages/nodes-base/nodes/NocoDB/OperationDescription.ts
@@ -328,6 +328,13 @@ export const operationFields: INodeProperties[] = [
 				default: false,
 				description: 'Whether to shuffle the results',
 			},
+			{
+				displayName: 'Offset',
+				name: 'offset',
+				type: 'number',
+				default: '',
+				description: 'The number of rows to skip from the beginning',
+			},
 		],
 	},
 	// ----------------------------------

--- a/packages/nodes-base/nodes/NocoDB/test/NocoDB.test.ts
+++ b/packages/nodes-base/nodes/NocoDB/test/NocoDB.test.ts
@@ -1,0 +1,846 @@
+import type {
+	IDataObject,
+	INode,
+	INodeExecutionData,
+	ILoadOptionsFunctions,
+	IExecuteFunctions,
+} from 'n8n-workflow';
+import { NodeApiError, NodeOperationError } from 'n8n-workflow';
+
+import { createMockExecuteFunction } from '@test/nodes/Helpers';
+
+import * as GenericFunctions from '../GenericFunctions';
+import { NocoDB } from '../NocoDB.node';
+
+// Mock the GenericFunctions
+jest.mock('../GenericFunctions');
+const mockedGenericFunctions = jest.mocked(GenericFunctions);
+
+const mockNode: INode = {
+	id: '1',
+	name: 'NocoDB',
+	typeVersion: 3,
+	type: 'n8n-nodes-base.nocoDb',
+	position: [60, 760],
+	parameters: {
+		authentication: 'nocoDb',
+		version: 3,
+		resource: 'row',
+		operation: 'get',
+		projectId: 'base123',
+		table: 'table123',
+	},
+};
+
+const defaultInputItems: INodeExecutionData[] = [
+	{ json: { id: 1, name: 'Test Item' }, pairedItem: { item: 0, input: undefined } },
+];
+
+const createNocoDBExecuteFunction = (
+	nodeParameters: IDataObject,
+	inputItems: INodeExecutionData[] = defaultInputItems,
+	continueOnFail = false,
+) => {
+	const fakeExecuteFunction = createMockExecuteFunction(nodeParameters, mockNode, continueOnFail);
+	// Add missing methods for NocoDB node
+	(fakeExecuteFunction as any).getInputData = () => inputItems;
+	(fakeExecuteFunction as any).helpers = {
+		...fakeExecuteFunction.helpers,
+		assertBinaryData: jest.fn().mockReturnValue({ fileName: 'test.txt', mimeType: 'text/plain' }),
+		getBinaryDataBuffer: jest.fn().mockResolvedValue(Buffer.from('test file content')),
+		returnJsonArray: jest.fn((data) => {
+			if (Array.isArray(data)) {
+				return data.map((item: any) => ({ json: item }));
+			}
+			return [{ json: data }];
+		}),
+	};
+	return fakeExecuteFunction as IExecuteFunctions;
+};
+
+const createMockLoadOptionsFunction = (nodeParameters: IDataObject = {}) => {
+	return {
+		getNodeParameter: jest.fn((parameterName: string) => nodeParameters[parameterName]),
+		getNode: () => mockNode,
+		getCurrentNodeParameter: jest.fn(),
+		getCurrentNodeParameters: jest.fn(),
+	} as unknown as ILoadOptionsFunctions;
+};
+
+describe('NocoDB Node', () => {
+	let nocoDbNode: NocoDB;
+
+	beforeEach(() => {
+		nocoDbNode = new NocoDB();
+		jest.clearAllMocks();
+	});
+
+	describe('Node Definition', () => {
+		it('should have correct node description', () => {
+			expect(nocoDbNode.description.displayName).toBe('NocoDB');
+			expect(nocoDbNode.description.name).toBe('nocoDb');
+			expect(nocoDbNode.description.group).toEqual(['input']);
+			expect(nocoDbNode.description.version).toEqual([1, 2, 3]);
+		});
+
+		it('should have required credentials', () => {
+			expect(nocoDbNode.description.credentials).toHaveLength(2);
+			expect(nocoDbNode.description.credentials![0].name).toBe('nocoDb');
+			expect(nocoDbNode.description.credentials![1].name).toBe('nocoDbApiToken');
+		});
+	});
+
+	describe('Load Options Methods', () => {
+		describe('getWorkspaces', () => {
+			it('should return workspaces list', async () => {
+				const mockWorkspaces = {
+					list: [
+						{ id: 'ws1', title: 'Workspace 1' },
+						{ id: 'ws2', title: 'Workspace 2' },
+					],
+				};
+				mockedGenericFunctions.apiRequest.mockResolvedValue(mockWorkspaces);
+
+				const mockLoadOptionsFunction = createMockLoadOptionsFunction({});
+				const result =
+					await nocoDbNode.methods!.loadOptions!.getWorkspaces.call(mockLoadOptionsFunction);
+
+				expect(result).toEqual([
+					{ name: 'Workspace 1', value: 'ws1' },
+					{ name: 'Workspace 2', value: 'ws2' },
+				]);
+			});
+
+			it('should return default when request fails', async () => {
+				mockedGenericFunctions.apiRequest.mockRejectedValue(new Error('API Error'));
+
+				const mockLoadOptionsFunction = createMockLoadOptionsFunction({});
+				const result =
+					await nocoDbNode.methods!.loadOptions!.getWorkspaces.call(mockLoadOptionsFunction);
+
+				expect(result).toEqual([{ name: 'No Workspace', value: 'none' }]);
+			});
+		});
+
+		describe('getBases', () => {
+			it('should return bases for v3 with workspace', async () => {
+				const mockBases = { list: [{ id: 'base1', title: 'Base 1' }] };
+				const mockLoadOptionsFunction = createMockLoadOptionsFunction({
+					version: 3,
+					workspaceId: 'ws1',
+				});
+				mockedGenericFunctions.apiRequest.mockResolvedValue(mockBases);
+
+				const result =
+					await nocoDbNode.methods!.loadOptions!.getBases.call(mockLoadOptionsFunction);
+
+				expect(result).toEqual([{ name: 'Base 1', value: 'base1' }]);
+				expect(mockedGenericFunctions.apiRequest).toHaveBeenCalledWith(
+					'GET',
+					'/api/v1/workspaces/ws1/bases/',
+					{},
+					{},
+				);
+			});
+
+			it('should return bases for v3 without workspace', async () => {
+				const mockBases = { list: [{ id: 'base1', title: 'Base 1' }] };
+				const mockLoadOptionsFunction = createMockLoadOptionsFunction({
+					version: 3,
+					workspaceId: 'none',
+				});
+				mockedGenericFunctions.apiRequest.mockResolvedValue(mockBases);
+
+				const result =
+					await nocoDbNode.methods!.loadOptions!.getBases.call(mockLoadOptionsFunction);
+
+				expect(result).toEqual([{ name: 'Base 1', value: 'base1' }]);
+				expect(mockedGenericFunctions.apiRequest).toHaveBeenCalledWith(
+					'GET',
+					'/api/v2/meta/bases/',
+					{},
+					{},
+				);
+			});
+		});
+
+		describe('getTables', () => {
+			it('should return tables for v3', async () => {
+				const mockTables = { list: [{ id: 'table1', title: 'Table 1' }] };
+				const mockLoadOptionsFunction = createMockLoadOptionsFunction({
+					version: 3,
+					projectId: 'base1',
+				});
+				mockedGenericFunctions.apiRequest.mockResolvedValue(mockTables);
+
+				const result =
+					await nocoDbNode.methods!.loadOptions!.getTables.call(mockLoadOptionsFunction);
+
+				expect(result).toEqual([{ name: 'Table 1', value: 'table1' }]);
+				expect(mockedGenericFunctions.apiRequest).toHaveBeenCalledWith(
+					'GET',
+					'/api/v2/meta/bases/base1/tables',
+					{},
+					{},
+				);
+			});
+
+			it('should throw error when no base selected', async () => {
+				const mockLoadOptionsFunction = createMockLoadOptionsFunction({
+					version: 3,
+					projectId: '',
+				});
+
+				await expect(
+					nocoDbNode.methods!.loadOptions!.getTables.call(mockLoadOptionsFunction),
+				).rejects.toThrow(NodeOperationError);
+			});
+		});
+	});
+
+	describe('Row Resource', () => {
+		describe('Create Operation', () => {
+			it('should create rows for v3', async () => {
+				const nodeParameters = {
+					version: 3,
+					resource: 'row',
+					operation: 'create',
+					projectId: 'base123',
+					table: 'table123',
+					dataToSend: 'defineBelow',
+					fieldsUi: {
+						fieldValues: [
+							{ fieldName: 'name', fieldValue: 'Test Name', binaryData: false },
+							{ fieldName: 'email', fieldValue: 'test@example.com', binaryData: false },
+						],
+					},
+				};
+
+				const mockResponse = [{ id: 1, name: 'Test Name', email: 'test@example.com' }];
+				mockedGenericFunctions.apiRequest.mockResolvedValue(mockResponse);
+
+				const executeFunction = createNocoDBExecuteFunction(nodeParameters);
+				const result = await nocoDbNode.execute.call(executeFunction);
+
+				expect(result[0]).toHaveLength(1);
+				expect(result[0][0].json).toEqual(
+					expect.objectContaining({
+						name: 'Test Name',
+						email: 'test@example.com',
+						id: 1,
+					}),
+				);
+				expect(mockedGenericFunctions.apiRequest).toHaveBeenCalledWith(
+					'POST',
+					'/api/v2/tables/table123/records',
+					expect.any(Array),
+					{},
+				);
+			});
+
+			it('should handle binary file upload', async () => {
+				const nodeParameters = {
+					version: 3,
+					resource: 'row',
+					operation: 'create',
+					projectId: 'base123',
+					table: 'table123',
+					dataToSend: 'defineBelow',
+					fieldsUi: {
+						fieldValues: [{ fieldName: 'attachment', binaryProperty: 'data', binaryData: true }],
+					},
+				};
+
+				const mockUploadResponse = { url: 'http://example.com/file.txt' };
+				const mockCreateResponse = [{ id: 1, attachment: JSON.stringify([mockUploadResponse]) }];
+				mockedGenericFunctions.apiRequest
+					.mockResolvedValueOnce(mockUploadResponse) // upload call
+					.mockResolvedValueOnce(mockCreateResponse); // create call
+
+				const executeFunction = createNocoDBExecuteFunction(nodeParameters);
+				const result = await nocoDbNode.execute.call(executeFunction);
+
+				expect(result[0]).toHaveLength(1);
+				expect(mockedGenericFunctions.apiRequest).toHaveBeenCalledTimes(2);
+			});
+		});
+
+		describe('Get Operation', () => {
+			it('should get single row for v3', async () => {
+				const nodeParameters = {
+					version: 3,
+					resource: 'row',
+					operation: 'get',
+					projectId: 'base123',
+					table: 'table123',
+					id: '1',
+					downloadAttachments: false,
+				};
+
+				const mockResponse = { id: 1, name: 'Test Item' };
+				mockedGenericFunctions.apiRequest.mockResolvedValue(mockResponse);
+
+				const executeFunction = createNocoDBExecuteFunction(nodeParameters);
+				const result = await nocoDbNode.execute.call(executeFunction);
+
+				expect(result[0]).toHaveLength(1);
+				expect(result[0][0].json).toEqual(mockResponse);
+				expect(mockedGenericFunctions.apiRequest).toHaveBeenCalledWith(
+					'GET',
+					'/api/v2/tables/table123/records/1',
+					{},
+					{},
+				);
+			});
+		});
+
+		describe('Get Many Operation', () => {
+			it('should get all rows for v3', async () => {
+				const nodeParameters = {
+					version: 3,
+					resource: 'row',
+					operation: 'getAll',
+					projectId: 'base123',
+					table: 'table123',
+					returnAll: true,
+					downloadAttachments: false,
+					options: {},
+				};
+
+				const mockResponse = [
+					{ id: 1, name: 'Item 1' },
+					{ id: 2, name: 'Item 2' },
+				];
+				mockedGenericFunctions.apiRequestAllItems.mockResolvedValue(mockResponse);
+
+				const executeFunction = createNocoDBExecuteFunction(nodeParameters);
+				const result = await nocoDbNode.execute.call(executeFunction);
+
+				expect(result[0]).toHaveLength(2);
+				expect(mockedGenericFunctions.apiRequestAllItems).toHaveBeenCalledWith(
+					'GET',
+					'/api/v2/tables/table123/records',
+					{},
+					{},
+				);
+			});
+
+			it('should limit results when returnAll is false', async () => {
+				const nodeParameters = {
+					version: 3,
+					resource: 'row',
+					operation: 'getAll',
+					projectId: 'base123',
+					table: 'table123',
+					returnAll: false,
+					limit: 5,
+					downloadAttachments: false,
+					options: {},
+				};
+
+				const mockResponse = { list: [{ id: 1, name: 'Item 1' }] };
+				mockedGenericFunctions.apiRequest.mockResolvedValue(mockResponse);
+
+				const executeFunction = createNocoDBExecuteFunction(nodeParameters);
+				const result = await nocoDbNode.execute.call(executeFunction);
+
+				expect(result[0]).toHaveLength(1);
+				expect(mockedGenericFunctions.apiRequest).toHaveBeenCalledWith(
+					'GET',
+					'/api/v2/tables/table123/records',
+					{},
+					{ limit: 5 },
+				);
+			});
+		});
+
+		describe('Update Operation', () => {
+			it('should update rows for v3', async () => {
+				const nodeParameters = {
+					version: 3,
+					resource: 'row',
+					operation: 'update',
+					projectId: 'base123',
+					table: 'table123',
+					dataToSend: 'defineBelow',
+					fieldsUi: {
+						fieldValues: [{ fieldName: 'name', fieldValue: 'Updated Name', binaryData: false }],
+					},
+				};
+
+				const mockResponse = [{ id: 1, name: 'Updated Name' }];
+				mockedGenericFunctions.apiRequest.mockResolvedValue(mockResponse);
+
+				const executeFunction = createNocoDBExecuteFunction(nodeParameters);
+				const result = await nocoDbNode.execute.call(executeFunction);
+
+				expect(result[0]).toHaveLength(1);
+				expect(result[0][0].json.name).toBe('Updated Name');
+				expect(mockedGenericFunctions.apiRequest).toHaveBeenCalledWith(
+					'PATCH',
+					'/api/v2/tables/table123/records',
+					expect.any(Array),
+					{},
+				);
+			});
+		});
+
+		describe('Delete Operation', () => {
+			it('should delete rows for v3', async () => {
+				const nodeParameters = {
+					version: 3,
+					resource: 'row',
+					operation: 'delete',
+					projectId: 'base123',
+					table: 'table123',
+					primaryKey: 'id',
+					id: '1',
+				};
+
+				const mockResponse = [{ id: 1, deleted: true }];
+				mockedGenericFunctions.apiRequest.mockResolvedValue(mockResponse);
+
+				const executeFunction = createNocoDBExecuteFunction(nodeParameters);
+				const result = await nocoDbNode.execute.call(executeFunction);
+
+				expect(result[0]).toHaveLength(1);
+				expect(mockedGenericFunctions.apiRequest).toHaveBeenCalledWith(
+					'DELETE',
+					'/api/v2/tables/table123/records',
+					[{ id: '1' }],
+					{},
+				);
+			});
+		});
+
+		describe('Error Handling', () => {
+			it('should throw NodeApiError on API failure', async () => {
+				const nodeParameters = {
+					version: 3,
+					resource: 'row',
+					operation: 'get',
+					projectId: 'base123',
+					table: 'table123',
+					id: '1',
+				};
+
+				const apiError = new Error('API Error');
+				mockedGenericFunctions.apiRequest.mockRejectedValue(apiError);
+
+				const executeFunction = createNocoDBExecuteFunction(nodeParameters);
+
+				await expect(nocoDbNode.execute.call(executeFunction)).rejects.toThrow(NodeApiError);
+			});
+
+			it('should return error object when continueOnFail is true for getAll operation', async () => {
+				const nodeParameters = {
+					version: 3,
+					resource: 'row',
+					operation: 'getAll',
+					projectId: 'base123',
+					table: 'table123',
+					returnAll: false,
+					limit: 5,
+					downloadAttachments: false,
+					options: {},
+				};
+
+				const apiError = new Error('API Error');
+				mockedGenericFunctions.apiRequest.mockRejectedValue(apiError);
+
+				const executeFunction = createNocoDBExecuteFunction(
+					nodeParameters,
+					defaultInputItems,
+					true,
+				);
+				const result = await nocoDbNode.execute.call(executeFunction);
+
+				expect(result[0]).toHaveLength(1);
+				expect(result[0][0].json.error).toContain('API Error');
+			});
+		});
+	});
+
+	describe('Link Resource', () => {
+		describe('Add Operation', () => {
+			it('should add link relationships for v3', async () => {
+				const nodeParameters = {
+					version: 3,
+					resource: 'link',
+					operation: 'add',
+					projectId: 'base123',
+					table: 'table123',
+					field: 'col123',
+					id: '1',
+					links: '2,3',
+				};
+
+				const mockResponse = { success: true };
+				mockedGenericFunctions.apiRequest.mockResolvedValue(mockResponse);
+
+				const executeFunction = createNocoDBExecuteFunction(nodeParameters);
+				const result = await nocoDbNode.execute.call(executeFunction);
+
+				expect(result[0]).toHaveLength(1);
+				expect(result[0][0].json).toEqual({ result: mockResponse });
+				expect(mockedGenericFunctions.apiRequest).toHaveBeenCalledWith(
+					'POST',
+					'/api/v2/tables/table123/links/col123/records/1',
+					[{ Id: '2' }, { Id: '3' }],
+					{},
+				);
+			});
+
+			it('should handle multiple input items for add operation', async () => {
+				const inputItems = [
+					{ json: { links: '2' }, pairedItem: { item: 0, input: undefined } },
+					{ json: { links: '3,4' }, pairedItem: { item: 1, input: undefined } },
+				];
+
+				const nodeParameters = {
+					version: 3,
+					resource: 'link',
+					operation: 'add',
+					projectId: 'base123',
+					table: 'table123',
+					field: 'col123',
+					id: '1',
+					links: '{{$json.links}}',
+				};
+
+				const mockResponse = { success: true };
+				mockedGenericFunctions.apiRequest.mockResolvedValue(mockResponse);
+
+				const executeFunction = createNocoDBExecuteFunction(nodeParameters, inputItems);
+				// Mock getNodeParameter for each item to return the expected links
+				(executeFunction as any).getNodeParameter = jest.fn(
+					(parameterName: string, itemIndex: number) => {
+						if (parameterName === 'links') {
+							return itemIndex === 0 ? '2' : '3,4';
+						}
+						return nodeParameters[parameterName as keyof typeof nodeParameters];
+					},
+				);
+
+				const result = await nocoDbNode.execute.call(executeFunction);
+
+				expect(result[0]).toHaveLength(1);
+				expect(mockedGenericFunctions.apiRequest).toHaveBeenCalledWith(
+					'POST',
+					'/api/v2/tables/table123/links/col123/records/1',
+					[{ Id: '2' }, { Id: '3' }, { Id: '4' }],
+					{},
+				);
+			});
+		});
+
+		describe('Delete Operation', () => {
+			it('should delete link relationships for v3', async () => {
+				const nodeParameters = {
+					version: 3,
+					resource: 'link',
+					operation: 'delete',
+					projectId: 'base123',
+					table: 'table123',
+					field: 'col123',
+					id: '1',
+					links: '2',
+				};
+
+				const mockResponse = { success: true };
+				mockedGenericFunctions.apiRequest.mockResolvedValue(mockResponse);
+
+				const executeFunction = createNocoDBExecuteFunction(nodeParameters);
+				const result = await nocoDbNode.execute.call(executeFunction);
+
+				expect(result[0]).toHaveLength(1);
+				expect(result[0][0].json).toEqual({ result: mockResponse });
+				expect(mockedGenericFunctions.apiRequest).toHaveBeenCalledWith(
+					'DELETE',
+					'/api/v2/tables/table123/links/col123/records/1',
+					[{ Id: '2' }],
+					{},
+				);
+			});
+
+			it('should handle multiple links for delete operation', async () => {
+				const nodeParameters = {
+					version: 3,
+					resource: 'link',
+					operation: 'delete',
+					projectId: 'base123',
+					table: 'table123',
+					field: 'col123',
+					id: '1',
+					links: '2,3,4',
+				};
+
+				const mockResponse = { success: true };
+				mockedGenericFunctions.apiRequest.mockResolvedValue(mockResponse);
+
+				const executeFunction = createNocoDBExecuteFunction(nodeParameters);
+				const result = await nocoDbNode.execute.call(executeFunction);
+
+				expect(result[0]).toHaveLength(1);
+				expect(mockedGenericFunctions.apiRequest).toHaveBeenCalledWith(
+					'DELETE',
+					'/api/v2/tables/table123/links/col123/records/1',
+					[{ Id: '2' }, { Id: '3' }, { Id: '4' }],
+					{},
+				);
+			});
+		});
+
+		describe('Get Many Operation', () => {
+			it('should get all linked records for v3', async () => {
+				const nodeParameters = {
+					version: 3,
+					resource: 'link',
+					operation: 'getAll',
+					projectId: 'base123',
+					table: 'table123',
+					field: 'col123',
+					id: '1',
+					returnAll: true,
+					downloadAttachments: false,
+					options: {},
+				};
+
+				const mockResponse = [
+					{ id: 2, name: 'Linked Item 1' },
+					{ id: 3, name: 'Linked Item 2' },
+				];
+				mockedGenericFunctions.apiRequestAllItems.mockResolvedValue(mockResponse);
+
+				const executeFunction = createNocoDBExecuteFunction(nodeParameters);
+				const result = await nocoDbNode.execute.call(executeFunction);
+
+				expect(result[0]).toHaveLength(2);
+				expect(mockedGenericFunctions.apiRequestAllItems).toHaveBeenCalledWith(
+					'GET',
+					'/api/v2/tables/table123/links/col123/records/1',
+					{},
+					{},
+				);
+			});
+
+			it('should handle pagination for linked records', async () => {
+				const nodeParameters = {
+					version: 3,
+					resource: 'link',
+					operation: 'getAll',
+					projectId: 'base123',
+					table: 'table123',
+					field: 'col123',
+					id: '1',
+					returnAll: false,
+					limit: 10,
+					downloadAttachments: false,
+					options: {},
+				};
+
+				const mockResponse = {
+					list: [{ id: 2, name: 'Linked Item 1' }],
+				};
+				mockedGenericFunctions.apiRequest.mockResolvedValue(mockResponse);
+
+				const executeFunction = createNocoDBExecuteFunction(nodeParameters);
+				const result = await nocoDbNode.execute.call(executeFunction);
+
+				expect(result[0]).toHaveLength(1);
+				expect(mockedGenericFunctions.apiRequest).toHaveBeenCalledWith(
+					'GET',
+					'/api/v2/tables/table123/links/col123/records/1',
+					{},
+					{ limit: 10 },
+				);
+			});
+
+			it('should handle sorting and field selection for linked records', async () => {
+				const nodeParameters = {
+					version: 3,
+					resource: 'link',
+					operation: 'getAll',
+					projectId: 'base123',
+					table: 'table123',
+					field: 'col123',
+					id: '1',
+					returnAll: false,
+					limit: 5,
+					downloadAttachments: false,
+					options: {
+						sort: {
+							property: [
+								{ field: 'name', direction: 'asc' },
+								{ field: 'created_at', direction: 'desc' },
+							],
+						},
+						fields: ['id', 'name'],
+					},
+				};
+
+				const mockResponse = {
+					list: [{ id: 2, name: 'Linked Item 1' }],
+				};
+				mockedGenericFunctions.apiRequest.mockResolvedValue(mockResponse);
+
+				const executeFunction = createNocoDBExecuteFunction(nodeParameters);
+				const result = await nocoDbNode.execute.call(executeFunction);
+
+				expect(result[0]).toHaveLength(1);
+				expect(mockedGenericFunctions.apiRequest).toHaveBeenCalledWith(
+					'GET',
+					'/api/v2/tables/table123/links/col123/records/1',
+					{},
+					{
+						limit: 5,
+						sort: 'name,-created_at',
+						fields: 'id,name',
+					},
+				);
+			});
+
+			it('should handle download attachments for linked records', async () => {
+				const nodeParameters = {
+					version: 3,
+					resource: 'link',
+					operation: 'getAll',
+					projectId: 'base123',
+					table: 'table123',
+					field: 'col123',
+					id: '1',
+					returnAll: true,
+					downloadAttachments: true,
+					downloadFieldNames: 'attachment,image',
+				};
+
+				const mockResponse = [{ id: 2, name: 'Linked Item 1', attachment: 'file.pdf' }];
+				const mockDownloadResponse = [
+					{
+						json: { id: 2 },
+						binary: {
+							attachment: {
+								data: 'base64encodeddata',
+								mimeType: 'application/pdf',
+								fileName: 'file.pdf',
+							},
+						},
+					},
+				];
+				mockedGenericFunctions.apiRequestAllItems.mockResolvedValue(mockResponse);
+				mockedGenericFunctions.downloadRecordAttachments.mockResolvedValue(mockDownloadResponse);
+
+				const executeFunction = createNocoDBExecuteFunction(nodeParameters);
+				const result = await nocoDbNode.execute.call(executeFunction);
+
+				expect(result[0]).toEqual(mockDownloadResponse);
+				expect(mockedGenericFunctions.downloadRecordAttachments).toHaveBeenCalledWith(
+					mockResponse,
+					['attachment', 'image'],
+					[{ item: 0 }],
+				);
+			});
+		});
+
+		describe('Error Handling', () => {
+			it('should throw NodeApiError on link add failure', async () => {
+				const nodeParameters = {
+					version: 3,
+					resource: 'link',
+					operation: 'add',
+					projectId: 'base123',
+					table: 'table123',
+					field: 'col123',
+					id: '1',
+					links: '2',
+				};
+
+				const apiError = new Error('Link API Error');
+				mockedGenericFunctions.apiRequest.mockRejectedValue(apiError);
+
+				const executeFunction = createNocoDBExecuteFunction(nodeParameters);
+
+				await expect(nocoDbNode.execute.call(executeFunction)).rejects.toThrow(NodeApiError);
+			});
+
+			it('should return error object when continueOnFail is true for add operation', async () => {
+				const nodeParameters = {
+					version: 3,
+					resource: 'link',
+					operation: 'add',
+					projectId: 'base123',
+					table: 'table123',
+					field: 'col123',
+					id: '1',
+					links: '2',
+				};
+
+				const apiError = new Error('Link creation failed');
+				mockedGenericFunctions.apiRequest.mockRejectedValue(apiError);
+
+				const executeFunction = createNocoDBExecuteFunction(
+					nodeParameters,
+					defaultInputItems,
+					true,
+				);
+				const result = await nocoDbNode.execute.call(executeFunction);
+
+				expect(result[0]).toHaveLength(1);
+				expect(result[0][0].json.error).toContain('Link creation failed');
+			});
+
+			it('should handle invalid field error for getAll operation', async () => {
+				const nodeParameters = {
+					version: 3,
+					resource: 'link',
+					operation: 'getAll',
+					projectId: 'base123',
+					table: 'table123',
+					field: 'invalid_field',
+					id: '1',
+					returnAll: true,
+					downloadAttachments: false,
+				};
+
+				const apiError = new Error('Field not found');
+				mockedGenericFunctions.apiRequestAllItems.mockRejectedValue(apiError);
+
+				const executeFunction = createNocoDBExecuteFunction(
+					nodeParameters,
+					defaultInputItems,
+					true,
+				);
+				const result = await nocoDbNode.execute.call(executeFunction);
+
+				expect(result[0]).toHaveLength(1);
+				expect(result[0][0].json.error).toContain('Field not found');
+			});
+
+			it('should handle missing record error for delete operation', async () => {
+				const nodeParameters = {
+					version: 3,
+					resource: 'link',
+					operation: 'delete',
+					projectId: 'base123',
+					table: 'table123',
+					field: 'col123',
+					id: '999',
+					links: '2',
+				};
+
+				const apiError = new Error('Record not found');
+				mockedGenericFunctions.apiRequest.mockRejectedValue(apiError);
+
+				const executeFunction = createNocoDBExecuteFunction(
+					nodeParameters,
+					defaultInputItems,
+					true,
+				);
+				const result = await nocoDbNode.execute.call(executeFunction);
+
+				expect(result[0]).toHaveLength(1);
+				expect(result[0][0].json.error).toContain('Record not found');
+			});
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Updates existing NocoDB node "Row" resource:

- Added "Shuffle" and "Offset" options to the "Get Many" operation
- Added "Fields" option to the "Get" operation
- Added a hint with a link to official documentation to the "Filter By Formula" option

Introduces new NocoDB node resource "Link" with the following operations:

- "Add" — add link/s between rows from two tables
- "Delete" — delete link/s between rows from two tables
- "Get Many" — fetch linked rows 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
