### PR TITLE
fix(core): Remove unneeded cookies from webhook requests

### DIFF
--- a/packages/cli/src/webhooks/__tests__/waiting-forms.test.ts
+++ b/packages/cli/src/webhooks/__tests__/waiting-forms.test.ts
@@ -206,17 +206,17 @@ describe('WaitingForms', () => {
 			});
 			executionRepository.findSingleExecution.mockResolvedValue(execution);
 
+			const req = mock<WaitingWebhookRequest>({
+				headers: {},
+				params: {
+					path: '123',
+					suffix: WAITING_FORMS_EXECUTION_STATUS,
+				},
+			});
+
 			const res = mock<express.Response>();
 
-			const result = await waitingForms.executeWebhook(
-				{
-					params: {
-						path: '123',
-						suffix: WAITING_FORMS_EXECUTION_STATUS,
-					},
-				} as WaitingWebhookRequest,
-				res,
-			);
+			const result = await waitingForms.executeWebhook(req, res);
 
 			expect(result).toEqual({ noWebhookResponse: true });
 			expect(res.send).toHaveBeenCalledWith(execution.status);

--- a/packages/cli/src/webhooks/__tests__/webhook-request-sanitizer.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-request-sanitizer.test.ts
@@ -1,0 +1,268 @@
+import type { Request } from 'express';
+import { mock } from 'jest-mock-extended';
+
+import { sanitizeWebhookRequest } from '@/webhooks/webhook-request-sanitizer';
+
+describe('webhookRequestSanitizer', () => {
+	let mockRequest: Request;
+
+	beforeEach(() => {
+		mockRequest = mock<Request>();
+	});
+
+	describe('when no cookies are present', () => {
+		it('should call next() without modifying request', () => {
+			sanitizeWebhookRequest(mockRequest);
+
+			expect(mockRequest.headers.cookie).toBeUndefined();
+		});
+
+		it('should handle undefined cookies object', () => {
+			(mockRequest.cookies as unknown) = undefined;
+
+			sanitizeWebhookRequest(mockRequest);
+		});
+	});
+
+	describe('when cookie is present in header', () => {
+		it('should remove cookie from cookie header', () => {
+			mockRequest.headers = {
+				cookie: 'n8n-auth=abc123; other-cookie=value; another-cookie=test',
+			};
+
+			sanitizeWebhookRequest(mockRequest);
+
+			expect(mockRequest.headers.cookie).toBe('other-cookie=value;another-cookie=test');
+		});
+
+		it('should remove cookie when it is the only cookie', () => {
+			mockRequest.headers = {
+				cookie: 'n8n-auth=abc123',
+			};
+
+			sanitizeWebhookRequest(mockRequest);
+
+			expect(mockRequest.headers.cookie).toBe('');
+		});
+
+		it('should remove cookie when it is the last cookie', () => {
+			mockRequest.headers = {
+				cookie: 'other-cookie=value; n8n-auth=abc123',
+			};
+
+			sanitizeWebhookRequest(mockRequest);
+
+			expect(mockRequest.headers.cookie).toBe('other-cookie=value');
+		});
+
+		it('should remove cookie when it is in the middle', () => {
+			mockRequest.headers = {
+				cookie: 'first-cookie=value1; n8n-auth=abc123; last-cookie=value2',
+			};
+
+			sanitizeWebhookRequest(mockRequest);
+
+			expect(mockRequest.headers.cookie).toBe('first-cookie=value1;last-cookie=value2');
+		});
+
+		it('should handle multiple n8n-auth cookies', () => {
+			mockRequest.headers = {
+				cookie: 'n8n-auth=abc123; other-cookie=value; n8n-auth=def456',
+			};
+
+			sanitizeWebhookRequest(mockRequest);
+
+			expect(mockRequest.headers.cookie).toBe('other-cookie=value');
+		});
+
+		it('should handle whitespace around cookies', () => {
+			mockRequest.headers = {
+				cookie: '  n8n-auth=abc123  ;  other-cookie=value  ',
+			};
+
+			sanitizeWebhookRequest(mockRequest);
+
+			expect(mockRequest.headers.cookie).toBe('other-cookie=value');
+		});
+
+		it('should not remove cookies that start with n8n-auth but are not exact match', () => {
+			mockRequest.headers = {
+				cookie: 'n8n-auth-extra=value; other-cookie=value',
+			};
+
+			sanitizeWebhookRequest(mockRequest);
+
+			expect(mockRequest.headers.cookie).toBe('n8n-auth-extra=value; other-cookie=value');
+		});
+	});
+
+	describe('when cookie is not present in header', () => {
+		it('should not modify cookie header when n8n-auth is not present', () => {
+			const originalCookie = 'other-cookie=value; another-cookie=test';
+			mockRequest.headers = {
+				cookie: originalCookie,
+			};
+
+			sanitizeWebhookRequest(mockRequest);
+
+			expect(mockRequest.headers.cookie).toBe(originalCookie);
+		});
+
+		it('should handle case sensitivity correctly', () => {
+			mockRequest.headers = {
+				cookie: 'N8N-AUTH=abc123; other-cookie=value',
+			};
+
+			sanitizeWebhookRequest(mockRequest);
+
+			expect(mockRequest.headers.cookie).toBe('N8N-AUTH=abc123; other-cookie=value');
+		});
+	});
+
+	describe('when cookie is present in parsed cookies', () => {
+		it('should remove n8n-auth from parsed cookies object', () => {
+			mockRequest.cookies = {
+				'n8n-auth': 'abc123',
+				'other-cookie': 'value',
+			};
+
+			sanitizeWebhookRequest(mockRequest);
+
+			expect(mockRequest.cookies).toEqual({
+				'other-cookie': 'value',
+			});
+		});
+
+		it('should handle when n8n-auth is the only cookie in parsed cookies', () => {
+			mockRequest.cookies = {
+				'n8n-auth': 'abc123',
+			};
+
+			sanitizeWebhookRequest(mockRequest);
+
+			expect(mockRequest.cookies).toEqual({});
+		});
+
+		it('should not modify other cookies when n8n-auth is not present in parsed cookies', () => {
+			const originalCookies = {
+				'other-cookie': 'value',
+				'another-cookie': 'test',
+			};
+			mockRequest.cookies = { ...originalCookies };
+
+			sanitizeWebhookRequest(mockRequest);
+
+			expect(mockRequest.cookies).toEqual(originalCookies);
+		});
+	});
+
+	describe('when both header and parsed cookies contain n8n-auth', () => {
+		it('should remove n8n-auth from both header and parsed cookies', () => {
+			mockRequest.headers = {
+				cookie: 'n8n-auth=abc123; other-cookie=value',
+			};
+			mockRequest.cookies = {
+				'n8n-auth': 'abc123',
+				'other-cookie': 'value',
+			};
+
+			sanitizeWebhookRequest(mockRequest);
+
+			expect(mockRequest.headers.cookie).toBe('other-cookie=value');
+			expect(mockRequest.cookies).toEqual({
+				'other-cookie': 'value',
+			});
+		});
+	});
+
+	describe('edge cases', () => {
+		it('should handle empty cookie header', () => {
+			mockRequest.headers = {
+				cookie: '',
+			};
+
+			sanitizeWebhookRequest(mockRequest);
+
+			expect(mockRequest.headers.cookie).toBe('');
+		});
+
+		it('should handle cookie header with only whitespace', () => {
+			mockRequest.headers = {
+				cookie: '   ',
+			};
+
+			sanitizeWebhookRequest(mockRequest);
+
+			expect(mockRequest.headers.cookie).toBe('   ');
+		});
+
+		it('should handle cookie header with only semicolons', () => {
+			mockRequest.headers = {
+				cookie: ';;;',
+			};
+
+			sanitizeWebhookRequest(mockRequest);
+
+			expect(mockRequest.headers.cookie).toBe(';;;');
+		});
+
+		it('should handle malformed cookies without equals sign', () => {
+			mockRequest.headers = {
+				cookie: 'n8n-auth; other-cookie=value',
+			};
+
+			sanitizeWebhookRequest(mockRequest);
+
+			expect(mockRequest.headers.cookie).toBe('n8n-auth; other-cookie=value');
+		});
+	});
+
+	describe('when n8n-browserId is present in header', () => {
+		it('should remove n8n-browserId from cookie header', () => {
+			mockRequest.headers = {
+				cookie: 'n8n-browserId=abc123; other-cookie=value',
+			};
+
+			sanitizeWebhookRequest(mockRequest);
+
+			expect(mockRequest.headers.cookie).toBe('other-cookie=value');
+		});
+
+		it('should remove n8n-browserId from parsed cookies', () => {
+			mockRequest.cookies = {
+				'n8n-browserId': 'abc123',
+				'other-cookie': 'value',
+			};
+
+			sanitizeWebhookRequest(mockRequest);
+
+			expect(mockRequest.cookies).toEqual({
+				'other-cookie': 'value',
+			});
+		});
+
+		it('should remove both n8n-auth and n8n-browserId from cookie header', () => {
+			mockRequest.headers = {
+				cookie: 'n8n-auth=abc123; n8n-browserId=def456; other-cookie=value',
+			};
+
+			sanitizeWebhookRequest(mockRequest);
+
+			expect(mockRequest.headers.cookie).toBe('other-cookie=value');
+		});
+
+		it('should remove both n8n-auth and n8n-browserId from parsed cookies', () => {
+			mockRequest.cookies = {
+				'n8n-auth': 'abc123',
+				'n8n-browserId': 'def456',
+				'other-cookie': 'value',
+			};
+
+			sanitizeWebhookRequest(mockRequest);
+
+			expect(mockRequest.cookies).toEqual({
+				'other-cookie': 'value',
+			});
+		});
+	});
+});

