### PR TITLE
fix(core): Prevent re-entry during workflow activation

### DIFF
--- a/packages/cli/src/__tests__/active-workflow-manager.test.ts
+++ b/packages/cli/src/__tests__/active-workflow-manager.test.ts
@@ -148,4 +148,21 @@ describe('ActiveWorkflowManager', () => {
 			);
 		});
 	});
+
+	describe('addActiveWorkflows', () => {
+		test('should prevent concurrent activations', async () => {
+			const getAllActiveIds = jest.spyOn(workflowRepository, 'getAllActiveIds');
+
+			workflowRepository.getAllActiveIds.mockImplementation(
+				async () => await new Promise((resolve) => setTimeout(() => resolve(['workflow-1']), 50)),
+			);
+
+			await Promise.all([
+				activeWorkflowManager.addActiveWorkflows('init'),
+				activeWorkflowManager.addActiveWorkflows('leadershipChange'),
+			]);
+
+			expect(getAllActiveIds).toHaveBeenCalledTimes(1);
+		});
+	});
 });


### PR DESCRIPTION
## Summary

We have a [guarantee](https://github.com/n8n-io/n8n/blob/f3ef0a713c1f63015b8aee55b1b9dd7bcea21f54/packages/cli/src/active-workflow-manager.ts#L96-L99) that an instance is a leader or a follower by the time we reach workflow activation, but there is a race condition where workflow activation is triggered in reaction to a leadership acquisition while regular workflow activation on bootup is ongoing.

Workflow activation logic ideally should be atomic, possibly by queuing activations, but that is a larger refactor that will need to be its own dedicated effort. For now this PR prevents re-entry to protect against the race condition.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1069

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
