### PR TITLE
feat(Aws): Add option to use systems credentials for AWS

### DIFF
--- a/packages/@n8n/config/src/configs/credentials.config.ts
+++ b/packages/@n8n/config/src/configs/credentials.config.ts
@@ -30,4 +30,10 @@ export class CredentialsConfig {
 
 	@Nested
 	overwrite: CredentialsOverwrite;
+
+	/**
+	 * If enabled, some credentials are allowed to use system-level credentials (e.g., ECS, EKS, ENV, etc.).
+	 */
+	@Env('CREDENTIALS_ALLOW_SYSTEMS')
+	allowSystems: boolean = false;
 }

--- a/packages/@n8n/config/src/index.ts
+++ b/packages/@n8n/config/src/index.ts
@@ -42,6 +42,7 @@ import { Config, Env, Nested } from './decorators';
 
 export { Config, Env, Nested } from './decorators';
 export { AiConfig } from './configs/ai.config';
+export { CredentialsConfig } from './configs/credentials.config';
 export { DatabaseConfig, SqliteConfig } from './configs/database.config';
 export { InstanceSettingsConfig } from './configs/instance-settings-config';
 export { sampleRateSchema } from './configs/sentry.config';

--- a/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsAwsBedrock/EmbeddingsAwsBedrock.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsAwsBedrock/EmbeddingsAwsBedrock.node.ts
@@ -4,6 +4,8 @@ import { BedrockEmbeddings } from '@langchain/aws';
 import { NodeHttpHandler } from '@smithy/node-http-handler';
 import { getNodeProxyAgent, logWrapper } from '@n8n/ai-utilities';
 import { getConnectionHintNoticeField } from '@utils/sharedFields';
