### PR TITLE
fix: Fix the RudderStack config response format (no-changelog)

### DIFF
--- a/packages/cli/src/controllers/telemetry.controller.ts
+++ b/packages/cli/src/controllers/telemetry.controller.ts
@@ -39,8 +39,12 @@ export class TelemetryController {
 	async page(req: AuthenticatedRequest, res: Response, next: NextFunction) {
 		await this.proxy(req, res, next);
 	}
-	@Get('/rudderstack/sourceConfig', { skipAuth: true, rateLimit: { limit: 50, windowMs: 60_000 } })
-	async sourceConfig() {
+	@Get('/rudderstack/sourceConfig', {
+		skipAuth: true,
+		rateLimit: { limit: 50, windowMs: 60_000 },
+		usesTemplates: true,
+	})
+	async sourceConfig(_: Request, res: Response) {
 		const response = await fetch('https://api-rs.n8n.io/sourceConfig', {
 			headers: {
 				authorization:
@@ -54,6 +58,7 @@ export class TelemetryController {
 
 		const config: unknown = await response.json();
 
-		return config;
+		// write directly to response to avoid wrapping the config in `data` key which is not expected by RudderStack sdk
+		res.json(config);
 	}
 }


### PR DESCRIPTION
## Summary
The RudderStack config was wrapped in a `data` key which we're doing by default for all controllers.

I'm still yet to find out what the extent of this is and if we've missed some metrics because of the incorrect config loading.

<img width="3024" height="1890" alt="image" src="https://github.com/user-attachments/assets/5e2dc43e-d37b-4579-8919-b0c24b216e2e" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3882/bug-rudderstack-is-possibly-receiving-unexpected-config


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
