### PR TITLE
fix: Add install step for playwright binaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:n8n": "node scripts/build-n8n.mjs",
     "build:docker": "node scripts/build-n8n.mjs && node scripts/dockerize-n8n.mjs",
     "build:docker:scan": "node scripts/build-n8n.mjs && node scripts/dockerize-n8n.mjs && node scripts/scan-n8n-image.mjs",
-    "build:docker:test": "node scripts/build-n8n.mjs && node scripts/dockerize-n8n.mjs && pnpm --filter=n8n-playwright run test:standard",
+    "build:docker:test": "node scripts/build-n8n.mjs && node scripts/dockerize-n8n.mjs && turbo run test:standard --filter=n8n-playwright",
     "typecheck": "turbo typecheck",
     "dev": "turbo run dev --parallel --env-mode=loose --filter=!@n8n/design-system --filter=!@n8n/chat --filter=!@n8n/task-runner",
     "dev:be": "turbo run dev --parallel --env-mode=loose --filter=!@n8n/design-system --filter=!@n8n/chat --filter=!@n8n/task-runner --filter=!n8n-editor-ui",

--- a/packages/testing/playwright/package.json
+++ b/packages/testing/playwright/package.json
@@ -12,7 +12,8 @@
     "test:clean": "docker rm -f $(docker ps -aq --filter 'name=n8n-*') 2>/dev/null || true && docker network prune -f",
     "lint": "eslint . --quiet",
     "lintfix": "eslint . --fix",
-    "install-browsers": "PLAYWRIGHT_BROWSERS_PATH=./ms-playwright-cache playwright install chromium --with-deps"
+    "install-browsers:ci": "PLAYWRIGHT_BROWSERS_PATH=./ms-playwright-cache playwright install chromium --with-deps --no-shell",
+    "install-browsers:local": "playwright install chromium --with-deps --no-shell"
   },
   "devDependencies": {
     "@currents/playwright": "1.14.1",

--- a/packages/testing/playwright/playwright.config.ts
+++ b/packages/testing/playwright/playwright.config.ts
@@ -117,6 +117,7 @@ export default defineConfig({
 		viewport: { width: 1536, height: 960 },
 		actionTimeout: 10000,
 		navigationTimeout: 10000,
+		channel: 'chromium',
 	},
 
 	projects: process.env.N8N_BASE_URL

--- a/turbo.json
+++ b/turbo.json
@@ -143,11 +143,19 @@
 			"cache": false,
 			"persistent": true
 		},
-		"install-browsers": {
+		"install-browsers:ci": {
 			"cache": true,
 			"inputs": ["package.json"],
 			"outputs": ["ms-playwright-cache/**"],
 			"env": ["PLAYWRIGHT_BROWSERS_PATH"]
+		},
+		"install-browsers:local": {
+			"cache": false,
+			"inputs": ["package.json"]
+		},
+		"test:standard": {
+			"dependsOn": ["install-browsers:local"],
+			"cache": false
 		}
 	}
 }


### PR DESCRIPTION
## Summary

When running the initial build:docker:test command it will now also take care of installing the binaries. This serves as a quick setup and test for local.

Separated out install steps for local/CI to allow for Turbo cache in CI, and standard install locally.

## Related Linear tickets, Github issues, and Community forum posts



## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
