### PR TITLE
fix: Using env values (no-changelog)

### DIFF
--- a/.github/workflows/release-push-to-channel.yml
+++ b/.github/workflows/release-push-to-channel.yml
@@ -27,8 +27,10 @@ jobs:
     steps:
       - name: Check Version Format
         id: check_version
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          input_version="${{ github.event.inputs.version }}"
+          input_version="${{ env.INPUT_VERSION }}"
           version_regex='^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$'
 
           if [[ "$input_version" =~ $version_regex ]]; then


### PR DESCRIPTION
## Summary

Using env values

## Related Linear tickets, Github issues, and Community forum posts




## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
