### PR TITLE
fix: Allow  new lines in field names in RMC

### DIFF
--- a/packages/frontend/editor-ui/src/components/ResourceMapper/MappingFields.vue
+++ b/packages/frontend/editor-ui/src/components/ResourceMapper/MappingFields.vue
@@ -19,6 +19,7 @@ import {
 	fieldCannotBeDeleted,
 	isMatchingField,
 	parseResourceMapperFieldName,
+	escapeResourceMapperFieldName,
 } from '@/utils/nodeTypesUtils';
 import { useNodeSpecificationValues } from '@/composables/useNodeSpecificationValues';
 import {
@@ -88,7 +89,8 @@ const fieldsUi = computed<Array<INodeProperties & { readOnly: boolean }>>(() => 
 			return {
 				displayName: getFieldLabel(field),
 				// Set part of the path to each param name so value can be fetched properly by input parameter list component
-				name: `value["${field.id}"]`,
+				// Escape special characters to prevent parameter name parsing issues
+				name: `value["${escapeResourceMapperFieldName(field.id)}"]`,
 				type: getParamType(field),
 				default: field.type === 'boolean' ? false : '',
 				required: field.required,

--- a/packages/frontend/editor-ui/src/utils/__tests__/nodeTypesUtils.test.ts
+++ b/packages/frontend/editor-ui/src/utils/__tests__/nodeTypesUtils.test.ts
@@ -1,0 +1,126 @@
+import {
+	escapeResourceMapperFieldName,
+	unescapeResourceMapperFieldName,
+	parseResourceMapperFieldName,
+} from '../nodeTypesUtils';
+
+describe('Resource Mapper Field Name Handling', () => {
+	describe('escapeResourceMapperFieldName', () => {
+		it('should encode field names with prefix', () => {
+			const result = escapeResourceMapperFieldName('Column Name');
+			expect(result).toMatch(/^__enc_/);
+			expect(result.length).toBeGreaterThan('__enc_'.length);
+		});
+
+		it('should encode newlines safely', () => {
+			const result = escapeResourceMapperFieldName('Column\nName');
+			expect(result).toMatch(/^__enc_/);
+			// Should not contain actual newlines in the encoded result
+			expect(result).not.toContain('\n');
+		});
+
+		it('should encode all special characters safely', () => {
+			const input = 'Column\n"With\tSpecial\\Characters\r';
+			const result = escapeResourceMapperFieldName(input);
+			expect(result).toMatch(/^__enc_/);
+			// Should not contain any of the problematic characters
+			expect(result).not.toContain('\n');
+			expect(result).not.toContain('\r');
+			expect(result).not.toContain('\t');
+			expect(result).not.toContain('"');
+			expect(result).not.toContain('\\');
+		});
+
+		it('should encode normal text consistently', () => {
+			const input = 'NormalColumnName';
+			const result = escapeResourceMapperFieldName(input);
+			expect(result).toMatch(/^__enc_/);
+		});
+	});
+
+	describe('unescapeResourceMapperFieldName', () => {
+		it('should decode encoded field names', () => {
+			const original = 'Column Name';
+			const encoded = escapeResourceMapperFieldName(original);
+			const decoded = unescapeResourceMapperFieldName(encoded);
+			expect(decoded).toBe(original);
+		});
+
+		it('should decode field names with newlines', () => {
+			const original = 'Column\nName';
+			const encoded = escapeResourceMapperFieldName(original);
+			const decoded = unescapeResourceMapperFieldName(encoded);
+			expect(decoded).toBe(original);
+		});
+
+		it('should decode field names with all special characters', () => {
+			const original = 'Column\n"With\tSpecial\\Characters\r';
+			const encoded = escapeResourceMapperFieldName(original);
+			const decoded = unescapeResourceMapperFieldName(encoded);
+			expect(decoded).toBe(original);
+		});
+
+		it('should handle non-encoded field names for backward compatibility', () => {
+			// Test old-style escaped field names
+			expect(unescapeResourceMapperFieldName('Column\\nName')).toBe('Column\nName');
+			expect(unescapeResourceMapperFieldName('Column\\"Name')).toBe('Column"Name');
+			expect(unescapeResourceMapperFieldName('Column\\\\Name')).toBe('Column\\Name');
+		});
+
+		it('should return original value if decoding fails', () => {
+			const invalidEncoded = '__enc_invalid-base64!@#';
+			// Should not throw and should return something reasonable
+			const result = unescapeResourceMapperFieldName(invalidEncoded);
+			expect(typeof result).toBe('string');
+		});
+	});
+
+	describe('parseResourceMapperFieldName', () => {
+		it('should parse and decode field names from parameter names', () => {
+			const testCases = [
+				{ fieldName: 'Normal Column', expected: 'Normal Column' },
+				{ fieldName: 'Column\nWith Newline', expected: 'Column\nWith Newline' },
+				{ fieldName: 'Column\rWith CR', expected: 'Column\rWith CR' },
+				{ fieldName: 'Column\tWith Tab', expected: 'Column\tWith Tab' },
+				{ fieldName: 'Column"With Quote', expected: 'Column"With Quote' },
+				{ fieldName: 'Column\\With Backslash', expected: 'Column\\With Backslash' },
+			];
+
+			testCases.forEach(({ fieldName, expected }) => {
+				const escaped = escapeResourceMapperFieldName(fieldName);
+				const parameterName = `value["${escaped}"]`;
+				const parsed = parseResourceMapperFieldName(parameterName);
+				expect(parsed).toBe(expected);
+			});
+		});
+
+		it('should return the original string if regex does not match', () => {
+			expect(parseResourceMapperFieldName('invalid-parameter-name')).toBe('invalid-parameter-name');
+		});
+
+		it('should handle round-trip encoding and decoding', () => {
+			const originalFieldNames = [
+				'Simple Column',
+				'Column\nWith\nMultiple\nNewlines',
+				'Column\tWith\tTabs',
+				'Column"With"Quotes',
+				'Column\\With\\Backslashes',
+				'Complex\n"Column\\Name\r\tWith\nAll"Special\\Characters',
+				'Unicode字符测试',
+				'Emoji😀Test🎉Column',
+			];
+
+			originalFieldNames.forEach((originalFieldName) => {
+				// Step 1: Encode the field name (what happens in MappingFields.vue)
+				const encoded = escapeResourceMapperFieldName(originalFieldName);
+				const parameterName = `value["${encoded}"]`;
+
+				// Step 2: Parse it back (what happens in parseResourceMapperFieldName)
+				const parsed = parseResourceMapperFieldName(parameterName);
+
+				// Step 3: Verify they match
+				expect(parsed).toBe(originalFieldName);
+			});
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/utils/__tests__/nodeTypesUtils.test.ts
+++ b/packages/frontend/editor-ui/src/utils/__tests__/nodeTypesUtils.test.ts
@@ -60,11 +60,11 @@ describe('Resource Mapper Field Name Handling', () => {
 			expect(decoded).toBe(original);
 		});
 
-		it('should handle non-encoded field names for backward compatibility', () => {
-			// Test old-style escaped field names
-			expect(unescapeResourceMapperFieldName('Column\\nName')).toBe('Column\nName');
-			expect(unescapeResourceMapperFieldName('Column\\"Name')).toBe('Column"Name');
-			expect(unescapeResourceMapperFieldName('Column\\\\Name')).toBe('Column\\Name');
+		it('should return non-encoded field names unchanged', () => {
+			// Non-encoded field names are returned as-is
+			expect(unescapeResourceMapperFieldName('Column\\nName')).toBe('Column\\nName');
+			expect(unescapeResourceMapperFieldName('Column Name')).toBe('Column Name');
+			expect(unescapeResourceMapperFieldName('NormalField')).toBe('NormalField');
 		});
 
 		it('should return original value if decoding fails', () => {

--- a/packages/frontend/editor-ui/src/utils/nodeTypesUtils.ts
+++ b/packages/frontend/editor-ui/src/utils/nodeTypesUtils.ts
@@ -413,9 +413,88 @@ export const isNodeParameterRequired = (
 	return true;
 };
 
+/**
+ * Safely encodes field names to base64 (works in both browser and Node.js)
+ */
+const safeBase64Encode = (str: string): string => {
+	// Use browser's btoa if available, otherwise fallback to Buffer (Node.js)
+	if (typeof btoa !== 'undefined') {
+		// Convert Unicode string to binary string for btoa
+		const utf8Bytes = new TextEncoder().encode(str);
+		const binaryString = Array.from(utf8Bytes, (byte) => String.fromCharCode(byte)).join('');
+		return btoa(binaryString);
+	} else if (typeof Buffer !== 'undefined') {
+		return Buffer.from(str, 'utf8').toString('base64');
+	}
+	// Fallback: use URI encoding (not ideal but works)
+	return encodeURIComponent(str);
+};
+
+/**
+ * Safely decodes base64 field names (works in both browser and Node.js)
+ */
+const safeBase64Decode = (str: string): string => {
+	// Use browser's atob if available, otherwise fallback to Buffer (Node.js)
+	if (typeof atob !== 'undefined') {
+		try {
+			// Convert binary string back to Unicode string
+			const binaryString = atob(str);
+			const utf8Bytes = new Uint8Array(Array.from(binaryString, (char) => char.charCodeAt(0)));
+			return new TextDecoder().decode(utf8Bytes);
+		} catch (error) {
+			// Fallback if atob fails
+			return decodeURIComponent(str);
+		}
+	} else if (typeof Buffer !== 'undefined') {
+		return Buffer.from(str, 'base64').toString('utf8');
+	}
+	// Fallback: use URI decoding (not ideal but works)
+	return decodeURIComponent(str);
+};
+
+/**
+ * Escapes special characters in field names by encoding them safely
+ * This prevents issues with newlines, quotes, and other special characters
+ */
+export const escapeResourceMapperFieldName = (fieldName: string): string => {
+	// Use base64 encoding to safely encode any special characters
+	// Prefix with "__enc_" to identify encoded field names
+	return '__enc_' + safeBase64Encode(fieldName);
+};
+
+/**
+ * Unescapes field names that were encoded
+ */
+export const unescapeResourceMapperFieldName = (fieldName: string): string => {
+	// Check if this is an encoded field name
+	if (fieldName.startsWith('__enc_')) {
+		try {
+			const encodedPart = fieldName.substring(6); // Remove "__enc_" prefix
+			return safeBase64Decode(encodedPart);
+		} catch (error) {
+			// If decoding fails, return the original field name
+			console.warn('Failed to decode field name:', fieldName, error);
+			return fieldName;
+		}
+	}
+
+	// For backward compatibility, handle old-style escaped field names
+	return fieldName
+		.replace(/\\n/g, '\n') // Unescape newlines
+		.replace(/\\r/g, '\r') // Unescape carriage returns
+		.replace(/\\t/g, '\t') // Unescape tabs
+		.replace(/\\"/g, '"') // Unescape quotes
+		.replace(/\\\\/g, '\\'); // Unescape backslashes last
+};
+
 export const parseResourceMapperFieldName = (fullName: string) => {
 	const match = fullName.match(RESOURCE_MAPPER_FIELD_NAME_REGEX);
 	const fieldName = match ? match.pop() : fullName;
+
+	// Unescape special characters that were escaped when creating the parameter name
+	if (fieldName) {
+		return unescapeResourceMapperFieldName(fieldName);
+	}
 
 	return fieldName;
 };


### PR DESCRIPTION
## Summary
This PR fixes resource mapper field name encoding to handle newlines and special characters properly.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-3399/community-issue-google-sheet-node-does-not-handle-line-breaks
Closes https://github.com/n8n-io/n8n/issues/17886

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
