### PR TITLE
feat(MCP Server Trigger Node): Terminate sessions on DELETE request

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpServer.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpServer.ts
@@ -229,12 +229,17 @@ export class McpServerManager {
 
 		const transport = this.getTransport(sessionId);
 
-		if (transport && transport instanceof FlushingStreamableHTTPTransport) {
-			await transport.handleRequest(req, resp);
-			return;
+		if (transport) {
+			if (transport instanceof FlushingStreamableHTTPTransport) {
+				await transport.handleRequest(req, resp);
+				return;
+			} else {
+				// For SSE transport, we don't support DELETE requests
+				resp.status(405).send('Method Not Allowed');
+				return;
+			}
 		}
 
-		// Session not found or wrong transport type (SSE doesn't support DELETE)
 		resp.status(404).send('Session not found');
 	}
 

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpServer.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpServer.ts
@@ -219,6 +219,25 @@ export class McpServerManager {
 		return wasToolCall(req.rawBody.toString());
 	}
 
+	async handleDeleteRequest(req: express.Request, resp: CompressionResponse) {
+		const sessionId = this.getSessionId(req);
+
+		if (!sessionId) {
+			resp.status(400).send('No sessionId provided');
+			return;
+		}
+
+		const transport = this.getTransport(sessionId);
+
+		if (transport && transport instanceof FlushingStreamableHTTPTransport) {
+			await transport.handleRequest(req, resp);
+			return;
+		}
+
+		// Session not found or wrong transport type (SSE doesn't support DELETE)
+		resp.status(404).send('Session not found');
+	}
+
 	setUpHandlers(server: Server) {
 		server.setRequestHandler(
 			ListToolsRequestSchema,

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpServer.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpServer.test.ts
@@ -510,7 +510,7 @@ describe('McpServer', () => {
 			expect(mockDeleteResponse.status).toHaveBeenCalledWith(404);
 		});
 
-		it('should return 404 for SSE transport session', async () => {
+		it('should return 405 for SSE transport session', async () => {
 			const sseSessionId = 'sse-session-id';
 			const mockDeleteRequest = mock<Request>({
 				query: { sessionId: sseSessionId },
@@ -525,8 +525,8 @@ describe('McpServer', () => {
 			// Call handleDeleteRequest
 			await mcpServerManager.handleDeleteRequest(mockDeleteRequest, mockDeleteResponse);
 
-			// Verify 404 response (DELETE not supported for SSE)
-			expect(mockDeleteResponse.status).toHaveBeenCalledWith(404);
+			// Verify 405 response (DELETE not supported for SSE)
+			expect(mockDeleteResponse.status).toHaveBeenCalledWith(405);
 		});
 	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpServer.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpServer.test.ts
@@ -445,4 +445,88 @@ describe('McpServer', () => {
 			expect(result2).toBe(mockTransport2);
 		});
 	});
+
+	describe('handleDeleteRequest', () => {
+		beforeEach(() => {
+			// Clear transports and servers before each test
+			mcpServerManager.transports = {};
+			mcpServerManager.servers = {};
+		});
+
+		it('should handle DELETE request for StreamableHTTP transport', async () => {
+			const deleteSessionId = 'delete-session-id';
+			const mockDeleteRequest = mock<Request>({
+				headers: { 'mcp-session-id': deleteSessionId },
+			});
+			const mockDeleteResponse = mock<CompressionResponse>();
+			mockDeleteResponse.status.mockReturnThis();
+
+			// Create a mock transport that passes instanceof check
+			const mockHttpTransport = Object.create(FlushingStreamableHTTPTransport.prototype);
+			mockHttpTransport.handleRequest = jest.fn();
+
+			// Set up the transport
+			mcpServerManager.transports[deleteSessionId] = mockHttpTransport;
+
+			// Call handleDeleteRequest
+			await mcpServerManager.handleDeleteRequest(mockDeleteRequest, mockDeleteResponse);
+
+			// Verify transport.handleRequest was called
+			expect(mockHttpTransport.handleRequest).toHaveBeenCalledWith(
+				mockDeleteRequest,
+				mockDeleteResponse,
+			);
+		});
+
+		it('should return 400 when no sessionId provided', async () => {
+			const mockDeleteRequest = mock<Request>({
+				query: {},
+				headers: {},
+			});
+			const mockDeleteResponse = mock<CompressionResponse>();
+			mockDeleteResponse.status.mockReturnThis();
+
+			// Mock getSessionId to return undefined
+			jest.spyOn(mcpServerManager, 'getSessionId').mockReturnValueOnce(undefined);
+
+			// Call handleDeleteRequest without sessionId
+			await mcpServerManager.handleDeleteRequest(mockDeleteRequest, mockDeleteResponse);
+
+			// Verify 400 response
+			expect(mockDeleteResponse.status).toHaveBeenCalledWith(400);
+		});
+
+		it('should return 404 for non-existent session', async () => {
+			const mockDeleteRequest = mock<Request>({
+				headers: { 'mcp-session-id': 'non-existent-session' },
+			});
+			const mockDeleteResponse = mock<CompressionResponse>();
+			mockDeleteResponse.status.mockReturnThis();
+
+			// Call handleDeleteRequest with non-existent sessionId
+			await mcpServerManager.handleDeleteRequest(mockDeleteRequest, mockDeleteResponse);
+
+			// Verify 404 response (session not found)
+			expect(mockDeleteResponse.status).toHaveBeenCalledWith(404);
+		});
+
+		it('should return 404 for SSE transport session', async () => {
+			const sseSessionId = 'sse-session-id';
+			const mockDeleteRequest = mock<Request>({
+				query: { sessionId: sseSessionId },
+			});
+			const mockDeleteResponse = mock<CompressionResponse>();
+			mockDeleteResponse.status.mockReturnThis();
+			const mockSSETransport = mock<FlushingSSEServerTransport>();
+
+			// Set up SSE transport
+			mcpServerManager.transports[sseSessionId] = mockSSETransport;
+
+			// Call handleDeleteRequest
+			await mcpServerManager.handleDeleteRequest(mockDeleteRequest, mockDeleteResponse);
+
+			// Verify 404 response (DELETE not supported for SSE)
+			expect(mockDeleteResponse.status).toHaveBeenCalledWith(404);
+		});
+	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpTrigger.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpTrigger.node.test.ts
@@ -5,7 +5,10 @@ import type { INode, IWebhookFunctions } from 'n8n-workflow';
 
 import * as helpers from '@utils/helpers';
 
-import type { FlushingSSEServerTransport } from '../FlushingTransport';
+import type {
+	FlushingSSEServerTransport,
+	FlushingStreamableHTTPTransport,
+} from '../FlushingTransport';
 import type { McpServerManager } from '../McpServer';
 import { McpTrigger } from '../McpTrigger.node';
 
@@ -136,6 +139,26 @@ describe('McpTrigger Node', () => {
 				'/custom-path',
 				mockResponse,
 			);
+		});
+
+		it('should handle DELETE webhook for StreamableHTTP session termination', async () => {
+			// Configure the context for DELETE webhook
+			mockContext.getWebhookName.mockReturnValue('default');
+			mockRequest.method = 'DELETE';
+			mockRequest.headers = { 'mcp-session-id': sessionId };
+
+			// Mock existing StreamableHTTP transport
+			mockServerManager.getSessionId.mockReturnValue(sessionId);
+			mockServerManager.getTransport.mockReturnValue(mock<FlushingStreamableHTTPTransport>({}));
+
+			// Call the webhook method
+			const result = await mcpTrigger.webhook(mockContext);
+
+			// Verify that handleDeleteRequest was called
+			expect(mockServerManager.handleDeleteRequest).toHaveBeenCalledWith(mockRequest, mockResponse);
+
+			// Verify the returned result
+			expect(result).toEqual({ noWebhookResponse: true });
 		});
 	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpTrigger.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpTrigger.node.test.ts
@@ -144,8 +144,12 @@ describe('McpTrigger Node', () => {
 		it('should handle DELETE webhook for StreamableHTTP session termination', async () => {
 			// Configure the context for DELETE webhook
 			mockContext.getWebhookName.mockReturnValue('default');
-			mockRequest.method = 'DELETE';
-			mockRequest.headers = { 'mcp-session-id': sessionId };
+			const mockDeleteRequest = mock<Request>({
+				method: 'DELETE',
+				headers: { 'mcp-session-id': sessionId },
+				path: '/custom-path',
+			});
+			mockContext.getRequestObject.mockReturnValueOnce(mockDeleteRequest);
 
 			// Mock existing StreamableHTTP transport
 			mockServerManager.getSessionId.mockReturnValue(sessionId);
@@ -155,7 +159,10 @@ describe('McpTrigger Node', () => {
 			const result = await mcpTrigger.webhook(mockContext);
 
 			// Verify that handleDeleteRequest was called
-			expect(mockServerManager.handleDeleteRequest).toHaveBeenCalledWith(mockRequest, mockResponse);
+			expect(mockServerManager.handleDeleteRequest).toHaveBeenCalledWith(
+				mockDeleteRequest,
+				mockResponse,
+			);
 
 			// Verify the returned result
 			expect(result).toEqual({ noWebhookResponse: true });


### PR DESCRIPTION
## Summary

Handle DELETE requests from clients for explicit session termination

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-1050/clean-up-mcp-servers-when-delete-method-is-sent


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
