### PR TITLE
fix(editor): Change the underlying data store db column types to support decimal numbers

### DIFF
--- a/packages/@n8n/db/src/migrations/dsl/column.ts
+++ b/packages/@n8n/db/src/migrations/dsl/column.ts
@@ -9,7 +9,8 @@ export class Column {
 		| 'json'
 		| 'timestamptz'
 		| 'timestamp'
-		| 'uuid';
+		| 'uuid'
+		| 'float';
 
 	private isGenerated = false;
 
@@ -36,6 +37,11 @@ export class Column {
 
 	get int() {
 		this.type = 'int';
+		return this;
+	}
+
+	get float() {
+		this.type = 'float';
 		return this;
 	}
 
@@ -162,6 +168,14 @@ export class Column {
 			if (isMysql) options.type = 'varchar(36)';
 			// we haven't been defining length on "uuid" varchar on sqlite
 			if (isSqlite) options.type = 'varchar';
+		} else if (type === 'float') {
+			if (isPostgres) {
+				options.type = 'double precision';
+			} else if (isMysql) {
+				options.type = 'double';
+			} else if (isSqlite) {
+				options.type = 'real';
+			}
 		}
 
 		if (

--- a/packages/@n8n/db/src/migrations/dsl/column.ts
+++ b/packages/@n8n/db/src/migrations/dsl/column.ts
@@ -10,7 +10,7 @@ export class Column {
 		| 'timestamptz'
 		| 'timestamp'
 		| 'uuid'
-		| 'float';
+		| 'double';
 
 	private isGenerated = false;
 
@@ -40,8 +40,8 @@ export class Column {
 		return this;
 	}
 
-	get float() {
-		this.type = 'float';
+	get double() {
+		this.type = 'double';
 		return this;
 	}
 
@@ -168,7 +168,7 @@ export class Column {
 			if (isMysql) options.type = 'varchar(36)';
 			// we haven't been defining length on "uuid" varchar on sqlite
 			if (isSqlite) options.type = 'varchar';
-		} else if (type === 'float') {
+		} else if (type === 'double') {
 			if (isPostgres) {
 				options.type = 'double precision';
 			} else if (isMysql) {

--- a/packages/cli/src/modules/data-store/__tests__/data-store.controller.test.ts
+++ b/packages/cli/src/modules/data-store/__tests__/data-store.controller.test.ts
@@ -62,7 +62,7 @@ beforeEach(async () => {
 });
 
 afterAll(async () => {
-	// await testDb.terminate();
+	await testDb.terminate();
 });
 
 describe('POST /projects/:projectId/data-stores', () => {

--- a/packages/cli/src/modules/data-store/__tests__/data-store.controller.test.ts
+++ b/packages/cli/src/modules/data-store/__tests__/data-store.controller.test.ts
@@ -62,7 +62,7 @@ beforeEach(async () => {
 });
 
 afterAll(async () => {
-	await testDb.terminate();
+	// await testDb.terminate();
 });
 
 describe('POST /projects/:projectId/data-stores', () => {
@@ -2072,6 +2072,14 @@ describe('POST /projects/:projectId/data-stores/:dataStoreId/insert', () => {
 					name: 'c',
 					type: 'number',
 				},
+				{
+					name: 'd',
+					type: 'number',
+				},
+				{
+					name: 'e',
+					type: 'number',
+				},
 			],
 		});
 
@@ -2081,7 +2089,8 @@ describe('POST /projects/:projectId/data-stores/:dataStoreId/insert', () => {
 					a: 1,
 					b: 0,
 					c: -1,
-					// d: 0.2340439341231259,
+					d: 0.2340439341231259,
+					e: 2340439341231259,
 				},
 			],
 		};
@@ -2099,8 +2108,7 @@ describe('POST /projects/:projectId/data-stores/:dataStoreId/insert', () => {
 		expect(readResponse.body.data.data[0]).toMatchObject(payload.data[0]);
 	});
 
-	// eslint-disable-next-line n8n-local-rules/no-skipped-tests
-	test.skip('should insert columns with null values', async () => {
+	test('should insert columns with null values', async () => {
 		const dataStore = await createDataStore(memberProject, {
 			columns: [
 				{

--- a/packages/cli/src/modules/data-store/__tests__/sql-utils.test.ts
+++ b/packages/cli/src/modules/data-store/__tests__/sql-utils.test.ts
@@ -10,13 +10,40 @@ import {
 
 describe('sql-utils', () => {
 	describe('addColumnQuery', () => {
-		it('should generate a valid SQL query for adding columns to a table', () => {
+		it('should generate a valid SQL query for adding columns to a table, sqlite', () => {
 			const tableName = 'data_store_user_abc';
 			const column = { name: 'email', type: 'number' as const };
 
 			const query = addColumnQuery(tableName, column, 'sqlite');
 
-			expect(query).toBe('ALTER TABLE "data_store_user_abc" ADD "email" FLOAT');
+			expect(query).toBe('ALTER TABLE "data_store_user_abc" ADD "email" REAL');
+		});
+
+		it('should generate a valid SQL query for adding columns to a table, postgres', () => {
+			const tableName = 'data_store_user_abc';
+			const column = { name: 'email', type: 'number' as const };
+
+			const query = addColumnQuery(tableName, column, 'postgres');
+
+			expect(query).toBe('ALTER TABLE "data_store_user_abc" ADD "email" DOUBLE PRECISION');
+		});
+
+		it('should generate a valid SQL query for adding columns to a table, mysql', () => {
+			const tableName = 'data_store_user_abc';
+			const column = { name: 'email', type: 'number' as const };
+
+			const query = addColumnQuery(tableName, column, 'mysql');
+
+			expect(query).toBe('ALTER TABLE `data_store_user_abc` ADD `email` DOUBLE');
+		});
+
+		it('should generate a valid SQL query for adding columns to a table, mariadb', () => {
+			const tableName = 'data_store_user_abc';
+			const column = { name: 'email', type: 'number' as const };
+
+			const query = addColumnQuery(tableName, column, 'mariadb');
+
+			expect(query).toBe('ALTER TABLE `data_store_user_abc` ADD `email` DOUBLE');
 		});
 	});
 

--- a/packages/cli/src/modules/data-store/utils/sql-utils.ts
+++ b/packages/cli/src/modules/data-store/utils/sql-utils.ts
@@ -18,7 +18,7 @@ export function toDslColumns(columns: DataStoreCreateColumnSchema[]): DslColumn[
 
 		switch (col.type) {
 			case 'number':
-				return name.float;
+				return name.double;
 			case 'boolean':
 				return name.bool;
 			case 'string':
@@ -48,7 +48,7 @@ function dataStoreColumnTypeToSql(
 				case 'sqlite':
 					return 'REAL';
 				default:
-					return 'FLOAT';
+					return 'DOUBLE';
 			}
 		case 'boolean':
 			return 'BOOLEAN';

--- a/packages/cli/src/modules/data-store/utils/sql-utils.ts
+++ b/packages/cli/src/modules/data-store/utils/sql-utils.ts
@@ -18,7 +18,7 @@ export function toDslColumns(columns: DataStoreCreateColumnSchema[]): DslColumn[
 
 		switch (col.type) {
 			case 'number':
-				return name.int;
+				return name.float;
 			case 'boolean':
 				return name.bool;
 			case 'string':
@@ -39,7 +39,17 @@ function dataStoreColumnTypeToSql(
 		case 'string':
 			return 'TEXT';
 		case 'number':
-			return 'FLOAT';
+			switch (dbType) {
+				case 'postgres':
+					return 'DOUBLE PRECISION';
+				case 'mysql':
+				case 'mariadb':
+					return 'DOUBLE';
+				case 'sqlite':
+					return 'REAL';
+				default:
+					return 'FLOAT';
+			}
 		case 'boolean':
 			return 'BOOLEAN';
 		case 'date':


### PR DESCRIPTION
## Summary

The database number columns were mistakenly defined as integer columns on postgres/mysql databases.

To fix this define the columns as floating point 64-bit columns, they should hopefully be able to store numbers originating from javascript code pretty well.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3937/be-fix-number-column-types

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
