### PR TITLE
chore(editor): Making health call only if custom hosted templates

### DIFF
--- a/packages/frontend/editor-ui/src/init.test.ts
+++ b/packages/frontend/editor-ui/src/init.test.ts
@@ -137,7 +137,6 @@ describe('Init', () => {
 
 		it('should not init authenticated features if user is not logged in', async () => {
 			const cloudStoreSpy = vi.spyOn(cloudPlanStore, 'initialize');
-			const templatesTestSpy = vi.spyOn(settingsStore, 'testTemplatesEndpoint');
 			const sourceControlSpy = vi.spyOn(sourceControlStore, 'getPreferences');
 			const nodeTranslationSpy = vi.spyOn(nodeTypesStore, 'getNodeTranslationHeaders');
 			vi.mocked(useUsersStore).mockReturnValue({ currentUser: null } as ReturnType<
@@ -146,14 +145,12 @@ describe('Init', () => {
 
 			await initializeAuthenticatedFeatures();
 			expect(cloudStoreSpy).not.toHaveBeenCalled();
-			expect(templatesTestSpy).not.toHaveBeenCalled();
 			expect(sourceControlSpy).not.toHaveBeenCalled();
 			expect(nodeTranslationSpy).not.toHaveBeenCalled();
 		});
 
 		it('should init authenticated features only once if user is logged in', async () => {
 			const cloudStoreSpy = vi.spyOn(cloudPlanStore, 'initialize');
-			const templatesTestSpy = vi.spyOn(settingsStore, 'testTemplatesEndpoint');
 			const sourceControlSpy = vi.spyOn(sourceControlStore, 'getPreferences');
 			const nodeTranslationSpy = vi.spyOn(nodeTypesStore, 'getNodeTranslationHeaders');
 			vi.mocked(useUsersStore).mockReturnValue({ currentUser: { id: '123' } } as ReturnType<
@@ -163,7 +160,6 @@ describe('Init', () => {
 			await initializeAuthenticatedFeatures();
 
 			expect(cloudStoreSpy).toHaveBeenCalled();
-			expect(templatesTestSpy).toHaveBeenCalled();
 			expect(sourceControlSpy).toHaveBeenCalled();
 			expect(nodeTranslationSpy).toHaveBeenCalled();
 

--- a/packages/frontend/editor-ui/src/init.ts
+++ b/packages/frontend/editor-ui/src/init.ts
@@ -121,12 +121,6 @@ export async function initializeAuthenticatedFeatures(
 		}
 	}
 
-	if (settingsStore.isTemplatesEnabled) {
-		try {
-			await settingsStore.testTemplatesEndpoint();
-		} catch (e) {}
-	}
-
 	if (rootStore.defaultLocale !== 'en') {
 		await nodeTypesStore.getNodeTranslationHeaders();
 	}

--- a/packages/frontend/editor-ui/src/views/TemplatesSearchView.vue
+++ b/packages/frontend/editor-ui/src/views/TemplatesSearchView.vue
@@ -301,6 +301,11 @@ onMounted(async () => {
 
 	restoreSearchFromRoute();
 
+	// Check if templates are enabled and check if the local templates store is available
+	if (settingsStore.isTemplatesEnabled) {
+		settingsStore.testTemplatesEndpoint().catch(() => {});
+	}
+
 	setTimeout(() => {
 		// Check if there is scroll position saved in route and scroll to it
 		const scrollOffset = route.meta?.scrollOffset;


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

A health check is done to see if the template library is available. 
This is necessary only if the user is [custom hosting their template library ](https://docs.n8n.io/workflows/templates/#add-your-workflow-to-the-n8n-library)

Currently, we make a health check call for all cases. This should be avoided. 

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/ADO-3677/feature-remove-health-endpoint-for-templates
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
