### PR TITLE
fix(editor): Fix dev build by exporting filter as type (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -86,8 +86,10 @@ export { UpdateDataStoreRowDto } from './data-store/update-data-store-row.dto';
 export { UpsertDataStoreRowsDto } from './data-store/upsert-data-store-rows.dto';
 export { ListDataStoreQueryDto } from './data-store/list-data-store-query.dto';
 export { ListDataStoreContentQueryDto } from './data-store/list-data-store-content-query.dto';
-export { ListDataStoreContentFilterConditionType } from './data-store/list-data-store-content-query.dto';
-export type { ListDataStoreContentFilter } from './data-store/list-data-store-content-query.dto';
+export type {
+	ListDataStoreContentFilter,
+	ListDataStoreContentFilterConditionType,
+} from './data-store/list-data-store-content-query.dto';
 export { CreateDataStoreColumnDto } from './data-store/create-data-store-column.dto';
 export { AddDataStoreRowsDto } from './data-store/add-data-store-rows.dto';
 export { AddDataStoreColumnDto } from './data-store/add-data-store-column.dto';


### PR DESCRIPTION
## Summary

We repeated the same issue as before, accidentally not exporting as type which somehow breaks on our dev mode but not regular prod builds, so this goes unnoticed on CI. :/ 

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
