### PR TITLE
feat(Stripe Node): Add meter events for billing (deprecated)

### DIFF
--- a/packages/nodes-base/nodes/Stripe/Stripe.node.ts
+++ b/packages/nodes-base/nodes/Stripe/Stripe.node.ts
@@ -449,9 +449,13 @@ export class Stripe implements INodeType {
 						//       meterEvent: create
 						// ----------------------------------
 
-						const eventName = this.getNodeParameter('eventName', i) as string;
-						const customerId = this.getNodeParameter('customerId', i) as string;
-						const value = this.getNodeParameter('value', i) as number;
+						const eventName = this.getNodeParameter('eventName', i);
+						const customerId = this.getNodeParameter('customerId', i);
+						const value = this.getNodeParameter('value', i);
+
+						if (typeof value !== 'number') {
+							throw new NodeOperationError(this.getNode(), 'Invalid value', { itemIndex: i });
+						}
 
 						const body = {
 							event_name: eventName,
@@ -459,7 +463,7 @@ export class Stripe implements INodeType {
 							'payload[value]': value.toString(),
 						} as IDataObject;
 
-						const additionalFields = this.getNodeParameter('additionalFields', i) as IDataObject;
+						const additionalFields = this.getNodeParameter('additionalFields', i);
 
 						if (additionalFields.identifier) {
 							body.identifier = additionalFields.identifier as string;

--- a/packages/nodes-base/nodes/Stripe/Stripe.node.ts
+++ b/packages/nodes-base/nodes/Stripe/Stripe.node.ts
@@ -484,7 +484,7 @@ export class Stripe implements INodeType {
 							) {
 								const customFields = additionalFields.customPayloadFields;
 								if ('values' in customFields && Array.isArray(customFields.values)) {
-									customFields.values.forEach((field: unknown) => {
+									customFields.values.forEach((field) => {
 										if (
 											typeof field === 'object' &&
 											field !== null &&

--- a/packages/nodes-base/nodes/Stripe/Stripe.node.ts
+++ b/packages/nodes-base/nodes/Stripe/Stripe.node.ts
@@ -474,9 +474,7 @@ export class Stripe implements INodeType {
 								typeof additionalFields.timestamp === 'string'
 							) {
 								// Convert to Unix timestamp
-								body.timestamp = Math.floor(
-									new Date(additionalFields.timestamp).getTime() / 1000,
-								).toString();
+								body.timestamp = Math.floor(new Date(additionalFields.timestamp).getTime() / 1000);
 							}
 
 							if (
@@ -484,25 +482,20 @@ export class Stripe implements INodeType {
 								typeof additionalFields.customPayloadFields === 'object' &&
 								additionalFields.customPayloadFields !== null
 							) {
-								const customFields = additionalFields.customPayloadFields as IDataObject;
-								if ('values' in customFields) {
-									const values = customFields.values;
-									if (Array.isArray(values)) {
-										values.forEach((field) => {
-											if (
-												typeof field === 'object' &&
-												field !== null &&
-												'key' in field &&
-												'value' in field
-											) {
-												const key = field.key;
-												const fieldValue = field.value;
-												if (typeof key === 'string' && typeof fieldValue === 'string') {
-													body[`payload[${key}]`] = fieldValue;
-												}
-											}
-										});
-									}
+								const customFields = additionalFields.customPayloadFields;
+								if ('values' in customFields && Array.isArray(customFields.values)) {
+									customFields.values.forEach((field: unknown) => {
+										if (
+											typeof field === 'object' &&
+											field !== null &&
+											'key' in field &&
+											'value' in field &&
+											typeof field.key === 'string' &&
+											typeof field.value === 'string'
+										) {
+											body[`payload[${field.key}]`] = field.value;
+										}
+									});
 								}
 							}
 						}

--- a/packages/nodes-base/nodes/Stripe/__schema__/v1.0.0/meterEvent/create.json
+++ b/packages/nodes-base/nodes/Stripe/__schema__/v1.0.0/meterEvent/create.json
@@ -1,0 +1,35 @@
+{
+	"type": "object",
+	"properties": {
+		"object": {
+			"type": "string"
+		},
+		"created": {
+			"type": "integer"
+		},
+		"event_name": {
+			"type": "string"
+		},
+		"identifier": {
+			"type": "string"
+		},
+		"livemode": {
+			"type": "boolean"
+		},
+		"payload": {
+			"type": "object",
+			"properties": {
+				"stripe_customer_id": {
+					"type": "string"
+				},
+				"value": {
+					"type": "string"
+				}
+			}
+		},
+		"timestamp": {
+			"type": "integer"
+		}
+	},
+	"version": 1
+}

--- a/packages/nodes-base/nodes/Stripe/__tests__/Stripe.meterEvent.test.ts
+++ b/packages/nodes-base/nodes/Stripe/__tests__/Stripe.meterEvent.test.ts
@@ -130,7 +130,7 @@ describe('Stripe Node - MeterEvent', () => {
 				'payload[stripe_customer_id]': 'cus_12345678',
 				'payload[value]': '50',
 				identifier: 'custom_id_123',
-				timestamp: '1704110400',
+				timestamp: 1704110400,
 			},
 			{},
 		);

--- a/packages/nodes-base/nodes/Stripe/__tests__/Stripe.meterEvent.test.ts
+++ b/packages/nodes-base/nodes/Stripe/__tests__/Stripe.meterEvent.test.ts
@@ -1,0 +1,138 @@
+import { mock } from 'jest-mock-extended';
+import type { IExecuteFunctions } from 'n8n-workflow';
+
+import { Stripe } from '../Stripe.node';
+import * as helpers from '../helpers';
+
+// Mock the helpers module
+jest.mock('../helpers');
+const mockHelpers = jest.mocked(helpers);
+
+describe('Stripe Node - MeterEvent', () => {
+	let node: Stripe;
+	let mockExecuteFunctions: jest.Mocked<IExecuteFunctions>;
+
+	beforeEach(() => {
+		node = new Stripe();
+		mockExecuteFunctions = mock<IExecuteFunctions>();
+		jest.clearAllMocks();
+
+		// Setup basic mocks
+		mockExecuteFunctions.getInputData.mockReturnValue([{ json: {} }]);
+		mockExecuteFunctions.helpers = {
+			constructExecutionMetaData: jest
+				.fn()
+				.mockImplementation((data, meta) => [{ json: data[0], ...meta }]),
+			returnJsonArray: jest
+				.fn()
+				.mockImplementation((data) => (Array.isArray(data) ? data : [data])),
+		} as any;
+	});
+
+	it('should create a meter event successfully', async () => {
+		// Setup parameters
+		mockExecuteFunctions.getNodeParameter.mockImplementation((paramName: string) => {
+			switch (paramName) {
+				case 'resource':
+					return 'meterEvent';
+				case 'operation':
+					return 'create';
+				case 'eventName':
+					return 'api_usage';
+				case 'customerId':
+					return 'cus_12345678';
+				case 'value':
+					return 25;
+				case 'additionalFields':
+					return {};
+				default:
+					return undefined;
+			}
+		});
+
+		// Mock API response
+		const mockResponse = {
+			object: 'billing.meter_event',
+			created: 1704824589,
+			event_name: 'api_usage',
+			identifier: 'generated_id_123',
+			livemode: false,
+			payload: {
+				stripe_customer_id: 'cus_12345678',
+				value: '25',
+			},
+			timestamp: 1704824589,
+		};
+
+		mockHelpers.stripeApiRequest.mockResolvedValue(mockResponse);
+
+		// Execute
+		const result = await node.execute.call(mockExecuteFunctions);
+
+		// Verify API call
+		expect(mockHelpers.stripeApiRequest).toHaveBeenCalledWith(
+			'POST',
+			'/billing/meter_events',
+			{
+				event_name: 'api_usage',
+				'payload[stripe_customer_id]': 'cus_12345678',
+				'payload[value]': '25',
+			},
+			{},
+		);
+
+		// Verify result structure
+		expect(result).toBeDefined();
+		expect(result[0]).toHaveLength(1);
+		expect(result[0][0].json).toEqual(mockResponse);
+	});
+
+	it('should handle additional fields correctly', async () => {
+		// Setup parameters with additional fields
+		mockExecuteFunctions.getNodeParameter.mockImplementation((paramName: string) => {
+			switch (paramName) {
+				case 'resource':
+					return 'meterEvent';
+				case 'operation':
+					return 'create';
+				case 'eventName':
+					return 'api_usage';
+				case 'customerId':
+					return 'cus_12345678';
+				case 'value':
+					return 50;
+				case 'additionalFields':
+					return {
+						identifier: 'custom_id_123',
+						timestamp: '2024-01-01T12:00:00Z',
+					};
+				default:
+					return undefined;
+			}
+		});
+
+		const mockResponse = {
+			object: 'billing.meter_event',
+			event_name: 'api_usage',
+			identifier: 'custom_id_123',
+		};
+
+		mockHelpers.stripeApiRequest.mockResolvedValue(mockResponse);
+
+		await node.execute.call(mockExecuteFunctions);
+
+		// Verify API call includes additional fields
+		expect(mockHelpers.stripeApiRequest).toHaveBeenCalledWith(
+			'POST',
+			'/billing/meter_events',
+			{
+				event_name: 'api_usage',
+				'payload[stripe_customer_id]': 'cus_12345678',
+				'payload[value]': '50',
+				identifier: 'custom_id_123',
+				timestamp: '1704110400',
+			},
+			{},
+		);
+	});
+});

--- a/packages/nodes-base/nodes/Stripe/descriptions/MeterEventDescription.ts
+++ b/packages/nodes-base/nodes/Stripe/descriptions/MeterEventDescription.ts
@@ -1,0 +1,137 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+export const meterEventOperations: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['meterEvent'],
+			},
+		},
+		options: [
+			{
+				name: 'Create',
+				value: 'create',
+				description: 'Create a billing meter event with synchronous validation',
+				action: 'Create a billing meter event',
+			},
+		],
+		default: 'create',
+	},
+];
+
+export const meterEventFields: INodeProperties[] = [
+	// ----------------------------------
+	//         meterEvent:create
+	// ----------------------------------
+	{
+		displayName: 'Event Name',
+		name: 'eventName',
+		type: 'string',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['meterEvent'],
+				operation: ['create'],
+			},
+		},
+		default: '',
+		description: 'The name of the meter event. Corresponds with the event_name field on a meter.',
+	},
+	{
+		displayName: 'Customer ID',
+		name: 'customerId',
+		type: 'string',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['meterEvent'],
+				operation: ['create'],
+			},
+		},
+		default: '',
+		description: 'The Stripe customer ID to associate with this meter event',
+	},
+	{
+		displayName: 'Value',
+		name: 'value',
+		type: 'number',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['meterEvent'],
+				operation: ['create'],
+			},
+		},
+		default: 1,
+		description: 'The usage value for this meter event. Must be a positive integer.',
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['meterEvent'],
+				operation: ['create'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Identifier',
+				name: 'identifier',
+				type: 'string',
+				default: '',
+				description:
+					'A unique identifier for the event. If not provided, one will be generated. We recommend using a globally unique identifier.',
+			},
+			{
+				displayName: 'Timestamp',
+				name: 'timestamp',
+				type: 'dateTime',
+				default: '',
+				description:
+					'The time of the event. Must be within the past 35 calendar days or up to 5 minutes in the future. Defaults to current timestamp if not specified.',
+			},
+			{
+				displayName: 'Custom Payload Fields',
+				name: 'customPayloadFields',
+				type: 'fixedCollection',
+				default: { values: [] },
+				description:
+					'Additional custom fields to include in the payload. These must correspond to your meter configuration.',
+				typeOptions: {
+					multipleValues: true,
+					sortable: true,
+				},
+				options: [
+					{
+						displayName: 'Field',
+						name: 'values',
+						values: [
+							{
+								displayName: 'Key',
+								name: 'key',
+								type: 'string',
+								default: '',
+								description: 'The name of the custom field',
+							},
+							{
+								displayName: 'Value',
+								name: 'value',
+								type: 'string',
+								default: '',
+								description: 'The value of the custom field',
+							},
+						],
+					},
+				],
+			},
+		],
+	},
+];

