### PR TITLE
fix(editor): Fix keyboard shortcut bugs in the log view

### DIFF
--- a/packages/frontend/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/Canvas.vue
@@ -6,7 +6,7 @@ import { useCanvasNodeHover } from '@/composables/useCanvasNodeHover';
 import { useCanvasTraversal } from '@/composables/useCanvasTraversal';
 import type { ContextMenuAction, ContextMenuTarget } from '@/composables/useContextMenu';
 import { useContextMenu } from '@/composables/useContextMenu';
-import { useKeybindings } from '@/composables/useKeybindings';
+import { type KeyMap, useKeybindings } from '@/composables/useKeybindings';
 import type { PinDataSource } from '@/composables/usePinnedData';
 import { CanvasKey } from '@/constants';
 import type { NodeCreatorOpenSource } from '@/Interface';
@@ -54,6 +54,7 @@ import CanvasArrowHeadMarker from './elements/edges/CanvasArrowHeadMarker.vue';
 import Edge from './elements/edges/CanvasEdge.vue';
 import Node from './elements/nodes/CanvasNode.vue';
 import { useViewportAutoAdjust } from '@/components/canvas/composables/useViewportAutoAdjust';
+import { isOutsideSelected } from '@/utils/htmlUtils';
 
 const $style = useCssModule();
 
@@ -278,9 +279,12 @@ function selectUpstreamNodes(id: string) {
 }
 
 const keyMap = computed(() => {
-	const readOnlyKeymap = {
+	const readOnlyKeymap: KeyMap = {
 		ctrl_shift_o: emitWithLastSelectedNode((id) => emit('open:sub-workflow', id)),
-		ctrl_c: emitWithSelectedNodes((ids) => emit('copy:nodes', ids)),
+		ctrl_c: {
+			disabled: () => isOutsideSelected(viewportRef.value),
+			run: emitWithSelectedNodes((ids) => emit('copy:nodes', ids)),
+		},
 		enter: emitWithLastSelectedNode((id) => onSetNodeActivated(id)),
 		ctrl_a: () => addSelectedNodes(graphNodes.value),
 		// Support both key and code for zooming in and out
@@ -301,7 +305,7 @@ const keyMap = computed(() => {
 
 	if (props.readOnly) return readOnlyKeymap;
 
-	const fullKeymap = {
+	const fullKeymap: KeyMap = {
 		...readOnlyKeymap,
 		ctrl_x: emitWithSelectedNodes((ids) => emit('cut:nodes', ids)),
 		'delete|backspace': emitWithSelectedNodes((ids) => emit('delete:nodes', ids)),

--- a/packages/frontend/editor-ui/src/composables/useKeybindings.ts
+++ b/packages/frontend/editor-ui/src/composables/useKeybindings.ts
@@ -3,7 +3,11 @@ import { useDeviceSupport } from '@n8n/composables/useDeviceSupport';
 import type { MaybeRef, Ref } from 'vue';
 import { computed, unref } from 'vue';
 
-export type KeyMap = Record<string, (event: KeyboardEvent) => void>;
+type KeyboardEventHandler =
+	| ((event: KeyboardEvent) => void)
+	| { disabled: () => boolean; run: (event: KeyboardEvent) => void };
+
+export type KeyMap = Partial<Record<string, KeyboardEventHandler>>;
 
 /**
  * Binds a `keydown` event to `document` and calls the approriate
@@ -134,11 +138,13 @@ export const useKeybindings = (
 		// - Dvorak works correctly
 		// - Non-ansi layouts work correctly
 		const handler = normalizedKeymap.value[byKey] ?? normalizedKeymap.value[byCode];
+		const run =
+			typeof handler === 'function' ? handler : handler?.disabled() ? undefined : handler?.run;
 
-		if (handler) {
+		if (run) {
 			event.preventDefault();
 			event.stopPropagation();
-			handler(event);
+			run(event);
 		}
 	}
 

--- a/packages/frontend/editor-ui/src/composables/useKeybindings.ts
+++ b/packages/frontend/editor-ui/src/composables/useKeybindings.ts
@@ -3,7 +3,7 @@ import { useDeviceSupport } from '@n8n/composables/useDeviceSupport';
 import type { MaybeRef, Ref } from 'vue';
 import { computed, unref } from 'vue';
 
-type KeyMap = Record<string, (event: KeyboardEvent) => void>;
+export type KeyMap = Record<string, (event: KeyboardEvent) => void>;
 
 /**
  * Binds a `keydown` event to `document` and calls the approriate

--- a/packages/frontend/editor-ui/src/stores/builder.store.ts
+++ b/packages/frontend/editor-ui/src/stores/builder.store.ts
@@ -95,6 +95,10 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 		// Looks smoother if we wait for slide animation to finish before updating the grid width
 		// Has to wait for longer than SlideTransition duration
 		setTimeout(() => {
+			if (!window) {
+				return; // for unit testing
+			}
+
 			uiStore.appGridDimensions = {
 				...uiStore.appGridDimensions,
 				width: window.innerWidth,

--- a/packages/frontend/editor-ui/src/utils/htmlUtils.ts
+++ b/packages/frontend/editor-ui/src/utils/htmlUtils.ts
@@ -74,3 +74,18 @@ export const getBannerRowHeight = async (): Promise<number> => {
 		}, 0);
 	});
 };
+
+export function isOutsideSelected(el: HTMLElement | null) {
+	const selection = document.getSelection();
+
+	if (!selection?.anchorNode || !selection.focusNode || !el) {
+		return false;
+	}
+
+	return (
+		!el.contains(selection.anchorNode) &&
+		!el.contains(selection.focusNode) &&
+		(selection.anchorNode !== selection.focusNode ||
+			selection.anchorOffset !== selection.focusOffset)
+	);
+}

--- a/packages/frontend/editor-ui/src/utils/htmlUtils.ts
+++ b/packages/frontend/editor-ui/src/utils/htmlUtils.ts
@@ -4,7 +4,6 @@ import { ALLOWED_HTML_ATTRIBUTES, ALLOWED_HTML_TAGS } from '@/constants';
 /*
 	Constants and utility functions that help in HTML, CSS and DOM manipulation
 */
-
 export function sanitizeHtml(dirtyHtml: string) {
 	const sanitizedHtml = xss(dirtyHtml, {
 		onTagAttr: (tag, name, value) => {
@@ -47,21 +46,6 @@ export const sanitizeIfString = <T>(message: T): string | T => {
 	}
 	return message;
 };
-
-export function convertRemToPixels(rem: string) {
-	return parseInt(rem, 10) * parseFloat(getComputedStyle(document.documentElement).fontSize);
-}
-
-export function isChildOf(parent: Element, child: Element): boolean {
-	if (child.parentElement === null) {
-		return false;
-	}
-	if (child.parentElement === parent) {
-		return true;
-	}
-
-	return isChildOf(parent, child.parentElement);
-}
 
 export const capitalizeFirstLetter = (text: string): string => {
 	return text.charAt(0).toUpperCase() + text.slice(1);


### PR DESCRIPTION
## Summary
This PR fixes two keyboard short related bugs:
- Cannot copy text in log view with Cmd+C (and other selected text outside of canvas, e.g., error notification message)
- Typing `i` `j` in search field in log input/output panel triggers selecting previous/next node

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/SUG-72/bug-cant-copy-selected-text-from-the-logs-with-cmdc
https://linear.app/n8n/issue/SUG-78/bug-logs-view-keyboard-shortcuts-arent-deregistered-when-focus-is-on

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
