### PR TITLE
fix(Embeddings Google Gemini Node): Use credential host as baseUrl 

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsGoogleGemini/EmbeddingsGoogleGemini.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsGoogleGemini/EmbeddingsGoogleGemini.node.ts
@@ -111,7 +111,7 @@ export class EmbeddingsGoogleGemini implements INodeType {
 						property: 'model',
 					},
 				},
-				default: 'textembedding-gecko-multilingual@latest',
+				default: 'models/text-embedding-004',
 			},
 		],
 	};
@@ -121,11 +121,12 @@ export class EmbeddingsGoogleGemini implements INodeType {
 		const modelName = this.getNodeParameter(
 			'modelName',
 			itemIndex,
-			'textembedding-gecko-multilingual@latest',
+			'models/text-embedding-004',
 		) as string;
 		const credentials = await this.getCredentials('googlePalmApi');
 		const embeddings = new GoogleGenerativeAIEmbeddings({
 			apiKey: credentials.apiKey as string,
+			baseUrl: credentials.host as string,
 			model: modelName,
 		});
 


### PR DESCRIPTION
## Summary
This PR adds the same passing of the baseUrl from the credentials to the Google Gemini Embeddings node. That's the same already present on the corresponding LLM node and should allow using custom URLs (e.g. as a proxy) in the same way.
Also updated the default model as the current one is not supported anymore.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-961/community-issue-gemini-embedding-node-ignores-custom-base-urlproxy
closes #15514 

## Review / Merge checklist
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
