### PR TITLE
Add support for passing application key in headers for Azure OpenAI models

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/LmChatAzureOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/LmChatAzureOpenAi.node.ts
@@ -86,6 +86,7 @@ export class LmChatAzureOpenAi implements INodeType {
 			) as AuthenticationType;
 			const modelName = this.getNodeParameter('model', itemIndex) as string;
 			const options = this.getNodeParameter('options', itemIndex, {}) as AzureOpenAIOptions;
+			const appKey = this.getNodeParameter('appKey', itemIndex, '') as string;
 
 			// Set up Authentication based on selection and get configuration
 			let modelConfig: AzureOpenAIApiKeyModelConfig | AzureOpenAIOAuth2ModelConfig;
@@ -111,6 +112,7 @@ export class LmChatAzureOpenAi implements INodeType {
 				...modelConfig,
 				...options,
 				timeout: options.timeout ?? 60000,
+				user: JSON.stringify({ appkey: appKey }),
 				maxRetries: options.maxRetries ?? 2,
 				callbacks: [new N8nLlmTracing(this)],
 				configuration: {

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/LmChatAzureOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/LmChatAzureOpenAi.node.ts
@@ -112,7 +112,6 @@ export class LmChatAzureOpenAi implements INodeType {
 				...modelConfig,
 				...options,
 				timeout: options.timeout ?? 60000,
-				user: JSON.stringify({ appkey: appKey }),
 				maxRetries: options.maxRetries ?? 2,
 				callbacks: [new N8nLlmTracing(this)],
 				configuration: {
@@ -125,6 +124,9 @@ export class LmChatAzureOpenAi implements INodeType {
 					: undefined,
 				onFailedAttempt: makeN8nLlmFailedAttemptHandler(this),
 			});
+			if (appKey !== '') {
+				model.user = JSON.stringify({appkey: appKey});
+			}
 
 			this.logger.info(`Azure OpenAI client initialized for deployment: ${modelName}`);
 

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/properties.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/properties.ts
@@ -45,6 +45,14 @@ export const properties: INodeProperties[] = [
 		default: '',
 	},
 	{
+		displayName: 'Application Key',
+		name: 'appKey',
+		type: 'string',
+		default: '',
+		description:
+			'The application key to identify the application. This will be used as json object in request headers.',
+	},
+	{
 		displayName: 'Options',
 		name: 'options',
 		placeholder: 'Add Option',


### PR DESCRIPTION
### Summary:
    For enterprise Azure Open AII LLM's application key is mandatory for authorization.

    - Updated `LmChatAzureOpenAi.node.ts` to include the ability to pass the application key through headers for user authorization.
    - Addresses the issue where LLM returns a 422 error if the application key is not provided in enterprise Azure Open AI LLM's.

    This change is necessary to enable proper authorization when interacting with Azure OpenAI models.


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
