### PR TITLE
Fix Wordpress getAll implementation: filter for post_status

### DIFF
--- a/packages/nodes-base/nodes/Wordpress/Wordpress.node.ts
+++ b/packages/nodes-base/nodes/Wordpress/Wordpress.node.ts
@@ -297,7 +297,7 @@ export class Wordpress implements INodeType {
 							qs.sticky = options.sticky as boolean;
 						}
 						if (options.status) {
-							qs.status = options.status as string;
+							qs.post_status = options.status as string;
 						}
 						if (returnAll) {
 							responseData = await wordpressApiRequestAllItems.call(this, 'GET', '/posts', {}, qs);


### PR DESCRIPTION
## Summary

The wordpress implementation for getAll (filter for status) is incorrectly implemented. The parameter must be "post_status", not "status".

