### PR TITLE
fix(editor): Prevent Ask Assistant button overlapping other buttons

### DIFF
--- a/packages/frontend/editor-ui/src/components/AskAssistant/Chat/AskAssistantFloatingButton.vue
+++ b/packages/frontend/editor-ui/src/components/AskAssistant/Chat/AskAssistantFloatingButton.vue
@@ -67,6 +67,13 @@ const onClick = () => {
 	bottom: calc(var(--canvas-panel-height-offset, 0px) + var(--spacing-s));
 	right: var(--spacing-s);
 	z-index: var(--z-index-ask-assistant-floating-button);
+
+	/* Prevent overlap with 'Execute Workflow' / 'Open Chat' buttons on small screens */
+	@include mixins.breakpoint('sm-only') {
+		bottom: calc(
+			var(--canvas-panel-height-offset, 0px) + var(--spacing-s) + var(--spacing-xs) + 42px
+		);
+	}
 }
 
 .tooltip {


### PR DESCRIPTION
## Summary

On small screens Ask AI assistant button would cover the execute workflow / open chat buttons.

Nudge that button up when we hit the small screen media breakpoint, which is when those other buttons get positioned to the right edge.

https://github.com/user-attachments/assets/85433dd4-54b1-4fba-8c3d-d6c32027b3d0

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3601/bug-ai-assistant-button-is-covering-the-stop-execution-button-on-small

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
