### PR TITLE
fix: Fix issue with restricted file access order

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
@@ -139,6 +139,16 @@ describe('isFilePathBlocked', () => {
 		const restrictedPath = join(userHome, 'somefile.txt');
 		expect(isFilePathBlocked(restrictedPath)).toBe(false);
 	});
+
+	it('should not block similar paths', () => {
+		const homeVarName = process.platform === 'win32' ? 'USERPROFILE' : 'HOME';
+		const userHome = process.env.N8N_USER_FOLDER ?? process.env[homeVarName] ?? process.cwd();
+
+		process.env[RESTRICT_FILE_ACCESS_TO] = userHome;
+		process.env[BLOCK_FILE_ACCESS_TO_N8N_FILES] = 'true';
+		const restrictedPath = join(userHome, '.n8n_x');
+		expect(isFilePathBlocked(restrictedPath)).toBe(false);
+	});
 });
 
 describe('getFileSystemHelperFunctions', () => {

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
@@ -119,6 +119,26 @@ describe('isFilePathBlocked', () => {
 		expect(isFilePathBlocked(invitePath)).toBe(true);
 		expect(isFilePathBlocked(pwResetPath)).toBe(true);
 	});
+
+	it('should block access to n8n files if restrict and block are set', () => {
+		const homeVarName = process.platform === 'win32' ? 'USERPROFILE' : 'HOME';
+		const userHome = process.env.N8N_USER_FOLDER ?? process.env[homeVarName] ?? process.cwd();
+
+		process.env[RESTRICT_FILE_ACCESS_TO] = userHome;
+		process.env[BLOCK_FILE_ACCESS_TO_N8N_FILES] = 'true';
+		const restrictedPath = instanceSettings.n8nFolder;
+		expect(isFilePathBlocked(restrictedPath)).toBe(true);
+	});
+
+	it('should allow access to parent folder if restrict and block are set', () => {
+		const homeVarName = process.platform === 'win32' ? 'USERPROFILE' : 'HOME';
+		const userHome = process.env.N8N_USER_FOLDER ?? process.env[homeVarName] ?? process.cwd();
+
+		process.env[RESTRICT_FILE_ACCESS_TO] = userHome;
+		process.env[BLOCK_FILE_ACCESS_TO_N8N_FILES] = 'true';
+		const restrictedPath = join(userHome, 'somefile.txt');
+		expect(isFilePathBlocked(restrictedPath)).toBe(false);
+	});
 });
 
 describe('getFileSystemHelperFunctions', () => {

--- a/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
@@ -63,7 +63,22 @@ export function isFilePathBlocked(filePath: string): boolean {
 		// Check if the file path is restricted - always block access to these paths
 		// regardless of allowed paths
 		for (const path of restrictedPaths) {
-			if (path && resolvedFilePath.startsWith(path)) {
+			if (!path) continue;
+
+			const restrictedPath = resolve(path);
+
+			// Check if it's the exact same path
+			if (resolvedFilePath === restrictedPath) {
+				return true;
+			}
+
+			// Check if it's a file/directory inside the restricted path by ensuring
+			// the next character after the restricted path is a separator
+			const isSubPath =
+				resolvedFilePath.startsWith(restrictedPath + '/') ||
+				resolvedFilePath.startsWith(restrictedPath + '\\');
+
+			if (isSubPath) {
 				return true;
 			}
 		}
@@ -72,7 +87,21 @@ export function isFilePathBlocked(filePath: string): boolean {
 	// If allowed paths are defined, only permit access to those paths
 	if (allowedPaths.length) {
 		for (const path of allowedPaths) {
-			if (resolvedFilePath.startsWith(path)) {
+			if (!path) continue;
+
+			const allowedPath = resolve(path);
+
+			// Check if it's the exact same path
+			if (resolvedFilePath === allowedPath) {
+				return false;
+			}
+
+			// Check if it's a file/directory inside the allowed path
+			const isSubPath =
+				resolvedFilePath.startsWith(allowedPath + '/') ||
+				resolvedFilePath.startsWith(allowedPath + '\\');
+
+			if (isSubPath) {
 				return false;
 			}
 		}


### PR DESCRIPTION
## Summary
Fixes the logic when using `BLOCK_FILE_ACCESS_TO` and `BLOCK_FILE_ACESS_TO_N8N_FILES` so that we always block the access to n8n files even when the access is restricted to the parent directory.

Testing
```
export N8N_BLOCK_FILE_ACCESS_TO_N8N_FILES=true && N8N_RESTRICT_FILE_ACCESS_TO='/Users/jon' && pnpm start
```

Accessing `/Users/jon/test.txt`
<img width="895" height="506" alt="image" src="https://github.com/user-attachments/assets/f1240af3-912e-4ee4-8ba0-eeb0ecdf545c" />

Accessing `/Users/jon/.n8n/n8nEventLog.log`
<img width="1167" height="528" alt="image" src="https://github.com/user-attachments/assets/30ee780c-98ec-459d-9e08-614e1153a3eb" />

Accessing `/Users/jon/.n8n_x`
<img width="894" height="540" alt="image" src="https://github.com/user-attachments/assets/81cc1a4d-c88e-4a7e-b6da-09961bd9f00c" />


## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/CP-1163/fixing-file-readwrite-access-in-cloud

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
