### PR TITLE
chore(editor): Drop rag starter callout experiment flag (no-changelog)

### DIFF
--- a/cypress/e2e/4-node-creator.cy.ts
+++ b/cypress/e2e/4-node-creator.cy.ts
@@ -535,6 +535,10 @@ describe('Node Creator', () => {
 
 			// Loop over all vector stores and check if they have the three actions
 			vectorStores.each((_i, vectorStore) => {
+				if (vectorStore.includes('RAG starter template')) {
+					return;
+				}
+
 				nodeCreatorFeature.getters.getCreatorItem(vectorStore).click();
 				actions.forEach((action) => {
 					nodeCreatorFeature.getters.getCreatorItem(action).should('be.visible').realHover();

--- a/cypress/e2e/52-rag-callout-experiment.cy.ts
+++ b/cypress/e2e/52-rag-callout-experiment.cy.ts
@@ -1,22 +1,10 @@
-import { overrideFeatureFlag } from '../composables/featureFlags';
 import { openNodeCreator, searchBar } from '../composables/nodeCreator';
 import { addNodeToCanvas, navigateToNewWorkflowPage } from '../composables/workflow';
 
 describe('RAG callout experiment', () => {
 	describe('NDV callout', () => {
-		it('should not show callout if experiment is control', () => {
-			overrideFeatureFlag('033_rag_template', 'control');
-
-			navigateToNewWorkflowPage();
-
-			addNodeToCanvas('Zep Vector Store', true, true, 'Add documents to vector store');
-
-			cy.contains('Tip: Get a feel for vector stores in n8n with our').should('not.exist');
-		});
-
-		it('should callout is variant and open on click', () => {
+		it('should show callout and open template on click', () => {
 			cy.intercept('workflows/templates/rag-starter-template?fromJson=true');
-			overrideFeatureFlag('033_rag_template', 'variant');
 
 			navigateToNewWorkflowPage();
 
@@ -37,20 +25,8 @@ describe('RAG callout experiment', () => {
 		});
 	});
 	describe('search callout', () => {
-		it('should not show callout if experiment is control', () => {
-			overrideFeatureFlag('033_rag_template', 'control');
-
-			navigateToNewWorkflowPage();
-
-			openNodeCreator();
-			searchBar().type('rag');
-
-			cy.contains('RAG starter template').should('not.exist');
-		});
-
-		it('should should callout is variant and open on click', () => {
+		it('should show callout and open template on click', () => {
 			cy.intercept('workflows/templates/rag-starter-template?fromJson=true');
-			overrideFeatureFlag('033_rag_template', 'variant');
 
 			navigateToNewWorkflowPage();
 

--- a/packages/frontend/editor-ui/src/components/ParameterInputList.vue
+++ b/packages/frontend/editor-ui/src/components/ParameterInputList.vue
@@ -415,13 +415,13 @@ function isCalloutVisible(parameter: INodeProperties): boolean {
 	return true;
 }
 
-async function onCalloutAction(action: CalloutActionType) {
+function onCalloutAction(action: CalloutActionType) {
 	if (action === 'openRagStarterTemplate') {
-		await openRagStarterTemplate(activeNode.value?.type ?? 'no active node');
+		openRagStarterTemplate(activeNode.value?.type ?? 'no active node');
 	}
 }
 
-const onCalloutDismiss = async (parameter: INodeProperties) => {
+async function onCalloutDismiss(parameter: INodeProperties) {
 	const dismissConfirmed = await message.confirm(
 		i18n.baseText('parameterInputList.callout.dismiss.confirm.text'),
 		{
@@ -440,7 +440,7 @@ const onCalloutDismiss = async (parameter: INodeProperties) => {
 	}
 
 	await dismissCallout(parameter.name);
-};
+}
 </script>
 
 <template>

--- a/packages/frontend/editor-ui/src/composables/useCalloutHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useCalloutHelpers.test.ts
@@ -63,14 +63,14 @@ describe('useCalloutHelpers()', () => {
 	});
 
 	describe('openRagStarterTemplate()', () => {
-		it('opens the RAG starter template successfully', async () => {
+		it('opens the RAG starter template successfully', () => {
 			vi.spyOn(window, 'open').mockImplementation(() => null);
 			mocks.resolve.mockReturnValue({ href: 'n8n.io' });
 
 			const { openRagStarterTemplate } = useCalloutHelpers();
 			const nodeType = 'testNode';
 
-			await openRagStarterTemplate('testNode');
+			openRagStarterTemplate('testNode');
 
 			expect(window.open).toHaveBeenCalledWith('n8n.io', '_blank');
 			expect(mocks.track).toHaveBeenCalledWith('User clicked on RAG callout', {
@@ -79,34 +79,15 @@ describe('useCalloutHelpers()', () => {
 		});
 	});
 
-	describe('isRagStarterWorkflowExperimentEnabled', () => {
-		it('should be false if the RAG starter workflow experiment is not enabled', () => {
-			const { isRagStarterWorkflowExperimentEnabled } = useCalloutHelpers();
-			expect(isRagStarterWorkflowExperimentEnabled.value).toBe(false);
-		});
-
-		it('should be true if the RAG starter workflow experiment is enabled', () => {
-			mocks.getVariant.mockReturnValueOnce('variant');
-
-			const { isRagStarterWorkflowExperimentEnabled } = useCalloutHelpers();
-			expect(isRagStarterWorkflowExperimentEnabled.value).toBe(true);
-		});
-	});
-
 	describe('isRagStarterCalloutVisible', () => {
-		it('should be false if the feature flag is disabled', () => {
-			const { isRagStarterCalloutVisible } = useCalloutHelpers();
-			expect(isRagStarterCalloutVisible.value).toBe(false);
-		});
-
-		it('should be true if the feature flag is enabled and not on the RAG starter template', () => {
+		it('should be true if current route is not on the RAG starter template', () => {
 			mocks.getVariant.mockReturnValueOnce('variant');
 
 			const { isRagStarterCalloutVisible } = useCalloutHelpers();
 			expect(isRagStarterCalloutVisible.value).toBe(true);
 		});
 
-		it('should be false if the feature flag is enabled and currently on unsaved RAG starter template', () => {
+		it('should be false and current route is not on unsaved RAG starter template', () => {
 			mocks.getVariant.mockReturnValueOnce('variant');
 			mocks.useRoute.mockReturnValueOnce({
 				query: { templateId: 'rag-starter-template' },
@@ -117,7 +98,7 @@ describe('useCalloutHelpers()', () => {
 			expect(isRagStarterCalloutVisible.value).toBe(false);
 		});
 
-		it('should be false if the feature flag is enabled and currently on saved RAG starter template', () => {
+		it('should be false if current route is on saved RAG starter template', () => {
 			mocks.getVariant.mockReturnValueOnce('variant');
 			mocks.getWorkflowById.mockReturnValueOnce({
 				meta: { templateId: 'rag-starter-template' },
@@ -129,13 +110,13 @@ describe('useCalloutHelpers()', () => {
 	});
 
 	describe('isCalloutDismissed()', () => {
-		it('should return false if callout is not dismissed', async () => {
+		it('should return false if callout is not dismissed', () => {
 			const { isCalloutDismissed } = useCalloutHelpers();
 			const result = isCalloutDismissed('testNode');
 			expect(result).toBe(false);
 		});
 
-		it('should return true if callout is dismissed', async () => {
+		it('should return true if callout is dismissed', () => {
 			mocks.isCalloutDismissed.mockReturnValueOnce(true);
 
 			const { isCalloutDismissed } = useCalloutHelpers();

--- a/packages/frontend/editor-ui/src/composables/useCalloutHelpers.ts
+++ b/packages/frontend/editor-ui/src/composables/useCalloutHelpers.ts
@@ -2,9 +2,8 @@ import { computed } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useTelemetry } from '@/composables/useTelemetry';
 import { useRootStore } from '@n8n/stores/useRootStore';
-import { usePostHog } from '@/stores/posthog.store';
 import { useUsersStore } from '@/stores/users.store';
-import { RAG_STARTER_WORKFLOW_EXPERIMENT, VIEWS } from '@/constants';
+import { VIEWS } from '@/constants';
 import { getRagStarterWorkflowJson } from '@/utils/easyAiWorkflowUtils';
 import { updateCurrentUserSettings } from '@/api/users';
 import { useWorkflowsStore } from '@/stores/workflows.store';
@@ -13,12 +12,11 @@ export function useCalloutHelpers() {
 	const route = useRoute();
 	const router = useRouter();
 	const telemetry = useTelemetry();
-	const posthogStore = usePostHog();
 	const rootStore = useRootStore();
 	const workflowsStore = useWorkflowsStore();
 	const usersStore = useUsersStore();
 
-	const openRagStarterTemplate = async (nodeType?: string) => {
+	const openRagStarterTemplate = (nodeType?: string) => {
 		telemetry.track('User clicked on RAG callout', {
 			node_type: nodeType ?? null,
 		});
@@ -34,13 +32,6 @@ export function useCalloutHelpers() {
 		window.open(href, '_blank');
 	};
 
-	const isRagStarterWorkflowExperimentEnabled = computed(() => {
-		return (
-			posthogStore.getVariant(RAG_STARTER_WORKFLOW_EXPERIMENT.name) ===
-			RAG_STARTER_WORKFLOW_EXPERIMENT.variant
-		);
-	});
-
 	const isRagStarterCalloutVisible = computed(() => {
 		const template = getRagStarterWorkflowJson();
 
@@ -53,7 +44,7 @@ export function useCalloutHelpers() {
 			return false;
 		}
 
-		return isRagStarterWorkflowExperimentEnabled.value;
+		return true;
 	});
 
 	const isCalloutDismissed = (callout: string) => {
@@ -73,7 +64,6 @@ export function useCalloutHelpers() {
 
 	return {
 		openRagStarterTemplate,
-		isRagStarterWorkflowExperimentEnabled,
 		isRagStarterCalloutVisible,
 		isCalloutDismissed,
 		dismissCallout,

--- a/packages/frontend/editor-ui/src/constants.ts
+++ b/packages/frontend/editor-ui/src/constants.ts
@@ -751,12 +751,6 @@ export const WORKFLOW_BUILDER_EXPERIMENT = {
 	variant: 'variant',
 };
 
-export const RAG_STARTER_WORKFLOW_EXPERIMENT = {
-	name: '033_rag_template',
-	control: 'control',
-	variant: 'variant',
-};
-
 export const EXTRA_TEMPLATE_LINKS_EXPERIMENT = {
 	name: '034_extra_template_links',
 	control: 'control',
@@ -779,7 +773,6 @@ export const BATCH_11AUG_EXPERIMENT = {
 
 export const EXPERIMENTS_TO_TRACK = [
 	WORKFLOW_BUILDER_EXPERIMENT.name,
-	RAG_STARTER_WORKFLOW_EXPERIMENT.name,
 	EXTRA_TEMPLATE_LINKS_EXPERIMENT.name,
 	TEMPLATE_ONBOARDING_EXPERIMENT.name,
 	NDV_UI_OVERHAUL_EXPERIMENT.name,


### PR DESCRIPTION
## Summary

Drop the `033_rag_template` experiment feature flag, as this has now been rolled out to 100% of the users and is staying.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3883/experiment-pre-built-agents

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
