### PR TITLE
fix(editor): Add right margin to AI Assistant Code Node 'Fix Error' replace code button icon

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/CodeDiff/CodeDiff.vue
+++ b/packages/frontend/@n8n/design-system/src/components/CodeDiff/CodeDiff.vue
@@ -207,6 +207,12 @@ const diffs = computed(() => {
 
 .actions {
 	padding: var(--spacing-2xs);
+
+	> button {
+		> span {
+			margin-right: var(--spacing-4xs);
+		}
+	}
 }
 
 .infoText {


### PR DESCRIPTION
## Summary

Before

![image](https://github.com/user-attachments/assets/823ed485-1474-4523-9714-4b18cb1fa5fc)


After

![image](https://github.com/user-attachments/assets/9d84f1e5-d765-4f19-b111-330b02daa374)


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3609/bug-add-space-to-after-the-icon-in-the-replace-my-code-button


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
