### PR TITLE
perf(OpenAI Node): Use streaming for file operations

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/audio/transcribe.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/audio/transcribe.operation.ts
@@ -2,6 +2,7 @@ import FormData from 'form-data';
 import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 import { updateDisplayOptions } from 'n8n-workflow';
 
+import { getBinaryDataFile } from '../../helpers/binary-data';
 import { apiRequest } from '../../transport';
 
 const properties: INodeProperties[] = [
@@ -71,19 +72,19 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 		formData.append('temperature', options.temperature.toString());
 	}
 
-	const binaryData = this.helpers.assertBinaryData(i, binaryPropertyName);
-	const dataBuffer = await this.helpers.getBinaryDataBuffer(i, binaryPropertyName);
-
-	formData.append('file', dataBuffer, {
-		filename: binaryData.fileName,
-		contentType: binaryData.mimeType,
+	const { filename, contentType, fileContent } = await getBinaryDataFile(
+		this,
+		i,
+		binaryPropertyName,
+	);
+	formData.append('file', fileContent, {
+		filename,
+		contentType,
 	});
 
 	const response = await apiRequest.call(this, 'POST', '/audio/transcriptions', {
 		option: { formData },
-		headers: {
-			'Content-Type': 'multipart/form-data',
-		},
+		headers: formData.getHeaders(),
 	});
 
 	return [

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/audio/translate.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/audio/translate.operation.ts
@@ -2,6 +2,7 @@ import FormData from 'form-data';
 import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 import { updateDisplayOptions } from 'n8n-workflow';
 
+import { getBinaryDataFile } from '../../helpers/binary-data';
 import { apiRequest } from '../../transport';
 
 const properties: INodeProperties[] = [
@@ -59,19 +60,19 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 		formData.append('temperature', options.temperature.toString());
 	}
 
-	const binaryData = this.helpers.assertBinaryData(i, binaryPropertyName);
-	const dataBuffer = await this.helpers.getBinaryDataBuffer(i, binaryPropertyName);
-
-	formData.append('file', dataBuffer, {
-		filename: binaryData.fileName,
-		contentType: binaryData.mimeType,
+	const { filename, contentType, fileContent } = await getBinaryDataFile(
+		this,
+		i,
+		binaryPropertyName,
+	);
+	formData.append('file', fileContent, {
+		filename,
+		contentType,
 	});
 
 	const response = await apiRequest.call(this, 'POST', '/audio/translations', {
 		option: { formData },
-		headers: {
-			'Content-Type': 'multipart/form-data',
-		},
+		headers: formData.getHeaders(),
 	});
 
 	return [

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/file/upload.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/file/upload.operation.ts
@@ -2,6 +2,7 @@ import FormData from 'form-data';
 import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 import { updateDisplayOptions, NodeOperationError } from 'n8n-workflow';
 
+import { getBinaryDataFile } from '../../helpers/binary-data';
 import { apiRequest } from '../../transport';
 
 const properties: INodeProperties[] = [
@@ -61,20 +62,20 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 
 	formData.append('purpose', options.purpose || 'assistants');
 
-	const binaryData = this.helpers.assertBinaryData(i, binaryPropertyName);
-	const dataBuffer = await this.helpers.getBinaryDataBuffer(i, binaryPropertyName);
-
-	formData.append('file', dataBuffer, {
-		filename: binaryData.fileName,
-		contentType: binaryData.mimeType,
+	const { filename, contentType, fileContent } = await getBinaryDataFile(
+		this,
+		i,
+		binaryPropertyName,
+	);
+	formData.append('file', fileContent, {
+		filename,
+		contentType,
 	});
 
 	try {
 		const response = await apiRequest.call(this, 'POST', '/files', {
 			option: { formData },
-			headers: {
-				'Content-Type': 'multipart/form-data',
-			},
+			headers: formData.getHeaders(),
 		});
 
 		return [

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/helpers/binary-data.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/helpers/binary-data.ts
@@ -1,0 +1,27 @@
+import type { IExecuteFunctions } from 'n8n-workflow';
+
+/** Chunk size to use for streaming. 256Kb */
+const CHUNK_SIZE = 256 * 1024;
+
+/**
+ * Gets the binary data file for the given item index and given property name.
+ * Returns the file name, content type and the file content. Uses streaming
+ * when possible.
+ */
+export async function getBinaryDataFile(
+	ctx: IExecuteFunctions,
+	itemIdx: number,
+	binaryPropertyName: string,
+) {
+	const binaryData = ctx.helpers.assertBinaryData(itemIdx, binaryPropertyName);
+
+	const fileContent = binaryData.id
+		? await ctx.helpers.getBinaryStream(binaryData.id, CHUNK_SIZE)
+		: await ctx.helpers.getBinaryDataBuffer(itemIdx, binaryPropertyName);
+
+	return {
+		filename: binaryData.fileName,
+		contentType: binaryData.mimeType,
+		fileContent,
+	};
+}

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/test/OpenAi.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/test/OpenAi.node.test.ts
@@ -1,3 +1,4 @@
+import FormData from 'form-data';
 import get from 'lodash/get';
 import type { IDataObject, IExecuteFunctions } from 'n8n-workflow';
 
@@ -362,7 +363,12 @@ describe('OpenAi, Audio resource', () => {
 			'POST',
 			'/audio/transcriptions',
 			expect.objectContaining({
-				headers: { 'Content-Type': 'multipart/form-data' },
+				headers: expect.objectContaining({
+					'content-type': expect.stringMatching(/^multipart\/form-data; boundary=/),
+				}),
+				option: expect.objectContaining({
+					formData: expect.any(FormData),
+				}),
 			}),
 		);
 	});
@@ -386,7 +392,12 @@ describe('OpenAi, Audio resource', () => {
 			'POST',
 			'/audio/translations',
 			expect.objectContaining({
-				headers: { 'Content-Type': 'multipart/form-data' },
+				headers: expect.objectContaining({
+					'content-type': expect.stringMatching(/^multipart\/form-data; boundary=/),
+				}),
+				option: expect.objectContaining({
+					formData: expect.any(FormData),
+				}),
 			}),
 		);
 	});
@@ -453,7 +464,12 @@ describe('OpenAi, File resource', () => {
 			'POST',
 			'/files',
 			expect.objectContaining({
-				headers: { 'Content-Type': 'multipart/form-data' },
+				headers: expect.objectContaining({
+					'content-type': expect.stringMatching(/^multipart\/form-data; boundary=/),
+				}),
+				option: expect.objectContaining({
+					formData: expect.any(FormData),
+				}),
 			}),
 		);
 	});


### PR DESCRIPTION
## Summary

To reduce memory consumption, stream the file in audio transcribe & translate and file upload operations. This way we don't load the entire file into memory.

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.slack.com/archives/C034S4SV6LX/p1755850878201989

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
