### PR TITLE
fix: Helper to set proper operation for sendAndWait action

### DIFF
--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/Modes/NodesMode.vue
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/Modes/NodesMode.vue
@@ -29,6 +29,7 @@ import {
 	transformNodeType,
 	getRootSearchCallouts,
 	shouldShowCommunityNodeDetails,
+	getHumanInTheLoopActions,
 } from '../utils';
 import { useViewStacks } from '../composables/useViewStacks';
 import { useKeyboardNavigation } from '../composables/useKeyboardNavigation';
@@ -40,7 +41,7 @@ import { useI18n } from '@n8n/i18n';
 import { getNodeIconSource } from '@/utils/nodeIcon';
 
 import { useActions } from '../composables/useActions';
-import { SEND_AND_WAIT_OPERATION, type INodeParameters } from 'n8n-workflow';
+import { type INodeParameters } from 'n8n-workflow';
 
 import { isCommunityPackageName } from '@/utils/nodeTypesUtils';
 import { useNodeTypesStore } from '@/stores/nodeTypes.store';
@@ -100,10 +101,6 @@ function getFilteredActions(
 		return activeViewStack.value.actionsFilter(nodeActions);
 	}
 	return nodeActions;
-}
-
-function getHumanInTheLoopActions(nodeActions: ActionTypeDescription[]) {
-	return nodeActions.filter((action) => action.actionKey === SEND_AND_WAIT_OPERATION);
 }
 
 function onSelected(item: INodeCreateElement) {

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/utils.test.ts
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/utils.test.ts
@@ -12,6 +12,7 @@ import {
 	removeTrailingTrigger,
 	sortNodeCreateElements,
 	shouldShowCommunityNodeDetails,
+	getHumanInTheLoopActions,
 } from './utils';
 import {
 	mockActionCreateElement,
@@ -23,6 +24,8 @@ import { createTestingPinia } from '@pinia/testing';
 
 import { mock } from 'vitest-mock-extended';
 import type { ViewStack } from './composables/useViewStacks';
+import { SEND_AND_WAIT_OPERATION } from 'n8n-workflow';
+import { DISCORD_NODE_TYPE, MICROSOFT_TEAMS_NODE_TYPE } from '../../../constants';
 
 vi.mock('@/stores/settings.store', () => ({
 	useSettingsStore: vi.fn(() => ({ settings: {}, isAskAiEnabled: true })),
@@ -377,6 +380,89 @@ describe('NodeCreator - utils', () => {
 
 		it('should return false if communityNode is false and communityNodeDetails is not defined in viewStack', () => {
 			expect(shouldShowCommunityNodeDetails(false, {})).toBe(false);
+		});
+	});
+
+	describe('getHumanInTheLoopActions', () => {
+		it('should return an empty array if no actions are passed in', () => {
+			const actions: ActionTypeDescription[] = [];
+			expect(getHumanInTheLoopActions(actions)).toEqual([]);
+		});
+
+		it('should return an empty array if no actions have the SEND_AND_WAIT_OPERATION actionKey', () => {
+			const actions: ActionTypeDescription[] = [
+				{
+					name: 'Test Action',
+					group: ['trigger'],
+					codex: {
+						label: 'Test Actions',
+						categories: ['Actions'],
+					},
+					iconUrl: 'icons/n8n-nodes-preview-test/dist/nodes/Test/test.svg',
+					outputs: ['main'],
+					defaults: {
+						name: 'TestAction',
+					},
+					actionKey: 'test',
+					description: 'Test action',
+					displayName: 'Test Action',
+				},
+			];
+			expect(getHumanInTheLoopActions(actions)).toEqual(actions);
+		});
+
+		it('should set the resource and operation for Discord actions', () => {
+			const actions: ActionTypeDescription[] = [
+				{
+					name: DISCORD_NODE_TYPE,
+					group: ['trigger'],
+					codex: {
+						label: 'Discord Actions',
+						categories: ['Actions'],
+					},
+					iconUrl: 'icons/n8n-nodes-preview-test/dist/nodes/Test/test.svg',
+					outputs: ['main'],
+					defaults: {
+						name: 'DiscordAction',
+					},
+					actionKey: SEND_AND_WAIT_OPERATION,
+					description: 'Discord action',
+					displayName: 'Discord Action',
+					values: {},
+				},
+			];
+			const result = getHumanInTheLoopActions(actions);
+			expect(result[0].values).toEqual({
+				resource: 'message',
+				operation: SEND_AND_WAIT_OPERATION,
+			});
+		});
+
+		it('should set the resource and operation for Microsoft Teams actions', () => {
+			const actions: ActionTypeDescription[] = [
+				{
+					name: MICROSOFT_TEAMS_NODE_TYPE,
+					group: ['trigger'],
+					codex: {
+						label: 'Microsoft Teams Actions',
+						categories: ['Actions'],
+					},
+					iconUrl: 'icons/n8n-nodes-preview-test/dist/nodes/Test/test.svg',
+					outputs: ['main'],
+					defaults: {
+						name: 'MicrosoftTeamsAction',
+					},
+					actionKey: SEND_AND_WAIT_OPERATION,
+					description: 'Microsoft Teams action',
+					displayName: 'Microsoft Teams Action',
+					values: {},
+				},
+			];
+			const result = getHumanInTheLoopActions(actions);
+			expect(result[0].values).toEqual({
+				resource: 'chatMessage',
+				operation: SEND_AND_WAIT_OPERATION,
+			});
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/utils.test.ts
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/utils.test.ts
@@ -389,7 +389,7 @@ describe('NodeCreator - utils', () => {
 			expect(getHumanInTheLoopActions(actions)).toEqual([]);
 		});
 
-		it('should return an actions array if no actions have the SEND_AND_WAIT_OPERATION actionKey', () => {
+		it('should return an empty array if no actions have the SEND_AND_WAIT_OPERATION actionKey', () => {
 			const actions: ActionTypeDescription[] = [
 				{
 					name: 'Test Action',
@@ -408,7 +408,7 @@ describe('NodeCreator - utils', () => {
 					displayName: 'Test Action',
 				},
 			];
-			expect(getHumanInTheLoopActions(actions)).toEqual(actions);
+			expect(getHumanInTheLoopActions(actions)).toEqual([]);
 		});
 
 		it('should set the resource and operation for Discord actions', () => {

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/utils.test.ts
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/utils.test.ts
@@ -389,7 +389,7 @@ describe('NodeCreator - utils', () => {
 			expect(getHumanInTheLoopActions(actions)).toEqual([]);
 		});
 
-		it('should return an empty array if no actions have the SEND_AND_WAIT_OPERATION actionKey', () => {
+		it('should return an actions array if no actions have the SEND_AND_WAIT_OPERATION actionKey', () => {
 			const actions: ActionTypeDescription[] = [
 				{
 					name: 'Test Action',

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/utils.ts
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/utils.ts
@@ -358,8 +358,6 @@ export function getHumanInTheLoopActions(nodeActions: ActionTypeDescription[]) {
 				operation: SEND_AND_WAIT_OPERATION,
 			};
 		}
-	} else {
-		return nodeActions;
 	}
 
 	return actions;

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/utils.ts
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/utils.ts
@@ -15,7 +15,9 @@ import {
 	AI_TRANSFORM_NODE_TYPE,
 	CORE_NODES_CATEGORY,
 	DEFAULT_SUBCATEGORY,
+	DISCORD_NODE_TYPE,
 	HUMAN_IN_THE_LOOP_CATEGORY,
+	MICROSOFT_TEAMS_NODE_TYPE,
 } from '@/constants';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -336,3 +338,29 @@ export const shouldShowCommunityNodeDetails = (communityNode: boolean, viewStack
 
 	return communityNode && !viewStack.communityNodeDetails;
 };
+
+export function getHumanInTheLoopActions(nodeActions: ActionTypeDescription[]) {
+	const actions = nodeActions.filter((action) => action.actionKey === SEND_AND_WAIT_OPERATION);
+
+	if (actions.length) {
+		const name = actions[0].name;
+		if (name === DISCORD_NODE_TYPE) {
+			actions[0].values = {
+				...actions[0].values,
+				resource: 'message',
+				operation: SEND_AND_WAIT_OPERATION,
+			};
+		}
+		if (name === MICROSOFT_TEAMS_NODE_TYPE) {
+			actions[0].values = {
+				...actions[0].values,
+				resource: 'chatMessage',
+				operation: SEND_AND_WAIT_OPERATION,
+			};
+		}
+	} else {
+		return nodeActions;
+	}
+
+	return actions;
+}


### PR DESCRIPTION
## Summary

from Human in the loop section node inserted with default resource, this PR adds helper to fix that by setting proper resource

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-3092/discord-node-creating-sendandwait-node-from-node-creator-human-in-the
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
