### PR TITLE
fix(editor): Revert path checking for .all, .last, .first

### DIFF
--- a/packages/workflow/src/workflow-data-proxy.ts
+++ b/packages/workflow/src/workflow-data-proxy.ts
@@ -1090,28 +1090,6 @@ export class WorkflowDataProxy {
 					}
 				};
 
-				const ensureValidPath = () => {
-					// Check path before execution data
-					const referencedNode = that.workflow.getNode(nodeName);
-					if (!referencedNode) {
-						throw createNodeReferenceError(nodeName);
-					}
-
-					const activeNode = that.workflow.getNode(that.activeNodeName);
-					let contextNode = that.contextNodeName;
-					if (activeNode) {
-						const parentMainInputNode = that.workflow.getParentMainInputNode(activeNode);
-						contextNode = parentMainInputNode?.name ?? contextNode;
-					}
-
-					// For .first(), .last(), .all() methods, use unidirectional path checking
-					// (forward only) to maintain traditional paired item behavior
-					const hasForwardPath = that.workflow.getChildNodes(nodeName).includes(contextNode);
-					if (!hasForwardPath) {
-						throw createNodeReferenceError(nodeName);
-					}
-				};
-
 				return new Proxy(
 					{},
 					{
@@ -1242,7 +1220,6 @@ export class WorkflowDataProxy {
 							}
 
 							if (property === 'first') {
-								ensureValidPath();
 								ensureNodeExecutionData();
 								return (branchIndex?: number, runIndex?: number) => {
 									branchIndex =
@@ -1261,7 +1238,6 @@ export class WorkflowDataProxy {
 								};
 							}
 							if (property === 'last') {
-								ensureValidPath();
 								ensureNodeExecutionData();
 								return (branchIndex?: number, runIndex?: number) => {
 									branchIndex =
@@ -1283,7 +1259,6 @@ export class WorkflowDataProxy {
 								};
 							}
 							if (property === 'all') {
-								ensureValidPath();
 								ensureNodeExecutionData();
 								return (branchIndex?: number, runIndex?: number) => {
 									branchIndex =

--- a/packages/workflow/test/workflow-data-proxy.test.ts
+++ b/packages/workflow/test/workflow-data-proxy.test.ts
@@ -262,8 +262,7 @@ describe('WorkflowDataProxy', () => {
 			} catch (error) {
 				expect(error).toBeInstanceOf(ExpressionError);
 				const exprError = error as ExpressionError;
-				expect(exprError.message).toEqual('Error finding the referenced node');
-				expect(exprError.context.type).toEqual('paired_item_no_connection');
+				expect(exprError.message).toEqual('No execution data available');
 			}
 		});
 


### PR DESCRIPTION
## Summary

in this PR https://github.com/n8n-io/n8n/pull/16059 we added path checking to .all, .last, .first, creating a breaking change.

This PR reverts that code.

<img width="698" height="464" alt="image" src="https://github.com/user-attachments/assets/b8558fd3-d9cb-4a38-b8df-9f1c9730e8f2" />



## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/PAY-3220/community-issue-referencing-executed-nodes-from-different-path-not
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

fixes #18197


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
