### PR TITLE
fix: Fix examples for `Array#includes` method

### DIFF
--- a/packages/workflow/src/native-methods/array.methods.ts
+++ b/packages/workflow/src/native-methods/array.methods.ts
@@ -241,8 +241,8 @@ export const arrayMethods: NativeDoc = {
 				name: 'includes',
 				description: 'Returns <code>true</code> if the array contains the specified element',
 				examples: [
-					{ example: "['Bob', 'Bill', 'Nat'].indexOf('Nat')", evaluated: 'true' },
-					{ example: "['Bob', 'Bill', 'Nat'].indexOf('Nathan')", evaluated: 'false' },
+					{ example: "['Bob', 'Bill', 'Nat'].includes('Nat')", evaluated: 'true' },
+					{ example: "['Bob', 'Bill', 'Nat'].includes('Nathan')", evaluated: 'false' },
 				],
 				docURL:
 					'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes',


### PR DESCRIPTION
## Summary

This fixes the examples for the `includes` function in expressions.


**Before**:

|                 |                |
|------------------------|------------------------|
| ![Screenshot 2025-06-15 at 03 49 44 PM@2x](https://github.com/user-attachments/assets/97a1a547-9e7d-453d-af7b-e7c5e9ba1f3a)        | ![Screenshot 2025-06-15 at 03 49 50 PM@2x](https://github.com/user-attachments/assets/c36915cc-a4ec-42fe-8a90-03ce152efdf0)     |



**After**:
|                 |                |
|------------------------|------------------------|
| ![Screenshot 2025-06-15 at 03 49 23 PM@2x](https://github.com/user-attachments/assets/7b4431dc-8a80-4d3a-80a5-9f86e517c9d3)        | ![Screenshot 2025-06-15 at 03 49 33 PM@2x](https://github.com/user-attachments/assets/b1dfcea2-e920-4d4b-a693-a70580d8305b)        |




<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
N/A
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
