### PR TITLE
feat: Update Chat SDK to support streaming responses

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/ToolsAgentV2.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/ToolsAgentV2.test.ts
@@ -487,10 +487,10 @@ describe('toolsAgentExecute', () => {
 
 			const result = await toolsAgentExecute.call(mockContext);
 
-			expect(mockContext.sendChunk).toHaveBeenCalledWith('begin');
-			expect(mockContext.sendChunk).toHaveBeenCalledWith('item', 'Hello ');
-			expect(mockContext.sendChunk).toHaveBeenCalledWith('item', 'world!');
-			expect(mockContext.sendChunk).toHaveBeenCalledWith('end');
+			expect(mockContext.sendChunk).toHaveBeenCalledWith('begin', 0);
+			expect(mockContext.sendChunk).toHaveBeenCalledWith('item', 0, 'Hello ');
+			expect(mockContext.sendChunk).toHaveBeenCalledWith('item', 0, 'world!');
+			expect(mockContext.sendChunk).toHaveBeenCalledWith('end', 0);
 			expect(mockExecutor.streamEvents).toHaveBeenCalledTimes(1);
 			expect(result[0]).toHaveLength(1);
 			expect(result[0][0].json.output).toBe('Hello world!');

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
@@ -591,6 +591,7 @@ export class ChatTrigger extends Node {
 					allowFileUploads: options.allowFileUploads,
 					allowedFilesMimeTypes: options.allowedFilesMimeTypes,
 					customCss: options.customCss,
+					enableStreaming,
 				});
 
 				res.status(200).send(page).end();

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/templates.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/templates.ts
@@ -12,6 +12,7 @@ export function createPage({
 	allowFileUploads,
 	allowedFilesMimeTypes,
 	customCss,
+	enableStreaming,
 }: {
 	instanceId: string;
 	webhookUrl?: string;
@@ -26,6 +27,7 @@ export function createPage({
 	allowFileUploads?: boolean;
 	allowedFilesMimeTypes?: string;
 	customCss?: string;
+	enableStreaming?: boolean;
 }) {
 	const validAuthenticationOptions: AuthenticationChatOption[] = [
 		'none',
@@ -124,6 +126,7 @@ export function createPage({
 							${en ? `en: ${JSON.stringify(en)},` : ''}
 						},
 						${initialMessages.length ? `initialMessages: ${JSON.stringify(initialMessages)},` : ''}
+						enableStreaming: ${!!enableStreaming},
 					});
 				})();
 			</script>

--- a/packages/cli/src/__tests__/active-executions.test.ts
+++ b/packages/cli/src/__tests__/active-executions.test.ts
@@ -225,6 +225,8 @@ describe('ActiveExecutions', () => {
 				metadata: {
 					nodeName: 'testNode',
 					nodeId: uuid(),
+					runIndex: 0,
+					itemIndex: 0,
 					timestamp: Date.now(),
 				},
 			};
@@ -242,6 +244,8 @@ describe('ActiveExecutions', () => {
 				metadata: {
 					nodeName: 'testNode',
 					nodeId: uuid(),
+					runIndex: 0,
+					itemIndex: 0,
 					timestamp: Date.now(),
 				},
 			};

--- a/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
@@ -2238,6 +2238,12 @@ describe('WorkflowExecute', () => {
 				{
 					type: 'error',
 					content: 'A detailed error description',
+					metadata: {
+						nodeId: errorNode.id,
+						nodeName: errorNode.name,
+						runIndex: 0,
+						itemIndex: 0,
+					},
 				},
 			]);
 		});
@@ -2296,6 +2302,12 @@ describe('WorkflowExecute', () => {
 				{
 					type: 'error',
 					content: 'The API returned an error',
+					metadata: {
+						nodeId: errorNode.id,
+						nodeName: errorNode.name,
+						runIndex: 0,
+						itemIndex: 0,
+					},
 				},
 			]);
 		});
@@ -2400,6 +2412,12 @@ describe('WorkflowExecute', () => {
 				{
 					type: 'error',
 					content: 'Custom error description',
+					metadata: {
+						nodeId: errorNode.id,
+						nodeName: errorNode.name,
+						runIndex: 0,
+						itemIndex: 0,
+					},
 				},
 			]);
 		});
