### PR TITLE
feat(editor): Propagate targetNodeParameterContext throughout expression resolution logic (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/Interface.ts
+++ b/packages/frontend/editor-ui/src/Interface.ts
@@ -1058,6 +1058,11 @@ export interface NDVState {
 	highlightDraggables: boolean;
 }
 
+export type TargetNodeParameterContext = {
+	nodeName: string;
+	parameterPath: string;
+};
+
 export interface NotificationOptions extends Partial<ElementNotificationOptions> {
 	message: string | ElementNotificationOptions['message'];
 }

--- a/packages/frontend/editor-ui/src/components/ExpressionEditorModal/ExpressionEditorModalInput.vue
+++ b/packages/frontend/editor-ui/src/components/ExpressionEditorModal/ExpressionEditorModalInput.vue
@@ -15,10 +15,12 @@ import { removeExpressionPrefix } from '@/utils/expressions';
 import { mappingDropCursor } from '@/plugins/codemirror/dragAndDrop';
 import { editorKeymap } from '@/plugins/codemirror/keymap';
 import { expressionCloseBrackets } from '@/plugins/codemirror/expressionCloseBrackets';
+import type { TargetNodeParameterContext } from '@/Interface';
 
 type Props = {
 	modelValue: string;
 	path: string;
+	targetNodeParameterContext?: TargetNodeParameterContext;
 	isReadOnly?: boolean;
 };
 
@@ -52,7 +54,11 @@ const { segments, readEditorValue, editor, hasFocus, focus } = useExpressionEdit
 	editorValue,
 	extensions,
 	isReadOnly: computed(() => props.isReadOnly),
-	autocompleteTelemetry: { enabled: true, parameterPath: props.path },
+	autocompleteTelemetry: {
+		enabled: true,
+		parameterPath: props.path,
+	},
+	targetNodeParameterContext: props.targetNodeParameterContext,
 });
 
 watch(

--- a/packages/frontend/editor-ui/src/composables/useCodeEditor.ts
+++ b/packages/frontend/editor-ui/src/composables/useCodeEditor.ts
@@ -50,7 +50,11 @@ import {
 } from 'vue';
 import { useCompleter } from '../components/CodeNodeEditor/completer';
 import { mappingDropCursor } from '../plugins/codemirror/dragAndDrop';
-import { languageFacet, type CodeEditorLanguage } from '../plugins/codemirror/format';
+import {
+	languageFacet,
+	type TargetNodeContext,
+	type CodeEditorLanguage,
+} from '../plugins/codemirror/format';
 import debounce from 'lodash/debounce';
 import { ignoreUpdateAnnotation } from '../utils/forceParse';
 
@@ -67,6 +71,7 @@ export const useCodeEditor = <L extends CodeEditorLanguage>({
 	language,
 	languageParams,
 	placeholder,
+	contextNodeName = undefined,
 	extensions = [],
 	isReadOnly = false,
 	theme = {},
@@ -77,6 +82,7 @@ export const useCodeEditor = <L extends CodeEditorLanguage>({
 	language: MaybeRefOrGetter<L>;
 	editorValue?: MaybeRefOrGetter<string>;
 	placeholder?: MaybeRefOrGetter<string>;
+	contextNodeName?: MaybeRefOrGetter<TargetNodeContext>;
 	extensions?: MaybeRefOrGetter<Extension[]>;
 	isReadOnly?: MaybeRefOrGetter<boolean>;
 	theme?: MaybeRefOrGetter<{
@@ -106,7 +112,7 @@ export const useCodeEditor = <L extends CodeEditorLanguage>({
 		const params = toValue(languageParams);
 		return params && 'mode' in params ? params.mode : 'runOnceForAllItems';
 	});
-	const { createWorker: createTsWorker } = useTypescript(editor, mode, id);
+	const { createWorker: createTsWorker } = useTypescript(editor, mode, id, contextNodeName);
 
 	function getInitialLanguageExtensions(lang: CodeEditorLanguage): Extension[] {
 		switch (lang) {

--- a/packages/frontend/editor-ui/src/composables/useCodeEditor.ts
+++ b/packages/frontend/editor-ui/src/composables/useCodeEditor.ts
@@ -50,13 +50,10 @@ import {
 } from 'vue';
 import { useCompleter } from '../components/CodeNodeEditor/completer';
 import { mappingDropCursor } from '../plugins/codemirror/dragAndDrop';
-import {
-	languageFacet,
-	type TargetNodeContext,
-	type CodeEditorLanguage,
-} from '../plugins/codemirror/format';
+import { languageFacet, type CodeEditorLanguage } from '../plugins/codemirror/format';
 import debounce from 'lodash/debounce';
 import { ignoreUpdateAnnotation } from '../utils/forceParse';
+import type { TargetNodeParameterContext } from '@/Interface';
 
 export type CodeEditorLanguageParamsMap = {
 	json: {};
@@ -71,7 +68,7 @@ export const useCodeEditor = <L extends CodeEditorLanguage>({
 	language,
 	languageParams,
 	placeholder,
-	contextNodeName = undefined,
+	targetNodeParameterContext = undefined,
 	extensions = [],
 	isReadOnly = false,
 	theme = {},
@@ -82,7 +79,7 @@ export const useCodeEditor = <L extends CodeEditorLanguage>({
 	language: MaybeRefOrGetter<L>;
 	editorValue?: MaybeRefOrGetter<string>;
 	placeholder?: MaybeRefOrGetter<string>;
-	contextNodeName?: MaybeRefOrGetter<TargetNodeContext>;
+	targetNodeParameterContext?: MaybeRefOrGetter<TargetNodeParameterContext>;
 	extensions?: MaybeRefOrGetter<Extension[]>;
 	isReadOnly?: MaybeRefOrGetter<boolean>;
 	theme?: MaybeRefOrGetter<{

--- a/packages/frontend/editor-ui/src/composables/useCodeEditor.ts
+++ b/packages/frontend/editor-ui/src/composables/useCodeEditor.ts
@@ -109,7 +109,12 @@ export const useCodeEditor = <L extends CodeEditorLanguage>({
 		const params = toValue(languageParams);
 		return params && 'mode' in params ? params.mode : 'runOnceForAllItems';
 	});
-	const { createWorker: createTsWorker } = useTypescript(editor, mode, id, contextNodeName);
+	const { createWorker: createTsWorker } = useTypescript(
+		editor,
+		mode,
+		id,
+		targetNodeParameterContext,
+	);
 
 	function getInitialLanguageExtensions(lang: CodeEditorLanguage): Extension[] {
 		switch (lang) {

--- a/packages/frontend/editor-ui/src/composables/useExpressionEditor.ts
+++ b/packages/frontend/editor-ui/src/composables/useExpressionEditor.ts
@@ -18,7 +18,7 @@ import { Expression, ExpressionExtensions } from 'n8n-workflow';
 import { EXPRESSION_EDITOR_PARSER_TIMEOUT } from '@/constants';
 import { useNDVStore } from '@/stores/ndv.store';
 
-import type { TargetItem } from '@/Interface';
+import type { TargetItem, TargetNodeParameterContext } from '@/Interface';
 import { useWorkflowHelpers } from '@/composables/useWorkflowHelpers';
 import { highlighter } from '@/plugins/codemirror/resolvableHighlighter';
 import { closeCursorInfoBox } from '@/plugins/codemirror/tooltips/InfoBoxTooltip';
@@ -43,7 +43,7 @@ import { ignoreUpdateAnnotation } from '../utils/forceParse';
 export const useExpressionEditor = ({
 	editorRef,
 	editorValue,
-	contextNodeName,
+	targetNodeParameterContext,
 	extensions = [],
 	additionalData = {},
 	skipSegments = [],
@@ -53,7 +53,7 @@ export const useExpressionEditor = ({
 }: {
 	editorRef: MaybeRefOrGetter<HTMLElement | undefined>;
 	editorValue?: MaybeRefOrGetter<string>;
-	contextNodeName?: MaybeRefOrGetter<string>;
+	targetNodeParameterContext?: MaybeRefOrGetter<TargetNodeParameterContext>;
 	extensions?: MaybeRefOrGetter<Extension[]>;
 	additionalData?: MaybeRefOrGetter<IDataObject>;
 	skipSegments?: MaybeRefOrGetter<string[]>;
@@ -307,15 +307,15 @@ export const useExpressionEditor = ({
 		};
 
 		try {
-			if (!ndvStore.activeNode && contextNodeName === undefined) {
+			if (!ndvStore.activeNode && targetNodeParameterContext === undefined) {
 				// e.g. credential modal
 				result.resolved = Expression.resolveWithoutWorkflow(resolvable, toValue(additionalData));
 			} else {
 				let opts: Record<string, unknown> = {
 					additionalKeys: toValue(additionalData),
-					contextNodeName,
+					targetNodeParameterContext,
 				};
-				if (contextNodeName === undefined && ndvStore.isInputParentOfActiveNode) {
+				if (targetNodeParameterContext === undefined && ndvStore.isInputParentOfActiveNode) {
 					opts = {
 						targetItem: target ?? undefined,
 						inputNodeName: ndvStore.ndvInputNodeName,

--- a/packages/frontend/editor-ui/src/composables/useExpressionEditor.ts
+++ b/packages/frontend/editor-ui/src/composables/useExpressionEditor.ts
@@ -43,6 +43,7 @@ import { ignoreUpdateAnnotation } from '../utils/forceParse';
 export const useExpressionEditor = ({
 	editorRef,
 	editorValue,
+	contextNodeName,
 	extensions = [],
 	additionalData = {},
 	skipSegments = [],
@@ -52,6 +53,7 @@ export const useExpressionEditor = ({
 }: {
 	editorRef: MaybeRefOrGetter<HTMLElement | undefined>;
 	editorValue?: MaybeRefOrGetter<string>;
+	contextNodeName?: MaybeRefOrGetter<string>;
 	extensions?: MaybeRefOrGetter<Extension[]>;
 	additionalData?: MaybeRefOrGetter<IDataObject>;
 	skipSegments?: MaybeRefOrGetter<string[]>;
@@ -305,12 +307,15 @@ export const useExpressionEditor = ({
 		};
 
 		try {
-			if (!ndvStore.activeNode) {
+			if (!ndvStore.activeNode && contextNodeName === undefined) {
 				// e.g. credential modal
 				result.resolved = Expression.resolveWithoutWorkflow(resolvable, toValue(additionalData));
 			} else {
-				let opts: Record<string, unknown> = { additionalKeys: toValue(additionalData) };
-				if (ndvStore.isInputParentOfActiveNode) {
+				let opts: Record<string, unknown> = {
+					additionalKeys: toValue(additionalData),
+					contextNodeName,
+				};
+				if (contextNodeName === undefined && ndvStore.isInputParentOfActiveNode) {
 					opts = {
 						targetItem: target ?? undefined,
 						inputNodeName: ndvStore.ndvInputNodeName,

--- a/packages/frontend/editor-ui/src/composables/useExpressionEditor.ts
+++ b/packages/frontend/editor-ui/src/composables/useExpressionEditor.ts
@@ -307,7 +307,7 @@ export const useExpressionEditor = ({
 		};
 
 		try {
-			if (!ndvStore.activeNode && targetNodeParameterContext === undefined) {
+			if (!ndvStore.activeNode && toValue(targetNodeParameterContext) === undefined) {
 				// e.g. credential modal
 				result.resolved = Expression.resolveWithoutWorkflow(resolvable, toValue(additionalData));
 			} else {
@@ -315,7 +315,10 @@ export const useExpressionEditor = ({
 					additionalKeys: toValue(additionalData),
 					targetNodeParameterContext,
 				};
-				if (targetNodeParameterContext === undefined && ndvStore.isInputParentOfActiveNode) {
+				if (
+					toValue(targetNodeParameterContext) === undefined &&
+					ndvStore.isInputParentOfActiveNode
+				) {
 					opts = {
 						targetItem: target ?? undefined,
 						inputNodeName: ndvStore.ndvInputNodeName,

--- a/packages/frontend/editor-ui/src/composables/useResolvedExpression.ts
+++ b/packages/frontend/editor-ui/src/composables/useResolvedExpression.ts
@@ -12,11 +12,13 @@ export function useResolvedExpression({
 	additionalData,
 	isForCredential,
 	stringifyObject,
+	contextNodeName,
 }: {
 	expression: MaybeRefOrGetter<unknown>;
 	additionalData?: MaybeRefOrGetter<IDataObject>;
 	isForCredential?: MaybeRefOrGetter<boolean>;
 	stringifyObject?: MaybeRefOrGetter<boolean>;
+	contextNodeName?: MaybeRefOrGetter<string>;
 }) {
 	const ndvStore = useNDVStore();
 	const workflowsStore = useWorkflowsStore();
@@ -45,9 +47,10 @@ export function useResolvedExpression({
 		let options: ResolveParameterOptions = {
 			isForCredential: toValue(isForCredential),
 			additionalKeys: toValue(additionalData),
+			contextNodeName: toValue(contextNodeName),
 		};
 
-		if (ndvStore.isInputParentOfActiveNode) {
+		if (contextNodeName === undefined && ndvStore.isInputParentOfActiveNode) {
 			options = {
 				...options,
 				targetItem: targetItem.value ?? undefined,

--- a/packages/frontend/editor-ui/src/plugins/codemirror/completions/blank.completions.ts
+++ b/packages/frontend/editor-ui/src/plugins/codemirror/completions/blank.completions.ts
@@ -18,7 +18,7 @@ export function blankCompletions(context: CompletionContext): CompletionResult |
 
 	return {
 		from: word.to,
-		options: dollarOptions().map(stripExcessParens(context)),
+		options: dollarOptions(context).map(stripExcessParens(context)),
 		filter: false,
 	};
 }

--- a/packages/frontend/editor-ui/src/plugins/codemirror/completions/completions.test.ts
+++ b/packages/frontend/editor-ui/src/plugins/codemirror/completions/completions.test.ts
@@ -3,7 +3,6 @@ import { setActivePinia } from 'pinia';
 import { DateTime } from 'luxon';
 
 import * as workflowHelpers from '@/composables/useWorkflowHelpers';
-import { dollarOptions } from '@/plugins/codemirror/completions/dollar.completions';
 import * as utils from '@/plugins/codemirror/completions/utils';
 import {
 	extensions,
@@ -62,7 +61,7 @@ describe('No completions', () => {
 describe('Top-level completions', () => {
 	test('should return dollar completions for blank position: {{ | }}', () => {
 		const result = completions('{{ | }}');
-		expect(result).toHaveLength(dollarOptions().length);
+		expect(result).toHaveLength(18);
 
 		expect(result?.[0]).toEqual(
 			expect.objectContaining({
@@ -109,7 +108,7 @@ describe('Top-level completions', () => {
 	});
 
 	test('should return dollar completions for: {{ $| }}', () => {
-		expect(completions('{{ $| }}')).toHaveLength(dollarOptions().length);
+		expect(completions('{{ $| }}')).toHaveLength(18);
 	});
 
 	test('should return node selector completions for: {{ $(| }}', () => {

--- a/packages/frontend/editor-ui/src/plugins/codemirror/completions/constants.ts
+++ b/packages/frontend/editor-ui/src/plugins/codemirror/completions/constants.ts
@@ -2,6 +2,8 @@ import type { Completion, CompletionSection } from '@codemirror/autocomplete';
 import { i18n } from '@n8n/i18n';
 import { withSectionHeader } from './utils';
 import { createInfoBoxRenderer } from './infoBoxRenderer';
+import { Facet } from '@codemirror/state';
+import type { TargetNodeParameterContext } from '@/Interface';
 
 export const FIELDS_SECTION: CompletionSection = withSectionHeader({
 	name: i18n.baseText('codeNodeEditor.completer.section.fields'),
@@ -436,3 +438,10 @@ export const STRING_SECTIONS: Record<string, CompletionSection> = {
 		rank: 5,
 	}),
 };
+
+export const TARGET_NODE_PARAMETER_FACET = Facet.define<
+	TargetNodeParameterContext | undefined,
+	TargetNodeParameterContext | undefined
+>({
+	combine: (values) => values[0],
+});

--- a/packages/frontend/editor-ui/src/plugins/codemirror/completions/dollar.completions.ts
+++ b/packages/frontend/editor-ui/src/plugins/codemirror/completions/dollar.completions.ts
@@ -20,6 +20,7 @@ import {
 	ROOT_DOLLAR_COMPLETIONS,
 } from './constants';
 import { createInfoBoxRenderer } from './infoBoxRenderer';
+import { targetNodeFacet } from '../format';
 
 /**
  * Completions offered at the dollar position: `$|`
@@ -31,7 +32,7 @@ export function dollarCompletions(context: CompletionContext): CompletionResult 
 
 	if (word.from === word.to && !context.explicit) return null;
 
-	let options = dollarOptions().map(stripExcessParens(context));
+	let options = dollarOptions(context).map(stripExcessParens(context));
 
 	const userInput = word.text;
 
@@ -53,7 +54,7 @@ export function dollarCompletions(context: CompletionContext): CompletionResult 
 	};
 }
 
-export function dollarOptions(): Completion[] {
+export function dollarOptions(context: CompletionContext): Completion[] {
 	const SKIP = new Set();
 	let recommendedCompletions: Completion[] = [];
 
@@ -117,11 +118,13 @@ export function dollarOptions(): Completion[] {
 			: [];
 	}
 
-	if (!hasActiveNode()) {
+	const targetNodeContext = context.state.facet(targetNodeFacet);
+
+	if (!hasActiveNode(targetNodeContext)) {
 		return [];
 	}
 
-	if (receivesNoBinaryData()) SKIP.add('$binary');
+	if (receivesNoBinaryData(targetNodeContext?.nodeName)) SKIP.add('$binary');
 
 	const previousNodesCompletions = autocompletableNodeNames().map((nodeName) => {
 		const label = `$('${escapeMappingString(nodeName)}')`;

--- a/packages/frontend/editor-ui/src/plugins/codemirror/completions/dollar.completions.ts
+++ b/packages/frontend/editor-ui/src/plugins/codemirror/completions/dollar.completions.ts
@@ -18,9 +18,9 @@ import {
 	PREVIOUS_NODES_SECTION,
 	RECOMMENDED_SECTION,
 	ROOT_DOLLAR_COMPLETIONS,
+	TARGET_NODE_PARAMETER_FACET,
 } from './constants';
 import { createInfoBoxRenderer } from './infoBoxRenderer';
-import { targetNodeFacet } from '../format';
 
 /**
  * Completions offered at the dollar position: `$|`
@@ -118,13 +118,13 @@ export function dollarOptions(context: CompletionContext): Completion[] {
 			: [];
 	}
 
-	const targetNodeContext = context.state.facet(targetNodeFacet);
+	const targetNodeParameterContext = context.state.facet(TARGET_NODE_PARAMETER_FACET);
 
-	if (!hasActiveNode(targetNodeContext)) {
+	if (!hasActiveNode(targetNodeParameterContext)) {
 		return [];
 	}
 
-	if (receivesNoBinaryData(targetNodeContext?.nodeName)) SKIP.add('$binary');
+	if (receivesNoBinaryData(targetNodeParameterContext?.nodeName)) SKIP.add('$binary');
 
 	const previousNodesCompletions = autocompletableNodeNames().map((nodeName) => {
 		const label = `$('${escapeMappingString(nodeName)}')`;

--- a/packages/frontend/editor-ui/src/plugins/codemirror/completions/utils.ts
+++ b/packages/frontend/editor-ui/src/plugins/codemirror/completions/utils.ts
@@ -19,7 +19,7 @@ import { EditorSelection, type TransactionSpec } from '@codemirror/state';
 import type { SyntaxNode, Tree } from '@lezer/common';
 import type { DocMetadata } from 'n8n-workflow';
 import { escapeMappingString } from '@/utils/mappingUtils';
-import { TargetNodeContext } from '../format';
+import type { TargetNodeParameterContext } from '@/Interface';
 
 /**
  * Split user input into base (to resolve) and tail (to filter).
@@ -192,12 +192,12 @@ export function resolveAutocompleteExpression(expression: string, contextNodeNam
 
 export const isCredentialsModalOpen = () => useUIStore().modalsById[CREDENTIAL_EDIT_MODAL_KEY].open;
 
-export const isInHttpNodePagination = (targetNodeContext?: TargetNodeContext) => {
+export const isInHttpNodePagination = (targetNodeParameterContext?: TargetNodeParameterContext) => {
 	let nodeType: string | undefined;
 	let path: string;
-	if (targetNodeContext) {
-		nodeType = targetNodeContext.nodeName;
-		path = targetNodeContext.parameterPath;
+	if (targetNodeParameterContext) {
+		nodeType = targetNodeParameterContext.nodeName;
+		path = targetNodeParameterContext.parameterPath;
 	} else {
 		const ndvStore = useNDVStore();
 		nodeType = ndvStore.activeNode?.type;
@@ -207,9 +207,9 @@ export const isInHttpNodePagination = (targetNodeContext?: TargetNodeContext) =>
 	return nodeType === HTTP_REQUEST_NODE_TYPE && path.startsWith('parameters.options.pagination');
 };
 
-export const hasActiveNode = (targetNodeContext?: TargetNodeContext) =>
-	(targetNodeContext !== undefined &&
-		useWorkflowsStore().getNodeByName(targetNodeContext.nodeName) !== null) ||
+export const hasActiveNode = (targetNodeParameterContext?: TargetNodeParameterContext) =>
+	(targetNodeParameterContext !== undefined &&
+		useWorkflowsStore().getNodeByName(targetNodeParameterContext.nodeName) !== null) ||
 	useNDVStore().activeNode?.name !== undefined;
 
 export const isSplitInBatchesAbsent = () =>

--- a/packages/frontend/editor-ui/src/plugins/codemirror/completions/utils.ts
+++ b/packages/frontend/editor-ui/src/plugins/codemirror/completions/utils.ts
@@ -19,6 +19,7 @@ import { EditorSelection, type TransactionSpec } from '@codemirror/state';
 import type { SyntaxNode, Tree } from '@lezer/common';
 import type { DocMetadata } from 'n8n-workflow';
 import { escapeMappingString } from '@/utils/mappingUtils';
+import { TargetNodeContext } from '../format';
 
 /**
  * Split user input into base (to resolve) and tail (to filter).
@@ -144,19 +145,19 @@ export const isAllowedInDotNotation = (str: string) => {
 //      resolution-based utils
 // ----------------------------------
 
-export function receivesNoBinaryData() {
+export function receivesNoBinaryData(contextNodeName?: string) {
 	try {
-		return resolveAutocompleteExpression('={{ $binary }}')?.data === undefined;
+		return resolveAutocompleteExpression('={{ $binary }}', contextNodeName)?.data === undefined;
 	} catch {
 		return true;
 	}
 }
 
-export function hasNoParams(toResolve: string) {
+export function hasNoParams(toResolve: string, contextNodeName?: string) {
 	let params;
 
 	try {
-		params = resolveAutocompleteExpression(`={{ ${toResolve}.params }}`);
+		params = resolveAutocompleteExpression(`={{ ${toResolve}.params }}`, contextNodeName);
 	} catch {
 		return true;
 	}
@@ -168,19 +169,21 @@ export function hasNoParams(toResolve: string) {
 	return paramKeys.length === 1 && isPseudoParam(paramKeys[0]);
 }
 
-export function resolveAutocompleteExpression(expression: string) {
+export function resolveAutocompleteExpression(expression: string, contextNodeName?: string) {
 	const ndvStore = useNDVStore();
-	return resolveParameter(
-		expression,
-		ndvStore.isInputParentOfActiveNode
+	const inputData =
+		contextNodeName === undefined && ndvStore.isInputParentOfActiveNode
 			? {
 					targetItem: ndvStore.expressionTargetItem ?? undefined,
 					inputNodeName: ndvStore.ndvInputNodeName,
 					inputRunIndex: ndvStore.ndvInputRunIndex,
 					inputBranchIndex: ndvStore.ndvInputBranchIndex,
 				}
-			: {},
-	);
+			: {};
+	return resolveParameter(expression, {
+		...inputData,
+		contextNodeName,
+	});
 }
 
 // ----------------------------------
@@ -189,21 +192,34 @@ export function resolveAutocompleteExpression(expression: string) {
 
 export const isCredentialsModalOpen = () => useUIStore().modalsById[CREDENTIAL_EDIT_MODAL_KEY].open;
 
-export const isInHttpNodePagination = () => {
-	const ndvStore = useNDVStore();
-	return (
-		ndvStore.activeNode?.type === HTTP_REQUEST_NODE_TYPE &&
-		ndvStore.focusedInputPath.startsWith('parameters.options.pagination')
-	);
+export const isInHttpNodePagination = (targetNodeContext?: TargetNodeContext) => {
+	let nodeType: string | undefined;
+	let path: string;
+	if (targetNodeContext) {
+		nodeType = targetNodeContext.nodeName;
+		path = targetNodeContext.parameterPath;
+	} else {
+		const ndvStore = useNDVStore();
+		nodeType = ndvStore.activeNode?.type;
+		path = ndvStore.focusedInputPath;
+	}
+
+	return nodeType === HTTP_REQUEST_NODE_TYPE && path.startsWith('parameters.options.pagination');
 };
 
-export const hasActiveNode = () => useNDVStore().activeNode?.name !== undefined;
+export const hasActiveNode = (targetNodeContext?: TargetNodeContext) =>
+	(targetNodeContext !== undefined &&
+		useWorkflowsStore().getNodeByName(targetNodeContext.nodeName) !== null) ||
+	useNDVStore().activeNode?.name !== undefined;
 
 export const isSplitInBatchesAbsent = () =>
 	!useWorkflowsStore().workflow.nodes.some((node) => node.type === SPLIT_IN_BATCHES_NODE_TYPE);
 
-export function autocompletableNodeNames() {
-	const activeNode = useNDVStore().activeNode;
+export function autocompletableNodeNames(contextNodeName?: string) {
+	const activeNode =
+		contextNodeName === undefined
+			? useNDVStore().activeNode
+			: useWorkflowsStore().getNodeByName(contextNodeName);
 
 	if (!activeNode) return [];
 

--- a/packages/frontend/editor-ui/src/plugins/codemirror/format.ts
+++ b/packages/frontend/editor-ui/src/plugins/codemirror/format.ts
@@ -10,18 +10,6 @@ export const languageFacet = Facet.define<CodeEditorLanguage, CodeEditorLanguage
 	combine: (values) => values[0] ?? 'javaScript',
 });
 
-export type TargetNodeContext = {
-	parameterPath: string;
-	nodeName: string;
-};
-
-export const targetNodeFacet = Facet.define<
-	TargetNodeContext | undefined,
-	TargetNodeContext | undefined
->({
-	combine: (values) => values[0],
-});
-
 export function formatDocument(view: EditorView) {
 	function format(parser: BuiltInParserName) {
 		void formatWithCursor(view.state.doc.toString(), {

--- a/packages/frontend/editor-ui/src/plugins/codemirror/format.ts
+++ b/packages/frontend/editor-ui/src/plugins/codemirror/format.ts
@@ -10,6 +10,18 @@ export const languageFacet = Facet.define<CodeEditorLanguage, CodeEditorLanguage
 	combine: (values) => values[0] ?? 'javaScript',
 });
 
+export type TargetNodeContext = {
+	parameterPath: string;
+	nodeName: string;
+};
+
+export const targetNodeFacet = Facet.define<
+	TargetNodeContext | undefined,
+	TargetNodeContext | undefined
+>({
+	combine: (values) => values[0],
+});
+
 export function formatDocument(view: EditorView) {
 	function format(parser: BuiltInParserName) {
 		void formatWithCursor(view.state.doc.toString(), {

--- a/packages/frontend/editor-ui/src/plugins/codemirror/typescript/client/useTypescript.ts
+++ b/packages/frontend/editor-ui/src/plugins/codemirror/typescript/client/useTypescript.ts
@@ -21,19 +21,20 @@ import { typescriptWorkerFacet } from './facet';
 import { typescriptHoverTooltips } from './hoverTooltip';
 import { linter } from '@codemirror/lint';
 import { typescriptLintSource } from './linter';
-import { targetNodeFacet, type TargetNodeContext } from '../../format';
+import type { TargetNodeParameterContext } from '@/Interface';
+import { TARGET_NODE_PARAMETER_FACET } from '../../completions/constants';
 
 export function useTypescript(
 	view: MaybeRefOrGetter<EditorView | undefined>,
 	mode: MaybeRefOrGetter<CodeExecutionMode>,
 	id: MaybeRefOrGetter<string>,
-	targetNodeContext?: MaybeRefOrGetter<TargetNodeContext>,
+	targetNodeParameterContext?: MaybeRefOrGetter<TargetNodeParameterContext>,
 ) {
 	const { getInputDataWithPinned, getSchemaForExecutionData } = useDataSchema();
 	const ndvStore = useNDVStore();
 	const workflowsStore = useWorkflowsStore();
 	const { debounce } = useDebounce();
-	const activeNodeName = toValue(targetNodeContext)?.nodeName ?? ndvStore.activeNodeName;
+	const activeNodeName = toValue(targetNodeParameterContext)?.nodeName ?? ndvStore.activeNodeName;
 	const worker = ref<Comlink.Remote<LanguageServiceWorker>>();
 	const webWorker = ref<Worker>();
 
@@ -66,7 +67,7 @@ export function useTypescript(
 						.getBinaryData(
 							execution?.data?.resultData?.runData ?? null,
 							node.name,
-							contextNodeName === undefined ? (ndvStore.ndvInputRunIndex ?? 0) : 0,
+							targetNodeParameterContext === undefined ? (ndvStore.ndvInputRunIndex ?? 0) : 0,
 							0,
 						)
 						.filter((data) => Boolean(data && Object.keys(data).length));
@@ -90,7 +91,7 @@ export function useTypescript(
 
 		return [
 			typescriptWorkerFacet.of({ worker: worker.value }),
-			targetNodeFacet.of(toValue(targetNodeContext)),
+			TARGET_NODE_PARAMETER_FACET.of(toValue(targetNodeParameterContext)),
 			new LanguageSupport(javascriptLanguage, [
 				javascriptLanguage.data.of({ autocomplete: typescriptCompletionSource }),
 			]),

--- a/packages/frontend/editor-ui/src/plugins/codemirror/typescript/client/useTypescript.ts
+++ b/packages/frontend/editor-ui/src/plugins/codemirror/typescript/client/useTypescript.ts
@@ -21,17 +21,19 @@ import { typescriptWorkerFacet } from './facet';
 import { typescriptHoverTooltips } from './hoverTooltip';
 import { linter } from '@codemirror/lint';
 import { typescriptLintSource } from './linter';
+import { targetNodeFacet, type TargetNodeContext } from '../../format';
 
 export function useTypescript(
 	view: MaybeRefOrGetter<EditorView | undefined>,
 	mode: MaybeRefOrGetter<CodeExecutionMode>,
 	id: MaybeRefOrGetter<string>,
+	targetNodeContext?: MaybeRefOrGetter<TargetNodeContext>,
 ) {
 	const { getInputDataWithPinned, getSchemaForExecutionData } = useDataSchema();
 	const ndvStore = useNDVStore();
 	const workflowsStore = useWorkflowsStore();
 	const { debounce } = useDebounce();
-	const activeNodeName = ndvStore.activeNodeName;
+	const activeNodeName = toValue(targetNodeContext)?.nodeName ?? ndvStore.activeNodeName;
 	const worker = ref<Comlink.Remote<LanguageServiceWorker>>();
 	const webWorker = ref<Worker>();
 
@@ -64,7 +66,7 @@ export function useTypescript(
 						.getBinaryData(
 							execution?.data?.resultData?.runData ?? null,
 							node.name,
-							ndvStore.ndvInputRunIndex ?? 0,
+							contextNodeName === undefined ? (ndvStore.ndvInputRunIndex ?? 0) : 0,
 							0,
 						)
 						.filter((data) => Boolean(data && Object.keys(data).length));
@@ -88,6 +90,7 @@ export function useTypescript(
 
 		return [
 			typescriptWorkerFacet.of({ worker: worker.value }),
+			targetNodeFacet.of(toValue(targetNodeContext)),
 			new LanguageSupport(javascriptLanguage, [
 				javascriptLanguage.data.of({ autocomplete: typescriptCompletionSource }),
 			]),

--- a/packages/frontend/editor-ui/src/plugins/codemirror/typescript/client/useTypescript.ts
+++ b/packages/frontend/editor-ui/src/plugins/codemirror/typescript/client/useTypescript.ts
@@ -67,7 +67,9 @@ export function useTypescript(
 						.getBinaryData(
 							execution?.data?.resultData?.runData ?? null,
 							node.name,
-							targetNodeParameterContext === undefined ? (ndvStore.ndvInputRunIndex ?? 0) : 0,
+							toValue(targetNodeParameterContext) === undefined
+								? (ndvStore.ndvInputRunIndex ?? 0)
+								: 0,
 							0,
 						)
 						.filter((data) => Boolean(data && Object.keys(data).length));


### PR DESCRIPTION
## Summary

Groundwork for autocomplete and expression evaluation to work in ExpressionEditors and Code blocks when rendered outside of an NDV-based context.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3683/feature-refactor-activenode-out-of-expression-composables-and


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
