### PR TITLE
fix(core): Fix partial execution in triggerless parent case

### DIFF
--- a/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
@@ -970,6 +970,47 @@ describe('WorkflowExecute', () => {
 				expect.objectContaining({ executionIndex: 1 }),
 			]);
 		});
+
+		//                    ►►
+		// ┌─────┐1     ┌─────┐
+		// │node1├──────►node2│
+		// └─────┘      └─────┘
+		test('should find closest parent with run data when no trigger exists', async () => {
+			// ARRANGE
+			const waitPromise = createDeferredPromise<IRun>();
+			const additionalData = Helpers.WorkflowExecuteAdditionalData(waitPromise);
+			const workflowExecute = new WorkflowExecute(additionalData, 'manual');
+
+			const node1 = createNodeData({ name: 'node1' });
+			const node2 = createNodeData({ name: 'node2' });
+			const workflow = new DirectedGraph()
+				.addNodes(node1, node2)
+				.addConnections({ from: node1, to: node2 })
+				.toWorkflow({ name: '', active: false, nodeTypes });
+
+			const pinData: IPinData = {};
+			const runData: IRunData = {
+				[node1.name]: [toITaskData([{ data: { name: node1.name } }])],
+			};
+			const dirtyNodeNames: string[] = [];
+			const destinationNode = node2.name;
+
+			const processRunExecutionDataSpy = jest
+				.spyOn(workflowExecute, 'processRunExecutionData')
+				.mockImplementationOnce(jest.fn());
+
+			// ACT
+			await workflowExecute.runPartialWorkflow2(
+				workflow,
+				runData,
+				pinData,
+				dirtyNodeNames,
+				destinationNode,
+			);
+
+			// ASSERT
+			expect(processRunExecutionDataSpy).toHaveBeenCalledTimes(1);
+		});
 	});
 
 	describe('checkReadyForExecution', () => {


### PR DESCRIPTION
## Summary

In the case of partial manual execution where the destination node has ancestors but none of them are triggers but at least one of them has run data, use that one as a starting point.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-986/execution-events-not-coming-in-when-running-node-a-second-time

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
