### PR TITLE
fix(core): Register transition handlers after modules init

### DIFF
--- a/packages/cli/src/commands/base-command.ts
+++ b/packages/cli/src/commands/base-command.ts
@@ -31,7 +31,6 @@ import { ModuleRegistry } from '@/modules/module-registry';
 import { ModulesConfig } from '@/modules/modules.config';
 import { NodeTypes } from '@/node-types';
 import { PostHogClient } from '@/posthog';
-import { MultiMainSetup } from '@/scaling/multi-main-setup.ee';
 import { ShutdownService } from '@/shutdown/shutdown.service';
 import { WorkflowHistoryManager } from '@/workflows/workflow-history.ee/workflow-history-manager.ee';
 
@@ -86,10 +85,6 @@ export abstract class BaseCommand extends Command {
 		}
 
 		this.moduleRegistry.addEntities();
-
-		if (this.instanceSettings.isMultiMain) {
-			Container.get(MultiMainSetup).registerEventHandlers();
-		}
 	}
 
 	async init(): Promise<void> {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -249,6 +249,10 @@ export class Start extends BaseCommand {
 		}
 
 		await this.moduleRegistry.initModules();
+
+		if (this.instanceSettings.isMultiMain) {
+			Container.get(MultiMainSetup).registerEventHandlers();
+		}
 	}
 
 	async initOrchestration() {

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -27,7 +27,6 @@ export class InsightsService {
 		this.logger = this.logger.scoped('insights');
 	}
 
-	@OnLeaderTakeover()
 	startTimers() {
 		this.collectionService.startFlushingTimer();
 


### PR DESCRIPTION
## Summary

At #15871 we moved module loading to the entrypoint, to allow modules to register their own DB entities before we establish the DB connection. But we missed that at this early stage the license has not initialized yet, i.e. `InstanceSettings.isMultiMain` still evaluates to `false` and so we fail to register the leadership transition handlers.

This PR moves transition handler registration back down to its [original position](https://github.com/n8n-io/n8n/pull/14940/files#diff-9127350789432874069fb52007d0658e9bb7ea76ca4ee3ee038d9a968b5e5284R98) after modules initialize. Also removed an excess decorator left behind by a misresolved merge.

To test, start two mains, wind down the leader, and watch as the new leader starts all the decorated services: adding triggers and pollers, wait tracking, executions pruning, etc.

## Related Linear tickets, Github issues, and Community forum posts

n/a

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
