### PR TITLE
fix(editor): Fix 'Shared with me' page tabs and header

### DIFF
--- a/packages/frontend/editor-ui/src/components/Projects/ProjectHeader.vue
+++ b/packages/frontend/editor-ui/src/components/Projects/ProjectHeader.vue
@@ -64,10 +64,10 @@ const headerIcon = computed((): IconOrEmoji => {
 
 const projectName = computed(() => {
 	if (!projectsStore.currentProject) {
-		if (projectPages.isOverviewSubPage) {
-			return i18n.baseText('projects.menu.overview');
-		} else if (projectPages.isSharedSubPage) {
+		if (projectPages.isSharedSubPage) {
 			return i18n.baseText('projects.header.shared.title');
+		} else if (projectPages.isOverviewSubPage) {
+			return i18n.baseText('projects.menu.overview');
 		}
 		return null;
 	} else if (projectsStore.currentProject.type === ProjectTypes.Personal) {
@@ -193,26 +193,26 @@ const actions: Record<ActionTypes, (projectId: string) => void> = {
 			},
 		});
 	},
-	[ACTION_TYPES.FOLDER]: async () => {
+	[ACTION_TYPES.FOLDER]: () => {
 		emit('createFolder');
 	},
 } as const;
 
 const pageType = computed(() => {
-	if (projectPages.isOverviewSubPage) {
-		return 'overview';
-	} else if (projectPages.isSharedSubPage) {
+	if (projectPages.isSharedSubPage) {
 		return 'shared';
+	} else if (projectPages.isOverviewSubPage) {
+		return 'overview';
 	} else {
 		return 'project';
 	}
 });
 
 const sectionDescription = computed(() => {
-	if (projectPages.isOverviewSubPage) {
-		return i18n.baseText('projects.header.overview.subtitle');
-	} else if (projectPages.isSharedSubPage) {
+	if (projectPages.isSharedSubPage) {
 		return i18n.baseText('projects.header.shared.subtitle');
+	} else if (projectPages.isOverviewSubPage) {
+		return i18n.baseText('projects.header.overview.subtitle');
 	} else if (isPersonalProject.value) {
 		return i18n.baseText('projects.header.personal.subtitle');
 	}


### PR DESCRIPTION
## Summary

Shared with me page header and tabs had been broken at some of the work related to Data Stores. `isOverviewSubPage` returns true also for Shared with you pages, so the order of these checks matters.

If we don't want to consider "Shared with you" as `isOverviewSubPage` then that function could be changed too, but perhaps that function returning true still makes sense?

This PR fixes the header and tabs by changing the order of the checks.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3896/shared-with-you-showing-wrong-page-header-and-tabs-broken

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
