### PR TITLE
fix: Use ghcr tag for scanning (no-changelog)

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -336,11 +336,11 @@ jobs:
     name: Security Scan
     needs: [build-and-push-docker]
     if: |
-      success() &&
+      success() && inputs.push_enabled == 'true' &&
       (github.event_name == 'schedule' ||
        (github.event_name == 'workflow_call' && inputs.release_type == 'stable'))
     uses: ./.github/workflows/security-trivy-scan-callable.yml
     with:
-      image_ref: ${{ needs.build-and-push-docker.outputs.image_ref }}
+      image_ref: ${{ needs.build-and-push-docker.outputs.primary_ghcr_manifest_tag }}
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary

We need to use the ghcr tag for pulling/scanning as the docker tag isn't output as expected due to the name being a secret.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
