### PR TITLE
feat(editor): Use remote filtering for error workflow search in settings

### DIFF
--- a/packages/frontend/editor-ui/src/components/WorkflowSettings.test.ts
+++ b/packages/frontend/editor-ui/src/components/WorkflowSettings.test.ts
@@ -30,7 +30,7 @@ let settingsStore: MockedStore<typeof useSettingsStore>;
 let sourceControlStore: MockedStore<typeof useSourceControlStore>;
 let pinia: ReturnType<typeof createTestingPinia>;
 
-let fetchAllWorkflowsSpy: MockInstance<(typeof workflowsStore)['fetchAllWorkflows']>;
+let searchWorkflowsSpy: MockInstance<(typeof workflowsStore)['searchWorkflows']>;
 
 const createComponent = createComponentRenderer(WorkflowSettingsVue, {
 	global: {
@@ -55,7 +55,7 @@ describe('WorkflowSettingsVue', () => {
 		} as FrontendSettings;
 		workflowsStore.workflowName = 'Test Workflow';
 		workflowsStore.workflowId = '1';
-		fetchAllWorkflowsSpy = workflowsStore.fetchAllWorkflows.mockResolvedValue([
+		searchWorkflowsSpy = workflowsStore.searchWorkflows.mockResolvedValue([
 			{
 				id: '1',
 				name: 'Test Workflow',
@@ -134,8 +134,12 @@ describe('WorkflowSettingsVue', () => {
 		// first is `- No Workflow -`, second is the workflow returned by
 		// `workflowsStore.fetchAllWorkflows`
 		expect(dropdownItems).toHaveLength(2);
-		expect(fetchAllWorkflowsSpy).toHaveBeenCalledTimes(1);
-		expect(fetchAllWorkflowsSpy).toHaveBeenCalledWith();
+		expect(searchWorkflowsSpy).toHaveBeenCalledTimes(1);
+		expect(searchWorkflowsSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				name: undefined,
+			}),
+		);
 	});
 
 	it('should not remove valid workflow ID characters', async () => {

--- a/packages/frontend/editor-ui/src/components/WorkflowSettings.vue
+++ b/packages/frontend/editor-ui/src/components/WorkflowSettings.vue
@@ -261,8 +261,16 @@ const loadTimezones = async () => {
 	}
 };
 
-const loadWorkflows = async () => {
-	const workflowsData = (await workflowsStore.fetchAllWorkflows()) as IWorkflowShortResponse[];
+const loadWorkflows = async (searchTerm?: string) => {
+	// Do not call the API if the search term is empty
+	// Call it if searchTerm is undefined for initial load
+	if (searchTerm === '') {
+		return;
+	}
+
+	const workflowsData = (await workflowsStore.searchWorkflows({
+		name: searchTerm,
+	})) as IWorkflowShortResponse[];
 	workflowsData.sort((a, b) => {
 		if (a.name.toLowerCase() < b.name.toLowerCase()) {
 			return -1;
@@ -527,6 +535,9 @@ onMounted(async () => {
 							v-model="workflowSettings.errorWorkflow"
 							placeholder="Select Workflow"
 							filterable
+							remote
+							remote-method="loadWorkflows"
+							remote-show-suffix
 							:disabled="readOnlyEnv || !workflowPermissions.update"
 							:limit-popper-width="true"
 							data-test-id="workflow-settings-error-workflow"

--- a/packages/frontend/editor-ui/src/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/stores/workflows.store.ts
@@ -612,15 +612,24 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		return data;
 	}
 
-	async function fetchAllWorkflows(projectId?: string): Promise<IWorkflowDb[]> {
+	async function searchWorkflows({
+		projectId,
+		name,
+	}: { projectId?: string; name?: string }): Promise<IWorkflowDb[]> {
 		const filter = {
 			projectId,
+			name,
 		};
 
 		const { data: workflows } = await workflowsApi.getWorkflows(
 			rootStore.restApiContext,
 			isEmpty(filter) ? undefined : filter,
 		);
+		return workflows;
+	}
+
+	async function fetchAllWorkflows(projectId?: string): Promise<IWorkflowDb[]> {
+		const workflows = await searchWorkflows({ projectId });
 		setWorkflows(workflows);
 		return workflows;
 	}
@@ -1990,6 +1999,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		getCurrentWorkflow,
 		getWorkflowFromUrl,
 		getActivationError,
+		searchWorkflows,
 		fetchAllWorkflows,
 		fetchWorkflowsPage,
 		fetchWorkflow,


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR transfort the local in memory filtering into remote filtering calling the workflows API with name filter when filtering the name in the error workflow dropdown in the workflow settings modal.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2998/searching-for-an-error-workflow-is-impossibly-slow

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
