### PR TITLE
build: Track index file bundle size (no-changelog)

### DIFF
--- a/.bundlemonrc.json
+++ b/.bundlemonrc.json
@@ -15,6 +15,14 @@
 		{
 			"path": "*.wasm",
 			"friendlyName": "WASM Dependencies"
+		},
+		{
+			"path": "**/index-<hash>.js",
+			"friendlyName": "JavaScript entrypoint"
+		},
+		{
+			"path": "**/index-<hash>.css",
+			"friendlyName": "CSS entrypoint"
 		}
 	],
 	"groups": [


### PR DESCRIPTION
## Summary

This PR updates BundleMon configuration to include index file sizes so that we can monitor the effectiveness of dynamic imports.

## Related Linear tickets, Github issues, and Community forum posts
N/A

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
