### PR TITLE
fix(editor): Fix "error connecting to n8n" error if not logged in

### DIFF
--- a/packages/frontend/editor-ui/src/init.ts
+++ b/packages/frontend/editor-ui/src/init.ts
@@ -205,12 +205,14 @@ function registerAuthenticationHooks() {
 	const npsSurveyStore = useNpsSurveyStore();
 	const telemetry = useTelemetry();
 	const RBACStore = useRBACStore();
+	const settingsStore = useSettingsStore();
 
 	usersStore.registerLoginHook((user) => {
 		RBACStore.setGlobalScopes(user.globalScopes ?? []);
 		telemetry.identify(rootStore.instanceId, user.id);
 		postHogStore.init(user.featureFlags);
 		npsSurveyStore.setupNpsSurveyOnLogin(user.id, user.settings);
+		void settingsStore.getModuleSettings();
 	});
 
 	usersStore.registerLogoutHook(() => {

--- a/packages/frontend/editor-ui/src/stores/settings.store.ts
+++ b/packages/frontend/editor-ui/src/stores/settings.store.ts
@@ -279,8 +279,6 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 		await getSettings();
 
 		initialized.value = true;
-
-		await getModuleSettings();
 	};
 
 	const stopShowingSetupPage = () => {

--- a/packages/frontend/editor-ui/src/views/SigninView.vue
+++ b/packages/frontend/editor-ui/src/views/SigninView.vue
@@ -136,10 +136,6 @@ const login = async (form: LoginRequestDto) => {
 		loading.value = false;
 		await settingsStore.getSettings();
 
-		if (settingsStore.activeModules.length > 0) {
-			await settingsStore.getModuleSettings();
-		}
-
 		toast.clearAllStickyNotifications();
 
 		if (settingsStore.isMFAEnforced && !usersStore.currentUser?.mfaAuthenticated) {


### PR DESCRIPTION
## Summary

In #18492 we moved `/module-settings` behind auth. The FE still assumed it could be called even when user hasn't logged in. This fixes it by loading the module settings after user has logged in.


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1254/if-not-logged-in-get-error-connecting-to-n8n


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
