### PR TITLE
fix(Gmail Node): Pass user-defined scopes for JWT auth

### DIFF
--- a/packages/nodes-base/nodes/Google/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/GenericFunctions.ts
@@ -66,10 +66,11 @@ export async function getGoogleAccessToken(
 	this: IExecuteFunctions | ILoadOptionsFunctions | ICredentialTestFunctions | IPollFunctions,
 	credentials: IDataObject,
 	service: GoogleServiceAccount,
+	scopes?: string[],
 ): Promise<IDataObject> {
 	//https://developers.google.com/identity/protocols/oauth2/service-account#httprest
 
-	const scopes = googleServiceAccountScopes[service];
+	const scopesToUse = scopes && scopes.length > 0 ? scopes : googleServiceAccountScopes[service];
 
 	const privateKey = formatPrivateKey(credentials.privateKey as string);
 	credentials.email = ((credentials.email as string) || '').trim();
@@ -80,7 +81,7 @@ export async function getGoogleAccessToken(
 		{
 			iss: credentials.email,
 			sub: credentials.delegatedEmail || credentials.email,
-			scope: scopes.join(' '),
+			scope: scopesToUse.join(' '),
 			aud: 'https://oauth2.googleapis.com/token',
 			iat: now,
 			exp: now + 3600,

--- a/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
@@ -65,7 +65,9 @@ export async function googleApiRequest(
 			const credentials = await this.getCredentials('googleApi');
 			credentialType = 'googleApi';
 
-			const { access_token } = await getGoogleAccessToken.call(this, credentials, 'gmail');
+			const scopes = (credentials.scopes as string)?.split(/[,\s\n]+/);
+
+			const { access_token } = await getGoogleAccessToken.call(this, credentials, 'gmail', scopes);
 
 			(options.headers as IDataObject).Authorization = `Bearer ${access_token}`;
 		}


### PR DESCRIPTION
The Gmail node was not correctly passing the user-defined scopes from the credentials when using a service account (JWT) for authentication. Instead, it was using a hardcoded list of scopes.

This change modifies the `getGoogleAccessToken` function to accept an optional `scopes` parameter. If provided, these scopes are used for the JWT; otherwise, it falls back to the hardcoded scopes. The `googleApiRequest` function in the Gmail node has been updated to read the scopes from the credentials and pass them to `getGoogleAccessToken`.

This resolves the issue where the Gmail node would fail with a 401 error when the required scopes were not in the hardcoded list.

Fixes #18174

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
