### PR TITLE
refactor(core): Extend task runner force shutdown timeout

### DIFF
--- a/packages/@n8n/task-runner/src/start.ts
+++ b/packages/@n8n/task-runner/src/start.ts
@@ -59,7 +59,7 @@ void (async function start() {
 	runner = new JsTaskRunner(config);
 	runner.on('runner:reached-idle-timeout', () => {
 		// Use shorter timeout since we know we don't have any tasks running
-		void createSignalHandler('IDLE_TIMEOUT', 1)();
+		void createSignalHandler('IDLE_TIMEOUT', 3)();
 	});
 
 	const { enabled, host, port } = config.baseRunnerConfig.healthcheckServer;


### PR DESCRIPTION
## Summary

On idle timeout, task runners set a force shutdown timeout of 1s. This length has turned out to be [too aggressive](https://linear.app/n8n/issue/PAY-2885/investigate-root-cause-of-community-license-failures#comment-30e8687b) in production. The force shutdown is mostly harmless, but can be misleading to see a frequent non-zero error code when debugging.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
