### PR TITLE
chore(core): Refactor logging for insights flushing

### DIFF
--- a/packages/cli/src/modules/insights/insights-collection.service.ts
+++ b/packages/cli/src/modules/insights/insights-collection.service.ts
@@ -75,20 +75,28 @@ export class InsightsCollectionService {
 
 	startFlushingTimer() {
 		this.isAsynchronouslySavingInsights = true;
-		this.stopFlushingTimer();
+		this.scheduleFlushing();
+		this.logger.debug('Started flushing timer');
+	}
+
+	scheduleFlushing() {
+		this.cancelScheduledFlushing();
 		this.flushInsightsRawBufferTimer = setTimeout(
 			async () => await this.flushEvents(),
 			this.insightsConfig.flushIntervalSeconds * 1000,
 		);
-		this.logger.debug('Started flushing timer');
 	}
 
-	stopFlushingTimer() {
+	cancelScheduledFlushing() {
 		if (this.flushInsightsRawBufferTimer !== undefined) {
 			clearTimeout(this.flushInsightsRawBufferTimer);
 			this.flushInsightsRawBufferTimer = undefined;
-			this.logger.debug('Stopped flushing timer');
 		}
+	}
+
+	stopFlushingTimer() {
+		this.cancelScheduledFlushing();
+		this.logger.debug('Stopped flushing timer');
 	}
 
 	async shutdown() {
@@ -228,12 +236,12 @@ export class InsightsCollectionService {
 		// Prevent flushing if there are no events to flush
 		if (this.bufferedInsights.size === 0) {
 			// reschedule the timer to flush again
-			this.startFlushingTimer();
+			this.scheduleFlushing();
 			return;
 		}
 
 		// Stop timer to prevent concurrent flush from timer
-		this.stopFlushingTimer();
+		this.cancelScheduledFlushing();
 
 		// Copy the buffer to a new set to avoid concurrent modification
 		// while we are flushing the events
@@ -250,7 +258,7 @@ export class InsightsCollectionService {
 					this.bufferedInsights.add(event);
 				}
 			} finally {
-				this.startFlushingTimer();
+				this.scheduleFlushing();
 				this.flushesInProgress.delete(flushPromise!);
 			}
 		})();


### PR DESCRIPTION
## Summary

Refactor logging in insights collection service to be less verbose.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-2902/fix-insights-flushing-timer-logs

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
