### PR TITLE
fix: Do not include word 'workflow' in auto-generated name (no-changelog)

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/chains/workflow-name.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/chains/workflow-name.ts
@@ -9,7 +9,7 @@ const workflowNamingPromptTemplate = PromptTemplate.fromTemplate(
 {initialPrompt}
 </initial_prompt>
 
-This name should be concise, descriptive, and suitable for a workflow that automates tasks related to the given prompt. The name should be in a format that is easy to read and understand.
+This name should be concise, descriptive, and suitable for a workflow that automates tasks related to the given prompt. The name should be in a format that is easy to read and understand. Do not include the word "workflow" in the name.
 `,
 );
 


### PR DESCRIPTION
## Summary

Minor change in the workflow auto-naming prompt to not include the word "workflow".

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
