### PR TITLE
feat(core): Replace user data stores with data tables (no-changelog)

### DIFF
--- a/packages/cli/src/modules/data-store/__tests__/data-store.controller.test.ts
+++ b/packages/cli/src/modules/data-store/__tests__/data-store.controller.test.ts
@@ -8,12 +8,11 @@ import {
 import type { Project, User } from '@n8n/db';
 import { ProjectRepository, QueryFailedError } from '@n8n/db';
 import { Container } from '@n8n/di';
-import { DateTime } from 'luxon';
-
 import { createDataStore } from '@test-integration/db/data-stores';
 import { createOwner, createMember, createAdmin } from '@test-integration/db/users';
 import type { SuperAgentTest } from '@test-integration/types';
 import * as utils from '@test-integration/utils';
+import { DateTime } from 'luxon';
 
 import { DataStoreColumnRepository } from '../data-store-column.repository';
 import { DataStoreRowsRepository } from '../data-store-rows.repository';
@@ -755,7 +754,7 @@ describe('DELETE /projects/:projectId/data-stores/:dataStoreId', () => {
 		expect(dataStoreInDb).toBeNull();
 	});
 
-	test("should delete data from 'data_store', 'data_store_column' tables and drop 'data_store_user_<id>' table", async () => {
+	test("should delete data from 'data_store', 'data_store_column' tables and drop 'data_table_user_<id>' table", async () => {
 		const personalProject = await projectRepository.getPersonalProjectForUserOrFail(owner.id);
 		const dataStore = await createDataStore(personalProject, {
 			name: 'Test Data Store',

--- a/packages/cli/src/modules/data-store/__tests__/sql-utils.test.ts
+++ b/packages/cli/src/modules/data-store/__tests__/sql-utils.test.ts
@@ -5,50 +5,50 @@ import { addColumnQuery, deleteColumnQuery, splitRowsByExistence } from '../util
 describe('sql-utils', () => {
 	describe('addColumnQuery', () => {
 		it('should generate a valid SQL query for adding columns to a table, sqlite', () => {
-			const tableName = 'data_store_user_abc';
+			const tableName = 'data_table_user_abc';
 			const column = { name: 'email', type: 'number' as const };
 
 			const query = addColumnQuery(tableName, column, 'sqlite');
 
-			expect(query).toBe('ALTER TABLE "data_store_user_abc" ADD "email" REAL');
+			expect(query).toBe('ALTER TABLE "data_table_user_abc" ADD "email" REAL');
 		});
 
 		it('should generate a valid SQL query for adding columns to a table, postgres', () => {
-			const tableName = 'data_store_user_abc';
+			const tableName = 'data_table_user_abc';
 			const column = { name: 'email', type: 'number' as const };
 
 			const query = addColumnQuery(tableName, column, 'postgres');
 
-			expect(query).toBe('ALTER TABLE "data_store_user_abc" ADD "email" DOUBLE PRECISION');
+			expect(query).toBe('ALTER TABLE "data_table_user_abc" ADD "email" DOUBLE PRECISION');
 		});
 
 		it('should generate a valid SQL query for adding columns to a table, mysql', () => {
-			const tableName = 'data_store_user_abc';
+			const tableName = 'data_table_user_abc';
 			const column = { name: 'email', type: 'number' as const };
 
 			const query = addColumnQuery(tableName, column, 'mysql');
 
-			expect(query).toBe('ALTER TABLE `data_store_user_abc` ADD `email` DOUBLE');
+			expect(query).toBe('ALTER TABLE `data_table_user_abc` ADD `email` DOUBLE');
 		});
 
 		it('should generate a valid SQL query for adding columns to a table, mariadb', () => {
-			const tableName = 'data_store_user_abc';
+			const tableName = 'data_table_user_abc';
 			const column = { name: 'email', type: 'number' as const };
 
 			const query = addColumnQuery(tableName, column, 'mariadb');
 
-			expect(query).toBe('ALTER TABLE `data_store_user_abc` ADD `email` DOUBLE');
+			expect(query).toBe('ALTER TABLE `data_table_user_abc` ADD `email` DOUBLE');
 		});
 	});
 
 	describe('deleteColumnQuery', () => {
 		it('should generate a valid SQL query for deleting columns from a table', () => {
-			const tableName = 'data_store_user_abc';
+			const tableName = 'data_table_user_abc';
 			const column = 'email';
 
 			const query = deleteColumnQuery(tableName, column, 'sqlite');
 
-			expect(query).toBe('ALTER TABLE "data_store_user_abc" DROP COLUMN "email"');
+			expect(query).toBe('ALTER TABLE "data_table_user_abc" DROP COLUMN "email"');
 		});
 	});
 

--- a/packages/cli/src/modules/data-store/data-store-rows.repository.ts
+++ b/packages/cli/src/modules/data-store/data-store-rows.repository.ts
@@ -51,7 +51,7 @@ export class DataStoreRowsRepository {
 
 	toTableName(dataStoreId: string): DataStoreUserTableName {
 		const { tablePrefix } = this.globalConfig.database;
-		return `${tablePrefix}data_store_user_${dataStoreId}`;
+		return `${tablePrefix}data_table_user_${dataStoreId}`;
 	}
 
 	async insertRows(dataStoreId: string, rows: DataStoreRows, columns: DataStoreColumn[]) {

--- a/packages/cli/src/modules/data-store/data-store.types.ts
+++ b/packages/cli/src/modules/data-store/data-store.types.ts
@@ -1,1 +1,1 @@
-export type DataStoreUserTableName = `${string}data_store_user_${string}`;
+export type DataStoreUserTableName = `${string}data_table_user_${string}`;


### PR DESCRIPTION
## Summary

This will break our existing tables and local databases, which seems fine.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3969

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
