### PR TITLE
feat: Update default Gemini model to `gemini-2.5-flash`

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/imageUtils.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/imageUtils.test.ts
@@ -191,7 +191,7 @@ describe('imageUtils', () => {
 			// Mock a Google model - using our mocked class
 			mockContext.getInputConnectionData.mockResolvedValue(
 				new ChatGoogleGenerativeAI({
-					model: 'gemini-1.0-pro',
+					model: 'gemini-2.5-flash',
 				}),
 			);
 

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleGemini/LmChatGoogleGemini.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleGemini/LmChatGoogleGemini.node.ts
@@ -118,7 +118,7 @@ export class LmChatGoogleGemini implements INodeType {
 						property: 'model',
 					},
 				},
-				default: 'models/gemini-1.0-pro',
+				default: 'models/gemini-2.5-flash',
 			},
 			additionalOptions,
 		],


### PR DESCRIPTION
## Summary

Gemini 1.0 Pro is no longer supported. 

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-1015/model-list-not-loading-all-options


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
