### PR TITLE
feat(nodes): expand Dropbox OAuth scopes for extended API capabilities

### DIFF
--- a/packages/nodes-base/credentials/DropboxOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/DropboxOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import type { ICredentialType, INodeProperties } from 'n8n-workflow';
 
-const scopes = ['files.content.write', 'files.content.read', 'sharing.read', 'account_info.read'];
+const scopes = ['account_info.write', 'account_info.read', 'files.metadata.write', 'files.metadata.read', 'files.content.write', 'files.content.read', 'sharing.write', 'sharing.read', 'file_requests.write', 'file_requests.read', 'contacts.write', 'contacts.read', 'profile', 'openid', 'email', 'team_info.write', 'team_info.read', 'team_data.member', 'team_data.team_space', 'team_data.governance.write', 'team_data.governance.read', 'team_data.content.write', 'team_data.content.read', 'files.team_metadata.write', 'files.team_metadata.read', 'files.permanent_delete', 'members.write', 'members.read', 'members.delete', 'groups.write', 'groups.read', 'sessions.modify', 'sessions.list', 'events.write', 'events.read'];
 
 export class DropboxOAuth2Api implements ICredentialType {
 	name = 'dropboxOAuth2Api';


### PR DESCRIPTION
Expanded the OAuth 2.0 scopes in the Dropbox node to support a broader set of API features including team data access, governance controls, file metadata, file requests, contact management, and OpenID profile information.

This change allows future workflows to leverage more advanced Dropbox functionality, including team and enterprise-level integrations.

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
