### PR TITLE
fix: avoid name collison when multiple custom nodes are loaded

### DIFF
--- a/packages/core/src/nodes-loader/custom-directory-loader.ts
+++ b/packages/core/src/nodes-loader/custom-directory-loader.ts
@@ -15,7 +15,7 @@ export class CustomDirectoryLoader extends DirectoryLoader {
 		this.packageName = createHash('sha256')
             .update(this.directory)
             .digest('hex')
-            .substring(0, 8);
+			.substring(0, 8);
 		
 		const nodes = await glob('**/*.node.js', {
 			cwd: this.directory,

--- a/packages/core/src/nodes-loader/custom-directory-loader.ts
+++ b/packages/core/src/nodes-loader/custom-directory-loader.ts
@@ -1,4 +1,5 @@
 import glob from 'fast-glob';
+import { createHash } from "crypto";
 
 import { DirectoryLoader } from './directory-loader';
 
@@ -10,6 +11,12 @@ export class CustomDirectoryLoader extends DirectoryLoader {
 	packageName = 'CUSTOM';
 
 	override async loadAll() {
+		// hash the name so that multiple custom nodes do not collide
+		this.packageName = createHash('sha256')
+            .update(this.directory)
+            .digest('hex')
+            .substring(0, 8);
+		
 		const nodes = await glob('**/*.node.js', {
 			cwd: this.directory,
 			absolute: true,


### PR DESCRIPTION
## Summary

Currently, if you supply n8n something like `N8N_CUSTOM_EXTENSIONS="/path1;/path2:/path3"`, it only ever loads `path3`, as it overrides `path1` and `path2` after it loads `path3`.

This PR allows all paths to be loaded.

The workarounds provided in #13356 are more of hacks than permanent solutions. This PR hashes the custom nodes' names so that multiple of them can be loaded at the same time, as documented.

## Related Linear tickets, Github issues, and Community forum posts

This PR resolves #13356 

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [ ] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~ not needed
- [ ] ~Tests included.~ not sure how to test this. guidance needed.
- [ ] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
