### PR TITLE
feat(editor): New users see whatsnew notification only if new

### DIFF
--- a/packages/frontend/editor-ui/src/stores/versions.store.test.ts
+++ b/packages/frontend/editor-ui/src/stores/versions.store.test.ts
@@ -528,6 +528,7 @@ describe('shouldShowWhatsNewCallout', () => {
 	});
 
 	it('returns false if there are no articles', () => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		vi.mocked(useUsersStore).mockReturnValue({ currentUser: null } as any);
 		versionsStore = useVersionsStore();
 		Object.defineProperty(versionsStore, 'lastDismissedWhatsNewCallout', { get: () => [] });
@@ -536,6 +537,7 @@ describe('shouldShowWhatsNewCallout', () => {
 	});
 
 	it('returns true if user has no createdAt and not all articles are dismissed', () => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		vi.mocked(useUsersStore).mockReturnValue({ currentUser: null } as any);
 		versionsStore = useVersionsStore();
 		Object.defineProperty(versionsStore, 'lastDismissedWhatsNewCallout', { get: () => [] });
@@ -544,6 +546,7 @@ describe('shouldShowWhatsNewCallout', () => {
 	});
 
 	it('returns false if all articles are dismissed', () => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		vi.mocked(useUsersStore).mockReturnValue({ currentUser: null } as any);
 		versionsStore = useVersionsStore();
 		versionsStore.whatsNew.items = [makeArticle()];
@@ -555,7 +558,8 @@ describe('shouldShowWhatsNewCallout', () => {
 		const now = Date.now();
 		vi.mocked(useUsersStore).mockReturnValue({
 			currentUser: { createdAt: new Date(now - 10000).toISOString() },
-		});
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		} as any);
 		versionsStore = useVersionsStore();
 		Object.defineProperty(versionsStore, 'lastDismissedWhatsNewCallout', { get: () => [] });
 		versionsStore.whatsNew.items = [makeArticle({ updatedAt: new Date(now).toISOString() })];
@@ -566,7 +570,8 @@ describe('shouldShowWhatsNewCallout', () => {
 		const now = Date.now();
 		vi.mocked(useUsersStore).mockReturnValue({
 			currentUser: { createdAt: new Date(now).toISOString() },
-		});
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		} as any);
 		versionsStore = useVersionsStore();
 		Object.defineProperty(versionsStore, 'lastDismissedWhatsNewCallout', { get: () => [] });
 		versionsStore.whatsNew.items = [
@@ -578,7 +583,8 @@ describe('shouldShowWhatsNewCallout', () => {
 	it('handles missing updatedAt on article', () => {
 		vi.mocked(useUsersStore).mockReturnValue({
 			currentUser: { createdAt: new Date().toISOString() },
-		});
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		} as any);
 		versionsStore = useVersionsStore();
 		Object.defineProperty(versionsStore, 'lastDismissedWhatsNewCallout', { get: () => [] });
 		versionsStore.whatsNew.items = [makeArticle({ updatedAt: undefined })];

--- a/packages/frontend/editor-ui/src/stores/versions.store.test.ts
+++ b/packages/frontend/editor-ui/src/stores/versions.store.test.ts
@@ -555,7 +555,7 @@ describe('shouldShowWhatsNewCallout', () => {
 		const now = Date.now();
 		vi.mocked(useUsersStore).mockReturnValue({
 			currentUser: { createdAt: new Date(now - 10000).toISOString() },
-		} as any);
+		});
 		versionsStore = useVersionsStore();
 		Object.defineProperty(versionsStore, 'lastDismissedWhatsNewCallout', { get: () => [] });
 		versionsStore.whatsNew.items = [makeArticle({ updatedAt: new Date(now).toISOString() })];
@@ -566,7 +566,7 @@ describe('shouldShowWhatsNewCallout', () => {
 		const now = Date.now();
 		vi.mocked(useUsersStore).mockReturnValue({
 			currentUser: { createdAt: new Date(now).toISOString() },
-		} as any);
+		});
 		versionsStore = useVersionsStore();
 		Object.defineProperty(versionsStore, 'lastDismissedWhatsNewCallout', { get: () => [] });
 		versionsStore.whatsNew.items = [
@@ -578,7 +578,7 @@ describe('shouldShowWhatsNewCallout', () => {
 	it('handles missing updatedAt on article', () => {
 		vi.mocked(useUsersStore).mockReturnValue({
 			currentUser: { createdAt: new Date().toISOString() },
-		} as any);
+		});
 		versionsStore = useVersionsStore();
 		Object.defineProperty(versionsStore, 'lastDismissedWhatsNewCallout', { get: () => [] });
 		versionsStore.whatsNew.items = [makeArticle({ updatedAt: undefined })];

--- a/packages/frontend/editor-ui/src/stores/versions.store.test.ts
+++ b/packages/frontend/editor-ui/src/stores/versions.store.test.ts
@@ -543,13 +543,13 @@ describe('shouldShowWhatsNewCallout', () => {
 		expect(versionsStore.shouldShowWhatsNewCallout()).toBe(true);
 	});
 
-	// it('returns false if all articles are dismissed', () => {
-	// 	vi.mocked(useUsersStore).mockReturnValue({ currentUser: null } as any);
-	// 	localStorage.setItem('n8n_whats_new_callout_dismissed', '[1]');
-	// 	versionsStore = useVersionsStore();
-	// 	versionsStore.whatsNew.items = [makeArticle()];
-	// 	expect(versionsStore.shouldShowWhatsNewCallout()).toBe(false);
-	// });
+	it('returns false if all articles are dismissed', () => {
+		vi.mocked(useUsersStore).mockReturnValue({ currentUser: null } as any);
+		versionsStore = useVersionsStore();
+		versionsStore.whatsNew.items = [makeArticle()];
+		versionsStore.dismissWhatsNewCallout();
+		expect(versionsStore.shouldShowWhatsNewCallout()).toBe(false);
+	});
 
 	it('returns true if user createdAt is before article updatedAt', () => {
 		const now = Date.now();

--- a/packages/frontend/editor-ui/src/stores/versions.store.test.ts
+++ b/packages/frontend/editor-ui/src/stores/versions.store.test.ts
@@ -1,5 +1,6 @@
 import { createPinia, setActivePinia } from 'pinia';
 import { useVersionsStore } from './versions.store';
+import { useUsersStore } from './users.store';
 import * as versionsApi from '@n8n/rest-api-client/api/versions';
 import type { IVersionNotificationSettings } from '@n8n/api-types';
 import type { Version, WhatsNewArticle, WhatsNewSection } from '@n8n/rest-api-client/api/versions';
@@ -17,6 +18,8 @@ vi.mock('@/composables/useToast', () => {
 		},
 	};
 });
+
+vi.mock('./users.store');
 
 const settings: IVersionNotificationSettings = {
 	enabled: true,
@@ -503,5 +506,82 @@ describe('versions.store', () => {
 
 			expect(versionsStore.hasSignificantUpdates).toBe(false);
 		});
+	});
+});
+
+describe('shouldShowWhatsNewCallout', () => {
+	let versionsStore: ReturnType<typeof useVersionsStore>;
+
+	const makeArticle = (overrides: Partial<WhatsNewArticle> = {}): WhatsNewArticle => ({
+		id: 1,
+		title: 'Test',
+		content: 'Content',
+		createdAt: new Date().toISOString(),
+		updatedAt: new Date().toISOString(),
+		publishedAt: new Date().toISOString(),
+		...overrides,
+	});
+
+	beforeEach(() => {
+		localStorage.clear();
+		setActivePinia(createPinia());
+	});
+
+	it('returns false if there are no articles', () => {
+		vi.mocked(useUsersStore).mockReturnValue({ currentUser: null } as any);
+		versionsStore = useVersionsStore();
+		Object.defineProperty(versionsStore, 'lastDismissedWhatsNewCallout', { get: () => [] });
+		versionsStore.whatsNew.items = [];
+		expect(versionsStore.shouldShowWhatsNewCallout()).toBe(false);
+	});
+
+	it('returns true if user has no createdAt and not all articles are dismissed', () => {
+		vi.mocked(useUsersStore).mockReturnValue({ currentUser: null } as any);
+		versionsStore = useVersionsStore();
+		Object.defineProperty(versionsStore, 'lastDismissedWhatsNewCallout', { get: () => [] });
+		versionsStore.whatsNew.items = [makeArticle()];
+		expect(versionsStore.shouldShowWhatsNewCallout()).toBe(true);
+	});
+
+	// it('returns false if all articles are dismissed', () => {
+	// 	vi.mocked(useUsersStore).mockReturnValue({ currentUser: null } as any);
+	// 	localStorage.setItem('n8n_whats_new_callout_dismissed', '[1]');
+	// 	versionsStore = useVersionsStore();
+	// 	versionsStore.whatsNew.items = [makeArticle()];
+	// 	expect(versionsStore.shouldShowWhatsNewCallout()).toBe(false);
+	// });
+
+	it('returns true if user createdAt is before article updatedAt', () => {
+		const now = Date.now();
+		vi.mocked(useUsersStore).mockReturnValue({
+			currentUser: { createdAt: new Date(now - 10000).toISOString() },
+		} as any);
+		versionsStore = useVersionsStore();
+		Object.defineProperty(versionsStore, 'lastDismissedWhatsNewCallout', { get: () => [] });
+		versionsStore.whatsNew.items = [makeArticle({ updatedAt: new Date(now).toISOString() })];
+		expect(versionsStore.shouldShowWhatsNewCallout()).toBe(true);
+	});
+
+	it('returns false if user createdAt is after article updatedAt', () => {
+		const now = Date.now();
+		vi.mocked(useUsersStore).mockReturnValue({
+			currentUser: { createdAt: new Date(now).toISOString() },
+		} as any);
+		versionsStore = useVersionsStore();
+		Object.defineProperty(versionsStore, 'lastDismissedWhatsNewCallout', { get: () => [] });
+		versionsStore.whatsNew.items = [
+			makeArticle({ updatedAt: new Date(now - 10000).toISOString() }),
+		];
+		expect(versionsStore.shouldShowWhatsNewCallout()).toBe(false);
+	});
+
+	it('handles missing updatedAt on article', () => {
+		vi.mocked(useUsersStore).mockReturnValue({
+			currentUser: { createdAt: new Date().toISOString() },
+		} as any);
+		versionsStore = useVersionsStore();
+		Object.defineProperty(versionsStore, 'lastDismissedWhatsNewCallout', { get: () => [] });
+		versionsStore.whatsNew.items = [makeArticle({ updatedAt: undefined })];
+		expect(versionsStore.shouldShowWhatsNewCallout()).toBe(false);
 	});
 });

--- a/packages/frontend/editor-ui/src/stores/versions.store.ts
+++ b/packages/frontend/editor-ui/src/stores/versions.store.ts
@@ -185,6 +185,7 @@ export const useVersionsStore = defineStore(STORES.VERSIONS, () => {
 		const allArticlesDismissed = whatsNewArticles.value.every((item) =>
 			lastDismissedWhatsNewCallout.value.includes(item.id),
 		);
+
 		return hasNewArticle && !allArticlesDismissed;
 	};
 
@@ -287,5 +288,6 @@ export const useVersionsStore = defineStore(STORES.VERSIONS, () => {
 		isWhatsNewArticleRead,
 		setWhatsNewArticleRead,
 		closeWhatsNewCallout,
+		shouldShowWhatsNewCallout,
 	};
 });

--- a/packages/frontend/editor-ui/src/stores/versions.store.ts
+++ b/packages/frontend/editor-ui/src/stores/versions.store.ts
@@ -289,5 +289,6 @@ export const useVersionsStore = defineStore(STORES.VERSIONS, () => {
 		setWhatsNewArticleRead,
 		closeWhatsNewCallout,
 		shouldShowWhatsNewCallout,
+		dismissWhatsNewCallout,
 	};
 });


### PR DESCRIPTION
## Summary

Whats new notification is only shown if an article has an update date higher than the created at date for the user

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/ADO-3824/exclude-new-users-from-receiving-the-whatsnew-notification
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
