### PR TITLE
fix(core): Fix dir in module path resolution for Docker

### DIFF
--- a/packages/@n8n/backend-common/src/modules/module-registry.ts
+++ b/packages/@n8n/backend-common/src/modules/module-registry.ts
@@ -54,7 +54,7 @@ export class ModuleRegistry {
 			// docker
 			const n8nPackagePath = require.resolve('n8n/package.json');
 			const n8nRoot = path.dirname(n8nPackagePath);
-			modulesDir = path.join(n8nRoot, 'src', 'modules');
+			modulesDir = path.join(n8nRoot, 'dist', 'modules');
 		} catch {
 			// local dev
 			const dir = process.env.NODE_ENV === 'test' ? 'src' : 'dist';


### PR DESCRIPTION
## Summary

[This line](https://github.com/n8n-io/n8n/pull/16693/files#diff-c24b9f317ad634f45c1032e8350e6616ae85cde636348e6d158a2c620ebcf6dfR57) incorrectly set the dir to `src` instead of `dist` when resolving path for module in Docker.

The related PR is unreleased so this is only an issue in nightly.

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.slack.com/archives/C03MZF137FV/p1750926338815219?thread_ts=1750925947.726999&cid=C03MZF137FV

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
