### PR TITLE
fix(editor): Make expression resolution work in embedded ndv (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/composables/useResolvedExpression.ts
+++ b/packages/frontend/editor-ui/src/composables/useResolvedExpression.ts
@@ -90,13 +90,9 @@ export function useResolvedExpression({
 
 	const debouncedUpdateExpression = debounce(updateExpression, 200);
 
-	function updateExpression(
-		watchValues?:
-			| []
-			| [ExpressionLocalResolveContext | undefined, unknown, unknown, unknown, unknown],
-	) {
+	function updateExpression() {
 		if (isExpression.value) {
-			const resolved = resolve(watchValues?.[0]);
+			const resolved = resolve(expressionLocalResolveCtx.value);
 			resolvedExpression.value = resolved.ok ? resolved.result : null;
 			resolvedExpressionString.value = stringifyExpressionResult(resolved, hasRunData.value);
 		} else {

--- a/packages/frontend/editor-ui/src/composables/useWorkflowHelpers.ts
+++ b/packages/frontend/editor-ui/src/composables/useWorkflowHelpers.ts
@@ -80,7 +80,7 @@ export function resolveParameter<T = IDataObject>(
 	if ('localResolve' in opts && opts.localResolve) {
 		return resolveParameterImpl(
 			parameter,
-			opts.workflow,
+			() => opts.workflow,
 			opts.envVars,
 			opts.workflow.getNode(opts.nodeName),
 			opts.execution,
@@ -99,7 +99,7 @@ export function resolveParameter<T = IDataObject>(
 
 	return resolveParameterImpl(
 		parameter,
-		workflowsStore.getCurrentWorkflow(),
+		workflowsStore.getCurrentWorkflow,
 		useEnvironmentsStore().variablesAsObject,
 		useNDVStore().activeNode,
 		workflowsStore.workflowExecutionData,
@@ -112,7 +112,7 @@ export function resolveParameter<T = IDataObject>(
 // TODO: move to separate file
 function resolveParameterImpl<T = IDataObject>(
 	parameter: NodeParameterValue | INodeParameters | NodeParameterValue[] | INodeParameters[],
-	workflow: Workflow,
+	getContextWorkflow: () => Workflow,
 	envVars: Record<string, string | boolean | number>,
 	ndvActiveNode: INodeUi | null,
 	executionData: IExecutionResponse | null,
@@ -121,6 +121,8 @@ function resolveParameterImpl<T = IDataObject>(
 	opts: ResolveParameterOptions = {},
 ): T | null {
 	let itemIndex = opts?.targetItem?.itemIndex || 0;
+
+	const workflow = getContextWorkflow();
 
 	const additionalKeys: IWorkflowDataProxyAdditionalKeys = {
 		$execution: {
@@ -202,7 +204,7 @@ function resolveParameterImpl<T = IDataObject>(
 		contextNode!.name,
 		inputName,
 		runIndexParent,
-		workflow,
+		getContextWorkflow,
 		shouldReplaceInputDataWithPinData,
 		pinData,
 		executionData?.data?.resultData.runData ?? null,
@@ -217,7 +219,7 @@ function resolveParameterImpl<T = IDataObject>(
 			contextNode.name,
 			inputName,
 			0,
-			workflow,
+			getContextWorkflow,
 			shouldReplaceInputDataWithPinData,
 			pinData,
 			executionData?.data?.resultData.runData ?? null,
@@ -267,7 +269,7 @@ function resolveParameterImpl<T = IDataObject>(
 		contextNode!.name,
 		inputName,
 		runIndexCurrent,
-		workflow,
+		getContextWorkflow,
 		shouldReplaceInputDataWithPinData,
 		pinData,
 		executionData?.data?.resultData.runData ?? null,
@@ -281,7 +283,7 @@ function resolveParameterImpl<T = IDataObject>(
 			contextNode!.name,
 			inputName,
 			runIndexParent,
-			workflow,
+			getContextWorkflow,
 			shouldReplaceInputDataWithPinData,
 			pinData,
 			executionData?.data?.resultData.runData ?? null,
@@ -384,7 +386,7 @@ function connectionInputData(
 	currentNode: string,
 	inputName: string,
 	runIndex: number,
-	workflow: Workflow,
+	getContextWorkflow: () => Workflow,
 	shouldReplaceInputDataWithPinData: boolean,
 	pinData: IPinData | undefined,
 	workflowRunData: IRunData | null,
@@ -396,7 +398,7 @@ function connectionInputData(
 		currentNode,
 		inputName,
 		runIndex,
-		workflow,
+		getContextWorkflow,
 		shouldReplaceInputDataWithPinData,
 		pinData,
 		workflowRunData,
@@ -442,7 +444,7 @@ export function executeData(
 		currentNode,
 		inputName,
 		runIndex,
-		workflowsStore.getCurrentWorkflow(),
+		workflowsStore.getCurrentWorkflow,
 		workflowsStore.shouldReplaceInputDataWithPinData,
 		workflowsStore.pinnedWorkflowData,
 		workflowsStore.getWorkflowRunData,
@@ -456,7 +458,7 @@ function executeDataImpl(
 	currentNode: string,
 	inputName: string,
 	runIndex: number,
-	workflow: Workflow,
+	getContextWorkflow: () => Workflow,
 	shouldReplaceInputDataWithPinData: boolean,
 	pinData: IPinData | undefined,
 	workflowRunData: IRunData | null,
@@ -505,6 +507,8 @@ function executeDataImpl(
 					[inputName]: workflowRunData[currentNode][runIndex].source,
 				};
 			} else {
+				const workflow = getContextWorkflow();
+
 				let previousNodeOutput: number | undefined;
 				// As the node can be connected through either of the outputs find the correct one
 				// and set it to make pairedItem work on not executed nodes

--- a/packages/frontend/editor-ui/src/composables/useWorkflowHelpers.ts
+++ b/packages/frontend/editor-ui/src/composables/useWorkflowHelpers.ts
@@ -15,6 +15,8 @@ import type {
 	INodeParameters,
 	INodeProperties,
 	INodeTypes,
+	IPinData,
+	IRunData,
 	IRunExecutionData,
 	IWebhookDescription,
 	IWorkflowDataProxyAdditionalKeys,
@@ -30,6 +32,7 @@ import {
 
 import type {
 	ICredentialsResponse,
+	IExecutionResponse,
 	INodeTypesMaxCount,
 	INodeUi,
 	IWorkflowDb,
@@ -58,6 +61,7 @@ import { useProjectsStore } from '@/stores/projects.store';
 import { useTagsStore } from '@/stores/tags.store';
 import { useWorkflowsEEStore } from '@/stores/workflows.ee.store';
 import { findWebhook } from '@n8n/rest-api-client/api/webhooks';
+import type { ExpressionLocalResolveContext } from '@/types/expressions';
 
 export type ResolveParameterOptions = {
 	targetItem?: TargetItem;
@@ -71,11 +75,55 @@ export type ResolveParameterOptions = {
 
 export function resolveParameter<T = IDataObject>(
 	parameter: NodeParameterValue | INodeParameters | NodeParameterValue[] | INodeParameters[],
+	opts: ResolveParameterOptions | ExpressionLocalResolveContext = {},
+): T | null {
+	if ('localResolve' in opts && opts.localResolve) {
+		if (opts.nodeName === 'Execution Data') {
+			debugger;
+		}
+		return resolveParameterImpl(
+			parameter,
+			opts.workflow,
+			opts.envVars,
+			opts.workflow.getNode(opts.nodeName),
+			opts.execution,
+			true,
+			opts.workflow.pinData,
+			{
+				inputNodeName: opts.inputNode?.name,
+				inputRunIndex: opts.inputNode?.runIndex,
+				inputBranchIndex: opts.inputNode?.branchIndex,
+				additionalKeys: opts.additionalKeys,
+			},
+		);
+	}
+
+	const workflowsStore = useWorkflowsStore();
+
+	return resolveParameterImpl(
+		parameter,
+		workflowsStore.getCurrentWorkflow(),
+		useEnvironmentsStore().variablesAsObject,
+		useNDVStore().activeNode,
+		workflowsStore.workflowExecutionData,
+		workflowsStore.shouldReplaceInputDataWithPinData,
+		workflowsStore.pinnedWorkflowData,
+		opts,
+	);
+}
+
+// TODO: move to separate file
+function resolveParameterImpl<T = IDataObject>(
+	parameter: NodeParameterValue | INodeParameters | NodeParameterValue[] | INodeParameters[],
+	workflow: Workflow,
+	envVars: Record<string, string | boolean | number>,
+	ndvActiveNode: INodeUi | null,
+	executionData: IExecutionResponse | null,
+	shouldReplaceInputDataWithPinData: boolean,
+	pinData: IPinData | undefined,
 	opts: ResolveParameterOptions = {},
 ): T | null {
 	let itemIndex = opts?.targetItem?.itemIndex || 0;
-
-	const workflow = getCurrentWorkflow();
 
 	const additionalKeys: IWorkflowDataProxyAdditionalKeys = {
 		$execution: {
@@ -84,7 +132,7 @@ export function resolveParameter<T = IDataObject>(
 			resumeUrl: PLACEHOLDER_FILLED_AT_EXECUTION_TIME,
 			resumeFormUrl: PLACEHOLDER_FILLED_AT_EXECUTION_TIME,
 		},
-		$vars: useEnvironmentsStore().variablesAsObject,
+		$vars: envVars,
 
 		// deprecated
 		$executionId: PLACEHOLDER_FILLED_AT_EXECUTION_TIME,
@@ -113,17 +161,15 @@ export function resolveParameter<T = IDataObject>(
 
 	const inputName = NodeConnectionTypes.Main;
 
-	const activeNode =
-		useNDVStore().activeNode ?? useWorkflowsStore().getNodeByName(opts.contextNodeName || '');
+	const activeNode = ndvActiveNode ?? workflow.getNode(opts.contextNodeName || '');
 	let contextNode = activeNode;
 
 	if (activeNode) {
 		contextNode = workflow.getParentMainInputNode(activeNode);
 	}
 
-	const workflowRunData = useWorkflowsStore().getWorkflowRunData;
+	const workflowRunData = executionData?.data?.resultData.runData ?? null;
 	let parentNode = workflow.getParentNodes(contextNode!.name, inputName, 1);
-	const executionData = useWorkflowsStore().getWorkflowExecution;
 
 	let runIndexParent = opts?.inputRunIndex ?? 0;
 	const nodeConnection = workflow.getNodeConnectionIndexes(contextNode!.name, parentNode[0]);
@@ -159,13 +205,26 @@ export function resolveParameter<T = IDataObject>(
 		contextNode!.name,
 		inputName,
 		runIndexParent,
+		workflow,
+		shouldReplaceInputDataWithPinData,
+		pinData,
+		executionData?.data?.resultData.runData ?? null,
 		nodeConnection,
 	);
 
 	if (_connectionInputData === null && contextNode && activeNode?.name !== contextNode.name) {
 		// For Sub-Nodes connected to Trigger-Nodes use the data of the root-node
 		// (Gets for example used by the Memory connected to the Chat-Trigger-Node)
-		const _executeData = executeData([contextNode.name], contextNode.name, inputName, 0);
+		const _executeData = executeDataImpl(
+			[contextNode.name],
+			contextNode.name,
+			inputName,
+			0,
+			workflow,
+			shouldReplaceInputDataWithPinData,
+			pinData,
+			executionData?.data?.resultData.runData ?? null,
+		);
 		_connectionInputData = get(_executeData, ['data', inputName, 0], null);
 	}
 
@@ -206,17 +265,30 @@ export function resolveParameter<T = IDataObject>(
 	) {
 		runIndexCurrent = workflowRunData[contextNode!.name].length - 1;
 	}
-	let _executeData = executeData(
+	let _executeData = executeDataImpl(
 		parentNode,
 		contextNode!.name,
 		inputName,
 		runIndexCurrent,
+		workflow,
+		shouldReplaceInputDataWithPinData,
+		pinData,
+		executionData?.data?.resultData.runData ?? null,
 		runIndexParent,
 	);
 
 	if (!_executeData.source) {
 		// fallback to parent's run index for multi-output case
-		_executeData = executeData(parentNode, contextNode!.name, inputName, runIndexParent);
+		_executeData = executeDataImpl(
+			parentNode,
+			contextNode!.name,
+			inputName,
+			runIndexParent,
+			workflow,
+			shouldReplaceInputDataWithPinData,
+			pinData,
+			executionData?.data?.resultData.runData ?? null,
+		);
 	}
 
 	return workflow.expression.getParameterValue(
@@ -308,16 +380,30 @@ function getNodeTypes(): INodeTypes {
 	return useWorkflowsStore().getNodeTypes();
 }
 
+// TODO: move to separate file
 // Returns connectionInputData to be able to execute an expression.
 function connectionInputData(
 	parentNode: string[],
 	currentNode: string,
 	inputName: string,
 	runIndex: number,
+	workflow: Workflow,
+	shouldReplaceInputDataWithPinData: boolean,
+	pinData: IPinData | undefined,
+	workflowRunData: IRunData | null,
 	nodeConnection: INodeConnection = { sourceIndex: 0, destinationIndex: 0 },
 ): INodeExecutionData[] | null {
 	let connectionInputData: INodeExecutionData[] | null = null;
-	const _executeData = executeData(parentNode, currentNode, inputName, runIndex);
+	const _executeData = executeDataImpl(
+		parentNode,
+		currentNode,
+		inputName,
+		runIndex,
+		workflow,
+		shouldReplaceInputDataWithPinData,
+		pinData,
+		workflowRunData,
+	);
 	if (parentNode.length) {
 		if (
 			!Object.keys(_executeData.data).length ||
@@ -352,6 +438,33 @@ export function executeData(
 	runIndex: number,
 	parentRunIndex?: number,
 ): IExecuteData {
+	const workflowsStore = useWorkflowsStore();
+
+	return executeDataImpl(
+		parentNodes,
+		currentNode,
+		inputName,
+		runIndex,
+		workflowsStore.getCurrentWorkflow(),
+		workflowsStore.shouldReplaceInputDataWithPinData,
+		workflowsStore.pinnedWorkflowData,
+		workflowsStore.getWorkflowRunData,
+		parentRunIndex,
+	);
+}
+
+// TODO: move to separate file
+function executeDataImpl(
+	parentNodes: string[],
+	currentNode: string,
+	inputName: string,
+	runIndex: number,
+	workflow: Workflow,
+	shouldReplaceInputDataWithPinData: boolean,
+	pinData: IPinData | undefined,
+	workflowRunData: IRunData | null,
+	parentRunIndex?: number,
+): IExecuteData {
 	const executeData = {
 		node: {},
 		data: {},
@@ -360,12 +473,10 @@ export function executeData(
 
 	parentRunIndex = parentRunIndex ?? runIndex;
 
-	const workflowsStore = useWorkflowsStore();
-
 	// Find the parent node which has data
 	for (const parentNodeName of parentNodes) {
-		if (workflowsStore.shouldReplaceInputDataWithPinData) {
-			const parentPinData = workflowsStore.pinnedWorkflowData![parentNodeName];
+		if (shouldReplaceInputDataWithPinData) {
+			const parentPinData = pinData?.[parentNodeName];
 
 			// populate `executeData` from `pinData`
 
@@ -378,7 +489,6 @@ export function executeData(
 		}
 
 		// populate `executeData` from `runData`
-		const workflowRunData = workflowsStore.getWorkflowRunData;
 		if (workflowRunData === null) {
 			return executeData;
 		}
@@ -398,8 +508,6 @@ export function executeData(
 					[inputName]: workflowRunData[currentNode][runIndex].source,
 				};
 			} else {
-				const workflow = getCurrentWorkflow();
-
 				let previousNodeOutput: number | undefined;
 				// As the node can be connected through either of the outputs find the correct one
 				// and set it to make pairedItem work on not executed nodes
@@ -739,7 +847,7 @@ export function useWorkflowHelpers() {
 	function resolveExpression(
 		expression: string,
 		siblingParameters: INodeParameters = {},
-		opts: ResolveParameterOptions & { c?: number } = {},
+		opts: ResolveParameterOptions | ExpressionLocalResolveContext = {},
 		stringifyObject = true,
 	) {
 		const parameters = {

--- a/packages/frontend/editor-ui/src/composables/useWorkflowHelpers.ts
+++ b/packages/frontend/editor-ui/src/composables/useWorkflowHelpers.ts
@@ -78,9 +78,6 @@ export function resolveParameter<T = IDataObject>(
 	opts: ResolveParameterOptions | ExpressionLocalResolveContext = {},
 ): T | null {
 	if ('localResolve' in opts && opts.localResolve) {
-		if (opts.nodeName === 'Execution Data') {
-			debugger;
-		}
 		return resolveParameterImpl(
 			parameter,
 			opts.workflow,

--- a/packages/frontend/editor-ui/src/constants.ts
+++ b/packages/frontend/editor-ui/src/constants.ts
@@ -10,7 +10,8 @@ import type {
 	CanvasNodeHandleInjectionData,
 	CanvasNodeInjectionData,
 } from '@/types';
-import type { InjectionKey, Ref } from 'vue';
+import type { ComputedRef, InjectionKey, Ref } from 'vue';
+import type { ExpressionLocalResolveContext } from './types/expressions';
 
 export const MAX_WORKFLOW_SIZE = 1024 * 1024 * 16; // Workflow size limit in bytes
 export const MAX_EXPECTED_REQUEST_SIZE = 2048; // Expected maximum workflow request metadata (i.e. headers) size in bytes
@@ -920,6 +921,9 @@ export const CanvasNodeKey = 'canvasNode' as unknown as InjectionKey<CanvasNodeI
 export const CanvasNodeHandleKey =
 	'canvasNodeHandle' as unknown as InjectionKey<CanvasNodeHandleInjectionData>;
 export const PiPWindowSymbol = 'PiPWindow' as unknown as InjectionKey<Ref<Window | undefined>>;
+export const ExpressionLocalResolveContextSymbol = Symbol(
+	'ExpressionLocalResolveContext',
+) as InjectionKey<ComputedRef<ExpressionLocalResolveContext | undefined>>;
 
 /** Auth */
 export const APP_MODALS_ELEMENT_ID = 'app-modals';

--- a/packages/frontend/editor-ui/src/types/expressions.ts
+++ b/packages/frontend/editor-ui/src/types/expressions.ts
@@ -1,3 +1,6 @@
+import type { Basic, IExecutionResponse } from '@/Interface';
+import type { IWorkflowDataProxyAdditionalKeys, Workflow } from 'n8n-workflow';
+
 type Range = { from: number; to: number };
 
 export type RawSegment = { text: string; token: string } & Range;
@@ -26,4 +29,25 @@ export namespace ColoringStateEffect {
 		kind?: 'plaintext' | 'resolvable';
 		state?: ResolvableState;
 	} & Range;
+}
+
+/**
+ * Collection of data, intended to be sufficient for resolving expressions
+ * in parameter name/value without referencing global state
+ */
+export interface ExpressionLocalResolveContext {
+	localResolve: true;
+	envVars: Record<string, Basic>;
+	additionalKeys: IWorkflowDataProxyAdditionalKeys;
+	workflow: Workflow;
+	execution: IExecutionResponse | null;
+	nodeName: string;
+	/**
+	 * Allowed to be undefined (for trigger node)
+	 */
+	inputNode?: {
+		name: string;
+		runIndex: number;
+		branchIndex: number;
+	};
 }

--- a/packages/frontend/editor-ui/src/types/expressions.ts
+++ b/packages/frontend/editor-ui/src/types/expressions.ts
@@ -43,7 +43,7 @@ export interface ExpressionLocalResolveContext {
 	execution: IExecutionResponse | null;
 	nodeName: string;
 	/**
-	 * Allowed to be undefined (for trigger node)
+	 * Allowed to be undefined (e.g., trigger node, partial execution)
 	 */
 	inputNode?: {
 		name: string;


### PR DESCRIPTION
## Summary

This PR fixes the bug that expressions don't resolve in the experimental embedded NDVs in canvas. Since the embedded NDV is still behind feature flag, the fix is marked as no-changelog.

The solution is implemented as follows:
1. Divide functions for expression resolution in `useWorkflowHelper` into (a) ones that contains logic only and (b) facade function that injects global state into (a)
2. Introduce `ExpressionLocalResolveContext` data type which contains all necessary data to resolve expressions
3. Update facade functions in `useWorkflowHelper` to accept `ExpressionLocalResolveContext` as options
4. Use provide/inject to pass down `ExpressionLocalResolveContext`

## Related Linear tickets, Github issues, and Community forum posts

Part of https://linear.app/n8n/issue/SUG-90/feature-add-data-mapping-to-zoomed-view


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
