### PR TITLE
fix(editor): Logs not shown when tools are partially executed

### DIFF
--- a/packages/@n8n/constants/src/execution.ts
+++ b/packages/@n8n/constants/src/execution.ts
@@ -1,0 +1,1 @@
+export const TOOL_EXECUTOR_NODE_NAME = 'PartialExecutionToolExecutor';

--- a/packages/@n8n/constants/src/index.ts
+++ b/packages/@n8n/constants/src/index.ts
@@ -2,6 +2,7 @@ export * from './api';
 export * from './browser';
 export * from './community-nodes';
 export * from './instance';
+export * from './execution';
 
 export const LICENSE_FEATURES = {
 	SHARING: 'feat:sharing',

--- a/packages/core/src/execution-engine/partial-execution-utils/rewire-graph.ts
+++ b/packages/core/src/execution-engine/partial-execution-utils/rewire-graph.ts
@@ -1,9 +1,8 @@
+import { TOOL_EXECUTOR_NODE_NAME } from '@n8n/constants';
 import * as a from 'assert/strict';
 import { type AiAgentRequest, type INode, NodeConnectionTypes } from 'n8n-workflow';
 
 import { type DirectedGraph } from './directed-graph';
-
-export const TOOL_EXECUTOR_NODE_NAME = 'PartialExecutionToolExecutor';
 
 export function rewireGraph(
 	tool: INode,

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
+import { TOOL_EXECUTOR_NODE_NAME } from '@n8n/constants';
 import { Container } from '@n8n/di';
 import * as assert from 'assert/strict';
 import { setMaxListeners } from 'events';
@@ -75,7 +76,6 @@ import {
 	isTool,
 	getNextExecutionIndex,
 } from './partial-execution-utils';
-import { TOOL_EXECUTOR_NODE_NAME } from './partial-execution-utils/rewire-graph';
 import { RoutingNode } from './routing-node';
 import { TriggersAndPollers } from './triggers-and-pollers';
 

--- a/packages/frontend/editor-ui/src/features/logs/components/LogsOverviewRow.vue
+++ b/packages/frontend/editor-ui/src/features/logs/components/LogsOverviewRow.vue
@@ -37,11 +37,15 @@ const nodeTypeStore = useNodeTypesStore();
 const type = computed(() => nodeTypeStore.getNodeType(props.data.node.type));
 const isSettled = computed(
 	() =>
-		props.data.runData.executionStatus &&
+		props.data.runData?.executionStatus &&
 		!['running', 'waiting'].includes(props.data.runData.executionStatus),
 );
-const isError = computed(() => !!props.data.runData.error);
+const isError = computed(() => !!props.data.runData?.error);
 const startedAtText = computed(() => {
+	if (props.data.runData === undefined) {
+		return '—';
+	}
+
 	const time = new Date(props.data.runData.startTime);
 
 	return locale.baseText('logs.overview.body.started', {
@@ -50,14 +54,16 @@ const startedAtText = computed(() => {
 		},
 	});
 });
-const statusText = computed(() => upperFirst(props.data.runData.executionStatus));
+const statusText = computed(() => upperFirst(props.data.runData?.executionStatus ?? ''));
 const timeText = computed(() =>
-	locale.displayTimer(
-		isSettled.value
-			? props.data.runData.executionTime
-			: Math.floor((now.value - props.data.runData.startTime) / 1000) * 1000,
-		true,
-	),
+	props.data.runData
+		? locale.displayTimer(
+				isSettled.value
+					? props.data.runData.executionTime
+					: Math.floor((now.value - props.data.runData.startTime) / 1000) * 1000,
+				true,
+			)
+		: undefined,
 );
 
 const subtreeConsumedTokens = computed(() =>
@@ -65,7 +71,7 @@ const subtreeConsumedTokens = computed(() =>
 );
 
 const hasChildren = computed(
-	() => props.data.children.length > 0 || !!props.data.runData.metadata?.subExecution,
+	() => props.data.children.length > 0 || !!props.data.runData?.metadata?.subExecution,
 );
 
 function isLastChild(level: number) {
@@ -144,13 +150,14 @@ watch(
 				</template>
 				<template #time>{{ timeText }}</template>
 			</I18nT>
-			<template v-else>
+			<template v-else-if="timeText !== undefined">
 				{{
 					locale.baseText('logs.overview.body.summaryText.for', {
 						interpolate: { status: statusText, time: timeText },
 					})
 				}}
 			</template>
+			<template v-else>—</template>
 		</N8nText>
 		<N8nText
 			v-if="!isCompact"

--- a/packages/frontend/editor-ui/src/features/logs/components/LogsPanel.vue
+++ b/packages/frontend/editor-ui/src/features/logs/components/LogsPanel.vue
@@ -90,7 +90,7 @@ async function handleOpenNdv(treeNode: LogEntry) {
 	ndvStore.setActiveNodeName(treeNode.node.name);
 
 	await nextTick(() => {
-		const source = treeNode.runData.source[0];
+		const source = treeNode.runData?.source[0];
 		const inputBranch = source?.previousNodeOutput ?? 0;
 
 		ndvEventBus.emit('updateInputNodeName', source?.previousNode);

--- a/packages/frontend/editor-ui/src/features/logs/components/LogsViewRunData.vue
+++ b/packages/frontend/editor-ui/src/features/logs/components/LogsViewRunData.vue
@@ -19,7 +19,9 @@ const locale = useI18n();
 const ndvStore = useNDVStore();
 
 const displayMode = ref<IRunDataDisplayMode>(paneType === 'input' ? 'schema' : 'table');
-const isMultipleInput = computed(() => paneType === 'input' && logEntry.runData.source.length > 1);
+const isMultipleInput = computed(
+	() => paneType === 'input' && (logEntry.runData?.source.length ?? 0) > 1,
+);
 const runDataProps = computed<
 	Pick<InstanceType<typeof RunData>['$props'], 'node' | 'runIndex' | 'overrideOutputs'> | undefined
 >(() => {
@@ -27,7 +29,7 @@ const runDataProps = computed<
 		return { node: logEntry.node, runIndex: logEntry.runIndex };
 	}
 
-	const source = logEntry.runData.source[0];
+	const source = logEntry.runData?.source[0];
 	const node = source && logEntry.workflow.getNode(source.previousNode);
 
 	if (!source || !node) {
@@ -46,8 +48,8 @@ const runDataProps = computed<
 const isExecuting = computed(
 	() =>
 		paneType === 'output' &&
-		(logEntry.runData.executionStatus === 'running' ||
-			logEntry.runData.executionStatus === 'waiting'),
+		(logEntry.runData?.executionStatus === 'running' ||
+			logEntry.runData?.executionStatus === 'waiting'),
 );
 
 function handleClickOpenNdv() {

--- a/packages/frontend/editor-ui/src/features/logs/composables/useLogsExecutionData.ts
+++ b/packages/frontend/editor-ui/src/features/logs/composables/useLogsExecutionData.ts
@@ -68,8 +68,8 @@ export function useLogsExecutionData() {
 	}
 
 	async function loadSubExecution(logEntry: LogEntry) {
-		const executionId = logEntry.runData.metadata?.subExecution?.executionId;
-		const workflowId = logEntry.runData.metadata?.subExecution?.workflowId;
+		const executionId = logEntry.runData?.metadata?.subExecution?.executionId;
+		const workflowId = logEntry.runData?.metadata?.subExecution?.workflowId;
 
 		if (!execData.value?.data || !executionId || !workflowId) {
 			return;

--- a/packages/frontend/editor-ui/src/features/logs/logs.types.ts
+++ b/packages/frontend/editor-ui/src/features/logs/logs.types.ts
@@ -9,7 +9,7 @@ export interface LogEntry {
 	children: LogEntry[];
 	depth: number;
 	runIndex: number;
-	runData: ITaskData;
+	runData: ITaskData | undefined;
 	consumedTokens: LlmTokenUsageData;
 	workflow: Workflow;
 	executionId: string;

--- a/packages/frontend/editor-ui/src/features/logs/logs.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/logs/logs.utils.test.ts
@@ -1047,42 +1047,39 @@ describe(createLogTree, () => {
 		expect(logs[0].children[0].node.name).toBe(aiModelNode.name);
 	});
 
-	it.todo(
-		'should not include duplicate sub node log when the node belongs to multiple root nodes with no run data',
-		() => {
-			const taskData = createTestTaskData({
-				source: [{ previousNode: 'PartialExecutionToolExecutor' }],
-			});
-			const logs = createLogTree(
-				createTestWorkflowObject({
-					nodes: [
-						{ ...aiAgentNode, name: 'Agent A' },
-						{ ...aiAgentNode, name: 'Agent B' },
-						aiModelNode,
-					],
-					connections: {
-						[aiModelNode.name]: {
-							[NodeConnectionTypes.AiLanguageModel]: [
-								[
-									{ node: 'Agent A', index: 0, type: NodeConnectionTypes.AiLanguageModel },
-									{ node: 'Agent B', index: 0, type: NodeConnectionTypes.AiLanguageModel },
-								],
+	it('should not include duplicate sub node log when the node belongs to multiple root nodes with no run data', () => {
+		const taskData = createTestTaskData({
+			source: [{ previousNode: 'PartialExecutionToolExecutor' }],
+		});
+		const logs = createLogTree(
+			createTestWorkflowObject({
+				nodes: [
+					{ ...aiAgentNode, name: 'Agent A' },
+					{ ...aiAgentNode, name: 'Agent B' },
+					aiModelNode,
+				],
+				connections: {
+					[aiModelNode.name]: {
+						[NodeConnectionTypes.AiLanguageModel]: [
+							[
+								{ node: 'Agent A', index: 0, type: NodeConnectionTypes.AiLanguageModel },
+								{ node: 'Agent B', index: 0, type: NodeConnectionTypes.AiLanguageModel },
 							],
-						},
+						],
 					},
-				}),
-				createTestWorkflowExecutionResponse({
-					data: { resultData: { runData: { [aiModelNode.name]: [taskData] } } },
-				}),
-			);
+				},
+			}),
+			createTestWorkflowExecutionResponse({
+				data: { resultData: { runData: { [aiModelNode.name]: [taskData] } } },
+			}),
+		);
 
-			expect(logs).toHaveLength(1);
-			expect(logs[0].node.name).toBe('Agent A');
-			expect(logs[0].runData).toBe(undefined);
-			expect(logs[0].children).toHaveLength(1);
-			expect(logs[0].children[0].node.name).toBe(aiModelNode.name);
-		},
-	);
+		expect(logs).toHaveLength(1);
+		expect(logs[0].node.name).toBe('Agent B');
+		expect(logs[0].runData).toBe(undefined);
+		expect(logs[0].children).toHaveLength(1);
+		expect(logs[0].children[0].node.name).toBe(aiModelNode.name);
+	});
 });
 
 describe(deepToRaw, () => {

--- a/packages/frontend/editor-ui/src/features/logs/logs.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/logs/logs.utils.test.ts
@@ -1009,10 +1009,13 @@ describe(createLogTree, () => {
 	});
 
 	it('should include sub node log without run data in its root node', () => {
+		const taskData = createTestTaskData({
+			source: [{ previousNode: 'PartialExecutionToolExecutor' }],
+		});
 		const logs = createLogTree(
 			createTestWorkflowObject(aiChatWorkflow),
 			createTestWorkflowExecutionResponse({
-				data: { resultData: { runData: { [aiModelNode.name]: [createTestTaskData({})] } } },
+				data: { resultData: { runData: { [aiModelNode.name]: [taskData] } } },
 			}),
 		);
 
@@ -1024,13 +1027,16 @@ describe(createLogTree, () => {
 	});
 
 	it('should include sub node log with its root node disabled', () => {
+		const taskData = createTestTaskData({
+			source: [{ previousNode: 'PartialExecutionToolExecutor' }],
+		});
 		const logs = createLogTree(
 			createTestWorkflowObject({
 				...aiChatWorkflow,
 				nodes: [{ ...aiAgentNode, disabled: true }, aiModelNode],
 			}),
 			createTestWorkflowExecutionResponse({
-				data: { resultData: { runData: { [aiModelNode.name]: [createTestTaskData({})] } } },
+				data: { resultData: { runData: { [aiModelNode.name]: [taskData] } } },
 			}),
 		);
 
@@ -1044,6 +1050,9 @@ describe(createLogTree, () => {
 	it.todo(
 		'should not include duplicate sub node log when the node belongs to multiple root nodes with no run data',
 		() => {
+			const taskData = createTestTaskData({
+				source: [{ previousNode: 'PartialExecutionToolExecutor' }],
+			});
 			const logs = createLogTree(
 				createTestWorkflowObject({
 					nodes: [
@@ -1063,7 +1072,7 @@ describe(createLogTree, () => {
 					},
 				}),
 				createTestWorkflowExecutionResponse({
-					data: { resultData: { runData: { [aiModelNode.name]: [createTestTaskData({})] } } },
+					data: { resultData: { runData: { [aiModelNode.name]: [taskData] } } },
 				}),
 			);
 

--- a/packages/frontend/editor-ui/src/features/logs/logs.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/logs/logs.utils.test.ts
@@ -20,7 +20,12 @@ import {
 	type ExecutionError,
 	type ITaskStartedData,
 } from 'n8n-workflow';
-import { createTestLogTreeCreationContext } from './__test__/data';
+import {
+	aiAgentNode,
+	aiChatWorkflow,
+	aiModelNode,
+	createTestLogTreeCreationContext,
+} from './__test__/data';
 import type { LogEntrySelection } from './logs.types';
 import type { IExecutionResponse } from '@/Interface';
 import { isReactive, reactive } from 'vue';
@@ -29,10 +34,11 @@ import { AGENT_NODE_TYPE, CHAT_TRIGGER_NODE_TYPE } from '@/constants';
 
 describe(getTreeNodeData, () => {
 	it('should generate one node per execution', () => {
+		const nodeA = createTestNode({ name: 'A', id: 'test-node-id-a' });
 		const workflow = createTestWorkflowObject({
 			id: 'test-wf-id',
 			nodes: [
-				createTestNode({ name: 'A', id: 'test-node-id-a' }),
+				nodeA,
 				createTestNode({ name: 'B', id: 'test-node-id-b' }),
 				createTestNode({ name: 'C', id: 'test-node-id-c' }),
 			],
@@ -68,7 +74,7 @@ describe(getTreeNodeData, () => {
 				createTestTaskData({ startTime: 1740528000004 }),
 			],
 		});
-		const logTree = getTreeNodeData('A', ctx.data.resultData.runData.A[0], undefined, ctx);
+		const logTree = getTreeNodeData(nodeA, ctx.data.resultData.runData.A[0], undefined, ctx);
 
 		expect(logTree.length).toBe(1);
 
@@ -76,14 +82,14 @@ describe(getTreeNodeData, () => {
 		expect(logTree[0].depth).toBe(0);
 		expect(logTree[0].runIndex).toBe(0);
 		expect(logTree[0].parent).toBe(undefined);
-		expect(logTree[0].runData.startTime).toBe(1740528000000);
+		expect(logTree[0].runData?.startTime).toBe(1740528000000);
 		expect(logTree[0].children.length).toBe(2);
 
 		expect(logTree[0].children[0].id).toBe('test-wf-id:B:test-execution-id:0');
 		expect(logTree[0].children[0].depth).toBe(1);
 		expect(logTree[0].children[0].runIndex).toBe(0);
 		expect(logTree[0].children[0].parent?.node.name).toBe('A');
-		expect(logTree[0].children[0].runData.startTime).toBe(1740528000001);
+		expect(logTree[0].children[0].runData?.startTime).toBe(1740528000001);
 		expect(logTree[0].children[0].consumedTokens.isEstimate).toBe(false);
 		expect(logTree[0].children[0].consumedTokens.completionTokens).toBe(1);
 		expect(logTree[0].children[0].children.length).toBe(1);
@@ -111,12 +117,10 @@ describe(getTreeNodeData, () => {
 	});
 
 	it('should filter node executions based on source node', () => {
+		const rootNode1 = createTestNode({ name: 'RootNode1' });
+		const rootNode2 = createTestNode({ name: 'RootNode2' });
 		const workflow = createTestWorkflowObject({
-			nodes: [
-				createTestNode({ name: 'RootNode1' }),
-				createTestNode({ name: 'RootNode2' }),
-				createTestNode({ name: 'SharedSubNode' }),
-			],
+			nodes: [rootNode1, rootNode2, createTestNode({ name: 'SharedSubNode' })],
 			connections: {
 				SharedSubNode: {
 					ai_tool: [
@@ -159,7 +163,7 @@ describe(getTreeNodeData, () => {
 
 		// Test for RootNode1 - should only show SharedSubNode with source RootNode1
 		const rootNode1Tree = getTreeNodeData(
-			'RootNode1',
+			rootNode1,
 			runData.RootNode1[0],
 			undefined,
 			createTestLogTreeCreationContext(workflow, runData),
@@ -170,7 +174,7 @@ describe(getTreeNodeData, () => {
 
 		// Test for RootNode2 - should only show SharedSubNode with source RootNode2
 		const rootNode2Tree = getTreeNodeData(
-			'RootNode2',
+			rootNode2,
 			runData.RootNode2[0],
 			undefined,
 			createTestLogTreeCreationContext(workflow, runData),
@@ -181,8 +185,9 @@ describe(getTreeNodeData, () => {
 	});
 
 	it('should filter node executions based on source run index', () => {
+		const rootNode = createTestNode({ name: 'RootNode' });
 		const workflow = createTestWorkflowObject({
-			nodes: [createTestNode({ name: 'RootNode' }), createTestNode({ name: 'SubNode' })],
+			nodes: [rootNode, createTestNode({ name: 'SubNode' })],
 			connections: {
 				SubNode: {
 					ai_tool: [[{ node: 'RootNode', type: NodeConnectionTypes.AiTool, index: 0 }]],
@@ -216,7 +221,7 @@ describe(getTreeNodeData, () => {
 
 		// Test for run #1 of RootNode - should only show SubNode with source run index 0
 		const rootNode1Tree = getTreeNodeData(
-			'RootNode',
+			rootNode,
 			runData.RootNode[0],
 			0,
 			createTestLogTreeCreationContext(workflow, runData),
@@ -227,7 +232,7 @@ describe(getTreeNodeData, () => {
 
 		// Test for run #2 of RootNode - should only show SubNode with source run index 1
 		const rootNode2Tree = getTreeNodeData(
-			'RootNode',
+			rootNode,
 			runData.RootNode[1],
 			1,
 			createTestLogTreeCreationContext(workflow, runData),
@@ -238,8 +243,9 @@ describe(getTreeNodeData, () => {
 	});
 
 	it('should include nodes without source information', () => {
+		const rootNode = createTestNode({ name: 'RootNode' });
 		const workflow = createTestWorkflowObject({
-			nodes: [createTestNode({ name: 'RootNode' }), createTestNode({ name: 'SubNode' })],
+			nodes: [rootNode, createTestNode({ name: 'SubNode' })],
 			connections: {
 				SubNode: {
 					ai_tool: [[{ node: 'RootNode', type: NodeConnectionTypes.AiTool, index: 0 }]],
@@ -267,7 +273,7 @@ describe(getTreeNodeData, () => {
 
 		// Test for RootNode - should still show SubNode even without source info
 		const rootNodeTree = getTreeNodeData(
-			'RootNode',
+			rootNode,
 			runData.RootNode[0],
 			undefined,
 			createTestLogTreeCreationContext(workflow, runData),
@@ -278,8 +284,9 @@ describe(getTreeNodeData, () => {
 	});
 
 	it('should include nodes with empty source array', () => {
+		const rootNode = createTestNode({ name: 'RootNode' });
 		const workflow = createTestWorkflowObject({
-			nodes: [createTestNode({ name: 'RootNode' }), createTestNode({ name: 'SubNode' })],
+			nodes: [rootNode, createTestNode({ name: 'SubNode' })],
 			connections: {
 				SubNode: {
 					ai_tool: [[{ node: 'RootNode', type: NodeConnectionTypes.AiTool, index: 0 }]],
@@ -307,7 +314,7 @@ describe(getTreeNodeData, () => {
 
 		// Test for RootNode - should still show SubNode even with empty source array
 		const rootNodeTree = getTreeNodeData(
-			'RootNode',
+			rootNode,
 			runData.RootNode[0],
 			undefined,
 			createTestLogTreeCreationContext(workflow, runData),
@@ -318,8 +325,9 @@ describe(getTreeNodeData, () => {
 	});
 
 	it('should include nodes with source array without previous node', () => {
+		const rootNode = createTestNode({ name: 'RootNode' });
 		const workflow = createTestWorkflowObject({
-			nodes: [createTestNode({ name: 'RootNode' }), createTestNode({ name: 'SubNode' })],
+			nodes: [rootNode, createTestNode({ name: 'SubNode' })],
 			connections: {
 				SubNode: {
 					ai_tool: [[{ node: 'RootNode', type: NodeConnectionTypes.AiTool, index: 0 }]],
@@ -334,7 +342,7 @@ describe(getTreeNodeData, () => {
 		};
 
 		const rootNodeTree = getTreeNodeData(
-			'RootNode',
+			rootNode,
 			runData.RootNode[0],
 			undefined,
 			createTestLogTreeCreationContext(workflow, runData),
@@ -345,10 +353,12 @@ describe(getTreeNodeData, () => {
 	});
 
 	it('should filter deeper nested nodes based on source', () => {
+		const rootNode1 = createTestNode({ name: 'RootNode1' });
+		const rootNode2 = createTestNode({ name: 'RootNode2' });
 		const workflow = createTestWorkflowObject({
 			nodes: [
-				createTestNode({ name: 'RootNode1' }),
-				createTestNode({ name: 'RootNode2' }),
+				rootNode1,
+				rootNode2,
 				createTestNode({ name: 'SharedSubNode' }),
 				createTestNode({ name: 'DeepSubNode' }),
 			],
@@ -411,7 +421,7 @@ describe(getTreeNodeData, () => {
 
 		// Test filtering for RootNode1
 		const rootNode1Tree = getTreeNodeData(
-			'RootNode1',
+			rootNode1,
 			runData.RootNode1[0],
 			undefined,
 			createTestLogTreeCreationContext(workflow, runData),
@@ -425,7 +435,7 @@ describe(getTreeNodeData, () => {
 
 		// Test filtering for RootNode2
 		const rootNode2Tree = getTreeNodeData(
-			'RootNode2',
+			rootNode2,
 			runData.RootNode2[0],
 			undefined,
 			createTestLogTreeCreationContext(workflow, runData),
@@ -439,10 +449,12 @@ describe(getTreeNodeData, () => {
 	});
 
 	it('should handle complex tree with multiple branches and filters correctly', () => {
+		const rootNode1 = createTestNode({ name: 'RootNode1' });
+		const rootNode2 = createTestNode({ name: 'RootNode2' });
 		const workflow = createTestWorkflowObject({
 			nodes: [
-				createTestNode({ name: 'RootNode1' }),
-				createTestNode({ name: 'RootNode2' }),
+				rootNode1,
+				rootNode2,
 				createTestNode({ name: 'SubNodeA' }),
 				createTestNode({ name: 'SubNodeB' }),
 				createTestNode({ name: 'DeepNode' }),
@@ -511,7 +523,7 @@ describe(getTreeNodeData, () => {
 
 		// Test filtering for RootNode1 -> SubNodeA -> DeepNode
 		const rootNode1Tree = getTreeNodeData(
-			'RootNode1',
+			rootNode1,
 			runData.RootNode1[0],
 			undefined,
 			createTestLogTreeCreationContext(workflow, runData),
@@ -524,7 +536,7 @@ describe(getTreeNodeData, () => {
 
 		// Test filtering for RootNode2 -> SubNodeB -> DeepNode
 		const rootNode2Tree = getTreeNodeData(
-			'RootNode2',
+			rootNode2,
 			runData.RootNode2[0],
 			undefined,
 			createTestLogTreeCreationContext(workflow, runData),
@@ -985,6 +997,30 @@ describe(createLogTree, () => {
 		expect(logs[0].children[1].children).toHaveLength(2);
 		expect(logs[0].children[1].children[0].node.name).toBe('C');
 		expect(logs[0].children[1].children[1].node.name).toBe('C');
+	});
+
+	it('should not include nodes without run data', () => {
+		const logs = createLogTree(
+			createTestWorkflowObject(aiChatWorkflow),
+			createTestWorkflowExecutionResponse({ data: { resultData: { runData: {} } } }),
+		);
+
+		expect(logs).toHaveLength(0);
+	});
+
+	it('should include sub node log even when its root node does not have run data', () => {
+		const logs = createLogTree(
+			createTestWorkflowObject(aiChatWorkflow),
+			createTestWorkflowExecutionResponse({
+				data: { resultData: { runData: { [aiModelNode.name]: [createTestTaskData({})] } } },
+			}),
+		);
+
+		expect(logs).toHaveLength(1);
+		expect(logs[0].node.name).toBe(aiAgentNode.name);
+		expect(logs[0].runData).toBe(undefined);
+		expect(logs[0].children).toHaveLength(1);
+		expect(logs[0].children[0].node.name).toBe(aiModelNode.name);
 	});
 });
 

--- a/packages/frontend/editor-ui/src/features/logs/logs.utils.ts
+++ b/packages/frontend/editor-ui/src/features/logs/logs.utils.ts
@@ -134,7 +134,7 @@ export function getTreeNodeData(
 	const treeNode = createNode(node, context, runIndex ?? 0, runData);
 	const children = getChildNodes(treeNode, node, runIndex, context).sort(sortLogEntries);
 
-	if (runData === undefined && children.length === 0) {
+	if ((runData === undefined || node.disabled) && children.length === 0) {
 		return [];
 	}
 
@@ -218,10 +218,9 @@ function createLogTreeRec(context: LogTreeCreationContext) {
 		}>((node) => {
 			const nodeName = node.name;
 			const taskData = context.data.resultData.runData[nodeName] ?? [];
-			const isSubNode = context.workflow.getChildNodes(nodeName, 'ALL_NON_MAIN').length > 0;
 
-			if (isSubNode || node.disabled) {
-				// skip sub nodes and disabled nodes
+			if (context.workflow.getChildNodes(nodeName, 'ALL_NON_MAIN').length > 0) {
+				// skip sub nodes
 				return [];
 			}
 


### PR DESCRIPTION
## Summary
This PR fixes the log view for partial execution of tools, making sure that the tool's log is shown. In order to show tool logs, the log view shows "placeholder" root node (e.g., agent node) in the logs like below:
| Details | Overview |
|--------|--------|
| <img width="1148" alt="Screenshot 2025-06-12 at 11 52 32" src="https://github.com/user-attachments/assets/421a9362-7a8f-44a9-b91c-b80e866c8af7" /> | <img width="1132" alt="Screenshot 2025-06-12 at 11 52 22" src="https://github.com/user-attachments/assets/28d9dcf6-ba63-43f9-bb51-636e36eab5e8" /> | 

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/SUG-76/bug-partial-execution-of-sub-nodes-not-properly-represented-in-log


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
