### PR TITLE
feat(ai-agent): optional token usage aggregation (tokenUsage) for Agent and Agent Tool

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/V2/AgentToolV2.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/V2/AgentToolV2.node.ts
@@ -80,6 +80,16 @@ export class AgentToolV2 implements INodeType {
 				},
 				...getToolsAgentProperties({ withStreaming: false }),
 			],
+			hints: [
+				{
+					message:
+						'Collect Token Usage is enabled. This execution returns a tokenUsage array with per-model totals (actual vs estimated).',
+					type: 'info',
+					location: 'outputPane',
+					whenToDisplay: 'afterExecution',
+					displayCondition: '={{ $parameter["options"]["collectTokenUsage"] === true }}',
+				},
+			],
 		};
 	}
 

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/V2/AgentV2.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/V2/AgentV2.node.ts
@@ -123,6 +123,14 @@ export class AgentV2 implements INodeType {
 					whenToDisplay: 'afterExecution',
 					displayCondition: '={{ $parameter["enableStreaming"] === true }}',
 				},
+				{
+					message:
+						'Collect Token Usage is enabled. This execution returns a tokenUsage array with per-model totals (actual vs estimated).',
+					type: 'info',
+					location: 'outputPane',
+					whenToDisplay: 'afterExecution',
+					displayCondition: '={{ $parameter["options"]["collectTokenUsage"] === true }}',
+				},
 			],
 		};
 	}

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V1/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V1/execute.ts
@@ -13,6 +13,7 @@ import { getModelNameForTiktoken } from '@langchain/core/language_models/base';
 import { estimateTokensFromStringList } from '@utils/tokenizer/token-estimator';
 import { jsonParse, NodeOperationError } from 'n8n-workflow';
 import type { IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
+import type { AgentTokenUsageRecord } from '../common';
 import type { TiktokenModel } from 'js-tiktoken';
 
 import { getPromptInputByType } from '@utils/helpers';
@@ -190,9 +191,9 @@ export async function toolsAgentExecute(this: IExecuteFunctions): Promise<INodeE
 				async handleLLMEnd(output: LLMResult, runId: string): Promise<void> {
 					try {
 						const key = this.runToModelKey[runId] ?? 'unknown:unknown';
-						const sep = key.indexOf(':');
-						const modelType = sep === -1 ? key : key.slice(0, sep);
-						const modelName = sep === -1 ? '' : key.slice(sep + 1);
+						const separatorIndex = key.indexOf(':');
+						const modelType = separatorIndex === -1 ? key : key.slice(0, separatorIndex);
+						const modelName = separatorIndex === -1 ? '' : key.slice(separatorIndex + 1);
 						let completionTokens = 0;
 						let promptTokens = 0;
 						const llmOutput = output?.llmOutput;
@@ -311,7 +312,7 @@ export async function toolsAgentExecute(this: IExecuteFunctions): Promise<INodeE
 					...(usageCollector ? { callbacks: [usageCollector] } : {}),
 				},
 			);
-			const usageRecords = usageCollector?.getUsageRecords();
+			const usageRecords: AgentTokenUsageRecord[] | undefined = usageCollector?.getUsageRecords();
 
 			// If memory and outputParser are connected, parse the output.
 			if (memory && outputParser) {

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V1/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V1/execute.ts
@@ -164,7 +164,9 @@ export async function toolsAgentExecute(this: IExecuteFunctions): Promise<INodeE
 				async handleLLMEnd(output: LLMResult, runId: string): Promise<void> {
 					try {
 						const key = this.runToModelKey[runId] ?? 'unknown:unknown';
-						const [modelType, modelName] = key.split(':');
+						const sep = key.indexOf(':');
+						const modelType = sep === -1 ? key : key.slice(0, sep);
+						const modelName = sep === -1 ? '' : key.slice(sep + 1);
 						const completionTokens = (output?.llmOutput as any)?.tokenUsage?.completionTokens ?? 0;
 						const promptTokens = (output?.llmOutput as any)?.tokenUsage?.promptTokens ?? 0;
 						if (completionTokens > 0 || promptTokens > 0) {

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V1/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V1/execute.ts
@@ -1,4 +1,4 @@
-// BaseLanguageModel import removed – not used after refactor
+import type { BaseLanguageModel } from '@langchain/core/language_models/base';
 import { RunnableSequence } from '@langchain/core/runnables';
 import { AgentExecutor, createToolCallingAgent } from 'langchain/agents';
 import omit from 'lodash/omit';
@@ -13,7 +13,6 @@ import { getModelNameForTiktoken } from '@langchain/core/language_models/base';
 import { estimateTokensFromStringList } from '@utils/tokenizer/token-estimator';
 import { jsonParse, NodeOperationError } from 'n8n-workflow';
 import type { IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
-import assert from 'node:assert';
 import type { TiktokenModel } from 'js-tiktoken';
 
 import { getPromptInputByType } from '@utils/helpers';
@@ -52,8 +51,7 @@ export async function toolsAgentExecute(this: IExecuteFunctions): Promise<INodeE
 
 	for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
 		try {
-			const model = await getChatModel(this);
-			assert(model, 'Please connect a model to the Chat Model input');
+			const model = (await getChatModel(this)) as BaseLanguageModel;
 			const memory = await getOptionalMemory(this);
 
 			// Token usage collector (per item)

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V1/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V1/execute.ts
@@ -261,7 +261,6 @@ export async function toolsAgentExecute(this: IExecuteFunctions): Promise<INodeE
 				},
 			);
 			if (usageCollector) {
-				response.__tokenUsageByModel = usageCollector.usageByModel;
 				response.__tokenUsageRecords = usageCollector.getUsageRecords();
 			}
 
@@ -287,7 +286,6 @@ export async function toolsAgentExecute(this: IExecuteFunctions): Promise<INodeE
 				),
 			};
 
-			const usageMap = response?.__tokenUsageByModel as Record<string, any> | undefined;
 			const usageRecords = response?.__tokenUsageRecords as
 				| Array<{
 						modelType: string;
@@ -298,9 +296,6 @@ export async function toolsAgentExecute(this: IExecuteFunctions): Promise<INodeE
 						isEstimate: boolean;
 				  }>
 				| undefined;
-			if (usageMap && Object.keys(usageMap).length > 0) {
-				(itemResult.json as any).tokenUsageByModel = usageMap;
-			}
 			if (usageRecords && usageRecords.length > 0) {
 				(itemResult.json as any).tokenUsageRecords = usageRecords;
 			}

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V1/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V1/execute.ts
@@ -261,7 +261,7 @@ export async function toolsAgentExecute(this: IExecuteFunctions): Promise<INodeE
 				},
 			);
 			if (usageCollector) {
-				response.__tokenUsageRecords = usageCollector.getUsageRecords();
+				response.__tokenUsage = usageCollector.getUsageRecords();
 			}
 
 			// If memory and outputParser are connected, parse the output.
@@ -282,11 +282,11 @@ export async function toolsAgentExecute(this: IExecuteFunctions): Promise<INodeE
 					'chat_history',
 					'agent_scratchpad',
 					'__tokenUsageByModel',
-					'__tokenUsageRecords',
+					'__tokenUsage',
 				),
 			};
 
