### PR TITLE
ci: Change runner to blacksmith on publish to npm release job

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   publish-to-npm:
     name: Publish to NPM
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2204
     if: github.event.pull_request.merged == true
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -25,23 +25,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: useblacksmith/setup-node@65c6ca86fdeb0ab3d85e78f57e4f6a7e4780b391 # v5.0.4
-        with:
-          node-version: 22.x
-
-      - name: Setup corepack and pnpm
-        run: |
-          npm i -g corepack@0.33
-          corepack enable
-
-      - run: pnpm install --frozen-lockfile
-
       - name: Set release version in env
         run: echo "RELEASE=$(node -e 'console.log(require("./package.json").version)')" >> "$GITHUB_ENV"
 
-      - name: Build
-        run: pnpm build
+      - name: Setup Node.js, install dependencies, and build
+        uses: ./.github/actions/setup-nodejs-blacksmith
+        with:
+          node-version: 22.x
 
+      # NOTE: Turborepo caching is handled by setup-nodejs-blacksmith action above
+      # This manual cache may be redundant but kept for safety
       - name: Cache build artifacts
         uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: useblacksmith/setup-node@65c6ca86fdeb0ab3d85e78f57e4f6a7e4780b391 # v5.0.4
         with:
           node-version: 22.x
 


### PR DESCRIPTION
## Summary
Should improve speed of release workflow by switching the initial job from github-ubuntu runner to faster Blacksmith runner and utilizing turborepo cache from setup-node-js-blacksmith reusable action.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/CAT-1280/switch-from-github-ubuntu-to-blacksmith-runner-in-the-release-job

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
