### PR TITLE
fix(core): Ignore pairedItem when checking for incorrect output data from a node

### DIFF
--- a/packages/core/src/errors/__tests__/error-reporter.test.ts
+++ b/packages/core/src/errors/__tests__/error-reporter.test.ts
@@ -194,5 +194,20 @@ describe('ErrorReporter', () => {
 			errorReporter.error(error);
 			expect(logger.error).toHaveBeenCalledWith('Test error', metadata);
 		});
+
+		it.each([true, undefined])(
+			'should log the error when shouldBeLogged is %s',
+			(shouldBeLogged) => {
+				error.level = 'error';
+				errorReporter.error(error, { shouldBeLogged });
+				expect(logger.error).toHaveBeenCalledTimes(1);
+			},
+		);
+
+		it('should not log the error when shouldBeLogged is false', () => {
+			error.level = 'error';
+			errorReporter.error(error, { shouldBeLogged: false });
+			expect(logger.error).toHaveBeenCalledTimes(0);
+		});
 	});
 });

--- a/packages/core/src/errors/error-reporter.ts
+++ b/packages/core/src/errors/error-reporter.ts
@@ -60,7 +60,10 @@ export class ErrorReporter {
 					meta = e.extra;
 				}
 				const msg = [e.message + context, stack].join('');
