### PR TITLE
fix(core): Update moment-timezone to resolve Mexico DST issue

### DIFF
--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -918,7 +918,7 @@
     "luxon": "catalog:",
     "mailparser": "3.6.7",
     "minifaker": "1.34.1",
-    "moment-timezone": "0.5.37",
+    "moment-timezone": "0.5.48",
     "mongodb": "6.11.0",
     "mqtt": "5.7.2",
     "mssql": "10.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23484,7 +23484,7 @@ snapshots:
       axios: 1.11.0(debug@4.4.1)
       is-retry-allowed: 2.2.0
 
-  axios-retry@4.5.0(axios@1.11.0(debug@4.4.1)):
+  axios-retry@4.5.0(axios@1.11.0):
     dependencies:
       axios: 1.11.0(debug@4.3.6)
       is-retry-allowed: 2.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2919,8 +2919,8 @@ importers:
         specifier: 1.34.1
         version: 1.34.1(patch_hash=bc707e2c34a2464da2c9c93ead33e80fd9883a00434ef64907ddc45208a08b33)
       moment-timezone:
-        specifier: 0.5.37
-        version: 0.5.37
+        specifier: 0.5.48
+        version: 0.5.48
       mongodb:
         specifier: 6.11.0
         version: 6.11.0(@aws-sdk/credential-providers@3.808.0)(gcp-metadata@5.3.0(encoding@0.1.13))(socks@2.8.3)
@@ -12912,8 +12912,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  moment-timezone@0.5.37:
-    resolution: {integrity: sha512-uEDzDNFhfaywRl+vwXxffjjq1q0Vzr+fcQpQ1bU0kbzorfS7zVtZnCnGc8mhWmF39d4g4YriF6kwA75mJKE/Zg==}
+  moment-timezone@0.5.48:
+    resolution: {integrity: sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==}
 
   moment@2.29.4:
     resolution: {integrity: sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==}
@@ -23484,7 +23484,7 @@ snapshots:
       axios: 1.11.0(debug@4.4.1)
       is-retry-allowed: 2.2.0
 
-  axios-retry@4.5.0(axios@1.11.0):
+  axios-retry@4.5.0(axios@1.11.0(debug@4.4.1)):
     dependencies:
       axios: 1.11.0(debug@4.3.6)
       is-retry-allowed: 2.2.0
@@ -29197,7 +29197,7 @@ snapshots:
       requirejs: 2.3.7
       requirejs-config-file: 4.0.0
 
-  moment-timezone@0.5.37:
+  moment-timezone@0.5.48:
     dependencies:
       moment: 2.29.4
 
@@ -31459,7 +31459,7 @@ snapshots:
       mime-types: 2.1.35
       mkdirp: 1.0.4
       moment: 2.29.4
-      moment-timezone: 0.5.37
+      moment-timezone: 0.5.48
       oauth4webapi: 3.5.1
       open: 7.4.2
       python-struct: 1.1.3


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
This PR updates `moment-timezone` dependency from `0.5.37` to `0.5.48` in the `nodes-base` package to fix timezone handling for  Mexico (`America/Mexico_City`). This resolves the issue where Google Calendar events were being scheduled 1 hour off due to outdated DST rules.

Mexico stopped observing Daylight Saving Time in most regions, but the previous `moment-timezone` version still contained the old DST rules, causing calendar events to be incorrectly offset by 1 hour. According to [1062](https://github.com/moment/moment-timezone/issues/1062#issuecomment-1556126530) from `moment-timezone`, version `0.5.40` or later is required to properly handle Mexico's DST changes.


### How to test
```js
const moment = require('./packages/nodes-base/node_modules/moment-timezone');

console.log('Testing Mexico DST Fix');
console.log('moment-timezone version:', require('./packages/nodes-base/node_modules/moment-timezone/package.json').version);
console.log('Required: >= 0.5.40\n');

// Test dates across different seasons
const testDates = [
  '2024-01-15 10:00', // Winter
  '2024-04-15 10:00', // Spring (old DST start)
  '2024-07-15 10:00', // Summer (old DST period)
  '2024-11-15 10:00', // Fall (old DST end)
];

let allPassed = true;

testDates.forEach(date => {
  const mexicoTime = moment.tz(date, 'America/Mexico_City');
  const offset = mexicoTime.format('Z');
  const passed = offset === '-06:00';
  
  console.log(`${date} - Offset: ${offset} ${passed ? 'PASS' : 'FAIL (expected -06:00)'}`);
  
  if (!passed) allPassed = false;
});

console.log('\nResult: ' + (allPassed ? 'All tests passed' : 'Tests failed'));
process.exit(allPassed ? 0 : 1);
```

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
Closes #17941 


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
