### PR TITLE
refactor(core): Restore typechecker strictness level in `@n8n/db`

### DIFF
--- a/packages/@n8n/db/src/migrations/common/1724951148974-AddApiKeysTable.ts
+++ b/packages/@n8n/db/src/migrations/common/1724951148974-AddApiKeysTable.ts
@@ -39,7 +39,6 @@ export class AddApiKeysTable1724951148974 implements ReversibleMigration {
 		// Move the apiKey from the users table to the new table
 		await Promise.all(
 			usersWithApiKeys.map(
-				// @ts-expect-error Tech debt
 				async (user: { id: string; apiKey: string }) =>
 					await runQuery(
 						`INSERT INTO ${userApiKeysTable} (${idColumn}, ${userIdColumn}, ${apiKeyColumn}, ${labelColumn}) VALUES (:id, :userId, :apiKey, :label)`,
@@ -97,7 +96,6 @@ export class AddApiKeysTable1724951148974 implements ReversibleMigration {
 
 		await Promise.all(
 			oldestApiKeysPerUser.map(
-				// @ts-expect-error Tech debt
 				async (user: { userId: string; apiKey: string }) =>
 					await runQuery(
 						`UPDATE ${userTable} SET ${apiKeyColumn} = :apiKey WHERE ${idColumn} = :userId`,

--- a/packages/@n8n/db/src/migrations/sqlite/1724951148974-AddApiKeysTable.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/1724951148974-AddApiKeysTable.ts
@@ -30,7 +30,6 @@ export class AddApiKeysTable1724951148974 implements ReversibleMigration {
 		// Move the apiKey from the users table to the new table
 		await Promise.all(
 			usersWithApiKeys.map(
-				// @ts-expect-error Tech debt
 				async (user: { id: string; apiKey: string }) =>
 					await runQuery(
 						`INSERT INTO ${tableName} ("id", "userId", "apiKey", "label") VALUES (:id, :userId, :apiKey, :label)`,
@@ -115,7 +114,6 @@ export class AddApiKeysTable1724951148974 implements ReversibleMigration {
 
 		await Promise.all(
 			oldestApiKeysPerUser.map(
-				// @ts-expect-error Tech debt
 				async (user: { userId: string; apiKey: string }) =>
 					await runQuery(
 						`UPDATE ${tablePrefix}user SET ${apiKeyColumn} = :apiKey WHERE ${idColumn} = :userId`,

--- a/packages/@n8n/db/tsconfig.json
+++ b/packages/@n8n/db/tsconfig.json
@@ -9,6 +9,7 @@
 		"emitDecoratorMetadata": true,
 
 		// remove all options below this line
+		"strict": false,
 		"strictPropertyInitialization": false
 	},
 	"include": ["src/**/*.ts"],


### PR DESCRIPTION
## Summary

We're occassionally seeing this build error, possibly coming from: https://github.com/typeorm/typeorm/issues/9826

<details>
<summary>Build error</summary>


```
n8n:build: cache miss, executing 2d501cf57e3bb13f
n8n:build:
n8n:build:
n8n:build: > n8n@1.97.0 build /Users/ivov/Development/n8n/packages/cli
n8n:build: > tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && node scripts/build.mjs
n8n:build:
n8n:build: src/commands/import/credentials.ts:105:74 - error TS2345: Argument of type 'Partial<CredentialsEntity>' is not assignable to parameter of type '_QueryDeepPartialEntity<CredentialsEntity> | _QueryDeepPartialEntity<CredentialsEntity>[]'.
n8n:build:   Type 'Partial<CredentialsEntity>' is not assignable to type '_QueryDeepPartialEntity<CredentialsEntity>'.
n8n:build:     Types of property 'shared' are incompatible.
n8n:build:       Type 'SharedCredentials[] | undefined' is not assignable to type '(() => string) | _QueryDeepPartialEntity<SharedCredentials>[] | undefined'.
n8n:build:         Type 'SharedCredentials[]' is not assignable to type '(() => string) | _QueryDeepPartialEntity<SharedCredentials>[] | undefined'.
n8n:build:           Type 'SharedCredentials[]' is not assignable to type '_QueryDeepPartialEntity<SharedCredentials>[]'.
n8n:build:             Type 'SharedCredentials' is not assignable to type '_QueryDeepPartialEntity<SharedCredentials>'.
n8n:build:               Types of property 'credentials' are incompatible.
n8n:build:                 Type 'CredentialsEntity' is not assignable to type '(() => string) | _QueryDeepPartialEntity<CredentialsEntity> | undefined'.
n8n:build:
n8n:build: 105   const result = await this.transactionManager.upsert(CredentialsEntity, credential, ['id']);
n8n:build:                                                                              ~~~~~~~~~~
n8n:build:
n8n:build: src/credentials-helper.ts:448:54 - error TS2345: Argument of type 'ICredentialsDb' is not assignable to parameter of type '_QueryDeepPartialEntity<CredentialsEntity>'.
n8n:build:   Types of property 'shared' are incompatible.
n8n:build:     Type 'SharedCredentials[] | undefined' is not assignable to type '(() => string) | _QueryDeepPartialEntity<SharedCredentials>[] | undefined'.
n8n:build:       Type 'SharedCredentials[]' is not assignable to type '(() => string) | _QueryDeepPartialEntity<SharedCredentials>[] | undefined'.
n8n:build:         Type 'SharedCredentials[]' is not assignable to type '_QueryDeepPartialEntity<SharedCredentials>[]'.
n8n:build:           Type 'SharedCredentials' is not assignable to type '_QueryDeepPartialEntity<SharedCredentials>'.
n8n:build:             Types of property 'credentials' are incompatible.
n8n:build:               Type 'CredentialsEntity' is not assignable to type '(() => string) | _QueryDeepPartialEntity<CredentialsEntity> | undefined'.
n8n:build:
n8n:build: 448   await this.credentialsRepository.update(findQuery, newCredentialsData);
n8n:build:                                                          ~~~~~~~~~~~~~~~~~~
n8n:build:
n8n:build: src/credentials/credentials.service.ts:391:57 - error TS2345: Argument of type 'ICredentialsDb' is not assignable to parameter of type '_QueryDeepPartialEntity<CredentialsEntity>'.
n8n:build:   Types of property 'shared' are incompatible.
n8n:build:     Type 'SharedCredentials[] | undefined' is not assignable to type '(() => string) | _QueryDeepPartialEntity<SharedCredentials>[] | undefined'.
n8n:build:       Type 'SharedCredentials[]' is not assignable to type '(() => string) | _QueryDeepPartialEntity<SharedCredentials>[] | undefined'.
n8n:build:         Type 'SharedCredentials[]' is not assignable to type '_QueryDeepPartialEntity<SharedCredentials>[]'.
n8n:build:           Type 'SharedCredentials' is not assignable to type '_QueryDeepPartialEntity<SharedCredentials>'.
n8n:build:             Types of property 'credentials' are incompatible.
n8n:build:               Type 'CredentialsEntity' is not assignable to type '(() => string) | _QueryDeepPartialEntity<CredentialsEntity> | undefined'.
n8n:build:
n8n:build: 391   await this.credentialsRepository.update(credentialId, newCredentialData);
n8n:build:                                                             ~~~~~~~~~~~~~~~~~
n8n:build:
n8n:build: src/environments.ee/source-control/source-control-import.service.ee.ts:565:52 - error TS2345: Argument of type '{ role: CredentialSharingRole; credentials: CredentialsEntity; credentialsId: string; project: Project; projectId: string; createdAt: Date; updatedAt: Date; setUpdateDate(): void; }' is not assignable to parameter of type '_QueryDeepPartialEntity<SharedCredentials> | _QueryDeepPartialEntity<SharedCredentials>[]'.
n8n:build:   Type '{ role: CredentialSharingRole; credentials: CredentialsEntity; credentialsId: string; project: Project; projectId: string; createdAt: Date; updatedAt: Date; setUpdateDate(): void; }' is not assignable to type '_QueryDeepPartialEntity<SharedCredentials>'.
n8n:build:     Types of property 'credentials' are incompatible.
n8n:build:       Type 'CredentialsEntity' is not assignable to type '(() => string) | _QueryDeepPartialEntity<CredentialsEntity> | undefined'.
n8n:build:         Type 'CredentialsEntity' is not assignable to type '_QueryDeepPartialEntity<CredentialsEntity>'.
n8n:build:           Types of property 'shared' are incompatible.
n8n:build:             Type 'SharedCredentials[]' is not assignable to type '(() => string) | _QueryDeepPartialEntity<SharedCredentials>[] | undefined'.
n8n:build:               Type 'SharedCredentials[]' is not assignable to type '_QueryDeepPartialEntity<SharedCredentials>[]'.
n8n:build:                 Type 'SharedCredentials' is not assignable to type '_QueryDeepPartialEntity<SharedCredentials>'.
n8n:build:                   Types of property 'project' are incompatible.
n8n:build:                     Type 'Project' is not assignable to type '(() => string) | _QueryDeepPartialEntity<Project> | undefined'.
n8n:build:                       Type 'Project' is not assignable to type '_QueryDeepPartialEntity<Project>'.
n8n:build:                         Types of property 'projectRelations' are incompatible.
n8n:build:                           Type 'ProjectRelation[]' is not assignable to type '(() => string) | _QueryDeepPartialEntity<ProjectRelation>[] | undefined'.
n8n:build:                             Type 'ProjectRelation[]' is not assignable to type '_QueryDeepPartialEntity<ProjectRelation>[]'.
n8n:build:                               Type 'ProjectRelation' is not assignable to type '_QueryDeepPartialEntity<ProjectRelation>'.
n8n:build:                                 Types of property 'user' are incompatible.
n8n:build:                                   Type 'User' is not assignable to type '(() => string) | _QueryDeepPartialEntity<User> | undefined'.
n8n:build:                                     Type 'User' is not assignable to type '_QueryDeepPartialEntity<User>'.
n8n:build:                                       Types of property 'authIdentities' are incompatible.
n8n:build:                                         Type 'AuthIdentity[]' is not assignable to type '(() => string) | _QueryDeepPartialEntity<AuthIdentity>[] | undefined'.
n8n:build:
n8n:build: 565      await this.sharedCredentialsRepository.upsert({ ...newSharedCredential }, [
n8n:build:                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~
n8n:build:
n8n:build: src/environments.ee/source-control/source-control-import.service.ee.ts:620:37 - error TS2345: Argument of type 'TagEntity' is not assignable to parameter of type '_QueryDeepPartialEntity<TagEntity> | _QueryDeepPartialEntity<TagEntity>[]'.
n8n:build:   Type 'TagEntity' is not assignable to type '_QueryDeepPartialEntity<TagEntity>'.
n8n:build:     Types of property 'workflows' are incompatible.
n8n:build:       Type 'WorkflowEntity[]' is not assignable to type '(() => string) | _QueryDeepPartialEntity<WorkflowEntity>[] | undefined'.
n8n:build:         Type 'WorkflowEntity[]' is not assignable to type '_QueryDeepPartialEntity<WorkflowEntity>[]'.
n8n:build:           Type 'WorkflowEntity' is not assignable to type '_QueryDeepPartialEntity<WorkflowEntity>'.
n8n:build:             Types of property 'tags' are incompatible.
n8n:build:               Type 'TagEntity[] | undefined' is not assignable to type '(() => string) | _QueryDeepPartialEntity<TagEntity[] | undefined>'.
n8n:build:                 Type 'TagEntity[]' is not assignable to type '(() => string) | _QueryDeepPartialEntity<TagEntity[] | undefined>'.
n8n:build:                   Type 'TagEntity[]' is not assignable to type '((() => string) | _QueryDeepPartialEntity<TagEntity> | undefined)[]'.
n8n:build:                     Type 'TagEntity' is not assignable to type '(() => string) | _QueryDeepPartialEntity<TagEntity> | undefined'.
n8n:build:
n8n:build: 620     await this.tagRepository.upsert(tagCopy, {
n8n:build:                                         ~~~~~~~
n8n:build:
n8n:build: src/environments.ee/source-control/source-control-import.service.ee.ts:675:40 - error TS2345: Argument of type 'Folder' is not assignable to parameter of type '_QueryDeepPartialEntity<Folder> | _QueryDeepPartialEntity<Folder>[]'.
n8n:build:   Type 'Folder' is not assignable to type '_QueryDeepPartialEntity<Folder>'.
n8n:build:     Types of property 'parentFolder' are incompatible.
n8n:build:       Type 'Folder | null' is not assignable to type '(() => string) | _QueryDeepPartialEntity<Folder | null> | undefined'.
n8n:build:         Type 'Folder' is not assignable to type '(() => string) | _QueryDeepPartialEntity<Folder | null> | undefined'.
n8n:build:           Type 'Folder' is not assignable to type '_QueryDeepPartialEntity<Folder>'.
n8n:build:             Types of property 'subFolders' are incompatible.
n8n:build:               Type 'Folder[]' is not assignable to type '(() => string) | _QueryDeepPartialEntity<Folder>[] | undefined'.
n8n:build:
n8n:build: 675     await this.folderRepository.upsert(folderCopy, {
n8n:build:                                            ~~~~~~~~~~
n8n:build:
n8n:build: src/public-api/v1/handlers/workflows/workflows.service.ts:107:68 - error TS2345: Argument of type 'WorkflowEntity' is not assignable to parameter of type '_QueryDeepPartialEntity<WorkflowEntity>'.
n8n:build:   Types of property 'tags' are incompatible.
n8n:build:     Type 'TagEntity[] | undefined' is not assignable to type '(() => string) | _QueryDeepPartialEntity<TagEntity[] | undefined>'.
n8n:build:       Type 'TagEntity[]' is not assignable to type '(() => string) | _QueryDeepPartialEntity<TagEntity[] | undefined>'.
n8n:build:         Type 'TagEntity[]' is not assignable to type '((() => string) | _QueryDeepPartialEntity<TagEntity> | undefined)[]'.
n8n:build:           Type 'TagEntity' is not assignable to type '(() => string) | _QueryDeepPartialEntity<TagEntity> | undefined'.
n8n:build:             Type 'TagEntity' is not assignable to type '_QueryDeepPartialEntity<TagEntity>'.
n8n:build:               Types of property 'workflows' are incompatible.
n8n:build:                 Type 'WorkflowEntity[]' is not assignable to type '(() => string) | _QueryDeepPartialEntity<WorkflowEntity>[] | undefined'.
n8n:build:
n8n:build: 107  return await Container.get(WorkflowRepository).update(workflowId, updateData);
n8n:build:                                                                        ~~~~~~~~~~
n8n:build:
n8n:build: src/services/import.service.ts:60:58 - error TS2345: Argument of type 'IWorkflowDb' is not assignable to parameter of type '_QueryDeepPartialEntity<WorkflowEntity> | _QueryDeepPartialEntity<WorkflowEntity>[]'.
n8n:build:   Type 'IWorkflowDb' is not assignable to type '_QueryDeepPartialEntity<WorkflowEntity>'.
n8n:build:     Types of property 'tags' are incompatible.
n8n:build:       Type 'TagEntity[] | undefined' is not assignable to type '(() => string) | _QueryDeepPartialEntity<TagEntity[] | undefined>'.
n8n:build:         Type 'TagEntity[]' is not assignable to type '(() => string) | _QueryDeepPartialEntity<TagEntity[] | undefined>'.
n8n:build:           Type 'TagEntity[]' is not assignable to type '((() => string) | _QueryDeepPartialEntity<TagEntity> | undefined)[]'.
n8n:build:             Type 'TagEntity' is not assignable to type '(() => string) | _QueryDeepPartialEntity<TagEntity> | undefined'.
n8n:build:               Type 'TagEntity' is not assignable to type '_QueryDeepPartialEntity<TagEntity>'.
n8n:build:                 Types of property 'workflows' are incompatible.
n8n:build:                   Type 'WorkflowEntity[]' is not assignable to type '(() => string) | _QueryDeepPartialEntity<WorkflowEntity>[] | undefined'.
n8n:build:                     Type 'WorkflowEntity[]' is not assignable to type '_QueryDeepPartialEntity<WorkflowEntity>[]'.
n8n:build:                       Type 'WorkflowEntity' is not assignable to type '_QueryDeepPartialEntity<WorkflowEntity>'.
n8n:build:                         Types of property 'tagMappings' are incompatible.
n8n:build:                           Type 'WorkflowTagMapping[]' is not assignable to type '(() => string) | _QueryDeepPartialEntity<WorkflowTagMapping>[] | undefined'.
n8n:build:                             Type 'WorkflowTagMapping[]' is not assignable to type '_QueryDeepPartialEntity<WorkflowTagMapping>[]'.
n8n:build:                               Type 'WorkflowTagMapping' is not assignable to type '_QueryDeepPartialEntity<WorkflowTagMapping>'.
n8n:build:                                 Types of property 'tags' are incompatible.
n8n:build:                                   Type 'TagEntity[]' is not assignable to type '(() => string) | _QueryDeepPartialEntity<TagEntity>[] | undefined'.
n8n:build:
n8n:build: 60     const upsertResult = await tx.upsert(WorkflowEntity, workflow, ['id']);
n8n:build:                                                             ~~~~~~~~
n8n:build:
n8n:build: src/services/project.service.ee.ts:383:4 - error TS2345: Argument of type 'ProjectRelation[]' is not assignable to parameter of type '_QueryDeepPartialEntity<ProjectRelation> | _QueryDeepPartialEntity<ProjectRelation>[]'.
n8n:build:   Type 'ProjectRelation[]' is not assignable to type '_QueryDeepPartialEntity<ProjectRelation>[]'.
n8n:build:     Type 'ProjectRelation' is not assignable to type '_QueryDeepPartialEntity<ProjectRelation>'.
n8n:build:       Types of property 'user' are incompatible.
n8n:build:         Type 'User' is not assignable to type '(() => string) | _QueryDeepPartialEntity<User> | undefined'.
n8n:build:           Type 'User' is not assignable to type '_QueryDeepPartialEntity<User>'.
n8n:build:             Types of property 'authIdentities' are incompatible.
n8n:build:               Type 'AuthIdentity[]' is not assignable to type '(() => string) | _QueryDeepPartialEntity<AuthIdentity>[] | undefined'.
n8n:build:
n8n:build: 383    relations.map((v) =>
n8n:build:        ~~~~~~~~~~~~~~~~~~~~
n8n:build: 384     this.projectRelationRepository.create({
n8n:build:     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
n8n:build: ...
n8n:build: 388     }),
n8n:build:     ~~~~~~~
n8n:build: 389    ),
n8n:build:     ~~~~
n8n:build:
n8n:build: src/services/public-api-key.service.ts:44:4 - error TS2345: Argument of type 'ApiKey' is not assignable to parameter of type '_QueryDeepPartialEntity<ApiKey> | _QueryDeepPartialEntity<ApiKey>[]'.
n8n:build:   Type 'ApiKey' is not assignable to type '_QueryDeepPartialEntity<ApiKey>'.
n8n:build:     Types of property 'user' are incompatible.
n8n:build:       Type 'User' is not assignable to type '(() => string) | _QueryDeepPartialEntity<User> | undefined'.
n8n:build:         Type 'User' is not assignable to type '_QueryDeepPartialEntity<User>'.
n8n:build:           Types of property 'authIdentities' are incompatible.
n8n:build:             Type 'AuthIdentity[]' is not assignable to type '(() => string) | _QueryDeepPartialEntity<AuthIdentity>[] | undefined'.
n8n:build:
n8n:build:  44    this.apiKeyRepository.create({
n8n:build:        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
n8n:build:  45     userId: user.id,
n8n:build:     ~~~~~~~~~~~~~~~~~~~~
n8n:build: ...
n8n:build:  48     scopes,
n8n:build:     ~~~~~~~~~~~
n8n:build:  49    }),
n8n:build:     ~~~~~
n8n:build:
n8n:build: src/workflows/workflow.service.ee.ts:344:63 - error TS2322: Type 'Folder | null' is not assignable to type '(() => string) | _QueryDeepPartialEntity<Folder | null> | undefined'.
n8n:build:   Type 'Folder' is not assignable to type '(() => string) | _QueryDeepPartialEntity<Folder | null> | undefined'.
n8n:build:     Type 'Folder' is not assignable to type '_QueryDeepPartialEntity<Folder>'.
n8n:build:       Types of property 'subFolders' are incompatible.
n8n:build:         Type 'Folder[]' is not assignable to type '(() => string) | _QueryDeepPartialEntity<Folder>[] | undefined'.
n8n:build:           Type 'Folder[]' is not assignable to type '_QueryDeepPartialEntity<Folder>[]'.
n8n:build:             Type 'Folder' is not assignable to type '_QueryDeepPartialEntity<Folder>'.
n8n:build:               Types of property 'homeProject' are incompatible.
n8n:build:                 Type 'Project' is not assignable to type '(() => string) | _QueryDeepPartialEntity<Project> | undefined'.
n8n:build:                   Type 'Project' is not assignable to type '_QueryDeepPartialEntity<Project>'.
n8n:build:                     Types of property 'projectRelations' are incompatible.
n8n:build:                       Type 'ProjectRelation[]' is not assignable to type '(() => string) | _QueryDeepPartialEntity<ProjectRelation>[] | undefined'.
n8n:build:                         Type 'ProjectRelation[]' is not assignable to type '_QueryDeepPartialEntity<ProjectRelation>[]'.
n8n:build:                           Type 'ProjectRelation' is not assignable to type '_QueryDeepPartialEntity<ProjectRelation>'.
n8n:build:                             Types of property 'user' are incompatible.
n8n:build:                               Type 'User' is not assignable to type '(() => string) | _QueryDeepPartialEntity<User> | undefined'.
n8n:build:                                 Type 'User' is not assignable to type '_QueryDeepPartialEntity<User>'.
n8n:build:                                   Types of property 'authIdentities' are incompatible.
n8n:build:                                     Type 'AuthIdentity[]' is not assignable to type '(() => string) | _QueryDeepPartialEntity<AuthIdentity>[] | undefined'.
n8n:build:
n8n:build: 344   await this.workflowRepository.update({ id: workflow.id }, { parentFolder });
n8n:build:                                                                   ~~~~~~~~~~~~
n8n:build:
n8n:build:   ../@n8n/db/dist/entities/workflow-entity.d.ts:27:5
n8n:build:     27     parentFolder: Folder | null;
n8n:build:            ~~~~~~~~~~~~
n8n:build:     The expected type comes from property 'parentFolder' which is declared here on type '_QueryDeepPartialEntity<WorkflowEntity>'
n8n:build:
n8n:build: src/workflows/workflows.controller.ts:172:77 - error TS2322: Type 'Folder' is not assignable to type '(() => string) | _QueryDeepPartialEntity<Folder | null> | undefined'.
n8n:build:   Type 'Folder' is not assignable to type '_QueryDeepPartialEntity<Folder>'.
n8n:build:     Types of property 'subFolders' are incompatible.
n8n:build:       Type 'Folder[]' is not assignable to type '(() => string) | _QueryDeepPartialEntity<Folder>[] | undefined'.
n8n:build:         Type 'Folder[]' is not assignable to type '_QueryDeepPartialEntity<Folder>[]'.
n8n:build:           Type 'Folder' is not assignable to type '_QueryDeepPartialEntity<Folder>'.
n8n:build:             Types of property 'homeProject' are incompatible.
n8n:build:               Type 'Project' is not assignable to type '(() => string) | _QueryDeepPartialEntity<Project> | undefined'.
n8n:build:                 Type 'Project' is not assignable to type '_QueryDeepPartialEntity<Project>'.
n8n:build:                   Types of property 'projectRelations' are incompatible.
n8n:build:                     Type 'ProjectRelation[]' is not assignable to type '(() => string) | _QueryDeepPartialEntity<ProjectRelation>[] | undefined'.
n8n:build:                       Type 'ProjectRelation[]' is not assignable to type '_QueryDeepPartialEntity<ProjectRelation>[]'.
n8n:build:                         Type 'ProjectRelation' is not assignable to type '_QueryDeepPartialEntity<ProjectRelation>'.
n8n:build:                           Types of property 'user' are incompatible.
n8n:build:                             Type 'User' is not assignable to type '(() => string) | _QueryDeepPartialEntity<User> | undefined'.
n8n:build:                               Type 'User' is not assignable to type '_QueryDeepPartialEntity<User>'.
n8n:build:                                 Types of property 'authIdentities' are incompatible.
n8n:build:                                   Type 'AuthIdentity[]' is not assignable to type '(() => string) | _QueryDeepPartialEntity<AuthIdentity>[] | undefined'.
n8n:build:
n8n:build: 172      await transactionManager.update(WorkflowEntity, { id: workflow.id }, { parentFolder });
n8n:build:                                                                                 ~~~~~~~~~~~~
n8n:build:
n8n:build:   ../@n8n/db/dist/entities/workflow-entity.d.ts:27:5
n8n:build:     27     parentFolder: Folder | null;
n8n:build:            ~~~~~~~~~~~~
n8n:build:     The expected type comes from property 'parentFolder' which is declared here on type '_QueryDeepPartialEntity<WorkflowEntity>'
n8n:build:
n8n:build:
n8n:build: Found 12 errors in 10 files.
n8n:build:
n8n:build: Errors  Files
n8n:build:      1  src/commands/import/credentials.ts:105
n8n:build:      1  src/credentials-helper.ts:448
n8n:build:      1  src/credentials/credentials.service.ts:391
n8n:build:      3  src/environments.ee/source-control/source-control-import.service.ee.ts:565
n8n:build:      1  src/public-api/v1/handlers/workflows/workflows.service.ts:107
n8n:build:      1  src/services/import.service.ts:60
n8n:build:      1  src/services/project.service.ee.ts:383
n8n:build:      1  src/services/public-api-key.service.ts:44
n8n:build:      1  src/workflows/workflow.service.ee.ts:344
n8n:build:      1  src/workflows/workflows.controller.ts:172
n8n:build:  ELIFECYCLE  Command failed with exit code 2.
n8n:build: ERROR: command finished with error: command (/Users/ivov/Development/n8n/packages/cli) /usr/local/bin/pnpm run build exited (2)
n8n#build: command (/Users/ivov/Development/n8n/packages/cli) /usr/local/bin/pnpm run build exited (2)

 Tasks:    30 successful, 31 total
Cached:    0 cached, 31 total
  Time:    4m50.523s
Failed:    n8n#build

 ERROR  run failed: command  exited (2)
 ELIFECYCLE  Command failed with exit code 2.

```

</details>

Originally, our ORM logic was under `strict: false` from the `tsconfig.json` in `cli` but now all ORM logic is in `@n8n/db`  with `strict: true`. This strictness change is likely surfacing type issues that have long existed in `cli`.

This PR brings `@n8n/db` strictness back in line with `cli` to prevent build issues, until we tackle type safety in a more dedicated effort.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
n/a

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
