### PR TITLE
fix(editor): Send evaluation telemetry event to Posthog

### DIFF
--- a/packages/frontend/editor-ui/src/views/Evaluations.ee/EvaluationsRootView.vue
+++ b/packages/frontend/editor-ui/src/views/Evaluations.ee/EvaluationsRootView.vue
@@ -105,22 +105,30 @@ watch(
 	(ready) => {
 		if (ready) {
 			if (showWizard.value) {
-				telemetry.track('User viewed tests tab', {
-					workflow_id: props.name,
-					test_type: 'evaluation',
-					view: 'setup',
-					trigger_set_up: evaluationStore.evaluationTriggerExists,
-					output_set_up: evaluationStore.evaluationSetOutputsNodeExist,
-					metrics_set_up: evaluationStore.evaluationSetMetricsNodeExist,
-					quota_reached: evaluationsQuotaExceeded.value,
-				});
+				telemetry.track(
+					'User viewed tests tab',
+					{
+						workflow_id: props.name,
+						test_type: 'evaluation',
+						view: 'setup',
+						trigger_set_up: evaluationStore.evaluationTriggerExists,
+						output_set_up: evaluationStore.evaluationSetOutputsNodeExist,
+						metrics_set_up: evaluationStore.evaluationSetMetricsNodeExist,
+						quota_reached: evaluationsQuotaExceeded.value,
+					},
+					{ withPostHog: true },
+				);
 			} else {
-				telemetry.track('User viewed tests tab', {
-					workflow_id: props.name,
-					test_type: 'evaluation',
-					view: 'overview',
-					run_count: runs.value.length,
-				});
+				telemetry.track(
+					'User viewed tests tab',
+					{
+						workflow_id: props.name,
+						test_type: 'evaluation',
+						view: 'overview',
+						run_count: runs.value.length,
+					},
+					{ withPostHog: true },
+				);
 			}
 		}
 	},

--- a/packages/frontend/editor-ui/src/views/Evaluations.ee/tests/EvaluationsRootView.test.ts
+++ b/packages/frontend/editor-ui/src/views/Evaluations.ee/tests/EvaluationsRootView.test.ts
@@ -143,15 +143,19 @@ describe('EvaluationsRootView', () => {
 			renderComponent({ props: { name: mockWorkflow.id } });
 
 			await waitFor(() => {
-				expect(useTelemetry().track).toHaveBeenCalledWith('User viewed tests tab', {
-					workflow_id: mockWorkflow.id,
-					test_type: 'evaluation',
-					view: 'setup',
-					trigger_set_up: false,
-					output_set_up: false,
-					metrics_set_up: false,
-					quota_reached: false,
-				});
+				expect(useTelemetry().track).toHaveBeenCalledWith(
+					'User viewed tests tab',
+					{
+						workflow_id: mockWorkflow.id,
+						test_type: 'evaluation',
+						view: 'setup',
+						trigger_set_up: false,
+						output_set_up: false,
+						metrics_set_up: false,
+						quota_reached: false,
+					},
+					{ withPostHog: true },
+				);
 			});
 		});
 
@@ -171,12 +175,16 @@ describe('EvaluationsRootView', () => {
 			renderComponent({ props: { name: mockWorkflow.id } });
 
 			await waitFor(() => {
-				expect(useTelemetry().track).toHaveBeenCalledWith('User viewed tests tab', {
-					workflow_id: mockWorkflow.id,
-					test_type: 'evaluation',
-					view: 'overview',
-					run_count: 2,
-				});
+				expect(useTelemetry().track).toHaveBeenCalledWith(
+					'User viewed tests tab',
+					{
+						workflow_id: mockWorkflow.id,
+						test_type: 'evaluation',
+						view: 'overview',
+						run_count: 2,
+					},
+					{ withPostHog: true },
+				);
 			});
 		});
 
@@ -212,15 +220,19 @@ describe('EvaluationsRootView', () => {
 			renderComponent({ props: { name: mockWorkflow.id } });
 
 			await waitFor(() => {
-				expect(useTelemetry().track).toHaveBeenCalledWith('User viewed tests tab', {
-					workflow_id: mockWorkflow.id,
-					test_type: 'evaluation',
-					view: 'setup',
-					trigger_set_up: true,
-					output_set_up: false,
-					metrics_set_up: false,
-					quota_reached: false,
-				});
+				expect(useTelemetry().track).toHaveBeenCalledWith(
+					'User viewed tests tab',
+					{
+						workflow_id: mockWorkflow.id,
+						test_type: 'evaluation',
+						view: 'setup',
+						trigger_set_up: true,
+						output_set_up: false,
+						metrics_set_up: false,
+						quota_reached: false,
+					},
+					{ withPostHog: true },
+				);
 			});
 		});
 
@@ -262,15 +274,19 @@ describe('EvaluationsRootView', () => {
 			renderComponent({ props: { name: mockWorkflow.id } });
 
 			await waitFor(() => {
-				expect(useTelemetry().track).toHaveBeenCalledWith('User viewed tests tab', {
-					workflow_id: mockWorkflow.id,
-					test_type: 'evaluation',
-					view: 'setup',
-					trigger_set_up: false,
-					output_set_up: true,
-					metrics_set_up: false,
-					quota_reached: false,
-				});
+				expect(useTelemetry().track).toHaveBeenCalledWith(
+					'User viewed tests tab',
+					{
+						workflow_id: mockWorkflow.id,
+						test_type: 'evaluation',
+						view: 'setup',
+						trigger_set_up: false,
+						output_set_up: true,
+						metrics_set_up: false,
+						quota_reached: false,
+					},
+					{ withPostHog: true },
+				);
 			});
 		});
 
@@ -312,15 +328,19 @@ describe('EvaluationsRootView', () => {
 			renderComponent({ props: { name: mockWorkflow.id } });
 
 			await waitFor(() => {
-				expect(useTelemetry().track).toHaveBeenCalledWith('User viewed tests tab', {
-					workflow_id: mockWorkflow.id,
-					test_type: 'evaluation',
-					view: 'setup',
-					trigger_set_up: false,
-					output_set_up: false,
-					metrics_set_up: true,
-					quota_reached: false,
-				});
+				expect(useTelemetry().track).toHaveBeenCalledWith(
+					'User viewed tests tab',
+					{
+						workflow_id: mockWorkflow.id,
+						test_type: 'evaluation',
+						view: 'setup',
+						trigger_set_up: false,
+						output_set_up: false,
+						metrics_set_up: true,
+						quota_reached: false,
+					},
+					{ withPostHog: true },
+				);
 			});
 		});
 
@@ -340,15 +360,19 @@ describe('EvaluationsRootView', () => {
 			renderComponent({ props: { name: mockWorkflow.id } });
 
 			await waitFor(() => {
-				expect(useTelemetry().track).toHaveBeenCalledWith('User viewed tests tab', {
-					workflow_id: mockWorkflow.id,
-					test_type: 'evaluation',
-					view: 'setup',
-					trigger_set_up: false,
-					output_set_up: false,
-					metrics_set_up: false,
-					quota_reached: true,
-				});
+				expect(useTelemetry().track).toHaveBeenCalledWith(
+					'User viewed tests tab',
+					{
+						workflow_id: mockWorkflow.id,
+						test_type: 'evaluation',
+						view: 'setup',
+						trigger_set_up: false,
+						output_set_up: false,
+						metrics_set_up: false,
+						quota_reached: true,
+					},
+					{ withPostHog: true },
+				);
 			});
 		});
 	});


### PR DESCRIPTION
## Summary

Added `withPostHog` flag to the 'User viewed tests tab' telemetry event.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-1023/event-user-viewed-tests-tab-is-not-being-sent-to-posthog


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
