### PR TITLE
fix: Use correct type for ListDataStoreContentFilter filter (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/dto/data-store/list-data-store-content-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/data-store/list-data-store-content-query.dto.ts
@@ -11,7 +11,7 @@ export type ListDataStoreContentFilterConditionType = z.infer<typeof FilterCondi
 const filterRecord = z.object({
 	columnName: dataStoreColumnNameSchema,
 	condition: FilterConditionSchema.default('eq'),
-	value: z.union([z.string(), z.number(), z.boolean(), z.date()]),
+	value: z.union([z.string(), z.number(), z.boolean(), z.date(), z.null()]),
 });
 
 const chainedFilterSchema = z.union([z.literal('and'), z.literal('or')]);

--- a/packages/workflow/src/data-store.types.ts
+++ b/packages/workflow/src/data-store.types.ts
@@ -47,7 +47,7 @@ export type ListDataStoreContentFilter = {
 	filters: Array<{
 		columnName: string;
 		condition: 'eq' | 'neq';
-		value: string | number | boolean | Date;
+		value: DataStoreColumnJsType;
 	}>;
 };
 


### PR DESCRIPTION
## Summary

This somehow slipped through CI and is breaking master

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
