### PR TITLE
feat(editor): Make auto-focus work for Focus Panel (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/components/CodeNodeEditor/CodeNodeEditor.vue
+++ b/packages/frontend/editor-ui/src/components/CodeNodeEditor/CodeNodeEditor.vue
@@ -71,7 +71,7 @@ const dragAndDropEnabled = computed(() => {
 	return !props.isReadOnly;
 });
 
-const { highlightLine, readEditorValue, editor } = useCodeEditor({
+const { highlightLine, readEditorValue, editor, focus } = useCodeEditor({
 	id: props.id,
 	editorRef: codeNodeEditorRef,
 	language: () => props.language,
@@ -208,13 +208,6 @@ async function onDrop(value: string, event: MouseEvent) {
 
 	await dropInCodeEditor(toRaw(editor.value), event, valueToInsert);
 }
-
-const focus = () => {
-	const view = editor.value;
-	if (view && typeof view.focus === 'function') {
-		view.focus();
-	}
-};
 
 defineExpose({
 	focus,

--- a/packages/frontend/editor-ui/src/components/CodeNodeEditor/CodeNodeEditor.vue
+++ b/packages/frontend/editor-ui/src/components/CodeNodeEditor/CodeNodeEditor.vue
@@ -208,6 +208,17 @@ async function onDrop(value: string, event: MouseEvent) {
 
 	await dropInCodeEditor(toRaw(editor.value), event, valueToInsert);
 }
+
+const focus = () => {
+	const view = editor.value;
+	if (view && typeof view.focus === 'function') {
+		view.focus();
+	}
+};
+
+defineExpose({
+	focus,
+});
 </script>
 
 <template>

--- a/packages/frontend/editor-ui/src/components/CssEditor/CssEditor.vue
+++ b/packages/frontend/editor-ui/src/components/CssEditor/CssEditor.vue
@@ -69,7 +69,11 @@ const extensions = computed(() => [
 	mappingDropCursor(),
 ]);
 
-const { editor: editorRef, readEditorValue } = useExpressionEditor({
+const {
+	editor: editorRef,
+	readEditorValue,
+	focus,
+} = useExpressionEditor({
 	editorRef: cssEditor,
 	editorValue,
 	extensions,
@@ -83,13 +87,6 @@ async function onDrop(value: string, event: MouseEvent) {
 
 	await dropInExpressionEditor(toRaw(editorRef.value), event, value);
 }
-
-const focus = () => {
-	const view = editorRef.value;
-	if (view && typeof view.focus === 'function') {
-		view.focus();
-	}
-};
 
 defineExpose({
 	focus,

--- a/packages/frontend/editor-ui/src/components/CssEditor/CssEditor.vue
+++ b/packages/frontend/editor-ui/src/components/CssEditor/CssEditor.vue
@@ -83,6 +83,17 @@ async function onDrop(value: string, event: MouseEvent) {
 
 	await dropInExpressionEditor(toRaw(editorRef.value), event, value);
 }
+
+const focus = () => {
+	const view = editorRef.value;
+	if (view && typeof view.focus === 'function') {
+		view.focus();
+	}
+};
+
+defineExpose({
+	focus,
+});
 </script>
 
 <template>

--- a/packages/frontend/editor-ui/src/components/FocusPanel.vue
+++ b/packages/frontend/editor-ui/src/components/FocusPanel.vue
@@ -357,6 +357,7 @@ watch(
 							v-if="editorType === 'codeNodeEditor'"
 							:id="resolvedParameter.parameterPath"
 							ref="inputField"
+							:class="$style.heightFull"
 							:mode="codeEditorMode"
 							:model-value="resolvedParameter.value"
 							:default-value="resolvedParameter.parameter.default"
@@ -521,5 +522,9 @@ watch(
 			}
 		}
 	}
+}
+
+.heightFull {
+	height: 100%;
 }
 </style>

--- a/packages/frontend/editor-ui/src/components/FocusPanel.vue
+++ b/packages/frontend/editor-ui/src/components/FocusPanel.vue
@@ -2,7 +2,7 @@
 import { useFocusPanelStore } from '@/stores/focusPanel.store';
 import { useNodeTypesStore } from '@/stores/nodeTypes.store';
 import { N8nText, N8nInput } from '@n8n/design-system';
-import { computed, nextTick, ref } from 'vue';
+import { computed, nextTick, ref, watch } from 'vue';
 import { useI18n } from '@n8n/i18n';
 import {
 	formatAsExpression,
@@ -244,6 +244,18 @@ function optionSelected(command: string) {
 }
 
 const valueChangedDebounced = debounce(valueChanged, { debounceTime: 0 });
+
+// Wait for editor to mount before focusing
+function focusWithDelay() {
+	setTimeout(() => {
+		void setFocus();
+	}, 50);
+}
+
+watch(
+	() => focusPanelStore.lastFocusTimestamp,
+	() => focusWithDelay(),
+);
 </script>
 
 <template>
@@ -310,6 +322,7 @@ const valueChangedDebounced = debounce(valueChanged, { debounceTime: 0 });
 						<CodeNodeEditor
 							v-if="editorType === 'codeNodeEditor'"
 							:id="resolvedParameter.parameterPath"
+							ref="inputField"
 							:mode="codeEditorMode"
 							:model-value="resolvedParameter.value"
 							:default-value="resolvedParameter.parameter.default"
@@ -321,6 +334,7 @@ const valueChangedDebounced = debounce(valueChanged, { debounceTime: 0 });
 							@update:model-value="valueChangedDebounced" />
 						<HtmlEditor
 							v-else-if="editorType === 'htmlEditor'"
+							ref="inputField"
 							:model-value="resolvedParameter.value"
 							:is-read-only="isReadOnly"
 							:rows="editorRows"
@@ -330,6 +344,7 @@ const valueChangedDebounced = debounce(valueChanged, { debounceTime: 0 });
 							@update:model-value="valueChangedDebounced" />
 						<CssEditor
 							v-else-if="editorType === 'cssEditor'"
+							ref="inputField"
 							:model-value="resolvedParameter.value"
 							:is-read-only="isReadOnly"
 							:rows="editorRows"
@@ -337,6 +352,7 @@ const valueChangedDebounced = debounce(valueChanged, { debounceTime: 0 });
 							@update:model-value="valueChangedDebounced" />
 						<SqlEditor
 							v-else-if="editorType === 'sqlEditor'"
+							ref="inputField"
 							:model-value="resolvedParameter.value"
 							:dialect="getTypeOption('sqlDialect')"
 							:is-read-only="isReadOnly"
@@ -345,6 +361,7 @@ const valueChangedDebounced = debounce(valueChanged, { debounceTime: 0 });
 							@update:model-value="valueChangedDebounced" />
 						<JsEditor
 							v-else-if="editorType === 'jsEditor'"
+							ref="inputField"
 							:model-value="resolvedParameter.value"
 							:is-read-only="isReadOnly"
 							:rows="editorRows"
@@ -353,6 +370,7 @@ const valueChangedDebounced = debounce(valueChanged, { debounceTime: 0 });
 							@update:model-value="valueChangedDebounced" />
 						<JsonEditor
 							v-else-if="resolvedParameter.parameter.type === 'json'"
+							ref="inputField"
 							:model-value="resolvedParameter.value"
 							:is-read-only="isReadOnly"
 							:rows="editorRows"

--- a/packages/frontend/editor-ui/src/components/FocusPanel.vue
+++ b/packages/frontend/editor-ui/src/components/FocusPanel.vue
@@ -204,11 +204,13 @@ function optionSelected(command: string) {
 	if (!resolvedParameter.value) return;
 
 	switch (command) {
-		case 'resetValue':
-			return (
-				typeof resolvedParameter.value.parameter.default === 'string' &&
-				valueChanged(resolvedParameter.value.parameter.default)
-			);
+		case 'resetValue': {
+			if (typeof resolvedParameter.value.parameter.default === 'string') {
+				valueChanged(resolvedParameter.value.parameter.default);
+			}
+			void setFocus();
+			break;
+		}
 
 		case 'addExpression': {
 			const newValue = formatAsExpression(
@@ -239,7 +241,7 @@ function optionSelected(command: string) {
 
 		case 'formatHtml':
 			htmlEditorEventBus.emit('format-html');
-			return;
+			break;
 	}
 }
 
@@ -252,9 +254,8 @@ function focusWithDelay() {
 	}, 50);
 }
 
-watch(
-	() => focusPanelStore.lastFocusTimestamp,
-	() => focusWithDelay(),
+watch([() => focusPanelStore.lastFocusTimestamp, () => expressionModeEnabled.value], () =>
+	focusWithDelay(),
 );
 </script>
 

--- a/packages/frontend/editor-ui/src/components/HtmlEditor/HtmlEditor.vue
+++ b/packages/frontend/editor-ui/src/components/HtmlEditor/HtmlEditor.vue
@@ -81,7 +81,11 @@ const extensions = computed(() => [
 	highlightActiveLine(),
 	mappingDropCursor(),
 ]);
-const { editor: editorRef, readEditorValue } = useExpressionEditor({
+const {
+	editor: editorRef,
+	readEditorValue,
+	focus,
+} = useExpressionEditor({
 	editorRef: htmlEditor,
 	editorValue: () => props.modelValue,
 	extensions,
@@ -235,13 +239,6 @@ async function onDrop(value: string, event: MouseEvent) {
 
 	await dropInExpressionEditor(toRaw(editorRef.value), event, value);
 }
-
-const focus = () => {
-	const view = editorRef.value;
-	if (view && typeof view.focus === 'function') {
-		view.focus();
-	}
-};
 
 defineExpose({
 	focus,

--- a/packages/frontend/editor-ui/src/components/HtmlEditor/HtmlEditor.vue
+++ b/packages/frontend/editor-ui/src/components/HtmlEditor/HtmlEditor.vue
@@ -235,6 +235,17 @@ async function onDrop(value: string, event: MouseEvent) {
 
 	await dropInExpressionEditor(toRaw(editorRef.value), event, value);
 }
+
+const focus = () => {
+	const view = editorRef.value;
+	if (view && typeof view.focus === 'function') {
+		view.focus();
+	}
+};
+
+defineExpose({
+	focus,
+});
 </script>
 
 <template>

--- a/packages/frontend/editor-ui/src/components/JsEditor/JsEditor.vue
+++ b/packages/frontend/editor-ui/src/components/JsEditor/JsEditor.vue
@@ -107,6 +107,17 @@ const extensions = computed(() => {
 	}
 	return extensionsToApply;
 });
+
+const focus = () => {
+	const view = editor.value;
+	if (view && typeof view.focus === 'function') {
+		view.focus();
+	}
+};
+
+defineExpose({
+	focus,
+});
 </script>
 
 <template>

--- a/packages/frontend/editor-ui/src/components/JsonEditor/JsonEditor.vue
+++ b/packages/frontend/editor-ui/src/components/JsonEditor/JsonEditor.vue
@@ -106,6 +106,17 @@ function createEditor() {
 function destroyEditor() {
 	editor.value?.destroy();
 }
+
+const focus = () => {
+	const view = editor.value;
+	if (view && typeof view.focus === 'function') {
+		view.focus();
+	}
+};
+
+defineExpose({
+	focus,
+});
 </script>
 
 <template>

--- a/packages/frontend/editor-ui/src/components/SqlEditor/SqlEditor.vue
+++ b/packages/frontend/editor-ui/src/components/SqlEditor/SqlEditor.vue
@@ -117,6 +117,7 @@ const {
 	segments: { all: segments },
 	readEditorValue,
 	hasFocus: editorHasFocus,
+	focus,
 } = useExpressionEditor({
 	editorRef: sqlEditor,
 	editorValue: () => props.modelValue,
@@ -128,8 +129,8 @@ const {
 	},
 });
 
-watch(editorHasFocus, (focus) => {
-	if (focus) {
+watch(editorHasFocus, (hasFocus) => {
+	if (hasFocus) {
 		isFocused.value = true;
 	}
 });
@@ -191,13 +192,6 @@ async function onDrop(value: string, event: MouseEvent) {
 
 	await dropInExpressionEditor(toRaw(editor.value), event, value);
 }
-
-const focus = () => {
-	const view = editor.value;
-	if (view && typeof view.focus === 'function') {
-		view.focus();
-	}
-};
 
 defineExpose({
 	focus,

--- a/packages/frontend/editor-ui/src/components/SqlEditor/SqlEditor.vue
+++ b/packages/frontend/editor-ui/src/components/SqlEditor/SqlEditor.vue
@@ -191,6 +191,17 @@ async function onDrop(value: string, event: MouseEvent) {
 
 	await dropInExpressionEditor(toRaw(editor.value), event, value);
 }
+
+const focus = () => {
+	const view = editor.value;
+	if (view && typeof view.focus === 'function') {
+		view.focus();
+	}
+};
+
+defineExpose({
+	focus,
+});
 </script>
 
 <template>

--- a/packages/frontend/editor-ui/src/stores/focusPanel.store.ts
+++ b/packages/frontend/editor-ui/src/stores/focusPanel.store.ts
@@ -1,6 +1,6 @@
 import { STORES } from '@n8n/stores';
 import { defineStore } from 'pinia';
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import get from 'lodash/get';
 
 import {
@@ -12,6 +12,7 @@ import {
 import { useWorkflowsStore } from './workflows.store';
 import { LOCAL_STORAGE_FOCUS_PANEL, PLACEHOLDER_EMPTY_WORKFLOW_ID } from '@/constants';
 import { useStorage } from '@/composables/useStorage';
+import { watchOnce } from '@vueuse/core';
 
 type FocusedNodeParameter = {
 	nodeId: string;
@@ -51,6 +52,8 @@ export const useFocusPanelStore = defineStore(STORES.FOCUS_PANEL, () => {
 		(): FocusPanelData =>
 			focusPanelData.value[workflowsStore.workflowId] ?? DEFAULT_FOCUS_PANEL_DATA,
 	);
+
+	const lastFocusTimestamp = ref(0);
 
 	const focusPanelActive = computed(() => currentFocusPanelData.value.isActive);
 	const _focusedNodeParameters = computed(() => currentFocusPanelData.value.parameters);
@@ -94,6 +97,10 @@ export const useFocusPanelStore = defineStore(STORES.FOCUS_PANEL, () => {
 				parameters: parameters ?? _focusedNodeParameters.value,
 			},
 		});
+
+		if (isActive) {
+			lastFocusTimestamp.value = Date.now();
+		}
 	}
 
 	// When a new workflow is saved, we should update the focus panel data with the new workflow ID
@@ -133,9 +140,20 @@ export const useFocusPanelStore = defineStore(STORES.FOCUS_PANEL, () => {
 		return 'value' in p && 'node' in p;
 	}
 
+	// Ensure lastFocusTimestamp is set on initial load if panel is already active (e.g. after reload)
+	watchOnce(
+		() => currentFocusPanelData.value,
+		(value) => {
+			if (value.isActive && value.parameters.length > 0) {
+				lastFocusTimestamp.value = Date.now();
+			}
+		},
+	);
+
 	return {
 		focusPanelActive,
 		focusedNodeParameters,
+		lastFocusTimestamp,
 		openWithFocusedNodeParameter,
 		isRichParameter,
 		closeFocusPanel,

--- a/packages/frontend/editor-ui/src/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/views/NodeView.vue
@@ -2157,7 +2157,11 @@ onBeforeUnmount(() => {
 				/>
 			</Suspense>
 		</WorkflowCanvas>
-		<FocusPanel v-if="isFocusPanelFeatureEnabled" :is-canvas-read-only="isCanvasReadOnly" />
+		<FocusPanel
+			v-if="isFocusPanelFeatureEnabled"
+			:is-canvas-read-only="isCanvasReadOnly"
+			@save-keyboard-shortcut="onSaveWorkflow"
+		/>
 	</div>
 </template>
 


### PR DESCRIPTION
## Summary

- Auto-focus editors when:
    - a parameter is focused,
    - focus panel is opened,
    - expression mode is changed,
    - value is reset,
    - page is reloaded.
- Introduce `lastFocusTimestamp` to watch for changes, instead of watching for value change (otherwise, focus would be changed every time you type)
- Save workflow from focus panel on keyboard shortcut

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3816/feature-make-auto-focus-work-for-focus-panel

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
