### PR TITLE
feat(Basic LLM Chain Node, Information Extractor Node): Switch to using withStructuredOutput

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/V2/AgentV2.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/V2/AgentV2.node.ts
@@ -76,6 +76,7 @@ function getInputs(hasOutputParser?: boolean): Array<NodeConnectionType | INodeI
 					'@n8n/n8n-nodes-langchain.lmChatDeepSeek',
 					'@n8n/n8n-nodes-langchain.lmChatOpenRouter',
 					'@n8n/n8n-nodes-langchain.lmChatXAiGrok',
+					'@n8n/n8n-nodes-langchain.code',
 				],
 			},
 		},

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/common.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/common.ts
@@ -303,18 +303,18 @@ export async function getTools(
 	const tools = (await getConnectedTools(ctx, true, false)) as Array<DynamicStructuredTool | Tool>;
 
 	// If an output parser is available, create a dynamic tool to validate the final output.
-	if (outputParser) {
-		const schema = getOutputParserSchema(outputParser);
-		const structuredOutputParserTool = new DynamicStructuredTool({
-			schema,
-			name: 'format_final_json_response',
-			description:
-				'Use this tool to format your final response to the user in a structured JSON format. This tool validates your output against a schema to ensure it meets the required format. ONLY use this tool when you have completed all necessary reasoning and are ready to provide your final answer. Do not use this tool for intermediate steps or for asking questions. The output from this tool will be directly returned to the user.',
-			// We do not use a function here because we intercept the output with the parser.
-			func: async () => '',
-		});
-		tools.push(structuredOutputParserTool);
-	}
+	// if (outputParser) {
+	// 	const schema = getOutputParserSchema(outputParser);
+	// 	const structuredOutputParserTool = new DynamicStructuredTool({
+	// 		schema,
+	// 		name: 'format_final_json_response',
+	// 		description:
+	// 			'Use this tool to format your final response to the user in a structured JSON format. This tool validates your output against a schema to ensure it meets the required format. ONLY use this tool when you have completed all necessary reasoning and are ready to provide your final answer. Do not use this tool for intermediate steps or for asking questions. The output from this tool will be directly returned to the user.',
+	// 		// We do not use a function here because we intercept the output with the parser.
+	// 		func: async () => '',
+	// 	});
+	// 	tools.push(structuredOutputParserTool);
+	// }
 	return tools;
 }
 

--- a/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/InformationExtractor.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/InformationExtractor.node.ts
@@ -1,6 +1,6 @@
 import type { BaseLanguageModel } from '@langchain/core/language_models/base';
 import type { JSONSchema7 } from 'json-schema';
-import { OutputFixingParser, StructuredOutputParser } from 'langchain/output_parsers';
+import { StructuredOutputParser } from 'langchain/output_parsers';
 import { jsonParse, NodeConnectionTypes, NodeOperationError, sleep } from 'n8n-workflow';
 import type {
 	INodeType,
@@ -231,7 +231,7 @@ export class InformationExtractor implements INodeType {
 			| 'fromJson'
 			| 'manual';
 
-		let parser: OutputFixingParser<object>;
+		let parser: StructuredOutputParser<z.ZodType<object, z.ZodTypeDef, object>>;
 
 		if (schemaType === 'fromAttributes') {
 			const attributes = this.getNodeParameter(
@@ -244,10 +244,7 @@ export class InformationExtractor implements INodeType {
 				throw new NodeOperationError(this.getNode(), 'At least one attribute must be specified');
 			}
 
-			parser = OutputFixingParser.fromLLM(
-				llm,
-				StructuredOutputParser.fromZodSchema(makeZodSchemaFromAttributes(attributes)),
-			);
+			parser = StructuredOutputParser.fromZodSchema(makeZodSchemaFromAttributes(attributes));
 		} else {
 			let jsonSchema: JSONSchema7;
 
@@ -264,7 +261,7 @@ export class InformationExtractor implements INodeType {
 
 			const zodSchema = convertJsonSchemaToZod<z.ZodSchema<object>>(jsonSchema);
 
-			parser = OutputFixingParser.fromLLM(llm, StructuredOutputParser.fromZodSchema(zodSchema));
+			parser = StructuredOutputParser.fromZodSchema(zodSchema);
 		}
 
 		const resultData: INodeExecutionData[] = [];


### PR DESCRIPTION
## Summary

This is a spike to try `withStructuredOutput` function from LangChain: https://js.langchain.com/docs/concepts/structured_outputs/#structured-output-method

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-1038/spike-withstructuredoutput-utility-function


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
