### PR TITLE
fix(n8n Form Trigger Node): Make order of form field name inputs consistent

### DIFF
--- a/packages/nodes-base/nodes/Form/common.descriptions.ts
+++ b/packages/nodes-base/nodes/Form/common.descriptions.ts
@@ -71,6 +71,19 @@ export const formFields: INodeProperties = {
 					},
 				},
 				{
+					displayName: 'Field Name',
+					name: 'fieldName',
+					description:
+						'The name of the field, used in input attributes and referenced by the workflow',
+					type: 'string',
+					default: '',
+					displayOptions: {
+						show: {
+							fieldType: ['hiddenField'],
+						},
+					},
+				},
+				{
 					displayName: 'Element Type',
 					name: 'fieldType',
 					type: 'options',
@@ -150,19 +163,6 @@ export const formFields: INodeProperties = {
 					displayOptions: {
 						hide: {
 							fieldType: ['dropdown', 'date', 'file', 'html', 'hiddenField', 'radio', 'checkbox'],
-						},
-					},
-				},
-				{
-					displayName: 'Field Name',
-					name: 'fieldName',
-					description:
-						'The name of the field, used in input attributes and referenced by the workflow',
-					type: 'string',
-					default: '',
-					displayOptions: {
-						show: {
-							fieldType: ['hiddenField'],
 						},
 					},
 				},


### PR DESCRIPTION
## Summary

Field Name input should not change order when switching between hidden and other input types

<img width="776" height="341" alt="image" src="https://github.com/user-attachments/assets/2658b130-489a-4d7f-b0c4-eeba53d4717a" />
<img width="776" height="341" alt="image" src="https://github.com/user-attachments/assets/ada53d1b-77d7-4e4f-9c69-6648790eaaa9" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3404/form-node-setting-element-type-to-hidden-field-switches-order-of

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
