### PR TITLE
chore: Add tests for useCanvasOperations replaceNodeParameters and replaceNodeConnections (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
@@ -111,6 +111,7 @@ import { chatEventBus } from '@n8n/chat/event-buses';
 import { useLogsStore } from '@/stores/logs.store';
 import { isChatNode } from '@/utils/aiUtils';
 import cloneDeep from 'lodash/cloneDeep';
+import uniq from 'lodash/uniq';
 
 type AddNodeData = Partial<INodeUi> & {
 	type: string;
@@ -469,11 +470,14 @@ export function useCanvasOperations() {
 		if (!previousNode || !newNode) {
 			return;
 		}
-
 		const wf = workflowsStore.getCurrentWorkflow();
 
-		const inputNodeNames = replaceInputs ? wf.getParentNodes(previousNode.name, 'main', 1) : [];
-		const outputNodeNames = replaceOutputs ? wf.getChildNodes(previousNode.name, 'main', 1) : [];
+		const inputNodeNames = replaceInputs
+			? uniq(wf.getParentNodes(previousNode.name, 'main', 1))
+			: [];
+		const outputNodeNames = replaceOutputs
+			? uniq(wf.getChildNodes(previousNode.name, 'main', 1))
+			: [];
 		const connectionPairs = [
 			...wf.getConnectionsBetweenNodes(inputNodeNames, [previousNode.name]),
 			...wf.getConnectionsBetweenNodes([previousNode.name], outputNodeNames),


### PR DESCRIPTION
## Summary

Testing these slipped through the original PR.

Also fixes a "bug" (no user impact) where we repeated a delete/add operation for the same connection if there were multiple connections between the same two nodes.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3605/tech-debt-add-missing-tests


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
