### PR TITLE
feat(GoogleChat): Enable creating messages in threads

### DIFF
--- a/packages/nodes-base/nodes/Google/Chat/GoogleChat.node.ts
+++ b/packages/nodes-base/nodes/Google/Chat/GoogleChat.node.ts
@@ -397,8 +397,8 @@ export class GoogleChat implements INodeType {
 
 						// get additional fields for threadKey and requestId
 						const additionalFields = this.getNodeParameter('additionalFields', i);
-						if (additionalFields.threadKey) {
-							qs.threadKey = additionalFields.threadKey;
+						if (additionalFields.messageReplyOption) {
+							qs.messageReplyOption = additionalFields.messageReplyOption;
 						}
 						if (additionalFields.requestId) {
 							qs.requestId = additionalFields.requestId;

--- a/packages/nodes-base/nodes/Google/Chat/descriptions/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Google/Chat/descriptions/MessageDescription.ts
@@ -201,13 +201,33 @@ export const messageFields: INodeProperties[] = [
 			},
 		},
 		options: [
-			// {
-			// 	displayName: 'Thread Key',
-			// 	name: 'threadKey',
-			// 	type: 'string',
-			// 	default: '',
-			// 	description: 'Thread identifier which groups messages into a single thread. Has no effect if thread field, corresponding to an existing thread, is set in message. Example: spaces/AAAAMpdlehY/threads/MZ8fXhZXGkk.',
-			// },
+			{
+				displayName: 'Message Reply Option',
+				name: 'messageReplyOption',
+				type: 'options',
+				default: '',
+				description: 'Configure the behavior if replying to threads',
+				options: [
+					{
+						name: 'Unspecified',
+						value: 'MESSAGE_REPLY_OPTION_UNSPECIFIED',
+						description:
+							'Ignores threadKey or thread name specified in the message and always starts a new thread.',
+					},
+					{
+						name: 'Reply and fallback to new thread',
+						value: 'REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD',
+						description:
+							'Replies to the thread specified in the message, or starts a new thread if no thread is specified.',
+					},
+					{
+						name: 'Reply or fail',
+						value: 'REPLY_MESSAGE_OR_FAIL',
+						description:
+							'Replies to the thread specified in the message, or fails if no thread is specified.',
+					},
+				],
+			},
 			{
 				displayName: 'Request ID',
 				name: 'requestId',


### PR DESCRIPTION
## Summary

With the current GoogleChat node its not possible to reply to threads. The google API requires the query parameter `messageReplyOption` to be set to something else than Unspecified, which is the default, and to pass the threadKey or name in the message object. The later can be done by toggling the JSON Parameters option and specifying something like
```
{"text": {{ $json.item.text }}, "thread": { "threadKey": "{{ $json.item.threadKey }}"}
```

## Related Linear tickets, Github issues, and Community forum posts
Did not yet create a ticket as I saw the missing feature and right away implemented it.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <- doesn't make sense to update it as long as I don't know it gets accepted.
- [x] Tests included. <- did not change anything on the overall behavior and there have been no special tests before.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
