### PR TITLE
fix(core): Handle Redis cache prefix on cluster mode

### DIFF
--- a/packages/cli/src/services/cache/cache.service.ts
+++ b/packages/cli/src/services/cache/cache.service.ts
@@ -40,9 +40,12 @@ export class CacheService extends TypedEmitter<CacheEvents> {
 			const redisClientService = Container.get(RedisClientService);
 
 			const prefixBase = this.globalConfig.redis.prefix;
-			const prefix = redisClientService.toValidPrefix(
-				`${prefixBase}:${this.globalConfig.cache.redis.prefix}:`,
-			);
+			const cachePrefix = this.globalConfig.cache.redis.prefix;
+			
+			// For cluster mode, we need to ensure proper hash tagging: {n8n:cache}:
+			// instead of {n8n:cache:} to keep the colon outside the hash tag
+			const hashTagPart = `${prefixBase}:${cachePrefix}`;
+			const prefix = redisClientService.toValidPrefix(hashTagPart) + ':';
 
 			const redisClient = redisClientService.createClient({
 				type: 'cache(n8n)',

--- a/packages/cli/src/services/cache/cache.service.ts
+++ b/packages/cli/src/services/cache/cache.service.ts
@@ -41,7 +41,7 @@ export class CacheService extends TypedEmitter<CacheEvents> {
 
 			const prefixBase = this.globalConfig.redis.prefix;
 			const cachePrefix = this.globalConfig.cache.redis.prefix;
-			
+
 			// For cluster mode, we need to ensure proper hash tagging: {n8n:cache}:
 			// instead of {n8n:cache:} to keep the colon outside the hash tag
 			const hashTagPart = `${prefixBase}:${cachePrefix}`;


### PR DESCRIPTION
## Summary

Fixes Redis cluster prefix handling for cache service to ensure proper hash tagging in cluster mode.

**Problem**: When using Redis cluster mode (`QUEUE_BULL_REDIS_CLUSTER_NODES`), the cache service was incorrectly constructing key prefixes as `{n8n:cache:}` which includes the trailing colon inside the hash tag braces.

<img width="897" height="440" alt="image" src="https://github.com/user-attachments/assets/a510aaac-9405-43b1-bdac-9ddd4d538b8d" />


**Solution**: Modified the cache service to construct cluster prefixes as `{n8n:cache}:` where only the meaningful hash tag part is wrapped in braces, and the final colon is placed outside.

**Why this matters**: 
- In Redis cluster mode, hash tags `{}` determine which slot keys are placed in
- All keys with the same hash tag go to the same Redis node
- This ensures atomic operations across related cache keys work correctly
- Follows Redis cluster best practices and Bull.js recommendations

**Changes**:
- Updated `CacheService.init()` to separate hash tag construction from final prefix
- Maintains backward compatibility for non-cluster Redis deployments

**Testing**:
- Existing cache functionality tests continue to pass
- No changes to memory cache behavior

## Related Linear tickets, Github issues, and Community forum posts

<!-- No specific issue referenced - this is a proactive fix for Redis cluster deployment scenarios -->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs