### PR TITLE
refactor(editor): Detangle `users` store from `ui` store (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/stores/ui.store.ts
+++ b/packages/frontend/editor-ui/src/stores/ui.store.ts
@@ -1,4 +1,3 @@
-import * as onboardingApi from '@/api/workflow-webhooks';
 import {
 	ABOUT_MODAL_KEY,
 	CHAT_EMBED_MODAL_KEY,
@@ -58,7 +57,6 @@ import { defineStore } from 'pinia';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useWorkflowsStore } from '@/stores/workflows.store';
 import { useSettingsStore } from '@/stores/settings.store';
-import { useUsersStore } from '@/stores/users.store';
 import { dismissBannerPermanently } from '@n8n/rest-api-client';
 import type { BannerName } from '@n8n/api-types';
 import {
@@ -233,7 +231,6 @@ export const useUIStore = defineStore(STORES.UI, () => {
 	const settingsStore = useSettingsStore();
 	const workflowsStore = useWorkflowsStore();
 	const rootStore = useRootStore();
-	const userStore = useUsersStore();
 
 	// Keep track of the preferred theme and update it when the system preference changes
 	const preferredTheme = getPreferredTheme();
@@ -425,20 +422,6 @@ export const useUIStore = defineStore(STORES.UI, () => {
 		openModal(CREDENTIAL_EDIT_MODAL_KEY);
 	};
 
-	const submitContactEmail = async (email: string, agree: boolean) => {
-		const instanceId = rootStore.instanceId;
-		const { currentUser } = userStore;
-		if (currentUser) {
-			return await onboardingApi.submitEmailOnSignup(
-				instanceId,
-				currentUser,
-				email ?? currentUser.email,
-				agree,
-			);
-		}
-		return null;
-	};
-
 	const openCommunityPackageUninstallConfirmModal = (packageName: string) => {
 		setMode(COMMUNITY_PACKAGE_CONFIRM_MODAL_KEY, COMMUNITY_PACKAGE_MANAGE_ACTIONS.UNINSTALL);
 		setActiveId(COMMUNITY_PACKAGE_CONFIRM_MODAL_KEY, packageName);
@@ -582,7 +565,6 @@ export const useUIStore = defineStore(STORES.UI, () => {
 		openDeleteUserModal,
 		openExistingCredential,
 		openNewCredential,
-		submitContactEmail,
 		openCommunityPackageUninstallConfirmModal,
 		openCommunityPackageUpdateConfirmModal,
 		addActiveAction,

--- a/packages/frontend/editor-ui/src/stores/users.store.ts
+++ b/packages/frontend/editor-ui/src/stores/users.store.ts
@@ -33,6 +33,7 @@ import { useNpsSurveyStore } from './npsSurvey.store';
 import { computed, ref } from 'vue';
 import { useTelemetry } from '@/composables/useTelemetry';
 import { useSettingsStore } from '@/stores/settings.store';
+import * as onboardingApi from '@/api/workflow-webhooks';
 
 const _isPendingUser = (user: IUserResponse | null) => !!user?.isPending;
 const _isInstanceOwner = (user: IUserResponse | null) => user?.role === ROLE.Owner;
@@ -376,6 +377,18 @@ export const useUsersStore = defineStore(STORES.USERS, () => {
 		currentUserCloudInfo.value = null;
 	};
 
+	const submitContactEmail = async (email: string, agree: boolean) => {
+		if (currentUser.value) {
+			return await onboardingApi.submitEmailOnSignup(
+				rootStore.instanceId,
+				currentUser.value,
+				email ?? currentUser.value.email,
+				agree,
+			);
+		}
+		return null;
+	};
+
 	return {
 		initialized,
 		currentUserId,
@@ -424,5 +437,6 @@ export const useUsersStore = defineStore(STORES.USERS, () => {
 		updateGlobalRole,
 		reset,
 		setEasyAIWorkflowOnboardingDone,
+		submitContactEmail,
 	};
 });

--- a/packages/frontend/editor-ui/src/views/SetupView.vue
+++ b/packages/frontend/editor-ui/src/views/SetupView.vue
@@ -6,7 +6,6 @@ import { useToast } from '@/composables/useToast';
 import { useI18n } from '@n8n/i18n';
 
 import { useSettingsStore } from '@/stores/settings.store';
-import { useUIStore } from '@/stores/ui.store';
 import { useUsersStore } from '@/stores/users.store';
 
 import type { IFormBoxConfig } from '@/Interface';
@@ -15,7 +14,6 @@ import { VIEWS } from '@/constants';
 import AuthView from '@/views/AuthView.vue';
 
 const settingsStore = useSettingsStore();
-const uiStore = useUIStore();
 const usersStore = useUsersStore();
 
 const toast = useToast();
@@ -90,7 +88,7 @@ const onSubmit = async (values: { [key: string]: string | boolean }) => {
 
 		if (values.agree === true) {
 			try {
-				await uiStore.submitContactEmail(values.email.toString(), values.agree);
+				await usersStore.submitContactEmail(values.email.toString(), values.agree);
 			} catch {}
 		}
 		if (forceRedirectedHere) {

--- a/packages/frontend/editor-ui/src/views/SignupView.vue
+++ b/packages/frontend/editor-ui/src/views/SignupView.vue
@@ -5,12 +5,10 @@ import { useToast } from '@/composables/useToast';
 import { computed, onMounted, ref } from 'vue';
 import type { IFormBoxConfig } from '@/Interface';
 import { VIEWS } from '@/constants';
-import { useUIStore } from '@/stores/ui.store';
 import { useUsersStore } from '@/stores/users.store';
 import { useI18n } from '@n8n/i18n';
 import { useRoute, useRouter } from 'vue-router';
 
-const uiStore = useUIStore();
 const usersStore = useUsersStore();
 
 const toast = useToast();
@@ -127,7 +125,7 @@ async function onSubmit(values: { [key: string]: string | boolean }) {
 
 		if (values.agree === true) {
 			try {
-				await uiStore.submitContactEmail(values.email.toString(), values.agree);
+				await usersStore.submitContactEmail(values.email.toString(), values.agree);
 			} catch {}
 		}
 


### PR DESCRIPTION
## Summary

Detangled `users` store from `ui` store

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-947/detangle-users-store-from-ui-store


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
