### PR TITLE
fix(Google Gemini Node): Use custom host from credential

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
@@ -272,7 +272,7 @@ export class McpClientTool implements INodeType {
 		const setError = (message: string, description?: string): SupplyData => {
 			const error = new NodeOperationError(node, message, { itemIndex, description });
 			this.addOutputData(NodeConnectionTypes.AiTool, itemIndex, error);
-			// throw error;
+			throw error;
 		};
 
 		if (!client.ok) {

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
@@ -272,7 +272,7 @@ export class McpClientTool implements INodeType {
 		const setError = (message: string, description?: string): SupplyData => {
 			const error = new NodeOperationError(node, message, { itemIndex, description });
 			this.addOutputData(NodeConnectionTypes.AiTool, itemIndex, error);
-			throw error;
+			// throw error;
 		};
 
 		if (!client.ok) {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/transport/index.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/transport/index.test.ts
@@ -11,7 +11,7 @@ describe('GoogleGemini transport', () => {
 
 	it('should call httpRequestWithAuthentication with correct parameters', async () => {
 		executeFunctionsMock.getCredentials.mockResolvedValue({
-			url: 'https://custom-url.com',
+			host: 'https://custom-url.com',
 		});
 
 		await apiRequest.call(executeFunctionsMock, 'GET', '/v1beta/models', {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/transport/index.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/transport/index.ts
@@ -12,6 +12,11 @@ type RequestParameters = {
 	option?: IDataObject;
 };
 
+type GooglePalmApiCredentials = {
+	host: string;
+	apiKey: string;
+};
+
 export async function apiRequest(
 	this: IExecuteFunctions | ILoadOptionsFunctions,
 	method: IHttpRequestMethods,
@@ -20,12 +25,12 @@ export async function apiRequest(
 ) {
 	const { body, qs, option, headers } = parameters ?? {};
 
-	const credentials = await this.getCredentials('googlePalmApi');
+	const credentials = await this.getCredentials<GooglePalmApiCredentials>('googlePalmApi');
 
 	let url = `https://generativelanguage.googleapis.com${endpoint}`;
 
-	if (credentials.url) {
-		url = `${credentials?.url as string}${endpoint}`;
+	if (credentials.host) {
+		url = `${credentials.host}${endpoint}`;
 	}
 
 	const options = {


### PR DESCRIPTION
## Summary

Use custom host from credential when set

## Related Linear tickets, Github issues, and Community forum posts

fixes #18338
https://linear.app/n8n/issue/NODE-3500/community-issue-google-gemini-node-doesnt-use-custom-host-provided-in


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
