### PR TITLE
fix(Postgres Node): Enable non-numeric comparisons for WHERE clause operators

### DIFF
--- a/packages/nodes-base/nodes/Postgres/test/v2/utils.test.ts
+++ b/packages/nodes-base/nodes/Postgres/test/v2/utils.test.ts
@@ -217,6 +217,85 @@ describe('Test PostgresV2, addWhereClauses', () => {
 		);
 		expect(updatedValues).toEqual(['public', 'my_table', 'id', '1', 'foo', 'select 2']);
 	});
+
+	it('should handle numeric comparison operators', () => {
+		const query = 'SELECT * FROM $1:name.$2:name';
+		const values = ['public', 'my_table'];
+		const whereClauses = [
+			{ column: 'age', condition: '>', value: '25' },
+			{ column: 'salary', condition: '>=', value: '50000' },
+		];
+
+		const [updatedQuery, updatedValues] = addWhereClauses(
+			node,
+			0,
+			query,
+			whereClauses,
+			values,
+			'AND',
+		);
+
+		expect(updatedQuery).toEqual(
+			'SELECT * FROM $1:name.$2:name WHERE $3:name > $4 AND $5:name >= $6',
+		);
+		// Values should be converted to numbers
+		expect(updatedValues).toEqual(['public', 'my_table', 'age', 25, 'salary', 50000]);
+	});
+
+	it('should handle date comparison operators', () => {
+		const query = 'SELECT * FROM $1:name.$2:name';
+		const values = ['public', 'my_table'];
+		const whereClauses = [
+			{ column: 'created_at', condition: '>=', value: '2025-04-28T00:00:00.000Z' },
+			{ column: 'updated_at', condition: '<', value: '2025-05-01' },
+		];
+
+		const [updatedQuery, updatedValues] = addWhereClauses(
+			node,
+			0,
+			query,
+			whereClauses,
+			values,
+			'AND',
+		);
+
+		expect(updatedQuery).toEqual(
+			'SELECT * FROM $1:name.$2:name WHERE $3:name >= $4 AND $5:name < $6',
+		);
+		// Date strings should remain as strings
+		expect(updatedValues).toEqual([
+			'public',
+			'my_table',
+			'created_at',
+			'2025-04-28T00:00:00.000Z',
+			'updated_at',
+			'2025-05-01',
+		]);
+	});
+
+	it('should handle string comparison operators', () => {
+		const query = 'SELECT * FROM $1:name.$2:name';
+		const values = ['public', 'my_table'];
+		const whereClauses = [
+			{ column: 'name', condition: '>', value: 'M' },
+			{ column: 'category', condition: '<=', value: 'Electronics' },
+		];
+
+		const [updatedQuery, updatedValues] = addWhereClauses(
+			node,
+			0,
+			query,
+			whereClauses,
+			values,
+			'AND',
+		);
+
+		expect(updatedQuery).toEqual(
+			'SELECT * FROM $1:name.$2:name WHERE $3:name > $4 AND $5:name <= $6',
+		);
+		// Text strings should remain as strings
+		expect(updatedValues).toEqual(['public', 'my_table', 'name', 'M', 'category', 'Electronics']);
+	});
 });
 
 describe('Test PostgresV2, addSortRules', () => {

--- a/packages/nodes-base/nodes/Postgres/test/v2/utils.test.ts
+++ b/packages/nodes-base/nodes/Postgres/test/v2/utils.test.ts
@@ -296,6 +296,37 @@ describe('Test PostgresV2, addWhereClauses', () => {
 		// Text strings should remain as strings
 		expect(updatedValues).toEqual(['public', 'my_table', 'name', 'M', 'category', 'Electronics']);
 	});
+
+	it('should not convert empty strings or whitespace-only strings to numbers', () => {
+		const query = 'SELECT * FROM $1:name.$2:name';
+		const values = ['public', 'my_table'];
+		const whereClauses = [
+			{ column: 'empty_field', condition: '>', value: '' },
+			{ column: 'whitespace_field', condition: '>=', value: '   ' },
+		];
+
+		const [updatedQuery, updatedValues] = addWhereClauses(
+			node,
+			0,
+			query,
+			whereClauses,
+			values,
+			'AND',
+		);
+
+		expect(updatedQuery).toEqual(
+			'SELECT * FROM $1:name.$2:name WHERE $3:name > $4 AND $5:name >= $6',
+		);
+		// These should NOT be converted to numbers
+		expect(updatedValues).toEqual([
+			'public',
+			'my_table',
+			'empty_field',
+			'',
+			'whitespace_field',
+			'   ',
+		]);
+	});
 });
 
 describe('Test PostgresV2, addSortRules', () => {

--- a/packages/nodes-base/nodes/Postgres/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/helpers/utils.ts
@@ -128,8 +128,8 @@ export function parsePostgresError(
 }
 
 export function addWhereClauses(
-	node: INode,
-	itemIndex: number,
+	_node: INode,
+	_itemIndex: number,
 	query: string,
 	clauses: WhereClause[],
 	replacements: QueryValues,
@@ -153,21 +153,12 @@ export function addWhereClauses(
 			clause.condition = '=';
 		}
 		if (['>', '<', '>=', '<='].includes(clause.condition)) {
-			const value = Number(clause.value);
+			const numericValue = Number(clause.value);
 
-			if (Number.isNaN(value)) {
-				throw new NodeOperationError(
-					node,
-					`Operator in entry ${index + 1} of 'Select Rows' works with numbers, but value ${
-						clause.value
-					} is not a number`,
-					{
-						itemIndex,
-					},
-				);
+			// Convert to number if numeric, otherwise keep as string for dates/text
+			if (!Number.isNaN(numericValue)) {
+				clause.value = numericValue;
 			}
-
-			clause.value = value;
 		}
 		const columnReplacement = `$${replacementIndex}:name`;
 		values.push(clause.column);

--- a/packages/nodes-base/nodes/Postgres/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/helpers/utils.ts
@@ -153,7 +153,12 @@ export function addWhereClauses(
 			clause.condition = '=';
 		}
 		if (['>', '<', '>=', '<='].includes(clause.condition)) {
-			const numericValue = Number(clause.value);
+			const numericValue =
+				typeof clause.value === 'string' &&
+				clause.value.trim() !== '' &&
+				!Number.isNaN(Number(clause.value))
+					? Number(clause.value)
+					: NaN;
 
 			// Convert to number if numeric, otherwise keep as string for dates/text
 			if (!Number.isNaN(numericValue)) {

--- a/packages/nodes-base/nodes/Postgres/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/helpers/utils.ts
@@ -153,15 +153,8 @@ export function addWhereClauses(
 			clause.condition = '=';
 		}
 		if (['>', '<', '>=', '<='].includes(clause.condition)) {
-			const numericValue =
-				typeof clause.value === 'string' &&
-				clause.value.trim() !== '' &&
-				!Number.isNaN(Number(clause.value))
-					? Number(clause.value)
-					: NaN;
-
-			// Convert to number if numeric, otherwise keep as string for dates/text
-			if (!Number.isNaN(numericValue)) {
+			const numericValue = Number(clause.value);
+			if (String(clause.value).trim() !== '' && !Number.isNaN(numericValue)) {
 				clause.value = numericValue;
 			}
 		}


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
This PR fixes an issue where the Postgres node threw "not a number" errors when using comparison operators (`>`, `>=`, `<`, `<=`) with dates or strings in WHERE clauses. The fix removes the numeric-only restriction while maintaining performance by converting numeric strings to numbers and leaving other values as strings for PostgreSQL's native type handling. This enables essential database operations like date comparisons (`created_at >= '2025-04-28'`) and string comparisons (`name > 'M'`).

### Screenshot
<img width="922" height="838" alt="image" src="https://github.com/user-attachments/assets/a23f3988-2618-4fdb-8d31-79dd607f2c39" />


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
Closes #14971 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
