### PR TITLE
fix(core): Update email template wording to avoid a/an typo (no-changelog)

### DIFF
--- a/packages/cli/src/user-management/email/__tests__/user-management-mailer.test.ts
+++ b/packages/cli/src/user-management/email/__tests__/user-management-mailer.test.ts
@@ -188,7 +188,7 @@ describe('UserManagementMailer', () => {
 
 				const callBody = nodeMailer.sendMail.mock.calls[index][0].body;
 				expect(callBody).toContain(
-					`You have been added as a ${sharee.role.replace('project:', '')} to the ${project.name} project`,
+					`You have been added to the ${project.name} project as ${sharee.role.replace('project:', '')}`,
 				);
 			});
 		});

--- a/packages/cli/src/user-management/email/templates/project-shared.mjml
+++ b/packages/cli/src/user-management/email/templates/project-shared.mjml
@@ -4,7 +4,7 @@
 		<mj-section>
 			<mj-column>
 				<mj-text font-size="24px" color="#ff6f5c"
-					>You have been added as a {{ role }} to the {{ projectName }} project</mj-text
+					>You have been added to the {{ projectName }} project as {{ role }}</mj-text
 				>
 			</mj-column>
 		</mj-section>


### PR DESCRIPTION
## Summary

n8n currently sends out grammatically wrong project share notifications for two out of three user roles ("You have been added as a admin to..."). This PR rewords the respective template to avoid running into the [a/an problem](https://www.britannica.com/dictionary/eb/qa/how-do-you-know-whether-to-use-a-or-an). It also updates the corresponding test.

## Related Linear tickets, Github issues, and Community forum posts

n/a

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
