### PR TITLE
fix(core): Add Dingbat emojis to expressions grammar

### DIFF
--- a/packages/@n8n/codemirror-lang/src/expressions/expressions.grammar
+++ b/packages/@n8n/codemirror-lang/src/expressions/expressions.grammar
@@ -15,7 +15,7 @@ entity { Plaintext | Resolvable }
 
   resolvableChar { unicodeChar | "}" ![}] | "\\}}" }
 
-  unicodeChar { $[\u0000-\u007C] | $[\u007E-\u20CF] | $[\u{1F300}-\u{1FAF8}] | $[\u4E00-\u9FFF] }
+  unicodeChar { $[\u0000-\u007C] | $[\u007E-\u20CF] | $[\u2700-\u27BF] | $[\u{1F300}-\u{1FAF8}] | $[\u4E00-\u9FFF] }
 }
 
 @detectDelim

--- a/packages/@n8n/codemirror-lang/src/expressions/grammar.ts
+++ b/packages/@n8n/codemirror-lang/src/expressions/grammar.ts
@@ -10,7 +10,7 @@ export const parser = LRParser.deserialize({
 	skippedNodes: [0],
 	repeatNodeCount: 1,
 	tokenData:
-		"&_~RTO#ob#o#p!h#p;'Sb;'S;=`!]<%lOb~gTQ~O#ob#o#pv#p;'Sb;'S;=`!]<%lOb~yUO#ob#p;'Sb;'S;=`!]<%l~b~Ob~~!c~!`P;=`<%lb~!hOQ~~!kVO#ob#o#p#Q#p;'Sb;'S;=`!]<%l~b~Ob~~!c~#TXO#O#Q#O#P#p#P#q#Q#q#r%d#r$Ml#Q*5S41d#Q;(b;(c&R;(c;(d%{;(d;(e&X~#sXO#O#Q#O#P#p#P#q#Q#q#r$`#r$Ml#Q*5S41d#Q;(b;(c&R;(c;(d%{;(d;(e&X~$cTO#q#Q#q#r$r#r;'S#Q;'S;=`%{<%lO#Q~$wXR~O#O#Q#O#P#p#P#q#Q#q#r%d#r$Ml#Q*5S41d#Q;(b;(c&R;(c;(d%{;(d;(e&X~%gTO#q#Q#q#r%v#r;'S#Q;'S;=`%{<%lO#Q~%{OR~~&OP;=`<%l#Q~&UP;NQ<%l#Q~&[P;=`;My#Q",
+		"&h~RTO#ob#o#p!h#p;'Sb;'S;=`!]<%lOb~gTQ~O#ob#o#pv#p;'Sb;'S;=`!]<%lOb~yUO#ob#p;'Sb;'S;=`!]<%l~b~Ob~~!c~!`P;=`<%lb~!hOQ~~!kVO#ob#o#p#Q#p;'Sb;'S;=`!]<%l~b~Ob~~!c~#TYO#O#Q#O#P#s#P#q#Q#q#r%m#r$Ml#Q%BQ%FY#Q*5S41d#Q;(b;(c&[;(c;(d&U;(d;(e&b~#vYO#O#Q#O#P#s#P#q#Q#q#r$f#r$Ml#Q%BQ%FY#Q*5S41d#Q;(b;(c&[;(c;(d&U;(d;(e&b~$iTO#q#Q#q#r$x#r;'S#Q;'S;=`&U<%lO#Q~$}YR~O#O#Q#O#P#s#P#q#Q#q#r%m#r$Ml#Q%BQ%FY#Q*5S41d#Q;(b;(c&[;(c;(d&U;(d;(e&b~%pTO#q#Q#q#r&P#r;'S#Q;'S;=`&U<%lO#Q~&UOR~~&XP;=`<%l#Q~&_P;NQ<%l#Q~&eP;=`;My#Q",
 	tokenizers: [0],
 	topRules: { Program: [0, 1] },
 	tokenPrec: 0,

--- a/packages/@n8n/codemirror-lang/test/expressions/cases.txt
+++ b/packages/@n8n/codemirror-lang/test/expressions/cases.txt
@@ -293,3 +293,19 @@ Program(Resolvable)
 ==>
 
 Program(Resolvable)
+
+# Resolvable with start of Dingbat range - U+2700
+
+{{ '✀' }}
+
+==>
+
+Program(Resolvable)
+
+# Resolvable with end of Dingbat range - U+27BF
+
+{{ '➿' }}
+
+==>
+
+Program(Resolvable)


### PR DESCRIPTION
## Summary

Add Dingbat emojis to expressions grammar. Allows ❌ ✅ etc. to work as expected.

See: [Dingbats unicode code points](https://symbl.cc/en/unicode-table/#dingbats)

## Related Linear tickets, Github issues, and Community forum posts

Fixes: #16498 
Fixes: PAY-2971

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- ~[ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- ~[ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
