### PR TITLE
fix(Webhook Node): Don't wrap response in an iframe if it doesn't have HTML

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,6 +56,7 @@
     "http-proxy-agent": "catalog:",
     "https-proxy-agent": "catalog:",
     "iconv-lite": "catalog:",
+    "jsdom": "23.0.1",
     "jsonwebtoken": "catalog:",
     "lodash": "catalog:",
     "luxon": "catalog:",

--- a/packages/core/src/__tests__/__snapshots__/html-sandbox.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/html-sandbox.test.ts.snap
@@ -23,3 +23,15 @@ exports[`sandboxHtmlResponse should sandbox even with no <body> tag 1`] = `
 			style="position:fixed; top:0; left:0; width:100vw; height:100vh; border:none; overflow:auto;"
 			allowtransparency="true"></iframe>"
 `;
+
+exports[`sandboxHtmlResponse should sandbox when outside <body> and <head> tags 1`] = `
+"<iframe srcdoc="<html><head><title>Test</title></head><body></body><script>alert(&quot;Hello&quot;)</script></html>" sandbox="allow-scripts allow-forms allow-popups allow-modals allow-orientation-lock allow-pointer-lock allow-presentation allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation"
+			style="position:fixed; top:0; left:0; width:100vw; height:100vh; border:none; overflow:auto;"
+			allowtransparency="true"></iframe>"
+`;
+
+exports[`sandboxHtmlResponse should sandbox when outside <html> tag 1`] = `
+"<iframe srcdoc="<html><head><title>Test</title></head></html><script>alert(&quot;Hello&quot;)</script>" sandbox="allow-scripts allow-forms allow-popups allow-modals allow-orientation-lock allow-pointer-lock allow-presentation allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation"
+			style="position:fixed; top:0; left:0; width:100vw; height:100vh; border:none; overflow:auto;"
+			allowtransparency="true"></iframe>"
+`;

--- a/packages/core/src/__tests__/__snapshots__/html-sandbox.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/html-sandbox.test.ts.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`sandboxHtmlResponse should handle HTML with special characters 1`] = `
-"<iframe srcdoc="<p>Special characters: <>&amp;&quot;'</p>" sandbox="allow-scripts allow-forms allow-popups allow-modals allow-orientation-lock allow-pointer-lock allow-presentation allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation"
+exports[`sandboxHtmlResponse should always sandbox if forceSandbox is true 1`] = `
+"<iframe srcdoc="Hello World" sandbox="allow-scripts allow-forms allow-popups allow-modals allow-orientation-lock allow-pointer-lock allow-presentation allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation"
 			style="position:fixed; top:0; left:0; width:100vw; height:100vh; border:none; overflow:auto;"
 			allowtransparency="true"></iframe>"
 `;
 
-exports[`sandboxHtmlResponse should handle empty HTML 1`] = `
-"<iframe srcdoc="" sandbox="allow-scripts allow-forms allow-popups allow-modals allow-orientation-lock allow-pointer-lock allow-presentation allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation"
+exports[`sandboxHtmlResponse should handle HTML with special characters 1`] = `
+"<iframe srcdoc="<p>Special characters: <>&amp;&quot;'</p>" sandbox="allow-scripts allow-forms allow-popups allow-modals allow-orientation-lock allow-pointer-lock allow-presentation allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation"
 			style="position:fixed; top:0; left:0; width:100vw; height:100vh; border:none; overflow:auto;"
 			allowtransparency="true"></iframe>"
 `;

