### PR TITLE
ci: Add memory limits to match runner sizes

### DIFF
--- a/.github/workflows/linting-reusable.yml
+++ b/.github/workflows/linting-reusable.yml
@@ -14,6 +14,9 @@ on:
         type: string
         default: 22.x
 
+env:
+  NODE_OPTIONS: --max-old-space-size=8192
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/test-workflows-callable.yml
+++ b/.github/workflows/test-workflows-callable.yml
@@ -28,6 +28,9 @@ on:
         description: 'Webhook URL to send test results to (if enabled).'
         required: false
 
+env:
+  NODE_OPTIONS: --max-old-space-size=4096
+
 jobs:
   build_and_test:
     name: Install, Build, and Test Workflows

--- a/.github/workflows/units-tests-reusable.yml
+++ b/.github/workflows/units-tests-reusable.yml
@@ -22,6 +22,9 @@ on:
         description: 'Codecov upload token.'
         required: false
 
+env:
+  NODE_OPTIONS: --max-old-space-size=8192
+
 jobs:
   unit-test:
     name: Unit tests


### PR DESCRIPTION
## Summary

Any job that can trigger a build/test should have memory limits in place to avoid going OOM.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
