### PR TITLE
feat(core): Fix types for Data Store endpoints (no-changelog)

### DIFF
--- a/packages/cli/src/modules/data-store/__tests__/data-store-aggregate.service.test.ts
+++ b/packages/cli/src/modules/data-store/__tests__/data-store-aggregate.service.test.ts
@@ -99,8 +99,8 @@ describe('dataStoreAggregate', () => {
 			// ASSERT
 			expect(result.data).toEqual(
 				expect.arrayContaining([
-					expect.objectContaining({ id: ds1!.id, name: ds1!.name }),
-					expect.objectContaining({ id: ds2!.id, name: ds2!.name }),
+					expect.objectContaining({ id: ds1.id, name: ds1.name }),
+					expect.objectContaining({ id: ds2.id, name: ds2.name }),
 				]),
 			);
 			expect(result.count).toBe(2);
@@ -162,13 +162,13 @@ describe('dataStoreAggregate', () => {
 
 			// ACT
 			const result = await dataStoreAggregateService.getManyAndCount(user, {
-				filter: { id: ds2!.id },
+				filter: { id: ds2.id },
 				skip: 0,
 				take: 10,
 			});
 
 			// ASSERT
-			expect(result.data).toEqual([expect.objectContaining({ id: ds2!.id, name: ds2!.name })]);
+			expect(result.data).toEqual([expect.objectContaining({ id: ds2.id, name: ds2.name })]);
 			expect(result.count).toBe(1);
 		});
 
@@ -208,7 +208,7 @@ describe('dataStoreAggregate', () => {
 
 			// ASSERT
 			expect(result.data.length).toBe(1);
-			expect([ds1!.id, ds2!.id, ds3!.id]).toContain(result.data[0].id);
+			expect([ds1.id, ds2.id, ds3.id]).toContain(result.data[0].id);
 			expect(result.count).toBe(3);
 		});
 	});

--- a/packages/cli/src/modules/data-store/__tests__/data-store.service.test.ts
+++ b/packages/cli/src/modules/data-store/__tests__/data-store.service.test.ts
@@ -54,7 +54,7 @@ describe('dataStore', () => {
 				name,
 				columns: [],
 			});
