### PR TITLE
fix(editor): Refresh NDV node connections if inputs change dynamically

### DIFF
--- a/packages/frontend/editor-ui/src/components/NDVSubConnections.vue
+++ b/packages/frontend/editor-ui/src/components/NDVSubConnections.vue
@@ -15,6 +15,7 @@ import type {
 import { useDebounce } from '@/composables/useDebounce';
 import { OnClickOutside } from '@vueuse/components';
 import { useI18n } from '@n8n/i18n';
+import { useNDVStore } from '@/stores/ndv.store';
 
 interface Props {
 	rootNode: INodeUi;
@@ -47,7 +48,7 @@ const nodeType = computed(() =>
 );
 
 const nodeData = computed(() => workflowsStore.getNodeByName(props.rootNode.name));
-
+const ndvStore = useNDVStore();
 const workflow = computed(() => workflowsStore.getCurrentWorkflow());
 
 const nodeInputIssues = computed(() => {
@@ -175,7 +176,7 @@ function showNodeInputsIssues() {
 }
 
 watch(
-	nodeData,
+	[nodeData, ndvStore.activeNode],
 	debounce(
 		() =>
 			setTimeout(() => {


### PR DESCRIPTION
## Summary

Some nodes, like `AI Agent`, `Structured Output Parser` and `Default Data Loader`  have parameters that change the inputs of the node when adjusted. The possible connections shown at the bottom of the screen on NDVSubConnections weren't updating when that happened - we weren't watching for active node changes that might cause the possible inputs to change. There's still 1 second debounce on this.

https://github.com/user-attachments/assets/139e42fc-90b3-41f7-80e7-f87f9ecb939c

Fix is simple, but making our tests accurately test this turned out to be hard. Here's the fix anyways - I might try adding the tests again tomorrow.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3620/feature-node-inputs-change-dynamically-based-on-properties

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
