### PR TITLE
Clarify title for Slack node's reply_broadcast option 

### DIFF
--- a/packages/nodes-base/nodes/Slack/V2/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V2/MessageDescription.ts
@@ -673,12 +673,12 @@ export const messageFields: INodeProperties[] = [
 									'Message timestamps are included in output data of Slack nodes, abbreviated to ts',
 							},
 							{
-								displayName: 'Reply to Thread',
+								displayName: 'Broadcast Reply',
 								name: 'reply_broadcast',
 								type: 'boolean',
 								default: false,
 								description:
-									'Whether the reply should be made visible to everyone in the channel or conversation',
+									'Whether the reply should also be broadcasted to everyone in the channel or conversation',
 							},
 						],
 					},


### PR DESCRIPTION
## Summary
There is a setting on a Slack node currently called "Reply to Thread". However, what it actually does is broadcast the reply to the channel in addition to replying to the thread. This confused me, and [has confused others](https://community.n8n.io/t/slack-answer-only-to-a-thread-and-not-to-the-main-channel-at-the-same-time/82283). This PR corrects the option title on the Slack node.

## Related Linear tickets, Github issues, and Community forum posts

https://community.n8n.io/t/slack-answer-only-to-a-thread-and-not-to-the-main-channel-at-the-same-time/82283


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [NA] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. (docs don't mention this setting)
- [NA] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [NA] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
