### PR TITLE
fix(editor): Make resource locator work with data tables (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/dto/dynamic-node-parameters/resource-locator-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/dynamic-node-parameters/resource-locator-request.dto.ts
@@ -6,4 +6,5 @@ export class ResourceLocatorRequestDto extends BaseDynamicParametersRequestDto.e
 	methodName: z.string(),
 	filter: z.string().optional(),
 	paginationToken: z.string().optional(),
+	projectId: z.string().optional(),
 }) {}

--- a/packages/cli/src/controllers/dynamic-node-parameters.controller.ts
+++ b/packages/cli/src/controllers/dynamic-node-parameters.controller.ts
@@ -10,6 +10,7 @@ import type { INodePropertyOptions, NodeParameterValueType } from 'n8n-workflow'
 
 import { DynamicNodeParametersService } from '@/services/dynamic-node-parameters.service';
 import { getBase } from '@/workflow-execute-additional-data';
+import { userHasScopes } from '@/permissions.ee/check-access';
 
 @RestController('/dynamic-node-parameters')
 export class DynamicNodeParametersController {
@@ -70,9 +71,21 @@ export class DynamicNodeParametersController {
 			credentials,
 			currentNodeParameters,
 			nodeTypeAndVersion,
+			projectId,
 		} = payload;
 
 		const additionalData = await getBase(req.user.id, currentNodeParameters);
+
+		if (projectId) {
+			if (await userHasScopes(req.user, ['dataStore:listProject'], false, { projectId })) {
+				// Project ID is currently only added on the additionalData if the user
+				// has data store listing permission for that project. We should consider
+				// turning this into a more general check, but as of now data stores are
+				// the only nodes with project specific resource locators where we want to ensure
+				// that only data stores belonging to their respective projects are shown.
+				additionalData.dataStoreProjectId = projectId;
+			}
+		}
 
 		return await this.service.getResourceLocatorResults(
 			methodName,

--- a/packages/cli/src/modules/data-table/data-store-proxy.service.ts
+++ b/packages/cli/src/modules/data-table/data-store-proxy.service.ts
@@ -47,9 +47,10 @@ export class DataStoreProxyService implements DataStoreProxyProvider {
 	async getDataStoreAggregateProxy(
 		workflow: Workflow,
 		node: INode,
+		dataStoreProjectId?: string,
 	): Promise<IDataStoreProjectAggregateService> {
 		this.validateRequest(node);
-		const projectId = await this.getProjectId(workflow);
+		const projectId = dataStoreProjectId ?? (await this.getProjectId(workflow));
 
 		return this.makeAggregateOperations(projectId);
 	}
@@ -58,9 +59,10 @@ export class DataStoreProxyService implements DataStoreProxyProvider {
 		workflow: Workflow,
 		node: INode,
 		dataStoreId: string,
+		dataStoreProjectId?: string,
 	): Promise<IDataStoreProjectService> {
 		this.validateRequest(node);
-		const projectId = await this.getProjectId(workflow);
+		const projectId = dataStoreProjectId ?? (await this.getProjectId(workflow));
 
 		return this.makeDataStoreOperations(projectId, dataStoreId);
 	}

--- a/packages/core/src/execution-engine/index.ts
+++ b/packages/core/src/execution-engine/index.ts
@@ -8,6 +8,7 @@ declare module 'n8n-workflow' {
 		hooks?: ExecutionLifecycleHooks;
 		externalSecretsProxy: ExternalSecretsProxy;
 		dataStoreProxyProvider?: DataStoreProxyProvider;
+		dataStoreProjectId?: string;
 	}
 }
 

--- a/packages/core/src/execution-engine/node-execution-context/utils/data-store-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/data-store-helper-functions.ts
@@ -14,8 +14,17 @@ export function getDataStoreHelperFunctions(
 	const dataStoreProxyProvider = additionalData.dataStoreProxyProvider;
 	return {
 		getDataStoreAggregateProxy: async () =>
-			await dataStoreProxyProvider.getDataStoreAggregateProxy(workflow, node),
+			await dataStoreProxyProvider.getDataStoreAggregateProxy(
+				workflow,
+				node,
+				additionalData.dataStoreProjectId,
+			),
 		getDataStoreProxy: async (dataStoreId: string) =>
-			await dataStoreProxyProvider.getDataStoreProxy(workflow, node, dataStoreId),
+			await dataStoreProxyProvider.getDataStoreProxy(
+				workflow,
+				node,
+				dataStoreId,
+				additionalData.dataStoreProjectId,
+			),
 	};
 }

--- a/packages/frontend/editor-ui/src/components/ResourceLocator/ResourceLocator.vue
+++ b/packages/frontend/editor-ui/src/components/ResourceLocator/ResourceLocator.vue
@@ -272,6 +272,7 @@ const currentRequestParams = computed(() => {
 		parameters: props.node?.parameters ?? {},
 		credentials: props.node?.credentials ?? {},
 		filter: searchFilter.value,
+		projectId: projectsStore.currentProject?.id,
 	};
 });
 

--- a/packages/frontend/editor-ui/src/components/ResourceLocator/ResourceLocator.vue
+++ b/packages/frontend/editor-ui/src/components/ResourceLocator/ResourceLocator.vue
@@ -272,7 +272,7 @@ const currentRequestParams = computed(() => {
 		parameters: props.node?.parameters ?? {},
 		credentials: props.node?.credentials ?? {},
 		filter: searchFilter.value,
-		projectId: projectsStore.currentProject?.id,
+		projectId: projectsStore.currentProjectId,
 	};
 });
 
