### PR TITLE
fix(editor): Send posthog session id to rudderstack (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/Interface.ts
+++ b/packages/frontend/editor-ui/src/Interface.ts
@@ -111,6 +111,7 @@ declare global {
 				set?(metadata: IDataObject): void;
 			};
 			debug?(): void;
+			get_session_id?(): string | null;
 		};
 		analytics?: {
 			identify(userId: string): void;

--- a/packages/frontend/editor-ui/src/plugins/telemetry.test.ts
+++ b/packages/frontend/editor-ui/src/plugins/telemetry.test.ts
@@ -206,10 +206,10 @@ describe('telemetry', () => {
 
 		it('should include the posthog session id in the parameters', () => {
 			const trackFunction = vi.spyOn(window.rudderanalytics, 'track');
-			window.posthog = {
+			vi.stubGlobal('posthog', {
 				init: vi.fn(),
 				get_session_id: vi.fn().mockReturnValue('test_session_id'),
-			};
+			});
 
 			const event = 'testEvent';
 			const properties = { test: '1' };
@@ -224,6 +224,8 @@ describe('telemetry', () => {
 				}),
 				expect.any(Object),
 			);
+
+			vi.unstubAllGlobals();
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/plugins/telemetry.test.ts
+++ b/packages/frontend/editor-ui/src/plugins/telemetry.test.ts
@@ -203,5 +203,27 @@ describe('telemetry', () => {
 				{ context: { ip: '0.0.0.0' } },
 			);
 		});
+
+		it('should include the posthog session id in the parameters', () => {
+			const trackFunction = vi.spyOn(window.rudderanalytics, 'track');
+			window.posthog = {
+				init: vi.fn(),
+				get_session_id: vi.fn().mockReturnValue('test_session_id'),
+			};
+
+			const event = 'testEvent';
+			const properties = { test: '1' };
+
+			telemetry.track(event, properties);
+
+			expect(trackFunction).toHaveBeenCalledTimes(1);
+			expect(trackFunction).toHaveBeenCalledWith(
+				event,
+				expect.objectContaining({
+					posthog_session_id: 'test_session_id',
+				}),
+				expect.any(Object),
+			);
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/plugins/telemetry/index.ts
+++ b/packages/frontend/editor-ui/src/plugins/telemetry/index.ts
@@ -99,9 +99,12 @@ export class Telemetry {
 	track(event: string, properties?: ITelemetryTrackProperties) {
 		if (!this.rudderStack) return;
 
+		const posthogSessionId = window.posthog?.get_session_id?.();
+
 		const updatedProperties = {
 			...properties,
 			version_cli: useRootStore().versionCli,
+			posthog_session_id: posthogSessionId,
 		};
 
 		this.rudderStack.track(event, updatedProperties, {


### PR DESCRIPTION
## Summary

Send the posthog ID to Rudderstack.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
