### PR TITLE
fix(core): Handle null workflow settings in toSaveSettings

### DIFF
--- a/packages/cli/src/execution-lifecycle/__tests__/to-save-settings.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/to-save-settings.test.ts
@@ -153,3 +153,21 @@ describe('execution progress', () => {
 		expect(_saveSettings.progress).toBe(false);
 	});
 });
+
+describe('null workflow settings', () => {
+	it('should handle null workflow settings without throwing', () => {
+		expect(() => toSaveSettings(null)).not.toThrow();
+
+		// Should use defaults from config when settings are null
+		config.set('executions.saveDataOnError', 'all');
+		config.set('executions.saveDataOnSuccess', 'all');
+		config.set('executions.saveDataManualExecutions', true);
+		config.set('executions.saveExecutionProgress', true);
+
+		const settingsWithNull = toSaveSettings(null);
+		expect(settingsWithNull.error).toBe(true);
+		expect(settingsWithNull.success).toBe(true);
+		expect(settingsWithNull.manual).toBe(true);
+		expect(settingsWithNull.progress).toBe(true);
+	});
+});

--- a/packages/cli/src/execution-lifecycle/to-save-settings.ts
+++ b/packages/cli/src/execution-lifecycle/to-save-settings.ts
@@ -17,7 +17,9 @@ export type ExecutionSaveSettings = {
  * - `manual`: Whether to save successful or failed manual executions.
  * - `progress`: Whether to save execution progress, i.e. after each node's execution.
  */
-export function toSaveSettings(workflowSettings: IWorkflowSettings = {}): ExecutionSaveSettings {
+export function toSaveSettings(
+	workflowSettings: IWorkflowSettings | null = {},
+): ExecutionSaveSettings {
 	const DEFAULTS = {
 		ERROR: config.getEnv('executions.saveDataOnError'),
 		SUCCESS: config.getEnv('executions.saveDataOnSuccess'),
@@ -30,7 +32,7 @@ export function toSaveSettings(workflowSettings: IWorkflowSettings = {}): Execut
 		saveDataSuccessExecution = DEFAULTS.SUCCESS,
 		saveManualExecutions = DEFAULTS.MANUAL,
 		saveExecutionProgress = DEFAULTS.PROGRESS,
-	} = workflowSettings;
+	} = workflowSettings ?? {};
 
 	return {
 		error: saveDataErrorExecution === 'DEFAULT' ? DEFAULTS.ERROR : saveDataErrorExecution === 'all',


### PR DESCRIPTION
## Summary
- Fixed a bug where null workflow settings from the database would cause a 'Cannot read properties of null' error
- Added nullish coalescing operator to handle null values gracefully

## Related Linear tickets, Github issues, and Community forum posts
- https://linear.app/n8n/issue/AI-1257/error-cannot-read-properties-of-null-reading-savedataerrorexecution

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)