### PR TITLE
build(editor): Skip config endpoint insertion in local dev (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/index.html
+++ b/packages/frontend/editor-ui/index.html
@@ -6,7 +6,7 @@
 		<meta name="viewport" content="width=device-width,initial-scale=1.0" />
 		<link rel="icon" href="/favicon.ico" />
 		<style>@media (prefers-color-scheme: dark) { body { background-color: rgb(45, 46, 46) } }</style>
-		<script src="/{{REST_ENDPOINT}}/config.js"></script>
+		%CONFIG_SCRIPT%
 		<script>!function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag onFeatureFlags reloadFeatureFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[])</script>
 
 		<title>n8n.io - Workflow Automation</title>

--- a/packages/frontend/editor-ui/vite.config.mts
+++ b/packages/frontend/editor-ui/vite.config.mts
@@ -115,6 +115,16 @@ const plugins = [
 		modernPolyfills: true,
 		renderLegacyChunks: false,
 	}),
+	{
+		name: 'Insert config script',
+		transformIndexHtml: (html, ctx) => {
+			const replacement = ctx.server
+				? '' // Skip when using Vite dev server
+				: '<script src="/{{REST_ENDPOINT}}/config.js"></script>';
+
+			return html.replace('%CONFIG_SCRIPT%', replacement);
+		},
+	},
 ];
 
 const { RELEASE: release } = process.env;


### PR DESCRIPTION
## Summary

This PR fixes the confusing error below that appears when opening editor UI through Vite dev server (with `pnpm run dev` command).

<img width="792" height="81" alt="Screenshot 2025-07-16 at 15 25 07" src="https://github.com/user-attachments/assets/194a89a6-fec2-47cb-a6b6-4a27943b894d" />


## Related Linear tickets, Github issues, and Community forum posts

Part of https://linear.app/n8n/issue/SUG-100/tech-debt-clean-up-warnings-in-browsers-console


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
