### PR TITLE
feat(core): Handle scoped resource not existing with 404

### DIFF
--- a/packages/cli/src/permissions.ee/__tests__/check-access.test.ts
+++ b/packages/cli/src/permissions.ee/__tests__/check-access.test.ts
@@ -1,0 +1,154 @@
+import {
+	ProjectRepository,
+	SharedCredentialsRepository,
+	SharedWorkflowRepository,
+	type User,
+} from '@n8n/db';
+import { Container } from '@n8n/di';
+import type { Scope } from '@n8n/permissions';
+import { mock } from 'jest-mock-extended';
+
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+
+import { userHasScopes } from '../check-access';
+
+describe('userHasScopes', () => {
+	const findByOneWorkflowMock = jest.fn();
+	const findByOneCredentialMock = jest.fn();
+
+	beforeAll(() => {
+		Container.set(
+			SharedWorkflowRepository,
+			mock<SharedWorkflowRepository>({
+				findOneBy: findByOneWorkflowMock,
+			}),
+		);
+
+		Container.set(
+			SharedCredentialsRepository,
+			mock<SharedCredentialsRepository>({
+				findOneBy: findByOneCredentialMock,
+			}),
+		);
+
+		Container.set(
+			ProjectRepository,
+			mock<ProjectRepository>({
+				find: jest.fn().mockResolvedValue([
+					{
+						id: 'projectId',
+						projectRelations: [{ userId: 'userId', role: 'project:admin' }],
+					},
+				]),
+			}),
+		);
+	});
+
+	beforeEach(() => {
+		findByOneWorkflowMock.mockReset();
+		findByOneCredentialMock.mockReset();
+	});
+
+	it.each<{ type: 'workflow' | 'credential'; id: string }>([
+		{
+			type: 'workflow',
+			id: 'workflowId',
+		},
+		{
+			type: 'credential',
+			id: 'credentialId',
+		},
+	])('should return 404 if the resource is not found', async ({ type, id }) => {
+		findByOneWorkflowMock.mockResolvedValueOnce(null);
+		findByOneCredentialMock.mockResolvedValueOnce(null);
+
+		const user = { id: 'userId', scopes: [], role: 'global:member' } as unknown as User;
+		const scopes = ['workflow:read', 'credential:read'] as Scope[];
+
+		const params: { credentialId?: string; workflowId?: string; projectId?: string } = {
+			projectId: 'projectId',
+		};
+		if (type === 'credential') {
+			params.credentialId = id;
+		} else {
+			params.workflowId = id;
+		}
+		await expect(userHasScopes(user, scopes, false, params)).rejects.toThrow(NotFoundError);
+	});
+
+	test.each<{
+		type: 'workflow' | 'credential';
+		id: string;
+		role: string;
+		scope: Scope;
+		userScopes: Scope[];
+		expected: boolean;
+	}>([
+		{
+			type: 'workflow',
+			id: 'workflowId',
+			role: 'workflow:member',
+			scope: 'workflow:delete',
+			userScopes: [],
+			expected: false,
+		},
+		{
+			type: 'credential',
+			id: 'credentialId',
+			role: 'credential:member',
+			scope: 'credential:delete',
+			userScopes: [],
+			expected: false,
+		},
+		{
+			type: 'workflow',
+			id: 'workflowId',
+			role: 'workflow:editor',
+			scope: 'workflow:read',
+			userScopes: ['workflow:read'],
+			expected: true,
+		},
+		{
+			type: 'credential',
+			id: 'credentialId',
+			role: 'credential:user',
+			scope: 'credential:read',
+			userScopes: ['credential:read'],
+			expected: true,
+		},
+	])(
+		'should return $expected if the user has the required scopes for a $type',
+		async ({ type, id, role, scope, userScopes, expected }) => {
+			if (type === 'workflow') {
+				findByOneWorkflowMock.mockResolvedValueOnce({
+					workflowId: id,
+					projectId: 'projectId',
+					role,
+				});
+			} else {
+				findByOneCredentialMock.mockResolvedValueOnce({
+					credentialId: id,
+					projectId: 'projectId',
+					role,
+				});
+			}
+
+			const user = {
+				id: 'userId',
+				scopes: userScopes,
+				role: 'global:member',
+			} as unknown as User;
+			const scopes = [scope] as Scope[];
+			const params: { credentialId?: string; workflowId?: string; projectId?: string } = {
+				projectId: 'projectId',
+			};
+			if (type === 'credential') {
+				params.credentialId = id;
+			} else {
+				params.workflowId = id;
+			}
+			const result = await userHasScopes(user, scopes, false, params);
+			expect(result).toBe(expected);
+		},
+	);
+});

