### PR TITLE
chore: Add telemetry on structured output errors (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/utils/output_parsers/N8nStructuredOutputParser.ts
+++ b/packages/@n8n/nodes-langchain/utils/output_parsers/N8nStructuredOutputParser.ts
@@ -31,6 +31,7 @@ export class N8nStructuredOutputParser extends StructuredOutputParser<
 		const { index } = this.context.addInputData(NodeConnectionTypes.AiOutputParser, [
 			[{ json: { action: 'parse', text } }],
 		]);
+
 		try {
 			const jsonString = text.includes('```') ? text.split(/```(?:json)?/)[1] : text;
 			const json = JSON.parse(jsonString.trim());
@@ -60,6 +61,24 @@ export class N8nStructuredOutputParser extends StructuredOutputParser<
 						"To continue the execution when this happens, change the 'On Error' parameter in the root node's settings",
 				},
 			);
+
+			// Add additional context to the error
+			if (e instanceof SyntaxError) {
+				nodeError.context.outputParserFailReason = 'Invalid JSON in model output';
+			} else if (
+				text.trim() === '{}' ||
+				(e instanceof z.ZodError &&
+					e.issues?.[0] &&
+					e.issues?.[0].code === 'invalid_type' &&
+					e.issues?.[0].path?.[0] === 'output' &&
+					e.issues?.[0].expected === 'object' &&
+					e.issues?.[0].received === 'undefined')
+			) {
+				nodeError.context.outputParserFailReason = 'Model output wrapper is an empty object';
+			} else if (e instanceof z.ZodError) {
+				nodeError.context.outputParserFailReason =
+					'Model output does not match the expected schema';
+			}
 
 			logAiEvent(this.context, 'ai-output-parsed', {
 				text,

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -730,8 +730,14 @@ export class TelemetryEventRelay extends EventRelay {
 					credential_type: null,
 					is_managed: false,
 					eval_rows_left: null,
+					output_parser_fail_reason: null,
 					...TelemetryHelpers.resolveAIMetrics(workflow.nodes, this.nodeTypes),
 					...TelemetryHelpers.resolveVectorStoreMetrics(workflow.nodes, this.nodeTypes, runData),
+					...TelemetryHelpers.extractLastExecutedNodeStructuredOutputErrorInfo(
+						workflow,
+						this.nodeTypes,
+						runData,
+					),
 				};
 
 				if (!manualExecEventProperties.node_graph_string) {

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -730,7 +730,6 @@ export class TelemetryEventRelay extends EventRelay {
 					credential_type: null,
 					is_managed: false,
 					eval_rows_left: null,
-					output_parser_fail_reason: null,
 					...TelemetryHelpers.resolveAIMetrics(workflow.nodes, this.nodeTypes),
 					...TelemetryHelpers.resolveVectorStoreMetrics(workflow.nodes, this.nodeTypes, runData),
 					...TelemetryHelpers.extractLastExecutedNodeStructuredOutputErrorInfo(

--- a/packages/workflow/src/telemetry-helpers.ts
+++ b/packages/workflow/src/telemetry-helpers.ts
@@ -253,7 +253,7 @@ export function generateNodesGraph(
 		if (node.type === AI_TRANSFORM_NODE_TYPE && options?.isCloudDeployment) {
 			nodeItem.prompts = { instructions: node.parameters.instructions as string };
 		} else if (node.type === AGENT_LANGCHAIN_NODE_TYPE) {
-			nodeItem.agent = (node.parameters.agent as string) ?? 'conversationalAgent';
+			nodeItem.agent = (node.parameters.agent as string) ?? 'toolsAgent';
 		} else if (node.type === MERGE_NODE_TYPE) {
 			nodeItem.operation = node.parameters.mode as string;
 

--- a/packages/workflow/src/telemetry-helpers.ts
+++ b/packages/workflow/src/telemetry-helpers.ts
@@ -711,11 +711,18 @@ export function extractLastExecutedNodeStructuredOutputErrorInfo(
 									nodeType.description,
 								);
 
-								if (nodeParameters?.model) {
-									info.model_name =
-										typeof nodeParameters.model === 'string'
-											? nodeParameters.model
-											: ((nodeParameters.model as INodeParameterResourceLocator).value as string);
+								const modelNameKeys = ['model', 'modelName'] as const;
+								for (const key of modelNameKeys) {
+									if (nodeParameters?.[key]) {
+										info.model_name =
+											typeof nodeParameters[key] === 'string'
+												? nodeParameters[key]
+												: ((nodeParameters[key] as INodeParameterResourceLocator).value as string);
+
+										if (info.model_name) {
+											break;
+										}
+									}
 								}
 							}
 						}

--- a/packages/workflow/test/telemetry-helpers.test.ts
+++ b/packages/workflow/test/telemetry-helpers.test.ts
@@ -2305,7 +2305,7 @@ describe('extractLastExecutedNodeStructuredOutputErrorInfo', () => {
 		const connectedTool2 = mockToolNode('ConnectedTool2');
 		const unconnectedTool1 = mockToolNode('UnconnectedTool1');
 		const unconnectedTool2 = mockToolNode('UnconnectedTool2');
-		const someOtherNode = {
+		const someOtherNode: INode = {
 			id: 'other-node',
 			name: 'SomeOtherNode',
 			type: 'n8n-nodes-base.set',

--- a/packages/workflow/test/telemetry-helpers.test.ts
+++ b/packages/workflow/test/telemetry-helpers.test.ts
@@ -2355,4 +2355,37 @@ describe('extractLastExecutedNodeStructuredOutputErrorInfo', () => {
 			num_tools: 2, // Only ConnectedTool1 and ConnectedTool2
 		});
 	});
+
+	it('should extract model name from modelName parameter when model parameter is not present', () => {
+		const agentNode = mockAgentNode();
+		const modelNode: INode = {
+			id: 'model-node-id',
+			name: 'Google Gemini Model',
+			type: 'n8n-nodes-langchain.lmChatGoogleGemini',
+			typeVersion: 1,
+			position: [200, 200],
+			parameters: {
+				// Using modelName instead of model
+				modelName: 'gemini-1.5-pro',
+			},
+		};
+		const workflow = mockWorkflow([agentNode, modelNode], {
+			'Google Gemini Model': {
+				[NodeConnectionTypes.AiLanguageModel]: [
+					[{ node: 'Agent', type: NodeConnectionTypes.AiLanguageModel, index: 0 }],
+				],
+			},
+		});
+		const runData = mockRunData('Agent', new Error('Some error'));
+
+		jest
+			.spyOn(nodeHelpers, 'getNodeParameters')
+			.mockReturnValueOnce(mock<INodeParameters>({ modelName: 'gemini-1.5-pro' }));
+
+		const result = extractLastExecutedNodeStructuredOutputErrorInfo(workflow, nodeTypes, runData);
+		expect(result).toEqual({
+			num_tools: 0,
+			model_name: 'gemini-1.5-pro',
+		});
+	});
 });


### PR DESCRIPTION
## Summary

This PR adds some debug info to the telemetry on manual execution errors related to Agent's structured output:
- Fail reason added to the exception thrown by Structured output Parser
- Additional info (model name and number of tools connected to Agent) collected on manual execution errors

As a side quest, default type of agent sent to telemetry was changed from 'conversationalAgen` to `toolsAgent` to align with the AI Agent node (which can be only ToolsAgent in latest versions).

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-780/add-telemetry-to-agent-when-output-parser-is-requested-and-format


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
