### PR TITLE
fix(editor): Fix an issue with overlapping elements in the Assignment component

### DIFF
--- a/packages/frontend/editor-ui/src/components/AssignmentCollection/Assignment.test.ts
+++ b/packages/frontend/editor-ui/src/components/AssignmentCollection/Assignment.test.ts
@@ -1,3 +1,4 @@
+import { computed, ref } from 'vue';
 import { createComponentRenderer } from '@/__tests__/render';
 import { createTestingPinia } from '@pinia/testing';
 import userEvent from '@testing-library/user-event';
@@ -6,6 +7,7 @@ import { defaultSettings } from '@/__tests__/defaults';
 import { STORES } from '@n8n/stores';
 import merge from 'lodash/merge';
 import { cleanupAppModals, createAppModals } from '@/__tests__/utils';
+import * as useResolvedExpression from '@/composables/useResolvedExpression';
 
 const DEFAULT_SETUP = {
 	pinia: createTestingPinia({
@@ -68,5 +70,28 @@ describe('Assignment.vue', () => {
 
 		// Check if the parameter input hint is not displayed
 		expect(() => getByTestId('parameter-input-hint')).toThrow();
+	});
+
+	it('should shorten the expression preview hint if options are on the bottom', () => {
+		vi.spyOn(useResolvedExpression, 'useResolvedExpression').mockReturnValueOnce({
+			resolvedExpressionString: ref('foo'),
+			resolvedExpression: ref(null),
+			isExpression: computed(() => true),
+		});
+		const { getByTestId } = renderComponent({
+			props: {
+				path: 'parameters.fields.0',
+				modelValue: {
+					name: 'test',
+					type: 'string',
+					value: '={{$json.foo}}',
+				},
+				issues: [],
+			},
+		});
+
+		expect(
+			getByTestId('parameter-expression-preview-value').classList.contains('optionsPadding'),
+		).toBe(true);
 	});
 });

--- a/packages/frontend/editor-ui/src/components/AssignmentCollection/Assignment.test.ts
+++ b/packages/frontend/editor-ui/src/components/AssignmentCollection/Assignment.test.ts
@@ -1,7 +1,8 @@
-import { computed, ref } from 'vue';
+import { computed, nextTick, ref } from 'vue';
 import { createComponentRenderer } from '@/__tests__/render';
 import { createTestingPinia } from '@pinia/testing';
 import userEvent from '@testing-library/user-event';
+import { fireEvent } from '@testing-library/vue';
 import Assignment from './Assignment.vue';
 import { defaultSettings } from '@/__tests__/defaults';
 import { STORES } from '@n8n/stores';
@@ -72,26 +73,21 @@ describe('Assignment.vue', () => {
 		expect(() => getByTestId('parameter-input-hint')).toThrow();
 	});
 
-	it('should shorten the expression preview hint if options are on the bottom', () => {
+	it('should shorten the expression preview hint if options are on the bottom', async () => {
 		vi.spyOn(useResolvedExpression, 'useResolvedExpression').mockReturnValueOnce({
 			resolvedExpressionString: ref('foo'),
 			resolvedExpression: ref(null),
 			isExpression: computed(() => true),
 		});
-		const { getByTestId } = renderComponent({
-			props: {
-				path: 'parameters.fields.0',
-				modelValue: {
-					name: 'test',
-					type: 'string',
-					value: '={{$json.foo}}',
-				},
-				issues: [],
-			},
-		});
+		const { getByTestId } = renderComponent();
 
-		expect(
-			getByTestId('parameter-expression-preview-value').classList.contains('optionsPadding'),
-		).toBe(true);
+		const previewValue = getByTestId('parameter-expression-preview-value');
+
+		expect(previewValue).not.toHaveClass('optionsPadding');
+
+		await fireEvent.mouseEnter(getByTestId('assignment-value'));
+		await nextTick();
+
+		expect(previewValue).toHaveClass('optionsPadding');
 	});
 });

--- a/packages/frontend/editor-ui/src/components/AssignmentCollection/Assignment.vue
+++ b/packages/frontend/editor-ui/src/components/AssignmentCollection/Assignment.vue
@@ -190,7 +190,10 @@ const onBlur = (): void => {
 						<ParameterInputHint
 							v-if="resolvedExpressionString"
 							data-test-id="parameter-expression-preview-value"
-							:class="$style.hint"
+							:class="{
+								[$style.hint]: true,
+								[$style.optionsPadding]: breakpoint !== 'default' && !isReadOnly,
+							}"
 							:highlight="highlightHint"
 							:hint="hint"
 							single-line
@@ -247,6 +250,10 @@ const onBlur = (): void => {
 		bottom: calc(var(--spacing-s) * -1);
 		left: 0;
 		right: 0;
+	}
+
+	.optionsPadding {
+		width: calc(100% - 140px);
 	}
 }
 

