### PR TITLE
fix: Hide settings hint from log view

### DIFF
--- a/packages/frontend/editor-ui/src/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/components/RunData.vue
@@ -148,6 +148,7 @@ type Props = {
 	compact?: boolean;
 	tableHeaderBgColor?: 'base' | 'light';
 	disableHoverHighlight?: boolean;
+	disableSettingsHint?: boolean;
 	disableAiContent?: boolean;
 	collapsingTableColumnName: string | null;
 };
@@ -169,6 +170,7 @@ const props = withDefaults(defineProps<Props>(), {
 	disableEdit: false,
 	disablePin: false,
 	disableHoverHighlight: false,
+	disableSettingsHint: false,
 	compact: false,
 	tableHeaderBgColor: 'base',
 	workflowExecution: undefined,
@@ -1541,7 +1543,10 @@ defineExpose({ enterEditMode });
 					</slot>
 				</N8nCallout>
 			</div>
-			<NodeSettingsHint v-if="props.paneType === 'output'" :node="node" />
+			<NodeSettingsHint
+				v-if="!props.disableSettingsHint && props.paneType === 'output'"
+				:node="node"
+			/>
 			<N8nCallout
 				v-for="hint in getNodeHints()"
 				:key="hint.message"

--- a/packages/frontend/editor-ui/src/features/logs/components/LogsViewRunData.vue
+++ b/packages/frontend/editor-ui/src/features/logs/components/LogsViewRunData.vue
@@ -87,6 +87,7 @@ function handleChangeDisplayMode(value: IRunDataDisplayMode) {
 		:disable-pin="true"
 		:disable-edit="true"
 		:disable-hover-highlight="true"
+		:disable-settings-hint="true"
 		:display-mode="displayMode"
 		:disable-ai-content="!isSubNodeLog(logEntry)"
 		:is-executing="isExecuting"


### PR DESCRIPTION
## Summary

This PR is a follow up to https://github.com/n8n-io/n8n/pull/15467 and it disables the settings hint from the log view panel to allow more space for logs

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3389/settings-notices-in-the-output-panel-should-be-hiddenremoved-from-log
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
