### PR TITLE
fix: Docker remove apk tools from docker image (no-changelog)

### DIFF
--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -67,6 +67,7 @@ RUN \
 
 # Install npm 11.4.1 to fix the vulnerable cross-spawn dependency
 RUN npm install -g npm@11.4.1
+RUN apk --purge del apk-tools
 
 ENV SHELL /bin/sh
 USER node


### PR DESCRIPTION
## Summary

Removes the libapk package manager tools from the final build.

## Related Linear tickets, Github issues, and Community forum posts

https://app.aikido.dev/queue?sidebarIssue=11391896


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
