### PR TITLE
fix(editor): Prevent node renaming to restricted JS method names

### DIFF
--- a/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
@@ -301,7 +301,15 @@ export function useCanvasOperations() {
 
 		// Rename the node and update the connections
 		const workflow = workflowsStore.getCurrentWorkflow(true);
-		workflow.renameNode(currentName, newName);
+		try {
+			workflow.renameNode(currentName, newName);
+		} catch (error) {
+			toast.showMessage({
+				type: 'error',
+				title: error.message,
+				message: error.description,
+			});
+		}
 
 		if (trackHistory) {
 			historyStore.pushCommandToUndo(new RenameNodeCommand(currentName, newName, Date.now()));

--- a/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
@@ -309,6 +309,7 @@ export function useCanvasOperations() {
 				title: error.message,
 				message: error.description,
 			});
+			return;
 		}
 
 		if (trackHistory) {

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -389,6 +389,13 @@ export class Workflow {
 			'toLocaleString',
 			'toString',
 			'valueOf',
+			'constructor',
+			'prototype',
+			'__proto__',
+			'__defineGetter__',
+			'__defineSetter__',
+			'__lookupGetter__',
+			'__lookupSetter__',
 		];
 
 		if (restrictedKeys.map((k) => k.toLowerCase()).includes(newName.toLowerCase())) {

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -7,6 +7,7 @@ import {
 	NODES_WITH_RENAMABLE_CONTENT,
 	STARTING_NODE_TYPES,
 } from './constants';
+import { UserError } from './errors';
 import { ApplicationError } from './errors/application.error';
 import { Expression } from './expression';
 import { getGlobalState } from './global-state';
@@ -379,6 +380,22 @@ export class Workflow {
 	 * @param {string} newName The new name
 	 */
 	renameNode(currentName: string, newName: string) {
+		// These keys are excluded to prevent accidental modification of inherited properties and
+		// to avoid any issues related to JavaScript's built-in methods that can cause unexpected behavior
+		const restrictedKeys = [
+			'hasOwnProperty',
+			'isPrototypeOf',
+			'propertyIsEnumerable',
+			'toLocaleString',
+			'toString',
+			'valueOf',
+		];
+
+		if (restrictedKeys.map((k) => k.toLowerCase()).includes(newName.toLowerCase())) {
+			throw new UserError(`Node name "${newName}" is a restricted name.`, {
+				description: `Node names cannot be any of the following: ${restrictedKeys.join(', ')}`,
+			});
+		}
 		// Rename the node itself
 		if (this.nodes[currentName] !== undefined) {
 			this.nodes[newName] = this.nodes[currentName];

--- a/packages/workflow/test/workflow.test.ts
+++ b/packages/workflow/test/workflow.test.ts
@@ -17,6 +17,7 @@ import { Workflow } from '@/workflow';
 process.env.TEST_VARIABLE_1 = 'valueEnvVariable1';
 
 import * as Helpers from './helpers';
+import { UserError } from '@/errors';
 
 interface StubNode {
 	name: string;
@@ -1077,6 +1078,122 @@ describe('Workflow', () => {
 				expect(workflow.connectionsBySourceNode).toEqual(testData.output.connections);
 			});
 		}
+
+		describe('with restricted node names', () => {
+			const restrictedNames = [
+				'hasOwnProperty',
+				'isPrototypeOf',
+				'propertyIsEnumerable',
+				'toLocaleString',
+				'toString',
+				'valueOf',
+			];
+
+			test.each(restrictedNames)(
+				'should throw error when renaming node to %s',
+				(restrictedName) => {
+					const workflow = new Workflow({
+						nodes: [
+							{
+								name: 'Node1',
+								parameters: {},
+								type: 'test.set',
+								typeVersion: 1,
+								id: 'uuid-1',
+								position: [100, 100],
+							},
+						],
+						connections: {},
+						active: false,
+						nodeTypes,
+					});
+
+					expect(() => workflow.renameNode('Node1', restrictedName)).toThrow(
+						`Node name "${restrictedName}" is a restricted name.`,
+					);
+				},
+			);
+
+			test.each(restrictedNames)(
+				'should throw error when renaming node to %s with different case',
+				(restrictedName) => {
+					const workflow = new Workflow({
+						nodes: [
+							{
+								name: 'Node1',
+								parameters: {},
+								type: 'test.set',
+								typeVersion: 1,
+								id: 'uuid-1',
+								position: [100, 100],
+							},
+						],
+						connections: {},
+						active: false,
+						nodeTypes,
+					});
+
+					const upperCaseName = restrictedName.toUpperCase();
+					expect(() => workflow.renameNode('Node1', upperCaseName)).toThrow(
+						`Node name "${upperCaseName}" is a restricted name.`,
+					);
+				},
+			);
+
+			test('should throw error with proper description', () => {
+				const workflow = new Workflow({
+					nodes: [
+						{
+							name: 'Node1',
+							parameters: {},
+							type: 'test.set',
+							typeVersion: 1,
+							id: 'uuid-1',
+							position: [100, 100],
+						},
+					],
+					connections: {},
+					active: false,
+					nodeTypes,
+				});
+
+				try {
+					workflow.renameNode('Node1', 'toString');
+				} catch (error) {
+					if (!(error instanceof UserError)) {
+						throw new Error('Expected error to be an instance of UserError');
+					}
+					expect(error).toBeInstanceOf(UserError);
+					expect(error.message).toBe('Node name "toString" is a restricted name.');
+					expect(error.description).toBe(
+						'Node names cannot be any of the following: hasOwnProperty, isPrototypeOf, propertyIsEnumerable, toLocaleString, toString, valueOf',
+					);
+				}
+			});
+
+			test('should allow renaming to names that contain restricted names as substring', () => {
+				const workflow = new Workflow({
+					nodes: [
+						{
+							name: 'Node1',
+							parameters: {},
+							type: 'test.set',
+							typeVersion: 1,
+							id: 'uuid-1',
+							position: [100, 100],
+						},
+					],
+					connections: {},
+					active: false,
+					nodeTypes,
+				});
+
+				// These should not throw as they're not exact matches
+				expect(() => workflow.renameNode('Node1', 'myToString')).not.toThrow();
+				expect(() => workflow.renameNode('Node1', 'toStringNode')).not.toThrow();
+				expect(() => workflow.renameNode('Node1', 'hasOwnPropertyChecker')).not.toThrow();
+			});
+		});
 	});
 
 	describe('getParameterValue', () => {

--- a/packages/workflow/test/workflow.test.ts
+++ b/packages/workflow/test/workflow.test.ts
@@ -1,5 +1,6 @@
 import { mock } from 'jest-mock-extended';
 
+import { UserError } from '@/errors';
 import { NodeConnectionTypes } from '@/interfaces';
 import type {
 	IBinaryKeyData,
@@ -17,7 +18,6 @@ import { Workflow } from '@/workflow';
 process.env.TEST_VARIABLE_1 = 'valueEnvVariable1';
 
 import * as Helpers from './helpers';
-import { UserError } from '@/errors';
 
 interface StubNode {
 	name: string;
@@ -1087,6 +1087,13 @@ describe('Workflow', () => {
 				'toLocaleString',
 				'toString',
 				'valueOf',
+				'constructor',
+				'prototype',
+				'__proto__',
+				'__defineGetter__',
+				'__defineSetter__',
+				'__lookupGetter__',
+				'__lookupSetter__',
 			];
 
 			test.each(restrictedNames)(
@@ -1166,7 +1173,7 @@ describe('Workflow', () => {
 					expect(error).toBeInstanceOf(UserError);
 					expect(error.message).toBe('Node name "toString" is a restricted name.');
 					expect(error.description).toBe(
-						'Node names cannot be any of the following: hasOwnProperty, isPrototypeOf, propertyIsEnumerable, toLocaleString, toString, valueOf',
+						'Node names cannot be any of the following: hasOwnProperty, isPrototypeOf, propertyIsEnumerable, toLocaleString, toString, valueOf, constructor, prototype, __proto__, __defineGetter__, __defineSetter__, __lookupGetter__, __lookupSetter__',
 					);
 				}
 			});


### PR DESCRIPTION
## Summary

## Problem
Renaming nodes to JavaScript built-in method names like "toString", "hasOwnProperty", "valueOf", etc. breaks workflow functionality. This occurs because these names conflict with Object.prototype methods when nodes are stored and accessed as object properties.

## Solution
Adds validation in `Workflow.renameNode()` to block restricted names:
- Validates against a list of JS object built-in method names
- Allows names containing restricted words as substrings (e.g., "myToString" is permitted)
- Throws `UserError` with message listing all restricted names
- Implements error handling in `useCanvasOperations` to display toast messages when renaming fails

## Alternative Approach Considered
Initially attempted to fix this by replacing all `object.hasOwnProperty(key)` calls with `Object.prototype.hasOwnProperty.call(object, key)` throughout the codebase (see commit cc976c2235e0bec1284ce037937250efd928e86f). While this approach would technically allow reserved names to be used, it was deemed too risky due to:
- Extensive changes required across multiple files
- Uncertainty about all the places where node names are used for object property access
- Potential for introducing subtle bugs in edge cases
- Risk of missing some usage patterns


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
resolves #14919


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
