### PR TITLE
fix(core): Normalize trailing slash when setting CORS headers for test webhooks

### DIFF
--- a/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
@@ -56,7 +56,7 @@ describe('TestWebhooks', () => {
 	});
 
 	beforeEach(() => {
-		jest.clearAllMocks();
+		jest.restoreAllMocks();
 	});
 
 	describe('needsWebhook()', () => {
@@ -190,6 +190,21 @@ describe('TestWebhooks', () => {
 			await testWebhooks.deactivateWebhooks(workflow);
 
 			expect(mockedAdditionalData.getBase).toHaveBeenCalledWith(userId);
+		});
+	});
+
+	describe('getWebhookMethods()', () => {
+		test('should normalize trailing slash', async () => {
+			const METHOD = 'POST';
+			const PATH_WITH_SLASH = 'register/';
+			const PATH_WITHOUT_SLASH = 'register';
+			registrations.getAllKeys.mockResolvedValue([`${METHOD}|${PATH_WITHOUT_SLASH}`]);
+
+			const resultWithSlash = await testWebhooks.getWebhookMethods(PATH_WITH_SLASH);
+			const resultWithoutSlash = await testWebhooks.getWebhookMethods(PATH_WITHOUT_SLASH);
+
+			expect(resultWithSlash).toEqual([METHOD]);
+			expect(resultWithoutSlash).toEqual([METHOD]);
 		});
 	});
 });

--- a/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
@@ -56,7 +56,7 @@ describe('TestWebhooks', () => {
 	});
 
 	beforeEach(() => {
-		jest.restoreAllMocks();
+		jest.resetAllMocks();
 	});
 
 	describe('needsWebhook()', () => {

--- a/packages/cli/src/webhooks/test-webhooks.ts
+++ b/packages/cli/src/webhooks/test-webhooks.ts
@@ -174,7 +174,8 @@ export class TestWebhooks implements IWebhookManager {
 		if (timeout) clearTimeout(timeout);
 	}
 
-	async getWebhookMethods(path: string) {
+	async getWebhookMethods(rawPath: string) {
+		const path = removeTrailingSlash(rawPath);
 		const allKeys = await this.registrations.getAllKeys();
 
 		const webhookMethods = allKeys


### PR DESCRIPTION
`WebhookRequestHandler.setupCorsHeaders` calls `TestWebhooks.getWebhookMethods` to set the `Access-Control-Allow-Methods` header, but `getWebhookMethods` is trailing slash sensitive, which leads a request like this to incorrectly fail to find the webhook:

```
curl -X POST 'https://domain.com/webhook-test/register/' \
-H 'Origin: https://domain.com' \
-H 'Content-Type: application/x-www-form-urlencoded' \
-H 'Accept: */*' \
--data-urlencode 'key=value'
```

This is not an issue for production webhooks because `ActiveWorkflowManager.addWebhooks` normalizes the path before persisting the webhook.

Fixes #13591