### PR TITLE
fix(Slack Trigger Node): Use correct channel_id for file_shared events

### DIFF
--- a/packages/nodes-base/nodes/Slack/SlackTrigger.node.ts
+++ b/packages/nodes-base/nodes/Slack/SlackTrigger.node.ts
@@ -343,7 +343,9 @@ export class SlackTrigger implements INodeType {
 		}
 
 		if (eventType !== 'team_join') {
-			eventChannel = req.body.event.channel ?? req.body.event.item.channel;
+			eventChannel = req.body.event?.channel 
+				?? req.body.event?.channel_id 
+				?? req.body.event?.item?.channel
 
 			// Check for single channel
 			if (!watchWorkspace) {


### PR DESCRIPTION
## Summary

use correct channel_id for file_shared events

<img width="1001" height="717" alt="image" src="https://github.com/user-attachments/assets/1d5be135-e3a0-4fa8-9865-01700a750db6" />

<img width="418" height="175" alt="image" src="https://github.com/user-attachments/assets/aa710adf-47d6-4cda-b483-4a41cf889eac" />
