### PR TITLE
perf(core): Stop typechecking during build

### DIFF
--- a/packages/@n8n/utils/package.json
+++ b/packages/@n8n/utils/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "pnpm run typecheck && tsup",
+    "build": "tsup",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/packages/frontend/@n8n/composables/package.json
+++ b/packages/frontend/@n8n/composables/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "pnpm run typecheck && tsup",
+    "build": "tsup",
     "preview": "vite preview",
     "typecheck": "vue-tsc --noEmit",
     "test": "vitest run",

--- a/packages/frontend/@n8n/i18n/package.json
+++ b/packages/frontend/@n8n/i18n/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "pnpm run typecheck && tsup",
+    "build": "tsup",
     "preview": "vite preview",
     "typecheck": "vue-tsc --noEmit",
     "test": "vitest run",

--- a/packages/frontend/@n8n/rest-api-client/package.json
+++ b/packages/frontend/@n8n/rest-api-client/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "pnpm run typecheck && tsup",
+    "build": "tsup",
     "preview": "vite preview",
     "typecheck": "vue-tsc --noEmit",
     "test": "vitest run",

--- a/packages/frontend/@n8n/stores/package.json
+++ b/packages/frontend/@n8n/stores/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "pnpm run typecheck && tsup",
+    "build": "tsup",
     "preview": "vite preview",
     "typecheck": "vue-tsc --noEmit",
     "test": "vitest run",


### PR DESCRIPTION
## Summary

Typechecking is slowing down the build for unnecessarily. CI takes care of typechecking already.

## Related Linear tickets, Github issues, and Community forum posts
n/a
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
