### PR TITLE
feat(core): Rebuild project roles to load from the database

### DIFF
--- a/packages/@n8n/api-types/src/dto/project/__tests__/change-user-role-in-project.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/project/__tests__/change-user-role-in-project.dto.test.ts
@@ -1,3 +1,5 @@
+import { PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
+
 import { ChangeUserRoleInProject } from '../change-user-role-in-project.dto';
 
 describe('ChangeUserRoleInProject', () => {
@@ -38,7 +40,7 @@ describe('ChangeUserRoleInProject', () => {
 			},
 			{
 				name: 'personal owner role',
-				request: { role: 'project:personalOwner' },
+				request: { role: PROJECT_OWNER_ROLE_SLUG },
 				expectedErrorPath: ['role'],
 			},
 		])('should reject $name', ({ request, expectedErrorPath }) => {

--- a/packages/@n8n/api-types/src/dto/project/change-user-role-in-project.dto.ts
+++ b/packages/@n8n/api-types/src/dto/project/change-user-role-in-project.dto.ts
@@ -1,6 +1,6 @@
-import { projectRoleSchema } from '@n8n/permissions';
+import { teamRoleSchema } from '@n8n/permissions';
 import { Z } from 'zod-class';
 
 export class ChangeUserRoleInProject extends Z.class({
-	role: projectRoleSchema.exclude(['project:personalOwner']),
+	role: teamRoleSchema,
 }) {}

--- a/packages/@n8n/api-types/src/schemas/project.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/project.schema.ts
@@ -1,4 +1,4 @@
-import { projectRoleSchema } from '@n8n/permissions';
+import { teamRoleSchema } from '@n8n/permissions';
 import { z } from 'zod';
 
 export const projectNameSchema = z.string().min(1).max(255);
@@ -16,6 +16,6 @@ export const projectDescriptionSchema = z.string().max(512);
 
 export const projectRelationSchema = z.object({
 	userId: z.string().min(1),
-	role: projectRoleSchema.exclude(['project:personalOwner']),
+	role: teamRoleSchema,
 });
 export type ProjectRelation = z.infer<typeof projectRelationSchema>;

--- a/packages/@n8n/backend-test-utils/src/db/projects.ts
+++ b/packages/@n8n/backend-test-utils/src/db/projects.ts
@@ -1,11 +1,11 @@
 import type { Project, User, ProjectRelation } from '@n8n/db';
 import { ProjectRelationRepository, ProjectRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
-import type { ProjectRole } from '@n8n/permissions';
+import type { CustomRole } from '@n8n/permissions';
 
 import { randomName } from '../random';
 
-export const linkUserToProject = async (user: User, project: Project, role: ProjectRole) => {
+export const linkUserToProject = async (user: User, project: Project, role: CustomRole) => {
 	const projectRelationRepository = Container.get(ProjectRelationRepository);
 	await projectRelationRepository.save(
 		projectRelationRepository.create({
@@ -67,10 +67,9 @@ export const getProjectRelations = async ({
 export const getProjectRoleForUser = async (
 	projectId: string,
 	userId: string,
-): Promise<ProjectRole | undefined> => {
+): Promise<CustomRole | undefined> => {
 	return (
 		await Container.get(ProjectRelationRepository).findOne({
-			select: ['role'],
 			where: { projectId, userId },
 		})
 	)?.role;

--- a/packages/@n8n/backend-test-utils/src/db/projects.ts
+++ b/packages/@n8n/backend-test-utils/src/db/projects.ts
@@ -1,7 +1,7 @@
 import type { Project, User, ProjectRelation } from '@n8n/db';
 import { ProjectRelationRepository, ProjectRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
-import type { CustomRole } from '@n8n/permissions';
+import { PROJECT_OWNER_ROLE_SLUG, type CustomRole } from '@n8n/permissions';
 
 import { randomName } from '../random';
 
@@ -11,7 +11,7 @@ export const linkUserToProject = async (user: User, project: Project, role: Cust
 		projectRelationRepository.create({
 			projectId: project.id,
 			userId: user.id,
-			role,
+			role: { slug: role },
 		}),
 	);
 };
@@ -41,7 +41,7 @@ export const getPersonalProject = async (user: User): Promise<Project> => {
 		where: {
 			projectRelations: {
 				userId: user.id,
-				role: 'project:personalOwner',
+				role: { slug: PROJECT_OWNER_ROLE_SLUG },
 			},
 			type: 'personal',
 		},
@@ -72,7 +72,7 @@ export const getProjectRoleForUser = async (
 		await Container.get(ProjectRelationRepository).findOne({
 			where: { projectId, userId },
 		})
-	)?.role;
+	)?.role?.slug;
 };
 
 export const getAllProjectRelations = async ({

--- a/packages/@n8n/backend-test-utils/src/db/projects.ts
+++ b/packages/@n8n/backend-test-utils/src/db/projects.ts
@@ -61,6 +61,7 @@ export const getProjectRelations = async ({
 }: Partial<ProjectRelation>): Promise<ProjectRelation[]> => {
 	return await Container.get(ProjectRelationRepository).find({
 		where: { projectId, userId, role },
+		relations: { role: true },
 	});
 };
 
@@ -71,6 +72,7 @@ export const getProjectRoleForUser = async (
 	return (
 		await Container.get(ProjectRelationRepository).findOne({
 			where: { projectId, userId },
+			relations: { role: true },
 		})
 	)?.role?.slug;
 };
@@ -80,5 +82,6 @@ export const getAllProjectRelations = async ({
 }: Partial<ProjectRelation>): Promise<ProjectRelation[]> => {
 	return await Container.get(ProjectRelationRepository).find({
 		where: { projectId },
+		relations: { role: true },
 	});
 };

--- a/packages/@n8n/db/src/constants.ts
+++ b/packages/@n8n/db/src/constants.ts
@@ -1,4 +1,13 @@
-import { GLOBAL_SCOPE_MAP, type GlobalRole } from '@n8n/permissions';
+import {
+	GLOBAL_SCOPE_MAP,
+	PROJECT_ADMIN_ROLE_SLUG,
+	PROJECT_EDITOR_ROLE_SLUG,
+	PROJECT_OWNER_ROLE_SLUG,
+	PROJECT_SCOPE_MAP,
+	PROJECT_VIEWER_ROLE_SLUG,
+	type GlobalRole,
+	type ProjectRole,
+} from '@n8n/permissions';
 
 import type { Role } from 'entities';
 
@@ -16,15 +25,44 @@ export function buildInRoleToRoleObject(role: GlobalRole): Role {
 		systemRole: true,
 		roleType: 'global',
 		description: `Built-in global role with ${role} permissions.`,
-	};
+	} as Role;
+}
+
+export function buildInProjectRoleToRoleObject(role: ProjectRole): Role {
+	return {
+		slug: role,
+		displayName: role,
+		scopes: PROJECT_SCOPE_MAP[role].map((scope) => {
+			return {
+				slug: scope,
+				displayName: scope,
+				description: null,
+			};
+		}),
+		systemRole: true,
+		roleType: 'project',
+		description: `Built-in project role with ${role} permissions.`,
+	} as Role;
 }
 
 export const GLOBAL_OWNER_ROLE = buildInRoleToRoleObject('global:owner');
 export const GLOBAL_ADMIN_ROLE = buildInRoleToRoleObject('global:admin');
 export const GLOBAL_MEMBER_ROLE = buildInRoleToRoleObject('global:member');
 
+export const PROJECT_OWNER_ROLE = buildInProjectRoleToRoleObject(PROJECT_OWNER_ROLE_SLUG);
+export const PROJECT_ADMIN_ROLE = buildInProjectRoleToRoleObject(PROJECT_ADMIN_ROLE_SLUG);
+export const PROJECT_EDITOR_ROLE = buildInProjectRoleToRoleObject(PROJECT_EDITOR_ROLE_SLUG);
+export const PROJECT_VIEWER_ROLE = buildInProjectRoleToRoleObject(PROJECT_VIEWER_ROLE_SLUG);
+
 export const GLOBAL_ROLES: Record<GlobalRole, Role> = {
 	'global:owner': GLOBAL_OWNER_ROLE,
 	'global:admin': GLOBAL_ADMIN_ROLE,
 	'global:member': GLOBAL_MEMBER_ROLE,
+};
+
+export const PROJECT_ROLES: Record<ProjectRole, Role> = {
+	[PROJECT_OWNER_ROLE_SLUG]: PROJECT_OWNER_ROLE,
+	[PROJECT_ADMIN_ROLE_SLUG]: PROJECT_ADMIN_ROLE,
+	[PROJECT_EDITOR_ROLE_SLUG]: PROJECT_EDITOR_ROLE,
+	[PROJECT_VIEWER_ROLE_SLUG]: PROJECT_VIEWER_ROLE,
 };

--- a/packages/@n8n/db/src/entities/project-relation.ts
+++ b/packages/@n8n/db/src/entities/project-relation.ts
@@ -1,14 +1,20 @@
-import { ProjectRole } from '@n8n/permissions';
-import { Column, Entity, ManyToOne, PrimaryColumn } from '@n8n/typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from '@n8n/typeorm';
 
 import { WithTimestamps } from './abstract-entity';
 import { Project } from './project';
+import { Role } from './role';
 import { User } from './user';
 
 @Entity()
 export class ProjectRelation extends WithTimestamps {
 	@Column({ type: 'varchar' })
-	role: ProjectRole;
+	role: string;
+
+	@ManyToOne('Role', 'projectRelations', {
+		eager: true,
+	})
+	@JoinColumn({ name: 'role', referencedColumnName: 'slug' })
+	roleEntity: Role;
 
 	@ManyToOne('User', 'projectRelations')
 	user: User;

--- a/packages/@n8n/db/src/entities/project-relation.ts
+++ b/packages/@n8n/db/src/entities/project-relation.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from '@n8n/typeorm';
+import { Entity, JoinColumn, ManyToOne, PrimaryColumn } from '@n8n/typeorm';
 
 import { WithTimestamps } from './abstract-entity';
 import { Project } from './project';
@@ -7,14 +7,11 @@ import { User } from './user';
 
 @Entity()
 export class ProjectRelation extends WithTimestamps {
-	@Column({ type: 'varchar' })
-	role: string;
-
 	@ManyToOne('Role', 'projectRelations', {
 		eager: true,
 	})
 	@JoinColumn({ name: 'role', referencedColumnName: 'slug' })
-	roleEntity: Role;
+	role: Role;
 
 	@ManyToOne('User', 'projectRelations')
 	user: User;

--- a/packages/@n8n/db/src/entities/project-relation.ts
+++ b/packages/@n8n/db/src/entities/project-relation.ts
@@ -7,9 +7,7 @@ import { User } from './user';
 
 @Entity()
 export class ProjectRelation extends WithTimestamps {
-	@ManyToOne('Role', 'projectRelations', {
-		eager: true,
-	})
+	@ManyToOne('Role', 'projectRelations')
 	@JoinColumn({ name: 'role', referencedColumnName: 'slug' })
 	role: Role;
 

--- a/packages/@n8n/db/src/entities/role.ts
+++ b/packages/@n8n/db/src/entities/role.ts
@@ -1,5 +1,6 @@
-import { Column, Entity, JoinTable, ManyToMany, PrimaryColumn } from '@n8n/typeorm';
+import { Column, Entity, JoinTable, ManyToMany, OneToMany, PrimaryColumn } from '@n8n/typeorm';
 
+import type { ProjectRelation } from './project-relation';
 import { Scope } from './scope';
 
 @Entity({
@@ -44,6 +45,9 @@ export class Role {
 	 * Type of the role, e.g., global, project, or workflow.
 	 */
 	roleType: 'global' | 'project' | 'workflow' | 'credential';
+
+	@OneToMany('ProjectRelation', 'roleEntity')
+	projectRelations: ProjectRelation[];
 
 	@ManyToMany(() => Scope, {
 		eager: true,

--- a/packages/@n8n/db/src/entities/role.ts
+++ b/packages/@n8n/db/src/entities/role.ts
@@ -46,7 +46,7 @@ export class Role {
 	 */
 	roleType: 'global' | 'project' | 'workflow' | 'credential';
 
-	@OneToMany('ProjectRelation', 'roleEntity')
+	@OneToMany('ProjectRelation', 'role')
 	projectRelations: ProjectRelation[];
 
 	@ManyToMany(() => Scope, {

--- a/packages/@n8n/db/src/entities/types-db.ts
+++ b/packages/@n8n/db/src/entities/types-db.ts
@@ -327,11 +327,7 @@ export namespace ListQuery {
 	};
 }
 
-export type ProjectRole =
-	| 'project:personalOwner'
-	| 'project:admin'
-	| 'project:editor'
-	| 'project:viewer';
+export type ProjectRole = string;
 
 export interface IGetExecutionsQueryFilter {
 	id?: FindOperator<string> | string;

--- a/packages/@n8n/db/src/entities/types-db.ts
+++ b/packages/@n8n/db/src/entities/types-db.ts
@@ -327,7 +327,11 @@ export namespace ListQuery {
 	};
 }
 
-export type ProjectRole = string;
+export type ProjectRole =
+	| 'project:personalOwner'
+	| 'project:admin'
+	| 'project:editor'
+	| 'project:viewer';
 
 export interface IGetExecutionsQueryFilter {
 	id?: FindOperator<string> | string;

--- a/packages/@n8n/db/src/migrations/common/1753953244168-LinkRoleToProjectRelationTable.ts
+++ b/packages/@n8n/db/src/migrations/common/1753953244168-LinkRoleToProjectRelationTable.ts
@@ -1,0 +1,48 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+/*
+ * This migration
+ */
+
+export class LinkRoleToProjectRelationTable1753953244168 implements ReversibleMigration {
+	async up({ schemaBuilder: { addForeignKey }, escape, dbType, runQuery }: MigrationContext) {
+		const tableName = escape.tableName('role');
+		const projectRelationTableName = escape.tableName('project_relation');
+		const slugColumn = escape.columnName('slug');
+		const roleColumn = escape.columnName('role');
+		const roleTypeColumn = escape.columnName('roleType');
+		const systemRoleColumn = escape.columnName('systemRole');
+
+		const isPostgresOrSqlite = dbType === 'postgresdb' || dbType === 'sqlite';
+		const query = isPostgresOrSqlite
+			? `INSERT INTO ${tableName} (${slugColumn}, ${roleTypeColumn}, ${systemRoleColumn}) VALUES (:slug, :roleType, :systemRole) ON CONFLICT DO NOTHING`
+			: `INSERT IGNORE INTO ${tableName} (${slugColumn}, ${roleTypeColumn}, ${systemRoleColumn}) VALUES (:slug, :roleType, :systemRole)`;
+
+		// Make sure that the global roles that we need exist
+		for (const role of [
+			'project:personalOwner',
+			'project:admin',
+			'project:editor',
+			'project:viewer',
+		]) {
+			await runQuery(query, {
+				slug: role,
+				roleType: 'project',
+				systemRole: true,
+			});
+		}
+
+		// Fallback to 'project:viewer' for users that do not have a correct role set
+		// This should not happen in a correctly set up system, but we want to ensure
+		// that all users have a role set, before we add the foreign key constraint
+		await runQuery(
+			`UPDATE ${projectRelationTableName} SET ${roleColumn} = 'project:viewer' WHERE NOT EXISTS (SELECT 1 FROM ${tableName} WHERE ${slugColumn} = ${roleColumn})`,
+		);
+
+		await addForeignKey('project_relation', 'role', ['role', 'slug']);
+	}
+
+	async down({ schemaBuilder: { dropForeignKey } }: MigrationContext) {
+		await dropForeignKey('project_relation', 'role', ['role', 'slug']);
+	}
+}

--- a/packages/@n8n/db/src/migrations/common/1753953244168-LinkRoleToProjectRelationTable.ts
+++ b/packages/@n8n/db/src/migrations/common/1753953244168-LinkRoleToProjectRelationTable.ts
@@ -1,3 +1,4 @@
+import { PROJECT_ROLES, PROJECT_VIEWER_ROLE } from '../../constants';
 import type { MigrationContext, ReversibleMigration } from '../migration-types';
 
 /*
@@ -19,16 +20,11 @@ export class LinkRoleToProjectRelationTable1753953244168 implements ReversibleMi
 			: `INSERT IGNORE INTO ${tableName} (${slugColumn}, ${roleTypeColumn}, ${systemRoleColumn}) VALUES (:slug, :roleType, :systemRole)`;
 
 		// Make sure that the global roles that we need exist
-		for (const role of [
-			'project:personalOwner',
-			'project:admin',
-			'project:editor',
-			'project:viewer',
-		]) {
+		for (const role of Object.values(PROJECT_ROLES)) {
 			await runQuery(query, {
-				slug: role,
-				roleType: 'project',
-				systemRole: true,
+				slug: role.slug,
+				roleType: role.roleType,
+				systemRole: role.systemRole,
 			});
 		}
 
@@ -36,7 +32,7 @@ export class LinkRoleToProjectRelationTable1753953244168 implements ReversibleMi
 		// This should not happen in a correctly set up system, but we want to ensure
 		// that all users have a role set, before we add the foreign key constraint
 		await runQuery(
-			`UPDATE ${projectRelationTableName} SET ${roleColumn} = 'project:viewer' WHERE NOT EXISTS (SELECT 1 FROM ${tableName} WHERE ${slugColumn} = ${roleColumn})`,
+			`UPDATE ${projectRelationTableName} SET ${roleColumn} = '${PROJECT_VIEWER_ROLE.slug}' WHERE NOT EXISTS (SELECT 1 FROM ${tableName} WHERE ${slugColumn} = ${roleColumn})`,
 		);
 
 		await addForeignKey('project_relation', 'role', ['role', 'slug']);

--- a/packages/@n8n/db/src/migrations/common/1753953244168-LinkRoleToProjectRelationTable.ts
+++ b/packages/@n8n/db/src/migrations/common/1753953244168-LinkRoleToProjectRelationTable.ts
@@ -2,12 +2,14 @@ import { PROJECT_ROLES, PROJECT_VIEWER_ROLE } from '../../constants';
 import type { MigrationContext, ReversibleMigration } from '../migration-types';
 
 /*
- * This migration
+ * This migration links the role table to the project relation table, by adding a new foreign key on the 'role' column
+ * It also ensures that all project relations have a valid role set in the 'role' column.
+ * The migration will insert the project roles that we need into the role table if they do not exist.
  */
 
 export class LinkRoleToProjectRelationTable1753953244168 implements ReversibleMigration {
 	async up({ schemaBuilder: { addForeignKey }, escape, dbType, runQuery }: MigrationContext) {
-		const tableName = escape.tableName('role');
+		const roleTableName = escape.tableName('role');
 		const projectRelationTableName = escape.tableName('project_relation');
 		const slugColumn = escape.columnName('slug');
 		const roleColumn = escape.columnName('role');
@@ -16,8 +18,8 @@ export class LinkRoleToProjectRelationTable1753953244168 implements ReversibleMi
 
 		const isPostgresOrSqlite = dbType === 'postgresdb' || dbType === 'sqlite';
 		const query = isPostgresOrSqlite
-			? `INSERT INTO ${tableName} (${slugColumn}, ${roleTypeColumn}, ${systemRoleColumn}) VALUES (:slug, :roleType, :systemRole) ON CONFLICT DO NOTHING`
-			: `INSERT IGNORE INTO ${tableName} (${slugColumn}, ${roleTypeColumn}, ${systemRoleColumn}) VALUES (:slug, :roleType, :systemRole)`;
+			? `INSERT INTO ${roleTableName} (${slugColumn}, ${roleTypeColumn}, ${systemRoleColumn}) VALUES (:slug, :roleType, :systemRole) ON CONFLICT DO NOTHING`
+			: `INSERT IGNORE INTO ${roleTableName} (${slugColumn}, ${roleTypeColumn}, ${systemRoleColumn}) VALUES (:slug, :roleType, :systemRole)`;
 
 		// Make sure that the project roles that we need exist
 		for (const role of Object.values(PROJECT_ROLES)) {
@@ -32,7 +34,7 @@ export class LinkRoleToProjectRelationTable1753953244168 implements ReversibleMi
 		// This should not happen in a correctly set up system, but we want to ensure
 		// that all users have a role set, before we add the foreign key constraint
 		await runQuery(
-			`UPDATE ${projectRelationTableName} SET ${roleColumn} = '${PROJECT_VIEWER_ROLE.slug}' WHERE NOT EXISTS (SELECT 1 FROM ${tableName} WHERE ${slugColumn} = ${roleColumn})`,
+			`UPDATE ${projectRelationTableName} SET ${roleColumn} = '${PROJECT_VIEWER_ROLE.slug}' WHERE NOT EXISTS (SELECT 1 FROM ${roleTableName} WHERE ${slugColumn} = ${roleColumn})`,
 		);
 
 		await addForeignKey('project_relation', 'role', ['role', 'slug']);

--- a/packages/@n8n/db/src/migrations/common/1753953244168-LinkRoleToProjectRelationTable.ts
+++ b/packages/@n8n/db/src/migrations/common/1753953244168-LinkRoleToProjectRelationTable.ts
@@ -19,7 +19,7 @@ export class LinkRoleToProjectRelationTable1753953244168 implements ReversibleMi
 			? `INSERT INTO ${tableName} (${slugColumn}, ${roleTypeColumn}, ${systemRoleColumn}) VALUES (:slug, :roleType, :systemRole) ON CONFLICT DO NOTHING`
 			: `INSERT IGNORE INTO ${tableName} (${slugColumn}, ${roleTypeColumn}, ${systemRoleColumn}) VALUES (:slug, :roleType, :systemRole)`;
 
-		// Make sure that the global roles that we need exist
+		// Make sure that the project roles that we need exist
 		for (const role of Object.values(PROJECT_ROLES)) {
 			await runQuery(query, {
 				slug: role.slug,

--- a/packages/@n8n/db/src/migrations/mysqldb/index.ts
+++ b/packages/@n8n/db/src/migrations/mysqldb/index.ts
@@ -1,4 +1,5 @@
 import { AddMfaColumns1690000000030 } from './../common/1690000000040-AddMfaColumns';
+import { LinkRoleToProjectRelationTable1753953244168 } from './../common/1753953244168-LinkRoleToProjectRelationTable';
 import { InitialMigration1588157391238 } from './1588157391238-InitialMigration';
 import { WebhookModel1592447867632 } from './1592447867632-WebhookModel';
 import { CreateIndexStoppedAt1594902918301 } from './1594902918301-CreateIndexStoppedAt';
@@ -197,4 +198,5 @@ export const mysqlMigrations: Migration[] = [
 	CreateDataStoreTables1754475614601,
 	RemoveOldRoleColumn1750252139170,
 	ReplaceDataStoreTablesWithDataTables1754475614602,
+	LinkRoleToProjectRelationTable1753953244168,
 ];

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -1,5 +1,6 @@
 import { AddMfaColumns1690000000030 } from './../common/1690000000040-AddMfaColumns';
 import { AddInputsOutputsToTestCaseExecution1752669793000 } from './../common/1752669793000-AddInputsOutputsToTestCaseExecution';
+import { LinkRoleToProjectRelationTable1753953244168 } from './../common/1753953244168-LinkRoleToProjectRelationTable';
 import { InitialMigration1587669153312 } from './1587669153312-InitialMigration';
 import { WebhookModel1589476000887 } from './1589476000887-WebhookModel';
 import { CreateIndexStoppedAt1594828256133 } from './1594828256133-CreateIndexStoppedAt';
@@ -195,4 +196,5 @@ export const postgresMigrations: Migration[] = [
 	CreateDataStoreTables1754475614601,
 	RemoveOldRoleColumn1750252139170,
 	ReplaceDataStoreTablesWithDataTables1754475614602,
+	LinkRoleToProjectRelationTable1753953244168,
 ];

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -93,6 +93,7 @@ import { AddInputsOutputsToTestCaseExecution1752669793000 } from '../common/1752
 import { CreateDataStoreTables1754475614601 } from '../common/1754475614601-CreateDataStoreTables';
 import { ReplaceDataStoreTablesWithDataTables1754475614602 } from '../common/1754475614602-ReplaceDataStoreTablesWithDataTables';
 import type { Migration } from '../migration-types';
+import { LinkRoleToProjectRelationTable1753953244168 } from './../common/1753953244168-LinkRoleToProjectRelationTable';
 
 const sqliteMigrations: Migration[] = [
 	InitialMigration1588102412422,
@@ -189,6 +190,7 @@ const sqliteMigrations: Migration[] = [
 	CreateDataStoreTables1754475614601,
 	RemoveOldRoleColumn1750252139170,
 	ReplaceDataStoreTablesWithDataTables1754475614602,
+	LinkRoleToProjectRelationTable1753953244168,
 ];
 
 export { sqliteMigrations };

--- a/packages/@n8n/db/src/repositories/project-relation.repository.ts
+++ b/packages/@n8n/db/src/repositories/project-relation.repository.ts
@@ -1,5 +1,5 @@
 import { Service } from '@n8n/di';
-import type { ProjectRole } from '@n8n/permissions';
+import { PROJECT_OWNER_ROLE_SLUG, type ProjectRole } from '@n8n/permissions';
 import { DataSource, In, Repository } from '@n8n/typeorm';
 
 import { ProjectRelation } from '../entities';
@@ -14,7 +14,7 @@ export class ProjectRelationRepository extends Repository<ProjectRelation> {
 		return await this.find({
 			where: {
 				projectId: In(projectIds),
-				role: 'project:personalOwner',
+				role: { slug: PROJECT_OWNER_ROLE_SLUG },
 			},
 			relations: {
 				user: {
@@ -28,7 +28,7 @@ export class ProjectRelationRepository extends Repository<ProjectRelation> {
 		const projectRelations = await this.find({
 			where: {
 				userId: In(userIds),
-				role: 'project:personalOwner',
+				role: { slug: PROJECT_OWNER_ROLE_SLUG },
 			},
 		});
 

--- a/packages/@n8n/db/src/repositories/project-relation.repository.ts
+++ b/packages/@n8n/db/src/repositories/project-relation.repository.ts
@@ -73,6 +73,7 @@ export class ProjectRelationRepository extends Repository<ProjectRelation> {
 			where: {
 				userId,
 			},
+			relations: { role: true },
 		});
 	}
 }

--- a/packages/@n8n/db/src/repositories/project.repository.ts
+++ b/packages/@n8n/db/src/repositories/project.repository.ts
@@ -1,4 +1,5 @@
 import { Service } from '@n8n/di';
+import { PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
 import type { EntityManager } from '@n8n/typeorm';
 import { DataSource, Repository } from '@n8n/typeorm';
 
@@ -14,7 +15,10 @@ export class ProjectRepository extends Repository<Project> {
 		const em = entityManager ?? this.manager;
 
 		return await em.findOne(Project, {
-			where: { type: 'personal', projectRelations: { userId, role: 'project:personalOwner' } },
+			where: {
+				type: 'personal',
+				projectRelations: { userId, role: { slug: PROJECT_OWNER_ROLE_SLUG } },
+			},
 		});
 	}
 
@@ -22,7 +26,10 @@ export class ProjectRepository extends Repository<Project> {
 		const em = entityManager ?? this.manager;
 
 		return await em.findOneOrFail(Project, {
-			where: { type: 'personal', projectRelations: { userId, role: 'project:personalOwner' } },
+			where: {
+				type: 'personal',
+				projectRelations: { userId, role: { slug: PROJECT_OWNER_ROLE_SLUG } },
+			},
 		});
 	}
 

--- a/packages/@n8n/db/src/repositories/project.repository.ts
+++ b/packages/@n8n/db/src/repositories/project.repository.ts
@@ -19,6 +19,7 @@ export class ProjectRepository extends Repository<Project> {
 				type: 'personal',
 				projectRelations: { userId, role: { slug: PROJECT_OWNER_ROLE_SLUG } },
 			},
+			relations: ['projectRelations.role'],
 		});
 	}
 

--- a/packages/@n8n/db/src/repositories/shared-credentials.repository.ts
+++ b/packages/@n8n/db/src/repositories/shared-credentials.repository.ts
@@ -120,7 +120,7 @@ export class SharedCredentialsRepository extends Repository<SharedCredentials> {
 				project: {
 					projectRelations: {
 						userId: In(userIds),
-						role: In(projectRoles),
+						role: { slug: In(projectRoles) },
 					},
 				},
 			},

--- a/packages/@n8n/db/src/repositories/shared-workflow.repository.ts
+++ b/packages/@n8n/db/src/repositories/shared-workflow.repository.ts
@@ -1,5 +1,5 @@
 import { Service } from '@n8n/di';
-import type { WorkflowSharingRole } from '@n8n/permissions';
+import { PROJECT_OWNER_ROLE_SLUG, type WorkflowSharingRole } from '@n8n/permissions';
 import { DataSource, Repository, In, Not } from '@n8n/typeorm';
 import type { EntityManager, FindManyOptions, FindOptionsWhere } from '@n8n/typeorm';
 
@@ -46,7 +46,7 @@ export class SharedWorkflowRepository extends Repository<SharedWorkflow> {
 			},
 			where: {
 				workflowId,
-				project: { projectRelations: { role: 'project:personalOwner', userId } },
+				project: { projectRelations: { role: { slug: PROJECT_OWNER_ROLE_SLUG }, userId } },
 			},
 		});
 

--- a/packages/@n8n/db/src/repositories/shared-workflow.repository.ts
+++ b/packages/@n8n/db/src/repositories/shared-workflow.repository.ts
@@ -28,7 +28,7 @@ export class SharedWorkflowRepository extends Repository<SharedWorkflow> {
 				role: 'workflow:owner',
 				workflowId: In(workflowIds),
 			},
-			relations: { project: { projectRelations: { user: true } } },
+			relations: { project: { projectRelations: { user: true, role: true } } },
 		});
 	}
 

--- a/packages/@n8n/db/src/repositories/user.repository.ts
+++ b/packages/@n8n/db/src/repositories/user.repository.ts
@@ -237,7 +237,7 @@ export class UserRepository extends Repository<User> {
 				.leftJoinAndSelect(
 					'user.projectRelations',
 					'projectRelations',
-					'projectRelations.role IS NOT NULL AND projectRelations.role <> :projectRole',
+					'projectRelations.role <> :projectRole',
 					{ projectRole: PROJECT_OWNER_ROLE_SLUG },
 				)
 				.leftJoinAndSelect('projectRelations.project', 'project')

--- a/packages/@n8n/db/src/repositories/user.repository.ts
+++ b/packages/@n8n/db/src/repositories/user.repository.ts
@@ -1,5 +1,6 @@
 import type { UsersListFilterDto } from '@n8n/api-types';
 import { Service } from '@n8n/di';
+import { PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
 import type { DeepPartial, EntityManager, SelectQueryBuilder } from '@n8n/typeorm';
 import { Brackets, DataSource, In, IsNull, Not, Repository } from '@n8n/typeorm';
 
@@ -106,8 +107,8 @@ export class UserRepository extends Repository<User> {
 			await entityManager.save<ProjectRelation>(
 				entityManager.create(ProjectRelation, {
 					projectId: savedProject.id,
-					userId: userWithRole.id,
-					role: 'project:personalOwner',
+					userId: savedUser.id,
+					role: { slug: PROJECT_OWNER_ROLE_SLUG },
 				}),
 			);
 			return { user: userWithRole, project: savedProject };
@@ -129,7 +130,7 @@ export class UserRepository extends Repository<User> {
 		return await this.findOne({
 			where: {
 				projectRelations: {
-					role: 'project:personalOwner',
+					role: { slug: PROJECT_OWNER_ROLE_SLUG },
 					project: { sharedWorkflows: { workflowId, role: 'workflow:owner' } },
 				},
 			},
@@ -146,7 +147,7 @@ export class UserRepository extends Repository<User> {
 		return await this.findOne({
 			where: {
 				projectRelations: {
-					role: 'project:personalOwner',
+					role: { slug: PROJECT_OWNER_ROLE_SLUG },
 					projectId,
 				},
 			},
@@ -232,15 +233,15 @@ export class UserRepository extends Repository<User> {
 		expand: UsersListFilterDto['expand'],
 	): SelectQueryBuilder<User> {
 		if (expand?.includes('projectRelations')) {
-			queryBuilder.leftJoinAndSelect(
-				'user.projectRelations',
-				'projectRelations',
-				'projectRelations.role <> :projectRole',
-				{
-					projectRole: 'project:personalOwner', // Exclude personal project relations
-				},
-			);
-			queryBuilder.leftJoinAndSelect('projectRelations.project', 'project');
+			queryBuilder
+				.leftJoinAndSelect(
+					'user.projectRelations',
+					'projectRelations',
+					'projectRelations.role IS NOT NULL AND projectRelations.role <> :projectRole',
+					{ projectRole: PROJECT_OWNER_ROLE_SLUG },
+				)
+				.leftJoinAndSelect('projectRelations.project', 'project')
+				.leftJoinAndSelect('projectRelations.role', 'projectRole');
 		}
 
 		return queryBuilder;

--- a/packages/@n8n/db/src/repositories/workflow-statistics.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-statistics.repository.ts
@@ -1,5 +1,6 @@
 import { GlobalConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
+import { PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
 import { DataSource, MoreThanOrEqual, QueryFailedError, Repository } from '@n8n/typeorm';
 
 import { WorkflowStatistics } from '../entities';
@@ -122,7 +123,7 @@ export class WorkflowStatisticsRepository extends Repository<WorkflowStatistics>
 				workflow: {
 					shared: {
 						role: 'workflow:owner',
-						project: { projectRelations: { userId, role: 'project:personalOwner' } },
+						project: { projectRelations: { userId, role: { slug: PROJECT_OWNER_ROLE_SLUG } } },
 					},
 					active: true,
 				},

--- a/packages/@n8n/db/src/services/auth.roles.service.ts
+++ b/packages/@n8n/db/src/services/auth.roles.service.ts
@@ -52,9 +52,9 @@ export class AuthRolesService {
 		}).filter((scope) => scope !== null);
 
 		if (scopesToUpdate.length > 0) {
-			this.logger.info(`Updating ${scopesToUpdate.length} scopes...`);
+			this.logger.debug(`Updating ${scopesToUpdate.length} scopes...`);
 			await this.scopeRepository.save(scopesToUpdate);
-			this.logger.info('Scopes updated successfully.');
+			this.logger.debug('Scopes updated successfully.');
 		} else {
 			this.logger.debug('No scopes to update.');
 		}
@@ -118,9 +118,9 @@ export class AuthRolesService {
 				})
 				.filter((role) => role !== null);
 			if (rolesToUpdate.length > 0) {
-				this.logger.info(`Updating ${rolesToUpdate.length} ${roleNamespace} roles...`);
+				this.logger.debug(`Updating ${rolesToUpdate.length} ${roleNamespace} roles...`);
 				await this.roleRepository.save(rolesToUpdate);
-				this.logger.info(`${roleNamespace} roles updated successfully.`);
+				this.logger.debug(`${roleNamespace} roles updated successfully.`);
 			} else {
 				this.logger.debug(`No ${roleNamespace} roles to update.`);
 			}
@@ -128,9 +128,9 @@ export class AuthRolesService {
 	}
 
 	async init() {
-		this.logger.info('Initializing AuthRolesService...');
+		this.logger.debug('Initializing AuthRolesService...');
 		await this.syncScopes();
 		await this.syncRoles();
-		this.logger.info('AuthRolesService initialized successfully.');
+		this.logger.debug('AuthRolesService initialized successfully.');
 	}
 }

--- a/packages/@n8n/permissions/src/__tests__/schemas.test.ts
+++ b/packages/@n8n/permissions/src/__tests__/schemas.test.ts
@@ -1,4 +1,11 @@
 import {
+	PROJECT_ADMIN_ROLE_SLUG,
+	PROJECT_EDITOR_ROLE_SLUG,
+	PROJECT_OWNER_ROLE_SLUG,
+	PROJECT_VIEWER_ROLE_SLUG,
+} from '@/constants.ee';
+
+import {
 	roleNamespaceSchema,
 	globalRoleSchema,
 	assignableGlobalRoleSchema,
@@ -53,10 +60,26 @@ describe('assignableGlobalRoleSchema', () => {
 
 describe('projectRoleSchema', () => {
 	test.each([
-		{ name: 'valid role: project:personalOwner', value: 'project:personalOwner', expected: true },
-		{ name: 'valid role: project:admin', value: 'project:admin', expected: true },
-		{ name: 'valid role: project:editor', value: 'project:editor', expected: true },
-		{ name: 'valid role: project:viewer', value: 'project:viewer', expected: true },
+		{
+			name: `valid role: ${PROJECT_OWNER_ROLE_SLUG}`,
+			value: PROJECT_OWNER_ROLE_SLUG,
+			expected: true,
+		},
+		{
+			name: `valid role: ${PROJECT_ADMIN_ROLE_SLUG}`,
+			value: PROJECT_ADMIN_ROLE_SLUG,
+			expected: true,
+		},
+		{
+			name: `valid role: ${PROJECT_EDITOR_ROLE_SLUG}`,
+			value: PROJECT_EDITOR_ROLE_SLUG,
+			expected: true,
+		},
+		{
+			name: `valid role: ${PROJECT_VIEWER_ROLE_SLUG}`,
+			value: PROJECT_VIEWER_ROLE_SLUG,
+			expected: true,
+		},
 		{ name: 'invalid role', value: 'invalid-role', expected: false },
 	])('should validate $name', ({ value, expected }) => {
 		const result = projectRoleSchema.safeParse(value);

--- a/packages/@n8n/permissions/src/constants.ee.ts
+++ b/packages/@n8n/permissions/src/constants.ee.ts
@@ -43,3 +43,8 @@ export const API_KEY_RESOURCES = {
 	sourceControl: ['pull'] as const,
 	workflowTags: ['update', 'list'] as const,
 } as const;
+
+export const PROJECT_OWNER_ROLE_SLUG = 'project:personalOwner';
+export const PROJECT_ADMIN_ROLE_SLUG = 'project:admin';
+export const PROJECT_EDITOR_ROLE_SLUG = 'project:editor';
+export const PROJECT_VIEWER_ROLE_SLUG = 'project:viewer';

--- a/packages/@n8n/permissions/src/index.ts
+++ b/packages/@n8n/permissions/src/index.ts
@@ -6,7 +6,7 @@ export * from './scope-information';
 export * from './roles/role-maps.ee';
 export * from './roles/all-roles';
 
-export { projectRoleSchema } from './schemas.ee';
+export { projectRoleSchema, teamRoleSchema } from './schemas.ee';
 
 export { hasScope } from './utilities/has-scope.ee';
 export { hasGlobalScope } from './utilities/has-global-scope.ee';

--- a/packages/@n8n/permissions/src/roles/all-roles.ts
+++ b/packages/@n8n/permissions/src/roles/all-roles.ts
@@ -1,4 +1,10 @@
 import {
+	PROJECT_ADMIN_ROLE_SLUG,
+	PROJECT_EDITOR_ROLE_SLUG,
+	PROJECT_OWNER_ROLE_SLUG,
+	PROJECT_VIEWER_ROLE_SLUG,
+} from '../constants.ee';
+import {
 	CREDENTIALS_SHARING_SCOPE_MAP,
 	GLOBAL_SCOPE_MAP,
 	PROJECT_SCOPE_MAP,
@@ -11,10 +17,10 @@ const ROLE_NAMES: Record<AllRoleTypes, string> = {
 	'global:owner': 'Owner',
 	'global:admin': 'Admin',
 	'global:member': 'Member',
-	'project:personalOwner': 'Project Owner',
-	'project:admin': 'Project Admin',
-	'project:editor': 'Project Editor',
-	'project:viewer': 'Project Viewer',
+	[PROJECT_OWNER_ROLE_SLUG]: 'Project Owner',
+	[PROJECT_ADMIN_ROLE_SLUG]: 'Project Admin',
+	[PROJECT_EDITOR_ROLE_SLUG]: 'Project Editor',
+	[PROJECT_VIEWER_ROLE_SLUG]: 'Project Viewer',
 	'credential:user': 'Credential User',
 	'credential:owner': 'Credential Owner',
 	'workflow:owner': 'Workflow Owner',

--- a/packages/@n8n/permissions/src/schemas.ee.ts
+++ b/packages/@n8n/permissions/src/schemas.ee.ts
@@ -12,12 +12,11 @@ export const personalRoleSchema = z.enum([
 	'project:personalOwner', // personalOwner is only used for personal projects
 ]);
 
-export const teamRoleSchema = z.union([
-	z.enum(['project:admin', 'project:editor', 'project:viewer']),
-	z.string().refine((val) => val !== 'project:personalOwner', {
-		message: "'project:personalOwner' is not assignable",
-	}),
-]);
+export const teamRoleSchema = z.enum(['project:admin', 'project:editor', 'project:viewer']);
+
+export const customRoleSchema = z.string().refine((val) => val !== 'project:personalOwner', {
+	message: "'project:personalOwner' is not assignable",
+});
 
 export const projectRoleSchema = z.union([personalRoleSchema, teamRoleSchema]);
 

--- a/packages/@n8n/permissions/src/schemas.ee.ts
+++ b/packages/@n8n/permissions/src/schemas.ee.ts
@@ -12,9 +12,14 @@ export const personalRoleSchema = z.enum([
 	'project:personalOwner', // personalOwner is only used for personal projects
 ]);
 
-export const teamRoleSchema = z.enum(['project:admin', 'project:editor', 'project:viewer']);
+export const teamRoleSchema = z.union([
+	z.enum(['project:admin', 'project:editor', 'project:viewer']),
+	z.string().refine((val) => val !== 'project:personalOwner', {
+		message: "'project:personalOwner' is not assignable",
+	}),
+]);
 
-export const projectRoleSchema = z.enum([...personalRoleSchema.options, ...teamRoleSchema.options]);
+export const projectRoleSchema = z.union([personalRoleSchema, teamRoleSchema]);
 
 export const credentialSharingRoleSchema = z.enum(['credential:owner', 'credential:user']);
 

--- a/packages/@n8n/permissions/src/schemas.ee.ts
+++ b/packages/@n8n/permissions/src/schemas.ee.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { PROJECT_OWNER_ROLE_SLUG } from './constants.ee';
+
 export const roleNamespaceSchema = z.enum(['global', 'project', 'credential', 'workflow']);
 
 export const globalRoleSchema = z.enum(['global:owner', 'global:admin', 'global:member']);
@@ -14,8 +16,8 @@ export const personalRoleSchema = z.enum([
 
 export const teamRoleSchema = z.enum(['project:admin', 'project:editor', 'project:viewer']);
 
-export const customRoleSchema = z.string().refine((val) => val !== 'project:personalOwner', {
-	message: "'project:personalOwner' is not assignable",
+export const customRoleSchema = z.string().refine((val) => val !== PROJECT_OWNER_ROLE_SLUG, {
+	message: `'${PROJECT_OWNER_ROLE_SLUG}' is not assignable`,
 });
 
 export const projectRoleSchema = z.union([personalRoleSchema, teamRoleSchema]);

--- a/packages/@n8n/permissions/src/types.ee.ts
+++ b/packages/@n8n/permissions/src/types.ee.ts
@@ -58,6 +58,7 @@ export type CredentialSharingRole = z.infer<typeof credentialSharingRoleSchema>;
 export type WorkflowSharingRole = z.infer<typeof workflowSharingRoleSchema>;
 export type TeamProjectRole = z.infer<typeof teamRoleSchema>;
 export type ProjectRole = z.infer<typeof projectRoleSchema>;
+export type CustomRole = string;
 
 /** Union of all possible role types in the system */
 export type AllRoleTypes = GlobalRole | ProjectRole | WorkflowSharingRole | CredentialSharingRole;

--- a/packages/cli/src/commands/__tests__/execute-batch.test.ts
+++ b/packages/cli/src/commands/__tests__/execute-batch.test.ts
@@ -1,7 +1,7 @@
 import { mockInstance } from '@n8n/backend-test-utils';
 import { GlobalConfig } from '@n8n/config';
 import type { User, WorkflowEntity } from '@n8n/db';
-import { WorkflowRepository, DbConnection } from '@n8n/db';
+import { WorkflowRepository, DbConnection, AuthRolesService } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { type SelectQueryBuilder } from '@n8n/typeorm';
 import { mock } from 'jest-mock-extended';
@@ -39,6 +39,7 @@ mockInstance(CommunityPackagesService);
 const dbConnection = mockInstance(DbConnection);
 dbConnection.init.mockResolvedValue(undefined);
 dbConnection.migrate.mockResolvedValue(undefined);
+mockInstance(AuthRolesService);
 
 test('should start a task runner when task runners are enabled', async () => {
 	// arrange

--- a/packages/cli/src/commands/__tests__/execute.test.ts
+++ b/packages/cli/src/commands/__tests__/execute.test.ts
@@ -1,10 +1,12 @@
 import { mockInstance } from '@n8n/backend-test-utils';
 import { GlobalConfig } from '@n8n/config';
 import type { User, WorkflowEntity } from '@n8n/db';
-import { WorkflowRepository, DbConnection } from '@n8n/db';
+import { WorkflowRepository, DbConnection, AuthRolesService } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
 import type { IRun } from 'n8n-workflow';
+
+import { Execute } from '../execute';
 
 import { ActiveExecutions } from '@/active-executions';
 import { DeprecationService } from '@/deprecation/deprecation.service';
@@ -18,8 +20,6 @@ import { OwnershipService } from '@/services/ownership.service';
 import { ShutdownService } from '@/shutdown/shutdown.service';
 import { TaskRunnerModule } from '@/task-runners/task-runner-module';
 import { WorkflowRunner } from '@/workflow-runner';
-
-import { Execute } from '../execute';
 
 const taskRunnerModule = mockInstance(TaskRunnerModule);
 const workflowRepository = mockInstance(WorkflowRepository);
@@ -38,6 +38,7 @@ mockInstance(CommunityPackagesService);
 const dbConnection = mockInstance(DbConnection);
 dbConnection.init.mockResolvedValue(undefined);
 dbConnection.migrate.mockResolvedValue(undefined);
+mockInstance(AuthRolesService);
 
 test('should start a task runner when task runners are enabled', async () => {
 	// arrange

--- a/packages/cli/src/commands/base-command.ts
+++ b/packages/cli/src/commands/base-command.ts
@@ -9,7 +9,7 @@ import {
 } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import { LICENSE_FEATURES } from '@n8n/constants';
-import { DbConnection } from '@n8n/db';
+import { AuthRolesService, DbConnection } from '@n8n/db';
 import { Container } from '@n8n/di';
 import {
 	BinaryDataConfig,
@@ -120,6 +120,9 @@ export abstract class BaseCommand<F = never> {
 				async (error: Error) =>
 					await this.exitWithCrash('There was an error running database migrations', error),
 			);
+
+		// Initialize the auth roles service to make sure that roles are correctly setup for the instance
+		await Container.get(AuthRolesService).init();
 
 		Container.get(DeprecationService).warn();
 

--- a/packages/cli/src/commands/import/credentials.ts
+++ b/packages/cli/src/commands/import/credentials.ts
@@ -8,6 +8,7 @@ import {
 } from '@n8n/db';
 import { Command } from '@n8n/decorators';
 import { Container } from '@n8n/di';
+import { PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import type { EntityManager } from '@n8n/typeorm';
 import glob from 'fast-glob';
@@ -17,9 +18,9 @@ import type { ICredentialsEncrypted } from 'n8n-workflow';
 import { jsonParse, UserError } from 'n8n-workflow';
 import { z } from 'zod';
 
-import { UM_FIX_INSTRUCTION } from '@/constants';
-
 import { BaseCommand } from '../base-command';
+
+import { UM_FIX_INSTRUCTION } from '@/constants';
 
 const flagsSchema = z.object({
 	input: z
@@ -239,7 +240,7 @@ export class ImportCredentialsCommand extends BaseCommand<z.infer<typeof flagsSc
 		if (sharedCredential && sharedCredential.project.type === 'personal') {
 			const user = await this.transactionManager.findOneByOrFail(User, {
 				projectRelations: {
-					role: 'project:personalOwner',
+					role: { slug: PROJECT_OWNER_ROLE_SLUG },
 					projectId: sharedCredential.projectId,
 				},
 			});

--- a/packages/cli/src/commands/import/workflow.ts
+++ b/packages/cli/src/commands/import/workflow.ts
@@ -9,17 +9,18 @@ import {
 } from '@n8n/db';
 import { Command } from '@n8n/decorators';
 import { Container } from '@n8n/di';
+import { PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
 import glob from 'fast-glob';
 import fs from 'fs';
 import type { IWorkflowBase, WorkflowId } from 'n8n-workflow';
 import { jsonParse, UserError } from 'n8n-workflow';
 import { z } from 'zod';
 
+import { BaseCommand } from '../base-command';
+
 import { UM_FIX_INSTRUCTION } from '@/constants';
 import type { IWorkflowToImport } from '@/interfaces';
 import { ImportService } from '@/services/import.service';
-
-import { BaseCommand } from '../base-command';
 
 function assertHasWorkflowsToImport(
 	workflows: unknown[],
@@ -167,7 +168,7 @@ export class ImportWorkflowsCommand extends BaseCommand<z.infer<typeof flagsSche
 		if (sharing && sharing.project.type === 'personal') {
 			const user = await Container.get(UserRepository).findOneByOrFail({
 				projectRelations: {
-					role: 'project:personalOwner',
+					role: { slug: PROJECT_OWNER_ROLE_SLUG },
 					projectId: sharing.projectId,
 				},
 			});

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -13,8 +13,6 @@ import replaceStream from 'replacestream';
 import { pipeline } from 'stream/promises';
 import { z } from 'zod';
 
-import { BaseCommand } from './base-command';
-
 import { ActiveExecutions } from '@/active-executions';
 import { ActiveWorkflowManager } from '@/active-workflow-manager';
 import config from '@/config';
@@ -33,6 +31,8 @@ import { ExecutionsPruningService } from '@/services/pruning/executions-pruning.
 import { UrlService } from '@/services/url.service';
 import { WaitTracker } from '@/wait-tracker';
 import { WorkflowRunner } from '@/workflow-runner';
+
+import { BaseCommand } from './base-command';
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const open = require('open');

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { LICENSE_FEATURES } from '@n8n/constants';
-import { AuthRolesService, ExecutionRepository, SettingsRepository } from '@n8n/db';
+import { ExecutionRepository, SettingsRepository } from '@n8n/db';
 import { Command } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 import glob from 'fast-glob';
@@ -172,8 +172,6 @@ export class Start extends BaseCommand<z.infer<typeof flagsSchema>> {
 		}
 
 		await super.init();
-
-		await Container.get(AuthRolesService).init();
 
 		this.activeWorkflowManager = Container.get(ActiveWorkflowManager);
 

--- a/packages/cli/src/controllers/project.controller.ts
+++ b/packages/cli/src/controllers/project.controller.ts
@@ -14,12 +14,7 @@ import {
 	Param,
 	Query,
 } from '@n8n/decorators';
-import {
-	combineScopes,
-	getAuthPrincipalScopes,
-	getRoleScopes,
-	hasGlobalScope,
-} from '@n8n/permissions';
+import { combineScopes, getAuthPrincipalScopes, hasGlobalScope } from '@n8n/permissions';
 import type { Scope } from '@n8n/permissions';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In, Not } from '@n8n/typeorm';
@@ -80,7 +75,7 @@ export class ProjectController {
 						project:
 							relations
 								.find((pr) => pr.userId === req.user.id)
-								?.roleEntity.scopes.map((scope) => scope.slug) || [],
+								?.role.scopes.map((scope) => scope.slug) || [],
 					}),
 				],
 			};
@@ -110,14 +105,14 @@ export class ProjectController {
 		for (const pr of relations) {
 			const result: ProjectRequest.GetMyProjectsResponse[number] = Object.assign(
 				this.projectRepository.create(pr.project),
-				{ role: pr.role, scopes: [] },
+				{ role: pr.role.slug, scopes: [] },
 			);
 
 			if (result.scopes) {
 				result.scopes.push(
 					...combineScopes({
 						global: getAuthPrincipalScopes(req.user),
-						project: pr.roleEntity.scopes.map((scope) => scope.slug),
+						project: pr.role.scopes.map((scope) => scope.slug),
 					}),
 				);
 			}
@@ -168,7 +163,7 @@ export class ProjectController {
 				project:
 					relations
 						.find((pr) => pr.userId === req.user.id)
-						?.roleEntity.scopes.map((scope) => scope.slug) ?? [],
+						?.role.scopes.map((scope) => scope.slug) ?? [],
 			}),
 		];
 		return {
@@ -201,14 +196,12 @@ export class ProjectController {
 				email: r.user.email,
 				firstName: r.user.firstName,
 				lastName: r.user.lastName,
-				role: r.role,
+				role: r.role.slug,
 			})),
 			scopes: [
 				...combineScopes({
 					global: getAuthPrincipalScopes(req.user),
-					...(myRelation
-						? { project: myRelation.roleEntity.scopes.map((scope) => scope.slug) }
-						: {}),
+					...(myRelation ? { project: myRelation.role.scopes.map((scope) => scope.slug) } : {}),
 				}),
 			],
 		};

--- a/packages/cli/src/controllers/project.controller.ts
+++ b/packages/cli/src/controllers/project.controller.ts
@@ -69,13 +69,18 @@ export class ProjectController {
 				uiContext: payload.uiContext,
 			});
 
+			const relations = await this.projectsService.getProjectRelations(project.id);
+
 			return {
 				...project,
 				role: 'project:admin',
 				scopes: [
 					...combineScopes({
 						global: getAuthPrincipalScopes(req.user),
-						project: getRoleScopes('project:admin'),
+						project:
+							relations
+								.find((pr) => pr.userId === req.user.id)
+								?.roleEntity.scopes.map((scope) => scope.slug) || [],
 					}),
 				],
 			};
@@ -112,7 +117,7 @@ export class ProjectController {
 				result.scopes.push(
 					...combineScopes({
 						global: getAuthPrincipalScopes(req.user),
-						project: getRoleScopes(pr.role),
+						project: pr.roleEntity.scopes.map((scope) => scope.slug),
 					}),
 				);
 			}
@@ -155,10 +160,15 @@ export class ProjectController {
 		if (!project) {
 			throw new NotFoundError('Could not find a personal project for this user');
 		}
+
+		const relations = await this.projectsService.getProjectRelations(project.id);
 		const scopes: Scope[] = [
 			...combineScopes({
 				global: getAuthPrincipalScopes(req.user),
-				project: getRoleScopes('project:personalOwner'),
+				project:
+					relations
+						.find((pr) => pr.userId === req.user.id)
+						?.roleEntity.scopes.map((scope) => scope.slug) ?? [],
 			}),
 		];
 		return {
@@ -196,7 +206,9 @@ export class ProjectController {
 			scopes: [
 				...combineScopes({
 					global: getAuthPrincipalScopes(req.user),
-					...(myRelation ? { project: getRoleScopes(myRelation.role) } : {}),
+					...(myRelation
+						? { project: myRelation.roleEntity.scopes.map((scope) => scope.slug) }
+						: {}),
 				}),
 			],
 		};

--- a/packages/cli/src/controllers/users.controller.ts
+++ b/packages/cli/src/controllers/users.controller.ts
@@ -124,7 +124,7 @@ export class UsersController {
 					...user,
 					projectRelations: u.projectRelations?.map((pr) => ({
 						id: pr.projectId,
-						role: pr.role, // normalize role for frontend
+						role: pr.role.slug, // normalize role for frontend
 						name: pr.project.name,
 					})),
 				};

--- a/packages/cli/src/credentials-helper.ts
+++ b/packages/cli/src/credentials-helper.ts
@@ -5,6 +5,7 @@
 import type { CredentialsEntity, ICredentialsDb } from '@n8n/db';
 import { CredentialsRepository, SharedCredentialsRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
+import { PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { EntityNotFoundError, In } from '@n8n/typeorm';
 import { Credentials, getAdditionalKeys } from 'n8n-core';
@@ -36,12 +37,12 @@ import {
 	isExpression,
 } from 'n8n-workflow';
 
-import { CredentialTypes } from '@/credential-types';
-import { CredentialsOverwrites } from '@/credentials-overwrites';
-
 import { RESPONSE_ERROR_MESSAGES } from './constants';
 import { CredentialNotFoundError } from './errors/credential-not-found.error';
 import { CacheService } from './services/cache/cache.service';
+
+import { CredentialTypes } from '@/credential-types';
+import { CredentialsOverwrites } from '@/credentials-overwrites';
 
 const mockNode = {
 	name: '',
@@ -496,7 +497,7 @@ export class CredentialsHelper extends ICredentialsHelper {
 							role: 'credential:owner',
 							project: {
 								projectRelations: {
-									role: In(['project:personalOwner', 'project:admin']),
+									role: { slug: In([PROJECT_OWNER_ROLE_SLUG, 'project:admin']) },
 									user: {
 										role: In(['global:owner', 'global:admin']),
 									},

--- a/packages/cli/src/credentials-helper.ts
+++ b/packages/cli/src/credentials-helper.ts
@@ -3,9 +3,14 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 import type { CredentialsEntity, ICredentialsDb } from '@n8n/db';
-import { CredentialsRepository, SharedCredentialsRepository } from '@n8n/db';
+import {
+	CredentialsRepository,
+	GLOBAL_ADMIN_ROLE,
+	GLOBAL_OWNER_ROLE,
+	SharedCredentialsRepository,
+} from '@n8n/db';
 import { Service } from '@n8n/di';
-import { PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
+import { PROJECT_ADMIN_ROLE_SLUG, PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { EntityNotFoundError, In } from '@n8n/typeorm';
 import { Credentials, getAdditionalKeys } from 'n8n-core';
@@ -37,12 +42,12 @@ import {
 	isExpression,
 } from 'n8n-workflow';
 
+import { CredentialTypes } from '@/credential-types';
+import { CredentialsOverwrites } from '@/credentials-overwrites';
+
 import { RESPONSE_ERROR_MESSAGES } from './constants';
 import { CredentialNotFoundError } from './errors/credential-not-found.error';
 import { CacheService } from './services/cache/cache.service';
-
-import { CredentialTypes } from '@/credential-types';
-import { CredentialsOverwrites } from '@/credentials-overwrites';
 
 const mockNode = {
 	name: '',
@@ -497,9 +502,9 @@ export class CredentialsHelper extends ICredentialsHelper {
 							role: 'credential:owner',
 							project: {
 								projectRelations: {
-									role: { slug: In([PROJECT_OWNER_ROLE_SLUG, 'project:admin']) },
+									role: { slug: In([PROJECT_OWNER_ROLE_SLUG, PROJECT_ADMIN_ROLE_SLUG]) },
 									user: {
-										role: In(['global:owner', 'global:admin']),
+										role: { slug: In([GLOBAL_OWNER_ROLE.slug, GLOBAL_ADMIN_ROLE.slug]) },
 									},
 								},
 							},

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -25,11 +25,16 @@ import {
 	Param,
 	Query,
 } from '@n8n/decorators';
+import { PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In } from '@n8n/typeorm';
 import { deepCopy } from 'n8n-workflow';
 import type { ICredentialDataDecryptedObject } from 'n8n-workflow';
 import { z } from 'zod';
+
+import { CredentialsFinderService } from './credentials-finder.service';
+import { CredentialsService } from './credentials.service';
+import { EnterpriseCredentialsService } from './credentials.service.ee';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
@@ -41,10 +46,6 @@ import { CredentialRequest } from '@/requests';
 import { NamingService } from '@/services/naming.service';
 import { UserManagementMailer } from '@/user-management/email';
 import * as utils from '@/utils';
-
-import { CredentialsFinderService } from './credentials-finder.service';
-import { CredentialsService } from './credentials.service';
-import { EnterpriseCredentialsService } from './credentials.service.ee';
 
 @RestController('/credentials')
 export class CredentialsController {
@@ -364,7 +365,7 @@ export class CredentialsController {
 
 		const projectsRelations = await this.projectRelationRepository.findBy({
 			projectId: In(newShareeIds),
-			role: 'project:personalOwner',
+			role: { slug: PROJECT_OWNER_ROLE_SLUG },
 		});
 
 		await this.userManagementMailer.notifyCredentialsShared({

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -10,7 +10,7 @@ import {
 	UserRepository,
 } from '@n8n/db';
 import { Service } from '@n8n/di';
-import { hasGlobalScope, type Scope } from '@n8n/permissions';
+import { hasGlobalScope, PROJECT_OWNER_ROLE_SLUG, type Scope } from '@n8n/permissions';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import {
 	In,
@@ -27,6 +27,8 @@ import type {
 } from 'n8n-workflow';
 import { CREDENTIAL_EMPTY_VALUE, deepCopy, NodeHelpers, UnexpectedError } from 'n8n-workflow';
 
+import { CredentialsFinderService } from './credentials-finder.service';
+
 import { CREDENTIAL_BLANKING_VALUE } from '@/constants';
 import { CredentialTypes } from '@/credential-types';
 import { createCredentialsFromCredentialsEntity } from '@/credentials-helper';
@@ -38,11 +40,8 @@ import { userHasScopes } from '@/permissions.ee/check-access';
 import type { CredentialRequest, ListQuery } from '@/requests';
 import { CredentialsTester } from '@/services/credentials-tester.service';
 import { OwnershipService } from '@/services/ownership.service';
-// eslint-disable-next-line import-x/no-cycle
 import { ProjectService } from '@/services/project.service.ee';
 import { RoleService } from '@/services/role.service';
-
-import { CredentialsFinderService } from './credentials-finder.service';
 
 export type CredentialsGetSharedOptions =
 	| { allowGlobalScope: true; globalScope: Scope }
@@ -300,7 +299,7 @@ export class CredentialsService {
 				role: 'credential:owner',
 				project: {
 					projectRelations: {
-						role: 'project:personalOwner',
+						role: { slug: PROJECT_OWNER_ROLE_SLUG },
 						userId: user.id,
 					},
 				},

--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control-export.service.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control-export.service.test.ts
@@ -11,6 +11,7 @@ import type {
 	WorkflowRepository,
 } from '@n8n/db';
 import { Container } from '@n8n/di';
+import { PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
 import { mock, captor } from 'jest-mock-extended';
 import { Cipher, type InstanceSettings } from 'n8n-core';
 import fsp from 'node:fs/promises';
@@ -83,10 +84,10 @@ describe('SourceControlExportService', () => {
 						type: 'personal',
 						projectRelations: [
 							{
-								role: 'project:personalOwner',
+								role: { slug: PROJECT_OWNER_ROLE_SLUG },
 								user: mock({ email: 'user@example.com' }),
 							},
-						],
+						] as any,
 					}),
 				}),
 			]);
@@ -268,7 +269,7 @@ describe('SourceControlExportService', () => {
 				mock<SharedWorkflow>({
 					project: mock({
 						type: 'personal',
-						projectRelations: [{ role: 'project:personalOwner', user: mock() }],
+						projectRelations: [{ role: { slug: PROJECT_OWNER_ROLE_SLUG }, user: mock() }] as any,
 					}),
 					workflow: mock(),
 				}),

--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control-export.service.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control-export.service.test.ts
@@ -1,5 +1,5 @@
 import type { SourceControlledFile } from '@n8n/api-types';
-import { GLOBAL_ADMIN_ROLE, User } from '@n8n/db';
+import { GLOBAL_ADMIN_ROLE, PROJECT_OWNER_ROLE, User } from '@n8n/db';
 import type {
 	SharedCredentials,
 	SharedWorkflow,
@@ -11,7 +11,6 @@ import type {
 	WorkflowRepository,
 } from '@n8n/db';
 import { Container } from '@n8n/di';
-import { PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
 import { mock, captor } from 'jest-mock-extended';
 import { Cipher, type InstanceSettings } from 'n8n-core';
 import fsp from 'node:fs/promises';
@@ -84,10 +83,10 @@ describe('SourceControlExportService', () => {
 						type: 'personal',
 						projectRelations: [
 							{
-								role: { slug: PROJECT_OWNER_ROLE_SLUG },
+								role: PROJECT_OWNER_ROLE,
 								user: mock({ email: 'user@example.com' }),
 							},
-						] as any,
+						],
 					}),
 				}),
 			]);
@@ -269,7 +268,7 @@ describe('SourceControlExportService', () => {
 				mock<SharedWorkflow>({
 					project: mock({
 						type: 'personal',
-						projectRelations: [{ role: { slug: PROJECT_OWNER_ROLE_SLUG }, user: mock() }] as any,
+						projectRelations: [{ role: PROJECT_OWNER_ROLE, user: mock() }],
 					}),
 					workflow: mock(),
 				}),

--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control-import.service.ee.test.ts
@@ -80,7 +80,7 @@ describe('SourceControlImportService', () => {
 			};
 
 			fsReadFile.mockResolvedValue(JSON.stringify(mockWorkflowData));
-			sourceControlScopedService.getAdminProjectsFromContext.mockResolvedValueOnce([]);
+			sourceControlScopedService.getAuthorizedProjectsFromContext.mockResolvedValueOnce([]);
 
 			const result = await service.getRemoteVersionIdsFromFiles(globalAdminContext);
 			expect(fsReadFile).toHaveBeenCalledWith(mockWorkflowFile, { encoding: 'utf8' });
@@ -312,7 +312,7 @@ describe('SourceControlImportService', () => {
 				],
 			};
 
-			sourceControlScopedService.getAdminProjectsFromContext.mockResolvedValue([
+			sourceControlScopedService.getAuthorizedProjectsFromContext.mockResolvedValue([
 				Object.assign(new Project(), {
 					id: 'project1',
 				}),

--- a/packages/cli/src/environments.ee/source-control/source-control-export.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-export.service.ee.ts
@@ -251,7 +251,7 @@ export class SourceControlExportService {
 			}
 
 			const allowedProjects =
-				await this.sourceControlScopedService.getAdminProjectsFromContext(context);
+				await this.sourceControlScopedService.getAuthorizedProjectsFromContext(context);
 
 			const fileName = getFoldersPath(this.gitFolder);
 

--- a/packages/cli/src/environments.ee/source-control/source-control-export.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-export.service.ee.ts
@@ -10,6 +10,7 @@ import {
 	WorkflowRepository,
 } from '@n8n/db';
 import { Service } from '@n8n/di';
+import { PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In } from '@n8n/typeorm';
 import { rmSync } from 'fs';
@@ -17,8 +18,6 @@ import { Credentials, InstanceSettings } from 'n8n-core';
 import { UnexpectedError, type ICredentialDataDecryptedObject } from 'n8n-workflow';
 import { writeFile as fsWriteFile, rm as fsRm } from 'node:fs/promises';
 import path from 'path';
-
-import { formatWorkflow } from '@/workflows/workflow.formatter';
 
 import {
 	SOURCE_CONTROL_CREDENTIAL_EXPORT_FOLDER,
@@ -43,6 +42,8 @@ import type { ExportableWorkflow } from './types/exportable-workflow';
 import type { RemoteResourceOwner } from './types/resource-owner';
 import type { SourceControlContext } from './types/source-control-context';
 import { VariablesService } from '../variables/variables.service.ee';
+
+import { formatWorkflow } from '@/workflows/workflow.formatter';
 
 @Service()
 export class SourceControlExportService {
@@ -145,7 +146,7 @@ export class SourceControlExportService {
 
 				if (project.type === 'personal') {
 					const ownerRelation = project.projectRelations.find(
-						(pr) => pr.role === 'project:personalOwner',
+						(pr) => pr.role.slug === PROJECT_OWNER_ROLE_SLUG,
 					);
 					if (!ownerRelation) {
 						throw new UnexpectedError(
@@ -409,7 +410,7 @@ export class SourceControlExportService {
 					let owner: RemoteResourceOwner | null = null;
 					if (sharing.project.type === 'personal') {
 						const ownerRelation = sharing.project.projectRelations.find(
-							(pr) => pr.role === 'project:personalOwner',
+							(pr) => pr.role.slug === PROJECT_OWNER_ROLE_SLUG,
 						);
 						if (ownerRelation) {
 							owner = {

--- a/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
@@ -148,7 +148,7 @@ export class SourceControlImportService {
 		});
 
 		const accessibleProjects =
-			await this.sourceControlScopedService.getAdminProjectsFromContext(context);
+			await this.sourceControlScopedService.getAuthorizedProjectsFromContext(context);
 
 		const remoteWorkflowsRead = await Promise.all(
 			remoteWorkflowFiles.map(async (file) => {
@@ -300,7 +300,7 @@ export class SourceControlImportService {
 		});
 
 		const accessibleProjects =
-			await this.sourceControlScopedService.getAdminProjectsFromContext(context);
+			await this.sourceControlScopedService.getAuthorizedProjectsFromContext(context);
 
 		const remoteCredentialFilesRead = await Promise.all(
 			remoteCredentialFiles.map(async (file) => {
@@ -426,7 +426,7 @@ export class SourceControlImportService {
 			});
 
 			const accessibleProjects =
-				await this.sourceControlScopedService.getAdminProjectsFromContext(context);
+				await this.sourceControlScopedService.getAuthorizedProjectsFromContext(context);
 
 			mappedFolders.folders = mappedFolders.folders.filter(
 				(folder) =>

--- a/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
@@ -15,6 +15,7 @@ import {
 	UserRepository,
 } from '@n8n/db';
 import { Service } from '@n8n/di';
+import { PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In } from '@n8n/typeorm';
 import glob from 'fast-glob';
@@ -22,14 +23,6 @@ import { Credentials, ErrorReporter, InstanceSettings } from 'n8n-core';
 import { jsonParse, ensureError, UserError, UnexpectedError } from 'n8n-workflow';
 import { readFile as fsReadFile } from 'node:fs/promises';
 import path from 'path';
-
-import { ActiveWorkflowManager } from '@/active-workflow-manager';
-import { CredentialsService } from '@/credentials/credentials.service';
-import type { IWorkflowToImport } from '@/interfaces';
-import { isUniqueConstraintError } from '@/response-helper';
-import { TagService } from '@/services/tag.service';
-import { assertNever } from '@/utils';
-import { WorkflowService } from '@/workflows/workflow.service';
 
 import {
 	SOURCE_CONTROL_CREDENTIAL_EXPORT_FOLDER,
@@ -52,6 +45,14 @@ import type { SourceControlContext } from './types/source-control-context';
 import type { SourceControlWorkflowVersionId } from './types/source-control-workflow-version-id';
 import { VariablesService } from '../variables/variables.service.ee';
 
+import { ActiveWorkflowManager } from '@/active-workflow-manager';
+import { CredentialsService } from '@/credentials/credentials.service';
+import type { IWorkflowToImport } from '@/interfaces';
+import { isUniqueConstraintError } from '@/response-helper';
+import { TagService } from '@/services/tag.service';
+import { assertNever } from '@/utils';
+import { WorkflowService } from '@/workflows/workflow.service';
+
 const findOwnerProject = (
 	owner: RemoteResourceOwner,
 	accessibleProjects: Project[],
@@ -59,7 +60,7 @@ const findOwnerProject = (
 	if (typeof owner === 'string') {
 		return accessibleProjects.find((project) =>
 			project.projectRelations.some(
-				(r) => r.role === 'project:personalOwner' && r.user.email === owner,
+				(r) => r.role.slug === PROJECT_OWNER_ROLE_SLUG && r.user.email === owner,
 			),
 		);
 	}
@@ -68,7 +69,7 @@ const findOwnerProject = (
 			(project) =>
 				project.type === 'personal' &&
 				project.projectRelations.some(
-					(r) => r.role === 'project:personalOwner' && r.user.email === owner.personalEmail,
+					(r) => r.role.slug === PROJECT_OWNER_ROLE_SLUG && r.user.email === owner.personalEmail,
 				),
 		);
 	}
@@ -82,7 +83,7 @@ const getOwnerFromProject = (remoteOwnerProject: Project): StatusResourceOwner |
 
 	if (remoteOwnerProject?.type === 'personal') {
 		const personalEmail = remoteOwnerProject.projectRelations?.find(
-			(r) => r.role === 'project:personalOwner',
+			(r) => r.role.slug === PROJECT_OWNER_ROLE_SLUG,
 		)?.user?.email;
 
 		if (personalEmail) {
@@ -251,7 +252,9 @@ export class SourceControlImportService {
 						name: true,
 						type: true,
 						projectRelations: {
-							role: true,
+							role: {
+								slug: true,
+							},
 							user: {
 								email: true,
 							},
@@ -368,7 +371,9 @@ export class SourceControlImportService {
 						name: true,
 						type: true,
 						projectRelations: {
-							role: true,
+							role: {
+								slug: true,
+							},
 							user: {
 								email: true,
 							},

--- a/packages/cli/src/environments.ee/source-control/source-control-scoped.service.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-scoped.service.ts
@@ -96,7 +96,7 @@ export class SourceControlScopedService {
 		return {
 			type: 'team',
 			projectRelations: {
-				roleEntity: {
+				role: {
 					scopes: {
 						slug: 'sourceControl:push',
 					},

--- a/packages/cli/src/environments.ee/source-control/source-control-scoped.service.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-scoped.service.ts
@@ -43,6 +43,7 @@ export class SourceControlScopedService {
 				relations: {
 					projectRelations: {
 						user: true,
+						role: true,
 					},
 				},
 			});
@@ -52,6 +53,7 @@ export class SourceControlScopedService {
 			relations: {
 				projectRelations: {
 					user: true,
+					role: true,
 				},
 			},
 			select: {

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -6,12 +6,16 @@ import {
 	WorkflowRepository,
 } from '@n8n/db';
 import { Service } from '@n8n/di';
+import { PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
 import { snakeCase } from 'change-case';
 import { BinaryDataConfig, InstanceSettings } from 'n8n-core';
 import type { ExecutionStatus, INodesGraphResult, ITelemetryTrackProperties } from 'n8n-workflow';
 import { TelemetryHelpers } from 'n8n-workflow';
 import os from 'node:os';
 import { get as pslGet } from 'psl';
+
+import { EventRelay } from './event-relay';
+import { Telemetry } from '../../telemetry';
 
 import config from '@/config';
 import { N8N_VERSION } from '@/constants';
@@ -21,9 +25,6 @@ import { determineFinalExecutionStatus } from '@/execution-lifecycle/shared/shar
 import type { IExecutionTrackProperties } from '@/interfaces';
 import { License } from '@/license';
 import { NodeTypes } from '@/node-types';
-
-import { EventRelay } from './event-relay';
-import { Telemetry } from '../../telemetry';
 
 @Service()
 export class TelemetryEventRelay extends EventRelay {
@@ -604,7 +605,7 @@ export class TelemetryEventRelay extends EventRelay {
 					projectId: workflowOwner.id,
 				});
 
-				if (projectRole && projectRole !== 'project:personalOwner') {
+				if (projectRole && projectRole?.slug !== PROJECT_OWNER_ROLE_SLUG) {
 					userRole = 'member';
 				}
 			}

--- a/packages/cli/src/executions/executions.controller.ts
+++ b/packages/cli/src/executions/executions.controller.ts
@@ -1,18 +1,18 @@
 import type { User, ExecutionSummaries } from '@n8n/db';
 import { Get, Patch, Post, RestController } from '@n8n/decorators';
-import type { Scope } from '@n8n/permissions';
-
-import { BadRequestError } from '@/errors/response-errors/bad-request.error';
-import { NotFoundError } from '@/errors/response-errors/not-found.error';
-import { License } from '@/license';
-import { isPositiveInteger } from '@/utils';
-import { WorkflowSharingService } from '@/workflows/workflow-sharing.service';
+import { PROJECT_OWNER_ROLE_SLUG, type Scope } from '@n8n/permissions';
 
 import { ExecutionService } from './execution.service';
 import { EnterpriseExecutionsService } from './execution.service.ee';
 import { ExecutionRequest } from './execution.types';
 import { parseRangeQuery } from './parse-range-query.middleware';
 import { validateExecutionUpdatePayload } from './validation';
+
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { License } from '@/license';
+import { isPositiveInteger } from '@/utils';
+import { WorkflowSharingService } from '@/workflows/workflow-sharing.service';
 
 @RestController('/executions')
 export class ExecutionsController {
@@ -29,7 +29,7 @@ export class ExecutionsController {
 		} else {
 			return await this.workflowSharingService.getSharedWorkflowIds(user, {
 				workflowRoles: ['workflow:owner'],
-				projectRoles: ['project:personalOwner'],
+				projectRoles: [PROJECT_OWNER_ROLE_SLUG],
 			});
 		}
 	}

--- a/packages/cli/src/modules/data-table/__tests__/data-store-aggregate.service.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/data-store-aggregate.service.test.ts
@@ -1,5 +1,6 @@
 import { createTeamProject, testDb, testModules } from '@n8n/backend-test-utils';
 import {
+	type Role,
 	GLOBAL_MEMBER_ROLE,
 	GLOBAL_OWNER_ROLE,
 	ProjectRelationRepository,
@@ -71,7 +72,7 @@ describe('dataStoreAggregate', () => {
 				{
 					userId: user.id,
 					projectId: project1.id,
-					role: 'project:admin',
+					role: { slug: 'project:admin' } as Role,
 					user,
 					project: project1,
 					createdAt: new Date(),
@@ -81,7 +82,7 @@ describe('dataStoreAggregate', () => {
 				{
 					userId: user.id,
 					projectId: project2.id,
-					role: 'project:viewer',
+					role: { slug: 'project:viewer' } as Role,
 					user,
 					project: project2,
 					createdAt: new Date(),
@@ -147,7 +148,7 @@ describe('dataStoreAggregate', () => {
 				{
 					userId: user.id,
 					projectId: project1.id,
-					role: 'project:admin',
+					role: { slug: 'project:admin' } as Role,
 					user,
 					project: project1,
 					createdAt: new Date(),
@@ -157,7 +158,7 @@ describe('dataStoreAggregate', () => {
 				{
 					userId: user.id,
 					projectId: project2.id,
-					role: 'project:viewer',
+					role: { slug: 'project:viewer' } as Role,
 					user,
 					project: project2,
 					createdAt: new Date(),
@@ -196,7 +197,7 @@ describe('dataStoreAggregate', () => {
 				{
 					userId: user.id,
 					projectId: project1.id,
-					role: 'project:admin',
+					role: { slug: 'project:admin' } as Role,
 					user,
 					project: project1,
 					createdAt: new Date(),

--- a/packages/cli/src/modules/data-table/__tests__/data-store-aggregate.service.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/data-store-aggregate.service.test.ts
@@ -6,6 +6,7 @@ import {
 	ProjectRelationRepository,
 	type Project,
 	type User,
+	PROJECT_ADMIN_ROLE,
 } from '@n8n/db';
 import { Container } from '@n8n/di';
 import type { EntityManager } from '@n8n/typeorm';
@@ -72,7 +73,7 @@ describe('dataStoreAggregate', () => {
 				{
 					userId: user.id,
 					projectId: project1.id,
-					role: { slug: 'project:admin' } as Role,
+					role: PROJECT_ADMIN_ROLE,
 					user,
 					project: project1,
 					createdAt: new Date(),
@@ -148,7 +149,7 @@ describe('dataStoreAggregate', () => {
 				{
 					userId: user.id,
 					projectId: project1.id,
-					role: { slug: 'project:admin' } as Role,
+					role: PROJECT_ADMIN_ROLE,
 					user,
 					project: project1,
 					createdAt: new Date(),
@@ -197,7 +198,7 @@ describe('dataStoreAggregate', () => {
 				{
 					userId: user.id,
 					projectId: project1.id,
-					role: { slug: 'project:admin' } as Role,
+					role: PROJECT_ADMIN_ROLE,
 					user,
 					project: project1,
 					createdAt: new Date(),

--- a/packages/cli/src/permissions.ee/__tests__/check-access.test.ts
+++ b/packages/cli/src/permissions.ee/__tests__/check-access.test.ts
@@ -32,15 +32,20 @@ describe('userHasScopes', () => {
 			}),
 		);
 
+		const mockQueryBuilder = {
+			innerJoin: jest.fn().mockReturnThis(),
+			where: jest.fn().mockReturnThis(),
+			andWhere: jest.fn().mockReturnThis(),
+			groupBy: jest.fn().mockReturnThis(),
+			having: jest.fn().mockReturnThis(),
+			select: jest.fn().mockReturnThis(),
+			getRawMany: jest.fn().mockResolvedValue([{ id: 'projectId' }]),
+		};
+
 		Container.set(
 			ProjectRepository,
 			mock<ProjectRepository>({
-				find: jest.fn().mockResolvedValue([
-					{
-						id: 'projectId',
-						projectRelations: [{ userId: 'userId', role: 'project:admin' }],
-					},
-				]),
+				createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
 			}),
 		);
 	});

--- a/packages/cli/src/permissions.ee/check-access.ts
+++ b/packages/cli/src/permissions.ee/check-access.ts
@@ -2,8 +2,6 @@ import type { User } from '@n8n/db';
 import { ProjectRepository, SharedCredentialsRepository, SharedWorkflowRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { hasGlobalScope, rolesWithScope, type Scope } from '@n8n/permissions';
-// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
-import { In } from '@n8n/typeorm';
 import { UnexpectedError } from 'n8n-workflow';
 
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
@@ -30,21 +28,21 @@ export async function userHasScopes(
 
 	if (globalOnly) return false;
 
-	// Find which project roles are defined to contain the required scopes.
-	// Then find projects having this user and having those project roles.
-
-	const projectRoles = rolesWithScope('project', scopes);
+	// Find which projects the user has access to with the required scopes.
+	// This is done by finding the projects where the user has a role with at least the required scopes
 	const userProjectIds = (
-		await Container.get(ProjectRepository).find({
-			where: {
-				projectRelations: {
-					userId: user.id,
-					role: In(projectRoles),
-				},
-			},
-			select: ['id'],
-		})
-	).map((p) => p.id);
+		await Container.get(ProjectRepository)
+			.createQueryBuilder('project')
+			.innerJoin('project.projectRelations', 'relation')
+			.innerJoin('relation.roleEntity', 'role')
+			.innerJoin('role.scopes', 'scope')
+			.where('relation.userId = :userId', { userId: user.id })
+			.andWhere('scope.slug IN (:...scopes)', { scopes })
+			.groupBy('project.id')
+			.having('COUNT(DISTINCT scope.slug) = :scopeCount', { scopeCount: scopes.length })
+			.select(['project.id AS id'])
+			.getRawMany()
+	).map((row: { id: string }) => row.id);
 
 	// Find which resource roles are defined to contain the required scopes.
 	// Then find at least one of the above qualifying projects having one of

--- a/packages/cli/src/permissions.ee/check-access.ts
+++ b/packages/cli/src/permissions.ee/check-access.ts
@@ -34,7 +34,7 @@ export async function userHasScopes(
 		await Container.get(ProjectRepository)
 			.createQueryBuilder('project')
 			.innerJoin('project.projectRelations', 'relation')
-			.innerJoin('relation.roleEntity', 'role')
+			.innerJoin('relation.role', 'role')
 			.innerJoin('role.scopes', 'scope')
 			.where('relation.userId = :userId', { userId: user.id })
 			.andWhere('scope.slug IN (:...scopes)', { scopes })

--- a/packages/cli/src/public-api/v1/handlers/workflows/workflows.service.ts
+++ b/packages/cli/src/public-api/v1/handlers/workflows/workflows.service.ts
@@ -9,7 +9,7 @@ import {
 	WorkflowRepository,
 } from '@n8n/db';
 import { Container } from '@n8n/di';
-import type { Scope, WorkflowSharingRole } from '@n8n/permissions';
+import { PROJECT_OWNER_ROLE_SLUG, type Scope, type WorkflowSharingRole } from '@n8n/permissions';
 import type { WorkflowId } from 'n8n-workflow';
 
 import { License } from '@/license';
@@ -32,7 +32,7 @@ export async function getSharedWorkflowIds(
 	} else {
 		return await Container.get(WorkflowSharingService).getSharedWorkflowIds(user, {
 			workflowRoles: ['workflow:owner'],
-			projectRoles: ['project:personalOwner'],
+			projectRoles: [PROJECT_OWNER_ROLE_SLUG],
 			projectId,
 		});
 	}

--- a/packages/cli/src/requests.ts
+++ b/packages/cli/src/requests.ts
@@ -8,7 +8,13 @@ import type {
 	ListQueryDb,
 	WorkflowHistory,
 } from '@n8n/db';
-import type { AssignableGlobalRole, ProjectRole, Scope } from '@n8n/permissions';
+import type {
+	AssignableGlobalRole,
+	CustomRole,
+	GlobalRole,
+	ProjectRole,
+	Scope,
+} from '@n8n/permissions';
 import type {
 	ICredentialDataDecryptedObject,
 	INodeCredentialTestRequest,
@@ -268,14 +274,16 @@ export declare namespace ActiveWorkflowRequest {
 // ----------------------------------
 
 export declare namespace ProjectRequest {
-	type GetMyProjectsResponse = Array<Project & { role: string; scopes?: Scope[] }>;
+	type GetMyProjectsResponse = Array<
+		Project & { role: ProjectRole | GlobalRole | CustomRole; scopes?: Scope[] }
+	>;
 
 	type ProjectRelationResponse = {
 		id: string;
 		email: string;
 		firstName: string;
 		lastName: string;
-		role: ProjectRole;
+		role: ProjectRole | CustomRole;
 	};
 	type ProjectWithRelations = {
 		id: string;

--- a/packages/cli/src/services/__tests__/credentials-finder.service.test.ts
+++ b/packages/cli/src/services/__tests__/credentials-finder.service.test.ts
@@ -1,11 +1,17 @@
 import { GLOBAL_MEMBER_ROLE, GLOBAL_OWNER_ROLE, SharedCredentials } from '@n8n/db';
 import type { CredentialsEntity, User } from '@n8n/db';
 import { Container } from '@n8n/di';
+import {
+	PROJECT_ADMIN_ROLE_SLUG,
+	PROJECT_EDITOR_ROLE_SLUG,
+	PROJECT_OWNER_ROLE_SLUG,
+	PROJECT_VIEWER_ROLE_SLUG,
+} from '@n8n/permissions';
 import { In } from '@n8n/typeorm';
+import { mockEntityManager } from '@test/mocking';
 import { mock } from 'jest-mock-extended';
 
 import { CredentialsFinderService } from '@/credentials/credentials-finder.service';
-import { mockEntityManager } from '@test/mocking';
 
 describe('CredentialsFinderService', () => {
 	const entityManager = mockEntityManager(SharedCredentials);
@@ -57,7 +63,7 @@ describe('CredentialsFinderService', () => {
 						projectRelations: {
 							role: In([
 								'project:admin',
-								'project:personalOwner',
+								PROJECT_OWNER_ROLE_SLUG,
 								'project:editor',
 								'project:viewer',
 							]),
@@ -84,10 +90,10 @@ describe('CredentialsFinderService', () => {
 					project: {
 						projectRelations: {
 							role: In([
-								'project:admin',
-								'project:personalOwner',
-								'project:editor',
-								'project:viewer',
+								PROJECT_ADMIN_ROLE_SLUG,
+								PROJECT_OWNER_ROLE_SLUG,
+								PROJECT_EDITOR_ROLE_SLUG,
+								PROJECT_VIEWER_ROLE_SLUG,
 							]),
 							userId: member.id,
 						},

--- a/packages/cli/src/services/__tests__/credentials-finder.service.test.ts
+++ b/packages/cli/src/services/__tests__/credentials-finder.service.test.ts
@@ -62,10 +62,10 @@ describe('CredentialsFinderService', () => {
 					project: {
 						projectRelations: {
 							role: In([
-								'project:admin',
+								PROJECT_ADMIN_ROLE_SLUG,
 								PROJECT_OWNER_ROLE_SLUG,
-								'project:editor',
-								'project:viewer',
+								PROJECT_EDITOR_ROLE_SLUG,
+								PROJECT_VIEWER_ROLE_SLUG,
 							]),
 							userId: member.id,
 						},

--- a/packages/cli/src/services/__tests__/ownership.service.test.ts
+++ b/packages/cli/src/services/__tests__/ownership.service.test.ts
@@ -11,12 +11,13 @@ import {
 	UserRepository,
 	GLOBAL_OWNER_ROLE,
 } from '@n8n/db';
+import { PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
+import { mockCredential, mockProject } from '@test/mock-objects';
 import { v4 as uuid } from 'uuid';
 
-import { OwnershipService } from '@/services/ownership.service';
-import { mockCredential, mockProject } from '@test/mock-objects';
-
 import { CacheService } from '../cache/cache.service';
+
+import { OwnershipService } from '@/services/ownership.service';
 
 describe('OwnershipService', () => {
 	const userRepository = mockInstance(UserRepository);
@@ -64,7 +65,7 @@ describe('OwnershipService', () => {
 			const owner = new User();
 			owner.role = GLOBAL_OWNER_ROLE;
 			const projectRelation = new ProjectRelation();
-			projectRelation.role = 'project:personalOwner';
+			projectRelation.role = { slug: PROJECT_OWNER_ROLE_SLUG } as any;
 			(projectRelation.project = project), (projectRelation.user = owner);
 
 			projectRelationRepository.getPersonalProjectOwners.mockResolvedValueOnce([projectRelation]);
@@ -92,7 +93,7 @@ describe('OwnershipService', () => {
 			owner.id = uuid();
 			owner.role = GLOBAL_OWNER_ROLE;
 			const projectRelation = new ProjectRelation();
-			projectRelation.role = 'project:personalOwner';
+			projectRelation.role = { slug: PROJECT_OWNER_ROLE_SLUG } as any;
 			(projectRelation.project = project), (projectRelation.user = owner);
 
 			cacheService.getHashValue.mockResolvedValueOnce(owner);
@@ -116,7 +117,7 @@ describe('OwnershipService', () => {
 			mockOwner.role = GLOBAL_OWNER_ROLE;
 
 			const projectRelation = Object.assign(new ProjectRelation(), {
-				role: 'project:personalOwner',
+				role: PROJECT_OWNER_ROLE_SLUG,
 				project: mockProject,
 				user: mockOwner,
 			});

--- a/packages/cli/src/services/__tests__/ownership.service.test.ts
+++ b/packages/cli/src/services/__tests__/ownership.service.test.ts
@@ -10,14 +10,15 @@ import {
 	SharedWorkflowRepository,
 	UserRepository,
 	GLOBAL_OWNER_ROLE,
+	PROJECT_OWNER_ROLE,
 } from '@n8n/db';
 import { PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
-import { mockCredential, mockProject } from '@test/mock-objects';
 import { v4 as uuid } from 'uuid';
 
-import { CacheService } from '../cache/cache.service';
-
 import { OwnershipService } from '@/services/ownership.service';
+import { mockCredential, mockProject } from '@test/mock-objects';
+
+import { CacheService } from '../cache/cache.service';
 
 describe('OwnershipService', () => {
 	const userRepository = mockInstance(UserRepository);
@@ -65,7 +66,7 @@ describe('OwnershipService', () => {
 			const owner = new User();
 			owner.role = GLOBAL_OWNER_ROLE;
 			const projectRelation = new ProjectRelation();
-			projectRelation.role = { slug: PROJECT_OWNER_ROLE_SLUG } as any;
+			projectRelation.role = PROJECT_OWNER_ROLE;
 			(projectRelation.project = project), (projectRelation.user = owner);
 
 			projectRelationRepository.getPersonalProjectOwners.mockResolvedValueOnce([projectRelation]);

--- a/packages/cli/src/services/__tests__/project.service.ee.test.ts
+++ b/packages/cli/src/services/__tests__/project.service.ee.test.ts
@@ -7,6 +7,7 @@ import type {
 	ProjectRelationRepository,
 	SharedCredentials,
 } from '@n8n/db';
+import { PROJECT_ADMIN_ROLE_SLUG, PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
 import type { EntityManager } from '@n8n/typeorm';
 import { mock } from 'jest-mock-extended';
 
@@ -58,7 +59,7 @@ describe('ProjectService', () => {
 			// ACT & ASSERT
 			await expect(
 				projectService.addUsersToProject(projectId, [
-					{ userId: '1234', role: 'project:personalOwner' },
+					{ userId: '1234', role: PROJECT_OWNER_ROLE_SLUG },
 				]),
 			).rejects.toThrowError("Can't add a personalOwner to a team project.");
 		});
@@ -139,7 +140,7 @@ describe('ProjectService', () => {
 				mock<Project>({
 					id: projectId,
 					type: 'team',
-					projectRelations: [{ userId: 'user1', role: 'project:admin' }],
+					projectRelations: [{ userId: 'user1', role: { slug: PROJECT_ADMIN_ROLE_SLUG } }] as any,
 				}),
 			);
 			roleService.isRoleLicensed.mockReturnValue(false);
@@ -156,9 +157,9 @@ describe('ProjectService', () => {
 
 	describe('changeUserRoleInProject', () => {
 		const projectId = '12345';
-		const mockRelations: ProjectRelation[] = [
-			{ userId: 'user1', role: 'project:admin' },
-			{ userId: 'user2', role: 'project:viewer' },
+		const mockRelations = [
+			{ userId: 'user1', role: { slug: 'project:admin' } },
+			{ userId: 'user2', role: { slug: 'project:viewer' } },
 		];
 
 		beforeEach(() => {
@@ -190,7 +191,7 @@ describe('ProjectService', () => {
 
 			expect(projectRelationRepository.update).toHaveBeenCalledWith(
 				{ projectId, userId: 'user2' },
-				{ role: 'project:admin' },
+				{ role: { slug: 'project:admin' } },
 			);
 		});
 
@@ -216,7 +217,7 @@ describe('ProjectService', () => {
 
 		it('should throw if the role to be set is `project:personalOwner`', async () => {
 			await expect(
-				projectService.changeUserRoleInProject(projectId, 'user2', 'project:personalOwner'),
+				projectService.changeUserRoleInProject(projectId, 'user2', PROJECT_OWNER_ROLE_SLUG),
 			).rejects.toThrow('Personal owner cannot be added to a team project.');
 		});
 

--- a/packages/cli/src/services/__tests__/project.service.ee.test.ts
+++ b/packages/cli/src/services/__tests__/project.service.ee.test.ts
@@ -101,7 +101,7 @@ describe('ProjectService', () => {
 
 			expect(projectRepository.findOne).toHaveBeenCalledWith({
 				where: { id: projectId, type: 'team' },
-				relations: { projectRelations: true },
+				relations: { projectRelations: { role: true } },
 			});
 
 			expect(manager.delete).toHaveBeenCalled();
@@ -186,7 +186,7 @@ describe('ProjectService', () => {
 
 			expect(projectRepository.findOne).toHaveBeenCalledWith({
 				where: { id: projectId, type: 'team' },
-				relations: { projectRelations: true },
+				relations: { projectRelations: { role: true } },
 			});
 
 			expect(projectRelationRepository.update).toHaveBeenCalledWith(
@@ -211,7 +211,7 @@ describe('ProjectService', () => {
 
 			expect(projectRepository.findOne).toHaveBeenCalledWith({
 				where: { id: projectId, type: 'team' },
-				relations: { projectRelations: true },
+				relations: { projectRelations: { role: true } },
 			});
 		});
 
@@ -231,7 +231,7 @@ describe('ProjectService', () => {
 
 			expect(projectRepository.findOne).toHaveBeenCalledWith({
 				where: { id: projectId, type: 'team' },
-				relations: { projectRelations: true },
+				relations: { projectRelations: { role: true } },
 			});
 		});
 	});

--- a/packages/cli/src/services/__tests__/project.service.ee.test.ts
+++ b/packages/cli/src/services/__tests__/project.service.ee.test.ts
@@ -1,13 +1,14 @@
 import type { ProjectRelation } from '@n8n/api-types';
 import type { DatabaseConfig } from '@n8n/config';
-import type {
-	Project,
-	ProjectRepository,
-	SharedCredentialsRepository,
-	ProjectRelationRepository,
-	SharedCredentials,
+import {
+	type Project,
+	type ProjectRepository,
+	type SharedCredentialsRepository,
+	type ProjectRelationRepository,
+	type SharedCredentials,
+	PROJECT_ADMIN_ROLE,
 } from '@n8n/db';
-import { PROJECT_ADMIN_ROLE_SLUG, PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
+import { PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
 import type { EntityManager } from '@n8n/typeorm';
 import { mock } from 'jest-mock-extended';
 
@@ -140,7 +141,7 @@ describe('ProjectService', () => {
 				mock<Project>({
 					id: projectId,
 					type: 'team',
-					projectRelations: [{ userId: 'user1', role: { slug: PROJECT_ADMIN_ROLE_SLUG } }] as any,
+					projectRelations: [{ userId: 'user1', role: PROJECT_ADMIN_ROLE }],
 				}),
 			);
 			roleService.isRoleLicensed.mockReturnValue(false);

--- a/packages/cli/src/services/project.service.ee.ts
+++ b/packages/cli/src/services/project.service.ee.ts
@@ -265,7 +265,7 @@ export class ProjectService {
 	async getProjectRelationsForUser(user: User): Promise<ProjectRelation[]> {
 		return await this.projectRelationRepository.find({
 			where: { userId: user.id },
-			relations: ['project'],
+			relations: ['project', 'role'],
 		});
 	}
 
@@ -322,7 +322,7 @@ export class ProjectService {
 	private async getTeamProjectWithRelations(projectId: string) {
 		const project = await this.projectRepository.findOne({
 			where: { id: projectId, type: 'team' },
-			relations: { projectRelations: true },
+			relations: { projectRelations: { role: true } },
 		});
 		ProjectNotFoundError.isDefinedAndNotNull(project, projectId);
 		return project;
@@ -471,7 +471,7 @@ export class ProjectService {
 	async getProjectRelations(projectId: string): Promise<ProjectRelation[]> {
 		return await this.projectRelationRepository.find({
 			where: { projectId },
-			relations: { user: true },
+			relations: { user: true, role: true },
 		});
 	}
 

--- a/packages/cli/src/services/project.service.ee.ts
+++ b/packages/cli/src/services/project.service.ee.ts
@@ -19,6 +19,7 @@ import {
 	type ProjectRole,
 	CustomRole,
 	PROJECT_OWNER_ROLE_SLUG,
+	PROJECT_ADMIN_ROLE_SLUG,
 } from '@n8n/permissions';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import type { FindOptionsWhere, EntityManager } from '@n8n/typeorm';
@@ -26,12 +27,12 @@ import type { FindOptionsWhere, EntityManager } from '@n8n/typeorm';
 import { In } from '@n8n/typeorm';
 import { UserError } from 'n8n-workflow';
 
-import { CacheService } from './cache/cache.service';
-import { RoleService } from './role.service';
-
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
+
+import { CacheService } from './cache/cache.service';
+import { RoleService } from './role.service';
 
 export class TeamProjectOverQuotaError extends UserError {
 	constructor(limit: number) {
@@ -480,7 +481,7 @@ export class ProjectService {
 			where: {
 				projectRelations: {
 					userId,
-					role: In([PROJECT_OWNER_ROLE_SLUG, 'project:admin']),
+					role: In([PROJECT_OWNER_ROLE_SLUG, PROJECT_ADMIN_ROLE_SLUG]),
 				},
 			},
 		});

--- a/packages/cli/src/services/role.service.ts
+++ b/packages/cli/src/services/role.service.ts
@@ -97,7 +97,7 @@ export class RoleService {
 			);
 			let projectScopes: Scope[] = [];
 			if (pr) {
-				projectScopes = pr.roleEntity.scopes.map((s) => s.slug);
+				projectScopes = pr.role.scopes.map((s) => s.slug);
 			}
 			const resourceMask = getRoleScopes(sharedEntity.role);
 			const mergedScopes = combineScopes(

--- a/packages/cli/src/services/role.service.ts
+++ b/packages/cli/src/services/role.service.ts
@@ -8,7 +8,7 @@ import type {
 	ProjectRelation,
 } from '@n8n/db';
 import { Service } from '@n8n/di';
-import type { AllRoleTypes, Scope } from '@n8n/permissions';
+import type { CustomRole, ProjectRole, Scope } from '@n8n/permissions';
 import { ALL_ROLES, combineScopes, getAuthPrincipalScopes, getRoleScopes } from '@n8n/permissions';
 import { UnexpectedError } from 'n8n-workflow';
 
@@ -97,7 +97,7 @@ export class RoleService {
 			);
 			let projectScopes: Scope[] = [];
 			if (pr) {
-				projectScopes = getRoleScopes(pr.role);
+				projectScopes = pr.roleEntity.scopes.map((s) => s.slug);
 			}
 			const resourceMask = getRoleScopes(sharedEntity.role);
 			const mergedScopes = combineScopes(
@@ -112,7 +112,7 @@ export class RoleService {
 		return [...scopesSet].sort();
 	}
 
-	isRoleLicensed(role: AllRoleTypes) {
+	isRoleLicensed(role: ProjectRole | CustomRole) {
 		// TODO: move this info into FrontendSettings
 		switch (role) {
 			case 'project:admin':
@@ -124,6 +124,7 @@ export class RoleService {
 			case 'global:admin':
 				return this.license.isAdvancedPermissionsLicensed();
 			default:
+				// TODO: handle custom roles licensing
 				return true;
 		}
 	}

--- a/packages/cli/src/workflows/workflow-sharing.service.ts
+++ b/packages/cli/src/workflows/workflow-sharing.service.ts
@@ -7,6 +7,7 @@ import {
 	type ProjectRole,
 	type WorkflowSharingRole,
 	type Scope,
+	PROJECT_OWNER_ROLE_SLUG,
 } from '@n8n/permissions';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In } from '@n8n/typeorm';
@@ -74,7 +75,7 @@ export class WorkflowSharingService {
 				project: {
 					projectRelations: {
 						userId: user.id,
-						role: 'project:personalOwner',
+						role: { slug: PROJECT_OWNER_ROLE_SLUG },
 					},
 				},
 			},
@@ -115,7 +116,7 @@ export class WorkflowSharingService {
 				project: {
 					projectRelations: {
 						userId: user.id,
-						role: 'project:personalOwner',
+						role: { slug: PROJECT_OWNER_ROLE_SLUG },
 					},
 				},
 			},

--- a/packages/cli/src/workflows/workflow.service.ee.ts
+++ b/packages/cli/src/workflows/workflow.service.ee.ts
@@ -23,6 +23,8 @@ import omit from 'lodash/omit';
 import type { IWorkflowBase, WorkflowId } from 'n8n-workflow';
 import { NodeOperationError, PROJECT_ROOT, UserError, WorkflowActivationError } from 'n8n-workflow';
 
+import { WorkflowFinderService } from './workflow-finder.service';
+
 import { ActiveWorkflowManager } from '@/active-workflow-manager';
 import { CredentialsFinderService } from '@/credentials/credentials-finder.service';
 import { CredentialsService } from '@/credentials/credentials.service';
@@ -33,8 +35,6 @@ import { TransferWorkflowError } from '@/errors/response-errors/transfer-workflo
 import { FolderService } from '@/services/folder.service';
 import { OwnershipService } from '@/services/ownership.service';
 import { ProjectService } from '@/services/project.service.ee';
-
-import { WorkflowFinderService } from './workflow-finder.service';
 
 @Service()
 export class EnterpriseWorkflowService {
@@ -74,7 +74,7 @@ export class EnterpriseWorkflowService {
 		);
 
 		const newSharedWorkflows = projects
-			// We filter by role === 'project:personalOwner' above and there should
+			// We filter by role === PROJECT_OWNER_ROLE_SLUG above and there should
 			// always only be one owner.
 			.map((project) =>
 				this.sharedWorkflowRepository.create({

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -30,12 +30,21 @@ import {
 	Query,
 	RestController,
 } from '@n8n/decorators';
+import { PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In, type FindOptionsRelations } from '@n8n/typeorm';
 import axios from 'axios';
 import express from 'express';
 import { UnexpectedError } from 'n8n-workflow';
 import { v4 as uuid } from 'uuid';
+
+import { WorkflowExecutionService } from './workflow-execution.service';
+import { WorkflowFinderService } from './workflow-finder.service';
+import { WorkflowHistoryService } from './workflow-history.ee/workflow-history.service.ee';
+import { WorkflowRequest } from './workflow.request';
+import { WorkflowService } from './workflow.service';
+import { EnterpriseWorkflowService } from './workflow.service.ee';
+import { CredentialsService } from '../credentials/credentials.service';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
@@ -55,14 +64,6 @@ import { TagService } from '@/services/tag.service';
 import { UserManagementMailer } from '@/user-management/email';
 import * as utils from '@/utils';
 import * as WorkflowHelpers from '@/workflow-helpers';
-
-import { WorkflowExecutionService } from './workflow-execution.service';
-import { WorkflowFinderService } from './workflow-finder.service';
-import { WorkflowHistoryService } from './workflow-history.ee/workflow-history.service.ee';
-import { WorkflowRequest } from './workflow.request';
-import { WorkflowService } from './workflow.service';
-import { EnterpriseWorkflowService } from './workflow.service.ee';
-import { CredentialsService } from '../credentials/credentials.service';
 
 @RestController('/workflows')
 export class WorkflowsController {
@@ -535,7 +536,7 @@ export class WorkflowsController {
 
 		const projectsRelations = await this.projectRelationRepository.findBy({
 			projectId: In(newShareeIds),
-			role: 'project:personalOwner',
+			role: { slug: PROJECT_OWNER_ROLE_SLUG },
 		});
 
 		await this.mailer.notifyWorkflowShared({

--- a/packages/cli/test/integration/api-keys.api.test.ts
+++ b/packages/cli/test/integration/api-keys.api.test.ts
@@ -328,7 +328,6 @@ describe('Member', () => {
 			.post('/api-keys')
 			.send({ label: 'My API Key', expiresAt: null, scopes: ['workflow:create'] });
 
-		console.log(newApiKeyResponse.body);
 		expect(newApiKeyResponse.statusCode).toBe(200);
 		expect(newApiKeyResponse.body.data.apiKey).toBeDefined();
 		expect(newApiKeyResponse.body.data.apiKey).not.toBeNull();

--- a/packages/cli/test/integration/controllers/invitation/invitation.controller.integration.test.ts
+++ b/packages/cli/test/integration/controllers/invitation/invitation.controller.integration.test.ts
@@ -13,12 +13,8 @@ import {
 	UserRepository,
 } from '@n8n/db';
 import { Container } from '@n8n/di';
+import { PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
 import { Not } from '@n8n/typeorm';
-
-import { EventService } from '@/events/event.service';
-import { ExternalHooks } from '@/external-hooks';
-import { PasswordUtility } from '@/services/password.utility';
-import { UserManagementMailer } from '@/user-management/email';
 
 import {
 	assertReturnedUserProps,
@@ -28,6 +24,11 @@ import {
 import { createMember, createOwner, createUserShell } from '../../shared/db/users';
 import * as utils from '../../shared/utils';
 import type { UserInvitationResult } from '../../shared/utils/users';
+
+import { EventService } from '@/events/event.service';
+import { ExternalHooks } from '@/external-hooks';
+import { PasswordUtility } from '@/services/password.utility';
+import { UserManagementMailer } from '@/user-management/email';
 
 describe('InvitationController', () => {
 	const mailer = mockInstance(UserManagementMailer);
@@ -296,7 +297,7 @@ describe('InvitationController', () => {
 			const projectRelation = await projectRelationRepository.findOneOrFail({
 				where: {
 					userId: storedUser.id,
-					role: 'project:personalOwner',
+					role: { slug: PROJECT_OWNER_ROLE_SLUG },
 					project: {
 						type: 'personal',
 					},

--- a/packages/cli/test/integration/project.service.integration.test.ts
+++ b/packages/cli/test/integration/project.service.integration.test.ts
@@ -61,7 +61,7 @@ describe('ProjectService', () => {
 			expect(relations[0]).toMatchObject({
 				projectId: project.id,
 				userId: user.id,
-				role: 'project:admin',
+				role: { slug: 'project:admin' },
 			});
 		});
 
@@ -82,7 +82,7 @@ describe('ProjectService', () => {
 			expect(relations[0]).toMatchObject({
 				projectId: project.id,
 				userId: user.id,
-				role: 'project:editor',
+				role: { slug: 'project:editor' },
 			});
 		});
 	});
@@ -103,7 +103,7 @@ describe('ProjectService', () => {
 			expect(relations[0]).toMatchObject({
 				projectId: project.id,
 				userId: user.id,
-				role: 'project:admin',
+				role: { slug: 'project:admin' },
 			});
 		});
 	});

--- a/packages/cli/test/integration/public-api/projects.test.ts
+++ b/packages/cli/test/integration/public-api/projects.test.ts
@@ -564,23 +564,20 @@ describe('Projects in Public API', () => {
 
 				expect(projectAfter.length).toEqual(3);
 				const adminRelation = projectAfter.find(
-					(relation) => relation.userId === owner.id && relation.role === 'project:admin',
+					(relation) => relation.userId === owner.id && relation.role.slug === 'project:admin',
 				);
-				expect(adminRelation).toEqual(
-					expect.objectContaining({ userId: owner.id, role: 'project:admin' }),
-				);
+				expect(adminRelation!.userId).toBe(owner.id);
+				expect(adminRelation!.role.slug).toBe('project:admin');
 				const viewerRelation = projectAfter.find(
-					(relation) => relation.userId === member.id && relation.role === 'project:viewer',
+					(relation) => relation.userId === member.id && relation.role.slug === 'project:viewer',
 				);
-				expect(viewerRelation).toEqual(
-					expect.objectContaining({ userId: member.id, role: 'project:viewer' }),
-				);
+				expect(viewerRelation!.userId).toBe(member.id);
+				expect(viewerRelation!.role.slug).toBe('project:viewer');
 				const editorRelation = projectAfter.find(
-					(relation) => relation.userId === member2.id && relation.role === 'project:editor',
+					(relation) => relation.userId === member2.id && relation.role.slug === 'project:editor',
 				);
-				expect(editorRelation).toEqual(
-					expect.objectContaining({ userId: member2.id, role: 'project:editor' }),
-				);
+				expect(editorRelation!.userId).toBe(member2.id);
+				expect(editorRelation!.role.slug).toBe('project:editor');
 			});
 
 			it('should reject with 400 if license does not include user role', async () => {
@@ -797,8 +794,12 @@ describe('Projects in Public API', () => {
 
 				expect(response.status).toBe(204);
 				expect(projectBefore.length).toEqual(2);
-				expect(projectBefore.find((p) => p.role === 'project:admin')?.userId).toEqual(owner.id);
-				expect(projectBefore.find((p) => p.role === 'project:viewer')?.userId).toEqual(member.id);
+				expect(projectBefore.find((p) => p.role.slug === 'project:admin')?.userId).toEqual(
+					owner.id,
+				);
+				expect(projectBefore.find((p) => p.role.slug === 'project:viewer')?.userId).toEqual(
+					member.id,
+				);
 
 				expect(projectAfter.length).toEqual(1);
 				expect(projectAfter[0].userId).toEqual(owner.id);

--- a/packages/cli/test/integration/role.api.test.ts
+++ b/packages/cli/test/integration/role.api.test.ts
@@ -1,4 +1,4 @@
-import { getRoleScopes } from '@n8n/permissions';
+import { getRoleScopes, PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
 import type {
 	GlobalRole,
 	ProjectRole,
@@ -76,8 +76,8 @@ beforeAll(async () => {
 	expectedProjectRoles = [
 		{
 			name: 'Project Owner',
-			role: 'project:personalOwner',
-			scopes: getRoleScopes('project:personalOwner'),
+			role: PROJECT_OWNER_ROLE_SLUG,
+			scopes: getRoleScopes(PROJECT_OWNER_ROLE_SLUG),
 			licensed: true,
 			description: 'Project Owner',
 		},

--- a/packages/cli/test/integration/services/project.service.test.ts
+++ b/packages/cli/test/integration/services/project.service.test.ts
@@ -1,11 +1,11 @@
 import { testDb } from '@n8n/backend-test-utils';
 import { ProjectRelationRepository, ProjectRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
-import type { ProjectRole, Scope } from '@n8n/permissions';
-
-import { ProjectService } from '@/services/project.service.ee';
+import { PROJECT_OWNER_ROLE_SLUG, type ProjectRole, type Scope } from '@n8n/permissions';
 
 import { createMember } from '../shared/db/users';
+
+import { ProjectService } from '@/services/project.service.ee';
 
 let projectRepository: ProjectRepository;
 let projectService: ProjectService;
@@ -33,7 +33,7 @@ describe('ProjectService', () => {
 			'project:viewer',
 			'project:admin',
 			'project:editor',
-			'project:personalOwner',
+			PROJECT_OWNER_ROLE_SLUG,
 		] as ProjectRole[])(
 			'creates a relation between the user and the project using the role %s',
 			async (role) => {
@@ -57,7 +57,7 @@ describe('ProjectService', () => {
 				// ASSERT
 				//
 				await projectRelationRepository.findOneOrFail({
-					where: { userId: member.id, projectId: project.id, role },
+					where: { userId: member.id, projectId: project.id, role: { slug: role } },
 				});
 			},
 		);
@@ -76,7 +76,7 @@ describe('ProjectService', () => {
 			await projectService.addUser(project.id, { userId: member.id, role: 'project:viewer' });
 
 			await projectRelationRepository.findOneOrFail({
-				where: { userId: member.id, projectId: project.id, role: 'project:viewer' },
+				where: { userId: member.id, projectId: project.id, role: { slug: 'project:viewer' } },
 			});
 
 			//
@@ -92,7 +92,7 @@ describe('ProjectService', () => {
 			});
 
 			expect(relationships).toHaveLength(1);
-			expect(relationships[0]).toHaveProperty('role', 'project:admin');
+			expect(relationships[0]).toHaveProperty('role.slug', 'project:admin');
 		});
 	});
 
@@ -202,7 +202,7 @@ describe('ProjectService', () => {
 
 	describe('deleteUserFromProject', () => {
 		it('should not allow project owner to be removed from the project', async () => {
-			const role = 'project:personalOwner';
+			const role = PROJECT_OWNER_ROLE_SLUG;
 
 			const user = await createMember();
 			const project = await projectRepository.save(
@@ -233,7 +233,7 @@ describe('ProjectService', () => {
 			await projectService.deleteUserFromProject(project.id, user.id);
 
 			const relations = await projectRelationRepository.findOne({
-				where: { userId: user.id, projectId: project.id, role },
+				where: { userId: user.id, projectId: project.id, role: { slug: role } },
 			});
 
 			expect(relations).toBeNull();

--- a/packages/cli/test/integration/services/project.service.test.ts
+++ b/packages/cli/test/integration/services/project.service.test.ts
@@ -89,6 +89,7 @@ describe('ProjectService', () => {
 			//
 			const relationships = await projectRelationRepository.find({
 				where: { userId: member.id, projectId: project.id },
+				relations: { role: true },
 			});
 
 			expect(relationships).toHaveLength(1);

--- a/packages/cli/test/integration/users.api.test.ts
+++ b/packages/cli/test/integration/users.api.test.ts
@@ -1092,7 +1092,7 @@ describe('DELETE /users/:id', () => {
 					id: teamProject.id,
 					projectRelations: {
 						userId: transferee.id,
-						role: 'project:editor',
+						role: { slug: 'project:editor' },
 					},
 				}),
 			).resolves.not.toBeNull(),


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
This PR changes the `role` field on the ProjectRelation entity to become the joined with the `role` table field, to have access to all the scopes of the role.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-3173/rebuild-project-roles-to-load-from-the-database


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
