### PR TITLE
feat(editor): Add Alt+Meta+O keyboard shortcut for the About modal

### DIFF
--- a/cypress/e2e/12-canvas.cy.ts
+++ b/cypress/e2e/12-canvas.cy.ts
@@ -448,4 +448,9 @@ describe('Canvas Node Manipulation and Navigation', () => {
 			NDVDialog.actions.close();
 		});
 	});
+
+	it('should open and close the about modal on keyboard shortcut', () => {
+		WorkflowPage.actions.hitOpenAbout();
+		cy.getByTestId('close-about-modal-button').click();
+	});
 });

--- a/cypress/e2e/12-canvas.cy.ts
+++ b/cypress/e2e/12-canvas.cy.ts
@@ -449,7 +449,7 @@ describe('Canvas Node Manipulation and Navigation', () => {
 		});
 	});
 
-	it.only('should open and close the about modal on keyboard shortcut', () => {
+	it('should open and close the about modal on keyboard shortcut', () => {
 		WorkflowPage.actions.hitOpenAbout();
 		cy.getByTestId('close-about-modal-button').click();
 	});

--- a/cypress/e2e/12-canvas.cy.ts
+++ b/cypress/e2e/12-canvas.cy.ts
@@ -449,7 +449,7 @@ describe('Canvas Node Manipulation and Navigation', () => {
 		});
 	});
 
