### PR TITLE
fix(editor): Restore background color of NDV backdrop

### DIFF
--- a/packages/frontend/@n8n/design-system/src/css/_tokens.dark.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.dark.scss
@@ -271,7 +271,6 @@
 	--color-ndv-droppable-parameter-background: var(--p-color-primary-320-a-010);
 	--color-ndv-droppable-parameter-active-background: var(--p-color-alt-a-600-a-015);
 	--color-ndv-back-font: var(--p-white);
-	--color-ndv-overlay-background: var(--prim-color-alt-j-alpha-095);
 
 	// Notice
 	--color-notice-warning-border: var(--p-color-alt-b-180);

--- a/packages/frontend/@n8n/design-system/src/css/_tokens.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.scss
@@ -339,7 +339,6 @@
 	--color-ndv-droppable-parameter: var(--color-secondary);
 	--color-ndv-droppable-parameter-background: var(--p-color-secondary-470-a-010);
 	--color-ndv-droppable-parameter-active-background: var(--p-color-alt-a-600-a-015);
-	--color-ndv-overlay-background: var(--prim-color-alt-j-alpha-095);
 	--color-ndv-back-font: var(--p-white);
 
 	// Notice

--- a/packages/frontend/editor-ui/src/components/NodeDetailsViewV2.vue
+++ b/packages/frontend/editor-ui/src/components/NodeDetailsViewV2.vue
@@ -851,7 +851,7 @@ onBeforeUnmount(() => {
 	left: 0;
 	right: 0;
 	bottom: 0;
-	background-color: var(--color-ndv-overlay-background);
+	background-color: var(--color-dialog-overlay-background-dark);
 }
 
 .dialog {


### PR DESCRIPTION
## Summary

<img width="1364" height="1043" alt="image" src="https://github.com/user-attachments/assets/4eeae32e-5b32-48de-8b95-4028d790d687" />


## Related Linear tickets, Github issues, and Community forum posts

fixes #18249
https://linear.app/n8n/issue/NODE-3484/community-issue-ndv-backdrop-not-dark-anymore

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
