### PR TITLE
fix(GoogleDrive Node): Fix google service accounts uploading to shared drives

### DIFF
--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/createFromText.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/createFromText.test.ts
@@ -63,7 +63,12 @@ describe('test GoogleDriveV2: file createFromText', () => {
 			expect.anything(), // Buffer of content goes here
 			{ uploadType: 'multipart', supportsAllDrives: true },
 			undefined,
-			{ headers: { 'Content-Length': 503, 'Content-Type': 'multipart/related; boundary=...' } },
+			{
+				headers: {
+					'Content-Length': 503,
+					'Content-Type': expect.stringMatching(/^multipart\/related; boundary=(\\S)*/),
+				},
+			},
 		);
 		expect(transport.googleApiRequest).toHaveBeenCalledWith(
 			'PATCH',

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/createFromText.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/createFromText.test.ts
@@ -61,9 +61,9 @@ describe('test GoogleDriveV2: file createFromText', () => {
 			'POST',
 			'/upload/drive/v3/files',
 			expect.anything(), // Buffer of content goes here
-			{ uploadType: 'media' },
+			{ uploadType: 'multipart', supportsAllDrives: true },
 			undefined,
-			{ headers: { 'Content-Length': 12, 'Content-Type': 'text/plain' } },
+			{ headers: { 'Content-Length': 503, 'Content-Type': 'multipart/related; boundary=...' } },
 		);
 		expect(transport.googleApiRequest).toHaveBeenCalledWith(
 			'PATCH',

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/upload.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/upload.test.ts
@@ -65,9 +65,9 @@ describe('test GoogleDriveV2: file upload', () => {
 			'POST',
 			'/upload/drive/v3/files',
 			expect.any(Buffer),
-			{ uploadType: 'media' },
+			{ uploadType: 'multipart', supportsAllDrives: true },
 			undefined,
-			{ headers: { 'Content-Length': '123', 'Content-Type': 'text/plain' } },
+			{ headers: { 'Content-Length': 498, 'Content-Type': 'multipart/related; boundary=...' } },
 		);
 		expect(transport.googleApiRequest).toHaveBeenCalledWith(
 			'PATCH',
@@ -124,7 +124,7 @@ describe('test GoogleDriveV2: file upload', () => {
 			'POST',
 			'/upload/drive/v3/files',
 			undefined,
-			{ uploadType: 'resumable' },
+			{ uploadType: 'resumable', supportsAllDrives: true },
 			undefined,
 			{ returnFullResponse: true, headers: { 'X-Upload-Content-Type': 'image/jpg' } },
 		);

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/upload.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/upload.test.ts
@@ -67,7 +67,12 @@ describe('test GoogleDriveV2: file upload', () => {
 			expect.any(Buffer),
 			{ uploadType: 'multipart', supportsAllDrives: true },
 			undefined,
-			{ headers: { 'Content-Length': 498, 'Content-Type': 'multipart/related; boundary=...' } },
+			{
+				headers: {
+					'Content-Length': 498,
+					'Content-Type': expect.stringMatching(/^multipart\/related; boundary=(\\S)*/),
+				},
+			},
 		);
 		expect(transport.googleApiRequest).toHaveBeenCalledWith(
 			'PATCH',
@@ -79,6 +84,7 @@ describe('test GoogleDriveV2: file upload', () => {
 				corpora: 'allDrives',
 				includeItemsFromAllDrives: true,
 				spaces: 'appDataFolder, drive',
+				uploadType: 'multipart',
 			},
 		);
 


### PR DESCRIPTION
## Summary

In April 2025 google changed service accounts to not having storage quota, making them unusable to upload files to personal `my drive` storage. Instead, service accounts should upload to shared drives. Service accounts created before April 2025 still have storage quota and can still be used to upload to `my drive`.

The google change broke uploading files to shared drives with new service accounts also, because of our 2 step upload approach:

1. Upload the file - POST `/upload/drive/v3/files` - without metadata (without setting parent drive/folder)
2. Update the file - PATCH `/upload/drive/v3/files` - with metadata (set parent drive/folder)

The first call failed because without metadata the parent defaults to `my drive`, throwing the error: 
`Service Accounts do not have storage quota. Leverage shared drives (https://developers.google.com/workspace/drive/api/guides/about-shareddrives), or use OAuth delegation (http://support.google.com/a/answer/7281227) instead.`

This PR changed the first call [uploading the file](https://developers.google.com/workspace/drive/api/guides/manage-uploads) to include metadata including the parent drive/folder using *Multipart upload (uploadType=multipart)*.

The change was implemented for the upload operations:
* File -> Upload
* File -> Create From Text

The change was implemented for BINARY_DATA_MODE default (memory) and filesystem (streaming)

## Related Linear tickets, Github issues, and Community forum posts

Fixes: https://community.n8n.io/t/upload-file-google-drive-node-with-service-account-not-working/147750
Fixes: #18896

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
