### PR TITLE
fix(n8n Evaluation Node): Make string similarity be inverted (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Evaluation/utils/metricHandlers.ts
+++ b/packages/nodes-base/nodes/Evaluation/utils/metricHandlers.ts
@@ -166,8 +166,12 @@ export const metricHandlers = {
 			'String similarity',
 		) as string;
 
+		const editDistance = distance(expectedAnswer, actualAnswer);
+		const longerStringLength = Math.max(expectedAnswer.length, actualAnswer.length);
+		const similarity = longerStringLength === 0 ? 1 : 1 - editDistance / longerStringLength;
+
 		return {
-			[metricName]: distance(expectedAnswer, actualAnswer),
+			[metricName]: similarity,
 		};
 	},
 


### PR DESCRIPTION
## Summary

Update the string similarity metric to use inverted score (i.e., similar strings are closer to 1, where dissimilar strings are close to 0).

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
