### PR TITLE
[Google Drive Node] Improve error message when folder ID is provided instead of file ID

### DIFF
--- a/packages/nodes-base/nodes/Google/Drive/v2/actions/file/download.operation.ts
+++ b/packages/nodes-base/nodes/Google/Drive/v2/actions/file/download.operation.ts
@@ -5,11 +5,13 @@ import type {
 	INodeExecutionData,
 	INodeProperties,
 } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
 
 import { updateDisplayOptions } from '@utils/utilities';
 
 import { googleApiRequest } from '../../transport';
 import { fileRLC } from '../common.descriptions';
+import { DRIVE } from '../../helpers/interfaces';
 
 const properties: INodeProperties[] = [
 	{
@@ -205,6 +207,15 @@ export async function execute(
 		{},
 		{ fields: 'mimeType,name', supportsTeamDrives: true, supportsAllDrives: true },
 	);
+
+	// If user accidentally provides a folder ID, throw a clear, actionable error
+	if (file?.mimeType === DRIVE.FOLDER) {
+		throw new NodeOperationError(
+			this.getNode(),
+			'The provided ID refers to a folder. Please provide a file ID to download.',
+			{ itemIndex: i },
+		);
+	}
 	let response;
 
 	if (file.mimeType?.includes('vnd.google-apps')) {


### PR DESCRIPTION
## Summary

When attempting to download a file from Google Drive, if the user mistakenly provided a **folder ID** instead of a **file ID**, the node was returning a generic:
`403 Forbidden – check your credentials`

This was misleading because the issue was not related to authentication/credentials, but to the wrong type of resource (folder instead of file).

This PR adds an explicit check for `mimeType === folder`, and throws a clear, actionable error message:
`The provided ID refers to a folder. Please provide a file ID to download.`

This way, users immediately understand the root cause and how to fix it.

---

## How to test

1. Use the **Google Drive** node → **Download** operation.  
2. Provide a **folder ID** instead of a **file ID**.  
3. **Before:** misleading `403 Forbidden – check your credentials`.  
   **After:** clear error message about using a folder ID.  

---
