### PR TITLE
feat(Telegram Node): Add protect_content option

### DIFF
--- a/packages/nodes-base/nodes/Telegram/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Telegram/GenericFunctions.ts
@@ -114,6 +114,10 @@ export function addAdditionalFields(
 			body.disable_web_page_preview = true;
 		}
 
+		if (additionalFields.protect_content === true) {
+			body.protect_content = true;
+		}
+
 		delete additionalFields.appendAttribution;
 	}
 

--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -1582,6 +1582,26 @@ export class Telegram implements INodeType {
 						description: 'Whether to disable link previews for links in this message',
 					},
 					{
+						displayName: 'Protect Content',
+						name: 'protect_content',
+						type: 'boolean',
+						displayOptions: {
+							show: {
+								'/operation': [
+									'sendMessage',
+									'sendAnimation',
+									'sendAudio',
+									'sendDocument',
+									'sendPhoto',
+									'sendVideo',
+								],
+							},
+						},
+						default: false,
+						description:
+							'Whether to protect the contents of the sent message from forwarding and saving',
+					},
+					{
 						displayName: 'Duration',
 						name: 'duration',
 						type: 'number',


### PR DESCRIPTION
## Summary

Add `protect_content` option to the Telegram node

![Screenshot 2025-07-07 142847](https://github.com/user-attachments/assets/34174665-0fcf-489d-922a-d1a84f9ba036)
![Screenshot 2025-07-07 143934](https://github.com/user-attachments/assets/1f6bd27c-e415-4143-8218-21552023a1ee)


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
