### PR TITLE
Add a section in contributing guide describing owner user creation and reset 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,6 +169,20 @@ To start n8n with tunnel:
 ./packages/cli/bin/n8n start --tunnel
 ```
 
+## First run
+
+The first time you run n8n locally you will be prompted to create an owner user.
+The owner user credentials are stored in the `n8n` database and are needed in subsequent runs to access the n8n UI.
+
+The location of the database is under $HOME/.n8n/database.sqlite (unless explicitly overridden).
+If for any reason the credentials are lost before setting up password recovery, you can either remove the database file or run the following SQL command to reset the owner user:
+
+```
+ ./packages/cli/bin/n8n user-management:reset
+```
+
+In both cases, you will need to set up the owner user again when you start n8n next time.
+
 ## Development cycle
 
 While iterating on n8n modules code, you can run `pnpm dev`. It will then


### PR DESCRIPTION
## Summary

The pull request introduces a section in the CONTRIBUTING.md that explain the process of owner user creation and reset. 

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
