### PR TITLE
fix(core): Deduplicate credential types when lazyloading

### DIFF
--- a/packages/core/src/nodes-loader/__tests__/directory-loader.test.ts
+++ b/packages/core/src/nodes-loader/__tests__/directory-loader.test.ts
@@ -568,6 +568,18 @@ describe('DirectoryLoader', () => {
 
 			expect(() => loader.loadCredentialFromFile(filePath)).toThrow('Class could not be found');
 		});
+
+		it('should not push credential to types array when lazy loaded', () => {
+			const loader = new CustomDirectoryLoader(directory);
+			loader.isLazyLoaded = true;
+
+			loader.loadCredentialFromFile('dist/Credential1.js');
+
+			expect(loader.credentialTypes).toEqual({
+				credential1: { sourcePath: 'dist/Credential1.js', type: mockCredential1 },
+			});
+			expect(loader.types.credentials).toEqual([]);
+		});
 	});
 
 	describe('getCredential', () => {

--- a/packages/core/src/nodes-loader/directory-loader.ts
+++ b/packages/core/src/nodes-loader/directory-loader.ts
@@ -242,6 +242,7 @@ export abstract class DirectoryLoader {
 			sourcePath: filePath,
 		};
 
+		if (this.isLazyLoaded) return;
 		this.types.credentials.push(tempCredential);
 	}
 


### PR DESCRIPTION
## Summary

For lazyloaded packages, we [load](https://github.com/n8n-io/n8n/blob/0debbc3503246d44741cff846482f5aab5f84dc6/packages/core/src/nodes-loader/lazy-package-directory-loader.ts#L9-L13) all credentials types descriptions and locations from build artifacts - and later when we need a credential type, we [instantiate](https://github.com/n8n-io/n8n/blob/0debbc3503246d44741cff846482f5aab5f84dc6/packages/core/src/nodes-loader/directory-loader.ts#L253-L256) it on demand from its class file location and cache the instance in memory.

But when we instantiate a credential type on demand, we also [push](https://github.com/n8n-io/n8n/blob/0debbc3503246d44741cff846482f5aab5f84dc6/packages/core/src/nodes-loader/directory-loader.ts#L245) it to the collection of loaded credential types, which was already populated with all credentials descriptions. This likely was intended for eagerly loaded credentials types, but not for lazyloaded ones. Therefore, all lazyloaded credential types that are instantiated on demand end up duplicated in memory. Also, these copies are not 100% identical to credentials descriptions - these copies lack the `iconUrl` and `supportedNodes` properties added to credentials types during startup.

When we later happen to trigger credentials types to be [regenerated](https://github.com/n8n-io/n8n/blob/0debbc3503246d44741cff846482f5aab5f84dc6/packages/cli/src/services/frontend.service.ts#L55) (e.g. on community package install), these credential types polluted with duplicates are written to the static cache at `~/.cache/n8n/public/types/credentials.json`. See a sample cache [here](https://gist.github.com/ivov/6e5f57340984c4ec384f6b462bab361c) with ~60 duplicates, e.g.  `salesforceOAuth2Api` and `payPalApi`. 

The FE then fetches this polluted cache and loads it in the Pinia store [by credential type name](https://github.com/n8n-io/n8n/blob/0debbc3503246d44741cff846482f5aab5f84dc6/packages/frontend/editor-ui/src/stores/credentials.store.ts#L218), so the duplicates overwrite the originals on the client side. As a result, the client stops requesting credentials icons because of the missing `iconUrl` and also loses track of some nodes-creds relations because of the missing `supportedNodes`.

Hence this PR stops us from loading lazyloaded credential types twice in memory. Lazyloaded node types are unaffected. In future we might want to enforce uniqueness with a map, and perhaps move away from having a monolithic cache for node and cred types.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-987

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
