### PR TITLE
docs: add beginner tip about ready-made workflowsdocs: add beginner tip about ready-made workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ docker run -it --rm --name n8n -p 5678:5678 -v n8n_data:/home/node/.n8n docker.n
 
 Access the editor at http://localhost:5678
 
+> 💡 Tip: If you are completely new to n8n, you can also explore [ready-made workflows](https://n8n.io/workflows) to learn faster before building your own.
+
+
 ## Resources
 
 - 📚 [Documentation](https://docs.n8n.io)


### PR DESCRIPTION
This PR adds a helpful tip in the Quick Start section of the README.md.  
The tip suggests that beginners can explore ready-made workflows on n8n.io to learn faster before building their own automations.  

This will make it easier for new users to get started with n8n.
