### PR TITLE
chore: Silence lint warnings for playwright package

### DIFF
--- a/packages/testing/playwright/package.json
+++ b/packages/testing/playwright/package.json
@@ -19,7 +19,7 @@
     "install-browsers:local": "playwright install chromium --with-deps",
     "install-browsers:ci": "PLAYWRIGHT_BROWSERS_PATH=./ms-playwright-cache playwright install chromium --with-deps",
     "browsers:uninstall": "playwright uninstall --all",
-    "lint": "eslint .",
+    "lint": "eslint . --quiet",
     "lint:fix": "eslint . --fix"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

We lint with `--quiet` to prevent noise like [this](https://github.com/n8n-io/n8n/pull/18485/files#diff-f90353821ae9b3c15d5bd1b1d5c7e7e59c96406be4eca064c8a8edcd0112c817) on every PR.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
