### PR TITLE
fix(core): Prevent worker from recovering finished executions

### DIFF
--- a/packages/cli/src/executions/__tests__/execution-recovery.service.test.ts
+++ b/packages/cli/src/executions/__tests__/execution-recovery.service.test.ts
@@ -152,6 +152,31 @@ describe('ExecutionRecoveryService', () => {
 				expect(amendedExecution).toBeNull();
 			});
 
+			test('for errored dataful execution, should return `null`', async () => {
+				/**
+				 * Arrange
+				 */
+				const workflow = await createWorkflow();
+				const execution = await createExecution(
+					{ status: 'error', data: stringify({ runData: { foo: 'bar' } }) },
+					workflow,
+				);
+				const messages = setupMessages(execution.id, 'Some workflow');
+
+				/**
+				 * Act
+				 */
+				const amendedExecution = await executionRecoveryService.recoverFromLogs(
+					execution.id,
+					messages,
+				);
+
+				/**
+				 * Assert
+				 */
+				expect(amendedExecution).toBeNull();
+			});
+
 			test('should return `null` if no execution found', async () => {
 				/**
 				 * Arrange

--- a/packages/cli/src/executions/execution-recovery.service.ts
+++ b/packages/cli/src/executions/execution-recovery.service.ts
@@ -72,7 +72,14 @@ export class ExecutionRecoveryService {
 			unflattenData: true,
 		});
 
-		if (!execution || (execution.status === 'success' && execution.data)) return null;
+		/**
+		 * The event bus is unable to correctly identify unfinished executions in workers,
+		 * because execution lifecycle hooks cause worker event logs to be partitioned.
+		 * Hence we need to filter out finished executions here.
+		 * */
+		if (!execution || (['success', 'error'].includes(execution.status) && execution.data)) {
+			return null;
+		}
 
 		const runExecutionData = execution.data ?? { resultData: { runData: {} } };
 


### PR DESCRIPTION
## Summary

Crash recovery has [plenty of known issues](https://linear.app/n8n/issue/CAT-581/bug-crash-handling-functionality-is-broken-main-mode#comment-d542017d) but I found a fundamental one.

Consider this scenario:

- Main enqueues a job for execution 1 whose workflow has an error-handling workflow
- Worker A picks up job, runs execution 1, which throws, finishing with `error` status
- Worker A enqueues job for execution 2, for the error-handling workflow
- Worker B picks up job, runs execution 2 successfully

In this scenario, we end up with inconsistent event logs:

```
n8nEventLog.log (main)
- n8n.workflow.started for execution 1
- n8n.workflow.failed for execution 1

n8nEventLog-worker.log (worker A)
- n8n.node.{started|finished} events for execution 1

n8nEventLog-worker.log (worker B)
- n8n.workflow.started for execution 2
- n8n.node.{started|finished} events for execution 2
- n8n.workflow.success for execution 2
```

This is because of our lifecycle hooks setup:

- Main uses `getLifecycleHooksForScalingMain` which includes `hookFunctionsWorkflowEvents`
- Worker uses `getLifecycleHooksForScalingWorker` which excludes `hookFunctionsWorkflowEvents`
- Subexecutions use `getLifecycleHooksForSubExecutions` which includes `hookFunctionsWorkflowEvents`

This event log inconsistency impacts crash recovery, which assumes all events for an execution are in the event log for a given instance. This means crash recovery [wrongly identifies execution 1 as unfinished](https://github.com/n8n-io/n8n/blob/c229e915eafda0e09c881c46ab921dca46715ef1/packages/cli/src/eventbus/message-event-bus-writer/message-event-bus-log-writer.ts#L220-L240) (instead of finished with an error) leading it to wrongly amend details for a finished execution (instead of skipping it), which will also lead to another crash recovery on the next restart, as the details are incomplete. 

In short, this means every worker tries to recover its own finished failed executions (instead of only unfinished crashed ones), which the worker does not even have the data for, and so this cycle repeats on restart. The root solution would be to straighten out our hooks setup and have event logs for workers remain with workers, but lifecycle hooks are so central and so legacy that this would be a big dedicated effort.

Hence for now, this fix filters out finished executions downstream and defers crash recovery logging until after we know which were the actually recovered execution IDs.

## Related Linear tickets, Github issues, and Community forum posts

n/a

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
