### PR TITLE
chore: Stop docs sync from creating multiple PRs

### DIFF
--- a/.github/workflows/sync-public-api-docs.yml
+++ b/.github/workflows/sync-public-api-docs.yml
@@ -96,9 +96,9 @@ jobs:
           author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
           signoff: false
 
-          # Create a unique branch and delete after we're done
-          branch: 'chore/openapi-sync-${{ github.run_id }}-${{ github.run_attempt }}'
-          delete-branch: true
+          # Create a single branch for multiple PRs
+          branch: 'chore/sync-public-api-schema'
+          delete-branch: false
 
           title: 'chore: Update Public API schema'
           body: |


### PR DESCRIPTION
## Summary

Change OpenAPI docs sync workflow from creating multiple PRs by using a single branch.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- ~[ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- ~[ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->~
- ~[ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
