### PR TITLE
fix(core): Prevent unauthorised workflow termination

### DIFF
--- a/packages/cli/src/executions/__tests__/execution.service.test.ts
+++ b/packages/cli/src/executions/__tests__/execution.service.test.ts
@@ -70,12 +70,13 @@ describe('ExecutionService', () => {
 			/**
 			 * Arrange
 			 */
-			executionRepository.findSingleExecution.mockResolvedValue(undefined);
+			executionRepository.findWithUnflattenedData.mockResolvedValue(undefined);
+			const req = mock<ExecutionRequest.Stop>();
 
 			/**
 			 * Act
 			 */
-			const stop = executionService.stop('inexistent-123');
+			const stop = executionService.stop(req, []);
 
 			/**
 			 * Assert
@@ -88,12 +89,13 @@ describe('ExecutionService', () => {
 			 * Arrange
 			 */
 			const execution = mock<IExecutionResponse>({ id: '123', status: 'success' });
-			executionRepository.findSingleExecution.mockResolvedValue(execution);
+			executionRepository.findWithUnflattenedData.mockResolvedValue(execution);
+			const req = mock<ExecutionRequest.Stop>();
 
 			/**
 			 * Act
 			 */
-			const stop = executionService.stop(execution.id);
+			const stop = executionService.stop(req, ['123']);
 
 			/**
 			 * Assert
@@ -107,16 +109,18 @@ describe('ExecutionService', () => {
 				 * Arrange
 				 */
 				const execution = mock<IExecutionResponse>({ id: '123', status: 'running' });
-				executionRepository.findSingleExecution.mockResolvedValue(execution);
+				executionRepository.findWithUnflattenedData.mockResolvedValue(execution);
 				concurrencyControl.has.mockReturnValue(false);
 				activeExecutions.has.mockReturnValue(true);
 				waitTracker.has.mockReturnValue(false);
 				executionRepository.stopDuringRun.mockResolvedValue(mock<IExecutionResponse>());
 
+				const req = mock<ExecutionRequest.Stop>();
+
 				/**
 				 * Act
 				 */
-				await executionService.stop(execution.id);
+				await executionService.stop(req, ['123']);
 
 				/**
 				 * Assert
@@ -132,16 +136,18 @@ describe('ExecutionService', () => {
 				 * Arrange
 				 */
 				const execution = mock<IExecutionResponse>({ id: '123', status: 'waiting' });
-				executionRepository.findSingleExecution.mockResolvedValue(execution);
+				executionRepository.findWithUnflattenedData.mockResolvedValue(execution);
 				concurrencyControl.has.mockReturnValue(false);
 				activeExecutions.has.mockReturnValue(true);
 				waitTracker.has.mockReturnValue(true);
 				executionRepository.stopDuringRun.mockResolvedValue(mock<IExecutionResponse>());
 
+				const req = mock<ExecutionRequest.Stop>();
+
 				/**
 				 * Act
 				 */
-				await executionService.stop(execution.id);
+				await executionService.stop(req, ['123']);
 
 				/**
 				 * Assert
@@ -157,16 +163,18 @@ describe('ExecutionService', () => {
 				 * Arrange
 				 */
 				const execution = mock<IExecutionResponse>({ id: '123', status: 'new', mode: 'trigger' });
-				executionRepository.findSingleExecution.mockResolvedValue(execution);
+				executionRepository.findWithUnflattenedData.mockResolvedValue(execution);
 				concurrencyControl.has.mockReturnValue(true);
 				activeExecutions.has.mockReturnValue(false);
 				waitTracker.has.mockReturnValue(false);
 				executionRepository.stopBeforeRun.mockResolvedValue(mock<IExecutionResponse>());
 
+				const req = mock<ExecutionRequest.Stop>();
+
 				/**
 				 * Act
 				 */
-				await executionService.stop(execution.id);
+				await executionService.stop(req, ['123']);
 
 				/**
 				 * Assert
@@ -193,10 +201,12 @@ describe('ExecutionService', () => {
 						mode: 'manual',
 						status: 'running',
 					});
-					executionRepository.findSingleExecution.mockResolvedValue(execution);
+					executionRepository.findWithUnflattenedData.mockResolvedValue(execution);
 					concurrencyControl.has.mockReturnValue(false);
 					activeExecutions.has.mockReturnValue(true);
 					waitTracker.has.mockReturnValue(false);
+
+					const req = mock<ExecutionRequest.Stop>();
 					const job = mock<Job>({ data: { executionId: '123' } });
 					scalingService.findJobsByStatus.mockResolvedValue([job]);
 					executionRepository.stopDuringRun.mockResolvedValue(mock<IExecutionResponse>());
@@ -206,7 +216,7 @@ describe('ExecutionService', () => {
 					/**
 					 * Act
 					 */
-					await executionService.stop(execution.id);
+					await executionService.stop(req, ['123']);
 
 					/**
 					 * Assert
@@ -228,8 +238,10 @@ describe('ExecutionService', () => {
 					 */
 					config.set('executions.mode', 'queue');
 					const execution = mock<IExecutionResponse>({ id: '123', status: 'running' });
-					executionRepository.findSingleExecution.mockResolvedValue(execution);
+					executionRepository.findWithUnflattenedData.mockResolvedValue(execution);
 					waitTracker.has.mockReturnValue(false);
+
+					const req = mock<ExecutionRequest.Stop>();
 					const job = mock<Job>({ data: { executionId: '123' } });
 					scalingService.findJobsByStatus.mockResolvedValue([job]);
 					executionRepository.stopDuringRun.mockResolvedValue(mock<IExecutionResponse>());
@@ -237,7 +249,7 @@ describe('ExecutionService', () => {
 					/**
 					 * Act
 					 */
-					await executionService.stop(execution.id);
+					await executionService.stop(req, ['123']);
 
 					/**
 					 * Assert
@@ -255,8 +267,10 @@ describe('ExecutionService', () => {
 					 */
 					config.set('executions.mode', 'queue');
 					const execution = mock<IExecutionResponse>({ id: '123', status: 'waiting' });
-					executionRepository.findSingleExecution.mockResolvedValue(execution);
+					executionRepository.findWithUnflattenedData.mockResolvedValue(execution);
 					waitTracker.has.mockReturnValue(true);
+
+					const req = mock<ExecutionRequest.Stop>();
 					const job = mock<Job>({ data: { executionId: '123' } });
 					scalingService.findJobsByStatus.mockResolvedValue([job]);
 					executionRepository.stopDuringRun.mockResolvedValue(mock<IExecutionResponse>());
@@ -264,7 +278,7 @@ describe('ExecutionService', () => {
 					/**
 					 * Act
 					 */
-					await executionService.stop(execution.id);
+					await executionService.stop(req, ['123']);
 
 					/**
 					 * Assert

--- a/packages/cli/src/executions/__tests__/execution.service.test.ts
+++ b/packages/cli/src/executions/__tests__/execution.service.test.ts
@@ -76,7 +76,7 @@ describe('ExecutionService', () => {
 			/**
 			 * Act
 			 */
-			const stop = executionService.stop(req, []);
+			const stop = executionService.stop(req.params.id, []);
 
 			/**
 			 * Assert
@@ -90,12 +90,12 @@ describe('ExecutionService', () => {
 			 */
 			const execution = mock<IExecutionResponse>({ id: '123', status: 'success' });
 			executionRepository.findWithUnflattenedData.mockResolvedValue(execution);
-			const req = mock<ExecutionRequest.Stop>({ params: { id: '123' } });
+			const req = mock<ExecutionRequest.Stop>({ params: { id: execution.id } });
 
 			/**
 			 * Act
 			 */
-			const stop = executionService.stop(req, ['123']);
+			const stop = executionService.stop(req.params.id, [execution.id]);
 
 			/**
 			 * Assert
@@ -115,12 +115,12 @@ describe('ExecutionService', () => {
 				waitTracker.has.mockReturnValue(false);
 				executionRepository.stopDuringRun.mockResolvedValue(mock<IExecutionResponse>());
 
-				const req = mock<ExecutionRequest.Stop>({ params: { id: '123' } });
+				const req = mock<ExecutionRequest.Stop>({ params: { id: execution.id } });
 
 				/**
 				 * Act
 				 */
-				await executionService.stop(req, ['123']);
+				await executionService.stop(req.params.id, [execution.id]);
 
 				/**
 				 * Assert
@@ -142,12 +142,12 @@ describe('ExecutionService', () => {
 				waitTracker.has.mockReturnValue(true);
 				executionRepository.stopDuringRun.mockResolvedValue(mock<IExecutionResponse>());
 
-				const req = mock<ExecutionRequest.Stop>({ params: { id: '123' } });
+				const req = mock<ExecutionRequest.Stop>({ params: { id: execution.id } });
 
 				/**
 				 * Act
 				 */
-				await executionService.stop(req, ['123']);
+				await executionService.stop(req.params.id, [execution.id]);
 
 				/**
 				 * Assert
@@ -169,12 +169,12 @@ describe('ExecutionService', () => {
 				waitTracker.has.mockReturnValue(false);
 				executionRepository.stopBeforeRun.mockResolvedValue(mock<IExecutionResponse>());
 
-				const req = mock<ExecutionRequest.Stop>({ params: { id: '123' } });
+				const req = mock<ExecutionRequest.Stop>({ params: { id: execution.id } });
 
 				/**
 				 * Act
 				 */
-				await executionService.stop(req, ['123']);
+				await executionService.stop(req.params.id, [execution.id]);
 
 				/**
 				 * Assert
@@ -206,8 +206,8 @@ describe('ExecutionService', () => {
 					activeExecutions.has.mockReturnValue(true);
 					waitTracker.has.mockReturnValue(false);
 
-					const req = mock<ExecutionRequest.Stop>({ params: { id: '123' } });
-					const job = mock<Job>({ data: { executionId: '123' } });
+					const req = mock<ExecutionRequest.Stop>({ params: { id: execution.id } });
+					const job = mock<Job>({ data: { executionId: execution.id } });
 					scalingService.findJobsByStatus.mockResolvedValue([job]);
 					executionRepository.stopDuringRun.mockResolvedValue(mock<IExecutionResponse>());
 					// @ts-expect-error Private method
@@ -216,7 +216,7 @@ describe('ExecutionService', () => {
 					/**
 					 * Act
 					 */
-					await executionService.stop(req, ['123']);
+					await executionService.stop(req.params.id, [execution.id]);
 
 					/**
 					 * Assert
@@ -241,15 +241,15 @@ describe('ExecutionService', () => {
 					executionRepository.findWithUnflattenedData.mockResolvedValue(execution);
 					waitTracker.has.mockReturnValue(false);
 
-					const req = mock<ExecutionRequest.Stop>({ params: { id: '123' } });
-					const job = mock<Job>({ data: { executionId: '123' } });
+					const req = mock<ExecutionRequest.Stop>({ params: { id: execution.id } });
+					const job = mock<Job>({ data: { executionId: execution.id } });
 					scalingService.findJobsByStatus.mockResolvedValue([job]);
 					executionRepository.stopDuringRun.mockResolvedValue(mock<IExecutionResponse>());
 
 					/**
 					 * Act
 					 */
-					await executionService.stop(req, ['123']);
+					await executionService.stop(req.params.id, [execution.id]);
 
 					/**
 					 * Assert
@@ -270,15 +270,15 @@ describe('ExecutionService', () => {
 					executionRepository.findWithUnflattenedData.mockResolvedValue(execution);
 					waitTracker.has.mockReturnValue(true);
 
-					const req = mock<ExecutionRequest.Stop>({ params: { id: '123' } });
-					const job = mock<Job>({ data: { executionId: '123' } });
+					const req = mock<ExecutionRequest.Stop>({ params: { id: execution.id } });
+					const job = mock<Job>({ data: { executionId: execution.id } });
 					scalingService.findJobsByStatus.mockResolvedValue([job]);
 					executionRepository.stopDuringRun.mockResolvedValue(mock<IExecutionResponse>());
 
 					/**
 					 * Act
 					 */
-					await executionService.stop(req, ['123']);
+					await executionService.stop(req.params.id, [execution.id]);
 
 					/**
 					 * Assert

--- a/packages/cli/src/executions/__tests__/execution.service.test.ts
+++ b/packages/cli/src/executions/__tests__/execution.service.test.ts
@@ -71,7 +71,7 @@ describe('ExecutionService', () => {
 			 * Arrange
 			 */
 			executionRepository.findWithUnflattenedData.mockResolvedValue(undefined);
-			const req = mock<ExecutionRequest.Stop>();
+			const req = mock<ExecutionRequest.Stop>({ params: { id: '1234' } });
 
 			/**
 			 * Act
@@ -90,7 +90,7 @@ describe('ExecutionService', () => {
 			 */
 			const execution = mock<IExecutionResponse>({ id: '123', status: 'success' });
 			executionRepository.findWithUnflattenedData.mockResolvedValue(execution);
-			const req = mock<ExecutionRequest.Stop>();
+			const req = mock<ExecutionRequest.Stop>({ params: { id: '123' } });
 
 			/**
 			 * Act
@@ -115,7 +115,7 @@ describe('ExecutionService', () => {
 				waitTracker.has.mockReturnValue(false);
 				executionRepository.stopDuringRun.mockResolvedValue(mock<IExecutionResponse>());
 
-				const req = mock<ExecutionRequest.Stop>();
+				const req = mock<ExecutionRequest.Stop>({ params: { id: '123' } });
 
 				/**
 				 * Act
@@ -142,7 +142,7 @@ describe('ExecutionService', () => {
 				waitTracker.has.mockReturnValue(true);
 				executionRepository.stopDuringRun.mockResolvedValue(mock<IExecutionResponse>());
 
-				const req = mock<ExecutionRequest.Stop>();
+				const req = mock<ExecutionRequest.Stop>({ params: { id: '123' } });
 
 				/**
 				 * Act
@@ -169,7 +169,7 @@ describe('ExecutionService', () => {
 				waitTracker.has.mockReturnValue(false);
 				executionRepository.stopBeforeRun.mockResolvedValue(mock<IExecutionResponse>());
 
-				const req = mock<ExecutionRequest.Stop>();
+				const req = mock<ExecutionRequest.Stop>({ params: { id: '123' } });
 
 				/**
 				 * Act
@@ -206,7 +206,7 @@ describe('ExecutionService', () => {
 					activeExecutions.has.mockReturnValue(true);
 					waitTracker.has.mockReturnValue(false);
 
-					const req = mock<ExecutionRequest.Stop>();
+					const req = mock<ExecutionRequest.Stop>({ params: { id: '123' } });
 					const job = mock<Job>({ data: { executionId: '123' } });
 					scalingService.findJobsByStatus.mockResolvedValue([job]);
 					executionRepository.stopDuringRun.mockResolvedValue(mock<IExecutionResponse>());
@@ -241,7 +241,7 @@ describe('ExecutionService', () => {
 					executionRepository.findWithUnflattenedData.mockResolvedValue(execution);
 					waitTracker.has.mockReturnValue(false);
 
-					const req = mock<ExecutionRequest.Stop>();
+					const req = mock<ExecutionRequest.Stop>({ params: { id: '123' } });
 					const job = mock<Job>({ data: { executionId: '123' } });
 					scalingService.findJobsByStatus.mockResolvedValue([job]);
 					executionRepository.stopDuringRun.mockResolvedValue(mock<IExecutionResponse>());
@@ -270,7 +270,7 @@ describe('ExecutionService', () => {
 					executionRepository.findWithUnflattenedData.mockResolvedValue(execution);
 					waitTracker.has.mockReturnValue(true);
 
-					const req = mock<ExecutionRequest.Stop>();
+					const req = mock<ExecutionRequest.Stop>({ params: { id: '123' } });
 					const job = mock<Job>({ data: { executionId: '123' } });
 					scalingService.findJobsByStatus.mockResolvedValue([job]);
 					executionRepository.stopDuringRun.mockResolvedValue(mock<IExecutionResponse>());

--- a/packages/cli/src/executions/__tests__/executions.controller.test.ts
+++ b/packages/cli/src/executions/__tests__/executions.controller.test.ts
@@ -148,11 +148,11 @@ describe('ExecutionsController', () => {
 		});
 
 		it('should call execution service with expected data when user has accessible workflows', async () => {
-			const mockAccessibleWorkflowIds = ['1234', '5678'];
+			const mockAccessibleWorkflowIds = ['1234', '999'];
 			workflowSharingService.getSharedWorkflowIds.mockResolvedValue(mockAccessibleWorkflowIds);
 
 			await executionsController.stop(req);
-			expect(executionService.stop).toHaveBeenCalledWith(req, mockAccessibleWorkflowIds);
+			expect(executionService.stop).toHaveBeenCalledWith(req.params.id, mockAccessibleWorkflowIds);
 		});
 	});
 });

--- a/packages/cli/src/executions/__tests__/executions.controller.test.ts
+++ b/packages/cli/src/executions/__tests__/executions.controller.test.ts
@@ -138,16 +138,16 @@ describe('ExecutionsController', () => {
 		const executionId = '999';
 		const req = mock<ExecutionRequest.Stop>({ params: { id: executionId } });
 
-		it('should 404 when all workflows are inaccessible for user', async () => {
+		it('should throw expected NotFoundError when all workflows are inaccessible for user', async () => {
 			workflowSharingService.getSharedWorkflowIds.mockResolvedValue([]);
 
 			const promise = executionsController.stop(req);
 
-			await expect(promise).rejects.toThrow('Execution not found');
+			await expect(promise).rejects.toThrow(new NotFoundError('Execution not found'));
 			expect(executionService.stop).not.toHaveBeenCalled();
 		});
 
-		it('should attempt to stop execution when user has accessible workflows but passed workflow ID is not accessible by user', async () => {
+		it('should call execution service with expected data when user has accessible workflows', async () => {
 			const mockAccessibleWorkflowIds = ['1234', '5678'];
 			workflowSharingService.getSharedWorkflowIds.mockResolvedValue(mockAccessibleWorkflowIds);
 

--- a/packages/cli/src/executions/__tests__/executions.controller.test.ts
+++ b/packages/cli/src/executions/__tests__/executions.controller.test.ts
@@ -143,7 +143,7 @@ describe('ExecutionsController', () => {
 
 			const promise = executionsController.stop(req);
 
-			await expect(promise).rejects.toThrow(new NotFoundError('Execution not found'));
+			await expect(promise).rejects.toThrow(NotFoundError);
 			expect(executionService.stop).not.toHaveBeenCalled();
 		});
 

--- a/packages/cli/src/executions/__tests__/executions.controller.test.ts
+++ b/packages/cli/src/executions/__tests__/executions.controller.test.ts
@@ -138,21 +138,21 @@ describe('ExecutionsController', () => {
 		const executionId = '999';
 		const req = mock<ExecutionRequest.Stop>({ params: { id: executionId } });
 
-		it('should 404 when execution is inaccessible for user', async () => {
+		it('should 404 when all workflows are inaccessible for user', async () => {
 			workflowSharingService.getSharedWorkflowIds.mockResolvedValue([]);
 
 			const promise = executionsController.stop(req);
 
-			await expect(promise).rejects.toThrow(NotFoundError);
+			await expect(promise).rejects.toThrow('Execution not found');
 			expect(executionService.stop).not.toHaveBeenCalled();
 		});
 
-		it('should call ask for an execution to be stopped', async () => {
-			workflowSharingService.getSharedWorkflowIds.mockResolvedValue(['123']);
+		it('should attempt to stop execution when user has accessible workflows but passed workflow ID is not accessible by user', async () => {
+			const mockAccessibleWorkflowIds = ['1234', '5678'];
+			workflowSharingService.getSharedWorkflowIds.mockResolvedValue(mockAccessibleWorkflowIds);
 
 			await executionsController.stop(req);
-
-			expect(executionService.stop).toHaveBeenCalledWith(executionId);
+			expect(executionService.stop).toHaveBeenCalledWith(req, mockAccessibleWorkflowIds);
 		});
 	});
 });

--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -422,6 +422,7 @@ export class ExecutionService {
 
 	async stop(req: ExecutionRequest.Stop, sharedWorkflowIds: string[]): Promise<StopResult> {
 		const { id: executionId } = req.params;
+
 		const execution = await this.executionRepository.findWithUnflattenedData(
 			executionId,
 			sharedWorkflowIds,
@@ -433,7 +434,6 @@ export class ExecutionService {
 				executionId,
 			});
 
-			// TODO: Should this be a NotFoundError to match the behavior of other methods?
 			throw new MissingExecutionStopError(executionId);
 		}
 

--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -420,17 +420,14 @@ export class ExecutionService {
 		);
 	}
 
-	async stop(req: ExecutionRequest.Stop, sharedWorkflowIds: string[]): Promise<StopResult> {
-		const { id: executionId } = req.params;
-
+	async stop(executionId: string, sharedWorkflowIds: string[]): Promise<StopResult> {
 		const execution = await this.executionRepository.findWithUnflattenedData(
 			executionId,
 			sharedWorkflowIds,
 		);
 
 		if (!execution) {
-			this.logger.info('Attempt to stop an execution was blocked due to insufficient permissions', {
-				userId: req.user.id,
+			this.logger.info(`Unable to stop execution "${executionId}" as it was not found`, {
 				executionId,
 			});
 

--- a/packages/cli/src/executions/executions.controller.ts
+++ b/packages/cli/src/executions/executions.controller.ts
@@ -96,7 +96,7 @@ export class ExecutionsController {
 
 		if (workflowIds.length === 0) throw new NotFoundError('Execution not found');
 
-		return await this.executionService.stop(req.params.id);
+		return await this.executionService.stop(req, workflowIds);
 	}
 
 	@Post('/:id/retry')

--- a/packages/cli/src/executions/executions.controller.ts
+++ b/packages/cli/src/executions/executions.controller.ts
@@ -96,7 +96,9 @@ export class ExecutionsController {
 
 		if (workflowIds.length === 0) throw new NotFoundError('Execution not found');
 
-		return await this.executionService.stop(req, workflowIds);
+		const executionId = req.params.id;
+
+		return await this.executionService.stop(executionId, workflowIds);
 	}
 
 	@Post('/:id/retry')

--- a/packages/cli/test/integration/executions.controller.test.ts
+++ b/packages/cli/test/integration/executions.controller.test.ts
@@ -130,7 +130,7 @@ describe('POST /executions/delete', () => {
 describe('POST /executions/stop', () => {
 	test('should not stop an execution we do not have access to', async () => {
 		await saveExecution({ belongingTo: owner });
-		const incorrectExecutionId = 'fakeExecutionsId';
+		const incorrectExecutionId = '1234';
 
 		await testServer
 			.authAgentFor(owner)

--- a/packages/cli/test/integration/executions.controller.test.ts
+++ b/packages/cli/test/integration/executions.controller.test.ts
@@ -3,7 +3,11 @@ import type { User } from '@n8n/db';
 import { ConcurrencyControlService } from '@/concurrency/concurrency-control.service';
 import { WaitTracker } from '@/wait-tracker';
 
-import { createSuccessfulExecution, getAllExecutions } from './shared/db/executions';
+import {
+	createSuccessfulExecution,
+	createWaitingExecution,
+	getAllExecutions,
+} from './shared/db/executions';
 import { createTeamProject, linkUserToProject } from './shared/db/projects';
 import { createMember, createOwner } from './shared/db/users';
 import { createWorkflow, shareWorkflowWithUsers } from './shared/db/workflows';
@@ -25,6 +29,11 @@ let member: User;
 const saveExecution = async ({ belongingTo }: { belongingTo: User }) => {
 	const workflow = await createWorkflow({}, belongingTo);
 	return await createSuccessfulExecution(workflow);
+};
+
+const saveWaitingExecution = async ({ belongingTo }: { belongingTo: User }) => {
+	const workflow = await createWorkflow({}, belongingTo);
+	return await createWaitingExecution(workflow);
 };
 
 beforeEach(async () => {
@@ -115,5 +124,23 @@ describe('POST /executions/delete', () => {
 		const executions = await getAllExecutions();
 
 		expect(executions).toHaveLength(0);
+	});
+});
+
+describe('POST /executions/stop', () => {
+	test('should not stop an execution we do not have access to', async () => {
+		await saveExecution({ belongingTo: owner });
+		const incorrectExecutionId = 'fakeExecutionsId';
+
+		await testServer
+			.authAgentFor(owner)
+			.post(`/executions/${incorrectExecutionId}/stop`)
+			.expect(500);
+	});
+
+	test('should stop an execution we have access to', async () => {
+		const execution = await saveWaitingExecution({ belongingTo: owner });
+
+		await testServer.authAgentFor(owner).post(`/executions/${execution.id}/stop`).expect(200);
 	});
 });


### PR DESCRIPTION
## Summary

This PR addresses a security vulnerability that allowed authenticated users to terminate any workflow execution, regardless of ownership. Previously, the 'stop workflow' endpoint improperly used a direct parameter reference, bypassing user-scoped authorisation. This fix ensures that only the workflow owner can stop an execution.

## Related Linear tickets, Github issues, and Community forum posts

Fixes: PAY-2960

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- ~[ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
