### PR TITLE
fix: Properly serialize metadata objects in Chat UI 

### DIFF
--- a/packages/frontend/@n8n/chat/src/__tests__/api/generic.spec.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/api/generic.spec.ts
@@ -1,0 +1,131 @@
+import { postWithFiles } from '@n8n/chat/api/generic';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('postWithFiles', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('should properly serialize object metadata to JSON string in FormData', async () => {
+		const mockResponse = {
+			ok: true,
+			status: 200,
+			json: async () => await Promise.resolve({ success: true }),
+			text: async () => await Promise.resolve('success'),
+			clone: () => mockResponse,
+		} as Response;
+
+		const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(mockResponse);
+
+		const testFile = new File(['test content'], 'test.txt', { type: 'text/plain' });
+		const metadata = {
+			userId: 'user-123',
+			token: 'abc-def-ghi',
+			nested: {
+				prop: 'value',
+				num: 42,
+			},
+		};
+
+		await postWithFiles(
+			'https://example.com/webhook',
+			{
+				action: 'sendMessage',
+				sessionId: 'test-session',
+				chatInput: 'test message',
+				metadata,
+			},
+			[testFile],
+		);
+
+		expect(fetchSpy).toHaveBeenCalledWith('https://example.com/webhook', {
+			method: 'POST',
+			body: expect.any(FormData),
+			mode: 'cors',
+			cache: 'no-cache',
+			headers: {},
+		});
+
+		// Get the FormData from the call
+		const formData = fetchSpy.mock.calls[0][1]?.body as FormData;
+		expect(formData).toBeInstanceOf(FormData);
+
+		// Verify that metadata was properly serialized as JSON, not "[object Object]"
+		const metadataValue = formData.get('metadata');
+		expect(metadataValue).toBe(JSON.stringify(metadata));
+
+		// Verify other fields are still strings
+		expect(formData.get('action')).toBe('sendMessage');
+		expect(formData.get('sessionId')).toBe('test-session');
+		expect(formData.get('chatInput')).toBe('test message');
+
+		// Verify file was included
+		expect(formData.get('files')).toBe(testFile);
+	});
+
+	it('should handle primitive values correctly', async () => {
+		const mockResponse = {
+			ok: true,
+			status: 200,
+			json: async () => await Promise.resolve({ success: true }),
+			text: async () => await Promise.resolve('success'),
+			clone: () => mockResponse,
+		} as Response;
+
+		const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(mockResponse);
+
+		await postWithFiles('https://example.com/webhook', {
+			stringValue: 'test',
+			numberValue: 123,
+			booleanValue: true,
+			nullValue: null,
+		});
+
+		const formData = fetchSpy.mock.calls[0][1]?.body as FormData;
+
+		expect(formData.get('stringValue')).toBe('test');
+		expect(formData.get('numberValue')).toBe('123');
+		expect(formData.get('booleanValue')).toBe('true');
+		expect(formData.get('nullValue')).toBe('null');
+	});
+
+	it('should handle arrays as JSON strings', async () => {
+		const mockResponse = {
+			ok: true,
+			status: 200,
+			json: async () => await Promise.resolve({ success: true }),
+			text: async () => await Promise.resolve('success'),
+			clone: () => mockResponse,
+		} as Response;
+
+		const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(mockResponse);
+
+		const arrayValue = ['item1', 'item2', { nested: 'object' }];
+
+		await postWithFiles('https://example.com/webhook', {
+			arrayValue,
+		});
+
+		const formData = fetchSpy.mock.calls[0][1]?.body as FormData;
+		expect(formData.get('arrayValue')).toBe(JSON.stringify(arrayValue));
+	});
+
+	it('should handle empty objects correctly', async () => {
+		const mockResponse = {
+			ok: true,
+			status: 200,
+			json: async () => await Promise.resolve({ success: true }),
+			text: async () => await Promise.resolve('success'),
+			clone: () => mockResponse,
+		} as Response;
+
+		const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(mockResponse);
+
+		await postWithFiles('https://example.com/webhook', {
+			emptyObject: {},
+		});
+
+		const formData = fetchSpy.mock.calls[0][1]?.body as FormData;
+		expect(formData.get('emptyObject')).toBe('{}');
+	});
+});

--- a/packages/frontend/@n8n/chat/src/__tests__/api/generic.spec.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/api/generic.spec.ts
@@ -76,17 +76,11 @@ describe('postWithFiles', () => {
 
 		await postWithFiles('https://example.com/webhook', {
 			stringValue: 'test',
-			numberValue: 123,
-			booleanValue: true,
-			nullValue: null,
 		});
 
 		const formData = fetchSpy.mock.calls[0][1]?.body as FormData;
 
 		expect(formData.get('stringValue')).toBe('test');
-		expect(formData.get('numberValue')).toBe('123');
-		expect(formData.get('booleanValue')).toBe('true');
-		expect(formData.get('nullValue')).toBe('null');
 	});
 
 	it('should handle arrays as JSON strings', async () => {

--- a/packages/frontend/@n8n/chat/src/__tests__/api/generic.spec.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/api/generic.spec.ts
@@ -1,5 +1,6 @@
-import { postWithFiles } from '@n8n/chat/api/generic';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { postWithFiles } from '@n8n/chat/api/generic';
 
 describe('postWithFiles', () => {
 	beforeEach(() => {

--- a/packages/frontend/@n8n/chat/src/api/generic.ts
+++ b/packages/frontend/@n8n/chat/src/api/generic.ts
@@ -62,7 +62,12 @@ export async function postWithFiles<T>(
 	const formData = new FormData();
 
 	for (const key in body) {
-		formData.append(key, body[key] as string);
+		const value = body[key];
+		if (typeof value === 'object' && value !== null) {
+			formData.append(key, JSON.stringify(value));
+		} else {
+			formData.append(key, value as string);
+		}
 	}
 
 	for (const file of files) {

--- a/packages/frontend/@n8n/chat/src/api/generic.ts
+++ b/packages/frontend/@n8n/chat/src/api/generic.ts
@@ -55,7 +55,7 @@ export async function post<T>(url: string, body: object = {}, options: RequestIn
 }
 export async function postWithFiles<T>(
 	url: string,
-	body: Record<string, unknown> = {},
+	body: Record<string, string | object> = {},
 	files: File[] = [],
 	options: RequestInit = {},
 ) {
@@ -66,7 +66,7 @@ export async function postWithFiles<T>(
 		if (typeof value === 'object' && value !== null) {
 			formData.append(key, JSON.stringify(value));
 		} else {
-			formData.append(key, value as string);
+			formData.append(key, value);
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Fix FormData serialization bug in `postWithFiles` function where objects were being converted to "[object Object]" instead of JSON strings
- Add comprehensive test coverage for the `postWithFiles` function including object serialization, arrays, and edge cases
- Ensure metadata and other object parameters are properly transmitted in multipart/form-data requests

## Screenshots

### Before
Shows the metadata being serialized as "[object Object]" in the network request:
<img width="608" height="1105" alt="before" src="https://github.com/user-attachments/assets/e27a490a-4b88-4cf2-a5d3-ffcd3d876363" />

### After  
Shows the metadata properly serialized as JSON string:
<img width="693" height="1025" alt="after" src="https://github.com/user-attachments/assets/5d12fb95-40b5-4e6e-ae66-82272500adf8" />

### community issue
https://github.com/n8n-io/n8n/issues/17922

🤖 Generated with [Claude Code](https://claude.ai/code)