### PR TITLE
fix(editor): Hide sso auth protocol selection if no license available

### DIFF
--- a/packages/frontend/editor-ui/src/views/SettingsSso.test.ts
+++ b/packages/frontend/editor-ui/src/views/SettingsSso.test.ts
@@ -80,9 +80,9 @@ describe('SettingsSso View', () => {
 
 			const pageRedirectionHelper = usePageRedirectionHelper();
 
-			const { getByTestId } = renderView();
+			const { getByTestId, queryByTestId } = renderView();
 
-			expect(() => getByTestId('sso-auth-protocol-select')).toThrow('Unable to find an element by');
+			expect(queryByTestId('sso-auth-protocol-select')).not.toBeInTheDocument();
 
 			const actionBox = getByTestId('sso-content-unlicensed');
 			expect(actionBox).toBeInTheDocument();

--- a/packages/frontend/editor-ui/src/views/SettingsSso.test.ts
+++ b/packages/frontend/editor-ui/src/views/SettingsSso.test.ts
@@ -82,6 +82,8 @@ describe('SettingsSso View', () => {
 
 			const { getByTestId } = renderView();
 
+			expect(() => getByTestId('sso-auth-protocol-select')).toThrow('Unable to find an element by');
+
 			const actionBox = getByTestId('sso-content-unlicensed');
 			expect(actionBox).toBeInTheDocument();
 
@@ -95,7 +97,10 @@ describe('SettingsSso View', () => {
 
 			ssoStore.getSamlConfig.mockResolvedValue(samlConfig);
 
-			const { getAllByTestId } = renderView();
+			const { getAllByTestId, getByTestId } = renderView();
+
+			const authProtocolSelect = getByTestId('sso-auth-protocol-select');
+			expect(authProtocolSelect).toBeInTheDocument();
 
 			expect(ssoStore.getSamlConfig).toHaveBeenCalledTimes(1);
 

--- a/packages/frontend/editor-ui/src/views/SettingsSso.vue
+++ b/packages/frontend/editor-ui/src/views/SettingsSso.vue
@@ -310,7 +310,11 @@ async function onOidcSettingsSave() {
 				{{ i18n.baseText('settings.sso.info.link') }}
 			</a>
 		</n8n-info-tip>
-		<div :class="$style.group">
+		<div
+			v-if="ssoStore.isEnterpriseSamlEnabled || ssoStore.isEnterpriseOidcEnabled"
+			data-test-id="sso-auth-protocol-select"
+			:class="$style.group"
+		>
 			<label>Select Authentication Protocol</label>
 			<div>
 				<N8nSelect


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Currently, when no SSO license (SAML or OIDC) are available, we still display the protocol selection dropdown in the settings. This PR hides it if no license are available.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-3299/do-not-show-select-authentication-protocol-selector-if-feature-is-not

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
