### PR TITLE
fix(editor): Debug in Editor preserves binary data and prevents incorrect dirty marking

### DIFF
--- a/packages/frontend/editor-ui/src/composables/useExecutionDebugging.ts
+++ b/packages/frontend/editor-ui/src/composables/useExecutionDebugging.ts
@@ -109,13 +109,18 @@ export const useExecutionDebugging = () => {
 		let pinnings = 0;
 
 		pinnableNodes.forEach((node: INodeUi) => {
-			const nodeData = runData[node.name]?.[0]?.data?.main?.[0];
-			if (nodeData) {
-				pinnings++;
-				workflowsStore.pinData({
-					node,
-					data: nodeData,
-				});
+			const taskData = runData[node.name]?.[0];
+			if (taskData?.data?.main) {
+				// Get the first main output that has data, preserving all execution data including binary
+				const nodeData = taskData.data.main.find((output) => output && output.length > 0);
+				if (nodeData) {
+					pinnings++;
+					workflowsStore.pinData({
+						node,
+						data: nodeData,
+						isRestoration: true,
+					});
+				}
 			}
 		});
 


### PR DESCRIPTION
## Summary

Fixes binary data disappearing during partial execution when using the "Debug in Editor" feature. When loading execution data into the workflow editor and performing subsequent partial executions, binary data would be lost. Additionally, trigger nodes were incorrectly marked as dirty, causing their run data to be discarded and replaced with incomplete pin data that was missing the binary data.

**Root cause**: Three interconnected issues in the Debug in Editor implementation:
1. Binary data loss in pin data storage - only `json` property preserved, `binary` discarded
2. Incomplete data extraction - only extracting first main output instead of finding first output with data  
3. Incorrect dirty marking - timestamp pollution during restoration caused triggers to be marked dirty, leading to run data being thrown away and replaced with pin data missing binary content

**Solution**:
- Preserve both `json` and `binary` properties in pin data storage
- Improve data extraction to find first non-empty output across multiple main outputs
- Add `isRestoration` flag to prevent timestamp updates and clear existing timestamps during debug restoration

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1259

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.ai/code)