### PR TITLE
fix(core): Fix warning on empty OIDC discovery endpoint

### DIFF
--- a/packages/cli/src/sso.ee/oidc/oidc.service.ee.ts
+++ b/packages/cli/src/sso.ee/oidc/oidc.service.ee.ts
@@ -58,7 +58,7 @@ export class OidcService {
 
 	async init() {
 		this.oidcConfig = await this.loadConfig(true);
-		console.log(`OIDC login is ${this.oidcConfig.loginEnabled ? 'enabled' : 'disabled'}.`);
+		this.logger.debug(`OIDC login is ${this.oidcConfig.loginEnabled ? 'enabled' : 'disabled'}.`);
 		await this.setOidcLoginEnabled(this.oidcConfig.loginEnabled);
 	}
 
@@ -156,6 +156,9 @@ export class OidcService {
 		if (currentConfig) {
 			try {
 				const oidcConfig = jsonParse<OidcConfigDto>(currentConfig.value);
+
+				if (oidcConfig.discoveryEndpoint === '') return DEFAULT_OIDC_RUNTIME_CONFIG;
+
 				const discoveryUrl = new URL(oidcConfig.discoveryEndpoint);
 
 				if (oidcConfig.clientSecret && decryptSecret) {


### PR DESCRIPTION
## Summary

Booting up an instance without OIDC leads to a false positive warning on every startup because the default OIDC config has its discovery endpoint as an empty string. 

> [!IMPORTANT]  
> I have zero context on OIDC so please review closely.

```
{"clientId":"","clientSecret":"","discoveryEndpoint":"","loginEnabled":false}
```

```
11:02:46.343   warn    Failed to load OIDC configuration from database, falling back to default configuration. { "error": { "name": "TypeError", "message": "Invalid URL", "stack": "TypeError:  Invalid URL\n    at new URL (node: internal/url: 818: 25)\n    at OidcService.loadConfig (/Users/ivov/Development/n8n/packages/cli/src/sso.ee/oidc/oidc.service.ee.ts: 159: 26)\n    at OidcService.init (/Users/ivov/Development/n8n/packages/cli/src/sso.ee/oidc/oidc.service.ee.ts: 60: 21)\n    at Server.registerAdditionalControllers (/Users/ivov/Development/n8n/packages/cli/src/server.ts: 163: 4)\n    at Server.configure (/Users/ivov/Development/n8n/packages/cli/src/server.ts: 249: 3)\n    at Server.start (/Users/ivov/Development/n8n/packages/cli/src/abstract-server.ts: 258: 3)\n    at Server.start (/Users/ivov/Development/n8n/packages/cli/src/server.ts: 97: 3)\n    at Start.run (/Users/ivov/Development/n8n/packages/cli/src/commands/start.ts: 319: 3)\n    at CommandRegistry.execute (/Users/ivov/Development/n8n/packages/cli/src/command-registry.ts: 65: 4)\n    at /Users/ivov/Development/n8n/packages/cli/bin/n8n: 63: 2" }, "file": "oidc.service.ee.js", "function": "loadConfig" }
```




## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
closes https://linear.app/n8n/issue/PAY-2962/investigate-oidc-error-on-startup


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
