### PR TITLE
fix(core): Handle non-existing files when checking if it is a symlink

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
@@ -160,6 +160,15 @@ describe('isFilePathBlocked', () => {
 		);
 		expect(await isFilePathBlocked(allowedPath)).toBe(true);
 	});
+
+	it('should handle non-existent file', async () => {
+		const filePath = '/non/existent/file';
+		const error = new Error('ENOENT');
+		// @ts-expect-error undefined property
+		error.code = 'ENOENT';
+		(fsRealpath as jest.Mock).mockRejectedValueOnce(error);
+		expect(await isFilePathBlocked(filePath)).toBe(true);
+	});
 });
 
 describe('getFileSystemHelperFunctions', () => {

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
@@ -167,7 +167,7 @@ describe('isFilePathBlocked', () => {
 		// @ts-expect-error undefined property
 		error.code = 'ENOENT';
 		(fsRealpath as jest.Mock).mockRejectedValueOnce(error);
-		expect(await isFilePathBlocked(filePath)).toBe(true);
+		expect(await isFilePathBlocked(filePath)).toBe(false);
 	});
 });
 

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
@@ -161,13 +161,24 @@ describe('isFilePathBlocked', () => {
 		expect(await isFilePathBlocked(allowedPath)).toBe(true);
 	});
 
-	it('should handle non-existent file', async () => {
+	it('should handle non-existent file when it is allowed', async () => {
 		const filePath = '/non/existent/file';
 		const error = new Error('ENOENT');
 		// @ts-expect-error undefined property
 		error.code = 'ENOENT';
 		(fsRealpath as jest.Mock).mockRejectedValueOnce(error);
 		expect(await isFilePathBlocked(filePath)).toBe(false);
+	});
+
+	it('should handle non-existent file when it is not allowed', async () => {
+		const filePath = '/non/existent/file';
+		const allowedPath = '/some/allowed/path';
+		process.env[RESTRICT_FILE_ACCESS_TO] = allowedPath;
+		const error = new Error('ENOENT');
+		// @ts-expect-error undefined property
+		error.code = 'ENOENT';
+		(fsRealpath as jest.Mock).mockRejectedValueOnce(error);
+		expect(await isFilePathBlocked(filePath)).toBe(true);
 	});
 });
 

--- a/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
@@ -8,6 +8,7 @@ import {
 	writeFile as fsWriteFile,
 	realpath as fsRealpath,
 } from 'node:fs/promises';
+import { resolve } from 'node:path';
 
 import {
 	BINARY_DATA_STORAGE_PATH,
@@ -34,7 +35,16 @@ const getAllowedPaths = () => {
 
 export async function isFilePathBlocked(filePath: string): Promise<boolean> {
 	const allowedPaths = getAllowedPaths();
-	const resolvedFilePath = await fsRealpath(filePath);
+	let resolvedFilePath = '';
+	try {
+		resolvedFilePath = await fsRealpath(filePath);
+	} catch (error) {
+		if (error.code === 'ENOENT') {
+			resolvedFilePath = resolve(filePath);
+		} else {
+			throw error;
+		}
+	}
 	const blockFileAccessToN8nFiles = process.env[BLOCK_FILE_ACCESS_TO_N8N_FILES] !== 'false';
 
 	const restrictedPaths = blockFileAccessToN8nFiles ? getN8nRestrictedPaths() : [];

--- a/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
@@ -39,6 +39,7 @@ export async function isFilePathBlocked(filePath: string): Promise<boolean> {
 	try {
 		resolvedFilePath = await fsRealpath(filePath);
 	} catch (error) {
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 		if (error.code === 'ENOENT') {
 			resolvedFilePath = resolve(filePath);
 		} else {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Fix an issue where a check to see if file is in a blocked path would fail if the file does not exist. In particular it affected "Write Binary File" node

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-3422/community-issue-unable-to-create-files-with-writebinaryfile-node
Closes #17998

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
