### PR TITLE
feat: Add endpoint to retrieve single workflow from GH

### DIFF
--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control-git.service.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control-git.service.test.ts
@@ -68,4 +68,41 @@ describe('SourceControlGitService', () => {
 			});
 		});
 	});
+
+	describe('getFileContent', () => {
+		it('should return file content at HEAD version', async () => {
+			// Arrange
+			const filePath = 'workflows/12345.json';
+			const expectedContent = '{"id":"12345","name":"Test Workflow"}';
+			const git = mock<SimpleGit>();
+			const showSpy = jest.spyOn(git, 'show');
+			showSpy.mockResolvedValue(expectedContent);
+			sourceControlGitService.git = git;
+
+			// Act
+			const content = await sourceControlGitService.getFileContent(filePath);
+
+			// Assert
+			expect(showSpy).toHaveBeenCalledWith([`HEAD:${filePath}`]);
+			expect(content).toBe(expectedContent);
+		});
+
+		it('should return file content at specific commit', async () => {
+			// Arrange
+			const filePath = 'workflows/12345.json';
+			const commitHash = 'abc123';
+			const expectedContent = '{"id":"12345","name":"Test Workflow"}';
+			const git = mock<SimpleGit>();
+			const showSpy = jest.spyOn(git, 'show');
+			showSpy.mockResolvedValue(expectedContent);
+			sourceControlGitService.git = git;
+
+			// Act
+			const content = await sourceControlGitService.getFileContent(filePath, commitHash);
+
+			// Assert
+			expect(showSpy).toHaveBeenCalledWith([`${commitHash}:${filePath}`]);
+			expect(content).toBe(expectedContent);
+		});
+	});
 });

--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control.service.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control.service.test.ts
@@ -6,6 +6,7 @@ import type {
 	User,
 	FolderRepository,
 	TagRepository,
+	WorkflowEntity,
 } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
@@ -15,7 +16,9 @@ import { SourceControlPreferencesService } from '@/environments.ee/source-contro
 import { SourceControlService } from '@/environments.ee/source-control/source-control.service.ee';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 
+import type { SourceControlGitService } from '../source-control-git.service.ee';
 import type { SourceControlImportService } from '../source-control-import.service.ee';
+import type { SourceControlScopedService } from '../source-control-scoped.service';
 import type { StatusExportableCredential } from '../types/exportable-credential';
 import type { SourceControlWorkflowVersionId } from '../types/source-control-workflow-version-id';
 
@@ -28,14 +31,17 @@ describe('SourceControlService', () => {
 		mock(),
 	);
 	const sourceControlImportService = mock<SourceControlImportService>();
+	const sourceControlScopedService = mock<SourceControlScopedService>();
 	const tagRepository = mock<TagRepository>();
 	const folderRepository = mock<FolderRepository>();
+	const gitService = mock<SourceControlGitService>();
 	const sourceControlService = new SourceControlService(
 		mock(),
-		mock(),
+		gitService,
 		preferencesService,
 		mock(),
 		sourceControlImportService,
+		sourceControlScopedService,
 		tagRepository,
 		folderRepository,
 		mock(),
@@ -373,6 +379,69 @@ describe('SourceControlService', () => {
 					preferLocalVersion: false,
 				}),
 			).rejects.toThrowError(ForbiddenError);
+		});
+	});
+
+	describe('getFileContent', () => {
+		it.each([
+			{ type: 'workflow' as SourceControlledFile['type'], id: '1234', content: 'workflow content' },
+		])('should return file content for $type', async ({ type, id, content }) => {
+			jest.spyOn(gitService, 'getFileContent').mockResolvedValue(content);
+			const user = mock<User>({ id: 'user-id', role: 'global:admin' });
+
+			const result = await sourceControlService.getFileContent({ user, type, id });
+
+			expect(result).toBe(content);
+		});
+
+		it.each<SourceControlledFile['type']>(['folders', 'credential', 'tags', 'variables'])(
+			'should throw an error if the file type is not handled',
+			async (type) => {
+				const user = mock<User>({ id: 'user-id', role: 'global:admin' });
+				await expect(
+					sourceControlService.getFileContent({ user, type, id: 'unknown' }),
+				).rejects.toThrow(`Unsupported file type: ${type}`);
+			},
+		);
+
+		it('should fail if the git service fails to get the file content', async () => {
+			jest
+				.spyOn(sourceControlService, 'getFileContent')
+				.mockRejectedValue(new Error('Git service error'));
+			const user = mock<User>({ id: 'user-id', role: 'global:admin' });
+
+			await expect(
+				sourceControlService.getFileContent({ user, type: 'workflow', id: '1234' }),
+			).rejects.toThrow('Git service error');
+		});
+
+		it('should throw an error if the user does not have access to the project', async () => {
+			const user = mock<User>({
+				id: 'user-id',
+				role: 'global:member',
+			});
+			jest
+				.spyOn(sourceControlScopedService, 'getWorkflowsInAdminProjectsFromContext')
+				.mockResolvedValue([]);
+
+			await expect(
+				sourceControlService.getFileContent({ user, type: 'workflow', id: '1234' }),
+			).rejects.toThrow('You are not allowed to access workflow with id 1234');
+		});
+
+		it('should return content for an authorized workflow', async () => {
+			const user = mock<User>({ id: 'user-id', role: 'global:member' });
+			jest
+				.spyOn(sourceControlScopedService, 'getWorkflowsInAdminProjectsFromContext')
+				.mockResolvedValue([{ id: '1234' } as WorkflowEntity]);
+			jest.spyOn(gitService, 'getFileContent').mockResolvedValue('workflow content');
+			const result = await sourceControlService.getFileContent({
+				user,
+				type: 'workflow',
+				id: '1234',
+			});
+
+			expect(result).toBe('workflow content');
 		});
 	});
 });

