### PR TITLE
fix(editor): Fit long words for draggable fields

### DIFF
--- a/packages/frontend/editor-ui/src/components/AssignmentCollection/AssignmentCollection.vue
+++ b/packages/frontend/editor-ui/src/components/AssignmentCollection/AssignmentCollection.vue
@@ -244,7 +244,11 @@ function optionSelected(action: string) {
 	min-height: 24px;
 
 	> span {
-		white-space: nowrap;
+		word-wrap: break-word;
+		overflow-wrap: break-word;
+		word-break: break-word;
+		white-space: normal;
+		max-width: 100%;
 	}
 }
 


### PR DESCRIPTION
## Summary

The long variable names now fit draggable boxes

```
{
  "nodes": [
    {
      "parameters": {},
      "type": "n8n-nodes-base.manualTrigger",
      "typeVersion": 1,
      "position": [
        -160,
        -64
      ],
      "id": "229e5c1c-efb9-4785-aca6-c0b87748c560",
      "name": "When clicking ‘Execute workflow’"
    },
    {
      "parameters": {
        "mode": "raw",
        "jsonOutput": "{\n  \"userAccountInformationDetails\": {\n    \"userPersonalProfileData\": {\n      \"userAddressAndLocationDetails\": {\n        \"userPrimaryResidentialAddress\": {\n          \"userPrimaryResidentialAddressStreetName\": \"123 Longfield Avenue\",\n          \"userPrimaryResidentialAddressCityName\": \"Exampleville\",\n          \"userPrimaryResidentialAddressStateOrProvinceName\": \"Sample State\",\n          \"userPrimaryResidentialAddressPostalCode\": \"12345\"\n        },\n        \"userSecondaryMailingAddressDetails\": {\n          \"userSecondaryMailingAddressStreetName\": \"456 Backup Street\",\n          \"userSecondaryMailingAddressCityName\": \"Fallback City\",\n          \"userSecondaryMailingAddressStateOrProvinceName\": \"Spare State\",\n          \"userSecondaryMailingAddressPostalCode\": \"67890\"\n        }\n      },\n      \"userContactInformationAndPreferences\": {\n        \"userPreferredContactPhoneNumber\": \"+1-234-567-8901\",\n        \"userPreferredContactEmailAddress\": \"user@example.com\",\n        \"userNotificationPreferenceSettings\": {\n          \"emailNotificationsEnabledStatus\": true,\n          \"smsNotificationsEnabledStatus\": false,\n          \"pushNotificationsEnabledStatus\": true\n        }\n      }\n    }\n  }\n}\n",
        "options": {}
      },
      "type": "n8n-nodes-base.set",
      "typeVersion": 3.4,
      "position": [
        64,
        -64
      ],
      "id": "1330b53c-7461-4c0d-b867-3418ca12c0e5",
      "name": "Edit Fields"
    },
    {
      "parameters": {
        "assignments": {
          "assignments": [
            {
              "id": "18f3a8ed-493d-484a-a5a4-82aa5a34b88d",
              "name": "userAccountInformationDetails.userPersonalProfileData.userContactInformationAndPreferences.userNotificationPreferenceSettings.emailNotificationsEnabledStatus",
              "value": "",
              "type": "string"
            },
            {
              "id": "fb0963f3-f404-47d3-a580-ebb908556546",
              "name": "userAccountInformationDetails.userPersonalProfileData.userAddressAndLocationDetails.userSecondaryMailingAddressDetails.userSecondaryMailingAddressPostalCode",
              "value": "={{ $json.userAccountInformationDetails.userPersonalProfileData.userAddressAndLocationDetails.userPrimaryResidentialAddress.userPrimaryResidentialAddressPostalCode }}",
              "type": "string"
            },
            {
              "id": "4781ea6c-5e2f-4412-be6c-4df1d3542873",
              "name": "userAccountInformationDetails.userPersonalProfileData.userAddressAndLocationDetails.userPrimaryResidentialAddress.userPrimaryResidentialAddressStreetName",
              "value": "={{ $json.userAccountInformationDetails.userPersonalProfileData.userAddressAndLocationDetails.userPrimaryResidentialAddress.userPrimaryResidentialAddressStreetName }}",
              "type": "string"
            },
            {
              "id": "abb76958-9e74-4da7-a3be-2589337e3d66",
              "name": "userAccountInformationDetails.userPersonalProfileData.userAddressAndLocationDetails.userSecondaryMailingAddressDetails.userSecondaryMailingAddressStreetName",
              "value": "={{ $json.userAccountInformationDetails.userPersonalProfileData.userAddressAndLocationDetails.userSecondaryMailingAddressDetails.userSecondaryMailingAddressStreetName }}",
              "type": "string"
            }
          ]
        },
        "options": {}
      },
      "type": "n8n-nodes-base.set",
      "typeVersion": 3.4,
      "position": [
        288,
        -64
      ],
      "id": "be98c6dc-f057-4251-8bb9-4ed8366cf8ae",
      "name": "Edit Fields1"
    }
  ],
  "connections": {
    "When clicking ‘Execute workflow’": {
      "main": [
        [
          {
            "node": "Edit Fields",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Edit Fields": {
      "main": [
        [
          {
            "node": "Edit Fields1",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {},
  "meta": {
    "instanceId": "ee90fdf8d57662f949e6c691dc07fa0fd2f66e1eee28ed82ef06658223e67255"
  }
}
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3139/edit-fields-node-long-field-names-break-the-ui-of-the-drop-zone

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
