### PR TITLE
fix(editor): Maintain back button when installing community nodes

### DIFF
--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/Panel/CommunityNodeDetails.test.ts
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/Panel/CommunityNodeDetails.test.ts
@@ -184,7 +184,6 @@ describe('CommunityNodeDetails', () => {
 				title: 'Node details',
 			},
 			{
-				resetStacks: true,
 				transitionDirection: 'none',
 			},
 		);

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/Panel/CommunityNodeDetails.test.ts
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/Panel/CommunityNodeDetails.test.ts
@@ -30,6 +30,7 @@ const getAllNodeCreateElements = vi.fn(() => [
 
 const popViewStack = vi.fn();
 const pushViewStack = vi.fn();
+const updateCurrentViewStack = vi.fn();
 
 const showError = vi.fn();
 
@@ -114,6 +115,7 @@ vi.mock('../composables/useViewStacks', () => ({
 		},
 		pushViewStack,
 		popViewStack,
+		updateCurrentViewStack,
 		getAllNodeCreateElements,
 	})),
 }));
@@ -148,6 +150,7 @@ describe('CommunityNodeDetails', () => {
 		expect(fetchCredentialTypes).toHaveBeenCalledWith(true);
 		expect(getAllNodeCreateElements).toHaveBeenCalled();
 		expect(popViewStack).toHaveBeenCalled();
+		expect(updateCurrentViewStack).toHaveBeenCalled();
 		expect(pushViewStack).toHaveBeenCalledWith(
 			{
 				communityNodeDetails: {

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/Panel/CommunityNodeDetails.vue
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/Panel/CommunityNodeDetails.vue
@@ -45,7 +45,6 @@ const updateViewStack = (key: string) => {
 		);
 
 		pushViewStack(viewStack, {
-			resetStacks: true,
 			transitionDirection: 'none',
 		});
 	} else {

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/Panel/CommunityNodeDetails.vue
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/Panel/CommunityNodeDetails.vue
@@ -16,7 +16,13 @@ import { prepareCommunityNodeDetailsViewStack, removePreviewToken } from '../uti
 
 import { N8nText } from '@n8n/design-system';
 
-const { activeViewStack, pushViewStack, popViewStack, getAllNodeCreateElements } = useViewStacks();
+const {
+	activeViewStack,
+	pushViewStack,
+	popViewStack,
+	getAllNodeCreateElements,
+	updateCurrentViewStack,
+} = useViewStacks();
 
 const { communityNodeDetails } = activeViewStack;
 
@@ -36,6 +42,8 @@ const updateViewStack = (key: string) => {
 		const nodeActions = nodeCreatorStore.actions?.[installedNode.key] || [];
 
 		popViewStack();
+
+		updateCurrentViewStack({ searchItems: nodeCreatorStore.mergedNodes });
 
 		const viewStack = prepareCommunityNodeDetailsViewStack(
 			installedNode,


### PR DESCRIPTION
## Summary

Maintain back button when installing community nodes. The problem was that verified official community nodes are now part of the `visibleNodeTypes` (see https://linear.app/n8n/issue/NODE-3009/distinguish-official-verified-nodes-from-community-built-ones) and we weren't updating `mergedNodes`, which is derived from `visibleNodeTypes`. 

Updating `mergedNodes` has to be done manually since the root view stack only passes the `mergedNodes` as a value (ie: It is not a `ref` or `computed`). Without doing a manual update, the problem would only be solved for unofficial verified nodes. Hence, we need to manually update the stack to solve the problem for both unofficial verified community nodes and official verified community nodes.

We do not need to worry about unverified nodes because they are not in Strapi, and they do not get displayed in the Node Creator panel.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3034/when-installing-an-official-verified-node-on-1941-and-above-the-nodes

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
