### PR TITLE
fix(Chat Memory Manager Node): Fix simplifyMessages to not overwrite consecutive messages of same type

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryManager/MemoryManager.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryManager/MemoryManager.node.ts
@@ -18,40 +18,26 @@ interface MessageRecord {
 	hideFromUI: boolean;
 }
 
-export function simplifyMessages(messages: BaseMessage[]) {
-	// This function strips the content of the messages to a simple format and
-	// simplifies the messages by grouping them based on their type
-	// and returning an array of objects where each object contains messages of different types.
+export function simplifyMessages(messages: BaseMessage[]): Array<Record<string, MessageContent>> {
 	if (messages.length === 0) return [];
 
-	const result = [];
-	let i = 0;
+	const result: Array<Record<string, MessageContent>> = [];
+	let index = 0;
 
-	while (i < messages.length) {
+	while (index < messages.length) {
 		const currentGroup: Record<string, MessageContent> = {};
-		const currentMessage = messages[i];
-		const currentType = currentMessage.getType();
-		const currentContent = currentMessage.content;
 
-		// Add current message to group
-		currentGroup[currentType] = currentContent;
-		i++;
+		do {
+			const message = messages[index];
+			const messageType = message.getType();
 
-		// Always try to add subsequent different message types to the current group
-		while (i < messages.length) {
-			const nextMessage = messages[i];
-			const nextType = nextMessage.getType();
-			const nextContent = nextMessage.content;
-
-			// If we already have this type, stop and start a new group
-			if (currentGroup[nextType] !== undefined) {
+			if (messageType in currentGroup) {
 				break;
 			}
 
-			// Add to current group
-			currentGroup[nextType] = nextContent;
-			i++;
-		}
+			currentGroup[messageType] = message.content;
+			index++;
+		} while (index < messages.length);
 
 		result.push(currentGroup);
 	}

--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryManager/MemoryManager.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryManager/MemoryManager.node.ts
@@ -19,7 +19,7 @@ interface MessageRecord {
 }
 
 export function simplifyMessages(messages: BaseMessage[]) {
-	// This function trips the content of the messages to a simple format and
+	// This function strips the content of the messages to a simple format and
 	// simplifies the messages by grouping them based on their type
 	// and returning an array of objects where each object contains messages of different types.
 	if (messages.length === 0) return [];

--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryManager/test/MemoryManager.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryManager/test/MemoryManager.node.test.ts
@@ -1,0 +1,102 @@
+import { AIMessage, HumanMessage, SystemMessage } from '@langchain/core/messages';
+
+import { simplifyMessages } from '../MemoryManager.node';
+
+describe('simplifyMessages', () => {
+	it('should handle single message', () => {
+		const messages = [new HumanMessage('Hello')];
+		const result = simplifyMessages(messages);
+		expect(result).toEqual([{ human: 'Hello' }]);
+	});
+
+	it('should group different message types together', () => {
+		const messages = [
+			new HumanMessage('Hello, how are you?'),
+			new AIMessage("I'm doing well, thank you for asking! How about you?"),
+		];
+		const result = simplifyMessages(messages);
+		expect(result).toEqual([
+			{
+				human: 'Hello, how are you?',
+				ai: "I'm doing well, thank you for asking! How about you?",
+			},
+		]);
+	});
+
+	it('should separate consecutive messages of same type into different groups', () => {
+		const messages = [
+			new HumanMessage('First human message'),
+			new HumanMessage('Second human message'),
+			new AIMessage('AI response'),
+		];
+		const result = simplifyMessages(messages);
+		expect(result).toEqual([
+			{ human: 'First human message' },
+			{ human: 'Second human message', ai: 'AI response' },
+		]);
+	});
+
+	it('should handle three consecutive messages of same type', () => {
+		const messages = [new HumanMessage('1'), new HumanMessage('2'), new HumanMessage('3')];
+		const result = simplifyMessages(messages);
+		expect(result).toEqual([{ human: '1' }, { human: '2' }, { human: '3' }]);
+	});
+
+	it('should handle mixed message types with grouping', () => {
+		const messages = [
+			new SystemMessage('System message'),
+			new HumanMessage('Hello'),
+			new AIMessage('Hi there'),
+			new HumanMessage('Another human message'),
+			new AIMessage('Another AI message'),
+		];
+		const result = simplifyMessages(messages);
+		expect(result).toEqual([
+			{
+				system: 'System message',
+				human: 'Hello',
+				ai: 'Hi there',
+			},
+			{
+				human: 'Another human message',
+				ai: 'Another AI message',
+			},
+		]);
+	});
+
+	it('should handle system messages correctly', () => {
+		const messages = [
+			new SystemMessage('System instruction'),
+			new HumanMessage('User question'),
+			new AIMessage('AI response'),
+		];
+		const result = simplifyMessages(messages);
+		expect(result).toEqual([
+			{
+				system: 'System instruction',
+				human: 'User question',
+				ai: 'AI response',
+			},
+		]);
+	});
+
+	it('should handle alternating same types correctly', () => {
+		const messages = [
+			new HumanMessage('Human 1'),
+			new AIMessage('AI 1'),
+			new HumanMessage('Human 2'),
+			new AIMessage('AI 2'),
+		];
+		const result = simplifyMessages(messages);
+		expect(result).toEqual([
+			{
+				human: 'Human 1',
+				ai: 'AI 1',
+			},
+			{
+				human: 'Human 2',
+				ai: 'AI 2',
+			},
+		]);
+	});
+});


### PR DESCRIPTION
## Summary

This PR fixes a bug where the `MemoryManager` node would potentially overwrite consecutive messages if they were of the same type (for example two human messages).
 
## Related Linear tickets, Github issues, and Community forum posts


<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->

https://linear.app/n8n/issue/AI-996/community-issue-when-using-chat-memory-manager-the-information-is-not

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
