### PR TITLE
fix: Add commands for tab interception and visiting (no-changelog)

### DIFF
--- a/cypress/e2e/39-projects.cy.ts
+++ b/cypress/e2e/39-projects.cy.ts
@@ -5,6 +5,7 @@ import {
 	clickCreateNewCredential,
 	getNdvContainer,
 	selectResourceLocatorAddResourceItem,
+	clickGetBackToCanvas,
 } from '../composables/ndv';
 import * as projects from '../composables/projects';
 import {
@@ -294,14 +295,12 @@ describe('Projects', { disableAutoLogin: true }, () => {
 			workflowPage.actions.saveWorkflowOnButtonClick();
 			workflowPage.actions.addNodeToCanvas('Execute Workflow', true, true);
 
-			// This mock fails when running with `test:e2e:dev` but works with `test:e2e:ui`,
-			// at least on macOS at version 1.94.0. ¯\_(ツ)_/¯
-			cy.window().then((win) => cy.stub(win, 'open').callsFake((url) => cy.visit(url)));
-
+			cy.interceptNewTab();
 			selectResourceLocatorAddResourceItem('workflowId', 'Create a');
-			// Need to wait for the trigger node to auto-open after a delay
+
+			cy.visitInterceptedTab();
 			getNdvContainer().should('be.visible');
-			cy.get('body').type('{esc}');
+			clickGetBackToCanvas();
 			workflowPage.actions.addNodeToCanvas(NOTION_NODE_NAME, true, true);
 			clickCreateNewCredential();
 			setCredentialValues({

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -240,3 +240,18 @@ Cypress.Commands.add('resetDatabase', () => {
 		admin: INSTANCE_ADMIN,
 	});
 });
+
+Cypress.Commands.add('interceptNewTab', () => {
+	cy.window().then((win) => {
+		cy.stub(win, 'open').as('windowOpen');
+	});
+});
+
+Cypress.Commands.add('visitInterceptedTab', () => {
+	cy.get('@windowOpen')
+		.should('have.been.called')
+		.then((stub: any) => {
+			const url = stub.firstCall.args[0];
+			cy.visit(url);
+		});
+});

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -86,6 +86,8 @@ declare global {
 			>;
 			resetDatabase(): void;
 			setAppDate(targetDate: number | Date): void;
+			interceptNewTab(): Chainable<void>;
+			visitInterceptedTab(): Chainable<void>;
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Use more reliable NDV close.
Clearer separation on tab interception

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-2815/flaky-ui-projects-when-starting-from-scratch-should-create-sub
Flaky Test Run (200 passed): https://github.com/n8n-io/n8n/actions/runs/15344751050/job/43178452448


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
