### PR TITLE
feat(editor): Disable reset value for code and sql editors (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/components/ParameterOptions.vue
+++ b/packages/frontend/editor-ui/src/components/ParameterOptions.vue
@@ -121,7 +121,16 @@ const actions = computed(() => {
 		disabled: isDefault.value,
 	};
 
-	const parameterActions = hasFocusAction.value ? [resetAction, focusAction] : [resetAction];
+	// The reset value action is not working correctly for these
+	const hasResetAction = !['codeNodeEditor', 'sqlEditor'].includes(
+		props.parameter.typeOptions?.editor ?? '',
+	);
+
+	// Conditionally build actions array without nulls to ensure correct typing
+	const parameterActions = [
+		hasResetAction ? [resetAction] : [],
+		hasFocusAction.value ? [focusAction] : [],
+	].flat();
 
 	if (
 		hasRemoteMethod.value ||


### PR DESCRIPTION
## Summary

We didn't show action dropdown for code and SQL editors, but when implementing the Focus Panel I added this action along with `Focus parameter` (only when the feature flag is on). It turned out that this action isn't yet working correctly, so we have to disable it for now.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3768/feature-disable-reset-value-for-code-node

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
