### PR TITLE
perf(core): Improvements to GET `/workflows` endpoint

### DIFF
--- a/packages/@n8n/db/src/repositories/tag.repository.ts
+++ b/packages/@n8n/db/src/repositories/tag.repository.ts
@@ -65,6 +65,12 @@ export class TagRepository extends Repository<TagEntity> {
 		const dbTags = await this.find({
 			where: { name: In(tags) },
 			relations: ['workflows'],
+			select: {
+				id: true,
+				workflows: {
+					id: true,
+				},
+			},
 		});
 
 		const workflowIdsPerTag = dbTags.map((tag) => tag.workflows.map((workflow) => workflow.id));

--- a/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
@@ -211,9 +211,30 @@ export = {
 				where.id = In(workflowsIds);
 			}
 
+			const selectFields: (keyof WorkflowEntity)[] = [
+				'id',
+				'name',
+				'active',
+				'createdAt',
+				'updatedAt',
+				'isArchived',
+				'nodes',
+				'connections',
+				'settings',
+				'staticData',
+				'meta',
+				'versionId',
+				'triggerCount',
+			];
+
+			if (!excludePinnedData) {
+				selectFields.push('pinData');
+			}
+
 			const [workflows, count] = await Container.get(WorkflowRepository).findAndCount({
 				skip: offset,
 				take: limit,
+				select: selectFields,
 				where,
 				...(!Container.get(GlobalConfig).tags.disabled && { relations: ['tags'] }),
 			});


### PR DESCRIPTION
## Summary

1. When filtering by tags load into memory all workflow data (including the pin data) which can be quite large, causing a a temporary memory spike.
2. Even when we send `excludePinnedData` via querystring, we still load into memory the pin data (which can be quite large), and later we delete it before returning the data to the user. This can also can cause temporary memory spikes.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3787/enterprise-user-kiwicom-is-encountering-memory-issues-when-using-the

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
