### PR TITLE
fix: Make sure modals are listed when using a free AI credits credential in the OpenAI node

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/methods/listSearch.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/methods/listSearch.ts
@@ -77,7 +77,7 @@ export async function modelSearch(
 ): Promise<INodeListSearchResult> {
 	const credentials = await this.getCredentials<{ url: string }>('openAiApi');
 	const url = credentials.url && new URL(credentials.url);
-	const isCustomAPI = url && url.hostname !== 'api.openai.com';
+	const isCustomAPI = url && !['api.openai.com', 'ai-assistant.n8n.io'].includes(url.hostname);
 	return await getModelSearch(
 		(model) =>
 			!isCustomAPI &&


### PR DESCRIPTION
## Summary

We filter out all models that do not come from `api.openai.com`. Since the models for free AI credits come from `ai-assistant.n8n.io`, they are currently being filtered out. This PR hardcodes the AI assistant URL so that these models are no longer excluded.

For more context see -> https://n8nio.slack.com/archives/C07BV4T1P6Y/p1743554653872829

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3610/bug-models-do-not-load-when-using-the-n8n-free-openai-api-credits

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
