### PR TITLE
fix(Telegram Node): Determine the MIME type when downloading the file

### DIFF
--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -657,6 +657,31 @@ export class Telegram implements INodeType {
 				default: true,
 				description: 'Whether to download the file',
 			},
+			{
+				displayName: 'Additional Fields',
+				name: 'additionalFields',
+				type: 'collection',
+				placeholder: 'Add Field',
+				displayOptions: {
+					show: {
+						operation: ['get'],
+						resource: ['file'],
+						download: [true],
+					},
+				},
+				default: {},
+				options: [
+					{
+						displayName: 'MIME Type',
+						name: 'mimeType',
+						type: 'string',
+						placeholder: 'image/jpeg',
+						default: '',
+						description:
+							'The MIME type of the file. If not specified, the MIME type will be determined by the file extension.',
+					},
+				],
+			},
 
 			// ----------------------------------
 			//         message
@@ -2171,7 +2196,9 @@ export class Telegram implements INodeType {
 						);
 
 						const fileName = filePath.split('/').pop() as string;
-						const mimeType = lookup(fileName) || 'application/octet-stream';
+						const additionalFields = this.getNodeParameter('additionalFields', 0);
+						const providedMimeType = additionalFields?.mimeType as string | undefined;
+						const mimeType = providedMimeType ?? (lookup(fileName) || 'application/octet-stream');
 
 						const data = await this.helpers.prepareBinaryData(
 							file.body as Buffer,

--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -1,3 +1,4 @@
+import { lookup } from 'mime-types';
 import type {
 	IExecuteFunctions,
 	IDataObject,
@@ -2169,11 +2170,13 @@ export class Telegram implements INodeType {
 							},
 						);
 
-						const fileName = filePath.split('/').pop();
+						const fileName = filePath.split('/').pop() as string;
+						const mimeType = lookup(fileName) || 'application/octet-stream';
 
 						const data = await this.helpers.prepareBinaryData(
 							file.body as Buffer,
-							fileName as string,
+							fileName,
+							mimeType,
 						);
 
 						returnData.push({

--- a/packages/nodes-base/nodes/Telegram/tests/Telegram.node.test.ts
+++ b/packages/nodes-base/nodes/Telegram/tests/Telegram.node.test.ts
@@ -1,0 +1,82 @@
+import { mockDeep } from 'jest-mock-extended';
+import type { IExecuteFunctions, INode } from 'n8n-workflow';
+
+import * as GenericFunctions from '../GenericFunctions';
+import { Telegram } from '../Telegram.node';
+
+describe('Telegram node', () => {
+	const executeFunctionsMock = mockDeep<IExecuteFunctions>();
+	const apiRequestSpy = jest.spyOn(GenericFunctions, 'apiRequest');
+	const node = new Telegram();
+
+	beforeEach(() => {
+		jest.resetAllMocks();
+		executeFunctionsMock.getCredentials.mockResolvedValue({
+			baseUrl: 'https://api.telegram.org',
+			accessToken: 'test-token',
+		});
+		executeFunctionsMock.getNode.mockReturnValue({
+			typeVersion: 1.2,
+		} as INode);
+		executeFunctionsMock.getInputData.mockReturnValue([{ json: {} }]);
+	});
+
+	describe('file:get', () => {
+		it('should determine the mime type of the file', async () => {
+			executeFunctionsMock.getNodeParameter.mockImplementation((p) => {
+				switch (p) {
+					case 'resource':
+						return 'file';
+					case 'operation':
+						return 'get';
+					case 'download':
+						return true;
+					case 'fileId':
+						return 'file-id';
+					default:
+						return undefined;
+				}
+			});
+			apiRequestSpy.mockResolvedValueOnce({
+				result: {
+					file_id: 'file-id',
+					file_path: 'documents/file_1.pdf',
+				},
+			});
+			apiRequestSpy.mockResolvedValueOnce({
+				body: Buffer.from('test-file'),
+			});
+			executeFunctionsMock.helpers.prepareBinaryData.mockResolvedValue({
+				data: 'test-file',
+				mimeType: 'application/pdf',
+			});
+
+			const result = await node.execute.call(executeFunctionsMock);
+
+			expect(result).toEqual([
+				[
+					{
+						json: {
+							result: {
+								file_id: 'file-id',
+								file_path: 'documents/file_1.pdf',
+							},
+						},
+						binary: {
+							data: {
+								data: 'test-file',
+								mimeType: 'application/pdf',
+							},
+						},
+						pairedItem: { item: 0 },
+					},
+				],
+			]);
+			expect(executeFunctionsMock.helpers.prepareBinaryData).toHaveBeenCalledWith(
+				Buffer.from('test-file'),
+				'file_1.pdf',
+				'application/pdf',
+			);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Fix an issue where every file downloaded from Telegram has MIME type of `application/octet-stream`. Since the Telegram API does not return a proper MIME type, the file extension is used to look it up. Also add an additional field to manually override the MIME type, if the user decides to do so

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-3351/telegram-node-incorrect-mime-type-when-fetching-image

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
