### PR TITLE
fix(RabbitMQ Node): Do not return early for manual executions

### DIFF
--- a/packages/nodes-base/nodes/RabbitMQ/test/RabbitMQTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/test/RabbitMQTrigger.node.test.ts
@@ -1,0 +1,139 @@
+import type { Channel } from 'amqplib';
+import { mock } from 'jest-mock-extended';
+import type { ITriggerFunctions } from 'n8n-workflow';
+
+import { MessageTracker, rabbitmqConnectQueue, parseMessage } from '../GenericFunctions';
+import { RabbitMQTrigger } from '../RabbitMQTrigger.node';
+import { setCloseFunction } from '../utils/close';
+
+// Mock all external dependencies
+jest.mock('amqplib');
+jest.mock('../GenericFunctions', () => ({
+	MessageTracker: jest.fn(),
+	rabbitmqConnectQueue: jest.fn(),
+	parseMessage: jest.fn(),
+}));
+jest.mock('../utils/close', () => ({
+	setCloseFunction: jest.fn(),
+}));
+
+describe('RabbitMQTrigger Node', () => {
+	let mockChannel: jest.Mocked<Channel>;
+	let mockMessageTracker: jest.Mocked<MessageTracker>;
+	let mockTriggerFunctions: jest.Mocked<ITriggerFunctions>;
+	let mockSetCloseFunction: jest.MockedFunction<typeof setCloseFunction>;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		mockChannel = mock<Channel>({
+			consume: jest.fn().mockResolvedValue({ consumerTag: 'test-consumer-tag' }),
+			prefetch: jest.fn(),
+			get: jest.fn().mockResolvedValue(false),
+			ack: jest.fn(),
+			nack: jest.fn(),
+			cancel: jest.fn(),
+			close: jest.fn(),
+			connection: { close: jest.fn() },
+		});
+
+		mockMessageTracker = mock<MessageTracker>({
+			received: jest.fn(),
+			answered: jest.fn(),
+			closeChannel: jest.fn(),
+		});
+
+		mockTriggerFunctions = mock<ITriggerFunctions>({
+			getNodeParameter: jest.fn(),
+			getMode: jest.fn(),
+			emit: jest.fn(),
+			getNode: jest.fn().mockReturnValue({ name: 'Test RabbitMQ Trigger' }),
+			getWorkflow: jest.fn().mockReturnValue({ id: 'test-workflow-id' }),
+			helpers: {
+				createDeferredPromise: jest.fn(),
+				returnJsonArray: jest.fn(),
+			},
+		});
+
+		(rabbitmqConnectQueue as jest.Mock).mockResolvedValue(mockChannel);
+		(MessageTracker as jest.Mock).mockReturnValue(mockMessageTracker);
+		(parseMessage as jest.Mock).mockResolvedValue({ json: { test: 'data' } });
+
+		mockSetCloseFunction = setCloseFunction as jest.MockedFunction<typeof setCloseFunction>;
+		const mockCloseFunction = jest.fn().mockResolvedValue(undefined);
+		mockSetCloseFunction.mockReturnValue(mockCloseFunction);
+	});
+
+	describe('setCloseFunction integration', () => {
+		it('should call setCloseFunction with correct parameters in trigger mode', async () => {
+			mockTriggerFunctions.getNodeParameter
+				.mockReturnValueOnce('test-queue')
+				.mockReturnValueOnce({});
+			mockTriggerFunctions.getMode.mockReturnValue('trigger');
+
+			const trigger = new RabbitMQTrigger();
+			await trigger.trigger.call(mockTriggerFunctions);
+
+			expect(mockSetCloseFunction).toHaveBeenCalledWith(
+				mockChannel,
+				mockMessageTracker,
+				'test-consumer-tag',
+			);
+			expect(mockSetCloseFunction).toHaveBeenCalledTimes(1);
+		});
+
+		it('should call setCloseFunction with correct parameters in manual mode', async () => {
+			mockTriggerFunctions.getNodeParameter
+				.mockReturnValueOnce('test-queue')
+				.mockReturnValueOnce({});
+			mockTriggerFunctions.getMode.mockReturnValue('manual');
+
+			const trigger = new RabbitMQTrigger();
+			await trigger.trigger.call(mockTriggerFunctions);
+
+			expect(mockSetCloseFunction).toHaveBeenCalledWith(
+				mockChannel,
+				mockMessageTracker,
+				'test-consumer-tag',
+			);
+			expect(mockSetCloseFunction).toHaveBeenCalledTimes(1);
+		});
+
+		it('should call setCloseFunction with correct consumer tag from channel.consume', async () => {
+			const customConsumerTag = 'custom-consumer-123';
+			mockChannel.consume.mockResolvedValue({ consumerTag: customConsumerTag });
+
+			mockTriggerFunctions.getNodeParameter
+				.mockReturnValueOnce('test-queue')
+				.mockReturnValueOnce({});
+			mockTriggerFunctions.getMode.mockReturnValue('trigger');
+
+			const trigger = new RabbitMQTrigger();
+			await trigger.trigger.call(mockTriggerFunctions);
+
+			expect(mockSetCloseFunction).toHaveBeenCalledWith(
+				mockChannel,
+				mockMessageTracker,
+				customConsumerTag,
+			);
+		});
+
+		it('should call setCloseFunction with MessageTracker instance', async () => {
+			mockTriggerFunctions.getNodeParameter
+				.mockReturnValueOnce('test-queue')
+				.mockReturnValueOnce({});
+			mockTriggerFunctions.getMode.mockReturnValue('trigger');
+
+			const trigger = new RabbitMQTrigger();
+			await trigger.trigger.call(mockTriggerFunctions);
+
+			expect(mockSetCloseFunction).toHaveBeenCalledWith(
+				mockChannel,
+				mockMessageTracker,
+				'test-consumer-tag',
+			);
+
+			expect(MessageTracker).toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/nodes-base/nodes/RabbitMQ/test/close.test.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/test/close.test.ts
@@ -1,0 +1,72 @@
+import type { Channel, Connection } from 'amqplib';
+import { mock } from 'jest-mock-extended';
+import type { ITriggerFunctions } from 'n8n-workflow';
+
+import type { MessageTracker } from '../GenericFunctions';
+import { setCloseFunction } from '../utils/close';
+
+describe('setCloseFunction', () => {
+	let mockChannel: Channel;
+	let mockConnection: Connection;
+	let mockMessageTracker: MessageTracker;
+	let mockTriggerFunctions: jest.Mocked<ITriggerFunctions>;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		mockChannel = mock<Channel>();
+		mockConnection = mock<Connection>();
+		mockChannel.connection = mockConnection;
+		mockMessageTracker = mock<MessageTracker>({
+			closeChannel: jest.fn(),
+		});
+
+		mockTriggerFunctions = mock<ITriggerFunctions>({
+			getNodeParameter: jest.fn(),
+			getMode: jest.fn(),
+			emit: jest.fn(),
+		});
+	});
+
+	describe('manual mode', () => {
+		it('should return close function that closes channel and connection directly', async () => {
+			mockTriggerFunctions.getMode.mockReturnValue('manual');
+
+			const closeFunction = setCloseFunction.call(
+				mockTriggerFunctions,
+				mockChannel,
+				mockMessageTracker,
+				'consumerTag123',
+			);
+
+			await closeFunction();
+
+			expect(mockChannel.close).toHaveBeenCalledTimes(1);
+			expect(mockConnection.close).toHaveBeenCalledTimes(1);
+			expect(mockMessageTracker.closeChannel).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('production mode', () => {
+		it('should work with different consumer tags', async () => {
+			mockTriggerFunctions.getMode.mockReturnValue('trigger');
+
+			const consumerTags = ['tag1', 'tag2', 'special-tag-123'];
+
+			for (const tag of consumerTags) {
+				const closeFunction = setCloseFunction.call(
+					mockTriggerFunctions,
+					mockChannel,
+					mockMessageTracker,
+					tag,
+				);
+
+				await closeFunction();
+
+				expect(mockMessageTracker.closeChannel).toHaveBeenCalledWith(mockChannel, tag);
+			}
+
+			expect(mockMessageTracker.closeChannel).toHaveBeenCalledTimes(3);
+		});
+	});
+});

--- a/packages/nodes-base/nodes/RabbitMQ/test/close.test.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/test/close.test.ts
@@ -39,7 +39,9 @@ describe('setCloseFunction', () => {
 				'consumerTag123',
 			);
 
-			await closeFunction();
+			if (closeFunction) {
+				await closeFunction();
+			}
 
 			expect(mockChannel.close).toHaveBeenCalledTimes(1);
 			expect(mockConnection.close).toHaveBeenCalledTimes(1);
@@ -61,8 +63,9 @@ describe('setCloseFunction', () => {
 					tag,
 				);
 
-				await closeFunction();
-
+				if (closeFunction) {
+					await closeFunction();
+				}
 				expect(mockMessageTracker.closeChannel).toHaveBeenCalledWith(mockChannel, tag);
 			}
 

--- a/packages/nodes-base/nodes/RabbitMQ/utils/close.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/utils/close.ts
@@ -1,0 +1,34 @@
+import type { ITriggerFunctions } from 'n8n-workflow';
+import type { Channel } from 'amqplib';
+import type { MessageTracker } from '../GenericFunctions';
+
+export function setCloseFunction(
+	this: ITriggerFunctions,
+	channel: Channel,
+	messageTracker: MessageTracker,
+	consumerTag: string,
+): (() => Promise<void>) | undefined {
+	if (this.getMode() === 'manual') {
+		return async () => {
+			await channel.close();
+			await channel.connection.close();
+			return;
+		};
+	} else {
+		return async () => {
+			try {
+				return await messageTracker.closeChannel(channel, consumerTag);
+			} catch (error) {
+				const workflow = this.getWorkflow();
+				const node = this.getNode();
+				this.logger.error(
+					`There was a problem closing the RabbitMQ Trigger node connection "${node.name}" in workflow "${workflow.id}": "${error.message}"`,
+					{
+						node: node.name,
+						workflowId: workflow.id,
+					},
+				);
+			}
+		};
+	}
+}


### PR DESCRIPTION
## Summary

We need to make use of `acknowledge` for manual executions, which means we shouldn't return early and have it go through the rest of the logic in trigger

This should've been done in https://github.com/n8n-io/n8n/pull/10663/files#diff-95c05523b9125df75bb2b9bef903a7e1ba8e823882ce07d8c24ec5ebb3b256a5

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2601/community-issue-rabbitmq-takes-the-item-from-the-queue-regardless-of
Fixes #13732

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
