### PR TITLE
Add streamable-http protocol support to McpClientTool node

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/loadOptions.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/loadOptions.ts
@@ -10,10 +10,12 @@ import { connectMcpClient, getAllTools, getAuthHeaders } from './utils';
 export async function getTools(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 	const authentication = this.getNodeParameter('authentication') as McpAuthenticationOption;
 	const sseEndpoint = this.getNodeParameter('sseEndpoint') as string;
+	const protocol = this.getNodeParameter('protocol') as string;
 	const node = this.getNode();
 	const { headers } = await getAuthHeaders(this, authentication);
 	const client = await connectMcpClient({
 		sseEndpoint,
+		protocol,
 		headers,
 		name: node.type,
 		version: node.typeVersion,

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/loadOptions.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/loadOptions.ts
@@ -8,11 +8,17 @@ import type { McpAuthenticationOption } from './types';
 import { connectMcpClient, getAllTools, getAuthHeaders } from './utils';
 
 export async function getTools(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-	const authentication = this.getNodeParameter('authentication') as McpAuthenticationOption;
-	const sseEndpoint = this.getNodeParameter('sseEndpoint') as string;
 	const protocol = this.getNodeParameter('protocol') as string;
+	const sseEndpoint = this.getNodeParameter('sseEndpoint') as string;
 	const node = this.getNode();
-	const { headers } = await getAuthHeaders(this, authentication);
+
+	let headers: Record<string, string> | undefined = undefined;
+	let authentication: McpAuthenticationOption | undefined = undefined;
+	if (protocol === 'sse' || protocol === 'streamable-http') {
+		authentication = this.getNodeParameter('authentication') as McpAuthenticationOption;
+		headers = (await getAuthHeaders(this, authentication)).headers;
+	}
+
 	const client = await connectMcpClient({
 		sseEndpoint,
 		protocol,

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/utils.ts
@@ -161,9 +161,20 @@ export async function connectMcpClient({
 	try {
 		let transport;
 		if (protocol === 'stdio') {
-			// For stdio: sseEndpoint is the command string, not a URL.
+			// For stdio: sseEndpoint is the command string, not a URL. split it into command and args.
+			const parts = sseEndpoint.trim().split(/\s+/);
+			const command = parts[0]; // first part as command
+			const args = parts.slice(1); // remaining parts as arguments
+			if (!command) {
+				return createResultError({
+					type: 'connection',
+					error: new Error('Invalid command in sseEndpoint'),
+				});
+			}
+			console.debug(`Connecting to MCP server using command: ${command} ${args.join(' ')}`);
 			transport = new StdioClientTransport({
-				command: sseEndpoint,
+				command,
+				args,
 			});
 		} else {
 			const endpoint = normalizeAndValidateUrl(sseEndpoint);

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/utils.ts
@@ -1,6 +1,8 @@
 import { DynamicStructuredTool, type DynamicStructuredToolInput } from '@langchain/core/tools';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { CompatibilityCallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
 import { Toolkit } from 'langchain/agents';
 import {
@@ -145,35 +147,49 @@ type ConnectMcpClientError =
 	| { type: 'connection'; error: Error };
 export async function connectMcpClient({
 	headers,
+	protocol,
 	sseEndpoint,
 	name,
 	version,
 }: {
 	sseEndpoint: string;
+	protocol: string;
 	headers?: Record<string, string>;
 	name: string;
 	version: number;
 }): Promise<Result<Client, ConnectMcpClientError>> {
 	try {
-		const endpoint = normalizeAndValidateUrl(sseEndpoint);
-
-		if (!endpoint.ok) {
-			return createResultError({ type: 'invalid_url', error: endpoint.error });
+		let transport;
+		if (protocol === 'stdio') {
+			// For stdio: sseEndpoint is the command string, not a URL.
+			transport = new StdioClientTransport({
+				command: sseEndpoint,
+			});
+		} else {
+			const endpoint = normalizeAndValidateUrl(sseEndpoint);
+			if (!endpoint.ok) {
+				return createResultError({ type: 'invalid_url', error: endpoint.error });
+			}
+			if (protocol === 'streamable-http') {
+				transport = new StreamableHTTPClientTransport(endpoint.result, {
+					requestInit: { headers },
+				});
+			} else {
+				transport = new SSEClientTransport(endpoint.result, {
+					eventSourceInit: {
+						fetch: async (url, init) =>
+							await fetch(url, {
+								...init,
+								headers: {
+									...headers,
+									Accept: 'text/event-stream',
+								},
+							}),
+					},
+					requestInit: { headers },
+				});
+			}
 		}
-
-		const transport = new SSEClientTransport(endpoint.result, {
-			eventSourceInit: {
-				fetch: async (url, init) =>
-					await fetch(url, {
-						...init,
-						headers: {
-							...headers,
-							Accept: 'text/event-stream',
-						},
-					}),
-			},
-			requestInit: { headers },
-		});
 
 		const client = new Client(
 			{ name, version: version.toString() },
@@ -183,7 +199,7 @@ export async function connectMcpClient({
 		await client.connect(transport);
 		return createResultOk(client);
 	} catch (error) {
-		return createResultError({ type: 'connection', error });
+		return createResultError({ type: 'connection', error: error as Error });
 	}
 }
 


### PR DESCRIPTION
This PR enhances the McpClientTool node by adding support for multiple protocols including streamable-http and stdio, in addition to the existing SSE protocol. The implementation provides more flexible communication methods with MCP servers through different transport protocols.

Key changes include:
- Added new protocol selection (STDIO, SSE, Streamable-HTTP)
- Updated authentication handling based on protocol
- Enhanced endpoint configuration
- Improved client connection handling with protocol-specific transports

## Related Linear tickets, Github issues, and Community forum posts

<!-- No related tickets mentioned, can be added later -->

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [ ] Docs updated or follow-up ticket created
- [x] Tests included for:
  - Connection using streamable-http protocol with authentication
  - STDIO protocol with local command execution
  - SSE functionality backward compatibility
  - Error handling for invalid inputs
  - Protocol-specific transport initialization

### Implementation Details

The changes provide flexible communication methods with MCP servers:
- SSE/Streamable-HTTP: Support for HTTP URLs (e.g., https://my-mcp-server.ai/mcp)
- STDIO: Support for executable commands (e.g., uvx mcp-server-time --local-timezone=America/New_York)
![image](https://github.com/user-attachments/assets/4466ccff-d571-4df0-ba0d-6b4b46b1bb6c)
![image](https://github.com/user-attachments/assets/2f04d73c-d317-4b3e-ae00-c7a39ce370da)
![image](https://github.com/user-attachments/assets/a02f67f0-76a5-4eee-9a59-6692e288436f)
![image](https://github.com/user-attachments/assets/53f5676b-c997-46a1-9f21-71d4ef181d10)
Authentication is properly handled based on selected protocol:
- SSE/Streamable-HTTP: Full authentication support
- STDIO: Authentication bypass for local execution