### PR TITLE
feat(Ollama Credentials): Add optional API key support to Ollama credentials (Openwebui proxy)

### DIFF
--- a/packages/@n8n/nodes-langchain/credentials/OllamaApi.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/OllamaApi.credentials.ts
@@ -1,4 +1,9 @@
-import type { ICredentialTestRequest, ICredentialType, INodeProperties } from 'n8n-workflow';
+import type {
+	ICredentialTestRequest,
+	ICredentialType,
+	INodeProperties,
+	IAuthenticateGeneric,
+} from 'n8n-workflow';
 
 export class OllamaApi implements ICredentialType {
 	name = 'ollamaApi';
@@ -15,12 +20,29 @@ export class OllamaApi implements ICredentialType {
 			type: 'string',
 			default: 'http://localhost:11434',
 		},
+		{
+			displayName: 'API Key (If Required)',
+			name: 'apiKey',
+			type: 'string',
+			typeOptions: { password: true },
+			default: '',
+			required: false,
+		},
 	];
+
+	authenticate: IAuthenticateGeneric = {
+		type: 'generic',
+		properties: {
+			headers: {
+				Authorization: '=Bearer {{$credentials.apiKey}}',
+			},
+		},
+	};
 
 	test: ICredentialTestRequest = {
 		request: {
 			baseURL: '={{ $credentials.baseUrl }}',
-			url: '/',
+			url: '/api/tags',
 			method: 'GET',
 		},
 	};

