### PR TITLE
refactor(core): Add env var to disable Python execution

### DIFF
--- a/packages/@n8n/config/src/configs/nodes.config.ts
+++ b/packages/@n8n/config/src/configs/nodes.config.ts
@@ -61,7 +61,7 @@ export class NodesConfig {
 	@Env('NODES_ERROR_TRIGGER_TYPE')
 	errorTriggerType: string = 'n8n-nodes-base.errorTrigger';
 
-	/** Whether to enable Python execution. */
+	/** Whether to enable Python execution on the Code node. */
 	@Env('N8N_PYTHON_ENABLED')
 	pythonEnabled: boolean = true;
 

--- a/packages/@n8n/config/src/configs/nodes.config.ts
+++ b/packages/@n8n/config/src/configs/nodes.config.ts
@@ -61,6 +61,10 @@ export class NodesConfig {
 	@Env('NODES_ERROR_TRIGGER_TYPE')
 	errorTriggerType: string = 'n8n-nodes-base.errorTrigger';
 
+	/** Whether to enable Python execution. */
+	@Env('N8N_PYTHON_ENABLED')
+	pythonEnabled: boolean = true;
+
 	@Nested
 	communityPackages: CommunityPackagesConfig;
 }

--- a/packages/@n8n/config/src/index.ts
+++ b/packages/@n8n/config/src/index.ts
@@ -48,6 +48,7 @@ export { DeploymentConfig } from './configs/deployment.config';
 export { MfaConfig } from './configs/mfa.config';
 export { HiringBannerConfig } from './configs/hiring-banner.config';
 export { PersonalizationConfig } from './configs/personalization.config';
+export { NodesConfig } from './configs/nodes.config';
 
 const protocolSchema = z.enum(['http', 'https']);
 

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -149,6 +149,7 @@ describe('GlobalConfig', () => {
 			errorTriggerType: 'n8n-nodes-base.errorTrigger',
 			include: [],
 			exclude: [],
+			pythonEnabled: true,
 		},
 		publicApi: {
 			disabled: false,

--- a/packages/nodes-base/nodes/Code/Code.node.ts
+++ b/packages/nodes-base/nodes/Code/Code.node.ts
@@ -1,8 +1,9 @@
-import { TaskRunnersConfig } from '@n8n/config';
+import { NodesConfig, TaskRunnersConfig } from '@n8n/config';
 import { Container } from '@n8n/di';
 import set from 'lodash/set';
 import {
 	NodeConnectionTypes,
+	UserError,
 	type CodeExecutionMode,
 	type CodeNodeEditorLanguage,
 	type IExecuteFunctions,
@@ -20,6 +21,14 @@ import { getSandboxContext } from './Sandbox';
 import { addPostExecutionWarning, standardizeOutput } from './utils';
 
 const { CODE_ENABLE_STDOUT } = process.env;
+
+class PythonDisabledError extends UserError {
+	constructor() {
+		super(
+			'This instance disallows Python execution because it has the environment variable `N8N_PYTHON_ENABLED` set to `false`. To restore Python execution, remove this environment variable or set it to `true` and restart the instance.',
+		);
+	}
+}
 
 export class Code implements INodeType {
 	description: INodeTypeDescription = {
@@ -96,16 +105,20 @@ export class Code implements INodeType {
 	};
 
 	async execute(this: IExecuteFunctions) {
-		const runnersConfig = Container.get(TaskRunnersConfig);
-
-		const nodeMode = this.getNodeParameter('mode', 0) as CodeExecutionMode;
-		const workflowMode = this.getMode();
-
 		const node = this.getNode();
 		const language: CodeNodeEditorLanguage =
 			node.typeVersion === 2
 				? (this.getNodeParameter('language', 0) as CodeNodeEditorLanguage)
 				: 'javaScript';
+
+		if (language === 'python' && !Container.get(NodesConfig).pythonEnabled) {
+			// eslint-disable-next-line n8n-nodes-base/node-execute-block-wrong-error-thrown
+			throw new PythonDisabledError();
+		}
+
+		const runnersConfig = Container.get(TaskRunnersConfig);
+		const nodeMode = this.getNodeParameter('mode', 0) as CodeExecutionMode;
+		const workflowMode = this.getMode();
 		const codeParameterName = language === 'python' ? 'pythonCode' : 'jsCode';
 
 		if (runnersConfig.enabled && language === 'javaScript') {


### PR DESCRIPTION
## Summary

This PR introduces the `N8N_PYTHON_ENABLED` env var to give users a way to prevent Python from executing on their instance.

This is a backend check only. Decided not to hide the option on the node type definition, to prevent this change from discarding the user's existing Python scripts, in case they disable Python and decide to re-enable it later.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
