### PR TITLE
feat: Improve Aws Credential to allow Assumption of IAM Roles

### DIFF
--- a/packages/nodes-base/credentials/Aws.credentials.ts
+++ b/packages/nodes-base/credentials/Aws.credentials.ts
@@ -372,7 +372,7 @@ export class Aws implements ICredentialType {
 			displayName: 'Use System Credentials for STS Call',
 			name: 'useSystemCredentialsForRole',
 			description:
-				'Use system credentials (environment variables, container role, etc.) to call STS.AssumeRole. If system credentials are not by your administrator, you must provide an access key id and secret access key below that has the necessary permissions to assume the role.',
+				'Use system credentials (environment variables, container role, etc.) to call STS.AssumeRole. If system credentials are not configured by your administrator, you must provide an access key id and secret access key below that has the necessary permissions to assume the role.',
 			type: 'boolean',
 			displayOptions: {
 				show: {
@@ -935,8 +935,8 @@ export class Aws implements ICredentialType {
 		// Get credentials for the STS call
 		let stsCallCredentials: { accessKeyId: string; secretAccessKey: string; sessionToken?: string };
 
-		// For backward compatibility: if useSystemCredentialsForRole is not set, default to true
-		const useSystemCredentialsForRole = credentials.useSystemCredentialsForRole ?? true;
+		// Use the user's choice for system credentials (defaults to false for security)
+		const useSystemCredentialsForRole = credentials.useSystemCredentialsForRole ?? false;
 
 		if (useSystemCredentialsForRole) {
 			// Use system credentials for the STS call

--- a/packages/nodes-base/credentials/Aws.credentials.ts
+++ b/packages/nodes-base/credentials/Aws.credentials.ts
@@ -806,18 +806,7 @@ export class Aws implements ICredentialType {
 			);
 		}
 
-		// 3. Try to get credentials from instance metadata service (EC2)
-		try {
-			const instanceCredentials = await this.getInstanceMetadataCredentials();
-			if (instanceCredentials) {
-				return instanceCredentials;
-			}
-		} catch (error) {
-			// Silently continue to next credential source
-			console.debug('Failed to get credentials from instance metadata:', error);
-		}
-
-		// 4. Try to get credentials from container metadata service (ECS/Fargate)
+		// 3. Try to get credentials from container metadata service (ECS/Fargate)
 		try {
 			const containerCredentials = await this.getContainerMetadataCredentials();
 			if (containerCredentials) {
@@ -826,6 +815,17 @@ export class Aws implements ICredentialType {
 		} catch (error) {
 			// Silently continue to next credential source
 			console.debug('Failed to get credentials from container metadata:', error);
+		}
+
+		// 4. Try to get credentials from instance metadata service (EC2)
+		try {
+			const instanceCredentials = await this.getInstanceMetadataCredentials();
+			if (instanceCredentials) {
+				return instanceCredentials;
+			}
+		} catch (error) {
+			// Silently continue to next credential source
+			console.debug('Failed to get credentials from instance metadata:', error);
 		}
 
 		// No credentials found

--- a/packages/nodes-base/credentials/Aws.credentials.ts
+++ b/packages/nodes-base/credentials/Aws.credentials.ts
@@ -197,11 +197,27 @@ export const regions = [
 export type AWSRegion = (typeof regions)[number]['name'];
 export type AwsCredentialsType = {
 	region: AWSRegion;
+	// Credential type (optional for backward compatibility)
+	credentialType?: 'iam' | 'assumeRole';
+	// Direct IAM credentials (for backward compatibility and direct access)
 	accessKeyId: string;
 	secretAccessKey: string;
 	temporaryCredentials: boolean;
-	customEndpoints: boolean;
 	sessionToken?: string;
+	// Role assumption fields (optional for backward compatibility)
+	assumeRole?: boolean;
+	roleArn?: string;
+	externalId?: string;
+	roleSessionName?: string;
+	// For role assumption: whether to use system credentials for STS call
+	useSystemCredentialsForRole?: boolean;
+	// STS credentials for role assumption (when not using system credentials)
+	temporaryStsCredentials?: boolean;
+	stsAccessKeyId?: string;
+	stsSecretAccessKey?: string;
+	stsSessionToken?: string;
+	// Custom endpoints
+	customEndpoints: boolean;
 	rekognitionEndpoint?: string;
 	lambdaEndpoint?: string;
 	snsEndpoint?: string;
@@ -240,15 +256,45 @@ export class Aws implements ICredentialType {
 			default: 'us-east-1',
 		},
 		{
+			displayName: 'Credential Type',
+			name: 'credentialType',
+			type: 'options',
+			options: [
+				{
+					name: 'IAM Access Key',
+					value: 'iam',
+					description: 'Use IAM access key and secret key directly',
+				},
+				{
+					name: 'Assume IAM Role',
+					value: 'assumeRole',
+					description: 'Assume an IAM role using STS',
+				},
+			],
+			default: 'iam',
+		},
+		{
 			displayName: 'Access Key ID',
 			name: 'accessKeyId',
 			type: 'string',
+			displayOptions: {
+				show: {
+					credentialType: ['iam'],
+				},
+			},
+			required: true,
 			default: '',
 		},
 		{
 			displayName: 'Secret Access Key',
 			name: 'secretAccessKey',
 			type: 'string',
+			displayOptions: {
+				show: {
+					credentialType: ['iam'],
+				},
+			},
+			required: true,
 			default: '',
 			typeOptions: {
 				password: true,
@@ -259,6 +305,11 @@ export class Aws implements ICredentialType {
 			name: 'temporaryCredentials',
 			description: 'Support for temporary credentials from AWS STS',
 			type: 'boolean',
+			displayOptions: {
+				show: {
+					credentialType: ['iam'],
+				},
+			},
 			default: false,
 		},
 		{
@@ -267,7 +318,126 @@ export class Aws implements ICredentialType {
 			type: 'string',
 			displayOptions: {
 				show: {
+					credentialType: ['iam'],
 					temporaryCredentials: [true],
+				},
+			},
+			default: '',
+			typeOptions: {
+				password: true,
+			},
+		},
+		{
+			displayName: 'Role ARN',
+			name: 'roleArn',
+			description: 'The ARN of the role to assume (e.g., arn:aws:iam::123456789012:role/MyRole)',
+			type: 'string',
+			displayOptions: {
+				show: {
+					credentialType: ['assumeRole'],
+				},
+			},
+			required: true,
+			default: '',
+			placeholder: 'arn:aws:iam::123456789012:role/MyRole',
+		},
+		{
+			displayName: 'External ID',
+			name: 'externalId',
+			description:
+				'External ID for cross-account role assumption (should be required by the role trust policy). For more information, see https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html',
+			type: 'string',
+			displayOptions: {
+				show: {
+					credentialType: ['assumeRole'],
+				},
+			},
+			required: true,
+			default: '',
+		},
+		{
+			displayName: 'Role Session Name',
+			name: 'roleSessionName',
+			description: 'Name for the role session (required, defaults to n8n-session)',
+			type: 'string',
+			displayOptions: {
+				show: {
+					credentialType: ['assumeRole'],
+				},
+			},
+			required: true,
+			default: 'n8n-session',
+		},
+		{
+			displayName: 'Use System Credentials for STS Call',
+			name: 'useSystemCredentialsForRole',
+			description:
+				'Use system credentials (environment variables, container role, etc.) to call STS.AssumeRole. If system credentials are not by your administrator, you must provide an access key id and secret access key below that has the necessary permissions to assume the role.',
+			type: 'boolean',
+			displayOptions: {
+				show: {
+					credentialType: ['assumeRole'],
+				},
+			},
+			default: false,
+		},
+		{
+			displayName: 'Temporary STS Credentials',
+			name: 'temporaryStsCredentials',
+			description: 'Support for temporary credentials for the STS.AssumeRole call',
+			type: 'boolean',
+			displayOptions: {
+				show: {
+					credentialType: ['assumeRole'],
+					useSystemCredentialsForRole: [false],
+				},
+			},
+			default: false,
+		},
+		{
+			displayName: 'STS Access Key ID',
+			name: 'stsAccessKeyId',
+			description:
+				'Access Key ID to use for the STS.AssumeRole call (only if not using system credentials)',
+			type: 'string',
+			displayOptions: {
+				show: {
+					credentialType: ['assumeRole'],
+					useSystemCredentialsForRole: [false],
+				},
+			},
+			required: true,
+			default: '',
+		},
+		{
+			displayName: 'STS Secret Access Key',
+			name: 'stsSecretAccessKey',
+			description:
+				'Secret Access Key to use for the STS.AssumeRole call (only if not using system credentials)',
+			type: 'string',
+			displayOptions: {
+				show: {
+					credentialType: ['assumeRole'],
+					useSystemCredentialsForRole: [false],
+				},
+			},
+			required: true,
+			default: '',
+			typeOptions: {
+				password: true,
+			},
+		},
+		{
+			displayName: 'STS Session Token',
+			name: 'stsSessionToken',
+			description:
+				'Session Token to use for the STS.AssumeRole call (only needed when using temporary STS credentials)',
+			type: 'string',
+			displayOptions: {
+				show: {
+					credentialType: ['assumeRole'],
+					useSystemCredentialsForRole: [false],
+					temporaryStsCredentials: [true],
 				},
 			},
 			default: '',
@@ -397,6 +567,39 @@ export class Aws implements ICredentialType {
 			delete requestOptions.qs._region;
 		}
 
+		// Determine credential mode (for backward compatibility)
+		const credentialType =
+			credentials.credentialType || (credentials.assumeRole ? 'assumeRole' : 'iam');
+
+		// Handle role assumption if enabled
+		let finalCredentials = credentials;
+		let assumedCredentials: {
+			accessKeyId: string;
+			secretAccessKey: string;
+			sessionToken: string;
+		} | null = null;
+
+		if (credentialType === 'assumeRole') {
+			if (!credentials.roleArn || credentials.roleArn.trim() === '') {
+				throw new Error('Role ARN is required when assuming a role.');
+			}
+			if (!credentials.externalId || credentials.externalId.trim() === '') {
+				throw new Error('External ID is required when assuming a role.');
+			}
+			if (!credentials.roleSessionName || credentials.roleSessionName.trim() === '') {
+				throw new Error('Role Session Name is required when assuming a role.');
+			}
+			try {
+				assumedCredentials = await this.assumeRole(credentials, region);
+				finalCredentials = { ...credentials, ...assumedCredentials };
+			} catch (error) {
+				console.error('Failed to assume role:', error);
+				throw new Error(
+					`Failed to assume role: ${error instanceof Error ? error.message : 'Unknown error'}`,
+				);
+			}
+		}
+
 		let query = requestOptions.qs?.query as IDataObject;
 		// ! Workaround as we still use the IRequestOptions interface which uses uri instead of url
 		// ! To change when we replace the interface with IHttpRequestOptions
@@ -424,22 +627,22 @@ export class Aws implements ICredentialType {
 		} else {
 			if (!requestOptions.baseURL && !requestOptions.url) {
 				let endpointString: string;
-				if (service === 'lambda' && credentials.lambdaEndpoint) {
-					endpointString = credentials.lambdaEndpoint;
-				} else if (service === 'sns' && credentials.snsEndpoint) {
-					endpointString = credentials.snsEndpoint;
-				} else if (service === 'sqs' && credentials.sqsEndpoint) {
-					endpointString = credentials.sqsEndpoint;
-				} else if (service === 's3' && credentials.s3Endpoint) {
-					endpointString = credentials.s3Endpoint;
-				} else if (service === 'ses' && credentials.sesEndpoint) {
-					endpointString = credentials.sesEndpoint;
-				} else if (service === 'rekognition' && credentials.rekognitionEndpoint) {
-					endpointString = credentials.rekognitionEndpoint;
+				if (service === 'lambda' && finalCredentials.lambdaEndpoint) {
+					endpointString = finalCredentials.lambdaEndpoint;
+				} else if (service === 'sns' && finalCredentials.snsEndpoint) {
+					endpointString = finalCredentials.snsEndpoint;
+				} else if (service === 'sqs' && finalCredentials.sqsEndpoint) {
+					endpointString = finalCredentials.sqsEndpoint;
+				} else if (service === 's3' && finalCredentials.s3Endpoint) {
+					endpointString = finalCredentials.s3Endpoint;
+				} else if (service === 'ses' && finalCredentials.sesEndpoint) {
+					endpointString = finalCredentials.sesEndpoint;
+				} else if (service === 'rekognition' && finalCredentials.rekognitionEndpoint) {
+					endpointString = finalCredentials.rekognitionEndpoint;
 				} else if (service) {
 					endpointString = `https://${service}.${region}.amazonaws.com`;
-				} else if (service === 'ssm' && credentials.ssmEndpoint) {
-					endpointString = credentials.ssmEndpoint;
+				} else if (service === 'ssm' && finalCredentials.ssmEndpoint) {
+					endpointString = finalCredentials.ssmEndpoint;
 				}
 				endpoint = new URL(endpointString!.replace('{region}', region) + path);
 			} else {
@@ -500,13 +703,25 @@ export class Aws implements ICredentialType {
 			region,
 		} as Request;
 
-		const securityHeaders = {
-			accessKeyId: `${credentials.accessKeyId}`.trim(),
-			secretAccessKey: `${credentials.secretAccessKey}`.trim(),
-			sessionToken: credentials.temporaryCredentials
-				? `${credentials.sessionToken}`.trim()
-				: undefined,
-		};
+		// Get credentials for signing - use assumed credentials if available, otherwise get from credential source
+		let securityHeaders: { accessKeyId: string; secretAccessKey: string; sessionToken?: string };
+		if (assumedCredentials) {
+			// Use the assumed credentials directly
+			securityHeaders = {
+				accessKeyId: assumedCredentials.accessKeyId,
+				secretAccessKey: assumedCredentials.secretAccessKey,
+				sessionToken: assumedCredentials.sessionToken,
+			};
+		} else {
+			// Get credentials from the normal credential source
+			securityHeaders = await this.getSecurityHeaders(finalCredentials);
+		}
+
+		// Always set sessionToken, even if undefined, to ensure test consistency
+		if (!('sessionToken' in securityHeaders)) {
+			securityHeaders.sessionToken = undefined;
+		}
+
 		try {
 			sign(signOpts, securityHeaders);
 		} catch (err) {
@@ -531,4 +746,306 @@ export class Aws implements ICredentialType {
 			method: 'POST',
 		},
 	};
+
+	private async getSecurityHeaders(credentials: AwsCredentialsType): Promise<{
+		accessKeyId: string;
+		secretAccessKey: string;
+		sessionToken?: string;
+	}> {
+		// For backward compatibility: if credentialType is not set, default to 'iam'
+		const credentialType =
+			credentials.credentialType || (credentials.assumeRole ? 'assumeRole' : 'iam');
+
+		if (credentialType === 'iam') {
+			// Use manually provided credentials
+			if (!credentials.accessKeyId || credentials.accessKeyId.trim() === '') {
+				throw new Error('Access Key ID is required for IAM credentials.');
+			}
+			if (!credentials.secretAccessKey || credentials.secretAccessKey.trim() === '') {
+				throw new Error('Secret Access Key is required for IAM credentials.');
+			}
+			return {
+				accessKeyId: `${credentials.accessKeyId}`.trim(),
+				secretAccessKey: `${credentials.secretAccessKey}`.trim(),
+				sessionToken: credentials.temporaryCredentials
+					? `${credentials.sessionToken}`.trim()
+					: undefined,
+			};
+		} else {
+			throw new Error('Invalid credential type. Expected IAM credentials for direct access.');
+		}
+	}
+
+	private async getSystemCredentials(): Promise<{
+		accessKeyId: string;
+		secretAccessKey: string;
+		sessionToken?: string;
+	} | null> {
+		// 1. Check for explicit environment variables
+		const accessKeyId = process.env.AWS_ACCESS_KEY_ID;
+		const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
+		const sessionToken = process.env.AWS_SESSION_TOKEN;
+
+		if (accessKeyId && secretAccessKey) {
+			return {
+				accessKeyId: accessKeyId.trim(),
+				secretAccessKey: secretAccessKey.trim(),
+				sessionToken: sessionToken?.trim(),
+			};
+		}
+
+		// 2. Check for AWS_PROFILE environment variable
+		if (process.env.AWS_PROFILE) {
+			// Note: In a real implementation, you might want to use AWS SDK to load credentials from profile
+			// For now, we'll just indicate that profile-based credentials are supported
+			console.warn(
+				'AWS_PROFILE is set but profile-based credential loading is not implemented in this credential. Please set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, or use instance/container role.',
+			);
+		}
+
+		// 3. Try to get credentials from instance metadata service (EC2)
+		try {
+			const instanceCredentials = await this.getInstanceMetadataCredentials();
+			if (instanceCredentials) {
+				return instanceCredentials;
+			}
+		} catch (error) {
+			// Silently continue to next credential source
+			console.debug('Failed to get credentials from instance metadata:', error);
+		}
+
+		// 4. Try to get credentials from container metadata service (ECS/Fargate)
+		try {
+			const containerCredentials = await this.getContainerMetadataCredentials();
+			if (containerCredentials) {
+				return containerCredentials;
+			}
+		} catch (error) {
+			// Silently continue to next credential source
+			console.debug('Failed to get credentials from container metadata:', error);
+		}
+
+		// No credentials found
+		return null;
+	}
+
+	private async getInstanceMetadataCredentials(): Promise<{
+		accessKeyId: string;
+		secretAccessKey: string;
+		sessionToken: string;
+	} | null> {
+		try {
+			// Check if we're running on EC2 by trying to access instance metadata
+			const response = await fetch(
+				'http://169.254.169.254/latest/meta-data/iam/security-credentials/',
+				{
+					method: 'GET',
+					headers: {
+						'User-Agent': 'n8n-aws-credential',
+					},
+					// Short timeout to avoid hanging
+					signal: AbortSignal.timeout(2000),
+				},
+			);
+
+			if (!response.ok) {
+				return null;
+			}
+
+			// Get the role name
+			const roleName = await response.text();
+			if (!roleName) {
+				return null;
+			}
+
+			// Get credentials for the role
+			const credentialsResponse = await fetch(
+				`http://169.254.169.254/latest/meta-data/iam/security-credentials/${roleName}`,
+				{
+					method: 'GET',
+					headers: {
+						'User-Agent': 'n8n-aws-credential',
+					},
+					signal: AbortSignal.timeout(2000),
+				},
+			);
+
+			if (!credentialsResponse.ok) {
+				return null;
+			}
+
+			const credentialsData = await credentialsResponse.json();
+
+			return {
+				accessKeyId: credentialsData.AccessKeyId,
+				secretAccessKey: credentialsData.SecretAccessKey,
+				sessionToken: credentialsData.Token,
+			};
+		} catch (error) {
+			// Not running on EC2 or metadata service unavailable
+			return null;
+		}
+	}
+
+	private async getContainerMetadataCredentials(): Promise<{
+		accessKeyId: string;
+		secretAccessKey: string;
+		sessionToken: string;
+	} | null> {
+		try {
+			// Check for ECS container credentials
+			const relativeUri = process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI;
+			if (!relativeUri) {
+				return null;
+			}
+
+			const response = await fetch(`http://169.254.170.2${relativeUri}`, {
+				method: 'GET',
+				headers: {
+					'User-Agent': 'n8n-aws-credential',
+				},
+				signal: AbortSignal.timeout(2000),
+			});
+
+			if (!response.ok) {
+				return null;
+			}
+
+			const credentialsData = await response.json();
+
+			return {
+				accessKeyId: credentialsData.AccessKeyId,
+				secretAccessKey: credentialsData.SecretAccessKey,
+				sessionToken: credentialsData.Token,
+			};
+		} catch (error) {
+			// Not running in ECS or metadata service unavailable
+			return null;
+		}
+	}
+
+	private async assumeRole(
+		credentials: AwsCredentialsType,
+		region: AWSRegion,
+	): Promise<{
+		accessKeyId: string;
+		secretAccessKey: string;
+		sessionToken: string;
+	}> {
+		// Get credentials for the STS call
+		let stsCallCredentials: { accessKeyId: string; secretAccessKey: string; sessionToken?: string };
+
+		// For backward compatibility: if useSystemCredentialsForRole is not set, default to true
+		const useSystemCredentialsForRole = credentials.useSystemCredentialsForRole ?? true;
+
+		if (useSystemCredentialsForRole) {
+			// Use system credentials for the STS call
+			const systemCredentials = await this.getSystemCredentials();
+			if (!systemCredentials) {
+				throw new Error(
+					'System AWS credentials are required for role assumption. Please ensure AWS credentials are available via environment variables, instance metadata, or container role.',
+				);
+			}
+			stsCallCredentials = systemCredentials;
+		} else {
+			// Use manually provided STS credentials
+			if (!credentials.stsAccessKeyId || credentials.stsAccessKeyId.trim() === '') {
+				throw new Error('STS Access Key ID is required when not using system credentials.');
+			}
+			if (!credentials.stsSecretAccessKey || credentials.stsSecretAccessKey.trim() === '') {
+				throw new Error('STS Secret Access Key is required when not using system credentials.');
+			}
+
+			// For backward compatibility: if temporaryStsCredentials is not set, default to false
+			const temporaryStsCredentials = credentials.temporaryStsCredentials ?? false;
+
+			stsCallCredentials = {
+				accessKeyId: credentials.stsAccessKeyId.trim(),
+				secretAccessKey: credentials.stsSecretAccessKey.trim(),
+				sessionToken: temporaryStsCredentials
+					? credentials.stsSessionToken?.trim() || undefined
+					: undefined,
+			};
+		}
+
+		// Prepare STS AssumeRole request
+		const stsEndpoint = `https://sts.${region}.amazonaws.com`;
+		const assumeRoleBody = {
+			RoleArn: credentials.roleArn,
+			RoleSessionName: credentials.roleSessionName || 'n8n-session',
+			...(credentials.externalId && { ExternalId: credentials.externalId }),
+		};
+
+		// Build URLSearchParams properly
+		const params = new URLSearchParams({
+			Action: 'AssumeRole',
+			Version: '2011-06-15',
+			RoleArn: assumeRoleBody.RoleArn!,
+			RoleSessionName: assumeRoleBody.RoleSessionName,
+		});
+		if (assumeRoleBody.ExternalId) {
+			params.append('ExternalId', assumeRoleBody.ExternalId);
+		}
+
+		const bodyContent = params.toString();
+
+		// Sign the STS request
+		const stsUrl = new URL(stsEndpoint);
+		const signOpts = {
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded',
+			},
+			host: stsUrl.host,
+			method: 'POST',
+			path: '/',
+			body: bodyContent,
+			region,
+		} as Request;
+
+		try {
+			sign(signOpts, stsCallCredentials);
+		} catch (err) {
+			console.error('Failed to sign STS request:', err);
+			throw new Error('Failed to sign STS request');
+		}
+
+		// Make the STS request
+		const response = await fetch(stsEndpoint, {
+			method: 'POST',
+			headers: signOpts.headers as Record<string, string>,
+			body: bodyContent,
+		});
+
+		if (!response.ok) {
+			const errorText = await response.text();
+			throw new Error(
+				`STS AssumeRole failed: ${response.status} ${response.statusText} - ${errorText}`,
+			);
+		}
+
+		const responseText = await response.text();
+		const responseData = await new Promise<IDataObject>((resolve, reject) => {
+			const { parseString } = require('xml2js');
+			parseString(responseText, { explicitArray: false }, (err: any, data: IDataObject) => {
+				if (err) {
+					reject(err);
+				} else {
+					resolve(data);
+				}
+			});
+		});
+
+		const assumeRoleResult = (responseData.AssumeRoleResponse as IDataObject)
+			?.AssumeRoleResult as IDataObject;
+		if (!assumeRoleResult?.Credentials) {
+			throw new Error('Invalid response from STS AssumeRole');
+		}
+
+		const assumedCredentials = assumeRoleResult.Credentials as IDataObject;
+		return {
+			accessKeyId: assumedCredentials.AccessKeyId as string,
+			secretAccessKey: assumedCredentials.SecretAccessKey as string,
+			sessionToken: assumedCredentials.SessionToken as string,
+		};
+	}
 }

--- a/packages/nodes-base/credentials/Aws.credentials.ts
+++ b/packages/nodes-base/credentials/Aws.credentials.ts
@@ -345,7 +345,7 @@ export class Aws implements ICredentialType {
 			displayName: 'External ID',
 			name: 'externalId',
 			description:
-				'External ID for cross-account role assumption (should be required by the role trust policy). For more information, see https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html',
+				"External ID for cross-account role assumption (should be required by your role's trust policy). This really should be generated automatically by n8n but there is not a way to do this automatically. Given this limitation, **you should treat this value as a secret and not share it with any other users of this n8n instance.** For more information, see https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html",
 			type: 'string',
 			displayOptions: {
 				show: {
@@ -354,6 +354,9 @@ export class Aws implements ICredentialType {
 			},
 			required: true,
 			default: '',
+			typeOptions: {
+				password: true,
+			},
 		},
 		{
 			displayName: 'Role Session Name',

--- a/packages/nodes-base/credentials/Aws.credentials.ts
+++ b/packages/nodes-base/credentials/Aws.credentials.ts
@@ -10,6 +10,7 @@ import type {
 	IRequestOptions,
 } from 'n8n-workflow';
 import { isObjectEmpty } from 'n8n-workflow';
+import { parseString } from 'xml2js';
 
 export const regions = [
 	{
@@ -411,6 +412,9 @@ export class Aws implements ICredentialType {
 			},
 			required: true,
 			default: '',
+			typeOptions: {
+				password: true,
+			},
 		},
 		{
 			displayName: 'STS Secret Access Key',
@@ -1075,7 +1079,6 @@ export class Aws implements ICredentialType {
 
 		const responseText = await response.text();
 		const responseData = await new Promise<IDataObject>((resolve, reject) => {
-			const { parseString } = require('xml2js');
 			parseString(responseText, { explicitArray: false }, (err: any, data: IDataObject) => {
 				if (err) {
 					reject(err);

--- a/packages/nodes-base/credentials/test/Aws.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/Aws.credentials.test.ts
@@ -33,6 +33,7 @@ describe('Aws Credential', () => {
 	describe('authenticate', () => {
 		const credentials: AwsCredentialsType = {
 			region: 'eu-central-1',
+			credentialType: 'iam',
 			accessKeyId: 'hakuna',
 			secretAccessKey: 'matata',
 			customEndpoints: false,
@@ -177,6 +178,410 @@ describe('Aws Credential', () => {
 			);
 			expect(result.method).toBe('POST');
 			expect(result.url).toBe('https://iam.amazonaws.com/');
+		});
+
+		it('should throw error if accessKeyId is missing for IAM credentials', async () => {
+			await expect(
+				aws.authenticate(
+					{
+						...credentials,
+						accessKeyId: '',
+					},
+					requestOptions,
+				),
+			).rejects.toThrow('Access Key ID is required for IAM credentials.');
+		});
+
+		it('should throw error if secretAccessKey is missing for IAM credentials', async () => {
+			await expect(
+				aws.authenticate(
+					{
+						...credentials,
+						secretAccessKey: '',
+					},
+					requestOptions,
+				),
+			).rejects.toThrow('Secret Access Key is required for IAM credentials.');
+		});
+
+		it('should work with backward compatibility (no credentialType field)', async () => {
+			// Create credentials without credentialType field to simulate old credentials
+			const { credentialType, ...oldCredentials } = credentials;
+			const result = await aws.authenticate(oldCredentials as AwsCredentialsType, requestOptions);
+
+			expect(mockSign).toHaveBeenCalledWith(signOpts, securityHeaders);
+
+			expect(result.method).toBe('POST');
+			expect(result.url).toBe(
+				'https://sts.eu-central-1.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15',
+			);
+		});
+
+		it('should work with backward compatibility (assumeRole field)', async () => {
+			// Create credentials with assumeRole field to simulate old role assumption credentials
+			const oldCredentials = {
+				...credentials,
+				assumeRole: true,
+				roleArn: 'arn:aws:iam::123456789012:role/TestRole',
+				externalId: 'test-external-id',
+				roleSessionName: 'test-session',
+			};
+			delete oldCredentials.credentialType;
+
+			// Mock system credentials for the STS call
+			const originalEnv = process.env;
+			process.env = {
+				...originalEnv,
+				AWS_ACCESS_KEY_ID: 'system-access-key',
+				AWS_SECRET_ACCESS_KEY: 'system-secret-key',
+			};
+
+			const mockStsResponse = {
+				ok: true,
+				text: () =>
+					Promise.resolve(`
+					<AssumeRoleResponse>
+						<AssumeRoleResult>
+							<Credentials>
+								<AccessKeyId>assumed-access-key</AccessKeyId>
+								<SecretAccessKey>assumed-secret-key</SecretAccessKey>
+								<SessionToken>assumed-session-token</SessionToken>
+							</Credentials>
+						</AssumeRoleResult>
+					</AssumeRoleResponse>
+				`),
+			};
+
+			// Mock fetch for role assumption
+			global.fetch = jest.fn().mockResolvedValue(mockStsResponse);
+
+			const result = await aws.authenticate(oldCredentials as AwsCredentialsType, requestOptions);
+
+			// Check that the final sign call uses the assumed credentials
+			expect(mockSign).toHaveBeenCalledTimes(2);
+			const lastCall = mockSign.mock.calls[1];
+			expect(lastCall[1]).toMatchObject({
+				accessKeyId: 'assumed-access-key',
+				secretAccessKey: 'assumed-secret-key',
+				sessionToken: 'assumed-session-token',
+			});
+
+			process.env = originalEnv;
+		});
+
+		it('should assume role with system credentials when useSystemCredentialsForRole is true', async () => {
+			const roleCredentials: AwsCredentialsType = {
+				region: 'eu-central-1',
+				credentialType: 'assumeRole',
+				accessKeyId: '', // Not used for role assumption
+				secretAccessKey: '', // Not used for role assumption
+				temporaryCredentials: false,
+				customEndpoints: false,
+				roleArn: 'arn:aws:iam::123456789012:role/TestRole',
+				externalId: 'test-external-id',
+				roleSessionName: 'test-session',
+				useSystemCredentialsForRole: true,
+			};
+
+			// Mock system credentials for the STS call
+			const originalEnv = process.env;
+			process.env = {
+				...originalEnv,
+				AWS_ACCESS_KEY_ID: 'system-access-key',
+				AWS_SECRET_ACCESS_KEY: 'system-secret-key',
+			};
+
+			const mockStsResponse = {
+				ok: true,
+				text: () =>
+					Promise.resolve(`
+					<AssumeRoleResponse>
+						<AssumeRoleResult>
+							<Credentials>
+								<AccessKeyId>assumed-access-key</AccessKeyId>
+								<SecretAccessKey>assumed-secret-key</SecretAccessKey>
+								<SessionToken>assumed-session-token</SessionToken>
+							</Credentials>
+						</AssumeRoleResult>
+					</AssumeRoleResponse>
+				`),
+			};
+
+			// Mock fetch for role assumption
+			global.fetch = jest.fn().mockResolvedValue(mockStsResponse);
+
+			const result = await aws.authenticate(roleCredentials, requestOptions);
+
+			// Check that the final sign call uses the assumed credentials
+			expect(mockSign).toHaveBeenCalledTimes(2);
+			const lastCall = mockSign.mock.calls[1];
+			expect(lastCall[1]).toMatchObject({
+				accessKeyId: 'assumed-access-key',
+				secretAccessKey: 'assumed-secret-key',
+				sessionToken: 'assumed-session-token',
+			});
+
+			process.env = originalEnv;
+		});
+
+		it('should assume role with manual STS credentials when useSystemCredentialsForRole is false', async () => {
+			const roleCredentials: AwsCredentialsType = {
+				region: 'eu-central-1',
+				credentialType: 'assumeRole',
+				accessKeyId: '', // Not used for role assumption
+				secretAccessKey: '', // Not used for role assumption
+				temporaryCredentials: false,
+				customEndpoints: false,
+				roleArn: 'arn:aws:iam::123456789012:role/TestRole',
+				externalId: 'test-external-id',
+				roleSessionName: 'test-session',
+				useSystemCredentialsForRole: false,
+				temporaryStsCredentials: false, // Not using temporary STS credentials
+				stsAccessKeyId: 'sts-access-key',
+				stsSecretAccessKey: 'sts-secret-key',
+				// stsSessionToken is not shown when temporaryStsCredentials is false
+			};
+
+			const mockStsResponse = {
+				ok: true,
+				text: () =>
+					Promise.resolve(`
+					<AssumeRoleResponse>
+						<AssumeRoleResult>
+							<Credentials>
+								<AccessKeyId>assumed-access-key</AccessKeyId>
+								<SecretAccessKey>assumed-secret-key</SecretAccessKey>
+								<SessionToken>assumed-session-token</SessionToken>
+							</Credentials>
+						</AssumeRoleResult>
+					</AssumeRoleResponse>
+				`),
+			};
+
+			// Mock fetch for role assumption
+			global.fetch = jest.fn().mockResolvedValue(mockStsResponse);
+
+			const result = await aws.authenticate(roleCredentials, requestOptions);
+
+			// Check that the final sign call uses the assumed credentials
+			expect(mockSign).toHaveBeenCalledTimes(2);
+			const lastCall = mockSign.mock.calls[1];
+			expect(lastCall[1]).toMatchObject({
+				accessKeyId: 'assumed-access-key',
+				secretAccessKey: 'assumed-secret-key',
+				sessionToken: 'assumed-session-token',
+			});
+		});
+
+		it('should assume role with manual STS credentials including session token when temporaryStsCredentials is true', async () => {
+			const roleCredentials: AwsCredentialsType = {
+				region: 'eu-central-1',
+				credentialType: 'assumeRole',
+				accessKeyId: '', // Not used for role assumption
+				secretAccessKey: '', // Not used for role assumption
+				temporaryCredentials: false,
+				customEndpoints: false,
+				roleArn: 'arn:aws:iam::123456789012:role/TestRole',
+				externalId: 'test-external-id',
+				roleSessionName: 'test-session',
+				useSystemCredentialsForRole: false,
+				temporaryStsCredentials: true, // Using temporary STS credentials
+				stsAccessKeyId: 'sts-access-key',
+				stsSecretAccessKey: 'sts-secret-key',
+				stsSessionToken: 'sts-session-token', // Session token is shown when temporaryStsCredentials is true
+			};
+
+			const mockStsResponse = {
+				ok: true,
+				text: () =>
+					Promise.resolve(`
+					<AssumeRoleResponse>
+						<AssumeRoleResult>
+							<Credentials>
+								<AccessKeyId>assumed-access-key</AccessKeyId>
+								<SecretAccessKey>assumed-secret-key</SecretAccessKey>
+								<SessionToken>assumed-session-token</SessionToken>
+							</Credentials>
+						</AssumeRoleResult>
+					</AssumeRoleResponse>
+				`),
+			};
+
+			// Mock fetch for role assumption
+			global.fetch = jest.fn().mockResolvedValue(mockStsResponse);
+
+			const result = await aws.authenticate(roleCredentials, requestOptions);
+
+			// Check that the final sign call uses the assumed credentials
+			expect(mockSign).toHaveBeenCalledTimes(2);
+			const lastCall = mockSign.mock.calls[1];
+			expect(lastCall[1]).toMatchObject({
+				accessKeyId: 'assumed-access-key',
+				secretAccessKey: 'assumed-secret-key',
+				sessionToken: 'assumed-session-token',
+			});
+		});
+
+		it('should work with backward compatibility (no temporaryStsCredentials field)', async () => {
+			const roleCredentials: AwsCredentialsType = {
+				region: 'eu-central-1',
+				credentialType: 'assumeRole',
+				accessKeyId: '',
+				secretAccessKey: '',
+				temporaryCredentials: false,
+				customEndpoints: false,
+				roleArn: 'arn:aws:iam::123456789012:role/TestRole',
+				externalId: 'test-external-id',
+				roleSessionName: 'test-session',
+				useSystemCredentialsForRole: false,
+				// temporaryStsCredentials field is missing (backward compatibility)
+				stsAccessKeyId: 'sts-access-key',
+				stsSecretAccessKey: 'sts-secret-key',
+				stsSessionToken: 'sts-session-token', // This should be ignored when temporaryStsCredentials is not set
+			};
+
+			const mockStsResponse = {
+				ok: true,
+				text: () =>
+					Promise.resolve(`
+					<AssumeRoleResponse>
+						<AssumeRoleResult>
+							<Credentials>
+								<AccessKeyId>assumed-access-key</AccessKeyId>
+								<SecretAccessKey>assumed-secret-key</SecretAccessKey>
+								<SessionToken>assumed-session-token</SessionToken>
+							</Credentials>
+						</AssumeRoleResult>
+					</AssumeRoleResponse>
+				`),
+			};
+
+			// Mock fetch for role assumption
+			global.fetch = jest.fn().mockResolvedValue(mockStsResponse);
+
+			const result = await aws.authenticate(roleCredentials, requestOptions);
+
+			// Check that the final sign call uses the assumed credentials
+			expect(mockSign).toHaveBeenCalledTimes(2);
+			const lastCall = mockSign.mock.calls[1];
+			expect(lastCall[1]).toMatchObject({
+				accessKeyId: 'assumed-access-key',
+				secretAccessKey: 'assumed-secret-key',
+				sessionToken: 'assumed-session-token',
+			});
+		});
+
+		it('should throw error when role assumption fails', async () => {
+			const roleCredentials: AwsCredentialsType = {
+				region: 'eu-central-1',
+				credentialType: 'assumeRole',
+				accessKeyId: '',
+				secretAccessKey: '',
+				temporaryCredentials: false,
+				customEndpoints: false,
+				roleArn: 'arn:aws:iam::123456789012:role/TestRole',
+				externalId: 'test-external-id',
+				roleSessionName: 'test-session',
+				useSystemCredentialsForRole: true,
+			};
+
+			// Mock system credentials for the STS call
+			const originalEnv = process.env;
+			process.env = {
+				...originalEnv,
+				AWS_ACCESS_KEY_ID: 'system-access-key',
+				AWS_SECRET_ACCESS_KEY: 'system-secret-key',
+			};
+
+			const mockStsResponse = {
+				ok: false,
+				status: 403,
+				statusText: 'Forbidden',
+				text: () => Promise.resolve('<Error><Message>Access Denied</Message></Error>'),
+			};
+
+			// Mock fetch for role assumption
+			global.fetch = jest.fn().mockResolvedValue(mockStsResponse);
+
+			await expect(aws.authenticate(roleCredentials, requestOptions)).rejects.toThrow(
+				'STS AssumeRole failed: 403 Forbidden',
+			);
+
+			process.env = originalEnv;
+		});
+
+		it('should throw error if roleArn is missing for role assumption', async () => {
+			const roleCredentials: AwsCredentialsType = {
+				region: 'eu-central-1',
+				credentialType: 'assumeRole',
+				accessKeyId: '',
+				secretAccessKey: '',
+				temporaryCredentials: false,
+				customEndpoints: false,
+				externalId: 'test-external-id',
+				roleSessionName: 'test-session',
+				useSystemCredentialsForRole: true,
+			};
+
+			await expect(aws.authenticate(roleCredentials, requestOptions)).rejects.toThrow(
+				'Role ARN is required when assuming a role.',
+			);
+		});
+
+		it('should throw error if externalId is missing for role assumption', async () => {
+			const roleCredentials: AwsCredentialsType = {
+				region: 'eu-central-1',
+				credentialType: 'assumeRole',
+				accessKeyId: '',
+				secretAccessKey: '',
+				temporaryCredentials: false,
+				customEndpoints: false,
+				roleArn: 'arn:aws:iam::123456789012:role/TestRole',
+				roleSessionName: 'test-session',
+				useSystemCredentialsForRole: true,
+			};
+
+			await expect(aws.authenticate(roleCredentials, requestOptions)).rejects.toThrow(
+				'External ID is required when assuming a role.',
+			);
+		});
+
+		it('should throw error if roleSessionName is missing for role assumption', async () => {
+			const roleCredentials: AwsCredentialsType = {
+				region: 'eu-central-1',
+				credentialType: 'assumeRole',
+				accessKeyId: '',
+				secretAccessKey: '',
+				temporaryCredentials: false,
+				customEndpoints: false,
+				roleArn: 'arn:aws:iam::123456789012:role/TestRole',
+				externalId: 'test-external-id',
+				useSystemCredentialsForRole: true,
+			};
+
+			await expect(aws.authenticate(roleCredentials, requestOptions)).rejects.toThrow(
+				'Role Session Name is required when assuming a role.',
+			);
+		});
+
+		it('should throw error if STS credentials are missing when not using system credentials', async () => {
+			const roleCredentials: AwsCredentialsType = {
+				region: 'eu-central-1',
+				credentialType: 'assumeRole',
+				accessKeyId: '',
+				secretAccessKey: '',
+				temporaryCredentials: false,
+				customEndpoints: false,
+				roleArn: 'arn:aws:iam::123456789012:role/TestRole',
+				externalId: 'test-external-id',
+				roleSessionName: 'test-session',
+				useSystemCredentialsForRole: false,
+				// Missing STS credentials
+			};
+
+			await expect(aws.authenticate(roleCredentials, requestOptions)).rejects.toThrow(
+				'STS Access Key ID is required when not using system credentials.',
+			);
 		});
 	});
 });

--- a/packages/nodes-base/credentials/test/Aws.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/Aws.credentials.test.ts
@@ -238,8 +238,7 @@ describe('Aws Credential', () => {
 
 			const mockStsResponse = {
 				ok: true,
-				text: async () =>
-					Promise.resolve(`
+				text: async () => `
 					<AssumeRoleResponse>
 						<AssumeRoleResult>
 							<Credentials>
@@ -249,7 +248,7 @@ describe('Aws Credential', () => {
 							</Credentials>
 						</AssumeRoleResult>
 					</AssumeRoleResponse>
-				`),
+				`,
 			};
 
 			// Mock fetch for role assumption
@@ -291,8 +290,7 @@ describe('Aws Credential', () => {
 
 			const mockStsResponse = {
 				ok: true,
-				text: async () =>
-					Promise.resolve(`
+				text: async () => `
 					<AssumeRoleResponse>
 						<AssumeRoleResult>
 							<Credentials>
@@ -302,7 +300,7 @@ describe('Aws Credential', () => {
 							</Credentials>
 						</AssumeRoleResult>
 					</AssumeRoleResponse>
-				`),
+				`,
 			};
 
 			// Mock fetch for role assumption
@@ -342,8 +340,7 @@ describe('Aws Credential', () => {
 
 			const mockStsResponse = {
 				ok: true,
-				text: async () =>
-					Promise.resolve(`
+				text: async () => `
 					<AssumeRoleResponse>
 						<AssumeRoleResult>
 							<Credentials>
@@ -353,7 +350,7 @@ describe('Aws Credential', () => {
 							</Credentials>
 						</AssumeRoleResult>
 					</AssumeRoleResponse>
-				`),
+				`,
 			};
 
 			// Mock fetch for role assumption
@@ -391,8 +388,7 @@ describe('Aws Credential', () => {
 
 			const mockStsResponse = {
 				ok: true,
-				text: async () =>
-					Promise.resolve(`
+				text: async () => `
 					<AssumeRoleResponse>
 						<AssumeRoleResult>
 							<Credentials>
@@ -402,7 +398,7 @@ describe('Aws Credential', () => {
 							</Credentials>
 						</AssumeRoleResult>
 					</AssumeRoleResponse>
-				`),
+				`,
 			};
 
 			// Mock fetch for role assumption
@@ -440,8 +436,7 @@ describe('Aws Credential', () => {
 
 			const mockStsResponse = {
 				ok: true,
-				text: async () =>
-					Promise.resolve(`
+				text: async () => `
 					<AssumeRoleResponse>
 						<AssumeRoleResult>
 							<Credentials>
@@ -451,7 +446,7 @@ describe('Aws Credential', () => {
 							</Credentials>
 						</AssumeRoleResult>
 					</AssumeRoleResponse>
-				`),
+				`,
 			};
 
 			// Mock fetch for role assumption
@@ -647,8 +642,7 @@ describe('Aws Credential', () => {
 
 				const mockStsResponse = {
 					ok: true,
-					text: async () =>
-						Promise.resolve(`
+					text: async () => `
 						<AssumeRoleResponse>
 							<AssumeRoleResult>
 								<Credentials>
@@ -658,7 +652,7 @@ describe('Aws Credential', () => {
 								</Credentials>
 							</AssumeRoleResult>
 						</AssumeRoleResponse>
-					`),
+					`,
 				};
 
 				global.fetch = jest.fn().mockResolvedValue(mockStsResponse);
@@ -695,8 +689,7 @@ describe('Aws Credential', () => {
 
 				const mockStsResponse = {
 					ok: true,
-					text: async () =>
-						Promise.resolve(`
+					text: async () => `
 						<AssumeRoleResponse>
 							<AssumeRoleResult>
 								<Credentials>
@@ -706,7 +699,7 @@ describe('Aws Credential', () => {
 								</Credentials>
 							</AssumeRoleResult>
 						</AssumeRoleResponse>
-					`),
+					`,
 				};
 
 				global.fetch = jest.fn().mockResolvedValue(mockStsResponse);
@@ -743,8 +736,7 @@ describe('Aws Credential', () => {
 
 				const mockStsResponse = {
 					ok: true,
-					text: async () =>
-						Promise.resolve(`
+					text: async () => `
 						<AssumeRoleResponse>
 							<AssumeRoleResult>
 								<Credentials>
@@ -754,7 +746,7 @@ describe('Aws Credential', () => {
 								</Credentials>
 							</AssumeRoleResult>
 						</AssumeRoleResponse>
-					`),
+					`,
 				};
 
 				global.fetch = jest.fn().mockResolvedValue(mockStsResponse);
@@ -818,8 +810,7 @@ describe('Aws Credential', () => {
 
 				const mockStsResponse = {
 					ok: true,
-					text: async () =>
-						Promise.resolve(`
+					text: async () => `
 						<AssumeRoleResponse>
 							<AssumeRoleResult>
 								<Credentials>
@@ -829,7 +820,7 @@ describe('Aws Credential', () => {
 								</Credentials>
 							</AssumeRoleResult>
 						</AssumeRoleResponse>
-					`),
+					`,
 				};
 
 				global.fetch = jest.fn().mockResolvedValue(mockStsResponse);

--- a/packages/nodes-base/credentials/test/Aws.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/Aws.credentials.test.ts
@@ -238,7 +238,7 @@ describe('Aws Credential', () => {
 
 			const mockStsResponse = {
 				ok: true,
-				text: () =>
+				text: async () =>
 					Promise.resolve(`
 					<AssumeRoleResponse>
 						<AssumeRoleResult>
@@ -291,7 +291,7 @@ describe('Aws Credential', () => {
 
 			const mockStsResponse = {
 				ok: true,
-				text: () =>
+				text: async () =>
 					Promise.resolve(`
 					<AssumeRoleResponse>
 						<AssumeRoleResult>
@@ -342,7 +342,7 @@ describe('Aws Credential', () => {
 
 			const mockStsResponse = {
 				ok: true,
-				text: () =>
+				text: async () =>
 					Promise.resolve(`
 					<AssumeRoleResponse>
 						<AssumeRoleResult>
@@ -391,7 +391,7 @@ describe('Aws Credential', () => {
 
 			const mockStsResponse = {
 				ok: true,
-				text: () =>
+				text: async () =>
 					Promise.resolve(`
 					<AssumeRoleResponse>
 						<AssumeRoleResult>
@@ -440,7 +440,7 @@ describe('Aws Credential', () => {
 
 			const mockStsResponse = {
 				ok: true,
-				text: () =>
+				text: async () =>
 					Promise.resolve(`
 					<AssumeRoleResponse>
 						<AssumeRoleResult>
@@ -495,7 +495,7 @@ describe('Aws Credential', () => {
 				ok: false,
 				status: 403,
 				statusText: 'Forbidden',
-				text: () => Promise.resolve('<Error><Message>Access Denied</Message></Error>'),
+				text: async () => Promise.resolve('<Error><Message>Access Denied</Message></Error>'),
 			};
 
 			// Mock fetch for role assumption
@@ -647,7 +647,7 @@ describe('Aws Credential', () => {
 
 				const mockStsResponse = {
 					ok: true,
-					text: () =>
+					text: async () =>
 						Promise.resolve(`
 						<AssumeRoleResponse>
 							<AssumeRoleResult>
@@ -695,7 +695,7 @@ describe('Aws Credential', () => {
 
 				const mockStsResponse = {
 					ok: true,
-					text: () =>
+					text: async () =>
 						Promise.resolve(`
 						<AssumeRoleResponse>
 							<AssumeRoleResult>
@@ -743,7 +743,7 @@ describe('Aws Credential', () => {
 
 				const mockStsResponse = {
 					ok: true,
-					text: () =>
+					text: async () =>
 						Promise.resolve(`
 						<AssumeRoleResponse>
 							<AssumeRoleResult>
@@ -818,7 +818,7 @@ describe('Aws Credential', () => {
 
 				const mockStsResponse = {
 					ok: true,
-					text: () =>
+					text: async () =>
 						Promise.resolve(`
 						<AssumeRoleResponse>
 							<AssumeRoleResult>

--- a/packages/nodes-base/credentials/test/Aws.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/Aws.credentials.test.ts
@@ -255,7 +255,7 @@ describe('Aws Credential', () => {
 			// Mock fetch for role assumption
 			global.fetch = jest.fn().mockResolvedValue(mockStsResponse);
 
-			const result = await aws.authenticate(oldCredentials as AwsCredentialsType, requestOptions);
+			await aws.authenticate(oldCredentials as AwsCredentialsType, requestOptions);
 
 			// Check that the final sign call uses the assumed credentials
 			expect(mockSign).toHaveBeenCalledTimes(2);
@@ -308,7 +308,7 @@ describe('Aws Credential', () => {
 			// Mock fetch for role assumption
 			global.fetch = jest.fn().mockResolvedValue(mockStsResponse);
 
-			const result = await aws.authenticate(roleCredentials, requestOptions);
+			await aws.authenticate(roleCredentials, requestOptions);
 
 			// Check that the final sign call uses the assumed credentials
 			expect(mockSign).toHaveBeenCalledTimes(2);
@@ -359,7 +359,7 @@ describe('Aws Credential', () => {
 			// Mock fetch for role assumption
 			global.fetch = jest.fn().mockResolvedValue(mockStsResponse);
 
-			const result = await aws.authenticate(roleCredentials, requestOptions);
+			await aws.authenticate(roleCredentials, requestOptions);
 
 			// Check that the final sign call uses the assumed credentials
 			expect(mockSign).toHaveBeenCalledTimes(2);
@@ -408,7 +408,7 @@ describe('Aws Credential', () => {
 			// Mock fetch for role assumption
 			global.fetch = jest.fn().mockResolvedValue(mockStsResponse);
 
-			const result = await aws.authenticate(roleCredentials, requestOptions);
+			await aws.authenticate(roleCredentials, requestOptions);
 
 			// Check that the final sign call uses the assumed credentials
 			expect(mockSign).toHaveBeenCalledTimes(2);
@@ -457,7 +457,7 @@ describe('Aws Credential', () => {
 			// Mock fetch for role assumption
 			global.fetch = jest.fn().mockResolvedValue(mockStsResponse);
 
-			const result = await aws.authenticate(roleCredentials, requestOptions);
+			await aws.authenticate(roleCredentials, requestOptions);
 
 			// Check that the final sign call uses the assumed credentials
 			expect(mockSign).toHaveBeenCalledTimes(2);
@@ -663,7 +663,7 @@ describe('Aws Credential', () => {
 
 				global.fetch = jest.fn().mockResolvedValue(mockStsResponse);
 
-				const result = await aws.authenticate(legacyRoleCredentials, requestOptions);
+				await aws.authenticate(legacyRoleCredentials, requestOptions);
 
 				expect(mockSign).toHaveBeenCalledTimes(2);
 				const lastCall = mockSign.mock.calls[1];
@@ -711,7 +711,7 @@ describe('Aws Credential', () => {
 
 				global.fetch = jest.fn().mockResolvedValue(mockStsResponse);
 
-				const result = await aws.authenticate(legacyRoleCredentials, requestOptions);
+				await aws.authenticate(legacyRoleCredentials, requestOptions);
 
 				expect(mockSign).toHaveBeenCalledTimes(2);
 				const lastCall = mockSign.mock.calls[1];
@@ -759,7 +759,7 @@ describe('Aws Credential', () => {
 
 				global.fetch = jest.fn().mockResolvedValue(mockStsResponse);
 
-				const result = await aws.authenticate(legacyRoleCredentials, requestOptions);
+				await aws.authenticate(legacyRoleCredentials, requestOptions);
 
 				expect(mockSign).toHaveBeenCalledTimes(2);
 				const lastCall = mockSign.mock.calls[1];
@@ -834,7 +834,7 @@ describe('Aws Credential', () => {
 
 				global.fetch = jest.fn().mockResolvedValue(mockStsResponse);
 
-				const result = await aws.authenticate(newFormatCredentials, requestOptions);
+				await aws.authenticate(newFormatCredentials, requestOptions);
 
 				expect(mockSign).toHaveBeenCalledTimes(2);
 				const lastCall = mockSign.mock.calls[1];

--- a/packages/nodes-base/credentials/test/Aws.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/Aws.credentials.test.ts
@@ -490,7 +490,7 @@ describe('Aws Credential', () => {
 				ok: false,
 				status: 403,
 				statusText: 'Forbidden',
-				text: async () => Promise.resolve('<Error><Message>Access Denied</Message></Error>'),
+				text: async () => '<Error><Message>Access Denied</Message></Error>',
 			};
 
 			// Mock fetch for role assumption


### PR DESCRIPTION
## Summary

This PR adds improvements to the AWS credential that address both security best practices and allows for advanced AWS access patterns, like enabling cross-account AWS access on behalf of the user's credentials, or the n8n server.

The current implementation only allows for IAM User Access Key / Secret Key (or temporary credentials that will need to be constantly refreshed). This pattern is against AWS's best practice recommendations to have workloads that assume an IAM Role rather than rely on long-lived credentials:

https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#bp-workloads-use-roles
https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user.html
https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_common-scenarios_third-party.html
https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-role.html?utm_source=chatgpt.com#cli-role-prepare

To address this, I've added a new feature to the AWS Credential. Once PR is reviewed and merged, I will gladly add documentation.

Summary:

1. Add a toggle for "Credential Type" which by default is the existing options for `IAM Access Key` and new option for `Assume IAM Role`

2. For Role Assumption: 

- the user must provide a Role ARN, an ExternalID (to address the "Confused Deputy" problem) and a Session Name
- the user can choose to "Use System Credentials for STS Call" if the n8n administrator has configured AWS credentials in the environment variables OR in an EC2/ECS/EKS role on the n8n server. The system creds must have permission to assume roles on behalf of any n8n users and should require an external id to be configured. (The system credentials will never be used for anything but `sts.AssumeRole` by this credential, users must not be allowed to use the system creds for workflows)
- the user can also choose to provide an Access Key & Secret Key that is used to perform the STS AssumeRole call if the administrator has not configured system AWS credentials. 

⚠️ Note about External ID: This should actually be something unique that n8n generates per-credential and displays to the user, and not something the user is able to configure. I couldn't figure out a way to make the credential editor do something like this though (generate a value that is used as part of the credential and display it read-only to the user). Instead, I've documented this deviation from best practice and suggest to the user that the External ID they generate on their own should be treated as a secret from any other users they don't trust within the same n8n instance. This is not ideal but is the best I can come up with.

https://aws.amazon.com/blogs/apn/securely-using-external-id-for-accessing-aws-accounts-owned-by-others/

3. For IAM Access Key:

- the behavior is still the same and is backward compatible with existing AWS credentials
- I have created several unit tests that show existing credentials should continue working fine, but someone else might want to review too

![aws_credential](https://github.com/user-attachments/assets/acec3b3b-56e5-4038-9601-73ae77288cd8)

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) 
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
