### PR TITLE
fix(Microsoft SharePoint Node): Access token not being refreshed

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/SharePoint/MicrosoftSharePoint.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/MicrosoftSharePoint.node.ts
@@ -30,7 +30,6 @@ export class MicrosoftSharePoint implements INodeType {
 		],
 		requestDefaults: {
 			baseURL: '=https://{{ $credentials.subdomain }}.sharepoint.com/_api/v2.0/',
-			ignoreHttpStatusErrors: true,
 		},
 		properties: [
 			{


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Remove the `ignoreHttpStatusErrors` option which caused the 401 errors being ignored, which in turn was not triggering the access token refresh logic

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-3091/community-issue-microsoft-sharepoint-node-access-token-has-expired
Closes #16070 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
