### PR TITLE
refactor(core): Extract health endpoint into controller and add more information to readiness check

### DIFF
--- a/packages/@n8n/decorators/src/controller/rest-controller.ts
+++ b/packages/@n8n/decorators/src/controller/rest-controller.ts
@@ -3,13 +3,18 @@ import { Container, Service } from '@n8n/di';
 import { ControllerRegistryMetadata } from './controller-registry-metadata';
 import type { Controller } from './types';
 
+interface RestControllerOptions {
+	skipPrefix?: boolean;
+}
+
 export const RestController =
-	(basePath: `/${string}` = '/'): ClassDecorator =>
+	(basePath: `/${string}` = '/', options?: RestControllerOptions): ClassDecorator =>
 	(target) => {
 		const metadata = Container.get(ControllerRegistryMetadata).getControllerMetadata(
 			target as unknown as Controller,
 		);
 		metadata.basePath = basePath;
+		metadata.skipPrefix = options?.skipPrefix;
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 		return Service()(target);
 	};

--- a/packages/@n8n/decorators/src/controller/types.ts
+++ b/packages/@n8n/decorators/src/controller/types.ts
@@ -41,6 +41,7 @@ export interface RouteMetadata {
 
 export interface ControllerMetadata {
 	basePath: `/${string}`;
+	skipPrefix?: boolean;
 	middlewares: HandlerName[];
 	routes: Map<HandlerName, RouteMetadata>;
 }

--- a/packages/cli/src/abstract-server.ts
+++ b/packages/cli/src/abstract-server.ts
@@ -122,23 +122,8 @@ export abstract class AbstractServer {
 	protected setupPushServer() {}
 
 	private async setupHealthCheck() {
-		// main health check should not care about DB connections
-		this.app.get('/healthz', (_req, res) => {
-			res.send({ status: 'ok' });
-		});
-
-		const { connectionState } = this.dbConnection;
-
-		this.app.get('/healthz/readiness', (_req, res) => {
-			const { connected, migrated } = connectionState;
-			if (connected && migrated) {
-				res.status(200).send({ status: 'ok' });
-			} else {
-				res.status(503).send({ status: 'error' });
-			}
-		});
-
 		this.app.use((_req, res, next) => {
+			const { connectionState } = this.dbConnection;
 			if (connectionState.connected) {
 				if (connectionState.migrated) next();
 				else res.send('n8n is starting up. Please wait');

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -24,7 +24,6 @@ import { MultiMainSetup } from '@/scaling/multi-main-setup.ee';
 import { Publisher } from '@/scaling/pubsub/publisher.service';
 import { PubSubRegistry } from '@/scaling/pubsub/pubsub.registry';
 import { Subscriber } from '@/scaling/pubsub/subscriber.service';
-import { Server } from '@/server';
 import { OwnershipService } from '@/services/ownership.service';
 import { ExecutionsPruningService } from '@/services/pruning/executions-pruning.service';
 import { UrlService } from '@/services/url.service';
@@ -63,8 +62,6 @@ export class Start extends BaseCommand {
 	};
 
 	protected activeWorkflowManager: ActiveWorkflowManager;
-
-	protected server = Container.get(Server);
 
 	override needsCommunityPackages = true;
 
@@ -314,7 +311,12 @@ export class Start extends BaseCommand {
 			);
 		}
 
-		await this.server.start();
+		// Importing server dynamically so we don't import all of this for the
+		// worker and webhook which extend the base command.
+		const { Server } = await import('@/server');
+		const server = Container.get(Server);
+		await server.init();
+		await server.start();
 
 		Container.get(ExecutionsPruningService).init();
 

--- a/packages/cli/src/controller.registry.ts
+++ b/packages/cli/src/controller.registry.ts
@@ -37,9 +37,11 @@ export class ControllerRegistry {
 		const metadata = this.metadata.getControllerMetadata(controllerClass);
 
 		const router = Router({ mergeParams: true });
-		const prefix = `/${this.globalConfig.endpoints.rest}/${metadata.basePath}`
-			.replace(/\/+/g, '/')
-			.replace(/\/$/, '');
+		const prefix = metadata.skipPrefix
+			? metadata.basePath.replace(/\/$/, '') || '/'
+			: `/${this.globalConfig.endpoints.rest}/${metadata.basePath}`
+					.replace(/\/+/g, '/')
+					.replace(/\/$/, '');
 		app.use(prefix, router);
 
 		const controller = Container.get(controllerClass) as Controller;

--- a/packages/cli/src/controllers/health.controller.ts
+++ b/packages/cli/src/controllers/health.controller.ts
@@ -1,0 +1,49 @@
+import { Logger } from '@n8n/backend-common';
+import { Get, RestController } from '@n8n/decorators';
+import { Request, Response } from 'express';
+
+import config from '@/config';
+import { DbConnection } from '@/databases/db-connection';
+import { RedisClientService } from '@/services/redis-client.service';
+
+@RestController('/healthz', { skipPrefix: true })
+export class HealthController {
+	constructor(
+		private readonly logger: Logger,
+		private readonly dbConnection: DbConnection,
+		private readonly redisClientService: RedisClientService,
+	) {}
+
+	@Get('/', { skipAuth: true })
+	healthz(_: Request, res: Response) {
+		res.send({ status: 'ok' });
+	}
+
+	@Get('/readiness', { skipAuth: true })
+	readiness(_: Request, res: Response) {
+		const { connected, migrated } = this.dbConnection.connectionState;
+
+		let ready = true;
+
+		if (!connected) {
+			ready = false;
+			this.logger.warn('Not connected to the database');
+		}
+
+		if (!migrated) {
+			ready = false;
+			this.logger.warn('Database not migrated yet');
+		}
+
+		if (config.getEnv('executions.mode') === 'queue' && !this.redisClientService.isConnected()) {
+			ready = false;
+			this.logger.warn('Not connected to redis');
+		}
+
+		if (!ready) {
+			res.status(503).send({ status: 'error' });
+		} else {
+			res.status(200).send({ status: 'ok' });
+		}
+	}
+}

--- a/packages/cli/src/scaling/worker-server.ts
+++ b/packages/cli/src/scaling/worker-server.ts
@@ -130,9 +130,11 @@ export class WorkerServer {
 			connectionState.migrated &&
 			this.redisClientService.isConnected();
 
+		const status = !Db.connectionState.connected ? 503 : !Db.connectionState.migrated ? 504 : 505;
+
 		return isReady
 			? res.status(200).send({ status: 'ok' })
-			: res.status(503).send({ status: 'error' });
+			: res.status(status).send({ status: 'error' });
 	}
 
 	private handleOverwrites(

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -48,6 +48,7 @@ import '@/controllers/role.controller';
 import '@/controllers/tags.controller';
 import '@/controllers/translation.controller';
 import '@/controllers/folder.controller';
+import '@/controllers/health.controller';
 import '@/controllers/users.controller';
 import '@/controllers/user-settings.controller';
 import '@/controllers/workflow-statistics.controller';

--- a/packages/cli/test/integration/healthcheck.controller.test.ts
+++ b/packages/cli/test/integration/healthcheck.controller.test.ts
@@ -1,10 +1,25 @@
+import { Logger } from '@n8n/backend-common';
+import { Container } from '@n8n/di';
+
+import config from '@/config';
+import { DbConnection } from '@/databases/db-connection';
+import { RedisClientService } from '@/services/redis-client.service';
+import { mockInstance } from '@test/mocking';
 import { setupTestServer } from '@test-integration/utils';
 
 import * as testDb from './shared/test-db';
 
 const testServer = setupTestServer({ endpointGroups: ['health'] });
 
-describe('HealthcheckController', () => {
+const logger: Logger = mockInstance(Logger, { scoped: () => logger });
+
+describe('HealthController', () => {
+	beforeEach(async () => {
+		await testDb.init();
+		jest.useRealTimers();
+		jest.resetAllMocks();
+	});
+
 	it('should return ok when DB is connected and migrated', async () => {
 		const response = await testServer.restlessAgent.get('/healthz/readiness');
 
@@ -13,11 +28,45 @@ describe('HealthcheckController', () => {
 	});
 
 	it('should return error when DB is not connected', async () => {
+		// ARRANGE
 		await testDb.terminate();
 
+		// ACT
 		const response = await testServer.restlessAgent.get('/healthz/readiness');
 
+		// ASSERT
 		expect(response.statusCode).toBe(503);
 		expect(response.body).toEqual({ status: 'error' });
+		expect(logger.warn).toHaveBeenCalledWith('Not connected to the database');
+	});
+
+	it('should return error when DB is not migrated', async () => {
+		// ARRANGE
+		Container.get(DbConnection).connectionState.migrated = false;
+
+		// ACT
+		const response = await testServer.restlessAgent.get('/healthz/readiness');
+
+		// ASSERT
+		expect(response.statusCode).toBe(503);
+		expect(response.body).toEqual({ status: 'error' });
+		expect(logger.warn).toHaveBeenCalledWith('Database not migrated yet');
+	});
+
+	it('should return error when redis is not connected', async () => {
+		// ARRANGE
+		config.set('executions.mode', 'queue');
+		jest.useFakeTimers();
+		const redisClientService = Container.get(RedisClientService);
+		redisClientService.emit('connection-lost', 1);
+		jest.advanceTimersByTime(1100);
+
+		// ACT
+		const response = await testServer.restlessAgent.get('/healthz/readiness');
+
+		// ASSERT
+		expect(response.statusCode).toBe(503);
+		expect(response.body).toEqual({ status: 'error' });
+		expect(logger.warn).toHaveBeenCalledWith('Not connected to redis');
 	});
 });

--- a/packages/cli/test/integration/shared/utils/test-server.ts
+++ b/packages/cli/test/integration/shared/utils/test-server.ts
@@ -146,13 +146,6 @@ export const setupTestServer = ({
 			app.use(...apiRouters);
 		}
 
-		if (endpointGroups?.includes('health')) {
-			app.get('/healthz/readiness', async (_req, res) => {
-				testDb.isReady()
-					? res.status(200).send({ status: 'ok' })
-					: res.status(503).send({ status: 'error' });
-			});
-		}
 		if (endpointGroups.length) {
 			for (const group of endpointGroups) {
 				switch (group) {
@@ -284,15 +277,23 @@ export const setupTestServer = ({
 
 					case 'ai':
 						await import('@/controllers/ai.controller');
+						break;
 
 					case 'folder':
 						await import('@/controllers/folder.controller');
+						break;
 
 					case 'externalSecrets':
 						await import('@/modules/external-secrets.ee/external-secrets.ee.module');
+						break;
 
 					case 'insights':
 						await import('@/modules/insights/insights.module');
+						break;
+
+					case 'health':
+						await import('@/controllers/health.controller');
+						break;
 				}
 			}
 


### PR DESCRIPTION

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This extracts the health checks into a controller (that hopefully can be re-used across main, worker and webhook processor).
To do that I had to update the decorator to allow controllers to be mounted without the prefix.

Additionally this now allows testing the health endpoints instead of testing their fake implementation in the test server.

TODO
- [ ] re-use the controller for the webhook and worker

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
