### PR TITLE
chore(core): Expose mfaEnabled field to users list endpoint

### DIFF
--- a/packages/@n8n/api-types/src/dto/user/users-list-filter.dto.ts
+++ b/packages/@n8n/api-types/src/dto/user/users-list-filter.dto.ts
@@ -11,6 +11,8 @@ const USERS_LIST_SORT_OPTIONS = [
 	'lastName:desc',
 	'role:asc', // ascending order by role is Owner, Admin, Member
 	'role:desc',
+	'mfaEnabled:asc',
+	'mfaEnabled:desc',
 	// 'lastActive:asc',
 	// 'lastActive:desc',
 ] as const;
@@ -32,6 +34,7 @@ const userFilterSchema = z.object({
 	firstName: z.string().optional(),
 	lastName: z.string().optional(),
 	email: z.string().optional(),
+	mfaEnabled: z.boolean().optional(),
 	fullText: z.string().optional(), // Full text search across firstName, lastName, and email
 });
 

--- a/packages/@n8n/api-types/src/schemas/user.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/user.schema.ts
@@ -35,6 +35,7 @@ export const userListItemSchema = z.object({
 	personalizationAnswers: z.object({}).passthrough().nullable().optional(),
 	lastActive: z.string().optional(),
 	projectRelations: z.array(userProjectSchema).nullable().optional(),
+	mfaEnabled: z.boolean().optional(),
 });
 
 export const usersListSchema = z.object({

--- a/packages/@n8n/db/src/repositories/user.repository.ts
+++ b/packages/@n8n/db/src/repositories/user.repository.ts
@@ -182,6 +182,12 @@ export class UserRepository extends Repository<User> {
 			});
 		}
 
+		if (filter?.mfaEnabled !== undefined) {
+			queryBuilder.andWhere('user.mfaEnabled = :mfaEnabled', {
+				mfaEnabled: filter.mfaEnabled,
+			});
+		}
+
 		if (filter?.isOwner !== undefined) {
 			if (filter.isOwner) {
 				queryBuilder.andWhere('user.role = :role', {
@@ -240,13 +246,13 @@ export class UserRepository extends Repository<User> {
 		if (sortBy) {
 			for (const sort of sortBy) {
 				const [field, order] = sort.split(':');
-				if (field === 'firstName' || field === 'lastName') {
-					queryBuilder.addOrderBy(`user.${field}`, order.toUpperCase() as 'ASC' | 'DESC');
-				} else if (field === 'role') {
+				if (field === 'role') {
 					queryBuilder.addOrderBy(
 						"CASE WHEN user.role='global:owner' THEN 0 WHEN user.role='global:admin' THEN 1 ELSE 2 END",
 						order.toUpperCase() as 'ASC' | 'DESC',
 					);
+				} else {
+					queryBuilder.addOrderBy(`user.${field}`, order.toUpperCase() as 'ASC' | 'DESC');
 				}
 			}
 		}

--- a/packages/cli/test/integration/shared/utils/users.ts
+++ b/packages/cli/test/integration/shared/utils/users.ts
@@ -13,6 +13,7 @@ export const validateUser = (user: PublicUser) => {
 	expect(user.personalizationAnswers).toBeNull();
 	expect(user.password).toBeUndefined();
 	expect(user.role).toBeDefined();
+	expect(typeof (user as any).mfaEnabled).toBe('boolean');
 };
 
 export type UserInvitationResult = {


### PR DESCRIPTION
## Summary

This exposes the `mfaEnabled` field in the users list endpoint. It also adds sorting and filtering based on the `mfaEnabled`field.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-2989/add-2fa-field-for-user-in-be

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
