### PR TITLE
fix(editor): Use native behaviour on arrow left and right in nodes panel

### DIFF
--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/composables/useKeyboardNavigation.ts
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/composables/useKeyboardNavigation.ts
@@ -31,11 +31,21 @@ export const useKeyboardNavigation = defineStore('nodeCreatorKeyboardNavigation'
 			return false;
 		}
 
-		// Allow horizontal arrows for cursor movement when input has content
-		const isHorizontalArrow = key === 'ArrowLeft' || key === 'ArrowRight';
 		const hasContent = target.value.length > 0;
 
-		return isHorizontalArrow && hasContent;
+		// Allow left arrow for cursor movement when input has content
+		if (key === 'ArrowLeft' && hasContent) {
+			return true;
+		}
+
+		// Allow right arrow for cursor movement only when cursor is NOT at the end
+		if (key === 'ArrowRight' && hasContent) {
+			const cursorPosition = target.selectionStart || 0;
+			const isAtEnd = cursorPosition >= target.value.length;
+			return !isAtEnd;
+		}
+
+		return false;
 	}
 
 	function getItemType(element?: Element) {

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/composables/useKeyboardNavigation.ts
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/composables/useKeyboardNavigation.ts
@@ -25,6 +25,19 @@ export const useKeyboardNavigation = defineStore('nodeCreatorKeyboardNavigation'
 	// Array of objects that contains key code and handler
 	const keysHooks = ref<Record<string, KeyHook>>({});
 
+	function shouldAllowNativeInputBehavior(target: EventTarget | null, key: string): boolean {
+		// Only check for input/textarea elements
+		if (!(target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement)) {
+			return false;
+		}
+
+		// Allow horizontal arrows for cursor movement when input has content
+		const isHorizontalArrow = key === 'ArrowLeft' || key === 'ArrowRight';
+		const hasContent = target.value.length > 0;
+
+		return isHorizontalArrow && hasContent;
+	}
+
 	function getItemType(element?: Element) {
 		return element?.getAttribute('data-keyboard-nav-type');
 	}
@@ -74,6 +87,12 @@ export const useKeyboardNavigation = defineStore('nodeCreatorKeyboardNavigation'
 
 		const pressedKey = e.key;
 		if (!WATCHED_KEYS.includes(pressedKey)) return;
+
+		// Allow arrow keys for cursor movement in non-empty input fields
+		if (shouldAllowNativeInputBehavior(e.target, pressedKey)) {
+			return;
+		}
+
 		e.preventDefault();
 		e.stopPropagation();
 


### PR DESCRIPTION
## Summary

https://www.loom.com/share/1730f56ac5694fd3bbd869f2f1554c4f
## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3908/bug-keyboard-arrows-do-not-work-in-nodes-search-input
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
