### PR TITLE
feat(Chat Trigger Node): Fix CSS variable `--chat--message--font-size` not applying correctly

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/README.md
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/README.md
@@ -29,7 +29,7 @@ openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -node
 Navigate to the chat package and build it:
 
 ```bash
-cd n8n/packages/frontend/@n8n/chat && pnpm run build 
+cd packages/frontend/@n8n/chat && pnpm run build 
 ```
 
 ### 4. Start HTTPS Server
@@ -37,7 +37,7 @@ cd n8n/packages/frontend/@n8n/chat && pnpm run build
 Run the HTTPS server to serve the chat bundle:
 
 ```bash
-http-server n8n/packages/frontend/@n8n/chat/dist -g -S -C cert.pem -K key.pem --port 8443 --cors
+http-server packages/frontend/@n8n/chat/dist -g -S -C cert.pem -K key.pem --port 8443 --cors
 ```
 
 ### 5. Update Import Paths

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/README.md
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/README.md
@@ -1,0 +1,54 @@
+# ChatTrigger Local Development
+
+This guide explains how to set up local development for the ChatTrigger node when working with the chat bundle.
+
+## Prerequisites
+
+Since the chat bundle is loaded via `<script type="module">`, it needs to be served over HTTPS for local development.
+
+## Setup Instructions
+
+### 1. Install HTTP Server
+
+Install the http-server globally:
+
+```bash
+npm install -g http-server
+```
+
+### 2. Generate SSL Certificate
+
+Generate a self-signed certificate for HTTPS:
+
+```bash
+openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -nodes
+```
+
+### 3. Build the Chat Bundle
+
+Navigate to the chat package and build it:
+
+```bash
+cd n8n/packages/frontend/@n8n/chat && pnpm run build 
+```
+
+### 4. Start HTTPS Server
+
+Run the HTTPS server to serve the chat bundle:
+
+```bash
+http-server n8n/packages/frontend/@n8n/chat/dist -g -S -C cert.pem -K key.pem --port 8443 --cors
+```
+
+### 5. Update Import Paths
+
+Modify the import paths in `templates.ts` to point to your local server:
+
+```html
+<script type="module">
+    import { createChat } from 'https://127.0.0.1:8443/chat.bundle.es.js';
+```
+
+```html
+<link href="https://127.0.0.1:8443/chat.css" rel="stylesheet" />
+```

--- a/packages/frontend/@n8n/chat/src/components/Message.vue
+++ b/packages/frontend/@n8n/chat/src/components/Message.vue
@@ -197,6 +197,7 @@ onMounted(async () => {
 	> .chat-message-markdown {
 		display: block;
 		box-sizing: border-box;
+		font-size: inherit;
 
 		> *:first-child {
 			margin-top: 0;


### PR DESCRIPTION
## Summary
The `--chat--message--font-size` CSS variable was not controlling message font sizes because the text content in `.chat-message-markdown` wasn't inheriting font-size from its parent `.chat-message` element.

**Changes:**
• Added `font-size: inherit;` to `.chat-message-markdown` CSS rule to fix inheritance
• Added local development documentation for ChatTrigger node with HTTPS setup instructions


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
fixes #15076

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
