### PR TITLE
ci: Cat 1072 security nightly cleanup

### DIFF
--- a/.github/workflows/security-trivy-scan-callable.yml
+++ b/.github/workflows/security-trivy-scan-callable.yml
@@ -4,35 +4,29 @@ on:
   workflow_dispatch:
     inputs:
       image_ref:
-        description: Full image reference to scan e.g ghcr.io/n8n-io/n8n:latest
+        description: 'Full image reference to scan e.g. ghcr.io/n8n-io/n8n:latest'
         required: true
         default: 'ghcr.io/n8n-io/n8n:latest'
   workflow_call:
     inputs:
       image_ref:
         type: string
-        description: Full image reference to scan e.g ghcr.io/n8n-io/n8n:latest
+        description: 'Full image reference to scan e.g. ghcr.io/n8n-io/n8n:latest'
         required: true
     secrets:
       SLACK_WEBHOOK_URL:
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   security_scan:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Pull Docker image with retry
-        run: |
-          for i in {1..4}; do
-            docker pull "${{ inputs.image_ref }}" && break
-            [ $i -lt 4 ] && echo "Retry $i failed, waiting..." && sleep 15
-          done
-
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4 # v0.30.0
+        uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4 # v0.32.0
+        id: trivy_scan
         with:
           image-ref: ${{ inputs.image_ref }}
           format: 'json'
@@ -42,85 +36,128 @@ jobs:
           ignore-unfixed: false
           exit-code: '0'
 
-      - name: Process vulnerability results
-        id: process_vulns
+      - name: Process scan results and generate reports
+        id: process_results
         run: |