--- a/packages/cli/src/environments.ee/source-control/source-control-git.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-git.service.ee.ts
@@ -387,4 +387,17 @@ export class SourceControlGitService {
 		const statusResult = await this.git.status();
 		return statusResult;
 	}
+
+	async getFileContent(filePath: string): Promise<string> {
+		if (!this.git) {
+			throw new UnexpectedError('Git is not initialized (getFileContent)');
+		}
+		try {
+			const content = await this.git.show([`HEAD:${filePath}`]);
+			return content;
+		} catch (error) {
+			this.logger.error('Failed to get file content', { filePath, error });
+			throw new UnexpectedError(`Could not get content for file: ${filePath}`, { cause: error });
+		}
+	}
 }

--- a/packages/cli/src/environments.ee/source-control/source-control-git.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-git.service.ee.ts
@@ -388,16 +388,19 @@ export class SourceControlGitService {
 		return statusResult;
 	}
 
-	async getFileContent(filePath: string): Promise<string> {
+	async getFileContent(filePath: string, commit: string = 'HEAD'): Promise<string> {
 		if (!this.git) {
 			throw new UnexpectedError('Git is not initialized (getFileContent)');
 		}
 		try {
-			const content = await this.git.show([`HEAD:${filePath}`]);
+			const content = await this.git.show([`${commit}:${filePath}`]);
 			return content;
 		} catch (error) {
 			this.logger.error('Failed to get file content', { filePath, error });
-			throw new UnexpectedError(`Could not get content for file: ${filePath}`, { cause: error });
+			throw new UnexpectedError(
+				`Could not get content for file: ${filePath}: ${(error as Error)?.message}`,
+				{ cause: error },
+			);
 		}
 	}
 }

--- a/packages/cli/src/environments.ee/source-control/source-control-scoped.service.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-scoped.service.ts
@@ -1,4 +1,4 @@
-import { ProjectRepository, WorkflowRepository } from '@n8n/db';
+import { CredentialsRepository, ProjectRepository, WorkflowRepository } from '@n8n/db';
 import {
 	type AuthenticatedRequest,
 	type CredentialsEntity,
@@ -21,6 +21,7 @@ export class SourceControlScopedService {
 	constructor(
 		private readonly projectRepository: ProjectRepository,
 		private readonly workflowRepository: WorkflowRepository,
+		private readonly credentialRepository: CredentialsRepository,
 	) {}
 
 	async ensureIsAllowedToPush(req: AuthenticatedRequest) {
@@ -76,6 +77,21 @@ export class SourceControlScopedService {
 				id: true,
 			},
 			where: this.getWorkflowsInAdminProjectsFromContextFilter(context),
+		});
+	}
+
+	async getCredentialsInAdminProjectsFromContext(
+		context: SourceControlContext,
+	): Promise<CredentialsEntity[] | undefined> {
+		if (context.hasAccessToAllProjects()) {
+			return;
+		}
+
+		return await this.credentialRepository.find({
+			select: {
+				id: true,
+			},
+			where: this.getCredentialsInAdminProjectsFromContextFilter(context),
 		});
 	}
 

--- a/packages/cli/src/environments.ee/source-control/source-control.controller.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control.controller.ee.ts
@@ -252,4 +252,17 @@ export class SourceControlController {
 			throw new BadRequestError((error as { message: string }).message);
 		}
 	}
+
+	@Get('/get-workflow/:workflowId', { middlewares: [sourceControlLicensedAndEnabledMiddleware] })
+	async getFileContent(req: AuthenticatedRequest & { params: { workflowId: string } }) {
+		try {
+			const workflowId = req.params.workflowId;
+			const content = await this.sourceControlService.getFileContent(
+				`workflows/${workflowId}.json`,
+			);
+			return { content };
+		} catch (error) {
+			throw new BadRequestError((error as { message: string }).message);
+		}
+	}
 }