--- a/packages/cli/src/permissions.ee/__tests__/check-access.test.ts
+++ b/packages/cli/src/permissions.ee/__tests__/check-access.test.ts
@@ -13,21 +13,21 @@ import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { userHasScopes } from '../check-access';
 
 describe('userHasScopes', () => {
-	const findByOneWorkflowMock = jest.fn();
-	const findByOneCredentialMock = jest.fn();
+	const findByWorkflowMock = jest.fn();
+	const findByCredentialMock = jest.fn();
 
 	beforeAll(() => {
 		Container.set(
 			SharedWorkflowRepository,
 			mock<SharedWorkflowRepository>({
-				findOneBy: findByOneWorkflowMock,
+				findBy: findByWorkflowMock,
 			}),
 		);
 
 		Container.set(
 			SharedCredentialsRepository,
 			mock<SharedCredentialsRepository>({
-				findOneBy: findByOneCredentialMock,
+				findBy: findByCredentialMock,
 			}),
 		);
 
@@ -45,8 +45,8 @@ describe('userHasScopes', () => {
 	});
 
 	beforeEach(() => {
-		findByOneWorkflowMock.mockReset();
-		findByOneCredentialMock.mockReset();
+		findByWorkflowMock.mockReset();
+		findByCredentialMock.mockReset();
 	});
 
 	it.each<{ type: 'workflow' | 'credential'; id: string }>([
@@ -59,8 +59,8 @@ describe('userHasScopes', () => {
 			id: 'credentialId',
 		},
 	])('should return 404 if the resource is not found', async ({ type, id }) => {
-		findByOneWorkflowMock.mockResolvedValueOnce(null);
-		findByOneCredentialMock.mockResolvedValueOnce(null);
+		findByWorkflowMock.mockResolvedValueOnce([]);
+		findByCredentialMock.mockResolvedValueOnce([]);
 
 		const user = { id: 'userId', scopes: [], role: 'global:member' } as unknown as User;
 		const scopes = ['workflow:read', 'credential:read'] as Scope[];
@@ -120,17 +120,21 @@ describe('userHasScopes', () => {
 		'should return $expected if the user has the required scopes for a $type',
 		async ({ type, id, role, scope, userScopes, expected }) => {
 			if (type === 'workflow') {
-				findByOneWorkflowMock.mockResolvedValueOnce({
-					workflowId: id,
-					projectId: 'projectId',
-					role,
-				});
+				findByWorkflowMock.mockResolvedValueOnce([
+					{
+						workflowId: id,
+						projectId: 'projectId',
+						role,
+					},
+				]);
 			} else {
-				findByOneCredentialMock.mockResolvedValueOnce({
-					credentialId: id,
-					projectId: 'projectId',
-					role,
-				});
+				findByCredentialMock.mockResolvedValueOnce([
+					{
+						credentialId: id,
+						projectId: 'projectId',
+						role,
+					},
+				]);
 			}
 
 			const user = {

--- a/packages/cli/src/permissions.ee/check-access.ts
+++ b/packages/cli/src/permissions.ee/check-access.ts
@@ -57,12 +57,11 @@ export async function userHasScopes(
 		if (!credential) {
 			throw new NotFoundError(`Credential with ID "${credentialId}" not found.`);
 		}
-		if (
+
+		return (
 			userProjectIds.includes(credential.projectId) &&
 			rolesWithScope('credential', scopes).includes(credential.role)
-		) {
-			return true;
-		}
+		);
 	}
 
 	if (workflowId) {
@@ -74,12 +73,10 @@ export async function userHasScopes(
 			throw new NotFoundError(`Workflow with ID "${workflowId}" not found.`);
 		}
 
-		if (
+		return (
 			userProjectIds.includes(workflow.projectId) &&
 			rolesWithScope('workflow', scopes).includes(workflow.role)
-		) {
-			return true;
-		}
+		);
 	}
 
 	if (projectId) return userProjectIds.includes(projectId);

--- a/packages/cli/src/permissions.ee/check-access.ts
+++ b/packages/cli/src/permissions.ee/check-access.ts
@@ -51,31 +51,32 @@ export async function userHasScopes(
 	// those resource roles over the resource being checked.
 
 	if (credentialId) {
-		const credential = await Container.get(SharedCredentialsRepository).findOneBy({
+		const credentials = await Container.get(SharedCredentialsRepository).findBy({
 			credentialsId: credentialId,
 		});
-		if (!credential) {
+		if (!credentials.length) {
 			throw new NotFoundError(`Credential with ID "${credentialId}" not found.`);
 		}
 
-		return (
-			userProjectIds.includes(credential.projectId) &&
-			rolesWithScope('credential', scopes).includes(credential.role)
+		return credentials.some(
+			(c) =>
+				userProjectIds.includes(c.projectId) &&
+				rolesWithScope('credential', scopes).includes(c.role),
 		);
 	}
 
 	if (workflowId) {
-		const workflow = await Container.get(SharedWorkflowRepository).findOneBy({
+		const workflows = await Container.get(SharedWorkflowRepository).findBy({
 			workflowId,
 		});
 
-		if (!workflow) {
+		if (!workflows.length) {
 			throw new NotFoundError(`Workflow with ID "${workflowId}" not found.`);
 		}
 
-		return (
-			userProjectIds.includes(workflow.projectId) &&
-			rolesWithScope('workflow', scopes).includes(workflow.role)
+		return workflows.some(
+			(w) =>
+				userProjectIds.includes(w.projectId) && rolesWithScope('workflow', scopes).includes(w.role),
 		);
 	}
 

--- a/packages/cli/src/public-api/v1/shared/middlewares/global.middleware.ts
+++ b/packages/cli/src/public-api/v1/shared/middlewares/global.middleware.ts
@@ -6,6 +6,7 @@ import type express from 'express';
 import type { NextFunction } from 'express';
 
 import { FeatureNotLicensedError } from '@/errors/feature-not-licensed.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { License } from '@/license';
 import { userHasScopes } from '@/permissions.ee/check-access';
 import type { AuthenticatedRequest } from '@/requests';
@@ -36,8 +37,16 @@ const buildScopeMiddleware = (
 				params.credentialId = req.params.id;
 			}
 		}
-		if (!(await userHasScopes(req.user, scopes, globalOnly, params))) {
-			return res.status(403).json({ message: 'Forbidden' });
+
+		try {
+			if (!(await userHasScopes(req.user, scopes, globalOnly, params))) {
+				return res.status(403).json({ message: 'Forbidden' });
+			}
+		} catch (error) {
+			if (error instanceof NotFoundError) {
+				return res.status(404).json({ message: error.message });
+			}
+			throw error;
 		}
 
 		return next();

--- a/packages/cli/test/integration/credentials/credentials.api.test.ts
+++ b/packages/cli/test/integration/credentials/credentials.api.test.ts
@@ -1260,12 +1260,12 @@ describe('PATCH /credentials/:id', () => {
 		expect(response.statusCode).toBe(404);
 	});
 
-	test('should fail with a 403 if the credential does not exist and the actor does not have the global credential:update scope', async () => {
+	test('should fail with a 404 if the credential does not exist and the actor does not have the global credential:update scope', async () => {
 		const response = await authMemberAgent
 			.patch('/credentials/123')
 			.send(randomCredentialPayload());
 
-		expect(response.statusCode).toBe(403);
+		expect(response.statusCode).toBe(404);
 	});
 
 	test('should fail with a 400 is credential is managed', async () => {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR handles differently the permission for project users depending on whether the resource exists or not, returning a 404 if the resource do not exists. I chose to do that in the middleware directy, because this middleware already handles "business" logic for workflow or credentials entities.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2877/investigate-be-scoping


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
