### PR TITLE
chore(core): Fail the cli commands with correct exit code

### DIFF
--- a/packages/cli/src/commands/base-command.ts
+++ b/packages/cli/src/commands/base-command.ts
@@ -37,6 +37,7 @@ import { NodeTypes } from '@/node-types';
 import { PostHogClient } from '@/posthog';
 import { ShutdownService } from '@/shutdown/shutdown.service';
 import { WorkflowHistoryManager } from '@/workflows/workflow-history.ee/workflow-history-manager.ee';
+import { Errors } from '@oclif/core';
 
 export abstract class BaseCommand<F = never> {
 	readonly flags: F;
@@ -282,7 +283,8 @@ export abstract class BaseCommand<F = never> {
 			await sleep(100); // give any in-flight query some time to finish
 			await this.dbConnection.close();
 		}
-		process.exit();
+		const exitCode = error instanceof Errors.ExitError ? error.oclif.exit : error ? 1 : 0;
+		process.exit(exitCode);
 	}
 
 	protected onTerminationSignal(signal: string) {

--- a/packages/cli/src/commands/base-command.ts
+++ b/packages/cli/src/commands/base-command.ts
@@ -37,7 +37,6 @@ import { NodeTypes } from '@/node-types';
 import { PostHogClient } from '@/posthog';
 import { ShutdownService } from '@/shutdown/shutdown.service';
 import { WorkflowHistoryManager } from '@/workflows/workflow-history.ee/workflow-history-manager.ee';
-import { Errors } from '@oclif/core';
 
 export abstract class BaseCommand<F = never> {
 	readonly flags: F;
@@ -283,7 +282,7 @@ export abstract class BaseCommand<F = never> {
 			await sleep(100); // give any in-flight query some time to finish
 			await this.dbConnection.close();
 		}
-		const exitCode = error instanceof Errors.ExitError ? error.oclif.exit : error ? 1 : 0;
+		const exitCode = error ? 1 : 0;
 		process.exit(exitCode);
 	}
 


### PR DESCRIPTION
## Summary

The cli always exists with an error code equal to 0. This is caused by this change https://github.com/n8n-io/n8n/commit/9f8d3d3bc85feb88f58c6acfb2cd6777ef56d722#diff-9127350789432874069fb52007d0658e9bb7ea76ca4ee3ee038d9a968b5e5284L272-L273

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-3069/community-issue-cli-regression-for-exit-codes
closes https://github.com/n8n-io/n8n/issues/17181

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
