### PR TITLE
feat(editor): Make popped out log view window maximizable

### DIFF
--- a/packages/frontend/editor-ui/src/Interface.ts
+++ b/packages/frontend/editor-ui/src/Interface.ts
@@ -121,16 +121,6 @@ declare global {
 			getVariant: (name: string) => string | boolean | undefined;
 			override: (name: string, value: string) => void;
 		};
-		// https://developer.mozilla.org/en-US/docs/Web/API/DocumentPictureInPicture
-		documentPictureInPicture?: {
-			window: Window | null;
-			requestWindow: (options?: {
-				width?: number;
-				height?: number;
-				preferInitialWindowPlacement?: boolean;
-				disallowReturnToOpener?: boolean;
-			}) => Promise<Window>;
-		};
 		Cypress: unknown;
 	}
 }

--- a/packages/frontend/editor-ui/src/components/RunDataJsonActions.vue
+++ b/packages/frontend/editor-ui/src/components/RunDataJsonActions.vue
@@ -9,7 +9,7 @@ import { useNDVStore } from '@/stores/ndv.store';
 import { useNodeHelpers } from '@/composables/useNodeHelpers';
 import { useToast } from '@/composables/useToast';
 import { useI18n } from '@n8n/i18n';
-import { nonExistingJsonPath, PiPWindowSymbol } from '@/constants';
+import { nonExistingJsonPath, PopOutWindowSymbol } from '@/constants';
 import { useClipboard } from '@/composables/useClipboard';
 import { usePinnedData } from '@/composables/usePinnedData';
 import { inject, computed, ref } from 'vue';
@@ -39,8 +39,8 @@ const props = withDefaults(
 	},
 );
 
-const pipWindow = inject(PiPWindowSymbol, ref<Window | undefined>());
-const isInPiPWindow = computed(() => pipWindow?.value !== undefined);
+const popOutWindow = inject(PopOutWindowSymbol, ref<Window | undefined>());
+const isInPopOutWindow = computed(() => popOutWindow?.value !== undefined);
 
 const ndvStore = useNDVStore();
 const workflowsStore = useWorkflowsStore();
@@ -195,7 +195,7 @@ function handleCopyClick(commandData: { command: string }) {
 			v-else
 			trigger="click"
 			:teleported="
-				!isInPiPWindow // disabling teleport ensures the menu is rendered in PiP window
+				!isInPopOutWindow // disabling teleport ensures the menu is rendered in pop-out window
 			"
 			@command="handleCopyClick"
 		>

--- a/packages/frontend/editor-ui/src/components/RunDataJsonActions.vue
+++ b/packages/frontend/editor-ui/src/components/RunDataJsonActions.vue
@@ -9,7 +9,7 @@ import { useNDVStore } from '@/stores/ndv.store';
 import { useNodeHelpers } from '@/composables/useNodeHelpers';
 import { useToast } from '@/composables/useToast';
 import { useI18n } from '@n8n/i18n';
-import { nonExistingJsonPath, PopOutWindowSymbol } from '@/constants';
+import { nonExistingJsonPath, PopOutWindowKey } from '@/constants';
 import { useClipboard } from '@/composables/useClipboard';
 import { usePinnedData } from '@/composables/usePinnedData';
 import { inject, computed, ref } from 'vue';
@@ -39,7 +39,7 @@ const props = withDefaults(
 	},
 );
 
-const popOutWindow = inject(PopOutWindowSymbol, ref<Window | undefined>());
+const popOutWindow = inject(PopOutWindowKey, ref<Window | undefined>());
 const isInPopOutWindow = computed(() => popOutWindow?.value !== undefined);
 
 const ndvStore = useNDVStore();

--- a/packages/frontend/editor-ui/src/composables/useClipboard.ts
+++ b/packages/frontend/editor-ui/src/composables/useClipboard.ts
@@ -1,6 +1,6 @@
 import { inject, onBeforeUnmount, onMounted, ref } from 'vue';
 import { useClipboard as useClipboardCore, useThrottleFn } from '@vueuse/core';
-import { PiPWindowSymbol } from '@/constants';
+import { PopOutWindowSymbol } from '@/constants';
 
 type ClipboardEventFn = (data: string, event?: ClipboardEvent) => void;
 
