### PR TITLE
fix(editor): Data tables UI fixes (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/dataStore/DataStoreDetailsView.vue
+++ b/packages/frontend/editor-ui/src/features/dataStore/DataStoreDetailsView.vue
@@ -82,8 +82,11 @@ const onToggleSave = (value: boolean) => {
 	}
 };
 
-const onAddColumn = (column: DataStoreColumnCreatePayload) => {
-	dataStoreTableRef.value?.addColumn(column);
+const onAddColumn = async (column: DataStoreColumnCreatePayload) => {
+	if (!dataStoreTableRef.value) {
+		return false;
+	}
+	return await dataStoreTableRef.value.addColumn(column);
 };
 
 onMounted(async () => {

--- a/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/AddColumnButton.test.ts
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/AddColumnButton.test.ts
@@ -43,7 +43,7 @@ vi.mock('@n8n/i18n', async (importOriginal) => ({
 }));
 
 describe('AddColumnButton', () => {
-	const addColumnHandler = vi.fn();
+	const addColumnHandler = vi.fn().mockResolvedValue(true);
 	const renderComponent = createComponentRenderer(AddColumnButton, {
 		props: {
 			params: {
@@ -241,6 +241,24 @@ describe('AddColumnButton', () => {
 
 		await waitFor(() => {
 			expect(queryByText('Column name')).not.toBeInTheDocument();
+		});
+	});
+
+	it('should not close popover if submission fails', async () => {
+		const { getByPlaceholderText, getByTestId, queryByText } = renderComponent();
+		addColumnHandler.mockResolvedValueOnce(false);
+		const addButton = getByTestId('data-store-add-column-trigger-button');
+
+		await fireEvent.click(addButton);
+
+		const nameInput = getByPlaceholderText('Enter column name');
+		await fireEvent.update(nameInput, 'testColumn');
+
+		const submitButton = getByTestId('data-store-add-column-submit-button');
+		await fireEvent.click(submitButton);
+
+		await waitFor(() => {
+			expect(getByTestId('data-store-add-column-submit-button')).toBeInTheDocument();
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/AddColumnButton.test.ts
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/AddColumnButton.test.ts
@@ -245,7 +245,7 @@ describe('AddColumnButton', () => {
 	});
 
 	it('should not close popover if submission fails', async () => {
-		const { getByPlaceholderText, getByTestId, queryByText } = renderComponent();
+		const { getByPlaceholderText, getByTestId } = renderComponent();
 		addColumnHandler.mockResolvedValueOnce(false);
 		const addButton = getByTestId('data-store-add-column-trigger-button');
 

--- a/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/AddColumnButton.vue
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/AddColumnButton.vue
@@ -39,7 +39,8 @@ const isSelectOpen = ref(false);
 const popoverId = computed(() => props.popoverId ?? 'add-column-popover');
 
 const onAddButtonClicked = async () => {
-	if (!columnName.value || !columnType.value) {
+	validateName();
+	if (!columnName.value || !columnType.value || error.value) {
 		return;
 	}
 	const success = await props.params.onAddColumn({

--- a/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/AddColumnButton.vue
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/AddColumnButton.vue
@@ -13,7 +13,7 @@ import { useDebounce } from '@/composables/useDebounce';
 const props = defineProps<{
 	// the params key is needed so that we can pass this directly to ag-grid as column
 	params: {
-		onAddColumn: (column: DataStoreColumnCreatePayload) => void;
+		onAddColumn: (column: DataStoreColumnCreatePayload) => Promise<boolean>;
 	};
 	popoverId?: string;
 	useTextTrigger?: boolean;
@@ -38,11 +38,17 @@ const isSelectOpen = ref(false);
 
 const popoverId = computed(() => props.popoverId ?? 'add-column-popover');
 
-const onAddButtonClicked = () => {
+const onAddButtonClicked = async () => {
 	if (!columnName.value || !columnType.value) {
 		return;
 	}
-	props.params.onAddColumn({ name: columnName.value, type: columnType.value });
+	const success = await props.params.onAddColumn({
+		name: columnName.value,
+		type: columnType.value,
+	});
+	if (!success) {
+		return;
+	}
 	columnName.value = '';
 	columnType.value = 'string';
 	popoverOpen.value = false;

--- a/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/DataStoreTable.test.ts
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/DataStoreTable.test.ts
@@ -20,6 +20,7 @@ vi.mock('ag-grid-vue3', () => ({
 				api: {
 					refreshHeader: vi.fn(),
 					applyTransaction: vi.fn(),
+					setGridOption: vi.fn(),
 				},
 			});
 		},

--- a/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/DataStoreTable.vue
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/DataStoreTable.vue
@@ -652,10 +652,9 @@ const handleCopyFocusedCell = async (params: CellKeyDownEvent<DataStoreRow>) => 
 		return;
 	}
 	const row = params.api.getDisplayedRowAtIndex(focused.rowIndex);
-	if (row) {
-		const colDef = focused.column.getColDef();
-		const field = (colDef.field as string) ?? focused.column.getColId();
-		const rawValue = (row.data as Record<string, unknown>)[field as string];
+	const colDef = focused.column.getColDef();
+	if (row?.data && colDef.field) {
+		const rawValue = row.data[colDef.field];
 		const text = rawValue === null || rawValue === undefined ? '' : String(rawValue);
 		await copyToClipboard(text);
 	}

--- a/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/DataStoreTable.vue
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/DataStoreTable.vue
@@ -239,8 +239,10 @@ const onAddColumn = async (column: DataStoreColumnCreatePayload) => {
 			return { ...row, [newColumn.name]: null };
 		});
 		refreshGridData();
+		return true;
 	} catch (error) {
 		toast.showError(error, i18n.baseText('dataStore.addColumn.error'));
+		return false;
 	}
 };
 


### PR DESCRIPTION
## Summary

2 small fixes in the data table UI

https://www.notion.so/n8n/Can-t-copy-the-value-of-a-cell-unless-it-s-in-active-mode-25e5b6e0c94f80558b93dc16e38d8091?source=copy_link

https://www.notion.so/n8n/Don-t-close-the-add-column-popover-on-error-25e5b6e0c94f80c982cad3d1837dd05e?source=copy_link

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
