### PR TITLE
refactor(editor): Detangle `ui` store from `settings` store (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/init.test.ts
+++ b/packages/frontend/editor-ui/src/init.test.ts
@@ -15,6 +15,7 @@ import { STORES } from '@n8n/stores';
 import { useSSOStore } from '@/stores/sso.store';
 import { UserManagementAuthenticationMethod } from '@/Interface';
 import { EnterpriseEditionFeature } from '@/constants';
+import { useUIStore } from '@/stores/ui.store';
 
 const showMessage = vi.fn();
 
@@ -38,6 +39,7 @@ describe('Init', () => {
 	let nodeTypesStore: ReturnType<typeof useNodeTypesStore>;
 	let versionsStore: ReturnType<typeof useVersionsStore>;
 	let ssoStore: ReturnType<typeof useSSOStore>;
+	let uiStore: ReturnType<typeof useUIStore>;
 
 	beforeEach(() => {
 		setActivePinia(
@@ -56,6 +58,7 @@ describe('Init', () => {
 		versionsStore = useVersionsStore();
 		versionsStore = useVersionsStore();
 		ssoStore = useSSOStore();
+		uiStore = useUIStore();
 	});
 
 	describe('initializeCore()', () => {
@@ -102,6 +105,18 @@ describe('Init', () => {
 					ldap: false,
 					oidc: false,
 				},
+			});
+		});
+
+		it('should initialize uiStore with banners based on settings', async () => {
+			settingsStore.isEnterpriseFeatureEnabled.showNonProdBanner = true;
+			settingsStore.settings.banners = { dismissed: [] };
+			settingsStore.settings.versionCli = '1.2.3';
+
+			await initializeCore();
+
+			expect(uiStore.initialize).toHaveBeenCalledWith({
+				banners: ['NON_PRODUCTION_LICENSE', 'V1'],
 			});
 		});
 	});

--- a/packages/frontend/editor-ui/src/init.ts
+++ b/packages/frontend/editor-ui/src/init.ts
@@ -16,6 +16,8 @@ import SourceControlInitializationErrorMessage from '@/components/SourceControlI
 import { useSSOStore } from '@/stores/sso.store';
 import { EnterpriseEditionFeature } from '@/constants';
 import type { UserManagementAuthenticationMethod } from '@/Interface';
+import { useUIStore } from '@/stores/ui.store';
+import type { BannerName } from '@n8n/api-types';
 
 export const state = {
 	initialized: false,
@@ -35,6 +37,7 @@ export async function initializeCore() {
 	const usersStore = useUsersStore();
 	const versionsStore = useVersionsStore();
 	const ssoStore = useSSOStore();
+	const uiStore = useUIStore();
 
 	await settingsStore.initialize();
 
@@ -47,6 +50,20 @@ export async function initializeCore() {
 			ldap: settingsStore.isEnterpriseFeatureEnabled[EnterpriseEditionFeature.Ldap],
 			oidc: settingsStore.isEnterpriseFeatureEnabled[EnterpriseEditionFeature.Oidc],
 		},
+	});
+
+	const banners: BannerName[] = [];
+	if (settingsStore.isEnterpriseFeatureEnabled.showNonProdBanner) {
+		banners.push('NON_PRODUCTION_LICENSE');
+	}
+	if (
+		!(settingsStore.settings.banners?.dismissed || []).includes('V1') &&
+		settingsStore.settings.versionCli.startsWith('1.')
+	) {
+		banners.push('V1');
+	}
+	uiStore.initialize({
+		banners,
 	});
 
 	void useExternalHooks().run('app.mount');

--- a/packages/frontend/editor-ui/src/stores/settings.store.ts
+++ b/packages/frontend/editor-ui/src/stores/settings.store.ts
@@ -15,7 +15,6 @@ import { UserManagementAuthenticationMethod } from '@/Interface';
 import type { IDataObject, WorkflowSettings } from 'n8n-workflow';
 import { defineStore } from 'pinia';
 import { useRootStore } from '@n8n/stores/useRootStore';
-import { useUIStore } from './ui.store';
 import { useUsersStore } from './users.store';
 import { useVersionsStore } from './versions.store';
 import { makeRestApiRequest } from '@n8n/rest-api-client';
@@ -190,10 +189,6 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 		mfa.value.enabled = settings.value.mfa?.enabled;
 		folders.value.enabled = settings.value.folders?.enabled;
 
-		if (settings.value.enterprise?.showNonProdBanner) {
-			useUIStore().pushBannerToStack('NON_PRODUCTION_LICENSE');
-		}
-
 		if (settings.value.versionCli) {
 			useRootStore().setVersionCli(settings.value.versionCli);
 		}
@@ -207,11 +202,6 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 				document.write(INSECURE_CONNECTION_WARNING);
 				return;
 			}
-		}
-
-		const isV1BannerDismissedPermanently = (settings.value.banners?.dismissed || []).includes('V1');
-		if (!isV1BannerDismissedPermanently && settings.value.versionCli.startsWith('1.')) {
-			useUIStore().pushBannerToStack('V1');
 		}
 	};
 

