### PR TITLE
fix: Also run DB tests in CI when any test inside CLI package have changes

### DIFF
--- a/.github/workflows/ci-postgres-mysql.yml
+++ b/.github/workflows/ci-postgres-mysql.yml
@@ -7,11 +7,11 @@ on:
   pull_request:
     paths:
       - packages/cli/src/databases/**
-      - packages/@n8n/db/**
       - packages/cli/src/modules/*/database/**
       - packages/cli/test/integration/**
       - packages/cli/test/shared/db/**
       - packages/@n8n/db/**
+      - packages/cli/**/__tests__/**
       - .github/workflows/ci-postgres-mysql.yml
       - .github/docker-compose.yml
   pull_request_review:


### PR DESCRIPTION
## Summary

Also run MySQL/Postgres tests in CI when any of the test files inside CLI package have changes.
Removed duplicate entry for `packages/@n8n/db/**`.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
