### PR TITLE
fix(editor): Stricter type check in `DataStoreBreadcrumbs` (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/dataStore/components/DataStoreBreadcrumbs.vue
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/DataStoreBreadcrumbs.vue
@@ -17,7 +17,7 @@ type Props = {
 
 const props = defineProps<Props>();
 
-const renameInput = useTemplateRef<{ forceFocus?: () => void }>('renameInput');
+const renameInput = useTemplateRef('renameInput');
 
 const dataStoreStore = useDataStoreStore();
 
@@ -58,7 +58,7 @@ const onRename = async () => {
 	// Focus rename input if the action is rename
 	// We need this timeout to ensure action toggle is closed before focusing
 	await nextTick();
-	if (renameInput.value?.forceFocus) {
+	if (renameInput.value && typeof renameInput.value.forceFocus === 'function') {
 		renameInput.value.forceFocus();
 	}
 };


### PR DESCRIPTION
## Summary
Addressing `typecheck` issue.


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
