### PR TITLE
fix: Allow node-cli to be published (no-changelog)

### DIFF
--- a/packages/@n8n/node-cli/package.json
+++ b/packages/@n8n/node-cli/package.json
@@ -1,5 +1,5 @@
 {
-  "private": true,
+  "private": false,
   "name": "@n8n/node-cli",
   "version": "0.1.0",
   "description": "Official CLI for developing community nodes for n8n",


### PR DESCRIPTION
## Summary
Allows the `node-cli` to be published as a public package.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
