### PR TITLE
fix(editor): Allow password managers to autocomplete MFA code during login

### DIFF
--- a/packages/frontend/@n8n/design-system/src/types/form.ts
+++ b/packages/frontend/@n8n/design-system/src/types/form.ts
@@ -95,5 +95,6 @@ export type InputAutocompletePropType =
 	| 'current-password'
 	| 'given-name'
 	| 'family-name'
+	| 'one-time-code'
 	| 'email'; // https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete
 export type ElementPlusSizePropType = '' | 'small' | 'large' | 'default' | undefined;

--- a/packages/frontend/editor-ui/src/views/MfaView.vue
+++ b/packages/frontend/editor-ui/src/views/MfaView.vue
@@ -112,7 +112,7 @@ const onSubmit = (formData: unknown) => {
 	emit('submit', data);
 };
 
-const focusMfaCodeAfterPasswordManager = async () => {
+const focusMfaCodeAfterPasswordManager = () => {
 	setTimeout(() => {
 		if (mfaFormRef.value) {
 			const container = mfaFormRef.value.$el;

--- a/packages/frontend/editor-ui/src/views/MfaView.vue
+++ b/packages/frontend/editor-ui/src/views/MfaView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { IFormInputs } from '@/Interface';
+import type { IFormInputs, InputAutocompletePropType } from '@/Interface';
 import Logo from '@/components/Logo/Logo.vue';
 import {
 	MFA_AUTHENTICATION_RECOVERY_CODE_INPUT_MAX_LENGTH,
@@ -65,12 +65,11 @@ const formField = (
 	placeholder: string,
 	maxlength: number,
 	focus = true,
-	autocomplete: string = 'text',
+	autocomplete: InputAutocompletePropType = 'off',
 ) => {
 	return {
 		name,
 		initialValue: '',
-		autocomplete: autocomplete,
 		properties: {
 			label,
 			placeholder,
@@ -78,6 +77,7 @@ const formField = (
 			capitalize: true,
 			validateOnBlur: false,
 			focusInitially: focus,
+			autocomplete,
 		},
 	};
 };
@@ -116,11 +116,8 @@ const focusMfaCodeAfterPasswordManager = () => {
 	setTimeout(() => {
 		if (mfaFormRef.value) {
 			const container = mfaFormRef.value.$el;
-
 			if (!container) return;
-
 			const inputElement = container.querySelector('input[name="mfaCode"]') as HTMLInputElement;
-
 			if (inputElement) {
 				inputElement.focus();
 			}


### PR DESCRIPTION
## Summary

The MFA code input did not have the proper autocomplete option so the password manager could find it. Also, we need to delay the focus or else the password manager ignores it. 

## Now

![CleanShot 2025-08-27 at 09 03 41](https://github.com/user-attachments/assets/46239d25-e873-4e5f-93c7-aefde5a2523a)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4006/2fa-field-does-not-work-with-pw-managers

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
