### PR TITLE
fix(Gmail Node): Do not break threads while creating drafts

### DIFF
--- a/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
@@ -250,7 +250,7 @@ export async function encodeEmail(email: IEmail) {
 
 	const mailBody = await mail.build();
 
-	return mailBody.toString('base64').replace(/\+/g, '-').replace(/\//g, '_');
+	return mailBody.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }
 
 export async function googleApiRequestAllItems(

--- a/packages/nodes-base/nodes/Google/Gmail/test/v2/GmailV2.node.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/v2/GmailV2.node.test.ts
@@ -194,10 +194,10 @@ describe('Test Gmail Node v2', () => {
 				.reply(200, messages[0]);
 			gmailNock.delete('/v1/users/me/drafts/test-draft-id').reply(200, messages[0]);
 			gmailNock
-				.get('/gmail/v1/users/me/threads/test-thread-id')
+				.get('/v1/users/me/threads/test-thread-id')
 				.query({
 					format: 'metadata',
-					metadataHeaders: 'Message-ID', // Not an array!
+					metadataHeaders: 'Message-ID',
 				})
 				.reply(200, {
 					messages: [{ payload: { headers: ['jjkjkjkf@reply.com'] } }],

--- a/packages/nodes-base/nodes/Google/Gmail/test/v2/GmailV2.node.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/v2/GmailV2.node.test.ts
@@ -194,6 +194,15 @@ describe('Test Gmail Node v2', () => {
 				.reply(200, messages[0]);
 			gmailNock.delete('/v1/users/me/drafts/test-draft-id').reply(200, messages[0]);
 			gmailNock
+				.get('/gmail/v1/users/me/threads/test-thread-id')
+				.query({
+					format: 'metadata',
+					metadataHeaders: 'Message-ID', // Not an array!
+				})
+				.reply(200, {
+					messages: [{ payload: { headers: ['jjkjkjkf@reply.com'] } }],
+				});
+			gmailNock
 				.get('/v1/users/me/drafts/test-draft-id')
 				.query({ format: 'raw' })
 				.reply(200, {

--- a/packages/nodes-base/nodes/Google/Gmail/test/v2/utils.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/v2/utils.test.ts
@@ -2,7 +2,11 @@ import { mock } from 'jest-mock-extended';
 import { DateTime } from 'luxon';
 import type { IExecuteFunctions, INode } from 'n8n-workflow';
 
+import type { IEmail } from '@utils/sendAndWait/interfaces';
+
+import * as GenericFunctions from '../../GenericFunctions';
 import { parseRawEmail, prepareTimestamp } from '../../GenericFunctions';
+import { addThreadHeadersToEmail } from '../../v2/utils/draft';
 
 const node: INode = {
 	id: '1',
@@ -126,5 +130,75 @@ describe('parseRawEmail', () => {
 
 		// ASSERT
 		expect(typeof json.date).toBe('string');
+	});
+});
+
+describe('addThreadHeadersToEmail', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should set inReplyTo and reference on the email object', async () => {
+		const mockThreadId = 'thread123';
+		const mockMessageId = '<message-id@example.com>';
+		const mockThread = {
+			messages: [
+				{ payload: { headers: [{ value: '<old-id@example.com>' }] } },
+				{ payload: { headers: [{ value: mockMessageId }] } },
+			],
+		};
+
+		jest.spyOn(GenericFunctions, 'googleApiRequest').mockImplementation(async function () {
+			return mockThread;
+		});
+
+		const email = mock<IEmail>({});
+
+		const thisArg = mock<IExecuteFunctions>({});
+
+		await addThreadHeadersToEmail.call(thisArg, email, mockThreadId);
+
+		expect(email.inReplyTo).toBe(mockMessageId);
+		expect(email.reference).toBe(mockMessageId);
+	});
+
+	it('should set inReplyTo and reference on the email object even if the message has only one item', async () => {
+		const mockThreadId = 'thread123';
+		const mockMessageId = '<message-id@example.com>';
+		const mockThread = {
+			messages: [{ payload: { headers: [{ value: mockMessageId }] } }],
+		};
+
+		jest.spyOn(GenericFunctions, 'googleApiRequest').mockImplementation(async function () {
+			return mockThread;
+		});
+
+		const email = mock<IEmail>({});
+
+		const thisArg = mock<IExecuteFunctions>({});
+
+		await addThreadHeadersToEmail.call(thisArg, email, mockThreadId);
+
+		expect(email.inReplyTo).toBe(mockMessageId);
+		expect(email.reference).toBe(mockMessageId);
+	});
+
+	it('should not do anything if the thread has no messages', async () => {
+		const mockThreadId = 'thread123';
+		const mockThread = {};
+
+		jest.spyOn(GenericFunctions, 'googleApiRequest').mockImplementation(async function () {
+			return mockThread;
+		});
+
+		const email = mock<IEmail>({});
+
+		const thisArg = mock<IExecuteFunctions>({});
+
+		await addThreadHeadersToEmail.call(thisArg, email, mockThreadId);
+
+		// We are using mock<IEmail>({}) which means the value of these will be a mock function
+		expect(typeof email.inReplyTo).toBe('function');
+		expect(typeof email.reference).toBe('function');
 	});
 });

--- a/packages/nodes-base/nodes/Google/Gmail/v2/DraftDescription.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/DraftDescription.ts
@@ -68,7 +68,7 @@ export const draftFields: INodeProperties[] = [
 	},
 	{
 		displayName:
-			'If you would like to reply to an existing thread, specify the same subject title as the thread you want to reply to here.',
+			'To reply to an existing thread, specify the exact subject title of that thread.',
 		name: 'threadNotice',
 		type: 'notice',
 		default: '',

--- a/packages/nodes-base/nodes/Google/Gmail/v2/DraftDescription.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/DraftDescription.ts
@@ -72,7 +72,7 @@ export const draftFields: INodeProperties[] = [
 		name: 'threadNotice',
 		type: 'notice',
 		default: '',
-		displayOptions: {},
+		displayOptions: { show: { resource: ['draft'], operation: ['create'] } },
 	},
 	{
 		displayName: 'Email Type',

--- a/packages/nodes-base/nodes/Google/Gmail/v2/DraftDescription.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/DraftDescription.ts
@@ -67,6 +67,14 @@ export const draftFields: INodeProperties[] = [
 		placeholder: 'Hello World!',
 	},
 	{
+		displayName:
+			'If you would like to reply to an existing thread, specify the same subject title as the thread you want to reply to here.',
+		name: 'threadNotice',
+		type: 'notice',
+		default: '',
+		displayOptions: {},
+	},
+	{
 		displayName: 'Email Type',
 		name: 'emailType',
 		type: 'options',

--- a/packages/nodes-base/nodes/Google/Gmail/v2/DraftDescription.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/DraftDescription.ts
@@ -67,8 +67,7 @@ export const draftFields: INodeProperties[] = [
 		placeholder: 'Hello World!',
 	},
 	{
-		displayName:
-			'To reply to an existing thread, specify the exact subject title of that thread.',
+		displayName: 'To reply to an existing thread, specify the exact subject title of that thread.',
 		name: 'threadNotice',
 		type: 'notice',
 		default: '',

--- a/packages/nodes-base/nodes/Google/Gmail/v2/GmailV2.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/GmailV2.node.ts
@@ -13,6 +13,7 @@ import { labelFields, labelOperations } from './LabelDescription';
 import { getGmailAliases, getLabels, getThreadMessages } from './loadOptions';
 import { messageFields, messageOperations } from './MessageDescription';
 import { threadFields, threadOperations } from './ThreadDescription';
+import { addThreadHeadersToEmail } from './utils/draft';
 import { configureWaitTillDate } from '../../../../utils/sendAndWait/configureWaitTillDate.util';
 import { sendAndWaitWebhooksDescription } from '../../../../utils/sendAndWait/descriptions';
 import type { IEmail } from '../../../../utils/sendAndWait/interfaces';
@@ -559,6 +560,12 @@ export class GmailV2 implements INodeType {
 							...prepareEmailBody.call(this, i),
 							attachments,
 						};
+
+						if (threadId && options.replyTo) {
+							// If a threadId is set, we need to add the Message-ID of the last message in the thread
+							// to the email so that Gmail can correctly associate the draft with the thread
+							await addThreadHeadersToEmail.call(this, email, threadId);
+						}
 
 						const body = {
 							message: {

--- a/packages/nodes-base/nodes/Google/Gmail/v2/utils/draft.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/utils/draft.ts
@@ -1,0 +1,30 @@
+import type { IExecuteFunctions } from 'n8n-workflow';
+
+import type { IEmail } from '@utils/sendAndWait/interfaces';
+
+import { googleApiRequest } from '../../GenericFunctions';
+
+/**
+ * Adds inReplyTo and reference headers to the email if threadId is provided.
+ */
+export async function addThreadHeadersToEmail(
+	this: IExecuteFunctions,
+	email: IEmail,
+	threadId: string,
+): Promise<void> {
+	const thread = await googleApiRequest.call(
+		this,
+		'GET',
+		`/gmail/v1/users/me/threads/${threadId}`,
+		{},
+		{ format: 'metadata', metadataHeaders: ['Message-ID'] },
+	);
+
+	if (thread?.messages) {
+		const lastMessage = thread.messages.length - 1;
+		const messageId: string = thread.messages[lastMessage].payload.headers[0].value;
+
+		email.inReplyTo = messageId;
+		email.reference = messageId;
+	}
+}


### PR DESCRIPTION
## Summary

We need to make our email parameters more compliant to what Gmail expects to maintain a thread when creating a draft email to be sent. We need to update the email parameters we are sending to Gmail by including `reference` and `inReplyTo` fields [see](https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.messages#Message). We need to also tell users to use the same subject title as the email thread they would like to reply to when entering the subject field. Lastly, we need to remove trailing `=` at the end of the encoded email since gmail requires base64url encoding without padding [see](https://stackoverflow.com/questions/29119350/google-rest-api-message-in-an-rfc-2822-formatted-and-base64url-encoded-string).

Tested with
- Gmail to Proton Mail
- Gmail to Gmail
- Gmail to Apple

Node for testing:
```
{
  "nodes": [
    {
      "parameters": {
        "pollTimes": {
          "item": [
            {
              "mode": "everyMinute"
            }
          ]
        },
        "filters": {}
      },
      "type": "n8n-nodes-base.gmailTrigger",
      "typeVersion": 1.2,
      "position": [
        0,
        0
      ],
      "id": "2b7a588a-887d-4d83-a2d1-37313731bb2c",
      "name": "Gmail Trigger",
      "credentials": {
        "gmailOAuth2": {
          "id": "SLV3D68Mpqomofzr",
          "name": "Gmail account"
        }
      }
    },
    {
      "parameters": {
        "resource": "draft",
        "subject": "={{ $json.Subject }}",
        "message": "=hello from n8n {{ $json.id }}",
        "options": {
          "replyTo": "={{ $json.From.match(/<(.+?)>/)[1] }}",
          "threadId": "={{ $json.threadId }}"
        }
      },
      "type": "n8n-nodes-base.gmail",
      "typeVersion": 2.1,
      "position": [
        220,
        0
      ],
      "id": "baccc6b7-1e4e-4586-b44a-89b29f216ef4",
      "name": "Gmail",
      "webhookId": "2ae44867-684e-49d1-b1a5-c85794b129d4",
      "credentials": {
        "gmailOAuth2": {
          "id": "SLV3D68Mpqomofzr",
          "name": "Gmail account"
        }
      }
    }
  ],
  "connections": {
    "Gmail Trigger": {
      "main": [
        [
          {
            "node": "Gmail",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {},
  "meta": {
    "templateCredsSetupCompleted": true,
    "instanceId": "ee90fdf8d57662f949e6c691dc07fa0fd2f66e1eee28ed82ef06658223e67255"
  }
}
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3052/community-issue-gmail-create-draft-to-reply-breaks-the-thread


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
