### PR TITLE
fix(slack): handle nested channel_id for file_upload events

### DIFF
--- a/packages/nodes-base/nodes/Slack/SlackTrigger.node.ts
+++ b/packages/nodes-base/nodes/Slack/SlackTrigger.node.ts
@@ -343,7 +343,10 @@ export class SlackTrigger implements INodeType {
 		}
 
 		if (eventType !== 'team_join') {
-			eventChannel = req.body.event.channel ?? req.body.event.item.channel;
+			eventChannel =  
+				req.body.event?.channel 
+				?? req.body.event?.item?.channel 
+				?? req.body.event?.file?.channel_id
 
 			// Check for single channel
 			if (!watchWorkspace) {

--- a/packages/nodes-base/nodes/Slack/SlackTrigger.node.ts
+++ b/packages/nodes-base/nodes/Slack/SlackTrigger.node.ts
@@ -345,8 +345,8 @@ export class SlackTrigger implements INodeType {
 		if (eventType !== 'team_join') {
 			eventChannel =  
 				req.body.event?.channel 
-				?? req.body.event?.item?.channel 
-				?? req.body.event?.file?.channel_id
+				?? req.body.event?.channel_id
+				?? req.body.event?.item?.channel;
 
 			// Check for single channel
 			if (!watchWorkspace) {


### PR DESCRIPTION
## Summary

Handle nested channel_id for file_upload events.

<img width="999" height="697" alt="image" src="https://github.com/user-attachments/assets/9dbb8ef4-35ba-452e-890e-9ad6c90682ca" />

<img width="402" height="198" alt="image" src="https://github.com/user-attachments/assets/442edf44-21a9-4fab-95dd-949e69264552" />
