### PR TITLE
chore(core): Always load oidc and add runtime license checks

### DIFF
--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -157,11 +157,12 @@ export class Server extends AbstractServer {
 		// ----------------------------------------
 
 		try {
-			if (this.licenseState.isOidcLicensed()) {
-				const { OidcService } = await import('@/sso.ee/oidc/oidc.service.ee');
-				await Container.get(OidcService).init();
-				await import('@/sso.ee/oidc/routes/oidc.controller.ee');
-			}
+			// in the short term, we load the OIDC module here to ensure it is initialized
+			// ideally we want to migrate this to a module and be able to load it dynamically
+			// when the license changes, but that requires some refactoring
+			const { OidcService } = await import('@/sso.ee/oidc/oidc.service.ee');
+			await Container.get(OidcService).init();
+			await import('@/sso.ee/oidc/routes/oidc.controller.ee');
 		} catch (error) {
 			this.logger.warn(`OIDC initialization failed: ${(error as Error).message}`);
 		}

--- a/packages/cli/src/sso.ee/oidc/routes/oidc.controller.ee.ts
+++ b/packages/cli/src/sso.ee/oidc/routes/oidc.controller.ee.ts
@@ -42,6 +42,7 @@ export class OidcController {
 	}
 
 	@Get('/login', { skipAuth: true })
+	@Licensed('feat:oidc')
 	async redirectToAuthProvider(_req: Request, res: Response) {
 		const authorizationURL = await this.oidcService.generateLoginUrl();
 
@@ -49,6 +50,7 @@ export class OidcController {
 	}
 
 	@Get('/callback', { skipAuth: true })
+	@Licensed('feat:oidc')
 	async callbackHandler(req: Request, res: Response) {
 		const fullUrl = `${this.urlService.getInstanceBaseUrl()}${req.originalUrl}`;
 		const callbackUrl = new URL(fullUrl);


### PR DESCRIPTION
## Summary

We always load OIDC during startup and introduce runtime license checks on it.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-3038/create-oidc-runtime-checks

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
