### PR TITLE
feat(VectorStorePGVector Node): Add option to skip table validation and creation (no-changelog)

### DIFF
--- a/packages/@n8n/ai-utilities/src/utils/vector-store/createVectorStoreNode/createVectorStoreNode.ts
+++ b/packages/@n8n/ai-utilities/src/utils/vector-store/createVectorStoreNode/createVectorStoreNode.ts
@@ -301,7 +301,7 @@ export const createVectorStoreNode = <T extends VectorStore = VectorStore>(
 			// Handle each operation mode with dedicated modules
 			if (mode === 'load') {
 				const items = this.getInputData(0);
-				const resultData = [];
+				const resultData: INodeExecutionData[] = [];
 
 				for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
 					const docs = await handleLoadOperation(this, args, embeddings, itemIndex);
@@ -323,7 +323,7 @@ export const createVectorStoreNode = <T extends VectorStore = VectorStore>(
 
 			if (mode === 'retrieve-as-tool') {
 				const items = this.getInputData(0);
-				const resultData = [];
+				const resultData: INodeExecutionData[] = [];
 
 				for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
 					const docs = await handleRetrieveAsToolExecuteOperation(
@@ -332,7 +332,7 @@ export const createVectorStoreNode = <T extends VectorStore = VectorStore>(
 						embeddings,
 						itemIndex,
 					);
-					resultData.push(...docs);
+					resultData.push.apply(resultData, docs);
 				}
 
 				return [resultData];

--- a/packages/@n8n/ai-utilities/src/utils/vector-store/createVectorStoreNode/createVectorStoreNode.ts
+++ b/packages/@n8n/ai-utilities/src/utils/vector-store/createVectorStoreNode/createVectorStoreNode.ts
@@ -305,7 +305,7 @@ export const createVectorStoreNode = <T extends VectorStore = VectorStore>(
 
 				for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
 					const docs = await handleLoadOperation(this, args, embeddings, itemIndex);
-					resultData.push(...docs);
+					resultData.push.apply(resultData, docs);
 				}
 
 				return [resultData];

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.test.ts
@@ -1,5 +1,7 @@
-import { VectorStorePGVector } from '../VectorStorePGVector/VectorStorePGVector.node';
+import * as pgModule from '@langchain/community/vectorstores/pgvector'; // <- added
 import { configurePostgres } from 'n8n-nodes-base/dist/nodes/Postgres/transport/index';
+
+import { VectorStorePGVector } from '../VectorStorePGVector/VectorStorePGVector.node';
 
 // Mock configurePostgres
 jest.mock('n8n-nodes-base/dist/nodes/Postgres/transport/index', () => ({
@@ -21,7 +23,7 @@ jest.mock('../../vector_store/shared/createVectorStoreNode/operations', () => {
 		handleInsertOperation: jest.fn(async (ctx: any, args: any, embeddings: any) => {
 			// Simulate creation of documents and call the node's populateVectorStore function
 			const documents = [{ id: '1', pageContent: 'hello' }];
-			await (args as any).populateVectorStore(ctx, embeddings, documents, 0);
+			await args.populateVectorStore(ctx, embeddings, documents, 0);
 			return [];
 		}),
 		handleUpdateOperation: jest.fn(),
@@ -112,16 +114,18 @@ describe('VectorStorePGVector -> execute (load) triggers ----', () => {
 		};
 	};
 
-	const pgModule = require('@langchain/community/vectorstores/pgvector');
-
 	beforeEach(() => {
 		jest.resetAllMocks();
 
 		// configurePostgres returns an object with db.$pool
 		(configurePostgres as jest.Mock).mockResolvedValue({ db: { $pool: mockPool } });
 
-		pgModule.PGVectorStore.prototype.ensureTableInDatabase.mockResolvedValue(undefined);
-		pgModule.PGVectorStore.prototype.ensureCollectionTableInDatabase.mockResolvedValue(undefined);
+		(pgModule.PGVectorStore.prototype.ensureTableInDatabase as jest.Mock).mockResolvedValue(
+			undefined,
+		);
+		(
+			pgModule.PGVectorStore.prototype.ensureCollectionTableInDatabase as jest.Mock
+		).mockResolvedValue(undefined);
 
 		// The node expects embeddings from input connection; return a dummy object
 		const mockEmbeddings = {

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.test.ts
@@ -1,0 +1,168 @@
+import { VectorStorePGVector } from '../VectorStorePGVector/VectorStorePGVector.node';
+import { configurePostgres } from 'n8n-nodes-base/dist/nodes/Postgres/transport/index';
+
+// Mock configurePostgres
+jest.mock('n8n-nodes-base/dist/nodes/Postgres/transport/index', () => ({
+	configurePostgres: jest.fn(),
+}));
+
+// Mock helpers
+jest.mock('@utils/helpers', () => ({
+	logAiEvent: jest.fn(),
+	getMetadataFiltersValues: jest.fn().mockReturnValue(undefined),
+}));
+
+// We only need handleInsertOperation for the insert test; others can be simple stubs.
+jest.mock('../../vector_store/shared/createVectorStoreNode/operations', () => {
+	// Use the real module so we can call the actual implementation when needed
+	const actual = jest.requireActual('../../vector_store/shared/createVectorStoreNode/operations');
+	return {
+		...actual,
+		handleInsertOperation: jest.fn(async (ctx: any, args: any, embeddings: any) => {
+			// Simulate creation of documents and call the node's populateVectorStore function
+			const documents = [{ id: '1', pageContent: 'hello' }];
+			await (args as any).populateVectorStore(ctx, embeddings, documents, 0);
+			return [];
+		}),
+		handleUpdateOperation: jest.fn(),
+		handleRetrieveOperation: jest.fn(),
+		handleRetrieveAsToolOperation: jest.fn(),
+	};
+});
+
+// Provide a class-like mock so ExtendedPGVectorStore can extend it
+jest.mock('@langchain/community/vectorstores/pgvector', () => {
+	const mockFromDocuments = jest.fn();
+	class MockPGVectorStore {
+		static fromDocuments = mockFromDocuments;
+		constructor(
+			public embeddings?: any,
+			public args?: any,
+		) {
+			(this as any).client = null;
+			(this as any).filter = args?.filter ?? {};
+			this.args = args;
+		}
+
+		async _initializeClient() {
+			return;
+		}
+		async ensureTableInDatabase() {
+			return;
+		}
+		async ensureCollectionTableInDatabase() {
+			return;
+		}
+		async similaritySearchVectorWithScore() {
+			return [];
+		}
+	}
+
+	// Make instance methods mockable via prototype
+	MockPGVectorStore.prototype._initializeClient = jest.fn().mockResolvedValue(undefined);
+	MockPGVectorStore.prototype.ensureTableInDatabase = jest.fn().mockResolvedValue(undefined);
+	MockPGVectorStore.prototype.ensureCollectionTableInDatabase = jest
+		.fn()
+		.mockResolvedValue(undefined);
+
+	return { PGVectorStore: MockPGVectorStore, __esModule: true };
+});
+
+describe('VectorStorePGVector -> execute (load) triggers ----', () => {
+	const mockPool = { dummy: 'pool' };
+
+	const mockContext: any = {
+		initialize: jest.fn(),
+		// These will be used by the code path / or by our mocked handleInsertOperation
+		getNodeParameter: jest.fn(),
+		getInputConnectionData: jest.fn(),
+		getInputData: jest.fn(),
+		getCredentials: jest.fn(),
+		getNode: jest.fn(),
+	};
+
+	const mockGetNodeParameter = (skipValidation: boolean) => {
+		return (name: string, itemIndex: number, defaultValue: any) => {
+			if (name === 'mode') return 'load';
+			if (name === 'tableName') return 'n8n_vectors';
+			if (name === 'options') return {};
+			if (name === 'options.collection.values')
+				return {
+					useCollection: true,
+					collectionName: 'my_collection',
+					collectionTableName: 'my_collection_table',
+				};
+			if (name === 'options.columnNames.values')
+				return {
+					idColumnName: 'id',
+					vectorColumnName: 'embedding',
+					contentColumnName: 'text',
+					metadataColumnName: 'metadata',
+				};
+			if (name === 'prompt') return '';
+			if (name === 'topK') return 4;
+			if (name === 'useReranker') return false;
+			if (name === 'includeDocumentMetadata') return false;
+			if (name === 'skipInitializationCheck') {
+				console.log('check: ' + skipValidation);
+				return skipValidation;
+			}
+
+			return defaultValue;
+		};
+	};
+
+	const pgModule = require('@langchain/community/vectorstores/pgvector');
+
+	beforeEach(() => {
+		jest.resetAllMocks();
+
+		// configurePostgres returns an object with db.$pool
+		(configurePostgres as jest.Mock).mockResolvedValue({ db: { $pool: mockPool } });
+
+		pgModule.PGVectorStore.prototype.ensureTableInDatabase.mockResolvedValue(undefined);
+		pgModule.PGVectorStore.prototype.ensureCollectionTableInDatabase.mockResolvedValue(undefined);
+
+		// The node expects embeddings from input connection; return a dummy object
+		const mockEmbeddings = {
+			embedDocuments: jest.fn(),
+			embedQuery: jest.fn(),
+		};
+		mockContext.getInputConnectionData.mockResolvedValue(mockEmbeddings);
+		mockContext.getInputData.mockReturnValue([1]);
+		mockEmbeddings.embedQuery.mockResolvedValue([]);
+		mockEmbeddings.embedDocuments.mockResolvedValue([]);
+		mockContext.getCredentials.mockResolvedValue({ user: 'pg', password: 'pw' });
+	});
+
+	it('execute (load) should call ensureTableInDatabase', async () => {
+		// Default node parameters used inside populateVectorStore
+		const mockCtx = { ...mockContext };
+		mockCtx.getNodeParameter.mockImplementation(mockGetNodeParameter(false));
+
+		// Create node instance
+		const nodeInstance: any = new VectorStorePGVector();
+
+		// Call the execute method with our mocked "this"
+		await nodeInstance.execute.call(mockCtx);
+		expect(mockCtx.getInputData).toHaveBeenCalledTimes(1);
+
+		// validate ensureTableInDatabase get a call
+		expect(pgModule.PGVectorStore.prototype.ensureTableInDatabase).toHaveBeenCalledTimes(1);
+	});
+
+	it('execute (load) should not call ensureTableInDatabase', async () => {
+		// Default node parameters used inside populateVectorStore
+		mockContext.getNodeParameter.mockImplementation(mockGetNodeParameter(true));
+
+		// Create node instance
+		const nodeInstance: any = new VectorStorePGVector();
+
+		// Call the execute method with our mocked "this"
+		await nodeInstance.execute.call(mockContext);
+		expect(mockContext.getInputData).toHaveBeenCalledTimes(1);
+
+		// validate ensureTableInDatabase arent execute
+		expect(pgModule.PGVectorStore.prototype.ensureTableInDatabase).toHaveBeenCalledTimes(0);
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.test.ts
@@ -1,44 +1,27 @@
+import type { Mock } from 'vitest';
 import * as pgModule from '@langchain/community/vectorstores/pgvector'; // <- added
 import { configurePostgres } from 'n8n-nodes-base/dist/nodes/Postgres/transport/index';
 
 import { VectorStorePGVector } from '../VectorStorePGVector/VectorStorePGVector.node';
 
 // Mock configurePostgres
-jest.mock('n8n-nodes-base/dist/nodes/Postgres/transport/index', () => ({
-	configurePostgres: jest.fn(),
+vi.mock('n8n-nodes-base/dist/nodes/Postgres/transport/index', () => ({
+	configurePostgres: vi.fn(),
 }));
 
 // Mock helpers (now in @n8n/ai-utilities)
-jest.mock('@n8n/ai-utilities/src/utils/helpers', () => ({
-	getMetadataFiltersValues: jest.fn().mockReturnValue(undefined),
-}));
-jest.mock('@n8n/ai-utilities/src/utils/log-ai-event', () => ({
-	logAiEvent: jest.fn(),
-}));
-
-// We only need handleInsertOperation for the insert test; others can be simple stubs.
-jest.mock('@n8n/ai-utilities/src/utils/vector-store/createVectorStoreNode/operations', () => {
-	// Use the real module so we can call the actual implementation when needed
-	const actual = jest.requireActual(
-		'@n8n/ai-utilities/src/utils/vector-store/createVectorStoreNode/operations',
-	);
+vi.mock('@n8n/ai-utilities', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('@n8n/ai-utilities')>();
 	return {
 		...actual,
-		handleInsertOperation: jest.fn(async (ctx: any, args: any, embeddings: any) => {
-			// Simulate creation of documents and call the node's populateVectorStore function
-			const documents = [{ id: '1', pageContent: 'hello' }];
-			await args.populateVectorStore(ctx, embeddings, documents, 0);
-			return [];
-		}),
-		handleUpdateOperation: jest.fn(),
-		handleRetrieveOperation: jest.fn(),
-		handleRetrieveAsToolOperation: jest.fn(),
+		logAiEvent: vi.fn(),
+		getMetadataFiltersValues: vi.fn().mockReturnValue(undefined),
 	};
 });
 
 // Provide a class-like mock so ExtendedPGVectorStore can extend it
-jest.mock('@langchain/community/vectorstores/pgvector', () => {
-	const mockFromDocuments = jest.fn();
+vi.mock('@langchain/community/vectorstores/pgvector', () => {
+	const mockFromDocuments = vi.fn();
 	class MockPGVectorStore {
 		static fromDocuments = mockFromDocuments;
 		constructor(
@@ -65,9 +48,9 @@ jest.mock('@langchain/community/vectorstores/pgvector', () => {
 	}
 
 	// Make instance methods mockable via prototype
-	MockPGVectorStore.prototype._initializeClient = jest.fn().mockResolvedValue(undefined);
-	MockPGVectorStore.prototype.ensureTableInDatabase = jest.fn().mockResolvedValue(undefined);
-	MockPGVectorStore.prototype.ensureCollectionTableInDatabase = jest
+	MockPGVectorStore.prototype._initializeClient = vi.fn().mockResolvedValue(undefined);
+	MockPGVectorStore.prototype.ensureTableInDatabase = vi.fn().mockResolvedValue(undefined);
+	MockPGVectorStore.prototype.ensureCollectionTableInDatabase = vi
 		.fn()
 		.mockResolvedValue(undefined);
 
@@ -78,13 +61,15 @@ describe('VectorStorePGVector -> execute (load) triggers ----', () => {
 	const mockPool = { dummy: 'pool' };
 
 	const mockContext: any = {
-		initialize: jest.fn(),
+		initialize: vi.fn(),
 		// These will be used by the code path / or by our mocked handleInsertOperation
-		getNodeParameter: jest.fn(),
-		getInputConnectionData: jest.fn(),
-		getInputData: jest.fn(),
-		getCredentials: jest.fn(),
-		getNode: jest.fn(),
+		getNodeParameter: vi.fn(),
+		getInputConnectionData: vi.fn(),
+		getInputData: vi.fn(),
+		getCredentials: vi.fn(),
+		getNode: vi.fn(),
+		logAiEvent: vi.fn(),
+		logger: { debug: vi.fn() },
 	};
 
 	const mockGetNodeParameter = (skipValidation: boolean) => {
@@ -119,22 +104,20 @@ describe('VectorStorePGVector -> execute (load) triggers ----', () => {
 	};
 
 	beforeEach(() => {
-		jest.resetAllMocks();
+		vi.resetAllMocks();
 
 		// configurePostgres returns an object with db.$pool
-		(configurePostgres as jest.Mock).mockResolvedValue({ db: { $pool: mockPool } });
+		(configurePostgres as Mock).mockResolvedValue({ db: { $pool: mockPool } });
 
-		(pgModule.PGVectorStore.prototype.ensureTableInDatabase as jest.Mock).mockResolvedValue(
+		(pgModule.PGVectorStore.prototype.ensureTableInDatabase as Mock).mockResolvedValue(undefined);
+		(pgModule.PGVectorStore.prototype.ensureCollectionTableInDatabase as Mock).mockResolvedValue(
 			undefined,
 		);
-		(
-			pgModule.PGVectorStore.prototype.ensureCollectionTableInDatabase as jest.Mock
-		).mockResolvedValue(undefined);
 
 		// The node expects embeddings from input connection; return a dummy object
 		const mockEmbeddings = {
-			embedDocuments: jest.fn(),
-			embedQuery: jest.fn(),
+			embedDocuments: vi.fn(),
+			embedQuery: vi.fn(),
 		};
 		mockContext.getInputConnectionData.mockResolvedValue(mockEmbeddings);
 		mockContext.getInputData.mockReturnValue([1]);

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.test.ts
@@ -8,16 +8,20 @@ jest.mock('n8n-nodes-base/dist/nodes/Postgres/transport/index', () => ({
 	configurePostgres: jest.fn(),
 }));
 
-// Mock helpers
-jest.mock('@utils/helpers', () => ({
-	logAiEvent: jest.fn(),
+// Mock helpers (now in @n8n/ai-utilities)
+jest.mock('@n8n/ai-utilities/src/utils/helpers', () => ({
 	getMetadataFiltersValues: jest.fn().mockReturnValue(undefined),
+}));
+jest.mock('@n8n/ai-utilities/src/utils/log-ai-event', () => ({
+	logAiEvent: jest.fn(),
 }));
 
 // We only need handleInsertOperation for the insert test; others can be simple stubs.
-jest.mock('../../vector_store/shared/createVectorStoreNode/operations', () => {
+jest.mock('@n8n/ai-utilities/src/utils/vector-store/createVectorStoreNode/operations', () => {
 	// Use the real module so we can call the actual implementation when needed
-	const actual = jest.requireActual('../../vector_store/shared/createVectorStoreNode/operations');
+	const actual = jest.requireActual(
+		'@n8n/ai-utilities/src/utils/vector-store/createVectorStoreNode/operations',
+	);
 	return {
 		...actual,
 		handleInsertOperation: jest.fn(async (ctx: any, args: any, embeddings: any) => {

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts
@@ -24,6 +24,15 @@ type ColumnOptions = {
 	metadataColumnName: string;
 };
 
+const skipTableCreation: INodeProperties = {
+	displayName: 'Skip table validation & creation',
+	name: 'skipInitializationCheck',
+	type: 'boolean',
+	default: false,
+	description:
+		'Whether to validate and automatically create the table/collection if it does not exist. Disable this if your credentials only allow data manipulation (DML) and do not have permission to create tables.',
+};
+
 const sharedFields: INodeProperties[] = [
 	{
 		displayName: 'Table Name',
@@ -33,6 +42,7 @@ const sharedFields: INodeProperties[] = [
 		description:
 			'The table name to store the vectors in. If table does not exist, it will be created.',
 	},
+	skipTableCreation,
 ];
 
 const collectionField: INodeProperties = {
@@ -239,11 +249,17 @@ export class VectorStorePGVector extends createVectorStoreNode<ExtendedPGVectorS
 		const credentials = await context.getCredentials('postgres');
 		const pgConf = await configurePostgres.call(context, credentials as PostgresNodeCredentials);
 		const pool = pgConf.db.$pool as unknown as pg.Pool;
+		const skipTableValidationAndCreation = context.getNodeParameter(
+			'skipInitializationCheck',
+			0,
+			false,
+		) as boolean;
 
 		const config: PGVectorStoreArgs = {
 			pool,
 			tableName,
 			filter,
+			skipInitializationCheck: skipTableValidationAndCreation,
 		};
 
 		const collectionOptions = context.getNodeParameter(
@@ -283,9 +299,16 @@ export class VectorStorePGVector extends createVectorStoreNode<ExtendedPGVectorS
 		const pgConf = await configurePostgres.call(context, credentials as PostgresNodeCredentials);
 		const pool = pgConf.db.$pool as unknown as pg.Pool;
 
+		const skipTableValidationAndCreation = context.getNodeParameter(
+			'skipInitializationCheck',
+			0,
+			false,
+		) as boolean;
+
 		const config: PGVectorStoreArgs = {
 			pool,
 			tableName,
+			skipInitializationCheck: skipTableValidationAndCreation,
 		};
 
 		const collectionOptions = context.getNodeParameter(

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts
@@ -253,14 +253,17 @@ export class VectorStorePGVector extends createVectorStoreNode<ExtendedPGVectorS
 			'skipInitializationCheck',
 			0,
 			false,
-		) as boolean;
+		);
 
 		const config: PGVectorStoreArgs = {
 			pool,
 			tableName,
 			filter,
-			skipInitializationCheck: skipTableValidationAndCreation,
 		};
+
+		if (skipTableValidationAndCreation && typeof skipTableValidationAndCreation == 'boolean') {
+			config.skipInitializationCheck = skipTableValidationAndCreation;
+		}
 
 		const collectionOptions = context.getNodeParameter(
 			'options.collection.values',
@@ -303,13 +306,16 @@ export class VectorStorePGVector extends createVectorStoreNode<ExtendedPGVectorS
 			'skipInitializationCheck',
 			0,
 			false,
-		) as boolean;
+		);
 
 		const config: PGVectorStoreArgs = {
 			pool,
 			tableName,
-			skipInitializationCheck: skipTableValidationAndCreation,
 		};
+
+		if (skipTableValidationAndCreation && typeof skipTableValidationAndCreation == 'boolean') {
+			config.skipInitializationCheck = skipTableValidationAndCreation;
+		}
 
 		const collectionOptions = context.getNodeParameter(
 			'options.collection.values',

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts
@@ -203,9 +203,12 @@ export class ExtendedPGVectorStore extends PGVectorStore {
 		const postgresqlVectorStore = new this(embeddings, rest);
 
 		await postgresqlVectorStore._initializeClient();
-		await postgresqlVectorStore.ensureTableInDatabase(dimensions);
-		if (postgresqlVectorStore.collectionTableName) {
-			await postgresqlVectorStore.ensureCollectionTableInDatabase();
+
+		if (!args.skipInitializationCheck) {
+			await postgresqlVectorStore.ensureTableInDatabase(dimensions);
+			if (postgresqlVectorStore.collectionTableName) {
+				await postgresqlVectorStore.ensureCollectionTableInDatabase();
+			}
 		}
 
 		return postgresqlVectorStore;

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts
@@ -25,7 +25,7 @@ type ColumnOptions = {
 };
 
 const skipTableCreation: INodeProperties = {
-	displayName: 'Skip table validation & creation',
+	displayName: 'Skip Table Validation & Creation',
 	name: 'skipInitializationCheck',
 	type: 'boolean',
 	default: false,
@@ -264,7 +264,7 @@ export class VectorStorePGVector extends createVectorStoreNode<ExtendedPGVectorS
 			filter,
 		};
 
-		if (skipTableValidationAndCreation && typeof skipTableValidationAndCreation == 'boolean') {
+		if (skipTableValidationAndCreation && typeof skipTableValidationAndCreation === 'boolean') {
 			config.skipInitializationCheck = skipTableValidationAndCreation;
 		}
 
@@ -316,7 +316,7 @@ export class VectorStorePGVector extends createVectorStoreNode<ExtendedPGVectorS
 			tableName,
 		};
 
-		if (skipTableValidationAndCreation && typeof skipTableValidationAndCreation == 'boolean') {
+		if (skipTableValidationAndCreation && typeof skipTableValidationAndCreation === 'boolean') {
 			config.skipInitializationCheck = skipTableValidationAndCreation;
 		}
 


### PR DESCRIPTION
## Summary

This update introduces an option to skip table validation and automatic creation (CREATE TABLE IF NOT EXISTS) specifically for the PGVector Store integration. Currently, the default behavior always attempts to create tables if they do not exist, which relies on functionality from the underlying LangChain dependency.

Since LangChain itself supports a flag to skip table validation and creation, this change brings the same flexibility to n8n users. This is important for production environments where database permissions are often segregated between DDL (schema changes) and DML (data manipulation). Many applications restrict AI agents or service accounts to only data read/write operations without permission to create or modify schemas.

By allowing this option, users can prevent runtime errors caused by insufficient permissions when the app needs only to fetch or insert data, improving stability and compatibility with stricter database access policies.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
### Tested & Added on insert workflows
<img width="959" height="472" alt="image" src="https://github.com/user-attachments/assets/7c27d1a5-5179-4dd4-868b-6065d14372ef" />

### Tested & Added on fetch and load workflows
<img width="959" height="476" alt="image" src="https://github.com/user-attachments/assets/c335e22f-8c96-4cb8-8cc2-9f0c9166c9ca" />



## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
