### PR TITLE
fix(core): Pagination was broken for users list

### DIFF
--- a/packages/@n8n/db/src/repositories/user.repository.ts
+++ b/packages/@n8n/db/src/repositories/user.repository.ts
@@ -247,10 +247,11 @@ export class UserRepository extends Repository<User> {
 			for (const sort of sortBy) {
 				const [field, order] = sort.split(':');
 				if (field === 'role') {
-					queryBuilder.addOrderBy(
+					queryBuilder.addSelect(
 						"CASE WHEN user.role='global:owner' THEN 0 WHEN user.role='global:admin' THEN 1 ELSE 2 END",
-						order.toUpperCase() as 'ASC' | 'DESC',
+						'userRoleOrder',
 					);
+					queryBuilder.addOrderBy('userRoleOrder', order.toUpperCase() as 'ASC' | 'DESC');
 				} else {
 					queryBuilder.addOrderBy(`user.${field}`, order.toUpperCase() as 'ASC' | 'DESC');
 				}
@@ -265,8 +266,8 @@ export class UserRepository extends Repository<User> {
 		take: number,
 		skip: number | undefined,
 	): SelectQueryBuilder<User> {
-		if (take >= 0) queryBuilder.limit(take);
-		if (skip) queryBuilder.offset(skip);
+		if (take >= 0) queryBuilder.take(take);
+		if (skip) queryBuilder.skip(skip);
 
 		return queryBuilder;
 	}

--- a/packages/@n8n/db/src/repositories/user.repository.ts
+++ b/packages/@n8n/db/src/repositories/user.repository.ts
@@ -249,9 +249,9 @@ export class UserRepository extends Repository<User> {
 				if (field === 'role') {
 					queryBuilder.addSelect(
 						"CASE WHEN user.role='global:owner' THEN 0 WHEN user.role='global:admin' THEN 1 ELSE 2 END",
-						'userRoleOrder',
+						'userroleorder',
 					);
-					queryBuilder.addOrderBy('userRoleOrder', order.toUpperCase() as 'ASC' | 'DESC');
+					queryBuilder.addOrderBy('userroleorder', order.toUpperCase() as 'ASC' | 'DESC');
 				} else {
 					queryBuilder.addOrderBy(`user.${field}`, order.toUpperCase() as 'ASC' | 'DESC');
 				}

--- a/packages/cli/test/integration/users.api.test.ts
+++ b/packages/cli/test/integration/users.api.test.ts
@@ -42,6 +42,7 @@ const testServer = utils.setupTestServer({
 describe('GET /users', () => {
 	let owner: User;
 	let member1: User;
+	let member2: User;
 	let ownerAgent: SuperAgentTest;
 	let userRepository: UserRepository;
 
@@ -63,7 +64,7 @@ describe('GET /users', () => {
 			lastName: 'Member1LastName',
 			mfaEnabled: true,
 		});
-		await createUser({
+		member2 = await createUser({
 			role: 'global:member',
 			email: 'member2@n8n.io',
 			firstName: 'Member2FirstName',
@@ -76,6 +77,10 @@ describe('GET /users', () => {
 			lastName: 'AdminLastName',
 			mfaEnabled: true,
 		});
+
+		for (let i = 0; i < 10; i++) {
+			await createTeamProject(`project${i}`, member1);
+		}
 
 		ownerAgent = testServer.authAgentFor(owner);
 	});
@@ -435,6 +440,18 @@ describe('GET /users', () => {
 				response.body.data.items.forEach(validateUser);
 			});
 
+			test('should return all users with large enough take', async () => {
+				const response = await ownerAgent
+					.get('/users')
+					.query('take=5&expand[]=projectRelations&sortBy[]=role:desc')
+					.expect(200);
+
+				expect(response.body.data.count).toBe(4);
+				expect(response.body.data.items).toHaveLength(4);
+
+				response.body.data.items.forEach(validateUser);
+			});
+
 			test('should return all users with negative take', async () => {
 				const users: User[] = [];
 
@@ -488,12 +505,12 @@ describe('GET /users', () => {
 		describe('expand', () => {
 			test('should expand on team projects', async () => {
 				const project = await createTeamProject('Test Project');
-				await linkUserToProject(member1, project, 'project:admin');
+				await linkUserToProject(member2, project, 'project:admin');
 
 				const response = await ownerAgent
 					.get('/users')
 					.query(
-						`filter={ "email": "${member1.email}" }&select[]=firstName&take=1&expand[]=projectRelations&sortBy[]=role:asc`,
+						`filter={ "email": "${member2.email}" }&select[]=firstName&take=1&expand[]=projectRelations&sortBy[]=role:asc`,
 					)
 					.expect(200);
 


### PR DESCRIPTION
## Summary

The pagination parameters of the endpoint take and skip where translated to SQL elements limit and offset, but in combination with a join of the project relations, the generated SQL query was limiting the results to the joined set and not as expected to the number of users. TypeORM can't handle a case statement in the order part, when take and limit is used, so the sorting by role was refactored to a computed column, on which the sorting happens.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-2992/users-list-not-returning-all-relevant-users-when-sorting-is-applied

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
