### PR TITLE
fix(Think Tool Node): Use dynamic tool name based on node name

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolThink/ToolThink.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolThink/ToolThink.node.ts
@@ -1,6 +1,7 @@
 import { DynamicTool } from 'langchain/tools';
 import {
 	NodeConnectionTypes,
+	nodeNameToToolName,
 	type INodeType,
 	type INodeTypeDescription,
 	type ISupplyDataFunctions,
@@ -22,7 +23,7 @@ export class ToolThink implements INodeType {
 		icon: 'fa:brain',
 		iconColor: 'black',
 		group: ['transform'],
-		version: 1,
+		version: [1, 1.1],
 		description: 'Invite the AI agent to do some thinking',
 		defaults: {
 			name: 'Think',
@@ -62,9 +63,14 @@ export class ToolThink implements INodeType {
 	};
 
 	async supplyData(this: ISupplyDataFunctions, itemIndex: number): Promise<SupplyData> {
+		const node = this.getNode();
+		const { typeVersion } = node;
+
+		const name = typeVersion === 1 ? 'thinking_tool' : nodeNameToToolName(node);
 		const description = this.getNodeParameter('description', itemIndex) as string;
+
 		const tool = new DynamicTool({
-			name: 'thinking_tool',
+			name,
 			description,
 			func: async (subject: string) => {
 				return subject;

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolThink/test/ToolThink.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolThink/test/ToolThink.node.test.ts
@@ -1,27 +1,34 @@
 import { mock } from 'jest-mock-extended';
 import { DynamicTool } from 'langchain/tools';
-import type { ISupplyDataFunctions } from 'n8n-workflow';
+import type { ISupplyDataFunctions, INode } from 'n8n-workflow';
 
 import { ToolThink } from '../ToolThink.node';
 
 describe('ToolThink', () => {
 	const thinkTool = new ToolThink();
 	const helpers = mock<ISupplyDataFunctions['helpers']>();
-	const executeFunctions = mock<ISupplyDataFunctions>({
-		helpers,
-	});
-	executeFunctions.addInputData.mockReturnValue({ index: 0 });
-	executeFunctions.getNodeParameter.mockImplementation((paramName: string) => {
-		switch (paramName) {
-			case 'description':
-				return 'Tool description';
-			default:
-				return undefined;
-		}
-	});
+
+	const createExecuteFunctions = (node: Partial<INode> = { typeVersion: 1 }) => {
+		const executeFunctions = mock<ISupplyDataFunctions>({
+			helpers,
+		});
+		executeFunctions.addInputData.mockReturnValue({ index: 0 });
+		executeFunctions.getNodeParameter.mockImplementation((paramName: string) => {
+			switch (paramName) {
+				case 'description':
+					return 'Tool description';
+				default:
+					return undefined;
+			}
+		});
+		executeFunctions.getNode.mockReturnValue(mock<INode>(node));
+		return executeFunctions;
+	};
 
 	describe('Tool response', () => {
 		it('should return the same text as response when receiving a text input', async () => {
+			const executeFunctions = createExecuteFunctions();
+
 			const { response } = (await thinkTool.supplyData.call(executeFunctions, 0)) as {
 				response: DynamicTool;
 			};
@@ -29,6 +36,27 @@ describe('ToolThink', () => {
 			expect(response.description).toEqual('Tool description');
 			const res = (await response.invoke('foo')) as string;
 			expect(res).toEqual('foo');
+		});
+
+		it('should use hardcoded name for version 1', async () => {
+			const executeFunctions = createExecuteFunctions({ typeVersion: 1 });
+
+			const { response } = (await thinkTool.supplyData.call(executeFunctions, 0)) as {
+				response: DynamicTool;
+			};
+			expect(response.name).toEqual('thinking_tool');
+		});
+
+		it('should use dynamic name from node for version 1.1', async () => {
+			const executeFunctions = createExecuteFunctions({
+				typeVersion: 1.1,
+				name: 'My Thinking Tool',
+			});
+
+			const { response } = (await thinkTool.supplyData.call(executeFunctions, 0)) as {
+				response: DynamicTool;
+			};
+			expect(response.name).toEqual('My_Thinking_Tool');
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Previously think tool used a hardcoded tool name 'thinking_tool'. The change is to use node's name, same as other tool nodes do.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-1198/tech-debt-make-thinking-tool-use-dynamic-name

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
