### PR TITLE
feat(editor): Use node name as tool name at Vector Store retriever tool nodes

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/__snapshots__/createVectorStoreNode.test.ts.snap
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/__snapshots__/createVectorStoreNode.test.ts.snap
@@ -127,6 +127,13 @@ exports[`createVectorStoreNode retrieve mode supplies vector store as data 1`] =
       "displayName": "Name",
       "displayOptions": {
         "show": {
+          "@version": [
+            {
+              "_cnd": {
+                "lte": 1.2,
+              },
+            },
+          ],
           "mode": [
             "retrieve-as-tool",
           ],
@@ -254,6 +261,7 @@ exports[`createVectorStoreNode retrieve mode supplies vector store as data 1`] =
     1,
     1.1,
     1.2,
+    1.3,
   ],
 }
 `;

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/createVectorStoreNode.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/createVectorStoreNode.ts
@@ -44,7 +44,8 @@ export const createVectorStoreNode = <T extends VectorStore = VectorStore>(
 			iconColor: args.meta.iconColor,
 			group: ['transform'],
 			// 1.2 has changes to VectorStoreInMemory node.
-			version: [1, 1.1, 1.2],
+			// 1.3 drops `toolName` and uses node name as the tool name.
+			version: [1, 1.1, 1.2, 1.3],
 			defaults: {
 				name: args.meta.displayName,
 			},
@@ -125,6 +126,7 @@ export const createVectorStoreNode = <T extends VectorStore = VectorStore>(
 					validateType: 'string-alphanumeric',
 					displayOptions: {
 						show: {
+							'@version': [{ _cnd: { lte: 1.2 } }],
 							mode: ['retrieve-as-tool'],
 						},
 					},

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/operations/retrieveAsToolOperation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/operations/retrieveAsToolOperation.ts
@@ -3,7 +3,7 @@ import type { VectorStore } from '@langchain/core/vectorstores';
 import { DynamicTool } from 'langchain/tools';
 import type { ISupplyDataFunctions, SupplyData } from 'n8n-workflow';
 
-import { getMetadataFiltersValues } from '@utils/helpers';
+import { getMetadataFiltersValues, nodeNameToToolName } from '@utils/helpers';
 import { logWrapper } from '@utils/logWrapper';
 
 import type { VectorStoreNodeConstructorArgs } from '../types';
@@ -20,7 +20,14 @@ export async function handleRetrieveAsToolOperation<T extends VectorStore = Vect
 ): Promise<SupplyData> {
 	// Get the tool configuration parameters
 	const toolDescription = context.getNodeParameter('toolDescription', itemIndex) as string;
-	const toolName = context.getNodeParameter('toolName', itemIndex) as string;
+
+	const node = context.getNode();
+	const { typeVersion } = node;
+	const toolName =
+		typeVersion < 1.3
+			? (context.getNodeParameter('toolName', itemIndex) as string)
+			: nodeNameToToolName(node);
+
 	const topK = context.getNodeParameter('topK', itemIndex, 4) as number;
 	const includeDocumentMetadata = context.getNodeParameter(
 		'includeDocumentMetadata',


### PR DESCRIPTION

## Summary

Align vector store retriever nodes to match other tools, using the name of the node converted to snake_case (with same casing as on the node name) as the tool name instead of using the separate field. This applies to only nodes with new version >= 1.3.

![image](https://github.com/user-attachments/assets/64852651-0aa9-440b-a9c5-433ebf43e8fa)

This behavior now matches how other tools we have work. The change was made for other nodes at ADO-3406 but these vector store retrieve tools were missed.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3604/feature-align-tool-name-field-also-on-vector-store-retrievers

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
