### PR TITLE
fix: Run evaluations as full manual executions in queue mode

### DIFF
--- a/packages/cli/src/__tests__/manual-execution.service.test.ts
+++ b/packages/cli/src/__tests__/manual-execution.service.test.ts
@@ -597,4 +597,36 @@ describe('ManualExecutionService', () => {
 			);
 		});
 	});
+
+	it('should call workflowExecute.run for full execution when execution mode is evaluation', async () => {
+		const data = mock<IWorkflowExecutionDataProcess>({
+			executionMode: 'evaluation',
+			destinationNode: undefined,
+			pinData: {},
+			runData: {},
+			triggerToStartFrom: undefined,
+		});
+
+		const workflow = mock<Workflow>({
+			getNode: jest.fn().mockReturnValue(null),
+			getTriggerNodes: jest.fn().mockReturnValue([]),
+		});
+
+		const additionalData = mock<IWorkflowExecuteAdditionalData>();
+		const executionId = 'test-execution-id-evaluation';
+
+		const mockRun = jest.fn().mockReturnValue('mockRunReturnEvaluation');
+		require('n8n-core').WorkflowExecute.mockImplementationOnce(() => ({
+			run: mockRun,
+			processRunExecutionData: jest.fn(),
+		}));
+
+		await manualExecutionService.runManually(data, workflow, additionalData, executionId);
+
+		expect(mockRun.mock.calls[0][0]).toBe(workflow);
+		expect(mockRun.mock.calls[0][1]).toBeUndefined(); // startNode
+		expect(mockRun.mock.calls[0][2]).toBeUndefined(); // destinationNode
+		expect(mockRun.mock.calls[0][3]).toBe(data.pinData); // pinData
+		expect(mockRun.mock.calls[0][4]).toBeUndefined(); // triggerToStartFrom
+	});
 });

--- a/packages/cli/src/evaluation.ee/test-runner/__tests__/test-runner.service.ee.test.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/__tests__/test-runner.service.ee.test.ts
@@ -3,6 +3,7 @@ import type { TestCaseExecutionRepository } from '@n8n/db';
 import type { TestRunRepository } from '@n8n/db';
 import type { WorkflowRepository } from '@n8n/db';
 import { readFileSync } from 'fs';
+import type { Mock } from 'jest-mock';
 import { mock } from 'jest-mock-extended';
 import type { ErrorReporter } from 'n8n-core';
 import { EVALUATION_NODE_TYPE, EVALUATION_TRIGGER_NODE_TYPE } from 'n8n-workflow';
@@ -20,7 +21,6 @@ import { mockInstance, mockLogger } from '@test/mocking';
 import { mockNodeTypesData } from '@test-integration/utils/node-types-data';
 
 import { TestRunnerService } from '../test-runner.service.ee';
-import { Mock } from 'jest-mock';
 
 const wfUnderTestJson = JSON.parse(
 	readFileSync(path.join(__dirname, './mock-data/workflow.under-test.json'), { encoding: 'utf-8' }),

--- a/packages/cli/src/evaluation.ee/test-runner/__tests__/test-runner.service.ee.test.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/__tests__/test-runner.service.ee.test.ts
@@ -20,6 +20,7 @@ import { mockInstance, mockLogger } from '@test/mocking';
 import { mockNodeTypesData } from '@test-integration/utils/node-types-data';
 
 import { TestRunnerService } from '../test-runner.service.ee';
+import { Mock } from 'jest-mock';
 
 const wfUnderTestJson = JSON.parse(
 	readFileSync(path.join(__dirname, './mock-data/workflow.under-test.json'), { encoding: 'utf-8' }),
@@ -690,6 +691,10 @@ describe('TestRunnerService', () => {
 					}
 					return undefined;
 				});
+			});
+
+			afterEach(() => {
+				(config.getEnv as unknown as Mock).mockRestore();
 			});
 
 			test('should call workflowRunner.run with correct data in queue mode', async () => {

--- a/packages/cli/src/evaluation.ee/test-runner/__tests__/test-runner.service.ee.test.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/__tests__/test-runner.service.ee.test.ts
@@ -11,6 +11,7 @@ import type { IRun, ExecutionError } from 'n8n-workflow';
 import path from 'path';
 
 import type { ActiveExecutions } from '@/active-executions';
+import config from '@/config';
 import { TestRunError } from '@/evaluation.ee/test-runner/errors.ee';
 import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 import type { Telemetry } from '@/telemetry';
@@ -19,7 +20,6 @@ import { mockInstance, mockLogger } from '@test/mocking';
 import { mockNodeTypesData } from '@test-integration/utils/node-types-data';
 
 import { TestRunnerService } from '../test-runner.service.ee';
-import config from '@/config';
 
 const wfUnderTestJson = JSON.parse(
 	readFileSync(path.join(__dirname, './mock-data/workflow.under-test.json'), { encoding: 'utf-8' }),

--- a/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
@@ -201,11 +201,8 @@ export class TestRunnerService {
 		// the same way as it would be passed in manual mode
 		if (config.getEnv('executions.mode') === 'queue') {
 			data.executionData = {
-				startData: {
-					// startNodes: startNodesData.startNodes,
-				},
 				resultData: {
-					// pinData,
+					pinData,
 					runData: {},
 				},
 				manualData: {

--- a/packages/cli/src/manual-execution.service.ts
+++ b/packages/cli/src/manual-execution.service.ts
@@ -113,7 +113,8 @@ export class ManualExecutionService {
 			return workflowExecute.processRunExecutionData(workflow);
 		} else if (
 			data.runData === undefined ||
-			(data.partialExecutionVersion !== 2 && (!data.startNodes || data.startNodes.length === 0))
+			(data.partialExecutionVersion !== 2 && (!data.startNodes || data.startNodes.length === 0)) ||
+			data.executionMode === 'evaluation'
 		) {
 			// Full Execution
 			// TODO: When the old partial execution logic is removed this block can


### PR DESCRIPTION
## Summary

When running evaluation in queue mode (1 worker) and single main, will run into this error.
![image](https://github.com/user-attachments/assets/719f7a78-42f3-422a-bfaf-f8da28763d98)
Because it's running a partial execution, instead of full manual execution.

Why? Here in `runManually`, because `data.runData` is `undefined`, the execution is running as a  partial execution.
https://github.com/n8n-io/n8n/blob/aa407350bbf14e0b6a76ad386ab6f211a9e4a77b/packages/cli/src/manual-execution.service.ts#L115

This fix ensures that evaluations always run as full executions even in queue mode.
Also passing pin data, which is needed here in order to ensure the dataset data is passed correctly in queue mode.


<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
