### PR TITLE
fix(core): Handle insights by workflow table for deleted workflows

### DIFF
--- a/packages/@n8n/api-types/src/schemas/__tests__/insights.schema.test.ts
+++ b/packages/@n8n/api-types/src/schemas/__tests__/insights.schema.test.ts
@@ -69,24 +69,40 @@ describe('insightsSummarySchema', () => {
 });
 
 describe('insightsByWorkflowSchema', () => {
+	const validInsightsByWorkflow = {
+		count: 2,
+		data: [
+			{
+				workflowId: 'w1',
+				workflowName: 'Test Workflow',
+				projectId: 'p1',
+				projectName: 'Test Project',
+				total: 100,
+				succeeded: 90,
+				failed: 10,
+				failureRate: 0.56,
+				runTime: 300,
+				averageRunTime: 30.5,
+				timeSaved: 50,
+			},
+		],
+	};
+
 	test.each([
 		{
 			name: 'valid workflow insights',
+			value: validInsightsByWorkflow,
+			expected: true,
+		},
+		{
+			name: 'workflow insights with nullable workflow id and project id',
 			value: {
-				count: 2,
+				...validInsightsByWorkflow,
 				data: [
 					{
-						workflowId: 'w1',
-						workflowName: 'Test Workflow',
-						projectId: 'p1',
-						projectName: 'Test Project',
-						total: 100,
-						succeeded: 90,
-						failed: 10,
-						failureRate: 0.56,
-						runTime: 300,
-						averageRunTime: 30.5,
-						timeSaved: 50,
+						...validInsightsByWorkflow.data[0],
+						workflowId: null,
+						projectId: null,
 					},
 				],
 			},

--- a/packages/@n8n/api-types/src/schemas/insights.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/insights.schema.ts
@@ -48,9 +48,11 @@ export const insightsByWorkflowDataSchemas = {
 	data: z.array(
 		z
 			.object({
-				workflowId: z.string(),
+				// Workflow id will be null if the workflow has been deleted
+				workflowId: z.string().nullable(),
 				workflowName: z.string(),
-				projectId: z.string(),
+				// Project id will be null if the project has been deleted
+				projectId: z.string().nullable(),
 				projectName: z.string(),
 				total: z.number(),
 				succeeded: z.number(),

--- a/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
+++ b/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
@@ -30,9 +30,9 @@ const summaryParser = z
 
 const aggregatedInsightsByWorkflowParser = z
 	.object({
-		workflowId: z.string(),
+		workflowId: z.string().nullable(),
 		workflowName: z.string(),
-		projectId: z.string(),
+		projectId: z.string().nullable(),
 		projectName: z.string(),
 		total: z.union([z.number(), z.string()]).transform((value) => Number(value)),
 		succeeded: z.union([z.number(), z.string()]).transform((value) => Number(value)),

--- a/packages/frontend/editor-ui/src/features/insights/components/tables/InsightsTableWorkflows.vue
+++ b/packages/frontend/editor-ui/src/features/insights/components/tables/InsightsTableWorkflows.vue
@@ -168,21 +168,28 @@ watch(sortBy, (newValue) => {
 			@update:options="emit('update:options', $event)"
 		>
 			<template #[`item.workflowName`]="{ item }">
-				<router-link
-					:to="getWorkflowLink(item)"
-					:class="$style.link"
-					@click="trackWorkflowClick(item)"
+				<component
+					:is="item.workflowId ? 'router-link' : 'div'"
+					v-bind="
+						item.workflowId
+							? {
+									to: getWorkflowLink(item),
+									class: $style.link,
+									onClick: () => trackWorkflowClick(item),
+								}
+							: {}
+					"
 				>
 					<N8nTooltip :content="item.workflowName" placement="top">
 						<div :class="$style.ellipsis">
 							{{ item.workflowName }}
 						</div>
 					</N8nTooltip>
-				</router-link>
+				</component>
 			</template>
 			<template #[`item.timeSaved`]="{ item, value }">
 				<router-link
-					v-if="!item.timeSaved"
+					v-if="!item.timeSaved && item.workflowId"
 					:to="getWorkflowLink(item, { settings: 'true' })"
 					:class="$style.link"
 				>


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

If a workflow is deleted, then the related insights metadata will have null workflow id and project id. This breaks the Insights by Workflow query parsing, although it's expected to happen and the feature should still work.
This PR makes sure the insights by workflow table works well and is displayed well, even for deleted workflows.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-3274/insights-null-value-in-project-id-causes-error-in-breakdown-by


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
