### PR TITLE
fix(editor): Support line breaks in resource mapper field names

### DIFF
--- a/packages/frontend/editor-ui/src/utils/nodeTypeUtils.test.ts
+++ b/packages/frontend/editor-ui/src/utils/nodeTypeUtils.test.ts
@@ -1,5 +1,9 @@
 import type { ResourceMapperField } from 'n8n-workflow';
-import { isCommunityPackageName, isResourceMapperFieldListStale } from './nodeTypesUtils';
+import {
+	isCommunityPackageName,
+	isResourceMapperFieldListStale,
+	parseResourceMapperFieldName,
+} from './nodeTypesUtils';
 
 describe('isResourceMapperFieldListStale', () => {
 	const baseField: ResourceMapperField = {
@@ -125,5 +129,29 @@ describe('isCommunityPackageName', () => {
 		expect(isCommunityPackageName('@user/n8n-nodes-example')).toBe(true);
 		expect(isCommunityPackageName('n8n-nodes-base')).toBe(false);
 		expect(isCommunityPackageName('@test-scope/n8n-nodes-test')).toBe(true);
+	});
+});
+
+describe('parseResourceMapperFieldName', () => {
+	test.each([
+		{ input: 'value["fieldName"]', expected: 'fieldName', desc: 'basic field name' },
+		{
+			input: 'value["field with spaces"]',
+			expected: 'field with spaces',
+			desc: 'field with spaces',
+		},
+		{
+			input: 'value["field\nwith\nactual\nnewlines"]',
+			expected: 'field\nwith\nactual\nnewlines',
+			desc: 'field with newlines',
+		},
+		{
+			input: 'value["field\\"with\\"quotes"]',
+			expected: 'field\\"with\\"quotes',
+			desc: 'field with escaped quotes',
+		},
+		{ input: 'fieldName', expected: 'fieldName', desc: 'no value wrapper' },
+	])('should parse $desc', ({ input, expected }) => {
+		expect(parseResourceMapperFieldName(input)).toBe(expected);
 	});
 });

--- a/packages/frontend/editor-ui/src/utils/nodeTypesUtils.ts
+++ b/packages/frontend/editor-ui/src/utils/nodeTypesUtils.ts
@@ -32,7 +32,7 @@ import {
 const CRED_KEYWORDS_TO_FILTER = ['API', 'OAuth1', 'OAuth2'];
 const NODE_KEYWORDS_TO_FILTER = ['Trigger'];
 const COMMUNITY_PACKAGE_NAME_REGEX = /^(?!@n8n\/)(@[\w.-]+\/)?n8n-nodes-(?!base\b)\b\w+/g;
-const RESOURCE_MAPPER_FIELD_NAME_REGEX = /value\[\"(.+)\"\]/;
+const RESOURCE_MAPPER_FIELD_NAME_REGEX = /value\["(.+?)"\]/s;
 
 export function getAppNameFromCredType(name: string) {
 	return name


### PR DESCRIPTION
## Summary

In the resource mapper components, when the name of a field has line breaks in it, the UI would break:
You were unable to drag input data into it, or delete the field.

An easy way to reproduce this is by using the Google Sheets (Update Row) node and selecting a sheet with line breaks in the header row:

<img width="515" height="219" alt="image" src="https://github.com/user-attachments/assets/4b967206-3d18-469c-a303-004ae37831a1" />

## Related Linear tickets, Github issues, and Community forum posts

fixes #17886
https://linear.app/n8n/issue/NODE-3399/community-issue-google-sheet-node-does-not-handle-line-breaks

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
