### PR TITLE
perf(core): Eliminate unnecessary license server calls

### DIFF
--- a/packages/cli/src/license/__tests__/license.service.test.ts
+++ b/packages/cli/src/license/__tests__/license.service.test.ts
@@ -76,6 +76,15 @@ describe('LicenseService', () => {
 	});
 
 	describe('renewLicense', () => {
+		test('should skip renewal for unlicensed user (Community plan)', async () => {
+			license.getPlanName.mockReturnValueOnce('Community');
+
+			await licenseService.renewLicense();
+
+			expect(license.renew).not.toHaveBeenCalled();
+			expect(eventService.emit).not.toHaveBeenCalled();
+		});
+
 		test('on success', async () => {
 			license.renew.mockResolvedValueOnce();
 			await licenseService.renewLicense();

--- a/packages/cli/src/license/license.service.ts
+++ b/packages/cli/src/license/license.service.ts
@@ -120,6 +120,8 @@ export class LicenseService {
 	}
 
 	async renewLicense() {
+		if (this.license.getPlanName() === 'Community') return; // unlicensed, nothing to renew
+
 		try {
 			await this.license.renew();
 		} catch (e) {

--- a/packages/cli/test/integration/license.api.test.ts
+++ b/packages/cli/test/integration/license.api.test.ts
@@ -101,6 +101,7 @@ describe('POST /license/renew', () => {
 	});
 
 	test('errors out properly', async () => {
+		License.prototype.getPlanName = jest.fn().mockReturnValue('Enterprise');
 		License.prototype.renew = jest.fn().mockImplementation(() => {
 			throw new Error(GENERIC_ERROR_MESSAGE);
 		});


### PR DESCRIPTION
## Summary

Every visit to `/settings/usage` as the instance owner triggers a renewal call to the license server, which always fails if the instance is unlicensed:

```
08:58:52.860   error   Failed to renew license: renewal failed because current cert is not initialized { "stack": "Error:  renewal failed because current cert is not initialized\n    at T._renew (/Users/ivov/Development/n8n/node_modules/.pnpm/@n8n_io+license-sdk@2.22.0/node_modules/@n8n_io/license-sdk/src/LicenseManager.ts: 443: 13)\n    at T.renew (/Users/ivov/Development/n8n/node_modules/.pnpm/@n8n_io+license-sdk@2.22.0/node_modules/@n8n_io/license-sdk/src/LicenseManager.ts: 432: 17)\n    at License.renew (/Users/ivov/Development/n8n/packages/cli/src/license.ts: 193: 22)\n    at LicenseService.renewLicense (/Users/ivov/Development/n8n/packages/cli/src/license/license.service.ts: 124: 23)\n    at LicenseController.renewLicense (/Users/ivov/Development/n8n/packages/cli/src/license/license.controller.ts: 69: 29)\n    at handler (/Users/ivov/Development/n8n/packages/cli/src/controller.registry.ts: 78: 41)\n    at /Users/ivov/Development/n8n/packages/cli/src/response-helper.ts: 157: 23\n    at Layer.handleRequest (/Users/ivov/Development/n8n/node_modules/.pnpm/router@2.2.0/node_modules/router/lib/layer.js: 152: 17)\n    at next (/Users/ivov/Development/n8n/node_modules/.pnpm/router@2.2.0/node_modules/router/lib/route.js: 157: 13)\n    at /Users/ivov/Development/n8n/packages/cli/src/controller.registry.ts: 153: 4", "file": "license.service.js", "function": "mapErrorMessage" }
08:58:52.861   error   400 Failed to renew license: renewal failed because current cert is not initialized { "file": "response-helper.js", "function": "sendErrorResponse" }
```

This PR ensures that the BE does not forward pointless renewal requests to license server.

This change was made on the BE, because the client makes the renewal call [without having license data in the store](https://github.com/n8n-io/n8n/blob/3b1483096625ead20803a320567f651df221137c/packages/frontend/editor-ui/src/views/SettingsUsageAndPlan.vue#L107-L112). Changing this on the FE would require a call to fetch license data from the license server to decide whether to renew, which would negate the benefit. No context on why the client is laid out like this - ideally in future we can optimize further if the FE can make sure to have license data by the time it mounts this component.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
https://n8nio.slack.com/archives/C0789EN39RC/p1751642858257839

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
