### PR TITLE
fix: Check for status when canceling execution

### DIFF
--- a/packages/frontend/editor-ui/src/composables/useRunWorkflow.ts
+++ b/packages/frontend/editor-ui/src/composables/useRunWorkflow.ts
@@ -504,7 +504,8 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 			// Wait for websocket event to update the execution status to 'canceled'
 			const markedAsStopped = await retry(
 				async () => {
-					if (workflowsStore.workflowExecutionData?.status !== 'running') {
+					const execution = await workflowsStore.getExecution(executionId);
+					if (!['running', 'waiting'].includes(execution?.status as string)) {
 						workflowsStore.markExecutionAsStopped();
 						return true;
 					}


### PR DESCRIPTION
## Summary

Fixes check for status when canceling execution

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-2961/form-node-cannot-stop-manual-execution-of-multi-step-form

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
