### PR TITLE
feat: PAY-2613 add missing status field for select

### DIFF
--- a/packages/@n8n/db/src/repositories/execution.repository.ts
+++ b/packages/@n8n/db/src/repositories/execution.repository.ts
@@ -706,6 +706,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 					'workflowId',
 					'waitTill',
 					'finished',
+					'status',
 				],
 				where,
 				order: { id: 'DESC' },

--- a/packages/cli/src/public-api/v1/handlers/executions/spec/schemas/execution.yml
+++ b/packages/cli/src/public-api/v1/handlers/executions/spec/schemas/execution.yml
@@ -33,3 +33,6 @@ properties:
     format: date-time
   customData:
     type: object
+  status:
+    type: string
+    enum: ['canceled', 'crashed', 'error', 'new', 'running', 'success', 'unknown', 'waiting']

--- a/packages/cli/test/integration/public-api/executions.test.ts
+++ b/packages/cli/test/integration/public-api/executions.test.ts
@@ -263,6 +263,7 @@ describe('GET /executions', () => {
 			stoppedAt,
 			workflowId,
 			waitTill,
+			status,
 		} = response.body.data[0];
 
 		expect(id).toBeDefined();
@@ -274,6 +275,7 @@ describe('GET /executions', () => {
 		expect(stoppedAt).not.toBeNull();
 		expect(workflowId).toBe(successfulExecution.workflowId);
 		expect(waitTill).toBeNull();
+		expect(status).toBe(successfulExecution.status);
 	});
 
 	test('should paginate two executions', async () => {
@@ -317,6 +319,7 @@ describe('GET /executions', () => {
 				stoppedAt,
 				workflowId,
 				waitTill,
+				status,
 			} = executions[i];
 
 			expect(id).toBeDefined();
@@ -328,6 +331,7 @@ describe('GET /executions', () => {
 			expect(stoppedAt).not.toBeNull();
 			expect(workflowId).toBe(successfulExecutions[i].workflowId);
 			expect(waitTill).toBeNull();
+			expect(status).toBe(successfulExecutions[i].status);
 		}
 	});
 
@@ -356,6 +360,7 @@ describe('GET /executions', () => {
 			stoppedAt,
 			workflowId,
 			waitTill,
+			status,
 		} = response.body.data[0];
 
 		expect(id).toBeDefined();
@@ -367,6 +372,7 @@ describe('GET /executions', () => {
 		expect(stoppedAt).not.toBeNull();
 		expect(workflowId).toBe(errorExecution.workflowId);
 		expect(waitTill).toBeNull();
+		expect(status).toBe(errorExecution.status);
 	});
 
 	test('should return all waiting executions', async () => {
@@ -396,6 +402,7 @@ describe('GET /executions', () => {
 			stoppedAt,
 			workflowId,
 			waitTill,
+			status,
 		} = response.body.data[0];
 
 		expect(id).toBeDefined();
@@ -407,6 +414,7 @@ describe('GET /executions', () => {
 		expect(stoppedAt).not.toBeNull();
 		expect(workflowId).toBe(waitingExecution.workflowId);
 		expect(new Date(waitTill).getTime()).toBeGreaterThan(Date.now() - 1000);
+		expect(status).toBe(waitingExecution.status);
 	});
 
 	test('should retrieve all executions of specific workflow', async () => {
@@ -434,6 +442,7 @@ describe('GET /executions', () => {
 				stoppedAt,
 				workflowId,
 				waitTill,
+				status,
 			} = execution;
 
 			expect(savedExecutions.some((exec) => exec.id === id)).toBe(true);
@@ -445,6 +454,7 @@ describe('GET /executions', () => {
 			expect(stoppedAt).not.toBeNull();
 			expect(workflowId).toBe(workflow.id);
 			expect(waitTill).toBeNull();
+			expect(status).toBe(execution.status);
 		}
 	});
 


### PR DESCRIPTION
## Summary

This PR adds a selector for the status field, to allow it to be returned on execution list responses.

PAY-2613 

Before:

<img width="1440" height="585" alt="image" src="https://github.com/user-attachments/assets/af2fde9b-630a-4ad8-8df8-71bf3c353724" />

After:

<img width="1440" height="585" alt="image" src="https://github.com/user-attachments/assets/d447bc67-a20e-40ff-a99d-80257569d996" />


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
