### PR TITLE
fix(Youtube Node): Correct playlist creation privacyStatus path

### DIFF
--- a/packages/nodes-base/nodes/Google/YouTube/YouTube.node.ts
+++ b/packages/nodes-base/nodes/Google/YouTube/YouTube.node.ts
@@ -503,6 +503,7 @@ export class YouTube implements INodeType {
 							snippet: {
 								title,
 							},
+							status: {},
 						};
 
 						if (options.tags) {
@@ -510,9 +511,9 @@ export class YouTube implements INodeType {
 							body.snippet.tags = (options.tags as string).split(',');
 						}
 
-						if (options.description) {
+						if (options.privacyStatus) {
 							//@ts-ignore
-							body.snippet.privacyStatus = options.privacyStatus as string;
+							body.status.privacyStatus = options.privacyStatus as string;
 						}
 
 						if (options.defaultLanguage) {

--- a/packages/nodes-base/nodes/Google/YouTube/YouTube.node.ts
+++ b/packages/nodes-base/nodes/Google/YouTube/YouTube.node.ts
@@ -497,13 +497,15 @@ export class YouTube implements INodeType {
 						const title = this.getNodeParameter('title', i) as string;
 						const options = this.getNodeParameter('options', i);
 
-						qs.part = 'snippet';
+						qs.part = 'snippet,status';
 
 						const body: IDataObject = {
 							snippet: {
 								title,
 							},
-							status: {},
+							status: {
+								privacyStatus: 'private',
+							},
 						};
 
 						if (options.tags) {

--- a/packages/nodes-base/nodes/Google/YouTube/__test__/node/YouTube.node.test.ts
+++ b/packages/nodes-base/nodes/Google/YouTube/__test__/node/YouTube.node.test.ts
@@ -74,7 +74,7 @@ describe('Test YouTube Node', () => {
 					snippet: { title: 'Playlist 1', defaultLanguage: 'en' },
 					status: { privacyStatus: 'public' },
 				})
-				.query({ part: 'snippet' })
+				.query({ part: 'snippet,status' })
 				.reply(200, playlists[0]);
 			youtubeNock
 				.put('/v3/playlists', {

--- a/packages/nodes-base/nodes/Google/YouTube/__test__/node/YouTube.node.test.ts
+++ b/packages/nodes-base/nodes/Google/YouTube/__test__/node/YouTube.node.test.ts
@@ -71,7 +71,8 @@ describe('Test YouTube Node', () => {
 		beforeAll(() => {
 			youtubeNock
 				.post('/v3/playlists', {
-					snippet: { title: 'Playlist 1', privacyStatus: 'public', defaultLanguage: 'en' },
+					snippet: { title: 'Playlist 1', defaultLanguage: 'en' },
+					status: { privacyStatus: 'public' },
 				})
 				.query({ part: 'snippet' })
 				.reply(200, playlists[0]);


### PR DESCRIPTION
## Summary

The `privacyStatus` for YouTube playlist creation was incorrectly mapped to `body.snippet.privacyStatus`. This commit
corrects the path to `body.status.privacyStatus` as per [YouTube Data API v3 documentation](https://developers.google.com/youtube/v3/docs/playlists#resource), ensuring the
privacy setting selected in the node is respected.

## Related Linear tickets, Github issues, and Community forum posts

resolves #16442

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
