### PR TITLE
fix(editor): Don't reset node name on click while renaming

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nInlineTextEdit/InlineTextEdit.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInlineTextEdit/InlineTextEdit.vue
@@ -104,11 +104,7 @@ const computedInlineStyles = computed(() => {
 		@update:model-value="onInput"
 		@update:state="onStateChange"
 	>
-		<EditableArea
-			:style="computedInlineStyles"
-			:class="$style.inlineRenameArea"
-			@click="forceFocus"
-		>
+		<EditableArea :style="computedInlineStyles" :class="$style.inlineRenameArea">
 			<span ref="measureSpan" :class="$style.measureSpan">
 				{{ temp }}
 			</span>


### PR DESCRIPTION
## Summary

The `edit()` call this line triggers resets the modelValue. I couldn't make sense of why we call this in the first place, I confirmed the parameter remains focused when clicked into as is.

Reviewer please double check this though as Rob (original author) is OOO.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3748/bug-cannot-rename-node-when-clicking-in-new-name

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
