### PR TITLE
chore(core): Stop reporting RLC workflow ID error

### DIFF
--- a/packages/cli/src/services/workflow-loader.service.ts
+++ b/packages/cli/src/services/workflow-loader.service.ts
@@ -1,6 +1,6 @@
 import { WorkflowRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
-import { UnexpectedError, type IWorkflowBase, type IWorkflowLoader } from 'n8n-workflow';
+import { UserError, type IWorkflowBase, type IWorkflowLoader } from 'n8n-workflow';
 
 @Service()
 export class WorkflowLoaderService implements IWorkflowLoader {
@@ -10,7 +10,7 @@ export class WorkflowLoaderService implements IWorkflowLoader {
 		const workflow = await this.workflowRepository.findById(workflowId);
 
 		if (!workflow) {
-			throw new UnexpectedError(`Failed to find workflow with ID "${workflowId}"`);
+			throw new UserError(`Failed to find workflow with ID "${workflowId}"`);
 		}
 
 		return workflow;


### PR DESCRIPTION
## Summary

Stop reporting error on workflow not found from resource locator component, as an ID may be incorrect user input or a formerly existing workflow that was deleted or is no longer accessible to the user.

![Capture 2025-06-24 at 11 29 29@2x](https://github.com/user-attachments/assets/d2e3a6a5-c91f-492a-9e27-1ce2b17780f1)

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
https://n8nio.slack.com/archives/C035KBDA917/p1750755663491459

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
