### PR TITLE
test(editor): Fix flaky UI tests by preventing truncated project names (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/__tests__/data/projects.ts
+++ b/packages/frontend/editor-ui/src/__tests__/data/projects.ts
@@ -6,10 +6,11 @@ import type {
 	ProjectType,
 } from '@/types/projects.types';
 import { ProjectTypes } from '@/types/projects.types';
+import { MAX_NAME_LENGTH } from '@/utils/projects.utils';
 
 export const createProjectSharingData = (projectType?: ProjectType): ProjectSharingData => ({
 	id: faker.string.uuid(),
-	name: faker.lorem.words({ min: 1, max: 3 }),
+	name: faker.lorem.words({ min: 1, max: 3 }).slice(0, MAX_NAME_LENGTH).trimEnd(),
 	icon: { type: 'icon', value: 'folder' },
 	type: projectType ?? ProjectTypes.Personal,
 	createdAt: faker.date.past().toISOString(),


### PR DESCRIPTION
## Summary

Recent new UI test was flaky if faker happened to generate long names for projects. We truncate long project names automatically, but the tests didn't expect that. Lets just generate shorter names.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
