### PR TITLE
fix(editor): Disable vue eslint rules that were conflicting with our formatting (no-changelog)

### DIFF
--- a/packages/@n8n/eslint-config/src/configs/frontend.ts
+++ b/packages/@n8n/eslint-config/src/configs/frontend.ts
@@ -90,6 +90,10 @@ export const frontendConfig = tseslint.config(
 				},
 			],
 			'vue/no-v-html': 'error',
+			'vue/html-indent': ['warn', 'tab'],
+
+			// Disabled as it conflicts with our current formatting style
+			'vue/max-attributes-per-line': 'off',
 
 			// TODO: remove these
 			'vue/no-mutating-props': 'warn',

--- a/packages/@n8n/eslint-config/src/configs/frontend.ts
+++ b/packages/@n8n/eslint-config/src/configs/frontend.ts
@@ -90,9 +90,9 @@ export const frontendConfig = tseslint.config(
 				},
 			],
 			'vue/no-v-html': 'error',
-			'vue/html-indent': ['warn', 'tab'],
 
-			// Disabled as it conflicts with our current formatting style
+			// Disabled as these conflict with our current formatting style, and we trust on prettier here.
+			'vue/html-indent': 'off',
 			'vue/max-attributes-per-line': 'off',
 
 			// TODO: remove these


### PR DESCRIPTION
## Summary

Change `vue/html-indent` to expect tabs and disable `vue/max-attributes-per-line` as it was conflicting with the way our code is currently formatted, leading to warnings on basically every `.vue` file.

Following the [ESLint 9 upgrade ](https://github.com/n8n-io/n8n/pull/16639) developers with ESLint warnings visible on their editor were seeing a lot of yellow this morning 🙈 

![image](https://github.com/user-attachments/assets/8db2fd93-68da-4476-a82a-c440ea2df808)

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
