### PR TITLE
fix(editor): Only drag folders when holding mouse 1 button

### DIFF
--- a/cypress/e2e/14-mapping.cy.ts
+++ b/cypress/e2e/14-mapping.cy.ts
@@ -76,7 +76,7 @@ describe('Data mapping', () => {
 			.inputTbodyCell(1, 0)
 			.find('span')
 			.contains('count')
-			.trigger('mousedown', { force: true });
+			.trigger('mousedown', { force: true, button: 0, buttons: 1 });
 		ndv.actions.mapToParameter('value');
 
 		ndv.getters.inlineExpressionEditorInput().should('have.text', '{{ $json.input[0].count }}');

--- a/packages/frontend/editor-ui/src/components/Draggable.vue
+++ b/packages/frontend/editor-ui/src/components/Draggable.vue
@@ -38,7 +38,7 @@ const draggableStyle = computed<StyleValue>(() => ({
 }));
 
 const onDragStart = (event: MouseEvent) => {
-	if (props.disabled) {
+	if (props.disabled || event.buttons !== 1) {
 		return;
 	}
 

--- a/packages/frontend/editor-ui/src/components/VirtualSchema.test.ts
+++ b/packages/frontend/editor-ui/src/components/VirtualSchema.test.ts
@@ -526,8 +526,8 @@ describe('VirtualSchema.vue', () => {
 		function dragDropPill(pill: HTMLElement) {
 			const ndvStore = useNDVStore();
 			const reset = vi.spyOn(ndvStore, 'resetMappingTelemetry');
-			fireEvent(pill, new MouseEvent('mousedown', { bubbles: true }));
-			fireEvent(window, new MouseEvent('mousemove', { bubbles: true }));
+			fireEvent(pill, new MouseEvent('mousedown', { bubbles: true, button: 0, buttons: 1 }));
+			fireEvent(window, new MouseEvent('mousemove', { bubbles: true, button: 0, buttons: 1 }));
 			expect(reset).toHaveBeenCalled();
 
 			vi.useRealTimers();


### PR DESCRIPTION
## Summary

Using `<Draggable>` dragging happens when holding any mouse buttons (including buttons like M3, M4, M5). This feels unexpected, and leads to odd interactions especially with M4/M5 which are normally bound to browser back/forward. Also on some views M2 opens the context menu, but drag still starts and after the context menu gets closed they're still dragging despite not holding M2.

Do we have any valid uses for dragging with other buttons than M1?

Dragging folders with M4/M5 makes ADO-3678 happen, but that's going to be prevented in https://github.com/n8n-io/n8n/pull/16808 - way to make that bad request happen on the UI isnt' getting fixed by that though.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
