### PR TITLE
fix: Make embedding model ID matching case-insensitive

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsOpenAI/EmbeddingsOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsOpenAI/EmbeddingsOpenAi.node.ts
@@ -37,7 +37,7 @@ const modelParameter: INodeProperties = {
 						{
 							type: 'filter',
 							properties: {
-								pass: "={{ $responseItem.id.includes('embed') }}",
+								pass: "={{ $responseItem.id.toLowerCase().includes('embed') }}",
 							},
 						},
 						{


### PR DESCRIPTION
## Summary

Fixes an issue where some embedding models (e.g. `Qwen3-Embedding-8B-4bit`) were not showing up in the model dropdown in the "Embeddings OpenAI" node due to a case-sensitive check (`id.includes('embed')`).

This PR makes the check case-insensitive by changing it to `id.toLowerCase().includes('embed')`.

To test:
1. Connect an OpenAI-compatible API with a model whose ID includes `Embedding` (capital E).
2. Go to the "Embeddings OpenAI" node.
3. Confirm that the model now appears in the "Model" dropdown.

Before:  
❌ `Qwen3-Embedding-8B-4bit` not listed.

After:  
✅ `Qwen3-Embedding-8B-4bit` now listed as expected.

---

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/Trans-N-ai/swama/issues/34

---

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. *(not needed for this UI fix)*
- [x] Tests included. *(N/A - minor UI filtering logic)*
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
