### PR TITLE
chore(Mattermost Node): Adjust name and description of Create Post "Make Comment" parameter

### DIFF
--- a/packages/nodes-base/nodes/Mattermost/v1/actions/message/post/description.ts
+++ b/packages/nodes-base/nodes/Mattermost/v1/actions/message/post/description.ts
@@ -370,11 +370,12 @@ export const messagePostDescription: MessageProperties = [
 		placeholder: 'Add option',
 		options: [
 			{
-				displayName: 'Make Comment',
+				displayName: 'Root Post ID',
 				name: 'root_id',
 				type: 'string',
 				default: '',
-				description: 'The post ID to comment on',
+				description:
+					'If set, the created message will be a threaded reply to the specified root post ID ',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Mattermost/v1/actions/message/post/description.ts
+++ b/packages/nodes-base/nodes/Mattermost/v1/actions/message/post/description.ts
@@ -370,12 +370,12 @@ export const messagePostDescription: MessageProperties = [
 		placeholder: 'Add option',
 		options: [
 			{
-				displayName: 'Root Post ID',
+				displayName: 'Parent Post ID',
 				name: 'root_id',
 				type: 'string',
 				default: '',
 				description:
-					'If set, the created message will be a threaded reply to the specified root post ID ',
+					'If set, the created message will be a threaded reply to the specified parent post ID',
 			},
 		],
 	},


### PR DESCRIPTION
## Summary
The "Root ID" parameter name while seemingly less descriptive initially, actually more closely mirrors Mattermost's API documentation. We noticed that "Make a Comment" was unclear, causing us to end up using a custom HTTP request (until I noticed in the code what it actually did). 

This PR changes "Make Comment" to "Root ID", and adjusts the "description" parameter to be more explanatory.

I played around with the backwards compatibility of this, and it seems to "just work", but if there's something further I should do, please let me know. 

## Related Linear tickets, Github issues, and Community forum posts
N/A - I opened this as a small improvement based on my own usage of the tool.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. There are no tests to update, but if it's necessary I can look into adding them.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported). **N/A**
