### PR TITLE
chore(editor): Increase trigger dropdown width

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nActionDropdown/ActionDropdown.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nActionDropdown/ActionDropdown.vue
@@ -28,6 +28,7 @@ interface ActionDropdownProps {
 	hideArrow?: boolean;
 	teleported?: boolean;
 	disabled?: boolean;
+	extraPopperClass?: string;
 }
 
 const props = withDefaults(defineProps<ActionDropdownProps>(), {
@@ -67,7 +68,8 @@ defineSlots<{
 const elementDropdown = ref<InstanceType<typeof ElDropdown>>();
 
 const popperClass = computed(
-	() => `${$style.shadow}${props.hideArrow ? ` ${$style.hideArrow}` : ''}`,
+	() =>
+		`${$style.shadow}${props.hideArrow ? ` ${$style.hideArrow}` : ''} ${props.extraPopperClass ?? ''}`,
 );
 
 const onSelect = (action: string) => emit('select', action);
@@ -127,7 +129,12 @@ defineExpose({ open, close });
 									{{ item.label }}
 								</slot>
 							</span>
-							<N8nIcon v-if="item.checked" icon="check" :size="iconSize" />
+							<N8nIcon
+								v-if="item.checked"
+								:class="$style.checkIcon"
+								icon="check"
+								:size="iconSize"
+							/>
 							<span v-if="item.badge">
 								<N8nBadge theme="primary" size="xsmall" v-bind="item.badgeProps">
 									{{ item.badge }}
@@ -198,6 +205,11 @@ defineExpose({ open, close });
 	svg {
 		width: 1.2em !important;
 	}
+}
+
+.checkIcon {
+	flex-grow: 0;
+	flex-shrink: 0;
 }
 
 .shortcut {

--- a/packages/frontend/@n8n/design-system/src/components/N8nActionDropdown/__snapshots__/ActionDropdown.test.ts.snap
+++ b/packages/frontend/@n8n/design-system/src/components/N8nActionDropdown/__snapshots__/ActionDropdown.test.ts.snap
@@ -2,12 +2,12 @@
 
 exports[`components > N8nActionDropdown > should render custom styling correctly 1`] = `
 "<div class="action-dropdown-container actionDropdownContainer">
-  <el-dropdown-stub trigger="click" effect="light" placement="bottom" popperoptions="[object Object]" size="" splitbutton="false" hideonclick="true" loop="true" showtimeout="150" hidetimeout="150" tabindex="0" maxheight="" popperclass="shadow" disabled="false" role="menu" teleported="true"></el-dropdown-stub>
+  <el-dropdown-stub trigger="click" effect="light" placement="bottom" popperoptions="[object Object]" size="" splitbutton="false" hideonclick="true" loop="true" showtimeout="150" hidetimeout="150" tabindex="0" maxheight="" popperclass="shadow " disabled="false" role="menu" teleported="true"></el-dropdown-stub>
 </div>"
 `;
 
 exports[`components > N8nActionDropdown > should render default styling correctly 1`] = `
 "<div class="action-dropdown-container actionDropdownContainer">
-  <el-dropdown-stub trigger="click" effect="light" placement="bottom" popperoptions="[object Object]" size="" splitbutton="false" hideonclick="true" loop="true" showtimeout="150" hidetimeout="150" tabindex="0" maxheight="" popperclass="shadow" disabled="false" role="menu" teleported="true"></el-dropdown-stub>
+  <el-dropdown-stub trigger="click" effect="light" placement="bottom" popperoptions="[object Object]" size="" splitbutton="false" hideonclick="true" loop="true" showtimeout="150" hidetimeout="150" tabindex="0" maxheight="" popperclass="shadow " disabled="false" role="menu" teleported="true"></el-dropdown-stub>
 </div>"
 `;

--- a/packages/frontend/editor-ui/src/components/canvas/elements/buttons/CanvasRunWorkflowButton.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/elements/buttons/CanvasRunWorkflowButton.vue
@@ -51,7 +51,7 @@ const actions = computed(() =>
 			return aY === bY ? aX - bX : aY - bY;
 		})
 		.map<ActionDropdownItem>((node) => ({
-			label: truncateBeforeLast(node.name, 25),
+			label: truncateBeforeLast(node.name, 50),
 			disabled: !!node.disabled || props.executing,
 			id: node.name,
 			checked: props.selectedTriggerNodeName === node.name,
@@ -112,6 +112,7 @@ function getNodeTypeByName(name: string): INodeTypeDescription | null {
 				:items="actions"
 				:disabled="disabled"
 				placement="top"
+				:extra-popper-class="$style.menuPopper"
 				@select="emit('selectTriggerNode', $event)"
 			>
 				<template #activator>
@@ -172,6 +173,11 @@ function getNodeTypeByName(name: string): INodeTypeDescription | null {
 
 .menu :global(.el-dropdown) {
 	height: 100%;
+}
+
+.menuPopper {
+	// Width upper bound is enforced by char count instead
+	max-width: none !important;
 }
 
 .menuItem {


### PR DESCRIPTION
## Summary

Based on [a request](https://n8nio.slack.com/archives/C035PCSN74K/p1754565999484289), increasing trigger dropdown on the execute button

## Related Linear tickets, Github issues, and Community forum posts

N/A


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
