### PR TITLE
fix(core): Improve error handling of getBinaryDataBuffer helper

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/execute-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/execute-context.ts
@@ -101,7 +101,7 @@ export class ExecuteContext extends BaseExecuteContext implements IExecuteFuncti
 			assertBinaryData: (itemIndex, propertyName) =>
 				assertBinaryData(inputData, node, itemIndex, propertyName, 0),
 			getBinaryDataBuffer: async (itemIndex, propertyName) =>
-				await getBinaryDataBuffer(inputData, itemIndex, propertyName, 0),
+				await getBinaryDataBuffer(inputData, node, itemIndex, propertyName, 0),
 			detectBinaryEncoding: (buffer: Buffer) => detectBinaryEncoding(buffer),
 		};
 

--- a/packages/core/src/execution-engine/node-execution-context/execute-single-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/execute-single-context.ts
@@ -67,7 +67,7 @@ export class ExecuteSingleContext extends BaseExecuteContext implements IExecute
 			assertBinaryData: (propertyName, inputIndex = 0) =>
 				assertBinaryData(inputData, node, itemIndex, propertyName, inputIndex),
 			getBinaryDataBuffer: async (propertyName, inputIndex = 0) =>
-				await getBinaryDataBuffer(inputData, itemIndex, propertyName, inputIndex),
+				await getBinaryDataBuffer(inputData, node, itemIndex, propertyName, inputIndex),
 			detectBinaryEncoding: (buffer) => detectBinaryEncoding(buffer),
 		};
 	}

--- a/packages/core/src/execution-engine/node-execution-context/supply-data-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/supply-data-context.ts
@@ -92,7 +92,7 @@ export class SupplyDataContext extends BaseExecuteContext implements ISupplyData
 			assertBinaryData: (itemIndex, propertyName) =>
 				assertBinaryData(inputData, node, itemIndex, propertyName, 0),
 			getBinaryDataBuffer: async (itemIndex, propertyName) =>
-				await getBinaryDataBuffer(inputData, itemIndex, propertyName, 0),
+				await getBinaryDataBuffer(inputData, node, itemIndex, propertyName, 0),
 			detectBinaryEncoding: (buffer: Buffer) => detectBinaryEncoding(buffer),
 
 			returnJsonArray,

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/binary-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/binary-helper-functions.test.ts
@@ -1,7 +1,7 @@
 import { Container } from '@n8n/di';
 import { mkdtempSync, readFileSync } from 'fs';
 import { IncomingMessage } from 'http';
-import { mock } from 'jest-mock-extended';
+import { mock, mockFn } from 'jest-mock-extended';
 import type {
 	IBinaryData,
 	INode,
@@ -53,6 +53,8 @@ describe('test binary data helper methods', () => {
 	});
 
 	test("test getBinaryDataBuffer(...) & setBinaryDataBuffer(...) methods in 'default' mode", async () => {
+		const mockNode = mock<INode>({ name: 'Test Node' });
+
 		// Setup a 'default' binary data manager instance
 		binaryDataConfig.mode = 'default';
 		await binaryDataService.init();
@@ -91,6 +93,7 @@ describe('test binary data helper methods', () => {
 		// Now, lets fetch our data! The item will be item index 0.
 		const getBinaryDataBufferResponse: Buffer = await getBinaryDataBuffer(
 			taskDataConnectionsInput,
+			mockNode,
 			0,
 			'data',
 			0,
@@ -100,6 +103,8 @@ describe('test binary data helper methods', () => {
 	});
 
 	test("test getBinaryDataBuffer(...) & setBinaryDataBuffer(...) methods in 'filesystem' mode", async () => {
+		const mockNode = mock<INode>({ name: 'Test Node' });
+
 		// Setup a 'filesystem' binary data manager instance
 		binaryDataConfig.mode = 'filesystem';
 		await binaryDataService.init();
@@ -145,6 +150,7 @@ describe('test binary data helper methods', () => {
 		// Now, lets fetch our data! The item will be item index 0.
 		const getBinaryDataBufferResponse: Buffer = await getBinaryDataBuffer(
 			taskDataConnectionsInput,
+			mockNode,
 			0,
 			'data',
 			0,

--- a/packages/core/src/execution-engine/node-execution-context/utils/binary-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/binary-helper-functions.ts
@@ -50,6 +50,9 @@ async function getBinaryStream(binaryDataId: string, chunkSize?: number): Promis
 	return await Container.get(BinaryDataService).getAsStream(binaryDataId, chunkSize);
 }
 
+/**
+ * Returns binary data for given item index and property name.
+ */
 export function assertBinaryData(
 	inputData: ITaskDataConnections,
 	node: INode,
@@ -90,11 +93,12 @@ export function assertBinaryData(
  */
 export async function getBinaryDataBuffer(
 	inputData: ITaskDataConnections,
+	node: INode,
 	itemIndex: number,
 	propertyName: string,
 	inputIndex: number,
 ): Promise<Buffer> {
-	const binaryData = inputData.main[inputIndex]![itemIndex].binary![propertyName];
+	const binaryData = assertBinaryData(inputData, node, itemIndex, propertyName, inputIndex);
 	return await Container.get(BinaryDataService).getAsBuffer(binaryData);
 }
 

--- a/packages/core/src/execution-engine/node-execution-context/utils/binary-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/binary-helper-functions.ts
@@ -50,9 +50,6 @@ async function getBinaryStream(binaryDataId: string, chunkSize?: number): Promis
 	return await Container.get(BinaryDataService).getAsStream(binaryDataId, chunkSize);
 }
 
-/**
- * Returns binary data for given item index and property name.
- */
 export function assertBinaryData(
 	inputData: ITaskDataConnections,
 	node: INode,


### PR DESCRIPTION
## Summary

This makes getBinaryDataBuffer helper reuse the same error handling as assertBinaryData does, making it produce better error messages in terms of the UX perspective.

## Related Linear tickets, Github issues, and Community forum posts

GHC-3363

closes #17717 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