@@ -2457,6 +2475,12 @@ describe('WorkflowExecute', () => {
 				{
 					type: 'error',
 					content: undefined, // When no description is available, content should be undefined
+					metadata: {
+						nodeId: errorNode.id,
+						nodeName: errorNode.name,
+						runIndex: 0,
+						itemIndex: 0,
+					},
 				},
 			]);
 		});

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/execute-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/execute-context.test.ts
@@ -292,7 +292,7 @@ describe('ExecuteContext', () => {
 				abortSignal,
 			);
 
-			await testExecuteContext.sendChunk('item', 'test');
+			await testExecuteContext.sendChunk('item', 0, 'test');
 
 			expect(hooksMock.runHook).toHaveBeenCalledWith('sendChunk', [
 				expect.objectContaining({
@@ -301,6 +301,8 @@ describe('ExecuteContext', () => {
 					metadata: expect.objectContaining({
 						nodeName: 'Test Node',
 						nodeId: 'test-node-id',
+						runIndex: 0,
+						itemIndex: 0,
 						timestamp: expect.any(Number),
 					}),
 				}),
@@ -330,7 +332,7 @@ describe('ExecuteContext', () => {
 				abortSignal,
 			);
 
-			await testExecuteContext.sendChunk('begin');
+			await testExecuteContext.sendChunk('begin', 0);
 
 			expect(hooksMock.runHook).toHaveBeenCalledWith('sendChunk', [
 				expect.objectContaining({
@@ -339,6 +341,8 @@ describe('ExecuteContext', () => {
 					metadata: expect.objectContaining({
 						nodeName: 'Test Node',
 						nodeId: 'test-node-id',
+						runIndex: 0,
+						itemIndex: 0,
 						timestamp: expect.any(Number),
 					}),
 				}),
@@ -366,7 +370,7 @@ describe('ExecuteContext', () => {
 			);
 
 			// Should not throw error
-			await expect(testExecuteContext.sendChunk('item', 'test')).resolves.toBeUndefined();
+			await expect(testExecuteContext.sendChunk('item', 0, 'test')).resolves.toBeUndefined();
 		});
 	});
 });

--- a/packages/core/src/execution-engine/node-execution-context/execute-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/execute-context.ts
@@ -146,11 +146,17 @@ export class ExecuteContext extends BaseExecuteContext implements IExecuteFuncti
 		return hasHandlers && isStreamingMode && streamingEnabled;
 	}
 
-	async sendChunk(type: ChunkType, content?: IDataObject | string): Promise<void> {
+	async sendChunk(
+		type: ChunkType,
+		itemIndex: number,
+		content?: IDataObject | string,
+	): Promise<void> {
 		const node = this.getNode();
 		const metadata = {
 			nodeId: node.id,
 			nodeName: node.name,
+			itemIndex,
+			runIndex: this.runIndex,
 			timestamp: Date.now(),
 		};
 

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -1721,7 +1721,16 @@ export class WorkflowExecute {
 
 						// Send error to the response if necessary
 						await hooks?.runHook('sendChunk', [
-							{ type: 'error', content: executionError.description },
+							{
+								type: 'error',
+								content: executionError.description,
+								metadata: {
+									nodeId: executionNode.id,
+									nodeName: executionNode.name,
+									runIndex,
+									itemIndex: 0,
+								},
+							},
 						]);
 
 						if (

--- a/packages/frontend/@n8n/chat/README.md
+++ b/packages/frontend/@n8n/chat/README.md
@@ -14,6 +14,9 @@ Open the **Chat Trigger** node and add your domain to the **Allowed Origins (COR
 
 [See example workflow](https://github.com/n8n-io/n8n/blob/master/packages/%40n8n/chat/resources/workflow.json)
 
+To use streaming responses, you need to enable the **Streaming response** response mode in the **Chat Trigger** node.
+[See example workflow with streaming](https://github.com/n8n-io/n8n/blob/master/packages/%40n8n/chat/resources/workflow-streaming.json)
+
 > Make sure the workflow is **Active.**
 
 ### How it works
@@ -129,6 +132,7 @@ createChat({
 			inputPlaceholder: 'Type your question..',
 		},
 	},
+	enableStreaming: false,
 });
 ```
 
@@ -175,7 +179,7 @@ createChat({
 ### `loadPreviousSession`
 - **Type**: `boolean`
 - **Default**: `true`
-- **Description**: Whether to load previous messages (chat context). 
+- **Description**: Whether to load previous messages (chat context).
 
 ### `defaultLanguage`
 - **Type**: `string`
@@ -199,6 +203,11 @@ createChat({
 - **Type**: `Ref<string> | string`
 - **Default**: `''`
 - **Description**: A comma-separated list of allowed MIME types for file uploads. Only applicable if `allowFileUploads` is set to `true`. If left empty, all file types are allowed. For example: `'image/*,application/pdf'`.
+
+### enableStreaming
+- Type: boolean
+- Default: false
+- Description: Whether to enable streaming responses from the n8n workflow. If set to `true`, the chat will display responses as they are being generated, providing a more interactive experience. For this to work the workflow must be configured as well to return streaming responses.
 
 ## Customization
 The Chat window is entirely customizable using CSS variables.

--- a/packages/frontend/@n8n/chat/resources/workflow-streaming.json
+++ b/packages/frontend/@n8n/chat/resources/workflow-streaming.json
@@ -1,0 +1,84 @@
+{
+	"nodes": [
+		{
+			"parameters": {
+				"model": {
+					"__rl": true,
+					"mode": "list",
+					"value": "gpt-4.1-mini"
+				},
+				"options": {}
+			},
+			"type": "@n8n/n8n-nodes-langchain.lmChatOpenAi",
+			"typeVersion": 1.2,
+			"position": [400, 224],
+			"id": "9593988a-2ca5-4a82-bd3a-3d8fcb69036d",
+			"name": "OpenAI Chat Model",
+			"credentials": {
+				"openAiApi": {
+					"id": "Rr1g6PqGGpNJcaBf",
+					"name": "OpenAi account"
+				}
+			}
+		},
+		{
+			"parameters": {
+				"options": {
+					"returnIntermediateSteps": false,
+					"enableStreaming": false
+				}
+			},
+			"type": "@n8n/n8n-nodes-langchain.agent",
+			"typeVersion": 2.2,
+			"position": [400, 48],
+			"id": "72b37ab2-7352-476b-bca6-5b41e2290082",
+			"name": "AI Agent"
+		},
+		{
+			"parameters": {
+				"public": true,
+				"options": {
+					"responseMode": "streaming"
+				}
+			},
+			"type": "@n8n/n8n-nodes-langchain.chatTrigger",
+			"typeVersion": 1.2,
+			"position": [32, 48],
+			"id": "012ecda4-3ae8-4328-a371-c7ae63cabf1c",
+			"name": "When chat message received",
+			"webhookId": "022d6461-e68d-4531-b713-833953c388c2"
+		}
+	],
+	"connections": {
+		"OpenAI Chat Model": {
+			"ai_languageModel": [
+				[
+					{
+						"node": "AI Agent",
+						"type": "ai_languageModel",
+						"index": 0
+					}
+				]
+			]
+		},
+		"AI Agent": {
+			"main": [[]]
+		},
+		"When chat message received": {
+			"main": [
+				[
+					{
+						"node": "AI Agent",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"pinData": {},
+	"meta": {
+		"templateCredsSetupCompleted": true,
+		"instanceId": "1d6725ae695aac02e442b627cd2266d305eba55a427b2dcc7702a0271b70043c"
+	}
+}

--- a/packages/frontend/@n8n/chat/src/__stories__/App.stories.ts
+++ b/packages/frontend/@n8n/chat/src/__stories__/App.stories.ts
@@ -32,6 +32,7 @@ export const Fullscreen: Story = {
 	args: {
 		webhookUrl,
 		mode: 'fullscreen',
+		enableStreaming: false,
 	} satisfies Partial<ChatOptions>,
 };
 
@@ -39,6 +40,7 @@ export const Windowed: Story = {
 	args: {
 		webhookUrl,
 		mode: 'window',
+		enableStreaming: false,
 	} satisfies Partial<ChatOptions>,
 };
 
@@ -51,5 +53,6 @@ export const WorkflowChat: Story = {
 		allowFileUploads: true,
 		showWelcomeScreen: false,
 		initialMessages: [],
+		enableStreaming: false,
 	} satisfies Partial<ChatOptions>,
 };

--- a/packages/frontend/@n8n/chat/src/__tests__/api/message.spec.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/api/message.spec.ts
@@ -94,15 +94,11 @@ describe('sendMessageStreaming', () => {
 		const onBeginMessage = vi.fn();
 		const onEndMessage = vi.fn();
 
-		await sendMessageStreaming(
-			'Test message',
-			[],
-			'test-session-id',
-			mockOptions,
+		await sendMessageStreaming('Test message', [], 'test-session-id', mockOptions, {
 			onChunk,
 			onBeginMessage,
 			onEndMessage,
-		);
+		});
 
 		expect(fetch).toHaveBeenCalledWith('https://test.example.com/webhook', {
 			method: 'POST',
@@ -216,15 +212,11 @@ describe('sendMessageStreaming', () => {
 		const onBeginMessage = vi.fn();
 		const onEndMessage = vi.fn();
 
-		await sendMessageStreaming(
-			'Test message',
-			[],
-			'test-session-id',
-			mockOptions,
+		await sendMessageStreaming('Test message', [], 'test-session-id', mockOptions, {
 			onChunk,
 			onBeginMessage,
 			onEndMessage,
-		);
+		});
 
 		expect(onBeginMessage).toHaveBeenCalledTimes(2);
 		expect(onBeginMessage).toHaveBeenCalledWith('node-1', 0);
@@ -309,15 +301,11 @@ describe('sendMessageStreaming', () => {
 		const onBeginMessage = vi.fn();
 		const onEndMessage = vi.fn();
 
-		await sendMessageStreaming(
-			'Test message',
-			[testFile],
-			'test-session-id',
-			mockOptions,
+		await sendMessageStreaming('Test message', [testFile], 'test-session-id', mockOptions, {
 			onChunk,
 			onBeginMessage,
 			onEndMessage,
-		);
+		});
 
 		// Verify FormData was used for file upload
 		expect(fetch).toHaveBeenCalledWith('https://test.example.com/webhook', {
@@ -348,15 +336,11 @@ describe('sendMessageStreaming', () => {
 		vi.spyOn(global, 'fetch').mockResolvedValue(mockResponse);
 
 		await expect(
-			sendMessageStreaming(
-				'Test message',
-				[],
-				'test-session-id',
-				mockOptions,
-				vi.fn(),
-				vi.fn(),
-				vi.fn(),
-			),
+			sendMessageStreaming('Test message', [], 'test-session-id', mockOptions, {
+				onChunk: vi.fn(),
+				onEndMessage: vi.fn(),
+				onBeginMessage: vi.fn(),
+			}),
 		).rejects.toThrow('Error while sending message. Error: Internal Server Error');
 	});
 
@@ -371,15 +355,11 @@ describe('sendMessageStreaming', () => {
 		vi.spyOn(global, 'fetch').mockResolvedValue(mockResponse);
 
 		await expect(
-			sendMessageStreaming(
-				'Test message',
-				[],
-				'test-session-id',
-				mockOptions,
-				vi.fn(),
-				vi.fn(),
-				vi.fn(),
-			),
+			sendMessageStreaming('Test message', [], 'test-session-id', mockOptions, {
+				onChunk: vi.fn(),
+				onEndMessage: vi.fn(),
+				onBeginMessage: vi.fn(),
+			}),
 		).rejects.toThrow('Response body is not readable');
 	});
 
@@ -421,15 +401,11 @@ describe('sendMessageStreaming', () => {
 
 		vi.spyOn(global, 'fetch').mockResolvedValue(mockResponse);
 
-		await sendMessageStreaming(
-			'Test message',
-			[],
-			'test-session-id',
-			optionsWithHeaders,
-			vi.fn(),
-			vi.fn(),
-			vi.fn(),
-		);
+		await sendMessageStreaming('Test message', [], 'test-session-id', optionsWithHeaders, {
+			onChunk: vi.fn(),
+			onEndMessage: vi.fn(),
+			onBeginMessage: vi.fn(),
+		});
 
 		expect(fetch).toHaveBeenCalledWith('https://test.example.com/webhook', {
 			method: 'POST',
@@ -483,15 +459,11 @@ describe('sendMessageStreaming', () => {
 
 		vi.spyOn(global, 'fetch').mockResolvedValue(mockResponse);
 
-		await sendMessageStreaming(
-			'Test message',
-			[],
-			'test-session-id',
-			optionsWithMetadata,
-			vi.fn(),
-			vi.fn(),
-			vi.fn(),
-		);
+		await sendMessageStreaming('Test message', [], 'test-session-id', optionsWithMetadata, {
+			onChunk: vi.fn(),
+			onEndMessage: vi.fn(),
+			onBeginMessage: vi.fn(),
+		});
 
 		expect(fetch).toHaveBeenCalledWith('https://test.example.com/webhook', {
 			method: 'POST',

--- a/packages/frontend/@n8n/chat/src/__tests__/api/message.spec.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/api/message.spec.ts
@@ -26,10 +26,21 @@ describe('sendMessageStreaming', () => {
 
 	it('should call the webhook URL with correct parameters', async () => {
 		const chunks = [
-			{ type: 'begin' },
-			{ type: 'progress', output: 'Hello ' },
-			{ type: 'progress', output: 'World!' },
-			{ type: 'end' },
+			{
+				type: 'begin',
+				metadata: { nodeId: 'node-1', nodeName: 'Test Node', timestamp: Date.now() },
+			},
+			{
+				type: 'item',
+				content: 'Hello ',
+				metadata: { nodeId: 'node-1', nodeName: 'Test Node', timestamp: Date.now() },
+			},
+			{
+				type: 'item',
+				content: 'World!',
+				metadata: { nodeId: 'node-1', nodeName: 'Test Node', timestamp: Date.now() },
+			},
+			{ type: 'end', metadata: { nodeId: 'node-1', nodeName: 'Test Node', timestamp: Date.now() } },
 		];
 
 		const encoder = new TextEncoder();
@@ -47,6 +58,7 @@ describe('sendMessageStreaming', () => {
 			ok: true,
 			status: 200,
 			body: stream,
+			headers: new Headers(),
 		} as Response;
 
 		const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(mockResponse);
@@ -69,6 +81,7 @@ describe('sendMessageStreaming', () => {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',
+				Accept: 'text/plain',
 			},
 			body: JSON.stringify({
 				action: 'sendMessage',
@@ -78,10 +91,12 @@ describe('sendMessageStreaming', () => {
 		});
 
 		expect(onBeginMessage).toHaveBeenCalledTimes(1);
+		expect(onBeginMessage).toHaveBeenCalledWith('node-1');
 		expect(onChunk).toHaveBeenCalledTimes(2);
-		expect(onChunk).toHaveBeenCalledWith('Hello ');
-		expect(onChunk).toHaveBeenCalledWith('World!');
+		expect(onChunk).toHaveBeenCalledWith('Hello ', 'node-1');
+		expect(onChunk).toHaveBeenCalledWith('World!', 'node-1');
 		expect(onEndMessage).toHaveBeenCalledTimes(1);
+		expect(onEndMessage).toHaveBeenCalledWith('node-1');
 	});
 
 	it('should reject file uploads', async () => {
@@ -104,6 +119,8 @@ describe('sendMessageStreaming', () => {
 		const mockResponse = {
 			ok: false,
 			status: 500,
+			headers: new Headers(),
+			text: () => Promise.resolve('Internal Server Error'),
 		} as Response;
 
 		vi.spyOn(global, 'fetch').mockResolvedValue(mockResponse);
@@ -126,6 +143,7 @@ describe('sendMessageStreaming', () => {
 			ok: true,
 			status: 200,
 			body: null,
+			headers: new Headers(),
 		} as Response;
 
 		vi.spyOn(global, 'fetch').mockResolvedValue(mockResponse);
@@ -154,7 +172,13 @@ describe('sendMessageStreaming', () => {
 			},
 		};
 
-		const chunks = [{ type: 'begin' }, { type: 'end' }];
+		const chunks = [
+			{
+				type: 'begin',
+				metadata: { nodeId: 'node-1', nodeName: 'Test Node', timestamp: Date.now() },
+			},
+			{ type: 'end', metadata: { nodeId: 'node-1', nodeName: 'Test Node', timestamp: Date.now() } },
+		];
 		const encoder = new TextEncoder();
 		const stream = new ReadableStream({
 			start(controller) {
@@ -170,6 +194,7 @@ describe('sendMessageStreaming', () => {
 			ok: true,
 			status: 200,
 			body: stream,
+			headers: new Headers(),
 		} as Response;
 
 		const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(mockResponse);
@@ -188,6 +213,7 @@ describe('sendMessageStreaming', () => {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',
+				Accept: 'text/plain',
 				Authorization: 'Bearer token',
 				'X-Custom-Header': 'value',
 			},
@@ -208,7 +234,13 @@ describe('sendMessageStreaming', () => {
 			},
 		};
 
-		const chunks = [{ type: 'begin' }, { type: 'end' }];
+		const chunks = [
+			{
+				type: 'begin',
+				metadata: { nodeId: 'node-1', nodeName: 'Test Node', timestamp: Date.now() },
+			},
+			{ type: 'end', metadata: { nodeId: 'node-1', nodeName: 'Test Node', timestamp: Date.now() } },
+		];
 		const encoder = new TextEncoder();
 		const stream = new ReadableStream({
 			start(controller) {
@@ -224,6 +256,7 @@ describe('sendMessageStreaming', () => {
 			ok: true,
 			status: 200,
 			body: stream,
+			headers: new Headers(),
 		} as Response;
 
 		const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(mockResponse);
@@ -242,6 +275,7 @@ describe('sendMessageStreaming', () => {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',
+				Accept: 'text/plain',
 			},
 			body: JSON.stringify({
 				action: 'sendMessage',

--- a/packages/frontend/@n8n/chat/src/__tests__/api/message.spec.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/api/message.spec.ts
@@ -342,7 +342,7 @@ describe('sendMessageStreaming', () => {
 			ok: false,
 			status: 500,
 			headers: new Headers(),
-			text: () => Promise.resolve('Internal Server Error'),
+			text: async () => 'Internal Server Error',
 		} as Response;
 
 		vi.spyOn(global, 'fetch').mockResolvedValue(mockResponse);

--- a/packages/frontend/@n8n/chat/src/__tests__/api/message.spec.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/api/message.spec.ts
@@ -1,0 +1,257 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { sendMessageStreaming } from '@n8n/chat/api';
+import type { ChatOptions } from '@n8n/chat/types';
+
+describe('sendMessageStreaming', () => {
+	const mockOptions: ChatOptions = {
+		webhookUrl: 'https://test.example.com/webhook',
+		chatSessionKey: 'sessionId',
+		chatInputKey: 'chatInput',
+		i18n: {
+			en: {
+				title: 'Test',
+				subtitle: 'Test',
+				footer: 'Test',
+				getStarted: 'Test',
+				inputPlaceholder: 'Test',
+				closeButtonTooltip: 'Test',
+			},
+		},
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should call the webhook URL with correct parameters', async () => {
+		const chunks = [
+			{ type: 'begin' },
+			{ type: 'progress', output: 'Hello ' },
+			{ type: 'progress', output: 'World!' },
+			{ type: 'end' },
+		];
+
+		const encoder = new TextEncoder();
+		const stream = new ReadableStream({
+			start(controller) {
+				chunks.forEach((chunk) => {
+					const data = JSON.stringify(chunk) + '\n';
+					controller.enqueue(encoder.encode(data));
+				});
+				controller.close();
+			},
+		});
+
+		const mockResponse = {
+			ok: true,
+			status: 200,
+			body: stream,
+		} as Response;
+
+		const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(mockResponse);
+
+		const onChunk = vi.fn();
+		const onBeginMessage = vi.fn();
+		const onEndMessage = vi.fn();
+
+		await sendMessageStreaming(
+			'Test message',
+			[],
+			'test-session-id',
+			mockOptions,
+			onChunk,
+			onBeginMessage,
+			onEndMessage,
+		);
+
+		expect(fetchSpy).toHaveBeenCalledWith('https://test.example.com/webhook', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				action: 'sendMessage',
+				sessionId: 'test-session-id',
+				chatInput: 'Test message',
+			}),
+		});
+
+		expect(onBeginMessage).toHaveBeenCalledTimes(1);
+		expect(onChunk).toHaveBeenCalledTimes(2);
+		expect(onChunk).toHaveBeenCalledWith('Hello ');
+		expect(onChunk).toHaveBeenCalledWith('World!');
+		expect(onEndMessage).toHaveBeenCalledTimes(1);
+	});
+
+	it('should reject file uploads', async () => {
+		const testFile = new File(['test'], 'test.txt', { type: 'text/plain' });
+
+		await expect(
+			sendMessageStreaming(
+				'Test message',
+				[testFile],
+				'test-session-id',
+				mockOptions,
+				vi.fn(),
+				vi.fn(),
+				vi.fn(),
+			),
+		).rejects.toThrow('File uploads are not supported with streaming responses');
+	});
+
+	it('should handle HTTP errors', async () => {
+		const mockResponse = {
+			ok: false,
+			status: 500,
+		} as Response;
+
+		vi.spyOn(global, 'fetch').mockResolvedValue(mockResponse);
+
+		await expect(
+			sendMessageStreaming(
+				'Test message',
+				[],
+				'test-session-id',
+				mockOptions,
+				vi.fn(),
+				vi.fn(),
+				vi.fn(),
+			),
+		).rejects.toThrow('HTTP error! status: 500');
+	});
+
+	it('should handle missing response body', async () => {
+		const mockResponse = {
+			ok: true,
+			status: 200,
+			body: null,
+		} as Response;
+
+		vi.spyOn(global, 'fetch').mockResolvedValue(mockResponse);
+
+		await expect(
+			sendMessageStreaming(
+				'Test message',
+				[],
+				'test-session-id',
+				mockOptions,
+				vi.fn(),
+				vi.fn(),
+				vi.fn(),
+			),
+		).rejects.toThrow('Response body is not readable');
+	});
+
+	it('should include custom headers from webhook config', async () => {
+		const optionsWithHeaders: ChatOptions = {
+			...mockOptions,
+			webhookConfig: {
+				headers: {
+					Authorization: 'Bearer token',
+					'X-Custom-Header': 'value',
+				},
+			},
+		};
+
+		const chunks = [{ type: 'begin' }, { type: 'end' }];
+		const encoder = new TextEncoder();
+		const stream = new ReadableStream({
+			start(controller) {
+				chunks.forEach((chunk) => {
+					const data = JSON.stringify(chunk) + '\n';
+					controller.enqueue(encoder.encode(data));
+				});
+				controller.close();
+			},
+		});
+
+		const mockResponse = {
+			ok: true,
+			status: 200,
+			body: stream,
+		} as Response;
+
+		const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(mockResponse);
+
+		await sendMessageStreaming(
+			'Test message',
+			[],
+			'test-session-id',
+			optionsWithHeaders,
+			vi.fn(),
+			vi.fn(),
+			vi.fn(),
+		);
+
+		expect(fetchSpy).toHaveBeenCalledWith('https://test.example.com/webhook', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: 'Bearer token',
+				'X-Custom-Header': 'value',
+			},
+			body: JSON.stringify({
+				action: 'sendMessage',
+				sessionId: 'test-session-id',
+				chatInput: 'Test message',
+			}),
+		});
+	});
+
+	it('should include metadata when provided', async () => {
+		const optionsWithMetadata: ChatOptions = {
+			...mockOptions,
+			metadata: {
+				userId: 'user-123',
+				source: 'chat-widget',
+			},
+		};
+
+		const chunks = [{ type: 'begin' }, { type: 'end' }];
+		const encoder = new TextEncoder();
+		const stream = new ReadableStream({
+			start(controller) {
+				chunks.forEach((chunk) => {
+					const data = JSON.stringify(chunk) + '\n';
+					controller.enqueue(encoder.encode(data));
+				});
+				controller.close();
+			},
+		});
+
+		const mockResponse = {
+			ok: true,
+			status: 200,
+			body: stream,
+		} as Response;
+
+		const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(mockResponse);
+
+		await sendMessageStreaming(
+			'Test message',
+			[],
+			'test-session-id',
+			optionsWithMetadata,
+			vi.fn(),
+			vi.fn(),
+			vi.fn(),
+		);
+
+		expect(fetchSpy).toHaveBeenCalledWith('https://test.example.com/webhook', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				action: 'sendMessage',
+				sessionId: 'test-session-id',
+				chatInput: 'Test message',
+				metadata: {
+					userId: 'user-123',
+					source: 'chat-widget',
+				},
+			}),
+		});
+	});
+});

--- a/packages/frontend/@n8n/chat/src/__tests__/api/message.spec.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/api/message.spec.ts
@@ -21,7 +21,7 @@ describe('sendMessageStreaming', () => {
 	};
 
 	beforeEach(() => {
-		vi.clearAllMocks();
+		vi.restoreAllMocks();
 	});
 
 	it('should call the webhook URL with correct parameters', async () => {
@@ -357,7 +357,7 @@ describe('sendMessageStreaming', () => {
 				vi.fn(),
 				vi.fn(),
 			),
-		).rejects.toThrow('HTTP error! status: 500');
+		).rejects.toThrow('Error while sending message. Error: Internal Server Error');
 	});
 
 	it('should handle missing response body', async () => {

--- a/packages/frontend/@n8n/chat/src/__tests__/api/message.spec.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/api/message.spec.ts
@@ -118,12 +118,12 @@ describe('sendMessageStreaming', () => {
 		});
 
 		expect(onBeginMessage).toHaveBeenCalledTimes(1);
-		expect(onBeginMessage).toHaveBeenCalledWith('node-1', 0, 0);
+		expect(onBeginMessage).toHaveBeenCalledWith('node-1', 0);
 		expect(onChunk).toHaveBeenCalledTimes(2);
-		expect(onChunk).toHaveBeenCalledWith('Hello ', 'node-1', 0, 0);
-		expect(onChunk).toHaveBeenCalledWith('World!', 'node-1', 0, 0);
+		expect(onChunk).toHaveBeenCalledWith('Hello ', 'node-1', 0);
+		expect(onChunk).toHaveBeenCalledWith('World!', 'node-1', 0);
 		expect(onEndMessage).toHaveBeenCalledTimes(1);
-		expect(onEndMessage).toHaveBeenCalledWith('node-1', 0, 0);
+		expect(onEndMessage).toHaveBeenCalledWith('node-1', 0);
 	});
 
 	it('should handle multiple runs and items correctly', async () => {
@@ -227,14 +227,14 @@ describe('sendMessageStreaming', () => {
 		);
 
 		expect(onBeginMessage).toHaveBeenCalledTimes(2);
-		expect(onBeginMessage).toHaveBeenCalledWith('node-1', 0, 0);
-		expect(onBeginMessage).toHaveBeenCalledWith('node-1', 1, 0);
+		expect(onBeginMessage).toHaveBeenCalledWith('node-1', 0);
+		expect(onBeginMessage).toHaveBeenCalledWith('node-1', 1);
 		expect(onChunk).toHaveBeenCalledTimes(2);
-		expect(onChunk).toHaveBeenCalledWith('Run 0 Item 0 ', 'node-1', 0, 0);
-		expect(onChunk).toHaveBeenCalledWith('Run 1 Item 0 ', 'node-1', 1, 0);
+		expect(onChunk).toHaveBeenCalledWith('Run 0 Item 0 ', 'node-1', 0);
+		expect(onChunk).toHaveBeenCalledWith('Run 1 Item 0 ', 'node-1', 1);
 		expect(onEndMessage).toHaveBeenCalledTimes(2);
-		expect(onEndMessage).toHaveBeenCalledWith('node-1', 0, 0);
-		expect(onEndMessage).toHaveBeenCalledWith('node-1', 1, 0);
+		expect(onEndMessage).toHaveBeenCalledWith('node-1', 0);
+		expect(onEndMessage).toHaveBeenCalledWith('node-1', 1);
 	});
 
 	it('should support file uploads with streaming', async () => {
@@ -329,12 +329,12 @@ describe('sendMessageStreaming', () => {
 		});
 
 		expect(onBeginMessage).toHaveBeenCalledTimes(1);
-		expect(onBeginMessage).toHaveBeenCalledWith('node-1', 0, 0);
+		expect(onBeginMessage).toHaveBeenCalledWith('node-1', 0);
 		expect(onChunk).toHaveBeenCalledTimes(2);
-		expect(onChunk).toHaveBeenCalledWith('File processed: ', 'node-1', 0, 0);
-		expect(onChunk).toHaveBeenCalledWith('test.txt', 'node-1', 0, 0);
+		expect(onChunk).toHaveBeenCalledWith('File processed: ', 'node-1', 0);
+		expect(onChunk).toHaveBeenCalledWith('test.txt', 'node-1', 0);
 		expect(onEndMessage).toHaveBeenCalledTimes(1);
-		expect(onEndMessage).toHaveBeenCalledWith('node-1', 0, 0);
+		expect(onEndMessage).toHaveBeenCalledWith('node-1', 0);
 	});
 
 	it('should handle HTTP errors', async () => {

--- a/packages/frontend/@n8n/chat/src/__tests__/index.spec.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/index.spec.ts
@@ -338,30 +338,5 @@ describe('createChat()', () => {
 			await waitFor(() => expect(getChatMessageTyping()).not.toBeInTheDocument());
 			expect(getChatMessageByText('Error: Failed to receive response')).toBeInTheDocument();
 		});
-
-		it('should show error message for file uploads with streaming enabled', async () => {
-			const input = 'Test with file';
-
-			const fetchSpy = vi.spyOn(window, 'fetch');
-			fetchSpy.mockImplementationOnce(createFetchResponse(createGetLatestMessagesResponse));
-
-			app = createChat({
-				mode: 'fullscreen',
-				enableStreaming: true,
-				allowFileUploads: true,
-			});
-
-			await waitFor(() => expect(getChatInputTextarea()).toBeInTheDocument());
-
-			// Simulate file upload by directly calling sendMessage with files
-			const chatInstance = (app as any)._instance?.proxy?.$chat;
-			if (chatInstance) {
-				const testFile = new File(['test'], 'test.txt', { type: 'text/plain' });
-				await chatInstance.sendMessage(input, [testFile]);
-
-				await waitFor(() => expect(getChatMessageTyping()).not.toBeInTheDocument());
-				expect(getChatMessageByText('Error: Failed to receive response')).toBeInTheDocument();
-			}
-		});
 	});
 });

--- a/packages/frontend/@n8n/chat/src/__tests__/index.spec.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/index.spec.ts
@@ -222,11 +222,29 @@ describe('createChat()', () => {
 		it('should handle streaming responses when enableStreaming is true', async () => {
 			const input = 'Tell me a story!';
 			const chunks = [
-				{ type: 'begin' },
-				{ type: 'progress', output: 'Once upon ' },
-				{ type: 'progress', output: 'a time, ' },
-				{ type: 'progress', output: 'there was a test.' },
-				{ type: 'end' },
+				{
+					type: 'begin',
+					metadata: { nodeId: 'node-1', nodeName: 'Test Node', timestamp: Date.now() },
+				},
+				{
+					type: 'item',
+					content: 'Once upon ',
+					metadata: { nodeId: 'node-1', nodeName: 'Test Node', timestamp: Date.now() },
+				},
+				{
+					type: 'item',
+					content: 'a time, ',
+					metadata: { nodeId: 'node-1', nodeName: 'Test Node', timestamp: Date.now() },
+				},
+				{
+					type: 'item',
+					content: 'there was a test.',
+					metadata: { nodeId: 'node-1', nodeName: 'Test Node', timestamp: Date.now() },
+				},
+				{
+					type: 'end',
+					metadata: { nodeId: 'node-1', nodeName: 'Test Node', timestamp: Date.now() },
+				},
 			];
 
 			const fetchSpy = vi.spyOn(window, 'fetch');
@@ -259,6 +277,7 @@ describe('createChat()', () => {
 					method: 'POST',
 					headers: {
 						'Content-Type': 'application/json',
+						Accept: 'text/plain',
 					},
 					body: expect.stringMatching(/"action":"sendMessage"/) as unknown,
 				}),

--- a/packages/frontend/@n8n/chat/src/__tests__/index.spec.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/index.spec.ts
@@ -4,7 +4,7 @@ import {
 	createFetchResponse,
 	createGetLatestMessagesResponse,
 	createSendMessageResponse,
-	createStreamingFetchResponse,
+	createMockStreamingFetchResponse,
 	getChatInputSendButton,
 	getChatInputTextarea,
 	getChatMessage,
@@ -280,7 +280,7 @@ describe('createChat()', () => {
 			const fetchSpy = vi.spyOn(window, 'fetch');
 			fetchSpy
 				.mockImplementationOnce(createFetchResponse(createGetLatestMessagesResponse))
-				.mockImplementationOnce(createStreamingFetchResponse(chunks));
+				.mockImplementationOnce(createMockStreamingFetchResponse(chunks));
 
 			app = createChat({
 				mode: 'fullscreen',

--- a/packages/frontend/@n8n/chat/src/__tests__/index.spec.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/index.spec.ts
@@ -224,26 +224,56 @@ describe('createChat()', () => {
 			const chunks = [
 				{
 					type: 'begin',
-					metadata: { nodeId: 'node-1', nodeName: 'Test Node', timestamp: Date.now() },
+					metadata: {
+						nodeId: 'node-1',
+						itemIndex: 0,
+						runIndex: 0,
+						nodeName: 'Test Node',
+						timestamp: Date.now(),
+					},
 				},
 				{
 					type: 'item',
 					content: 'Once upon ',
-					metadata: { nodeId: 'node-1', nodeName: 'Test Node', timestamp: Date.now() },
+					metadata: {
+						nodeId: 'node-1',
+						itemIndex: 0,
+						runIndex: 0,
+						nodeName: 'Test Node',
+						timestamp: Date.now(),
+					},
 				},
 				{
 					type: 'item',
 					content: 'a time, ',
-					metadata: { nodeId: 'node-1', nodeName: 'Test Node', timestamp: Date.now() },
+					metadata: {
+						nodeId: 'node-1',
+						itemIndex: 0,
+						runIndex: 0,
+						nodeName: 'Test Node',
+						timestamp: Date.now(),
+					},
 				},
 				{
 					type: 'item',
 					content: 'there was a test.',
-					metadata: { nodeId: 'node-1', nodeName: 'Test Node', timestamp: Date.now() },
+					metadata: {
+						nodeId: 'node-1',
+						itemIndex: 0,
+						runIndex: 0,
+						nodeName: 'Test Node',
+						timestamp: Date.now(),
+					},
 				},
 				{
 					type: 'end',
-					metadata: { nodeId: 'node-1', nodeName: 'Test Node', timestamp: Date.now() },
+					metadata: {
+						nodeId: 'node-1',
+						itemIndex: 0,
+						runIndex: 0,
+						nodeName: 'Test Node',
+						timestamp: Date.now(),
+					},
 				},
 			];
 

--- a/packages/frontend/@n8n/chat/src/__tests__/utils/fetch.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/utils/fetch.ts
@@ -16,3 +16,24 @@ export const createSendMessageResponse = (
 ): SendMessageResponse => ({
 	output,
 });
+
+export function createStreamingFetchResponse(chunks: Array<{ type: string; output?: string }>) {
+	return async () => {
+		const encoder = new TextEncoder();
+		const stream = new ReadableStream({
+			start(controller) {
+				chunks.forEach((chunk) => {
+					const data = JSON.stringify(chunk) + '\n';
+					controller.enqueue(encoder.encode(data));
+				});
+				controller.close();
+			},
+		});
+
+		return {
+			ok: true,
+			status: 200,
+			body: stream,
+		} as Response;
+	};
+}

--- a/packages/frontend/@n8n/chat/src/__tests__/utils/fetch.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/utils/fetch.ts
@@ -17,7 +17,7 @@ export const createSendMessageResponse = (
 	output,
 });
 
-export function createStreamingFetchResponse(
+export function createMockStreamingFetchResponse(
 	chunks: Array<{
 		type: string;
 		content?: string;

--- a/packages/frontend/@n8n/chat/src/__tests__/utils/fetch.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/utils/fetch.ts
@@ -17,7 +17,13 @@ export const createSendMessageResponse = (
 	output,
 });
 
-export function createStreamingFetchResponse(chunks: Array<{ type: string; output?: string }>) {
+export function createStreamingFetchResponse(
+	chunks: Array<{
+		type: string;
+		content?: string;
+		metadata?: { nodeId: string; nodeName: string; timestamp: number };
+	}>,
+) {
 	return async () => {
 		const encoder = new TextEncoder();
 		const stream = new ReadableStream({
@@ -34,6 +40,7 @@ export function createStreamingFetchResponse(chunks: Array<{ type: string; outpu
 			ok: true,
 			status: 200,
 			body: stream,
+			headers: new Headers(),
 		} as Response;
 	};
 }

--- a/packages/frontend/@n8n/chat/src/__tests__/utils/streaming.spec.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/utils/streaming.spec.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ChatMessageText } from '@n8n/chat/types';
+import {
+	StreamingMessageManager,
+	createBotMessage,
+	updateMessageInArray,
+} from '@n8n/chat/utils/streaming';
+
+describe('StreamingMessageManager', () => {
+	it('should initialize nodes correctly', () => {
+		const manager = new StreamingMessageManager();
+
+		manager.initializeNode('node-1');
+
+		expect(manager.getNodeCount()).toBe(1);
+	});
+
+	it('should add chunks to nodes and return combined content', () => {
+		const manager = new StreamingMessageManager();
+
+		const content1 = manager.addChunkToNode('node-1', 'Hello ');
+		const content2 = manager.addChunkToNode('node-2', 'World!');
+		const content3 = manager.addChunkToNode('node-1', 'from ');
+		const content4 = manager.addChunkToNode('node-1', 'node1');
+
+		expect(content1).toBe('Hello ');
+		expect(content2).toBe('Hello World!');
+		expect(content3).toBe('Hello from World!');
+		expect(content4).toBe('Hello from node1World!');
+	});
+
+	it('should track active nodes correctly', () => {
+		const manager = new StreamingMessageManager();
+
+		manager.addNodeToActive('node-1');
+		manager.addNodeToActive('node-2');
+
+		expect(manager.getNodeCount()).toBe(2);
+
+		manager.removeNodeFromActive('node-1');
+		expect(manager.areAllNodesComplete()).toBe(false);
+
+		manager.removeNodeFromActive('node-2');
+		expect(manager.areAllNodesComplete()).toBe(true);
+	});
+
+	it('should reset correctly', () => {
+		const manager = new StreamingMessageManager();
+
+		manager.addChunkToNode('node-1', 'test');
+		manager.addNodeToActive('node-2');
+
+		expect(manager.getNodeCount()).toBe(2);
+
+		manager.reset();
+
+		expect(manager.getNodeCount()).toBe(0);
+		expect(manager.getCombinedContent()).toBe('');
+	});
+});
+
+describe('createBotMessage', () => {
+	it('should create a bot message with default values', () => {
+		const message = createBotMessage();
+
+		expect(message.type).toBe('text');
+		expect(message.text).toBe('');
+		expect(message.sender).toBe('bot');
+		expect(message.id).toBeDefined();
+	});
+
+	it('should create a bot message with custom id', () => {
+		const customId = 'custom-id-123';
+		const message = createBotMessage(customId);
+
+		expect(message.id).toBe(customId);
+	});
+});
+
+describe('updateMessageInArray', () => {
+	it('should update message in array', () => {
+		const messages: ChatMessageText[] = [
+			{
+				id: 'msg-1',
+				type: 'text',
+				text: 'Hello',
+				sender: 'bot',
+			},
+			{
+				id: 'msg-2',
+				type: 'text',
+				text: 'World',
+				sender: 'user',
+			},
+		];
+
+		const updatedMessage: ChatMessageText = {
+			id: 'msg-1',
+			type: 'text',
+			text: 'Hello Updated',
+			sender: 'bot',
+		};
+
+		updateMessageInArray(messages, 'msg-1', updatedMessage);
+
+		expect(messages[0].text).toBe('Hello Updated');
+		expect(messages[1].text).toBe('World'); // Should remain unchanged
+	});
+
+	it('should handle non-existent message id gracefully', () => {
+		const messages: ChatMessageText[] = [
+			{
+				id: 'msg-1',
+				type: 'text',
+				text: 'Hello',
+				sender: 'bot',
+			},
+		];
+
+		const updatedMessage: ChatMessageText = {
+			id: 'non-existent',
+			type: 'text',
+			text: 'Should not be added',
+			sender: 'bot',
+		};
+
+		updateMessageInArray(messages, 'non-existent', updatedMessage);
+
+		expect(messages).toHaveLength(1);
+		expect(messages[0].text).toBe('Hello');
+	});
+});

--- a/packages/frontend/@n8n/chat/src/__tests__/utils/streaming.spec.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/utils/streaming.spec.ts
@@ -30,6 +30,32 @@ describe('StreamingMessageManager', () => {
 		expect(content4).toBe('Hello from node1World!');
 	});
 
+	it('should handle runIndex and itemIndex correctly', () => {
+		const manager = new StreamingMessageManager();
+
+		// Same node, different run indexes
+		const content1 = manager.addChunkToNode('node-1', 'Run 0 ', 0);
+		const content2 = manager.addChunkToNode('node-1', 'Run 1 ', 1);
+		const content3 = manager.addChunkToNode('node-1', 'more', 0);
+
+		expect(content1).toBe('Run 0 ');
+		expect(content2).toBe('Run 0 Run 1 ');
+		expect(content3).toBe('Run 0 moreRun 1 ');
+	});
+
+	it('should handle itemIndex correctly', () => {
+		const manager = new StreamingMessageManager();
+
+		// Same node, same run, different items
+		const content1 = manager.addChunkToNode('node-1', 'Item 0 ', 0, 0);
+		const content2 = manager.addChunkToNode('node-1', 'Item 1 ', 0, 1);
+		const content3 = manager.addChunkToNode('node-1', 'more', 0, 0);
+
+		expect(content1).toBe('Item 0 ');
+		expect(content2).toBe('Item 0 Item 1 ');
+		expect(content3).toBe('Item 0 moreItem 1 ');
+	});
+
 	it('should track active nodes correctly', () => {
 		const manager = new StreamingMessageManager();
 
@@ -42,6 +68,25 @@ describe('StreamingMessageManager', () => {
 		expect(manager.areAllNodesComplete()).toBe(false);
 
 		manager.removeNodeFromActive('node-2');
+		expect(manager.areAllNodesComplete()).toBe(true);
+	});
+
+	it('should track active nodes with runIndex and itemIndex correctly', () => {
+		const manager = new StreamingMessageManager();
+
+		manager.addNodeToActive('node-1', 0, 0);
+		manager.addNodeToActive('node-1', 0, 1);
+		manager.addNodeToActive('node-1', 1, 0);
+
+		expect(manager.getNodeCount()).toBe(3);
+
+		manager.removeNodeFromActive('node-1', 0, 0);
+		expect(manager.areAllNodesComplete()).toBe(false);
+
+		manager.removeNodeFromActive('node-1', 0, 1);
+		expect(manager.areAllNodesComplete()).toBe(false);
+
+		manager.removeNodeFromActive('node-1', 1, 0);
 		expect(manager.areAllNodesComplete()).toBe(true);
 	});
 

--- a/packages/frontend/@n8n/chat/src/__tests__/utils/streaming.spec.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/utils/streaming.spec.ts
@@ -157,7 +157,7 @@ describe('updateMessageInArray', () => {
 		expect(messages[1].text).toBe('World'); // Should remain unchanged
 	});
 
-	it('should handle non-existent message id gracefully', () => {
+	it('should throw error on non-existent message id', () => {
 		const messages: ChatMessageText[] = [
 			{
 				id: 'msg-1',
@@ -174,9 +174,8 @@ describe('updateMessageInArray', () => {
 			sender: 'bot',
 		};
 
-		updateMessageInArray(messages, 'non-existent', updatedMessage);
-
-		expect(messages).toHaveLength(1);
-		expect(messages[0].text).toBe('Hello');
+		expect(() => updateMessageInArray(messages, 'non-existent', updatedMessage)).toThrow(
+			"Can't update message. No message with id non-existent found",
+		);
 	});
 });

--- a/packages/frontend/@n8n/chat/src/__tests__/utils/streamingHandlers.spec.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/utils/streamingHandlers.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { ref, type Ref } from 'vue';
 
-import type { ChatMessageText } from '@n8n/chat/types';
+import type { ChatMessage, ChatMessageText } from '@n8n/chat/types';
 import { StreamingMessageManager } from '@n8n/chat/utils/streaming';
 import {
 	handleStreamingChunk,
@@ -17,15 +17,13 @@ vi.mock('@n8n/chat/event-buses', () => ({
 }));
 
 describe('streamingHandlers', () => {
-	let messages: Ref<unknown[]>;
+	let messages: Ref<ChatMessage[]>;
 	let receivedMessage: Ref<ChatMessageText | null>;
-	let waitingForResponse: Ref<boolean>;
 	let streamingManager: StreamingMessageManager;
 
 	beforeEach(() => {
-		messages = ref<unknown[]>([]);
+		messages = ref<ChatMessage[]>([]);
 		receivedMessage = ref<ChatMessageText | null>(null);
-		waitingForResponse = ref(false);
 		streamingManager = new StreamingMessageManager();
 		vi.clearAllMocks();
 	});
@@ -98,17 +96,12 @@ describe('streamingHandlers', () => {
 		});
 
 		it('should handle errors gracefully', () => {
-			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-
 			// Simulate an error by passing invalid parameters
 			const invalidStreamingManager = null as unknown as StreamingMessageManager;
 
 			expect(() => {
 				handleStreamingChunk('test', 'node-1', invalidStreamingManager, receivedMessage, messages);
 			}).not.toThrow();
-
-			expect(consoleSpy).toHaveBeenCalledWith('Error handling streaming chunk:', expect.any(Error));
-			consoleSpy.mockRestore();
 		});
 	});
 
@@ -137,16 +130,11 @@ describe('streamingHandlers', () => {
 		});
 
 		it('should handle errors gracefully', () => {
-			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-
 			const invalidStreamingManager = null as unknown as StreamingMessageManager;
 
 			expect(() => {
 				handleNodeStart('node-1', invalidStreamingManager);
 			}).not.toThrow();
-
-			expect(consoleSpy).toHaveBeenCalledWith('Error handling node start:', expect.any(Error));
-			consoleSpy.mockRestore();
 		});
 	});
 
@@ -161,8 +149,6 @@ describe('streamingHandlers', () => {
 		});
 
 		it('should handle multiple runs completion', () => {
-			waitingForResponse.value = true;
-
 			// Setup two runs
 			streamingManager.addRunToActive('node-1', 0);
 			streamingManager.addRunToActive('node-1', 1);
@@ -177,7 +163,6 @@ describe('streamingHandlers', () => {
 		});
 
 		it('should handle runs without runIndex', () => {
-			waitingForResponse.value = true;
 			streamingManager.addRunToActive('node-1');
 
 			handleNodeComplete('node-1', streamingManager);
@@ -186,16 +171,11 @@ describe('streamingHandlers', () => {
 		});
 
 		it('should handle errors gracefully', () => {
-			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-
 			const invalidStreamingManager = null as unknown as StreamingMessageManager;
 
 			expect(() => {
 				handleNodeComplete('node-1', invalidStreamingManager);
 			}).not.toThrow();
-
-			expect(consoleSpy).toHaveBeenCalledWith('Error handling node complete:', expect.any(Error));
-			consoleSpy.mockRestore();
 		});
 	});
 });

--- a/packages/frontend/@n8n/chat/src/__tests__/utils/streamingHandlers.spec.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/utils/streamingHandlers.spec.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { ref, type Ref } from 'vue';
+
+import type { ChatMessageText } from '@n8n/chat/types';
+import { StreamingMessageManager } from '@n8n/chat/utils/streaming';
+import {
+	handleStreamingChunk,
+	handleNodeStart,
+	handleNodeComplete,
+} from '@n8n/chat/utils/streamingHandlers';
+
+// Mock the chatEventBus
+vi.mock('@n8n/chat/event-buses', () => ({
+	chatEventBus: {
+		emit: vi.fn(),
+	},
+}));
+
+describe('streamingHandlers', () => {
+	let messages: Ref<unknown[]>;
+	let receivedMessage: Ref<ChatMessageText | null>;
+	let waitingForResponse: Ref<boolean>;
+	let streamingManager: StreamingMessageManager;
+
+	beforeEach(() => {
+		messages = ref<unknown[]>([]);
+		receivedMessage = ref<ChatMessageText | null>(null);
+		waitingForResponse = ref(false);
+		streamingManager = new StreamingMessageManager();
+		vi.clearAllMocks();
+	});
+
+	describe('handleStreamingChunk', () => {
+		it('should handle single-node streaming (no nodeId)', () => {
+			handleStreamingChunk('Hello', undefined, streamingManager, receivedMessage, messages);
+
+			expect(receivedMessage.value).toBeDefined();
+			expect(receivedMessage.value?.text).toBe('Hello');
+			expect(messages.value).toHaveLength(1);
+
+			handleStreamingChunk(' World!', undefined, streamingManager, receivedMessage, messages);
+
+			expect(receivedMessage.value?.text).toBe('Hello World!');
+			expect(messages.value).toHaveLength(1);
+		});
+
+		it('should handle multi-node streaming', () => {
+			handleStreamingChunk('Hello', 'node-1', streamingManager, receivedMessage, messages);
+
+			expect(receivedMessage.value).toBeDefined();
+			expect(receivedMessage.value?.text).toBe('Hello');
+			expect(messages.value).toHaveLength(1);
+
+			handleStreamingChunk(' World!', 'node-2', streamingManager, receivedMessage, messages);
+
+			expect(receivedMessage.value?.text).toBe('Hello World!');
+		});
+
+		it('should handle errors gracefully', () => {
+			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+			// Simulate an error by passing invalid parameters
+			const invalidStreamingManager = null as unknown as StreamingMessageManager;
+
+			expect(() => {
+				handleStreamingChunk('test', 'node-1', invalidStreamingManager, receivedMessage, messages);
+			}).not.toThrow();
+
+			expect(consoleSpy).toHaveBeenCalledWith('Error handling streaming chunk:', expect.any(Error));
+			consoleSpy.mockRestore();
+		});
+	});
+
+	describe('handleNodeStart', () => {
+		it('should initialize node and create message if needed', () => {
+			handleNodeStart('node-1', streamingManager, receivedMessage, messages);
+
+			expect(receivedMessage.value).toBeDefined();
+			expect(messages.value).toHaveLength(1);
+			expect(streamingManager.getNodeCount()).toBe(1);
+		});
+
+		it('should not create duplicate message if one exists', () => {
+			const existingMessage = {
+				id: 'existing',
+				type: 'text' as const,
+				text: 'existing',
+				sender: 'bot' as const,
+			};
+			receivedMessage.value = existingMessage;
+			messages.value.push(existingMessage);
+
+			handleNodeStart('node-1', streamingManager, receivedMessage, messages);
+
+			expect(messages.value).toHaveLength(1);
+			expect(receivedMessage.value.id).toBe('existing');
+		});
+
+		it('should handle errors gracefully', () => {
+			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+			const invalidStreamingManager = null as unknown as StreamingMessageManager;
+
+			expect(() => {
+				handleNodeStart('node-1', invalidStreamingManager, receivedMessage, messages);
+			}).not.toThrow();
+
+			expect(consoleSpy).toHaveBeenCalledWith('Error handling node start:', expect.any(Error));
+			consoleSpy.mockRestore();
+		});
+	});
+
+	describe('handleNodeComplete', () => {
+		it('should mark node as complete and update message', () => {
+			// Setup initial state
+			streamingManager.addNodeToActive('node-1');
+			streamingManager.addChunkToNode('node-1', 'Hello');
+			receivedMessage.value = {
+				id: 'msg-1',
+				type: 'text',
+				text: 'Hello',
+				sender: 'bot',
+			};
+			messages.value.push(receivedMessage.value);
+
+			handleNodeComplete('node-1', streamingManager, receivedMessage, messages, waitingForResponse);
+
+			expect(streamingManager.areAllNodesComplete()).toBe(true);
+		});
+
+		it('should set waitingForResponse to false when all nodes complete', () => {
+			waitingForResponse.value = true;
+			streamingManager.addNodeToActive('node-1');
+			streamingManager.addNodeToActive('node-2');
+
+			receivedMessage.value = {
+				id: 'msg-1',
+				type: 'text',
+				text: '',
+				sender: 'bot',
+			};
+
+			// Complete first node
+			handleNodeComplete('node-1', streamingManager, receivedMessage, messages, waitingForResponse);
+			expect(waitingForResponse.value).toBe(true);
+
+			// Complete second node
+			handleNodeComplete('node-2', streamingManager, receivedMessage, messages, waitingForResponse);
+			expect(waitingForResponse.value).toBe(false);
+		});
+
+		it('should handle errors gracefully', () => {
+			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+			const invalidStreamingManager = null as unknown as StreamingMessageManager;
+
+			expect(() => {
+				handleNodeComplete(
+					'node-1',
+					invalidStreamingManager,
+					receivedMessage,
+					messages,
+					waitingForResponse,
+				);
+			}).not.toThrow();
+
+			expect(consoleSpy).toHaveBeenCalledWith('Error handling node complete:', expect.any(Error));
+			consoleSpy.mockRestore();
+		});
+	});
+});

--- a/packages/frontend/@n8n/chat/src/__tests__/utils/streamingHandlers.spec.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/utils/streamingHandlers.spec.ts
@@ -72,12 +72,12 @@ describe('streamingHandlers', () => {
 	});
 
 	describe('handleNodeStart', () => {
-		it('should initialize node and create message if needed', () => {
-			handleNodeStart('node-1', streamingManager, receivedMessage, messages);
+		it('should initialize node without creating message', () => {
+			handleNodeStart('node-1', streamingManager);
 
-			expect(receivedMessage.value).toBeDefined();
-			expect(messages.value).toHaveLength(1);
-			expect(streamingManager.getNodeCount()).toBe(1);
+			expect(receivedMessage.value).toBeNull(); // No message created yet
+			expect(messages.value).toHaveLength(0); // No messages until first content
+			expect(streamingManager.getNodeCount()).toBe(1); // But node is initialized
 		});
 
 		it('should not create duplicate message if one exists', () => {
@@ -90,7 +90,7 @@ describe('streamingHandlers', () => {
 			receivedMessage.value = existingMessage;
 			messages.value.push(existingMessage);
 
-			handleNodeStart('node-1', streamingManager, receivedMessage, messages);
+			handleNodeStart('node-1', streamingManager);
 
 			expect(messages.value).toHaveLength(1);
 			expect(receivedMessage.value.id).toBe('existing');
@@ -102,7 +102,7 @@ describe('streamingHandlers', () => {
 			const invalidStreamingManager = null as unknown as StreamingMessageManager;
 
 			expect(() => {
-				handleNodeStart('node-1', invalidStreamingManager, receivedMessage, messages);
+				handleNodeStart('node-1', invalidStreamingManager);
 			}).not.toThrow();
 
 			expect(consoleSpy).toHaveBeenCalledWith('Error handling node start:', expect.any(Error));

--- a/packages/frontend/@n8n/chat/src/__tests__/utils/streamingHandlers.spec.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/utils/streamingHandlers.spec.ts
@@ -46,8 +46,8 @@ describe('streamingHandlers', () => {
 
 		it('should handle streaming with separate messages per runIndex', () => {
 			// Start the runs (doesn't create messages yet)
-			handleNodeStart('node-1', streamingManager, messages, 0);
-			handleNodeStart('node-1', streamingManager, messages, 1);
+			handleNodeStart('node-1', streamingManager, 0);
+			handleNodeStart('node-1', streamingManager, 1);
 
 			expect(messages.value).toHaveLength(0); // No messages created yet
 
@@ -82,7 +82,7 @@ describe('streamingHandlers', () => {
 
 		it('should accumulate chunks within the same run', () => {
 			// Start a run (doesn't create message yet)
-			handleNodeStart('node-1', streamingManager, messages, 0);
+			handleNodeStart('node-1', streamingManager, 0);
 
 			expect(messages.value).toHaveLength(0);
 
@@ -114,8 +114,8 @@ describe('streamingHandlers', () => {
 
 	describe('handleNodeStart', () => {
 		it('should register runs but not create messages yet', () => {
-			handleNodeStart('node-1', streamingManager, messages, 0);
-			handleNodeStart('node-1', streamingManager, messages, 1);
+			handleNodeStart('node-1', streamingManager, 0);
+			handleNodeStart('node-1', streamingManager, 1);
 
 			// No messages created yet - they'll be created on first chunk
 			expect(messages.value).toHaveLength(0);
@@ -127,9 +127,8 @@ describe('streamingHandlers', () => {
 		});
 
 		it('should handle runs without runIndex', () => {
-			handleNodeStart('node-1', streamingManager, messages);
+			handleNodeStart('node-1', streamingManager);
 
-			// No message created yet
 			expect(messages.value).toHaveLength(0);
 
 			// Verify run is registered by adding a chunk
@@ -143,7 +142,7 @@ describe('streamingHandlers', () => {
 			const invalidStreamingManager = null as unknown as StreamingMessageManager;
 
 			expect(() => {
-				handleNodeStart('node-1', invalidStreamingManager, messages);
+				handleNodeStart('node-1', invalidStreamingManager);
 			}).not.toThrow();
 
 			expect(consoleSpy).toHaveBeenCalledWith('Error handling node start:', expect.any(Error));
@@ -156,14 +155,7 @@ describe('streamingHandlers', () => {
 			// Setup initial state
 			streamingManager.addRunToActive('node-1', 0);
 
-			handleNodeComplete(
-				'node-1',
-				streamingManager,
-				receivedMessage,
-				messages,
-				waitingForResponse,
-				0,
-			);
+			handleNodeComplete('node-1', streamingManager, 0);
 
 			expect(streamingManager.areAllRunsComplete()).toBe(true);
 		});
@@ -176,66 +168,21 @@ describe('streamingHandlers', () => {
 			streamingManager.addRunToActive('node-1', 1);
 
 			// Complete first run
-			handleNodeComplete(
-				'node-1',
-				streamingManager,
-				receivedMessage,
-				messages,
-				waitingForResponse,
-				0,
-			);
+			handleNodeComplete('node-1', streamingManager, 0);
 			expect(streamingManager.areAllRunsComplete()).toBe(false);
-			expect(waitingForResponse.value).toBe(true);
 
 			// Complete second run
-			handleNodeComplete(
-				'node-1',
-				streamingManager,
-				receivedMessage,
-				messages,
-				waitingForResponse,
-				1,
-			);
+			handleNodeComplete('node-1', streamingManager, 1);
 			expect(streamingManager.areAllRunsComplete()).toBe(true);
-			expect(waitingForResponse.value).toBe(false);
-		});
-
-		it('should set waitingForResponse to false when all runs complete', () => {
-			waitingForResponse.value = true;
-			streamingManager.addRunToActive('node-1', 0);
-			streamingManager.addRunToActive('node-2', 0);
-
-			// Complete first run
-			handleNodeComplete(
-				'node-1',
-				streamingManager,
-				receivedMessage,
-				messages,
-				waitingForResponse,
-				0,
-			);
-			expect(waitingForResponse.value).toBe(true);
-
-			// Complete second run
-			handleNodeComplete(
-				'node-2',
-				streamingManager,
-				receivedMessage,
-				messages,
-				waitingForResponse,
-				0,
-			);
-			expect(waitingForResponse.value).toBe(false);
 		});
 
 		it('should handle runs without runIndex', () => {
 			waitingForResponse.value = true;
 			streamingManager.addRunToActive('node-1');
 
-			handleNodeComplete('node-1', streamingManager, receivedMessage, messages, waitingForResponse);
+			handleNodeComplete('node-1', streamingManager);
 
 			expect(streamingManager.areAllRunsComplete()).toBe(true);
-			expect(waitingForResponse.value).toBe(false);
 		});
 
 		it('should handle errors gracefully', () => {
@@ -244,13 +191,7 @@ describe('streamingHandlers', () => {
 			const invalidStreamingManager = null as unknown as StreamingMessageManager;
 
 			expect(() => {
-				handleNodeComplete(
-					'node-1',
-					invalidStreamingManager,
-					receivedMessage,
-					messages,
-					waitingForResponse,
-				);
+				handleNodeComplete('node-1', invalidStreamingManager);
 			}).not.toThrow();
 
 			expect(consoleSpy).toHaveBeenCalledWith('Error handling node complete:', expect.any(Error));

--- a/packages/frontend/@n8n/chat/src/api/message.ts
+++ b/packages/frontend/@n8n/chat/src/api/message.ts
@@ -69,6 +69,7 @@ export async function sendMessageStreaming(
 	let response: Response;
 
 	if (files.length > 0) {
+		console.log('Files message');
 		// Handle file uploads with FormData for streaming
 		const formData = new FormData();
 		formData.append('action', 'sendMessage');
@@ -93,6 +94,7 @@ export async function sendMessageStreaming(
 			body: formData,
 		});
 	} else {
+		console.log('Text only message');
 		// Handle text-only messages with JSON
 		const body = {
 			action: 'sendMessage',
@@ -144,22 +146,28 @@ export async function sendMessageStreaming(
 
 				if (line.trim()) {
 					try {
+						console.log(line);
 						const decoded: StructuredChunk = JSON.parse(line);
 						const nodeId = decoded.metadata?.nodeId || 'unknown';
 						const runIndex = decoded.metadata?.runIndex;
 						const itemIndex = decoded.metadata?.itemIndex;
 
 						if (decoded?.type === 'begin') {
+							console.log('Begin message:', decoded);
 							onBeginMessage(nodeId, runIndex, itemIndex);
 						}
 						if (decoded?.type === 'item') {
+							console.log('item message:', decoded);
 							onChunk(decoded?.content ?? '', nodeId, runIndex, itemIndex);
 						}
 						if (decoded?.type === 'end') {
+							console.log('end message:', decoded);
 							onEndMessage(nodeId, runIndex, itemIndex);
 						}
 						if (decoded?.type === 'error') {
+							console.log('error message:', decoded);
 							onChunk(`Error: ${decoded.content ?? 'Unknown error'}`, nodeId, runIndex, itemIndex);
+							onEndMessage(nodeId, runIndex, itemIndex);
 						}
 					} catch (error) {
 						console.warn('Failed to parse JSON line:', line, error);

--- a/packages/frontend/@n8n/chat/src/api/message.ts
+++ b/packages/frontend/@n8n/chat/src/api/message.ts
@@ -114,8 +114,8 @@ export async function sendMessageStreaming(
 
 	if (!response.ok) {
 		const errorText = await response.text();
-		console.error('HTTP error response:', errorText);
-		throw new Error(`HTTP error! status: ${response.status} - ${errorText}`);
+		console.error('HTTP error response:', response.status, errorText);
+		throw new Error(`Error while sending message. Error: ${errorText}`);
 	}
 
 	const reader = response.body?.getReader();
@@ -162,8 +162,6 @@ export async function sendMessageStreaming(
 							onEndMessage(nodeId, runIndex);
 						}
 					} catch (error) {
-						console.warn('Failed to parse JSON line:', line, error);
-						// Fallback: treat as plain text chunk without nodeId
 						onChunk(line, undefined);
 					}
 				}
@@ -180,7 +178,6 @@ export async function sendMessageStreaming(
 					onChunk(decoded?.content ?? '', nodeId, runIndex);
 				}
 			} catch (error) {
-				console.warn('Failed to parse remaining buffer as JSON, treating as plain text:', buffer);
 				onChunk(buffer, undefined);
 			}
 		}

--- a/packages/frontend/@n8n/chat/src/api/message.ts
+++ b/packages/frontend/@n8n/chat/src/api/message.ts
@@ -55,3 +55,70 @@ export async function sendMessage(
 		},
 	);
 }
+
+export async function sendMessageStreaming(
+	message: string,
+	files: File[],
+	sessionId: string,
+	options: ChatOptions,
+	onChunk: (chunk: string) => void,
+	onBeginMessage: () => void,
+	onEndMessage: () => void,
+): Promise<void> {
+	if (files.length > 0) {
+		throw new Error('File uploads are not supported with streaming responses');
+	}
+
+	const body = {
+		action: 'sendMessage',
+		[options.chatSessionKey as string]: sessionId,
+		[options.chatInputKey as string]: message,
+		...(options.metadata ? { metadata: options.metadata } : {}),
+	};
+
+	const response = await fetch(options.webhookUrl, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			...options.webhookConfig?.headers,
+		},
+		body: JSON.stringify(body),
+	});
+
+	if (!response.ok) {
+		throw new Error(`HTTP error! status: ${response.status}`);
+	}
+
+	const reader = response.body?.getReader();
+	if (!reader) {
+		throw new Error('Response body is not readable');
+	}
+
+	const decoder = new TextDecoder();
+
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) {
+				break;
+			}
+
+			const chunk = decoder.decode(value, { stream: true });
+
+			if (chunk.includes('\n')) {
+				const decoded = JSON.parse(chunk.substring(0, chunk.indexOf('\n')));
+				if (decoded?.type === 'begin') {
+					onBeginMessage();
+				}
+				if (decoded?.type === 'progress') {
+					onChunk(decoded?.output);
+				}
+				if (decoded?.type === 'end') {
+					onEndMessage();
+				}
+			}
+		}
+	} finally {
+		reader.releaseLock();
+	}
+}

--- a/packages/frontend/@n8n/chat/src/api/message.ts
+++ b/packages/frontend/@n8n/chat/src/api/message.ts
@@ -145,9 +145,6 @@ export async function sendMessageStreaming(
 
 		// Process any remaining buffer content
 		if (buffer.trim()) {
-			if (process.env.NODE_ENV === 'development') {
-				console.log('Processing remaining buffer:', buffer);
-			}
 			try {
 				const decoded: StructuredChunk = JSON.parse(buffer);
 				const nodeId = decoded.metadata?.nodeId || 'unknown';

--- a/packages/frontend/@n8n/chat/src/constants/defaults.ts
+++ b/packages/frontend/@n8n/chat/src/constants/defaults.ts
@@ -25,6 +25,7 @@ export const defaultOptions: ChatOptions = {
 		},
 	},
 	theme: {},
+	enableStreaming: false,
 };
 
 export const defaultMountingTarget = '#n8n-chat';

--- a/packages/frontend/@n8n/chat/src/plugins/chat.ts
+++ b/packages/frontend/@n8n/chat/src/plugins/chat.ts
@@ -49,6 +49,7 @@ export const ChatPlugin: Plugin<ChatOptions> = {
 
 			try {
 				if (options?.enableStreaming) {
+					// Set up a safety timeout to ensure typing indicator disappears
 					await api.sendMessageStreaming(
 						text,
 						files,
@@ -66,7 +67,7 @@ export const ChatPlugin: Plugin<ChatOptions> = {
 							);
 						},
 						(nodeId: string, runIndex?: number, itemIndex?: number) => {
-							handleNodeStart(nodeId, streamingManager, runIndex, itemIndex);
+							handleNodeStart(nodeId, streamingManager, messages, runIndex, itemIndex);
 						},
 						(nodeId: string, runIndex?: number, itemIndex?: number) => {
 							handleNodeComplete(
@@ -74,15 +75,11 @@ export const ChatPlugin: Plugin<ChatOptions> = {
 								streamingManager,
 								receivedMessage,
 								messages,
-								waitingForResponse,
 								runIndex,
 								itemIndex,
 							);
 						},
 					);
-
-					// Mark streaming as complete after the function finishes
-					waitingForResponse.value = false;
 				} else {
 					receivedMessage.value = createBotMessage();
 

--- a/packages/frontend/@n8n/chat/src/plugins/chat.ts
+++ b/packages/frontend/@n8n/chat/src/plugins/chat.ts
@@ -49,12 +49,8 @@ export const ChatPlugin: Plugin<ChatOptions> = {
 
 			try {
 				if (options?.enableStreaming) {
-					await api.sendMessageStreaming(
-						text,
-						files,
-						currentSessionId.value as string,
-						options,
-						(chunk: string, nodeId?: string, runIndex?: number) => {
+					const handlers: api.StreamingEventHandlers = {
+						onChunk: (chunk: string, nodeId?: string, runIndex?: number) => {
 							handleStreamingChunk(
 								chunk,
 								nodeId,
@@ -64,12 +60,20 @@ export const ChatPlugin: Plugin<ChatOptions> = {
 								runIndex,
 							);
 						},
-						(nodeId: string, runIndex?: number) => {
+						onBeginMessage: (nodeId: string, runIndex?: number) => {
 							handleNodeStart(nodeId, streamingManager, runIndex);
 						},
-						(nodeId: string, runIndex?: number) => {
+						onEndMessage: (nodeId: string, runIndex?: number) => {
 							handleNodeComplete(nodeId, streamingManager, runIndex);
 						},
+					};
+
+					await api.sendMessageStreaming(
+						text,
+						files,
+						currentSessionId.value as string,
+						options,
+						handlers,
 					);
 				} else {
 					receivedMessage.value = createBotMessage();

--- a/packages/frontend/@n8n/chat/src/plugins/chat.ts
+++ b/packages/frontend/@n8n/chat/src/plugins/chat.ts
@@ -59,7 +59,7 @@ export const ChatPlugin: Plugin<ChatOptions> = {
 							handleStreamingChunk(chunk, nodeId, streamingManager, receivedMessage, messages);
 						},
 						(nodeId: string) => {
-							handleNodeStart(nodeId, streamingManager, receivedMessage, messages);
+							handleNodeStart(nodeId, streamingManager);
 						},
 						(nodeId: string) => {
 							handleNodeComplete(

--- a/packages/frontend/@n8n/chat/src/plugins/chat.ts
+++ b/packages/frontend/@n8n/chat/src/plugins/chat.ts
@@ -30,7 +30,6 @@ export const ChatPlugin: Plugin<ChatOptions> = {
 		);
 
 		async function sendMessage(text: string, files: File[] = []) {
-			console.log('Chat sendMessage called with:', text, files);
 			const sentMessage: ChatMessage = {
 				id: uuidv4(),
 				text,

--- a/packages/frontend/@n8n/chat/src/plugins/chat.ts
+++ b/packages/frontend/@n8n/chat/src/plugins/chat.ts
@@ -55,7 +55,7 @@ export const ChatPlugin: Plugin<ChatOptions> = {
 						files,
 						currentSessionId.value as string,
 						options,
-						(chunk: string, nodeId?: string, runIndex?: number, itemIndex?: number) => {
+						(chunk: string, nodeId?: string, runIndex?: number) => {
 							handleStreamingChunk(
 								chunk,
 								nodeId,
@@ -63,21 +63,13 @@ export const ChatPlugin: Plugin<ChatOptions> = {
 								receivedMessage,
 								messages,
 								runIndex,
-								itemIndex,
 							);
 						},
-						(nodeId: string, runIndex?: number, itemIndex?: number) => {
-							handleNodeStart(nodeId, streamingManager, messages, runIndex, itemIndex);
+						(nodeId: string, runIndex?: number) => {
+							handleNodeStart(nodeId, streamingManager, runIndex);
 						},
-						(nodeId: string, runIndex?: number, itemIndex?: number) => {
-							handleNodeComplete(
-								nodeId,
-								streamingManager,
-								receivedMessage,
-								messages,
-								runIndex,
-								itemIndex,
-							);
+						(nodeId: string, runIndex?: number) => {
+							handleNodeComplete(nodeId, streamingManager, runIndex);
 						},
 					);
 				} else {

--- a/packages/frontend/@n8n/chat/src/plugins/chat.ts
+++ b/packages/frontend/@n8n/chat/src/plugins/chat.ts
@@ -49,7 +49,6 @@ export const ChatPlugin: Plugin<ChatOptions> = {
 
 			try {
 				if (options?.enableStreaming) {
-					// Set up a safety timeout to ensure typing indicator disappears
 					await api.sendMessageStreaming(
 						text,
 						files,

--- a/packages/frontend/@n8n/chat/src/plugins/chat.ts
+++ b/packages/frontend/@n8n/chat/src/plugins/chat.ts
@@ -54,19 +54,29 @@ export const ChatPlugin: Plugin<ChatOptions> = {
 						files,
 						currentSessionId.value as string,
 						options,
-						(chunk: string, nodeId?: string) => {
-							handleStreamingChunk(chunk, nodeId, streamingManager, receivedMessage, messages);
+						(chunk: string, nodeId?: string, runIndex?: number, itemIndex?: number) => {
+							handleStreamingChunk(
+								chunk,
+								nodeId,
+								streamingManager,
+								receivedMessage,
+								messages,
+								runIndex,
+								itemIndex,
+							);
 						},
-						(nodeId: string) => {
-							handleNodeStart(nodeId, streamingManager);
+						(nodeId: string, runIndex?: number, itemIndex?: number) => {
+							handleNodeStart(nodeId, streamingManager, runIndex, itemIndex);
 						},
-						(nodeId: string) => {
+						(nodeId: string, runIndex?: number, itemIndex?: number) => {
 							handleNodeComplete(
 								nodeId,
 								streamingManager,
 								receivedMessage,
 								messages,
 								waitingForResponse,
+								runIndex,
+								itemIndex,
 							);
 						},
 					);

--- a/packages/frontend/@n8n/chat/src/types/index.ts
+++ b/packages/frontend/@n8n/chat/src/types/index.ts
@@ -2,3 +2,4 @@ export * from './chat';
 export * from './messages';
 export * from './options';
 export * from './webhook';
+export * from './streaming';

--- a/packages/frontend/@n8n/chat/src/types/options.ts
+++ b/packages/frontend/@n8n/chat/src/types/options.ts
@@ -33,4 +33,5 @@ export interface ChatOptions {
 	disabled?: Ref<boolean>;
 	allowFileUploads?: Ref<boolean> | boolean;
 	allowedFilesMimeTypes?: Ref<string> | string;
+	enableStreaming?: boolean;
 }

--- a/packages/frontend/@n8n/chat/src/types/streaming.ts
+++ b/packages/frontend/@n8n/chat/src/types/streaming.ts
@@ -1,0 +1,17 @@
+export type ChunkType = 'begin' | 'item' | 'end' | 'error';
+export interface StructuredChunk {
+	type: ChunkType;
+	content?: string;
+	metadata: {
+		nodeId: string;
+		nodeName: string;
+		timestamp: number;
+	};
+}
+
+export interface NodeStreamingState {
+	nodeId: string;
+	chunks: string[];
+	isActive: boolean;
+	startTime: number;
+}

--- a/packages/frontend/@n8n/chat/src/types/streaming.ts
+++ b/packages/frontend/@n8n/chat/src/types/streaming.ts
@@ -6,6 +6,8 @@ export interface StructuredChunk {
 		nodeId: string;
 		nodeName: string;
 		timestamp: number;
+		runIndex?: number;
+		itemIndex?: number;
 	};
 }
 

--- a/packages/frontend/@n8n/chat/src/types/streaming.ts
+++ b/packages/frontend/@n8n/chat/src/types/streaming.ts
@@ -6,8 +6,8 @@ export interface StructuredChunk {
 		nodeId: string;
 		nodeName: string;
 		timestamp: number;
-		runIndex?: number;
-		itemIndex?: number;
+		runIndex: number;
+		itemIndex: number;
 	};
 }
 

--- a/packages/frontend/@n8n/chat/src/utils/streaming.ts
+++ b/packages/frontend/@n8n/chat/src/utils/streaming.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 
-import type { ChatMessageText } from '@n8n/chat/types';
+import type { ChatMessage, ChatMessageText } from '@n8n/chat/types';
 
 export interface NodeRunData {
 	content: string;
@@ -8,6 +8,12 @@ export interface NodeRunData {
 	message: ChatMessageText;
 }
 
+/**
+ * Manages the state of streaming messages for nodes.
+ * This class is responsible for tracking the state of each run of nodes,
+ * including the content of each chunk, whether it's complete, and the message
+ * object that represents the run of a given node.
+ */
 export class StreamingMessageManager {
 	private nodeRuns = new Map<string, NodeRunData>();
 	private runOrder: string[] = [];
@@ -114,14 +120,14 @@ export function createBotMessage(id?: string): ChatMessageText {
 }
 
 export function updateMessageInArray(
-	messages: unknown[],
+	messages: ChatMessage[],
 	messageId: string,
 	updatedMessage: ChatMessageText,
 ): void {
-	const messageIndex = messages.findIndex(
-		(msg: unknown) => (msg as { id: string }).id === messageId,
-	);
-	if (messageIndex !== -1) {
-		messages[messageIndex] = updatedMessage;
+	const messageIndex = messages.findIndex((msg: ChatMessage) => msg.id === messageId);
+	if (messageIndex === -1) {
+		throw new Error(`Can't update message. No message with id ${messageId} found`);
 	}
+
+	messages[messageIndex] = updatedMessage;
 }

--- a/packages/frontend/@n8n/chat/src/utils/streaming.ts
+++ b/packages/frontend/@n8n/chat/src/utils/streaming.ts
@@ -1,0 +1,87 @@
+import { v4 as uuidv4 } from 'uuid';
+
+import type { ChatMessageText } from '@n8n/chat/types';
+
+export interface NodeStreamingData {
+	content: string;
+	isComplete: boolean;
+}
+
+export class StreamingMessageManager {
+	private nodeMessages = new Map<string, NodeStreamingData>();
+	private nodeOrder: string[] = [];
+	private activeNodes = new Set<string>();
+
+	constructor() {}
+
+	initializeNode(nodeId: string): void {
+		if (!this.nodeMessages.has(nodeId)) {
+			this.nodeMessages.set(nodeId, { content: '', isComplete: false });
+			this.nodeOrder.push(nodeId);
+		}
+	}
+
+	addNodeToActive(nodeId: string): void {
+		this.activeNodes.add(nodeId);
+		this.initializeNode(nodeId);
+	}
+
+	removeNodeFromActive(nodeId: string): void {
+		this.activeNodes.delete(nodeId);
+		const nodeData = this.nodeMessages.get(nodeId);
+		if (nodeData) {
+			nodeData.isComplete = true;
+		}
+	}
+
+	addChunkToNode(nodeId: string, chunk: string): string {
+		this.initializeNode(nodeId);
+		const nodeData = this.nodeMessages.get(nodeId)!;
+		nodeData.content += chunk;
+
+		return this.getCombinedContent();
+	}
+
+	getCombinedContent(): string {
+		return this.nodeOrder
+			.map((id) => this.nodeMessages.get(id)?.content ?? '')
+			.filter((content) => content.length > 0)
+			.join('');
+	}
+
+	areAllNodesComplete(): boolean {
+		return Array.from(this.nodeMessages.values()).every((data) => data.isComplete);
+	}
+
+	getNodeCount(): number {
+		return this.nodeOrder.length;
+	}
+
+	reset(): void {
+		this.nodeMessages.clear();
+		this.nodeOrder = [];
+		this.activeNodes.clear();
+	}
+}
+
+export function createBotMessage(id?: string): ChatMessageText {
+	return {
+		id: id ?? uuidv4(),
+		type: 'text',
+		text: '',
+		sender: 'bot',
+	};
+}
+
+export function updateMessageInArray(
+	messages: unknown[],
+	messageId: string,
+	updatedMessage: ChatMessageText,
+): void {
+	const messageIndex = messages.findIndex(
+		(msg: unknown) => (msg as { id: string }).id === messageId,
+	);
+	if (messageIndex !== -1) {
+		messages[messageIndex] = updatedMessage;
+	}
+}

--- a/packages/frontend/@n8n/chat/src/utils/streaming.ts
+++ b/packages/frontend/@n8n/chat/src/utils/streaming.ts
@@ -22,14 +22,6 @@ export class StreamingMessageManager {
 		return nodeId;
 	}
 
-	private getItemKey(nodeId: string, runIndex?: number, itemIndex?: number): string {
-		const runKey = this.getRunKey(nodeId, runIndex);
-		if (itemIndex !== undefined) {
-			return `${runKey}-${itemIndex}`;
-		}
-		return runKey;
-	}
-
 	initializeRun(nodeId: string, runIndex?: number): ChatMessageText {
 		const runKey = this.getRunKey(nodeId, runIndex);
 		if (!this.nodeRuns.has(runKey)) {

--- a/packages/frontend/@n8n/chat/src/utils/streaming.ts
+++ b/packages/frontend/@n8n/chat/src/utils/streaming.ts
@@ -14,29 +14,43 @@ export class StreamingMessageManager {
 
 	constructor() {}
 
-	initializeNode(nodeId: string): void {
-		if (!this.nodeMessages.has(nodeId)) {
-			this.nodeMessages.set(nodeId, { content: '', isComplete: false });
-			this.nodeOrder.push(nodeId);
+	private getNodeKey(nodeId: string, runIndex?: number, itemIndex?: number): string {
+		if (runIndex !== undefined && itemIndex !== undefined) {
+			return `${nodeId}-${runIndex}-${itemIndex}`;
+		}
+		if (runIndex !== undefined) {
+			return `${nodeId}-${runIndex}`;
+		}
+		return nodeId;
+	}
+
+	initializeNode(nodeId: string, runIndex?: number, itemIndex?: number): void {
+		const key = this.getNodeKey(nodeId, runIndex, itemIndex);
+		if (!this.nodeMessages.has(key)) {
+			this.nodeMessages.set(key, { content: '', isComplete: false });
+			this.nodeOrder.push(key);
 		}
 	}
 
-	addNodeToActive(nodeId: string): void {
-		this.activeNodes.add(nodeId);
-		this.initializeNode(nodeId);
+	addNodeToActive(nodeId: string, runIndex?: number, itemIndex?: number): void {
+		const key = this.getNodeKey(nodeId, runIndex, itemIndex);
+		this.activeNodes.add(key);
+		this.initializeNode(nodeId, runIndex, itemIndex);
 	}
 
-	removeNodeFromActive(nodeId: string): void {
-		this.activeNodes.delete(nodeId);
-		const nodeData = this.nodeMessages.get(nodeId);
+	removeNodeFromActive(nodeId: string, runIndex?: number, itemIndex?: number): void {
+		const key = this.getNodeKey(nodeId, runIndex, itemIndex);
+		this.activeNodes.delete(key);
+		const nodeData = this.nodeMessages.get(key);
 		if (nodeData) {
 			nodeData.isComplete = true;
 		}
 	}
 
-	addChunkToNode(nodeId: string, chunk: string): string {
-		this.initializeNode(nodeId);
-		const nodeData = this.nodeMessages.get(nodeId)!;
+	addChunkToNode(nodeId: string, chunk: string, runIndex?: number, itemIndex?: number): string {
+		this.initializeNode(nodeId, runIndex, itemIndex);
+		const key = this.getNodeKey(nodeId, runIndex, itemIndex);
+		const nodeData = this.nodeMessages.get(key)!;
 		nodeData.content += chunk;
 
 		return this.getCombinedContent();

--- a/packages/frontend/@n8n/chat/src/utils/streamingHandlers.ts
+++ b/packages/frontend/@n8n/chat/src/utils/streamingHandlers.ts
@@ -1,0 +1,126 @@
+import { nextTick } from 'vue';
+import type { Ref } from 'vue';
+
+import { chatEventBus } from '@n8n/chat/event-buses';
+import type { ChatMessageText } from '@n8n/chat/types';
+
+import type { StreamingMessageManager } from './streaming';
+import { createBotMessage, updateMessageInArray } from './streaming';
+
+export function handleStreamingChunk(
+	chunk: string,
+	nodeId: string | undefined,
+	streamingManager: StreamingMessageManager,
+	receivedMessage: Ref<ChatMessageText | null>,
+	messages: Ref<unknown[]>,
+): void {
+	try {
+		if (process.env.NODE_ENV === 'development') {
+			console.log('Processing chunk:', { nodeId, length: chunk.length });
+		}
+
+		if (!nodeId) {
+			// Simple single-node streaming (backwards compatibility)
+			if (!receivedMessage.value) {
+				receivedMessage.value = createBotMessage();
+				messages.value.push(receivedMessage.value);
+			}
+
+			const updatedMessage: ChatMessageText = {
+				...receivedMessage.value,
+				text: receivedMessage.value.text + chunk,
+			};
+
+			updateMessageInArray(messages.value, receivedMessage.value.id, updatedMessage);
+			receivedMessage.value = updatedMessage;
+
+			if (process.env.NODE_ENV === 'development') {
+				console.log('Updated single message, total length:', updatedMessage.text.length);
+			}
+		} else {
+			// Multi-node parallel streaming
+			if (!receivedMessage.value) {
+				receivedMessage.value = createBotMessage();
+				messages.value.push(receivedMessage.value);
+			}
+
+			const combinedContent = streamingManager.addChunkToNode(nodeId, chunk);
+			const updatedMessage: ChatMessageText = {
+				...receivedMessage.value,
+				text: combinedContent,
+			};
+
+			updateMessageInArray(messages.value, receivedMessage.value.id, updatedMessage);
+			receivedMessage.value = updatedMessage;
+
+			if (process.env.NODE_ENV === 'development') {
+				console.log('Updated combined message with', streamingManager.getNodeCount(), 'nodes');
+			}
+		}
+
+		void nextTick(() => {
+			chatEventBus.emit('scrollToBottom');
+		});
+	} catch (error) {
+		console.error('Error handling streaming chunk:', error);
+		// Continue gracefully without breaking the stream
+	}
+}
+
+export function handleNodeStart(
+	nodeId: string,
+	streamingManager: StreamingMessageManager,
+	receivedMessage: Ref<ChatMessageText | null>,
+	messages: Ref<unknown[]>,
+): void {
+	try {
+		streamingManager.addNodeToActive(nodeId);
+
+		if (!receivedMessage.value) {
+			receivedMessage.value = createBotMessage();
+			messages.value.push(receivedMessage.value);
+		}
+
+		void nextTick(() => {
+			chatEventBus.emit('scrollToBottom');
+		});
+	} catch (error) {
+		console.error('Error handling node start:', error);
+	}
+}
+
+export function handleNodeComplete(
+	nodeId: string,
+	streamingManager: StreamingMessageManager,
+	receivedMessage: Ref<ChatMessageText | null>,
+	messages: Ref<unknown[]>,
+	waitingForResponse: Ref<boolean>,
+): void {
+	try {
+		if (process.env.NODE_ENV === 'development') {
+			console.log('Node completed:', nodeId);
+		}
+
+		streamingManager.removeNodeFromActive(nodeId);
+
+		if (receivedMessage.value) {
+			const combinedContent = streamingManager.getCombinedContent();
+			const updatedMessage: ChatMessageText = {
+				...receivedMessage.value,
+				text: combinedContent,
+			};
+
+			updateMessageInArray(messages.value, receivedMessage.value.id, updatedMessage);
+			receivedMessage.value = updatedMessage;
+
+			if (streamingManager.areAllNodesComplete()) {
+				if (process.env.NODE_ENV === 'development') {
+					console.log('All nodes completed, streaming finished');
+				}
+				waitingForResponse.value = false;
+			}
+		}
+	} catch (error) {
+		console.error('Error handling node complete:', error);
+	}
+}

--- a/packages/frontend/@n8n/chat/src/utils/streamingHandlers.ts
+++ b/packages/frontend/@n8n/chat/src/utils/streamingHandlers.ts
@@ -14,7 +14,6 @@ export function handleStreamingChunk(
 	receivedMessage: Ref<ChatMessageText | null>,
 	messages: Ref<unknown[]>,
 	runIndex?: number,
-	itemIndex?: number,
 ): void {
 	try {
 		// Skip empty chunks to avoid showing empty responses
@@ -64,9 +63,7 @@ export function handleStreamingChunk(
 export function handleNodeStart(
 	nodeId: string,
 	streamingManager: StreamingMessageManager,
-	messages: Ref<unknown[]>,
 	runIndex?: number,
-	itemIndex?: number,
 ): void {
 	try {
 		// Just register the run as starting, don't create a message yet
@@ -80,10 +77,7 @@ export function handleNodeStart(
 export function handleNodeComplete(
 	nodeId: string,
 	streamingManager: StreamingMessageManager,
-	receivedMessage: Ref<ChatMessageText | null>,
-	messages: Ref<unknown[]>,
 	runIndex?: number,
-	itemIndex?: number,
 ): void {
 	try {
 		streamingManager.removeRunFromActive(nodeId, runIndex);

--- a/packages/frontend/@n8n/chat/src/utils/streamingHandlers.ts
+++ b/packages/frontend/@n8n/chat/src/utils/streamingHandlers.ts
@@ -2,7 +2,7 @@ import { nextTick } from 'vue';
 import type { Ref } from 'vue';
 
 import { chatEventBus } from '@n8n/chat/event-buses';
-import type { ChatMessageText } from '@n8n/chat/types';
+import type { ChatMessage, ChatMessageText } from '@n8n/chat/types';
 
 import type { StreamingMessageManager } from './streaming';
 import { createBotMessage, updateMessageInArray } from './streaming';
@@ -12,7 +12,7 @@ export function handleStreamingChunk(
 	nodeId: string | undefined,
 	streamingManager: StreamingMessageManager,
 	receivedMessage: Ref<ChatMessageText | null>,
-	messages: Ref<unknown[]>,
+	messages: Ref<ChatMessage[]>,
 	runIndex?: number,
 ): void {
 	try {
@@ -55,7 +55,7 @@ export function handleStreamingChunk(
 			chatEventBus.emit('scrollToBottom');
 		});
 	} catch (error) {
-		console.error('Error handling streaming chunk:', error);
+		console.error('Error handling stream chunk:', error);
 		// Continue gracefully without breaking the stream
 	}
 }

--- a/packages/frontend/@n8n/chat/src/utils/streamingHandlers.ts
+++ b/packages/frontend/@n8n/chat/src/utils/streamingHandlers.ts
@@ -15,10 +15,6 @@ export function handleStreamingChunk(
 	messages: Ref<unknown[]>,
 ): void {
 	try {
-		if (process.env.NODE_ENV === 'development') {
-			console.log('Processing chunk:', { nodeId, length: chunk.length });
-		}
-
 		// Only create the bot message when we receive the first actual content
 		if (!receivedMessage.value && chunk.trim()) {
 			receivedMessage.value = createBotMessage();
@@ -40,10 +36,6 @@ export function handleStreamingChunk(
 
 				updateMessageInArray(messages.value, receivedMessage.value.id, updatedMessage);
 				receivedMessage.value = updatedMessage;
-
-				if (process.env.NODE_ENV === 'development') {
-					console.log('Updated single message, total length:', updatedMessage.text.length);
-				}
 			}
 		} else {
 			// Multi-node parallel streaming
@@ -56,10 +48,6 @@ export function handleStreamingChunk(
 
 				updateMessageInArray(messages.value, receivedMessage.value.id, updatedMessage);
 				receivedMessage.value = updatedMessage;
-
-				if (process.env.NODE_ENV === 'development') {
-					console.log('Updated combined message with', streamingManager.getNodeCount(), 'nodes');
-				}
 			}
 		}
 
@@ -74,18 +62,7 @@ export function handleStreamingChunk(
 
 export function handleNodeStart(nodeId: string, streamingManager: StreamingMessageManager): void {
 	try {
-		if (process.env.NODE_ENV === 'development') {
-			console.log('Node started:', nodeId);
-		}
-
 		streamingManager.addNodeToActive(nodeId);
-
-		// Don't create the message yet - wait for the first content chunk
-		// This prevents showing <Empty Response> before actual content arrives
-
-		void nextTick(() => {
-			chatEventBus.emit('scrollToBottom');
-		});
 	} catch (error) {
 		console.error('Error handling node start:', error);
 	}
@@ -99,10 +76,6 @@ export function handleNodeComplete(
 	waitingForResponse: Ref<boolean>,
 ): void {
 	try {
-		if (process.env.NODE_ENV === 'development') {
-			console.log('Node completed:', nodeId);
-		}
-
 		streamingManager.removeNodeFromActive(nodeId);
 
 		if (receivedMessage.value) {
@@ -116,9 +89,6 @@ export function handleNodeComplete(
 			receivedMessage.value = updatedMessage;
 
 			if (streamingManager.areAllNodesComplete()) {
-				if (process.env.NODE_ENV === 'development') {
-					console.log('All nodes completed, streaming finished');
-				}
 				waitingForResponse.value = false;
 			}
 		}

--- a/packages/frontend/@n8n/chat/src/utils/streamingHandlers.ts
+++ b/packages/frontend/@n8n/chat/src/utils/streamingHandlers.ts
@@ -13,6 +13,8 @@ export function handleStreamingChunk(
 	streamingManager: StreamingMessageManager,
 	receivedMessage: Ref<ChatMessageText | null>,
 	messages: Ref<unknown[]>,
+	runIndex?: number,
+	itemIndex?: number,
 ): void {
 	try {
 		// Only create the bot message when we receive the first actual content
@@ -40,7 +42,7 @@ export function handleStreamingChunk(
 		} else {
 			// Multi-node parallel streaming
 			if (receivedMessage.value) {
-				const combinedContent = streamingManager.addChunkToNode(nodeId, chunk);
+				const combinedContent = streamingManager.addChunkToNode(nodeId, chunk, runIndex, itemIndex);
 				const updatedMessage: ChatMessageText = {
 					...receivedMessage.value,
 					text: combinedContent,
@@ -60,9 +62,14 @@ export function handleStreamingChunk(
 	}
 }
 
-export function handleNodeStart(nodeId: string, streamingManager: StreamingMessageManager): void {
+export function handleNodeStart(
+	nodeId: string,
+	streamingManager: StreamingMessageManager,
+	runIndex?: number,
+	itemIndex?: number,
+): void {
 	try {
-		streamingManager.addNodeToActive(nodeId);
+		streamingManager.addNodeToActive(nodeId, runIndex, itemIndex);
 	} catch (error) {
 		console.error('Error handling node start:', error);
 	}
@@ -74,9 +81,11 @@ export function handleNodeComplete(
 	receivedMessage: Ref<ChatMessageText | null>,
 	messages: Ref<unknown[]>,
 	waitingForResponse: Ref<boolean>,
+	runIndex?: number,
+	itemIndex?: number,
 ): void {
 	try {
-		streamingManager.removeNodeFromActive(nodeId);
+		streamingManager.removeNodeFromActive(nodeId, runIndex, itemIndex);
 
 		if (receivedMessage.value) {
 			const combinedContent = streamingManager.getCombinedContent();

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -919,7 +919,7 @@ export type IExecuteFunctions = ExecuteFunctions.GetNodeParameterFn &
 		putExecutionToWait(waitTill: Date): Promise<void>;
 		sendMessageToUI(message: any): void;
 		sendResponse(response: IExecuteResponsePromiseData): void;
-		sendChunk(type: ChunkType, content?: IDataObject | string): void;
+		sendChunk(type: ChunkType, itemIndex: number, content?: IDataObject | string): void;
 		isStreaming(): boolean;
 
 		// TODO: Make this one then only available in the new config one
@@ -2935,6 +2935,8 @@ export interface StructuredChunk {
 	metadata: {
 		nodeId: string;
 		nodeName: string;
+		runIndex: number;
+		itemIndex: number;
 		timestamp: number;
 	};
 }


### PR DESCRIPTION
## Summary
This PR adds support for streaming to the Chat SDK. 
- Adds an option to enable streaming
- Adds handling of structured chunk send by the n8n backend
- Adds management of chunks to support streaming from the same node in parallel (e.g. during batching)
- Enhances metadata of  chunks in the backend
- Updated readme

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-1112/add-streaming-response-handling-on-the-public-chat-sdk


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
