### PR TITLE
feat(core): Unlock queue metrics for multi-main

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -248,6 +248,12 @@ export class Start extends BaseCommand<z.infer<typeof flagsSchema>> {
 		await this.moduleRegistry.initModules();
 
 		if (this.instanceSettings.isMultiMain) {
+			// we instantiate `PrometheusMetricsService` early to register its multi-main event handlers
+			if (this.globalConfig.endpoints.metrics.enable) {
+				const { PrometheusMetricsService } = await import('@/metrics/prometheus-metrics.service');
+				Container.get(PrometheusMetricsService);
+			}
+
 			Container.get(MultiMainSetup).registerEventHandlers();
 		}
 	}

--- a/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
+++ b/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
@@ -174,7 +174,7 @@ describe('PrometheusMetricsService', () => {
 				includeStatusCode: false,
 			});
 
-			expect(promClient.Gauge).toHaveBeenNthCalledWith(2, {
+			expect(promClient.Gauge).toHaveBeenNthCalledWith(3, {
 				name: 'n8n_last_activity',
 				help: 'last instance activity (backend request) in Unix time (seconds).',
 			});
@@ -209,12 +209,12 @@ describe('PrometheusMetricsService', () => {
 
 			// call 1 is for `n8n_version_info` (always enabled)
 
-			expect(promClient.Gauge).toHaveBeenNthCalledWith(2, {
+			expect(promClient.Gauge).toHaveBeenNthCalledWith(3, {
 				name: 'n8n_scaling_mode_queue_jobs_waiting',
 				help: 'Current number of enqueued jobs waiting for pickup in scaling mode.',
 			});
 
-			expect(promClient.Gauge).toHaveBeenNthCalledWith(3, {
+			expect(promClient.Gauge).toHaveBeenNthCalledWith(4, {
 				name: 'n8n_scaling_mode_queue_jobs_active',
 				help: 'Current number of jobs being processed across all workers in scaling mode.',
 			});
@@ -238,7 +238,7 @@ describe('PrometheusMetricsService', () => {
 
 			await prometheusMetricsService.init(app);
 
-			expect(promClient.Gauge).toHaveBeenCalledTimes(2); // version metric + active workflow count metric
+			expect(promClient.Gauge).toHaveBeenCalledTimes(3); // version metric + active workflow count metric + instance role metric
 			expect(promClient.Counter).toHaveBeenCalledTimes(0); // cache metrics
 			expect(eventService.on).not.toHaveBeenCalled();
 		});
@@ -260,9 +260,9 @@ describe('PrometheusMetricsService', () => {
 			await prometheusMetricsService.init(app);
 
 			// First call is n8n version metric
-			expect(promClient.Gauge).toHaveBeenCalledTimes(2);
+			expect(promClient.Gauge).toHaveBeenCalledTimes(3);
 
-			expect(promClient.Gauge).toHaveBeenNthCalledWith(2, {
+			expect(promClient.Gauge).toHaveBeenNthCalledWith(3, {
 				name: 'n8n_active_workflow_count',
 				help: 'Total number of active workflows.',
 				collect: expect.any(Function),

--- a/packages/cli/src/metrics/prometheus-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus-metrics.service.ts
@@ -1,6 +1,7 @@
 import { GlobalConfig } from '@n8n/config';
 import { Time } from '@n8n/constants';
 import { WorkflowRepository } from '@n8n/db';
+import { OnLeaderStepdown, OnLeaderTakeover } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 import type express from 'express';
 import promBundle from 'express-prom-bundle';
@@ -59,6 +60,7 @@ export class PrometheusMetricsService {
 		promClient.register.clear(); // clear all metrics in case we call this a second time
 		this.initDefaultMetrics();
 		this.initN8nVersionMetric();
+		if (this.instanceSettings.instanceType === 'main') this.initInstanceRoleMetric();
 		this.initCacheMetrics();
 		this.initEventBusMetrics();
 		this.initRouteMetrics(app);
@@ -110,6 +112,25 @@ export class PrometheusMetricsService {
 		const { version, major, minor, patch } = n8nVersion;
 
 		versionGauge.set({ version: 'v' + version, major, minor, patch }, 1);
+	}
+
+	private initInstanceRoleMetric() {
+		this.gauges.instanceRoleLeader = new promClient.Gauge({
+			name: this.prefix + 'instance_role_leader',
+			help: 'Whether this main instance is the leader (1) or not (0).',
+		});
+
+		this.gauges.instanceRoleLeader.set(this.instanceSettings.isLeader ? 1 : 0);
+	}
+
+	@OnLeaderTakeover()
+	updateOnLeaderTakeover() {
+		this.gauges.instanceRoleLeader?.set(1);
+	}
+
+	@OnLeaderStepdown()
+	updateOnLeaderStepdown() {
+		this.gauges.instanceRoleLeader?.set(0);
 	}
 
 	/**

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -405,8 +405,7 @@ export class ScalingService {
 	get isQueueMetricsEnabled() {
 		return (
 			this.globalConfig.endpoints.metrics.includeQueueMetrics &&
-			this.instanceSettings.instanceType === 'main' &&
-			this.instanceSettings.isSingleMain
+			this.instanceSettings.instanceType === 'main'
 		);
 	}
 


### PR DESCRIPTION
## Summary

This PR allows mains in a multi-main setup to start reporting queue metrics e.g. `scaling_mode_queue_jobs_waiting` and  introduces a new Prometheus gauge `instance_role_leader`. See [original discussion](https://n8nio.slack.com/archives/C069HS026UF/p1724226550685209) last year.

In future we may optimize by enabling or disabling the reporting of queue metrics on a main in response to leadership takeover or stepdown events.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-3184/investigate-prometheus-metrics-queue-metrics-for-multi-main

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
