### PR TITLE
perf(core): Shorten bootup for all instance types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ build-storybook.log
 *.junit.xml
 junit.xml
 test-results.json
+*.0x

--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -4,7 +4,6 @@ import { Flags } from '@oclif/core';
 import { UserError } from 'n8n-workflow';
 
 import { RISK_CATEGORIES } from '@/security-audit/constants';
-import { SecurityAuditService } from '@/security-audit/security-audit.service';
 import type { Risk } from '@/security-audit/types';
 
 import { BaseCommand } from './base-command';
@@ -50,6 +49,8 @@ export class SecurityAudit extends BaseCommand {
 
 			throw new UserError([message, hint].join('. '));
 		}
+
+		const { SecurityAuditService } = await import('@/security-audit/security-audit.service');
 
 		const result = await Container.get(SecurityAuditService).run(
 			categories,


### PR DESCRIPTION
## Summary

Anything that is imported in an `oclif` command ends up loaded in-memory for other commands as well. 

Until we move away from this setup, we have to lazyload as much as possible in commands, e.g. `SecurityAuditService` which takes up ~20% of bootup time.

![Capture 2025-05-30 at 10 29 43@2x](https://github.com/user-attachments/assets/63dc194e-a11b-47d8-ae99-27b7660c86c2)

## Related Linear tickets, Github issues, and Community forum posts

n/a

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