-			const usageRecords = response?.__tokenUsageRecords as
+			const usageRecords = response?.__tokenUsage as
 				| Array<{
 						modelType: string;
 						modelName: string;
@@ -297,7 +297,7 @@ export async function toolsAgentExecute(this: IExecuteFunctions): Promise<INodeE
 				  }>
 				| undefined;
 			if (usageRecords && usageRecords.length > 0) {
-				(itemResult.json as any).tokenUsageRecords = usageRecords;
+				(itemResult.json as any).tokenUsage = usageRecords;
 			}
 
 			returnData.push(itemResult);

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V1/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V1/execute.ts
@@ -2,6 +2,15 @@ import type { BaseLanguageModel } from '@langchain/core/language_models/base';
 import { RunnableSequence } from '@langchain/core/runnables';
 import { AgentExecutor, createToolCallingAgent } from 'langchain/agents';
 import omit from 'lodash/omit';
+import { BaseCallbackHandler } from '@langchain/core/callbacks/base';
+import type {
+	Serialized,
+	SerializedNotImplemented,
+	SerializedSecret,
+} from '@langchain/core/load/serializable';
+import type { LLMResult } from '@langchain/core/outputs';
+import { getModelNameForTiktoken } from '@langchain/core/language_models/base';
+import { estimateTokensFromStringList } from '@utils/tokenizer/token-estimator';
 import { jsonParse, NodeOperationError } from 'n8n-workflow';
 import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 
