### PR TITLE
fix: Reduce the width of the resize handle in the NDV (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nResizeWrapper/ResizeWrapper.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nResizeWrapper/ResizeWrapper.vue
@@ -185,7 +185,7 @@ const resizerMove = (event: MouseEvent) => {
 
 <style lang="scss" module>
 .resize {
-	--resizer--size: 12px;
+	--resizer--size: 4px;
 	--resizer--side-offset: -2px;
 	--resizer--corner-offset: -3px;
 


### PR DESCRIPTION
## Summary

Within the NDV if the input pane has long content and scrollbar, that scrollbar wasn't usable because the pane resize handle was too thick so it had to be shrinked.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3762/difficult-to-click-on-the-scroller-in-ndv
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://www.loom.com/share/56e0105aca8649f1b536f456f32f0ba8?sid=5ff78791-d600-406a-bc88-36fbd984f16f

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
