### PR TITLE
fix: Track responseMode and public chat in node graph (no-changelog)

### DIFF
--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2617,12 +2617,13 @@ export interface INodeGraphItem {
 	src_node_id?: string;
 	src_instance_id?: string;
 	agent?: string; //@n8n/n8n-nodes-langchain.agent
+	is_streaming?: boolean; //@n8n/n8n-nodes-langchain.agent
 	prompts?: IDataObject[] | IDataObject; //ai node's prompts, cloud only
 	toolSettings?: IDataObject; //various langchain tool's settings
 	sql?: string; //merge node combineBySql, cloud only
 	workflow_id?: string; //@n8n/n8n-nodes-langchain.toolWorkflow and n8n-nodes-base.executeWorkflow
-	response_mode?: string; // Webhook and Chat Trigger node response mode
-	public_chat?: boolean; // Chat Trigger node public setting
+	response_mode?: string; // @n8n/n8n-nodes-langchain.chatTrigger, n8n-nodes-base.webhook selected response mode
+	public_chat?: boolean; // @n8n/n8n-nodes-langchain.chatTrigger
 	runs?: number;
 	items_total?: number;
 	metric_names?: string[];

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2621,6 +2621,8 @@ export interface INodeGraphItem {
 	toolSettings?: IDataObject; //various langchain tool's settings
 	sql?: string; //merge node combineBySql, cloud only
 	workflow_id?: string; //@n8n/n8n-nodes-langchain.toolWorkflow and n8n-nodes-base.executeWorkflow
+	response_mode?: WebhookResponseMode; // Webhook and Chat Trigger node response mode
+	public_chat?: boolean; // Chat Trigger node public setting
 	runs?: number;
 	items_total?: number;
 	metric_names?: string[];

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2621,7 +2621,7 @@ export interface INodeGraphItem {
 	toolSettings?: IDataObject; //various langchain tool's settings
 	sql?: string; //merge node combineBySql, cloud only
 	workflow_id?: string; //@n8n/n8n-nodes-langchain.toolWorkflow and n8n-nodes-base.executeWorkflow
-	response_mode?: WebhookResponseMode; // Webhook and Chat Trigger node response mode
+	response_mode?: string; // Webhook and Chat Trigger node response mode
 	public_chat?: boolean; // Chat Trigger node public setting
 	runs?: number;
 	items_total?: number;

--- a/packages/workflow/src/telemetry-helpers.ts
+++ b/packages/workflow/src/telemetry-helpers.ts
@@ -257,7 +257,7 @@ export function generateNodesGraph(
 			nodeItem.agent = (node.parameters.agent as string) ?? 'toolsAgent';
 
 			if (node.typeVersion >= 2.1) {
-				const options = node.parameters?.options as IDataObject;
+				const options = node.parameters?.options;
 				if (options?.['enableStreaming'] === false) {
 					nodeItem.is_streaming = false;
 				} else {
@@ -375,11 +375,16 @@ export function generateNodesGraph(
 			}
 		} else if (node.type === WEBHOOK_NODE_TYPE) {
 			webhookNodeNames.push(node.name);
-			nodeItem.response_mode = (node.parameters?.responseMode as string) ?? 'onReceived';
+			const responseMode = node.parameters?.responseMode;
+			nodeItem.response_mode = typeof responseMode === 'string' ? responseMode : 'onReceived';
 		} else if (node.type === CHAT_TRIGGER_NODE_TYPE) {
 			// Capture streaming response mode parameter
-			const options = node.parameters?.options as IDataObject;
-			if (options && typeof options.responseMode === 'string') {
+			const options = node.parameters?.options;
+			if (
+				typeof options === 'object' &&
+				'responseMode' in options &&
+				typeof options.responseMode === 'string'
+			) {
 				nodeItem.response_mode = options.responseMode;
 			}
 			// Capture public chat setting

--- a/packages/workflow/src/telemetry-helpers.ts
+++ b/packages/workflow/src/telemetry-helpers.ts
@@ -3,6 +3,7 @@ import {
 	AI_TRANSFORM_NODE_TYPE,
 	CHAIN_LLM_LANGCHAIN_NODE_TYPE,
 	CHAIN_SUMMARIZATION_LANGCHAIN_NODE_TYPE,
+	CHAT_TRIGGER_NODE_TYPE,
 	EVALUATION_NODE_TYPE,
 	EVALUATION_TRIGGER_NODE_TYPE,
 	EXECUTE_WORKFLOW_NODE_TYPE,
@@ -365,6 +366,18 @@ export function generateNodesGraph(
 			}
 		} else if (node.type === WEBHOOK_NODE_TYPE) {
 			webhookNodeNames.push(node.name);
+			nodeItem.response_mode = (node.parameters?.responseMode as string) ?? 'onReceived';
+		} else if (node.type === CHAT_TRIGGER_NODE_TYPE) {
+			// Capture streaming response mode parameter
+			const options = node.parameters?.options as IDataObject;
+			if (options && typeof options.responseMode === 'string') {
+				nodeItem.response_mode = options.responseMode;
+			}
+			// Capture public chat setting
+			const isPublic = node.parameters?.public;
+			if (typeof isPublic === 'boolean') {
+				nodeItem.public_chat = isPublic;
+			}
 		} else if (
 			node.type === EXECUTE_WORKFLOW_NODE_TYPE ||
 			node.type === WORKFLOW_TOOL_LANGCHAIN_NODE_TYPE

--- a/packages/workflow/src/telemetry-helpers.ts
+++ b/packages/workflow/src/telemetry-helpers.ts
@@ -260,6 +260,7 @@ export function generateNodesGraph(
 				const options = node.parameters?.options;
 				if (
 					typeof options === 'object' &&
+					options &&
 					'enableStreaming' in options &&
 					options.enableStreaming === false
 				) {
@@ -386,6 +387,7 @@ export function generateNodesGraph(
 			const options = node.parameters?.options;
 			if (
 				typeof options === 'object' &&
+				options &&
 				'responseMode' in options &&
 				typeof options.responseMode === 'string'
 			) {

--- a/packages/workflow/src/telemetry-helpers.ts
+++ b/packages/workflow/src/telemetry-helpers.ts
@@ -258,7 +258,11 @@ export function generateNodesGraph(
 
 			if (node.typeVersion >= 2.1) {
 				const options = node.parameters?.options;
-				if (options?.['enableStreaming'] === false) {
+				if (
+					typeof options === 'object' &&
+					'enableStreaming' in options &&
+					options.enableStreaming === false
+				) {
 					nodeItem.is_streaming = false;
 				} else {
 					nodeItem.is_streaming = true;

--- a/packages/workflow/src/telemetry-helpers.ts
+++ b/packages/workflow/src/telemetry-helpers.ts
@@ -255,6 +255,15 @@ export function generateNodesGraph(
 			nodeItem.prompts = { instructions: node.parameters.instructions as string };
 		} else if (node.type === AGENT_LANGCHAIN_NODE_TYPE) {
 			nodeItem.agent = (node.parameters.agent as string) ?? 'toolsAgent';
+
+			if (node.typeVersion >= 2.1) {
+				const options = node.parameters?.options as IDataObject;
+				if (options?.['enableStreaming'] === false) {
+					nodeItem.is_streaming = false;
+				} else {
+					nodeItem.is_streaming = true;
+				}
+			}
 		} else if (node.type === MERGE_NODE_TYPE) {
 			nodeItem.operation = node.parameters.mode as string;
 

--- a/packages/workflow/test/telemetry-helpers.test.ts
+++ b/packages/workflow/test/telemetry-helpers.test.ts
@@ -2389,6 +2389,79 @@ describe('extractLastExecutedNodeStructuredOutputErrorInfo', () => {
 		});
 	});
 
+	it('should capture Agent node streaming parameters', () => {
+		const workflow: Partial<IWorkflowBase> = {
+			nodes: [
+				{
+					parameters: {
+						agent: 'toolsAgent',
+						options: {
+							enableStreaming: false,
+						},
+					},
+					id: 'agent-id-streaming-disabled',
+					name: 'Agent with streaming disabled',
+					type: '@n8n/n8n-nodes-langchain.agent',
+					typeVersion: 2.1,
+					position: [100, 100],
+				},
+				{
+					parameters: {
+						agent: 'conversationalAgent',
+						options: {
+							enableStreaming: true,
+						},
+					},
+					id: 'agent-id-streaming-enabled',
+					name: 'Agent with streaming enabled',
+					type: '@n8n/n8n-nodes-langchain.agent',
+					typeVersion: 2.1,
+					position: [300, 100],
+				},
+				{
+					parameters: {
+						agent: 'openAiFunctionsAgent',
+					},
+					id: 'agent-id-default-streaming',
+					name: 'Agent with default streaming',
+					type: '@n8n/n8n-nodes-langchain.agent',
+					typeVersion: 2.1,
+					position: [500, 100],
+				},
+			],
+			connections: {},
+		};
+
+		const result = generateNodesGraph(workflow, nodeTypes);
+
+		expect(result.nodeGraph.nodes['0']).toEqual({
+			id: 'agent-id-streaming-disabled',
+			type: '@n8n/n8n-nodes-langchain.agent',
+			version: 2.1,
+			position: [100, 100],
+			agent: 'toolsAgent',
+			is_streaming: false,
+		});
+
+		expect(result.nodeGraph.nodes['1']).toEqual({
+			id: 'agent-id-streaming-enabled',
+			type: '@n8n/n8n-nodes-langchain.agent',
+			version: 2.1,
+			position: [300, 100],
+			agent: 'conversationalAgent',
+			is_streaming: true,
+		});
+
+		expect(result.nodeGraph.nodes['2']).toEqual({
+			id: 'agent-id-default-streaming',
+			type: '@n8n/n8n-nodes-langchain.agent',
+			version: 2.1,
+			position: [500, 100],
+			agent: 'openAiFunctionsAgent',
+			is_streaming: true,
+		});
+	});
+
 	it('should capture Chat Trigger node streaming parameters', () => {
 		const workflow: Partial<IWorkflowBase> = {
 			nodes: [

--- a/packages/workflow/test/telemetry-helpers.test.ts
+++ b/packages/workflow/test/telemetry-helpers.test.ts
@@ -500,6 +500,7 @@ describe('generateNodesGraph', () => {
 						type: 'n8n-nodes-base.webhook',
 						version: 1.1,
 						position: [520, 380],
+						response_mode: 'onReceived',
 					},
 				},
 				notes: {},
@@ -2385,6 +2386,60 @@ describe('extractLastExecutedNodeStructuredOutputErrorInfo', () => {
 		expect(result).toEqual({
 			num_tools: 0,
 			model_name: 'gemini-1.5-pro',
+		});
+	});
+
+	it('should capture Chat Trigger node streaming parameters', () => {
+		const workflow: Partial<IWorkflowBase> = {
+			nodes: [
+				{
+					parameters: {
+						public: true,
+						options: {
+							responseMode: 'streaming',
+						},
+					},
+					id: 'chat-trigger-id',
+					name: 'Chat Trigger',
+					type: '@n8n/n8n-nodes-langchain.chatTrigger',
+					typeVersion: 1,
+					position: [100, 100],
+				},
+				{
+					parameters: {
+						public: false,
+						options: {
+							responseMode: 'lastNode',
+						},
+					},
+					id: 'chat-trigger-id-2',
+					name: 'Chat Trigger 2',
+					type: '@n8n/n8n-nodes-langchain.chatTrigger',
+					typeVersion: 1,
+					position: [300, 100],
+				},
+			],
+			connections: {},
+		};
+
+		const result = generateNodesGraph(workflow, nodeTypes);
+
+		expect(result.nodeGraph.nodes['0']).toEqual({
+			id: 'chat-trigger-id',
+			type: '@n8n/n8n-nodes-langchain.chatTrigger',
+			version: 1,
+			position: [100, 100],
+			response_mode: 'streaming',
+			public_chat: true,
+		});
+
+		expect(result.nodeGraph.nodes['1']).toEqual({
+			id: 'chat-trigger-id-2',
+			type: '@n8n/n8n-nodes-langchain.chatTrigger',
+			version: 1,
+			position: [300, 100],
+			response_mode: 'lastNode',
+			public_chat: false,
 		});
 	});
 });


### PR DESCRIPTION
## Summary
This PR adds telemetry attributes for:
- the response mode set on ChatTrigger and Webhook nodes
- wether or not the public chat is enabled on ChatTrigger 
- whether streaming is enabled on agents to the existing node graph.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-1128/feature-make-sure-we-know-how-much-streaming-is-used-ie-send-telemetry

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
