### PR TITLE
fix(core): Prometheus metrics can't be ingested by datadog

### DIFF
--- a/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
+++ b/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
@@ -151,6 +151,7 @@ describe('PrometheusMetricsService', () => {
 			await prometheusMetricsService.init(app);
 
 			expect(promBundle).toHaveBeenCalledWith({
+				httpDurationMetricName: 'n8n_http_request_duration_seconds',
 				autoregister: false,
 				includeUp: false,
 				includePath: false,

--- a/packages/cli/src/metrics/__tests__/prometheus-metrics.service.unmocked.test.ts
+++ b/packages/cli/src/metrics/__tests__/prometheus-metrics.service.unmocked.test.ts
@@ -95,22 +95,18 @@ workflow_success_total{workflow_id="1234"} 1"
 			workflowRepository,
 		);
 
+		// ACT
 		await prometheusMetricsService.init(app);
 
-		// ACT
-		const event = new EventMessageWorkflow({
-			eventName: 'n8n.workflow.success',
-			payload: { workflowId: '1234' },
-		});
-
-		eventBus.emit('metrics.eventBus.event', event);
-
 		// ASSERT
-		const versionInfoMetric = promClient.register.getSingleMetric(`${customPrefix}version_info`);
-
-		if (!versionInfoMetric) {
-			fail(`Could not find a metric called "${customPrefix}version_info"`);
-		}
+		const eventLoopLagMetric = await promClient.register.getSingleMetricAsString(
+			`${customPrefix}nodejs_eventloop_lag_seconds`,
+		);
+		expect(eventLoopLagMetric.split('\n')).toMatchObject([
+			'# HELP custom_nodejs_eventloop_lag_seconds Lag of event loop in seconds.',
+			'# TYPE custom_nodejs_eventloop_lag_seconds gauge',
+			expect.stringMatching('custom_nodejs_eventloop_lag_seconds .*'),
+		]);
 	});
 });
 

--- a/packages/cli/src/metrics/__tests__/prometheus-metrics.service.unmocked.test.ts
+++ b/packages/cli/src/metrics/__tests__/prometheus-metrics.service.unmocked.test.ts
@@ -99,6 +99,7 @@ workflow_success_total{workflow_id="1234"} 1"
 		await prometheusMetricsService.init(app);
 
 		// ASSERT
+		// native metric from promClient
 		const eventLoopLagMetric = await promClient.register.getSingleMetricAsString(
 			`${customPrefix}nodejs_eventloop_lag_seconds`,
 		);
@@ -106,6 +107,15 @@ workflow_success_total{workflow_id="1234"} 1"
 			'# HELP custom_nodejs_eventloop_lag_seconds Lag of event loop in seconds.',
 			'# TYPE custom_nodejs_eventloop_lag_seconds gauge',
 			expect.stringMatching('custom_nodejs_eventloop_lag_seconds .*'),
+		]);
+		// custom metric
+		const versionMetric = await promClient.register.getSingleMetricAsString(
+			`${customPrefix}version_info`,
+		);
+		expect(versionMetric.split('\n')).toMatchObject([
+			'# HELP custom_version_info n8n version info.',
+			'# TYPE custom_version_info gauge',
+			expect.stringMatching('custom_version_info.*'),
 		]);
 	});
 });

--- a/packages/cli/src/metrics/prometheus-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus-metrics.service.ts
@@ -132,6 +132,7 @@ export class PrometheusMetricsService {
 			includePath: this.includes.labels.apiPath,
 			includeMethod: this.includes.labels.apiMethod,
 			includeStatusCode: this.includes.labels.apiStatusCode,
+			httpDurationMetricName: this.prefix + 'http_request_duration_seconds',
 		});
 
 		const activityGauge = new promClient.Gauge({

--- a/packages/cli/src/metrics/prometheus-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus-metrics.service.ts
@@ -116,7 +116,7 @@ export class PrometheusMetricsService {
 	private initDefaultMetrics() {
 		if (!this.includes.metrics.default) return;
 
-		promClient.collectDefaultMetrics();
+		promClient.collectDefaultMetrics({ prefix: this.globalConfig.endpoints.metrics.prefix });
 	}
 
 	/**
@@ -165,23 +165,9 @@ export class PrometheusMetricsService {
 	private mountMetricsEndpoint(app: express.Application) {
 		app.get('/metrics', async (_req: express.Request, res: express.Response) => {
 			const metrics = await promClient.register.metrics();
-			const prefixedMetrics = this.addPrefixToMetrics(metrics);
 			res.setHeader('Content-Type', promClient.register.contentType);
-			res.send(prefixedMetrics).end();
+			res.send(metrics).end();
 		});
-	}
-
-	private addPrefixToMetrics(metrics: string) {
-		return metrics
-			.split('\n')
-			.map((rawLine) => {
-				const line = rawLine.trim();
-
-				if (!line || line.startsWith('#') || line.startsWith(this.prefix)) return rawLine;
-
-				return this.prefix + line;
-			})
-			.join('\n');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Datadog expects the type and the metric name to match, our method of prefixing only changes the metric name, not the type:

This PR uses the native way of adding prefixes.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/CAT-896/metrics-cant-be-ingested-into-datadog

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
