### PR TITLE
docs: Fix docs link in Perplexity credential (no-changelog)

### DIFF
--- a/packages/nodes-base/credentials/PerplexityApi.credentials.ts
+++ b/packages/nodes-base/credentials/PerplexityApi.credentials.ts
@@ -10,7 +10,7 @@ export class PerplexityApi implements ICredentialType {
 
 	displayName = 'Perplexity API';
 
-	documentationUrl = 'https://docs.perplexity.ai';
+	documentationUrl = 'perplexity';
 
 	properties: INodeProperties[] = [
 		{


### PR DESCRIPTION
## Summary

Fixes the docs link in the Perplexity credential to point to our documentation instead of directly to the project's docs.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
