### PR TITLE
feat(editor): Refactor the executable node logic (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/components/NodeDetailsView.vue
+++ b/packages/frontend/editor-ui/src/components/NodeDetailsView.vue
@@ -331,7 +331,7 @@ const blockUi = computed(
 );
 
 const foreignCredentials = computed(() =>
-	nodeHelpers.getForeignCredentials(activeNode.value?.credentials),
+	nodeHelpers.getForeignCredentialsIfSharingEnabled(activeNode.value?.credentials),
 );
 
 const hasForeignCredential = computed(() => foreignCredentials.value.length > 0);

--- a/packages/frontend/editor-ui/src/components/NodeDetailsView.vue
+++ b/packages/frontend/editor-ui/src/components/NodeDetailsView.vue
@@ -19,7 +19,6 @@ import TriggerPanel from './TriggerPanel.vue';
 import {
 	APP_MODALS_ELEMENT_ID,
 	BASE_NODE_SURVEY_URL,
-	EnterpriseEditionFeature,
 	EXECUTABLE_TRIGGER_NODE_TYPES,
 	MODAL_CONFIRM,
 	START_NODE_TYPE,
@@ -31,7 +30,6 @@ import { dataPinningEventBus, ndvEventBus } from '@/event-bus';
 import { useWorkflowsStore } from '@/stores/workflows.store';
 import { useNDVStore } from '@/stores/ndv.store';
 import { useNodeTypesStore } from '@/stores/nodeTypes.store';
-import { useSettingsStore } from '@/stores/settings.store';
 import { useDeviceSupport } from '@n8n/composables/useDeviceSupport';
 import { useNodeHelpers } from '@/composables/useNodeHelpers';
 import { useMessage } from '@/composables/useMessage';
@@ -76,7 +74,6 @@ const pinnedData = usePinnedData(activeNode);
 const workflowActivate = useWorkflowActivate();
 const nodeTypesStore = useNodeTypesStore();
 const workflowsStore = useWorkflowsStore();
-const settingsStore = useSettingsStore();
 const deviceSupport = useDeviceSupport();
 const telemetry = useTelemetry();
 const i18n = useI18n();
@@ -333,25 +330,9 @@ const blockUi = computed(
 	() => workflowsStore.isWorkflowRunning || isExecutionWaitingForWebhook.value,
 );
 
-const foreignCredentials = computed(() => {
-	const credentials = activeNode.value?.credentials;
-	const usedCredentials = workflowsStore.usedCredentials;
-
-	const foreignCredentialsArray: string[] = [];
-	if (credentials && settingsStore.isEnterpriseFeatureEnabled[EnterpriseEditionFeature.Sharing]) {
-		Object.values(credentials).forEach((credential) => {
-			if (
-				credential.id &&
-				usedCredentials[credential.id] &&
-				!usedCredentials[credential.id].currentUserHasAccess
-			) {
-				foreignCredentialsArray.push(credential.id);
-			}
-		});
-	}
-
-	return foreignCredentialsArray;
-});
+const foreignCredentials = computed(() =>
+	nodeHelpers.getForeignCredentials(activeNode.value?.credentials),
+);
 
 const hasForeignCredential = computed(() => foreignCredentials.value.length > 0);
 
@@ -850,7 +831,6 @@ onBeforeUnmount(() => {
 						:event-bus="settingsEventBus"
 						:dragging="isDragging"
 						:push-ref="pushRef"
-						:node-type="activeNodeType"
 						:foreign-credentials="foreignCredentials"
 						:read-only="readOnly"
 						:block-u-i="blockUi && showTriggerPanel"

--- a/packages/frontend/editor-ui/src/components/NodeSettings.vue
+++ b/packages/frontend/editor-ui/src/components/NodeSettings.vue
@@ -170,7 +170,7 @@ const executeButtonTooltip = computed(() => {
 });
 
 const nodeVersionTag = computed(() => {
-	if (!nodeType.value || nodeType.value) {
+	if (!nodeType.value || nodeType.value.hidden) {
 		return i18n.baseText('nodeSettings.deprecated');
 	}
 

--- a/packages/frontend/editor-ui/src/components/NodeSettings.vue
+++ b/packages/frontend/editor-ui/src/components/NodeSettings.vue
@@ -1,14 +1,13 @@
 <script setup lang="ts">
 import { useTemplateRef, computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import type {
-	INodeTypeDescription,
 	INodeParameters,
 	INodeProperties,
 	NodeConnectionType,
 	NodeParameterValue,
 	INodeCredentialDescription,
 } from 'n8n-workflow';
-import { NodeHelpers, NodeConnectionTypes, deepCopy } from 'n8n-workflow';
+import { NodeHelpers, deepCopy } from 'n8n-workflow';
 import type {
 	CurlToJSONResponse,
 	INodeUi,
@@ -49,7 +48,6 @@ const props = withDefaults(
 		eventBus: EventBus;
 		dragging: boolean;
 		pushRef: string;
-		nodeType: INodeTypeDescription | null;
 		readOnly: boolean;
 		foreignCredentials: string[];
 		blockUI: boolean;
@@ -134,31 +132,17 @@ const isReadOnly = computed(
 );
 const node = computed(() => props.activeNode ?? ndvStore.activeNode);
 
+const nodeType = computed(() =>
+	node.value ? nodeTypesStore.getNodeType(node.value.type, node.value.typeVersion) : null,
+);
+
 const isTriggerNode = computed(() => !!node.value && nodeTypesStore.isTriggerNode(node.value.type));
 
 const isToolNode = computed(() => !!node.value && nodeTypesStore.isToolNode(node.value.type));
 
-const isExecutable = computed(() => {
-	if (props.nodeType && node.value) {
-		const workflowNode = currentWorkflowInstance.value.getNode(node.value.name);
-		const inputs = NodeHelpers.getNodeInputs(
-			currentWorkflowInstance.value,
-			workflowNode!,
-			props.nodeType,
-		);
-		const inputNames = NodeHelpers.getConnectionTypes(inputs);
-
-		if (
-			!inputNames.includes(NodeConnectionTypes.Main) &&
-			!isToolNode.value &&
-			!isTriggerNode.value
-		) {
-			return false;
-		}
-	}
-
-	return props.executable || props.foreignCredentials.length > 0;
-});
+const isExecutable = computed(() =>
+	nodeHelpers.isNodeExecutable(node.value, props.executable, props.foreignCredentials),
+);
 
 const nodeTypeVersions = computed(() => {
 	if (!node.value) return [];
@@ -186,7 +170,7 @@ const executeButtonTooltip = computed(() => {
 });
 
 const nodeVersionTag = computed(() => {
-	if (!props.nodeType || props.nodeType.hidden) {
+	if (!nodeType.value || nodeType.value) {
 		return i18n.baseText('nodeSettings.deprecated');
 	}
 
@@ -200,11 +184,11 @@ const nodeVersionTag = computed(() => {
 });
 
 const parameters = computed(() => {
-	if (props.nodeType === null) {
+	if (nodeType.value === null) {
 		return [];
 	}
 
-	return props.nodeType?.properties ?? [];
+	return nodeType.value?.properties ?? [];
 });
 
 const parametersSetting = computed(() => parameters.value.filter((item) => item.isNodeSetting));
@@ -219,7 +203,7 @@ const parametersNoneSetting = computed(() => {
 const isDisplayingCredentials = computed(
 	() =>
 		credentialsStore
-			.getCredentialTypesNodeDescriptions('', props.nodeType)
+			.getCredentialTypesNodeDescriptions('', nodeType.value)
 			.filter((credentialTypeDescription) => displayCredentials(credentialTypeDescription)).length >
 		0,
 );
@@ -292,19 +276,19 @@ const valueChanged = (parameterData: IUpdateInformation) => {
 		};
 		emit('valueChanged', sendData);
 	} else if (parameterData.name === 'parameters') {
-		const nodeType = nodeTypesStore.getNodeType(_node.type, _node.typeVersion);
-		if (!nodeType) {
+		const _nodeType = nodeTypesStore.getNodeType(_node.type, _node.typeVersion);
+		if (!_nodeType) {
 			return;
 		}
 
 		// Get only the parameters which are different to the defaults
 		let nodeParameters = NodeHelpers.getNodeParameters(
-			nodeType.properties,
+			_nodeType.properties,
 			_node.parameters,
 			false,
 			false,
 			_node,
-			nodeType,
+			_nodeType,
 		);
 
 		const oldNodeParameters = Object.assign({}, nodeParameters);
@@ -321,7 +305,7 @@ const valueChanged = (parameterData: IUpdateInformation) => {
 					parameterName,
 					newValue,
 					nodeParameters,
-					nodeType,
+					_nodeType,
 					_node.typeVersion,
 				);
 
@@ -337,12 +321,12 @@ const valueChanged = (parameterData: IUpdateInformation) => {
 		// Get the parameters with the now new defaults according to the
 		// from the user actually defined parameters
 		nodeParameters = NodeHelpers.getNodeParameters(
-			nodeType.properties,
+			_nodeType.properties,
 			nodeParameters as INodeParameters,
 			true,
 			false,
 			_node,
-			nodeType,
+			_nodeType,
 		);
 
 		for (const key of Object.keys(nodeParameters as object)) {
@@ -581,7 +565,7 @@ const setNodeValues = () => {
 		return;
 	}
 
-	if (props.nodeType !== null) {
+	if (nodeType.value !== null) {
 		nodeValid.value = true;
 
 		const foundNodeSettings = [];
@@ -725,7 +709,7 @@ onMounted(() => {
 	setNodeValues();
 	props.eventBus?.on('openSettings', openSettings);
 	if (node.value !== null) {
-		nodeHelpers.updateNodeParameterIssues(node.value, props.nodeType);
+		nodeHelpers.updateNodeParameterIssues(node.value, nodeType.value);
 	}
 	importCurlEventBus.on('setHttpNodeParameters', setHttpNodeParameters);
 	ndvEventBus.on('updateParameterValue', valueChanged);

--- a/packages/frontend/editor-ui/src/components/canvas/experimental/components/ExperimentalCanvasNodeSettings.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/experimental/components/ExperimentalCanvasNodeSettings.vue
@@ -2,7 +2,6 @@
 import NodeSettings from '@/components/NodeSettings.vue';
 import { useCanvasOperations } from '@/composables/useCanvasOperations';
 import { type IUpdateInformation } from '@/Interface';
-import { useNodeTypesStore } from '@/stores/nodeTypes.store';
 import { useWorkflowsStore } from '@/stores/workflows.store';
 import { createEventBus } from '@n8n/utils/event-bus';
 import { computed } from 'vue';
@@ -12,17 +11,10 @@ const { nodeId, noWheel } = defineProps<{ nodeId: string; noWheel?: boolean }>()
 defineSlots<{ actions?: {} }>();
 
 const settingsEventBus = createEventBus();
-const nodeTypesStore = useNodeTypesStore();
 const workflowsStore = useWorkflowsStore();
 const { renameNode } = useCanvasOperations();
 
 const activeNode = computed(() => workflowsStore.getNodeById(nodeId));
-const activeNodeType = computed(() => {
-	if (activeNode.value) {
-		return nodeTypesStore.getNodeType(activeNode.value.type, activeNode.value.typeVersion);
-	}
-	return null;
-});
 
 function handleValueChanged(parameterData: IUpdateInformation) {
 	if (parameterData.name === 'name' && parameterData.oldValue) {
@@ -36,7 +28,6 @@ function handleValueChanged(parameterData: IUpdateInformation) {
 		:event-bus="settingsEventBus"
 		:dragging="false"
 		:active-node="activeNode"
-		:node-type="activeNodeType"
 		push-ref=""
 		:foreign-credentials="[]"
 		:read-only="false"

--- a/packages/frontend/editor-ui/src/composables/useNodeHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useNodeHelpers.test.ts
@@ -1,5 +1,11 @@
 import { setActivePinia } from 'pinia';
-import type { INode, INodeTypeDescription, Workflow } from 'n8n-workflow';
+import {
+	NodeConnectionTypes,
+	NodeHelpers,
+	type INode,
+	type INodeTypeDescription,
+	type Workflow,
+} from 'n8n-workflow';
 import { createTestingPinia } from '@pinia/testing';
 import { useNodeHelpers } from '@/composables/useNodeHelpers';
 import { createTestNode, createMockEnterpriseSettings } from '@/__tests__/mocks';
@@ -10,7 +16,8 @@ import { mockedStore } from '@/__tests__/utils';
 import { mock } from 'vitest-mock-extended';
 import type { ExecutionStatus, IRunData } from 'n8n-workflow';
 import { faker } from '@faker-js/faker';
-import type { IUsedCredential } from '@/Interface';
+import type { INodeUi, IUsedCredential } from '@/Interface';
+import { useNodeTypesStore } from '@/stores/nodeTypes.store';
 
 describe('useNodeHelpers()', () => {
 	beforeAll(() => {
@@ -19,6 +26,178 @@ describe('useNodeHelpers()', () => {
 
 	afterEach(() => {
 		vi.clearAllMocks();
+	});
+
+	describe('isNodeExecutable()', () => {
+		it('should return true if the node is null but explicitly executable', () => {
+			const { isNodeExecutable } = useNodeHelpers();
+
+			const result = isNodeExecutable(null, true, []);
+			expect(result).toBe(true);
+		});
+
+		it('should return false if node has no Main input and is not trigger or tool', () => {
+			const { isNodeExecutable } = useNodeHelpers();
+
+			const node: INodeUi = {
+				id: 'node-id',
+				name: 'Code',
+				type: 'n8n-nodes-base.code',
+				typeVersion: 1,
+				position: [0, 0],
+				parameters: {},
+			};
+
+			const mockWorkflow = {
+				id: 'workflow-id',
+				getNode: () => node,
+			};
+
+			mockedStore(useWorkflowsStore).getCurrentWorkflow = vi.fn().mockReturnValue(mockWorkflow);
+			mockedStore(useNodeTypesStore).getNodeType = vi.fn().mockReturnValue({});
+			mockedStore(useNodeTypesStore).isTriggerNode = vi.fn().mockReturnValue(false);
+			mockedStore(useNodeTypesStore).isToolNode = vi.fn().mockReturnValue(false);
+			vi.spyOn(NodeHelpers, 'getNodeInputs').mockReturnValue([]);
+			vi.spyOn(NodeHelpers, 'getConnectionTypes').mockReturnValue([NodeConnectionTypes.AiDocument]);
+
+			const result = isNodeExecutable(node, true, []);
+			expect(result).toBe(false);
+		});
+
+		it('should return true if node has Main input and is marked executable', () => {
+			const { isNodeExecutable } = useNodeHelpers();
+
+			const node: INodeUi = {
+				id: 'node-id',
+				name: 'Code',
+				type: 'n8n-nodes-base.code',
+				typeVersion: 1,
+				position: [0, 0],
+				parameters: {},
+			};
+
+			const mockWorkflow = {
+				getNode: () => node,
+			};
+
+			mockedStore(useWorkflowsStore).getCurrentWorkflow = vi.fn().mockReturnValue(mockWorkflow);
+			mockedStore(useNodeTypesStore).getNodeType = vi.fn().mockReturnValue({});
+			mockedStore(useNodeTypesStore).isTriggerNode = vi.fn().mockReturnValue(false);
+			mockedStore(useNodeTypesStore).isToolNode = vi.fn().mockReturnValue(false);
+			vi.spyOn(NodeHelpers, 'getNodeInputs').mockReturnValue([]);
+			vi.spyOn(NodeHelpers, 'getConnectionTypes').mockReturnValue([NodeConnectionTypes.Main]);
+
+			const result = isNodeExecutable(node, true, []);
+			expect(result).toBe(true);
+		});
+
+		it('should return true if node has foreign credentials even if not marked executable', () => {
+			const { isNodeExecutable } = useNodeHelpers();
+
+			const node: INodeUi = {
+				id: 'node-id',
+				name: 'Code',
+				type: 'n8n-nodes-base.code',
+				typeVersion: 1,
+				position: [0, 0],
+				parameters: {},
+			};
+
+			const mockWorkflow = {
+				getNode: () => node,
+			};
+
+			mockedStore(useWorkflowsStore).getCurrentWorkflow = vi.fn().mockReturnValue(mockWorkflow);
+			mockedStore(useNodeTypesStore).getNodeType = vi.fn().mockReturnValue({});
+			mockedStore(useNodeTypesStore).isTriggerNode = vi.fn().mockReturnValue(false);
+			mockedStore(useNodeTypesStore).isToolNode = vi.fn().mockReturnValue(false);
+			vi.spyOn(NodeHelpers, 'getNodeInputs').mockReturnValue([]);
+			vi.spyOn(NodeHelpers, 'getConnectionTypes').mockReturnValue([NodeConnectionTypes.Main]);
+
+			const result = isNodeExecutable(node, false, ['foreign-cred-id']);
+			expect(result).toBe(true);
+		});
+
+		it('should return true for trigger nodes regardless of inputs', () => {
+			const { isNodeExecutable } = useNodeHelpers();
+
+			const triggerNode: INodeUi = {
+				id: 'node-id',
+				name: 'Manual Trigger',
+				type: 'n8n-nodes-base.manualTrigger',
+				typeVersion: 1,
+				position: [0, 0],
+				parameters: {},
+			};
+
+			const mockWorkflow = {
+				getNode: () => triggerNode,
+			};
+
+			mockedStore(useWorkflowsStore).getCurrentWorkflow = vi.fn().mockReturnValue(mockWorkflow);
+			mockedStore(useNodeTypesStore).getNodeType = vi.fn().mockReturnValue({});
+			mockedStore(useNodeTypesStore).isTriggerNode = vi.fn().mockReturnValue(true);
+			mockedStore(useNodeTypesStore).isToolNode = vi.fn().mockReturnValue(false);
+			vi.spyOn(NodeHelpers, 'getNodeInputs').mockReturnValue([]);
+			vi.spyOn(NodeHelpers, 'getConnectionTypes').mockReturnValue([]);
+
+			const result = isNodeExecutable(triggerNode, true, []);
+			expect(result).toBe(true);
+		});
+
+		it('should return true for tool nodes regardless of inputs', () => {
+			const { isNodeExecutable } = useNodeHelpers();
+
+			const toolNode: INodeUi = {
+				id: 'node-id',
+				name: 'Tool Node',
+				type: 'n8n-nodes-base.ai-tool',
+				typeVersion: 1,
+				position: [0, 0],
+				parameters: {},
+			};
+
+			const mockWorkflow = {
+				getNode: () => toolNode,
+			};
+
+			mockedStore(useWorkflowsStore).getCurrentWorkflow = vi.fn().mockReturnValue(mockWorkflow);
+			mockedStore(useNodeTypesStore).getNodeType = vi.fn().mockReturnValue({});
+			mockedStore(useNodeTypesStore).isTriggerNode = vi.fn().mockReturnValue(false);
+			mockedStore(useNodeTypesStore).isToolNode = vi.fn().mockReturnValue(true);
+			vi.spyOn(NodeHelpers, 'getNodeInputs').mockReturnValue([]);
+			vi.spyOn(NodeHelpers, 'getConnectionTypes').mockReturnValue([]);
+
+			const result = isNodeExecutable(toolNode, true, []);
+			expect(result).toBe(true);
+		});
+
+		it('should return true if node is structurally valid and has foreign credentials, even if not executable', () => {
+			const { isNodeExecutable } = useNodeHelpers();
+
+			const node: INodeUi = {
+				id: 'node-id',
+				name: 'Code',
+				type: 'n8n-nodes-base.code',
+				typeVersion: 1,
+				position: [0, 0],
+				parameters: {},
+			};
+
+			const mockWorkflow = {
+				getNode: () => node,
+			};
+
+			mockedStore(useWorkflowsStore).getCurrentWorkflow = vi.fn().mockReturnValue(mockWorkflow);
+			mockedStore(useNodeTypesStore).getNodeType = vi.fn().mockReturnValue({});
+			mockedStore(useNodeTypesStore).isTriggerNode = vi.fn().mockReturnValue(false);
+			mockedStore(useNodeTypesStore).isToolNode = vi.fn().mockReturnValue(false);
+			vi.spyOn(NodeHelpers, 'getNodeInputs').mockReturnValue([]);
+			vi.spyOn(NodeHelpers, 'getConnectionTypes').mockReturnValue([NodeConnectionTypes.Main]);
+
+			const result = isNodeExecutable(node, false, ['cred-1']);
+			expect(result).toBe(true);
+		});
 	});
 
 	describe('getForeignCredentialsIfSharingEnabled()', () => {

--- a/packages/frontend/editor-ui/src/composables/useNodeHelpers.ts
+++ b/packages/frontend/editor-ui/src/composables/useNodeHelpers.ts
@@ -99,6 +99,19 @@ export function useNodeHelpers() {
 		return false;
 	}
 
+	/**
+	 * Determines whether a given node is considered executable in the workflow editor.
+	 *
+	 * A node is considered executable if:
+	 * - It structurally qualifies for execution (e.g. is a trigger, tool, or has a 'Main' input),
+	 *   AND
+	 * - It is either explicitly marked as `executable`, OR uses foreign credentials
+	 *   (credentials the current user cannot access, allowed under Workflow Sharing).
+	 *
+	 * @param node The node to check
+	 * @param executable Whether the node is in a state that allows execution (e.g. not readonly)
+	 * @param foreignCredentials List of credential IDs that the current user cannot access
+	 */
 	function isNodeExecutable(
 		node: INodeUi | null,
 		executable: boolean | undefined,


### PR DESCRIPTION
## Summary

This PR moves the logic needed to determine whether a node is executable to a composable, so that we could later reuse it in the Focus Panel.

- Move `isNodeExecutable` a composable
- Move and refactor `getForeignCredentials` to a composable
- Add tests and JSDoc comments for clarity
- Remove `nodeType` from the node settings (it should come from the active node)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3780/feature-refactor-the-executable-node-logic

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
