### PR TITLE
chore(core): Calculate workflow timeout based on startedAt date of execution

### DIFF
--- a/packages/cli/src/__tests__/wait-tracker.test.ts
+++ b/packages/cli/src/__tests__/wait-tracker.test.ts
@@ -31,6 +31,7 @@ describe('WaitTracker', () => {
 			pushRef: 'push_ref',
 			parentExecution: undefined,
 		}),
+		startedAt: undefined,
 	});
 	execution.workflowData = mock<IWorkflowBase>({ id: 'abcd' });
 
@@ -196,6 +197,7 @@ describe('WaitTracker', () => {
 					workflowData: parentExecution.workflowData,
 					projectId: project.id,
 					pushRef: parentExecution.data.pushRef,
+					startedAt: parentExecution.startedAt,
 				},
 				false,
 				false,

--- a/packages/cli/src/__tests__/workflow-runner.test.ts
+++ b/packages/cli/src/__tests__/workflow-runner.test.ts
@@ -354,13 +354,9 @@ describe('workflow timeout with startedAt', () => {
 			// The timeout should be adjusted: 10 seconds - 5 seconds elapsed = ~5 seconds remaining
 			expect(mockSetTimeout).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
 
-			let actualTimeout = mockSetTimeout.mock.calls[0][1];
-			if (mockSetTimeout.mock.calls.length > 1) {
-				if (actualTimeout === 60000) {
-					// If the first call was for 60 seconds, the second call should be the adjusted timeout
-					actualTimeout = mockSetTimeout.mock.calls[1][1];
-				}
-			}
+			// We take the second call, because the first one is setting up
+			// the regular pull of waiting executions
+			const actualTimeout = mockSetTimeout.mock.calls[1][1];
 
 			// Get the actual timeout value passed to setTimeout
 

--- a/packages/cli/src/__tests__/workflow-runner.test.ts
+++ b/packages/cli/src/__tests__/workflow-runner.test.ts
@@ -317,58 +317,63 @@ describe('workflow timeout with startedAt', () => {
 			return {} as NodeJS.Timeout;
 		});
 
-		// Mock config to return a workflow timeout of 10 seconds
-		jest.spyOn(config, 'getEnv').mockReturnValue(10);
+		try {
+			// Mock config to return a workflow timeout of 10 seconds
+			jest.spyOn(config, 'getEnv').mockReturnValue(10);
 
-		const startedAt = new Date(Date.now() - 5000); // 5 seconds ago
-		const data = mock<IWorkflowExecutionDataProcess>({
-			workflowData: {
-				nodes: [],
-				settings: { executionTimeout: 10 }, // 10 seconds timeout
-			},
-			executionData: undefined,
-			executionMode: 'webhook',
-			startedAt,
-		});
+			const startedAt = new Date(Date.now() - 5000); // 5 seconds ago
+			const data = mock<IWorkflowExecutionDataProcess>({
+				workflowData: {
+					nodes: [],
+					settings: { executionTimeout: 10 }, // 10 seconds timeout
+				},
+				executionData: undefined,
+				executionMode: 'webhook',
+				startedAt,
+			});
 
-		const mockHooks = mock<core.ExecutionLifecycleHooks>();
-		jest
-			.spyOn(ExecutionLifecycleHooks, 'getLifecycleHooksForRegularMain')
-			.mockReturnValue(mockHooks);
+			const mockHooks = mock<core.ExecutionLifecycleHooks>();
+			jest
+				.spyOn(ExecutionLifecycleHooks, 'getLifecycleHooksForRegularMain')
+				.mockReturnValue(mockHooks);
 
-		const mockAdditionalData = mock<IWorkflowExecuteAdditionalData>();
-		jest.spyOn(WorkflowExecuteAdditionalData, 'getBase').mockResolvedValue(mockAdditionalData);
+			const mockAdditionalData = mock<IWorkflowExecuteAdditionalData>();
+			jest.spyOn(WorkflowExecuteAdditionalData, 'getBase').mockResolvedValue(mockAdditionalData);
 
-		const manualExecutionService = Container.get(ManualExecutionService);
-		jest.spyOn(manualExecutionService, 'runManually').mockReturnValue(
-			new PCancelable(() => {
-				return mock<IRun>();
-			}),
-		);
+			const manualExecutionService = Container.get(ManualExecutionService);
+			jest.spyOn(manualExecutionService, 'runManually').mockReturnValue(
+				new PCancelable(() => {
+					return mock<IRun>();
+				}),
+			);
 
-		// ACT
-		await runner.run(data);
+			// ACT
+			await runner.run(data);
 
-		// ASSERT
-		// The timeout should be adjusted: 10 seconds - 5 seconds elapsed = ~5 seconds remaining
-		expect(mockSetTimeout).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
+			// ASSERT
+			// The timeout should be adjusted: 10 seconds - 5 seconds elapsed = ~5 seconds remaining
+			expect(mockSetTimeout).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
 
-		let actualTimeout = mockSetTimeout.mock.calls[0][1];
-		if (mockSetTimeout.mock.calls.length > 1) {
-			if (actualTimeout === 60000) {
-				// If the first call was for 60 seconds, the second call should be the adjusted timeout
-				actualTimeout = mockSetTimeout.mock.calls[1][1];
+			let actualTimeout = mockSetTimeout.mock.calls[0][1];
+			if (mockSetTimeout.mock.calls.length > 1) {
+				if (actualTimeout === 60000) {
+					// If the first call was for 60 seconds, the second call should be the adjusted timeout
+					actualTimeout = mockSetTimeout.mock.calls[1][1];
+				}
 			}
+
+			// Get the actual timeout value passed to setTimeout
+
+			// Should be approximately 5000ms (5 seconds remaining), allowing for timing differences
+			expect(actualTimeout).toBeLessThan(6000);
+			expect(actualTimeout).toBeGreaterThan(4000);
+
+			// Execution should not be stopped immediately
+			expect(mockStopExecution).not.toHaveBeenCalled();
+		} finally {
+			// Restore the original setTimeout implementation
+			mockSetTimeout.mockRestore();
 		}
-
-		// Get the actual timeout value passed to setTimeout
-
-		// Should be approximately 5000ms (5 seconds remaining), allowing for timing differences
-		expect(actualTimeout).toBeLessThan(6000);
-		expect(actualTimeout).toBeGreaterThan(4000);
-
-		// Execution should not be stopped immediately
-		expect(mockStopExecution).not.toHaveBeenCalled();
 	});
 
 	it('should stop execution immediately when timeout has already elapsed', async () => {

--- a/packages/cli/src/wait-tracker.ts
+++ b/packages/cli/src/wait-tracker.ts
@@ -119,6 +119,7 @@ export class WaitTracker {
 			workflowData: fullExecutionData.workflowData,
 			projectId: project.id,
 			pushRef: fullExecutionData.data.pushRef,
+			startedAt: fullExecutionData.startedAt,
 		};
 
 		// Start the execution again

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -307,7 +307,7 @@ export class WorkflowRunner {
 			this.activeExecutions.attachWorkflowExecution(executionId, workflowExecution);
 
 			if (workflowTimeout > 0) {
-				let timeout = Math.min(workflowTimeout, config.getEnv('executions.maxTimeout')) * 1000; // as seconds
+				let timeout = Math.min(workflowTimeout, config.getEnv('executions.maxTimeout')) * 1000; // as milliseconds
 				if (data.startedAt && data.startedAt instanceof Date) {
 					// If startedAt is set, we calculate the timeout based on the startedAt time
 					// This is useful for executions that were waiting in a waiting state

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -307,10 +307,21 @@ export class WorkflowRunner {
 			this.activeExecutions.attachWorkflowExecution(executionId, workflowExecution);
 
 			if (workflowTimeout > 0) {
-				const timeout = Math.min(workflowTimeout, config.getEnv('executions.maxTimeout')) * 1000; // as seconds
-				executionTimeout = setTimeout(() => {
-					void this.activeExecutions.stopExecution(executionId);
-				}, timeout);
+				let timeout = Math.min(workflowTimeout, config.getEnv('executions.maxTimeout')) * 1000; // as seconds
+				if (data.startedAt) {
+					// If startedAt is set, we calculate the timeout based on the startedAt time
+					// This is useful for executions that were waiting in a waiting state
+					// and we want to ensure the timeout is relative to when the execution started.
+					const now = Date.now();
+					timeout = Math.max(timeout - (now - data.startedAt.getTime()), 0);
+				}
+				if (timeout === 0) {
+					this.activeExecutions.stopExecution(executionId);
+				} else {
+					executionTimeout = setTimeout(() => {
+						void this.activeExecutions.stopExecution(executionId);
+					}, timeout);
+				}
 			}
 
 			workflowExecution

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -308,7 +308,7 @@ export class WorkflowRunner {
 
 			if (workflowTimeout > 0) {
 				let timeout = Math.min(workflowTimeout, config.getEnv('executions.maxTimeout')) * 1000; // as seconds
-				if (data.startedAt) {
+				if (data.startedAt && data.startedAt instanceof Date) {
 					// If startedAt is set, we calculate the timeout based on the startedAt time
 					// This is useful for executions that were waiting in a waiting state
 					// and we want to ensure the timeout is relative to when the execution started.

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2342,6 +2342,7 @@ export interface IWorkflowExecutionDataProcess {
 	agentRequest?: AiAgentRequest;
 	httpResponse?: express.Response; // Used for streaming responses
 	streamingEnabled?: boolean;
+	startedAt?: Date;
 }
 
 export interface ExecuteWorkflowOptions {


### PR DESCRIPTION
## Summary

When a workflow has a wait node which suspends it into the waiting state (wait for > 65 seconds), the workflow timeout is not respected, since it starts the full timer again, when the workflow continues. This changes the timeout to be relative to the startedAt date if it exists.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-1072/workflow-was-running-longer-than-the-timeout

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
