### PR TITLE
feat(n8n Form Node): Allow basic styling of form completion message

### DIFF
--- a/packages/cli/templates/form-trigger-completion.handlebars
+++ b/packages/cli/templates/form-trigger-completion.handlebars
@@ -115,7 +115,7 @@
 					<div class='card'>
 						<div class='header'>
 							<h1>{{title}}</h1>
-							<p>{{message}}</p>
+							<p>{{{message}}}</p>
 						</div>
 					</div>
 					{{#if appendAttribution}}

--- a/packages/nodes-base/nodes/Form/utils/formCompletionUtils.ts
+++ b/packages/nodes-base/nodes/Form/utils/formCompletionUtils.ts
@@ -68,7 +68,7 @@ export const renderFormCompletion = async (
 
 	res.render('form-trigger-completion', {
 		title: completionTitle,
-		message: completionMessage,
+		message: sanitizeHtml(completionMessage),
 		formTitle: title,
 		appendAttribution,
 		responseText: sanitizeHtml(responseText),


### PR DESCRIPTION
## Summary

Users can now use `html` tags in the completion message

Workflow for testing

```
{
  "nodes": [
    {
      "parameters": {
        "formTitle": "Form",
        "formDescription": "description",
        "formFields": {
          "values": [
            {
              "fieldLabel": "name",
              "placeholder": "bar"
            }
          ]
        },
        "options": {}
      },
      "type": "n8n-nodes-base.formTrigger",
      "typeVersion": 2.2,
      "position": [
        -288,
        -48
      ],
      "id": "09367fcb-5cb2-4c45-8573-fec49776697d",
      "name": "On form submission",
      "webhookId": "eb1eed7e-5b3e-4582-962f-fd955d9f44f1"
    },
    {
      "parameters": {
        "operation": "completion",
        "completionTitle": "okay",
        "completionMessage": "={{ $json.text }}",
        "options": {}
      },
      "type": "n8n-nodes-base.form",
      "typeVersion": 1,
      "position": [
        -176,
        208
      ],
      "id": "97d2b6f0-0976-4ad3-903f-067ad39f4730",
      "name": "Form1",
      "webhookId": "2a14736c-3374-4613-b215-f82d7759d097"
    },
    {
      "parameters": {
        "assignments": {
          "assignments": [
            {
              "id": "e8be7d0d-8815-4a00-8634-0b8474b7900a",
              "name": "text",
              "value": "<h1>hello</h1><br>bye",
              "type": "string"
            }
          ]
        },
        "options": {}
      },
      "type": "n8n-nodes-base.set",
      "typeVersion": 3.4,
      "position": [
        -80,
        -48
      ],
      "id": "f541a76b-f2d4-42aa-bfdd-524d62237334",
      "name": "Edit Fields"
    }
  ],
  "connections": {
    "On form submission": {
      "main": [
        [
          {
            "node": "Edit Fields",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Edit Fields": {
      "main": [
        [
          {
            "node": "Form1",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {},
  "meta": {
    "instanceId": "ee90fdf8d57662f949e6c691dc07fa0fd2f66e1eee28ed82ef06658223e67255"
  }
}
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2053/n8n-form-ending-allow-styling-of-completion-message
https://github.com/n8n-io/n8n/issues/11818

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
