### PR TITLE
fix(n8n Form Node): Make customizing form custom styles possible on mobile screens and on form end redirect

### DIFF
--- a/packages/cli/templates/form-trigger.handlebars
+++ b/packages/cli/templates/form-trigger.handlebars
@@ -400,7 +400,7 @@
 
 			@media only screen and (max-width: 500px) {
 				body {
-					background-color: #ffffff;
+					background-color: var(--color-background);
 				}
 				hr {
 					display: block;
@@ -409,14 +409,13 @@
 					width: 95%;
 					min-height: 100vh;
 					padding: 24px;
-					background-color: #ffffff;
 					border: 0px solid var(--color-input-border);
 					border-radius: 0px;
 					box-shadow: 0px 0px 0px 0px #ffffff;
 				}
 				.card {
 					padding: 0px;
-					background-color: #ffffff;
+					background-color: var(--color-card-bg);
 					border: 0px solid var(--color-input-border);
 					border-radius: 0px;
 					box-shadow: 0px 0px 0px 0px #ffffff;

--- a/packages/nodes-base/nodes/Form/Form.node.ts
+++ b/packages/nodes-base/nodes/Form/Form.node.ts
@@ -253,7 +253,7 @@ const completionProperties = updateDisplayOptions(
 			],
 			displayOptions: {
 				show: {
-					respondWith: ['text', 'returnBinary'],
+					respondWith: ['text', 'returnBinary', 'redirect'],
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

We are taking n8n forms in use at the welcome personalization survey. To support that use case I've been building a form with custom styles that gets embedded on that page. This PR fixes some annoyances I've noticed:

- It wasn't possible to style the background using `var(--color-background)` and `var(--color-card-bg)` on mobile screens like one would expect
- It wasn't possible to apply custom styles to the redirect page that briefly shows up as the redirect happens

This PR fixes both of those annoyances. Default forms on mobile do exactly the same.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3733/feature-replace-typeform-with-n8n-form-in-cloud-signup

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
