### PR TITLE
refactor(editor): Move user login and logout side effects into hooks (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/init.test.ts
+++ b/packages/frontend/editor-ui/src/init.test.ts
@@ -24,7 +24,11 @@ vi.mock('@/composables/useToast', () => ({
 }));
 
 vi.mock('@/stores/users.store', () => ({
-	useUsersStore: vi.fn().mockReturnValue({ initialize: vi.fn() }),
+	useUsersStore: vi.fn().mockReturnValue({
+		initialize: vi.fn(),
+		registerLoginHook: vi.fn(),
+		registerLogoutHook: vi.fn(),
+	}),
 }));
 
 vi.mock('@n8n/stores/useRootStore', () => ({
@@ -84,6 +88,16 @@ describe('Init', () => {
 			await initializeCore();
 
 			expect(settingsStoreSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it('should initialize authentication hooks', async () => {
+			const registerLoginHookSpy = vi.spyOn(usersStore, 'registerLoginHook');
+			const registerLogoutHookSpy = vi.spyOn(usersStore, 'registerLogoutHook');
+
+			await initializeCore();
+
+			expect(registerLoginHookSpy).toHaveBeenCalled();
+			expect(registerLogoutHookSpy).toHaveBeenCalled();
 		});
 
 		it('should initialize ssoStore with settings SSO configuration', async () => {

--- a/packages/frontend/editor-ui/src/init.ts
+++ b/packages/frontend/editor-ui/src/init.ts
@@ -181,11 +181,11 @@ function registerAuthenticationHooks() {
 	});
 
 	usersStore.registerLogoutHook(() => {
-		RBACStore.setGlobalScopes([]);
-		telemetry.reset();
-		cloudPlanStore.reset();
-		postHogStore.reset();
 		uiStore.clearBannerStack();
 		npsSurveyStore.resetNpsSurveyOnLogOut();
+		postHogStore.reset();
+		cloudPlanStore.reset();
+		telemetry.reset();
+		RBACStore.setGlobalScopes([]);
 	});
 }

--- a/packages/frontend/editor-ui/src/init.ts
+++ b/packages/frontend/editor-ui/src/init.ts
@@ -22,7 +22,6 @@ import { useNpsSurveyStore } from '@/stores/npsSurvey.store';
 import { usePostHog } from '@/stores/posthog.store';
 import { useTelemetry } from '@/composables/useTelemetry';
 import { useRBACStore } from '@/stores/rbac.store';
-import type { Scope } from '@n8n/permissions';
 
 export const state = {
 	initialized: false,

--- a/packages/frontend/editor-ui/src/stores/posthog.test.ts
+++ b/packages/frontend/editor-ui/src/stores/posthog.test.ts
@@ -44,7 +44,12 @@ function setCurrentUser() {
 
 function resetStores() {
 	useSettingsStore().reset();
-	useUsersStore().reset();
+
+	const usersStore = useUsersStore();
+	usersStore.initialized = false;
+	usersStore.currentUserId = null;
+	usersStore.usersById = {};
+	usersStore.currentUserCloudInfo = null;
 }
 
 function setup() {

--- a/packages/frontend/editor-ui/src/stores/users.store.test.ts
+++ b/packages/frontend/editor-ui/src/stores/users.store.test.ts
@@ -2,7 +2,7 @@ import type { CurrentUserResponse } from '@/Interface';
 import { useUsersStore } from './users.store';
 import { createPinia, setActivePinia } from 'pinia';
 
-const { loginCurrentUser, identify, inviteUsers } = vi.hoisted(() => {
+const { loginCurrentUser, inviteUsers } = vi.hoisted(() => {
 	return {
 		loginCurrentUser: vi.fn(),
 		identify: vi.fn(),
@@ -16,12 +16,6 @@ vi.mock('@/api/users', () => ({
 
 vi.mock('@/api/invitation', () => ({
 	inviteUsers,
-}));
-
-vi.mock('@/composables/useTelemetry', () => ({
-	useTelemetry: vi.fn(() => ({
-		identify,
-	})),
 }));
 
 vi.mock('@n8n/stores/useRootStore', () => ({
@@ -59,8 +53,6 @@ describe('users.store', () => {
 				isDefaultUser: false,
 				isPendingUser: false,
 			});
-
-			expect(identify).toHaveBeenCalledWith('test-instance-id', mockUser.id);
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/stores/users.store.ts
+++ b/packages/frontend/editor-ui/src/stores/users.store.ts
@@ -146,7 +146,7 @@ export const useUsersStore = defineStore(STORES.USERS, () => {
 
 		for (const hook of loginHooks.value) {
 			try {
-				hook();
+				hook(user);
 			} catch (error) {
 				console.error('Error executing login hook:', error);
 			}

--- a/packages/frontend/editor-ui/src/stores/users.store.ts
+++ b/packages/frontend/editor-ui/src/stores/users.store.ts
@@ -36,7 +36,7 @@ const _isInstanceOwner = (user: IUserResponse | null) => user?.role === ROLE.Own
 const _isDefaultUser = (user: IUserResponse | null) =>
 	_isInstanceOwner(user) && _isPendingUser(user);
 
-type LoginHook = (user: IUser) => void | Promise<void>;
+type LoginHook = (user: CurrentUserResponse) => void | Promise<void>;
 type LogoutHook = () => void | Promise<void>;
 
 export const useUsersStore = defineStore(STORES.USERS, () => {
@@ -149,7 +149,7 @@ export const useUsersStore = defineStore(STORES.USERS, () => {
 		}
 
 		loginHooks.value.forEach(async (hook) => {
-			await hook(currentUser.value);
+			await hook(user);
 		});
 	};
 

--- a/packages/frontend/editor-ui/src/stores/users.store.ts
+++ b/packages/frontend/editor-ui/src/stores/users.store.ts
@@ -36,8 +36,8 @@ const _isInstanceOwner = (user: IUserResponse | null) => user?.role === ROLE.Own
 const _isDefaultUser = (user: IUserResponse | null) =>
 	_isInstanceOwner(user) && _isPendingUser(user);
 
-type LoginHook = (user: CurrentUserResponse) => void | Promise<void>;
-type LogoutHook = () => void | Promise<void>;
+type LoginHook = (user: CurrentUserResponse) => void;
+type LogoutHook = () => void;
 
 export const useUsersStore = defineStore(STORES.USERS, () => {
 	const initialized = ref(false);
@@ -144,9 +144,13 @@ export const useUsersStore = defineStore(STORES.USERS, () => {
 		addUsers([user]);
 		currentUserId.value = user.id;
 
-		loginHooks.value.forEach(async (hook) => {
-			await hook(user);
-		});
+		for (const hook of loginHooks.value) {
+			try {
+				hook();
+			} catch (error) {
+				console.error('Error executing login hook:', error);
+			}
+		}
 	};
 
 	const loginWithCookie = async () => {
@@ -219,9 +223,13 @@ export const useUsersStore = defineStore(STORES.USERS, () => {
 
 		unsetCurrentUser();
 
-		logoutHooks.value.forEach(async (hook) => {
-			await hook();
-		});
+		for (const hook of logoutHooks.value) {
+			try {
+				hook();
+			} catch (error) {
+				console.error('Error executing logout hook:', error);
+			}
+		}
 
 		localStorage.removeItem(BROWSER_ID_STORAGE_KEY);
 	};

--- a/packages/frontend/editor-ui/src/stores/users.store.ts
+++ b/packages/frontend/editor-ui/src/stores/users.store.ts
@@ -144,10 +144,6 @@ export const useUsersStore = defineStore(STORES.USERS, () => {
 		addUsers([user]);
 		currentUserId.value = user.id;
 
-		if (!currentUser.value) {
-			throw new Error('Current user not found');
-		}
-
 		loginHooks.value.forEach(async (hook) => {
 			await hook(user);
 		});


### PR DESCRIPTION
## Summary

Move user login and logout side effects into hooks.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-969/detangle-users-store-login-and-logout-from-other-stores


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
