### PR TITLE
feat(core): Add queue events to log streaming

### DIFF
--- a/packages/cli/src/__tests__/workflow-runner.test.ts
+++ b/packages/cli/src/__tests__/workflow-runner.test.ts
@@ -295,7 +295,7 @@ describe('enqueueExecution', () => {
 		addJob.mockRejectedValueOnce(error);
 
 		// @ts-expect-error Private method
-		await expect(runner.enqueueExecution('1', data)).rejects.toThrowError(error);
+		await expect(runner.enqueueExecution('1', 'workflow-xyz', data)).rejects.toThrowError(error);
 
 		expect(setupQueue).toHaveBeenCalledTimes(1);
 	});

--- a/packages/cli/src/eventbus/event-message-classes/event-message-queue.ts
+++ b/packages/cli/src/eventbus/event-message-classes/event-message-queue.ts
@@ -1,0 +1,44 @@
+import type { JsonObject } from 'n8n-workflow';
+import { EventMessageTypeNames } from 'n8n-workflow';
+
+import { AbstractEventMessage, isEventMessageOptionsWithType } from './abstract-event-message';
+import type { AbstractEventMessageOptions } from './abstract-event-message-options';
+import type { AbstractEventPayload } from './abstract-event-payload';
+
+export interface EventPayloadQueue extends AbstractEventPayload {
+	workflowId: string;
+	jobId: string;
+	executionId: string;
+	hostId: string;
+}
+
+export interface EventMessageQueueOptions extends AbstractEventMessageOptions {
+	payload?: EventPayloadQueue;
+}
+
+export class EventMessageQueue extends AbstractEventMessage {
+	readonly __type = EventMessageTypeNames.runner;
+
+	payload: EventPayloadQueue;
+
+	constructor(options: EventMessageQueueOptions) {
+		super(options);
+		if (options.payload) this.setPayload(options.payload);
+		if (options.anonymize) {
+			this.anonymize();
+		}
+	}
+
+	setPayload(payload: EventPayloadQueue): this {
+		this.payload = payload;
+		return this;
+	}
+
+	deserialize(data: JsonObject): this {
+		if (isEventMessageOptionsWithType(data, this.__type)) {
+			this.setOptionsOrDefault(data);
+			if (data.payload) this.setPayload(data.payload as EventPayloadQueue);
+		}
+		return this;
+	}
+}

--- a/packages/cli/src/eventbus/event-message-classes/index.ts
+++ b/packages/cli/src/eventbus/event-message-classes/index.ts
@@ -3,6 +3,7 @@ import type { EventMessageAudit } from './event-message-audit';
 import type { EventMessageExecution } from './event-message-execution';
 import type { EventMessageGeneric } from './event-message-generic';
 import type { EventMessageNode } from './event-message-node';
+import type { EventMessageQueue } from './event-message-queue';
 import type { EventMessageRunner } from './event-message-runner';
 import type { EventMessageWorkflow } from './event-message-workflow';
 
@@ -31,6 +32,16 @@ export const eventNamesRunner = [
 ] as const;
 
 export type EventNamesRunnerType = (typeof eventNamesRunner)[number];
