### PR TITLE
fix(Execute Sub-workflow Node): Don't expose the file contens when reading the workflow from a file and it's not valid JSON

### DIFF
--- a/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow/GenericFunctions.test.ts
@@ -1,0 +1,30 @@
+import { mockDeep, type DeepMockProxy } from 'jest-mock-extended';
+import type { IExecuteFunctions, ILoadOptionsFunctions, INode } from 'n8n-workflow';
+
+import { getWorkflowInfo } from './GenericFunctions';
+
+jest.mock('fs/promises', () => ({
+	readFile: jest.fn().mockResolvedValue('sensitive data'),
+}));
+
+describe('ExecuteWorkflow node - GenericFunctions', () => {
+	let executeFunctionsMock: DeepMockProxy<ILoadOptionsFunctions | IExecuteFunctions>;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		executeFunctionsMock = mockDeep<ILoadOptionsFunctions | IExecuteFunctions>();
+	});
+
+	describe('getWorkflowInfo', () => {
+		it('should throw an error without the file content when source is localFile and the file is not json', async () => {
+			executeFunctionsMock.getNode.mockReturnValue({
+				typeVersion: 1,
+			} as INode);
+			executeFunctionsMock.getNodeParameter.mockReturnValue('path/to/file');
+
+			await expect(getWorkflowInfo.call(executeFunctionsMock, 'localFile', 0)).rejects.toThrow(
+				'The file content is not valid JSON',
+			);
+		});
+	});
+});

--- a/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow/GenericFunctions.ts
@@ -45,7 +45,9 @@ export async function getWorkflowInfo(
 			throw error;
 		}
 
-		workflowInfo.code = jsonParse(workflowJson);
+		workflowInfo.code = jsonParse(workflowJson, {
+			errorMessage: 'The file content is not valid JSON', // pass a custom error message to not expose the file contents
+		});
 	} else if (source === 'parameter') {
 		// Read workflow from parameter
 		const workflowJson = this.getNodeParameter('workflowJson', itemIndex) as string;


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Update the error message thrown by the Execute Workflow Node to not include the file contents when it tries to read a workflow from a file that is not actually JSON

Before:
![image](https://github.com/user-attachments/assets/1fcbd752-355c-48be-a675-549adb35d7ef)
After:
![image](https://github.com/user-attachments/assets/d236a1c8-0ebb-4229-8ce9-5b6887b3848f)

_Related to node v1 and v1.1, since the option to read a workflow from a file was removed in v1.2_

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-3007/execute-workflow-node-local-file-read-vulnerability

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
