### PR TITLE
fix(editor): Fix broken project creation no-changelog

### DIFF
--- a/packages/frontend/editor-ui/src/components/Projects/ProjectNavigation.vue
+++ b/packages/frontend/editor-ui/src/components/Projects/ProjectNavigation.vue
@@ -179,7 +179,7 @@ onBeforeMount(async () => {
 				type="secondary"
 				icon="plus"
 				data-test-id="add-first-project-button"
-				@click="globalEntityCreation.createProject"
+				@click="globalEntityCreation.createProject('add_first_project_button')"
 			>
 				<span>{{ locale.baseText('projects.menu.addFirstProject') }}</span>
 			</N8nButton>


### PR DESCRIPTION
## Summary

This adds uiContext to the create project button on the empty project list state. Since no version with this problem was released, we don't need to include it in the changelog.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-3727/project-creation-broken-for-empty-projects-state

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
