### PR TITLE
fix: Remove APK tools from base (no-changelog)

### DIFF
--- a/docker/images/n8n-base/Dockerfile
+++ b/docker/images/n8n-base/Dockerfile
@@ -20,8 +20,8 @@ RUN apk add --no-cache git openssh graphicsmagick tini tzdata ca-certificates li
 # Remove npm update after vulnerability is fixed in in node image
 RUN npm install -g full-icu@1.5.0 npm@11.4.2
 
-RUN apk del apk-tools && \
-  rm -rf /tmp/* /root/.npm /root/.cache/node /opt/yarn* /var/cache/apk/* /lib/apk/db
+RUN rm -rf /tmp/* /root/.npm /root/.cache/node /opt/yarn* && \
+  apk del apk-tools
 
 # ==============================================================================
 # STAGE 2: Final Base Runtime Image


### PR DESCRIPTION
## Summary

Changing the cleanup to be the last instruction is required.
Built base + full images locally, scanned with license scan from Trivy and it's no longer present.
Verified by running tests against created docker image.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/SEC-258/gpl-20

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
