### PR TITLE
fix: Update packages in base image to resolve CVE-2025-58050

### DIFF
--- a/docker/images/n8n-base/Dockerfile
+++ b/docker/images/n8n-base/Dockerfile
@@ -14,7 +14,7 @@ RUN \
   find /usr/share/fonts/truetype/msttcorefonts/ -type l -exec unlink {} \;
 
 # Install essential OS dependencies
-RUN echo "http://dl-cdn.alpinelinux.org/alpine/v3.22/main" >> /etc/apk/repositories && \
+RUN echo "https://dl-cdn.alpinelinux.org/alpine/v3.22/main" >> /etc/apk/repositories && echo "https://dl-cdn.alpinelinux.org/alpine/v3.22/community" >> /etc/apk/repositories && \
     apk update && \
     apk add --no-cache \
         git \

--- a/docker/images/n8n-base/Dockerfile
+++ b/docker/images/n8n-base/Dockerfile
@@ -13,24 +13,22 @@ RUN \
   apk del .build-deps-fonts && \
   find /usr/share/fonts/truetype/msttcorefonts/ -type l -exec unlink {} \;
 
-# Install essential OS dependencies with pinned versions
-RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
+# Install essential OS dependencies
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/v3.22/main" >> /etc/apk/repositories && \
     apk update && \
-    apk upgrade && \
     apk add --no-cache \
-        git=2.50.1-r0 \
-        openssh=10.0_p1-r7 \
-        openssl=3.5.1-r0 \
-        graphicsmagick=1.3.45-r0 \
-        tini=0.19.0-r3 \
-        tzdata=2025b-r0 \
-        ca-certificates=20241121-r2 \
-        libc6-compat=1.1.0-r4 \
-        jq=1.8.0-r0
+        git \
+        openssh \
+        openssl \
+        graphicsmagick \
+        tini \
+        tzdata \
+        ca-certificates \
+        libc6-compat \
+        jq
 
-# Update npm, install full-icu and npm@11.4.2 to fix brace-expansion vulnerability
-# Remove npm update after vulnerability is fixed in in node image
-RUN npm install -g full-icu@1.5.0 npm@11.4.2
+# Install full-icu
+RUN npm install -g full-icu@1.5.0
 
 RUN rm -rf /tmp/* /root/.npm /root/.cache/node /opt/yarn* && \
   apk del apk-tools

--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -62,8 +62,6 @@ RUN cd /usr/local/lib/node_modules/n8n && \
     mkdir -p /home/node/.n8n && \
     chown -R node:node /home/node
 
-# Install npm@11.4.2 to fix brace-expansion vulnerability, remove after vulnerability is fixed in node image
-RUN npm install -g npm@11.4.2
 RUN cd /usr/local/lib/node_modules/n8n/node_modules/pdfjs-dist && npm install @napi-rs/canvas
 
 EXPOSE 5678/tcp


### PR DESCRIPTION

## Summary

Update base image to 3.22 stable to pull in latest CVE fixes.

This fixes: CVE-2025-58050


Removes update npm call as the brace-expansion vuln has been fixed


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1283/trivy-scan-0-critical-0-high-1-medium-0-low-vulnerabilities-found-in

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
