### PR TITLE
fix: Intercepts are defined before login (no-changelog)

### DIFF
--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -27,15 +27,13 @@ before(() => {
 });
 
 beforeEach(() => {
-	if (!cy.config('disableAutoLogin')) {
-		cy.signinAsOwner();
-	}
-
 	cy.window().then((win): void => {
 		win.localStorage.setItem('N8N_THEME', 'light');
 		win.localStorage.setItem('N8N_AUTOCOMPLETE_ONBOARDED', 'true');
 		win.localStorage.setItem('N8N_MAPPING_ONBOARDED', 'true');
 	});
+
+	// #region ===== Intercepts =====
 
 	cy.intercept('GET', '/rest/settings', (req) => {
 		// Disable cache
@@ -106,4 +104,10 @@ beforeEach(() => {
 			items: [],
 		},
 	).as('getWhatsNew');
+
+	// #endregion ===== Intercepts =====
+
+	if (!cy.config('disableAutoLogin')) {
+		cy.signinAsOwner();
+	}
 });


### PR DESCRIPTION


## Summary

Guarantees that network request interceptions are set up before the user authentication process begins. This resolves potential issues where requests made during the login sequence might not be correctly intercepted.

## Related Linear tickets, Github issues, and Community forum posts



## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
