### PR TITLE
fix: Evaluation nodes - add missing test function and credentialTest to methods

### DIFF
--- a/packages/nodes-base/nodes/Evaluation/Evaluation/Evaluation.node.ee.ts
+++ b/packages/nodes-base/nodes/Evaluation/Evaluation/Evaluation.node.ee.ts
@@ -13,7 +13,7 @@ import {
 	setOutputProperties,
 } from './Description.node';
 import { authentication } from '../../Google/Sheet/v2/actions/versionDescription';
-import { listSearch, loadOptions } from '../methods';
+import { listSearch, loadOptions, credentialTest } from '../methods';
 import { checkIfEvaluating, setMetrics, setOutputs, setOutput } from '../utils/evaluationUtils';
 
 export class Evaluation implements INodeType {
@@ -87,7 +87,7 @@ export class Evaluation implements INodeType {
 		],
 	};
 
-	methods = { loadOptions, listSearch };
+	methods = { loadOptions, listSearch, credentialTest };
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const operation = this.getNodeParameter('operation', 0);

--- a/packages/nodes-base/nodes/Evaluation/EvaluationTrigger/EvaluationTrigger.node.ee.ts
+++ b/packages/nodes-base/nodes/Evaluation/EvaluationTrigger/EvaluationTrigger.node.ee.ts
@@ -12,7 +12,7 @@ import { document, sheet } from '../../Google/Sheet/GoogleSheetsTrigger.node';
 import { readFilter } from '../../Google/Sheet/v2/actions/sheet/read.operation';
 import { authentication } from '../../Google/Sheet/v2/actions/versionDescription';
 import type { ILookupValues } from '../../Google/Sheet/v2/helpers/GoogleSheets.types';
-import { listSearch, loadOptions } from '../methods';
+import { listSearch, loadOptions, credentialTest } from '../methods';
 import {
 	getGoogleSheet,
 	getResults,
@@ -106,7 +106,7 @@ export class EvaluationTrigger implements INodeType {
 		],
 	};
 
-	methods = { loadOptions, listSearch };
+	methods = { loadOptions, listSearch, credentialTest };
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const inputData = this.getInputData();

--- a/packages/nodes-base/nodes/Evaluation/methods/index.ts
+++ b/packages/nodes-base/nodes/Evaluation/methods/index.ts
@@ -1,2 +1,3 @@
 export * as loadOptions from './loadOptions';
 export * as listSearch from './../../Google/Sheet/v2/methods/listSearch';
+export * as credentialTest from './../../Google/Sheet/v2/methods/credentialTest';

--- a/packages/nodes-base/nodes/Evaluation/test/Evaluation.node.test.ts
+++ b/packages/nodes-base/nodes/Evaluation/test/Evaluation.node.test.ts
@@ -44,6 +44,11 @@ describe('Test Evaluation', () => {
 			return { sheetId: 1, title: sheetName };
 		});
 
+		test('credential test for googleApi should be in methods', async () => {
+			const evaluationNode = new Evaluation();
+			expect(evaluationNode.methods.credentialTest.googleApiCredentialTest).toBeDefined();
+		});
+
 		test('should throw error if output values is empty', async () => {
 			mockExecuteFunctions.getNodeParameter.mockImplementation(
 				(key: string, _: number, fallbackValue?: string | number | boolean | object) => {

--- a/packages/nodes-base/nodes/Evaluation/test/EvaluationTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Evaluation/test/EvaluationTrigger.node.test.ts
@@ -53,6 +53,11 @@ describe('Evaluation Trigger Node', () => {
 				});
 			});
 
+			test('credential test for googleApi should be in methods', async () => {
+				const evaluationTrigger = new EvaluationTrigger();
+				expect(evaluationTrigger.methods.credentialTest.googleApiCredentialTest).toBeDefined();
+			});
+
 			test('should return a single row from google sheet', async () => {
 				mockExecuteFunctions.getNodeParameter.mockImplementation(
 					(key: string, _: number, fallbackValue?: string | number | boolean | object) => {


### PR DESCRIPTION
## Summary

This PR fixes an issue causing the credentials test for Google API Service Account to fail.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
https://linear.app/n8n/issue/NODE-3135/google-service-account-googleapicredentialtest-undefined
https://community.n8n.io/t/google-services-cloud-account-creds-stuck-on-testing/134018/4
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
