### PR TITLE
feat(Structured Output Parser Node): Mark all parameters as required for schemas generated from JSON example

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/InformationExtractor.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/InformationExtractor.node.ts
@@ -11,7 +11,12 @@ import type {
 } from 'n8n-workflow';
 import type { z } from 'zod';
 
-import { inputSchemaField, jsonSchemaExampleField, schemaTypeField } from '@utils/descriptions';
+import {
+	buildJsonSchemaExampleNotice,
+	inputSchemaField,
+	jsonSchemaExampleField,
+	schemaTypeField,
+} from '@utils/descriptions';
 import { convertJsonSchemaToZod, generateSchemaFromExample } from '@utils/schemaParsing';
 import { getBatchingOptionFields } from '@utils/sharedFields';
 
@@ -27,7 +32,8 @@ export class InformationExtractor implements INodeType {
 		icon: 'fa:project-diagram',
 		iconColor: 'black',
 		group: ['transform'],
-		version: [1, 1.1],
+		version: [1, 1.1, 1.2],
+		defaultVersion: 1.2,
 		description: 'Extract information from text in a structured format',
 		codex: {
 			alias: ['NER', 'parse', 'parsing', 'JSON', 'data extraction', 'structured'],
@@ -88,6 +94,11 @@ export class InformationExtractor implements INodeType {
 	"cities": ["Los Angeles", "San Francisco", "San Diego"]
 }`,
 			},
+			buildJsonSchemaExampleNotice({
+				showExtraProps: {
+					'@version': [{ _cnd: { gte: 1.2 } }],
+				},
+			}),
 			{
 				...inputSchemaField,
 				default: `{
@@ -254,7 +265,10 @@ export class InformationExtractor implements INodeType {
 
 			if (schemaType === 'fromJson') {
 				const jsonExample = this.getNodeParameter('jsonSchemaExample', 0, '') as string;
-				jsonSchema = generateSchemaFromExample(jsonExample);
+				// Enforce all fields to be required in the generated schema if the node version is 1.2 or higher
+				const jsonExampleAllFieldsRequired = this.getNode().typeVersion >= 1.2;
+
+				jsonSchema = generateSchemaFromExample(jsonExample, jsonExampleAllFieldsRequired);
 			} else {
 				const inputSchema = this.getNodeParameter('inputSchema', 0, '') as string;
 				jsonSchema = jsonParse<JSONSchema7>(inputSchema);

--- a/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/InformationExtractor.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/InformationExtractor.node.ts
@@ -12,7 +12,7 @@ import type {
 import type { z } from 'zod';
 
 import { inputSchemaField, jsonSchemaExampleField, schemaTypeField } from '@utils/descriptions';
-import { convertJsonSchemaToZod, generateSchema } from '@utils/schemaParsing';
+import { convertJsonSchemaToZod, generateSchemaFromExample } from '@utils/schemaParsing';
 import { getBatchingOptionFields } from '@utils/sharedFields';
 
 import { SYSTEM_PROMPT_TEMPLATE } from './constants';
@@ -254,7 +254,7 @@ export class InformationExtractor implements INodeType {
 
 			if (schemaType === 'fromJson') {
 				const jsonExample = this.getNodeParameter('jsonSchemaExample', 0, '') as string;
-				jsonSchema = generateSchema(jsonExample);
+				jsonSchema = generateSchemaFromExample(jsonExample);
 			} else {
 				const inputSchema = this.getNodeParameter('inputSchema', 0, '') as string;
 				jsonSchema = jsonParse<JSONSchema7>(inputSchema);

--- a/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/test/InformationExtraction.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/test/InformationExtraction.node.test.ts
@@ -1,7 +1,8 @@
 import type { BaseLanguageModel } from '@langchain/core/language_models/base';
 import { FakeListChatModel } from '@langchain/core/utils/testing';
+import { mock } from 'jest-mock-extended';
 import get from 'lodash/get';
-import type { IDataObject, IExecuteFunctions } from 'n8n-workflow';
+import type { IDataObject, IExecuteFunctions, INode } from 'n8n-workflow';
 
 import { makeZodSchemaFromAttributes } from '../helpers';
 import { InformationExtractor } from '../InformationExtractor.node';
@@ -85,6 +86,208 @@ describe('InformationExtractor', () => {
 			expect(schema.parse({ name: 'John', age: 30 })).toEqual({ name: 'John', age: 30 });
 			expect(schema.parse({ name: 'John' })).toEqual({ name: 'John' });
 			expect(schema.parse({ age: 30 })).toEqual({ age: 30 });
+		});
+	});
+
+	describe('Single Item Processing with JSON Schema from Example', () => {
+		it('should extract information using JSON schema from example - version 1.2 (required fields)', async () => {
+			const node = new InformationExtractor();
+			const inputData = [
+				{
+					json: { text: 'John lives in California and has visited Los Angeles and San Francisco' },
+				},
+			];
+
+			const mockExecuteFunctions = createExecuteFunctionsMock(
+				{
+					text: 'John lives in California and has visited Los Angeles and San Francisco',
+					schemaType: 'fromJson',
+					jsonSchemaExample: JSON.stringify({
+						state: 'California',
+						cities: ['Los Angeles', 'San Francisco'],
+					}),
+					options: {
+						systemPromptTemplate: '',
+					},
+				},
+				new FakeListChatModel({
+					responses: [
+						formatFakeLlmResponse({
+							state: 'California',
+							cities: ['Los Angeles', 'San Francisco'],
+						}),
+					],
+				}),
+				inputData,
+			);
+
+			// Mock version 1.2 to test required fields behavior
+			mockExecuteFunctions.getNode = () => mock<INode>({ typeVersion: 1.2 });
+
+			const response = await node.execute.call(mockExecuteFunctions);
+
+			expect(response).toEqual([
+				[
+					{
+						json: {
+							output: {
+								state: 'California',
+								cities: ['Los Angeles', 'San Francisco'],
+							},
+						},
+					},
+				],
+			]);
+		});
+
+		it('should extract information using JSON schema from example - version 1.1 (optional fields)', async () => {
+			const node = new InformationExtractor();
+			const inputData = [{ json: { text: 'John lives in California' } }];
+
+			const mockExecuteFunctions = createExecuteFunctionsMock(
+				{
+					text: 'John lives in California',
+					schemaType: 'fromJson',
+					jsonSchemaExample: JSON.stringify({
+						state: 'California',
+						cities: ['Los Angeles', 'San Francisco'],
+					}),
+					options: {
+						systemPromptTemplate: '',
+					},
+				},
+				new FakeListChatModel({
+					responses: [
+						formatFakeLlmResponse({
+							state: 'California',
+							// cities field missing - should be allowed in v1.1
+						}),
+					],
+				}),
+				inputData,
+			);
+
+			// Mock version 1.1 to test optional fields behavior
+			mockExecuteFunctions.getNode = () => mock<INode>({ typeVersion: 1.1 });
+
+			const response = await node.execute.call(mockExecuteFunctions);
+
+			expect(response).toEqual([
+				[
+					{
+						json: {
+							output: {
+								state: 'California',
+							},
+						},
+					},
+				],
+			]);
+		});
+
+		it('should throw error for incomplete model output in version 1.2 (required fields)', async () => {
+			const node = new InformationExtractor();
+			const inputData = [{ json: { text: 'John lives in California' } }];
+
+			const mockExecuteFunctions = createExecuteFunctionsMock(
+				{
+					text: 'John lives in California',
+					schemaType: 'fromJson',
+					jsonSchemaExample: JSON.stringify({
+						state: 'California',
+						cities: ['Los Angeles', 'San Francisco'],
+						zipCode: '90210',
+					}),
+					options: {
+						systemPromptTemplate: '',
+					},
+				},
+				new FakeListChatModel({
+					responses: [
+						formatFakeLlmResponse({
+							state: 'California',
+							// Missing cities and zipCode - should fail in v1.2 since all fields are required
+						}),
+					],
+				}),
+				inputData,
+			);
+
+			mockExecuteFunctions.getNode = () => mock<INode>({ typeVersion: 1.2 });
+
+			await expect(node.execute.call(mockExecuteFunctions)).rejects.toThrow();
+		});
+
+		it('should extract information using complex nested JSON schema from example', async () => {
+			const node = new InformationExtractor();
+			const inputData = [
+				{
+					json: {
+						text: 'John Doe works at Acme Corp as a Software Engineer with 5 years experience',
+					},
+				},
+			];
+
+			const complexSchema = {
+				person: {
+					name: 'John Doe',
+					company: {
+						name: 'Acme Corp',
+						position: 'Software Engineer',
+					},
+				},
+				experience: {
+					years: 5,
+					skills: ['JavaScript', 'TypeScript'],
+				},
+			};
+
+			const mockExecuteFunctions = createExecuteFunctionsMock(
+				{
+					text: 'John Doe works at Acme Corp as a Software Engineer with 5 years experience',
+					schemaType: 'fromJson',
+					jsonSchemaExample: JSON.stringify(complexSchema),
+					options: {
+						systemPromptTemplate: '',
+					},
+				},
+				new FakeListChatModel({
+					responses: [
+						formatFakeLlmResponse({
+							person: {
+								name: 'John Doe',
+								company: {
+									name: 'Acme Corp',
+									position: 'Software Engineer',
+								},
+							},
+							experience: {
+								years: 5,
+								skills: ['JavaScript', 'TypeScript'],
+							},
+						}),
+					],
+				}),
+				inputData,
+			);
+
+			mockExecuteFunctions.getNode = () => mock<INode>({ typeVersion: 1.2 });
+
+			const response = await node.execute.call(mockExecuteFunctions);
+
+			expect(response[0][0].json.output).toMatchObject({
+				person: {
+					name: 'John Doe',
+					company: {
+						name: 'Acme Corp',
+						position: 'Software Engineer',
+					},
+				},
+				experience: {
+					years: 5,
+					skills: expect.arrayContaining(['JavaScript', 'TypeScript']),
+				},
+			});
 		});
 	});
 

--- a/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/OutputParserStructured.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/OutputParserStructured.node.ts
@@ -29,8 +29,8 @@ export class OutputParserStructured implements INodeType {
 		icon: 'fa:code',
 		iconColor: 'black',
 		group: ['transform'],
-		version: [1, 1.1, 1.2],
-		defaultVersion: 1.2,
+		version: [1, 1.1, 1.2, 1.3],
+		defaultVersion: 1.3,
 		description: 'Return data in a defined JSON format',
 		defaults: {
 			name: 'Structured Output Parser',
@@ -73,6 +73,28 @@ export class OutputParserStructured implements INodeType {
 	"state": "California",
 	"cities": ["Los Angeles", "San Francisco", "San Diego"]
 }`,
+			},
+			{
+				displayName: 'All Fields Are',
+				name: 'exampleFieldsOptionality',
+				type: 'options',
+				options: [
+					{
+						name: 'Required',
+						value: 'required',
+					},
+					{
+						name: 'Optional',
+						value: 'optional',
+					},
+				],
+				default: 'required',
+				description: 'If all fields in the JSON example are required or optional',
+				displayOptions: {
+					show: {
+						schemaType: ['fromJson'],
+					},
+				},
 			},
 			{
 				...inputSchemaField,
@@ -182,6 +204,10 @@ export class OutputParserStructured implements INodeType {
 
 		let inputSchema: string;
 
+		const jsonExampleAllFieldsRequired =
+			this.getNode().typeVersion >= 1.3 &&
+			this.getNodeParameter('exampleFieldsOptionality', itemIndex, 'required') === 'required';
+
 		if (this.getNode().typeVersion <= 1.1) {
 			inputSchema = this.getNodeParameter('jsonSchema', itemIndex, '') as string;
 		} else {
@@ -190,7 +216,7 @@ export class OutputParserStructured implements INodeType {
 
 		const jsonSchema =
 			schemaType === 'fromJson'
-				? generateSchemaFromExample(jsonExample)
+				? generateSchemaFromExample(jsonExample, jsonExampleAllFieldsRequired)
 				: jsonParse<JSONSchema7>(inputSchema);
 
 		const zodSchema = convertJsonSchemaToZod<z.ZodSchema<object>>(jsonSchema);

--- a/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/OutputParserStructured.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/OutputParserStructured.node.ts
@@ -17,7 +17,7 @@ import {
 	N8nOutputFixingParser,
 	N8nStructuredOutputParser,
 } from '@utils/output_parsers/N8nOutputParser';
-import { convertJsonSchemaToZod, generateSchema } from '@utils/schemaParsing';
+import { convertJsonSchemaToZod, generateSchemaFromExample } from '@utils/schemaParsing';
 import { getConnectionHintNoticeField } from '@utils/sharedFields';
 
 import { NAIVE_FIX_PROMPT } from './prompt';
@@ -189,7 +189,9 @@ export class OutputParserStructured implements INodeType {
 		}
 
 		const jsonSchema =
-			schemaType === 'fromJson' ? generateSchema(jsonExample) : jsonParse<JSONSchema7>(inputSchema);
+			schemaType === 'fromJson'
+				? generateSchemaFromExample(jsonExample)
+				: jsonParse<JSONSchema7>(inputSchema);
 
 		const zodSchema = convertJsonSchemaToZod<z.ZodSchema<object>>(jsonSchema);
 		const nodeVersion = this.getNode().typeVersion;

--- a/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/OutputParserStructured.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/OutputParserStructured.node.ts
@@ -13,9 +13,9 @@ import {
 import type { z } from 'zod';
 
 import {
+	buildJsonSchemaExampleNotice,
 	inputSchemaField,
 	jsonSchemaExampleField,
-	jsonSchemaPropertiesOptionalityField,
 	schemaTypeField,
 } from '@utils/descriptions';
 import {
@@ -79,16 +79,11 @@ export class OutputParserStructured implements INodeType {
 	"cities": ["Los Angeles", "San Francisco", "San Diego"]
 }`,
 			},
-			{
-				...jsonSchemaPropertiesOptionalityField,
-				displayOptions: {
-					...jsonSchemaPropertiesOptionalityField.displayOptions,
-					show: {
-						...jsonSchemaPropertiesOptionalityField.displayOptions?.show,
-						'@version': [{ _cnd: { gte: 1.3 } }],
-					},
+			buildJsonSchemaExampleNotice({
+				showExtraProps: {
+					'@version': [{ _cnd: { gte: 1.3 } }],
 				},
-			},
+			}),
 			{
 				...inputSchemaField,
 				default: `{
@@ -197,9 +192,8 @@ export class OutputParserStructured implements INodeType {
 
 		let inputSchema: string;
 
-		const jsonExampleAllFieldsRequired =
-			this.getNode().typeVersion >= 1.3 &&
-			this.getNodeParameter('exampleFieldsOptionality', itemIndex, 'required') === 'required';
+		// Enforce all fields to be required in the generated schema if the node version is 1.3 or higher
+		const jsonExampleAllFieldsRequired = this.getNode().typeVersion >= 1.3;
 
 		if (this.getNode().typeVersion <= 1.1) {
 			inputSchema = this.getNodeParameter('jsonSchema', itemIndex, '') as string;

--- a/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/OutputParserStructured.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/OutputParserStructured.node.ts
@@ -12,7 +12,12 @@ import {
 } from 'n8n-workflow';
 import type { z } from 'zod';
 
-import { inputSchemaField, jsonSchemaExampleField, schemaTypeField } from '@utils/descriptions';
+import {
+	inputSchemaField,
+	jsonSchemaExampleField,
+	jsonSchemaPropertiesOptionalityField,
+	schemaTypeField,
+} from '@utils/descriptions';
 import {
 	N8nOutputFixingParser,
 	N8nStructuredOutputParser,
@@ -75,24 +80,12 @@ export class OutputParserStructured implements INodeType {
 }`,
 			},
 			{
-				displayName: 'All Fields Are',
-				name: 'exampleFieldsOptionality',
-				type: 'options',
-				options: [
-					{
-						name: 'Required',
-						value: 'required',
-					},
-					{
-						name: 'Optional',
-						value: 'optional',
-					},
-				],
-				default: 'required',
-				description: 'If all fields in the JSON example are required or optional',
+				...jsonSchemaPropertiesOptionalityField,
 				displayOptions: {
+					...jsonSchemaPropertiesOptionalityField.displayOptions,
 					show: {
-						schemaType: ['fromJson'],
+						...jsonSchemaPropertiesOptionalityField.displayOptions?.show,
+						'@version': [{ _cnd: { gte: 1.3 } }],
 					},
 				},
 			},

--- a/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/test/OutputParserStructured.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/test/OutputParserStructured.node.test.ts
@@ -478,7 +478,7 @@ describe('OutputParserStructured', () => {
 				thisArg.getNode.mockReturnValue(mock<INode>({ typeVersion: 1.3 }));
 			});
 
-			describe('exampleFieldsOptionality: required', () => {
+			describe('schema from JSON example', () => {
 				it('should make all fields required when generating schema from JSON example', async () => {
 					const jsonExample = `{
             "user": {
@@ -495,9 +495,6 @@ describe('OutputParserStructured', () => {
 					thisArg.getNodeParameter
 						.calledWith('jsonSchemaExample', 0)
 						.mockReturnValueOnce(jsonExample);
-					thisArg.getNodeParameter
-						.calledWith('exampleFieldsOptionality', 0, 'required')
-						.mockReturnValueOnce('required');
 
 					const { response } = (await outputParser.supplyData.call(thisArg, 0)) as {
 						response: N8nStructuredOutputParser;
@@ -536,9 +533,6 @@ describe('OutputParserStructured', () => {
 					thisArg.getNodeParameter
 						.calledWith('jsonSchemaExample', 0)
 						.mockReturnValueOnce(jsonExample);
-					thisArg.getNodeParameter
-						.calledWith('exampleFieldsOptionality', 0, 'required')
-						.mockReturnValueOnce('required');
 
 					const { response } = (await outputParser.supplyData.call(thisArg, 0)) as {
 						response: N8nStructuredOutputParser;
@@ -582,9 +576,6 @@ describe('OutputParserStructured', () => {
 					thisArg.getNodeParameter
 						.calledWith('jsonSchemaExample', 0)
 						.mockReturnValueOnce(jsonExample);
-					thisArg.getNodeParameter
-						.calledWith('exampleFieldsOptionality', 0, 'required')
-						.mockReturnValueOnce('required');
 
 					const { response } = (await outputParser.supplyData.call(thisArg, 0)) as {
 						response: N8nStructuredOutputParser;
@@ -616,138 +607,6 @@ describe('OutputParserStructured', () => {
 							(e) => e,
 						),
 					).rejects.toThrow('Required');
-				});
-			});
-
-			describe('exampleFieldsOptionality: optional', () => {
-				it('should make all fields optional when generating schema from JSON example', async () => {
-					const jsonExample = `{
-            "user": {
-              "name": "Alice",
-              "email": "alice@example.com",
-              "profile": {
-                "age": 30,
-                "city": "New York"
-              }
-            },
-            "tags": ["work", "important"]
-          }`;
-					thisArg.getNodeParameter.calledWith('schemaType', 0).mockReturnValueOnce('fromJson');
-					thisArg.getNodeParameter
-						.calledWith('jsonSchemaExample', 0)
-						.mockReturnValueOnce(jsonExample);
-					thisArg.getNodeParameter
-						.calledWith('exampleFieldsOptionality', 0, 'required')
-						.mockReturnValueOnce('optional');
-
-					const { response } = (await outputParser.supplyData.call(thisArg, 0)) as {
-						response: N8nStructuredOutputParser;
-					};
-
-					const partialOutput = {
-						output: {
-							user: {
-								name: 'Bob',
-								// Missing email and profile
-							},
-							// Missing tags
-						},
-					};
-
-					const parsersOutput = await response.parse(`Here's the partial output:
-            \`\`\`json
-            ${JSON.stringify(partialOutput)}
-            \`\`\`
-          `);
-
-					expect(parsersOutput).toEqual(partialOutput);
-				});
-
-				it('should accept incomplete array items when fields are optional', async () => {
-					const jsonExample = `{
-            "products": [
-              {
-                "id": 1,
-                "name": "Product A",
-                "price": 29.99,
-                "category": "Electronics"
-              }
-            ]
-          }`;
-					thisArg.getNodeParameter.calledWith('schemaType', 0).mockReturnValueOnce('fromJson');
-					thisArg.getNodeParameter
-						.calledWith('jsonSchemaExample', 0)
-						.mockReturnValueOnce(jsonExample);
-					thisArg.getNodeParameter
-						.calledWith('exampleFieldsOptionality', 0, 'required')
-						.mockReturnValueOnce('optional');
-
-					const { response } = (await outputParser.supplyData.call(thisArg, 0)) as {
-						response: N8nStructuredOutputParser;
-					};
-
-					const partialArrayOutput = {
-						output: {
-							products: [
-								{
-									id: 2,
-									name: 'Product B',
-									// Missing price and category
-								},
-								{
-									id: 3,
-									price: 49.99,
-									// Missing name and category
-								},
-							],
-						},
-					};
-
-					const parsersOutput = await response.parse(`Here's the partial array output:
-            \`\`\`json
-            ${JSON.stringify(partialArrayOutput)}
-            \`\`\`
-          `);
-
-					expect(parsersOutput).toEqual(partialArrayOutput);
-				});
-
-				it('should handle empty objects when fields are optional', async () => {
-					const jsonExample = `{
-            "config": {
-              "theme": "dark",
-              "notifications": true
-            },
-            "user": {
-              "name": "Alice"
-            }
-          }`;
-					thisArg.getNodeParameter.calledWith('schemaType', 0).mockReturnValueOnce('fromJson');
-					thisArg.getNodeParameter
-						.calledWith('jsonSchemaExample', 0)
-						.mockReturnValueOnce(jsonExample);
-					thisArg.getNodeParameter
-						.calledWith('exampleFieldsOptionality', 0, 'required')
-						.mockReturnValueOnce('optional');
-
-					const { response } = (await outputParser.supplyData.call(thisArg, 0)) as {
-						response: N8nStructuredOutputParser;
-					};
-
-					const emptyObjectOutput = {
-						output: {
-							config: {},
-							user: {},
-						},
-					};
-
-					const parsersOutput = await response.parse(`Here's the empty object output:
-            \`\`\`json
-            ${JSON.stringify(emptyObjectOutput)}
-            \`\`\`
-          `);
-
-					expect(parsersOutput).toEqual(emptyObjectOutput);
 				});
 			});
 
@@ -806,46 +665,6 @@ describe('OutputParserStructured', () => {
 				});
 			});
 
-			describe('default behavior', () => {
-				it('should default to required fields when exampleFieldsOptionality is not specified', async () => {
-					const jsonExample = `{
-            "name": "Alice",
-            "age": 30
-          }`;
-					thisArg.getNodeParameter.calledWith('schemaType', 0).mockReturnValueOnce('fromJson');
-					thisArg.getNodeParameter
-						.calledWith('jsonSchemaExample', 0)
-						.mockReturnValueOnce(jsonExample);
-					// Mock the default parameter behavior
-					thisArg.getNodeParameter
-						.calledWith('exampleFieldsOptionality', 0, 'required')
-						.mockReturnValueOnce('required');
-
-					const { response } = (await outputParser.supplyData.call(thisArg, 0)) as {
-						response: N8nStructuredOutputParser;
-					};
-
-					const incompleteOutput = {
-						output: {
-							name: 'Bob',
-							// Missing age field
-						},
-					};
-
-					await expect(
-						response.parse(
-							`Here's the incomplete output:
-              \`\`\`json
-              ${JSON.stringify(incompleteOutput)}
-              \`\`\`
-            `,
-							undefined,
-							(e) => e,
-						),
-					).rejects.toThrow('Required');
-				});
-			});
-
 			describe('complex nested structures', () => {
 				it('should handle deeply nested objects with required fields', async () => {
 					const jsonExample = `{
@@ -874,9 +693,6 @@ describe('OutputParserStructured', () => {
 					thisArg.getNodeParameter
 						.calledWith('jsonSchemaExample', 0)
 						.mockReturnValueOnce(jsonExample);
-					thisArg.getNodeParameter
-						.calledWith('exampleFieldsOptionality', 0, 'required')
-						.mockReturnValueOnce('required');
 
 					const { response } = (await outputParser.supplyData.call(thisArg, 0)) as {
 						response: N8nStructuredOutputParser;

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolCode/ToolCode.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolCode/ToolCode.node.ts
@@ -17,7 +17,8 @@ import { jsonParse, NodeConnectionTypes, NodeOperationError } from 'n8n-workflow
 
 import {
 	buildInputSchemaField,
-	buildJsonSchemaExampleFields,
+	buildJsonSchemaExampleField,
+	buildJsonSchemaExampleNotice,
 	schemaTypeField,
 } from '@utils/descriptions';
 import { nodeNameToToolName } from '@utils/helpers';
@@ -26,7 +27,7 @@ import { getConnectionHintNoticeField } from '@utils/sharedFields';
 
 import type { DynamicZodObject } from '../../../types/zod.types';
 
-const [jsonSchemaExampleField, _] = buildJsonSchemaExampleFields({
+const jsonSchemaExampleField = buildJsonSchemaExampleField({
 	showExtraProps: { specifyInputSchema: [true] },
 });
 

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolCode/ToolCode.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolCode/ToolCode.node.ts
@@ -31,6 +31,13 @@ const jsonSchemaExampleField = buildJsonSchemaExampleField({
 	showExtraProps: { specifyInputSchema: [true] },
 });
 
+const jsonSchemaExampleNotice = buildJsonSchemaExampleNotice({
+	showExtraProps: {
+		specifyInputSchema: [true],
+		'@version': [{ _cnd: { gte: 1.3 } }],
+	},
+});
+
 const jsonSchemaField = buildInputSchemaField({ showExtraProps: { specifyInputSchema: [true] } });
 
 export class ToolCode implements INodeType {
@@ -40,7 +47,7 @@ export class ToolCode implements INodeType {
 		icon: 'fa:code',
 		iconColor: 'black',
 		group: ['transform'],
-		version: [1, 1.1, 1.2],
+		version: [1, 1.1, 1.2, 1.3],
 		description: 'Write a tool in JS or Python',
 		defaults: {
 			name: 'Code Tool',
@@ -181,6 +188,7 @@ export class ToolCode implements INodeType {
 			},
 			{ ...schemaTypeField, displayOptions: { show: { specifyInputSchema: [true] } } },
 			jsonSchemaExampleField,
+			jsonSchemaExampleNotice,
 			jsonSchemaField,
 		],
 	};
@@ -282,9 +290,10 @@ export class ToolCode implements INodeType {
 				const inputSchema = this.getNodeParameter('inputSchema', itemIndex, '') as string;
 
 				const schemaType = this.getNodeParameter('schemaType', itemIndex) as 'fromJson' | 'manual';
+
 				const jsonSchema =
 					schemaType === 'fromJson'
-						? generateSchemaFromExample(jsonExample)
+						? generateSchemaFromExample(jsonExample, this.getNode().typeVersion >= 1.3)
 						: jsonParse<JSONSchema7>(inputSchema);
 
 				const zodSchema = convertJsonSchemaToZod<DynamicZodObject>(jsonSchema);

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolCode/ToolCode.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolCode/ToolCode.node.ts
@@ -21,7 +21,7 @@ import {
 	schemaTypeField,
 } from '@utils/descriptions';
 import { nodeNameToToolName } from '@utils/helpers';
-import { convertJsonSchemaToZod, generateSchema } from '@utils/schemaParsing';
+import { convertJsonSchemaToZod, generateSchemaFromExample } from '@utils/schemaParsing';
 import { getConnectionHintNoticeField } from '@utils/sharedFields';
 
 import type { DynamicZodObject } from '../../../types/zod.types';
@@ -277,7 +277,7 @@ export class ToolCode implements INodeType {
 				const schemaType = this.getNodeParameter('schemaType', itemIndex) as 'fromJson' | 'manual';
 				const jsonSchema =
 					schemaType === 'fromJson'
-						? generateSchema(jsonExample)
+						? generateSchemaFromExample(jsonExample)
 						: jsonParse<JSONSchema7>(inputSchema);
 
 				const zodSchema = convertJsonSchemaToZod<DynamicZodObject>(jsonSchema);

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolCode/ToolCode.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolCode/ToolCode.node.ts
@@ -17,7 +17,7 @@ import { jsonParse, NodeConnectionTypes, NodeOperationError } from 'n8n-workflow
 
 import {
 	buildInputSchemaField,
-	buildJsonSchemaExampleField,
+	buildJsonSchemaExampleFields,
 	schemaTypeField,
 } from '@utils/descriptions';
 import { nodeNameToToolName } from '@utils/helpers';
@@ -25,6 +25,12 @@ import { convertJsonSchemaToZod, generateSchemaFromExample } from '@utils/schema
 import { getConnectionHintNoticeField } from '@utils/sharedFields';
 
 import type { DynamicZodObject } from '../../../types/zod.types';
+
+const [jsonSchemaExampleField, _] = buildJsonSchemaExampleFields({
+	showExtraProps: { specifyInputSchema: [true] },
+});
+
+const jsonSchemaField = buildInputSchemaField({ showExtraProps: { specifyInputSchema: [true] } });
 
 export class ToolCode implements INodeType {
 	description: INodeTypeDescription = {
@@ -173,8 +179,8 @@ export class ToolCode implements INodeType {
 				default: false,
 			},
 			{ ...schemaTypeField, displayOptions: { show: { specifyInputSchema: [true] } } },
-			buildJsonSchemaExampleField({ showExtraProps: { specifyInputSchema: [true] } }),
-			buildInputSchemaField({ showExtraProps: { specifyInputSchema: [true] } }),
+			jsonSchemaExampleField,
+			jsonSchemaField,
 		],
 	};
 

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v1/ToolWorkflowV1.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v1/ToolWorkflowV1.node.ts
@@ -24,7 +24,7 @@ import { NodeConnectionTypes, NodeOperationError, jsonParse } from 'n8n-workflow
 
 import { versionDescription } from './versionDescription';
 import type { DynamicZodObject } from '../../../../types/zod.types';
-import { convertJsonSchemaToZod, generateSchema } from '../../../../utils/schemaParsing';
+import { convertJsonSchemaToZod, generateSchemaFromExample } from '../../../../utils/schemaParsing';
 
 export class ToolWorkflowV1 implements INodeType {
 	description: INodeTypeDescription;
@@ -215,7 +215,7 @@ export class ToolWorkflowV1 implements INodeType {
 				const schemaType = this.getNodeParameter('schemaType', itemIndex) as 'fromJson' | 'manual';
 				const jsonSchema =
 					schemaType === 'fromJson'
-						? generateSchema(jsonExample)
+						? generateSchemaFromExample(jsonExample)
 						: jsonParse<JSONSchema7>(inputSchema);
 
 				const zodSchema = convertJsonSchemaToZod<DynamicZodObject>(jsonSchema);

--- a/packages/@n8n/nodes-langchain/utils/descriptions.ts
+++ b/packages/@n8n/nodes-langchain/utils/descriptions.ts
@@ -22,7 +22,8 @@ export const schemaTypeField: INodeProperties = {
 };
 
 /**
- * Returns a field to input a JSON example that can be used to generate the schema.
+ * Returns a tuple of fields to append to a node properties configuration:
+ * First field to input a JSON example that can be used to generate the schema;
  * The second field is a selector for whether all properties from example should be required or optional
  * @param props
  */

--- a/packages/@n8n/nodes-langchain/utils/descriptions.ts
+++ b/packages/@n8n/nodes-langchain/utils/descriptions.ts
@@ -22,60 +22,52 @@ export const schemaTypeField: INodeProperties = {
 };
 
 /**
- * Returns a tuple of fields to append to a node properties configuration:
- * First field to input a JSON example that can be used to generate the schema;
- * The second field is a selector for whether all properties from example should be required or optional
+ * Returns a field for inputting a JSON example that can be used to generate the schema.
  * @param props
  */
-export const buildJsonSchemaExampleFields = (props?: {
+export const buildJsonSchemaExampleField = (props?: {
 	showExtraProps?: Record<string, Array<NodeParameterValue | DisplayCondition> | undefined>;
-}): [INodeProperties, INodeProperties] => [
-	{
-		displayName: 'JSON Example',
-		name: 'jsonSchemaExample',
-		type: 'json',
-		default: `{
+}): INodeProperties => ({
+	displayName: 'JSON Example',
+	name: 'jsonSchemaExample',
+	type: 'json',
+	default: `{
 	"some_input": "some_value"
 }`,
-		noDataExpression: true,
-		typeOptions: {
-			rows: 10,
-		},
-		displayOptions: {
-			show: {
-				...props?.showExtraProps,
-				schemaType: ['fromJson'],
-			},
-		},
-		description: 'Example JSON object to use to generate the schema',
+	noDataExpression: true,
+	typeOptions: {
+		rows: 10,
 	},
-	{
-		displayName: 'All Fields Are',
-		name: 'exampleFieldsOptionality',
-		type: 'options',
-		options: [
-			{
-				name: 'Required',
-				value: 'required',
-			},
-			{
-				name: 'Optional',
-				value: 'optional',
-			},
-		],
-		default: 'required',
-		description: 'If all fields in the JSON example are required or optional',
-		displayOptions: {
-			show: {
-				...props?.showExtraProps,
-				schemaType: ['fromJson'],
-			},
+	displayOptions: {
+		show: {
+			...props?.showExtraProps,
+			schemaType: ['fromJson'],
 		},
 	},
-];
+	description: 'Example JSON object to use to generate the schema',
+});
 
-export const [jsonSchemaExampleField, jsonSchemaPropertiesOptionalityField] =
-	buildJsonSchemaExampleFields();
+/**
+ * Returns a notice field about the generated schema properties being required by default.
+ * @param props
+ */
+export const buildJsonSchemaExampleNotice = (props?: {
+	showExtraProps?: Record<string, Array<NodeParameterValue | DisplayCondition> | undefined>;
+}): INodeProperties => ({
+	displayName:
+		'All properties will be required in the generated schema. For optional properties, switch to manual schema definition.',
+	name: 'notice',
+	type: 'notice',
+	default: '',
+	displayOptions: {
+		show: {
+			...props?.showExtraProps,
+			schemaType: ['fromJson'],
+		},
+	},
+});
+
+export const jsonSchemaExampleField = buildJsonSchemaExampleField();
 
 export const buildInputSchemaField = (props?: {
 	showExtraProps?: Record<string, Array<NodeParameterValue | DisplayCondition> | undefined>;

--- a/packages/@n8n/nodes-langchain/utils/descriptions.ts
+++ b/packages/@n8n/nodes-langchain/utils/descriptions.ts
@@ -21,29 +21,60 @@ export const schemaTypeField: INodeProperties = {
 	description: 'How to specify the schema for the function',
 };
 
-export const buildJsonSchemaExampleField = (props?: {
+/**
+ * Returns a field to input a JSON example that can be used to generate the schema.
+ * The second field is a selector for whether all properties from example should be required or optional
+ * @param props
+ */
+export const buildJsonSchemaExampleFields = (props?: {
 	showExtraProps?: Record<string, Array<NodeParameterValue | DisplayCondition> | undefined>;
-}): INodeProperties => ({
-	displayName: 'JSON Example',
-	name: 'jsonSchemaExample',
-	type: 'json',
-	default: `{
+}): [INodeProperties, INodeProperties] => [
+	{
+		displayName: 'JSON Example',
+		name: 'jsonSchemaExample',
+		type: 'json',
+		default: `{
 	"some_input": "some_value"
 }`,
-	noDataExpression: true,
-	typeOptions: {
-		rows: 10,
+		noDataExpression: true,
+		typeOptions: {
+			rows: 10,
+		},
+		displayOptions: {
+			show: {
+				...props?.showExtraProps,
+				schemaType: ['fromJson'],
+			},
+		},
+		description: 'Example JSON object to use to generate the schema',
 	},
-	displayOptions: {
-		show: {
-			...props?.showExtraProps,
-			schemaType: ['fromJson'],
+	{
+		displayName: 'All Fields Are',
+		name: 'exampleFieldsOptionality',
+		type: 'options',
+		options: [
+			{
+				name: 'Required',
+				value: 'required',
+			},
+			{
+				name: 'Optional',
+				value: 'optional',
+			},
+		],
+		default: 'required',
+		description: 'If all fields in the JSON example are required or optional',
+		displayOptions: {
+			show: {
+				...props?.showExtraProps,
+				schemaType: ['fromJson'],
+			},
 		},
 	},
-	description: 'Example JSON object to use to generate the schema',
-});
+];
 
-export const jsonSchemaExampleField = buildJsonSchemaExampleField();
+export const [jsonSchemaExampleField, jsonSchemaPropertiesOptionalityField] =
+	buildJsonSchemaExampleFields();
 
 export const buildInputSchemaField = (props?: {
 	showExtraProps?: Record<string, Array<NodeParameterValue | DisplayCondition> | undefined>;

--- a/packages/@n8n/nodes-langchain/utils/descriptions.ts
+++ b/packages/@n8n/nodes-langchain/utils/descriptions.ts
@@ -55,7 +55,7 @@ export const buildJsonSchemaExampleNotice = (props?: {
 	showExtraProps?: Record<string, Array<NodeParameterValue | DisplayCondition> | undefined>;
 }): INodeProperties => ({
 	displayName:
-		'All properties will be required in the generated schema. For optional properties, switch to manual schema definition.',
+		"All properties will be required. To make them optional, use the 'JSON Schema' schema type instead",
 	name: 'notice',
 	type: 'notice',
 	default: '',

--- a/packages/@n8n/nodes-langchain/utils/descriptions.ts
+++ b/packages/@n8n/nodes-langchain/utils/descriptions.ts
@@ -12,7 +12,7 @@ export const schemaTypeField: INodeProperties = {
 			description: 'Generate a schema from an example JSON object',
 		},
 		{
-			name: 'Define Below',
+			name: 'Define using JSON Schema',
 			value: 'manual',
 			description: 'Define the JSON schema manually',
 		},

--- a/packages/@n8n/nodes-langchain/utils/output_parsers/N8nStructuredOutputParser.ts
+++ b/packages/@n8n/nodes-langchain/utils/output_parsers/N8nStructuredOutputParser.ts
@@ -106,9 +106,13 @@ export class N8nStructuredOutputParser extends StructuredOutputParser<
 						},
 					),
 			});
-		} else {
+		} else if (nodeVersion < 1.3) {
 			returnSchema = z.object({
 				output: zodSchema.optional(),
+			});
+		} else {
+			returnSchema = z.object({
+				output: zodSchema,
 			});
 		}
 

--- a/packages/@n8n/nodes-langchain/utils/schemaParsing.ts
+++ b/packages/@n8n/nodes-langchain/utils/schemaParsing.ts
@@ -6,10 +6,10 @@ import type { IExecuteFunctions } from 'n8n-workflow';
 import { NodeOperationError, jsonParse } from 'n8n-workflow';
 import type { z } from 'zod';
 
-export function generateSchema(schemaString: string): JSONSchema7 {
-	const parsedSchema = jsonParse<SchemaObject>(schemaString);
+export function generateSchemaFromExample(exampleJsonString: string): JSONSchema7 {
+	const parsedExample = jsonParse<SchemaObject>(exampleJsonString);
 
-	return generateJsonSchema(parsedSchema) as JSONSchema7;
+	return generateJsonSchema(parsedExample) as JSONSchema7;
 }
 
 export function convertJsonSchemaToZod<T extends z.ZodTypeAny = z.ZodTypeAny>(schema: JSONSchema7) {

--- a/packages/@n8n/nodes-langchain/utils/schemaParsing.ts
+++ b/packages/@n8n/nodes-langchain/utils/schemaParsing.ts
@@ -1,15 +1,48 @@
 import { jsonSchemaToZod } from '@n8n/json-schema-to-zod';
 import { json as generateJsonSchema } from 'generate-schema';
 import type { SchemaObject } from 'generate-schema';
-import type { JSONSchema7 } from 'json-schema';
+import type { JSONSchema7, JSONSchema7Definition } from 'json-schema';
 import type { IExecuteFunctions } from 'n8n-workflow';
 import { NodeOperationError, jsonParse } from 'n8n-workflow';
 import type { z } from 'zod';
 
-export function generateSchemaFromExample(exampleJsonString: string): JSONSchema7 {
+function makeAllPropertiesRequired(schema: JSONSchema7): JSONSchema7 {
+	function isPropertySchema(property: JSONSchema7Definition): property is JSONSchema7 {
+		return typeof property === 'object' && property !== null && 'type' in property;
+	}
+
+	if (!schema.properties) {
+		return schema;
+	}
+
+	const requiredProperties = Object.keys(schema.properties);
+	if (requiredProperties.length > 0) {
+		schema.required = requiredProperties;
+	}
+
+	for (const key of requiredProperties) {
+		const property = schema.properties[key];
+		if (isPropertySchema(property) && property.properties) {
+			makeAllPropertiesRequired(property);
+		}
+	}
+
+	return schema;
+}
+
+export function generateSchemaFromExample(
+	exampleJsonString: string,
+	allFieldsRequired = false,
+): JSONSchema7 {
 	const parsedExample = jsonParse<SchemaObject>(exampleJsonString);
 
-	return generateJsonSchema(parsedExample) as JSONSchema7;
+	const schema = generateJsonSchema(parsedExample) as JSONSchema7;
+
+	if (allFieldsRequired) {
+		return makeAllPropertiesRequired(schema);
+	}
+
+	return schema;
 }
 
 export function convertJsonSchemaToZod<T extends z.ZodTypeAny = z.ZodTypeAny>(schema: JSONSchema7) {

--- a/packages/@n8n/nodes-langchain/utils/schemaParsing.ts
+++ b/packages/@n8n/nodes-langchain/utils/schemaParsing.ts
@@ -13,12 +13,12 @@ function makeAllPropertiesRequired(schema: JSONSchema7): JSONSchema7 {
 
 	// Handle object properties
 	if (schema.type === 'object' && schema.properties) {
-		const requiredProperties = Object.keys(schema.properties);
-		if (requiredProperties.length > 0) {
-			schema.required = requiredProperties;
+		const properties = Object.keys(schema.properties);
+		if (properties.length > 0) {
+			schema.required = properties;
 		}
 
-		for (const key of requiredProperties) {
+		for (const key of properties) {
 			if (isPropertySchema(schema.properties[key])) {
 				makeAllPropertiesRequired(schema.properties[key]);
 			}

--- a/packages/@n8n/nodes-langchain/utils/tests/schemaParsing.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/tests/schemaParsing.test.ts
@@ -1,0 +1,353 @@
+import type { JSONSchema7 } from 'json-schema';
+import { createMockExecuteFunction } from 'n8n-nodes-base/test/nodes/Helpers';
+import { NodeOperationError } from 'n8n-workflow';
+import type { INode, IExecuteFunctions } from 'n8n-workflow';
+
+import {
+	generateSchemaFromExample,
+	convertJsonSchemaToZod,
+	throwIfToolSchema,
+} from './../schemaParsing';
+
+const mockNode: INode = {
+	id: '1',
+	name: 'Mock node',
+	typeVersion: 1,
+	type: 'n8n-nodes-base.mock',
+	position: [60, 760],
+	parameters: {},
+};
+
+describe('generateSchemaFromExample', () => {
+	it('should generate schema from simple object', () => {
+		const example = JSON.stringify({
+			name: 'John',
+			age: 30,
+			active: true,
+		});
+
+		const schema = generateSchemaFromExample(example);
+
+		expect(schema).toMatchObject({
+			type: 'object',
+			properties: {
+				name: { type: 'string' },
+				age: { type: 'number' },
+				active: { type: 'boolean' },
+			},
+		});
+	});
+
+	it('should generate schema from nested object', () => {
+		const example = JSON.stringify({
+			user: {
+				profile: {
+					name: 'Jane',
+					email: 'jane@example.com',
+				},
+				preferences: {
+					theme: 'dark',
+					notifications: true,
+				},
+			},
+		});
+
+		const schema = generateSchemaFromExample(example);
+
+		expect(schema).toMatchObject({
+			type: 'object',
+			properties: {
+				user: {
+					type: 'object',
+					properties: {
+						profile: {
+							type: 'object',
+							properties: {
+								name: { type: 'string' },
+								email: { type: 'string' },
+							},
+						},
+						preferences: {
+							type: 'object',
+							properties: {
+								theme: { type: 'string' },
+								notifications: { type: 'boolean' },
+							},
+						},
+					},
+				},
+			},
+		});
+	});
+
+	it('should generate schema from array', () => {
+		const example = JSON.stringify({
+			items: ['apple', 'banana', 'cherry'],
+			numbers: [1, 2, 3],
+		});
+
+		const schema = generateSchemaFromExample(example);
+
+		expect(schema).toMatchObject({
+			type: 'object',
+			properties: {
+				items: {
+					type: 'array',
+					items: { type: 'string' },
+				},
+				numbers: {
+					type: 'array',
+					items: { type: 'number' },
+				},
+			},
+		});
+	});
+
+	it('should generate schema from complex nested structure', () => {
+		const example = JSON.stringify({
+			metadata: {
+				version: '1.0.0',
+				tags: ['production', 'api'],
+			},
+			data: [
+				{
+					id: 1,
+					name: 'Item 1',
+					properties: {
+						color: 'red',
+						size: 'large',
+					},
+				},
+			],
+		});
+
+		const schema = generateSchemaFromExample(example);
+
+		expect(schema.type).toBe('object');
+		expect(schema.properties).toHaveProperty('metadata');
+		expect(schema.properties).toHaveProperty('data');
+		expect((schema.properties?.data as JSONSchema7).type).toBe('array');
+		expect(((schema.properties?.data as JSONSchema7).items as JSONSchema7).type).toBe('object');
+	});
+
+	it('should handle null values', () => {
+		const example = JSON.stringify({
+			name: 'John',
+			middleName: null,
+			age: 30,
+		});
+
+		const schema = generateSchemaFromExample(example);
+
+		expect(schema).toMatchObject({
+			type: 'object',
+			properties: {
+				name: { type: 'string' },
+				middleName: { type: 'null' },
+				age: { type: 'number' },
+			},
+		});
+	});
+
+	it('should not require fields by default', () => {
+		const example = JSON.stringify({
+			name: 'John',
+			age: 30,
+		});
+
+		const schema = generateSchemaFromExample(example);
+
+		expect(schema.required).toBeUndefined();
+	});
+
+	it('should make all fields required when allFieldsRequired is true', () => {
+		const example = JSON.stringify({
+			name: 'John',
+			age: 30,
+			active: true,
+		});
+
+		const schema = generateSchemaFromExample(example, true);
+
+		expect(schema.required).toEqual(['name', 'age', 'active']);
+	});
+
+	it('should make all nested fields required when allFieldsRequired is true', () => {
+		const example = JSON.stringify({
+			user: {
+				profile: {
+					name: 'Jane',
+					email: 'jane@example.com',
+				},
+				preferences: {
+					theme: 'dark',
+					notifications: true,
+				},
+			},
+		});
+
+		const schema = generateSchemaFromExample(example, true);
+
+		expect(schema.required).toEqual(['user']);
+
+		const userSchema = schema.properties?.user as JSONSchema7;
+
+		expect(userSchema.required).toEqual(['profile', 'preferences']);
+		expect((userSchema.properties?.profile as JSONSchema7).required).toEqual(['name', 'email']);
+		expect((userSchema.properties?.preferences as JSONSchema7).required).toEqual([
+			'theme',
+			'notifications',
+		]);
+
+		// Check the full structure
+		expect(schema).toMatchObject({
+			type: 'object',
+			properties: {
+				user: {
+					type: 'object',
+					properties: {
+						profile: {
+							type: 'object',
+							properties: {
+								name: { type: 'string' },
+								email: { type: 'string' },
+							},
+							required: ['name', 'email'],
+						},
+						preferences: {
+							type: 'object',
+							properties: {
+								theme: { type: 'string' },
+								notifications: { type: 'boolean' },
+							},
+							required: ['theme', 'notifications'],
+						},
+					},
+					required: ['profile', 'preferences'],
+				},
+			},
+			required: ['user'],
+		});
+	});
+
+	it('should handle empty object', () => {
+		const example = JSON.stringify({});
+
+		const schema = generateSchemaFromExample(example);
+
+		expect(schema).toMatchObject({
+			type: 'object',
+			properties: {},
+		});
+	});
+
+	it('should handle empty object with allFieldsRequired true', () => {
+		const example = JSON.stringify({});
+
+		const schema = generateSchemaFromExample(example, true);
+
+		expect(schema).toMatchObject({
+			type: 'object',
+			properties: {},
+		});
+	});
+
+	it('should throw error for invalid JSON', () => {
+		const invalidJson = '{ name: "John", age: 30 }'; // Missing quotes around property names
+
+		expect(() => generateSchemaFromExample(invalidJson)).toThrow();
+	});
+
+	it('should handle array of objects', () => {
+		const example = JSON.stringify([
+			{ id: 1, name: 'Item 1' },
+			{ id: 2, name: 'Item 2' },
+		]);
+
+		const schema = generateSchemaFromExample(example);
+
+		expect(schema).toMatchObject({
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: {
+					id: { type: 'number' },
+					name: { type: 'string' },
+				},
+			},
+		});
+	});
+});
+
+describe('convertJsonSchemaToZod', () => {
+	it('should convert simple object schema to zod', () => {
+		const schema: JSONSchema7 = {
+			type: 'object',
+			properties: {
+				name: { type: 'string' },
+				age: { type: 'number' },
+			},
+			required: ['name'],
+		};
+
+		const zodSchema = convertJsonSchemaToZod(schema);
+
+		expect(zodSchema).toBeDefined();
+		expect(typeof zodSchema.parse).toBe('function');
+	});
+
+	it('should convert and validate with zod schema', () => {
+		const schema: JSONSchema7 = {
+			type: 'object',
+			properties: {
+				name: { type: 'string' },
+				age: { type: 'number' },
+			},
+			required: ['name'],
+		};
+
+		const zodSchema = convertJsonSchemaToZod(schema);
+
+		// Valid data should pass
+		expect(() => zodSchema.parse({ name: 'John', age: 30 })).not.toThrow();
+		expect(() => zodSchema.parse({ name: 'John' })).not.toThrow();
+
+		// Invalid data should throw
+		expect(() => zodSchema.parse({ age: 30 })).toThrow(); // Missing required name
+		expect(() => zodSchema.parse({ name: 'John', age: 'thirty' })).toThrow(); // Wrong type for age
+	});
+});
+
+describe('throwIfToolSchema', () => {
+	it('should throw NodeOperationError for tool schema error', () => {
+		const ctx = createMockExecuteFunction<IExecuteFunctions>({}, mockNode);
+		const error = new Error('tool input did not match expected schema');
+
+		expect(() => throwIfToolSchema(ctx, error)).toThrow(NodeOperationError);
+		expect(() => throwIfToolSchema(ctx, error)).toThrow(/tool input did not match expected schema/);
+		expect(() => throwIfToolSchema(ctx, error)).toThrow(
+			/This is most likely because some of your tools are configured to require a specific schema/,
+		);
+	});
+
+	it('should not throw for non-tool schema errors', () => {
+		const ctx = createMockExecuteFunction<IExecuteFunctions>({}, mockNode);
+		const error = new Error('Some other error');
+
+		expect(() => throwIfToolSchema(ctx, error)).not.toThrow();
+	});
+
+	it('should not throw for errors without message', () => {
+		const ctx = createMockExecuteFunction<IExecuteFunctions>({}, mockNode);
+		const error = new Error();
+
+		expect(() => throwIfToolSchema(ctx, error)).not.toThrow();
+	});
+
+	it('should handle errors that are not Error instances', () => {
+		const ctx = createMockExecuteFunction<IExecuteFunctions>({}, mockNode);
+		const error = { message: 'tool input did not match expected schema' } as Error;
+
+		expect(() => throwIfToolSchema(ctx, error)).toThrow(NodeOperationError);
+	});
+});

--- a/packages/@n8n/nodes-langchain/utils/tests/schemaParsing.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/tests/schemaParsing.test.ts
@@ -277,6 +277,34 @@ describe('generateSchemaFromExample', () => {
 			},
 		});
 	});
+
+	it('should handle array of objects with allFieldsRequired true', () => {
+		const example = JSON.stringify([
+			{ id: 1, name: 'Item 1', metadata: { tag: 'prod' } },
+			{ id: 2, name: 'Item 2', metadata: { tag: 'dev' } },
+		]);
+
+		const schema = generateSchemaFromExample(example, true);
+
+		expect(schema).toMatchObject({
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: {
+					id: { type: 'number' },
+					name: { type: 'string' },
+					metadata: {
+						type: 'object',
+						properties: {
+							tag: { type: 'string' },
+						},
+						required: ['tag'],
+					},
+				},
+				required: ['id', 'name', 'metadata'],
+			},
+		});
+	});
 });
 
 describe('convertJsonSchemaToZod', () => {


### PR DESCRIPTION
## Summary

This PR modifies the JSON schema generation from JSON example. It marks all the properties as required recursively.
This logic affects the following nodes:
- Structured Output Parser
- Information Extractor
- Code Tool

The new behavior will be enabled for the new versions of each node.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-980/allow-for-json-schemas-generated-from-example-be-marked-as-all


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
