### PR TITLE
chore(core): Check for instance type in offloading warning

### DIFF
--- a/packages/cli/src/deprecation/__tests__/deprecation.service.test.ts
+++ b/packages/cli/src/deprecation/__tests__/deprecation.service.test.ts
@@ -1,6 +1,7 @@
 import type { Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import { captor, mock } from 'jest-mock-extended';
+import { InstanceSettings } from 'n8n-core';
 
 import config from '@/config';
 import { mockInstance } from '@test/mocking';
@@ -10,7 +11,8 @@ import { DeprecationService } from '../deprecation.service';
 describe('DeprecationService', () => {
 	const logger = mock<Logger>();
 	const globalConfig = mockInstance(GlobalConfig, { nodes: { exclude: [] } });
-	const deprecationService = new DeprecationService(logger, globalConfig);
+	const instanceSettings = mockInstance(InstanceSettings, { instanceType: 'main' });
+	const deprecationService = new DeprecationService(logger, globalConfig, instanceSettings);
 
 	beforeEach(() => {
 		// Ignore environment variables coming in from the environment when running
@@ -122,7 +124,7 @@ describe('DeprecationService', () => {
 				},
 			});
 
-			new DeprecationService(logger, globalConfig).warn();
+			new DeprecationService(logger, globalConfig, instanceSettings).warn();
 
 			expect(logger.warn).not.toHaveBeenCalled();
 		});
@@ -141,61 +143,83 @@ describe('DeprecationService', () => {
 		});
 
 		describe('when executions.mode is queue', () => {
-			test('should warn when OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS is false', () => {
-				process.env[envVar] = 'false';
-
-				const service = new DeprecationService(logger, globalConfig);
-				service.warn();
-
-				expect(logger.warn).toHaveBeenCalledTimes(1);
-				const warningMessage = logger.warn.mock.calls[0][0];
-				expect(warningMessage).toContain(envVar);
-			});
-
-			test('should warn when OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS is empty', () => {
-				process.env[envVar] = '';
-
-				const service = new DeprecationService(logger, globalConfig);
-				service.warn();
-
-				expect(logger.warn).toHaveBeenCalledTimes(1);
-				const warningMessage = logger.warn.mock.calls[0][0];
-				expect(warningMessage).toContain(envVar);
-			});
-
-			test('should not warn when OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS is true', () => {
-				process.env[envVar] = 'true';
-
-				const service = new DeprecationService(logger, globalConfig);
-				service.warn();
-
-				expect(logger.warn).not.toHaveBeenCalled();
-			});
-
-			test('should warn when OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS is undefined', () => {
-				delete process.env[envVar];
-
-				const service = new DeprecationService(logger, globalConfig);
-				service.warn();
-
-				expect(logger.warn).toHaveBeenCalledTimes(1);
-				const warningMessage = logger.warn.mock.calls[0][0];
-				expect(warningMessage).toContain(envVar);
-			});
-		});
-
-		describe('when executions.mode is not queue', () => {
-			test('should not warn', () => {
-				jest.spyOn(config, 'getEnv').mockImplementation((key) => {
-					if (key === 'executions.mode') return 'regular';
-					return;
+			describe('when instanceType is worker', () => {
+				test.each([
+					['false', 'false'],
+					['empty string', ''],
+				])(`should not warn when ${envVar} is %s`, (_description, envValue) => {
+					process.env[envVar] = envValue;
+					const service = new DeprecationService(
+						logger,
+						globalConfig,
+						mock<InstanceSettings>({ instanceType: 'worker' }),
+					);
+					service.warn();
+					expect(logger.warn).not.toHaveBeenCalled();
 				});
-				process.env[envVar] = 'false';
+			});
 
-				const service = new DeprecationService(logger, globalConfig);
-				service.warn();
+			describe('when instanceType is webhook', () => {
+				test.each([
+					['false', 'false'],
+					['empty string', ''],
+				])(`should not warn when ${envVar} is %s`, (_description, envValue) => {
+					process.env[envVar] = envValue;
+					const service = new DeprecationService(
+						logger,
+						globalConfig,
+						mock<InstanceSettings>({ instanceType: 'webhook' }),
+					);
+					service.warn();
+					expect(logger.warn).not.toHaveBeenCalled();
+				});
+			});
 
-				expect(logger.warn).not.toHaveBeenCalled();
+			describe('when instanceType is main', () => {
+				test.each([
+					['false', 'false'],
+					['empty string', ''],
+				])(`should warn when ${envVar} is %s`, (_description, envValue) => {
+					process.env[envVar] = envValue;
+					const service = new DeprecationService(logger, globalConfig, instanceSettings);
+					service.warn();
+					expect(logger.warn).toHaveBeenCalled();
+				});
+
+				test('should not warn when OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS is true', () => {
+					process.env[envVar] = 'true';
+
+					const service = new DeprecationService(logger, globalConfig, instanceSettings);
+					service.warn();
+
+					expect(logger.warn).not.toHaveBeenCalled();
+				});
+
+				test('should warn when OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS is undefined', () => {
+					delete process.env[envVar];
+
+					const service = new DeprecationService(logger, globalConfig, instanceSettings);
+					service.warn();
+
+					expect(logger.warn).toHaveBeenCalledTimes(1);
+					const warningMessage = logger.warn.mock.calls[0][0];
+					expect(warningMessage).toContain(envVar);
+				});
+			});
+
+			describe('when executions.mode is not queue', () => {
+				test('should not warn', () => {
+					jest.spyOn(config, 'getEnv').mockImplementation((key) => {
+						if (key === 'executions.mode') return 'regular';
+						return;
+					});
+					process.env[envVar] = 'false';
+
+					const service = new DeprecationService(logger, globalConfig, instanceSettings);
+					service.warn();
+
+					expect(logger.warn).not.toHaveBeenCalled();
+				});
 			});
 		});
 	});

--- a/packages/cli/src/deprecation/__tests__/deprecation.service.test.ts
+++ b/packages/cli/src/deprecation/__tests__/deprecation.service.test.ts
@@ -2,6 +2,7 @@ import type { Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import { captor, mock } from 'jest-mock-extended';
 import { InstanceSettings } from 'n8n-core';
+import type { InstanceType } from 'n8n-core';
 
 import config from '@/config';
 import { mockInstance } from '@test/mocking';
@@ -142,6 +143,26 @@ describe('DeprecationService', () => {
 			});
 		});
 
+		describe('when executions.mode is not queue', () => {
+			test.each([['main'], ['worker'], ['webhook']])(
+				'should not warn for instanceType %s',
+				(instanceType: InstanceType) => {
+					jest.spyOn(config, 'getEnv').mockImplementation((key) => {
+						if (key === 'executions.mode') return 'regular';
+						return;
+					});
+					process.env[envVar] = 'false';
+					const service = new DeprecationService(
+						logger,
+						globalConfig,
+						mock<InstanceSettings>({ instanceType }),
+					);
+					service.warn();
+					expect(logger.warn).not.toHaveBeenCalled();
+				},
+			);
+		});
+
 		describe('when executions.mode is queue', () => {
 			describe('when instanceType is worker', () => {
 				test.each([
@@ -204,21 +225,6 @@ describe('DeprecationService', () => {
 					expect(logger.warn).toHaveBeenCalledTimes(1);
 					const warningMessage = logger.warn.mock.calls[0][0];
 					expect(warningMessage).toContain(envVar);
-				});
-			});
-
-			describe('when executions.mode is not queue', () => {
-				test('should not warn', () => {
-					jest.spyOn(config, 'getEnv').mockImplementation((key) => {
-						if (key === 'executions.mode') return 'regular';
-						return;
-					});
-					process.env[envVar] = 'false';
-
-					const service = new DeprecationService(logger, globalConfig, instanceSettings);
-					service.warn();
-
-					expect(logger.warn).not.toHaveBeenCalled();
 				});
 			});
 		});

--- a/packages/cli/src/deprecation/deprecation.service.ts
+++ b/packages/cli/src/deprecation/deprecation.service.ts
@@ -1,6 +1,7 @@
 import { Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
+import { InstanceSettings } from 'n8n-core';
 
 import config from '@/config';
 
@@ -65,6 +66,7 @@ export class DeprecationService {
 			checkValue: (value?: string) => value?.toLowerCase() !== 'true' && value !== '1',
 			warnIfMissing: true,
 			matchConfig: config.getEnv('executions.mode') === 'queue',
+			disableIf: () => this.instanceSettings.instanceType !== 'main',
 		},
 		{
 			envVar: 'N8N_PARTIAL_EXECUTION_VERSION_DEFAULT',
@@ -103,6 +105,7 @@ export class DeprecationService {
 	constructor(
 		private readonly logger: Logger,
 		private readonly globalConfig: GlobalConfig,
+		private readonly instanceSettings: InstanceSettings,
 	) {}
 
 	warn() {


### PR DESCRIPTION
## Summary

The warning for `OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS` applies only to main-type instances but is currently being shown to all instance types.

## Related Linear tickets, Github issues, and Community forum posts

n/a


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
