### PR TITLE
fix(editor): Update community node type

### DIFF
--- a/packages/@n8n/api-types/src/community-node-types.ts
+++ b/packages/@n8n/api-types/src/community-node-types.ts
@@ -17,4 +17,10 @@ export type CommunityNodeType = {
 	companyName?: string;
 	nodeDescription: INodeTypeDescription;
 	isInstalled: boolean;
+	nodeVersions: [
+		{
+			checksum: string;
+			npmVersion: string;
+		},
+	];
 };

--- a/packages/cli/src/services/community-node-types.service.ts
+++ b/packages/cli/src/services/community-node-types.service.ts
@@ -25,6 +25,12 @@ export type StrapiCommunityNodeType = {
 	isOfficialNode: boolean;
 	companyName?: string;
 	nodeDescription: INodeTypeDescription;
+	nodeVersions: [
+		{
+			checksum: string;
+			npmVersion: string;
+		},
+	];
 };
 
 @Service()

--- a/packages/cli/src/utils/community-node-types-utils.ts
+++ b/packages/cli/src/utils/community-node-types-utils.ts
@@ -17,6 +17,12 @@ export type StrapiCommunityNodeType = {
 	npmVersion: string;
 	isOfficialNode: boolean;
 	companyName?: string;
+	nodeVersions: [
+		{
+			checksum: string;
+			npmVersion: string;
+		},
+	];
 	nodeDescription: INodeTypeDescription;
 };
 


### PR DESCRIPTION
## Summary

We updated the strapi schema https://github.com/n8n-io/creators-site/pull/402 so we will now use the updated form of storing the checksum and npmVersion to prevent a lag when it comes to updating strapi and verdaccio

## Related Linear tickets, Github issues, and Community forum posts

Resolves https://linear.app/n8n/issue/NODE-3047/prevent-this-gap-between-verdacciostrapi-where-things-break
https://github.com/n8n-io/creators-site/pull/402

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
