### PR TITLE
fix: Add explicit icon to Google Sheet credential (no-changelog)

### DIFF
--- a/packages/nodes-base/credentials/GoogleSheetsOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/GoogleSheetsOAuth2Api.credentials.ts
@@ -1,4 +1,4 @@
-import type { ICredentialType, INodeProperties } from 'n8n-workflow';
+import type { Icon, ICredentialType, INodeProperties } from 'n8n-workflow';
 
 const scopes = [
 	'https://www.googleapis.com/auth/drive.file',
@@ -12,6 +12,8 @@ export class GoogleSheetsOAuth2Api implements ICredentialType {
 	extends = ['googleOAuth2Api'];
 
 	displayName = 'Google Sheets OAuth2 API';
+
+	icon: Icon = 'node:n8n-nodes-base.googleSheets';
 
 	documentationUrl = 'google/oauth-single-service';
 


### PR DESCRIPTION
## Summary

<img width="1148" alt="image" src="https://github.com/user-attachments/assets/6af37ffd-8ed9-467d-a5fd-2bdb684dca92" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-1077/bug-google-sheets-icon-is-now-the-evaluations-icon

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
