### PR TITLE
chore: Do not reset .claude dir on reset

### DIFF
--- a/scripts/reset.mjs
+++ b/scripts/reset.mjs
@@ -4,7 +4,7 @@ import { $, echo, fs } from 'zx';
 $.verbose = true;
 process.env.FORCE_COLOR = '1';
 
-const excludePatterns = ['/.vscode/', '/.idea/', '.env'];
+const excludePatterns = ['/.vscode/', '/.idea/', '.env', '/.claude/'];
 const excludeFlags = excludePatterns.map((exclude) => ['-e', exclude]).flat();
 
 echo(


### PR DESCRIPTION
## Summary

So the dir doesn't get removed on `pnpm reset`


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
