### PR TITLE
fix(Google Sheets Node): Inconsistent Google Sheet Tool update behavior due to wrong type of row_number field

### DIFF
--- a/packages/nodes-base/nodes/Google/Sheet/test/v2/methods/resourceMapping.test.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/test/v2/methods/resourceMapping.test.ts
@@ -84,7 +84,7 @@ describe('Google Sheets, getMappingColumns', () => {
 				readOnly: true,
 				removed: true,
 				required: false,
-				type: 'string',
+				type: 'number',
 			},
 		]);
 	});

--- a/packages/nodes-base/nodes/Google/Sheet/v2/methods/resourceMapping.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/methods/resourceMapping.ts
@@ -70,7 +70,7 @@ export async function getMappingColumns(
 			required: false,
 			defaultMatch: false,
 			display: true,
-			type: 'string',
+			type: 'number',
 			canBeUsedToMatch: true,
 			readOnly: true,
 			removed: true,


### PR DESCRIPTION
## Summary

`row_number` field property used to match rows for the update operation in Google Sheet was `string`, but used as a number:
https://github.com/n8n-io/n8n/blob/f4d0b9f79609633f86a6126d060fdc1c13ca5ab9/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheet.ts#L610

Using the Google Sheet node's update operation as a tool for AI Agent ended up with incorrect tool schema (`row_number: string`). Also, when switching to expression mode to customize `$fromAi` parameters – it was possible to accidentally add a space after the `{{ $fromAi(...) }} `, which led to Google Sheet API error `Unable to parse range`

So the type for the field was changed to `number`.

## Related Linear tickets, Github issues, and Community forum posts

- https://github.com/n8n-io/n8n/issues/13366
- https://linear.app/n8n/issue/AI-856/community-issue-error-using-google-sheets-tools-with-ai-agents-to


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
