### PR TITLE
feat(editor): Display created and updated at data table columns (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/ColumnHeader.test.ts
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/ColumnHeader.test.ts
@@ -38,6 +38,7 @@ const renderComponent = createComponentRenderer(ColumnHeader, {
 			displayName: 'My Column',
 			column: { getColId: () => 'col-1', getColDef: () => ({ cellDataType: 'string' }) },
 			onDelete: onDeleteMock,
+			allowMenuActions: true,
 		},
 	},
 });

--- a/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/ColumnHeader.vue
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/ColumnHeader.vue
@@ -7,6 +7,7 @@ import { isAGGridCellType } from '@/features/dataStore/typeGuards';
 
 type HeaderParamsWithDelete = IHeaderParams & {
 	onDelete: (columnId: string) => void;
+	allowMenuActions: boolean;
 };
 
 const props = defineProps<{
@@ -42,7 +43,7 @@ const onDropdownVisibleChange = (visible: boolean) => {
 };
 
 const isDropdownVisible = computed(() => {
-	return isHovered.value || isDropdownOpen.value;
+	return props.params.allowMenuActions && (isHovered.value || isDropdownOpen.value);
 });
 
 const typeIcon = computed(() => {

--- a/packages/frontend/editor-ui/src/features/dataStore/dataStore.api.ts
+++ b/packages/frontend/editor-ui/src/features/dataStore/dataStore.api.ts
@@ -151,11 +151,12 @@ export const insertDataStoreRowApi = async (
 	row: DataStoreRow,
 	projectId: string,
 ) => {
-	return await makeRestApiRequest<Array<{ id: number }>>(
+	return await makeRestApiRequest<DataStoreRow[]>(
 		context,
 		'POST',
 		`/projects/${projectId}/data-tables/${dataStoreId}/insert`,
 		{
+			returnData: true,
 			data: [row],
 		},
 	);

--- a/packages/frontend/editor-ui/src/features/dataStore/dataStore.store.ts
+++ b/packages/frontend/editor-ui/src/features/dataStore/dataStore.store.ts
@@ -177,17 +177,13 @@ export const useDataStoreStore = defineStore(DATA_STORE_STORE, () => {
 	};
 
 	const insertEmptyRow = async (dataStore: DataStore) => {
-		const emptyRow: DataStoreRow = {};
-		dataStore.columns.forEach((column) => {
-			emptyRow[column.name] = null;
-		});
 		const inserted = await insertDataStoreRowApi(
 			rootStore.restApiContext,
 			dataStore.id,
-			emptyRow,
+			{},
 			dataStore.projectId,
 		);
-		return inserted[0].id;
+		return inserted[0];
 	};
 
 	const updateRow = async (


### PR DESCRIPTION
## Summary

The backend returns the system created and updated at columns for each data table row so we want to display those in the UI.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3997/fe-show-createdat-and-updatedat-in-the-ui

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
