### PR TITLE
feat(editor): Tweak split execute button style (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/components/canvas/elements/buttons/CanvasRunWorkflowButton.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/elements/buttons/CanvasRunWorkflowButton.vue
@@ -51,7 +51,7 @@ const actions = computed(() =>
 		})
 		.map<ActionDropdownItem>((node) => ({
 			label: truncateBeforeLast(node.name, 25),
-			disabled: !!node.disabled,
+			disabled: !!node.disabled || props.executing,
 			id: node.name,
 			checked: props.selectedTriggerNodeName === node.name,
 		})),
@@ -105,6 +105,7 @@ function getNodeTypeByName(name: string): INodeTypeDescription | null {
 			</N8nButton>
 		</KeyboardShortcutTooltip>
 		<template v-if="isSplitButton">
+			<div role="presentation" :class="$style.divider" />
 			<N8nActionDropdown
 				:class="$style.menu"
 				:items="actions"
@@ -115,8 +116,8 @@ function getNodeTypeByName(name: string): INodeTypeDescription | null {
 				<template #activator>
 					<N8nButton
 						type="primary"
-						size="large"
-						:disabled="disabled || executing"
+						icon-size="large"
+						:disabled="disabled"
 						:class="$style.chevron"
 						aria-label="Select trigger node"
 						icon="angle-down"
@@ -151,28 +152,21 @@ function getNodeTypeByName(name: string): INodeTypeDescription | null {
 		height: var(--spacing-2xl);
 
 		padding-inline-start: var(--spacing-xs);
-		padding-inline-end: var(--spacing-xl);
 		padding-block: 0;
+		border-top-right-radius: 0;
+		border-bottom-right-radius: 0;
 	}
 }
 
+.divider {
+	width: 1px;
+	background-color: var(--button-font-color, var(--color-button-primary-font));
+}
+
 .chevron {
-	position: absolute;
-	right: var(--spacing-3xs);
-	top: var(--spacing-3xs);
-	width: 18px;
-	height: calc(100% - var(--spacing-3xs) * 2);
-	border: none;
-	padding: 0;
-	background-color: transparent;
-
-	&:not(:disabled):hover {
-		background-color: var(--prim-color-primary-tint-100);
-	}
-
-	&:disabled {
-		background-color: transparent !important;
-	}
+	width: 40px;
+	border-top-left-radius: 0;
+	border-bottom-left-radius: 0;
 }
 
 .menu :global(.el-dropdown) {


### PR DESCRIPTION
## Summary
This PR changes the style of split execute button to look similar to other split buttons.

Before:
<img width="351" alt="Screenshot 2025-06-24 at 11 55 38" src="https://github.com/user-attachments/assets/8fd8c178-addd-409a-9b48-82a9300a3ad7" />
After:
<img width="345" alt="Screenshot 2025-06-24 at 11 55 21" src="https://github.com/user-attachments/assets/42206308-2554-4f9e-96ae-793bbf89bdc1" />


## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/SUG-84/tweak-execute-workflow-using-splitbutton-component


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
