### PR TITLE
test(editor): Mock /api/whats-new request during E2E tests (no-changelog)

### DIFF
--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -94,4 +94,16 @@ beforeEach(() => {
 			description: 'Includes <strong>core functionality</strong> and <strong>bug fixes</strong>',
 		},
 	]).as('getVersions');
+	cy.intercept(
+		{ pathname: '/api/whats-new' },
+		{
+			id: 1,
+			title: "What's new",
+			calloutText: '',
+			footer: '',
+			createdAt: '2025-06-27T14:55:58.717Z',
+			updatedAt: '2025-06-27T15:06:44.092Z',
+			items: [],
+		},
+	).as('getWhatsNew');
 });


### PR DESCRIPTION
## Summary

Mock the request to fetch What's new articles during cypress E2E tests to not have the callout notification change & show up, covering other UI elements unexpectedly depending on the returned data. Always returns empty list of what's new items.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
