### PR TITLE
chore(core): Allow undefined in the node output value

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "optimize-svg": "find ./packages -name '*.svg' ! -name 'pipedrive.svg' -print0 | xargs -0 -P16 -L20 npx svgo",
     "setup-backend-module": "node scripts/ensure-zx.mjs && zx scripts/backend-module/setup.mjs",
     "start": "run-script-os",
-    "start:default": "cd packages/cli/bin && ./n8n",
+    "start:default": "cd packages/cli/bin && node --inspect ./n8n",
     "start:tunnel": "./packages/cli/bin/n8n start --tunnel",
     "start:windows": "cd packages/cli/bin && n8n",
     "test": "JEST_JUNIT_CLASSNAME={filepath} turbo run test",

--- a/packages/core/src/utils/__tests__/is-json-compatible.test.ts
+++ b/packages/core/src/utils/__tests__/is-json-compatible.test.ts
@@ -119,7 +119,7 @@ describe('isJsonCompatible', () => {
 	const objectRef = {};
 	test.each([
 		{ name: 'null', value: { null: null } },
-		{ name: 'undefined', value: { undefined: undefined } },
+		{ name: 'undefined', value: { noValue: undefined } },
 		{ name: 'an array of primitives', value: { array: [1, 'string', true, false] } },
 		{
 			name: 'an object without a prototype chain',

--- a/packages/core/src/utils/__tests__/is-json-compatible.test.ts
+++ b/packages/core/src/utils/__tests__/is-json-compatible.test.ts
@@ -100,12 +100,6 @@ describe('isJsonCompatible', () => {
 			errorMessage: 'is NaN, which is not JSON-compatible',
 		},
 		{
-			name: 'undefined',
-			value: { undefined },
-			errorPath: 'value.undefined',
-			errorMessage: 'is of unknown type (undefined) with value undefined',
-		},
-		{
 			name: 'an object with symbol keys',
 			value: { [Symbol.for('key')]: 1 },
 			errorPath: 'value.Symbol(key)',
@@ -125,6 +119,7 @@ describe('isJsonCompatible', () => {
 	const objectRef = {};
 	test.each([
 		{ name: 'null', value: { null: null } },
+		{ name: 'undefined', value: { undefined: undefined } },
 		{ name: 'an array of primitives', value: { array: [1, 'string', true, false] } },
 		{
 			name: 'an object without a prototype chain',

--- a/packages/core/src/utils/is-json-compatible.ts
+++ b/packages/core/src/utils/is-json-compatible.ts
@@ -6,7 +6,7 @@ const check = (
 ): { isValid: true } | { isValid: false; errorPath: string; errorMessage: string } => {
 	const type = typeof val;
 
-	if (val === null || type === 'boolean' || type === 'string') {
+	if (val === null || type === 'boolean' || type === 'string' || type === 'undefined') {
 		return { isValid: true };
 	}
 

--- a/packages/core/src/utils/is-json-compatible.ts
+++ b/packages/core/src/utils/is-json-compatible.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line complexity
 const check = (
 	val: unknown,
 	path = 'value',
@@ -46,52 +47,44 @@ const check = (
 		return { isValid: true };
 	}
 
-	if (type === 'object') {
-		if (stack.has(val)) {
-			return {
-				isValid: false,
-				errorPath: path,
-				errorMessage: 'contains a circular reference',
-			};
-		}
-		stack.add(val);
-
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-		const proto = Object.getPrototypeOf(val);
-		if (proto !== Object.prototype && proto !== null) {
-			return {
-				isValid: false,
-				errorPath: path,
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				errorMessage: `has non-plain prototype (${proto?.constructor?.name || 'unknown'})`,
-			};
-		}
-		for (const key of Reflect.ownKeys(val as object)) {
-			if (typeof key === 'symbol') {
-				return {
-					isValid: false,
-					errorPath: `${path}.${key.toString()}`,
-					errorMessage: `has a symbol key (${String(key)}), which is not JSON-compatible`,
-				};
-			}
-
-			if (keysToIgnore.has(key)) {
-				continue;
-			}
-
-			const subVal = (val as Record<string, unknown>)[key];
-			const result = check(subVal, `${path}.${key}`, stack, keysToIgnore);
-			if (!result.isValid) return result;
-		}
-		stack.delete(val);
-		return { isValid: true };
+	if (stack.has(val)) {
+		return {
+			isValid: false,
+			errorPath: path,
+			errorMessage: 'contains a circular reference',
+		};
 	}
+	stack.add(val);
 
-	return {
-		isValid: false,
-		errorPath: path,
-		errorMessage: `is of unknown type (${type}) with value ${JSON.stringify(val)}`,
-	};
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+	const proto = Object.getPrototypeOf(val);
+	if (proto !== Object.prototype && proto !== null) {
+		return {
+			isValid: false,
+			errorPath: path,
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+			errorMessage: `has non-plain prototype (${proto?.constructor?.name || 'unknown'})`,
+		};
+	}
+	for (const key of Reflect.ownKeys(val as object)) {
+		if (typeof key === 'symbol') {
+			return {
+				isValid: false,
+				errorPath: `${path}.${key.toString()}`,
+				errorMessage: `has a symbol key (${String(key)}), which is not JSON-compatible`,
+			};
+		}
+
+		if (keysToIgnore.has(key)) {
+			continue;
+		}
+
+		const subVal = (val as Record<string, unknown>)[key];
+		const result = check(subVal, `${path}.${key}`, stack, keysToIgnore);
+		if (!result.isValid) return result;
+	}
+	stack.delete(val);
+	return { isValid: true };
 };
 
 /**


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR do not log the `incorrect ouput` error on node execution if the ouput contains undefined fields. That's because undefined value are serialized / deserialized ok, and should not lead to frontend / backend behavior mismatch. 

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-3201/error-node-execution-returned-incorrect-data

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
