### PR TITLE
fix(editor): Fix schema view output index filtering 

### DIFF
--- a/packages/frontend/editor-ui/src/components/VirtualSchema.vue
+++ b/packages/frontend/editor-ui/src/components/VirtualSchema.vue
@@ -117,11 +117,24 @@ const getNodeSchema = async (fullNode: INodeUi, connectedNode: IConnectedNode) =
 		}))
 		.filter(({ runIndex }) => runIndex !== -1);
 
-	// If outputIndex is specified, only use data from that specific output branch
-	const filteredOutputsWithData =
-		props.outputIndex !== undefined
-			? connectedOutputsWithData.filter(({ outputIndex }) => outputIndex === props.outputIndex)
-			: connectedOutputsWithData;
+	// For connected nodes with multiple outputs that connect to the current node,
+	// filter by outputIndex if it's specified and matches one of the connected outputs
+	// This ensures we show the correct branch when viewing multi-output nodes like SplitInBatches
+	let filteredOutputsWithData = connectedOutputsWithData;
+
+	// Only apply outputIndex filtering if:
+	// 1. outputIndex is specified
+	// 2. The node has multiple connected outputs
+	// 3. The specified outputIndex is one of the connected outputs
+	if (
+		props.outputIndex !== undefined &&
+		connectedOutputIndexes.length > 1 &&
+		connectedOutputIndexes.includes(props.outputIndex)
+	) {
+		filteredOutputsWithData = connectedOutputsWithData.filter(
+			({ outputIndex }) => outputIndex === props.outputIndex,
+		);
+	}
 
 	const nodeData = filteredOutputsWithData
 		.map(({ outputIndex, runIndex }) =>


### PR DESCRIPTION
## Summary

When viewing a node's input panel in schema view, connected nodes would incorrectly appear empty if the current node had a non-zero output index selected. This occurred because the current node's `outputIndex` was being incorrectly applied to filter all connected nodes' outputs.

## Root Cause
The `outputIndex` prop (representing which output branch of the current node is selected) was being universally applied to filter data from all connected nodes, even though it should only affect multi-output nodes that have multiple connections to the current node.

## Fix
Modified the filtering logic in `VirtualSchema.vue` to:
- Only apply `outputIndex` filtering to nodes with multiple connected outputs
- Only filter when the `outputIndex` matches one of the actually connected outputs (`indicies`)
- Leave single-output connections unfiltered

This ensures each node displays the correct data based on actual workflow connections, regardless of the viewing node's selected output.


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
https://linear.app/n8n/issue/ADO-3909/community-issue-switch-node-malfunction-output-data-not-shown-for

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
