### PR TITLE
fix(editor): Recenter fromAI override close button

### DIFF
--- a/packages/frontend/editor-ui/src/components/ParameterInputOverrides/FromAiOverrideField.vue
+++ b/packages/frontend/editor-ui/src/components/ParameterInputOverrides/FromAiOverrideField.vue
@@ -58,7 +58,7 @@ const emit = defineEmits<{
 }
 
 .overrideCloseButton {
-	padding: 0px 8px 3px; // the icon used is off-center vertically
+	padding: 0px var(--spacing-2xs);
 	border: 0px;
 	color: var(--color-text-base);
 	margin-left: auto;
@@ -68,6 +68,7 @@ const emit = defineEmits<{
 
 .contentOverrideContainer {
 	display: flex;
+	align-items: center;
 	white-space: nowrap;
 	width: 100%;
 	gap: var(--spacing-4xs);


### PR DESCRIPTION
## Summary

Recenter the button, this was broken by the icon change update.

Before:

<img width="389" height="127" alt="image" src="https://github.com/user-attachments/assets/67311030-f35d-422c-93d1-a296b75d25fd" />

After:

<img width="544" height="103" alt="image" src="https://github.com/user-attachments/assets/d053c60b-a2a6-4eea-b573-50ebf3ded757" />



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3849


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
