### PR TITLE
refactor(core): Block `__import__` via AST validation in native Python runner

### DIFF
--- a/packages/@n8n/task-runner-python/src/constants.py
+++ b/packages/@n8n/task-runner-python/src/constants.py
@@ -57,7 +57,7 @@ TASK_REJECTED_REASON_OFFER_EXPIRED = (
 TASK_REJECTED_REASON_AT_CAPACITY = "No open task slots - runner already at capacity"
 
 # Security
-BUILTINS_DENY_DEFAULT = "eval,exec,compile,open,input,breakpoint,__import__,getattr,object,type,vars,setattr,delattr,hasattr,dir,memoryview,__build_class__"
+BUILTINS_DENY_DEFAULT = "eval,exec,compile,open,input,breakpoint,getattr,object,type,vars,setattr,delattr,hasattr,dir,memoryview,__build_class__"
 ALWAYS_BLOCKED_ATTRIBUTES = {
     "__subclasses__",
     "__globals__",
@@ -112,4 +112,5 @@ ERROR_RELATIVE_IMPORT = "Relative imports are disallowed."
 ERROR_STDLIB_DISALLOWED = "Import of standard library module '{module}' is disallowed. Allowed stdlib modules: {allowed}"
 ERROR_EXTERNAL_DISALLOWED = "Import of external package '{module}' is disallowed. Allowed external packages: {allowed}"
 ERROR_DANGEROUS_ATTRIBUTE = "Access to attribute '{attr}' is disallowed, because it can be used to bypass security restrictions."
+ERROR_DYNAMIC_IMPORT = "Dynamic __import__() calls are not allowed for security reasons."
 ERROR_SECURITY_VIOLATIONS = "Security violations detected:\n{violations}"

--- a/packages/@n8n/task-runner-python/src/constants.py
+++ b/packages/@n8n/task-runner-python/src/constants.py
@@ -112,5 +112,7 @@ ERROR_RELATIVE_IMPORT = "Relative imports are disallowed."
 ERROR_STDLIB_DISALLOWED = "Import of standard library module '{module}' is disallowed. Allowed stdlib modules: {allowed}"
 ERROR_EXTERNAL_DISALLOWED = "Import of external package '{module}' is disallowed. Allowed external packages: {allowed}"
 ERROR_DANGEROUS_ATTRIBUTE = "Access to attribute '{attr}' is disallowed, because it can be used to bypass security restrictions."
-ERROR_DYNAMIC_IMPORT = "Dynamic __import__() calls are not allowed for security reasons."
+ERROR_DYNAMIC_IMPORT = (
+    "Dynamic __import__() calls are not allowed for security reasons."
+)
 ERROR_SECURITY_VIOLATIONS = "Security violations detected:\n{violations}"

--- a/packages/@n8n/task-runner-python/src/task_analyzer.py
+++ b/packages/@n8n/task-runner-python/src/task_analyzer.py
@@ -11,6 +11,7 @@ from src.constants import (
     ERROR_STDLIB_DISALLOWED,
     ERROR_EXTERNAL_DISALLOWED,
     ERROR_DANGEROUS_ATTRIBUTE,
+    ERROR_DYNAMIC_IMPORT,
     ERROR_SECURITY_VIOLATIONS,
     ALWAYS_BLOCKED_ATTRIBUTES,
     UNSAFE_ATTRIBUTES,
@@ -56,7 +57,7 @@ class SecurityValidator(ast.NodeVisitor):
         self.generic_visit(node)
 
     def visit_Attribute(self, node: ast.Attribute) -> None:
-        """Detect access to unsafe attributes that could bypass security."""
+        """Detect access to unsafe attributes that could bypass security restrictions."""
 
         if node.attr in UNSAFE_ATTRIBUTES:
             # Block regardless of context
@@ -69,6 +70,22 @@ class SecurityValidator(ast.NodeVisitor):
                 self._add_violation(
                     node.lineno, ERROR_DANGEROUS_ATTRIBUTE.format(attr=node.attr)
                 )
+
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        """Detect calls to __import__() that could bypass security restrictions."""
+
+        if isinstance(node.func, ast.Name) and node.func.id == "__import__":
+            if (
+                node.args
+                and isinstance(node.args[0], ast.Constant)
+                and isinstance(node.args[0].value, str)
+            ):
+                module_name = node.args[0].value
+                self._validate_import(module_name, node.lineno)
+            else:
+                self._add_violation(node.lineno, ERROR_DYNAMIC_IMPORT)
 
         self.generic_visit(node)
 


### PR DESCRIPTION
## Summary

Python's `import` internally uses `__import__` so we cannot block the latter outright. Hence block disallowed uses of `__import__` via AST validation: 
- `__import__('allowed')` passes
- `__import__('disallowed')` fails
- `__import__(var)` always fails

Follow-up to: #18826

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
