### PR TITLE
fix(Local File Trigger Node): Fix ignored option on Mac os

### DIFF
--- a/packages/nodes-base/nodes/LocalFileTrigger/LocalFileTrigger.node.ts
+++ b/packages/nodes-base/nodes/LocalFileTrigger/LocalFileTrigger.node.ts
@@ -146,7 +146,7 @@ export class LocalFileTrigger implements INodeType {
 						name: 'ignored',
 						type: 'string',
 						default: '',
-						placeholder: '**/*.txt',
+						placeholder: '**/*.txt or ignore-me/subfolder',
 						description:
 							'Files or paths to ignore. The whole path is tested, not just the filename. Supports <a href="https://github.com/micromatch/anymatch">Anymatch</a>- syntax.',
 					},
@@ -202,6 +202,26 @@ export class LocalFileTrigger implements INodeType {
 						description:
 							'Whether to use polling for watching. Typically necessary to successfully watch files over a network.',
 					},
+					{
+						displayName: 'Ignore Mode',
+						name: 'ignoreMode',
+						type: 'options',
+						options: [
+							{
+								name: 'Regex',
+								value: 'regex',
+								description: 'Use regex patterns (e.g., **/*.txt)',
+							},
+							{
+								name: 'Function',
+								value: 'function',
+								description:
+									'Wraps the ignored value in a function that checks if the file path includes the ignored value',
+							},
+						],
+						default: 'regex',
+						description: 'Whether to use regex Anymatch patterns or a function to ignore files',
+					},
 				],
 			},
 		],
@@ -218,9 +238,9 @@ export class LocalFileTrigger implements INodeType {
 		} else {
 			events = this.getNodeParameter('events', []) as string[];
 		}
