### PR TITLE
fix(n8n Form Node): Update version in Breaking Changes doc

### DIFF
--- a/packages/cli/BREAKING-CHANGES.md
+++ b/packages/cli/BREAKING-CHANGES.md
@@ -2,17 +2,6 @@
 
 This list shows all the versions which include breaking changes and how to upgrade.
 
-## 1.99.1
-
-### What changed?
-
-Stricter parameters for `iframe`, `video`, and `source` tags when using the Form node.
-
-### When is action necessary?
-
-If you are using `iframe`, `video`, or `source` tags with attributes beyond those listed [here](https://github.com/n8n-io/n8n/blob/master/packages/nodes-base/nodes/Form/utils/utils.ts#L61-L71) or are using schemes which are neither `http` or `https`, you will need to update your node or workflow.
-
-
 ## 1.98.0
 
 ### What changed?
@@ -21,11 +10,15 @@ The `last_activity` metric included as a part of route metrics has been changed 
 the previous timestamp label approach. The labeling approach could result in high cardinality within Prometheus and
 thus result in poorer performance.
 
+Stricter parameters for `iframe`, `video`, and `source` tags when using the Form node.
+
 ### When is action necessary?
 
 If you've been ingesting route metrics from your n8n instance (version 1.81.0 and newer), you should analyze
 how the `last_activity` metric has affected your Prometheus instance and potentially clean up the old data. Future
 metrics will also be served in a different format, which needs to be taken into account.
+
+If you are using `iframe`, `video`, or `source` tags with attributes beyond those listed [here](https://github.com/n8n-io/n8n/blob/master/packages/nodes-base/nodes/Form/utils/utils.ts#L61-L71) or are using schemes which are neither `http` or `https`, you will need to update your node or workflow.
 
 ### What changed?
 


### PR DESCRIPTION
## Summary

We are able to backport the vulnerability to `1.98.x` so we should update the breaking changes doc.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3121/xss-in-form-submission

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
