### PR TITLE
fix(core): Remove temporary uploaded files from webhook calls

### DIFF
--- a/packages/nodes-base/nodes/Webhook/Webhook.node.ts
+++ b/packages/nodes-base/nodes/Webhook/Webhook.node.ts
@@ -364,7 +364,7 @@ export class Webhook extends Node {
 				);
 
 				// Delete original file to prevent tmp directory from growing too large
-				await rm(file.filepath);
+				await rm(file.filepath, { force: true });
 
 				count += 1;
 			}
@@ -409,7 +409,6 @@ export class Webhook extends Node {
 
 			return { workflowData: prepareOutput(returnItem) };
 		} catch (error) {
-			console.log(error);
 			throw new NodeOperationError(context.getNode(), error as Error);
 		} finally {
 			await binaryFile.cleanup();

--- a/packages/nodes-base/nodes/Webhook/Webhook.node.ts
+++ b/packages/nodes-base/nodes/Webhook/Webhook.node.ts
@@ -404,9 +404,6 @@ export class Webhook extends Node {
 					fileName,
 					req.contentType ?? 'application/octet-stream',
 				);
-
-				// Delete original file to prevent tmp directory from growing too large
-				await rm(binaryFile.path);
 				returnItem.binary = { [binaryPropertyName]: binaryData };
 			}
 

--- a/packages/nodes-base/nodes/Webhook/Webhook.node.ts
+++ b/packages/nodes-base/nodes/Webhook/Webhook.node.ts
@@ -1,6 +1,6 @@
 /* eslint-disable n8n-nodes-base/node-execute-block-wrong-error-thrown */
 import { createWriteStream } from 'fs';
-import { stat } from 'fs/promises';
+import { rm, stat } from 'fs/promises';
 import isbot from 'isbot';
 import type {
 	IWebhookFunctions,
@@ -363,6 +363,9 @@ export class Webhook extends Node {
 					file.mimetype,
 				);
 
+				// Delete original file to prevent tmp directory from growing too large
+				await rm(file.filepath);
+
 				count += 1;
 			}
 		}
@@ -401,11 +404,15 @@ export class Webhook extends Node {
 					fileName,
 					req.contentType ?? 'application/octet-stream',
 				);
+
+				// Delete original file to prevent tmp directory from growing too large
+				await rm(binaryFile.path);
 				returnItem.binary = { [binaryPropertyName]: binaryData };
 			}
 
 			return { workflowData: prepareOutput(returnItem) };
 		} catch (error) {
+			console.log(error);
 			throw new NodeOperationError(context.getNode(), error as Error);
 		} finally {
 			await binaryFile.cleanup();

--- a/packages/nodes-base/nodes/Webhook/test/Webhook.test.ts
+++ b/packages/nodes-base/nodes/Webhook/test/Webhook.test.ts
@@ -65,7 +65,7 @@ describe('Test Webhook Node', () => {
 		const req = mock<Request>();
 		context.getRequestObject.mockReturnValue(req);
 
-		mockFs.stat.mockResolvedValue({ size: 1024 } as fs.Stats);
+		mockFs.stat.mockResolvedValue({ size: BigInt(1024) } as any);
 
 		beforeEach(() => {
 			mockFs.rm.mockClear();

--- a/packages/nodes-base/nodes/Webhook/test/Webhook.test.ts
+++ b/packages/nodes-base/nodes/Webhook/test/Webhook.test.ts
@@ -3,18 +3,12 @@ import type { Request, Response } from 'express';
 import fs from 'fs/promises';
 import { mock } from 'jest-mock-extended';
 import type { IWebhookFunctions } from 'n8n-workflow';
-import stream from 'stream/promises';
 
 import { Webhook } from '../Webhook.node';
 
 jest.mock('fs/promises');
 const mockFs = mock<typeof fs>();
 fs.rm = mockFs.rm;
-fs.stat = mockFs.stat;
-
-jest.mock('stream/promises');
-const mockStream = mock<typeof stream>();
-stream.pipeline = mockStream.pipeline;
 
 describe('Test Webhook Node', () => {
 	new NodeTestHarness().setupTests();
@@ -49,7 +43,7 @@ describe('Test Webhook Node', () => {
 			const returnData = await node.webhook(context);
 			expect(returnData.workflowData?.[0][0].binary).not.toBeUndefined();
 			expect(context.nodeHelpers.copyBinaryFile).toHaveBeenCalled();
-			expect(mockFs.rm).toHaveBeenCalledWith('/tmp/test.txt');
+			expect(mockFs.rm).toHaveBeenCalledWith('/tmp/test.txt', { force: true });
 		});
 	});
 

--- a/packages/nodes-base/nodes/Webhook/test/Webhook.test.ts
+++ b/packages/nodes-base/nodes/Webhook/test/Webhook.test.ts
@@ -7,8 +7,7 @@ import type { IWebhookFunctions } from 'n8n-workflow';
 import { Webhook } from '../Webhook.node';
 
 jest.mock('fs/promises');
-const mockFs = mock<typeof fs>();
-fs.rm = mockFs.rm;
+const mockFs = jest.mocked(fs);
 
 describe('Test Webhook Node', () => {
 	new NodeTestHarness().setupTests();

--- a/packages/nodes-base/nodes/Webhook/test/Webhook.test.ts
+++ b/packages/nodes-base/nodes/Webhook/test/Webhook.test.ts
@@ -53,44 +53,6 @@ describe('Test Webhook Node', () => {
 		});
 	});
 
-	describe('handleBinaryData', () => {
-		const node = new Webhook();
-		const context = mock<IWebhookFunctions>({
-			nodeHelpers: mock(),
-		});
-		context.getNode.calledWith().mockReturnValue({
-			type: 'n8n-nodes-base.webhook',
-			typeVersion: 1.1,
-		} as any);
-		const req = mock<Request>();
-		context.getRequestObject.mockReturnValue(req);
-
-		mockFs.stat.mockResolvedValue({ size: BigInt(1024) } as any);
-
-		beforeEach(() => {
-			mockFs.rm.mockClear();
-			jest.clearAllMocks();
-			req.headers = {};
-			req.params = {};
-			req.query = {};
-			req.body = {};
-		});
-
-		it('should handle binary data when binaryData option is enabled', async () => {
-			context.getNodeParameter.calledWith('options').mockReturnValue({
-				binaryData: true,
-			});
-			req.contentType = 'application/octet-stream';
-			req.contentDisposition = { type: 'attachment', filename: 'test.bin' };
-
-			const returnData = await node.webhook(context);
-
-			expect(returnData.workflowData?.[0][0].binary).toBeDefined();
-			expect(context.nodeHelpers.copyBinaryFile).toHaveBeenCalled();
-			expect(mockFs.rm).toHaveBeenCalledWith(expect.stringContaining('n8n-webhook-'));
-		});
-	});
-
 	describe('streaming response mode', () => {
 		const node = new Webhook();
 		const context = mock<IWebhookFunctions>({


### PR DESCRIPTION
## Summary

Currenty, when a webhook is called with a file in the HTTP data, the file is put in the TMPDIR by the formidable middleware. It is then copied to binary data, but the temporary file is never cleaned.
This PR deletes the files once it has been copied to binary data.

Better long term solution would be to enable custom file writer from formidable middleware (https://github.com/n8n-io/n8n/blob/master/packages/cli/src/webhooks/webhook-form-data.ts#L27), but it's a significantly bigger task that needs to be planned.

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

closes #16652 
https://linear.app/n8n/issue/PAY-3006/community-issue-docker-tmp-overflow

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
