### PR TITLE
fix(editor): Make sure HTML editor field is not editable when workflow is in read only mode

### DIFF
--- a/packages/frontend/editor-ui/src/components/CodeNodeEditor/AskAI/AskAI.vue
+++ b/packages/frontend/editor-ui/src/components/CodeNodeEditor/AskAI/AskAI.vue
@@ -33,9 +33,15 @@ const emit = defineEmits<{
 	finishedLoading: [];
 }>();
 
-const props = defineProps<{
-	hasChanges: boolean;
-}>();
+const props = withDefaults(
+	defineProps<{
+		hasChanges: boolean;
+		isReadOnly?: boolean;
+	}>(),
+	{
+		isReadOnly: false,
+	},
+);
 
 const { getSchemaForExecutionData, getInputDataWithPinned } = useDataSchema();
 const i18n = useI18n();
@@ -278,6 +284,7 @@ onMounted(() => {
 				:maxlength="ASK_AI_MAX_PROMPT_LENGTH"
 				:placeholder="i18n.baseText('codeNodeEditor.askAi.placeholder')"
 				data-test-id="ask-ai-prompt-input"
+				:readonly="props.isReadOnly"
 				@input="onPromptInput"
 			/>
 		</div>

--- a/packages/frontend/editor-ui/src/components/CodeNodeEditor/CodeNodeEditor.vue
+++ b/packages/frontend/editor-ui/src/components/CodeNodeEditor/CodeNodeEditor.vue
@@ -80,6 +80,7 @@ const { highlightLine, readEditorValue, editor, focus } = useCodeEditor({
 	placeholder,
 	extensions,
 	isReadOnly: () => props.isReadOnly,
+
 	theme: {
 		maxHeight: props.fillParent ? '100%' : '40vh',
 		minHeight: '20vh',
@@ -263,6 +264,7 @@ defineExpose({
 				<AskAI
 					:key="activeTab"
 					:has-changes="hasManualChanges"
+					:is-read-only="props.isReadOnly"
 					@replace-code="onAiReplaceCode"
 					@started-loading="onAiLoadStart"
 					@finished-loading="onAiLoadEnd"

--- a/packages/frontend/editor-ui/src/components/CodeNodeEditor/CodeNodeEditor.vue
+++ b/packages/frontend/editor-ui/src/components/CodeNodeEditor/CodeNodeEditor.vue
@@ -80,7 +80,6 @@ const { highlightLine, readEditorValue, editor, focus } = useCodeEditor({
 	placeholder,
 	extensions,
 	isReadOnly: () => props.isReadOnly,
-
 	theme: {
 		maxHeight: props.fillParent ? '100%' : '40vh',
 		minHeight: '20vh',

--- a/packages/frontend/editor-ui/src/components/HtmlEditor/HtmlEditor.vue
+++ b/packages/frontend/editor-ui/src/components/HtmlEditor/HtmlEditor.vue
@@ -7,7 +7,7 @@ import {
 	foldGutter,
 	indentOnInput,
 } from '@codemirror/language';
-import { Prec } from '@codemirror/state';
+import { Prec, EditorState } from '@codemirror/state';
 import {
 	dropCursor,
 	highlightActiveLine,
@@ -80,6 +80,7 @@ const extensions = computed(() => [
 	indentOnInput(),
 	highlightActiveLine(),
 	mappingDropCursor(),
+	...(props.isReadOnly ? [EditorState.readOnly.of(true)] : []),
 ]);
 const {
 	editor: editorRef,


### PR DESCRIPTION
## Summary

Also, makes the Ask AI tab in the code node, not editable. 

## Before

https://www.loom.com/share/963a99f5be5745b99407d0b42e9c48cb?sid=a1561047-014c-42f2-bdb3-908fdaf59562

## Now

![CleanShot 2025-07-22 at 16 05 39](https://github.com/user-attachments/assets/ba22df90-bfb5-4ff4-b145-b6c9dc88f531)


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3858/can-write-text-in-html-node-and-code-node-ai-tab-even-when-workflow-is

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
