### PR TITLE
chore(Telegram Node): Allow parse mode to be blank

### DIFF
--- a/packages/nodes-base/nodes/Telegram/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Telegram/GenericFunctions.ts
@@ -89,7 +89,7 @@ export function addAdditionalFields(
 			additionalFields.appendAttribution = true;
 		}
 
-		if (!additionalFields.parse_mode) {
+		if (additionalFields.parse_mode == null) {
 			additionalFields.parse_mode = 'Markdown';
 		}
 
@@ -105,6 +105,8 @@ export function addAdditionalFields(
 				body.text = `${body.text}\n\n_${attributionText}_[n8n](${link})`;
 			} else if (additionalFields.parse_mode === 'HTML') {
 				body.text = `${body.text}\n\n<em>${attributionText}</em><a href="${link}" target="_blank">n8n</a>`;
+			} else if (additionalFields.parse_mode === '') {
+				body.text = `${body.text}\n\n${attributionText}n8n (${link})`;
 			}
 		}
 
@@ -120,6 +122,10 @@ export function addAdditionalFields(
 	}
 
 	Object.assign(body, additionalFields);
+
+	if (body.parse_mode === '') {
+		delete body.parse_mode;
+	}
 
 	// Add the reply markup
 	addReplyMarkup.call(this, body, index);

