### PR TITLE
chore(core): Enforce email format for user entity, remove unused user validators

### DIFF
--- a/packages/@n8n/db/package.json
+++ b/packages/@n8n/db/package.json
@@ -38,7 +38,8 @@
     "p-lazy": "3.1.0",
     "reflect-metadata": "catalog:",
     "uuid": "catalog:",
-    "xss": "catalog:"
+    "xss": "catalog:",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@n8n/typescript-config": "workspace:*",

--- a/packages/@n8n/db/src/entities/__tests__/user.entity.test.ts
+++ b/packages/@n8n/db/src/entities/__tests__/user.entity.test.ts
@@ -1,3 +1,5 @@
+import { UserError } from 'n8n-workflow';
+
 import { User } from '../user';
 
 describe('User Entity', () => {
@@ -31,5 +33,219 @@ describe('User Entity', () => {
 				expect(user.createPersonalProjectName()).toBe(projectName);
 			},
 		);
+	});
+
+	describe('preUpsertHook email validation', () => {
+		describe('valid email scenarios', () => {
+			it('should allow null email', () => {
+				const user = new User();
+				(user as { email: string | null }).email = null;
+
+				expect(() => user.preUpsertHook()).not.toThrow();
+				expect(user.email).toBeNull();
+			});
+
+			it('should allow undefined email', () => {
+				const user = new User();
+				(user as { email: string | undefined }).email = undefined;
+
+				expect(() => user.preUpsertHook()).not.toThrow();
+				expect(user.email).toBeNull();
+			});
+
+			it('should lowercase valid emails', () => {
+				const user = new User();
+				user.email = 'TEST@EXAMPLE.COM';
+
+				expect(() => user.preUpsertHook()).not.toThrow();
+				expect(user.email).toBe('test@example.com');
+			});
+
+			it('should accept standard valid email formats', () => {
+				const validEmails = [
+					'test@example.com',
+					'user.name@example.com',
+					'user+tag@example.com',
+					'user123@example123.com',
+					'test@sub.example.com',
+					'a@b.co',
+				];
+
+				validEmails.forEach((email) => {
+					const user = new User();
+					user.email = email;
+
+					expect(() => user.preUpsertHook()).not.toThrow();
+					expect(user.email).toBe(email.toLowerCase());
+				});
+			});
+		});
+
+		describe('invalid email scenarios', () => {
+			it('should throw UserError for invalid email format', () => {
+				const user = new User();
+				user.email = 'invalid-email';
+
+				expect(() => user.preUpsertHook()).toThrow(UserError);
+				expect(() => user.preUpsertHook()).toThrow('Invalid email address: invalid-email');
+			});
+
+			it('should throw UserError for email without domain', () => {
+				const user = new User();
+				user.email = 'test@';
+
+				expect(() => user.preUpsertHook()).toThrow(UserError);
+				expect(() => user.preUpsertHook()).toThrow('Invalid email address: test@');
+			});
+
+			it('should throw UserError for email without @ symbol', () => {
+				const user = new User();
+				user.email = 'testexample.com';
+
+				expect(() => user.preUpsertHook()).toThrow(UserError);
+				expect(() => user.preUpsertHook()).toThrow('Invalid email address: testexample.com');
+			});
+
+			it('should throw UserError for email without local part', () => {
+				const user = new User();
+				user.email = '@example.com';
+
+				expect(() => user.preUpsertHook()).toThrow(UserError);
+				expect(() => user.preUpsertHook()).toThrow('Invalid email address: @example.com');
+			});
+
+			it('should throw UserError for various invalid formats', () => {
+				const invalidEmails = [
+					'test..email@example.com',
+					'test@',
+					'@example.com',
+					'test@@example.com',
+					'test @example.com',
+					'test@ example.com',
+					'.test@example.com',
+					'test.@example.com',
+					'test@example.',
+					'test@.example.com',
+				];
+
+				invalidEmails.forEach((email) => {
+					const user = new User();
+					user.email = email;
+
+					expect(() => user.preUpsertHook()).toThrow(UserError);
+					expect(() => user.preUpsertHook()).toThrow(`Invalid email address: ${email}`);
+				});
+			});
+		});
+
+		describe('edge cases', () => {
+			it('should throw UserError for empty string email', () => {
+				const user = new User();
+				user.email = '';
+
+				expect(() => user.preUpsertHook()).toThrow(UserError);
+				expect(() => user.preUpsertHook()).toThrow('Invalid email address: ');
+			});
+
+			it('should throw UserError for whitespace-only email', () => {
+				const user = new User();
+				user.email = '   ';
+
+				expect(() => user.preUpsertHook()).toThrow(UserError);
+				expect(() => user.preUpsertHook()).toThrow('Invalid email address:    ');
+			});
+
+			it('should throw UserError for very long invalid email', () => {
+				const user = new User();
+				const longInvalidEmail = 'a'.repeat(300) + '@invalid';
+				user.email = longInvalidEmail;
+
+				expect(() => user.preUpsertHook()).toThrow(UserError);
+				expect(() => user.preUpsertHook()).toThrow(`Invalid email address: ${longInvalidEmail}`);
+			});
+
+			it('should throw UserError for emails with special characters that should fail', () => {
+				const invalidEmailsWithSpecialChars = [
+					'test<>@example.com',
+					'test[]@example.com',
+					'test()@example.com',
+					'test,@example.com',
+					'test;@example.com',
+					'test:@example.com',
+					'test"@example.com',
+					'test\\@example.com',
+				];
+
+				invalidEmailsWithSpecialChars.forEach((email) => {
+					const user = new User();
+					user.email = email;
+
+					expect(() => user.preUpsertHook()).toThrow(UserError);
+					expect(() => user.preUpsertHook()).toThrow(`Invalid email address: ${email}`);
+				});
+			});
+		});
+
+		describe('BeforeInsert and BeforeUpdate triggers', () => {
+			it('should validate email during entity creation (BeforeInsert)', () => {
+				const user = new User();
+				user.email = 'invalid-email-format';
+
+				// The preUpsertHook is decorated with @BeforeInsert, so it should be called
+				expect(() => user.preUpsertHook()).toThrow(UserError);
+				expect(() => user.preUpsertHook()).toThrow('Invalid email address: invalid-email-format');
+			});
+
+			it('should validate email during entity update (BeforeUpdate)', () => {
+				const user = new User();
+				user.email = 'valid@example.com';
+
+				// First call should succeed
+				expect(() => user.preUpsertHook()).not.toThrow();
+
+				// Change to invalid email
+				user.email = 'invalid-email';
+
+				// The preUpsertHook is decorated with @BeforeUpdate, so it should be called
+				expect(() => user.preUpsertHook()).toThrow(UserError);
+				expect(() => user.preUpsertHook()).toThrow('Invalid email address: invalid-email');
+			});
+
+			it('should preserve email lowercasing functionality during lifecycle events', () => {
+				const user = new User();
+				user.email = 'VALID@EXAMPLE.COM';
+
+				expect(() => user.preUpsertHook()).not.toThrow();
+				expect(user.email).toBe('valid@example.com');
+			});
+
+			it('should handle null/undefined to valid email transitions', () => {
+				const user = new User();
+				(user as { email: string | null }).email = null;
+
+				// First call with null should succeed
+				expect(() => user.preUpsertHook()).not.toThrow();
+				expect(user.email).toBeNull();
+
+				// Change to valid email should succeed
+				user.email = 'valid@example.com';
+				expect(() => user.preUpsertHook()).not.toThrow();
+				expect(user.email).toBe('valid@example.com');
+			});
+
+			it('should handle valid to invalid email transitions', () => {
+				const user = new User();
+				user.email = 'valid@example.com';
+
+				// First call with valid email should succeed
+				expect(() => user.preUpsertHook()).not.toThrow();
+				expect(user.email).toBe('valid@example.com');
+
+				// Change to invalid email should throw
+				user.email = 'invalid-email';
+				expect(() => user.preUpsertHook()).toThrow(UserError);
+				expect(() => user.preUpsertHook()).toThrow('Invalid email address: invalid-email');
+			});
+		});
 	});
 });

