### PR TITLE
fix(Jira Software Node): Get All Issues operation with Return All hangs

### DIFF
--- a/packages/nodes-base/nodes/Jira/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Jira/GenericFunctions.ts
@@ -92,8 +92,11 @@ export function handlePagination(
 				body.maxResults = 100;
 			}
 		} else {
-			// token pagination is used only in POST requests
-			body.maxResults = 100;
+			if (method === 'GET') {
+				query.maxResults = 100;
+			} else {
+				body.maxResults = 100;
+			}
 		}
 
 		return true;
@@ -109,7 +112,12 @@ export function handlePagination(
 
 		return nextStartAt < responseData.total;
 	} else {
-		body.nextPageToken = responseData.nextPageToken as string;
+		if (method === 'GET') {
+			query.nextPageToken = responseData.nextPageToken as string;
+		} else {
+			body.nextPageToken = responseData.nextPageToken as string;
+		}
+
 		return !!responseData.nextPageToken;
 	}
 }

--- a/packages/nodes-base/nodes/Jira/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Jira/GenericFunctions.ts
@@ -85,16 +85,20 @@ export function handlePagination(
 	if (!responseData) {
 		if (paginationType === 'offset') {
 			if (method === 'GET') {
+				// Example: https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-search/#api-rest-api-2-search-get
 				query.startAt = 0;
 				query.maxResults = 100;
 			} else {
+				// Example: https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-search/#api-rest-api-2-search-post
 				body.startAt = 0;
 				body.maxResults = 100;
 			}
 		} else {
 			if (method === 'GET') {
+				// Example: https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-search/#api-rest-api-2-search-jql-get
 				query.maxResults = 100;
 			} else {
+				// Example: https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-search/#api-rest-api-2-search-jql-post
 				body.maxResults = 100;
 			}
 		}

--- a/packages/nodes-base/nodes/Jira/__test__/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Jira/__test__/GenericFunctions.test.ts
@@ -80,7 +80,18 @@ describe('Jira -> GenericFunctions', () => {
 			expect(query).toEqual({});
 		});
 
-		it('should initialize token pagination parameters when responseData is not provided', () => {
+		it('should initialize token pagination parameters with GET when responseData is not provided', () => {
+			const body: IDataObject = {};
+			const query: IDataObject = {};
+
+			const result = handlePagination('GET', body, query, 'token');
+
+			expect(result).toBe(true);
+			expect(query.maxResults).toBe(100);
+			expect(body).toEqual({});
+		});
+
+		it('should initialize token pagination parameters with POST when responseData is not provided', () => {
 			const body: IDataObject = {};
 			const query: IDataObject = {};
 
@@ -155,7 +166,21 @@ describe('Jira -> GenericFunctions', () => {
 			expect(query).toEqual({});
 		});
 
-		it('should handle token pagination with more pages available', () => {
+		it('should handle token pagination with GET and more pages available', () => {
+			const body: IDataObject = {};
+			const query: IDataObject = {};
+			const responseData = {
+				nextPageToken: 'someToken123',
+			};
+
+			const result = handlePagination('GET', body, query, 'token', responseData);
+
+			expect(result).toBe(true);
+			expect(query.nextPageToken).toBe('someToken123');
+			expect(body).toEqual({});
+		});
+
+		it('should handle token pagination with POST and more pages available', () => {
 			const body: IDataObject = {};
 			const query: IDataObject = {};
 			const responseData = {
@@ -169,7 +194,21 @@ describe('Jira -> GenericFunctions', () => {
 			expect(query).toEqual({});
 		});
 
-		it('should handle token pagination with no more pages available', () => {
+		it('should handle token pagination with GET and no more pages available', () => {
+			const body: IDataObject = {};
+			const query: IDataObject = {};
+			const responseData = {
+				nextPageToken: '',
+			};
+
+			const result = handlePagination('GET', body, query, 'token', responseData);
+
+			expect(result).toBe(false);
+			expect(query.nextPageToken).toBe('');
+			expect(body).toEqual({});
+		});
+
+		it('should handle token pagination with POST and no more pages available', () => {
 			const body: IDataObject = {};
 			const query: IDataObject = {};
 			const responseData = {

--- a/packages/nodes-base/nodes/Jira/__test__/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Jira/__test__/GenericFunctions.test.ts
@@ -56,11 +56,11 @@ describe('Jira -> GenericFunctions', () => {
 	});
 
 	describe('handlePagination', () => {
-		it('should initialize offset pagination parameters when responseData is not provided', () => {
-			const body = {};
+		it('should initialize offset pagination parameters with GET when responseData is not provided', () => {
+			const body: IDataObject = {};
 			const query: IDataObject = {};
 
-			const result = handlePagination(body, query, 'offset');
+			const result = handlePagination('GET', body, query, 'offset');
 
 			expect(result).toBe(true);
 			expect(query.startAt).toBe(0);
@@ -68,18 +68,30 @@ describe('Jira -> GenericFunctions', () => {
 			expect(body).toEqual({});
 		});
 
+		it('should initialize offset pagination parameters with POST when responseData is not provided', () => {
+			const body: IDataObject = {};
+			const query: IDataObject = {};
+
+			const result = handlePagination('POST', body, query, 'offset');
+
+			expect(result).toBe(true);
+			expect(body.startAt).toBe(0);
+			expect(body.maxResults).toBe(100);
+			expect(query).toEqual({});
+		});
+
 		it('should initialize token pagination parameters when responseData is not provided', () => {
 			const body: IDataObject = {};
 			const query: IDataObject = {};
 
-			const result = handlePagination(body, query, 'token');
+			const result = handlePagination('POST', body, query, 'token');
 
 			expect(result).toBe(true);
 			expect(query).toEqual({});
 			expect(body.maxResults).toBe(100);
 		});
 
-		it('should handle offset pagination with more pages available', () => {
+		it('should handle offset pagination with GET and more pages available', () => {
 			const body: IDataObject = {};
 			const query: IDataObject = {};
 			const responseData = {
@@ -88,14 +100,30 @@ describe('Jira -> GenericFunctions', () => {
 				total: 250,
 			};
 
-			const result = handlePagination(body, query, 'offset', responseData);
+			const result = handlePagination('GET', body, query, 'offset', responseData);
 
 			expect(result).toBe(true);
 			expect(query.startAt).toBe(100);
 			expect(body).toEqual({});
 		});
 
-		it('should handle offset pagination with no more pages available', () => {
+		it('should handle offset pagination with POST and more pages available', () => {
+			const body: IDataObject = {};
+			const query: IDataObject = {};
+			const responseData = {
+				startAt: 0,
+				maxResults: 100,
+				total: 250,
+			};
+
+			const result = handlePagination('POST', body, query, 'offset', responseData);
+
+			expect(result).toBe(true);
+			expect(body.startAt).toBe(100);
+			expect(query).toEqual({});
+		});
+
+		it('should handle offset pagination with GET and no more pages available', () => {
 			const body: IDataObject = {};
 			const query: IDataObject = {};
 			const responseData = {
@@ -104,11 +132,27 @@ describe('Jira -> GenericFunctions', () => {
 				total: 250,
 			};
 
-			const result = handlePagination(body, query, 'offset', responseData);
+			const result = handlePagination('GET', body, query, 'offset', responseData);
 
 			expect(result).toBe(false);
 			expect(query.startAt).toBe(300);
 			expect(body).toEqual({});
+		});
+
+		it('should handle offset pagination with POST and no more pages available', () => {
+			const body: IDataObject = {};
+			const query: IDataObject = {};
+			const responseData = {
+				startAt: 200,
+				maxResults: 100,
+				total: 250,
+			};
+
+			const result = handlePagination('POST', body, query, 'offset', responseData);
+
+			expect(result).toBe(false);
+			expect(body.startAt).toBe(300);
+			expect(query).toEqual({});
 		});
 
 		it('should handle token pagination with more pages available', () => {
@@ -118,7 +162,7 @@ describe('Jira -> GenericFunctions', () => {
 				nextPageToken: 'someToken123',
 			};
 
-			const result = handlePagination(body, query, 'token', responseData);
+			const result = handlePagination('POST', body, query, 'token', responseData);
 
 			expect(result).toBe(true);
 			expect(body.nextPageToken).toBe('someToken123');
@@ -132,7 +176,7 @@ describe('Jira -> GenericFunctions', () => {
 				nextPageToken: '',
 			};
 
-			const result = handlePagination(body, query, 'token', responseData);
+			const result = handlePagination('POST', body, query, 'token', responseData);
 
 			expect(result).toBe(false);
 			expect(body.nextPageToken).toBe('');


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Fix a bug where when executing `issue:getAll` operation with `returnAll` enabled, the node is stuck in an infinite loop. This was caused by improper handling of offset-based pagination with `POST` requests. The issue is present only on self-hosted

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-3229/community-issue-jira-node-get-all-issues-never-ends
Closes #16493

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
