### PR TITLE
ci: Fix timing issue

### DIFF
--- a/packages/testing/playwright/global-setup.ts
+++ b/packages/testing/playwright/global-setup.ts
@@ -34,7 +34,8 @@ async function globalSetup() {
 	}
 
 	console.log(`🔄 Resetting database for ${n8nBaseUrl}...`);
-
+	// Quick hack till we find out a better health check for the database reset command!
+	await new Promise((resolve) => setTimeout(resolve, 3000));
 	// Create standalone API request context
 	const requestContext = await request.newContext({
 		baseURL: n8nBaseUrl,


### PR DESCRIPTION
DB reset sometimes occurs before server is ready.
So added a small wait.

## Summary

The server start up -> playwright test reset progression is too fast. The current way of waiting for the favicon isn't adequate. This is a quick work around.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