-	it('should open and close the about modal on keyboard shortcut', () => {
+	it.only('should open and close the about modal on keyboard shortcut', () => {
 		WorkflowPage.actions.hitOpenAbout();
 		cy.getByTestId('close-about-modal-button').click();
 	});

--- a/cypress/pages/workflow.ts
+++ b/cypress/pages/workflow.ts
@@ -391,7 +391,7 @@ export class WorkflowPage extends BasePage {
 			cy.get('body').type('d');
 		},
 		hitOpenAbout: () => {
-			cy.get('body').type('{alt}{meta}o');
+			this.actions.hitComboShortcut(`alt+${META_KEY}`, 'o');
 		},
 		hitCopy: () => {
 			this.actions.hitComboShortcut(`{${META_KEY}}`, 'c');

--- a/cypress/pages/workflow.ts
+++ b/cypress/pages/workflow.ts
@@ -391,7 +391,7 @@ export class WorkflowPage extends BasePage {
 			cy.get('body').type('d');
 		},
 		hitOpenAbout: () => {
-			this.actions.hitComboShortcut(`alt+${META_KEY}`, 'o');
+			cy.get('body').type(`{alt}{${META_KEY}}o`);
 		},
 		hitCopy: () => {
 			this.actions.hitComboShortcut(`{${META_KEY}}`, 'c');

--- a/cypress/pages/workflow.ts
+++ b/cypress/pages/workflow.ts
@@ -390,6 +390,9 @@ export class WorkflowPage extends BasePage {
 		hitDisableNodeShortcut: () => {
 			cy.get('body').type('d');
 		},
+		hitOpenAbout: () => {
+			cy.get('body').type('{alt}{meta}o');
+		},
 		hitCopy: () => {
 			this.actions.hitComboShortcut(`{${META_KEY}}`, 'c');
 		},

--- a/packages/frontend/editor-ui/src/components/MainSidebar.vue
+++ b/packages/frontend/editor-ui/src/components/MainSidebar.vue
@@ -255,6 +255,7 @@ const userIsTrialing = computed(() => cloudPlanStore.userIsTrialing);
 
 onMounted(async () => {
 	window.addEventListener('resize', onResize);
+	window.addEventListener('keydown', onKeyDown);
 	basePath.value = rootStore.baseUrl;
 	if (user.value) {
 		void externalHooks.run('mainSidebar.mounted', {
@@ -270,6 +271,7 @@ onMounted(async () => {
 onBeforeUnmount(() => {
 	becomeTemplateCreatorStore.stopMonitoringCta();
 	window.removeEventListener('resize', onResize);
+	window.removeEventListener('keydown', onKeyDown);
 });
 
 const trackHelpItemClick = (itemType: string) => {
@@ -360,6 +362,12 @@ const handleSelect = (key: string) => {
 
 function onResize() {
 	void callDebounced(onResizeEnd, { debounceTime: 250 });
+}
+
+function onKeyDown(e: KeyboardEvent) {
+	if (e.altKey && e.metaKey && e.code === 'KeyO') {
+		handleSelect('about');
+	}
 }
 
 async function onResizeEnd() {

--- a/packages/frontend/editor-ui/src/components/MainSidebar.vue
+++ b/packages/frontend/editor-ui/src/components/MainSidebar.vue
@@ -36,6 +36,7 @@ import VersionUpdateCTA from '@/components/VersionUpdateCTA.vue';
 import { TemplateClickSource, trackTemplatesClick } from '@/utils/experiments';
 import { I18nT } from 'vue-i18n';
 import { usePersonalizedTemplatesV2Store } from '@/experiments/templateRecoV2/stores/templateRecoV2.store';
+import { useKeybindings } from '@/composables/useKeybindings';
 
 const becomeTemplateCreatorStore = useBecomeTemplateCreatorStore();
 const cloudPlanStore = useCloudPlanStore();
@@ -58,6 +59,9 @@ const telemetry = useTelemetry();
 const pageRedirectionHelper = usePageRedirectionHelper();
 const { getReportingURL } = useBugReporting();
 
+useKeybindings({
+	ctrl_alt_o: () => handleSelect('about'),
+});
 useUserHelpers(router, route);
 
 // Template refs
@@ -255,7 +259,6 @@ const userIsTrialing = computed(() => cloudPlanStore.userIsTrialing);
 
 onMounted(async () => {
 	window.addEventListener('resize', onResize);
-	window.addEventListener('keydown', onKeyDown);
 	basePath.value = rootStore.baseUrl;
 	if (user.value) {
 		void externalHooks.run('mainSidebar.mounted', {
@@ -271,7 +274,6 @@ onMounted(async () => {
 onBeforeUnmount(() => {
 	becomeTemplateCreatorStore.stopMonitoringCta();
 	window.removeEventListener('resize', onResize);
-	window.removeEventListener('keydown', onKeyDown);
 });
 
 const trackHelpItemClick = (itemType: string) => {
@@ -362,12 +364,6 @@ const handleSelect = (key: string) => {
 
 function onResize() {
 	void callDebounced(onResizeEnd, { debounceTime: 250 });
-}
-
-function onKeyDown(e: KeyboardEvent) {
-	if (e.altKey && e.metaKey && e.code === 'KeyO') {
-		handleSelect('about');
-	}
 }
 
 async function onResizeEnd() {

--- a/packages/frontend/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/Canvas.vue
@@ -345,6 +345,7 @@ const keyMap = computed(() => {
 		shift_alt_t: async () => await onTidyUp({ source: 'keyboard-shortcut' }),
 		alt_x: emitWithSelectedNodes((ids) => emit('extract-workflow', ids)),
 		c: () => emit('start-chat'),
+		ctrl_alt_o: () => emit('open:about'),
 	};
 	return fullKeymap;
 });

--- a/packages/frontend/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/Canvas.vue
@@ -107,6 +107,7 @@ const emit = defineEmits<{
 	'viewport:change': [viewport: ViewportTransform, dimensions: Dimensions];
 	'selection:end': [position: XYPosition];
 	'open:sub-workflow': [nodeId: string];
+	'open:about': [];
 	'start-chat': [];
 	'extract-workflow': [ids: string[]];
 }>();

--- a/packages/frontend/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/Canvas.vue
@@ -107,7 +107,6 @@ const emit = defineEmits<{
 	'viewport:change': [viewport: ViewportTransform, dimensions: Dimensions];
 	'selection:end': [position: XYPosition];
 	'open:sub-workflow': [nodeId: string];
-	'open:about': [];
 	'start-chat': [];
 	'extract-workflow': [ids: string[]];
 }>();
@@ -346,7 +345,6 @@ const keyMap = computed(() => {
 		shift_alt_t: async () => await onTidyUp({ source: 'keyboard-shortcut' }),
 		alt_x: emitWithSelectedNodes((ids) => emit('extract-workflow', ids)),
 		c: () => emit('start-chat'),
-		ctrl_alt_o: () => emit('open:about'),
 	};
 	return fullKeymap;
 });

--- a/packages/frontend/editor-ui/src/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/views/NodeView.vue
@@ -140,6 +140,7 @@ import CanvasChatButton from '@/components/canvas/elements/buttons/CanvasChatBut
 import { useFocusPanelStore } from '@/stores/focusPanel.store';
 import { useAITemplatesStarterCollectionStore } from '@/experiments/aiTemplatesStarterCollection/stores/aiTemplatesStarterCollection.store';
 import { useReadyToRunWorkflowsStore } from '@/experiments/readyToRunWorkflows/stores/readyToRunWorkflows.store';
+import { useKeybindings } from '@/composables/useKeybindings';
 
 defineOptions({
 	name: 'NodeView',
@@ -255,6 +256,9 @@ const {
 const { extractWorkflow } = useWorkflowExtraction();
 const { applyExecutionData } = useExecutionDebugging();
 useClipboard({ onPaste: onClipboardPaste });
+useKeybindings({
+	ctrl_alt_o: () => uiStore.openModal(ABOUT_MODAL_KEY),
+});
 
 const isLoading = ref(true);
 const isBlankRedirect = ref(false);
@@ -2083,7 +2087,6 @@ onBeforeUnmount(() => {
 			@toggle:focus-panel="onToggleFocusPanel"
 			@extract-workflow="onExtractWorkflow"
 			@start-chat="startChat()"
-			@open:about="uiStore.openModal(ABOUT_MODAL_KEY)"
 		>
 			<Suspense>
 				<LazySetupWorkflowCredentialsButton :class="$style.setupCredentialsButtonWrapper" />

--- a/packages/frontend/editor-ui/src/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/views/NodeView.vue
@@ -67,6 +67,7 @@ import {
 	VIEWS,
 	NDV_UI_OVERHAUL_EXPERIMENT,
 	WORKFLOW_SETTINGS_MODAL_KEY,
+	ABOUT_MODAL_KEY,
 } from '@/constants';
 import { useSourceControlStore } from '@/stores/sourceControl.store';
 import { useNodeCreatorStore } from '@/stores/nodeCreator.store';
@@ -2082,6 +2083,7 @@ onBeforeUnmount(() => {
 			@toggle:focus-panel="onToggleFocusPanel"
 			@extract-workflow="onExtractWorkflow"
 			@start-chat="startChat()"
+			@open:about="uiStore.openModal(ABOUT_MODAL_KEY)"
 		>
 			<Suspense>
 				<LazySetupWorkflowCredentialsButton :class="$style.setupCredentialsButtonWrapper" />


### PR DESCRIPTION
## Summary

Add a shortcut to open the About modal in order to make verifying the n8n version on the demo route easier.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3931/add-hotkey-to-bring-up-debug-info


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
