### PR TITLE
fix(microsoft-teams-node): Use Microsoft Graph API  query params for pagination instead of splice

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channel/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channel/getAll.operation.ts
@@ -37,7 +37,10 @@ export async function execute(this: IExecuteFunctions, i: number) {
 			'GET',
 			`/v1.0/teams/${teamId}/channels`,
 			{},
+			{
+				$top: limit,
+			},
 		);
-		return responseData.splice(0, limit);
+		return responseData;
 	}
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channelMessage/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channelMessage/getAll.operation.ts
@@ -37,9 +37,12 @@ export async function execute(this: IExecuteFunctions, i: number) {
 			this,
 			'value',
 			'GET',
-			`/beta/teams/${teamId}/channels/${channelId}/messages`,
+			`/beta/teams/${teamId}/channels/${channelId}/messages`, 
 			{},
+			{
+				$top: limit,
+			},
 		);
-		return responseData.splice(0, limit);
+		return responseData;
 	}
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/getAll.operation.ts
@@ -38,7 +38,10 @@ export async function execute(this: IExecuteFunctions, i: number) {
 			'GET',
 			`/v1.0/chats/${chatId}/messages`,
 			{},
+			{
+				$top: limit,
+			},
 		);
-		return responseData.splice(0, limit);
+		return responseData;
 	}
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/task/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/task/getAll.operation.ts
@@ -71,8 +71,11 @@ export async function execute(this: IExecuteFunctions, i: number) {
 				'GET',
 				`/v1.0/users/${memberId}/planner/tasks`,
 				{},
+				{
+					$top: limit,
+				},
 			);
-			return responseData.splice(0, limit);
+			return responseData;
 		}
 	} else {
 		//https://docs.microsoft.com/en-us/graph/api/plannerplan-list-tasks?view=graph-rest-1.0&tabs=http
@@ -91,7 +94,9 @@ export async function execute(this: IExecuteFunctions, i: number) {
 				'value',
 				'GET',
 				`/v1.0/planner/plans/${planId}/tasks`,
-				{},
+				{
+					$top: limit,
+				},
 			);
 			return responseData.splice(0, limit);
 		}

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/task/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/task/getAll.operation.ts
@@ -94,11 +94,12 @@ export async function execute(this: IExecuteFunctions, i: number) {
 				'value',
 				'GET',
 				`/v1.0/planner/plans/${planId}/tasks`,
+				{},
 				{
 					$top: limit,
 				},
 			);
-			return responseData.splice(0, limit);
+			return responseData;
 		}
 	}
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/transport/index.ts
@@ -69,7 +69,10 @@ export async function microsoftApiRequestAllItems(
 		responseData = await microsoftApiRequest.call(this, method, endpoint, body, query, uri);
 		uri = responseData['@odata.nextLink'];
 		returnData.push.apply(returnData, responseData[propertyName] as IDataObject[]);
-		const limit = query.limit as number | undefined;
+
+		// Handle both $top and limit parameters
+		const limit = query.$top || query.limit as number | undefined;
+		
 		if (limit && limit <= returnData.length) {
 			return returnData;
 		}


### PR DESCRIPTION
## Summary

Currently, the getAll methods fetch all data and then use splice() to limit results client-side.

This PR switches to proper server-side pagination using the $top query parameter as recommended in the [official Microsoft Graph documentation](https://learn.microsoft.com/en-us/graph/paging?tabs=http#implementing-client-side-paging).

Before: Fetch everything → splice locally
After: Use ?$top={limit} to only fetch what we need

Sure, current implementation works but it's painfully slow - I tried fetching just one message from a channel with 3 years of history and eventually I stopped waiting and create a PR 😄 

## Related Linear tickets, Github issues, and Community forum posts

[https://community.n8n.io/t/microsoft-teams-node-performance-is-poor-when-fetching-channel-messages/166853](https://community.n8n.io/t/microsoft-teams-node-performance-is-poor-when-fetching-channel-messages/166853)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