--- a/packages/@n8n/db/src/entities/__tests__/user.entity.test.ts
+++ b/packages/@n8n/db/src/entities/__tests__/user.entity.test.ts
@@ -1,5 +1,3 @@
-import { UserError } from 'n8n-workflow';
-
 import { User } from '../user';
 
 describe('User Entity', () => {
@@ -82,39 +80,47 @@ describe('User Entity', () => {
 		});
 
 		describe('invalid email scenarios', () => {
-			it('should throw UserError for invalid email format', () => {
+			it('should throw Error for invalid email format', () => {
 				const user = new User();
 				user.email = 'invalid-email';
 
-				expect(() => user.preUpsertHook()).toThrow(UserError);
-				expect(() => user.preUpsertHook()).toThrow('Invalid email address: invalid-email');
+				expect(() => user.preUpsertHook()).toThrow(Error);
+				expect(() => user.preUpsertHook()).toThrow(
+					'Cannot save user <invalid-email>: Provided email is invalid',
+				);
 			});
 
-			it('should throw UserError for email without domain', () => {
+			it('should throw Error for email without domain', () => {
 				const user = new User();
 				user.email = 'test@';
 
-				expect(() => user.preUpsertHook()).toThrow(UserError);
-				expect(() => user.preUpsertHook()).toThrow('Invalid email address: test@');
+				expect(() => user.preUpsertHook()).toThrow(Error);
+				expect(() => user.preUpsertHook()).toThrow(
+					'Cannot save user <test@>: Provided email is invalid',
+				);
 			});
 
-			it('should throw UserError for email without @ symbol', () => {
+			it('should throw Error for email without @ symbol', () => {
 				const user = new User();
 				user.email = 'testexample.com';
 
-				expect(() => user.preUpsertHook()).toThrow(UserError);
-				expect(() => user.preUpsertHook()).toThrow('Invalid email address: testexample.com');
+				expect(() => user.preUpsertHook()).toThrow(Error);
+				expect(() => user.preUpsertHook()).toThrow(
+					'Cannot save user <testexample.com>: Provided email is invalid',
+				);
 			});
 
-			it('should throw UserError for email without local part', () => {
+			it('should throw Error for email without local part', () => {
 				const user = new User();
 				user.email = '@example.com';
 
-				expect(() => user.preUpsertHook()).toThrow(UserError);
-				expect(() => user.preUpsertHook()).toThrow('Invalid email address: @example.com');
+				expect(() => user.preUpsertHook()).toThrow(Error);
+				expect(() => user.preUpsertHook()).toThrow(
+					'Cannot save user <@example.com>: Provided email is invalid',
+				);
 			});
 
-			it('should throw UserError for various invalid formats', () => {
+			it('should throw Error for various invalid formats', () => {
 				const invalidEmails = [
 					'test..email@example.com',
 					'test@',
@@ -132,39 +138,47 @@ describe('User Entity', () => {
 					const user = new User();
 					user.email = email;
 
-					expect(() => user.preUpsertHook()).toThrow(UserError);
-					expect(() => user.preUpsertHook()).toThrow(`Invalid email address: ${email}`);
+					expect(() => user.preUpsertHook()).toThrow(Error);
+					expect(() => user.preUpsertHook()).toThrow(
+						`Cannot save user <${email}>: Provided email is invalid`,
+					);
 				});
 			});
 		});
 
 		describe('edge cases', () => {
-			it('should throw UserError for empty string email', () => {
+			it('should throw Error for empty string email', () => {
 				const user = new User();
 				user.email = '';
 
-				expect(() => user.preUpsertHook()).toThrow(UserError);
-				expect(() => user.preUpsertHook()).toThrow('Invalid email address: ');
+				expect(() => user.preUpsertHook()).toThrow(Error);
+				expect(() => user.preUpsertHook()).toThrow(
+					'Cannot save user <>: Provided email is invalid',
+				);
 			});
 
-			it('should throw UserError for whitespace-only email', () => {
+			it('should throw Error for whitespace-only email', () => {
 				const user = new User();
 				user.email = '   ';
 
-				expect(() => user.preUpsertHook()).toThrow(UserError);
-				expect(() => user.preUpsertHook()).toThrow('Invalid email address:    ');
+				expect(() => user.preUpsertHook()).toThrow(Error);
+				expect(() => user.preUpsertHook()).toThrow(
+					'Cannot save user <   >: Provided email is invalid',
+				);
 			});
 
-			it('should throw UserError for very long invalid email', () => {
+			it('should throw Error for very long invalid email', () => {
 				const user = new User();
 				const longInvalidEmail = 'a'.repeat(300) + '@invalid';
 				user.email = longInvalidEmail;
 
-				expect(() => user.preUpsertHook()).toThrow(UserError);
-				expect(() => user.preUpsertHook()).toThrow(`Invalid email address: ${longInvalidEmail}`);
+				expect(() => user.preUpsertHook()).toThrow(Error);
+				expect(() => user.preUpsertHook()).toThrow(
+					`Cannot save user <${longInvalidEmail}>: Provided email is invalid`,
+				);
 			});
 
-			it('should throw UserError for emails with special characters that should fail', () => {
+			it('should throw Error for emails with special characters that should fail', () => {
 				const invalidEmailsWithSpecialChars = [
 					'test<>@example.com',
 					'test[]@example.com',
@@ -180,8 +194,10 @@ describe('User Entity', () => {
 					const user = new User();
 					user.email = email;
 
-					expect(() => user.preUpsertHook()).toThrow(UserError);
-					expect(() => user.preUpsertHook()).toThrow(`Invalid email address: ${email}`);
+					expect(() => user.preUpsertHook()).toThrow(Error);
+					expect(() => user.preUpsertHook()).toThrow(
+						`Cannot save user <${email}>: Provided email is invalid`,
+					);
 				});
 			});
 		});
@@ -192,8 +208,10 @@ describe('User Entity', () => {
 				user.email = 'invalid-email-format';
 
 				// The preUpsertHook is decorated with @BeforeInsert, so it should be called
-				expect(() => user.preUpsertHook()).toThrow(UserError);
-				expect(() => user.preUpsertHook()).toThrow('Invalid email address: invalid-email-format');
+				expect(() => user.preUpsertHook()).toThrow(Error);
+				expect(() => user.preUpsertHook()).toThrow(
+					'Cannot save user <invalid-email-format>: Provided email is invalid',
+				);
 			});
 
 			it('should validate email during entity update (BeforeUpdate)', () => {
@@ -207,8 +225,10 @@ describe('User Entity', () => {
 				user.email = 'invalid-email';
 
 				// The preUpsertHook is decorated with @BeforeUpdate, so it should be called
-				expect(() => user.preUpsertHook()).toThrow(UserError);
-				expect(() => user.preUpsertHook()).toThrow('Invalid email address: invalid-email');
+				expect(() => user.preUpsertHook()).toThrow(Error);
+				expect(() => user.preUpsertHook()).toThrow(
+					'Cannot save user <invalid-email>: Provided email is invalid',
+				);
 			});
 
 			it('should preserve email lowercasing functionality during lifecycle events', () => {
@@ -243,8 +263,10 @@ describe('User Entity', () => {
 
 				// Change to invalid email should throw
 				user.email = 'invalid-email';
-				expect(() => user.preUpsertHook()).toThrow(UserError);
-				expect(() => user.preUpsertHook()).toThrow('Invalid email address: invalid-email');
+				expect(() => user.preUpsertHook()).toThrow(Error);
+				expect(() => user.preUpsertHook()).toThrow(
+					'Cannot save user <invalid-email>: Provided email is invalid',
+				);
 			});
 		});
 	});

--- a/packages/@n8n/db/src/entities/user.ts
+++ b/packages/@n8n/db/src/entities/user.ts
@@ -10,8 +10,9 @@ import {
 	PrimaryGeneratedColumn,
 	BeforeInsert,
 } from '@n8n/typeorm';
-import { IsEmail, IsString, Length } from 'class-validator';
+import { IsEmail, validateSync } from 'class-validator';
 import type { IUser, IUserSettings } from 'n8n-workflow';
+import { UserError } from 'n8n-workflow';
 
 import { JsonColumn, WithTimestamps } from './abstract-entity';
 import type { ApiKey } from './api-key';
@@ -21,8 +22,6 @@ import type { SharedCredentials } from './shared-credentials';
 import type { SharedWorkflow } from './shared-workflow';
 import type { IPersonalizationSurveyAnswers } from './types-db';
 import { lowerCaser, objectRetriever } from '../utils/transformers';
-import { NoUrl } from '../utils/validators/no-url.validator';
-import { NoXss } from '../utils/validators/no-xss.validator';
 
 @Entity()
 export class User extends WithTimestamps implements IUser, AuthPrincipal {
@@ -39,21 +38,12 @@ export class User extends WithTimestamps implements IUser, AuthPrincipal {
 	email: string;
 
 	@Column({ length: 32, nullable: true })
-	@NoXss()
-	@NoUrl()
-	@IsString({ message: 'First name must be of type string.' })
-	@Length(1, 32, { message: 'First name must be $constraint1 to $constraint2 characters long.' })
 	firstName: string;
 
 	@Column({ length: 32, nullable: true })
-	@NoXss()
-	@NoUrl()
-	@IsString({ message: 'Last name must be of type string.' })
-	@Length(1, 32, { message: 'Last name must be $constraint1 to $constraint2 characters long.' })
 	lastName: string;
 
 	@Column({ type: String, nullable: true })
-	@IsString({ message: 'Password must be of type string.' })
 	password: string | null;
 
 	@JsonColumn({
@@ -90,6 +80,15 @@ export class User extends WithTimestamps implements IUser, AuthPrincipal {
 	@BeforeUpdate()
 	preUpsertHook(): void {
 		this.email = this.email?.toLowerCase() ?? null;
+
+		// Validate email if present (including empty strings)
+		if (this.email !== null && this.email !== undefined) {
+			const errors = validateSync(this, { skipMissingProperties: true });
+			const emailError = errors.find((error) => error.property === 'email');
+			if (emailError) {
+				throw new UserError(`Invalid email address: ${this.email}`);
+			}
+		}
 	}
 
 	@Column({ type: Boolean, default: false })

--- a/packages/@n8n/db/src/entities/user.ts
+++ b/packages/@n8n/db/src/entities/user.ts
@@ -11,7 +11,6 @@ import {
 	BeforeInsert,
 } from '@n8n/typeorm';
 import type { IUser, IUserSettings } from 'n8n-workflow';
-import { z } from 'zod';
 
 import { JsonColumn, WithTimestamps } from './abstract-entity';
 import type { ApiKey } from './api-key';
@@ -20,6 +19,7 @@ import type { ProjectRelation } from './project-relation';
 import type { SharedCredentials } from './shared-credentials';
 import type { SharedWorkflow } from './shared-workflow';
 import type { IPersonalizationSurveyAnswers } from './types-db';
+import { isValidEmail } from '../utils/is-valid-email';
 import { lowerCaser, objectRetriever } from '../utils/transformers';
 
 @Entity()
@@ -81,8 +81,8 @@ export class User extends WithTimestamps implements IUser, AuthPrincipal {
 
 		// Validate email if present (including empty strings)
 		if (this.email !== null && this.email !== undefined) {
-			const result = z.string().email().safeParse(this.email);
-			if (!result.success) {
+			const result = isValidEmail(this.email);
+			if (!result) {
 				throw new Error(`Cannot save user <${this.email}>: Provided email is invalid`);
 			}
 		}

--- a/packages/@n8n/db/src/index.ts
+++ b/packages/@n8n/db/src/index.ts
@@ -11,6 +11,7 @@ export {
 
 export { generateNanoId } from './utils/generators';
 export { isStringArray } from './utils/is-string-array';
+export { isValidEmail } from './utils/is-valid-email';
 export { separate } from './utils/separate';
 export { sql } from './utils/sql';
 export { idStringifier, lowerCaser, objectRetriever, sqlite } from './utils/transformers';

--- a/packages/@n8n/db/src/utils/is-valid-email.ts
+++ b/packages/@n8n/db/src/utils/is-valid-email.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+
+export function isValidEmail(email: string): boolean {
+	return z.string().email().safeParse(email).success;
+}

--- a/packages/cli/src/ldap.ee/ldap.service.ee.ts
+++ b/packages/cli/src/ldap.ee/ldap.service.ee.ts
@@ -351,7 +351,7 @@ export class LdapService {
 
 		const filteredUsersToCreate = usersToCreate.filter(([id, user]) => {
 			if (!isValidEmail(user.email)) {
-				this.logger.error(`LDAP - Invalid email format for user ${id}`);
+				this.logger.warn(`LDAP - Invalid email format for user ${id}`);
 				return false;
 			}
 			return true;
@@ -359,7 +359,7 @@ export class LdapService {
 
 		const filteredUsersToUpdate = usersToUpdate.filter(([id, user]) => {
 			if (!isValidEmail(user.email)) {
-				this.logger.error(`LDAP - Invalid email format for user ${id}`);
+				this.logger.warn(`LDAP - Invalid email format for user ${id}`);
 				return false;
 			}
 			return true;

--- a/packages/cli/src/ldap.ee/ldap.service.ee.ts
+++ b/packages/cli/src/ldap.ee/ldap.service.ee.ts
@@ -2,7 +2,7 @@ import { Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import type { LdapConfig } from '@n8n/constants';
 import { LDAP_FEATURE_NAME } from '@n8n/constants';
-import { SettingsRepository } from '@n8n/db';
+import { isValidEmail, SettingsRepository } from '@n8n/db';
 import type { User, RunningMode, SyncStatus } from '@n8n/db';
 import { Service, Container } from '@n8n/di';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
@@ -349,9 +349,25 @@ export class LdapService {
 			localAdUsers,
 		);
 
+		const filteredUsersToCreate = usersToCreate.filter(([id, user]) => {
+			if (!isValidEmail(user.email)) {
+				this.logger.error(`LDAP - Invalid email format for user ${id}`);
+				return false;
+			}
+			return true;
+		});
+
+		const filteredUsersToUpdate = usersToUpdate.filter(([id, user]) => {
+			if (!isValidEmail(user.email)) {
+				this.logger.error(`LDAP - Invalid email format for user ${id}`);
+				return false;
+			}
+			return true;
+		});
+
 		this.logger.debug('LDAP - Users to process', {
-			created: usersToCreate.length,
-			updated: usersToUpdate.length,
+			created: filteredUsersToCreate.length,
+			updated: filteredUsersToUpdate.length,
 			disabled: usersToDisable.length,
 		});
 
@@ -361,7 +377,7 @@ export class LdapService {
 
 		try {
 			if (mode === 'live') {
-				await processUsers(usersToCreate, usersToUpdate, usersToDisable);
+				await processUsers(filteredUsersToCreate, filteredUsersToUpdate, usersToDisable);
 			}
 		} catch (error) {
 			if (error instanceof QueryFailedError) {
@@ -373,8 +389,8 @@ export class LdapService {
 		await saveLdapSynchronization({
 			startedAt,
 			endedAt,
-			created: usersToCreate.length,
-			updated: usersToUpdate.length,
+			created: filteredUsersToCreate.length,
+			updated: filteredUsersToUpdate.length,
 			disabled: usersToDisable.length,
 			scanned: adUsers.length,
 			runMode: mode,
@@ -385,7 +401,8 @@ export class LdapService {
 		this.eventService.emit('ldap-general-sync-finished', {
 			type: !this.syncTimer ? 'scheduled' : `manual_${mode}`,
 			succeeded: true,
-			usersSynced: usersToCreate.length + usersToUpdate.length + usersToDisable.length,
+			usersSynced:
+				filteredUsersToCreate.length + filteredUsersToUpdate.length + usersToDisable.length,
 			error: errorMessage,
 		});
 

--- a/packages/cli/src/sso.ee/oidc/oidc.service.ee.ts
+++ b/packages/cli/src/sso.ee/oidc/oidc.service.ee.ts
@@ -4,6 +4,7 @@ import { GlobalConfig } from '@n8n/config';
 import {
 	AuthIdentity,
 	AuthIdentityRepository,
+	isValidEmail,
 	SettingsRepository,
 	type User,
 	UserRepository,
@@ -102,6 +103,10 @@ export class OidcService {
 
 		if (!userInfo.email) {
 			throw new BadRequestError('An email is required');
+		}
+
+		if (!isValidEmail(userInfo.email)) {
+			throw new BadRequestError('Invalid email format');
 		}
 
 		const openidUser = await this.authIdentityRepository.findOne({

--- a/packages/cli/src/sso.ee/saml/saml.service.ee.ts
+++ b/packages/cli/src/sso.ee/saml/saml.service.ee.ts
@@ -1,7 +1,7 @@
 import type { SamlPreferences } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import type { Settings, User } from '@n8n/db';
-import { SettingsRepository, UserRepository } from '@n8n/db';
+import { isValidEmail, SettingsRepository, UserRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
 import axios from 'axios';
 import type express from 'express';
@@ -197,6 +197,11 @@ export class SamlService {
 		const attributes = await this.getAttributesFromLoginResponse(req, binding);
 		if (attributes.email) {
 			const lowerCasedEmail = attributes.email.toLowerCase();
+
+			if (!isValidEmail(lowerCasedEmail)) {
+				throw new BadRequestError('Invalid email format');
+			}
+
 			const user = await this.userRepository.findOne({
 				where: { email: lowerCasedEmail },
 				relations: ['authIdentities'],

--- a/packages/cli/test/integration/auth.api.test.ts
+++ b/packages/cli/test/integration/auth.api.test.ts
@@ -382,7 +382,7 @@ describe('GET /resolve-signup-token', () => {
 
 		// cause inconsistent DB state
 		owner.email = '';
-		await Container.get(UserRepository).save(owner);
+		await Container.get(UserRepository).save(owner, { listeners: false });
 		const fifth = await authOwnerAgent
 			.get('/resolve-signup-token')
 			.query({ inviterId: owner.id })

--- a/packages/cli/test/integration/ldap/ldap.api.test.ts
+++ b/packages/cli/test/integration/ldap/ldap.api.test.ts
@@ -467,6 +467,9 @@ describe('POST /ldap/sync', () => {
 				expect.stringContaining(`LDAP - Invalid email format for user ${invalidLdapUser.uid}`),
 			);
 
+			loggerSpy.mockReset();
+			loggerSpy.mockRestore();
+
 			// Verify only valid user was created
 			const allUsers = await getAllUsers();
 			expect(allUsers.length).toBe(2); // owner + valid user
@@ -510,6 +513,9 @@ describe('POST /ldap/sync', () => {
 			expect(loggerSpy).toHaveBeenCalledWith(
 				expect.stringContaining(`LDAP - Invalid email format for user ${originalUserId}`),
 			);
+
+			loggerSpy.mockReset();
+			loggerSpy.mockRestore();
 
 			// Verify user still has original email
 			const localLdapIdentities = await getLdapIdentities();

--- a/packages/cli/test/integration/ldap/ldap.api.test.ts
+++ b/packages/cli/test/integration/ldap/ldap.api.test.ts
@@ -455,7 +455,7 @@ describe('POST /ldap/sync', () => {
 
 			const ldapUsers = [validLdapUser, invalidLdapUser];
 
-			const loggerSpy = jest.spyOn(Container.get(LdapService)['logger'], 'error');
+			const loggerSpy = jest.spyOn(Container.get(LdapService)['logger'], 'warn');
 
 			const synchronization = await runTest(ldapUsers);
 
@@ -466,6 +466,9 @@ describe('POST /ldap/sync', () => {
 			expect(loggerSpy).toHaveBeenCalledWith(
 				expect.stringContaining(`LDAP - Invalid email format for user ${invalidLdapUser.uid}`),
 			);
+
+			loggerSpy.mockReset();
+			loggerSpy.mockRestore();
 
 			// Verify only valid user was created
 			const allUsers = await getAllUsers();
@@ -499,7 +502,7 @@ describe('POST /ldap/sync', () => {
 				uid: originalUserId,
 			};
 
-			const loggerSpy = jest.spyOn(Container.get(LdapService)['logger'], 'error');
+			const loggerSpy = jest.spyOn(Container.get(LdapService)['logger'], 'warn');
 
 			const synchronization = await runTest([invalidLdapUser]);
 
@@ -510,6 +513,9 @@ describe('POST /ldap/sync', () => {
 			expect(loggerSpy).toHaveBeenCalledWith(
 				expect.stringContaining(`LDAP - Invalid email format for user ${originalUserId}`),
 			);
+
+			loggerSpy.mockReset();
+			loggerSpy.mockRestore();
 
 			// Verify user still has original email
 			const localLdapIdentities = await getLdapIdentities();

--- a/packages/cli/test/integration/ldap/ldap.api.test.ts
+++ b/packages/cli/test/integration/ldap/ldap.api.test.ts
@@ -435,6 +435,88 @@ describe('POST /ldap/sync', () => {
 			const response = await testServer.authAgentFor(member).get('/login');
 			expect(response.status).toBe(401);
 		});
+
+		test('should filter out users with invalid email addresses during sync', async () => {
+			const validLdapUser = {
+				mail: randomEmail(),
+				dn: '',
+				sn: randomName(),
+				givenName: randomName(),
+				uid: uniqueId(),
+			};
+
+			const invalidLdapUser = {
+				mail: 'invalid-email',
+				dn: '',
+				sn: randomName(),
+				givenName: randomName(),
+				uid: uniqueId(),
+			};
+
+			const ldapUsers = [validLdapUser, invalidLdapUser];
+
+			const loggerSpy = jest.spyOn(Container.get(LdapService)['logger'], 'error');
+
+			const synchronization = await runTest(ldapUsers);
+
+			// Should only create 1 user (the valid one)
+			expect(synchronization.created).toBe(1);
+
+			// Should log error for invalid email
+			expect(loggerSpy).toHaveBeenCalledWith(
+				expect.stringContaining(`LDAP - Invalid email format for user ${invalidLdapUser.uid}`),
+			);
+
+			// Verify only valid user was created
+			const allUsers = await getAllUsers();
+			expect(allUsers.length).toBe(2); // owner + valid user
+
+			const memberUser = allUsers.find((u) => u.email !== owner.email)!;
+			expect(memberUser.email).toBe(validLdapUser.mail);
+		});
+
+		test('should filter out users with invalid email addresses during update', async () => {
+			const originalEmail = randomEmail();
+			const originalUserId = uniqueId();
+
+			// Create user with valid email first
+			await createLdapUser(
+				{
+					role: 'global:member',
+					email: originalEmail,
+					firstName: randomName(),
+					lastName: randomName(),
+				},
+				originalUserId,
+			);
+
+			// Now try to update with invalid email
+			const invalidLdapUser = {
+				mail: 'not-an-email',
+				dn: '',
+				sn: randomName(),
+				givenName: randomName(),
+				uid: originalUserId,
+			};
+
+			const loggerSpy = jest.spyOn(Container.get(LdapService)['logger'], 'error');
+
+			const synchronization = await runTest([invalidLdapUser]);
+
+			// Should not update any users
+			expect(synchronization.updated).toBe(0);
+
+			// Should log error for invalid email
+			expect(loggerSpy).toHaveBeenCalledWith(
+				expect.stringContaining(`LDAP - Invalid email format for user ${originalUserId}`),
+			);
+
+			// Verify user still has original email
+			const localLdapIdentities = await getLdapIdentities();
+			const localLdapUsers = localLdapIdentities.map(({ user }) => user);
+			expect(localLdapUsers.length).toBe(1);
+			expect(localLdapUsers[0].email).toBe(originalEmail);
+		});
 	});
 });
 

--- a/packages/cli/test/integration/ldap/ldap.api.test.ts
+++ b/packages/cli/test/integration/ldap/ldap.api.test.ts
@@ -467,9 +467,6 @@ describe('POST /ldap/sync', () => {
 				expect.stringContaining(`LDAP - Invalid email format for user ${invalidLdapUser.uid}`),
 			);
 
-			loggerSpy.mockReset();
-			loggerSpy.mockRestore();
-
 			// Verify only valid user was created
 			const allUsers = await getAllUsers();
 			expect(allUsers.length).toBe(2); // owner + valid user
@@ -513,9 +510,6 @@ describe('POST /ldap/sync', () => {
 			expect(loggerSpy).toHaveBeenCalledWith(
 				expect.stringContaining(`LDAP - Invalid email format for user ${originalUserId}`),
 			);
-
-			loggerSpy.mockReset();
-			loggerSpy.mockRestore();
 
 			// Verify user still has original email
 			const localLdapIdentities = await getLdapIdentities();

--- a/packages/cli/test/integration/oidc/oidc.service.ee.test.ts
+++ b/packages/cli/test/integration/oidc/oidc.service.ee.test.ts
@@ -353,6 +353,83 @@ describe('OIDC service', () => {
 			await expect(oidcService.loginUser(callbackUrl)).rejects.toThrowError(BadRequestError);
 		});
 
+		it('should throw `BadRequestError` if OIDC Idp provides an invalid email format', async () => {
+			const callbackUrl = new URL(
+				'http://localhost:5678/rest/sso/oidc/callback?code=valid-code&state=valid-state',
+			);
+
+			const mockTokens: mocked_oidc_client.TokenEndpointResponse &
+				mocked_oidc_client.TokenEndpointResponseHelpers = {
+				access_token: 'mock-access-token-invalid',
+				id_token: 'mock-id-token-invalid',
+				token_type: 'bearer',
+				claims: () => {
+					return {
+						sub: 'mock-subject-invalid',
+						iss: 'https://example.com/auth/realms/n8n',
+						aud: 'test-client-id',
+						iat: Math.floor(Date.now() / 1000) - 1000,
+						exp: Math.floor(Date.now() / 1000) + 3600,
+					} as mocked_oidc_client.IDToken;
+				},
+				expiresIn: () => 3600,
+			} as mocked_oidc_client.TokenEndpointResponse &
+				mocked_oidc_client.TokenEndpointResponseHelpers;
+
+			authorizationCodeGrantMock.mockResolvedValueOnce(mockTokens);
+
+			// Provide an invalid email format
+			fetchUserInfoMock.mockResolvedValueOnce({
+				email_verified: true,
+				email: 'invalid-email-format',
+			});
+
+			const error = await oidcService.loginUser(callbackUrl).catch((e) => e);
+			expect(error.message).toBe('Invalid email format');
+		});
+
+		it('should handle multiple invalid email formats', async () => {
+			const callbackUrl = new URL(
+				'http://localhost:5678/rest/sso/oidc/callback?code=valid-code&state=valid-state',
+			);
+
+			const mockTokens: mocked_oidc_client.TokenEndpointResponse &
+				mocked_oidc_client.TokenEndpointResponseHelpers = {
+				access_token: 'mock-access-token-multi',
+				id_token: 'mock-id-token-multi',
+				token_type: 'bearer',
+				claims: () => {
+					return {
+						sub: 'mock-subject-multi',
+						iss: 'https://example.com/auth/realms/n8n',
+						aud: 'test-client-id',
+						iat: Math.floor(Date.now() / 1000) - 1000,
+						exp: Math.floor(Date.now() / 1000) + 3600,
+					} as mocked_oidc_client.IDToken;
+				},
+				expiresIn: () => 3600,
+			} as mocked_oidc_client.TokenEndpointResponse &
+				mocked_oidc_client.TokenEndpointResponseHelpers;
+
+			const invalidEmails = [
+				'not-an-email',
+				'@missinglocal.com',
+				'missing@.com',
+				'spaces in@email.com',
+				'double@@domain.com',
+			];
+
+			for (const invalidEmail of invalidEmails) {
+				authorizationCodeGrantMock.mockResolvedValueOnce(mockTokens);
+				fetchUserInfoMock.mockResolvedValueOnce({
+					email_verified: true,
+					email: invalidEmail,
+				});
+
+				await expect(oidcService.loginUser(callbackUrl)).rejects.toThrowError(BadRequestError);
+			}
+		});
+
 		it('should throw `ForbiddenError` if OIDC token does not provide claims', async () => {
 			const callbackUrl = new URL(
 				'http://localhost:5678/rest/sso/oidc/callback?code=valid-code&state=valid-state',

--- a/packages/cli/test/integration/saml/saml-helpers.test.ts
+++ b/packages/cli/test/integration/saml/saml-helpers.test.ts
@@ -20,7 +20,7 @@ describe('sso/saml/samlHelpers', () => {
 			const samlUserAttributes: SamlUserAttributes = {
 				firstName: 'Nathan',
 				lastName: 'Nathaniel',
-				email: 'n@8.n',
+				email: 'nathan@n8n.io',
 				userPrincipalName: 'Huh?',
 			};
 

--- a/packages/cli/test/integration/saml/saml.api.test.ts
+++ b/packages/cli/test/integration/saml/saml.api.test.ts
@@ -380,21 +380,5 @@ describe('SAML email validation', () => {
 			expect(result).toBeDefined();
 			expect(result.attributes.email).toBe(upperCaseEmail); // Original email should be preserved in attributes
 		});
-
-		test('should handle no email provided case', async () => {
-			jest.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue({
-				email: undefined,
-				firstName: 'John',
-				lastName: 'Doe',
-				userPrincipalName: 'john.doe',
-			});
-
-			const mockRequest = {} as express.Request;
-
-			// Should not throw email validation error when no email is provided
-			// (other validation logic should handle this case)
-			const result = await samlService.handleSamlLogin(mockRequest, 'post');
-			expect(result).toBeDefined();
-		});
 	});
 });

--- a/packages/cli/test/integration/saml/saml.api.test.ts
+++ b/packages/cli/test/integration/saml/saml.api.test.ts
@@ -2,8 +2,11 @@ import { randomEmail, randomName, randomValidPassword } from '@n8n/backend-test-
 import { GlobalConfig } from '@n8n/config';
 import type { User } from '@n8n/db';
 import { Container } from '@n8n/di';
+import type express from 'express';
 
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { setSamlLoginEnabled } from '@/sso.ee/saml/saml-helpers';
+import { SamlService } from '@/sso.ee/saml/saml.service.ee';
 import {
 	getCurrentAuthenticationMethod,
 	setCurrentAuthenticationMethod,
@@ -280,6 +283,118 @@ describe('Check endpoint permissions', () => {
 
 		test('should NOT be able to access GET /sso/saml/config/test', async () => {
 			await testServer.authlessAgent.get('/sso/saml/config/test').expect(401);
+		});
+	});
+});
+
+describe('SAML email validation', () => {
+	let samlService: SamlService;
+
+	beforeAll(async () => {
+		samlService = Container.get(SamlService);
+	});
+
+	describe('handleSamlLogin', () => {
+		test('should throw BadRequestError for invalid email format', async () => {
+			// Mock getAttributesFromLoginResponse to return invalid email
+			jest.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue({
+				email: 'invalid-email-format',
+				firstName: 'John',
+				lastName: 'Doe',
+				userPrincipalName: 'john.doe',
+			});
+
+			const mockRequest = {} as express.Request;
+
+			await expect(samlService.handleSamlLogin(mockRequest, 'post')).rejects.toThrow(
+				new BadRequestError('Invalid email format'),
+			);
+		});
+
+		test('should throw BadRequestError for multiple invalid email formats', async () => {
+			const invalidEmails = [
+				'not-an-email',
+				'@missinglocal.com',
+				'missing@.com',
+				'spaces in@email.com',
+				'double@@domain.com',
+				'trailing.dot@domain.com.',
+				'user@',
+			];
+
+			const mockRequest = {} as express.Request;
+
+			for (const invalidEmail of invalidEmails) {
+				jest.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue({
+					email: invalidEmail,
+					firstName: 'John',
+					lastName: 'Doe',
+					userPrincipalName: 'john.doe',
+				});
+
+				await expect(samlService.handleSamlLogin(mockRequest, 'post')).rejects.toThrow(
+					new BadRequestError('Invalid email format'),
+				);
+			}
+		});
+
+		test('should handle valid email formats successfully', async () => {
+			const validEmails = [
+				'user@example.com',
+				'test.email@domain.org',
+				'user+tag@example.com',
+				'user123@test-domain.com',
+			];
+
+			const mockRequest = {} as express.Request;
+
+			for (const validEmail of validEmails) {
+				jest.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue({
+					email: validEmail,
+					firstName: 'John',
+					lastName: 'Doe',
+					userPrincipalName: 'john.doe',
+				});
+
+				// Should not throw an error for valid emails
+				const result = await samlService.handleSamlLogin(mockRequest, 'post');
+				expect(result).toBeDefined();
+				expect(result.attributes.email).toBe(validEmail);
+			}
+		});
+
+		test('should convert email to lowercase before validation', async () => {
+			const upperCaseEmail = 'USER@EXAMPLE.COM';
+
+			jest.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue({
+				email: upperCaseEmail,
+				firstName: 'John',
+				lastName: 'Doe',
+				userPrincipalName: 'john.doe',
+			});
+
+			const mockRequest = {} as express.Request;
+
+			// Should not throw an error as the email is valid when converted to lowercase
+			const result = await samlService.handleSamlLogin(mockRequest, 'post');
+			expect(result).toBeDefined();
+			expect(result.attributes.email).toBe(upperCaseEmail); // Original email should be preserved in attributes
+		});
+
+		test('should handle no email provided case', async () => {
+			jest.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue({
+				email: undefined,
+				firstName: 'John',
+				lastName: 'Doe',
+				userPrincipalName: 'john.doe',
+			});
+
+			const mockRequest = {} as express.Request;
+
+			// Should not throw email validation error when no email is provided
+			// (other validation logic should handle this case)
+			const result = await samlService.handleSamlLogin(mockRequest, 'post');
+			expect(result).toBeDefined();
 		});
 	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -698,6 +698,9 @@ importers:
       xss:
         specifier: 'catalog:'
         version: 1.0.15
+      zod:
+        specifier: 'catalog:'
+        version: 3.25.67
     devDependencies:
       '@n8n/typescript-config':
         specifier: workspace:*
@@ -25552,7 +25555,7 @@ snapshots:
 
   eslint-import-resolver-node@0.3.9:
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
       is-core-module: 2.16.1
       resolve: 1.22.10
     transitivePeerDependencies:
@@ -25576,7 +25579,7 @@ snapshots:
 
   eslint-module-utils@2.12.1(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@1.21.7))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.3)(eslint@9.29.0(jiti@1.21.7)):
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
     optionalDependencies:
       '@typescript-eslint/parser': 8.35.0(eslint@9.29.0(jiti@1.21.7))(typescript@5.9.2)
       eslint: 9.29.0(jiti@1.21.7)
@@ -25615,7 +25618,7 @@ snapshots:
       array.prototype.findlastindex: 1.2.6
       array.prototype.flat: 1.3.3
       array.prototype.flatmap: 1.3.3
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
       doctrine: 2.1.0
       eslint: 9.29.0(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
@@ -26574,7 +26577,7 @@ snapshots:
       array-parallel: 0.1.3
       array-series: 0.1.5
       cross-spawn: 7.0.6
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -29979,7 +29982,7 @@ snapshots:
 
   pdf-parse@1.1.1:
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
       node-ensure: 0.0.0
     transitivePeerDependencies:
       - supports-color
@@ -30967,7 +30970,7 @@ snapshots:
 
   rhea@1.0.24:
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Summary

The class-validators on the user entity were never enforced, we should make sure that we only store valid email values into the database. Since the other validators are not enforced, they were removed for now.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-3180/provision-users-with-invalid-email-field

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
