### PR TITLE
fix(editor): Change the checkbox logic for log streaming event selection

### DIFF
--- a/packages/frontend/editor-ui/src/components/SettingsLogStreaming/EventSelection.ee.vue
+++ b/packages/frontend/editor-ui/src/components/SettingsLogStreaming/EventSelection.ee.vue
@@ -73,7 +73,7 @@ export default defineComponent({
 			<!-- <template #header> -->
 			<Checkbox
 				:model-value="group.selected"
-				:indeterminate="!group.selected && group.indeterminate"
+				:indeterminate="group.indeterminate"
 				:disabled="readonly"
 				@update:model-value="onInput"
 				@change="onCheckboxChecked(group.name, $event)"
@@ -108,15 +108,11 @@ export default defineComponent({
 			</Checkbox>
 			<!-- </template> -->
 			<ul :class="$style.eventList">
-				<li
-					v-for="event in group.children"
-					:key="event.name"
-					:class="`${$style.eventListItem} ${group.selected ? $style.eventListItemDisabled : ''}`"
-				>
+				<li v-for="event in group.children" :key="event.name" :class="`${$style.eventListItem}`">
 					<Checkbox
 						:model-value="event.selected || group.selected"
 						:indeterminate="event.indeterminate"
-						:disabled="group.selected || readonly"
+						:disabled="readonly"
 						@update:model-value="onInput"
 						@change="onCheckboxChecked(event.name, $event)"
 					>

--- a/packages/frontend/editor-ui/src/stores/logStreaming.store.test.ts
+++ b/packages/frontend/editor-ui/src/stores/logStreaming.store.test.ts
@@ -1,0 +1,101 @@
+import { setActivePinia } from 'pinia';
+import { useLogStreamingStore } from './logStreaming.store';
+import { createTestingPinia } from '@pinia/testing';
+
+describe('LogStreamingStore', () => {
+	let logStreamingStore: ReturnType<typeof useLogStreamingStore>;
+
+	beforeAll(() => {
+		setActivePinia(createTestingPinia({ stubActions: false }));
+		logStreamingStore = useLogStreamingStore();
+	});
+
+	describe('addEventName', () => {
+		it('should add a new event name', () => {
+			logStreamingStore.addEventName('n8n.node.started');
+			logStreamingStore.addEventName('n8n.node.success');
+			logStreamingStore.addEventName('n8n.node.failed');
+		});
+	});
+
+	describe('addDestination', () => {
+		it('should add a new destination', () => {
+			logStreamingStore.addDestination({
+				id: 'destinationId',
+				label: 'Test Destination',
+				enabled: true,
+				subscribedEvents: [],
+				anonymizeAuditMessages: false,
+			});
+			expect(logStreamingStore.items.destinationId).toBeDefined();
+			expect(logStreamingStore.items.destinationId.destination.label).toBe('Test Destination');
+			expect(logStreamingStore.items.destinationId.eventGroups).toHaveLength(2);
+			const nodeEventGroup = logStreamingStore.items.destinationId.eventGroups.find(
+				(group) => group.name === 'n8n.node',
+			);
+			expect(nodeEventGroup).toBeDefined();
+			expect(nodeEventGroup!.children).toHaveLength(3);
+			expect(nodeEventGroup!.children.every((c) => !c.selected)).toBe(true);
+		});
+	});
+
+	describe('setSelectedInGroup', () => {
+		it('should select the group and unselect all children', () => {
+			logStreamingStore.setSelectedInGroup('destinationId', 'n8n.node', true);
+			const nodeEventGroup = logStreamingStore.items.destinationId.eventGroups.find(
+				(group) => group.name === 'n8n.node',
+			);
+			expect(nodeEventGroup).toBeDefined();
+			expect(nodeEventGroup!.selected).toBe(true);
+			expect(nodeEventGroup!.children.every((e) => !e.selected)).toBe(true);
+		});
+
+		it('should select an event in a group and mark the group as indeterminate', () => {
+			logStreamingStore.addSelectedEvent('destinationId', 'n8n.node.started');
+			const nodeEventGroup = logStreamingStore.items.destinationId.eventGroups.find(
+				(group) => group.name === 'n8n.node',
+			);
+			expect(nodeEventGroup).toBeDefined();
+			expect(nodeEventGroup!.indeterminate).toBe(true);
+			const startedEvent = nodeEventGroup!.children.find((e) => e.name === 'n8n.node.started');
+			expect(startedEvent?.selected).toBe(true);
+		});
+
+		it('should select the group if all children are selected', () => {
+			logStreamingStore.setSelectedInGroup('destinationId', 'n8n.node.started', true);
+			logStreamingStore.setSelectedInGroup('destinationId', 'n8n.node.success', true);
+			logStreamingStore.setSelectedInGroup('destinationId', 'n8n.node.failed', true);
+			const nodeEventGroup = logStreamingStore.items.destinationId.eventGroups.find(
+				(group) => group.name === 'n8n.node',
+			);
+			expect(nodeEventGroup).toBeDefined();
+			expect(nodeEventGroup!.selected).toBe(true);
+			expect(nodeEventGroup!.indeterminate).toBe(false);
+			expect(nodeEventGroup!.children.every((e) => !e.selected)).toBe(true);
+		});
+
+		it('should deselect the group if any child is deselected', () => {
+			logStreamingStore.setSelectedInGroup('destinationId', 'n8n.node.success', true);
+			logStreamingStore.setSelectedInGroup('destinationId', 'n8n.node.failed', true);
+			logStreamingStore.setSelectedInGroup('destinationId', 'n8n.node.started', false);
+			const nodeEventGroup = logStreamingStore.items.destinationId.eventGroups.find(
+				(group) => group.name === 'n8n.node',
+			);
+			expect(nodeEventGroup).toBeDefined();
+			expect(nodeEventGroup!.selected).toBe(false);
+			expect(nodeEventGroup!.indeterminate).toBe(true);
+		});
+
+		it('should unset the group indeterminate state if no children are selected', () => {
+			logStreamingStore.setSelectedInGroup('destinationId', 'n8n.node.success', false);
+			logStreamingStore.setSelectedInGroup('destinationId', 'n8n.node.failed', false);
+			logStreamingStore.setSelectedInGroup('destinationId', 'n8n.node.started', false);
+			const nodeEventGroup = logStreamingStore.items.destinationId.eventGroups.find(
+				(group) => group.name === 'n8n.node',
+			);
+			expect(nodeEventGroup).toBeDefined();
+			expect(nodeEventGroup!.selected).toBe(false);
+			expect(nodeEventGroup!.indeterminate).toBe(false);
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/stores/logStreaming.store.ts
+++ b/packages/frontend/editor-ui/src/stores/logStreaming.store.ts
@@ -33,19 +33,74 @@ export interface DestinationSettingsStore {
 	[key: string]: DestinationStoreItem;
 }
 
+const eventGroupFromEventName = (eventName: string): string | undefined => {
+	const matches = eventName.match(/^[\w\s]+\.[\w\s]+/);
+	if (matches && matches?.length > 0) {
+		return matches[0];
+	}
+	return undefined;
+};
+
+const prettifyEventName = (label: string, group = ''): string => {
+	label = label.replace(group + '.', '');
+	if (label.length > 0) {
+		label = label[0].toUpperCase() + label.substring(1);
+		label = label.replaceAll('.', ' ');
+	}
+	return label;
+};
+
+const eventGroupsFromStringList = (
+	dottedList: Set<string>,
+	selectionList: Set<string> = new Set(),
+) => {
+	const result = [] as EventSelectionGroup[];
+	const eventNameArray = Array.from(dottedList.values());
+
+	const groups: Set<string> = new Set<string>();
+
+	// since a Set returns iteration items on the order they were added, we can make sure workflow and nodes come first
+	groups.add('n8n.workflow');
+	groups.add('n8n.node');
+
+	for (const eventName of eventNameArray) {
+		const matches = eventName.match(/^[\w\s]+\.[\w\s]+/);
+		if (matches && matches?.length > 0) {
+			groups.add(matches[0]);
+		}
+	}
+
+	for (const group of groups) {
+		const collection: EventSelectionGroup = {
+			children: [],
+			label: group,
+			name: group,
+			selected: selectionList.has(group),
+			indeterminate: false,
+		};
+		const eventsOfGroup = eventNameArray.filter((e) => e.startsWith(group));
+		for (const event of eventsOfGroup) {
+			if (!collection.selected && selectionList.has(event)) {
+				collection.indeterminate = true;
+			}
+			const subCollection: EventSelectionItem = {
+				label: prettifyEventName(event, group),
+				name: event,
+				selected: selectionList.has(event),
+				indeterminate: false,
+			};
+			collection.children.push(subCollection);
+		}
+		result.push(collection);
+	}
+	return result;
+};
+
 export const useLogStreamingStore = defineStore('logStreaming', () => {
 	const items = ref<DestinationSettingsStore>({});
 	const eventNames = ref(new Set<string>());
 
 	const rootStore = useRootStore();
-
-	const addDestination = (destination: MessageEventBusDestinationOptions) => {
-		if (destination.id && items.value[destination.id]) {
-			items.value[destination.id].destination = destination;
-		} else {
-			setSelectionAndBuildItems(destination);
-		}
-	};
 
 	const setSelectionAndBuildItems = (destination: MessageEventBusDestinationOptions) => {
 		if (destination.id) {
@@ -67,6 +122,14 @@ export const useLogStreamingStore = defineStore('logStreaming', () => {
 				eventNames.value,
 				items.value[destination.id]?.selectedEvents,
 			);
+		}
+	};
+
+	const addDestination = (destination: MessageEventBusDestinationOptions) => {
+		if (destination.id && items.value[destination.id]) {
+			items.value[destination.id].destination = destination;
+		} else {
+			setSelectionAndBuildItems(destination);
 		}
 	};
 
@@ -101,6 +164,45 @@ export const useLogStreamingStore = defineStore('logStreaming', () => {
 		eventNames.value.clear();
 	};
 
+	const setSelectedInGroup = (destinationId: string, name: string, isSelected: boolean) => {
+		if (!items.value[destinationId]) return;
+
+		const groupName = eventGroupFromEventName(name);
+		const group = items.value[destinationId].eventGroups.find((e) => e.name === groupName);
+		if (!group) return;
+
+		const children = group.children;
+		if (groupName === name) {
+			group.selected = isSelected;
+			group.indeterminate = false;
+			// if the whole group is toggled, all children are unselected
+			children.forEach((e) => (e.selected = false));
+			return;
+		}
+
+		const event = children.find((e) => e.name === name);
+		if (!event) return;
+
+		event.selected = isSelected;
+
+		// If whole group is selected and the event is unselected,
+		// we unselect the group but keep other children selected
+		if (!isSelected && group.selected) {
+			group.selected = false;
+			group.children.filter((e) => e !== event).forEach((e) => (e.selected = true));
+		}
+
+		// If all children are selected, we select the group
+		// and unselect all children
+		const selectedChildren = children.filter((e) => e.selected);
+		if (isSelected && selectedChildren.length === children.length) {
+			group.selected = true;
+			group.children.forEach((e) => (e.selected = false));
+		}
+
+		group.indeterminate = selectedChildren.length > 0 && selectedChildren.length < children.length;
+	};
+
 	const addSelectedEvent = (id: string, name: string) => {
 		items.value[id]?.selectedEvents?.add(name);
 		setSelectedInGroup(id, name, true);
@@ -109,42 +211,6 @@ export const useLogStreamingStore = defineStore('logStreaming', () => {
 	const removeSelectedEvent = (id: string, name: string) => {
 		items.value[id]?.selectedEvents?.delete(name);
 		setSelectedInGroup(id, name, false);
-	};
-
-	const setSelectedInGroup = (destinationId: string, name: string, isSelected: boolean) => {
-		if (items.value[destinationId]) {
-			const groupName = eventGroupFromEventName(name);
-			const group = items.value[destinationId].eventGroups.find((e) => e.name === groupName);
-			if (group) {
-				const children = group.children;
-				if (groupName === name) {
-					group.selected = isSelected;
-					// if the group is selected (or unselected), all children should be deselected
-					children.forEach((e) => (e.selected = false));
-				} else {
-					const event = children.find((e) => e.name === name);
-					if (event) {
-						event.selected = isSelected;
-						if (!isSelected && group.selected) {
-							// If whole group is selected and the event is unselected,
-							// we unselect the group but keep other children selected
-							group.selected = false;
-							group.children.filter((e) => e !== event).forEach((e) => (e.selected = true));
-						}
-						if (isSelected && children.every((e) => e.selected)) {
-							// If all children are selected, we select the group
-							// and unselect all children
-							group.selected = true;
-							group.children.forEach((e) => (e.selected = false));
-						}
-					}
-				}
-				const selectedChildren = children.filter((e) => e.selected);
-				group.indeterminate =
-					selectedChildren.length > 0 && selectedChildren.length < children.length;
-				group.selected = group.selected || selectedChildren.length === children.length;
-			}
-		}
 	};
 
 	const removeDestinationItemTree = (id: string) => {
@@ -191,7 +257,7 @@ export const useLogStreamingStore = defineStore('logStreaming', () => {
 			await saveDestinationToDb(rootStore.restApiContext, destination, selectedEvents);
 			updateDestination(destination);
 			return true;
-		} catch (e) {
+		} catch {
 			return false;
 		}
 	};
@@ -244,66 +310,3 @@ export const useLogStreamingStore = defineStore('logStreaming', () => {
 		items,
 	};
 });
-
-export const eventGroupFromEventName = (eventName: string): string | undefined => {
-	const matches = eventName.match(/^[\w\s]+\.[\w\s]+/);
-	if (matches && matches?.length > 0) {
-		return matches[0];
-	}
-	return undefined;
-};
-
-const prettifyEventName = (label: string, group = ''): string => {
-	label = label.replace(group + '.', '');
-	if (label.length > 0) {
-		label = label[0].toUpperCase() + label.substring(1);
-		label = label.replaceAll('.', ' ');
-	}
-	return label;
-};
-
-export const eventGroupsFromStringList = (
-	dottedList: Set<string>,
-	selectionList: Set<string> = new Set(),
-) => {
-	const result = [] as EventSelectionGroup[];
-	const eventNameArray = Array.from(dottedList.values());
-
-	const groups: Set<string> = new Set<string>();
-
-	// since a Set returns iteration items on the order they were added, we can make sure workflow and nodes come first
-	groups.add('n8n.workflow');
-	groups.add('n8n.node');
-
-	for (const eventName of eventNameArray) {
-		const matches = eventName.match(/^[\w\s]+\.[\w\s]+/);
-		if (matches && matches?.length > 0) {
-			groups.add(matches[0]);
-		}
-	}
-
-	for (const group of groups) {
-		const collection: EventSelectionGroup = {
-			children: [],
-			label: group,
-			name: group,
-			selected: selectionList.has(group),
-			indeterminate: false,
-		};
-		const eventsOfGroup = eventNameArray.filter((e) => e.startsWith(group));
-		for (const event of eventsOfGroup) {
-			if (!collection.selected && selectionList.has(event)) {
-				collection.indeterminate = true;
-			}
-			const subCollection: EventSelectionItem = {
-				label: prettifyEventName(event, group),
-				name: event,
-				selected: selectionList.has(event),
-				indeterminate: false,
-			};
-			collection.children.push(subCollection);
-		}
-		result.push(collection);
-	}
-	return result;
-};


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Previously, when a log streaming event group checkbox is selected, it disables the children (because all are selected).
This PR suggest to instead enable all the children (expected UX behavior). It does that by revamping the selection logic a little bit to make it more explicit of the side effects.
But under the hood, we keep the internal logic (if all group children are selected, save only the group in the subscribed events)

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2621/bug-log-streaming-event-selection-checkbox-works-incorrectly

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
