### PR TITLE
fix(core): Add retry mechanism to tools

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/ToolWorkflowV2.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/ToolWorkflowV2.test.ts
@@ -17,7 +17,6 @@ jest.mock('n8n-workflow', () => ({
 	sleep: jest.fn().mockResolvedValue(undefined),
 }));
 
-// Helper to create a properly mocked cloned context
 function createMockClonedContext(
 	baseContext: ISupplyDataFunctions,
 	executeWorkflowMock?: jest.MockedFunction<any>,
@@ -62,9 +61,7 @@ function createMockContext(overrides?: Partial<ISupplyDataFunctions>): ISupplyDa
 		},
 		...overrides,
 	} as ISupplyDataFunctions;
-	context.cloneWith = jest
-		.fn()
-		.mockImplementation((cloneOverrides) => createMockClonedContext(context));
+	context.cloneWith = jest.fn().mockImplementation((_) => createMockClonedContext(context));
 	return context;
 }
 

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/utils/WorkflowToolService.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/utils/WorkflowToolService.ts
@@ -25,6 +25,7 @@ import {
 	NodeConnectionTypes,
 	NodeOperationError,
 	parseErrorMetadata,
+	sleep,
 	traverseNodeParameters,
 } from 'n8n-workflow';
 import { z } from 'zod';
