### PR TITLE
refactor(core): Use query builder at data table deletes (no-changelog)

### DIFF
--- a/packages/cli/src/modules/data-table/data-store-rows.repository.ts
+++ b/packages/cli/src/modules/data-table/data-store-rows.repository.ts
@@ -17,7 +17,6 @@ import {
 	deleteColumnQuery,
 	extractInsertedIds,
 	extractReturningData,
-	getPlaceholder,
 	normalizeRows,
 	normalizeValue,
 	quoteIdentifier,
@@ -226,12 +225,15 @@ export class DataStoreRowsRepository {
 			return true;
 		}
 
-		const dbType = this.dataSource.options.type;
-		const quotedTableName = quoteIdentifier(this.toTableName(dataStoreId), dbType);
-		const placeholders = ids.map((_, index) => getPlaceholder(index + 1, dbType)).join(', ');
-		const query = `DELETE FROM ${quotedTableName} WHERE id IN (${placeholders})`;
+		const table = this.toTableName(dataStoreId);
 
-		await this.dataSource.query(query, ids);
+		await this.dataSource
+			.createQueryBuilder()
+			.delete()
+			.from(table, 'dataStore')
+			.where({ id: In(ids) })
+			.execute();
+
 		return true;
 	}
 

--- a/packages/cli/src/modules/data-table/utils/sql-utils.ts
+++ b/packages/cli/src/modules/data-table/utils/sql-utils.ts
@@ -261,7 +261,3 @@ export function normalizeValue(
 
 	return value;
 }
-
-export function getPlaceholder(index: number, dbType: DataSourceOptions['type']): string {
-	return dbType.includes('postgres') ? `$${index}` : '?';
-}


### PR DESCRIPTION
## Summary

Use query builder instead of manually construcing the delete row queries at data tables.
This allows us to drop the `getPlaceholder` helper.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
