### PR TITLE
fix(editor): Update node status icons precedence (executing -> highest)

### DIFF
--- a/packages/frontend/editor-ui/src/components/canvas/elements/nodes/render-types/parts/CanvasNodeStatusIcons.test.ts
+++ b/packages/frontend/editor-ui/src/components/canvas/elements/nodes/render-types/parts/CanvasNodeStatusIcons.test.ts
@@ -104,4 +104,57 @@ describe('CanvasNodeStatusIcons', () => {
 
 		expect(getByTestId('canvas-node-status-warning')).toBeInTheDocument();
 	});
+
+	describe('status precedence', () => {
+		it('should render executing status even if node is invalid', () => {
+			const { getByTestId, queryByTestId } = renderComponent({
+				global: {
+					provide: {
+						...createCanvasProvide({
+							isExecuting: true,
+						}),
+						...createCanvasNodeProvide({
+							data: {
+								execution: { running: true },
+								runData: { outputMap: {}, iterations: 15, visible: true },
+								render: {
+									type: CanvasNodeRenderType.Default,
+									options: { dirtiness: CanvasNodeDirtiness.PARAMETERS_UPDATED },
+								},
+							},
+						}),
+					},
+				},
+			});
+
+			expect(getByTestId('canvas-node-status-running')).toBeVisible();
+			expect(queryByTestId('canvas-node-status-warning')).not.toBeInTheDocument();
+		});
+
+		it('should render executing status even if node is disabled', () => {
+			const { getByTestId, queryByTestId } = renderComponent({
+				global: {
+					provide: {
+						...createCanvasProvide({
+							isExecuting: true,
+						}),
+						...createCanvasNodeProvide({
+							data: {
+								disabled: true,
+								execution: { running: true },
+								runData: { outputMap: {}, iterations: 15, visible: true },
+								render: {
+									type: CanvasNodeRenderType.Default,
+									options: { dirtiness: CanvasNodeDirtiness.PARAMETERS_UPDATED },
+								},
+							},
+						}),
+					},
+				},
+			});
+
+			expect(getByTestId('canvas-node-status-running')).toBeVisible();
+			expect(queryByTestId('canvas-node-status-warning')).not.toBeInTheDocument();
+		});
+	});
 });

--- a/packages/frontend/editor-ui/src/components/canvas/elements/nodes/render-types/parts/CanvasNodeStatusIcons.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/elements/nodes/render-types/parts/CanvasNodeStatusIcons.vue
@@ -61,6 +61,13 @@ const commonClasses = computed(() => [$style.status, spinnerScrim ? $style.spinn
 			<N8nIcon icon="refresh-cw" spin />
 		</div>
 	</div>
+	<div
+		v-else-if="isNodeExecuting"
+		data-test-id="canvas-node-status-running"
+		:class="[...commonClasses, $style.running]"
+	>
+		<N8nIcon icon="refresh-cw" spin />
+	</div>
 	<div v-else-if="isDisabled" :class="[...commonClasses, $style.disabled]">
 		<N8nIcon icon="power" :size="size" />
 	</div>
@@ -78,13 +85,6 @@ const commonClasses = computed(() => [$style.status, spinnerScrim ? $style.spinn
 	</div>
 	<div v-else-if="executionStatus === 'unknown'">
 		<!-- Do nothing, unknown means the node never executed -->
-	</div>
-	<div
-		v-else-if="isNodeExecuting"
-		data-test-id="canvas-node-status-running"
-		:class="[...commonClasses, $style.running]"
-	>
-		<N8nIcon icon="refresh-cw" spin />
 	</div>
 	<div
 		v-else-if="hasPinnedData && !nodeHelpers.isProductionExecutionPreview.value"

--- a/packages/frontend/editor-ui/src/components/canvas/elements/nodes/render-types/parts/CanvasNodeStatusIcons.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/elements/nodes/render-types/parts/CanvasNodeStatusIcons.vue
@@ -48,7 +48,20 @@ const commonClasses = computed(() => [$style.status, spinnerScrim ? $style.spinn
 </script>
 
 <template>
-	<div v-if="isDisabled" :class="[...commonClasses, $style.disabled]">
+	<div v-if="executionWaiting || executionStatus === 'waiting'">
+		<div :class="[...commonClasses, $style.waiting]">
+			<N8nTooltip placement="bottom">
+				<template #content>
+					<div v-text="executionWaiting"></div>
+				</template>
+				<N8nIcon icon="clock" :size="size" />
+			</N8nTooltip>
+		</div>
+		<div :class="[...commonClasses, $style['node-waiting-spinner']]">
+			<N8nIcon icon="refresh-cw" spin />
+		</div>
+	</div>
+	<div v-else-if="isDisabled" :class="[...commonClasses, $style.disabled]">
 		<N8nIcon icon="power" :size="size" />
 	</div>
 	<div
@@ -62,19 +75,6 @@ const commonClasses = computed(() => [$style.status, spinnerScrim ? $style.spinn
 			</template>
 			<N8nIcon icon="node-error" :size="size" />
 		</N8nTooltip>
-	</div>
-	<div v-else-if="executionWaiting || executionStatus === 'waiting'">
-		<div :class="[...commonClasses, $style.waiting]">
-			<N8nTooltip placement="bottom">
-				<template #content>
-					<div v-text="executionWaiting"></div>
-				</template>
-				<N8nIcon icon="clock" :size="size" />
-			</N8nTooltip>
-		</div>
-		<div :class="[...commonClasses, $style['node-waiting-spinner']]">
-			<N8nIcon icon="refresh-cw" spin />
-		</div>
 	</div>
 	<div v-else-if="executionStatus === 'unknown'">
 		<!-- Do nothing, unknown means the node never executed -->


### PR DESCRIPTION
## Summary

Error and disabled nodes were taking precedence over executing status, leading to inaccurate status icons when manually executing a node.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-835/canvas-execution-spinner-missing


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
