### PR TITLE
fix: Add missing type check, updated turbo config

### DIFF
--- a/packages/frontend/editor-ui/src/features/dataStore/components/DataStoreBreadcrumbs.vue
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/DataStoreBreadcrumbs.vue
@@ -17,7 +17,7 @@ type Props = {
 
 const props = defineProps<Props>();
 
-const renameInput = useTemplateRef('renameInput');
+const renameInput = useTemplateRef<{ forceFocus: () => void }>('renameInput');
 
 const dataStoreStore = useDataStoreStore();
 

--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,7 @@
 			"outputs": ["dist/**"]
 		},
 		"typecheck": {
-			"dependsOn": ["^typecheck"]
+			"dependsOn": ["^typecheck", "^build"]
 		},
 		"format": {},
 		"format:check": {},


### PR DESCRIPTION
## Summary

Turbo typecheck will now depend on build explicitly, even though previously we were already building there can still be some cache discrepencies between the tasks.

## Related Linear tickets, Github issues, and Community forum posts



## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
