### PR TITLE
chore(core): Add browser id on the oidc issue cookie

### DIFF
--- a/packages/cli/src/sso.ee/oidc/routes/oidc.controller.ee.ts
+++ b/packages/cli/src/sso.ee/oidc/routes/oidc.controller.ee.ts
@@ -8,6 +8,7 @@ import { UrlService } from '@/services/url.service';
 
 import { OIDC_CLIENT_SECRET_REDACTED_VALUE } from '../constants';
 import { OidcService } from '../oidc.service.ee';
+import { AuthlessRequest } from '@/requests';
 
 @RestController('/sso/oidc')
 export class OidcController {
@@ -51,13 +52,13 @@ export class OidcController {
 
 	@Get('/callback', { skipAuth: true })
 	@Licensed('feat:oidc')
-	async callbackHandler(req: Request, res: Response) {
+	async callbackHandler(req: AuthlessRequest, res: Response) {
 		const fullUrl = `${this.urlService.getInstanceBaseUrl()}${req.originalUrl}`;
 		const callbackUrl = new URL(fullUrl);
 
 		const user = await this.oidcService.loginUser(callbackUrl);
 
-		this.authService.issueCookie(res, user, true);
+		this.authService.issueCookie(res, user, true, req.browserId);
 
 		res.redirect('/');
 	}


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

The current OIDC cookie issuing on login does not contain the browserId (as setup by the frontend client). This PR adds it so the browser id is set in the cookie (same as standard login and SAML)

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
https://linear.app/n8n/issue/PAY-3283/auth-cookies-issued-with-oidc-login-are-missing-browserid

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
