### PR TITLE
fix: Add a missing word to tooltip

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -2442,7 +2442,7 @@
 	"workflowSettings.defaultTimezoneNotValid": "Default Timezone not valid",
 	"workflowSettings.errorWorkflow": "Error Workflow",
 	"workflowSettings.executionOrder": "Execution Order",
-	"workflowSettings.helpTexts.errorWorkflow": "A second workflow to run if the current one fails.<br />The second workflow should an 'Error Trigger' node.",
+	"workflowSettings.helpTexts.errorWorkflow": "A second workflow to run if the current one fails.<br />The second workflow should have an 'Error Trigger' node.",
 	"workflowSettings.helpTexts.executionTimeout": "How long the workflow should wait before timing out",
 	"workflowSettings.helpTexts.executionTimeoutToggle": "Whether to cancel workflow execution after a defined time",
 	"workflowSettings.helpTexts.saveDataErrorExecution": "Whether to save data of executions that fail",


### PR DESCRIPTION
## Summary
This PR adds the missing word to the tooltip 

If we go to ... > Settings > Error Workflow and put the cursor on top of the question mark, the tooltip reads "... The second workflow should an 'Error Trigger' node", missing the word have before 'Error Trigger'.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3051/community-issue-minor-wording-issue
fixes https://github.com/n8n-io/n8n/issues/15701


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
