### PR TITLE
feat(ServiceNow Node): Allow connection to custom host

### DIFF
--- a/packages/nodes-base/credentials/ServiceNowBasicApi.credentials.ts
+++ b/packages/nodes-base/credentials/ServiceNowBasicApi.credentials.ts
@@ -69,8 +69,6 @@ export class ServiceNowBasicApi implements ICredentialType {
 	authenticate: IAuthenticateGeneric = {
 		type: 'generic',
 		properties: {
-			baseURL:
-				'={{ $credentials.useCustomHost ? $credentials.customHost.replace(/\\/$/, "") : `https://${$credentials.subdomain}.service-now.com` }}',
 			auth: {
 				username: '={{ $credentials.user }}',
 				password: '={{ $credentials.password }}',

--- a/packages/nodes-base/credentials/ServiceNowBasicApi.credentials.ts
+++ b/packages/nodes-base/credentials/ServiceNowBasicApi.credentials.ts
@@ -7,12 +7,14 @@ import type {
 
 export class ServiceNowBasicApi implements ICredentialType {
 	name = 'serviceNowBasicApi';
+
 	extends = ['httpBasicAuth'];
+
 	displayName = 'ServiceNow Basic Auth API';
+
 	documentationUrl = 'serviceNow';
 
 	properties: INodeProperties[] = [
-		/* ───────────────────────── Credentials ───────────────────────── */
 		{
 			displayName: 'User',
 			name: 'user',
@@ -25,11 +27,11 @@ export class ServiceNowBasicApi implements ICredentialType {
 			name: 'password',
 			type: 'string',
 			required: true,
-			typeOptions: { password: true },
+			typeOptions: {
+				password: true,
+			},
 			default: '',
 		},
-
-		/* ─────────────────────── Instance selector ───────────────────── */
 		{
 			displayName: 'Use custom host?',
 			name: 'useCustomHost',
@@ -65,18 +67,16 @@ export class ServiceNowBasicApi implements ICredentialType {
 		},
 	];
 
-	/* ─────────────────────── Authentication ─────────────────────── */
 	authenticate: IAuthenticateGeneric = {
 		type: 'generic',
 		properties: {
 			auth: {
-				username: '={{ $credentials.user }}',
-				password: '={{ $credentials.password }}',
+				username: '={{$credentials.user}}',
+				password: '={{$credentials.password}}',
 			},
 		},
 	};
 
-	/* ───────────────────────── Credential test ─────────────────────── */
 	test: ICredentialTestRequest = {
 		request: {
 			baseURL:

--- a/packages/nodes-base/credentials/ServiceNowBasicApi.credentials.ts
+++ b/packages/nodes-base/credentials/ServiceNowBasicApi.credentials.ts
@@ -7,14 +7,12 @@ import type {
 
 export class ServiceNowBasicApi implements ICredentialType {
 	name = 'serviceNowBasicApi';
-
 	extends = ['httpBasicAuth'];
-
 	displayName = 'ServiceNow Basic Auth API';
-
 	documentationUrl = 'serviceNow';
 
 	properties: INodeProperties[] = [
+		/* ───────────────────────── Credentials ───────────────────────── */
 		{
 			displayName: 'User',
 			name: 'user',
@@ -27,34 +25,64 @@ export class ServiceNowBasicApi implements ICredentialType {
 			name: 'password',
 			type: 'string',
 			required: true,
-			typeOptions: {
-				password: true,
-			},
+			typeOptions: { password: true },
 			default: '',
+		},
+
+		/* ─────────────────────── Instance selector ───────────────────── */
+		{
+			displayName: 'Use custom host?',
+			name: 'useCustomHost',
+			type: 'boolean',
+			default: false,
+			description:
+				'Enable if your ServiceNow instance is hosted on a custom domain or behind a reverse-proxy',
+		},
+		{
+			displayName: 'Custom Host',
+			name: 'customHost',
+			type: 'string',
+			placeholder: 'https://sn.my-company.internal',
+			description: 'Full base-URL of the instance (no trailing slash)',
+			default: '',
+			displayOptions: {
+				show: {
+					useCustomHost: [true],
+				},
+			},
 		},
 		{
 			displayName: 'Subdomain',
 			name: 'subdomain',
 			type: 'string',
+			hint: 'For https://dev99890.service-now.com the subdomain is “dev99890”',
 			default: '',
-			hint: 'The subdomain can be extracted from the URL. If the URL is: https://dev99890.service-now.com the subdomain is dev99890',
-			required: true,
+			displayOptions: {
+				show: {
+					useCustomHost: [false],
+				},
+			},
 		},
 	];
 
+	/* ─────────────────────── Authentication ─────────────────────── */
 	authenticate: IAuthenticateGeneric = {
 		type: 'generic',
 		properties: {
+			baseURL:
+				'={{ $credentials.useCustomHost ? $credentials.customHost.replace(/\\/$/, "") : `https://${$credentials.subdomain}.service-now.com` }}',
 			auth: {
-				username: '={{$credentials.user}}',
-				password: '={{$credentials.password}}',
+				username: '={{ $credentials.user }}',
+				password: '={{ $credentials.password }}',
 			},
 		},
 	};
 
+	/* ───────────────────────── Credential test ─────────────────────── */
 	test: ICredentialTestRequest = {
 		request: {
-			baseURL: '=https://{{$credentials?.subdomain}}.service-now.com',
+			baseURL:
+				'={{ $credentials.useCustomHost ? $credentials.customHost.replace(/\\/$/, "") : `https://${$credentials.subdomain}.service-now.com` }}',
 			url: '/api/now/table/sys_user_role',
 		},
 	};

--- a/packages/nodes-base/credentials/ServiceNowBasicApi.credentials.ts
+++ b/packages/nodes-base/credentials/ServiceNowBasicApi.credentials.ts
@@ -45,7 +45,7 @@ export class ServiceNowBasicApi implements ICredentialType {
 			name: 'customHost',
 			type: 'string',
 			placeholder: 'https://sn.my-company.internal',
-			description: 'Full base-URL of the instance (no trailing slash)',
+			description: 'Full base-URL of the instance',
 			default: '',
 			displayOptions: {
 				show: {
@@ -57,7 +57,7 @@ export class ServiceNowBasicApi implements ICredentialType {
 			displayName: 'Subdomain',
 			name: 'subdomain',
 			type: 'string',
-			hint: 'For https://dev99890.service-now.com the subdomain is “dev99890”',
+			hint: 'The subdomain can be extracted from the URL. If the URL is: https://dev99890.service-now.com the subdomain is dev99890',
 			default: '',
 			displayOptions: {
 				show: {

--- a/packages/nodes-base/credentials/ServiceNowBasicApi.credentials.ts
+++ b/packages/nodes-base/credentials/ServiceNowBasicApi.credentials.ts
@@ -46,6 +46,7 @@ export class ServiceNowBasicApi implements ICredentialType {
 			type: 'string',
 			placeholder: 'https://sn.my-company.internal',
 			description: 'Full base-URL of the instance',
+			required: true,
 			default: '',
 			displayOptions: {
 				show: {
@@ -57,8 +58,9 @@ export class ServiceNowBasicApi implements ICredentialType {
 			displayName: 'Subdomain',
 			name: 'subdomain',
 			type: 'string',
-			hint: 'The subdomain can be extracted from the URL. If the URL is: https://dev99890.service-now.com the subdomain is dev99890',
 			default: '',
+			hint: 'The subdomain can be extracted from the URL. If the URL is: https://dev99890.service-now.com the subdomain is dev99890',
+			required: true,
 			displayOptions: {
 				show: {
 					useCustomHost: [false],

--- a/packages/nodes-base/credentials/ServiceNowOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/ServiceNowOAuth2Api.credentials.ts
@@ -16,14 +16,14 @@ export class ServiceNowOAuth2Api implements ICredentialType {
 			type: 'boolean',
 			default: false,
 			description:
-				'Enable if your ServiceNow instance lives on a custom domain or behind a reverse-proxy',
+				'Enable if your ServiceNow instance is hosted on a custom domain or behind a reverse-proxy',
 		},
 		{
 			displayName: 'Custom Host',
 			name: 'customHost',
 			type: 'string',
 			placeholder: 'https://sn.my-company.internal',
-			description: 'Full base URL **without** a trailing slash',
+			description: 'Full base-URL of the instance',
 			default: '',
 			displayOptions: {
 				show: {
@@ -35,7 +35,7 @@ export class ServiceNowOAuth2Api implements ICredentialType {
 			displayName: 'Subdomain',
 			name: 'subdomain',
 			type: 'string',
-			hint: 'For https://dev99890.service-now.com the subdomain is “dev99890”',
+			hint: 'The subdomain can be extracted from the URL. If the URL is: https://dev99890.service-now.com the subdomain is dev99890',
 			default: '',
 			required: true,
 			displayOptions: {
@@ -83,8 +83,8 @@ export class ServiceNowOAuth2Api implements ICredentialType {
 			default: 'response_type=code',
 		},
 		{
-			displayName: 'Token URI Query Parameters',
-			name: 'tokenQueryParameters',
+			displayName: 'Auth URI Query Parameters',
+			name: 'authQueryParameters',
 			type: 'hidden',
 			default: 'grant_type=authorization_code',
 		},

--- a/packages/nodes-base/credentials/ServiceNowOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/ServiceNowOAuth2Api.credentials.ts
@@ -24,6 +24,7 @@ export class ServiceNowOAuth2Api implements ICredentialType {
 			type: 'string',
 			placeholder: 'https://sn.my-company.internal',
 			description: 'Full base-URL of the instance',
+			required: true,
 			default: '',
 			displayOptions: {
 				show: {
@@ -35,8 +36,8 @@ export class ServiceNowOAuth2Api implements ICredentialType {
 			displayName: 'Subdomain',
 			name: 'subdomain',
 			type: 'string',
-			hint: 'The subdomain can be extracted from the URL. If the URL is: https://dev99890.service-now.com the subdomain is dev99890',
 			default: '',
+			hint: 'The subdomain can be extracted from the URL. If the URL is: https://dev99890.service-now.com the subdomain is dev99890',
 			required: true,
 			displayOptions: {
 				show: {

--- a/packages/nodes-base/credentials/ServiceNowOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/ServiceNowOAuth2Api.credentials.ts
@@ -2,13 +2,14 @@ import type { ICredentialType, INodeProperties } from 'n8n-workflow';
 
 export class ServiceNowOAuth2Api implements ICredentialType {
 	name = 'serviceNowOAuth2Api';
+
 	extends = ['oAuth2Api'];
+
 	displayName = 'ServiceNow OAuth2 API';
+
 	documentationUrl = 'serviceNow';
 
-	/* ────────────────────────── Properties ────────────────────────── */
 	properties: INodeProperties[] = [
-		/* ----------  Instance selector  ---------- */
 		{
 			displayName: 'Use custom host?',
 			name: 'useCustomHost',
@@ -24,7 +25,11 @@ export class ServiceNowOAuth2Api implements ICredentialType {
 			placeholder: 'https://sn.my-company.internal',
 			description: 'Full base URL **without** a trailing slash',
 			default: '',
-			displayOptions: { show: { useCustomHost: [true] } },
+			displayOptions: {
+				show: {
+					useCustomHost: [true],
+				},
+			},
 		},
 		{
 			displayName: 'Subdomain',
@@ -33,10 +38,12 @@ export class ServiceNowOAuth2Api implements ICredentialType {
 			hint: 'For https://dev99890.service-now.com the subdomain is “dev99890”',
 			default: '',
 			required: true,
-			displayOptions: { show: { useCustomHost: [false] } },
+			displayOptions: {
+				show: {
+					useCustomHost: [false],
+				},
+			},
 		},
-
-		/* ----------  OAuth2 settings  ---------- */
 		{
 			displayName: 'Grant Type',
 			name: 'grantType',
@@ -48,18 +55,10 @@ export class ServiceNowOAuth2Api implements ICredentialType {
 			name: 'authUrl',
 			type: 'hidden',
 			required: true,
-			/*
-			 *  Builds:
-			 *    • https://<sub>.service-now.com/oauth_auth.do      (legacy)
-			 *    • https://<customHost>/oauth_auth.do               (custom)
-			 *
-			 *  .replace(/\/$/, '') strips **one** trailing slash in case
-			 *  the user pastes `https://host/` instead of `https://host`.
-			 */
 			default:
-				'= {{$self.useCustomHost' +
-				' ? $self.customHost.replace(/\\/$/, "")' +
-				' : "https://" + $self.subdomain + ".service-now.com"}}/oauth_auth.do',
+				'= {{$self.useCustomHost ? ' +
+				'$self.customHost.replace(/\\/$/, "") : ' +
+				'"https://" + $self.subdomain + ".service-now.com"}}/oauth_auth.do',
 		},
 		{
 			displayName: 'Access Token URL',
@@ -67,9 +66,9 @@ export class ServiceNowOAuth2Api implements ICredentialType {
 			type: 'hidden',
 			required: true,
 			default:
-				'= {{$self.useCustomHost' +
-				' ? $self.customHost.replace(/\\/$/, "")' +
-				' : "https://" + $self.subdomain + ".service-now.com"}}/oauth_token.do',
+				'= {{$self.useCustomHost ? ' +
+				'$self.customHost.replace(/\\/$/, "") : ' +
+				'"https://" + $self.subdomain + ".service-now.com"}}/oauth_token.do',
 		},
 		{
 			displayName: 'Scope',

--- a/packages/nodes-base/credentials/ServiceNowOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/ServiceNowOAuth2Api.credentials.ts
@@ -2,22 +2,41 @@ import type { ICredentialType, INodeProperties } from 'n8n-workflow';
 
 export class ServiceNowOAuth2Api implements ICredentialType {
 	name = 'serviceNowOAuth2Api';
-
 	extends = ['oAuth2Api'];
-
 	displayName = 'ServiceNow OAuth2 API';
-
 	documentationUrl = 'serviceNow';
 
+	/* ────────────────────────── Properties ────────────────────────── */
 	properties: INodeProperties[] = [
+		/* ----------  Instance selector  ---------- */
+		{
+			displayName: 'Use custom host?',
+			name: 'useCustomHost',
+			type: 'boolean',
+			default: false,
+			description:
+				'Enable if your ServiceNow instance lives on a custom domain or behind a reverse-proxy',
+		},
+		{
+			displayName: 'Custom Host',
+			name: 'customHost',
+			type: 'string',
+			placeholder: 'https://sn.my-company.internal',
+			description: 'Full base URL **without** a trailing slash',
+			default: '',
+			displayOptions: { show: { useCustomHost: [true] } },
+		},
 		{
 			displayName: 'Subdomain',
 			name: 'subdomain',
 			type: 'string',
+			hint: 'For https://dev99890.service-now.com the subdomain is “dev99890”',
 			default: '',
-			hint: 'The subdomain can be extracted from the URL. If the URL is: https://dev99890.service-now.com the subdomain is dev99890',
 			required: true,
+			displayOptions: { show: { useCustomHost: [false] } },
 		},
+
+		/* ----------  OAuth2 settings  ---------- */
 		{
 			displayName: 'Grant Type',
 			name: 'grantType',
@@ -28,15 +47,29 @@ export class ServiceNowOAuth2Api implements ICredentialType {
 			displayName: 'Authorization URL',
 			name: 'authUrl',
 			type: 'hidden',
-			default: '=https://{{$self["subdomain"]}}.service-now.com/oauth_auth.do',
 			required: true,
+			/*
+			 *  Builds:
+			 *    • https://<sub>.service-now.com/oauth_auth.do      (legacy)
+			 *    • https://<customHost>/oauth_auth.do               (custom)
+			 *
+			 *  .replace(/\/$/, '') strips **one** trailing slash in case
+			 *  the user pastes `https://host/` instead of `https://host`.
+			 */
+			default:
+				'= {{$self.useCustomHost' +
+				' ? $self.customHost.replace(/\\/$/, "")' +
+				' : "https://" + $self.subdomain + ".service-now.com"}}/oauth_auth.do',
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
 			type: 'hidden',
-			default: '=https://{{$self["subdomain"]}}.service-now.com/oauth_token.do',
 			required: true,
+			default:
+				'= {{$self.useCustomHost' +
+				' ? $self.customHost.replace(/\\/$/, "")' +
+				' : "https://" + $self.subdomain + ".service-now.com"}}/oauth_token.do',
 		},
 		{
 			displayName: 'Scope',
@@ -51,8 +84,8 @@ export class ServiceNowOAuth2Api implements ICredentialType {
 			default: 'response_type=code',
 		},
 		{
-			displayName: 'Auth URI Query Parameters',
-			name: 'authQueryParameters',
+			displayName: 'Token URI Query Parameters',
+			name: 'tokenQueryParameters',
 			type: 'hidden',
 			default: 'grant_type=authorization_code',
 		},

--- a/packages/nodes-base/nodes/ServiceNow/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/ServiceNow/GenericFunctions.ts
@@ -30,12 +30,26 @@ export async function serviceNowApiRequest(
 		credentials = await this.getCredentials('serviceNowOAuth2Api');
 	}
 
+	/* -----------------------------------------------------------------------
+	   Build base URL – backwards-compatible
+	   -----------------------------------------------------------------------
+	   • Using subdomain:  subdomain         → https://<sub>.service-now.com
+	   • Using full host:  customHost toggle → https://your.host.tld
+	--------------------------------------------------------------------- */
+	let baseUrl;
+
+	if (credentials.useCustomHost && credentials.customHost) {
+		baseUrl = (credentials.customHost as string).replace(/\/$/, ''); /* strip 1 trailing “/” */
+	} else {
+		baseUrl = `https://${credentials.subdomain}.service-now.com`;
+	}
+
 	const options = {
 		headers,
 		method,
 		qs,
 		body,
-		uri: uri || `https://${credentials.subdomain}.service-now.com/api${resource}`,
+		uri: uri ?? `${baseUrl}/api${resource}`,
 		json: true,
 	} satisfies IRequestOptions;
 	if (!Object.keys(body as IDataObject).length) {

--- a/packages/nodes-base/nodes/ServiceNow/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/ServiceNow/GenericFunctions.ts
@@ -40,10 +40,6 @@ export async function serviceNowApiRequest(
 
 	if (credentials.useCustomHost && credentials.customHost) {
 		baseUrl = String(credentials.customHost).replace(/\/$/, ''); // strip trailing slash
-	} else if (credentials.useCustomHost && !credentials.customHost) {
-		throw new NodeApiError(this.getNode(), {
-			message: 'Custom host is enabled but no custom host was provided.',
-		});
 	} else {
 		baseUrl = `https://${credentials.subdomain}.service-now.com`;
 	}

--- a/packages/nodes-base/nodes/ServiceNow/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/ServiceNow/GenericFunctions.ts
@@ -39,7 +39,7 @@ export async function serviceNowApiRequest(
 	let baseUrl;
 
 	if (credentials.useCustomHost && credentials.customHost) {
-		baseUrl = (credentials.customHost as string).replace(/\/$/, ''); /* strip 1 trailing “/” */
+		baseUrl = credentials.customHost.replace(/\/$/, ''); /* strip 1 trailing “/” */
 	} else {
 		baseUrl = `https://${credentials.subdomain}.service-now.com`;
 	}

--- a/packages/nodes-base/nodes/ServiceNow/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/ServiceNow/GenericFunctions.ts
@@ -31,7 +31,7 @@ export async function serviceNowApiRequest(
 	}
 
 	/* -----------------------------------------------------------------------
-	   Build base URL – backwards-compatible
+	   Build base URL
 	   -----------------------------------------------------------------------
 	   • Using subdomain:  subdomain         → https://<sub>.service-now.com
 	   • Using full host:  customHost toggle → https://your.host.tld
@@ -39,7 +39,11 @@ export async function serviceNowApiRequest(
 	let baseUrl;
 
 	if (credentials.useCustomHost && credentials.customHost) {
-		baseUrl = credentials.customHost.replace(/\/$/, ''); /* strip 1 trailing “/” */
+		baseUrl = String(credentials.customHost).replace(/\/$/, ''); // strip trailing slash
+	} else if (credentials.useCustomHost && !credentials.customHost) {
+		throw new NodeApiError(this.getNode(), {
+			message: 'Custom host is enabled but no custom host was provided.',
+		});
 	} else {
 		baseUrl = `https://${credentials.subdomain}.service-now.com`;
 	}


### PR DESCRIPTION
## Summary
Until now, ServiceNow credentials in n8n accepted **only a sub-domain**, which excluded
users whose instances sit behind a reverse proxy or run on a completely custom host.

This PR adds an optional **“Use custom host?”** toggle plus **Custom Host** field to both
Basic-Auth and OAuth2 credentials, enabling any ServiceNow URL.

## Related Linear tickets, Github issues, and Community forum posts
https://community.n8n.io/t/self-hosted-servicenow-support/160389


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. - https://github.com/n8n-io/n8n-docs/pull/3429
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
