### PR TITLE
chore(core): Expose owner information for environment changes

### DIFF
--- a/packages/@n8n/api-types/src/schemas/source-controlled-file.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/source-controlled-file.schema.ts
@@ -19,17 +19,11 @@ export const SOURCE_CONTROL_FILE_STATUS = FileStatusSchema.Values;
 const FileLocationSchema = z.enum(['local', 'remote']);
 export const SOURCE_CONTROL_FILE_LOCATION = FileLocationSchema.Values;
 
-const ResourceOwnerSchema = z.discriminatedUnion('type', [
-	z.object({
-		type: z.literal('personal'),
-		personalEmail: z.string(),
-	}),
-	z.object({
-		type: z.literal('team'),
-		teamId: z.string(),
-		teamName: z.string(),
-	}),
-]);
+const ResourceOwnerSchema = z.object({
+	type: z.enum(['personal', 'team']),
+	projectId: z.string(),
+	projectName: z.string(),
+});
 
 export const SourceControlledFileSchema = z.object({
 	file: z.string(),

--- a/packages/@n8n/api-types/src/schemas/source-controlled-file.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/source-controlled-file.schema.ts
@@ -19,6 +19,18 @@ export const SOURCE_CONTROL_FILE_STATUS = FileStatusSchema.Values;
 const FileLocationSchema = z.enum(['local', 'remote']);
 export const SOURCE_CONTROL_FILE_LOCATION = FileLocationSchema.Values;
 
+const ResourceOwnerSchema = z.discriminatedUnion('type', [
+	z.object({
+		type: z.literal('personal'),
+		personalEmail: z.string(),
+	}),
+	z.object({
+		type: z.literal('team'),
+		teamId: z.string(),
+		teamName: z.string(),
+	}),
+]);
+
 export const SourceControlledFileSchema = z.object({
 	file: z.string(),
 	id: z.string(),
@@ -29,6 +41,7 @@ export const SourceControlledFileSchema = z.object({
 	conflict: z.boolean(),
 	updatedAt: z.string(),
 	pushed: z.boolean().optional(),
+	owner: ResourceOwnerSchema.optional(), // Resource owner can be a personal email or team information
 });
 
 export type SourceControlledFile = z.infer<typeof SourceControlledFileSchema>;

--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control-import.service.ee.test.ts
@@ -66,9 +66,14 @@ describe('SourceControlImportService', () => {
 				id: 'workflow1',
 				versionId: 'v1',
 				name: 'Test Workflow',
+				owner: {
+					type: 'personal',
+					personalEmail: 'email@email.com',
+				},
 			};
 
 			fsReadFile.mockResolvedValue(JSON.stringify(mockWorkflowData));
+			sourceControlScopedService.getAdminProjectsFromContext.mockResolvedValueOnce([]);
 
 			const result = await service.getRemoteVersionIdsFromFiles(globalAdminContext);
 			expect(fsReadFile).toHaveBeenCalledWith(mockWorkflowFile, { encoding: 'utf8' });

--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control.service.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control.service.test.ts
@@ -14,7 +14,7 @@ import { SourceControlService } from '@/environments.ee/source-control/source-co
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 
 import type { SourceControlImportService } from '../source-control-import.service.ee';
-import type { ExportableCredential } from '../types/exportable-credential';
+import type { StatusExportableCredential } from '../types/exportable-credential';
 import type { SourceControlWorkflowVersionId } from '../types/source-control-workflow-version-id';
 
 describe('SourceControlService', () => {
@@ -157,7 +157,7 @@ describe('SourceControlService', () => {
 			// Pushing this is conflict free.
 			sourceControlImportService.getRemoteCredentialsFromFiles.mockResolvedValue([]);
 			sourceControlImportService.getLocalCredentialsFromDb.mockResolvedValue([
-				mock<ExportableCredential & { filename: string }>(),
+				mock<StatusExportableCredential>(),
 			]);
 
 			// Define a variable that does only exist locally.

--- a/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
@@ -48,7 +48,6 @@ import type { ResourceOwner } from './types/resource-owner';
 import type { SourceControlContext } from './types/source-control-context';
 import type { SourceControlWorkflowVersionId } from './types/source-control-workflow-version-id';
 import { VariablesService } from '../variables/variables.service.ee';
-import { OwnerController } from '@/controllers/owner.controller';
 
 @Service()
 export class SourceControlImportService {

--- a/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
@@ -329,8 +329,8 @@ export class SourceControlImportService {
 					ownedBy: project
 						? {
 								type: project.type,
-								projectId: project?.id ?? '',
-								projectName: project?.name ?? '',
+								projectId: project.id,
+								projectName: project.name,
 							}
 						: undefined,
 					filename: getCredentialExportPath(remote.id, this.credentialExportFolder),

--- a/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
@@ -41,13 +41,62 @@ import {
 } from './constants';
 import { getCredentialExportPath, getWorkflowExportPath } from './source-control-helper.ee';
 import { SourceControlScopedService } from './source-control-scoped.service';
-import type { ExportableCredential } from './types/exportable-credential';
+import type {
+	ExportableCredential,
+	StatusExportableCredential,
+} from './types/exportable-credential';
 import type { ExportableFolder } from './types/exportable-folders';
 import type { ExportableTags } from './types/exportable-tags';
-import type { ResourceOwner } from './types/resource-owner';
+import type { StatusResourceOwner, RemoteResourceOwner } from './types/resource-owner';
 import type { SourceControlContext } from './types/source-control-context';
 import type { SourceControlWorkflowVersionId } from './types/source-control-workflow-version-id';
 import { VariablesService } from '../variables/variables.service.ee';
+
+const findOwnerProject = (
+	owner: RemoteResourceOwner,
+	accessibleProjects: Project[],
+): Project | undefined => {
+	if (typeof owner === 'string') {
+		return accessibleProjects.find((project) =>
+			project.projectRelations.some((r) => r.user.email === owner),
+		);
+	}
+	if (owner.type === 'personal') {
+		return accessibleProjects.find(
+			(project) =>
+				project.type === 'personal' &&
+				project.projectRelations.some((r) => r.user.email === owner.personalEmail),
+		);
+	}
+	return accessibleProjects.find(
+		(project) => project.type === 'team' && project.id === owner.teamId,
+	);
+};
+
+const getOwnerFromProject = (remoteOwnerProject: Project): StatusResourceOwner | undefined => {
+	let owner: StatusResourceOwner | undefined = undefined;
+
+	if (remoteOwnerProject?.type === 'personal') {
+		const personalEmail = remoteOwnerProject.projectRelations?.find(
+			(r) => r.role === 'project:personalOwner',
+		)?.user?.email;
+
+		if (personalEmail) {
+			owner = {
+				type: 'personal',
+				projectId: remoteOwnerProject.id,
+				projectName: remoteOwnerProject.name,
+			};
+		}
+	} else if (remoteOwnerProject?.type === 'team') {
+		owner = {
+			type: 'team',
+			projectId: remoteOwnerProject.id,
+			projectName: remoteOwnerProject.name,
+		};
+	}
+	return owner;
+};
 
 @Service()
 export class SourceControlImportService {
@@ -109,18 +158,12 @@ export class SourceControlImportService {
 				if (!remote?.id) {
 					return false;
 				}
-				if (Array.isArray(accessibleProjects)) {
-					const owner = remote.owner;
-					// The workflow `remote` belongs not to a project, that the context has access to
-					return (
-						typeof owner === 'object' &&
-						owner?.type === 'team' &&
-						accessibleProjects.some((project) => project.id === owner.teamId)
-					);
-				}
-				return true;
+				return (
+					context.hasAccessToAllProjects() || findOwnerProject(remote.owner, accessibleProjects)
+				);
 			})
 			.map((remote) => {
+				const project = findOwnerProject(remote.owner, accessibleProjects);
 				return {
 					id: remote.id,
 					versionId: remote.versionId ?? '',
@@ -128,7 +171,7 @@ export class SourceControlImportService {
 					parentFolderId: remote.parentFolderId,
 					remoteId: remote.id,
 					filename: getWorkflowExportPath(remote.id, this.workflowExportFolder),
-					owner: remote.owner,
+					owner: project ? getOwnerFromProject(project) : undefined,
 				};
 			});
 
@@ -212,6 +255,7 @@ export class SourceControlImportService {
 			},
 			where: this.sourceControlScopedService.getWorkflowsInAdminProjectsFromContextFilter(context),
 		});
+
 		return localWorkflows.map((local) => {
 			let updatedAt: Date;
 			if (local.updatedAt instanceof Date) {
@@ -227,27 +271,6 @@ export class SourceControlImportService {
 			}
 			const remoteOwnerProject = local.shared?.find((s) => s.role === 'workflow:owner')?.project;
 
-			let owner: ResourceOwner | undefined = undefined;
-
-			if (remoteOwnerProject?.type === 'personal') {
-				const personalEmail = remoteOwnerProject.projectRelations?.find(
-					(r) => r.role === 'project:personalOwner',
-				)?.user?.email;
-
-				if (personalEmail) {
-					owner = {
-						type: 'personal',
-						personalEmail,
-					};
-				}
-			} else if (remoteOwnerProject?.type === 'team') {
-				owner = {
-					type: 'team',
-					teamId: remoteOwnerProject.id,
-					teamName: remoteOwnerProject.name,
-				};
-			}
-
 			return {
 				id: local.id,
 				versionId: local.versionId,
@@ -256,14 +279,14 @@ export class SourceControlImportService {
 				parentFolderId: local.parentFolder?.id ?? null,
 				filename: getWorkflowExportPath(local.id, this.workflowExportFolder),
 				updatedAt: updatedAt.toISOString(),
-				owner,
+				owner: remoteOwnerProject ? getOwnerFromProject(remoteOwnerProject) : undefined,
 			};
 		});
 	}
 
 	async getRemoteCredentialsFromFiles(
 		context: SourceControlContext,
-	): Promise<Array<ExportableCredential & { filename: string }>> {
+	): Promise<StatusExportableCredential[]> {
 		const remoteCredentialFiles = await glob('*.json', {
 			cwd: this.credentialExportFolder,
 			absolute: true,
@@ -287,43 +310,79 @@ export class SourceControlImportService {
 				if (!remote?.id) {
 					return false;
 				}
-				if (Array.isArray(accessibleProjects)) {
-					const owner = remote.ownedBy;
-					// The credential `remote` belongs not to a project, that the context has access to
-					return (
-						typeof owner === 'object' &&
-						owner?.type === 'team' &&
-						accessibleProjects.some((project) => project.id === owner.teamId)
-					);
-				}
-				return true;
+				const owner = remote.ownedBy;
+				// The credential `remote` belongs not to a project, that the context has access to
+				return (
+					!owner || context.hasAccessToAllProjects() || findOwnerProject(owner, accessibleProjects)
+				);
 			})
 			.map((remote) => {
+				const project = remote.ownedBy
+					? findOwnerProject(remote.ownedBy, accessibleProjects)
+					: null;
 				return {
 					...remote,
+					ownedBy: project
+						? {
+								type: project.type,
+								projectId: project?.id ?? '',
+								projectName: project?.name ?? '',
+							}
+						: undefined,
 					filename: getCredentialExportPath(remote.id, this.credentialExportFolder),
 				};
 			});
 
-		return remoteCredentialFilesParsed.filter((e) => e !== undefined) as Array<
-			ExportableCredential & { filename: string }
-		>;
+		return remoteCredentialFilesParsed.filter(
+			(e) => e !== undefined,
+		) as StatusExportableCredential[];
 	}
 
 	async getLocalCredentialsFromDb(
 		context: SourceControlContext,
-	): Promise<Array<ExportableCredential & { filename: string }>> {
+	): Promise<StatusExportableCredential[]> {
 		const localCredentials = await this.credentialsRepository.find({
-			select: ['id', 'name', 'type'],
+			relations: {
+				shared: {
+					project: {
+						projectRelations: {
+							user: true,
+						},
+					},
+				},
+			},
+			select: {
+				id: true,
+				name: true,
+				type: true,
+				shared: {
+					project: {
+						id: true,
+						name: true,
+						type: true,
+						projectRelations: {
+							role: true,
+							user: {
+								email: true,
+							},
+						},
+					},
+					role: true,
+				},
+			},
 			where:
 				this.sourceControlScopedService.getCredentialsInAdminProjectsFromContextFilter(context),
 		});
-		return localCredentials.map((local) => ({
-			id: local.id,
-			name: local.name,
-			type: local.type,
-			filename: getCredentialExportPath(local.id, this.credentialExportFolder),
-		})) as Array<ExportableCredential & { filename: string }>;
+		return localCredentials.map((local) => {
+			const remoteOwnerProject = local.shared?.find((s) => s.role === 'credential:owner')?.project;
+			return {
+				id: local.id,
+				name: local.name,
+				type: local.type,
+				filename: getCredentialExportPath(local.id, this.credentialExportFolder),
+				ownedBy: remoteOwnerProject ? getOwnerFromProject(remoteOwnerProject) : undefined,
+			};
+		}) as StatusExportableCredential[];
 	}
 
 	async getRemoteVariablesFromFile(): Promise<Variables[]> {
@@ -362,11 +421,11 @@ export class SourceControlImportService {
 			const accessibleProjects =
 				await this.sourceControlScopedService.getAdminProjectsFromContext(context);
 
-			if (Array.isArray(accessibleProjects)) {
-				mappedFolders.folders = mappedFolders.folders.filter((folder) =>
+			mappedFolders.folders = mappedFolders.folders.filter(
+				(folder) =>
+					context.hasAccessToAllProjects() ||
 					accessibleProjects.some((project) => project.id === folder.homeProjectId),
-				);
-			}
+			);
 
 			return mappedFolders;
 		}
@@ -842,7 +901,7 @@ export class SourceControlImportService {
 		}
 	}
 
-	private async findOrCreateOwnerProject(owner: ResourceOwner): Promise<Project | null> {
+	private async findOrCreateOwnerProject(owner: RemoteResourceOwner): Promise<Project | null> {
 		if (typeof owner === 'string' || owner.type === 'personal') {
 			const email = typeof owner === 'string' ? owner : owner.personalEmail;
 			const user = await this.userRepository.findOne({
@@ -880,7 +939,7 @@ export class SourceControlImportService {
 
 		assertNever(owner);
 
-		const errorOwner = owner as ResourceOwner;
+		const errorOwner = owner as RemoteResourceOwner;
 		throw new UnexpectedError(
 			`Unknown resource owner type "${
 				typeof errorOwner !== 'string' ? errorOwner.type : 'UNKNOWN'

--- a/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
@@ -235,13 +235,12 @@ export class SourceControlImportService {
 					(r) => r.role === 'project:personalOwner',
 				)?.user.email;
 
-				if (!personalEmail) {
-					throw new UnexpectedError(`Failed to find owner of workflow ${local.name}`);
+				if (personalEmail) {
+					owner = {
+						type: 'personal',
+						personalEmail,
+					};
 				}
-				owner = {
-					type: 'personal',
-					personalEmail,
-				};
 			} else if (remoteOwnerProject?.type === 'team') {
 				owner = {
 					type: 'team',

--- a/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
@@ -58,14 +58,18 @@ const findOwnerProject = (
 ): Project | undefined => {
 	if (typeof owner === 'string') {
 		return accessibleProjects.find((project) =>
-			project.projectRelations.some((r) => r.user.email === owner),
+			project.projectRelations.some(
+				(r) => r.role === 'project:personalOwner' && r.user.email === owner,
+			),
 		);
 	}
 	if (owner.type === 'personal') {
 		return accessibleProjects.find(
 			(project) =>
 				project.type === 'personal' &&
-				project.projectRelations.some((r) => r.user.email === owner.personalEmail),
+				project.projectRelations.some(
+					(r) => r.role === 'project:personalOwner' && r.user.email === owner.personalEmail,
+				),
 		);
 	}
 	return accessibleProjects.find(

--- a/packages/cli/src/environments.ee/source-control/source-control-scoped.service.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-scoped.service.ts
@@ -37,19 +37,28 @@ export class SourceControlScopedService {
 		}
 	}
 
-	async getAdminProjectsFromContext(context: SourceControlContext): Promise<Project[] | undefined> {
+	async getAdminProjectsFromContext(context: SourceControlContext): Promise<Project[]> {
 		if (context.hasAccessToAllProjects()) {
 			// In case the user is a global admin or owner, we don't need a filter
-			return;
+			return await this.projectRepository.find({
+				relations: {
+					projectRelations: {
+						user: true,
+					},
+				},
+			});
 		}
 
 		return await this.projectRepository.find({
 			relations: {
-				projectRelations: true,
+				projectRelations: {
+					user: true,
+				},
 			},
 			select: {
 				id: true,
 				name: true,
+				type: true,
 			},
 			where: this.getAdminProjectsByContextFilter(context),
 		});

--- a/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
@@ -749,7 +749,12 @@ export class SourceControlService {
 				conflict: false,
 				file: item.filename,
 				updatedAt: new Date().toISOString(),
-				owner: item.ownedBy && typeof item.ownedBy === 'object' ? item.ownedBy : undefined,
+				owner:
+					item.ownedBy && typeof item?.ownedBy === 'object'
+						? item.ownedBy
+						: item.ownedBy && typeof item?.ownedBy === 'string'
+							? { type: 'personal', personalEmail: item.ownedBy }
+							: undefined,
 			});
 		});
 
@@ -763,7 +768,12 @@ export class SourceControlService {
 				conflict: options.direction === 'push' ? false : true,
 				file: item.filename,
 				updatedAt: new Date().toISOString(),
-				owner: item.ownedBy && typeof item.ownedBy === 'object' ? item.ownedBy : undefined,
+				owner:
+					item.ownedBy && typeof item?.ownedBy === 'object'
+						? item.ownedBy
+						: item.ownedBy && typeof item?.ownedBy === 'string'
+							? { type: 'personal', personalEmail: item.ownedBy }
+							: undefined,
 			});
 		});
 
@@ -777,7 +787,12 @@ export class SourceControlService {
 				conflict: true,
 				file: item.filename,
 				updatedAt: new Date().toISOString(),
-				owner: item.ownedBy && typeof item.ownedBy === 'object' ? item.ownedBy : undefined,
+				owner:
+					item.ownedBy && typeof item?.ownedBy === 'object'
+						? item.ownedBy
+						: item.ownedBy && typeof item?.ownedBy === 'string'
+							? { type: 'personal', personalEmail: item.ownedBy }
+							: undefined,
 			});
 		});
 		return {

--- a/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
@@ -42,7 +42,7 @@ import {
 } from './source-control-helper.ee';
 import { SourceControlImportService } from './source-control-import.service.ee';
 import { SourceControlPreferencesService } from './source-control-preferences.service.ee';
-import type { ExportableCredential } from './types/exportable-credential';
+import type { StatusExportableCredential } from './types/exportable-credential';
 import type { ExportableFolder } from './types/exportable-folders';
 import type { ImportResult } from './types/import-result';
 import { SourceControlContext } from './types/source-control-context';
@@ -722,11 +722,7 @@ export class SourceControlService {
 		);
 
 		// only compares the name, since that is the only change synced for credentials
-		const credModifiedInEither: Array<
-			ExportableCredential & {
-				filename: string;
-			}
-		> = [];
+		const credModifiedInEither: StatusExportableCredential[] = [];
 		credLocalIds.forEach((local) => {
 			const mismatchingCreds = credRemoteIds.find((remote) => {
 				return remote.id === local.id && (remote.name !== local.name || remote.type !== local.type);
@@ -749,12 +745,7 @@ export class SourceControlService {
 				conflict: false,
 				file: item.filename,
 				updatedAt: new Date().toISOString(),
-				owner:
-					item.ownedBy && typeof item?.ownedBy === 'object'
-						? item.ownedBy
-						: item.ownedBy && typeof item?.ownedBy === 'string'
-							? { type: 'personal', personalEmail: item.ownedBy }
-							: undefined,
+				owner: item.ownedBy,
 			});
 		});
 
@@ -768,12 +759,7 @@ export class SourceControlService {
 				conflict: options.direction === 'push' ? false : true,
 				file: item.filename,
 				updatedAt: new Date().toISOString(),
-				owner:
-					item.ownedBy && typeof item?.ownedBy === 'object'
-						? item.ownedBy
-						: item.ownedBy && typeof item?.ownedBy === 'string'
-							? { type: 'personal', personalEmail: item.ownedBy }
-							: undefined,
+				owner: item.ownedBy,
 			});
 		});
 
@@ -787,12 +773,7 @@ export class SourceControlService {
 				conflict: true,
 				file: item.filename,
 				updatedAt: new Date().toISOString(),
-				owner:
-					item.ownedBy && typeof item?.ownedBy === 'object'
-						? item.ownedBy
-						: item.ownedBy && typeof item?.ownedBy === 'string'
-							? { type: 'personal', personalEmail: item.ownedBy }
-							: undefined,
+				owner: item.ownedBy,
 			});
 		});
 		return {

--- a/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
@@ -663,6 +663,7 @@ export class SourceControlService {
 				conflict: false,
 				file: item.filename,
 				updatedAt: item.updatedAt ?? new Date().toISOString(),
+				owner: item.owner,
 			});
 		});
 
@@ -676,6 +677,7 @@ export class SourceControlService {
 				conflict: options.direction === 'push' ? false : true,
 				file: item.filename,
 				updatedAt: item.updatedAt ?? new Date().toISOString(),
+				owner: item.owner,
 			});
 		});
 
@@ -689,6 +691,7 @@ export class SourceControlService {
 				conflict: true,
 				file: item.filename,
 				updatedAt: item.updatedAt ?? new Date().toISOString(),
+				owner: item.owner,
 			});
 		});
 
@@ -746,6 +749,7 @@ export class SourceControlService {
 				conflict: false,
 				file: item.filename,
 				updatedAt: new Date().toISOString(),
+				owner: item.ownedBy && typeof item.ownedBy === 'object' ? item.ownedBy : undefined,
 			});
 		});
 
@@ -759,6 +763,7 @@ export class SourceControlService {
 				conflict: options.direction === 'push' ? false : true,
 				file: item.filename,
 				updatedAt: new Date().toISOString(),
+				owner: item.ownedBy && typeof item.ownedBy === 'object' ? item.ownedBy : undefined,
 			});
 		});
 
@@ -772,6 +777,7 @@ export class SourceControlService {
 				conflict: true,
 				file: item.filename,
 				updatedAt: new Date().toISOString(),
+				owner: item.ownedBy && typeof item.ownedBy === 'object' ? item.ownedBy : undefined,
 			});
 		});
 		return {

--- a/packages/cli/src/environments.ee/source-control/types/exportable-credential.ts
+++ b/packages/cli/src/environments.ee/source-control/types/exportable-credential.ts
@@ -1,6 +1,6 @@
 import type { ICredentialDataDecryptedObject } from 'n8n-workflow';
 
-import type { ResourceOwner } from './resource-owner';
+import type { RemoteResourceOwner, StatusResourceOwner } from './resource-owner';
 
 export interface ExportableCredential {
 	id: string;
@@ -12,5 +12,10 @@ export interface ExportableCredential {
 	 * Email of the user who owns this credential at the source instance.
 	 * Ownership is mirrored at target instance if user is also present there.
 	 */
-	ownedBy: ResourceOwner | null;
+	ownedBy: RemoteResourceOwner | null;
 }
+
+export type StatusExportableCredential = ExportableCredential & {
+	filename: string;
+	ownedBy?: StatusResourceOwner;
+};

--- a/packages/cli/src/environments.ee/source-control/types/exportable-workflow.ts
+++ b/packages/cli/src/environments.ee/source-control/types/exportable-workflow.ts
@@ -1,6 +1,6 @@
 import type { INode, IConnections, IWorkflowSettings } from 'n8n-workflow';
 
-import type { ResourceOwner } from './resource-owner';
+import type { RemoteResourceOwner } from './resource-owner';
 
 export interface ExportableWorkflow {
 	id: string;
@@ -10,7 +10,7 @@ export interface ExportableWorkflow {
 	settings?: IWorkflowSettings;
 	triggerCount: number;
 	versionId?: string;
-	owner: ResourceOwner;
+	owner: RemoteResourceOwner;
 	parentFolderId: string | null;
 	isArchived: boolean;
 }

--- a/packages/cli/src/environments.ee/source-control/types/resource-owner.ts
+++ b/packages/cli/src/environments.ee/source-control/types/resource-owner.ts
@@ -1,7 +1,9 @@
-export type ResourceOwner =
+export type RemoteResourceOwner =
 	| string
 	| {
 			type: 'personal';
+			projectId?: string; // Optional for retrocompatibility
+			projectName?: string; // Optional for retrocompatibility
 			personalEmail: string;
 	  }
 	| {
@@ -9,3 +11,9 @@ export type ResourceOwner =
 			teamId: string;
 			teamName: string;
 	  };
+
+export type StatusResourceOwner = {
+	type: 'personal' | 'team';
+	projectId: string;
+	projectName: string;
+};

--- a/packages/cli/src/environments.ee/source-control/types/source-control-workflow-version-id.ts
+++ b/packages/cli/src/environments.ee/source-control/types/source-control-workflow-version-id.ts
@@ -1,3 +1,5 @@
+import type { StatusResourceOwner } from './resource-owner';
+
 export interface SourceControlWorkflowVersionId {
 	id: string;
 	versionId: string;
@@ -7,14 +9,5 @@ export interface SourceControlWorkflowVersionId {
 	remoteId?: string;
 	parentFolderId: string | null;
 	updatedAt?: string;
-	owner?:
-		| {
-				type: 'personal';
-				personalEmail: string;
-		  }
-		| {
-				type: 'team';
-				teamId: string;
-				teamName: string;
-		  };
+	owner?: StatusResourceOwner;
 }

--- a/packages/cli/src/environments.ee/source-control/types/source-control-workflow-version-id.ts
+++ b/packages/cli/src/environments.ee/source-control/types/source-control-workflow-version-id.ts
@@ -7,4 +7,14 @@ export interface SourceControlWorkflowVersionId {
 	remoteId?: string;
 	parentFolderId: string | null;
 	updatedAt?: string;
+	owner:
+		| {
+				type: 'personal';
+				personalEmail: string;
+		  }
+		| {
+				type: 'team';
+				teamId: string;
+				teamName: string;
+		  };
 }

--- a/packages/cli/src/environments.ee/source-control/types/source-control-workflow-version-id.ts
+++ b/packages/cli/src/environments.ee/source-control/types/source-control-workflow-version-id.ts
@@ -7,7 +7,7 @@ export interface SourceControlWorkflowVersionId {
 	remoteId?: string;
 	parentFolderId: string | null;
 	updatedAt?: string;
-	owner:
+	owner?:
 		| {
 				type: 'personal';
 				personalEmail: string;

--- a/packages/cli/test/integration/environments/source-control.service.test.ts
+++ b/packages/cli/test/integration/environments/source-control.service.test.ts
@@ -30,7 +30,7 @@ import { SourceControlService } from '@/environments.ee/source-control/source-co
 import type { ExportableCredential } from '@/environments.ee/source-control/types/exportable-credential';
 import type { ExportableFolder } from '@/environments.ee/source-control/types/exportable-folders';
 import type { ExportableWorkflow } from '@/environments.ee/source-control/types/exportable-workflow';
-import type { ResourceOwner } from '@/environments.ee/source-control/types/resource-owner';
+import type { RemoteResourceOwner } from '@/environments.ee/source-control/types/resource-owner';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { EventService } from '@/events/event.service';
@@ -68,7 +68,7 @@ function toExportableCredential(
 	cred: CredentialsEntity,
 	owner: Project | User,
 ): ExportableCredential {
-	let resourceOwner: ResourceOwner;
+	let resourceOwner: RemoteResourceOwner;
 
 	if (owner instanceof Project) {
 		resourceOwner = {
@@ -97,7 +97,7 @@ function toExportableWorkflow(
 	owner: Project | User,
 	versionId?: string,
 ): ExportableWorkflow {
-	let resourceOwner: ResourceOwner;
+	let resourceOwner: RemoteResourceOwner;
 
 	if (owner instanceof Project) {
 		resourceOwner = {


### PR DESCRIPTION
## Summary

Expose owner information for workflow and credential changes for source control

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-2967/allow-filtering-source-controlled-files-by-name-status-and-project

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
