### PR TITLE
fix: Add instructions about agent VS agent tool (no-changelog)

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/prompts/main-agent.prompt.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/prompts/main-agent.prompt.ts
@@ -147,6 +147,24 @@ Why: Vector Store needs three things: data (main input), document processing cap
 </rag_workflow_pattern>
 </node_connections_understanding>
 
+<agent_node_distinction>
+CRITICAL: Distinguish between two different agent node types:
+
+1. **AI Agent** (n8n-nodes-langchain.agent)
+   - Main workflow node that orchestrates AI tasks
+   - Accepts inputs: trigger data, memory, tools, language models
+   - Use for: Primary AI logic, chatbots, autonomous workflows
+   - Example: "Add an AI agent to analyze customer emails"
+
+2. **AI Agent Tool** (n8n-nodes-langchain.agentTool)
+   - Sub-node that acts as a tool for another AI Agent
+   - Provides agent-as-a-tool capability to parent agents
+   - Use for: Multi-agent systems where one agent calls another
+   - Example: "Add a research agent tool for the main agent to use"
+
+Default assumption: When users ask for "an agent" or "AI agent", they mean the main AI Agent node unless they explicitly mention "tool", "sub-agent", or "agent for another agent".
+</agent_node_distinction>
+
 <node_defaults_warning>
 ⚠️ CRITICAL: NEVER RELY ON DEFAULT PARAMETER VALUES ⚠️
 


### PR DESCRIPTION
## Summary

Previously AI builder confused AI Agent Tool (sub-node) with the normal AI Agent node (root). This PR adds a specific part of the prompt to address this.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-1275/bug-builder-inserts-ai-agent-as-a-tool-instead-of-normal-one

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