--- a/packages/nodes-base/nodes/Stripe/descriptions/MeterEventDescription.ts
+++ b/packages/nodes-base/nodes/Stripe/descriptions/MeterEventDescription.ts
@@ -67,7 +67,7 @@ export const meterEventFields: INodeProperties[] = [
 			},
 		},
 		default: 1,
-		description: 'The usage value for this meter event. Must be a positive integer.',
+		description: 'The usage value for this meter event. Can be positive or negative.',
 	},
 	{
 		displayName: 'Additional Fields',

--- a/packages/nodes-base/nodes/Stripe/descriptions/MeterEventDescription.ts
+++ b/packages/nodes-base/nodes/Stripe/descriptions/MeterEventDescription.ts
@@ -102,7 +102,7 @@ export const meterEventFields: INodeProperties[] = [
 				displayName: 'Custom Payload Fields',
 				name: 'customPayloadFields',
 				type: 'fixedCollection',
-				default: { values: [] },
+				default: {},
 				description:
 					'Additional custom fields to include in the payload. These must correspond to your meter configuration.',
 				typeOptions: {

--- a/packages/nodes-base/nodes/Stripe/descriptions/index.ts
+++ b/packages/nodes-base/nodes/Stripe/descriptions/index.ts
@@ -3,5 +3,6 @@ export * from './CustomerCardDescription';
 export * from './ChargeDescription';
 export * from './CouponDescription';
 export * from './CustomerDescription';
+export * from './MeterEventDescription';
 export * from './SourceDescription';
 export * from './TokenDescription';


### PR DESCRIPTION
## Summary

Add the meter event to the Stripe node, so that it's possible to use the [Create a billing meter event](https://docs.stripe.com/api/billing/meter-event/create)-API (v1).


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
