### PR TITLE
fix(workflow): Replace any types with proper TypeScript types

### DIFF
--- a/packages/workflow/src/utils.ts
+++ b/packages/workflow/src/utils.ts
@@ -254,7 +254,7 @@ export function assert<T>(condition: T, msg?: string): asserts condition {
 	}
 }
 
-export const isTraversableObject = (value: any): value is JsonObject => {
+export const isTraversableObject = (value: unknown): value is JsonObject => {
 	return value && typeof value === 'object' && !Array.isArray(value) && !!Object.keys(value).length;
 };
 

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -355,8 +355,7 @@ export class Workflow {
 		}
 
 		if (Array.isArray(parameterValue)) {
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			const returnArray: any[] = [];
+			const returnArray: NodeParameterValueType[] = [];
 
 			for (const currentValue of parameterValue) {
 				returnArray.push(
@@ -371,8 +370,7 @@ export class Workflow {
 			return returnArray;
 		}
 
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const returnData: any = {};
+		const returnData: INodeParameters = {};
 
 		for (const parameterName of Object.keys(parameterValue || {})) {
 			returnData[parameterName] = this.renameNodeInParameterValue(


### PR DESCRIPTION
- Replace any types in IWorkflowDataProxyData with proper interfaces
- Add ProxyNodeContext and ProxyWorkflowContext interfaces
- Create NodeDataProxy interface for node data access
- Fix fallbackValue parameters to use NodeParameterValueType
- Update webhook response and input schema types
- Replace any[] with proper array types in workflow.ts
- Use unknown instead of any for type guards in utils.ts

These changes improve type safety and make the codebase more maintainable by providing better TypeScript support for workflow proxy data structures.

🤖 Generated with [Claude Code](https://claude.ai/code)
