### PR TITLE
ci: Fix InstanceType import in DeprecationService tests

### DIFF
--- a/packages/cli/src/deprecation/__tests__/deprecation.service.test.ts
+++ b/packages/cli/src/deprecation/__tests__/deprecation.service.test.ts
@@ -1,8 +1,8 @@
 import type { Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
+import type { InstanceType } from '@n8n/constants';
 import { captor, mock } from 'jest-mock-extended';
 import { InstanceSettings } from 'n8n-core';
-import type { InstanceType } from 'n8n-core';
 
 import config from '@/config';
 import { mockInstance } from '@test/mocking';


### PR DESCRIPTION
## Summary

#15960 did not have the latest `master` merged in, so this issue wasn't caught by the CI.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
