### PR TITLE
fix(editor): Mitigate performance issue in FE manual executions

### DIFF
--- a/packages/frontend/editor-ui/src/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/components/RunData.vue
@@ -1455,7 +1455,6 @@ defineExpose({ enterEditMode });
 							(inputData.length || binaryData.length || search || hasMultipleInputNodes) &&
 							!editMode.enabled)
 					"
-					:class="$style.displayModeSelect"
 					:compact="props.compact"
 					:value="displayMode"
 					:has-binary-data="binaryData.length > 0"
@@ -1467,8 +1466,6 @@ defineExpose({ enterEditMode });
 					:has-renderable-data="hasParsedAiContent"
 					@change="onDisplayModeChange"
 				/>
-
-				<RunDataItemCount v-if="props.compact" v-bind="itemsCountProps" />
 
 				<N8nIconButton
 					v-if="!props.disableEdit && canPinData && !isReadOnlyRoute && !readOnlyEnv"
@@ -1509,6 +1506,8 @@ defineExpose({ enterEditMode });
 					/>
 				</div>
 			</div>
+
+			<RunDataItemCount v-if="props.compact" v-bind="itemsCountProps" />
 		</div>
 
 		<div v-if="inputSelectLocation === 'header'" :class="$style.inputSelect">
@@ -2071,6 +2070,7 @@ defineExpose({ enterEditMode });
 		flex-shrink: 0;
 		flex-grow: 0;
 		min-height: auto;
+		gap: var(--spacing-2xs);
 	}
 
 	> *:first-child {
@@ -2250,6 +2250,15 @@ defineExpose({ enterEditMode });
 	.compact & {
 		/* let title text alone decide the height */
 		height: 0;
+		visibility: hidden;
+
+		:global(.el-input__prefix) {
+			transition-duration: 0ms;
+		}
+	}
+
+	.compact:hover & {
+		visibility: visible;
 	}
 }
 
@@ -2329,18 +2338,6 @@ defineExpose({ enterEditMode });
 
 .schema {
 	padding: 0 var(--ndv-spacing);
-}
-
-.search,
-.displayModeSelect {
-	.compact:not(:hover) & {
-		opacity: 0;
-		display: none;
-	}
-
-	.compact:hover & {
-		opacity: 1;
-	}
 }
 
 .executingMessage {

--- a/packages/frontend/editor-ui/src/components/__snapshots__/InputPanel.test.ts.snap
+++ b/packages/frontend/editor-ui/src/components/__snapshots__/InputPanel.test.ts.snap
@@ -75,7 +75,7 @@ exports[`InputPanel > should render 1`] = `
         <!---->
         <!--v-if-->
         <div
-          class="n8n-radio-buttons radioGroup displayModeSelect"
+          class="n8n-radio-buttons radioGroup"
           data-test-id="ndv-run-data-display-mode"
           data-v-2e5cd75c=""
           role="radiogroup"
@@ -130,7 +130,6 @@ exports[`InputPanel > should render 1`] = `
         </div>
         <!--v-if-->
         <!--v-if-->
-        <!--v-if-->
         <div
           class="editModeActions"
           data-v-2e5cd75c=""
@@ -158,6 +157,7 @@ exports[`InputPanel > should render 1`] = `
           </button>
         </div>
       </div>
+      <!--v-if-->
     </div>
     <!--v-if-->
     <!--v-if-->


### PR DESCRIPTION
## Summary

This PR implements some mitigation measures against memory leak on the FE that happens when manual execution is triggered multiple times with the log view open. Since it was tricky to identify the root cause, this PR only implements what seemed effective, though doesn't prevent the leakage perfectly. Some more details in Linear ticket.

### How I tested the mitigation

- Use production build and perform manual execution 20 times in the canvas, with roughly 1s intervals.
- Compare allocation timeline of Chrome devtools between before/after implementing the mitigation (below)
  - Blue bars mean allocated memory still retained, gray bars mean freed up
  - The comparison indicates memory allocated per execution is mostly freed up after the mitigation (NB: I think the last blue bar is fine because data is still showing in UI)

| Before | After |
|--------|--------|
| <img width="1512" alt="Screenshot 2025-07-08 at 15 45 21" src="https://github.com/user-attachments/assets/0b28d20c-af05-432c-a2f5-9b372134abdd" /> | <img width="1512" alt="Screenshot 2025-07-08 at 16 50 09" src="https://github.com/user-attachments/assets/b6d24508-b3b4-4a60-a4f9-95149e8ff5a0" /> | 


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/SUG-92/bug-memory-consumption-during-manual-evals


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
