### PR TITLE
feat(Respond to Webhook Node): Implement streaming to response

### DIFF
--- a/packages/nodes-base/nodes/RespondToWebhook/RespondToWebhook.node.ts
+++ b/packages/nodes-base/nodes/RespondToWebhook/RespondToWebhook.node.ts
@@ -458,10 +458,17 @@ export class RespondToWebhook implements INodeType {
 				}
 			} else if (respondWith === 'text') {
 				// If a user doesn't set the content-type header and uses html, the html can still be rendered on the browser
+				const rawBody = this.getNodeParameter('responseBody', 0) as string;
 				if (hasHtmlContentType || !headers['content-type']) {
-					responseBody = sandboxHtmlResponse(this.getNodeParameter('responseBody', 0) as string);
+					responseBody = sandboxHtmlResponse(rawBody);
 				} else {
-					responseBody = this.getNodeParameter('responseBody', 0) as string;
+					responseBody = rawBody;
+				}
+				// Send the raw body to the stream
+				if (shouldStream) {
+					this.sendChunk('begin', 0);
+					this.sendChunk('item', 0, rawBody);
+					this.sendChunk('end', 0);
 				}
 			} else if (respondWith === 'binary') {
 				const item = items[0];

--- a/packages/nodes-base/nodes/RespondToWebhook/RespondToWebhook.node.ts
+++ b/packages/nodes-base/nodes/RespondToWebhook/RespondToWebhook.node.ts
@@ -316,6 +316,19 @@ export class RespondToWebhook implements INodeType {
 						description: 'The name of the response field to put all items in',
 						placeholder: 'e.g. data',
 					},
+					{
+						displayName: 'Enable Streaming',
+						name: 'enableStreaming',
+						type: 'boolean',
+						default: true,
+						description: 'Whether to enable streaming to the response',
+						displayOptions: {
+							show: {
+								['/respondWith']: ['allIncomingItems', 'firstIncomingItem', 'text', 'json', 'jwt'],
+								'@version': [{ _cnd: { gte: 1.5 } }],
+							},
+						},
+					},
 				],
 			},
 		],
@@ -334,7 +347,10 @@ export class RespondToWebhook implements INodeType {
 
 		let response: IN8nHttpFullResponse;
 
-		const shouldStream = this.isStreaming();
+		const options = this.getNodeParameter('options', 0, {});
+
+		const shouldStream =
+			nodeVersion >= 1.5 && this.isStreaming() && options.enableStreaming !== false;
 
 		try {
 			if (nodeVersion >= 1.1) {
@@ -352,7 +368,6 @@ export class RespondToWebhook implements INodeType {
 			}
 
 			const respondWith = this.getNodeParameter('respondWith', 0) as string;
-			const options = this.getNodeParameter('options', 0, {});
 
 			const headers = {} as IDataObject;
 			if (options.responseHeaders) {
@@ -386,6 +401,12 @@ export class RespondToWebhook implements INodeType {
 						}
 					}
 				}
+
+				if (shouldStream) {
+					this.sendChunk('begin', 0);
+					this.sendChunk('item', 0, responseBody as IDataObject);
+					this.sendChunk('end', 0);
+				}
 			} else if (respondWith === 'jwt') {
 				try {
 					const { keyType, secret, algorithm, privateKey } = await this.getCredentials<{
@@ -405,13 +426,24 @@ export class RespondToWebhook implements INodeType {
 					const payload = this.getNodeParameter('payload', 0, {}) as IDataObject;
 					const token = jwt.sign(payload, secretOrPrivateKey, { algorithm });
 					responseBody = { token };
+
+					if (shouldStream) {
+						this.sendChunk('begin', 0);
+						this.sendChunk('item', 0, responseBody as IDataObject);
+						this.sendChunk('end', 0);
+					}
 				} catch (error) {
 					throw new NodeOperationError(this.getNode(), error as Error, {
 						message: 'Error signing JWT token',
 					});
 				}
 			} else if (respondWith === 'allIncomingItems') {
-				const respondItems = items.map((item) => item.json);
+				const respondItems = items.map((item, index) => {
+					this.sendChunk('begin', index);
+					this.sendChunk('item', index, item.json);
+					this.sendChunk('end', index);
+					return item.json;
+				});
 				responseBody = options.responseKey
 					? set({}, options.responseKey as string, respondItems)
 					: respondItems;
@@ -419,6 +451,11 @@ export class RespondToWebhook implements INodeType {
 				responseBody = options.responseKey
 					? set({}, options.responseKey as string, items[0].json)
 					: items[0].json;
+				if (shouldStream) {
+					this.sendChunk('begin', 0);
+					this.sendChunk('item', 0, items[0].json);
+					this.sendChunk('end', 0);
+				}
 			} else if (respondWith === 'text') {
 				// If a user doesn't set the content-type header and uses html, the html can still be rendered on the browser
 				if (hasHtmlContentType || !headers['content-type']) {
@@ -478,11 +515,7 @@ export class RespondToWebhook implements INodeType {
 				statusCode,
 			};
 
-			if (nodeVersion >= 1.5 && shouldStream && respondWith !== 'binary') {
-				this.sendChunk('begin');
-				this.sendChunk('item', responseBody?.toString());
-				this.sendChunk('end');
-			} else {
+			if (!shouldStream || respondWith === 'binary') {
 				this.sendResponse(response);
 			}
 		} catch (error) {

--- a/packages/nodes-base/nodes/Webhook/utils.ts
+++ b/packages/nodes-base/nodes/Webhook/utils.ts
@@ -155,7 +155,7 @@ export const checkResponseModeConfiguration = (context: IWebhookFunctions) => {
 		(node) => node.type === 'n8n-nodes-base.respondToWebhook',
 	);
 
-	if (!isRespondToWebhookConnected && responseMode === 'responseNode') {
+	if (!isRespondToWebhookConnected && ['responseNode', 'streaming'].includes(responseMode)) {
 		throw new NodeOperationError(
 			context.getNode(),
 			new Error('No Respond to Webhook node found in the workflow'),
@@ -166,7 +166,7 @@ export const checkResponseModeConfiguration = (context: IWebhookFunctions) => {
 		);
 	}
 
-	if (isRespondToWebhookConnected && responseMode !== 'responseNode') {
+	if (isRespondToWebhookConnected && !['responseNode', 'streaming'].includes(responseMode)) {
 		throw new NodeOperationError(
 			context.getNode(),
 			new Error('Webhook node not correctly configured'),

--- a/packages/nodes-base/nodes/Webhook/utils.ts
+++ b/packages/nodes-base/nodes/Webhook/utils.ts
@@ -155,7 +155,7 @@ export const checkResponseModeConfiguration = (context: IWebhookFunctions) => {
 		(node) => node.type === 'n8n-nodes-base.respondToWebhook',
 	);
 
-	if (!isRespondToWebhookConnected && ['responseNode', 'streaming'].includes(responseMode)) {
+	if (!isRespondToWebhookConnected && responseMode === 'responseNode') {
 		throw new NodeOperationError(
 			context.getNode(),
 			new Error('No Respond to Webhook node found in the workflow'),


### PR DESCRIPTION
## Summary
This PR adds an option to enable streaming. If the option is enabled and the current execution is in streaming response mode the node will stream the configured output to the response.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-1040/implement-streaming-on-respond-to-webhook-node


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
