### PR TITLE
fix(HTTP Request Node): Fix paginated requests with HttpBearerAuth

### DIFF
--- a/packages/cli/src/credentials-helper.ts
+++ b/packages/cli/src/credentials-helper.ts
@@ -28,7 +28,13 @@ import type {
 	IExecuteData,
 	IDataObject,
 } from 'n8n-workflow';
-import { ICredentialsHelper, NodeHelpers, Workflow, UnexpectedError } from 'n8n-workflow';
+import {
+	ICredentialsHelper,
+	NodeHelpers,
+	Workflow,
+	UnexpectedError,
+	isExpression,
+} from 'n8n-workflow';
 
 import { CredentialTypes } from '@/credential-types';
 import { CredentialsOverwrites } from '@/credentials-overwrites';
@@ -208,7 +214,7 @@ export class CredentialsHelper extends ICredentialsHelper {
 		workflow: Workflow,
 		node: INode,
 	): string {
-		if (typeof parameterValue !== 'string' || parameterValue.charAt(0) !== '=') {
+		if (!isExpression(parameterValue)) {
 			return parameterValue;
 		}
 

--- a/packages/frontend/editor-ui/src/utils/expressions.ts
+++ b/packages/frontend/editor-ui/src/utils/expressions.ts
@@ -1,12 +1,9 @@
 import { i18n } from '@n8n/i18n';
 import { useWorkflowsStore } from '@/stores/workflows.store';
 import type { ResolvableState } from '@/types/expressions';
-import { ExpressionError, ExpressionParser, type Result } from 'n8n-workflow';
+import { ExpressionError, ExpressionParser, isExpression, type Result } from 'n8n-workflow';
 
-export const isExpression = (expr: unknown) => {
-	if (typeof expr !== 'string') return false;
-	return expr.startsWith('=');
-};
+export { isExpression };
 
 export const isEmptyExpression = (expr: string) => {
 	return /\{\{\s*\}\}/.test(expr);
@@ -17,7 +14,7 @@ export const unwrapExpression = (expr: string) => {
 };
 
 export const removeExpressionPrefix = <T = unknown>(expr: T): T | string => {
-	return typeof expr === 'string' && expr.startsWith('=') ? expr.slice(1) : (expr ?? '');
+	return isExpression(expr) ? expr.slice(1) : (expr ?? '');
 };
 
 export const isTestableExpression = (expr: string) => {

--- a/packages/nodes-base/credentials/HttpBearerAuth.credentials.ts
+++ b/packages/nodes-base/credentials/HttpBearerAuth.credentials.ts
@@ -36,7 +36,7 @@ export class HttpBearerAuth implements ICredentialType {
 		type: 'generic',
 		properties: {
 			headers: {
-				Authorization: 'Bearer ={{$credentials.token}}',
+				Authorization: '=Bearer {{$credentials.token}}',
 			},
 		},
 	};

--- a/packages/workflow/src/expression.ts
+++ b/packages/workflow/src/expression.ts
@@ -25,6 +25,7 @@ import type {
 } from './interfaces';
 import type { Workflow } from './workflow';
 import { WorkflowDataProxy } from './workflow-data-proxy';
+import { isExpression } from './expressions/expression-helpers';
 
 const IS_FRONTEND_IN_DEV_MODE =
 	typeof process === 'object' &&
@@ -118,7 +119,7 @@ export class Expression {
 		contextNodeName?: string,
 	): NodeParameterValue | INodeParameters | NodeParameterValue[] | INodeParameters[] {
 		// Check if it is an expression
-		if (typeof parameterValue !== 'string' || parameterValue.charAt(0) !== '=') {
+		if (!isExpression(parameterValue)) {
 			// Is no expression so return value
 			return parameterValue;
 		}

--- a/packages/workflow/src/expressions/expression-helpers.ts
+++ b/packages/workflow/src/expressions/expression-helpers.ts
@@ -1,0 +1,9 @@
+/**
+ * Checks if the given value is an expression. An expression is a string that
+ * starts with '='.
+ */
+export const isExpression = (expr: unknown): expr is string => {
+	if (typeof expr !== 'string') return false;
+
+	return expr.charAt(0) === '=';
+};

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -12,6 +12,7 @@ export * from './interfaces';
 export * from './message-event-bus';
 export * from './execution-status';
 export * from './expression';
+export * from './expressions/expression-helpers';
 export * from './from-ai-parse-utils';
 export * from './node-helpers';
 export * from './node-reference-parser-utils';

--- a/packages/workflow/test/expressions/expression-helpers.test.ts
+++ b/packages/workflow/test/expressions/expression-helpers.test.ts
@@ -1,0 +1,25 @@
+import { isExpression } from '../../src/expressions/expression-helpers';
+
+describe('ExpressionHelpers', () => {
+	describe('isExpression', () => {
+		describe('should return true for valid expressions', () => {
+			test.each([
+				['=1', 'simple number expression'],
+				['=true', 'boolean expression'],
+				['="hello"', 'string expression'],
+				['={{ $json.field }}', 'complex expression with spaces'],
+			])('"$s" should be an expression', (expr) => {
+				expect(isExpression(expr)).toBe(true);
+			});
+		});
+
+		describe('should return false for invalid expressions', () => {
+			test.each([[null], [undefined], [1], [true], [''], ['hello']])(
+				'"$s" should not be an expression',
+				(expr) => {
+					expect(isExpression(expr)).toBe(false);
+				},
+			);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Fixes HttpBearerAuth not working with HTTP Request Node when using pagination. The expression to evaluate the header value was incorrect, and hence didn't work.

Also includes a commit:
- refactor(core): Extract isExpression to own function

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1001/community-issue-bearer-auth-generic-authentication-on-the-http-request

closes #15261

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
