### PR TITLE
fix(editor): Display error messages from AI service on status 500 errors

### DIFF
--- a/cypress/e2e/6-code-node.cy.ts
+++ b/cypress/e2e/6-code-node.cy.ts
@@ -180,7 +180,7 @@ return []
 				{ code: 400, message: 'Code generation failed due to an unknown reason' },
 				{ code: 413, message: 'Your workflow data is too large for AI to process' },
 				{ code: 429, message: "We've hit our rate limit with our AI partner" },
-				{ code: 500, message: 'Code generation failed due to an unknown reason' },
+				{ code: 500, message: 'Request failed with status code 500' },
 			];
 
 			handledCodes.forEach(({ code, message }) => {

--- a/packages/frontend/editor-ui/src/components/CodeNodeEditor/AskAI/AskAI.vue
+++ b/packages/frontend/editor-ui/src/components/CodeNodeEditor/AskAI/AskAI.vue
@@ -66,12 +66,12 @@ const isEachItemMode = computed(() => {
 	return mode === 'runOnceForEachItem';
 });
 
-function getErrorMessageByStatusCode(statusCode: number) {
+function getErrorMessageByStatusCode(statusCode: number, message: string | undefined): string {
 	const errorMessages: Record<number, string> = {
-		400: i18n.baseText('codeNodeEditor.askAi.generationFailedUnknown'),
-		413: i18n.baseText('codeNodeEditor.askAi.generationFailedTooLarge'),
-		429: i18n.baseText('codeNodeEditor.askAi.generationFailedRate'),
-		500: i18n.baseText('codeNodeEditor.askAi.generationFailedUnknown'),
+		[413]: i18n.baseText('codeNodeEditor.askAi.generationFailedTooLarge'),
+		[400]: i18n.baseText('codeNodeEditor.askAi.generationFailedUnknown'),
+		[429]: i18n.baseText('codeNodeEditor.askAi.generationFailedRate'),
+		[500]: message ?? i18n.baseText('codeNodeEditor.askAi.generationFailedUnknown'),
 	};
 
 	return errorMessages[statusCode] || i18n.baseText('codeNodeEditor.askAi.generationFailedUnknown');
@@ -189,7 +189,10 @@ async function onSubmit() {
 		showMessage({
 			type: 'error',
 			title: i18n.baseText('codeNodeEditor.askAi.generationFailed'),
-			message: getErrorMessageByStatusCode(error.httpStatusCode || error?.response.status),
+			message: getErrorMessageByStatusCode(
+				error.httpStatusCode || error?.response.status,
+				error?.message,
+			),
 		});
 		stopLoading();
 		useTelemetry().trackAskAI('askAi.generationFinished', {


### PR DESCRIPTION
## Summary

If our AI service returns errors we currently end up just displaying an unhelpful `Code generation failed due to an unknown reason. Try again in a few minutes.` message, even if the message would contain something helpful in debugging.

The real issue is that it looks like the AI client loses the error statuses that the underlying AI assistant service returns.

But as a remedy just show the message if its present.

<img width="370" alt="image" src="https://github.com/user-attachments/assets/f2809f24-127b-445b-adb6-6e2e1fc67ddc" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3749/ask-ai-error-message-is-not-helpful

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