+
+export const eventNamesQueue = [
+	'n8n.queue.job.enqueued',
+	'n8n.queue.job.dequeued',
+	'n8n.queue.job.completed',
+	'n8n.queue.job.failed',
+	'n8n.queue.job.stalled',
+] as const;
+
+export type EventNamesQueueType = (typeof eventNamesQueue)[number];
 
 export const eventNamesWorkflow = [
 	'n8n.workflow.started',
@@ -85,6 +96,7 @@ export type EventNamesTypes =
 	| EventNamesGenericType
 	| EventNamesAiNodesType
 	| EventNamesRunnerType
+	| EventNamesQueueType
 	| 'n8n.destination.test';
 
 export const eventNamesAll = [
@@ -94,6 +106,7 @@ export const eventNamesAll = [
 	...eventNamesGeneric,
 	...eventNamesAiNodes,
 	...eventNamesRunner,
+	...eventNamesQueue,
 ];
 
 export type EventMessageTypes =
@@ -103,4 +116,5 @@ export type EventMessageTypes =
 	| EventMessageNode
 	| EventMessageExecution
 	| EventMessageAiNode
+	| EventMessageQueue
 	| EventMessageRunner;

--- a/packages/cli/src/eventbus/message-event-bus/message-event-bus.ts
+++ b/packages/cli/src/eventbus/message-event-bus/message-event-bus.ts
@@ -32,6 +32,8 @@ import {
 } from '../event-message-classes/event-message-generic';
 import type { EventMessageNodeOptions } from '../event-message-classes/event-message-node';
 import { EventMessageNode } from '../event-message-classes/event-message-node';
+import type { EventMessageQueueOptions } from '../event-message-classes/event-message-queue';
+import { EventMessageQueue } from '../event-message-classes/event-message-queue';
 import type { EventMessageRunnerOptions } from '../event-message-classes/event-message-runner';
 import { EventMessageRunner } from '../event-message-classes/event-message-runner';
 import type { EventMessageWorkflowOptions } from '../event-message-classes/event-message-workflow';
@@ -424,5 +426,9 @@ export class MessageEventBus extends EventEmitter {
 
 	async sendRunnerEvent(options: EventMessageRunnerOptions) {
 		await this.send(new EventMessageRunner(options));
+	}
+
+	async sendQueueEvent(options: EventMessageQueueOptions) {
+		await this.send(new EventMessageQueue(options));
 	}
 }

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -514,4 +514,29 @@ export type RelayEventMap = {
 	};
 
 	// #endregion
+
+	// #region queue
+
+	'job-enqueued': {
+		executionId: string;
+		workflowId: string;
+		hostId: string;
+		jobId: string;
+	};
+
+	'job-dequeued': {
+		executionId: string;
+		workflowId: string;
+		hostId: string;
+		jobId: string;
+	};
+
+	'job-stalled': {
+		executionId: string;
+		workflowId: string;
+		hostId: string;
+		jobId: string;
+	};
+
+	// #endregion
 } & AiEventMap;

--- a/packages/cli/src/events/relays/log-streaming.event-relay.ts
+++ b/packages/cli/src/events/relays/log-streaming.event-relay.ts
@@ -1,5 +1,6 @@
 import { Redactable } from '@n8n/decorators';
 import { Service } from '@n8n/di';
+import { InstanceSettings } from 'n8n-core';
 import type { IWorkflowBase } from 'n8n-workflow';
 
 import { MessageEventBus } from '@/eventbus/message-event-bus/message-event-bus';
@@ -12,6 +13,7 @@ export class LogStreamingEventRelay extends EventRelay {
 	constructor(
 		readonly eventService: EventService,
 		private readonly eventBus: MessageEventBus,
+		private readonly instanceSettings: InstanceSettings,
 	) {
 		super(eventService);
 	}
@@ -65,6 +67,9 @@ export class LogStreamingEventRelay extends EventRelay {
 			'ai-vector-store-updated': (event) => this.aiVectorStoreUpdated(event),
 			'runner-task-requested': (event) => this.runnerTaskRequested(event),
 			'runner-response-received': (event) => this.runnerResponseReceived(event),
+			'job-enqueued': (event) => this.jobEnqueued(event),
+			'job-dequeued': (event) => this.jobDequeued(event),
+			'job-stalled': (event) => this.jobStalled(event),
 		});
 	}
 
@@ -143,10 +148,11 @@ export class LogStreamingEventRelay extends EventRelay {
 	}
 
 	private workflowPostExecute(event: RelayEventMap['workflow-post-execute']) {
-		const { runData, workflow, ...rest } = event;
+		const { runData, workflow, executionId, ...rest } = event;
 
 		const payload = {
 			...rest,
+			executionId,
 			success: !!runData?.finished, // despite the `success` name, this reports `finished` state
 			isManual: runData?.mode === 'manual',
 			workflowId: workflow.id,
@@ -158,6 +164,18 @@ export class LogStreamingEventRelay extends EventRelay {
 				eventName: 'n8n.workflow.success',
 				payload,
 			});
+
+			if (runData?.jobId) {
+				void this.eventBus.sendQueueEvent({
+					eventName: 'n8n.queue.job.completed',
+					payload: {
+						executionId,
+						workflowId: workflow.id,
+						hostId: this.instanceSettings.hostId,
+						jobId: runData.jobId.toString(),
+					},
+				});
+			}
 
 			return;
 		}
@@ -174,6 +192,18 @@ export class LogStreamingEventRelay extends EventRelay {
 				errorMessage: runData?.data.resultData.error?.message.toString(),
 			},
 		});
+
+		if (runData?.jobId) {
+			void this.eventBus.sendQueueEvent({
+				eventName: 'n8n.queue.job.failed',
+				payload: {
+					executionId,
+					workflowId: workflow.id,
+					hostId: this.instanceSettings.hostId,
+					jobId: runData.jobId.toString(),
+				},
+			});
+		}
 	}
 
 	// #endregion
