### PR TITLE
fix(Telegram Node): "source.on is not a function" in Telegram with binary file and Reply Markup

### DIFF
--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -2138,6 +2138,10 @@ export class Telegram implements INodeType {
 						},
 					};
 
+					if (formData.reply_markup) {
+						formData.reply_markup = JSON.stringify(formData.reply_markup);
+					}
+
 					responseData = await apiRequest.call(this, requestMethod, endpoint, {}, qs, {
 						formData,
 					});

--- a/packages/nodes-base/nodes/Telegram/tests/Workflow/apiResponses.ts
+++ b/packages/nodes-base/nodes/Telegram/tests/Workflow/apiResponses.ts
@@ -397,3 +397,41 @@ export const getMemberResponse = {
 		is_anonymous: false,
 	},
 };
+
+export const sendMessageWithBinaryDataAndReplyMarkupResponse = {
+	ok: true,
+	result: {
+		message_id: 123,
+		from: {
+			id: 1234578901,
+			is_bot: true,
+			first_name: 'TestBot',
+			username: 'TestBot',
+		},
+		chat: {
+			id: 987654321,
+			first_name: 'Some',
+			last_name: 'Guy',
+			username: 'SomeGuy',
+			type: 'private',
+		},
+		date: 1750195377,
+		document: {
+			file_name: 'file.json',
+			mime_type: 'application/json',
+			file_id: 'BQACAgIAAxkDAANFaFHcsX7_6XEYxKTw3Y93hBKxdPEAAm1_AAJ3NpBKL3xbHXAyvIU2BA',
+			file_unique_id: 'AgADbX8AAnc2kEo',
+			file_size: 24,
+		},
+		reply_markup: {
+			inline_keyboard: [
+				[
+					{
+						text: 'Test Button',
+						callback_data: '123',
+					},
+				],
+			],
+		},
+	},
+};

--- a/packages/nodes-base/nodes/Telegram/tests/Workflow/binaryData.workflow.json
+++ b/packages/nodes-base/nodes/Telegram/tests/Workflow/binaryData.workflow.json
@@ -1,0 +1,170 @@
+{
+	"name": "Telegram Binary Data and Reply Markup",
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [-700, 160],
+			"id": "6acb0d3b-6f5e-43dd-adeb-152ab4e9cc90",
+			"name": "When clicking ‘Test workflow’"
+		},
+		{
+			"parameters": {
+				"operation": "sendDocument",
+				"chatId": "123456789",
+				"binaryData": true,
+				"replyMarkup": "inlineKeyboard",
+				"inlineKeyboard": {
+					"rows": [
+						{
+							"row": {
+								"buttons": [
+									{
+										"text": "Test Button",
+										"additionalFields": {
+											"callback_data": "123"
+										}
+									}
+								]
+							}
+						}
+					]
+				},
+				"additionalFields": {}
+			},
+			"type": "n8n-nodes-base.telegram",
+			"typeVersion": 1.2,
+			"position": [-40, 160],
+			"id": "71580477-ff66-487d-9762-4bdf5cc0b5a9",
+			"name": "Send a document",
+			"webhookId": "bea3ccc9-bda6-4353-904e-bff92d608457",
+			"credentials": {
+				"telegramApi": {
+					"id": "HcIHBfGmAEOgtHgq",
+					"name": "Telegram account"
+				}
+			}
+		},
+		{
+			"parameters": {
+				"operation": "toJson",
+				"options": {}
+			},
+			"type": "n8n-nodes-base.convertToFile",
+			"typeVersion": 1.1,
+			"position": [-260, 160],
+			"id": "deeef2c2-dd75-4719-9288-e8612d67c09f",
+			"name": "Convert to File"
+		},
+		{
+			"parameters": {
+				"assignments": {
+					"assignments": [
+						{
+							"id": "2c5d3b18-1876-49a8-bf71-02cfebf2e5f3",
+							"name": "data",
+							"value": "lorem ipsum",
+							"type": "string"
+						}
+					]
+				},
+				"options": {}
+			},
+			"type": "n8n-nodes-base.set",
+			"typeVersion": 3.4,
+			"position": [-480, 160],
+			"id": "79bf86ea-d10d-4e00-b251-b4126554d993",
+			"name": "Edit Fields"
+		}
+	],
+	"pinData": {
+		"Send a document": [
+			{
+				"json": {
+					"ok": true,
+					"result": {
+						"message_id": 123,
+						"from": {
+							"id": 1234578901,
+							"is_bot": true,
+							"first_name": "TestBot",
+							"username": "TestBot"
+						},
+						"chat": {
+							"id": 987654321,
+							"first_name": "Some",
+							"last_name": "Guy",
+							"username": "SomeGuy",
+							"type": "private"
+						},
+						"date": 1750195377,
+						"document": {
+							"file_name": "file.json",
+							"mime_type": "application/json",
+							"file_id": "BQACAgIAAxkDAANFaFHcsX7_6XEYxKTw3Y93hBKxdPEAAm1_AAJ3NpBKL3xbHXAyvIU2BA",
+							"file_unique_id": "AgADbX8AAnc2kEo",
+							"file_size": 24
+						},
+						"reply_markup": {
+							"inline_keyboard": [
+								[
+									{
+										"text": "Test Button",
+										"callback_data": "123"
+									}
+								]
+							]
+						}
+					}
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking ‘Test workflow’": {
+			"main": [
+				[
+					{
+						"node": "Edit Fields",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Convert to File": {
+			"main": [
+				[
+					{
+						"node": "Send a document",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Edit Fields": {
+			"main": [
+				[
+					{
+						"node": "Convert to File",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "007f0573-7089-4353-9d41-30d705b432ed",
+	"meta": {
+		"templateCredsSetupCompleted": true,
+		"instanceId": "e115be144a6a5547dbfca93e774dfffa178aa94a181854c13e2ce5e14d195b2e"
+	},
+	"id": "6axpOZWb9wBsnrBS",
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Telegram/tests/Workflow/workflow.test.ts
+++ b/packages/nodes-base/nodes/Telegram/tests/Workflow/workflow.test.ts
@@ -13,6 +13,7 @@ import {
 	sendAnimationMessageResponse,
 	sendAudioResponse,
 	getMemberResponse,
+	sendMessageWithBinaryDataAndReplyMarkupResponse,
 } from './apiResponses';
 
 describe('Telegram', () => {
@@ -47,6 +48,17 @@ describe('Telegram', () => {
 			mock.post('/bottestToken/getChatMember').reply(200, getMemberResponse);
 		});
 
-		new NodeTestHarness().setupTests({ credentials });
+		new NodeTestHarness().setupTests({ credentials, workflowFiles: ['workflow.json'] });
+	});
+
+	describe('Binary Data and Reply Markup', () => {
+		beforeAll(() => {
+			const mock = nock(credentials.telegramApi.baseUrl);
+			mock
+				.post('/bottestToken/sendDocument')
+				.reply(200, sendMessageWithBinaryDataAndReplyMarkupResponse);
+		});
+
+		new NodeTestHarness().setupTests({ credentials, workflowFiles: ['binaryData.workflow.json'] });
 	});
 });


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Fix the `source.on is not a function` error when there is a binary file and reply markup option. The issue is that the data for `reply_markup` is an object or an array, which causes problems when passed in the form data (see [this](https://github.com/request/request/issues/2366)). One of the ways to fix this is to `JSON.stringify` the `reply_markup` data

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-2974/community-issue-error-sourceon-is-not-a-function-in-telegram-with
Closes #15380

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
