### PR TITLE
chore: Run watch mode concurrently

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "test:affected": "turbo run test --affected --concurrency=1",
     "test:with:docker": "pnpm --filter=n8n-playwright test:container:standard",
     "test:show:report": "pnpm --filter=n8n-playwright exec playwright show-report",
-    "watch": "turbo run watch",
+    "watch": "turbo run watch --concurrency=30",
     "webhook": "./packages/cli/bin/n8n webhook",
     "worker": "./packages/cli/bin/n8n worker"
   },


### PR DESCRIPTION
## Summary

Running pnpm run watch from the root folder fails with
```
You have 24 persistent tasks but `turbo` is configured for concurrency of 10. Set --concurrency to at least 25 
```

This was fixed in #8278 and reintroduced in #17595. This PR adds `--concurrency=30` parameter to `turbo run watch`.
The correct/recommend approach now according to turbo is to use the `--concurrency` flag because `--parallel` ignores dependency graph.

## Related Linear tickets, Github issues, and Community forum posts

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
