### PR TITLE
fix: Don't use isinstance for Toolkit, use ducktyping instead

### DIFF
--- a/packages/@n8n/nodes-langchain/utils/helpers.ts
+++ b/packages/@n8n/nodes-langchain/utils/helpers.ts
@@ -195,11 +195,11 @@ export const getConnectedTools = async (
 		((await ctx.getInputConnectionData(NodeConnectionTypes.AiTool, 0)) as Array<Toolkit | Tool>) ??
 		[]
 	).flatMap((toolOrToolkit) => {
-		if (toolOrToolkit instanceof Toolkit) {
-			return toolOrToolkit.getTools() as Tool[];
+		if (typeof (toolOrToolkit as Toolkit).getTools === 'function') {
+			return (toolOrToolkit as Toolkit).getTools() as Tool[];
 		}
 
-		return toolOrToolkit;
+		return toolOrToolkit as Tool;
 	});
 
 	if (!enforceUniqueNames) return connectedTools;

--- a/packages/@n8n/nodes-langchain/utils/tests/helpers.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/tests/helpers.test.ts
@@ -325,6 +325,37 @@ describe('getConnectedTools', () => {
 			{ name: 'toolkitTool2', description: 'toolkitToolDesc2' },
 		]);
 	});
+
+	it('should flatten tools from a toolkit-like object', async () => {
+		class MockToolkit {
+			tools: Tool[];
+
+			getTools() {
+				return this.tools;
+			}
+
+			constructor(tools: unknown[]) {
+				this.tools = tools as Tool[];
+			}
+		}
+		const mockTools = [
+			{ name: 'tool1', description: 'desc1' },
+
+			new MockToolkit([
+				{ name: 'toolkitTool1', description: 'toolkitToolDesc1' },
+				{ name: 'toolkitTool2', description: 'toolkitToolDesc2' },
+			]),
+		];
+
+		mockExecuteFunctions.getInputConnectionData = jest.fn().mockResolvedValue(mockTools);
+
+		const tools = await getConnectedTools(mockExecuteFunctions, false);
+		expect(tools).toEqual([
+			{ name: 'tool1', description: 'desc1' },
+			{ name: 'toolkitTool1', description: 'toolkitToolDesc1' },
+			{ name: 'toolkitTool2', description: 'toolkitToolDesc2' },
+		]);
+	});
 });
 
 describe('unwrapNestedOutput', () => {


### PR DESCRIPTION
## Summary

When developing a custom Node (using the [template](https://github.com/n8n-io/n8n-nodes-starter/) that uses a Toolkit, the `isinstance` check fails.

This is an approach that is already used in [other places](https://github.com/n8n-io/n8n/blob/master/packages/@n8n/nodes-langchain/nodes/ToolExecutor/ToolExecutor.node.ts#L66)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. 
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
