### PR TITLE
fix(core): Return default tags-mappings and folders value when file not found

### DIFF
--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control-helper.ee.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control-helper.ee.test.ts
@@ -313,3 +313,44 @@ describe('isWorkflowModified', () => {
 		expect(isWorkflowModified(local, remote)).toBe(false);
 	});
 });
+
+describe('readTagAndMappingsFromSourceControlFile', () => {
+	beforeEach(() => {
+		// Reset module registry so we can unmock properly
+		jest.resetModules();
+		jest.unmock('node:fs/promises');
+	});
+
+	it('should return default mapping if the file path is not valid', async () => {
+		const filePath = 'invalid/path/tags-and-mappings.json';
+		// Import the function after resetting modules
+		const { readTagAndMappingsFromSourceControlFile } = await import(
+			'@/environments.ee/source-control/source-control-helper.ee'
+		);
+		const result = await readTagAndMappingsFromSourceControlFile(filePath);
+		expect(result).toEqual({
+			tags: [],
+			mappings: [],
+		});
+	});
+});
+
+describe('readFoldersFromSourceControlFile', () => {
+	beforeEach(() => {
+		// Reset module registry so we can unmock properly
+		jest.resetModules();
+		jest.unmock('node:fs/promises');
+	});
+
+	it('should return default folders if the file path is not valid', async () => {
+		const filePath = 'invalid/path/folders.json';
+		// Import the function after resetting modules
+		const { readFoldersFromSourceControlFile } = await import(
+			'@/environments.ee/source-control/source-control-helper.ee'
+		);
+		const result = await readFoldersFromSourceControlFile(filePath);
+		expect(result).toEqual({
+			folders: [],
+		});
+	});
+});

--- a/packages/cli/src/environments.ee/source-control/source-control-helper.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-helper.ee.ts
@@ -54,16 +54,32 @@ export async function readTagAndMappingsFromSourceControlFile(file: string): Pro
 	tags: TagEntity[];
 	mappings: WorkflowTagMapping[];
 }> {
-	return jsonParse<{ tags: TagEntity[]; mappings: WorkflowTagMapping[] }>(
-		await fsReadFile(file, { encoding: 'utf8' }),
-		{ fallbackValue: { tags: [], mappings: [] } },
-	);
+	try {
+		return jsonParse<{ tags: TagEntity[]; mappings: WorkflowTagMapping[] }>(
+			await fsReadFile(file, { encoding: 'utf8' }),
+			{ fallbackValue: { tags: [], mappings: [] } },
+		);
+	} catch (error) {
+		// Return fallback if file not found
+		if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+			return { tags: [], mappings: [] };
+		}
+		throw error;
+	}
 }
 
 export async function readFoldersFromSourceControlFile(file: string): Promise<ExportedFolders> {
-	return jsonParse<ExportedFolders>(await fsReadFile(file, { encoding: 'utf8' }), {
-		fallbackValue: { folders: [] },
-	});
+	try {
+		return jsonParse<ExportedFolders>(await fsReadFile(file, { encoding: 'utf8' }), {
+			fallbackValue: { folders: [] },
+		});
+	} catch (error) {
+		// Return fallback if file not found
+		if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+			return { folders: [] };
+		}
+		throw error;
+	}
 }
 
 export function sourceControlFoldersExistCheck(


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR fixes the issue when exporting folders and tag mappings for source control, when the file does not exist (like on first push).
The source control export service tries to read the folders and tag-mappings files on push, to keep data that is outside the scope of the push. But it does not check that the file exists nor catch error when it does not.
This fix suggests to return fallback value (default folders / tag mappings data) if file does not exists, so it's going to get created with default value on first push.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
