### PR TITLE
fix(Beeminder Node): Remove unnecessary form data conversion for API token auth to work

### DIFF
--- a/packages/nodes-base/nodes/Beeminder/Beeminder.node.functions.ts
+++ b/packages/nodes-base/nodes/Beeminder/Beeminder.node.functions.ts
@@ -27,7 +27,7 @@ export async function createDatapoint(
 ) {
 	const endpoint = `/users/me/goals/${data.goalName}/datapoints.json`;
 
-	return await beeminderApiRequest.call(this, 'POST', endpoint, data, {}, true);
+	return await beeminderApiRequest.call(this, 'POST', endpoint, data, {});
 }
 
 export async function getAllDatapoints(
@@ -55,7 +55,7 @@ export async function updateDatapoint(
 ) {
 	const endpoint = `/users/me/goals/${data.goalName}/datapoints/${data.datapointId}.json`;
 
-	return await beeminderApiRequest.call(this, 'PUT', endpoint, data, {}, true);
+	return await beeminderApiRequest.call(this, 'PUT', endpoint, data, {});
 }
 
 export async function deleteDatapoint(
@@ -80,7 +80,7 @@ export async function createCharge(
 		...(data.dryrun && { dryrun: data.dryrun }),
 	};
 
-	return await beeminderApiRequest.call(this, 'POST', endpoint, body, {}, true);
+	return await beeminderApiRequest.call(this, 'POST', endpoint, body, {});
 }
 
 export async function uncleGoal(
@@ -102,7 +102,7 @@ export async function createAllDatapoints(
 		datapoints: data.datapoints,
 	};
 
-	return await beeminderApiRequest.call(this, 'POST', endpoint, body, {}, true);
+	return await beeminderApiRequest.call(this, 'POST', endpoint, body, {});
 }
 
 export async function getSingleDatapoint(
@@ -162,7 +162,7 @@ export async function createGoal(
 ) {
 	const endpoint = '/users/me/goals.json';
 
-	return await beeminderApiRequest.call(this, 'POST', endpoint, data, {}, true);
+	return await beeminderApiRequest.call(this, 'POST', endpoint, data, {});
 }
 
 export async function updateGoal(
@@ -182,7 +182,7 @@ export async function updateGoal(
 ) {
 	const endpoint = `/users/me/goals/${data.goalName}.json`;
 
-	return await beeminderApiRequest.call(this, 'PUT', endpoint, data, {}, true);
+	return await beeminderApiRequest.call(this, 'PUT', endpoint, data, {});
 }
 
 export async function refreshGoal(

--- a/packages/nodes-base/nodes/Beeminder/test/Beeminder.node.functions.test.ts
+++ b/packages/nodes-base/nodes/Beeminder/test/Beeminder.node.functions.test.ts
@@ -54,7 +54,6 @@ describe('Beeminder Node Functions', () => {
 					'/users/me/goals/testgoal/datapoints.json',
 					data,
 					{},
-					true,
 				);
 				expect(result).toBe(mockResponse);
 			});
@@ -78,7 +77,6 @@ describe('Beeminder Node Functions', () => {
 					'/users/me/goals/testgoal/datapoints.json',
 					data,
 					{},
-					true,
 				);
 				expect(result).toBe(mockResponse);
 			});
@@ -160,7 +158,6 @@ describe('Beeminder Node Functions', () => {
 					'/users/me/goals/testgoal/datapoints/123.json',
 					data,
 					{},
-					true,
 				);
 				expect(result).toBe(mockResponse);
 			});
@@ -184,7 +181,6 @@ describe('Beeminder Node Functions', () => {
 					'/users/me/goals/testgoal/datapoints/123.json',
 					data,
 					{},
-					true,
 				);
 				expect(result).toBe(mockResponse);
 			});
@@ -232,7 +228,6 @@ describe('Beeminder Node Functions', () => {
 					'/users/me/goals/testgoal/datapoints/create_all.json',
 					{ datapoints },
 					{},
-					true,
 				);
 				expect(result).toBe(mockResponse);
 			});
@@ -387,7 +382,6 @@ describe('Beeminder Node Functions', () => {
 					'/users/me/goals.json',
 					data,
 					{},
-					true,
 				);
 				expect(result).toBe(mockResponse);
 			});
@@ -419,7 +413,6 @@ describe('Beeminder Node Functions', () => {
 					'/users/me/goals.json',
 					data,
 					{},
-					true,
 				);
 				expect(result).toBe(mockResponse);
 			});
@@ -442,7 +435,6 @@ describe('Beeminder Node Functions', () => {
 					'/users/me/goals/testgoal.json',
 					data,
 					{},
-					true,
 				);
 				expect(result).toBe(mockResponse);
 			});
@@ -471,7 +463,6 @@ describe('Beeminder Node Functions', () => {
 					'/users/me/goals/testgoal.json',
 					data,
 					{},
-					true,
 				);
 				expect(result).toBe(mockResponse);
 			});
@@ -564,7 +555,6 @@ describe('Beeminder Node Functions', () => {
 						amount: 5,
 					},
 					{},
-					true,
 				);
 				expect(result).toBe(mockResponse);
 			});
@@ -591,7 +581,6 @@ describe('Beeminder Node Functions', () => {
 						dryrun: true,
 					},
 					{},
-					true,
 				);
 				expect(result).toBe(mockResponse);
 			});
@@ -616,7 +605,6 @@ describe('Beeminder Node Functions', () => {
 						amount: 5,
 					},
 					{},
-					true,
 				);
 				expect(result).toBe(mockResponse);
 			});


### PR DESCRIPTION
## Summary
- Remove the `useFormData` parameter and `convertToFormData` function from `beeminderApiRequest`
- Update all function calls to use standard JSON request bodies instead of form data
- Fix API token authentication that was broken by unnecessary form data conversion
- Update unit tests to reflect the simplified function signature

## Root Cause
The form data conversion was breaking API token authentication calls. After manual testing of all API endpoints, it was determined that form data conversion is not needed - all Beeminder API endpoints work correctly with standard JSON request bodies.

## Changes Made
- **GenericFunctions.ts**: Removed `useFormData` parameter and `convertToFormData` function
- **Beeminder.node.functions.ts**: Updated all function calls to omit the `useFormData` parameter
- **Test files**: Updated all unit tests to match the new function signature

## Test Plan
- [x] All unit tests pass (29/29)
- [x] All integration tests pass 
- [x] Type checking passes with no errors
- [x] Manual testing of all API operations confirmed working with API token auth

🤖 Generated with [Claude Code](https://claude.ai/code)