### PR TITLE
fix(core): Prevent accidentally moving folders to their sub folders

### DIFF
--- a/packages/cli/test/integration/folder/folder.controller.test.ts
+++ b/packages/cli/test/integration/folder/folder.controller.test.ts
@@ -765,10 +765,12 @@ describe('PATCH /projects/:projectId/folders/:folderId', () => {
 			parentFolderId: folder.id,
 		};
 
-		await authOwnerAgent
+		const response = await authOwnerAgent
 			.patch(`/projects/${project.id}/folders/${folder.id}`)
 			.send(payload)
 			.expect(400);
+
+		expect(response.body.message).toBe('Cannot set a folder as its own parent');
 
 		const folderInDb = await folderRepository.findOne({
 			where: { id: folder.id },
@@ -777,6 +779,89 @@ describe('PATCH /projects/:projectId/folders/:folderId', () => {
 
 		expect(folderInDb).toBeDefined();
 		expect(folderInDb?.parentFolder).toBeNull();
+	});
+
+	test("should not allow setting folder's parent to a folder that is a direct child", async () => {
+		const project = await createTeamProject(undefined, owner);
+
+		// A
+		// └── B
+		//     └── C
+		const folderA = await createFolder(project, { name: 'A' });
+		const folderB = await createFolder(project, {
+			name: 'B',
+			parentFolder: folderA,
+		});
+		const folderC = await createFolder(project, {
+			name: 'C',
+			parentFolder: folderB,
+		});
+
+		// Attempt to make the parent of B its child C
+		const payload = {
+			parentFolderId: folderC.id,
+		};
+
+		const response = await authOwnerAgent
+			.patch(`/projects/${project.id}/folders/${folderB.id}`)
+			.send(payload)
+			.expect(400);
+
+		expect(response.body.message).toBe(
+			"Cannot set a folder's parent to a folder that is a descendant of the current folder",
+		);
+
+		const folderBInDb = await folderRepository.findOne({
+			where: { id: folderB.id },
+			relations: ['parentFolder'],
+		});
+
+		expect(folderBInDb).toBeDefined();
+		expect(folderBInDb?.parentFolder?.id).toBe(folderA.id);
+	});
+
+	test("should not allow setting folder's parent to a folder that is a descendant", async () => {
+		const project = await createTeamProject(undefined, owner);
+
+		// A
+		// └── B
+		//     └── C
+		//         └── D
+		const folderA = await createFolder(project, { name: 'A' });
+		const folderB = await createFolder(project, {
+			name: 'B',
+			parentFolder: folderA,
+		});
+		const folderC = await createFolder(project, {
+			name: 'C',
+			parentFolder: folderB,
+		});
+		const folderD = await createFolder(project, {
+			name: 'D',
+			parentFolder: folderC,
+		});
+
+		// Attempt to make the parent of A the descendant D
+		const payload = {
+			parentFolderId: folderD.id,
+		};
+
+		const response = await authOwnerAgent
+			.patch(`/projects/${project.id}/folders/${folderA.id}`)
+			.send(payload)
+			.expect(400);
+
+		expect(response.body.message).toBe(
+			"Cannot set a folder's parent to a folder that is a descendant of the current folder",
+		);
+
+		const folderAInDb = await folderRepository.findOne({
+			where: { id: folderA.id },
+			relations: ['parentFolder'],
+		});
+
+		expect(folderAInDb).toBeDefined();
+		expect(folderAInDb?.parentFolder?.id).not.toBeDefined();
 	});
 });
 


### PR DESCRIPTION
## Summary

Under certain circumstances, like when using M4 / M5 buttons it was possible to drag a folder so that it got moved into its sub folder. Backend allowed this, which created a looped file structure, and accessing such structure would OOM and crash the instance.

Prevent creation of such folder structures on the backend.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3678/bug-customer-had-created-a-nested-folder-loop
https://linear.app/n8n/issue/GHC-2800/community-issue-folder-inside-folder-crashing-n8n
https://github.com/n8n-io/n8n/issues/16785

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
