### PR TITLE
chore(core): Do not overwrite execution progress status in canceled workflow execution

### DIFF
--- a/packages/cli/src/execution-lifecycle/save-execution-progress.ts
+++ b/packages/cli/src/execution-lifecycle/save-execution-progress.ts
@@ -32,6 +32,15 @@ export async function saveExecutionProgress(
 			return;
 		}
 
+		if (fullExecutionData.status === 'canceled') {
+			// If the execution was canceled, we do not save any progress
+			logger.debug(`Execution ${executionId} was canceled, skipping save progress`, {
+				executionId,
+				nodeName,
+			});
+			return;
+		}
+
 		if (fullExecutionData.finished) {
 			// We already received ´workflowExecuteAfter´ webhook, so this is just an async call
 			// that was left behind. We skip saving because the other call should have saved everything


### PR DESCRIPTION
## Summary

When saving execution progress is turned on and a workflow execution is canceled during a node execution, we should not overwrite the workflow progress any more, in the nodeExecuteAfter hook. 

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-3051/community-issue-bug-report-timeout-failures-with-save-execution#comment-1e121adf
closes https://github.com/n8n-io/n8n/issues/17025


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
