### PR TITLE
feat(Vector Store Retriever Node): Add reranker support to retriever for QA chain

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/retrievers/RetrieverVectorStore/test/RetrieverVectorStore.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/retrievers/RetrieverVectorStore/test/RetrieverVectorStore.node.test.ts
@@ -46,7 +46,7 @@ describe('RetrieverVectorStore', () => {
 				0,
 			);
 			expect(mockVectorStore.asRetriever).toHaveBeenCalledWith(4);
-			expect(result.response).toBeDefined();
+			expect(result).toHaveProperty('response', { test: 'retriever' });
 		});
 
 		it('should create a retriever with custom topK parameter', async () => {
@@ -62,7 +62,7 @@ describe('RetrieverVectorStore', () => {
 			const result = await retrieverNode.supplyData.call(mockContext, 0);
 
 			expect(mockVectorStore.asRetriever).toHaveBeenCalledWith(10);
-			expect(result.response).toBeDefined();
+			expect(result).toHaveProperty('response', { test: 'retriever' });
 		});
 
 		it('should create a ContextualCompressionRetriever when input contains reranker and vectorStore', async () => {
@@ -120,15 +120,14 @@ describe('RetrieverVectorStore', () => {
 			mockVectorStore.asRetriever = jest.fn().mockReturnValue({ test: 'retriever' });
 
 			mockContext.getNodeParameter.mockImplementation((_param, _itemIndex, defaultValue) => {
-				return defaultValue; // Always return default value
+				return defaultValue;
 			});
 			mockContext.getInputConnectionData.mockResolvedValue(mockVectorStore);
 
-			const result = await retrieverNode.supplyData.call(mockContext, 0);
+			await retrieverNode.supplyData.call(mockContext, 0);
 
 			expect(mockContext.getNodeParameter).toHaveBeenCalledWith('topK', 0, 4);
 			expect(mockVectorStore.asRetriever).toHaveBeenCalledWith(4);
-			expect(result.response).toBeDefined();
 		});
 	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/retrievers/RetrieverVectorStore/test/RetrieverVectorStore.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/retrievers/RetrieverVectorStore/test/RetrieverVectorStore.node.test.ts
@@ -1,0 +1,134 @@
+import type { BaseDocumentCompressor } from '@langchain/core/retrievers/document_compressors';
+import { VectorStore } from '@langchain/core/vectorstores';
+import { ContextualCompressionRetriever } from 'langchain/retrievers/contextual_compression';
+import type { ISupplyDataFunctions } from 'n8n-workflow';
+import { NodeConnectionTypes } from 'n8n-workflow';
+
+import { RetrieverVectorStore } from '../RetrieverVectorStore.node';
+
+const mockLogger = {
+	debug: jest.fn(),
+	info: jest.fn(),
+	warn: jest.fn(),
+	error: jest.fn(),
+};
+
+describe('RetrieverVectorStore', () => {
+	let retrieverNode: RetrieverVectorStore;
+	let mockContext: jest.Mocked<ISupplyDataFunctions>;
+
+	beforeEach(() => {
+		retrieverNode = new RetrieverVectorStore();
+		mockContext = {
+			logger: mockLogger,
+			getNodeParameter: jest.fn(),
+			getInputConnectionData: jest.fn(),
+		} as unknown as jest.Mocked<ISupplyDataFunctions>;
+		jest.clearAllMocks();
+	});
+
+	describe('supplyData', () => {
+		it('should create a retriever from a basic VectorStore', async () => {
+			const mockVectorStore = Object.create(VectorStore.prototype) as VectorStore;
+			mockVectorStore.asRetriever = jest.fn().mockReturnValue({ test: 'retriever' });
+
+			mockContext.getNodeParameter.mockImplementation((param, _itemIndex, defaultValue) => {
+				if (param === 'topK') return 4;
+				return defaultValue;
+			});
+
+			mockContext.getInputConnectionData.mockResolvedValue(mockVectorStore);
+
+			const result = await retrieverNode.supplyData.call(mockContext, 0);
+
+			expect(mockContext.getInputConnectionData).toHaveBeenCalledWith(
+				NodeConnectionTypes.AiVectorStore,
+				0,
+			);
+			expect(mockVectorStore.asRetriever).toHaveBeenCalledWith(4);
+			expect(result.response).toBeDefined();
+		});
+
+		it('should create a retriever with custom topK parameter', async () => {
+			const mockVectorStore = Object.create(VectorStore.prototype) as VectorStore;
+			mockVectorStore.asRetriever = jest.fn().mockReturnValue({ test: 'retriever' });
+
+			mockContext.getNodeParameter.mockImplementation((param, _itemIndex, defaultValue) => {
+				if (param === 'topK') return 10;
+				return defaultValue;
+			});
+			mockContext.getInputConnectionData.mockResolvedValue(mockVectorStore);
+
+			const result = await retrieverNode.supplyData.call(mockContext, 0);
+
+			expect(mockVectorStore.asRetriever).toHaveBeenCalledWith(10);
+			expect(result.response).toBeDefined();
+		});
+
+		it('should create a ContextualCompressionRetriever when input contains reranker and vectorStore', async () => {
+			const mockVectorStore = Object.create(VectorStore.prototype) as VectorStore;
+			mockVectorStore.asRetriever = jest.fn().mockReturnValue({ test: 'base-retriever' });
+
+			const mockReranker = {} as BaseDocumentCompressor;
+
+			const inputWithReranker = {
+				reranker: mockReranker,
+				vectorStore: mockVectorStore,
+			};
+
+			mockContext.getNodeParameter.mockImplementation((param, _itemIndex, defaultValue) => {
+				if (param === 'topK') return 4;
+				return defaultValue;
+			});
+			mockContext.getInputConnectionData.mockResolvedValue(inputWithReranker);
+
+			const result = await retrieverNode.supplyData.call(mockContext, 0);
+
+			expect(mockContext.getInputConnectionData).toHaveBeenCalledWith(
+				NodeConnectionTypes.AiVectorStore,
+				0,
+			);
+			expect(mockVectorStore.asRetriever).toHaveBeenCalledWith(4);
+			expect(result.response).toBeInstanceOf(ContextualCompressionRetriever);
+		});
+
+		it('should create a ContextualCompressionRetriever with custom topK when using reranker', async () => {
+			const mockVectorStore = Object.create(VectorStore.prototype) as VectorStore;
+			mockVectorStore.asRetriever = jest.fn().mockReturnValue({ test: 'base-retriever' });
+
+			const mockReranker = {} as BaseDocumentCompressor;
+
+			const inputWithReranker = {
+				reranker: mockReranker,
+				vectorStore: mockVectorStore,
+			};
+
+			mockContext.getNodeParameter.mockImplementation((param, _itemIndex, defaultValue) => {
+				if (param === 'topK') return 8;
+				return defaultValue;
+			});
+			mockContext.getInputConnectionData.mockResolvedValue(inputWithReranker);
+
+			const result = await retrieverNode.supplyData.call(mockContext, 0);
+
+			expect(mockVectorStore.asRetriever).toHaveBeenCalledWith(8);
+			expect(result.response).toBeInstanceOf(ContextualCompressionRetriever);
+		});
+
+		it('should use default topK value when parameter is not provided', async () => {
+			const mockVectorStore = Object.create(VectorStore.prototype) as VectorStore;
+			mockVectorStore.asRetriever = jest.fn().mockReturnValue({ test: 'retriever' });
+
+			mockContext.getNodeParameter.mockImplementation((_param, _itemIndex, defaultValue) => {
+				return defaultValue; // Always return default value
+			});
+			mockContext.getInputConnectionData.mockResolvedValue(mockVectorStore);
+
+			const result = await retrieverNode.supplyData.call(mockContext, 0);
+
+			expect(mockContext.getNodeParameter).toHaveBeenCalledWith('topK', 0, 4);
+			expect(mockVectorStore.asRetriever).toHaveBeenCalledWith(4);
+			expect(result.response).toBeDefined();
+		});
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/__snapshots__/createVectorStoreNode.test.ts.snap
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/__snapshots__/createVectorStoreNode.test.ts.snap
@@ -44,7 +44,7 @@ exports[`createVectorStoreNode retrieve mode supplies vector store as data 1`] =
 				const useReranker = parameters?.useReranker;
 				const inputs = [{ displayName: "Embedding", type: "ai_embedding", required: true, maxConnections: 1}]
 
-				if (['load', 'retrieve-as-tool'].includes(mode) && useReranker) {
+				if (['load', 'retrieve', 'retrieve-as-tool'].includes(mode) && useReranker) {
 					inputs.push({ displayName: "Reranker", type: "ai_reranker", required: true, maxConnections: 1})
 				}
 
@@ -246,6 +246,7 @@ exports[`createVectorStoreNode retrieve mode supplies vector store as data 1`] =
         "show": {
           "mode": [
             "load",
+            "retrieve",
             "retrieve-as-tool",
           ],
         },

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/createVectorStoreNode.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/createVectorStoreNode.ts
@@ -72,7 +72,7 @@ export const createVectorStoreNode = <T extends VectorStore = VectorStore>(
 				const useReranker = parameters?.useReranker;
 				const inputs = [{ displayName: "Embedding", type: "${NodeConnectionTypes.AiEmbedding}", required: true, maxConnections: 1}]
 
-				if (['load', 'retrieve-as-tool'].includes(mode) && useReranker) {
+				if (['load', 'retrieve', 'retrieve-as-tool'].includes(mode) && useReranker) {
 					inputs.push({ displayName: "Reranker", type: "${NodeConnectionTypes.AiReranker}", required: true, maxConnections: 1})
 				}
 
@@ -215,7 +215,7 @@ export const createVectorStoreNode = <T extends VectorStore = VectorStore>(
 					description: 'Whether or not to rerank results',
 					displayOptions: {
 						show: {
-							mode: ['load', 'retrieve-as-tool'],
+							mode: ['load', 'retrieve', 'retrieve-as-tool'],
 						},
 					},
 				},

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/operations/__tests__/retrieveOperation.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/operations/__tests__/retrieveOperation.test.ts
@@ -100,10 +100,8 @@ describe('handleRetrieveOperation', () => {
 
 		const result = await handleRetrieveOperation(mockContext, mockArgs, mockEmbeddings, 0);
 
-		// Should check useReranker parameter
 		expect(mockContext.getNodeParameter).toHaveBeenCalledWith('useReranker', 0, false);
 
-		// Should get vector store client with filters
 		expect(mockArgs.getVectorStoreClient).toHaveBeenCalledWith(
 			mockContext,
 			{ testFilter: 'value' },
@@ -115,9 +113,6 @@ describe('handleRetrieveOperation', () => {
 		expect(result).toHaveProperty('response', mockVectorStore);
 		expect(result).toHaveProperty('closeFunction');
 
-		// Should wrap vector store with logWrapper
-		expect(logWrapper).toHaveBeenCalledWith(mockVectorStore, mockContext);
-
 		// Should not try to get reranker input connection
 		expect(mockContext.getInputConnectionData).not.toHaveBeenCalled();
 	});
@@ -128,31 +123,17 @@ describe('handleRetrieveOperation', () => {
 
 		const result = await handleRetrieveOperation(mockContext, mockArgs, mockEmbeddings, 0);
 
-		// Should check useReranker parameter
 		expect(mockContext.getNodeParameter).toHaveBeenCalledWith('useReranker', 0, false);
 
-		// Should get reranker from input connection
 		expect(mockContext.getInputConnectionData).toHaveBeenCalledWith(
 			NodeConnectionTypes.AiReranker,
 			0,
 		);
 
-		// Should get vector store client with filters
-		expect(mockArgs.getVectorStoreClient).toHaveBeenCalledWith(
-			mockContext,
-			{ testFilter: 'value' },
-			mockEmbeddings,
-			0,
-		);
-
-		// Result should contain reranker and vector store object
 		expect(result.response).toEqual({
 			reranker: mockReranker,
 			vectorStore: mockVectorStore,
 		});
 		expect(result).toHaveProperty('closeFunction');
-
-		// Should wrap vector store with logWrapper for the vectorStore property
-		expect(logWrapper).toHaveBeenCalledWith(mockVectorStore, mockContext);
 	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/operations/__tests__/retrieveOperation.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/operations/__tests__/retrieveOperation.test.ts
@@ -1,8 +1,10 @@
 import type { Embeddings } from '@langchain/core/embeddings';
+import type { BaseDocumentCompressor } from '@langchain/core/retrievers/document_compressors';
 import type { VectorStore } from '@langchain/core/vectorstores';
 import type { MockProxy } from 'jest-mock-extended';
 import { mock } from 'jest-mock-extended';
 import type { ISupplyDataFunctions } from 'n8n-workflow';
+import { NodeConnectionTypes } from 'n8n-workflow';
 
 import { logWrapper } from '@utils/logWrapper';
 
@@ -22,14 +24,18 @@ describe('handleRetrieveOperation', () => {
 	let mockContext: MockProxy<ISupplyDataFunctions>;
 	let mockEmbeddings: MockProxy<Embeddings>;
 	let mockVectorStore: MockProxy<VectorStore>;
+	let mockReranker: MockProxy<BaseDocumentCompressor>;
 	let mockArgs: VectorStoreNodeConstructorArgs<VectorStore>;
 
 	beforeEach(() => {
 		mockContext = mock<ISupplyDataFunctions>();
+		mockContext.getNodeParameter.mockReturnValue(false); // Default useReranker to false
 
 		mockEmbeddings = mock<Embeddings>();
 
 		mockVectorStore = mock<VectorStore>();
+
+		mockReranker = mock<BaseDocumentCompressor>();
 
 		mockArgs = {
 			meta: {
@@ -87,5 +93,66 @@ describe('handleRetrieveOperation', () => {
 
 		// Call the closeFunction - should not throw error even with no release method
 		await expect(result.closeFunction!()).resolves.not.toThrow();
+	});
+
+	it('should retrieve vector store without reranker when useReranker is false', async () => {
+		mockContext.getNodeParameter.mockReturnValue(false);
+
+		const result = await handleRetrieveOperation(mockContext, mockArgs, mockEmbeddings, 0);
+
+		// Should check useReranker parameter
+		expect(mockContext.getNodeParameter).toHaveBeenCalledWith('useReranker', 0, false);
+
+		// Should get vector store client with filters
+		expect(mockArgs.getVectorStoreClient).toHaveBeenCalledWith(
+			mockContext,
+			{ testFilter: 'value' },
+			mockEmbeddings,
+			0,
+		);
+
+		// Result should contain vector store and close function
+		expect(result).toHaveProperty('response', mockVectorStore);
+		expect(result).toHaveProperty('closeFunction');
+
+		// Should wrap vector store with logWrapper
+		expect(logWrapper).toHaveBeenCalledWith(mockVectorStore, mockContext);
+
+		// Should not try to get reranker input connection
+		expect(mockContext.getInputConnectionData).not.toHaveBeenCalled();
+	});
+
+	it('should retrieve vector store with reranker when useReranker is true', async () => {
+		mockContext.getNodeParameter.mockReturnValue(true);
+		mockContext.getInputConnectionData.mockResolvedValue(mockReranker);
+
+		const result = await handleRetrieveOperation(mockContext, mockArgs, mockEmbeddings, 0);
+
+		// Should check useReranker parameter
+		expect(mockContext.getNodeParameter).toHaveBeenCalledWith('useReranker', 0, false);
+
+		// Should get reranker from input connection
+		expect(mockContext.getInputConnectionData).toHaveBeenCalledWith(
+			NodeConnectionTypes.AiReranker,
+			0,
+		);
+
+		// Should get vector store client with filters
+		expect(mockArgs.getVectorStoreClient).toHaveBeenCalledWith(
+			mockContext,
+			{ testFilter: 'value' },
+			mockEmbeddings,
+			0,
+		);
+
+		// Result should contain reranker and vector store object
+		expect(result.response).toEqual({
+			reranker: mockReranker,
+			vectorStore: mockVectorStore,
+		});
+		expect(result).toHaveProperty('closeFunction');
+
+		// Should wrap vector store with logWrapper for the vectorStore property
+		expect(logWrapper).toHaveBeenCalledWith(mockVectorStore, mockContext);
 	});
 });


### PR DESCRIPTION
## Summary
This PR adds support for rerankers in the retrieve operation of vector stores that's used by QA chain nodes. 

Changes in retrieve operation:
- Get and return reranker and VectorStore if reranker is connected
- Only return VectorStore otherwise

Changes in Vector Store Retriever Node:
- Handle response from the vector store operation (with and without reranker)
- With reranker build a ContextualCompressionRetriever which combines the base retriever (vector store) and a compressor (here the reranker) and calls them internally in the correct way
- Without a passed reranker it will behave as before
 
## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-1019/add-reranker-support-to-retrieverqa-chain


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
