### PR TITLE
chore(core): Change incorrect node output sentry error to ignore previous one

### DIFF
--- a/packages/core/src/execution-engine/__tests__/workflow-execute-run-node.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute-run-node.test.ts
@@ -527,7 +527,7 @@ describe('WorkflowExecute.runNode - Real Implementation', () => {
 
 			// Verify that ErrorReporter.error was called due to invalid JSON data
 			expect(mockErrorReporter.error).toHaveBeenCalledWith(
-				'node execution returned incorrect data',
+				'node execution returned incorrect output',
 				expect.objectContaining({
 					shouldBeLogged: false,
 					extra: expect.objectContaining({

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -1196,7 +1196,7 @@ export class WorkflowExecute {
 			// Does not block the execution from continuing
 			const jsonCompatibleResult = isJsonCompatible(data, new Set(['pairedItem']));
 			if (!jsonCompatibleResult.isValid) {
-				Container.get(ErrorReporter).error('node execution returned incorrect data', {
+				Container.get(ErrorReporter).error('node execution returned incorrect output', {
 					shouldBeLogged: false,
 					extra: {
 						nodeName: node.name,


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR changes the error wording for node returning incorrect output data, so that we can ignore previous sentry errors which were triggered too frequently (ref: https://github.com/n8n-io/n8n/pull/18198).

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-3201/error-node-execution-returned-incorrect-data

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
