### PR TITLE
feat(core): Allow inserting rows into data stores with no columns (no-changelog)

### DIFF
--- a/packages/cli/src/modules/data-store/__tests__/data-store.service.test.ts
+++ b/packages/cli/src/modules/data-store/__tests__/data-store.service.test.ts
@@ -1174,24 +1174,6 @@ describe('dataStore', () => {
 			await expect(result).rejects.toThrow(DataStoreNotFoundError);
 		});
 
-		it('rejects on empty column list', async () => {
-			// ARRANGE
-			const { id: dataStoreId } = await dataStoreService.createDataStore(project1.id, {
-				name: 'dataStore',
-				columns: [],
-			});
-
-			// ACT
-			const result = dataStoreService.insertRows(dataStoreId, project1.id, [{}, {}]);
-
-			// ASSERT
-			await expect(result).rejects.toThrow(
-				new DataStoreValidationError(
-					'No columns found for this data store or data store not found',
-				),
-			);
-		});
-
 		it('fails on type mismatch', async () => {
 			// ARRANGE
 			const { id: dataStoreId } = await dataStoreService.createDataStore(project1.id, {
@@ -1209,6 +1191,29 @@ describe('dataStore', () => {
 			await expect(result).rejects.toThrow(
 				new DataStoreValidationError("value 'true' does not match column type 'number'"),
 			);
+		});
+
+		it('inserts rows into an existing table with no columns', async () => {
+			// ARRANGE
+			const { id: dataStoreId } = await dataStoreService.createDataStore(project1.id, {
+				name: 'dataStore',
+				columns: [],
+			});
+
+			// ACT
+			const rows = [{}, {}, {}];
+			const result = await dataStoreService.insertRows(dataStoreId, project1.id, rows);
+
+			// ASSERT
+			expect(result).toEqual([1, 2, 3]);
+
+			const { count, data } = await dataStoreService.getManyRowsAndCount(
+				dataStoreId,
+				project1.id,
+				{},
+			);
+			expect(count).toEqual(3);
+			expect(data).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
 		});
 	});
 

--- a/packages/cli/src/modules/data-store/data-store.service.ts
+++ b/packages/cli/src/modules/data-store/data-store.service.ts
@@ -210,12 +210,6 @@ export class DataStoreService {
 		includeSystemColumns = false,
 	): Promise<void> {
 		const columns = await this.dataStoreColumnRepository.getColumns(dataStoreId);
-		if (columns.length === 0) {
-			throw new DataStoreValidationError(
-				'No columns found for this data store or data store not found',
-			);
-		}
-
 		this.validateRowsWithColumns(rows, columns, allowPartial, includeSystemColumns);
 	}
 


### PR DESCRIPTION
## Summary

If user is working with a brand new data store with no columns we still want to allow inserting new rows into it, with just the auto generated ID column.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3946/be-allow-inserting-rows-to-data-stores-with-only-id-column

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
