### PR TITLE
fix(editor): Dont check for whats new if in demo mode

### DIFF
--- a/packages/frontend/editor-ui/src/init.ts
+++ b/packages/frontend/editor-ui/src/init.ts
@@ -14,7 +14,7 @@ import { useToast } from '@/composables/useToast';
 import { useI18n } from '@n8n/i18n';
 import SourceControlInitializationErrorMessage from '@/components/SourceControlInitializationErrorMessage.vue';
 import { useSSOStore } from '@/stores/sso.store';
-import { EnterpriseEditionFeature } from '@/constants';
+import { EnterpriseEditionFeature, VIEWS } from '@/constants';
 import type { UserManagementAuthenticationMethod } from '@/Interface';
 import { useUIStore } from '@/stores/ui.store';
 import type { BannerName } from '@n8n/api-types';
@@ -111,6 +111,7 @@ export async function initializeCore() {
  */
 export async function initializeAuthenticatedFeatures(
 	initialized: boolean = authenticatedFeaturesInitialized,
+	routeName?: string,
 ) {
 	if (initialized) {
 		return;
@@ -175,7 +176,8 @@ export async function initializeAuthenticatedFeatures(
 		void insightsStore.weeklySummary.execute();
 	}
 
-	if (!settingsStore.isPreviewMode) {
+	// Don't check for new versions in preview mode or demo view (ex: executions iframe)
+	if (!settingsStore.isPreviewMode && routeName !== VIEWS.DEMO) {
 		void versionsStore.checkForNewVersions();
 	}
 

--- a/packages/frontend/editor-ui/src/router.ts
+++ b/packages/frontend/editor-ui/src/router.ts
@@ -788,7 +788,8 @@ router.beforeEach(async (to: RouteLocationNormalized, from, next) => {
 		 */
 
 		await initializeCore();
-		await initializeAuthenticatedFeatures();
+		// Pass undefined for first param to use default
+		await initializeAuthenticatedFeatures(undefined, to.name as string);
 
 		/**
 		 * Redirect to setup page. User should be redirected to this only once

--- a/packages/frontend/editor-ui/src/stores/versions.store.ts
+++ b/packages/frontend/editor-ui/src/stores/versions.store.ts
@@ -4,7 +4,6 @@ import {
 	LOCAL_STORAGE_DISMISSED_WHATS_NEW_CALLOUT,
 	LOCAL_STORAGE_READ_WHATS_NEW_ARTICLES,
 	VERSIONS_MODAL_KEY,
-	VIEWS,
 	WHATS_NEW_MODAL_KEY,
 } from '@/constants';
 import { STORES } from '@n8n/stores';
@@ -20,7 +19,6 @@ import { useUsersStore } from './users.store';
 import { useStorage } from '@/composables/useStorage';
 import { jsonParse } from 'n8n-workflow';
 import { useTelemetry } from '@/composables/useTelemetry';
-import { useRoute } from 'vue-router';
 
 type SetVersionParams = { versions: Version[]; currentVersion: string };
 
@@ -56,7 +54,6 @@ export const useVersionsStore = defineStore(STORES.VERSIONS, () => {
 	const uiStore = useUIStore();
 	const settingsStore = useSettingsStore();
 	const usersStore = useUsersStore();
-	const route = useRoute();
 	const readWhatsNewArticlesStorage = useStorage(LOCAL_STORAGE_READ_WHATS_NEW_ARTICLES);
 	const lastDismissedWhatsNewCalloutStorage = useStorage(LOCAL_STORAGE_DISMISSED_WHATS_NEW_CALLOUT);
 
@@ -174,11 +171,6 @@ export const useVersionsStore = defineStore(STORES.VERSIONS, () => {
 	};
 
 	const shouldShowWhatsNewCallout = (): boolean => {
-		// Never show if embedded, e.g. in executions iframe
-		if (route.name === VIEWS.DEMO) {
-			return false;
-		}
-
 		const createdAt = usersStore.currentUser?.createdAt;
 		let hasNewArticle = false;
 		if (createdAt) {


### PR DESCRIPTION
## Summary

In the check we had in `versions.store.ts`, the value of `route.name` was often undefined.
This is because the route is fetched at store creation level, which is at time before the init of Vue Router. 
As an alternative, the route information is now being passed to the initialization function

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3926/feature-whats-new-box-being-shown-twice

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
