### PR TITLE
fix(editor): Make sure to delete all connections when a node is deleted

### DIFF
--- a/packages/frontend/editor-ui/src/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasOperations.test.ts
@@ -2408,6 +2408,38 @@ describe('useCanvasOperations', () => {
 			expect(workflowsStore.workflow.connections[node1.name]).toBeUndefined();
 		});
 
+		it('should delete all incoming connections from a node', () => {
+			setActivePinia(createTestingPinia({ stubActions: false }));
+
+			const workflowsStore = useWorkflowsStore();
+			const { deleteConnectionsByNodeId } = useCanvasOperations({ router });
+
+			const node1 = createTestNode({ id: 'node1', name: 'Node 1' });
+			const node2 = createTestNode({ id: 'node2', name: 'Node 2' });
+
+			workflowsStore.setNodes([node1, node2]);
+			workflowsStore.setConnections({
+				[node1.name]: {
+					[NodeConnectionTypes.Main]: [
+						[
+							{ node: node2.name, type: NodeConnectionTypes.Main, index: 0 },
+							{ node: node2.name, type: NodeConnectionTypes.Main, index: 1 },
+						],
+					],
+				},
+			});
+
+			expect(
+				workflowsStore.workflow.connections[node1.name][NodeConnectionTypes.Main][0],
+			).toHaveLength(2);
+
+			deleteConnectionsByNodeId(node2.id);
+
+			expect(
+				workflowsStore.workflow.connections[node1.name][NodeConnectionTypes.Main][0],
+			).toHaveLength(0);
+		});
+
 		it('should not delete connections if node ID does not exist', () => {
 			const workflowsStore = mockedStore(useWorkflowsStore);
 			const { deleteConnectionsByNodeId } = useCanvasOperations({ router });

--- a/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
@@ -1221,7 +1221,9 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 			for (const type of Object.keys(connections[nodeName])) {
 				for (const index of Object.keys(connections[nodeName][type])) {
 					const connectionsToDelete = connections[nodeName][type][parseInt(index, 10)] ?? [];
-					for (const connectionIndex of Object.keys(connectionsToDelete)) {
+
+					// Process highest index first with reverse() because the item gets removed in the loop, affecting index
+					for (const connectionIndex of Object.keys(connectionsToDelete).reverse()) {
 						const connectionData = connectionsToDelete[parseInt(connectionIndex, 10)];
 						if (!connectionData) {
 							continue;


### PR DESCRIPTION
## Summary
This PR fixes the bug where the canvas does not delete all incoming connections when a node is deleted, causing an execution error.

While #13840 adds a fix in the execution engine to gracefully handle "ghost" connections, this PR is to not generate such ghost connections.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/CAT-660/community-issue-cannot-read-properties-of-undefined-in-no-operation


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
