### PR TITLE
fix(editor): Focus editable text input when clicking anywhere on the element

### DIFF
--- a/cypress/e2e/2-credentials.cy.ts
+++ b/cypress/e2e/2-credentials.cy.ts
@@ -193,7 +193,6 @@ describe('Credentials', () => {
 		credentialsModal.actions.fillCredentialsForm();
 		workflowPage.getters.nodeCredentialsEditButton().click();
 		credentialsModal.getters.credentialsEditModal().should('be.visible');
-		credentialsModal.getters.name().click();
 		credentialsModal.actions.renameCredential(NEW_CREDENTIAL_NAME);
 		saveCredential();
 		credentialsModal.getters.closeButton().click();
@@ -211,7 +210,6 @@ describe('Credentials', () => {
 		cy.get('body').type('{enter}');
 		workflowPage.getters.nodeCredentialsEditButton().click();
 		credentialsModal.getters.credentialsEditModal().should('be.visible');
-		credentialsModal.getters.name().click();
 		credentialsModal.actions.renameCredential(NEW_CREDENTIAL_NAME2);
 		saveCredential();
 		credentialsModal.getters.closeButton().click();
@@ -236,7 +234,6 @@ describe('Credentials', () => {
 		credentialsModal.actions.fillCredentialsForm();
 		workflowPage.getters.nodeCredentialsEditButton().click();
 		credentialsModal.getters.credentialsEditModal().should('be.visible');
-		credentialsModal.getters.name().click();
 		credentialsModal.actions.renameCredential(NEW_CREDENTIAL_NAME);
 		saveCredential();
 		credentialsModal.getters.closeButton().click();

--- a/packages/frontend/@n8n/design-system/src/components/N8nInlineTextEdit/InlineTextEdit.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInlineTextEdit/InlineTextEdit.stories.ts
@@ -15,7 +15,7 @@ const Template: StoryFn = (args, { argTypes }) => ({
 	},
 	template: `
 		<div class="story">
-			<N8nInlineTextEdit v-bind="args" />
+			<InlineTextEdit v-bind="args" />
 		</div>
 	`,
 });

--- a/packages/frontend/@n8n/design-system/src/components/N8nInlineTextEdit/InlineTextEdit.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInlineTextEdit/InlineTextEdit.test.ts
@@ -105,4 +105,24 @@ describe('N8nInlineTextEdit', () => {
 		const emittedEvents = wrapper.emitted('update:model-value');
 		expect(emittedEvents).toBeUndefined();
 	});
+
+	it('should focus input when any child element is clicked', async () => {
+		const wrapper = renderComponent({
+			props: {
+				modelValue: 'Test Value',
+			},
+		});
+		const editableArea = wrapper.getByTestId('inline-editable-area');
+		const rect = editableArea.getBoundingClientRect();
+
+		// Click the bottom right corner of the parent element
+		await userEvent.pointer([
+			{ coords: { clientX: rect.right - 1, clientY: rect.bottom - 1 } },
+			{ target: editableArea },
+			{ keys: '[MouseLeft]' },
+		]);
+
+		const input = wrapper.getByTestId('inline-edit-input');
+		expect(input).toHaveFocus();
+	});
 });

--- a/packages/frontend/@n8n/design-system/src/components/N8nInlineTextEdit/InlineTextEdit.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInlineTextEdit/InlineTextEdit.vue
@@ -101,6 +101,7 @@ defineExpose({ forceFocus, forceCancel });
 		:readonly="readOnly"
 		select-on-focus
 		auto-resize
+		@click="forceFocus"
 		@submit="onSubmit"
 		@update:model-value="onInput"
 		@update:state="onStateChange"

--- a/packages/frontend/@n8n/design-system/src/components/N8nInlineTextEdit/InlineTextEdit.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInlineTextEdit/InlineTextEdit.vue
@@ -52,7 +52,7 @@ const computedInlineStyles = computed(() => ({
 }));
 
 function forceFocus() {
-	if (editableRoot.value && !props.readOnly) {
+	if (editableRoot.value && !props.readOnly && !props.disabled) {
 		editableRoot.value.edit();
 	}
 }


### PR DESCRIPTION
## Summary
Click was not registering on all parts of the editable area, have added a click handler to the parent and included a test for click events on the very edge of the component.

## Related Linear tickets, Github issues, and Community forum posts
fixes DS-199
https://linear.app/n8n/issue/DS-199/renaming-a-credential-doesnt-work-when-clicking-the-edge-of-the-input

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
