### PR TITLE
fix(editor): Recommend Simple Vector Store even if WF has no AI nodes

### DIFF
--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/composables/useViewStacks.ts
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/composables/useViewStacks.ts
@@ -241,8 +241,12 @@ export const useViewStacks = defineStore('nodeCreatorViewStacks', () => {
 	) {
 		const aiNodes = items.filter((node): node is NodeCreateElement => isAINode(node));
 		const canvasHasAINodes = useCanvasStore().aiNodes.length > 0;
+		const isVectorStoresCategory = stackCategory === AI_CATEGORY_VECTOR_STORES;
 
-		if (aiNodes.length > 0 && (canvasHasAINodes || isAiRootView(getLastActiveStack()))) {
+		if (
+			aiNodes.length > 0 &&
+			(canvasHasAINodes || isAiRootView(getLastActiveStack()) || isVectorStoresCategory)
+		) {
 			const sectionsMap = new Map<string, NodeViewItemSection>();
 			const aiRootNodes = filterAiRootNodes(aiNodes);
 			const aiSubNodes = difference(aiNodes, aiRootNodes);


### PR DESCRIPTION
## Summary

Earlier we tried to make Simple Vector Store show up as recommended on Node creator panel, but it was missed that the logic behaves differently if current workflow has no AI nodes.

Add one more piece of spaghetti to this logic to make it show up also on the node creator when navigating `AI -> Other AI nodes -> Vector Stores` on a WF with no AI nodes on it.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3727/fix-simple-vector-store-grouping-if-workflow-has-no-ai-nodes

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
