### PR TITLE
fix(core): Sanitize all non-alphanumeric characters from tool names

### DIFF
--- a/packages/workflow/src/tool-helpers.ts
+++ b/packages/workflow/src/tool-helpers.ts
@@ -6,5 +6,5 @@ import type { INode } from './interfaces';
  */
 export function nodeNameToToolName(nodeOrName: INode | string): string {
 	const name = typeof nodeOrName === 'string' ? nodeOrName : nodeOrName.name;
-	return name.replace(/[\s.?!=+#@&*()[\]{}:;,<>\/\\'"^%$_]+/g, '_');
+	return name.replace(/[^a-zA-Z0-9_-]+/g, '_');
 }

--- a/packages/workflow/test/tool-helpers.test.ts
+++ b/packages/workflow/test/tool-helpers.test.ts
@@ -49,6 +49,18 @@ describe('nodeNameToToolName', () => {
 		expect(nodeNameToToolName(getNodeWithName('Test#+*()[]{}:;,<>/\\\'"%$Node'))).toBe('Test_Node');
 	});
 
+	it('should replace emojis with underscores', () => {
+		expect(nodeNameToToolName(getNodeWithName('Test 😀 Node'))).toBe('Test_Node');
+	});
+
+	it('should replace multiple emojis with underscores', () => {
+		expect(nodeNameToToolName(getNodeWithName('🚀 Test 📊 Node 🎉'))).toBe('_Test_Node_');
+	});
+
+	it('should handle complex emoji sequences', () => {
+		expect(nodeNameToToolName(getNodeWithName('Test 👨‍💻 Node 🔥'))).toBe('Test_Node_');
+	});
+
 	describe('when passed a string directly', () => {
 		it('should replace spaces with underscores', () => {
 			expect(nodeNameToToolName('Test Node')).toBe('Test_Node');


### PR DESCRIPTION
## Summary

When using strange characters, e.g., emojis, in Tool names, LLMs might not accept these. We now sanitize all but the non-alphanumeric (and underscore and dash) from the tool name before passing it on to the LLM.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-1362/emojis-in-tool-names-causes-error-in-call-to-llm-tested-with-openai

<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
