### PR TITLE
refactor: Remove `nanoid` dependency from native Python task runner

### DIFF
--- a/packages/@n8n/task-runner-python/pyproject.toml
+++ b/packages/@n8n/task-runner-python/pyproject.toml
@@ -5,7 +5,6 @@ description = "Native Python task runner for n8n"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "nanoid>=2.0.0",
     "websockets>=15.0.1",
 ]
 

--- a/packages/@n8n/task-runner-python/src/nanoid.py
+++ b/packages/@n8n/task-runner-python/src/nanoid.py
@@ -1,0 +1,21 @@
+import secrets
+import string
+
+
+NANOID_CHARSET = string.ascii_uppercase + string.ascii_lowercase + string.digits
+TARGET_NANOID_LEN = 22
+CHARSET_LEN = len(NANOID_CHARSET)
+
+# Collision probability is roughly k^2/(2n) where k=IDs generated, n=possibilities
+# At 10^12 IDs generated with 62^22 possibilities -> ~1.8e-16 chance of collision
+
+
+def nanoid() -> str:
+    nanoid = ""
+
+    while len(nanoid) < TARGET_NANOID_LEN:
+        index = secrets.randbits(6)
+        if index < CHARSET_LEN:
+            nanoid += NANOID_CHARSET[index]
+
+    return nanoid

--- a/packages/@n8n/task-runner-python/src/nanoid_utils.py
+++ b/packages/@n8n/task-runner-python/src/nanoid_utils.py
@@ -1,9 +1,0 @@
-from nanoid.generate import generate
-import string
-
-NANOID_CHARSET = string.ascii_uppercase + string.ascii_lowercase + string.digits
-NANOID_LENGTH = 21
-
-
-def nanoid() -> str:
-    return generate(NANOID_CHARSET, NANOID_LENGTH)

--- a/packages/@n8n/task-runner-python/src/task_runner.py
+++ b/packages/@n8n/task-runner-python/src/task_runner.py
@@ -13,7 +13,7 @@ from src.errors import (
     TaskMissingError,
 )
 from src.message_types.broker import TaskSettings
-from src.nanoid_utils import nanoid
+from src.nanoid import nanoid
 
 from src.constants import (
     RUNNER_NAME,

--- a/packages/@n8n/task-runner-python/uv.lock
+++ b/packages/@n8n/task-runner-python/uv.lock
@@ -3,15 +3,6 @@ revision = 3
 requires-python = ">=3.13"
 
 [[package]]
-name = "nanoid"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b7/9d/0250bf5935d88e214df469d35eccc0f6ff7e9db046fc8a9aeb4b2a192775/nanoid-2.0.0.tar.gz", hash = "sha256:5a80cad5e9c6e9ae3a41fa2fb34ae189f7cb420b2a5d8f82bd9d23466e4efa68", size = 3290, upload-time = "2018-11-20T14:45:51.578Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/0d/8630f13998638dc01e187fadd2e5c6d42d127d08aeb4943d231664d6e539/nanoid-2.0.0-py3-none-any.whl", hash = "sha256:90aefa650e328cffb0893bbd4c236cfd44c48bc1f2d0b525ecc53c3187b653bb", size = 5844, upload-time = "2018-11-20T14:45:50.165Z" },
-]
-
-[[package]]
 name = "ruff"
 version = "0.12.8"
 source = { registry = "https://pypi.org/simple" }
@@ -41,7 +32,6 @@ name = "task-runner-python"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
-    { name = "nanoid" },
     { name = "websockets" },
 ]
 
@@ -52,10 +42,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "nanoid", specifier = ">=2.0.0" },
-    { name = "websockets", specifier = ">=15.0.1" },
-]
+requires-dist = [{ name = "websockets", specifier = ">=15.0.1" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Per title