### PR TITLE
fix(Perplexity Node): Allow for penalties below 1

### DIFF
--- a/packages/nodes-base/nodes/Perplexity/descriptions/chat/complete.operation.ts
+++ b/packages/nodes-base/nodes/Perplexity/descriptions/chat/complete.operation.ts
@@ -130,9 +130,9 @@ const properties: INodeProperties[] = [
 				displayName: 'Frequency Penalty',
 				name: 'frequencyPenalty',
 				type: 'number',
-				default: 1,
+				default: 0,
 				typeOptions: {
-					minValue: 1,
+					minValue: 0,
 				},
 				description:
 					"Values greater than 1.0 penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim",


### PR DESCRIPTION
## Summary

Allow for penalties below 1

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3155/community-issue-perplexity-node-cannot-set-frequency-penalty-below-1

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
