### PR TITLE
fix(core): Prevent DoS via malformed binary data ID

### DIFF
--- a/packages/cli/src/controllers/__tests__/binary-data.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/binary-data.controller.test.ts
@@ -26,7 +26,7 @@ describe('BinaryDataController', () => {
 			await controller.get(request, response, query);
 
 			expect(response.status).toHaveBeenCalledWith(400);
-			expect(response.end).toHaveBeenCalledWith('Missing binary data mode');
+			expect(response.end).toHaveBeenCalledWith('Malformed binary data ID');
 		});
 
 		it('should return 400 if binary data mode is invalid', async () => {
@@ -152,6 +152,24 @@ describe('BinaryDataController', () => {
 			expect(result).toBe(stream);
 			expect(binaryDataService.getAsStream).toHaveBeenCalledWith('filesystem:123');
 		});
+
+		describe('with malicious binary data IDs', () => {
+			it.each([
+				['filesystem:'],
+				['filesystem-v2:'],
+				['filesystem:/'],
+				['filesystem-v2:/'],
+				['filesystem://'],
+				['filesystem-v2://'],
+			])('should return 400 for ID "%s"', async (maliciousId) => {
+				const query = { id: maliciousId, action: 'download' } as BinaryDataQueryDto;
+
+				await controller.get(request, response, query);
+
+				expect(response.status).toHaveBeenCalledWith(400);
+				expect(response.end).toHaveBeenCalledWith('Malformed binary data ID');
+			});
+		});
 	});
 
 	describe('getSigned', () => {
@@ -162,7 +180,7 @@ describe('BinaryDataController', () => {
 			await controller.getSigned(request, response, query);
 
 			expect(response.status).toHaveBeenCalledWith(400);
-			expect(response.end).toHaveBeenCalledWith('Missing binary data mode');
+			expect(response.end).toHaveBeenCalledWith('Malformed binary data ID');
 		});
 
 		it('should return 400 if binary data mode is invalid', async () => {

--- a/packages/cli/src/controllers/binary-data.controller.ts
+++ b/packages/cli/src/controllers/binary-data.controller.ts
@@ -47,13 +47,22 @@ export class BinaryDataController {
 			throw new BadRequestError('Missing binary data ID');
 		}
 
-		if (!binaryDataId.includes(':')) {
-			throw new BadRequestError('Missing binary data mode');
+		const separatorIndex = binaryDataId.indexOf(':');
+
+		if (separatorIndex === -1) {
+			throw new BadRequestError('Malformed binary data ID');
 		}
 
-		const [mode] = binaryDataId.split(':');
+		const mode = binaryDataId.substring(0, separatorIndex);
+
 		if (!isValidNonDefaultMode(mode)) {
 			throw new BadRequestError('Invalid binary data mode');
+		}
+
+		const path = binaryDataId.substring(separatorIndex + 1);
+
+		if (path === '' || path === '/' || path === '//') {
+			throw new BadRequestError('Malformed binary data ID');
 		}
 	}
 


### PR DESCRIPTION
## Summary

Requests with malformed binary data IDs like `filesystem-v2://` or `filesystem:` were not being rejected, leading to expensive metadata lookups on the binary data root dir.

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.slack.com/archives/C042WDXPTEZ/p1749634750395649


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
