### PR TITLE
feat(abstract-server): add healthz endpoint to check for main instance being a leader or not

### DIFF
--- a/packages/cli/src/abstract-server.ts
+++ b/packages/cli/src/abstract-server.ts
@@ -9,6 +9,7 @@ import { engine as expressHandlebars } from 'express-handlebars';
 import { readFile } from 'fs/promises';
 import type { Server } from 'http';
 import isbot from 'isbot';
+import { InstanceSettings } from 'n8n-core';
 
 import config from '@/config';
 import { N8N_VERSION, TEMPLATES_DIR } from '@/constants';
@@ -63,6 +64,8 @@ export abstract class AbstractServer {
 	protected testWebhooksEnabled = false;
 
 	readonly uniqueInstanceId: string;
+
+	readonly InstanceSettings = Container.get(InstanceSettings);
 
 	constructor() {
 		this.app = express();
@@ -135,6 +138,14 @@ export abstract class AbstractServer {
 				res.status(200).send({ status: 'ok' });
 			} else {
 				res.status(503).send({ status: 'error' });
+			}
+		});
+
+		this.app.get('/healthz/is_leader', (_req, res) => {
+			if (this.InstanceSettings.isLeader) {
+				res.status(200).send({ status: 'leader' });
+			} else {
+				res.status(503).send({ status: 'not_leader' });
 			}
 		});
 


### PR DESCRIPTION
## Summary

by adding a /healthz/is_leader endpoint, deployments can check if a given instance is a leader or not to decide to route traffic to it

this is useful for multi-main environments where load balancers lack stickiness but still need a way to route the UI traffic to the leader main instance

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
