### PR TITLE
Fixed Postgres Execute Query Parameters Comma splitting

### DIFF
--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/executeQuery.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/executeQuery.operation.ts
@@ -102,7 +102,7 @@ export async function execute(
 							}
 						}
 					} else {
-						values.push(...parseCSVWithQuotes(rawValues).map((v) => v)); // Ensure single values
+						values.push(...stringToArray(rawValues));
 					}
 				} else {
 					const evaluatedValue = evaluateExpression(this.evaluateExpression(rawValues, index));


### PR DESCRIPTION
Hey there, this here fixes the issue with the Postgres node, where text Parameters that include a comma got wrongly separated as single parameters.

I have tested it and it works now as it supposed to.

## Summary

Fixing the known problem on the Postgres Node, where given text parameters that include a comma got wrongfully splittet.

## Related Linear tickets, Github issues, and Community forum posts

fixes: #16354, #14955