### PR TITLE
chore(core): Add inviteAcceptUrl to users list schema

### DIFF
--- a/packages/@n8n/api-types/src/schemas/user.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/user.schema.ts
@@ -37,6 +37,7 @@ export const userListItemSchema = z.object({
 	projectRelations: z.array(userProjectSchema).nullable().optional(),
 	mfaEnabled: z.boolean().optional(),
 	lastActiveAt: z.string().nullable().optional(),
+	inviteAcceptUrl: z.string().optional(),
 });
 
 export const usersListSchema = z.object({


### PR DESCRIPTION
## Summary

Exposes the `inviteAcceptUrl` to the users list

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-3022/expose-inviteaccepturl-in-users-list

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
