### PR TITLE
fix(editor): Prevent default action on Enter key in commit and push dialog

### DIFF
--- a/packages/frontend/editor-ui/src/components/SourceControlPushModal.ee.vue
+++ b/packages/frontend/editor-ui/src/components/SourceControlPushModal.ee.vue
@@ -864,7 +864,7 @@ function openDiffModal(id: string) {
 					:placeholder="
 						i18n.baseText('settings.sourceControl.modals.push.commitMessage.placeholder')
 					"
-					@keydown.enter="onCommitKeyDownEnter"
+					@keydown.enter.stop="onCommitKeyDownEnter"
 				/>
 				<N8nButton
 					data-test-id="source-control-push-modal-submit"


### PR DESCRIPTION
## Summary

Hitting enter in Commit and push changes dialog propagates to canvas


https://github.com/user-attachments/assets/e3810269-d5ea-4755-954f-3d7c80416ceb


## Related Linear tickets, Github issues, and Community forum posts

PAY-3148

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
