### PR TITLE
feat: Add global repository search to GitHub node

### DIFF
--- a/packages/nodes-base/nodes/Github/Github.node.ts
+++ b/packages/nodes-base/nodes/Github/Github.node.ts
@@ -123,6 +123,10 @@ export class Github implements INodeType {
 						value: 'review',
 					},
 					{
+						name: 'Search',
+						value: 'search',
+					},
+					{
 						name: 'User',
 						value: 'user',
 					},
@@ -476,6 +480,26 @@ export class Github implements INodeType {
 				default: 'dispatch',
 			},
 			{
+				displayName: 'Operation',
+				name: 'operation',
+				type: 'options',
+				noDataExpression: true,
+				displayOptions: {
+					show: {
+						resource: ['search'],
+					},
+				},
+				options: [
+					{
+						name: 'Search Repositories',
+						value: 'searchRepositories',
+						description: 'Search repositories across all of GitHub',
+						action: 'Search repositories globally',
+					},
+				],
+				default: 'searchRepositories',
+			},
+			{
 				displayName:
 					'Your execution will pause until a webhook is called. This URL will be generated at runtime and passed to your Github workflow as a resumeUrl input.',
 				name: 'webhookNotice',
@@ -549,6 +573,7 @@ export class Github implements INodeType {
 				displayOptions: {
 					hide: {
 						operation: ['invite'],
+						resource: ['search'],
 					},
 				},
 			},
@@ -610,7 +635,7 @@ export class Github implements INodeType {
 				],
 				displayOptions: {
 					hide: {
-						resource: ['user', 'organization'],
+						resource: ['user', 'organization', 'search'],
 						operation: ['getRepositories'],
 					},
 				},
@@ -750,6 +775,115 @@ export class Github implements INodeType {
 					},
 				},
 				description: 'JSON object with input parameters for the workflow',
+			},
+
+			// ----------------------------------
+			//         search
+			// ----------------------------------
+
+			// ----------------------------------
+			//         search:searchRepositories
+			// ----------------------------------
+			{
+				displayName: 'Search Query',
+				name: 'query',
+				type: 'string',
+				default: '',
+				required: true,
+				displayOptions: {
+					show: {
+						resource: ['search'],
+						operation: ['searchRepositories'],
+					},
+				},
+				placeholder: 'language:javascript stars:>1000',
+				description:
+					'The search query. Supports GitHub search syntax like language:javascript, stars:>1000, etc.',
+			},
+			{
+				displayName: 'Sort By',
+				name: 'sort',
+				type: 'options',
+				options: [
+					{
+						name: 'Best Match',
+						value: 'best-match',
+					},
+					{
+						name: 'Stars',
+						value: 'stars',
+					},
+					{
+						name: 'Forks',
+						value: 'forks',
+					},
+					{
+						name: 'Help Wanted Issues',
+						value: 'help-wanted-issues',
+					},
+					{
+						name: 'Updated',
+						value: 'updated',
+					},
+				],
+				default: 'best-match',
+				displayOptions: {
+					show: {
+						resource: ['search'],
+						operation: ['searchRepositories'],
+					},
+				},
+				description: 'The sort field',
+			},
+			{
+				displayName: 'Order',
+				name: 'order',
+				type: 'options',
+				options: [
+					{
+						name: 'Descending',
+						value: 'desc',
+					},
+					{
+						name: 'Ascending',
+						value: 'asc',
+					},
+				],
+				default: 'desc',
+				displayOptions: {
+					show: {
+						resource: ['search'],
+						operation: ['searchRepositories'],
+					},
+				},
+				description: 'The sort order',
+			},
+			{
+				displayName: 'Return All',
+				name: 'returnAll',
+				type: 'boolean',
+				default: false,
+				displayOptions: {
+					show: {
+						resource: ['search'],
+						operation: ['searchRepositories'],
+					},
+				},
+				description: 'Whether to return all results or only up to a given limit',
+			},
+			{
+				displayName: 'Limit',
+				name: 'limit',
+				type: 'number',
+				default: 30,
+				displayOptions: {
+					show: {
+						resource: ['search'],
+						operation: ['searchRepositories'],
+						returnAll: [false],
+					},
+				},
+				description: 'Max number of results to return',
 			},
 
 			// ----------------------------------
