### PR TITLE
fix(API): Check if version exists in registry for community node installation

### DIFF
--- a/packages/cli/src/services/community-packages.service.ts
+++ b/packages/cli/src/services/community-packages.service.ts
@@ -28,7 +28,7 @@ import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 import { Publisher } from '@/scaling/pubsub/publisher.service';
 import { toError } from '@/utils';
 
-import { verifyIntegrity } from '../utils/npm-utils';
+import { isVersionExists, verifyIntegrity } from '../utils/npm-utils';
 
 const DEFAULT_REGISTRY = 'https://registry.npmjs.org';
 const NPM_COMMON_ARGS = ['--audit=false', '--fund=false'];
@@ -399,6 +399,8 @@ export class CommunityPackagesService {
 		if (options.checksum) {
 			await verifyIntegrity(packageName, packageVersion, this.getNpmRegistry(), options.checksum);
 		}
+
+		await isVersionExists(packageName, packageVersion, this.getNpmRegistry());
 
 		try {
 			await this.downloadPackage(packageName, packageVersion);

--- a/packages/cli/src/utils/npm-utils.ts
+++ b/packages/cli/src/utils/npm-utils.ts
@@ -25,3 +25,24 @@ export async function verifyIntegrity(
 		throw new UnexpectedError('Checksum verification failed', { cause: error });
 	}
 }
+
+export async function isVersionExists(
+	packageName: string,
+	version: string,
+	registryUrl: string,
+): Promise<boolean> {
+	const timeoutOption = { timeout: REQUEST_TIMEOUT };
+
+	try {
+		const url = `${registryUrl.replace(/\/+$/, '')}/${encodeURIComponent(packageName)}`;
+		await axios.get(`${url}/${version}`, timeoutOption);
+		return true;
+	} catch (error) {
+		if (axios.isAxiosError(error) && error.response?.status === 404) {
+			throw new UnexpectedError('Package version does not exist', {
+				cause: error,
+			});
+		}
+		throw new UnexpectedError('Failed to check package version existence', { cause: error });
+	}
+}


### PR DESCRIPTION
## Summary

This is to make the installation endpoint more secure

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3162/remote-code-execute-in-restcommunity-packages-endpoint

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
