### PR TITLE
fix(core): Allow sending timezones from .npm folder

### DIFF
--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -234,7 +234,11 @@ export class Server extends AbstractServer {
 
 		// Returns all the available timezones
 		const tzDataFile = resolve(CLI_DIR, 'dist/timezones.json');
-		this.app.get(`/${this.restEndpoint}/options/timezones`, (_, res) => res.sendFile(tzDataFile));
+		this.app.get(`/${this.restEndpoint}/options/timezones`, (_, res) =>
+			// Allow sending file if the file path contains a dot (which is the case for npx n8n - file is under .npm/_npx folder)
+			// See: https://github.com/pillarjs/send/blob/1.1.0/index.js#L469
+			res.sendFile(tzDataFile, { dotfiles: 'allow' }),
+		);
 
 		// ----------------------------------------
 		// Settings


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

When running `npx n8n`, npm download and store the n8n package under .npm/_npx folder.
By default, express does not allow sending file from a path that contains a `.`
Thus, the /rest/options/timezones endpoint returns 404, even though the timezones file exists. This makes the timezone list in the workflow settings empty.
This PR fixes it by allowing this specific sendFile to respond with files inside a `.` folder

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2886/community-issue-timezone-error-when-i-run-n8n-locally
closes #15857 

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
