### PR TITLE
ci: Drop MySQL 8.0.13

### DIFF
--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -10,16 +10,6 @@ services:
     tmpfs:
       - /var/lib/mysql
 
-  mysql-8.0.13:
-    image: mysql:8.0.13
-    environment:
-      - MYSQL_DATABASE=n8n
-      - MYSQL_ROOT_PASSWORD=password
-    ports:
-      - 3306:3306
-    tmpfs:
-      - /var/lib/mysql
-
   mysql-8.4:
     image: mysql:8.4
     environment:

--- a/.github/workflows/ci-postgres-mysql.yml
+++ b/.github/workflows/ci-postgres-mysql.yml
@@ -80,13 +80,10 @@ jobs:
         run: pnpm test:mariadb --testTimeout 120000
 
   mysql:
-    name: MySQL (${{ matrix.service-name }})
+    name: MySQL 8.4
     needs: build
     runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 20
-    strategy:
-      matrix:
-        service-name: ['mysql-8.0.13', 'mysql-8.4']
     env:
       DB_MYSQLDB_PASSWORD: password
     steps:
@@ -99,8 +96,7 @@ jobs:
         uses: isbang/compose-action@802a148945af6399a338c7906c267331b39a71af # v2.0.0
         with:
           compose-file: ./.github/docker-compose.yml
-          services: |
-            ${{ matrix.service-name }}
+          services: mysql-8.4
 
       - name: Test MySQL
         working-directory: packages/cli


### PR DESCRIPTION
## Summary

Regular LTS support for MySQL 8.0.13 ended 3 months ago.

## Related Linear tickets, Github issues, and Community forum posts

Context: https://n8nio.slack.com/archives/C0789EN39RC/p1756127793383739

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
