### PR TITLE
fix(editor): Include session_id in AI builder tracking (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/components/AskAssistant/Agent/AskAssistantBuild.test.ts
+++ b/packages/frontend/editor-ui/src/components/AskAssistant/Agent/AskAssistantBuild.test.ts
@@ -105,6 +105,7 @@ describe('AskAssistantBuild', () => {
 		builderStore.workflowMessages = [];
 		builderStore.toolMessages = [];
 		builderStore.workflowPrompt = workflowPrompt;
+		builderStore.trackingSessionId = 'app_session_id';
 
 		workflowsStore.workflowId = 'abc123';
 	});
@@ -187,6 +188,7 @@ describe('AskAssistantBuild', () => {
 				expect(trackMock).toHaveBeenCalledWith('User rated workflow generation', {
 					helpful: true,
 					workflow_id: 'abc123',
+					session_id: 'app_session_id',
 				});
 			});
 
@@ -203,6 +205,7 @@ describe('AskAssistantBuild', () => {
 
 				expect(trackMock).toHaveBeenCalledWith('User rated workflow generation', {
 					helpful: false,
+					session_id: 'app_session_id',
 					workflow_id: 'abc123',
 				});
 			});

--- a/packages/frontend/editor-ui/src/components/AskAssistant/Agent/AskAssistantBuild.vue
+++ b/packages/frontend/editor-ui/src/components/AskAssistant/Agent/AskAssistantBuild.vue
@@ -105,14 +105,14 @@ function onFeedback(feedback: RatingFeedback) {
 		telemetry.track('User rated workflow generation', {
 			helpful: feedback.rating === 'up',
 			workflow_id: workflowsStore.workflowId,
-			session_id: builderStore.sessionId,
+			session_id: builderStore.trackingSessionId,
 		});
 	}
 	if (feedback.feedback) {
 		telemetry.track('User submitted workflow generation feedback', {
 			feedback: feedback.feedback,
 			workflow_id: workflowsStore.workflowId,
-			session_id: builderStore.sessionId,
+			session_id: builderStore.trackingSessionId,
 		});
 	}
 }

--- a/packages/frontend/editor-ui/src/components/AskAssistant/Agent/AskAssistantBuild.vue
+++ b/packages/frontend/editor-ui/src/components/AskAssistant/Agent/AskAssistantBuild.vue
@@ -82,6 +82,7 @@ watch(
 
 						telemetry.track('Workflow modified by builder', {
 							tools_called: newToolMessages.map((toolMsg) => toolMsg.toolName),
+							session_id: builderStore.trackingSessionId,
 							start_workflow_json: currentWorkflowJson,
 							end_workflow_json: msg.codeSnippet,
 							workflow_id: workflowsStore.workflowId,
@@ -104,12 +105,14 @@ function onFeedback(feedback: RatingFeedback) {
 		telemetry.track('User rated workflow generation', {
 			helpful: feedback.rating === 'up',
 			workflow_id: workflowsStore.workflowId,
+			session_id: builderStore.sessionId,
 		});
 	}
 	if (feedback.feedback) {
 		telemetry.track('User submitted workflow generation feedback', {
 			feedback: feedback.feedback,
 			workflow_id: workflowsStore.workflowId,
+			session_id: builderStore.sessionId,
 		});
 	}
 }

--- a/packages/frontend/editor-ui/src/stores/builder.store.ts
+++ b/packages/frontend/editor-ui/src/stores/builder.store.ts
@@ -175,7 +175,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 
 		telemetry.track('Workflow generation errored', {
 			error: e.message,
-			session_id: trackingSessionId,
+			session_id: trackingSessionId.value,
 			workflow_id: workflowsStore.workflowId,
 		});
 	}
@@ -231,7 +231,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 		telemetry.track('User submitted builder message', {
 			source,
 			message: text,
-			session_id: trackingSessionId,
+			session_id: trackingSessionId.value,
 			start_workflow_json: currentWorkflowJson,
 			workflow_id: workflowsStore.workflowId,
 		});

--- a/packages/frontend/editor-ui/src/stores/builder.store.ts
+++ b/packages/frontend/editor-ui/src/stores/builder.store.ts
@@ -59,6 +59,8 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 	// Computed properties
 	const isAssistantEnabled = computed(() => settings.isAiAssistantEnabled);
 
+	const trackingSessionId = computed(() => rootStore.pushRef);
+
 	const workflowPrompt = computed(() => {
 		const firstUserMessage = chatMessages.value.find(
 			(msg) => msg.role === 'user' && msg.type === 'text',
@@ -173,6 +175,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 
 		telemetry.track('Workflow generation errored', {
 			error: e.message,
+			session_id: trackingSessionId,
 			workflow_id: workflowsStore.workflowId,
 		});
 	}
@@ -228,6 +231,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 		telemetry.track('User submitted builder message', {
 			source,
 			message: text,
+			session_id: trackingSessionId,
 			start_workflow_json: currentWorkflowJson,
 			workflow_id: workflowsStore.workflowId,
 		});
@@ -388,6 +392,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 		workflowPrompt,
 		toolMessages,
 		workflowMessages,
+		trackingSessionId,
 
 		// Methods
 		updateWindowWidth,


### PR DESCRIPTION
## Summary

Include app session id in tracking calls for AI workflow builder

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
