### PR TITLE
feat(editor): Add hint for showing archived workflows when there are no active ones

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -2738,6 +2738,8 @@
 	"workflows.readyToRunWorkflows.cta": "Run a workflow",
 	"workflows.readyToRunWorkflows.folder.name": "🚀 Ready-to-run workflows",
 	"workflows.readyToRunWorkflows.error": "Error loading n8n collection. Please try again later.",
+	"workflows.archivedOnly.hint": "Archived workflows are hidden in this view. {link}",
+	"workflows.archivedOnly.hint.link": "Update filters",
 	"workflowSelectorParameterInput.createNewSubworkflow.name": "My Sub-Workflow",
 	"importCurlModal.title": "Import cURL command",
 	"importCurlModal.input.label": "cURL Command",

--- a/packages/frontend/editor-ui/src/stores/folders.store.ts
+++ b/packages/frontend/editor-ui/src/stores/folders.store.ts
@@ -100,7 +100,7 @@ export const useFoldersStore = defineStore(STORES.FOLDERS, () => {
 	async function fetchTotalWorkflowsAndFoldersCount(projectId?: string): Promise<number> {
 		const { count } = await workflowsApi.getWorkflowsAndFolders(
 			rootStore.restApiContext,
-			{ projectId, isArchived: false },
+			{ projectId },
 			{ skip: 0, take: 1 },
 			true,
 		);
@@ -292,13 +292,13 @@ export const useFoldersStore = defineStore(STORES.FOLDERS, () => {
 
 					// Add all descendants of this child
 					if (child.children?.length) {
-						childResult.push(...processFolderWithChildren(child).slice(1));
+						childResult.push.apply(childResult, processFolderWithChildren(child).slice(1));
 					}
 
 					return childResult;
 				});
 
-				result.push(...childItems);
+				result.push.apply(result, childItems);
 			}
 			return result;
 		};

--- a/packages/frontend/editor-ui/src/views/WorkflowsView.test.ts
+++ b/packages/frontend/editor-ui/src/views/WorkflowsView.test.ts
@@ -397,6 +397,19 @@ describe('WorkflowsView', () => {
 			await waitAllPromises();
 			await waitFor(() => expect(router.currentRoute.value.query).toStrictEqual({}));
 		});
+
+		it('should show archived only hint', async () => {
+			foldersStore.totalWorkflowCount = 1;
+			workflowsStore.fetchWorkflowsPage.mockResolvedValue([]);
+			const { getByTestId } = renderComponent({ pinia });
+			await waitAllPromises();
+
+			const showArchivedLink = getByTestId('show-archived-link');
+			expect(showArchivedLink).toBeInTheDocument();
+
+			await userEvent.click(showArchivedLink);
+			expect(router.currentRoute.value.query).toStrictEqual({ showArchived: 'true' });
+		});
 	});
 
 	describe('source control', () => {

--- a/packages/frontend/editor-ui/src/views/WorkflowsView.vue
+++ b/packages/frontend/editor-ui/src/views/WorkflowsView.vue
@@ -381,6 +381,17 @@ const hasFilters = computed(() => {
 	);
 });
 
+// When there are no visible results but the project contains archived workflows,
+// inform the user how to reveal them
+const showArchivedOnlyHint = computed(() => {
+	return (
+		workflowsAndFolders.value.length === 0 &&
+		!hasFilters.value &&
+		!filters.value.showArchived &&
+		foldersStore.totalWorkflowCount > 0
+	);
+});
+
 const isSelfHostedDeployment = computed(() => settingsStore.deploymentType === 'default');
 
 const canUserRegisterCommunityPlus = computed(
@@ -914,6 +925,11 @@ const openAIWorkflow = async (source: string) => {
 const dismissStarterCollectionCallout = () => {
 	aiStarterTemplatesStore.dismissCallout();
 	aiStarterTemplatesStore.trackUserDismissedCallout();
+};
+
+const onShowArchived = async () => {
+	filters.value.showArchived = true;
+	await onFiltersUpdated();
 };
 
 const dismissEasyAICallout = () => {
@@ -2130,6 +2146,12 @@ const onNameSubmit = async (name: string) => {
 				:class="$style['empty-folder-container']"
 				data-test-id="empty-folder-container"
 			>
+				<N8nInfoTip v-if="showArchivedOnlyHint" :bold="false">
+					{{ i18n.baseText('workflows.archivedOnly.hint') }}
+					<N8nLink size="small" data-test-id="show-archived-link" @click="onShowArchived">
+						{{ i18n.baseText('workflows.archivedOnly.hint.link') }}
+					</N8nLink>
+				</N8nInfoTip>
 				<EmptySharedSectionActionBox
 					v-if="projectPages.isSharedSubPage && personalProject"
 					:personal-project="personalProject"


### PR DESCRIPTION
## Summary

The user was not able to access their archived workflows in the case where they only got archived ones. Instead they were seeing the "create your first workflow message".

https://github.com/user-attachments/assets/e81157a2-7eb8-40ac-9473-4c9b4dabd572



Added a hint for selecting the archived workflows filter in the case where the user only have archived ones.

https://github.com/user-attachments/assets/2dec868f-12b8-49be-a262-c8390b7e48c6



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3821/bug-cant-unarchive-workflow-if-it-was-the-only-one-in-project


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