-				this.logger.error(msg, meta);
+				// Default to logging the error if option is not specified
+				if (options?.shouldBeLogged ?? true) {
+					this.logger.error(msg, meta);
+				}
 				e = e.cause as Error;
 			} while (e);
 		}

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -1213,7 +1213,7 @@ export class WorkflowExecute {
 
 			// If data is not json compatible then log it as incorrect output
 			// Does not block the execution from continuing
-			const jsonCompatibleResult = isJsonCompatible(data);
+			const jsonCompatibleResult = isJsonCompatible(data, new Set(['pairedItem']));
 			if (!jsonCompatibleResult.isValid) {
 				Container.get(ErrorReporter).error(
 					new UnexpectedError('node execution output incorrect data'),

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -1215,21 +1215,19 @@ export class WorkflowExecute {
 			// Does not block the execution from continuing
 			const jsonCompatibleResult = isJsonCompatible(data, new Set(['pairedItem']));
 			if (!jsonCompatibleResult.isValid) {
-				Container.get(ErrorReporter).error(
-					new UnexpectedError('node execution returned incorrect data'),
-					{
-						extra: {
-							nodeName: node.name,
-							nodeType: node.type,
-							nodeVersion: node.typeVersion,
-							workflowId: workflow.id,
-							workflowName: workflow.name ?? 'Unnamed workflow',
-							executionId: this.additionalData.executionId ?? 'unsaved-execution',
-							errorPath: jsonCompatibleResult.errorPath,
-							errorMessage: jsonCompatibleResult.errorMessage,
-						},
+				Container.get(ErrorReporter).error('node execution returned incorrect data', {
+					shouldBeLogged: false,
+					extra: {
+						nodeName: node.name,
+						nodeType: node.type,
+						nodeVersion: node.typeVersion,
+						workflowId: workflow.id,
+						workflowName: workflow.name ?? 'Unnamed workflow',
+						executionId: this.additionalData.executionId ?? 'unsaved-execution',
+						errorPath: jsonCompatibleResult.errorPath,
+						errorMessage: jsonCompatibleResult.errorMessage,
 					},
-				);
+				});
 			}
 
 			const closeFunctionsResults = await Promise.allSettled(

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -1216,7 +1216,7 @@ export class WorkflowExecute {
 			const jsonCompatibleResult = isJsonCompatible(data, new Set(['pairedItem']));
 			if (!jsonCompatibleResult.isValid) {
 				Container.get(ErrorReporter).error(
-					new UnexpectedError('node execution output incorrect data'),
+					new UnexpectedError('node execution returned incorrect data'),
 					{
 						extra: {
 							nodeName: node.name,

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
+import { GlobalConfig } from '@n8n/config';
 import { TOOL_EXECUTOR_NODE_NAME } from '@n8n/constants';
 import { Container } from '@n8n/di';
 import * as assert from 'assert/strict';
@@ -1211,23 +1212,25 @@ export class WorkflowExecute {
 						: await nodeType.execute.call(context);
 			}
 
-			// If data is not json compatible then log it as incorrect output
-			// Does not block the execution from continuing
-			const jsonCompatibleResult = isJsonCompatible(data, new Set(['pairedItem']));
-			if (!jsonCompatibleResult.isValid) {
-				Container.get(ErrorReporter).error('node execution returned incorrect data', {
-					shouldBeLogged: false,
-					extra: {
-						nodeName: node.name,
-						nodeType: node.type,
-						nodeVersion: node.typeVersion,
-						workflowId: workflow.id,
-						workflowName: workflow.name ?? 'Unnamed workflow',
-						executionId: this.additionalData.executionId ?? 'unsaved-execution',
-						errorPath: jsonCompatibleResult.errorPath,
-						errorMessage: jsonCompatibleResult.errorMessage,
-					},
-				});
+			if (Container.get(GlobalConfig).sentry.backendDsn) {
+				// If data is not json compatible then log it as incorrect output
+				// Does not block the execution from continuing
+				const jsonCompatibleResult = isJsonCompatible(data, new Set(['pairedItem']));
+				if (!jsonCompatibleResult.isValid) {
+					Container.get(ErrorReporter).error('node execution returned incorrect data', {
+						shouldBeLogged: false,
+						extra: {
+							nodeName: node.name,
+							nodeType: node.type,
+							nodeVersion: node.typeVersion,
+							workflowId: workflow.id,
+							workflowName: workflow.name ?? 'Unnamed workflow',
+							executionId: this.additionalData.executionId ?? 'unsaved-execution',
+							errorPath: jsonCompatibleResult.errorPath,
+							errorMessage: jsonCompatibleResult.errorMessage,
+						},
+					});
+				}
 			}
 
 			const closeFunctionsResults = await Promise.allSettled(

--- a/packages/core/src/utils/__tests__/is-json-compatible.test.ts
+++ b/packages/core/src/utils/__tests__/is-json-compatible.test.ts
@@ -131,4 +131,14 @@ describe('isJsonCompatible', () => {
 
 		expect(result.isValid).toBe(true);
 	});
+
+	test('skip keys that are in the keysToIgnore set', () => {
+		const value = {
+			invalidObject: { invalidBecauseUndefined: undefined },
+			validObject: { key: 'value' },
+		};
+		const result = isJsonCompatible(value, new Set(['invalidObject']));
+
+		expect(result.isValid).toBe(true);
+	});
 });

--- a/packages/core/src/utils/__tests__/is-json-compatible.test.ts
+++ b/packages/core/src/utils/__tests__/is-json-compatible.test.ts
@@ -28,6 +28,18 @@ describe('isJsonCompatible', () => {
 			errorMessage: 'has non-plain prototype (Date)',
 		},
 		{
+			name: 'a RegExp',
+			value: { regexp: new RegExp('') },
+			errorPath: 'value.regexp',
+			errorMessage: 'has non-plain prototype (RegExp)',
+		},
+		{
+			name: 'a Buffer',
+			value: { buffer: Buffer.from('') },
+			errorPath: 'value.buffer',
+			errorMessage: 'has non-plain prototype (Buffer)',
+		},
+		{
 			name: 'a function',
 			value: { fn: () => {} },
 			errorPath: 'value.fn',

--- a/packages/core/src/utils/is-json-compatible.ts
+++ b/packages/core/src/utils/is-json-compatible.ts
@@ -2,6 +2,7 @@ const check = (
 	val: unknown,
 	path = 'value',
 	stack: Set<unknown> = new Set(),
+	keysToIgnore: Set<string> = new Set(),
 ): { isValid: true } | { isValid: false; errorPath: string; errorMessage: string } => {
 	const type = typeof val;
 
@@ -38,7 +39,7 @@ const check = (
 		}
 		stack.add(val);
 		for (let i = 0; i < val.length; i++) {
-			const result = check(val[i], `${path}[${i}]`, stack);
+			const result = check(val[i], `${path}[${i}]`, stack, keysToIgnore);
 			if (!result.isValid) return result;
 		}
 		stack.delete(val);
@@ -74,8 +75,12 @@ const check = (
 				};
 			}
 
+			if (keysToIgnore.has(key)) {
+				continue;
+			}
+
 			const subVal = (val as Record<string, unknown>)[key];
-			const result = check(subVal, `${path}.${key}`, stack);
+			const result = check(subVal, `${path}.${key}`, stack, keysToIgnore);
 			if (!result.isValid) return result;
 		}
 		stack.delete(val);
@@ -92,14 +97,18 @@ const check = (
 /**
  * This function checks if a value matches JSON data type restrictions.
  * @param value
+ * @param keysToIgnore - Set of keys to ignore for objects
  * @returns boolean
  */
-export function isJsonCompatible(value: unknown):
+export function isJsonCompatible(
+	value: unknown,
+	keysToIgnore: Set<string> = new Set(),
+):
 	| { isValid: true }
 	| {
 			isValid: false;
 			errorPath: string;
 			errorMessage: string;
 	  } {
-	return check(value);
+	return check(value, undefined, undefined, keysToIgnore);
 }

--- a/packages/workflow/src/errors/error.types.ts
+++ b/packages/workflow/src/errors/error.types.ts
@@ -7,6 +7,8 @@ export type ErrorTags = NonNullable<Event['tags']>;
 export type ReportingOptions = {
 	/** Whether the error should be reported to Sentry */
 	shouldReport?: boolean;
+	/** Whether the error log should be logged (default to true) */
+	shouldBeLogged?: boolean;
 	level?: ErrorLevel;
 	tags?: ErrorTags;
 	extra?: Event['extra'];


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

The current check for node output data returns a lot of false positive because of the `pairedItem` output that sometimes contains an undefined value. 
This PR adds the possibility to ignore specific keys when checking for incorrect output, so that the algorithm will disregard those key values when checking.
It's an heuristic, but since this code is mostly used for internal monitoring of incorrect output data, it's ok to have true negative (in case the node really returns a `pairedItem` data)

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-3085/fix-check-node-incorrect-output-data

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
