### PR TITLE
fix(OpenAI Node): Fix memory connector for assistant message

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/message.operation.ts
@@ -281,10 +281,9 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 			await memory.saveContext({ input }, { output: response.output });
 
 			if (response.threadId && response.runId) {
-				const threadRun = await client.beta.threads.runs.retrieve(
-					response.threadId,
-					response.runId,
-				);
+				const threadRun = await client.beta.threads.runs.retrieve(response.runId, {
+					thread_id: response.threadId,
+				});
 				response.usage = threadRun.usage;
 			}
 		}


### PR DESCRIPTION
## Summary

`threads.runs.retrieve` now expects runId and options object as arguments so we need to update it from the old format.

## Related Linear tickets, Github issues, and Community forum posts
fixes #17313

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
