### PR TITLE
feat(Zen mode): Enable zen mode in workflow editor to maximize building space

### DIFF
--- a/packages/frontend/editor-ui/src/App.vue
+++ b/packages/frontend/editor-ui/src/App.vue
@@ -17,6 +17,7 @@ import { useBuilderStore } from '@/stores/builder.store';
 import { useUIStore } from '@/stores/ui.store';
 import { useUsersStore } from '@/stores/users.store';
 import { useSettingsStore } from '@/stores/settings.store';
+import { useZenModeStore } from '@/stores/zenMode.store';
 import { useHistoryHelper } from '@/composables/useHistoryHelper';
 import { useStyles } from './composables/useStyles';
 import { locale } from '@n8n/design-system';
@@ -29,6 +30,7 @@ const builderStore = useBuilderStore();
 const uiStore = useUIStore();
 const usersStore = useUsersStore();
 const settingsStore = useSettingsStore();
+const zenModeStore = useZenModeStore();
 
 const { setAppZIndexes } = useStyles();
 
@@ -100,16 +102,27 @@ watch(
 		:class="{
 			[$style.container]: true,
 			[$style.sidebarCollapsed]: uiStore.sidebarMenuCollapsed,
+			[$style.zenMode]: zenModeStore.isZenModeActive,
 		}"
 	>
 		<div id="app-grid" ref="appGrid" :class="$style['app-grid']">
-			<div id="banners" :class="$style.banners">
+			<div
+				id="banners"
+				:class="[$style.banners, { [$style.zenModeHidden]: zenModeStore.isZenModeActive }]"
+			>
 				<BannerStack v-if="!isDemoMode" />
 			</div>
-			<div id="header" :class="$style.header">
+			<div
+				id="header"
+				:class="[$style.header, { [$style.zenModeHidden]: zenModeStore.isZenModeActive }]"
+			>
 				<RouterView name="header" />
 			</div>
-			<div v-if="usersStore.currentUser" id="sidebar" :class="$style.sidebar">
+			<div
+				v-if="usersStore.currentUser"
+				id="sidebar"
+				:class="[$style.sidebar, { [$style.zenModeHidden]: zenModeStore.isZenModeActive }]"
+			>
 				<RouterView name="sidebar" />
 			</div>
 			<div id="content" :class="$style.content">
