### PR TITLE
fix(core): Ensure updatedAt field exists on folder object for source control

### DIFF
--- a/packages/cli/src/environments.ee/source-control/source-control.controller.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control.controller.ee.ts
@@ -216,10 +216,10 @@ export class SourceControlController {
 	@Get('/get-status', { middlewares: [sourceControlLicensedAndEnabledMiddleware] })
 	async getStatus(req: SourceControlRequest.GetStatus) {
 		try {
-			const result = (await this.sourceControlService.getStatus(
+			const result = await this.sourceControlService.getStatus(
 				req.user,
 				new SourceControlGetStatus(req.query),
-			)) as SourceControlledFile[];
+			);
 			return result;
 		} catch (error) {
 			throw new BadRequestError((error as { message: string }).message);

--- a/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
@@ -963,6 +963,8 @@ export class SourceControlService {
 			select: ['updatedAt'],
 		});
 
+		const lastUpdatedDate = lastUpdatedFolder[0]?.updatedAt ?? new Date();
+
 		const foldersMappingsRemote =
 			await this.sourceControlImportService.getRemoteFoldersAndMappingsFromFile(context);
 		const foldersMappingsLocal =
@@ -999,7 +1001,7 @@ export class SourceControlService {
 				location: options.direction === 'push' ? 'local' : 'remote',
 				conflict: false,
 				file: getFoldersPath(this.gitFolder),
-				updatedAt: lastUpdatedFolder[0]?.updatedAt.toISOString(),
+				updatedAt: lastUpdatedDate.toISOString(),
 			});
 		});
 		foldersMissingInRemote.forEach((item) => {
@@ -1011,7 +1013,7 @@ export class SourceControlService {
 				location: options.direction === 'push' ? 'local' : 'remote',
 				conflict: options.direction === 'push' ? false : true,
 				file: getFoldersPath(this.gitFolder),
-				updatedAt: lastUpdatedFolder[0]?.updatedAt.toISOString(),
+				updatedAt: lastUpdatedDate.toISOString(),
 			});
 		});
 


### PR DESCRIPTION
## Summary

In a special case, where the last folder on an instance was deleted, no updatedAt field for folders can be fetched, with this PR we are falling back to the current date in that case.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-2953/environments-unable-to-committing-workflow-updates


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
