### PR TITLE
ci: Exclude test controller in CI by default

### DIFF
--- a/.github/workflows/playwright-test-reusable.yml
+++ b/.github/workflows/playwright-test-reusable.yml
@@ -49,6 +49,8 @@ jobs:
         with:
           build-command: ${{ inputs.test-mode == 'docker-build' && 'pnpm build:docker' || 'pnpm turbo build:playwright' }}
           enable-docker-cache: ${{ inputs.test-mode != 'local' }}
+        env:
+          INCLUDE_TEST_CONTROLLER: ${{ inputs.test-mode == 'docker-build' && 'true' || '' }}
 
       - name: Install Browsers (Docker Build)
         if: inputs.test-mode == 'docker-build'


### PR DESCRIPTION
## Summary

Will now exclude test controller from the docker images by default.
Will still remain in local builds and can be added into CI by INCLUDE_TEST_CONTROLLER variable.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1035/e2e-remove-test-controller-from-docker-image

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
