### PR TITLE
fix(editor): Make Code node lint errors colorblind friendly

### DIFF
--- a/packages/frontend/editor-ui/src/components/CodeNodeEditor/theme.ts
+++ b/packages/frontend/editor-ui/src/components/CodeNodeEditor/theme.ts
@@ -196,6 +196,10 @@ export const codeEditorTheme = ({ isReadOnly, minHeight, maxHeight, rows }: Them
 			backgroundColor: 'var(--color-background-base)',
 			border: 'var(--border-base)',
 		},
+		'.cm-lintRange-error': {
+			backgroundImage:
+				"url(\"data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='6' height='3'%3e%3cpath d='m0 2.5 l2 -1.5 l1 0 l2 1.5 l1 0' stroke='%23F56565' fill='none' stroke-width='.7'/%3e%3c/svg%3e\") !important", // #F56565 is --color-text-danger
+		},
 		'.cm-selectionMatch': {
 			background: 'var(--color-code-selection-highlight)',
 		},


### PR DESCRIPTION
## Summary

Code node lint errors in dark mode are barely visible to colorblind users, hence use `--color-text-danger`

- https://share.cleanshot.com/83HxCsCQ
- https://share.cleanshot.com/sZDLTxrh

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.slack.com/archives/C03594NKD7W/p1756282966870099


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
