### PR TITLE
fix(Google Sheets Node): Get Rows operation returns an empty string when the cell has a value of 0

### DIFF
--- a/packages/nodes-base/nodes/Google/Sheet/test/v2/helpers/GoogleSheet.test.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/test/v2/helpers/GoogleSheet.test.ts
@@ -122,6 +122,21 @@ describe('GoogleSheet', () => {
 				{ name: 'Jane', age: '25' },
 			]);
 		});
+
+		it('should handle zero values correctly', () => {
+			const data = [
+				['name', 'age'],
+				['John', 30],
+				['Jane', 0],
+			];
+
+			const result = googleSheet.convertSheetDataArrayToObjectArray(data, 1, ['name', 'age']);
+
+			expect(result).toEqual([
+				{ name: 'John', age: 30 },
+				{ name: 'Jane', age: 0 },
+			]);
+		});
 	});
 
 	describe('lookupValues', () => {

--- a/packages/nodes-base/nodes/Google/Sheet/test/v2/helpers/GoogleSheet.test.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/test/v2/helpers/GoogleSheet.test.ts
@@ -137,6 +137,21 @@ describe('GoogleSheet', () => {
 				{ name: 'Jane', age: 0 },
 			]);
 		});
+
+		it('should handle nullish values correctly', () => {
+			const data = [
+				['name', 'age'],
+				['John', null as unknown as number],
+				['Jane', undefined as unknown as number],
+			];
+
+			const result = googleSheet.convertSheetDataArrayToObjectArray(data, 1, ['name', 'age']);
+
+			expect(result).toEqual([
+				{ name: 'John', age: '' },
+				{ name: 'Jane', age: '' },
+			]);
+		});
 	});
 
 	describe('lookupValues', () => {

--- a/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheet.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheet.ts
@@ -334,7 +334,7 @@ export class GoogleSheet {
 			for (let columnIndex = 0; columnIndex < columnCount; columnIndex++) {
 				const key = columnKeys[columnIndex];
 				if (key) {
-					item[key] = sheet[rowIndex][columnIndex] || '';
+					item[key] = sheet[rowIndex][columnIndex] ?? '';
 				}
 			}
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Fix a bug where an empty string is returned when a cell has a value of `0` and number type. This happened because the `||` operator replaces `0` with `''`, since `0` is falsy. Using `??` instead fixes this

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-3288/community-issue-google-sheets-get-rows-node-returns-null-for-0-value
Closes #17147

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
