### PR TITLE
chore(core): Add error log for more detail when git phases fail

### DIFF
--- a/packages/cli/src/environments.ee/source-control/source-control-git.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-git.service.ee.ts
@@ -51,6 +51,7 @@ export class SourceControlGitService {
 			});
 			this.logger.debug(`Git binary found: ${gitResult.toString()}`);
 		} catch (error) {
+			this.logger.error('Git binary check failed', { error });
 			throw new UnexpectedError('Git binary not found', { cause: error });
 		}
 		try {
@@ -59,6 +60,7 @@ export class SourceControlGitService {
 			});
 			this.logger.debug(`SSH binary found: ${sshResult.toString()}`);
 		} catch (error) {
+			this.logger.error('SSH binary check failed', { error });
 			throw new UnexpectedError('SSH binary not found', { cause: error });
 		}
 		return true;
@@ -153,6 +155,7 @@ export class SourceControlGitService {
 				return true;
 			}
 		} catch (error) {
+			this.logger.error('Git remote check failed', { error });
 			throw new UnexpectedError('Git is not initialized', { cause: error });
 		}
 		this.logger.debug(`Git remote not found: ${remote}`);
@@ -256,6 +259,7 @@ export class SourceControlGitService {
 				currentBranch: current,
 			};
 		} catch (error) {
+			this.logger.error('Failed to get branches', { error });
 			throw new UnexpectedError('Could not get remote branches from repository', { cause: error });
 		}
 	}


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Error caught in source control git service are re-thrown as UnexpectedError, which implies losing the root cause of the error. 
This PR adds specific logging of the root cause to help diagnose those issues.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-3029/bug-enterprise-client-worldstream-git-not-initialized#comment-c3d90bb0


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
