### PR TITLE
fix: Build eslint as dependency (no-changelog)

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -31,6 +31,7 @@
 		"format:check": {},
 		"lint:backend": {
 			"dependsOn": [
+				"@n8n/eslint-config#build",
 				"^build",
 				"@n8n/api-types#lint",
 				"@n8n/config#lint",
@@ -52,6 +53,7 @@
 		},
 		"lint:frontend": {
 			"dependsOn": [
+				"@n8n/eslint-config#build",
 				"^build",
 				"@n8n/rest-api-client#lint",
 				"@n8n/api-types#lint",
@@ -71,6 +73,7 @@
 		},
 		"lint:nodes": {
 			"dependsOn": [
+				"@n8n/eslint-config#build",
 				"^build",
 				"n8n-nodes-base#lint",
 				"@n8n/n8n-nodes-langchain#lint",


### PR DESCRIPTION
## Summary

Adds eslint build task as an explicit dependency to the lint jobs in Turbo, this will force it to be built.

## Related Linear tickets, Github issues, and Community forum posts



## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
