### PR TITLE
fix(editor): Hide the Github stars button when telemetry is disabled

### DIFF
--- a/packages/frontend/editor-ui/src/components/MainHeader/MainHeader.vue
+++ b/packages/frontend/editor-ui/src/components/MainHeader/MainHeader.vue
@@ -86,8 +86,15 @@ const readOnly = computed(() => sourceControlStore.preferences.branchReadOnly);
 const isEnterprise = computed(
 	() => settingsStore.isQueueModeEnabled && settingsStore.isWorkerViewAvailable,
 );
+const isTelemetryEnabled = computed((): boolean => {
+	return settingsStore.isTelemetryEnabled;
+});
 const showGitHubButton = computed(
-	() => !isEnterprise.value && !settingsStore.settings.inE2ETests && !githubButtonHidden.value,
+	() =>
+		!isEnterprise.value &&
+		!settingsStore.settings.inE2ETests &&
+		!githubButtonHidden.value &&
+		isTelemetryEnabled.value,
 );
 
 const parentFolderForBreadcrumbs = computed<FolderShortInfo | undefined>(() => {


### PR DESCRIPTION
## Summary

This PR hides the Github stars widget when N8N_DIAGNOSTICS_ENABLED=false

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-3096/do-not-load-the-github-stars-widget-in-the-ui


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
