### PR TITLE
fix: Detect if n8n instance is staging or production for community nodes

### DIFF
--- a/packages/cli/src/services/community-node-types.service.ts
+++ b/packages/cli/src/services/community-node-types.service.ts
@@ -1,5 +1,5 @@
 import type { CommunityNodeType } from '@n8n/api-types';
-import { Logger } from '@n8n/backend-common';
+import { Logger, inProduction } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
 import { ensureError, type INodeTypeDescription } from 'n8n-workflow';
@@ -46,7 +46,9 @@ export class CommunityNodeTypesService {
 				this.globalConfig.nodes.communityPackages.enabled &&
 				this.globalConfig.nodes.communityPackages.verifiedEnabled
 			) {
-				const environment = this.globalConfig.license.tenantId === 1 ? 'production' : 'staging';
+				// Cloud sets ENVIRONMENT to 'production' or 'staging' depending on the environment
+				const environment =
+					inProduction || process.env.ENVIRONMENT === 'production' ? 'production' : 'staging';
 				data = await getCommunityNodeTypes(environment);
 			}
 


### PR DESCRIPTION
## Summary
Currently all n8n cloud instances point to Strapi staging for community nodes because we implemented this check wrong. This updated check now looks at node_env and also the Cloud specific environment option so we can fix this.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-3070/update-staging-check-to-be-correct


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
