### PR TITLE
fix: Stringify data before sandboxing in sandboxHtmlResponse (no-changelog)

### DIFF
--- a/packages/core/src/__tests__/html-sandbox.test.ts
+++ b/packages/core/src/__tests__/html-sandbox.test.ts
@@ -276,3 +276,20 @@ describe('createHtmlSandboxTransformStream', () => {
 		expect(result).toEqual(getComparableHtml(input));
 	});
 });
+
+describe('sandboxHtmlResponse > not string types', () => {
+	it('should not throw if data is number', () => {
+		const data = 123;
+		expect(() => sandboxHtmlResponse(data)).not.toThrow();
+	});
+
+	it('should not throw if data is object', () => {
+		const data = {};
+		expect(() => sandboxHtmlResponse(data)).not.toThrow();
+	});
+
+	it('should not throw if data is boolean', () => {
+		const data = true;
+		expect(() => sandboxHtmlResponse(data)).not.toThrow();
+	});
+});

--- a/packages/core/src/html-sandbox.ts
+++ b/packages/core/src/html-sandbox.ts
@@ -6,8 +6,6 @@ import { Transform } from 'stream';
  * response in an iframe to make sure the HTML has a different origin.
  */
 export const sandboxHtmlResponse = <T>(data: T) => {
-	if (!data || ['number', 'boolean', 'object'].includes(typeof data)) return data;
-
 	let text;
 	if (typeof data !== 'string') {
 		text = JSON.stringify(data);

--- a/packages/core/src/html-sandbox.ts
+++ b/packages/core/src/html-sandbox.ts
@@ -5,10 +5,19 @@ import { Transform } from 'stream';
  * Sandboxes the HTML response to prevent possible exploitation. Embeds the
  * response in an iframe to make sure the HTML has a different origin.
  */
-export const sandboxHtmlResponse = (html: string) => {
+export const sandboxHtmlResponse = <T>(data: T) => {
+	if (!data || ['number', 'boolean', 'object'].includes(typeof data)) return data;
+
+	let text;
+	if (typeof data !== 'string') {
+		text = JSON.stringify(data);
+	} else {
+		text = data;
+	}
+
 	// Escape & and " as mentioned in the spec:
 	// https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element
-	const escapedHtml = html.replaceAll('&', '&amp;').replaceAll('"', '&quot;');
+	const escapedHtml = text.replaceAll('&', '&amp;').replaceAll('"', '&quot;');
 
 	return `<iframe srcdoc="${escapedHtml}" sandbox="allow-scripts allow-forms allow-popups allow-modals allow-orientation-lock allow-pointer-lock allow-presentation allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation"
 			style="position:fixed; top:0; left:0; width:100vw; height:100vh; border:none; overflow:auto;"


### PR DESCRIPTION
## Summary

Stringify data before sandboxing in sandboxHtmlResponse
## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
https://linear.app/n8n/issue/NODE-3350/respond-to-webhook-node-respond-with-text-bug
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