--- a/packages/@n8n/nodes-langchain/credentials/OllamaApi.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/OllamaApi.credentials.ts
@@ -21,7 +21,9 @@ export class OllamaApi implements ICredentialType {
 			default: 'http://localhost:11434',
 		},
 		{
-			displayName: 'API Key (If Required)',
+			displayName: 'API Key',
+			description:
+				'When using Ollama behind a proxy with authentication (such as Open WebUI), provide the Bearer token/API key here. This is not required for the default Ollama installation',
 			name: 'apiKey',
 			type: 'string',
 			typeOptions: { password: true },

--- a/packages/@n8n/nodes-langchain/credentials/OllamaApi.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/OllamaApi.credentials.ts
@@ -22,8 +22,7 @@ export class OllamaApi implements ICredentialType {
 		},
 		{
 			displayName: 'API Key',
-			description:
-				'When using Ollama behind a proxy with authentication (such as Open WebUI), provide the Bearer token/API key here. This is not required for the default Ollama installation',
+			hint: 'When using Ollama behind a proxy with authentication (such as Open WebUI), provide the Bearer token/API key here. This is not required for the default Ollama installation',
 			name: 'apiKey',
 			type: 'string',
 			typeOptions: { password: true },

--- a/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsOllama/EmbeddingsOllama.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsOllama/EmbeddingsOllama.node.ts
@@ -49,15 +49,16 @@ export class EmbeddingsOllama implements INodeType {
 		this.logger.debug('Supply data for embeddings Ollama');
 		const modelName = this.getNodeParameter('model', itemIndex) as string;
 		const credentials = await this.getCredentials('ollamaApi');
+		const headers = credentials.apiKey
+			? {
+					Authorization: `Bearer ${credentials.apiKey as string}`,
+				}
+			: undefined;
 
 		const embeddings = new OllamaEmbeddings({
 			baseUrl: credentials.baseUrl as string,
 			model: modelName,
-			headers: credentials.apiKey
-				? {
-						Authorization: `Bearer ${credentials.apiKey as string}`,
-					}
-				: undefined,
+			headers,
 		});
 
 		return {

--- a/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsOllama/EmbeddingsOllama.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsOllama/EmbeddingsOllama.node.ts
@@ -53,6 +53,11 @@ export class EmbeddingsOllama implements INodeType {
 		const embeddings = new OllamaEmbeddings({
 			baseUrl: credentials.baseUrl as string,
 			model: modelName,
+			headers: credentials.apiKey
+				? {
+						Authorization: `Bearer ${credentials.apiKey as string}`,
+					}
+				: undefined,
 		});
 
 		return {

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOllama/LmChatOllama.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOllama/LmChatOllama.node.ts
@@ -58,6 +58,11 @@ export class LmChatOllama implements INodeType {
 
 		const modelName = this.getNodeParameter('model', itemIndex) as string;
 		const options = this.getNodeParameter('options', itemIndex, {}) as ChatOllamaInput;
+		const headers = credentials.apiKey
+			? {
+					Authorization: `Bearer ${credentials.apiKey as string}`,
+				}
+			: undefined;
 
 		const model = new ChatOllama({
 			...options,
@@ -66,11 +71,7 @@ export class LmChatOllama implements INodeType {
 			format: options.format === 'default' ? undefined : options.format,
 			callbacks: [new N8nLlmTracing(this)],
 			onFailedAttempt: makeN8nLlmFailedAttemptHandler(this),
-			headers: credentials.apiKey
-				? {
-						Authorization: `Bearer ${credentials.apiKey as string}`,
-					}
-				: undefined,
+			headers,
 		});
 
 		return {

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOllama/LmChatOllama.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOllama/LmChatOllama.node.ts
@@ -66,6 +66,11 @@ export class LmChatOllama implements INodeType {
 			format: options.format === 'default' ? undefined : options.format,
 			callbacks: [new N8nLlmTracing(this)],
 			onFailedAttempt: makeN8nLlmFailedAttemptHandler(this),
+			headers: credentials.apiKey
+				? {
+						Authorization: `Bearer ${credentials.apiKey as string}`,
+					}
+				: undefined,
 		});
 
 		return {

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMOllama/LmOllama.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMOllama/LmOllama.node.ts
@@ -64,6 +64,11 @@ export class LmOllama implements INodeType {
 			...options,
 			callbacks: [new N8nLlmTracing(this)],
 			onFailedAttempt: makeN8nLlmFailedAttemptHandler(this),
+			headers: credentials.apiKey
+				? {
+						Authorization: `Bearer ${credentials.apiKey as string}`,
+					}
+				: undefined,
 		});
 
 		return {

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMOllama/LmOllama.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMOllama/LmOllama.node.ts
@@ -57,6 +57,11 @@ export class LmOllama implements INodeType {
 
 		const modelName = this.getNodeParameter('model', itemIndex) as string;
 		const options = this.getNodeParameter('options', itemIndex, {}) as object;
+		const headers = credentials.apiKey
+			? {
+					Authorization: `Bearer ${credentials.apiKey as string}`,
+				}
+			: undefined;
 
 		const model = new Ollama({
 			baseUrl: credentials.baseUrl as string,
@@ -64,11 +69,7 @@ export class LmOllama implements INodeType {
 			...options,
 			callbacks: [new N8nLlmTracing(this)],
 			onFailedAttempt: makeN8nLlmFailedAttemptHandler(this),
-			headers: credentials.apiKey
-				? {
-						Authorization: `Bearer ${credentials.apiKey as string}`,
-					}
-				: undefined,
+			headers,
 		});
 
 		return {


### PR DESCRIPTION
## Summary
Adds optional API key authentication to Ollama credentials to support [OpenWebUI](https://github.com/open-webui/open-webui) integration.

**Background:**
Many users deploy Ollama with OpenWebUI to provide a public chat interface for their models. OpenWebUI acts as a proxy for Ollama and provides features like user management, conversation history, and web access. However, when OpenWebUI proxies Ollama requests, it requires Bearer token authentication.

Currently, n8n's Ollama integration cannot authenticate with [OpenWebUI-proxied](https://docs.openwebui.com/getting-started/api-endpoints/#-ollama-api-proxy-support) instances, limiting users to direct Ollama connections only.

**Changes:**
- **Added optional `apiKey` field** to Ollama credentials.
- **Implemented Bearer token authentication** when API key is provided  
- **Maintains full backward compatibility** - existing workflows continue working unchanged
- **Improved test endpoint** from `/` to `/api/tags` for more reliable connection validation

**Testing:**
✅ **Without API key**: Direct Ollama connection works as before  
✅ **With API key**: OpenWebUI-proxied Ollama connection authenticates successfully  
✅ **Connection test**: Updated endpoint properly validates Ollama availability

## Related Linear tickets, Github issues, and Community forum posts
No tickets or issues.

## Review / Merge checklist
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)