### PR TITLE
fix(core): Fix direct import of DTOs (no-changelog)

### DIFF
--- a/packages/cli/src/modules/data-store/data-store.service.ts
+++ b/packages/cli/src/modules/data-store/data-store.service.ts
@@ -6,8 +6,8 @@ import type {
 	DataStoreListOptions,
 	DataStoreRows,
 	UpsertDataStoreRowsDto,
+	UpdateDataStoreDto,
 } from '@n8n/api-types';
-import { UpdateDataStoreDto } from '@n8n/api-types/src/dto/data-store/update-data-store.dto';
 import { Logger } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
 

--- a/packages/cli/src/services/public-api-key.service.ts
+++ b/packages/cli/src/services/public-api-key.service.ts
@@ -1,5 +1,4 @@
-import type { UnixTimestamp, UpdateApiKeyRequestDto } from '@n8n/api-types';
-import type { CreateApiKeyRequestDto } from '@n8n/api-types/src/dto/api-keys/create-api-key-request.dto';
+import type { CreateApiKeyRequestDto, UnixTimestamp, UpdateApiKeyRequestDto } from '@n8n/api-types';
 import type { AuthenticatedRequest, User } from '@n8n/db';
 import { ApiKey, ApiKeyRepository, UserRepository } from '@n8n/db';
 import { Service } from '@n8n/di';

--- a/packages/cli/src/workflows/__tests__/workflows.controller.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflows.controller.test.ts
@@ -1,4 +1,4 @@
-import type { ImportWorkflowFromUrlDto } from '@n8n/api-types/src/dto/workflows/import-workflow-from-url.dto';
+import type { ImportWorkflowFromUrlDto } from '@n8n/api-types';
 import type { AuthenticatedRequest } from '@n8n/db';
 import axios from 'axios';
 import type { Response } from 'express';


### PR DESCRIPTION
## Summary

Fix existing occurrences of these direct imports. Root cause is vscode automatically importing the file on autocomplete acceptance, unclear how to prevent this moving forward.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
