### PR TITLE
perf(core)!: Switch transliteration lib

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -20,7 +20,7 @@ const config = {
 	testRegex: '\\.(test|spec)\\.(js|ts)$',
 	testPathIgnorePatterns: ['/dist/', '/node_modules/'],
 	transform: {
-		'^.+\\.ts$': ['ts-jest', tsJestOptions],
+		'^.+\\.(t|j)s$': ['ts-jest', tsJestOptions],
 		'node_modules/pdfjs-dist/.+\\.mjs$': [
 			'babel-jest',
 			{
@@ -29,7 +29,10 @@ const config = {
 			},
 		],
 	},
-	transformIgnorePatterns: ['/dist/', '/node_modules/(?!.*pdfjs-dist/)'],
+	transformIgnorePatterns: [
+		'/dist/',
+		'/node_modules/(?!.*(pdfjs-dist|@sindresorhus/transliterate|escape-string-regexp)/)',
+	],
 	// This resolve the path mappings from the tsconfig relative to each jest.config.js
 	moduleNameMapper: compilerOptions?.paths
 		? pathsToModuleNameMapper(compilerOptions.paths, {

--- a/packages/cli/BREAKING-CHANGES.md
+++ b/packages/cli/BREAKING-CHANGES.md
@@ -2,6 +2,16 @@
 
 This list shows all the versions which include breaking changes and how to upgrade.
 
+## 1.99.0
+
+### What changed?
+
+The expression extension `String.replaceSpecialChars` no longer supports Chinese characters.
+
+### When is action necessary?
+
+If you are using the expression extension `String.replaceSpecialChars` on Chinese characters, please install a community node that supports transliteration of Chinese characters, e.g. `n8n-nodes-transliterate`.
+
 ## 1.98.0
 
 ### What changed?

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@n8n/tournament": "1.0.6",
+    "@sindresorhus/transliterate": "^1.6.0",
     "ast-types": "0.15.2",
     "callsites": "catalog:",
     "esprima-next": "5.8.4",
@@ -54,7 +55,6 @@
     "md5": "2.3.0",
     "recast": "0.22.0",
     "title-case": "3.0.3",
-    "transliteration": "2.3.5",
     "xml2js": "catalog:",
     "zod": "catalog:"
   }

--- a/packages/workflow/src/extensions/string-extensions.ts
+++ b/packages/workflow/src/extensions/string-extensions.ts
@@ -1,9 +1,9 @@
+import transliterate from '@sindresorhus/transliterate';
 import { toBase64, fromBase64 } from 'js-base64';
 import SHA from 'jssha';
 import { DateTime } from 'luxon';
 import MD5 from 'md5';
 import { titleCase } from 'title-case';
-import { transliterate } from 'transliteration';
 
 import type { Extension, ExtensionMap } from './extensions';
 import { toDateTime as numberToDateTime } from './number-extensions';
@@ -332,7 +332,7 @@ function toTitleCase(value: string) {
 }
 
 function replaceSpecialChars(value: string) {
-	return transliterate(value, { unknown: '?' });
+	return transliterate(value);
 }
 
 function toSentenceCase(value: string) {
@@ -609,7 +609,8 @@ urlDecode.doc = {
 
 replaceSpecialChars.doc = {
 	name: 'replaceSpecialChars',
-	description: 'Replaces special characters in the string with the closest ASCII character',
+	description:
+		'Replaces special characters in the string with the closest ASCII character (Chinese not supported)',
 	section: 'edit',
 	returnType: 'string',
 	docURL:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2746,6 +2746,9 @@ importers:
       '@n8n/tournament':
         specifier: 1.0.6
         version: 1.0.6
+      '@sindresorhus/transliterate':
+        specifier: ^1.6.0
+        version: 1.6.0
       ast-types:
         specifier: 0.15.2
         version: 0.15.2
@@ -2782,9 +2785,6 @@ importers:
       title-case:
         specifier: 3.0.3
         version: 3.0.3
-      transliteration:
-        specifier: 2.3.5
-        version: 2.3.5
       xml2js:
         specifier: 'catalog:'
         version: 0.6.2
@@ -5877,6 +5877,10 @@ packages:
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
+  '@sindresorhus/transliterate@1.6.0':
+    resolution: {integrity: sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ==}
+    engines: {node: '>=12'}
+
   '@sinonjs/commons@2.0.0':
     resolution: {integrity: sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==}
 
@@ -8895,6 +8899,10 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
 
   escodegen@1.14.3:
     resolution: {integrity: sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==}
@@ -13487,11 +13495,6 @@ packages:
   tr46@5.0.0:
     resolution: {integrity: sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==}
     engines: {node: '>=18'}
-
-  transliteration@2.3.5:
-    resolution: {integrity: sha512-HAGI4Lq4Q9dZ3Utu2phaWgtm3vB6PkLUFqWAScg/UW+1eZ/Tg6Exo4oC0/3VUol/w4BlefLhUUSVBr/9/ZGQOw==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -18695,6 +18698,10 @@ snapshots:
 
   '@sinclair/typebox@0.27.8': {}
 
+  '@sindresorhus/transliterate@1.6.0':
+    dependencies:
+      escape-string-regexp: 5.0.0
+
   '@sinonjs/commons@2.0.0':
     dependencies:
       type-detect: 4.0.8
@@ -22485,6 +22492,8 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  escape-string-regexp@5.0.0: {}
+
   escodegen@1.14.3:
     dependencies:
       esprima: 4.0.1
@@ -22529,7 +22538,7 @@ snapshots:
 
   eslint-import-resolver-node@0.3.9:
     dependencies:
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7(supports-color@8.1.1)
       is-core-module: 2.13.1
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -22554,7 +22563,7 @@ snapshots:
 
   eslint-module-utils@2.8.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7(supports-color@8.1.1)
     optionalDependencies:
       '@typescript-eslint/parser': 7.2.0(eslint@8.57.0)(typescript@5.8.2)
       eslint: 8.57.0
@@ -22574,7 +22583,7 @@ snapshots:
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.2
       array.prototype.flatmap: 1.3.2
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7(supports-color@8.1.1)
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
@@ -23403,7 +23412,7 @@ snapshots:
       array-parallel: 0.1.3
       array-series: 0.1.5
       cross-spawn: 7.0.6
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -26295,7 +26304,7 @@ snapshots:
 
   pdf-parse@1.1.1:
     dependencies:
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7(supports-color@8.1.1)
       node-ensure: 0.0.0
     transitivePeerDependencies:
       - supports-color
@@ -27124,7 +27133,7 @@ snapshots:
 
   rhea@1.0.24:
     dependencies:
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -28211,10 +28220,6 @@ snapshots:
   tr46@5.0.0:
     dependencies:
       punycode: 2.3.1
-
-  transliteration@2.3.5:
-    dependencies:
-      yargs: 17.7.2
 
   tree-kill@1.2.2: {}
 


### PR DESCRIPTION
## Summary

The introduction of expression extensions at #4372 brought in the `transliteration` lib for the niche extension `String.replaceSpecialChars`. This is a heavy lib that [increases memory usage in all expressions code](https://n8nio.slack.com/archives/C069HS026UF/p1748599808777319) across mains, workers, and runners. Hence this PR switches this lib to the more lightweight `@sindresorhus/transliterate`.

**Breaking change:** This change removes built-in support for transliterating Chinese characters, which are now returned as is by the extension. To restore this functionality, please install a community node like `n8n-nodes-transliterate`.

## Related Linear tickets, Github issues, and Community forum posts

n/a

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
