### PR TITLE
fix: Overhaul DataTableRowWithId type and include createdAt, insertedAt in getMany return (no-changelog)

### DIFF
--- a/packages/cli/src/modules/data-table/__tests__/data-store-proxy.service.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/data-store-proxy.service.test.ts
@@ -209,7 +209,7 @@ describe('DataStoreProxyService', () => {
 		);
 		await dataStoreOperations.insertRows(rows);
 
-		expect(dataStoreServiceMock.insertRows).toBeCalledWith('dataStore-id', PROJECT_ID, rows);
+		expect(dataStoreServiceMock.insertRows).toBeCalledWith('dataStore-id', PROJECT_ID, rows, true);
 	});
 
 	it('should call upsertRows with correct parameters', async () => {
@@ -225,6 +225,11 @@ describe('DataStoreProxyService', () => {
 		);
 		await dataStoreOperations.upsertRows(options);
 
-		expect(dataStoreServiceMock.upsertRows).toBeCalledWith('dataStore-id', PROJECT_ID, options);
+		expect(dataStoreServiceMock.upsertRows).toBeCalledWith(
+			'dataStore-id',
+			PROJECT_ID,
+			options,
+			true,
+		);
 	});
 });

--- a/packages/cli/src/modules/data-table/__tests__/data-store.controller.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/data-store.controller.test.ts
@@ -1961,11 +1961,15 @@ describe('POST /projects/:projectId/data-stores/:dataStoreId/insert', () => {
 					id: 1,
 					first: 'first row',
 					second: 'some value',
+					createdAt: expect.any(String),
+					updatedAt: expect.any(String),
 				},
 				{
 					id: 2,
 					first: 'another row',
 					second: 'another value',
+					createdAt: expect.any(String),
+					updatedAt: expect.any(String),
 				},
 			],
 		});
@@ -2951,9 +2955,27 @@ describe('POST /projects/:projectId/data-stores/:dataStoreId/upsert', () => {
 
 		expect(result.body.data).toEqual(
 			expect.arrayContaining([
-				{ id: 1, first: 'test row', second: 'updated value' },
-				{ id: 2, first: 'test row', second: 'updated value' },
-				{ id: 3, first: 'new row', second: 'new value' },
+				{
+					id: 1,
+					first: 'test row',
+					second: 'updated value',
+					createdAt: expect.any(String),
+					updatedAt: expect.any(String),
+				},
+				{
+					id: 2,
+					first: 'test row',
+					second: 'updated value',
+					createdAt: expect.any(String),
+					updatedAt: expect.any(String),
+				},
+				{
+					id: 3,
+					first: 'new row',
+					second: 'new value',
+					createdAt: expect.any(String),
+					updatedAt: expect.any(String),
+				},
 			]),
 		);
 	});

