### PR TITLE
feat: Env variables to control allowed weaver scripts are allowed, disable specific tags, attributes and headers in webhook response

### DIFF
--- a/packages/nodes-base/nodes/RespondToWebhook/RespondToWebhook.node.ts
+++ b/packages/nodes-base/nodes/RespondToWebhook/RespondToWebhook.node.ts
@@ -28,6 +28,7 @@ import {
 	formatPrivateKey,
 	generatePairedItemData,
 	isHTML,
+	sanitizeHtmlBasedOnEnv,
 } from '../../utils/utilities';
 
 const respondWithProperty: INodeProperties = {
@@ -464,7 +465,8 @@ export class RespondToWebhook implements INodeType {
 			}
 
 			if (typeof responseBody === 'string' && isHTML(responseBody)) {
-				responseBody = responseBody;
+				console.log('sanitize html');
+				responseBody = sanitizeHtmlBasedOnEnv(responseBody);
 			}
 
 			if (Object.keys(headers).length) checkDisallowedHeaders(headers);

--- a/packages/nodes-base/nodes/RespondToWebhook/RespondToWebhook.node.ts
+++ b/packages/nodes-base/nodes/RespondToWebhook/RespondToWebhook.node.ts
@@ -23,7 +23,12 @@ import {
 import type { Readable } from 'stream';
 
 import { configuredOutputs } from './utils';
-import { formatPrivateKey, generatePairedItemData } from '../../utils/utilities';
+import {
+	checkDisallowedHeaders,
+	formatPrivateKey,
+	generatePairedItemData,
+	isHTML,
+} from '../../utils/utilities';
 
 const respondWithProperty: INodeProperties = {
 	displayName: 'Respond With',
@@ -457,6 +462,12 @@ export class RespondToWebhook implements INodeType {
 					`The Response Data option "${respondWith}" is not supported!`,
 				);
 			}
+
+			if (typeof responseBody === 'string' && isHTML(responseBody)) {
+				responseBody = responseBody;
+			}
+
+			if (Object.keys(headers).length) checkDisallowedHeaders(headers);
 
 			response = {
 				body: responseBody,

--- a/packages/nodes-base/utils/utilities.ts
+++ b/packages/nodes-base/utils/utilities.ts
@@ -482,6 +482,8 @@ export const removeTrailingSlash = (url: string) => {
 };
 
 export function isHTML(input: string): boolean {
+	if (!input) return false;
+	if (!/<([a-z][a-z0-9]*)[^>]*>/.test(input)) return false;
 	const $ = cheerio.load(input);
 	return $.root()
 		.children()


### PR DESCRIPTION
## Summary

Env variables to control allowed weaver scripts are allowed, disable specific tags, attributes and headers in webhook response:

DISALLOWED_HEADERS
DISABLE_SCRIPT_TAG
DISABLE_TAGS
DISABLE_ATTRIBUTES

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-3121/xss-in-form-submission
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
