### PR TITLE
fix(OpenAi Node): optional chaining for error handling in router

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/router.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/router.test.ts
@@ -1,0 +1,42 @@
+import { mockDeep } from 'jest-mock-extended';
+import type { IExecuteFunctions, INode } from 'n8n-workflow';
+import { NodeApiError } from 'n8n-workflow';
+
+import * as audio from './audio';
+import { router } from './router';
+
+describe('OpenAI router', () => {
+	const mockExecuteFunctions = mockDeep<IExecuteFunctions>();
+	const mockAudio = jest.spyOn(audio.transcribe, 'execute');
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should handle NodeApiError undefined error chaining', async () => {
+		const errorNode: INode = {
+			id: 'error-node-id',
+			name: 'ErrorNode',
+			type: 'test.error',
+			typeVersion: 1,
+			position: [100, 200],
+			parameters: {},
+		};
+		const nodeApiError = new NodeApiError(
+			errorNode,
+			{ message: 'API error occurred', error: { error: { message: 'Rate limit exceeded' } } },
+			{ itemIndex: 0 },
+		);
+
+		mockExecuteFunctions.getNodeParameter.mockImplementation((parameter) =>
+			parameter === 'resource' ? 'audio' : 'transcribe',
+		);
+		mockExecuteFunctions.getInputData.mockReturnValue([{ json: {} }]);
+		mockExecuteFunctions.getNode.mockReturnValue(errorNode);
+		mockExecuteFunctions.continueOnFail.mockReturnValue(false);
+
+		mockAudio.mockRejectedValue(nodeApiError);
+
+		await expect(router.call(mockExecuteFunctions)).rejects.toThrow(NodeApiError);
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/router.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/router.ts
@@ -62,7 +62,7 @@ export async function router(this: IExecuteFunctions) {
 
 			if (error instanceof NodeApiError) {
 				// If the error is a rate limit error, we want to handle it differently
-				const errorCode: string | undefined = (error.cause as any).error?.error?.code;
+				const errorCode: string | undefined = (error.cause as any)?.error?.error?.code;
 				if (errorCode) {
 					const customErrorMessage = getCustomErrorMessage(errorCode);
 					if (customErrorMessage) {


### PR DESCRIPTION
## Summary

Fixes optional chaining for error handing in OpenAI router

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/GHC-3149

fixes #17389 

https://community.n8n.io/t/bug-openai-message-a-model-node-fails-cannot-read-properties-of-undefined-reading-error/151173


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
