### PR TITLE
fix(Embeddings OpenAI Node): Disable model list filter when custom baseURL is set

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsOpenAI/EmbeddingsOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsOpenAI/EmbeddingsOpenAi.node.ts
@@ -38,7 +38,12 @@ const modelParameter: INodeProperties = {
 						{
 							type: 'filter',
 							properties: {
-								pass: "={{ $responseItem.id.includes('embed') }}",
+								// If the baseURL is not set or is set to api.openai.com, include only embedding models
+								pass: `={{
+									($parameter.options?.baseURL && !$parameter.options?.baseURL?.startsWith('https://api.openai.com/')) ||
+									($credentials?.url && !$credentials.url.startsWith('https://api.openai.com/')) ||
+									$responseItem.id.includes('embed')
+								}}`,
 							},
 						},
 						{
@@ -236,7 +241,7 @@ export class EmbeddingsOpenAi implements INodeType {
 		}
 
 		const embeddings = new OpenAIEmbeddings({
-			modelName: this.getNodeParameter('model', itemIndex, 'text-embedding-3-small') as string,
+			model: this.getNodeParameter('model', itemIndex, 'text-embedding-3-small') as string,
 			openAIApiKey: credentials.apiKey as string,
 			...options,
 			configuration,

--- a/packages/core/src/execution-engine/__tests__/routing-node.test.ts
+++ b/packages/core/src/execution-engine/__tests__/routing-node.test.ts
@@ -20,6 +20,7 @@ import type {
 	IWorkflowExecuteAdditionalData,
 } from 'n8n-workflow';
 import { Workflow } from 'n8n-workflow';
+import type { ICredentialsDecrypted } from 'n8n-workflow/src';
 
 import * as executionContexts from '@/execution-engine/node-execution-context';
 import { DirectoryLoader } from '@/nodes-loader';
@@ -71,6 +72,18 @@ const getExecuteSingleFunctions = (
 		}),
 		helpers: mock<IExecuteSingleFunctions['helpers']>({
 			async httpRequest(
+				requestOptions: IHttpRequestOptions,
+			): Promise<IN8nHttpFullResponse | IN8nHttpResponse> {
+				return {
+					body: {
+						headers: {},
+						statusCode: 200,
+						requestOptions,
+					},
+				};
+			},
+			async httpRequestWithAuthentication(
+				_credentialType: string,
 				requestOptions: IHttpRequestOptions,
 			): Promise<IN8nHttpFullResponse | IN8nHttpResponse> {
 				return {
@@ -1809,6 +1822,159 @@ describe('RoutingNode', () => {
 				],
 			},
 			{
+				description: 'single parameter, postReceive: rootProperty, filter',
+				input: {
+					nodeType: {
+						requestDefaults: {
+							baseURL: 'http://127.0.0.1:5678',
+							url: '/test-url',
+						},
+						properties: [
+							{
+								displayName: 'JSON Data',
+								name: 'jsonData',
+								type: 'string',
+								routing: {
+									send: {
+										property: 'jsonData',
+										type: 'body',
+									},
+									output: {
+										postReceive: [
+											{
+												type: 'rootProperty',
+												properties: {
+													property: 'requestOptions',
+												},
+											},
+											{
+												type: 'rootProperty',
+												properties: {
+													property: 'body.jsonData.root',
+												},
+											},
+											{
+												type: 'filter',
+												properties: {
+													pass: '={{ $responseItem.age > 40 }}',
+												},
+											},
+										],
+									},
+								},
+								default: '',
+							},
+						],
+					},
+					node: {
+						parameters: {
+							jsonData: {
+								root: [
+									{
+										name: 'Jim',
+										age: 34,
+									},
+									{
+										name: 'James',
+										age: 44,
+									},
+								],
+							},
+						},
+					},
+				},
+				output: [
+					[
+						{
+							json: {
+								name: 'James',
+								age: 44,
+							},
+						},
+					],
+				],
+			},
+			{
+				description:
+					'single parameter, postReceive: rootProperty, filter with expression containing $credentials',
+				input: {
+					nodeType: {
+						credentials: [
+							{
+								name: 'testCredentials',
+								required: true,
+							},
+						],
+						requestDefaults: {
+							baseURL: 'http://127.0.0.1:5678',
+							url: '/test-url',
+						},
+						properties: [
+							{
+								displayName: 'JSON Data',
+								name: 'jsonData',
+								type: 'string',
+								routing: {
+									send: {
+										property: 'jsonData',
+										type: 'body',
+									},
+									output: {
+										postReceive: [
+											{
+												type: 'rootProperty',
+												properties: {
+													property: 'requestOptions',
+												},
+											},
+											{
+												type: 'rootProperty',
+												properties: {
+													property: 'body.jsonData.root',
+												},
+											},
+											{
+												type: 'filter',
+												properties: {
+													pass: "={{ $credentials.baseUrl.startsWith('https://example.com') && $responseItem.age > 40 }}",
+												},
+											},
+										],
+									},
+								},
+								default: '',
+							},
+						],
+					},
+					node: {
+						parameters: {
+							jsonData: {
+								root: [
+									{
+										name: 'Jim',
+										age: 34,
+									},
+									{
+										name: 'James',
+										age: 44,
+									},
+								],
+							},
+						},
+					},
+				},
+				output: [
+					[
+						{
+							json: {
+								name: 'James',
+								age: 44,
+							},
+						},
+					],
+				],
+			},
+			{
 				description: 'single parameter, multiple postReceive: rootProperty, setKeyValue, sort',
 				input: {
 					nodeType: {
@@ -1993,7 +2159,17 @@ describe('RoutingNode', () => {
 						? testData.input.node.parameters[parameterName]
 						: (getNodeParameter(parameterName) ?? {});
 
-				const routingNode = new RoutingNode(executeFunctions, nodeType);
+				const mockCredentials = mock<ICredentialsDecrypted>({
+					data: {
+						apiKey: 'testApiKey',
+						baseUrl: 'https://example.com',
+					},
+				});
+
+				const routingNode = nodeType.description.credentials
+					? new RoutingNode(executeFunctions, nodeType, mockCredentials)
+					: new RoutingNode(executeFunctions, nodeType);
+
 				const result = await routingNode.runNode();
 
 				if (testData.input.specialTestOptions?.sleepCalls) {

--- a/packages/core/src/execution-engine/routing-node.ts
+++ b/packages/core/src/execution-engine/routing-node.ts
@@ -68,46 +68,7 @@ export class RoutingNode {
 			inputData[NodeConnectionTypes.AiTool])[0] as INodeExecutionData[];
 		const returnData: INodeExecutionData[] = [];
 
-		let credentialDescription: INodeCredentialDescription | undefined;
-
-		if (nodeType.description.credentials?.length) {
-			if (nodeType.description.credentials.length === 1) {
-				credentialDescription = nodeType.description.credentials[0];
-			} else {
-				const authenticationMethod = context.getNodeParameter('authentication', 0) as string;
-				credentialDescription = nodeType.description.credentials.find((x) =>
-					x.displayOptions?.show?.authentication?.includes(authenticationMethod),
-				);
-				if (!credentialDescription) {
-					throw new NodeOperationError(
-						node,
-						`Node type "${node.type}" does not have any credentials of type "${authenticationMethod}" defined`,
-						{ level: 'warning' },
-					);
-				}
-			}
-		}
-
-		let credentials: ICredentialDataDecryptedObject | undefined;
-		if (credentialsDecrypted) {
-			credentials = credentialsDecrypted.data;
-		} else if (credentialDescription) {
-			try {
-				credentials =
-					(await context.getCredentials<ICredentialDataDecryptedObject>(
-						credentialDescription.name,
-						0,
-					)) || {};
-			} catch (error) {
-				if (credentialDescription.required) {
-					// Only throw error if credential is mandatory
-					throw error;
-				} else {
-					// Do not request cred type since it doesn't exist
-					credentialDescription = undefined;
-				}
-			}
-		}
+		const { credentials, credentialDescription } = await this.prepareCredentials();
 
 		const { batching } = context.getNodeParameter('requestOptions', 0, {}) as {
 			batching: { batch: { batchSize: number; batchInterval: number } };
@@ -375,6 +336,7 @@ export class RoutingNode {
 
 		if (action.type === 'filter') {
 			const passValue = action.properties.pass;
+			const { credentials } = await this.prepareCredentials();
 
 			inputData = inputData.filter((item) => {
 				// If the value is an expression resolve it
@@ -384,6 +346,7 @@ export class RoutingNode {
 					runIndex,
 					executeSingleFunctions.getExecuteData(),
 					{
+						$credentials: credentials,
 						$response: responseData,
 						$responseItem: item.json,
 						$value: parameterValue,
@@ -1107,5 +1070,53 @@ export class RoutingNode {
 			}
 		}
 		return returnData;
+	}
+
+	async prepareCredentials() {
+		const { context, nodeType, credentialsDecrypted } = this;
+		const { node } = context;
+
+		let credentialDescription: INodeCredentialDescription | undefined;
+
+		if (nodeType.description.credentials?.length) {
+			if (nodeType.description.credentials.length === 1) {
+				credentialDescription = nodeType.description.credentials[0];
+			} else {
+				const authenticationMethod = context.getNodeParameter('authentication', 0) as string;
+				credentialDescription = nodeType.description.credentials.find((x) =>
+					x.displayOptions?.show?.authentication?.includes(authenticationMethod),
+				);
+				if (!credentialDescription) {
+					throw new NodeOperationError(
+						node,
+						`Node type "${node.type}" does not have any credentials of type "${authenticationMethod}" defined`,
+						{ level: 'warning' },
+					);
+				}
+			}
+		}
+
+		let credentials: ICredentialDataDecryptedObject | undefined;
+		if (credentialsDecrypted) {
+			credentials = credentialsDecrypted.data;
+		} else if (credentialDescription) {
+			try {
+				credentials =
+					(await context.getCredentials<ICredentialDataDecryptedObject>(
+						credentialDescription.name,
+						0,
+					)) || {};
+			} catch (error) {
+				if (credentialDescription.required) {
+					// Only throw error if credential is mandatory
+					throw error;
+				} else {
+					// Do not request cred type since it doesn't exist
+					credentialDescription = undefined;
+				}
+			}
+		}
+
+		return { credentials, credentialDescription };
 	}
 }

--- a/packages/core/src/execution-engine/routing-node.ts
+++ b/packages/core/src/execution-engine/routing-node.ts
@@ -1072,7 +1072,7 @@ export class RoutingNode {
 		return returnData;
 	}
 
-	async prepareCredentials() {
+	private async prepareCredentials() {
 		const { context, nodeType, credentialsDecrypted } = this;
 		const { node } = context;
 


### PR DESCRIPTION
## Summary
- Disable model filtering for custom baseURL endpoints to allow non-embedding models like `intfloat/multilingual-e5-large`
- Fix deprecated `modelName` parameter to use `model` instead
- Refactor `routing-node` to include `$credentials` when resolving values in `postReceive` of the parameter's `loadOptions` definitions

## Related Linear tickets, Github issues, and Community forum posts
- Linear: https://linear.app/n8n/issue/AI-1108
- Fixes #16716
- Closes #16644

## Review / Merge checklist
- [x] PR title and summary are descriptive. ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] [Tests](https://github.com/n8n-io/n8n/blob/master/CONTRIBUTING.md#test-suite) included. 
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)