### PR TITLE
fix(editor): Fix invisible node creator icons

### DIFF
--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/ItemTypes/NodeItem.vue
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/ItemTypes/NodeItem.vue
@@ -232,6 +232,7 @@ function onCommunityNodeTooltipClick(event: MouseEvent) {
 .nodeItem {
 	--trigger-icon-background-color: #{$trigger-icon-background-color};
 	--trigger-icon-border-color: #{$trigger-icon-border-color};
+	--canvas-node-icon-color: var(--color-foreground-xdark);
 	margin-left: 15px;
 	margin-right: 12px;
 	user-select: none;


### PR DESCRIPTION
## Summary
Adding missing value for `--canvas-node-icon-color` css variable that made node creator icons invisible in dark mode.

## Related Linear tickets, Github issues, and Community forum posts
Fixes ADO-3874
Fixes #17836

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
