### PR TITLE
fix(core): Copy metadata information for binary data when data is migrated using filesystem (no-changelog)

### DIFF
--- a/packages/core/src/binary-data/__tests__/file-system.manager.test.ts
+++ b/packages/core/src/binary-data/__tests__/file-system.manager.test.ts
@@ -99,6 +99,7 @@ describe('getMetadata()', () => {
 describe('copyByFileId()', () => {
 	it('should copy by file ID and return the file ID', async () => {
 		fsp.copyFile = jest.fn().mockResolvedValue(undefined);
+		fsp.writeFile = jest.fn().mockResolvedValue(undefined);
 
 		// @ts-expect-error - private method
 		jest.spyOn(fsManager, 'toFileId').mockReturnValue(otherFileId);
@@ -109,6 +110,9 @@ describe('copyByFileId()', () => {
 		const targetPath = toFullFilePath(targetFileId);
 
 		expect(fsp.copyFile).toHaveBeenCalledWith(sourcePath, targetPath);
+
+		// Make sure metadata file was written
+		expect(fsp.writeFile).toBeCalledTimes(1);
 	});
 });
 

--- a/packages/core/src/binary-data/file-system.manager.ts
+++ b/packages/core/src/binary-data/file-system.manager.ts
@@ -127,10 +127,13 @@ export class FileSystemManager implements BinaryData.Manager {
 		const targetFileId = this.toFileId(workflowId, executionId);
 		const sourcePath = this.resolvePath(sourceFileId);
 		const targetPath = this.resolvePath(targetFileId);
+		const sourceMetadata = await this.getMetadata(sourceFileId);
 
 		await assertDir(path.dirname(targetPath));
 
 		await fs.copyFile(sourcePath, targetPath);
+
+		await this.storeMetadata(targetFileId, sourceMetadata);
 
 		return targetFileId;
 	}


### PR DESCRIPTION
## Summary

When the filesystem binary data manager is used to store binary data and binary data is moved between workflow execution contexts, the metadata file was not copied. This copies the necessary metadata information now as well.

## Related Linear tickets, Github issues, and Community forum posts

fixes https://github.com/n8n-io/n8n/issues/15891
closes https://linear.app/n8n/issue/PAY-2892/community-issue-parent-workflow-cannot-find-sub%E2%80%90workflows-binary


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
