### PR TITLE
fix(Airtable Node): Create record: skip type validation when typecast is enabled

### DIFF
--- a/packages/nodes-base/nodes/Airtable/test/v2/node/helpers.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/helpers.ts
@@ -15,23 +15,25 @@ export const node: INode = {
 
 export const createMockExecuteFunction = (nodeParameters: IDataObject) => {
 	const fakeExecuteFunction = {
-		getInputData() {
+		getInputData: jest.fn(() => {
 			return [{ json: {} }];
-		},
-		getNodeParameter(
-			parameterName: string,
-			_itemIndex: number,
-			fallbackValue?: IDataObject,
-			options?: IGetNodeParameterOptions,
-		) {
-			const parameter = options?.extractValue ? `${parameterName}.value` : parameterName;
-			return get(nodeParameters, parameter, fallbackValue);
-		},
-		getNode() {
+		}),
+		getNodeParameter: jest.fn(
+			(
+				parameterName: string,
+				_itemIndex: number,
+				fallbackValue?: IDataObject,
+				options?: IGetNodeParameterOptions,
+			) => {
+				const parameter = options?.extractValue ? `${parameterName}.value` : parameterName;
+				return get(nodeParameters, parameter, fallbackValue);
+			},
+		),
+		getNode: jest.fn(() => {
 			return node;
-		},
-		helpers: { constructExecutionMetaData },
-		continueOnFail: () => false,
+		}),
+		helpers: { constructExecutionMetaData: jest.fn(constructExecutionMetaData) },
+		continueOnFail: jest.fn(() => false),
 	} as unknown as IExecuteFunctions;
 	return fakeExecuteFunction;
 };

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/record/create.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/record/create.test.ts
@@ -154,4 +154,55 @@ describe('Test AirtableV2, create operation', () => {
 			typecast: false,
 		});
 	});
+
+	it('should skip validation if typecast option is true', async () => {
+		const nodeParameters = {
+			operation: 'create',
+			columns: {
+				mappingMode: 'defineBelow',
+				value: {
+					bar: 'bar 1',
+					foo: 'foo 1',
+				},
+				matchingColumns: [],
+				schema: [
+					{
+						id: 'foo',
+						displayName: 'foo',
+						required: false,
+						defaultMatch: false,
+						display: true,
+						type: 'string',
+					},
+					{
+						id: 'bar',
+						displayName: 'bar',
+						required: false,
+						defaultMatch: false,
+						display: true,
+						type: 'string',
+					},
+				],
+			},
+			options: {
+				typecast: true,
+			},
+		};
+
+		const mockExecuteFunctions = createMockExecuteFunction(nodeParameters);
+		await create.execute.call(mockExecuteFunctions, [{ json: {} }], 'appYoLbase', 'tblltable');
+
+		expect(mockExecuteFunctions.getNodeParameter).toHaveBeenCalledWith('columns.value', 0, [], {
+			skipValidation: true,
+		});
+
+		expect(transport.apiRequest).toHaveBeenCalledTimes(1);
+		expect(transport.apiRequest).toHaveBeenCalledWith('POST', 'appYoLbase/tblltable', {
+			fields: {
+				foo: 'foo 1',
+				bar: 'bar 1',
+			},
+			typecast: true,
+		});
+	});
 });

--- a/packages/nodes-base/nodes/Airtable/v2/actions/record/create.operation.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/actions/record/create.operation.ts
@@ -63,17 +63,18 @@ export async function execute(
 	for (let i = 0; i < items.length; i++) {
 		try {
 			const options = this.getNodeParameter('options', i, {});
+			const typecast = Boolean(options.typecast);
 
-			const body: IDataObject = {
-				typecast: options.typecast ? true : false,
-			};
+			const body: IDataObject = { typecast };
 
 			if (dataMode === 'autoMapInputData') {
 				body.fields = removeIgnored(items[i].json, options.ignoreFields as string);
 			}
 
 			if (dataMode === 'defineBelow') {
-				const fields = this.getNodeParameter('columns.value', i, []) as IDataObject;
+				const fields = this.getNodeParameter('columns.value', i, [], {
+					skipValidation: typecast,
+				}) as IDataObject;
 
 				body.fields = fields;
 			}
@@ -85,7 +86,7 @@ export async function execute(
 				{ itemData: { item: i } },
 			);
 
-			returnData.push(...executionData);
+			returnData.push.apply(returnData, executionData);
 		} catch (error) {
 			error = processAirtableError(error as NodeApiError, undefined, i);
 			if (this.continueOnFail()) {


### PR DESCRIPTION
## Summary

Enabling the Typecast option, should allow adding new options to an Airtable (multi-)select field.

<img width="1255" height="1109" alt="image" src="https://github.com/user-attachments/assets/400a4d2f-b72a-478d-b5d3-ea2a341baf2d" />
<img width="1255" height="1109" alt="image" src="https://github.com/user-attachments/assets/b945f9d4-88a7-45fc-87db-fcffaadade8c" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3167/community-issue-airtable-typecast-not-working
fixes #16679
fixes #14338 

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
