### PR TITLE
feat(editor): Add new ways to discover templates

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -2623,6 +2623,7 @@
 	"workflows.empty.description.readOnlyEnv": "No workflows here yet",
 	"workflows.empty.description.noPermission": "There are currently no workflows to view",
 	"workflows.empty.startFromScratch": "Start from scratch",
+	"workflows.empty.startWithTemplate": "Start with a template",
 	"workflows.empty.browseTemplates": "Explore workflow templates",
 	"workflows.empty.learnN8n": "Learn n8n",
 	"workflows.empty.button.disabled.tooltip": "Your current role in the project does not allow you to create workflows",

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -1484,6 +1484,7 @@
 	"nodeView.cantExecuteNoTrigger": "Cannot execute workflow",
 	"nodeView.canvasAddButton.addATriggerNodeBeforeExecuting": "Add a Trigger Node before executing the workflow",
 	"nodeView.canvasAddButton.addFirstStep": "Add first step…",
+	"nodeView.templateLink": "or start from a template",
 	"nodeView.confirmMessage.onClipboardPasteEvent.cancelButtonText": "",
 	"nodeView.confirmMessage.onClipboardPasteEvent.confirmButtonText": "Yes, import",
 	"nodeView.confirmMessage.onClipboardPasteEvent.headline": "Import Workflow?",

--- a/packages/frontend/editor-ui/src/components/MainSidebar.vue
+++ b/packages/frontend/editor-ui/src/components/MainSidebar.vue
@@ -254,6 +254,7 @@ const trackTemplatesClick = () => {
 	telemetry.track('User clicked on templates', {
 		role: cloudPlanStore.currentUserCloudInfo?.role,
 		active_workflow_count: workflowsStore.activeWorkflows.length,
+		source: 'sidebar_button',
 	});
 };
 

--- a/packages/frontend/editor-ui/src/components/MainSidebar.vue
+++ b/packages/frontend/editor-ui/src/components/MainSidebar.vue
@@ -27,6 +27,7 @@ import { useGlobalEntityCreation } from '@/composables/useGlobalEntityCreation';
 import { useBecomeTemplateCreatorStore } from '@/components/BecomeTemplateCreatorCta/becomeTemplateCreatorStore';
 import Logo from '@/components/Logo/Logo.vue';
 import VersionUpdateCTA from '@/components/VersionUpdateCTA.vue';
+import { TemplateClickSource, trackTemplatesClick } from '@/utils/experiments';
 
 const becomeTemplateCreatorStore = useBecomeTemplateCreatorStore();
 const cloudPlanStore = useCloudPlanStore();
@@ -250,14 +251,6 @@ onBeforeUnmount(() => {
 	window.removeEventListener('resize', onResize);
 });
 
