### PR TITLE
fix(editor): Fix loading of error workflows in settings

### DIFF
--- a/packages/frontend/editor-ui/src/components/WorkflowSettings.vue
+++ b/packages/frontend/editor-ui/src/components/WorkflowSettings.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue';
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue';
 import { useRoute } from 'vue-router';
 import { useToast } from '@/composables/useToast';
 import type { ITimeoutHMS, IWorkflowSettings, IWorkflowShortResponse } from '@/Interface';
@@ -475,6 +475,10 @@ onMounted(async () => {
 	telemetry.track('User opened workflow settings', {
 		workflow_id: workflowsStore.workflowId,
 	});
+});
+
+onBeforeUnmount(() => {
+	debouncedLoadWorkflows.cancel?.();
 });
 </script>
 


### PR DESCRIPTION
## Summary

The parameter for loading workflows wasn't passed correctly to the Select element which was breaking the filtering functionality.

Before the fix:
https://github.com/user-attachments/assets/2f8131e6-e0e1-46aa-9fa0-403f9a4a8679

After the fix:

https://github.com/user-attachments/assets/dff6c71c-c993-4e81-8c8e-e786acd0bc96


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3801/bug-these-settings-are-now-not-usable-as-admin-on-internal-instance

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
