### PR TITLE
feat(editor): Close focus panel when necessary (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
@@ -53,6 +53,7 @@ import { useSettingsStore } from '@/stores/settings.store';
 import { useTagsStore } from '@/stores/tags.store';
 import { useUIStore } from '@/stores/ui.store';
 import { useWorkflowsStore } from '@/stores/workflows.store';
+import { useFocusPanelStore } from '@/stores/focusPanel.store';
 import type {
 	CanvasConnection,
 	CanvasConnectionCreateData,
@@ -152,6 +153,7 @@ export function useCanvasOperations() {
 	const settingsStore = useSettingsStore();
 	const tagsStore = useTagsStore();
 	const nodeCreatorStore = useNodeCreatorStore();
+	const focusPanelStore = useFocusPanelStore();
 	const executionsStore = useExecutionsStore();
 	const projectsStore = useProjectsStore();
 	const logsStore = useLogsStore();
@@ -1607,6 +1609,8 @@ export function useCanvasOperations() {
 		workflowsStore.resetState();
 		workflowsStore.currentWorkflowExecutions = [];
 		workflowsStore.setActiveExecutionId(undefined);
+
+		focusPanelStore.reset();
 
 		// Reset actions
 		uiStore.resetLastInteractedWith();

--- a/packages/frontend/editor-ui/src/stores/focusPanel.store.ts
+++ b/packages/frontend/editor-ui/src/stores/focusPanel.store.ts
@@ -54,6 +54,11 @@ export const useFocusPanelStore = defineStore(STORES.FOCUS_PANEL, () => {
 		focusPanelActive.value = !focusPanelActive.value;
 	};
 
+	const reset = () => {
+		focusPanelActive.value = false;
+		_focusedNodeParameters.value = [];
+	};
+
 	function isRichParameter(
 		p: RichFocusedNodeParameter | FocusedNodeParameter,
 	): p is RichFocusedNodeParameter {
@@ -67,5 +72,6 @@ export const useFocusPanelStore = defineStore(STORES.FOCUS_PANEL, () => {
 		isRichParameter,
 		closeFocusPanel,
 		toggleFocusPanel,
+		reset,
 	};
 });

--- a/packages/frontend/editor-ui/src/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/views/NodeView.vue
@@ -1209,6 +1209,10 @@ function onOpenNodeCreatorFromCanvas(source: NodeCreatorOpenSource) {
 function onToggleNodeCreator(options: ToggleNodeCreatorOptions) {
 	nodeCreatorStore.setNodeCreatorState(options);
 
+	if (options.createNodeActive) {
+		focusPanelStore.closeFocusPanel();
+	}
+
 	if (!options.createNodeActive && !options.hasAddedNodes) {
 		uiStore.resetLastInteractedWith();
 	}


### PR DESCRIPTION
## Summary

- Close the Focus panel when Nodes panel is opened

- Reset Focus panel to defaults when workspace is reset

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3742/feature-close-focus-panel-when-necessary

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
