### PR TITLE
fix(AI Agent Node): Prevent fallback input to be added in version <2.1

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/V2/AgentV2.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/V2/AgentV2.node.ts
@@ -114,7 +114,7 @@ export class AgentV2 implements INodeType {
 				((hasOutputParser, needsFallback) => {
 					${getInputs.toString()};
 					return getInputs(hasOutputParser, needsFallback)
-				})($parameter.hasOutputParser === undefined || $parameter.hasOutputParser === true, $parameter.needsFallback === undefined || $parameter.needsFallback === true)
+				})($parameter.hasOutputParser === undefined || $parameter.hasOutputParser === true, $parameter.needsFallback !== undefined && $parameter.needsFallback === true)
 			}}`,
 			outputs: [NodeConnectionTypes.Main],
 			properties: [
@@ -148,11 +148,6 @@ export class AgentV2 implements INodeType {
 					type: 'boolean',
 					default: false,
 					noDataExpression: true,
-					displayOptions: {
-						show: {
-							'@version': [{ _cnd: { gte: 2.1 } }],
-						},
-					},
 				},
 				{
 					displayName: `Connect an <a data-action='openSelectiveNodeCreator' data-action-parameter-connectiontype='${NodeConnectionTypes.AiOutputParser}'>output parser</a> on the canvas to specify the output format you require`,


### PR DESCRIPTION
## Summary
This PR prevents the fallback output to be added when the `needsFallback` property doesn't exist. This broke version 2 of that node

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-1164/bug-agent-node-obligating-the-user-to-have-a-fall-back-model


## Review / Merge checklist
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
