### PR TITLE
feat(AWS Bedrock Chat Model Node): Add inference profile support

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/LmChatAwsBedrock.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/LmChatAwsBedrock.node.ts
@@ -76,7 +76,7 @@ export class LmChatAwsBedrock implements INodeType {
 						name: 'Inference Profiles',
 						value: 'inferenceProfile',
 						description:
-							'Cross-region inference profiles (required for some newer models like Claude 3.5 Sonnet v2)',
+							'Cross-region inference profiles (required for models like Claude Sonnet 4 and others)',
 					},
 				],
 				default: 'onDemand',

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/LmChatAwsBedrock.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/LmChatAwsBedrock.node.ts
@@ -24,7 +24,6 @@ export class LmChatAwsBedrock implements INodeType {
 		description: 'Language Model AWS Bedrock',
 		defaults: {
 			name: 'AWS Bedrock Chat Model',
-			modelSource: 'onDemand',
 		},
 		codex: {
 			categories: ['AI'],

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/LmChatAwsBedrock.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/LmChatAwsBedrock.node.ts
@@ -20,10 +20,11 @@ export class LmChatAwsBedrock implements INodeType {
 		name: 'lmChatAwsBedrock',
 		icon: 'file:bedrock.svg',
 		group: ['transform'],
-		version: 1,
+		version: [1, 1.1],
 		description: 'Language Model AWS Bedrock',
 		defaults: {
 			name: 'AWS Bedrock Chat Model',
+			modelSource: 'onDemand',
 		},
 		codex: {
 			categories: ['AI'],
@@ -57,13 +58,44 @@ export class LmChatAwsBedrock implements INodeType {
 		properties: [
 			getConnectionHintNoticeField([NodeConnectionTypes.AiChain, NodeConnectionTypes.AiChain]),
 			{
+				displayName: 'Model Source',
+				name: 'modelSource',
+				type: 'options',
+				displayOptions: {
+					show: {
+						'@version': [{ _cnd: { gte: 1.1 } }],
+					},
+				},
+				options: [
+					{
+						name: 'On-Demand Models',
+						value: 'onDemand',
+						description: 'Standard foundation models with on-demand pricing',
+					},
+					{
+						name: 'Inference Profiles',
+						value: 'inferenceProfile',
+						description:
+							'Cross-region inference profiles (required for some newer models like Claude 3.5 Sonnet v2)',
+					},
+				],
+				default: 'onDemand',
+				description: 'Choose between on-demand foundation models or inference profiles',
+			},
+			{
 				displayName: 'Model',
 				name: 'model',
 				type: 'options',
 				allowArbitraryValues: true, // Hide issues when model name is specified in the expression and does not match any of the options
 				description:
 					'The model which will generate the completion. <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/foundation-models.html">Learn more</a>.',
+				displayOptions: {
+					hide: {
+						modelSource: ['inferenceProfile'],
+					},
+				},
 				typeOptions: {
+					loadOptionsDependsOn: ['modelSource'],
 					loadOptions: {
 						routing: {
 							request: {
@@ -84,6 +116,62 @@ export class LmChatAwsBedrock implements INodeType {
 											name: '={{$responseItem.modelName}}',
 											description: '={{$responseItem.modelArn}}',
 											value: '={{$responseItem.modelId}}',
+										},
+									},
+									{
+										type: 'sort',
+										properties: {
+											key: 'name',
+										},
+									},
+								],
+							},
+						},
+					},
+				},
+				routing: {
+					send: {
+						type: 'body',
+						property: 'model',
+					},
+				},
+				default: '',
+			},
+			{
+				displayName: 'Model',
+				name: 'model',
+				type: 'options',
+				allowArbitraryValues: true,
+				description:
+					'The inference profile which will generate the completion. <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-use.html">Learn more</a>.',
+				displayOptions: {
+					show: {
+						modelSource: ['inferenceProfile'],
+					},
+				},
+				typeOptions: {
+					loadOptionsDependsOn: ['modelSource'],
+					loadOptions: {
+						routing: {
+							request: {
+								method: 'GET',
+								url: '/inference-profiles?maxResults=1000',
+							},
+							output: {
+								postReceive: [
+									{
+										type: 'rootProperty',
+										properties: {
+											property: 'inferenceProfileSummaries',
+										},
+									},
+									{
+										type: 'setKeyValue',
+										properties: {
+											name: '={{$responseItem.inferenceProfileName}}',
+											description:
+												'={{$responseItem.description || $responseItem.inferenceProfileArn}}',
+											value: '={{$responseItem.inferenceProfileId}}',
 										},
 									},
 									{


### PR DESCRIPTION
Add support for AWS Bedrock inference profiles to access newer models like Claude 3.5 Sonnet v2 that require cross-region inference profiles instead of direct model access.

- Add Model Source selector in version 1.1 to choose between on-demand models and inference profiles
- Add inference profiles API integration with proper response handling
- Maintain backward compatibility with existing workflows in version 1.0
- Add dynamic model list refresh when switching between model sources
- Support both standard foundation models and cross-region inference profiles

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-1133/feature-support-models-through-inference-profiles-in-aws-bedrock
https://linear.app/n8n/issue/AI-1239/community-issue-unable-to-view-some-of-the-bedrock-models-on-n8n
https://github.com/n8n-io/n8n/issues/17788
https://github.com/n8n-io/n8n/issues/17324

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