--- a/packages/cli/src/webhooks/__tests__/webhook-request-sanitizer.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-request-sanitizer.test.ts
@@ -32,7 +32,7 @@ describe('webhookRequestSanitizer', () => {
 
 			sanitizeWebhookRequest(mockRequest);
 
-			expect(mockRequest.headers.cookie).toBe('other-cookie=value;another-cookie=test');
+			expect(mockRequest.headers.cookie).toBe('other-cookie=value; another-cookie=test');
 		});
 
 		it('should remove cookie when it is the only cookie', () => {
@@ -62,7 +62,7 @@ describe('webhookRequestSanitizer', () => {
 
 			sanitizeWebhookRequest(mockRequest);
 
-			expect(mockRequest.headers.cookie).toBe('first-cookie=value1;last-cookie=value2');
+			expect(mockRequest.headers.cookie).toBe('first-cookie=value1; last-cookie=value2');
 		});
 
 		it('should handle multiple n8n-auth cookies', () => {
@@ -213,7 +213,7 @@ describe('webhookRequestSanitizer', () => {
 
 			sanitizeWebhookRequest(mockRequest);
 
-			expect(mockRequest.headers.cookie).toBe('n8n-auth; other-cookie=value');
+			expect(mockRequest.headers.cookie).toBe('other-cookie=value');
 		});
 	});
 

--- a/packages/cli/src/webhooks/constants.ts
+++ b/packages/cli/src/webhooks/constants.ts
@@ -1,0 +1,1 @@
+export const authWhitelistedNodes = new Set<string>(['@n8n/n8n-nodes-langchain.chatTrigger']);

--- a/packages/cli/src/webhooks/constants.ts
+++ b/packages/cli/src/webhooks/constants.ts
@@ -1,1 +1,3 @@
-export const authAllowlistedNodes = new Set(['@n8n/n8n-nodes-langchain.chatTrigger']);
+import { CHAT_TRIGGER_NODE_TYPE } from 'n8n-workflow';
+
+export const authAllowlistedNodes = new Set([CHAT_TRIGGER_NODE_TYPE]);

--- a/packages/cli/src/webhooks/constants.ts
+++ b/packages/cli/src/webhooks/constants.ts
@@ -1,1 +1,1 @@
-export const authWhitelistedNodes = new Set<string>(['@n8n/n8n-nodes-langchain.chatTrigger']);
+export const authAllowlistedNodes = new Set(['@n8n/n8n-nodes-langchain.chatTrigger']);

--- a/packages/cli/src/webhooks/live-webhooks.ts
+++ b/packages/cli/src/webhooks/live-webhooks.ts
@@ -19,7 +19,7 @@ import type {
 	WebhookAccessControlOptions,
 	WebhookRequest,
 } from './webhook.types';
-import { authWhitelistedNodes } from './constants';
+import { authAllowlistedNodes } from './constants';
 import { sanitizeWebhookRequest } from './webhook-request-sanitizer';
 
 /**
@@ -128,7 +128,7 @@ export class LiveWebhooks implements IWebhookManager {
 			throw new NotFoundError('Could not find node to process webhook.');
 		}
 
-		if (!authWhitelistedNodes.has(workflowStartNode.type)) {
+		if (!authAllowlistedNodes.has(workflowStartNode.type)) {
 			sanitizeWebhookRequest(request);
 		}
 

--- a/packages/cli/src/webhooks/live-webhooks.ts
+++ b/packages/cli/src/webhooks/live-webhooks.ts
@@ -19,6 +19,8 @@ import type {
 	WebhookAccessControlOptions,
 	WebhookRequest,
 } from './webhook.types';
+import { authWhitelistedNodes } from './constants';
+import { sanitizeWebhookRequest } from './webhook-request-sanitizer';
 
 /**
  * Service for handling the execution of live webhooks, i.e. webhooks
@@ -124,6 +126,10 @@ export class LiveWebhooks implements IWebhookManager {
 
 		if (workflowStartNode === null) {
 			throw new NotFoundError('Could not find node to process webhook.');
+		}
+
+		if (!authWhitelistedNodes.has(workflowStartNode.type)) {
+			sanitizeWebhookRequest(request);
 		}
 
 		return await new Promise((resolve, reject) => {

--- a/packages/cli/src/webhooks/test-webhooks.ts
+++ b/packages/cli/src/webhooks/test-webhooks.ts
@@ -32,7 +32,7 @@ import type {
 	WebhookAccessControlOptions,
 	WebhookRequest,
 } from './webhook.types';
-import { authWhitelistedNodes } from './constants';
+import { authAllowlistedNodes } from './constants';
 import { sanitizeWebhookRequest } from './webhook-request-sanitizer';
 
 /**
@@ -116,7 +116,7 @@ export class TestWebhooks implements IWebhookManager {
 			throw new NotFoundError('Could not find node to process webhook.');
 		}
 
-		if (!authWhitelistedNodes.has(workflowStartNode.type)) {
+		if (!authAllowlistedNodes.has(workflowStartNode.type)) {
 			sanitizeWebhookRequest(request);
 		}
 

--- a/packages/cli/src/webhooks/test-webhooks.ts
+++ b/packages/cli/src/webhooks/test-webhooks.ts
@@ -32,6 +32,8 @@ import type {
 	WebhookAccessControlOptions,
 	WebhookRequest,
 } from './webhook.types';
+import { authWhitelistedNodes } from './constants';
+import { sanitizeWebhookRequest } from './webhook-request-sanitizer';
 
 /**
  * Service for handling the execution of webhooks of manual executions
@@ -112,6 +114,10 @@ export class TestWebhooks implements IWebhookManager {
 
 		if (workflowStartNode === null) {
 			throw new NotFoundError('Could not find node to process webhook.');
+		}
+
+		if (!authWhitelistedNodes.has(workflowStartNode.type)) {
+			sanitizeWebhookRequest(request);
 		}
 
 		return await new Promise(async (resolve, reject) => {

--- a/packages/cli/src/webhooks/waiting-forms.ts
+++ b/packages/cli/src/webhooks/waiting-forms.ts
@@ -14,6 +14,7 @@ import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { WaitingWebhooks } from '@/webhooks/waiting-webhooks';
 
 import type { IWebhookResponseCallbackData, WaitingWebhookRequest } from './webhook.types';
+import { sanitizeWebhookRequest } from './webhook-request-sanitizer';
 
 @Service()
 export class WaitingForms extends WaitingWebhooks {
@@ -73,6 +74,8 @@ export class WaitingForms extends WaitingWebhooks {
 		const { path: executionId, suffix } = req.params;
 
 		this.logReceivedWebhook(req.method, executionId);
+
+		sanitizeWebhookRequest(req);
 
 		// Reset request parameters
 		req.params = {} as WaitingWebhookRequest['params'];

--- a/packages/cli/src/webhooks/waiting-webhooks.ts
+++ b/packages/cli/src/webhooks/waiting-webhooks.ts
@@ -24,6 +24,7 @@ import type {
 	IWebhookManager,
 	WaitingWebhookRequest,
 } from './webhook.types';
+import { sanitizeWebhookRequest } from './webhook-request-sanitizer';
 
 /**
  * Service for handling the execution of webhooks of Wait nodes that use the
@@ -88,6 +89,8 @@ export class WaitingWebhooks implements IWebhookManager {
 		const { path: executionId, suffix } = req.params;
 
 		this.logReceivedWebhook(req.method, executionId);
+
+		sanitizeWebhookRequest(req);
 
 		// Reset request parameters
 		req.params = {} as WaitingWebhookRequest['params'];

--- a/packages/cli/src/webhooks/webhook-request-sanitizer.ts
+++ b/packages/cli/src/webhooks/webhook-request-sanitizer.ts
@@ -29,7 +29,7 @@ const removeCookiesFromHeader = (req: Request) => {
  * Removes a cookie with the given name from the parsed cookies object
  */
 const removeCookiesFromParsedCookies = (req: Request) => {
-	if (req.cookies && typeof req.cookies === 'object') {
+	if (req.cookies !== null && typeof req.cookies === 'object') {
 		for (const cookieName of DISALLOWED_COOKIES) {
 			delete req.cookies[cookieName];
 		}

--- a/packages/cli/src/webhooks/webhook-request-sanitizer.ts
+++ b/packages/cli/src/webhooks/webhook-request-sanitizer.ts
@@ -3,43 +3,40 @@ import type { Request } from 'express';
 
 const BROWSER_ID_COOKIE_NAME = 'n8n-browserId';
 
+const DISALLOWED_COOKIES = new Set([AUTH_COOKIE_NAME, BROWSER_ID_COOKIE_NAME]);
+
 /**
  * Removes a cookie with the given name from the request header
  */
-const removeCookiesFromHeader = (req: Request, cookieNames: string[]) => {
-	const cookiesHeader = req.headers?.cookie;
-	if (!cookiesHeader) {
+const removeCookiesFromHeader = (req: Request) => {
+	const cookiesHeader = req.headers.cookie;
+	if (typeof cookiesHeader !== 'string') {
 		return;
 	}
 
-	const cookiesToSearchFor = cookieNames.map((cookieName) => `${cookieName}=`);
-	const isSomeCookiePresent = cookiesToSearchFor.some((cookieToSearchFor) =>
-		cookiesHeader.includes(cookieToSearchFor),
-	);
-	if (!isSomeCookiePresent) {
-		return;
-	}
-
-	const cookies = cookiesHeader.split(';').map((cookie: string) => cookie.trim());
-	const filteredCookies = cookies.filter((cookie: string) => {
-		return !cookiesToSearchFor.some((cookieToSearchFor) => cookie.startsWith(cookieToSearchFor));
+	const cookies = cookiesHeader.split(';').map((cookie) => cookie.trim());
+	const filteredCookies = cookies.filter((cookie) => {
+		const cookieName = cookie.split('=')[0];
+		return !DISALLOWED_COOKIES.has(cookieName);
 	});
 
-	req.headers.cookie = filteredCookies.join(';');
+	if (filteredCookies.length !== cookies.length) {
+		req.headers.cookie = filteredCookies.join('; ');
+	}
 };
 
 /**
  * Removes a cookie with the given name from the parsed cookies object
  */
-const removeCookiesFromParsedCookies = (req: Request, cookieNames: string[]) => {
+const removeCookiesFromParsedCookies = (req: Request) => {
 	if (req.cookies && typeof req.cookies === 'object') {
-		for (const cookieName of cookieNames) {
+		for (const cookieName of DISALLOWED_COOKIES) {
 			delete req.cookies[cookieName];
 		}
 	}
 };
 
 export const sanitizeWebhookRequest = (req: Request) => {
-	removeCookiesFromHeader(req, [AUTH_COOKIE_NAME, BROWSER_ID_COOKIE_NAME]);
-	removeCookiesFromParsedCookies(req, [AUTH_COOKIE_NAME, BROWSER_ID_COOKIE_NAME]);
+	removeCookiesFromHeader(req);
+	removeCookiesFromParsedCookies(req);
 };

--- a/packages/cli/src/webhooks/webhook-request-sanitizer.ts
+++ b/packages/cli/src/webhooks/webhook-request-sanitizer.ts
@@ -1,0 +1,45 @@
+import { AUTH_COOKIE_NAME } from '@/constants';
+import type { Request } from 'express';
+
+const BROWSER_ID_COOKIE_NAME = 'n8n-browserId';
+
+/**
+ * Removes a cookie with the given name from the request header
+ */
+const removeCookiesFromHeader = (req: Request, cookieNames: string[]) => {
+	const cookiesHeader = req.headers?.cookie;
+	if (!cookiesHeader) {
+		return;
+	}
+
+	const cookiesToSearchFor = cookieNames.map((cookieName) => `${cookieName}=`);
+	const isSomeCookiePresent = cookiesToSearchFor.some((cookieToSearchFor) =>
+		cookiesHeader.includes(cookieToSearchFor),
+	);
+	if (!isSomeCookiePresent) {
+		return;
+	}
+
+	const cookies = cookiesHeader.split(';').map((cookie: string) => cookie.trim());
+	const filteredCookies = cookies.filter((cookie: string) => {
+		return !cookiesToSearchFor.some((cookieToSearchFor) => cookie.startsWith(cookieToSearchFor));
+	});
+
+	req.headers.cookie = filteredCookies.join(';');
+};
+
+/**
+ * Removes a cookie with the given name from the parsed cookies object
+ */
+const removeCookiesFromParsedCookies = (req: Request, cookieNames: string[]) => {
+	if (req.cookies && typeof req.cookies === 'object') {
+		for (const cookieName of cookieNames) {
+			delete req.cookies[cookieName];
+		}
+	}
+};
+
+export const sanitizeWebhookRequest = (req: Request) => {
+	removeCookiesFromHeader(req, [AUTH_COOKIE_NAME, BROWSER_ID_COOKIE_NAME]);
+	removeCookiesFromParsedCookies(req, [AUTH_COOKIE_NAME, BROWSER_ID_COOKIE_NAME]);
+};

--- a/packages/cli/src/webhooks/webhook.types.ts
+++ b/packages/cli/src/webhooks/webhook.types.ts
@@ -9,7 +9,7 @@ export type WebhookRequest = Request<{ path: string }> & {
 };
 
 export type WaitingWebhookRequest = WebhookRequest & {
-	params: WebhookRequest['path'] & { suffix?: string };
+	params: Pick<WebhookRequest['params'], 'path'> & { suffix?: string };
 };
 
 export interface WebhookAccessControlOptions {


### PR DESCRIPTION
## Summary

Remove unneeded cookies from webhook & form requests

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-964

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
