### PR TITLE
fix(editor): Update default positions for AI sub-nodes (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasOperations.test.ts
@@ -388,6 +388,144 @@ describe('useCanvasOperations', () => {
 
 			expect(position).toEqual([0, 0]);
 		});
+
+		it('should apply custom Y offset for AI Language Model connection type', () => {
+			const uiStore = mockedStore(useUIStore);
+			const workflowsStore = mockedStore(useWorkflowsStore);
+			const nodeTypesStore = mockedStore(useNodeTypesStore);
+
+			const node = createTestNode({ id: '0' });
+			const nodeTypeDescription = mockNodeTypeDescription();
+			const workflowObject = createTestWorkflowObject(workflowsStore.workflow);
+
+			uiStore.lastInteractedWithNode = createTestNode({
+				position: [100, 100],
+				type: 'test',
+				typeVersion: 1,
+			});
+			uiStore.lastInteractedWithNodeHandle = `outputs/${NodeConnectionTypes.AiLanguageModel}/0`;
+			nodeTypesStore.getNodeType = vi.fn().mockReturnValue(nodeTypeDescription);
+			workflowsStore.getCurrentWorkflow.mockReturnValue(workflowObject);
+			workflowObject.getNode = vi.fn().mockReturnValue(node);
+
+			vi.spyOn(NodeHelpers, 'getNodeOutputs').mockReturnValueOnce([
+				{ type: NodeConnectionTypes.AiLanguageModel },
+			]);
+			vi.spyOn(NodeHelpers, 'getConnectionTypes')
+				.mockReturnValueOnce([])
+				.mockReturnValueOnce([])
+				.mockReturnValueOnce([NodeConnectionTypes.AiLanguageModel]);
+
+			const { resolveNodePosition } = useCanvasOperations();
+			const position = resolveNodePosition({ ...node, position: undefined }, nodeTypeDescription);
+
+			// Configuration node size is [200, 80], so customOffset = 200 * 2 = 400
+			// Expected position: [100 + (200/1) * 1 - 200/2 - 400, 100 + 220] = [-200, 320]
+			expect(position[0]).toBeLessThan(100); // Node should be moved left due to custom offset
+			expect(position[1]).toEqual(320); // Standard Y position for configuration nodes
+		});
+
+		it('should apply custom Y offset for AI Memory connection type', () => {
+			const uiStore = mockedStore(useUIStore);
+			const workflowsStore = mockedStore(useWorkflowsStore);
+			const nodeTypesStore = mockedStore(useNodeTypesStore);
+
+			const node = createTestNode({ id: '0' });
+			const nodeTypeDescription = mockNodeTypeDescription();
+			const workflowObject = createTestWorkflowObject(workflowsStore.workflow);
+
+			uiStore.lastInteractedWithNode = createTestNode({
+				position: [100, 100],
+				type: 'test',
+				typeVersion: 1,
+			});
+			uiStore.lastInteractedWithNodeHandle = `outputs/${NodeConnectionTypes.AiMemory}/0`;
+			nodeTypesStore.getNodeType = vi.fn().mockReturnValue(nodeTypeDescription);
+			workflowsStore.getCurrentWorkflow.mockReturnValue(workflowObject);
+			workflowObject.getNode = vi.fn().mockReturnValue(node);
+
+			vi.spyOn(NodeHelpers, 'getNodeOutputs').mockReturnValueOnce([
+				{ type: NodeConnectionTypes.AiMemory },
+			]);
+			vi.spyOn(NodeHelpers, 'getConnectionTypes')
+				.mockReturnValueOnce([])
+				.mockReturnValueOnce([])
+				.mockReturnValueOnce([NodeConnectionTypes.AiMemory]);
+
+			const { resolveNodePosition } = useCanvasOperations();
+			const position = resolveNodePosition({ ...node, position: undefined }, nodeTypeDescription);
+
+			expect(position[0]).toBeLessThan(100); // Node should be moved left due to custom offset
+			expect(position[1]).toEqual(320); // Standard Y position for configuration nodes
+		});
+
+		it('should not apply custom offset for regular connection types', () => {
+			const uiStore = mockedStore(useUIStore);
+			const workflowsStore = mockedStore(useWorkflowsStore);
+			const nodeTypesStore = mockedStore(useNodeTypesStore);
+
+			const node = createTestNode({ id: '0' });
+			const nodeTypeDescription = mockNodeTypeDescription();
+			const workflowObject = createTestWorkflowObject(workflowsStore.workflow);
+
+			uiStore.lastInteractedWithNode = createTestNode({
+				position: [100, 100],
+				type: 'test',
+				typeVersion: 1,
+			});
+			uiStore.lastInteractedWithNodeHandle = `outputs/${NodeConnectionTypes.AiTool}/0`;
+			nodeTypesStore.getNodeType = vi.fn().mockReturnValue(nodeTypeDescription);
+			workflowsStore.getCurrentWorkflow.mockReturnValue(workflowObject);
+			workflowObject.getNode = vi.fn().mockReturnValue(node);
+
+			vi.spyOn(NodeHelpers, 'getNodeOutputs').mockReturnValueOnce([
+				{ type: NodeConnectionTypes.AiTool },
+			]);
+			vi.spyOn(NodeHelpers, 'getConnectionTypes')
+				.mockReturnValueOnce([])
+				.mockReturnValueOnce([])
+				.mockReturnValueOnce([NodeConnectionTypes.AiTool]);
+
+			const { resolveNodePosition } = useCanvasOperations();
+			const position = resolveNodePosition({ ...node, position: undefined }, nodeTypeDescription);
+
+			// No custom offset applied
+			expect(position).toEqual([60, 320]);
+		});
+
+		it('should handle missing connection type gracefully', () => {
+			const uiStore = mockedStore(useUIStore);
+			const workflowsStore = mockedStore(useWorkflowsStore);
+			const nodeTypesStore = mockedStore(useNodeTypesStore);
+
+			const node = createTestNode({ id: '0' });
+			const nodeTypeDescription = mockNodeTypeDescription();
+			const workflowObject = createTestWorkflowObject(workflowsStore.workflow);
+
+			uiStore.lastInteractedWithNode = createTestNode({
+				position: [100, 100],
+				type: 'test',
+				typeVersion: 1,
+			});
+			// No lastInteractedWithNodeHandle set
+			nodeTypesStore.getNodeType = vi.fn().mockReturnValue(nodeTypeDescription);
+			workflowsStore.getCurrentWorkflow.mockReturnValue(workflowObject);
+			workflowObject.getNode = vi.fn().mockReturnValue(node);
+
+			vi.spyOn(NodeHelpers, 'getNodeOutputs').mockReturnValueOnce([
+				{ type: NodeConnectionTypes.AiTool },
+			]);
+			vi.spyOn(NodeHelpers, 'getConnectionTypes')
+				.mockReturnValueOnce([])
+				.mockReturnValueOnce([])
+				.mockReturnValueOnce([NodeConnectionTypes.AiTool]);
+
+			const { resolveNodePosition } = useCanvasOperations();
+			const position = resolveNodePosition({ ...node, position: undefined }, nodeTypeDescription);
+
+			// No custom offset applied
+			expect(position).toEqual([60, 320]);
+		});
 	});
 
 	describe('updateNodesPosition', () => {

--- a/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
@@ -1137,7 +1137,7 @@ export function useCanvasOperations() {
 				 */
 				const CUSTOM_Y_OFFSETS: Record<string, number> = {
 					[NodeConnectionTypes.AiLanguageModel]: nodeSize[0] * 2,
-					[NodeConnectionTypes.AiMemory]: nodeSize[1],
+					[NodeConnectionTypes.AiMemory]: nodeSize[0],
 				};
 
 				const customOffset: number = CUSTOM_Y_OFFSETS[connectionType as string] ?? 0;

--- a/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
@@ -1029,7 +1029,7 @@ export function useCanvasOperations() {
 
 		const nodeSize =
 			connectionType === NodeConnectionTypes.Main ? DEFAULT_NODE_SIZE : CONFIGURATION_NODE_SIZE;
-		let pushOffsets: XYPosition = [nodeSize[0] / 2, nodeSize[1] / 2];
+		const pushOffsets: XYPosition = [nodeSize[0] / 2, nodeSize[1] / 2];
 
 		let position: XYPosition | undefined = node.position;
 		if (position) {

--- a/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
@@ -1130,7 +1130,17 @@ export function useCanvasOperations() {
 				} catch (e) {}
 				const outputTypes = NodeHelpers.getConnectionTypes(outputs);
 
-				pushOffsets = [100, 0];
+				/**
+				 * Custom Y offsets for specific connection types when adding them using the plus button:
+				 * - AI Language Model: Moved left by 2 node widths
+				 * - AI Memory: Moved left by 1 node width
+				 */
+				const CUSTOM_Y_OFFSETS: Record<string, number> = {
+					[NodeConnectionTypes.AiLanguageModel]: nodeSize[0] * 2,
+					[NodeConnectionTypes.AiMemory]: nodeSize[1],
+				};
+
+				const customOffset: number = CUSTOM_Y_OFFSETS[connectionType as string] ?? 0;
 
 				if (
 					outputTypes.length > 0 &&
@@ -1152,7 +1162,8 @@ export function useCanvasOperations() {
 						lastInteractedWithNode.position[0] +
 							(CONFIGURABLE_NODE_SIZE[0] / lastInteractedWithNodeWidthDivisions) *
 								(scopedConnectionIndex + 1) -
-							nodeSize[0] / 2,
+							nodeSize[0] / 2 -
+							customOffset,
 						lastInteractedWithNode.position[1] + PUSH_NODES_OFFSET,
 					];
 				} else {


### PR DESCRIPTION
## Summary
Prevent connections from overlapping agent node `+` button when adding memory. This also pushes model nodes a bit to the left for better-looking distribution.

#### Before
![image](https://github.com/user-attachments/assets/2da44ac1-36ec-410b-b3da-4ef5bfb4f2c9)

#### After
![image](https://github.com/user-attachments/assets/9e68f06b-c6c1-4807-aaf5-40126d6b28f8)


## Related Linear tickets, Github issues, and Community forum posts
Fixes ADO-3417


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
