### PR TITLE
ci: Update base image packages

### DIFF
--- a/docker/images/n8n-base/Dockerfile
+++ b/docker/images/n8n-base/Dockerfile
@@ -13,14 +13,20 @@ RUN \
   apk del .build-deps-fonts && \
   find /usr/share/fonts/truetype/msttcorefonts/ -type l -exec unlink {} \;
 
-# Install essential OS dependencies
-
-# Install essential OS dependencies with edge repositories: Gets latest releases so we get security fixes
+# Install essential OS dependencies with pinned versions
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
-    echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
     apk update && \
     apk upgrade && \
-    apk add --no-cache git openssh openssl graphicsmagick tini tzdata ca-certificates libc6-compat jq
+    apk add --no-cache \
+        git=2.50.1-r0 \
+        openssh=10.0_p1-r7 \
+        openssl=3.5.1-r0 \
+        graphicsmagick=1.3.45-r0 \
+        tini=0.19.0-r3 \
+        tzdata=2025b-r0 \
+        ca-certificates=20241121-r2 \
+        libc6-compat=1.1.0-r4 \
+        jq=1.8.0-r0
 
 # Update npm, install full-icu and npm@11.4.2 to fix brace-expansion vulnerability
 # Remove npm update after vulnerability is fixed in in node image

--- a/docker/images/n8n-base/Dockerfile
+++ b/docker/images/n8n-base/Dockerfile
@@ -14,7 +14,13 @@ RUN \
   find /usr/share/fonts/truetype/msttcorefonts/ -type l -exec unlink {} \;
 
 # Install essential OS dependencies
-RUN apk add --no-cache git openssh graphicsmagick tini tzdata ca-certificates libc6-compat jq
+
+# Install essential OS dependencies with edge repositories: Gets latest releases so we get security fixes
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
+    echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
+    apk update && \
+    apk upgrade && \
+    apk add --no-cache git openssh openssl graphicsmagick tini tzdata ca-certificates libc6-compat jq
 
 # Update npm, install full-icu and npm@11.4.2 to fix brace-expansion vulnerability
 # Remove npm update after vulnerability is fixed in in node image


### PR DESCRIPTION
Configures the Dockerfile to use Alpine's edge repositories and pins versions.

## Summary

We now pin the package versions in the base image. This will allow give us more stability in our images as they will always be the same when they are built. It also gives us better control over what packages we want to use.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
