### PR TITLE
fix(core): Ensure queue is ready when enqueueing

### DIFF
--- a/packages/cli/src/__tests__/workflow-runner.test.ts
+++ b/packages/cli/src/__tests__/workflow-runner.test.ts
@@ -1,6 +1,6 @@
 import type { User } from '@n8n/db';
 import type { ExecutionEntity } from '@n8n/db';
-import { Container } from '@n8n/di';
+import { Container, Service } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
 import { DirectedGraph, WorkflowExecute } from 'n8n-core';
 import * as core from 'n8n-core';
@@ -27,7 +27,7 @@ import { ManualExecutionService } from '@/manual-execution.service';
 import { Telemetry } from '@/telemetry';
 import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
 import { WorkflowRunner } from '@/workflow-runner';
-import { mockInstance } from '@test/mocking';
+import { mockInstance, mockLogger } from '@test/mocking';
 import { createExecution } from '@test-integration/db/executions';
 import { createUser } from '@test-integration/db/users';
 import { createWorkflow } from '@test-integration/db/workflows';
@@ -39,6 +39,7 @@ let runner: WorkflowRunner;
 setupTestServer({ endpointGroups: [] });
 
 mockInstance(Telemetry);
+mockLogger();
 
 beforeAll(async () => {
 	owner = await createUser({ role: 'global:owner' });
@@ -256,5 +257,41 @@ describe('run', () => {
 			'1',
 			undefined,
 		);
+	});
+});
+
+describe('enqueueExecution', () => {
+	const setupQueue = jest.fn();
+
+	@Service()
+	class MockScalingService {
+		setupQueue = setupQueue;
+
+		addJob = jest.fn();
+	}
+
+	beforeAll(() => {
+		jest.mock('@/scaling/scaling.service', () => ({
+			ScalingService: MockScalingService,
+		}));
+	});
+
+	afterAll(() => {
+		jest.unmock('@/scaling/scaling.service');
+	});
+
+	it('should setup queue when scalingService is not initialized', async () => {
+		const activeExecutions = Container.get(ActiveExecutions);
+		jest.spyOn(activeExecutions, 'attachWorkflowExecution').mockReturnValue();
+		jest.spyOn(runner, 'processError').mockResolvedValue();
+		const data = mock<IWorkflowExecutionDataProcess>({
+			workflowData: { nodes: [] },
+			executionData: undefined,
+		});
+
+		// @ts-expect-error Private method
+		await runner.enqueueExecution('1', data);
+
+		expect(setupQueue).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/cli/src/__tests__/workflow-runner.test.ts
+++ b/packages/cli/src/__tests__/workflow-runner.test.ts
@@ -27,7 +27,7 @@ import { ManualExecutionService } from '@/manual-execution.service';
 import { Telemetry } from '@/telemetry';
 import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
 import { WorkflowRunner } from '@/workflow-runner';
-import { mockInstance, mockLogger } from '@test/mocking';
+import { mockInstance } from '@test/mocking';
 import { createExecution } from '@test-integration/db/executions';
 import { createUser } from '@test-integration/db/users';
 import { createWorkflow } from '@test-integration/db/workflows';
@@ -39,7 +39,6 @@ let runner: WorkflowRunner;
 setupTestServer({ endpointGroups: [] });
 
 mockInstance(Telemetry);
-mockLogger();
 
 beforeAll(async () => {
 	owner = await createUser({ role: 'global:owner' });

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -55,10 +55,11 @@ export class ScalingService {
 	// #region Lifecycle
 
 	async setupQueue() {
-		if (this.queue) return;
-
 		const { default: BullQueue } = await import('bull');
 		const { RedisClientService } = await import('@/services/redis-client.service');
+
+		if (this.queue) return;
+
 		const service = Container.get(RedisClientService);
 
 		const bullPrefix = this.globalConfig.queue.bull.prefix;

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -55,6 +55,8 @@ export class ScalingService {
 	// #region Lifecycle
 
 	async setupQueue() {
+		if (this.queue) return;
+
 		const { default: BullQueue } = await import('bull');
 		const { RedisClientService } = await import('@/services/redis-client.service');
 		const service = Container.get(RedisClientService);

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -348,6 +348,7 @@ export class WorkflowRunner {
 		if (!this.scalingService) {
 			const { ScalingService } = await import('@/scaling/scaling.service');
 			this.scalingService = Container.get(ScalingService);
+			await this.scalingService.setupQueue();
 		}
 
 		// TODO: For realtime jobs should probably also not do retry or not retry if they are older than x seconds.


### PR DESCRIPTION
## Summary

There are edge cases where `WorkflowRunner` attempts to enqueue before the queue is ready. For legacy reasons `ScalingService` is being dynamically imported in multiple spots, so this is a risk and appears to be related to workers enqueuing executions of error-handling workflows, but I have not been able to reproduce the edge case locally.

This PR ensures the queue is ready when enqueuing. The root solution would be to modularize scaling mode and remove its multiple dynamic imports, and so that all code paths relying on scaling mode are guaranteed that scaling mode init is complete. Adi made an attempt at #11278 but was not satisfied. 

Let's fix this now for the time being and work towards modularizing scaling mode when time allows.

## Related Linear tickets, Github issues, and Community forum posts


https://linear.app/n8n/issue/CAT-784
Fix #15233

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