@@ -75,69 +76,99 @@ export class WorkflowToolService {
 		// This function will execute the sub-workflow and return the response
 		// We get the runIndex from the context to handle multiple executions
 		// of the same tool when the tool is used in a loop or in a parallel execution.
+		const node = ctx.getNode();
+
 		let runIndex: number = ctx.getNextRunIndex();
 		const toolHandler = async (
 			query: string | IDataObject,
 			runManager?: CallbackManagerForToolRun,
 		): Promise<IDataObject | IDataObject[] | string> => {
-			const localRunIndex = runIndex++;
-			// We need to clone the context here to handle runIndex correctly
-			// Otherwise the runIndex will be shared between different executions
-			// Causing incorrect data to be passed to the sub-workflow and via $fromAI
-			const context = this.baseContext.cloneWith({
-				runIndex: localRunIndex,
-				inputData: [[{ json: { query } }]],
-			});
-
-			try {
-				const response = await this.runFunction(context, query, itemIndex, runManager);
-
-				const processedResponse = this.handleToolResponse(response);
-
-				let responseData: INodeExecutionData[];
-				if (isNodeExecutionData(response)) {
-					responseData = response;
-				} else {
-					const reParsedData = jsonParse<IDataObject>(processedResponse, {
-						fallbackValue: { response: processedResponse },
-					});
-
-					responseData = [{ json: reParsedData }];
-				}
-
-				// Once the sub-workflow is executed, add the output data to the context
-				// This will be used to link the sub-workflow execution in the parent workflow
-				let metadata: ITaskMetadata | undefined;
-				if (this.subExecutionId && this.subWorkflowId) {
-					metadata = {
-						subExecution: {
-							executionId: this.subExecutionId,
-							workflowId: this.subWorkflowId,
-						},
-					};
-				}
-
-				void context.addOutputData(
-					NodeConnectionTypes.AiTool,
-					localRunIndex,
-					[responseData],
-					metadata,
-				);
-
-				return processedResponse;
-			} catch (error) {
-				const executionError = error as ExecutionError;
-				const errorResponse = `There was an error: "${executionError.message}"`;
-
-				const metadata = parseErrorMetadata(error);
-				void context.addOutputData(
-					NodeConnectionTypes.AiTool,
-					localRunIndex,
-					executionError,
-					metadata,
-				);
-				return errorResponse;
+			let maxTries = 1;
+			if (node.retryOnFail === true) {
+				maxTries = Math.min(5, Math.max(2, node.maxTries ?? 3));
 			}
+
+			let waitBetweenTries = 0;
+			if (node.retryOnFail === true) {
+				waitBetweenTries = Math.min(5000, Math.max(0, node.waitBetweenTries ?? 1000));
+			}
+
+			let lastError: ExecutionError | undefined;
+
+			for (let tryIndex = 0; tryIndex < maxTries; tryIndex++) {
+				if (tryIndex !== 0) {
+					// Reset error from previous attempt
+					lastError = undefined;
+					if (waitBetweenTries !== 0) {
+						await sleep(waitBetweenTries);
+					}
+				}
+
+				const localRunIndex = runIndex++;
+				// We need to clone the context here to handle runIndex correctly
+				// Otherwise the runIndex will be shared between different executions
+				// Causing incorrect data to be passed to the sub-workflow and via $fromAI
+				const context = this.baseContext.cloneWith({
+					runIndex: localRunIndex,
+					inputData: [[{ json: { query } }]],
+				});
+
+				try {
+					const response = await this.runFunction(context, query, itemIndex, runManager);
+
+					const processedResponse = this.handleToolResponse(response);
+
+					let responseData: INodeExecutionData[];
+					if (isNodeExecutionData(response)) {
+						responseData = response;
+					} else {
+						const reParsedData = jsonParse<IDataObject>(processedResponse, {
+							fallbackValue: { response: processedResponse },
+						});
+
+						responseData = [{ json: reParsedData }];
+					}
+
+					// Once the sub-workflow is executed, add the output data to the context
+					// This will be used to link the sub-workflow execution in the parent workflow
+					let metadata: ITaskMetadata | undefined;
+					if (this.subExecutionId && this.subWorkflowId) {
+						metadata = {
+							subExecution: {
+								executionId: this.subExecutionId,
+								workflowId: this.subWorkflowId,
+							},
+						};
+					}
+
+					void context.addOutputData(
+						NodeConnectionTypes.AiTool,
+						localRunIndex,
+						[responseData],
+						metadata,
+					);
+
+					return processedResponse;
+				} catch (error) {
+					const executionError = error as ExecutionError;
+					lastError = executionError;
+					const errorResponse = `There was an error: "${executionError.message}"`;
+
+					const metadata = parseErrorMetadata(error);
+					void context.addOutputData(
+						NodeConnectionTypes.AiTool,
+						localRunIndex,
+						executionError,
+						metadata,
+					);
+
+					if (tryIndex === maxTries - 1) {
+						return errorResponse;
+					}
+				}
+			}
+
+			return `There was an error: ${lastError?.message ?? 'Unknown error'}`;
 		};
 
 		// Create structured tool if input schema is provided

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-input-connection-data.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-input-connection-data.test.ts
@@ -716,7 +716,7 @@ describe('makeHandleToolInvocation', () => {
 		const contextFactory = jest.fn();
 		const toolArgs = { input: 'test' };
 		let handleToolInvocation: ReturnType<typeof makeHandleToolInvocation>;
-		let mockContext: any;
+		let mockContext: unknown;
 
 		beforeEach(() => {
 			jest.clearAllMocks();

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-input-connection-data.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-input-connection-data.test.ts
@@ -711,4 +711,156 @@ describe('makeHandleToolInvocation', () => {
 		expect(contextFactory).toHaveBeenCalledWith(1);
 		expect(contextFactory).toHaveBeenCalledWith(2);
 	});
+
+	describe('retry functionality', () => {
+		const contextFactory = jest.fn();
+		const toolArgs = { input: 'test' };
+		let handleToolInvocation: ReturnType<typeof makeHandleToolInvocation>;
+		let mockContext: any;
+
+		beforeEach(() => {
+			jest.clearAllMocks();
+			mockContext = {
+				addInputData: jest.fn(),
+				addOutputData: jest.fn(),
+				logger: { warn: jest.fn() },
+			};
+			contextFactory.mockReturnValue(mockContext);
+		});
+
+		it('should not retry when retryOnFail is false', async () => {
+			const connectedNode = mock<INode>({
+				name: 'Test Tool',
+				retryOnFail: false,
+			});
+			const connectedNodeType = mock<INodeType>({
+				execute: jest.fn().mockRejectedValue(new Error('Test error')),
+			});
+
+			handleToolInvocation = makeHandleToolInvocation(
+				contextFactory,
+				connectedNode,
+				connectedNodeType,
+				runExecutionData,
+			);
+
+			const result = await handleToolInvocation(toolArgs);
+
+			expect(contextFactory).toHaveBeenCalledTimes(1);
+			expect(connectedNodeType.execute).toHaveBeenCalledTimes(1);
+			expect(result).toContain('Error during node execution');
+		});
+
+		it('should retry up to maxTries when retryOnFail is true', async () => {
+			const connectedNode = mock<INode>({
+				name: 'Test Tool',
+				retryOnFail: true,
+				maxTries: 3,
+				waitBetweenTries: 0,
+			});
+			const connectedNodeType = mock<INodeType>({
+				execute: jest.fn().mockRejectedValue(new Error('Test error')),
+			});
+
+			handleToolInvocation = makeHandleToolInvocation(
+				contextFactory,
+				connectedNode,
+				connectedNodeType,
+				runExecutionData,
+			);
+
+			const result = await handleToolInvocation(toolArgs);
+
+			expect(contextFactory).toHaveBeenCalledTimes(3);
+			expect(connectedNodeType.execute).toHaveBeenCalledTimes(3);
+			expect(result).toContain('Error during node execution');
+		});
+
+		it('should succeed on retry after initial failure', async () => {
+			const connectedNode = mock<INode>({
+				name: 'Test Tool',
+				retryOnFail: true,
+				maxTries: 3,
+				waitBetweenTries: 0,
+			});
+			const connectedNodeType = mock<INodeType>({
+				execute: jest
+					.fn()
+					.mockRejectedValueOnce(new Error('First attempt fails'))
+					.mockResolvedValueOnce([[{ json: { result: 'success' } }]]),
+			});
+
+			handleToolInvocation = makeHandleToolInvocation(
+				contextFactory,
+				connectedNode,
+				connectedNodeType,
+				runExecutionData,
+			);
+
+			const result = await handleToolInvocation(toolArgs);
+
+			expect(contextFactory).toHaveBeenCalledTimes(2);
+			expect(connectedNodeType.execute).toHaveBeenCalledTimes(2);
+			expect(result).toBe(JSON.stringify([{ result: 'success' }]));
+		});
+
+		it('should respect maxTries limits (2-5)', async () => {
+			const testCases = [
+				{ maxTries: 1, expected: 2 }, // Should be clamped to minimum 2
+				{ maxTries: 3, expected: 3 },
+				{ maxTries: 6, expected: 5 }, // Should be clamped to maximum 5
+			];
+
+			for (const { maxTries, expected } of testCases) {
+				jest.clearAllMocks();
+
+				const connectedNode = mock<INode>({
+					name: 'Test Tool',
+					retryOnFail: true,
+					maxTries,
+					waitBetweenTries: 0,
+				});
+				const connectedNodeType = mock<INodeType>({
+					execute: jest.fn().mockRejectedValue(new Error('Test error')),
+				});
+
+				handleToolInvocation = makeHandleToolInvocation(
+					contextFactory,
+					connectedNode,
+					connectedNodeType,
+					runExecutionData,
+				);
+
+				await handleToolInvocation(toolArgs);
+
+				expect(connectedNodeType.execute).toHaveBeenCalledTimes(expected);
+			}
+		});
+
+		it('should respect waitBetweenTries limits (0-5000ms)', async () => {
+			const sleepSpy = jest.spyOn(require('n8n-workflow'), 'sleep').mockResolvedValue(undefined);
+
+			const connectedNode = mock<INode>({
+				name: 'Test Tool',
+				retryOnFail: true,
+				maxTries: 2,
+				waitBetweenTries: 1500,
+			});
+			const connectedNodeType = mock<INodeType>({
+				execute: jest.fn().mockRejectedValue(new Error('Test error')),
+			});
+
+			handleToolInvocation = makeHandleToolInvocation(
+				contextFactory,
+				connectedNode,
+				connectedNodeType,
+				runExecutionData,
+			);
+
+			await handleToolInvocation(toolArgs);
+
+			expect(sleepSpy).toHaveBeenCalledWith(1500);
+			sleepSpy.mockRestore();
+		});
+	});
 });

--- a/packages/core/src/execution-engine/node-execution-context/utils/get-input-connection-data.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/get-input-connection-data.ts
@@ -24,6 +24,7 @@ import {
 	ExecutionBaseError,
 	ApplicationError,
 	UserError,
+	sleep,
 } from 'n8n-workflow';
 
 import { createNodeAsTool } from './create-node-as-tool';
@@ -50,41 +51,72 @@ export function makeHandleToolInvocation(
 	let runIndex = getNextRunIndex(runExecutionData, node.name);
 
 	return async (toolArgs: IDataObject) => {
-		// Increment the runIndex for the next invocation
-		const localRunIndex = runIndex++;
-		const context = contextFactory(localRunIndex);
-		context.addInputData(NodeConnectionTypes.AiTool, [[{ json: toolArgs }]]);
+		let maxTries = 1;
+		if (node.retryOnFail === true) {
+			maxTries = Math.min(5, Math.max(2, node.maxTries ?? 3));
+		}
 
-		try {
-			// Execute the sub-node with the proxied context
-			const result = await nodeType.execute?.call(context as unknown as IExecuteFunctions);
+		let waitBetweenTries = 0;
+		if (node.retryOnFail === true) {
+			waitBetweenTries = Math.min(5000, Math.max(0, node.waitBetweenTries ?? 1000));
+		}
 
-			// Process and map the results
-			const mappedResults = result?.[0]?.flatMap((item) => item.json);
-			let response: string | typeof mappedResults = mappedResults;
+		let lastError: NodeOperationError | undefined;
 
-			// Warn if any (unusable) binary data was returned
-			if (result?.some((x) => x.some((y) => y.binary))) {
-				if (!mappedResults || mappedResults.flatMap((x) => Object.keys(x ?? {})).length === 0) {
-					response =
-						'Error: The Tool attempted to return binary data, which is not supported in Agents';
-				} else {
-					context.logger.warn(
-						`Response from Tool '${node.name}' included binary data, which is not supported in Agents. The binary data was omitted from the response.`,
-					);
+		for (let tryIndex = 0; tryIndex < maxTries; tryIndex++) {
+			if (tryIndex !== 0) {
+				// Reset error from previous attempt
+				lastError = undefined;
+				if (waitBetweenTries !== 0) {
+					await sleep(waitBetweenTries);
 				}
 			}
+			// Increment the runIndex for the next invocation
+			const localRunIndex = runIndex++;
+			const context = contextFactory(localRunIndex);
+			context.addInputData(NodeConnectionTypes.AiTool, [[{ json: toolArgs }]]);
 
-			// Add output data to the context
-			context.addOutputData(NodeConnectionTypes.AiTool, localRunIndex, [[{ json: { response } }]]);
+			try {
+				// Execute the sub-node with the proxied context
+				const result = await nodeType.execute?.call(context as unknown as IExecuteFunctions);
 
-			// Return the stringified results
-			return JSON.stringify(response);
-		} catch (error) {
-			const nodeError = new NodeOperationError(node, error as Error);
-			context.addOutputData(NodeConnectionTypes.AiTool, localRunIndex, nodeError);
-			return 'Error during node execution: ' + (nodeError.description ?? nodeError.message);
+				// Process and map the results
+				const mappedResults = result?.[0]?.flatMap((item) => item.json);
+				let response: string | typeof mappedResults = mappedResults;
+
+				// Warn if any (unusable) binary data was returned
+				if (result?.some((x) => x.some((y) => y.binary))) {
+					if (!mappedResults || mappedResults.flatMap((x) => Object.keys(x ?? {})).length === 0) {
+						response =
+							'Error: The Tool attempted to return binary data, which is not supported in Agents';
+					} else {
+						context.logger.warn(
+							`Response from Tool '${node.name}' included binary data, which is not supported in Agents. The binary data was omitted from the response.`,
+						);
+					}
+				}
+
+				// Add output data to the context
+				context.addOutputData(NodeConnectionTypes.AiTool, localRunIndex, [
+					[{ json: { response } }],
+				]);
+
+				// Return the stringified results
+				return JSON.stringify(response);
+			} catch (error) {
+				const nodeError = new NodeOperationError(node, error as Error);
+				context.addOutputData(NodeConnectionTypes.AiTool, localRunIndex, nodeError);
+
+				lastError = nodeError;
+
+				// If this is the last attempt, throw the error
+				if (tryIndex === maxTries - 1) {
+					return 'Error during node execution: ' + (nodeError.description ?? nodeError.message);
+				}
+			}
 		}
+
+		return 'Error during node execution : ' + (lastError?.description ?? lastError?.message);
 	};
 }
 

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -31,6 +31,7 @@ export {
 	jsonStringify,
 	replaceCircularReferences,
 	sleep,
+	sleepWithAbort,
 	fileTypeFromMimeType,
 	assert,
 	removeCircularRefs,


### PR DESCRIPTION
## Summary
This PR adds the same retry mechanism we have for normal nodes on tool nodes.
The mechanism is added to 
- General nodes-as-tools nodes
- Call n8n Workflow tool

https://github.com/user-attachments/assets/a78b63d9-5b21-442e-810f-c15a467b40af


## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-992/community-issue-ai-tool-does-not-retry-on-fail
fixes #15813 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
