### PR TITLE
fix(core): Fix waiting webhooks validation when n8n is behind proxy

### DIFF
--- a/packages/cli/src/webhooks/__tests__/waiting-forms.test.ts
+++ b/packages/cli/src/webhooks/__tests__/waiting-forms.test.ts
@@ -9,7 +9,7 @@ import type { WaitingWebhookRequest } from '../webhook.types';
 
 describe('WaitingForms', () => {
 	const executionRepository = mock<ExecutionRepository>();
-	const waitingForms = new WaitingForms(mock(), mock(), executionRepository, mock());
+	const waitingForms = new WaitingForms(mock(), mock(), executionRepository, mock(), mock());
 
 	beforeEach(() => {
 		jest.restoreAllMocks();

--- a/packages/cli/src/webhooks/__tests__/waiting-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/waiting-webhooks.test.ts
@@ -1,6 +1,8 @@
 import type { IExecutionResponse, ExecutionRepository } from '@n8n/db';
 import type express from 'express';
 import { mock } from 'jest-mock-extended';
+import type { InstanceSettings } from 'n8n-core';
+import { generateUrlSignature, prepareUrlForSigning, WAITING_TOKEN_QUERY_PARAM } from 'n8n-core';
 
 import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
@@ -8,8 +10,18 @@ import { WaitingWebhooks } from '@/webhooks/waiting-webhooks';
 import type { WaitingWebhookRequest } from '@/webhooks/webhook.types';
 
 describe('WaitingWebhooks', () => {
+	const SIGNING_SECRET = 'test-secret';
 	const executionRepository = mock<ExecutionRepository>();
-	const waitingWebhooks = new WaitingWebhooks(mock(), mock(), executionRepository, mock());
+	const mockInstanceSettings = mock<InstanceSettings>({
+		hmacSignatureSecret: SIGNING_SECRET,
+	});
+	const waitingWebhooks = new WaitingWebhooks(
+		mock(),
+		mock(),
+		executionRepository,
+		mock(),
+		mockInstanceSettings,
+	);
 
 	beforeEach(() => {
 		jest.restoreAllMocks();
@@ -77,5 +89,112 @@ describe('WaitingWebhooks', () => {
 		 * Assert
 		 */
 		await expect(promise).rejects.toThrowError(ConflictError);
+	});
+
+	describe('validateSignatureInRequest', () => {
+		const EXAMPLE_HOST = 'example.com';
+		const generateValidSignature = (host = EXAMPLE_HOST) =>
+			generateUrlSignature(
+				prepareUrlForSigning(new URL('/webhook/test', `http://${host}`)),
+				SIGNING_SECRET,
+			);
+
+		const createMockRequest = (opts: { host?: string; signature: string }) =>
+			mock<express.Request>({
+				url: `/webhook/test?${WAITING_TOKEN_QUERY_PARAM}=` + opts.signature,
+				host: opts.host ?? EXAMPLE_HOST,
+				query: { [WAITING_TOKEN_QUERY_PARAM]: opts.signature },
+				headers: { host: opts.host ?? EXAMPLE_HOST },
+			});
+
+		it('should validate signature correctly', () => {
+			/* Arrange */
+			const signature = generateValidSignature();
+			const mockReq = createMockRequest({ signature });
+
+			/* Act */
+			const result = waitingWebhooks.validateSignatureInRequest(mockReq);
+
+			/* Assert */
+			expect(result).toBe(true);
+		});
+
+		it('should validate signature correctly when host contains a port', () => {
+			/* Arrange */
+			const signature = generateValidSignature('example.com:8080');
+			const mockReq = createMockRequest({
+				signature,
+				host: 'example.com:8080',
+			});
+
+			/* Act */
+			const result = waitingWebhooks.validateSignatureInRequest(mockReq);
+
+			/* Assert */
+			expect(result).toBe(true);
+		});
+
+		it('should validate signature correctly when n8n is behind a reverse proxy', () => {
+			/* Arrange */
+			const signature = generateValidSignature('proxy.example.com');
+			const mockReq = mock<express.Request>({
+				url: `/webhook/test?${WAITING_TOKEN_QUERY_PARAM}=` + signature,
+				host: 'proxy.example.com',
+				query: { [WAITING_TOKEN_QUERY_PARAM]: signature },
+				headers: {
+					host: 'localhost',
+					// eslint-disable-next-line @typescript-eslint/naming-convention
+					'x-forwarded-host': 'proxy.example.com',
+				},
+			});
+
+			/* Act */
+			const result = waitingWebhooks.validateSignatureInRequest(mockReq);
+
+			/* Assert */
+			expect(result).toBe(true);
+		});
+
+		it('should return false when signature is missing', () => {
+			/* Arrange */
+			const mockReq = mock<express.Request>({
+				url: '/webhook/test',
+				hostname: 'example.com',
+				query: {},
+			});
+
+			/* Act */
+			const result = waitingWebhooks.validateSignatureInRequest(mockReq);
+
+			/* Assert */
+			expect(result).toBe(false);
+		});
+
+		it('should return false when signature is empty', () => {
+			/* Arrange */
+			const mockReq = mock<express.Request>({
+				url: `/webhook/test?${WAITING_TOKEN_QUERY_PARAM}=`,
+				hostname: 'example.com',
+				query: { [WAITING_TOKEN_QUERY_PARAM]: '' },
+			});
+
+			/* Act */
+			const result = waitingWebhooks.validateSignatureInRequest(mockReq);
+
+			/* Assert */
+			expect(result).toBe(false);
+		});
+
+		it('should return false when signatures do not match', () => {
+			/* Arrange */
+			const wrongSignature = 'wrong-signature';
+			const mockReq = createMockRequest({ signature: wrongSignature });
+
+			/* Act */
+			const result = waitingWebhooks.validateSignatureInRequest(mockReq);
+
+			/* Assert */
+			expect(result).toBe(false);
+		});
 	});
 });


### PR DESCRIPTION

## Summary

We were using the host incorrectly from the `host` header, which might be the reverse proxy's hostname when n8n is behind a reverse proxy. Using `req.hostname` works correctly as long as `N8N_PROXY_HOPS` is set correctly and the reverse proxy sends the correct headers.


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1252/community-issue-sendandwait-broken-with-missinginvalid-token

Resolves #18610


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
