### PR TITLE
fix: Adding this back as it's still needed for darwin builds locally

### DIFF
--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -56,7 +56,9 @@ COPY --from=launcher-downloader /launcher-bin/* /usr/local/bin/
 COPY docker/images/n8n/docker-entrypoint.sh /
 COPY docker/images/n8n/n8n-task-runners.json /etc/n8n-task-runners.json
 
-RUN ln -s /usr/local/lib/node_modules/n8n/bin/n8n /usr/local/bin/n8n && \
+RUN cd /usr/local/lib/node_modules/n8n && \
+		npm rebuild sqlite3 && \
+		ln -s /usr/local/lib/node_modules/n8n/bin/n8n /usr/local/bin/n8n && \
     mkdir -p /home/node/.n8n && \
     chown -R node:node /home/node
 


### PR DESCRIPTION
## Summary

Adding the rebuild of sqlite back to the runtime image. This is needed for darwin builds.

## Related Linear tickets, Github issues, and Community forum posts



## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
