### PR TITLE
Openrouter improvements (reasoning effort + preset models + app attribution)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/LmChatOpenRouter.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/LmChatOpenRouter.node.test.ts
@@ -1,0 +1,171 @@
+import type { ILoadOptionsFunctions, ISupplyDataFunctions } from 'n8n-workflow';
+import { LmChatOpenRouter } from './LmChatOpenRouter.node';
+
+describe('LmChatOpenRouter', () => {
+	let mockContext: jest.Mocked<ILoadOptionsFunctions>;
+	let mockSupplyContext: jest.Mocked<ISupplyDataFunctions>;
+
+	beforeEach(() => {
+		mockContext = {
+			getCredentials: jest.fn().mockResolvedValue({
+				apiKey: 'test-api-key',
+				url: 'https://openrouter.ai/api/v1',
+			}),
+			getNodeParameter: jest.fn().mockReturnValue(''),
+			helpers: {
+				httpRequest: jest.fn().mockResolvedValue({
+					data: [{ id: 'openai/gpt-4' }, { id: 'anthropic/claude-3' }, { id: 'google/gemini-pro' }],
+				}),
+			},
+		} as unknown as jest.Mocked<ILoadOptionsFunctions>;
+
+		mockSupplyContext = {
+			getCredentials: jest.fn().mockResolvedValue({
+				apiKey: 'test-api-key',
+				url: 'https://openrouter.ai/api/v1',
+			}),
+			getNodeParameter: jest.fn(),
+			getNode: jest.fn().mockReturnValue({ typeVersion: 1 }),
+		} as unknown as jest.Mocked<ISupplyDataFunctions>;
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('getModels', () => {
+		it('should return formatted models from OpenRouter API', async () => {
+			const nodeInstance = new LmChatOpenRouter();
+			const result = await nodeInstance.methods.listSearch.getModels.call(mockContext);
+
+			expect(mockContext.helpers.httpRequest).toHaveBeenCalledWith({
+				method: 'GET',
+				url: 'https://openrouter.ai/api/v1/models',
+				headers: {
+					Authorization: 'Bearer test-api-key',
+				},
+			});
+
+			expect(result.results).toEqual([
+				{ name: 'openai/gpt-4', value: 'openai/gpt-4' },
+				{ name: 'anthropic/claude-3', value: 'anthropic/claude-3' },
+				{ name: 'google/gemini-pro', value: 'google/gemini-pro' },
+			]);
+		});
+
+		it('should filter models based on search term', async () => {
+			mockContext.helpers.httpRequest = jest.fn().mockResolvedValue({
+				data: [
+					{ id: 'openai/gpt-4' },
+					{ id: 'anthropic/claude-3' },
+					{ id: 'openai/gpt-3.5-turbo' },
+				],
+			});
+
+			const nodeInstance = new LmChatOpenRouter();
+			const result = await nodeInstance.methods.listSearch.getModels.call(mockContext, 'gpt');
+
+			expect(result.results).toEqual([
+				{ name: 'openai/gpt-4', value: 'openai/gpt-4' },
+				{ name: 'openai/gpt-3.5-turbo', value: 'openai/gpt-3.5-turbo' },
+			]);
+		});
+
+		it('should handle case-insensitive search', async () => {
+			mockContext.helpers.httpRequest = jest.fn().mockResolvedValue({
+				data: [{ id: 'openai/gpt-4' }, { id: 'anthropic/claude-3' }],
+			});
+
+			const nodeInstance = new LmChatOpenRouter();
+			const result = await nodeInstance.methods.listSearch.getModels.call(mockContext, 'GPT');
+
+			expect(result.results).toEqual([{ name: 'openai/gpt-4', value: 'openai/gpt-4' }]);
+		});
+
+		it('should handle API errors gracefully', async () => {
+			mockContext.helpers.httpRequest = jest.fn().mockRejectedValue(new Error('API Error'));
+
+			const nodeInstance = new LmChatOpenRouter();
+			await expect(nodeInstance.methods.listSearch.getModels.call(mockContext)).rejects.toThrow(
+				'API Error',
+			);
+		});
+	});
+
+	describe('supplyData', () => {
+		it('should create ChatOpenAI instance with correct configuration', async () => {
+			mockSupplyContext.getNodeParameter
+				.mockReturnValueOnce({ mode: 'list', value: 'openai/gpt-4' }) // model
+				.mockReturnValueOnce({}); // options
+
+			const nodeInstance = new LmChatOpenRouter();
+			const result = await nodeInstance.supplyData.call(mockSupplyContext, 0);
+
+			expect(result.response).toBeDefined();
+			// Verify that the model instance is created (we can't easily test the exact instance without mocking)
+			expect(result).toHaveProperty('response');
+		});
+
+		it('should handle resourceLocator model parameter correctly', async () => {
+			mockSupplyContext.getNodeParameter
+				.mockReturnValueOnce({ mode: 'id', value: '@preset/gpt-oss-120b-cerebras' }) // custom model ID
+				.mockReturnValueOnce({}); // options
+
+			const nodeInstance = new LmChatOpenRouter();
+			const result = await nodeInstance.supplyData.call(mockSupplyContext, 0);
+
+			expect(result.response).toBeDefined();
+		});
+
+		it('should handle string model parameter for backward compatibility', async () => {
+			mockSupplyContext.getNodeParameter
+				.mockReturnValueOnce('openai/gpt-4') // string model (legacy)
+				.mockReturnValueOnce({}); // options
+
+			const nodeInstance = new LmChatOpenRouter();
+			const result = await nodeInstance.supplyData.call(mockSupplyContext, 0);
+
+			expect(result.response).toBeDefined();
+		});
+
+		it('should include app attribution headers', async () => {
+			mockSupplyContext.getNodeParameter
+				.mockReturnValueOnce({ mode: 'list', value: 'openai/gpt-4' })
+				.mockReturnValueOnce({});
+
+			const nodeInstance = new LmChatOpenRouter();
+			await nodeInstance.supplyData.call(mockSupplyContext, 0);
+
+			// The headers should be set in the configuration, but we can't easily test this
+			// without mocking the ChatOpenAI constructor
+		});
+
+		it('should handle reasoning effort parameter', async () => {
+			mockSupplyContext.getNodeParameter
+				.mockReturnValueOnce({ mode: 'list', value: 'openai/gpt-4' })
+				.mockReturnValueOnce({
+					reasoningEffort: 'high',
+					responseFormat: 'text',
+				});
+
+			const nodeInstance = new LmChatOpenRouter();
+			const result = await nodeInstance.supplyData.call(mockSupplyContext, 0);
+
+			expect(result.response).toBeDefined();
+		});
+
+		it('should validate reasoning effort values', async () => {
+			mockSupplyContext.getNodeParameter
+				.mockReturnValueOnce({ mode: 'list', value: 'openai/gpt-4' })
+				.mockReturnValueOnce({
+					reasoningEffort: 'invalid',
+				});
+
+			const nodeInstance = new LmChatOpenRouter();
+			const result = await nodeInstance.supplyData.call(mockSupplyContext, 0);
+
+			expect(result.response).toBeDefined();
+			// Invalid reasoning effort should be ignored, not cause an error
+		});
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/LmChatOpenRouter.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/LmChatOpenRouter.node.ts
@@ -39,6 +39,9 @@ export class LmChatOpenRouter implements INodeType {
 					return model.id.toLowerCase().includes(filter.toLowerCase());
 				});
 
+				// Sort models alphabetically for better user experience
+				filteredModels.sort((a: any, b: any) => a.id.localeCompare(b.id));
+
 				return {
 					results: filteredModels.map((model: any) => ({
 						name: model.id,
@@ -255,7 +258,7 @@ export class LmChatOpenRouter implements INodeType {
 							{
 								name: 'Medium',
 								value: 'medium',
-								description: 'Balanced reasoning effort (default)',
+								description: 'Balanced reasoning effort',
 							},
 							{
 								name: 'High',

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/LmChatOpenRouter.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/LmChatOpenRouter.node.ts
@@ -5,6 +5,8 @@ import {
 	type INodeTypeDescription,
 	type ISupplyDataFunctions,
 	type SupplyData,
+	type ILoadOptionsFunctions,
+	type INodeListSearchResult,
 } from 'n8n-workflow';
 
 import { getProxyAgent } from '@utils/httpProxyAgent';
@@ -17,8 +19,11 @@ import { N8nLlmTracing } from '../N8nLlmTracing';
 
 export class LmChatOpenRouter implements INodeType {
 	methods = {
-		loadOptions: {
-			async getModels(this: any) {
+		listSearch: {
+			async getModels(
+				this: ILoadOptionsFunctions,
+				filter?: string,
+			): Promise<INodeListSearchResult> {
 				const credentials = await this.getCredentials('openRouterApi');
 
 				const response = await this.helpers.httpRequest({
@@ -29,10 +34,17 @@ export class LmChatOpenRouter implements INodeType {
 					},
 				});
 
-				return response.data.map((model: any) => ({
-					name: model.id,
-					value: model.id,
-				}));
+				const filteredModels = response.data.filter((model: any) => {
+					if (!filter) return true;
+					return model.id.toLowerCase().includes(filter.toLowerCase());
+				});
+
+				return {
+					results: filteredModels.map((model: any) => ({
+						name: model.id,
+						value: model.id,
+					})),
+				};
 			},
 		},
 	};

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/test/LmChatOpenRouter.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/test/LmChatOpenRouter.node.test.ts
@@ -1,5 +1,5 @@
 import type { ILoadOptionsFunctions, ISupplyDataFunctions } from 'n8n-workflow';
-import { LmChatOpenRouter } from './LmChatOpenRouter.node';
+import { LmChatOpenRouter } from '../LmChatOpenRouter.node';
 
 describe('LmChatOpenRouter', () => {
 	let mockContext: jest.Mocked<ILoadOptionsFunctions>;
@@ -47,9 +47,9 @@ describe('LmChatOpenRouter', () => {
 			});
 
 			expect(result.results).toEqual([
-				{ name: 'openai/gpt-4', value: 'openai/gpt-4' },
 				{ name: 'anthropic/claude-3', value: 'anthropic/claude-3' },
 				{ name: 'google/gemini-pro', value: 'google/gemini-pro' },
+				{ name: 'openai/gpt-4', value: 'openai/gpt-4' },
 			]);
 		});
 
@@ -66,8 +66,8 @@ describe('LmChatOpenRouter', () => {
 			const result = await nodeInstance.methods.listSearch.getModels.call(mockContext, 'gpt');
 
 			expect(result.results).toEqual([
-				{ name: 'openai/gpt-4', value: 'openai/gpt-4' },
 				{ name: 'openai/gpt-3.5-turbo', value: 'openai/gpt-3.5-turbo' },
+				{ name: 'openai/gpt-4', value: 'openai/gpt-4' },
 			]);
 		});
 
@@ -89,6 +89,29 @@ describe('LmChatOpenRouter', () => {
 			await expect(nodeInstance.methods.listSearch.getModels.call(mockContext)).rejects.toThrow(
 				'API Error',
 			);
+		});
+
+		it('should return models sorted alphabetically by id', async () => {
+			mockContext.helpers.httpRequest = jest.fn().mockResolvedValue({
+				data: [
+					{ id: 'openai/gpt-4' },
+					{ id: 'anthropic/claude-3' },
+					{ id: 'google/gemini-pro' },
+					{ id: 'meta/llama-2-70b' },
+					{ id: 'anthropic/claude-2' },
+				],
+			});
+
+			const nodeInstance = new LmChatOpenRouter();
+			const result = await nodeInstance.methods.listSearch.getModels.call(mockContext);
+
+			expect(result.results).toEqual([
+				{ name: 'anthropic/claude-2', value: 'anthropic/claude-2' },
+				{ name: 'anthropic/claude-3', value: 'anthropic/claude-3' },
+				{ name: 'google/gemini-pro', value: 'google/gemini-pro' },
+				{ name: 'meta/llama-2-70b', value: 'meta/llama-2-70b' },
+				{ name: 'openai/gpt-4', value: 'openai/gpt-4' },
+			]);
 		});
 	});
 


### PR DESCRIPTION
## Summary

This PR enhances the OpenRouter Chat Model node with several key improvements that expand functionality and improve user experience.

### Video:

https://github.com/user-attachments/assets/83995283-ff29-4258-8592-af700dc6ee23


### Changes Made

**🔧 Model Selection Enhancement:**
- Replaced basic `type: 'options'` with advanced `type: 'resourceLocator'` 
- Added dual-mode model selection: "From List" (API-fetched models) and "Custom Model ID" (manual entry)
- Enables support for OpenRouter **preset models** like `@preset/gpt-oss-120b-cerebras`

**📊 App Attribution:**
- Added automatic n8n app attribution headers to all OpenRouter API requests
- Includes `HTTP-Referer: https://n8n.io` and `X-Title: n8n` headers
- Ensures n8n workflows appear in OpenRouter rankings and analytics

**⚙️ Reasoning Effort Parameter:**
- Added comprehensive reasoning effort parameter with all levels: `minimal`, `low`, `medium`, `high`
- Full validation and type safety implementation
- Allows users to control reasoning tokens vs speed/cost trade-offs

### How to Test

1. **Model Selection Testing:**
   - Open OpenRouter Chat Model node
   - Verify "From List" mode shows models from OpenRouter API
   - Create a preset in Openrouter: https://openrouter.ai/settings/presets
   - Switch to "Custom Model ID" mode and enter `@preset/xxxxxxxx`
   - Test both modes work correctly

2. **App Attribution Testing:**
   - Run any OpenRouter workflow
   - Check OpenRouter dashboard/analytics to see n8n attribution
   - Verify `n8n` appears in rankings and model usage analytics

3. **Reasoning Effort Testing:**
   - Add reasoning effort parameter to node options
   - Test all levels (minimal, low, medium, high)
   - Verify parameter validation works correctly

4. **Backward Compatibility:**
   - Test existing OpenRouter workflows continue to work
   - Verify no breaking changes for current users

### Technical Details

- **Files Changed:** `packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/LmChatOpenRouter.node.ts`
- **Breaking Changes:** None - fully backward compatible
- **Dependencies:** No new dependencies required
- **API Changes:** Adds new headers to OpenRouter API requests


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
