### PR TITLE
refactor: Simplify webhook helpers

### DIFF
--- a/packages/cli/src/webhooks/__tests__/webhook-last-node-response-extractor.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-last-node-response-extractor.test.ts
@@ -70,7 +70,7 @@ describe('extractWebhookLastNodeResponse', () => {
 			expect(result).toEqual({
 				ok: true,
 				result: {
-					type: 'nonstream',
+					type: 'static',
 					body: jsonData,
 					contentType: undefined,
 				},
@@ -120,7 +120,7 @@ describe('extractWebhookLastNodeResponse', () => {
 			expect(result).toEqual({
 				ok: true,
 				result: {
-					type: 'nonstream',
+					type: 'static',
 					body: 'test',
 					contentType: undefined,
 				},
@@ -151,7 +151,7 @@ describe('extractWebhookLastNodeResponse', () => {
 			expect(result).toEqual({
 				ok: true,
 				result: {
-					type: 'nonstream',
+					type: 'static',
 					body: jsonData,
 					contentType: 'application/xml',
 				},
@@ -189,7 +189,7 @@ describe('extractWebhookLastNodeResponse', () => {
 			expect(result).toEqual({
 				ok: true,
 				result: {
-					type: 'nonstream',
+					type: 'static',
 					body: Buffer.from('test binary data'),
 					contentType: 'text/plain',
 				},
@@ -378,7 +378,7 @@ describe('extractWebhookLastNodeResponse', () => {
 			expect(result).toEqual({
 				ok: true,
 				result: {
-					type: 'nonstream',
+					type: 'static',
 					body: undefined,
 					contentType: undefined,
 				},
@@ -408,7 +408,7 @@ describe('extractWebhookLastNodeResponse', () => {
 			expect(result).toEqual({
 				ok: true,
 				result: {
-					type: 'nonstream',
+					type: 'static',
 					body: [jsonData1, jsonData2, jsonData3],
 					contentType: undefined,
 				},
@@ -433,7 +433,7 @@ describe('extractWebhookLastNodeResponse', () => {
 			expect(result).toEqual({
 				ok: true,
 				result: {
-					type: 'nonstream',
+					type: 'static',
 					body: [],
 					contentType: undefined,
 				},

--- a/packages/cli/src/webhooks/__tests__/webhook-last-node-response-extractor.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-last-node-response-extractor.test.ts
@@ -18,32 +18,32 @@ import { Readable } from 'node:stream';
 import { extractWebhookLastNodeResponse } from '../webhook-last-node-response-extractor';
 
 describe('extractWebhookLastNodeResponse', () => {
-	let mockWorkflow: MockProxy<Workflow>;
-	let mockWorkflowStartNode: MockProxy<INode>;
-	let mockWebhookData: MockProxy<IWebhookData>;
-	let mockLastNodeRunData: MockProxy<ITaskData>;
-	let mockBinaryDataService: MockProxy<BinaryDataService>;
-	let mockAdditionalKeys: MockProxy<IWorkflowDataProxyAdditionalKeys>;
+	let workflow: MockProxy<Workflow>;
+	let workflowStartNode: MockProxy<INode>;
+	let webhookData: MockProxy<IWebhookData>;
+	let lastNodeRunData: MockProxy<ITaskData>;
+	let binaryDataService: MockProxy<BinaryDataService>;
+	let additionalKeys: MockProxy<IWorkflowDataProxyAdditionalKeys>;
 
 	beforeEach(() => {
-		mockWorkflow = mock<Workflow>();
-		mockWorkflowStartNode = mock<INode>();
-		mockWebhookData = mock<IWebhookData>({
+		workflow = mock<Workflow>();
+		workflowStartNode = mock<INode>();
+		webhookData = mock<IWebhookData>({
 			webhookDescription: {
 				responsePropertyName: undefined,
 				responseContentType: undefined,
 				responseBinaryPropertyName: undefined,
 			},
 		});
-		mockLastNodeRunData = mock<ITaskData>();
-		mockBinaryDataService = mock<BinaryDataService>();
-		mockAdditionalKeys = mock<IWorkflowDataProxyAdditionalKeys>();
+		lastNodeRunData = mock<ITaskData>();
+		binaryDataService = mock<BinaryDataService>();
+		additionalKeys = mock<IWorkflowDataProxyAdditionalKeys>();
 
-		mockWorkflow.expression = mock<Expression>({
+		workflow.expression = mock<Expression>({
 			getSimpleParameterValue: jest.fn(),
 		});
 
-		Container.set(BinaryDataService, mockBinaryDataService);
+		Container.set(BinaryDataService, binaryDataService);
 	});
 
 	afterEach(() => {
@@ -53,18 +53,18 @@ describe('extractWebhookLastNodeResponse', () => {
 	describe('responseDataType: firstEntryJson', () => {
 		it('should return first entry JSON data', async () => {
 			const jsonData = { foo: 'bar', test: 123 };
-			mockLastNodeRunData.data = {
+			lastNodeRunData.data = {
 				main: [[{ json: jsonData }]],
 			};
 
 			const result = await extractWebhookLastNodeResponse(
 				'firstEntryJson',
-				mockLastNodeRunData,
-				mockWorkflow,
-				mockWorkflowStartNode,
-				mockWebhookData,
+				lastNodeRunData,
+				workflow,
+				workflowStartNode,
+				webhookData,
 				'manual',
-				mockAdditionalKeys,
+				additionalKeys,
 			);
 
 			expect(result).toEqual({
@@ -78,18 +78,18 @@ describe('extractWebhookLastNodeResponse', () => {
 		});
 
 		it('should return error when no item to return', async () => {
-			mockLastNodeRunData.data = {
+			lastNodeRunData.data = {
 				main: [[]],
 			};
 
 			const result = await extractWebhookLastNodeResponse(
 				'firstEntryJson',
-				mockLastNodeRunData,
-				mockWorkflow,
-				mockWorkflowStartNode,
-				mockWebhookData,
+				lastNodeRunData,
+				workflow,
+				workflowStartNode,
+				webhookData,
 				'manual',
-				mockAdditionalKeys,
+				additionalKeys,
 			);
 
 			assert(!result.ok);
@@ -98,23 +98,23 @@ describe('extractWebhookLastNodeResponse', () => {
 
 		it('should extract specific property when responsePropertyName is set', async () => {
 			const jsonData = { foo: 'bar', nested: { value: 'test' } };
-			mockLastNodeRunData.data = {
+			lastNodeRunData.data = {
 				main: [[{ json: jsonData }]],
 			};
 
-			mockWebhookData.webhookDescription.responsePropertyName = 'nested.value';
-			(mockWorkflow.expression.getSimpleParameterValue as jest.Mock)
+			webhookData.webhookDescription.responsePropertyName = 'nested.value';
+			(workflow.expression.getSimpleParameterValue as jest.Mock)
 				.mockReturnValueOnce('nested.value')
 				.mockReturnValueOnce(undefined);
 
 			const result = await extractWebhookLastNodeResponse(
 				'firstEntryJson',
-				mockLastNodeRunData,
-				mockWorkflow,
-				mockWorkflowStartNode,
-				mockWebhookData,
+				lastNodeRunData,
+				workflow,
+				workflowStartNode,
+				webhookData,
 				'manual',
-				mockAdditionalKeys,
+				additionalKeys,
 			);
 
 			expect(result).toEqual({
@@ -129,23 +129,23 @@ describe('extractWebhookLastNodeResponse', () => {
 
 		it('should set content type when responseContentType is provided', async () => {
 			const jsonData = { foo: 'bar' };
-			mockLastNodeRunData.data = {
+			lastNodeRunData.data = {
 				main: [[{ json: jsonData }]],
 			};
 
-			mockWebhookData.webhookDescription.responseContentType = 'application/xml';
-			(mockWorkflow.expression.getSimpleParameterValue as jest.Mock)
+			webhookData.webhookDescription.responseContentType = 'application/xml';
+			(workflow.expression.getSimpleParameterValue as jest.Mock)
 				.mockReturnValueOnce(undefined)
 				.mockReturnValueOnce('application/xml');
 
 			const result = await extractWebhookLastNodeResponse(
 				'firstEntryJson',
-				mockLastNodeRunData,
-				mockWorkflow,
-				mockWorkflowStartNode,
-				mockWebhookData,
+				lastNodeRunData,
+				workflow,
+				workflowStartNode,
+				webhookData,
 				'manual',
-				mockAdditionalKeys,
+				additionalKeys,
 			);
 
 			expect(result).toEqual({
@@ -169,21 +169,21 @@ describe('extractWebhookLastNodeResponse', () => {
 				json: {},
 				binary: { data: binaryData },
 			};
-			mockLastNodeRunData.data = {
+			lastNodeRunData.data = {
 				main: [[nodeExecutionData]],
 			};
 
-			mockWebhookData.webhookDescription.responseBinaryPropertyName = 'data';
-			(mockWorkflow.expression.getSimpleParameterValue as jest.Mock).mockReturnValue('data');
+			webhookData.webhookDescription.responseBinaryPropertyName = 'data';
+			(workflow.expression.getSimpleParameterValue as jest.Mock).mockReturnValue('data');
 
 			const result = await extractWebhookLastNodeResponse(
 				'firstEntryBinary',
-				mockLastNodeRunData,
-				mockWorkflow,
-				mockWorkflowStartNode,
-				mockWebhookData,
+				lastNodeRunData,
+				workflow,
+				workflowStartNode,
+				webhookData,
 				'manual',
-				mockAdditionalKeys,
+				additionalKeys,
 			);
 
 			expect(result).toEqual({
@@ -198,7 +198,7 @@ describe('extractWebhookLastNodeResponse', () => {
 
 		it('should return binary data as stream when ID is present', async () => {
 			const mockStream = new Readable();
-			mockBinaryDataService.getAsStream.mockResolvedValue(mockStream);
+			binaryDataService.getAsStream.mockResolvedValue(mockStream);
 
 			const binaryData: IBinaryData = {
 				id: 'binary-123',
@@ -209,21 +209,21 @@ describe('extractWebhookLastNodeResponse', () => {
 				json: {},
 				binary: { data: binaryData },
 			};
-			mockLastNodeRunData.data = {
+			lastNodeRunData.data = {
 				main: [[nodeExecutionData]],
 			};
 
-			mockWebhookData.webhookDescription.responseBinaryPropertyName = 'data';
-			(mockWorkflow.expression.getSimpleParameterValue as jest.Mock).mockReturnValue('data');
+			webhookData.webhookDescription.responseBinaryPropertyName = 'data';
+			(workflow.expression.getSimpleParameterValue as jest.Mock).mockReturnValue('data');
 
 			const result = await extractWebhookLastNodeResponse(
 				'firstEntryBinary',
-				mockLastNodeRunData,
-				mockWorkflow,
-				mockWorkflowStartNode,
-				mockWebhookData,
+				lastNodeRunData,
+				workflow,
+				workflowStartNode,
+				webhookData,
 				'manual',
-				mockAdditionalKeys,
+				additionalKeys,
 			);
 
 			expect(result).toEqual({
@@ -234,22 +234,22 @@ describe('extractWebhookLastNodeResponse', () => {
 					contentType: 'image/jpeg',
 				},
 			});
-			assert(mockBinaryDataService.getAsStream.mock.calls[0][0] === 'binary-123');
+			assert(binaryDataService.getAsStream.mock.calls[0][0] === 'binary-123');
 		});
 
 		it('should return error when no item found', async () => {
-			mockLastNodeRunData.data = {
+			lastNodeRunData.data = {
 				main: [[]],
 			};
 
 			const result = await extractWebhookLastNodeResponse(
 				'firstEntryBinary',
-				mockLastNodeRunData,
-				mockWorkflow,
-				mockWorkflowStartNode,
-				mockWebhookData,
+				lastNodeRunData,
+				workflow,
+				workflowStartNode,
+				webhookData,
 				'manual',
-				mockAdditionalKeys,
+				additionalKeys,
 			);
 
 			assert(!result.ok);
@@ -261,18 +261,18 @@ describe('extractWebhookLastNodeResponse', () => {
 			const nodeExecutionData: INodeExecutionData = {
 				json: { foo: 'bar' },
 			};
-			mockLastNodeRunData.data = {
+			lastNodeRunData.data = {
 				main: [[nodeExecutionData]],
 			};
 
 			const result = await extractWebhookLastNodeResponse(
 				'firstEntryBinary',
-				mockLastNodeRunData,
-				mockWorkflow,
-				mockWorkflowStartNode,
-				mockWebhookData,
+				lastNodeRunData,
+				workflow,
+				workflowStartNode,
+				webhookData,
 				'manual',
-				mockAdditionalKeys,
+				additionalKeys,
 			);
 
 			assert(!result.ok);
@@ -285,20 +285,20 @@ describe('extractWebhookLastNodeResponse', () => {
 				json: {},
 				binary: { data: { data: 'test', mimeType: 'text/plain' } },
 			};
-			mockLastNodeRunData.data = {
+			lastNodeRunData.data = {
 				main: [[nodeExecutionData]],
 			};
 
-			(mockWorkflow.expression.getSimpleParameterValue as jest.Mock).mockReturnValue(undefined);
+			(workflow.expression.getSimpleParameterValue as jest.Mock).mockReturnValue(undefined);
 
 			const result = await extractWebhookLastNodeResponse(
 				'firstEntryBinary',
-				mockLastNodeRunData,
-				mockWorkflow,
-				mockWorkflowStartNode,
-				mockWebhookData,
+				lastNodeRunData,
+				workflow,
+				workflowStartNode,
+				webhookData,
 				'manual',
-				mockAdditionalKeys,
+				additionalKeys,
 			);
 
 			assert(!result.ok);
@@ -311,20 +311,20 @@ describe('extractWebhookLastNodeResponse', () => {
 				json: {},
 				binary: { data: { data: 'test', mimeType: 'text/plain' } },
 			};
-			mockLastNodeRunData.data = {
+			lastNodeRunData.data = {
 				main: [[nodeExecutionData]],
 			};
 
-			(mockWorkflow.expression.getSimpleParameterValue as jest.Mock).mockReturnValue(123);
+			(workflow.expression.getSimpleParameterValue as jest.Mock).mockReturnValue(123);
 
 			const result = await extractWebhookLastNodeResponse(
 				'firstEntryBinary',
-				mockLastNodeRunData,
-				mockWorkflow,
-				mockWorkflowStartNode,
-				mockWebhookData,
+				lastNodeRunData,
+				workflow,
+				workflowStartNode,
+				webhookData,
 				'manual',
-				mockAdditionalKeys,
+				additionalKeys,
 			);
 
 			assert(!result.ok);
@@ -337,22 +337,22 @@ describe('extractWebhookLastNodeResponse', () => {
 				json: {},
 				binary: { otherProperty: { data: 'test', mimeType: 'text/plain' } },
 			};
-			mockLastNodeRunData.data = {
+			lastNodeRunData.data = {
 				main: [[nodeExecutionData]],
 			};
 
-			(mockWorkflow.expression.getSimpleParameterValue as jest.Mock).mockReturnValue(
+			(workflow.expression.getSimpleParameterValue as jest.Mock).mockReturnValue(
 				'nonExistentProperty',
 			);
 
 			const result = await extractWebhookLastNodeResponse(
 				'firstEntryBinary',
-				mockLastNodeRunData,
-				mockWorkflow,
-				mockWorkflowStartNode,
-				mockWebhookData,
+				lastNodeRunData,
+				workflow,
+				workflowStartNode,
+				webhookData,
 				'manual',
-				mockAdditionalKeys,
+				additionalKeys,
 			);
 
 			assert(!result.ok);
@@ -367,12 +367,12 @@ describe('extractWebhookLastNodeResponse', () => {
 		it('should return undefined body and contentType', async () => {
 			const result = await extractWebhookLastNodeResponse(
 				'noData',
-				mockLastNodeRunData,
-				mockWorkflow,
-				mockWorkflowStartNode,
-				mockWebhookData,
+				lastNodeRunData,
+				workflow,
+				workflowStartNode,
+				webhookData,
 				'manual',
-				mockAdditionalKeys,
+				additionalKeys,
 			);
 
 			expect(result).toEqual({
@@ -391,18 +391,18 @@ describe('extractWebhookLastNodeResponse', () => {
 			const jsonData1 = { foo: 'bar' };
 			const jsonData2 = { test: 123 };
 			const jsonData3 = { nested: { value: 'test' } };
-			mockLastNodeRunData.data = {
+			lastNodeRunData.data = {
 				main: [[{ json: jsonData1 }, { json: jsonData2 }, { json: jsonData3 }]],
 			};
 
 			const result = await extractWebhookLastNodeResponse(
 				undefined,
-				mockLastNodeRunData,
-				mockWorkflow,
-				mockWorkflowStartNode,
-				mockWebhookData,
+				lastNodeRunData,
+				workflow,
+				workflowStartNode,
+				webhookData,
 				'manual',
-				mockAdditionalKeys,
+				additionalKeys,
 			);
 
 			expect(result).toEqual({
@@ -416,18 +416,18 @@ describe('extractWebhookLastNodeResponse', () => {
 		});
 
 		it('should return empty array when no entries', async () => {
-			mockLastNodeRunData.data = {
+			lastNodeRunData.data = {
 				main: [[]],
 			};
 
 			const result = await extractWebhookLastNodeResponse(
 				undefined,
-				mockLastNodeRunData,
-				mockWorkflow,
-				mockWorkflowStartNode,
-				mockWebhookData,
+				lastNodeRunData,
+				workflow,
+				workflowStartNode,
+				webhookData,
 				'manual',
-				mockAdditionalKeys,
+				additionalKeys,
 			);
 
 			expect(result).toEqual({

--- a/packages/cli/src/webhooks/__tests__/webhook-last-node-response-extractor.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-last-node-response-extractor.test.ts
@@ -1,0 +1,443 @@
+import { Container } from '@n8n/di';
+import { mock, type MockProxy } from 'jest-mock-extended';
+import { BinaryDataService } from 'n8n-core';
+import type {
+	INode,
+	ITaskData,
+	IWebhookData,
+	Workflow,
+	IWorkflowDataProxyAdditionalKeys,
+	INodeExecutionData,
+	IBinaryData,
+	Expression,
+} from 'n8n-workflow';
+import { BINARY_ENCODING, OperationalError } from 'n8n-workflow';
+import assert from 'node:assert';
+import { Readable } from 'node:stream';
+
+import { extractWebhookLastNodeResponse } from '../webhook-last-node-response-extractor';
+
+describe('extractWebhookLastNodeResponse', () => {
+	let mockWorkflow: MockProxy<Workflow>;
+	let mockWorkflowStartNode: MockProxy<INode>;
+	let mockWebhookData: MockProxy<IWebhookData>;
+	let mockLastNodeRunData: MockProxy<ITaskData>;
+	let mockBinaryDataService: MockProxy<BinaryDataService>;
+	let mockAdditionalKeys: MockProxy<IWorkflowDataProxyAdditionalKeys>;
+
+	beforeEach(() => {
+		mockWorkflow = mock<Workflow>();
+		mockWorkflowStartNode = mock<INode>();
+		mockWebhookData = mock<IWebhookData>({
+			webhookDescription: {
+				responsePropertyName: undefined,
+				responseContentType: undefined,
+				responseBinaryPropertyName: undefined,
+			},
+		});
+		mockLastNodeRunData = mock<ITaskData>();
+		mockBinaryDataService = mock<BinaryDataService>();
+		mockAdditionalKeys = mock<IWorkflowDataProxyAdditionalKeys>();
+
+		mockWorkflow.expression = mock<Expression>({
+			getSimpleParameterValue: jest.fn(),
+		});
+
+		Container.set(BinaryDataService, mockBinaryDataService);
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('responseDataType: firstEntryJson', () => {
+		it('should return first entry JSON data', async () => {
+			const jsonData = { foo: 'bar', test: 123 };
+			mockLastNodeRunData.data = {
+				main: [[{ json: jsonData }]],
+			};
+
+			const result = await extractWebhookLastNodeResponse(
+				'firstEntryJson',
+				mockLastNodeRunData,
+				mockWorkflow,
+				mockWorkflowStartNode,
+				mockWebhookData,
+				'manual',
+				mockAdditionalKeys,
+			);
+
+			expect(result).toEqual({
+				ok: true,
+				result: {
+					type: 'nonstream',
+					body: jsonData,
+					contentType: undefined,
+				},
+			});
+		});
+
+		it('should return error when no item to return', async () => {
+			mockLastNodeRunData.data = {
+				main: [[]],
+			};
+
+			const result = await extractWebhookLastNodeResponse(
+				'firstEntryJson',
+				mockLastNodeRunData,
+				mockWorkflow,
+				mockWorkflowStartNode,
+				mockWebhookData,
+				'manual',
+				mockAdditionalKeys,
+			);
+
+			assert(!result.ok);
+			expect(result.error).toBeInstanceOf(OperationalError);
+		});
+
+		it('should extract specific property when responsePropertyName is set', async () => {
+			const jsonData = { foo: 'bar', nested: { value: 'test' } };
+			mockLastNodeRunData.data = {
+				main: [[{ json: jsonData }]],
+			};
+
+			mockWebhookData.webhookDescription.responsePropertyName = 'nested.value';
+			(mockWorkflow.expression.getSimpleParameterValue as jest.Mock)
+				.mockReturnValueOnce('nested.value')
+				.mockReturnValueOnce(undefined);
+
+			const result = await extractWebhookLastNodeResponse(
+				'firstEntryJson',
+				mockLastNodeRunData,
+				mockWorkflow,
+				mockWorkflowStartNode,
+				mockWebhookData,
+				'manual',
+				mockAdditionalKeys,
+			);
+
+			expect(result).toEqual({
+				ok: true,
+				result: {
+					type: 'nonstream',
+					body: 'test',
+					contentType: undefined,
+				},
+			});
+		});
+
+		it('should set content type when responseContentType is provided', async () => {
+			const jsonData = { foo: 'bar' };
+			mockLastNodeRunData.data = {
+				main: [[{ json: jsonData }]],
+			};
+
+			mockWebhookData.webhookDescription.responseContentType = 'application/xml';
+			(mockWorkflow.expression.getSimpleParameterValue as jest.Mock)
+				.mockReturnValueOnce(undefined)
+				.mockReturnValueOnce('application/xml');
+
+			const result = await extractWebhookLastNodeResponse(
+				'firstEntryJson',
+				mockLastNodeRunData,
+				mockWorkflow,
+				mockWorkflowStartNode,
+				mockWebhookData,
+				'manual',
+				mockAdditionalKeys,
+			);
+
+			expect(result).toEqual({
+				ok: true,
+				result: {
+					type: 'nonstream',
+					body: jsonData,
+					contentType: 'application/xml',
+				},
+			});
+		});
+	});
+
+	describe('responseDataType: firstEntryBinary', () => {
+		it('should return binary data as buffer when no ID is present', async () => {
+			const binaryData: IBinaryData = {
+				data: Buffer.from('test binary data').toString(BINARY_ENCODING),
+				mimeType: 'text/plain',
+			};
+			const nodeExecutionData: INodeExecutionData = {
+				json: {},
+				binary: { data: binaryData },
+			};
+			mockLastNodeRunData.data = {
+				main: [[nodeExecutionData]],
+			};
+
+			mockWebhookData.webhookDescription.responseBinaryPropertyName = 'data';
+			(mockWorkflow.expression.getSimpleParameterValue as jest.Mock).mockReturnValue('data');
+
+			const result = await extractWebhookLastNodeResponse(
+				'firstEntryBinary',
+				mockLastNodeRunData,
+				mockWorkflow,
+				mockWorkflowStartNode,
+				mockWebhookData,
+				'manual',
+				mockAdditionalKeys,
+			);
+
+			expect(result).toEqual({
+				ok: true,
+				result: {
+					type: 'nonstream',
+					body: Buffer.from('test binary data'),
+					contentType: 'text/plain',
+				},
+			});
+		});
+
+		it('should return binary data as stream when ID is present', async () => {
+			const mockStream = new Readable();
+			mockBinaryDataService.getAsStream.mockResolvedValue(mockStream);
+
+			const binaryData: IBinaryData = {
+				id: 'binary-123',
+				mimeType: 'image/jpeg',
+				data: '',
+			};
+			const nodeExecutionData: INodeExecutionData = {
+				json: {},
+				binary: { data: binaryData },
+			};
+			mockLastNodeRunData.data = {
+				main: [[nodeExecutionData]],
+			};
+
+			mockWebhookData.webhookDescription.responseBinaryPropertyName = 'data';
+			(mockWorkflow.expression.getSimpleParameterValue as jest.Mock).mockReturnValue('data');
+
+			const result = await extractWebhookLastNodeResponse(
+				'firstEntryBinary',
+				mockLastNodeRunData,
+				mockWorkflow,
+				mockWorkflowStartNode,
+				mockWebhookData,
+				'manual',
+				mockAdditionalKeys,
+			);
+
+			expect(result).toEqual({
+				ok: true,
+				result: {
+					type: 'stream',
+					stream: mockStream,
+					contentType: 'image/jpeg',
+				},
+			});
+			assert(mockBinaryDataService.getAsStream.mock.calls[0][0] === 'binary-123');
+		});
+
+		it('should return error when no item found', async () => {
+			mockLastNodeRunData.data = {
+				main: [[]],
+			};
+
+			const result = await extractWebhookLastNodeResponse(
+				'firstEntryBinary',
+				mockLastNodeRunData,
+				mockWorkflow,
+				mockWorkflowStartNode,
+				mockWebhookData,
+				'manual',
+				mockAdditionalKeys,
+			);
+
+			assert(!result.ok);
+			expect(result.error).toBeInstanceOf(OperationalError);
+			expect(result.error.message).toBe('No item was found to return');
+		});
+
+		it('should return error when no binary data found', async () => {
+			const nodeExecutionData: INodeExecutionData = {
+				json: { foo: 'bar' },
+			};
+			mockLastNodeRunData.data = {
+				main: [[nodeExecutionData]],
+			};
+
+			const result = await extractWebhookLastNodeResponse(
+				'firstEntryBinary',
+				mockLastNodeRunData,
+				mockWorkflow,
+				mockWorkflowStartNode,
+				mockWebhookData,
+				'manual',
+				mockAdditionalKeys,
+			);
+
+			assert(!result.ok);
+			expect(result.error).toBeInstanceOf(OperationalError);
+			expect(result.error.message).toBe('No binary data was found to return');
+		});
+
+		it('should return error when responseBinaryPropertyName is undefined', async () => {
+			const nodeExecutionData: INodeExecutionData = {
+				json: {},
+				binary: { data: { data: 'test', mimeType: 'text/plain' } },
+			};
+			mockLastNodeRunData.data = {
+				main: [[nodeExecutionData]],
+			};
+
+			(mockWorkflow.expression.getSimpleParameterValue as jest.Mock).mockReturnValue(undefined);
+
+			const result = await extractWebhookLastNodeResponse(
+				'firstEntryBinary',
+				mockLastNodeRunData,
+				mockWorkflow,
+				mockWorkflowStartNode,
+				mockWebhookData,
+				'manual',
+				mockAdditionalKeys,
+			);
+
+			assert(!result.ok);
+			expect(result.error).toBeInstanceOf(OperationalError);
+			expect(result.error.message).toBe("No 'responseBinaryPropertyName' is set");
+		});
+
+		it('should return error when responseBinaryPropertyName is not a string', async () => {
+			const nodeExecutionData: INodeExecutionData = {
+				json: {},
+				binary: { data: { data: 'test', mimeType: 'text/plain' } },
+			};
+			mockLastNodeRunData.data = {
+				main: [[nodeExecutionData]],
+			};
+
+			(mockWorkflow.expression.getSimpleParameterValue as jest.Mock).mockReturnValue(123);
+
+			const result = await extractWebhookLastNodeResponse(
+				'firstEntryBinary',
+				mockLastNodeRunData,
+				mockWorkflow,
+				mockWorkflowStartNode,
+				mockWebhookData,
+				'manual',
+				mockAdditionalKeys,
+			);
+
+			assert(!result.ok);
+			expect(result.error).toBeInstanceOf(OperationalError);
+			expect(result.error.message).toBe("'responseBinaryPropertyName' is not a string");
+		});
+
+		it('should return error when specified binary property does not exist', async () => {
+			const nodeExecutionData: INodeExecutionData = {
+				json: {},
+				binary: { otherProperty: { data: 'test', mimeType: 'text/plain' } },
+			};
+			mockLastNodeRunData.data = {
+				main: [[nodeExecutionData]],
+			};
+
+			(mockWorkflow.expression.getSimpleParameterValue as jest.Mock).mockReturnValue(
+				'nonExistentProperty',
+			);
+
+			const result = await extractWebhookLastNodeResponse(
+				'firstEntryBinary',
+				mockLastNodeRunData,
+				mockWorkflow,
+				mockWorkflowStartNode,
+				mockWebhookData,
+				'manual',
+				mockAdditionalKeys,
+			);
+
+			assert(!result.ok);
+			expect(result.error).toBeInstanceOf(OperationalError);
+			expect(result.error.message).toBe(
+				"The binary property 'nonExistentProperty' which should be returned does not exist",
+			);
+		});
+	});
+
+	describe('responseDataType: noData', () => {
+		it('should return undefined body and contentType', async () => {
+			const result = await extractWebhookLastNodeResponse(
+				'noData',
+				mockLastNodeRunData,
+				mockWorkflow,
+				mockWorkflowStartNode,
+				mockWebhookData,
+				'manual',
+				mockAdditionalKeys,
+			);
+
+			expect(result).toEqual({
+				ok: true,
+				result: {
+					type: 'nonstream',
+					body: undefined,
+					contentType: undefined,
+				},
+			});
+		});
+	});
+
+	describe('responseDataType: default (allEntries)', () => {
+		it('should return all entries as JSON array', async () => {
+			const jsonData1 = { foo: 'bar' };
+			const jsonData2 = { test: 123 };
+			const jsonData3 = { nested: { value: 'test' } };
+			mockLastNodeRunData.data = {
+				main: [[{ json: jsonData1 }, { json: jsonData2 }, { json: jsonData3 }]],
+			};
+
+			const result = await extractWebhookLastNodeResponse(
+				undefined,
+				mockLastNodeRunData,
+				mockWorkflow,
+				mockWorkflowStartNode,
+				mockWebhookData,
+				'manual',
+				mockAdditionalKeys,
+			);
+
+			expect(result).toEqual({
+				ok: true,
+				result: {
+					type: 'nonstream',
+					body: [jsonData1, jsonData2, jsonData3],
+					contentType: undefined,
+				},
+			});
+		});
+
+		it('should return empty array when no entries', async () => {
+			mockLastNodeRunData.data = {
+				main: [[]],
+			};
+
+			const result = await extractWebhookLastNodeResponse(
+				undefined,
+				mockLastNodeRunData,
+				mockWorkflow,
+				mockWorkflowStartNode,
+				mockWebhookData,
+				'manual',
+				mockAdditionalKeys,
+			);
+
+			expect(result).toEqual({
+				ok: true,
+				result: {
+					type: 'nonstream',
+					body: [],
+					contentType: undefined,
+				},
+			});
+		});
+	});
+});

--- a/packages/cli/src/webhooks/__tests__/webhook-last-node-response-extractor.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-last-node-response-extractor.test.ts
@@ -1,16 +1,7 @@
 import { Container } from '@n8n/di';
 import { mock, type MockProxy } from 'jest-mock-extended';
 import { BinaryDataService } from 'n8n-core';
-import type {
-	INode,
-	ITaskData,
-	IWebhookData,
-	Workflow,
-	IWorkflowDataProxyAdditionalKeys,
-	INodeExecutionData,
-	IBinaryData,
-	Expression,
-} from 'n8n-workflow';
+import type { ITaskData, INodeExecutionData, IBinaryData } from 'n8n-workflow';
 import { BINARY_ENCODING, OperationalError } from 'n8n-workflow';
 import assert from 'node:assert';
 import { Readable } from 'node:stream';
@@ -20,32 +11,14 @@ import { extractWebhookLastNodeResponse } from '../webhook-last-node-response-ex
 import type { WebhookExecutionContext } from '@/webhooks/webhook-execution-context';
 
 describe('extractWebhookLastNodeResponse', () => {
-	let workflow: MockProxy<Workflow>;
-	let workflowStartNode: MockProxy<INode>;
-	let webhookData: MockProxy<IWebhookData>;
+	let context: MockProxy<WebhookExecutionContext>;
 	let lastNodeTaskData: MockProxy<ITaskData>;
 	let binaryDataService: MockProxy<BinaryDataService>;
-	let additionalKeys: MockProxy<IWorkflowDataProxyAdditionalKeys>;
-	let context: MockProxy<WebhookExecutionContext>;
 
 	beforeEach(() => {
-		workflow = mock<Workflow>();
-		workflowStartNode = mock<INode>();
-		webhookData = mock<IWebhookData>({
-			webhookDescription: {
-				responsePropertyName: undefined,
-				responseContentType: undefined,
-				responseBinaryPropertyName: undefined,
-			},
-		});
+		context = mock<WebhookExecutionContext>();
 		lastNodeTaskData = mock<ITaskData>();
 		binaryDataService = mock<BinaryDataService>();
-		additionalKeys = mock<IWorkflowDataProxyAdditionalKeys>();
-		context = mock<WebhookExecutionContext>();
-
-		workflow.expression = mock<Expression>({
-			getSimpleParameterValue: jest.fn(),
-		});
 
 		Container.set(BinaryDataService, binaryDataService);
 	});

--- a/packages/cli/src/webhooks/webhook-execution-context.ts
+++ b/packages/cli/src/webhooks/webhook-execution-context.ts
@@ -1,0 +1,60 @@
+import type {
+	IWebhookData,
+	INode,
+	IWorkflowDataProxyAdditionalKeys,
+	Workflow,
+	WorkflowExecuteMode,
+	IExecuteData,
+	IWebhookDescription,
+	NodeParameterValueType,
+} from 'n8n-workflow';
+
+/**
+ * A helper class that holds the context for the webhook execution.
+ * Provides quality of life methods for evaluating expressions.
+ */
+export class WebhookExecutionContext {
+	constructor(
+		readonly workflow: Workflow,
+		readonly workflowStartNode: INode,
+		readonly webhookData: IWebhookData,
+		readonly executionMode: WorkflowExecuteMode,
+		readonly additionalKeys: IWorkflowDataProxyAdditionalKeys,
+	) {}
+
+	/**
+	 * Evaluates a simple expression from the webhook description.
+	 */
+	evaluateSimpleWebhookDescriptionExpression<T extends boolean | number | string | unknown[]>(
+		propertyName: keyof IWebhookDescription,
+		executeData?: IExecuteData,
+		defaultValue?: T,
+	): T | undefined {
+		return this.workflow.expression.getSimpleParameterValue(
+			this.workflowStartNode,
+			this.webhookData.webhookDescription[propertyName],
+			this.executionMode,
+			this.additionalKeys,
+			executeData,
+			defaultValue,
+		) as T | undefined;
+	}
+
+	/**
+	 * Evaluates a complex expression from the webhook description.
+	 */
+	evaluateComplexWebhookDescriptionExpression<T extends NodeParameterValueType>(
+		propertyName: keyof IWebhookDescription,
+		executeData?: IExecuteData,
+		defaultValue?: T,
+	): T | undefined {
+		return this.workflow.expression.getComplexParameterValue(
+			this.workflowStartNode,
+			this.webhookData.webhookDescription[propertyName],
+			this.executionMode,
+			this.additionalKeys,
+			executeData,
+			defaultValue,
+		) as T | undefined;
+	}
+}

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -64,7 +64,7 @@ import { WebhookExecutionContext } from '@/webhooks/webhook-execution-context';
 import { createMultiFormDataParser } from '@/webhooks/webhook-form-data';
 import { extractWebhookLastNodeResponse } from '@/webhooks/webhook-last-node-response-extractor';
 import type { WebhookResponse } from '@/webhooks/webhook-response';
-import { createNonStreamResponse, createStreamResponse } from '@/webhooks/webhook-response';
+import { createStaticResponse, createStreamResponse } from '@/webhooks/webhook-response';
 import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
 import * as WorkflowHelpers from '@/workflow-helpers';
 import { WorkflowRunner } from '@/workflow-runner';
@@ -717,7 +717,7 @@ export async function executeWebhook(
 					responseCallback(
 						null,
 						response.type === 'static'
-							? createNonStreamResponse(response.body, responseCode, responseHeaders)
+							? createStaticResponse(response.body, responseCode, responseHeaders)
 							: createStreamResponse(response.stream, responseCode, responseHeaders),
 					);
 					didSendResponse = true;

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -862,25 +862,26 @@ function evaluateResponseHeaders(
 	executionMode: WorkflowExecuteMode,
 	additionalKeys: IWorkflowDataProxyAdditionalKeys,
 ): WebhookResponseHeaders | undefined {
-	let headers: WebhookResponseHeaders | undefined = undefined;
+	if (webhookData.webhookDescription.responseHeaders === undefined) {
+		return undefined;
+	}
 
-	if (webhookData.webhookDescription.responseHeaders !== undefined) {
-		const evaluatedHeaders = workflow.expression.getComplexParameterValue(
-			workflowStartNode,
-			webhookData.webhookDescription.responseHeaders,
-			executionMode,
-			additionalKeys,
-			undefined,
-			undefined,
-		) as WebhookNodeResponseHeaders | undefined;
+	const evaluatedHeaders = workflow.expression.getComplexParameterValue(
+		workflowStartNode,
+		webhookData.webhookDescription.responseHeaders,
+		executionMode,
+		additionalKeys,
+		undefined,
+		undefined,
+	) as WebhookNodeResponseHeaders | undefined;
+	if (evaluatedHeaders?.entries === undefined) {
+		return undefined;
+	}
 
-		if (evaluatedHeaders?.entries) {
-			headers = new Map();
+	const headers = new Map();
 
-			for (const entry of evaluatedHeaders.entries) {
-				headers.set(entry.name.toLowerCase(), entry.value);
-			}
-		}
+	for (const entry of evaluatedHeaders.entries) {
+		headers.set(entry.name.toLowerCase(), entry.value);
 	}
 
 	return headers;

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -711,7 +711,7 @@ export async function executeWebhook(
 					const response = result.result;
 					// Apply potential content-type override
 					if (response.contentType) {
-						responseHeaders?.set('content-type', response.contentType);
+						responseHeaders.set('content-type', response.contentType);
 					}
 
 					responseCallback(
@@ -854,11 +854,11 @@ async function parseRequestBody(
 /**
  * Evaluates the `responseHeaders` parameter of a webhook node
  */
-function evaluateResponseHeaders(
-	context: WebhookExecutionContext,
-): WebhookResponseHeaders | undefined {
+function evaluateResponseHeaders(context: WebhookExecutionContext): WebhookResponseHeaders {
+	const headers = new Map<string, string>();
+
 	if (context.webhookData.webhookDescription.responseHeaders === undefined) {
-		return undefined;
+		return headers;
 	}
 
 	const evaluatedHeaders =
@@ -866,10 +866,8 @@ function evaluateResponseHeaders(
 			'responseHeaders',
 		);
 	if (evaluatedHeaders?.entries === undefined) {
-		return undefined;
+		return headers;
 	}
-
-	const headers = new Map();
 
 	for (const entry of evaluatedHeaders.entries) {
 		headers.set(entry.name.toLowerCase(), entry.value);

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -656,8 +656,8 @@ export async function executeWebhook(
 						runData.data.resultData.pinData = pinData;
 					}
 
-					const lastNodeRunData = WorkflowHelpers.getDataLastExecutedNodeData(runData);
-					if (runData.data.resultData.error || lastNodeRunData?.error !== undefined) {
+					const lastNodeTaskData = WorkflowHelpers.getDataLastExecutedNodeData(runData);
+					if (runData.data.resultData.error || lastNodeTaskData?.error !== undefined) {
 						if (!didSendResponse) {
 							responseCallback(null, {
 								data: {
@@ -676,7 +676,7 @@ export async function executeWebhook(
 						return undefined;
 					}
 
-					if (lastNodeRunData === undefined) {
+					if (lastNodeTaskData === undefined) {
 						if (!didSendResponse) {
 							responseCallback(null, {
 								data: {
@@ -696,7 +696,7 @@ export async function executeWebhook(
 
 					const result = await extractWebhookLastNodeResponse(
 						responseData as WebhookResponseData,
-						lastNodeRunData,
+						lastNodeTaskData,
 						workflow,
 						workflowStartNode,
 						webhookData,

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -717,7 +717,7 @@ export async function executeWebhook(
 
 					responseCallback(
 						null,
-						response.type === 'nonstream'
+						response.type === 'static'
 							? createNonStreamResponse(response.body, responseCode, responseHeaders)
 							: createStreamResponse(response.stream, responseCode, responseHeaders),
 					);

--- a/packages/cli/src/webhooks/webhook-last-node-response-extractor.ts
+++ b/packages/cli/src/webhooks/webhook-last-node-response-extractor.ts
@@ -28,7 +28,7 @@ type StreamResponse = {
 };
 
 /**
- * Extracts the response for a webhook when the responde mode is set to
++ * Extracts the response for a webhook when the response mode is set to
  * `lastNode`.
  */
 export async function extractWebhookLastNodeResponse(

--- a/packages/cli/src/webhooks/webhook-last-node-response-extractor.ts
+++ b/packages/cli/src/webhooks/webhook-last-node-response-extractor.ts
@@ -34,7 +34,7 @@ type StreamResponse = {
  */
 export async function extractWebhookLastNodeResponse(
 	responseDataType: WebhookResponseData | undefined,
-	lastNodeRunData: ITaskData,
+	lastNodeTaskData: ITaskData,
 	workflow: Workflow,
 	workflowStartNode: INode,
 	webhookData: IWebhookData,
@@ -42,8 +42,8 @@ export async function extractWebhookLastNodeResponse(
 	additionalKeys: IWorkflowDataProxyAdditionalKeys,
 ): Promise<Result<StaticResponse | StreamResponse, OperationalError>> {
 	if (responseDataType === 'firstEntryJson') {
-		return extractFirstEntryJsonFromRunData(
-			lastNodeRunData,
+		return extractFirstEntryJsonFromTaskData(
+			lastNodeTaskData,
 			workflow,
 			workflowStartNode,
 			webhookData,
@@ -53,8 +53,8 @@ export async function extractWebhookLastNodeResponse(
 	}
 
 	if (responseDataType === 'firstEntryBinary') {
-		return await extractFirstEntryBinaryFromRunData(
-			lastNodeRunData,
+		return await extractFirstEntryBinaryFromTaskData(
+			lastNodeTaskData,
 			workflow,
 			workflowStartNode,
 			webhookData,
@@ -72,25 +72,25 @@ export async function extractWebhookLastNodeResponse(
 	}
 
 	// Default to all entries JSON
-	return extractAllEntriesJsonFromRunData(lastNodeRunData);
+	return extractAllEntriesJsonFromTaskData(lastNodeTaskData);
 }
 
 /**
  * Extracts the JSON data of the first item of the last node
  */
-function extractFirstEntryJsonFromRunData(
-	lastNodeRunData: ITaskData,
+function extractFirstEntryJsonFromTaskData(
+	lastNodeTaskData: ITaskData,
 	workflow: Workflow,
 	workflowStartNode: INode,
 	webhookData: IWebhookData,
 	executionMode: WorkflowExecuteMode,
 	additionalKeys: IWorkflowDataProxyAdditionalKeys,
 ): Result<StaticResponse, OperationalError> {
-	if (lastNodeRunData.data!.main[0]![0] === undefined) {
+	if (lastNodeTaskData.data!.main[0]![0] === undefined) {
 		return createResultError(new OperationalError('No item to return was found'));
 	}
 
-	let lastNodeFirstJsonItem: unknown = lastNodeRunData.data!.main[0]![0].json;
+	let lastNodeFirstJsonItem: unknown = lastNodeTaskData.data!.main[0]![0].json;
 
 	const responsePropertyName = workflow.expression.getSimpleParameterValue(
 		workflowStartNode,
@@ -126,8 +126,8 @@ function extractFirstEntryJsonFromRunData(
 /**
  * Extracts the binary data of the first item of the last node
  */
-async function extractFirstEntryBinaryFromRunData(
-	lastNodeRunData: ITaskData,
+async function extractFirstEntryBinaryFromTaskData(
+	lastNodeTaskData: ITaskData,
 	workflow: Workflow,
 	workflowStartNode: INode,
 	webhookData: IWebhookData,
@@ -135,7 +135,7 @@ async function extractFirstEntryBinaryFromRunData(
 	additionalKeys: IWorkflowDataProxyAdditionalKeys,
 ): Promise<Result<StaticResponse | StreamResponse, OperationalError>> {
 	// Return the binary data of the first entry
-	const lastNodeFirstJsonItem: INodeExecutionData = lastNodeRunData.data!.main[0]![0];
+	const lastNodeFirstJsonItem: INodeExecutionData = lastNodeTaskData.data!.main[0]![0];
 
 	if (lastNodeFirstJsonItem === undefined) {
 		return createResultError(new OperationalError('No item was found to return'));
@@ -190,11 +190,11 @@ async function extractFirstEntryBinaryFromRunData(
 /**
  * Extracts the JSON data of all the items of the last node
  */
-function extractAllEntriesJsonFromRunData(
-	lastNodeRunData: ITaskData,
+function extractAllEntriesJsonFromTaskData(
+	lastNodeTaskData: ITaskData,
 ): Result<StaticResponse, OperationalError> {
 	const data: unknown[] = [];
-	for (const entry of lastNodeRunData.data!.main[0]!) {
+	for (const entry of lastNodeTaskData.data!.main[0]!) {
 		data.push(entry.json);
 	}
 

--- a/packages/cli/src/webhooks/webhook-last-node-response-extractor.ts
+++ b/packages/cli/src/webhooks/webhook-last-node-response-extractor.ts
@@ -15,8 +15,9 @@ import type {
 import { BINARY_ENCODING, createResultError, createResultOk, OperationalError } from 'n8n-workflow';
 import type { Readable } from 'node:stream';
 
-type NonStreamResponse = {
-	type: 'nonstream';
+/** Response that is not a stream */
+type StaticResponse = {
+	type: 'static';
 	body: unknown;
 	contentType: string | undefined;
 };
@@ -39,7 +40,7 @@ export async function extractWebhookLastNodeResponse(
 	webhookData: IWebhookData,
 	executionMode: WorkflowExecuteMode,
 	additionalKeys: IWorkflowDataProxyAdditionalKeys,
-): Promise<Result<NonStreamResponse | StreamResponse, OperationalError>> {
+): Promise<Result<StaticResponse | StreamResponse, OperationalError>> {
 	if (responseDataType === 'firstEntryJson') {
 		return extractFirstEntryJsonFromRunData(
 			lastNodeRunData,
@@ -64,7 +65,7 @@ export async function extractWebhookLastNodeResponse(
 
 	if (responseDataType === 'noData') {
 		return createResultOk({
-			type: 'nonstream',
+			type: 'static',
 			body: undefined,
 			contentType: undefined,
 		});
@@ -84,7 +85,7 @@ function extractFirstEntryJsonFromRunData(
 	webhookData: IWebhookData,
 	executionMode: WorkflowExecuteMode,
 	additionalKeys: IWorkflowDataProxyAdditionalKeys,
-): Result<NonStreamResponse, OperationalError> {
+): Result<StaticResponse, OperationalError> {
 	if (lastNodeRunData.data!.main[0]![0] === undefined) {
 		return createResultError(new OperationalError('No item to return was found'));
 	}
@@ -116,7 +117,7 @@ function extractFirstEntryJsonFromRunData(
 	) as string | undefined;
 
 	return createResultOk({
-		type: 'nonstream',
+		type: 'static',
 		body: lastNodeFirstJsonItem,
 		contentType: responseContentType,
 	});
@@ -132,7 +133,7 @@ async function extractFirstEntryBinaryFromRunData(
 	webhookData: IWebhookData,
 	executionMode: WorkflowExecuteMode,
 	additionalKeys: IWorkflowDataProxyAdditionalKeys,
-): Promise<Result<NonStreamResponse | StreamResponse, OperationalError>> {
+): Promise<Result<StaticResponse | StreamResponse, OperationalError>> {
 	// Return the binary data of the first entry
 	const lastNodeFirstJsonItem: INodeExecutionData = lastNodeRunData.data!.main[0]![0];
 
@@ -179,7 +180,7 @@ async function extractFirstEntryBinaryFromRunData(
 		});
 	} else {
 		return createResultOk({
-			type: 'nonstream',
+			type: 'static',
 			body: Buffer.from(binaryData.data, BINARY_ENCODING),
 			contentType: binaryData.mimeType,
 		});
@@ -191,14 +192,14 @@ async function extractFirstEntryBinaryFromRunData(
  */
 function extractAllEntriesJsonFromRunData(
 	lastNodeRunData: ITaskData,
-): Result<NonStreamResponse, OperationalError> {
+): Result<StaticResponse, OperationalError> {
 	const data: unknown[] = [];
 	for (const entry of lastNodeRunData.data!.main[0]!) {
 		data.push(entry.json);
 	}
 
 	return createResultOk({
-		type: 'nonstream',
+		type: 'static',
 		body: data,
 		// No content-type override in this case. User can set the content-type
 		// header if they wish. We default to application/json later on when the

--- a/packages/cli/src/webhooks/webhook-last-node-response-extractor.ts
+++ b/packages/cli/src/webhooks/webhook-last-node-response-extractor.ts
@@ -1,0 +1,208 @@
+import { Container } from '@n8n/di';
+import get from 'lodash/get';
+import { BinaryDataService } from 'n8n-core';
+import type {
+	INode,
+	INodeExecutionData,
+	ITaskData,
+	IWebhookData,
+	IWorkflowDataProxyAdditionalKeys,
+	Result,
+	WebhookResponseData,
+	Workflow,
+	WorkflowExecuteMode,
+} from 'n8n-workflow';
+import { BINARY_ENCODING, createResultError, createResultOk, OperationalError } from 'n8n-workflow';
+import type { Readable } from 'node:stream';
+
+type NonStreamResponse = {
+	type: 'nonstream';
+	body: unknown;
+	contentType: string | undefined;
+};
+
+type StreamResponse = {
+	type: 'stream';
+	stream: Readable;
+	contentType: string | undefined;
+};
+
+/**
+ * Extracts the response for a webhook when the responde mode is set to
+ * `lastNode`.
+ */
+export async function extractWebhookLastNodeResponse(
+	responseDataType: WebhookResponseData | undefined,
+	lastNodeRunData: ITaskData,
+	workflow: Workflow,
+	workflowStartNode: INode,
+	webhookData: IWebhookData,
+	executionMode: WorkflowExecuteMode,
+	additionalKeys: IWorkflowDataProxyAdditionalKeys,
+): Promise<Result<NonStreamResponse | StreamResponse, OperationalError>> {
+	if (responseDataType === 'firstEntryJson') {
+		return extractFirstEntryJsonFromRunData(
+			lastNodeRunData,
+			workflow,
+			workflowStartNode,
+			webhookData,
+			executionMode,
+			additionalKeys,
+		);
+	}
+
+	if (responseDataType === 'firstEntryBinary') {
+		return await extractFirstEntryBinaryFromRunData(
+			lastNodeRunData,
+			workflow,
+			workflowStartNode,
+			webhookData,
+			executionMode,
+			additionalKeys,
+		);
+	}
+
+	if (responseDataType === 'noData') {
+		return createResultOk({
+			type: 'nonstream',
+			body: undefined,
+			contentType: undefined,
+		});
+	}
+
+	// Default to all entries JSON
+	return extractAllEntriesJsonFromRunData(lastNodeRunData);
+}
+
+/**
+ * Extracts the JSON data of the first item of the last node
+ */
+function extractFirstEntryJsonFromRunData(
+	lastNodeRunData: ITaskData,
+	workflow: Workflow,
+	workflowStartNode: INode,
+	webhookData: IWebhookData,
+	executionMode: WorkflowExecuteMode,
+	additionalKeys: IWorkflowDataProxyAdditionalKeys,
+): Result<NonStreamResponse, OperationalError> {
+	if (lastNodeRunData.data!.main[0]![0] === undefined) {
+		return createResultError(new OperationalError('No item to return got found'));
+	}
+
+	let lastNodeFirstJsonItem: unknown = lastNodeRunData.data!.main[0]![0].json;
+
+	const responsePropertyName = workflow.expression.getSimpleParameterValue(
+		workflowStartNode,
+		webhookData.webhookDescription.responsePropertyName,
+		executionMode,
+		additionalKeys,
+		undefined,
+		undefined,
+	) as string | undefined;
+
+	if (responsePropertyName !== undefined) {
+		lastNodeFirstJsonItem = get(lastNodeFirstJsonItem, responsePropertyName);
+	}
+
+	// User can set the content type of the response and also the headers.
+	// The `responseContentType` only applies to `firstEntryJson` mode.
+	const responseContentType = workflow.expression.getSimpleParameterValue(
+		workflowStartNode,
+		webhookData.webhookDescription.responseContentType,
+		executionMode,
+		additionalKeys,
+		undefined,
+		undefined,
+	) as string | undefined;
+
+	return createResultOk({
+		type: 'nonstream',
+		body: lastNodeFirstJsonItem,
+		contentType: responseContentType,
+	});
+}
+
+/**
+ * Extracts the binary data of the first item of the last node
+ */
+async function extractFirstEntryBinaryFromRunData(
+	lastNodeRunData: ITaskData,
+	workflow: Workflow,
+	workflowStartNode: INode,
+	webhookData: IWebhookData,
+	executionMode: WorkflowExecuteMode,
+	additionalKeys: IWorkflowDataProxyAdditionalKeys,
+): Promise<Result<NonStreamResponse | StreamResponse, OperationalError>> {
+	// Return the binary data of the first entry
+	const lastNodeFirstJsonItem: INodeExecutionData = lastNodeRunData.data!.main[0]![0];
+
+	if (lastNodeFirstJsonItem === undefined) {
+		return createResultError(new OperationalError('No item was found to return'));
+	}
+
+	if (lastNodeFirstJsonItem.binary === undefined) {
+		return createResultError(new OperationalError('No binary data was found to return'));
+	}
+
+	const responseBinaryPropertyName = workflow.expression.getSimpleParameterValue(
+		workflowStartNode,
+		webhookData.webhookDescription.responseBinaryPropertyName,
+		executionMode,
+		additionalKeys,
+		undefined,
+		'data',
+	);
+
+	if (responseBinaryPropertyName === undefined) {
+		return createResultError(new OperationalError("No 'responseBinaryPropertyName' is set"));
+	} else if (typeof responseBinaryPropertyName !== 'string') {
+		return createResultError(new OperationalError("'responseBinaryPropertyName' is not a string"));
+	}
+
+	const binaryData = lastNodeFirstJsonItem.binary[responseBinaryPropertyName];
+	if (binaryData === undefined) {
+		return createResultError(
+			new OperationalError(
+				`The binary property '${responseBinaryPropertyName}' which should be returned does not exist`,
+			),
+		);
+	}
+
+	// In binary data's case, the mime type takes precedence over any manually
+	// set content type header
+	if (binaryData.id) {
+		const stream = await Container.get(BinaryDataService).getAsStream(binaryData.id);
+		return createResultOk({
+			type: 'stream',
+			stream,
+			contentType: binaryData.mimeType,
+		});
+	} else {
+		return createResultOk({
+			type: 'nonstream',
+			body: Buffer.from(binaryData.data, BINARY_ENCODING),
+			contentType: binaryData.mimeType,
+		});
+	}
+}
+
+/**
+ * Extracts the JSON data of all the items of the last node
+ */
+function extractAllEntriesJsonFromRunData(
+	lastNodeRunData: ITaskData,
+): Result<NonStreamResponse, OperationalError> {
+	const data: unknown[] = [];
+	for (const entry of lastNodeRunData.data!.main[0]!) {
+		data.push(entry.json);
+	}
+
+	return createResultOk({
+		type: 'nonstream',
+		body: data,
+		// No content-type override in this case. User can set the content-type
+		// header if they wish. We default to application/json later on when the
+		// response is sent.
+		contentType: undefined,
+	});
+}

--- a/packages/cli/src/webhooks/webhook-last-node-response-extractor.ts
+++ b/packages/cli/src/webhooks/webhook-last-node-response-extractor.ts
@@ -86,7 +86,7 @@ function extractFirstEntryJsonFromRunData(
 	additionalKeys: IWorkflowDataProxyAdditionalKeys,
 ): Result<NonStreamResponse, OperationalError> {
 	if (lastNodeRunData.data!.main[0]![0] === undefined) {
-		return createResultError(new OperationalError('No item to return got found'));
+		return createResultError(new OperationalError('No item to return was found'));
 	}
 
 	let lastNodeFirstJsonItem: unknown = lastNodeRunData.data!.main[0]![0].json;

--- a/packages/cli/src/webhooks/webhook-request-handler.ts
+++ b/packages/cli/src/webhooks/webhook-request-handler.ts
@@ -9,13 +9,13 @@ import { WebhookService } from './webhook.service';
 import { WebhookNotFoundError } from '@/errors/response-errors/webhook-not-found.error';
 import * as ResponseHelper from '@/response-helper';
 import type {
-	WebhookNonStreamResponse,
+	WebhookStaticResponse,
 	WebhookResponse,
 	WebhookResponseStream,
 } from '@/webhooks/webhook-response';
 import {
 	isWebhookNoResponse,
-	isWebhookNonStreamResponse,
+	isWebhookStaticResponse,
 	isWebhookResponse,
 	isWebhookStreamResponse,
 } from '@/webhooks/webhook-response';
@@ -104,8 +104,8 @@ class WebhookRequestHandler {
 			return;
 		}
 
-		if (isWebhookNonStreamResponse(webhookResponse)) {
-			this.sendNonStreamResponse(res, webhookResponse);
+		if (isWebhookStaticResponse(webhookResponse)) {
+			this.sendStaticResponse(res, webhookResponse);
 			return;
 		}
 
@@ -126,7 +126,7 @@ class WebhookRequestHandler {
 		process.nextTick(() => res.end());
 	}
 
-	private sendNonStreamResponse(res: express.Response, webhookResponse: WebhookNonStreamResponse) {
+	private sendStaticResponse(res: express.Response, webhookResponse: WebhookStaticResponse) {
 		const { body, code, headers } = webhookResponse;
 
 		this.setResponseStatus(res, code);

--- a/packages/cli/src/webhooks/webhook-request-handler.ts
+++ b/packages/cli/src/webhooks/webhook-request-handler.ts
@@ -64,7 +64,10 @@ class WebhookRequestHandler {
 			if (isWebhookResponse(response)) {
 				await this.sendWebhookResponse(res, response);
 			} else {
-				// Legacy way of responding to webhooks
+				// Legacy way of responding to webhooks. `WebhookResponse` should be used to
+				// pass the response from the webhookManager. However, we still have code
+				// that doesn't use that yet. We need to keep this here until all codepaths
+				// return a `WebhookResponse` instead.
 				if (response.noWebhookResponse !== true) {
 					ResponseHelper.sendSuccessResponse(
 						res,

--- a/packages/cli/src/webhooks/webhook-response.ts
+++ b/packages/cli/src/webhooks/webhook-response.ts
@@ -15,8 +15,8 @@ export type WebhookNoResponse = {
 /**
  * Result that indicates that a non-stream response needs to be sent.
  */
-export type WebhookNonStreamResponse = {
-	[WebhookResponseTag]: 'nonstream';
+export type WebhookStaticResponse = {
+	[WebhookResponseTag]: 'static';
 	body: unknown;
 	headers: WebhookResponseHeaders | undefined;
 	code: number | undefined;
@@ -32,7 +32,7 @@ export type WebhookResponseStream = {
 	headers: WebhookResponseHeaders | undefined;
 };
 
-export type WebhookResponse = WebhookNoResponse | WebhookNonStreamResponse | WebhookResponseStream;
+export type WebhookResponse = WebhookNoResponse | WebhookStaticResponse | WebhookResponseStream;
 
 export const isWebhookResponse = (response: unknown): response is WebhookResponse => {
 	return typeof response === 'object' && response !== null && WebhookResponseTag in response;
@@ -42,10 +42,8 @@ export const isWebhookNoResponse = (response: unknown): response is WebhookNoRes
 	return isWebhookResponse(response) && response[WebhookResponseTag] === 'noResponse';
 };
 
-export const isWebhookNonStreamResponse = (
-	response: unknown,
-): response is WebhookNonStreamResponse => {
-	return isWebhookResponse(response) && response[WebhookResponseTag] === 'nonstream';
+export const isWebhookStaticResponse = (response: unknown): response is WebhookStaticResponse => {
+	return isWebhookResponse(response) && response[WebhookResponseTag] === 'static';
 };
 
 export const isWebhookStreamResponse = (response: unknown): response is WebhookResponseStream => {
@@ -58,13 +56,13 @@ export const createNoResponse = (): WebhookNoResponse => {
 	};
 };
 
-export const createNonStreamResponse = (
+export const createStaticResponse = (
 	body: unknown,
 	code: number | undefined,
 	headers: WebhookResponseHeaders | undefined,
-): WebhookNonStreamResponse => {
+): WebhookStaticResponse => {
 	return {
-		[WebhookResponseTag]: 'nonstream',
+		[WebhookResponseTag]: 'static',
 		body,
 		code,
 		headers,

--- a/packages/cli/src/webhooks/webhook-response.ts
+++ b/packages/cli/src/webhooks/webhook-response.ts
@@ -1,0 +1,85 @@
+import type { Readable } from 'stream';
+
+import type { WebhookResponseHeaders } from './webhook.types';
+
+export const WebhookResponseTag = Symbol('WebhookResponse');
+
+/**
+ * Result that indicates that no response needs to be sent. This is used
+ * when the node or something else has already sent a response.
+ */
+export type WebhookNoResponse = {
+	[WebhookResponseTag]: 'noResponse';
+};
+
+/**
+ * Result that indicates that a non-stream response needs to be sent.
+ */
+export type WebhookNonStreamResponse = {
+	[WebhookResponseTag]: 'nonstream';
+	body: unknown;
+	headers: WebhookResponseHeaders | undefined;
+	code: number | undefined;
+};
+
+/**
+ * Result that indicates that a stream response needs to be sent.
+ */
+export type WebhookResponseStream = {
+	[WebhookResponseTag]: 'stream';
+	stream: Readable;
+	code: number | undefined;
+	headers: WebhookResponseHeaders | undefined;
+};
+
+export type WebhookResponse = WebhookNoResponse | WebhookNonStreamResponse | WebhookResponseStream;
+
+export const isWebhookResponse = (response: unknown): response is WebhookResponse => {
+	return typeof response === 'object' && response !== null && WebhookResponseTag in response;
+};
+
+export const isWebhookNoResponse = (response: unknown): response is WebhookNoResponse => {
+	return isWebhookResponse(response) && response[WebhookResponseTag] === 'noResponse';
+};
+
+export const isWebhookNonStreamResponse = (
+	response: unknown,
+): response is WebhookNonStreamResponse => {
+	return isWebhookResponse(response) && response[WebhookResponseTag] === 'nonstream';
+};
+
+export const isWebhookStreamResponse = (response: unknown): response is WebhookResponseStream => {
+	return isWebhookResponse(response) && response[WebhookResponseTag] === 'stream';
+};
+
+export const createNoResponse = (): WebhookNoResponse => {
+	return {
+		[WebhookResponseTag]: 'noResponse',
+	};
+};
+
+export const createNonStreamResponse = (
+	body: unknown,
+	code: number | undefined,
+	headers: WebhookResponseHeaders | undefined,
+): WebhookNonStreamResponse => {
+	return {
+		[WebhookResponseTag]: 'nonstream',
+		body,
+		code,
+		headers,
+	};
+};
+
+export const createStreamResponse = (
+	stream: Readable,
+	code: number | undefined,
+	headers: WebhookResponseHeaders | undefined,
+): WebhookResponseStream => {
+	return {
+		[WebhookResponseTag]: 'stream',
+		stream,
+		code,
+		headers,
+	};
+};

--- a/packages/cli/src/webhooks/webhook.types.ts
+++ b/packages/cli/src/webhooks/webhook.types.ts
@@ -37,3 +37,16 @@ export interface IWebhookResponseCallbackData {
 }
 
 export type Method = NonNullable<IHttpRequestMethods>;
+
+/** Response headers. Keys are always lower-cased. */
+export type WebhookResponseHeaders = Map<string, string>;
+
+/**
+ * The headers object that node's `responseHeaders` property can return
+ */
+export type WebhookNodeResponseHeaders = {
+	entries?: Array<{
+		name: string;
+		value: string;
+	}>;
+};


### PR DESCRIPTION
## Summary

1. refactor(core): Simplify how webhook response is generated in `lastNode` mode

WebhookHelper's `executeWebhook` function does a lot. This PR attempts make it a bit more manageable by extracting how the response payload is created. It also centralizes the actual
sending of the response to `WebhookRequestHandler` based on what `executeWebhook`
resolves using the `responseCallback`.

It is possible this change has unforeseen consequences as there can be subtle differences in
the implementation in different modes and nodes.

2. refactor(core): Extract webhook headers evaluation to function

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
