### PR TITLE
ci: Automate base image + sbom + attestation

### DIFF
--- a/.github/workflows/docker-base-image.yml
+++ b/.github/workflows/docker-base-image.yml
@@ -1,55 +1,58 @@
 name: Docker Base Image CI
 
 on:
-  workflow_dispatch:
-    inputs:
-      node_version:
-        description: 'Node.js version to build this image with.'
-        type: choice
-        required: true
-        default: '20'
-        options:
-          - '20'
-          - '22'
-          - '24'
+  push:
+    branches:
+      - master
+    paths:
+      - 'docker/images/n8n-base/Dockerfile'
+  pull_request:
+    paths:
+      - 'docker/images/n8n-base/Dockerfile'
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node_version: ['20', '22', '24']
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a # v3.3.0
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to DockerHub
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build
-        uses: docker/build-push-action@b32b51a8eda65d6793cd0494a773d4f6bcef32dc # v6.11.0
-        env:
-          DOCKER_BUILD_SUMMARY: false
+      - name: Build and push
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           file: ./docker/images/n8n-base/Dockerfile
           build-args: |
-            NODE_VERSION=${{github.event.inputs.node_version}}
+            NODE_VERSION=${{ matrix.node_version }}
           platforms: linux/amd64,linux/arm64
-          provenance: false
-          push: true
+          provenance: ${{ github.event_name == 'push' }}
+          sbom: ${{ github.event_name == 'push' }}
+          push: ${{ github.event_name == 'push' }}
           tags: |
-            ${{ secrets.DOCKER_USERNAME }}/base:${{ github.event.inputs.node_version }}
-            ghcr.io/${{ github.repository_owner }}/base:${{ github.event.inputs.node_version }}
+            ${{ secrets.DOCKER_USERNAME }}/base:${{ matrix.node_version }}-${{ github.sha }}
+            ${{ secrets.DOCKER_USERNAME }}/base:${{ matrix.node_version }}
+            ghcr.io/${{ github.repository_owner }}/base:${{ matrix.node_version }}-${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/base:${{ matrix.node_version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-base-image.yml
+++ b/.github/workflows/docker-base-image.yml
@@ -26,6 +26,7 @@ jobs:
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Login to GitHub Container Registry
+        if: github.event_name == 'push'
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ghcr.io

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -292,7 +292,8 @@ jobs:
             N8N_VERSION=${{ needs.determine-build-context.outputs.n8n_version }}
             N8N_RELEASE_TYPE=${{ needs.determine-build-context.outputs.release_type }}
           platforms: ${{ matrix.docker_platform }}
-          provenance: false
+          provenance: true
+          sbom: true
           push: ${{ needs.determine-build-context.outputs.push_enabled == 'true' }}
           tags: ${{ steps.determine-tags.outputs.tags }}
 


### PR DESCRIPTION
Replaces manual workflow dispatch with automated CI based on Dockerfile changes.

The new workflow triggers on pushes to the `master` branch when the base Dockerfile is modified. It builds and pushes multi-platform images with Node.js versions 20, 22, and 24 to both GitHub Container Registry and Docker Hub.

The base images will also now be published with the extra tags for the git commit sha, this will allow us to pin to those versions.

Also enables provenance and SBOM generation for the main Docker build push workflow.

## Summary

This PR adds SBOM and provenance attestations to our Docker images for improved supply chain security and license compliance.
Changes

Added sbom: true and provenance: true to all Docker build actions
Updated base image workflow to build on Dockerfile changes with immutable tags
Both n8n-base and n8n images now include attestation

### Check base image attestations
docker buildx imagetools inspect n8nio/base:20 --format "{{json .}}" | jq

#### Check main image attestations  
docker buildx imagetools inspect n8nio/n8n:latest --format "{{json .}}" | jq

### Look for these attestation types in the output:
 - "application/vnd.in-toto+json" entries
 - Predicates: "https://spdx.dev/Document" (SBOM)
 - Predicates: "https://slsa.dev/provenance/v0.2" (Provenance)



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1020/security-add-sbomattestation


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
