### PR TITLE
chore: Refactor nodeValues back to NodeSettings (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/components/FocusPanel.vue
+++ b/packages/frontend/editor-ui/src/components/FocusPanel.vue
@@ -2,7 +2,7 @@
 import { useFocusPanelStore } from '@/stores/focusPanel.store';
 import { useNodeTypesStore } from '@/stores/nodeTypes.store';
 import { N8nText, N8nInput } from '@n8n/design-system';
-import { computed, nextTick, ref } from 'vue';
+import { computed, nextTick, ref, toRef } from 'vue';
 import { useI18n } from '@n8n/i18n';
 import {
 	formatAsExpression,
@@ -179,6 +179,7 @@ function valueChanged(value: string) {
 	}
 
 	nodeSettingsParameters.updateNodeParameter(
+		toRef(resolvedParameter.value.node.parameters),
 		{ value, name: resolvedParameter.value.parameterPath as `parameters.${string}` },
 		value,
 		resolvedParameter.value.node,

--- a/packages/frontend/editor-ui/src/components/NodeSettings.vue
+++ b/packages/frontend/editor-ui/src/components/NodeSettings.vue
@@ -94,6 +94,19 @@ const emit = defineEmits<{
 
 const slots = defineSlots<{ actions?: {} }>();
 
+const nodeValues = ref<INodeParameters>({
+	color: '#ff0000',
+	alwaysOutputData: false,
+	executeOnce: false,
+	notesInFlow: false,
+	onError: 'stopWorkflow',
+	retryOnFail: false,
+	maxTries: 3,
+	waitBetweenTries: 1000,
+	notes: '',
+	parameters: {},
+});
+
 const nodeTypesStore = useNodeTypesStore();
 const ndvStore = useNDVStore();
 const workflowsStore = useWorkflowsStore();
@@ -106,7 +119,6 @@ const nodeHelpers = useNodeHelpers();
 const externalHooks = useExternalHooks();
 const i18n = useI18n();
 const nodeSettingsParameters = useNodeSettingsParameters();
-const nodeValues = nodeSettingsParameters.nodeValues;
 
 const nodeParameterWrapper = useTemplateRef('nodeParameterWrapper');
 const shouldShowStaticScrollbar = ref(false);
@@ -355,7 +367,11 @@ const valueChanged = (parameterData: IUpdateInformation) => {
 
 		for (const key of Object.keys(nodeParameters as object)) {
 			if (nodeParameters?.[key] !== null && nodeParameters?.[key] !== undefined) {
-				nodeSettingsParameters.setValue(`parameters.${key}`, nodeParameters[key] as string);
+				nodeSettingsParameters.setValue(
+					nodeValues,
+					`parameters.${key}`,
+					nodeParameters[key] as string,
+				);
 			}
 		}
 
@@ -372,7 +388,13 @@ const valueChanged = (parameterData: IUpdateInformation) => {
 		}
 	} else if (nameIsParameter(parameterData)) {
 		// A node parameter changed
-		nodeSettingsParameters.updateNodeParameter(parameterData, newValue, _node, isToolNode.value);
+		nodeSettingsParameters.updateNodeParameter(
+			nodeValues,
+			parameterData,
+			newValue,
+			_node,
+			isToolNode.value,
+		);
 	} else {
 		// A property on the node itself changed
 

--- a/packages/frontend/editor-ui/src/composables/useNodeSettingsParameters.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useNodeSettingsParameters.test.ts
@@ -14,47 +14,6 @@ import { mockedStore } from '@/__tests__/utils';
 import type { INodeUi } from '@/Interface';
 
 describe('useNodeSettingsParameters', () => {
-	describe('setValue', () => {
-		beforeEach(() => {
-			setActivePinia(createTestingPinia());
-		});
-
-		afterEach(() => {
-			vi.clearAllMocks();
-		});
-
-		it('mutates nodeValues as expected', () => {
-			const nodeSettingsParameters = useNodeSettingsParameters();
-
-			expect(nodeSettingsParameters.nodeValues.value.color).toBe('#ff0000');
-			expect(nodeSettingsParameters.nodeValues.value.parameters).toEqual({});
-
-			nodeSettingsParameters.setValue('color', '#ffffff');
-
-			expect(nodeSettingsParameters.nodeValues.value.color).toBe('#ffffff');
-			expect(nodeSettingsParameters.nodeValues.value.parameters).toEqual({});
-
-			nodeSettingsParameters.setValue('parameters.key', 3);
-
-			expect(nodeSettingsParameters.nodeValues.value.parameters).toEqual({ key: 3 });
-
-			nodeSettingsParameters.nodeValues.value = { parameters: { some: { nested: {} } } };
-			nodeSettingsParameters.setValue('parameters.some.nested.key', true);
-
-			expect(nodeSettingsParameters.nodeValues.value.parameters).toEqual({
-				some: { nested: { key: true } },
-			});
-
-			nodeSettingsParameters.setValue('parameters', null);
-
-			expect(nodeSettingsParameters.nodeValues.value.parameters).toBe(undefined);
-
-			nodeSettingsParameters.setValue('newProperty', 'newValue');
-
-			expect(nodeSettingsParameters.nodeValues.value.newProperty).toBe('newValue');
-		});
-	});
-
 	describe('handleFocus', () => {
 		let ndvStore: MockedStore<typeof useNDVStore>;
 		let focusPanelStore: MockedStore<typeof useFocusPanelStore>;

--- a/packages/frontend/editor-ui/src/utils/nodeSettingsUtils.ts
+++ b/packages/frontend/editor-ui/src/utils/nodeSettingsUtils.ts
@@ -17,6 +17,7 @@ import {
 	isINodePropertyOptionsList,
 	displayParameter,
 	isResourceLocatorValue,
+	deepCopy,
 } from 'n8n-workflow';
 import type { INodeUi, IUpdateInformation } from '@/Interface';
 import { CUSTOM_API_CALL_KEY, SWITCH_NODE_TYPE } from '@/constants';
@@ -27,6 +28,84 @@ import unset from 'lodash/unset';
 
 import { captureException } from '@sentry/vue';
 import { isPresent } from './typesUtils';
+import type { Ref } from 'vue';
+import { omitKey } from './objectUtils';
+
+export function setValue(
+	nodeValues: Ref<INodeParameters>,
+	name: string,
+	value: NodeParameterValue,
+) {
+	const nameParts = name.split('.');
+	let lastNamePart: string | undefined = nameParts.pop();
+
+	let isArray = false;
+	if (lastNamePart?.includes('[')) {
+		// It includes an index so we have to extract it
+		const lastNameParts = lastNamePart.match(/(.*)\[(\d+)\]$/);
+		if (lastNameParts) {
+			nameParts.push(lastNameParts[1]);
+			lastNamePart = lastNameParts[2];
+			isArray = true;
+		}
+	}
+
+	// Set the value so that everything updates correctly in the UI
+	if (nameParts.length === 0) {
+		// Data is on top level
+		if (value === null) {
+			// Property should be deleted
+			if (lastNamePart) {
+				nodeValues.value = omitKey(nodeValues.value, lastNamePart);
+			}
+		} else {
+			// Value should be set
+			nodeValues.value = {
+				...nodeValues.value,
+				[lastNamePart as string]: value,
+			};
+		}
+	} else {
+		// Data is on lower level
+		if (value === null) {
+			// Property should be deleted
+			let tempValue = get(nodeValues.value, nameParts.join('.')) as
+				| INodeParameters
+				| INodeParameters[];
+
+			if (lastNamePart && !Array.isArray(tempValue)) {
+				tempValue = omitKey(tempValue, lastNamePart);
+			}
+
+			if (isArray && Array.isArray(tempValue) && tempValue.length === 0) {
+				// If a value from an array got delete and no values are left
+				// delete also the parent
+				lastNamePart = nameParts.pop();
+				tempValue = get(nodeValues.value, nameParts.join('.')) as INodeParameters;
+				if (lastNamePart) {
+					tempValue = omitKey(tempValue, lastNamePart);
+				}
+			}
+		} else {
+			// Value should be set
+			if (typeof value === 'object') {
+				set(
+					get(nodeValues.value, nameParts.join('.')) as Record<string, unknown>,
+					lastNamePart as string,
+					deepCopy(value),
+				);
+			} else {
+				set(
+					get(nodeValues.value, nameParts.join('.')) as Record<string, unknown>,
+					lastNamePart as string,
+					value,
+				);
+			}
+		}
+	}
+
+	nodeValues.value = { ...nodeValues.value };
+}
 
 export function updateDynamicConnections(
 	node: INodeUi,


### PR DESCRIPTION
## Summary

We don't need the ref in the composable after all as we can work directly off of the workflow store parameters in the FocusPanel, so lets move it back to NodeSettings to avoid confusion

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3819/tech-debt-clean-up-nodevalues-in-composable


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
