### PR TITLE
chore(core): Stop server when access to port is not allowed

### DIFF
--- a/packages/cli/src/abstract-server.ts
+++ b/packages/cli/src/abstract-server.ts
@@ -168,8 +168,18 @@ export abstract class AbstractServer {
 
 		this.server.on('error', (error: Error & { code: string }) => {
 			if (error.code === 'EADDRINUSE') {
+				// EADDRINUSE is thrown when the port is already in use
 				this.logger.info(
 					`n8n's port ${port} is already in use. Do you have another instance of n8n running already?`,
+				);
+				process.exit(1);
+			} else if (error.code === 'EACCES') {
+				// EACCES is thrown when the process is not allowed to use the port
+				// This can happen if the port is below 1024 and the process is not run as root
+				// or when the port is reserved by the system, for example Windows reserves random ports
+				// for NAT for Hyper-V and other virtualization software.
+				this.logger.info(
+					`n8n does not have permission to use port ${port}. Please run n8n with a different port.`,
 				);
 				process.exit(1);
 			}

--- a/packages/cli/src/abstract-server.ts
+++ b/packages/cli/src/abstract-server.ts
@@ -172,7 +172,6 @@ export abstract class AbstractServer {
 				this.logger.info(
 					`n8n's port ${port} is already in use. Do you have another instance of n8n running already?`,
 				);
-				process.exit(1);
 			} else if (error.code === 'EACCES') {
 				// EACCES is thrown when the process is not allowed to use the port
 				// This can happen if the port is below 1024 and the process is not run as root
@@ -181,8 +180,12 @@ export abstract class AbstractServer {
 				this.logger.info(
 					`n8n does not have permission to use port ${port}. Please run n8n with a different port.`,
 				);
-				process.exit(1);
+			} else {
+				// Other errors are unexpected and should be logged
+				this.logger.error('n8n webserver failed, exiting', { error });
 			}
+			// we always exit on error, so that n8n does not run in an inconsistent state
+			process.exit(1);
 		});
 
 		await new Promise<void>((resolve) => this.server.listen(port, address, () => resolve()));


### PR DESCRIPTION
## Summary

When n8n tries to listen on a port that it is not allowed to listen on, for example a port < 1024 or a reserved port on windows, this gracefully handles this case and exits the process.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-3083/community-issue-n8n-start-stuck-in-windows-with-no-error-message-due
closes https://github.com/n8n-io/n8n/issues/17319

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
