### PR TITLE
feat(Microsoft SharePoint Node): Allow filtering on non-indexed columns

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/SharePoint/descriptions/item/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/descriptions/item/getAll.operation.ts
@@ -1,7 +1,7 @@
 import type { IExecuteSingleFunctions, IHttpRequestOptions, INodeProperties } from 'n8n-workflow';
 import { updateDisplayOptions } from 'n8n-workflow';
 
-import { itemGetAllFieldsPreSend } from '../../helpers/utils';
+import { addHonorNonIndexedQueriesHeader, itemGetAllFieldsPreSend } from '../../helpers/utils';
 import { listRLC, siteRLC, untilSiteSelected } from '../common.descriptions';
 
 const properties: INodeProperties[] = [
@@ -31,6 +31,7 @@ const properties: INodeProperties[] = [
 				property: '$filter',
 				type: 'query',
 				value: '={{ $value ? $value : undefined }}',
+				preSend: [addHonorNonIndexedQueriesHeader],
 			},
 		},
 		type: 'string',

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/helpers/utils.ts
@@ -111,6 +111,20 @@ export async function itemGetAllFieldsPreSend(
 		requestOptions.qs.$expand = 'fields';
 	}
 	requestOptions.qs.$select = fields.map((x) => x);
+
+	await addHonorNonIndexedQueriesHeader.call(this, requestOptions);
+
+	return requestOptions;
+}
+
+export async function addHonorNonIndexedQueriesHeader(
+	this: IExecuteSingleFunctions,
+	requestOptions: IHttpRequestOptions,
+): Promise<IHttpRequestOptions> {
+	if (requestOptions.qs?.$filter) {
+		requestOptions.headers ??= {};
+		requestOptions.headers.Prefer = 'HonorNonIndexedQueriesWarningMayFailRandomly';
+	}
 	return requestOptions;
 }
 

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/helpers/utils.ts
@@ -123,7 +123,12 @@ export async function addHonorNonIndexedQueriesHeader(
 ): Promise<IHttpRequestOptions> {
 	if (requestOptions.qs?.$filter) {
 		requestOptions.headers ??= {};
-		requestOptions.headers.Prefer = 'HonorNonIndexedQueriesWarningMayFailRandomly';
+		requestOptions.headers.Prefer = [
+			requestOptions.headers.Prefer,
+			'HonorNonIndexedQueriesWarningMayFailRandomly',
+		]
+			.filter(Boolean)
+			.join(', ');
 	}
 	return requestOptions;
 }


### PR DESCRIPTION
## Summary

Adds the `Prefer: HonorNonIndexedQueriesWarningMayFailRandomly` header to `item:getAll` operations when a filter is applied.

This allows users to filter on list columns that are not indexed in SharePoint (like `FileDirRef` and `FileLeafRef`), which would otherwise result in an error from the Microsoft Graph API.

![Pasted image 20250709143030-opt](https://github.com/user-attachments/assets/5b95cb63-e5c1-4770-9de5-d54f67bc34c2)

## Related Linear tickets, Github issues, and Community forum posts

- None

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [X] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
