### PR TITLE
chore(core): Disable event loop block integration for user code in task runner

### DIFF
--- a/packages/@n8n/task-runner/src/task-runner-sentry.ts
+++ b/packages/@n8n/task-runner/src/task-runner-sentry.ts
@@ -9,6 +9,8 @@ import { SentryConfig } from './config/sentry-config';
  */
 @Service()
 export class TaskRunnerSentry {
+	isEnabled = false;
+
 	constructor(
 		private readonly config: SentryConfig,
 		private readonly errorReporter: ErrorReporter,
@@ -27,6 +29,8 @@ export class TaskRunnerSentry {
 			serverName: deploymentName,
 			beforeSendFilter: this.filterOutUserCodeErrors,
 		});
+
+		this.isEnabled = true;
 	}
 
 	async shutdown() {


### PR DESCRIPTION
## Summary

Disable Sentry's event loop block integration for user code in the task runner. This should prevent [non-actionable Sentry reports](https://n8nio.sentry.io/issues/?project=4508342481780736&statsPeriod=30d), without disabling the integration for rest of the task runner.

Follow-up to: https://github.com/n8n-io/n8n/pull/17805

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-3198/

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
