### PR TITLE
perf(core): Lazyload community packages

### DIFF
--- a/packages/cli/src/load-nodes-and-credentials.ts
+++ b/packages/cli/src/load-nodes-and-credentials.ts
@@ -143,11 +143,11 @@ export class LoadNodesAndCredentials {
 		for (const packagePath of installedPackagePaths) {
 			const fullPackagePath = path.join(nodeModulesDir, packagePath);
 
-			if (nodeModulesDir === path.join(this.instanceSettings.nodesDownloadDir, 'node_modules')) {
-				await this.generateLazyLoadingFiles(fullPackagePath);
-			}
-
 			try {
+				if (nodeModulesDir === path.join(this.instanceSettings.nodesDownloadDir, 'node_modules')) {
+					await this.generateLazyLoadingFiles(fullPackagePath);
+				}
+
 				await this.runDirectoryLoader(LazyPackageDirectoryLoader, fullPackagePath);
 			} catch (error) {
 				this.logger.error((error as Error).message);
@@ -232,7 +232,9 @@ export class LoadNodesAndCredentials {
 		try {
 			await fsPromises.access(knownNodesPath);
 			return;
-		} catch {}
+		} catch {
+			// absent so generate
+		}
 
 		const loader = new PackageDirectoryLoader(packagePath);
 		await loader.loadAll();


### PR DESCRIPTION
## Summary

On bootup we lazyload `n8n-nodes-base` and `@n8n/n8n-nodes-langchain` but we eagerly load community packages, which are published to npm without `known` and `types` files. 

This PR extends lazyloading to community packages, to reduce memory usage and startup time.

```
14:24:00.953   info    Initializing n8n process { "file": "start.js", "function": "init" }
14:24:01.044   debug   Lazy-loading nodes and credentials from n8n-nodes-base { "nodes": 481, "credentials": 384, "file": "lazy-package-directory-loader.js", "function": "loadAll" }
14:24:01.057   debug   Lazy-loading nodes and credentials from @n8n/n8n-nodes-langchain { "nodes": 92, "credentials": 21, "file": "lazy-package-directory-loader.js", "function": "loadAll" }
14:24:01.069   debug   Lazy-loading nodes and credentials from n8n-nodes-ntfy-next { "nodes": 1, "credentials": 1, "file": "lazy-package-directory-loader.js", "function": "loadAll" }
14:24:01.071   debug   Lazy-loading nodes and credentials from n8n-nodes-text-manipulation { "nodes": 1, "credentials": 0, "file": "lazy-package-directory-loader.js", "function": "loadAll" }
14:24:01.207   info    n8n ready on ::, port 5678 { "file": "abstract-server.js", "function": "init" }
```

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
n/a

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
