### PR TITLE
fix(Discord Node): Prevent redundant URL wrapping for embed images in JSON mode

### DIFF
--- a/packages/nodes-base/nodes/Discord/test/v2/utils.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/utils.test.ts
@@ -82,6 +82,56 @@ describe('Test Discord > prepareEmbeds', () => {
 
 		expect(result).toEqual(embeds);
 	});
+
+	it('should wrap string image URLs but preserve object format', () => {
+		const executeFunction = {};
+
+		// Test with string URL (should be wrapped)
+		const embedsWithStringUrl = [
+			{
+				description: 'Test embed',
+				image: 'https://example.com/image.png',
+			},
+		];
+
+		const resultString = prepareEmbeds.call(
+			executeFunction as unknown as IExecuteFunctions,
+			embedsWithStringUrl,
+		);
+
+		expect(resultString).toEqual([
+			{
+				description: 'Test embed',
+				image: {
+					url: 'https://example.com/image.png',
+				},
+			},
+		]);
+
+		// Test with already formatted object (should NOT be wrapped again)
+		const embedsWithObject = [
+			{
+				description: 'Test embed',
+				image: {
+					url: 'https://example.com/image.png',
+				},
+			},
+		];
+
+		const resultObject = prepareEmbeds.call(
+			executeFunction as unknown as IExecuteFunctions,
+			embedsWithObject,
+		);
+
+		expect(resultObject).toEqual([
+			{
+				description: 'Test embed',
+				image: {
+					url: 'https://example.com/image.png',
+				},
+			},
+		]);
+	});
 });
 
 describe('Test Discord > checkAccessToGuild', () => {

--- a/packages/nodes-base/nodes/Discord/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Discord/v2/helpers/utils.ts
@@ -161,9 +161,11 @@ export function prepareEmbeds(this: IExecuteFunctions, embeds: IDataObject[]) {
 				};
 			}
 			if (embedReturnData.image) {
-				embedReturnData.image = {
-					url: embedReturnData.image,
-				};
+				if (typeof embedReturnData.image === 'string') {
+					embedReturnData.image = {
+						url: embedReturnData.image,
+					};
+				}
 			}
 
 			return embedReturnData;


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
### Problem
The Discord node's `prepareEmbeds` function always wraps the `image` field value in a `{url: ...}` object. This works correctly for "Enter Fields" mode where users input plain URL strings that need to be converted to Discord's required format. However, when using "Raw JSON" mode with properly formatted Discord embed objects `{image: {url: "..."}}`, the function incorrectly wraps them again, creating invalid nested structures `{image: {url: {url: "..."}}}`, causing Discord API errors.

### Solution
This PR added type checking to only wrap string URLs into objects. When the `image` value is already an object from Raw JSON input, it's preserved as it is. This maintains compatibility with both input modes: strings from UI fields get wrapped, while pre-formatted objects from Raw JSON pass through unchanged.

<img width="690" height="722" alt="image" src="https://github.com/user-attachments/assets/cde33194-93d5-4b48-9f27-ea71ee34b96b" />


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
Closes #16921 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
