### PR TITLE
fix(editor): Restore checkbox label styling after sign-in (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/views/AuthView.vue
+++ b/packages/frontend/editor-ui/src/views/AuthView.vue
@@ -86,9 +86,3 @@ body {
 	padding-bottom: var(--spacing-xl);
 }
 </style>
-
-<style lang="scss">
-.el-checkbox__label span {
-	font-size: var(--font-size-2xs) !important;
-}
-</style>


### PR DESCRIPTION
## Summary

This PR removes a conflicting style from the AuthView component that incorrectly applied only after accessing the component (e.g., after signing in). This style affected checkbox label appearance in the following areas:

- Workflow filters
- Credential filters
- Execution filters
- Variable filters

Before the change:
![image](https://github.com/user-attachments/assets/fbcad85c-b2aa-4760-b159-4dac611374d2)

After the change:
![image](https://github.com/user-attachments/assets/b31d22bd-6479-484a-9173-5aaf386f42e6)


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3621/bug-checkboxes-have-incorrect-styling-when-opening-them-after-signing

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
