### PR TITLE
chore(core): Provide details on access token exchange error

### DIFF
--- a/packages/@n8n/client-oauth2/src/client-oauth2.ts
+++ b/packages/@n8n/client-oauth2/src/client-oauth2.ts
@@ -42,8 +42,9 @@ export class ResponseError extends Error {
 		readonly status: number,
 		readonly body: unknown,
 		readonly code = 'ESTATUS',
+		readonly message = `HTTP status ${status}`,
 	) {
-		super(`HTTP status ${status}`);
+		super(message);
 	}
 }
 
@@ -133,6 +134,11 @@ export class ClientOAuth2 {
 			return qs.parse(body) as T;
 		}
 
-		throw new Error(`Unsupported content type: ${contentType}`);
+		throw new ResponseError(
+			response.status,
+			body,
+			undefined,
+			`Unsupported content type: ${contentType}`,
+		);
 	}
 }


### PR DESCRIPTION
## Summary

In case we receive an html error page, or a response with a different content type than json or url form encoded in the access token exchange, we should expose more detailed information on the error received.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-3132/community-issue-error-unsupported-content-type-texthtmlcharset=utf-8

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
