### PR TITLE
fix(Microsoft Teams Trigger Node): Forbidden when trying to listen for channel messages

### DIFF
--- a/packages/nodes-base/credentials/MicrosoftTeamsOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftTeamsOAuth2Api.credentials.ts
@@ -15,7 +15,8 @@ export class MicrosoftTeamsOAuth2Api implements ICredentialType {
 			displayName: 'Scope',
 			name: 'scope',
 			type: 'hidden',
-			default: 'openid offline_access User.ReadWrite.All Group.ReadWrite.All Chat.ReadWrite',
+			default:
+				'openid offline_access User.ReadWrite.All Group.ReadWrite.All Chat.ReadWrite ChannelMessage.Read.All',
 		},
 		{
 			displayName: `


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Fix an issue where it is not possible to listen for new messages in the channel. The app needs to have `ChannelMessage.Read.All` delegated permission enabled and it needs to be included in the scope

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-3160/community-issue-microsoft-teams-oauth2-connector-not-working-for-get
Closes #17260, closes #16613

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
