### PR TITLE
fix(core): Handle dynamic webhook edge cases

### DIFF
--- a/packages/cli/src/webhooks/__tests__/webhook.service.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook.service.test.ts
@@ -386,4 +386,116 @@ describe('WebhookService', () => {
 			expect(webhookRepository.findBy).toHaveBeenCalledTimes(2);
 		});
 	});
+
+	describe('isDynamicPath', () => {
+		test.each(['a', 'a/b'])('should treat static path (%s) as static', (path) => {
+			const workflow = new Workflow({
+				id: 'test-workflow',
+				nodes: [],
+				connections: {},
+				active: true,
+				nodeTypes,
+			});
+
+			const node = mock<INode>({
+				name: 'Webhook',
+				type: 'n8n-nodes-base.webhook',
+			});
+
+			const nodeType = mock<INodeType>({
+				description: {
+					webhooks: [
+						{
+							name: 'default',
+							httpMethod: 'GET',
+							path,
+							isFullPath: false,
+							restartWebhook: false,
+						},
+					],
+				},
+			});
+
+			nodeTypes.getByNameAndVersion.mockReturnValue(nodeType);
+
+			const webhooks = webhookService.getNodeWebhooks(workflow, node, additionalData);
+
+			expect(webhooks).toHaveLength(1);
+			expect(webhooks[0].webhookId).toBeUndefined();
+		});
+
+		test.each([':', '/:'])('should treat literal colon path (%s) as static', (path) => {
+			const workflow = new Workflow({
+				id: 'test-workflow',
+				nodes: [],
+				connections: {},
+				active: true,
+				nodeTypes,
+			});
+
+			const nodeWithWebhookId = mock<INode>({
+				name: 'Webhook',
+				type: 'n8n-nodes-base.webhook',
+			});
+
+			const nodeType = mock<INodeType>({
+				description: {
+					webhooks: [
+						{
+							name: 'default',
+							httpMethod: 'GET',
+							path,
+							isFullPath: false,
+							restartWebhook: false,
+						},
+					],
+				},
+			});
+
+			nodeTypes.getByNameAndVersion.mockReturnValue(nodeType);
+
+			const webhooks = webhookService.getNodeWebhooks(workflow, nodeWithWebhookId, additionalData);
+
+			expect(webhooks).toHaveLength(1);
+			expect(webhooks[0].webhookId).toBeUndefined();
+		});
+
+		test('should treat dynamic path (user/:id) as dynamic', () => {
+			const workflow = new Workflow({
+				id: 'test-workflow',
+				nodes: [],
+				connections: {},
+				active: true,
+				nodeTypes,
+			});
+
+			const nodeWithWebhookId = mock<INode>({
+				name: 'Webhook',
+				type: 'n8n-nodes-base.webhook',
+				disabled: false,
+				webhookId: 'test-webhook-id',
+			});
+
+			const nodeType = mock<INodeType>({
+				description: {
+					webhooks: [
+						{
+							name: 'default',
+							httpMethod: 'GET',
+							path: 'user/:id',
+							isFullPath: false,
+							restartWebhook: false,
+						},
+					],
+				},
+			});
+
+			nodeTypes.getByNameAndVersion.mockReturnValue(nodeType);
+
+			const webhooks = webhookService.getNodeWebhooks(workflow, nodeWithWebhookId, additionalData);
+
+			expect(webhooks).toHaveLength(1);
+			expect(webhooks[0].webhookId).toBe('test-webhook-id');
+		});
+	});
 });

--- a/packages/cli/src/webhooks/webhook.service.ts
+++ b/packages/cli/src/webhooks/webhook.service.ts
@@ -139,6 +139,17 @@ export class WebhookService {
 			.then((rows) => rows.map((r) => r.method));
 	}
 
+	private isDynamicPath(rawPath: string) {
+		const firstSlashIndex = rawPath.indexOf('/');
+		const path = firstSlashIndex !== -1 ? rawPath.substring(firstSlashIndex + 1) : rawPath;
+
+		// if dynamic, first segment is webhook ID so disregard it
+
+		if (path === '' || path === ':' || path === '/:') return false;
+
+		return path.startsWith(':') || path.includes('/:');
+	}
+
 	/**
 	 * Returns all the webhooks which should be created for the give node
 	 */
@@ -232,7 +243,8 @@ export class WebhookService {
 			}
 
 			let webhookId: string | undefined;
-			if ((path.startsWith(':') || path.includes('/:')) && node.webhookId) {
+
+			if (this.isDynamicPath(path) && node.webhookId) {
 				webhookId = node.webhookId;
 			}
 


### PR DESCRIPTION
## Summary

Literal colon `:` and slash colon `/:` do not qualify as dynamic webhooks, but we are persisting them as if they are, writing values to `webhookId` and `pathLength` which must stay `NULL` for static webhooks.

## Related Linear tickets, Github issues, and Community forum posts

Context: https://linear.app/n8n/issue/CAT-772/webhook-gets-de-registered-for-touristical#comment-f51ad216

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
