### PR TITLE
fix(Basic LLM Chain Node): Remove fallback connection on lower versions

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/config.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/config.ts
@@ -25,7 +25,7 @@ export function getInputs(parameters: IDataObject) {
 
 	const needsFallback = parameters?.needsFallback;
 
-	if (needsFallback === undefined || needsFallback === true) {
+	if (needsFallback === true) {
 		inputs.push({
 			displayName: 'Fallback Model',
 			maxConnections: 1,

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/config.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/config.test.ts
@@ -7,27 +7,25 @@ describe('config', () => {
 		it('should return basic inputs for all parameters', () => {
 			const inputs = getInputs({});
 
-			expect(inputs).toHaveLength(4);
+			expect(inputs).toHaveLength(3);
 			expect(inputs[0].type).toBe(NodeConnectionTypes.Main);
 			expect(inputs[1].type).toBe(NodeConnectionTypes.AiLanguageModel);
-			expect(inputs[2].type).toBe(NodeConnectionTypes.AiLanguageModel);
-			expect(inputs[3].type).toBe(NodeConnectionTypes.AiOutputParser);
+			expect(inputs[2].type).toBe(NodeConnectionTypes.AiOutputParser);
 		});
 
 		it('should exclude the OutputParser when hasOutputParser is false', () => {
 			const inputs = getInputs({ hasOutputParser: false });
 
-			expect(inputs).toHaveLength(3);
+			expect(inputs).toHaveLength(2);
 			expect(inputs[0].type).toBe(NodeConnectionTypes.Main);
 			expect(inputs[1].type).toBe(NodeConnectionTypes.AiLanguageModel);
-			expect(inputs[2].type).toBe(NodeConnectionTypes.AiLanguageModel);
 		});
 
 		it('should include the OutputParser when hasOutputParser is true', () => {
 			const inputs = getInputs({ hasOutputParser: true });
 
-			expect(inputs).toHaveLength(4);
-			expect(inputs[3].type).toBe(NodeConnectionTypes.AiOutputParser);
+			expect(inputs).toHaveLength(3);
+			expect(inputs[2].type).toBe(NodeConnectionTypes.AiOutputParser);
 		});
 
 		it('should exclude the FallbackInput when needsFallback is false', () => {


### PR DESCRIPTION
## Summary
Removes the mandatory fallback connection on node versions that don't have a fallback property. 


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
