### PR TITLE
fix(Execution Data Node): Set nulish values as empty string, continue on fail support

### DIFF
--- a/packages/nodes-base/nodes/ExecutionData/test/ExecutionData.node.test.ts
+++ b/packages/nodes-base/nodes/ExecutionData/test/ExecutionData.node.test.ts
@@ -24,7 +24,8 @@ describe('ExecutionData Node', () => {
 
 		expect(result).toEqual([mockInputData]);
 	});
-it('should set nullish values to empty string', async () => {
+
+	it('should set nullish values to empty string', async () => {
 		const mockInputData: INodeExecutionData[] = [
 			{ json: { item: 0, foo: undefined } },
 			{ json: { item: 1, foo: null } },

--- a/packages/nodes-base/nodes/ExecutionData/test/ExecutionData.node.test.ts
+++ b/packages/nodes-base/nodes/ExecutionData/test/ExecutionData.node.test.ts
@@ -1,6 +1,11 @@
 import { NodeTestHarness } from '@nodes-testing/node-test-harness';
 import { mock } from 'jest-mock-extended';
-import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import type {
+	IExecuteFunctions,
+	INodeExecutionData,
+	IWorkflowDataProxyData,
+	INode,
+} from 'n8n-workflow';
 
 import { ExecutionData } from '../ExecutionData.node';
 
@@ -12,9 +17,36 @@ describe('ExecutionData Node', () => {
 		];
 		const executeFns = mock<IExecuteFunctions>({
 			getInputData: () => mockInputData,
+			getNode: () => mock<INode>({ typeVersion: 1 }),
 		});
+
 		const result = await new ExecutionData().execute.call(executeFns);
 
+		expect(result).toEqual([mockInputData]);
+	});
+	it('should set nulish values to empty string', async () => {
+		const mockInputData: INodeExecutionData[] = [
+			{ json: { item: 0, foo: undefined } },
+			{ json: { item: 1, foo: null } },
+			{ json: { item: 1, foo: 'bar' } },
+		];
+		const setAllMock = jest.fn();
+		const executeFns = mock<IExecuteFunctions>({
+			getInputData: () => mockInputData,
+			getWorkflowDataProxy: () =>
+				mock<IWorkflowDataProxyData>({ $execution: { customData: { setAll: setAllMock } } }),
+			getNode: () => mock<INode>({ typeVersion: 1.1 }),
+		});
+		executeFns.getNodeParameter.mockReturnValueOnce('save');
+		executeFns.getNodeParameter.mockReturnValueOnce({ values: [{ key: 'foo', value: undefined }] });
+		executeFns.getNodeParameter.mockReturnValueOnce({ values: [{ key: 'foo', value: null }] });
+		executeFns.getNodeParameter.mockReturnValueOnce({ values: [{ key: 'foo', value: 'bar' }] });
+		const result = await new ExecutionData().execute.call(executeFns);
+
+		expect(setAllMock).toBeCalledTimes(3);
+		expect(setAllMock).toBeCalledWith({ foo: '' });
+		expect(setAllMock).toBeCalledWith({ foo: '' });
+		expect(setAllMock).toBeCalledWith({ foo: 'bar' });
 		expect(result).toEqual([mockInputData]);
 	});
 });

--- a/packages/nodes-base/nodes/ExecutionData/test/ExecutionData.node.test.ts
+++ b/packages/nodes-base/nodes/ExecutionData/test/ExecutionData.node.test.ts
@@ -24,7 +24,7 @@ describe('ExecutionData Node', () => {
 
 		expect(result).toEqual([mockInputData]);
 	});
-	it('should set nulish values to empty string', async () => {
+it('should set nullish values to empty string', async () => {
 		const mockInputData: INodeExecutionData[] = [
 			{ json: { item: 0, foo: undefined } },
 			{ json: { item: 1, foo: null } },


### PR DESCRIPTION
## Summary

Set nulish values as empty string, continue on fail support

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-2631/exec-data-node-errors-when-value-being-saved-is-null

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
