### PR TITLE
fix(Google Sheets Node): Include all headers

### DIFF
--- a/packages/nodes-base/nodes/Evaluation/test/evaluationTriggerUtils.test.ts
+++ b/packages/nodes-base/nodes/Evaluation/test/evaluationTriggerUtils.test.ts
@@ -62,6 +62,7 @@ describe('getFilteredResults', () => {
 				rangeDefinition: 'specifyRange',
 				headerRow: 1,
 				firstDataRow: startingRow,
+				includeHeadersWithEmptyCells: true,
 			},
 		);
 

--- a/packages/nodes-base/nodes/Evaluation/utils/evaluationTriggerUtils.ts
+++ b/packages/nodes-base/nodes/Evaluation/utils/evaluationTriggerUtils.ts
@@ -104,7 +104,7 @@ export async function getResults(
 		this.getNode().typeVersion,
 		[],
 		undefined,
-		rangeOptions,
+		{ ...rangeOptions, includeEmptyColumns: true },
 	);
 
 	return operationResult;

--- a/packages/nodes-base/nodes/Evaluation/utils/evaluationTriggerUtils.ts
+++ b/packages/nodes-base/nodes/Evaluation/utils/evaluationTriggerUtils.ts
@@ -54,6 +54,7 @@ export async function getFilteredResults(
 			rangeDefinition: 'specifyRange',
 			headerRow: 1,
 			firstDataRow: startingRow,
+			includeHeadersWithEmptyCells: true,
 		},
 	);
 

--- a/packages/nodes-base/nodes/Evaluation/utils/evaluationTriggerUtils.ts
+++ b/packages/nodes-base/nodes/Evaluation/utils/evaluationTriggerUtils.ts
@@ -104,7 +104,7 @@ export async function getResults(
 		this.getNode().typeVersion,
 		[],
 		undefined,
-		{ ...rangeOptions, includeEmptyColumns: true },
+		{ ...rangeOptions, includeHeadersWithEmptyCells: true },
 	);
 
 	return operationResult;

--- a/packages/nodes-base/nodes/Google/Sheet/test/v2/helpers/GoogleSheet.test.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/test/v2/helpers/GoogleSheet.test.ts
@@ -100,6 +100,28 @@ describe('GoogleSheet', () => {
 				{ name: 'Jane', age: '25' },
 			]);
 		});
