### PR TITLE
feat: add Koncile node to upload files via API

### DIFF
--- a/packages/nodes-base/credentials/KoncileApi.credentials.ts
+++ b/packages/nodes-base/credentials/KoncileApi.credentials.ts
@@ -1,0 +1,39 @@
+import {
+	ICredentialType,
+	INodeProperties,
+	ICredentialTestRequest,
+} from 'n8n-workflow';
+
+import type { IHttpRequestMethods } from 'n8n-workflow';
+
+export class KoncileApi implements ICredentialType {
+	name = 'koncileApi';
+	displayName = 'Koncile API';
+	documentationUrl = 'https://docs.koncile.ai/api-setup/api-key-generation';
+
+	properties: INodeProperties[] = [
+		{
+			displayName: 'API Key',
+			name: 'api_key',
+			type: 'string',
+			typeOptions: { password: true },
+			default: '',
+		},
+	];
+
+	authenticate = {
+		type: 'generic' as const,
+		properties: {
+			headers: {
+				Authorization: 'Bearer={{$credentials.api_key}}',
+			},
+		},
+	};
+
+	test: ICredentialTestRequest = {
+		request: {
+			method: 'POST' as IHttpRequestMethods,
+			url: 'https://api.koncile.ai/v1/check_api_key/',
+		},
+	};
+}

--- a/packages/nodes-base/nodes/Koncile/Koncile.node.ts
+++ b/packages/nodes-base/nodes/Koncile/Koncile.node.ts
@@ -1,0 +1,181 @@
+import {
+	IExecuteFunctions,
+	ILoadOptionsFunctions,
+	NodeApiError,
+} from 'n8n-workflow';
+
+import {
+	INodeExecutionData,
+	INodeType,
+	INodeTypeDescription,
+	NodeConnectionType,
+} from 'n8n-workflow';
+
+
+import axios from 'axios';
+const FormData = require('form-data');
+
+export class Koncile implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Koncile',
+		name: 'koncile',
+    icon: 'file:koncile.svg',
+		group: ['transform'],
+		version: 1,
+		description: 'Send files to Koncile.ai',
+		defaults: {
+			name: 'Koncile',
+		},
+		inputs: [NodeConnectionType.Main],
+		outputs: [NodeConnectionType.Main],
+		credentials: [
+			{
+				name: 'koncileApi',
+				required: true,
+			},
+		],
+		properties: [
+			{
+				displayName: 'Binary Property',
+				name: 'binaryPropertyName',
+				type: 'string',
+				default: 'data',
+				required: true,
+				description: 'Name of the binary property that contains the file',
+			},
+			{
+				displayName: 'Folder Name or ID',
+				name: 'folder_id',
+				type: 'options',
+				description: 'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				typeOptions: {
+					loadOptionsMethod: 'getFolders',
+				},
+				default: '',
+				required: true,
+			},
+			{
+				displayName: 'Template Name or ID',
+				name: 'template_id',
+				type: 'options',
+				description: 'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				typeOptions: {
+					loadOptionsMethod: 'getTemplates',
+					loadOptionsDependsOn: ['folder_id'],
+				},
+				default: '',
+				required: true,
+			},
+		],
+	};
+
+	methods = {
+	loadOptions: {
+		async getFolders(this: ILoadOptionsFunctions) {
+			const credentials = await this.getCredentials('koncileApi');
+			const apiKey = credentials.api_key;
+
+    const response = await this.helpers.httpRequest({
+      method: 'GET',
+      url: 'https://api.koncile.ai/v1/fetch_all_folders/',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+    });
+
+
+			return response.folders.map((folder: any) => ({
+				name: folder.name,
+				value: folder.id,
+			}));
+		},
+
+		async getTemplates(this: ILoadOptionsFunctions) {
+			const credentials = await this.getCredentials('koncileApi');
+			const apiKey = credentials.api_key;
+			const folderId = this.getCurrentNodeParameter('folder_id') as number;
+
+      const response = await this.helpers.httpRequest({
+        method: 'GET',
+        url: 'https://api.koncile.ai/v1/fetch_all_folders/',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+        },
+      });
+
+
+			const folder = response.folders.find((f: any) => f.id === folderId);
+			if (!folder?.templates?.length) {
+				return [];
+			}
+
+			return folder.templates.map((template: any) => ({
+				name: template.name,
+				value: template.id,
+			}));
+		},
+	},
+};
+
+
+	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+		const items = this.getInputData();
+		const returnData: INodeExecutionData[] = [];
+
+		const credentials = await this.getCredentials('koncileApi');
+		const apiKey = credentials.api_key;
+
+		for (let i = 0; i < items.length; i++) {
+			const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i) as string;
+			const template_id = this.getNodeParameter('template_id', i) as number;
+			const folder_id = this.getNodeParameter('folder_id', i) as number;
+
+			const item = items[i];
+			const binaryData = item.binary?.[binaryPropertyName];
+
+			if (!binaryData) {
+				throw new NodeApiError(this.getNode(), {
+					message: `No binary data property '${binaryPropertyName}' found on input`,
+				});
+			}
+
+			const fileBuffer = await this.helpers.getBinaryDataBuffer(i, binaryPropertyName);
+
+			const form = new FormData();
+			form.append('files', fileBuffer, {
+				filename: binaryData.fileName || 'upload.pdf',
+				contentType: binaryData.mimeType || 'application/pdf',
+			});
+
+			try {
+				const response = await axios.post(
+					'https://api.koncile.ai/v1/upload_file/',
+					form,
+					{
+						headers: {
+							...form.getHeaders(),
+							Authorization: `Bearer ${apiKey}`,
+						},
+						params: {
+							template_id,
+							folder_id,
+						},
+						maxContentLength: Infinity,
+						maxBodyLength: Infinity,
+					}
+				);
+        console.log('📦 Réponse de Koncile Upload API :\n', JSON.stringify(response.data, null, 2));
+				returnData.push({
+					json: {
+						...response.data,
+						uploaded_file_name: binaryData.fileName,
+					},
+				});
+			} catch (error: any) {
+				throw new NodeApiError(this.getNode(), error);
+			}
+		}
+
+		return [returnData];
+	}
+}

--- a/packages/nodes-base/nodes/Koncile/koncile.svg
+++ b/packages/nodes-base/nodes/Koncile/koncile.svg
@@ -1,0 +1,4 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="256" height="256" rx="4" fill="black"/>
+<path d="M161.934 64L124.383 119.541H106.473V64H88.5106V192H106.473V136.485H124.383L161.934 192H183.83L140.982 128.013L183.83 64H161.934Z" fill="#FDF769"/>
+</svg>


### PR DESCRIPTION
## Summary

This PR introduces a new community node to connect with [Koncile.ai](https://koncile.ai), a document processing platform.

The node allows users to:
- Upload files to a specific folder and template
- Authenticate using a personal API key from Koncile
- Retrieve available folders/templates via dynamic dropdowns

## Features
- API Key authentication
- File upload via `/upload_file/`
- Dynamic loading of folders & templates via `/fetch_all_folders/`

## Example
Upload a file from a trigger directly to a chosen Koncile folder/template.

## Notes
Tested against live Koncile API with successful responses. Video demo & screenshots attached.


This is useful for automating document processing directly from n8n.
Describe what the PR does and how to test.
Photos and videos are recommended.

https://github.com/user-attachments/assets/4852ced7-c467-46ec-a29e-7a1bf40f4e90

-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
