### PR TITLE
perf(editor): Fix log view related slowdown of manual execution with large data

### DIFF
--- a/packages/frontend/editor-ui/src/features/logs/composables/useLogsExecutionData.ts
+++ b/packages/frontend/editor-ui/src/features/logs/composables/useLogsExecutionData.ts
@@ -4,12 +4,7 @@ import { Workflow, type IRunExecutionData } from 'n8n-workflow';
 import { useWorkflowsStore } from '@/stores/workflows.store';
 import { useNodeHelpers } from '@/composables/useNodeHelpers';
 import { useThrottleFn } from '@vueuse/core';
-import {
-	createLogTree,
-	deepToRaw,
-	findSubExecutionLocator,
-	mergeStartData,
-} from '@/features/logs/logs.utils';
+import { createLogTree, findSubExecutionLocator, mergeStartData } from '@/features/logs/logs.utils';
 import { parse } from 'flatted';
 import { useToast } from '@/composables/useToast';
 import type { LatestNodeInfo, LogEntry } from '../logs.types';
@@ -113,12 +108,10 @@ export function useLogsExecutionData() {
 				execData.value =
 					workflowsStore.workflowExecutionData === null
 						? undefined
-						: deepToRaw(
-								mergeStartData(
-									workflowsStore.workflowExecutionStartedData?.[1] ?? {},
-									workflowsStore.workflowExecutionData,
-								),
-							); // Create deep copy to disable reactivity
+						: mergeStartData(
+								workflowsStore.workflowExecutionStartedData?.[1] ?? {},
+								workflowsStore.workflowExecutionData,
+							);
 
 				if (executionId !== previousExecutionId) {
 					// Reset sub workflow data when top-level execution changes

--- a/packages/frontend/editor-ui/src/features/logs/logs.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/logs/logs.utils.test.ts
@@ -7,7 +7,6 @@ import {
 } from '@/__tests__/mocks';
 import {
 	createLogTree,
-	deepToRaw,
 	findSelectedLogEntry,
 	findSubExecutionLocator,
 	getDefaultCollapsedEntries,
@@ -27,7 +26,6 @@ import {
 } from './__test__/data';
 import type { LogEntrySelection } from './logs.types';
 import type { IExecutionResponse } from '@/Interface';
-import { isReactive, reactive } from 'vue';
 import { createTestLogEntry } from './__test__/mocks';
 import { AGENT_NODE_TYPE, CHAT_TRIGGER_NODE_TYPE } from '@/constants';
 
@@ -1276,29 +1274,6 @@ describe('extractBotResponse', () => {
 		const executionId = 'test-exec-id';
 		const result = extractBotResponse(resultData, executionId);
 		expect(result).toBeUndefined();
-	});
-});
-
-describe(deepToRaw, () => {
-	it('should convert reactive fields to raw in data with circular structure', () => {
-		const data = reactive({
-			foo: reactive({ bar: {} }),
-			bazz: {},
-		});
-
-		data.foo.bar = data;
-		data.bazz = data;
-
-		const raw = deepToRaw(data);
-
-		expect(isReactive(data)).toBe(true);
-		expect(isReactive(data.foo)).toBe(true);
-		expect(isReactive(data.foo.bar)).toBe(true);
-		expect(isReactive(data.bazz)).toBe(true);
-		expect(isReactive(raw)).toBe(false);
-		expect(isReactive(raw.foo)).toBe(false);
-		expect(isReactive(raw.foo.bar)).toBe(false);
-		expect(isReactive(raw.bazz)).toBe(false);
 	});
 });
 

--- a/packages/frontend/editor-ui/src/features/logs/logs.utils.ts
+++ b/packages/frontend/editor-ui/src/features/logs/logs.utils.ts
@@ -14,7 +14,6 @@ import {
 	type RelatedExecution,
 } from 'n8n-workflow';
 import type { LogEntry, LogEntrySelection, LogTreeCreationContext } from './logs.types';
-import { isProxy, isReactive, isRef, toRaw } from 'vue';
 import { CHAT_TRIGGER_NODE_TYPE, MANUAL_CHAT_TRIGGER_NODE_TYPE } from '@/constants';
 import { type ChatMessage } from '@n8n/chat/types';
 import get from 'lodash/get';
@@ -310,44 +309,6 @@ export function findSelectedLogEntry(
 			return found;
 		}
 	}
-}
-
-export function deepToRaw<T>(sourceObj: T): T {
-	const seen = new WeakMap();
-
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const objectIterator = (input: any): any => {
-		if (seen.has(input)) {
-			return input;
-		}
-
-		if (input !== null && typeof input === 'object') {
-			seen.set(input, true);
-		}
-
-		if (Array.isArray(input)) {
-			return input.map((item) => objectIterator(item));
-		}
-
-		if (isRef(input) || isReactive(input) || isProxy(input)) {
-			return objectIterator(toRaw(input));
-		}
-
-		if (
-			input !== null &&
-			typeof input === 'object' &&
-			Object.getPrototypeOf(input) === Object.prototype
-		) {
-			return Object.keys(input).reduce((acc, key) => {
-				acc[key as keyof typeof acc] = objectIterator(input[key]);
-				return acc;
-			}, {} as T);
-		}
-
-		return input;
-	};
-
-	return objectIterator(sourceObj);
 }
 
 export function flattenLogEntries(


### PR DESCRIPTION
## Summary

This PR removes `deepToRaw` which is confirmed to be not relevant anymore and improves UI performance in manual execution.

| Before | After |
|--------|--------|
| <img width="1512" height="945" alt="0  before" src="https://github.com/user-attachments/assets/ec00a405-6763-421e-8871-3657665584c6" /> | <img width="1512" height="945" alt="1  deepToRaw removed" src="https://github.com/user-attachments/assets/bbe6d693-c8aa-4514-b884-82ebe9bf08b2" /> | 



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/SUG-115/tech-debt-investigate-slow-log-view-rendering-while-manual-execution


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
