### PR TITLE
refactor(editor): Migrate `sso` to `@n8n/rest-api-client` (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/rest-api-client/src/api/index.ts
+++ b/packages/frontend/@n8n/rest-api-client/src/api/index.ts
@@ -8,5 +8,6 @@ export * from './nodeTypes';
 export * from './npsSurvey';
 export * from './orchestration';
 export * from './roles';
+export * from './sso';
 export * from './ui';
 export * from './webhooks';

--- a/packages/frontend/@n8n/rest-api-client/src/api/sso.ts
+++ b/packages/frontend/@n8n/rest-api-client/src/api/sso.ts
@@ -1,7 +1,12 @@
 import type { SamlPreferences, SamlToggleDto } from '@n8n/api-types';
-import { makeRestApiRequest } from '@n8n/rest-api-client';
-import type { SamlPreferencesExtractedData } from '@/Interface';
-import type { IRestApiContext } from '@n8n/rest-api-client';
+
+import type { IRestApiContext } from '../types';
+import { makeRestApiRequest } from '../utils';
+
+export type SamlPreferencesExtractedData = {
+	entityID: string;
+	returnUrl: string;
+};
 
 export const initSSO = async (context: IRestApiContext, redirectUrl = ''): Promise<string> => {
 	return await makeRestApiRequest(context, 'GET', `/sso/saml/initsso?redirect=${redirectUrl}`);

--- a/packages/frontend/editor-ui/src/Interface.ts
+++ b/packages/frontend/editor-ui/src/Interface.ts
@@ -1368,11 +1368,6 @@ export type ExecutionsQueryFilter = {
 	vote?: ExecutionFilterVote;
 };
 
-export type SamlPreferencesExtractedData = {
-	entityID: string;
-	returnUrl: string;
-};
-
 export declare namespace Cloud {
 	export interface PlanData {
 		planId: number;

--- a/packages/frontend/editor-ui/src/__tests__/server/endpoints/sso.ts
+++ b/packages/frontend/editor-ui/src/__tests__/server/endpoints/sso.ts
@@ -1,7 +1,7 @@
 import type { SamlPreferences } from '@n8n/api-types';
 import type { Server, Request } from 'miragejs';
 import { Response } from 'miragejs';
-import type { SamlPreferencesExtractedData } from '@/Interface';
+import type { SamlPreferencesExtractedData } from '@n8n/rest-api-client/api/sso';
 import { faker } from '@faker-js/faker';
 import type { AppSchema } from '@/__tests__/server/types';
 import { jsonParse } from 'n8n-workflow';

--- a/packages/frontend/editor-ui/src/stores/sso.store.ts
+++ b/packages/frontend/editor-ui/src/stores/sso.store.ts
@@ -5,8 +5,8 @@ import { defineStore } from 'pinia';
 import { EnterpriseEditionFeature } from '@/constants';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useSettingsStore } from '@/stores/settings.store';
-import * as ssoApi from '@/api/sso';
-import type { SamlPreferencesExtractedData } from '@/Interface';
+import * as ssoApi from '@n8n/rest-api-client/api/sso';
+import type { SamlPreferencesExtractedData } from '@n8n/rest-api-client/api/sso';
 import { updateCurrentUser } from '@/api/users';
 import { useUsersStore } from '@/stores/users.store';
 

--- a/packages/frontend/editor-ui/src/views/SettingsSso.test.ts
+++ b/packages/frontend/editor-ui/src/views/SettingsSso.test.ts
@@ -12,7 +12,7 @@ import { createComponentRenderer } from '@/__tests__/render';
 import { EnterpriseEditionFeature } from '@/constants';
 import { nextTick } from 'vue';
 import { usePageRedirectionHelper } from '@/composables/usePageRedirectionHelper';
-import type { SamlPreferencesExtractedData } from '@/Interface';
+import type { SamlPreferencesExtractedData } from '@n8n/rest-api-client/api/sso';
 
 const renderView = createComponentRenderer(SettingsSso);
 


### PR DESCRIPTION
## Summary

Migrated `sso` to `@n8n/rest-api-client` 

## Related Linear tickets, Github issues, and Community forum posts


https://linear.app/n8n/issue/N8N-8590/migrate-sso-to-n8nrest-api-client

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
