### PR TITLE
feat(editor): Add mechanism for showing hidden nodes if required modules are enabled

### DIFF
--- a/packages/frontend/editor-ui/src/constants.ts
+++ b/packages/frontend/editor-ui/src/constants.ts
@@ -12,6 +12,7 @@ import type {
 } from '@/types';
 import type { ComputedRef, InjectionKey, Ref } from 'vue';
 import type { ExpressionLocalResolveContext } from './types/expressions';
+import { DATA_STORE_MODULE_NAME } from './features/dataStore/constants';
 
 export const MAX_WORKFLOW_SIZE = 1024 * 1024 * 16; // Workflow size limit in bytes
 export const MAX_EXPECTED_REQUEST_SIZE = 2048; // Expected maximum workflow request metadata (i.e. headers) size in bytes
@@ -223,6 +224,7 @@ export const SLACK_TRIGGER_NODE_TYPE = 'n8n-nodes-base.slackTrigger';
 export const TELEGRAM_TRIGGER_NODE_TYPE = 'n8n-nodes-base.telegramTrigger';
 export const FACEBOOK_LEAD_ADS_TRIGGER_NODE_TYPE = 'n8n-nodes-base.facebookLeadAdsTrigger';
 export const RESPOND_TO_WEBHOOK_NODE_TYPE = 'n8n-nodes-base.respondToWebhook';
+export const DATA_STORE_NODE_TYPE = 'n8n-nodes-base.dataStore';
 
 export const CREDENTIAL_ONLY_NODE_PREFIX = 'n8n-creds-base';
 export const CREDENTIAL_ONLY_HTTP_NODE_VERSION = 4.1;
@@ -249,6 +251,10 @@ export const NODES_USING_CODE_NODE_EDITOR = [
 	CODE_NODE_TYPE,
 	AI_CODE_NODE_TYPE,
 	AI_TRANSFORM_NODE_TYPE,
+];
+
+export const MODULE_ENABLED_NODES = [
+	{ nodeType: DATA_STORE_NODE_TYPE, module: DATA_STORE_MODULE_NAME },
 ];
 
 export const NODE_POSITION_CONFLICT_ALLOWLIST = [STICKY_NODE_TYPE];

--- a/packages/frontend/editor-ui/src/features/dataStore/constants.ts
+++ b/packages/frontend/editor-ui/src/features/dataStore/constants.ts
@@ -23,3 +23,5 @@ export const COLUMN_NAME_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9-]*$/;
 export const NO_TABLE_YET_MESSAGE = 'SQLITE_ERROR: no such table:';
 
 export const MIN_LOADING_TIME = 500; // ms
+
+export const DATA_STORE_MODULE_NAME = 'data-store';

--- a/packages/frontend/editor-ui/src/stores/nodeTypes.store.ts
+++ b/packages/frontend/editor-ui/src/stores/nodeTypes.store.ts
@@ -6,7 +6,11 @@ import type {
 	ResourceMapperFieldsRequestDto,
 } from '@n8n/api-types';
 import * as nodeTypesApi from '@n8n/rest-api-client/api/nodeTypes';
-import { HTTP_REQUEST_NODE_TYPE, CREDENTIAL_ONLY_HTTP_NODE_VERSION } from '@/constants';
+import {
+	HTTP_REQUEST_NODE_TYPE,
+	CREDENTIAL_ONLY_HTTP_NODE_VERSION,
+	MODULE_ENABLED_NODES,
+} from '@/constants';
 import { STORES } from '@n8n/stores';
 import type { NodeTypesByTypeNameAndVersion } from '@/Interface';
 import { addHeaders, addNodeTranslation } from '@n8n/i18n';
@@ -30,7 +34,6 @@ import { computed, ref } from 'vue';
 import { useActionsGenerator } from '../components/Node/NodeCreator/composables/useActionsGeneration';
 import { removePreviewToken } from '../components/Node/NodeCreator/utils';
 import { useSettingsStore } from '@/stores/settings.store';
-import { DATA_STORE_MODULE_NAME } from '@/features/dataStore/constants';
 
 export type NodeTypesStore = ReturnType<typeof useNodeTypesStore>;
 
@@ -86,13 +89,9 @@ export const useNodeTypesStore = defineStore(STORES.NODE_TYPES, () => {
 			.filter(Boolean);
 	});
 
+	// Nodes defined with `hidden: true` that are still shown if their modules are enabled
 	const moduleEnabledNodeTypes = computed<INodeTypeDescription[]>(() => {
-		// Nodes defined with `hidden: true`, but shown if certain modules are enabled
-		const moduleEnabledNodes = [
-			{ nodeType: 'n8n-nodes-base.dataStore', module: DATA_STORE_MODULE_NAME },
-		];
-
-		return moduleEnabledNodes.flatMap((node) => {
+		return MODULE_ENABLED_NODES.flatMap((node) => {
 			const nodeVersions = nodeTypes.value[node.nodeType] ?? {};
 			const versionNumbers = Object.keys(nodeVersions).map(Number);
 			const latest = nodeVersions[Math.max(...versionNumbers)];


### PR DESCRIPTION
## Summary

Add a mechanism for showing `hidden: true` nodes if certain modules are enabled on the backend. This is to enable us developing new modules that introduce new nodes without having to worry about those showing up for our end users prematurely.

Use this mechanism to show the Data Store node if the data-store module is enabled, the node will be added on another ticket.

For now there's just the Data stores node use case, but made it generic anyways.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3940/only-show-the-node-if-data-stores-module-is-enabled

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
