### PR TITLE
fix: Update packages for security fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
       "@types/node": "^20.17.50",
       "chokidar": "^4.0.1",
       "esbuild": "^0.24.0",
-      "multer": "^2.0.1",
+      "multer": "^2.0.2",
       "prebuild-install": "7.1.3",
       "pug": "^3.0.3",
       "semver": "^7.5.4",
@@ -109,7 +109,7 @@
       "brace-expansion@2": "2.0.2",
       "date-fns": "2.30.0",
       "date-fns-tz": "2.0.0",
-      "form-data@<=4.0.4": "4.0.4"
+      "form-data": "4.0.4"
     },
     "patchedDependencies": {
       "bull@4.16.4": "patches/bull@4.16.4.patch",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -114,7 +114,7 @@
     "change-case": "4.1.2",
     "class-transformer": "0.5.1",
     "class-validator": "0.14.0",
-    "compression": "1.8.0",
+    "compression": "1.8.1",
     "convict": "6.2.4",
     "cookie-parser": "1.4.7",
     "csrf": "3.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,9 +66,6 @@ catalogs:
     flatted:
       specifier: 3.2.7
       version: 3.2.7
-    form-data:
-      specifier: 4.0.0
-      version: 4.0.0
     http-proxy-agent:
       specifier: 7.0.2
       version: 7.0.2
@@ -187,7 +184,7 @@ overrides:
   '@types/node': ^20.17.50
   chokidar: ^4.0.1
   esbuild: ^0.24.0
-  multer: ^2.0.1
+  multer: ^2.0.2
   prebuild-install: 7.1.3
   pug: ^3.0.3
   semver: ^7.5.4
@@ -202,7 +199,7 @@ overrides:
   brace-expansion@2: 2.0.2
   date-fns: 2.30.0
   date-fns-tz: 2.0.0
-  form-data@<=4.0.4: 4.0.4
+  form-data: 4.0.4
 
 patchedDependencies:
   '@lezer/highlight':
@@ -1027,8 +1024,8 @@ importers:
         specifier: 3.0.2
         version: 3.0.2(ts-toolbelt@9.6.0)
       form-data:
-        specifier: 'catalog:'
-        version: 4.0.0
+        specifier: 4.0.4
+        version: 4.0.4
       generate-schema:
         specifier: 2.6.0
         version: 2.6.0
@@ -1386,8 +1383,8 @@ importers:
         specifier: 0.14.0
         version: 0.14.0
       compression:
-        specifier: 1.8.0
-        version: 1.8.0
+        specifier: 1.8.1
+        version: 1.8.1
       convict:
         specifier: 6.2.4
         version: 6.2.4
@@ -1729,8 +1726,8 @@ importers:
         specifier: 16.5.4
         version: 16.5.4
       form-data:
-        specifier: 'catalog:'
-        version: 4.0.0
+        specifier: 4.0.4
+        version: 4.0.4
       http-proxy-agent:
         specifier: 'catalog:'
         version: 7.0.2
@@ -2999,8 +2996,8 @@ importers:
         specifier: 5.8.4
         version: 5.8.4
       form-data:
-        specifier: 'catalog:'
-        version: 4.0.0
+        specifier: 4.0.4
+        version: 4.0.4
       jmespath:
         specifier: 0.16.0
         version: 0.16.0
@@ -8924,8 +8921,8 @@ packages:
     resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
     engines: {node: '>= 0.6'}
 
-  compression@1.8.0:
-    resolution: {integrity: sha512-k6WLKfunuqCYD3t6AsuPGvQWaKwuLLh2/xHNcX4qE+vIfDNXpSqnrhwA7O53R7WVQUnt8dVAIW+YHr7xTgOgGA==}
+  compression@1.8.1:
+    resolution: {integrity: sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==}
     engines: {node: '>= 0.8.0'}
 
   concat-map@0.0.1:
@@ -10377,10 +10374,6 @@ packages:
   form-data-encoder@4.0.2:
     resolution: {integrity: sha512-KQVhvhK8ZkWzxKxOr56CPulAhH3dobtuQ4+hNQ+HekH/Wp5gSOafqRAeTphQUJAIk0GBvHZgJ2ZGRWd5kphMuw==}
     engines: {node: '>= 18'}
-
-  form-data@4.0.0:
-    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
-    engines: {node: '>= 6'}
 
   form-data@4.0.4:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
@@ -12660,8 +12653,8 @@ packages:
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
-  multer@2.0.1:
-    resolution: {integrity: sha512-Ug8bXeTIUlxurg8xLTEskKShvcKDZALo1THEX5E41pYCD2sCVub5/kIRIGqWNoqV6szyLyQKV6mD4QUrWE5GCQ==}
+  multer@2.0.2:
+    resolution: {integrity: sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==}
     engines: {node: '>= 10.16.0'}
 
   mustache@4.2.0:
@@ -13011,8 +13004,8 @@ packages:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
 
-  on-headers@1.0.2:
-    resolution: {integrity: sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==}
+  on-headers@1.1.0:
+    resolution: {integrity: sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==}
     engines: {node: '>= 0.8'}
 
   once@1.4.0:
@@ -15776,8 +15769,8 @@ packages:
   vue-component-type-helpers@2.2.10:
     resolution: {integrity: sha512-iDUO7uQK+Sab2tYuiP9D1oLujCWlhHELHMgV/cB13cuGbG4qwkLHvtfWb6FzvxrIOPDnU0oHsz2MlQjhYDeaHA==}
 
-  vue-component-type-helpers@3.0.3:
-    resolution: {integrity: sha512-koiBu7lO8e6w/UlbZAAIW11qcFQocYIl7Nh/SVwGZ804ej5KrncU32bRxi2zfU2Kyf6HWuk1CeeVP2rhIL+vyQ==}
+  vue-component-type-helpers@3.0.4:
+    resolution: {integrity: sha512-WtR3kPk8vqKYfCK/HGyT47lK/T3FaVyWxaCNuosaHYE8h9/k0lYRZ/PI/+T/z2wP+uuNKmL6z30rOcBboOu/YA==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -21286,7 +21279,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.5.13(typescript@5.8.3)
-      vue-component-type-helpers: 3.0.3
+      vue-component-type-helpers: 3.0.4
 
   '@stylistic/eslint-plugin@5.0.0(eslint@9.29.0(jiti@1.21.7))':
     dependencies:
@@ -23839,15 +23832,15 @@ snapshots:
 
   compressible@2.0.18:
     dependencies:
-      mime-db: 1.52.0
+      mime-db: 1.54.0
 
-  compression@1.8.0:
+  compression@1.8.1:
     dependencies:
       bytes: 3.1.2
       compressible: 2.0.18
       debug: 2.6.9
       negotiator: 0.6.4
-      on-headers: 1.0.2
+      on-headers: 1.1.0
       safe-buffer: 5.2.1
       vary: 1.1.2
     transitivePeerDependencies:
@@ -25410,7 +25403,7 @@ snapshots:
       lodash.clonedeep: 4.5.0
       lodash.get: 4.4.2
       media-typer: 1.1.0
-      multer: 2.0.1
+      multer: 2.0.2
       ono: 7.1.3
       path-to-regexp: 8.2.0
       qs: 6.14.0
@@ -25700,12 +25693,6 @@ snapshots:
   form-data-encoder@1.7.2: {}
 
   form-data-encoder@4.0.2: {}
-
-  form-data@4.0.0:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      mime-types: 2.1.35
 
   form-data@4.0.4:
     dependencies:
@@ -27666,7 +27653,7 @@ snapshots:
 
   lazystream@1.0.1:
     dependencies:
-      readable-stream: 2.3.7
+      readable-stream: 2.3.8
 
   ldapts@4.2.6:
     dependencies:
@@ -28693,7 +28680,7 @@ snapshots:
 
   muggle-string@0.4.1: {}
 
-  multer@2.0.1:
+  multer@2.0.2:
     dependencies:
       append-field: 1.0.0
       busboy: 1.6.0
@@ -29108,7 +29095,7 @@ snapshots:
     dependencies:
       ee-first: 1.1.1
 
-  on-headers@1.0.2: {}
+  on-headers@1.1.0: {}
 
   once@1.4.0:
     dependencies:
@@ -32308,7 +32295,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.10: {}
 
-  vue-component-type-helpers@3.0.3: {}
+  vue-component-type-helpers@3.0.4: {}
 
   vue-demi@0.14.10(vue@3.5.13(typescript@5.8.3)):
     dependencies:


### PR DESCRIPTION
## Summary

Updates packages for security vulnerabilities, addresses the following CVEs
- CVE-2025-7783
- CVE-2025-7338
- CVE-2025-7339
- 
## Related Linear tickets, Github issues, and Community forum posts

Replaces:
https://github.com/n8n-io/n8n/pull/17508
https://github.com/n8n-io/n8n/pull/17525


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
