### PR TITLE
fix(editor): Refetch module settings on manual license activation

### DIFF
--- a/packages/frontend/editor-ui/src/stores/usage.store.ts
+++ b/packages/frontend/editor-ui/src/stores/usage.store.ts
@@ -83,6 +83,7 @@ export const useUsageStore = defineStore('usage', () => {
 		const data = await usageApi.activateLicenseKey(rootStore.restApiContext, { activationKey });
 		setData(data);
 		await settingsStore.getSettings();
+		await settingsStore.getModuleSettings();
 	};
 
 	const refreshLicenseManagementToken = async () => {


### PR DESCRIPTION
## Summary

On manual license activation via the UI, we should refetch `/module-settings` to ensure the Pinia store is updated with the latest license values.

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.slack.com/archives/C04B1GZ4T0U/p1751527060125409

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
