### PR TITLE
fix(editor): Fix inaccurate message in log view when input data is empty

### DIFF
--- a/packages/frontend/editor-ui/src/components/VirtualSchema.vue
+++ b/packages/frontend/editor-ui/src/components/VirtualSchema.vue
@@ -193,7 +193,8 @@ const contextItems = computed(() => {
 		return [];
 	}
 
-	const fields: Renders[] = flattenSchema({ schema, depth: 1 }).flatMap((renderItem) => {
+	const flatSchema = flattenSchema({ schema, depth: 1, isDataEmpty: false });
+	const fields: Renders[] = flatSchema.flatMap((renderItem) => {
 		const isVars =
 			renderItem.type === 'item' && renderItem.depth === 1 && renderItem.title === '$vars';
 
@@ -320,7 +321,14 @@ const flattenedNodes = computed(() =>
 );
 
 const flattenNodeSchema = computed(() =>
-	nodeSchema.value ? flattenSchema({ schema: nodeSchema.value, depth: 0, level: -1 }) : [],
+	nodeSchema.value
+		? flattenSchema({
+				schema: nodeSchema.value,
+				depth: 0,
+				level: -1,
+				isDataEmpty: props.data.length === 0,
+			})
+		: [],
 );
 
 /**

--- a/packages/frontend/editor-ui/src/composables/useDataSchema.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useDataSchema.test.ts
@@ -817,6 +817,7 @@ describe('useFlattenSchema', () => {
 			expect(
 				useFlattenSchema().flattenSchema({
 					schema,
+					isDataEmpty: false,
 				}).length,
 			).toBe(3);
 		});
@@ -835,8 +836,18 @@ describe('useFlattenSchema', () => {
 					},
 				],
 			};
-			const node1Schema = flattenSchema({ schema, expressionPrefix: '$("First Node")', depth: 1 });
-			const node2Schema = flattenSchema({ schema, expressionPrefix: '$("Second Node")', depth: 1 });
+			const node1Schema = flattenSchema({
+				schema,
+				expressionPrefix: '$("First Node")',
+				depth: 1,
+				isDataEmpty: false,
+			});
+			const node2Schema = flattenSchema({
+				schema,
+				expressionPrefix: '$("Second Node")',
+				depth: 1,
+				isDataEmpty: false,
+			});
 
 			expect(node1Schema[0].id).not.toBe(node2Schema[0].id);
 		});

--- a/packages/frontend/editor-ui/src/composables/useDataSchema.ts
+++ b/packages/frontend/editor-ui/src/composables/useDataSchema.ts
@@ -347,6 +347,7 @@ export const useFlattenSchema = () => {
 	};
 
 	const flattenSchema = ({
+		isDataEmpty,
 		schema,
 		nodeType,
 		nodeName,
@@ -356,6 +357,7 @@ export const useFlattenSchema = () => {
 		level = 0,
 		preview,
 	}: {
+		isDataEmpty: boolean;
 		schema: Schema;
 		expressionPrefix?: string;
 		nodeType?: string;
@@ -367,7 +369,7 @@ export const useFlattenSchema = () => {
 	}): Renders[] => {
 		// only show empty item for the first level
 		if (isEmptySchema(schema) && level < 0) {
-			return [emptyItem('emptyData')];
+			return [emptyItem(isDataEmpty ? 'emptyData' : 'emptySchema')];
 		}
 
 		const expression = `{{ ${expressionPrefix ? expressionPrefix + schema.path : schema.path.slice(1)} }}`;
@@ -403,6 +405,7 @@ export const useFlattenSchema = () => {
 					.map((item) => {
 						const itemPrefix = schema.type === 'array' ? schema.key : '';
 						return flattenSchema({
+							isDataEmpty,
 							schema: item,
 							expressionPrefix,
 							nodeType,
@@ -474,6 +477,7 @@ export const useFlattenSchema = () => {
 
 			acc = acc.concat(
 				flattenSchema({
+					isDataEmpty: item.isDataEmpty,
 					schema: item.schema,
 					depth: item.depth,
 					nodeType: item.node.type,


### PR DESCRIPTION
## Summary
This PR fixes inaccurate message shown in the log view when the node's input data is empty:

**Before**: No fields - node executed, but no items were sent on this branch
**After**: No fields - item(s) exist, but they're empty

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/SUG-61/bug-log-view-shows-incorrect-data-input-panel


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
