### PR TITLE
fix(editor): Make search work for "rendered" display type

### DIFF
--- a/packages/frontend/editor-ui/src/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/components/RunData.vue
@@ -1886,7 +1886,12 @@ defineExpose({ enterEditMode });
 			</Suspense>
 
 			<Suspense v-else-if="hasNodeRun && displayMode === 'ai'">
-				<LazyRunDataAi render-type="rendered" :compact="compact" :content="parsedAiContent" />
+				<LazyRunDataAi
+					render-type="rendered"
+					:compact="compact"
+					:content="parsedAiContent"
+					:search="search"
+				/>
 			</Suspense>
 
 			<Suspense v-else-if="(hasNodeRun || hasPreviewSchema) && isSchemaView">

--- a/packages/frontend/editor-ui/src/components/RunDataParsedAiContent.test.ts
+++ b/packages/frontend/editor-ui/src/components/RunDataParsedAiContent.test.ts
@@ -46,6 +46,29 @@ describe('RunDataParsedAiContent', () => {
 		expect(rendered.getByText('markdown', { selector: 'em' })).toBeInTheDocument();
 	});
 
+	it('highlight matches to the search keyword in markdown', () => {
+		const rendered = renderComponent({
+			renderType: 'rendered',
+			content: [
+				{
+					raw: {},
+					parsedContent: {
+						type: 'markdown',
+						data: 'The **quick** brown fox jumps over the ~~lazy~~ dog',
+						parsed: true,
+					},
+				},
+			],
+			search: 'the',
+		});
+
+		const marks = rendered.container.querySelectorAll('mark');
+
+		expect(marks).toHaveLength(2);
+		expect(marks[0]).toHaveTextContent('The');
+		expect(marks[1]).toHaveTextContent('the');
+	});
+
 	it('renders AI content parsed as JSON', () => {
 		const rendered = renderComponent({
 			renderType: 'rendered',
@@ -70,5 +93,18 @@ describe('RunDataParsedAiContent', () => {
 		expect(
 			rendered.getByText('{ "key": "value" }', { selector: 'code', exact: false }),
 		).toBeInTheDocument();
+	});
+
+	it.todo('highlight matches to the search keyword in raw data', () => {
+		const rendered = renderComponent({
+			renderType: 'rendered',
+			content: [{ raw: { key: 'value' }, parsedContent: null }],
+			search: 'key',
+		});
+
+		const marks = rendered.container.querySelectorAll('mark');
+
+		expect(marks).toHaveLength(1);
+		expect(marks[0]).toHaveTextContent('key');
 	});
 });

--- a/packages/frontend/editor-ui/src/components/RunDataParsedAiContent.test.ts
+++ b/packages/frontend/editor-ui/src/components/RunDataParsedAiContent.test.ts
@@ -95,7 +95,73 @@ describe('RunDataParsedAiContent', () => {
 		).toBeInTheDocument();
 	});
 
-	it.todo('highlight matches to the search keyword in raw data', () => {
+	it('highlight matches to the search keyword in inline code in markdown', () => {
+		const rendered = renderComponent({
+			renderType: 'rendered',
+			content: [
+				{
+					raw: {},
+					parsedContent: {
+						type: 'markdown',
+						data: 'The `quick brown fox` jumps over the lazy dog',
+						parsed: true,
+					},
+				},
+			],
+			search: 'fox',
+		});
+
+		const marks = rendered.container.querySelectorAll('mark');
+
+		expect(marks).toHaveLength(1);
+		expect(marks[0]).toHaveTextContent('fox');
+	});
+
+	it('highlight matches to the search keyword in a code block in markdown', () => {
+		const rendered = renderComponent({
+			renderType: 'rendered',
+			content: [
+				{
+					raw: {},
+					parsedContent: {
+						type: 'markdown',
+						data: 'Code:\n\n    quickFox.jump({ over: lazyDog });\n',
+						parsed: true,
+					},
+				},
+			],
+			search: 'fox',
+		});
+
+		const marks = rendered.container.querySelectorAll('mark');
+
+		expect(marks).toHaveLength(1);
+		expect(marks[0]).toHaveTextContent('Fox');
+	});
+
+	it('highlight matches to the search keyword in fence syntax in markdown', () => {
+		const rendered = renderComponent({
+			renderType: 'rendered',
+			content: [
+				{
+					raw: {},
+					parsedContent: {
+						type: 'markdown',
+						data: '```\nquickFox.jump({ over: lazyDog });\n```',
+						parsed: true,
+					},
+				},
+			],
+			search: 'fox',
+		});
+
+		const marks = rendered.container.querySelectorAll('mark');
+
+		expect(marks).toHaveLength(1);
+		expect(marks[0]).toHaveTextContent('Fox');
+	});
+
+	it('highlight matches to the search keyword in raw data', () => {
 		const rendered = renderComponent({
 			renderType: 'rendered',
 			content: [{ raw: { key: 'value' }, parsedContent: null }],

--- a/packages/frontend/editor-ui/src/components/RunDataParsedAiContent.vue
+++ b/packages/frontend/editor-ui/src/components/RunDataParsedAiContent.vue
@@ -9,8 +9,9 @@ import VueMarkdown from 'vue-markdown-render';
 import hljs from 'highlight.js/lib/core';
 import { splitTextBySearch } from '@/utils/stringUtils';
 import { escapeHtml } from 'xss';
-import { type Token } from 'markdown-it';
+import type MarkdownIt from 'markdown-it';
 import { computed } from 'vue';
+import { unescapeAll } from 'markdown-it/lib/common/utils';
 
 const {
 	content,
@@ -27,6 +28,60 @@ const {
 const i18n = useI18n();
 const clipboard = useClipboard();
 const { showMessage } = useToast();
+
+const vueMarkdownPlugins = computed(() => {
+	function createHtmlFragmentWithSearchHighlight(text: string): string {
+		const escaped = escapeHtml(text);
+
+		if (!search) {
+			return escaped;
+		}
+
+		const parts: string[] = [];
+
+		for (const part of splitTextBySearch(escaped, search ?? '')) {
+			parts.push(part.isMatched ? `<mark>${part.content}</mark>` : part.content);
+		}
+
+		return parts.join('');
+	}
+
+	function searchHighlightPlugin(md: MarkdownIt) {
+		md.renderer.rules.text = (tokens, idx) =>
+			createHtmlFragmentWithSearchHighlight(tokens[idx].content);
+
+		md.renderer.rules.code_inline = (tokens, idx, _, __, slf) =>
+			`<code${slf.renderAttrs(tokens[idx])}>${createHtmlFragmentWithSearchHighlight(tokens[idx].content)}</code>`;
+
+		md.renderer.rules.code_block = (tokens, idx, _, __, slf) =>
+			`<pre${slf.renderAttrs(tokens[idx])}><code>${createHtmlFragmentWithSearchHighlight(tokens[idx].content)}</code></pre>\n`;
+
+		md.renderer.rules.fence = (tokens, idx, options, _, slf) => {
+			const token = tokens[idx];
+			const info = token.info ? unescapeAll(token.info).trim() : '';
+			let langName = '';
+			let langAttrs = '';
+
+			if (info) {
+				const arr = info.split(/(\s+)/g);
+				langName = arr[0];
+				langAttrs = arr.slice(2).join('');
+			}
+
+			const highlighted =
+				options.highlight?.(token.content, langName, langAttrs) ??
+				createHtmlFragmentWithSearchHighlight(token.content);
+
+			if (highlighted.indexOf('<pre') === 0) {
+				return highlighted + '\n';
+			}
+
+			return `<pre><code${slf.renderAttrs(token)}>${highlighted}</code></pre>\n`;
+		};
+	}
+
+	return [searchHighlightPlugin];
+});
 
 function isJsonString(text: string) {
 	try {
@@ -45,7 +100,7 @@ const markdownOptions = {
 			} catch {}
 		}
 
-		return ''; // use external default escaping
+		return undefined; // use external default escaping
 	},
 };
 
@@ -98,27 +153,6 @@ function onCopyToClipboard(object: IDataObject | IDataObject[]) {
 		});
 	} catch {}
 }
-
-const vueMarkdownPlugins = computed(() => [
-	(md: { renderer: { rules: { text: (tokens: Token[], idx: number) => string } } }) => {
-		debugger;
-		md.renderer.rules.text = (tokens, idx) => {
-			const escaped = escapeHtml(tokens[idx].content);
-
-			if (!search) {
-				return escaped;
-			}
-
-			const parts: string[] = [];
-
-			for (const part of splitTextBySearch(escaped, search ?? '')) {
-				parts.push(part.isMatched ? `<mark>${part.content}</mark>` : part.content);
-			}
-
-			return parts.join('');
-		};
-	},
-]);
 </script>
 
 <template>

--- a/packages/frontend/editor-ui/src/components/TextWithHighlights.vue
+++ b/packages/frontend/editor-ui/src/components/TextWithHighlights.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import { splitTextBySearch } from '@/utils/stringUtils';
 import type { GenericValue } from 'n8n-workflow';
 import { computed } from 'vue';
 
@@ -6,26 +7,6 @@ const props = defineProps<{
 	content: GenericValue;
 	search?: string;
 }>();
-
-const splitTextBySearch = (
-	text = '',
-	search = '',
-): Array<{ tag: 'span' | 'mark'; content: string }> => {
-	if (!search) {
-		return [
-			{
-				tag: 'span',
-				content: text,
-			},
-		];
-	}
-
-	const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
-	const pattern = new RegExp(`(${escapeRegExp(search)})`, 'i');
-	const splitText = text.split(pattern);
-
-	return splitText.map((t) => ({ tag: pattern.test(t) ? 'mark' : 'span', content: t }));
-};
 
 const parts = computed(() => {
 	return props.search && typeof props.content === 'string'
@@ -37,9 +18,9 @@ const parts = computed(() => {
 <template>
 	<span v-if="parts.length && typeof props.content === 'string'">
 		<template v-for="(part, index) in parts">
-			<mark v-if="part.tag === 'mark' && part.content" :key="`mark-${index}`">{{
-				part.content
-			}}</mark>
+			<mark v-if="part.isMatched && part.content" :key="`mark-${index}`">
+				{{ part.content }}
+			</mark>
 			<span v-else-if="part.content" :key="`span-${index}`">{{ part.content }}</span>
 		</template>
 	</span>

--- a/packages/frontend/editor-ui/src/components/__snapshots__/VirtualSchema.test.ts.snap
+++ b/packages/frontend/editor-ui/src/components/__snapshots__/VirtualSchema.test.ts.snap
@@ -2762,15 +2762,9 @@ exports[`VirtualSchema.vue > should expand all nodes when searching 1`] = `
           >
             
             
-            <!--v-if-->
-            
-            
             <mark>
               John
             </mark>
-            
-            
-            <!--v-if-->
             
             
           </span>
@@ -2900,15 +2894,9 @@ exports[`VirtualSchema.vue > should expand all nodes when searching 1`] = `
           >
             
             
-            <!--v-if-->
-            
-            
             <mark>
               John
             </mark>
-            
-            
-            <!--v-if-->
             
             
           </span>

--- a/packages/frontend/editor-ui/src/utils/stringUtils.test.ts
+++ b/packages/frontend/editor-ui/src/utils/stringUtils.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect } from 'vitest';
+import { splitTextBySearch } from './stringUtils';
+
+describe(splitTextBySearch, () => {
+	it('should return one element with isMatched=false if search text is empty', () => {
+		expect(splitTextBySearch('The quick brown fox jumps over the lazy dog', '')).toEqual([
+			{ isMatched: false, content: 'The quick brown fox jumps over the lazy dog' },
+		]);
+	});
+
+	it('should split given text by matches to the search', () => {
+		expect(splitTextBySearch('The quick brown fox jumps over the lazy dog', 'quick')).toEqual([
+			{ isMatched: false, content: 'The ' },
+			{ isMatched: true, content: 'quick' },
+			{ isMatched: false, content: ' brown fox jumps over the lazy dog' },
+		]);
+	});
+
+	it('should match case insensitive', () => {
+		expect(splitTextBySearch('The quick brown fox jumps over the lazy dog', 'Quick')).toEqual([
+			{ isMatched: false, content: 'The ' },
+			{ isMatched: true, content: 'quick' },
+			{ isMatched: false, content: ' brown fox jumps over the lazy dog' },
+		]);
+	});
+
+	it('should match all occurrences', () => {
+		expect(splitTextBySearch('The quick brown fox jumps over the lazy dog', 'the')).toEqual([
+			{ isMatched: true, content: 'The' },
+			{ isMatched: false, content: ' quick brown fox jumps over ' },
+			{ isMatched: true, content: 'the' },
+			{ isMatched: false, content: ' lazy dog' },
+		]);
+	});
+});

--- a/packages/frontend/editor-ui/src/utils/stringUtils.ts
+++ b/packages/frontend/editor-ui/src/utils/stringUtils.ts
@@ -1,0 +1,16 @@
+export function splitTextBySearch(
+	text: string,
+	search: string,
+): Array<{ isMatched: boolean; content: string }> {
+	if (!search) {
+		return [{ isMatched: false, content: text }];
+	}
+
+	const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+	const pattern = new RegExp(`(${escapeRegExp(search)})`, 'i');
+
+	return text
+		.split(pattern)
+		.map((part) => ({ isMatched: pattern.test(part), content: part }))
+		.filter((part) => part.content !== '');
+}

--- a/packages/frontend/editor-ui/src/utils/stringUtils.ts
+++ b/packages/frontend/editor-ui/src/utils/stringUtils.ts
@@ -1,3 +1,10 @@
+/**
+ * Split given text by the search term
+ *
+ * @param text Text to split
+ * @param search The search term
+ * @returns An array containing splitted text, each containing text fragment and the match flag.
+ */
 export function splitTextBySearch(
 	text: string,
 	search: string,


### PR DESCRIPTION
## Summary

This PR fix the keyword search in the log view's input/output panel to work when "rendered" display mode is selected.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/SUG-82/bug-text-search-not-working-for-rendered-display-mode


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
