### PR TITLE
fix(HTTP Request Node): Process text files

### DIFF
--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -833,7 +833,7 @@ export class HttpRequestV3 implements INodeType {
 					}
 				}
 
-				const responseContentType: string | undefined = response.headers['content-type'] ?? '';
+				const responseContentType = response.headers['content-type'] ?? '';
 				if (autoDetectResponseFormat) {
 					if (responseContentType.includes('application/json')) {
 						responseFormat = 'json';

--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -255,7 +255,7 @@ export class HttpRequestV3 implements INodeType {
 					lowercaseHeaders: boolean;
 				};
 
-				responseFileName = response.response?.outputPropertyName;
+				responseFileName = response?.response?.outputPropertyName;
 
 				const url = this.getNodeParameter('url', itemIndex) as string;
 

--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -833,7 +833,7 @@ export class HttpRequestV3 implements INodeType {
 					}
 				}
 
-				const responseContentType: string = response.headers['content-type'] ?? '';
+				const responseContentType: string | undefined = response.headers['content-type'] ?? '';
 				if (autoDetectResponseFormat) {
 					if (responseContentType.includes('application/json')) {
 						responseFormat = 'json';

--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -124,6 +124,8 @@ export class HttpRequestV3 implements INodeType {
 
 		let autoDetectResponseFormat = false;
 
+		let responseFileName: string | undefined;
+
 		// Can not be defined on a per item level
 		const pagination = this.getNodeParameter('options.pagination.pagination', 0, null, {
 			rawExpressions: true,
@@ -241,11 +243,18 @@ export class HttpRequestV3 implements INodeType {
 					allowUnauthorizedCerts: boolean;
 					queryParameterArrays: 'indices' | 'brackets' | 'repeat';
 					response: {
-						response: { neverError: boolean; responseFormat: string; fullResponse: boolean };
+						response: {
+							neverError: boolean;
+							responseFormat: string;
+							fullResponse: boolean;
+							outputPropertyName: string;
+						};
 					};
 					redirect: { redirect: { maxRedirects: number; followRedirects: boolean } };
 					lowercaseHeaders: boolean;
 				};
+
+				responseFileName = response.response?.outputPropertyName;
 
 				const url = this.getNodeParameter('url', itemIndex) as string;
 

--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -39,6 +39,7 @@ import {
 	setAgentOptions,
 } from '../GenericFunctions';
 import { configureResponseOptimizer } from '../shared/optimizeResponse';
+import { mimeTypeFromResponse } from './utils/parse';
 
 function toText<T>(data: T) {
 	if (typeof data === 'object' && data !== null) {
@@ -904,7 +905,7 @@ export class HttpRequestV3 implements INodeType {
 					const preparedBinaryData = await this.helpers.prepareBinaryData(
 						binaryData,
 						undefined,
-						responseContentType || undefined,
+						mimeTypeFromResponse(responseContentType),
 					);
 
 					if (

--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -39,6 +39,7 @@ import {
 	setAgentOptions,
 } from '../GenericFunctions';
 import { configureResponseOptimizer } from '../shared/optimizeResponse';
+import { setFilename } from './utils/binaryData';
 import { mimeTypeFromResponse } from './utils/parse';
 
 function toText<T>(data: T) {
@@ -832,7 +833,7 @@ export class HttpRequestV3 implements INodeType {
 					}
 				}
 
-				const responseContentType = response.headers['content-type'] ?? '';
+				const responseContentType: string = response.headers['content-type'] ?? '';
 				if (autoDetectResponseFormat) {
 					if (responseContentType.includes('application/json')) {
 						responseFormat = 'json';
@@ -917,14 +918,11 @@ export class HttpRequestV3 implements INodeType {
 						mimeTypeFromResponse(responseContentType),
 					);
 
-					if (
-						!preparedBinaryData.fileName &&
-						preparedBinaryData.fileExtension &&
-						typeof requestOptions.uri === 'string' &&
-						requestOptions.uri.endsWith(preparedBinaryData.fileExtension)
-					) {
-						preparedBinaryData.fileName = requestOptions.uri.split('/').pop();
-					}
+					preparedBinaryData.fileName = setFilename(
+						preparedBinaryData,
+						requestOptions,
+						responseFileName,
+					);
 
 					newItem.binary![outputPropertyName] = preparedBinaryData;
 

--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -27,6 +27,8 @@ import type { Readable } from 'stream';
 import { keysToLowercase } from '@utils/utilities';
 
 import { mainProperties } from './Description';
+import { setFilename } from './utils/binaryData';
+import { mimeTypeFromResponse } from './utils/parse';
 import type { BodyParameter, IAuthDataSanitizeKeys } from '../GenericFunctions';
 import {
 	binaryContentTypes,
@@ -39,8 +41,6 @@ import {
 	setAgentOptions,
 } from '../GenericFunctions';
 import { configureResponseOptimizer } from '../shared/optimizeResponse';
-import { setFilename } from './utils/binaryData';
-import { mimeTypeFromResponse } from './utils/parse';
 
 function toText<T>(data: T) {
 	if (typeof data === 'object' && data !== null) {

--- a/packages/nodes-base/nodes/HttpRequest/V3/utils/binaryData.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/utils/binaryData.ts
@@ -1,0 +1,22 @@
+import type { IBinaryData, IRequestOptions } from 'n8n-workflow';
+
+export const setFilename = (
+	preparedBinaryData: IBinaryData,
+	requestOptions: IRequestOptions,
+	responseFileName: string | undefined,
+) => {
+	if (
+		!preparedBinaryData.fileName &&
+		preparedBinaryData.fileExtension &&
+		typeof requestOptions.uri === 'string' &&
+		requestOptions.uri.endsWith(preparedBinaryData.fileExtension)
+	) {
+		return requestOptions.uri.split('/').pop();
+	}
+
+	if (!preparedBinaryData.fileName && preparedBinaryData.fileExtension) {
+		return `${responseFileName ?? 'data'}.${preparedBinaryData.fileExtension}`;
+	}
+
+	return preparedBinaryData.fileName;
+};

--- a/packages/nodes-base/nodes/HttpRequest/V3/utils/parse.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/utils/parse.ts
@@ -5,9 +5,5 @@ export const mimeTypeFromResponse = (
 		return undefined;
 	}
 
-	// TODO Test:
-	// 'image/png'
-	// 'text/html; charset=utf-8'
-	// 'multipart/form-data; boundary=ExampleBoundaryString'
 	return responseContentType.split(' ')[0].split(';')[0];
 };

--- a/packages/nodes-base/nodes/HttpRequest/V3/utils/parse.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/utils/parse.ts
@@ -1,0 +1,13 @@
+export const mimeTypeFromResponse = (
+	responseContentType: string | undefined,
+): string | undefined => {
+	if (!responseContentType) {
+		return undefined;
+	}
+
+	// TODO Test:
+	// 'image/png'
+	// 'text/html; charset=utf-8'
+	// 'multipart/form-data; boundary=ExampleBoundaryString'
+	return responseContentType.split(' ')[0].split(';')[0];
+};

--- a/packages/nodes-base/nodes/HttpRequest/test/binaryData/HttpRequest.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/binaryData/HttpRequest.test.ts
@@ -12,6 +12,11 @@ describe('Test Binary Data Download', () => {
 
 		nock(baseUrl)
 			.persist()
+			.get('/path/to/text.txt')
+			.reply(200, Buffer.from('test'), { 'content-type': 'text/plain; charset=utf-8' });
+
+		nock(baseUrl)
+			.persist()
 			.get('/redirect-to-image')
 			.reply(302, {}, { location: baseUrl + '/path/to/image.png' });
 

--- a/packages/nodes-base/nodes/HttpRequest/test/binaryData/binaryData.test.json
+++ b/packages/nodes-base/nodes/HttpRequest/test/binaryData/binaryData.test.json
@@ -78,23 +78,6 @@
 			"position": [1020, 560]
 		},
 		{
-			"parameters": {
-				"url": "https://dummy.domain/path/to/text.txt",
-				"options": {
-					"response": {
-						"response": {
-							"responseFormat": "file"
-						}
-					}
-				}
-			},
-			"name": "HTTP Request (v3)2",
-			"type": "n8n-nodes-base.httpRequest",
-			"typeVersion": 3,
-			"position": [960, 1420],
-			"id": "edb61e8a-546f-492b-a74f-500fa54469e5"
-		},
-		{
 			"name": "Content Disposition",
 			"type": "n8n-nodes-base.httpRequest",
 			"typeVersion": 4.1,
@@ -109,6 +92,23 @@
 				}
 			},
 			"position": [1020, 720]
+		},
+		{
+			"parameters": {
+				"url": "https://dummy.domain/path/to/text.txt",
+				"options": {
+					"response": {
+						"response": {
+							"responseFormat": "file"
+						}
+					}
+				}
+			},
+			"name": "HTTP Request (v4)2",
+			"type": "n8n-nodes-base.httpRequest",
+			"typeVersion": 4,
+			"position": [1680, 600],
+			"id": "665fef5c-6380-4bc0-be2a-430446b140ca"
 		}
 	],
 	"pinData": {
@@ -201,6 +201,21 @@
 				},
 				"json": {}
 			}
+		],
+		"HTTP Request (v4)2": [
+			{
+				"binary": {
+					"data": {
+						"data": "dGVzdA==",
+						"mimeType": "text/plain",
+						"fileType": "text",
+						"fileExtension": "txt",
+						"fileName": "text.txt",
+						"fileSize": "4 B"
+					}
+				},
+				"json": {}
+			}
 		]
 	},
 	"connections": {
@@ -234,6 +249,11 @@
 					},
 					{
 						"node": "Content Disposition",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "HTTP Request (v4)2",
 						"type": "main",
 						"index": 0
 					}

--- a/packages/nodes-base/nodes/HttpRequest/test/binaryData/binaryData.test.json
+++ b/packages/nodes-base/nodes/HttpRequest/test/binaryData/binaryData.test.json
@@ -1,227 +1,244 @@
 {
-  "name": "Download as Binary Data",
-  "nodes": [
-    {
-      "name": "When clicking \"Execute Workflow\"",
-      "type": "n8n-nodes-base.manualTrigger",
-      "typeVersion": 1,
-      "parameters": {},
-      "position": [580, 300]
-    },
-    {
-      "name": "HTTP Request (v1)",
-      "type": "n8n-nodes-base.httpRequest",
-      "typeVersion": 1,
-      "parameters": {
-        "url": "https://dummy.domain/path/to/image.png",
-        "responseFormat": "file"
-      },
-      "position": [1020, -100]
-    },
-    {
-      "name": "HTTP Request (v2)",
-      "type": "n8n-nodes-base.httpRequest",
-      "typeVersion": 2,
-      "parameters": {
-        "url": "https://dummy.domain/path/to/image.png",
-        "responseFormat": "file",
-        "options": {}
-      },
-      "position": [1020, 80]
-    },
-    {
-      "name": "HTTP Request (v3)",
-      "type": "n8n-nodes-base.httpRequest",
-      "typeVersion": 3,
-      "parameters": {
-        "url": "https://dummy.domain/path/to/image.png",
-        "options": {
-          "response": {
-            "response": {
-              "responseFormat": "file"
-            }
-          }
-        }
-      },
-      "position": [1020, 240]
-    },
-    {
-      "name": "HTTP Request (v4)",
-      "type": "n8n-nodes-base.httpRequest",
-      "typeVersion": 4,
-      "parameters": {
-        "url": "https://dummy.domain/path/to/image.png",
-        "options": {
-          "response": {
-            "response": {
-              "responseFormat": "file"
-            }
-          }
-        }
-      },
-      "position": [1020, 400]
-    },
-    {
-      "name": "Follow Redirect",
-      "type": "n8n-nodes-base.httpRequest",
-      "typeVersion": 4.1,
-      "parameters": {
-        "url": "https://dummy.domain/redirect-to-image",
-        "options": {
-          "response": {
-            "response": {
-              "responseFormat": "file"
-            }
-          }
-        }
-      },
-      "position": [1020, 560]
-    },
-    {
-      "name": "Content Disposition",
-      "type": "n8n-nodes-base.httpRequest",
-      "typeVersion": 4.1,
-      "parameters": {
-        "url": "https://dummy.domain/custom-content-disposition",
-        "options": {
-          "response": {
-            "response": {
-              "responseFormat": "file"
-            }
-          }
-        }
-      },
-      "position": [1020, 720]
-    }
-  ],
-  "pinData": {
-    "HTTP Request (v1)": [
-      {
-        "binary": {
-          "data": {
-            "data": "dGVzdA==",
-            "mimeType": "image/png",
-            "fileType": "image",
-            "fileExtension": "png",
-            "fileName": "image.png",
-            "fileSize": "4 B"
-          }
-        },
-        "json": {}
-      }
-    ],
-    "HTTP Request (v2)": [
-      {
-        "binary": {
-          "data": {
-            "data": "dGVzdA==",
-            "mimeType": "image/png",
-            "fileType": "image",
-            "fileExtension": "png",
-            "fileName": "image.png",
-            "fileSize": "4 B"
-          }
-        },
-        "json": {}
-      }
-    ],
-    "HTTP Request (v3)": [
-      {
-        "binary": {
-          "data": {
-            "data": "dGVzdA==",
-            "mimeType": "image/png",
-            "fileType": "image",
-            "fileExtension": "png",
-            "fileName": "image.png",
-            "fileSize": "4 B"
-          }
-        },
-        "json": {}
-      }
-    ],
-    "HTTP Request (v4)": [
-      {
-        "binary": {
-          "data": {
-            "data": "dGVzdA==",
-            "mimeType": "image/png",
-            "fileType": "image",
-            "fileExtension": "png",
-            "fileName": "image.png",
-            "fileSize": "4 B"
-          }
-        },
-        "json": {}
-      }
-    ],
-    "Follow Redirect": [
-      {
-        "binary": {
-          "data": {
-            "data": "dGVzdA==",
-            "mimeType": "image/png",
-            "fileType": "image",
-            "fileExtension": "png",
-            "fileName": "image.png",
-            "fileSize": "4 B"
-          }
-        },
-        "json": {}
-      }
-    ],
-    "Content Disposition": [
-      {
-        "binary": {
-          "data": {
-            "data": "dGVzdGluZw==",
-            "mimeType": "image/jpeg",
-            "fileType": "image",
-            "fileExtension": "jpg",
-            "fileName": "testing.jpg",
-            "fileSize": "7 B"
-          }
-        },
-        "json": {}
-      }
-    ]
-  },
-  "connections": {
-    "When clicking \"Execute Workflow\"": {
-      "main": [
-        [
-          {
-            "node": "HTTP Request (v1)",
-            "type": "main",
-            "index": 0
-          },
-          {
-            "node": "HTTP Request (v2)",
-            "type": "main",
-            "index": 0
-          },
-          {
-            "node": "HTTP Request (v3)",
-            "type": "main",
-            "index": 0
-          },
-          {
-            "node": "HTTP Request (v4)",
-            "type": "main",
-            "index": 0
-          },
-          {
-            "node": "Follow Redirect",
-            "type": "main",
-            "index": 0
-          },
-          {
-            "node": "Content Disposition",
-            "type": "main",
-            "index": 0
-          }
-        ]
-      ]
-    }
-  }
+	"name": "Download as Binary Data",
+	"nodes": [
+		{
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"parameters": {},
+			"position": [580, 300]
+		},
+		{
+			"name": "HTTP Request (v1)",
+			"type": "n8n-nodes-base.httpRequest",
+			"typeVersion": 1,
+			"parameters": {
+				"url": "https://dummy.domain/path/to/image.png",
+				"responseFormat": "file"
+			},
+			"position": [1020, -100]
+		},
+		{
+			"name": "HTTP Request (v2)",
+			"type": "n8n-nodes-base.httpRequest",
+			"typeVersion": 2,
+			"parameters": {
+				"url": "https://dummy.domain/path/to/image.png",
+				"responseFormat": "file",
+				"options": {}
+			},
+			"position": [1020, 80]
+		},
+		{
+			"name": "HTTP Request (v3)",
+			"type": "n8n-nodes-base.httpRequest",
+			"typeVersion": 3,
+			"parameters": {
+				"url": "https://dummy.domain/path/to/image.png",
+				"options": {
+					"response": {
+						"response": {
+							"responseFormat": "file"
+						}
+					}
+				}
+			},
+			"position": [1020, 240]
+		},
+		{
+			"name": "HTTP Request (v4)",
+			"type": "n8n-nodes-base.httpRequest",
+			"typeVersion": 4,
+			"parameters": {
+				"url": "https://dummy.domain/path/to/image.png",
+				"options": {
+					"response": {
+						"response": {
+							"responseFormat": "file"
+						}
+					}
+				}
+			},
+			"position": [1020, 400]
+		},
+		{
+			"name": "Follow Redirect",
+			"type": "n8n-nodes-base.httpRequest",
+			"typeVersion": 4.1,
+			"parameters": {
+				"url": "https://dummy.domain/redirect-to-image",
+				"options": {
+					"response": {
+						"response": {
+							"responseFormat": "file"
+						}
+					}
+				}
+			},
+			"position": [1020, 560]
+		},
+		{
+			"parameters": {
+				"url": "https://dummy.domain/path/to/text.txt",
+				"options": {
+					"response": {
+						"response": {
+							"responseFormat": "file"
+						}
+					}
+				}
+			},
+			"name": "HTTP Request (v3)2",
+			"type": "n8n-nodes-base.httpRequest",
+			"typeVersion": 3,
+			"position": [960, 1420],
+			"id": "edb61e8a-546f-492b-a74f-500fa54469e5"
+		},
+		{
+			"name": "Content Disposition",
+			"type": "n8n-nodes-base.httpRequest",
+			"typeVersion": 4.1,
+			"parameters": {
+				"url": "https://dummy.domain/custom-content-disposition",
+				"options": {
+					"response": {
+						"response": {
+							"responseFormat": "file"
+						}
+					}
+				}
+			},
+			"position": [1020, 720]
+		}
+	],
+	"pinData": {
+		"HTTP Request (v1)": [
+			{
+				"binary": {
+					"data": {
+						"data": "dGVzdA==",
+						"mimeType": "image/png",
+						"fileType": "image",
+						"fileExtension": "png",
+						"fileName": "image.png",
+						"fileSize": "4 B"
+					}
+				},
+				"json": {}
+			}
+		],
+		"HTTP Request (v2)": [
+			{
+				"binary": {
+					"data": {
+						"data": "dGVzdA==",
+						"mimeType": "image/png",
+						"fileType": "image",
+						"fileExtension": "png",
+						"fileName": "image.png",
+						"fileSize": "4 B"
+					}
+				},
+				"json": {}
+			}
+		],
+		"HTTP Request (v3)": [
+			{
+				"binary": {
+					"data": {
+						"data": "dGVzdA==",
+						"mimeType": "image/png",
+						"fileType": "image",
+						"fileExtension": "png",
+						"fileName": "image.png",
+						"fileSize": "4 B"
+					}
+				},
+				"json": {}
+			}
+		],
+		"HTTP Request (v4)": [
+			{
+				"binary": {
+					"data": {
+						"data": "dGVzdA==",
+						"mimeType": "image/png",
+						"fileType": "image",
+						"fileExtension": "png",
+						"fileName": "image.png",
+						"fileSize": "4 B"
+					}
+				},
+				"json": {}
+			}
+		],
+		"Follow Redirect": [
+			{
+				"binary": {
+					"data": {
+						"data": "dGVzdA==",
+						"mimeType": "image/png",
+						"fileType": "image",
+						"fileExtension": "png",
+						"fileName": "image.png",
+						"fileSize": "4 B"
+					}
+				},
+				"json": {}
+			}
+		],
+		"Content Disposition": [
+			{
+				"binary": {
+					"data": {
+						"data": "dGVzdGluZw==",
+						"mimeType": "image/jpeg",
+						"fileType": "image",
+						"fileExtension": "jpg",
+						"fileName": "testing.jpg",
+						"fileSize": "7 B"
+					}
+				},
+				"json": {}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "HTTP Request (v1)",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "HTTP Request (v2)",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "HTTP Request (v3)",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "HTTP Request (v4)",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "Follow Redirect",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "Content Disposition",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	}
 }

--- a/packages/nodes-base/nodes/HttpRequest/test/utils/binaryData.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/utils/binaryData.test.ts
@@ -1,3 +1,5 @@
+import type { IBinaryData, IRequestOptions } from 'n8n-workflow';
+
 import { setFilename } from '../../V3/utils/binaryData';
 
 describe('setFilename', () => {

--- a/packages/nodes-base/nodes/HttpRequest/test/utils/binaryData.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/utils/binaryData.test.ts
@@ -1,0 +1,27 @@
+import { setFilename } from '../../V3/utils/binaryData';
+
+describe('setFilename', () => {
+	it('returns filename from URI if fileName is missing and URI ends with fileExtension', () => {
+		const preparedBinaryData = { fileExtension: 'png' } as IBinaryData;
+		const requestOptions = { uri: 'https://example.com/image.png' } as IRequestOptions;
+		expect(setFilename(preparedBinaryData, requestOptions, undefined)).toBe('image.png');
+	});
+
+	it('returns constructed filename if fileName is missing and URI does not end with fileExtension', () => {
+		const preparedBinaryData = { fileExtension: 'jpg' } as IBinaryData;
+		const requestOptions = { uri: 'https://example.com/image.png' } as IRequestOptions;
+		expect(setFilename(preparedBinaryData, requestOptions, 'response')).toBe('response.jpg');
+	});
+
+	it('returns constructed filename with default "data" if responseFileName is undefined', () => {
+		const preparedBinaryData = { fileExtension: 'txt' } as IBinaryData;
+		const requestOptions = { uri: 'https://example.com/file' } as IRequestOptions;
+		expect(setFilename(preparedBinaryData, requestOptions, undefined)).toBe('data.txt');
+	});
+
+	it('returns fileName if it exists', () => {
+		const preparedBinaryData = { fileName: 'myfile.pdf', fileExtension: 'pdf' } as IBinaryData;
+		const requestOptions = { uri: 'https://example.com/file.pdf' } as IRequestOptions;
+		expect(setFilename(preparedBinaryData, requestOptions, 'response')).toBe('myfile.pdf');
+	});
+});

--- a/packages/nodes-base/nodes/HttpRequest/test/utils/parse.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/utils/parse.test.ts
@@ -1,0 +1,33 @@
+import { mimeTypeFromResponse } from '../../V3/utils/parse';
+
+describe('mimeTypeFromResponse', () => {
+	it('should return undefined if input is undefined', () => {
+		expect(mimeTypeFromResponse(undefined)).toBeUndefined();
+	});
+
+	it('should return the mime type for a simple type', () => {
+		expect(mimeTypeFromResponse('image/png')).toBe('image/png');
+	});
+
+	it('should strip charset from content type', () => {
+		expect(mimeTypeFromResponse('text/html; charset=utf-8')).toBe('text/html');
+	});
+
+	it('should strip charset from content type', () => {
+		expect(mimeTypeFromResponse('text/plain; charset=utf-8')).toBe('text/plain');
+	});
+
+	it('should strip boundary from multipart content type', () => {
+		expect(mimeTypeFromResponse('multipart/form-data; boundary=ExampleBoundaryString')).toBe(
+			'multipart/form-data',
+		);
+	});
+
+	it('should handle content type with extra spaces', () => {
+		expect(mimeTypeFromResponse('application/json ; charset=utf-8')).toBe('application/json');
+	});
+
+	it('should handle content type with space before semicolon', () => {
+		expect(mimeTypeFromResponse('application/xml ;charset=utf-8')).toBe('application/xml');
+	});
+});


### PR DESCRIPTION
## Summary

This resolves the issue for when a user makes a `GET` request for a file which is in text form

Workflow for testing:

```
{
  "nodes": [
    {
      "parameters": {
        "url": "={{ $json.attachments[0].url }}",
        "options": {
          "response": {
            "response": {
              "responseFormat": "file",
              "outputPropertyName": "res"
            }
          }
        }
      },
      "type": "n8n-nodes-base.httpRequest",
      "typeVersion": 4.2,
      "position": [
        860,
        -120
      ],
      "id": "241cb290-e341-4584-8bff-d57b3ce713b3",
      "name": "HTTP Request"
    },
    {
      "parameters": {
        "resource": "message",
        "guildId": {
          "__rl": true,
          "value": "1334172894812569620",
          "mode": "list",
          "cachedResultName": "danan8n's server",
          "cachedResultUrl": "https://discord.com/channels/1334172894812569620"
        },
        "channelId": {
          "__rl": true,
          "value": "1334172895374741556",
          "mode": "list",
          "cachedResultName": "general",
          "cachedResultUrl": "https://discord.com/channels/1334172894812569620/1334172895374741556"
        },
        "content": "txt",
        "options": {},
        "files": {
          "values": [
            {}
          ]
        }
      },
      "type": "n8n-nodes-base.discord",
      "typeVersion": 2,
      "position": [
        560,
        -120
      ],
      "id": "19bb69a9-a006-4241-9908-b7b621be9913",
      "name": "Discord",
      "webhookId": "16cbdc0b-d9e9-4e6d-8d7a-72af3c5ce92b",
      "credentials": {
        "discordBotApi": {
          "id": "SwbgfYk3EuH13wi5",
          "name": "Discord Bot account"
        }
      }
    },
    {
      "parameters": {
        "operation": "download",
        "fileId": {
          "__rl": true,
          "value": "1JSlDF82Y2lGrD_fGwDe7VEBEbosN57N0",
          "mode": "list",
          "cachedResultName": "_OLD_Discourse-Server-Setup.txt",
          "cachedResultUrl": "https://drive.google.com/file/d/1JSlDF82Y2lGrD_fGwDe7VEBEbosN57N0/view?usp=drivesdk"
        },
        "options": {}
      },
      "type": "n8n-nodes-base.googleDrive",
      "typeVersion": 3,
      "position": [
        300,
        -120
      ],
      "id": "322ab42a-dfd2-4a8e-8ab6-92a98685a91d",
      "name": "Google Drive",
      "credentials": {
        "googleDriveOAuth2Api": {
          "id": "8Tnz5dJIYBlNQLJU",
          "name": "Google Drive account"
        }
      }
    },
    {
      "parameters": {
        "resource": "message",
        "guildId": {
          "__rl": true,
          "value": "1334172894812569620",
          "mode": "list",
          "cachedResultName": "danan8n's server",
          "cachedResultUrl": "https://discord.com/channels/1334172894812569620"
        },
        "channelId": {
          "__rl": true,
          "value": "1334172895374741556",
          "mode": "list",
          "cachedResultName": "general",
          "cachedResultUrl": "https://discord.com/channels/1334172894812569620/1334172895374741556"
        },
        "content": "txt resy",
        "options": {},
        "files": {
          "values": [
            {
              "inputFieldName": "res"
            }
          ]
        }
      },
      "type": "n8n-nodes-base.discord",
      "typeVersion": 2,
      "position": [
        1120,
        -120
      ],
      "id": "cc01aa86-052d-4813-8fbb-8a56abfbb223",
      "name": "Discord2",
      "webhookId": "16cbdc0b-d9e9-4e6d-8d7a-72af3c5ce92b",
      "credentials": {
        "discordBotApi": {
          "id": "SwbgfYk3EuH13wi5",
          "name": "Discord Bot account"
        }
      }
    }
  ],
  "connections": {
    "HTTP Request": {
      "main": [
        [
          {
            "node": "Discord2",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Discord": {
      "main": [
        [
          {
            "node": "HTTP Request",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Google Drive": {
      "main": [
        [
          {
            "node": "Discord",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {},
  "meta": {
    "templateCredsSetupCompleted": true,
    "instanceId": "ee90fdf8d57662f949e6c691dc07fa0fd2f66e1eee28ed82ef06658223e67255"
  }
}
```

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/NODE-2970/community-issue-http-node-cannot-get-file-name


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
