### PR TITLE
fix(benchmark): Archive workflow before deleting them

### DIFF
--- a/packages/@n8n/benchmark/src/n8n-api-client/workflows-api-client.ts
+++ b/packages/@n8n/benchmark/src/n8n-api-client/workflows-api-client.ts
@@ -26,6 +26,10 @@ export class WorkflowApiClient {
 		return response.data.data;
 	}
 
+	async archiveWorkflow(workflowId: Workflow['id']): Promise<void> {
+		await this.apiClient.post(`/workflows/${workflowId}/archive`, {});
+	}
+
 	async deleteWorkflow(workflowId: Workflow['id']): Promise<void> {
 		await this.apiClient.delete(`/workflows/${workflowId}`);
 	}

--- a/packages/@n8n/benchmark/src/test-execution/scenario-data-importer.ts
+++ b/packages/@n8n/benchmark/src/test-execution/scenario-data-importer.ts
@@ -27,6 +27,7 @@ export class ScenarioDataImporter {
 		const existingWorkflows = this.findExistingWorkflows(opts.existingWorkflows, opts.workflow);
 		if (existingWorkflows.length > 0) {
 			for (const toDelete of existingWorkflows) {
+				await this.workflowApiClient.archiveWorkflow(toDelete.id);
 				await this.workflowApiClient.deleteWorkflow(toDelete.id);
 			}
 		}


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
The current benchmark setup tries to delete workflow if they exist, before re-creating them. But with the new archiving feature, the workflow needs to be archived before it can be deleted. That's what this PR is doing.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
