### PR TITLE
fix(editor): Remove automatic resizing of output view

### DIFF
--- a/packages/frontend/editor-ui/src/components/OutputPanel.vue
+++ b/packages/frontend/editor-ui/src/components/OutputPanel.vue
@@ -13,7 +13,6 @@ import { useWorkflowsStore } from '@/stores/workflows.store';
 import { useNDVStore } from '@/stores/ndv.store';
 import { useNodeTypesStore } from '@/stores/nodeTypes.store';
 import RunDataAi from './RunDataAi/RunDataAi.vue';
-import { ndvEventBus } from '@/event-bus';
 import { useNodeType } from '@/composables/useNodeType';
 import { usePinnedData } from '@/composables/usePinnedData';
 import { useTelemetry } from '@/composables/useTelemetry';
@@ -294,14 +293,6 @@ const onRunIndexChange = (run: number) => {
 	emit('runChange', run);
 };
 
-const onUpdateOutputMode = (newOutputMode: OutputType) => {
-	if (newOutputMode === OUTPUT_TYPE.LOGS) {
-		ndvEventBus.emit('setPositionByName', 'minLeft');
-	} else {
-		ndvEventBus.emit('setPositionByName', 'initial');
-	}
-};
-
 // Set the initial output mode when the component is mounted
 onMounted(() => {
 	outputMode.value = defaultOutputMode.value;
@@ -360,7 +351,6 @@ const activatePane = () => {
 						v-model="outputMode"
 						data-test-id="ai-output-mode-select"
 						:options="outputTypes"
-						@update:model-value="onUpdateOutputMode"
 					/>
 				</template>
 				<span v-else :class="$style.title">


### PR DESCRIPTION
## Summary
This PR removes the automatic resizing of the output panel when switching between logs and output mode in the nodes details view.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-963/ai-agent-changing-output-panel-size-when-switching-outputlogs-is


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
