### PR TITLE
fix(Slack Node): Change Slack ts and thread_ts type to string

### DIFF
--- a/packages/nodes-base/nodes/Slack/V2/ChannelDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V2/ChannelDescription.ts
@@ -1190,8 +1190,8 @@ export const channelFields: INodeProperties[] = [
 	{
 		displayName: 'Message Timestamp',
 		name: 'ts',
-		type: 'number',
-		default: undefined,
+		type: 'string',
+		default: '',
 		displayOptions: {
 			show: {
 				operation: ['replies'],

--- a/packages/nodes-base/nodes/Slack/V2/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V2/MessageDescription.ts
@@ -243,8 +243,8 @@ export const messageFields: INodeProperties[] = [
 		displayName: 'Message Timestamp',
 		name: 'timestamp',
 		required: true,
-		type: 'number',
-		default: undefined,
+		type: 'string',
+		default: '',
 		displayOptions: {
 			show: {
 				resource: ['message'],
@@ -513,8 +513,8 @@ export const messageFields: INodeProperties[] = [
 			{
 				displayName: 'Message Timestamp',
 				name: 'ts',
-				type: 'number',
-				default: 0,
+				type: 'string',
+				default: '',
 				description: 'Timestamp of the message to post',
 				placeholder: '1663233118.856619',
 			},
@@ -666,8 +666,8 @@ export const messageFields: INodeProperties[] = [
 							{
 								displayName: 'Message Timestamp to Reply To',
 								name: 'thread_ts',
-								type: 'number',
-								default: undefined,
+								type: 'string',
+								default: '',
 								placeholder: '1663233118.856619',
 								description:
 									'Message timestamps are included in output data of Slack nodes, abbreviated to ts',
@@ -863,8 +863,8 @@ export const messageFields: INodeProperties[] = [
 		displayName: 'Message Timestamp',
 		name: 'ts',
 		required: true,
-		type: 'number',
-		default: undefined,
+		type: 'string',
+		default: '',
 		displayOptions: {
 			show: {
 				resource: ['message'],
@@ -1156,8 +1156,8 @@ export const messageFields: INodeProperties[] = [
 		displayName: 'Message Timestamp',
 		name: 'timestamp',
 		required: true,
-		type: 'number',
-		default: undefined,
+		type: 'string',
+		default: '',
 		displayOptions: {
 			show: {
 				resource: ['message'],

--- a/packages/nodes-base/nodes/Slack/V2/ReactionDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V2/ReactionDescription.ts
@@ -101,8 +101,8 @@ export const reactionFields: INodeProperties[] = [
 		displayName: 'Message Timestamp',
 		name: 'timestamp',
 		required: true,
-		type: 'number',
-		default: undefined,
+		type: 'string',
+		default: '',
 		displayOptions: {
 			show: {
 				resource: ['reaction'],

--- a/packages/nodes-base/nodes/Slack/V2/StarDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V2/StarDescription.ts
@@ -142,8 +142,8 @@ export const starFields: INodeProperties[] = [
 	{
 		displayName: 'Message Timestamp',
 		name: 'timestamp',
-		type: 'number',
-		default: undefined,
+		type: 'string',
+		default: '',
 		displayOptions: {
 			show: {
 				resource: ['star'],
@@ -223,8 +223,8 @@ export const starFields: INodeProperties[] = [
 			{
 				displayName: 'Message Timestamp',
 				name: 'timestamp',
-				type: 'number',
-				default: 0,
+				type: 'string',
+				default: '',
 				description: 'Timestamp of the message to delete',
 				placeholder: '1663233118.856619',
 			},


### PR DESCRIPTION
## Summary

Slack treats their message timestamp (`ts` and `thread_ts`) as `string`. Due to the timestamp property type is defined as `number` here, n8n makes Slack API calls with `number` instead, unless it is specifically converted to `string`.

Some related official documents:
* https://api.slack.com/methods/chat.postMessage#arg_thread_ts
* https://api.slack.com/methods/chat.update#arg_ts
* https://github.com/slackapi/node-slack-sdk/issues/780

In the case of replying to a thread, it's silently sent the message to the channel as a separate thread. It doesn't throw any errors.

The issue seems to be started since https://github.com/n8n-io/n8n/commit/bbc103fc268f65b69a556d6e6e83435f04403bfe. It was `string`, but converted to `number` for FE validation purposes.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
