### PR TITLE
fix(core): Don't swallow connection errors when fetching credentials

### DIFF
--- a/packages/cli/src/credentials-helper.ts
+++ b/packages/cli/src/credentials-helper.ts
@@ -6,7 +6,7 @@ import type { CredentialsEntity, ICredentialsDb } from '@n8n/db';
 import { CredentialsRepository, SharedCredentialsRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
-import { In } from '@n8n/typeorm';
+import { EntityNotFoundError, In } from '@n8n/typeorm';
 import { Credentials, getAdditionalKeys } from 'n8n-core';
 import type {
 	ICredentialDataDecryptedObject,
@@ -257,7 +257,11 @@ export class CredentialsHelper extends ICredentialsHelper {
 				type,
 			});
 		} catch (error) {
-			throw new CredentialNotFoundError(nodeCredential.id, type);
+			if (error instanceof EntityNotFoundError) {
+				throw new CredentialNotFoundError(nodeCredential.id, type);
+			}
+
+			throw error;
 		}
 
 		return new Credentials(


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

We have had multiple reports of executions failing, because the credential could not be found:
`Credential with ID "305" does not exist for type "googleBigQueryOAuth2Api".`
![image](https://github.com/user-attachments/assets/59a48864-5ca2-4f8b-8400-88a645b8cc5c)


Sometimes these have been false positives, because the error thrown by TypeORM was actually a connection error that we just ignore.
This PR first checks if the error thrown is an `EntityNotFoundError` before replacing it with a `CredentialNotFoundError`. 
If it's any other error it will be re-thrown so that user reports contain the correct error when they report this. (most of the time it's [this](https://github.com/brianc/node-postgres/blob/03642abec1c09337fa9cfb4b7ce5543b086c6437/packages/pg-pool/index.js#L262), but we can't be sure because we're hiding it).

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://n8nio.slack.com/archives/C035KBDA917/p1748612791750639

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
