### PR TITLE
MCP tool should return result to AI Agent event it is an error

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
@@ -244,9 +244,10 @@ export class McpClientTool implements INodeType {
 					tool,
 					createCallTool(tool.name, client.result, (error) => {
 						this.logger.error(`McpClientTool: Tool "${tool.name}" failed to execute`, { error });
-						throw new NodeOperationError(node, `Failed to execute tool "${tool.name}"`, {
-							description: error,
-						});
+						if (error !== undefined) {
+							return error;
+						}
+						return `Failed to execute tool "${tool.name}"`;
 					}),
 				),
 				this,


### PR DESCRIPTION
## Summary

MCP tools **may** return errors! 

It could be wrong parameters, a network problem, a bug in the tool, etc. AI Agent should know that an error has occurred to react properly. Otherwise AI agent thinks that everything went fine and continues working.

## Related Linear tickets, Github issues, and Community forum posts

fixes #16670

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
