### PR TITLE
feat(core): Rename data store row id to an internal id (no-changelog)

### DIFF
--- a/packages/cli/src/modules/data-store/__tests__/data-store.controller.test.ts
+++ b/packages/cli/src/modules/data-store/__tests__/data-store.controller.test.ts
@@ -18,6 +18,7 @@ import * as utils from '@test-integration/utils';
 import { DataStoreColumnRepository } from '../data-store-column.repository';
 import { DataStoreRowsRepository } from '../data-store-rows.repository';
 import { DataStoreRepository } from '../data-store.repository';
+import { DATA_STORE_ROW_INTERNAL_ID } from '../data-store.types';
 import { toTableName } from '../utils/sql-utils';
 
 let owner: User;
@@ -1587,7 +1588,7 @@ describe('GET /projects/:projectId/data-stores/:dataStoreId/rows', () => {
 			count: 1,
 			data: [
 				{
-					n8n_row_id: 1,
+					[DATA_STORE_ROW_INTERNAL_ID]: 1,
 					first: 'test value',
 					second: 'another value',
 				},
@@ -1626,7 +1627,7 @@ describe('GET /projects/:projectId/data-stores/:dataStoreId/rows', () => {
 			count: 1,
 			data: [
 				{
-					n8n_row_id: 1,
+					[DATA_STORE_ROW_INTERNAL_ID]: 1,
 					first: 'test value',
 					second: 'another value',
 				},
@@ -1665,7 +1666,7 @@ describe('GET /projects/:projectId/data-stores/:dataStoreId/rows', () => {
 			count: 1,
 			data: [
 				{
-					n8n_row_id: 1,
+					[DATA_STORE_ROW_INTERNAL_ID]: 1,
 					first: 'test value',
 					second: 'another value',
 				},
@@ -1701,7 +1702,7 @@ describe('GET /projects/:projectId/data-stores/:dataStoreId/rows', () => {
 			count: 1,
 			data: [
 				{
-					n8n_row_id: 1,
+					[DATA_STORE_ROW_INTERNAL_ID]: 1,
 					first: 'test value',
 					second: 'another value',
 				},
@@ -2539,7 +2540,7 @@ describe('POST /projects/:projectId/data-stores/:dataStoreId/upsert', () => {
 			.expect(200);
 
 		const rowsInDb = await dataStoreRowsRepository.getManyAndCount(toTableName(dataStore.id), {
-			sortBy: ['n8n_row_id', 'ASC'],
+			sortBy: ['DATA_STORE_ROW_INTERNAL_ID', 'ASC'],
 		});
 		expect(rowsInDb.count).toBe(3);
 		expect(rowsInDb.data[0]).toMatchObject(payload.rows[0]);

--- a/packages/cli/src/modules/data-store/__tests__/data-store.controller.test.ts
+++ b/packages/cli/src/modules/data-store/__tests__/data-store.controller.test.ts
@@ -2540,7 +2540,7 @@ describe('POST /projects/:projectId/data-stores/:dataStoreId/upsert', () => {
 			.expect(200);
 
 		const rowsInDb = await dataStoreRowsRepository.getManyAndCount(toTableName(dataStore.id), {
-			sortBy: ['DATA_STORE_ROW_INTERNAL_ID', 'ASC'],
+			sortBy: [DATA_STORE_ROW_INTERNAL_ID, 'ASC'],
 		});
 		expect(rowsInDb.count).toBe(3);
 		expect(rowsInDb.data[0]).toMatchObject(payload.rows[0]);

--- a/packages/cli/src/modules/data-store/__tests__/data-store.controller.test.ts
+++ b/packages/cli/src/modules/data-store/__tests__/data-store.controller.test.ts
@@ -8,11 +8,12 @@ import {
 import type { Project, User } from '@n8n/db';
 import { ProjectRepository, QueryFailedError } from '@n8n/db';
 import { Container } from '@n8n/di';
+import { DateTime } from 'luxon';
+
 import { createDataStore } from '@test-integration/db/data-stores';
 import { createOwner, createMember, createAdmin } from '@test-integration/db/users';
 import type { SuperAgentTest } from '@test-integration/types';
 import * as utils from '@test-integration/utils';
-import { DateTime } from 'luxon';
 
 import { DataStoreColumnRepository } from '../data-store-column.repository';
 import { DataStoreRowsRepository } from '../data-store-rows.repository';
@@ -1586,7 +1587,7 @@ describe('GET /projects/:projectId/data-stores/:dataStoreId/rows', () => {
 			count: 1,
 			data: [
 				{
-					id: 1,
+					n8n_row_id: 1,
 					first: 'test value',
 					second: 'another value',
 				},
@@ -1625,7 +1626,7 @@ describe('GET /projects/:projectId/data-stores/:dataStoreId/rows', () => {
 			count: 1,
 			data: [
 				{
-					id: 1,
+					n8n_row_id: 1,
 					first: 'test value',
 					second: 'another value',
 				},
@@ -1664,7 +1665,7 @@ describe('GET /projects/:projectId/data-stores/:dataStoreId/rows', () => {
 			count: 1,
 			data: [
 				{
-					id: 1,
+					n8n_row_id: 1,
 					first: 'test value',
 					second: 'another value',
 				},
@@ -1700,7 +1701,7 @@ describe('GET /projects/:projectId/data-stores/:dataStoreId/rows', () => {
 			count: 1,
 			data: [
 				{
-					id: 1,
+					n8n_row_id: 1,
 					first: 'test value',
 					second: 'another value',
 				},
@@ -2538,7 +2539,7 @@ describe('POST /projects/:projectId/data-stores/:dataStoreId/upsert', () => {
 			.expect(200);
 
 		const rowsInDb = await dataStoreRowsRepository.getManyAndCount(toTableName(dataStore.id), {
-			sortBy: ['id', 'ASC'],
+			sortBy: ['n8n_row_id', 'ASC'],
 		});
 		expect(rowsInDb.count).toBe(3);
 		expect(rowsInDb.data[0]).toMatchObject(payload.rows[0]);

--- a/packages/cli/src/modules/data-store/__tests__/data-store.service.test.ts
+++ b/packages/cli/src/modules/data-store/__tests__/data-store.service.test.ts
@@ -6,6 +6,7 @@ import { Container } from '@n8n/di';
 import { DataStoreRowsRepository } from '../data-store-rows.repository';
 import { DataStoreRepository } from '../data-store.repository';
 import { DataStoreService } from '../data-store.service';
+import { DATA_STORE_ROW_INTERNAL_ID } from '../data-store.types';
 import { DataStoreColumnNameConflictError } from '../errors/data-store-column-name-conflict.error';
 import { DataStoreColumnNotFoundError } from '../errors/data-store-column-not-found.error';
 import { DataStoreNameConflictError } from '../errors/data-store-name-conflict.error';
@@ -147,7 +148,7 @@ describe('dataStore', () => {
 			expect(rows).toEqual([]);
 		});
 
-		it('should allow creating a column named "id" and use n8n_row_id for internal row ID', async () => {
+		it('should allow creating a column named "id" and use DATA_STORE_ROW_INTERNAL_ID for internal row ID', async () => {
 			// ARRANGE
 			const { id: dataStoreId } = await dataStoreService.createDataStore(project1.id, {
 				name: 'dataStore',
@@ -172,8 +173,8 @@ describe('dataStore', () => {
 
 			expect(count).toBe(2);
 			expect(data).toEqual([
-				{ id: 'user-123', name: 'Alice', n8n_row_id: 1 },
-				{ id: 'user-456', name: 'Bob', n8n_row_id: 2 },
+				{ id: 'user-123', name: 'Alice', [DATA_STORE_ROW_INTERNAL_ID]: 1 },
+				{ id: 'user-456', name: 'Bob', [DATA_STORE_ROW_INTERNAL_ID]: 2 },
 			]);
 		});
 
@@ -920,7 +921,7 @@ describe('dataStore', () => {
 			expect(data).toEqual(
 				rows.map((row, i) => ({
 					...row,
-					n8n_row_id: i + 1,
+					[DATA_STORE_ROW_INTERNAL_ID]: i + 1,
 					c1: row.c1,
 					c2: row.c2,
 					c3: row.c3 instanceof Date ? row.c3.toISOString() : row.c3,
@@ -957,8 +958,8 @@ describe('dataStore', () => {
 
 			expect(count).toEqual(2);
 			expect(data).toEqual([
-				{ c1: 1, c2: 'foo', n8n_row_id: 1 },
-				{ c1: 1, c2: 'foo', n8n_row_id: 2 },
+				{ c1: 1, c2: 'foo', [DATA_STORE_ROW_INTERNAL_ID]: 1 },
+				{ c1: 1, c2: 'foo', [DATA_STORE_ROW_INTERNAL_ID]: 2 },
 			]);
 		});
 
@@ -1120,7 +1121,9 @@ describe('dataStore', () => {
 			);
 
 			expect(count).toEqual(1);
-			expect(data).toEqual([{ fullName: 'Alicia', age: 31, n8n_row_id: 1, pid: '1995-111a' }]);
+			expect(data).toEqual([
+				{ fullName: 'Alicia', age: 31, [DATA_STORE_ROW_INTERNAL_ID]: 1, pid: '1995-111a' },
+			]);
 		});
 
 		it('inserts a row if filter does not match', async () => {
@@ -1155,8 +1158,8 @@ describe('dataStore', () => {
 
 			expect(count).toEqual(2);
 			expect(data).toEqual([
-				{ fullName: 'Alice', age: 30, n8n_row_id: 1, pid: '1995-111a' },
-				{ fullName: 'Alice', age: 30, n8n_row_id: 2, pid: '1992-222b' },
+				{ fullName: 'Alice', age: 30, [DATA_STORE_ROW_INTERNAL_ID]: 1, pid: '1995-111a' },
+				{ fullName: 'Alice', age: 30, [DATA_STORE_ROW_INTERNAL_ID]: 2, pid: '1992-222b' },
 			]);
 		});
 	});
@@ -1192,7 +1195,7 @@ describe('dataStore', () => {
 
 			const rows = await dataStoreService.getManyRowsAndCount(dataStoreId, project1.id, {});
 			expect(rows.count).toBe(1);
-			expect(rows.data).toEqual([{ name: 'Bob', age: 25, n8n_row_id: 2 }]);
+			expect(rows.data).toEqual([{ name: 'Bob', age: 25, [DATA_STORE_ROW_INTERNAL_ID]: 2 }]);
 		});
 
 		it('returns true when deleting empty list of IDs', async () => {
@@ -1272,28 +1275,28 @@ describe('dataStore', () => {
 					c2: rows[0].c2,
 					c3: '1970-01-01T00:00:00.000Z',
 					c4: rows[0].c4,
-					n8n_row_id: 1,
+					[DATA_STORE_ROW_INTERNAL_ID]: 1,
 				},
 				{
 					c1: rows[1].c1,
 					c2: rows[1].c2,
 					c3: '1970-01-01T00:00:00.001Z',
 					c4: rows[1].c4,
-					n8n_row_id: 2,
+					[DATA_STORE_ROW_INTERNAL_ID]: 2,
 				},
 				{
 					c1: rows[2].c1,
 					c2: rows[2].c2,
 					c3: '1970-01-01T00:00:00.002Z',
 					c4: rows[2].c4,
-					n8n_row_id: 3,
+					[DATA_STORE_ROW_INTERNAL_ID]: 3,
 				},
 			]);
 		});
 	});
 
 	describe('custom id column', () => {
-		it('can delete rows by n8n_row_id even when there is a custom id column', async () => {
+		it('can delete rows by DATA_STORE_ROW_INTERNAL_ID even when there is a custom id column', async () => {
 			// ARRANGE
 			const { id: dataStoreId } = await dataStoreService.createDataStore(project1.id, {
 				name: 'dataStore',
@@ -1309,7 +1312,7 @@ describe('dataStore', () => {
 				{ id: 'user-789', name: 'Charlie' },
 			]);
 
-			// ACT - Delete by n8n_row_id (system ID)
+			// ACT - Delete by internal ID
 			const result = await dataStoreService.deleteRows(dataStoreId, project1.id, [1, 3]);
 
 			// ASSERT
@@ -1322,7 +1325,7 @@ describe('dataStore', () => {
 			);
 
 			expect(count).toBe(1);
-			expect(data).toEqual([{ id: 'user-456', name: 'Bob', n8n_row_id: 2 }]);
+			expect(data).toEqual([{ id: 'user-456', name: 'Bob', [DATA_STORE_ROW_INTERNAL_ID]: 2 }]);
 		});
 	});
 });

--- a/packages/cli/src/modules/data-store/data-store-rows.repository.ts
+++ b/packages/cli/src/modules/data-store/data-store-rows.repository.ts
@@ -106,7 +106,7 @@ export class DataStoreRowsRepository {
 		const dbType = this.dataSource.options.type;
 		const quotedTableName = quoteIdentifier(tableName, dbType);
 		const placeholders = ids.map((_, index) => getPlaceholder(index + 1, dbType)).join(', ');
-		const query = `DELETE FROM ${quotedTableName} WHERE id IN (${placeholders})`;
+		const query = `DELETE FROM ${quotedTableName} WHERE n8n_row_id IN (${placeholders})`;
 
 		await this.dataSource.query(query, ids);
 		return true;
@@ -117,7 +117,10 @@ export class DataStoreRowsRepository {
 		columns: DataStoreColumn[],
 		queryRunner: QueryRunner,
 	) {
-		const dslColumns = [new DslColumn('id').int.autoGenerate2.primary, ...toDslColumns(columns)];
+		const dslColumns = [
+			new DslColumn('n8n_row_id').int.autoGenerate2.primary,
+			...toDslColumns(columns),
+		];
 		const createTable = new CreateTable(tableName, '', queryRunner);
 		createTable.withColumns.apply(createTable, dslColumns);
 		await createTable.execute(queryRunner);
@@ -160,7 +163,7 @@ export class DataStoreRowsRepository {
 
 	async getRowIds(dataStoreId: DataStoreUserTableName, dto: ListDataStoreContentQueryDto) {
 		const [_, query] = this.getManyQuery(dataStoreId, dto);
-		const result = await query.select('dataStore.id').getRawMany<number>();
+		const result = await query.select('dataStore.n8n_row_id').getRawMany<number>();
 		return result;
 	}
 

--- a/packages/cli/src/modules/data-store/data-store.types.ts
+++ b/packages/cli/src/modules/data-store/data-store.types.ts
@@ -1,1 +1,3 @@
+export const DATA_STORE_ROW_INTERNAL_ID = 'n8n_row_id';
+
 export type DataStoreUserTableName = `data_store_user_${string}`;


### PR DESCRIPTION
## Summary

[we decided to leave id]

Rename the data store row ID to an internal ID, allowing users to create their own column named `id`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3916/be-rename-id-to-an-internal-id

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
