### PR TITLE
test(API): Add tests for UpdateProjectDto (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/dto/project/__tests__/update-project.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/project/__tests__/update-project.dto.test.ts
@@ -4,13 +4,13 @@ describe('UpdateProjectDto', () => {
 	describe('Valid requests', () => {
 		test.each([
 			{
-				name: 'with just the name',
+				name: 'just the name',
 				request: {
 					name: 'My Updated Project',
 				},
 			},
 			{
-				name: 'with name and emoji icon',
+				name: 'name and emoji icon',
 				request: {
 					name: 'My Updated Project',
 					icon: {
@@ -20,7 +20,7 @@ describe('UpdateProjectDto', () => {
 				},
 			},
 			{
-				name: 'with name and regular icon',
+				name: 'name and regular icon',
 				request: {
 					name: 'My Updated Project',
 					icon: {
@@ -30,7 +30,19 @@ describe('UpdateProjectDto', () => {
 				},
 			},
 			{
-				name: 'with relations',
+				name: 'just the description',
+				request: {
+					description: 'My Updated Project Description',
+				},
+			},
+			{
+				name: 'an empty description',
+				request: {
+					description: '',
+				},
+			},
+			{
+				name: 'just the relations',
 				request: {
 					relations: [
 						{
@@ -41,7 +53,7 @@ describe('UpdateProjectDto', () => {
 				},
 			},
 			{
-				name: 'with all fields',
+				name: 'all fields',
 				request: {
 					name: 'My Updated Project',
 					icon: {
@@ -54,9 +66,10 @@ describe('UpdateProjectDto', () => {
 							role: 'project:admin',
 						},
 					],
+					description: 'My Updated Project Description',
 				},
 			},
-		])('should validate $name', ({ request }) => {
+		])('should pass validation for $name', ({ request }) => {
 			const result = UpdateProjectDto.safeParse(request);
 			expect(result.success).toBe(true);
 		});
@@ -67,6 +80,11 @@ describe('UpdateProjectDto', () => {
 			{
 				name: 'invalid name type',
 				request: { name: 123 },
+				expectedErrorPath: ['name'],
+			},
+			{
+				name: 'empty name',
+				request: { name: '', icon: { type: 'emoji', value: '🚀' } },
 				expectedErrorPath: ['name'],
 			},
 			{
@@ -107,6 +125,16 @@ describe('UpdateProjectDto', () => {
 					],
 				},
 				expectedErrorPath: ['relations', 0, 'role'],
+			},
+			{
+				name: 'invalid description type',
+				request: { description: 123 },
+				expectedErrorPath: ['description'],
+			},
+			{
+				name: 'description too long',
+				request: { description: 'a'.repeat(513) },
+				expectedErrorPath: ['description'],
 			},
 		])('should fail validation for $name', ({ request, expectedErrorPath }) => {
 			const result = UpdateProjectDto.safeParse(request);

--- a/packages/cli/src/controllers/project.controller.ts
+++ b/packages/cli/src/controllers/project.controller.ts
@@ -204,7 +204,7 @@ export class ProjectController {
 		@Param('projectId') projectId: string,
 	) {
 		const { name, icon, relations, description } = payload;
-		if ([name, icon, description].some((data) => typeof data === 'string')) {
+		if (name || icon || description) {
 			await this.projectsService.updateProject(projectId, { name, icon, description });
 		}
 		if (relations) {


### PR DESCRIPTION
## Summary

This PR adds tests for `UpdateProjectDto`.

It also reverts a line introduced in [Project Descriptions PR](https://github.com/n8n-io/n8n/pull/15611/files#diff-aa47c3814b0b1070f7eb6255757bb1ce38c97d2a388e6b12f6e8c4dbd688cbf0), which incorrectly assumed that the icon field is a string. While this doesn't currently break the app (since we always send all fields when updating a project, making the condition always evaluate to true), it's still misleading and technically incorrect.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3670/tech-debt-add-tests-for-update-project-dto

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
