### PR TITLE
chore(core): Load OIDC module at runtime when license enables feature

### DIFF
--- a/packages/@n8n/backend-common/src/license-state.ts
+++ b/packages/@n8n/backend-common/src/license-state.ts
@@ -3,6 +3,7 @@ import { UNLIMITED_LICENSE_QUOTA } from '@n8n/constants';
 import { Service } from '@n8n/di';
 import { UnexpectedError } from 'n8n-workflow';
 
+import { Logger } from './logging';
 import type { FeatureChangedCallback, FeatureReturnType, LicenseProvider } from './types';
 
 class ProviderNotSetError extends UnexpectedError {
@@ -18,6 +19,8 @@ export class LicenseState {
 
 	onChangeCallbacks: FeatureChangedCallback[] = [];
 
+	constructor(private readonly logger: Logger) {}
+
 	setLicenseProvider(provider: LicenseProvider) {
 		if (this.cleanup !== null) {
 			this.cleanup();
@@ -25,6 +28,9 @@ export class LicenseState {
 		}
 		this.licenseProvider = provider;
 		this.cleanup = this.licenseProvider.addOnChangeCallback(() => {
+			this.logger.debug('License state changed, License state notified', {
+				cbs: this.onChangeCallbacks,
+			});
 			this.notifyOnChange();
 		});
 	}
@@ -45,6 +51,9 @@ export class LicenseState {
 	}
 
 	private notifyOnChange() {
+		this.logger.debug('License state changed, notifying callbacks, in license state', {
+			cbs: this.onChangeCallbacks,
+		});
 		this.onChangeCallbacks.forEach((notifier) => {
 			try {
 				notifier();

--- a/packages/@n8n/backend-common/src/types.ts
+++ b/packages/@n8n/backend-common/src/types.ts
@@ -6,7 +6,13 @@ export type FeatureReturnType = Partial<
 	} & { [K in NumericLicenseFeature]: number } & { [K in BooleanLicenseFeature]: boolean }
 >;
 
-export interface LicenseProvider {
+export type FeatureChangedCallback = () => void;
+
+export interface LicenseFeatureChanged {
+	addOnChangeCallback(notifier: FeatureChangedCallback): () => void;
+}
+
+export interface LicenseProvider extends LicenseFeatureChanged {
 	/** Returns whether a feature is included in the user's license plan. */
 	isLicensed(feature: BooleanLicenseFeature): boolean;
 

--- a/packages/@n8n/decorators/src/controller/controller-registry-metadata.ts
+++ b/packages/@n8n/decorators/src/controller/controller-registry-metadata.ts
@@ -13,6 +13,7 @@ export class ControllerRegistryMetadata {
 				basePath: '/',
 				middlewares: [],
 				routes: new Map(),
+				registered: false,
 			};
 			this.registry.set(controllerClass, metadata);
 		}

--- a/packages/@n8n/decorators/src/controller/types.ts
+++ b/packages/@n8n/decorators/src/controller/types.ts
@@ -44,6 +44,7 @@ export interface ControllerMetadata {
 	basePath: `/${string}`;
 	middlewares: HandlerName[];
 	routes: Map<HandlerName, RouteMetadata>;
+	registered: boolean;
 }
 
 export type Controller = Constructable<object> &

--- a/packages/cli/src/controller.registry.ts
+++ b/packages/cli/src/controller.registry.ts
@@ -23,6 +23,8 @@ import { LastActiveAtService } from './services/last-active-at.service';
 
 @Service()
 export class ControllerRegistry {
+	private app: Application;
+
 	constructor(
 		private readonly license: License,
 		private readonly authService: AuthService,
@@ -31,14 +33,23 @@ export class ControllerRegistry {
 		private readonly lastActiveAtService: LastActiveAtService,
 	) {}
 
-	activate(app: Application) {
+	setApplication(app: Application) {
+		this.app = app;
+	}
+
+	activate() {
 		for (const controllerClass of this.metadata.controllerClasses) {
-			this.activateController(app, controllerClass);
+			this.activateController(this.app, controllerClass);
 		}
 	}
 
 	private activateController(app: Application, controllerClass: Controller) {
 		const metadata = this.metadata.getControllerMetadata(controllerClass);
+
+		if (metadata.registered) {
+			return; // Controller already registered
+		}
+		metadata.registered = true;
 
 		const router = Router({ mergeParams: true });
 		const prefix = `/${this.globalConfig.endpoints.rest}/${metadata.basePath}`

--- a/packages/cli/src/license.ts
+++ b/packages/cli/src/license.ts
@@ -133,6 +133,9 @@ export class License implements LicenseProvider {
 	}
 
 	private notifyOnChange() {
+		this.logger.debug('License state changed, notifying callbacks', {
+			cbs: this.onChangeCallbacks,
+		});
 		this.onChangeCallbacks.forEach((notifier) => {
 			try {
 				notifier();
@@ -191,6 +194,7 @@ export class License implements LicenseProvider {
 		}
 
 		await this.manager.activate(activationKey);
+		this.notifyOnChange();
 		this.logger.debug('License activated');
 	}
 

--- a/packages/cli/src/license.ts
+++ b/packages/cli/src/license.ts
@@ -1,4 +1,4 @@
-import type { LicenseProvider } from '@n8n/backend-common';
+import type { FeatureChangedCallback, LicenseProvider } from '@n8n/backend-common';
 import { Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import {
@@ -33,6 +33,7 @@ export type FeatureReturnType = Partial<
 @Service()
 export class License implements LicenseProvider {
 	private manager: LicenseManager | undefined;
+	private onChangeCallbacks: FeatureChangedCallback[] = [];
 
 	private isShuttingDown = false;
 
@@ -124,6 +125,23 @@ export class License implements LicenseProvider {
 		}
 	}
 
+	addOnChangeCallback(notifier: FeatureChangedCallback): () => void {
+		this.onChangeCallbacks.push(notifier);
+		return () => {
+			this.onChangeCallbacks = this.onChangeCallbacks.filter((c) => c !== notifier);
+		};
+	}
+
+	private notifyOnChange() {
+		this.onChangeCallbacks.forEach((notifier) => {
+			try {
+				notifier();
+			} catch (error) {
+				console.error('Error in license state change callback:', error);
+			}
+		});
+	}
+
 	async loadCertStr(): Promise<TLicenseBlock> {
 		// if we have an ephemeral license, we don't want to load it from the database
 		const ephemeralLicense = this.globalConfig.license.cert;
@@ -191,6 +209,7 @@ export class License implements LicenseProvider {
 		}
 
 		await this.manager.renew();
+		this.notifyOnChange();
 		this.logger.debug('License renewed');
 	}
 

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -187,6 +187,8 @@ export class Server extends AbstractServer {
 	}
 
 	async configure(): Promise<void> {
+		Container.get(ControllerRegistry).setApplication(this.app);
+
 		if (this.globalConfig.endpoints.metrics.enable) {
 			const { PrometheusMetricsService } = await import('@/metrics/prometheus-metrics.service');
 			await Container.get(PrometheusMetricsService).init(this.app);
@@ -248,7 +250,7 @@ export class Server extends AbstractServer {
 		await this.registerAdditionalControllers();
 
 		// register all known controllers
-		Container.get(ControllerRegistry).activate(app);
+		Container.get(ControllerRegistry).activate();
 
 		// ----------------------------------------
 		// Options

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -63,6 +63,7 @@ import '@/workflows/workflow-history.ee/workflow-history.controller.ee';
 import '@/workflows/workflows.controller';
 import '@/webhooks/webhooks.controller';
 import { MfaService } from './mfa/mfa.service';
+import { OidcInitializationService } from './sso.ee/oidc/init.service.ee';
 
 @Service()
 export class Server extends AbstractServer {
@@ -156,15 +157,11 @@ export class Server extends AbstractServer {
 		// OIDC
 		// ----------------------------------------
 
-		try {
-			if (this.licenseState.isOidcLicensed()) {
-				const { OidcService } = await import('@/sso.ee/oidc/oidc.service.ee');
-				await Container.get(OidcService).init();
-				await import('@/sso.ee/oidc/routes/oidc.controller.ee');
-			}
-		} catch (error) {
-			this.logger.warn(`OIDC initialization failed: ${(error as Error).message}`);
-		}
+		Container.get(OidcInitializationService)
+			.init()
+			.catch((error) => {
+				this.logger.warn(`OIDC initialization failed: ${(error as Error).message}`);
+			});
 
 		// ----------------------------------------
 		// Source Control

--- a/packages/cli/src/sso.ee/oidc/init.service.ee.ts
+++ b/packages/cli/src/sso.ee/oidc/init.service.ee.ts
@@ -1,0 +1,48 @@
+import { LicenseState, Logger } from '@n8n/backend-common';
+import { Container, Service } from '@n8n/di';
+
+@Service()
+export class OidcInitializationService {
+	private loadOidcModuleOnce: Promise<void> | null = null;
+	constructor(
+		private readonly licenseState: LicenseState,
+		private readonly logger: Logger,
+	) {}
+
+	private loadOidcModule() {
+		if (this.loadOidcModuleOnce) {
+			return this.loadOidcModuleOnce;
+		}
+
+		this.loadOidcModuleOnce = (async () => {
+			try {
+				const { OidcService } = await import('@/sso.ee/oidc/oidc.service.ee');
+				await Container.get(OidcService).init();
+				await import('@/sso.ee/oidc/routes/oidc.controller.ee');
+			} catch (error) {
+				this.logger.warn(`OIDC initialization failed: ${(error as Error).message}`);
+			}
+		})();
+
+		return this.loadOidcModuleOnce;
+	}
+	/**
+	 * Initializes the OIDC module if the OIDC feature is licensed.
+	 * Sets up a listener to re-initialize if the license changes.
+	 */
+	async init() {
+		if (this.licenseState.isOidcLicensed()) {
+			await this.loadOidcModule();
+		} else {
+			this.logger.debug('OIDC is not licensed, skipping initialization');
+		}
+		this.licenseState.addOnChangeCallback(() => {
+			if (this.licenseState.isOidcLicensed()) {
+				this.logger.debug('OIDC license changed, re-initializing OIDC module');
+				this.loadOidcModule().catch((error) => {
+					this.logger.error(`Error during OIDC re-initialization: ${(error as Error).message}`);
+				});
+			}
+		});
+	}
+}

--- a/packages/cli/src/sso.ee/oidc/init.service.ee.ts
+++ b/packages/cli/src/sso.ee/oidc/init.service.ee.ts
@@ -1,3 +1,4 @@
+import { ControllerRegistry } from '@/controller.registry';
 import { LicenseState, Logger } from '@n8n/backend-common';
 import { Container, Service } from '@n8n/di';
 
@@ -7,6 +8,7 @@ export class OidcInitializationService {
 	constructor(
 		private readonly licenseState: LicenseState,
 		private readonly logger: Logger,
+		private readonly controllerRegistry: ControllerRegistry,
 	) {}
 
 	private loadOidcModule() {
@@ -19,6 +21,7 @@ export class OidcInitializationService {
 				const { OidcService } = await import('@/sso.ee/oidc/oidc.service.ee');
 				await Container.get(OidcService).init();
 				await import('@/sso.ee/oidc/routes/oidc.controller.ee');
+				await this.controllerRegistry.activate();
 			} catch (error) {
 				this.logger.warn(`OIDC initialization failed: ${(error as Error).message}`);
 			}

--- a/packages/cli/src/sso.ee/oidc/routes/oidc.controller.ee.ts
+++ b/packages/cli/src/sso.ee/oidc/routes/oidc.controller.ee.ts
@@ -42,6 +42,7 @@ export class OidcController {
 	}
 
 	@Get('/login', { skipAuth: true })
+	@Licensed('feat:oidc')
 	async redirectToAuthProvider(_req: Request, res: Response) {
 		const authorizationURL = await this.oidcService.generateLoginUrl();
 
@@ -49,6 +50,7 @@ export class OidcController {
 	}
 
 	@Get('/callback', { skipAuth: true })
+	@Licensed('feat:oidc')
 	async callbackHandler(req: Request, res: Response) {
 		const fullUrl = `${this.urlService.getInstanceBaseUrl()}${req.originalUrl}`;
 		const callbackUrl = new URL(fullUrl);


### PR DESCRIPTION
## Summary

This implements an event service to listen for changes on the license. It showcases a dynamic integration of the OIDC module if the OIDC feature is turned on.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
