### PR TITLE
feat(Data Table Node): Add isEmpty and isNotEmpty operations (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/DataTable/common/constants.ts
+++ b/packages/nodes-base/nodes/DataTable/common/constants.ts
@@ -5,18 +5,13 @@ export const ALL_FILTERS = 'allFilters';
 
 export type FilterType = typeof ANY_FILTER | typeof ALL_FILTERS;
 
-export type FieldEntry = {
-	keyName: string;
-	condition:
-		| 'eq'
-		| 'neq'
-		| 'like'
-		| 'ilike'
-		| 'gt'
-		| 'gte'
-		| 'lt'
-		| 'lte'
-		| 'isEmpty'
-		| 'isNotEmpty';
-	keyValue?: DataStoreColumnJsType;
-};
+export type FieldEntry =
+	| {
+			keyName: string;
+			condition: 'isEmpty' | 'isNotEmpty';
+	  }
+	| {
+			keyName: string;
+			condition: 'eq' | 'neq' | 'like' | 'ilike' | 'gt' | 'gte' | 'lt' | 'lte';
+			keyValue: DataStoreColumnJsType;
+	  };

--- a/packages/nodes-base/nodes/DataTable/common/constants.ts
+++ b/packages/nodes-base/nodes/DataTable/common/constants.ts
@@ -7,6 +7,16 @@ export type FilterType = typeof ANY_FILTER | typeof ALL_FILTERS;
 
 export type FieldEntry = {
 	keyName: string;
-	condition: 'eq' | 'neq' | 'like' | 'ilike' | 'gt' | 'gte' | 'lt' | 'lte';
-	keyValue: DataStoreColumnJsType;
+	condition:
+		| 'eq'
+		| 'neq'
+		| 'like'
+		| 'ilike'
+		| 'gt'
+		| 'gte'
+		| 'lt'
+		| 'lte'
+		| 'isEmpty'
+		| 'isNotEmpty';
+	keyValue?: DataStoreColumnJsType;
 };

--- a/packages/nodes-base/nodes/DataTable/common/methods.ts
+++ b/packages/nodes-base/nodes/DataTable/common/methods.ts
@@ -75,6 +75,8 @@ export async function getConditionsForColumn(this: ILoadOptionsFunctions) {
 	const baseConditions: INodePropertyOptions[] = [
 		{ name: 'Equals', value: 'eq' },
 		{ name: 'Not Equals', value: 'neq' },
+		{ name: 'Is Empty', value: 'isEmpty' },
+		{ name: 'Is Not Empty', value: 'isNotEmpty' },
 	];
 
 	const comparableConditions: INodePropertyOptions[] = [

--- a/packages/nodes-base/nodes/DataTable/common/selectMany.ts
+++ b/packages/nodes-base/nodes/DataTable/common/selectMany.ts
@@ -78,6 +78,11 @@ export function getSelectFields(
 							name: 'keyValue',
 							type: 'string',
 							default: '',
+							displayOptions: {
+								hide: {
+									condition: ['isEmpty', 'isNotEmpty'],
+								},
+							},
 						},
 					],
 				},
@@ -89,16 +94,17 @@ export function getSelectFields(
 
 export function getSelectFilter(ctx: IExecuteFunctions, index: number) {
 	const fields = ctx.getNodeParameter('filters.conditions', index, []);
-	const matchType = ctx.getNodeParameter('matchType', index, []);
+	const matchType = ctx.getNodeParameter('matchType', index, 'anyFilter');
+	const node = ctx.getNode();
 
 	if (!isMatchType(matchType)) {
-		throw new NodeOperationError(ctx.getNode(), 'unexpected match type');
+		throw new NodeOperationError(node, 'unexpected match type');
 	}
 	if (!isFieldArray(fields)) {
-		throw new NodeOperationError(ctx.getNode(), 'unexpected fields input');
+		throw new NodeOperationError(node, 'unexpected fields input');
 	}
 
-	return buildGetManyFilter(fields, matchType);
+	return buildGetManyFilter(fields, matchType, node);
 }
 
 export async function executeSelectMany(

--- a/packages/nodes-base/nodes/DataTable/common/selectMany.ts
+++ b/packages/nodes-base/nodes/DataTable/common/selectMany.ts
@@ -104,7 +104,7 @@ export function getSelectFilter(ctx: IExecuteFunctions, index: number) {
 		throw new NodeOperationError(node, 'unexpected fields input');
 	}
 
-	return buildGetManyFilter(fields, matchType, node);
+	return buildGetManyFilter(fields, matchType);
 }
 
 export async function executeSelectMany(

--- a/packages/nodes-base/nodes/DataTable/common/utils.ts
+++ b/packages/nodes-base/nodes/DataTable/common/utils.ts
@@ -82,36 +82,28 @@ export function isMatchType(obj: unknown): obj is FilterType {
 export function buildGetManyFilter(
 	fieldEntries: FieldEntry[],
 	matchType: FilterType,
-	node: INode,
 ): ListDataStoreContentFilter {
 	const filters = fieldEntries.map((x) => {
-		if (x.condition === 'isEmpty') {
-			return {
-				columnName: x.keyName,
-				condition: 'eq' as const,
-				value: null,
-			};
+		switch (x.condition) {
+			case 'isEmpty':
+				return {
+					columnName: x.keyName,
+					condition: 'eq' as const,
+					value: null,
+				};
+			case 'isNotEmpty':
+				return {
+					columnName: x.keyName,
+					condition: 'neq' as const,
+					value: null,
+				};
+			default:
+				return {
+					columnName: x.keyName,
+					condition: x.condition,
+					value: x.keyValue,
+				};
 		}
-		if (x.condition === 'isNotEmpty') {
-			return {
-				columnName: x.keyName,
-				condition: 'neq' as const,
-				value: null,
-			};
-		}
-
-		if (x.keyValue === undefined) {
-			throw new NodeOperationError(
-				node,
-				`Condition '${x.condition}' requires a value for column '${x.keyName}'`,
-			);
-		}
-
-		return {
-			columnName: x.keyName,
-			condition: x.condition,
-			value: x.keyValue,
-		};
 	});
 	return { type: matchType === 'allFilters' ? 'and' : 'or', filters };
 }

--- a/packages/nodes-base/nodes/DataTable/test/common/utils.test.ts
+++ b/packages/nodes-base/nodes/DataTable/test/common/utils.test.ts
@@ -206,7 +206,7 @@ describe('buildGetManyFilter - isEmpty/isNotEmpty translation', () => {
 	it('should translate isEmpty to eq with null value', () => {
 		const fieldEntries = [{ keyName: 'name', condition: 'isEmpty' as const, keyValue: 'ignored' }];
 
-		const result = buildGetManyFilter(fieldEntries, 'allFilters', mockNode);
+		const result = buildGetManyFilter(fieldEntries, 'allFilters');
 
 		expect(result).toEqual({
 			type: 'and',
@@ -225,7 +225,7 @@ describe('buildGetManyFilter - isEmpty/isNotEmpty translation', () => {
 			{ keyName: 'email', condition: 'isNotEmpty' as const, keyValue: 'ignored' },
 		];
 
-		const result = buildGetManyFilter(fieldEntries, 'anyFilter', mockNode);
+		const result = buildGetManyFilter(fieldEntries, 'anyFilter');
 
 		expect(result).toEqual({
 			type: 'or',
@@ -246,7 +246,7 @@ describe('buildGetManyFilter - isEmpty/isNotEmpty translation', () => {
 			{ keyName: 'phone', condition: 'isNotEmpty' as const, keyValue: 'ignored' },
 		];
 
-		const result = buildGetManyFilter(fieldEntries, 'allFilters', mockNode);
+		const result = buildGetManyFilter(fieldEntries, 'allFilters');
 
 		expect(result).toEqual({
 			type: 'and',
@@ -276,7 +276,7 @@ describe('buildGetManyFilter - isEmpty/isNotEmpty translation', () => {
 			{ keyName: 'name', condition: 'like' as const, keyValue: '%john%' },
 		];
 
-		const result = buildGetManyFilter(fieldEntries, 'anyFilter', mockNode);
+		const result = buildGetManyFilter(fieldEntries, 'anyFilter');
 
 		expect(result).toEqual({
 			type: 'or',
@@ -293,18 +293,5 @@ describe('buildGetManyFilter - isEmpty/isNotEmpty translation', () => {
 				},
 			],
 		});
-	});
-
-	it('should throw error when keyValue is undefined for conditions that require it', () => {
-		const fieldEntries = [
-			{ keyName: 'name', condition: 'eq' as const }, // keyValue is undefined
-		];
-
-		expect(() => buildGetManyFilter(fieldEntries, 'allFilters', mockNode)).toThrow(
-			NodeOperationError,
-		);
-		expect(() => buildGetManyFilter(fieldEntries, 'allFilters', mockNode)).toThrow(
-			"Condition 'eq' requires a value for column 'name'",
-		);
 	});
 });

--- a/packages/nodes-base/nodes/DataTable/test/common/utils.test.ts
+++ b/packages/nodes-base/nodes/DataTable/test/common/utils.test.ts
@@ -2,18 +2,18 @@ import { DateTime } from 'luxon';
 import type { INode } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 
-import { dataObjectToApiInput } from '../../common/utils';
+import { dataObjectToApiInput, buildGetManyFilter } from '../../common/utils';
+
+const mockNode: INode = {
+	id: 'test-node',
+	name: 'Test Node',
+	type: 'test',
+	typeVersion: 1,
+	position: [0, 0],
+	parameters: {},
+};
 
 describe('dataObjectToApiInput', () => {
-	const mockNode: INode = {
-		id: 'test-node',
-		name: 'Test Node',
-		type: 'test',
-		typeVersion: 1,
-		position: [0, 0],
-		parameters: {},
-	};
-
 	describe('primitive types', () => {
 		it('should handle string values', () => {
 			const input = { name: 'John', email: 'john@example.com' };
@@ -199,5 +199,112 @@ describe('dataObjectToApiInput', () => {
 			expect(result.deletedAt).toBe(null);
 			expect(result.description).toBe(null);
 		});
+	});
+});
+
+describe('buildGetManyFilter - isEmpty/isNotEmpty translation', () => {
+	it('should translate isEmpty to eq with null value', () => {
+		const fieldEntries = [{ keyName: 'name', condition: 'isEmpty' as const, keyValue: 'ignored' }];
+
+		const result = buildGetManyFilter(fieldEntries, 'allFilters', mockNode);
+
+		expect(result).toEqual({
+			type: 'and',
+			filters: [
+				{
+					columnName: 'name',
+					condition: 'eq',
+					value: null,
+				},
+			],
+		});
+	});
+
+	it('should translate isNotEmpty to neq with null value', () => {
+		const fieldEntries = [
+			{ keyName: 'email', condition: 'isNotEmpty' as const, keyValue: 'ignored' },
+		];
+
+		const result = buildGetManyFilter(fieldEntries, 'anyFilter', mockNode);
+
+		expect(result).toEqual({
+			type: 'or',
+			filters: [
+				{
+					columnName: 'email',
+					condition: 'neq',
+					value: null,
+				},
+			],
+		});
+	});
+
+	it('should handle mixed conditions including isEmpty/isNotEmpty', () => {
+		const fieldEntries = [
+			{ keyName: 'name', condition: 'eq' as const, keyValue: 'John' },
+			{ keyName: 'email', condition: 'isEmpty' as const, keyValue: 'ignored' },
+			{ keyName: 'phone', condition: 'isNotEmpty' as const, keyValue: 'ignored' },
+		];
+
+		const result = buildGetManyFilter(fieldEntries, 'allFilters', mockNode);
+
+		expect(result).toEqual({
+			type: 'and',
+			filters: [
+				{
+					columnName: 'name',
+					condition: 'eq',
+					value: 'John',
+				},
+				{
+					columnName: 'email',
+					condition: 'eq',
+					value: null,
+				},
+				{
+					columnName: 'phone',
+					condition: 'neq',
+					value: null,
+				},
+			],
+		});
+	});
+
+	it('should preserve existing conditions unchanged', () => {
+		const fieldEntries = [
+			{ keyName: 'age', condition: 'gt' as const, keyValue: 18 },
+			{ keyName: 'name', condition: 'like' as const, keyValue: '%john%' },
+		];
+
+		const result = buildGetManyFilter(fieldEntries, 'anyFilter', mockNode);
+
+		expect(result).toEqual({
+			type: 'or',
+			filters: [
+				{
+					columnName: 'age',
+					condition: 'gt',
+					value: 18,
+				},
+				{
+					columnName: 'name',
+					condition: 'like',
+					value: '%john%',
+				},
+			],
+		});
+	});
+
+	it('should throw error when keyValue is undefined for conditions that require it', () => {
+		const fieldEntries = [
+			{ keyName: 'name', condition: 'eq' as const }, // keyValue is undefined
+		];
+
+		expect(() => buildGetManyFilter(fieldEntries, 'allFilters', mockNode)).toThrow(
+			NodeOperationError,
+		);
+		expect(() => buildGetManyFilter(fieldEntries, 'allFilters', mockNode)).toThrow(
+			"Condition 'eq' requires a value for column 'name'",
+		);
 	});
 });


### PR DESCRIPTION
## Summary

Add new operations to Data Table Node to deal with nulls:
- Is Empty = equals `null`
- Is Not Empty = not equals `null`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4052/add-is-empty-and-is-not-empty-operations-to-the-node

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
