### PR TITLE
feat(GitHub Node): Add get notifications

### DIFF
--- a/packages/nodes-base/nodes/Github/Github.node.ts
+++ b/packages/nodes-base/nodes/Github/Github.node.ts
@@ -107,6 +107,10 @@ export class Github implements INodeType {
 						value: 'issue',
 					},
 					{
+						name: 'Notification',
+						value: 'notification',
+					},
+					{
 						name: 'Organization',
 						value: 'organization',
 					},
@@ -201,6 +205,27 @@ export class Github implements INodeType {
 					},
 				],
 				default: 'create',
+			},
+
+			{
+				displayName: 'Operation',
+				name: 'operation',
+				type: 'options',
+				noDataExpression: true,
+				displayOptions: {
+					show: {
+						resource: ['notification'],
+					},
+				},
+				options: [
+					{
+						name: 'Get',
+						value: 'get',
+						description: 'Get the authenticated user\'s notifications',
+						action: 'Get notifications',
+					},
+				],
+				default: 'get',
 			},
 
 			{
@@ -2091,6 +2116,86 @@ export class Github implements INodeType {
 				default: 50,
 				description: 'Max number of results to return',
 			},
+
+			// ----------------------------------
+			//         notification
+			// ----------------------------------
+			{
+				displayName: 'Additional Fields',
+				name: 'additionalFields',
+				type: 'collection',
+				placeholder: 'Add Field',
+				default: {},
+				displayOptions: {
+					show: {
+						resource: ['notification'],
+						operation: ['get'],
+					},
+				},
+				options: [
+					{
+						displayName: 'All',
+						name: 'all',
+						type: 'boolean',
+						default: false,
+						description: 'Whether to show notifications marked as read',
+					},
+					{
+						displayName: 'Participating',
+						name: 'participating',
+						type: 'boolean',
+						default: false,
+						description: 'Whether to only show notifications in which the user is directly participating',
+					},
+					{
+						displayName: 'Since',
+						name: 'since',
+						type: 'dateTime',
+						default: '',
+						description: 'Only show notifications updated after the given time (ISO 8601 timestamp)',
+					},
+					{
+						displayName: 'Before',
+						name: 'before',
+						type: 'dateTime',
+						default: '',
+						description: 'Only show notifications updated before the given time (ISO 8601 timestamp)',
+					},
+				],
+			},
+
+			{
+				displayName: 'Return All',
+				name: 'returnAll',
+				type: 'boolean',
+				displayOptions: {
+					show: {
+						resource: ['notification'],
+						operation: ['get'],
+					},
+				},
+				default: false,
+				description: 'Whether to return all results or only up to a given limit',
+			},
+
+			{
+				displayName: 'Limit',
+				name: 'limit',
+				type: 'number',
+				displayOptions: {
+					show: {
+						resource: ['notification'],
+						operation: ['get'],
+						returnAll: [false],
+					},
+				},
+				typeOptions: {
+					minValue: 1,
+					maxValue: 100,
+				},
+				default: 50,
+				description: 'Max number of results to return',
+			},
 		],
 	};
 
@@ -2151,6 +2256,7 @@ export class Github implements INodeType {
 		// and has so to be merged with the data of other items
 		const overwriteDataOperationsArray = [
 			'file:list',
+			'notification:get',
 			'repository:getIssues',
 			'repository:getPullRequests',
 			'repository:listPopularPaths',
@@ -2428,6 +2534,40 @@ export class Github implements INodeType {
 						qs.lock_reason = this.getNodeParameter('lockReason', i) as string;
 
 						endpoint = `/repos/${owner}/${repository}/issues/${issueNumber}/lock`;
+					}
+				} else if (resource === 'notification') {
+					if (operation === 'get') {
+						// ----------------------------------
+						//         get
+						// ----------------------------------
+
+						requestMethod = 'GET';
+
+						const additionalFields = this.getNodeParameter('additionalFields', i, {});
+
+						if (additionalFields.all !== undefined) {
+							qs.all = additionalFields.all;
+						}
+
+						if (additionalFields.participating !== undefined) {
+							qs.participating = additionalFields.participating;
+						}
+
+						if (additionalFields.since) {
+							qs.since = additionalFields.since;
+						}
+
+						if (additionalFields.before) {
+							qs.before = additionalFields.before;
+						}
+
+						endpoint = '/notifications';
+
+						returnAll = this.getNodeParameter('returnAll', 0);
+
+						if (!returnAll) {
+							qs.per_page = this.getNodeParameter('limit', 0);
+						}
 					}
 				} else if (resource === 'release') {
 					if (operation === 'create') {


### PR DESCRIPTION
## Summary

This adds to the GitHub Node the ability to fetch notifications for the authenticated user. It allows for multiple options to be passed to filter the notifications, such as `all`, `participating`, `since` and `before` per [the API docs](https://docs.github.com/en/rest/activity/notifications?apiVersion=2022-11-28).

> [!NOTE]
> This PR was created mostly by :copilot:

## Related Linear tickets, Github issues, and Community forum posts

I couldn't find any related tickets. :shrug:

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
