### PR TITLE
feat(Structured Output Parser Node): Add auto-fix support to Strucutred Output Parser

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
@@ -25,7 +25,7 @@ export class LmChatOpenAi implements INodeType {
 	};
 
 	description: INodeTypeDescription = {
-		displayName: 'OpenAI Chat Model',
+		displayName: 'fr',
 		// eslint-disable-next-line n8n-nodes-base/node-class-description-name-miscased
 		name: 'lmChatOpenAi',
 		icon: { light: 'file:openAiLight.svg', dark: 'file:openAiLight.dark.svg' },

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
@@ -25,7 +25,7 @@ export class LmChatOpenAi implements INodeType {
 	};
 
 	description: INodeTypeDescription = {
-		displayName: 'fr',
+		displayName: 'OpenAI Chat Model',
 		// eslint-disable-next-line n8n-nodes-base/node-class-description-name-miscased
 		name: 'lmChatOpenAi',
 		icon: { light: 'file:openAiLight.svg', dark: 'file:openAiLight.dark.svg' },

--- a/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserAutofixing/OutputParserAutofixing.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserAutofixing/OutputParserAutofixing.node.ts
@@ -24,7 +24,7 @@ export class OutputParserAutofixing implements INodeType {
 		iconColor: 'black',
 		group: ['transform'],
 		version: 1,
-		description: 'Automatically fix the output if it is not in the correct format',
+		description: 'Deprecated, use structured output parser',
 		defaults: {
 			name: 'Auto-fixing Output Parser',
 		},

--- a/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/prompt.ts
+++ b/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/prompt.ts
@@ -1,0 +1,16 @@
+export const NAIVE_FIX_PROMPT = `Instructions:
+--------------
+{instructions}
+--------------
+Completion:
+--------------
+{completion}
+--------------
+
+Above, the Completion did not satisfy the constraints given in the Instructions.
+Error:
+--------------
+{error}
+--------------
+
+Please try again. Please only respond with an answer that satisfies the constraints laid out in the Instructions:`;

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -1335,6 +1335,7 @@
 	"nodeCreator.aiPanel.workflowTriggerDescription": "Runs the flow when called by the Execute Workflow node from a different workflow",
 	"nodeCreator.nodeItem.triggerIconTitle": "Trigger Node",
 	"nodeCreator.nodeItem.aiIconTitle": "LangChain AI Node",
+	"nodeCreator.nodeItem.deprecated": "Deprecated",
 	"nodeCredentials.createNew": "Create new credential",
 	"nodeCredentials.credentialFor": "Credential for {credentialType}",
 	"nodeCredentials.credentialsLabel": "Credential to connect with",

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/ItemTypes/NodeItem.vue
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/ItemTypes/NodeItem.vue
@@ -124,6 +124,16 @@ const author = computed(() => {
 	return communityNodeType.value?.displayName ?? displayName.value;
 });
 
+const tag = computed(() => {
+	if (props.nodeType.tag) {
+		return { text: props.nodeType.tag };
+	}
+	if (description.value.toLowerCase().includes('deprecated')) {
+		return { text: i18n.baseText('nodeCreator.nodeItem.deprecated'), type: 'info' };
+	}
+	return undefined;
+});
+
 function onDragStart(event: DragEvent): void {
 	if (event.dataTransfer) {
 		event.dataTransfer.effectAllowed = 'copy';
@@ -163,7 +173,7 @@ function onCommunityNodeTooltipClick(event: MouseEvent) {
 		:is-trigger="isTrigger"
 		:is-official="isOfficial"
 		:data-test-id="dataTestId"
-		:tag="nodeType.tag"
+		:tag="tag"
 		@dragstart="onDragStart"
 		@dragend="onDragEnd"
 	>


### PR DESCRIPTION
## Summary

This PR merges `Auto-fixing Output Parser` auto-fix functionality to `Structured Output Parser` node. User can now turn on Auto-Fix on these nodes, and optionally provide a custom prompt instructions for fixing the output like on the auto-fixing node. If Auto-Fix mode is enabled a Model input has to be connected to the node.

https://github.com/user-attachments/assets/04808f00-1208-40ab-9872-fd68474e968f

With this change `Auto-fixing Output Parser` is should be considered deprecated, as the `Structured Output Parser` now offers the same functionality. The old node is still kept available for now, with a 'Deprecated' tag on it and we may remove it in the future.

This is the first time we're displaying such 'Deprecated' tag - to display it, make node's description contain string "deprecated". In future we may want to add a way to add tags node definitions.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3549/merge-auto-fixing-and-structured-output-nodes

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
