### PR TITLE
feat(editor): Improve style of Canvas action buttons

### DIFF
--- a/cypress/e2e/25-stickies.cy.ts
+++ b/cypress/e2e/25-stickies.cy.ts
@@ -12,7 +12,7 @@ describe('Canvas Actions', () => {
 	});
 
 	it('adds sticky to canvas with default text and position', () => {
-		workflowPage.getters.addStickyButton().should('not.be.visible');
+		workflowPage.getters.addStickyButton().should('be.visible');
 
 		addDefaultSticky();
 		workflowPage.actions.deselectAll();

--- a/cypress/pages/workflow.ts
+++ b/cypress/pages/workflow.ts
@@ -437,7 +437,6 @@ export class WorkflowPage extends BasePage {
 				.click({ force: true });
 		},
 		addSticky: () => {
-			this.getters.nodeCreatorPlusButton().realHover();
 			this.getters.addStickyButton().click();
 		},
 		deleteSticky: () => {


### PR DESCRIPTION
## Summary

This PR makes the sticky note button always visible (not only when open node panel button is hovered). This also fixes the bug with the sticky note button being hidden when the AI assistant is open.
![image](https://github.com/user-attachments/assets/7bbe1758-7562-40d2-939d-5d75b2d92cf0)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3718/feature-improve-style-of-canvas-action-buttons

https://linear.app/n8n/issue/ADO-3764/sticky-note-button-hidden-when-ai-assistant-is-active

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
