### PR TITLE
fix(editor): Using a for-of loop on Map entries (forEach supported from node v22)

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflow-diff/useWorkflowDiff.ts
+++ b/packages/frontend/editor-ui/src/features/workflow-diff/useWorkflowDiff.ts
@@ -52,7 +52,7 @@ export function compareWorkflowsNodes<T extends { id: string }>(
 
 	const diff: WorkflowDiff<T> = new Map();
 
-	baseNodes.entries().forEach(([id, node]) => {
+	for (const [id, node] of baseNodes.entries()) {
 		if (!targetNodes.has(id)) {
 			diff.set(id, { status: NodeDiffStatus.Deleted, node });
 		} else if (!nodesEqual(baseNodes.get(id), targetNodes.get(id))) {
@@ -60,13 +60,13 @@ export function compareWorkflowsNodes<T extends { id: string }>(
 		} else {
 			diff.set(id, { status: NodeDiffStatus.Eq, node });
 		}
-	});
+	}
 
-	targetNodes.entries().forEach(([id, node]) => {
+	for (const [id, node] of targetNodes.entries()) {
 		if (!baseNodes.has(id)) {
 			diff.set(id, { status: NodeDiffStatus.Added, node });
 		}
-	});
+	}
 
 	return diff;
 }


### PR DESCRIPTION
## Summary

Fixed Map.entries().forEach error by replacing with for...of loops since Map.entries() returns an iterator, not an array.

## Related Linear tickets, Github issues, and Community forum posts

PAY-3200

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
