### PR TITLE
fix(core): Prevent queue starvation from subworkflow executions

### DIFF
--- a/packages/cli/src/__tests__/workflow-runner.test.ts
+++ b/packages/cli/src/__tests__/workflow-runner.test.ts
@@ -299,4 +299,25 @@ describe('enqueueExecution', () => {
 
 		expect(setupQueue).toHaveBeenCalledTimes(1);
 	});
+
+	it('should assign subworkflow executions a priority of 25', async () => {
+		runner.setExecutionMode('queue');
+
+		const activeExecutions = Container.get(ActiveExecutions);
+		jest.spyOn(activeExecutions, 'add').mockResolvedValue('1');
+		jest.spyOn(activeExecutions, 'attachWorkflowExecution').mockReturnValue();
+		const permissionChecker = Container.get(CredentialsPermissionChecker);
+		jest.spyOn(permissionChecker, 'check').mockResolvedValueOnce();
+
+		const data = mock<IWorkflowExecutionDataProcess>({
+			workflowData: { nodes: [] },
+			executionMode: 'integrated',
+		});
+
+		addJob.mockResolvedValueOnce({ finished: jest.fn().mockResolvedValue(undefined) });
+
+		await runner.run(data);
+
+		expect(addJob).toHaveBeenCalledWith(expect.any(Object), { priority: 25 });
+	});
 });

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -167,7 +167,8 @@ export class WorkflowRunner {
 				: this.executionsMode === 'queue' && data.executionMode !== 'manual';
 
 		if (shouldEnqueue) {
-			await this.enqueueExecution(executionId, data, loadStaticData, realtime);
+			const priority = data.executionMode === 'integrated' ? 25 : realtime ? 50 : 100;
+			await this.enqueueExecution(executionId, data, loadStaticData, priority);
 		} else {
 			await this.runMainProcess(executionId, data, loadStaticData, restartExecutionId);
 		}
@@ -337,7 +338,7 @@ export class WorkflowRunner {
 		executionId: string,
 		data: IWorkflowExecutionDataProcess,
 		loadStaticData?: boolean,
-		realtime?: boolean,
+		priority = 100,
 	): Promise<void> {
 		const jobData: JobData = {
 			executionId,
@@ -356,7 +357,7 @@ export class WorkflowRunner {
 		let job: Job;
 		let lifecycleHooks: ExecutionLifecycleHooks;
 		try {
-			job = await this.scalingService.addJob(jobData, { priority: realtime ? 50 : 100 });
+			job = await this.scalingService.addJob(jobData, { priority });
 
 			lifecycleHooks = getLifecycleHooksForScalingMain(data, executionId);
 


### PR DESCRIPTION
## Summary

Follow-up to #16094

Since workers enqueue subworkflow executions like any other job, we risk a scenario where a high volume of incoming jobs that require subworkflow calls can lead to queue starvation, i.e. workers enqueuing child executions but never getting to them, bringing processing to a halt. This change protects against this by prioritizing subworkflow executions over webhook and regular executions.

## Related Linear tickets, Github issues, and Community forum posts

n/a

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
