### PR TITLE
ci: Increase timeout for MariaDB and MySQL tests again

### DIFF
--- a/.github/workflows/ci-postgres-mysql.yml
+++ b/.github/workflows/ci-postgres-mysql.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Test MariaDB
         working-directory: packages/cli
-        run: pnpm test:mariadb --testTimeout 60000
+        run: pnpm test:mariadb --testTimeout 90000
 
   mysql:
     name: MySQL (${{ matrix.service-name }})
@@ -104,7 +104,7 @@ jobs:
 
       - name: Test MySQL
         working-directory: packages/cli
-        run: pnpm test:mysql --testTimeout 60000
+        run: pnpm test:mysql --testTimeout 90000
 
   postgres:
     name: Postgres

--- a/.github/workflows/ci-postgres-mysql.yml
+++ b/.github/workflows/ci-postgres-mysql.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Test MariaDB
         working-directory: packages/cli
-        run: pnpm test:mariadb --testTimeout 90000
+        run: pnpm test:mariadb --testTimeout 120000
 
   mysql:
     name: MySQL (${{ matrix.service-name }})
@@ -104,7 +104,7 @@ jobs:
 
       - name: Test MySQL
         working-directory: packages/cli
-        run: pnpm test:mysql --testTimeout 90000
+        run: pnpm test:mysql --testTimeout 120000
 
   postgres:
     name: Postgres


### PR DESCRIPTION
## Summary

https://n8nio.slack.com/archives/C04CPHD7VDW/p1756117199767839

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
