### PR TITLE
refactor(core): Add `workflowId` to all job processor logs

### DIFF
--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -72,6 +72,7 @@ export class JobProcessor {
 
 		this.logger.info(`Worker started execution ${executionId} (job ${job.id})`, {
 			executionId,
+			workflowId,
 			jobId: job.id,
 		});
 
@@ -168,6 +169,11 @@ export class JobProcessor {
 			// Can't set the status directly in the queued worker, but it will happen in InternalHook.onWorkflowPostExecute
 			this.logger.debug(
 				`Queued worker execution status for execution ${executionId} (job ${job.id}) is "${status}"`,
+				{
+					executionId,
+					workflowId,
+					jobId: job.id,
+				},
 			);
 		};
 
@@ -241,6 +247,7 @@ export class JobProcessor {
 
 		this.logger.info(`Worker finished execution ${executionId} (job ${job.id})`, {
 			executionId,
+			workflowId,
 			jobId: job.id,
 		});
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This allows grouping logs by workflow ID (and also job ID), which allows using o11y tools to create metrics about which workflows crash workers most (e.g. have started but did not finish before the worker ran out of memory).

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/CAT-899/add-workflowid-to-the-job-processor-logs


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] ~Tests included.~ <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
