### PR TITLE
chore(core): Hide invite URL in users list if not an admin

### DIFF
--- a/packages/@n8n/db/src/entities/user.ts
+++ b/packages/@n8n/db/src/entities/user.ts
@@ -55,7 +55,7 @@ export class User extends WithTimestamps implements IUser, AuthPrincipal {
 
 	@Column({ nullable: true })
 	@IsString({ message: 'Password must be of type string.' })
-	password: string;
+	password: string | null;
 
 	@JsonColumn({
 		nullable: true,

--- a/packages/@n8n/db/src/entities/user.ts
+++ b/packages/@n8n/db/src/entities/user.ts
@@ -53,7 +53,7 @@ export class User extends WithTimestamps implements IUser, AuthPrincipal {
 	@Length(1, 32, { message: 'Last name must be $constraint1 to $constraint2 characters long.' })
 	lastName: string;
 
-	@Column({ nullable: true })
+	@Column({ type: String, nullable: true })
 	@IsString({ message: 'Password must be of type string.' })
 	password: string | null;
 

--- a/packages/cli/src/controllers/users.controller.ts
+++ b/packages/cli/src/controllers/users.controller.ts
@@ -41,6 +41,7 @@ import { FolderService } from '@/services/folder.service';
 import { ProjectService } from '@/services/project.service.ee';
 import { UserService } from '@/services/user.service';
 import { WorkflowService } from '@/workflows/workflow.service';
+import { hasGlobalScope } from '@n8n/permissions';
 
 @RestController('/users')
 export class UsersController {
@@ -106,10 +107,12 @@ export class UsersController {
 
 		const [users, count] = response;
 
+		const withInviteUrl = hasGlobalScope(req.user, 'user:create');
+
 		const publicUsers = await Promise.all(
 			users.map(async (u) => {
 				const user = await this.userService.toPublic(u, {
-					withInviteUrl: true,
+					withInviteUrl,
 					inviterId: req.user.id,
 				});
 				return {

--- a/packages/cli/src/external-hooks.ts
+++ b/packages/cli/src/external-hooks.ts
@@ -61,7 +61,7 @@ type ExternalHooksMap = {
 		payload: UserUpdateRequestDto,
 	];
 	'user.profile.update': [currentEmail: string, publicUser: PublicUser];
-	'user.password.update': [updatedEmail: string, updatedPassword: string];
+	'user.password.update': [updatedEmail: string, updatedPassword: string | null];
 	'user.invited': [emails: string[]];
 
 	'workflow.create': [createdWorkflow: IWorkflowBase];

--- a/packages/cli/src/services/password.utility.ts
+++ b/packages/cli/src/services/password.utility.ts
@@ -9,7 +9,10 @@ export class PasswordUtility {
 		return await hash(plaintext, SALT_ROUNDS);
 	}
 
-	async compare(plaintext: string, hashed: string) {
+	async compare(plaintext: string, hashed: string | null) {
+		if (hashed === null) {
+			return false;
+		}
 		return await compare(plaintext, hashed);
 	}
 }

--- a/packages/cli/test/integration/controllers/invitation/invitation.controller.integration.test.ts
+++ b/packages/cli/test/integration/controllers/invitation/invitation.controller.integration.test.ts
@@ -188,7 +188,7 @@ describe('InvitationController', () => {
 			expect(storedMember.password).not.toBe(memberProps.password);
 
 			const comparisonResult = await Container.get(PasswordUtility).compare(
-				member.password,
+				member.password!,
 				storedMember.password,
 			);
 

--- a/packages/cli/test/integration/password-reset.api.test.ts
+++ b/packages/cli/test/integration/password-reset.api.test.ts
@@ -279,7 +279,7 @@ describe('POST /change-password', () => {
 			id: owner.id,
 		});
 
-		const comparisonResult = await compare(passwordToStore, storedPassword);
+		const comparisonResult = await compare(passwordToStore, storedPassword!);
 		expect(comparisonResult).toBe(true);
 		expect(storedPassword).not.toBe(passwordToStore);
 

--- a/packages/cli/test/integration/users.api.test.ts
+++ b/packages/cli/test/integration/users.api.test.ts
@@ -9,7 +9,7 @@ import {
 	testDb,
 	mockInstance,
 } from '@n8n/backend-test-utils';
-import type { User } from '@n8n/db';
+import type { PublicUser, User } from '@n8n/db';
 import {
 	FolderRepository,
 	ProjectRelationRepository,
@@ -572,95 +572,62 @@ describe('GET /users', () => {
 		});
 
 		describe('inviteAcceptUrl', () => {
-			test('should include inviteAcceptUrl for pending users', async () => {
-				// Create a pending user
-				const pendingUser = await createUser({
+			let pendingUser: User;
+			beforeAll(async () => {
+				pendingUser = await createUser({
 					role: 'global:member',
 					email: 'pending@n8n.io',
 					firstName: 'PendingFirstName',
 					lastName: 'PendingLastName',
+					password: null,
 				});
+			});
 
-				await userRepository.update(
-					{ id: pendingUser.id },
-					{
-						password: null as unknown as string,
-					},
+			afterAll(async () => {
+				await userRepository.delete({ id: pendingUser.id });
+			});
+
+			test('should include inviteAcceptUrl for pending users', async () => {
+				const response = await ownerAgent.get('/users').expect(200);
+
+				const responseData = response.body.data as {
+					count: number;
+					items: PublicUser[];
+				};
+
+				const pendingUserInResponse = responseData.items.find((user) => user.id === pendingUser.id);
+
+				expect(pendingUserInResponse).toBeDefined();
+				expect(pendingUserInResponse!.inviteAcceptUrl).toBeDefined();
+				expect(pendingUserInResponse!.inviteAcceptUrl).toMatch(
+					new RegExp(`/signup\\?inviterId=${owner.id}&inviteeId=${pendingUser.id}`),
 				);
 
-				try {
-					const response = await ownerAgent.get('/users').expect(200);
+				const nonPendingUser = responseData.items.find((user) => user.id === member1.id);
 
-					expect(response.body.data).toHaveProperty('count');
-					expect(response.body.data).toHaveProperty('items');
-
-					// Find the pending user in the response
-					const pendingUserInResponse = response.body.data.items.find(
-						(user: any) => user.id === pendingUser.id,
-					);
-
-					expect(pendingUserInResponse).toBeDefined();
-					expect(pendingUserInResponse.inviteAcceptUrl).toBeDefined();
-					expect(pendingUserInResponse.inviteAcceptUrl).toMatch(
-						new RegExp(`/signup\\?inviterId=${owner.id}&inviteeId=${pendingUser.id}`),
-					);
-
-					// Verify that non-pending users don't have inviteAcceptUrl
-					const nonPendingUser = response.body.data.items.find(
-						(user: any) => user.id === member1.id,
-					);
-
-					expect(nonPendingUser).toBeDefined();
-					expect(nonPendingUser.isPending).toBe(false);
-					expect(nonPendingUser.inviteAcceptUrl).toBeUndefined();
-				} finally {
-					// Clean up
-					await userRepository.delete({ id: pendingUser.id });
-				}
+				expect(nonPendingUser).toBeDefined();
+				expect(nonPendingUser!.isPending).toBe(false);
+				expect(nonPendingUser!.inviteAcceptUrl).toBeUndefined();
 			});
 
 			test('should not include inviteAcceptUrl for pending users, if member requests it', async () => {
-				// Create a pending user
-				const pendingUser = await createUser({
-					role: 'global:member',
-					email: 'pending@n8n.io',
-					firstName: 'PendingFirstName',
-					lastName: 'PendingLastName',
-				});
+				const response = await memberAgent.get('/users').expect(200);
 
-				await userRepository.update(
-					{ id: pendingUser.id },
-					{
-						password: null as unknown as string,
-					},
-				);
+				const responseData = response.body.data as {
+					count: number;
+					items: PublicUser[];
+				};
 
-				try {
-					const response = await memberAgent.get('/users').expect(200);
+				const pendingUserInResponse = responseData.items.find((user) => user.id === pendingUser.id);
 
-					expect(response.body.data).toHaveProperty('count');
-					expect(response.body.data).toHaveProperty('items');
+				expect(pendingUserInResponse).toBeDefined();
+				expect(pendingUserInResponse!.inviteAcceptUrl).not.toBeDefined();
 
-					// Find the pending user in the response
-					const pendingUserInResponse = response.body.data.items.find(
-						(user: any) => user.id === pendingUser.id,
-					);
+				const nonPendingUser = responseData.items.find((user) => user.id === member1.id);
 
-					expect(pendingUserInResponse).toBeDefined();
-					expect(pendingUserInResponse.inviteAcceptUrl).not.toBeDefined();
-
-					// Verify that non-pending users don't have inviteAcceptUrl
-					const nonPendingUser = response.body.data.items.find(
-						(user: any) => user.id === member1.id,
-					);
-
-					expect(nonPendingUser).toBeDefined();
-					expect(nonPendingUser.isPending).toBe(false);
-					expect(nonPendingUser.inviteAcceptUrl).toBeUndefined();
-				} finally {
-					// Clean up
-					await userRepository.delete({ id: pendingUser.id });
-				}
+				expect(nonPendingUser).toBeDefined();
+				expect(nonPendingUser!.isPending).toBe(false);
+				expect(nonPendingUser!.inviteAcceptUrl).toBeUndefined();
 			});
 		});
 


### PR DESCRIPTION
## Summary

We should not expose the inviteAcceptUrl to all users, but only to admin users

## Related Linear tickets, Github issues, and Community forum posts

related https://linear.app/n8n/issue/PAY-3046/security-vulnerability-report-rbac-bypass-in-n8n

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
