### PR TITLE
feat: add HTTP streamable option to MCP client

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
@@ -11,7 +11,7 @@ import { logWrapper } from '@utils/logWrapper';
 import { getConnectionHintNoticeField } from '@utils/sharedFields';
 
 import { getTools } from './loadOptions';
-import type { McpAuthenticationOption, McpToolIncludeMode } from './types';
+import type { McpServerTransport, McpAuthenticationOption, McpToolIncludeMode } from './types';
 import {
 	connectMcpClient,
 	createCallTool,
@@ -76,13 +76,30 @@ export class McpClientTool implements INodeType {
 		properties: [
 			getConnectionHintNoticeField([NodeConnectionTypes.AiAgent]),
 			{
-				displayName: 'SSE Endpoint',
-				name: 'sseEndpoint',
+				displayName: 'Endpoint',
+				name: 'endpointUrl',
 				type: 'string',
-				description: 'SSE Endpoint of your MCP server',
-				placeholder: 'e.g. https://my-mcp-server.ai/sse',
+				description: 'Endpoint of your MCP server',
+				placeholder: 'e.g. https://my-mcp-server.ai/mcp',
 				default: '',
 				required: true,
+			},
+			{
+				displayName: 'Server Transport',
+				name: 'serverTransport',
+				type: 'options',
+				options: [
+					{
+						name: 'Server Sent Events (Deprecated)',
+						value: 'sse',
+					},
+					{
+						name: 'Streamable HTTP',
+						value: 'streamableHTTP',
+					},
+				],
+				default: 'sse',
+				description: 'The transport required by your server',
 			},
 			{
 				displayName: 'Authentication',
@@ -103,7 +120,7 @@ export class McpClientTool implements INodeType {
 					},
 				],
 				default: 'none',
-				description: 'The way to authenticate with your SSE endpoint',
+				description: 'The way to authenticate with your endpoint',
 			},
 			{
 				displayName: 'Credentials',
@@ -187,11 +204,16 @@ export class McpClientTool implements INodeType {
 			'authentication',
 			itemIndex,
 		) as McpAuthenticationOption;
-		const sseEndpoint = this.getNodeParameter('sseEndpoint', itemIndex) as string;
+		const serverTransport = this.getNodeParameter(
+			'serverTransport',
+			itemIndex,
+		) as McpServerTransport;
+		const endpointUrl = this.getNodeParameter('endpointUrl', itemIndex) as string;
 		const node = this.getNode();
 		const { headers } = await getAuthHeaders(this, authentication);
 		const client = await connectMcpClient({
-			sseEndpoint,
+			serverTransport,
+			endpointUrl,
 			headers,
 			name: node.type,
 			version: node.typeVersion,

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/loadOptions.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/loadOptions.ts
@@ -9,11 +9,13 @@ import { connectMcpClient, getAllTools, getAuthHeaders } from './utils';
 
 export async function getTools(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 	const authentication = this.getNodeParameter('authentication') as McpAuthenticationOption;
-	const sseEndpoint = this.getNodeParameter('sseEndpoint') as string;
+	const sseEndpoint = this.getNodeParameter('endpointUrl') as string;
+
 	const node = this.getNode();
 	const { headers } = await getAuthHeaders(this, authentication);
 	const client = await connectMcpClient({
-		sseEndpoint,
+		serverTransport: 'streamableHTTP',
+		endpointUrl: sseEndpoint,
 		headers,
 		name: node.type,
 		version: node.typeVersion,

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/types.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/types.ts
@@ -2,6 +2,8 @@ import type { JSONSchema7 } from 'json-schema';
 
 export type McpTool = { name: string; description?: string; inputSchema: JSONSchema7 };
 
+export type McpServerTransport = 'sse' | 'streamableHTTP';
+
 export type McpToolIncludeMode = 'all' | 'selected' | 'except';
 
 export type McpAuthenticationOption = 'none' | 'headerAuth' | 'bearerAuth';

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/utils.ts
@@ -1,8 +1,9 @@
-import { DynamicStructuredTool, type DynamicStructuredToolInput } from '@langchain/core/tools';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { CompatibilityCallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
 import { Toolkit } from 'langchain/agents';
+import { DynamicStructuredTool, type DynamicStructuredToolInput } from 'langchain/tools';
 import {
 	createResultError,
 	createResultOk,
@@ -10,11 +11,16 @@ import {
 	type IExecuteFunctions,
 	type Result,
 } from 'n8n-workflow';
-import { z } from 'zod';
+import { type ZodTypeAny } from 'zod';
 
 import { convertJsonSchemaToZod } from '@utils/schemaParsing';
 
-import type { McpAuthenticationOption, McpTool, McpToolIncludeMode } from './types';
+import type {
+	McpAuthenticationOption,
+	McpTool,
+	McpServerTransport,
+	McpToolIncludeMode,
+} from './types';
 
 export async function getAllTools(client: Client, cursor?: string): Promise<McpTool[]> {
 	const { tools, nextCursor } = await client.listTools({ cursor });
@@ -99,24 +105,18 @@ export const createCallTool =
 export function mcpToolToDynamicTool(
 	tool: McpTool,
 	onCallTool: DynamicStructuredToolInput['func'],
-): DynamicStructuredTool<z.ZodObject<any, any, any, any>> {
-	const rawSchema = convertJsonSchemaToZod(tool.inputSchema);
-
-	// Ensure we always have an object schema for structured tools
-	const objectSchema =
-		rawSchema instanceof z.ZodObject ? rawSchema : z.object({ value: rawSchema });
-
+) {
 	return new DynamicStructuredTool({
 		name: tool.name,
 		description: tool.description ?? '',
-		schema: objectSchema,
+		schema: convertJsonSchemaToZod(tool.inputSchema),
 		func: onCallTool,
 		metadata: { isFromToolkit: true },
 	});
 }
 
 export class McpToolkit extends Toolkit {
-	constructor(public tools: Array<DynamicStructuredTool<z.ZodObject<any, any, any, any>>>) {
+	constructor(public tools: Array<DynamicStructuredTool<ZodTypeAny>>) {
 		super();
 	}
 }
@@ -145,23 +145,46 @@ type ConnectMcpClientError =
 	| { type: 'connection'; error: Error };
 export async function connectMcpClient({
 	headers,
-	sseEndpoint,
+	serverTransport,
+	endpointUrl,
 	name,
 	version,
 }: {
-	sseEndpoint: string;
+	serverTransport: McpServerTransport;
+	endpointUrl: string;
 	headers?: Record<string, string>;
 	name: string;
 	version: number;
 }): Promise<Result<Client, ConnectMcpClientError>> {
-	try {
-		const endpoint = normalizeAndValidateUrl(sseEndpoint);
+	const endpoint = normalizeAndValidateUrl(endpointUrl);
 
-		if (!endpoint.ok) {
-			return createResultError({ type: 'invalid_url', error: endpoint.error });
+	if (!endpoint.ok) {
+		return createResultError({ type: 'invalid_url', error: endpoint.error });
+	}
+
+	const client = new Client({ name, version: version.toString() }, { capabilities: { tools: {} } });
+
+	if (serverTransport === 'streamableHTTP') {
+		try {
+			// eslint-disable-next-line @typescript-eslint/no-shadow
+			let client: Client | undefined = undefined;
+			client = new Client({
+				name: 'streamable-http-client',
+				version: '1.0.0',
+			});
+			const transport = new StreamableHTTPClientTransport(new URL(endpointUrl), {
+				requestInit: { headers },
+			});
+			await client.connect(transport);
+
+			return createResultOk(client);
+		} catch (error) {
+			return createResultError({ type: 'connection', error });
 		}
+	}
 
-		const transport = new SSEClientTransport(endpoint.result, {
+	try {
+		const sseTransport = new SSEClientTransport(endpoint.result, {
 			eventSourceInit: {
 				fetch: async (url, init) =>
 					await fetch(url, {
@@ -174,13 +197,7 @@ export async function connectMcpClient({
 			},
 			requestInit: { headers },
 		});
-
-		const client = new Client(
-			{ name, version: version.toString() },
-			{ capabilities: { tools: {} } },
-		);
-
-		await client.connect(transport);
+		await client.connect(sseTransport);
 		return createResultOk(client);
 	} catch (error) {
 		return createResultError({ type: 'connection', error });


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR introduces support for HTTP streamable responses when using the MCP client in the HTTP Request node.
This enables scenarios where the response body is large or long-lived (e.g., streamed AI completions).

### How to test:

Added a new mcp client connector, added one http streamable source, like this image
![image](https://github.com/user-attachments/assets/00bfb513-4cf7-4301-8ac2-782a9d7ad287)

Example workflow to test
![image](https://github.com/user-attachments/assets/a46bed52-900d-4d67-8398-bc4726202dc1)

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->

<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

No related tickets or issues at the moment.
Feature added proactively for advanced use cases with large or streamed data.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
