### PR TITLE
fix(editor): Use nodes and connection from passed in workflow in RunData (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/components/RunData.vue
@@ -807,8 +807,8 @@ function getNodeHints(): NodeHint[] {
 					node: node.value,
 					nodeType: nodeType.value,
 					nodeOutputData,
-					nodes: workflowsStore.allNodes,
-					connections: workflowsStore.connectionsBySourceNode,
+					nodes: props.workflow.nodes,
+					connections: props.workflow.connectionsBySourceNode,
 					hasNodeRun: hasNodeRun.value,
 					hasMultipleInputItems,
 				});

--- a/packages/frontend/editor-ui/src/utils/nodeViewUtils.test.ts
+++ b/packages/frontend/editor-ui/src/utils/nodeViewUtils.test.ts
@@ -61,7 +61,7 @@ describe('getGenericHints', () => {
 			nodeOutputData: mockNodeOutputData,
 			hasMultipleInputItems,
 			hasNodeRun,
-			nodes: [],
+			nodes: {},
 			connections: {},
 		});
 
@@ -87,7 +87,7 @@ describe('getGenericHints', () => {
 			nodeOutputData: mockNodeOutputData,
 			hasMultipleInputItems,
 			hasNodeRun,
-			nodes: [],
+			nodes: {},
 			connections: {},
 		});
 
@@ -126,7 +126,7 @@ describe('getGenericHints', () => {
 			nodeOutputData: mockNodeOutputData,
 			hasMultipleInputItems,
 			hasNodeRun,
-			nodes: [],
+			nodes: {},
 			connections: {},
 		});
 
@@ -151,7 +151,7 @@ describe('getGenericHints', () => {
 			nodeOutputData: mockNodeOutputData,
 			hasMultipleInputItems,
 			hasNodeRun,
-			nodes: [],
+			nodes: {},
 			connections: {},
 		});
 
@@ -176,7 +176,7 @@ describe('getGenericHints', () => {
 			nodeOutputData: mockNodeOutputData,
 			hasMultipleInputItems,
 			hasNodeRun,
-			nodes: [],
+			nodes: {},
 			connections: {},
 		});
 
@@ -202,7 +202,7 @@ describe('getGenericHints', () => {
 			nodeOutputData: mockNodeOutputData,
 			hasMultipleInputItems,
 			hasNodeRun,
-			nodes: [],
+			nodes: {},
 			connections: {},
 		});
 

--- a/packages/frontend/editor-ui/src/utils/nodeViewUtils.ts
+++ b/packages/frontend/editor-ui/src/utils/nodeViewUtils.ts
@@ -14,6 +14,7 @@ import type {
 	IConnections,
 	INode,
 	INodeExecutionData,
+	INodes,
 	INodeTypeDescription,
 	NodeHint,
 } from 'n8n-workflow';
@@ -381,7 +382,7 @@ export function getGenericHints({
 	nodeType: INodeTypeDescription;
 	nodeOutputData: INodeExecutionData[];
 	hasMultipleInputItems: boolean;
-	nodes: INode[];
+	nodes: INodes;
 	connections: IConnections;
 	hasNodeRun: boolean;
 }) {


### PR DESCRIPTION
## Summary

- Fixes a bug related to #16148 

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1053/update-workflow-usage-in-rundata-component


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
