### PR TITLE
chore: Create correct GitHub token for document sync

### DIFF
--- a/.github/workflows/sync-public-api-docs.yml
+++ b/.github/workflows/sync-public-api-docs.yml
@@ -27,8 +27,18 @@ jobs:
       - name: Checkout Main n8n Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Setup Environment and Build Project
-        uses: ./.github/actions/setup-and-build
+      - name: Setup PNPM
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22.x'
+          cache: 'pnpm'
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+        shell: bash
 
       - name: Build Public API Schema
         run: pnpm run build:data

--- a/.github/workflows/sync-public-api-docs.yml
+++ b/.github/workflows/sync-public-api-docs.yml
@@ -52,6 +52,8 @@ jobs:
         with:
           app-id: ${{ secrets.N8N_ASSISTANT_APP_ID }}
           private-key: ${{ secrets.N8N_ASSISTANT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: n8n-docs
 
       - name: Checkout Docs Repository
         if: steps.verify_file.outputs.file_exists == 'true'


### PR DESCRIPTION
## Summary

- Fix to ensure GitHub token is scoped to the `n8n-docs` repo.
- Remove full application build as it's unnecessary for the document sync.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- ~[ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- ~[ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->~
- ~[ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
