### PR TITLE
fix(MySQL Node): Prevent precision loss for string numbers in query parameters

### DIFF
--- a/packages/nodes-base/nodes/MySql/v2/actions/database/executeQuery.operation.ts
+++ b/packages/nodes-base/nodes/MySql/v2/actions/database/executeQuery.operation.ts
@@ -84,7 +84,15 @@ export async function execute(
 
 		if ((nodeOptions.nodeVersion as number) >= 2.3) {
 			const parsedNumbers = preparedQuery.values.map((value) => {
-				return Number(value) ? Number(value) : value;
+				// Convert string numbers to integers for MySQL queries (e.g., LIMIT clauses)
+				// Only convert safe integers to prevent precision loss
+				if (typeof value === 'string') {
+					const numValue = Number(value);
+					if (!isNaN(numValue) && Number.isSafeInteger(numValue) && numValue.toString() === value) {
+						return numValue;
+					}
+				}
+				return value;
 			});
 			preparedQuery.values = parsedNumbers;
 		}


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
This PR fixes an issue where the MySQL node was converting string numbers to JavaScript numbers in query parameters, causing precision loss for large numbers and unintended format changes.

### Problem
The MySQL node was automatically converting all numeric strings to JavaScript numbers before executing queries. This caused critical issues when working with large numbers. For example, the value `"123456789012345678901234567890"` became `"1.2345678901234568e+29"`, and formatted strings like `"00123"` lost their leading zeros.

### Solution
String parameters are now only converted to numbers when they can be safely represented without any data loss. The fix validates that numbers are within JavaScript's safe integer range and that no precision or formatting is lost during conversion.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
Closes #10151 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
