### PR TITLE
ci: Add Renovate configuration file

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,98 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": [
+		"config:base",
+		":dependencyDashboard",
+		":semanticCommits",
+		":separateMajorReleases",
+		":enableVulnerabilityAlertsWithLabel(security)"
+	],
+	"schedule": ["after 2am and before 4am"],
+	"timezone": "UTC",
+	"prConcurrentLimit": 3,
+	"prHourlyLimit": 1,
+	"packageRules": [
+		{
+			"description": "Use pnpm catalog for shared dependencies",
+			"matchFileNames": ["pnpm-workspace.yaml"],
+			"matchManagers": ["pnpm"],
+			"enabled": true
+		},
+		{
+			"description": "Group all catalog updates together",
+			"matchFiles": ["pnpm-workspace.yaml"],
+			"groupName": "pnpm catalog",
+			"commitMessageTopic": "pnpm catalog"
+		},
+		{
+			"description": "Dev dependencies - no auto-merge for now",
+			"matchDepTypes": ["devDependencies"],
+			"matchUpdateTypes": ["patch", "minor"],
+			"automerge": false
+		},
+		{
+			"description": "Patch updates - no auto-merge for now",
+			"matchUpdateTypes": ["patch", "pin", "digest"],
+			"automerge": false
+		},
+		{
+			"description": "TypeScript types - no auto-merge for now",
+			"matchPackagePatterns": ["^@types/"],
+			"automerge": false
+		},
+		{
+			"description": "Require approval for major updates",
+			"matchUpdateTypes": ["major"],
+			"dependencyDashboardApproval": true
+		},
+		{
+			"description": "Security updates get highest priority",
+			"matchPackagePatterns": ["*"],
+			"vulnerabilityAlerts": true,
+			"prPriority": 20,
+			"labels": ["security", "dependencies"]
+		},
+		{
+			"description": "Group ESLint related packages",
+			"matchPackagePatterns": ["eslint"],
+			"groupName": "ESLint"
+		},
+		{
+			"description": "Group Vue ecosystem packages",
+			"matchPackagePatterns": ["vue", "@vue/", "@vueuse/"],
+			"groupName": "Vue ecosystem"
+		},
+		{
+			"description": "Group testing packages",
+			"matchPackagePatterns": ["vitest", "playwright", "cypress", "@testing-library/"],
+			"groupName": "testing packages"
+		},
+		{
+			"description": "Group TypeScript packages",
+			"matchPackagePatterns": ["typescript", "tsx", "tsup"],
+			"groupName": "TypeScript"
+		}
+	],
+	"lockFileMaintenance": {
+		"enabled": true,
+		"schedule": ["before 6am on monday"]
+	},
+	"vulnerabilityAlerts": {
+		"enabled": true,
+		"prPriority": 20
+	},
+	"osvVulnerabilityAlerts": true,
+	"vulnerabilityAlertsLabels": ["security", "vulnerability"],
+	"labels": ["dependencies"],
+	"branchPrefix": "renovate/",
+	"commitMessagePrefix": "chore(deps): ",
+	"commitMessageTopic": "{{depName}}",
+	"commitMessageExtra": "to {{newVersion}}",
+	"prTitle": "{{#if isSingleManager}}{{#if isGrouped}}{{commitMessagePrefix}}update {{groupName}}{{else}}{{commitMessagePrefix}}update {{depName}}{{/if}}{{else}}{{commitMessagePrefix}}update dependencies{{/if}}{{#if hasReleaseNotes}} ({{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#each newValue}}{{#unless @first}}, {{/unless}}{{this}}{{/each}}{{/if}}){{/if}}",
+	"ignoreDeps": [],
+	"ignorePaths": ["**/node_modules/**", "**/dist/**", "**/build/**"],
+	"enabledManagers": ["npm", "pnpm", "dockerfile", "github-actions"],
+	"npmrc": "auto-detect",
+	"respectShrinkwrap": true,
+	"updateNotScheduled": false
+}

--- a/renovate.json
+++ b/renovate.json
@@ -20,7 +20,7 @@
 		},
 		{
 			"description": "Group all catalog updates together",
-			"matchFiles": ["pnpm-workspace.yaml"],
+			"matchFileNames": ["pnpm-workspace.yaml"],
 			"groupName": "pnpm catalog",
 			"commitMessageTopic": "pnpm catalog"
 		},
@@ -47,7 +47,6 @@
 		},
 		{
 			"description": "Security updates get highest priority",
-			"matchPackagePatterns": ["*"],
 			"vulnerabilityAlerts": true,
 			"prPriority": 20,
 			"labels": ["security", "dependencies"]
@@ -88,7 +87,7 @@
 	"commitMessagePrefix": "chore(deps): ",
 	"commitMessageTopic": "{{depName}}",
 	"commitMessageExtra": "to {{newVersion}}",
-	"prTitle": "{{#if isSingleManager}}{{#if isGrouped}}{{commitMessagePrefix}}update {{groupName}}{{else}}{{commitMessagePrefix}}update {{depName}}{{/if}}{{else}}{{commitMessagePrefix}}update dependencies{{/if}}{{#if hasReleaseNotes}} ({{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#each newValue}}{{#unless @first}}, {{/unless}}{{this}}{{/each}}{{/if}}){{/if}}",
+	"prTitle": "{{commitMessagePrefix}}update {{#if isSingleManager}}{{#if isGrouped}}{{groupName}}{{else}}{{depName}}{{/if}}{{else}}dependencies{{/if}}{{#if hasReleaseNotes}} ({{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#each newValue}}{{#unless @first}}, {{/unless}}{{this}}{{/each}}{{/if}}){{/if}}",
 	"ignoreDeps": [],
 	"ignorePaths": ["**/node_modules/**", "**/dist/**", "**/build/**"],
 	"enabledManagers": ["npm", "pnpm", "dockerfile", "github-actions"],


### PR DESCRIPTION
Initializes Renovate Bot configuration to automate dependency updates.

## Summary

- Adds renovate configuration
- Should handle lockfile/pnpm catalog
- Should handle dockerfile versions/github actions/npm packages

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1135/setup-renovate-for-automated-dependency-updates-across-n8n-repo

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
