### PR TITLE
ci: Pass through env variables to turbo

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,4 +1,5 @@
 {
+	"globalEnv": ["CI", "COVERAGE_ENABLED"],
 	"tasks": {
 		"clean": { "cache": false },
 		"build": {


### PR DESCRIPTION
## Summary

The turbo.json refactor dropped the ENV variables that needed to be passed through.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1075/investigate-potential-issues-related-to-recent-turbo-changes

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
