### PR TITLE
fix(editor): Correct ai template url

### DIFF
--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/viewsData.ts
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/viewsData.ts
@@ -57,6 +57,7 @@ import {
 	AI_CODE_TOOL_LANGCHAIN_NODE_TYPE,
 	AI_WORKFLOW_TOOL_LANGCHAIN_NODE_TYPE,
 	HUMAN_IN_THE_LOOP_CATEGORY,
+	TEMPLATE_CATEGORY_AI,
 } from '@/constants';
 import { useI18n } from '@n8n/i18n';
 import { useNodeTypesStore } from '@/stores/nodeTypes.store';
@@ -176,8 +177,10 @@ export function AIView(_nodes: SimplifiedNodeType[]): NodeView {
 
 	const websiteCategoryURLParams = templatesStore.websiteTemplateRepositoryParameters;
 	websiteCategoryURLParams.append('utm_user_role', 'AdvancedAI');
-	const websiteCategoryURL =
-		templatesStore.constructTemplateRepositoryURL(websiteCategoryURLParams);
+	const aiTemplatesURL = templatesStore.constructTemplateRepositoryURL(
+		websiteCategoryURLParams,
+		TEMPLATE_CATEGORY_AI,
+	);
 
 	const askAiEnabled = useSettingsStore().isAskAiEnabled;
 	const aiTransformNode = nodeTypesStore.getNodeType(AI_TRANSFORM_NODE_TYPE);
@@ -196,7 +199,7 @@ export function AIView(_nodes: SimplifiedNodeType[]): NodeView {
 					icon: 'box-open',
 					description: i18n.baseText('nodeCreator.aiPanel.linkItem.description'),
 					name: 'ai_templates_root',
-					url: websiteCategoryURL,
+					url: aiTemplatesURL,
 					tag: {
 						type: 'info',
 						text: i18n.baseText('nodeCreator.triggerHelperPanel.manualTriggerTag'),

--- a/packages/frontend/editor-ui/src/constants.ts
+++ b/packages/frontend/editor-ui/src/constants.ts
@@ -223,6 +223,9 @@ export const RESPOND_TO_WEBHOOK_NODE_TYPE = 'n8n-nodes-base.respondToWebhook';
 export const CREDENTIAL_ONLY_NODE_PREFIX = 'n8n-creds-base';
 export const CREDENTIAL_ONLY_HTTP_NODE_VERSION = 4.1;
 
+// template categories
+export const TEMPLATE_CATEGORY_AI = 'categories/ai';
+
 export const EXECUTABLE_TRIGGER_NODE_TYPES = [
 	START_NODE_TYPE,
 	MANUAL_TRIGGER_NODE_TYPE,

--- a/packages/frontend/editor-ui/src/stores/templates.store.ts
+++ b/packages/frontend/editor-ui/src/stores/templates.store.ts
@@ -195,8 +195,11 @@ export const useTemplatesStore = defineStore(STORES.TEMPLATES, () => {
 			`${TEMPLATES_URLS.BASE_WEBSITE_URL}${getTemplatePathByRole(userRole.value)}?${websiteTemplateRepositoryParameters.value.toString()}`,
 	);
 
-	const constructTemplateRepositoryURL = (params: URLSearchParams): string => {
-		return `${TEMPLATES_URLS.BASE_WEBSITE_URL}?${params.toString()}`;
+	const constructTemplateRepositoryURL = (params: URLSearchParams, category?: string): string => {
+		const baseUrl = category
+			? `${TEMPLATES_URLS.BASE_WEBSITE_URL}${category}`
+			: TEMPLATES_URLS.BASE_WEBSITE_URL;
+		return `${baseUrl}?${params.toString()}`;
 	};
 
 	const addCategories = (_categories: ITemplatesCategory[]): void => {


### PR DESCRIPTION
## Summary
The CTA for AI templates now lead to https://n8n.io/workflows/categories/ai/
<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/ADO-3876/ai-template-link-in-nodes-panel-doesnt-link-to-ai-page-on-template
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
