### PR TITLE
chore: Silence warnings for `@n8n/nodes-langchain`

### DIFF
--- a/packages/@n8n/nodes-langchain/package.json
+++ b/packages/@n8n/nodes-langchain/package.json
@@ -12,7 +12,7 @@
     "build": "tsup --tsconfig tsconfig.build.json && pnpm copy-nodes-json && tsc-alias -p tsconfig.build.json && pnpm copy-tokenizer-json && pnpm n8n-copy-static-files && pnpm n8n-generate-metadata",
     "format": "biome format --write .",
     "format:check": "biome ci .",
-    "lint": "eslint nodes credentials utils",
+    "lint": "eslint nodes credentials utils --quiet",
     "lintfix": "eslint nodes credentials utils --fix",
     "watch": "tsup --watch --tsconfig tsconfig.build.json --onSuccess \"pnpm copy-nodes-json && tsc-alias -p tsconfig.build.json && pnpm n8n-generate-metadata\"",
     "test": "jest",


### PR DESCRIPTION
## Summary

All packages except `@n8n/nodes-langchain` are silencing warnings to prevent unrelated lints from showing in all PRs:

![Capture 2025-06-30 at 09 28 53@2x](https://github.com/user-attachments/assets/29b69d3a-a8b8-4ab4-b099-4f6c01567758)

Follow-up to #16639

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
