### PR TITLE
fix(core): Fix getting webhook methods from path only when dynamic webhook path

### DIFF
--- a/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
@@ -220,14 +220,14 @@ describe('TestWebhooks', () => {
 			const PATH_WITHOUT_SLASH = 'register';
 			const webhookData = {
 				httpMethod: METHOD as IHttpRequestMethods,
-				path: PATH_WITH_SLASH.endsWith('/') ? PATH_WITH_SLASH.slice(0, -1) : PATH_WITH_SLASH,
-			};
+				path: PATH_WITHOUT_SLASH,
+			} as IWebhookData;
 
 			registrations.getRegistrationsHash.mockImplementation(async () => {
 				return {
 					[registrations.toKey(webhookData)]: {
 						workflowEntity: mock<WorkflowEntity>(),
-						webhook: webhookData as IWebhookData,
+						webhook: webhookData,
 					},
 				};
 			});

--- a/packages/cli/src/webhooks/__tests__/webhook.service.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook.service.test.ts
@@ -154,6 +154,21 @@ describe('WebhookService', () => {
 
 			expect(returnedMethods).toEqual([]);
 		});
+
+		test('should return dynamic webhook method when static search returns nothing', async () => {
+			const webhookId = uuid();
+			const dynamicPath = `${webhookId}/user/1`;
+			const mockDynamicWebhook = createWebhook('POST', 'user/:id', webhookId, 2);
+
+			// Mock static webhook search to return empty
+			webhookRepository.find.mockResolvedValue([]);
+			// Mock dynamic webhook search to return a webhook
+			webhookRepository.findBy.mockResolvedValue([mockDynamicWebhook]);
+
+			const returnedMethods = await webhookService.getWebhookMethods(dynamicPath);
+
+			expect(returnedMethods).toEqual(['POST']);
+		});
 	});
 
 	describe('deleteWorkflowWebhooks()', () => {

--- a/packages/cli/src/webhooks/test-webhook-registrations.service.ts
+++ b/packages/cli/src/webhooks/test-webhook-registrations.service.ts
@@ -71,6 +71,10 @@ export class TestWebhookRegistrationsService {
 		return Object.values(hash);
 	}
 
+	async getRegistrationsHash() {
+		return await this.cacheService.getHash<TestWebhookRegistration>(this.cacheKey);
+	}
+
 	async deregisterAll() {
 		await this.cacheService.delete(this.cacheKey);
 	}

--- a/packages/cli/src/webhooks/webhook.service.ts
+++ b/packages/cli/src/webhooks/webhook.service.ts
@@ -57,7 +57,7 @@ export class WebhookService {
 			return dbStaticWebhook;
 		}
 
-		return await this.findDynamicWebhook(method, path);
+		return await this.findDynamicWebhook(path, method);
 	}
 
 	/**
@@ -71,7 +71,7 @@ export class WebhookService {
 	 * Find a matching webhook with one or more dynamic path segments, e.g. `<uuid>/user/:id/posts`.
 	 * It is mandatory for dynamic webhooks to have `<uuid>/` at the base.
 	 */
-	private async findDynamicWebhook(method: Method, path: string) {
+	private async findDynamicWebhook(path: string, method?: Method) {
 		const [uuidSegment, ...otherSegments] = path.split('/');
 
 		const dynamicWebhooks = await this.webhookRepository.findBy({
@@ -133,10 +133,19 @@ export class WebhookService {
 		return await this.webhookRepository.remove(webhooks);
 	}
 
-	async getWebhookMethods(path: string) {
-		return await this.webhookRepository
-			.find({ select: ['method'], where: { webhookPath: path } })
+	async getWebhookMethods(rawPath: string) {
+		// Try to find static webhooks first
+		const webhooks = await this.webhookRepository
+			.find({ select: ['method'], where: { webhookPath: rawPath } })
 			.then((rows) => rows.map((r) => r.method));
+
+		if (webhooks.length > 0) {
+			return webhooks;
+		}
+
+		// Otherwise, try to find dynamic webhooks based on path only
+		const dynamicWebhooks = await this.findDynamicWebhook(rawPath);
+		return dynamicWebhooks ? [dynamicWebhooks.method] : [];
 	}
 
 	private isDynamicPath(rawPath: string) {

--- a/packages/cli/src/webhooks/webhook.service.ts
+++ b/packages/cli/src/webhooks/webhook.service.ts
@@ -135,12 +135,12 @@ export class WebhookService {
 
 	async getWebhookMethods(rawPath: string) {
 		// Try to find static webhooks first
-		const webhooks = await this.webhookRepository
+		const staticMethods = await this.webhookRepository
 			.find({ select: ['method'], where: { webhookPath: rawPath } })
 			.then((rows) => rows.map((r) => r.method));
 
-		if (webhooks.length > 0) {
-			return webhooks;
+		if (staticMethods.length > 0) {
+			return staticMethods;
 		}
 
 		// Otherwise, try to find dynamic webhooks based on path only


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Currently, when a webhook is dynamic (has a param in its path - e.g /path/:id), has a CORS wildcard setup, and the user calls the webhook from a browser on a different domain, the getWebhookMethods fails (both on test and live webhooks). That's because for now, the getWebhookMethods only try to find webhooks that exactly match the path, and thus dynamic path are not matched

This PR suggests to use the same method we use to find dynamic webhook from path in the getWebhookMethods, but extend it to search for all http methods. This should be safe because if the path is dynamic, the webhook id is in the path and unique.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-3170/cors-error-on-patch-and-detete-methods


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
