### PR TITLE
fix(editor): Adjust time format for negative numbers (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/i18n/src/index.test.ts
+++ b/packages/frontend/@n8n/i18n/src/index.test.ts
@@ -3,6 +3,7 @@ import { I18nClass } from './index';
 describe(I18nClass, () => {
 	describe('displayTimer', () => {
 		it('should format duration with hours, minutes and seconds', () => {
+			expect(new I18nClass().displayTimer(-1)).toBe('-1s');
 			expect(new I18nClass().displayTimer(0)).toBe('0s');
 			expect(new I18nClass().displayTimer(12)).toBe('0s');
 			expect(new I18nClass().displayTimer(123)).toBe('0s');

--- a/packages/frontend/@n8n/i18n/src/index.ts
+++ b/packages/frontend/@n8n/i18n/src/index.ts
@@ -107,11 +107,9 @@ export class I18nClass {
 			remainingMs = remainingMs % minute;
 		}
 
-		if (!showMs) {
-			remainingMs -= remainingMs % second;
-		}
+		const remainingSec = showMs ? remainingMs / second : Math.floor(remainingMs / second);
 
-		parts.push(`${remainingMs / second}${this.baseText('genericHelpers.secShort')}`);
+		parts.push(`${remainingSec}${this.baseText('genericHelpers.secShort')}`);
 
 		return parts.join(' ');
 	}

--- a/packages/frontend/@n8n/rest-api-client/src/api/ldap.ts
+++ b/packages/frontend/@n8n/rest-api-client/src/api/ldap.ts
@@ -1,6 +1,7 @@
+import type { IDataObject } from 'n8n-workflow';
+
 import type { IRestApiContext } from '../types';
 import { makeRestApiRequest } from '../utils';
-import type { IDataObject } from 'n8n-workflow';
 
 export interface LdapSyncData {
 	id: number;

--- a/packages/frontend/@n8n/rest-api-client/src/utils.ts
+++ b/packages/frontend/@n8n/rest-api-client/src/utils.ts
@@ -284,6 +284,6 @@ export async function streamRequest<T extends object>(
 		}
 	} catch (e: unknown) {
 		assert(e instanceof Error);
-		onError?.(e as Error);
+		onError?.(e);
 	}
 }

--- a/packages/frontend/editor-ui/src/components/executions/global/GlobalExecutionsListItem.test.ts
+++ b/packages/frontend/editor-ui/src/components/executions/global/GlobalExecutionsListItem.test.ts
@@ -199,6 +199,6 @@ describe('GlobalExecutionsListItem', () => {
 
 		const executionTimeElement = getByTestId('execution-time');
 		expect(executionTimeElement).toBeVisible();
-		expect(executionTimeElement.textContent).toBe('30:00m');
+		expect(executionTimeElement.textContent).toBe('30m 0s');
 	});
 });

--- a/turbo.json
+++ b/turbo.json
@@ -53,6 +53,13 @@
 		"lint:frontend": {
 			"dependsOn": [
 				"^build",
+				"@n8n/rest-api-client#lint",
+				"@n8n/api-types#lint",
+				"@n8n/constants#lint",
+				"@n8n/i18n#lint",
+				"@n8n/permissions#lint",
+				"@n8n/stores#lint",
+				"@n8n/utils#lint",
 				"@n8n/chat#lint",
 				"@n8n/codemirror-lang#lint",
 				"@n8n/storybook#lint",
@@ -94,6 +101,13 @@
 		},
 		"test:frontend": {
 			"dependsOn": [
+				"@n8n/rest-api-client#test",
+				"@n8n/api-types#test",
+				"@n8n/constants#test",
+				"@n8n/i18n#test",
+				"@n8n/permissions#test",
+				"@n8n/stores#test",
+				"@n8n/utils#test",
 				"@n8n/chat#test",
 				"@n8n/codemirror-lang#test",
 				"@n8n/composables#build",


### PR DESCRIPTION
## Summary

This PR resolves some failing unit tests by adjusting the new logic of time formatting, also updates turbo.json to ensure that tests and linting are executed in CI

## Related Linear tickets, Github issues, and Community forum posts



## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
