### PR TITLE
fix(editor): Hide `What's New` notification in executions demo view

### DIFF
--- a/packages/frontend/editor-ui/src/stores/versions.store.test.ts
+++ b/packages/frontend/editor-ui/src/stores/versions.store.test.ts
@@ -7,6 +7,7 @@ import type { Version, WhatsNewArticle, WhatsNewSection } from '@n8n/rest-api-cl
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useSettingsStore } from './settings.store';
 import { useToast } from '@/composables/useToast';
+import { VIEWS } from '@/constants';
 
 vi.mock('@/composables/useToast', () => {
 	const showToast = vi.fn();
@@ -20,6 +21,14 @@ vi.mock('@/composables/useToast', () => {
 });
 
 vi.mock('./users.store');
+
+vi.mock('vue-router', () => ({
+	useRoute: vi.fn().mockReturnValue({
+		name: VIEWS.HOMEPAGE,
+	}),
+	useRouter: vi.fn(),
+	RouterLink: vi.fn(),
+}));
 
 const settings: IVersionNotificationSettings = {
 	enabled: true,

--- a/packages/frontend/editor-ui/src/stores/versions.store.test.ts
+++ b/packages/frontend/editor-ui/src/stores/versions.store.test.ts
@@ -7,7 +7,12 @@ import type { Version, WhatsNewArticle, WhatsNewSection } from '@n8n/rest-api-cl
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useSettingsStore } from './settings.store';
 import { useToast } from '@/composables/useToast';
+import { reactive } from 'vue';
 import { VIEWS } from '@/constants';
+
+vi.mock('vue-router', () => ({
+	useRoute: () => reactive({ name: VIEWS.HOMEPAGE }),
+}));
 
 vi.mock('@/composables/useToast', () => {
 	const showToast = vi.fn();
@@ -21,14 +26,6 @@ vi.mock('@/composables/useToast', () => {
 });
 
 vi.mock('./users.store');
-
-vi.mock('vue-router', () => ({
-	useRoute: vi.fn().mockReturnValue({
-		name: VIEWS.HOMEPAGE,
-	}),
-	useRouter: vi.fn(),
-	RouterLink: vi.fn(),
-}));
 
 const settings: IVersionNotificationSettings = {
 	enabled: true,

--- a/packages/frontend/editor-ui/src/stores/versions.store.ts
+++ b/packages/frontend/editor-ui/src/stores/versions.store.ts
@@ -4,6 +4,7 @@ import {
 	LOCAL_STORAGE_DISMISSED_WHATS_NEW_CALLOUT,
 	LOCAL_STORAGE_READ_WHATS_NEW_ARTICLES,
 	VERSIONS_MODAL_KEY,
+	VIEWS,
 	WHATS_NEW_MODAL_KEY,
 } from '@/constants';
 import { STORES } from '@n8n/stores';
@@ -19,6 +20,7 @@ import { useUsersStore } from './users.store';
 import { useStorage } from '@/composables/useStorage';
 import { jsonParse } from 'n8n-workflow';
 import { useTelemetry } from '@/composables/useTelemetry';
+import { useRoute } from 'vue-router';
 
 type SetVersionParams = { versions: Version[]; currentVersion: string };
 
@@ -54,6 +56,7 @@ export const useVersionsStore = defineStore(STORES.VERSIONS, () => {
 	const uiStore = useUIStore();
 	const settingsStore = useSettingsStore();
 	const usersStore = useUsersStore();
+	const route = useRoute();
 	const readWhatsNewArticlesStorage = useStorage(LOCAL_STORAGE_READ_WHATS_NEW_ARTICLES);
 	const lastDismissedWhatsNewCalloutStorage = useStorage(LOCAL_STORAGE_DISMISSED_WHATS_NEW_CALLOUT);
 
@@ -171,6 +174,11 @@ export const useVersionsStore = defineStore(STORES.VERSIONS, () => {
 	};
 
 	const shouldShowWhatsNewCallout = (): boolean => {
+		// Never show if embedded, e.g. in executions iframe
+		if (route.name === VIEWS.DEMO) {
+			return false;
+		}
+
 		const createdAt = usersStore.currentUser?.createdAt;
 		let hasNewArticle = false;
 		if (createdAt) {


### PR DESCRIPTION
## Summary

Never show `What's new?` in demo route, used e.g. when in an iframe inside executions.

Tested by returning true immediately after the early return introduced here, which makes the pop up always... pop up, but not in the execution view.


## Related Linear tickets, Github issues, and Community forum posts


https://linear.app/n8n/issue/ADO-3867



## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
