### PR TITLE
fix(Gmail Node): Set References and In-Reply-To only when user provides threadId

### DIFF
--- a/packages/nodes-base/nodes/Google/Gmail/test/v2/GmailV2.node.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/v2/GmailV2.node.test.ts
@@ -175,7 +175,7 @@ describe('Test Gmail Node v2', () => {
 							mail
 								.replace(/boundary=".*"/g, 'boundary="--test-boundary"')
 								.replace(/----.*/g, '----test-boundary')
-								.replace(/Message-ID:.*/g, 'Message-ID: test-message-id'),
+								.replace(/Message-ID:.*/g, 'Message-ID: <test-message-id@mail.com>'),
 							'utf-8',
 						).toString('base64');
 
@@ -184,11 +184,10 @@ describe('Test Gmail Node v2', () => {
 						return body;
 					}
 				})
-				.post('/v1/users/me/drafts', {
-					message: {
-						raw: 'Q29udGVudC1UeXBlOiBtdWx0aXBhcnQvbWl4ZWQ7IGJvdW5kYXJ5PSItLXRlc3QtYm91bmRhcnkiDQpGcm9tOiB0ZXN0LWFsaWFzQG44bi5pbw0KVG86IHRlc3QtdG9AbjhuLmlvDQpDYzogdGVzdC1jY0BuOG4uaW8NCkJjYzogdGVzdC1iY2NAbjhuLmlvDQpSZXBseS1UbzogdGVzdC1yZXBseUBuOG4uaW8NClN1YmplY3Q6IFRlc3QgRHJhZnQgU3ViamVjdA0KTWVzc2FnZS1JRDogdGVzdC1tZXNzYWdlLWlkDQpEYXRlOiBNb24sIDE2IERlYyAyMDI0IDEyOjM0OjU2ICswMDAwDQpNSU1FLVZlcnNpb246IDEuMA0KDQotLS0tdGVzdC1ib3VuZGFyeQ0KQ29udGVudC1UeXBlOiB0ZXh0L3BsYWluOyBjaGFyc2V0PXV0Zi04DQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiA3Yml0DQoNClRlc3QgRHJhZnQgTWVzc2FnZQ0KLS0tLXRlc3QtYm91bmRhcnkNCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbjsgbmFtZT1maWxlLmpzb24NCkNvbnRlbnQtVHJhbnNmZXItRW5jb2Rpbmc6IGJhc2U2NA0KQ29udGVudC1EaXNwb3NpdGlvbjogYXR0YWNobWVudDsgZmlsZW5hbWU9ZmlsZS5qc29uDQoNClczc2lZbWx1WVhKNUlqcDBjblZsZlYwPQ0KLS0tLXRlc3QtYm91bmRhcnkNCg==',
-						threadId: 'test-thread-id',
-					},
+				.post('/v1/users/me/drafts', (body) => {
+					return (
+						typeof body.message?.raw === 'string' && body.message.threadId === 'test-thread-id'
+					);
 				})
 				.query({ userId: 'me', uploadType: 'media' })
 				.reply(200, messages[0]);
@@ -200,7 +199,9 @@ describe('Test Gmail Node v2', () => {
 					metadataHeaders: 'Message-ID',
 				})
 				.reply(200, {
-					messages: [{ payload: { headers: ['jjkjkjkf@reply.com'] } }],
+					messages: [
+						{ payload: { headers: [{ name: 'Message-ID', value: '<test-message-id@mail.com>' }] } },
+					],
 				});
 			gmailNock
 				.get('/v1/users/me/drafts/test-draft-id')

--- a/packages/nodes-base/nodes/Google/Gmail/test/v2/utils.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/v2/utils.test.ts
@@ -143,8 +143,8 @@ describe('addThreadHeadersToEmail', () => {
 		const mockMessageId = '<message-id@example.com>';
 		const mockThread = {
 			messages: [
-				{ payload: { headers: [{ value: '<old-id@example.com>' }] } },
-				{ payload: { headers: [{ value: mockMessageId }] } },
+				{ payload: { headers: [{ name: 'Message-ID', value: '<old-id@example.com>' }] } },
+				{ payload: { headers: [{ name: 'Message-ID', value: mockMessageId }] } },
 			],
 		};
 

--- a/packages/nodes-base/nodes/Google/Gmail/test/v2/utils.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/v2/utils.test.ts
@@ -159,7 +159,7 @@ describe('addThreadHeadersToEmail', () => {
 		await addThreadHeadersToEmail.call(thisArg, email, mockThreadId);
 
 		expect(email.inReplyTo).toBe(mockMessageId);
-		expect(email.reference).toBe(mockMessageId);
+		expect(email.references).toBe(mockMessageId);
 	});
 
 	it('should set inReplyTo and reference on the email object even if the message has only one item', async () => {
@@ -180,7 +180,7 @@ describe('addThreadHeadersToEmail', () => {
 		await addThreadHeadersToEmail.call(thisArg, email, mockThreadId);
 
 		expect(email.inReplyTo).toBe(mockMessageId);
-		expect(email.reference).toBe(mockMessageId);
+		expect(email.references).toBe(mockMessageId);
 	});
 
 	it('should not do anything if the thread has no messages', async () => {
@@ -199,6 +199,6 @@ describe('addThreadHeadersToEmail', () => {
 
 		// We are using mock<IEmail>({}) which means the value of these will be a mock function
 		expect(typeof email.inReplyTo).toBe('function');
-		expect(typeof email.reference).toBe('function');
+		expect(typeof email.references).toBe('function');
 	});
 });

--- a/packages/nodes-base/nodes/Google/Gmail/test/v2/utils.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/v2/utils.test.ts
@@ -166,7 +166,7 @@ describe('addThreadHeadersToEmail', () => {
 		const mockThreadId = 'thread123';
 		const mockMessageId = '<message-id@example.com>';
 		const mockThread = {
-			messages: [{ payload: { headers: [{ value: mockMessageId }] } }],
+			messages: [{ payload: { headers: [{ name: 'Message-ID', value: mockMessageId }] } }],
 		};
 
 		jest.spyOn(GenericFunctions, 'googleApiRequest').mockImplementation(async function () {

--- a/packages/nodes-base/nodes/Google/Gmail/v2/DraftDescription.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/DraftDescription.ts
@@ -209,18 +209,18 @@ export const draftFields: INodeProperties[] = [
 				name: 'references',
 				type: 'string',
 				default: '',
-				placeholder: '<message-id-1@example.com>',
+				placeholder: '<message-1@example.com>',
 				description:
-					'The full chain of message IDs in the conversation thread to be used to reply to a thread with a thread ID.',
+					'The full chain of message IDs in the conversation thread to be used to reply to a thread with a thread ID',
 			},
 			{
 				displayName: 'In-Reply-To',
 				name: 'inReplyTo',
 				type: 'string',
 				default: '',
-				placeholder: '<message-id-1@example.com>',
+				placeholder: '<message-1@example.com>',
 				description:
-					'The specific message this email is directly replying to. To be used to reply to a thread with a thread ID.',
+					'The specific message this email is directly replying to. To be used to reply to a thread with a thread ID',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Google/Gmail/v2/DraftDescription.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/DraftDescription.ts
@@ -204,6 +204,24 @@ export const draftFields: INodeProperties[] = [
 				description:
 					'The email addresses of the recipients. Multiple addresses can be separated by a comma. e.g. jay@getsby.com, jon@smith.com.',
 			},
+			{
+				displayName: 'References',
+				name: 'references',
+				type: 'string',
+				default: '',
+				placeholder: '<message-id-1@example.com>',
+				description:
+					'The full chain of message IDs in the conversation thread to be used to reply to a thread with a thread ID.',
+			},
+			{
+				displayName: 'In-Reply-To',
+				name: 'inReplyTo',
+				type: 'string',
+				default: '',
+				placeholder: '<message-id-1@example.com>',
+				description:
+					'The specific message this email is directly replying to. To be used to reply to a thread with a thread ID.',
+			},
 		],
 	},
 	{

--- a/packages/nodes-base/nodes/Google/Gmail/v2/DraftDescription.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/DraftDescription.ts
@@ -220,7 +220,7 @@ export const draftFields: INodeProperties[] = [
 				default: '',
 				placeholder: '<message-1@example.com>',
 				description:
-					'The specific message this email is directly replying to. To be used to reply to a thread with a thread ID',
+					'The specific message this email is directly replying to. To be used to reply to a thread with a thread ID.',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Google/Gmail/v2/DraftDescription.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/DraftDescription.ts
@@ -204,24 +204,6 @@ export const draftFields: INodeProperties[] = [
 				description:
 					'The email addresses of the recipients. Multiple addresses can be separated by a comma. e.g. jay@getsby.com, jon@smith.com.',
 			},
-			{
-				displayName: 'References',
-				name: 'references',
-				type: 'string',
-				default: '',
-				placeholder: '<message-1@example.com>',
-				description:
-					'The full chain of message IDs in the conversation thread to be used to reply to a thread with a thread ID',
-			},
-			{
-				displayName: 'In-Reply-To',
-				name: 'inReplyTo',
-				type: 'string',
-				default: '',
-				placeholder: '<message-1@example.com>',
-				description:
-					'The specific message this email is directly replying to. To be used to reply to a thread with a thread ID.',
-			},
 		],
 	},
 	{

--- a/packages/nodes-base/nodes/Google/Gmail/v2/GmailV2.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/GmailV2.node.ts
@@ -564,10 +564,16 @@ export class GmailV2 implements INodeType {
 							attachments,
 						};
 
-						if (threadId && options.replyTo && (!references || !inReplyTo)) {
+						if (threadId) {
 							// If a threadId is set, we need to add the Message-ID of the last message in the thread
 							// to the email so that Gmail can correctly associate the draft with the thread
-							await addThreadHeadersToEmail.call(this, email, threadId as string);
+							await addThreadHeadersToEmail.call(
+								this,
+								email,
+								threadId as string,
+								references,
+								inReplyTo,
+							);
 						}
 
 						if (references && inReplyTo) {

--- a/packages/nodes-base/nodes/Google/Gmail/v2/GmailV2.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/GmailV2.node.ts
@@ -511,9 +511,6 @@ export class GmailV2 implements INodeType {
 						let fromAlias = '';
 						let threadId = null;
 
-						const references = options.references as string | undefined;
-						const inReplyTo = options.inReplyTo as string | undefined;
-
 						if (options.sendTo) {
 							to += prepareEmailsInput.call(this, options.sendTo as string, 'To', i);
 						}
@@ -567,18 +564,7 @@ export class GmailV2 implements INodeType {
 						if (threadId) {
 							// If a threadId is set, we need to add the Message-ID of the last message in the thread
 							// to the email so that Gmail can correctly associate the draft with the thread
-							await addThreadHeadersToEmail.call(
-								this,
-								email,
-								threadId as string,
-								references,
-								inReplyTo,
-							);
-						}
-
-						if (references && inReplyTo) {
-							email.inReplyTo = inReplyTo;
-							email.reference = references;
+							await addThreadHeadersToEmail.call(this, email, threadId as string);
 						}
 
 						const body = {

--- a/packages/nodes-base/nodes/Google/Gmail/v2/GmailV2.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/GmailV2.node.ts
@@ -511,6 +511,9 @@ export class GmailV2 implements INodeType {
 						let fromAlias = '';
 						let threadId = null;
 
+						const references = options.references as string | undefined;
+						const inReplyTo = options.inReplyTo as string | undefined;
+
 						if (options.sendTo) {
 							to += prepareEmailsInput.call(this, options.sendTo as string, 'To', i);
 						}
@@ -561,10 +564,15 @@ export class GmailV2 implements INodeType {
 							attachments,
 						};
 
-						if (threadId && options.replyTo) {
+						if (threadId && options.replyTo && (!references || !inReplyTo)) {
 							// If a threadId is set, we need to add the Message-ID of the last message in the thread
 							// to the email so that Gmail can correctly associate the draft with the thread
-							await addThreadHeadersToEmail.call(this, email, threadId);
+							await addThreadHeadersToEmail.call(this, email, threadId as string);
+						}
+
+						if (references && inReplyTo) {
+							email.inReplyTo = inReplyTo;
+							email.reference = references;
 						}
 
 						const body = {

--- a/packages/nodes-base/nodes/Google/Gmail/v2/utils/draft.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/utils/draft.ts
@@ -4,6 +4,13 @@ import type { IEmail } from '@utils/sendAndWait/interfaces';
 
 import { googleApiRequest } from '../../GenericFunctions';
 
+function setEmailReplyHeaders(email: IEmail, messageId: string | undefined): void {
+	if (messageId) {
+		email.inReplyTo = messageId;
+		email.reference = messageId;
+	}
+}
+
 function setThreadHeaders(
 	email: IEmail,
 	thread: { messages: Array<{ payload: { headers: Array<{ name: string; value: string }> } }> },
@@ -14,8 +21,7 @@ function setThreadHeaders(
 			(header: { name: string; value: string }) => header.name === 'Message-ID',
 		)?.value;
 
-		email.inReplyTo = messageId;
-		email.reference = messageId;
+		setEmailReplyHeaders(email, messageId);
 	}
 }
 

--- a/packages/nodes-base/nodes/Google/Gmail/v2/utils/draft.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/utils/draft.ts
@@ -7,7 +7,7 @@ import { googleApiRequest } from '../../GenericFunctions';
 function setEmailReplyHeaders(email: IEmail, messageId: string | undefined): void {
 	if (messageId) {
 		email.inReplyTo = messageId;
-		email.reference = messageId;
+		email.references = messageId;
 	}
 }
 

--- a/packages/nodes-base/nodes/Google/Gmail/v2/utils/draft.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/utils/draft.ts
@@ -22,7 +22,9 @@ export async function addThreadHeadersToEmail(
 
 	if (thread?.messages) {
 		const lastMessage = thread.messages.length - 1;
-		const messageId: string = thread.messages[lastMessage].payload.headers[0].value;
+		const messageId = thread.messages[lastMessage].payload.headers.find(
+			(header: { name: string; value: string }) => header.name === 'Message-ID',
+		)?.value;
 
 		email.inReplyTo = messageId;
 		email.reference = messageId;

--- a/packages/nodes-base/nodes/Google/Gmail/v2/utils/draft.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/utils/draft.ts
@@ -26,21 +26,14 @@ export async function addThreadHeadersToEmail(
 	this: IExecuteFunctions,
 	email: IEmail,
 	threadId: string,
-	references: string | undefined = undefined,
-	inReplyTo: string | undefined = undefined,
 ): Promise<void> {
-	if (references && inReplyTo) {
-		email.inReplyTo = inReplyTo;
-		email.reference = references;
-	} else {
-		const thread = await googleApiRequest.call(
-			this,
-			'GET',
-			`/gmail/v1/users/me/threads/${threadId}`,
-			{},
-			{ format: 'metadata', metadataHeaders: ['Message-ID'] },
-		);
+	const thread = await googleApiRequest.call(
+		this,
+		'GET',
+		`/gmail/v1/users/me/threads/${threadId}`,
+		{},
+		{ format: 'metadata', metadataHeaders: ['Message-ID'] },
+	);
 
-		setThreadHeaders(email, thread);
-	}
+	setThreadHeaders(email, thread);
 }

--- a/packages/nodes-base/nodes/Google/Gmail/v2/utils/draft.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/utils/draft.ts
@@ -18,7 +18,8 @@ function setThreadHeaders(
 	if (thread?.messages) {
 		const lastMessage = thread.messages.length - 1;
 		const messageId = thread.messages[lastMessage].payload.headers.find(
-			(header: { name: string; value: string }) => header.name === 'Message-ID',
+			(header: { name: string; value: string }) =>
+				header.name.toLowerCase().includes('message') && header.name.toLowerCase().includes('id'),
 		)?.value;
 
 		setEmailReplyHeaders(email, messageId);

--- a/packages/nodes-base/utils/sendAndWait/interfaces.ts
+++ b/packages/nodes-base/utils/sendAndWait/interfaces.ts
@@ -8,6 +8,7 @@ export interface IEmail {
 	replyTo?: string;
 	inReplyTo?: string;
 	reference?: string;
+	references?: string;
 	subject: string;
 	body: string;
 	htmlBody?: string;


### PR DESCRIPTION
## Summary

Set References and In-Reply-To only when user provides threadId. Gets the latest message from the thread to do this.

We also need to adapt the `nock` for creating a draft in tests since the encoding for the email gets dynamically generated we can no longer rely on the raw message being the same on each run

Workflow for testing:
```
{
  "nodes": [
    {
      "parameters": {
        "pollTimes": {
          "item": [
            {
              "mode": "everyMinute"
            }
          ]
        },
        "filters": {}
      },
      "type": "n8n-nodes-base.gmailTrigger",
      "typeVersion": 1.2,
      "position": [
        -64,
        560
      ],
      "id": "8346fdd7-9e69-4f78-b9f2-349678d27a8e",
      "name": "Gmail Trigger1",
      "credentials": {
        "gmailOAuth2": {
          "id": "SLV3D68Mpqomofzr",
          "name": "Gmail account"
        }
      }
    },
    {
      "parameters": {
        "resource": "draft",
        "subject": "={{ $('Gmail Trigger1').item.json.Subject }}",
        "message": "=hello from n8n ",
        "options": {
          "threadId": "={{ $('Gmail Trigger1').item.json.threadId }}"
        }
      },
      "type": "n8n-nodes-base.gmail",
      "typeVersion": 2.1,
      "position": [
        416,
        688
      ],
      "id": "919d9fcd-c3fd-4f08-ad38-0afe0a29684f",
      "name": "no set, no reply to, draft",
      "webhookId": "2ae44867-684e-49d1-b1a5-c85794b129d4",
      "credentials": {
        "gmailOAuth2": {
          "id": "SLV3D68Mpqomofzr",
          "name": "Gmail account"
        }
      }
    }
  ],
  "connections": {
    "Gmail Trigger1": {
      "main": [
        [
          {
            "node": "no set, no reply to, draft",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {},
  "meta": {
    "templateCredsSetupCompleted": true,
    "instanceId": "ee90fdf8d57662f949e6c691dc07fa0fd2f66e1eee28ed82ef06658223e67255"
  }
}
```

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/issues/15775
https://linear.app/n8n/issue/NODE-3052/community-issue-gmail-create-draft-to-reply-breaks-the-thread

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
