### PR TITLE
fix(editor): Clear error states before copy to editor action

### DIFF
--- a/packages/frontend/editor-ui/src/composables/useExecutionDebugging.ts
+++ b/packages/frontend/editor-ui/src/composables/useExecutionDebugging.ts
@@ -98,6 +98,7 @@ export const useExecutionDebugging = () => {
 		}
 
 		// Set execution data
+		workflowsStore.resetAllNodesIssues();
 		workflowsStore.setWorkflowExecutionData(execution);
 
 		// Pin data of all nodes which do not have a parent node


### PR DESCRIPTION
## Summary

Remove all issues from the workflow execution state before applying the new state.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-2683/bug-errors-arent-cleared-when-copying-to-editor

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
