### PR TITLE
fix(editor): Case-sensitive credential search in `NodeCredentials` component

### DIFF
--- a/packages/frontend/editor-ui/src/components/NodeCredentials.test.ts
+++ b/packages/frontend/editor-ui/src/components/NodeCredentials.test.ts
@@ -232,6 +232,15 @@ describe('NodeCredentials', () => {
 
 		expect(screen.queryByText('OpenAi account')).not.toBeInTheDocument();
 		expect(screen.queryByText('Test OpenAi account')).toBeInTheDocument();
+
+		await userEvent.keyboard('{Escape}');
+
+		await userEvent.click(credentialsSelect);
+
+		await userEvent.type(credentialSearch, 'Test');
+
+		expect(screen.queryByText('OpenAi account')).not.toBeInTheDocument();
+		expect(screen.queryByText('Test OpenAi account')).toBeInTheDocument();
 	});
 
 	it('should open the new credential modal when clicked', async () => {

--- a/packages/frontend/editor-ui/src/components/NodeCredentials.vue
+++ b/packages/frontend/editor-ui/src/components/NodeCredentials.vue
@@ -500,7 +500,7 @@ function setFilter(newFilter = '') {
 }
 
 function matches(needle: string, haystack: string) {
-	return haystack.toLocaleLowerCase().includes(needle);
+	return haystack.toLocaleLowerCase().includes(needle.toLocaleLowerCase());
 }
 
 async function onClickCreateCredential(type: ICredentialType | INodeCredentialDescription) {


### PR DESCRIPTION
## Summary

In the matches() function on line 515, only the haystack parameter (credential name) was converted to lowercase using toLocaleLowerCase(), but the needle parameter (user's search input) remained in its original case.

## Before 

https://uploads.linear.app/1c35bbc6-9cd4-427e-8bc5-e5d370a9869f/0795b15e-6aaf-420c-9c57-15ac7e887cc6/3b1914c3-57cf-482c-9bc6-ff69bd134a4f
## Now 

![CleanShot 2025-07-22 at 16 23 53](https://github.com/user-attachments/assets/c004cf9a-7df3-4f16-861e-00dcc5aab980)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3859/credential-search-does-not-work-correctly-with-lower-and-uppercasing

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
