### PR TITLE
fix(editor): Only do new versions & what's new check after login

### DIFF
--- a/packages/frontend/editor-ui/src/init.test.ts
+++ b/packages/frontend/editor-ui/src/init.test.ts
@@ -80,13 +80,11 @@ describe('Init', () => {
 		it('should initialize core features only once', async () => {
 			const usersStoreSpy = vi.spyOn(usersStore, 'initialize');
 			const settingsStoreSpy = vi.spyOn(settingsStore, 'initialize');
-			const versionsSpy = vi.spyOn(versionsStore, 'checkForNewVersions');
 
 			await initializeCore();
 
 			expect(settingsStoreSpy).toHaveBeenCalled();
 			expect(usersStoreSpy).toHaveBeenCalled();
-			expect(versionsSpy).toHaveBeenCalled();
 
 			await initializeCore();
 
@@ -173,6 +171,7 @@ describe('Init', () => {
 			const cloudStoreSpy = vi.spyOn(cloudPlanStore, 'initialize');
 			const sourceControlSpy = vi.spyOn(sourceControlStore, 'getPreferences');
 			const nodeTranslationSpy = vi.spyOn(nodeTypesStore, 'getNodeTranslationHeaders');
+			const versionsSpy = vi.spyOn(versionsStore, 'checkForNewVersions');
 			vi.mocked(useUsersStore).mockReturnValue({ currentUser: null } as ReturnType<
 				typeof useUsersStore
 			>);
@@ -181,12 +180,14 @@ describe('Init', () => {
 			expect(cloudStoreSpy).not.toHaveBeenCalled();
 			expect(sourceControlSpy).not.toHaveBeenCalled();
 			expect(nodeTranslationSpy).not.toHaveBeenCalled();
+			expect(versionsSpy).not.toHaveBeenCalled();
 		});
 
 		it('should init authenticated features only once if user is logged in', async () => {
 			const cloudStoreSpy = vi.spyOn(cloudPlanStore, 'initialize');
 			const sourceControlSpy = vi.spyOn(sourceControlStore, 'getPreferences');
 			const nodeTranslationSpy = vi.spyOn(nodeTypesStore, 'getNodeTranslationHeaders');
+			const versionsSpy = vi.spyOn(versionsStore, 'checkForNewVersions');
 			vi.mocked(useUsersStore).mockReturnValue({ currentUser: { id: '123' } } as ReturnType<
 				typeof useUsersStore
 			>);
@@ -196,6 +197,7 @@ describe('Init', () => {
 			expect(cloudStoreSpy).toHaveBeenCalled();
 			expect(sourceControlSpy).toHaveBeenCalled();
 			expect(nodeTranslationSpy).toHaveBeenCalled();
+			expect(versionsSpy).toHaveBeenCalled();
 
 			await initializeAuthenticatedFeatures();
 

--- a/packages/frontend/editor-ui/src/init.ts
+++ b/packages/frontend/editor-ui/src/init.ts
@@ -96,8 +96,6 @@ export async function initializeCore() {
 		await usersStore.initialize({
 			quota: settingsStore.userManagement.quota,
 		});
-
-		void versionsStore.checkForNewVersions();
 	}
 
 	state.initialized = true;
@@ -129,6 +127,7 @@ export async function initializeAuthenticatedFeatures(
 	const rolesStore = useRolesStore();
 	const insightsStore = useInsightsStore();
 	const uiStore = useUIStore();
+	const versionsStore = useVersionsStore();
 
 	if (sourceControlStore.isEnterpriseSourceControlEnabled) {
 		try {
@@ -168,6 +167,10 @@ export async function initializeAuthenticatedFeatures(
 
 	if (insightsStore.isSummaryEnabled) {
 		void insightsStore.weeklySummary.execute();
+	}
+
+	if (!settingsStore.isPreviewMode) {
+		void versionsStore.checkForNewVersions();
 	}
 
 	await Promise.all([


### PR DESCRIPTION
## Summary

Don't do new versions check while user hasn't signed in. Only do this check on `initializeAuthenticatedFeatures`, which fires after user has been authenticated.

This prevents the `What's new` and `Security updates` notification from being shown on the login screen.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/ADO-3779/bug-alert-shows-up-even-if-not-logged-in

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
