### PR TITLE
docs: Update README nodes-langchain removing beta copy.md

### DIFF
--- a/packages/@n8n/nodes-langchain/README.md
+++ b/packages/@n8n/nodes-langchain/README.md
@@ -4,8 +4,6 @@
 
 This repo contains nodes to use n8n in combination with [LangChain](https://langchain.com/).
 
-These nodes are still in Beta state and are only compatible with the Docker image `docker.n8n.io/n8nio/n8n:ai-beta`.
-
 ## License
 
 You can find the license information [here](https://github.com/n8n-io/n8n/blob/master/README.md#license)


### PR DESCRIPTION
It was originally speaking about only working for a specific docker image

## Summary
Original readme contained this line: These nodes are still in Beta state and are only compatible with the Docker image docker.n8n.io/n8nio/n8n:ai-beta.

So I removed it as this is not true
<img width="961" alt="Screenshot 2025-06-20 at 08 57 04" src="https://github.com/user-attachments/assets/a72225d9-2e42-406c-ae5b-787371bc39e2" />


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
