### PR TITLE
fix(editor): Set workflow project to be shown in the breadcrumb

### DIFF
--- a/packages/frontend/editor-ui/src/views/WorkflowExecutionsView.vue
+++ b/packages/frontend/editor-ui/src/views/WorkflowExecutionsView.vue
@@ -6,6 +6,7 @@ import { useI18n } from '@n8n/i18n';
 import type { ExecutionFilterType, IWorkflowDb } from '@/Interface';
 import { useWorkflowsStore } from '@/stores/workflows.store';
 import { useNodeTypesStore } from '@/stores/nodeTypes.store';
+import { useProjectsStore } from '@/stores/projects.store';
 import { NO_NETWORK_ERROR_CODE } from '@n8n/rest-api-client';
 import { useToast } from '@/composables/useToast';
 import { NEW_WORKFLOW_ID, PLACEHOLDER_EMPTY_WORKFLOW_ID, VIEWS } from '@/constants';
@@ -19,6 +20,7 @@ import { executionRetryMessage } from '@/utils/executionUtils';
 const executionsStore = useExecutionsStore();
 const workflowsStore = useWorkflowsStore();
 const nodeTypesStore = useNodeTypesStore();
+const projectsStore = useProjectsStore();
 const i18n = useI18n();
 const telemetry = useTelemetry();
 const route = useRoute();
@@ -146,6 +148,9 @@ async function fetchWorkflow() {
 		}
 
 		workflow.value = workflowsStore.getWorkflowById(workflowId.value);
+		const workflowData = await workflowsStore.fetchWorkflow(workflow.value.id);
+
+		await projectsStore.setProjectNavActiveIdByWorkflowHomeProject(workflowData.homeProject);
 	} else {
 		workflow.value = workflowsStore.workflow;
 	}


### PR DESCRIPTION
## Summary

There are two ways to reproduce the issue.
- Go to executions view outside of workflow and pick an execution
- Refresh execution view inside a workflow

The breadcrumbs are shown as Personal project, which is incorrect

https://www.loom.com/share/eecea769f6b44d489a88c097d34de341?sid=ef7a25bd-d69f-404b-8546-9d9ac863dfe5

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/ADO-3641/community-issue-entering-the-execution-log-from-any-project-shows-the
https://github.com/n8n-io/n8n/issues/16046
fixes #16046
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
