### PR TITLE
fix(core): Add headers to telemetry cross origin request

### DIFF
--- a/packages/cli/src/middlewares/cors.ts
+++ b/packages/cli/src/middlewares/cors.ts
@@ -8,7 +8,7 @@ export const corsMiddleware: RequestHandler = (req, res, next) => {
 		res.header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH, DELETE');
 		res.header(
 			'Access-Control-Allow-Headers',
-			'Origin, X-Requested-With, Content-Type, Accept, push-ref, browser-id',
+			'Origin, X-Requested-With, Content-Type, Accept, push-ref, browser-id, anonymousid, authorization',
 		);
 	}
 


### PR DESCRIPTION
## Summary

The rudderstack telemetry events are routed through the backend. 
In local dev set up, if you have FE running on :8080 and backend on :5678, the backend will throw CORS errors since some headers are not expected. 
<img width="3024" height="612" alt="Screenshot 2025-07-24 at 12 50 56" src="https://github.com/user-attachments/assets/bbf8337f-0db2-403c-bc4b-599664ed3a19" />

To fix, adding headers to the `Access-Control-Allow-Headers` list
<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
