### PR TITLE
chore: Remove "User added action" telemetry event

### DIFF
--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/composables/useActions.ts
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/composables/useActions.ts
@@ -397,7 +397,6 @@ export const useActions = () => {
 			resource: (action.value as INodeParameters).resource || '',
 		};
 		void useExternalHooks().run('nodeCreateList.addAction', payload);
-		useNodeCreatorStore().onAddActions(payload);
 	}
 
 	return {

--- a/packages/frontend/editor-ui/src/stores/nodeCreator.store.test.ts
+++ b/packages/frontend/editor-ui/src/stores/nodeCreator.store.test.ts
@@ -21,9 +21,6 @@ const node_type = 'node-type';
 const node_id = 'node-id';
 const node_version = 1;
 const input_node_type = 'input-node-type';
-const action = 'action';
-const source_mode = 'source-mode';
-const resource = 'resource';
 const actions = ['action1'];
 
 vi.mock('@/composables/useTelemetry', () => {

--- a/packages/frontend/editor-ui/src/stores/nodeCreator.store.test.ts
+++ b/packages/frontend/editor-ui/src/stores/nodeCreator.store.test.ts
@@ -162,28 +162,6 @@ describe('useNodeCreatorStore', () => {
 		});
 	});
 
-	it('tracks event when action is added', () => {
-		nodeCreatorStore.onCreatorOpened({
-			source,
-			mode,
-			workflow_id,
-		});
-		nodeCreatorStore.onAddActions({
-			node_type,
-			action,
-			source_mode,
-			resource,
-		});
-
-		expect(useTelemetry().track).toHaveBeenCalledWith('User added action', {
-			node_type,
-			action,
-			source_mode,
-			resource,
-			nodes_panel_session_id: getSessionId(now),
-		});
-	});
-
 	it('tracks when custom api action is clicked', () => {
 		nodeCreatorStore.onCreatorOpened({
 			source,

--- a/packages/frontend/editor-ui/src/stores/nodeCreator.store.ts
+++ b/packages/frontend/editor-ui/src/stores/nodeCreator.store.ts
@@ -23,7 +23,6 @@ import { transformNodeType } from '@/components/Node/NodeCreator/utils';
 import type {
 	IDataObject,
 	INodeInputConfiguration,
-	NodeParameterValueType,
 	NodeConnectionType,
 	Workflow,
 } from 'n8n-workflow';
@@ -391,15 +390,6 @@ export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, () => {
 		trackNodeCreatorEvent('User clicked custom API from node actions', properties);
 	}
 
-	function onAddActions(properties: {
-		node_type?: string;
-		action: string;
-		source_mode: string;
-		resource: NodeParameterValueType;
-	}) {
-		trackNodeCreatorEvent('User added action', properties);
-	}
-
 	function onSubcategorySelected(properties: { subcategory: string }) {
 		trackNodeCreatorEvent('User viewed node category', {
 			category_name: properties.subcategory,
@@ -459,7 +449,6 @@ export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, () => {
 		onCategoryExpanded,
 		onActionsCustomAPIClicked,
 		onViewActions,
-		onAddActions,
 		onSubcategorySelected,
 		onNodeAddedToCanvas,
 	};


### PR DESCRIPTION
## Summary
Remove "User added action" telemetry event because it's duplicated by "user added node to workflow canvas"

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