@@ -553,6 +583,31 @@ export class LogStreamingEventRelay extends EventRelay {
 	private runnerResponseReceived(payload: RelayEventMap['runner-response-received']) {
 		void this.eventBus.sendRunnerEvent({
 			eventName: 'n8n.runner.response.received',
+			payload,
+		});
+	}
+
+	// #endregion
+
+	// #region queue
+
+	private jobEnqueued(payload: RelayEventMap['job-enqueued']) {
+		void this.eventBus.sendQueueEvent({
+			eventName: 'n8n.queue.job.enqueued',
+			payload,
+		});
+	}
+
+	private jobDequeued(payload: RelayEventMap['job-dequeued']) {
+		void this.eventBus.sendQueueEvent({
+			eventName: 'n8n.queue.job.dequeued',
+			payload,
+		});
+	}
+
+	private jobStalled(payload: RelayEventMap['job-stalled']) {
+		void this.eventBus.sendQueueEvent({
+			eventName: 'n8n.queue.job.stalled',
 			payload,
 		});
 	}

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -86,6 +86,13 @@ export class ScalingService {
 
 		void this.queue.process(JOB_TYPE_NAME, concurrency, async (job: Job) => {
 			try {
+				this.eventService.emit('job-dequeued', {
+					executionId: job.data.executionId,
+					workflowId: job.data.workflowId,
+					hostId: this.instanceSettings.hostId,
+					jobId: job.id.toString(),
+				});
+
 				if (!this.hasValidJobData(job)) {
 					throw new UnexpectedError('Worker received invalid job', {
 						extra: { jobData: jsonStringify(job, { replaceCircularRefs: true }) },
@@ -196,6 +203,12 @@ export class ScalingService {
 		const jobId = job.id;
 
 		this.logger.info(`Enqueued execution ${executionId} (job ${jobId})`, { executionId, jobId });
+		this.eventService.emit('job-enqueued', {
+			executionId,
+			workflowId: jobData.workflowId,
+			hostId: this.instanceSettings.hostId,
+			jobId: jobId.toString(),
+		});
 
 		return job;
 	}

--- a/packages/cli/src/scaling/scaling.types.ts
+++ b/packages/cli/src/scaling/scaling.types.ts
@@ -10,6 +10,7 @@ export type Job = Bull.Job<JobData>;
 export type JobId = Job['id'];
 
 export type JobData = {
+	workflowId: string;
 	executionId: string;
 	loadStaticData: boolean;
 	pushRef?: string;

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -2015,6 +2015,8 @@
 	"settings.log-streaming.eventGroup.n8n.node.info": "Will send step-wise execution events every time a node executes. Please note that this can lead to a high frequency of logged events and is probably not suitable for general use.",
 	"settings.log-streaming.eventGroup.n8n.runner": "Runner tasks",
 	"settings.log-streaming.eventGroup.n8n.runner.info": "Will send an event when a Code node execution is requested from a task runner, and when a response is received from the runner with the result.",
+	"settings.log-streaming.eventGroup.n8n.queue": "Queue events",
+	"settings.log-streaming.eventGroup.n8n.queue.info": "Will send an event when a queue-related event occurs, e.g. enqueuing, dequeueing, completion, failure, or stalling.",
 	"settings.log-streaming.eventGroup.n8n.worker": "Worker",
 	"settings.log-streaming.$$AbstractMessageEventBusDestination": "Generic",
 	"settings.log-streaming.$$MessageEventBusDestinationWebhook": "Webhook",

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2143,6 +2143,9 @@ export interface IRun {
 	startedAt: Date;
 	stoppedAt?: Date;
 	status: ExecutionStatus;
+
+	/** ID of the job this execution belongs to. Only in scaling mode. */
+	jobId?: string;
 }
 
 // Contains all the data which is needed to execute a workflow and so also to

--- a/packages/workflow/src/message-event-bus.ts
+++ b/packages/workflow/src/message-event-bus.ts
@@ -15,6 +15,7 @@ export const enum EventMessageTypeNames {
 	execution = '$$EventMessageExecution',
 	aiNode = '$$EventMessageAiNode',
 	runner = '$$EventMessageRunner',
+	queue = '$$EventMessageQueue',
 }
 
 export const enum MessageEventBusDestinationTypeNames {


### PR DESCRIPTION
## Summary

Add to queue events to log streaming for easier debugging:

- `n8n.queue.job.enqueued`
- `n8n.queue.job.dequeued`
- `n8n.queue.job.completed`
- `n8n.queue.job.failed`
- `n8n.queue.job.stalled`

Notes:

- To follow existing log streaming conventions and to avoid coupling to Bull's implementation, `completed` and `failed` were added to `workflowExecuteAfter` (at main) instead of latching onto Bull's `global:progress` messages.
- Eventbus is in dire need of refactoring with lots of overhead and duplication, but in this PR I'm following suit with what exists as is.
## Related Linear tickets, Github issues, and Community forum posts

n/a


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
