### PR TITLE
fix: update attachments typo across the repo

### DIFF
--- a/cypress/fixtures/Test_Template_2.json
+++ b/cypress/fixtures/Test_Template_2.json
@@ -6,7 +6,7 @@
 			"recentViews": 9887,
 			"totalViews": 650,
 			"createdAt": "2021-11-29T13:59:16.771Z",
-			"description": "This workflow will take all emails you put into a certain folder, upload any attachements to Nextcloud, and mark the emails as read (configurable).\n\nAttachements will be saved with automatically generated filenames:\n`2021-01-01_From-Sender-Name_Filename-of-attachement.pdf`\n\nInstructions:\n1. **Allow lodash to be used in n8n** (or rewrite the code...)\n  `NODE_FUNCTION_ALLOW_EXTERNAL=lodash` (environment variable)\n2. Import workflow\n3. Set credentials for Email & Nextcloud nodes\n4. Configure to use correct folder / custom filters\n5. Activate\n\nCustom filter examples:\n- Only unread emails:\n  `Custom Email Config` = `[\"UNSEEN\"]`\n- Filter emails by 'to' address:\n  `Custom Email Config` = `[[\"TO\", \"example+invoices@posteo.de\"]]`",
+			"description": "This workflow will take all emails you put into a certain folder, upload any attachments to Nextcloud, and mark the emails as read (configurable).\n\nAttachements will be saved with automatically generated filenames:\n`2021-01-01_From-Sender-Name_Filename-of-attachement.pdf`\n\nInstructions:\n1. **Allow lodash to be used in n8n** (or rewrite the code...)\n  `NODE_FUNCTION_ALLOW_EXTERNAL=lodash` (environment variable)\n2. Import workflow\n3. Set credentials for Email & Nextcloud nodes\n4. Configure to use correct folder / custom filters\n5. Activate\n\nCustom filter examples:\n- Only unread emails:\n  `Custom Email Config` = `[\"UNSEEN\"]`\n- Filter emails by 'to' address:\n  `Custom Email Config` = `[[\"TO\", \"example+invoices@posteo.de\"]]`",
 			"workflow": {
 					"nodes": [
 							{

--- a/packages/nodes-base/nodes/Twitter/V2/TweetDescription.ts
+++ b/packages/nodes-base/nodes/Twitter/V2/TweetDescription.ts
@@ -163,7 +163,7 @@ export const tweetFields: INodeProperties[] = [
 		default: '',
 	},
 	{
-		displayName: 'Attachements are not supported due to Twitter V2 API limitations',
+		displayName: 'Attachments are not supported due to Twitter V2 API limitations',
 		name: 'noticeAttachments',
 		type: 'notice',
 		displayOptions: {


### PR DESCRIPTION
## Summary

I'm fixing the `attachements` -> `attachments` typo across the repo

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
