### PR TITLE
fix(core): Restore community node types controller

### DIFF
--- a/packages/cli/src/modules/community-packages/community-packages.module.ts
+++ b/packages/cli/src/modules/community-packages/community-packages.module.ts
@@ -8,6 +8,7 @@ import path from 'node:path';
 export class CommunityPackagesModule implements ModuleInterface {
 	async init() {
 		await import('./community-packages.controller');
+		await import('./community-node-types.controller');
 	}
 
 	async entities() {


### PR DESCRIPTION
## Summary

At #18641 I missed that the community packages feature has two controllers.

Else we get: https://share.cleanshot.com/CtNL2MMz

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
