### PR TITLE
feat(Document Default Data Loader Node): Add value type option for metadata

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/document_loaders/DocumentDefaultDataLoader/DocumentDefaultDataLoader.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/document_loaders/DocumentDefaultDataLoader/DocumentDefaultDataLoader.node.ts
@@ -314,6 +314,37 @@ export class DocumentDefaultDataLoader implements INodeType {
 						description:
 							'Metadata to add to each document. Could be used for filtering during retrieval',
 						placeholder: 'Add property',
+						options: [
+							{
+								name: 'metadataValues',
+								displayName: 'Fields to Set',
+								values: [
+									{
+										displayName: 'Name',
+										name: 'name',
+										type: 'string',
+										default: '',
+										required: true,
+									},
+									{
+										displayName: 'Value Type',
+										name: 'valueType',
+										type: 'options',
+										options: [
+											{ name: 'String', value: 'string' },
+											{ name: 'Number', value: 'number' },
+										],
+										default: 'string',
+									},
+									{
+										displayName: 'Value',
+										name: 'value',
+										type: 'string',
+										default: '',
+									},
+								],
+							},
+						],
 					},
 				],
 			},

--- a/packages/@n8n/nodes-langchain/utils/helpers.ts
+++ b/packages/@n8n/nodes-langchain/utils/helpers.ts
@@ -38,10 +38,24 @@ export function getMetadataFiltersValues(
 			metadataValues: Array<{
 				name: string;
 				value: string;
+				valueType?: string;
 			}>;
 		};
 		if (metadata.length > 0) {
-			return metadata.reduce((acc, { name, value }) => ({ ...acc, [name]: value }), {});
+			return metadata.reduce((acc, { name, value, valueType }) => {
+				if (valueType === 'number') {
+					const numValue = Number(value);
+					if (isNaN(numValue)) {
+						throw new NodeOperationError(
+							ctx.getNode(),
+							`Metadata field "${name}" expects a number but got "${value}".`,
+							{ itemIndex },
+						);
+					}
+					return { ...acc, [name]: Number(value) };
+				}
+				return { ...acc, [name]: value };
+			}, {});
 		}
 	}
 


### PR DESCRIPTION
## Summary
Introduces support for selecting metadata type (number or string) in the Document Default Data Loader node.
A new field, "Value Type", has been added to the node.
If "Number" is selected and the input is not a valid number, the workflow will throw an error at runtime.

## Motivation
Previously, all metadata values were stored as strings. However, some vector databases like Qdrant require proper data types for filtering. For example, range-based filter operations expect numeric metadata. Without support for numeric types, these filters cannot function correctly


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
