### PR TITLE
fix: Rename chat.css to style.css in chat package build

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/README.md
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/README.md
@@ -50,5 +50,5 @@ Modify the import paths in `templates.ts` to point to your local server:
 ```
 
 ```html
-<link href="https://127.0.0.1:8443/chat.css" rel="stylesheet" />
+<link href="https://127.0.0.1:8443/style.css" rel="stylesheet" />
 ```

--- a/packages/frontend/@n8n/chat/vite.config.mts
+++ b/packages/frontend/@n8n/chat/vite.config.mts
@@ -1,5 +1,6 @@
 import { defineConfig, mergeConfig } from 'vite';
 import { resolve } from 'path';
+import { renameSync } from 'fs';
 import vue from '@vitejs/plugin-vue';
 import icons from 'unplugin-icons/vite';
 import dts from 'vite-plugin-dts';
@@ -18,6 +19,21 @@ export default mergeConfig(
 				autoInstall: true,
 			}),
 			dts(),
+			{
+				name: 'rename-css-file',
+				buildEnd() {
+					// The chat.css is automatically named based on vite.config.ts library name.
+					// ChatTrigger Node requires https://cdn.jsdelivr.net/npm/@n8n/chat/dist/style.css
+					// As such for backwards compatibility, we need to maintain the same name file
+					const cssPath = resolve(__dirname, 'dist', 'chat.css');
+					const newCssPath = resolve(__dirname, 'dist', 'style.css');
+					try {
+						renameSync(cssPath, newCssPath);
+					} catch (error) {
+						console.error('Failed to rename chat.css file:', error);
+					}
+				},
+			},
 		],
 		resolve: {
 			alias: {

--- a/packages/frontend/@n8n/chat/vite.config.mts
+++ b/packages/frontend/@n8n/chat/vite.config.mts
@@ -21,7 +21,7 @@ export default mergeConfig(
 			dts(),
 			{
 				name: 'rename-css-file',
-				buildEnd() {
+				closeBundle() {
 					// The chat.css is automatically named based on vite.config.ts library name.
 					// ChatTrigger Node requires https://cdn.jsdelivr.net/npm/@n8n/chat/dist/style.css
 					// As such for backwards compatibility, we need to maintain the same name file


### PR DESCRIPTION
## Summary

In the chat trigger node we are loading

```
<link href="https://cdn.jsdelivr.net/npm/normalize.css@8.0.1/normalize.min.css" rel="stylesheet" /> 
<link href="https://cdn.jsdelivr.net/npm/@n8n/chat/dist/style.css" rel="stylesheet" />
```

Looks like around [chat@0.33.0 ](https://cdn.jsdelivr.net/npm/@n8n/chat@0.33.0/dist/) we stopped creating style.css file when building the chat package. Instead we are creating chat.css

That means jsdeliver is returning non-matching styles and js files. For styles, it's returning 0.33.0 and for js it's returning 0.44.0, the latest. 

Before
<img width="1467" alt="Screenshot 2025-06-23 at 11 47 33" src="https://github.com/user-attachments/assets/e8aa8244-3b2f-4ebc-8c11-39eb0bef3194" />

After (redirecting style.css -> chat.css)
<img width="1431" alt="Screenshot 2025-06-23 at 11 48 29" src="https://github.com/user-attachments/assets/0228102c-8429-4f93-97d6-747e99e5de58" />

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-1081/chat-input-field-is-messed-up
 https://github.com/n8n-io/n8n/issues/16608
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
