### PR TITLE
fix(RabbitMQ Trigger Node): Respect the "Delete From Queue When" option with manual executions

### DIFF
--- a/packages/nodes-base/nodes/RabbitMQ/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/GenericFunctions.ts
@@ -1,8 +1,11 @@
 import * as amqplib from 'amqplib';
 import type {
+	IDeferredPromise,
+	IExecuteResponsePromiseData,
 	IDataObject,
 	IExecuteFunctions,
 	INodeExecutionData,
+	IRun,
 	ITriggerFunctions,
 } from 'n8n-workflow';
 import { jsonParse, sleep } from 'n8n-workflow';
@@ -114,11 +117,11 @@ export class MessageTracker {
 
 	isClosing = false;
 
-	received(message: amqplib.ConsumeMessage) {
+	received(message: amqplib.Message) {
 		this.messages.push(message.fields.deliveryTag);
 	}
 
-	answered(message: amqplib.ConsumeMessage) {
+	answered(message: amqplib.Message) {
 		if (this.messages.length === 0) {
 			return;
 		}
@@ -131,14 +134,16 @@ export class MessageTracker {
 		return this.messages.length;
 	}
 
-	async closeChannel(channel: amqplib.Channel, consumerTag: string) {
+	async closeChannel(channel: amqplib.Channel, consumerTag?: string) {
 		if (this.isClosing) {
 			return;
 		}
 		this.isClosing = true;
 
 		// Do not accept any new messages
-		await channel.cancel(consumerTag);
+		if (consumerTag) {
+			await channel.cancel(consumerTag);
+		}
 
 		let count = 0;
 		let unansweredMessages = this.unansweredMessages();
@@ -195,3 +200,70 @@ export const parseMessage = async (
 		}
 	}
 };
+
+export async function handleMessage(
+	this: ITriggerFunctions,
+	message: amqplib.Message,
+	channel: amqplib.Channel,
+	messageTracker: MessageTracker,
+	acknowledgeMode: string,
+	options: TriggerOptions,
+) {
+	try {
+		if (acknowledgeMode !== 'immediately') {
+			messageTracker.received(message);
+		}
+
+		const item = await parseMessage(message, options, this.helpers);
+
+		let responsePromise: IDeferredPromise<IRun> | undefined = undefined;
+		let responsePromiseHook: IDeferredPromise<IExecuteResponsePromiseData> | undefined = undefined;
+		if (acknowledgeMode !== 'immediately' && acknowledgeMode !== 'laterMessageNode') {
+			responsePromise = this.helpers.createDeferredPromise();
+		} else if (acknowledgeMode === 'laterMessageNode') {
+			responsePromiseHook = this.helpers.createDeferredPromise<IExecuteResponsePromiseData>();
+		}
+		if (responsePromiseHook) {
+			this.emit([[item]], responsePromiseHook, undefined);
+		} else {
+			this.emit([[item]], undefined, responsePromise);
+		}
+		if (responsePromise && acknowledgeMode !== 'laterMessageNode') {
+			// Acknowledge message after the execution finished
+			await responsePromise.promise.then(async (data: IRun) => {
+				if (data.data.resultData.error) {
+					// The execution did fail
+					if (acknowledgeMode === 'executionFinishesSuccessfully') {
+						channel.nack(message);
+						messageTracker.answered(message);
+						return;
+					}
+				}
+				channel.ack(message);
+				messageTracker.answered(message);
+			});
+		} else if (responsePromiseHook && acknowledgeMode === 'laterMessageNode') {
+			await responsePromiseHook.promise.then(() => {
+				channel.ack(message);
+				messageTracker.answered(message);
+			});
+		} else {
+			// Acknowledge message directly
+			channel.ack(message);
+		}
+	} catch (error) {
+		const workflow = this.getWorkflow();
+		const node = this.getNode();
+		if (acknowledgeMode !== 'immediately') {
+			messageTracker.answered(message);
+		}
+
+		this.logger.error(
+			`There was a problem with the RabbitMQ Trigger node "${node.name}" in workflow "${workflow.id}": "${error.message}"`,
+			{
+				node: node.name,
+				workflowId: workflow.id,
+			},
+		);
+	}
+}

--- a/packages/nodes-base/nodes/RabbitMQ/RabbitMQTrigger.node.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/RabbitMQTrigger.node.ts
@@ -1,19 +1,16 @@
 /* eslint-disable n8n-nodes-base/node-filename-against-convention */
 import type { Message } from 'amqplib';
 import type {
-	IDeferredPromise,
-	IExecuteResponsePromiseData,
 	INodeProperties,
 	INodeType,
 	INodeTypeDescription,
-	IRun,
 	ITriggerFunctions,
 	ITriggerResponse,
 } from 'n8n-workflow';
 import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 
 import { rabbitDefaultOptions } from './DefaultOptions';
-import { MessageTracker, rabbitmqConnectQueue, parseMessage } from './GenericFunctions';
+import { MessageTracker, rabbitmqConnectQueue, handleMessage } from './GenericFunctions';
 import type { TriggerOptions } from './types';
 
 export class RabbitMQTrigger implements INodeType {
@@ -207,131 +204,10 @@ export class RabbitMQTrigger implements INodeType {
 		const options = this.getNodeParameter('options', {}) as TriggerOptions;
 		const channel = await rabbitmqConnectQueue.call(this, queue, options);
 
-		if (this.getMode() === 'manual') {
-			const manualTriggerFunction = async () => {
-				// Do only catch a single message when executing manually, else messages will leak
-				await channel.prefetch(1);
-
-				const processMessage = async (message: Message | null) => {
-					if (message !== null) {
-						const item = await parseMessage(message, options, this.helpers);
-						channel.ack(message);
-						this.emit([[item]]);
-					} else {
-						this.emitError(new Error('Connection got closed unexpectedly'));
-					}
-				};
-
-				const existingMessage = await channel.get(queue);
-				if (existingMessage) await processMessage(existingMessage);
-				else await channel.consume(queue, processMessage);
-			};
-
-			const closeFunction = async () => {
-				await channel.close();
-				await channel.connection.close();
-				return;
-			};
-
-			return {
-				closeFunction,
-				manualTriggerFunction,
-			};
-		}
-
-		const parallelMessages = options.parallelMessages ?? -1;
-		if (isNaN(parallelMessages) || parallelMessages === 0 || parallelMessages < -1) {
-			throw new NodeOperationError(
-				this.getNode(),
-				'Parallel message processing limit must be a number greater than zero (or -1 for no limit)',
-			);
-		}
-
-		let acknowledgeMode = options.acknowledge ?? 'immediately';
-
-		if (parallelMessages !== -1 && acknowledgeMode === 'immediately') {
-			// If parallel message limit is set, then the default mode is "executionFinishes"
-			// unless acknowledgeMode got set specifically. Be aware that the mode "immediately"
-			// can not be supported in this case.
-			acknowledgeMode = 'executionFinishes';
-		}
-
 		const messageTracker = new MessageTracker();
+		let acknowledgeMode = options.acknowledge ?? 'immediately';
 		let closeGotCalled = false;
-
-		if (parallelMessages !== -1) {
-			await channel.prefetch(parallelMessages);
-		}
-
-		channel.on('close', () => {
-			if (!closeGotCalled) {
-				this.emitError(new Error('Connection got closed unexpectedly'));
-			}
-		});
-
-		const consumerInfo = await channel.consume(queue, async (message) => {
-			if (message !== null) {
-				try {
-					if (acknowledgeMode !== 'immediately') {
-						messageTracker.received(message);
-					}
-
-					const item = await parseMessage(message, options, this.helpers);
-
-					let responsePromise: IDeferredPromise<IRun> | undefined = undefined;
-					let responsePromiseHook: IDeferredPromise<IExecuteResponsePromiseData> | undefined =
-						undefined;
-					if (acknowledgeMode !== 'immediately' && acknowledgeMode !== 'laterMessageNode') {
-						responsePromise = this.helpers.createDeferredPromise();
-					} else if (acknowledgeMode === 'laterMessageNode') {
-						responsePromiseHook = this.helpers.createDeferredPromise<IExecuteResponsePromiseData>();
-					}
-					if (responsePromiseHook) {
-						this.emit([[item]], responsePromiseHook, undefined);
-					} else {
-						this.emit([[item]], undefined, responsePromise);
-					}
-					if (responsePromise && acknowledgeMode !== 'laterMessageNode') {
-						// Acknowledge message after the execution finished
-						await responsePromise.promise.then(async (data: IRun) => {
-							if (data.data.resultData.error) {
-								// The execution did fail
-								if (acknowledgeMode === 'executionFinishesSuccessfully') {
-									channel.nack(message);
-									messageTracker.answered(message);
-									return;
-								}
-							}
-							channel.ack(message);
-							messageTracker.answered(message);
-						});
-					} else if (responsePromiseHook && acknowledgeMode === 'laterMessageNode') {
-						await responsePromiseHook.promise.then(() => {
-							channel.ack(message);
-							messageTracker.answered(message);
-						});
-					} else {
-						// Acknowledge message directly
-						channel.ack(message);
-					}
-				} catch (error) {
-					const workflow = this.getWorkflow();
-					const node = this.getNode();
-					if (acknowledgeMode !== 'immediately') {
-						messageTracker.answered(message);
-					}
-
-					this.logger.error(
-						`There was a problem with the RabbitMQ Trigger node "${node.name}" in workflow "${workflow.id}": "${error.message}"`,
-						{
-							node: node.name,
-							workflowId: workflow.id,
-						},
-					);
-				}
-			}
-		});
-		const consumerTag = consumerInfo.consumerTag;
+		let consumerTag: string | undefined;
 
 		// The "closeFunction" function gets called by n8n whenever
 		// the workflow gets deactivated and can so clean up.
@@ -351,6 +227,66 @@ export class RabbitMQTrigger implements INodeType {
 				);
 			}
 		};
+
+		if (this.getMode() === 'manual') {
+			const manualTriggerFunction = async () => {
+				// Do only catch a single message when executing manually, else messages will leak
+				await channel.prefetch(1);
+
+				const processMessage = async (message: Message | null) => {
+					if (message !== null) {
+						handleMessage.call(this, message, channel, messageTracker, acknowledgeMode, options);
+					} else {
+						this.emitError(new Error('Connection got closed unexpectedly'));
+					}
+				};
+
+				const existingMessage = await channel.get(queue);
+				if (existingMessage) {
+					await processMessage(existingMessage);
+				} else {
+					const consumerInfo = await channel.consume(queue, processMessage);
+					consumerTag = consumerInfo.consumerTag;
+				}
+			};
+
+			return {
+				closeFunction,
+				manualTriggerFunction,
+			};
+		}
+
+		const parallelMessages = options.parallelMessages ?? -1;
+		if (isNaN(parallelMessages) || parallelMessages === 0 || parallelMessages < -1) {
+			throw new NodeOperationError(
+				this.getNode(),
+				'Parallel message processing limit must be a number greater than zero (or -1 for no limit)',
+			);
+		}
+
+		if (parallelMessages !== -1 && acknowledgeMode === 'immediately') {
+			// If parallel message limit is set, then the default mode is "executionFinishes"
+			// unless acknowledgeMode got set specifically. Be aware that the mode "immediately"
+			// can not be supported in this case.
+			acknowledgeMode = 'executionFinishes';
+		}
+
+		if (parallelMessages !== -1) {
+			await channel.prefetch(parallelMessages);
+		}
+
+		channel.on('close', () => {
+			if (!closeGotCalled) {
+				this.emitError(new Error('Connection got closed unexpectedly'));
+			}
+		});
+
+		const consumerInfo = await channel.consume(queue, async (message) => {
+			if (message !== null) {
+				handleMessage.call(this, message, channel, messageTracker, acknowledgeMode, options);
+			}
+		});
+		consumerTag = consumerInfo.consumerTag;
 
 		return {
 			closeFunction,

--- a/packages/nodes-base/nodes/RabbitMQ/RabbitMQTrigger.node.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/RabbitMQTrigger.node.ts
@@ -235,7 +235,14 @@ export class RabbitMQTrigger implements INodeType {
 
 				const processMessage = async (message: Message | null) => {
 					if (message !== null) {
-						handleMessage.call(this, message, channel, messageTracker, acknowledgeMode, options);
+						void handleMessage.call(
+							this,
+							message,
+							channel,
+							messageTracker,
+							acknowledgeMode,
+							options,
+						);
 					} else {
 						this.emitError(new Error('Connection got closed unexpectedly'));
 					}
@@ -283,7 +290,7 @@ export class RabbitMQTrigger implements INodeType {
 
 		const consumerInfo = await channel.consume(queue, async (message) => {
 			if (message !== null) {
-				handleMessage.call(this, message, channel, messageTracker, acknowledgeMode, options);
+				void handleMessage.call(this, message, channel, messageTracker, acknowledgeMode, options);
 			}
 		});
 		consumerTag = consumerInfo.consumerTag;

--- a/packages/nodes-base/nodes/RabbitMQ/test/RabbitMQTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/test/RabbitMQTrigger.node.test.ts
@@ -1,7 +1,7 @@
 import { mockDeep } from 'jest-mock-extended';
 import type { ITriggerFunctions } from 'n8n-workflow';
 import * as GenericFunctions from '../GenericFunctions';
-import { Channel, GetMessage } from 'amqplib';
+import type { Channel, GetMessage } from 'amqplib';
 import { RabbitMQTrigger } from '../RabbitMQTrigger.node';
 
 describe('RabbitMQTrigger node', () => {

--- a/packages/nodes-base/nodes/RabbitMQ/test/RabbitMQTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/test/RabbitMQTrigger.node.test.ts
@@ -1,0 +1,118 @@
+import { mockDeep } from 'jest-mock-extended';
+import type { ITriggerFunctions } from 'n8n-workflow';
+import * as GenericFunctions from '../GenericFunctions';
+import { Channel, GetMessage } from 'amqplib';
+import { RabbitMQTrigger } from '../RabbitMQTrigger.node';
+
+describe('RabbitMQTrigger node', () => {
+	const trigger = new RabbitMQTrigger();
+	const mockTriggerFunctions = mockDeep<ITriggerFunctions>();
+	const connectSpy = jest.spyOn(GenericFunctions, 'rabbitmqConnectQueue');
+	const handleMessageSpy = jest.spyOn(GenericFunctions, 'handleMessage');
+	const mockChannel = mockDeep<Channel>();
+
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
+	describe('manual execution', () => {
+		it('should get a message from the queue', async () => {
+			const message = {
+				content: {
+					foo: 'bar',
+				},
+				fields: {
+					deliveryTag: 1,
+				},
+			};
+			const options = { acknowledge: 'immediately' };
+			mockTriggerFunctions.getMode.mockReturnValue('manual');
+			mockTriggerFunctions.getNodeParameter.mockImplementation((parameterName) => {
+				switch (parameterName) {
+					case 'queue':
+						return 'testQueue';
+					case 'options':
+						return options;
+				}
+				return undefined;
+			});
+			connectSpy.mockResolvedValue(mockChannel);
+			mockChannel.get.mockResolvedValue(message as unknown as GetMessage);
+
+			const { closeFunction, manualTriggerFunction } =
+				await trigger.trigger.call(mockTriggerFunctions);
+			await manualTriggerFunction!();
+
+			expect(mockChannel.prefetch).toHaveBeenCalledWith(1);
+			expect(mockChannel.get).toHaveBeenCalledWith('testQueue');
+			expect(handleMessageSpy).toHaveBeenCalledWith(
+				message,
+				mockChannel,
+				expect.anything(),
+				'immediately',
+				options,
+			);
+			expect(mockChannel.consume).not.toHaveBeenCalled();
+			expect(mockChannel.close).not.toHaveBeenCalled();
+			await closeFunction!();
+			expect(mockChannel.close).toHaveBeenCalled();
+		});
+
+		it('should listen for a message from the queue', async () => {
+			const options = { acknowledge: 'immediately' };
+			mockTriggerFunctions.getMode.mockReturnValue('manual');
+			mockTriggerFunctions.getNodeParameter.mockImplementation((parameterName) => {
+				switch (parameterName) {
+					case 'queue':
+						return 'testQueue';
+					case 'options':
+						return options;
+				}
+				return undefined;
+			});
+			connectSpy.mockResolvedValue(mockChannel);
+			mockChannel.consume.mockResolvedValue({
+				consumerTag: 'testConsumerTag',
+			});
+
+			const { closeFunction, manualTriggerFunction } =
+				await trigger.trigger.call(mockTriggerFunctions);
+			await manualTriggerFunction!();
+
+			expect(mockChannel.prefetch).toHaveBeenCalledWith(1);
+			expect(mockChannel.consume).toHaveBeenCalledWith('testQueue', expect.anything());
+			expect(mockChannel.close).not.toHaveBeenCalled();
+			await closeFunction!();
+			expect(mockChannel.close).toHaveBeenCalled();
+		});
+	});
+
+	describe('regular execution', () => {
+		it('should listen for a message from the queue', async () => {
+			const options = { acknowledge: 'immediately' };
+			mockTriggerFunctions.getMode.mockReturnValue('trigger');
+			mockTriggerFunctions.getNodeParameter.mockImplementation((parameterName) => {
+				switch (parameterName) {
+					case 'queue':
+						return 'testQueue';
+					case 'options':
+						return options;
+				}
+				return undefined;
+			});
+			connectSpy.mockResolvedValue(mockChannel);
+			mockChannel.consume.mockResolvedValue({
+				consumerTag: 'testConsumerTag',
+			});
+
+			const { closeFunction } = await trigger.trigger.call(mockTriggerFunctions);
+
+			expect(mockChannel.prefetch).not.toHaveBeenCalled();
+			expect(mockChannel.consume).toHaveBeenCalledWith('testQueue', expect.anything());
+			expect(mockChannel.get).not.toHaveBeenCalled();
+			expect(mockChannel.close).not.toHaveBeenCalled();
+			await closeFunction!();
+			expect(mockChannel.close).toHaveBeenCalled();
+		});
+	});
+});


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Fix a bug where the "Delete When Option" is ignored when using manual execution and instead the message is acked immediately after getting it from the queue

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-2601/community-issue-rabbitmq-takes-the-item-from-the-queue-regardless-of
Closes #13732

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
