### PR TITLE
ci: Add retry to docker pull to allow for manifest to propagate in release job

### DIFF
--- a/.github/workflows/security-trivy-scan-callable.yml
+++ b/.github/workflows/security-trivy-scan-callable.yml
@@ -29,6 +29,13 @@ jobs:
     name: Security - Scan Docker Image With Trivy
     runs-on: ubuntu-latest
     steps:
+      - name: Pull Docker image with retry
+        run: |
+          for i in {1..4}; do
+            docker pull "${{ inputs.image_ref }}" && break
+            [ "$i" -lt 4 ] && echo "Retry $i failed, waiting..." && sleep 15
+          done
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4 # v0.32.0
         id: trivy_scan


### PR DESCRIPTION
## Summary

Workaround for race condition in [release-publish.yml](https://github.com/n8n-io/n8n/blob/master/.github/workflows/release-publish.yml) for Trivy scan of Docker image.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1282/fix-trivy-scan-step-for-docker-image-in-release-job


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