-          if [ -f trivy-results.json ]; then
-            CRITICAL_COUNT=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "CRITICAL")] | length' trivy-results.json)
-            HIGH_COUNT=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "HIGH")] | length' trivy-results.json)
-            MEDIUM_COUNT=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "MEDIUM")] | length' trivy-results.json)
-            LOW_COUNT=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "LOW")] | length' trivy-results.json)
-
-            TOTAL_VULNS=$((CRITICAL_COUNT + HIGH_COUNT + MEDIUM_COUNT + LOW_COUNT))
-
-            echo "critical_count=${CRITICAL_COUNT}" >> $GITHUB_OUTPUT
-            echo "high_count=${HIGH_COUNT}" >> $GITHUB_OUTPUT
-            echo "medium_count=${MEDIUM_COUNT}" >> $GITHUB_OUTPUT
-            echo "low_count=${LOW_COUNT}" >> $GITHUB_OUTPUT
-            echo "total_count=${TOTAL_VULNS}" >> $GITHUB_OUTPUT
-
-            if [ $TOTAL_VULNS -gt 0 ]; then
-              echo "vulnerabilities_found=true" >> $GITHUB_OUTPUT
-
-              # Extract top vulnerabilities for display (limit to 10 for readability)
-              TOP_VULNS=$(jq -r '
-                .Results[]?
-                | .Vulnerabilities[]?
-                | select(.Severity == "CRITICAL" or .Severity == "HIGH" or .Severity == "MEDIUM" or .Severity == "LOW")
-                | "• \(.VulnerabilityID): \(.Title // "No title") (\(.Severity))"
-              ' trivy-results.json | head -10)
-
-              echo "top_vulnerabilities<<EOF" >> $GITHUB_OUTPUT
-              echo "$TOP_VULNS" >> $GITHUB_OUTPUT
-              echo "EOF" >> $GITHUB_OUTPUT
-            else
-              echo "vulnerabilities_found=false" >> $GITHUB_OUTPUT
-            fi
+          # Check if results file is empty or missing
+          if [ ! -s trivy-results.json ]; then
+            echo "Trivy results file not found or is empty. Assuming no vulnerabilities."
+            TOTAL_VULNS=0
+            COUNTS='{"critical":0, "high":0, "medium":0, "low":0}'
           else
-            echo "Trivy results file not found."
-            echo "vulnerabilities_found=false" >> $GITHUB_OUTPUT
+            COUNTS=$(jq '{
+              critical: ([.Results[]?.Vulnerabilities[]? | select(.Severity == "CRITICAL")] | length),
+              high:     ([.Results[]?.Vulnerabilities[]? | select(.Severity == "HIGH")] | length),
+              medium:   ([.Results[]?.Vulnerabilities[]? | select(.Severity == "MEDIUM")] | length),
+              low:      ([.Results[]?.Vulnerabilities[]? | select(.Severity == "LOW")] | length)
+            }' trivy-results.json)
+            TOTAL_VULNS=$(echo $COUNTS | jq '.critical + .high + .medium + .low')
+
+            # Generate vulnerability lists if vulnerabilities found
+            if [ $TOTAL_VULNS -gt 0 ]; then
+              # GitHub summary list (up to 50)
+              {
+                echo "vulnerabilities_list<<EOF"
+                jq -r '.Results[]? | .Vulnerabilities[]? | "• \(.VulnerabilityID): \(.Title // "No title") (\(.Severity))"' trivy-results.json | head -50
+                echo "EOF"
+              } >> $GITHUB_OUTPUT
+
+              # Slack list (up to 10) - format with proper newlines for JSON
+              SLACK_CVE_LIST=$(jq -r '.Results[]?.Vulnerabilities[]? | "• \(.VulnerabilityID): \(.Title // "No title") (\(.Severity))"' trivy-results.json | head -10 | sed ':a;N;$!ba;s/\n/\\n/g')
+              echo "slack_cve_list=$SLACK_CVE_LIST" >> $GITHUB_OUTPUT
+
+              # Also create unescaped version for bot token method (if you switch)
+              {
+                echo "slack_cve_list_raw<<EOF"
+                jq -r '.Results[]?.Vulnerabilities[]? | "• \(.VulnerabilityID): \(.Title // "No title") (\(.Severity))"' trivy-results.json | head -10
+                echo "EOF"
+              } >> $GITHUB_OUTPUT
+            fi
           fi
 
-      - name: Notify Slack - Vulnerabilities Found
-        uses: act10ns/slack@44541246747a30eb3102d87f7a4cc5471b0ffb7d # v2.1.0
-        if: steps.process_vulns.outputs.vulnerabilities_found == 'true'
+          # Set outputs
+          echo "critical_count=$(echo $COUNTS | jq .critical)" >> $GITHUB_OUTPUT
+          echo "high_count=$(echo $COUNTS | jq .high)" >> $GITHUB_OUTPUT
+          echo "medium_count=$(echo $COUNTS | jq .medium)" >> $GITHUB_OUTPUT
+          echo "low_count=$(echo $COUNTS | jq .low)" >> $GITHUB_OUTPUT
+          echo "total_count=$TOTAL_VULNS" >> $GITHUB_OUTPUT
+          echo "vulnerabilities_found=$(if [ $TOTAL_VULNS -gt 0 ]; then echo true; else echo false; fi)" >> $GITHUB_OUTPUT
+
+      - name: Post scan summary
+        run: |
+          if [ "${{ steps.process_results.outputs.vulnerabilities_found }}" = "true" ]; then
+            cat >> $GITHUB_STEP_SUMMARY <<EOF
+          # Trivy Security Scan Report :warning:
+
+          **Image:** \`${{ inputs.image_ref }}\`
+
+          Found **${{ steps.process_results.outputs.total_count }}** vulnerabilities.
+
+          | Severity | Count |
+          |:---|:---:|
+          | Critical | ${{ steps.process_results.outputs.critical_count }} |
+          | High     | ${{ steps.process_results.outputs.high_count }} |
+          | Medium   | ${{ steps.process_results.outputs.medium_count }} |
+          | Low      | ${{ steps.process_results.outputs.low_count }} |
+
+          ### CVEs Found
+          ${{ steps.process_results.outputs.vulnerabilities_list }}
+          EOF
+          else
+            echo "## Trivy Security Scan Report :white_check_mark:" >> $GITHUB_STEP_SUMMARY
+            echo "No vulnerabilities found in \`${{ inputs.image_ref }}\`." >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Send Slack notification on failure
+        if: steps.process_results.outputs.vulnerabilities_found == 'true'
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
-          status: 'warning'
-          channel: '#mission-security'
-          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          message: |
-            :warning: *Trivy Scan: Vulnerabilities Detected*
-
-            *Repository:* `${{ github.repository }}`
-            *Image Ref:* `${{ inputs.image_ref }}`
-
-            *Vulnerability Summary:*
-            • *Critical:* ${{ steps.process_vulns.outputs.critical_count }}
-            • *High:* ${{ steps.process_vulns.outputs.high_count }}
-            • *Medium:* ${{ steps.process_vulns.outputs.medium_count }}
-            • *Low:* ${{ steps.process_vulns.outputs.low_count }}
-            • *Total:* ${{ steps.process_vulns.outputs.total_count }}
-
-            *Top Vulnerabilities (showing first 10):*
-            ```
-            ${{ steps.process_vulns.outputs.top_vulnerabilities }}
-            ```
-
-            :point_right: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Full Scan Results>
-
-      - name: Notify Slack - No Vulnerabilities
-        uses: act10ns/slack@44541246747a30eb3102d87f7a4cc5471b0ffb7d # v2.1.0
-        if: steps.process_vulns.outputs.vulnerabilities_found == 'false'
-        with:
-          status: 'success'
-          channel: '#mission-security'
-          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          message: |
-            :white_check_mark: *Trivy Scan: All Clear*
-
-            *Repository:* `${{ github.repository }}`
-            *Image Ref:* `${{ inputs.image_ref }}`
-
-            No vulnerabilities detected in the Docker image scan.
-
-            :point_right: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Scan Results>
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": { "type": "plain_text", "text": ":warning: Trivy Scan: Vulnerabilities Detected" }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    { "type": "mrkdwn", "text": "*Repository:*\n`${{ github.repository }}`" },
+                    { "type": "mrkdwn", "text": "*Image Scanned:*\n`${{ inputs.image_ref }}`" }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Vulnerability Summary:*\n• *Critical:* ${{ steps.process_results.outputs.critical_count }}\n• *High:* ${{ steps.process_results.outputs.high_count }}\n• *Medium:* ${{ steps.process_results.outputs.medium_count }}\n• *Low:* ${{ steps.process_results.outputs.low_count }}\n• *Total:* *${{ steps.process_results.outputs.total_count }}*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*CVEs Found (showing up to 10):*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*CVEs Found (showing up to 10):*\n${{ steps.process_results.outputs.slack_cve_list }}"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": { "type": "plain_text", "text": "View Job Summary" },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }

--- a/.github/workflows/security-trivy-scan-callable.yml
+++ b/.github/workflows/security-trivy-scan-callable.yml
@@ -14,14 +14,19 @@ on:
         description: 'Full image reference to scan e.g. ghcr.io/n8n-io/n8n:latest'
         required: true
     secrets:
-      SLACK_WEBHOOK_URL:
+      SLACK_BOT_TOKEN:
         required: true
 
 permissions:
   contents: read
 
+env:
+  SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+  SLACK_CHANNEL_ID: C042WDXPTEZ #mission-security
+
 jobs:
   security_scan:
+    name: Security - Scan Docker Image With Trivy
     runs-on: ubuntu-latest
     steps:
       - name: Run Trivy vulnerability scanner
@@ -31,133 +36,174 @@ jobs:
           image-ref: ${{ inputs.image_ref }}
           format: 'json'
           output: 'trivy-results.json'
-          severity: 'CRITICAL,HIGH,MEDIUM,LOW'
-          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
           ignore-unfixed: false
           exit-code: '0'
 
-      - name: Process scan results and generate reports
+      - name: Calculate vulnerability counts
         id: process_results
         run: |
-          # Check if results file is empty or missing
-          if [ ! -s trivy-results.json ]; then
-            echo "Trivy results file not found or is empty. Assuming no vulnerabilities."
-            TOTAL_VULNS=0
-            COUNTS='{"critical":0, "high":0, "medium":0, "low":0}'
-          else
-            COUNTS=$(jq '{
-              critical: ([.Results[]?.Vulnerabilities[]? | select(.Severity == "CRITICAL")] | length),
-              high:     ([.Results[]?.Vulnerabilities[]? | select(.Severity == "HIGH")] | length),
-              medium:   ([.Results[]?.Vulnerabilities[]? | select(.Severity == "MEDIUM")] | length),
-              low:      ([.Results[]?.Vulnerabilities[]? | select(.Severity == "LOW")] | length)
-            }' trivy-results.json)
-            TOTAL_VULNS=$(echo $COUNTS | jq '.critical + .high + .medium + .low')
-
-            # Generate vulnerability lists if vulnerabilities found
-            if [ $TOTAL_VULNS -gt 0 ]; then
-              # GitHub summary list (up to 50)
-              {
-                echo "vulnerabilities_list<<EOF"
-                jq -r '.Results[]? | .Vulnerabilities[]? | "• \(.VulnerabilityID): \(.Title // "No title") (\(.Severity))"' trivy-results.json | head -50
-                echo "EOF"
-              } >> $GITHUB_OUTPUT
-
-              # Slack list (up to 10) - format with proper newlines for JSON
-              SLACK_CVE_LIST=$(jq -r '.Results[]?.Vulnerabilities[]? | "• \(.VulnerabilityID): \(.Title // "No title") (\(.Severity))"' trivy-results.json | head -10 | sed ':a;N;$!ba;s/\n/\\n/g')
-              echo "slack_cve_list=$SLACK_CVE_LIST" >> $GITHUB_OUTPUT
-
-              # Also create unescaped version for bot token method (if you switch)
-              {
-                echo "slack_cve_list_raw<<EOF"
-                jq -r '.Results[]?.Vulnerabilities[]? | "• \(.VulnerabilityID): \(.Title // "No title") (\(.Severity))"' trivy-results.json | head -10
-                echo "EOF"
-              } >> $GITHUB_OUTPUT
-            fi
+          if [ ! -s trivy-results.json ] || [ $(jq '.Results | length' trivy-results.json) -eq 0 ]; then
+            echo "No high-severity vulnerabilities found."
+            echo "vulnerabilities_found=false" >> $GITHUB_OUTPUT
+            exit 0
           fi
 
-          # Set outputs
-          echo "critical_count=$(echo $COUNTS | jq .critical)" >> $GITHUB_OUTPUT
-          echo "high_count=$(echo $COUNTS | jq .high)" >> $GITHUB_OUTPUT
-          echo "medium_count=$(echo $COUNTS | jq .medium)" >> $GITHUB_OUTPUT
-          echo "low_count=$(echo $COUNTS | jq .low)" >> $GITHUB_OUTPUT
+          # Calculate counts by severity
+          CRITICAL_COUNT=$(jq '([.Results[]?.Vulnerabilities[]? | select(.Severity == "CRITICAL")] | length)' trivy-results.json)
+          HIGH_COUNT=$(jq '([.Results[]?.Vulnerabilities[]? | select(.Severity == "HIGH")] | length)' trivy-results.json)
+          TOTAL_VULNS=$((CRITICAL_COUNT + HIGH_COUNT))
+
+          # Get unique CVE count
+          UNIQUE_CVES=$(jq -r '[.Results[]?.Vulnerabilities[]?.VulnerabilityID] | unique | length' trivy-results.json)
+
+          # Get affected packages count
+          AFFECTED_PACKAGES=$(jq -r '[.Results[]?.Vulnerabilities[]? | .PkgName] | unique | length' trivy-results.json)
+
+          echo "vulnerabilities_found=$( [ $TOTAL_VULNS -gt 0 ] && echo 'true' || echo 'false' )" >> $GITHUB_OUTPUT
           echo "total_count=$TOTAL_VULNS" >> $GITHUB_OUTPUT
-          echo "vulnerabilities_found=$(if [ $TOTAL_VULNS -gt 0 ]; then echo true; else echo false; fi)" >> $GITHUB_OUTPUT
+          echo "critical_count=$CRITICAL_COUNT" >> $GITHUB_OUTPUT
+          echo "high_count=$HIGH_COUNT" >> $GITHUB_OUTPUT
+          echo "unique_cves=$UNIQUE_CVES" >> $GITHUB_OUTPUT
+          echo "affected_packages=$AFFECTED_PACKAGES" >> $GITHUB_OUTPUT
 
-      - name: Post scan summary
+      - name: Generate GitHub Job Summary
+        if: always()
         run: |
-          if [ "${{ steps.process_results.outputs.vulnerabilities_found }}" = "true" ]; then
-            cat >> $GITHUB_STEP_SUMMARY <<EOF
-          # Trivy Security Scan Report :warning:
+          {
+            echo "# 🛡️ Trivy Security Scan Results"
+            echo ""
+            echo "**Image:** \`${{ inputs.image_ref }}\`"
+            echo "**Scan Date:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+            echo ""
+          } >> $GITHUB_STEP_SUMMARY
 
-          **Image:** \`${{ inputs.image_ref }}\`
-
-          Found **${{ steps.process_results.outputs.total_count }}** vulnerabilities.
-
-          | Severity | Count |
-          |:---|:---:|
-          | Critical | ${{ steps.process_results.outputs.critical_count }} |
-          | High     | ${{ steps.process_results.outputs.high_count }} |
-          | Medium   | ${{ steps.process_results.outputs.medium_count }} |
-          | Low      | ${{ steps.process_results.outputs.low_count }} |
-
-          ### CVEs Found
-          ${{ steps.process_results.outputs.vulnerabilities_list }}
-          EOF
+          if [ "${{ steps.process_results.outputs.vulnerabilities_found }}" == "false" ]; then
+            echo "✅ **No critical or high severity vulnerabilities found!**" >> $GITHUB_STEP_SUMMARY
           else
-            echo "## Trivy Security Scan Report :white_check_mark:" >> $GITHUB_STEP_SUMMARY
-            echo "No vulnerabilities found in \`${{ inputs.image_ref }}\`." >> $GITHUB_STEP_SUMMARY
+            {
+              echo "## 📊 Summary"
+              echo "| Metric | Count |"
+              echo "|--------|-------|"
+              echo "| 🔴 Critical Vulnerabilities | ${{ steps.process_results.outputs.critical_count }} |"
+              echo "| 🟠 High Vulnerabilities | ${{ steps.process_results.outputs.high_count }} |"
+              echo "| 📋 Unique CVEs | ${{ steps.process_results.outputs.unique_cves }} |"
+              echo "| 📦 Affected Packages | ${{ steps.process_results.outputs.affected_packages }} |"
+              echo ""
+              echo "## 🚨 Top Vulnerabilities"
+              echo ""
+            } >> $GITHUB_STEP_SUMMARY
+
+            # Generate detailed vulnerability table
+            jq -r --arg image_ref "${{ inputs.image_ref }}" '
+              # Collect all vulnerabilities
+              [.Results[] | select(.Vulnerabilities != null) | .Vulnerabilities[]] |
+              # Group by CVE ID to avoid duplicates
+              group_by(.VulnerabilityID) |
+              map({
+                cve: .[0].VulnerabilityID,
+                severity: .[0].Severity,
+                cvss: (.[0].CVSS.nvd.V3Score // "N/A"),
+                cvss_sort: (.[0].CVSS.nvd.V3Score // 0),
+                packages: [.[] | "\(.PkgName)@\(.InstalledVersion)"] | unique | join(", "),
+                fixed: (.[0].FixedVersion // "No fix available"),
+                description: (.[0].Description // "No description available") | split("\n")[0] | .[0:150]
+              }) |
+              # Sort by severity (CRITICAL first) and CVSS score
+              sort_by((.severity == "HIGH" | if . then 1 else 0 end), -.cvss_sort) |
+              # Take top 15
+              .[:15] |
+              # Generate markdown table
+              "| CVE | Severity | CVSS | Package(s) | Fix Version | Description |",
+              "|-----|----------|------|------------|-------------|-------------|",
+              (.[] | "| [\(.cve)](https://nvd.nist.gov/vuln/detail/\(.cve)) | \(.severity) | \(.cvss) | `\(.packages)` | `\(.fixed)` | \(.description) |")
+            ' trivy-results.json >> $GITHUB_STEP_SUMMARY
+
+            {
+              echo ""
+              echo "---"
+              echo "🔍 **View detailed logs above for full analysis**"
+            } >> $GITHUB_STEP_SUMMARY
           fi
 
-      - name: Send Slack notification on failure
+      - name: Generate Slack Blocks JSON
         if: steps.process_results.outputs.vulnerabilities_found == 'true'
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
+        id: generate_blocks
+        run: |
+          BLOCKS_JSON=$(jq -c --arg image_ref "${{ inputs.image_ref }}" \
+          --arg repo_url "${{ github.server_url }}/${{ github.repository }}" \
+          --arg repo_name "${{ github.repository }}" \
+          --arg run_url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+          --arg critical_count "${{ steps.process_results.outputs.critical_count }}" \
+          --arg high_count "${{ steps.process_results.outputs.high_count }}" \
+          --arg unique_cves "${{ steps.process_results.outputs.unique_cves }}" \
+          '
+          # Function to create a vulnerability block with emoji indicators
+          def vuln_block: {
+              "type": "section",
+              "text": {
+                "type": "mrkdwn",
+                "text": "\(if .Severity == "CRITICAL" then ":red_circle:" else ":large_orange_circle:" end) *<https://nvd.nist.gov/vuln/detail/\(.VulnerabilityID)|\(.VulnerabilityID)>* (CVSS: `\(.CVSS.nvd.V3Score // "N/A")`)\n*Package:* `\(.PkgName)@\(.InstalledVersion)` → `\(.FixedVersion // "No fix available")`"
+              }
+            };
+
+          # Main structure
+          [
             {
-              "blocks": [
+              "type": "header",
+              "text": { "type": "plain_text", "text": ":warning: Trivy Scan: Vulnerabilities Detected" }
+            },
+            {
+              "type": "section",
+              "fields": [
+                { "type": "mrkdwn", "text": "*Repository:*\n<\($repo_url)|\($repo_name)>" },
+                { "type": "mrkdwn", "text": "*Image:*\n`\($image_ref)`" },
+                { "type": "mrkdwn", "text": "*Critical:*\n:red_circle: \($critical_count)" },
+                { "type": "mrkdwn", "text": "*High:*\n:large_orange_circle: \($high_count)" }
+              ]
+            },
+            {
+              "type": "context",
+              "elements": [
+                { "type": "mrkdwn", "text": ":shield: \($unique_cves) unique CVEs affecting packages" }
+              ]
+            },
+            { "type": "divider" }
+          ] +
+          (
+            # Group vulnerabilities by CVE to avoid duplicates in notification
+            [.Results[] | select(.Vulnerabilities != null) | .Vulnerabilities[]] |
+            group_by(.VulnerabilityID) |
+            map(.[0]) |
+            sort_by((.Severity == "HIGH" | if . then 1 else 0 end), -((.CVSS.nvd.V3Score // 0) | tonumber? // 0)) |
+            .[:8] |
+            map(. | vuln_block)
+          ) +
+          [
+            { "type": "divider" },
+            {
+              "type": "actions",
+              "elements": [
                 {
-                  "type": "header",
-                  "text": { "type": "plain_text", "text": ":warning: Trivy Scan: Vulnerabilities Detected" }
-                },
-                {
-                  "type": "section",
-                  "fields": [
-                    { "type": "mrkdwn", "text": "*Repository:*\n`${{ github.repository }}`" },
-                    { "type": "mrkdwn", "text": "*Image Scanned:*\n`${{ inputs.image_ref }}`" }
-                  ]
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*Vulnerability Summary:*\n• *Critical:* ${{ steps.process_results.outputs.critical_count }}\n• *High:* ${{ steps.process_results.outputs.high_count }}\n• *Medium:* ${{ steps.process_results.outputs.medium_count }}\n• *Low:* ${{ steps.process_results.outputs.low_count }}\n• *Total:* *${{ steps.process_results.outputs.total_count }}*"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*CVEs Found (showing up to 10):*"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*CVEs Found (showing up to 10):*\n${{ steps.process_results.outputs.slack_cve_list }}"
-                  }
-                },
-                {
-                  "type": "actions",
-                  "elements": [
-                    {
-                      "type": "button",
-                      "text": { "type": "plain_text", "text": "View Job Summary" },
-                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    }
-                  ]
+                  "type": "button",
+                  "text": { "type": "plain_text", "text": ":github: View Full Report" },
+                  "style": "primary",
+                  "url": $run_url
                 }
               ]
             }
+          ]
+          ' trivy-results.json)
+
+          echo "slack_blocks=$BLOCKS_JSON" >> $GITHUB_OUTPUT
+
+      - name: Send Slack Notification
+        if: steps.process_results.outputs.vulnerabilities_found == 'true'
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ env.SLACK_CHANNEL_ID }}
+            text: "🚨 Trivy Scan: ${{ steps.process_results.outputs.critical_count }} Critical, ${{ steps.process_results.outputs.high_count }} High vulnerabilities found in ${{ inputs.image_ref }}"
+            blocks: ${{ steps.generate_blocks.outputs.slack_blocks }}

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ compiled_app_output
 trivy_report*
 compiled
 packages/cli/src/modules/my-feature
+.secrets


### PR DESCRIPTION
## Summary

- Includes CVE details in scan slack message
- Uses slack official action instead of 3rd party action
- Adds detailed summary report to the Github action using Github Summaries
- No longer sends on successful check, but will still add summary.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1072/ci-remove-positive-result-from-nightly-security-scan

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
