### PR TITLE
fix(Google Gemini Node): Error when used as tool with "Message a model" operation

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/GoogleGemini.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/GoogleGemini.node.test.ts
@@ -51,6 +51,7 @@ describe('GoogleGemini Node', () => {
 						return undefined;
 				}
 			});
+			executeFunctionsMock.getNodeInputs.mockReturnValue([{ type: 'main' }, { type: 'ai_tool' }]);
 			getConnectedToolsMock.mockResolvedValue([]);
 			apiRequestMock.mockResolvedValue({
 				candidates: [

--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/text/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/text/message.operation.ts
@@ -236,7 +236,10 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 		responseMimeType: jsonOutput ? 'application/json' : undefined,
 	};
 
-	const availableTools = await getConnectedTools(this, true);
+	const nodeInputs = this.getNodeInputs();
+	const availableTools = nodeInputs.some((i) => i.type === 'ai_tool')
+		? await getConnectedTools(this, true)
+		: [];
 	const tools: Tool[] = [
 		{
 			functionDeclarations: availableTools.map((t) => ({


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Fix a bug where the Gemini node always throws an error if used as tool with "Message a model" operation

Workflow to test:
```json
{
  "name": "Gemini as Tool - Message Operation",
  "nodes": [
    {
      "parameters": {
        "promptType": "define",
        "text": "Use \"message a model\" tool to get what's 9 + 10",
        "options": {}
      },
      "type": "@n8n/n8n-nodes-langchain.agent",
      "typeVersion": 2.1,
      "position": [
        224,
        0
      ],
      "id": "f3ef07d6-fe2e-4a83-ba51-989b0d913a4c",
      "name": "AI Agent"
    },
    {
      "parameters": {},
      "type": "n8n-nodes-base.manualTrigger",
      "typeVersion": 1,
      "position": [
        0,
        0
      ],
      "id": "df2b5644-6349-4326-b603-1897fe2e7cc8",
      "name": "When clicking ‘Execute workflow’"
    },
    {
      "parameters": {
        "options": {}
      },
      "type": "@n8n/n8n-nodes-langchain.lmChatGoogleGemini",
      "typeVersion": 1,
      "position": [
        208,
        224
      ],
      "id": "c39c693a-a3f3-43f7-9528-68e92c01d46d",
      "name": "Google Gemini Chat Model",
      "credentials": {
        "googlePalmApi": {
          "id": "54PDtnNoqmwvYOVD",
          "name": "Google Gemini (Login) | Trial"
        }
      }
    },
    {
      "parameters": {
        "modelId": {
          "__rl": true,
          "value": "models/gemini-2.5-flash",
          "mode": "list",
          "cachedResultName": "models/gemini-2.5-flash"
        },
        "messages": {
          "values": [
            {
              "content": "={{ /*n8n-auto-generated-fromAI-override*/ $fromAI('values0_Prompt', ``, 'string') }}"
            }
          ]
        },
        "jsonOutput": true,
        "options": {}
      },
      "type": "@n8n/n8n-nodes-langchain.googleGeminiTool",
      "typeVersion": 1,
      "position": [
        432,
        224
      ],
      "id": "b389a07f-9b97-40b2-b1c7-60c363439a9b",
      "name": "Message a model",
      "credentials": {
        "googlePalmApi": {
          "id": "54PDtnNoqmwvYOVD",
          "name": "Google Gemini (Login) | Trial"
        }
      }
    }
  ],
  "pinData": {},
  "connections": {
    "When clicking ‘Execute workflow’": {
      "main": [
        [
          {
            "node": "AI Agent",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Google Gemini Chat Model": {
      "ai_languageModel": [
        [
          {
            "node": "AI Agent",
            "type": "ai_languageModel",
            "index": 0
          }
        ]
      ]
    },
    "Message a model": {
      "ai_tool": [
        [
          {
            "node": "AI Agent",
            "type": "ai_tool",
            "index": 0
          }
        ]
      ]
    }
  },
  "active": false,
  "settings": {
    "executionOrder": "v1"
  },
  "versionId": "15f449bc-2d3c-4e06-a4e5-7fe68976fbd6",
  "meta": {
    "templateCredsSetupCompleted": true,
    "instanceId": "eeda9e3069aca300d1dfceeb64beb5b53d715db44a50461bbc5cb0cf6daa01e3"
  },
  "id": "sMDpv9o9CyCWTUhc",
  "tags": []
}
```

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-3336/error-in-gemini-node-when-using-it-as-a-tool-with-message-a-model

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
