### PR TITLE
fix(GraphQL Node): Refresh OAuth2 token when it expires

### DIFF
--- a/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
+++ b/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
@@ -497,9 +497,20 @@ export class GraphQL implements INodeType {
 				if (oAuth1Api !== undefined) {
 					response = await this.helpers.requestOAuth1.call(this, 'oAuth1Api', requestOptions);
 				} else if (oAuth2Api !== undefined) {
-					response = await this.helpers.requestOAuth2.call(this, 'oAuth2Api', requestOptions, {
-						tokenType: 'Bearer',
-					});
+					response = await this.helpers.requestOAuth2.call(
+						this,
+						'oAuth2Api',
+						{
+							...requestOptions,
+							// needed for the refresh mechanism to work properly
+							resolveWithFullResponse: true,
+						},
+						{
+							tokenType: 'Bearer',
+						},
+					);
+					// since we are using `resolveWithFullResponse: true`, we need to grab the body
+					response = response.body;
 				} else {
 					response = await this.helpers.request(requestOptions);
 				}

--- a/packages/nodes-base/nodes/GraphQL/test/GraphQL.node.test.ts
+++ b/packages/nodes-base/nodes/GraphQL/test/GraphQL.node.test.ts
@@ -2,9 +2,8 @@ import { NodeTestHarness } from '@nodes-testing/node-test-harness';
 import nock from 'nock';
 
 describe('GraphQL Node', () => {
-	const baseUrl = 'https://api.n8n.io/';
-
-	beforeAll(async () => {
+	describe('valid request', () => {
+		const baseUrl = 'https://api.n8n.io/';
 		nock(baseUrl)
 			.matchHeader('accept', 'application/json')
 			.matchHeader('content-type', 'application/json')
@@ -54,7 +53,61 @@ describe('GraphQL Node', () => {
 					},
 				},
 			});
+
+		new NodeTestHarness().setupTests({
+			workflowFiles: ['workflow.json'],
+		});
 	});
 
-	new NodeTestHarness().setupTests();
+	describe('invalid expression', () => {
+		new NodeTestHarness().setupTests({
+			workflowFiles: ['workflow.error_invalid_expression.json'],
+		});
+	});
+
+	describe('oauth2 refresh token', () => {
+		const credentials = {
+			oAuth2Api: {
+				scope: '',
+				accessTokenUrl: 'http://test/token',
+				clientId: 'dummy_client_id',
+				clientSecret: 'dummy_client_secret',
+				oauthTokenData: {
+					access_token: 'dummy_access_token',
+					refresh_token: 'dummy_refresh_token',
+				},
+			},
+		};
+		const baseUrl = 'http://test';
+		nock(baseUrl)
+			.post('/graphql', '{"query":"query { foo }","variables":{},"operationName":null}')
+			.reply(401, {
+				errors: [
+					{
+						message: 'Unauthorized',
+					},
+				],
+			});
+		nock(baseUrl)
+			.post('/token', {
+				refresh_token: 'dummy_refresh_token',
+				grant_type: 'refresh_token',
+			})
+			.reply(200, {
+				access_token: 'dummy_access_token',
+				refresh_token: 'dummy_refresh_token',
+				expires_in: 3600,
+			});
+		nock(baseUrl)
+			.post('/graphql', '{"query":"query { foo }","variables":{},"operationName":null}')
+			.reply(200, {
+				data: {
+					foo: 'bar',
+				},
+			});
+		new NodeTestHarness().setupTests({
+			workflowFiles: ['workflow.refresh_token.json'],
+			credentials,
+		});
+	});
 });

--- a/packages/nodes-base/nodes/GraphQL/test/workflow.refresh_token.json
+++ b/packages/nodes-base/nodes/GraphQL/test/workflow.refresh_token.json
@@ -1,0 +1,67 @@
+{
+	"name": "GraphQL Refersh Token",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "ae67b437-48c0-4c4b-9c8f-005b8911ca5f",
+			"name": "When clicking ‘Execute workflow’",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [32, 80]
+		},
+		{
+			"parameters": {
+				"authentication": "oAuth2",
+				"endpoint": "http://test/graphql",
+				"requestFormat": "json",
+				"query": "query { foo }"
+			},
+			"name": "GraphQL",
+			"type": "n8n-nodes-base.graphql",
+			"typeVersion": 1,
+			"position": [256, 80],
+			"id": "6cb4c117-907a-40b9-b3ba-cd3756b1cb7b",
+			"credentials": {
+				"oAuth2Api": {
+					"id": "PpmTbnw41Q2nqqoW",
+					"name": "Dummy (local)"
+				}
+			}
+		}
+	],
+	"pinData": {
+		"GraphQL": [
+			{
+				"json": {
+					"data": {
+						"foo": "bar"
+					}
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking ‘Execute workflow’": {
+			"main": [
+				[
+					{
+						"node": "GraphQL",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "659c76f4-ac29-4c2f-bf40-70b476afbc1d",
+	"meta": {
+		"templateCredsSetupCompleted": true,
+		"instanceId": "eeda9e3069aca300d1dfceeb64beb5b53d715db44a50461bbc5cb0cf6daa01e3"
+	},
+	"id": "O4IzQ2D7h7cfZtB4",
+	"tags": []
+}


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Fix an issue where the OAuth2 access token is not refreshed in the GraphQL node when receiving a 401

Dummy NodeJS server that can be used to test the refresh logic:
```javascript
const http = require("http");
const url = require("url");
const querystring = require("querystring");

let reject = true;

const server = http.createServer((req, res) => {
  const parsedUrl = url.parse(req.url);
  const pathname = parsedUrl.pathname;
  const query = querystring.parse(parsedUrl.query);

  if (pathname === "/authorize") {
    console.log("Endpoint /authorize hit");
    const code = "dummy_code";
    const redirectUri = query.redirect_uri;
    const redirectWithCode = `${redirectUri}?code=${code}&state=${query.state || ""}`;
    res.writeHead(302, { Location: redirectWithCode });
    res.end();
  } else if (pathname === "/token" && req.method === "POST") {
    console.log("Endpoint /token hit");
    let body = "";
    req.on("data", (chunk) => (body += chunk));
    req.on("end", () => {
      const parsedBody = querystring.parse(body);
      if (parsedBody.grant_type === "refresh_token") {
        console.log("Refreshing the token");
      } else {
        console.log("Returning the initial token");
      }

      res.writeHead(200, { "Content-Type": "application/json" });
      res.end(
        JSON.stringify({
          access_token: "dummy_access_token",
          refresh_token: "dummy_refresh_token",
          token_type: "Bearer",
          expires_in: 3600,
        }),
      );
    });
  } else {
    console.log(`Endpoint ${pathname} hit`);
    if (reject) {
      console.log("Responding with 401");
      res.writeHead(401, { "content-type": "application/json" });
      res.end(JSON.stringify({ error: "unauthorized" }));
    } else {
      console.log("Responding with 200");
      res.writeHead(200, { "content-type": "application/json" });
      res.end(JSON.stringify({ foo: "bar" }));
    }

    reject = !reject;
  }
});

server.listen(3000, () => {
  console.log(`Running on http://localhost:3000`);
});
```

Add an OAuth2 credential with `Authorization URL: http://localhost:3000/authorize` and `Token URL: http://localhost:3000/token` (client ID and secret can be whatever) to test with this code. Before the fix the GraphQL would not try to refresh the token after getting a 401, after the fix - it does

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-1766/graphql-node-not-refreshing-oauth2-token-in-graphql-node
https://community.n8n.io/t/n8n-not-refreshing-oauth-token-in-graphql-node/54363/2

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
