### PR TITLE
fix(editor): Fix RAG Callout keyboard navigation in nodes search

### DIFF
--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/Modes/NodesMode.vue
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/Modes/NodesMode.vue
@@ -277,6 +277,7 @@ function arrowLeft() {
 
 function onKeySelect(activeItemId: string) {
 	const mergedItems = flattenCreateElements([
+		...(globalCallouts.value ?? []),
 		...(activeViewStack.value.items ?? []),
 		...(globalSearchItemsDiff.value ?? []),
 		...(moreFromCommunity.value ?? []),
@@ -290,13 +291,13 @@ function onKeySelect(activeItemId: string) {
 
 registerKeyHook('MainViewArrowRight', {
 	keyboardKeys: ['ArrowRight', 'Enter'],
-	condition: (type) => ['subcategory', 'node', 'link', 'view'].includes(type),
+	condition: (type) => ['subcategory', 'node', 'link', 'view', 'openTemplate'].includes(type),
 	handler: onKeySelect,
 });
 
 registerKeyHook('MainViewArrowLeft', {
 	keyboardKeys: ['ArrowLeft'],
-	condition: (type) => ['subcategory', 'node', 'link', 'view'].includes(type),
+	condition: (type) => ['subcategory', 'node', 'link', 'view', 'openTemplate'].includes(type),
 	handler: arrowLeft,
 });
 </script>

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/utils.ts
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/utils.ts
@@ -314,6 +314,7 @@ export function getRootSearchCallouts(search: string, { isRagStarterCalloutVisib
 	const ragKeywords = ['rag', 'vec', 'know'];
 	if (isRagStarterCalloutVisible && ragKeywords.some((x) => search.toLowerCase().startsWith(x))) {
 		results.push({
+			uuid: 'rag-starter-template',
 			key: 'rag-starter-template',
 			type: 'openTemplate',
 			properties: {


### PR DESCRIPTION
## Summary

The missing uuid (it's optional on the interface v_v) broke up/down navigation, the other changes broke left/right navigation.

`window.featureFlags.override('033_rag_template', 'variant')` to test locally.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3794


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
