### PR TITLE
feat: Add credential sharing disable feature

### DIFF
--- a/packages/@n8n/config/src/configs/credentials.config.ts
+++ b/packages/@n8n/config/src/configs/credentials.config.ts
@@ -20,6 +20,10 @@ export class CredentialsConfig {
 	@Env('CREDENTIALS_DEFAULT_NAME')
 	defaultName: string = 'My credentials';
 
+	/** Whether credential sharing is disabled */
+	@Env('N8N_DISABLE_CREDENTIAL_SHARING')
+	disableSharing: boolean = false;
+
 	@Nested
 	overwrite: CredentialsOverwrite;
 }

--- a/packages/cli/src/credentials/__tests__/credentials.service.ee.test.ts
+++ b/packages/cli/src/credentials/__tests__/credentials.service.ee.test.ts
@@ -1,0 +1,203 @@
+import type { User } from '@n8n/db';
+import { Project, SharedCredentialsRepository } from '@n8n/db';
+import { GlobalConfig } from '@n8n/config';
+import { mock } from 'jest-mock-extended';
+import type { EntityManager } from '@n8n/typeorm';
+
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { OwnershipService } from '@/services/ownership.service';
+import { ProjectService } from '@/services/project.service.ee';
+
+import { EnterpriseCredentialsService } from '../credentials.service.ee';
+import { CredentialsFinderService } from '../credentials-finder.service';
+import { CredentialsService } from '../credentials.service';
+
+describe('EnterpriseCredentialsService', () => {
+	const sharedCredentialsRepository = mock<SharedCredentialsRepository>();
+	const ownershipService = mock<OwnershipService>();
+	const credentialsService = mock<CredentialsService>();
+	const projectService = mock<ProjectService>();
+	const credentialsFinderService = mock<CredentialsFinderService>();
+	const globalConfig = mock<GlobalConfig>();
+	const mockEntityManager = mock<EntityManager>();
+
+	const service = new EnterpriseCredentialsService(
+		sharedCredentialsRepository,
+		ownershipService,
+		credentialsService,
+		projectService,
+		credentialsFinderService,
+		globalConfig,
+	);
+
+	const mockUser = mock<User>({ id: 'user123' });
+
+	beforeEach(() => {
+		jest.resetAllMocks();
+		// Setup repository manager mock
+		(sharedCredentialsRepository as any).manager = mockEntityManager;
+	});
+
+	describe('shareWithProjects', () => {
+		const credentialId = 'cred123';
+		const shareWithIds = ['project1', 'project2'];
+
+		describe('when credential sharing is disabled', () => {
+			beforeEach(() => {
+				globalConfig.credentials = { disableSharing: true } as any;
+			});
+
+			it('should throw BadRequestError', async () => {
+				await expect(
+					service.shareWithProjects(mockUser, credentialId, shareWithIds),
+				).rejects.toThrow(new BadRequestError('Credential sharing is disabled on this instance.'));
+			});
+
+			it('should not proceed with sharing logic', async () => {
+				await expect(
+					service.shareWithProjects(mockUser, credentialId, shareWithIds),
+				).rejects.toThrow(BadRequestError);
+
+				expect(mockEntityManager.find).not.toHaveBeenCalled();
+			});
+		});
+
+		describe('when credential sharing is enabled', () => {
+			beforeEach(() => {
+				globalConfig.credentials = { disableSharing: false } as any;
+				(sharedCredentialsRepository as any).manager = mockEntityManager;
+				mockEntityManager.find.mockResolvedValue([]);
+				mockEntityManager.save.mockResolvedValue([]);
+			});
+
+			it('should proceed with normal sharing logic', async () => {
+				await service.shareWithProjects(mockUser, credentialId, shareWithIds);
+
+				expect(mockEntityManager.find).toHaveBeenCalledWith(Project, expect.any(Object));
+			});
+
+			it('should use provided entity manager', async () => {
+				const customEntityManager = mock<EntityManager>();
+				customEntityManager.find.mockResolvedValue([]);
+				customEntityManager.save.mockResolvedValue([]);
+
+				await service.shareWithProjects(mockUser, credentialId, shareWithIds, customEntityManager);
+
+				expect(customEntityManager.find).toHaveBeenCalledWith(Project, expect.any(Object));
+				expect(customEntityManager.save).toHaveBeenCalled();
+			});
+		});
+	});
+
+	describe('transferOne', () => {
+		const credentialId = 'cred123';
+		const destinationProjectId = 'project456';
+
+		describe('when credential sharing is disabled', () => {
+			beforeEach(() => {
+				globalConfig.credentials = { disableSharing: true } as any;
+			});
+
+			it('should throw BadRequestError', async () => {
+				await expect(
+					service.transferOne(mockUser, credentialId, destinationProjectId),
+				).rejects.toThrow(new BadRequestError('Credential transfer is disabled on this instance.'));
+			});
+
+			it('should not proceed with transfer logic', async () => {
+				await expect(
+					service.transferOne(mockUser, credentialId, destinationProjectId),
+				).rejects.toThrow(BadRequestError);
+
+				expect(credentialsFinderService.findCredentialForUser).not.toHaveBeenCalled();
+			});
+		});
+
+		describe('when credential sharing is enabled', () => {
+			const mockCredential = {
+				id: credentialId,
+				shared: [
+					{
+						role: 'credential:owner',
+						project: { id: 'sourceProject' },
+					},
+				],
+			};
+
+			const mockDestinationProject = {
+				id: destinationProjectId,
+				name: 'Destination Project',
+			};
+
+			beforeEach(() => {
+				globalConfig.credentials = { disableSharing: false } as any;
+				credentialsFinderService.findCredentialForUser.mockResolvedValue(mockCredential as any);
+				projectService.getProjectWithScope.mockResolvedValue(mockDestinationProject as any);
+				(sharedCredentialsRepository.manager.transaction as jest.Mock).mockImplementation(
+					async (callback: any) => await callback(mockEntityManager),
+				);
+				mockEntityManager.remove.mockResolvedValue([]);
+				mockEntityManager.save.mockResolvedValue({});
+				mockEntityManager.create.mockReturnValue({} as any);
+			});
+
+			it('should proceed with normal transfer logic', async () => {
+				await service.transferOne(mockUser, credentialId, destinationProjectId);
+
+				expect(credentialsFinderService.findCredentialForUser).toHaveBeenCalledWith(
+					credentialId,
+					mockUser,
+					['credential:move'],
+				);
+			});
+
+			it('should throw error when transferring to same project', async () => {
+				const sameProjectCredential = {
+					...mockCredential,
+					shared: [
+						{
+							role: 'credential:owner',
+							project: { id: destinationProjectId }, // Same as destination
+						},
+					],
+				};
+
+				credentialsFinderService.findCredentialForUser.mockResolvedValue(
+					sameProjectCredential as any,
+				);
+
+				await expect(
+					service.transferOne(mockUser, credentialId, destinationProjectId),
+				).rejects.toThrow(
+					"You can't transfer a credential into the project that's already owning it.",
+				);
+			});
+		});
+	});
+
+	describe('getOne', () => {
+		const credentialId = 'cred123';
+
+		it('should work normally regardless of sharing disable setting', async () => {
+			globalConfig.credentials = { disableSharing: true } as any;
+
+			const mockCredential = {
+				id: credentialId,
+				name: 'Test Credential',
+				data: 'encrypted-data',
+			};
+
+			credentialsFinderService.findCredentialForUser.mockResolvedValue(mockCredential as any);
+			ownershipService.addOwnedByAndSharedWith.mockReturnValue(mockCredential as any);
+
+			const result = await service.getOne(mockUser, credentialId, false);
+
+			expect(result).toEqual({ id: credentialId, name: 'Test Credential' });
+			expect(credentialsFinderService.findCredentialForUser).toHaveBeenCalledWith(
+				credentialId,
+				mockUser,
+				['credential:read'],
+			);
+		});
+	});
+});


### PR DESCRIPTION
- Add N8N_DISABLE_CREDENTIAL_SHARING environment variable support
- Implement configuration-based approach using GlobalConfig
- Add disableSharing boolean to CredentialsConfig with @Env decorator
- Replace direct process.env checks with this.globalConfig.credentials.disableSharing
- Use BadRequestError instead of generic Error for proper HTTP responses
- Add comprehensive unit tests covering all scenarios (9 test cases)
- Ensure proper dependency injection patterns
- Remove temporary docker-compose.yml file

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
