### PR TITLE
fix(Structured Output Parser Node): Handle passed objects that do not match schema

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/test/OutputParserStructured.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/test/OutputParserStructured.node.test.ts
@@ -608,6 +608,33 @@ describe('OutputParserStructured', () => {
 						),
 					).rejects.toThrow('Required');
 				});
+
+				it('should raise schema fit error when passing in empty object', async () => {
+					const jsonExample = `{
+            "user": {
+              "name": "Alice",
+              "email": "alice@example.com",
+              "profile": {
+                "age": 30,
+                "city": "New York"
+              }
+            },
+            "tags": ["work", "important"]
+          }`;
+					thisArg.getNodeParameter.calledWith('schemaType', 0).mockReturnValueOnce('fromJson');
+					thisArg.getNodeParameter
+						.calledWith('jsonSchemaExample', 0)
+						.mockReturnValueOnce(jsonExample);
+
+					const { response } = (await outputParser.supplyData.call(thisArg, 0)) as {
+						response: N8nStructuredOutputParser;
+					};
+
+					// @ts-expect-error 2345
+					await expect(response.parse({})).rejects.toThrow(
+						"Model output doesn't fit required format",
+					);
+				});
 			});
 
 			describe('manual schema mode', () => {

--- a/packages/@n8n/nodes-langchain/utils/output_parsers/N8nStructuredOutputParser.ts
+++ b/packages/@n8n/nodes-langchain/utils/output_parsers/N8nStructuredOutputParser.ts
@@ -66,7 +66,7 @@ export class N8nStructuredOutputParser extends StructuredOutputParser<
 			if (e instanceof SyntaxError) {
 				nodeError.context.outputParserFailReason = 'Invalid JSON in model output';
 			} else if (
-				(typeof text.trim === 'function' && text.trim() === '{}') ||
+				(typeof text === 'string' && text.trim() === '{}') ||
 				(e instanceof z.ZodError &&
 					e.issues?.[0] &&
 					e.issues?.[0].code === 'invalid_type' &&

--- a/packages/@n8n/nodes-langchain/utils/output_parsers/N8nStructuredOutputParser.ts
+++ b/packages/@n8n/nodes-langchain/utils/output_parsers/N8nStructuredOutputParser.ts
@@ -66,7 +66,7 @@ export class N8nStructuredOutputParser extends StructuredOutputParser<
 			if (e instanceof SyntaxError) {
 				nodeError.context.outputParserFailReason = 'Invalid JSON in model output';
 			} else if (
-				text.trim() === '{}' ||
+				(typeof text.trim === 'function' && text.trim() === '{}') ||
 				(e instanceof z.ZodError &&
 					e.issues?.[0] &&
 					e.issues?.[0].code === 'invalid_type' &&


### PR DESCRIPTION
This prevents the unexpected `text.trim is not a function` error.

## Summary

In some cases, the structured output parser would yield `text.trim is not a function`. The assumption is that an object of some kind is then passed to the structured output parser, that doesn't have the `trim` method. In this case, we explicitly check if the type is a string before applying the `trim` method.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-1236/community-issue-getting-texttrim-is-not-a-function-error-in-ai-agent
https://github.com/n8n-io/n8n/issues/17700

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
