### PR TITLE
fix(core): Don't reveal whether files exists if they're not within allowed paths

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
@@ -223,6 +223,19 @@ describe('getFileSystemHelperFunctions', () => {
 			);
 		});
 
+		it('should not reveal if file exists if it is within restricted path', async () => {
+			process.env[RESTRICT_FILE_ACCESS_TO] = '/allowed/path';
+
+			const error = new Error('ENOENT');
+			// @ts-expect-error undefined property
+			error.code = 'ENOENT';
+			(fsAccess as jest.Mock).mockRejectedValueOnce(error);
+
+			await expect(helperFunctions.createReadStream('/blocked/path')).rejects.toThrow(
+				'Access to the file is not allowed',
+			);
+		});
+
 		it('should create a read stream if file access is permitted', async () => {
 			const filePath = '/allowed/path';
 			(fsAccess as jest.Mock).mockResolvedValueOnce({});

--- a/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
@@ -63,7 +63,7 @@ export async function isFilePathBlocked(filePath: string): Promise<boolean> {
 
 export const getFileSystemHelperFunctions = (node: INode): FileSystemHelperFunctions => ({
 	async createReadStream(filePath) {
-		if (await isFilePathBlocked(filePath as string)) {
+		if (await isFilePathBlocked(filePath.toString())) {
 			const allowedPaths = getAllowedPaths();
 			const message = allowedPaths.length ? ` Allowed paths: ${allowedPaths.join(', ')}` : '';
 			throw new NodeOperationError(node, `Access to the file is not allowed.${message}`, {

--- a/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
@@ -38,9 +38,8 @@ export async function isFilePathBlocked(filePath: string): Promise<boolean> {
 	let resolvedFilePath = '';
 	try {
 		resolvedFilePath = await fsRealpath(filePath);
-	} catch (error) {
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-		if (error.code === 'ENOENT') {
+	} catch (error: unknown) {
+		if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
 			resolvedFilePath = resolve(filePath);
 		} else {
 			throw error;
@@ -64,6 +63,14 @@ export async function isFilePathBlocked(filePath: string): Promise<boolean> {
 
 export const getFileSystemHelperFunctions = (node: INode): FileSystemHelperFunctions => ({
 	async createReadStream(filePath) {
+		if (await isFilePathBlocked(filePath as string)) {
+			const allowedPaths = getAllowedPaths();
+			const message = allowedPaths.length ? ` Allowed paths: ${allowedPaths.join(', ')}` : '';
+			throw new NodeOperationError(node, `Access to the file is not allowed.${message}`, {
+				level: 'warning',
+			});
+		}
+
 		try {
 			await fsAccess(filePath);
 		} catch (error) {
@@ -76,13 +83,7 @@ export const getFileSystemHelperFunctions = (node: INode): FileSystemHelperFunct
 					})
 				: error;
 		}
-		if (await isFilePathBlocked(filePath as string)) {
-			const allowedPaths = getAllowedPaths();
-			const message = allowedPaths.length ? ` Allowed paths: ${allowedPaths.join(', ')}` : '';
-			throw new NodeOperationError(node, `Access to the file is not allowed.${message}`, {
-				level: 'warning',
-			});
-		}
+
 		return createReadStream(filePath);
 	},
 


### PR DESCRIPTION
## Summary

If a file is within a restricted path we revealed its existence on the `createReadStream` as the fsAccess check happened before the check for access. By switching them around `createReadStream` now first checks if the file can be accessed before revealing if it exists.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/SEC-288/potential-file-inclusion-attack-via-reading-file-redux

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
