### PR TITLE
fix(Google Sheets Node): Make it possible to set cell values empty on updates

### DIFF
--- a/packages/frontend/editor-ui/src/components/ParameterInputList.vue
+++ b/packages/frontend/editor-ui/src/components/ParameterInputList.vue
@@ -607,6 +607,7 @@ const onCalloutDismiss = async (parameter: INodeProperties) => {
 				:path="getPath(parameter.name)"
 				:dependent-parameters-values="getDependentParametersValues(parameter)"
 				:is-read-only="isReadOnly"
+				:is-allow-empty-values="parameter.typeOptions?.resourceMapper?.allowEmptyValues"
 				input-size="small"
 				label-size="small"
 				@value-changed="valueChanged"

--- a/packages/frontend/editor-ui/src/components/ParameterInputList.vue
+++ b/packages/frontend/editor-ui/src/components/ParameterInputList.vue
@@ -607,7 +607,7 @@ const onCalloutDismiss = async (parameter: INodeProperties) => {
 				:path="getPath(parameter.name)"
 				:dependent-parameters-values="getDependentParametersValues(parameter)"
 				:is-read-only="isReadOnly"
-				:is-allow-empty-values="parameter.typeOptions?.resourceMapper?.allowEmptyValues"
+				:allow-empty-strings="parameter.typeOptions?.resourceMapper?.allowEmptyValues"
 				input-size="small"
 				label-size="small"
 				@value-changed="valueChanged"

--- a/packages/frontend/editor-ui/src/components/ResourceMapper/ResourceMapper.vue
+++ b/packages/frontend/editor-ui/src/components/ResourceMapper/ResourceMapper.vue
@@ -40,7 +40,7 @@ type Props = {
 	teleported?: boolean;
 	dependentParametersValues?: string | null;
 	isReadOnly?: boolean;
-	isAllowEmptyValues?: boolean;
+	allowEmptyStrings?: boolean;
 };
 
 const nodeTypesStore = useNodeTypesStore();
@@ -51,7 +51,7 @@ const props = withDefaults(defineProps<Props>(), {
 	teleported: true,
 	dependentParametersValues: null,
 	isReadOnly: false,
-	isAllowEmptyValues: false,
+	allowEmptyStrings: false,
 });
 
 const { onDocumentVisible } = useDocumentVisibility();
@@ -439,7 +439,7 @@ function fieldValueChanged(updateInfo: IUpdateInformation): void {
 	if (
 		updateInfo.value !== undefined &&
 		updateInfo.value !== null &&
-		(props.isAllowEmptyValues || updateInfo.value !== '') &&
+		(props.allowEmptyStrings || updateInfo.value !== '') &&
 		isResourceMapperValue(updateInfo.value)
 	) {
 		newValue = updateInfo.value;

--- a/packages/frontend/editor-ui/src/components/ResourceMapper/ResourceMapper.vue
+++ b/packages/frontend/editor-ui/src/components/ResourceMapper/ResourceMapper.vue
@@ -40,6 +40,7 @@ type Props = {
 	teleported?: boolean;
 	dependentParametersValues?: string | null;
 	isReadOnly?: boolean;
+	isAllowEmptyValues?: boolean;
 };
 
 const nodeTypesStore = useNodeTypesStore();
@@ -50,6 +51,7 @@ const props = withDefaults(defineProps<Props>(), {
 	teleported: true,
 	dependentParametersValues: null,
 	isReadOnly: false,
+	isAllowEmptyValues: false,
 });
 
 const { onDocumentVisible } = useDocumentVisibility();
@@ -436,8 +438,8 @@ function fieldValueChanged(updateInfo: IUpdateInformation): void {
 	let newValue = null;
 	if (
 		updateInfo.value !== undefined &&
-		updateInfo.value !== '' &&
 		updateInfo.value !== null &&
+		(props.isAllowEmptyValues || updateInfo.value !== '') &&
 		isResourceMapperValue(updateInfo.value)
 	) {
 		newValue = updateInfo.value;

--- a/packages/nodes-base/nodes/Google/Sheet/GoogleSheets.node.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/GoogleSheets.node.ts
@@ -11,7 +11,7 @@ export class GoogleSheets extends VersionedNodeType {
 			name: 'googleSheets',
 			icon: 'file:googleSheets.svg',
 			group: ['input', 'output'],
-			defaultVersion: 4.6,
+			defaultVersion: 4.7,
 			subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
 			description: 'Read, update and write data to Google Sheets',
 		};
@@ -27,6 +27,7 @@ export class GoogleSheets extends VersionedNodeType {
 			4.4: new GoogleSheetsV2(baseDescription),
 			4.5: new GoogleSheetsV2(baseDescription),
 			4.6: new GoogleSheetsV2(baseDescription),
+			4.7: new GoogleSheetsV2(baseDescription),
 		};
 
 		super(nodeVersions, baseDescription);

--- a/packages/nodes-base/nodes/Google/Sheet/test/v2/node/appendOrUpdate.test.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/test/v2/node/appendOrUpdate.test.ts
@@ -120,24 +120,22 @@ describe('Google Sheet - Append or Update v4.6 vs v4.7 Behavior', () => {
 			},
 		]);
 
-		mockExecuteFunctions.getNodeParameter.mockImplementation(
-			(parameterName: string, itemIndex?: number) => {
-				const params: { [key: string]: any } = {
-					'options.cellFormat': 'USER_ENTERED',
-					options: {},
-					'columns.mappingMode': 'defineBelow',
-					'columns.schema': [],
-					'columns.matchingColumns': ['id'],
-					'columns.value': {
-						id: 1,
-						name: 'John',
-						// email field is NOT present here because user typed '' in UI
-						// and v4.6 frontend filtered it out (allowEmptyValues: false)
-					},
-				};
-				return params[parameterName];
-			},
-		);
+		mockExecuteFunctions.getNodeParameter.mockImplementation((parameterName: string) => {
+			const params: { [key: string]: any } = {
+				'options.cellFormat': 'USER_ENTERED',
+				options: {},
+				'columns.mappingMode': 'defineBelow',
+				'columns.schema': [],
+				'columns.matchingColumns': ['id'],
+				'columns.value': {
+					id: 1,
+					name: 'John',
+					// email field is NOT present here because user typed '' in UI
+					// and v4.6 frontend filtered it out (allowEmptyValues: false)
+				},
+			};
+			return params[parameterName];
+		});
 
 		mockGoogleSheet.getData.mockResolvedValueOnce([
 			['id', 'name', 'email'],
@@ -192,23 +190,21 @@ describe('Google Sheet - Append or Update v4.6 vs v4.7 Behavior', () => {
 			},
 		]);
 
-		mockExecuteFunctions.getNodeParameter.mockImplementation(
-			(parameterName: string, itemIndex?: number) => {
-				const params: { [key: string]: any } = {
-					'options.cellFormat': 'USER_ENTERED',
-					options: {},
-					'columns.mappingMode': 'defineBelow',
-					'columns.schema': [],
-					'columns.matchingColumns': ['id'],
-					'columns.value': {
-						id: 1,
-						name: 'John',
-						email: '', // Empty string is preserved in v4.7 (allowEmptyValues: true)
-					},
-				};
-				return params[parameterName];
-			},
-		);
+		mockExecuteFunctions.getNodeParameter.mockImplementation((parameterName: string) => {
+			const params: { [key: string]: any } = {
+				'options.cellFormat': 'USER_ENTERED',
+				options: {},
+				'columns.mappingMode': 'defineBelow',
+				'columns.schema': [],
+				'columns.matchingColumns': ['id'],
+				'columns.value': {
+					id: 1,
+					name: 'John',
+					email: '', // Empty string is preserved in v4.7 (allowEmptyValues: true)
+				},
+			};
+			return params[parameterName];
+		});
 
 		mockGoogleSheet.getData.mockResolvedValueOnce([
 			['id', 'name', 'email'],

--- a/packages/nodes-base/nodes/Google/Sheet/test/v2/node/appendOrUpdate.test.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/test/v2/node/appendOrUpdate.test.ts
@@ -96,3 +96,155 @@ describe('Google Sheet - Append or Update', () => {
 		});
 	});
 });
+
+describe('Google Sheet - Append or Update v4.6 vs v4.7 Behavior', () => {
+	let mockExecuteFunctions: MockProxy<IExecuteFunctions>;
+	let mockGoogleSheet: MockProxy<GoogleSheet>;
+
+	afterEach(() => {
+		jest.resetAllMocks();
+	});
+
+	it('v4.6: empty string in UI gets filtered out, field not sent to backend', async () => {
+		mockExecuteFunctions = mock<IExecuteFunctions>();
+		mockGoogleSheet = mock<GoogleSheet>();
+
+		mockExecuteFunctions.getNode
+			.mockReturnValueOnce(mock<INode>({ typeVersion: 4.6 }))
+			.mockReturnValueOnce(mock<INode>({ typeVersion: 4.6 }));
+
+		mockExecuteFunctions.getInputData.mockReturnValueOnce([
+			{
+				json: {},
+				pairedItem: { item: 0, input: undefined },
+			},
+		]);
+
+		mockExecuteFunctions.getNodeParameter.mockImplementation(
+			(parameterName: string, itemIndex?: number) => {
+				const params: { [key: string]: any } = {
+					'options.cellFormat': 'USER_ENTERED',
+					options: {},
+					'columns.mappingMode': 'defineBelow',
+					'columns.schema': [],
+					'columns.matchingColumns': ['id'],
+					'columns.value': {
+						id: 1,
+						name: 'John',
+						// email field is NOT present here because user typed '' in UI
+						// and v4.6 frontend filtered it out (allowEmptyValues: false)
+					},
+				};
+				return params[parameterName];
+			},
+		);
+
+		mockGoogleSheet.getData.mockResolvedValueOnce([
+			['id', 'name', 'email'],
+			['1', 'Old Name', 'old@email.com'],
+		]);
+
+		mockGoogleSheet.getColumnValues.mockResolvedValueOnce(['1']);
+		mockGoogleSheet.updateRows.mockResolvedValueOnce([]);
+
+		mockGoogleSheet.prepareDataForUpdateOrUpsert.mockResolvedValueOnce({
+			updateData: [],
+			appendData: [
+				{
+					id: 1,
+					name: 'John',
+					// email is not included, so it keeps old value
+				},
+			],
+		});
+
+		mockGoogleSheet.appendEmptyRowsOrColumns.mockResolvedValueOnce([]);
+		mockGoogleSheet.appendSheetData.mockResolvedValueOnce([]);
+
+		await execute.call(mockExecuteFunctions, mockGoogleSheet, 'Sheet1', '1234');
+
+		// v4.6: Only fields with non-empty values are sent to prepareDataForUpdateOrUpsert
+		expect(mockGoogleSheet.prepareDataForUpdateOrUpsert).toHaveBeenCalledWith(
+			expect.objectContaining({
+				inputData: [
+					{
+						id: 1,
+						name: 'John',
+						// email is NOT in the inputData, so cell keeps old value
+					},
+				],
+			}),
+		);
+	});
+
+	it('v4.7: empty string in UI is preserved and sent to backend to clear cell', async () => {
+		mockExecuteFunctions = mock<IExecuteFunctions>();
+		mockGoogleSheet = mock<GoogleSheet>();
+
+		mockExecuteFunctions.getNode
+			.mockReturnValueOnce(mock<INode>({ typeVersion: 4.7 }))
+			.mockReturnValueOnce(mock<INode>({ typeVersion: 4.7 }));
+
+		mockExecuteFunctions.getInputData.mockReturnValueOnce([
+			{
+				json: {},
+				pairedItem: { item: 0, input: undefined },
+			},
+		]);
+
+		mockExecuteFunctions.getNodeParameter.mockImplementation(
+			(parameterName: string, itemIndex?: number) => {
+				const params: { [key: string]: any } = {
+					'options.cellFormat': 'USER_ENTERED',
+					options: {},
+					'columns.mappingMode': 'defineBelow',
+					'columns.schema': [],
+					'columns.matchingColumns': ['id'],
+					'columns.value': {
+						id: 1,
+						name: 'John',
+						email: '', // Empty string is preserved in v4.7 (allowEmptyValues: true)
+					},
+				};
+				return params[parameterName];
+			},
+		);
+
+		mockGoogleSheet.getData.mockResolvedValueOnce([
+			['id', 'name', 'email'],
+			['1', 'Old Name', 'old@email.com'],
+		]);
+
+		mockGoogleSheet.getColumnValues.mockResolvedValueOnce(['1']);
+		mockGoogleSheet.updateRows.mockResolvedValueOnce([]);
+
+		mockGoogleSheet.prepareDataForUpdateOrUpsert.mockResolvedValueOnce({
+			updateData: [],
+			appendData: [
+				{
+					id: 1,
+					name: 'John',
+					email: '', // Empty string will clear the cell
+				},
+			],
+		});
+
+		mockGoogleSheet.appendEmptyRowsOrColumns.mockResolvedValueOnce([]);
+		mockGoogleSheet.appendSheetData.mockResolvedValueOnce([]);
+
+		await execute.call(mockExecuteFunctions, mockGoogleSheet, 'Sheet1', '1234');
+
+		// v4.7: Empty strings are preserved and sent to prepareDataForUpdateOrUpsert
+		expect(mockGoogleSheet.prepareDataForUpdateOrUpsert).toHaveBeenCalledWith(
+			expect.objectContaining({
+				inputData: [
+					{
+						id: 1,
+						name: 'John',
+						email: '', // Empty string is preserved and will clear the cell
+					},
+				],
+			}),
+		);
+	});
+});

--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/appendOrUpdate.operation.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/appendOrUpdate.operation.ts
@@ -182,13 +182,48 @@ export const description: SheetProperties = [
 				},
 				addAllFields: true,
 				multiKeyMatch: false,
+				allowEmptyValues: true,
 			},
 		},
 		displayOptions: {
 			show: {
 				resource: ['sheet'],
 				operation: ['appendOrUpdate'],
-				'@version': [{ _cnd: { gte: 4 } }],
+				'@version': [{ _cnd: { gte: 4.7 } }],
+			},
+			hide: {
+				...untilSheetSelected,
+			},
+		},
+	},
+	{
+		displayName: 'Columns',
+		name: 'columns',
+		type: 'resourceMapper',
+		noDataExpression: true,
+		default: {
+			mappingMode: 'defineBelow',
+			value: null,
+		},
+		required: true,
+		typeOptions: {
+			loadOptionsDependsOn: ['sheetName.value'],
+			resourceMapper: {
+				resourceMapperMethod: 'getMappingColumns',
+				mode: 'upsert',
+				fieldWords: {
+					singular: 'column',
+					plural: 'columns',
+				},
+				addAllFields: true,
+				multiKeyMatch: false,
+			},
+		},
+		displayOptions: {
+			show: {
+				resource: ['sheet'],
+				operation: ['appendOrUpdate'],
+				'@version': [{ _cnd: { between: { from: 4, to: 4.6 } } }],
 			},
 			hide: {
 				...untilSheetSelected,

--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/update.operation.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/update.operation.ts
@@ -168,13 +168,48 @@ export const description: SheetProperties = [
 				},
 				addAllFields: true,
 				multiKeyMatch: false,
+				allowEmptyValues: true,
 			},
 		},
 		displayOptions: {
 			show: {
 				resource: ['sheet'],
 				operation: ['update'],
-				'@version': [{ _cnd: { gte: 4 } }],
+				'@version': [{ _cnd: { gte: 4.7 } }],
+			},
+			hide: {
+				...untilSheetSelected,
+			},
+		},
+	},
+	{
+		displayName: 'Columns',
+		name: 'columns',
+		type: 'resourceMapper',
+		noDataExpression: true,
+		default: {
+			mappingMode: 'defineBelow',
+			value: null,
+		},
+		required: true,
+		typeOptions: {
+			loadOptionsDependsOn: ['sheetName.value'],
+			resourceMapper: {
+				resourceMapperMethod: 'getMappingColumns',
+				mode: 'update',
+				fieldWords: {
+					singular: 'column',
+					plural: 'columns',
+				},
+				addAllFields: true,
+				multiKeyMatch: false,
+			},
+		},
+		displayOptions: {
+			show: {
+				resource: ['sheet'],
+				operation: ['update'],
+				'@version': [{ _cnd: { between: { from: 4, to: 4.6 } } }],
 			},
 			hide: {
 				...untilSheetSelected,

--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/versionDescription.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/versionDescription.ts
@@ -28,7 +28,7 @@ export const versionDescription: INodeTypeDescription = {
 	name: 'googleSheets',
 	icon: 'file:googleSheets.svg',
 	group: ['input', 'output'],
-	version: [3, 4, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6],
+	version: [3, 4, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7],
 	subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
 	description: 'Read, update and write data to Google Sheets',
 	defaults: {

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1364,6 +1364,7 @@ export interface ResourceMapperTypeOptionsBase {
 		hint?: string;
 	};
 	showTypeConversionOptions?: boolean;
+	allowEmptyValues?: boolean;
 }
 
 // Enforce at least one of resourceMapperMethod or localResourceMapperMethod


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/7a076c6a-9194-4a33-bfc6-b24a5a9531e9

On current <=4.6 versions of the Google Sheets Node `n8n-nodes-base.googleSheets` it isn't possible to update cells' value back to empty using the `Update Row` or `Append or Update Row` operations, like one would expect.

This PR makes that possible by adding a new optional type option to Resouce Mapper Component (RMC), currently named `allowEmptyValues`. If node wishes to use `resourceMapper` but still accept empty strings as valid values (instead of skipping them) the node can opt in to this behaviour by enabling the flag on its property definition.

<img width="436" height="448" alt="image" src="https://github.com/user-attachments/assets/c5fedf5d-4ae2-4be6-a796-779bebd9780d" />

I've now enabled this for the update and appendOrUpdate operations, and created a new 4.7 version of the Google Sheets Node with that enabled to avoid breaking changes to existing workflows.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3584/bug-google-sheets-cant-set-cell-to-empty

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
