### PR TITLE
fix(core): Account for readonly properties when replacing circular references

### DIFF
--- a/packages/workflow/src/utils.ts
+++ b/packages/workflow/src/utils.ts
@@ -1,12 +1,13 @@
+import { ApplicationError } from '@n8n/errors';
 import { parse as esprimaParse, Syntax } from 'esprima-next';
 import type { Node as SyntaxNode, ExpressionStatement } from 'esprima-next';
 import FormData from 'form-data';
 import merge from 'lodash/merge';
 
 import { ALPHABET } from './constants';
-import { ApplicationError } from '@n8n/errors';
 import { ExecutionCancelledError } from './errors/execution-cancelled.error';
 import type { BinaryFileType, IDisplayOptions, INodeProperties, JsonObject } from './interfaces';
+import * as LoggerProxy from './logger-proxy';
 
 const readStreamClasses = new Set(['ReadStream', 'Readable', 'ReadableStream']);
 
@@ -181,7 +182,16 @@ export const replaceCircularReferences = <T>(value: T, knownObjects = new WeakSe
 	knownObjects.add(value);
 	const copy = (Array.isArray(value) ? [] : {}) as T;
 	for (const key in value) {
-		copy[key] = replaceCircularReferences(value[key], knownObjects);
+		try {
+			copy[key] = replaceCircularReferences(value[key], knownObjects);
+		} catch (error: unknown) {
+			// Skip properties that cannot be assigned to (readonly, non-configurable, etc.)
+			LoggerProxy.error(
+				'Error while replacing circular references: ' +
+					(error instanceof Error ? error.message : 'unknown'),
+				{ error },
+			);
+		}
 	}
 	knownObjects.delete(value);
 	return copy;

--- a/packages/workflow/src/utils.ts
+++ b/packages/workflow/src/utils.ts
@@ -185,12 +185,14 @@ export const replaceCircularReferences = <T>(value: T, knownObjects = new WeakSe
 		try {
 			copy[key] = replaceCircularReferences(value[key], knownObjects);
 		} catch (error: unknown) {
-			// Skip properties that cannot be assigned to (readonly, non-configurable, etc.)
-			LoggerProxy.error(
-				'Error while replacing circular references: ' +
-					(error instanceof Error ? error.message : 'unknown'),
-				{ error },
-			);
+			if (
+				error instanceof TypeError &&
+				error.message.includes('Cannot assign to read only property')
+			) {
+				LoggerProxy.error('Error while replacing circular references: ' + error.message, { error });
+				continue; // Skip properties that cannot be assigned to (readonly, non-configurable, etc.)
+			}
+			throw error;
 		}
 	}
 	knownObjects.delete(value);


### PR DESCRIPTION
## Summary

With runners enabled, a Code node that tries to log an object with a readonly property errors out, because of the assignment when replacing circular references when serializing for the RPC call. This can be reproduced with this Code node script:

```js
const testObj = {};
Object.defineProperty(testObj, 'toString', {
 value: function() { return '[readonly]'; },
 writable: false,
 enumerable: true,
 configurable: false
});

console.log(testObj);

return [];
```

:warning: **Note on testing:** Spent a reasonable amount of time trying to write a Vitest test case that reproduces this scenario, but all my attempts either _always pass_ (before and after fix) or _always fail_ (before and after fix). Let me know if you find a way to test this. Else let's move forward as this is a rare case.

## Related Linear tickets, Github issues, and Community forum posts

#18328

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
