### PR TITLE
fix: Postgres node with ssh tunnel getting into a broken state and not being recreated

### DIFF
--- a/packages/@n8n/config/src/configs/logging.config.ts
+++ b/packages/@n8n/config/src/configs/logging.config.ts
@@ -18,6 +18,7 @@ export const LOG_SCOPES = [
 	'task-runner',
 	'insights',
 	'workflow-activation',
+	'ssh-client',
 ] as const;
 
 export type LogScope = (typeof LOG_SCOPES)[number];

--- a/packages/core/src/execution-engine/__tests__/ssh-clients-manager.test.ts
+++ b/packages/core/src/execution-engine/__tests__/ssh-clients-manager.test.ts
@@ -1,34 +1,43 @@
+import type { Logger } from '@n8n/backend-common';
 import { mock } from 'jest-mock-extended';
 import type { SSHCredentials } from 'n8n-workflow';
 import { Client } from 'ssh2';
 
 import { SSHClientsManager } from '../ssh-clients-manager';
 
-describe('SSHClientsManager', () => {
-	const idleTimeout = 5 * 60;
-	const credentials: SSHCredentials = {
-		sshAuthenticateWith: 'password',
-		sshHost: 'example.com',
-		sshPort: 22,
-		sshUser: 'username',
-		sshPassword: 'password',
-	};
+const idleTimeout = 5 * 60;
+const cleanUpInterval = 60;
+const credentials: SSHCredentials = {
+	sshAuthenticateWith: 'password',
+	sshHost: 'example.com',
+	sshPort: 22,
+	sshUser: 'username',
+	sshPassword: 'password',
+};
 
-	let sshClientsManager: SSHClientsManager;
-	const connectSpy = jest.spyOn(Client.prototype, 'connect');
-	const endSpy = jest.spyOn(Client.prototype, 'end');
+let sshClientsManager: SSHClientsManager;
+const connectSpy = jest.spyOn(Client.prototype, 'connect');
+const endSpy = jest.spyOn(Client.prototype, 'end');
 
-	beforeEach(() => {
-		jest.clearAllMocks();
-		jest.useFakeTimers();
+beforeEach(() => {
+	jest.clearAllMocks();
+	jest.useFakeTimers();
 
-		sshClientsManager = new SSHClientsManager(mock({ idleTimeout }));
-		connectSpy.mockImplementation(function (this: Client) {
-			this.emit('ready');
-			return this;
-		});
+	sshClientsManager = new SSHClientsManager(
+		mock({ idleTimeout }),
+		mock<Logger>({ scoped: () => mock<Logger>() }),
+	);
+	connectSpy.mockImplementation(function (this: Client) {
+		this.emit('ready');
+		return this;
 	});
+});
 
+afterEach(() => {
+	sshClientsManager.onShutdown();
+});
+
+describe('getClient', () => {
 	it('should create a new SSH client', async () => {
 		const client = await sshClientsManager.getClient(credentials);
 
@@ -48,23 +57,113 @@ describe('SSHClientsManager', () => {
 
 		expect(client1).toBe(client2);
 	});
+});
 
-	it('should close all SSH connections on process exit', async () => {
+describe('onShutdown', () => {
+	it('should close all SSH connections when onShutdown is called', async () => {
 		await sshClientsManager.getClient(credentials);
 		sshClientsManager.onShutdown();
 
 		expect(endSpy).toHaveBeenCalledTimes(1);
 	});
 
-	it('should cleanup stale SSH connections', async () => {
-		await sshClientsManager.getClient({ ...credentials, sshHost: 'host1' });
-		await sshClientsManager.getClient({ ...credentials, sshHost: 'host2' });
-		await sshClientsManager.getClient({ ...credentials, sshHost: 'host3' });
+	it('should close all SSH connections on process exit', async () => {
+		// ARRANGE
+		await sshClientsManager.getClient(credentials);
 
-		jest.advanceTimersByTime((idleTimeout + 1) * 1000);
-		sshClientsManager.cleanupStaleConnections();
+		// ACT
+		// @ts-expect-error we're not supposed to emit `exit` so it's missing from
+		// the type definition
+		process.emit('exit');
 
-		expect(endSpy).toHaveBeenCalledTimes(3);
-		expect(sshClientsManager.clients.size).toBe(0);
+		// ASSERT
+		expect(endSpy).toHaveBeenCalledTimes(1);
+	});
+});
+
+it('should cleanup stale SSH connections', async () => {
+	await sshClientsManager.getClient({ ...credentials, sshHost: 'host1' });
+	await sshClientsManager.getClient({ ...credentials, sshHost: 'host2' });
+	await sshClientsManager.getClient({ ...credentials, sshHost: 'host3' });
+
+	jest.advanceTimersByTime((idleTimeout + cleanUpInterval + 1) * 1000);
+
+	expect(endSpy).toHaveBeenCalledTimes(3);
+	expect(sshClientsManager.clients.size).toBe(0);
+});
+
+describe('updateLastUsed', () => {
+	test('updates lastUsed in the registration', async () => {
+		// ARRANGE
+		const client = await sshClientsManager.getClient(credentials);
+		// schedule client for clean up soon
+		jest.advanceTimersByTime((idleTimeout - 1) * 1000);
+
+		// ACT 1
+		// updating lastUsed should prevent the clean up
+		sshClientsManager.updateLastUsed(client);
+		jest.advanceTimersByTime(idleTimeout * 1000);
+
+		// ASSERT 1
+		expect(endSpy).toHaveBeenCalledTimes(0);
+
+		// ACT 1
+		jest.advanceTimersByTime(cleanUpInterval * 1000);
+
+		// ASSERT 1
+		expect(endSpy).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('abort controller', () => {
+	test('call `abort` when the client emits `error`', async () => {
+		// ARRANGE
+		const abortController = new AbortController();
+		const client = await sshClientsManager.getClient(credentials, abortController);
+
+		// ACT 1
+		client.emit('error', new Error());
+
+		// ASSERT 1
+		expect(abortController.signal.aborted).toBe(true);
+		expect(endSpy).toHaveBeenCalledTimes(1);
+	});
+
+	test('call `abort` when the client emits `end`', async () => {
+		// ARRANGE
+		const abortController = new AbortController();
+		const client = await sshClientsManager.getClient(credentials, abortController);
+
+		// ACT 1
+		client.emit('end');
+
+		// ASSERT 1
+		expect(abortController.signal.aborted).toBe(true);
+		expect(endSpy).toHaveBeenCalledTimes(1);
+	});
+
+	test('call `abort` when the client emits `close`', async () => {
+		// ARRANGE
+		const abortController = new AbortController();
+		const client = await sshClientsManager.getClient(credentials, abortController);
+
+		// ACT 1
+		client.emit('close');
+
+		// ASSERT 1
+		expect(abortController.signal.aborted).toBe(true);
+		expect(endSpy).toHaveBeenCalledTimes(1);
+	});
+
+	test('closes client when `abort` is being called', async () => {
+		// ARRANGE
+		const abortController = new AbortController();
+		await sshClientsManager.getClient(credentials, abortController);
+
+		// ACT 1
+		abortController.abort();
+
+		// ASSERT 1
+		expect(endSpy).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/ssh-tunnel-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/ssh-tunnel-helper-functions.test.ts
@@ -7,6 +7,7 @@ import { SSHClientsManager } from '../../../ssh-clients-manager';
 import { getSSHTunnelFunctions } from '../ssh-tunnel-helper-functions';
 
 describe('getSSHTunnelFunctions', () => {
+	const abortController = new AbortController();
 	const credentials = mock<SSHCredentials>();
 	const sshClientsManager = mockInstance(SSHClientsManager);
 	const sshTunnelFunctions = getSSHTunnelFunctions();
@@ -17,9 +18,9 @@ describe('getSSHTunnelFunctions', () => {
 
 	describe('getSSHClient', () => {
 		it('should invoke sshClientsManager.getClient', async () => {
-			await sshTunnelFunctions.getSSHClient(credentials);
+			await sshTunnelFunctions.getSSHClient(credentials, abortController);
 
-			expect(sshClientsManager.getClient).toHaveBeenCalledWith(credentials);
+			expect(sshClientsManager.getClient).toHaveBeenCalledWith(credentials, abortController);
 		});
 	});
 });

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/ssh-tunnel-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/ssh-tunnel-helper-functions.test.ts
@@ -23,4 +23,17 @@ describe('getSSHTunnelFunctions', () => {
 			expect(sshClientsManager.getClient).toHaveBeenCalledWith(credentials, abortController);
 		});
 	});
+
+	describe('updateLastUsed', () => {
+		it('should invoke sshClientsManager.updateLastUsed', async () => {
+			// ARRANGE
+			const client = await sshTunnelFunctions.getSSHClient(credentials, abortController);
+
+			// ACT
+			sshTunnelFunctions.updateLastUsed(client);
+
+			// ASSERT
+			expect(sshClientsManager.updateLastUsed).toHaveBeenCalledWith(client);
+		});
+	});
 });

--- a/packages/core/src/execution-engine/node-execution-context/utils/ssh-tunnel-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/ssh-tunnel-helper-functions.ts
@@ -6,6 +6,7 @@ import { SSHClientsManager } from '../../ssh-clients-manager';
 export const getSSHTunnelFunctions = (): SSHTunnelFunctions => {
 	const sshClientsManager = Container.get(SSHClientsManager);
 	return {
-		getSSHClient: async (credentials) => await sshClientsManager.getClient(credentials),
+		getSSHClient: async (credentials, abortController) =>
+			await sshClientsManager.getClient(credentials, abortController),
 	};
 };

--- a/packages/core/src/execution-engine/node-execution-context/utils/ssh-tunnel-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/ssh-tunnel-helper-functions.ts
@@ -1,5 +1,6 @@
 import { Container } from '@n8n/di';
 import type { SSHTunnelFunctions } from 'n8n-workflow';
+import type { Client } from 'ssh2';
 
 import { SSHClientsManager } from '../../ssh-clients-manager';
 
@@ -8,5 +9,6 @@ export const getSSHTunnelFunctions = (): SSHTunnelFunctions => {
 	return {
 		getSSHClient: async (credentials, abortController) =>
 			await sshClientsManager.getClient(credentials, abortController),
+		updateLastUsed: (client: Client) => sshClientsManager.updateLastUsed(client),
 	};
 };

--- a/packages/core/src/execution-engine/ssh-clients-manager.ts
+++ b/packages/core/src/execution-engine/ssh-clients-manager.ts
@@ -30,7 +30,7 @@ export class SSHClientsManager {
 
 	readonly clientsReversed = new WeakMap<Client, string>();
 
-	private cleanupTimer: NodeJS.Timer;
+	private cleanupTimer: NodeJS.Timeout;
 
 	constructor(
 		private readonly config: SSHClientsConfig,

--- a/packages/core/src/execution-engine/ssh-clients-manager.ts
+++ b/packages/core/src/execution-engine/ssh-clients-manager.ts
@@ -56,6 +56,14 @@ export class SSHClientsManager {
 			if (registration) {
 				registration.lastUsed = new Date();
 			}
+		} else {
+			const metadata = {};
+			// eslint-disable-next-line @typescript-eslint/unbound-method
+			Error.captureStackTrace(metadata, this.updateLastUsed);
+			this.logger.warn(
+				'Tried to update `lastUsed` for a client that has been cleaned up already. Probably forgot to subscribe to the AbortController somewhere.',
+				metadata,
+			);
 		}
 	}
 

--- a/packages/core/src/execution-engine/ssh-clients-manager.ts
+++ b/packages/core/src/execution-engine/ssh-clients-manager.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@n8n/backend-common';
 import { Config, Env } from '@n8n/config';
 import { Service } from '@n8n/di';
 import type { SSHCredentials } from 'n8n-workflow';
@@ -11,11 +12,26 @@ class SSHClientsConfig {
 	idleTimeout: number = 5 * 60;
 }
 
+type Registration = {
+	client: Client;
+
+	/**
+	 * We keep this timestamp to check if a client hasn't been used in a while,
+	 * and if it needs to be closed.
+	 */
+	lastUsed: Date;
+
+	abortController: AbortController;
+};
+
 @Service()
 export class SSHClientsManager {
-	readonly clients = new Map<string, { client: Client; lastUsed: Date }>();
+	readonly clients = new Map<string, Registration>();
 
-	constructor(private readonly config: SSHClientsConfig) {
+	constructor(
+		private readonly config: SSHClientsConfig,
+		private readonly logger: Logger,
+	) {
 		// Close all SSH connections when the process exits
 		process.on('exit', () => this.onShutdown());
 
@@ -23,9 +39,13 @@ export class SSHClientsManager {
 
 		// Regularly close stale SSH connections
 		setInterval(() => this.cleanupStaleConnections(), 60 * 1000);
+
+		this.logger = logger.scoped('ssh-client');
 	}
 
-	async getClient(credentials: SSHCredentials): Promise<Client> {
+	async getClient(credentials: SSHCredentials, abortController?: AbortController): Promise<Client> {
+		abortController = abortController ?? new AbortController();
+
 		const { sshAuthenticateWith, sshHost, sshPort, sshUser } = credentials;
 		const sshConfig: ConnectConfig = {
 			host: sshHost,
@@ -48,14 +68,14 @@ export class SSHClientsManager {
 		}
 
 		return await new Promise((resolve, reject) => {
-			const sshClient = new Client();
+			const sshClient = this.withCleanupHandler(new Client(), abortController, clientHash);
 			sshClient.once('error', reject);
 			sshClient.once('ready', () => {
 				sshClient.off('error', reject);
-				sshClient.once('close', () => this.clients.delete(clientHash));
 				this.clients.set(clientHash, {
 					client: sshClient,
 					lastUsed: new Date(),
+					abortController,
 				});
 				resolve(sshClient);
 			});
@@ -63,9 +83,48 @@ export class SSHClientsManager {
 		});
 	}
 
+	/**
+	 * Registers the cleanup handler for events (error, close, end) on the ssh
+	 * client and in the abort signal is received.
+	 */
+	private withCleanupHandler(sshClient: Client, abortController: AbortController, key: string) {
+		sshClient.on('error', (error) => {
+			this.logger.error('encountered error, calling cleanup', { error });
+			this.cleanupClient(key);
+		});
+		sshClient.on('end', () => {
+			this.logger.debug('socket was disconnected, calling abort signal', {});
+			this.cleanupClient(key);
+		});
+		sshClient.on('close', () => {
+			this.logger.debug('socket was closed, calling abort signal', {});
+			this.cleanupClient(key);
+		});
+		abortController.signal.addEventListener('abort', () => {
+			this.logger.debug('Got abort signal, cleaning up ssh client.', {
+				reason: abortController.signal.reason,
+			});
+			this.cleanupClient(key);
+		});
+
+		return sshClient;
+	}
+
+	private cleanupClient(key: string) {
+		const registration = this.clients.get(key);
+		if (registration) {
+			this.clients.delete(key);
+			registration.client.end();
+			if (!registration.abortController.signal.aborted) {
+				registration.abortController.abort();
+			}
+		}
+	}
+
 	onShutdown() {
-		for (const { client } of this.clients.values()) {
-			client.end();
+		this.logger.debug('Shutting down. Cleaning up all clients');
+		for (const key of this.clients.keys()) {
+			this.cleanupClient(key);
 		}
 	}
 
@@ -74,10 +133,10 @@ export class SSHClientsManager {
 		if (clients.size === 0) return;
 
 		const now = Date.now();
-		for (const [hash, { client, lastUsed }] of clients.entries()) {
+		for (const [key, { lastUsed }] of clients.entries()) {
 			if (now - lastUsed.getTime() > this.config.idleTimeout * 1000) {
-				client.end();
-				clients.delete(hash);
+				this.logger.debug('Found stale client. Cleaning it up.');
+				this.cleanupClient(key);
 			}
 		}
 	}

--- a/packages/nodes-base/nodes/Postgres/transport/index.ts
+++ b/packages/nodes-base/nodes/Postgres/transport/index.ts
@@ -165,5 +165,10 @@ export async function configurePostgres(
 		nodeType: 'postgres',
 		nodeVersion: options.nodeVersion as unknown as string,
 		fallBackHandler,
+		wasUsed: ({ sshClient }) => {
+			if (sshClient) {
+				this.helpers.updateLastUsed(sshClient);
+			}
+		},
 	});
 }

--- a/packages/nodes-base/utils/__tests__/connection-pool-manager.test.ts
+++ b/packages/nodes-base/utils/__tests__/connection-pool-manager.test.ts
@@ -1,26 +1,31 @@
+import { mock } from 'jest-mock-extended';
+import { OperationalError, type Logger } from 'n8n-workflow';
+
 import { ConnectionPoolManager } from '@utils/connection-pool-manager';
 
 const ttl = 5 * 60 * 1000;
 const cleanUpInterval = 60 * 1000;
 
+const logger = mock<Logger>();
+
 let cpm: ConnectionPoolManager;
 
 beforeAll(() => {
 	jest.useFakeTimers();
-	cpm = ConnectionPoolManager.getInstance();
+	cpm = ConnectionPoolManager.getInstance(logger);
 });
 
 beforeEach(async () => {
-	await cpm.purgeConnections();
+	cpm.purgeConnections();
 });
 
 afterAll(() => {
-	cpm.onShutdown();
+	cpm.purgeConnections();
 });
 
 test('getInstance returns a singleton', () => {
-	const instance1 = ConnectionPoolManager.getInstance();
-	const instance2 = ConnectionPoolManager.getInstance();
+	const instance1 = ConnectionPoolManager.getInstance(logger);
+	const instance2 = ConnectionPoolManager.getInstance(logger);
 
 	expect(instance1).toBe(instance2);
 });
@@ -29,25 +34,28 @@ describe('getConnection', () => {
 	test('calls fallBackHandler only once and returns the first value', async () => {
 		// ARRANGE
 		const connectionType = {};
-		const fallBackHandler = jest.fn().mockResolvedValue(connectionType);
-		const cleanUpHandler = jest.fn();
+		const fallBackHandler = jest.fn(async () => {
+			return connectionType;
+		});
+
 		const options = {
 			credentials: {},
 			nodeType: 'example',
 			nodeVersion: '1',
 			fallBackHandler,
-			cleanUpHandler,
+			// TODO: test wasUsed
+			wasUsed: jest.fn(),
 		};
 
 		// ACT 1
-		const connection = await cpm.getConnection<string>(options);
+		const connection = await cpm.getConnection(options);
 
 		// ASSERT 1
 		expect(fallBackHandler).toHaveBeenCalledTimes(1);
 		expect(connection).toBe(connectionType);
 
 		// ACT 2
-		const connection2 = await cpm.getConnection<string>(options);
+		const connection2 = await cpm.getConnection(options);
 		// ASSERT 2
 		expect(fallBackHandler).toHaveBeenCalledTimes(1);
 		expect(connection2).toBe(connectionType);
@@ -56,27 +64,29 @@ describe('getConnection', () => {
 	test('creates different pools for different node versions', async () => {
 		// ARRANGE
 		const connectionType1 = {};
-		const fallBackHandler1 = jest.fn().mockResolvedValue(connectionType1);
-		const cleanUpHandler1 = jest.fn();
+		const fallBackHandler1 = jest.fn(async () => {
+			return connectionType1;
+		});
 
 		const connectionType2 = {};
-		const fallBackHandler2 = jest.fn().mockResolvedValue(connectionType2);
-		const cleanUpHandler2 = jest.fn();
+		const fallBackHandler2 = jest.fn(async () => {
+			return connectionType2;
+		});
 
 		// ACT 1
-		const connection1 = await cpm.getConnection<string>({
+		const connection1 = await cpm.getConnection({
 			credentials: {},
 			nodeType: 'example',
 			nodeVersion: '1',
 			fallBackHandler: fallBackHandler1,
-			cleanUpHandler: cleanUpHandler1,
+			wasUsed: jest.fn(),
 		});
-		const connection2 = await cpm.getConnection<string>({
+		const connection2 = await cpm.getConnection({
 			credentials: {},
 			nodeType: 'example',
 			nodeVersion: '2',
 			fallBackHandler: fallBackHandler2,
-			cleanUpHandler: cleanUpHandler2,
+			wasUsed: jest.fn(),
 		});
 
 		// ASSERT
@@ -92,21 +102,54 @@ describe('getConnection', () => {
 	test('calls cleanUpHandler after TTL expires', async () => {
 		// ARRANGE
 		const connectionType = {};
-		const fallBackHandler = jest.fn().mockResolvedValue(connectionType);
-		const cleanUpHandler = jest.fn();
-		await cpm.getConnection<string>({
+		let abortController: AbortController | undefined;
+		const fallBackHandler = jest.fn(async (ac: AbortController) => {
+			abortController = ac;
+			return connectionType;
+		});
+		await cpm.getConnection({
 			credentials: {},
 			nodeType: 'example',
 			nodeVersion: '1',
 			fallBackHandler,
-			cleanUpHandler,
+			wasUsed: jest.fn(),
 		});
 
 		// ACT
 		jest.advanceTimersByTime(ttl + cleanUpInterval * 2);
 
 		// ASSERT
-		expect(cleanUpHandler).toHaveBeenCalledTimes(1);
+		if (abortController === undefined) {
+			fail("abortController haven't been initialized");
+		}
+		expect(abortController.signal.aborted).toBe(true);
+	});
+
+	test('throws OperationsError if the fallBackHandler aborts during connection initialization', async () => {
+		// ARRANGE
+		const connectionType = {};
+		let abortController: AbortController | undefined;
+		const fallBackHandler = jest.fn(async (ac: AbortController) => {
+			ac.abort();
+			abortController = ac;
+			return connectionType;
+		});
+
+		// ACT
+		const connectionPromise = cpm.getConnection({
+			credentials: {},
+			nodeType: 'example',
+			nodeVersion: '1',
+			fallBackHandler,
+			wasUsed: jest.fn(),
+		});
+
+		// ASSERT
+
+		await expect(connectionPromise).rejects.toThrow(OperationalError);
+		await expect(connectionPromise).rejects.toThrow(
+			'Could not create pool. Connection attempt was aborted.',
+		);
 	});
 });
 
@@ -114,66 +157,115 @@ describe('onShutdown', () => {
 	test('calls all clean up handlers', async () => {
 		// ARRANGE
 		const connectionType1 = {};
-		const fallBackHandler1 = jest.fn().mockResolvedValue(connectionType1);
-		const cleanUpHandler1 = jest.fn();
-		await cpm.getConnection<string>({
+		let abortController1: AbortController | undefined;
+		const fallBackHandler1 = jest.fn(async (ac: AbortController) => {
+			abortController1 = ac;
+			return connectionType1;
+		});
+		await cpm.getConnection({
 			credentials: {},
 			nodeType: 'example',
 			nodeVersion: '1',
 			fallBackHandler: fallBackHandler1,
-			cleanUpHandler: cleanUpHandler1,
+			wasUsed: jest.fn(),
 		});
 
 		const connectionType2 = {};
-		const fallBackHandler2 = jest.fn().mockResolvedValue(connectionType2);
-		const cleanUpHandler2 = jest.fn();
-		await cpm.getConnection<string>({
+		let abortController2: AbortController | undefined;
+		const fallBackHandler2 = jest.fn(async (ac: AbortController) => {
+			abortController2 = ac;
+			return connectionType2;
+		});
+		await cpm.getConnection({
 			credentials: {},
 			nodeType: 'example',
 			nodeVersion: '2',
 			fallBackHandler: fallBackHandler2,
-			cleanUpHandler: cleanUpHandler2,
+			wasUsed: jest.fn(),
 		});
 
-		// ACT 1
-		cpm.onShutdown();
+		// ACT
+		cpm.purgeConnections();
 
 		// ASSERT
-		expect(cleanUpHandler1).toHaveBeenCalledTimes(1);
-		expect(cleanUpHandler2).toHaveBeenCalledTimes(1);
+		if (abortController1 === undefined || abortController2 === undefined) {
+			fail("abortController haven't been initialized");
+		}
+		expect(abortController1.signal.aborted).toBe(true);
+		expect(abortController2.signal.aborted).toBe(true);
 	});
 
 	test('calls all clean up handlers when `exit` is emitted on process', async () => {
 		// ARRANGE
 		const connectionType1 = {};
-		const fallBackHandler1 = jest.fn().mockResolvedValue(connectionType1);
-		const cleanUpHandler1 = jest.fn();
-		await cpm.getConnection<string>({
+		let abortController1: AbortController | undefined;
+		const fallBackHandler1 = jest.fn(async (ac: AbortController) => {
+			abortController1 = ac;
+			return connectionType1;
+		});
+		await cpm.getConnection({
 			credentials: {},
 			nodeType: 'example',
 			nodeVersion: '1',
 			fallBackHandler: fallBackHandler1,
-			cleanUpHandler: cleanUpHandler1,
+			wasUsed: jest.fn(),
 		});
 
 		const connectionType2 = {};
-		const fallBackHandler2 = jest.fn().mockResolvedValue(connectionType2);
-		const cleanUpHandler2 = jest.fn();
-		await cpm.getConnection<string>({
+		let abortController2: AbortController | undefined;
+		const fallBackHandler2 = jest.fn(async (ac: AbortController) => {
+			abortController2 = ac;
+			return connectionType2;
+		});
+		await cpm.getConnection({
 			credentials: {},
 			nodeType: 'example',
 			nodeVersion: '2',
 			fallBackHandler: fallBackHandler2,
-			cleanUpHandler: cleanUpHandler2,
+			wasUsed: jest.fn(),
 		});
 
-		// ACT 1
+		// ACT
 		// @ts-expect-error we're not supposed to emit `exit` so it's missing from
 		// the type definition
 		process.emit('exit');
 
 		// ASSERT
-		expect(cleanUpHandler1).toHaveBeenCalledTimes(1);
-		expect(cleanUpHandler2).toHaveBeenCalledTimes(1);
+		if (abortController1 === undefined || abortController2 === undefined) {
+			fail("abortController haven't been initialized");
+		}
+		expect(abortController1.signal.aborted).toBe(true);
+		expect(abortController2.signal.aborted).toBe(true);
+	});
+});
+
+describe('wasUsed', () => {
+	test('is called for every successive `getConnection` call', async () => {
+		// ARRANGE
+		const connectionType = {};
+		const fallBackHandler = jest.fn(async () => {
+			return connectionType;
+		});
+
+		const wasUsed = jest.fn();
+		const options = {
+			credentials: {},
+			nodeType: 'example',
+			nodeVersion: '1',
+			fallBackHandler,
+			wasUsed,
+		};
+
+		// ACT 1
+		await cpm.getConnection(options);
+
+		// ASSERT 1
+		expect(wasUsed).toHaveBeenCalledTimes(0);
+
+		// ACT 2
+		await cpm.getConnection(options);
+
+		// ASSERT 2
+		expect(wasUsed).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/nodes-base/utils/__tests__/connection-pool-manager.test.ts
+++ b/packages/nodes-base/utils/__tests__/connection-pool-manager.test.ts
@@ -128,10 +128,8 @@ describe('getConnection', () => {
 	test('throws OperationsError if the fallBackHandler aborts during connection initialization', async () => {
 		// ARRANGE
 		const connectionType = {};
-		let abortController: AbortController | undefined;
 		const fallBackHandler = jest.fn(async (ac: AbortController) => {
 			ac.abort();
-			abortController = ac;
 			return connectionType;
 		});
 

--- a/packages/nodes-base/utils/__tests__/connection-pool-manager.test.ts
+++ b/packages/nodes-base/utils/__tests__/connection-pool-manager.test.ts
@@ -43,7 +43,6 @@ describe('getConnection', () => {
 			nodeType: 'example',
 			nodeVersion: '1',
 			fallBackHandler,
-			// TODO: test wasUsed
 			wasUsed: jest.fn(),
 		};
 

--- a/packages/nodes-base/utils/connection-pool-manager.ts
+++ b/packages/nodes-base/utils/connection-pool-manager.ts
@@ -1,4 +1,6 @@
 import { createHash } from 'crypto';
+import { OperationsError } from 'ldapts';
+import { type Logger } from 'n8n-workflow';
 
 let instance: ConnectionPoolManager;
 
@@ -15,19 +17,19 @@ type RegistrationOptions = {
 };
 
 type GetConnectionOption<Pool> = RegistrationOptions & {
-	/** When a node requests for a connection pool, but none is available, this handler is called to create new instance of the pool, which then cached and re-used until it goes stale.  */
-	fallBackHandler: () => Promise<Pool>;
-
-	/** When a pool hasn't been used in a while, or when the server is shutting down, this handler is invoked to close the pool */
-	cleanUpHandler: (pool: Pool) => Promise<void>;
+	/**
+	 * When a node requests for a connection pool, but none is available, this
+	 * handler is called to create new instance of the pool, which is then cached
+	 * and re-used until it goes stale.
+	 */
+	fallBackHandler: (abortController: AbortController) => Promise<Pool>;
 };
 
 type Registration<Pool> = {
 	/** This is an instance of a Connection Pool class, that gets reused across multiple executions */
 	pool: Pool;
 
-	/** @see GetConnectionOption['closeHandler'] */
-	cleanUpHandler: (pool: Pool) => Promise<void>;
+	abortController: AbortController;
 
 	/** We keep this timestamp to check if a pool hasn't been used in a while, and if it needs to be closed */
 	lastUsed: number;
@@ -38,9 +40,9 @@ export class ConnectionPoolManager {
 	 * Gets the singleton instance of the ConnectionPoolManager.
 	 * Creates a new instance if one doesn't exist.
 	 */
-	static getInstance(): ConnectionPoolManager {
+	static getInstance(logger: Logger): ConnectionPoolManager {
 		if (!instance) {
-			instance = new ConnectionPoolManager();
+			instance = new ConnectionPoolManager(logger);
 		}
 		return instance;
 	}
@@ -51,9 +53,12 @@ export class ConnectionPoolManager {
 	 * Private constructor that initializes the connection pool manager.
 	 * Sets up cleanup handlers for process exit and stale connections.
 	 */
-	private constructor() {
+	private constructor(private readonly logger: Logger) {
 		// Close all open pools when the process exits
-		process.on('exit', () => this.onShutdown());
+		process.on('exit', () => {
+			this.logger.debug('ConnectionPoolManager: Shutting down. Cleaning up all pools');
+			this.purgeConnections();
+		});
 
 		// Regularly close stale pools
 		setInterval(() => this.cleanupStaleConnections(), cleanUpInterval);
@@ -84,23 +89,43 @@ export class ConnectionPoolManager {
 		const key = this.makeKey(options);
 
 		let value = this.map.get(key);
-		if (!value) {
-			value = {
-				pool: await options.fallBackHandler(),
-				cleanUpHandler: options.cleanUpHandler,
-			} as Registration<unknown>;
+
+		if (value) {
+			value.lastUsed = Date.now();
+			return value.pool as T;
+		}
+
+		const abortController = new AbortController();
+		value = {
+			pool: await options.fallBackHandler(abortController),
+			abortController,
+		} as Registration<unknown>;
+
+		// It's possible that `options.fallBackHandler` already called the abort
+		// function. If that's the case let's not continue.
+		if (abortController.signal.aborted) {
+			throw new OperationsError(
+				abortController.signal.reason
+					? String(abortController.signal.reason)
+					: 'Could not connect to postgres. Connection attempt was aborted.',
+			);
 		}
 
 		this.map.set(key, { ...value, lastUsed: Date.now() });
+		abortController.signal.addEventListener('abort', async () => {
+			this.logger.debug('ConnectionPoolManager: Got abort signal, cleaning up pool.');
+			this.cleanupConnection(key);
+		});
+
 		return value.pool as T;
 	}
 
-	private async cleanupConnection(key: string) {
+	private cleanupConnection(key: string) {
 		const registration = this.map.get(key);
 
 		if (registration) {
 			this.map.delete(key);
-			await registration.cleanUpHandler(registration.pool);
+			registration.abortController.abort();
 		}
 	}
 
@@ -112,35 +137,19 @@ export class ConnectionPoolManager {
 		const now = Date.now();
 		for (const [key, { lastUsed }] of this.map.entries()) {
 			if (now - lastUsed > ttl) {
-				this.cleanupConnection(key);
-				this.map.delete(key);
+				this.logger.debug('ConnectionPoolManager: Found stale pool. Cleaning it up.');
+				void this.cleanupConnection(key);
 			}
 		}
 	}
 
 	/**
 	 * Removes and cleans up all existing connection pools.
+	 * Connections are closed in the background.
 	 */
-	async purgeConnections(): Promise<void> {
-		await Promise.all(
-			[...this.map.entries()].map(async ([key, value]) => {
-				this.map.delete(key);
-
-				return await value.cleanUpHandler(value.pool);
-			}),
-		);
-	}
-
-	/**
-	 * Cleans up all connection pools when the process is shutting down.
-	 * Does not wait for cleanup promises to resolve also does not remove the
-	 * references from the pool.
-	 *
-	 * Only call this on process shutdown.
-	 */
-	onShutdown() {
-		for (const { cleanUpHandler, pool } of this.map.values()) {
-			void cleanUpHandler(pool);
+	purgeConnections(): void {
+		for (const key of this.map.keys()) {
+			this.cleanupConnection(key);
 		}
 	}
 }

--- a/packages/nodes-base/utils/connection-pool-manager.ts
+++ b/packages/nodes-base/utils/connection-pool-manager.ts
@@ -1,6 +1,5 @@
 import { createHash } from 'crypto';
-import { OperationsError } from 'ldapts';
-import { type Logger } from 'n8n-workflow';
+import { OperationalError, type Logger } from 'n8n-workflow';
 
 let instance: ConnectionPoolManager;
 
@@ -110,11 +109,9 @@ export class ConnectionPoolManager {
 		// It's possible that `options.fallBackHandler` already called the abort
 		// function. If that's the case let's not continue.
 		if (abortController.signal.aborted) {
-			throw new OperationsError(
-				abortController.signal.reason
-					? String(abortController.signal.reason)
-					: 'Could not connect to postgres. Connection attempt was aborted.',
-			);
+			throw new OperationalError('Could not create pool. Connection attempt was aborted.', {
+				cause: abortController.signal.reason,
+			});
 		}
 
 		this.map.set(key, { ...value, lastUsed: Date.now() });

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -830,6 +830,7 @@ export type SSHCredentials = {
 
 export interface SSHTunnelFunctions {
 	getSSHClient(credentials: SSHCredentials, abortController?: AbortController): Promise<SSHClient>;
+	updateLastUsed(client: SSHClient): void;
 }
 
 type CronUnit = number | '*' | `*/${number}`;

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -829,7 +829,7 @@ export type SSHCredentials = {
 );
 
 export interface SSHTunnelFunctions {
-	getSSHClient(credentials: SSHCredentials): Promise<SSHClient>;
+	getSSHClient(credentials: SSHCredentials, abortController?: AbortController): Promise<SSHClient>;
 }
 
 type CronUnit = number | '*' | `*/${number}`;


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Review commit by commit.

- **extract pool clean up logic into private function**
- **remove code that never worked correctly**
- **clean up using an abort controller**
- **bump lastUsed time of ssh clients when the pool lastUsed time is bumped**

**What we're doing:**

1. creating an ssh client, connecting to the server
2. creating a local TCP server as a proxy
3. setting up the proxy to create a port-forwarding from the local port to the remote pg instance through the ssh client
4. creating a pg pool connecting to the local proxy

All packets send to the local proxy are send through the ssh client to the remote pg instance.

We have 3 different connections/servers that need to be maintained:
1. ssh client
2. TCP server
3. pg pool

The TCP server uses a randomly assigned port (we're asking the OS to just give us a port that is free).

**What can go wrong:**

1. If the pg pool looses connection, it will try to create a new one. ✅
2. If the ssh client looses the connection we close the TCP server and never retry to recreate the whole setup. ❌
3. If the TCP server looses the connection we don't do anything (but since that one is fully local, there is a low chance of anything going wrong here)

Additionally we never update the TTL of the ssh client, which means it will always be closed after 5 minutes (the default at least), so we're always creating problem 2 if the pool is used continuously.

I'm assuming this is what happens.

Additional problems are that we don't log anything about the life cycle of theses connections. So we don't know which one of them was closed in which order and why.

**What this PR does:**

Fix the immediate issue of the TTL of the ssh client not being bumped, by adding a `wasUsed` callback that `configurePostgres` can use to update the ssh client's last use. For this I added `SSHClientsManager.updateLastUsed`.

Refactor this to use an AbortController that connects everything and allows everything being cleaned up if one part fails.

Add logs for errors and clean up logic. For that I had to add a logger to the `ConnectionPoolManager` and the `SSHClientsManager`.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
https://linear.app/n8n/issue/CAT-900/community-issue-postgres-node-with-ssh-tunnel-random-connection
https://github.com/n8n-io/n8n/issues/12807

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
