### PR TITLE
feat(core): Dynamic max page size limit for pagination dto

### DIFF
--- a/packages/@n8n/api-types/src/dto/insights/__tests__/list-workflow-query.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/insights/__tests__/list-workflow-query.dto.test.ts
@@ -44,6 +44,19 @@ describe('ListInsightsWorkflowQueryDto', () => {
 					sortBy: 'total:desc',
 				},
 			},
+			{
+				name: 'limit take to 100',
+				request: {
+					skip: '0',
+					take: '200',
+					sortBy: 'total:asc',
+				},
+				parsedResult: {
+					skip: 0,
+					take: 100,
+					sortBy: 'total:asc',
+				},
+			},
 		])('should validate $name', ({ request, parsedResult }) => {
 			const result = ListInsightsWorkflowQueryDto.safeParse(request);
 			expect(result.success).toBe(true);

--- a/packages/@n8n/api-types/src/dto/insights/list-workflow-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/insights/list-workflow-query.dto.ts
@@ -2,7 +2,9 @@ import { z } from 'zod';
 import { Z } from 'zod-class';
 
 import { InsightsDateFilterDto } from './date-filter.dto';
-import { paginationSchema } from '../pagination/pagination.dto';
+import { createTakeValidator, skipValidator } from '../pagination/pagination.dto';
+
+export const MAX_ITEMS_PER_PAGE = 100;
 
 const VALID_SORT_OPTIONS = [
 	'total:asc',
@@ -30,7 +32,8 @@ const sortByValidator = z
 	.optional();
 
 export class ListInsightsWorkflowQueryDto extends Z.class({
-	...paginationSchema,
+	skip: skipValidator,
+	take: createTakeValidator(MAX_ITEMS_PER_PAGE),
 	dateRange: InsightsDateFilterDto.shape.dateRange,
 	sortBy: sortByValidator,
 }) {}

--- a/packages/@n8n/api-types/src/dto/insights/list-workflow-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/insights/list-workflow-query.dto.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { Z } from 'zod-class';
 
 import { InsightsDateFilterDto } from './date-filter.dto';
-import { createTakeValidator, skipValidator } from '../pagination/pagination.dto';
+import { createTakeValidator, paginationSchema } from '../pagination/pagination.dto';
 
 export const MAX_ITEMS_PER_PAGE = 100;
 
@@ -32,7 +32,7 @@ const sortByValidator = z
 	.optional();
 
 export class ListInsightsWorkflowQueryDto extends Z.class({
-	skip: skipValidator,
+	...paginationSchema,
 	take: createTakeValidator(MAX_ITEMS_PER_PAGE),
 	dateRange: InsightsDateFilterDto.shape.dateRange,
 	sortBy: sortByValidator,

--- a/packages/@n8n/api-types/src/dto/pagination/__tests__/pagination.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/pagination/__tests__/pagination.dto.test.ts
@@ -1,4 +1,4 @@
-import { PaginationDto, MAX_ITEMS_PER_PAGE } from '../pagination.dto';
+import { PaginationDto, MAX_ITEMS_PER_PAGE, createTakeValidator } from '../pagination.dto';
 
 describe('PaginationDto', () => {
 	describe('valid inputs', () => {
@@ -130,6 +130,19 @@ describe('PaginationDto', () => {
 			expect(result.success).toBe(true);
 			if (result.success) {
 				expect(result.data.take).toBe(10);
+			}
+		});
+	});
+
+	describe('createTakeValidator', () => {
+		test('should create a take validator with custom maxItems', () => {
+			const customMaxItems = 100;
+			const customTakeValidator = createTakeValidator(customMaxItems);
+			const result = customTakeValidator.safeParse('150');
+
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data).toBe(customMaxItems);
 			}
 		});
 	});

--- a/packages/@n8n/api-types/src/dto/pagination/pagination.dto.ts
+++ b/packages/@n8n/api-types/src/dto/pagination/pagination.dto.ts
@@ -3,7 +3,7 @@ import { Z } from 'zod-class';
 
 export const MAX_ITEMS_PER_PAGE = 50;
 
-export const skipValidator = z
+const skipValidator = z
 	.string()
 	.optional()
 	.transform((val) => (val ? parseInt(val, 10) : 0))
@@ -27,7 +27,7 @@ export const createTakeValidator = (maxItems: number) =>
 		})
 		.transform((val) => Math.min(val, maxItems));
 
-const paginationSchema = {
+export const paginationSchema = {
 	skip: skipValidator,
 	take: createTakeValidator(MAX_ITEMS_PER_PAGE),
 };

--- a/packages/@n8n/api-types/src/dto/pagination/pagination.dto.ts
+++ b/packages/@n8n/api-types/src/dto/pagination/pagination.dto.ts
@@ -3,7 +3,7 @@ import { Z } from 'zod-class';
 
 export const MAX_ITEMS_PER_PAGE = 50;
 
-const skipValidator = z
+export const skipValidator = z
 	.string()
 	.optional()
 	.transform((val) => (val ? parseInt(val, 10) : 0))
@@ -14,21 +14,22 @@ const skipValidator = z
 		message: 'Param `skip` must be a non-negative integer',
 	});
 
-const takeValidator = z
-	.string()
-	.optional()
-	.transform((val) => (val ? parseInt(val, 10) : 10))
-	.refine((val) => !isNaN(val) && Number.isInteger(val), {
-		message: 'Param `take` must be a valid integer',
-	})
-	.refine((val) => val >= 0, {
-		message: 'Param `take` must be a non-negative integer',
-	})
-	.transform((val) => Math.min(val, MAX_ITEMS_PER_PAGE));
+export const createTakeValidator = (maxItems: number) =>
+	z
+		.string()
+		.optional()
+		.transform((val) => (val ? parseInt(val, 10) : 10))
+		.refine((val) => !isNaN(val) && Number.isInteger(val), {
+			message: 'Param `take` must be a valid integer',
+		})
+		.refine((val) => val >= 0, {
+			message: 'Param `take` must be a non-negative integer',
+		})
+		.transform((val) => Math.min(val, maxItems));
 
-export const paginationSchema = {
+const paginationSchema = {
 	skip: skipValidator,
-	take: takeValidator,
+	take: createTakeValidator(MAX_ITEMS_PER_PAGE),
 };
 
 export class PaginationDto extends Z.class(paginationSchema) {}


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Make the max page size dynamic when parsing the pagination DTO, because insights require a max page size of 100.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2924/insights-table-page-size-does-not-work

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