--- a/packages/cli/src/modules/data-table/__tests__/data-store.service.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/data-store.service.test.ts
@@ -1102,8 +1102,8 @@ describe('dataStore', () => {
 				true,
 			);
 			expect(ids).toEqual([
-				{ id: 1, c1: 1, c2: 'foo' },
-				{ id: 2, c1: 2, c2: 'bar' },
+				{ id: 1, c1: 1, c2: 'foo', createdAt: expect.any(String), updatedAt: expect.any(String) },
+				{ id: 2, c1: 2, c2: 'bar', createdAt: expect.any(String), updatedAt: expect.any(String) },
 			]);
 
 			await dataStoreService.deleteRows(dataStoreId, project1.id, [ids[0].id]);
@@ -1120,8 +1120,8 @@ describe('dataStore', () => {
 
 			// ASSERT
 			expect(result).toEqual([
-				{ id: 3, c1: 1, c2: 'baz' },
-				{ id: 4, c1: 2, c2: 'faz' },
+				{ id: 3, c1: 1, c2: 'baz', createdAt: expect.any(String), updatedAt: expect.any(String) },
+				{ id: 4, c1: 2, c2: 'faz', createdAt: expect.any(String), updatedAt: expect.any(String) },
 			]);
 		});
 
@@ -1677,11 +1677,11 @@ describe('dataStore', () => {
 			expect(updatedRows[0].createdAt).not.toBeNull();
 			expect(updatedRows[0].updatedAt).not.toBeNull();
 			expect(initialRows[0].updatedAt).not.toBeNull();
-			expect(new Date(updatedRows[0].updatedAt as string).getTime()).toBeGreaterThan(
-				new Date(initialRows[0].updatedAt as string).getTime(),
+			expect(new Date(updatedRows[0].updatedAt).getTime()).toBeGreaterThan(
+				new Date(initialRows[0].updatedAt).getTime(),
 			);
-			expect(new Date(updatedRows[0].updatedAt as string).getTime()).toBeGreaterThan(
-				new Date(updatedRows[0].createdAt as string).getTime(),
+			expect(new Date(updatedRows[0].updatedAt).getTime()).toBeGreaterThan(
+				new Date(updatedRows[0].createdAt).getTime(),
 			);
 		});
 

--- a/packages/cli/src/modules/data-table/__tests__/data-store.service.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/data-store.service.test.ts
@@ -1113,8 +1113,8 @@ describe('dataStore', () => {
 					c2: 'foo',
 					c3: true,
 					c4: now,
-					createdAt: expect.any(String),
-					updatedAt: expect.any(String),
+					createdAt: expect.any(Date),
+					updatedAt: expect.any(Date),
 				},
 				{
 					id: 2,
@@ -1122,8 +1122,8 @@ describe('dataStore', () => {
 					c2: 'bar',
 					c3: false,
 					c4: now,
-					createdAt: expect.any(String),
-					updatedAt: expect.any(String),
+					createdAt: expect.any(Date),
+					updatedAt: expect.any(Date),
 				},
 				{
 					id: 3,
@@ -1131,8 +1131,8 @@ describe('dataStore', () => {
 					c2: null,
 					c3: null,
 					c4: null,
-					createdAt: expect.any(String),
-					updatedAt: expect.any(String),
+					createdAt: expect.any(Date),
+					updatedAt: expect.any(Date),
 				},
 			]);
 		});
@@ -1509,6 +1509,8 @@ describe('dataStore', () => {
 						age: 31,
 						pid: '1995-111a',
 						birthday: new Date('1995-01-01'),
+						createdAt: expect.any(Date),
+						updatedAt: expect.any(Date),
 					},
 					{
 						id: 2,
@@ -1516,6 +1518,8 @@ describe('dataStore', () => {
 						age: 30,
 						pid: '1992-222b',
 						birthday: new Date('1992-01-01'),
+						createdAt: expect.any(Date),
+						updatedAt: expect.any(Date),
 					},
 				]),
 			);

--- a/packages/cli/src/modules/data-table/data-store-proxy.service.ts
+++ b/packages/cli/src/modules/data-table/data-store-proxy.service.ts
@@ -125,11 +125,15 @@ export class DataStoreProxyService implements DataStoreProxyProvider {
 			},
 
 			async insertRows(rows: DataStoreRows) {
-				return await dataStoreService.insertRows(dataStoreId, projectId, rows);
+				return await dataStoreService.insertRows(dataStoreId, projectId, rows, true);
 			},
 
 			async upsertRows(options: UpsertDataStoreRowsOptions) {
 				return await dataStoreService.upsertRows(dataStoreId, projectId, options);
+			},
+
+			async deleteRows(ids: number[]) {
+				return await dataStoreService.deleteRows(dataStoreId, projectId, ids);
 			},
 		};
 	}

--- a/packages/cli/src/modules/data-table/data-store-proxy.service.ts
+++ b/packages/cli/src/modules/data-table/data-store-proxy.service.ts
@@ -129,7 +129,7 @@ export class DataStoreProxyService implements DataStoreProxyProvider {
 			},
 
 			async upsertRows(options: UpsertDataStoreRowsOptions) {
-				return await dataStoreService.upsertRows(dataStoreId, projectId, options);
+				return await dataStoreService.upsertRows(dataStoreId, projectId, options, true);
 			},
 
 			async deleteRows(ids: number[]) {

--- a/packages/cli/src/modules/data-table/data-store-rows.repository.ts
+++ b/packages/cli/src/modules/data-table/data-store-rows.repository.ts
@@ -80,7 +80,7 @@ export class DataStoreRowsRepository {
 		const table = this.toTableName(dataStoreId);
 		const columnNames = columns.map((c) => c.name);
 		const escapedColumns = columns.map((c) => this.dataSource.driver.escape(c.name));
-		const selectColumns = ['id', ...escapedColumns];
+		const selectColumns = ['id', 'createdAt', 'updatedAt', ...escapedColumns];
 
 		// We insert one by one as the default behavior of returning the last inserted ID
 		// is consistent, whereas getting all inserted IDs when inserting multiple values is

--- a/packages/cli/src/modules/data-table/data-store-rows.repository.ts
+++ b/packages/cli/src/modules/data-table/data-store-rows.repository.ts
@@ -73,8 +73,6 @@ export class DataStoreRowsRepository {
 		columns: DataStoreColumn[],
 		returnData?: boolean,
 	): Promise<Array<DataStoreRowReturn | Pick<DataStoreRowReturn, 'id'>>> {
-		const doReturnData = returnData ?? false;
-
 		const inserted: Array<Pick<DataStoreRowReturn, 'id'>> = [];
 		const dbType = this.dataSource.options.type;
 		const useReturning = dbType === 'postgres' || dbType === 'mariadb';
@@ -100,7 +98,7 @@ export class DataStoreRowsRepository {
 				.values(row);
 
 			if (useReturning) {
-				query.returning(doReturnData ? selectColumns.join(',') : 'id');
+				query.returning(returnData ? selectColumns.join(',') : 'id');
 			}
 
 			const result = await query.execute();
@@ -117,7 +115,7 @@ export class DataStoreRowsRepository {
 				throw new UnexpectedError("Couldn't find the inserted row ID");
 			}
 
-			if (!doReturnData) {
+			if (!returnData) {
 				inserted.push(...rowIds.map((id) => ({ id })));
 				continue;
 			}

--- a/packages/cli/src/modules/data-table/data-store-rows.repository.ts
+++ b/packages/cli/src/modules/data-table/data-store-rows.repository.ts
@@ -77,7 +77,10 @@ export class DataStoreRowsRepository {
 		const table = this.toTableName(dataStoreId);
 		const columnNames = columns.map((c) => c.name);
 		const escapedColumns = columns.map((c) => this.dataSource.driver.escape(c.name));
-		const selectColumns = [...DATA_TABLE_SYSTEM_COLUMNS, ...escapedColumns];
+		const escapedSystemColumns = DATA_TABLE_SYSTEM_COLUMNS.map((x) =>
+			this.dataSource.driver.escape(x),
+		);
+		const selectColumns = [...escapedSystemColumns, ...escapedColumns];
 
 		// We insert one by one as the default behavior of returning the last inserted ID
 		// is consistent, whereas getting all inserted IDs when inserting multiple values is
@@ -139,7 +142,10 @@ export class DataStoreRowsRepository {
 
 		const table = this.toTableName(dataStoreId);
 		const escapedColumns = columns.map((c) => this.dataSource.driver.escape(c.name));
-		const selectColumns = [...DATA_TABLE_SYSTEM_COLUMNS, ...escapedColumns];
+		const escapedSystemColumns = DATA_TABLE_SYSTEM_COLUMNS.map((x) =>
+			this.dataSource.driver.escape(x),
+		);
+		const selectColumns = [...escapedSystemColumns, ...escapedColumns];
 
 		for (const column of columns) {
 			if (column.name in setData) {
@@ -298,7 +304,10 @@ export class DataStoreRowsRepository {
 	async getManyByIds(dataStoreId: string, ids: number[], columns: DataStoreColumn[]) {
 		const table = this.toTableName(dataStoreId);
 		const escapedColumns = columns.map((c) => this.dataSource.driver.escape(c.name));
-		const selectColumns = [...DATA_TABLE_SYSTEM_COLUMNS, ...escapedColumns];
+		const escapedSystemColumns = DATA_TABLE_SYSTEM_COLUMNS.map((x) =>
+			this.dataSource.driver.escape(x),
+		);
+		const selectColumns = [...escapedSystemColumns, ...escapedColumns];
 
 		if (ids.length === 0) {
 			return [];

--- a/packages/cli/src/modules/data-table/data-store-rows.repository.ts
+++ b/packages/cli/src/modules/data-table/data-store-rows.repository.ts
@@ -103,7 +103,7 @@ export class DataStoreRowsRepository {
 			if (useReturning) {
 				const returned = returnData
 					? normalizeRows(extractReturningData(result.raw), columns)
-					: extractInsertedIds(result.raw, dbType);
+					: extractInsertedIds(result.raw, dbType).map((id) => ({ id }));
 				inserted.push.apply(inserted, returned);
 				continue;
 			}

--- a/packages/cli/src/modules/data-table/data-store-rows.repository.ts
+++ b/packages/cli/src/modules/data-table/data-store-rows.repository.ts
@@ -137,7 +137,7 @@ export class DataStoreRowsRepository {
 
 		const table = this.toTableName(dataStoreId);
 		const escapedColumns = columns.map((c) => this.dataSource.driver.escape(c.name));
-		const selectColumns = ['id', ...escapedColumns];
+		const selectColumns = [...DATA_TABLE_SYSTEM_COLUMNS, ...escapedColumns];
 
 		for (const column of columns) {
 			if (column.name in setData) {

--- a/packages/cli/src/modules/data-table/data-store-rows.repository.ts
+++ b/packages/cli/src/modules/data-table/data-store-rows.repository.ts
@@ -101,7 +101,9 @@ export class DataStoreRowsRepository {
 			const result = await query.execute();
 
 			if (useReturning) {
-				const returned = normalizeRows(extractReturningData(result.raw), columns);
+				const returned = returnData
+					? normalizeRows(extractReturningData(result.raw), columns)
+					: extractInsertedIds(result.raw, dbType);
 				inserted.push.apply(inserted, returned);
 				continue;
 			}

--- a/packages/cli/src/modules/data-table/data-store-rows.repository.ts
+++ b/packages/cli/src/modules/data-table/data-store-rows.repository.ts
@@ -9,6 +9,7 @@ import {
 	DataStoreRowReturn,
 	UnexpectedError,
 	DataStoreRowsReturn,
+	DATA_TABLE_SYSTEM_COLUMNS,
 } from 'n8n-workflow';
 
 import { DataStoreColumn } from './data-store-column.entity';
@@ -76,7 +77,7 @@ export class DataStoreRowsRepository {
 		const table = this.toTableName(dataStoreId);
 		const columnNames = columns.map((c) => c.name);
 		const escapedColumns = columns.map((c) => this.dataSource.driver.escape(c.name));
-		const selectColumns = ['id', 'createdAt', 'updatedAt', ...escapedColumns];
+		const selectColumns = [...DATA_TABLE_SYSTEM_COLUMNS, ...escapedColumns];
 
 		// We insert one by one as the default behavior of returning the last inserted ID
 		// is consistent, whereas getting all inserted IDs when inserting multiple values is
@@ -295,7 +296,7 @@ export class DataStoreRowsRepository {
 	async getManyByIds(dataStoreId: string, ids: number[], columns: DataStoreColumn[]) {
 		const table = this.toTableName(dataStoreId);
 		const escapedColumns = columns.map((c) => this.dataSource.driver.escape(c.name));
-		const selectColumns = ['id', ...escapedColumns];
+		const selectColumns = [...DATA_TABLE_SYSTEM_COLUMNS, ...escapedColumns];
 
 		if (ids.length === 0) {
 			return [];

--- a/packages/cli/src/modules/data-table/data-store-rows.repository.ts
+++ b/packages/cli/src/modules/data-table/data-store-rows.repository.ts
@@ -182,13 +182,21 @@ export class DataStoreRowsRepository {
 	}
 
 	// TypeORM cannot infer the columns for a dynamic table name, so we use a raw query
+	async upsertRows<T extends boolean | undefined>(
+		dataStoreId: string,
+		matchFields: string[],
+		rows: DataStoreRows,
+		columns: DataStoreColumn[],
+		returnData?: T,
+	): Promise<T extends true ? DataStoreRowReturn[] : true>;
 	async upsertRows(
 		dataStoreId: string,
 		matchFields: string[],
 		rows: DataStoreRows,
 		columns: DataStoreColumn[],
-		returnData = false,
+		returnData?: boolean,
 	) {
+		returnData = returnData ?? false;
 		const { rowsToInsert, rowsToUpdate } = await this.fetchAndSplitRowsByExistence(
 			dataStoreId,
 			matchFields,

--- a/packages/cli/src/modules/data-table/data-store.controller.ts
+++ b/packages/cli/src/modules/data-table/data-store.controller.ts
@@ -34,6 +34,7 @@ import { DataStoreColumnNotFoundError } from './errors/data-store-column-not-fou
 import { DataStoreNameConflictError } from './errors/data-store-name-conflict.error';
 import { DataStoreNotFoundError } from './errors/data-store-not-found.error';
 import { DataStoreValidationError } from './errors/data-store-validation.error';
+import { DataStoreRowReturn } from 'n8n-workflow';
 
 @RestController('/projects/:projectId/data-stores')
 export class DataStoreController {
@@ -237,6 +238,12 @@ export class DataStoreController {
 	/**
 	 * @returns the IDs of the inserted rows
 	 */
+	async appendDataStoreRows<T extends boolean>(
+		req: AuthenticatedRequest<{ projectId: string }>,
+		_res: Response,
+		dataStoreId: string,
+		dto: AddDataStoreRowsDto & { returnData: T },
+	): Promise<Array<T extends true ? DataStoreRowReturn : Pick<DataStoreRowReturn, 'id'>>>;
 	@Post('/:dataStoreId/insert')
 	@ProjectScope('dataStore:writeRow')
 	async appendDataStoreRows(

--- a/packages/cli/src/modules/data-table/data-store.controller.ts
+++ b/packages/cli/src/modules/data-table/data-store.controller.ts
@@ -238,11 +238,11 @@ export class DataStoreController {
 	/**
 	 * @returns the IDs of the inserted rows
 	 */
-	async appendDataStoreRows<T extends boolean>(
+	async appendDataStoreRows<T extends boolean | undefined>(
 		req: AuthenticatedRequest<{ projectId: string }>,
 		_res: Response,
 		dataStoreId: string,
-		dto: AddDataStoreRowsDto & { returnData: T },
+		dto: AddDataStoreRowsDto & { returnData?: T },
 	): Promise<Array<T extends true ? DataStoreRowReturn : Pick<DataStoreRowReturn, 'id'>>>;
 	@Post('/:dataStoreId/insert')
 	@ProjectScope('dataStore:writeRow')

--- a/packages/cli/src/modules/data-table/data-store.service.ts
+++ b/packages/cli/src/modules/data-table/data-store.service.ts
@@ -11,7 +11,7 @@ import type {
 } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
-import type { DataStoreRow, DataStoreRows } from 'n8n-workflow';
+import type { DataStoreRow, DataStoreRowReturn, DataStoreRows } from 'n8n-workflow';
 
 import { DataStoreColumnRepository } from './data-store-column.repository';
 import { DataStoreRowsRepository } from './data-store-rows.repository';
@@ -125,17 +125,23 @@ export class DataStoreService {
 		return await this.dataStoreColumnRepository.getColumns(dataStoreId);
 	}
 
-	async insertRows(
+	async insertRows<T extends boolean>(
 		dataStoreId: string,
 		projectId: string,
 		rows: DataStoreRows,
-		returnData: boolean = false,
-	) {
+		returnData: T,
+	): Promise<Array<T extends true ? DataStoreRowReturn : Pick<DataStoreRowReturn, 'id'>>>;
+	async insertRows<T extends boolean>(
+		dataStoreId: string,
+		projectId: string,
+		rows: DataStoreRows,
+		returnData?: T,
+	): Promise<Array<T extends true ? DataStoreRowReturn : Pick<DataStoreRowReturn, 'id'>>> {
 		await this.validateDataStoreExists(dataStoreId, projectId);
 		await this.validateRows(dataStoreId, rows);
 
 		const columns = await this.dataStoreColumnRepository.getColumns(dataStoreId);
-		return await this.dataStoreRowsRepository.insertRows(dataStoreId, rows, columns, returnData);
+		return await this.dataStoreRowsRepository.insertRows<T>(dataStoreId, rows, columns, returnData);
 	}
 
 	async upsertRows(dataStoreId: string, projectId: string, dto: UpsertDataStoreRowsDto) {

--- a/packages/cli/src/modules/data-table/data-store.service.ts
+++ b/packages/cli/src/modules/data-table/data-store.service.ts
@@ -144,6 +144,12 @@ export class DataStoreService {
 		return await this.dataStoreRowsRepository.insertRows(dataStoreId, rows, columns, returnData);
 	}
 
+	async upsertRows<T extends boolean | undefined>(
+		dataStoreId: string,
+		projectId: string,
+		dto: Omit<UpsertDataStoreRowsDto, 'returnData'>,
+		returnData?: T,
+	): Promise<T extends true ? DataStoreRowReturn[] : true>;
 	async upsertRows(
 		dataStoreId: string,
 		projectId: string,

--- a/packages/cli/src/modules/data-table/data-store.service.ts
+++ b/packages/cli/src/modules/data-table/data-store.service.ts
@@ -125,23 +125,23 @@ export class DataStoreService {
 		return await this.dataStoreColumnRepository.getColumns(dataStoreId);
 	}
 
-	async insertRows<T extends boolean>(
-		dataStoreId: string,
-		projectId: string,
-		rows: DataStoreRows,
-		returnData: T,
-	): Promise<Array<T extends true ? DataStoreRowReturn : Pick<DataStoreRowReturn, 'id'>>>;
-	async insertRows<T extends boolean>(
+	async insertRows<T extends boolean | undefined>(
 		dataStoreId: string,
 		projectId: string,
 		rows: DataStoreRows,
 		returnData?: T,
-	): Promise<Array<T extends true ? DataStoreRowReturn : Pick<DataStoreRowReturn, 'id'>>> {
+	): Promise<Array<T extends true ? DataStoreRowReturn : Pick<DataStoreRowReturn, 'id'>>>;
+	async insertRows(
+		dataStoreId: string,
+		projectId: string,
+		rows: DataStoreRows,
+		returnData?: boolean,
+	) {
 		await this.validateDataStoreExists(dataStoreId, projectId);
 		await this.validateRows(dataStoreId, rows);
 
 		const columns = await this.dataStoreColumnRepository.getColumns(dataStoreId);
-		return await this.dataStoreRowsRepository.insertRows<T>(dataStoreId, rows, columns, returnData);
+		return await this.dataStoreRowsRepository.insertRows(dataStoreId, rows, columns, returnData);
 	}
 
 	async upsertRows(dataStoreId: string, projectId: string, dto: UpsertDataStoreRowsDto) {

--- a/packages/cli/src/modules/data-table/utils/sql-utils.ts
+++ b/packages/cli/src/modules/data-table/utils/sql-utils.ts
@@ -172,6 +172,10 @@ function hasRowReturnData(data: unknown): data is DataStoreRowReturn {
 	);
 }
 
+function hasRowId(data: unknown): data is Pick<DataStoreRowReturn, 'id'> {
+	return typeof data === 'object' && data !== null && 'id' in data && isNumber(data.id);
+}
+
 export function extractReturningData(raw: unknown): DataStoreRowReturn[] {
 	if (!isArrayOf(raw, hasRowReturnData)) {
 		throw new UnexpectedError(
@@ -186,7 +190,7 @@ export function extractInsertedIds(raw: unknown, dbType: DataSourceOptions['type
 	switch (dbType) {
 		case 'postgres':
 		case 'mariadb': {
-			if (!isArrayOf(raw, hasRowReturnData)) {
+			if (!isArrayOf(raw, hasRowId)) {
 				throw new UnexpectedError(
 					'Expected INSERT INTO raw to be { id: number }[] on Postgres or MariaDB',
 				);

--- a/packages/cli/src/modules/data-table/utils/sql-utils.ts
+++ b/packages/cli/src/modules/data-table/utils/sql-utils.ts
@@ -151,8 +151,8 @@ const isNumber = (value: unknown): value is number => {
 	return typeof value === 'number' && Number.isFinite(value);
 };
 
-const isDate = (value: unknown): value is Date => {
-	return value instanceof Date;
+const isString = (value: unknown): value is string => {
+	return typeof value === 'string';
 };
 
 function hasInsertId(data: unknown): data is WithInsertId {
@@ -166,9 +166,9 @@ function hasRowReturnData(data: unknown): data is DataStoreRowReturn {
 		'id' in data &&
 		isNumber(data.id) &&
 		'createdAt' in data &&
-		isDate(data.createdAt) &&
+		isString(data.createdAt) &&
 		'updatedAt' in data &&
-		isDate(data.updatedAt)
+		isString(data.updatedAt)
 	);
 }
 

--- a/packages/cli/src/modules/data-table/utils/sql-utils.ts
+++ b/packages/cli/src/modules/data-table/utils/sql-utils.ts
@@ -179,7 +179,7 @@ function hasRowId(data: unknown): data is Pick<DataStoreRowReturn, 'id'> {
 export function extractReturningData(raw: unknown): DataStoreRowReturn[] {
 	if (!isArrayOf(raw, hasRowReturnData)) {
 		throw new UnexpectedError(
-			'Expected INSERT INTO raw to be { id: number }[] on Postgres or MariaDB',
+			`Expected INSERT INTO raw to be { id: number; createdAt: string; updatedAt: string }[] on Postgres or MariaDB. Is '${JSON.stringify(raw)}'`,
 		);
 	}
 
@@ -192,7 +192,7 @@ export function extractInsertedIds(raw: unknown, dbType: DataSourceOptions['type
 		case 'mariadb': {
 			if (!isArrayOf(raw, hasRowId)) {
 				throw new UnexpectedError(
-					'Expected INSERT INTO raw to be { id: number }[] on Postgres or MariaDB',
+					`Expected INSERT INTO raw to be { id: number }[] on Postgres or MariaDB. Is '${JSON.stringify(raw)}'`,
 				);
 			}
 			return raw.map((r) => r.id);

--- a/packages/cli/src/modules/data-table/utils/sql-utils.ts
+++ b/packages/cli/src/modules/data-table/utils/sql-utils.ts
@@ -151,8 +151,8 @@ const isNumber = (value: unknown): value is number => {
 	return typeof value === 'number' && Number.isFinite(value);
 };
 
-const isString = (value: unknown): value is string => {
-	return typeof value === 'string';
+const isDate = (value: unknown): value is Date => {
+	return value instanceof Date;
 };
 
 function hasInsertId(data: unknown): data is WithInsertId {
@@ -166,9 +166,9 @@ function hasRowReturnData(data: unknown): data is DataStoreRowReturn {
 		'id' in data &&
 		isNumber(data.id) &&
 		'createdAt' in data &&
-		isString(data.createdAt) &&
+		isDate(data.createdAt) &&
 		'updatedAt' in data &&
-		isString(data.updatedAt)
+		isDate(data.updatedAt)
 	);
 }
 

--- a/packages/workflow/src/data-store.types.ts
+++ b/packages/workflow/src/data-store.types.ts
@@ -72,9 +72,15 @@ export type AddDataStoreColumnOptions = Pick<DataStoreColumn, 'name' | 'type'> &
 
 export type DataStoreColumnJsType = string | number | boolean | Date | null;
 
+export type DataStoreRowReturnBase = {
+	id: number;
+	createdAt: Date;
+	updatedAt: Date;
+};
 export type DataStoreRow = Record<string, DataStoreColumnJsType>;
 export type DataStoreRows = DataStoreRow[];
-export type DataStoreRowWithId = DataStoreRow & { id: number };
+export type DataStoreRowReturn = DataStoreRow & DataStoreRowReturnBase;
+export type DataStoreRowsReturn = DataStoreRowReturn[];
 
 // APIs for a data store service operating on a specific projectId
 export interface IDataStoreProjectAggregateService {
@@ -100,9 +106,11 @@ export interface IDataStoreProjectService {
 
 	getManyRowsAndCount(
 		dto: Partial<ListDataStoreRowsOptions>,
-	): Promise<{ count: number; data: DataStoreRows }>;
+	): Promise<{ count: number; data: DataStoreRowsReturn }>;
 
-	insertRows(rows: DataStoreRows): Promise<Array<{ id: number }>>;
+	insertRows(rows: DataStoreRows): Promise<DataStoreRowReturn[]>;
 
 	upsertRows(options: UpsertDataStoreRowsOptions): Promise<boolean>;
+
+	deleteRows(ids: number[]): Promise<boolean>;
 }

--- a/packages/workflow/src/data-store.types.ts
+++ b/packages/workflow/src/data-store.types.ts
@@ -110,7 +110,7 @@ export interface IDataStoreProjectService {
 
 	insertRows(rows: DataStoreRows): Promise<DataStoreRowReturn[]>;
 
-	upsertRows(options: UpsertDataStoreRowsOptions): Promise<boolean | DataStoreRowReturn[]>;
+	upsertRows(options: UpsertDataStoreRowsOptions): Promise<DataStoreRowReturn[]>;
 
 	deleteRows(ids: number[]): Promise<boolean>;
 }

--- a/packages/workflow/src/data-store.types.ts
+++ b/packages/workflow/src/data-store.types.ts
@@ -74,8 +74,8 @@ export type DataStoreColumnJsType = string | number | boolean | Date | null;
 
 export type DataStoreRowReturnBase = {
 	id: number;
-	createdAt: Date;
-	updatedAt: Date;
+	createdAt: string;
+	updatedAt: string;
 };
 export type DataStoreRow = Record<string, DataStoreColumnJsType>;
 export type DataStoreRows = DataStoreRow[];

--- a/packages/workflow/src/data-store.types.ts
+++ b/packages/workflow/src/data-store.types.ts
@@ -72,10 +72,12 @@ export type AddDataStoreColumnOptions = Pick<DataStoreColumn, 'name' | 'type'> &
 
 export type DataStoreColumnJsType = string | number | boolean | Date | null;
 
+export const DATA_TABLE_SYSTEM_COLUMNS = ['id', 'createdAt', 'updatedAt'] as const;
+
 export type DataStoreRowReturnBase = {
 	id: number;
-	createdAt: string;
-	updatedAt: string;
+	createdAt: Date;
+	updatedAt: Date;
 };
 export type DataStoreRow = Record<string, DataStoreColumnJsType>;
 export type DataStoreRows = DataStoreRow[];


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
