### PR TITLE
perf(core): Populate cache only with static webhooks

### DIFF
--- a/packages/@n8n/db/src/repositories/webhook.repository.ts
+++ b/packages/@n8n/db/src/repositories/webhook.repository.ts
@@ -1,5 +1,5 @@
 import { Service } from '@n8n/di';
-import { DataSource, Repository } from '@n8n/typeorm';
+import { DataSource, IsNull, Repository } from '@n8n/typeorm';
 
 import { WebhookEntity } from '../entities';
 
@@ -7,5 +7,13 @@ import { WebhookEntity } from '../entities';
 export class WebhookRepository extends Repository<WebhookEntity> {
 	constructor(dataSource: DataSource) {
 		super(WebhookEntity, dataSource.manager);
+	}
+
+	/**
+	 * Retrieve all webhooks whose paths only have static segments, e.g. `{uuid}` or `user/profile`.
+	 * This excludes webhooks having paths with dynamic segments, e.g. `{uuid}/user/:id/posts`.
+	 */
+	async getStaticWebhooks() {
+		return await this.findBy({ webhookId: IsNull() });
 	}
 }

--- a/packages/cli/src/webhooks/webhook.service.ts
+++ b/packages/cli/src/webhooks/webhook.service.ts
@@ -32,11 +32,11 @@ export class WebhookService {
 	) {}
 
 	async populateCache() {
-		const allWebhooks = await this.webhookRepository.find();
+		const staticWebhooks = await this.webhookRepository.getStaticWebhooks();
 
-		if (!allWebhooks) return;
+		if (staticWebhooks.length === 0) return;
 
-		void this.cacheService.setMany(allWebhooks.map((w) => [w.cacheKey, w]));
+		void this.cacheService.setMany(staticWebhooks.map((w) => [w.cacheKey, w]));
 	}
 
 	async findAll() {


### PR DESCRIPTION
## Summary

This PR excludes dynamic webhooks when priming the cache on startup, to rule this out as a cause for [this issue](https://linear.app/n8n/issue/CAT-772/webhook-gets-de-registered-for-touristical#comment-55b94852) with intermittent 404s on dynamic webhooks. Dynamic webhook paths contain segments like `/:id/` where caching is of little benefit.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-772

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
