### PR TITLE
fix(editor): Disable all potential eslint rule conflicts with prettier

### DIFF
--- a/packages/@n8n/eslint-config/src/configs/frontend.ts
+++ b/packages/@n8n/eslint-config/src/configs/frontend.ts
@@ -1,6 +1,7 @@
 import { globalIgnores } from 'eslint/config';
 import tseslint from 'typescript-eslint';
 import VuePlugin from 'eslint-plugin-vue';
+import eslintConfigPrettier from 'eslint-config-prettier/flat';
 import globals from 'globals';
 import { baseConfig } from './base.js';
 
@@ -91,10 +92,6 @@ export const frontendConfig = tseslint.config(
 			],
 			'vue/no-v-html': 'error',
 
-			// Disabled as these conflict with our current formatting style, and we trust on prettier here.
-			'vue/html-indent': 'off',
-			'vue/max-attributes-per-line': 'off',
-
 			// TODO: remove these
 			'vue/no-mutating-props': 'warn',
 			'vue/no-side-effects-in-computed-properties': 'warn',
@@ -102,4 +99,5 @@ export const frontendConfig = tseslint.config(
 			'vue/return-in-computed-property': 'warn',
 		},
 	},
+	eslintConfigPrettier,
 );


### PR DESCRIPTION
## Summary

Refactor ESLint config to delegate formatting rules to Prettier

- Removed custom Vue formatting rule overrides (vue/html-indent, vue/max-attributes-per-line) that conflicted with Prettier.
- Appended`eslint-config-prettier` to the exported config.

This change ensures consistent formatting by deferring to Prettier and reduces rule conflicts in Vue files (as seen on the screenshot below)

![CleanShot 2025-06-30 at 12 46 20](https://github.com/user-attachments/assets/e05fcd41-a1a5-4848-84a7-31fc221c7d09)
