### PR TITLE
fix(editor): Don't show email banner if cloud info is missing (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/init.test.ts
+++ b/packages/frontend/editor-ui/src/init.test.ts
@@ -280,6 +280,22 @@ describe('Init', () => {
 				expect(cloudStoreSpy).toHaveBeenCalled();
 				expect(uiStore.pushBannerToStack).toHaveBeenCalledWith('EMAIL_CONFIRMATION');
 			});
+
+			it('should not push EMAIL_CONFIRMATION banner if user cloud account does not exist', async () => {
+				settingsStore.settings.deployment.type = 'cloud';
+				usersStore.usersById = { '123': { id: '123', email: '' } as IUser };
+				usersStore.currentUserId = '123';
+
+				cloudPlanStore.userIsTrialing = false;
+				cloudPlanStore.currentUserCloudInfo = null;
+
+				const cloudStoreSpy = vi.spyOn(cloudPlanStore, 'initialize').mockResolvedValueOnce();
+
+				await initializeAuthenticatedFeatures(false);
+
+				expect(cloudStoreSpy).toHaveBeenCalled();
+				expect(uiStore.pushBannerToStack).not.toHaveBeenCalledWith('EMAIL_CONFIRMATION');
+			});
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/init.ts
+++ b/packages/frontend/editor-ui/src/init.ts
@@ -157,7 +157,7 @@ export async function initializeAuthenticatedFeatures(
 				} else {
 					uiStore.pushBannerToStack('TRIAL');
 				}
-			} else if (!cloudPlanStore.currentUserCloudInfo?.confirmed) {
+			} else if (cloudPlanStore.currentUserCloudInfo?.confirmed === false) {
 				uiStore.pushBannerToStack('EMAIL_CONFIRMATION');
 			}
 		} catch (e) {


### PR DESCRIPTION
## Summary
This will prevent the `Confirm email` banner from showing if user cloud account is not fetched (in case of error or for instance members).

## Related Linear tickets, Github issues, and Community forum posts
Fixes ADO-3788

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
