### PR TITLE
chore: Upgrade launcher to 1.2.0

### DIFF
--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -1,6 +1,6 @@
 ARG NODE_VERSION=22
 ARG N8N_VERSION=snapshot
-ARG LAUNCHER_VERSION=1.1.5
+ARG LAUNCHER_VERSION=1.2.0
 ARG TARGETPLATFORM
 
 # ==============================================================================


### PR DESCRIPTION
## Summary

Upgrade task runner launcher to [1.2.0](https://github.com/n8n-io/task-runner-launcher/releases/tag/1.2.0)

The new feature isn't being used yet, but this starts the clock on the deprecation included in https://github.com/n8n-io/task-runner-launcher/pull/68.

## Related Linear tickets, Github issues, and Community forum posts

n/a

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
