### PR TITLE
fix(editor): Resolve CSV binary data viewer blank screen issue

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -226,6 +226,7 @@
 	"binaryDataDisplay.backToList": "Back to list",
 	"binaryDataDisplay.backToOverviewPage": "Back to overview page",
 	"binaryDataDisplay.noDataFoundToDisplay": "No data found to display",
+	"binaryDataDisplay.noCsvDataToDisplay": "No CSV data to display",
 	"binaryDataDisplay.yourBrowserDoesNotSupport": "Your browser does not support the video element. Kindly update it to latest version.",
 	"chat.hide": "Hide chat",
 	"chat.open": "Open chat",

--- a/packages/frontend/editor-ui/src/components/BinaryDataDisplayEmbed.test.ts
+++ b/packages/frontend/editor-ui/src/components/BinaryDataDisplayEmbed.test.ts
@@ -288,5 +288,38 @@ describe('BinaryDataDisplayEmbed.vue', () => {
 				expect(getByText('Error loading binary data')).toBeInTheDocument();
 			});
 		});
+
+		it('should handle CSV with CRLF line endings and newlines in quoted fields', async () => {
+			// Using CRLF (\r\n) line endings and a newline within a quoted field
+			const csvData = btoa('Name,Description\r\nJohn,"Line 1\nLine 2"\r\nJane,"Single line"');
+			const binaryData: IBinaryData = {
+				data: csvData,
+				fileName: 'test.csv',
+				mimeType: 'text/csv',
+			};
+
+			const { container, getByText } = renderComponent({
+				props: { binaryData },
+				pinia: createTestingPinia(),
+			});
+
+			await waitFor(() => {
+				// Headers
+				expect(getByText('Name')).toBeInTheDocument();
+				expect(getByText('Description')).toBeInTheDocument();
+
+				// Data
+				expect(getByText('John')).toBeInTheDocument();
+				expect(getByText('Jane')).toBeInTheDocument();
+				expect(getByText('Single line')).toBeInTheDocument();
+
+				// Check that the multiline text is preserved in the cell
+				const cells = container.querySelectorAll('td');
+				const multilineCell = Array.from(cells).find((cell) =>
+					cell.textContent?.includes('Line 1'),
+				);
+				expect(multilineCell?.textContent).toBe('Line 1\nLine 2');
+			});
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/components/BinaryDataDisplayEmbed.test.ts
+++ b/packages/frontend/editor-ui/src/components/BinaryDataDisplayEmbed.test.ts
@@ -21,16 +21,16 @@ vi.mock('@/stores/workflows.store', () => ({
 	})),
 }));
 
-// Mock fetch for testing binary data with ID
-global.fetch = vi.fn();
-
 describe('BinaryDataDisplayEmbed.vue', () => {
 	beforeEach(() => {
+		// Mock fetch for each test to avoid contamination
+		global.fetch = vi.fn();
 		vi.clearAllMocks();
 	});
 
 	afterEach(() => {
-		vi.clearAllMocks();
+		// Clean up fetch mock after each test
+		vi.restoreAllMocks();
 	});
 
 	describe('CSV parsing and display', () => {

--- a/packages/frontend/editor-ui/src/components/BinaryDataDisplayEmbed.test.ts
+++ b/packages/frontend/editor-ui/src/components/BinaryDataDisplayEmbed.test.ts
@@ -189,7 +189,8 @@ describe('BinaryDataDisplayEmbed.vue', () => {
 			});
 
 			await waitFor(() => {
-				expect(getByText('binaryDataDisplay.noCsvDataToDisplay')).toBeInTheDocument();
+				// The i18n mock in tests returns the actual translated text
+				expect(getByText('No CSV data to display')).toBeInTheDocument();
 			});
 		});
 

--- a/packages/frontend/editor-ui/src/components/BinaryDataDisplayEmbed.test.ts
+++ b/packages/frontend/editor-ui/src/components/BinaryDataDisplayEmbed.test.ts
@@ -189,7 +189,7 @@ describe('BinaryDataDisplayEmbed.vue', () => {
 			});
 
 			await waitFor(() => {
-				expect(getByText('No CSV data to display')).toBeInTheDocument();
+				expect(getByText('binaryDataDisplay.noCsvDataToDisplay')).toBeInTheDocument();
 			});
 		});
 

