### PR TITLE
feat(core): Implement lifecycle hooks to support streaming responses (no-changelog)

### DIFF
--- a/packages/cli/src/__tests__/workflow-runner.test.ts
+++ b/packages/cli/src/__tests__/workflow-runner.test.ts
@@ -1,6 +1,7 @@
 import type { User } from '@n8n/db';
 import type { ExecutionEntity } from '@n8n/db';
 import { Container, Service } from '@n8n/di';
+import type { Response } from 'express';
 import { mock } from 'jest-mock-extended';
 import { DirectedGraph, WorkflowExecute } from 'n8n-core';
 import * as core from 'n8n-core';
@@ -22,6 +23,7 @@ import PCancelable from 'p-cancelable';
 import { ActiveExecutions } from '@/active-executions';
 import config from '@/config';
 import { ExecutionNotFoundError } from '@/errors/execution-not-found-error';
+import * as ExecutionLifecycleHooks from '@/execution-lifecycle/execution-lifecycle-hooks';
 import { CredentialsPermissionChecker } from '@/executions/pre-execution-checks';
 import { ManualExecutionService } from '@/manual-execution.service';
 import { Telemetry } from '@/telemetry';
@@ -298,5 +300,87 @@ describe('enqueueExecution', () => {
 		await expect(runner.enqueueExecution('1', 'workflow-xyz', data)).rejects.toThrowError(error);
 
 		expect(setupQueue).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('streaming functionality', () => {
+	it('should setup sendChunk handler when streaming is enabled and execution mode is not manual', async () => {
+		// ARRANGE
+		const activeExecutions = Container.get(ActiveExecutions);
+		jest.spyOn(activeExecutions, 'add').mockResolvedValue('1');
+		jest.spyOn(activeExecutions, 'attachWorkflowExecution').mockReturnValueOnce();
+		const permissionChecker = Container.get(CredentialsPermissionChecker);
+		jest.spyOn(permissionChecker, 'check').mockResolvedValueOnce();
+
+		const mockResponse = mock<Response>();
+
+		const data = mock<IWorkflowExecutionDataProcess>({
+			workflowData: { nodes: [] },
+			executionData: undefined,
+			executionMode: 'webhook',
+			streamingEnabled: true,
+			httpResponse: mockResponse,
+		});
+
+		const mockHooks = mock<core.ExecutionLifecycleHooks>();
+		jest
+			.spyOn(ExecutionLifecycleHooks, 'getLifecycleHooksForRegularMain')
+			.mockReturnValue(mockHooks);
+
+		const mockAdditionalData = mock<IWorkflowExecuteAdditionalData>();
+		jest.spyOn(WorkflowExecuteAdditionalData, 'getBase').mockResolvedValue(mockAdditionalData);
+
+		const manualExecutionService = Container.get(ManualExecutionService);
+		jest.spyOn(manualExecutionService, 'runManually').mockReturnValue(
+			new PCancelable(() => {
+				return mock<IRun>();
+			}),
+		);
+
+		// ACT
+		await runner.run(data);
+
+		// ASSERT
+		expect(mockHooks.addHandler).toHaveBeenCalledWith('sendChunk', expect.any(Function));
+	});
+
+	it('should not setup sendChunk handler when streaming is enabled but execution mode is manual', async () => {
+		// ARRANGE
+		const activeExecutions = Container.get(ActiveExecutions);
+		jest.spyOn(activeExecutions, 'add').mockResolvedValue('1');
+		jest.spyOn(activeExecutions, 'attachWorkflowExecution').mockReturnValueOnce();
+		const permissionChecker = Container.get(CredentialsPermissionChecker);
+		jest.spyOn(permissionChecker, 'check').mockResolvedValueOnce();
+
+		const mockResponse = mock<Response>();
+
+		const data = mock<IWorkflowExecutionDataProcess>({
+			workflowData: { nodes: [] },
+			executionData: undefined,
+			executionMode: 'manual',
+			streamingEnabled: true,
+			httpResponse: mockResponse,
+		});
+
+		const mockHooks = mock<core.ExecutionLifecycleHooks>();
+		jest
+			.spyOn(ExecutionLifecycleHooks, 'getLifecycleHooksForRegularMain')
+			.mockReturnValue(mockHooks);
+
+		const mockAdditionalData = mock<IWorkflowExecuteAdditionalData>();
+		jest.spyOn(WorkflowExecuteAdditionalData, 'getBase').mockResolvedValue(mockAdditionalData);
+
+		const manualExecutionService = Container.get(ManualExecutionService);
+		jest.spyOn(manualExecutionService, 'runManually').mockReturnValue(
+			new PCancelable(() => {
+				return mock<IRun>();
+			}),
+		);
+
+		// ACT
+		await runner.run(data);
+
+		// ASSERT
+		expect(mockHooks.addHandler).not.toHaveBeenCalledWith('sendChunk', expect.any(Function));
 	});
 });

--- a/packages/cli/src/active-executions.ts
+++ b/packages/cli/src/active-executions.ts
@@ -177,6 +177,17 @@ export class ActiveExecutions {
 	finalizeExecution(executionId: string, fullRunData?: IRun) {
 		if (!this.has(executionId)) return;
 		const execution = this.getExecutionOrFail(executionId);
+
+		// Close response if it exists (for streaming responses)
+		if (execution.executionData.httpResponse) {
+			try {
+				this.logger.debug('Closing response for execution', { executionId });
+				execution.executionData.httpResponse.end();
+			} catch (error) {
+				this.logger.error('Error closing streaming response', { executionId, error });
+			}
+		}
+
 		execution.postExecutePromise.resolve(fullRunData);
 		this.logger.debug('Execution finalized', { executionId });
 	}

--- a/packages/cli/src/active-executions.ts
+++ b/packages/cli/src/active-executions.ts
@@ -144,10 +144,10 @@ export class ActiveExecutions {
 		execution?.responsePromise?.resolve(response);
 	}
 
-	/** Used for sending a chunk toa a streaming response */
+	/** Used for sending a chunk to a streaming response */
 	sendChunk(executionId: string, chunkText: StructuredChunk): void {
 		const execution = this.activeExecutions[executionId];
-		if (execution.httpResponse) {
+		if (execution?.httpResponse) {
 			execution?.httpResponse.write(JSON.stringify(chunkText) + '\n');
 			execution?.httpResponse.flush();
 		}

--- a/packages/cli/src/active-executions.ts
+++ b/packages/cli/src/active-executions.ts
@@ -184,7 +184,10 @@ export class ActiveExecutions {
 				this.logger.debug('Closing response for execution', { executionId });
 				execution.executionData.httpResponse.end();
 			} catch (error) {
-				this.logger.error('Error closing streaming response', { executionId, error });
+				this.logger.error('Error closing streaming response', {
+					executionId,
+					error: (error as Error).message,
+				});
 			}
 		}
 

--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -294,6 +294,7 @@ describe('Execution Lifecycle Hooks', () => {
 			expect(handlers.workflowExecuteAfter).toHaveLength(5);
 			expect(handlers.nodeFetchedData).toHaveLength(1);
 			expect(handlers.sendResponse).toHaveLength(0);
+			expect(handlers.sendChunk).toHaveLength(0);
 		});
 
 		describe('nodeExecuteBefore', () => {
@@ -610,6 +611,7 @@ describe('Execution Lifecycle Hooks', () => {
 			expect(handlers.workflowExecuteAfter).toHaveLength(4);
 			expect(handlers.nodeFetchedData).toHaveLength(0);
 			expect(handlers.sendResponse).toHaveLength(0);
+			expect(handlers.sendChunk).toHaveLength(0);
 		});
 
 		describe('workflowExecuteBefore', () => {
@@ -697,6 +699,7 @@ describe('Execution Lifecycle Hooks', () => {
 			expect(handlers.workflowExecuteAfter).toHaveLength(4);
 			expect(handlers.nodeFetchedData).toHaveLength(1);
 			expect(handlers.sendResponse).toHaveLength(0);
+			expect(handlers.sendChunk).toHaveLength(0);
 		});
 
 		describe('saving static data', () => {
@@ -794,6 +797,7 @@ describe('Execution Lifecycle Hooks', () => {
 			expect(handlers.workflowExecuteAfter).toHaveLength(4);
 			expect(handlers.nodeFetchedData).toHaveLength(1);
 			expect(handlers.sendResponse).toHaveLength(0);
+			expect(handlers.sendChunk).toHaveLength(0);
 		});
 	});
 });

--- a/packages/cli/src/interfaces.ts
+++ b/packages/cli/src/interfaces.ts
@@ -1,6 +1,6 @@
 import type { ICredentialsBase, IExecutionBase, IExecutionDb, ITagBase } from '@n8n/db';
 import type { AssignableGlobalRole } from '@n8n/permissions';
-import type { Application } from 'express';
+import type { Application, Response } from 'express';
 import type {
 	ExecutionError,
 	ICredentialDataDecryptedObject,
@@ -114,6 +114,8 @@ export interface IExecutingWorkflowData {
 	startedAt: Date;
 	/** This promise rejects when the execution is stopped. When the execution finishes (successfully or not), the promise resolves. */
 	postExecutePromise: IDeferredPromise<IRun | undefined>;
+	/** HTTPResponse needed for streaming responses */
+	httpResponse?: Response;
 	responsePromise?: IDeferredPromise<IExecuteResponsePromiseData>;
 	workflowExecution?: PCancelable<IRun>;
 	status: ExecutionStatus;

--- a/packages/cli/src/scaling/__tests__/scaling.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/scaling.service.test.ts
@@ -6,13 +6,13 @@ import { mock } from 'jest-mock-extended';
 import { InstanceSettings } from 'n8n-core';
 import { ApplicationError, ExecutionCancelledError } from 'n8n-workflow';
 
+import type { ActiveExecutions } from '@/active-executions';
 import { mockInstance } from '@test/mocking';
 
 import { JOB_TYPE_NAME, QUEUE_NAME } from '../constants';
 import type { JobProcessor } from '../job-processor';
 import { ScalingService } from '../scaling.service';
 import type { Job, JobData, JobId, JobQueue } from '../scaling.types';
-import { ActiveExecutions } from '@/active-executions';
 
 const queue = mock<JobQueue>({
 	client: { ping: jest.fn() },

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -8,6 +8,7 @@ import type {
 	IExecuteResponsePromiseData,
 	IRun,
 	IWorkflowExecutionDataProcess,
+	StructuredChunk,
 } from 'n8n-workflow';
 import { BINARY_ENCODING, Workflow, UnexpectedError } from 'n8n-workflow';
 import type PCancelable from 'p-cancelable';
@@ -25,6 +26,7 @@ import type {
 	JobResult,
 	RespondToWebhookMessage,
 	RunningJob,
+	SendChunkMessage,
 } from './scaling.types';
 
 /**
@@ -143,6 +145,17 @@ export class JobProcessor {
 				kind: 'respond-to-webhook',
 				executionId,
 				response: this.encodeWebhookResponse(response),
+				workerId: this.instanceSettings.hostId,
+			};
+
+			await job.progress(msg);
+		});
+
+		lifecycleHooks.addHandler('sendChunk', async (chunk: StructuredChunk): Promise<void> => {
+			const msg: SendChunkMessage = {
+				kind: 'send-chunk',
+				executionId,
+				chunkText: chunk,
 				workerId: this.instanceSettings.hostId,
 			};
 

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -316,6 +316,9 @@ export class ScalingService {
 			// than natively provided by Bull in `global:completed` and `global:failed` events
 
 			switch (msg.kind) {
+				case 'send-chunk':
+					this.activeExecutions.sendChunk(msg.executionId, msg.chunkText);
+					break;
 				case 'respond-to-webhook':
 					const decodedResponse = this.decodeWebhookResponse(msg.response);
 					this.activeExecutions.resolveResponsePromise(msg.executionId, decodedResponse);

--- a/packages/cli/src/scaling/scaling.types.ts
+++ b/packages/cli/src/scaling/scaling.types.ts
@@ -1,6 +1,6 @@
 import type { RunningJobSummary } from '@n8n/api-types';
 import type Bull from 'bull';
-import type { ExecutionError, IExecuteResponsePromiseData, IRun } from 'n8n-workflow';
+import type { ExecutionError, IDataObject, IExecuteResponsePromiseData, IRun } from 'n8n-workflow';
 import type PCancelable from 'p-cancelable';
 
 export type JobQueue = Bull.Queue<JobData>;
@@ -35,7 +35,8 @@ export type JobMessage =
 	| RespondToWebhookMessage
 	| JobFinishedMessage
 	| JobFailedMessage
-	| AbortJobMessage;
+	| AbortJobMessage
+	| SendChunkMessage;
 
 /** Message sent by worker to main to respond to a webhook. */
 export type RespondToWebhookMessage = {
@@ -49,6 +50,13 @@ export type RespondToWebhookMessage = {
 export type JobFinishedMessage = {
 	kind: 'job-finished';
 	executionId: string;
+	workerId: string;
+};
+
+export type SendChunkMessage = {
+	kind: 'send-chunk';
+	executionId: string;
+	chunkText: IDataObject;
 	workerId: string;
 };
 

--- a/packages/cli/src/scaling/scaling.types.ts
+++ b/packages/cli/src/scaling/scaling.types.ts
@@ -1,6 +1,11 @@
 import type { RunningJobSummary } from '@n8n/api-types';
 import type Bull from 'bull';
-import type { ExecutionError, IDataObject, IExecuteResponsePromiseData, IRun } from 'n8n-workflow';
+import type {
+	ExecutionError,
+	IExecuteResponsePromiseData,
+	IRun,
+	StructuredChunk,
+} from 'n8n-workflow';
 import type PCancelable from 'p-cancelable';
 
 export type JobQueue = Bull.Queue<JobData>;
@@ -56,7 +61,7 @@ export type JobFinishedMessage = {
 export type SendChunkMessage = {
 	kind: 'send-chunk';
 	executionId: string;
-	chunkText: IDataObject;
+	chunkText: StructuredChunk;
 	workerId: string;
 };
 

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -234,6 +234,9 @@ async function startExecution(
 		// This one already contains changes to talk to parent process
 		// and get executionID from `activeExecutions` running on main process
 		additionalDataIntegrated.executeWorkflow = additionalData.executeWorkflow;
+		if (additionalData.httpResponse) {
+			additionalDataIntegrated.httpResponse = additionalData.httpResponse;
+		}
 
 		let subworkflowTimeout = additionalData.executionTimeoutTimestamp;
 		const workflowSettings = workflowData.settings;

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -251,6 +251,10 @@ export class WorkflowRunner {
 
 		additionalData.executionId = executionId;
 
+		if (data.streamingEnabled) {
+			// TODO: Add stream handling
+		}
+
 		this.logger.debug(
 			`Execution for workflow ${data.workflowData.name} was assigned id ${executionId}`,
 			{ executionId },

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -251,10 +251,6 @@ export class WorkflowRunner {
 
 		additionalData.executionId = executionId;
 
-		if (data.streamingEnabled) {
-			// TODO: Add stream handling
-		}
-
 		this.logger.debug(
 			`Execution for workflow ${data.workflowData.name} was assigned id ${executionId}`,
 			{ executionId },
@@ -269,6 +265,15 @@ export class WorkflowRunner {
 			lifecycleHooks.addHandler('sendResponse', (response) => {
 				this.activeExecutions.resolveResponsePromise(executionId, response);
 			});
+
+			if (data.streamingEnabled) {
+				if (data.executionMode !== 'manual') {
+					lifecycleHooks.addHandler('sendChunk', (chunk) => {
+						data.httpResponse?.write(JSON.stringify(chunk) + '\n');
+						data.httpResponse?.flush();
+					});
+				}
+			}
 
 			additionalData.setExecutionStatus = WorkflowExecuteAdditionalData.setExecutionStatus.bind({
 				executionId,

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -270,7 +270,7 @@ export class WorkflowRunner {
 				if (data.executionMode !== 'manual') {
 					lifecycleHooks.addHandler('sendChunk', (chunk) => {
 						data.httpResponse?.write(JSON.stringify(chunk) + '\n');
-						data.httpResponse?.flush();
+						data.httpResponse?.flush?.();
 					});
 				}
 			}

--- a/packages/core/src/execution-engine/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/core/src/execution-engine/__tests__/execution-lifecycle-hooks.test.ts
@@ -39,6 +39,7 @@ describe('ExecutionLifecycleHooks', () => {
 				sendResponse: [],
 				workflowExecuteAfter: [],
 				workflowExecuteBefore: [],
+				sendChunk: [],
 			});
 		});
 	});

--- a/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
@@ -2179,11 +2179,9 @@ describe('WorkflowExecute', () => {
 			const testAdditionalData = Helpers.WorkflowExecuteAdditionalData(waitPromise);
 			testAdditionalData.hooks = mockHooks;
 
-			const testWorkflowExecute = new WorkflowExecute(testAdditionalData, 'manual');
-
 			// ACT
 			try {
-				await testWorkflowExecute.run(workflow, errorNode);
+				await workflowExecute.run(workflow, errorNode);
 			} catch {
 				// Expected to throw
 			}
@@ -2239,11 +2237,9 @@ describe('WorkflowExecute', () => {
 			const testAdditionalData = Helpers.WorkflowExecuteAdditionalData(waitPromise);
 			testAdditionalData.hooks = mockHooks;
 
-			const testWorkflowExecute = new WorkflowExecute(testAdditionalData, 'manual');
-
 			// ACT
 			try {
-				await testWorkflowExecute.run(workflow, errorNode);
+				await workflowExecute.run(workflow, errorNode);
 			} catch {
 				// Expected to throw
 			}
@@ -2296,10 +2292,8 @@ describe('WorkflowExecute', () => {
 			const testAdditionalData = Helpers.WorkflowExecuteAdditionalData(waitPromise);
 			testAdditionalData.hooks = mockHooks;
 
-			const testWorkflowExecute = new WorkflowExecute(testAdditionalData, 'manual');
-
 			// ACT
-			await testWorkflowExecute.run(workflow, successNode);
+			await workflowExecute.run(workflow, successNode);
 
 			// ASSERT
 			expect(mockHooks.runHook).not.toHaveBeenCalledWith('sendChunk', expect.anything());
@@ -2347,11 +2341,9 @@ describe('WorkflowExecute', () => {
 			const testAdditionalData = Helpers.WorkflowExecuteAdditionalData(waitPromise);
 			testAdditionalData.hooks = mockHooks;
 
-			const testWorkflowExecute = new WorkflowExecute(testAdditionalData, 'manual');
-
 			// ACT
 			try {
-				await testWorkflowExecute.run(workflow, errorNode);
+				await workflowExecute.run(workflow, errorNode);
 			} catch {
 				// Expected to throw
 			}
@@ -2406,11 +2398,9 @@ describe('WorkflowExecute', () => {
 			const testAdditionalData = Helpers.WorkflowExecuteAdditionalData(waitPromise);
 			testAdditionalData.hooks = mockHooks;
 
-			const testWorkflowExecute = new WorkflowExecute(testAdditionalData, 'manual');
-
 			// ACT
 			try {
-				await testWorkflowExecute.run(workflow, errorNode);
+				await workflowExecute.run(workflow, errorNode);
 			} catch {
 				// Expected to throw
 			}

--- a/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
@@ -38,8 +38,10 @@ import type {
 import {
 	ApplicationError,
 	createDeferredPromise,
+	NodeApiError,
 	NodeConnectionTypes,
 	NodeHelpers,
+	NodeOperationError,
 	Workflow,
 } from 'n8n-workflow';
 
@@ -2102,6 +2104,324 @@ describe('WorkflowExecute', () => {
 
 				expect(result).toEqual(expectedOutput);
 			});
+		});
+	});
+
+	describe('error chunk handling', () => {
+		const nodeTypes = mock<INodeTypes>();
+		let workflowExecute: WorkflowExecute;
+		let additionalData: IWorkflowExecuteAdditionalData;
+		let runExecutionData: IRunExecutionData;
+		let mockHooks: ExecutionLifecycleHooks;
+
+		beforeEach(() => {
+			runExecutionData = {
+				startData: {},
+				resultData: { runData: {} },
+				executionData: {
+					contextData: {},
+					nodeExecutionStack: [],
+					metadata: {},
+					waitingExecution: {},
+					waitingExecutionSource: null,
+				},
+			};
+
+			mockHooks = mock<ExecutionLifecycleHooks>();
+			additionalData = mock<IWorkflowExecuteAdditionalData>();
+			additionalData.hooks = mockHooks;
+			additionalData.currentNodeExecutionIndex = 0;
+
+			workflowExecute = new WorkflowExecute(additionalData, 'manual', runExecutionData);
+
+			jest.spyOn(mockHooks, 'runHook').mockResolvedValue(undefined);
+		});
+
+		test('should send error chunk when workflow execution fails', async () => {
+			// ARRANGE
+			const errorNode: INode = {
+				id: '1',
+				name: 'ErrorNode',
+				type: 'test.error',
+				typeVersion: 1,
+				position: [0, 0],
+				parameters: {},
+			};
+
+			const nodeOperationError = new NodeOperationError(errorNode, 'Node execution failed');
+			nodeOperationError.description = 'A detailed error description';
+
+			const errorNodeType = mock<INodeType>({
+				description: {
+					name: 'test.error',
+					displayName: 'Test Error Node',
+					defaultVersion: 1,
+					properties: [],
+					inputs: [{ type: NodeConnectionTypes.Main }],
+					outputs: [{ type: NodeConnectionTypes.Main }],
+				},
+				async execute() {
+					throw nodeOperationError;
+				},
+			});
+
+			nodeTypes.getByNameAndVersion.mockReturnValue(errorNodeType);
+
+			const workflow = new Workflow({
+				id: 'test',
+				nodes: [errorNode],
+				connections: {},
+				active: false,
+				nodeTypes,
+			});
+
+			const waitPromise = createDeferredPromise<IRun>();
+			const testAdditionalData = Helpers.WorkflowExecuteAdditionalData(waitPromise);
+			testAdditionalData.hooks = mockHooks;
+
+			const testWorkflowExecute = new WorkflowExecute(testAdditionalData, 'manual');
+
+			// ACT
+			try {
+				await testWorkflowExecute.run(workflow, errorNode);
+			} catch {
+				// Expected to throw
+			}
+
+			// ASSERT
+			expect(mockHooks.runHook).toHaveBeenCalledWith('sendChunk', [
+				{
+					type: 'error',
+					content: 'A detailed error description',
+				},
+			]);
+		});
+
+		test('should send error chunk when workflow execution fails with NodeApiError', async () => {
+			// ARRANGE
+			const errorNode: INode = {
+				id: 'error-node-id',
+				name: 'ErrorNode',
+				type: 'test.error',
+				typeVersion: 1,
+				position: [100, 200],
+				parameters: {},
+			};
+
+			const nodeApiError = new NodeApiError(errorNode, { message: 'API request failed' });
+			nodeApiError.description = 'The API returned an error';
+
+			const errorNodeType = mock<INodeType>({
+				description: {
+					name: 'test.error',
+					displayName: 'Test Error Node',
+					defaultVersion: 1,
+					properties: [],
+					inputs: [{ type: NodeConnectionTypes.Main }],
+					outputs: [{ type: NodeConnectionTypes.Main }],
+				},
+				async execute() {
+					throw nodeApiError;
+				},
+			});
+
+			nodeTypes.getByNameAndVersion.mockReturnValue(errorNodeType);
+
+			const workflow = new Workflow({
+				id: 'test',
+				nodes: [errorNode],
+				connections: {},
+				active: false,
+				nodeTypes,
+			});
+
+			const waitPromise = createDeferredPromise<IRun>();
+			const testAdditionalData = Helpers.WorkflowExecuteAdditionalData(waitPromise);
+			testAdditionalData.hooks = mockHooks;
+
+			const testWorkflowExecute = new WorkflowExecute(testAdditionalData, 'manual');
+
+			// ACT
+			try {
+				await testWorkflowExecute.run(workflow, errorNode);
+			} catch {
+				// Expected to throw
+			}
+
+			// ASSERT
+			expect(mockHooks.runHook).toHaveBeenCalledWith('sendChunk', [
+				{
+					type: 'error',
+					content: 'The API returned an error',
+				},
+			]);
+		});
+
+		test('should not send error chunk when workflow execution succeeds', async () => {
+			// ARRANGE
+			const successNode: INode = {
+				id: '1',
+				name: 'SuccessNode',
+				type: 'test.success',
+				typeVersion: 1,
+				position: [0, 0],
+				parameters: {},
+			};
+
+			const successNodeType = mock<INodeType>({
+				description: {
+					name: 'test.success',
+					displayName: 'Test Success Node',
+					defaultVersion: 1,
+					properties: [],
+					inputs: [{ type: NodeConnectionTypes.Main }],
+					outputs: [{ type: NodeConnectionTypes.Main }],
+				},
+				async execute() {
+					return [[{ json: { success: true } }]];
+				},
+			});
+
+			nodeTypes.getByNameAndVersion.mockReturnValue(successNodeType);
+
+			const workflow = new Workflow({
+				id: 'test',
+				nodes: [successNode],
+				connections: {},
+				active: false,
+				nodeTypes,
+			});
+
+			const waitPromise = createDeferredPromise<IRun>();
+			const testAdditionalData = Helpers.WorkflowExecuteAdditionalData(waitPromise);
+			testAdditionalData.hooks = mockHooks;
+
+			const testWorkflowExecute = new WorkflowExecute(testAdditionalData, 'manual');
+
+			// ACT
+			await testWorkflowExecute.run(workflow, successNode);
+
+			// ASSERT
+			expect(mockHooks.runHook).not.toHaveBeenCalledWith('sendChunk', expect.anything());
+		});
+
+		test('should send error chunk when workflow execution fails with NodeOperationError', async () => {
+			// ARRANGE
+			const errorNode: INode = {
+				id: '1',
+				name: 'ErrorNode',
+				type: 'test.error',
+				typeVersion: 1,
+				position: [0, 0],
+				parameters: {},
+			};
+
+			const nodeOperationError = new NodeOperationError(errorNode, 'Operation failed');
+			nodeOperationError.description = 'Custom error description';
+
+			const errorNodeType = mock<INodeType>({
+				description: {
+					name: 'test.error',
+					displayName: 'Test Error Node',
+					defaultVersion: 1,
+					properties: [],
+					inputs: [{ type: NodeConnectionTypes.Main }],
+					outputs: [{ type: NodeConnectionTypes.Main }],
+				},
+				async execute() {
+					throw nodeOperationError;
+				},
+			});
+
+			nodeTypes.getByNameAndVersion.mockReturnValue(errorNodeType);
+
+			const workflow = new Workflow({
+				id: 'test',
+				nodes: [errorNode],
+				connections: {},
+				active: false,
+				nodeTypes,
+			});
+
+			const waitPromise = createDeferredPromise<IRun>();
+			const testAdditionalData = Helpers.WorkflowExecuteAdditionalData(waitPromise);
+			testAdditionalData.hooks = mockHooks;
+
+			const testWorkflowExecute = new WorkflowExecute(testAdditionalData, 'manual');
+
+			// ACT
+			try {
+				await testWorkflowExecute.run(workflow, errorNode);
+			} catch {
+				// Expected to throw
+			}
+
+			// ASSERT
+			expect(mockHooks.runHook).toHaveBeenCalledWith('sendChunk', [
+				{
+					type: 'error',
+					content: 'Custom error description',
+				},
+			]);
+		});
+
+		test('should send error chunk with undefined content when error has no description', async () => {
+			// ARRANGE
+			const errorNode: INode = {
+				id: '1',
+				name: 'ErrorNode',
+				type: 'test.error',
+				typeVersion: 1,
+				position: [0, 0],
+				parameters: {},
+			};
+
+			const simpleError = new Error('Simple error message');
+
+			const errorNodeType = mock<INodeType>({
+				description: {
+					name: 'test.error',
+					displayName: 'Test Error Node',
+					defaultVersion: 1,
+					properties: [],
+					inputs: [{ type: NodeConnectionTypes.Main }],
+					outputs: [{ type: NodeConnectionTypes.Main }],
+				},
+				async execute() {
+					throw simpleError;
+				},
+			});
+
+			nodeTypes.getByNameAndVersion.mockReturnValue(errorNodeType);
+
+			const workflow = new Workflow({
+				id: 'test',
+				nodes: [errorNode],
+				connections: {},
+				active: false,
+				nodeTypes,
+			});
+
+			const waitPromise = createDeferredPromise<IRun>();
+			const testAdditionalData = Helpers.WorkflowExecuteAdditionalData(waitPromise);
+			testAdditionalData.hooks = mockHooks;
+
+			const testWorkflowExecute = new WorkflowExecute(testAdditionalData, 'manual');
+
+			// ACT
+			try {
+				await testWorkflowExecute.run(workflow, errorNode);
+			} catch {
+				// Expected to throw
+			}
+
+			// ASSERT
+			expect(mockHooks.runHook).toHaveBeenCalledWith('sendChunk', [
+				{
+					type: 'error',
+					content: undefined, // When no description is available, content should be undefined
+				},
+			]);
 		});
 	});
 });

--- a/packages/core/src/execution-engine/execution-lifecycle-hooks.ts
+++ b/packages/core/src/execution-engine/execution-lifecycle-hooks.ts
@@ -7,6 +7,7 @@ import type {
 	ITaskData,
 	ITaskStartedData,
 	IWorkflowBase,
+	StructuredChunk,
 	Workflow,
 	WorkflowExecuteMode,
 } from 'n8n-workflow';
@@ -46,6 +47,9 @@ export type ExecutionLifecycleHookHandlers = {
 		(this: ExecutionLifecycleHooks, response: IExecuteResponsePromiseData) => Promise<void> | void
 	>;
 
+	/** Used by nodes to send chunks to streaming responses */
+	sendChunk: Array<(this: ExecutionLifecycleHooks, chunk: StructuredChunk) => Promise<void> | void>;
+
 	/**
 	 * Executed after a node fetches data
 	 * - For a webhook node, after the node had been run.
@@ -84,6 +88,7 @@ export class ExecutionLifecycleHooks {
 		sendResponse: [],
 		workflowExecuteAfter: [],
 		workflowExecuteBefore: [],
+		sendChunk: [],
 	};
 
 	constructor(

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/execute-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/execute-context.test.ts
@@ -16,10 +16,11 @@ import type {
 } from 'n8n-workflow';
 import { ApplicationError, ExpressionError, NodeConnectionTypes } from 'n8n-workflow';
 
+import type { ExecutionLifecycleHooks } from '@/execution-engine/execution-lifecycle-hooks';
+
 import { describeCommonTests } from './shared-tests';
 import { ExecuteContext } from '../execute-context';
 import * as validateUtil from '../utils/validate-value-against-schema';
-import { randomUUID } from 'node:crypto';
 
 describe('ExecuteContext', () => {
 	const testCredentialType = 'testCredential';
@@ -51,6 +52,7 @@ describe('ExecuteContext', () => {
 		credentials: {
 			[testCredentialType]: {
 				id: 'testCredentialId',
+				name: 'testCredential',
 			},
 		},
 		parameters: {},
@@ -268,10 +270,10 @@ describe('ExecuteContext', () => {
 
 	describe('sendChunk', () => {
 		test('should send call hook with structured chunk', async () => {
-			const hooksMock = {
+			const hooksMock: ExecutionLifecycleHooks = mock<ExecutionLifecycleHooks>({
 				runHook: jest.fn(),
-			};
-			const additionalDataWithHooks = {
+			});
+			const additionalDataWithHooks: IWorkflowExecuteAdditionalData = {
 				...additionalData,
 				hooks: hooksMock,
 			};
@@ -306,10 +308,10 @@ describe('ExecuteContext', () => {
 		});
 
 		test('should send chunk without content when content is undefined', async () => {
-			const hooksMock = {
+			const hooksMock: ExecutionLifecycleHooks = mock<ExecutionLifecycleHooks>({
 				runHook: jest.fn(),
-			};
-			const additionalDataWithHooks = {
+			});
+			const additionalDataWithHooks: IWorkflowExecuteAdditionalData = {
 				...additionalData,
 				hooks: hooksMock,
 			};
@@ -328,11 +330,11 @@ describe('ExecuteContext', () => {
 				abortSignal,
 			);
 
-			await testExecuteContext.sendChunk('start');
+			await testExecuteContext.sendChunk('begin');
 
 			expect(hooksMock.runHook).toHaveBeenCalledWith('sendChunk', [
 				expect.objectContaining({
-					type: 'start',
+					type: 'begin',
 					content: undefined,
 					metadata: expect.objectContaining({
 						nodeName: 'Test Node',

--- a/packages/core/src/execution-engine/node-execution-context/execute-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/execute-context.ts
@@ -1,7 +1,9 @@
 import type {
 	AINodeConnectionType,
 	CallbackManager,
+	ChunkType,
 	CloseFunction,
+	IDataObject,
 	IExecuteData,
 	IExecuteFunctions,
 	IExecuteResponsePromiseData,
@@ -13,6 +15,7 @@ import type {
 	IWorkflowExecuteAdditionalData,
 	NodeExecutionHint,
 	Result,
+	StructuredChunk,
 	Workflow,
 	WorkflowExecuteMode,
 } from 'n8n-workflow';
@@ -126,6 +129,23 @@ export class ExecuteContext extends BaseExecuteContext implements IExecuteFuncti
 				fallbackValue,
 				options,
 			)) as IExecuteFunctions['getNodeParameter'];
+	}
+
+	async sendChunk(type: ChunkType, content?: IDataObject | string): Promise<void> {
+		const node = this.getNode();
+		const metadata = {
+			nodeId: node.id,
+			nodeName: node.name,
+			timestamp: Date.now(),
+		};
+
+		const message: StructuredChunk = {
+			type,
+			content: content ? JSON.stringify(content) : undefined,
+			metadata,
+		};
+
+		await this.additionalData.hooks?.runHook('sendChunk', [message]);
 	}
 
 	async startJob<T = unknown, E = unknown>(

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -1673,6 +1673,11 @@ export class WorkflowExecute {
 						taskData.error = executionError;
 						taskData.executionStatus = 'error';
 
+						// Send error to the response if necessary
+						await hooks?.runHook('sendChunk', [
+							{ type: 'error', content: executionError.description },
+						]);
+
 						if (
 							executionData.node.continueOnFail === true ||
 							['continueRegularOutput', 'continueErrorOutput'].includes(

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -919,6 +919,7 @@ export type IExecuteFunctions = ExecuteFunctions.GetNodeParameterFn &
 		putExecutionToWait(waitTill: Date): Promise<void>;
 		sendMessageToUI(message: any): void;
 		sendResponse(response: IExecuteResponsePromiseData): void;
+		sendChunk(type: ChunkType, content?: IDataObject | string): void;
 
 		// TODO: Make this one then only available in the new config one
 		addInputData(
@@ -2922,3 +2923,14 @@ export type IPersonalizationSurveyAnswersV4 = {
 	reportedSource?: string | null;
 	reportedSourceOther?: string | null;
 };
+
+export type ChunkType = 'begin' | 'item' | 'end';
+export interface StructuredChunk {
+	type: ChunkType;
+	content?: string;
+	metadata: {
+		nodeId: string;
+		nodeName: string;
+		timestamp: number;
+	};
+}

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2924,7 +2924,7 @@ export type IPersonalizationSurveyAnswersV4 = {
 	reportedSourceOther?: string | null;
 };
 
-export type ChunkType = 'begin' | 'item' | 'end';
+export type ChunkType = 'begin' | 'item' | 'end' | 'error';
 export interface StructuredChunk {
 	type: ChunkType;
 	content?: string;

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2093,7 +2093,12 @@ export interface IWebhookResponseData {
 }
 
 export type WebhookResponseData = 'allEntries' | 'firstEntryJson' | 'firstEntryBinary' | 'noData';
-export type WebhookResponseMode = 'onReceived' | 'lastNode' | 'responseNode' | 'formPage';
+export type WebhookResponseMode =
+	| 'onReceived'
+	| 'lastNode'
+	| 'responseNode'
+	| 'formPage'
+	| 'streaming';
 
 export interface INodeTypes {
 	getByName(nodeType: string): INodeType | IVersionedNodeType;
@@ -2324,6 +2329,8 @@ export interface IWorkflowExecutionDataProcess {
 		data?: ITaskData;
 	};
 	agentRequest?: AiAgentRequest;
+	httpResponse?: express.Response; // Used for streaming responses
+	streamingEnabled?: boolean;
 }
 
 export interface ExecuteWorkflowOptions {


### PR DESCRIPTION
## Summary
This PR adds infrastructure to support streaming responses:
- Add new response mode `streaming`
- Add response to execution data while `streaming`
- Add lifecycle hooks to send a chunk to the response
- Add message and hook for workers to support streaming in queue mode
- Close an open response at the end of execution

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-1033/add-response-mode-streaming
https://linear.app/n8n/issue/AI-1032/add-lifecycle-hooks-for-sending-chunks

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
