### PR TITLE
feat(core): Allow custom project roles from being set to a user project relation

### DIFF
--- a/packages/@n8n/api-types/src/dto/invitation/__tests__/invite-users-request.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/invitation/__tests__/invite-users-request.dto.test.ts
@@ -16,6 +16,7 @@ describe('InviteUsersRequestDto', () => {
 				request: [
 					{ email: 'user1@example.com', role: 'global:member' },
 					{ email: 'user2@example.com', role: 'global:admin' },
+					{ email: 'user3@example.com', role: 'custom:role' },
 				],
 			},
 		])('should validate $name', ({ request }) => {
@@ -42,7 +43,7 @@ describe('InviteUsersRequestDto', () => {
 				request: [
 					{
 						email: 'user@example.com',
-						role: 'invalid-role',
+						role: 'global:owner',
 					},
 				],
 				expectedErrorPath: [0, 'role'],

--- a/packages/@n8n/api-types/src/dto/invitation/invite-users-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/invitation/invite-users-request.dto.ts
@@ -1,11 +1,9 @@
 import { assignableGlobalRoleSchema } from '@n8n/permissions';
 import { z } from 'zod';
 
-const roleSchema = assignableGlobalRoleSchema;
-
 const invitedUserSchema = z.object({
 	email: z.string().email(),
-	role: roleSchema.default('global:member'),
+	role: assignableGlobalRoleSchema.default('global:member'),
 });
 
 const invitationsSchema = z.array(invitedUserSchema);

--- a/packages/@n8n/api-types/src/dto/invitation/invite-users-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/invitation/invite-users-request.dto.ts
@@ -1,6 +1,7 @@
+import { assignableGlobalRoleSchema } from '@n8n/permissions';
 import { z } from 'zod';
 
-const roleSchema = z.enum(['global:member', 'global:admin']);
+const roleSchema = assignableGlobalRoleSchema;
 
 const invitedUserSchema = z.object({
 	email: z.string().email(),

--- a/packages/@n8n/api-types/src/dto/project/__tests__/add-users-to-project.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/project/__tests__/add-users-to-project.dto.test.ts
@@ -93,7 +93,7 @@ describe('AddUsersToProjectDto', () => {
 					relations: [
 						{
 							userId: 'user-123',
-							role: 'invalid-role',
+							role: '',
 						},
 					],
 				},

--- a/packages/@n8n/api-types/src/dto/project/__tests__/change-user-role-in-project.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/project/__tests__/change-user-role-in-project.dto.test.ts
@@ -32,13 +32,6 @@ describe('ChangeUserRoleInProject', () => {
 				expectedErrorPath: ['role'],
 			},
 			{
-				name: 'invalid role value',
-				request: {
-					role: 'invalid-role',
-				},
-				expectedErrorPath: ['role'],
-			},
-			{
 				name: 'personal owner role',
 				request: { role: PROJECT_OWNER_ROLE_SLUG },
 				expectedErrorPath: ['role'],

--- a/packages/@n8n/api-types/src/dto/project/__tests__/update-project.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/project/__tests__/update-project.dto.test.ts
@@ -120,7 +120,7 @@ describe('UpdateProjectDto', () => {
 					relations: [
 						{
 							userId: 'user-123',
-							role: 'invalid-role',
+							role: 'project:personalOwner',
 						},
 					],
 				},

--- a/packages/@n8n/api-types/src/dto/project/change-user-role-in-project.dto.ts
+++ b/packages/@n8n/api-types/src/dto/project/change-user-role-in-project.dto.ts
@@ -1,6 +1,6 @@
-import { teamRoleSchema } from '@n8n/permissions';
+import { assignableProjectRoleSchema } from '@n8n/permissions';
 import { Z } from 'zod-class';
 
 export class ChangeUserRoleInProject extends Z.class({
-	role: teamRoleSchema,
+	role: assignableProjectRoleSchema,
 }) {}

--- a/packages/@n8n/api-types/src/dto/user/__tests__/role-change-request.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/user/__tests__/role-change-request.dto.test.ts
@@ -11,27 +11,28 @@ describe('RoleChangeRequestDto', () => {
 		expect(result.error?.issues[0].message).toBe('New role is required');
 	});
 
-	it('should fail validation with invalid newRoleName', () => {
+	it('should fail validation with invalid newRoleName global:owner', () => {
 		const data = {
-			newRoleName: 'invalidRole',
+			newRoleName: 'global:owner',
 		};
 
 		const result = RoleChangeRequestDto.safeParse(data);
 
 		expect(result.success).toBe(false);
 		expect(result.error?.issues[0].path[0]).toBe('newRoleName');
-		expect(result.error?.issues[0].message).toBe(
-			"Invalid enum value. Expected 'global:admin' | 'global:member', received 'invalidRole'",
-		);
+		expect(result.error?.issues[0].message).toBe('This global role value is not assignable');
 	});
 
-	it('should pass validation with valid data', () => {
-		const data = {
-			newRoleName: 'global:admin',
-		};
+	it.each<string>(['global:admin', 'custom:role'])(
+		'should pass validation with valid newRoleName %s',
+		(role) => {
+			const data = {
+				newRoleName: role,
+			};
 
-		const result = RoleChangeRequestDto.safeParse(data);
+			const result = RoleChangeRequestDto.safeParse(data);
 
-		expect(result.success).toBe(true);
-	});
+			expect(result.success).toBe(true);
+		},
+	);
 });

--- a/packages/@n8n/api-types/src/dto/user/role-change-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/user/role-change-request.dto.ts
@@ -1,8 +1,11 @@
-import { z } from 'zod';
+import { assignableGlobalRoleSchema } from '@n8n/permissions';
 import { Z } from 'zod-class';
 
 export class RoleChangeRequestDto extends Z.class({
-	newRoleName: z.enum(['global:admin', 'global:member'], {
-		required_error: 'New role is required',
-	}),
+	newRoleName: assignableGlobalRoleSchema
+		// enforce required (non-nullable, non-optional) with custom error message on undefined
+		.nullish()
+		.refine((val): val is NonNullable<typeof val> => val !== null && typeof val !== 'undefined', {
+			message: 'New role is required',
+		}),
 }) {}

--- a/packages/@n8n/api-types/src/schemas/__tests__/project.schema.test.ts
+++ b/packages/@n8n/api-types/src/schemas/__tests__/project.schema.test.ts
@@ -82,7 +82,7 @@ describe('project.schema', () => {
 			},
 			{
 				name: 'invalid role',
-				value: { userId: 'user-123', role: 'invalid-role' },
+				value: { userId: 'user-123', role: 'project:personalOwner' },
 				expected: false,
 			},
 			{

--- a/packages/@n8n/api-types/src/schemas/project.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/project.schema.ts
@@ -1,4 +1,4 @@
-import { teamRoleSchema } from '@n8n/permissions';
+import { assignableProjectRoleSchema } from '@n8n/permissions';
 import { z } from 'zod';
 
 export const projectNameSchema = z.string().min(1).max(255);
@@ -16,6 +16,6 @@ export const projectDescriptionSchema = z.string().max(512);
 
 export const projectRelationSchema = z.object({
 	userId: z.string().min(1),
-	role: teamRoleSchema,
+	role: assignableProjectRoleSchema,
 });
 export type ProjectRelation = z.infer<typeof projectRelationSchema>;

--- a/packages/@n8n/backend-test-utils/src/db/projects.ts
+++ b/packages/@n8n/backend-test-utils/src/db/projects.ts
@@ -1,11 +1,16 @@
 import type { Project, User, ProjectRelation } from '@n8n/db';
 import { ProjectRelationRepository, ProjectRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
-import { PROJECT_OWNER_ROLE_SLUG, type CustomRole } from '@n8n/permissions';
+import type { AssignableProjectRole } from '@n8n/permissions';
+import { PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
 
 import { randomName } from '../random';
 
-export const linkUserToProject = async (user: User, project: Project, role: CustomRole) => {
+export const linkUserToProject = async (
+	user: User,
+	project: Project,
+	role: AssignableProjectRole,
+) => {
 	const projectRelationRepository = Container.get(ProjectRelationRepository);
 	await projectRelationRepository.save(
 		projectRelationRepository.create({
@@ -68,7 +73,7 @@ export const getProjectRelations = async ({
 export const getProjectRoleForUser = async (
 	projectId: string,
 	userId: string,
-): Promise<CustomRole | undefined> => {
+): Promise<AssignableProjectRole | undefined> => {
 	return (
 		await Container.get(ProjectRelationRepository).findOne({
 			where: { projectId, userId },

--- a/packages/@n8n/db/src/entities/types-db.ts
+++ b/packages/@n8n/db/src/entities/types-db.ts
@@ -327,12 +327,6 @@ export namespace ListQuery {
 	};
 }
 
-export type ProjectRole =
-	| 'project:personalOwner'
-	| 'project:admin'
-	| 'project:editor'
-	| 'project:viewer';
-
 export interface IGetExecutionsQueryFilter {
 	id?: FindOperator<string> | string;
 	finished?: boolean;

--- a/packages/@n8n/db/src/repositories/role.repository.ts
+++ b/packages/@n8n/db/src/repositories/role.repository.ts
@@ -1,6 +1,6 @@
 import { DatabaseConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
-import { DataSource, EntityManager, Repository } from '@n8n/typeorm';
+import { DataSource, EntityManager, In, Repository } from '@n8n/typeorm';
 import { UserError } from 'n8n-workflow';
 
 import { Role } from '../entities';
@@ -21,6 +21,13 @@ export class RoleRepository extends Repository<Role> {
 	async findBySlug(slug: string) {
 		return await this.findOne({
 			where: { slug },
+			relations: ['scopes'],
+		});
+	}
+
+	async findBySlugs(slugs: string[], roleType: 'global' | 'project' | 'workflow' | 'credential') {
+		return await this.find({
+			where: { slug: In(slugs), roleType },
 			relations: ['scopes'],
 		});
 	}

--- a/packages/@n8n/permissions/src/__tests__/schemas.test.ts
+++ b/packages/@n8n/permissions/src/__tests__/schemas.test.ts
@@ -9,9 +9,10 @@ import {
 	roleNamespaceSchema,
 	globalRoleSchema,
 	assignableGlobalRoleSchema,
-	projectRoleSchema,
+	systemProjectRoleSchema,
 	credentialSharingRoleSchema,
 	workflowSharingRoleSchema,
+	customProjectRoleSchema,
 } from '../schemas.ee';
 
 describe('roleNamespaceSchema', () => {
@@ -58,7 +59,7 @@ describe('assignableGlobalRoleSchema', () => {
 	});
 });
 
-describe('projectRoleSchema', () => {
+describe('systemProjectRoleSchema', () => {
 	test.each([
 		{
 			name: `valid role: ${PROJECT_OWNER_ROLE_SLUG}`,
@@ -82,7 +83,7 @@ describe('projectRoleSchema', () => {
 		},
 		{ name: 'invalid role', value: 'invalid-role', expected: false },
 	])('should validate $name', ({ value, expected }) => {
-		const result = projectRoleSchema.safeParse(value);
+		const result = systemProjectRoleSchema.safeParse(value);
 		expect(result.success).toBe(expected);
 	});
 });
@@ -111,6 +112,18 @@ describe('workflowSharingRoleSchema', () => {
 		{ name: 'empty string', value: '', expected: false },
 	])('should validate $name', ({ value, expected }) => {
 		const result = workflowSharingRoleSchema.safeParse(value);
+		expect(result.success).toBe(expected);
+	});
+});
+
+describe('customProjectRoleSchema', () => {
+	test.each([
+		{ name: 'valid role: custom:role', value: 'custom:role', expected: true },
+		{ name: 'undefined value', value: undefined, expected: false },
+		{ name: 'empty string', value: '', expected: false },
+		{ name: 'system role', value: PROJECT_ADMIN_ROLE_SLUG, expected: false },
+	])('should validate $name', ({ value, expected }) => {
+		const result = customProjectRoleSchema.safeParse(value);
 		expect(result.success).toBe(expected);
 	});
 });

--- a/packages/@n8n/permissions/src/__tests__/schemas.test.ts
+++ b/packages/@n8n/permissions/src/__tests__/schemas.test.ts
@@ -50,8 +50,6 @@ describe('assignableGlobalRoleSchema', () => {
 		{ name: 'excluded role: global:owner', value: 'global:owner', expected: false },
 		{ name: 'valid role: global:admin', value: 'global:admin', expected: true },
 		{ name: 'valid role: global:member', value: 'global:member', expected: true },
-		{ name: 'invalid role', value: 'global:invalid', expected: false },
-		{ name: 'invalid prefix', value: 'invalid:admin', expected: false },
 		{ name: 'object value', value: {}, expected: false },
 	])('should validate $name', ({ value, expected }) => {
 		const result = assignableGlobalRoleSchema.safeParse(value);

--- a/packages/@n8n/permissions/src/index.ts
+++ b/packages/@n8n/permissions/src/index.ts
@@ -11,6 +11,8 @@ export {
 	teamRoleSchema,
 	roleSchema,
 	type Role,
+	systemProjectRoleSchema,
+	assignableProjectRoleSchema,
 	scopeSchema,
 } from './schemas.ee';
 

--- a/packages/@n8n/permissions/src/index.ts
+++ b/packages/@n8n/permissions/src/index.ts
@@ -7,12 +7,13 @@ export * from './roles/role-maps.ee';
 export * from './roles/all-roles';
 
 export {
+	systemProjectRoleSchema,
+	assignableProjectRoleSchema,
+	assignableGlobalRoleSchema,
 	projectRoleSchema,
 	teamRoleSchema,
 	roleSchema,
 	type Role,
-	systemProjectRoleSchema,
-	assignableProjectRoleSchema,
 	scopeSchema,
 } from './schemas.ee';
 

--- a/packages/@n8n/permissions/src/schemas.ee.ts
+++ b/packages/@n8n/permissions/src/schemas.ee.ts
@@ -7,8 +7,18 @@ export const roleNamespaceSchema = z.enum(['global', 'project', 'credential', 'w
 
 export const globalRoleSchema = z.enum(['global:owner', 'global:admin', 'global:member']);
 
-export const assignableGlobalRoleSchema = globalRoleSchema.exclude([
-	'global:owner', // Owner cannot be changed
+const customGlobalRoleSchema = z
+	.string()
+	.nonempty()
+	.refine((val) => !globalRoleSchema.safeParse(val).success, {
+		message: 'This global role value is not assignable',
+	});
+
+export const assignableGlobalRoleSchema = z.union([
+	globalRoleSchema.exclude([
+		'global:owner', // Owner cannot be changed
+	]),
+	customGlobalRoleSchema,
 ]);
 
 export const personalRoleSchema = z.enum([
@@ -23,7 +33,7 @@ export const customProjectRoleSchema = z
 	.string()
 	.nonempty()
 	.refine((val) => val !== PROJECT_OWNER_ROLE_SLUG && !teamRoleSchema.safeParse(val).success, {
-		message: 'This role value is not assignable',
+		message: 'This global role value is not assignable',
 	});
 
 // Those are all the system roles for projects

--- a/packages/@n8n/permissions/src/schemas.ee.ts
+++ b/packages/@n8n/permissions/src/schemas.ee.ts
@@ -15,13 +15,24 @@ export const personalRoleSchema = z.enum([
 	'project:personalOwner', // personalOwner is only used for personal projects
 ]);
 
+// Those are the system roles for projects assignable to a user
 export const teamRoleSchema = z.enum(['project:admin', 'project:editor', 'project:viewer']);
 
-export const customRoleSchema = z.string().refine((val) => val !== PROJECT_OWNER_ROLE_SLUG, {
-	message: `'${PROJECT_OWNER_ROLE_SLUG}' is not assignable`,
-});
+// Custom project role can be anything but the system roles
+export const customProjectRoleSchema = z
+	.string()
+	.nonempty()
+	.refine((val) => val !== PROJECT_OWNER_ROLE_SLUG && !teamRoleSchema.safeParse(val).success, {
+		message: 'This role value is not assignable',
+	});
 
-export const projectRoleSchema = z.union([personalRoleSchema, teamRoleSchema]);
+// Those are all the system roles for projects
+export const systemProjectRoleSchema = z.union([personalRoleSchema, teamRoleSchema]);
+
+// Those are the roles that can be assigned to a user for a project (all roles except personalOwner)
+export const assignableProjectRoleSchema = z.union([teamRoleSchema, customProjectRoleSchema]);
+
+export const projectRoleSchema = z.union([systemProjectRoleSchema, customProjectRoleSchema]);
 
 export const credentialSharingRoleSchema = z.enum(['credential:owner', 'credential:user']);
 

--- a/packages/@n8n/permissions/src/types.ee.ts
+++ b/packages/@n8n/permissions/src/types.ee.ts
@@ -5,11 +5,12 @@ import type {
 	assignableGlobalRoleSchema,
 	credentialSharingRoleSchema,
 	globalRoleSchema,
-	projectRoleSchema,
 	Role,
+	systemProjectRoleSchema,
 	roleNamespaceSchema,
 	teamRoleSchema,
 	workflowSharingRoleSchema,
+	assignableProjectRoleSchema,
 } from './schemas.ee';
 import { ALL_API_KEY_SCOPES } from './scope-information';
 
@@ -58,8 +59,8 @@ export type AssignableGlobalRole = z.infer<typeof assignableGlobalRoleSchema>;
 export type CredentialSharingRole = z.infer<typeof credentialSharingRoleSchema>;
 export type WorkflowSharingRole = z.infer<typeof workflowSharingRoleSchema>;
 export type TeamProjectRole = z.infer<typeof teamRoleSchema>;
-export type ProjectRole = z.infer<typeof projectRoleSchema>;
-export type CustomRole = string;
+export type ProjectRole = z.infer<typeof systemProjectRoleSchema>;
+export type AssignableProjectRole = z.infer<typeof assignableProjectRoleSchema>;
 
 /** Union of all possible role types in the system */
 export type AllRoleTypes = GlobalRole | ProjectRole | WorkflowSharingRole | CredentialSharingRole;

--- a/packages/cli/src/controllers/project.controller.ts
+++ b/packages/cli/src/controllers/project.controller.ts
@@ -64,7 +64,10 @@ export class ProjectController {
 				uiContext: payload.uiContext,
 			});
 
-			const relations = await this.projectsService.getProjectRelations(project.id);
+			const relation = await this.projectsService.getProjectRelationForUserAndProject(
+				req.user.id,
+				project.id,
+			);
 
 			return {
 				...project,
@@ -72,10 +75,7 @@ export class ProjectController {
 				scopes: [
 					...combineScopes({
 						global: getAuthPrincipalScopes(req.user),
-						project:
-							relations
-								.find((pr) => pr.userId === req.user.id)
-								?.role.scopes.map((scope) => scope.slug) || [],
+						project: relation?.role.scopes.map((scope) => scope.slug) ?? [],
 					}),
 				],
 			};
@@ -156,14 +156,14 @@ export class ProjectController {
 			throw new NotFoundError('Could not find a personal project for this user');
 		}
 
-		const relations = await this.projectsService.getProjectRelations(project.id);
+		const relation = await this.projectsService.getProjectRelationForUserAndProject(
+			req.user.id,
+			project.id,
+		);
 		const scopes: Scope[] = [
 			...combineScopes({
 				global: getAuthPrincipalScopes(req.user),
-				project:
-					relations
-						.find((pr) => pr.userId === req.user.id)
-						?.role.scopes.map((scope) => scope.slug) ?? [],
+				project: relation?.role.scopes.map((scope) => scope.slug) ?? [],
 			}),
 		];
 		return {
@@ -220,6 +220,8 @@ export class ProjectController {
 			await this.projectsService.updateProject(projectId, { name, icon, description });
 		}
 		if (relations) {
+			// TODO: validate that the project relations roles exist in db
+			// otherwise throws BadRequest
 			try {
 				const { project, newRelations } = await this.projectsService.syncProjectRelations(
 					projectId,

--- a/packages/cli/src/controllers/project.controller.ts
+++ b/packages/cli/src/controllers/project.controller.ts
@@ -220,8 +220,6 @@ export class ProjectController {
 			await this.projectsService.updateProject(projectId, { name, icon, description });
 		}
 		if (relations) {
-			// TODO: validate that the project relations roles exist in db
-			// otherwise throws BadRequest
 			try {
 				const { project, newRelations } = await this.projectsService.syncProjectRelations(
 					projectId,

--- a/packages/cli/src/public-api/v1/handlers/users/spec/paths/users.id.role.yml
+++ b/packages/cli/src/public-api/v1/handlers/users/spec/paths/users.id.role.yml
@@ -17,7 +17,7 @@ patch:
           properties:
             newRoleName:
               type: string
-              enum: [global:admin, global:member]
+              example: global:member
           required:
             - newRoleName
   responses:

--- a/packages/cli/src/public-api/v1/handlers/users/spec/paths/users.yml
+++ b/packages/cli/src/public-api/v1/handlers/users/spec/paths/users.yml
@@ -48,7 +48,7 @@ post:
                 format: email
               role:
                 type: string
-                enum: [global:admin, global:member]
+                example: global:member
             required:
               - email
   responses:

--- a/packages/cli/src/requests.ts
+++ b/packages/cli/src/requests.ts
@@ -10,7 +10,7 @@ import type {
 } from '@n8n/db';
 import type {
 	AssignableGlobalRole,
-	CustomRole,
+	AssignableProjectRole,
 	GlobalRole,
 	ProjectRole,
 	Scope,
@@ -275,7 +275,7 @@ export declare namespace ActiveWorkflowRequest {
 
 export declare namespace ProjectRequest {
 	type GetMyProjectsResponse = Array<
-		Project & { role: ProjectRole | GlobalRole | CustomRole; scopes?: Scope[] }
+		Project & { role: ProjectRole | AssignableProjectRole | GlobalRole; scopes?: Scope[] }
 	>;
 
 	type ProjectRelationResponse = {
@@ -283,7 +283,7 @@ export declare namespace ProjectRequest {
 		email: string;
 		firstName: string;
 		lastName: string;
-		role: ProjectRole | CustomRole;
+		role: ProjectRole | AssignableProjectRole;
 	};
 	type ProjectWithRelations = {
 		id: string;

--- a/packages/cli/src/services/role.service.ts
+++ b/packages/cli/src/services/role.service.ts
@@ -128,6 +128,25 @@ export class RoleService {
 		return this.dbRoleToRoleDTO(createdRole);
 	}
 
+	async checkRolesExist(
+		roleSlugs: string[],
+		roleType: 'global' | 'project' | 'workflow' | 'credential',
+	) {
+		const uniqueRoleSlugs = new Set(roleSlugs);
+		const roles = await this.roleRepository.findBySlugs(Array.from(uniqueRoleSlugs), roleType);
+
+		if (roles.length < uniqueRoleSlugs.size) {
+			const nonExistentRoles = Array.from(uniqueRoleSlugs).filter(
+				(slug) => !roles.find((role) => role.slug === slug),
+			);
+			throw new BadRequestError(
+				nonExistentRoles.length === 1
+					? `Role ${nonExistentRoles[0]} does not exist`
+					: `Roles ${nonExistentRoles.join(', ')} do not exist`,
+			);
+		}
+	}
+
 	addScopes(
 		rawWorkflow: ListQueryDb.Workflow.WithSharing | ListQueryDb.Workflow.WithOwnedByAndSharedWith,
 		user: User,

--- a/packages/cli/src/services/role.service.ts
+++ b/packages/cli/src/services/role.service.ts
@@ -1,3 +1,4 @@
+import { CreateRoleDto, UpdateRoleDto } from '@n8n/api-types';
 import {
 	CredentialsEntity,
 	SharedCredentials,
@@ -10,21 +11,24 @@ import {
 	Role,
 	Scope as DBScope,
 	ScopeRepository,
+	GLOBAL_ADMIN_ROLE,
 } from '@n8n/db';
 import { Service } from '@n8n/di';
-import type { CustomRole, ProjectRole, Scope, Role as RoleDTO } from '@n8n/permissions';
+import type { Scope, Role as RoleDTO, AssignableProjectRole } from '@n8n/permissions';
 import {
 	combineScopes,
 	getAuthPrincipalScopes,
 	getRoleScopes,
 	isBuiltInRole,
+	PROJECT_ADMIN_ROLE_SLUG,
+	PROJECT_EDITOR_ROLE_SLUG,
+	PROJECT_VIEWER_ROLE_SLUG,
 } from '@n8n/permissions';
 import { UnexpectedError, UserError } from 'n8n-workflow';
 
-import { License } from '@/license';
-import { CreateRoleDto, UpdateRoleDto } from '@n8n/api-types';
-import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { License } from '@/license';
 
 @Service()
 export class RoleService {
@@ -209,7 +213,7 @@ export class RoleService {
 		return [...scopesSet].sort();
 	}
 
-	isRoleLicensed(role: ProjectRole | CustomRole) {
+	isRoleLicensed(role: AssignableProjectRole) {
 		// TODO: move this info into FrontendSettings
 
 		if (!isBuiltInRole(role)) {
@@ -220,13 +224,13 @@ export class RoleService {
 		}
 
 		switch (role) {
-			case 'project:admin':
+			case PROJECT_ADMIN_ROLE_SLUG:
 				return this.license.isProjectRoleAdminLicensed();
-			case 'project:editor':
+			case PROJECT_EDITOR_ROLE_SLUG:
 				return this.license.isProjectRoleEditorLicensed();
-			case 'project:viewer':
+			case PROJECT_VIEWER_ROLE_SLUG:
 				return this.license.isProjectRoleViewerLicensed();
-			case 'global:admin':
+			case GLOBAL_ADMIN_ROLE.slug:
 				return this.license.isAdvancedPermissionsLicensed();
 			default:
 				// TODO: handle custom roles licensing

--- a/packages/cli/src/services/user.service.ts
+++ b/packages/cli/src/services/user.service.ts
@@ -210,6 +210,8 @@ export class UserService {
 				: 'Creating 1 user shell...',
 		);
 
+		// TODO: check that roles exists in db
+
 		try {
 			await this.getManager().transaction(
 				async (transactionManager) =>
@@ -246,6 +248,8 @@ export class UserService {
 	}
 
 	async changeUserRole(user: User, targetUser: User, newRole: RoleChangeRequestDto) {
+		// TODO: check that new role  exists in db
+
 		return await this.userRepository.manager.transaction(async (trx) => {
 			await trx.update(User, { id: targetUser.id }, { role: { slug: newRole.newRoleName } });
 

--- a/packages/cli/src/user-management/email/__tests__/user-management-mailer.test.ts
+++ b/packages/cli/src/user-management/email/__tests__/user-management-mailer.test.ts
@@ -1,6 +1,7 @@
 import { mockInstance } from '@n8n/backend-test-utils';
 import type { GlobalConfig } from '@n8n/config';
-import type { ProjectRole, User, UserRepository } from '@n8n/db';
+import type { User, UserRepository } from '@n8n/db';
+import { PROJECT_EDITOR_ROLE_SLUG, PROJECT_VIEWER_ROLE_SLUG } from '@n8n/permissions';
 import { mock } from 'jest-mock-extended';
 import type { IWorkflowBase } from 'n8n-workflow';
 
@@ -157,8 +158,8 @@ describe('UserManagementMailer', () => {
 		it('should send project share notifications', async () => {
 			const sharer = mock<User>({ firstName: 'Sharer', email: 'sharer@user.com' });
 			const newSharees = [
-				{ userId: 'recipient1', role: 'project:editor' as ProjectRole },
-				{ userId: 'recipient2', role: 'project:viewer' as ProjectRole },
+				{ userId: 'recipient1', role: PROJECT_EDITOR_ROLE_SLUG },
+				{ userId: 'recipient2', role: PROJECT_VIEWER_ROLE_SLUG },
 			];
 			const project = { id: 'project1', name: 'Test Project' };
 			userRepository.getEmailsByIds.mockResolvedValue([

--- a/packages/cli/src/user-management/email/user-management-mailer.ts
+++ b/packages/cli/src/user-management/email/user-management-mailer.ts
@@ -1,22 +1,23 @@
 import { inTest, Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
-import type { ProjectRole, User } from '@n8n/db';
+import type { User } from '@n8n/db';
 import { UserRepository } from '@n8n/db';
 import { Container, Service } from '@n8n/di';
+import { AssignableProjectRole } from '@n8n/permissions';
 import { existsSync } from 'fs';
 import { readFile } from 'fs/promises';
 import Handlebars from 'handlebars';
 import type { IWorkflowBase } from 'n8n-workflow';
 import { join as pathJoin } from 'path';
 
+import type { InviteEmailData, PasswordResetData, SendEmailResult } from './interfaces';
+import { NodeMailer } from './node-mailer';
+
 import { InternalServerError } from '@/errors/response-errors/internal-server.error';
 import { EventService } from '@/events/event.service';
 import type { RelayEventMap } from '@/events/maps/relay.event-map';
 import { UrlService } from '@/services/url.service';
 import { toError } from '@/utils';
-
-import type { InviteEmailData, PasswordResetData, SendEmailResult } from './interfaces';
-import { NodeMailer } from './node-mailer';
 
 type Template = HandlebarsTemplateDelegate<unknown>;
 type TemplateName =
@@ -193,7 +194,7 @@ export class UserManagementMailer {
 		project,
 	}: {
 		sharer: User;
-		newSharees: Array<{ userId: string; role: ProjectRole }>;
+		newSharees: Array<{ userId: string; role: AssignableProjectRole }>;
 		project: { id: string; name: string };
 	}): Promise<SendEmailResult> {
 		const recipients = await this.userRepository.getEmailsByIds(newSharees.map((s) => s.userId));

--- a/packages/cli/test/integration/folder/folder.controller.test.ts
+++ b/packages/cli/test/integration/folder/folder.controller.test.ts
@@ -9,13 +9,11 @@ import {
 	testDb,
 	mockInstance,
 } from '@n8n/backend-test-utils';
-import type { Project, ProjectRole, User } from '@n8n/db';
+import type { Project, User } from '@n8n/db';
 import { FolderRepository, ProjectRepository, WorkflowRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
-import { DateTime } from 'luxon';
-import { ApplicationError, PROJECT_ROOT } from 'n8n-workflow';
-
-import { ActiveWorkflowManager } from '@/active-workflow-manager';
+import type { ProjectRole } from '@n8n/permissions';
+import { PROJECT_EDITOR_ROLE_SLUG, PROJECT_VIEWER_ROLE_SLUG } from '@n8n/permissions';
 import {
 	createCredentials,
 	getCredentialSharings,
@@ -25,10 +23,14 @@ import {
 } from '@test-integration/db/credentials';
 import { createFolder } from '@test-integration/db/folders';
 import { createTag } from '@test-integration/db/tags';
+import { DateTime } from 'luxon';
+import { ApplicationError, PROJECT_ROOT } from 'n8n-workflow';
 
 import { createOwner, createMember, createUser, createAdmin } from '../shared/db/users';
 import type { SuperAgentTest } from '../shared/types';
 import * as utils from '../shared/utils/';
+
+import { ActiveWorkflowManager } from '@/active-workflow-manager';
 
 let owner: User;
 let member: User;
@@ -1863,7 +1865,7 @@ describe('PUT /projects/:projectId/folders/:folderId/transfer', () => {
 			.expect(404);
 	});
 
-	test.each<ProjectRole>(['project:editor', 'project:viewer'])(
+	test.each<ProjectRole>([PROJECT_EDITOR_ROLE_SLUG, PROJECT_VIEWER_ROLE_SLUG])(
 		'%ss cannot transfer workflows',
 		async (projectRole) => {
 			//

--- a/packages/cli/test/integration/public-api/projects.test.ts
+++ b/packages/cli/test/integration/public-api/projects.test.ts
@@ -483,8 +483,8 @@ describe('Projects in Public API', () => {
 					relations: [
 						{
 							userId: member.id,
-							// role does not exist
-							role: 'project:boss',
+							// field does not exist
+							invalidField: 'invalidValue',
 						},
 					],
 				};
@@ -499,8 +499,31 @@ describe('Projects in Public API', () => {
 				// ASSERT
 				expect(response.body).toHaveProperty(
 					'message',
-					"Invalid enum value. Expected 'project:admin' | 'project:editor' | 'project:viewer', received 'project:boss'",
+					"request/body/relations/0 must have required property 'role'",
 				);
+			});
+
+			it('should reject if the relations have a role that do not exist', async () => {
+				const owner = await createOwnerWithApiKey();
+				const member = await createMember();
+				const project = await createTeamProject('shared-project', owner);
+
+				const payload = {
+					relations: [
+						{
+							userId: member.id,
+							role: 'project:invalid-role',
+						},
+					],
+				};
+
+				await testServer
+					.publicApiAgentFor(owner)
+					.post(`/projects/${project.id}/users`)
+					.send(payload)
+					.expect(400);
+
+				// TODO: add message check once we properly validate role from database
 			});
 
 			it('should reject with 404 if no project found', async () => {
@@ -654,23 +677,23 @@ describe('Projects in Public API', () => {
 				testServer.license.enable('feat:projectRole:admin');
 			});
 
-			it("should reject with 400 if the payload can't be validated", async () => {
+			it('should reject with 400 if the role do not exist', async () => {
 				// ARRANGE
 				const owner = await createOwnerWithApiKey();
+				const member = await createMember();
+				const project = await createTeamProject('shared-project', owner);
+				await linkUserToProject(member, project, 'project:viewer');
 
 				// ACT
-				const response = await testServer
+				await testServer
 					.publicApiAgentFor(owner)
-					.patch('/projects/1234/users/1235')
+					.patch(`/projects/${project.id}/users/${member.id}`)
 					// role does not exist
 					.send({ role: 'project:boss' })
 					.expect(400);
 
 				// ASSERT
-				expect(response.body).toHaveProperty(
-					'message',
-					"Invalid enum value. Expected 'project:admin' | 'project:editor' | 'project:viewer', received 'project:boss'",
-				);
+				// TODO: add message check once we properly validate that the role exists
 			});
 
 			it("should change a user's role in a project", async () => {

--- a/packages/cli/test/integration/public-api/users.test.ts
+++ b/packages/cli/test/integration/public-api/users.test.ts
@@ -9,6 +9,7 @@ import {
 	getUserById,
 } from '@test-integration/db/users';
 import { setupTestServer } from '@test-integration/utils';
+import { createRole } from '@test-integration/db/roles';
 
 describe('Users in Public API', () => {
 	const testServer = setupTestServer({ endpointGroups: ['publicApi'] });
@@ -61,13 +62,32 @@ describe('Users in Public API', () => {
 			expect(response.body).toHaveProperty('message', 'Forbidden');
 		});
 
+		it('should fail if role does not exist', async () => {
+			/**
+			 * Arrange
+			 */
+			testServer.license.enable('feat:advancedPermissions');
+			const owner = await createOwnerWithApiKey();
+			const payload = [{ email: 'test@test.com', role: 'non-existing-role' }];
+
+			/**
+			 * Act
+			 */
+			const response = await testServer.publicApiAgentFor(owner).post('/users').send(payload);
+
+			/**
+			 * Assert
+			 */
+			expect(response.status).toBe(400);
+			expect(response.body).toHaveProperty('message', 'Role non-existing-role does not exist');
+		});
+
 		it('should create a user', async () => {
 			/**
 			 * Arrange
 			 */
 			testServer.license.enable('feat:advancedPermissions');
 			const owner = await createOwnerWithApiKey();
-			await createOwnerWithApiKey();
 			const payload = [{ email: 'test@test.com', role: 'global:admin' }];
 
 			/**
@@ -96,6 +116,27 @@ describe('Users in Public API', () => {
 			expect(returnedUser.email).toBe(storedUser.email);
 			expect(returnedUser.email).toBe(payloadUser.email);
 			expect(storedUser.role.slug).toBe(payloadUser.role);
+		});
+
+		it('should create a user with an existing custom role', async () => {
+			/**
+			 * Arrange
+			 */
+			testServer.license.enable('feat:advancedPermissions');
+			const owner = await createOwnerWithApiKey();
+			const customRole = 'custom:role';
+			await createRole({ slug: customRole, displayName: 'Custom role', roleType: 'global' });
+			const payload = [{ email: 'test@test.com', role: customRole }];
+
+			/**
+			 * Act
+			 */
+			const response = await testServer.publicApiAgentFor(owner).post('/users').send(payload);
+
+			/**
+			 * Assert
+			 */
+			expect(response.status).toBe(201);
 		});
 	});
 
@@ -261,6 +302,33 @@ describe('Users in Public API', () => {
 			const owner = await createOwnerWithApiKey();
 			const member = await createMember();
 			const payload = { newRoleName: 'global:admin' };
+
+			/**
+			 * Act
+			 */
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.patch(`/users/${member.id}/role`)
+				.send(payload);
+
+			/**
+			 * Assert
+			 */
+			expect(response.status).toBe(204);
+			const storedUser = await getUserById(member.id);
+			expect(storedUser.role.slug).toBe(payload.newRoleName);
+		});
+
+		it('should change a user role to an existing custom role', async () => {
+			/**
+			 * Arrange
+			 */
+			testServer.license.enable('feat:advancedPermissions');
+			const owner = await createOwnerWithApiKey();
+			const member = await createMember();
+			const customRole = 'custom:role';
+			await createRole({ slug: customRole, displayName: 'Custom role', roleType: 'global' });
+			const payload = { newRoleName: customRole };
 
 			/**
 			 * Act


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR allows custom roles to be set when adding a user to a project. 
It creates new types from the permission package, changes the DTO accordingly.
Some validation still remains to be done once the role service will be implemented, in order to check if a role selected exists in the database, and provide clearer error messaging if not.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-3644/allow-custom-roles-on-existing-types-and-apis

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
