### PR TITLE
refactor(editor): Remove `i18n` and `toast` usage from setting store (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/init.test.ts
+++ b/packages/frontend/editor-ui/src/init.test.ts
@@ -18,9 +18,10 @@ import { EnterpriseEditionFeature } from '@/constants';
 import { useUIStore } from '@/stores/ui.store';
 
 const showMessage = vi.fn();
+const showToast = vi.fn();
 
 vi.mock('@/composables/useToast', () => ({
-	useToast: () => ({ showMessage }),
+	useToast: () => ({ showMessage, showToast }),
 }));
 
 vi.mock('@/stores/users.store', () => ({
@@ -88,6 +89,23 @@ describe('Init', () => {
 			await initializeCore();
 
 			expect(settingsStoreSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it('should throw an error if settings initialization fails', async () => {
+			const error = new Error('Settings initialization failed');
+
+			vi.spyOn(settingsStore, 'initialize').mockImplementation(() => {
+				throw error;
+			});
+
+			await initializeCore();
+
+			expect(showToast).toHaveBeenCalledWith(
+				expect.objectContaining({
+					title: 'Error connecting to n8n',
+					type: 'error',
+				}),
+			);
 		});
 
 		it('should initialize authentication hooks', async () => {

--- a/packages/frontend/editor-ui/src/init.ts
+++ b/packages/frontend/editor-ui/src/init.ts
@@ -43,13 +43,25 @@ export async function initializeCore() {
 	const ssoStore = useSSOStore();
 	const uiStore = useUIStore();
 
+	const toast = useToast();
+	const i18n = useI18n();
+
 	registerAuthenticationHooks();
 
 	/**
 	 * Initialize stores
 	 */
 
-	await settingsStore.initialize();
+	try {
+		await settingsStore.initialize();
+	} catch (error) {
+		toast.showToast({
+			title: i18n.baseText('startupError'),
+			message: i18n.baseText('startupError.message'),
+			type: 'error',
+			duration: 0,
+		});
+	}
 
 	ssoStore.initialize({
 		authenticationMethod: settingsStore.userManagement

--- a/packages/frontend/editor-ui/src/stores/settings.store.ts
+++ b/packages/frontend/editor-ui/src/stores/settings.store.ts
@@ -263,9 +263,10 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 		}
 
 		await getSettings();
-		await getModuleSettings();
 
 		initialized.value = true;
+
+		await getModuleSettings();
 	};
 
 	const stopShowingSetupPage = () => {

--- a/packages/frontend/editor-ui/src/stores/settings.store.ts
+++ b/packages/frontend/editor-ui/src/stores/settings.store.ts
@@ -21,12 +21,9 @@ import type { IDataObject, WorkflowSettings } from 'n8n-workflow';
 import { defineStore } from 'pinia';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { makeRestApiRequest } from '@n8n/rest-api-client';
-import { useToast } from '@/composables/useToast';
-import { useI18n } from '@n8n/i18n';
 import { useLocalStorage } from '@vueuse/core';
 
 export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
-	const i18n = useI18n();
 	const initialized = ref(false);
 	const settings = ref<FrontendSettings>({} as FrontendSettings);
 	const moduleSettings = ref<FrontendModuleSettings>({});
@@ -265,23 +262,10 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 			return;
 		}
 
-		const { showToast } = useToast();
-		try {
-			await getSettings();
+		await getSettings();
+		await getModuleSettings();
 
-			initialized.value = true;
-
-			await getModuleSettings();
-		} catch (e) {
-			showToast({
-				title: i18n.baseText('startupError'),
-				message: i18n.baseText('startupError.message'),
-				type: 'error',
-				duration: 0,
-			});
-
-			throw e;
-		}
+		initialized.value = true;
 	};
 
 	const stopShowingSetupPage = () => {


### PR DESCRIPTION
## Summary

Remove i18n and toast usage from setting store.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-979/remove-dom-components-from-settings-store

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
