### PR TITLE
fix: handle channel_id attribute in Slack file_share events

### DIFF
--- a/packages/nodes-base/nodes/Slack/SlackTrigger.node.ts
+++ b/packages/nodes-base/nodes/Slack/SlackTrigger.node.ts
@@ -352,7 +352,8 @@ export class SlackTrigger implements INodeType {
 		}
 
 		if (eventType !== 'team_join') {
-			eventChannel = req.body.event.channel ?? req.body.event.item.channel;
+			eventChannel =
+				req.body.event.channel ?? req.body.event.item?.channel ?? req.body.event.channel_id;
 
 			// Check for single channel
 			if (!watchWorkspace) {


### PR DESCRIPTION
## Summary

This PR fixes a critical bug in the Slack Trigger node where `file_share` events were throwing `TypeError: Cannot read properties of undefined (reading 'channel')` errors. The issue occurred because the `file_share` event structure in Slack uses a `channel_id` attribute that wasn't being handled by the existing channel detection logic.

**Changes made:**
- Added support for `req.body.event.channel_id` as a fallback option when determining the event channel
- Improved null safety with optional chaining for `req.body.event.item?.channel`
- Maintained backward compatibility with existing channel detection logic

**Testing:**
To test this fix:
1. Configure a Slack app with file sharing event subscriptions
2. Set up a workflow with Slack Trigger node listening for file sharing events
3. Upload a file to Slack (any type/size) - single or multiple files
4. Verify the trigger processes the event without errors and captures the file(s) properly

## Related Linear tickets, Github issues, and Community forum posts

- **Fixes #11994**: Slack Trigger node throws errors on `File Shared` event
- **Fixes #18426**: Error when multiple files are sent through Slack
- **Community post**: https://community.n8n.io/t/slack-trigger-throwing-error-on-audio-file-create/92364/3

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)