### PR TITLE
ci: Update config to match PR convention

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -57,7 +57,13 @@
 		},
 		{
 			"description": "Group testing packages",
-			"matchPackageNames": ["*vitest*", "*playwright*", "*cypress*", "@testing-library/**"],
+			"matchPackageNames": [
+				"*vitest*",
+				"*playwright*",
+				"*cypress*",
+				"@testing-library/**",
+				"*jest*"
+			],
 			"groupName": "testing packages"
 		},
 		{
@@ -77,10 +83,10 @@
 	"osvVulnerabilityAlerts": true,
 	"labels": ["dependencies"],
 	"branchPrefix": "renovate/",
-	"commitMessagePrefix": "chore(deps): ",
+	"commitMessagePrefix": "chore: ",
 	"commitMessageTopic": "{{depName}}",
 	"commitMessageExtra": "to {{newVersion}}",
-	"commitMessageAction": "update",
+	"commitMessageAction": "Update",
 	"ignoreDeps": [],
 	"ignorePaths": ["**/node_modules/**", "**/dist/**", "**/build/**"],
 	"enabledManagers": ["npm", "dockerfile", "github-actions"],


### PR DESCRIPTION
## Summary

PR's made by Renovate don't match our PR convention, slight update to make them match.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
