### PR TITLE
fix(core): Consider pinned data as valid paths for single node execution

### DIFF
--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -931,6 +931,12 @@ export class Workflow {
 	hasPath(fromNodeName: string, toNodeName: string, maxDepth = 50): boolean {
 		if (fromNodeName === toNodeName) return true;
 
+		// Special case: If the source node has pinned data, consider it as having a valid path
+		// This is important for single node execution scenarios where pinned data creates virtual paths
+		if (this.getPinDataOfNode(fromNodeName)) {
+			return true;
+		}
+
 		// Get connection types that actually exist in this workflow
 		// We need both source and destination connection types for bidirectional search
 		const connectionTypes = new Set<NodeConnectionType>();

--- a/packages/workflow/test/workflow.test.ts
+++ b/packages/workflow/test/workflow.test.ts
@@ -11,6 +11,7 @@ import type {
 	INode,
 	INodeExecutionData,
 	INodeParameters,
+	IPinData,
 	IRunExecutionData,
 	NodeParameterValueType,
 } from '../src/interfaces';
@@ -3582,6 +3583,57 @@ describe('Workflow', () => {
 
 			expect(workflow.hasPath('Node1', 'Node2')).toBe(false);
 			expect(workflow.hasPath('Node2', 'Node1')).toBe(false);
+		});
+
+		it('should return true when source node has pinned data (virtual path)', () => {
+			const nodes: INode[] = [
+				{
+					id: '1',
+					name: 'Trigger',
+					type: 'n8n-nodes-base.executeWorkflowTrigger',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: {},
+				},
+				{
+					id: '2',
+					name: 'EditFields',
+					type: 'n8n-nodes-base.set',
+					typeVersion: 1,
+					position: [200, 0],
+					parameters: {},
+				},
+			];
+
+			const connections: IConnections = {
+				Trigger: {
+					main: [[{ node: 'EditFields', type: 'main', index: 0 }]],
+				},
+			};
+
+			const pinData: IPinData = {
+				Trigger: [
+					{
+						json: {
+							name: 'Test item',
+							value: 123,
+						},
+					},
+				],
+			};
+
+			const workflow = new Workflow({
+				nodes,
+				connections,
+				active: false,
+				nodeTypes,
+				pinData,
+			});
+
+			// Should return true because Trigger has pinned data, creating a virtual path
+			expect(workflow.hasPath('Trigger', 'EditFields')).toBe(true);
+			// Should also work for self-reference with pinned data
+			expect(workflow.hasPath('Trigger', 'Trigger')).toBe(true);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Executing a single node that references pinned data fails by treating pinned data as valid virtual paths in the workflow execution path validation

## Related Linear tickets, Github issues, and Community forum posts

CAT-1062

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
