### PR TITLE
fix(core): Add supportedNodes for custom nodes

### DIFF
--- a/packages/cli/src/load-nodes-and-credentials.ts
+++ b/packages/cli/src/load-nodes-and-credentials.ts
@@ -346,7 +346,7 @@ export class LoadNodesAndCredentials {
 				types.credentials.map(({ supportedNodes, ...rest }) => ({
 					...rest,
 					supportedNodes:
-						loader instanceof PackageDirectoryLoader
+						loader instanceof PackageDirectoryLoader || loader instanceof CustomDirectoryLoader
 							? supportedNodes?.map((nodeName) => `${loader.packageName}.${nodeName}`)
 							: undefined,
 				})),
@@ -380,7 +380,7 @@ export class LoadNodesAndCredentials {
 					className,
 					sourcePath: path.join(directory, sourcePath),
 					supportedNodes:
-						loader instanceof PackageDirectoryLoader
+						loader instanceof PackageDirectoryLoader || loader instanceof CustomDirectoryLoader
 							? supportedNodes?.map((nodeName) => `${loader.packageName}.${nodeName}`)
 							: undefined,
 					extends: extendsArr,

--- a/packages/core/src/nodes-loader/directory-loader.ts
+++ b/packages/core/src/nodes-loader/directory-loader.ts
@@ -234,11 +234,13 @@ export abstract class DirectoryLoader {
 		this.fixIconPaths(tempCredential, filePath);
 
 		const credentialType = tempCredential.name;
+		tempCredential.supportedNodes = this.nodesByCredential[credentialType];
+
 		this.known.credentials[credentialType] = {
 			className: tempCredential.constructor.name,
 			sourcePath: filePath,
 			extends: tempCredential.extends,
-			supportedNodes: this.nodesByCredential[credentialType],
+			supportedNodes: tempCredential.supportedNodes,
 		};
 
 		this.credentialTypes[credentialType] = {


### PR DESCRIPTION
## Summary

The credential test declared directly in a custom node (`methods.credentialTest`), is not executed.
The `supportedNodes` is not correctly set for custom nodes. If this is not set, the credential is not testable in the frontend.
https://github.com/n8n-io/n8n/blob/4247477b3d6b6de63615c263b03ebde1add4a630/packages/frontend/editor-ui/src/components/CredentialEdit/CredentialEdit.vue#L168-L194

https://github.com/n8n-io/n8n/blob/4247477b3d6b6de63615c263b03ebde1add4a630/packages/frontend/editor-ui/src/stores/credentials.store.ts#L138-L150


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
