### PR TITLE
refactor(core): Decouple datastore from workflow execution context

### DIFF
--- a/packages/cli/src/modules/data-table/data-store-column.repository.ts
+++ b/packages/cli/src/modules/data-table/data-store-column.repository.ts
@@ -60,6 +60,7 @@ export class DataStoreColumnRepository extends Repository<DataTableColumn> {
 				dataTableId,
 			});
 
+			// @ts-ignore
 			await em.insert(DataTableColumn, column);
 
 			const queryRunner = em.queryRunner;

--- a/packages/cli/src/modules/data-table/data-store-column.repository.ts
+++ b/packages/cli/src/modules/data-table/data-store-column.repository.ts
@@ -60,7 +60,7 @@ export class DataStoreColumnRepository extends Repository<DataTableColumn> {
 				dataTableId,
 			});
 
-			// @ts-ignore
+			// @ts-ignore Workaround for intermittent typecheck issue with _QueryDeepPartialEntity
 			await em.insert(DataTableColumn, column);
 
 			const queryRunner = em.queryRunner;

--- a/packages/cli/src/modules/data-table/data-store.repository.ts
+++ b/packages/cli/src/modules/data-table/data-store.repository.ts
@@ -28,6 +28,7 @@ export class DataStoreRepository extends Repository<DataTable> {
 		let dataTableId: string | undefined;
 		await this.manager.transaction(async (em) => {
 			const dataStore = em.create(DataTable, { name, columns, projectId });
+			// @ts-ignore
 			await em.insert(DataTable, dataStore);
 			dataTableId = dataStore.id;
 

--- a/packages/cli/src/modules/data-table/data-store.repository.ts
+++ b/packages/cli/src/modules/data-table/data-store.repository.ts
@@ -28,7 +28,7 @@ export class DataStoreRepository extends Repository<DataTable> {
 		let dataTableId: string | undefined;
 		await this.manager.transaction(async (em) => {
 			const dataStore = em.create(DataTable, { name, columns, projectId });
-			// @ts-ignore
+			// @ts-ignore Workaround for intermittent typecheck issue with _QueryDeepPartialEntity
 			await em.insert(DataTable, dataStore);
 			dataTableId = dataStore.id;
 

--- a/packages/cli/src/modules/data-table/data-table.module.ts
+++ b/packages/cli/src/modules/data-table/data-table.module.ts
@@ -2,7 +2,6 @@ import { Logger } from '@n8n/backend-common';
 import type { ModuleInterface } from '@n8n/decorators';
 import { BackendModule, OnShutdown } from '@n8n/decorators';
 import { Container } from '@n8n/di';
-import { BaseEntity } from '@n8n/typeorm';
 
 const YELLOW = '\x1b[33m';
 const CLEAR = '\x1b[0m';
@@ -38,6 +37,12 @@ export class DataStoreModule implements ModuleInterface {
 		const { DataTable } = await import('./data-table.entity');
 		const { DataTableColumn } = await import('./data-table-column.entity');
 
-		return [DataTable, DataTableColumn] as unknown as Array<new () => BaseEntity>;
+		return [DataTable, DataTableColumn];
+	}
+
+	async context() {
+		const { DataStoreProxyService } = await import('./data-store-proxy.service');
+
+		return { dataStoreProxyProvider: Container.get(DataStoreProxyService) };
 	}
 }

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -377,15 +377,7 @@ export async function getBase(
 
 	const eventService = Container.get(EventService);
 
-	const moduleRegistry = Container.get(ModuleRegistry);
-	const dataStoreProxyProvider = moduleRegistry.isActive('data-table')
-		? Container.get(
-				(await import('@/modules/data-table/data-store-proxy.service')).DataStoreProxyService,
-			)
-		: undefined;
-
 	const additionalData: IWorkflowExecuteAdditionalData = {
-		dataStoreProxyProvider,
 		currentNodeExecutionIndex: 0,
 		credentialsHelper: Container.get(CredentialsHelper),
 		executeWorkflow,

--- a/packages/core/src/execution-engine/index.ts
+++ b/packages/core/src/execution-engine/index.ts
@@ -7,7 +7,7 @@ declare module 'n8n-workflow' {
 	interface IWorkflowExecuteAdditionalData {
 		hooks?: ExecutionLifecycleHooks;
 		externalSecretsProxy: ExternalSecretsProxy;
-		dataStoreProxyProvider?: DataStoreProxyProvider;
+		'data-table'?: { dataStoreProxyProvider: DataStoreProxyProvider };
 		dataStoreProjectId?: string;
 	}
 }

--- a/packages/core/src/execution-engine/node-execution-context/utils/data-store-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/data-store-helper-functions.ts
@@ -10,8 +10,8 @@ export function getDataStoreHelperFunctions(
 	workflow: Workflow,
 	node: INode,
 ): Partial<DataStoreProxyFunctions> {
-	if (additionalData.dataStoreProxyProvider === undefined) return {};
-	const dataStoreProxyProvider = additionalData.dataStoreProxyProvider;
+	const dataStoreProxyProvider = additionalData['data-table']?.dataStoreProxyProvider;
+	if (!dataStoreProxyProvider) return {};
 	return {
 		getDataStoreAggregateProxy: async () =>
 			await dataStoreProxyProvider.getDataStoreAggregateProxy(


### PR DESCRIPTION
## Summary

Use the [newly introduced](https://github.com/n8n-io/n8n/pull/18551) `context` method to decouple data store from workflow execution context.

Feature continues to work:

- https://share.cleanshot.com/vmgLSNvz
- https://share.cleanshot.com/l74jdxTc



## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
