### PR TITLE
fix: provide HOME env for node version manager compatibility

### DIFF
--- a/packages/cli/src/services/community-packages.service.ts
+++ b/packages/cli/src/services/community-packages.service.ts
@@ -159,6 +159,7 @@ export class CommunityPackagesService {
 			env: {
 				NODE_PATH: process.env.NODE_PATH,
 				PATH: process.env.PATH,
+				HOME: process.env.HOME,
 				APPDATA: process.env.APPDATA,
 				NODE_ENV: 'production',
 			},


### PR DESCRIPTION
## Summary

[asdf version manager](https://asdf-vm.com/) shims requires `$HOME` to be set for finding the correct thing to execute.
See: #16361

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

Resolves #16361


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
