### PR TITLE
fix(editor): Don't wait for cloud plan store to initialize (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/init.test.ts
+++ b/packages/frontend/editor-ui/src/init.test.ts
@@ -176,7 +176,7 @@ describe('Init', () => {
 				typeof useUsersStore
 			>);
 
-			await initializeAuthenticatedFeatures();
+			await initializeAuthenticatedFeatures(false);
 			expect(cloudStoreSpy).not.toHaveBeenCalled();
 			expect(sourceControlSpy).not.toHaveBeenCalled();
 			expect(nodeTranslationSpy).not.toHaveBeenCalled();
@@ -184,7 +184,7 @@ describe('Init', () => {
 		});
 
 		it('should init authenticated features only once if user is logged in', async () => {
-			const cloudStoreSpy = vi.spyOn(cloudPlanStore, 'initialize');
+			const cloudStoreSpy = vi.spyOn(cloudPlanStore, 'initialize').mockResolvedValue();
 			const sourceControlSpy = vi.spyOn(sourceControlStore, 'getPreferences');
 			const nodeTranslationSpy = vi.spyOn(nodeTypesStore, 'getNodeTranslationHeaders');
 			const versionsSpy = vi.spyOn(versionsStore, 'checkForNewVersions');
@@ -192,7 +192,7 @@ describe('Init', () => {
 				typeof useUsersStore
 			>);
 
-			await initializeAuthenticatedFeatures();
+			await initializeAuthenticatedFeatures(false);
 
 			expect(cloudStoreSpy).toHaveBeenCalled();
 			expect(sourceControlSpy).toHaveBeenCalled();
@@ -204,7 +204,46 @@ describe('Init', () => {
 			expect(cloudStoreSpy).toHaveBeenCalledTimes(1);
 		});
 
+		it('should handle cloud plan initialization error', async () => {
+			const cloudStoreSpy = vi
+				.spyOn(cloudPlanStore, 'initialize')
+				.mockRejectedValue(new AxiosError('Something went wrong', '404'));
+			const sourceControlSpy = vi.spyOn(sourceControlStore, 'getPreferences');
+			const nodeTranslationSpy = vi.spyOn(nodeTypesStore, 'getNodeTranslationHeaders');
+			const versionsSpy = vi.spyOn(versionsStore, 'checkForNewVersions');
+			vi.mocked(useUsersStore).mockReturnValue({ currentUser: { id: '123' } } as ReturnType<
+				typeof useUsersStore
+			>);
+
+			await initializeAuthenticatedFeatures(false);
+
+			expect(cloudStoreSpy).toHaveBeenCalled();
+			expect(sourceControlSpy).toHaveBeenCalled();
+			expect(nodeTranslationSpy).toHaveBeenCalled();
+			expect(versionsSpy).toHaveBeenCalled();
+		});
+
+		it('should initialize even if cloud requests get stuck', async () => {
+			const cloudStoreSpy = vi.spyOn(cloudPlanStore, 'initialize').mockImplementation(async () => {
+				await new Promise((resolve) => setTimeout(resolve, 10000));
+			});
+			const sourceControlSpy = vi.spyOn(sourceControlStore, 'getPreferences');
+			const nodeTranslationSpy = vi.spyOn(nodeTypesStore, 'getNodeTranslationHeaders');
+			const versionsSpy = vi.spyOn(versionsStore, 'checkForNewVersions');
+			vi.mocked(useUsersStore).mockReturnValue({ currentUser: { id: '123' } } as ReturnType<
+				typeof useUsersStore
+			>);
+
+			await initializeAuthenticatedFeatures(false);
+
+			expect(cloudStoreSpy).toHaveBeenCalled();
+			expect(sourceControlSpy).toHaveBeenCalled();
+			expect(nodeTranslationSpy).toHaveBeenCalled();
+			expect(versionsSpy).toHaveBeenCalled();
+		}, 5000);
+
 		it('should handle source control initialization error', async () => {
+			vi.spyOn(cloudPlanStore, 'initialize').mockResolvedValue();
 			vi.mocked(useUsersStore).mockReturnValue({ currentUser: { id: '123' } } as ReturnType<
 				typeof useUsersStore
 			>);

--- a/packages/frontend/editor-ui/src/init.ts
+++ b/packages/frontend/editor-ui/src/init.ts
@@ -148,21 +148,22 @@ export async function initializeAuthenticatedFeatures(
 	}
 
 	if (settingsStore.isCloudDeployment) {
-		try {
-			await cloudPlanStore.initialize();
-
-			if (cloudPlanStore.userIsTrialing) {
-				if (cloudPlanStore.trialExpired) {
-					uiStore.pushBannerToStack('TRIAL_OVER');
-				} else {
-					uiStore.pushBannerToStack('TRIAL');
+		void cloudPlanStore
+			.initialize()
+			.then(() => {
+				if (cloudPlanStore.userIsTrialing) {
+					if (cloudPlanStore.trialExpired) {
+						uiStore.pushBannerToStack('TRIAL_OVER');
+					} else {
+						uiStore.pushBannerToStack('TRIAL');
+					}
+				} else if (cloudPlanStore.currentUserCloudInfo?.confirmed === false) {
+					uiStore.pushBannerToStack('EMAIL_CONFIRMATION');
 				}
-			} else if (cloudPlanStore.currentUserCloudInfo?.confirmed === false) {
-				uiStore.pushBannerToStack('EMAIL_CONFIRMATION');
-			}
-		} catch (e) {
-			console.error('Failed to initialize cloud plan store:', e);
-		}
+			})
+			.catch((error) => {
+				console.error('Failed to initialize cloud plan store:', error);
+			});
 	}
 
 	if (insightsStore.isSummaryEnabled) {

--- a/packages/frontend/editor-ui/src/stores/versions.store.ts
+++ b/packages/frontend/editor-ui/src/stores/versions.store.ts
@@ -130,7 +130,9 @@ export const useVersionsStore = defineStore(STORES.VERSIONS, () => {
 				const versions = await versionsApi.getNextVersions(endpoint, current, instanceId);
 				setVersions({ versions, currentVersion: current });
 			}
-		} catch (e) {}
+		} catch (e) {
+			console.error('Failed to fetch versions:', e);
+		}
 	};
 
 	const setVersions = (params: SetVersionParams) => {
@@ -208,7 +210,9 @@ export const useVersionsStore = defineStore(STORES.VERSIONS, () => {
 					}
 				}
 			}
-		} catch (e) {}
+		} catch (e) {
+			console.error('Failed to fetch Whats New section:', e);
+		}
 	};
 
 	const initialize = (settings: IVersionNotificationSettings) => {


### PR DESCRIPTION
## Summary

On previous cloud incidents UI has refused to load as the cloud requests we send have been left in a pending state, never succeeding or failing (except perhaps after _long_ timeouts).

UI seems to be able to load regardless, lets just not wait for the cloud plan requests on the hot initialization path, and let those requests happen asynchronously, ensuring our UI loads even if cloud is having a hard time.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CP-1955/remove-n8n-cloud-instance-dependency-on-dashboard-backend

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
