### PR TITLE
ci: Prevent cancelling in-progress Postgres and MySQL tests

### DIFF
--- a/.github/workflows/ci-postgres-mysql.yml
+++ b/.github/workflows/ci-postgres-mysql.yml
@@ -19,7 +19,7 @@ on:
 
 concurrency:
   group: db-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   build:


### PR DESCRIPTION
Prevent cancelling in-progress Postgres and MySQL, as the AI reviewer is [interrupting](https://github.com/n8n-io/n8n/actions/runs/15557344232/attempts/1) them on every PR that qualifies. This means we'll run these tests on every push, so ideally we shouldn't push after every commit on qualifying PRs, but most PRs don't qualify for Postgres and MySQL tests, so the tradeoff should be acceptable. Let me know if you disagree.