### PR TITLE
fix: Remove parameter merging from node update tool of AI Builder (no-changelog)

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/test/update-node-parameters.tool.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/test/update-node-parameters.tool.test.ts
@@ -192,7 +192,7 @@ describe('UpdateNodeParametersTool', () => {
 			});
 		});
 
-		it('should merge parameters instead of replacing them', async () => {
+		it('should be able to remove parameters', async () => {
 			const existingWorkflow = createWorkflow([
 				createNode({
 					id: 'node1',
@@ -208,9 +208,10 @@ describe('UpdateNodeParametersTool', () => {
 			]);
 			setupWorkflowState(mockGetCurrentTaskInput, existingWorkflow);
 
-			// Mock chain response - only updating URL
+			// Mock chain response - removing authentication
 			mockChain.invoke.mockResolvedValue({
 				parameters: {
+					method: 'GET',
 					url: 'https://api.example.com/v2',
 				},
 			});
@@ -218,19 +219,17 @@ describe('UpdateNodeParametersTool', () => {
 			const mockConfig = createToolConfig('update_node_parameters', 'test-call-3');
 
 			const result = await updateNodeParametersTool.invoke(
-				buildUpdateNodeInput('node1', ['Update URL to v2 endpoint']),
+				buildUpdateNodeInput('node1', ['Update URL to v2 endpoint', 'Remove authentication']),
 				mockConfig,
 			);
 
 			const content = parseToolResult<ParsedToolContent>(result);
 
-			// Should keep existing parameters and only update URL
+			// Should remove authentication and keep other parameters
 			expectNodeUpdated(content, 'node1', {
 				parameters: expect.objectContaining({
 					method: 'GET', // preserved
 					url: 'https://api.example.com/v2', // updated
-					authentication: 'genericCredentialType', // preserved
-					genericAuthType: 'httpBasicAuth', // preserved
 				}),
 			});
 		});

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/update-node-parameters.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/update-node-parameters.tool.ts
@@ -18,7 +18,6 @@ import {
 	extractNodeParameters,
 	formatChangesForPrompt,
 	updateNodeWithParameters,
-	mergeParameters,
 	fixExpressionPrefixes,
 } from './utils/parameter-update.utils';
 import type { UpdateNodeParametersOutput } from '../types/tools';
@@ -140,16 +139,12 @@ export function createUpdateNodeParametersTool(
 					}
 
 					// Fix expression prefixes in the new parameters
-					const fixedParameters = fixExpressionPrefixes(newParameters.parameters);
-
-					// Merge the new parameters with existing ones
-					const updatedParameters = mergeParameters(
-						currentParameters,
-						fixedParameters as INodeParameters,
-					);
+					const fixedParameters = fixExpressionPrefixes(
+						newParameters.parameters,
+					) as INodeParameters;
 
 					// Create updated node
-					const updatedNode = updateNodeWithParameters(node, updatedParameters);
+					const updatedNode = updateNodeWithParameters(node, fixedParameters);
 
 					// Build success message
 					const message = buildSuccessMessage(node, changes);
@@ -159,7 +154,7 @@ export function createUpdateNodeParametersTool(
 						nodeId,
 						nodeName: node.name,
 						nodeType: node.type,
-						updatedParameters,
+						updatedParameters: fixedParameters,
 						appliedChanges: changes,
 						message,
 					};


### PR DESCRIPTION
## Summary

Deep merging of the entire object with node's parameters prevent the parameter updater tool from removing existing parameters. The parameter updater chain is prompted to always return the whole parameters object and it seem to work well, so we can remove merging logic.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-1293/feature-remove-merge-parameters-behavior


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
