### PR TITLE
perf(core): Skip init for unlicensed modules

### DIFF
--- a/packages/@n8n/decorators/src/module/__tests__/module.test.ts
+++ b/packages/@n8n/decorators/src/module/__tests__/module.test.ts
@@ -19,7 +19,7 @@ describe('@BackendModule decorator', () => {
 			initialize() {}
 		}
 
-		const registeredModules = Array.from(moduleMetadata.getModules());
+		const registeredModules = moduleMetadata.getEntries().map((entry) => entry.class);
 
 		expect(registeredModules).toContain(TestModule);
 		expect(registeredModules).toHaveLength(1);
@@ -41,7 +41,7 @@ describe('@BackendModule decorator', () => {
 			initialize() {}
 		}
 
-		const registeredModules = Array.from(moduleMetadata.getModules());
+		const registeredModules = moduleMetadata.getEntries().map((entry) => entry.class);
 
 		expect(registeredModules).toContain(FirstModule);
 		expect(registeredModules).toContain(SecondModule);
@@ -53,7 +53,7 @@ describe('@BackendModule decorator', () => {
 		@BackendModule()
 		class TestModule {}
 
-		const registeredModules = Array.from(moduleMetadata.getModules());
+		const registeredModules = moduleMetadata.getEntries().map((entry) => entry.class);
 
 		expect(registeredModules).toContain(TestModule);
 		expect(registeredModules).toHaveLength(1);
@@ -69,7 +69,7 @@ describe('@BackendModule decorator', () => {
 			}
 		}
 
-		const registeredModules = Array.from(moduleMetadata.getModules());
+		const registeredModules = moduleMetadata.getEntries().map((entry) => entry.class);
 
 		expect(registeredModules).toContain(TestModule);
 
@@ -87,7 +87,7 @@ describe('@BackendModule decorator', () => {
 			@BackendModule()
 			class SecondModule {}
 
-			const registeredModules = Array.from(moduleMetadata.getModules());
+			const registeredModules = moduleMetadata.getEntries().map((entry) => entry.class);
 
 			expect(registeredModules).toContain(FirstModule);
 			expect(registeredModules).toContain(SecondModule);

--- a/packages/@n8n/decorators/src/module/module-metadata.ts
+++ b/packages/@n8n/decorators/src/module/module-metadata.ts
@@ -1,16 +1,21 @@
 import { Service } from '@n8n/di';
 
-import type { ModuleClass } from './module';
+import type { LicenseFlag, ModuleClass } from './module';
+
+type ModuleEntry = {
+	class: ModuleClass;
+	licenseFlag?: LicenseFlag;
+};
 
 @Service()
 export class ModuleMetadata {
-	private readonly modules: Set<ModuleClass> = new Set();
+	private readonly modules: Map<string, ModuleEntry> = new Map();
 
-	register(module: ModuleClass) {
-		this.modules.add(module);
+	register(moduleName: string, moduleEntry: ModuleEntry) {
+		this.modules.set(moduleName, moduleEntry);
 	}
 
-	getModules() {
-		return this.modules.keys();
+	getEntries() {
+		return [...this.modules.values()];
 	}
 }

--- a/packages/@n8n/decorators/src/module/module.ts
+++ b/packages/@n8n/decorators/src/module/module.ts
@@ -1,3 +1,4 @@
+import type { LICENSE_FEATURES } from '@n8n/constants';
 import { Container, Service, type Constructable } from '@n8n/di';
 
 import { ModuleMetadata } from './module-metadata';
@@ -24,9 +25,16 @@ export interface ModuleInterface {
 
 export type ModuleClass = Constructable<ModuleInterface>;
 
-export const BackendModule = (): ClassDecorator => (target) => {
-	Container.get(ModuleMetadata).register(target as unknown as ModuleClass);
+export type LicenseFlag = (typeof LICENSE_FEATURES)[keyof typeof LICENSE_FEATURES];
 
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-	return Service()(target);
-};
+export const BackendModule =
+	(opts?: { licenseFlag: LicenseFlag }): ClassDecorator =>
+	(target) => {
+		Container.get(ModuleMetadata).register(target.name, {
+			class: target as unknown as ModuleClass,
+			licenseFlag: opts?.licenseFlag,
+		});
+
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+		return Service()(target);
+	};

--- a/packages/cli/src/modules/external-secrets.ee/external-secrets.module.ts
+++ b/packages/cli/src/modules/external-secrets.ee/external-secrets.module.ts
@@ -2,7 +2,7 @@ import type { ModuleInterface } from '@n8n/decorators';
 import { BackendModule } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 
-@BackendModule()
+@BackendModule({ licenseFlag: 'feat:externalSecrets' })
 export class ExternalSecretsModule implements ModuleInterface {
 	async init() {
 		await import('./external-secrets.controller.ee');

--- a/packages/cli/test/integration/external-secrets/external-secrets.api.test.ts
+++ b/packages/cli/test/integration/external-secrets/external-secrets.api.test.ts
@@ -1,3 +1,4 @@
+import { LicenseState } from '@n8n/backend-common';
 import { SettingsRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
@@ -31,6 +32,9 @@ let authMemberAgent: SuperAgentTest;
 
 const mockProvidersInstance = new MockProviders();
 mockInstance(ExternalSecretsProviders, mockProvidersInstance);
+const licenseMock = mock<LicenseState>();
+licenseMock.isLicensed.mockReturnValue(true);
+Container.set(LicenseState, licenseMock);
 
 const testServer = setupTestServer({
 	endpointGroups: ['externalSecrets'],


### PR DESCRIPTION
## Summary

As part of the extensions project, we finally have a mechanism to stop loading into memory expensive features that are excluded from the user's license. This will benefit most cloud instances and self-hosters, as comparatively only very few instances have access to Enterprise features. On bootup we now load the entrypoints for all modules, register their DB entities, and initialize only free and licensed features that are enabled.

In future we could explore more optimizations like not loading entrypoints and entities at all, but the effort there is bigger and the benefit smaller, because entrypoints dynamically load dependencies and DB entities are unlikely to have any.

## Related Linear tickets, Github issues, and Community forum posts

n/a


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
