### PR TITLE
build: Add dependency on @n8n/eslint-config#build to lint scripts

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -31,6 +31,7 @@
 		"format:check": {},
 		"lint:backend": {
 			"dependsOn": [
+				"@n8n/eslint-config#build",
 				"^build",
 				"@n8n/api-types#lint",
 				"@n8n/config#lint",
@@ -52,6 +53,7 @@
 		},
 		"lint:frontend": {
 			"dependsOn": [
+				"@n8n/eslint-config#build",
 				"^build",
 				"@n8n/rest-api-client#lint",
 				"@n8n/api-types#lint",
@@ -71,6 +73,7 @@
 		},
 		"lint:nodes": {
 			"dependsOn": [
+				"@n8n/eslint-config#build",
 				"^build",
 				"n8n-nodes-base#lint",
 				"@n8n/n8n-nodes-langchain#lint",
@@ -78,7 +81,7 @@
 			]
 		},
 		"lint": {
-			"dependsOn": ["^build"]
+			"dependsOn": ["^build", "@n8n/eslint-config#build"]
 		},
 		"lintfix": {},
 		"test:backend": {


### PR DESCRIPTION
## Summary

CI/CD on master is failing because the eslint config is not built before linting

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
