### PR TITLE
build: Only enable no-argument-spread lint rule in node packages

### DIFF
--- a/packages/@n8n/eslint-config/src/plugin.ts
+++ b/packages/@n8n/eslint-config/src/plugin.ts
@@ -24,7 +24,6 @@ export const localRulesPlugin = {
 				'n8n-local-rules/no-interpolation-in-regular-string': 'error',
 				'n8n-local-rules/no-unused-param-in-catch-clause': 'error',
 				'n8n-local-rules/no-useless-catch-throw': 'error',
-				'n8n-local-rules/no-argument-spread': 'warn', // TODO: mark error
 			},
 		},
 	},

--- a/packages/@n8n/nodes-langchain/eslint.config.mjs
+++ b/packages/@n8n/nodes-langchain/eslint.config.mjs
@@ -9,17 +9,19 @@ export default defineConfig(
 			// TODO: remove all the following rules
 			eqeqeq: 'warn',
 			'id-denylist': 'warn',
-			'import-x/extensions': 'warn',
-			'prefer-spread': 'warn',
 			'no-case-declarations': 'warn',
 			'no-extra-boolean-cast': 'warn',
 			'no-empty': 'warn',
 			'no-prototype-builtins': 'warn',
-			'import-x/order': 'warn',
-			'@typescript-eslint/no-unnecessary-type-assertion': 'warn',
 			'no-async-promise-executor': 'warn',
 			'no-useless-escape': 'warn',
 
+			'import-x/order': 'warn',
+			'import-x/extensions': 'warn',
+
+			'n8n-local-rules/no-argument-spread': 'warn', // TODO: mark error
+
+			'@typescript-eslint/no-unnecessary-type-assertion': 'warn',
 			'@typescript-eslint/naming-convention': ['error', { selector: 'memberLike', format: null }],
 			'@typescript-eslint/no-explicit-any': 'warn', //812 warnings, better to fix in separate PR
 			'@typescript-eslint/no-non-null-assertion': 'warn', //665 errors, better to fix in separate PR

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -2,7 +2,6 @@
 
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable id-denylist */
-/* eslint-disable prefer-spread */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
 import { Logger } from '@n8n/backend-common';

--- a/packages/frontend/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/frontend/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
@@ -586,7 +586,7 @@ function getParentTypes(name: string): string[] {
 	const types: string[] = [];
 	for (const typeName of type.extends) {
 		types.push(typeName);
-		types.push.apply(types, getParentTypes(typeName)); // eslint-disable-line prefer-spread
+		types.push.apply(types, getParentTypes(typeName));
 	}
 
 	return types;

--- a/packages/nodes-base/eslint.config.mjs
+++ b/packages/nodes-base/eslint.config.mjs
@@ -10,7 +10,6 @@ export default defineConfig(
 			// TODO: remove all the following rules
 			eqeqeq: 'warn',
 			'id-denylist': 'warn',
-			'prefer-spread': 'warn',
 			'no-empty': 'warn',
 			'no-useless-escape': 'warn',
 			'no-prototype-builtins': 'warn',
@@ -22,12 +21,16 @@ export default defineConfig(
 			'no-dupe-else-if': 'warn',
 			'no-extra-boolean-cast': 'warn',
 			'no-fallthrough': 'warn',
+
 			'import-x/extensions': 'warn',
 			'import-x/no-default-export': 'warn',
 			'import-x/export': 'warn',
 			'import-x/order': 'warn',
 			'import-x/no-default-export': 'warn',
 			'import-x/no-extraneous-dependencies': 'warn',
+
+			'n8n-local-rules/no-argument-spread': 'warn', // TODO: mark error
+
 			'@typescript-eslint/ban-ts-comment': ['warn', { 'ts-ignore': true }],
 			'@typescript-eslint/naming-convention': ['warn'],
 			'@typescript-eslint/no-explicit-any': 'warn', //812 warnings, better to fix in separate PR

--- a/packages/testing/playwright/utils/path-helper.ts
+++ b/packages/testing/playwright/utils/path-helper.ts
@@ -44,6 +44,5 @@ const playwrightRoot = findProjectRoot('playwright.config.ts');
  * @returns An absolute path to the file or directory.
  */
 export function resolveFromRoot(...pathSegments: string[]): string {
-	// eslint-disable-next-line n8n-local-rules/no-argument-spread
 	return path.join(playwrightRoot, ...pathSegments);
 }

--- a/packages/workflow/src/node-helpers.ts
+++ b/packages/workflow/src/node-helpers.ts
@@ -2,7 +2,6 @@
 
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
-/* eslint-disable prefer-spread */
 import get from 'lodash/get';
 import isEqual from 'lodash/isEqual';
 


### PR DESCRIPTION
## Summary

Only enable `n8n-local-rules/no-argument-spread` rule in node packages

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
