### PR TITLE
fix(Mandrill Node): Fix a typo in subaccount in options

### DIFF
--- a/packages/nodes-base/nodes/Mandrill/Mandrill.node.ts
+++ b/packages/nodes-base/nodes/Mandrill/Mandrill.node.ts
@@ -766,8 +766,8 @@ export class Mandrill implements INodeType {
 						message.from_name = options.fromName;
 					}
 
-					if (options.subaccount) {
-						message.subaccount = options.subaccount;
+					if (options.subAccount) {
+						message.subaccount = options.subAccount.toString();
 					}
 
 					const body: Body = {

--- a/packages/nodes-base/nodes/Mandrill/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Mandrill/test/GenericFunctions.test.ts
@@ -1,0 +1,143 @@
+import {
+	getGoogleAnalyticsDomainsArray,
+	getTags,
+	getToEmailArray,
+	validateJSON,
+} from '../GenericFunctions';
+
+describe('Mandrill GenericFunctions', () => {
+	describe('getToEmailArray', () => {
+		it('should convert single email to array', () => {
+			const result = getToEmailArray('test@example.com');
+			expect(result).toEqual([
+				{
+					email: 'test@example.com',
+					type: 'to',
+				},
+			]);
+		});
+
+		it('should convert comma-separated emails to array', () => {
+			const result = getToEmailArray('test1@example.com,test2@example.com,test3@example.com');
+			expect(result).toEqual([
+				{
+					email: 'test1@example.com',
+					type: 'to',
+				},
+				{
+					email: 'test2@example.com',
+					type: 'to',
+				},
+				{
+					email: 'test3@example.com',
+					type: 'to',
+				},
+			]);
+		});
+
+		it('should handle emails with spaces after commas', () => {
+			const result = getToEmailArray('test1@example.com, test2@example.com, test3@example.com');
+			expect(result).toEqual([
+				{
+					email: 'test1@example.com',
+					type: 'to',
+				},
+				{
+					email: ' test2@example.com',
+					type: 'to',
+				},
+				{
+					email: ' test3@example.com',
+					type: 'to',
+				},
+			]);
+		});
+	});
+
+	describe('getGoogleAnalyticsDomainsArray', () => {
+		it('should convert single domain to array', () => {
+			const result = getGoogleAnalyticsDomainsArray('example.com');
+			expect(result).toEqual(['example.com']);
+		});
+
+		it('should convert comma-separated domains to array', () => {
+			const result = getGoogleAnalyticsDomainsArray('example.com,test.com,demo.org');
+			expect(result).toEqual(['example.com', 'test.com', 'demo.org']);
+		});
+
+		it('should handle domains with spaces after commas', () => {
+			const result = getGoogleAnalyticsDomainsArray('example.com, test.com, demo.org');
+			expect(result).toEqual(['example.com', ' test.com', ' demo.org']);
+		});
+
+		it('should handle empty string', () => {
+			const result = getGoogleAnalyticsDomainsArray('');
+			expect(result).toEqual(['']);
+		});
+	});
+
+	describe('getTags', () => {
+		it('should convert single tag to array', () => {
+			const result = getTags('newsletter');
+			expect(result).toEqual(['newsletter']);
+		});
+
+		it('should convert comma-separated tags to array', () => {
+			const result = getTags('newsletter,marketing,promotion');
+			expect(result).toEqual(['newsletter', 'marketing', 'promotion']);
+		});
+
+		it('should handle tags with spaces after commas', () => {
+			const result = getTags('newsletter, marketing, promotion');
+			expect(result).toEqual(['newsletter', ' marketing', ' promotion']);
+		});
+
+		it('should handle empty string', () => {
+			const result = getTags('');
+			expect(result).toEqual(['']);
+		});
+	});
+
+	describe('validateJSON', () => {
+		it('should parse valid JSON object', () => {
+			const result = validateJSON('{"test": "value", "number": 123}');
+			expect(result).toEqual({ test: 'value', number: 123 });
+		});
+
+		it('should parse valid JSON array', () => {
+			const result = validateJSON('[{"name": "test", "value": "data"}]');
+			expect(result).toEqual([{ name: 'test', value: 'data' }]);
+		});
+
+		it('should return empty array for invalid JSON', () => {
+			const result = validateJSON('invalid json');
+			expect(result).toEqual([]);
+		});
+
+		it('should return empty array for undefined input', () => {
+			const result = validateJSON(undefined);
+			expect(result).toEqual([]);
+		});
+
+		it('should return empty array for null input', () => {
+			const result = validateJSON('null');
+			expect(result).toEqual(null);
+		});
+
+		it('should parse nested JSON correctly', () => {
+			const result = validateJSON('{"metadata": {"key": "value"}, "array": [1, 2, 3]}');
+			expect(result).toEqual({
+				metadata: { key: 'value' },
+				array: [1, 2, 3],
+			});
+		});
+
+		it('should handle JSON with special characters', () => {
+			const result = validateJSON('{"message": "Hello\\nWorld\\t!", "emoji": "🎉"}');
+			expect(result).toEqual({
+				message: 'Hello\nWorld\t!',
+				emoji: '🎉',
+			});
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Mandrill/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Mandrill/test/GenericFunctions.test.ts
@@ -100,13 +100,13 @@ describe('Mandrill GenericFunctions', () => {
 
 	describe('validateJSON', () => {
 		it('should parse valid JSON object', () => {
-			const result = validateJSON('{"test": "value", "number": 123}');
-			expect(result).toEqual({ test: 'value', number: 123 });
+			const result = validateJSON('{"Test": "value", "number": 123}');
+			expect(result).toEqual({ Test: 'value', number: 123 });
 		});
 
 		it('should parse valid JSON array', () => {
-			const result = validateJSON('[{"name": "test", "value": "data"}]');
-			expect(result).toEqual([{ name: 'test', value: 'data' }]);
+			const result = validateJSON('[{"name": "Test", "value": "data"}]');
+			expect(result).toEqual([{ name: 'Test', value: 'data' }]);
 		});
 
 		it('should return empty array for invalid JSON', () => {

--- a/packages/nodes-base/nodes/Mandrill/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Mandrill/test/GenericFunctions.test.ts
@@ -119,7 +119,7 @@ describe('Mandrill GenericFunctions', () => {
 			expect(result).toEqual([]);
 		});
 
-		it('should return empty array for null input', () => {
+		it('should return null for null JSON string', () => {
 			const result = validateJSON('null');
 			expect(result).toEqual(null);
 		});

--- a/packages/nodes-base/nodes/Mandrill/test/Mandrill.node.test.ts
+++ b/packages/nodes-base/nodes/Mandrill/test/Mandrill.node.test.ts
@@ -1,0 +1,69 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import { mock, mockDeep } from 'jest-mock-extended';
+import type { ILoadOptionsFunctions, INode } from 'n8n-workflow';
+import nock from 'nock';
+
+import { Mandrill } from '../Mandrill.node';
+
+describe('Test Mandrill Node', () => {
+	describe('Messages', () => {
+		const mandrillNock = nock('https://mandrillapp.com/api/1.0');
+
+		beforeAll(() => {
+			// Mock sendTemplate API call
+			mandrillNock.post('/messages/send-template.json').reply(200, [
+				{
+					email: 'recipient@example.com',
+					status: 'sent',
+					reject_reason: null,
+					_id: 'test-message-id-456',
+				},
+			]);
+
+			// Mock sendHtml API call
+			mandrillNock.post('/messages/send.json').reply(200, [
+				{
+					email: 'recipient@example.com',
+					status: 'rejected',
+					_id: 'test-message-id-123',
+					reject_reason: 'global-block',
+					queued_reason: null,
+				},
+			]);
+		});
+
+		afterAll(() => mandrillNock.done());
+
+		new NodeTestHarness().setupTests({
+			workflowFiles: ['sendTemplate.workflow.json', 'sendHtml.workflow.json'],
+		});
+	});
+
+	describe('loadOptions', () => {
+		describe('getTemplates', () => {
+			it('should return a list of Mandrill templates', async () => {
+				const mandrill = new Mandrill();
+				const loadOptionsFunctions = mockDeep<ILoadOptionsFunctions>();
+				loadOptionsFunctions.getNode.mockReturnValue(mock<INode>());
+				loadOptionsFunctions.getCredentials.mockResolvedValue({ apiKey: 'test-api-key' });
+				loadOptionsFunctions.helpers.request.mockResolvedValue([
+					{
+						slug: 'template-1',
+						name: 'Test Template 1',
+					},
+					{
+						slug: 'template-2',
+						name: 'Test Template 2',
+					},
+				]);
+
+				const result = await mandrill.methods.loadOptions.getTemplates.call(loadOptionsFunctions);
+
+				expect(result).toEqual([
+					{ name: 'Test Template 1', value: 'template-1' },
+					{ name: 'Test Template 2', value: 'template-2' },
+				]);
+			});
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Mandrill/test/Mandrill.node.test.ts
+++ b/packages/nodes-base/nodes/Mandrill/test/Mandrill.node.test.ts
@@ -10,15 +10,43 @@ describe('Test Mandrill Node', () => {
 		const mandrillNock = nock('https://mandrillapp.com/api/1.0');
 
 		beforeAll(() => {
-			// Mock sendTemplate API call
-			mandrillNock.post('/messages/send-template.json').reply(200, [
-				{
-					email: 'recipient@example.com',
-					status: 'sent',
-					reject_reason: null,
-					_id: 'test-message-id-456',
-				},
-			]);
+			// Mock sendTemplate API call with subaccount verification
+			mandrillNock
+				.post('/messages/send-template.json', (body) => {
+					// Verify that subaccount is properly passed to the API
+					return (
+						body.message &&
+						body.message.subaccount === 'test-subaccount' &&
+						body.template_name === 'test-template'
+					);
+				})
+				.reply(200, [
+					{
+						email: 'recipient@example.com',
+						status: 'sent',
+						reject_reason: null,
+						_id: 'test-message-id-456',
+					},
+				]);
+
+			// Mock sendTemplate API call specifically for subaccount regression test
+			mandrillNock
+				.post('/messages/send-template.json', (body) => {
+					// Verify regression test scenario: subaccount is properly passed
+					return (
+						body.message &&
+						body.message.subaccount === 'regression-test-subaccount' &&
+						body.template_name === 'test-template-subaccount'
+					);
+				})
+				.reply(200, [
+					{
+						email: 'recipient@example.com',
+						status: 'sent',
+						reject_reason: null,
+						_id: 'test-subaccount-message-id',
+					},
+				]);
 
 			// Mock sendHtml API call
 			mandrillNock.post('/messages/send.json').reply(200, [
@@ -35,7 +63,11 @@ describe('Test Mandrill Node', () => {
 		afterAll(() => mandrillNock.done());
 
 		new NodeTestHarness().setupTests({
-			workflowFiles: ['sendTemplate.workflow.json', 'sendHtml.workflow.json'],
+			workflowFiles: [
+				'sendTemplate.workflow.json',
+				'sendTemplateWithSubaccount.workflow.json',
+				'sendHtml.workflow.json',
+			],
 		});
 	});
 

--- a/packages/nodes-base/nodes/Mandrill/test/sendHtml.workflow.json
+++ b/packages/nodes-base/nodes/Mandrill/test/sendHtml.workflow.json
@@ -1,0 +1,72 @@
+{
+	"name": "sendHtml",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "test-trigger-node-id",
+			"name": "When clicking 'Execute workflow'",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0]
+		},
+		{
+			"parameters": {
+				"operation": "sendHtml",
+				"fromEmail": "sender@example.com",
+				"toEmail": "recipient@example.com",
+				"options": {
+					"html": "<h1>Test HTML Content</h1>",
+					"subject": "Test HTML Subject"
+				}
+			},
+			"id": "test-mandrill-node-id",
+			"name": "Mandrill",
+			"type": "n8n-nodes-base.mandrill",
+			"typeVersion": 1,
+			"position": [220, 0],
+			"credentials": {
+				"mandrillApi": {
+					"id": "test-credentials-id",
+					"name": "Test Mandrill API"
+				}
+			}
+		}
+	],
+	"connections": {
+		"When clicking 'Execute workflow'": {
+			"main": [
+				[
+					{
+						"node": "Mandrill",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"pinData": {
+		"Mandrill": [
+			{
+				"json": {
+					"email": "recipient@example.com",
+					"status": "rejected",
+					"_id": "test-message-id-123",
+					"reject_reason": "global-block",
+					"queued_reason": null
+				}
+			}
+		]
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "test-version-id",
+	"meta": {
+		"templateCredsSetupCompleted": true,
+		"instanceId": "test-instance-id"
+	},
+	"id": "test-workflow-id-2",
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Mandrill/test/sendTemplate.workflow.json
+++ b/packages/nodes-base/nodes/Mandrill/test/sendTemplate.workflow.json
@@ -1,0 +1,68 @@
+{
+	"name": "sendTemplate",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "test-trigger-node-id",
+			"name": "When clicking 'Execute workflow'",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0]
+		},
+		{
+			"parameters": {
+				"resource": "message",
+				"operation": "sendTemplate",
+				"template": "test-template",
+				"fromEmail": "sender@example.com",
+				"toEmail": "recipient@example.com"
+			},
+			"id": "test-mandrill-node-id",
+			"name": "Mandrill",
+			"type": "n8n-nodes-base.mandrill",
+			"typeVersion": 1,
+			"position": [220, 0],
+			"credentials": {
+				"mandrillApi": {
+					"id": "test-credentials-id",
+					"name": "Test Mandrill API"
+				}
+			}
+		}
+	],
+	"connections": {
+		"When clicking 'Execute workflow'": {
+			"main": [
+				[
+					{
+						"node": "Mandrill",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"pinData": {
+		"Mandrill": [
+			{
+				"json": {
+					"email": "recipient@example.com",
+					"status": "sent",
+					"reject_reason": null,
+					"_id": "test-message-id-456"
+				}
+			}
+		]
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "test-version-id",
+	"meta": {
+		"instanceId": "test-instance"
+	},
+	"id": "test-workflow-id",
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Mandrill/test/sendTemplateWithSubaccount.workflow.json
+++ b/packages/nodes-base/nodes/Mandrill/test/sendTemplateWithSubaccount.workflow.json
@@ -1,5 +1,5 @@
 {
-	"name": "sendTemplate",
+	"name": "sendTemplateWithSubaccount",
 	"nodes": [
 		{
 			"parameters": {},
@@ -13,11 +13,12 @@
 			"parameters": {
 				"resource": "message",
 				"operation": "sendTemplate",
-				"template": "test-template",
+				"template": "test-template-subaccount",
 				"fromEmail": "sender@example.com",
 				"toEmail": "recipient@example.com",
 				"options": {
-					"subAccount": "test-subaccount"
+					"subAccount": "regression-test-subaccount",
+					"subject": "Testing subaccount functionality"
 				}
 			},
 			"id": "test-mandrill-node-id",
@@ -53,7 +54,7 @@
 					"email": "recipient@example.com",
 					"status": "sent",
 					"reject_reason": null,
-					"_id": "test-message-id-456"
+					"_id": "test-subaccount-message-id"
 				}
 			}
 		]
@@ -66,6 +67,6 @@
 	"meta": {
 		"instanceId": "test-instance"
 	},
-	"id": "test-workflow-id",
+	"id": "test-workflow-subaccount-id",
 	"tags": []
 }


### PR DESCRIPTION
## Summary
This PR fixes a typo in subaccount that caused the option to be ignored.

## Testing
- Tested locally to confirm the fix works
- Added node tests using Claude Code

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3283/community-issue-mandrill-node-ignores-subaccount-in-options
Closes https://github.com/n8n-io/n8n/issues/16214


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
