### PR TITLE
fix(core): AI Agent intermediate steps missing in non-streaming mode

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
@@ -184,6 +184,10 @@ function processNonStreamingIntermediateSteps(
 		if (step.action) {
 			processedStep.action = { ...step.action };
 
+			// Generate a consistent toolCallId if missing (only once!)
+			const toolCallId =
+				processedStep.action.toolCallId || `call_${step.action.tool}_${Date.now()}`;
+
 			// Add missing metadata that streaming provides
 			// Note: In non-streaming mode, we don't have access to the full LLM response
 			// with tool_calls, so we construct what we can from available data
@@ -198,8 +202,8 @@ function processNonStreamingIntermediateSteps(
 							{
 								name: step.action.tool,
 								args: step.action.toolInput,
-								// Generate a consistent toolCallId if missing
-								id: step.action.toolCallId || `call_${step.action.tool}_${Date.now()}`,
+								// Use the consistent toolCallId
+								id: toolCallId,
 								type: step.action.type || 'function',
 							},
 						],
@@ -207,10 +211,8 @@ function processNonStreamingIntermediateSteps(
 				];
 			}
 
-			// Ensure toolCallId is present
-			if (!processedStep.action.toolCallId) {
-				processedStep.action.toolCallId = `call_${step.action.tool}_${Date.now()}`;
-			}
+			// Ensure toolCallId is present (use the same generated ID)
+			processedStep.action.toolCallId = toolCallId;
 
 			// Ensure type is present
 			if (!processedStep.action.type) {

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/ToolsAgentV2.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/ToolsAgentV2.test.ts
@@ -638,6 +638,12 @@ describe('toolsAgentExecute', () => {
 			expect(step.action.messageLog[0]).toHaveProperty('content');
 			expect(step.action.messageLog[0]).toHaveProperty('tool_calls');
 			expect(step.action.type).toBe('function');
+
+			// Verify toolCallId consistency between action and messageLog
+			const toolCallInMessage = step.action.messageLog[0].tool_calls[0];
+			expect(step.action.toolCallId).toBe(toolCallInMessage.id);
+			expect(toolCallInMessage.name).toBe('TestTool');
+			expect(toolCallInMessage.args).toEqual({ input: 'test data' });
 		});
 
 		it('should use regular execution on version 2.2 when enableStreaming is false', async () => {

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/ToolsAgentV2.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/ToolsAgentV2.test.ts
@@ -580,6 +580,66 @@ describe('toolsAgentExecute', () => {
 			expect(step.observation).toBe('Tool execution result');
 		});
 
+		it('should capture intermediate steps in non-streaming execution when returnIntermediateSteps is true', async () => {
+			jest.spyOn(helpers, 'getConnectedTools').mockResolvedValue([mock<Tool>()]);
+			jest.spyOn(outputParserModule, 'getOptionalOutputParser').mockResolvedValue(undefined);
+
+			mockContext.getNodeParameter.mockImplementation((param, _i, defaultValue) => {
+				if (param === 'enableStreaming') return false; // Streaming disabled - this is the key condition
+				if (param === 'text') return 'test input';
+				if (param === 'options.batching.batchSize') return defaultValue;
+				if (param === 'options.batching.delayBetweenBatches') return defaultValue;
+				if (param === 'options')
+					return {
+						systemMessage: 'You are a helpful assistant',
+						maxIterations: 10,
+						returnIntermediateSteps: true, // User expects intermediate steps to be shown
+						passthroughBinaryImages: true,
+					};
+				return defaultValue;
+			});
+
+			// Mock executor.invoke to return what LangChain's AgentExecutor actually returns
+			// when returnIntermediateSteps is true in real scenarios
+			const mockExecutor = {
+				invoke: jest.fn().mockResolvedValue({
+					output: 'Final response',
+					intermediateSteps: [
+						{
+							action: {
+								tool: 'TestTool',
+								toolInput: { input: 'test data' },
+								log: 'I need to call a tool',
+							},
+							observation: 'Tool execution result',
+						},
+					],
+				}),
+				streamEvents: jest.fn(),
+			};
+
+			jest.spyOn(AgentExecutor, 'fromAgentAndTools').mockReturnValue(mockExecutor as any);
+
+			const result = await toolsAgentExecute.call(mockContext);
+
+			expect(result[0][0].json.output).toBe('Final response');
+
+			// FIXED: Non-streaming mode now processes intermediate steps consistently
+			// with streaming mode, providing the same rich metadata
+			const step = (result[0][0].json.intermediateSteps as any[])[0];
+
+			// These are now present in non-streaming mode (like in streaming mode):
+			expect(step.action.messageLog).toBeDefined(); // ✓ Fixed: LLM response messages
+			expect(step.action.toolCallId).toBeDefined(); // ✓ Fixed: Tool call ID
+			expect(step.action.type).toBeDefined(); // ✓ Fixed: Tool call type
+
+			// Verify the content structure matches expectations
+			expect(step.action.messageLog).toHaveLength(1);
+			expect(step.action.messageLog[0]).toHaveProperty('content');
+			expect(step.action.messageLog[0]).toHaveProperty('tool_calls');
+			expect(step.action.type).toBe('function');
+		});
+
 		it('should use regular execution on version 2.2 when enableStreaming is false', async () => {
 			jest.spyOn(helpers, 'getConnectedTools').mockResolvedValue([mock<Tool>()]);
 			jest.spyOn(outputParserModule, 'getOptionalOutputParser').mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary

This PR fixes an issue where the AI Agent node V2 was not displaying intermediate steps when
streaming was disabled. Users reported seeing "no intermediate results" even when the `Return
Intermediate Steps` option was enabled.

### What was the problem?
- **Streaming mode**: Properly processed intermediate steps via `processEventStream()` with rich
metadata
- **Non-streaming mode**: Directly returned `executor.invoke()` results without processing, missing
 essential metadata like `messageLog`, `toolCallId`, and `type`

### What this PR does:
- Adds `processNonStreamingIntermediateSteps()` function to process intermediate steps consistently

- Ensures non-streaming execution provides the same rich metadata as streaming mode
- Adds missing fields: `messageLog`, `toolCallId`, and `type` for better UI display
- Includes comprehensive test coverage for the fix

### How to test:
1. Create an AI Agent workflow with tools
2. Disable streaming (`Enable Streaming: false`)
3. Enable `Return Intermediate Steps: true`
4. Execute the workflow
5. Verify intermediate steps are now visible with proper metadata

**Before:** No intermediate steps displayed or missing metadata
**After:** Rich intermediate steps with full LLM reasoning chains

## Related Linear tickets, Github issues, and Community forum posts

Fixes #18419

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