--- a/packages/frontend/editor-ui/src/components/AssignmentCollection/Assignment.vue
+++ b/packages/frontend/editor-ui/src/components/AssignmentCollection/Assignment.vue
@@ -25,6 +25,7 @@ interface Props {
 const props = defineProps<Props>();
 
 const assignment = ref<AssignmentValue>(props.modelValue);
+const valueInputHovered = ref(false);
 
 const emit = defineEmits<{
 	'update:model-value': [value: AssignmentValue];
@@ -113,6 +114,10 @@ const onRemove = (): void => {
 const onBlur = (): void => {
 	emit('update:model-value', assignment.value);
 };
+
+const onValueInputHoverChange = (hovered: boolean): void => {
+	valueInputHovered.value = hovered;
+};
 </script>
 
 <template>
@@ -186,13 +191,15 @@ const onBlur = (): void => {
 							data-test-id="assignment-value"
 							@update="onAssignmentValueChange"
 							@blur="onBlur"
+							@hover="onValueInputHoverChange"
 						/>
 						<ParameterInputHint
 							v-if="resolvedExpressionString"
 							data-test-id="parameter-expression-preview-value"
 							:class="{
 								[$style.hint]: true,
-								[$style.optionsPadding]: breakpoint !== 'default' && !isReadOnly,
+								[$style.optionsPadding]:
+									breakpoint !== 'default' && !isReadOnly && valueInputHovered,
 							}"
 							:highlight="highlightHint"
 							:hint="hint"

--- a/packages/frontend/editor-ui/src/components/ParameterInputFull.test.ts
+++ b/packages/frontend/editor-ui/src/components/ParameterInputFull.test.ts
@@ -1,4 +1,4 @@
-import { renderComponent } from '@/__tests__/render';
+import { nextTick } from 'vue';
 import type { useNDVStore } from '@/stores/ndv.store';
 import { createTestingPinia } from '@pinia/testing';
 import type { useNodeTypesStore } from '@/stores/nodeTypes.store';
@@ -6,6 +6,8 @@ import type { useSettingsStore } from '@/stores/settings.store';
 import { cleanupAppModals, createAppModals } from '@/__tests__/utils';
 import ParameterInputFull from './ParameterInputFull.vue';
 import { FROM_AI_AUTO_GENERATED_MARKER } from 'n8n-workflow';
+import { fireEvent } from '@testing-library/vue';
+import { createComponentRenderer } from '@/__tests__/render';
 
 type Writeable<T> = { -readonly [P in keyof T]: T[P] };
 
@@ -29,6 +31,7 @@ beforeEach(() => {
 	};
 	mockNodeTypesState = {
 		allNodeTypes: [],
+		getNodeType: vi.fn().mockReturnValue({}),
 	};
 	mockSettingsState = {
 		settings: {
@@ -57,6 +60,19 @@ vi.mock('@/stores/settings.store', () => {
 	};
 });
 
+const renderComponent = createComponentRenderer(ParameterInputFull, {
+	pinia: createTestingPinia(),
+	props: {
+		path: 'myParam',
+		value: '',
+		parameter: {
+			displayName: 'My Param',
+			name: 'myParam',
+			type: 'string',
+		},
+	},
+});
+
 describe('ParameterInputFull.vue', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -68,18 +84,7 @@ describe('ParameterInputFull.vue', () => {
 	});
 
 	it('should render basic parameter', async () => {
-		mockNodeTypesState.getNodeType = vi.fn().mockReturnValue({});
-		const { getByTestId } = renderComponent(ParameterInputFull, {
-			pinia: createTestingPinia(),
-			props: {
-				path: 'myParam',
-				parameter: {
-					displayName: 'My Param',
-					name: 'myParam',
-					type: 'string',
-				},
-			},
-		});
+		const { getByTestId } = renderComponent();
 		expect(getByTestId('parameter-input')).toBeInTheDocument();
 	});
 
@@ -90,18 +95,7 @@ describe('ParameterInputFull.vue', () => {
 				subcategories: { AI: ['Tools'] },
 			},
 		});
-		const { getByTestId } = renderComponent(ParameterInputFull, {
-			pinia: createTestingPinia(),
-			props: {
-				path: 'myParam',
-				parameter: {
-					displayName: 'My Param',
-					name: 'myParam',
-					type: 'string',
-				},
-				value: '',
-			},
-		});
+		const { getByTestId } = renderComponent();
 		expect(getByTestId('parameter-input')).toBeInTheDocument();
 		expect(getByTestId('from-ai-override-button')).toBeInTheDocument();
 	});
@@ -113,15 +107,8 @@ describe('ParameterInputFull.vue', () => {
 				subcategories: { AI: ['Tools'] },
 			},
 		});
-		const { getByTestId } = renderComponent(ParameterInputFull, {
-			pinia: createTestingPinia(),
+		const { getByTestId } = renderComponent({
 			props: {
-				path: 'myParam',
-				parameter: {
-					displayName: 'My Param',
-					name: 'myParam',
-					type: 'string',
-				},
 				value: `={{
 					'and the air is free'
 
@@ -140,19 +127,27 @@ describe('ParameterInputFull.vue', () => {
 				subcategories: { AI: ['Tools'] },
 			},
 		});
-		const { queryByTestId, getByTestId } = renderComponent(ParameterInputFull, {
-			pinia: createTestingPinia(),
+		const { queryByTestId, getByTestId } = renderComponent({
 			props: {
-				path: 'myParam',
 				value: `={{ ${FROM_AI_AUTO_GENERATED_MARKER} $fromAI('myParam') }}`,
-				parameter: {
-					displayName: 'My Param',
-					name: 'myParam',
-					type: 'string',
-				},
 			},
 		});
 		expect(getByTestId('fromAI-override-field')).toBeInTheDocument();
 		expect(queryByTestId('override-button')).not.toBeInTheDocument();
+	});
+
+	it('should emit on wrapper hover', async () => {
+		const { getByTestId, emitted } = renderComponent();
+		const wrapper = getByTestId('parameter-input-wrapper');
+
+		await fireEvent.mouseEnter(wrapper);
+		await nextTick();
+
+		expect(emitted().hover).toEqual([[true]]);
+
+		await fireEvent.mouseLeave(wrapper);
+		await nextTick();
+
+		expect(emitted().hover).toEqual([[true], [false]]);
 	});
 });

--- a/packages/frontend/editor-ui/src/components/ParameterInputFull.test.ts
+++ b/packages/frontend/editor-ui/src/components/ParameterInputFull.test.ts
@@ -138,7 +138,7 @@ describe('ParameterInputFull.vue', () => {
 
 	it('should emit on wrapper hover', async () => {
 		const { getByTestId, emitted } = renderComponent();
-		const wrapper = getByTestId('parameter-input-wrapper');
+		const wrapper = getByTestId('input-label');
 
 		await fireEvent.mouseEnter(wrapper);
 		await nextTick();

--- a/packages/frontend/editor-ui/src/components/ParameterInputFull.vue
+++ b/packages/frontend/editor-ui/src/components/ParameterInputFull.vue
@@ -57,6 +57,7 @@ const props = withDefaults(defineProps<Props>(), {
 const emit = defineEmits<{
 	blur: [];
 	update: [value: IUpdateInformation];
+	hover: [hovered: boolean];
 }>();
 
 const i18n = useI18n();
@@ -66,6 +67,7 @@ const eventBus = ref(createEventBus());
 const focused = ref(false);
 const menuExpanded = ref(false);
 const forceShowExpression = ref(false);
+const wrapperHovered = ref(false);
 
 const ndvStore = useNDVStore();
 const telemetry = useTelemetry();
@@ -137,6 +139,14 @@ function onBlur() {
 
 function onMenuExpanded(expanded: boolean) {
 	menuExpanded.value = expanded;
+}
+
+function onWrapperMouseEnter() {
+	wrapperHovered.value = true;
+}
+
+function onWrapperMouseLeave() {
+	wrapperHovered.value = false;
 }
 
 function optionSelected(command: string) {
@@ -249,6 +259,10 @@ watch(
 	},
 );
 
+watch(wrapperHovered, (hovered) => {
+	emit('hover', hovered);
+});
+
 const parameterInputWrapper = useTemplateRef('parameterInputWrapper');
 const isSingleLineInput: ComputedRef<boolean> = computed(
 	() => parameterInputWrapper.value?.isSingleLineInput ?? false,
@@ -305,6 +319,9 @@ function removeOverride(clearField = false) {
 		:bold="false"
 		:size="label.size"
 		color="text-dark"
+		data-test-id="parameter-input-wrapper"
+		@mouseenter="onWrapperMouseEnter"
+		@mouseleave="onWrapperMouseLeave"
 	>
 		<template
 			v-if="showOverrideButton && !isSingleLineInput && optionsPosition === 'top'"

--- a/packages/frontend/editor-ui/src/components/ParameterInputFull.vue
+++ b/packages/frontend/editor-ui/src/components/ParameterInputFull.vue
@@ -319,7 +319,6 @@ function removeOverride(clearField = false) {
 		:bold="false"
 		:size="label.size"
 		color="text-dark"
-		data-test-id="parameter-input-wrapper"
 		@mouseenter="onWrapperMouseEnter"
 		@mouseleave="onWrapperMouseLeave"
 	>


### PR DESCRIPTION
## Summary

The expression preview text and the parameter options were overlapping in the Assignment component when the pane is narrower.
<img width="633" height="267" alt="image" src="https://github.com/user-attachments/assets/0450f6e0-ab59-4e26-8a32-c7a1ef24f666" />
Added padding to the preview text to account for the options element. Discussed with @RobTF9 
<img width="842" height="384" alt="image" src="https://github.com/user-attachments/assets/61663621-ecde-4d65-986e-a29968b26915" />

Things that may be improved:
- the padding value is currently hardcoded as the width of the options component is based on its contents
- the condition for setting the padding should be the same for the condition to showing the options component but I didn't find an easy way to reuse the condition so it's duplicated


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3857/bug-expression-preview-clashes-with-node-options


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
