### PR TITLE
chore: Correct path filter for OpenAPI sync workflow

### DIFF
--- a/.github/workflows/sync-public-api-docs.yml
+++ b/.github/workflows/sync-public-api-docs.yml
@@ -8,7 +8,7 @@ on:
     paths:
       # Trigger if:
       # - any of the public API files change
-      - 'packages/cli/src/public-api/*.{css,yaml,yml}'
+      - 'packages/cli/src/public-api/**/*.{css,yaml,yml}'
       # - the build script or dependencies change
       - 'packages/cli/package.json'
       # - any main dependencies change


### PR DESCRIPTION
## Summary

Fix the path glob for OpenAPI docs sync trigger.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- ~[ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- ~[ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->~
- ~[ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
