### PR TITLE
feat: add workflow data proxy to webhook nodes

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/__tests__/webhook-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/webhook-context.test.ts
@@ -158,4 +158,20 @@ describe('WebhookContext', () => {
 			expect(parameter).toBe('fallback');
 		});
 	});
+
+	describe('getWorkflowDataProxy', () => {
+		it('should return the workflow data proxy', () => {
+			const workflowDataProxy = webhookContext.getWorkflowDataProxy(0);
+			expect(workflowDataProxy).toBeDefined();
+			expect(workflowDataProxy.$execution.customData.getAll()).toEqual({});
+		});
+
+		it('should return the workflow data proxy with custom data', () => {
+			const workflowDataProxy = webhookContext.getWorkflowDataProxy(0);
+			workflowDataProxy.$execution.customData.setAll({
+				key1: 'test',
+			});
+			expect(workflowDataProxy.$execution.customData.getAll()).toEqual({ key1: 'test' });
+		});
+	});
 });

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/webhook-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/webhook-context.test.ts
@@ -160,10 +160,17 @@ describe('WebhookContext', () => {
 	});
 
 	describe('getWorkflowDataProxy', () => {
-		it('should return the workflow data proxy', () => {
+		it('should return the workflow data proxy correctly', () => {
 			const workflowDataProxy = webhookContext.getWorkflowDataProxy(0);
-			expect(workflowDataProxy).toBeDefined();
-			expect(workflowDataProxy.$execution.customData.getAll()).toEqual({});
+			expect(workflowDataProxy.isProxy).toBe(true);
+			expect(Object.keys(workflowDataProxy.$input)).toEqual([
+				'all',
+				'context',
+				'first',
+				'item',
+				'last',
+				'params',
+			]);
 		});
 
 		it('should return the workflow data proxy with custom data', () => {

--- a/packages/core/src/execution-engine/node-execution-context/webhook-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/webhook-context.ts
@@ -177,7 +177,7 @@ export class WebhookContext extends NodeExecutionContext implements IWebhookFunc
 		return await getInputConnectionData.call(
 			this,
 			this.workflow,
-			this.runExecutionData!,
+			this.runExecutionData ?? { resultData: { runData: {} } },
 			this.runIndex,
 			connectionInputData,
 			{} as ITaskDataConnections,

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1098,6 +1098,7 @@ export interface IHookFunctions
 export interface IWebhookFunctions extends FunctionsBaseWithRequiredKeys<'getMode'> {
 	getBodyData(): IDataObject;
 	getHeaderData(): IncomingHttpHeaders;
+	getWorkflowDataProxy(itemIndex: number): IWorkflowDataProxyData;
 	getInputConnectionData(
 		connectionType: AINodeConnectionType,
 		itemIndex: number,


### PR DESCRIPTION
## Summary

This PR adds `getWorkflowDataProxy` to Webhook nodes. This enables webhook nodes to customize execution data similar to other nodes (e.g: [Execution Data node](https://github.com/n8n-io/n8n/blob/master/packages/nodes-base/nodes/ExecutionData/ExecutionData.node.ts#L132)):
```ts
async webhook(ctx: IWebhookFunctions): Promise<IWebhookResponseData> {
  const proxy = await ctx.getWorkflowDataProxy(0)
  // I expect that this data will be added to execution logs as metadata
  // as per https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.executiondata/
  proxy.$execution.customData.setAll({
    sessionId: 'abc123',
    userId: 'user456'
  })

  // ...
}
```

Webhook nodes can now use the same execution data customization capabilities as other node types, providing consistency across the n8n execution engine while maintaining backward compatibility.

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

resolves: https://community.n8n.io/t/execution-data-cannot-be-modified-via-custom-trigger-node/142331

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
