### PR TITLE
XFLOW-63: Extend Milvus node

### DIFF
--- a/packages/@n8n/nodes-langchain/credentials/MilvusApi.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/MilvusApi.credentials.ts
@@ -33,6 +33,13 @@ export class MilvusApi implements ICredentialType {
 			typeOptions: { password: true },
 			default: '',
 		},
+		{
+			displayName: 'Database Name',
+			name: 'databaseName',
+			type: 'string',
+			default: 'default',
+			placeholder: 'default',
+		}
 	];
 
 	authenticate: IAuthenticateGeneric = {

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreMilvus/VectorStoreMilvus.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreMilvus/VectorStoreMilvus.node.ts
@@ -1,6 +1,6 @@
 import { Milvus } from '@langchain/community/vectorstores/milvus';
-import type { MilvusLibArgs } from '@langchain/community/vectorstores/milvus';
-import { MilvusClient } from '@zilliz/milvus2-sdk-node';
+import type { IndexCreateOptions, MilvusLibArgs } from '@langchain/community/vectorstores/milvus';
+import { IndexType, MetricType, MilvusClient } from '@zilliz/milvus2-sdk-node';
 import type { INodeProperties } from 'n8n-workflow';
 
 import { createVectorStoreNode } from '../shared/createVectorStoreNode/createVectorStoreNode';
@@ -8,6 +8,25 @@ import { milvusCollectionsSearch } from '../shared/createVectorStoreNode/methods
 import { milvusCollectionRLC } from '../shared/descriptions';
 
 const sharedFields: INodeProperties[] = [milvusCollectionRLC];
+
+const distanceStrategyField: INodeProperties = {
+	displayName: 'Distance Strategy',
+	name: 'distanceStrategy',
+	type: 'options',
+	default: MetricType.L2,
+	description: 'The method to calculate the distance between two vectors',
+	options: Object.values(MetricType).map(m => ({"name": m, "value": m})),
+};
+
+const indexTypeField: INodeProperties = {
+	displayName: 'Index Type',
+	name: 'indexType',
+	type: 'options',
+	default: IndexType.AUTOINDEX,
+	description: 'The type of index used in the Milvus database',
+	options: Object.values(IndexType).map(i => ({"name": i, "value": i})),
+};
+
 const insertFields: INodeProperties[] = [
 	{
 		displayName: 'Options',
@@ -24,6 +43,16 @@ const insertFields: INodeProperties[] = [
 				description: 'Whether to clear the collection before inserting new data',
 			},
 		],
+	},
+];
+const retrieveFields: INodeProperties[] = [
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		placeholder: 'Add Option',
+		default: {},
+		options: [distanceStrategyField, indexTypeField],
 	},
 ];
 
@@ -46,6 +75,8 @@ export class VectorStoreMilvus extends createVectorStoreNode<Milvus>({
 	methods: { listSearch: { milvusCollectionsSearch } },
 	sharedFields,
 	insertFields,
+	loadFields: retrieveFields,
+	retrieveFields,
 	async getVectorStoreClient(context, _filter, embeddings, itemIndex): Promise<Milvus> {
 		const collection = context.getNodeParameter('milvusCollection', itemIndex, '', {
 			extractValue: true,
@@ -54,12 +85,26 @@ export class VectorStoreMilvus extends createVectorStoreNode<Milvus>({
 			baseUrl: string;
 			username: string;
 			password: string;
+			databaseName: string;
 		}>('milvusApi');
+		const indexCreateOptions: IndexCreateOptions = {
+			index_type: context.getNodeParameter(
+				'options.indexType',
+				0,
+				IndexType.AUTOINDEX,
+			) as IndexCreateOptions["index_type"],
+			metric_type: context.getNodeParameter(
+				'options.distanceStrategy',
+				0,
+				MetricType.IP,
+			) as IndexCreateOptions["metric_type"]
+		}
 		const config: MilvusLibArgs = {
 			url: credentials.baseUrl,
 			username: credentials.username,
 			password: credentials.password,
 			collectionName: collection,
+			indexCreateOptions: indexCreateOptions,
 		};
 
 		return await Milvus.fromExistingCollection(embeddings, config);
@@ -75,6 +120,7 @@ export class VectorStoreMilvus extends createVectorStoreNode<Milvus>({
 			baseUrl: string;
 			username: string;
 			password: string;
+			databaseName: string;
 		}>('milvusApi');
 		const config: MilvusLibArgs = {
 			url: credentials.baseUrl,
@@ -87,6 +133,7 @@ export class VectorStoreMilvus extends createVectorStoreNode<Milvus>({
 			const client = new MilvusClient({
 				address: credentials.baseUrl,
 				token: `${credentials.username}:${credentials.password}`,
+				database: credentials.databaseName,
 			});
 			await client.dropCollection({ collection_name: collection });
 		}

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/methods/listSearch.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/methods/listSearch.ts
@@ -75,11 +75,13 @@ export async function milvusCollectionsSearch(this: ILoadOptionsFunctions) {
 		baseUrl: string;
 		username: string;
 		password: string;
+		databaseName: string;
 	}>('milvusApi');
 
 	const client = new MilvusClient({
 		address: credentials.baseUrl,
 		token: `${credentials.username}:${credentials.password}`,
+		database: credentials.databaseName,
 	});
 
 	const response = await client.listCollections();


### PR DESCRIPTION
## Summary

Added options to change metric and index types. Added field in Milvus credentials to allow accessing non-default databases; this field is set to `default` if left empty.