### PR TITLE
ci: Add retry to docker pull to allow for manifest to propogate

### DIFF
--- a/.github/workflows/security-trivy-scan-callable.yml
+++ b/.github/workflows/security-trivy-scan-callable.yml
@@ -24,12 +24,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Pull Docker image
+      - name: Pull Docker image with retry
         run: |
-          docker pull ${{ inputs.image_ref }}
+          for i in {1..4}; do
+            docker pull "${{ inputs.image_ref }}" && break
+            [ $i -lt 4 ] && echo "Retry $i failed, waiting..." && sleep 15
+          done
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9724c8a5e33bc2d97a5 # v0.30.0
+        uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4 # v0.30.0
         with:
           image-ref: ${{ inputs.image_ref }}
           format: 'json'


### PR DESCRIPTION


## Summary

- Adds retry to docker pull, to allow time between release publish/pull and scan
- Updates trivy action to latest.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
