### PR TITLE
fix(core): Set more reasonable defaults for scaling mode queue lock

### DIFF
--- a/packages/@n8n/config/src/configs/scaling-mode.config.ts
+++ b/packages/@n8n/config/src/configs/scaling-mode.config.ts
@@ -62,11 +62,11 @@ class RedisConfig {
 class SettingsConfig {
 	/** How long (in milliseconds) is the lease period for a worker processing a job. */
 	@Env('QUEUE_WORKER_LOCK_DURATION')
-	lockDuration: number = 30_000;
+	lockDuration: number = 60_000;
 
 	/** How often (in milliseconds) a worker must renew the lease. */
 	@Env('QUEUE_WORKER_LOCK_RENEW_TIME')
-	lockRenewTime: number = 15_000;
+	lockRenewTime: number = 10_000;
 
 	/** How often (in milliseconds) Bull must check for stalled jobs. `0` to disable. */
 	@Env('QUEUE_WORKER_STALLED_INTERVAL')

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -234,8 +234,8 @@ describe('GlobalConfig', () => {
 				gracefulShutdownTimeout: 30,
 				prefix: 'bull',
 				settings: {
-					lockDuration: 30_000,
-					lockRenewTime: 15_000,
+					lockDuration: 60_000,
+					lockRenewTime: 10_000,
 					stalledInterval: 30_000,
 					maxStalledCount: 1,
 				},


### PR DESCRIPTION

## Summary

In scaling mode, `bull` uses a lock to reserve the job for a specific worker. The lock has an expiration time that is used to detect worker crashes and stalls. The default values for the lock duration are 30s and by default it's renewed every 15s (in practice longer due to the renewal is scheduled only after the new lock has been acquired).

It has been noticed that under heavy load workers might not be able to renew the lock during that time, which causes `Queue errored` and `Missing lock` errors. Depending on the `QUEUE_WORKER_MAX_STALLED_COUNT` value, this might also cause `bull` to retry the workflow execution.

This PR increases the defaults from 30s and 15s to 60s and 10s. This gives workers more leeway to renew the lock during heavy load.

It would also make sense to change the default of `QUEUE_WORKER_MAX_STALLED_COUNT` to 0, or remove it altogether, but we probably have to do that in v2.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1269/multiple-workflows-getting-executed-twice


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
