### PR TITLE
fix(Gmail Trigger Node): Filter sent emails from trigger results

### DIFF
--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -327,6 +327,10 @@ export class GmailTrigger implements INodeType {
 					}
 				}
 
+				if (fullMessage.labelIds?.includes('SENT')) {
+					continue;
+				}
+
 				if (!simple) {
 					const dataPropertyNameDownload =
 						options.dataPropertyAttachmentsPrefixName || 'attachment_';

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -33,7 +33,7 @@ export class GmailTrigger implements INodeType {
 		name: 'gmailTrigger',
 		icon: 'file:gmail.svg',
 		group: ['trigger'],
-		version: [1, 1.1, 1.2],
+		version: [1, 1.1, 1.2, 1.3],
 		description:
 			'Fetches emails from Gmail and starts the workflow on specified polling intervals.',
 		subtitle: '={{"Gmail Trigger"}}',
@@ -327,7 +327,7 @@ export class GmailTrigger implements INodeType {
 					}
 				}
 
-				if (fullMessage.labelIds?.includes('SENT')) {
+				if (node.typeVersion > 1.2 && fullMessage.labelIds?.includes('SENT')) {
 					continue;
 				}
 


### PR DESCRIPTION
## Summary
In this PR, all emails labelled `SENT` are filtered out in the Gmail trigger results. This behaviour was happening when the Account owner sends an email and the trigger fired. 

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
- fixes #16029
- https://linear.app/n8n/issue/NODE-3144/community-issue-gmail-node-sent-email-issue
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
