### PR TITLE
fix(MongoDB Atlas Vector Store Node): Old credentials used even after credentials are updated/changed

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreMongoDBAtlas/VectorStoreMongoDBAtlas.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreMongoDBAtlas/VectorStoreMongoDBAtlas.node.test.ts
@@ -19,7 +19,7 @@ describe('VectorStoreMongoDBAtlas -> getMongoClient', () => {
 	const MockMongoClient = MongoClient as jest.MockedClass<typeof MongoClient>;
 
 	beforeEach(() => {
-		jest.clearAllMocks();
+		jest.resetAllMocks();
 		mongoConfig.client = null;
 		mongoConfig.connectionString = '';
 	});

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreMongoDBAtlas/VectorStoreMongoDBAtlas.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreMongoDBAtlas/VectorStoreMongoDBAtlas.node.test.ts
@@ -12,9 +12,11 @@ describe('VectorStoreMongoDBAtlas -> getMongoClient', () => {
 	};
 	const mockClient1 = {
 		connect: jest.fn().mockResolvedValue(undefined),
+		close: jest.fn().mockResolvedValue(undefined),
 	};
 	const mockClient2 = {
 		connect: jest.fn().mockResolvedValue(undefined),
+		close: jest.fn().mockResolvedValue(undefined),
 	};
 	const MockMongoClient = MongoClient as jest.MockedClass<typeof MongoClient>;
 
@@ -38,6 +40,8 @@ describe('VectorStoreMongoDBAtlas -> getMongoClient', () => {
 			appName: 'devrel.integration.n8n_vector_integ',
 		});
 		expect(mockClient1.connect).toHaveBeenCalledTimes(1);
+		expect(mockClient1.close).not.toHaveBeenCalled();
+		expect(mockClient2.connect).not.toHaveBeenCalled();
 		expect(client1).toBe(mockClient1);
 		expect(client2).toBe(mockClient1);
 	});
@@ -65,7 +69,9 @@ describe('VectorStoreMongoDBAtlas -> getMongoClient', () => {
 			appName: 'devrel.integration.n8n_vector_integ',
 		});
 		expect(mockClient1.connect).toHaveBeenCalledTimes(1);
+		expect(mockClient1.close).toHaveBeenCalledTimes(1);
 		expect(mockClient2.connect).toHaveBeenCalledTimes(1);
+		expect(mockClient2.close).not.toHaveBeenCalled();
 		expect(client1).toBe(mockClient1);
 		expect(client2).toBe(mockClient2);
 	});

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreMongoDBAtlas/VectorStoreMongoDBAtlas.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreMongoDBAtlas/VectorStoreMongoDBAtlas.node.test.ts
@@ -1,0 +1,72 @@
+import { MongoClient } from 'mongodb';
+
+import { getMongoClient, mongoConfig } from './VectorStoreMongoDBAtlas.node';
+
+jest.mock('mongodb', () => ({
+	MongoClient: jest.fn(),
+}));
+
+describe('VectorStoreMongoDBAtlas -> getMongoClient', () => {
+	const mockContext = {
+		getCredentials: jest.fn(),
+	};
+	const mockClient1 = {
+		connect: jest.fn().mockResolvedValue(undefined),
+	};
+	const mockClient2 = {
+		connect: jest.fn().mockResolvedValue(undefined),
+	};
+	const MockMongoClient = MongoClient as jest.MockedClass<typeof MongoClient>;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mongoConfig.client = null;
+		mongoConfig.connectionString = '';
+	});
+
+	it('should reuse the same client when connection string is unchanged', async () => {
+		MockMongoClient.mockImplementation(() => mockClient1 as unknown as MongoClient);
+		mockContext.getCredentials.mockResolvedValue({
+			connectionString: 'mongodb://localhost:27017',
+		});
+
+		const client1 = await getMongoClient(mockContext);
+		const client2 = await getMongoClient(mockContext);
+
+		expect(MockMongoClient).toHaveBeenCalledTimes(1);
+		expect(MockMongoClient).toHaveBeenCalledWith('mongodb://localhost:27017', {
+			appName: 'devrel.integration.n8n_vector_integ',
+		});
+		expect(mockClient1.connect).toHaveBeenCalledTimes(1);
+		expect(client1).toBe(mockClient1);
+		expect(client2).toBe(mockClient1);
+	});
+
+	it('should create new client when connection string changes', async () => {
+		MockMongoClient.mockImplementationOnce(
+			() => mockClient1 as unknown as MongoClient,
+		).mockImplementationOnce(() => mockClient2 as unknown as MongoClient);
+		mockContext.getCredentials
+			.mockResolvedValueOnce({
+				connectionString: 'mongodb://localhost:27017',
+			})
+			.mockResolvedValueOnce({
+				connectionString: 'mongodb://different-host:27017',
+			});
+
+		const client1 = await getMongoClient(mockContext);
+		const client2 = await getMongoClient(mockContext);
+
+		expect(MockMongoClient).toHaveBeenCalledTimes(2);
+		expect(MockMongoClient).toHaveBeenNthCalledWith(1, 'mongodb://localhost:27017', {
+			appName: 'devrel.integration.n8n_vector_integ',
+		});
+		expect(MockMongoClient).toHaveBeenNthCalledWith(2, 'mongodb://different-host:27017', {
+			appName: 'devrel.integration.n8n_vector_integ',
+		});
+		expect(mockClient1.connect).toHaveBeenCalledTimes(1);
+		expect(mockClient2.connect).toHaveBeenCalledTimes(1);
+		expect(client1).toBe(mockClient1);
+		expect(client2).toBe(mockClient2);
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreMongoDBAtlas/VectorStoreMongoDBAtlas.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreMongoDBAtlas/VectorStoreMongoDBAtlas.node.ts
@@ -112,6 +112,10 @@ export async function getMongoClient(context: any) {
 	const credentials = await context.getCredentials('mongoDb');
 	const connectionString = credentials.connectionString as string;
 	if (!mongoConfig.client || mongoConfig.connectionString !== connectionString) {
+		if (mongoConfig.client) {
+			await mongoConfig.client.close();
+		}
+
 		mongoConfig.connectionString = connectionString;
 		mongoConfig.client = new MongoClient(connectionString, {
 			appName: 'devrel.integration.n8n_vector_integ',

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreMongoDBAtlas/VectorStoreMongoDBAtlas.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreMongoDBAtlas/VectorStoreMongoDBAtlas.node.ts
@@ -103,17 +103,22 @@ const insertFields: INodeProperties[] = [
 	},
 ];
 
-let mongoClient: MongoClient | null = null;
+const mongoConfig = {
+	client: null as MongoClient | null,
+	connectionString: '',
+};
 
 async function getMongoClient(context: any) {
-	if (!mongoClient) {
-		const credentials = await context.getCredentials('mongoDb');
-		mongoClient = new MongoClient(credentials.connectionString as string, {
+	const credentials = await context.getCredentials('mongoDb');
+	const connectionString = credentials.connectionString as string;
+	if (!mongoConfig.client || mongoConfig.connectionString !== connectionString) {
+		mongoConfig.connectionString = connectionString;
+		mongoConfig.client = new MongoClient(connectionString, {
 			appName: 'devrel.integration.n8n_vector_integ',
 		});
-		await mongoClient.connect();
+		await mongoConfig.client.connect();
 	}
-	return mongoClient;
+	return mongoConfig.client;
 }
 
 async function mongoClientAndDatabase(context: any) {

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreMongoDBAtlas/VectorStoreMongoDBAtlas.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreMongoDBAtlas/VectorStoreMongoDBAtlas.node.ts
@@ -103,12 +103,12 @@ const insertFields: INodeProperties[] = [
 	},
 ];
 
-const mongoConfig = {
+export const mongoConfig = {
 	client: null as MongoClient | null,
 	connectionString: '',
 };
 
-async function getMongoClient(context: any) {
+export async function getMongoClient(context: any) {
 	const credentials = await context.getCredentials('mongoDb');
 	const connectionString = credentials.connectionString as string;
 	if (!mongoConfig.client || mongoConfig.connectionString !== connectionString) {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Update the MongoDB vector store node to recreate the Mongo client every time the connection string has changed. Before the client would get created once and never change, even if the credentials are updated or entirely different credentials are used

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-3120/potential-vulnerability-mongodb-credentials

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
