### PR TITLE
fix(Set Node): Handle special replacement patterns in JSON expressions

### DIFF
--- a/packages/nodes-base/nodes/Set/test/v2/utils.test.ts
+++ b/packages/nodes-base/nodes/Set/test/v2/utils.test.ts
@@ -3,7 +3,12 @@ import { constructExecutionMetaData } from 'n8n-core';
 import type { IDataObject, IExecuteFunctions, IGetNodeParameterOptions, INode } from 'n8n-workflow';
 
 import type { SetNodeOptions } from '../../v2/helpers/interfaces';
-import { composeReturnItem, parseJsonParameter, validateEntry } from '../../v2/helpers/utils';
+import {
+	composeReturnItem,
+	parseJsonParameter,
+	validateEntry,
+	resolveRawData,
+} from '../../v2/helpers/utils';
 
 export const node: INode = {
 	id: '11',
@@ -340,5 +345,91 @@ describe('test Set2, validateEntry', () => {
 			name: 'foo',
 			value: 'undefined',
 		});
+	});
+});
+
+describe('test Set2, resolveRawData', () => {
+	const createMockExecuteFunctionForResolve = (returnValue: any) => {
+		return {
+			evaluateExpression: jest.fn().mockReturnValue(returnValue),
+		} as unknown as IExecuteFunctions;
+	};
+
+	it('should handle strings with special replacement patterns like $&', () => {
+		const mockFunction = createMockExecuteFunctionForResolve('hello world $&');
+		const input = '{{ "hello world $&" }}';
+		const result = resolveRawData.call(mockFunction, input, 0);
+
+		// The result should contain the literal $& and not have it replaced
+		expect(result).toBe('hello world $&');
+		expect(mockFunction.evaluateExpression).toHaveBeenCalledWith('{{ "hello world $&" }}', 0);
+	});
+
+	it('should handle strings with $` pattern', () => {
+		const mockFunction = createMockExecuteFunctionForResolve('hello world $`');
+		const input = '{{ "hello world $`" }}';
+		const result = resolveRawData.call(mockFunction, input, 0);
+
+		expect(result).toBe('hello world $`');
+	});
+
+	it("should handle strings with $' pattern", () => {
+		const mockFunction = createMockExecuteFunctionForResolve("hello world $'");
+		const input = '{{ "hello world $\'" }}';
+		const result = resolveRawData.call(mockFunction, input, 0);
+
+		expect(result).toBe("hello world $'");
+	});
+
+	it('should handle strings with $n pattern', () => {
+		const mockFunction = createMockExecuteFunctionForResolve('hello world $1 $2');
+		const input = '{{ "hello world $1 $2" }}';
+		const result = resolveRawData.call(mockFunction, input, 0);
+
+		expect(result).toBe('hello world $1 $2');
+	});
+
+	it('should handle JSON objects with special patterns', () => {
+		const mockFunction = createMockExecuteFunctionForResolve({ message: 'hello world $&' });
+		const input = '{{ {"message": "hello world $&"} }}';
+		const result = resolveRawData.call(mockFunction, input, 0);
+
+		expect(result).toBe('{"message":"hello world $&"}');
+	});
+
+	it('should handle multiple expressions with special patterns', () => {
+		const mockFunction = {
+			evaluateExpression: jest.fn().mockReturnValueOnce('hello $&').mockReturnValueOnce('world $`'),
+		} as unknown as IExecuteFunctions;
+
+		const input = 'start {{ expr1 }} middle {{ expr2 }} end';
+		const result = resolveRawData.call(mockFunction, input, 0);
+
+		expect(result).toBe('start hello $& middle world $` end');
+	});
+
+	it('should handle regular strings without special patterns', () => {
+		const mockFunction = createMockExecuteFunctionForResolve('hello world');
+		const input = '{{ "hello world" }}';
+		const result = resolveRawData.call(mockFunction, input, 0);
+
+		expect(result).toBe('hello world');
+	});
+
+	it('should handle objects and stringify them', () => {
+		const mockFunction = createMockExecuteFunctionForResolve({ message: 'hello world', count: 42 });
+		const input = '{{ someExpression }}';
+		const result = resolveRawData.call(mockFunction, input, 0);
+
+		expect(result).toBe('{"message":"hello world","count":42}');
+	});
+
+	it('should return raw data when no resolvables are found', () => {
+		const mockFunction = createMockExecuteFunctionForResolve('unused');
+		const input = 'hello world without expressions';
+		const result = resolveRawData.call(mockFunction, input, 0);
+
+		expect(result).toBe('hello world without expressions');
+		expect(mockFunction.evaluateExpression).not.toHaveBeenCalled();
 	});
 });

--- a/packages/nodes-base/nodes/Set/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Set/v2/helpers/utils.ts
@@ -232,10 +232,11 @@ export function resolveRawData(
 		for (const resolvable of resolvables) {
 			const resolvedValue = this.evaluateExpression(`${resolvable}`, i);
 
+			// Use a function replacer to avoid issues with special replacement patterns like $&
 			if (typeof resolvedValue === 'object' && resolvedValue !== null) {
-				returnData = returnData.replace(resolvable, JSON.stringify(resolvedValue));
+				returnData = returnData.replace(resolvable, () => JSON.stringify(resolvedValue));
 			} else {
-				returnData = returnData.replace(resolvable, resolvedValue as string);
+				returnData = returnData.replace(resolvable, () => resolvedValue as string);
 			}
 		}
 	}

--- a/packages/nodes-base/nodes/Set/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Set/v2/helpers/utils.ts
@@ -236,7 +236,7 @@ export function resolveRawData(
 			if (typeof resolvedValue === 'object' && resolvedValue !== null) {
 				returnData = returnData.replace(resolvable, () => JSON.stringify(resolvedValue));
 			} else {
-				returnData = returnData.replace(resolvable, () => resolvedValue as string);
+				returnData = returnData.replace(resolvable, () => String(resolvedValue));
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
The Set/Edit Fields node was failing to parse JSON containing `$&` characters. The root cause was JavaScript's `string.replace()` interpreting `$&` as a special replacement pattern, which corrupted the JSON structure. The fix uses a function replacer that treats the replacement text as a literal string, preventing the special pattern interpretation.

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
<img width="630" height="386" alt="image" src="https://github.com/user-attachments/assets/da3b2f0a-a15b-4889-8256-c50697339054" />

## How to test
```bash
cd packages/nodes-base
pnpm test -- nodes/Set/test/v2/utils.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
Fixes #17336 
Fixes #18291 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
