### PR TITLE
fix(editor): Persist SSO protocol setting properly in the UI

### DIFF
--- a/packages/frontend/editor-ui/src/stores/sso.store.ts
+++ b/packages/frontend/editor-ui/src/stores/sso.store.ts
@@ -196,11 +196,20 @@ export const useSSOStore = defineStore('sso', () => {
 		return await ldapApi.runLdapSync(rootStore.restApiContext, data);
 	};
 
+	const initializeSelectedProtocol = () => {
+		if (selectedAuthProtocol.value) return;
+
+		selectedAuthProtocol.value = isDefaultAuthenticationOidc.value
+			? SupportedProtocols.OIDC
+			: SupportedProtocols.SAML;
+	};
+
 	return {
 		showSsoLoginButton,
 		getSSORedirectUrl,
 		initialize,
 		selectedAuthProtocol,
+		initializeSelectedProtocol,
 
 		saml,
 		samlConfig,

--- a/packages/frontend/editor-ui/src/stores/sso.store.ts
+++ b/packages/frontend/editor-ui/src/stores/sso.store.ts
@@ -9,10 +9,18 @@ import type { LdapConfig } from '@n8n/rest-api-client/api/ldap';
 import type { IDataObject } from 'n8n-workflow';
 import { UserManagementAuthenticationMethod } from '@/Interface';
 
+export const SupportedProtocols = {
+	SAML: 'saml',
+	OIDC: 'oidc',
+} as const;
+
+export type SupportedProtocolType = (typeof SupportedProtocols)[keyof typeof SupportedProtocols];
+
 export const useSSOStore = defineStore('sso', () => {
 	const rootStore = useRootStore();
 
 	const authenticationMethod = ref<UserManagementAuthenticationMethod | undefined>(undefined);
+	const selectedAuthProtocol = ref<SupportedProtocolType | undefined>(undefined);
 
 	const showSsoLoginButton = computed(
 		() =>
@@ -192,6 +200,7 @@ export const useSSOStore = defineStore('sso', () => {
 		showSsoLoginButton,
 		getSSORedirectUrl,
 		initialize,
+		selectedAuthProtocol,
 
 		saml,
 		samlConfig,

--- a/packages/frontend/editor-ui/src/stores/sso.test.ts
+++ b/packages/frontend/editor-ui/src/stores/sso.test.ts
@@ -1,5 +1,5 @@
 import { createPinia, setActivePinia } from 'pinia';
-import { useSSOStore } from '@/stores/sso.store';
+import { useSSOStore, SupportedProtocols } from '@/stores/sso.store';
 import type { UserManagementAuthenticationMethod } from '@/Interface';
 
 let ssoStore: ReturnType<typeof useSSOStore>;
@@ -36,4 +36,118 @@ describe('SSO store', () => {
 			expect(ssoStore.showSsoLoginButton).toBe(expectation);
 		},
 	);
+
+	describe('Protocol Selection Initialization', () => {
+		beforeEach(() => {
+			setActivePinia(createPinia());
+			ssoStore = useSSOStore();
+		});
+
+		it('should initialize selectedAuthProtocol to OIDC when default authentication is OIDC', () => {
+			// Initialize with OIDC as default authentication method
+			ssoStore.initialize({
+				authenticationMethod: 'oidc' as UserManagementAuthenticationMethod,
+				config: {
+					oidc: { loginEnabled: true },
+				},
+				features: {
+					saml: false,
+					ldap: false,
+					oidc: true,
+				},
+			});
+
+			// selectedAuthProtocol should be undefined initially
+			expect(ssoStore.selectedAuthProtocol).toBeUndefined();
+
+			// Call initializeSelectedProtocol
+			ssoStore.initializeSelectedProtocol();
+
+			// Should now be set to OIDC
+			expect(ssoStore.selectedAuthProtocol).toBe(SupportedProtocols.OIDC);
+		});
+
+		it('should initialize selectedAuthProtocol to SAML when default authentication is SAML', () => {
+			// Initialize with SAML as default authentication method
+			ssoStore.initialize({
+				authenticationMethod: 'saml' as UserManagementAuthenticationMethod,
+				config: {
+					saml: { loginEnabled: true },
+				},
+				features: {
+					saml: true,
+					ldap: false,
+					oidc: false,
+				},
+			});
+
+			// selectedAuthProtocol should be undefined initially
+			expect(ssoStore.selectedAuthProtocol).toBeUndefined();
+
+			// Call initializeSelectedProtocol
+			ssoStore.initializeSelectedProtocol();
+
+			// Should now be set to SAML
+			expect(ssoStore.selectedAuthProtocol).toBe(SupportedProtocols.SAML);
+		});
+
+		it('should initialize selectedAuthProtocol to SAML when default authentication is email', () => {
+			// Initialize with email as default authentication method
+			ssoStore.initialize({
+				authenticationMethod: 'email' as UserManagementAuthenticationMethod,
+				config: {},
+				features: {
+					saml: true,
+					ldap: false,
+					oidc: true,
+				},
+			});
+
+			// selectedAuthProtocol should be undefined initially
+			expect(ssoStore.selectedAuthProtocol).toBeUndefined();
+
+			// Call initializeSelectedProtocol
+			ssoStore.initializeSelectedProtocol();
+
+			// Should default to SAML when not OIDC
+			expect(ssoStore.selectedAuthProtocol).toBe(SupportedProtocols.SAML);
+		});
+
+		it('should not reinitialize selectedAuthProtocol if already set', () => {
+			// Initialize with SAML as default authentication method
+			ssoStore.initialize({
+				authenticationMethod: 'saml' as UserManagementAuthenticationMethod,
+				config: {
+					saml: { loginEnabled: true },
+				},
+				features: {
+					saml: true,
+					ldap: false,
+					oidc: true,
+				},
+			});
+
+			// Manually set selectedAuthProtocol to OIDC
+			ssoStore.selectedAuthProtocol = SupportedProtocols.OIDC;
+
+			// Call initializeSelectedProtocol
+			ssoStore.initializeSelectedProtocol();
+
+			// Should remain OIDC (not overwritten)
+			expect(ssoStore.selectedAuthProtocol).toBe(SupportedProtocols.OIDC);
+		});
+
+		it('should handle undefined authentication method gracefully', () => {
+			// Don't initialize the store (authenticationMethod remains undefined)
+
+			// selectedAuthProtocol should be undefined initially
+			expect(ssoStore.selectedAuthProtocol).toBeUndefined();
+
+			// Call initializeSelectedProtocol
+			ssoStore.initializeSelectedProtocol();
+
+			// Should default to SAML when authentication method is undefined
+			expect(ssoStore.selectedAuthProtocol).toBe(SupportedProtocols.SAML);
+		});
+	});
 });


### PR DESCRIPTION
## Summary

After configuring the OIDC settings when navigating back to SSO SAML is selected. n8n is not persisting the fact that i setup and chose OIDC

## Related Linear tickets, Github issues, and Community forum posts

PAY-3138

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