@@ -43,6 +52,113 @@ export async function toolsAgentExecute(this: IExecuteFunctions): Promise<INodeE
 		try {
 			const model = (await getChatModel(this)) as BaseLanguageModel;
 			const memory = await getOptionalMemory(this);
+
+			// Token usage collector (per item)
+			class AgentTokenUsageCollector extends BaseCallbackHandler {
+				name = 'AgentTokenUsageCollector';
+
+				usageByModel: Record<
+					string,
+					{
+						modelType: string;
+						modelName: string;
+						promptTokens: number;
+						completionTokens: number;
+						totalTokens: number;
+						isEstimate: boolean;
+					}
+				> = {};
+
+				private runToModelKey: Record<string, string> = {};
+				private promptEstimateByRun: Record<string, number> = {};
+
+				constructor(private readonly tiktokenModel: string = getModelNameForTiktoken('gpt-4o')) {
+					super();
+				}
+
+				async handleLLMStart(
+					llm: Serialized | SerializedSecret | SerializedNotImplemented,
+					prompts: string[],
+					runId: string,
+				): Promise<void> {
+					try {
+						const llmAny = llm as any;
+						const modelName = llmAny?.kwargs?.model ?? llmAny?.kwargs?.modelName ?? 'unknown';
+						const modelType = llmAny?.id?.[0] ?? llmAny?.lc_namespace?.[0] ?? 'unknown';
+						const key = `${modelType}:${modelName}`;
+						this.runToModelKey[runId] = key;
+						const estimatedPrompt = await estimateTokensFromStringList(
+							Array.isArray(prompts) ? prompts : [],
+							this.tiktokenModel as any,
+						);
+						this.promptEstimateByRun[runId] = estimatedPrompt;
+					} catch {}
+				}
+
+				private addUsage(
+					modelKey: string,
+					modelType: string,
+					modelName: string,
+					promptTokens: number,
+					completionTokens: number,
+					isEstimate: boolean,
+				) {
+					const total = (promptTokens || 0) + (completionTokens || 0);
+					if (!this.usageByModel[modelKey]) {
+						this.usageByModel[modelKey] = {
+							modelType,
+							modelName,
+							promptTokens: 0,
+							completionTokens: 0,
+							totalTokens: 0,
+							isEstimate,
+						};
+					}
+					const agg = this.usageByModel[modelKey];
+					agg.promptTokens += promptTokens || 0;
+					agg.completionTokens += completionTokens || 0;
+					agg.totalTokens += total;
+					if (!isEstimate) agg.isEstimate = false;
+				}
+
+				async handleLLMEnd(output: LLMResult, runId: string): Promise<void> {
+					try {
+						const key = this.runToModelKey[runId] ?? 'unknown:unknown';
+						const [modelType, modelName] = key.split(':');
+						const completionTokens = (output?.llmOutput as any)?.tokenUsage?.completionTokens ?? 0;
+						const promptTokens = (output?.llmOutput as any)?.tokenUsage?.promptTokens ?? 0;
+						if (completionTokens > 0 || promptTokens > 0) {
+							this.addUsage(
+								key,
+								modelType,
+								modelName,
+								promptTokens || 0,
+								completionTokens || 0,
+								false,
+							);
+							return;
+						}
+						const generationsTexts =
+							output?.generations?.flatMap((gen) => gen.map((g) => (g as any).text ?? '')) ?? [];
+						const estimatedCompletion = await estimateTokensFromStringList(
+							generationsTexts,
+							this.tiktokenModel as any,
+						);
+						const estimatedPrompt = this.promptEstimateByRun[runId] ?? 0;
+						this.addUsage(key, modelType, modelName, estimatedPrompt, estimatedCompletion, true);
+					} catch {
+					} finally {
+						delete this.runToModelKey[runId];
+						delete this.promptEstimateByRun[runId];
+					}
+				}
+			}
+
+			const optionsAll = this.getNodeParameter('options', itemIndex, {}) as {
+				collectTokenUsage?: boolean;
+			};
+			const collectTokenUsage = optionsAll.collectTokenUsage === true;
+			const usageCollector = collectTokenUsage ? new AgentTokenUsageCollector() : undefined;
 
 			const input = getPromptInputByType({
 				ctx: this,
@@ -92,15 +208,19 @@ export async function toolsAgentExecute(this: IExecuteFunctions): Promise<INodeE
 			});
 
 			// Invoke the executor with the given input and system message.
-			const response = await executor.invoke(
+			const response: any = await executor.invoke(
 				{
 					input,
 					system_message: options.systemMessage ?? SYSTEM_MESSAGE,
 					formatting_instructions:
 						'IMPORTANT: For your response to user, you MUST use the `format_final_json_response` tool with your complete answer formatted according to the required schema. Do not attempt to format the JSON manually - always use this tool. Your response will be rejected if it is not properly formatted through this tool. Only use this tool once you are ready to provide your final answer.',
 				},
-				{ signal: this.getExecutionCancelSignal() },
+				{
+					signal: this.getExecutionCancelSignal(),
+					...(usageCollector ? { callbacks: [usageCollector] } : {}),
+				},
 			);
+			if (usageCollector) response.__tokenUsageByModel = usageCollector.usageByModel;
 
 			// If memory and outputParser are connected, parse the output.
 			if (memory && outputParser) {
@@ -121,6 +241,11 @@ export async function toolsAgentExecute(this: IExecuteFunctions): Promise<INodeE
 					'agent_scratchpad',
 				),
 			};
+
+			const usageMap = response?.__tokenUsageByModel as Record<string, any> | undefined;
+			if (usageMap && Object.keys(usageMap).length > 0) {
+				(itemResult.json as any).tokenUsageByModel = usageMap;
+			}
 
 			returnData.push(itemResult);
 		} catch (error) {

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V1/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V1/execute.ts
@@ -239,6 +239,7 @@ export async function toolsAgentExecute(this: IExecuteFunctions): Promise<INodeE
 					'input',
 					'chat_history',
 					'agent_scratchpad',
+					'__tokenUsageByModel',
 				),
 			};
 

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
@@ -464,14 +464,12 @@ export async function toolsAgentExecute(
 				// attach usage for later aggregation
 				return {
 					...streamResult,
-					__tokenUsageByModel: usageCollector?.usageByModel,
 					__tokenUsageRecords: usageCollector?.getUsageRecords(),
 				} as any;
 			} else {
 				// Handle regular execution
 				const res: any = await executor.invoke(invokeParams, executeOptions);
 				if (usageCollector) {
-					res.__tokenUsageByModel = usageCollector.usageByModel;
 					res.__tokenUsageRecords = usageCollector.getUsageRecords();
 				}
 				return res;
@@ -520,12 +518,8 @@ export async function toolsAgentExecute(
 				pairedItem: { item: itemIndex },
 			};
 
-			// Attach aggregated token usage by model to the result
-			const usageMap = (response as any)?.__tokenUsageByModel as Record<string, any> | undefined;
+			// Attach token usage records (estimate vs actual per model)
 			const usageRecords = (response as any)?.__tokenUsageRecords as ModelUsage[] | undefined;
-			if (usageMap && Object.keys(usageMap).length > 0) {
-				(itemResult.json as any).tokenUsageByModel = usageMap;
-			}
 			if (usageRecords && usageRecords.length > 0) {
 				(itemResult.json as any).tokenUsageRecords = usageRecords;
 			}

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
@@ -464,13 +464,13 @@ export async function toolsAgentExecute(
 				// attach usage for later aggregation
 				return {
 					...streamResult,
-					__tokenUsageRecords: usageCollector?.getUsageRecords(),
+					__tokenUsage: usageCollector?.getUsageRecords(),
 				} as any;
 			} else {
 				// Handle regular execution
 				const res: any = await executor.invoke(invokeParams, executeOptions);
 				if (usageCollector) {
-					res.__tokenUsageRecords = usageCollector.getUsageRecords();
+					res.__tokenUsage = usageCollector.getUsageRecords();
 				}
 				return res;
 			}
@@ -513,15 +513,15 @@ export async function toolsAgentExecute(
 					'chat_history',
 					'agent_scratchpad',
 					'__tokenUsageByModel',
-					'__tokenUsageRecords',
+					'__tokenUsage',
 				),
 				pairedItem: { item: itemIndex },
 			};
 
 			// Attach token usage records (estimate vs actual per model)
