### PR TITLE
fix(core): Redact secrets from credential test error message

### DIFF
--- a/packages/cli/src/services/__tests__/credentials-tester.service.test.ts
+++ b/packages/cli/src/services/__tests__/credentials-tester.service.test.ts
@@ -85,7 +85,9 @@ describe('CredentialsTester', () => {
 				...computedCredentialsData,
 				testNestedData: {
 					...computedCredentialsData.testNestedData,
-					apiKey: '{{ $secrets.apiKey }}',
+					secretData: {
+						apiKey: '{{ $secrets.apiKey }}',
+					},
 				},
 			};
 			const redactedMessage = await credentialsTester.testCredentials(

--- a/packages/cli/src/services/__tests__/credentials-tester.service.test.ts
+++ b/packages/cli/src/services/__tests__/credentials-tester.service.test.ts
@@ -1,19 +1,28 @@
 import mock from 'jest-mock-extended/lib/Mock';
-import type { ICredentialType, INodeType } from 'n8n-workflow';
+import type {
+	ICredentialsDecrypted,
+	ICredentialType,
+	INodeCredentialTestResult,
+	INodeType,
+	IWorkflowExecuteAdditionalData,
+} from 'n8n-workflow';
 
 import type { CredentialTypes } from '@/credential-types';
+import type { CredentialsHelper } from '@/credentials-helper';
 import type { NodeTypes } from '@/node-types';
 import { CredentialsTester } from '@/services/credentials-tester.service';
+import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
 
 describe('CredentialsTester', () => {
 	const credentialTypes = mock<CredentialTypes>();
 	const nodeTypes = mock<NodeTypes>();
+	const credentialsHelper = mock<CredentialsHelper>();
 	const credentialsTester = new CredentialsTester(
 		mock(),
 		mock(),
 		credentialTypes,
 		nodeTypes,
-		mock(),
+		credentialsHelper,
 	);
 
 	beforeEach(() => {
@@ -35,5 +44,101 @@ describe('CredentialsTester', () => {
 		if (typeof testFn !== 'function') fail();
 
 		expect(testFn.name).toBe('oauth2CredTest');
+	});
+
+	describe('testCredentials', () => {
+		const testCredentialsFunctionReturn: INodeCredentialTestResult = {
+			status: 'Error',
+			message: 'Test failed for apiKey secret_api_key',
+		};
+
+		beforeEach(() => {
+			credentialTypes.getByName.mockReturnValue(mock<ICredentialType>({ test: undefined }));
+			credentialTypes.getSupportedNodes.mockReturnValue(['testCredentials']);
+			credentialTypes.getParentTypes.mockReturnValue([]);
+			nodeTypes.getByName.mockReturnValue(
+				mock<INodeType>({
+					methods: {
+						credentialTest: {
+							testCredentialsFunction: async (credentials: ICredentialsDecrypted) =>
+								testCredentialsFunctionReturn,
+						},
+					},
+					description: {
+						credentials: [{ name: 'testCredentials', testedBy: 'testCredentialsFunction' }],
+					},
+				}),
+			);
+			jest
+				.spyOn(WorkflowExecuteAdditionalData, 'getBase')
+				.mockResolvedValue({} as IWorkflowExecuteAdditionalData);
+		});
+
+		it('should redact secrets in error messages', async () => {
+			const computedCredentialsData = {
+				testNestedData: {
+					access_token: 'abc123',
+					secretData: {
+						apiKey: 'secret_api_key',
+					},
+				},
+			};
+			credentialsHelper.applyDefaultsAndOverwrites.mockResolvedValue(computedCredentialsData);
+
+			const rawCredentialsData = {
+				...computedCredentialsData,
+				testNestedData: {
+					...computedCredentialsData.testNestedData,
+					apiKey: '{{ $secrets.apiKey }}',
+				},
+			};
+			const redactedMessage = await credentialsTester.testCredentials(
+				'user-id',
+				'testCredentials',
+				{
+					id: 'credential-id',
+					name: 'credential-name',
+					type: 'oAuth2Api',
+					data: rawCredentialsData,
+				},
+			);
+
+			expect(redactedMessage.status).toBe('Error');
+			expect(redactedMessage.message).toBe('Test failed for apiKey *****key');
+		});
+
+		it('should not redact secrets with value shorter than 3 characters', async () => {
+			const computedCredentialsData = {
+				testNestedData: {
+					access_token: 'abc123',
+					secretData: {
+						apiKey: 'se',
+					},
+				},
+			};
+			credentialsHelper.applyDefaultsAndOverwrites.mockResolvedValue(computedCredentialsData);
+
+			const rawCredentialsData = {
+				...computedCredentialsData,
+				testNestedData: {
+					...computedCredentialsData.testNestedData,
+					apiKey: '{{ $secrets.apiKey }}',
+				},
+			};
+			testCredentialsFunctionReturn.message = 'Test failed for apiKey se';
+			const redactedMessage = await credentialsTester.testCredentials(
+				'user-id',
+				'testCredentials',
+				{
+					id: 'credential-id',
+					name: 'credential-name',
+					type: 'oAuth2Api',
+					data: rawCredentialsData,
+				},
+			);
+
+			expect(redactedMessage.status).toBe('Error');
+			expect(redactedMessage.message).toBe('Test failed for apiKey se');
+		});
 	});
 });

--- a/packages/cli/src/services/__tests__/credentials-tester.service.test.ts
+++ b/packages/cli/src/services/__tests__/credentials-tester.service.test.ts
@@ -1,6 +1,5 @@
 import mock from 'jest-mock-extended/lib/Mock';
 import type {
-	ICredentialsDecrypted,
 	ICredentialType,
 	INodeCredentialTestResult,
 	INodeType,
@@ -60,8 +59,7 @@ describe('CredentialsTester', () => {
 				mock<INodeType>({
 					methods: {
 						credentialTest: {
-							testCredentialsFunction: async (credentials: ICredentialsDecrypted) =>
-								testCredentialsFunctionReturn,
+							testCredentialsFunction: async () => testCredentialsFunctionReturn,
 						},
 					},
 					description: {

--- a/packages/cli/src/services/credentials-tester.service.ts
+++ b/packages/cli/src/services/credentials-tester.service.ts
@@ -86,7 +86,10 @@ const getAllKeys = (
 const getAllKeyValuesAsString = (obj: unknown, keys: string[]): string[] => {
 	const result: string[] = [];
 	if (Array.isArray(obj)) {
-		result.push(...obj.flatMap((item) => getAllKeyValuesAsString(item, keys)));
+		result.push.apply(
+			result,
+			obj.flatMap((item) => getAllKeyValuesAsString(item, keys)),
+		);
 	} else if (typeof obj === 'object' && obj !== null) {
 		Object.keys(obj).forEach((key) => {
 			// Check if the key is in the list of keys to filter
@@ -96,7 +99,10 @@ const getAllKeyValuesAsString = (obj: unknown, keys: string[]): string[] => {
 					result.push(value.toString());
 				}
 			} else {
-				result.push(...getAllKeyValuesAsString((obj as Record<string, unknown>)[key], keys));
+				result.push.apply(
+					result,
+					getAllKeyValuesAsString((obj as Record<string, unknown>)[key], keys),
+				);
 			}
 		});
 	}
@@ -216,6 +222,8 @@ export class CredentialsTester {
 			// Filter out short values as it's obviously either an error
 			// or a "debug" value that we do not want to redact
 			.filter((value) => value.length > 3)
+			// Sort by descending length to avoid partial redaction of longer secrets
+			.sort((a, b) => b.length - a.length)
 			.forEach((value) => {
 				message = message.replaceAll(value, `*****${value.slice(-3)}`);
 			});

--- a/packages/cli/src/services/credentials-tester.service.ts
+++ b/packages/cli/src/services/credentials-tester.service.ts
@@ -35,6 +35,7 @@ import { CredentialsHelper } from '../credentials-helper';
 import { CredentialTypes } from '@/credential-types';
 import { NodeTypes } from '@/node-types';
 import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
+import { getAllKeys, getAllKeyValuesAsString } from '@/utils';
 
 const { OAUTH2_CREDENTIAL_TEST_SUCCEEDED, OAUTH2_CREDENTIAL_TEST_FAILED } = RESPONSE_ERROR_MESSAGES;
 
@@ -62,51 +63,6 @@ const mockNodeTypes: INodeTypes = {
 		}
 		return NodeHelpers.getVersionedNodeType(mockNodesData[nodeType].type, version);
 	},
-};
-
-// This function recursively get all keys of an object / array
-// Filtered by the provided value filter
-const getAllKeys = (
-	obj: unknown,
-	keys: string[],
-	valueFilter: (value: string) => boolean,
-): string[] => {
-	if (Array.isArray(obj)) {
-		obj.forEach((item) => getAllKeys(item, keys, valueFilter));
-	} else if (obj && typeof obj === 'object') {
-		for (const [key, value] of Object.entries(obj)) {
-			if (typeof value === 'string' && valueFilter(value)) keys.push(key);
-			else getAllKeys(value, keys, valueFilter);
-		}
-	}
-	return keys;
-};
-
-// This function gets all stringified values of an object, filtered by the provided keys subset
-const getAllKeyValuesAsString = (obj: unknown, keys: string[]): string[] => {
-	const result: string[] = [];
-	if (Array.isArray(obj)) {
-		result.push.apply(
-			result,
-			obj.flatMap((item) => getAllKeyValuesAsString(item, keys)),
-		);
-	} else if (typeof obj === 'object' && obj !== null) {
-		Object.keys(obj).forEach((key) => {
-			// Check if the key is in the list of keys to filter
-			if (keys.includes(key)) {
-				const value = (obj as Record<string, unknown>)[key];
-				if (typeof value !== 'undefined' && value !== null) {
-					result.push(value.toString());
-				}
-			} else {
-				result.push.apply(
-					result,
-					getAllKeyValuesAsString((obj as Record<string, unknown>)[key], keys),
-				);
-			}
-		});
-	}
-	return result;
 };
 
 @Service()

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -92,3 +92,58 @@ export const shouldAssignExecuteMethod = (nodeType: INodeType) => {
 		(!nodeType.methods || isDeclarativeNode)
 	);
 };
+
+/**
+ * Recursively gets all keys of an object or array, filtered by the provided value filter.
+ * @param obj - The object or array to search.
+ * @param keys - The array to store matching keys.
+ * @param valueFilter - A function to filter values.
+ * @returns The array of matching keys.
+ */
+export const getAllKeys = (
+	obj: unknown,
+	keys: string[],
+	valueFilter: (value: string) => boolean,
+): string[] => {
+	if (Array.isArray(obj)) {
+		obj.forEach((item) => getAllKeys(item, keys, valueFilter));
+	} else if (obj && typeof obj === 'object') {
+		for (const [key, value] of Object.entries(obj)) {
+			if (typeof value === 'string' && valueFilter(value)) keys.push(key);
+			else getAllKeys(value, keys, valueFilter);
+		}
+	}
+	return keys;
+};
+
+/**
+ * Gets all stringified values of an object, filtered by the provided keys subset.
+ * @param obj - The object or array to search.
+ * @param keys - The subset of keys to filter.
+ * @returns An array of stringified values for the matching keys.
+ */
+export const getAllKeyValuesAsString = (obj: unknown, keys: string[]): string[] => {
+	const result: string[] = [];
+	if (Array.isArray(obj)) {
+		result.push.apply(
+			result,
+			obj.flatMap((item) => getAllKeyValuesAsString(item, keys)),
+		);
+	} else if (typeof obj === 'object' && obj !== null) {
+		Object.keys(obj).forEach((key) => {
+			// Check if the key is in the list of keys to filter
+			if (keys.includes(key)) {
+				const value = (obj as Record<string, unknown>)[key];
+				if (typeof value !== 'undefined' && value !== null) {
+					result.push(value.toString());
+				}
+			} else {
+				result.push.apply(
+					result,
+					getAllKeyValuesAsString((obj as Record<string, unknown>)[key], keys),
+				);
+			}
+		});
+	}
+	return result;
+};


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR redacts the secrets value potentially revealed in credential test error message. It does so by extracting the credentials data fields that were replaced by secrets, and replacing those secret values in the error message with a mask

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
https://linear.app/n8n/issue/PAY-3223/postgres-error-message-reveals-external-vault-expressions


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
