### PR TITLE
fix(core): Honor absolute paths for `N8N_LOG_FILE_LOCATION`

### DIFF
--- a/packages/@n8n/backend-common/src/logging/logger.ts
+++ b/packages/@n8n/backend-common/src/logging/logger.ts
@@ -195,10 +195,9 @@ export class Logger implements LoggerType {
 			winston.format.json(),
 		);
 
-		const filename = path.join(
-			this.instanceSettingsConfig.n8nFolder,
-			this.globalConfig.logging.file.location,
-		);
+		const filename = path.isAbsolute(this.globalConfig.logging.file.location)
+			? this.globalConfig.logging.file.location
+			: path.join(this.instanceSettingsConfig.n8nFolder, this.globalConfig.logging.file.location);
 
 		const { fileSizeMax, fileCountMax } = this.globalConfig.logging.file;
 


### PR DESCRIPTION

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

We used to accept absolute paths for `N8N_LOG_FILE_LOCATION`. [This refactor ](https://github.com/n8n-io/n8n/pull/11031) added a regression that instead joins the absolute path with the n8n folder. You can still write outside of the n8n folder, but you have to do the path-math yourself now (e.g. `../../../tmp/n8n.log`)

With this PR absolute paths are not joined with the n8n folder's path anymore.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2888/allow-using-an-absolute-paths-for-n8n-log-file-location-again


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
