### PR TITLE
fix(core): Show correct error messages when nodes can't be used in an expression

### DIFF
--- a/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
@@ -519,7 +519,7 @@ describe('WorkflowExecute', () => {
 		// ┌───────┐1     ┌─────┐1     ┌─────┐
 		// │trigger├──────►node1├──────►node2│
 		// └───────┘      └─────┘      └─────┘
-		test('removes disabled nodes from the workflow', async () => {
+		test('removes disabled nodes from the runNodeFilter, but not the graph', async () => {
 			// ARRANGE
 			const waitPromise = createDeferredPromise<IRun>();
 			const additionalData = Helpers.WorkflowExecuteAdditionalData(waitPromise);
@@ -555,11 +555,17 @@ describe('WorkflowExecute', () => {
 			);
 
 			// ASSERT
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const runNodeFilter: string[] = (workflowExecute as any).runExecutionData.startData
+				?.runNodeFilter;
+			expect(runNodeFilter).toContain(trigger.name);
+			expect(runNodeFilter).toContain(node2.name);
+			expect(runNodeFilter).not.toContain(node1.name);
 			expect(processRunExecutionDataSpy).toHaveBeenCalledTimes(1);
 			const nodes = Object.keys(processRunExecutionDataSpy.mock.calls[0][0].nodes);
 			expect(nodes).toContain(trigger.name);
 			expect(nodes).toContain(node2.name);
-			expect(nodes).not.toContain(node1.name);
+			expect(nodes).toContain(node1.name);
 		});
 
 		//                             ►►

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -473,7 +473,11 @@ export class WorkflowExecute {
 			},
 		};
 
-		return this.processRunExecutionData(graph.toWorkflow({ ...workflow }));
+		// Still passing the original workflow here, because the WorkflowDataProxy
+		// needs it to create more useful error messages, e.g. differentiate
+		// between a node not being connected to the node referencing it or a node
+		// not existing in the workflow.
+		return this.processRunExecutionData(workflow);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Because partial executions trim the workflow down to only the nodes that connect the trigger and the destination node the `WorkflowDataProxy` can't differentiate between nodes that are not connected to the node referencing them and nodes that simply don't exist.

Take this workflow as an example:
![image](https://github.com/user-attachments/assets/8af741d3-74ae-4a9f-9a91-a25bf3f33d80)

For the orphaned node:
 

https://github.com/user-attachments/assets/bc9e46f9-1418-4d2f-9a7c-7e3498b9fe1e

For the child node:

https://github.com/user-attachments/assets/dc387c18-79a1-4f07-8f56-9f0cebfeb0e3

For a missing node:

https://github.com/user-attachments/assets/893039e8-a1f2-4cc2-ae18-e85e1d371449

After evaluating different ways to fix this, including:
1. giving a more generic error during partial executions (e.g. "Error finding the referenced node. Make sure the node you referenced is spelled correctly and is a parent of this node.")
	* impacts UX
	* complicates the `WorkflowDataProxy`
2. threading the original workflow through to the `WorkflowDataProxy`, (e.g. adding an optional `originalWorkflow` property to the `Worfklow`)
	* complicates the `WorkflowDataProxy`
3. passing the original workflow to the `WorkflowExecute.processRunExecutionData` and relying on `runNodeFilter` to pass over disabled and unrelated nodes correctly
	* risk of introducing partial execution regressions

I chose the 3rd option as it may just work and retain the UX while avoiding complicating the `WorkflowDataProxy`.

*After*

For the orphaned node:

https://github.com/user-attachments/assets/b6d5be76-a25d-467c-80c2-469fa9be8cde


For the child node:

https://github.com/user-attachments/assets/a94a8f46-aeb8-40b4-8ad8-07e560e25b95


For a missing node:
 

https://github.com/user-attachments/assets/e364b9c0-2ae1-4a86-bc1d-c06b45a9734e



## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
