### PR TITLE
refactor(editor): use el-switch `:loading` instead of v-loading

### DIFF
--- a/packages/frontend/@n8n/design-system/src/css/common/var.scss
+++ b/packages/frontend/@n8n/design-system/src/css/common/var.scss
@@ -665,6 +665,8 @@ $switch-width: 40px;
 $switch-height: 20px;
 // height||Other|4
 $switch-button-size: 16px;
+// height||Other|4
+$switch-content-padding: 4px;
 
 /* Dialog
 -------------------------- */

--- a/packages/frontend/@n8n/design-system/src/css/icon.scss
+++ b/packages/frontend/@n8n/design-system/src/css/icon.scss
@@ -754,10 +754,6 @@
 	content: '\e6ce';
 }
 
-.el-icon-loading:before {
-	content: '\e6cf';
-}
-
 .el-icon-rank:before {
 	content: '\e6d1';
 }
@@ -1166,7 +1162,7 @@
 	content: '\e7ca';
 }
 
-.el-icon-loading {
+.el-icon.is-loading {
 	animation: rotating 2s linear infinite;
 }
 

--- a/packages/frontend/@n8n/design-system/src/css/switch.scss
+++ b/packages/frontend/@n8n/design-system/src/css/switch.scss
@@ -1,4 +1,5 @@
 @use 'mixins/mixins';
+@use 'mixins/utils';
 @use './common/var';
 
 @include mixins.b(switch) {
@@ -9,9 +10,6 @@
 	line-height: var.$switch-height;
 	height: var.$switch-height;
 	vertical-align: middle;
-	& .el-loading-mask {
-		border-radius: 10px;
-	}
 	@include mixins.when(disabled) {
 		& .el-switch__core,
 		& .el-switch__label {
@@ -52,36 +50,61 @@
 		height: 0;
 		opacity: 0;
 		margin: 0;
+		&:focus-visible {
+			& ~ .el-switch__core {
+				outline: 2px solid getCssVar('switch-on-color');
+				outline-offset: 1px;
+			}
+		}
 	}
 
 	@include mixins.e(core) {
-		margin: 0;
-		display: inline-block;
+		display: inline-flex;
 		position: relative;
-		width: var.$switch-width;
+		align-items: center;
+		min-width: var.$switch-width;
 		height: var.$switch-height;
-		border: 1px solid var.$switch-off-color;
+		border: 1px solid var(--color-switch-border-color, --color-switch-off-color);
 		outline: none;
 		border-radius: var.$switch-core-border-radius;
 		box-sizing: border-box;
 		background: var.$switch-off-color;
-		border: 1px solid var(--color-switch-border-color);
 		cursor: pointer;
 		transition:
 			border-color 0.1s,
 			background-color 0.1s;
-		vertical-align: middle;
 
-		&:after {
-			content: '';
+		.el-switch__inner {
+			width: 100%;
+			transition: all 0.1s;
+			height: var.$switch-button-size;
+			display: flex;
+			justify-content: center;
+			align-items: center;
+			overflow: hidden;
+
+			.is-icon,
+			.is-text {
+				font-size: 12px;
+				color: var(--color-text-dark);
+				user-select: none;
+				@include utils.utils-ellipsis;
+			}
+			padding: 0 var.$switch-content-padding 0 calc(var.$switch-button-size + 2px);
+		}
+
+		.el-switch__action {
 			position: absolute;
-			top: 1px;
 			left: 1px;
 			border-radius: var.$border-radius-circle;
 			transition: all 0.1s;
 			width: var.$switch-button-size;
 			height: var.$switch-button-size;
 			background-color: var.$switch-toggle-color;
+			display: flex;
+			justify-content: center;
+			align-items: center;
+			color: var.$switch-off-color;
 		}
 	}
 
@@ -89,9 +112,12 @@
 		.el-switch__core {
 			border-color: var.$switch-on-color;
 			background-color: var.$switch-on-color;
-			&::after {
-				left: 100%;
-				margin-left: -(var.$switch-button-size) - 1px;
+			.el-switch__action {
+				left: calc(100% - calc(var.$switch-button-size + 1px));
+				color: var.$switch-on-color;
+			}
+			.el-switch__inner {
+				padding: 0 calc(var.$switch-button-size + 2px) 0 var.$switch-content-padding;
 			}
 		}
 	}

--- a/packages/frontend/@n8n/design-system/src/css/switch.scss
+++ b/packages/frontend/@n8n/design-system/src/css/switch.scss
@@ -52,7 +52,7 @@
 		margin: 0;
 		&:focus-visible {
 			& ~ .el-switch__core {
-				outline: 2px solid getCssVar('switch-on-color');
+				outline: 2px solid var.$switch-on-color;
 				outline-offset: 1px;
 			}
 		}
@@ -85,7 +85,7 @@
 
 			.is-icon,
 			.is-text {
-				font-size: 12px;
+				font-size: var(--font-size-2xs);
 				color: var(--color-text-dark);
 				user-select: none;
 				@include utils.utils-ellipsis;

--- a/packages/frontend/editor-ui/src/components/WorkflowActivator.vue
+++ b/packages/frontend/editor-ui/src/components/WorkflowActivator.vue
@@ -234,18 +234,14 @@ watch(
 				</div>
 			</template>
 			<el-switch
-				v-loading="workflowActivate.updatingWorkflowActivation.value"
 				:model-value="workflowActive"
 				:title="
 					workflowActive
 						? i18n.baseText('workflowActivator.deactivateWorkflow')
 						: i18n.baseText('workflowActivator.activateWorkflow')
 				"
-				:disabled="
-					disabled ||
-					workflowActivate.updatingWorkflowActivation.value ||
-					(!isNewWorkflow && !workflowPermissions.update)
-				"
+				:disabled="disabled || (!isNewWorkflow && !workflowPermissions.update)"
+				:loading="workflowActivate.updatingWorkflowActivation.value"
 				:active-color="getActiveColor"
 				inactive-color="#8899AA"
 				data-test-id="workflow-activate-switch"


### PR DESCRIPTION
## Summary
The `el-switch` style from element-plus was out of date causing the `loading` attribute not working.
I forked the style from the according `2.4.3` version of element-plus

---

Before
![before_switch_n8n](https://github.com/user-attachments/assets/2cc96e21-da79-452a-bccf-ddd372882f21)

---

After
![switch_n8n_after](https://github.com/user-attachments/assets/f0e01ece-7e2e-467b-8bfd-27593c28d796)


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
