### PR TITLE
fix(editor): Fix markdown checkbox text duplication in sticky notes

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nMarkdown/Markdown.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMarkdown/Markdown.test.ts
@@ -102,5 +102,30 @@ describe('components', () => {
 				'<p><iframe width="100%" src="https://www.youtube-nocookie.com/embed/ZCuL2e4zC_4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe></p>',
 			);
 		});
+
+		it('should not duplicate checkbox text when followed by text without blank line', () => {
+			const wrapper = render(N8nMarkdown, {
+				global: {
+					directives: {
+						n8nHtml,
+					},
+				},
+				props: {
+					content: '- [ ] Test item\nTest item',
+				},
+			});
+
+			const html = wrapper.html();
+			// Count occurrences of the text in the rendered HTML
+			const textOccurrences = (html.match(/Test item/g) || []).length;
+
+			// Should appear exactly twice: once as checkbox label, once as continuation text
+			// Not 4 times as in the bug
+			expect(textOccurrences).toBe(2);
+
+			// Should have exactly one checkbox
+			const checkboxes = wrapper.getAllByRole('checkbox');
+			expect(checkboxes).toHaveLength(1);
+		});
 	});
 });

--- a/packages/frontend/@n8n/design-system/src/components/N8nMarkdown/Markdown.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMarkdown/Markdown.test.ts
@@ -120,7 +120,6 @@ describe('components', () => {
 			const textOccurrences = (html.match(/Test item/g) || []).length;
 
 			// Should appear exactly twice: once as checkbox label, once as continuation text
-			// Not 4 times as in the bug
 			expect(textOccurrences).toBe(2);
 
 			// Should have exactly one checkbox

--- a/packages/frontend/@n8n/design-system/src/components/N8nMarkdown/Markdown.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMarkdown/Markdown.vue
@@ -58,7 +58,7 @@ const props = withDefaults(defineProps<MarkdownProps>(), {
 		tasklists: {
 			enabled: true,
 			label: true,
-			labelAfter: true,
+			labelAfter: false,
 		},
 		youtube: {},
 	}),


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
This PR fixes an issue where checkbox text in sticky notes was being duplicated multiple times when followed by text without a blank line separator.

### Problem
When using markdown checkboxes in sticky notes, if text immediately followed a checkbox item without a blank line, the text would be rendered multiple times. This occurred because the `markdown-it-task-lists` plugin was configured with both `label` and `labelAfter` options enabled, causing the plugin to duplicate the label content both within and after the checkbox element.
```
### Test
- [ ] Test.
- [ ] Test item.
Test item.

### Test2
```
<img width="1620" height="554" alt="image" src="https://github.com/user-attachments/assets/976763a4-ed32-4c69-bac7-4eb33306121b" />

### Solution
The fix disables the `labelAfter` option in the `markdown-it-task-lists` configuration. This prevents the plugin from rendering the checkbox label text after the checkbox element, eliminating the duplication while maintaining proper checkbox functionality. The checkbox label is now only rendered once in its correct position, and any continuation text is processed normally without creating multiple duplicates.

<img width="1580" height="530" alt="image" src="https://github.com/user-attachments/assets/a0243e24-46c1-4b1a-9e33-ecb5dc6233d6" />



## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
Closes #18855 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
