### PR TITLE
fix(editor): Support 'Save Workflow' key shortcut in new workflows

### DIFF
--- a/packages/frontend/editor-ui/src/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/views/NodeView.vue
@@ -848,7 +848,7 @@ function onPinNodes(ids: string[], source: PinDataSource) {
 }
 
 async function onSaveWorkflow() {
-	const workflowIsSaved = !uiStore.stateIsDirty;
+	const workflowIsSaved = !uiStore.stateIsDirty && !workflowsStore.isNewWorkflow;
 	const workflowIsArchived = workflowsStore.workflow.isArchived;
 
 	if (workflowIsSaved || workflowIsArchived) {


### PR DESCRIPTION
## Summary

Align the check in `NodeView` closer with the one in `WorkflowDetails`. Note that the `isNewWorkflow` in the `workflowsStore` is simpler than the one used in `WorkflowDetails`:

workflowsStore: 
```ts
const isNewWorkflow = computed(() => workflow.value.id === PLACEHOLDER_EMPTY_WORKFLOW_ID);
```

WorkflowDetails:

```ts
const isNewWorkflow = computed(() => {
	return !props.id || props.id === PLACEHOLDER_EMPTY_WORKFLOW_ID || props.id === 'new';
});
```

I'm tempted to port this over but am not knowledgeable enough to understand the implications, please advise.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3594/bug-ctrl-s-only-works-after-a-node-has-been-added-to-the-canvas


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
