### PR TITLE
fix(Data Table Node): Use same color as Execute Workflow Node (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/DataTable/DataTable.node.ts
+++ b/packages/nodes-base/nodes/DataTable/DataTable.node.ts
@@ -15,7 +15,7 @@ export class DataTable implements INodeType {
 		displayName: 'Data Table',
 		name: 'dataTable',
 		icon: 'fa:table',
-		iconColor: 'orange',
+		iconColor: 'orange-red',
 		group: ['input', 'transform'],
 		version: 1,
 		subtitle: '={{$parameter["action"]}}',


### PR DESCRIPTION
## Summary

Align color with ExecuteWorkflow node per suggestion

## Related Linear tickets, Github issues, and Community forum posts

https://www.notion.so/n8n/Icon-for-datatable-same-color-as-sub-workflow-25e5b6e0c94f80cc9130e56beccb8930?source=copy_link


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
