### PR TITLE
Fix: Consistent Use of `testTimeout` in Jest Configurations

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -50,6 +50,7 @@ const config = {
 	setupFilesAfterEnv: ['jest-expect-message'],
 	collectCoverage: isCoverageEnabled,
 	coverageReporters: ['text-summary', 'lcov', 'html-spa'],
+	testTimeout: 5_000, // Default timeout for tests in milliseconds
 	workerIdleMemoryLimit: '1MB',
 };
 


### PR DESCRIPTION
The `testTimeout` property is used to define the maximum time a test can run before Jest considers it a failure. While some `jest.config.js` files define it (e.g., `packages\cli\jest.config.js` and `packages\@n8n\ai-workflow-builder\jest.config.js`), others do not. For consistency and to ensure tests do not run indefinitely, it is good practice to define a default `testTimeout` in the root `jest.config.js` so all packages inherit it.

Applied fixes:
--- a/jest.config.js
+++ b/jest.config.js
@@ -50,6 +50,7 @@
 	collectCoverage: isCoverageEnabled,
 	coverageReporters: ['text-summary', 'lcov', 'html-spa'],
 	workerIdleMemoryLimit: '1MB',
+	testTimeout: 5_000, // Default timeout for tests in milliseconds
 };
 
 if (process.env.CI === 'true') {