### PR TITLE
refactor(editor): Refine INodeUpdatePropertiesInformation type and remove unnecessary type assertions

### DIFF
--- a/packages/frontend/editor-ui/src/Interface.ts
+++ b/packages/frontend/editor-ui/src/Interface.ts
@@ -160,10 +160,7 @@ export interface IUpdateInformation<T extends NodeParameterValueType = NodeParam
 
 export interface INodeUpdatePropertiesInformation {
 	name: string; // Node-Name
-	properties: {
-		position: XYPosition;
-		[key: string]: IDataObject | XYPosition;
-	};
+	properties: Partial<INodeUi>;
 }
 
 export type XYPosition = [number, number];

--- a/packages/frontend/editor-ui/src/components/NodeCredentials.vue
+++ b/packages/frontend/editor-ui/src/components/NodeCredentials.vue
@@ -295,7 +295,6 @@ function clearSelectedCredential(credentialType: string) {
 		name: props.node.name,
 		properties: {
 			credentials,
-			position: props.node.position,
 		},
 	};
 
@@ -412,7 +411,6 @@ function onCredentialSelected(
 		name: props.node.name,
 		properties: {
 			credentials,
-			position: props.node.position,
 		},
 	};
 

--- a/packages/frontend/editor-ui/src/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/components/RunData.vue
@@ -24,13 +24,7 @@ import {
 } from 'n8n-workflow';
 import { computed, defineAsyncComponent, onBeforeUnmount, onMounted, ref, toRef, watch } from 'vue';
 
-import type {
-	INodeUi,
-	INodeUpdatePropertiesInformation,
-	IRunDataDisplayMode,
-	ITab,
-	NodePanelType,
-} from '@/Interface';
+import type { INodeUi, IRunDataDisplayMode, ITab, NodePanelType } from '@/Interface';
 
 import {
 	CORE_NODES_CATEGORY,
@@ -1311,8 +1305,8 @@ function enableNode() {
 			name: node.value.name,
 			properties: {
 				disabled: !node.value.disabled,
-			} as IDataObject,
-		} as INodeUpdatePropertiesInformation;
+			},
+		};
 
 		workflowsStore.updateNodeProperties(updateInformation);
 	}

--- a/packages/frontend/editor-ui/src/components/SettingsLogStreaming/EventDestinationSettingsModal.ee.vue
+++ b/packages/frontend/editor-ui/src/components/SettingsLogStreaming/EventDestinationSettingsModal.ee.vue
@@ -5,7 +5,6 @@ import set from 'lodash/set';
 import unset from 'lodash/unset';
 
 import type {
-	IDataObject,
 	NodeParameterValue,
 	MessageEventBusDestinationOptions,
 	INodeParameters,
@@ -252,7 +251,7 @@ function valueChanged(parameterData: IUpdateInformation) {
 	nodeParameters.value = deepCopy(nodeParametersCopy);
 	workflowsStore.updateNodeProperties({
 		name: node.value.name,
-		properties: { parameters: nodeParameters.value as unknown as IDataObject, position: [0, 0] },
+		properties: { parameters: nodeParameters.value, position: [0, 0] },
 	});
 	if (hasOnceBeenSaved.value) {
 		logStreamingStore.updateDestination(nodeParameters.value);

--- a/packages/frontend/editor-ui/src/components/SetupWorkflowCredentialsModal/useSetupWorkflowCredentialsModalState.ts
+++ b/packages/frontend/editor-ui/src/components/SetupWorkflowCredentialsModal/useSetupWorkflowCredentialsModalState.ts
@@ -66,7 +66,6 @@ export const useSetupWorkflowCredentialsModalState = () => {
 			workflowsStore.updateNodeProperties({
 				name: node.name,
 				properties: {
-					position: node.position,
 					credentials: {
 						...node.credentials,
 						[usages.credentialType]: credential,
@@ -101,7 +100,6 @@ export const useSetupWorkflowCredentialsModalState = () => {
 			workflowsStore.updateNodeProperties({
 				name: node.name,
 				properties: {
-					position: node.position,
 					credentials,
 				},
 			});

--- a/packages/frontend/editor-ui/src/composables/useNodeHelpers.ts
+++ b/packages/frontend/editor-ui/src/composables/useNodeHelpers.ts
@@ -20,7 +20,6 @@ import type {
 	ITaskDataConnections,
 	IRunData,
 	IBinaryKeyData,
-	IDataObject,
 	INode,
 	INodePropertyOptions,
 	INodeCredentialsDetails,
@@ -722,8 +721,8 @@ export function useNodeHelpers() {
 				name: node.name,
 				properties: {
 					disabled: newDisabledState,
-				} as IDataObject,
-			} as INodeUpdatePropertiesInformation;
+				},
+			};
 
 			telemetry.track('User set node enabled status', {
 				node_type: node.type,

--- a/packages/frontend/editor-ui/src/utils/nodeTypesUtils.ts
+++ b/packages/frontend/editor-ui/src/utils/nodeTypesUtils.ts
@@ -1,9 +1,4 @@
-import type {
-	AppliedThemeOption,
-	INodeUi,
-	INodeUpdatePropertiesInformation,
-	NodeAuthenticationOption,
-} from '@/Interface';
+import type { AppliedThemeOption, INodeUi, NodeAuthenticationOption } from '@/Interface';
 import type { ITemplatesNode } from '@n8n/rest-api-client/api/templates';
 import {
 	CORE_NODES_CATEGORY,
@@ -386,8 +381,8 @@ export const updateNodeAuthType = (node: INodeUi | null, type: string) => {
 						...node.parameters,
 						[nodeAuthField.name]: type,
 					},
-				} as IDataObject,
-			} as INodeUpdatePropertiesInformation;
+				},
+			};
 			useWorkflowsStore().updateNodeProperties(updateInformation);
 		}
 	}


### PR DESCRIPTION
## Summary

This PR updates `INodeUpdatePropertiesInformation` so that it doesn't always require to include `position` in properties and to make it better match what `updateNodeAtIndex` function in workflows store expects.

## Related Linear tickets, Github issues, and Community forum posts

n/a


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
