### PR TITLE
fix(core): Support `helpers.request` in task runners

### DIFF
--- a/packages/@n8n/task-runner/src/runner-types.ts
+++ b/packages/@n8n/task-runner/src/runner-types.ts
@@ -119,6 +119,9 @@ export const EXPOSED_RPC_METHODS = [
 
 	// httpRequest(opts: IHttpRequestOptions): Promise<IN8nHttpFullResponse | IN8nHttpResponse>
 	'helpers.httpRequest',
+
+	// (deprecated) request(uriOrObject: string | IRequestOptions, options?: IRequestOptions): Promise<any>;
+	'helpers.request',
 ];
 
 /** Helpers that exist but that we are not exposing to the Code Node */

--- a/packages/cli/src/task-runners/task-managers/__tests__/task-manager.test.ts
+++ b/packages/cli/src/task-runners/task-managers/__tests__/task-manager.test.ts
@@ -30,6 +30,7 @@ describe('TaskRequester', () => {
 			['helpers.setBinaryDataBuffer', [{ data: '123' }, Buffer.from('data').toJSON()]],
 			['helpers.binaryToString', [Buffer.from('data').toJSON(), 'utf8']],
 			['helpers.httpRequest', [{ url: 'http://localhost' }]],
+			['helpers.request', [{ url: 'http://localhost' }]],
 		])('should handle %s rpc call', async (methodName, args) => {
 			const executeFunctions = set({}, methodName.split('.'), jest.fn());
 


### PR DESCRIPTION
## Summary

Support deprecated method `helper.request` in task runners for backwards compatibility.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-782
https://github.com/n8n-io/n8n/issues/15301

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
