### PR TITLE
feat(editor): Rename debugging tab to fromai

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -1111,7 +1111,7 @@
 	"ndv.input.nodeDistance": "{count} node back | {count} nodes back",
 	"ndv.input.noNodesFound": "No nodes found",
 	"ndv.input.mapping": "Mapping",
-	"ndv.input.debugging": "Debugging",
+	"ndv.input.debugging": "From AI",
 	"ndv.input.parentNodes": "Parent nodes",
 	"ndv.input.tooMuchData.title": "Display data?",
 	"ndv.input.noOutputDataInBranch": "No input data in this branch",

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -1111,7 +1111,7 @@
 	"ndv.input.nodeDistance": "{count} node back | {count} nodes back",
 	"ndv.input.noNodesFound": "No nodes found",
 	"ndv.input.mapping": "Mapping",
-	"ndv.input.debugging": "From AI",
+	"ndv.input.fromAI": "From AI",
 	"ndv.input.parentNodes": "Parent nodes",
 	"ndv.input.tooMuchData.title": "Display data?",
 	"ndv.input.noOutputDataInBranch": "No input data in this branch",

--- a/packages/frontend/editor-ui/src/components/InputPanel.vue
+++ b/packages/frontend/editor-ui/src/components/InputPanel.vue
@@ -83,7 +83,7 @@ const draggableHintShown = ref(false);
 const mappedNode = ref<string | null>(null);
 const inputModes = [
 	{ value: 'mapping', label: i18n.baseText('ndv.input.mapping') },
-	{ value: 'debugging', label: i18n.baseText('ndv.input.debugging') },
+	{ value: 'debugging', label: i18n.baseText('ndv.input.fromAI') },
 ];
 
 const nodeTypesStore = useNodeTypesStore();

--- a/packages/frontend/editor-ui/src/components/__snapshots__/InputPanel.test.ts.snap
+++ b/packages/frontend/editor-ui/src/components/__snapshots__/InputPanel.test.ts.snap
@@ -17,7 +17,7 @@ exports[`InputPanel > should render 1`] = `
         class="title"
         data-v-2e5cd75c=""
       >
-
+        
         <div
           class="titleSection"
         >
@@ -31,7 +31,7 @@ exports[`InputPanel > should render 1`] = `
             data-test-id="input-panel-mode"
             role="radiogroup"
           >
-
+            
             <label
               aria-checked="true"
               class="n8n-radio-button container hoverable"
@@ -42,9 +42,9 @@ exports[`InputPanel > should render 1`] = `
                 class="button active medium"
                 data-test-id="radio-button-mapping"
               >
-
+                
                 Mapping
-
+                
               </div>
             </label>
             <label
@@ -57,15 +57,15 @@ exports[`InputPanel > should render 1`] = `
                 class="button medium"
                 data-test-id="radio-button-debugging"
               >
-
-                Debugging
-
+                
+                From AI
+                
               </div>
             </label>
-
+            
           </div>
         </div>
-
+        
       </div>
       <div
         class="displayModes"
@@ -79,7 +79,7 @@ exports[`InputPanel > should render 1`] = `
           data-v-2e5cd75c=""
           role="radiogroup"
         >
-
+          
           <label
             aria-checked="true"
             class="n8n-radio-button container hoverable"
@@ -90,9 +90,9 @@ exports[`InputPanel > should render 1`] = `
               class="button active medium"
               data-test-id="radio-button-schema"
             >
-
+              
               Schema
-
+              
             </div>
           </label>
           <label
@@ -105,9 +105,9 @@ exports[`InputPanel > should render 1`] = `
               class="button medium"
               data-test-id="radio-button-table"
             >
-
+              
               Table
-
+              
             </div>
           </label>
           <label
@@ -120,12 +120,12 @@ exports[`InputPanel > should render 1`] = `
               class="button medium"
               data-test-id="radio-button-json"
             >
-
+              
               JSON
-
+              
             </div>
           </label>
-
+          
         </div>
         <!--v-if-->
         <!--v-if-->
@@ -162,8 +162,8 @@ exports[`InputPanel > should render 1`] = `
     <!--v-if-->
     <!--v-if-->
     <!--v-if-->
-
-
+    
+    
     <!--v-if-->
     <div
       class="dataContainer"

--- a/packages/frontend/editor-ui/src/components/__snapshots__/InputPanel.test.ts.snap
+++ b/packages/frontend/editor-ui/src/components/__snapshots__/InputPanel.test.ts.snap
@@ -58,7 +58,7 @@ exports[`InputPanel > should render 1`] = `
                 data-test-id="radio-button-debugging"
               >
 
-                From AI
+                Debugging
 
               </div>
             </label>

--- a/packages/frontend/editor-ui/src/components/__snapshots__/InputPanel.test.ts.snap
+++ b/packages/frontend/editor-ui/src/components/__snapshots__/InputPanel.test.ts.snap
@@ -17,7 +17,7 @@ exports[`InputPanel > should render 1`] = `
         class="title"
         data-v-2e5cd75c=""
       >
-        
+
         <div
           class="titleSection"
         >
@@ -31,7 +31,7 @@ exports[`InputPanel > should render 1`] = `
             data-test-id="input-panel-mode"
             role="radiogroup"
           >
-            
+
             <label
               aria-checked="true"
               class="n8n-radio-button container hoverable"
@@ -42,9 +42,9 @@ exports[`InputPanel > should render 1`] = `
                 class="button active medium"
                 data-test-id="radio-button-mapping"
               >
-                
+
                 Mapping
-                
+
               </div>
             </label>
             <label
@@ -57,15 +57,15 @@ exports[`InputPanel > should render 1`] = `
                 class="button medium"
                 data-test-id="radio-button-debugging"
               >
-                
-                Debugging
-                
+
+                From AI
+
               </div>
             </label>
-            
+
           </div>
         </div>
-        
+
       </div>
       <div
         class="displayModes"
@@ -79,7 +79,7 @@ exports[`InputPanel > should render 1`] = `
           data-v-2e5cd75c=""
           role="radiogroup"
         >
-          
+
           <label
             aria-checked="true"
             class="n8n-radio-button container hoverable"
@@ -90,9 +90,9 @@ exports[`InputPanel > should render 1`] = `
               class="button active medium"
               data-test-id="radio-button-schema"
             >
-              
+
               Schema
-              
+
             </div>
           </label>
           <label
@@ -105,9 +105,9 @@ exports[`InputPanel > should render 1`] = `
               class="button medium"
               data-test-id="radio-button-table"
             >
-              
+
               Table
-              
+
             </div>
           </label>
           <label
@@ -120,12 +120,12 @@ exports[`InputPanel > should render 1`] = `
               class="button medium"
               data-test-id="radio-button-json"
             >
-              
+
               JSON
-              
+
             </div>
           </label>
-          
+
         </div>
         <!--v-if-->
         <!--v-if-->
@@ -162,8 +162,8 @@ exports[`InputPanel > should render 1`] = `
     <!--v-if-->
     <!--v-if-->
     <!--v-if-->
-    
-    
+
+
     <!--v-if-->
     <div
       class="dataContainer"


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
The information coming from the AI Agent node is currently shown under the tab named "Debugging" 
![old](https://github.com/user-attachments/assets/7f8b06b0-abce-4e40-bdd5-68bf5c45d186)

This creates confusion. To fix this, this tab has been renamed to "From AI"
![new](https://github.com/user-attachments/assets/268c6bf1-b2e3-49ff-a063-60535d01cb2f)

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/ADO-3597/feature-rename-debugging-tab-to-fromai
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
