### PR TITLE
fix(core): Block access to JS object constructor and `js` module in Pyodide

### DIFF
--- a/packages/nodes-base/nodes/Code/Pyodide.ts
+++ b/packages/nodes-base/nodes/Code/Pyodide.ts
@@ -30,10 +30,10 @@ export async function LoadPyodide(packageCacheDir: string): Promise<PyodideInter
 		await pyodideInstance.runPythonAsync(`
 import os
 
-def blocked_system(*args, **kwargs):
-    raise RuntimeError("os.system is blocked for security reasons.")
+def blocked_function(*args, **kwargs):
+    raise RuntimeError("Blocked for security reasons")
 
-os.system = blocked_system
+os.system = blocked_function
 
 from importlib.abc import MetaPathFinder
 from importlib.machinery import ModuleSpec
@@ -42,6 +42,15 @@ from typing import Sequence, Optional
 
 from _pyodide_core import jsproxy_typedict
 from js import Object
+
+Object.constructor.constructor = blocked_function
+
+import sys
+class blocked_module:
+    def __getattr__(self, name):
+        blocked_function()
+
+sys.modules['js'] = blocked_module()
 `);
 	}
 


### PR DESCRIPTION
## Summary

See story.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/SEC-270

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