--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -1102,6 +1102,10 @@ export class Telegram implements INodeType {
 										type: 'options',
 										options: [
 											{
+												name: 'None',
+												value: '',
+											},
+											{
 												name: 'Markdown (Legacy)',
 												value: 'Markdown',
 											},
@@ -1742,6 +1746,10 @@ export class Telegram implements INodeType {
 						type: 'options',
 						options: [
 							{
+								name: 'None',
+								value: '',
+							},
+							{
 								name: 'Markdown (Legacy)',
 								value: 'Markdown',
 							},
@@ -1923,6 +1931,10 @@ export class Telegram implements INodeType {
 						name: 'parse_mode',
 						type: 'options',
 						options: [
+							{
+								name: 'None',
+								value: '',
+							},
 							{
 								name: 'Markdown (Legacy)',
 								value: 'Markdown',
@@ -2328,6 +2340,9 @@ export class Telegram implements INodeType {
 								Object.assign(mediaItem, mediaItem.additionalFields);
 								delete mediaItem.additionalFields;
 							}
+							if (mediaItem.parse_mode === '') {
+								delete mediaItem.parse_mode;
+							}
 							(body.media as IDataObject[]).push(mediaItem);
 						}
 					} else if (operation === 'sendPhoto') {
@@ -2386,6 +2401,9 @@ export class Telegram implements INodeType {
 
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						Object.assign(body, additionalFields);
+						if (body.parse_mode === '') {
+							delete body.parse_mode;
+						}
 					} else if (operation === 'sendRichMessage' || operation === 'sendRichMessageDraft') {
 						// ----------------------------------------------
 						//   message:sendRichMessage/sendRichMessageDraft

--- a/packages/nodes-base/nodes/Telegram/tests/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Telegram/tests/GenericFunctions.test.ts
@@ -160,6 +160,34 @@ describe('Telegram > GenericFunctions', () => {
 			});
 		});
 
+		it('should omit parse_mode when None is selected', () => {
+			const body: IDataObject = { text: 'Hello, world!' };
+			const index = 0;
+			const nodeVersion = 1.1;
+			const instanceId = '45';
+
+			(mockThis.getNodeParameter as Mock).mockImplementation((paramName: string) => {
+				switch (paramName) {
+					case 'operation':
+						return 'sendMessage';
+					case 'additionalFields':
+						return { parse_mode: '', appendAttribution: true };
+					case 'replyMarkup':
+						return 'none';
+					default:
+						return '';
+				}
+			});
+
+			addAdditionalFields.call(mockThis, body, index, nodeVersion, instanceId);
+
+			expect(body).toEqual({
+				text: 'Hello, world!\n\nThis message was sent automatically with n8n (https://n8n.io/?utm_source=n8n-internal&utm_medium=powered_by&utm_campaign=n8n-nodes-base.telegram_45)',
+				disable_web_page_preview: true,
+			});
+			expect(body).not.toHaveProperty('parse_mode');
+		});
+
 		it('should add reply markup for inlineKeyboard', () => {
 			const body: IDataObject = { text: 'Hello, world!' };
 			const index = 0;

--- a/packages/nodes-base/nodes/Telegram/tests/Telegram.node.test.ts
+++ b/packages/nodes-base/nodes/Telegram/tests/Telegram.node.test.ts
@@ -753,6 +753,63 @@ describe('Telegram node', () => {
 		});
 	});
 
+	describe('message:sendMediaGroup', () => {
+		it('should omit empty parse_mode values from media items', async () => {
+			executeFunctionsMock.getNodeParameter.mockImplementation((p) => {
+				switch (p) {
+					case 'resource':
+						return 'message';
+					case 'operation':
+						return 'sendMediaGroup';
+					case 'binaryData':
+						return false;
+					case 'chatId':
+						return '123456789';
+					case 'additionalFields':
+						return {};
+					case 'media':
+						return {
+							media: [
+								{
+									type: 'photo',
+									media: 'photo-1',
+									additionalFields: { caption: 'Plain text', parse_mode: '' },
+								},
+								{
+									type: 'photo',
+									media: 'photo-2',
+									additionalFields: { caption: '<b>HTML</b>', parse_mode: 'HTML' },
+								},
+							],
+						};
+					default:
+						return undefined;
+				}
+			});
+			apiRequestSpy.mockResolvedValue([{ ok: true, result: true }]);
+
+			await node.execute.call(executeFunctionsMock);
+
+			expect(apiRequestSpy).toHaveBeenCalledWith(
+				'POST',
+				'sendMediaGroup',
+				{
+					chat_id: '123456789',
+					media: [
+						{ type: 'photo', media: 'photo-1', caption: 'Plain text' },
+						{
+							type: 'photo',
+							media: 'photo-2',
+							caption: '<b>HTML</b>',
+							parse_mode: 'HTML',
+						},
+					],
+				},
+				{},
+			);
+		});
+	});
+
 	describe('message:sendMessageDraft', () => {
 		it('should send the draft with chat_id, draft_id, text and additional fields', async () => {
 			executeFunctionsMock.getNodeParameter.mockImplementation((p) => {
@@ -787,6 +844,44 @@ describe('Telegram node', () => {
 					draft_id: 42,
 					text: 'Generating an answer',
 					parse_mode: 'HTML',
+					message_thread_id: 7,
+				},
+				{},
+			);
+		});
+
+		it('should omit parse_mode when None is selected', async () => {
+			executeFunctionsMock.getNodeParameter.mockImplementation((p) => {
+				switch (p) {
+					case 'resource':
+						return 'message';
+					case 'operation':
+						return 'sendMessageDraft';
+					case 'binaryData':
+						return false;
+					case 'chatId':
+						return '123456789';
+					case 'draftId':
+						return 42;
+					case 'text':
+						return 'Generating an answer';
+					case 'additionalFields':
+						return { parse_mode: '', message_thread_id: 7 };
+					default:
+						return undefined;
+				}
+			});
+			apiRequestSpy.mockResolvedValue([{ ok: true, result: true }]);
+
+			await node.execute.call(executeFunctionsMock);
+
+			expect(apiRequestSpy).toHaveBeenCalledWith(
+				'POST',
+				'sendMessageDraft',
+				{
+					chat_id: '123456789',
+					draft_id: 42,
+					text: 'Generating an answer',
 					message_thread_id: 7,
 				},
 				{},


### PR DESCRIPTION
## Summary
This PR allows users to set the parse_mode to be "None", which means that the parse_mode option will not be sent when calling the Telegram Bot API method.

For cases where users want to freely write plain text without worrying about special characters, "HTML" is not an ideal workaround as it contains its own set of special characters to take note of and escape.

Reference:
https://t.me/grammyjs/288130
https://core.telegram.org/bots/api#html-style

## Related Linear tickets, Github issues, and Community forum posts

Potentially related issues include: https://github.com/n8n-io/n8n/issues/13376

Where recommendations of "HTML" parse_mode may work on a case-by-case basis, it does not always work as HTML also has its own set of characters it must escape.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
