### PR TITLE
fix(editor): Fix color of selection state on execution table (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/css/_tokens.dark.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.dark.scss
@@ -208,14 +208,14 @@
 
 	// Button secondary
 	--color-button-secondary-font: var(--p-gray-070);
-	--color-button-secondary-border: var(--p-gray-070);
+	--color-button-secondary-border: var(--color-foreground-base);
 	--color-button-secondary-background: var(--color-background-light);
 	--color-button-secondary-hover-active-focus-font: var(--p-color-primary-220);
 	--color-button-secondary-hover-background: var(--color-background-light);
 	--color-button-secondary-active-focus-background: var(--p-color-primary-320-a-010);
 	--color-button-secondary-focus-outline: var(--p-color-primary-320-a-035);
 	--color-button-secondary-disabled-font: var(--p-white-a-030);
-	--color-button-secondary-disabled-border: var(--p-white-a-030);
+	--color-button-secondary-disabled-border: var(--color-foreground-base);
 
 	// Button highlight
 	--color-button-highlight-font: var(--prim-gray-320);

--- a/packages/frontend/@n8n/design-system/src/css/_tokens.dark.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.dark.scss
@@ -209,7 +209,7 @@
 	// Button secondary
 	--color-button-secondary-font: var(--p-gray-070);
 	--color-button-secondary-border: var(--p-gray-070);
-	--color-button-secondary-background: transparent;
+	--color-button-secondary-background: var(--color-background-light);
 	--color-button-secondary-hover-active-focus-font: var(--p-color-primary-220);
 	--color-button-secondary-hover-background: transparent;
 	--color-button-secondary-active-focus-background: var(--p-color-primary-320-a-010);
@@ -259,8 +259,8 @@
 	// Execution
 	--execution-card-background: var(--color-foreground-light);
 	--execution-card-background-hover: var(--color-foreground-base);
-	--execution-selector-background: var(--p-gray-740);
-	--execution-selector-text: var(--color-text-base);
+	--execution-selector-background: var(--color-background-dark);
+	--execution-selector-text: var(--color-text-xlight);
 	--execution-select-all-text: var(--color-text-base);
 	--execution-card-text-waiting: var(--p-color-secondary-370);
 

--- a/packages/frontend/@n8n/design-system/src/css/_tokens.dark.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.dark.scss
@@ -211,7 +211,7 @@
 	--color-button-secondary-border: var(--p-gray-070);
 	--color-button-secondary-background: var(--color-background-light);
 	--color-button-secondary-hover-active-focus-font: var(--p-color-primary-220);
-	--color-button-secondary-hover-background: transparent;
+	--color-button-secondary-hover-background: var(--color-background-light);
 	--color-button-secondary-active-focus-background: var(--p-color-primary-320-a-010);
 	--color-button-secondary-focus-outline: var(--p-color-primary-320-a-035);
 	--color-button-secondary-disabled-font: var(--p-white-a-030);

--- a/packages/frontend/editor-ui/src/n8n-theme.scss
+++ b/packages/frontend/editor-ui/src/n8n-theme.scss
@@ -70,7 +70,7 @@
 }
 
 .el-message-box {
-	background-color: var(--color-background-base);
+	background-color: var(--color-background-light);
 	border: none;
 	.el-message-box__headerbtn {
 		.el-message-box__close {


### PR DESCRIPTION
## Summary

Fixes ADO-4037, where the selection state for the exectution table and in turn the new Data tables was wrong. Had to change some secondary button styles in dark mode which has the added benefit of them no longer being transparent.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/ADO-4037/executions-table-select-state-on-dark-mode-has-wrong-background-color

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
