### PR TITLE
fix(core): Improve handling of disabled Set Metrics node

### DIFF
--- a/packages/cli/src/evaluation.ee/test-runner/__tests__/test-runner.service.ee.test.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/__tests__/test-runner.service.ee.test.ts
@@ -1022,6 +1022,46 @@ describe('TestRunnerService', () => {
 			}
 		});
 
+		it('should throw SET_METRICS_NODE_NOT_CONFIGURED when metrics node is disabled', () => {
+			const workflow = mock<IWorkflowBase>({
+				nodes: [
+					{
+						id: 'node1',
+						name: 'Set Metrics',
+						type: EVALUATION_NODE_TYPE,
+						typeVersion: 1,
+						position: [0, 0],
+						disabled: true,
+						parameters: {
+							operation: 'setMetrics',
+							metrics: {
+								assignments: [
+									{
+										id: '1',
+										name: 'assignment1',
+										value: 0.95,
+									},
+								],
+							},
+						},
+					},
+				],
+				connections: {},
+			});
+
+			expect(() => {
+				(testRunnerService as any).validateSetMetricsNodes(workflow);
+			}).toThrow(TestRunError);
+
+			try {
+				(testRunnerService as any).validateSetMetricsNodes(workflow);
+			} catch (error) {
+				expect(error).toBeInstanceOf(TestRunError);
+				expect(error.code).toBe('SET_METRICS_NODE_NOT_CONFIGURED');
+				expect(error.extra).toEqual({ node_name: 'Set Metrics' });
+			}
+		});
+
 		it('should throw SET_METRICS_NODE_NOT_CONFIGURED when assignment has null value', () => {
 			const workflow = mock<IWorkflowBase>({
 				nodes: [

--- a/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
@@ -108,6 +108,7 @@ export class TestRunnerService {
 
 		const unconfiguredMetricsNode = metricsNodes.find(
 			(node) =>
+				node.disabled === true ||
 				!node.parameters ||
 				!node.parameters.metrics ||
 				(node.parameters.metrics as AssignmentCollectionValue).assignments?.length === 0 ||


### PR DESCRIPTION
## Summary
This PR fixes a problem in test runner executions with disabled `Set Metric` node. The test run will now fail with the not configured error if all set metric nodes are disabled instead of finishing the execution with an error (`Evaluation metrics node returned invalid metrics. Only numeric values are expected. View workflow.` and `Test case execution failed` in console).

![image](https://github.com/user-attachments/assets/a2222fef-bc53-4d22-ba91-c8ab57208404)

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-1156/disabling-the-set-metrics-node-doesnt-cause-the-validation-to-fail



## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