--- a/packages/frontend/editor-ui/src/components/BinaryDataDisplayEmbed.test.ts
+++ b/packages/frontend/editor-ui/src/components/BinaryDataDisplayEmbed.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { waitFor } from '@testing-library/vue';
+import { createComponentRenderer } from '@/__tests__/render';
+import { createTestingPinia } from '@pinia/testing';
+import BinaryDataDisplayEmbed from '@/components/BinaryDataDisplayEmbed.vue';
+import type { IBinaryData } from 'n8n-workflow';
+
+const renderComponent = createComponentRenderer(BinaryDataDisplayEmbed);
+
+// Mock the workflows store
+vi.mock('@/stores/workflows.store', () => ({
+	useWorkflowsStore: vi.fn(() => ({
+		getBinaryUrl: vi.fn((id: string, action: string, fileName: string, mimeType: string) => {
+			const params = new URLSearchParams();
+			params.append('id', id);
+			params.append('action', action);
+			if (fileName) params.append('fileName', fileName);
+			if (mimeType) params.append('mimeType', mimeType);
+			return `/rest/binary-data?${params.toString()}`;
+		}),
+	})),
+}));
+
+// Mock fetch for testing binary data with ID
+global.fetch = vi.fn();
+
+describe('BinaryDataDisplayEmbed.vue', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('CSV parsing and display', () => {
+		it('should render CSV data correctly with simple comma-separated values', async () => {
+			const csvData = btoa('Name,Age,City\nJohn,25,Boston\nJane,30,NYC');
+			const binaryData: IBinaryData = {
+				data: csvData,
+				fileName: 'test.csv',
+				mimeType: 'text/csv',
+			};
+
+			const { container, getByText } = renderComponent({
+				props: { binaryData },
+				pinia: createTestingPinia(),
+			});
+
+			await waitFor(() => {
+				expect(getByText('Name')).toBeInTheDocument();
+				expect(getByText('Age')).toBeInTheDocument();
+				expect(getByText('City')).toBeInTheDocument();
+				expect(getByText('John')).toBeInTheDocument();
+				expect(getByText('25')).toBeInTheDocument();
+				expect(getByText('Boston')).toBeInTheDocument();
+				expect(getByText('Jane')).toBeInTheDocument();
+				expect(getByText('30')).toBeInTheDocument();
+				expect(getByText('NYC')).toBeInTheDocument();
+			});
+
+			// Check table structure
+			const table = container.querySelector('.csv-table');
+			expect(table).toBeInTheDocument();
+
+			const headers = container.querySelectorAll('th');
+			expect(headers).toHaveLength(3);
+
+			const rows = container.querySelectorAll('tbody tr');
+			expect(rows).toHaveLength(2);
+		});
+
+		it('should handle CSV with quoted values containing commas', async () => {
+			const csvData = btoa(
+				'"Last, First",Age,Department\n"Smith, John",25,"Engineering, Software"\n"Doe, Jane",30,Marketing',
+			);
+			const binaryData: IBinaryData = {
+				data: csvData,
+				fileName: 'test.csv',
+				mimeType: 'text/csv',
+			};
+
+			const { getByText } = renderComponent({
+				props: { binaryData },
+				pinia: createTestingPinia(),
+			});
+
+			await waitFor(() => {
+				// Headers
+				expect(getByText('Last, First')).toBeInTheDocument();
+				expect(getByText('Age')).toBeInTheDocument();
+				expect(getByText('Department')).toBeInTheDocument();
+
+				// Data with commas preserved
+				expect(getByText('Smith, John')).toBeInTheDocument();
+				expect(getByText('Engineering, Software')).toBeInTheDocument();
+				expect(getByText('Doe, Jane')).toBeInTheDocument();
+				expect(getByText('Marketing')).toBeInTheDocument();
+			});
+		});
+
+		it('should handle CSV with escaped quotes', async () => {
+			const csvData = btoa('"Name","Description"\n"John ""Johnny"" Smith","He said ""Hello"""');
+			const binaryData: IBinaryData = {
+				data: csvData,
+				fileName: 'test.csv',
+				mimeType: 'text/csv',
+			};
+
+			const { getByText } = renderComponent({
+				props: { binaryData },
+				pinia: createTestingPinia(),
+			});
+
+			await waitFor(() => {
+				expect(getByText('Name')).toBeInTheDocument();
+				expect(getByText('Description')).toBeInTheDocument();
+				expect(getByText('John "Johnny" Smith')).toBeInTheDocument();
+				expect(getByText('He said "Hello"')).toBeInTheDocument();
+			});
+		});
+
+		it('should handle empty CSV fields and trailing commas', async () => {
+			const csvData = btoa('Name,Age,City\nJohn,,Boston\nJane,30,\n,25,NYC');
+			const binaryData: IBinaryData = {
+				data: csvData,
+				fileName: 'test.csv',
+				mimeType: 'text/csv',
+			};
+
+			const { container } = renderComponent({
+				props: { binaryData },
+				pinia: createTestingPinia(),
+			});
+
+			await waitFor(() => {
+				const cells = container.querySelectorAll('td');
+				expect(cells).toHaveLength(9); // 3 rows × 3 columns
+
+				// Check that empty cells are rendered
+				expect(cells[1].textContent).toBe(''); // John's age is empty
+				expect(cells[5].textContent).toBe(''); // Jane's city is empty
+				expect(cells[6].textContent).toBe(''); // Third row's name is empty
+			});
+		});
+
+		it('should handle CSV with binary data ID (fetched from server)', async () => {
+			const csvContent = 'Name,Age\nJohn,25\nJane,30';
+			(global.fetch as any).mockResolvedValueOnce({
+				text: async () => csvContent,
+			});
+
+			const binaryData: IBinaryData = {
+				id: 'test-binary-id',
+				data: '',
+				fileName: 'test.csv',
+				mimeType: 'text/csv',
+			};
+
+			const { getByText } = renderComponent({
+				props: { binaryData },
+				pinia: createTestingPinia(),
+			});
+
+			await waitFor(() => {
+				expect(getByText('Name')).toBeInTheDocument();
+				expect(getByText('Age')).toBeInTheDocument();
+				expect(getByText('John')).toBeInTheDocument();
+				expect(getByText('25')).toBeInTheDocument();
+			});
+
+			expect(global.fetch).toHaveBeenCalledWith(
+				'/rest/binary-data?id=test-binary-id&action=view&fileName=test.csv&mimeType=text%2Fcsv',
+				{ credentials: 'include' },
+			);
+		});
+
+		it('should display empty state for CSV with no data', async () => {
+			const csvData = btoa('');
+			const binaryData: IBinaryData = {
+				data: csvData,
+				fileName: 'empty.csv',
+				mimeType: 'text/csv',
+			};
+
+			const { getByText } = renderComponent({
+				props: { binaryData },
+				pinia: createTestingPinia(),
+			});
+
+			await waitFor(() => {
+				expect(getByText('No CSV data to display')).toBeInTheDocument();
+			});
+		});
+
+		it('should render CSV table with proper structure and classes', async () => {
+			const csvData = btoa('Header1,Header2\nValue1,Value2');
+			const binaryData: IBinaryData = {
+				data: csvData,
+				fileName: 'test.csv',
+				mimeType: 'text/csv',
+			};
+
+			const { container } = renderComponent({
+				props: { binaryData },
+				pinia: createTestingPinia(),
+			});
+
+			await waitFor(() => {
+				// Check table structure and CSS classes
+				const csvContainer = container.querySelector('.csv-container');
+				expect(csvContainer).toBeInTheDocument();
+
+				const table = container.querySelector('.csv-table');
+				expect(table).toBeInTheDocument();
+
+				const headers = container.querySelectorAll('th');
+				expect(headers).toHaveLength(2);
+
+				const rows = container.querySelectorAll('tbody tr');
+				expect(rows).toHaveLength(1);
+			});
+		});
+
+		it('should handle mixed quoted and unquoted fields', async () => {
+			const csvData = btoa('Name,Age,"Location"\nJohn,25,"New York, NY"\n"Jane Smith",30,Boston');
+			const binaryData: IBinaryData = {
+				data: csvData,
+				fileName: 'test.csv',
+				mimeType: 'text/csv',
+			};
+
+			const { getByText } = renderComponent({
+				props: { binaryData },
+				pinia: createTestingPinia(),
+			});
+
+			await waitFor(() => {
+				expect(getByText('Location')).toBeInTheDocument();
+				expect(getByText('John')).toBeInTheDocument();
+				expect(getByText('New York, NY')).toBeInTheDocument();
+				expect(getByText('Jane Smith')).toBeInTheDocument();
+				expect(getByText('Boston')).toBeInTheDocument();
+			});
+		});
+
+		it('should handle CSV with only headers', async () => {
+			const csvData = btoa('Header1,Header2,Header3');
+			const binaryData: IBinaryData = {
+				data: csvData,
+				fileName: 'headers-only.csv',
+				mimeType: 'text/csv',
+			};
+
+			const { container, getByText } = renderComponent({
+				props: { binaryData },
+				pinia: createTestingPinia(),
+			});
+
+			await waitFor(() => {
+				expect(getByText('Header1')).toBeInTheDocument();
+				expect(getByText('Header2')).toBeInTheDocument();
+				expect(getByText('Header3')).toBeInTheDocument();
+
+				// Should have no tbody rows
+				const tbody = container.querySelector('tbody');
+				const rows = tbody?.querySelectorAll('tr') || [];
+				expect(rows).toHaveLength(0);
+			});
+		});
+
+		it('should handle error when fetching CSV data', async () => {
+			(global.fetch as any).mockRejectedValueOnce(new Error('Network error'));
+
+			const binaryData: IBinaryData = {
+				id: 'test-binary-id',
+				data: '',
+				fileName: 'test.csv',
+				mimeType: 'text/csv',
+			};
+
+			const { getByText } = renderComponent({
+				props: { binaryData },
+				pinia: createTestingPinia(),
+			});
+
+			await waitFor(() => {
+				expect(getByText('Error loading binary data')).toBeInTheDocument();
+			});
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/components/BinaryDataDisplayEmbed.vue
+++ b/packages/frontend/editor-ui/src/components/BinaryDataDisplayEmbed.vue
@@ -138,7 +138,9 @@ onMounted(async () => {
 			/>
 			<RunDataHtml v-else-if="binaryData.fileType === 'html'" :input-html="data" />
 			<div v-else-if="binaryData.mimeType === 'text/csv'" class="csv-container">
-				<div v-if="csvData.length === 0">No CSV data to display</div>
+				<div v-if="csvData.length === 0">
+					{{ i18n.baseText('binaryDataDisplay.noCsvDataToDisplay') }}
+				</div>
 				<table v-else class="csv-table">
 					<thead v-if="csvData.length > 0">
 						<tr>

--- a/packages/frontend/editor-ui/src/components/BinaryDataDisplayEmbed.vue
+++ b/packages/frontend/editor-ui/src/components/BinaryDataDisplayEmbed.vue
@@ -52,7 +52,7 @@ const parseCSV = (csvText: string): string[][] => {
 				}
 			} else if (char === ',' && !inQuotes) {
 				// End of field
-				row.push(currentField.trim());
+				row.push(currentField);
 				currentField = '';
 			} else {
 				currentField += char;
@@ -61,7 +61,7 @@ const parseCSV = (csvText: string): string[][] => {
 
 		// Add last field
 		if (currentField || line.endsWith(',')) {
-			row.push(currentField.trim());
+			row.push(currentField);
 		}
 
 		rows.push(row);

--- a/packages/frontend/editor-ui/src/components/BinaryDataDisplayEmbed.vue
+++ b/packages/frontend/editor-ui/src/components/BinaryDataDisplayEmbed.vue
@@ -15,6 +15,7 @@ const isLoading = ref(true);
 const embedSource = ref('');
 const error = ref(false);
 const data = ref('');
+const csvData = ref<string[][]>([]);
 
 const workflowsStore = useWorkflowsStore();
 
@@ -24,24 +25,85 @@ const embedClass = computed(() => {
 	return [props.binaryData.fileType ?? 'other'];
 });
 
+// Proper CSV parser that handles quoted values containing commas
+const parseCSV = (csvText: string): string[][] => {
+	const rows: string[][] = [];
+	const lines = csvText.split('\n');
+
+	for (const line of lines) {
+		if (!line.trim()) continue;
+
+		const row: string[] = [];
+		let currentField = '';
+		let inQuotes = false;
+
+		for (let i = 0; i < line.length; i++) {
+			const char = line[i];
+			const nextChar = line[i + 1];
+
+			if (char === '"') {
+				if (inQuotes && nextChar === '"') {
+					// Double quote within quotes - add single quote
+					currentField += '"';
+					i++; // Skip next quote
+				} else {
+					// Toggle quote state
+					inQuotes = !inQuotes;
+				}
+			} else if (char === ',' && !inQuotes) {
+				// End of field
+				row.push(currentField.trim());
+				currentField = '';
+			} else {
+				currentField += char;
+			}
+		}
+
+		// Add last field
+		if (currentField || line.endsWith(',')) {
+			row.push(currentField.trim());
+		}
+
+		rows.push(row);
+	}
+
+	return rows;
+};
+
 onMounted(async () => {
 	const { id, data: binaryData, fileName, fileType, mimeType } = props.binaryData;
 	const isJSONData = fileType === 'json';
 	const isHTMLData = fileType === 'html';
+	const isCSVData = mimeType === 'text/csv';
+
 	if (!id) {
-		if (isJSONData || isHTMLData) {
-			data.value = isJSONData
-				? jsonParse(base64DecodeUTF8(binaryData))
-				: base64DecodeUTF8(binaryData);
+		if (isJSONData || isHTMLData || isCSVData) {
+			const decodedData = base64DecodeUTF8(binaryData);
+			if (isJSONData) {
+				data.value = jsonParse(decodedData);
+			} else if (isCSVData) {
+				// Parse CSV data with proper handling of quoted values
+				csvData.value = parseCSV(decodedData);
+			} else {
+				data.value = decodedData;
+			}
 		} else {
 			embedSource.value = `data:${mimeType};charset=utf-8;base64,${binaryData}`;
 		}
 	} else {
 		try {
 			const binaryUrl = workflowsStore.getBinaryUrl(id, 'view', fileName ?? '', mimeType);
-			if (isJSONData || isHTMLData) {
+			if (isJSONData || isHTMLData || isCSVData) {
 				const fetchedData = await fetch(binaryUrl, { credentials: 'include' });
-				data.value = await (isJSONData ? fetchedData.json() : fetchedData.text());
+				if (isJSONData) {
+					data.value = await fetchedData.json();
+				} else if (isCSVData) {
+					const csvText = await fetchedData.text();
+					// Parse CSV data with proper handling of quoted values
+					csvData.value = parseCSV(csvText);
+				} else {
+					data.value = await fetchedData.text();
+				}
 			} else {
 				embedSource.value = binaryUrl;
 			}
@@ -75,6 +137,21 @@ onMounted(async () => {
 				:show-length="true"
 			/>
 			<RunDataHtml v-else-if="binaryData.fileType === 'html'" :input-html="data" />
+			<div v-else-if="binaryData.mimeType === 'text/csv'" class="csv-container">
+				<div v-if="csvData.length === 0">No CSV data to display</div>
+				<table v-else class="csv-table">
+					<thead v-if="csvData.length > 0">
+						<tr>
+							<th v-for="(header, index) in csvData[0]" :key="index">{{ header }}</th>
+						</tr>
+					</thead>
+					<tbody v-if="csvData.length > 1">
+						<tr v-for="(row, rowIndex) in csvData.slice(1)" :key="rowIndex">
+							<td v-for="(cell, cellIndex) in row" :key="cellIndex">{{ cell }}</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
 			<embed v-else :src="embedSource" class="binary-data" :class="embedClass" />
 		</span>
 	</span>
@@ -91,6 +168,50 @@ video {
 	&.pdf {
 		height: 100%;
 		width: 100%;
+	}
+}
+
+.csv-container {
+	width: 100%;
+	height: calc(100% - 2em);
+	overflow-x: auto;
+	overflow-y: auto;
+	padding: 0;
+	box-sizing: border-box;
+	position: relative;
+	display: flex;
+	justify-content: center;
+}
+
+.csv-table {
+	width: max-content;
+	border-collapse: collapse;
+	font-size: 0.8em;
+	background-color: var(--color-background-xlight);
+	margin: 0.5em;
+	align-self: flex-start;
+
+	th,
+	td {
+		border: 1px solid var(--color-foreground-base);
+		padding: 4px 8px;
+		text-align: left;
+		white-space: nowrap;
+		max-width: 300px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	th {
+		background-color: var(--color-background-base);
+		font-weight: bold;
+		position: sticky;
+		top: 0;
+		z-index: 1;
+	}
+
+	tbody tr:hover {
+		background-color: var(--color-background-light);
 	}
 }
 </style>


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
This PR fixes the CSV binary data viewer showing a blank screen when clicking `view` via the Google Drive node. The issue was caused by the absence of functionality to parse and display CSV data. The fix adds a proper CSV parser that handles quoted values, escaped quotes, and empty fields, along with table rendering logic. Minor CSS improvements for table styling and comprehensive test coverage with test cases are also included.

<img width="1092" height="940" alt="image" src="https://github.com/user-attachments/assets/8bdf6823-2c36-4864-8320-5ff969e3998d" />


## Related Linear tickets, Github issues, and Community forum posts
Fixes #17644 

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
