### PR TITLE
chore(core): Show a warning if `N8N_BLOCK_ENV_ACCESS_IN_NODE` is not set

### DIFF
--- a/packages/cli/src/deprecation/__tests__/deprecation.service.test.ts
+++ b/packages/cli/src/deprecation/__tests__/deprecation.service.test.ts
@@ -237,8 +237,6 @@ describe('DeprecationService', () => {
 
 	describe('N8N_BLOCK_ENV_ACCESS_IN_NODE', () => {
 		beforeEach(() => {
-			// Ignore environment variables coming in from the environment when running
-			// this test suite.
 			process.env = {
 				N8N_RUNNERS_ENABLED: 'true',
 			};

--- a/packages/cli/src/deprecation/__tests__/deprecation.service.test.ts
+++ b/packages/cli/src/deprecation/__tests__/deprecation.service.test.ts
@@ -18,7 +18,9 @@ describe('DeprecationService', () => {
 	beforeEach(() => {
 		// Ignore environment variables coming in from the environment when running
 		// this test suite.
-		process.env = {};
+		process.env = {
+			N8N_BLOCK_ENV_ACCESS_IN_NODE: 'false',
+		};
 
 		jest.resetAllMocks();
 	});
@@ -135,7 +137,10 @@ describe('DeprecationService', () => {
 		const envVar = 'OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS';
 
 		beforeEach(() => {
-			process.env = { N8N_RUNNERS_ENABLED: 'true' };
+			process.env = {
+				N8N_RUNNERS_ENABLED: 'true',
+				N8N_BLOCK_ENV_ACCESS_IN_NODE: 'false',
+			};
 
 			jest.spyOn(config, 'getEnv').mockImplementation((key) => {
 				if (key === 'executions.mode') return 'queue';
@@ -228,5 +233,32 @@ describe('DeprecationService', () => {
 				});
 			});
 		});
+	});
+
+	describe('N8N_BLOCK_ENV_ACCESS_IN_NODE', () => {
+		beforeEach(() => {
+			// Ignore environment variables coming in from the environment when running
+			// this test suite.
+			process.env = {
+				N8N_RUNNERS_ENABLED: 'true',
+			};
+
+			jest.resetAllMocks();
+		});
+
+		test('should warn when N8N_BLOCK_ENV_ACCESS_IN_NODE is not set', () => {
+			delete process.env.N8N_BLOCK_ENV_ACCESS_IN_NODE;
+			deprecationService.warn();
+			expect(logger.warn).toHaveBeenCalled();
+		});
+
+		test.each(['false', 'true'])(
+			'should not warn when N8N_BLOCK_ENV_ACCESS_IN_NODE is %s',
+			(value) => {
+				process.env.N8N_BLOCK_ENV_ACCESS_IN_NODE = value;
+				deprecationService.warn();
+				expect(logger.warn).not.toHaveBeenCalled();
+			},
+		);
 	});
 });

--- a/packages/cli/src/deprecation/deprecation.service.ts
+++ b/packages/cli/src/deprecation/deprecation.service.ts
@@ -106,7 +106,7 @@ export class DeprecationService {
 		{
 			envVar: 'N8N_BLOCK_ENV_ACCESS_IN_NODE',
 			message:
-				'The default value of N8N_BLOCK_ENV_ACCESS_IN_NODE will be changed from false to true. If you need to access environment variables from the Code Node or from expressions, please set N8N_BLOCK_ENV_ACCESS_IN_NODE=false. Learn more: https://docs.n8n.io/hosting/configuration/environment-variables/security/',
+				'The default value of N8N_BLOCK_ENV_ACCESS_IN_NODE will be changed from false to true in a future version. If you need to access environment variables from the Code Node or from expressions, please set N8N_BLOCK_ENV_ACCESS_IN_NODE=false. Learn more: https://docs.n8n.io/hosting/configuration/environment-variables/security/',
 			checkValue: (value: string | undefined) => value === undefined || value === '',
 		},
 	];

--- a/packages/cli/src/deprecation/deprecation.service.ts
+++ b/packages/cli/src/deprecation/deprecation.service.ts
@@ -103,6 +103,12 @@ export class DeprecationService {
 				'n8n does not support `own` mode since May 2023. Please remove this environment variable to allow n8n to start. If you need the isolation and performance gains, please consider queue mode: https://docs.n8n.io/hosting/scaling/queue-mode/',
 			checkValue: (value: string) => value === 'own',
 		},
+		{
+			envVar: 'N8N_BLOCK_ENV_ACCESS_IN_NODE',
+			message:
+				'The default value of N8N_BLOCK_ENV_ACCESS_IN_NODE will be changed from false to true. If you need to access environment variables from the Code Node or from expressions, please set N8N_BLOCK_ENV_ACCESS_IN_NODE=false. Learn more: https://docs.n8n.io/hosting/configuration/environment-variables/security/',
+			checkValue: (value: string | undefined) => value === undefined || value === '',
+		},
 	];
 
 	/** Runtime state of deprecation-related env vars. */


### PR DESCRIPTION
## Summary

The default value of `N8N_BLOCK_ENV_ACCESS_IN_NODE` will be changed from `false` to `true` in a future version. Show a warning for users who have not configured this environment variable.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1245/mark-n8n-block-env-access-in-nodedefault-value-to-change


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
