### PR TITLE
fix(core): Decouple removing and closing destination from actually deleting it

### DIFF
--- a/packages/cli/src/controllers/e2e.controller.ts
+++ b/packages/cli/src/controllers/e2e.controller.ts
@@ -269,6 +269,7 @@ export class E2EController {
 	private async resetLogStreaming() {
 		for (const id in this.eventBus.destinations) {
 			await this.eventBus.removeDestination(id, false);
+			await this.eventBus.deleteDestination(id);
 		}
 	}
 

--- a/packages/cli/src/eventbus/event-bus.controller.ts
+++ b/packages/cli/src/eventbus/event-bus.controller.ts
@@ -124,7 +124,8 @@ export class EventBusController {
 	@GlobalScope('eventBusDestination:delete')
 	async deleteDestination(req: AuthenticatedRequest) {
 		if (isWithIdString(req.query)) {
-			return await this.eventBus.removeDestination(req.query.id);
+			await this.eventBus.removeDestination(req.query.id);
+			return await this.eventBus.deleteDestination(req.query.id);
 		} else {
 			throw new BadRequestError('Query is missing id');
 		}

--- a/packages/cli/src/eventbus/message-event-bus/message-event-bus.ts
+++ b/packages/cli/src/eventbus/message-event-bus/message-event-bus.ts
@@ -240,20 +240,20 @@ export class MessageEventBus extends EventEmitter {
 		return result.sort((a, b) => (a.__type ?? '').localeCompare(b.__type ?? ''));
 	}
 
-	async removeDestination(
-		id: string,
-		notifyWorkers: boolean = true,
-	): Promise<DeleteResult | undefined> {
-		let result;
+	async removeDestination(id: string, notifyWorkers: boolean = true) {
 		if (Object.keys(this.destinations).includes(id)) {
 			await this.destinations[id].close();
-			result = await this.destinations[id].deleteFromDb();
 			delete this.destinations[id];
 		}
 		if (notifyWorkers) {
 			void this.publisher.publishCommand({ command: 'restart-event-bus' });
 		}
-		return result;
+	}
+
+	async deleteDestination(id: string): Promise<DeleteResult | undefined> {
+		return await this.eventDestinationsRepository.delete({
+			id,
+		});
 	}
 
 	private async trySendingUnsent(msgs?: EventMessageTypes[]) {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
Currently, when updating the log streaming configuration, it gets deleted before being re-created again after some side effect is run. This can lead to some edge case where the configuration is deleted without being re-created again.
This PR suggest to remove the deletion, because the follow up code upserts the config, which is enough to update it.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2837/community-issue-syslog-keeps-being-deleted

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
