### PR TITLE
fix(editor): Reset `lastAddedExecutingNode` on execution finished event (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/executionFinished.test.ts
+++ b/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/executionFinished.test.ts
@@ -5,7 +5,7 @@ import {
 	executionFinished,
 	type SimplifiedExecution,
 } from './executionFinished';
-import type { ExecutionStatus, ITaskData } from 'n8n-workflow';
+import type { ITaskData } from 'n8n-workflow';
 import { EVALUATION_TRIGGER_NODE_TYPE } from 'n8n-workflow';
 import type { INodeUi } from '@/Interface';
 import type { Router } from 'vue-router';

--- a/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/executionFinished.test.ts
+++ b/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/executionFinished.test.ts
@@ -185,12 +185,12 @@ describe('executionFinished', () => {
 		setActivePinia(pinia);
 	});
 
-	it('should clear lastAddedExecutingNode when execution is finished', () => {
+	it('should clear lastAddedExecutingNode when execution is finished', async () => {
 		const workflowsStore = mockedStore(useWorkflowsStore);
 
 		workflowsStore.lastAddedExecutingNode = 'test-node';
 
-		executionFinished(
+		await executionFinished(
 			{
 				type: 'executionFinished',
 				data: {

--- a/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/executionFinished.test.ts
+++ b/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/executionFinished.test.ts
@@ -1,10 +1,18 @@
 import { describe, it, expect, vi } from 'vitest';
 import { mock } from 'vitest-mock-extended';
-import { continueEvaluationLoop, type SimplifiedExecution } from './executionFinished';
-import type { ITaskData } from 'n8n-workflow';
+import {
+	continueEvaluationLoop,
+	executionFinished,
+	type SimplifiedExecution,
+} from './executionFinished';
+import type { ExecutionStatus, ITaskData } from 'n8n-workflow';
 import { EVALUATION_TRIGGER_NODE_TYPE } from 'n8n-workflow';
 import type { INodeUi } from '@/Interface';
 import type { Router } from 'vue-router';
+import { mockedStore } from '@/__tests__/utils';
+import { useWorkflowsStore } from '@/stores/workflows.store';
+import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
 
 const runWorkflow = vi.fn();
 
@@ -168,5 +176,31 @@ describe('continueEvaluationLoop()', () => {
 		continueEvaluationLoop(execution, mock<Router>());
 
 		expect(runWorkflow).not.toHaveBeenCalled();
+	});
+});
+
+describe('executionFinished', () => {
+	beforeEach(() => {
+		const pinia = createTestingPinia();
+		setActivePinia(pinia);
+	});
+
+	it('should clear lastAddedExecutingNode when execution is finished', () => {
+		const workflowsStore = mockedStore(useWorkflowsStore);
+
+		workflowsStore.lastAddedExecutingNode = 'test-node';
+
+		executionFinished(
+			{
+				executionId: '1',
+				workflowId: '1',
+				status: 'success',
+			},
+			{
+				router: mock<Router>(),
+			},
+		);
+
+		expect(workflowsStore.lastAddedExecutingNode).toBeNull();
 	});
 });

--- a/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/executionFinished.test.ts
+++ b/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/executionFinished.test.ts
@@ -192,9 +192,12 @@ describe('executionFinished', () => {
 
 		executionFinished(
 			{
-				executionId: '1',
-				workflowId: '1',
-				status: 'success',
+				type: 'executionFinished',
+				data: {
+					executionId: '1',
+					workflowId: '1',
+					status: 'success',
+				},
 			},
 			{
 				router: mock<Router>(),

--- a/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/executionFinished.ts
+++ b/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/executionFinished.ts
@@ -43,6 +43,8 @@ export async function executionFinished(
 	const workflowsStore = useWorkflowsStore();
 	const uiStore = useUIStore();
 
+	workflowsStore.lastAddedExecutingNode = null;
+
 	// No workflow is actively running, therefore we ignore this event
 	if (typeof workflowsStore.activeExecutionId === 'undefined') {
 		return;


### PR DESCRIPTION
## Summary

Reset `lastAddedExecutingNode` on execution finished event to prevent pending spinner from showing when re-executing.

https://github.com/user-attachments/assets/1deeb1d3-7345-4dc6-a9b9-9fdac7678a43

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-971/bug-partial-execs-cause-a-spinner-to-be-shown-on-that-node-at-the

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