-			const { id: dataStoreId } = result!;
+			const { id: dataStoreId } = result;
 
 			// ASSERT
 			expect(result).toEqual({
@@ -104,7 +104,7 @@ describe('dataStore', () => {
 				name,
 				columns: [],
 			});
-			const { id: dataStoreId } = result!;
+			const { id: dataStoreId } = result;
 
 			const created = await dataStoreRepository.findOneBy({ name, projectId: project1.id });
 			expect(created?.id).toBe(dataStoreId);
@@ -115,7 +115,7 @@ describe('dataStore', () => {
 				name: 'dataStoreWithColumns',
 				columns: [{ name: 'foo', type: 'string' }],
 			});
-			const { id: dataStoreId } = dataStore!;
+			const { id: dataStoreId } = dataStore;
 
 			await expect(dataStoreService.getColumns(dataStoreId)).resolves.toEqual([
 				{
@@ -154,7 +154,7 @@ describe('dataStore', () => {
 			});
 
 			// ASSERT
-			const { project } = result!;
+			const { project } = result;
 			expect(project.id).toBe(project1.id);
 			expect(project.name).toBe(project1.name);
 		});
@@ -188,7 +188,7 @@ describe('dataStore', () => {
 				name: 'myDataStore1',
 				columns: [],
 			});
-			const { id: dataStoreId, updatedAt } = dataStore!;
+			const { id: dataStoreId, updatedAt } = dataStore;
 
 			// ACT
 			// Wait to get second difference
@@ -222,7 +222,7 @@ describe('dataStore', () => {
 				name: 'myDataStore',
 				columns: [],
 			});
-			const { id: dataStoreId } = dataStore!;
+			const { id: dataStoreId } = dataStore;
 
 			// ACT
 			const result = dataStoreService.updateDataStore(dataStoreId, { name: '' });
@@ -237,7 +237,7 @@ describe('dataStore', () => {
 				name: 'myDataStore1',
 				columns: [],
 			});
-			const { id: dataStoreId } = dataStore!;
+			const { id: dataStoreId } = dataStore;
 
 			// ACT
 			const result = dataStoreService.updateDataStore(dataStoreId, { name: '   aNewName  ' });
@@ -261,7 +261,7 @@ describe('dataStore', () => {
 				name: 'myDataStoreNew',
 				columns: [],
 			});
-			const { id: dataStoreNewId } = dataStoreNew!;
+			const { id: dataStoreNewId } = dataStoreNew;
 
 			// ACT
 			const result = dataStoreService.updateDataStore(dataStoreNewId, { name });
@@ -280,7 +280,7 @@ describe('dataStore', () => {
 				name: 'myDataStore1',
 				columns: [],
 			});
-			const { id: dataStoreId } = dataStore!;
+			const { id: dataStoreId } = dataStore;
 
 			// ACT
 			const result = await dataStoreService.deleteDataStore(dataStoreId);
@@ -319,7 +319,7 @@ describe('dataStore', () => {
 				name: 'dataStoreWithColumns',
 				columns: existingColumns,
 			});
-			const { id: dataStoreId } = dataStore!;
+			const { id: dataStoreId } = dataStore;
 
 			const columns: AddDataStoreColumnDto[] = [
 				{ name: 'myColumn1', type: 'string' },
@@ -404,7 +404,7 @@ describe('dataStore', () => {
 				name: 'dataStore',
 				columns: [],
 			});
-			const { id: dataStoreId } = dataStore!;
+			const { id: dataStoreId } = dataStore;
 
 			// ACT
 			const result = await dataStoreService.addColumn(dataStoreId, {
@@ -437,7 +437,7 @@ describe('dataStore', () => {
 					},
 				],
 			});
-			const { id: dataStoreId } = dataStore!;
+			const { id: dataStoreId } = dataStore;
 
 			// ACT
 			const result = dataStoreService.addColumn(dataStoreId, {
@@ -472,7 +472,7 @@ describe('dataStore', () => {
 				name: 'dataStore',
 				columns: [],
 			});
-			const { id: dataStoreId } = dataStore!;
+			const { id: dataStoreId } = dataStore;
 
 			const c1 = await dataStoreService.addColumn(dataStoreId, {
 				name: 'myColumn1',
@@ -515,7 +515,7 @@ describe('dataStore', () => {
 					},
 				],
 			});
-			const { id: dataStoreId } = dataStore!;
+			const { id: dataStoreId } = dataStore;
 
 			// ACT
 			const result = dataStoreService.deleteColumn(dataStoreId, 'thisIsNotAnId');
@@ -532,7 +532,7 @@ describe('dataStore', () => {
 				name: 'dataStore',
 				columns: [],
 			});
-			const c1 = await dataStoreService.addColumn(dataStore!.id, {
+			const c1 = await dataStoreService.addColumn(dataStore.id, {
 				name: 'myColumn1',
 				type: 'string',
 			});
@@ -554,7 +554,7 @@ describe('dataStore', () => {
 				name: 'dataStore',
 				columns: [],
 			});
-			const { id: dataStoreId } = dataStore!;
+			const { id: dataStoreId } = dataStore;
 
 			const c1 = await dataStoreService.addColumn(dataStoreId, {
 				name: 'myColumn1',
@@ -600,7 +600,7 @@ describe('dataStore', () => {
 				name: 'dataStore',
 				columns: [],
 			});
-			const { name } = dataStore!;
+			const { name } = dataStore;
 
 			// ACT
 			const result = await dataStoreService.getManyAndCount({
@@ -629,13 +629,13 @@ describe('dataStore', () => {
 				name: 'myDataStore1',
 				columns: [],
 			});
-			const { id: dataStoreId1 } = dataStore1!;
+			const { id: dataStoreId1 } = dataStore1;
 
 			const dataStore2 = await dataStoreService.createDataStore(project1.id, {
 				name: 'myDataStore2',
 				columns: [],
 			});
-			const { id: dataStoreId2 } = dataStore2!;
+			const { id: dataStoreId2 } = dataStore2;
 
 			// ACT
 			const result = await dataStoreService.getManyAndCount({
@@ -663,14 +663,14 @@ describe('dataStore', () => {
 				name: 'myDataStore',
 				columns: [],
 			});
-			const { name } = dataStore!;
+			const { name } = dataStore;
 			const names = [name];
 			for (let i = 0; i < 10; ++i) {
 				const ds = await dataStoreService.createDataStore(project1.id, {
 					name: `anotherDataStore${i}`,
 					columns: [],
 				});
-				names.push(ds!.name);
+				names.push(ds.name);
 			}
 
 			// ACT
@@ -689,7 +689,7 @@ describe('dataStore', () => {
 				name: 'myDataStore',
 				columns: [],
 			});
-			const { name } = dataStore!;
+			const { name } = dataStore;
 			const names = [name];
 
 			for (let i = 0; i < 10; ++i) {
@@ -697,7 +697,7 @@ describe('dataStore', () => {
 					name: `anotherDataStore${i}`,
 					columns: [],
 				});
-				names.push(ds!.name);
+				names.push(ds.name);
 			}
 
 			// ACT
@@ -748,7 +748,7 @@ describe('dataStore', () => {
 				name: 'myDataStore',
 				columns,
 			});
-			const { id: dataStoreId } = dataStore!;
+			const { id: dataStoreId } = dataStore;
 
 			// ACT
 			const result = await dataStoreService.getManyAndCount({
@@ -887,7 +887,7 @@ describe('dataStore', () => {
 					name: 'ds1',
 					columns: [],
 				});
-				const { id: ds1Id } = ds1!;
+				const { id: ds1Id } = ds1;
 
 				// Wait to get seconds difference
 				await new Promise((resolve) => setTimeout(resolve, 1001));
@@ -930,7 +930,7 @@ describe('dataStore', () => {
 					{ name: 'c4', type: 'string' },
 				],
 			});
-			const { id: dataStoreId } = dataStore!;
+			const { id: dataStoreId } = dataStore;
 
 			// ACT
 			const rows = [
@@ -966,7 +966,7 @@ describe('dataStore', () => {
 					{ name: 'c2', type: 'string' },
 				],
 			});
-			const { id: dataStoreId } = dataStore!;
+			const { id: dataStoreId } = dataStore;
 
 			// Insert initial row
 			await dataStoreService.insertRows(dataStoreId, [{ c1: 1, c2: 'foo' }]);
@@ -1000,7 +1000,7 @@ describe('dataStore', () => {
 					{ name: 'c4', type: 'string' },
 				],
 			});
-			const { id: dataStoreId } = dataStore!;
+			const { id: dataStoreId } = dataStore;
 
 			// ACT
 			const result = dataStoreService.insertRows(dataStoreId, [
@@ -1023,7 +1023,7 @@ describe('dataStore', () => {
 					{ name: 'c4', type: 'string' },
 				],
 			});
-			const { id: dataStoreId } = dataStore!;
+			const { id: dataStoreId } = dataStore;
 
 			// ACT
 			const result = dataStoreService.insertRows(dataStoreId, [
@@ -1046,7 +1046,7 @@ describe('dataStore', () => {
 					{ name: 'c4', type: 'string' },
 				],
 			});
-			const { id: dataStoreId } = dataStore!;
+			const { id: dataStoreId } = dataStore;
 
 			// ACT
 			const result = dataStoreService.insertRows(dataStoreId, [
@@ -1098,7 +1098,7 @@ describe('dataStore', () => {
 				name: 'dataStore',
 				columns: [{ name: 'c1', type: 'number' }],
 			});
-			const { id: dataStoreId } = dataStore!;
+			const { id: dataStoreId } = dataStore;
 
 			// ACT
 			const result = dataStoreService.insertRows(dataStoreId, [{ c1: 3 }, { c1: true }]);
@@ -1119,7 +1119,7 @@ describe('dataStore', () => {
 					{ name: 'age', type: 'number' },
 				],
 			});
-			const { id: dataStoreId } = dataStore!;
+			const { id: dataStoreId } = dataStore;
 
 			// Insert initial row
 			await dataStoreService.insertRows(dataStoreId, [
@@ -1154,7 +1154,7 @@ describe('dataStore', () => {
 					{ name: 'age', type: 'number' },
 				],
 			});
-			const { id: dataStoreId } = dataStore!;
+			const { id: dataStoreId } = dataStore;
 
 			// Insert initial row
 			await dataStoreService.insertRows(dataStoreId, [
@@ -1195,7 +1195,7 @@ describe('dataStore', () => {
 					{ name: 'c4', type: 'string' },
 				],
 			});
-			const { id: dataStoreId } = dataStore!;
+			const { id: dataStoreId } = dataStore;
 
 			const rows = [
 				{ c1: 3, c2: true, c3: new Date(0), c4: 'hello?' },

--- a/packages/cli/src/modules/data-store/data-store-rows.repository.ts
+++ b/packages/cli/src/modules/data-store/data-store-rows.repository.ts
@@ -135,7 +135,7 @@ export class DataStoreRowsRepository {
 
 	async getManyAndCount(dataStoreId: DataStoreUserTableName, dto: ListDataStoreContentQueryDto) {
 		const [countQuery, query] = this.getManyQuery(dataStoreId, dto);
-		const data: Array<Record<string, unknown>> = await query.select('*').getRawMany();
+		const data: DataStoreRows = await query.select('*').getRawMany();
 		const countResult = await countQuery.select('COUNT(*) as count').getRawOne<{
 			count: number | string | null;
 		}>();

--- a/packages/cli/src/modules/data-store/data-store.repository.ts
+++ b/packages/cli/src/modules/data-store/data-store.repository.ts
@@ -65,14 +65,10 @@ export class DataStoreRepository extends Repository<DataStore> {
 			throw new UnexpectedError('Data store creation failed');
 		}
 
-		const createdDataStore = await this.findOne({
+		const createdDataStore = await this.findOneOrFail({
 			where: { id: dataStoreId },
 			relations: ['project', 'columns'],
 		});
-
-		if (!createdDataStore) {
-			throw new UnexpectedError('Failed to retrieve created data store');
-		}
 
 		return createdDataStore;
 	}

--- a/packages/cli/src/modules/data-store/data-store.repository.ts
+++ b/packages/cli/src/modules/data-store/data-store.repository.ts
@@ -65,10 +65,16 @@ export class DataStoreRepository extends Repository<DataStore> {
 			throw new UnexpectedError('Data store creation failed');
 		}
 
-		return await this.findOne({
+		const createdDataStore = await this.findOne({
 			where: { id: dataStoreId },
 			relations: ['project', 'columns'],
 		});
+
+		if (!createdDataStore) {
+			throw new UnexpectedError('Failed to retrieve created data store');
+		}
+
+		return createdDataStore;
 	}
 
 	async deleteDataStore(dataStoreId: string, entityManager?: EntityManager) {

--- a/packages/cli/src/modules/data-store/data-store.service.ts
+++ b/packages/cli/src/modules/data-store/data-store.service.ts
@@ -157,8 +157,22 @@ export class DataStoreService {
 		return await this.dataStoreColumnRepository.getColumns(dataStoreId);
 	}
 
+	async insertRows(dataStoreId: string, rows: DataStoreRows) {
+		await this.validateRows(dataStoreId, rows);
+		const columns = await this.dataStoreColumnRepository.getColumns(dataStoreId);
+
+		return await this.dataStoreRowsRepository.insertRows(toTableName(dataStoreId), rows, columns);
+	}
+
+	async upsertRows(dataStoreId: string, dto: UpsertDataStoreRowsDto) {
+		await this.validateRows(dataStoreId, dto.rows);
+		const columns = await this.dataStoreColumnRepository.getColumns(dataStoreId);
+
+		return await this.dataStoreRowsRepository.upsertRows(toTableName(dataStoreId), dto, columns);
+	}
+
 	// TODO: move to utils and test
-	private normalizeRows(rows: Array<Record<string, unknown>>, columns: DataStoreColumn[]) {
+	private normalizeRows(rows: DataStoreRows, columns: DataStoreColumn[]): DataStoreRows {
 		const typeMap = new Map(columns.map((col) => [col.name, col.type]));
 		return rows.map((row) => {
 			const normalized = { ...row };
@@ -237,20 +251,6 @@ export class DataStoreService {
 				}
 			}
 		}
-	}
-
-	async insertRows(dataStoreId: string, rows: DataStoreRows) {
-		await this.validateRows(dataStoreId, rows);
-		const columns = await this.dataStoreColumnRepository.getColumns(dataStoreId);
-
-		return await this.dataStoreRowsRepository.insertRows(toTableName(dataStoreId), rows, columns);
-	}
-
-	async upsertRows(dataStoreId: string, dto: UpsertDataStoreRowsDto) {
-		await this.validateRows(dataStoreId, dto.rows);
-		const columns = await this.dataStoreColumnRepository.getColumns(dataStoreId);
-
-		return await this.dataStoreRowsRepository.upsertRows(toTableName(dataStoreId), dto, columns);
 	}
 
 	private async validateDataStoreExists(dataStoreId: string, msg?: string) {


### PR DESCRIPTION
## Summary

- `getManyAndCount` of rows repository returns now data as `DataStoreRows`
- `createDataStore` does not return `null` anymore

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3914/be-fix-types-for-data-store-endpoints

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
