### PR TITLE
fix(Code Node): Only Block os.system vs Blocking import os

### DIFF
--- a/packages/nodes-base/nodes/Code/Pyodide.ts
+++ b/packages/nodes-base/nodes/Code/Pyodide.ts
@@ -28,29 +28,17 @@ export async function LoadPyodide(packageCacheDir: string): Promise<PyodideInter
 		)) as PyodideInterface;
 
 		await pyodideInstance.runPythonAsync(`
-blocked_modules = ["os"]
+import os
 
-import sys
-for module_name in blocked_modules:
-	del sys.modules[module_name]
+def blocked_system(*args, **kwargs):
+    raise RuntimeError("os.system is blocked for security reasons.")
+
+os.system = blocked_system
 
 from importlib.abc import MetaPathFinder
 from importlib.machinery import ModuleSpec
 from types import ModuleType
 from typing import Sequence, Optional
-
-class ImportBlocker(MetaPathFinder):
-	def find_spec(
-		self,
-		fullname: str,
-		path: Sequence[bytes | str] | None,
-		target: ModuleType | None = None,
-) -> Optional[ModuleSpec]:
-		if fullname in blocked_modules:
-				raise ModuleNotFoundError(f"Module {fullname!r} is blocked", name=fullname)
-		return None
-
-sys.meta_path.insert(0, ImportBlocker())
 
 from _pyodide_core import jsproxy_typedict
 from js import Object


### PR DESCRIPTION
## Summary

Improve the previous PR below. Rather than blocking the entire os module, since os is needed for many, many imports, let's just block the os.system call.

https://github.com/n8n-io/n8n/pull/15970

⚠️ It should be noted, os.system shouldn't work in the first place since Pyodide shouldn't have the ability to spawn subprocesses. I suppose it's fine to block just for "theater" purposes, but it's not like the subprocess module is explicitly blocked currently, which would have the same abilities (but also doesn't work in Pyodide).

## Related Linear tickets, Github issues, and Community forum posts

closes https://github.com/n8n-io/n8n/issues/16532
closes #15583

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
