### PR TITLE
refactor(editor): Fix warnings caused by missing child (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/components/Node/NodeCreation.vue
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreation.vue
@@ -139,10 +139,9 @@ function onAskAssistantButtonClick() {
 				@click="focusPanelStore.toggleFocusPanel"
 			/>
 		</KeyboardShortcutTooltip>
-		<n8n-tooltip placement="left">
+		<n8n-tooltip v-if="assistantStore.canShowAssistantButtonsOnCanvas" placement="left">
 			<template #content> {{ i18n.baseText('aiAssistant.tooltip') }}</template>
 			<n8n-button
-				v-if="assistantStore.canShowAssistantButtonsOnCanvas"
 				type="tertiary"
 				size="large"
 				square

--- a/packages/frontend/editor-ui/src/components/Projects/ProjectCardBadge.vue
+++ b/packages/frontend/editor-ui/src/components/Projects/ProjectCardBadge.vue
@@ -153,9 +153,12 @@ const projectLocation = computed(() => {
 </script>
 <template>
 	<div :class="{ [$style.wrapper]: true, [$style['no-border']]: showBadgeBorder }" v-bind="$attrs">
-		<N8nTooltip :disabled="!badgeTooltip || numberOfMembersInHomeTeamProject !== 0" placement="top">
+		<N8nTooltip
+			v-if="badgeText"
+			:disabled="!badgeTooltip || numberOfMembersInHomeTeamProject !== 0"
+			placement="top"
+		>
 			<N8nBadge
-				v-if="badgeText"
 				:class="[$style.badge, $style.projectBadge]"
 				theme="tertiary"
 				data-test-id="card-badge"
@@ -172,13 +175,12 @@ const projectLocation = computed(() => {
 			</template>
 		</N8nTooltip>
 		<slot />
-		<N8nTooltip :disabled="!badgeTooltip || numberOfMembersInHomeTeamProject === 0" placement="top">
-			<div
-				v-if="numberOfMembersInHomeTeamProject"
-				:class="$style['count-badge']"
-				theme="tertiary"
-				bold
-			>
+		<N8nTooltip
+			v-if="numberOfMembersInHomeTeamProject"
+			:disabled="!badgeTooltip || numberOfMembersInHomeTeamProject === 0"
+			placement="top"
+		>
+			<div :class="$style['count-badge']" theme="tertiary" bold>
 				+{{ numberOfMembersInHomeTeamProject }}
 			</div>
 			<template #content>

--- a/packages/frontend/editor-ui/src/components/Projects/ProjectNavigation.vue
+++ b/packages/frontend/editor-ui/src/components/Projects/ProjectNavigation.vue
@@ -8,6 +8,7 @@ import type { ProjectListItem } from '@/types/projects.types';
 import { useGlobalEntityCreation } from '@/composables/useGlobalEntityCreation';
 import { useSettingsStore } from '@/stores/settings.store';
 import { useUsersStore } from '@/stores/users.store';
+import { ElMenu } from 'element-plus';
 
 type Props = {
 	collapsed: boolean;
@@ -128,12 +129,12 @@ onBeforeMount(async () => {
 		>
 			<span>{{ locale.baseText('projects.menu.title') }}</span>
 			<N8nTooltip
+				v-if="projectsStore.canCreateProjects"
 				placement="right"
 				:disabled="projectsStore.hasPermissionToCreateProjects"
 				:content="locale.baseText('projects.create.permissionDenied')"
 			>
 				<N8nButton
-					v-if="projectsStore.canCreateProjects"
 					icon="plus"
 					text
 					data-test-id="project-plus-button"
@@ -162,12 +163,12 @@ onBeforeMount(async () => {
 			/>
 		</ElMenu>
 		<N8nTooltip
+			v-if="showAddFirstProject"
 			placement="right"
 			:disabled="projectsStore.hasPermissionToCreateProjects"
 			:content="locale.baseText('projects.create.permissionDenied')"
 		>
 			<N8nButton
-				v-if="showAddFirstProject"
 				:class="[
 					$style.addFirstProjectBtn,
 					{

--- a/packages/frontend/editor-ui/src/components/RunDataTable.vue
+++ b/packages/frontend/editor-ui/src/components/RunDataTable.vue
@@ -514,6 +514,7 @@ watch(
 						@mouseleave="onMouseLeaveCell"
 					>
 						<N8nTooltip
+							v-if="tableData.metadata.data[index1]"
 							:content="
 								i18n.baseText('runData.table.viewSubExecution', {
 									interpolate: {
@@ -525,7 +526,6 @@ watch(
 							:hide-after="0"
 						>
 							<N8nIconButton
-								v-if="tableData.metadata.data[index1]"
 								v-show="showExecutionLink(index1)"
 								element="a"
 								type="secondary"
@@ -676,6 +676,7 @@ watch(
 						@mouseleave="onMouseLeaveCell"
 					>
 						<N8nTooltip
+							v-if="tableData.metadata.data[index1]"
 							:content="
 								i18n.baseText('runData.table.viewSubExecution', {
 									interpolate: {
@@ -687,7 +688,6 @@ watch(
 							:hide-after="0"
 						>
 							<N8nIconButton
-								v-if="tableData.metadata.data[index1]"
 								v-show="showExecutionLink(index1)"
 								element="a"
 								type="secondary"

--- a/packages/frontend/editor-ui/src/components/canvas/elements/nodes/CanvasNodeToolbar.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/elements/nodes/CanvasNodeToolbar.vue
@@ -118,12 +118,12 @@ function onFocusNode() {
 	>
 		<div :class="$style.canvasNodeToolbarItems">
 			<N8nTooltip
+				v-if="isExecuteNodeVisible"
 				placement="top"
 				:disabled="!isDisabled"
 				:content="i18n.baseText('ndv.execute.deactivated')"
 			>
 				<N8nIconButton
-					v-if="isExecuteNodeVisible"
 					data-test-id="execute-node-button"
 					type="tertiary"
 					text


### PR DESCRIPTION
## Summary
This PR fixes warnings like below shown while developing editor UI locally.

<img width="718" height="375" alt="Screenshot 2025-07-16 at 13 52 15" src="https://github.com/user-attachments/assets/9e9ebb03-dc65-43b1-a7f0-fbae2b95c18e" />

## Related Linear tickets, Github issues, and Community forum posts

Part of https://linear.app/n8n/issue/SUG-100/tech-debt-clean-up-warnings-in-browsers-console


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
