### PR TITLE
fix(editor): Account for subpath when serving `config.js`

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -147,7 +147,6 @@ export class Start extends BaseCommand<z.infer<typeof flagsSchema>> {
 					replaceStream('/{{BASE_PATH}}/', n8nPath, { ignoreCase: false }),
 					replaceStream('/%7B%7BBASE_PATH%7D%7D/', n8nPath, { ignoreCase: false }),
 					replaceStream('/%257B%257BBASE_PATH%257D%257D/', n8nPath, { ignoreCase: false }),
-					replaceStream('/static/', n8nPath + 'static/', { ignoreCase: false }),
 				];
 				if (filePath.endsWith('index.html')) {
 					streams.push(

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -293,7 +293,6 @@ export class Server extends AbstractServer {
 					release: `n8n@${N8N_VERSION}`,
 				});
 				const frontendConfig = [
-					`window.BASE_PATH = '${this.globalConfig.path}';`,
 					`window.REST_ENDPOINT = '${this.globalConfig.endpoints.rest}';`,
 					`window.sentry = ${frontendSentryConfig};`,
 				].join('\n');

--- a/packages/frontend/editor-ui/index.html
+++ b/packages/frontend/editor-ui/index.html
@@ -7,6 +7,7 @@
 		<link rel="icon" href="/favicon.ico" />
         <link rel="stylesheet" href="/static/prefers-color-scheme.css">
 		%CONFIG_SCRIPT%
+		<script src="/static/base-path.js" type="text/javascript"></script>
 		<script src="/static/posthog.init.js" type="text/javascript"></script>
 
 		<title>n8n.io - Workflow Automation</title>

--- a/packages/frontend/editor-ui/index.html
+++ b/packages/frontend/editor-ui/index.html
@@ -5,10 +5,10 @@
 		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 		<meta name="viewport" content="width=device-width,initial-scale=1.0" />
 		<link rel="icon" href="/favicon.ico" />
-        <link rel="stylesheet" href="/static/prefers-color-scheme.css">
 		%CONFIG_SCRIPT%
-		<script src="/static/base-path.js" type="text/javascript"></script>
-		<script src="/static/posthog.init.js" type="text/javascript"></script>
+		<link rel="stylesheet" href="/{{BASE_PATH}}/static/prefers-color-scheme.css">
+		<script src="/{{BASE_PATH}}/static/base-path.js" type="text/javascript"></script>
+		<script src="/{{BASE_PATH}}/static/posthog.init.js" type="text/javascript"></script>
 
 		<title>n8n.io - Workflow Automation</title>
 	</head>

--- a/packages/frontend/editor-ui/public/static/base-path.js
+++ b/packages/frontend/editor-ui/public/static/base-path.js
@@ -1,0 +1,1 @@
+window.BASE_PATH = '/{{BASE_PATH}}/';

--- a/packages/frontend/editor-ui/vite.config.mts
+++ b/packages/frontend/editor-ui/vite.config.mts
@@ -128,7 +128,7 @@ const plugins: UserConfig['plugins'] = [
 		transformIndexHtml: (html, ctx) => {
 			const replacement = ctx.server
 				? '' // Skip when using Vite dev server
-				: '<script src="/{{BASE_PATH}}{{REST_ENDPOINT}}/config.js"></script>';
+				: '<script src="/{{BASE_PATH}}/{{REST_ENDPOINT}}/config.js"></script>';
 
 			return html.replace('%CONFIG_SCRIPT%', replacement);
 		},

--- a/packages/frontend/editor-ui/vite.config.mts
+++ b/packages/frontend/editor-ui/vite.config.mts
@@ -128,7 +128,7 @@ const plugins: UserConfig['plugins'] = [
 		transformIndexHtml: (html, ctx) => {
 			const replacement = ctx.server
 				? '' // Skip when using Vite dev server
-				: '<script src="/{{REST_ENDPOINT}}/config.js"></script>';
+				: '<script src="/{{BASE_PATH}}{{REST_ENDPOINT}}/config.js"></script>';
 
 			return html.replace('%CONFIG_SCRIPT%', replacement);
 		},


### PR DESCRIPTION
## Summary

Instances relying on `BASE_PATH` need this path on the client to fetch `/{basePath}/rest/config.js`. This PR is a hotfix to give the client access to `BASE_PATH` until we drop this feature in v2.

## Related Linear tickets, Github issues, and Community forum posts

#17817
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
