### PR TITLE
feat(editor): Show node type on hover over node icon in NDV

### DIFF
--- a/packages/frontend/editor-ui/src/components/NodeIcon.vue
+++ b/packages/frontend/editor-ui/src/components/NodeIcon.vue
@@ -62,7 +62,9 @@ const badge = computed(() => {
 	return iconSource.value.badge;
 });
 
-const nodeTypeName = computed(() => props.nodeName ?? props.nodeType?.displayName);
+const nodeTypeName = computed(() =>
+	props.nodeName && props.nodeName !== '' ? props.nodeName : props.nodeType?.displayName,
+);
 </script>
 
 <template>

--- a/packages/frontend/editor-ui/src/components/NodeTitle.vue
+++ b/packages/frontend/editor-ui/src/components/NodeTitle.vue
@@ -34,7 +34,7 @@ const { width } = useElementSize(wrapperRef);
 <template>
 	<span :class="$style.container" data-test-id="node-title-container">
 		<span :class="$style.iconWrapper">
-			<NodeIcon :node-type="nodeType" :size="18" :show-tooltip="true" />
+			<NodeIcon :node-type="nodeType" :size="18" :show-tooltip="true" tooltip-position="left" />
 		</span>
 		<div ref="wrapperRef" :class="$style.textWrapper">
 			<N8nInlineTextEdit

--- a/packages/frontend/editor-ui/src/components/NodeTitle.vue
+++ b/packages/frontend/editor-ui/src/components/NodeTitle.vue
@@ -34,7 +34,7 @@ const { width } = useElementSize(wrapperRef);
 <template>
 	<span :class="$style.container" data-test-id="node-title-container">
 		<span :class="$style.iconWrapper">
-			<NodeIcon :node-type="nodeType" :size="18" />
+			<NodeIcon :node-type="nodeType" :size="18" :show-tooltip="true" />
 		</span>
 		<div ref="wrapperRef" :class="$style.textWrapper">
 			<N8nInlineTextEdit


### PR DESCRIPTION
## Summary

Show the node type on hover over the icon in the NDV. Also fix an issue where an empty node name would be shown instead of the node type if the tooltip is enabled.

Would have preferred top but there's not enough space and it automatically ends up as bottom so went with left instead:

<img width="749" alt="image" src="https://github.com/user-attachments/assets/20b08646-2fae-4209-b5fd-cabc516785b5" />



## Related Linear tickets, Github issues, and Community forum posts

n/a


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
