### PR TITLE
fix(editor): Only show AI starter pack experiment to cloud users (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/experiments/aiTemplatesStarterCollection/stores/aiTemplatesStarterCollection.store.ts
+++ b/packages/frontend/editor-ui/src/experiments/aiTemplatesStarterCollection/stores/aiTemplatesStarterCollection.store.ts
@@ -12,6 +12,7 @@ import { usePostHog } from '@/stores/posthog.store';
 import { TEMPLATE_ONBOARDING_EXPERIMENT } from '@/constants';
 import { useLocalStorage } from '@vueuse/core';
 import { useI18n } from '@n8n/i18n';
+import { useSettingsStore } from '@/stores/settings.store';
 
 const LOCAL_STORAGE_SETTING_KEY = 'N8N_AI_TEMPLATES_STARTER_COLLECTION_CALL_OUT_DISMISSED';
 
@@ -24,14 +25,16 @@ export const useAITemplatesStarterCollectionStore = defineStore(
 		const foldersStore = useFoldersStore();
 		const workflowsStore = useWorkflowsStore();
 		const posthogStore = usePostHog();
+		const settingsStore = useSettingsStore();
 
 		const calloutDismissedRef = useLocalStorage(LOCAL_STORAGE_SETTING_KEY, false);
 		const calloutDismissed = computed(() => calloutDismissedRef.value);
 
 		const isFeatureEnabled = computed(() => {
 			return (
+				settingsStore.isCloudDeployment &&
 				posthogStore.getVariant(TEMPLATE_ONBOARDING_EXPERIMENT.name) ===
-				TEMPLATE_ONBOARDING_EXPERIMENT.variantStarterPack
+					TEMPLATE_ONBOARDING_EXPERIMENT.variantStarterPack
 			);
 		});
 


### PR DESCRIPTION
## Summary
Fix the `AI Starter pack` experiment so it only shows for cloud users.


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
