### PR TITLE
fix(Jira Software Node): Fix issue with credential test not working correctly

### DIFF
--- a/packages/nodes-base/credentials/JiraSoftwareCloudApi.credentials.ts
+++ b/packages/nodes-base/credentials/JiraSoftwareCloudApi.credentials.ts
@@ -49,7 +49,7 @@ export class JiraSoftwareCloudApi implements ICredentialType {
 	test: ICredentialTestRequest = {
 		request: {
 			baseURL: '={{$credentials?.domain}}',
-			url: '/rest/api/2/project',
+			url: '/rest/api/2/myself',
 		},
 	};
 }

--- a/packages/nodes-base/credentials/JiraSoftwareServerApi.credentials.ts
+++ b/packages/nodes-base/credentials/JiraSoftwareServerApi.credentials.ts
@@ -51,7 +51,7 @@ export class JiraSoftwareServerApi implements ICredentialType {
 	test: ICredentialTestRequest = {
 		request: {
 			baseURL: '={{$credentials?.domain}}',
-			url: '/rest/api/2/project',
+			url: '/rest/api/2/myself',
 		},
 	};
 }

--- a/packages/nodes-base/credentials/JiraSoftwareServerPatApi.credentials.ts
+++ b/packages/nodes-base/credentials/JiraSoftwareServerPatApi.credentials.ts
@@ -41,7 +41,7 @@ export class JiraSoftwareServerPatApi implements ICredentialType {
 	test: ICredentialTestRequest = {
 		request: {
 			baseURL: '={{$credentials?.domain}}',
-			url: '/rest/api/2/project',
+			url: '/rest/api/2/myself',
 		},
 	};
 }


### PR DESCRIPTION
## Summary
This updates the Credenital test to use an endpoint that doesn't return a 200 status code if the authentication fails.

https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-myself/#api-rest-api-2-myself-get

## Related Linear tickets, Github issues, and Community forum posts
https://support.n8n.io/#ticket/zoom/25752
https://linear.app/n8n/issue/NODE-3146/jira-trigger-node-client-must-be-authenticated-to-access-this-resource


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