-
+		const ignored = options.ignored === '' ? undefined : (options.ignored as string);
 		const watcher = watch(path, {
-			ignored: options.ignored === '' ? undefined : (options.ignored as string),
+			ignored: options.ignoreMode === 'regex' ? ignored : (x) => x.includes(ignored as string),
 			persistent: true,
 			ignoreInitial:
 				options.ignoreInitial === undefined ? true : (options.ignoreInitial as boolean),

--- a/packages/nodes-base/nodes/LocalFileTrigger/LocalFileTrigger.node.ts
+++ b/packages/nodes-base/nodes/LocalFileTrigger/LocalFileTrigger.node.ts
@@ -148,7 +148,7 @@ export class LocalFileTrigger implements INodeType {
 						default: '',
 						placeholder: '**/*.txt or ignore-me/subfolder',
 						description:
-							'Files or paths to ignore. The whole path is tested, not just the filename. Supports <a href="https://github.com/micromatch/anymatch">Anymatch</a>- syntax.',
+							"Files or paths to ignore. The whole path is tested, not just the filename. Supports <a href=\"https://github.com/micromatch/anymatch\">Anymatch</a>- syntax. Regex patterns may not work on macOS. To ignore files based on substring matching, use the 'Ignore Mode' option with 'Contain'.",
 					},
 					{
 						displayName: 'Ignore Existing Files/Folders',
@@ -208,19 +208,20 @@ export class LocalFileTrigger implements INodeType {
 						type: 'options',
 						options: [
 							{
-								name: 'Regex',
-								value: 'regex',
-								description: 'Use regex patterns (e.g., **/*.txt)',
+								name: 'Match',
+								value: 'match',
+								description:
+									'Ignore files using regex patterns (e.g., **/*.txt), Not supported on macOS',
 							},
 							{
-								name: 'Function',
-								value: 'function',
-								description:
-									'Wraps the ignored value in a function that checks if the file path includes the ignored value',
+								name: 'Contain',
+								value: 'contain',
+								description: 'Ignore files if their path contains the specified value',
 							},
 						],
-						default: 'regex',
-						description: 'Whether to use regex Anymatch patterns or a function to ignore files',
+						default: 'match',
+						description:
+							'Whether to ignore files using regex matching (Anymatch patterns) or by checking if the path contains a specified value',
 					},
 				],
 			},
@@ -240,7 +241,7 @@ export class LocalFileTrigger implements INodeType {
 		}
 		const ignored = options.ignored === '' ? undefined : (options.ignored as string);
 		const watcher = watch(path, {
-			ignored: options.ignoreMode === 'regex' ? ignored : (x) => x.includes(ignored as string),
+			ignored: options.ignoreMode === 'match' ? ignored : (x) => x.includes(ignored as string),
 			persistent: true,
 			ignoreInitial:
 				options.ignoreInitial === undefined ? true : (options.ignoreInitial as boolean),

--- a/packages/nodes-base/nodes/LocalFileTrigger/__test__/LocalFileTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/LocalFileTrigger/__test__/LocalFileTrigger.node.test.ts
@@ -1,0 +1,110 @@
+import chokidar from 'chokidar';
+import type { ITriggerFunctions } from 'n8n-workflow';
+
+import { LocalFileTrigger } from '../LocalFileTrigger.node';
+
+jest.mock('chokidar');
+
+const mockWatcher = {
+	on: jest.fn(),
+	close: jest.fn().mockResolvedValue(undefined),
+};
+
+(chokidar.watch as unknown as jest.Mock).mockReturnValue(mockWatcher);
+
+describe('LocalFileTrigger', () => {
+	let node: LocalFileTrigger;
+	let emitSpy: jest.Mock;
+	let context: ITriggerFunctions;
+
+	beforeEach(() => {
+		node = new LocalFileTrigger();
+		emitSpy = jest.fn();
+
+		context = {
+			getNodeParameter: jest.fn(),
+			emit: emitSpy,
+			helpers: {
+				returnJsonArray: (data: unknown[]) => data,
+			},
+		} as unknown as ITriggerFunctions;
+
+		jest.clearAllMocks();
+	});
+
+	it('should set up chokidar with correct options for folder + regex ignore', async () => {
+		(context.getNodeParameter as jest.Mock)
+			.mockReturnValueOnce('folder')
+			.mockReturnValueOnce('/some/folder')
+			.mockReturnValueOnce({
+				ignored: '**/*.txt',
+				ignoreMode: 'regex',
+				ignoreInitial: true,
+				followSymlinks: true,
+				depth: 1,
+				usePolling: false,
+				awaitWriteFinish: false,
+			})
+			.mockReturnValueOnce(['add']);
+
+		await node.trigger.call(context);
+
+		expect(chokidar.watch).toHaveBeenCalledWith(
+			'/some/folder',
+			expect.objectContaining({
+				ignored: '**/*.txt',
+				ignoreInitial: true,
+				depth: 1,
+				followSymlinks: true,
+				usePolling: false,
+				awaitWriteFinish: false,
+			}),
+		);
+
+		expect(mockWatcher.on).toHaveBeenCalledWith('add', expect.any(Function));
+	});
+
+	it('should wrap ignored in function for ignoreMode=function', async () => {
+		(context.getNodeParameter as jest.Mock)
+			.mockReturnValueOnce('folder')
+			.mockReturnValueOnce('/folder')
+			.mockReturnValueOnce({
+				ignored: 'node_modules',
+				ignoreMode: 'function',
+			})
+			.mockReturnValueOnce(['change']);
+
+		await node.trigger.call(context);
+
+		const call = (chokidar.watch as jest.Mock).mock.calls[0][1];
+		expect(typeof call.ignored).toBe('function');
+		expect(call.ignored('folder/node_modules/stuff')).toBe(true);
+		expect(call.ignored('folder/src/index.js')).toBe(false);
+	});
+
+	it('should emit an event when a file changes', async () => {
+		(context.getNodeParameter as jest.Mock)
+			.mockReturnValueOnce('folder')
+			.mockReturnValueOnce('/watched')
+			.mockReturnValueOnce({})
+			.mockReturnValueOnce(['change']);
+
+		await node.trigger.call(context);
+
+		const callback = mockWatcher.on.mock.calls.find(([event]) => event === 'change')?.[1];
+		callback?.('/watched/file.txt');
+
+		expect(emitSpy).toHaveBeenCalledWith([[{ event: 'change', path: '/watched/file.txt' }]]);
+	});
+
+	it('should use "change" as the only event if watching a specific file', async () => {
+		(context.getNodeParameter as jest.Mock)
+			.mockReturnValueOnce('file')
+			.mockReturnValueOnce('/watched/file.txt')
+			.mockReturnValueOnce({});
+
+		await node.trigger.call(context);
+
+		expect(mockWatcher.on).toHaveBeenCalledWith('change', expect.any(Function));
+	});
+});

--- a/packages/nodes-base/nodes/LocalFileTrigger/__test__/LocalFileTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/LocalFileTrigger/__test__/LocalFileTrigger.node.test.ts
@@ -32,13 +32,13 @@ describe('LocalFileTrigger', () => {
 		jest.clearAllMocks();
 	});
 
-	it('should set up chokidar with correct options for folder + regex ignore', async () => {
+	it('should set up chokidar with correct options for folder + match ignore', async () => {
 		(context.getNodeParameter as jest.Mock)
 			.mockReturnValueOnce('folder')
 			.mockReturnValueOnce('/some/folder')
 			.mockReturnValueOnce({
 				ignored: '**/*.txt',
-				ignoreMode: 'regex',
+				ignoreMode: 'match',
 				ignoreInitial: true,
 				followSymlinks: true,
 				depth: 1,
@@ -64,13 +64,13 @@ describe('LocalFileTrigger', () => {
 		expect(mockWatcher.on).toHaveBeenCalledWith('add', expect.any(Function));
 	});
 
-	it('should wrap ignored in function for ignoreMode=function', async () => {
+	it('should wrap ignored in function for ignoreMode=contain', async () => {
 		(context.getNodeParameter as jest.Mock)
 			.mockReturnValueOnce('folder')
 			.mockReturnValueOnce('/folder')
 			.mockReturnValueOnce({
 				ignored: 'node_modules',
-				ignoreMode: 'function',
+				ignoreMode: 'contain',
 			})
 			.mockReturnValueOnce(['change']);
 


### PR DESCRIPTION
## Summary
This PR adds a new "Ignore Mode" option to the Local File Trigger node, allowing users to choose between:

- Regex (default): standard regex ignore patterns using [anymatch](https://github.com/micromatch/anymatch) syntax.

- Function: wraps the ignored value in a function (e.g. (path) => path.includes(value)) to match paths programmatically.

This change addresses a known issue with Chokidar on macOS, where the default ignore behavior using regex does not reliably filter paths. See [Chokidar Issue #773](https://github.com/paulmillr/chokidar/issues/773) for details.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-2520/community-issue-local-file-trigger-ignore-option-does-not-ignore-files
https://community.n8n.io/t/local-file-trigger-not-ignore-file-paterns/84654/2
fixes https://github.com/n8n-io/n8n/issues/13711


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
