### PR TITLE
refactor(editor): Move optionSelected logic to a composable

### DIFF
--- a/packages/frontend/editor-ui/src/components/NodeSettings.vue
+++ b/packages/frontend/editor-ui/src/components/NodeSettings.vue
@@ -24,6 +24,7 @@ import NDVSubConnections from '@/components/NDVSubConnections.vue';
 import get from 'lodash/get';
 
 import NodeExecuteButton from './NodeExecuteButton.vue';
+import { nameIsParameter } from '@/utils/nodeSettingsUtils';
 import { isCommunityPackageName } from '@/utils/nodeTypesUtils';
 import { useWorkflowsStore } from '@/stores/workflows.store';
 import { useNDVStore } from '@/stores/ndv.store';
@@ -346,7 +347,7 @@ const valueChanged = (parameterData: IUpdateInformation) => {
 			nodeHelpers.updateNodeParameterIssuesByName(_node.name);
 			nodeHelpers.updateNodeCredentialIssuesByName(_node.name);
 		}
-	} else if (nodeSettingsParameters.nameIsParameter(parameterData)) {
+	} else if (nameIsParameter(parameterData)) {
 		// A node parameter changed
 		nodeSettingsParameters.updateNodeParameter(parameterData, newValue, _node, isToolNode.value);
 	} else {

--- a/packages/frontend/editor-ui/src/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/components/ParameterInput.vue
@@ -234,7 +234,7 @@ const displayValue = computed(() => {
 	if (
 		Array.isArray(returnValue) &&
 		props.parameter.type === 'color' &&
-		getArgument('showAlpha') === true &&
+		nodeSettingsParameters.getParameterTypeOption(props.parameter, 'showAlpha') === true &&
 		(returnValue as unknown as string).charAt(0) === '#'
 	) {
 		// Convert the value to rgba that el-color-picker can display it correctly
@@ -276,7 +276,10 @@ const expressionDisplayValue = computed(() => {
 const isModelValueExpression = computed(() => isValueExpression(props.parameter, props.modelValue));
 
 const dependentParametersValues = computed<string | null>(() => {
-	const loadOptionsDependsOn = getArgument<string[] | undefined>('loadOptionsDependsOn');
+	const loadOptionsDependsOn = nodeSettingsParameters.getParameterTypeOption<string[] | undefined>(
+		props.parameter,
+		'loadOptionsDependsOn',
+	);
 
 	if (loadOptionsDependsOn === undefined) {
 		return null;
@@ -318,7 +321,7 @@ const displayTitle = computed<string>(() => {
 });
 
 const getStringInputType = computed(() => {
-	if (getArgument('password') === true) {
+	if (nodeSettingsParameters.getParameterTypeOption(props.parameter, 'password') === true) {
 		return 'password';
 	}
 
@@ -430,16 +433,24 @@ const displayIssues = computed(
 );
 
 const editorType = computed<EditorType | 'json' | 'code' | 'cssEditor'>(() => {
-	return getArgument<EditorType>('editor');
+	return nodeSettingsParameters.getParameterTypeOption<EditorType>(props.parameter, 'editor');
 });
 const editorIsReadOnly = computed<boolean>(() => {
-	return getArgument<boolean>('editorIsReadOnly') ?? false;
+	return (
+		nodeSettingsParameters.getParameterTypeOption<boolean>(props.parameter, 'editorIsReadOnly') ??
+		false
+	);
 });
 
 const editorLanguage = computed<CodeNodeEditorLanguage>(() => {
 	if (editorType.value === 'json' || props.parameter.type === 'json')
 		return 'json' as CodeNodeEditorLanguage;
-	return getArgument<CodeNodeEditorLanguage>('editorLanguage') ?? 'javaScript';
+	return (
+		nodeSettingsParameters.getParameterTypeOption<CodeNodeEditorLanguage>(
+			props.parameter,
+			'editorLanguage',
+		) ?? 'javaScript'
+	);
 });
 
 const parameterOptions = computed(() => {
@@ -501,7 +512,10 @@ const parameterInputWrapperStyle = computed(() => {
 });
 
 const hasRemoteMethod = computed<boolean>(() => {
-	return !!getArgument('loadOptionsMethod') || !!getArgument('loadOptions');
+	return (
+		!!nodeSettingsParameters.getParameterTypeOption(props.parameter, 'loadOptionsMethod') ||
+		!!nodeSettingsParameters.getParameterTypeOption(props.parameter, 'loadOptions')
+	);
 });
 
 const shortPath = computed<string>(() => {
@@ -519,7 +533,7 @@ const isResourceLocatorParameter = computed<boolean>(() => {
 });
 
 const isSecretParameter = computed<boolean>(() => {
-	return getArgument('password') === true;
+	return nodeSettingsParameters.getParameterTypeOption(props.parameter, 'password') === true;
 });
 
 const remoteParameterOptionsKeys = computed<string[]>(() => {
@@ -546,7 +560,9 @@ const modelValueExpressionEdit = computed<string>(() => {
 		: (props.modelValue as string);
 });
 
-const editorRows = computed(() => getArgument<number>('rows'));
+const editorRows = computed(() =>
+	nodeSettingsParameters.getParameterTypeOption<number>(props.parameter, 'rows'),
+);
 
 const codeEditorMode = computed<CodeExecutionMode>(() => {
 	return node.value?.parameters.mode as CodeExecutionMode;
@@ -581,12 +597,7 @@ const showDragnDropTip = computed(
 		!props.isForCredential,
 );
 
-const shouldCaptureForPosthog = computed(() => {
-	if (node.value?.type) {
-		return [AI_TRANSFORM_NODE_TYPE].includes(node.value?.type);
-	}
-	return false;
-});
+const shouldCaptureForPosthog = computed(() => node.value?.type === AI_TRANSFORM_NODE_TYPE);
 
 function isValidParameterOption(
 	option: INodePropertyOptions | INodeProperties | INodePropertyCollection,
@@ -662,8 +673,14 @@ async function loadRemoteParameterOptions() {
 			props.parameter,
 			currentNodeParameters,
 		) as INodeParameters;
-		const loadOptionsMethod = getArgument<string | undefined>('loadOptionsMethod');
-		const loadOptions = getArgument<ILoadOptions | undefined>('loadOptions');
+		const loadOptionsMethod = nodeSettingsParameters.getParameterTypeOption<string | undefined>(
+			props.parameter,
+			'loadOptionsMethod',
+		);
+		const loadOptions = nodeSettingsParameters.getParameterTypeOption<ILoadOptions | undefined>(
+			props.parameter,
+			'loadOptions',
+		);
 
 		const options = await nodeTypesStore.getNodeParameterOptions({
 			nodeTypeAndVersion: {
@@ -739,10 +756,6 @@ function displayEditDialog() {
 	}
 }
 
-function getArgument<T = string | number | boolean | undefined>(argumentName: string): T {
-	return props.parameter.typeOptions?.[argumentName] as T;
-}
-
 function expressionUpdated(value: string) {
 	const val: NodeParameterValueType = isResourceLocatorParameter.value
 		? { __rl: true, value, mode: modelValueResourceLocator.value.mode }
@@ -810,7 +823,10 @@ function selectInput() {
 }
 
 async function setFocus() {
-	if (['json'].includes(props.parameter.type) && getArgument('alwaysOpenEditWindow')) {
+	if (
+		['json'].includes(props.parameter.type) &&
+		nodeSettingsParameters.getParameterTypeOption(props.parameter, 'alwaysOpenEditWindow')
+	) {
 		displayEditDialog();
 		return;
 	}
@@ -907,7 +923,7 @@ function valueChanged(value: NodeParameterValueType | {} | Date) {
 
 	if (
 		props.parameter.type === 'color' &&
-		getArgument('showAlpha') === true &&
+		nodeSettingsParameters.getParameterTypeOption(props.parameter, 'showAlpha') === true &&
 		value !== null &&
 		value !== undefined &&
 		(value as string).toString().charAt(0) !== '#'
@@ -1031,7 +1047,7 @@ onMounted(() => {
 
 	if (
 		props.parameter.type === 'color' &&
-		getArgument('showAlpha') === true &&
+		nodeSettingsParameters.getParameterTypeOption(props.parameter, 'showAlpha') === true &&
 		displayValue.value !== null &&
 		displayValue.value.toString().charAt(0) !== '#'
 	) {
@@ -1102,7 +1118,10 @@ watch(dependentParametersValues, async () => {
 watch(
 	() => props.modelValue,
 	async () => {
-		if (props.parameter.type === 'color' && getArgument('showAlpha') === true) {
+		if (
+			props.parameter.type === 'color' &&
+			nodeSettingsParameters.getParameterTypeOption(props.parameter, 'showAlpha') === true
+		) {
 			// Do not set for color with alpha else wrong value gets displayed in field
 			return;
 		}
@@ -1297,7 +1316,9 @@ onUpdated(async () => {
 						<SqlEditor
 							v-else-if="editorType === 'sqlEditor' && codeEditDialogVisible"
 							:model-value="modelValueString"
-							:dialect="getArgument('sqlDialect')"
+							:dialect="
+								nodeSettingsParameters.getParameterTypeOption(props.parameter, 'sqlDialect')
+							"
 							:is-read-only="isReadOnly"
 							:rows="editorRows"
 							fullscreen
@@ -1412,7 +1433,7 @@ onUpdated(async () => {
 				<SqlEditor
 					v-else-if="editorType === 'sqlEditor'"
 					:model-value="modelValueString"
-					:dialect="getArgument('sqlDialect')"
+					:dialect="nodeSettingsParameters.getParameterTypeOption(props.parameter, 'sqlDialect')"
 					:is-read-only="isReadOnly"
 					:rows="editorRows"
 					@update:model-value="valueChangedDebounced"
@@ -1541,7 +1562,7 @@ onUpdated(async () => {
 					:model-value="displayValue"
 					:disabled="isReadOnly"
 					:title="displayTitle"
-					:show-alpha="getArgument('showAlpha')"
+					:show-alpha="nodeSettingsParameters.getParameterTypeOption(props.parameter, 'showAlpha')"
 					@focus="setFocus"
 					@blur="onBlur"
 					@update:model-value="valueChanged"
@@ -1587,9 +1608,11 @@ onUpdated(async () => {
 				:size="inputSize"
 				:model-value="displayValue"
 				:controls="false"
-				:max="getArgument('maxValue')"
-				:min="getArgument('minValue')"
-				:precision="getArgument('numberPrecision')"
+				:max="nodeSettingsParameters.getParameterTypeOption(props.parameter, 'maxValue')"
+				:min="nodeSettingsParameters.getParameterTypeOption(props.parameter, 'minValue')"
+				:precision="
+					nodeSettingsParameters.getParameterTypeOption(props.parameter, 'numberPrecision')
+				"
 				:disabled="isReadOnly"
 				:class="{ 'ph-no-capture': shouldRedactValue }"
 				:title="displayTitle"

--- a/packages/frontend/editor-ui/src/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/components/ParameterInput.vue
@@ -373,7 +373,7 @@ const getIssues = computed<string[]>(() => {
 
 		let checkValues: string[] = [];
 
-		if (!skipCheck(displayValue.value)) {
+		if (!nodeSettingsParameters.shouldSkipParamValidation(displayValue.value)) {
 			if (Array.isArray(displayValue.value)) {
 				checkValues = checkValues.concat(displayValue.value);
 			} else {
@@ -621,13 +621,6 @@ function credentialSelected(updateInformation: INodeUpdatePropertiesInformation)
 	}
 
 	void externalHooks.run('nodeSettings.credentialSelected', { updateInformation });
-}
-
-/**
- * Check whether a param value must be skipped when collecting node param issues for validation.
- */
-function skipCheck(value: string | number | boolean | null) {
-	return typeof value === 'string' && value.includes(CUSTOM_API_CALL_KEY);
 }
 
 function getPlaceholder(): string {

--- a/packages/frontend/editor-ui/src/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/components/ParameterInput.vue
@@ -191,6 +191,10 @@ const shortPath = computed<string>(() => {
 	return short.join('.');
 });
 
+function getTypeOption<T>(optionName: string): T {
+	return nodeSettingsParameters.getParameterTypeOption<T>(props.parameter, optionName);
+}
+
 const isModelValueExpression = computed(() => isValueExpression(props.parameter, props.modelValue));
 
 const isResourceLocatorParameter = computed<boolean>(() => {
@@ -198,14 +202,11 @@ const isResourceLocatorParameter = computed<boolean>(() => {
 });
 
 const isSecretParameter = computed<boolean>(() => {
-	return nodeSettingsParameters.getParameterTypeOption(props.parameter, 'password') === true;
+	return getTypeOption('password') === true;
 });
 
 const hasRemoteMethod = computed<boolean>(() => {
-	return (
-		!!nodeSettingsParameters.getParameterTypeOption(props.parameter, 'loadOptionsMethod') ||
-		!!nodeSettingsParameters.getParameterTypeOption(props.parameter, 'loadOptions')
-	);
+	return !!getTypeOption('loadOptionsMethod') || !!getTypeOption('loadOptions');
 });
 
 const parameterOptions = computed(() => {
@@ -231,29 +232,19 @@ const modelValueExpressionEdit = computed<string>(() => {
 		: (props.modelValue as string);
 });
 
-const editorRows = computed(() =>
-	nodeSettingsParameters.getParameterTypeOption<number>(props.parameter, 'rows'),
-);
+const editorRows = computed(() => getTypeOption<number>('rows'));
 
 const editorType = computed<EditorType | 'json' | 'code' | 'cssEditor'>(() => {
-	return nodeSettingsParameters.getParameterTypeOption<EditorType>(props.parameter, 'editor');
+	return getTypeOption<EditorType>('editor');
 });
 const editorIsReadOnly = computed<boolean>(() => {
-	return (
-		nodeSettingsParameters.getParameterTypeOption<boolean>(props.parameter, 'editorIsReadOnly') ??
-		false
-	);
+	return getTypeOption<boolean>('editorIsReadOnly') ?? false;
 });
 
 const editorLanguage = computed<CodeNodeEditorLanguage>(() => {
 	if (editorType.value === 'json' || props.parameter.type === 'json')
 		return 'json' as CodeNodeEditorLanguage;
-	return (
-		nodeSettingsParameters.getParameterTypeOption<CodeNodeEditorLanguage>(
-			props.parameter,
-			'editorLanguage',
-		) ?? 'javaScript'
-	);
+	return getTypeOption<CodeNodeEditorLanguage>('editorLanguage') ?? 'javaScript';
 });
 
 const codeEditorMode = computed<CodeExecutionMode>(() => {
@@ -313,7 +304,7 @@ const displayValue = computed(() => {
 	if (
 		Array.isArray(returnValue) &&
 		props.parameter.type === 'color' &&
-		nodeSettingsParameters.getParameterTypeOption(props.parameter, 'showAlpha') === true &&
+		getTypeOption('showAlpha') === true &&
 		(returnValue as unknown as string).charAt(0) === '#'
 	) {
 		// Convert the value to rgba that el-color-picker can display it correctly
@@ -353,10 +344,7 @@ const expressionDisplayValue = computed(() => {
 });
 
 const dependentParametersValues = computed<string | null>(() => {
-	const loadOptionsDependsOn = nodeSettingsParameters.getParameterTypeOption<string[] | undefined>(
-		props.parameter,
-		'loadOptionsDependsOn',
-	);
+	const loadOptionsDependsOn = getTypeOption<string[] | undefined>('loadOptionsDependsOn');
 
 	if (loadOptionsDependsOn === undefined) {
 		return null;
@@ -379,7 +367,7 @@ const dependentParametersValues = computed<string | null>(() => {
 });
 
 const getStringInputType = computed(() => {
-	if (nodeSettingsParameters.getParameterTypeOption(props.parameter, 'password') === true) {
+	if (getTypeOption('password') === true) {
 		return 'password';
 	}
 
@@ -654,14 +642,8 @@ async function loadRemoteParameterOptions() {
 			props.parameter,
 			currentNodeParameters,
 		) as INodeParameters;
-		const loadOptionsMethod = nodeSettingsParameters.getParameterTypeOption<string | undefined>(
-			props.parameter,
-			'loadOptionsMethod',
-		);
-		const loadOptions = nodeSettingsParameters.getParameterTypeOption<ILoadOptions | undefined>(
-			props.parameter,
-			'loadOptions',
-		);
+		const loadOptionsMethod = getTypeOption<string | undefined>('loadOptionsMethod');
+		const loadOptions = getTypeOption<ILoadOptions | undefined>('loadOptions');
 
 		const options = await nodeTypesStore.getNodeParameterOptions({
 			nodeTypeAndVersion: {
@@ -759,10 +741,7 @@ function selectInput() {
 }
 
 async function setFocus() {
-	if (
-		['json'].includes(props.parameter.type) &&
-		nodeSettingsParameters.getParameterTypeOption(props.parameter, 'alwaysOpenEditWindow')
-	) {
+	if (['json'].includes(props.parameter.type) && getTypeOption('alwaysOpenEditWindow')) {
 		displayEditDialog();
 		return;
 	}
@@ -865,7 +844,7 @@ function valueChanged(value: NodeParameterValueType | {} | Date) {
 
 	if (
 		props.parameter.type === 'color' &&
-		nodeSettingsParameters.getParameterTypeOption(props.parameter, 'showAlpha') === true &&
+		getTypeOption('showAlpha') === true &&
 		value !== null &&
 		value !== undefined &&
 		(value as string).toString().charAt(0) !== '#'
@@ -1033,7 +1012,7 @@ onMounted(() => {
 
 	if (
 		props.parameter.type === 'color' &&
-		nodeSettingsParameters.getParameterTypeOption(props.parameter, 'showAlpha') === true &&
+		getTypeOption('showAlpha') === true &&
 		displayValue.value !== null &&
 		displayValue.value.toString().charAt(0) !== '#'
 	) {
@@ -1105,10 +1084,7 @@ watch(dependentParametersValues, async () => {
 watch(
 	() => props.modelValue,
 	() => {
-		if (
-			props.parameter.type === 'color' &&
-			nodeSettingsParameters.getParameterTypeOption(props.parameter, 'showAlpha') === true
-		) {
+		if (props.parameter.type === 'color' && getTypeOption('showAlpha') === true) {
 			// Do not set for color with alpha else wrong value gets displayed in field
 			return;
 		}
@@ -1305,9 +1281,7 @@ onUpdated(async () => {
 						<SqlEditor
 							v-else-if="editorType === 'sqlEditor' && codeEditDialogVisible"
 							:model-value="modelValueString"
-							:dialect="
-								nodeSettingsParameters.getParameterTypeOption(props.parameter, 'sqlDialect')
-							"
+							:dialect="getTypeOption('sqlDialect')"
 							:is-read-only="isReadOnly"
 							:rows="editorRows"
 							fullscreen
@@ -1422,7 +1396,7 @@ onUpdated(async () => {
 				<SqlEditor
 					v-else-if="editorType === 'sqlEditor'"
 					:model-value="modelValueString"
-					:dialect="nodeSettingsParameters.getParameterTypeOption(props.parameter, 'sqlDialect')"
+					:dialect="getTypeOption('sqlDialect')"
 					:is-read-only="isReadOnly"
 					:rows="editorRows"
 					@update:model-value="valueChangedDebounced"
@@ -1551,7 +1525,7 @@ onUpdated(async () => {
 					:model-value="displayValue"
 					:disabled="isReadOnly"
 					:title="displayTitle"
-					:show-alpha="nodeSettingsParameters.getParameterTypeOption(props.parameter, 'showAlpha')"
+					:show-alpha="getTypeOption('showAlpha')"
 					@focus="setFocus"
 					@blur="onBlur"
 					@update:model-value="valueChanged"
@@ -1597,11 +1571,9 @@ onUpdated(async () => {
 				:size="inputSize"
 				:model-value="displayValue"
 				:controls="false"
-				:max="nodeSettingsParameters.getParameterTypeOption(props.parameter, 'maxValue')"
-				:min="nodeSettingsParameters.getParameterTypeOption(props.parameter, 'minValue')"
-				:precision="
-					nodeSettingsParameters.getParameterTypeOption(props.parameter, 'numberPrecision')
-				"
+				:max="getTypeOption('maxValue')"
+				:min="getTypeOption('minValue')"
+				:precision="getTypeOption('numberPrecision')"
 				:disabled="isReadOnly"
 				:class="{ 'ph-no-capture': shouldRedactValue }"
 				:title="displayTitle"

--- a/packages/frontend/editor-ui/src/composables/useNodeSettingsParameters.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useNodeSettingsParameters.test.ts
@@ -3,43 +3,12 @@ import { setActivePinia } from 'pinia';
 import { useNDVStore } from '@/stores/ndv.store';
 import { useFocusPanelStore } from '@/stores/focusPanel.store';
 import { useNodeSettingsParameters } from './useNodeSettingsParameters';
-import type { INodeProperties, INodePropertyOptions } from 'n8n-workflow';
+import type { INodeProperties } from 'n8n-workflow';
 import type { MockedStore } from '@/__tests__/utils';
 import { mockedStore } from '@/__tests__/utils';
 import type { INodeUi } from '@/Interface';
 
 describe('useNodeSettingsParameters', () => {
-	describe('nameIsParameter', () => {
-		beforeEach(() => {
-			setActivePinia(createTestingPinia());
-		});
-
-		afterEach(() => {
-			vi.clearAllMocks();
-		});
-
-		it.each([
-			['', false],
-			['parameters', false],
-			['parameters.', true],
-			['parameters.path.to.some', true],
-			['', false],
-		])('%s should be %s', (input, expected) => {
-			const { nameIsParameter } = useNodeSettingsParameters();
-			const result = nameIsParameter({ name: input } as never);
-			expect(result).toBe(expected);
-		});
-
-		it('should reject path on other input', () => {
-			const { nameIsParameter } = useNodeSettingsParameters();
-			const result = nameIsParameter({
-				name: 'aName',
-				value: 'parameters.path.to.parameters',
-			} as never);
-			expect(result).toBe(false);
-		});
-	});
-
 	describe('setValue', () => {
 		beforeEach(() => {
 			setActivePinia(createTestingPinia());
@@ -78,109 +47,6 @@ describe('useNodeSettingsParameters', () => {
 			nodeSettingsParameters.setValue('newProperty', 'newValue');
 
 			expect(nodeSettingsParameters.nodeValues.value.newProperty).toBe('newValue');
-		});
-	});
-
-	describe('formatAsExpression', () => {
-		it('wraps string value with "="', () => {
-			const { formatAsExpression } = useNodeSettingsParameters();
-			expect(formatAsExpression('foo', 'string')).toBe('=foo');
-		});
-
-		it('wraps number value with "={{ }}"', () => {
-			const { formatAsExpression } = useNodeSettingsParameters();
-			expect(formatAsExpression(42, 'number')).toBe('={{ 42 }}');
-		});
-
-		it('wraps boolean value with "={{ }}"', () => {
-			const { formatAsExpression } = useNodeSettingsParameters();
-			expect(formatAsExpression(true, 'boolean')).toBe('={{ true }}');
-		});
-
-		it('wraps multiOptions value with "={{ }}" and stringifies', () => {
-			const { formatAsExpression } = useNodeSettingsParameters();
-			expect(formatAsExpression(['a', 'b'], 'multiOptions')).toBe('={{ ["a","b"] }}');
-		});
-
-		it('returns "={{ 0 }}" for number with empty value', () => {
-			const { formatAsExpression } = useNodeSettingsParameters();
-			expect(formatAsExpression('', 'number')).toBe('={{ 0 }}');
-			expect(formatAsExpression('[Object: null]', 'number')).toBe('={{ 0 }}');
-		});
-
-		it('wraps non-string, non-number, non-boolean value with "={{ }}"', () => {
-			const { formatAsExpression } = useNodeSettingsParameters();
-			expect(formatAsExpression({ foo: 'bar' }, 'string')).toBe('={{ [object Object] }}');
-		});
-
-		it('handles resourceLocator value', () => {
-			const { formatAsExpression } = useNodeSettingsParameters();
-			const value = { __rl: true, value: 'abc', mode: 'url' };
-			expect(formatAsExpression(value, 'resourceLocator')).toEqual({
-				__rl: true,
-				value: '=abc',
-				mode: 'url',
-			});
-		});
-
-		it('handles resourceLocator value as string', () => {
-			const { formatAsExpression } = useNodeSettingsParameters();
-			expect(formatAsExpression('abc', 'resourceLocator')).toEqual({
-				__rl: true,
-				value: '=abc',
-				mode: '',
-			});
-		});
-	});
-
-	describe('parseFromExpression', () => {
-		it('removes expression from multiOptions string value', () => {
-			const { parseFromExpression } = useNodeSettingsParameters();
-			const options: INodePropertyOptions[] = [
-				{ name: 'Option A', value: 'a' },
-				{ name: 'Option B', value: 'b' },
-				{ name: 'Option C', value: 'c' },
-			];
-			expect(parseFromExpression('', 'a,b,c', 'multiOptions', [], options)).toEqual([
-				'a',
-				'b',
-				'c',
-			]);
-			expect(parseFromExpression('', 'a,x', 'multiOptions', [], options)).toEqual(['a']);
-		});
-
-		it('removes expression from resourceLocator value', () => {
-			const { parseFromExpression } = useNodeSettingsParameters();
-			const modelValue = { __rl: true, value: '=abc', mode: 'url' };
-			expect(parseFromExpression(modelValue, 'abc', 'resourceLocator', '', [])).toEqual({
-				__rl: true,
-				value: 'abc',
-				mode: 'url',
-			});
-		});
-
-		it('removes leading "=" from string parameter', () => {
-			const { parseFromExpression } = useNodeSettingsParameters();
-			expect(parseFromExpression('=foo', undefined, 'string', '', [])).toBe('foo');
-			expect(parseFromExpression('==bar', undefined, 'string', '', [])).toBe('bar');
-			expect(parseFromExpression('', undefined, 'string', '', [])).toBeNull();
-		});
-
-		it('returns value if defined and not string/resourceLocator/multiOptions', () => {
-			const { parseFromExpression } = useNodeSettingsParameters();
-			expect(parseFromExpression(123, 456, 'number', 0, [])).toBe(456);
-			expect(parseFromExpression(true, false, 'boolean', true, [])).toBe(false);
-		});
-
-		it('returns defaultValue for number/boolean if value is undefined', () => {
-			const { parseFromExpression } = useNodeSettingsParameters();
-			expect(parseFromExpression(123, undefined, 'number', 0, [])).toBe(0);
-			expect(parseFromExpression(true, undefined, 'boolean', false, [])).toBe(false);
-		});
-
-		it('returns null for other types if value is undefined', () => {
-			const { parseFromExpression } = useNodeSettingsParameters();
-			expect(parseFromExpression({}, undefined, 'json', null, [])).toBeNull();
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/composables/useNodeSettingsParameters.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useNodeSettingsParameters.test.ts
@@ -1,17 +1,23 @@
 import { createTestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';
+import { useNDVStore } from '@/stores/ndv.store';
+import { useFocusPanelStore } from '@/stores/focusPanel.store';
 import { useNodeSettingsParameters } from './useNodeSettingsParameters';
+import type { INodeProperties, INodePropertyOptions } from 'n8n-workflow';
+import type { MockedStore } from '@/__tests__/utils';
+import { mockedStore } from '@/__tests__/utils';
+import type { INodeUi } from '@/Interface';
 
 describe('useNodeSettingsParameters', () => {
-	beforeEach(() => {
-		setActivePinia(createTestingPinia());
-	});
-
-	afterEach(() => {
-		vi.clearAllMocks();
-	});
-
 	describe('nameIsParameter', () => {
+		beforeEach(() => {
+			setActivePinia(createTestingPinia());
+		});
+
+		afterEach(() => {
+			vi.clearAllMocks();
+		});
+
 		it.each([
 			['', false],
 			['parameters', false],
@@ -35,6 +41,14 @@ describe('useNodeSettingsParameters', () => {
 	});
 
 	describe('setValue', () => {
+		beforeEach(() => {
+			setActivePinia(createTestingPinia());
+		});
+
+		afterEach(() => {
+			vi.clearAllMocks();
+		});
+
 		it('mutates nodeValues as expected', () => {
 			const nodeSettingsParameters = useNodeSettingsParameters();
 
@@ -64,6 +78,181 @@ describe('useNodeSettingsParameters', () => {
 			nodeSettingsParameters.setValue('newProperty', 'newValue');
 
 			expect(nodeSettingsParameters.nodeValues.value.newProperty).toBe('newValue');
+		});
+	});
+
+	describe('formatAsExpression', () => {
+		it('wraps string value with "="', () => {
+			const { formatAsExpression } = useNodeSettingsParameters();
+			expect(formatAsExpression('foo', 'string')).toBe('=foo');
+		});
+
+		it('wraps number value with "={{ }}"', () => {
+			const { formatAsExpression } = useNodeSettingsParameters();
+			expect(formatAsExpression(42, 'number')).toBe('={{ 42 }}');
+		});
+
+		it('wraps boolean value with "={{ }}"', () => {
+			const { formatAsExpression } = useNodeSettingsParameters();
+			expect(formatAsExpression(true, 'boolean')).toBe('={{ true }}');
+		});
+
+		it('wraps multiOptions value with "={{ }}" and stringifies', () => {
+			const { formatAsExpression } = useNodeSettingsParameters();
+			expect(formatAsExpression(['a', 'b'], 'multiOptions')).toBe('={{ ["a","b"] }}');
+		});
+
+		it('returns "={{ 0 }}" for number with empty value', () => {
+			const { formatAsExpression } = useNodeSettingsParameters();
+			expect(formatAsExpression('', 'number')).toBe('={{ 0 }}');
+			expect(formatAsExpression('[Object: null]', 'number')).toBe('={{ 0 }}');
+		});
+
+		it('wraps non-string, non-number, non-boolean value with "={{ }}"', () => {
+			const { formatAsExpression } = useNodeSettingsParameters();
+			expect(formatAsExpression({ foo: 'bar' }, 'string')).toBe('={{ [object Object] }}');
+		});
+
+		it('handles resourceLocator value', () => {
+			const { formatAsExpression } = useNodeSettingsParameters();
+			const value = { __rl: true, value: 'abc', mode: 'url' };
+			expect(formatAsExpression(value, 'resourceLocator')).toEqual({
+				__rl: true,
+				value: '=abc',
+				mode: 'url',
+			});
+		});
+
+		it('handles resourceLocator value as string', () => {
+			const { formatAsExpression } = useNodeSettingsParameters();
+			expect(formatAsExpression('abc', 'resourceLocator')).toEqual({
+				__rl: true,
+				value: '=abc',
+				mode: '',
+			});
+		});
+	});
+
+	describe('parseFromExpression', () => {
+		it('removes expression from multiOptions string value', () => {
+			const { parseFromExpression } = useNodeSettingsParameters();
+			const options: INodePropertyOptions[] = [
+				{ name: 'Option A', value: 'a' },
+				{ name: 'Option B', value: 'b' },
+				{ name: 'Option C', value: 'c' },
+			];
+			expect(parseFromExpression('', 'a,b,c', 'multiOptions', [], options)).toEqual([
+				'a',
+				'b',
+				'c',
+			]);
+			expect(parseFromExpression('', 'a,x', 'multiOptions', [], options)).toEqual(['a']);
+		});
+
+		it('removes expression from resourceLocator value', () => {
+			const { parseFromExpression } = useNodeSettingsParameters();
+			const modelValue = { __rl: true, value: '=abc', mode: 'url' };
+			expect(parseFromExpression(modelValue, 'abc', 'resourceLocator', '', [])).toEqual({
+				__rl: true,
+				value: 'abc',
+				mode: 'url',
+			});
+		});
+
+		it('removes leading "=" from string parameter', () => {
+			const { parseFromExpression } = useNodeSettingsParameters();
+			expect(parseFromExpression('=foo', undefined, 'string', '', [])).toBe('foo');
+			expect(parseFromExpression('==bar', undefined, 'string', '', [])).toBe('bar');
+			expect(parseFromExpression('', undefined, 'string', '', [])).toBeNull();
+		});
+
+		it('returns value if defined and not string/resourceLocator/multiOptions', () => {
+			const { parseFromExpression } = useNodeSettingsParameters();
+			expect(parseFromExpression(123, 456, 'number', 0, [])).toBe(456);
+			expect(parseFromExpression(true, false, 'boolean', true, [])).toBe(false);
+		});
+
+		it('returns defaultValue for number/boolean if value is undefined', () => {
+			const { parseFromExpression } = useNodeSettingsParameters();
+			expect(parseFromExpression(123, undefined, 'number', 0, [])).toBe(0);
+			expect(parseFromExpression(true, undefined, 'boolean', false, [])).toBe(false);
+		});
+
+		it('returns null for other types if value is undefined', () => {
+			const { parseFromExpression } = useNodeSettingsParameters();
+			expect(parseFromExpression({}, undefined, 'json', null, [])).toBeNull();
+		});
+	});
+
+	describe('handleFocus', () => {
+		let ndvStore: MockedStore<typeof useNDVStore>;
+		let focusPanelStore: MockedStore<typeof useFocusPanelStore>;
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+
+			ndvStore = mockedStore(useNDVStore);
+			focusPanelStore = mockedStore(useFocusPanelStore);
+
+			ndvStore.activeNode = {
+				id: '123',
+				name: 'myParam',
+				parameters: {},
+				position: [0, 0],
+				type: 'test',
+				typeVersion: 1,
+			};
+			ndvStore.activeNodeName = 'Node1';
+			ndvStore.setActiveNodeName = vi.fn();
+			ndvStore.resetNDVPushRef = vi.fn();
+			focusPanelStore.setFocusedNodeParameter = vi.fn();
+			focusPanelStore.focusPanelActive = false;
+		});
+
+		it('sets focused node parameter and activates panel', () => {
+			const { handleFocus } = useNodeSettingsParameters();
+			const node: INodeUi = {
+				id: '1',
+				name: 'Node1',
+				position: [0, 0],
+				typeVersion: 1,
+				type: 'test',
+				parameters: {},
+			};
+			const path = 'parameters.foo';
+			const parameter: INodeProperties = {
+				name: 'foo',
+				displayName: 'Foo',
+				type: 'string',
+				default: '',
+			};
+
+			handleFocus(node, path, parameter);
+
+			expect(focusPanelStore.setFocusedNodeParameter).toHaveBeenCalledWith({
+				nodeId: node.id,
+				parameterPath: path,
+				parameter,
+			});
+			expect(focusPanelStore.focusPanelActive).toBe(true);
+
+			expect(ndvStore.setActiveNodeName).toHaveBeenCalledWith(null);
+			expect(ndvStore.resetNDVPushRef).toHaveBeenCalled();
+		});
+
+		it('does nothing if node is undefined', () => {
+			const { handleFocus } = useNodeSettingsParameters();
+
+			const parameter: INodeProperties = {
+				name: 'foo',
+				displayName: 'Foo',
+				type: 'string',
+				default: '',
+			};
+
+			handleFocus(undefined, 'parameters.foo', parameter);
+
+			expect(focusPanelStore.setFocusedNodeParameter).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/composables/useNodeSettingsParameters.ts
+++ b/packages/frontend/editor-ui/src/composables/useNodeSettingsParameters.ts
@@ -26,6 +26,7 @@ import { useNDVStore } from '@/stores/ndv.store';
 import { useWorkflowsStore } from '@/stores/workflows.store';
 import { CUSTOM_API_CALL_KEY } from '@/constants';
 import { isPresent } from '@/utils/typesUtils';
+import { omitKey } from '@/utils/objectUtils';
 
 export function useNodeSettingsParameters() {
 	const workflowsStore = useWorkflowsStore();
@@ -82,9 +83,7 @@ export function useNodeSettingsParameters() {
 			if (value === null) {
 				// Property should be deleted
 				if (lastNamePart) {
-					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					const { [lastNamePart]: _removedNodeValue, ...remainingNodeValues } = nodeValues.value;
-					nodeValues.value = remainingNodeValues;
+					nodeValues.value = omitKey(nodeValues.value, lastNamePart);
 				}
 			} else {
 				// Value should be set
@@ -102,9 +101,7 @@ export function useNodeSettingsParameters() {
 					| INodeParameters[];
 
 				if (lastNamePart && !Array.isArray(tempValue)) {
-					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					const { [lastNamePart]: _removedNodeValue, ...remainingNodeValues } = tempValue;
-					tempValue = remainingNodeValues;
+					tempValue = omitKey(tempValue, lastNamePart);
 				}
 
 				if (isArray && Array.isArray(tempValue) && tempValue.length === 0) {
@@ -113,10 +110,7 @@ export function useNodeSettingsParameters() {
 					lastNamePart = nameParts.pop();
 					tempValue = get(nodeValues.value, nameParts.join('.')) as INodeParameters;
 					if (lastNamePart) {
-						// eslint-disable-next-line @typescript-eslint/no-unused-vars
-						const { [lastNamePart]: _removedArrayNodeValue, ...remainingArrayNodeValues } =
-							tempValue;
-						tempValue = remainingArrayNodeValues;
+						tempValue = omitKey(tempValue, lastNamePart);
 					}
 				}
 			} else {
@@ -277,7 +271,7 @@ export function useNodeSettingsParameters() {
 		}
 
 		if (isNumber || isBoolean || typeof value !== 'string') {
-			// eslint-disable-next-line @typescript-eslint/no-base-to-string
+			// eslint-disable-next-line @typescript-eslint/no-base-to-string -- stringified intentionally
 			return `={{ ${String(value)} }}`;
 		}
 

--- a/packages/frontend/editor-ui/src/composables/useNodeSettingsParameters.ts
+++ b/packages/frontend/editor-ui/src/composables/useNodeSettingsParameters.ts
@@ -1,6 +1,6 @@
-import type { INodeUi, IUpdateInformation } from '@/Interface';
 import get from 'lodash/get';
 import set from 'lodash/set';
+import { ref } from 'vue';
 import {
 	type INode,
 	type INodeParameters,
@@ -14,15 +14,15 @@ import {
 	isResourceLocatorValue,
 } from 'n8n-workflow';
 import { useTelemetry } from './useTelemetry';
-import { useWorkflowsStore } from '@/stores/workflows.store';
 import { useNodeHelpers } from './useNodeHelpers';
 import { useCanvasOperations } from './useCanvasOperations';
 import { useExternalHooks } from './useExternalHooks';
-import { ref } from 'vue';
+import type { INodeUi, IUpdateInformation } from '@/Interface';
 import { updateDynamicConnections, updateParameterByPath } from '@/utils/nodeSettingsUtils';
 import { useNodeTypesStore } from '@/stores/nodeTypes.store';
 import { useFocusPanelStore } from '@/stores/focusPanel.store';
 import { useNDVStore } from '@/stores/ndv.store';
+import { useWorkflowsStore } from '@/stores/workflows.store';
 
 export function useNodeSettingsParameters() {
 	const workflowsStore = useWorkflowsStore();
@@ -44,6 +44,13 @@ export function useNodeSettingsParameters() {
 		notes: '',
 		parameters: {},
 	});
+
+	function getParameterTypeOption<T = string | number | boolean | undefined>(
+		parameter: INodeProperties,
+		optionName: string,
+	): T {
+		return parameter.typeOptions?.[optionName] as T;
+	}
 
 	function setValue(name: string, value: NodeParameterValue) {
 		const nameParts = name.split('.');
@@ -319,6 +326,7 @@ export function useNodeSettingsParameters() {
 
 	return {
 		nodeValues,
+		getParameterTypeOption,
 		setValue,
 		updateParameterByPath,
 		updateNodeParameter,

--- a/packages/frontend/editor-ui/src/composables/useNodeSettingsParameters.ts
+++ b/packages/frontend/editor-ui/src/composables/useNodeSettingsParameters.ts
@@ -23,6 +23,7 @@ import { useNodeTypesStore } from '@/stores/nodeTypes.store';
 import { useFocusPanelStore } from '@/stores/focusPanel.store';
 import { useNDVStore } from '@/stores/ndv.store';
 import { useWorkflowsStore } from '@/stores/workflows.store';
+import { CUSTOM_API_CALL_KEY } from '@/constants';
 
 export function useNodeSettingsParameters() {
 	const workflowsStore = useWorkflowsStore();
@@ -324,6 +325,10 @@ export function useNodeSettingsParameters() {
 		focusPanelStore.focusPanelActive = true;
 	}
 
+	function shouldSkipParamValidation(value: string | number | boolean | null) {
+		return typeof value === 'string' && value.includes(CUSTOM_API_CALL_KEY);
+	}
+
 	return {
 		nodeValues,
 		getParameterTypeOption,
@@ -335,5 +340,6 @@ export function useNodeSettingsParameters() {
 		formatAsExpression,
 		parseFromExpression,
 		handleFocus,
+		shouldSkipParamValidation,
 	};
 }

--- a/packages/frontend/editor-ui/src/composables/useNodeSettingsParameters.ts
+++ b/packages/frontend/editor-ui/src/composables/useNodeSettingsParameters.ts
@@ -58,7 +58,7 @@ export function useNodeSettingsParameters() {
 		let lastNamePart: string | undefined = nameParts.pop();
 
 		let isArray = false;
-		if (lastNamePart !== undefined && lastNamePart.includes('[')) {
+		if (lastNamePart?.includes('[')) {
 			// It includes an index so we have to extract it
 			const lastNameParts = lastNamePart.match(/(.*)\[(\d+)\]$/);
 			if (lastNameParts) {
@@ -74,7 +74,8 @@ export function useNodeSettingsParameters() {
 			if (value === null) {
 				// Property should be deleted
 				if (lastNamePart) {
-					const { [lastNamePart]: removedNodeValue, ...remainingNodeValues } = nodeValues.value;
+					// eslint-disable-next-line @typescript-eslint/no-unused-vars
+					const { [lastNamePart]: _removedNodeValue, ...remainingNodeValues } = nodeValues.value;
 					nodeValues.value = remainingNodeValues;
 				}
 			} else {
@@ -93,7 +94,8 @@ export function useNodeSettingsParameters() {
 					| INodeParameters[];
 
 				if (lastNamePart && !Array.isArray(tempValue)) {
-					const { [lastNamePart]: removedNodeValue, ...remainingNodeValues } = tempValue;
+					// eslint-disable-next-line @typescript-eslint/no-unused-vars
+					const { [lastNamePart]: _removedNodeValue, ...remainingNodeValues } = tempValue;
 					tempValue = remainingNodeValues;
 				}
 
@@ -103,7 +105,8 @@ export function useNodeSettingsParameters() {
 					lastNamePart = nameParts.pop();
 					tempValue = get(nodeValues.value, nameParts.join('.')) as INodeParameters;
 					if (lastNamePart) {
-						const { [lastNamePart]: removedArrayNodeValue, ...remainingArrayNodeValues } =
+						// eslint-disable-next-line @typescript-eslint/no-unused-vars
+						const { [lastNamePart]: _removedArrayNodeValue, ...remainingArrayNodeValues } =
 							tempValue;
 						tempValue = remainingArrayNodeValues;
 					}

--- a/packages/frontend/editor-ui/src/utils/expressions.ts
+++ b/packages/frontend/editor-ui/src/utils/expressions.ts
@@ -150,8 +150,12 @@ export const completeExpressionSyntax = <T>(value: T, isSpecializedEditor = fals
 	return value;
 };
 
-export const shouldConvertToExpression = <T>(value: T, isSpecializedEditor = false): boolean => {
+export const shouldConvertToExpression = (
+	value: unknown,
+	isSpecializedEditor = false,
+): value is string => {
 	if (isSpecializedEditor) return false;
+
 	return (
 		typeof value === 'string' &&
 		!value.startsWith('=') &&

--- a/packages/frontend/editor-ui/src/utils/objectUtils.test.ts
+++ b/packages/frontend/editor-ui/src/utils/objectUtils.test.ts
@@ -1,4 +1,10 @@
-import { isObjectOrArray, isObject, searchInObject, getObjectSizeInKB } from '@/utils/objectUtils';
+import {
+	isObjectOrArray,
+	isObject,
+	searchInObject,
+	getObjectSizeInKB,
+	omitKey,
+} from '@/utils/objectUtils';
 
 const testData = [1, '', true, null, undefined, new Date(), () => {}].map((value) => [
 	value,
@@ -152,6 +158,39 @@ describe('objectUtils', () => {
 		it('handles special characters correctly', () => {
 			const obj = { name: '测试' };
 			expect(getObjectSizeInKB(obj)).toBe(0.02);
+		});
+	});
+
+	describe('omitKey', () => {
+		it('should remove a top-level key from a flat object', () => {
+			const input = { a: 1, b: 2, c: 3 };
+			const result = omitKey(input, 'b');
+			expect(result).toEqual({ a: 1, c: 3 });
+		});
+
+		it('should not mutate the original object', () => {
+			const input = { a: 1, b: 2 };
+			const copy = { ...input };
+			omitKey(input, 'b');
+			expect(input).toEqual(copy);
+		});
+
+		it('should return the same object if the key does not exist', () => {
+			const input = { a: 1, b: 2 };
+			const result = omitKey(input, 'z');
+			expect(result).toEqual(input);
+		});
+
+		it('should remove a key with an undefined value', () => {
+			const input = { a: 1, b: undefined };
+			const result = omitKey(input, 'b');
+			expect(result).toEqual({ a: 1 });
+		});
+
+		it('should work with nested objects but only remove the top-level key', () => {
+			const input = { a: { nested: true }, b: 2 };
+			const result = omitKey(input, 'a');
+			expect(result).toEqual({ b: 2 });
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/utils/objectUtils.ts
+++ b/packages/frontend/editor-ui/src/utils/objectUtils.ts
@@ -51,6 +51,9 @@ export const getObjectSizeInKB = (obj: unknown): number => {
 	}
 };
 
-export function omitKey<T extends Record<string, unknown>>(obj: T, key: string): T {
-	return Object.fromEntries(Object.entries(obj).filter(([k]) => k !== key)) as T;
+export function omitKey<T extends Record<string, unknown>, S extends string>(
+	obj: T,
+	key: S,
+): Omit<T, S> {
+	return Object.fromEntries(Object.entries(obj).filter(([k]) => k !== key)) as Omit<T, S>;
 }

--- a/packages/frontend/editor-ui/src/utils/objectUtils.ts
+++ b/packages/frontend/editor-ui/src/utils/objectUtils.ts
@@ -50,3 +50,7 @@ export const getObjectSizeInKB = (obj: unknown): number => {
 		);
 	}
 };
+
+export function omitKey<T extends Record<string, unknown>>(obj: T, key: string): T {
+	return Object.fromEntries(Object.entries(obj).filter(([k]) => k !== key)) as T;
+}

--- a/packages/frontend/editor-ui/src/utils/typesUtils.ts
+++ b/packages/frontend/editor-ui/src/utils/typesUtils.ts
@@ -170,3 +170,39 @@ export const tryToParseNumber = (value: string): number | string => {
 export function isPresent<T>(arg: T): arg is Exclude<T, null | undefined> {
 	return arg !== null && arg !== undefined;
 }
+
+export function isFocusableEl(el: unknown): el is HTMLElement & { focus: () => void } {
+	return (
+		typeof el === 'object' &&
+		el !== null &&
+		'focus' in el &&
+		typeof (el as { focus?: unknown }).focus === 'function'
+	);
+}
+
+export function isBlurrableEl(el: unknown): el is HTMLElement & { blur: () => void } {
+	return (
+		typeof el === 'object' &&
+		el !== null &&
+		'blur' in el &&
+		typeof (el as { blur?: unknown }).blur === 'function'
+	);
+}
+
+export function isSelectableEl(el: unknown): el is HTMLInputElement | { select: () => void } {
+	return (
+		typeof el === 'object' &&
+		el !== null &&
+		'select' in el &&
+		typeof (el as { select?: unknown }).select === 'function'
+	);
+}
+
+export function hasFocusOnInput(el: unknown): el is { focusOnInput: () => void } {
+	return (
+		typeof el === 'object' &&
+		el !== null &&
+		'focusOnInput' in el &&
+		typeof (el as { focusOnInput?: unknown }).focusOnInput === 'function'
+	);
+}


### PR DESCRIPTION
## Summary

- Move reusable logic from `ParameterInput` component to a composable and utils.
- Add tests.
- Fix TS warnings in `ParameterInput` component and `useNodeSettingsParameters` composable.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3786/feature-move-optionselected-from-parameterinput-to-a-composable

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
