### PR TITLE
chore: Enable logging for OpenAPI doc generation

### DIFF
--- a/packages/cli/scripts/build.mjs
+++ b/packages/cli/scripts/build.mjs
@@ -60,7 +60,7 @@ function bundleOpenApiSpecs() {
 		.forEach((specPath) => {
 			const distSpecPath = path.resolve(ROOT_DIR, 'dist', specPath);
 			const command = `pnpm openapi bundle src/${specPath} --output ${distSpecPath}`;
-			shell.exec(command, { silent: true });
+			shell.exec(command, { silent: false });
 		});
 }
 


### PR DESCRIPTION
## Summary

Enable logging when building OpenAPI docs.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- ~[ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- ~[ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->~
- ~[ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
