### PR TITLE
fix: Mark n8n-containers as private to avoid publishing (no-changelog)

### DIFF
--- a/packages/testing/containers/package.json
+++ b/packages/testing/containers/package.json
@@ -1,5 +1,6 @@
 {
   "name": "n8n-containers",
+  "private": true,
   "version": "1.0.0",
   "description": "",
   "main": "index.js",


### PR DESCRIPTION
## Summary

n8n-containers doesn't need to be published so should be marked private.

## Related Linear tickets, Github issues, and Community forum posts



## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
