### PR TITLE
chore: Update ssh2 dependency to 1.16.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -71,7 +71,7 @@
     "pretty-bytes": "5.6.0",
     "proxy-from-env": "^1.1.0",
     "qs": "6.11.0",
-    "ssh2": "1.15.0",
+    "ssh2": "1.16.0",
     "uuid": "catalog:",
     "winston": "3.14.2",
     "xml2js": "catalog:",


### PR DESCRIPTION
## Summary

Updates the ssh2 dependency from version 1.15.0 to 1.16.0 in the n8n-core package. This brings the latest security patches and improvements to the SSH functionality used by n8n.

**Testing**: 
- Verify that SSH/SFTP nodes still work correctly after the update
- Test credential creation and connection testing for SSH-based services

## Related Linear tickets, Github issues, and Community forum posts

Related to: #18395 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!-- Dependency updates typically don't require new tests unless there are breaking changes -->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)