### PR TITLE
chore(core): Use tsc-watch in node-cli dev mode

### DIFF
--- a/packages/@n8n/node-cli/package.json
+++ b/packages/@n8n/node-cli/package.json
@@ -19,7 +19,7 @@
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "copy-templates": "node scripts/copy-templates.mjs",
-    "dev": "tsc -p tsconfig.build.json -w --onCompilationComplete \"pnpm copy-templates\"",
+    "dev": "tsc-watch -p tsconfig.build.json -w --onCompilationComplete \"pnpm copy-templates\"",
     "format": "biome format --write src",
     "format:check": "biome ci src",
     "lint": "eslint src --quiet",


### PR DESCRIPTION
## Summary
There's a typo that causes the `pnpm dev` command to fail

<img width="843" height="101" alt="image" src="https://github.com/user-attachments/assets/59667c20-cb1d-45de-a971-56fc736876c2" />


## Related Linear tickets, Github issues, and Community forum posts

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
