### PR TITLE
feat(editor): Forbid focusing on node settings parameter (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/components/NodeSettings.vue
+++ b/packages/frontend/editor-ui/src/components/NodeSettings.vue
@@ -435,6 +435,7 @@ const populateSettings = () => {
 					default: false,
 					noDataExpression: true,
 					description: i18n.baseText('nodeSettings.alwaysOutputData.description'),
+					isNodeSetting: true,
 				},
 				{
 					displayName: i18n.baseText('nodeSettings.executeOnce.displayName'),
@@ -443,6 +444,7 @@ const populateSettings = () => {
 					default: false,
 					noDataExpression: true,
 					description: i18n.baseText('nodeSettings.executeOnce.description'),
+					isNodeSetting: true,
 				},
 				{
 					displayName: i18n.baseText('nodeSettings.retryOnFail.displayName'),
@@ -451,6 +453,7 @@ const populateSettings = () => {
 					default: false,
 					noDataExpression: true,
 					description: i18n.baseText('nodeSettings.retryOnFail.description'),
+					isNodeSetting: true,
 				},
 				{
 					displayName: i18n.baseText('nodeSettings.maxTries.displayName'),
@@ -468,6 +471,7 @@ const populateSettings = () => {
 					},
 					noDataExpression: true,
 					description: i18n.baseText('nodeSettings.maxTries.description'),
+					isNodeSetting: true,
 				},
 				{
 					displayName: i18n.baseText('nodeSettings.waitBetweenTries.displayName'),
@@ -485,6 +489,7 @@ const populateSettings = () => {
 					},
 					noDataExpression: true,
 					description: i18n.baseText('nodeSettings.waitBetweenTries.description'),
+					isNodeSetting: true,
 				},
 				{
 					displayName: i18n.baseText('nodeSettings.onError.displayName'),
@@ -514,6 +519,7 @@ const populateSettings = () => {
 					default: 'stopWorkflow',
 					description: i18n.baseText('nodeSettings.onError.description'),
 					noDataExpression: true,
+					isNodeSetting: true,
 				},
 			] as INodeProperties[]),
 		);
@@ -530,6 +536,7 @@ const populateSettings = () => {
 				default: '',
 				noDataExpression: true,
 				description: i18n.baseText('nodeSettings.notes.description'),
+				isNodeSetting: true,
 			},
 			{
 				displayName: i18n.baseText('nodeSettings.notesInFlow.displayName'),
@@ -538,6 +545,7 @@ const populateSettings = () => {
 				default: false,
 				noDataExpression: true,
 				description: i18n.baseText('nodeSettings.notesInFlow.description'),
+				isNodeSetting: true,
 			},
 		] as INodeProperties[]),
 	);

--- a/packages/frontend/editor-ui/src/components/ParameterOptions.vue
+++ b/packages/frontend/editor-ui/src/components/ParameterOptions.vue
@@ -90,8 +90,9 @@ const isFocusPanelFeatureEnabled = computed(() => {
 const hasFocusAction = computed(
 	() =>
 		isFocusPanelFeatureEnabled.value &&
+		!props.parameter.isNodeSetting &&
 		!props.isReadOnly &&
-		activeNode.value &&
+		activeNode.value && // checking that it's inside ndv
 		(props.parameter.type === 'string' || props.parameter.type === 'json'),
 );
 


### PR DESCRIPTION
## Summary

It was possible to focus on node settings parameters, like e.g. Notes of AI Agent:
<img height="400" alt="image" src="https://github.com/user-attachments/assets/0afd3ebd-bfc4-4759-b073-71929cc0d318" />

This PR forbids that.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3805/feature-forbid-focusing-on-node-settings

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
