### PR TITLE
fix(editor): Remove overflow hidden for scrollbar wrap on test run tables

### DIFF
--- a/packages/frontend/editor-ui/src/components/Evaluations.ee/shared/TestTableBase.vue
+++ b/packages/frontend/editor-ui/src/components/Evaluations.ee/shared/TestTableBase.vue
@@ -214,7 +214,8 @@ defineSlots<{
 	border-radius: 12px;
 
 	:global(.el-scrollbar__wrap) {
-		overflow: hidden;
+		overflow-y: hidden;
+		overflow-x: auto;
 	}
 
 	:global(.el-table__column-resize-proxy) {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
An overflow: hidden property on the execution tests table prevented horizontal scroll when the execution test results had too many columns (because columns are dynamic and depend on the selected evaluation metrics).
This PR keeps the overflow hidden on Y axis for retrocompatiblity, but make it auto on X axis.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
