### PR TITLE
fix(core): Add metadata as required item key

### DIFF
--- a/packages/nodes-base/nodes/Code/result-validation.ts
+++ b/packages/nodes-base/nodes/Code/result-validation.ts
@@ -11,7 +11,7 @@ export interface TextKeys {
 	};
 }
 
-export const REQUIRED_N8N_ITEM_KEYS = new Set(['json', 'binary', 'pairedItem', 'error', 'index']);
+export const REQUIRED_N8N_ITEM_KEYS = new Set(['json', 'binary', 'pairedItem', 'error', 'metadata', 'index']);
 
 export function getTextKey(
 	textKeys: TextKeys,


### PR DESCRIPTION
## Summary

In node [ExecuteWorkflow](https://github.com/n8n-io/n8n/blob/2ea3d034e3fb419497f0b23abc1e99175f4746dd/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow/ExecuteWorkflow.node.ts#L328) the item key "metadata" is used, which seems to be a reserved key. So it should be added in key validation in task runner, otherwise an error is thrown if using a "Code" node after "ExecuteWorkflow".

Steps to reproduce:

1. Create a simple sub-workflow returning some dummy data
2. Use "ExecuteWorkflow" node in a new workflow referencing the workflow from previous step
3. Add a "Code" node with simply returning all items
4. Error "Invalid output format" is thrown in "Code" node

## Related Linear tickets, Github issues, and Community forum posts

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
