### PR TITLE
fix: Run evaluations as full manual executions in queue mode

### DIFF
--- a/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
@@ -206,7 +206,8 @@ export class TestRunnerService {
 				},
 				resultData: {
 					// pinData,
-					runData: {},
+					// trigger full manual run instead of partial execution
+					runData: undefined,
 				},
 				manualData: {
 					userId: metadata.userId,

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2138,7 +2138,7 @@ export interface IRunExecutionData {
 	};
 	resultData: {
 		error?: ExecutionError;
-		runData: IRunData;
+		runData?: IRunData;
 		pinData?: IPinData;
 		lastNodeExecuted?: string;
 		metadata?: Record<string, string>;


### PR DESCRIPTION
## Summary

When running evaluation in queue mode (1 worker) and single main, will run into this error.
![image](https://github.com/user-attachments/assets/719f7a78-42f3-422a-bfaf-f8da28763d98)
Because it's running a partial execution, instead of full manual execution.

Here in `runManually`, the `data.runData` must be `undefined` otherwise execution run partial execution.
https://github.com/n8n-io/n8n/blob/aa407350bbf14e0b6a76ad386ab6f211a9e4a77b/packages/cli/src/manual-execution.service.ts#L115


<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
