### PR TITLE
fix(AWS DynamoDB Node): Incorrect parameter names

### DIFF
--- a/packages/nodes-base/nodes/Aws/DynamoDB/AwsDynamoDB.node.ts
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/AwsDynamoDB.node.ts
@@ -180,7 +180,7 @@ export class AwsDynamoDB implements INodeType {
 						};
 
 						const eavUi = this.getNodeParameter(
-							'additionalFields.eavUi.eavValues',
+							'additionalFields.expressionAttributeUi.expressionAttributeValues',
 							i,
 							[],
 						) as IAttributeValueUi[];

--- a/packages/nodes-base/nodes/Aws/DynamoDB/AwsDynamoDB.node.ts
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/AwsDynamoDB.node.ts
@@ -130,7 +130,7 @@ export class AwsDynamoDB implements INodeType {
 						const expressionAttributeName = adjustExpressionAttributeName(eanUi);
 
 						if (Object.keys(expressionAttributeName).length) {
-							body.expressionAttributeNames = expressionAttributeName;
+							body.ExpressionAttributeNames = expressionAttributeName;
 						}
 
 						if (conditionExpession) {
@@ -213,7 +213,7 @@ export class AwsDynamoDB implements INodeType {
 						const expressionAttributeName = adjustExpressionAttributeName(eanUi);
 
 						if (Object.keys(expressionAttributeName).length) {
-							body.expressionAttributeNames = expressionAttributeName;
+							body.ExpressionAttributeNames = expressionAttributeName;
 						}
 
 						const headers = {
@@ -260,7 +260,7 @@ export class AwsDynamoDB implements INodeType {
 						const expressionAttributeName = adjustExpressionAttributeName(eanUi);
 
 						if (Object.keys(expressionAttributeName).length) {
-							body.expressionAttributeNames = expressionAttributeName;
+							body.ExpressionAttributeNames = expressionAttributeName;
 						}
 
 						if (additionalFields.readType) {

--- a/packages/nodes-base/nodes/Aws/DynamoDB/AwsDynamoDB.node.ts
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/AwsDynamoDB.node.ts
@@ -107,7 +107,7 @@ export class AwsDynamoDB implements INodeType {
 							[],
 						) as IAttributeValueUi[];
 						const conditionExpession = this.getNodeParameter(
-							'conditionExpression',
+							'additionalFields.conditionExpression',
 							i,
 							'',
 						) as string;

--- a/packages/nodes-base/nodes/Aws/DynamoDB/ItemDescription.ts
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/ItemDescription.ts
@@ -404,7 +404,7 @@ export const itemFields: INodeProperties[] = [
 			},
 			{
 				displayName: 'Expression Attribute Values',
-				name: 'expressionAttributeUi',
+				name: 'eavUi',
 				description:
 					'Substitution tokens for attribute names in an expression. Only needed when the parameter "condition expression" is set.',
 				placeholder: 'Add Attribute Value',
@@ -417,8 +417,8 @@ export const itemFields: INodeProperties[] = [
 				},
 				options: [
 					{
-						name: 'expressionAttributeValues',
-						displayName: 'Expression Attribute Vaue',
+						name: 'eavValues',
+						displayName: 'Expression Attribute Value',
 						values: [
 							{
 								displayName: 'Attribute',

--- a/packages/nodes-base/nodes/Aws/DynamoDB/ItemDescription.ts
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/ItemDescription.ts
@@ -404,7 +404,7 @@ export const itemFields: INodeProperties[] = [
 			},
 			{
 				displayName: 'Expression Attribute Values',
-				name: 'eavUi',
+				name: 'expressionAttributeUi',
 				description:
 					'Substitution tokens for attribute names in an expression. Only needed when the parameter "condition expression" is set.',
 				placeholder: 'Add Attribute Value',
@@ -417,7 +417,7 @@ export const itemFields: INodeProperties[] = [
 				},
 				options: [
 					{
-						name: 'eavValues',
+						name: 'expressionAttributeValues',
 						displayName: 'Expression Attribute Value',
 						values: [
 							{

--- a/packages/nodes-base/nodes/Aws/DynamoDB/__test__/node/AwsDynamoDB.node.test.ts
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/__test__/node/AwsDynamoDB.node.test.ts
@@ -1,0 +1,82 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+import { credentials } from '../../../__tests__/credentials';
+
+describe('AWS DynamoDB Node', () => {
+	const dynamoDbNock = nock('https://dynamodb.eu-central-1.amazonaws.com');
+
+	beforeAll(() => {
+		dynamoDbNock
+			.post('/', {
+				TableName: 'n8n-testing',
+				KeyConditionExpression: 'id = :idVal',
+				ExpressionAttributeValues: {
+					':idVal': { S: 'foo' },
+				},
+				ProjectionExpression: '#time',
+				ExpressionAttributeNames: {
+					'#time': 'timestamp',
+				},
+				Limit: 50,
+				Select: 'SPECIFIC_ATTRIBUTES',
+			})
+			.reply(200, {
+				Items: [
+					{
+						timestamp: { S: '2025-01-01' },
+					},
+				],
+			});
+
+		dynamoDbNock
+			.post(
+				'/',
+				(body) =>
+					body?.TableName === 'n8n-testing' &&
+					body?.Key?.id?.S === 'foo' &&
+					body?.Key?.timestamp?.S === '2025-01-01' &&
+					body?.ExpressionAttributeNames?.['#time'] === 'timestamp' &&
+					body?.ProjectionExpression === '#time',
+			)
+			.reply(200, {
+				Item: {
+					timestamp: { S: '2025-01-01' },
+				},
+			});
+
+		dynamoDbNock
+			.post(
+				'/',
+				(body) =>
+					body?.TableName === 'n8n-testing' &&
+					body?.Item?.id?.S === 'foo' &&
+					body?.Item?.timestamp?.S === '2025-01-01' &&
+					body?.Item?.data?.S === 'payload' &&
+					body?.ConditionExpression === '#d = :v' &&
+					body?.ExpressionAttributeNames?.['#d'] === 'data' &&
+					body?.ExpressionAttributeValues?.[':v']?.S === 'lorem ipsum',
+			)
+			.reply(200, {});
+
+		dynamoDbNock
+			.post(
+				'/',
+				(body) =>
+					body?.TableName === 'n8n-testing' &&
+					body?.Key?.id?.S === 'foo' &&
+					body?.Key?.timestamp?.S === '2025-01-01' &&
+					body?.ConditionExpression === '#d = :v' &&
+					body?.ExpressionAttributeNames?.['#d'] === 'data' &&
+					body?.ExpressionAttributeValues?.[':v']?.S === 'payload',
+			)
+			.reply(200, {});
+	});
+
+	afterAll(() => dynamoDbNock.done());
+
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Aws/DynamoDB/__test__/node/workflow.json
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/__test__/node/workflow.json
@@ -1,0 +1,261 @@
+{
+	"name": "AWS DynamoDB",
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, -40],
+			"id": "efd3f04e-8695-4f2c-8f8d-0b0166390d3f",
+			"name": "When clicking ‘Execute workflow’"
+		},
+		{
+			"parameters": {
+				"operation": "getAll",
+				"tableName": "n8n-testing",
+				"keyConditionExpression": "id = :idVal",
+				"eavUi": {
+					"eavValues": [
+						{
+							"attribute": ":idVal",
+							"value": "foo"
+						}
+					]
+				},
+				"select": "SPECIFIC_ATTRIBUTES",
+				"options": {
+					"projectionExpression": "#time",
+					"eanUi": {
+						"eanValues": [
+							{
+								"key": "#time",
+								"value": "timestamp"
+							}
+						]
+					}
+				}
+			},
+			"type": "n8n-nodes-base.awsDynamoDb",
+			"typeVersion": 1,
+			"position": [220, -340],
+			"id": "fe8a7fbf-83af-45bb-ae58-77f143ce2f30",
+			"name": "Get many items",
+			"credentials": {
+				"aws": {
+					"id": "UamouRLgIHQY0AXg",
+					"name": "AWS account"
+				}
+			}
+		},
+		{
+			"parameters": {
+				"operation": "get",
+				"tableName": "n8n-testing",
+				"keysUi": {
+					"keyValues": [
+						{
+							"key": "id",
+							"value": "foo"
+						},
+						{
+							"key": "timestamp",
+							"value": "2025-01-01"
+						}
+					]
+				},
+				"additionalFields": {
+					"projectionExpression": "#time",
+					"eanUi": {
+						"eanValues": [
+							{
+								"key": "#time",
+								"value": "timestamp"
+							}
+						]
+					}
+				}
+			},
+			"type": "n8n-nodes-base.awsDynamoDb",
+			"typeVersion": 1,
+			"position": [220, -140],
+			"id": "4cbddd91-c851-4ef6-b76a-d84d84f1d598",
+			"name": "Get an item",
+			"credentials": {
+				"aws": {
+					"id": "UamouRLgIHQY0AXg",
+					"name": "AWS account"
+				}
+			}
+		},
+		{
+			"parameters": {
+				"tableName": "n8n-testing",
+				"fieldsUi": {
+					"fieldValues": [
+						{
+							"fieldId": "id",
+							"fieldValue": "foo"
+						},
+						{
+							"fieldId": "timestamp",
+							"fieldValue": "2025-01-01"
+						},
+						{
+							"fieldId": "data",
+							"fieldValue": "payload"
+						}
+					]
+				},
+				"additionalFields": {
+					"eavUi": {
+						"eavValues": [
+							{
+								"attribute": ":v",
+								"value": "lorem ipsum"
+							}
+						]
+					},
+					"conditionExpression": "#d = :v",
+					"eanUi": {
+						"eanValues": [
+							{
+								"key": "#d",
+								"value": "data"
+							}
+						]
+					}
+				}
+			},
+			"type": "n8n-nodes-base.awsDynamoDb",
+			"typeVersion": 1,
+			"position": [220, 60],
+			"id": "17eee2d1-6547-4d99-b168-74d407cc252c",
+			"name": "Create or update an item",
+			"credentials": {
+				"aws": {
+					"id": "UamouRLgIHQY0AXg",
+					"name": "AWS account"
+				}
+			}
+		},
+		{
+			"parameters": {
+				"operation": "delete",
+				"tableName": "n8n-testing",
+				"keysUi": {
+					"keyValues": [
+						{
+							"key": "id",
+							"value": "foo"
+						},
+						{
+							"key": "timestamp",
+							"value": "2025-01-01"
+						}
+					]
+				},
+				"additionalFields": {
+					"conditionExpression": "#d = :v",
+					"eanUi": {
+						"eanValues": [
+							{
+								"key": "#d",
+								"value": "data"
+							}
+						]
+					},
+					"eavUi": {
+						"eavValues": [
+							{
+								"attribute": ":v",
+								"value": "payload"
+							}
+						]
+					}
+				}
+			},
+			"type": "n8n-nodes-base.awsDynamoDb",
+			"typeVersion": 1,
+			"position": [220, 260],
+			"id": "6d266500-16b0-4ee9-a3b2-a4300bc23b1f",
+			"name": "Delete an item",
+			"credentials": {
+				"aws": {
+					"id": "UamouRLgIHQY0AXg",
+					"name": "AWS account"
+				}
+			}
+		}
+	],
+	"pinData": {
+		"Get many items": [
+			{
+				"json": {
+					"timestamp": "2025-01-01"
+				}
+			}
+		],
+		"Get an item": [
+			{
+				"json": {
+					"timestamp": "2025-01-01"
+				}
+			}
+		],
+		"Create or update an item": [
+			{
+				"json": {
+					"id": "foo",
+					"timestamp": "2025-01-01",
+					"data": "payload"
+				}
+			}
+		],
+		"Delete an item": [
+			{
+				"json": {
+					"success": true
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking ‘Execute workflow’": {
+			"main": [
+				[
+					{
+						"node": "Get many items",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "Get an item",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "Create or update an item",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "Delete an item",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "ada45c19-f09e-43e5-8e5c-d66f54f78d4f",
+	"meta": {
+		"templateCredsSetupCompleted": true,
+		"instanceId": "e115be144a6a5547dbfca93e774dfffa178aa94a181854c13e2ce5e14d195b2e"
+	},
+	"id": "Ffm7CA1AIhKGiOlK",
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Aws/DynamoDB/__test__/node/workflow.json
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/__test__/node/workflow.json
@@ -164,8 +164,8 @@
 							}
 						]
 					},
-					"eavUi": {
-						"eavValues": [
+					"expressionAttributeUi": {
+						"expressionAttributeValues": [
 							{
 								"attribute": ":v",
 								"value": "payload"


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Update the AWS DynamoDB Node to use the proper parameter names (`ExpressionAttributeNames` instead of `expressionAttributeNames`). Fix the reference to `additionalFields.conditionExpression` and the names of "Expression Attribute Values" fields

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-3105/community-issue-aws-dynamodb-node-incorrect-parameter-case
Closes #14625

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
