### PR TITLE
fix(frontend): set focus to input after submit

### DIFF
--- a/packages/frontend/@n8n/chat/src/components/Input.vue
+++ b/packages/frontend/@n8n/chat/src/components/Input.vue
@@ -3,7 +3,7 @@ import { useFileDialog } from '@vueuse/core';
 import { v4 as uuidv4 } from 'uuid';
 import IconPaperclip from 'virtual:icons/mdi/paperclip';
 import IconSend from 'virtual:icons/mdi/send';
-import { computed, onMounted, onUnmounted, ref, unref } from 'vue';
+import { computed, onMounted, onUnmounted, ref, unref, nextTick } from 'vue';
 
 import { useI18n, useChat, useOptions } from '@n8n/chat/composables';
 import { chatEventBus } from '@n8n/chat/event-buses';
@@ -259,6 +259,9 @@ async function onSubmit(event: MouseEvent | KeyboardEvent) {
 	}
 
 	isSubmitting.value = false;
+
+	await nextTick();
+	focusChatInput();
 }
 
 async function onSubmitKeydown(event: KeyboardEvent) {


### PR DESCRIPTION
fix: #15783

## Summary

This pull request modifies the Input.vue component to reset focus to the component after submitting the message.

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/issues/15783
fixes #15783 


## Review / Merge checklist

- [] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