-			const usageRecords = (response as any)?.__tokenUsageRecords as ModelUsage[] | undefined;
+			const usageRecords = (response as any)?.__tokenUsage as ModelUsage[] | undefined;
 			if (usageRecords && usageRecords.length > 0) {
-				(itemResult.json as any).tokenUsageRecords = usageRecords;
+				(itemResult.json as any).tokenUsage = usageRecords;
 			}
 
 			returnData.push(itemResult);

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
@@ -486,6 +486,7 @@ export async function toolsAgentExecute(
 					'input',
 					'chat_history',
 					'agent_scratchpad',
+					'__tokenUsageByModel',
 				),
 				pairedItem: { item: itemIndex },
 			};

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/common.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/common.ts
@@ -13,6 +13,18 @@ import { z } from 'zod';
 
 import { isChatInstance, getConnectedTools } from '@utils/helpers';
 import { type N8nOutputParser } from '@utils/output_parsers/N8nOutputParser';
+
+/* -----------------------------------------------------------
+   Shared Types
+----------------------------------------------------------- */
+export interface AgentTokenUsageRecord {
+	modelType: string;
+	modelName: string;
+	promptTokens: number;
+	completionTokens: number;
+	totalTokens: number;
+	isEstimate: boolean;
+}
 /* -----------------------------------------------------------
    Output Parser Helper
 ----------------------------------------------------------- */

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/options.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/options.ts
@@ -33,7 +33,7 @@ export const commonOptions: INodeProperties[] = [
 		type: 'boolean',
 		default: false,
 		description:
-			'When enabled, adds a tokenUsage array to the output with per-model token counts, split into actual vs estimated totals across the node execution.',
+			'Whether to add a tokenUsage array to the output with per-model token counts, split into actual vs estimated totals across the node execution',
 	},
 	{
 		displayName: 'Automatically Passthrough Binary Images',

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/options.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/options.ts
@@ -33,7 +33,7 @@ export const commonOptions: INodeProperties[] = [
 		type: 'boolean',
 		default: false,
 		description:
-			'Aggregate and return per-model token usage for this node execution. Disabled by default.',
+			'When enabled, adds a tokenUsage array to the output with per-model token counts, split into actual vs estimated totals across the node execution.',
 	},
 	{
 		displayName: 'Automatically Passthrough Binary Images',

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/options.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/options.ts
@@ -28,6 +28,14 @@ export const commonOptions: INodeProperties[] = [
 		description: 'Whether or not the output should include intermediate steps the agent took',
 	},
 	{
+		displayName: 'Collect Token Usage',
+		name: 'collectTokenUsage',
+		type: 'boolean',
+		default: false,
+		description:
+			'Aggregate and return per-model token usage for this node execution. Disabled by default.',
+	},
+	{
 		displayName: 'Automatically Passthrough Binary Images',
 		name: 'passthroughBinaryImages',
 		type: 'boolean',

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/ToolsAgentV2.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/ToolsAgentV2.test.ts
@@ -784,9 +784,9 @@ describe('toolsAgentExecute', () => {
 			});
 
 			const mockExecutor = {
-				invoke: jest.fn().mockImplementation((_params, options) => {
+				invoke: jest.fn().mockImplementation(async (_params, options) => {
 					capturedCallbacks = options?.callbacks || [];
-					return Promise.resolve({ output: 'Test response' });
+					return { output: 'Test response' };
 				}),
 			};
 


### PR DESCRIPTION
Summary
- Adds an optional "Collect Token Usage" setting to AI Agent and Agent Tool nodes. When enabled, node outputs include a `tokenUsage` array with per‑model token counters, split into actual vs estimated totals across the node execution (including streaming and fallback flows). Disabled by default.

Details
- Per‑model grouping: Each record includes `modelType`, `modelName`, `promptTokens`, `completionTokens`, `totalTokens`, and `isEstimate` (true when estimated).
- Multiple passes & fallback: Aggregates across all LLM passes within a single node execution and keeps separate records per model (and estimate kind), including fallback models.
- Streaming & non‑streaming: Works in both code paths; for streaming, counts are captured via LangChain event callbacks.
- Output field: `json.tokenUsage` (array). Internal fields are omitted from the final output.
- UI hint: After execution, an informational hint appears in the output pane when the option is enabled, in both Agent and Agent Tool V2 nodes.
- Backward compatibility: Off by default; no changes to existing outputs unless enabled.

Files
- option + docs
  - packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/options.ts
- AI Agent V2 logic + streaming
  - packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
  - packages/@n8n/nodes-langchain/nodes/agents/Agent/V2/AgentV2.node.ts (UI hint)
- Agent Tool V2
  - packages/@n8n/nodes-langchain/nodes/agents/Agent/V2/AgentToolV2.node.ts (UI hint)
- AI Agent V1 logic
  - packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V1/execute.ts
