### PR TITLE
fix(core): Fix pdf extract not working

### DIFF
--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -10,15 +10,21 @@ RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store --moun
 RUN pnpm build
 
 # Delete all dev dependencies
-RUN jq 'del(.pnpm.patchedDependencies)' package.json > package.json.tmp; mv package.json.tmp package.json
 RUN node .github/scripts/trim-fe-packageJson.js
+# We don't want to remove all patches because we want them still to be applied
+# in `pnpm deploy`. However, we need to remove FE patches because we trim the FE
+# package.json files and `pnpm deploy` will fail otherwise. element-plus is the
+# only FE patch that we need to remove.
+RUN jq 'del(.pnpm.patchedDependencies."element-plus@2.4.3")' package.json > package.json.tmp; mv package.json.tmp package.json
 
 # Delete any source code or typings
 RUN find . -type f -name "*.ts" -o -name "*.vue" -o -name "tsconfig.json" -o -name "*.tsbuildinfo" | xargs rm -rf
 
 # Deploy the `n8n` package into /compiled
 RUN mkdir /compiled
-RUN NODE_ENV=production DOCKER_BUILD=true pnpm --filter=n8n --prod --no-optional --legacy deploy /compiled
+# We don't want to use --no-optional because pdfjs-dist has an optional dependency on
+# @napi-rs/canvas, which is required for the pdfjs-dist package to work.
+RUN NODE_ENV=production DOCKER_BUILD=true pnpm --filter=n8n --prod --legacy deploy /compiled
 
 # 2. Start with a new clean image with just the code that is needed to run n8n
 FROM n8nio/base:${NODE_VERSION}

--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -15,7 +15,7 @@ RUN node .github/scripts/trim-fe-packageJson.js
 # in `pnpm deploy`. However, we need to remove FE patches because we trim the FE
 # package.json files and `pnpm deploy` will fail otherwise. element-plus is the
 # only FE patch that we need to remove.
-RUN jq 'del(.pnpm.patchedDependencies."element-plus@2.4.3")' package.json > package.json.tmp; mv package.json.tmp package.json
+RUN jq '.pnpm.patchedDependencies |= with_entries(select(.key | startswith("pdfjs-dist") or startswith("pkce-challenge")))' package.json > package.json.tmp; mv package.json.tmp package.json
 
 # Delete any source code or typings
 RUN find . -type f -name "*.ts" -o -name "*.vue" -o -name "tsconfig.json" -o -name "*.tsbuildinfo" | xargs rm -rf


### PR DESCRIPTION
## Summary

Make sure patches are applied in Docker builds and optional deps are available.

This broke in combination of https://github.com/n8n-io/n8n/pull/14966 and https://github.com/n8n-io/n8n/pull/15729. The issue is:
- Patches were no longer applied because of an issue in https://github.com/n8n-io/n8n/pull/14966
- After https://github.com/n8n-io/n8n/pull/15729 optional dependencies are also required, which were removed in https://github.com/n8n-io/n8n/pull/14966

Including optional dependencies increases the `node_modules` size from `915.5M` to `1.0G`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-956/community-issue-binary-files-broken-in-version-1980-next

Fixes #16281

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
