### PR TITLE
perf(editor): Improve `executionDataToJson` performance (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/utils/nodeTypesUtils.ts
+++ b/packages/frontend/editor-ui/src/utils/nodeTypesUtils.ts
@@ -100,10 +100,13 @@ export function isValueExpression(
 }
 
 export const executionDataToJson = (inputData: INodeExecutionData[]): IDataObject[] =>
-	inputData.reduce<IDataObject[]>(
-		(acc, item) => (isJsonKeyObject(item) ? acc.concat(item.json) : acc),
-		[],
-	);
+	inputData.reduce<IDataObject[]>((acc, item) => {
+		if (isJsonKeyObject(item)) {
+			acc.push(item.json);
+		}
+
+		return acc;
+	}, []);
 
 export const hasOnlyListMode = (parameter: INodeProperties): boolean => {
 	return (


### PR DESCRIPTION
## Summary

Greatly improves `executionDataToJson` (called when opening NDV and other locations):
- With the previous implementation, we were creating one array of n items for each iteration.
- With the new implementation, we're creating one array of n items for all iterations.

Before (5MB items):

<img width="1257" height="240" alt="Screenshot 2025-08-13 at 16 19 52" src="https://github.com/user-attachments/assets/1b8b4ca1-acf0-4f4e-bf2c-387c3d2251d8" />

After (5MB items):

<img width="889" height="602" alt="image" src="https://github.com/user-attachments/assets/b08de0d1-0898-4e4d-b7c4-47a8dbdca230" />



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1164/improve-executiondatatojson-performance

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
