### PR TITLE
feat(editor): Expand telemetry for "User added node to workflow canvas" event

### DIFF
--- a/packages/frontend/editor-ui/src/Interface.ts
+++ b/packages/frontend/editor-ui/src/Interface.ts
@@ -742,6 +742,7 @@ export type NodeTypeSelectedPayload = {
 		resource?: string;
 		operation?: string;
 	};
+	actionName?: string;
 };
 
 export interface SubcategorizedNodeTypes {
@@ -1227,6 +1228,7 @@ export type AddedNode = {
 	type: string;
 	openDetail?: boolean;
 	isAutoAdd?: boolean;
+	actionName?: string;
 } & Partial<INodeUi>;
 
 export type AddedNodeConnection = {

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/composables/useActions.ts
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/composables/useActions.ts
@@ -182,6 +182,7 @@ export const useActions = () => {
 	function actionDataToNodeTypeSelectedPayload(actionData: ActionData): NodeTypeSelectedPayload {
 		const result: NodeTypeSelectedPayload = {
 			type: actionData.key,
+			actionName: actionData.name,
 		};
 
 		if (

--- a/packages/frontend/editor-ui/src/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasOperations.test.ts
@@ -273,6 +273,36 @@ describe('useCanvasOperations', () => {
 
 			await waitFor(() => expect(ndvStore.setActiveNodeName).not.toHaveBeenCalled());
 		});
+
+		it('should pass actionName to telemetry when adding node with action', () => {
+			const workflowsStore = mockedStore(useWorkflowsStore);
+			const nodeCreatorStore = mockedStore(useNodeCreatorStore);
+			const nodeTypeDescription = mockNodeTypeDescription({ name: 'hubspot' });
+			const actionName = 'Create Contact';
+
+			workflowsStore.addNode = vi.fn();
+			nodeCreatorStore.onNodeAddedToCanvas = vi.fn();
+
+			const { addNode } = useCanvasOperations();
+			addNode(
+				{
+					type: 'hubspot',
+					typeVersion: 1,
+				},
+				nodeTypeDescription,
+				{
+					telemetry: true,
+					actionName,
+				},
+			);
+
+			expect(nodeCreatorStore.onNodeAddedToCanvas).toHaveBeenCalledWith(
+				expect.objectContaining({
+					action: actionName,
+					node_type: 'hubspot',
+				}),
+			);
+		});
 	});
 
 	describe('resolveNodePosition', () => {
@@ -895,6 +925,41 @@ describe('useCanvasOperations', () => {
 			await addNodes(nodes, { keepPristine: true });
 
 			expect(uiStore.stateIsDirty).toEqual(false);
+		});
+
+		it('should pass actionName to telemetry when adding nodes with actions', async () => {
+			const workflowsStore = mockedStore(useWorkflowsStore);
+			const nodeCreatorStore = mockedStore(useNodeCreatorStore);
+			const nodeTypesStore = useNodeTypesStore();
+			const nodeTypeName = 'hubspot';
+			const actionName = 'Create Contact';
+			const nodes = [
+				{
+					...mockNode({
+						name: 'HubSpot Node',
+						type: nodeTypeName,
+						position: [100, 100],
+					}),
+					actionName,
+				},
+			];
+
+			workflowsStore.workflowObject = createTestWorkflowObject(workflowsStore.workflow);
+			nodeCreatorStore.onNodeAddedToCanvas = vi.fn();
+
+			nodeTypesStore.nodeTypes = {
+				[nodeTypeName]: { 1: mockNodeTypeDescription({ name: nodeTypeName }) },
+			};
+
+			const { addNodes } = useCanvasOperations();
+			await addNodes(nodes, { telemetry: true });
+
+			expect(nodeCreatorStore.onNodeAddedToCanvas).toHaveBeenCalledWith(
+				expect.objectContaining({
+					action: actionName,
+					node_type: nodeTypeName,
+				}),
+			);
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasOperations.test.ts
@@ -274,7 +274,7 @@ describe('useCanvasOperations', () => {
 			await waitFor(() => expect(ndvStore.setActiveNodeName).not.toHaveBeenCalled());
 		});
 
-		it('should pass actionName to telemetry when adding node with action', () => {
+		it('should pass actionName to telemetry when adding node with action', async () => {
 			const workflowsStore = mockedStore(useWorkflowsStore);
 			const nodeCreatorStore = mockedStore(useNodeCreatorStore);
 			const nodeTypeDescription = mockNodeTypeDescription({ name: 'hubspot' });
@@ -296,12 +296,14 @@ describe('useCanvasOperations', () => {
 				},
 			);
 
-			expect(nodeCreatorStore.onNodeAddedToCanvas).toHaveBeenCalledWith(
-				expect.objectContaining({
-					action: actionName,
-					node_type: 'hubspot',
-				}),
-			);
+			await waitFor(() => {
+				expect(nodeCreatorStore.onNodeAddedToCanvas).toHaveBeenCalledWith(
+					expect.objectContaining({
+						action: actionName,
+						node_type: 'hubspot',
+					}),
+				);
+			});
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
@@ -904,6 +904,13 @@ export function useCanvasOperations() {
 	}
 
 	function trackAddDefaultNode(nodeData: INodeUi, options: AddNodeOptions) {
+		// Extract action-related parameters from node parameters if available
+		const nodeParameters = nodeData.parameters;
+		const resource =
+			typeof nodeParameters?.resource === 'string' ? nodeParameters.resource : undefined;
+		const operation =
+			typeof nodeParameters?.operation === 'string' ? nodeParameters.operation : undefined;
+
 		nodeCreatorStore.onNodeAddedToCanvas({
 			node_id: nodeData.id,
 			node_type: nodeData.type,
@@ -914,6 +921,8 @@ export function useCanvasOperations() {
 			input_node_type: uiStore.lastInteractedWithNode
 				? uiStore.lastInteractedWithNode.type
 				: undefined,
+			resource,
+			operation,
 		});
 	}
 

--- a/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasOperations.ts
@@ -139,6 +139,7 @@ type AddNodesOptions = AddNodesBaseOptions & {
 type AddNodeOptions = AddNodesBaseOptions & {
 	openNDV?: boolean;
 	isAutoAdd?: boolean;
+	actionName?: string;
 };
 
 export function useCanvasOperations() {
@@ -667,7 +668,7 @@ export function useCanvasOperations() {
 		}
 
 		for (const [index, nodeAddData] of nodesWithTypeVersion.entries()) {
-			const { isAutoAdd, openDetail: openNDV, ...node } = nodeAddData;
+			const { isAutoAdd, openDetail: openNDV, actionName, ...node } = nodeAddData;
 			const position = node.position ?? insertPosition;
 			const nodeTypeDescription = requireNodeTypeDescription(node.type, node.typeVersion);
 
@@ -683,6 +684,7 @@ export function useCanvasOperations() {
 						...(index === 0 ? { viewport } : {}),
 						openNDV,
 						isAutoAdd,
+						actionName,
 					},
 				);
 				lastAddedNode = newNode;
@@ -923,6 +925,7 @@ export function useCanvasOperations() {
 				: undefined,
 			resource,
 			operation,
+			action: options.actionName,
 		});
 	}
 

--- a/packages/frontend/editor-ui/src/stores/nodeCreator.store.test.ts
+++ b/packages/frontend/editor-ui/src/stores/nodeCreator.store.test.ts
@@ -334,6 +334,34 @@ describe('useNodeCreatorStore', () => {
 			expect(nodeCreatorStore.selectedView).not.toEqual(REGULAR_NODE_CREATOR_VIEW);
 		});
 	});
+
+	it('tracks when node is added to canvas with action parameter', () => {
+		nodeCreatorStore.onCreatorOpened({
+			source,
+			mode,
+			workflow_id,
+		});
+		nodeCreatorStore.onNodeAddedToCanvas({
+			node_id,
+			node_type,
+			node_version,
+			workflow_id,
+			action: 'Create Contact',
+			resource: 'contact',
+			operation: 'create',
+		});
+
+		expect(useTelemetry().track).toHaveBeenCalledWith('User added node to workflow canvas', {
+			node_id,
+			node_type,
+			node_version,
+			workflow_id,
+			action: 'Create Contact',
+			resource: 'contact',
+			operation: 'create',
+			nodes_panel_session_id: getSessionId(now),
+		});
+	});
 });
 
 function getSessionId(time: number) {

--- a/packages/frontend/editor-ui/src/stores/nodeCreator.store.ts
+++ b/packages/frontend/editor-ui/src/stores/nodeCreator.store.ts
@@ -414,6 +414,8 @@ export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, () => {
 		workflow_id: string;
 		drag_and_drop?: boolean;
 		input_node_type?: string;
+		resource?: string;
+		operation?: string;
 	}) {
 		trackNodeCreatorEvent('User added node to workflow canvas', properties);
 	}

--- a/packages/frontend/editor-ui/src/stores/nodeCreator.store.ts
+++ b/packages/frontend/editor-ui/src/stores/nodeCreator.store.ts
@@ -416,6 +416,7 @@ export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, () => {
 		input_node_type?: string;
 		resource?: string;
 		operation?: string;
+		action?: string;
 	}) {
 		trackNodeCreatorEvent('User added node to workflow canvas', properties);
 	}


### PR DESCRIPTION
## Summary

Add `action`, `resource` and `operation` to "User added node to workflow canvas" 

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
