### PR TITLE
fix(SSH Node): Resolve working directory option failing on Windows server

### DIFF
--- a/packages/nodes-base/nodes/Ssh/Ssh.node.ts
+++ b/packages/nodes-base/nodes/Ssh/Ssh.node.ts
@@ -39,10 +39,9 @@ async function resolveHomeDir(
 	this: IExecuteFunctions,
 	path: string,
 	ssh: NodeSSH,
+	remoteOS: RemoteOS,
 	itemIndex: number,
 ) {
-	const remoteOS = await detectRemoteOS(ssh);
-
 	// Mark Windows absolute paths (C:\, D:/) for special handling
 	if (remoteOS === RemoteOS.Windows && /^[A-Za-z]:[\\\/]/.test(path)) {
 		return `${WINDOWS_PATH_PREFIX}${path}`;
@@ -385,6 +384,9 @@ export class Ssh implements INodeType {
 				await ssh.connect(options);
 			}
 
+			// Detect OS once after connection is established, before processing items
+			const remoteOS = await detectRemoteOS(ssh);
+
 			for (let i = 0; i < items.length; i++) {
 				try {
 					if (resource === 'command') {
@@ -394,6 +396,7 @@ export class Ssh implements INodeType {
 								this,
 								this.getNodeParameter('cwd', i) as string,
 								ssh,
+								remoteOS,
 								i,
 							);
 
@@ -431,6 +434,7 @@ export class Ssh implements INodeType {
 								this,
 								this.getNodeParameter('path', i) as string,
 								ssh,
+								remoteOS,
 								i,
 							);
 
@@ -470,6 +474,7 @@ export class Ssh implements INodeType {
 								this,
 								this.getNodeParameter('path', i) as string,
 								ssh,
+								remoteOS,
 								i,
 							);
 							const fileName = this.getNodeParameter('options.fileName', i, '') as string;

--- a/packages/nodes-base/nodes/Ssh/Ssh.node.ts
+++ b/packages/nodes-base/nodes/Ssh/Ssh.node.ts
@@ -409,8 +409,14 @@ export class Ssh implements INodeType {
 								execOptions = { cwd };
 							}
 
+							const result = await ssh.execCommand(finalCommand, execOptions);
 							returnItems.push({
-								json: (await ssh.execCommand(finalCommand, execOptions)) as unknown as IDataObject,
+								json: {
+									code: result.code,
+									signal: result.signal,
+									stdout: result.stdout,
+									stderr: result.stderr,
+								},
 								pairedItem: {
 									item: i,
 								},

--- a/packages/nodes-base/nodes/Ssh/__test__/Ssh.node.test.ts
+++ b/packages/nodes-base/nodes/Ssh/__test__/Ssh.node.test.ts
@@ -1,0 +1,132 @@
+import type { DeepMockProxy } from 'jest-mock-extended';
+import { mockDeep } from 'jest-mock-extended';
+import type { IExecuteFunctions } from 'n8n-workflow';
+import { NodeSSH } from 'node-ssh';
+
+import { Ssh } from '../Ssh.node';
+
+// Mock NodeSSH
+jest.mock('node-ssh');
+const MockedNodeSSH = NodeSSH as jest.MockedClass<typeof NodeSSH>;
+
+describe('SSH Node', () => {
+	let sshNode: Ssh;
+	let executeFunctionsMock: DeepMockProxy<IExecuteFunctions>;
+	let mockSshInstance: DeepMockProxy<NodeSSH>;
+
+	const createSSHResponse = (code: number, stdout: string, stderr = '') => ({
+		code,
+		stdout,
+		stderr,
+		signal: null,
+	});
+
+	const mockSSHCommands = (isWindows: boolean, homeDir = '/home/user') => {
+		mockSshInstance.execCommand.mockImplementation(async (command: string) => {
+			if (command === 'ver') {
+				return isWindows
+					? createSSHResponse(0, 'Microsoft Windows [Version 10.0.19041.1]')
+					: createSSHResponse(1, '', 'command not found');
+			}
+			if (command === 'echo $HOME') {
+				return createSSHResponse(0, homeDir);
+			}
+			return createSSHResponse(0, '');
+		});
+	};
+
+	const mockNodeParameters = (params: Record<string, any>) => {
+		executeFunctionsMock.getNodeParameter.mockImplementation((parameterName: string) => {
+			return params[parameterName] || null;
+		});
+	};
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		sshNode = new Ssh();
+		executeFunctionsMock = mockDeep<IExecuteFunctions>();
+		mockSshInstance = mockDeep<NodeSSH>();
+		MockedNodeSSH.mockImplementation(() => mockSshInstance);
+
+		// Default mocks
+		executeFunctionsMock.getInputData.mockReturnValue([{ json: {} }]);
+		executeFunctionsMock.getNode.mockReturnValue({
+			id: 'test-ssh-node-id',
+			name: 'SSH Test',
+			type: 'ssh',
+			typeVersion: 1,
+			position: [0, 0],
+			parameters: {},
+		});
+		executeFunctionsMock.getCredentials.mockResolvedValue({
+			host: 'localhost',
+			username: 'testuser',
+			password: 'testpass',
+			port: 22,
+		});
+	});
+
+	describe('Windows paths', () => {
+		beforeEach(() => {
+			mockSSHCommands(true);
+			mockNodeParameters({
+				resource: 'command',
+				operation: 'execute',
+				authentication: 'password',
+				command: 'dir',
+				cwd: 'C:\\Windows\\System32',
+			});
+		});
+
+		it('should prepend cd /d before command', async () => {
+			await sshNode.execute.call(executeFunctionsMock);
+
+			expect(mockSshInstance.execCommand).toHaveBeenCalledWith(
+				'cd /d "C:\\Windows\\System32" && dir',
+				{},
+			);
+		});
+	});
+
+	describe('Unix paths', () => {
+		beforeEach(() => {
+			mockSSHCommands(false);
+			mockNodeParameters({
+				resource: 'command',
+				operation: 'execute',
+				authentication: 'password',
+				command: 'ls -la',
+				cwd: '/home/user/documents',
+			});
+		});
+
+		it('should use cwd option for directory change', async () => {
+			await sshNode.execute.call(executeFunctionsMock);
+
+			expect(mockSshInstance.execCommand).toHaveBeenCalledWith('ls -la', {
+				cwd: '/home/user/documents',
+			});
+		});
+	});
+
+	describe('Tilde expansion', () => {
+		beforeEach(() => {
+			mockSSHCommands(false, '/home/testuser');
+			mockNodeParameters({
+				resource: 'command',
+				operation: 'execute',
+				authentication: 'password',
+				command: 'pwd',
+				cwd: '~/documents',
+			});
+		});
+
+		it('should expand ~/ to home directory', async () => {
+			await sshNode.execute.call(executeFunctionsMock);
+
+			expect(mockSshInstance.execCommand).toHaveBeenCalledWith('pwd', {
+				cwd: '/home/testuser/documents',
+			});
+		});
+	});
+});


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
The SSH node's working directory option fails when connecting to Windows SSH servers. This fix ensures that commands are executed in the correct directory on Windows systems by using Windows-specific directory change commands.

### Problem
When using the SSH node with Windows servers, setting a working directory causes commands to fail. For example, executing `dir` with working directory `C:\Users` returns the error _"The filename, directory name, or volume label syntax is incorrect"_.

### Solution
This PR added OS detection to identify Windows servers by running the `ver` command. For Windows servers, the fix prepends `cd /d` to change directories before executing the command, such as `cd /d "C:\Users" && echo hello`. The `/d` flag is essential as it allows changing between different drives.

For Unix/Linux servers, the node continues using the standard `cwd` option like `ssh.execCommand('ls', { cwd: '/home/user' })`. This ensures no changes to existing Unix/Linux behavior and maintains backward compatibility.

### Screenshots
<img width="1198" height="332" alt="image" src="https://github.com/user-attachments/assets/ae1ecc9b-61f2-4ffa-9073-411ecc4a23f9" />

<img width="1198" height="332" alt="image" src="https://github.com/user-attachments/assets/ef556401-9b6b-4d2e-a945-eb3dfe24e875" />



## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
Closes #15323 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
