### PR TITLE
fix: Community update/uninstall e2e test fix (no-changelog)

### DIFF
--- a/cypress/pages/settings-community-nodes.ts
+++ b/cypress/pages/settings-community-nodes.ts
@@ -14,9 +14,13 @@ export const installFirstCommunityNode = (nodeName: string) => {
 };
 
 export const confirmCommunityNodeUpdate = () => {
-	cy.getByTestId('communityPackageManageConfirm-modal').find('button').eq(1).click();
+	cy.getByTestId('communityPackageManageConfirm-modal')
+		.contains('button', 'Confirm update')
+		.click();
 };
 
 export const confirmCommunityNodeUninstall = () => {
-	cy.getByTestId('communityPackageManageConfirm-modal').find('button').eq(1).click();
+	cy.getByTestId('communityPackageManageConfirm-modal')
+		.contains('button', 'Confirm uninstall')
+		.click();
 };


### PR DESCRIPTION
## Summary

test failing due to presence of additional Cancel button in confirmation modal

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
