### PR TITLE
refactor(core): Port some legacy top-level schema keys

### DIFF
--- a/packages/@n8n/config/src/index.ts
+++ b/packages/@n8n/config/src/index.ts
@@ -178,4 +178,16 @@ export class GlobalConfig {
 	/** Number of reverse proxies n8n is running behind. */
 	@Env('N8N_PROXY_HOPS')
 	proxy_hops: number = 0;
+
+	/** SSL key for HTTPS protocol. */
+	@Env('N8N_SSL_KEY')
+	ssl_key: string = '';
+
+	/** SSL cert for HTTPS protocol. */
+	@Env('N8N_SSL_CERT')
+	ssl_cert: string = '';
+
+	/** Public URL where the editor is accessible. Also used for emails sent from n8n. */
+	@Env('N8N_EDITOR_BASE_URL')
+	editorBaseUrl: string = '';
 }

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -48,6 +48,9 @@ describe('GlobalConfig', () => {
 			enabled: true,
 		},
 		proxy_hops: 0,
+		ssl_key: '',
+		ssl_cert: '',
+		editorBaseUrl: '',
 		database: {
 			logging: {
 				enabled: false,

--- a/packages/cli/src/abstract-server.ts
+++ b/packages/cli/src/abstract-server.ts
@@ -75,8 +75,8 @@ export abstract class AbstractServer {
 		const proxyHops = this.globalConfig.proxy_hops;
 		if (proxyHops > 0) this.app.set('trust proxy', proxyHops);
 
-		this.sslKey = config.getEnv('ssl_key');
-		this.sslCert = config.getEnv('ssl_cert');
+		this.sslKey = this.globalConfig.ssl_key;
+		this.sslCert = this.globalConfig.ssl_cert;
 
 		const { endpoints } = this.globalConfig;
 		this.restEndpoint = endpoints.rest;

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -102,25 +102,6 @@ export const schema = {
 		},
 	},
 
-	ssl_key: {
-		format: String,
-		default: '',
-		env: 'N8N_SSL_KEY',
-		doc: 'SSL Key for HTTPS Protocol',
-	},
-	ssl_cert: {
-		format: String,
-		default: '',
-		env: 'N8N_SSL_CERT',
-		doc: 'SSL Cert for HTTPS Protocol',
-	},
-	editorBaseUrl: {
-		format: String,
-		default: '',
-		env: 'N8N_EDITOR_BASE_URL',
-		doc: 'Public URL where the editor is accessible. Also used for emails sent from n8n.',
-	},
-
 	userManagement: {
 		jwtSecret: {
 			doc: 'Set a specific JWT secret (optional - n8n can generate one)', // Generated @ start.ts

--- a/packages/cli/src/services/__tests__/url.service.test.ts
+++ b/packages/cli/src/services/__tests__/url.service.test.ts
@@ -1,42 +1,51 @@
 import type { GlobalConfig } from '@n8n/config';
 import { mock } from 'jest-mock-extended';
 
-import config from '@/config';
-
 import { UrlService } from '../url.service';
 
 describe('UrlService', () => {
 	beforeEach(() => {
 		process.env.WEBHOOK_URL = undefined;
-		config.load(config.default);
 	});
 
 	describe('getInstanceBaseUrl', () => {
 		it('should set URL from N8N_EDITOR_BASE_URL', () => {
-			config.set('editorBaseUrl', 'https://example.com/');
 			process.env.WEBHOOK_URL = undefined;
-			const urlService = new UrlService(mock<GlobalConfig>());
+			const urlService = new UrlService(
+				mock<GlobalConfig>({
+					editorBaseUrl: 'https://example.com/',
+				}),
+			);
 			expect(urlService.getInstanceBaseUrl()).toBe('https://example.com');
 		});
 
 		it('should set URL from WEBHOOK_URL', () => {
-			config.set('editorBaseUrl', '');
 			process.env.WEBHOOK_URL = 'https://example.com/';
-			const urlService = new UrlService(mock<GlobalConfig>());
+			const urlService = new UrlService(
+				mock<GlobalConfig>({
+					editorBaseUrl: '',
+				}),
+			);
 			expect(urlService.getInstanceBaseUrl()).toBe('https://example.com');
 		});
 
 		it('should trim quotes when setting URL from N8N_EDITOR_BASE_URL', () => {
-			config.set('editorBaseUrl', '"https://example.com"');
 			process.env.WEBHOOK_URL = undefined;
-			const urlService = new UrlService(mock<GlobalConfig>());
+			const urlService = new UrlService(
+				mock<GlobalConfig>({
+					editorBaseUrl: '"https://example.com"',
+				}),
+			);
 			expect(urlService.getInstanceBaseUrl()).toBe('https://example.com');
 		});
 
 		it('should trim quotes when setting URL from WEBHOOK_URL', () => {
-			config.set('editorBaseUrl', '');
 			process.env.WEBHOOK_URL = '"https://example.com/"';
-			const urlService = new UrlService(mock<GlobalConfig>());
+			const urlService = new UrlService(
+				mock<GlobalConfig>({
+					editorBaseUrl: '',
+				}),
+			);
 			expect(urlService.getInstanceBaseUrl()).toBe('https://example.com');
 		});
 	});

--- a/packages/cli/src/services/__tests__/user.service.test.ts
+++ b/packages/cli/src/services/__tests__/user.service.test.ts
@@ -15,6 +15,7 @@ describe('UserService', () => {
 		port: 5678,
 		listen_address: '::',
 		protocol: 'http',
+		editorBaseUrl: '',
 	});
 	const urlService = new UrlService(globalConfig);
 	const userRepository = mockInstance(UserRepository);

--- a/packages/cli/src/services/url.service.ts
+++ b/packages/cli/src/services/url.service.ts
@@ -1,8 +1,6 @@
 import { GlobalConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
 
-import config from '@/config';
-
 @Service()
 export class UrlService {
 	/** Returns the base URL n8n is reachable from */
@@ -23,7 +21,7 @@ export class UrlService {
 
 	/** Return the n8n instance base URL without trailing slash */
 	getInstanceBaseUrl(): string {
-		const n8nBaseUrl = this.trimQuotes(config.getEnv('editorBaseUrl')) || this.getWebhookBaseUrl();
+		const n8nBaseUrl = this.trimQuotes(this.globalConfig.editorBaseUrl) || this.getWebhookBaseUrl();
 
 		return n8nBaseUrl.endsWith('/') ? n8nBaseUrl.slice(0, n8nBaseUrl.length - 1) : n8nBaseUrl;
 	}


### PR DESCRIPTION
## Summary

Quick PR to continue porting legacy schema keys. 

Follow-up to #16318


## Related Linear tickets, Github issues, and Community forum posts

n/a
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
