### PR TITLE
feat(editor): Move element plus plugin config to design system test setup

### DIFF
--- a/packages/frontend/@n8n/design-system/src/__tests__/setup.ts
+++ b/packages/frontend/@n8n/design-system/src/__tests__/setup.ts
@@ -1,12 +1,13 @@
 import '@testing-library/jest-dom';
 import { configure } from '@testing-library/vue';
 import { config } from '@vue/test-utils';
+import ElementPlus from 'element-plus';
 
 import { N8nPlugin } from '@n8n/design-system/plugin';
 
 configure({ testIdAttribute: 'data-test-id' });
 
-config.global.plugins = [N8nPlugin];
+config.global.plugins = [N8nPlugin, ElementPlus];
 
 window.ResizeObserver =
 	window.ResizeObserver ||

--- a/packages/frontend/@n8n/design-system/src/components/N8nDataTableServer/N8nDataTableServer.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDataTableServer/N8nDataTableServer.test.ts
@@ -1,7 +1,5 @@
 import userEvent from '@testing-library/user-event';
 import { render, screen, waitFor, within } from '@testing-library/vue';
-import { config } from '@vue/test-utils';
-import ElementPlus from 'element-plus';
 
 import { createComponentRenderer } from '@n8n/design-system/__tests__/render';
 
@@ -14,8 +12,6 @@ const getRenderedOptions = async () => {
 	expect(dropdown).toBeInTheDocument();
 	return dropdown.querySelectorAll('.el-select-dropdown__item');
 };
-
-config.global.plugins.push(ElementPlus);
 
 const itemFactory = () => ({
 	id: crypto.randomUUID() as string,


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Just move the line to render element plus on design test to global setup

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
