### PR TITLE
fix(editor): Prevent submit when composing with IME on chat textarea

### DIFF
--- a/packages/frontend/@n8n/chat/src/components/Input.vue
+++ b/packages/frontend/@n8n/chat/src/components/Input.vue
@@ -144,7 +144,7 @@ async function onSubmit(event: MouseEvent | KeyboardEvent) {
 }
 
 async function onSubmitKeydown(event: KeyboardEvent) {
-	if (event.shiftKey) {
+	if (event.shiftKey || event.isComposing) {
 		return;
 	}
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

on chat textarea, Vue keydown.enter event submits even when composing with IME, so made it fixed not to send submit event when event.isComposing is true.

see below videos to compare the both behavior of the master and this branch.

master - current behavior

https://github.com/user-attachments/assets/b1ed9014-2922-4e0e-9eab-572e5b7527f5

this - improved one

https://github.com/user-attachments/assets/c638d761-d62c-435d-8137-d90e5d13b08d



## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
