### PR TITLE
feat: Auto-compact workflow builder conversation history (no-changelog)

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/chains/conversation-compact.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/chains/conversation-compact.ts
@@ -1,9 +1,28 @@
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import type { BaseMessage } from '@langchain/core/messages';
 import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import { PromptTemplate } from '@langchain/core/prompts';
 import z from 'zod';
 
-export async function conversationCompactChain(llm: BaseChatModel, messages: BaseMessage[]) {
+const compactPromptTemplate = PromptTemplate.fromTemplate(
+	`Please summarize the following conversation between a user and an AI assistant building an n8n workflow:
+
+<previous_summary>
+{previousSummary}
+</previous_summary>
+
+<conversation>
+{conversationText}
+</conversation>
+
+Provide a structured summary that captures the key points, decisions made, current state of the workflow, and suggested next steps.`,
+);
+
+export async function conversationCompactChain(
+	llm: BaseChatModel,
+	messages: BaseMessage[],
+	previousSummary: string = '',
+) {
 	// Use structured output for consistent summary format
 	const CompactedSession = z.object({
 		summary: z.string().describe('A concise summary of the conversation so far'),
@@ -21,19 +40,22 @@ export async function conversationCompactChain(llm: BaseChatModel, messages: Bas
 				// eslint-disable-next-line @typescript-eslint/no-base-to-string, @typescript-eslint/restrict-template-expressions
 				return `User: ${msg.content}`;
 			} else if (msg instanceof AIMessage) {
-				// eslint-disable-next-line @typescript-eslint/no-base-to-string, @typescript-eslint/restrict-template-expressions
-				return `Assistant: ${msg.content ?? 'Used tools'}`;
+				if (typeof msg.content === 'string') {
+					return `Assistant: ${msg.content}`;
+				} else {
+					return 'Assistant: Used tools';
+				}
 			}
+
 			return '';
 		})
 		.filter(Boolean)
 		.join('\n');
 
-	const compactPrompt = `Please summarize the following conversation between a user and an AI assistant building an n8n workflow:
-
-${conversationText}
-
-Provide a structured summary that captures the key points, decisions made, current state of the workflow, and suggested next steps.`;
+	const compactPrompt = await compactPromptTemplate.invoke({
+		previousSummary,
+		conversationText,
+	});
 
 	const structuredOutput = await modelWithStructure.invoke(compactPrompt);
 
@@ -48,20 +70,9 @@ ${(structuredOutput.key_decisions as string[]).map((d: string) => `- ${d}`).join
 
 **Next Steps:** ${structuredOutput.next_steps}`;
 
-	// Create a new compacted message
-	// const compactedMessage = new AIMessage({
-	// 	content: formattedSummary,
-	// });
-
-	// // Keep only the last message plus the summary
-	// const lastUserMessage = messages.slice(-1);
-	// const newMessages = [lastUserMessage[0], compactedMessage];
-
 	return {
 		success: true,
 		summary: structuredOutput,
 		summaryPlain: formattedSummary,
-		// newMessages,
-		// messagesRemoved: messages.length - newMessages.length,
 	};
 }

--- a/packages/@n8n/ai-workflow-builder.ee/src/chains/conversation-compact.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/chains/conversation-compact.ts
@@ -37,9 +37,7 @@ Provide a structured summary that captures the key points, decisions made, curre
 
 	const structuredOutput = await modelWithStructure.invoke(compactPrompt);
 
-	// Create a new compacted message
-	const compactedMessage = new AIMessage({
-		content: `## Previous Conversation Summary
+	const formattedSummary = `## Previous Conversation Summary
 
 **Summary:** ${structuredOutput.summary}
 
@@ -48,17 +46,22 @@ ${(structuredOutput.key_decisions as string[]).map((d: string) => `- ${d}`).join
 
 **Current State:** ${structuredOutput.current_state}
 
-**Next Steps:** ${structuredOutput.next_steps}`,
-	});
+**Next Steps:** ${structuredOutput.next_steps}`;
 
-	// Keep only the last message(request to compact from user) plus the summary
-	const lastUserMessage = messages.slice(-1);
-	const newMessages = [lastUserMessage[0], compactedMessage];
+	// Create a new compacted message
+	// const compactedMessage = new AIMessage({
+	// 	content: formattedSummary,
+	// });
+
+	// // Keep only the last message plus the summary
+	// const lastUserMessage = messages.slice(-1);
+	// const newMessages = [lastUserMessage[0], compactedMessage];
 
 	return {
 		success: true,
 		summary: structuredOutput,
-		newMessages,
-		messagesRemoved: messages.length - newMessages.length,
+		summaryPlain: formattedSummary,
+		// newMessages,
+		// messagesRemoved: messages.length - newMessages.length,
 	};
 }

--- a/packages/@n8n/ai-workflow-builder.ee/src/chains/test/conversation-compact.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/chains/test/conversation-compact.test.ts
@@ -1,0 +1,226 @@
+import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import { FakeListChatModel } from '@langchain/core/utils/testing';
+
+import { conversationCompactChain } from '../conversation-compact';
+
+// Mock structured output for testing
+class MockStructuredLLM extends FakeListChatModel {
+	private readonly structuredResponse: Record<string, unknown>;
+
+	constructor(response: Record<string, unknown>) {
+		super({ responses: ['mock'] });
+		this.structuredResponse = response;
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	withStructuredOutput(): any {
+		return {
+			invoke: async () => this.structuredResponse,
+		};
+	}
+}
+
+describe('conversationCompactChain', () => {
+	let fakeLLM: BaseChatModel;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('Basic functionality', () => {
+		it('should summarize a conversation without previous summary', async () => {
+			fakeLLM = new MockStructuredLLM({
+				summary: 'Test summary of the conversation',
+				key_decisions: ['Decision 1', 'Decision 2'],
+				current_state: 'Current workflow state',
+				next_steps: 'Suggested next steps',
+			});
+
+			const messages: BaseMessage[] = [
+				new HumanMessage('Create a workflow'),
+				new AIMessage('I will help you create a workflow'),
+				new HumanMessage('Add an HTTP node'),
+				new AIMessage('Added HTTP node'),
+			];
+
+			const result = await conversationCompactChain(fakeLLM, messages);
+
+			expect(result.success).toBe(true);
+			expect(result.summary).toEqual({
+				summary: 'Test summary of the conversation',
+				key_decisions: ['Decision 1', 'Decision 2'],
+				current_state: 'Current workflow state',
+				next_steps: 'Suggested next steps',
+			});
+
+			expect(result.summaryPlain).toContain('## Previous Conversation Summary');
+			expect(result.summaryPlain).toContain('**Summary:** Test summary of the conversation');
+			expect(result.summaryPlain).toContain('- Decision 1');
+			expect(result.summaryPlain).toContain('- Decision 2');
+			expect(result.summaryPlain).toContain('**Current State:** Current workflow state');
+			expect(result.summaryPlain).toContain('**Next Steps:** Suggested next steps');
+		});
+
+		it('should include previous summary when provided', async () => {
+			fakeLLM = new MockStructuredLLM({
+				summary: 'Continued conversation summary',
+				key_decisions: ['Previous decision', 'New decision'],
+				current_state: 'Updated workflow state',
+				next_steps: 'Continue with next steps',
+			});
+
+			const previousSummary = 'This is a previous summary of earlier conversation';
+			const messages: BaseMessage[] = [
+				new HumanMessage('Continue with the workflow'),
+				new AIMessage('Continuing from where we left off'),
+			];
+
+			const result = await conversationCompactChain(fakeLLM, messages, previousSummary);
+
+			expect(result.success).toBe(true);
+			expect(result.summary.summary).toBe('Continued conversation summary');
+		});
+	});
+
+	describe('Message formatting', () => {
+		beforeEach(() => {
+			fakeLLM = new MockStructuredLLM({
+				summary: 'Message formatting test',
+				key_decisions: [],
+				current_state: 'Test state',
+				next_steps: 'Test steps',
+			});
+		});
+
+		it('should format HumanMessages correctly', async () => {
+			const messages: BaseMessage[] = [
+				new HumanMessage('User message 1'),
+				new HumanMessage('User message 2'),
+			];
+
+			const result = await conversationCompactChain(fakeLLM, messages);
+			expect(result.success).toBe(true);
+		});
+
+		it('should format AIMessages with string content correctly', async () => {
+			const messages: BaseMessage[] = [
+				new AIMessage('Assistant response 1'),
+				new AIMessage('Assistant response 2'),
+			];
+
+			const result = await conversationCompactChain(fakeLLM, messages);
+			expect(result.success).toBe(true);
+		});
+
+		it('should handle AIMessages with non-string content', async () => {
+			const messages: BaseMessage[] = [
+				new AIMessage({ content: 'structured', additional_kwargs: {} }),
+				new AIMessage('Plain message'),
+			];
+
+			// The function should handle both object and string content
+			const result = await conversationCompactChain(fakeLLM, messages);
+			expect(result.success).toBe(true);
+		});
+
+		it('should filter out ToolMessages and other message types', async () => {
+			const messages: BaseMessage[] = [
+				new HumanMessage('User message'),
+				new ToolMessage({ content: 'Tool output', tool_call_id: 'tool-1' }),
+				new AIMessage('Assistant message'),
+			];
+
+			// ToolMessages should be filtered out during processing
+			const result = await conversationCompactChain(fakeLLM, messages);
+			expect(result.success).toBe(true);
+		});
+
+		it('should handle empty messages array', async () => {
+			const messages: BaseMessage[] = [];
+
+			const result = await conversationCompactChain(fakeLLM, messages);
+			expect(result.success).toBe(true);
+		});
+
+		it('should handle messages with empty content', async () => {
+			const messages: BaseMessage[] = [
+				new HumanMessage(''),
+				new AIMessage(''),
+				new HumanMessage('Valid message'),
+			];
+
+			const result = await conversationCompactChain(fakeLLM, messages);
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe('Structured output', () => {
+		it('should format the structured output correctly', async () => {
+			fakeLLM = new MockStructuredLLM({
+				summary: 'Workflow creation initiated',
+				key_decisions: ['Use HTTP node', 'Add authentication', 'Set up error handling'],
+				current_state: 'Workflow has HTTP node configured',
+				next_steps: 'Add data transformation node',
+			});
+
+			const messages: BaseMessage[] = [new HumanMessage('Create workflow')];
+
+			const result = await conversationCompactChain(fakeLLM, messages);
+
+			expect(result.summaryPlain).toBe(
+				`## Previous Conversation Summary
+
+**Summary:** Workflow creation initiated
+
+**Key Decisions:**
+- Use HTTP node
+- Add authentication
+- Set up error handling
+
+**Current State:** Workflow has HTTP node configured
+
+**Next Steps:** Add data transformation node`,
+			);
+		});
+
+		it('should handle empty key_decisions array', async () => {
+			fakeLLM = new MockStructuredLLM({
+				summary: 'Test summary',
+				key_decisions: [],
+				current_state: 'Test state',
+				next_steps: 'Test steps',
+			});
+
+			const messages: BaseMessage[] = [new HumanMessage('Test')];
+
+			const result = await conversationCompactChain(fakeLLM, messages);
+
+			expect(result.summaryPlain).toContain('**Key Decisions:**\n');
+			expect(result.summary.key_decisions).toEqual([]);
+		});
+	});
+
+	describe('Error handling', () => {
+		it('should propagate LLM errors', async () => {
+			class ErrorLLM extends FakeListChatModel {
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				withStructuredOutput(): any {
+					return {
+						invoke: async () => {
+							throw new Error('LLM invocation failed');
+						},
+					};
+				}
+			}
+
+			const errorLLM = new ErrorLLM({ responses: [] });
+			const messages: BaseMessage[] = [new HumanMessage('Test message')];
+
+			await expect(conversationCompactChain(errorLLM, messages)).rejects.toThrow(
+				'LLM invocation failed',
+			);
+		});
+	});
+});

--- a/packages/@n8n/ai-workflow-builder.ee/src/constants.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/constants.ts
@@ -1,3 +1,3 @@
 export const MAX_AI_BUILDER_PROMPT_LENGTH = 1000; // characters
 
-export const MAX_USER_MESSAGES = 10; // Maximum number of user messages to keep in the state
+export const AUTO_COMPACT_THRESHOLD_TOKENS = 15_000; // Tokens threshold for auto-compacting the conversation

--- a/packages/@n8n/ai-workflow-builder.ee/src/constants.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/constants.ts
@@ -1,3 +1,3 @@
 export const MAX_AI_BUILDER_PROMPT_LENGTH = 1000; // characters
 
-export const AUTO_COMPACT_THRESHOLD_TOKENS = 15_000; // Tokens threshold for auto-compacting the conversation
+export const AUTO_COMPACT_THRESHOLD_TOKENS = 20_000; // Tokens threshold for auto-compacting the conversation

--- a/packages/@n8n/ai-workflow-builder.ee/src/constants.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/constants.ts
@@ -1,3 +1,3 @@
 export const MAX_AI_BUILDER_PROMPT_LENGTH = 1000; // characters
 
-export const AUTO_COMPACT_THRESHOLD_TOKENS = 20_000; // Tokens threshold for auto-compacting the conversation
+export const DEFAULT_AUTO_COMPACT_THRESHOLD_TOKENS = 20_000; // Tokens threshold for auto-compacting the conversation

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/prompts/main-agent.prompt.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/prompts/main-agent.prompt.ts
@@ -359,6 +359,12 @@ const currentExecutionNodesSchemas = `
 <current_execution_nodes_schemas>
 {executionSchema}
 </current_execution_nodes_schemas>`;
+
+const previousConversationSummary = `
+<previous_summary>
+{previousSummary}
+</previous_summary>`;
+
 export const mainAgentPrompt = ChatPromptTemplate.fromMessages([
 	[
 		'system',
@@ -383,6 +389,11 @@ export const mainAgentPrompt = ChatPromptTemplate.fromMessages([
 			{
 				type: 'text',
 				text: responsePatterns,
+				cache_control: { type: 'ephemeral' },
+			},
+			{
+				type: 'text',
+				text: previousConversationSummary,
 				cache_control: { type: 'ephemeral' },
 			},
 		],

--- a/packages/@n8n/ai-workflow-builder.ee/src/utils/test/operations-processor.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/utils/test/operations-processor.test.ts
@@ -386,6 +386,7 @@ describe('operations-processor', () => {
 			workflowOperations,
 			messages: [],
 			workflowContext: {},
+			previousSummary: 'EMPTY',
 		});
 
 		it('should process operations and clear them', () => {

--- a/packages/@n8n/ai-workflow-builder.ee/src/utils/test/tool-executor.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/utils/test/tool-executor.test.ts
@@ -48,6 +48,7 @@ describe('tool-executor', () => {
 			workflowOperations: null,
 			messages,
 			workflowContext: {},
+			previousSummary: 'EMPTY',
 		});
 
 		// Helper to create mock tool

--- a/packages/@n8n/ai-workflow-builder.ee/src/utils/token-usage.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/utils/token-usage.ts
@@ -1,0 +1,34 @@
+import { AIMessage } from '@langchain/core/messages';
+
+type AIMessageWithUsageMetadata = AIMessage & {
+	response_metadata: {
+		usage: {
+			input_tokens: number;
+			output_tokens: number;
+		};
+	};
+};
+
+export interface TokenUsage {
+	input_tokens: number;
+	output_tokens: number;
+}
+
+/**
+ * Extracts token usage information from the last AI assistant message
+ */
+export function extractLastTokenUsage(messages: unknown[]): TokenUsage | undefined {
+	const lastAiAssistantMessage = messages.findLast(
+		(m): m is AIMessageWithUsageMetadata =>
+			m instanceof AIMessage &&
+			m.response_metadata?.usage !== undefined &&
+			'input_tokens' in m.response_metadata.usage &&
+			'output_tokens' in m.response_metadata.usage,
+	);
+
+	if (!lastAiAssistantMessage) {
+		return undefined;
+	}
+
+	return lastAiAssistantMessage.response_metadata.usage;
+}

--- a/packages/@n8n/ai-workflow-builder.ee/src/workflow-builder-agent.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/workflow-builder-agent.ts
@@ -194,6 +194,10 @@ export class WorkflowBuilderAgent {
 			const lastHumanMessage = messages[messages.length - 1] as HumanMessage;
 			const isAutoCompact = lastHumanMessage.content !== '/compact';
 
+			this.logger?.debug('Compacting conversation history', {
+				isAutoCompact,
+			});
+
 			const compactedMessages = await conversationCompactChain(
 				this.llmSimpleTask,
 				messages,

--- a/packages/@n8n/ai-workflow-builder.ee/src/workflow-builder-agent.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/workflow-builder-agent.ts
@@ -190,11 +190,15 @@ export class WorkflowBuilderAgent {
 				throw new LLMServiceError('LLM not setup');
 			}
 
-			const messages = state.messages;
+			const { messages, previousSummary } = state;
 			const lastHumanMessage = messages[messages.length - 1] as HumanMessage;
 			const isAutoCompact = lastHumanMessage.content !== '/compact';
 
-			const compactedMessages = await conversationCompactChain(this.llmSimpleTask, messages);
+			const compactedMessages = await conversationCompactChain(
+				this.llmSimpleTask,
+				messages,
+				previousSummary,
+			);
 
 			// The summarized conversation history will become a part of system prompt
 			// and will be used in the next LLM call.

--- a/packages/@n8n/ai-workflow-builder.ee/tsconfig.json
+++ b/packages/@n8n/ai-workflow-builder.ee/tsconfig.json
@@ -4,6 +4,8 @@
 		"@n8n/typescript-config/tsconfig.backend.json"
 	],
 	"compilerOptions": {
+		"target": "es2023",
+		"lib": ["es2023"],
 		"rootDir": ".",
 		"emitDecoratorMetadata": true,
 		"experimentalDecorators": true,


### PR DESCRIPTION
## Summary

This PR implements conversation history compaction for the AI Workflow Builder to prevent token limit issues in long conversations.

### Key changes
- Before execution goes to the main agent node, system checks the current token usage (from the last AIMessage)
- If token usage is greater than the threshold - run conversation compacting chain
- Summary saved to the state (`previousSummary`) and added to the system prompt
- Compacting prompt updated to also include previous summary
- Previous naive message trimming logic was removed

The threshold is 20k tokens now, which is roughly fit initial generation + several message turns.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-1266/feature-compact-message-history


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
