### PR TITLE
ci: Adjust memory usage and build/test steps

### DIFF
--- a/.github/workflows/ci-postgres-mysql.yml
+++ b/.github/workflows/ci-postgres-mysql.yml
@@ -22,11 +22,22 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  NODE_OPTIONS: '--max-old-space-size=4096'
+  NODE_OPTIONS: '--max-old-space-size=3072'
 
 jobs:
+  build:
+    name: Install & Build
+    runs-on: blacksmith-2vcpu-ubuntu-2204
+    if: github.event_name != 'pull_request_review' || startsWith(github.event.pull_request.base.ref, 'release/')
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Setup and Build
+        uses: n8n-io/n8n/.github/actions/setup-nodejs-blacksmith@f5fbbbe0a28a886451c886cac6b49192a39b0eea # v1.104.1
+
   sqlite-pooled:
     name: SQLite Pooled
+    needs: build
     runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 20
     env:
@@ -44,6 +55,7 @@ jobs:
 
   mariadb:
     name: MariaDB
+    needs: build
     runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 20
     env:
@@ -67,6 +79,7 @@ jobs:
 
   mysql:
     name: MySQL (${{ matrix.service-name }})
+    needs: build
     runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 20
     strategy:
@@ -93,6 +106,7 @@ jobs:
 
   postgres:
     name: Postgres
+    needs: build
     runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 20
     env:

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -11,7 +11,7 @@ jobs:
     name: Install & Build
     runs-on: blacksmith-2vcpu-ubuntu-2204
     env:
-      NODE_OPTIONS: '--max-old-space-size=4096'
+      NODE_OPTIONS: '--max-old-space-size=3072'
     outputs:
       frontend_changed: ${{ steps.paths-filter.outputs.frontend == 'true' }}
     steps:

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -7,7 +7,7 @@
 name: 'Docker: Build and Push'
 
 env:
-  NODE_OPTIONS: '--max-old-space-size=8192'
+  NODE_OPTIONS: '--max-old-space-size=7168'
 
 on:
   schedule:

--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -45,7 +45,7 @@ on:
         required: true
 
 env:
-  NODE_OPTIONS: --max-old-space-size=4096
+  NODE_OPTIONS: --max-old-space-size=3072
 
 jobs:
   testing:

--- a/.github/workflows/linting-reusable.yml
+++ b/.github/workflows/linting-reusable.yml
@@ -15,7 +15,7 @@ on:
         default: 22.x
 
 env:
-  NODE_OPTIONS: --max-old-space-size=8192
+  NODE_OPTIONS: --max-old-space-size=7168
 
 jobs:
   lint:

--- a/.github/workflows/playwright-test-reusable.yml
+++ b/.github/workflows/playwright-test-reusable.yml
@@ -25,7 +25,7 @@ on:
 
 env:
   PLAYWRIGHT_BROWSERS_PATH: packages/testing/playwright/ms-playwright-cache
-  NODE_OPTIONS: --max-old-space-size=4096
+  NODE_OPTIONS: --max-old-space-size=3072
   # Disable Ryuk to avoid issues with Docker since it needs privileged access, containers are cleaned on teardown anyway
   TESTCONTAINERS_RYUK_DISABLED: true
 

--- a/.github/workflows/test-workflows-callable.yml
+++ b/.github/workflows/test-workflows-callable.yml
@@ -29,7 +29,7 @@ on:
         required: false
 
 env:
-  NODE_OPTIONS: --max-old-space-size=4096
+  NODE_OPTIONS: --max-old-space-size=3072
 
 jobs:
   build_and_test:

--- a/.github/workflows/units-tests-reusable.yml
+++ b/.github/workflows/units-tests-reusable.yml
@@ -23,7 +23,7 @@ on:
         required: false
 
 env:
-  NODE_OPTIONS: --max-old-space-size=8192
+  NODE_OPTIONS: --max-old-space-size=7168
 
 jobs:
   unit-test:
@@ -36,11 +36,13 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      - name: Build and Test
+      - name: Build
         uses: n8n-io/n8n/.github/actions/setup-nodejs-blacksmith@f5fbbbe0a28a886451c886cac6b49192a39b0eea # v1.104.1
         with:
-          build-command: pnpm test:ci
           node-version: ${{ inputs.nodeVersion }}
+
+      - name: Test
+        run: pnpm test:ci
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}

--- a/turbo.json
+++ b/turbo.json
@@ -15,7 +15,7 @@
 		},
 		"lint:fix": {},
 		"test": {
-			"dependsOn": ["^build", "build", "n8n-nodes-base#build"],
+			"dependsOn": ["^build", "build"],
 			"outputs": ["coverage/**", "*.xml"]
 		},
 		"watch": { "cache": false, "persistent": true },

--- a/turbo.json
+++ b/turbo.json
@@ -15,7 +15,7 @@
 		},
 		"lint:fix": {},
 		"test": {
-			"dependsOn": ["^build", "build"],
+			"dependsOn": ["^build", "build", "n8n-nodes-base#build"],
 			"outputs": ["coverage/**", "*.xml"]
 		},
 		"watch": { "cache": false, "persistent": true },


### PR DESCRIPTION
## Summary

Adjust memory limits for all jobs to match runners. (leaving extra)
Separate build and test into 2 steps to allow for circular dependencies.
Added build step back to DB tests because it acted as a filter.

## Related Linear tickets, Github issues, and Community forum posts



## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
