### PR TITLE
fix(core)!: Change last activity to use unix time

### DIFF
--- a/packages/cli/BREAKING-CHANGES.md
+++ b/packages/cli/BREAKING-CHANGES.md
@@ -2,6 +2,20 @@
 
 This list shows all the versions which include breaking changes and how to upgrade.
 
+## 1.98.0
+
+### What changed?
+
+The `last_activity` metric included as a part of route metrics has been changed to output a Unix time in seconds from
+the previous timestamp label approach. The labeling approach could result in high cardinality within Prometheus and
+thus result in poorer performance.
+
+### When is action necessary?
+
+If you've been ingesting route metrics from your n8n instance (version 1.81.0 and newer), you should analyze
+how the `last_activity` metric has affected your Prometheus instance and potentially clean up the old data. Future
+metrics will also be served in a different format, which needs to be taken into account.
+
 ## 1.83.0
 
 ### What changed?

--- a/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
+++ b/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
@@ -160,8 +160,7 @@ describe('PrometheusMetricsService', () => {
 
 			expect(promClient.Gauge).toHaveBeenNthCalledWith(2, {
 				name: 'n8n_last_activity',
-				help: 'last instance activity (backend request).',
-				labelNames: ['timestamp'],
+				help: 'last instance activity (backend request) in Unix time.',
 			});
 
 			expect(app.use).toHaveBeenCalledWith(

--- a/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
+++ b/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
@@ -160,7 +160,7 @@ describe('PrometheusMetricsService', () => {
 
 			expect(promClient.Gauge).toHaveBeenNthCalledWith(2, {
 				name: 'n8n_last_activity',
-				help: 'last instance activity (backend request) in Unix time.',
+				help: 'last instance activity (backend request) in Unix time (seconds).',
 			});
 
 			expect(app.use).toHaveBeenCalledWith(

--- a/packages/cli/src/metrics/prometheus-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus-metrics.service.ts
@@ -3,6 +3,7 @@ import { WorkflowRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
 import type express from 'express';
 import promBundle from 'express-prom-bundle';
+import { DateTime } from 'luxon';
 import { InstanceSettings } from 'n8n-core';
 import { EventMessageTypeNames } from 'n8n-workflow';
 import promClient, { type Counter, type Gauge } from 'prom-client';
@@ -136,11 +137,10 @@ export class PrometheusMetricsService {
 
 		const activityGauge = new promClient.Gauge({
 			name: this.prefix + 'last_activity',
-			help: 'last instance activity (backend request).',
-			labelNames: ['timestamp'],
+			help: 'last instance activity (backend request) in Unix time.',
 		});
 
-		activityGauge.set({ timestamp: new Date().toISOString() }, 1);
+		activityGauge.set(DateTime.now().toUnixInteger());
 
 		app.use(
 			[
@@ -154,8 +154,7 @@ export class PrometheusMetricsService {
 				`/${this.globalConfig.endpoints.formTest}/`,
 			],
 			async (req, res, next) => {
-				activityGauge.reset();
-				activityGauge.set({ timestamp: new Date().toISOString() }, 1);
+				activityGauge.set(DateTime.now().toUnixInteger());
 
 				await metricsMiddleware(req, res, next);
 			},

--- a/packages/cli/src/metrics/prometheus-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus-metrics.service.ts
@@ -137,7 +137,7 @@ export class PrometheusMetricsService {
 
 		const activityGauge = new promClient.Gauge({
 			name: this.prefix + 'last_activity',
-			help: 'last instance activity (backend request) in Unix time.',
+			help: 'last instance activity (backend request) in Unix time (seconds).',
 		});
 
 		activityGauge.set(DateTime.now().toUnixInteger());

--- a/packages/cli/test/integration/prometheus-metrics.test.ts
+++ b/packages/cli/test/integration/prometheus-metrics.test.ts
@@ -54,6 +54,11 @@ describe('PrometheusMetricsService', () => {
 		prometheusService.disableAllLabels();
 	});
 
+	afterEach(() => {
+		// Make sure fake timers aren't in effect after a test
+		jest.useRealTimers();
+	});
+
 	it('should return n8n version', async () => {
 		/**
 		 * Arrange


### PR DESCRIPTION
## Summary

Earlier implementation relied on labels to communicate the last activity inside an instance, but this can result in high cardinality within Prometheus, leading into performance issues. This commit changes the last activity gauge to output Unix time and removes the labels.

## Related Linear tickets, Github issues, and Community forum posts



## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