--- a/packages/cli/src/environments.ee/source-control/source-control.controller.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control.controller.ee.ts
@@ -258,7 +258,7 @@ export class SourceControlController {
 	@Get('/remote-content/:type/:id', { middlewares: [sourceControlLicensedAndEnabledMiddleware] })
 	async getFileContent(
 		req: AuthenticatedRequest & { params: { type: SourceControlledFile['type']; id: string } },
-	): Promise<{ content: IWorkflowToImport }> {
+	): Promise<{ content: IWorkflowToImport; type: SourceControlledFile['type'] }> {
 		try {
 			const { type, id } = req.params;
 			const content = await this.sourceControlService.getRemoteFileEntity({
@@ -266,7 +266,7 @@ export class SourceControlController {
 				type,
 				id,
 			});
-			return { content };
+			return { content, type };
 		} catch (error) {
 			if (error instanceof ForbiddenError) {
 				throw error;

--- a/packages/cli/src/environments.ee/source-control/source-control.controller.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control.controller.ee.ts
@@ -1,3 +1,4 @@
+import { IWorkflowToImport } from '@/interfaces';
 import { PullWorkFolderRequestDto, PushWorkFolderRequestDto } from '@n8n/api-types';
 import type { SourceControlledFile } from '@n8n/api-types';
 import { AuthenticatedRequest } from '@n8n/db';
@@ -22,7 +23,6 @@ import type { SourceControlPreferences } from './types/source-control-preference
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { EventService } from '@/events/event.service';
-import { IWorkflowBase } from 'n8n-workflow';
 
 @RestController('/source-control')
 export class SourceControlController {
@@ -258,7 +258,7 @@ export class SourceControlController {
 	@Get('/remote-content/:type/:id', { middlewares: [sourceControlLicensedAndEnabledMiddleware] })
 	async getFileContent(
 		req: AuthenticatedRequest & { params: { type: SourceControlledFile['type']; id: string } },
-	): Promise<{ content: Omit<IWorkflowBase, 'createdAt' | 'updatedAt'> }> {
+	): Promise<{ content: IWorkflowToImport }> {
 		try {
 			const { type, id } = req.params;
 			const content = await this.sourceControlService.getRemoteFileEntity({

--- a/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
@@ -1048,4 +1048,10 @@ export class SourceControlService {
 		await this.sanityCheck();
 		await this.gitService.setGitUserDetails(name, email);
 	}
+
+	async getFileContent(filePath: string): Promise<string> {
+		await this.sanityCheck();
+		const fileContent = await this.gitService.getFileContent(filePath);
+		return fileContent;
+	}
 }

--- a/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
@@ -1068,9 +1068,13 @@ export class SourceControlService {
 		const context = new SourceControlContext(user);
 		switch (type) {
 			case 'workflow': {
+				if (typeof id === 'undefined') {
+					throw new BadRequestError('Workflow ID is required to fetch workflow content');
+				}
+
 				const authorizedWorkflows =
-					await this.sourceControlScopedService.getWorkflowsInAdminProjectsFromContext(context);
-				if (authorizedWorkflows && !authorizedWorkflows.find((wf) => wf.id === id)) {
+					await this.sourceControlScopedService.getWorkflowsInAdminProjectsFromContext(context, id);
+				if (authorizedWorkflows && authorizedWorkflows.length === 0) {
 					throw new ForbiddenError(`You are not allowed to access workflow with id ${id}`);
 				}
 				const content = await this.gitService.getFileContent(

--- a/packages/cli/test/integration/environments/source-control.service.test.ts
+++ b/packages/cli/test/integration/environments/source-control.service.test.ts
@@ -27,6 +27,7 @@ import { SourceControlExportService } from '@/environments.ee/source-control/sou
 import type { SourceControlGitService } from '@/environments.ee/source-control/source-control-git.service.ee';
 import { SourceControlImportService } from '@/environments.ee/source-control/source-control-import.service.ee';
 import { SourceControlPreferencesService } from '@/environments.ee/source-control/source-control-preferences.service.ee';
+import { SourceControlScopedService } from '@/environments.ee/source-control/source-control-scoped.service';
 import { SourceControlService } from '@/environments.ee/source-control/source-control.service.ee';
 import type { ExportableCredential } from '@/environments.ee/source-control/types/exportable-credential';
 import type { ExportableFolder } from '@/environments.ee/source-control/types/exportable-folders';
@@ -428,6 +429,7 @@ describe('SourceControlService', () => {
 			sourceControlPreferencesService,
 			Container.get(SourceControlExportService),
 			Container.get(SourceControlImportService),
+			Container.get(SourceControlScopedService),
 			Container.get(TagRepository),
 			Container.get(FolderRepository),
 			Container.get(EventService),


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR adds a new endpoint on the source control feature to fetch the content of a workflow in the git repository.
This will be used by the workflow diff feature to display workflow diff between local and remote

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/PAY-3076/create-endpoint-to-retrieve-single-workflow-from-git
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
