### PR TITLE
fix(core): Remove default for manual trigger in manual executions

### DIFF
--- a/packages/cli/src/__tests__/manual-execution.service.test.ts
+++ b/packages/cli/src/__tests__/manual-execution.service.test.ts
@@ -94,7 +94,7 @@ describe('ManualExecutionService', () => {
 				},
 			});
 			const executionStartNode = manualExecutionService.getExecutionStartNode(data, workflow);
-			expect(executionStartNode?.name).toBe(undefined);
+			expect(executionStartNode?.name).toBeUndefined();
 		});
 	});
 

--- a/packages/cli/src/__tests__/manual-execution.service.test.ts
+++ b/packages/cli/src/__tests__/manual-execution.service.test.ts
@@ -71,28 +71,6 @@ describe('ManualExecutionService', () => {
 			const executionStartNode = manualExecutionService.getExecutionStartNode(data, workflow);
 			expect(executionStartNode?.name).toEqual('node3');
 		});
-
-		it('should default to The manual trigger', () => {
-			const data = mock<IWorkflowExecutionDataProcess>();
-			const manualTrigger = mock<INode>({
-				type: 'n8n-nodes-base.manualTrigger',
-				name: 'When clicking ‘Execute workflow’',
-			});
-
-			const workflow = mock<Workflow>({
-				getTriggerNodes() {
-					return [
-						mock<INode>({
-							type: 'n8n-nodes-base.scheduleTrigger',
-							name: 'Wed 12:00',
-						}),
-						manualTrigger,
-					];
-				},
-			});
-			const executionStartNode = manualExecutionService.getExecutionStartNode(data, workflow);
-			expect(executionStartNode?.name).toBe(manualTrigger.name);
-		});
 	});
 
 	describe('runManually', () => {

--- a/packages/cli/src/__tests__/manual-execution.service.test.ts
+++ b/packages/cli/src/__tests__/manual-execution.service.test.ts
@@ -71,6 +71,31 @@ describe('ManualExecutionService', () => {
 			const executionStartNode = manualExecutionService.getExecutionStartNode(data, workflow);
 			expect(executionStartNode?.name).toEqual('node3');
 		});
+
+		it('should return undefined, even if manual trigger node is available', () => {
+			const scheduleTrigger = mock<INode>({
+				type: 'n8n-nodes-base.scheduleTrigger',
+				name: 'Wed 12:00',
+			});
+
+			const manualTrigger = mock<INode>({
+				type: 'n8n-nodes-base.manualTrigger',
+				name: 'When clicking ‘Execute workflow’',
+			});
+
+			const data = mock<IWorkflowExecutionDataProcess>({
+				startNodes: [scheduleTrigger],
+				triggerToStartFrom: undefined,
+			});
+
+			const workflow = mock<Workflow>({
+				getTriggerNodes() {
+					return [scheduleTrigger, manualTrigger];
+				},
+			});
+			const executionStartNode = manualExecutionService.getExecutionStartNode(data, workflow);
+			expect(executionStartNode?.name).toBe(undefined);
+		});
 	});
 
 	describe('runManually', () => {

--- a/packages/cli/src/manual-execution.service.ts
+++ b/packages/cli/src/manual-execution.service.ts
@@ -9,7 +9,7 @@ import {
 	WorkflowExecute,
 	rewireGraph,
 } from 'n8n-core';
-import { MANUAL_TRIGGER_NODE_TYPE, NodeHelpers } from 'n8n-workflow';
+import { NodeHelpers } from 'n8n-workflow';
 import type {
 	IExecuteData,
 	IPinData,
@@ -43,15 +43,7 @@ export class ManualExecutionService {
 			startNode = workflow.getNode(data.startNodes[0].name) ?? undefined;
 		}
 
-		if (startNode) {
-			return startNode;
-		}
-
-		const manualTrigger = workflow
-			.getTriggerNodes()
-			.find((node) => node.type === MANUAL_TRIGGER_NODE_TYPE);
-
-		return manualTrigger;
+		return startNode;
 	}
 
 	// eslint-disable-next-line @typescript-eslint/promise-function-async


### PR DESCRIPTION
## Summary

If Manual Trigger node in workflow, does not allow for partial executions of other trigger nodes. 

Root cause commit is [here](https://github.com/n8n-io/n8n/commit/c1760631cf86942a8da19d0bf647d2eb70fc0477) as fix for [PAY-2800](https://linear.app/n8n/issue/PAY-2800/bug-test-workflow-button-triggers-wrong-node)
Reverting this fix because it's now unnecessary now that we have the split button.

before

https://github.com/user-attachments/assets/f078847f-9aae-4b0d-9892-c28a1dcb6e35

after

https://github.com/user-attachments/assets/a411d19a-71c8-46e9-9b2f-45ba2680e587


<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