-const trackTemplatesClick = () => {
-	telemetry.track('User clicked on templates', {
-		role: cloudPlanStore.currentUserCloudInfo?.role,
-		active_workflow_count: workflowsStore.activeWorkflows.length,
-		source: 'sidebar_button',
-	});
-};
-
 const trackHelpItemClick = (itemType: string) => {
 	telemetry.track('User clicked help resource', {
 		type: itemType,
@@ -298,7 +291,7 @@ const handleSelect = (key: string) => {
 	switch (key) {
 		case 'templates':
 			if (settingsStore.isTemplatesEnabled && !templatesStore.hasCustomTemplatesHost) {
-				trackTemplatesClick();
+				trackTemplatesClick(TemplateClickSource.sidebarButton);
 			}
 			break;
 		case 'about': {

--- a/packages/frontend/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeAddNodes.test.ts
+++ b/packages/frontend/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeAddNodes.test.ts
@@ -4,6 +4,7 @@ import { TEMPLATES_URLS } from '@/constants';
 import { useSettingsStore } from '@/stores/settings.store';
 import { TemplateClickSource } from '@/utils/experiments';
 import { createTestingPinia } from '@pinia/testing';
+import userEvent from '@testing-library/user-event';
 import { setActivePinia } from 'pinia';
 import CanvasNodeAddNodes from './CanvasNodeAddNodes.vue';
 
@@ -99,7 +100,7 @@ describe('CanvasNodeAddNodes', () => {
 			});
 
 			const link = getByTestId('canvas-template-link');
-			link.click();
+			await userEvent.click(link);
 
 			expect(mockTrack).toHaveBeenCalledWith(
 				'User clicked on templates',

--- a/packages/frontend/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeAddNodes.test.ts
+++ b/packages/frontend/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeAddNodes.test.ts
@@ -1,0 +1,112 @@
+import { createCanvasNodeProvide, createCanvasProvide } from '@/__tests__/data';
+import { createComponentRenderer } from '@/__tests__/render';
+import { TEMPLATES_URLS } from '@/constants';
+import { useSettingsStore } from '@/stores/settings.store';
+import { TemplateClickSource } from '@/utils/experiments';
+import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
+import CanvasNodeAddNodes from './CanvasNodeAddNodes.vue';
+
+vi.mock('@/stores/posthog.store', () => ({
+	usePostHog: vi.fn(() => ({
+		getVariant: vi.fn(() => 'variant'),
+	})),
+}));
+
+vi.mock('@/utils/experiments', async (importOriginal) => {
+	const actual = await importOriginal<object>();
+
+	return {
+		...actual,
+		isExtraTemplateLinksExperimentEnabled: vi.fn(() => true),
+	};
+});
+
+const mockTrack = vi.fn();
+vi.mock('@/composables/useTelemetry', () => ({
+	useTelemetry: vi.fn(() => ({
+		track: mockTrack,
+	})),
+}));
+
+let settingsStore: ReturnType<typeof useSettingsStore>;
+
+const renderComponent = createComponentRenderer(CanvasNodeAddNodes, {
+	global: {
+		provide: {
+			...createCanvasProvide(),
+		},
+	},
+});
+
+describe('CanvasNodeAddNodes', () => {
+	beforeEach(() => {
+		const pinia = createTestingPinia();
+		setActivePinia(pinia);
+
+		settingsStore = useSettingsStore();
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should render node correctly', () => {
+		const { getByTestId } = renderComponent({
+			global: {
+				provide: {
+					...createCanvasNodeProvide(),
+				},
+			},
+		});
+
+		expect(getByTestId('canvas-add-button')).toMatchSnapshot();
+	});
+
+	describe('template link', () => {
+		it.each([
+			{
+				host: 'https://example.com',
+				type: 'custom',
+			},
+			{
+				host: TEMPLATES_URLS.DEFAULT_API_HOST,
+				type: 'default',
+			},
+		])('should render with $type template store', ({ host }) => {
+			settingsStore.settings.templates = { enabled: true, host };
+
+			const { getByTestId } = renderComponent({
+				global: {
+					provide: {
+						...createCanvasNodeProvide(),
+					},
+				},
+			});
+
+			expect(getByTestId('canvas-template-link')).toBeDefined();
+		});
+
+		it('should track user click', async () => {
+			settingsStore.settings.templates = { enabled: true, host: '' };
+
+			const { getByTestId } = renderComponent({
+				global: {
+					provide: {
+						...createCanvasNodeProvide(),
+					},
+				},
+			});
+
+			const link = getByTestId('canvas-template-link');
+			link.click();
+
+			expect(mockTrack).toHaveBeenCalledWith(
+				'User clicked on templates',
+				expect.objectContaining({
+					source: TemplateClickSource.emptyWorkflowLink,
+				}),
+			);
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeAddNodes.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeAddNodes.vue
@@ -84,6 +84,7 @@ function onClick() {
 				:target="templateRepository.target"
 				:underline="true"
 				size="small"
+				data-test-id="canvas-template-link"
 				@click="trackTemplatesClick(TemplateClickSource.emptyWorkflowLink)"
 			>
 				{{ i18n.baseText('nodeView.templateLink') }}

--- a/packages/frontend/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeAddNodes.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeAddNodes.vue
@@ -1,12 +1,20 @@
 <script setup lang="ts">
 import { onBeforeUnmount, onMounted, ref } from 'vue';
+import { useTelemetry } from '@/composables/useTelemetry';
 import { useNodeCreatorStore } from '@/stores/nodeCreator.store';
+import { useCloudPlanStore } from '@/stores/cloudPlan.store';
+import { useTemplatesStore } from '@/stores/templates.store';
+import { useWorkflowsStore } from '@/stores/workflows.store';
 import { NODE_CREATOR_OPEN_SOURCES } from '@/constants';
 import { nodeViewEventBus } from '@/event-bus';
 import { useI18n } from '@n8n/i18n';
 
 const nodeCreatorStore = useNodeCreatorStore();
 const i18n = useI18n();
+const telemetry = useTelemetry();
+const cloudPlanStore = useCloudPlanStore();
+const templatesStore = useTemplatesStore();
+const workflowsStore = useWorkflowsStore();
 
 const isTooltipVisible = ref(false);
 
@@ -33,6 +41,14 @@ function onClick() {
 		NODE_CREATOR_OPEN_SOURCES.TRIGGER_PLACEHOLDER_BUTTON,
 	);
 }
+
+const trackTemplatesClick = () => {
+	telemetry.track('User clicked on templates', {
+		role: cloudPlanStore.currentUserCloudInfo?.role,
+		active_workflow_count: workflowsStore.activeWorkflows.length,
+		source: 'empty_workflow_link',
+	});
+};
 </script>
 <template>
 	<div ref="container" :class="$style.addNodes" data-test-id="canvas-add-button">
@@ -50,7 +66,18 @@ function onClick() {
 				{{ i18n.baseText('nodeView.canvasAddButton.addATriggerNodeBeforeExecuting') }}
 			</template>
 		</N8nTooltip>
-		<p :class="$style.label" v-text="i18n.baseText('nodeView.canvasAddButton.addFirstStep')" />
+		<p :class="$style.label">
+			{{ i18n.baseText('nodeView.canvasAddButton.addFirstStep') }}
+			<N8nLink
+				:to="templatesStore.websiteTemplateRepositoryURL"
+				:underline="true"
+				size="small"
+				target="_self"
+				@click="trackTemplatesClick"
+			>
+				{{ i18n.baseText('executionsLandingPage.emptyState.noTrigger.templateLinkText') }}
+			</N8nLink>
+		</p>
 	</div>
 </template>
 
@@ -86,5 +113,7 @@ function onClick() {
 	line-height: var(--font-line-height-xloose);
 	color: var(--color-text-dark);
 	margin-top: var(--spacing-2xs);
+	display: flex;
+	flex-direction: column;
 }
 </style>

--- a/packages/frontend/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeAddNodes.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeAddNodes.vue
@@ -86,7 +86,7 @@ function onClick() {
 				size="small"
 				@click="trackTemplatesClick(TemplateClickSource.emptyWorkflowLink)"
 			>
-				{{ i18n.baseText('executionsLandingPage.emptyState.noTrigger.templateLinkText') }}
+				{{ i18n.baseText('nodeView.templateLink') }}
 			</N8nLink>
 		</p>
 	</div>

--- a/packages/frontend/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeAddNodes.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeAddNodes.vue
@@ -1,23 +1,21 @@
 <script setup lang="ts">
-import { useTelemetry } from '@/composables/useTelemetry';
 import { NODE_CREATOR_OPEN_SOURCES, VIEWS } from '@/constants';
 import { nodeViewEventBus } from '@/event-bus';
-import { isExtraTemplateLinksExperimentEnabled } from '@/experiments';
-import { useCloudPlanStore } from '@/stores/cloudPlan.store';
+import {
+	isExtraTemplateLinksExperimentEnabled,
+	TemplateClickSource,
+	trackTemplatesClick,
+} from '@/utils/experiments';
 import { useNodeCreatorStore } from '@/stores/nodeCreator.store';
 import { useSettingsStore } from '@/stores/settings.store';
 import { useTemplatesStore } from '@/stores/templates.store';
-import { useWorkflowsStore } from '@/stores/workflows.store';
 import { useI18n } from '@n8n/i18n';
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 
 const nodeCreatorStore = useNodeCreatorStore();
 const i18n = useI18n();
-const telemetry = useTelemetry();
-const cloudPlanStore = useCloudPlanStore();
 const settingsStore = useSettingsStore();
 const templatesStore = useTemplatesStore();
-const workflowsStore = useWorkflowsStore();
 
 const isTooltipVisible = ref(false);
 
@@ -61,14 +59,6 @@ function onClick() {
 		NODE_CREATOR_OPEN_SOURCES.TRIGGER_PLACEHOLDER_BUTTON,
 	);
 }
-
-const trackTemplatesClick = () => {
-	telemetry.track('User clicked on templates', {
-		role: cloudPlanStore.currentUserCloudInfo?.role,
-		active_workflow_count: workflowsStore.activeWorkflows.length,
-		source: 'empty_workflow_link',
-	});
-};
 </script>
 <template>
 	<div ref="container" :class="$style.addNodes" data-test-id="canvas-add-button">
@@ -94,7 +84,7 @@ const trackTemplatesClick = () => {
 				:target="templateRepository.target"
 				:underline="true"
 				size="small"
-				@click="trackTemplatesClick"
+				@click="trackTemplatesClick(TemplateClickSource.emptyWorkflowLink)"
 			>
 				{{ i18n.baseText('executionsLandingPage.emptyState.noTrigger.templateLinkText') }}
 			</N8nLink>

--- a/packages/frontend/editor-ui/src/components/canvas/elements/nodes/render-types/__snapshots__/CanvasNodeAddNodes.test.ts.snap
+++ b/packages/frontend/editor-ui/src/components/canvas/elements/nodes/render-types/__snapshots__/CanvasNodeAddNodes.test.ts.snap
@@ -1,0 +1,43 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CanvasNodeAddNodes > should render node correctly 1`] = `
+<div
+  class="addNodes"
+  data-test-id="canvas-add-button"
+>
+  
+  <button
+    class="button el-tooltip__trigger el-tooltip__trigger"
+    data-test-id="canvas-plus-button"
+  >
+    <svg
+      aria-hidden="true"
+      class="n8n-icon"
+      data-icon="plus"
+      focusable="false"
+      height="40px"
+      role="img"
+      viewBox="0 0 24 24"
+      width="40px"
+    >
+      <path
+        d="M5 12h14m-7-7v14"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+  </button>
+  <!--teleport start-->
+  <!--teleport end-->
+  
+  <p
+    class="label"
+  >
+    Add first step… 
+    <!--v-if-->
+  </p>
+</div>
+`;

--- a/packages/frontend/editor-ui/src/constants.ts
+++ b/packages/frontend/editor-ui/src/constants.ts
@@ -747,6 +747,12 @@ export const RAG_STARTER_WORKFLOW_EXPERIMENT = {
 	variant: 'variant',
 };
 
+export const EXTRA_TEMPLATE_LINKS_EXPERIMENT = {
+	name: '034_extra_template_links',
+	control: 'control',
+	variant: 'variant',
+};
+
 export const FOCUS_PANEL_EXPERIMENT = {
 	name: 'focus_panel',
 	control: 'control',
@@ -756,6 +762,7 @@ export const FOCUS_PANEL_EXPERIMENT = {
 export const EXPERIMENTS_TO_TRACK = [
 	WORKFLOW_BUILDER_EXPERIMENT.name,
 	RAG_STARTER_WORKFLOW_EXPERIMENT.name,
+	EXTRA_TEMPLATE_LINKS_EXPERIMENT.name,
 ];
 export const WORKFLOW_EVALUATION_EXPERIMENT = '032_evaluation_mvp';
 

--- a/packages/frontend/editor-ui/src/constants.ts
+++ b/packages/frontend/editor-ui/src/constants.ts
@@ -896,7 +896,7 @@ export const MOUSE_EVENT_BUTTONS = {
  */
 export const TEMPLATES_URLS = {
 	DEFAULT_API_HOST: 'https://api.n8n.io/api/',
-	BASE_WEBSITE_URL: 'https://n8n.io/workflows',
+	BASE_WEBSITE_URL: 'https://n8n.io/workflows/',
 	UTM_QUERY: {
 		utm_source: 'n8n_app',
 		utm_medium: 'template_library',

--- a/packages/frontend/editor-ui/src/experiments.ts
+++ b/packages/frontend/editor-ui/src/experiments.ts
@@ -1,9 +1,0 @@
-import { EXTRA_TEMPLATE_LINKS_EXPERIMENT } from '@/constants';
-import { usePostHog } from '@/stores/posthog.store';
-
-export const isExtraTemplateLinksExperimentEnabled = () => {
-	return (
-		usePostHog().getVariant(EXTRA_TEMPLATE_LINKS_EXPERIMENT.name) ===
-		EXTRA_TEMPLATE_LINKS_EXPERIMENT.variant
-	);
-};

--- a/packages/frontend/editor-ui/src/experiments.ts
+++ b/packages/frontend/editor-ui/src/experiments.ts
@@ -1,0 +1,9 @@
+import { EXTRA_TEMPLATE_LINKS_EXPERIMENT } from '@/constants';
+import { usePostHog } from '@/stores/posthog.store';
+
+export const isExtraTemplateLinksExperimentEnabled = () => {
+	return (
+		usePostHog().getVariant(EXTRA_TEMPLATE_LINKS_EXPERIMENT.name) ===
+		EXTRA_TEMPLATE_LINKS_EXPERIMENT.variant
+	);
+};

--- a/packages/frontend/editor-ui/src/utils/experiments.test.ts
+++ b/packages/frontend/editor-ui/src/utils/experiments.test.ts
@@ -1,0 +1,87 @@
+import {
+	isExtraTemplateLinksExperimentEnabled,
+	TemplateClickSource,
+	trackTemplatesClick,
+} from './experiments';
+
+const getVariant = vi.fn();
+vi.mock('@/stores/posthog.store', () => ({
+	usePostHog: vi.fn(() => ({
+		getVariant,
+	})),
+}));
+
+let isTrialing = false;
+vi.mock('@/stores/cloudPlan.store', () => ({
+	useCloudPlanStore: vi.fn(() => ({
+		userIsTrialing: isTrialing,
+		currentUserCloudInfo: {
+			role: 'test_role',
+		},
+	})),
+}));
+
+vi.mock('@/stores/workflows.store', () => ({
+	useWorkflowsStore: vi.fn(() => ({
+		userIsTrialing: isTrialing,
+		activeWorkflows: [1, 2, 3],
+	})),
+}));
+
+const mockTrack = vi.fn();
+vi.mock('@/composables/useTelemetry', () => ({
+	useTelemetry: vi.fn(() => ({
+		track: mockTrack,
+	})),
+}));
+
+describe('Utils: experiments', () => {
+	describe('isExtraTemplateLinksExperimentEnabled()', () => {
+		it.each([
+			{
+				variant: 'control',
+				trial: false,
+				enabled: false,
+			},
+			{
+				variant: 'variant',
+				trial: false,
+				enabled: false,
+			},
+			{
+				variant: 'control',
+				trial: true,
+				enabled: false,
+			},
+			{
+				variant: 'variant',
+				trial: true,
+				enabled: true,
+			},
+		])(
+			'should return $enabled when the variant is $variant and user trialing is $trial',
+			({ variant, trial, enabled }) => {
+				getVariant.mockReturnValueOnce(variant);
+				isTrialing = trial;
+
+				expect(isExtraTemplateLinksExperimentEnabled()).toEqual(enabled);
+			},
+		);
+	});
+
+	describe('trackTemplatesClick()', () => {
+		it.each([
+			TemplateClickSource.sidebarButton,
+			TemplateClickSource.emptyInstanceCard,
+			TemplateClickSource.emptyWorkflowLink,
+		])('should call telemetry track with correct parameters', (source) => {
+			trackTemplatesClick(source);
+
+			expect(mockTrack).toHaveBeenCalledWith('User clicked on templates', {
+				role: 'test_role',
+				active_workflow_count: 3,
+				source,
+			});
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/utils/experiments.test.ts
+++ b/packages/frontend/editor-ui/src/utils/experiments.test.ts
@@ -1,4 +1,5 @@
 import {
+	getTemplatePathByRole,
 	isExtraTemplateLinksExperimentEnabled,
 	TemplateClickSource,
 	trackTemplatesClick,
@@ -67,6 +68,24 @@ describe('Utils: experiments', () => {
 				expect(isExtraTemplateLinksExperimentEnabled()).toEqual(enabled);
 			},
 		);
+	});
+
+	describe('getTemplatePathByRole()', () => {
+		it.each([
+			['Executive/Owner', 'categories/ai/'],
+			['Product & Design', 'categories/ai/'],
+			['Support', 'categories/support/'],
+			['Sales', 'categories/sales/'],
+			['IT', 'categories/it-ops/'],
+			['Engineering', 'categories/it-ops/'],
+			['Marketing', 'categories/marketing/'],
+			['Other', 'categories/other/'],
+			[null, ''],
+			[undefined, ''],
+			['Unknown Role', ''],
+		])('should return correct path for role "%s"', (role, expectedPath) => {
+			expect(getTemplatePathByRole(role)).toBe(expectedPath);
+		});
 	});
 
 	describe('trackTemplatesClick()', () => {

--- a/packages/frontend/editor-ui/src/utils/experiments.ts
+++ b/packages/frontend/editor-ui/src/utils/experiments.ts
@@ -7,7 +7,7 @@ import { useWorkflowsStore } from '@/stores/workflows.store';
 export const isExtraTemplateLinksExperimentEnabled = () => {
 	return (
 		usePostHog().getVariant(EXTRA_TEMPLATE_LINKS_EXPERIMENT.name) ===
-		EXTRA_TEMPLATE_LINKS_EXPERIMENT.variant
+			EXTRA_TEMPLATE_LINKS_EXPERIMENT.variant && useCloudPlanStore().userIsTrialing
 	);
 };
 

--- a/packages/frontend/editor-ui/src/utils/experiments.ts
+++ b/packages/frontend/editor-ui/src/utils/experiments.ts
@@ -1,0 +1,26 @@
+import { useTelemetry } from '@/composables/useTelemetry';
+import { EXTRA_TEMPLATE_LINKS_EXPERIMENT } from '@/constants';
+import { useCloudPlanStore } from '@/stores/cloudPlan.store';
+import { usePostHog } from '@/stores/posthog.store';
+import { useWorkflowsStore } from '@/stores/workflows.store';
+
+export const isExtraTemplateLinksExperimentEnabled = () => {
+	return (
+		usePostHog().getVariant(EXTRA_TEMPLATE_LINKS_EXPERIMENT.name) ===
+		EXTRA_TEMPLATE_LINKS_EXPERIMENT.variant
+	);
+};
+
+export const enum TemplateClickSource {
+	emptyWorkflowLink = 'empty_workflow_link',
+	emptyInstanceCard = 'empty_instance_card',
+	sidebarButton = 'sidebar_button',
+}
+
+export const trackTemplatesClick = (source: TemplateClickSource) => {
+	useTelemetry().track('User clicked on templates', {
+		role: useCloudPlanStore().currentUserCloudInfo?.role,
+		active_workflow_count: useWorkflowsStore().activeWorkflows.length,
+		source,
+	});
+};

--- a/packages/frontend/editor-ui/src/utils/experiments.ts
+++ b/packages/frontend/editor-ui/src/utils/experiments.ts
@@ -17,6 +17,37 @@ export const enum TemplateClickSource {
 	sidebarButton = 'sidebar_button',
 }
 
+export const getTemplatePathByRole = (role: string | null | undefined) => {
+	if (!role) {
+		return '';
+	}
+
+	switch (role) {
+		case 'Executive/Owner':
+		case 'Product & Design':
+			return 'categories/ai/';
+
+		case 'Support':
+			return 'categories/support/';
+
+		case 'Sales':
+			return 'categories/sales/';
+
+		case 'IT':
+		case 'Engineering':
+			return 'categories/it-ops/';
+
+		case 'Marketing':
+			return 'categories/marketing/';
+
+		case 'Other':
+			return 'categories/other/';
+
+		default:
+			return '';
+	}
+};
+
 export const trackTemplatesClick = (source: TemplateClickSource) => {
 	useTelemetry().track('User clicked on templates', {
 		role: useCloudPlanStore().currentUserCloudInfo?.role,

--- a/packages/frontend/editor-ui/src/views/WorkflowsView.vue
+++ b/packages/frontend/editor-ui/src/views/WorkflowsView.vue
@@ -35,6 +35,7 @@ import {
 import InsightsSummary from '@/features/insights/components/InsightsSummary.vue';
 import { useInsightsStore } from '@/features/insights/insights.store';
 import { getResourcePermissions } from '@n8n/permissions';
+import { useCloudPlanStore } from '@/stores/cloudPlan.store';
 import { useFoldersStore } from '@/stores/folders.store';
 import { useProjectsStore } from '@/stores/projects.store';
 import { useSettingsStore } from '@/stores/settings.store';
@@ -63,6 +64,7 @@ import debounce from 'lodash/debounce';
 import { type IUser, PROJECT_ROOT } from 'n8n-workflow';
 import { useTemplateRef, computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { type LocationQueryRaw, useRoute, useRouter } from 'vue-router';
+import { useTemplatesStore } from '@/stores/templates.store';
 
 const SEARCH_DEBOUNCE_TIME = 300;
 const FILTERS_DEBOUNCE_TIME = 100;
@@ -105,6 +107,8 @@ const tagsStore = useTagsStore();
 const foldersStore = useFoldersStore();
 const usageStore = useUsageStore();
 const insightsStore = useInsightsStore();
+const cloudPlanStore = useCloudPlanStore();
+const templatesStore = useTemplatesStore();
 
 const documentTitle = useDocumentTitle();
 const { callDebounced } = useDebounce();
@@ -321,6 +325,11 @@ const statusFilterOptions = computed(() => [
 const showEasyAIWorkflowCallout = computed(() => {
 	const easyAIWorkflowOnboardingDone = usersStore.isEasyAIWorkflowOnboardingDone;
 	return !easyAIWorkflowOnboardingDone;
+});
+
+// TODO: implement feature flag
+const showStartFromTemplate = computed(() => {
+	return true;
 });
 
 const projectPermissions = computed(() => {
@@ -744,6 +753,19 @@ const addWorkflow = () => {
 		source: 'Workflows list',
 	});
 	trackEmptyCardClick('blank');
+};
+
+const trackTemplatesClick = () => {
+	telemetry.track('User clicked on templates', {
+		role: cloudPlanStore.currentUserCloudInfo?.role,
+		active_workflow_count: workflowsStore.activeWorkflows.length,
+		source: 'empty_instance_card',
+	});
+};
+
+const openTemplatesRepository = () => {
+	trackTemplatesClick();
+	window.open(templatesStore.websiteTemplateRepositoryURL, '_blank');
 };
 
 const trackEmptyCardClick = (option: 'blank' | 'templates' | 'courses') => {
@@ -1797,6 +1819,25 @@ const onNameSubmit = async (name: string) => {
 							/>
 							<N8nText size="large" class="mt-xs pl-2xs pr-2xs">
 								{{ i18n.baseText('workflows.empty.easyAI') }}
+							</N8nText>
+						</div>
+					</N8nCard>
+					<N8nCard
+						v-if="showStartFromTemplate"
+						:class="$style.emptyStateCard"
+						hoverable
+						data-test-id="new-workflow-from-template-card"
+						@click="openTemplatesRepository"
+					>
+						<div :class="$style.emptyStateCardContent">
+							<N8nIcon
+								:class="$style.emptyStateCardIcon"
+								:stroke-width="1.5"
+								icon="package-open"
+								color="foreground-dark"
+							/>
+							<N8nText size="large" class="mt-xs pl-2xs pr-2xs">
+								{{ i18n.baseText('workflows.empty.startWithTemplate') }}
 							</N8nText>
 						</div>
 					</N8nCard>

--- a/packages/frontend/editor-ui/src/views/WorkflowsView.vue
+++ b/packages/frontend/editor-ui/src/views/WorkflowsView.vue
@@ -1,17 +1,6 @@
 <script lang="ts" setup>
 import Draggable from '@/components/Draggable.vue';
 import { FOLDER_LIST_ITEM_ACTIONS } from '@/components/Folders/constants';
-import type {
-	BaseFilters,
-	FolderResource,
-	Resource,
-	SortingAndPaginationUpdates,
-	WorkflowResource,
-	FolderListItem,
-	UserAction,
-	WorkflowListItem,
-	WorkflowListResource,
-} from '@/Interface';
 import ResourcesListLayout from '@/components/layouts/ResourcesListLayout.vue';
 import ProjectHeader from '@/components/Projects/ProjectHeader.vue';
 import WorkflowCard from '@/components/WorkflowCard.vue';
@@ -20,7 +9,6 @@ import { useDebounce } from '@/composables/useDebounce';
 import { useDocumentTitle } from '@/composables/useDocumentTitle';
 import type { DragTarget, DropTarget } from '@/composables/useFolders';
 import { useFolders } from '@/composables/useFolders';
-import { useI18n } from '@n8n/i18n';
 import { useMessage } from '@/composables/useMessage';
 import { useProjectPages } from '@/composables/useProjectPages';
 import { useTelemetry } from '@/composables/useTelemetry';
@@ -32,15 +20,30 @@ import {
 	MODAL_CONFIRM,
 	VIEWS,
 } from '@/constants';
+import {
+	isExtraTemplateLinksExperimentEnabled,
+	TemplateClickSource,
+	trackTemplatesClick,
+} from '@/utils/experiments';
 import InsightsSummary from '@/features/insights/components/InsightsSummary.vue';
 import { useInsightsStore } from '@/features/insights/insights.store';
-import { getResourcePermissions } from '@n8n/permissions';
-import { useCloudPlanStore } from '@/stores/cloudPlan.store';
+import type {
+	BaseFilters,
+	FolderListItem,
+	FolderResource,
+	Resource,
+	SortingAndPaginationUpdates,
+	UserAction,
+	WorkflowListItem,
+	WorkflowListResource,
+	WorkflowResource,
+} from '@/Interface';
 import { useFoldersStore } from '@/stores/folders.store';
 import { useProjectsStore } from '@/stores/projects.store';
 import { useSettingsStore } from '@/stores/settings.store';
 import { useSourceControlStore } from '@/stores/sourceControl.store';
 import { useTagsStore } from '@/stores/tags.store';
+import { useTemplatesStore } from '@/stores/templates.store';
 import { useUIStore } from '@/stores/ui.store';
 import { useUsageStore } from '@/stores/usage.store';
 import { useUsersStore } from '@/stores/users.store';
@@ -48,6 +51,7 @@ import { useWorkflowsStore } from '@/stores/workflows.store';
 import { type Project, type ProjectSharingData, ProjectTypes } from '@/types/projects.types';
 import { getEasyAiWorkflowJson } from '@/utils/easyAiWorkflowUtils';
 import {
+	N8nButton,
 	N8nCard,
 	N8nHeading,
 	N8nIcon,
@@ -56,16 +60,15 @@ import {
 	N8nOption,
 	N8nSelect,
 	N8nText,
-	N8nButton,
 } from '@n8n/design-system';
 import type { PathItem } from '@n8n/design-system/components/N8nBreadcrumbs/Breadcrumbs.vue';
+import { useI18n } from '@n8n/i18n';
+import { getResourcePermissions } from '@n8n/permissions';
 import { createEventBus } from '@n8n/utils/event-bus';
 import debounce from 'lodash/debounce';
 import { type IUser, PROJECT_ROOT } from 'n8n-workflow';
-import { useTemplateRef, computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from 'vue';
 import { type LocationQueryRaw, useRoute, useRouter } from 'vue-router';
-import { useTemplatesStore } from '@/stores/templates.store';
-import { isExtraTemplateLinksExperimentEnabled } from '@/experiments';
 
 const SEARCH_DEBOUNCE_TIME = 300;
 const FILTERS_DEBOUNCE_TIME = 100;
@@ -108,7 +111,6 @@ const tagsStore = useTagsStore();
 const foldersStore = useFoldersStore();
 const usageStore = useUsageStore();
 const insightsStore = useInsightsStore();
-const cloudPlanStore = useCloudPlanStore();
 const templatesStore = useTemplatesStore();
 
 const documentTitle = useDocumentTitle();
@@ -756,11 +758,7 @@ const addWorkflow = () => {
 };
 
 const openTemplatesRepository = async () => {
-	telemetry.track('User clicked on templates', {
-		role: cloudPlanStore.currentUserCloudInfo?.role,
-		active_workflow_count: workflowsStore.activeWorkflows.length,
-		source: 'empty_instance_card',
-	});
+	trackTemplatesClick(TemplateClickSource.emptyInstanceCard);
 
 	if (templatesStore.hasCustomTemplatesHost) {
 		await router.push({ name: VIEWS.TEMPLATES });


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

1. Introduce 2 new ways for users to discover the template repository.
2. Introduce custom template repository paths based on user role.

New template links:

1. In an empty project

![image](https://github.com/user-attachments/assets/414b5aba-b94f-4ee8-9fc8-ffd6217f49c9)

3. In an empty workflow

![image (1)](https://github.com/user-attachments/assets/9ab74bf1-3140-4c76-93da-b5dd1a7e56ab)

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
https://linear.app/n8n/issue/GRO-89/add-new-ways-for-user-to-discover-templates

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
