### PR TITLE
fix(Data Table Node): Remove system columns in autoMap mode (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/DataTable/common/addRow.ts
+++ b/packages/nodes-base/nodes/DataTable/common/addRow.ts
@@ -1,8 +1,9 @@
-import type {
-	IDataObject,
-	IDisplayOptions,
-	IExecuteFunctions,
-	INodeProperties,
+import {
+	DATA_TABLE_SYSTEM_COLUMNS,
+	type IDataObject,
+	type IDisplayOptions,
+	type IExecuteFunctions,
+	type INodeProperties,
 } from 'n8n-workflow';
 
 import { DATA_TABLE_ID_FIELD } from './fields';
@@ -44,7 +45,12 @@ export function getAddRow(ctx: IExecuteFunctions, index: number) {
 	let data: IDataObject;
 
 	if (dataMode === 'autoMapInputData') {
-		data = items[index].json;
+		data = { ...items[index].json };
+		// We automatically remove our system columns for better UX when feeding Data Table outputs
+		// into another Data Table node
+		for (const systemColumn of DATA_TABLE_SYSTEM_COLUMNS) {
+			delete data[systemColumn];
+		}
 	} else {
 		const fields = ctx.getNodeParameter('columns.value', index, {}) as IDataObject;
 


### PR DESCRIPTION
## Summary

Passing these columns into the node will always error, we should ideally warn if these are present but for now let's just remove them if they exist to make the UX of chaining DT nodes better.

## Related Linear tickets, Github issues, and Community forum posts

https://www.notion.so/n8n/Error-sending-id-via-upsert-or-update-25e5b6e0c94f80449cadf4227e4aaa56?source=copy_link


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
