### PR TITLE
fix(editor): Log view is missing in debug mode

### DIFF
--- a/packages/frontend/editor-ui/src/router.ts
+++ b/packages/frontend/editor-ui/src/router.ts
@@ -207,6 +207,7 @@ export const routes: RouteRecordRaw[] = [
 			default: NodeView,
 			header: MainHeader,
 			sidebar: MainSidebar,
+			footer: LogsPanel,
 		},
 		meta: {
 			nodeView: true,


### PR DESCRIPTION
## Summary
This PR fixes the issue where the canvas doesn't show log view when it's opened from "Copy to editor" button in the execution history view. This will also resolve a flaky e2e test for the debugging feature, caused by layout shift of the execution button.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/SUG-77/bug-log-view-missing-in-debug-mode


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