--- a/packages/frontend/editor-ui/src/stores/ui.store.ts
+++ b/packages/frontend/editor-ui/src/stores/ui.store.ts
@@ -527,9 +527,7 @@ export const useUIStore = defineStore(STORES.UI, () => {
 	};
 
 	const initialize = (options: { banners: BannerName[] }) => {
-		options.banners.forEach((banner) => {
-			pushBannerToStack(banner);
-		});
+		options.banners.forEach(pushBannerToStack);
 	};
 
 	return {

--- a/packages/frontend/editor-ui/src/stores/ui.store.ts
+++ b/packages/frontend/editor-ui/src/stores/ui.store.ts
@@ -526,6 +526,12 @@ export const useUIStore = defineStore(STORES.UI, () => {
 		processingExecutionResults.value = value;
 	};
 
+	const initialize = (options: { banners: BannerName[] }) => {
+		options.banners.forEach((banner) => {
+			pushBannerToStack(banner);
+		});
+	};
+
 	return {
 		appGridDimensions,
 		appliedTheme,
@@ -579,6 +585,7 @@ export const useUIStore = defineStore(STORES.UI, () => {
 		setProcessingExecutionResults,
 		openDeleteFolderModal,
 		openMoveToFolderModal,
+		initialize,
 	};
 });
 

--- a/packages/frontend/editor-ui/src/stores/ui.test.ts
+++ b/packages/frontend/editor-ui/src/stores/ui.test.ts
@@ -70,34 +70,24 @@ describe('UI store', () => {
 	});
 
 	it('should add non-production license banner to stack based on enterprise settings', () => {
-		settingsStore.setSettings(
-			merge({}, defaultSettings, {
-				enterprise: {
-					showNonProdBanner: true,
-				},
-			}),
-		);
+		uiStore.initialize({
+			banners: ['NON_PRODUCTION_LICENSE'],
+		});
 		expect(uiStore.bannerStack).toContain('NON_PRODUCTION_LICENSE');
 	});
 
 	it("should add V1 banner to stack if it's not dismissed", () => {
-		settingsStore.setSettings(
-			merge({}, defaultSettings, {
-				versionCli: '1.0.0',
-			}),
-		);
+		uiStore.initialize({
+			banners: ['V1'],
+		});
 		expect(uiStore.bannerStack).toContain('V1');
 	});
 
 	it("should not add V1 banner to stack if it's dismissed", () => {
-		settingsStore.setSettings(
-			merge({}, defaultSettings, {
-				versionCli: '1.0.0',
-				banners: {
-					dismissed: ['V1'],
-				},
-			}),
-		);
+		uiStore.initialize({
+			banners: [],
+		});
+
 		expect(uiStore.bannerStack).not.toContain('V1');
 	});
 


### PR DESCRIPTION
## Summary

Detangle `ui` store from `settings` store
## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-938/refactor-usesettingsstore-to-no-longer-import-external-stores


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
