### PR TITLE
fix(editor): Position executions filter popover so that it doesn't hide executions

### DIFF
--- a/packages/frontend/editor-ui/src/components/executions/workflow/WorkflowExecutionsSidebar.vue
+++ b/packages/frontend/editor-ui/src/components/executions/workflow/WorkflowExecutionsSidebar.vue
@@ -211,7 +211,7 @@ const goToUpgrade = () => {
 			>
 				{{ i18n.baseText('executionsList.autoRefresh') }}
 			</el-checkbox>
-			<ExecutionsFilter popover-placement="left-start" @filter-changed="onFilterChanged" />
+			<ExecutionsFilter popover-placement="right-start" @filter-changed="onFilterChanged" />
 		</div>
 		<div
 			ref="executionListRef"

--- a/packages/frontend/editor-ui/src/styles/_animations.scss
+++ b/packages/frontend/editor-ui/src/styles/_animations.scss
@@ -1,15 +1,18 @@
 .executions-list-move,
-.executions-list-enter-active,
-.executions-list-leave-active {
+.executions-list-enter-active {
 	transition: all 1.5s cubic-bezier(0.19, 1, 0.22, 1);
 }
 
-.executions-list-enter-from,
-.executions-list-leave-to {
+.executions-list-leave-active {
+	transition: all 0.3s cubic-bezier(0.19, 1, 0.22, 1);
+	position: absolute;
+}
+
+.executions-list-enter-from {
 	opacity: 0;
 	transform: translateX(-100px);
 }
 
-.executions-list-leave-active {
-	position: absolute;
+.executions-list-leave-to {
+	opacity: 0;
 }

--- a/packages/frontend/editor-ui/src/styles/_animations.scss
+++ b/packages/frontend/editor-ui/src/styles/_animations.scss
@@ -4,7 +4,7 @@
 }
 
 .executions-list-leave-active {
-	transition: all 0.3s cubic-bezier(0.19, 1, 0.22, 1);
+	transition: none;
 	position: absolute;
 }
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Open the executions filter to the right of the button so that it doesn't hide the executions list while open.

Doing so revealed some ugliness, the leave animation was way too long and looked weird

https://github.com/user-attachments/assets/d1df1277-b0b7-4fce-b0f8-e561b454cd72

So I made it faster & not translate back to left, instead just moving and disappearing up.

https://github.com/user-attachments/assets/a241dedf-0a04-4429-9e86-933a18e1c13f

This animation isn't perfect either, but it is still an improvement - at least in my opinion.

The ticket also mentions this filter not closing if user clicks outside it. The filter popover seems to close correctly if user clicks outside it on any regular UI elements, but not if they click on the canvas - I'm assuming the canvas prevents the click event and popover doesn't become aware of it, and I'm not spend time looking for a fix on it now I think. Now that the popover doesn't cover most of the normal UI elements this should be less of an issue.

Third suggestion on that ticket is starting to list available Execution Data keys on the picker. We don't have that data efficiently available and while a backend for it could be added + we could change the component to a a picker that fetches options from backend, but I think that's unrelated to this PR.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/ADO-3608/feature-open-execution-filters-modal-in-the-right

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