+
+		it('should handle empty columns when includeHeadersWithEmptyCells is true', () => {
+			const data = [
+				['name', 'age'],
+				['John', '30'],
+				['MARY', ''],
+				['Jane', '25'],
+			];
+			const result = googleSheet.convertSheetDataArrayToObjectArray(
+				data,
+				1,
+				['name', 'age'],
+				false,
+				true,
+			);
+
+			expect(result).toEqual([
+				{ name: 'John', age: '30' },
+				{ name: 'MARY', age: '' },
+				{ name: 'Jane', age: '25' },
+			]);
+		});
 	});
 
 	describe('lookupValues', () => {

--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/utils/readOperation.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/utils/readOperation.ts
@@ -33,6 +33,8 @@ export async function readSheet(
 		dataLocationOnSheetOptions.rangeDefinition = 'detectAutomatically';
 	}
 
+	const includeEmptyColumns = (additionalOptions?.includeEmptyColumns as boolean) ?? false;
+
 	const range = rangeString ?? getRangeString(sheetName, dataLocationOnSheetOptions);
 
 	const valueRenderMode = (outputFormattingOption.general ||
@@ -95,7 +97,12 @@ export async function readSheet(
 			combineFilters,
 		});
 	} else {
-		responseData = sheet.structureArrayDataByColumn(inputData, keyRowIndex, dataStartRowIndex);
+		responseData = sheet.structureArrayDataByColumn(
+			inputData,
+			keyRowIndex,
+			dataStartRowIndex,
+			includeEmptyColumns,
+		);
 	}
 
 	returnData.push(

--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/utils/readOperation.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/utils/readOperation.ts
@@ -33,7 +33,8 @@ export async function readSheet(
 		dataLocationOnSheetOptions.rangeDefinition = 'detectAutomatically';
 	}
 
-	const includeEmptyColumns = (additionalOptions?.includeEmptyColumns as boolean) ?? false;
+	const includeHeadersWithEmptyCells =
+		(additionalOptions?.includeHeadersWithEmptyCells as boolean) ?? false;
 
 	const range = rangeString ?? getRangeString(sheetName, dataLocationOnSheetOptions);
 
@@ -101,7 +102,7 @@ export async function readSheet(
 			inputData,
 			keyRowIndex,
 			dataStartRowIndex,
-			includeEmptyColumns,
+			includeHeadersWithEmptyCells,
 		);
 	}
 

--- a/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheet.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheet.ts
@@ -317,7 +317,7 @@ export class GoogleSheet {
 	 * Returns the given sheet data in a structured way
 	 */
 	convertSheetDataArrayToObjectArray(
-		data: SheetRangeData,
+		sheet: SheetRangeData,
 		startRow: number,
 		columnKeys: string[],
 		addEmpty?: boolean,
@@ -325,16 +325,16 @@ export class GoogleSheet {
 	): IDataObject[] {
 		const returnData = [];
 
-		for (let rowIndex = startRow; rowIndex < data.length; rowIndex++) {
+		for (let rowIndex = startRow; rowIndex < sheet.length; rowIndex++) {
 			const item: IDataObject = {};
 
-			const rowCount = data[rowIndex].length;
+			const rowCount = sheet[rowIndex].length;
 			const columnCount = includeHeadersWithEmptyCells ? columnKeys.length : rowCount;
 
 			for (let columnIndex = 0; columnIndex < columnCount; columnIndex++) {
 				const key = columnKeys[columnIndex];
 				if (key) {
-					item[key] = data[rowIndex][columnIndex] || '';
+					item[key] = sheet[rowIndex][columnIndex] || '';
 				}
 			}
 

--- a/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheet.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheet.ts
@@ -321,17 +321,23 @@ export class GoogleSheet {
 		startRow: number,
 		columnKeys: string[],
 		addEmpty?: boolean,
+		includeEmptyColumns?: boolean,
 	): IDataObject[] {
 		const returnData = [];
 
 		for (let rowIndex = startRow; rowIndex < data.length; rowIndex++) {
 			const item: IDataObject = {};
-			for (let columnIndex = 0; columnIndex < data[rowIndex].length; columnIndex++) {
+
+			const rowCount = data[rowIndex].length;
+			const columnCount = includeEmptyColumns ? columnKeys.length : rowCount;
+
+			for (let columnIndex = 0; columnIndex < columnCount; columnIndex++) {
 				const key = columnKeys[columnIndex];
 				if (key) {
-					item[key] = data[rowIndex][columnIndex];
+					item[key] = data[rowIndex][columnIndex] || '';
 				}
 			}
+
 			if (Object.keys(item).length || addEmpty === true) {
 				returnData.push(item);
 			}
@@ -348,6 +354,7 @@ export class GoogleSheet {
 		inputData: string[][],
 		keyRow: number,
 		dataStartRow: number,
+		includeEmptyColumns?: boolean,
 	): IDataObject[] {
 		const keys: string[] = [];
 
@@ -361,7 +368,13 @@ export class GoogleSheet {
 			keys.push(inputData[keyRow][columnIndex] || `col_${columnIndex}`);
 		}
 
-		return this.convertSheetDataArrayToObjectArray(inputData, dataStartRow, keys);
+		return this.convertSheetDataArrayToObjectArray(
+			inputData,
+			dataStartRow,
+			keys,
+			false,
+			includeEmptyColumns,
+		);
 	}
 
 	testFilter(inputData: string[][], keyRow: number, dataStartRow: number): string[] {

--- a/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheet.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheet.ts
@@ -321,7 +321,7 @@ export class GoogleSheet {
 		startRow: number,
 		columnKeys: string[],
 		addEmpty?: boolean,
-		includeEmptyColumns?: boolean,
+		includeHeadersWithEmptyCells?: boolean,
 	): IDataObject[] {
 		const returnData = [];
 
@@ -329,7 +329,7 @@ export class GoogleSheet {
 			const item: IDataObject = {};
 
 			const rowCount = data[rowIndex].length;
-			const columnCount = includeEmptyColumns ? columnKeys.length : rowCount;
+			const columnCount = includeHeadersWithEmptyCells ? columnKeys.length : rowCount;
 
 			for (let columnIndex = 0; columnIndex < columnCount; columnIndex++) {
 				const key = columnKeys[columnIndex];
@@ -354,7 +354,7 @@ export class GoogleSheet {
 		inputData: string[][],
 		keyRow: number,
 		dataStartRow: number,
-		includeEmptyColumns?: boolean,
+		includeHeadersWithEmptyCells?: boolean,
 	): IDataObject[] {
 		const keys: string[] = [];
 
@@ -373,7 +373,7 @@ export class GoogleSheet {
 			dataStartRow,
 			keys,
 			false,
-			includeEmptyColumns,
+			includeHeadersWithEmptyCells,
 		);
 	}
 


### PR DESCRIPTION
## Summary

When the number of headers in a sheet is more than the number of items
in a row, this causes values to be missing. This was causing the evaluation trigger to return an inaccurate number columns, which cause the evaluation node to overwrite.

To test:

1. Setup a Google Sheet like this. Note that Column C, first row has a value but the other rows in Column C are empty.
<img width="560" alt="Screenshot 2025-07-02 at 17 02 16" src="https://github.com/user-attachments/assets/0d2bc358-081d-424a-8b52-3cc0035e4168" />

2. Use this workflow

```
{
  "nodes": [
    {
      "parameters": {
        "documentId": {
          "__rl": true,
          "value": "1oqFpPgEPTGDw7BPkp1SfPXq3Cb3Hyr1SROtf-Ec4zvA",
          "mode": "list",
          "cachedResultName": "my sheet",
          "cachedResultUrl": "https://docs.google.com/spreadsheets/d/1oqFpPgEPTGDw7BPkp1SfPXq3Cb3Hyr1SROtf-Ec4zvA/edit?usp=drivesdk"
        },
        "sheetName": {
          "__rl": true,
          "value": 1944804301,
          "mode": "list",
          "cachedResultName": "davidbug",
          "cachedResultUrl": "https://docs.google.com/spreadsheets/d/1oqFpPgEPTGDw7BPkp1SfPXq3Cb3Hyr1SROtf-Ec4zvA/edit#gid=1944804301"
        },
        "limitRows": true
      },
      "type": "n8n-nodes-base.evaluationTrigger",
      "typeVersion": 4.6,
      "position": [
        -480,
        160
      ],
      "id": "3a1f0a22-a0d8-4026-8ccd-1c348daf7dd0",
      "name": "When fetching a dataset row",
      "credentials": {
        "googleSheetsOAuth2Api": {
          "id": "jxkDDD4FYFxW5o7W",
          "name": "Google Sheets account 2"
        }
      }
    },
    {
      "parameters": {
        "assignments": {
          "assignments": [
            {
              "id": "1a586375-0f84-4992-98f5-081b87e472fd",
              "name": "message.content.category",
              "value": "err",
              "type": "string"
            }
          ]
        },
        "options": {}
      },
      "type": "n8n-nodes-base.set",
      "typeVersion": 3.4,
      "position": [
        32,
        160
      ],
      "id": "9889f1db-60de-427d-bbe6-a9b1233981d7",
      "name": "Edit Fields"
    },
    {
      "parameters": {
        "documentId": {
          "__rl": true,
          "value": "1oqFpPgEPTGDw7BPkp1SfPXq3Cb3Hyr1SROtf-Ec4zvA",
          "mode": "list",
          "cachedResultName": "my sheet",
          "cachedResultUrl": "https://docs.google.com/spreadsheets/d/1oqFpPgEPTGDw7BPkp1SfPXq3Cb3Hyr1SROtf-Ec4zvA/edit?usp=drivesdk"
        },
        "sheetName": {
          "__rl": true,
          "value": 1944804301,
          "mode": "list",
          "cachedResultName": "davidbug",
          "cachedResultUrl": "https://docs.google.com/spreadsheets/d/1oqFpPgEPTGDw7BPkp1SfPXq3Cb3Hyr1SROtf-Ec4zvA/edit#gid=1944804301"
        },
        "outputs": {
          "values": [
            {
              "outputName": "classification_test",
              "outputValue": "={{ $json.message.content.category.concat(\"50\") }}"
            }
          ]
        }
      },
      "type": "n8n-nodes-base.evaluation",
      "typeVersion": 4.6,
      "position": [
        352,
        160
      ],
      "id": "16cadd36-49c2-4cff-aaa2-414370e52dcd",
      "name": "Set output",
      "credentials": {
        "googleSheetsOAuth2Api": {
          "id": "jxkDDD4FYFxW5o7W",
          "name": "Google Sheets account 2"
        }
      }
    }
  ],
  "connections": {
    "When fetching a dataset row": {
      "main": [
        [
          {
            "node": "Edit Fields",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Edit Fields": {
      "main": [
        [
          {
            "node": "Set output",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {},
  "meta": {
    "instanceId": "ee90fdf8d57662f949e6c691dc07fa0fd2f66e1eee28ed82ef06658223e67255"
  }
}
```
3. Observe that the `rating` column does not get overwritten

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3200/bug-evals-set-output-op-overwrites-wrong-column
fixes [16923](https://github.com/n8n-io/n8n/issues/16923)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
