### PR TITLE
fix(editor): Fix `@n8n/i18n` package loading locales and hot-reloading (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/i18n/docs/README.md
+++ b/packages/frontend/@n8n/i18n/docs/README.md
@@ -50,11 +50,11 @@ Press "o" to open in Browser.
 
 ## Base text
 
-Base text is rendered with no dependencies, i.e. base text is fixed and does not change in any circumstances. Base text is supplied by the user in one file per locale in the `/frontend/editor-ui` package.
+Base text is rendered with no dependencies, i.e. base text is fixed and does not change in any circumstances. Base text is supplied by the user in one file per locale in the `/frontend/@n8n/i18n` package.
 
 ### Locating base text
 
-The base text file for each locale is located at `/packages/frontend/editor-ui/src/plugins/i18n/locales/` and is named `{localeIdentifier}.json`. Keys in the base text file can be Vue component dirs, Vue component names, and references to symbols in those Vue components. These keys are added by the team as the UI is modified or expanded.
+The base text file for each locale is located at `/packages/frontend/@n8n/i18n/src/locales/` and is named `{localeIdentifier}.json`. Keys in the base text file can be Vue component dirs, Vue component names, and references to symbols in those Vue components. These keys are added by the team as the UI is modified or expanded.
 
 ```json
 {
@@ -69,7 +69,7 @@ The base text file for each locale is located at `/packages/frontend/editor-ui/s
 1. Select a new locale identifier, e.g. `de`, copy the `en` JSON base text file with a new name:
 
 ```
-cp ./packages/frontend/editor-ui/src/plugins/i18n/locales/en.json ./packages/frontend/editor-ui/src/plugins/i18n/locales/de.json
+cp ./packages/frontend/@n8n/i18n/src/locales/en.json ./packages/frontend/@n8n/i18n/src/locales/de.json
 ```
 
 2. Find in the UI a string to translate, and search for it in the newly created base text file. Alternatively, find in `/frontend/editor-ui` a call to `i18n.baseText(key)`, e.g. `i18n.baseText('workflowActivator.deactivateWorkflow')`, and take note of the key and find it in the newly created base text file.

--- a/packages/frontend/@n8n/i18n/src/index.ts
+++ b/packages/frontend/@n8n/i18n/src/index.ts
@@ -383,7 +383,7 @@ export async function loadLanguage(language: string) {
 		return await setLanguage(language);
 	}
 
-	const { numberFormats, ...rest } = (await import(`./locales/${language}.json`)).default;
+	const { numberFormats, ...rest } = (await import(`@n8n/i18n/locales/${language}.json`)).default;
 
 	i18nInstance.global.setLocaleMessage(language, rest);
 

--- a/packages/frontend/@n8n/i18n/src/types.ts
+++ b/packages/frontend/@n8n/i18n/src/types.ts
@@ -4,10 +4,6 @@ export type GetBaseTextKey<T> = T extends `_${string}` ? never : T;
 
 export type BaseTextKey = GetBaseTextKey<keyof typeof englishBaseText>;
 
-export type GetCategoryName<T> = T extends `nodeCreator.categoryNames.${infer C}` ? C : never;
-
-export type CategoryName = GetCategoryName<keyof typeof englishBaseText>;
-
 export interface INodeTranslationHeaders {
 	data: {
 		[key: string]: {


### PR DESCRIPTION
## Summary

- Fixed loading non-`en` locales
- Fixed hot-reloading

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-852/extract-n8napi-requests-package
Fixes #15979

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
