### PR TITLE
fix(Redis): Allow for using AWS ElastiCache Serverless in Queue Mode

### DIFF
--- a/packages/@n8n/config/src/configs/scaling-mode.config.ts
+++ b/packages/@n8n/config/src/configs/scaling-mode.config.ts
@@ -56,6 +56,10 @@ class RedisConfig {
 	/** Whether to enable dual-stack hostname resolution for Redis connections. */
 	@Env('QUEUE_BULL_REDIS_DUALSTACK')
 	dualStack: boolean = false;
+
+	/** Whether to enable AWS ElastiCache Serverless support. */
+	@Env('QUEUE_BULL_REDIS_ELASTICACHE_SERVERLESS')
+	elasticacheServerless: boolean = false;
 }
 
 @Config

--- a/packages/@n8n/config/src/configs/scaling-mode.config.ts
+++ b/packages/@n8n/config/src/configs/scaling-mode.config.ts
@@ -56,10 +56,6 @@ class RedisConfig {
 	/** Whether to enable dual-stack hostname resolution for Redis connections. */
 	@Env('QUEUE_BULL_REDIS_DUALSTACK')
 	dualStack: boolean = false;
-
-	/** Whether to enable AWS ElastiCache Serverless support. */
-	@Env('QUEUE_BULL_REDIS_ELASTICACHE_SERVERLESS')
-	elasticacheServerless: boolean = false;
 }
 
 @Config


### PR DESCRIPTION
## Summary

This PR adds a flag `QUEUE_BULL_REDIS_ELASTICACHE_SERVERLESS` that, when set to `true`, will update the Redis.Cluster initialization with required parameters to work with AWS ElastiCache Serverless Valkey/Redis Clusters.

## Related Linear tickets, Github issues, and Community forum posts

closes https://github.com/n8n-io/n8n/issues/16590

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) 
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. 
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