@@ -9,9 +9,9 @@ export function useClipboard({
 }: {
 	onPaste?: ClipboardEventFn;
 } = {}) {
-	const pipWindow = inject(PiPWindowSymbol, ref<Window | undefined>());
+	const popOutWindow = inject(PopOutWindowSymbol, ref<Window | undefined>());
 	const { copy, copied, isSupported, text } = useClipboardCore({
-		navigator: pipWindow?.value?.navigator ?? window.navigator,
+		navigator: popOutWindow?.value?.navigator ?? window.navigator,
 		legacy: true,
 	});
 

--- a/packages/frontend/editor-ui/src/composables/useClipboard.ts
+++ b/packages/frontend/editor-ui/src/composables/useClipboard.ts
@@ -1,6 +1,6 @@
 import { inject, onBeforeUnmount, onMounted, ref } from 'vue';
 import { useClipboard as useClipboardCore, useThrottleFn } from '@vueuse/core';
-import { PopOutWindowSymbol } from '@/constants';
+import { PopOutWindowKey } from '@/constants';
 
 type ClipboardEventFn = (data: string, event?: ClipboardEvent) => void;
 
@@ -9,7 +9,7 @@ export function useClipboard({
 }: {
 	onPaste?: ClipboardEventFn;
 } = {}) {
-	const popOutWindow = inject(PopOutWindowSymbol, ref<Window | undefined>());
+	const popOutWindow = inject(PopOutWindowKey, ref<Window | undefined>());
 	const { copy, copied, isSupported, text } = useClipboardCore({
 		navigator: popOutWindow?.value?.navigator ?? window.navigator,
 		legacy: true,

--- a/packages/frontend/editor-ui/src/composables/useDocumentTitle.ts
+++ b/packages/frontend/editor-ui/src/composables/useDocumentTitle.ts
@@ -1,9 +1,10 @@
 import { useSettingsStore } from '@/stores/settings.store';
+import type { Ref } from 'vue';
 
 const DEFAULT_TITLE = 'n8n';
 const DEFAULT_TAGLINE = 'Workflow Automation';
 
-export function useDocumentTitle() {
+export function useDocumentTitle(windowRef?: Ref<Window | undefined>) {
 	const settingsStore = useSettingsStore();
 	const { releaseChannel } = settingsStore.settings;
 	const suffix =
@@ -13,7 +14,7 @@ export function useDocumentTitle() {
 
 	const set = (title: string) => {
 		const sections = [title || DEFAULT_TAGLINE, suffix];
-		document.title = sections.join(' - ');
+		(windowRef?.value?.document ?? document).title = sections.join(' - ');
 	};
 
 	const reset = () => {

--- a/packages/frontend/editor-ui/src/composables/useKeybindings.ts
+++ b/packages/frontend/editor-ui/src/composables/useKeybindings.ts
@@ -1,4 +1,4 @@
-import { PiPWindowSymbol } from '@/constants';
+import { PopOutWindowSymbol } from '@/constants';
 import { useDeviceSupport } from '@n8n/composables/useDeviceSupport';
 import { useActiveElement, useEventListener } from '@vueuse/core';
 import type { MaybeRefOrGetter } from 'vue';
@@ -30,8 +30,8 @@ export const useKeybindings = (
 		disabled: MaybeRefOrGetter<boolean>;
 	},
 ) => {
-	const pipWindow = inject(PiPWindowSymbol, ref<Window | undefined>());
-	const activeElement = useActiveElement({ window: pipWindow?.value });
+	const popOutWindow = inject(PopOutWindowSymbol, ref<Window | undefined>());
+	const activeElement = useActiveElement({ window: popOutWindow?.value });
 	const { isCtrlKeyPressed } = useDeviceSupport();
 
 	const isDisabled = computed(() => toValue(options?.disabled));
@@ -150,5 +150,5 @@ export const useKeybindings = (
 		}
 	}
 
-	useEventListener(pipWindow?.value?.document ?? document, 'keydown', onKeyDown);
+	useEventListener(popOutWindow?.value?.document ?? document, 'keydown', onKeyDown);
 };

--- a/packages/frontend/editor-ui/src/composables/useKeybindings.ts
+++ b/packages/frontend/editor-ui/src/composables/useKeybindings.ts
@@ -1,4 +1,4 @@
-import { PopOutWindowSymbol } from '@/constants';
+import { PopOutWindowKey } from '@/constants';
 import { useDeviceSupport } from '@n8n/composables/useDeviceSupport';
 import { useActiveElement, useEventListener } from '@vueuse/core';
 import type { MaybeRefOrGetter } from 'vue';
@@ -30,7 +30,7 @@ export const useKeybindings = (
 		disabled: MaybeRefOrGetter<boolean>;
 	},
 ) => {
-	const popOutWindow = inject(PopOutWindowSymbol, ref<Window | undefined>());
+	const popOutWindow = inject(PopOutWindowKey, ref<Window | undefined>());
 	const activeElement = useActiveElement({ window: popOutWindow?.value });
 	const { isCtrlKeyPressed } = useDeviceSupport();
 

--- a/packages/frontend/editor-ui/src/constants.ts
+++ b/packages/frontend/editor-ui/src/constants.ts
@@ -964,7 +964,7 @@ export const CanvasKey = 'canvas' as unknown as InjectionKey<CanvasInjectionData
 export const CanvasNodeKey = 'canvasNode' as unknown as InjectionKey<CanvasNodeInjectionData>;
 export const CanvasNodeHandleKey =
 	'canvasNodeHandle' as unknown as InjectionKey<CanvasNodeHandleInjectionData>;
-export const PiPWindowSymbol = 'PiPWindow' as unknown as InjectionKey<Ref<Window | undefined>>;
+export const PopOutWindowSymbol = Symbol('PopOutWindow') as InjectionKey<Ref<Window | undefined>>;
 export const ExpressionLocalResolveContextSymbol = Symbol(
 	'ExpressionLocalResolveContext',
 ) as InjectionKey<ComputedRef<ExpressionLocalResolveContext | undefined>>;

--- a/packages/frontend/editor-ui/src/constants.ts
+++ b/packages/frontend/editor-ui/src/constants.ts
@@ -964,7 +964,7 @@ export const CanvasKey = 'canvas' as unknown as InjectionKey<CanvasInjectionData
 export const CanvasNodeKey = 'canvasNode' as unknown as InjectionKey<CanvasNodeInjectionData>;
 export const CanvasNodeHandleKey =
 	'canvasNodeHandle' as unknown as InjectionKey<CanvasNodeHandleInjectionData>;
-export const PopOutWindowSymbol = Symbol('PopOutWindow') as InjectionKey<Ref<Window | undefined>>;
+export const PopOutWindowKey = Symbol('PopOutWindow') as InjectionKey<Ref<Window | undefined>>;
 export const ExpressionLocalResolveContextSymbol = Symbol(
 	'ExpressionLocalResolveContext',
 ) as InjectionKey<ComputedRef<ExpressionLocalResolveContext | undefined>>;

--- a/packages/frontend/editor-ui/src/constants.ts
+++ b/packages/frontend/editor-ui/src/constants.ts
@@ -964,10 +964,10 @@ export const CanvasKey = 'canvas' as unknown as InjectionKey<CanvasInjectionData
 export const CanvasNodeKey = 'canvasNode' as unknown as InjectionKey<CanvasNodeInjectionData>;
 export const CanvasNodeHandleKey =
 	'canvasNodeHandle' as unknown as InjectionKey<CanvasNodeHandleInjectionData>;
-export const PopOutWindowKey = Symbol('PopOutWindow') as InjectionKey<Ref<Window | undefined>>;
-export const ExpressionLocalResolveContextSymbol = Symbol(
-	'ExpressionLocalResolveContext',
-) as InjectionKey<ComputedRef<ExpressionLocalResolveContext | undefined>>;
+export const PopOutWindowKey: InjectionKey<Ref<Window | undefined>> = Symbol('PopOutWindow');
+export const ExpressionLocalResolveContextSymbol: InjectionKey<
+	ComputedRef<ExpressionLocalResolveContext | undefined>
+> = Symbol('ExpressionLocalResolveContext');
 
 export const APP_MODALS_ELEMENT_ID = 'app-modals';
 export const CODEMIRROR_TOOLTIP_CONTAINER_ELEMENT_ID = 'cm-tooltip-container';

--- a/packages/frontend/editor-ui/src/features/logs/components/LogsPanel.vue
+++ b/packages/frontend/editor-ui/src/features/logs/components/LogsPanel.vue
@@ -248,13 +248,6 @@ function handleChangeOutputTableColumnCollapsing(columnName: string | null) {
 </template>
 
 <style lang="scss" module>
-@media all and (display-mode: picture-in-picture) {
-	.resizeWrapper {
-		height: 100% !important;
-		max-height: 100vh !important;
-	}
-}
-
 .popOutContent {
 	height: 100%;
 	position: relative;

--- a/packages/frontend/editor-ui/src/features/logs/components/LogsPanel.vue
+++ b/packages/frontend/editor-ui/src/features/logs/components/LogsPanel.vue
@@ -16,16 +16,19 @@ import { useLogsStore } from '@/stores/logs.store';
 import { useLogsPanelLayout } from '@/features/logs/composables/useLogsPanelLayout';
 import { type KeyMap } from '@/composables/useKeybindings';
 import LogsViewKeyboardEventListener from './LogsViewKeyboardEventListener.vue';
+import { useWorkflowsStore } from '@/stores/workflows.store';
 
 const props = withDefaults(defineProps<{ isReadOnly?: boolean }>(), { isReadOnly: false });
 
 const container = useTemplateRef('container');
 const logsContainer = useTemplateRef('logsContainer');
-const pipContainer = useTemplateRef('pipContainer');
-const pipContent = useTemplateRef('pipContent');
+const popOutContainer = useTemplateRef('popOutContainer');
+const popOutContent = useTemplateRef('popOutContent');
 
 const logsStore = useLogsStore();
 const ndvStore = useNDVStore();
+const workflowsStore = useWorkflowsStore();
+const workflowName = computed(() => workflowsStore.workflow.name);
 
 const {
 	height,
@@ -36,7 +39,7 @@ const {
 	isPoppedOut,
 	isCollapsingDetailsPanel,
 	isOverviewPanelFullWidth,
-	pipWindow,
+	popOutWindow,
 	onResize,
 	onResizeEnd,
 	onToggleOpen,
@@ -45,7 +48,7 @@ const {
 	onChatPanelResizeEnd,
 	onOverviewPanelResize,
 	onOverviewPanelResizeEnd,
-} = useLogsPanelLayout(pipContainer, pipContent, container, logsContainer);
+} = useLogsPanelLayout(workflowName, popOutContainer, popOutContent, container, logsContainer);
 
 const {
 	currentSessionId,
@@ -136,20 +139,20 @@ function handleChangeOutputTableColumnCollapsing(columnName: string | null) {
 </script>
 
 <template>
-	<div ref="pipContainer">
-		<!-- force re-create with key for shortcuts to work in PiP window -->
+	<div ref="popOutContainer">
+		<!-- force re-create with key for shortcuts to work in pop-out window -->
 		<LogsViewKeyboardEventListener
-			:key="String(!!pipWindow)"
+			:key="String(!!popOutWindow)"
 			:key-map="keyMap"
 			:container="container"
 		/>
-		<div ref="pipContent" :class="$style.pipContent">
+		<div ref="popOutContent" :class="[$style.popOutContent, isPoppedOut ? $style.poppedOut : '']">
 			<N8nResizeWrapper
-				:height="height"
+				:height="isPoppedOut ? undefined : height"
 				:supported-directions="['top']"
 				:is-resizing-enabled="!isPoppedOut"
 				:class="$style.resizeWrapper"
-				:style="{ height: isOpen ? `${height}px` : 'auto' }"
+				:style="{ height: isOpen && !isPoppedOut ? `${height}px` : 'auto' }"
 				@resize="onResize"
 				@resizeend="onResizeEnd"
 			>
@@ -161,12 +164,12 @@ function handleChangeOutputTableColumnCollapsing(columnName: string | null) {
 						:width="chatPanelWidth"
 						:style="{ width: `${chatPanelWidth}px` }"
 						:class="$style.chat"
-						:window="pipWindow"
+						:window="popOutWindow"
 						@resize="onChatPanelResize"
 						@resizeend="onChatPanelResizeEnd"
 					>
 						<ChatMessagesPanel
-							:key="`canvas-chat-${currentSessionId}${isPoppedOut ? '-pip' : ''}`"
+							:key="`canvas-chat-${currentSessionId}${isPoppedOut ? '-pop-out' : ''}`"
 							data-test-id="canvas-chat"
 							:is-open="isOpen"
 							:is-read-only="isReadOnly"
@@ -189,7 +192,7 @@ function handleChangeOutputTableColumnCollapsing(columnName: string | null) {
 							:style="{ width: isLogDetailsVisuallyOpen ? `${overviewPanelWidth}px` : '' }"
 							:supported-directions="['right']"
 							:is-resizing-enabled="isLogDetailsOpen"
-							:window="pipWindow"
+							:window="popOutWindow"
 							@resize="onOverviewPanelResize"
 							@resizeend="handleResizeOverviewPanelEnd"
 						>
@@ -222,7 +225,7 @@ function handleChangeOutputTableColumnCollapsing(columnName: string | null) {
 							:class="$style.logDetails"
 							:is-open="isOpen"
 							:log-entry="selected"
-							:window="pipWindow"
+							:window="popOutWindow"
 							:latest-info="latestNodeNameById[selected.node.id]"
 							:panels="logsStore.detailsState"
 							:collapsing-input-table-column-name="inputCollapsingColumnName"
@@ -252,7 +255,7 @@ function handleChangeOutputTableColumnCollapsing(columnName: string | null) {
 	}
 }
 
-.pipContent {
+.popOutContent {
 	height: 100%;
 	position: relative;
 	overflow: hidden;
@@ -264,6 +267,10 @@ function handleChangeOutputTableColumnCollapsing(columnName: string | null) {
 	flex-basis: 0;
 	border-top: var(--border-base);
 	background-color: var(--color-background-light);
+
+	.poppedOut & {
+		border-top: none;
+	}
 }
 
 .container {

--- a/packages/frontend/editor-ui/src/features/logs/components/LogsPanelActions.vue
+++ b/packages/frontend/editor-ui/src/features/logs/components/LogsPanelActions.vue
@@ -71,7 +71,7 @@ function handleSelectMenuItem(selected: string) {
 			activator-icon="ellipsis"
 			activator-size="small"
 			:items="menuItems"
-			:teleported="false /* for PiP window */"
+			:teleported="false /* for pop-out window */"
 			@select="handleSelectMenuItem"
 		/>
 		<KeyboardShortcutTooltip

--- a/packages/frontend/editor-ui/src/features/logs/components/LogsViewKeyboardEventListener.vue
+++ b/packages/frontend/editor-ui/src/features/logs/components/LogsViewKeyboardEventListener.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { type KeyMap, useKeybindings } from '@/composables/useKeybindings';
-import { PopOutWindowSymbol } from '@/constants';
+import { PopOutWindowKey } from '@/constants';
 import { useActiveElement } from '@vueuse/core';
 import { ref, computed, toRef, inject } from 'vue';
 
 const { container, keyMap } = defineProps<{ keyMap: KeyMap; container: HTMLElement | null }>();
-const popOutWindow = inject(PopOutWindowSymbol, ref<Window | undefined>());
+const popOutWindow = inject(PopOutWindowKey, ref<Window | undefined>());
 
 const activeElement = useActiveElement({ window: popOutWindow?.value });
 const isBlurred = computed(() => {

--- a/packages/frontend/editor-ui/src/features/logs/components/LogsViewKeyboardEventListener.vue
+++ b/packages/frontend/editor-ui/src/features/logs/components/LogsViewKeyboardEventListener.vue
@@ -1,16 +1,16 @@
 <script setup lang="ts">
 import { type KeyMap, useKeybindings } from '@/composables/useKeybindings';
-import { PiPWindowSymbol } from '@/constants';
+import { PopOutWindowSymbol } from '@/constants';
 import { useActiveElement } from '@vueuse/core';
 import { ref, computed, toRef, inject } from 'vue';
 
 const { container, keyMap } = defineProps<{ keyMap: KeyMap; container: HTMLElement | null }>();
-const pipWindow = inject(PiPWindowSymbol, ref<Window | undefined>());
+const popOutWindow = inject(PopOutWindowSymbol, ref<Window | undefined>());
 
-const activeElement = useActiveElement({ window: pipWindow?.value });
+const activeElement = useActiveElement({ window: popOutWindow?.value });
 const isBlurred = computed(() => {
-	if (pipWindow?.value) {
-		return pipWindow.value.document.activeElement === null;
+	if (popOutWindow?.value) {
+		return popOutWindow.value.document.activeElement === null;
 	}
 
 	return (

--- a/packages/frontend/editor-ui/src/features/logs/components/LogsViewRunData.vue
+++ b/packages/frontend/editor-ui/src/features/logs/components/LogsViewRunData.vue
@@ -8,7 +8,7 @@ import { waitingNodeTooltip } from '@/utils/executionUtils';
 import { N8nLink, N8nText } from '@n8n/design-system';
 import { computed, inject, ref } from 'vue';
 import { I18nT } from 'vue-i18n';
-import { PiPWindowSymbol } from '@/constants';
+import { PopOutWindowSymbol } from '@/constants';
 import { isSubNodeLog } from '../logs.utils';
 
 const { title, logEntry, paneType, collapsingTableColumnName } = defineProps<{
@@ -25,7 +25,7 @@ const emit = defineEmits<{
 const locale = useI18n();
 const ndvStore = useNDVStore();
 
-const pipWindow = inject(PiPWindowSymbol, ref<Window | undefined>());
+const popOutWindow = inject(PopOutWindowSymbol, ref<Window | undefined>());
 
 const displayMode = ref<IRunDataDisplayMode>(paneType === 'input' ? 'schema' : 'table');
 const isMultipleInput = computed(
@@ -74,7 +74,7 @@ function handleChangeDisplayMode(value: IRunDataDisplayMode) {
 	<RunData
 		v-if="runDataProps"
 		v-bind="runDataProps"
-		:key="`run-data${pipWindow ? '-pip' : ''}`"
+		:key="`run-data${popOutWindow ? '-pop-out' : ''}`"
 		:class="$style.component"
 		:workflow-object="logEntry.workflow"
 		:workflow-execution="logEntry.execution"

--- a/packages/frontend/editor-ui/src/features/logs/components/LogsViewRunData.vue
+++ b/packages/frontend/editor-ui/src/features/logs/components/LogsViewRunData.vue
@@ -8,7 +8,7 @@ import { waitingNodeTooltip } from '@/utils/executionUtils';
 import { N8nLink, N8nText } from '@n8n/design-system';
 import { computed, inject, ref } from 'vue';
 import { I18nT } from 'vue-i18n';
-import { PopOutWindowSymbol } from '@/constants';
+import { PopOutWindowKey } from '@/constants';
 import { isSubNodeLog } from '../logs.utils';
 
 const { title, logEntry, paneType, collapsingTableColumnName } = defineProps<{
@@ -25,7 +25,7 @@ const emit = defineEmits<{
 const locale = useI18n();
 const ndvStore = useNDVStore();
 
-const popOutWindow = inject(PopOutWindowSymbol, ref<Window | undefined>());
+const popOutWindow = inject(PopOutWindowKey, ref<Window | undefined>());
 
 const displayMode = ref<IRunDataDisplayMode>(paneType === 'input' ? 'schema' : 'table');
 const isMultipleInput = computed(

--- a/packages/frontend/editor-ui/src/features/logs/composables/useLogsPanelLayout.ts
+++ b/packages/frontend/editor-ui/src/features/logs/composables/useLogsPanelLayout.ts
@@ -65,7 +65,7 @@ export function useLogsPanelLayout(
 		initialWidth: window.document.body.offsetWidth * 0.8,
 		container: popOutContainer,
 		content: popOutContent,
-		shouldPopOut: shouldPopOut,
+		shouldPopOut,
 		onRequestClose: () => {
 			if (!isOpen.value) {
 				return;

--- a/packages/frontend/editor-ui/src/features/logs/composables/useLogsPanelLayout.ts
+++ b/packages/frontend/editor-ui/src/features/logs/composables/useLogsPanelLayout.ts
@@ -52,18 +52,20 @@ export function useLogsPanelLayout(
 			: resizer.isResizing.value && resizer.size.value > 0,
 	);
 	const isCollapsingDetailsPanel = computed(() => overviewPanelResizer.isFullSize.value);
+	const popOutWindowTitle = computed(() => `Logs - ${workflowName.value}`);
+	const shouldPopOut = computed(() => logsStore.state === LOGS_PANEL_STATE.FLOATING);
 
 	const {
 		canPopOut,
 		isPoppedOut,
 		popOutWindow: popOutWindow,
 	} = usePopOutWindow({
-		workflowName,
+		title: popOutWindowTitle,
 		initialHeight: 400,
 		initialWidth: window.document.body.offsetWidth * 0.8,
 		container: popOutContainer,
 		content: popOutContent,
-		shouldPopOut: computed(() => logsStore.state === LOGS_PANEL_STATE.FLOATING),
+		shouldPopOut: shouldPopOut,
 		onRequestClose: () => {
 			if (!isOpen.value) {
 				return;

--- a/packages/frontend/editor-ui/src/features/logs/composables/useLogsPanelLayout.ts
+++ b/packages/frontend/editor-ui/src/features/logs/composables/useLogsPanelLayout.ts
@@ -96,10 +96,6 @@ export function useLogsPanelLayout(
 		logsStore.setPreferPoppedOut(true);
 	}
 
-	function handlePopIn() {
-		logsStore.setPreferPoppedOut(false);
-	}
-
 	function handleResizeEnd() {
 		if (!logsStore.isOpen && !resizer.isCollapsed.value) {
 			handleToggleOpen(true);
@@ -138,7 +134,6 @@ export function useLogsPanelLayout(
 		popOutWindow,
 		onToggleOpen: handleToggleOpen,
 		onPopOut: handlePopOut,
-		onPopIn: handlePopIn,
 		onResize: resizer.onResize,
 		onResizeEnd: handleResizeEnd,
 		onChatPanelResize: chatPanelResizer.onResize,

--- a/packages/frontend/editor-ui/src/features/logs/composables/usePopOutWindow.test.ts
+++ b/packages/frontend/editor-ui/src/features/logs/composables/usePopOutWindow.test.ts
@@ -7,81 +7,20 @@ import { setActivePinia } from 'pinia';
 import { createTestingPinia } from '@pinia/testing';
 
 describe(usePopOutWindow, () => {
-	const documentPictureInPicture: NonNullable<Window['documentPictureInPicture']> = {
-		window: null,
-		requestWindow: async () =>
-			({
-				document: { body: { append: vi.fn(), removeChild: vi.fn() } },
-				addEventListener: vi.fn(),
-				close: vi.fn(),
-			}) as unknown as Window,
-	};
-
 	beforeEach(() => {
 		setActivePinia(createTestingPinia({ stubActions: false }));
 	});
 
-	describe('canPopOut', () => {
-		it('should return false if window.documentPictureInPicture is not available', () => {
-			const MyComponent = defineComponent({
-				setup() {
-					const container = ref<HTMLDivElement | null>(null);
-					const content = ref<HTMLDivElement | null>(null);
-					const popOutWindow = usePopOutWindow({
-						title: computed(() => ''),
-						container,
-						content,
-						shouldPopOut: computed(() => true),
-						onRequestClose: vi.fn(),
-					});
-
-					return () =>
-						h(
-							'div',
-							{ ref: container },
-							h('div', { ref: content }, String(popOutWindow.canPopOut.value)),
-						);
-				},
-			});
-
-			const { queryByText } = renderComponent(MyComponent);
-
-			expect(queryByText('false')).toBeInTheDocument();
-		});
-
-		it('should return true if window.documentPictureInPicture is available', () => {
-			Object.assign(window, { documentPictureInPicture });
-
-			const MyComponent = defineComponent({
-				setup() {
-					const container = ref<HTMLDivElement | null>(null);
-					const content = ref<HTMLDivElement | null>(null);
-					const popOutWindow = usePopOutWindow({
-						title: computed(() => ''),
-						container,
-						content,
-						shouldPopOut: computed(() => true),
-						onRequestClose: vi.fn(),
-					});
-
-					return () =>
-						h(
-							'div',
-							{ ref: container },
-							h('div', { ref: content }, String(popOutWindow.canPopOut.value)),
-						);
-				},
-			});
-
-			const { queryByText } = renderComponent(MyComponent);
-
-			expect(queryByText('true')).toBeInTheDocument();
-		});
-	});
-
 	describe('isPoppedOut', () => {
 		beforeEach(() => {
-			Object.assign(window, { documentPictureInPicture });
+			Object.assign(window, {
+				open: () =>
+					({
+						document: { body: { append: vi.fn() } },
+						addEventListener: vi.fn(),
+						close: vi.fn(),
+					}) as unknown as Window,
+			});
 		});
 
 		it('should be set to true when popped out', async () => {

--- a/packages/frontend/editor-ui/src/features/logs/composables/usePopOutWindow.test.ts
+++ b/packages/frontend/editor-ui/src/features/logs/composables/usePopOutWindow.test.ts
@@ -28,7 +28,7 @@ describe(usePopOutWindow, () => {
 					const container = ref<HTMLDivElement | null>(null);
 					const content = ref<HTMLDivElement | null>(null);
 					const popOutWindow = usePopOutWindow({
-						workflowName: computed(() => ''),
+						title: computed(() => ''),
 						container,
 						content,
 						shouldPopOut: computed(() => true),
@@ -57,7 +57,7 @@ describe(usePopOutWindow, () => {
 					const container = ref<HTMLDivElement | null>(null);
 					const content = ref<HTMLDivElement | null>(null);
 					const popOutWindow = usePopOutWindow({
-						workflowName: computed(() => ''),
+						title: computed(() => ''),
 						container,
 						content,
 						shouldPopOut: computed(() => true),
@@ -91,7 +91,7 @@ describe(usePopOutWindow, () => {
 					const container = ref<HTMLDivElement | null>(null);
 					const content = ref<HTMLDivElement | null>(null);
 					const popOutWindow = usePopOutWindow({
-						workflowName: computed(() => ''),
+						title: computed(() => ''),
 						container,
 						content,
 						shouldPopOut: computed(() => shouldPopOut.value),

--- a/packages/frontend/editor-ui/src/features/logs/composables/usePopOutWindow.test.ts
+++ b/packages/frontend/editor-ui/src/features/logs/composables/usePopOutWindow.test.ts
@@ -1,12 +1,12 @@
 /* eslint-disable vue/one-component-per-file */
 import { computed, defineComponent, h, ref } from 'vue';
-import { usePiPWindow } from './usePiPWindow';
+import { usePopOutWindow } from './usePopOutWindow';
 import { waitFor } from '@testing-library/vue';
 import { renderComponent } from '@/__tests__/render';
 import { setActivePinia } from 'pinia';
 import { createTestingPinia } from '@pinia/testing';
 
-describe(usePiPWindow, () => {
+describe(usePopOutWindow, () => {
 	const documentPictureInPicture: NonNullable<Window['documentPictureInPicture']> = {
 		window: null,
 		requestWindow: async () =>
@@ -27,7 +27,8 @@ describe(usePiPWindow, () => {
 				setup() {
 					const container = ref<HTMLDivElement | null>(null);
 					const content = ref<HTMLDivElement | null>(null);
-					const pipWindow = usePiPWindow({
+					const popOutWindow = usePopOutWindow({
+						workflowName: computed(() => ''),
 						container,
 						content,
 						shouldPopOut: computed(() => true),
@@ -38,7 +39,7 @@ describe(usePiPWindow, () => {
 						h(
 							'div',
 							{ ref: container },
-							h('div', { ref: content }, String(pipWindow.canPopOut.value)),
+							h('div', { ref: content }, String(popOutWindow.canPopOut.value)),
 						);
 				},
 			});
@@ -55,7 +56,8 @@ describe(usePiPWindow, () => {
 				setup() {
 					const container = ref<HTMLDivElement | null>(null);
 					const content = ref<HTMLDivElement | null>(null);
-					const pipWindow = usePiPWindow({
+					const popOutWindow = usePopOutWindow({
+						workflowName: computed(() => ''),
 						container,
 						content,
 						shouldPopOut: computed(() => true),
@@ -66,7 +68,7 @@ describe(usePiPWindow, () => {
 						h(
 							'div',
 							{ ref: container },
-							h('div', { ref: content }, String(pipWindow.canPopOut.value)),
+							h('div', { ref: content }, String(popOutWindow.canPopOut.value)),
 						);
 				},
 			});
@@ -88,7 +90,8 @@ describe(usePiPWindow, () => {
 				setup() {
 					const container = ref<HTMLDivElement | null>(null);
 					const content = ref<HTMLDivElement | null>(null);
-					const pipWindow = usePiPWindow({
+					const popOutWindow = usePopOutWindow({
+						workflowName: computed(() => ''),
 						container,
 						content,
 						shouldPopOut: computed(() => shouldPopOut.value),
@@ -99,7 +102,7 @@ describe(usePiPWindow, () => {
 						h(
 							'div',
 							{ ref: container },
-							h('div', { ref: content }, String(pipWindow.isPoppedOut.value)),
+							h('div', { ref: content }, String(popOutWindow.isPoppedOut.value)),
 						);
 				},
 			});

--- a/packages/frontend/editor-ui/src/features/logs/composables/usePopOutWindow.ts
+++ b/packages/frontend/editor-ui/src/features/logs/composables/usePopOutWindow.ts
@@ -58,6 +58,19 @@ function syncStyleMutations(destination: Window, mutations: MutationRecord[]) {
 	}
 }
 
+function copeFavicon(popOutWindow: Window) {
+	const iconUrl = document.querySelector('link[rel=icon]')?.getAttribute('href');
+
+	if (iconUrl) {
+		const link = document.createElement('link');
+
+		link.setAttribute('rel', 'icon');
+		link.setAttribute('href', iconUrl);
+
+		popOutWindow.document.head.appendChild(link);
+	}
+}
+
 /**
  * A composable that allows to pop out given content in child window
  */
@@ -106,28 +119,15 @@ export function usePopOutWindow({
 			return;
 		}
 
-		popOutWindow.value.document.title = 'Logs'; // TODO: include workflow name
+		copeFavicon(popOutWindow.value);
 
-		const iconUrl = document.querySelector('link[rel=icon]')?.getAttribute('href');
-
-		if (iconUrl) {
-			const link = document.createElement('link');
-
-			link.setAttribute('rel', 'icon');
-			link.setAttribute('href', iconUrl);
-
-			popOutWindow.value?.document.head.appendChild(link);
-		}
-
-		// Copy style sheets over from the initial document
-		// so that the content looks the same.
-		[...document.styleSheets].forEach((styleSheet) => {
+		for (const styleSheet of [...document.styleSheets]) {
 			try {
 				const cssRules = [...styleSheet.cssRules].map((rule) => rule.cssText).join('');
 				const style = document.createElement('style');
 
 				style.textContent = cssRules;
-				popOutWindow.value?.document.head.appendChild(style);
+				popOutWindow.value.document.head.appendChild(style);
 			} catch (e) {
 				const link = document.createElement('link');
 
@@ -135,13 +135,13 @@ export function usePopOutWindow({
 				link.type = styleSheet.type;
 				link.media = styleSheet.media as unknown as string;
 				link.href = styleSheet.href as string;
-				popOutWindow.value?.document.head.appendChild(link);
+				popOutWindow.value.document.head.appendChild(link);
 			}
-		});
+		}
 
 		// Move the content to the Picture-in-Picture window.
-		popOutWindow.value?.document.body.append(content.value);
-		popOutWindow.value?.addEventListener('pagehide', () => !isUnmounting.value && onRequestClose());
+		popOutWindow.value.document.body.append(content.value);
+		popOutWindow.value.addEventListener('pagehide', () => !isUnmounting.value && onRequestClose());
 	}
 
 	function hidePopOut() {

--- a/packages/frontend/editor-ui/src/features/logs/composables/usePopOutWindow.ts
+++ b/packages/frontend/editor-ui/src/features/logs/composables/usePopOutWindow.ts
@@ -14,7 +14,7 @@ import {
 } from 'vue';
 
 interface UsePopOutWindowOptions {
-	workflowName: ComputedRef<string>;
+	title: ComputedRef<string>;
 	initialWidth?: number;
 	initialHeight?: number;
 	container: Readonly<ShallowRef<HTMLElement | null>>;
@@ -62,7 +62,7 @@ function syncStyleMutations(destination: Window, mutations: MutationRecord[]) {
  * A composable that allows to pop out given content in child window
  */
 export function usePopOutWindow({
-	workflowName,
+	title,
 	container,
 	content,
 	initialHeight,
@@ -159,10 +159,11 @@ export function usePopOutWindow({
 	});
 
 	watch(
-		[workflowName, popOutWindow],
-		([name, win]) => {
+		[title, popOutWindow],
+		([newTitle, win]) => {
 			if (win) {
-				documentTitle.set(`Logs - ${name}`);
+				console.log(newTitle);
+				documentTitle.set(newTitle);
 			}
 		},
 		{ immediate: true },

--- a/packages/frontend/editor-ui/src/features/logs/composables/usePopOutWindow.ts
+++ b/packages/frontend/editor-ui/src/features/logs/composables/usePopOutWindow.ts
@@ -139,7 +139,7 @@ export function usePopOutWindow({
 			}
 		}
 
-		// Move the content to the Picture-in-Picture window.
+		// Move the content to child window.
 		popOutWindow.value.document.body.append(content.value);
 		popOutWindow.value.addEventListener('pagehide', () => !isUnmounting.value && onRequestClose());
 	}

--- a/packages/frontend/editor-ui/src/features/logs/composables/usePopOutWindow.ts
+++ b/packages/frontend/editor-ui/src/features/logs/composables/usePopOutWindow.ts
@@ -174,7 +174,10 @@ export function usePopOutWindow({
 
 	onBeforeUnmount(() => {
 		isUnmounting.value = true;
-		popOutWindow.value?.close();
+		if (popOutWindow.value) {
+			popOutWindow.value.close();
+			onRequestClose();
+		}
 	});
 
 	return { canPopOut, isPoppedOut, popOutWindow };

--- a/packages/frontend/editor-ui/src/features/logs/composables/usePopOutWindow.ts
+++ b/packages/frontend/editor-ui/src/features/logs/composables/usePopOutWindow.ts
@@ -1,5 +1,5 @@
 import { useDocumentTitle } from '@/composables/useDocumentTitle';
-import { PopOutWindowSymbol } from '@/constants';
+import { PopOutWindowKey } from '@/constants';
 import { useProvideTooltipAppendTo } from '@n8n/design-system/composables/useTooltipAppendTo';
 import {
 	computed,
@@ -87,7 +87,7 @@ export function usePopOutWindow({
 	// Copy over dynamic styles to child window to support lazily imported modules
 	observer.observe(document.head, { childList: true, subtree: true });
 
-	provide(PopOutWindowSymbol, popOutWindow);
+	provide(PopOutWindowKey, popOutWindow);
 	useProvideTooltipAppendTo(tooltipContainer);
 
 	async function showPopOut() {
@@ -162,7 +162,6 @@ export function usePopOutWindow({
 		[title, popOutWindow],
 		([newTitle, win]) => {
 			if (win) {
-				console.log(newTitle);
 				documentTitle.set(newTitle);
 			}
 		},

--- a/packages/frontend/editor-ui/src/features/logs/composables/usePopOutWindow.ts
+++ b/packages/frontend/editor-ui/src/features/logs/composables/usePopOutWindow.ts
@@ -1,6 +1,5 @@
-import { PiPWindowSymbol } from '@/constants';
-import { useUIStore } from '@/stores/ui.store';
-import { applyThemeToBody } from '@/stores/ui.utils';
+import { useDocumentTitle } from '@/composables/useDocumentTitle';
+import { PopOutWindowSymbol } from '@/constants';
 import { useProvideTooltipAppendTo } from '@n8n/design-system/composables/useTooltipAppendTo';
 import {
 	computed,
@@ -14,7 +13,8 @@ import {
 	watch,
 } from 'vue';
 
-interface UsePiPWindowOptions {
+interface UsePopOutWindowOptions {
+	workflowName: ComputedRef<string>;
 	initialWidth?: number;
 	initialHeight?: number;
 	container: Readonly<ShallowRef<HTMLElement | null>>;
@@ -23,10 +23,10 @@ interface UsePiPWindowOptions {
 	onRequestClose: () => void;
 }
 
-interface UsePiPWindowReturn {
+interface UsePopOutWindowReturn {
 	isPoppedOut: ComputedRef<boolean>;
 	canPopOut: ComputedRef<boolean>;
-	pipWindow?: Ref<Window | undefined>;
+	popOutWindow?: Ref<Window | undefined>;
 }
 
 function isStyle(node: Node): node is HTMLElement {
@@ -59,52 +59,65 @@ function syncStyleMutations(destination: Window, mutations: MutationRecord[]) {
 }
 
 /**
- * A composable that allows to pop out given content in document PiP (picture-in-picture) window
+ * A composable that allows to pop out given content in child window
  */
-export function usePiPWindow({
+export function usePopOutWindow({
+	workflowName,
 	container,
 	content,
 	initialHeight,
 	initialWidth,
 	shouldPopOut,
 	onRequestClose,
-}: UsePiPWindowOptions): UsePiPWindowReturn {
-	const pipWindow = ref<Window>();
+}: UsePopOutWindowOptions): UsePopOutWindowReturn {
+	const popOutWindow = ref<Window>();
 	const isUnmounting = ref(false);
-	const canPopOut = computed(
-		() =>
-			!!window.documentPictureInPicture /* Browser supports the API */ &&
-			window.parent === window /* Not in iframe */,
-	);
-	const isPoppedOut = computed(() => !!pipWindow.value);
+	const canPopOut = computed(() => window.parent === window /* Not in iframe */);
+	const isPoppedOut = computed(() => !!popOutWindow.value);
 	const tooltipContainer = computed(() =>
 		isPoppedOut.value ? (content.value ?? undefined) : undefined,
 	);
-	const uiStore = useUIStore();
 	const observer = new MutationObserver((mutations) => {
-		if (pipWindow.value) {
-			syncStyleMutations(pipWindow.value, mutations);
+		if (popOutWindow.value) {
+			syncStyleMutations(popOutWindow.value, mutations);
 		}
 	});
+	const documentTitle = useDocumentTitle(popOutWindow);
 
-	// Copy over dynamic styles to PiP window to support lazily imported modules
+	// Copy over dynamic styles to child window to support lazily imported modules
 	observer.observe(document.head, { childList: true, subtree: true });
 
-	provide(PiPWindowSymbol, pipWindow);
+	provide(PopOutWindowSymbol, popOutWindow);
 	useProvideTooltipAppendTo(tooltipContainer);
 
-	async function showPip() {
+	async function showPopOut() {
 		if (!content.value) {
 			return;
 		}
 
-		pipWindow.value =
-			pipWindow.value ??
-			(await window.documentPictureInPicture?.requestWindow({
-				width: initialWidth,
-				height: initialHeight,
-				disallowReturnToOpener: true,
-			}));
+		if (!popOutWindow.value) {
+			// Chrome ignores these options but effective in Firefox
+			const options = `popup=yes,width=${initialWidth},height=${initialHeight},left=100,top=100,toolbar=no,menubar=no,scrollbars=yes,resizable=yes`;
+
+			popOutWindow.value = window.open('', '_blank', options) ?? undefined;
+		}
+
+		if (!popOutWindow.value) {
+			return;
+		}
+
+		popOutWindow.value.document.title = 'Logs'; // TODO: include workflow name
+
+		const iconUrl = document.querySelector('link[rel=icon]')?.getAttribute('href');
+
+		if (iconUrl) {
+			const link = document.createElement('link');
+
+			link.setAttribute('rel', 'icon');
+			link.setAttribute('href', iconUrl);
+
+			popOutWindow.value?.document.head.appendChild(link);
+		}
 
 		// Copy style sheets over from the initial document
 		// so that the content looks the same.
@@ -114,7 +127,7 @@ export function usePiPWindow({
 				const style = document.createElement('style');
 
 				style.textContent = cssRules;
-				pipWindow.value?.document.head.appendChild(style);
+				popOutWindow.value?.document.head.appendChild(style);
 			} catch (e) {
 				const link = document.createElement('link');
 
@@ -122,18 +135,18 @@ export function usePiPWindow({
 				link.type = styleSheet.type;
 				link.media = styleSheet.media as unknown as string;
 				link.href = styleSheet.href as string;
-				pipWindow.value?.document.head.appendChild(link);
+				popOutWindow.value?.document.head.appendChild(link);
 			}
 		});
 
 		// Move the content to the Picture-in-Picture window.
-		pipWindow.value?.document.body.append(content.value);
-		pipWindow.value?.addEventListener('pagehide', () => !isUnmounting.value && onRequestClose());
+		popOutWindow.value?.document.body.append(content.value);
+		popOutWindow.value?.addEventListener('pagehide', () => !isUnmounting.value && onRequestClose());
 	}
 
-	function hidePiP() {
-		pipWindow.value?.close();
-		pipWindow.value = undefined;
+	function hidePopOut() {
+		popOutWindow.value?.close();
+		popOutWindow.value = undefined;
 
 		if (content.value) {
 			container.value?.appendChild(content.value);
@@ -141,17 +154,15 @@ export function usePiPWindow({
 	}
 
 	// `requestAnimationFrame()` to make sure the content is already rendered
-	watch(shouldPopOut, (value) => (value ? requestAnimationFrame(showPip) : hidePiP()), {
+	watch(shouldPopOut, (value) => (value ? requestAnimationFrame(showPopOut) : hidePopOut()), {
 		immediate: true,
 	});
 
-	// It seems "prefers-color-scheme: dark" media query matches in PiP window by default
-	// So we're enforcing currently applied theme in the main window by setting data-theme in PiP's body element
 	watch(
-		[() => uiStore.appliedTheme, pipWindow],
-		([theme, pip]) => {
-			if (pip) {
-				applyThemeToBody(theme, pip);
+		[workflowName, popOutWindow],
+		([name, win]) => {
+			if (win) {
+				documentTitle.set(`Logs - ${name}`);
 			}
 		},
 		{ immediate: true },
@@ -163,8 +174,8 @@ export function usePiPWindow({
 
 	onBeforeUnmount(() => {
 		isUnmounting.value = true;
-		pipWindow.value?.close();
+		popOutWindow.value?.close();
 	});
 
-	return { canPopOut, isPoppedOut, pipWindow };
+	return { canPopOut, isPoppedOut, popOutWindow };
 }

--- a/packages/frontend/editor-ui/src/features/logs/composables/usePopOutWindow.ts
+++ b/packages/frontend/editor-ui/src/features/logs/composables/usePopOutWindow.ts
@@ -58,16 +58,16 @@ function syncStyleMutations(destination: Window, mutations: MutationRecord[]) {
 	}
 }
 
-function copeFavicon(popOutWindow: Window) {
-	const iconUrl = document.querySelector('link[rel=icon]')?.getAttribute('href');
+function copyFavicon(source: Window, target: Window) {
+	const iconUrl = source.document.querySelector('link[rel=icon]')?.getAttribute('href');
 
 	if (iconUrl) {
-		const link = document.createElement('link');
+		const link = target.document.createElement('link');
 
 		link.setAttribute('rel', 'icon');
 		link.setAttribute('href', iconUrl);
 
-		popOutWindow.document.head.appendChild(link);
+		target.document.head.appendChild(link);
 	}
 }
 
@@ -119,7 +119,7 @@ export function usePopOutWindow({
 			return;
 		}
 
-		copeFavicon(popOutWindow.value);
+		copyFavicon(window, popOutWindow.value);
 
 		for (const styleSheet of [...document.styleSheets]) {
 			try {


### PR DESCRIPTION
## Summary

This PR switches the browser API used for popping out log view from Chrome's experimental `documentPictureInPicture` to `window.open()`. This change makes the popped out log view:
- Cross browser compatible
- Maximizable
- Follows normal window order (doesn't always stay in front)

<img width="1512" height="982" alt="Screenshot 2025-08-12 at 10 54 21" src="https://github.com/user-attachments/assets/ad84e00f-1345-4818-8d2c-b2f5132e9cac" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/SUG-116/feature-make-popped-out-log-view-window-maximizable


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
