### PR TITLE
Update README.md link to `docker compose` example

### DIFF
--- a/docker/images/n8n/README.md
+++ b/docker/images/n8n/README.md
@@ -121,7 +121,7 @@ docker run -it --rm \
  docker.n8n.io/n8nio/n8n
 ```
 
-A full working setup with docker-compose can be found [here](https://github.com/n8n-io/n8n-hosting/blob/main/docker-compose/withPostgres/README.md).
+A full working setup with docker-compose can be found [here](https://github.com/n8n-io/n8n-hosting/blob/main/docker-compose/withPostgres/).
 
 ## Passing sensitive data using files
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This is a small change that updates the current link from the main Readme to the "n8n with PostgreSQL" example: linking to the folder instead of the README file itself makes it easier to quickly see the docker compose file.


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
