### PR TITLE
fix(editor): Sync log selection doesn't work for renamed nodes

### DIFF
--- a/packages/frontend/editor-ui/src/features/logs/components/LogDetailsPanel.vue
+++ b/packages/frontend/editor-ui/src/features/logs/components/LogDetailsPanel.vue
@@ -78,8 +78,7 @@ function handleResizeEnd() {
 				<div :class="$style.title">
 					<NodeIcon :node-type="type" :size="16" :class="$style.icon" />
 					<LogsViewNodeName
-						:latest-name="latestInfo?.name ?? logEntry.node.name"
-						:name="logEntry.node.name"
+						:name="latestInfo?.name ?? logEntry.node.name"
 						:is-deleted="latestInfo?.deleted ?? false"
 					/>
 					<LogsViewExecutionSummary

--- a/packages/frontend/editor-ui/src/features/logs/components/LogsOverviewRow.vue
+++ b/packages/frontend/editor-ui/src/features/logs/components/LogsOverviewRow.vue
@@ -131,8 +131,7 @@ watch(
 		<NodeIcon :node-type="type" :size="16" :class="$style.icon" />
 		<LogsViewNodeName
 			:class="$style.name"
-			:latest-name="latestInfo?.name ?? props.data.node.name"
-			:name="props.data.node.name"
+			:name="latestInfo?.name ?? props.data.node.name"
 			:is-error="isError"
 			:is-deleted="latestInfo?.deleted ?? false"
 		/>

--- a/packages/frontend/editor-ui/src/features/logs/components/LogsPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/logs/components/LogsPanel.test.ts
@@ -451,7 +451,7 @@ describe('LogsPanel', () => {
 		).toBeInTheDocument();
 		expect(within(rendered.getByRole('tree')).getByText('AI Model')).toBeInTheDocument();
 
-		canvasOperations.renameNode('AI Model', 'Renamed!!');
+		await canvasOperations.renameNode('AI Model', 'Renamed!!');
 
 		await waitFor(() => {
 			expect(
@@ -516,7 +516,7 @@ describe('LogsPanel', () => {
 			expect(await findByRole('treeitem', { selected: true })).toHaveTextContent(/AI Model/);
 		});
 
-		it('should automatically select log for a renamed node', async () => {
+		it("should automatically select a log for the selected node on canvas even after it's renamed", async () => {
 			const canvasOperations = useCanvasOperations();
 
 			workflowsStore.setWorkflow(deepCopy(aiChatWorkflow));
@@ -528,7 +528,7 @@ describe('LogsPanel', () => {
 
 			expect(await findByRole('treeitem', { selected: true })).toHaveTextContent(/AI Model/);
 
-			canvasOperations.renameNode('AI Agent', 'Renamed Agent');
+			await canvasOperations.renameNode('AI Agent', 'Renamed Agent');
 			uiStore.lastSelectedNode = 'Renamed Agent';
 
 			await rerender({});

--- a/packages/frontend/editor-ui/src/features/logs/components/LogsPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/logs/components/LogsPanel.test.ts
@@ -515,6 +515,25 @@ describe('LogsPanel', () => {
 			await rerender({});
 			expect(await findByRole('treeitem', { selected: true })).toHaveTextContent(/AI Model/);
 		});
+
+		it('should automatically select log for a renamed node', async () => {
+			const canvasOperations = useCanvasOperations();
+
+			workflowsStore.setWorkflow(deepCopy(aiChatWorkflow));
+			workflowsStore.setWorkflowExecutionData(deepCopy(aiChatExecutionResponse));
+
+			logsStore.toggleLogSelectionSync(true);
+
+			const { rerender, findByRole } = render();
+
+			expect(await findByRole('treeitem', { selected: true })).toHaveTextContent(/AI Model/);
+
+			canvasOperations.renameNode('AI Agent', 'Renamed Agent');
+			uiStore.lastSelectedNode = 'Renamed Agent';
+
+			await rerender({});
+			expect(await findByRole('treeitem', { selected: true })).toHaveTextContent(/Renamed Agent/);
+		});
 	});
 
 	describe('chat', () => {

--- a/packages/frontend/editor-ui/src/features/logs/components/LogsPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/logs/components/LogsPanel.test.ts
@@ -433,6 +433,34 @@ describe('LogsPanel', () => {
 		expect(rendered.queryByTestId('log-details-output')).not.toBeInTheDocument();
 	});
 
+	it('should show new name when a node is renamed', async () => {
+		const canvasOperations = useCanvasOperations();
+
+		logsStore.toggleOpen(true);
+
+		// Create deep copy so that renaming doesn't affect other test cases
+		workflowsStore.setWorkflow(deepCopy(aiChatWorkflow));
+		workflowsStore.setWorkflowExecutionData(deepCopy(aiChatExecutionResponse));
+
+		const rendered = render();
+
+		await nextTick();
+
+		expect(
+			within(rendered.getByTestId('log-details-header')).getByText('AI Model'),
+		).toBeInTheDocument();
+		expect(within(rendered.getByRole('tree')).getByText('AI Model')).toBeInTheDocument();
+
+		canvasOperations.renameNode('AI Model', 'Renamed!!');
+
+		await waitFor(() => {
+			expect(
+				within(rendered.getByTestId('log-details-header')).getByText('Renamed!!'),
+			).toBeInTheDocument();
+			expect(within(rendered.getByRole('tree')).getByText('Renamed!!')).toBeInTheDocument();
+		});
+	});
+
 	describe('selection', () => {
 		beforeEach(() => {
 			logsStore.toggleOpen(true);

--- a/packages/frontend/editor-ui/src/features/logs/components/LogsPanel.vue
+++ b/packages/frontend/editor-ui/src/features/logs/components/LogsPanel.vue
@@ -200,7 +200,7 @@ function handleOpenNdv(treeNode: LogEntry) {
 							:is-open="isOpen"
 							:log-entry="selected"
 							:window="pipWindow"
-							:latest-info="latestNodeNameById[selected.id]"
+							:latest-info="latestNodeNameById[selected.node.id]"
 							:panels="logsStore.detailsState"
 							@click-header="onToggleOpen(true)"
 							@toggle-input-open="logsStore.toggleInputOpen"

--- a/packages/frontend/editor-ui/src/features/logs/components/LogsViewNodeName.vue
+++ b/packages/frontend/editor-ui/src/features/logs/components/LogsViewNodeName.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
 import { N8nText } from '@n8n/design-system';
 
-const { name, latestName, isError, isDeleted } = defineProps<{
+const { name, isError, isDeleted } = defineProps<{
 	name: string;
-	latestName: string;
 	isError?: boolean;
 	isDeleted?: boolean;
 }>();
@@ -17,12 +16,12 @@ const { name, latestName, isError, isDeleted } = defineProps<{
 		:class="$style.name"
 		:color="isError ? 'danger' : undefined"
 	>
-		<del v-if="isDeleted || name !== latestName">
+		<del v-if="isDeleted">
 			{{ name }}
 		</del>
-		<span v-if="!isDeleted">
-			{{ latestName }}
-		</span>
+		<template v-else>
+			{{ name }}
+		</template>
 	</N8nText>
 </template>
 


### PR DESCRIPTION
## Summary
This PR fixes the bug where synchronizing node selection on canvas and the log view doesn't work after the node is renamed. Also it changes how renamed node is shown in the logs for clarity, from
> ~~old name~~ new name

to simply

> new name

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/SUG-87/sync-selection-with-canvas-in-logs-pane-doesnt-work-when-selecting


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
