### PR TITLE
fix(editor): Remove the enlarged thumb-target area for the scrollbar

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nScrollArea/N8nScrollArea.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nScrollArea/N8nScrollArea.vue
@@ -118,6 +118,7 @@ const viewportStyle = computed(() => {
 	padding: var(--spacing-5xs);
 	background: transparent;
 	transition: background 160ms ease-out;
+	pointer-events: none;
 
 	&:hover {
 		background: var(--color-foreground-light);
@@ -138,18 +139,7 @@ const viewportStyle = computed(() => {
 	background: var(--color-foreground-base);
 	border-radius: 4px;
 	position: relative;
-
-	&::before {
-		content: '';
-		position: absolute;
-		top: 50%;
-		left: 50%;
-		transform: translate(-50%, -50%);
-		width: 100%;
-		height: 100%;
-		min-width: 44px;
-		min-height: 44px;
-	}
+	pointer-events: auto;
 
 	&:hover {
 		background: var(--color-foreground-dark);


### PR DESCRIPTION
This gives some space to the icons that might be underneath that thumb-target area.

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-1314/cant-click-hideshow-icon-on-eval-table-anymore


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
