### PR TITLE
fix(editor): Fix primitive values for code line highlight (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/css/_tokens.dark.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.dark.scss
@@ -176,7 +176,7 @@
 	--color-json-highlight: var(--color-background-base);
 	--color-code-background: var(--p-gray-820);
 	--color-code-background-readonly: var(--p-gray-740);
-	--color-code-lineHighlight: var(--p-gray-320-alpha-010);
+	--color-code-lineHighlight: var(--p-gray-320-a-010);
 	--color-code-foreground: var(--p-gray-070);
 	--color-code-caret: var(--p-gray-010);
 	--color-code-selection: #3392ff44;
@@ -226,7 +226,7 @@
 	--color-button-highlight-hover-background: var(--prim-gray-670);
 	--color-button-highlight-active-focus-background: var(--prim-gray-670);
 	--color-button-highlight-focus-outline: var(--prim-gray-670);
-	--color-button-highlight-disabled-font: var(--prim-gray-0-alpha-010);
+	--color-button-highlight-disabled-font: var(--prim-gray-0-a-010);
 	--color-button-highlight-disabled-border: transparent;
 
 	// Button success, warning, danger


### PR DESCRIPTION
## Summary
This PR fixes line highlighting in the code editor, currently not displaying in dark mode becuase of an incorrectly refrenched primitive color value.

## Related Linear tickets, Github issues, and Community forum posts
Discussed here: https://n8nio.slack.com/archives/C03594NKD7W/p1756465145417709
Fixes DS-207


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
