### PR TITLE
perf(editor): Introduce execution data throttling for logs and canvas updates (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/constants.ts
+++ b/packages/frontend/editor-ui/src/constants.ts
@@ -984,3 +984,10 @@ export const AI_NODES_PACKAGE_NAME = '@n8n/n8n-nodes-langchain';
 export const AI_ASSISTANT_MAX_CONTENT_LENGTH = 100; // in kilobytes
 
 export const RUN_DATA_DEFAULT_PAGE_SIZE = 25;
+
+/**
+ * Performance Optimizations
+ */
+
+export const LOGS_EXECUTION_DATA_THROTTLE_DURATION = 1000;
+export const CANVAS_EXECUTION_DATA_THROTTLE_DURATION = 500;

--- a/packages/frontend/editor-ui/src/features/logs/composables/useLogsExecutionData.ts
+++ b/packages/frontend/editor-ui/src/features/logs/composables/useLogsExecutionData.ts
@@ -9,7 +9,7 @@ import { parse } from 'flatted';
 import { useToast } from '@/composables/useToast';
 import type { LatestNodeInfo, LogEntry } from '../logs.types';
 import { isChatNode } from '@/utils/aiUtils';
-import { PLACEHOLDER_EMPTY_WORKFLOW_ID } from '@/constants';
+import { LOGS_EXECUTION_DATA_THROTTLE_DURATION, PLACEHOLDER_EMPTY_WORKFLOW_ID } from '@/constants';
 
 export function useLogsExecutionData() {
 	const nodeHelpers = useNodeHelpers();
@@ -62,7 +62,9 @@ export function useLogsExecutionData() {
 		);
 	});
 
-	const updateInterval = computed(() => ((entries.value?.length ?? 0) > 1 ? 1000 : 0));
+	const updateInterval = computed(() =>
+		(entries.value?.length ?? 0) > 1 ? LOGS_EXECUTION_DATA_THROTTLE_DURATION : 0,
+	);
 
 	function resetExecutionData() {
 		execData.value = undefined;


### PR DESCRIPTION
## Summary

This pull request introduces performance optimizations for execution data handling in the canvas. The main change is the introduction of throttling for updates to execution data, which helps reduce unnecessary computations and improves UI responsiveness, especially during rapid data changes.

**Before**

<img width="630" height="814" alt="Screenshot 2025-08-26 at 14 17 29" src="https://github.com/user-attachments/assets/38786aef-73df-466a-8cde-1fb1dfdced7e" />

**After**

<img width="630" height="817" alt="Screenshot 2025-08-26 at 14 25 18" src="https://github.com/user-attachments/assets/8f681a86-92e1-4c7b-bdf6-4baa5f831779" />


**Performance optimizations:**

* Introduced two new constants, `LOGS_EXECUTION_DATA_THROTTLE_DURATION` and `CANVAS_EXECUTION_DATA_THROTTLE_DURATION`, in `constants.ts` to control the throttling duration for execution data updates.

* In `useCanvasMapping.ts`, replaced the computed property for `nodeExecutionRunDataOutputMapById` with a throttled watcher using `throttledWatch` from `@vueuse/core`, utilizing the new `CANVAS_EXECUTION_DATA_THROTTLE_DURATION` constant to limit update frequency. [[1]](diffhunk://#diff-9550a2d635157447f2dc60721226413e1aaf55f7c42469a3e94be5767a4a750bL358-R367) [[2]](diffhunk://#diff-9550a2d635157447f2dc60721226413e1aaf55f7c42469a3e94be5767a4a750bR393-R395)

* In `useLogsExecutionData.ts`, replaced a hardcoded update interval with the new `LOGS_EXECUTION_DATA_THROTTLE_DURATION` constant, ensuring consistent throttling for log updates. [[1]](diffhunk://#diff-2e219bd6dd78653c85243ea832be45a108b9ba2bc2731a05b59a34535b83b9ccL12-R12) [[2]](diffhunk://#diff-2e219bd6dd78653c85243ea832be45a108b9ba2bc2731a05b59a34535b83b9ccL65-R67)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1255/improve-usecanvasmapping-execution-data-handling-performance


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