@@ -156,6 +169,39 @@ watch(
 		'sidebar content';
 	grid-template-columns: auto 1fr;
 	grid-template-rows: auto auto 1fr;
+}
+
+// Focus mode styles
+.zenMode {
+	.app-grid {
+		grid-template-areas: 'content';
+		grid-template-columns: 1fr;
+		grid-template-rows: 1fr;
+	}
+
+	.content {
+		position: fixed !important;
+		top: 0 !important;
+		left: 0 !important;
+		width: 100vw !important;
+		height: 100vh !important;
+		overflow: hidden !important;
+		z-index: 1000;
+	}
+
+	.contentWrapper {
+		width: 100vw !important;
+		height: 100vh !important;
+		overflow: hidden !important;
+	}
+}
+
+.zenModeHidden {
+	opacity: 0;
+	visibility: hidden;
+	transition:
+		opacity 0.2s ease-in-out,
+		visibility 0.2s ease-in-out;
 }
 
 .banners {

--- a/packages/frontend/editor-ui/src/App.vue
+++ b/packages/frontend/editor-ui/src/App.vue
@@ -108,20 +108,20 @@ watch(
 		<div id="app-grid" ref="appGrid" :class="$style['app-grid']">
 			<div
 				id="banners"
-				:class="[$style.banners, { [$style.zenModeHidden]: zenModeStore.isZenModeActive }]"
+				:class="[$style.banners, { [$style.bannersSlideUp]: zenModeStore.isZenModeActive }]"
 			>
 				<BannerStack v-if="!isDemoMode" />
 			</div>
 			<div
 				id="header"
-				:class="[$style.header, { [$style.zenModeHidden]: zenModeStore.isZenModeActive }]"
+				:class="[$style.header, { [$style.headerSlideUp]: zenModeStore.isZenModeActive }]"
 			>
 				<RouterView name="header" />
 			</div>
 			<div
 				v-if="usersStore.currentUser"
 				id="sidebar"
-				:class="[$style.sidebar, { [$style.zenModeHidden]: zenModeStore.isZenModeActive }]"
+				:class="[$style.sidebar, { [$style.sidebarSlideLeft]: zenModeStore.isZenModeActive }]"
 			>
 				<RouterView name="sidebar" />
 			</div>
@@ -174,9 +174,29 @@ watch(
 // Focus mode styles
 .zenMode {
 	.app-grid {
-		grid-template-areas: 'content';
-		grid-template-columns: 1fr;
-		grid-template-rows: 1fr;
+		// Keep original grid layout to prevent layout shifts
+		// grid-template-areas: 'content';
+		// grid-template-columns: 1fr;
+		// grid-template-rows: 1fr;
+	}
+
+	.header {
+		/* Header is already full width in grid, just needs to slide up */
+		z-index: var(--z-index-app-header);
+		left: 0;
+	}
+
+	.banners {
+		/* Banners are already full width in grid, just need to slide up */
+		z-index: var(--z-index-top-banners);
+	}
+
+	.sidebar {
+		position: absolute !important;
+		top: 0;
+		left: 0;
+		bottom: 0;
+		z-index: var(--z-index-app-sidebar);
 	}
 
 	.content {
@@ -196,17 +216,15 @@ watch(
 	}
 }
 
-.zenModeHidden {
-	opacity: 0;
-	visibility: hidden;
-	transition:
-		opacity 0.2s ease-in-out,
-		visibility 0.2s ease-in-out;
-}
-
 .banners {
 	grid-area: banners;
 	z-index: var(--z-index-top-banners);
+	transition: transform 0.3s ease-in-out;
+}
+
+.bannersSlideUp {
+	transform: translateY(-100%);
+	left: 0 !important; /* Expand to full width */
 }
 .content {
 	display: flex;
@@ -247,11 +265,30 @@ watch(
 	z-index: var(--z-index-app-header);
 	min-width: 0;
 	min-height: 0;
+	transition: transform 0.15s ease-in-out;
+	/* Make header span full width by positioning it to cover the entire row */
+	position: relative;
+	left: -200px; /* Offset to account for sidebar width */
+	padding-left: 200px;
+	width: calc(100% + 200px); /* Extend width to cover sidebar area */
+}
+
+.headerSlideUp {
+	transform: translateY(-150%);
+}
+
+.bannersSlideUp {
+	transform: translateY(-100%);
 }
 
 .sidebar {
 	grid-area: sidebar;
 	z-index: var(--z-index-app-sidebar);
+	transition: transform 0.15s ease-in-out;
+}
+
+.sidebarSlideLeft {
+	transform: translateX(-100%);
 }
 
 .modals {

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/NodeCreator.vue
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/NodeCreator.vue
@@ -3,6 +3,7 @@ import { watch, reactive, toRefs, computed, onBeforeUnmount } from 'vue';
 
 import { useNodeTypesStore } from '@/stores/nodeTypes.store';
 import { useNodeCreatorStore } from '@/stores/nodeCreator.store';
+import { useZenModeStore } from '@/stores/zenMode.store';
 import SlideTransition from '@/components/transitions/SlideTransition.vue';
 
 import { useViewStacks } from './composables/useViewStacks';
@@ -32,6 +33,7 @@ const emit = defineEmits<{
 const uiStore = useUIStore();
 const assistantStore = useAssistantStore();
 const builderStore = useBuilderStore();
+const zenModeStore = useZenModeStore();
 
 const { setShowScrim, setActions, setMergeNodes } = useNodeCreatorStore();
 const { generateMergedNodesAndActions } = useActionsGenerator();
@@ -46,8 +48,20 @@ const showScrim = computed(() => useNodeCreatorStore().showScrim);
 const viewStacksLength = computed(() => useViewStacks().viewStacks.length);
 
 const nodeCreatorInlineStyle = computed(() => {
+	const zenModeActive = zenModeStore.isZenModeActive;
 	const rightPosition = getRightOffset();
-	return { top: `${uiStore.bannersHeight + uiStore.headerHeight}px`, right: `${rightPosition}px` };
+	return {
+		top: zenModeActive ? '0px' : `${uiStore.bannersHeight + uiStore.headerHeight}px`,
+		right: `${rightPosition}px`,
+	};
+});
+
+const scrimInlineStyle = computed(() => {
+	const zenModeActive = zenModeStore.isZenModeActive;
+	return {
+		top: zenModeActive ? '0px' : `${uiStore.bannersHeight + uiStore.headerHeight}px`,
+		left: zenModeActive ? '0px' : '65px', // Use the SCSS variable value directly
+	};
 });
 
 function getRightOffset() {
@@ -160,6 +174,7 @@ onBeforeUnmount(() => {
 				[$style.nodeCreatorScrim]: true,
 				[$style.active]: showScrim,
 			}"
+			:style="scrimInlineStyle"
 		/>
 		<N8nIconButton
 			v-if="active"
@@ -195,9 +210,9 @@ onBeforeUnmount(() => {
 	--node-creator-width: #{$node-creator-width};
 	--node-icon-color: var(--color-text-base);
 	position: fixed;
-	top: $header-height;
+	top: 0; /* Will be overridden by inline styles */
 	bottom: 0;
-	right: 0;
+	right: 0; /* Will be overridden by inline styles */
 	z-index: var(--z-index-node-creator);
 	width: var(--node-creator-width);
 	color: $node-creator-text-color;
@@ -205,10 +220,10 @@ onBeforeUnmount(() => {
 
 .nodeCreatorScrim {
 	position: fixed;
-	top: $header-height;
+	top: 0; /* Will be overridden by inline styles */
 	right: 0;
 	bottom: 0;
-	left: $sidebar-width;
+	left: 65px; /* Will be overridden by inline styles */
 	opacity: 0;
 	z-index: 1;
 	background: var(--color-dialog-overlay-background);

--- a/packages/frontend/editor-ui/src/components/ZenModeIcon.vue
+++ b/packages/frontend/editor-ui/src/components/ZenModeIcon.vue
@@ -1,0 +1,7 @@
+<template>
+	<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<circle cx="9" cy="9" r="7.5" stroke="currentColor" stroke-width="1.5" fill="none" />
+		<circle cx="9" cy="9" r="4.5" stroke="currentColor" stroke-width="1.5" fill="none" />
+		<circle cx="9" cy="9" r="1.5" fill="currentColor" />
+	</svg>
+</template>

--- a/packages/frontend/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/Canvas.vue
@@ -323,7 +323,7 @@ const keyMap = computed(() => {
 		f2: emitWithLastSelectedNode((id) => emit('update:node:name', id)),
 		tab: () => emit('create:node', 'tab'),
 		shift_s: () => emit('create:sticky'),
-		// shift_f: () => emit('toggle:focus-panel'), // Disabled in favor of Zen mode
+		shift_f: () => emit('toggle:focus-panel'),
 		ctrl_alt_n: () => emit('create:workflow'),
 		ctrl_enter: () => emit('run:workflow'),
 		ctrl_s: () => emit('save:workflow'),

--- a/packages/frontend/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/Canvas.vue
@@ -56,6 +56,7 @@ import Node from './elements/nodes/CanvasNode.vue';
 import { useViewportAutoAdjust } from './composables/useViewportAutoAdjust';
 import { isOutsideSelected } from '@/utils/htmlUtils';
 import { useExperimentalNdvStore } from './experimental/experimentalNdv.store';
+import { useZenModeStore } from '@/stores/zenMode.store';
 
 const $style = useCssModule();
 
@@ -103,7 +104,7 @@ const emit = defineEmits<{
 	'create:workflow': [];
 	'drag-and-drop': [position: XYPosition, event: DragEvent];
 	'tidy-up': [CanvasLayoutEvent];
-	'toggle:focus-panel': [];
+	'toggle-zen-mode': [];
 	'viewport:change': [viewport: ViewportTransform, dimensions: Dimensions];
 	'selection:end': [position: XYPosition];
 	'open:sub-workflow': [nodeId: string];
@@ -179,9 +180,12 @@ const experimentalNdvStore = useExperimentalNdvStore();
 
 const isPaneReady = ref(false);
 
+const zenModeStore = useZenModeStore();
+
 const classes = computed(() => ({
 	[$style.canvas]: true,
 	[$style.ready]: !props.loading && isPaneReady.value,
+	zenMode: zenModeStore.isZenModeActive,
 }));
 
 /**
@@ -319,13 +323,14 @@ const keyMap = computed(() => {
 		f2: emitWithLastSelectedNode((id) => emit('update:node:name', id)),
 		tab: () => emit('create:node', 'tab'),
 		shift_s: () => emit('create:sticky'),
-		shift_f: () => emit('toggle:focus-panel'),
+		// shift_f: () => emit('toggle:focus-panel'), // Disabled in favor of Zen mode
 		ctrl_alt_n: () => emit('create:workflow'),
 		ctrl_enter: () => emit('run:workflow'),
 		ctrl_s: () => emit('save:workflow'),
 		shift_alt_t: async () => await onTidyUp({ source: 'keyboard-shortcut' }),
 		alt_x: emitWithSelectedNodes((ids) => emit('extract-workflow', ids)),
 		c: () => emit('start-chat'),
+		z: onToggleZenMode,
 	};
 	return fullKeymap;
 });
@@ -727,6 +732,33 @@ async function onTidyUp(payload: { source: CanvasLayoutSource }) {
 	}
 }
 
+function onToggleZenMode() {
+	zenModeStore.toggleZenMode();
+	// Center on the currently selected node when entering Zen mode
+	if (zenModeStore.isZenModeActive) {
+		if (selectedNodes.value.length === 1) {
+			const targetNode = selectedNodes.value[0];
+			const newViewport = updateViewportToContainNodes(
+				viewport.value,
+				dimensions.value,
+				[targetNode],
+				200,
+			);
+			void setViewport(newViewport, { duration: 300 });
+		} else if (selectedNodes.value.length > 1) {
+			const newViewport = updateViewportToContainNodes(
+				viewport.value,
+				dimensions.value,
+				selectedNodes.value,
+				100,
+			);
+			void setViewport(newViewport, { duration: 300 });
+		} else {
+			void onFitView();
+		}
+	}
+}
+
 /**
  * Drag and drop
  */
@@ -958,6 +990,7 @@ provide(CanvasKey, {
 			@zoom-out="onZoomOut"
 			@reset-zoom="onResetZoom"
 			@tidy-up="onTidyUp({ source: 'canvas-button' })"
+			@toggle-zen-mode="onToggleZenMode"
 		/>
 
 		<Suspense>

--- a/packages/frontend/editor-ui/src/components/canvas/elements/buttons/CanvasControlButtons.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/elements/buttons/CanvasControlButtons.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import KeyboardShortcutTooltip from '@/components/KeyboardShortcutTooltip.vue';
 import TidyUpIcon from '@/components/TidyUpIcon.vue';
+import ZenModeIcon from '@/components/ZenModeIcon.vue';
 import { useI18n } from '@n8n/i18n';
 import { Controls } from '@vue-flow/controls';
 import { computed } from 'vue';
+import { useZenModeStore } from '@/stores/zenMode.store';
 
 const props = withDefaults(
 	defineProps<{
@@ -22,11 +24,14 @@ const emit = defineEmits<{
 	'zoom-out': [];
 	'zoom-to-fit': [];
 	'tidy-up': [];
+	'toggle-zen-mode': [];
 }>();
 
 const i18n = useI18n();
+const zenModeStore = useZenModeStore();
 
 const isResetZoomVisible = computed(() => props.zoom !== 1);
+const isZenModeActive = computed(() => zenModeStore.isZenModeActive);
 
 function onResetZoom() {
 	emit('reset-zoom');
@@ -46,6 +51,10 @@ function onZoomToFit() {
 
 function onTidyUp() {
 	emit('tidy-up');
+}
+
+function onToggleZenMode() {
+	emit('toggle-zen-mode');
 }
 </script>
 <template>
@@ -109,6 +118,20 @@ function onTidyUp() {
 				<TidyUpIcon />
 			</N8nButton>
 		</KeyboardShortcutTooltip>
+		<KeyboardShortcutTooltip
+			:label="isZenModeActive ? 'Exit Zen Mode' : 'Enter Zen Mode'"
+			:shortcut="{ keys: ['z'] }"
+		>
+			<N8nButton
+				class="zenModeBtn"
+				type="tertiary"
+				size="medium"
+				data-test-id="zen-mode-button"
+				@click="onToggleZenMode"
+			>
+				<ZenModeIcon />
+			</N8nButton>
+		</KeyboardShortcutTooltip>
 	</Controls>
 </template>
 
@@ -120,6 +143,30 @@ function onTidyUp() {
 	svg {
 		width: 16px;
 		height: 16px;
+	}
+}
+
+.zenModeActive {
+	// Remove background/gradient for GitHub style
+	background: none !important;
+	border-color: transparent !important;
+	color: var(--color-text-dark, #222) !important;
+}
+
+.zenModeBtn {
+	display: flex;
+	align-items: center;
+	font-weight: 500;
+	font-size: 15px;
+	background: none !important;
+	border: none !important;
+	box-shadow: none !important;
+	color: var(--color-text-dark, #222) !important;
+	padding: 4px 12px;
+	border-radius: 6px;
+	transition: background 0.2s;
+	&:hover {
+		background: #f3f4f6 !important;
 	}
 }
 </style>

--- a/packages/frontend/editor-ui/src/stores/zenMode.store.ts
+++ b/packages/frontend/editor-ui/src/stores/zenMode.store.ts
@@ -1,0 +1,25 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+
+export const useZenModeStore = defineStore('zenMode', () => {
+	const isZenModeActive = ref(false);
+
+	function toggleZenMode() {
+		isZenModeActive.value = !isZenModeActive.value;
+	}
+
+	function enableZenMode() {
+		isZenModeActive.value = true;
+	}
+
+	function disableZenMode() {
+		isZenModeActive.value = false;
+	}
+
+	return {
+		isZenModeActive,
+		toggleZenMode,
+		enableZenMode,
+		disableZenMode,
+	};
+});

--- a/packages/frontend/editor-ui/src/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/views/NodeView.vue
@@ -136,6 +136,7 @@ import { needsAgentInput } from '@/utils/nodes/nodeTransforms';
 import { useLogsStore } from '@/stores/logs.store';
 import { canvasEventBus } from '@/event-bus/canvas';
 import CanvasChatButton from '@/components/canvas/elements/buttons/CanvasChatButton.vue';
+import { useZenModeStore } from '@/stores/zenMode.store';
 import { useFocusPanelStore } from '@/stores/focusPanel.store';
 
 defineOptions({
@@ -197,6 +198,7 @@ const foldersStore = useFoldersStore();
 const posthogStore = usePostHog();
 const agentRequestStore = useAgentRequestStore();
 const logsStore = useLogsStore();
+const zenModeStore = useZenModeStore();
 
 const { addBeforeUnloadEventBindings, removeBeforeUnloadEventBindings } = useBeforeUnload({
 	route,
@@ -679,6 +681,14 @@ const allTriggerNodesDisabled = computed(() => {
 
 function onTidyUp(event: CanvasLayoutEvent) {
 	tidyUp(event);
+}
+
+function onToggleZenMode() {
+	zenModeStore.toggleZenMode();
+	toast.showMessage({
+		title: zenModeStore.isZenModeActive ? 'Zen Mode Enabled' : 'Zen Mode Disabled',
+		type: 'info',
+	});
 }
 
 function onExtractWorkflow(nodeIds: string[]) {
@@ -2054,6 +2064,7 @@ onBeforeUnmount(() => {
 			@selection:end="onSelectionEnd"
 			@drag-and-drop="onDragAndDrop"
 			@tidy-up="onTidyUp"
+			@toggle-zen-mode="onToggleZenMode"
 			@toggle:focus-panel="onToggleFocusPanel"
 			@extract-workflow="onExtractWorkflow"
 			@start-chat="startChat()"


### PR DESCRIPTION
## Summary
- AAUser, when I go to the workflow edition view at /workflow/<existing workflow id> or /workflow/new, I see I can enter Zen mode where sidebar and header are hidden, So that I can have the full width possible for building my workflow

https://github.com/user-attachments/assets/fd6269b7-95c2-4691-853c-8519119a36ed

Details:
- Can be toggled via "Z" shortcut
- Inspired by Github zen mode

Limits:
- A more appropriate shortcut should be "cmd + \" -> need to harmonize current shortcuts
- The animation should be re-worked to avoid layout glitch on the header bar -> need a new layout strategy moving away from grid to have the header bar below the sidebar
- Both limits can be reconsidered if the Zen mode experience proves valuable.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
