### PR TITLE
fix(editor): Editor tooltip style is lost (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/components/CodeNodeEditor/theme.ts
+++ b/packages/frontend/editor-ui/src/components/CodeNodeEditor/theme.ts
@@ -1,5 +1,6 @@
+import { CODEMIRROR_TOOLTIP_CONTAINER_ELEMENT_ID } from '@/constants';
 import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
-import { EditorView } from '@codemirror/view';
+import { EditorView, tooltips } from '@codemirror/view';
 import { tags } from '@lezer/highlight';
 
 /**
@@ -259,4 +260,7 @@ export const codeEditorTheme = ({ isReadOnly, minHeight, maxHeight, rows }: Them
 		},
 	}),
 	codeEditorSyntaxHighlighting,
+	tooltips({
+		parent: document.getElementById(CODEMIRROR_TOOLTIP_CONTAINER_ELEMENT_ID) ?? undefined,
+	}),
 ];


### PR DESCRIPTION
## Summary
Code node editor's tooltip style is lost in #18048.
This PR adds it back for all affected editor types (JS, CSS, SQL, ...) and makes it work in zoomed view too.

<img width="702" height="402" alt="Screenshot 2025-08-11 at 09 50 18" src="https://github.com/user-attachments/assets/a1fbdd45-d4ec-44ad-a657-08b1155adc8e" />

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
