### PR TITLE
refactor(MongoDB Vector Store Node): Refactor mongodb vector store node

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreMongoDBAtlas/VectorStoreMongoDBAtlas.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreMongoDBAtlas/VectorStoreMongoDBAtlas.node.test.ts
@@ -1,78 +1,147 @@
+import { mock } from 'jest-mock-extended';
 import { MongoClient } from 'mongodb';
+import type { ILoadOptionsFunctions } from 'n8n-workflow';
 
-import { getMongoClient, mongoConfig } from './VectorStoreMongoDBAtlas.node';
+import {
+	EMBEDDING_NAME,
+	getCollectionName,
+	getEmbeddingFieldName,
+	getMetadataFieldName,
+	getMongoClient,
+	getVectorIndexName,
+	mongoConfig,
+	METADATA_FIELD_NAME,
+	MONGODB_COLLECTION_NAME,
+	VECTOR_INDEX_NAME,
+} from './VectorStoreMongoDBAtlas.node';
 
 jest.mock('mongodb', () => ({
 	MongoClient: jest.fn(),
 }));
 
-describe('VectorStoreMongoDBAtlas -> getMongoClient', () => {
-	const mockContext = {
-		getCredentials: jest.fn(),
-	};
-	const mockClient1 = {
-		connect: jest.fn().mockResolvedValue(undefined),
-		close: jest.fn().mockResolvedValue(undefined),
-	};
-	const mockClient2 = {
-		connect: jest.fn().mockResolvedValue(undefined),
-		close: jest.fn().mockResolvedValue(undefined),
-	};
-	const MockMongoClient = MongoClient as jest.MockedClass<typeof MongoClient>;
+describe('VectorStoreMongoDBAtlas', () => {
+	const helpers = mock<ILoadOptionsFunctions['helpers']>();
+	const executeFunctions = mock<ILoadOptionsFunctions>({ helpers });
 
 	beforeEach(() => {
 		jest.resetAllMocks();
-		mongoConfig.client = null;
-		mongoConfig.connectionString = '';
 	});
 
-	it('should reuse the same client when connection string is unchanged', async () => {
-		MockMongoClient.mockImplementation(() => mockClient1 as unknown as MongoClient);
-		mockContext.getCredentials.mockResolvedValue({
-			connectionString: 'mongodb://localhost:27017',
+	describe('.getMongoClient', () => {
+		const mockContext = {
+			getCredentials: jest.fn(),
+		};
+		const mockClient1 = {
+			connect: jest.fn().mockResolvedValue(undefined),
+			close: jest.fn().mockResolvedValue(undefined),
+		};
+		const mockClient2 = {
+			connect: jest.fn().mockResolvedValue(undefined),
+			close: jest.fn().mockResolvedValue(undefined),
+		};
+		const MockMongoClient = MongoClient as jest.MockedClass<typeof MongoClient>;
+
+		beforeEach(() => {
+			mongoConfig.client = null;
+			mongoConfig.connectionString = '';
 		});
 
-		const client1 = await getMongoClient(mockContext);
-		const client2 = await getMongoClient(mockContext);
-
-		expect(MockMongoClient).toHaveBeenCalledTimes(1);
-		expect(MockMongoClient).toHaveBeenCalledWith('mongodb://localhost:27017', {
-			appName: 'devrel.integration.n8n_vector_integ',
-		});
-		expect(mockClient1.connect).toHaveBeenCalledTimes(1);
-		expect(mockClient1.close).not.toHaveBeenCalled();
-		expect(mockClient2.connect).not.toHaveBeenCalled();
-		expect(client1).toBe(mockClient1);
-		expect(client2).toBe(mockClient1);
-	});
-
-	it('should create new client when connection string changes', async () => {
-		MockMongoClient.mockImplementationOnce(
-			() => mockClient1 as unknown as MongoClient,
-		).mockImplementationOnce(() => mockClient2 as unknown as MongoClient);
-		mockContext.getCredentials
-			.mockResolvedValueOnce({
+		it('should reuse the same client when connection string is unchanged', async () => {
+			MockMongoClient.mockImplementation(() => mockClient1 as unknown as MongoClient);
+			mockContext.getCredentials.mockResolvedValue({
 				connectionString: 'mongodb://localhost:27017',
-			})
-			.mockResolvedValueOnce({
-				connectionString: 'mongodb://different-host:27017',
 			});
 
-		const client1 = await getMongoClient(mockContext);
-		const client2 = await getMongoClient(mockContext);
+			const client1 = await getMongoClient(mockContext);
+			const client2 = await getMongoClient(mockContext);
 
-		expect(MockMongoClient).toHaveBeenCalledTimes(2);
-		expect(MockMongoClient).toHaveBeenNthCalledWith(1, 'mongodb://localhost:27017', {
-			appName: 'devrel.integration.n8n_vector_integ',
+			expect(MockMongoClient).toHaveBeenCalledTimes(1);
+			expect(MockMongoClient).toHaveBeenCalledWith('mongodb://localhost:27017', {
+				appName: 'devrel.integration.n8n_vector_integ',
+			});
+			expect(mockClient1.connect).toHaveBeenCalledTimes(1);
+			expect(mockClient1.close).not.toHaveBeenCalled();
+			expect(mockClient2.connect).not.toHaveBeenCalled();
+			expect(client1).toBe(mockClient1);
+			expect(client2).toBe(mockClient1);
 		});
-		expect(MockMongoClient).toHaveBeenNthCalledWith(2, 'mongodb://different-host:27017', {
-			appName: 'devrel.integration.n8n_vector_integ',
+
+		it('should create new client when connection string changes', async () => {
+			MockMongoClient.mockImplementationOnce(
+				() => mockClient1 as unknown as MongoClient,
+			).mockImplementationOnce(() => mockClient2 as unknown as MongoClient);
+			mockContext.getCredentials
+				.mockResolvedValueOnce({
+					connectionString: 'mongodb://localhost:27017',
+				})
+				.mockResolvedValueOnce({
+					connectionString: 'mongodb://different-host:27017',
+				});
+
+			const client1 = await getMongoClient(mockContext);
+			const client2 = await getMongoClient(mockContext);
+
+			expect(MockMongoClient).toHaveBeenCalledTimes(2);
+			expect(MockMongoClient).toHaveBeenNthCalledWith(1, 'mongodb://localhost:27017', {
+				appName: 'devrel.integration.n8n_vector_integ',
+			});
+			expect(MockMongoClient).toHaveBeenNthCalledWith(2, 'mongodb://different-host:27017', {
+				appName: 'devrel.integration.n8n_vector_integ',
+			});
+			expect(mockClient1.connect).toHaveBeenCalledTimes(1);
+			expect(mockClient1.close).toHaveBeenCalledTimes(1);
+			expect(mockClient2.connect).toHaveBeenCalledTimes(1);
+			expect(mockClient2.close).not.toHaveBeenCalled();
+			expect(client1).toBe(mockClient1);
+			expect(client2).toBe(mockClient2);
 		});
-		expect(mockClient1.connect).toHaveBeenCalledTimes(1);
-		expect(mockClient1.close).toHaveBeenCalledTimes(1);
-		expect(mockClient2.connect).toHaveBeenCalledTimes(1);
-		expect(mockClient2.close).not.toHaveBeenCalled();
-		expect(client1).toBe(mockClient1);
-		expect(client2).toBe(mockClient2);
+	});
+
+	describe('.getCollectionName', () => {
+		beforeEach(() => {
+			executeFunctions.getNodeParameter.mockImplementation((paramName: string) => {
+				if (paramName === MONGODB_COLLECTION_NAME) return 'testCollection';
+			});
+		});
+
+		it('returns the collection name from the context', () => {
+			expect(getCollectionName(executeFunctions, 0)).toEqual('testCollection');
+		});
+	});
+
+	describe('.getVectorIndexName', () => {
+		beforeEach(() => {
+			executeFunctions.getNodeParameter.mockImplementation((paramName: string) => {
+				if (paramName === VECTOR_INDEX_NAME) return 'testIndex';
+			});
+		});
+
+		it('returns the index name from the context', () => {
+			expect(getVectorIndexName(executeFunctions, 0)).toEqual('testIndex');
+		});
+	});
+
+	describe('.getEmbeddingFieldName', () => {
+		beforeEach(() => {
+			executeFunctions.getNodeParameter.mockImplementation((paramName: string) => {
+				if (paramName === EMBEDDING_NAME) return 'testEmbedding';
+			});
+		});
+
+		it('returns the embedding name from the context', () => {
+			expect(getEmbeddingFieldName(executeFunctions, 0)).toEqual('testEmbedding');
+		});
+	});
+
+	describe('.getMetadataFieldName', () => {
+		beforeEach(() => {
+			executeFunctions.getNodeParameter.mockImplementation((paramName: string) => {
+				if (paramName === METADATA_FIELD_NAME) return 'testMetadata';
+			});
+		});
+
+		it('returns the metadata field name from the context', () => {
+			expect(getMetadataFieldName(executeFunctions, 0)).toEqual('testMetadata');
+		});
 	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreMongoDBAtlas/VectorStoreMongoDBAtlas.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreMongoDBAtlas/VectorStoreMongoDBAtlas.node.test.ts
@@ -101,6 +101,7 @@ describe('VectorStoreMongoDBAtlas', () => {
 		beforeEach(() => {
 			executeFunctions.getNodeParameter.mockImplementation((paramName: string) => {
 				if (paramName === MONGODB_COLLECTION_NAME) return 'testCollection';
+				return '';
 			});
 		});
 
@@ -113,6 +114,7 @@ describe('VectorStoreMongoDBAtlas', () => {
 		beforeEach(() => {
 			executeFunctions.getNodeParameter.mockImplementation((paramName: string) => {
 				if (paramName === VECTOR_INDEX_NAME) return 'testIndex';
+				return '';
 			});
 		});
 
@@ -125,6 +127,7 @@ describe('VectorStoreMongoDBAtlas', () => {
 		beforeEach(() => {
 			executeFunctions.getNodeParameter.mockImplementation((paramName: string) => {
 				if (paramName === EMBEDDING_NAME) return 'testEmbedding';
+				return '';
 			});
 		});
 
@@ -137,6 +140,7 @@ describe('VectorStoreMongoDBAtlas', () => {
 		beforeEach(() => {
 			executeFunctions.getNodeParameter.mockImplementation((paramName: string) => {
 				if (paramName === METADATA_FIELD_NAME) return 'testMetadata';
+				return '';
 			});
 		});
 

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreMongoDBAtlas/VectorStoreMongoDBAtlas.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreMongoDBAtlas/VectorStoreMongoDBAtlas.node.ts
@@ -1,3 +1,5 @@
+import type { EmbeddingsInterface } from '@langchain/core/embeddings';
+import type { MongoDBAtlasVectorSearchLibArgs } from '@langchain/mongodb';
 import { MongoDBAtlasVectorSearch } from '@langchain/mongodb';
 import { metadataFilterField } from '@utils/sharedFields';
 import { MongoClient } from 'mongodb';
@@ -204,92 +206,129 @@ export const getVectorIndexName = getParameter.bind(null, VECTOR_INDEX_NAME);
 export const getEmbeddingFieldName = getParameter.bind(null, EMBEDDING_NAME);
 export const getMetadataFieldName = getParameter.bind(null, METADATA_FIELD_NAME);
 
-export class VectorStoreMongoDBAtlas extends createVectorStoreNode({
-	meta: {
-		displayName: 'MongoDB Atlas Vector Store',
-		name: 'vectorStoreMongoDBAtlas',
-		description: 'Work with your data in MongoDB Atlas Vector Store',
-		icon: { light: 'file:mongodb.svg', dark: 'file:mongodb.dark.svg' },
-		docsUrl:
-			'https://docs.n8n.io/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoremongodbatlas/',
-		credentials: [
-			{
-				name: 'mongoDb',
-				required: true,
-			},
-		],
-		operationModes: ['load', 'insert', 'retrieve', 'update', 'retrieve-as-tool'],
-	},
-	methods: { listSearch: { mongoCollectionSearch: getCollections } },
-	retrieveFields,
-	loadFields: retrieveFields,
-	insertFields,
-	sharedFields,
-	async getVectorStoreClient(context, _filter, embeddings, itemIndex) {
-		const client = await getMongoClient(context);
-		try {
-			const db = await getDatabase(context, client);
-			const collectionName = getCollectionName(context, itemIndex);
-			const mongoVectorIndexName = getVectorIndexName(context, itemIndex);
-			const embeddingFieldName = getEmbeddingFieldName(context, itemIndex);
-			const metadataFieldName = getMetadataFieldName(context, itemIndex);
+/**
+ * Convenience method to get all the required field names in one shot.
+ * @param context - The context.
+ * @param itemIndex - The index.
+ * @returns The field names.
+ */
+function getFieldNames(context: IFunctionsContext, itemIndex: number) {
+	return {
+		collectionName: getCollectionName(context, itemIndex),
+		mongoVectorIndexName: getVectorIndexName(context, itemIndex),
+		embeddingFieldName: getEmbeddingFieldName(context, itemIndex),
+		metadataFieldName: getMetadataFieldName(context, itemIndex),
+	};
+}
 
-			const collection = db.collection(collectionName);
+/**
+ * The MongoClient on the collection needs to be accessible in order to close it properly
+ * when the node needs to release the client. We extend the class here to add access.
+ */
+class ExtendedMongoDBAtlasVectorSearch extends MongoDBAtlasVectorSearch {
+	client: MongoClient;
 
-			// test index exists
-			const indexes = await collection.listSearchIndexes().toArray();
+	constructor(embeddings: EmbeddingsInterface, args: MongoDBAtlasVectorSearchLibArgs) {
+		super(embeddings, args);
+		// @ts-expect-error Client exists on the collection, it's flagged as internal.
+		this.client = args.collection.client as MongoClient;
+	}
+}
 
-			const indexExists = indexes.some((index) => index.name === mongoVectorIndexName);
+/**
+ * The MongoDB Atlas Vector Store node.
+ */
+export class VectorStoreMongoDBAtlas extends createVectorStoreNode<ExtendedMongoDBAtlasVectorSearch>(
+	{
+		meta: {
+			displayName: 'MongoDB Atlas Vector Store',
+			name: 'vectorStoreMongoDBAtlas',
+			description: 'Work with your data in MongoDB Atlas Vector Store',
+			icon: { light: 'file:mongodb.svg', dark: 'file:mongodb.dark.svg' },
+			docsUrl:
+				'https://docs.n8n.io/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoremongodbatlas/',
+			credentials: [
+				{
+					name: 'mongoDb',
+					required: true,
+				},
+			],
+			operationModes: ['load', 'insert', 'retrieve', 'update', 'retrieve-as-tool'],
+		},
+		methods: { listSearch: { mongoCollectionSearch: getCollections } },
+		retrieveFields,
+		loadFields: retrieveFields,
+		insertFields,
+		sharedFields,
+		async getVectorStoreClient(context, _filter, embeddings, itemIndex) {
+			const client = await getMongoClient(context);
+			try {
+				const db = await getDatabase(context, client);
+				const { collectionName, mongoVectorIndexName, embeddingFieldName, metadataFieldName } =
+					getFieldNames(context, itemIndex);
 
-			if (!indexExists) {
-				throw new NodeOperationError(context.getNode(), `Index ${mongoVectorIndexName} not found`, {
+				const collection = db.collection(collectionName);
+
+				// test index exists
+				const indexes = await collection.listSearchIndexes().toArray();
+
+				const indexExists = indexes.some((index) => index.name === mongoVectorIndexName);
+
+				if (!indexExists) {
+					throw new NodeOperationError(
+						context.getNode(),
+						`Index ${mongoVectorIndexName} not found`,
+						{
+							itemIndex,
+							description: 'Please check that the index exists in your collection',
+						},
+					);
+				}
+
+				return new ExtendedMongoDBAtlasVectorSearch(embeddings, {
+					collection,
+					indexName: mongoVectorIndexName, // Default index name
+					textKey: metadataFieldName, // Field containing raw text
+					embeddingKey: embeddingFieldName, // Field containing embeddings
+				});
+			} catch (error) {
+				if (error instanceof NodeOperationError) {
+					throw error;
+				}
+				throw new NodeOperationError(context.getNode(), `Error: ${error.message}`, {
 					itemIndex,
-					description: 'Please check that the index exists in your collection',
+					description: 'Please check your MongoDB Atlas connection details',
 				});
 			}
+		},
+		async populateVectorStore(context, embeddings, documents, itemIndex) {
+			const client = await getMongoClient(context);
+			try {
+				const db = await getDatabase(context, client);
+				const { collectionName, mongoVectorIndexName, embeddingFieldName, metadataFieldName } =
+					getFieldNames(context, itemIndex);
 
-			return new MongoDBAtlasVectorSearch(embeddings, {
-				collection,
-				indexName: mongoVectorIndexName, // Default index name
-				textKey: metadataFieldName, // Field containing raw text
-				embeddingKey: embeddingFieldName, // Field containing embeddings
-			});
-		} catch (error) {
-			if (error instanceof NodeOperationError) {
-				throw error;
+				// Check if collection exists
+				const collections = await db.listCollections({ name: collectionName }).toArray();
+				if (collections.length === 0) {
+					await db.createCollection(collectionName);
+				}
+				const collection = db.collection(collectionName);
+				await ExtendedMongoDBAtlasVectorSearch.fromDocuments(documents, embeddings, {
+					collection,
+					indexName: mongoVectorIndexName, // Default index name
+					textKey: metadataFieldName, // Field containing raw text
+					embeddingKey: embeddingFieldName, // Field containing embeddings
+				});
+			} catch (error) {
+				throw new NodeOperationError(context.getNode(), `Error: ${error.message}`, {
+					itemIndex,
+					description: 'Please check your MongoDB Atlas connection details',
+				});
 			}
-			throw new NodeOperationError(context.getNode(), `Error: ${error.message}`, {
-				itemIndex,
-				description: 'Please check your MongoDB Atlas connection details',
-			});
-		}
+		},
+		releaseVectorStoreClient(vectorStore) {
+			void vectorStore.client?.close();
+		},
 	},
-	async populateVectorStore(context, embeddings, documents, itemIndex) {
-		const client = await getMongoClient(context);
-		try {
-			const db = await getDatabase(context, client);
-			const collectionName = getCollectionName(context, itemIndex);
-			const mongoVectorIndexName = getVectorIndexName(context, itemIndex);
-			const embeddingFieldName = getEmbeddingFieldName(context, itemIndex);
-			const metadataFieldName = getMetadataFieldName(context, itemIndex);
-
-			// Check if collection exists
-			const collections = await db.listCollections({ name: collectionName }).toArray();
-			if (collections.length === 0) {
-				await db.createCollection(collectionName);
-			}
-			const collection = db.collection(collectionName);
-			await MongoDBAtlasVectorSearch.fromDocuments(documents, embeddings, {
-				collection,
-				indexName: mongoVectorIndexName, // Default index name
-				textKey: metadataFieldName, // Field containing raw text
-				embeddingKey: embeddingFieldName, // Field containing embeddings
-			});
-		} catch (error) {
-			throw new NodeOperationError(context.getNode(), `Error: ${error.message}`, {
-				itemIndex,
-				description: 'Please check your MongoDB Atlas connection details',
-			});
-		}
-	},
-}) {}
+) {}

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreMongoDBAtlas/VectorStoreMongoDBAtlas.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreMongoDBAtlas/VectorStoreMongoDBAtlas.node.ts
@@ -1,8 +1,13 @@
 import { MongoDBAtlasVectorSearch } from '@langchain/mongodb';
-import { MongoClient } from 'mongodb';
-import { type ILoadOptionsFunctions, NodeOperationError, type INodeProperties } from 'n8n-workflow';
-
 import { metadataFilterField } from '@utils/sharedFields';
+import { MongoClient } from 'mongodb';
+import {
+	type ILoadOptionsFunctions,
+	NodeOperationError,
+	type INodeProperties,
+	type IExecuteFunctions,
+	type ISupplyDataFunctions,
+} from 'n8n-workflow';
 
 import { createVectorStoreNode } from '../shared/createVectorStoreNode/createVectorStoreNode';
 
@@ -108,8 +113,27 @@ export const mongoConfig = {
 	connectionString: '',
 };
 
+/**
+ * Constants for the name of the credentials and Node parameters.
+ */
+export const MONGODB_CREDENTIALS = 'mongoDb';
+export const MONGODB_COLLECTION_NAME = 'mongoCollection';
+export const VECTOR_INDEX_NAME = 'vectorIndexName';
+export const EMBEDDING_NAME = 'embedding';
+export const METADATA_FIELD_NAME = 'metadata_field';
+
+/**
+ * Type used for cleaner, more intentional typing.
+ */
+type IFunctionsContext = IExecuteFunctions | ISupplyDataFunctions | ILoadOptionsFunctions;
+
+/**
+ * Get the mongo client.
+ * @param context - The context.
+ * @returns the MongoClient for the node.
+ */
 export async function getMongoClient(context: any) {
-	const credentials = await context.getCredentials('mongoDb');
+	const credentials = await context.getCredentials(MONGODB_CREDENTIALS);
 	const connectionString = credentials.connectionString as string;
 	if (!mongoConfig.client || mongoConfig.connectionString !== connectionString) {
 		if (mongoConfig.client) {
@@ -125,15 +149,24 @@ export async function getMongoClient(context: any) {
 	return mongoConfig.client;
 }
 
-async function mongoClientAndDatabase(context: any) {
-	const client = await getMongoClient(context);
-	const credentials = await context.getCredentials('mongoDb');
-	const db = client.db(credentials.database as string);
-	return { client, db };
+/**
+ * Get the database object from the MongoClient by the configured name.
+ * @param context - The context.
+ * @returns the Db object.
+ */
+export async function getDatabase(context: IFunctionsContext, client: MongoClient) {
+	const credentials = await context.getCredentials(MONGODB_CREDENTIALS);
+	return client.db(credentials.database as string);
 }
 
-async function mongoCollectionSearch(this: ILoadOptionsFunctions) {
-	const { db } = await mongoClientAndDatabase(this);
+/**
+ * Get all the collection in the database.
+ * @param this The load options context.
+ * @returns The list of collections.
+ */
+export async function getCollections(this: ILoadOptionsFunctions) {
+	const client = await getMongoClient(this);
+	const db = await getDatabase(this, client);
 	try {
 		const collections = await db.listCollections().toArray();
 		const results = collections.map((collection) => ({
@@ -144,8 +177,33 @@ async function mongoCollectionSearch(this: ILoadOptionsFunctions) {
 		return { results };
 	} catch (error) {
 		throw new NodeOperationError(this.getNode(), `Error: ${error.message}`);
+	} finally {
+		await client.close();
 	}
 }
+
+/**
+ * Get a parameter from the context.
+ * @param key - The key of the parameter.
+ * @param context - The context.
+ * @param itemIndex - The index.
+ * @returns The value.
+ */
+export function getParameter(key: string, context: IFunctionsContext, itemIndex: number): string {
+	const value = context.getNodeParameter(key, itemIndex, '', {
+		extractValue: true,
+	}) as string;
+	if (typeof value !== 'string') {
+		throw new NodeOperationError(context.getNode(), `Parameter ${key} must be a string`);
+	}
+	return value;
+}
+
+export const getCollectionName = getParameter.bind(null, MONGODB_COLLECTION_NAME);
+export const getVectorIndexName = getParameter.bind(null, VECTOR_INDEX_NAME);
+export const getEmbeddingFieldName = getParameter.bind(null, EMBEDDING_NAME);
+export const getMetadataFieldName = getParameter.bind(null, METADATA_FIELD_NAME);
+
 export class VectorStoreMongoDBAtlas extends createVectorStoreNode({
 	meta: {
 		displayName: 'MongoDB Atlas Vector Store',
@@ -162,64 +220,44 @@ export class VectorStoreMongoDBAtlas extends createVectorStoreNode({
 		],
 		operationModes: ['load', 'insert', 'retrieve', 'update', 'retrieve-as-tool'],
 	},
-	methods: { listSearch: { mongoCollectionSearch } },
+	methods: { listSearch: { getCollections } },
 	retrieveFields,
 	loadFields: retrieveFields,
 	insertFields,
 	sharedFields,
 	async getVectorStoreClient(context, _filter, embeddings, itemIndex) {
+		const client = await getMongoClient(context);
 		try {
-			const { db } = await mongoClientAndDatabase(context);
-			try {
-				const collectionName = context.getNodeParameter('mongoCollection', itemIndex, '', {
-					extractValue: true,
-				}) as string;
+			const db = await getDatabase(context, client);
+			const collectionName = getCollectionName(context, itemIndex);
+			const mongoVectorIndexName = getVectorIndexName(context, itemIndex);
+			const embeddingFieldName = getEmbeddingFieldName(context, itemIndex);
+			const metadataFieldName = getMetadataFieldName(context, itemIndex);
 
-				const mongoVectorIndexName = context.getNodeParameter('vectorIndexName', itemIndex, '', {
-					extractValue: true,
-				}) as string;
+			const collection = db.collection(collectionName);
 
-				const embeddingFieldName = context.getNodeParameter('embedding', itemIndex, '', {
-					extractValue: true,
-				}) as string;
+			// test index exists
+			const indexes = await collection.listSearchIndexes().toArray();
 
-				const metadataFieldName = context.getNodeParameter('metadata_field', itemIndex, '', {
-					extractValue: true,
-				}) as string;
+			const indexExists = indexes.some((index) => index.name === mongoVectorIndexName);
 
-				const collection = db.collection(collectionName);
-
-				// test index exists
-				const indexes = await collection.listSearchIndexes().toArray();
-
-				const indexExists = indexes.some((index) => index.name === mongoVectorIndexName);
-
-				if (!indexExists) {
-					throw new NodeOperationError(
-						context.getNode(),
-						`Index ${mongoVectorIndexName} not found`,
-						{
-							itemIndex,
-							description: 'Please check that the index exists in your collection',
-						},
-					);
-				}
-
-				return new MongoDBAtlasVectorSearch(embeddings, {
-					collection,
-					indexName: mongoVectorIndexName, // Default index name
-					textKey: metadataFieldName, // Field containing raw text
-					embeddingKey: embeddingFieldName, // Field containing embeddings
-				});
-			} catch (error) {
-				throw new NodeOperationError(context.getNode(), `Error: ${error.message}`, {
+			if (!indexExists) {
+				throw new NodeOperationError(context.getNode(), `Index ${mongoVectorIndexName} not found`, {
 					itemIndex,
-					description: 'Please check your MongoDB Atlas connection details',
+					description: 'Please check that the index exists in your collection',
 				});
-			} finally {
-				// Don't close the client here to maintain connection pooling
 			}
+
+			return new MongoDBAtlasVectorSearch(embeddings, {
+				collection,
+				indexName: mongoVectorIndexName, // Default index name
+				textKey: metadataFieldName, // Field containing raw text
+				embeddingKey: embeddingFieldName, // Field containing embeddings
+			});
 		} catch (error) {
+			if (error instanceof NodeOperationError) {
+				throw error;
+			}
 			throw new NodeOperationError(context.getNode(), `Error: ${error.message}`, {
 				itemIndex,
 				description: 'Please check your MongoDB Atlas connection details',
@@ -227,44 +265,26 @@ export class VectorStoreMongoDBAtlas extends createVectorStoreNode({
 		}
 	},
 	async populateVectorStore(context, embeddings, documents, itemIndex) {
+		const client = await getMongoClient(context);
 		try {
-			const { db } = await mongoClientAndDatabase(context);
-			try {
-				const mongoCollectionName = context.getNodeParameter('mongoCollection', itemIndex, '', {
-					extractValue: true,
-				}) as string;
-				const embeddingFieldName = context.getNodeParameter('embedding', itemIndex, '', {
-					extractValue: true,
-				}) as string;
+			const db = await getDatabase(context, client);
+			const collectionName = getCollectionName(context, itemIndex);
+			const mongoVectorIndexName = getVectorIndexName(context, itemIndex);
+			const embeddingFieldName = getEmbeddingFieldName(context, itemIndex);
+			const metadataFieldName = getMetadataFieldName(context, itemIndex);
 
-				const metadataFieldName = context.getNodeParameter('metadata_field', itemIndex, '', {
-					extractValue: true,
-				}) as string;
-
-				const mongoDBAtlasVectorIndex = context.getNodeParameter('vectorIndexName', itemIndex, '', {
-					extractValue: true,
-				}) as string;
-
-				// Check if collection exists
-				const collections = await db.listCollections({ name: mongoCollectionName }).toArray();
-				if (collections.length === 0) {
-					await db.createCollection(mongoCollectionName);
-				}
-				const collection = db.collection(mongoCollectionName);
-				await MongoDBAtlasVectorSearch.fromDocuments(documents, embeddings, {
-					collection,
-					indexName: mongoDBAtlasVectorIndex, // Default index name
-					textKey: metadataFieldName, // Field containing raw text
-					embeddingKey: embeddingFieldName, // Field containing embeddings
-				});
-			} catch (error) {
-				throw new NodeOperationError(context.getNode(), `Error: ${error.message}`, {
-					itemIndex,
-					description: 'Please check your MongoDB Atlas connection details',
-				});
-			} finally {
-				// Don't close the client here to maintain connection pooling
+			// Check if collection exists
+			const collections = await db.listCollections({ name: collectionName }).toArray();
+			if (collections.length === 0) {
+				await db.createCollection(collectionName);
 			}
+			const collection = db.collection(collectionName);
+			await MongoDBAtlasVectorSearch.fromDocuments(documents, embeddings, {
+				collection,
+				indexName: mongoVectorIndexName, // Default index name
+				textKey: metadataFieldName, // Field containing raw text
+				embeddingKey: embeddingFieldName, // Field containing embeddings
+			});
 		} catch (error) {
 			throw new NodeOperationError(context.getNode(), `Error: ${error.message}`, {
 				itemIndex,

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreMongoDBAtlas/VectorStoreMongoDBAtlas.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreMongoDBAtlas/VectorStoreMongoDBAtlas.node.ts
@@ -220,7 +220,7 @@ export class VectorStoreMongoDBAtlas extends createVectorStoreNode({
 		],
 		operationModes: ['load', 'insert', 'retrieve', 'update', 'retrieve-as-tool'],
 	},
-	methods: { listSearch: { getCollections } },
+	methods: { listSearch: { mongoCollectionSearch: getCollections } },
 	retrieveFields,
 	loadFields: retrieveFields,
 	insertFields,

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreMongoDBAtlas/VectorStoreMongoDBAtlas.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreMongoDBAtlas/VectorStoreMongoDBAtlas.node.ts
@@ -7,7 +7,6 @@ import {
 	type IExecuteFunctions,
 	type ISupplyDataFunctions,
 } from 'n8n-workflow';
-
 import { metadataFilterField } from '@utils/sharedFields';
 
 import { createVectorStoreNode } from '../shared/createVectorStoreNode/createVectorStoreNode';
@@ -166,9 +165,9 @@ export async function getDatabase(context: IFunctionsContext, client: MongoClien
  * @returns The list of collections.
  */
 export async function getCollections(this: ILoadOptionsFunctions) {
-	const client = await getMongoClient(this);
-	const db = await getDatabase(this, client);
 	try {
+		const client = await getMongoClient(this);
+		const db = await getDatabase(this, client);
 		const collections = await db.listCollections().toArray();
 		const results = collections.map((collection) => ({
 			name: collection.name,
@@ -178,8 +177,6 @@ export async function getCollections(this: ILoadOptionsFunctions) {
 		return { results };
 	} catch (error) {
 		throw new NodeOperationError(this.getNode(), `Error: ${error.message}`);
-	} finally {
-		await client.close();
 	}
 }
 
@@ -227,8 +224,8 @@ export class VectorStoreMongoDBAtlas extends createVectorStoreNode({
 	insertFields,
 	sharedFields,
 	async getVectorStoreClient(context, _filter, embeddings, itemIndex) {
-		const client = await getMongoClient(context);
 		try {
+			const client = await getMongoClient(context);
 			const db = await getDatabase(context, client);
 			const collectionName = getCollectionName(context, itemIndex);
 			const mongoVectorIndexName = getVectorIndexName(context, itemIndex);
@@ -266,8 +263,8 @@ export class VectorStoreMongoDBAtlas extends createVectorStoreNode({
 		}
 	},
 	async populateVectorStore(context, embeddings, documents, itemIndex) {
-		const client = await getMongoClient(context);
 		try {
+			const client = await getMongoClient(context);
 			const db = await getDatabase(context, client);
 			const collectionName = getCollectionName(context, itemIndex);
 			const mongoVectorIndexName = getVectorIndexName(context, itemIndex);


### PR DESCRIPTION
## Summary

This refactors the `VectorStoreMongoDBAtlas` to reduce duplication, eliminate excess try/catch blocks, and adds unit tests.

- For listing collections in the node's config dialog, the client now gets created and then closed in the list, which is in line with the behaviour in the general MongoDB Node for CRUD operations.
- Adds unit tests to the vector store node where there previously were none.
- Refactors the Node to get rid of some duplicate code.

Open question: Since this is my introduction to the langchain codebase and the other vector store nodes didn't have any real meaningful tests, is there some preferred way you would like more test coverage and potentially point me in the direction of where to look for examples?

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
