### PR TITLE
fix: Empty onclick breaks range parser in HTML editor

### DIFF
--- a/packages/frontend/editor-ui/src/components/HtmlEditor/HtmlEditor.vue
+++ b/packages/frontend/editor-ui/src/components/HtmlEditor/HtmlEditor.vue
@@ -10,6 +10,7 @@ import {
 import { Prec, EditorState } from '@codemirror/state';
 import {
 	dropCursor,
+	EditorView,
 	highlightActiveLine,
 	highlightActiveLineGutter,
 	keymap,
@@ -35,7 +36,7 @@ import { n8nAutocompletion } from '@/plugins/codemirror/n8nLang';
 import { autoCloseTags, htmlLanguage } from 'codemirror-lang-html-n8n';
 import { codeEditorTheme } from '../CodeNodeEditor/theme';
 import type { Range, Section } from './types';
-import { nonTakenRanges } from './utils';
+import { nonTakenRanges, pasteHandler } from './utils';
 import type { TargetNodeParameterContext } from '@/Interface';
 
 type Props = {
@@ -67,6 +68,7 @@ const extensions = computed(() => [
 	]),
 	autoCloseTags,
 	expressionCloseBrackets(),
+	pasteSanitizer(),
 	Prec.highest(keymap.of(editorKeymap)),
 	indentOnInput(),
 	codeEditorTheme({
@@ -228,6 +230,12 @@ async function formatHtml() {
 
 	editor.dispatch({
 		changes: { from: 0, to: editor.state.doc.length, insert: formatted.join('\n\n') },
+	});
+}
+
+function pasteSanitizer() {
+	return EditorView.domEventHandlers({
+		paste: pasteHandler,
 	});
 }
 

--- a/packages/frontend/editor-ui/src/components/HtmlEditor/utils.test.ts
+++ b/packages/frontend/editor-ui/src/components/HtmlEditor/utils.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest'; // Change to jest if needed
+import { pasteHandler } from './utils';
+import type { EditorView } from '@codemirror/view';
+
+describe('pasteHandler', () => {
+	it('replaces empty onclick attributes and dispatches changes', () => {
+		const clipboardData = {
+			getData: (type: string) => (type === 'text/html' ? '<div onclick=""></div>' : ''),
+		};
+
+		const preventDefault = vi.fn();
+		const dispatch = vi.fn();
+
+		const event = { clipboardData, preventDefault } as unknown as ClipboardEvent;
+		const view = {
+			state: {
+				selection: {
+					main: { from: 0, to: 0 },
+				},
+			},
+			dispatch,
+		} as unknown as EditorView;
+
+		const result = pasteHandler(event, view);
+
+		expect(result).toBe(true);
+		expect(preventDefault).toHaveBeenCalled();
+		expect(dispatch).toHaveBeenCalledWith({
+			changes: {
+				from: 0,
+				to: 0,
+				insert: '<div onclick=" "></div>',
+			},
+			scrollIntoView: true,
+		});
+	});
+
+	it('does nothing if there is no onclick="" in pasted content', () => {
+		const clipboardData = {
+			getData: (type: string) => (type === 'text/html' ? '<p>Hello world</p>' : ''),
+		};
+		const preventDefault = vi.fn();
+		const dispatch = vi.fn();
+
+		const event = { clipboardData, preventDefault } as unknown as ClipboardEvent;
+		const view = {
+			state: {
+				selection: {
+					main: { from: 0, to: 0 },
+				},
+			},
+			dispatch,
+		} as unknown as EditorView;
+
+		const result = pasteHandler(event, view);
+
+		expect(result).toBe(false);
+		expect(preventDefault).not.toHaveBeenCalled();
+		expect(dispatch).not.toHaveBeenCalled();
+	});
+
+	it('does nothing if clipboard data is empty', () => {
+		const clipboardData = {
+			getData: () => '',
+		};
+		const preventDefault = vi.fn();
+		const dispatch = vi.fn();
+
+		const event = { clipboardData, preventDefault } as unknown as ClipboardEvent;
+		const view = {
+			state: {
+				selection: {
+					main: { from: 0, to: 0 },
+				},
+			},
+			dispatch,
+		} as unknown as EditorView;
+
+		const result = pasteHandler(event, view);
+
+		expect(result).toBe(false);
+		expect(preventDefault).not.toHaveBeenCalled();
+		expect(dispatch).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

Fix for empty `onclick` as it breaks range parser in HTML editor

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-3172/community-issue-onclick=-in-generate-html-template
closes https://github.com/n8n-io/n8n/issues/16618

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
