### PR TITLE
fix(core): Support MCP server when offloading is enabled

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -171,10 +171,6 @@ export class Start extends BaseCommand<z.infer<typeof flagsSchema>> {
 			scopedLogger.debug(`Host ID: ${this.instanceSettings.hostId}`);
 		}
 
-		if (process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS === 'true') {
-			this.needsTaskRunner = false;
-		}
-
 		await super.init();
 		this.activeWorkflowManager = Container.get(ActiveWorkflowManager);
 


### PR DESCRIPTION
## Summary

Typically nothing should execute on main in queue mode with offloading enabled, so main should not need access to a runner. But it turns out that the MCP Server Trigger runs tools _from within the trigger itself_, which means that a main does need access to a runner if the MCP Server Trigger calls a Code node.

No context on why the MCP Server Trigger is set up like this - it strikes me any actual execution from a trigger (tool invocation or otherwise) should be enqueued and main should remain a producer. But rearchitecting this feature would be a dedicated effort, so for now we restore the runner on main even when offloading is enabled.

To test:
1. Create a workflow with an MCP server trigger and connect a Call n8n Workflow tool. Activate it.
2. Create a subworkflow with a Code node and configure the first workflow to call the second one.
3. Start a main in queue mode with `N8N_RUNNERS_MODE=internal` and `OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS=true`.
4. [Configure](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-langchain.mcptrigger/#integrating-with-claude-desktop) Claude Desktop to call the production webhook URL of the MCP Server Trigger.
5. Prompt Claude to call the n8n workflow.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1034
https://linear.app/n8n/issue/AI-1210
fixes #15662
fixes #16688

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
