### PR TITLE
fix(core): Always save evaluation executions

### DIFF
--- a/packages/cli/src/evaluation.ee/test-runner/__tests__/test-runner.service.ee.test.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/__tests__/test-runner.service.ee.test.ts
@@ -618,7 +618,16 @@ describe('TestRunnerService', () => {
 					pinData: {
 						[triggerNodeName]: [testCase],
 					},
-					workflowData: workflow,
+					workflowData: {
+						...workflow,
+						settings: {
+							...workflow.settings,
+							saveManualExecutions: true,
+							saveDataErrorExecution: 'all',
+							saveDataSuccessExecution: 'all',
+							saveExecutionProgress: false,
+						},
+					},
 					userId: metadata.userId,
 					partialExecutionVersion: 2,
 					triggerToStartFrom: {
@@ -742,7 +751,16 @@ describe('TestRunnerService', () => {
 						pinData: {
 							[triggerNodeName]: [testCase],
 						},
-						workflowData: workflow,
+						workflowData: {
+							...workflow,
+							settings: {
+								...workflow.settings,
+								saveManualExecutions: true,
+								saveDataErrorExecution: 'all',
+								saveDataSuccessExecution: 'all',
+								saveExecutionProgress: false,
+							},
+						},
 						userId: metadata.userId,
 						partialExecutionVersion: 2,
 						triggerToStartFrom: {

--- a/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
@@ -189,7 +189,16 @@ export class TestRunnerService {
 		const data: IWorkflowExecutionDataProcess = {
 			executionMode: 'evaluation',
 			pinData,
-			workflowData: workflow,
+			workflowData: {
+				...workflow,
+				settings: {
+					...workflow.settings,
+					saveManualExecutions: true,
+					saveDataErrorExecution: 'all',
+					saveDataSuccessExecution: 'all',
+					saveExecutionProgress: false,
+				},
+			},
 			userId: metadata.userId,
 			partialExecutionVersion: 2,
 			triggerToStartFrom: {


### PR DESCRIPTION
## Summary

When workflow has the "Do not save" executions setting – it leads to a failure of entire test run (because of DB constraints on execution column of a test case table).
This PR overrides workflow settings (the same way as was done previously for the fetching dataset partial execution) to always save evaluation executions.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-772/evaluation-executions-should-be-saved-regardless-of-settings#comment-7f43a03c


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
