### PR TITLE
fix: chalk import to prevent errors

### DIFF
--- a/scripts/dockerize-n8n.mjs
+++ b/scripts/dockerize-n8n.mjs
@@ -7,7 +7,8 @@
  * Override with IMAGE_BASE_NAME and IMAGE_TAG environment variables.
  */
 
-import { $, echo, fs, chalk, os } from 'zx';
+import { $, echo, fs, os } from 'zx';
+import chalk from 'chalk';
 import { fileURLToPath } from 'url';
 import path from 'path';
 


### PR DESCRIPTION
## Summary

`chalk` isn’t part of `zx`, so using it from there breaks stuff.

i switched to importing `chalk` directly to fix the error.


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
