### PR TITLE
fix(editor): Fix insights loading on FE

### DIFF
--- a/packages/frontend/editor-ui/src/__tests__/server/endpoints/index.ts
+++ b/packages/frontend/editor-ui/src/__tests__/server/endpoints/index.ts
@@ -8,6 +8,7 @@ import { routesForSSO } from './sso';
 import { routesForSourceControl } from './sourceControl';
 import { routesForWorkflows } from './workflow';
 import { routesForTags } from './tag';
+import { routesForModuleSettings } from './module';
 
 const endpoints: Array<(server: Server) => void> = [
 	routesForCredentials,
@@ -19,6 +20,7 @@ const endpoints: Array<(server: Server) => void> = [
 	routesForSourceControl,
 	routesForWorkflows,
 	routesForTags,
+	routesForModuleSettings,
 ];
 
 export { endpoints };

--- a/packages/frontend/editor-ui/src/__tests__/server/endpoints/module.ts
+++ b/packages/frontend/editor-ui/src/__tests__/server/endpoints/module.ts
@@ -1,0 +1,7 @@
+import type { Server } from 'miragejs';
+
+export function routesForModuleSettings(server: Server) {
+	server.get('/rest/module-settings', () => {
+		return {};
+	});
+}

--- a/packages/frontend/editor-ui/src/stores/settings.store.ts
+++ b/packages/frontend/editor-ui/src/stores/settings.store.ts
@@ -270,6 +270,8 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 			await getSettings();
 
 			initialized.value = true;
+
+			await getModuleSettings();
 		} catch (e) {
 			showToast({
 				title: i18n.baseText('startupError'),


### PR DESCRIPTION
## Summary

We are missing a call to load module settings on initializing the settings store, alongside the regular settings.

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.slack.com/archives/C04B1GZ4T0U/p1750777280626799

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
