### PR TITLE
fix(core): Populate MCP endpoints in frontend settings

### DIFF
--- a/packages/frontend/@n8n/stores/src/useRootStore.ts
+++ b/packages/frontend/@n8n/stores/src/useRootStore.ts
@@ -157,6 +157,14 @@ export const useRootStore = defineStore(STORES.ROOT, () => {
 		state.value.endpointWebhookWaiting = value;
 	};
 
+	const setEndpointMcp = (value: string) => {
+		state.value.endpointMcp = value;
+	};
+
+	const setEndpointMcpTest = (value: string) => {
+		state.value.endpointMcpTest = value;
+	};
+
 	const setTimezone = (value: string) => {
 		state.value.timezone = value;
 		setGlobalState({ defaultTimezone: value });
@@ -226,6 +234,8 @@ export const useRootStore = defineStore(STORES.ROOT, () => {
 		setEndpointWebhook,
 		setEndpointWebhookTest,
 		setEndpointWebhookWaiting,
+		setEndpointMcp,
+		setEndpointMcpTest,
 		setTimezone,
 		setExecutionTimeout,
 		setMaxExecutionTimeout,

--- a/packages/frontend/editor-ui/src/stores/settings.store.test.ts
+++ b/packages/frontend/editor-ui/src/stores/settings.store.test.ts
@@ -32,6 +32,8 @@ vi.mock('@n8n/stores/useRootStore', () => ({
 		setEndpointWebhook: vi.fn(),
 		setEndpointWebhookTest: vi.fn(),
 		setEndpointWebhookWaiting: vi.fn(),
+		setEndpointMcp: vi.fn(),
+		setEndpointMcpTest: vi.fn(),
 		setTimezone: vi.fn(),
 		setExecutionTimeout: vi.fn(),
 		setMaxExecutionTimeout: vi.fn(),

--- a/packages/frontend/editor-ui/src/stores/settings.store.ts
+++ b/packages/frontend/editor-ui/src/stores/settings.store.ts
@@ -254,6 +254,8 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 		rootStore.setEndpointWebhook(fetchedSettings.endpointWebhook);
 		rootStore.setEndpointWebhookTest(fetchedSettings.endpointWebhookTest);
 		rootStore.setEndpointWebhookWaiting(fetchedSettings.endpointWebhookWaiting);
+		rootStore.setEndpointMcp(fetchedSettings.endpointMcp);
+		rootStore.setEndpointMcpTest(fetchedSettings.endpointMcpTest);
 		rootStore.setTimezone(fetchedSettings.timezone);
 		rootStore.setExecutionTimeout(fetchedSettings.executionTimeout);
 		rootStore.setMaxExecutionTimeout(fetchedSettings.maxExecutionTimeout);


### PR DESCRIPTION

## Summary

This PR resolves a bug where the `N8N_ENDPOINT_MCP` and `N8N_ENDPOINT_MCP_TEST` environment variables were not being correctly passed to the frontend when n8n is deployed behind a proxy. This resulted in nodes like "MCP Trigger" displaying broken URLs.

The fix ensures that these endpoint settings are properly loaded into the frontend's `rootStore` during initialization, making their behavior consistent with other endpoints like webhooks and forms.

### How to test:

1.  Set up an n8n instance with environment variables to simulate a proxy (e.g., `WEBHOOK_URL="http://localhost/"`, `N8N_ENDPOINT_MCP_TEST="n8n/mcp-test"`).
2.  In the UI, create a new workflow and add an "MCP Trigger" node.
3.  Check the "Test URL" displayed in the node's properties panel.
      - **Before fix:** The URL is broken (e.g., `http://localhost/mcp-test/<id>`).
    
       <img width="1826" height="657" alt="image" src="https://github.com/user-attachments/assets/fea99b1e-f601-4dc9-a683-2a962a89fdb0" />

      - **After fix:** The URL renders correctly with the full path (e.g., `http://localhost/n8n/mcp-test/<id>`).
      
      <img width="1862" height="748" alt="image" src="https://github.com/user-attachments/assets/c7a1de69-c537-47d8-99d8-4fa3814435df" />

PD1: I'm using the same configuration as the issue above \#17923
PD2: I'm new to contributing, so please let me know if this PR needs any adjustments. I've reviewed the guidelines and will gladly make any requested changes.

## Related Linear tickets, Github issues, and Community forum posts

closes \#17923
