### PR TITLE
fix(editor): Allow executing none single webhook triggers in active workflows with multiple triggers

### DIFF
--- a/packages/frontend/editor-ui/src/composables/useRunWorkflow.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useRunWorkflow.test.ts
@@ -259,7 +259,7 @@ describe('useRunWorkflow({ router })', () => {
 			});
 		});
 
-		it('should execute workflow has pin data and is active with single webhook trigger', async () => {
+		it('should execute the workflow if the single webhook trigger has pin data', async () => {
 			const pinia = createTestingPinia({ stubActions: false });
 			setActivePinia(pinia);
 			const toast = useToast();

--- a/packages/frontend/editor-ui/src/composables/useRunWorkflow.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useRunWorkflow.test.ts
@@ -27,6 +27,7 @@ import { usePushConnectionStore } from '@/stores/pushConnection.store';
 import { createTestNode, createTestWorkflow } from '@/__tests__/mocks';
 import { waitFor } from '@testing-library/vue';
 import { useAgentRequestStore } from '@n8n/stores/useAgentRequestStore';
+import { SLACK_TRIGGER_NODE_TYPE } from '@/constants';
 
 vi.mock('@/stores/workflows.store', () => {
 	const storeState: Partial<ReturnType<typeof useWorkflowsStore>> & {
@@ -241,7 +242,7 @@ describe('useRunWorkflow({ router })', () => {
 				nodes: [
 					{
 						name: 'Slack',
-						type: 'n8n-nodes-base.slackTrigger',
+						type: SLACK_TRIGGER_NODE_TYPE,
 						disabled: false,
 					},
 				],
@@ -272,7 +273,7 @@ describe('useRunWorkflow({ router })', () => {
 				nodes: [
 					{
 						name: 'Slack',
-						type: 'n8n-nodes-base.slackTrigger',
+						type: SLACK_TRIGGER_NODE_TYPE,
 						disabled: false,
 					},
 				],

--- a/packages/frontend/editor-ui/src/composables/useRunWorkflow.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useRunWorkflow.test.ts
@@ -289,10 +289,6 @@ describe('useRunWorkflow({ router })', () => {
 			} as unknown as Workflow);
 			vi.mocked(workflowsStore).runWorkflow.mockResolvedValue(mockExecutionResponse);
 			vi.mocked(workflowsStore).nodesIssuesExist = true;
-			vi.mocked(workflowHelpers).getWorkflowDataToSave.mockResolvedValue({
-				id: 'workflowId',
-				nodes: [],
-			} as unknown as WorkflowData);
 			vi.mocked(workflowsStore).getWorkflowRunData = {
 				NodeName: [],
 			};

--- a/packages/frontend/editor-ui/src/composables/useRunWorkflow.ts
+++ b/packages/frontend/editor-ui/src/composables/useRunWorkflow.ts
@@ -276,9 +276,15 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 					return true;
 				});
 
-			const singleWebhookTrigger = triggers.find((node) =>
-				SINGLE_WEBHOOK_TRIGGERS.includes(node.type),
-			);
+			const singleWebhookTrigger =
+				options.triggerNode === undefined
+					? // if there is no chosen trigger we check all triggers
+						triggers.find((node) => SINGLE_WEBHOOK_TRIGGERS.includes(node.type))
+					: // if there is a chosen trigger we check this one only
+						workflowData.nodes.find(
+							(node) =>
+								node.name === options.triggerNode && SINGLE_WEBHOOK_TRIGGERS.includes(node.type),
+						);
 
 			if (
 				singleWebhookTrigger &&


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

It's not possible to execute another trigger in a workflow that has a single webhook trigger, neither with the trigger picker nor with the floating button.

This PR fixes the full manual execution by checking specifically for the chosen trigger, if one has been chosen.

Disclaimer: This does not fix this issue for executions that only have a destination node, since check for the single webhook triggers happens on the FE, but when there is only a destination node the BE choses the trigger. Fixing this is a bit more involved and includes moving the whole check to the BE. I created a [ticket](https://linear.app/n8n/issue/CAT-985/cant-execute-workflow-using-a-destination-node-if-the-workflow) for this.

*Before:*

https://github.com/user-attachments/assets/1e48c3d5-0027-4eba-86fd-21fa77981184



*After (fixed)::*

https://github.com/user-attachments/assets/a73cf009-80ba-4926-901c-6b6f1d953a1d



*After (still broken)::*

https://github.com/user-attachments/assets/9fe6f1bc-4e09-4716-8e01-73b8d1bc0595


Smaller changes:
- **improve test name**
- **fix test not testing anything because the trigger is removed from the workflowData**
- **use constants instead of hard coded strings**

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
https://linear.app/n8n/issue/CAT-977/can-not-execute-workflow-manually-if-theres-a-telegram-trigger#comment-c17e1fa9

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
