### PR TITLE
fix: Add success url to docker build and push (no-changelog)

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -43,6 +43,10 @@ on:
         required: false
         type: boolean
         default: true
+      success_url:
+        description: 'URL to call after the build is successful'
+        required: false
+        type: string
 
   pull_request:
     types:
@@ -317,6 +321,16 @@ jobs:
             --tag $MANIFEST_TAG \
             ${MANIFEST_TAG}-amd64 \
             ${MANIFEST_TAG}-arm64
+
+  call-success-url:
+    name: Call Success URL
+    needs: [create_multi_arch_manifest]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call Success URL - optionally
+        if: ${{ github.event.inputs.success_url != '' }}
+        run: curl -v ${{github.event.inputs.success_url}} || echo ""
+        shell: bash
 
   security-scan:
     name: Security Scan


### PR DESCRIPTION
## Summary

Added the success_url parameter to the docker build and push job. This is needed for triggering other changes after the job is finished.

## Related Linear tickets, Github issues, and Community forum posts



## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
