### PR TITLE
fix(editor): AI Agent shows logs from multiple runs in same view

### DIFF
--- a/packages/frontend/editor-ui/src/components/RunDataAi/RunDataAi.vue
+++ b/packages/frontend/editor-ui/src/components/RunDataAi/RunDataAi.vue
@@ -30,6 +30,14 @@ const selectedRun: Ref<IAiData[]> = ref([]);
 
 const i18n = useI18n();
 
+const aiData = computed<AIResult[]>(() =>
+	createAiData(props.node.name, props.workflow, workflowsStore.getWorkflowResultDataByNodeName),
+);
+
+const executionTree = computed<TreeNode[]>(() =>
+	getTreeNodeData(props.node.name, props.workflow, aiData.value, props.runIndex),
+);
+
 function isTreeNodeSelected(node: TreeNode) {
 	return selectedRun.value.some((run) => run.node === node.node && run.runIndex === node.runIndex);
 }
@@ -79,14 +87,6 @@ function selectFirst() {
 	}
 }
 
-const aiData = computed<AIResult[]>(() =>
-	createAiData(props.node.name, props.workflow, workflowsStore.getWorkflowResultDataByNodeName),
-);
-
-const executionTree = computed<TreeNode[]>(() =>
-	getTreeNodeData(props.node.name, props.workflow, aiData.value, props.runIndex),
-);
-
 watch(() => props.runIndex, selectFirst, { immediate: true });
 </script>
 
@@ -103,7 +103,7 @@ watch(() => props.runIndex, selectFirst, { immediate: true });
 					data-test-id="lm-chat-logs-tree"
 					@node-click="onItemClick"
 				>
-					<template #default="{ node, data }">
+					<template #default="{ node: currentNode, data }">
 						<div
 							:class="{
 								[$style.treeNode]: true,
@@ -115,13 +115,13 @@ watch(() => props.runIndex, selectFirst, { immediate: true });
 							<button
 								v-if="data.children.length"
 								:class="$style.treeToggle"
-								@click="toggleTreeItem(node)"
+								@click="toggleTreeItem(currentNode.node)"
 							>
-								<font-awesome-icon :icon="node.expanded ? 'angle-down' : 'angle-right'" />
+								<font-awesome-icon :icon="currentNode.expanded ? 'angle-down' : 'angle-right'" />
 							</button>
 							<n8n-tooltip :disabled="!slim" placement="right">
 								<template #content>
-									{{ node.label }}
+									{{ currentNode.label }}
 								</template>
 								<span :class="$style.leafLabel">
 									<NodeIcon
@@ -129,7 +129,7 @@ watch(() => props.runIndex, selectFirst, { immediate: true });
 										:size="17"
 										:class="$style.nodeIcon"
 									/>
-									<span v-if="!slim" v-text="node.label" />
+									<span v-if="!slim" v-text="currentNode.label" />
 								</span>
 							</n8n-tooltip>
 						</div>
@@ -157,7 +157,9 @@ watch(() => props.runIndex, selectFirst, { immediate: true });
 				</div>
 			</div>
 		</template>
-		<div v-else :class="$style.noData">{{ i18n.baseText('ndv.output.ai.waiting') }}</div>
+		<div v-else :class="$style.noData">
+			{{ i18n.baseText('ndv.output.ai.waiting') }}
+		</div>
 	</div>
 </template>
 

--- a/packages/frontend/editor-ui/src/components/RunDataAi/RunDataAi.vue
+++ b/packages/frontend/editor-ui/src/components/RunDataAi/RunDataAi.vue
@@ -84,7 +84,7 @@ const aiData = computed<AIResult[]>(() =>
 );
 
 const executionTree = computed<TreeNode[]>(() =>
-	getTreeNodeData(props.node.name, props.workflow, aiData.value),
+	getTreeNodeData(props.node.name, props.workflow, aiData.value, props.runIndex),
 );
 
 watch(() => props.runIndex, selectFirst, { immediate: true });

--- a/packages/frontend/editor-ui/src/components/RunDataAi/RunDataAi.vue
+++ b/packages/frontend/editor-ui/src/components/RunDataAi/RunDataAi.vue
@@ -115,7 +115,7 @@ watch(() => props.runIndex, selectFirst, { immediate: true });
 							<button
 								v-if="data.children.length"
 								:class="$style.treeToggle"
-								@click="toggleTreeItem(currentNode.node)"
+								@click="toggleTreeItem(currentNode)"
 							>
 								<font-awesome-icon :icon="currentNode.expanded ? 'angle-down' : 'angle-right'" />
 							</button>


### PR DESCRIPTION
## Summary

This PR fixes duplicate logs in the AI log view in NDV by utilizing `source` field in task data.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/SUG-89/ai-agent-shows-logs-from-multiple-runs-in-same-view-very-confusing

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
