### PR TITLE
refactor(core): Move single node check outside of the nodes loop

### DIFF
--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -902,13 +902,16 @@ export class Workflow {
 		// Check if there are any trigger or poll nodes and then return the first one
 		let node: INode;
 		let nodeType: INodeType;
-		for (const nodeName of nodeNames) {
-			node = this.nodes[nodeName];
 
-			if (nodeNames.length === 1 && !node.disabled) {
+		if (nodeNames.length === 1) {
+			node = this.nodes[nodeNames[0]];
+			if (node && !node.disabled) {
 				return node;
 			}
+		}
 
+		for (const nodeName of nodeNames) {
+			node = this.nodes[nodeName];
 			nodeType = this.nodeTypes.getByNameAndVersion(node.type, node.typeVersion);
 
 			// TODO: Identify later differently

--- a/packages/workflow/test/workflow.test.ts
+++ b/packages/workflow/test/workflow.test.ts
@@ -2586,6 +2586,25 @@ describe('Workflow', () => {
 
 			expect(workflow.getStartNode()).toBeUndefined();
 		});
+
+		test('returns the single node when only one non-disabled node exists', () => {
+			const singleNode = {
+				name: 'SingleNode',
+				type: 'test.set',
+				typeVersion: 1,
+				id: 'uuid-single',
+				position: [0, 0],
+				parameters: {},
+			} as INode;
+			const workflow = new Workflow({
+				nodes: [singleNode],
+				connections: {},
+				active: false,
+				nodeTypes,
+			});
+
+			expect(workflow.getStartNode()).toBe(singleNode);
+		});
 	});
 
 	describe('getNode', () => {


### PR DESCRIPTION
## Summary

The pull request brings in a minor improvement, by moving the single node check outside of the nodes loop.
The change slightly improves the efficiency of the code as it removes redundant checks.

Additionally, it introduces a unit test that reproduces the single node issue the check originally tries to address.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/PAY-3071/community-pr-choreworkflow-move-single-node-check-outside-of-the-nodes
## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

