### PR TITLE
fix(core): Fix module path resolution for Docker

### DIFF
--- a/packages/@n8n/backend-common/src/modules/module-registry.ts
+++ b/packages/@n8n/backend-common/src/modules/module-registry.ts
@@ -49,8 +49,21 @@ export class ModuleRegistry {
 	 */
 	async loadModules(modules?: ModuleName[]) {
 		const moduleDir = process.env.NODE_ENV === 'test' ? 'src' : 'dist';
-		const modulesDir = path.resolve(__dirname, `../../../../cli/${moduleDir}/modules`);
+		let modulesDir: string;
 
+		if (process.env.NODE_ENV === 'test') {
+			modulesDir = path.resolve(__dirname, `../../../../cli/${moduleDir}/modules`);
+		} else {
+			try {
+				// For Docker
+				const n8nPackagePath = require.resolve('n8n/package.json');
+				const n8nRoot = path.dirname(n8nPackagePath);
+				modulesDir = path.join(n8nRoot, moduleDir, 'modules');
+			} catch {
+				// Fallback to relative path for development
+				modulesDir = path.resolve(__dirname, `../../../../cli/${moduleDir}/modules`);
+			}
+		}
 		for (const moduleName of modules ?? this.eligibleModules) {
 			try {
 				await import(`${modulesDir}/${moduleName}/${moduleName}.module`);


### PR DESCRIPTION
## Summary

At #16528 we moved module loading from `cli` to `@n8n/backend-common` and to account for loading cross-package, we added path traversal, which turned out to be incompatible with the tree structure of the built Docker image. This PR is a quickfix to account for this as well.

## Related Linear tickets, Github issues, and Community forum posts

Context: https://github.com/n8n-io/n8n-cloud/actions/runs/15804593100

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
