### PR TITLE
refactor(core): Add language to node graph schema for Code nodes

### DIFF
--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2629,6 +2629,7 @@ export interface INodeGraphItem {
 	runs?: number;
 	items_total?: number;
 	metric_names?: string[];
+	language?: string; // only for Code node: 'javascript' or 'python'
 }
 
 export interface INodeNameIndex {

--- a/packages/workflow/src/telemetry-helpers.ts
+++ b/packages/workflow/src/telemetry-helpers.ts
@@ -5,6 +5,7 @@ import {
 	CHAIN_LLM_LANGCHAIN_NODE_TYPE,
 	CHAIN_SUMMARIZATION_LANGCHAIN_NODE_TYPE,
 	CHAT_TRIGGER_NODE_TYPE,
+	CODE_NODE_TYPE,
 	EVALUATION_NODE_TYPE,
 	EVALUATION_TRIGGER_NODE_TYPE,
 	EXECUTE_WORKFLOW_NODE_TYPE,
@@ -418,6 +419,10 @@ export function generateNodesGraph(
 			nodeItem.metric_names = (metrics.assignments as Array<{ name: string }> | undefined)?.map(
 				(metric: { name: string }) => metric.name,
 			);
+		} else if (node.type === CODE_NODE_TYPE) {
+			const { language } = node.parameters;
+			nodeItem.language =
+				language === undefined ? 'javascript' : language === 'python' ? 'python' : 'unknown';
 		} else {
 			try {
 				const nodeType = nodeTypes.getByNameAndVersion(node.type, node.typeVersion);


### PR DESCRIPTION
## Summary

This PR adds `language` to the node graph for Code nodes.

Updated [node graph schema](https://www.notion.so/n8n/Node-graph-format-in-telemetry-node_graph_string-083c59448b224e85925182cb7b1fc578).

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.slack.com/archives/C036PA5D42D/p1752750604279449
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
