### PR TITLE
chore: Fix GitHub workflow directory for OpenAPI sync

### DIFF
--- a/.github/workflows/sync-public-api-docs.yml
+++ b/.github/workflows/sync-public-api-docs.yml
@@ -32,6 +32,7 @@ jobs:
 
       - name: Build Public API Schema
         run: pnpm run build:data
+        working-directory: ./packages/cli
 
       - name: Verify OpenAPI schema exists
         id: verify_file


### PR DESCRIPTION
## Summary

Ensure GitHub workflow which builds the OpenAPI schema runs in the correct cirectory.

## Related Linear tickets, Github issues, and Community forum posts

Related: #15985

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- ~[ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- ~[ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->~
- ~[ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
