### PR TITLE
fix(slack): file upload trigger channel id support

### DIFF
--- a/packages/nodes-base/nodes/Slack/SlackTrigger.node.ts
+++ b/packages/nodes-base/nodes/Slack/SlackTrigger.node.ts
@@ -343,7 +343,7 @@ export class SlackTrigger implements INodeType {
 		}
 
 		if (eventType !== 'team_join') {
-			eventChannel = req.body.event.channel ?? req.body.event.item.channel;
+			let eventChannel = req.body.event.channel ?? req.body.event.item?.channel ?? req.body.event.file?.channel_id;
 
 			// Check for single channel
 			if (!watchWorkspace) {

--- a/packages/nodes-base/nodes/Slack/SlackTrigger.node.ts
+++ b/packages/nodes-base/nodes/Slack/SlackTrigger.node.ts
@@ -343,7 +343,7 @@ export class SlackTrigger implements INodeType {
 		}
 
 		if (eventType !== 'team_join') {
-			let eventChannel = req.body.event.channel ?? req.body.event.item?.channel ?? req.body.event.file?.channel_id;
+			eventChannel = req.body.event.channel ?? req.body.event.item?.channel ?? req.body.event.file?.channel_id;
 
 			// Check for single channel
 			if (!watchWorkspace) {


### PR DESCRIPTION
## Summary

Fixed issue with "file_upload" for the Slack connector not working at all due to incorrect channel_id check location. 

<img width="990" height="701" alt="image" src="https://github.com/user-attachments/assets/f1394c5a-fbb5-45d4-b299-47fb1d712797" />

<img width="335" height="200" alt="image" src="https://github.com/user-attachments/assets/2c7cf52d-980f-4591-8d35-28c1ecdeee8a" />


