### PR TITLE
feat(core): Send email notification when a user invited to a project

### DIFF
--- a/packages/@n8n/config/src/configs/user-management.config.ts
+++ b/packages/@n8n/config/src/configs/user-management.config.ts
@@ -64,6 +64,10 @@ export class TemplateConfig {
 	/** Overrides default HTML template for notifying that credentials were shared (use full path) */
 	@Env('N8N_UM_EMAIL_TEMPLATES_CREDENTIALS_SHARED')
 	'credentials-shared': string = '';
+
+	/** Overrides default HTML template for notifying that credentials were shared (use full path) */
+	@Env('N8N_UM_EMAIL_TEMPLATES_PROJECT_SHARED')
+	'project-shared': string = '';
 }
 
 const emailModeSchema = z.enum(['', 'smtp']);

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -121,6 +121,7 @@ describe('GlobalConfig', () => {
 					'user-invited': '',
 					'password-reset-requested': '',
 					'workflow-shared': '',
+					'project-shared': '',
 				},
 			},
 		},

--- a/packages/@n8n/db/src/repositories/user.repository.ts
+++ b/packages/@n8n/db/src/repositories/user.repository.ts
@@ -80,7 +80,7 @@ export class UserRepository extends Repository<User> {
 	 */
 	async getEmailsByIds(userIds: string[]) {
 		return await this.find({
-			select: ['email'],
+			select: ['id', 'email'],
 			where: { id: In(userIds), password: Not(IsNull()) },
 		});
 	}

--- a/packages/cli/src/controllers/project.controller.ts
+++ b/packages/cli/src/controllers/project.controller.ts
@@ -30,6 +30,7 @@ import {
 	TeamProjectOverQuotaError,
 	UnlicensedProjectRoleError,
 } from '@/services/project.service.ee';
+import { UserManagementMailer } from '@/user-management/email';
 
 @RestController('/projects')
 export class ProjectController {
@@ -37,6 +38,7 @@ export class ProjectController {
 		private readonly projectsService: ProjectService,
 		private readonly projectRepository: ProjectRepository,
 		private readonly eventService: EventService,
+		private readonly userManagementMailer: UserManagementMailer,
 	) {}
 
 	@Get('/')
@@ -209,7 +211,17 @@ export class ProjectController {
 		}
 		if (relations) {
 			try {
-				await this.projectsService.syncProjectRelations(projectId, relations);
+				const { project, newRelations } = await this.projectsService.syncProjectRelations(
+					projectId,
+					relations,
+				);
+
+				// Send email notifications to new sharees
+				await this.userManagementMailer.notifyProjectShared({
+					sharer: req.user,
+					newSharees: newRelations,
+					project: { id: project.id, name: project.name },
+				});
 			} catch (e) {
 				if (e instanceof UnlicensedProjectRoleError) {
 					throw new BadRequestError(e.message);

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -238,7 +238,8 @@ export type RelayEventMap = {
 			| 'New user invite'
 			| 'Resend invite'
 			| 'Workflow shared'
-			| 'Credentials shared';
+			| 'Credentials shared'
+			| 'Project shared';
 		publicApi: boolean;
 	};
 
@@ -274,7 +275,8 @@ export type RelayEventMap = {
 			| 'New user invite'
 			| 'Resend invite'
 			| 'Workflow shared'
-			| 'Credentials shared';
+			| 'Credentials shared'
+			| 'Project shared';
 		publicApi: boolean;
 	};
 

--- a/packages/cli/src/services/project.service.ee.ts
+++ b/packages/cli/src/services/project.service.ee.ts
@@ -269,7 +269,7 @@ export class ProjectService {
 	async syncProjectRelations(
 		projectId: string,
 		relations: Required<UpdateProjectDto>['relations'],
-	) {
+	): Promise<{ project: Project; newRelations: Required<UpdateProjectDto>['relations'] }> {
 		const project = await this.getTeamProjectWithRelations(projectId);
 		this.checkRolesLicensed(project, relations);
 
@@ -277,7 +277,13 @@ export class ProjectService {
 			await this.pruneRelations(em, project);
 			await this.addManyRelations(em, project, relations);
 		});
+
+		const newRelations = relations.filter(
+			(relation) => !project.projectRelations.some((r) => r.userId === relation.userId),
+		);
 		await this.clearCredentialCanUseExternalSecretsCache(projectId);
+
+		return { project, newRelations };
 	}
 
 	/**

--- a/packages/cli/src/user-management/email/__tests__/user-management-mailer.test.ts
+++ b/packages/cli/src/user-management/email/__tests__/user-management-mailer.test.ts
@@ -1,5 +1,7 @@
 import type { GlobalConfig } from '@n8n/config';
+import type { ProjectRole, User, UserRepository } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
+import type { IWorkflowBase } from 'n8n-workflow';
 
 import type { UrlService } from '@/services/url.service';
 import type { InviteEmailData, PasswordResetData } from '@/user-management/email/interfaces';
@@ -58,10 +60,11 @@ describe('UserManagementMailer', () => {
 			},
 		});
 		const urlService = mock<UrlService>();
+		const userRepository = mock<UserRepository>();
 		const userManagementMailer = new UserManagementMailer(
 			config,
 			mock(),
-			mock(),
+			userRepository,
 			urlService,
 			mock(),
 		);
@@ -92,6 +95,101 @@ describe('UserManagementMailer', () => {
 				body: expect.stringContaining(`href="${passwordResetData.passwordResetUrl}"`),
 				emailRecipients: email,
 				subject: 'n8n password reset',
+			});
+		});
+
+		it('should send workflow share notifications', async () => {
+			const sharer = mock<User>({ firstName: 'Sharer', email: 'sharer@user.com' });
+			const newShareeIds = ['recipient1', 'recipient2'];
+			const workflow = mock<IWorkflowBase>({ id: 'workflow1', name: 'Test Workflow' });
+			userRepository.getEmailsByIds.mockResolvedValue([
+				{ id: 'recipient1', email: 'recipient1@user.com' },
+				{ id: 'recipient2', email: 'recipient2@user.com' },
+			] as User[]);
+			const result = await userManagementMailer.notifyWorkflowShared({
+				sharer,
+				newShareeIds,
+				workflow,
+			});
+
+			expect(result.emailSent).toBe(true);
+			expect(nodeMailer.sendMail).toHaveBeenCalledTimes(2);
+			newShareeIds.forEach((id, index) => {
+				expect(nodeMailer.sendMail).toHaveBeenNthCalledWith(index + 1, {
+					body: expect.stringContaining(`href="https://n8n.url/workflow/${workflow.id}"`),
+					emailRecipients: `${id}@user.com`,
+					subject: 'Sharer has shared an n8n workflow with you',
+				});
+
+				const callBody = nodeMailer.sendMail.mock.calls[index][0].body;
+				expect(callBody).toContain('Test Workflow');
+				expect(callBody).toContain('A workflow has been shared with you');
+			});
+		});
+
+		it('should send credentials share notifications', async () => {
+			const sharer = mock<User>({ firstName: 'Sharer', email: 'sharer@user.com' });
+			const newShareeIds = ['recipient1', 'recipient2'];
+			userRepository.getEmailsByIds.mockResolvedValue([
+				{ id: 'recipient1', email: 'recipient1@user.com' },
+				{ id: 'recipient2', email: 'recipient2@user.com' },
+			] as User[]);
+			const result = await userManagementMailer.notifyCredentialsShared({
+				sharer,
+				newShareeIds,
+				credentialsName: 'Test Credentials',
+			});
+			expect(result.emailSent).toBe(true);
+			expect(nodeMailer.sendMail).toHaveBeenCalledTimes(2);
+			newShareeIds.forEach((id, index) => {
+				expect(nodeMailer.sendMail).toHaveBeenNthCalledWith(index + 1, {
+					body: expect.stringContaining('href="https://n8n.url/home/credentials"'),
+					emailRecipients: `${id}@user.com`,
+					subject: 'Sharer has shared an n8n credential with you',
+				});
+
+				const callBody = nodeMailer.sendMail.mock.calls[index][0].body;
+				expect(callBody).toContain('Test Credentials');
+				expect(callBody).toContain('A credential has been shared with you');
+			});
+		});
+
+		it('should send project share notifications', async () => {
+			const sharer = mock<User>({ firstName: 'Sharer', email: 'sharer@user.com' });
+			const newSharees = [
+				{ userId: 'recipient1', role: 'project:editor' as ProjectRole },
+				{ userId: 'recipient2', role: 'project:viewer' as ProjectRole },
+			];
+			const project = { id: 'project1', name: 'Test Project' };
+			userRepository.getEmailsByIds.mockResolvedValue([
+				{
+					id: 'recipient1',
+					email: 'recipient1@user.com',
+				} as User,
+				{
+					id: 'recipient2',
+					email: 'recipient2@user.com',
+				} as User,
+			]);
+			const result = await userManagementMailer.notifyProjectShared({
+				sharer,
+				newSharees,
+				project,
+			});
+
+			expect(result.emailSent).toBe(true);
+			expect(nodeMailer.sendMail).toHaveBeenCalledTimes(2);
+			newSharees.forEach((sharee, index) => {
+				expect(nodeMailer.sendMail).toHaveBeenCalledWith({
+					body: expect.stringContaining(`href="https://n8n.url/projects/${project.id}"`),
+					emailRecipients: `recipient${index + 1}@user.com`,
+					subject: 'Sharer has invited you to a project',
+				});
+
+				const callBody = nodeMailer.sendMail.mock.calls[index][0].body;
+				expect(callBody).toContain(
+					`You have been added as a ${sharee.role.replace('project:', '')} to the ${project.name} project`,
+				);
 			});
 		});
 	});

--- a/packages/cli/src/user-management/email/interfaces.ts
+++ b/packages/cli/src/user-management/email/interfaces.ts
@@ -11,11 +11,13 @@ export type PasswordResetData = {
 
 export type SendEmailResult = {
 	emailSent: boolean;
+	errors?: string[];
 };
 
 export type MailData = {
 	body: string | Buffer;
 	emailRecipients: string | string[];
+	bcc?: string | string[];
 	subject: string;
 	textOnly?: string;
 };

--- a/packages/cli/src/user-management/email/interfaces.ts
+++ b/packages/cli/src/user-management/email/interfaces.ts
@@ -17,7 +17,6 @@ export type SendEmailResult = {
 export type MailData = {
 	body: string | Buffer;
 	emailRecipients: string | string[];
-	bcc?: string | string[];
 	subject: string;
 	textOnly?: string;
 };

--- a/packages/cli/src/user-management/email/node-mailer.ts
+++ b/packages/cli/src/user-management/email/node-mailer.ts
@@ -50,7 +50,6 @@ export class NodeMailer {
 			await this.transport.sendMail({
 				from: this.sender,
 				to: mailData.emailRecipients,
-				bcc: mailData.bcc,
 				subject: mailData.subject,
 				text: mailData.textOnly,
 				html: mailData.body,

--- a/packages/cli/src/user-management/email/node-mailer.ts
+++ b/packages/cli/src/user-management/email/node-mailer.ts
@@ -50,6 +50,7 @@ export class NodeMailer {
 			await this.transport.sendMail({
 				from: this.sender,
 				to: mailData.emailRecipients,
+				bcc: mailData.bcc,
 				subject: mailData.subject,
 				text: mailData.textOnly,
 				html: mailData.body,

--- a/packages/cli/src/user-management/email/templates/project-shared.mjml
+++ b/packages/cli/src/user-management/email/templates/project-shared.mjml
@@ -1,0 +1,21 @@
+<mjml>
+	<mj-include path="./_common.mjml" />
+	<mj-body>
+		<mj-section>
+			<mj-column>
+				<mj-text font-size="24px" color="#ff6f5c"
+					>You have been added as a {{ role }} to the {{ projectName }} project</mj-text
+				>
+			</mj-column>
+		</mj-section>
+		<mj-section background-color="#FFFFFF" border="1px solid #ddd">
+			<mj-column>
+				<mj-text
+					>This gives you access to all the workflows and credentials in that project</mj-text
+				>
+				<mj-button href="{{projectUrl}}">View project</mj-button>
+			</mj-column>
+		</mj-section>
+		<mj-include path="./_logo.mjml" />
+	</mj-body>
+</mjml>

--- a/packages/cli/src/user-management/email/user-management-mailer.ts
+++ b/packages/cli/src/user-management/email/user-management-mailer.ts
@@ -1,6 +1,6 @@
 import { inTest, Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
-import type { User } from '@n8n/db';
+import type { ProjectRole, User } from '@n8n/db';
 import { UserRepository } from '@n8n/db';
 import { Container, Service } from '@n8n/di';
 import { existsSync } from 'fs';
@@ -11,6 +11,7 @@ import { join as pathJoin } from 'path';
 
 import { InternalServerError } from '@/errors/response-errors/internal-server.error';
 import { EventService } from '@/events/event.service';
+import type { RelayEventMap } from '@/events/maps/relay.event-map';
 import { UrlService } from '@/services/url.service';
 import { toError } from '@/utils';
 
@@ -22,7 +23,8 @@ type TemplateName =
 	| 'user-invited'
 	| 'password-reset-requested'
 	| 'workflow-shared'
-	| 'credentials-shared';
+	| 'credentials-shared'
+	| 'project-shared';
 
 @Service()
 export class UserManagementMailer {
@@ -73,6 +75,68 @@ export class UserManagementMailer {
 		});
 	}
 
+	private async sendNotificationEmails({
+		mailerTemplate,
+		recipientsEmail,
+		sharer,
+		getTemplateData,
+		subjectBuilder,
+		messageType,
+	}: {
+		mailerTemplate: TemplateName;
+		recipientsEmail: string[];
+		sharer: User;
+		getTemplateData: (recipient: any) => Record<string, any>;
+		subjectBuilder: () => string;
+		messageType: RelayEventMap['user-transactional-email-sent']['messageType'];
+	}): Promise<SendEmailResult> {
+		if (!this.mailer) return { emailSent: false };
+		if (recipientsEmail.length === 0) return { emailSent: false };
+
+		const populateTemplate = await this.getTemplate(mailerTemplate);
+
+		try {
+			const promises = recipientsEmail.map(async (recipientEmail) => {
+				const templateData = getTemplateData(recipientEmail);
+				return await this.mailer!.sendMail({
+					emailRecipients: [recipientEmail],
+					subject: subjectBuilder(),
+					body: populateTemplate(templateData),
+				});
+			});
+
+			const results = await Promise.allSettled(promises);
+			const errors = results.filter((result) => result.status === 'rejected');
+
+			this.logger.info(
+				`Sent ${messageType} email ${errors.length ? 'with errors' : 'successfully'}`,
+				{
+					sharerId: sharer.id,
+				},
+			);
+
+			this.eventService.emit('user-transactional-email-sent', {
+				userId: sharer.id,
+				messageType,
+				publicApi: false,
+			});
+
+			return {
+				emailSent: true,
+				errors: errors.map((e) => e.reason as string),
+			};
+		} catch (e) {
+			this.eventService.emit('email-failed', {
+				user: sharer,
+				messageType,
+				publicApi: false,
+			});
+
+			const error = toError(e);
+			throw new InternalServerError(`Please contact your administrator: ${error.message}`, e);
+		}
+	}
+
 	async notifyWorkflowShared({
 		sharer,
 		newShareeIds,
@@ -82,50 +146,20 @@ export class UserManagementMailer {
 		newShareeIds: string[];
 		workflow: IWorkflowBase;
 	}): Promise<SendEmailResult> {
-		if (!this.mailer) return { emailSent: false };
-
 		const recipients = await this.userRepository.getEmailsByIds(newShareeIds);
-
-		if (recipients.length === 0) return { emailSent: false };
-
-		const emailRecipients = recipients.map(({ email }) => email);
-
-		const populateTemplate = await this.getTemplate('workflow-shared');
-
 		const baseUrl = this.urlService.getInstanceBaseUrl();
 
-		try {
-			const result = await this.mailer.sendMail({
-				emailRecipients,
-				subject: `${sharer.firstName} has shared an n8n workflow with you`,
-				body: populateTemplate({
-					workflowName: workflow.name,
-					workflowUrl: `${baseUrl}/workflow/${workflow.id}`,
-				}),
-			});
-
-			if (!result) return { emailSent: false };
-
-			this.logger.info('Sent workflow shared email successfully', { sharerId: sharer.id });
-
-			this.eventService.emit('user-transactional-email-sent', {
-				userId: sharer.id,
-				messageType: 'Workflow shared',
-				publicApi: false,
-			});
-
-			return result;
-		} catch (e) {
-			this.eventService.emit('email-failed', {
-				user: sharer,
-				messageType: 'Workflow shared',
-				publicApi: false,
-			});
-
-			const error = toError(e);
-
-			throw new InternalServerError(`Please contact your administrator: ${error.message}`, e);
-		}
+		return await this.sendNotificationEmails({
+			mailerTemplate: 'workflow-shared',
+			recipientsEmail: recipients.map((recipient) => recipient.email),
+			sharer,
+			getTemplateData: () => ({
+				workflowName: workflow.name,
+				workflowUrl: `${baseUrl}/workflow/${workflow.id}`,
+			}),
+			subjectBuilder: () => `${sharer.firstName} has shared an n8n workflow with you`,
+			messageType: 'Workflow shared',
+		});
 	}
 
 	async notifyCredentialsShared({
@@ -137,50 +171,58 @@ export class UserManagementMailer {
 		newShareeIds: string[];
 		credentialsName: string;
 	}): Promise<SendEmailResult> {
-		if (!this.mailer) return { emailSent: false };
-
 		const recipients = await this.userRepository.getEmailsByIds(newShareeIds);
-
-		if (recipients.length === 0) return { emailSent: false };
-
-		const emailRecipients = recipients.map(({ email }) => email);
-
-		const populateTemplate = await this.getTemplate('credentials-shared');
-
 		const baseUrl = this.urlService.getInstanceBaseUrl();
 
-		try {
-			const result = await this.mailer.sendMail({
-				emailRecipients,
-				subject: `${sharer.firstName} has shared an n8n credential with you`,
-				body: populateTemplate({
-					credentialsName,
-					credentialsListUrl: `${baseUrl}/home/credentials`,
-				}),
-			});
+		return await this.sendNotificationEmails({
+			mailerTemplate: 'credentials-shared',
+			recipientsEmail: recipients.map((recipient) => recipient.email),
+			sharer,
+			getTemplateData: () => ({
+				credentialsName,
+				credentialsListUrl: `${baseUrl}/home/credentials`,
+			}),
+			subjectBuilder: () => `${sharer.firstName} has shared an n8n credential with you`,
+			messageType: 'Credentials shared',
+		});
+	}
 
-			if (!result) return { emailSent: false };
+	async notifyProjectShared({
+		sharer,
+		newSharees,
+		project,
+	}: {
+		sharer: User;
+		newSharees: Array<{ userId: string; role: ProjectRole }>;
+		project: { id: string; name: string };
+	}): Promise<SendEmailResult> {
+		const recipients = await this.userRepository.getEmailsByIds(newSharees.map((s) => s.userId));
+		const baseUrl = this.urlService.getInstanceBaseUrl();
 
-			this.logger.info('Sent credentials shared email successfully', { sharerId: sharer.id });
+		// Merge recipient data with role
+		const recipientsData = newSharees
+			.map((sharee) => {
+				const recipient = recipients.find((r) => r.id === sharee.userId);
+				if (!recipient) return null;
+				return {
+					email: recipient.email,
+					role: sharee.role.split('project:')?.[1] ?? sharee.role,
+				};
+			})
+			.filter(Boolean) as Array<{ email: string; role: string }>;
 
-			this.eventService.emit('user-transactional-email-sent', {
-				userId: sharer.id,
-				messageType: 'Credentials shared',
-				publicApi: false,
-			});
-
-			return result;
-		} catch (e) {
-			this.eventService.emit('email-failed', {
-				user: sharer,
-				messageType: 'Credentials shared',
-				publicApi: false,
-			});
-
-			const error = toError(e);
-
-			throw new InternalServerError(`Please contact your administrator: ${error.message}`, e);
-		}
+		return await this.sendNotificationEmails({
+			mailerTemplate: 'project-shared',
+			recipientsEmail: recipientsData.map((r) => r.email),
+			sharer,
+			getTemplateData: ({ role }: { role: string }) => ({
+				role,
+				projectName: project.name,
+				projectUrl: `${baseUrl}/projects/${project.id}`,
+			}),
+			subjectBuilder: () => `${sharer.firstName} has invited you to a project`,
+			messageType: 'Project shared',
+		});
 	}
 
 	async getTemplate(templateName: TemplateName): Promise<Template> {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR does 2 things:
- Change the user notification email behavior to send one email for each user the resource was shared with
  - The current behavior is to put all newly added users to the recipient list
  - This is not optimal in terms of privacy, personalization of email, debugging and retrying for a single user
  - That's why we moved to a per-user email notification system
- Implement project shared email notification

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2975/send-email-notification-when-a-user-invited-to-a-project


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