+import { getAwsCredentials, getAwsCredentialProvider } from 'n8n-nodes-base/dist/nodes/Aws/GenericFunctions';
+import { awsNodeAuthOptions, awsNodeCredentials } from 'n8n-nodes-base/dist/nodes/Aws/utils';
 import {
 	NodeConnectionTypes,
 	type INodeType,
@@ -17,12 +19,7 @@ export class EmbeddingsAwsBedrock implements INodeType {
 		displayName: 'Embeddings AWS Bedrock',
 		name: 'embeddingsAwsBedrock',
 		icon: 'file:bedrock.svg',
-		credentials: [
-			{
-				name: 'aws',
-				required: true,
-			},
-		],
+		credentials: awsNodeCredentials,
 		group: ['transform'],
 		version: 1,
 		description: 'Use Embeddings AWS Bedrock',
@@ -53,6 +50,7 @@ export class EmbeddingsAwsBedrock implements INodeType {
 			baseURL: '=https://bedrock.{{$credentials?.region ?? "eu-central-1"}}.amazonaws.com',
 		},
 		properties: [
+			awsNodeAuthOptions,
 			getConnectionHintNoticeField([NodeConnectionTypes.AiVectorStore]),
 			{
 				displayName: 'Model',
@@ -106,21 +104,13 @@ export class EmbeddingsAwsBedrock implements INodeType {
 	};
 
 	async supplyData(this: ISupplyDataFunctions, itemIndex: number): Promise<SupplyData> {
-		const credentials = await this.getCredentials<{
-			region: string;
-			secretAccessKey: string;
-			accessKeyId: string;
-			sessionToken: string;
-		}>('aws');
+		const { credentials, credentialsType } = await getAwsCredentials(this);
+
 		const modelName = this.getNodeParameter('model', itemIndex) as string;
 
 		const clientConfig: BedrockRuntimeClientConfig = {
 			region: credentials.region,
-			credentials: {
-				secretAccessKey: credentials.secretAccessKey,
-				accessKeyId: credentials.accessKeyId,
-				sessionToken: credentials.sessionToken,
-			},
+			credentials: getAwsCredentialProvider(credentials, credentialsType),
 		};
 
 		const proxyAgent = getNodeProxyAgent();

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/LmChatAwsBedrock.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/LmChatAwsBedrock.node.ts
@@ -16,6 +16,9 @@ import {
 	type SupplyData,
 } from 'n8n-workflow';
 
+import { getAwsCredentials, getAwsCredentialProvider } from 'n8n-nodes-base/dist/nodes/Aws/GenericFunctions';
+import { awsNodeAuthOptions, awsNodeCredentials } from 'n8n-nodes-base/dist/nodes/Aws/utils';
+
 export class LmChatAwsBedrock implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'AWS Bedrock Chat Model',
@@ -47,17 +50,13 @@ export class LmChatAwsBedrock implements INodeType {
 
 		outputs: [NodeConnectionTypes.AiLanguageModel],
 		outputNames: ['Model'],
-		credentials: [
-			{
-				name: 'aws',
-				required: true,
-			},
-		],
+		credentials: awsNodeCredentials,
 		requestDefaults: {
 			ignoreHttpStatusErrors: true,
 			baseURL: '=https://bedrock.{{$credentials?.region ?? "eu-central-1"}}.amazonaws.com',
 		},
 		properties: [
+			awsNodeAuthOptions,
 			getConnectionHintNoticeField([NodeConnectionTypes.AiChain, NodeConnectionTypes.AiChain]),
 			{
 				displayName: 'Model Source',
@@ -225,12 +224,7 @@ export class LmChatAwsBedrock implements INodeType {
 	};
 
 	async supplyData(this: ISupplyDataFunctions, itemIndex: number): Promise<SupplyData> {
-		const credentials = await this.getCredentials<{
-			region: string;
-			secretAccessKey: string;
-			accessKeyId: string;
-			sessionToken: string;
-		}>('aws');
+		const { credentials, credentialsType } = await getAwsCredentials(this);
 		const modelName = this.getNodeParameter('model', itemIndex) as string;
 		const options = this.getNodeParameter('options', itemIndex, {}) as {
 			temperature: number;
@@ -241,11 +235,7 @@ export class LmChatAwsBedrock implements INodeType {
 		const proxyAgent = getNodeProxyAgent();
 		const clientConfig: BedrockRuntimeClientConfig = {
 			region: credentials.region,
-			credentials: {
-				secretAccessKey: credentials.secretAccessKey,
-				accessKeyId: credentials.accessKeyId,
-				...(credentials.sessionToken && { sessionToken: credentials.sessionToken }),
-			},
+			credentials: getAwsCredentialProvider(credentials, credentialsType),
 		};
 
 		if (proxyAgent) {

--- a/packages/nodes-base/credentials/Aws.credentials.ts
+++ b/packages/nodes-base/credentials/Aws.credentials.ts
@@ -1,3 +1,4 @@
+import type { AwsCredentialIdentity, AwsCredentialIdentityProvider } from '@aws-sdk/types';
 import type {
 	ICredentialDataDecryptedObject,
 	ICredentialType,
@@ -87,16 +88,24 @@ export class Aws implements ICredentialType {
 			region,
 		);
 
-		const securityHeaders = {
+		const securityHeaders = await Aws.getSecurityHeaders(credentials);
+
+		return signOptions(requestOptions, signOpts, securityHeaders, url, method);
+	}
+
+	test = awsCredentialsTest;
+
+	static async getSecurityHeaders(credentials: AwsIamCredentialsType): Promise<AwsCredentialIdentity> {
+		return {
 			accessKeyId: `${credentials.accessKeyId}`.trim(),
 			secretAccessKey: `${credentials.secretAccessKey}`.trim(),
 			sessionToken: credentials.temporaryCredentials
 				? `${credentials.sessionToken}`.trim()
 				: undefined,
 		};
-
-		return signOptions(requestOptions, signOpts, securityHeaders, url, method);
 	}
 
-	test = awsCredentialsTest;
+	static getCredentialProvider(credentials: AwsIamCredentialsType): AwsCredentialIdentityProvider {
+		return () => Aws.getSecurityHeaders(credentials);
+	}
 }

--- a/packages/nodes-base/credentials/AwsAssumeRole.credentials.ts
+++ b/packages/nodes-base/credentials/AwsAssumeRole.credentials.ts
@@ -1,12 +1,12 @@
+import type { AwsCredentialIdentity, AwsCredentialIdentityProvider } from '@aws-sdk/types';
 import type {
 	ICredentialDataDecryptedObject,
 	ICredentialType,
 	IHttpRequestOptions,
 	INodeProperties,
 } from 'n8n-workflow';
+import type { AwsAssumeRoleCredentialsType, AWSRegion, AwsSecurityHeaders } from './common/aws/types';
 import { ApplicationError } from 'n8n-workflow';
-
-import { type AwsAssumeRoleCredentialsType, type AWSRegion } from './common/aws/types';
 import { awsCustomEndpoints, awsRegionProperty } from './common/aws/descriptions';
 import {
 	assumeRole,
@@ -131,11 +131,7 @@ export class AwsAssumeRole implements ICredentialType {
 		}
 
 		let finalCredentials = credentials;
-		let securityHeaders: {
-			accessKeyId: string;
-			secretAccessKey: string;
-			sessionToken: string;
-		};
+		let securityHeaders: AwsSecurityHeaders;
 
 		if (!credentials.roleArn || credentials.roleArn.trim() === '') {
 			throw new ApplicationError('Role ARN is required when assuming a role.');
@@ -147,7 +143,7 @@ export class AwsAssumeRole implements ICredentialType {
 			throw new ApplicationError('Role Session Name is required when assuming a role.');
 		}
 		try {
-			securityHeaders = await assumeRole(credentials, region);
+			securityHeaders = await AwsAssumeRole.getSecurityHeaders(credentials, region);
 			finalCredentials = { ...credentials, ...securityHeaders };
 		} catch (error) {
 			console.error('Failed to assume role:', error);
@@ -169,4 +165,12 @@ export class AwsAssumeRole implements ICredentialType {
 	}
 
 	test = awsCredentialsTest;
+
+	static async getSecurityHeaders(credentials: AwsAssumeRoleCredentialsType, region?: string): Promise<AwsCredentialIdentity> {
+		return await assumeRole(credentials, region || credentials.region);
+	}
+
+	static getCredentialProvider(credentials: AwsAssumeRoleCredentialsType): AwsCredentialIdentityProvider {
+		return () => AwsAssumeRole.getSecurityHeaders(credentials);
+	}
 }

--- a/packages/nodes-base/credentials/AwsSystem.credentials.ts
+++ b/packages/nodes-base/credentials/AwsSystem.credentials.ts
@@ -1,0 +1,80 @@
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
+import type { AwsCredentialIdentity, AwsCredentialIdentityProvider } from '@aws-sdk/types';
+import { CredentialsConfig } from '@n8n/config';
+import { Container } from '@n8n/di';
+import type {
+	ICredentialDataDecryptedObject,
+	ICredentialType,
+	IHttpRequestOptions,
+	INodeProperties,
+} from 'n8n-workflow';
+import { ApplicationError } from 'n8n-workflow';
+
+import type { AwsSystemCredentialsType, AWSRegion } from './common/aws/types';
+import {
+	awsGetSignInOptionsAndUpdateRequest,
+	signOptions,
+} from './common/aws/utils';
+import { awsCustomEndpoints, awsRegionProperty } from './common/aws/descriptions';
+
+export class AwsSystem implements ICredentialType {
+	name = 'awsSystem';
+
+	displayName = 'AWS (System)';
+
+	documentationUrl = 'awssystem';
+
+	icon = { light: 'file:icons/AWS.svg', dark: 'file:icons/AWS.dark.svg' } as const;
+
+	properties: INodeProperties[] = [
+		awsRegionProperty,
+		...awsCustomEndpoints,
+	];
+
+	async authenticate(
+		rawCredentials: ICredentialDataDecryptedObject,
+		requestOptions: IHttpRequestOptions,
+	): Promise<IHttpRequestOptions> {
+		const credentials = rawCredentials as AwsSystemCredentialsType;
+		const service = requestOptions.qs?.service as string;
+		const path = (requestOptions.qs?.path as string) ?? '';
+		const method = requestOptions.method;
+
+		let region = credentials.region;
+		if (requestOptions.qs?._region) {
+			region = requestOptions.qs._region as AWSRegion;
+			delete requestOptions.qs._region;
+		}
+
+		const { signOpts, url } = awsGetSignInOptionsAndUpdateRequest(
+			requestOptions,
+			credentials,
+			path,
+			method,
+			service,
+			region,
+		);
+
+		const securityHeaders = await AwsSystem.getSecurityHeaders(credentials);
+		return signOptions(requestOptions, signOpts, securityHeaders, url, method);
+	}
+
+	static async getSecurityHeaders(credentials: AwsSystemCredentialsType): Promise<AwsCredentialIdentity> {
+		const provider = AwsSystem.getCredentialProvider(credentials);
+		return await provider();
+	}
+
+	static getCredentialProvider(credentials: AwsSystemCredentialsType): AwsCredentialIdentityProvider {
+		if (!Container.get(CredentialsConfig).allowSystems) {
+			throw new ApplicationError(
+				"CREDENTIALS_ALLOW_SYSTEMS must be enable to use system's credentials",
+			);
+		}
+
+		return fromNodeProviderChain({
+			clientConfig: {
+				region: credentials.region,
+			},
+		});
+	}
+}

--- a/packages/nodes-base/credentials/common/aws/types.ts
+++ b/packages/nodes-base/credentials/common/aws/types.ts
@@ -225,8 +225,14 @@ export type AwsAssumeRoleCredentialsType = AwsCredentialsTypeBase & {
 	stsSessionToken?: string;
 };
 
+export type AwsSystemCredentialsType = AwsCredentialsTypeBase;
+
+export type AwsCredentials = AwsIamCredentialsType | AwsAssumeRoleCredentialsType | AwsSystemCredentialsType;
+
+export type AwsCredentialsType = 'aws' | 'awsAssumeRole' | 'awsSystem';
+
 export type AwsSecurityHeaders = {
 	accessKeyId: string;
 	secretAccessKey: string;
-	sessionToken: string | undefined;
+	sessionToken?: string;
 };

--- a/packages/nodes-base/nodes/Aws/Cognito/AwsCognito.node.ts
+++ b/packages/nodes-base/nodes/Aws/Cognito/AwsCognito.node.ts
@@ -4,6 +4,7 @@ import { NodeConnectionTypes } from 'n8n-workflow';
 import { group, user, userPool } from './descriptions';
 import { preSendStringifyBody } from './helpers/utils';
 import { listSearch } from './methods';
+import { awsNodeAuthOptions, awsNodeCredentials } from '../utils';
 
 export class AwsCognito implements INodeType {
 	description: INodeTypeDescription = {
@@ -22,12 +23,7 @@ export class AwsCognito implements INodeType {
 		},
 		inputs: [NodeConnectionTypes.Main],
 		outputs: [NodeConnectionTypes.Main],
-		credentials: [
-			{
-				name: 'aws',
-				required: true,
-			},
-		],
+		credentials: awsNodeCredentials,
 		requestDefaults: {
 			headers: {
 				'Content-Type': 'application/x-amz-json-1.1',
@@ -38,6 +34,7 @@ export class AwsCognito implements INodeType {
 			},
 		},
 		properties: [
+			awsNodeAuthOptions,
 			{
 				displayName: 'Resource',
 				name: 'resource',

--- a/packages/nodes-base/nodes/Aws/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/GenericFunctions.ts
@@ -3,36 +3,57 @@ import type {
 	IHookFunctions,
 	ILoadOptionsFunctions,
 	IWebhookFunctions,
+	ISupplyDataFunctions,
 	IHttpRequestOptions,
 	JsonObject,
 	IHttpRequestMethods,
 } from 'n8n-workflow';
 import { NodeApiError } from 'n8n-workflow';
 import { parseString as parseXml } from 'xml2js';
+import { Aws } from '../../credentials/Aws.credentials';
+import { AwsAssumeRole } from '../../credentials/AwsAssumeRole.credentials';
+import { AwsSystem } from '../../credentials/AwsSystem.credentials';
 import type {
-	AwsAssumeRoleCredentialsType,
-	AwsIamCredentialsType,
+	AwsCredentials,
+	AwsCredentialsType,
+	AwsSecurityHeaders,
 } from '../../credentials/common/aws/types';
 
+const CredentialNameByAuthType = {
+	'iam' : 'aws',
+	'assumeRole' : 'awsAssumeRole',
+	'system' : 'awsSystem',
+}
+
+const ClassByCredentialType = {
+	'aws' : Aws,
+	'awsAssumeRole' : AwsAssumeRole,
+	'awsSystem' : AwsSystem,
+}
+
+export async function getAwsCredentialSecurityHeaders(credentials: AwsCredentials, credentialsType: AwsCredentialsType) : Promise<AwsSecurityHeaders> {
+	return await ClassByCredentialType[credentialsType].getSecurityHeaders(credentials as any)
+}
+export function getAwsCredentialProvider(credentials: AwsCredentials, credentialsType: AwsCredentialsType) : () => Promise<AwsSecurityHeaders> {
+	return ClassByCredentialType[credentialsType].getCredentialProvider(credentials as any)
+}
+
 export async function getAwsCredentials(
-	context: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions | IWebhookFunctions,
-) {
-	let credentialsType: 'aws' | 'awsAssumeRole' = 'aws';
+	context: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions | IWebhookFunctions | ISupplyDataFunctions,
+) : Promise<{credentials: AwsCredentials, credentialsType: AwsCredentialsType}> {
+	let credentialsType: string = 'aws';
 
 	try {
-		const authentication = context.getNodeParameter('authentication', 0) as 'iam' | 'assumeRole';
+		const authentication = context.getNodeParameter('authentication', 0) as 'iam' | 'assumeRole' | 'system';
 
-		if (authentication === 'assumeRole') {
-			credentialsType = 'awsAssumeRole';
-		}
+		credentialsType = CredentialNameByAuthType[authentication];
 	} catch (error) {
 		context.logger.warn('Could not get authentication type');
 	}
 
-	const credentials: AwsIamCredentialsType | AwsAssumeRoleCredentialsType =
-		await context.getCredentials(credentialsType);
+	const credentials: AwsCredentials = await context.getCredentials(credentialsType);
 
-	return { credentials, credentialsType };
+	return { credentials, credentialsType: credentialsType as AwsCredentialsType };
 }
 
 export async function awsApiRequest(

--- a/packages/nodes-base/nodes/Aws/IAM/AwsIam.node.ts
+++ b/packages/nodes-base/nodes/Aws/IAM/AwsIam.node.ts
@@ -5,6 +5,7 @@ import { user, group } from './descriptions';
 import { BASE_URL } from './helpers/constants';
 import { encodeBodyAsFormUrlEncoded } from './helpers/utils';
 import { searchGroups, searchUsers, searchGroupsForUser } from './methods/listSearch';
+import { awsNodeAuthOptions, awsNodeCredentials } from '../utils';
 
 export class AwsIam implements INodeType {
 	description: INodeTypeDescription = {
@@ -18,12 +19,7 @@ export class AwsIam implements INodeType {
 		defaults: { name: 'AWS IAM' },
 		inputs: [NodeConnectionTypes.Main],
 		outputs: [NodeConnectionTypes.Main],
-		credentials: [
-			{
-				name: 'aws',
-				required: true,
-			},
-		],
+		credentials: awsNodeCredentials,
 		requestDefaults: {
 			baseURL: BASE_URL,
 			json: true,
@@ -32,6 +28,7 @@ export class AwsIam implements INodeType {
 			},
 		},
 		properties: [
+			awsNodeAuthOptions,
 			{
 				displayName: 'Resource',
 				name: 'resource',

--- a/packages/nodes-base/nodes/Aws/S3/V1/AwsS3V1.node.ts
+++ b/packages/nodes-base/nodes/Aws/S3/V1/AwsS3V1.node.ts
@@ -19,6 +19,7 @@ import {
 	awsApiRequestSOAP,
 	awsApiRequestSOAPAllItems,
 } from './GenericFunctions';
+import { awsNodeAuthOptions, awsNodeCredentials } from '../../utils';
 
 export class AwsS3V1 implements INodeType {
 	description: INodeTypeDescription;
@@ -38,13 +39,9 @@ export class AwsS3V1 implements INodeType {
 			},
 			inputs: [NodeConnectionTypes.Main],
 			outputs: [NodeConnectionTypes.Main],
-			credentials: [
-				{
-					name: 'aws',
-					required: true,
-				},
-			],
+			credentials: awsNodeCredentials,
 			properties: [
+				awsNodeAuthOptions,
 				{
 					displayName: 'Resource',
 					name: 'resource',

--- a/packages/nodes-base/nodes/Aws/Textract/AwsTextract.node.ts
+++ b/packages/nodes-base/nodes/Aws/Textract/AwsTextract.node.ts
@@ -1,19 +1,15 @@
 import {
 	BINARY_ENCODING,
 	NodeConnectionTypes,
-	type ICredentialDataDecryptedObject,
-	type ICredentialsDecrypted,
-	type ICredentialTestFunctions,
 	type IDataObject,
 	type IExecuteFunctions,
-	type INodeCredentialTestResult,
 	type INodeExecutionData,
 	type INodeType,
 	type INodeTypeDescription,
 } from 'n8n-workflow';
 
 import type { IExpenseDocument } from './GenericFunctions';
-import { awsApiRequestREST, simplify, validateCredentials } from './GenericFunctions';
+import { awsApiRequestREST, simplify } from './GenericFunctions';
 import { awsNodeAuthOptions, awsNodeCredentials } from '../utils';
 
 export class AwsTextract implements INodeType {
@@ -75,33 +71,6 @@ export class AwsTextract implements INodeType {
 					'Whether to return a simplified version of the response instead of the raw data',
 			},
 		],
-	};
-
-	methods = {
-		credentialTest: {
-			async awsTextractApiCredentialTest(
-				this: ICredentialTestFunctions,
-				credential: ICredentialsDecrypted,
-			): Promise<INodeCredentialTestResult> {
-				try {
-					await validateCredentials.call(
-						this,
-						credential.data as ICredentialDataDecryptedObject,
-						'sts',
-					);
-				} catch (error) {
-					return {
-						status: 'Error',
-						message: 'The security token included in the request is invalid',
-					};
-				}
-
-				return {
-					status: 'OK',
-					message: 'Connection successful!',
-				};
-			},
-		},
 	};
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {

--- a/packages/nodes-base/nodes/Aws/Textract/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/Textract/GenericFunctions.ts
@@ -1,8 +1,4 @@
-import type { Request } from 'aws4';
-import { sign } from 'aws4';
 import type {
-	ICredentialDataDecryptedObject,
-	ICredentialTestFunctions,
 	IExecuteFunctions,
 	IHookFunctions,
 	ILoadOptionsFunctions,
@@ -10,27 +6,10 @@ import type {
 	IHttpRequestOptions,
 	JsonObject,
 	IHttpRequestMethods,
-	IRequestOptions,
 } from 'n8n-workflow';
 import { NodeApiError } from 'n8n-workflow';
-import { URL } from 'url';
 import { parseString } from 'xml2js';
 import { getAwsCredentials } from '../GenericFunctions';
-
-function getEndpointForService(
-	service: string,
-	credentials: ICredentialDataDecryptedObject,
-): string {
-	let endpoint;
-	if (service === 'lambda' && credentials.lambdaEndpoint) {
-		endpoint = credentials.lambdaEndpoint;
-	} else if (service === 'sns' && credentials.snsEndpoint) {
-		endpoint = credentials.snsEndpoint;
-	} else {
-		endpoint = `https://${service}.${credentials.region}.amazonaws.com`;
-	}
-	return (endpoint as string).replace('{region}', credentials.region as string);
-}
 
 export async function awsApiRequest(
 	this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions | IWebhookFunctions,
@@ -133,51 +112,4 @@ export interface IExpenseDocument {
 			];
 		},
 	];
-}
-
-export async function validateCredentials(
-	this: ICredentialTestFunctions,
-	decryptedCredentials: ICredentialDataDecryptedObject,
-	service: string,
-): Promise<any> {
-	const credentials = decryptedCredentials;
-
-	// Concatenate path and instantiate URL object so it parses correctly query strings
-	const endpoint = new URL(
-		getEndpointForService(service, credentials) + '?Action=GetCallerIdentity&Version=2011-06-15',
-	);
-
-	// Sign AWS API request with the user credentials
-	const signOpts = {
-		host: endpoint.host,
-		method: 'POST',
-		path: '?Action=GetCallerIdentity&Version=2011-06-15',
-	} as Request;
-	const securityHeaders = {
-		accessKeyId: `${credentials.accessKeyId}`.trim(),
-		secretAccessKey: `${credentials.secretAccessKey}`.trim(),
-		sessionToken: credentials.temporaryCredentials
-			? `${credentials.sessionToken}`.trim()
-			: undefined,
-	};
-
-	sign(signOpts, securityHeaders);
-
-	const options: IRequestOptions = {
-		headers: signOpts.headers,
-		method: 'POST',
-		uri: endpoint.href,
-		body: signOpts.body,
-	};
-
-	const response = await this.helpers.request(options);
-
-	return await new Promise((resolve, reject) => {
-		parseString(response as string, { explicitArray: false }, (err, data) => {
-			if (err) {
-				return reject(err);
-			}
-			resolve(data);
-		});
-	});
 }

--- a/packages/nodes-base/nodes/Aws/Transcribe/AwsTranscribe.node.ts
+++ b/packages/nodes-base/nodes/Aws/Transcribe/AwsTranscribe.node.ts
@@ -8,6 +8,7 @@ import type {
 import { NodeConnectionTypes } from 'n8n-workflow';
 
 import { awsApiRequestREST, awsApiRequestRESTAllItems } from './GenericFunctions';
+import { awsNodeAuthOptions, awsNodeCredentials } from '../utils';
 
 export class AwsTranscribe implements INodeType {
 	description: INodeTypeDescription = {
@@ -24,13 +25,9 @@ export class AwsTranscribe implements INodeType {
 		usableAsTool: true,
 		inputs: [NodeConnectionTypes.Main],
 		outputs: [NodeConnectionTypes.Main],
-		credentials: [
-			{
-				name: 'aws',
-				required: true,
-			},
-		],
+		credentials: awsNodeCredentials,
 		properties: [
+			awsNodeAuthOptions,
 			{
 				displayName: 'Resource',
 				name: 'resource',

--- a/packages/nodes-base/nodes/Aws/Transcribe/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/Transcribe/GenericFunctions.ts
@@ -1,3 +1,4 @@
+import { getAwsCredentials, getAwsCredentialSecurityHeaders } from '../GenericFunctions';
 import type { Request } from 'aws4';
 import { sign } from 'aws4';
 import get from 'lodash/get';
@@ -38,20 +39,14 @@ export async function awsApiRequest(
 	body?: string,
 	headers?: object,
 ): Promise<any> {
-	const credentials = await this.getCredentials('aws');
+	const { credentials, credentialsType } = await getAwsCredentials(this);
 
 	// Concatenate path and instantiate URL object so it parses correctly query strings
 	const endpoint = new URL(getEndpointForService(service, credentials) + path);
 
 	// Sign AWS API request with the user credentials
 	const signOpts = { headers: headers || {}, host: endpoint.host, method, path, body } as Request;
-	const securityHeaders = {
-		accessKeyId: `${credentials.accessKeyId}`.trim(),
-		secretAccessKey: `${credentials.secretAccessKey}`.trim(),
-		sessionToken: credentials.temporaryCredentials
-			? `${credentials.sessionToken}`.trim()
-			: undefined,
-	};
+	const securityHeaders = await getAwsCredentialSecurityHeaders(credentials, credentialsType);
 
 	sign(signOpts, securityHeaders);
 

--- a/packages/nodes-base/nodes/Aws/utils.ts
+++ b/packages/nodes-base/nodes/Aws/utils.ts
@@ -19,6 +19,15 @@ export const awsNodeCredentials: INodeCredentialDescription[] = [
 			},
 		},
 	},
+	{
+		name: 'awsSystem',
+		required: true,
+		displayOptions: {
+			show: {
+				authentication: ['system'],
+			},
+		},
+	},
 ];
 export const awsNodeAuthOptions: INodeProperties = {
 	displayName: 'Authentication',
@@ -32,6 +41,10 @@ export const awsNodeAuthOptions: INodeProperties = {
 		{
 			name: 'AWS (Assume Role)',
 			value: 'assumeRole',
+		},
+		{
+			name: 'AWS (System)',
+			value: 'system',
 		},
 	],
 	default: 'iam',

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -43,6 +43,7 @@
       "dist/credentials/AutopilotApi.credentials.js",
       "dist/credentials/Aws.credentials.js",
       "dist/credentials/AwsAssumeRole.credentials.js",
+      "dist/credentials/AwsSystem.credentials.js",
       "dist/credentials/AzureStorageOAuth2Api.credentials.js",
       "dist/credentials/AzureStorageSharedKeyApi.credentials.js",
       "dist/credentials/BambooHrApi.credentials.js",
@@ -886,7 +887,9 @@
     "n8n-core": "workspace:*"
   },
   "dependencies": {
+    "@aws-sdk/types": "3.804.0",
     "@aws-sdk/client-sso-oidc": "3.808.0",
+    "@aws-sdk/credential-providers": "3.808.0",
     "@kafkajs/confluent-schema-registry": "3.8.0",
     "@mozilla/readability": "0.6.0",
     "@n8n/config": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3292,6 +3292,12 @@ importers:
       '@aws-sdk/client-sso-oidc':
         specifier: 3.808.0
         version: 3.808.0
+      '@aws-sdk/credential-providers':
+        specifier: 3.808.0
+        version: 3.808.0
+      '@aws-sdk/types':
+        specifier: 3.804.0
+        version: 3.804.0
       '@kafkajs/confluent-schema-registry':
         specifier: 3.8.0
         version: 3.8.0
@@ -8054,10 +8060,6 @@ packages:
     resolution: {integrity: sha512-jN6M6zaGVyB8FmNGG+xOPQB4N89M1x97MMdMnm1ESjljLS3Qju/IegQizKujaNcy2vXAvrz0en8bobe6E55FEA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/credential-provider-imds@4.2.3':
-    resolution: {integrity: sha512-hA1MQ/WAHly4SYltJKitEsIDVsNmXcQfYBRv2e+q04fnqtAX5qXaybxy/fhUeAMCnQIdAjaGDb04fMHQefWRhw==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/credential-provider-imds@4.2.5':
     resolution: {integrity: sha512-BZwotjoZWn9+36nimwm/OLIcVe+KYRwzMjfhd4QT7QxPm9WY0HiOV8t/Wlh+HVUif0SBVV7ksq8//hPaBC/okQ==}
     engines: {node: '>=18.0.0'}
@@ -8218,10 +8220,6 @@ packages:
 
   '@smithy/property-provider@4.0.2':
     resolution: {integrity: sha512-wNRoQC1uISOuNc2s4hkOYwYllmiyrvVXWMtq+TysNRVQaHm4yoafYQyjN/goYZS+QbYlPIbb/QRjaUZMuzwQ7A==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/property-provider@4.2.3':
-    resolution: {integrity: sha512-+1EZ+Y+njiefCohjlhyOcy1UNYjT+1PwGFHCxA/gYctjg3DQWAU19WigOXAco/Ql8hZokNehpzLd0/+3uCreqQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/property-provider@4.2.5':
@@ -19233,26 +19231,26 @@ snapshots:
   '@aws-crypto/crc32@3.0.0':
     dependencies:
       '@aws-crypto/util': 3.0.0
-      '@aws-sdk/types': 3.936.0
+      '@aws-sdk/types': 3.804.0
       tslib: 2.8.1
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.936.0
+      '@aws-sdk/types': 3.804.0
       tslib: 2.8.1
 
   '@aws-crypto/crc32c@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.936.0
+      '@aws-sdk/types': 3.804.0
       tslib: 2.8.1
 
   '@aws-crypto/sha1-browser@5.2.0':
     dependencies:
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.936.0
+      '@aws-sdk/types': 3.804.0
       '@aws-sdk/util-locate-window': 3.310.0
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -19262,7 +19260,7 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.936.0
+      '@aws-sdk/types': 3.804.0
       '@aws-sdk/util-locate-window': 3.310.0
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -19270,7 +19268,7 @@ snapshots:
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.936.0
+      '@aws-sdk/types': 3.804.0
       tslib: 2.8.1
 
   '@aws-crypto/supports-web-crypto@5.2.0':
@@ -19279,13 +19277,13 @@ snapshots:
 
   '@aws-crypto/util@3.0.0':
     dependencies:
-      '@aws-sdk/types': 3.936.0
+      '@aws-sdk/types': 3.804.0
       '@aws-sdk/util-utf8-browser': 3.259.0
       tslib: 2.8.1
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.936.0
+      '@aws-sdk/types': 3.804.0
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
@@ -20063,8 +20061,8 @@ snapshots:
       '@aws-sdk/credential-provider-sso': 3.916.0
       '@aws-sdk/credential-provider-web-identity': 3.918.0
       '@aws-sdk/types': 3.914.0
-      '@smithy/credential-provider-imds': 4.2.3
-      '@smithy/property-provider': 4.2.3
+      '@smithy/credential-provider-imds': 4.2.5
+      '@smithy/property-provider': 4.2.5
       '@smithy/shared-ini-file-loader': 4.3.3
       '@smithy/types': 4.9.0
       tslib: 2.8.1
@@ -20205,9 +20203,9 @@ snapshots:
       '@aws-sdk/types': 3.804.0
       '@smithy/config-resolver': 4.4.3
       '@smithy/core': 3.18.5
-      '@smithy/credential-provider-imds': 4.0.4
+      '@smithy/credential-provider-imds': 4.2.5
       '@smithy/node-config-provider': 4.3.5
-      '@smithy/property-provider': 4.0.2
+      '@smithy/property-provider': 4.2.5
       '@smithy/types': 4.9.0
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -25101,14 +25099,6 @@ snapshots:
       '@smithy/url-parser': 4.2.5
       tslib: 2.8.1
 
-  '@smithy/credential-provider-imds@4.2.3':
-    dependencies:
-      '@smithy/node-config-provider': 4.3.5
-      '@smithy/property-provider': 4.2.5
-      '@smithy/types': 4.9.0
-      '@smithy/url-parser': 4.2.5
-      tslib: 2.8.1
-
   '@smithy/credential-provider-imds@4.2.5':
     dependencies:
       '@smithy/node-config-provider': 4.3.5
@@ -25378,11 +25368,6 @@ snapshots:
       tslib: 2.8.1
 
   '@smithy/property-provider@4.0.2':
-    dependencies:
-      '@smithy/types': 4.9.0
-      tslib: 2.8.1
-
-  '@smithy/property-provider@4.2.3':
     dependencies:
       '@smithy/types': 4.9.0
       tslib: 2.8.1

--- a/scripts/prepare.mjs
+++ b/scripts/prepare.mjs
@@ -7,4 +7,4 @@ if (process.env.CI || process.env.DOCKER_BUILD) {
 	process.exit(0);
 }
 
-execSync('pnpm lefthook install', { stdio: 'inherit' });
+execSync('pnpm lefthook install || true', { stdio: 'inherit' });


### PR DESCRIPTION
## Summary

Adds a "Credential Type" field that allow the user to pick "System" to load AWS credential from the system environment with the AWS SDK.

This option is only available if the settings `CREDENTIALS_ALLOW_SYSTEM` is set to `true`. It default to `false` to avoid regression where system credentials are made available to all n8n users.

Systems credentials are much easier to manage than explicit keys, especially when deploying inside cloud environment that supply the credential with the right role. This also allow to quickly run n8n locally with AWS access.

<img width="1235" height="784" alt="image" src="https://github.com/user-attachments/assets/82cf4d33-50c3-4a1e-8818-98dd3d6d3b05" />

<img width="1227" height="783" alt="image" src="https://github.com/user-attachments/assets/ef37e2e9-d1bc-4b08-a1ec-c907af6f9f24" />

<img width="1220" height="771" alt="image" src="https://github.com/user-attachments/assets/25bb3694-8bdc-4b0a-9039-727cda7abb44" />


## Related Linear tickets, Github issues, and Community forum posts

Alternative implementation of https://github.com/n8n-io/n8n/pull/16612 (Thanks for it though, it allowed me to quickly bootstrap my own approach)

Resolves #14948

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
