### PR TITLE
fix(editor): Skip community node types request on preview mode (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/stores/nodeTypes.store.ts
+++ b/packages/frontend/editor-ui/src/stores/nodeTypes.store.ts
@@ -366,7 +366,7 @@ export const useNodeTypesStore = defineStore(STORES.NODE_TYPES, () => {
 	};
 
 	const fetchCommunityNodePreviews = async () => {
-		if (!settingsStore.isCommunityNodesFeatureEnabled) {
+		if (!settingsStore.isCommunityNodesFeatureEnabled || settingsStore.isPreviewMode) {
 			return;
 		}
 		try {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This request is behind authentication, and only populates the list of community nodes for the node creator. since that isn't available on the preview mode skip the request, which would fail anyways.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3782/preview-service-shows-error-connecting-to-n8n-error

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
