### PR TITLE
feat(HTTP Request Node): Add option to disable Gzip compression

### DIFF
--- a/packages/nodes-base/nodes/HttpRequest/V3/Description.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/Description.ts
@@ -1184,6 +1184,14 @@ export const mainProperties: INodeProperties[] = [
 				description:
 					'Time in ms to wait for the server to send response headers (and start the response body) before aborting the request',
 			},
+			{
+				displayName: 'Disable Gzip',
+				name: 'disableGzip',
+				type: 'boolean',
+				default: false,
+				noDataExpression: true,
+				description: 'Disable gzip compression',
+			},
 		],
 	},
 	...optimizeResponseProperties.map((prop) => ({

--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -237,6 +237,7 @@ export class HttpRequestV3 implements INodeType {
 					queryParameterArrays,
 					response,
 					lowercaseHeaders,
+					disableGzip,
 				} = this.getNodeParameter('options', itemIndex, {}) as {
 					batching: { batch: { batchSize: number; batchInterval: number } };
 					proxy: string;
@@ -253,6 +254,7 @@ export class HttpRequestV3 implements INodeType {
 					};
 					redirect: { redirect: { maxRedirects: number; followRedirects: boolean } };
 					lowercaseHeaders: boolean;
+					disableGzip: boolean;
 				};
 
 				responseFileName = response?.response?.outputPropertyName;
@@ -302,6 +304,10 @@ export class HttpRequestV3 implements INodeType {
 
 				if (response?.response?.neverError) {
 					requestOptions.simple = false;
+				}
+
+				if (disableGzip) {
+					requestOptions.gzip = false;
 				}
 
 				if (proxy) {


### PR DESCRIPTION
## Summary

Adds an option to the HTTP Request v3 Node to disable Gzip compression:

<img width="418" height="746" alt="Screenshot 2025-08-16 at 11 28 13" src="https://github.com/user-attachments/assets/381db058-c56a-44c9-a7df-9270270e55d1" />
<img width="418" height="746" alt="Screenshot 2025-08-16 at 11 28 23" src="https://github.com/user-attachments/assets/cfc2e41a-f25f-4ede-8663-9f44b8f7e6bf" />


## Related Linear tickets, Github issues, and Community forum posts

The motivation for this PR started when I was unable to use the [Lexware Office API](https://developers.lexware.io/docs/) (a very popular bookkeeping SaaS in the German-speaking region) because their API ignores compressed requests. The developers confirmed that this is the case and that there is no intention to change this behavior.

I also created a feature request in the community:

https://community.n8n.io/t/add-option-to-disable-gzip-in-http-request/166363

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)