### PR TITLE
chore: Deprecate Zep nodes

### DIFF
--- a/packages/@n8n/nodes-langchain/credentials/ZepApi.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/ZepApi.credentials.ts
@@ -14,6 +14,12 @@ export class ZepApi implements ICredentialType {
 
 	properties: INodeProperties[] = [
 		{
+			displayName: 'This Zep integration is deprecated and will be removed in a future version.',
+			name: 'deprecationNotice',
+			type: 'notice',
+			default: '',
+		},
+		{
 			displayName: 'API Key',
 			name: 'apiKey',
 			type: 'string',

--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryZep/MemoryZep.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryZep/MemoryZep.node.ts
@@ -33,6 +33,7 @@ export class MemoryZep implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'Zep',
 		name: 'memoryZep',
+		hidden: true,
 		// eslint-disable-next-line n8n-nodes-base/node-class-description-icon-not-svg
 		icon: 'file:zep.png',
 		group: ['transform'],
@@ -67,6 +68,12 @@ export class MemoryZep implements INodeType {
 			},
 		],
 		properties: [
+			{
+				displayName: 'This Zep integration is deprecated and will be removed in a future version.',
+				name: 'deprecationNotice',
+				type: 'notice',
+				default: '',
+			},
 			getConnectionHintNoticeField([NodeConnectionTypes.AiAgent]),
 			{
 				displayName: 'Only works with Zep Cloud and Community edition <= v0.27.2',

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreZep/VectorStoreZep.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreZep/VectorStoreZep.node.ts
@@ -50,6 +50,7 @@ export class VectorStoreZep extends createVectorStoreNode<ZepVectorStore | ZepCl
 	meta: {
 		displayName: 'Zep Vector Store',
 		name: 'vectorStoreZep',
+		hidden: true,
 		description: 'Work with your data in Zep Vector Store',
 		credentials: [
 			{
@@ -62,6 +63,12 @@ export class VectorStoreZep extends createVectorStoreNode<ZepVectorStore | ZepCl
 			'https://docs.n8n.io/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorezep/',
 	},
 	sharedFields: [
+		{
+			displayName: 'This Zep integration is deprecated and will be removed in a future version.',
+			name: 'deprecationNotice',
+			type: 'notice',
+			default: '',
+		},
 		{
 			displayName: 'Collection Name',
 			name: 'collectionName',

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreZepInsert/VectorStoreZepInsert.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreZepInsert/VectorStoreZepInsert.node.ts
@@ -64,6 +64,12 @@ export class VectorStoreZepInsert implements INodeType {
 		outputs: [NodeConnectionTypes.Main],
 		properties: [
 			{
+				displayName: 'This Zep integration is deprecated and will be removed in a future version.',
+				name: 'deprecationNotice',
+				type: 'notice',
+				default: '',
+			},
+			{
 				displayName: 'Collection Name',
 				name: 'collectionName',
 				type: 'string',

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreZepLoad/VectorStoreZepLoad.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreZepLoad/VectorStoreZepLoad.node.ts
@@ -58,6 +58,12 @@ export class VectorStoreZepLoad implements INodeType {
 		outputNames: ['Vector Store'],
 		properties: [
 			{
+				displayName: 'This Zep integration is deprecated and will be removed in a future version.',
+				name: 'deprecationNotice',
+				type: 'notice',
+				default: '',
+			},
+			{
 				displayName: 'Collection Name',
 				name: 'collectionName',
 				type: 'string',

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/types.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/types.ts
@@ -19,6 +19,7 @@ export type NodeOperationMode = 'insert' | 'load' | 'retrieve' | 'update' | 'ret
 export interface NodeMeta {
 	displayName: string;
 	name: string;
+	hidden?: boolean;
 	description: string;
 	docsUrl: string;
 	icon: Icon;


### PR DESCRIPTION
## Summary

Deprecates Zep components. Zep no longer supports the LangChain components upon which the n8n functionality is built. These LangChain components no longer work.

Components are hidden and have deprecation notices.

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
