### PR TITLE
SQL AG Multi Subnet Option

### DIFF
--- a/packages/nodes-base/credentials/MicrosoftSql.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftSql.credentials.ts
@@ -61,6 +61,13 @@ export class MicrosoftSql implements ICredentialType {
 			description: 'Whether to connect even if SSL certificate validation is not possible',
 		},
 		{
+			displayName: 'AG Multisubnet',
+			name: 'agMultiSubnet',
+			type: 'boolean',
+			default: false,
+			description: 'Enable multisubnet failover awareness for SQL connection object. To be used when AG servers span more than one network (Production<->DR)',
+		},
+		{
 			displayName: 'Connect Timeout',
 			name: 'connectTimeout',
 			type: 'number',

--- a/packages/nodes-base/nodes/Microsoft/Sql/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/Sql/GenericFunctions.ts
@@ -108,6 +108,7 @@ export function configurePool(credentials: IDataObject) {
 			enableArithAbort: false,
 			tdsVersion: credentials.tdsVersion as string,
 			trustServerCertificate: credentials.allowUnauthorizedCerts as boolean,
+			multiSubnetFailover: credentials.agMultiSubnet as boolean,
 		},
 	};
 


### PR DESCRIPTION
When SQL availability clusters (AG's) have cluster members in separate subnets the connection string requires the   multiSubnetFailover option to be set to true. If this option is not set the connection string will sometimes fail if the DNS query trying to resolve the listener returns one of the passive nodes instead of the current active node.  The change required to add this functionality was a new option in the SQL pool code and matching Boolean option on credential definition.

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
