### PR TITLE
refactor(core): Prepare insights for move to standalone module

### DIFF
--- a/packages/@n8n/integration-test-utils/package.json
+++ b/packages/@n8n/integration-test-utils/package.json
@@ -21,6 +21,8 @@
     "dist/**/*"
   ],
   "dependencies": {
+    "@n8n/backend-common": "workspace:^",
+    "jest-mock-extended": "^3.0.4",
     "reflect-metadata": "catalog:"
   },
   "devDependencies": {

--- a/packages/@n8n/integration-test-utils/src/index.ts
+++ b/packages/@n8n/integration-test-utils/src/index.ts
@@ -1,1 +1,5 @@
-export {};
+import type { Logger } from '@n8n/backend-common';
+import { mock } from 'jest-mock-extended';
+
+export const mockLogger = (): Logger =>
+	mock<Logger>({ scoped: jest.fn().mockReturnValue(mock<Logger>()) });

--- a/packages/cli/src/__tests__/active-workflow-manager.test.ts
+++ b/packages/cli/src/__tests__/active-workflow-manager.test.ts
@@ -1,5 +1,6 @@
 import type { WorkflowEntity } from '@n8n/db';
 import type { WorkflowRepository } from '@n8n/db';
+import { mockLogger } from '@n8n/integration-test-utils';
 import { mock } from 'jest-mock-extended';
 import type { InstanceSettings } from 'n8n-core';
 import type {
@@ -13,7 +14,6 @@ import { Workflow } from 'n8n-workflow';
 
 import { ActiveWorkflowManager } from '@/active-workflow-manager';
 import type { NodeTypes } from '@/node-types';
-import { mockLogger } from '@test/mocking';
 
 describe('ActiveWorkflowManager', () => {
 	let activeWorkflowManager: ActiveWorkflowManager;

--- a/packages/cli/src/__tests__/license.test.ts
+++ b/packages/cli/src/__tests__/license.test.ts
@@ -1,11 +1,11 @@
 import type { GlobalConfig } from '@n8n/config';
+import { mockLogger } from '@n8n/integration-test-utils';
 import { LicenseManager } from '@n8n_io/license-sdk';
 import { mock } from 'jest-mock-extended';
 import type { InstanceSettings } from 'n8n-core';
 
 import { N8N_VERSION } from '@/constants';
 import { License } from '@/license';
-import { mockLogger } from '@test/mocking';
 
 jest.mock('@n8n_io/license-sdk');
 

--- a/packages/cli/src/__tests__/wait-tracker.test.ts
+++ b/packages/cli/src/__tests__/wait-tracker.test.ts
@@ -1,6 +1,7 @@
 import type { Project } from '@n8n/db';
 import type { IExecutionResponse } from '@n8n/db';
 import type { ExecutionRepository } from '@n8n/db';
+import { mockLogger } from '@n8n/integration-test-utils';
 import { mock } from 'jest-mock-extended';
 import type { InstanceSettings } from 'n8n-core';
 import type { IRun, IWorkflowBase } from 'n8n-workflow';
@@ -11,7 +12,6 @@ import type { MultiMainSetup } from '@/scaling/multi-main-setup.ee';
 import type { OwnershipService } from '@/services/ownership.service';
 import { WaitTracker } from '@/wait-tracker';
 import type { WorkflowRunner } from '@/workflow-runner';
-import { mockLogger } from '@test/mocking';
 
 jest.useFakeTimers({ advanceTimers: true });
 

--- a/packages/cli/src/concurrency/__tests__/concurrency-control.service.test.ts
+++ b/packages/cli/src/concurrency/__tests__/concurrency-control.service.test.ts
@@ -1,5 +1,6 @@
 import type { GlobalConfig } from '@n8n/config';
 import type { ExecutionRepository } from '@n8n/db';
+import { mockLogger } from '@n8n/integration-test-utils';
 import { mock } from 'jest-mock-extended';
 import type { WorkflowExecuteMode as ExecutionMode } from 'n8n-workflow';
 
@@ -13,7 +14,6 @@ import config from '@/config';
 import { InvalidConcurrencyLimitError } from '@/errors/invalid-concurrency-limit.error';
 import type { EventService } from '@/events/event.service';
 import type { Telemetry } from '@/telemetry';
-import { mockLogger } from '@test/mocking';
 
 import { ConcurrencyQueue } from '../concurrency-queue';
 

--- a/packages/cli/src/evaluation.ee/test-runner/__tests__/test-runner.service.ee.test.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/__tests__/test-runner.service.ee.test.ts
@@ -2,6 +2,7 @@ import type { TestRun } from '@n8n/db';
 import type { TestCaseExecutionRepository } from '@n8n/db';
 import type { TestRunRepository } from '@n8n/db';
 import type { WorkflowRepository } from '@n8n/db';
+import { mockLogger } from '@n8n/integration-test-utils';
 import { readFileSync } from 'fs';
 import type { Mock } from 'jest-mock';
 import { mock } from 'jest-mock-extended';
@@ -17,7 +18,7 @@ import { TestRunError } from '@/evaluation.ee/test-runner/errors.ee';
 import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 import type { Telemetry } from '@/telemetry';
 import type { WorkflowRunner } from '@/workflow-runner';
-import { mockInstance, mockLogger } from '@test/mocking';
+import { mockInstance } from '@test/mocking';
 import { mockNodeTypesData } from '@test-integration/utils/node-types-data';
 
 import { TestRunnerService } from '../test-runner.service.ee';

--- a/packages/cli/src/ldap.ee/__tests__/ldap.service.test.ts
+++ b/packages/cli/src/ldap.ee/__tests__/ldap.service.test.ts
@@ -1,6 +1,7 @@
 import { LDAP_FEATURE_NAME, type LdapConfig } from '@n8n/constants';
 import type { Settings } from '@n8n/db';
 import { AuthIdentityRepository, SettingsRepository } from '@n8n/db';
+import { mockLogger } from '@n8n/integration-test-utils';
 import { QueryFailedError } from '@n8n/typeorm';
 import { mock } from 'jest-mock-extended';
 import { Client } from 'ldapts';
@@ -9,7 +10,7 @@ import { randomString } from 'n8n-workflow';
 
 import config from '@/config';
 import type { EventService } from '@/events/event.service';
-import { mockInstance, mockLogger } from '@test/mocking';
+import { mockInstance } from '@test/mocking';
 
 import { BINARY_AD_ATTRIBUTES, LDAP_LOGIN_ENABLED, LDAP_LOGIN_LABEL } from '../constants';
 import {

--- a/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-manager.ee.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-manager.ee.test.ts
@@ -1,4 +1,5 @@
 import type { Settings, SettingsRepository } from '@n8n/db';
+import { mockLogger } from '@n8n/integration-test-utils';
 import { captor, mock } from 'jest-mock-extended';
 
 import type { License } from '@/license';
@@ -9,7 +10,7 @@ import {
 	FailedProvider,
 	MockProviders,
 } from '@test/external-secrets/utils';
-import { mockCipher, mockLogger } from '@test/mocking';
+import { mockCipher } from '@test/mocking';
 
 import { EXTERNAL_SECRETS_DB_KEY } from '../constants';
 import { ExternalSecretsManager } from '../external-secrets-manager.ee';

--- a/packages/cli/src/modules/insights/__tests__/insights-collection.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights-collection.service.test.ts
@@ -4,6 +4,7 @@ import type { IWorkflowDb } from '@n8n/db';
 import type { SharedWorkflowRepository } from '@n8n/db';
 import type { WorkflowExecuteAfterContext } from '@n8n/decorators';
 import { Container } from '@n8n/di';
+import { mockLogger } from '@n8n/integration-test-utils';
 import { In } from '@n8n/typeorm';
 import { mock } from 'jest-mock-extended';
 import { DateTime } from 'luxon';
@@ -17,7 +18,6 @@ import {
 import type { TypeUnit } from '@/modules/insights/database/entities/insights-shared';
 import { InsightsMetadataRepository } from '@/modules/insights/database/repositories/insights-metadata.repository';
 import { InsightsRawRepository } from '@/modules/insights/database/repositories/insights-raw.repository';
-import { mockLogger } from '@test/mocking';
 import { createTeamProject } from '@test-integration/db/projects';
 import { createWorkflow } from '@test-integration/db/workflows';
 import * as testDb from '@test-integration/test-db';

--- a/packages/cli/src/modules/insights/__tests__/insights-compaction.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights-compaction.service.test.ts
@@ -1,9 +1,9 @@
 import { Container } from '@n8n/di';
+import { mockLogger } from '@n8n/integration-test-utils';
 import { mock } from 'jest-mock-extended';
 import { DateTime } from 'luxon';
 
 import { InsightsRawRepository } from '@/modules/insights/database/repositories/insights-raw.repository';
-import { mockLogger } from '@test/mocking';
 import { createTeamProject } from '@test-integration/db/projects';
 import { createWorkflow } from '@test-integration/db/workflows';
 import * as testDb from '@test-integration/test-db';

--- a/packages/cli/src/modules/insights/__tests__/insights-pruning.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights-pruning.service.test.ts
@@ -1,10 +1,10 @@
 import type { LicenseState } from '@n8n/backend-common';
 import { Container } from '@n8n/di';
+import { mockLogger } from '@n8n/integration-test-utils';
 import { mock } from 'jest-mock-extended';
 import { DateTime } from 'luxon';
 
 import { Time } from '@/constants';
-import { mockLogger } from '@test/mocking';
 import { createTeamProject } from '@test-integration/db/projects';
 import { createWorkflow } from '@test-integration/db/workflows';
 import * as testDb from '@test-integration/test-db';

--- a/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
@@ -5,13 +5,13 @@ import type { WorkflowEntity } from '@n8n/db';
 import type { IWorkflowDb } from '@n8n/db';
 import type { WorkflowExecuteAfterContext } from '@n8n/decorators';
 import { Container } from '@n8n/di';
+import { mockLogger } from '@n8n/integration-test-utils';
 import type { MockProxy } from 'jest-mock-extended';
 import { mock } from 'jest-mock-extended';
 import { DateTime } from 'luxon';
 import type { InstanceSettings } from 'n8n-core';
 import type { IRun } from 'n8n-workflow';
 
-import { mockLogger } from '@test/mocking';
 import { createTeamProject } from '@test-integration/db/projects';
 import { createWorkflow } from '@test-integration/db/workflows';
 import * as testDb from '@test-integration/test-db';

--- a/packages/cli/src/modules/insights/insights.controller.ts
+++ b/packages/cli/src/modules/insights/insights.controller.ts
@@ -3,10 +3,15 @@ import type { InsightsSummary, InsightsByTime, InsightsByWorkflow } from '@n8n/a
 import { Get, GlobalScope, Licensed, Query, RestController } from '@n8n/decorators';
 import type { UserError } from 'n8n-workflow';
 
-import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { AuthenticatedRequest } from '@/requests';
 
 import { InsightsService } from './insights.service';
+
+export class ForbiddenError extends Error {
+	readonly httpStatusCode = 403;
+
+	readonly level = 'warning';
+}
 
 @RestController('/insights')
 export class InsightsController {

--- a/packages/cli/src/modules/insights/insights.controller.ts
+++ b/packages/cli/src/modules/insights/insights.controller.ts
@@ -10,7 +10,9 @@ import { InsightsService } from './insights.service';
 export class ForbiddenError extends Error {
 	readonly httpStatusCode = 403;
 
-	readonly level = 'warning';
+	readonly errorCode = 403;
+
+	readonly shouldReport = false;
 }
 
 @RestController('/insights')

--- a/packages/cli/src/scaling/__tests__/scaling.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/scaling.service.test.ts
@@ -1,11 +1,12 @@
 import { GlobalConfig } from '@n8n/config';
 import { Container } from '@n8n/di';
+import { mockLogger } from '@n8n/integration-test-utils';
 import * as BullModule from 'bull';
 import { mock } from 'jest-mock-extended';
 import { InstanceSettings } from 'n8n-core';
 import { ApplicationError, ExecutionCancelledError } from 'n8n-workflow';
 
-import { mockInstance, mockLogger } from '@test/mocking';
+import { mockInstance } from '@test/mocking';
 
 import { JOB_TYPE_NAME, QUEUE_NAME } from '../constants';
 import type { JobProcessor } from '../job-processor';

--- a/packages/cli/src/scaling/__tests__/worker-server.test.ts
+++ b/packages/cli/src/scaling/__tests__/worker-server.test.ts
@@ -1,4 +1,5 @@
 import type { GlobalConfig } from '@n8n/config';
+import { mockLogger } from '@n8n/integration-test-utils';
 import type express from 'express';
 import { mock } from 'jest-mock-extended';
 import type { InstanceSettings } from 'n8n-core';
@@ -9,7 +10,6 @@ import type { DbConnection } from '@/databases/db-connection';
 import type { ExternalHooks } from '@/external-hooks';
 import type { PrometheusMetricsService } from '@/metrics/prometheus-metrics.service';
 import { bodyParser, rawBodyReader } from '@/middlewares';
-import { mockLogger } from '@test/mocking';
 
 import { WorkerServer } from '../worker-server';
 

--- a/packages/cli/src/scaling/pubsub/__tests__/publisher.service.test.ts
+++ b/packages/cli/src/scaling/pubsub/__tests__/publisher.service.test.ts
@@ -1,10 +1,10 @@
+import { mockLogger } from '@n8n/integration-test-utils';
 import type { Redis as SingleNodeClient } from 'ioredis';
 import { mock } from 'jest-mock-extended';
 import type { InstanceSettings } from 'n8n-core';
 
 import config from '@/config';
 import type { RedisClientService } from '@/services/redis-client.service';
-import { mockLogger } from '@test/mocking';
 
 import { Publisher } from '../publisher.service';
 import type { PubSub } from '../pubsub.types';

--- a/packages/cli/src/scaling/pubsub/__tests__/pubsub.registry.test.ts
+++ b/packages/cli/src/scaling/pubsub/__tests__/pubsub.registry.test.ts
@@ -1,9 +1,8 @@
 import { OnPubSubEvent, PubSubMetadata } from '@n8n/decorators';
 import { Container, Service } from '@n8n/di';
+import { mockLogger } from '@n8n/integration-test-utils';
 import { mock } from 'jest-mock-extended';
 import type { InstanceSettings } from 'n8n-core';
-
-import { mockLogger } from '@test/mocking';
 
 import { PubSubEventBus } from '../pubsub.eventbus';
 import { PubSubRegistry } from '../pubsub.registry';

--- a/packages/cli/src/services/pruning/__tests__/executions-pruning.service.test.ts
+++ b/packages/cli/src/services/pruning/__tests__/executions-pruning.service.test.ts
@@ -1,9 +1,9 @@
 import type { ExecutionsConfig } from '@n8n/config';
+import { mockLogger } from '@n8n/integration-test-utils';
 import { mock } from 'jest-mock-extended';
 import type { InstanceSettings } from 'n8n-core';
 
 import type { DbConnection } from '@/databases/db-connection';
-import { mockLogger } from '@test/mocking';
 
 import { ExecutionsPruningService } from '../executions-pruning.service';
 

--- a/packages/cli/src/workflows/workflow-history.ee/__tests__/workflow-history.service.ee.test.ts
+++ b/packages/cli/src/workflows/workflow-history.ee/__tests__/workflow-history.service.ee.test.ts
@@ -1,10 +1,11 @@
 import { User } from '@n8n/db';
 import { WorkflowHistoryRepository } from '@n8n/db';
+import { mockLogger } from '@n8n/integration-test-utils';
 import { mockClear } from 'jest-mock-extended';
 
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import { WorkflowHistoryService } from '@/workflows/workflow-history.ee/workflow-history.service.ee';
-import { mockInstance, mockLogger } from '@test/mocking';
+import { mockInstance } from '@test/mocking';
 import { getWorkflow } from '@test-integration/workflow';
 
 const workflowHistoryRepository = mockInstance(WorkflowHistoryRepository);

--- a/packages/cli/test/integration/executions-pruning.service.test.ts
+++ b/packages/cli/test/integration/executions-pruning.service.test.ts
@@ -2,6 +2,7 @@ import { ExecutionsConfig } from '@n8n/config';
 import type { ExecutionEntity } from '@n8n/db';
 import { ExecutionRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
+import { mockLogger } from '@n8n/integration-test-utils';
 import { BinaryDataService, InstanceSettings } from 'n8n-core';
 import type { ExecutionStatus, IWorkflowBase } from 'n8n-workflow';
 
@@ -16,7 +17,7 @@ import {
 } from './shared/db/executions';
 import { createWorkflow } from './shared/db/workflows';
 import * as testDb from './shared/test-db';
-import { mockInstance, mockLogger } from '../shared/mocking';
+import { mockInstance } from '../shared/mocking';
 
 describe('softDeleteOnPruningCycle()', () => {
 	let pruningService: ExecutionsPruningService;

--- a/packages/cli/test/integration/external-secrets/external-secrets.api.test.ts
+++ b/packages/cli/test/integration/external-secrets/external-secrets.api.test.ts
@@ -1,6 +1,7 @@
 import { LicenseState } from '@n8n/backend-common';
 import { SettingsRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
+import { mockLogger } from '@n8n/integration-test-utils';
 import { mock } from 'jest-mock-extended';
 import { Cipher } from 'n8n-core';
 import type { IDataObject } from 'n8n-workflow';
@@ -22,7 +23,7 @@ import {
 	MockProviders,
 	TestFailProvider,
 } from '../../shared/external-secrets/utils';
-import { mockInstance, mockLogger } from '../../shared/mocking';
+import { mockInstance } from '../../shared/mocking';
 import { createOwner, createUser } from '../shared/db/users';
 import type { SuperAgentTest } from '../shared/types';
 import { setupTestServer } from '../shared/utils';

--- a/packages/cli/test/integration/shared/utils/test-server.ts
+++ b/packages/cli/test/integration/shared/utils/test-server.ts
@@ -1,6 +1,7 @@
 import { LicenseState } from '@n8n/backend-common';
 import type { User } from '@n8n/db';
 import { Container } from '@n8n/di';
+import { mockLogger } from '@n8n/integration-test-utils';
 import cookieParser from 'cookie-parser';
 import express from 'express';
 import type superagent from 'superagent';
@@ -19,7 +20,7 @@ import type { APIRequest } from '@/requests';
 import { Telemetry } from '@/telemetry';
 import * as testModules from '@test-integration/test-modules';
 
-import { mockInstance, mockLogger } from '../../../shared/mocking';
+import { mockInstance } from '../../../shared/mocking';
 import { PUBLIC_API_REST_PATH_SEGMENT, REST_PATH_SEGMENT } from '../constants';
 import { LicenseMocker } from '../license';
 import * as testDb from '../test-db';

--- a/packages/cli/test/shared/mocking.ts
+++ b/packages/cli/test/shared/mocking.ts
@@ -1,4 +1,3 @@
-import type { Logger } from '@n8n/backend-common';
 import { Container } from '@n8n/di';
 import { DataSource, EntityManager, type EntityMetadata } from '@n8n/typeorm';
 import { mock } from 'jest-mock-extended';
@@ -23,8 +22,6 @@ export const mockEntityManager = (entityClass: Class) => {
 	Object.assign(entityManager, { connection: dataSource });
 	return entityManager;
 };
-
-export const mockLogger = () => mock<Logger>({ scoped: jest.fn().mockReturnValue(mock<Logger>()) });
 
 export const mockCipher = () =>
 	mock<Cipher>({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -740,6 +740,12 @@ importers:
 
   packages/@n8n/integration-test-utils:
     dependencies:
+      '@n8n/backend-common':
+        specifier: workspace:^
+        version: link:../backend-common
+      jest-mock-extended:
+        specifier: ^3.0.4
+        version: 3.0.4(jest@29.6.2(@types/node@20.17.57)(ts-node@10.9.2(@types/node@20.17.57)(typescript@5.8.2)))(typescript@5.8.2)
       reflect-metadata:
         specifier: 'catalog:'
         version: 0.2.2


### PR DESCRIPTION
## Summary

This PR moves `mockLogger` to `@n8n/integration-test-utils` so that it can be consumed by insights once it becomes a standalone module, and also removes insights' dependency on `ForbiddenError`.

Notes:
- In future we may want a new package `@n8n/errors`. For now I'd rather not incur more work if it's only for a single simple error class `ForbiddenError`.
- `mockLogger` is used in both integration and unit tests, so I'm thinking `@n8n/integration-test-utils` might be better named `@n8n/backend-test-utils`. If you agree, I'll do a follow-up to rename the package.

## Related Linear tickets, Github issues, and Community forum posts

n/a


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
