### PR TITLE
fix(core): Allow undefined workflow owner on source control for retro compatibility

### DIFF
--- a/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
@@ -163,11 +163,14 @@ export class SourceControlImportService {
 					return false;
 				}
 				return (
-					context.hasAccessToAllProjects() || findOwnerProject(remote.owner, accessibleProjects)
+					context.hasAccessToAllProjects() ||
+					(remote.owner && findOwnerProject(remote.owner, accessibleProjects))
 				);
 			})
 			.map((remote) => {
-				const project = findOwnerProject(remote.owner, accessibleProjects);
+				const project = remote.owner
+					? findOwnerProject(remote.owner, accessibleProjects)
+					: undefined;
 				return {
 					id: remote.id,
 					versionId: remote.versionId ?? '',

--- a/packages/cli/src/interfaces.ts
+++ b/packages/cli/src/interfaces.ts
@@ -48,7 +48,7 @@ export interface IWorkflowResponse extends IWorkflowBase {
 
 export interface IWorkflowToImport
 	extends Omit<IWorkflowBase, 'staticData' | 'pinData' | 'createdAt' | 'updatedAt'> {
-	owner:
+	owner?:
 		| {
 				type: 'personal';
 				personalEmail: string;


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Currently, when remote workflow file do not have an owner (because the owner field was introduced quite recently, and before it was not pushed to git files), the code is failing because when parsing remote workflow files, we expect parsed workflow files to have owner defined. 
This PR handles the case when owner does not exist on the workflow file.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
https://linear.app/n8n/issue/PAY-3093/community-issue-source-control-and-environments-error-cannot-read

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
