### PR TITLE
fix(core): Fix license in test containers

### DIFF
--- a/packages/testing/containers/n8n-test-container-creation.ts
+++ b/packages/testing/containers/n8n-test-container-creation.ts
@@ -35,7 +35,7 @@ const N8N_IMAGE = process.env.N8N_DOCKER_IMAGE || N8N_E2E_IMAGE;
 const BASE_ENV: Record<string, string> = {
 	N8N_LOG_LEVEL: 'debug',
 	N8N_ENCRYPTION_KEY: 'test-encryption-key',
-	E2E_TESTS: 'true',
+	E2E_TESTS: 'false',
 	QUEUE_HEALTH_CHECK_ACTIVE: 'true',
 	N8N_DIAGNOSTICS_ENABLED: 'false',
 	NODE_ENV: 'development', // If this is set to test, the n8n container will not start, insights module is not found??


### PR DESCRIPTION
## Summary

Test containers activate the e2e controller, which [disables all license features](https://github.com/n8n-io/n8n/blob/657e5a3b3a5184b9f1f6b6303faabb9feef0d70a/packages/cli/src/controllers/e2e.controller.ts#L79-L110), leading to all license features being disabled in test containers except multi-main. 

Assuming the e2e controller is unneeded in the test container stack, we should keep it disabled. This does not affect multi-main because it is [explicitly enabled](https://github.com/n8n-io/n8n/blob/1a39ab62ac99bf0733dc0cef16b3bc74a1cc26d2/packages/testing/containers/n8n-test-container-creation.ts#L153) by the test containers.

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.slack.com/archives/C0789EN39RC/p1751642858257839

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
