### PR TITLE
fix(SSH Node): Ignore ECONNRESET during dispose

### DIFF
--- a/packages/nodes-base/nodes/Ssh/Ssh.node.ts
+++ b/packages/nodes-base/nodes/Ssh/Ssh.node.ts
@@ -284,6 +284,7 @@ export class Ssh implements INodeType {
 			): Promise<INodeCredentialTestResult> {
 				const credentials = credential.data as IDataObject;
 				const ssh = new NodeSSH();
+				let isDisposing = false;
 				try {
 					if (!credentials.privateKey) {
 						await ssh.connect({
@@ -306,6 +307,15 @@ export class Ssh implements INodeType {
 
 						await ssh.connect(options);
 					}
+
+					ssh.connection?.on('error', () => {
+						if (isDisposing) {
+							return;
+						}
+
+						isDisposing = true;
+						ssh.dispose();
+					});
 				} catch (error) {
 					const message = `SSH connection failed: ${error.message}`;
 					return {
@@ -313,6 +323,7 @@ export class Ssh implements INodeType {
 						message,
 					};
 				} finally {
+					isDisposing = true;
 					ssh.dispose();
 				}
 				return {
@@ -333,6 +344,7 @@ export class Ssh implements INodeType {
 		const authentication = this.getNodeParameter('authentication', 0) as string;
 
 		const ssh = new NodeSSH();
+		let isDisposing = false;
 
 		try {
 			if (authentication === 'password') {
@@ -359,6 +371,15 @@ export class Ssh implements INodeType {
 
 				await ssh.connect(options);
 			}
+
+			ssh.connection?.on('error', () => {
+				if (isDisposing) {
+					return;
+				}
+
+				isDisposing = true;
+				ssh.dispose();
+			});
 
 			for (let i = 0; i < items.length; i++) {
 				try {
@@ -488,6 +509,7 @@ export class Ssh implements INodeType {
 				}
 			}
 		} finally {
+			isDisposing = true;
 			ssh.dispose();
 		}
 


### PR DESCRIPTION
## Summary

Fixes a Windows-specific issue in the **SSH node** where calling `ssh.dispose()` always raises an `ECONNRESET`.
The connection teardown now ignores `ECONNRESET` errors when disposing, while still surfacing all other errors.

**How to test:**

* Run the SSH node against a Windows OpenSSH server (with either `cmd` or `powershell` as default shell).
* Execute a command and allow the node to complete.
* Verify that the workflow succeeds without throwing an `ECONNRESET` at the end.
* Confirm on Linux/macOS that disposal still behaves as before (no regression).

## Related Linear tickets, Github issues, and Community forum posts

N/A (no open issue).
This behavior is documented in `ssh2` and downstream clients (e.g. `ssh2-sftp-client`) as a known Windows peculiarity.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport`
