### PR TITLE
ci: Optimize Docker build for multi-platform releases

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -74,7 +74,7 @@ jobs:
     needs: [publish-to-npm]
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true
-    timeout-minutes: 30
+    timeout-minutes: 15
 
     steps:
       - name: Checkout
@@ -101,7 +101,20 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build
+      - name: Build application on linux/amd64
+        uses: docker/build-push-action@b32b51a8eda65d6793cd0494a773d4f6bcef32dc # v6.11.0
+        with:
+          context: .
+          file: docker/images/n8n/Dockerfile
+          target: builder
+          build-args: |
+            N8N_VERSION=${{ needs.publish-to-npm.outputs.release }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64
+          outputs: type=cacheonly
+
+      - name: Package for linux/amd64 and linux/arm64
         uses: docker/build-push-action@b32b51a8eda65d6793cd0494a773d4f6bcef32dc # v6.11.0
         env:
           DOCKER_BUILD_SUMMARY: false
@@ -111,7 +124,7 @@ jobs:
           build-args: |
             N8N_VERSION=${{ needs.publish-to-npm.outputs.release }}
             N8N_RELEASE_TYPE=stable
-          cache-from: type=gha
+          cache-from: type=gha # reuse cached builder
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
           provenance: false

--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -2,13 +2,13 @@ ARG NODE_VERSION=20
 ARG N8N_VERSION=snapshot
 
 # 1. Create an image to build n8n
-FROM --platform=linux/amd64 n8nio/base:${NODE_VERSION} AS builder
+FROM n8nio/base:${NODE_VERSION} AS builder
 
 # Build the application from source
 WORKDIR /src
 COPY . /src
 RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store --mount=type=cache,id=pnpm-metadata,target=/root/.cache/pnpm/metadata DOCKER_BUILD=true pnpm install --frozen-lockfile
-RUN pnpm build
+RUN TURBO_TELEMETRY_DISABLED=1 pnpm build
 
 # Delete all dev dependencies
 RUN jq 'del(.pnpm.patchedDependencies)' package.json > package.json.tmp; mv package.json.tmp package.json


### PR DESCRIPTION
## Summary

On release we're currently building and packaging for amd64 and then building and packaging for arm64, which caused us to hit the 15m timeout during yesterday's release.

This PR adds a CI step to build and cache the platform-agnostic part of the image-building process, so that the next CI step can use those cached layers when finalizing the images for each platform.

## Related Linear tickets, Github issues, and Community forum posts

Context: https://n8nio.slack.com/archives/C0789EN39RC/p1748849874463569

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
