### PR TITLE
feat(core): Add workflow name label to workflow metrics

### DIFF
--- a/packages/@n8n/config/src/configs/endpoints.config.ts
+++ b/packages/@n8n/config/src/configs/endpoints.config.ts
@@ -61,6 +61,10 @@ class PrometheusMetricsConfig {
 	/** How often (in seconds) to update active workflow metric */
 	@Env('N8N_METRICS_ACTIVE_WORKFLOW_METRIC_INTERVAL')
 	activeWorkflowCountInterval: number = 60;
+
+	/** Whether to include a label for workflow name on workflow metrics. */
+	@Env('N8N_METRICS_INCLUDE_WORKFLOW_NAME_LABEL')
+	includeWorkflowNameLabel: boolean = false;
 }
 
 @Config

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -176,6 +176,7 @@ describe('GlobalConfig', () => {
 				enable: false,
 				prefix: 'n8n_',
 				includeWorkflowIdLabel: false,
+				includeWorkflowNameLabel: false,
 				includeDefaultMetrics: true,
 				includeMessageEventBusMetrics: false,
 				includeNodeTypeLabel: false,

--- a/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
+++ b/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
@@ -51,11 +51,11 @@ describe('PrometheusMetricsService', () => {
 		},
 	});
 
-	const app = mock<express.Application>();
-	const eventBus = mock<MessageEventBus>();
-	const eventService = mock<EventService>();
-	const instanceSettings = mock<InstanceSettings>({ instanceType: 'main' });
-	const workflowRepository = mock<WorkflowRepository>();
+	// const app = mock<express.Application>();
+	// const eventBus = mock<MessageEventBus>();
+	// const eventService = mock<EventService>();
+	// const instanceSettings = mock<InstanceSettings>({ instanceType: 'main' });
+	// const workflowRepository = mock<WorkflowRepository>();
 	// const prometheusMetricsService = new PrometheusMetricsService(
 	// 	mock(),
 	// 	eventBus,
@@ -64,9 +64,21 @@ describe('PrometheusMetricsService', () => {
 	// 	instanceSettings,
 	// 	workflowRepository,
 	// );
+
+	let app: express.Application;
+	let eventBus: MessageEventBus;
+	let eventService: EventService;
+	let instanceSettings: InstanceSettings;
+	let workflowRepository: WorkflowRepository;
 	let prometheusMetricsService: PrometheusMetricsService;
 
 	beforeEach(() => {
+		app = mock<express.Application>();
+		eventBus = mock<MessageEventBus>();
+		eventService = mock<EventService>();
+		instanceSettings = mock<InstanceSettings>({ instanceType: 'main' });
+		workflowRepository = mock<WorkflowRepository>();
+
 		prometheusMetricsService = new PrometheusMetricsService(
 			mock(),
 			eventBus,
@@ -208,8 +220,6 @@ describe('PrometheusMetricsService', () => {
 
 			await prometheusMetricsService.init(app);
 
-			console.log(promClient.Counter.mock.calls);
-
 			// call 1 is for `n8n_version_info` (always enabled)
 
 			expect(promClient.Gauge).toHaveBeenNthCalledWith(2, {
@@ -221,6 +231,8 @@ describe('PrometheusMetricsService', () => {
 				name: 'n8n_scaling_mode_queue_jobs_active',
 				help: 'Current number of jobs being processed across all workers in scaling mode.',
 			});
+
+			console.log(promClient.Counter.mock.calls);
 
 			expect(promClient.Counter).toHaveBeenNthCalledWith(1, {
 				name: 'n8n_scaling_mode_queue_jobs_completed',
@@ -388,6 +400,8 @@ describe('PrometheusMetricsService', () => {
 				payload: { workflowId: 'wf_789' },
 			};
 			eventHandler(mockEvent);
+
+			console.log(promClient.Counter.mock.calls);
 
 			expect(promClient.Counter).toHaveBeenCalledWith({
 				name: 'n8n_workflow_execution_finished_total',

--- a/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
+++ b/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
@@ -10,6 +10,7 @@ import promClient from 'prom-client';
 import config from '@/config';
 import type { MessageEventBus } from '@/eventbus/message-event-bus/message-event-bus';
 import type { EventService } from '@/events/event.service';
+import { EventMessageTypeNames } from 'n8n-workflow';
 
 import { PrometheusMetricsService } from '../prometheus-metrics.service';
 
@@ -23,8 +24,6 @@ jest.mock('prom-client');
 jest.mock('express-prom-bundle', () => jest.fn(() => mockMiddleware));
 
 describe('PrometheusMetricsService', () => {
-	promClient.Counter.prototype.inc = jest.fn();
-
 	const globalConfig = mockInstance(GlobalConfig, {
 		endpoints: {
 			metrics: {
@@ -40,6 +39,7 @@ describe('PrometheusMetricsService', () => {
 				includeApiMethodLabel: false,
 				includeApiStatusCodeLabel: false,
 				includeQueueMetrics: false,
+				includeWorkflowNameLabel: false,
 			},
 			rest: 'rest',
 			form: 'form',
@@ -56,18 +56,34 @@ describe('PrometheusMetricsService', () => {
 	const eventService = mock<EventService>();
 	const instanceSettings = mock<InstanceSettings>({ instanceType: 'main' });
 	const workflowRepository = mock<WorkflowRepository>();
-	const prometheusMetricsService = new PrometheusMetricsService(
-		mock(),
-		eventBus,
-		globalConfig,
-		eventService,
-		instanceSettings,
-		workflowRepository,
-	);
+	// const prometheusMetricsService = new PrometheusMetricsService(
+	// 	mock(),
+	// 	eventBus,
+	// 	globalConfig,
+	// 	eventService,
+	// 	instanceSettings,
+	// 	workflowRepository,
+	// );
+	let prometheusMetricsService: PrometheusMetricsService;
+
+	beforeEach(() => {
+		prometheusMetricsService = new PrometheusMetricsService(
+			mock(),
+			eventBus,
+			globalConfig,
+			eventService,
+			instanceSettings,
+			workflowRepository,
+		);
+
+		promClient.Counter.prototype.inc = jest.fn();
+		(promClient.validateMetricName as jest.Mock).mockReturnValue(true);
+	});
 
 	afterEach(() => {
 		jest.clearAllMocks();
 		prometheusMetricsService.disableAllMetrics();
+		prometheusMetricsService.disableAllLabels();
 	});
 
 	describe('constructor', () => {
@@ -192,6 +208,8 @@ describe('PrometheusMetricsService', () => {
 
 			await prometheusMetricsService.init(app);
 
+			console.log(promClient.Counter.mock.calls);
+
 			// call 1 is for `n8n_version_info` (always enabled)
 
 			expect(promClient.Gauge).toHaveBeenNthCalledWith(2, {
@@ -252,6 +270,132 @@ describe('PrometheusMetricsService', () => {
 				help: 'Total number of active workflows.',
 				collect: expect.any(Function),
 			});
+		});
+	});
+
+	describe('when event bus events are sent', () => {
+		// Helper to find the event handler function registered by initEventBusMetrics
+		const getEventHandler = () => {
+			const eventBusOnCall = (eventBus.on as jest.Mock).mock.calls.find(
+				(call) => call[0] === 'metrics.eventBus.event',
+			);
+			// The handler is the second argument in the .on(eventName, handler) call
+			return eventBusOnCall ? eventBusOnCall[1] : undefined;
+		};
+
+		it('should create a counter with `credential_type` label for user credentials audit events', async () => {
+			prometheusMetricsService.enableMetric('logs');
+			prometheusMetricsService.enableLabels(['credentialsType']);
+			await prometheusMetricsService.init(app);
+
+			const eventHandler = getEventHandler();
+			const mockEvent = {
+				__type: EventMessageTypeNames.audit,
+				eventName: 'n8n.audit.user.credentials.created',
+				payload: { credentialType: 'n8n-nodes-base.googleApi' },
+			};
+
+			eventHandler(mockEvent);
+
+			expect(promClient.Counter).toHaveBeenCalledWith({
+				name: 'n8n_audit_user_credentials_created_total',
+				help: 'Total number of n8n.audit.user.credentials.created events.',
+				labelNames: ['credential_type'],
+			});
+
+			expect(promClient.Counter.prototype.inc).toHaveBeenCalledWith(
+				{ credential_type: 'n8n-nodes-base_googleApi' },
+				1,
+			);
+		});
+
+		it('should create a counter with `workflow_id` label for workflow audit events', async () => {
+			prometheusMetricsService.enableMetric('logs');
+			prometheusMetricsService.enableLabels(['workflowId']);
+			await prometheusMetricsService.init(app);
+
+			const eventHandler = getEventHandler();
+			const mockEvent = {
+				__type: EventMessageTypeNames.audit,
+				eventName: 'n8n.audit.workflow.created',
+				payload: { workflowId: 'wf_123' },
+			};
+			eventHandler(mockEvent);
+
+			expect(promClient.Counter).toHaveBeenCalledWith({
+				name: 'n8n_audit_workflow_created_total',
+				help: 'Total number of n8n.audit.workflow.created events.',
+				labelNames: ['workflow_id'],
+			});
+
+			expect(promClient.Counter.prototype.inc).toHaveBeenCalledWith({ workflow_id: 'wf_123' }, 1);
+		});
+
+		it('should create a counter with `node_type` label for node events', async () => {
+			prometheusMetricsService.enableMetric('logs');
+			prometheusMetricsService.enableLabels(['nodeType']);
+			await prometheusMetricsService.init(app);
+
+			const eventHandler = getEventHandler();
+			const mockEvent = {
+				__type: EventMessageTypeNames.node,
+				eventName: 'n8n.node.execution.started',
+				payload: { nodeType: 'n8n-nodes-base.if' },
+			};
+
+			eventHandler(mockEvent);
+
+			expect(promClient.Counter).toHaveBeenCalledWith({
+				name: 'n8n_node_execution_started_total',
+				help: 'Total number of n8n.node.execution.started events.',
+				labelNames: ['node_type'],
+			});
+
+			expect(promClient.Counter.prototype.inc).toHaveBeenCalledWith({ node_type: 'base_if' }, 1);
+		});
+
+		it('should create a counter with `workflow_id` label for workflow events', async () => {
+			prometheusMetricsService.enableMetric('logs');
+			prometheusMetricsService.enableLabels(['workflowId']);
+			await prometheusMetricsService.init(app);
+
+			const eventHandler = getEventHandler();
+			const mockEvent = {
+				__type: EventMessageTypeNames.workflow,
+				eventName: 'n8n.workflow.execution.finished',
+				payload: { workflowId: 'wf_456' },
+			};
+			eventHandler(mockEvent);
+
+			expect(promClient.Counter).toHaveBeenCalledWith({
+				name: 'n8n_workflow_execution_finished_total',
+				help: 'Total number of n8n.workflow.execution.finished events.',
+				labelNames: ['workflow_id'],
+			});
+
+			expect(promClient.Counter.prototype.inc).toHaveBeenCalledWith({ workflow_id: 'wf_456' }, 1);
+		});
+
+		it('should create a counter with no labels if the corresponding config is disabled', async () => {
+			prometheusMetricsService.enableMetric('logs');
+			// Note: `includeWorkflowIdLabel` is false by default, so we don't enable it
+			await prometheusMetricsService.init(app);
+
+			const eventHandler = getEventHandler();
+			const mockEvent = {
+				__type: EventMessageTypeNames.workflow,
+				eventName: 'n8n.workflow.execution.finished',
+				payload: { workflowId: 'wf_789' },
+			};
+			eventHandler(mockEvent);
+
+			expect(promClient.Counter).toHaveBeenCalledWith({
+				name: 'n8n_workflow_execution_finished_total',
+				help: 'Total number of n8n.workflow.execution.finished events.',
+				labelNames: [], // Expecting no labels
+			});
+
+			expect(promClient.Counter.prototype.inc).toHaveBeenCalledWith({}, 1); // Expecting empty labels object
 		});
 	});
 });

--- a/packages/cli/src/metrics/prometheus-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus-metrics.service.ts
@@ -327,14 +327,7 @@ export class PrometheusMetricsService {
 				}
 
 				if (eventName.startsWith('n8n.audit.workflow')) {
-					const labels: Record<string, string> = {};
-					if (this.includes.labels.workflowId) {
-						labels.workflow_id = String(payload.workflowId ?? 'unknown');
-					}
-					if (this.includes.labels.workflowName) {
-						labels.workflow_name = String(payload.workflowName ?? 'unknown');
-					}
-					return labels;
+					return this.buildWorkflowLabels(payload);
 				}
 				break;
 
@@ -354,16 +347,20 @@ export class PrometheusMetricsService {
 				return nodeLabels;
 
 			case EventMessageTypeNames.workflow:
-				const workflowLabels: Record<string, string> = {};
-				if (this.includes.labels.workflowId) {
-					workflowLabels.workflow_id = String(payload.workflowId ?? 'unknown');
-				}
-				if (this.includes.labels.workflowName) {
-					workflowLabels.workflow_name = String(payload.workflowName ?? 'unknown');
-				}
-				return workflowLabels;
+				return this.buildWorkflowLabels(payload);
 		}
 
 		return {};
+	}
+
+	private buildWorkflowLabels(payload: any): Record<string, string> {
+		const labels: Record<string, string> = {};
+		if (this.includes.labels.workflowId) {
+			labels.workflow_id = String(payload.workflowId ?? 'unknown');
+		}
+		if (this.includes.labels.workflowName) {
+			labels.workflow_name = String(payload.workflowName ?? 'unknown');
+		}
+		return labels;
 	}
 }

--- a/packages/cli/src/metrics/prometheus-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus-metrics.service.ts
@@ -28,7 +28,7 @@ export class PrometheusMetricsService {
 		private readonly eventService: EventService,
 		private readonly instanceSettings: InstanceSettings,
 		private readonly workflowRepository: WorkflowRepository,
-	) { }
+	) {}
 
 	private readonly counters: { [key: string]: Counter<string> | null } = {};
 
@@ -318,17 +318,21 @@ export class PrometheusMetricsService {
 			case EventMessageTypeNames.audit:
 				if (eventName.startsWith('n8n.audit.user.credentials')) {
 					return this.includes.labels.credentialsType
-						? { credential_type: (event.payload.credentialType ?? 'unknown').replace(/\./g, '_') }
+						? {
+								credential_type: String(
+									(event.payload.credentialType ?? 'unknown').replace(/\./g, '_'),
+								),
+							}
 						: {};
 				}
 
 				if (eventName.startsWith('n8n.audit.workflow')) {
 					const labels: Record<string, string> = {};
 					if (this.includes.labels.workflowId) {
-						labels.workflow_id = payload.workflowId ?? 'unknown';
+						labels.workflow_id = String(payload.workflowId ?? 'unknown');
 					}
 					if (this.includes.labels.workflowName) {
-						labels.workflow_name = payload.workflowName ?? 'unknown';
+						labels.workflow_name = String(payload.workflowName ?? 'unknown');
 					}
 					return labels;
 				}
@@ -337,25 +341,25 @@ export class PrometheusMetricsService {
 			case EventMessageTypeNames.node:
 				const nodeLabels: Record<string, string> = {};
 				if (this.includes.labels.nodeType) {
-					nodeLabels.node_type = (payload.nodeType ?? 'unknown')
-						.replace('n8n-nodes-', '')
-						.replace(/\./g, '_');
+					nodeLabels.node_type = String(
+						(payload.nodeType ?? 'unknown').replace('n8n-nodes-', '').replace(/\./g, '_'),
+					);
 				}
 				if (this.includes.labels.workflowId) {
-					nodeLabels.workflow_id = payload.workflowId ?? 'unknown';
+					nodeLabels.workflow_id = String(payload.workflowId ?? 'unknown');
 				}
 				if (this.includes.labels.workflowName) {
-					nodeLabels.workflow_name = payload.workflowName ?? 'unknown';
+					nodeLabels.workflow_name = String(payload.workflowName ?? 'unknown');
 				}
 				return nodeLabels;
 
 			case EventMessageTypeNames.workflow:
 				const workflowLabels: Record<string, string> = {};
 				if (this.includes.labels.workflowId) {
-					workflowLabels.workflow_id = payload.workflowId ?? 'unknown';
+					workflowLabels.workflow_id = String(payload.workflowId ?? 'unknown');
 				}
 				if (this.includes.labels.workflowName) {
-					workflowLabels.workflow_name = payload.workflowName ?? 'unknown';
+					workflowLabels.workflow_name = String(payload.workflowName ?? 'unknown');
 				}
 				return workflowLabels;
 		}

--- a/packages/cli/src/metrics/prometheus-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus-metrics.service.ts
@@ -332,18 +332,14 @@ export class PrometheusMetricsService {
 				break;
 
 			case EventMessageTypeNames.node:
-				const nodeLabels: Record<string, string> = {};
+				const nodeLabels: Record<string, string> = this.buildWorkflowLabels(payload);
+
 				if (this.includes.labels.nodeType) {
 					nodeLabels.node_type = String(
 						(payload.nodeType ?? 'unknown').replace('n8n-nodes-', '').replace(/\./g, '_'),
 					);
 				}
-				if (this.includes.labels.workflowId) {
-					nodeLabels.workflow_id = String(payload.workflowId ?? 'unknown');
-				}
-				if (this.includes.labels.workflowName) {
-					nodeLabels.workflow_name = String(payload.workflowName ?? 'unknown');
-				}
+
 				return nodeLabels;
 
 			case EventMessageTypeNames.workflow:

--- a/packages/cli/src/metrics/types.ts
+++ b/packages/cli/src/metrics/types.ts
@@ -4,6 +4,7 @@ export type MetricLabel =
 	| 'credentialsType'
 	| 'nodeType'
 	| 'workflowId'
+	| 'workflowName'
 	| 'apiPath'
 	| 'apiMethod'
 	| 'apiStatusCode';

--- a/packages/cli/test/integration/prometheus-metrics.test.ts
+++ b/packages/cli/test/integration/prometheus-metrics.test.ts
@@ -31,6 +31,7 @@ globalConfig.endpoints.metrics = {
 	includeCredentialTypeLabel: false,
 	includeNodeTypeLabel: false,
 	includeWorkflowIdLabel: false,
+	includeWorkflowNameLabel: false,
 	includeApiPathLabel: true,
 	includeApiMethodLabel: true,
 	includeApiStatusCodeLabel: true,


### PR DESCRIPTION
## Summary

<!--
Option to add workflowName as a label to prometheus.
-->

Add `workflowName` as a label to workflow metrics.
The need came from building a grafana dashboard, and the metric only expose `workflowId`, which is not easy to understand which workflow was success or failed.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
