### PR TITLE
feat(Structured Output Parser Node): Add notice about $refs support in JSON schema

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/InformationExtractor.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/InformationExtractor.node.ts
@@ -107,7 +107,7 @@ export class InformationExtractor implements INodeType {
 			},
 			{
 				displayName:
-					'The schema has to be defined in the <a target="_blank" href="https://json-schema.org/">JSON Schema</a> format. Look at <a target="_blank" href="https://json-schema.org/learn/miscellaneous-examples.html">this</a> page for examples.',
+					'The schema has to be defined in the <a target="_blank" href="https://json-schema.org/">JSON Schema</a> format. Look at <a target="_blank" href="https://json-schema.org/learn/miscellaneous-examples.html">this</a> page for examples. Please note that we don\'t support references (using $refs) in JSON schema.',
 				name: 'notice',
 				type: 'notice',
 				default: '',

--- a/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/InformationExtractor.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/InformationExtractor.node.ts
@@ -106,18 +106,6 @@ export class InformationExtractor implements INodeType {
 }`,
 			},
 			{
-				displayName:
-					'The schema has to be defined in the <a target="_blank" href="https://json-schema.org/">JSON Schema</a> format. Look at <a target="_blank" href="https://json-schema.org/learn/miscellaneous-examples.html">this</a> page for examples. Please note that we don\'t support references (using $refs) in JSON schema.',
-				name: 'notice',
-				type: 'notice',
-				default: '',
-				displayOptions: {
-					show: {
-						schemaType: ['manual'],
-					},
-				},
-			},
-			{
 				displayName: 'Attributes',
 				name: 'attributes',
 				placeholder: 'Add Attribute',

--- a/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/OutputParserStructured.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/OutputParserStructured.node.ts
@@ -122,7 +122,7 @@ export class OutputParserStructured implements INodeType {
 			},
 			{
 				displayName:
-					'The schema has to be defined in the <a target="_blank" href="https://json-schema.org/">JSON Schema</a> format. Look at <a target="_blank" href="https://json-schema.org/learn/miscellaneous-examples.html">this</a> page for examples. Please note that we don\'t support references (using $refs) in JSON schema.',
+					'The schema has to be defined in the <a target="_blank" href="https://json-schema.org/">JSON Schema</a> format. Look at <a target="_blank" href="https://json-schema.org/learn/miscellaneous-examples.html">this</a> page for examples.',
 				name: 'notice',
 				type: 'notice',
 				default: '',
@@ -170,6 +170,19 @@ export class OutputParserStructured implements INodeType {
 				hint: 'Should include "{error}", "{instructions}", and "{completion}" placeholders',
 				description:
 					'Prompt template used for fixing the output. Uses placeholders: "{instructions}" for parsing rules, "{completion}" for the failed attempt, and "{error}" for the validation error message.',
+			},
+			{
+				displayName: "Please note that we don't support references (using $refs) in JSON schema.",
+				name: 'jsonSchemaRefsWarning',
+				type: 'notice',
+				noDataExpression: true,
+				default: '',
+				displayOptions: {
+					show: {
+						schemaType: ['manual'],
+						inputSchema: [{ _cnd: { includes: '"$ref"' } }],
+					},
+				},
 			},
 		],
 	};

--- a/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/OutputParserStructured.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/OutputParserStructured.node.ts
@@ -122,7 +122,7 @@ export class OutputParserStructured implements INodeType {
 			},
 			{
 				displayName:
-					'The schema has to be defined in the <a target="_blank" href="https://json-schema.org/">JSON Schema</a> format. Look at <a target="_blank" href="https://json-schema.org/learn/miscellaneous-examples.html">this</a> page for examples.',
+					'The schema has to be defined in the <a target="_blank" href="https://json-schema.org/">JSON Schema</a> format. Look at <a target="_blank" href="https://json-schema.org/learn/miscellaneous-examples.html">this</a> page for examples. Please note that we don\'t support references (using $refs) in JSON schema.',
 				name: 'notice',
 				type: 'notice',
 				default: '',

--- a/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/OutputParserStructured.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/OutputParserStructured.node.ts
@@ -121,18 +121,6 @@ export class OutputParserStructured implements INodeType {
 				},
 			},
 			{
-				displayName:
-					'The schema has to be defined in the <a target="_blank" href="https://json-schema.org/">JSON Schema</a> format. Look at <a target="_blank" href="https://json-schema.org/learn/miscellaneous-examples.html">this</a> page for examples.',
-				name: 'notice',
-				type: 'notice',
-				default: '',
-				displayOptions: {
-					hide: {
-						schemaType: ['fromJson'],
-					},
-				},
-			},
-			{
 				displayName: 'Auto-Fix Format',
 				description:
 					'Whether to automatically fix the output when it is not in the correct format. Will cause another LLM call.',
@@ -171,18 +159,15 @@ export class OutputParserStructured implements INodeType {
 				description:
 					'Prompt template used for fixing the output. Uses placeholders: "{instructions}" for parsing rules, "{completion}" for the failed attempt, and "{error}" for the validation error message.',
 			},
+		],
+		hints: [
 			{
-				displayName: "Please note that we don't support references (using $refs) in JSON schema.",
-				name: 'jsonSchemaRefsWarning',
-				type: 'notice',
-				noDataExpression: true,
-				default: '',
-				displayOptions: {
-					show: {
-						schemaType: ['manual'],
-						inputSchema: [{ _cnd: { includes: '"$ref"' } }],
-					},
-				},
+				message: '$ref syntax in JSON schema is currently not supported',
+				type: 'warning',
+				location: 'outputPane',
+				whenToDisplay: 'afterExecution',
+				displayCondition:
+					'={{ $parameter["schemaType"] === "manual" && $parameter["inputSchema"]?.includes("$ref") }}',
 			},
 		],
 	};

--- a/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/OutputParserStructured.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/OutputParserStructured.node.ts
@@ -162,7 +162,8 @@ export class OutputParserStructured implements INodeType {
 		],
 		hints: [
 			{
-				message: '$ref syntax in JSON schema is currently not supported',
+				message:
+					'Fields that use $refs might have the wrong type, since this syntax is not currently supported',
 				type: 'warning',
 				location: 'outputPane',
 				whenToDisplay: 'afterExecution',

--- a/packages/@n8n/nodes-langchain/utils/descriptions.ts
+++ b/packages/@n8n/nodes-langchain/utils/descriptions.ts
@@ -12,7 +12,7 @@ export const schemaTypeField: INodeProperties = {
 			description: 'Generate a schema from an example JSON object',
 		},
 		{
-			name: 'Define Below',
+			name: 'Define using JSON Schema',
 			value: 'manual',
 			description: 'Define the JSON schema manually',
 		},
@@ -71,6 +71,7 @@ export const buildInputSchemaField = (props?: {
 		},
 	},
 	description: 'Schema to use for the function',
+	hint: 'Use <a target="_blank" href="https://json-schema.org/">JSON Schema</a> format (<a target="_blank" href="https://json-schema.org/learn/miscellaneous-examples.html">examples</a>). $refs syntax is currently not supported.',
 });
 
 export const inputSchemaField = buildInputSchemaField();


### PR DESCRIPTION
## Summary

We do not support references in JSON schema (using `$ref`s and `[$defs]`(https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-00#defs)).

This PR adds a note about this near the JSON Schema input field.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-1003/add-notice-that-we-dont-support-dollarrefs-in-json-schema


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
