### PR TITLE
fix(editor): Do not focus expression input if it was not in focus before switching

### DIFF
--- a/packages/frontend/editor-ui/src/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/components/ParameterInput.vue
@@ -1150,7 +1150,7 @@ watch(remoteParameterOptionsLoading, () => {
 
 // Focus input field when changing between fixed and expression
 watch(isModelValueExpression, async (isExpression, wasExpression) => {
-	if (!props.isReadOnly && isExpression !== wasExpression) {
+	if (!props.isReadOnly && isFocused.value && isExpression !== wasExpression) {
 		await nextTick();
 		await setFocus();
 	}


### PR DESCRIPTION
## Summary

When deleting a collection item in a large collection, multiple ParameterInput components try to set focus causing an infinite loop that freezes the browser.

You can test with the workflow in Linear

Fixed the loop by only setting focus if the input was focused before switching from Fixed to Expression.

## Related Linear tickets, Github issues, and Community forum posts

fixes #16711
https://linear.app/n8n/issue/NODE-3273/community-issue-n8n-freeze-when-deleting-a-body-parameter-of-an-http

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
