### PR TITLE
fix(API): Allow `false` as a dependant value for public api json schema validation

### DIFF
--- a/packages/cli/src/public-api/v1/handlers/credentials/__tests__/credentials.service.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/credentials/__tests__/credentials.service.test.ts
@@ -1,0 +1,71 @@
+import type { GenericValue, IDataObject, INodeProperties } from 'n8n-workflow';
+
+import type { IDependency } from '@/public-api/types';
+
+import { toJsonSchema } from '../credentials.service';
+
+describe('CredentialsService', () => {
+	describe('toJsonSchema', () => {
+		it('should add "false" displayOptions.show dependant value as allof condition', () => {
+			const properties: INodeProperties[] = [
+				{ name: 'field1', type: 'string', required: true, displayName: 'Field 1', default: '' },
+				{
+					name: 'field2',
+					type: 'options',
+					required: true,
+					options: [
+						{ value: 'opt1', name: 'opt1' },
+						{ value: 'opt2', name: 'opt2' },
+					],
+					displayName: 'Field 2',
+					default: 'opt1',
+				},
+				{
+					name: 'field3',
+					type: 'string',
+					displayName: 'Field 3',
+					default: '',
+					displayOptions: {
+						show: {
+							field2: [false], // boolean false as dependant value
+						},
+					},
+				},
+			];
+
+			const schema = toJsonSchema(properties);
+
+			// Cast properties as IDataObject
+			const props = schema.properties as IDataObject;
+
+			expect(props).toBeDefined();
+			expect(props.field1).toEqual({ type: 'string' });
+			expect(props.field2).toEqual({
+				type: 'string',
+				enum: ['opt1', 'opt2'],
+			});
+			expect(props.field3).toEqual({ type: 'string' });
+
+			// field1 and field2 required globally, field3 required conditionally
+			expect(schema.required).toEqual(expect.arrayContaining(['field1', 'field2']));
+			expect(schema.required).not.toContain('field3');
+
+			const allOf = schema.allOf as GenericValue[] | IDataObject[];
+			expect(Array.isArray(allOf)).toBe(true);
+			expect(allOf?.length).toBeGreaterThan(0);
+
+			const condition = allOf?.find((cond) => (cond as any).if?.properties?.field2) as IDependency;
+			expect(condition).toBeDefined();
+			expect((condition.if?.properties as any).field2).toEqual({
+				enum: [false], // boolean false as dependant value
+			});
+
+			// then block requires field3 when field2 === false
+			expect(condition.then?.allOf.some((req: any) => req.required?.includes('field3'))).toBe(true);
+			// else block forbids field3 when field2 !== false
+			expect(
+				condition.else?.allOf.some((notReq: any) => notReq.not?.required?.includes('field3')),
+			).toBe(true);
+		});
+	});
+});

--- a/packages/cli/src/public-api/v1/handlers/credentials/credentials.service.ts
+++ b/packages/cli/src/public-api/v1/handlers/credentials/credentials.service.ts
@@ -206,7 +206,12 @@ export function toJsonSchema(properties: INodeProperties[]): IDataObject {
 			const displayOptionsValues = property.displayOptions.show[dependantName];
 			let dependantValue: DisplayCondition | string | number | boolean = '';
 
-			if (displayOptionsValues && Array.isArray(displayOptionsValues) && displayOptionsValues[0]) {
+			if (
+				displayOptionsValues &&
+				Array.isArray(displayOptionsValues) &&
+				displayOptionsValues[0] !== undefined &&
+				displayOptionsValues[0] !== null
+			) {
 				dependantValue = displayOptionsValues[0];
 			}
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

When creating json schema validation for the public API from node properties, we previously discard `false` show conditions when schema validation condition.
This PR fixes that by checking if the show condition on the dependant field is not null or undefined, instead of truthy

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2883/community-issue-incorrect-validation-for-disablestarttls-when-creating
Fixes: https://github.com/n8n-io/n8n/issues/15759

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
