### PR TITLE
chore(editor): Make storybook work

### DIFF
--- a/packages/frontend/@n8n/design-system/.storybook/fonts.scss
+++ b/packages/frontend/@n8n/design-system/.storybook/fonts.scss
@@ -1,3 +1,5 @@
+@use '../src/css/_tokens.scss';
+
 /* Storybook-specific font paths */
 @font-face {
 	font-family: InterVariable;
@@ -22,5 +24,3 @@
 	font-display: swap;
 	src: url('../src/css/fonts/CommitMonoVariable.woff2') format('woff2');
 }
-
-@use '../src/css/_tokens.scss';


### PR DESCRIPTION
## Summary

This PR makes storybook working with `pnpm run dev` command again.

The error on the screen:
<img width="1205" height="474" alt="Screenshot 2025-08-05 at 10 35 15" src="https://github.com/user-attachments/assets/033fade6-2dc3-48b7-81cc-ca5dbb9b9f94" />

Errors on the console:
```
10:35:07 AM [vite] Internal server error: [sass] @use rules must be written before any other rules.
   ╷
26 │ @use '../src/css/_tokens.scss';
   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
  .storybook/fonts.scss 26:1     @use
  .storybook/storybook.scss 1:1  root stylesheet
  Plugin: vite:css
  File: /Users/suguruinoue/github.com/n8n-io/n8n/packages/frontend/@n8n/design-system/.storybook/storybook.scss:26:1
  [sass] @use rules must be written before any other rules.
     ╷
  26 │ @use '../src/css/_tokens.scss';
     │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     ╵
    .storybook/fonts.scss 26:1     @use
    .storybook/storybook.scss 1:1  root stylesheet
```

## Related Linear tickets, Github issues, and Community forum posts
N/A


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
