### PR TITLE
fix(core): Correctly apply maxRows limit when fetching the dataset

### DIFF
--- a/packages/nodes-base/nodes/Evaluation/EvaluationTrigger/EvaluationTrigger.node.ee.ts
+++ b/packages/nodes-base/nodes/Evaluation/EvaluationTrigger/EvaluationTrigger.node.ee.ts
@@ -143,7 +143,7 @@ export class EvaluationTrigger implements INodeType {
 				{},
 			);
 
-			const result = testRunnerResult.filter((row) => (row?.json?.row_number as number) <= maxRows);
+			const result = testRunnerResult.slice(0, maxRows - 1);
 
 			return [result];
 		}


### PR DESCRIPTION
## Summary

When returning the dataset from the Evaluation Trigger Node, a limit of `maxRows` is applied defaulting to 1000 rows.
In addition, filters can be applied to the dataset. 
The current implementation uses `row?.json?.row_number` to apply the limit which leads to rows being lost if there is a filter that would include rows after `maxRows`. 
We fix this by simplifying and instead of filtering based on `row_number` simply slicing the filtered result.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
https://linear.app/n8n/issue/AI-1027/bug-workflow-evaluation-does-not-process-all-rows-if-filter-is-set

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
