### PR TITLE
feat(core): Link error workflow's Error Trigger nodes to the parent execution that errored

### DIFF
--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -320,6 +320,14 @@ export class WorkflowExecutionService {
 				return;
 			}
 
+			const parentExecution =
+				workflowErrorData.execution?.id && workflowErrorData.workflow?.id
+					? {
+							executionId: workflowErrorData.execution.id,
+							workflowId: workflowErrorData.workflow.id,
+						}
+					: undefined;
+
 			// Can execute without webhook so go on
 			// Initialize the data of the webhook node
 			const nodeExecutionStack: IExecuteData[] = [];
@@ -335,6 +343,11 @@ export class WorkflowExecutionService {
 					],
 				},
 				source: null,
+				...(parentExecution && {
+					metadata: {
+						parentExecution,
+					},
+				}),
 			});
 
 			const runExecutionData: IRunExecutionData = {


### PR DESCRIPTION
## Summary

![image](https://github.com/user-attachments/assets/cc38bc37-fd16-4ea3-bf44-10ba5fe57ed6)

Show a link to the parent execution that caused the error workflow to trigger on `Error Trigger` nodes, like we show on sub workflows `When Executed by Another Workflow` nodes. The link will show up as `View parent execution <id>`.

This is accomplished by providing similar metadata as we do on sub workflow executions when error workflows are executed. While I feel this is the correct and consistent way to implement this (rather than inspecting the input data of Error Trigger nodes at frontend) this also means that this metadata will only be present on new errors that happen after this change has been deployed. On older errors the link simply won't show up.

Also added a test for `executeErrorWorkflow()` while touching it as it had none.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-2882/feature-add-debugging-for-error-workflows

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