--- a/packages/core/src/__tests__/__snapshots__/html-sandbox.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/html-sandbox.test.ts.snap
@@ -17,3 +17,9 @@ exports[`sandboxHtmlResponse should replace ampersands and double quotes in HTML
 			style="position:fixed; top:0; left:0; width:100vw; height:100vh; border:none; overflow:auto;"
 			allowtransparency="true"></iframe>"
 `;
+
+exports[`sandboxHtmlResponse should sandbox even with no <body> tag 1`] = `
+"<iframe srcdoc="<html><head><title>Test</title><script>alert(&quot;Hello&quot;)</script></head></html>" sandbox="allow-scripts allow-forms allow-popups allow-modals allow-orientation-lock allow-pointer-lock allow-presentation allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation"
+			style="position:fixed; top:0; left:0; width:100vw; height:100vh; border:none; overflow:auto;"
+			allowtransparency="true"></iframe>"
+`;

--- a/packages/core/src/__tests__/html-sandbox.test.ts
+++ b/packages/core/src/__tests__/html-sandbox.test.ts
@@ -40,6 +40,11 @@ describe('sandboxHtmlResponse', () => {
 		expect(sandboxHtmlResponse(data)).toBe(expected);
 	});
 
+	it('should sandbox even with no <body> tag', () => {
+		const html = '<html><head><title>Test</title><script>alert("Hello")</script></head></html>';
+		expect(sandboxHtmlResponse(html)).toMatchSnapshot();
+	});
+
 	it('should always sandbox if forceSandbox is true', () => {
 		const text = 'Hello World';
 		expect(sandboxHtmlResponse(text, true)).toMatchSnapshot();

--- a/packages/core/src/__tests__/html-sandbox.test.ts
+++ b/packages/core/src/__tests__/html-sandbox.test.ts
@@ -45,6 +45,17 @@ describe('sandboxHtmlResponse', () => {
 		expect(sandboxHtmlResponse(html)).toMatchSnapshot();
 	});
 
+	it('should sandbox when outside <body> and <head> tags', () => {
+		const html =
+			'<html><head><title>Test</title></head><body></body><script>alert("Hello")</script></html>';
+		expect(sandboxHtmlResponse(html)).toMatchSnapshot();
+	});
+
+	it('should sandbox when outside <html> tag', () => {
+		const html = '<html><head><title>Test</title></head></html><script>alert("Hello")</script>';
+		expect(sandboxHtmlResponse(html)).toMatchSnapshot();
+	});
+
 	it('should always sandbox if forceSandbox is true', () => {
 		const text = 'Hello World';
 		expect(sandboxHtmlResponse(text, true)).toMatchSnapshot();

--- a/packages/core/src/__tests__/html-sandbox.test.ts
+++ b/packages/core/src/__tests__/html-sandbox.test.ts
@@ -24,14 +24,25 @@ describe('sandboxHtmlResponse', () => {
 		expect(sandboxHtmlResponse(html)).toMatchSnapshot();
 	});
 
-	it('should handle empty HTML', () => {
-		const html = '';
-		expect(sandboxHtmlResponse(html)).toMatchSnapshot();
-	});
-
 	it('should handle HTML with special characters', () => {
 		const html = '<p>Special characters: <>&"\'</p>';
 		expect(sandboxHtmlResponse(html)).toMatchSnapshot();
+	});
+
+	it.each([
+		['Hello World', 'Hello World'],
+		['< not html >', '< not html >'],
+		['# Test', '# Test'],
+		['', ''],
+		[123, '123'],
+		[null, 'null'],
+	])('should not sandbox if not html', (data, expected) => {
+		expect(sandboxHtmlResponse(data)).toBe(expected);
+	});
+
+	it('should always sandbox if forceSandbox is true', () => {
+		const text = 'Hello World';
+		expect(sandboxHtmlResponse(text, true)).toMatchSnapshot();
 	});
 });
 
@@ -143,7 +154,7 @@ describe('bufferEscapeHtml', () => {
 
 describe('createHtmlSandboxTransformStream', () => {
 	const getComparableHtml = (input: Buffer | string) =>
-		sandboxHtmlResponse(input.toString()).replace(/\s+/g, ' ');
+		sandboxHtmlResponse(input.toString(), true).replace(/\s+/g, ' ');
 
 	it('should wrap single chunk in iframe with proper escaping', async () => {
 		const input = Buffer.from('Hello & "World"', 'utf8');

--- a/packages/core/src/html-sandbox.ts
+++ b/packages/core/src/html-sandbox.ts
@@ -8,7 +8,9 @@ import { Transform } from 'stream';
 export const hasHtml = (str: string) => {
 	try {
 		const dom = new JSDOM(str);
-		return dom.window.document.body.children.length > 0;
+		return (
+			dom.window.document.body.children.length > 0 || dom.window.document.head.children.length > 0
+		);
 	} catch {
 		return false;
 	}

--- a/packages/core/src/html-sandbox.ts
+++ b/packages/core/src/html-sandbox.ts
@@ -2,9 +2,12 @@ import { JSDOM } from 'jsdom';
 import type { TransformCallback } from 'stream';
 import { Transform } from 'stream';
 
-export const hasHtml = (data: string) => {
+/**
+ * Checks if the given string contains HTML.
+ */
+export const hasHtml = (str: string) => {
 	try {
-		const dom = new JSDOM(data);
+		const dom = new JSDOM(str);
 		return dom.window.document.body.children.length > 0;
 	} catch {
 		return false;
@@ -12,8 +15,13 @@ export const hasHtml = (data: string) => {
 };
 
 /**
- * Sandboxes the HTML response to prevent possible exploitation. Embeds the
- * response in an iframe to make sure the HTML has a different origin.
+ * Sandboxes the HTML response to prevent possible exploitation, if the data has HTML.
+ * If the data does not have HTML, it will be returned as is.
+ * Otherwise, it embeds the response in an iframe to make sure the HTML has a different origin.
+ *
+ * @param data - The data to sandbox.
+ * @param forceSandbox - Whether to force sandboxing even if the data does not contain HTML.
+ * @returns The sandboxed HTML response.
  */
 export const sandboxHtmlResponse = <T>(data: T, forceSandbox = false) => {
 	let text;

--- a/packages/core/src/html-sandbox.ts
+++ b/packages/core/src/html-sandbox.ts
@@ -1,5 +1,15 @@
 import type { TransformCallback } from 'stream';
 import { Transform } from 'stream';
+import { JSDOM } from 'jsdom';
+
+export const hasHtml = (data: string) => {
+	try {
+		const dom = new JSDOM(data);
+		return dom.window.document.body.children.length > 0;
+	} catch {
+		return false;
+	}
+};
 
 /**
  * Sandboxes the HTML response to prevent possible exploitation. Embeds the
@@ -11,6 +21,10 @@ export const sandboxHtmlResponse = <T>(data: T) => {
 		text = JSON.stringify(data);
 	} else {
 		text = data;
+	}
+
+	if (!hasHtml(text)) {
+		return text;
 	}
 
 	// Escape & and " as mentioned in the spec:

--- a/packages/core/src/html-sandbox.ts
+++ b/packages/core/src/html-sandbox.ts
@@ -1,6 +1,6 @@
+import { JSDOM } from 'jsdom';
 import type { TransformCallback } from 'stream';
 import { Transform } from 'stream';
-import { JSDOM } from 'jsdom';
 
 export const hasHtml = (data: string) => {
 	try {
@@ -15,7 +15,7 @@ export const hasHtml = (data: string) => {
  * Sandboxes the HTML response to prevent possible exploitation. Embeds the
  * response in an iframe to make sure the HTML has a different origin.
  */
-export const sandboxHtmlResponse = <T>(data: T) => {
+export const sandboxHtmlResponse = <T>(data: T, forceSandbox = false) => {
 	let text;
 	if (typeof data !== 'string') {
 		text = JSON.stringify(data);
@@ -23,7 +23,7 @@ export const sandboxHtmlResponse = <T>(data: T) => {
 		text = data;
 	}
 
-	if (!hasHtml(text)) {
+	if (!forceSandbox && !hasHtml(text)) {
 		return text;
 	}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1739,6 +1739,9 @@ importers:
       iconv-lite:
         specifier: 'catalog:'
         version: 0.6.3
+      jsdom:
+        specifier: 23.0.1
+        version: 23.0.1
       jsonwebtoken:
         specifier: 'catalog:'
         version: 9.0.2


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

If `Content-Type` header is not specified - try to parse the response text as HTML. If the result doesn't contain any HTML elements - avoid wrapping the response in an `iframe`

The fix applies to both the Webhook Node itself when using "Respond: Immediately" with "Response Data" and to the Respond to Webhook Node

Workflow to test:
```json
{
  "nodes": [
    {
      "parameters": {
        "path": "iframe",
        "responseMode": "responseNode",
        "options": {}
      },
      "type": "n8n-nodes-base.webhook",
      "typeVersion": 2,
      "position": [
        0,
        288
      ],
      "id": "316e73a8-8970-4942-99f7-306a4a9f74da",
      "name": "Webhook",
      "webhookId": "c1c44fb7-f2eb-4d44-a733-d91cb4675df1"
    },
    {
      "parameters": {
        "respondWith": "text",
        "responseBody": "not html",
        "options": {}
      },
      "type": "n8n-nodes-base.respondToWebhook",
      "typeVersion": 1.4,
      "position": [
        224,
        0
      ],
      "id": "5edf1d57-2a6b-47a4-840e-e4de0aeda47a",
      "name": "Not HTML"
    },
    {
      "parameters": {
        "respondWith": "text",
        "responseBody": "1 < 2",
        "options": {}
      },
      "type": "n8n-nodes-base.respondToWebhook",
      "typeVersion": 1.4,
      "position": [
        224,
        192
      ],
      "id": "d3c78a74-f642-4789-b852-0f1d5d9b7d70",
      "name": "Angle Brackets"
    },
    {
      "parameters": {
        "respondWith": "text",
        "responseBody": "<button onclick=\"alert('hi')\">Button 1</button>",
        "options": {}
      },
      "type": "n8n-nodes-base.respondToWebhook",
      "typeVersion": 1.4,
      "position": [
        224,
        384
      ],
      "id": "fd2fbc8e-45bc-4367-96e2-094a8933ec03",
      "name": "Valid HTML"
    },
    {
      "parameters": {
        "respondWith": "text",
        "responseBody": "<button onclick=\"alert('hi')\">Button 2",
        "options": {}
      },
      "type": "n8n-nodes-base.respondToWebhook",
      "typeVersion": 1.4,
      "position": [
        224,
        576
      ],
      "id": "b342fce6-aff4-4af5-9e51-81c62259b85f",
      "name": "Unfinished HTML"
    }
  ],
  "connections": {
    "Webhook": {
      "main": [
        [
          {
            "node": "Not HTML",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {},
  "meta": {
    "templateCredsSetupCompleted": true,
    "instanceId": "eeda9e3069aca300d1dfceeb64beb5b53d715db44a50461bbc5cb0cf6daa01e3"
  }
}
```

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-3363/bug-webhook-node-now-returns-iframe-in-response
Closes #17659

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
