### PR TITLE
fix(Data Table Node): Fix date handling on the node (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/DataTable/common/utils.ts
+++ b/packages/nodes-base/nodes/DataTable/common/utils.ts
@@ -129,6 +129,9 @@ export function dataObjectToApiInput(
 				if (isDateLike(v)) {
 					try {
 						const dateObj = new Date(v.toISOString());
+						if (isNaN(dateObj.getTime())) {
+							throw new Error('Invalid date');
+						}
 						return [k, dateObj];
 					} catch {
 						// Fall through

--- a/packages/nodes-base/nodes/DataTable/common/utils.ts
+++ b/packages/nodes-base/nodes/DataTable/common/utils.ts
@@ -1,3 +1,4 @@
+import { DateTime } from 'luxon';
 import type {
 	IDataObject,
 	INode,
@@ -6,12 +7,24 @@ import type {
 	IDataStoreProjectService,
 	IExecuteFunctions,
 	ILoadOptionsFunctions,
+	DataStoreColumnJsType,
 } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 
 import type { FieldEntry, FilterType } from './constants';
 import { ALL_FILTERS, ANY_FILTER } from './constants';
 import { DATA_TABLE_ID_FIELD } from './fields';
+
+type DateLike = { toISOString: () => string };
+
+function isDateLike(v: unknown): v is DateLike {
+	return (
+		v !== null &&
+		typeof v === 'object' &&
+		'toISOString' in v &&
+		typeof (v as { toISOString?: unknown }).toISOString === 'function'
+	);
+}
 
 // We need two functions here since the available getNodeParameter
 // overloads vary with the index
@@ -87,9 +100,13 @@ export function isFieldArray(value: unknown): value is FieldEntry[] {
 	);
 }
 
-export function dataObjectToApiInput(data: IDataObject, node: INode, row: number) {
+export function dataObjectToApiInput(
+	data: IDataObject,
+	node: INode,
+	row: number,
+): Record<string, DataStoreColumnJsType> {
 	return Object.fromEntries(
-		Object.entries(data).map(([k, v]) => {
+		Object.entries(data).map(([k, v]): [string, DataStoreColumnJsType] => {
 			if (v === undefined || v === null) return [k, null];
 
 			if (Array.isArray(v)) {
@@ -99,7 +116,25 @@ export function dataObjectToApiInput(data: IDataObject, node: INode, row: number
 				);
 			}
 
-			if (!(v instanceof Date) && typeof v === 'object') {
+			if (v instanceof Date) {
+				return [k, v];
+			}
+
+			if (typeof v === 'object') {
+				// Luxon DateTime
+				if (DateTime.isDateTime(v)) {
+					return [k, v.toJSDate()];
+				}
+
+				if (isDateLike(v)) {
+					try {
+						const dateObj = new Date(v.toISOString());
+						return [k, dateObj];
+					} catch {
+						// Fall through
+					}
+				}
+
 				throw new NodeOperationError(
 					node,
 					`unexpected object input '${JSON.stringify(v)}' in row ${row}`,

--- a/packages/nodes-base/nodes/DataTable/common/utils.ts
+++ b/packages/nodes-base/nodes/DataTable/common/utils.ts
@@ -22,7 +22,7 @@ function isDateLike(v: unknown): v is DateLike {
 		v !== null &&
 		typeof v === 'object' &&
 		'toISOString' in v &&
-		typeof (v as { toISOString?: unknown }).toISOString === 'function'
+		typeof Reflect.get(Object(v), 'toISOString') === 'function'
 	);
 }
 

--- a/packages/nodes-base/nodes/DataTable/common/utils.ts
+++ b/packages/nodes-base/nodes/DataTable/common/utils.ts
@@ -19,10 +19,7 @@ type DateLike = { toISOString: () => string };
 
 function isDateLike(v: unknown): v is DateLike {
 	return (
-		v !== null &&
-		typeof v === 'object' &&
-		'toISOString' in v &&
-		typeof Reflect.get(Object(v), 'toISOString') === 'function'
+		v !== null && typeof v === 'object' && 'toISOString' in v && typeof v.toISOString === 'function'
 	);
 }
 

--- a/packages/nodes-base/nodes/DataTable/test/common/utils.test.ts
+++ b/packages/nodes-base/nodes/DataTable/test/common/utils.test.ts
@@ -146,6 +146,18 @@ describe('dataObjectToApiInput', () => {
 			expect(() => dataObjectToApiInput(input, mockNode, 0)).toThrow('unexpected object input');
 		});
 
+		test('dataObjectToApiInput throws on invalid date-like object', () => {
+			const dateLikeObject = {
+				toISOString: () => 'not-a-date',
+			};
+			const input = { createdAt: dateLikeObject, name: 'test' };
+
+			expect(() => dataObjectToApiInput(input, mockNode, 0)).toThrow(NodeOperationError);
+			expect(() => dataObjectToApiInput(input, mockNode, 0)).toThrow(
+				"unexpected object input '{}' in row 0",
+			);
+		});
+
 		it('should include correct row number in error message', () => {
 			const input = { items: ['item1'] };
 

--- a/packages/nodes-base/nodes/DataTable/test/common/utils.test.ts
+++ b/packages/nodes-base/nodes/DataTable/test/common/utils.test.ts
@@ -1,0 +1,191 @@
+import { DateTime } from 'luxon';
+import type { INode } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
+
+import { dataObjectToApiInput } from '../../common/utils';
+
+describe('dataObjectToApiInput', () => {
+	const mockNode: INode = {
+		id: 'test-node',
+		name: 'Test Node',
+		type: 'test',
+		typeVersion: 1,
+		position: [0, 0],
+		parameters: {},
+	};
+
+	describe('primitive types', () => {
+		it('should handle string values', () => {
+			const input = { name: 'John', email: 'john@example.com' };
+			const result = dataObjectToApiInput(input, mockNode, 0);
+
+			expect(result).toEqual({
+				name: 'John',
+				email: 'john@example.com',
+			});
+		});
+
+		it('should handle number values', () => {
+			const input = { age: 25, price: 99.99, count: 0 };
+			const result = dataObjectToApiInput(input, mockNode, 0);
+
+			expect(result).toEqual({
+				age: 25,
+				price: 99.99,
+				count: 0,
+			});
+		});
+
+		it('should handle boolean values', () => {
+			const input = { isActive: true, isDeleted: false };
+			const result = dataObjectToApiInput(input, mockNode, 0);
+
+			expect(result).toEqual({
+				isActive: true,
+				isDeleted: false,
+			});
+		});
+	});
+
+	describe('null and undefined values', () => {
+		it('should convert null values to null', () => {
+			const input = { field1: null, field2: 'value' };
+			const result = dataObjectToApiInput(input, mockNode, 0);
+
+			expect(result).toEqual({
+				field1: null,
+				field2: 'value',
+			});
+		});
+
+		it('should convert undefined values to null', () => {
+			const input = { field1: undefined, field2: 'value' };
+			const result = dataObjectToApiInput(input, mockNode, 0);
+
+			expect(result).toEqual({
+				field1: null,
+				field2: 'value',
+			});
+		});
+	});
+
+	describe('Date objects', () => {
+		it('should handle JavaScript Date objects', () => {
+			const testDate = new Date('2025-09-01T12:00:00.000Z');
+			const input = { createdAt: testDate, name: 'test' };
+			const result = dataObjectToApiInput(input, mockNode, 0);
+
+			expect(result).toEqual({
+				createdAt: testDate,
+				name: 'test',
+			});
+		});
+	});
+
+	describe('Luxon DateTime objects', () => {
+		it('should convert Luxon DateTime objects to JavaScript Date', () => {
+			const luxonDateTime = DateTime.fromISO('2025-09-01T12:00:00.000Z');
+			const input = { createdAt: luxonDateTime, name: 'test' };
+			const result = dataObjectToApiInput(input, mockNode, 0);
+
+			expect(result.name).toBe('test');
+			expect(result.createdAt).toBeInstanceOf(Date);
+			expect((result.createdAt as Date).toISOString()).toBe('2025-09-01T12:00:00.000Z');
+		});
+	});
+
+	describe('date-like objects', () => {
+		it('should convert objects with toISOString method to Date', () => {
+			const dateLikeObject = {
+				toISOString: () => '2025-09-01T12:00:00.000Z',
+			};
+			const input = { createdAt: dateLikeObject, name: 'test' };
+			const result = dataObjectToApiInput(input, mockNode, 0);
+
+			expect(result.name).toBe('test');
+			expect(result.createdAt).toBeInstanceOf(Date);
+			expect((result.createdAt as Date).toISOString()).toBe('2025-09-01T12:00:00.000Z');
+		});
+
+		it('should handle date-like objects where toISOString throws', () => {
+			const dateLikeObject = {
+				toISOString: () => {
+					throw new Error('toISOString failed');
+				},
+			};
+			const input = { createdAt: dateLikeObject, name: 'test' };
+
+			expect(() => dataObjectToApiInput(input, mockNode, 0)).toThrow(NodeOperationError);
+			expect(() => dataObjectToApiInput(input, mockNode, 0)).toThrow('unexpected object input');
+		});
+	});
+
+	describe('error cases', () => {
+		it('should throw error for array inputs', () => {
+			const input = { items: ['item1', 'item2'] };
+
+			expect(() => dataObjectToApiInput(input, mockNode, 0)).toThrow(NodeOperationError);
+			expect(() => dataObjectToApiInput(input, mockNode, 0)).toThrow(
+				'unexpected array input \'["item1","item2"]\' in row 0',
+			);
+		});
+
+		it('should throw error for plain objects', () => {
+			const input = { metadata: { key: 'value' } };
+
+			expect(() => dataObjectToApiInput(input, mockNode, 0)).toThrow(NodeOperationError);
+			expect(() => dataObjectToApiInput(input, mockNode, 0)).toThrow(
+				'unexpected object input \'{"key":"value"}\' in row 0',
+			);
+		});
+
+		it('should throw error for objects without toISOString method', () => {
+			const input = { config: { setting1: true, setting2: 'value' } };
+
+			expect(() => dataObjectToApiInput(input, mockNode, 0)).toThrow(NodeOperationError);
+			expect(() => dataObjectToApiInput(input, mockNode, 0)).toThrow('unexpected object input');
+		});
+
+		it('should include correct row number in error message', () => {
+			const input = { items: ['item1'] };
+
+			expect(() => dataObjectToApiInput(input, mockNode, 5)).toThrow(
+				'unexpected array input \'["item1"]\' in row 5',
+			);
+		});
+	});
+
+	describe('mixed data types', () => {
+		it('should handle mixed valid data types', () => {
+			const testDate = new Date('2025-09-01T12:00:00.000Z');
+			const luxonDateTime = DateTime.fromISO('2025-09-02T10:30:00.000Z');
+			const dateLikeObject = {
+				toISOString: () => '2025-09-03T08:15:00.000Z',
+			};
+
+			const input = {
+				name: 'John Doe',
+				age: 30,
+				isActive: true,
+				createdAt: testDate,
+				updatedAt: luxonDateTime,
+				scheduledAt: dateLikeObject,
+				deletedAt: null,
+				description: undefined,
+			};
+
+			const result = dataObjectToApiInput(input, mockNode, 0);
+
+			expect(result.name).toBe('John Doe');
+			expect(result.age).toBe(30);
+			expect(result.isActive).toBe(true);
+			expect(result.createdAt).toBe(testDate);
+			expect(result.updatedAt).toBeInstanceOf(Date);
+			expect((result.updatedAt as Date).toISOString()).toBe('2025-09-02T10:30:00.000Z');
+			expect(result.scheduledAt).toBeInstanceOf(Date);
+			expect((result.scheduledAt as Date).toISOString()).toBe('2025-09-03T08:15:00.000Z');
+			expect(result.deletedAt).toBe(null);
+			expect(result.description).toBe(null);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

When selecting a date time through a date picker on the node, we're getting a Luxon Datetime which is not an instance of `Date` expected by backend. We're now converting it to a JS Date. Also, we're not throwing an error for JS dates anymore.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4050/fix-problem-with-date-operations-on-the-node

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
