### PR TITLE
fix(editor): Fix button spacing (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.scss
+++ b/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.scss
@@ -28,6 +28,8 @@
 		width 0s,
 		height 0s;
 
+	gap: var(--spacing-3xs);
+
 	@include utils-user-select(none);
 
 	// Solution for a inside button
@@ -110,10 +112,6 @@
 		display: flex;
 		justify-content: center;
 		align-items: center;
-	}
-
-	span + span {
-		margin-left: var(--spacing-3xs);
 	}
 }
 


### PR DESCRIPTION
## Summary
Some of our button didn't have the proper spacing applied because the old css rule required specific HTML structure in order to apply `margin`:
![image](https://github.com/user-attachments/assets/3e6a9946-c8bf-43e4-9111-df7dadfad6c5)

This PR switches to using `gap` to make sure spacing is always applied.


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
