### PR TITLE
fix: Do not wait for community nodes to load

### DIFF
--- a/packages/frontend/editor-ui/src/stores/nodeTypes.store.ts
+++ b/packages/frontend/editor-ui/src/stores/nodeTypes.store.ts
@@ -316,8 +316,6 @@ export const useNodeTypesStore = defineStore(STORES.NODE_TYPES, () => {
 	const getNodeTypes = async () => {
 		const nodeTypes = await nodeTypesApi.getNodeTypes(rootStore.baseUrl);
 
-		await fetchCommunityNodePreviews();
-
 		if (nodeTypes.length) {
 			setNodeTypes(nodeTypes);
 		}
@@ -417,6 +415,7 @@ export const useNodeTypesStore = defineStore(STORES.NODE_TYPES, () => {
 		isConfigurableNode,
 		communityNodesAndActions,
 		communityNodeType,
+		fetchCommunityNodePreviews,
 		getResourceMapperFields,
 		getLocalResourceMapperFields,
 		getNodeParameterActionResult,

--- a/packages/frontend/editor-ui/src/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/views/NodeView.vue
@@ -343,6 +343,8 @@ async function initializeData() {
 
 	try {
 		await Promise.all(loadPromises);
+		//We don't need to await this as community node previews are not critical and needed only in nodes search panel
+		void nodeTypesStore.fetchCommunityNodePreviews();
 	} catch (error) {
 		toast.showError(
 			error,


### PR DESCRIPTION
## Summary
This PR improves the performance of community nodes fetching by:

- Moving the fetch community nodes call outside of the getNodes function
- Centralizing the call to execute in only one location
- Using void to make the call non-blocking and avoid waiting for completion

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-3416/community-issue-community-node-types-is-blocking-the-frontend-from
Fixes https://github.com/n8n-io/n8n/issues/15841

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
