### PR TITLE
fix(editor): Mark workflow as unsaved when reverting deletion of a node

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/CodeDiff/CodeDiff.vue
+++ b/packages/frontend/@n8n/design-system/src/components/CodeDiff/CodeDiff.vue
@@ -207,6 +207,12 @@ const diffs = computed(() => {
 
 .actions {
 	padding: var(--spacing-2xs);
+
+	> button {
+		> span {
+			margin-right: var(--spacing-4xs);
+		}
+	}
 }
 
 .infoText {

--- a/packages/frontend/@n8n/design-system/src/components/CodeDiff/CodeDiff.vue
+++ b/packages/frontend/@n8n/design-system/src/components/CodeDiff/CodeDiff.vue
@@ -207,12 +207,6 @@ const diffs = computed(() => {
 
 .actions {
 	padding: var(--spacing-2xs);
-
-	> button {
-		> span {
-			margin-right: var(--spacing-4xs);
-		}
-	}
 }
 
 .infoText {

--- a/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
@@ -437,6 +437,7 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 
 	function revertDeleteNode(node: INodeUi) {
 		workflowsStore.addNode(node);
+		uiStore.stateIsDirty = true;
 	}
 
 	function trackDeleteNode(id: string) {


### PR DESCRIPTION
## Summary

Steps to reproduce:

1. In the canvas, create a node and save the workflow -> save button becomes disabled

2. Delete the node -> save button becomes enabled

3. Press the save button -> save button becomes disabled

4. Press Cmd+z -> save button incorrectly remains disabled

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3614/bug-save-button-stays-disabled-after-restoring-a-deleted-node-with


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