@@ -725,7 +725,7 @@ async function loadResources() {
 			methodName: loadOptionsMethod,
 			currentNodeParameters: resolvedNodeParameters,
 			credentials: props.node.credentials,
-			projectId: projectsStore.currentProject?.id,
+			projectId: projectsStore.currentProjectId,
 		};
 
 		if (params.filter) {

--- a/packages/frontend/editor-ui/src/components/ResourceLocator/ResourceLocator.vue
+++ b/packages/frontend/editor-ui/src/components/ResourceLocator/ResourceLocator.vue
@@ -55,6 +55,7 @@ import {
 } from '../../utils/fromAIOverrideUtils';
 import { N8nNotice } from '@n8n/design-system';
 import { completeExpressionSyntax } from '@/utils/expressions';
+import { useProjectsStore } from '@/stores/projects.store';
 
 /**
  * Regular expression to check if the error message contains credential-related phrases.
@@ -144,6 +145,7 @@ const ndvStore = useNDVStore();
 const rootStore = useRootStore();
 const uiStore = useUIStore();
 const workflowsStore = useWorkflowsStore();
+const projectsStore = useProjectsStore();
 
 const appName = computed(() => {
 	if (!props.node) {
@@ -722,6 +724,7 @@ async function loadResources() {
 			methodName: loadOptionsMethod,
 			currentNodeParameters: resolvedNodeParameters,
 			credentials: props.node.credentials,
+			projectId: projectsStore.currentProject?.id,
 		};
 
 		if (params.filter) {

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -924,11 +924,13 @@ export type DataStoreProxyProvider = {
 	getDataStoreAggregateProxy(
 		workflow: Workflow,
 		node: INode,
+		dataStoreProjectId?: string,
 	): Promise<IDataStoreProjectAggregateService>;
 	getDataStoreProxy(
 		workflow: Workflow,
 		node: INode,
 		dataStoreId: string,
+		dataStoreProjectId?: string,
 	): Promise<IDataStoreProjectService>;
 };
 


### PR DESCRIPTION
## Summary

When resource locator requests for available data stores the context only has a mock fake workflow. This workflow doesn't have a workflow ID and it doesn't necessarily even exist in the DB yet, meaning that we can't get the project ID to look data tables from using it.

Make resource locator pass the current project ID from frontend to backend, validate that user has access to the data tables scope for listing tables in projects and use that project ID if its set at data store proxy.

I don't like us including this in IWorkflowExecuteAdditionalData and we could perhaps look into using [module context](https://github.com/n8n-io/n8n/blob/0488ea3e8d42d228f3b663f1cb37ca7502494bc9/packages/@n8n/decorators/src/module/module.ts#L71)
 instead, but that's tech debt for another day unless someone has a better idea on how to do this now 🤔 

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.slack.com/archives/C03MZF137FV/p1755594523615349

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