@@ -2161,6 +2295,7 @@ export class Github implements INodeType {
 			'release:getAll',
 			'review:getAll',
 			'organization:getRepositories',
+			'search:searchRepositories',
 		];
 
 		// For Post
@@ -2231,7 +2366,7 @@ export class Github implements INodeType {
 				qs = {};
 
 				let owner = '';
-				if (fullOperation !== 'user:invite') {
+				if (fullOperation !== 'user:invite' && fullOperation !== 'search:searchRepositories') {
 					// Request the parameters which almost all operations need
 					owner = this.getNodeParameter('owner', i, '', { extractValue: true }) as string;
 				}
@@ -2240,7 +2375,8 @@ export class Github implements INodeType {
 				if (
 					fullOperation !== 'user:getRepositories' &&
 					fullOperation !== 'user:invite' &&
-					fullOperation !== 'organization:getRepositories'
+					fullOperation !== 'organization:getRepositories' &&
+					fullOperation !== 'search:searchRepositories'
 				) {
 					repository = this.getNodeParameter('repository', i, '', { extractValue: true }) as string;
 				}
@@ -2651,6 +2787,30 @@ export class Github implements INodeType {
 						requestMethod = 'GET';
 
 						endpoint = `/orgs/${owner}/repos`;
+						returnAll = this.getNodeParameter('returnAll', 0);
+
+						if (!returnAll) {
+							qs.per_page = this.getNodeParameter('limit', 0);
+						}
+					}
+				} else if (resource === 'search') {
+					if (operation === 'searchRepositories') {
+						// ----------------------------------
+						//         searchRepositories
+						// ----------------------------------
+
+						requestMethod = 'GET';
+
+						endpoint = '/search/repositories';
+
+						const query = this.getNodeParameter('query', i) as string;
+						const sort = this.getNodeParameter('sort', i) as string;
+						const order = this.getNodeParameter('order', i) as string;
+
+						qs.q = query;
+						qs.sort = sort;
+						qs.order = order;
+
 						returnAll = this.getNodeParameter('returnAll', 0);
 
 						if (!returnAll) {

--- a/packages/nodes-base/nodes/Github/Github.node.ts
+++ b/packages/nodes-base/nodes/Github/Github.node.ts
@@ -2803,7 +2803,7 @@ export class Github implements INodeType {
 
 						endpoint = '/search/repositories';
 
-						const query = this.getNodeParameter('query', i) as string;
+							const query: string = this.getNodeParameter('query', i);
 						const sort = this.getNodeParameter('sort', i) as string;
 						const order = this.getNodeParameter('order', i) as string;
 

--- a/packages/nodes-base/nodes/Github/Github.node.ts
+++ b/packages/nodes-base/nodes/Github/Github.node.ts
@@ -2807,7 +2807,7 @@ export class Github implements INodeType {
 
 						endpoint = '/search/repositories';
 
-							const query: string = this.getNodeParameter('query', i);
+						const query = this.getNodeParameter('query', i) as string;
 						const sort = this.getNodeParameter('sort', i) as string;
 						const order = this.getNodeParameter('order', i) as string;
 

--- a/packages/nodes-base/nodes/Github/Github.node.ts
+++ b/packages/nodes-base/nodes/Github/Github.node.ts
@@ -876,6 +876,10 @@ export class Github implements INodeType {
 				name: 'limit',
 				type: 'number',
 				default: 30,
+				typeOptions: {
+					minValue: 1,
+					maxValue: 100,
+				},
 				displayOptions: {
 					show: {
 						resource: ['search'],
@@ -883,7 +887,7 @@ export class Github implements INodeType {
 						returnAll: [false],
 					},
 				},
-				description: 'Max number of results to return',
+				description: 'Max number of results to return (GitHub API limit: 100)',
 			},
 
 			// ----------------------------------
@@ -2808,8 +2812,13 @@ export class Github implements INodeType {
 						const order = this.getNodeParameter('order', i) as string;
 
 						qs.q = query;
-						qs.sort = sort;
-						qs.order = order;
+
+						// GitHub API doesn't accept 'best-match' as a sort parameter
+						// When sort is 'best-match', we omit the sort and order parameters
+						if (sort !== 'best-match') {
+							qs.sort = sort;
+							qs.order = order;
+						}
 
 						returnAll = this.getNodeParameter('returnAll', 0);
 

--- a/packages/nodes-base/nodes/Github/__tests__/node/GithubSearch.test.ts
+++ b/packages/nodes-base/nodes/Github/__tests__/node/GithubSearch.test.ts
@@ -1,0 +1,329 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import { NodeApiError, NodeOperationError } from 'n8n-workflow';
+
+import * as utilities from '../../../../utils/utilities';
+import { Github } from '../../Github.node';
+
+// Mock the GitHub API functions
+jest.mock('../../GenericFunctions', () => ({
+	githubApiRequest: jest.fn(),
+	githubApiRequestAllItems: jest.fn(),
+}));
+
+import { githubApiRequest, githubApiRequestAllItems } from '../../GenericFunctions';
+
+describe('Test Github Search Node', () => {
+	describe('Search Repositories', () => {
+		const searchResponse = {
+			total_count: 1234,
+			incomplete_results: false,
+			items: [
+				{
+					id: 123456789,
+					node_id: 'MDEwOlJlcG9zaXRvcnkxMjM0NTY3ODk=',
+					name: 'test-repo',
+					full_name: 'test-owner/test-repo',
+					private: false,
+					owner: {
+						login: 'test-owner',
+						id: 123456,
+						type: 'User',
+					},
+					html_url: 'https://github.com/test-owner/test-repo',
+					description: 'A test repository',
+					fork: false,
+					url: 'https://api.github.com/repos/test-owner/test-repo',
+					created_at: '2023-01-01T00:00:00Z',
+					updated_at: '2023-01-02T00:00:00Z',
+					pushed_at: '2023-01-03T00:00:00Z',
+					git_url: 'git://github.com/test-owner/test-repo.git',
+					ssh_url: 'git@github.com:test-owner/test-repo.git',
+					clone_url: 'https://github.com/test-owner/test-repo.git',
+					size: 1024,
+					language: 'JavaScript',
+					has_issues: true,
+					has_projects: true,
+					has_downloads: true,
+					has_wiki: true,
+					has_pages: false,
+					has_discussions: false,
+					forks_count: 10,
+					mirror_url: null,
+					archived: false,
+					disabled: false,
+					open_issues_count: 5,
+					license: {
+						key: 'mit',
+						name: 'MIT License',
+						url: 'https://api.github.com/licenses/mit',
+					},
+					allow_forking: true,
+					is_template: false,
+					web_commit_signoff_required: false,
+					topics: ['test', 'example'],
+					visibility: 'public',
+					forks: 10,
+					open_issues: 5,
+					watchers: 20,
+					default_branch: 'main',
+					score: 1.0,
+				},
+			],
+		};
+
+		beforeAll(async () => {
+			jest.useFakeTimers({ doNotFake: ['nextTick'] });
+		});
+
+		describe('Search Repositories Operation', () => {
+			let githubNode: Github;
+			let mockExecutionContext: any;
+
+			beforeEach(() => {
+				githubNode = new Github();
+				mockExecutionContext = {
+					getNode: jest.fn().mockReturnValue({ name: 'Github' }),
+					getNodeParameter: jest.fn(),
+					getInputData: jest.fn().mockReturnValue([{ json: {} }]),
+					continueOnFail: jest.fn().mockReturnValue(false),
+					getCredentials: jest.fn().mockResolvedValue({
+						server: 'https://api.github.com',
+						user: 'test',
+						accessToken: 'test',
+					}),
+					helpers: {
+						returnJsonArray: jest.fn().mockReturnValue([{ json: searchResponse }]),
+						constructExecutionMetaData: jest.fn().mockReturnValue([{ json: searchResponse }]),
+					},
+				};
+
+				// Reset mocks
+				(githubApiRequest as jest.Mock).mockReset();
+				(githubApiRequestAllItems as jest.Mock).mockReset();
+			});
+
+			it('should search repositories with basic query', async () => {
+				mockExecutionContext.getNodeParameter.mockImplementation((parameterName: string) => {
+					switch (parameterName) {
+						case 'resource':
+							return 'search';
+						case 'operation':
+							return 'searchRepositories';
+						case 'query':
+							return 'language:javascript stars:>1000';
+						case 'sort':
+							return 'stars';
+						case 'order':
+							return 'desc';
+						case 'returnAll':
+							return false;
+						case 'limit':
+							return 30;
+						default:
+							return '';
+					}
+				});
+
+				(githubApiRequest as jest.Mock).mockResolvedValue(searchResponse);
+
+				const result = await githubNode.execute.call(mockExecutionContext);
+
+				expect(githubApiRequest).toHaveBeenCalledWith(
+					'GET',
+					'/search/repositories',
+					{},
+					{
+						q: 'language:javascript stars:>1000',
+						sort: 'stars',
+						order: 'desc',
+						per_page: 30,
+					},
+				);
+
+				expect(result).toEqual([[{ json: searchResponse }]]);
+			});
+
+			it('should search repositories with returnAll enabled', async () => {
+				mockExecutionContext.getNodeParameter.mockImplementation((parameterName: string) => {
+					switch (parameterName) {
+						case 'resource':
+							return 'search';
+						case 'operation':
+							return 'searchRepositories';
+						case 'query':
+							return 'react hooks';
+						case 'sort':
+							return 'best-match';
+						case 'order':
+							return 'desc';
+						case 'returnAll':
+							return true;
+						default:
+							return '';
+					}
+				});
+
+				(githubApiRequestAllItems as jest.Mock).mockResolvedValue(searchResponse.items);
+
+				const result = await githubNode.execute.call(mockExecutionContext);
+
+				expect(githubApiRequestAllItems).toHaveBeenCalledWith(
+					'GET',
+					'/search/repositories',
+					{},
+					{
+						q: 'react hooks',
+						sort: 'best-match',
+						order: 'desc',
+					},
+				);
+
+				expect(result).toEqual([[{ json: searchResponse }]]);
+			});
+
+			it('should handle search with different sort options', async () => {
+				mockExecutionContext.getNodeParameter.mockImplementation((parameterName: string) => {
+					switch (parameterName) {
+						case 'resource':
+							return 'search';
+						case 'operation':
+							return 'searchRepositories';
+						case 'query':
+							return 'machine learning';
+						case 'sort':
+							return 'forks';
+						case 'order':
+							return 'asc';
+						case 'returnAll':
+							return false;
+						case 'limit':
+							return 10;
+						default:
+							return '';
+					}
+				});
+
+				(githubApiRequest as jest.Mock).mockResolvedValue(searchResponse);
+
+				const result = await githubNode.execute.call(mockExecutionContext);
+
+				expect(githubApiRequest).toHaveBeenCalledWith(
+					'GET',
+					'/search/repositories',
+					{},
+					{
+						q: 'machine learning',
+						sort: 'forks',
+						order: 'asc',
+						per_page: 10,
+					},
+				);
+
+				expect(result).toEqual([[{ json: searchResponse }]]);
+			});
+
+			it('should handle search with user filter', async () => {
+				mockExecutionContext.getNodeParameter.mockImplementation((parameterName: string) => {
+					switch (parameterName) {
+						case 'resource':
+							return 'search';
+						case 'operation':
+							return 'searchRepositories';
+						case 'query':
+							return 'user:facebook react';
+						case 'sort':
+							return 'updated';
+						case 'order':
+							return 'desc';
+						case 'returnAll':
+							return false;
+						case 'limit':
+							return 50;
+						default:
+							return '';
+					}
+				});
+
+				(githubApiRequest as jest.Mock).mockResolvedValue(searchResponse);
+
+				const result = await githubNode.execute.call(mockExecutionContext);
+
+				expect(githubApiRequest).toHaveBeenCalledWith(
+					'GET',
+					'/search/repositories',
+					{},
+					{
+						q: 'user:facebook react',
+						sort: 'updated',
+						order: 'desc',
+						per_page: 50,
+					},
+				);
+
+				expect(result).toEqual([[{ json: searchResponse }]]);
+			});
+
+			it('should handle search with organization filter', async () => {
+				mockExecutionContext.getNodeParameter.mockImplementation((parameterName: string) => {
+					switch (parameterName) {
+						case 'resource':
+							return 'search';
+						case 'operation':
+							return 'searchRepositories';
+						case 'query':
+							return 'org:microsoft language:typescript';
+						case 'sort':
+							return 'help-wanted-issues';
+						case 'order':
+							return 'desc';
+						case 'returnAll':
+							return false;
+						case 'limit':
+							return 25;
+						default:
+							return '';
+					}
+				});
+
+				(githubApiRequest as jest.Mock).mockResolvedValue(searchResponse);
+
+				const result = await githubNode.execute.call(mockExecutionContext);
+
+				expect(githubApiRequest).toHaveBeenCalledWith(
+					'GET',
+					'/search/repositories',
+					{},
+					{
+						q: 'org:microsoft language:typescript',
+						sort: 'help-wanted-issues',
+						order: 'desc',
+						per_page: 25,
+					},
+				);
+
+				expect(result).toEqual([[{ json: searchResponse }]]);
+			});
+
+			it('should handle API errors gracefully', async () => {
+				mockExecutionContext.getNodeParameter.mockImplementation((parameterName: string) => {
+					switch (parameterName) {
+						case 'resource':
+							return 'search';
+						case 'operation':
+							return 'searchRepositories';
+						case 'query':
+							return 'invalid:query:';
+						default:
+							return '';
+					}
+				});
+
+				(githubApiRequest as jest.Mock).mockRejectedValue(
+					new NodeApiError('GitHub API Error', { statusCode: 422 }),
+				);
+
+				await expect(githubNode.execute.call(mockExecutionContext)).rejects.toThrow(NodeApiError);
+			});
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Github/__tests__/node/GithubSearch.test.ts
+++ b/packages/nodes-base/nodes/Github/__tests__/node/GithubSearch.test.ts
@@ -1,7 +1,4 @@
-import { NodeTestHarness } from '@nodes-testing/node-test-harness';
-import { NodeApiError, NodeOperationError } from 'n8n-workflow';
-
-import * as utilities from '../../../../utils/utilities';
+import { NodeApiError } from 'n8n-workflow';
 import { Github } from '../../Github.node';
 
 // Mock the GitHub API functions

--- a/packages/nodes-base/nodes/Github/__tests__/node/GithubSearch.test.ts
+++ b/packages/nodes-base/nodes/Github/__tests__/node/GithubSearch.test.ts
@@ -173,8 +173,6 @@ describe('Test Github Search Node', () => {
 					{},
 					{
 						q: 'react hooks',
-						sort: 'best-match',
-						order: 'desc',
 					},
 				);
 
@@ -319,7 +317,10 @@ describe('Test Github Search Node', () => {
 				});
 
 				(githubApiRequest as jest.Mock).mockRejectedValue(
-					new NodeApiError('GitHub API Error', { statusCode: 422 }),
+					new NodeApiError(mockExecutionContext.getNode(), {
+						statusCode: 422,
+						message: 'GitHub API Error',
+					}),
 				);
 
 				await expect(githubNode.execute.call(mockExecutionContext)).rejects.toThrow(NodeApiError);

--- a/packages/nodes-base/nodes/Github/__tests__/node/GithubSearchWorkflow.json
+++ b/packages/nodes-base/nodes/Github/__tests__/node/GithubSearchWorkflow.json
@@ -1,0 +1,87 @@
+{
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [-300, 260],
+			"id": "b14bf20f-78b0-490a-bbc6-d02b1af4c03c",
+			"name": "When clicking 'Execute workflow'"
+		},
+		{
+			"parameters": {
+				"resource": "search",
+				"operation": "searchRepositories",
+				"query": "language:javascript stars:>1000",
+				"sort": "stars",
+				"order": "desc",
+				"returnAll": false,
+				"limit": 10
+			},
+			"type": "n8n-nodes-base.github",
+			"typeVersion": 1,
+			"position": [-80, 260],
+			"id": "061752c9-507c-4b27-ba18-47b21d487aed",
+			"name": "GitHub Search",
+			"credentials": {
+				"githubApi": {
+					"id": "1",
+					"name": "GitHub account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [120, 260],
+			"id": "3bc54e8f-eeba-496d-a95f-bb8927eff671",
+			"name": "No Operation, do nothing"
+		}
+	],
+	"connections": {
+		"When clicking 'Execute workflow'": {
+			"main": [
+				[
+					{
+						"node": "GitHub Search",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"GitHub Search": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"total_count": 1234,
+					"incomplete_results": false,
+					"items": [
+						{
+							"id": 123456789,
+							"name": "test-repo",
+							"full_name": "test-owner/test-repo",
+							"description": "A test repository",
+							"language": "JavaScript",
+							"stars": 1000,
+							"forks": 10
+						}
+					]
+				}
+			}
+		]
+	}
+}

--- a/packages/nodes-base/nodes/Github/__tests__/node/GithubSearchWorkflow.json
+++ b/packages/nodes-base/nodes/Github/__tests__/node/GithubSearchWorkflow.json
@@ -76,7 +76,7 @@
 							"full_name": "test-owner/test-repo",
 							"description": "A test repository",
 							"language": "JavaScript",
-							"stars": 1000,
+               "stargazers_count": 1000,
 							"forks": 10
 						}
 					]


### PR DESCRIPTION
# Add Global Repository Search to GitHub Node

## Description
This PR adds a new "Search" resource to the GitHub node that allows users to search repositories globally across all of GitHub using the GitHub Search API.

## Changes Made

### Core Implementation
- **Added "Search" resource** to the GitHub node resource options
- **Added "Search Repositories" operation** with comprehensive parameters:
  - `query`: Search query string (supports GitHub search syntax)
  - `sort`: Sort options (best-match, stars, forks, help-wanted-issues, updated)
  - `order`: Sort order (asc/desc)
  - `returnAll`: Boolean to control pagination
  - `limit`: Maximum results when returnAll is false
- **Added execution logic** to call GitHub's `/search/repositories` API endpoint
- **Updated parameter visibility** to hide owner/repository fields for global search

### Testing
- **Unit Tests**: Created `GithubSearch.test.ts` with 6 comprehensive test cases
- **Workflow Tests**: Created `GithubSearchWorkflow.json` for workflow testing
- **Test Coverage**: Tests cover basic queries, returnAll functionality, different sort options, user filters, organization filters, and error handling

## Use Cases
This feature enables users to:
- Search for repositories by language, stars, forks, etc.
- Filter by user or organization: `user:facebook react`
- Find trending repositories: `language:javascript stars:>1000`
- Discover projects by topic: `org:microsoft language:typescript`
- Search for help-wanted repositories: `help-wanted-issues:>5`

## API Compatibility
- Uses official GitHub Search API (`/search/repositories`)
- Supports all GitHub search syntax and filters
- Handles pagination correctly with `returnAll` parameter
- Maintains existing authentication methods (Access Token/OAuth2)

## Testing
All tests pass:
```bash
- search repositories with basic query
-search repositories with returnAll enabled  
- handle search with different sort options
- handle search with user filter
- handle search with organization filter
- handle API errors gracefully
```

## Breaking Changes
None. This is a purely additive feature that doesn't affect existing functionality.

## Checklist
- [x] Tests included for new functionality
- [x] Code follows n8n conventions
- [x] Small, focused PR
- [x] Not a new node (enhancement to existing GitHub node)
- [x] Documentation updated (if applicable)