### PR TITLE
feat(MicrosoftOutlook Node): Add createForward operation for MicrosoftOutlook node

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/message/createForward.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/message/createForward.test.ts
@@ -1,0 +1,18 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+describe('Test MicrosoftOutlookV2, message => createForward', () => {
+	nock('https://graph.microsoft.com/v1.0/me')
+		.post(
+			'/messages/AAMkADlhOTA0MTc5LWUwOTMtNDRkZS05NzE0LTNlYmI0ZWM5OWI5OABGAAAAAABPLqzvT6b9RLP0CKzHiJrRBwBZf4De-LkrSqpPI8eyjUmAAAAAAAEJAABZf4De-LkrSqpPI8eyjUmAAAFXBEVwAAA=/createForward',
+			{
+				toRecipients: [{ emailAddress: { address: 'to@mail.com' } }],
+				comment: 'Test Comment',
+			},
+		)
+		.reply(200);
+
+	new NodeTestHarness().setupTests({
+		workflowFiles: ['createForward.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/message/createForward.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/message/createForward.workflow.json
@@ -1,0 +1,64 @@
+{
+	"name": "My workflow",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "161c54a2-a925-4462-a41e-db05a73d32e2",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [520, 160]
+		},
+		{
+			"parameters": {
+				"operation": "createForward",
+				"messageId": {
+					"__rl": true,
+					"value": "AAMkADlhOTA0MTc5LWUwOTMtNDRkZS05NzE0LTNlYmI0ZWM5OWI5OABGAAAAAABPLqzvT6b9RLP0CKzHiJrRBwBZf4De-LkrSqpPI8eyjUmAAAAAAAEJAABZf4De-LkrSqpPI8eyjUmAAAFXBEVwAAA=",
+					"mode": "list",
+					"cachedResultName": "Hello",
+					"cachedResultUrl": "https://outlook.office365.com/owa/?ItemID=AAMkADlhOTA0MTc5LWUwOTMtNDRkZS05NzE0LTNlYmI0ZWM5OWI5OABGAAAAAABPLqzvT6b9RLP0CKzHiJrRBwBZf4De%2FLkrSqpPI8eyjUmAAAAAAAEJAABZf4De%2FLkrSqpPI8eyjUmAAAFXBEVwAAA%3D&exvsurl=1&viewmodel=ReadMessageItem"
+				},
+				"toRecipients": "to@mail.com",
+				"comment": "Test Comment"
+			},
+			"id": "fe7fbd9f-e3c6-445a-96fb-910d82210b64",
+			"name": "Microsoft Outlook",
+			"type": "n8n-nodes-base.microsoftOutlook",
+			"typeVersion": 2,
+			"position": [740, 160],
+			"webhookId": "a3e0930c-6d3d-403e-b270-41f68d153c57",
+			"credentials": {
+				"microsoftOutlookOAuth2Api": {
+					"id": "1T1PrdT4uMw8uNfT",
+					"name": "Microsoft Outlook account"
+				}
+			}
+		}
+	],
+	"pinData": {},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Outlook",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "6741e697-643e-4bf4-ad96-e9e660606cb0",
+	"meta": {
+		"templateCredsSetupCompleted": true,
+		"instanceId": "e527f2a33eb3d1430899ff27ce88c903aae237f007f3a82750d920a5062d76fc"
+	},
+	"id": "znOzc7TFURgatXsC",
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/message/createForward.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/message/createForward.operation.ts
@@ -1,0 +1,155 @@
+import type { IDataObject, IExecuteFunctions, INodeProperties } from 'n8n-workflow';
+
+import { updateDisplayOptions } from '@utils/utilities';
+
+import { messageRLC } from '../../descriptions';
+import { microsoftApiRequest } from '../../transport';
+
+export const properties: INodeProperties[] = [
+	messageRLC,
+	{
+		displayName: 'To Recipients',
+		name: 'toRecipients',
+		type: 'string',
+		description: 'Comma-separated list of email addresses of recipients',
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['message'],
+				operation: ['createForward'],
+			},
+		},
+	},
+	{
+		displayName: 'Message Options',
+		name: 'messageOptions',
+		type: 'options',
+		options: [
+			{
+				name: 'Comment',
+				value: 'comment',
+			},
+			{
+				name: 'Body',
+				value: 'body',
+			},
+		],
+		default: 'comment',
+		description: 'Choose between adding a comment or setting the full message body',
+		displayOptions: {
+			show: {
+				resource: ['message'],
+				operation: ['createForward'],
+			},
+		},
+	},
+	{
+		displayName: 'Comment',
+		name: 'comment',
+		type: 'string',
+		default: '',
+		description: 'A comment to include. Set a comment or body, but not both.',
+		displayOptions: {
+			show: {
+				resource: ['message'],
+				operation: ['createForward'],
+				messageOptions: ['comment'],
+			},
+		},
+	},
+	{
+		displayName: 'Body',
+		name: 'body',
+		type: 'string',
+		default: '',
+		description: 'The body of the message. Set a comment or body, but not both.',
+		displayOptions: {
+			show: {
+				resource: ['message'],
+				operation: ['createForward'],
+				messageOptions: ['body'],
+			},
+		},
+	},
+	{
+		displayName: 'Message Type',
+		name: 'bodyContentType',
+		description: 'Message body content type',
+		displayOptions: {
+			show: {
+				resource: ['message'],
+				operation: ['createForward'],
+				messageOptions: ['body'],
+			},
+		},
+		type: 'options',
+		options: [
+			{
+				name: 'HTML',
+				value: 'html',
+			},
+			{
+				name: 'Text',
+				value: 'Text',
+			},
+		],
+		default: 'html',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['message'],
+		operation: ['createForward'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(this: IExecuteFunctions, index: number) {
+	const messageId = this.getNodeParameter('messageId', index, undefined, {
+		extractValue: true,
+	}) as string;
+
+	const toRecipients = (this.getNodeParameter('toRecipients', index, '') as string)
+		.split(',')
+		.map((email) => email.trim())
+		.filter((email) => !!email);
+	const messageOptions = this.getNodeParameter('messageOptions', index) as string;
+
+	const body: {
+		toRecipients: Array<{ emailAddress: { address: string } }>;
+		comment?: string;
+		message?: { body: { content: string; contentType: string } };
+	} = {
+		toRecipients: toRecipients.map((email) => ({ emailAddress: { address: email } })),
+	};
+
+	if (messageOptions === 'comment') {
+		const comment = this.getNodeParameter('comment', index, '') as string;
+		body.comment = comment;
+	} else {
+		const messageBody = this.getNodeParameter('body', index, '') as string;
+		const messageBodyContentType = this.getNodeParameter('bodyContentType', index) as string;
+		body.message = {
+			body: {
+				content: messageBody,
+				contentType: messageBodyContentType,
+			},
+		};
+	}
+
+	const responseData = await microsoftApiRequest.call(
+		this,
+		'POST',
+		`/messages/${messageId}/createForward`,
+		body,
+	);
+
+	const executionData = this.helpers.constructExecutionMetaData(
+		this.helpers.returnJsonArray(responseData as IDataObject),
+		{ itemData: { item: index } },
+	);
+
+	return executionData;
+}

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/message/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/message/index.ts
@@ -1,5 +1,6 @@
 import { SEND_AND_WAIT_OPERATION, type INodeProperties } from 'n8n-workflow';
 
+import * as createForward from './createForward.operation';
 import * as del from './delete.operation';
 import * as get from './get.operation';
 import * as getAll from './getAll.operation';
@@ -9,7 +10,7 @@ import * as send from './send.operation';
 import * as sendAndWait from './sendAndWait.operation';
 import * as update from './update.operation';
 
-export { del as delete, get, getAll, move, reply, send, sendAndWait, update };
+export { createForward, del as delete, get, getAll, move, reply, send, sendAndWait, update };
 
 export const description: INodeProperties[] = [
 	{
@@ -23,6 +24,12 @@ export const description: INodeProperties[] = [
 			},
 		},
 		options: [
+			{
+				name: 'Create Forward',
+				value: 'createForward',
+				description: 'Creates a forward message draft',
+				action: 'Creates a forward message draft',
+			},
 			{
 				name: 'Delete',
 				value: 'delete',
@@ -75,6 +82,7 @@ export const description: INodeProperties[] = [
 		default: 'send',
 	},
 
+	...createForward.description,
 	...del.description,
 	...get.description,
 	...getAll.description,

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/node.type.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/node.type.ts
@@ -7,7 +7,16 @@ type NodeMap = {
 	event: 'create' | 'delete' | 'get' | 'getAll' | 'update';
 	folder: 'create' | 'delete' | 'get' | 'getAll' | 'update';
 	folderMessage: 'getAll';
-	message: 'delete' | 'get' | 'getAll' | 'move' | 'update' | 'send' | 'reply' | 'sendAndWait';
+	message:
+		| 'createForward'
+		| 'delete'
+		| 'get'
+		| 'getAll'
+		| 'move'
+		| 'update'
+		| 'send'
+		| 'reply'
+		| 'sendAndWait';
 	messageAttachment: 'add' | 'download' | 'getAll' | 'get';
 };
 


### PR DESCRIPTION
## Summary

This PR adds the ability to use the 'createForward' method form the MS Graph Outlook API.  This allows to create a forward draft that contains all the original content and attachments from the original message.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs/pull/3271)
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
