### PR TITLE
fix(core): Ensure getNodeOutputs always returns an array

### DIFF
--- a/packages/workflow/src/node-helpers.ts
+++ b/packages/workflow/src/node-helpers.ts
@@ -1035,32 +1035,6 @@ export function getNodeInputs(
 	}
 }
 
-/**
- * Type guard to validate that a value is a valid outputs array
- */
-function isValidOutputsArray(
-	value: unknown,
-): value is Array<NodeConnectionType | INodeOutputConfiguration> {
-	if (!Array.isArray(value)) {
-		return false;
-	}
-
-	return value.every((item) => {
-		// Check if item is a string (NodeConnectionType)
-		if (typeof item === 'string') {
-			return true;
-		}
-
-		// Check if item is an INodeOutputConfiguration object
-		if (typeof item === 'object' && item !== null && 'type' in item) {
-			const potentialConfig = item as Record<string, unknown>;
-			return typeof potentialConfig.type === 'string';
-		}
-
-		return false;
-	});
-}
-
 export function getNodeOutputs(
 	workflow: Workflow,
 	node: INode,
@@ -1079,7 +1053,9 @@ export function getNodeOutputs(
 				'internal',
 				{},
 			);
-			outputs = isValidOutputsArray(result) ? result : [];
+			outputs = Array.isArray(result)
+				? (result as Array<NodeConnectionType | INodeOutputConfiguration>)
+				: [];
 		} catch (e) {
 			console.warn('Could not calculate outputs dynamically for node: ', node.name);
 		}

--- a/packages/workflow/src/node-helpers.ts
+++ b/packages/workflow/src/node-helpers.ts
@@ -1035,6 +1035,32 @@ export function getNodeInputs(
 	}
 }
 
+/**
+ * Type guard to validate that a value is a valid outputs array
+ */
+function isValidOutputsArray(
+	value: unknown,
+): value is Array<NodeConnectionType | INodeOutputConfiguration> {
+	if (!Array.isArray(value)) {
+		return false;
+	}
+
+	return value.every((item) => {
+		// Check if item is a string (NodeConnectionType)
+		if (typeof item === 'string') {
+			return true;
+		}
+
+		// Check if item is an INodeOutputConfiguration object
+		if (typeof item === 'object' && item !== null && 'type' in item) {
+			const potentialConfig = item as Record<string, unknown>;
+			return typeof potentialConfig.type === 'string';
+		}
+
+		return false;
+	});
+}
+
 export function getNodeOutputs(
 	workflow: Workflow,
 	node: INode,
@@ -1053,9 +1079,7 @@ export function getNodeOutputs(
 				'internal',
 				{},
 			);
-			outputs = Array.isArray(result)
-				? (result as Array<NodeConnectionType | INodeOutputConfiguration>)
-				: [];
+			outputs = isValidOutputsArray(result) ? result : [];
 		} catch (e) {
 			console.warn('Could not calculate outputs dynamically for node: ', node.name);
 		}
@@ -1082,11 +1106,6 @@ export function getNodeOutputs(
 				displayName: 'Error',
 			},
 		];
-	}
-
-	// Ensure we always return an array
-	if (!Array.isArray(outputs)) {
-		outputs = [];
 	}
 
 	return outputs;

--- a/packages/workflow/src/node-helpers.ts
+++ b/packages/workflow/src/node-helpers.ts
@@ -1047,12 +1047,13 @@ export function getNodeOutputs(
 	} else {
 		// Calculate the outputs dynamically
 		try {
-			outputs = (workflow.expression.getSimpleParameterValue(
+			const result = workflow.expression.getSimpleParameterValue(
 				node,
 				nodeTypeData.outputs,
 				'internal',
 				{},
-			) || []) as NodeConnectionType[];
+			);
+			outputs = Array.isArray(result) ? result : [];
 		} catch (e) {
 			console.warn('Could not calculate outputs dynamically for node: ', node.name);
 		}
@@ -1079,6 +1080,11 @@ export function getNodeOutputs(
 				displayName: 'Error',
 			},
 		];
+	}
+
+	// Ensure we always return an array
+	if (!Array.isArray(outputs)) {
+		outputs = [];
 	}
 
 	return outputs;

--- a/packages/workflow/src/node-helpers.ts
+++ b/packages/workflow/src/node-helpers.ts
@@ -1053,7 +1053,9 @@ export function getNodeOutputs(
 				'internal',
 				{},
 			);
-			outputs = Array.isArray(result) ? result : [];
+			outputs = Array.isArray(result)
+				? (result as Array<NodeConnectionType | INodeOutputConfiguration>)
+				: [];
 		} catch (e) {
 			console.warn('Could not calculate outputs dynamically for node: ', node.name);
 		}

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -697,15 +697,10 @@ export class Workflow {
 			const outputs = NodeHelpers.getNodeOutputs(this, node, nodeType.description);
 			const nonMainConnectionTypes: NodeConnectionType[] = [];
 
-			// Defensive check: NodeHelpers.getNodeOutputs should always return an array,
-			// but in some edge cases (particularly during testing with incomplete node setup),
-			// it may return undefined or null
-			if (Array.isArray(outputs)) {
-				for (const output of outputs) {
-					const type = typeof output === 'string' ? output : output.type;
-					if (type !== NodeConnectionTypes.Main) {
-						nonMainConnectionTypes.push(type);
-					}
+			for (const output of outputs) {
+				const type = typeof output === 'string' ? output : output.type;
+				if (type !== NodeConnectionTypes.Main) {
+					nonMainConnectionTypes.push(type);
 				}
 			}
 


### PR DESCRIPTION
## Summary

Fixing the root cause of why `getParentMainInputNode` had to check if the node output is an array, despite the types definition tells it's always an array.

## Related Linear tickets, Github issues, and Community forum posts

PAY-3738

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
