### PR TITLE
fix(Microsoft SQL Node): Handle connection errors correctly with continueOnFail

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Sql/test/MicrosoftSql.node.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Sql/test/MicrosoftSql.node.test.ts
@@ -1,0 +1,83 @@
+import { mock } from 'jest-mock-extended';
+import * as mssql from 'mssql';
+import { constructExecutionMetaData, returnJsonArray } from 'n8n-core';
+import type { IExecuteFunctions } from 'n8n-workflow';
+
+import { MicrosoftSql } from '../MicrosoftSql.node';
+
+jest.mock('mssql');
+
+function getMockedExecuteFunctions(overrides: Partial<IExecuteFunctions> = {}) {
+	return mock<IExecuteFunctions>({
+		getCredentials: jest.fn().mockResolvedValue({
+			server: 'localhost',
+			database: 'testdb',
+			user: 'testuser',
+			password: 'testpass',
+			port: 1433,
+			tls: false,
+			allowUnauthorizedCerts: true,
+			tdsVersion: '7_4',
+			connectTimeout: 1000,
+			requestTimeout: 10000,
+		}),
+		getInputData: jest.fn().mockReturnValue([{ json: {} }]),
+		getNode: jest.fn().mockReturnValue({ typeVersion: 1 }),
+		continueOnFail: jest.fn().mockReturnValue(true),
+		helpers: {
+			constructExecutionMetaData,
+			returnJsonArray,
+		},
+		evaluateExpression: jest.fn((_val) => _val),
+		...overrides,
+	});
+}
+
+describe('MicrosoftSql Node', () => {
+	let mockedConnectionPool: jest.MockedClass<typeof mssql.ConnectionPool>;
+
+	beforeEach(() => {
+		mockedConnectionPool = mssql.ConnectionPool as jest.MockedClass<typeof mssql.ConnectionPool>;
+	});
+
+	test('handles connection error with continueOnFail', async () => {
+		const fakeError = new Error('Connection failed');
+		mockedConnectionPool.mockReturnValue(
+			mock<mssql.ConnectionPool>({
+				connect: jest.fn().mockRejectedValue(fakeError),
+				close: jest.fn(),
+			}),
+		);
+
+		const node = new MicrosoftSql();
+		const context = getMockedExecuteFunctions();
+		const result = await node.execute.call(context);
+
+		expect(result).toEqual([[{ json: { error: 'Connection failed' }, pairedItem: [{ item: 0 }] }]]);
+	});
+
+	test('executes query on happy path', async () => {
+		const queryResult = { recordsets: [[{ value: 1 }]] };
+		const mockRequest = { query: jest.fn().mockResolvedValue(queryResult) };
+		const mockPool = mock<mssql.ConnectionPool>({
+			connect: jest.fn().mockResolvedValue(undefined),
+			close: jest.fn(),
+			request: jest.fn().mockReturnValue(mockRequest),
+		});
+
+		mockedConnectionPool.mockReturnValue(mockPool);
+
+		const node = new MicrosoftSql();
+		const context = getMockedExecuteFunctions({
+			getNodeParameter: jest
+				.fn()
+				.mockReturnValueOnce('executeQuery')
+				.mockReturnValueOnce('SELECT 1 AS value'),
+		});
+		const result = await node.execute.call(context);
+
+		expect(result).toEqual([[{ json: { value: 1 }, pairedItem: [{ item: 0 }] }]]);
+		expect(mockRequest.query).toHaveBeenCalledWith('SELECT 1 AS value');
+		expect(mockPool.close).toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

Connection errors should return data in the error branch instead of throwing

<img width="1270" alt="image" src="https://github.com/user-attachments/assets/5db50dfa-047a-40e0-91a5-2b8266f67bfb" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2460/microsoft-sql-node-not-all-errors-use-error-branch


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
