### PR TITLE
fix(Github Node): Modify regex validation to support custom urls

### DIFF
--- a/packages/nodes-base/nodes/Github/Github.node.ts
+++ b/packages/nodes-base/nodes/Github/Github.node.ts
@@ -517,7 +517,7 @@ export class Github implements INodeType {
 						placeholder: 'e.g. https://github.com/n8n-io',
 						extractValue: {
 							type: 'regex',
-							regex: 'https:\\/\\/([^/]+)\\/([-_0-9a-zA-Z]+)',
+							regex: 'https:\\/\\/(?:[^/]+)\\/([-_0-9a-zA-Z]+)',
 						},
 						validation: [
 							{
@@ -579,7 +579,7 @@ export class Github implements INodeType {
 						placeholder: 'e.g. https://github.com/n8n-io/n8n',
 						extractValue: {
 							type: 'regex',
-							regex: 'https:\\/\\/([^/]+)\\/(?:[-_0-9a-zA-Z]+)\\/([-_.0-9a-zA-Z]+)',
+							regex: 'https:\\/\\/(?:[^/]+)\\/(?:[-_0-9a-zA-Z]+)\\/([-_.0-9a-zA-Z]+)',
 						},
 						validation: [
 							{

--- a/packages/nodes-base/nodes/Github/Github.node.ts
+++ b/packages/nodes-base/nodes/Github/Github.node.ts
@@ -517,13 +517,13 @@ export class Github implements INodeType {
 						placeholder: 'e.g. https://github.com/n8n-io',
 						extractValue: {
 							type: 'regex',
-							regex: 'https:\\/\\/github.com\\/([-_0-9a-zA-Z]+)',
+							regex: 'https:\\/\\/([^/]+)\\/([-_0-9a-zA-Z]+)',
 						},
 						validation: [
 							{
 								type: 'regex',
 								properties: {
-									regex: 'https:\\/\\/github.com\\/([-_0-9a-zA-Z]+)(?:.*)',
+									regex: 'https:\\/\\/([^/]+)\\/([-_0-9a-zA-Z]+)(?:.*)',
 									errorMessage: 'Not a valid Github URL',
 								},
 							},
@@ -579,13 +579,13 @@ export class Github implements INodeType {
 						placeholder: 'e.g. https://github.com/n8n-io/n8n',
 						extractValue: {
 							type: 'regex',
-							regex: 'https:\\/\\/github.com\\/(?:[-_0-9a-zA-Z]+)\\/([-_.0-9a-zA-Z]+)',
+							regex: 'https:\\/\\/([^/]+)\\/(?:[-_0-9a-zA-Z]+)\\/([-_.0-9a-zA-Z]+)',
 						},
 						validation: [
 							{
 								type: 'regex',
 								properties: {
-									regex: 'https:\\/\\/github.com\\/(?:[-_0-9a-zA-Z]+)\\/([-_.0-9a-zA-Z]+)(?:.*)',
+									regex: 'https:\\/\\/([^/]+)\\/(?:[-_0-9a-zA-Z]+)\\/([-_.0-9a-zA-Z]+)(?:.*)',
 									errorMessage: 'Not a valid Github Repository URL',
 								},
 							},

--- a/packages/nodes-base/nodes/Github/GithubTrigger.node.ts
+++ b/packages/nodes-base/nodes/Github/GithubTrigger.node.ts
@@ -104,7 +104,7 @@ export class GithubTrigger implements INodeType {
 						placeholder: 'e.g. https://github.com/n8n-io',
 						extractValue: {
 							type: 'regex',
-							regex: 'https:\\/\\/([^/]+)\\/([-_0-9a-zA-Z]+)',
+							regex: 'https:\\/\\/(?:[^/]+)\\/([-_0-9a-zA-Z]+)',
 						},
 						validation: [
 							{
@@ -158,7 +158,7 @@ export class GithubTrigger implements INodeType {
 						placeholder: 'e.g. https://github.com/n8n-io/n8n',
 						extractValue: {
 							type: 'regex',
-							regex: 'https:\\/\\/([^/]+)\\/(?:[-_0-9a-zA-Z]+)\\/([-_.0-9a-zA-Z]+)',
+							regex: 'https:\\/\\/(?:[^/]+)\\/(?:[-_0-9a-zA-Z]+)\\/([-_.0-9a-zA-Z]+)',
 						},
 						validation: [
 							{

--- a/packages/nodes-base/nodes/Github/GithubTrigger.node.ts
+++ b/packages/nodes-base/nodes/Github/GithubTrigger.node.ts
@@ -104,13 +104,13 @@ export class GithubTrigger implements INodeType {
 						placeholder: 'e.g. https://github.com/n8n-io',
 						extractValue: {
 							type: 'regex',
-							regex: 'https:\\/\\/github.com\\/([-_0-9a-zA-Z]+)',
+							regex: 'https:\\/\\/([^/]+)\\/([-_0-9a-zA-Z]+)',
 						},
 						validation: [
 							{
 								type: 'regex',
 								properties: {
-									regex: 'https:\\/\\/github.com\\/([-_0-9a-zA-Z]+)(?:.*)',
+									regex: 'https:\\/\\/([^/]+)\\/([-_0-9a-zA-Z]+)(?:.*)',
 									errorMessage: 'Not a valid Github URL',
 								},
 							},
@@ -158,13 +158,13 @@ export class GithubTrigger implements INodeType {
 						placeholder: 'e.g. https://github.com/n8n-io/n8n',
 						extractValue: {
 							type: 'regex',
-							regex: 'https:\\/\\/github.com\\/(?:[-_0-9a-zA-Z]+)\\/([-_.0-9a-zA-Z]+)',
+							regex: 'https:\\/\\/([^/]+)\\/(?:[-_0-9a-zA-Z]+)\\/([-_.0-9a-zA-Z]+)',
 						},
 						validation: [
 							{
 								type: 'regex',
 								properties: {
-									regex: 'https:\\/\\/github.com\\/(?:[-_0-9a-zA-Z]+)\\/([-_.0-9a-zA-Z]+)(?:.*)',
+									regex: 'https:\\/\\/([^/]+)\\/(?:[-_0-9a-zA-Z]+)\\/([-_.0-9a-zA-Z]+)(?:.*)',
 									errorMessage: 'Not a valid Github Repository URL',
 								},
 							},

--- a/packages/nodes-base/nodes/Github/__tests__/UrlPatterns.test.ts
+++ b/packages/nodes-base/nodes/Github/__tests__/UrlPatterns.test.ts
@@ -1,4 +1,5 @@
 import { Github } from '../Github.node';
+import { GithubTrigger } from '../GithubTrigger.node';
 
 interface ValidationRule {
 	type: string;
@@ -10,6 +11,7 @@ interface ValidationRule {
 
 describe('GitHub Node URL Pattern Tests', () => {
 	let githubNode: Github;
+	let githubTriggerNode: GithubTrigger;
 
 	const getOwnerUrlMode = () => {
 		const ownerParam = githubNode.description.properties.find((prop) => prop.name === 'owner');
@@ -43,8 +45,46 @@ describe('GitHub Node URL Pattern Tests', () => {
 		return new RegExp(validation?.properties?.regex ?? '');
 	};
 
+	// Helper functions for GithubTrigger node
+	const getTriggerOwnerUrlMode = () => {
+		const ownerParam = githubTriggerNode.description.properties.find(
+			(prop) => prop.name === 'owner',
+		);
+		return ownerParam?.modes?.find((mode) => mode.name === 'url');
+	};
+
+	const getTriggerRepositoryUrlMode = () => {
+		const repoParam = githubTriggerNode.description.properties.find(
+			(prop) => prop.name === 'repository',
+		);
+		return repoParam?.modes?.find((mode) => mode.name === 'url');
+	};
+
+	const getTriggerOwnerExtractRegex = () => {
+		const mode = getTriggerOwnerUrlMode();
+		return new RegExp(mode?.extractValue?.regex ?? '');
+	};
+
+	const getTriggerOwnerValidationRegex = () => {
+		const mode = getTriggerOwnerUrlMode();
+		const validation = mode?.validation?.[0] as ValidationRule;
+		return new RegExp(validation?.properties?.regex ?? '');
+	};
+
+	const getTriggerRepositoryExtractRegex = () => {
+		const mode = getTriggerRepositoryUrlMode();
+		return new RegExp(mode?.extractValue?.regex ?? '');
+	};
+
+	const getTriggerRepositoryValidationRegex = () => {
+		const mode = getTriggerRepositoryUrlMode();
+		const validation = mode?.validation?.[0] as ValidationRule;
+		return new RegExp(validation?.properties?.regex ?? '');
+	};
+
 	beforeEach(() => {
 		githubNode = new Github();
+		githubTriggerNode = new GithubTrigger();
 	});
 
 	describe('GitHub Node Resource Locator Patterns', () => {
@@ -128,27 +168,27 @@ describe('GitHub Node URL Pattern Tests', () => {
 	describe('GitHub Trigger Node Resource Locator Patterns', () => {
 		describe('Owner URL Pattern', () => {
 			it('should extract owner from github.com URL', () => {
-				const regex = getOwnerExtractRegex();
+				const regex = getTriggerOwnerExtractRegex();
 				const url = 'https://github.com/n8n-io';
 				const match = url.match(regex);
 				expect(match?.[1]).toBe('n8n-io');
 			});
 
 			it('should extract owner from custom GitHub URL', () => {
-				const regex = getOwnerExtractRegex();
+				const regex = getTriggerOwnerExtractRegex();
 				const url = 'https://github.company.com/my-org';
 				const match = url.match(regex);
 				expect(match?.[1]).toBe('my-org');
 			});
 
 			it('should validate github.com URL', () => {
-				const validationRegex = getOwnerValidationRegex();
+				const validationRegex = getTriggerOwnerValidationRegex();
 				const url = 'https://github.com/n8n-io';
 				expect(validationRegex.test(url)).toBe(true);
 			});
 
 			it('should validate custom GitHub URL', () => {
-				const validationRegex = getOwnerValidationRegex();
+				const validationRegex = getTriggerOwnerValidationRegex();
 				const url = 'https://github.company.com/my-org';
 				expect(validationRegex.test(url)).toBe(true);
 			});
@@ -156,27 +196,27 @@ describe('GitHub Node URL Pattern Tests', () => {
 
 		describe('Repository URL Pattern', () => {
 			it('should extract repository from github.com URL', () => {
-				const regex = getRepositoryExtractRegex();
+				const regex = getTriggerRepositoryExtractRegex();
 				const url = 'https://github.com/n8n-io/n8n';
 				const match = url.match(regex);
 				expect(match?.[1]).toBe('n8n');
 			});
 
 			it('should extract repository from custom GitHub URL', () => {
-				const regex = getRepositoryExtractRegex();
+				const regex = getTriggerRepositoryExtractRegex();
 				const url = 'https://github.company.com/my-org/my-repo';
 				const match = url.match(regex);
 				expect(match?.[1]).toBe('my-repo');
 			});
 
 			it('should validate github.com repository URL', () => {
-				const validationRegex = getRepositoryValidationRegex();
+				const validationRegex = getTriggerRepositoryValidationRegex();
 				const url = 'https://github.com/n8n-io/n8n';
 				expect(validationRegex.test(url)).toBe(true);
 			});
 
 			it('should validate custom GitHub repository URL', () => {
-				const validationRegex = getRepositoryValidationRegex();
+				const validationRegex = getTriggerRepositoryValidationRegex();
 				const url = 'https://github.company.com/my-org/my-repo';
 				expect(validationRegex.test(url)).toBe(true);
 			});

--- a/packages/nodes-base/nodes/Github/__tests__/UrlPatterns.test.ts
+++ b/packages/nodes-base/nodes/Github/__tests__/UrlPatterns.test.ts
@@ -1,56 +1,82 @@
 import { Github } from '../Github.node';
-import { GithubTrigger } from '../GithubTrigger.node';
+
+interface ValidationRule {
+	type: string;
+	properties: {
+		regex: string;
+		errorMessage: string;
+	};
+}
 
 describe('GitHub Node URL Pattern Tests', () => {
+	let githubNode: Github;
+
+	const getOwnerUrlMode = () => {
+		const ownerParam = githubNode.description.properties.find((prop) => prop.name === 'owner');
+		return ownerParam?.modes?.find((mode) => mode.name === 'url');
+	};
+
+	const getRepositoryUrlMode = () => {
+		const repoParam = githubNode.description.properties.find((prop) => prop.name === 'repository');
+		return repoParam?.modes?.find((mode) => mode.name === 'url');
+	};
+
+	const getOwnerExtractRegex = () => {
+		const mode = getOwnerUrlMode();
+		return new RegExp(mode?.extractValue?.regex ?? '');
+	};
+
+	const getOwnerValidationRegex = () => {
+		const mode = getOwnerUrlMode();
+		const validation = mode?.validation?.[0] as ValidationRule;
+		return new RegExp(validation?.properties?.regex ?? '');
+	};
+
+	const getRepositoryExtractRegex = () => {
+		const mode = getRepositoryUrlMode();
+		return new RegExp(mode?.extractValue?.regex ?? '');
+	};
+
+	const getRepositoryValidationRegex = () => {
+		const mode = getRepositoryUrlMode();
+		const validation = mode?.validation?.[0] as ValidationRule;
+		return new RegExp(validation?.properties?.regex ?? '');
+	};
+
+	beforeEach(() => {
+		githubNode = new Github();
+	});
+
 	describe('GitHub Node Resource Locator Patterns', () => {
-		let githubNode: Github;
-
-		beforeEach(() => {
-			githubNode = new Github();
-		});
-
 		describe('Owner URL Pattern', () => {
-			const getOwnerUrlMode = () => {
-				const ownerParam = githubNode.description.properties.find((prop) => prop.name === 'owner');
-				return ownerParam?.modes?.find((mode) => mode.name === 'url');
-			};
-
 			it('should extract owner from github.com URL', () => {
-				const mode = getOwnerUrlMode();
-				const regex = new RegExp(mode?.extractValue?.regex || '');
+				const regex = getOwnerExtractRegex();
 				const url = 'https://github.com/n8n-io';
 				const match = url.match(regex);
-				expect(match?.[2]).toBe('n8n-io');
+				expect(match?.[1]).toBe('n8n-io');
 			});
 
 			it('should extract owner from custom GitHub URL', () => {
-				const mode = getOwnerUrlMode();
-				const regex = new RegExp(mode?.extractValue?.regex || '');
+				const regex = getOwnerExtractRegex();
 				const url = 'https://github.company.com/acme-corp';
 				const match = url.match(regex);
-				expect(match?.[2]).toBe('acme-corp');
+				expect(match?.[1]).toBe('acme-corp');
 			});
 
 			it('should validate github.com URL', () => {
-				const mode = getOwnerUrlMode();
-				const validation = mode?.validation?.[0] as any;
-				const validationRegex = new RegExp(validation?.properties?.regex ?? '');
+				const validationRegex = getOwnerValidationRegex();
 				const url = 'https://github.com/n8n-io';
 				expect(validationRegex.test(url)).toBe(true);
 			});
 
 			it('should validate custom GitHub URL', () => {
-				const mode = getOwnerUrlMode();
-				const validation = mode?.validation?.[0] as any;
-				const validationRegex = new RegExp(validation?.properties?.regex ?? '');
+				const validationRegex = getOwnerValidationRegex();
 				const url = 'https://github.company.com/acme-corp';
 				expect(validationRegex.test(url)).toBe(true);
 			});
 
 			it('should reject invalid URLs', () => {
-				const mode = getOwnerUrlMode();
-				const validation = mode?.validation?.[0] as any;
-				const validationRegex = new RegExp(validation?.properties?.regex ?? '');
+				const validationRegex = getOwnerValidationRegex();
 				expect(validationRegex.test('not-a-url')).toBe(false);
 				expect(validationRegex.test('http://github.com/user')).toBe(false);
 				expect(validationRegex.test('https://')).toBe(false);
@@ -58,57 +84,40 @@ describe('GitHub Node URL Pattern Tests', () => {
 		});
 
 		describe('Repository URL Pattern', () => {
-			const getRepositoryUrlMode = () => {
-				const repoParam = githubNode.description.properties.find(
-					(prop) => prop.name === 'repository',
-				);
-				return repoParam?.modes?.find((mode) => mode.name === 'url');
-			};
-
 			it('should extract repository from github.com URL', () => {
-				const mode = getRepositoryUrlMode();
-				const regex = new RegExp(mode?.extractValue?.regex || '');
+				const regex = getRepositoryExtractRegex();
 				const url = 'https://github.com/n8n-io/n8n';
 				const match = url.match(regex);
-				expect(match?.[2]).toBe('n8n');
+				expect(match?.[1]).toBe('n8n');
 			});
 
 			it('should extract repository from custom GitHub URL', () => {
-				const mode = getRepositoryUrlMode();
-				const regex = new RegExp(mode?.extractValue?.regex || '');
+				const regex = getRepositoryExtractRegex();
 				const url = 'https://github.company.com/acme-corp/my-repo';
 				const match = url.match(regex);
-				expect(match?.[2]).toBe('my-repo');
+				expect(match?.[1]).toBe('my-repo');
 			});
 
 			it('should validate github.com repository URL', () => {
-				const mode = getRepositoryUrlMode();
-				const validation = mode?.validation?.[0] as any;
-				const validationRegex = new RegExp(validation?.properties?.regex ?? '');
+				const validationRegex = getRepositoryValidationRegex();
 				const url = 'https://github.com/n8n-io/n8n';
 				expect(validationRegex.test(url)).toBe(true);
 			});
 
 			it('should validate custom GitHub repository URL', () => {
-				const mode = getRepositoryUrlMode();
-				const validation = mode?.validation?.[0] as any;
-				const validationRegex = new RegExp(validation?.properties?.regex ?? '');
+				const validationRegex = getRepositoryValidationRegex();
 				const url = 'https://github.company.com/acme-corp/my-repo';
 				expect(validationRegex.test(url)).toBe(true);
 			});
 
 			it('should validate URLs with additional paths', () => {
-				const mode = getRepositoryUrlMode();
-				const validation = mode?.validation?.[0] as any;
-				const validationRegex = new RegExp(validation?.properties?.regex ?? '');
+				const validationRegex = getRepositoryValidationRegex();
 				expect(validationRegex.test('https://github.com/n8n-io/n8n/issues/123')).toBe(true);
 				expect(validationRegex.test('https://github.company.com/org/repo/pulls')).toBe(true);
 			});
 
 			it('should reject invalid repository URLs', () => {
-				const mode = getRepositoryUrlMode();
-				const validation = mode?.validation?.[0] as any;
-				const validationRegex = new RegExp(validation?.properties?.regex ?? '');
+				const validationRegex = getRepositoryValidationRegex();
 				expect(validationRegex.test('https://github.com/user')).toBe(false);
 				expect(validationRegex.test('not-a-url')).toBe(false);
 				expect(validationRegex.test('https://')).toBe(false);
@@ -117,89 +126,57 @@ describe('GitHub Node URL Pattern Tests', () => {
 	});
 
 	describe('GitHub Trigger Node Resource Locator Patterns', () => {
-		let githubTriggerNode: GithubTrigger;
-
-		beforeEach(() => {
-			githubTriggerNode = new GithubTrigger();
-		});
-
 		describe('Owner URL Pattern', () => {
-			const getOwnerUrlMode = () => {
-				const ownerParam = githubTriggerNode.description.properties.find(
-					(prop) => prop.name === 'owner',
-				);
-				return ownerParam?.modes?.find((mode) => mode.name === 'url');
-			};
-
 			it('should extract owner from github.com URL', () => {
-				const mode = getOwnerUrlMode();
-				const regex = new RegExp(mode?.extractValue?.regex || '');
+				const regex = getOwnerExtractRegex();
 				const url = 'https://github.com/n8n-io';
 				const match = url.match(regex);
-				expect(match?.[2]).toBe('n8n-io');
+				expect(match?.[1]).toBe('n8n-io');
 			});
 
 			it('should extract owner from custom GitHub URL', () => {
-				const mode = getOwnerUrlMode();
-				const regex = new RegExp(mode?.extractValue?.regex || '');
+				const regex = getOwnerExtractRegex();
 				const url = 'https://github.company.com/my-org';
 				const match = url.match(regex);
-				expect(match?.[2]).toBe('my-org');
+				expect(match?.[1]).toBe('my-org');
 			});
 
 			it('should validate github.com URL', () => {
-				const mode = getOwnerUrlMode();
-				const validation = mode?.validation?.[0] as any;
-				const validationRegex = new RegExp(validation?.properties?.regex ?? '');
+				const validationRegex = getOwnerValidationRegex();
 				const url = 'https://github.com/n8n-io';
 				expect(validationRegex.test(url)).toBe(true);
 			});
 
 			it('should validate custom GitHub URL', () => {
-				const mode = getOwnerUrlMode();
-				const validation = mode?.validation?.[0] as any;
-				const validationRegex = new RegExp(validation?.properties?.regex ?? '');
+				const validationRegex = getOwnerValidationRegex();
 				const url = 'https://github.company.com/my-org';
 				expect(validationRegex.test(url)).toBe(true);
 			});
 		});
 
 		describe('Repository URL Pattern', () => {
-			const getRepositoryUrlMode = () => {
-				const repoParam = githubTriggerNode.description.properties.find(
-					(prop) => prop.name === 'repository',
-				);
-				return repoParam?.modes?.find((mode) => mode.name === 'url');
-			};
-
 			it('should extract repository from github.com URL', () => {
-				const mode = getRepositoryUrlMode();
-				const regex = new RegExp(mode?.extractValue?.regex || '');
+				const regex = getRepositoryExtractRegex();
 				const url = 'https://github.com/n8n-io/n8n';
 				const match = url.match(regex);
-				expect(match?.[2]).toBe('n8n');
+				expect(match?.[1]).toBe('n8n');
 			});
 
 			it('should extract repository from custom GitHub URL', () => {
-				const mode = getRepositoryUrlMode();
-				const regex = new RegExp(mode?.extractValue?.regex || '');
+				const regex = getRepositoryExtractRegex();
 				const url = 'https://github.company.com/my-org/my-repo';
 				const match = url.match(regex);
-				expect(match?.[2]).toBe('my-repo');
+				expect(match?.[1]).toBe('my-repo');
 			});
 
 			it('should validate github.com repository URL', () => {
-				const mode = getRepositoryUrlMode();
-				const validation = mode?.validation?.[0] as any;
-				const validationRegex = new RegExp(validation?.properties?.regex ?? '');
+				const validationRegex = getRepositoryValidationRegex();
 				const url = 'https://github.com/n8n-io/n8n';
 				expect(validationRegex.test(url)).toBe(true);
 			});
 
 			it('should validate custom GitHub repository URL', () => {
-				const mode = getRepositoryUrlMode();
-				const validation = mode?.validation?.[0] as any;
-				const validationRegex = new RegExp(validation?.properties?.regex ?? '');
+				const validationRegex = getRepositoryValidationRegex();
 				const url = 'https://github.company.com/my-org/my-repo';
 				expect(validationRegex.test(url)).toBe(true);
 			});
@@ -208,34 +185,33 @@ describe('GitHub Node URL Pattern Tests', () => {
 
 	describe('URL Pattern Edge Cases', () => {
 		it('should handle URLs with subdomains', () => {
-			const ownerPattern = /https:\/\/([^/]+)\/([-_0-9a-zA-Z]+)/;
-			const repoPattern = /https:\/\/([^/]+)\/(?:[-_0-9a-zA-Z]+)\/([-_.0-9a-zA-Z]+)/;
+			const ownerRegex = getOwnerExtractRegex();
+			const repoRegex = getRepositoryExtractRegex();
 
 			// Test complex custom URLs
-			expect('https://git.internal.company.com/dev-team'.match(ownerPattern)?.[2]).toBe('dev-team');
-			expect('https://github.acme.corp/engineering/backend-api'.match(repoPattern)?.[2]).toBe(
+			expect('https://git.internal.company.com/dev-team'.match(ownerRegex)?.[1]).toBe('dev-team');
+			expect('https://github.acme.corp/engineering/backend-api'.match(repoRegex)?.[1]).toBe(
 				'backend-api',
 			);
 		});
 
 		it('should handle URLs with ports', () => {
-			const ownerPattern = /https:\/\/([^/]+)\/([-_0-9a-zA-Z]+)/;
-			const repoPattern = /https:\/\/([^/]+)\/(?:[-_0-9a-zA-Z]+)\/([-_.0-9a-zA-Z]+)/;
+			const ownerRegex = getOwnerExtractRegex();
+			const repoRegex = getRepositoryExtractRegex();
 
 			// Test URLs with ports
-			expect('https://github.local:8080/testuser'.match(ownerPattern)?.[2]).toBe('testuser');
-			expect('https://git.company.com:443/org/project'.match(repoPattern)?.[2]).toBe('project');
+			expect('https://github.local:8080/testuser'.match(ownerRegex)?.[1]).toBe('testuser');
+			expect('https://git.company.com:443/org/project'.match(repoRegex)?.[1]).toBe('project');
 		});
 
 		it('should handle URLs with additional path segments', () => {
-			const validationOwnerPattern = /https:\/\/([^/]+)\/([-_0-9a-zA-Z]+)(?:.*)/;
-			const validationRepoPattern =
-				/https:\/\/([^/]+)\/(?:[-_0-9a-zA-Z]+)\/([-_.0-9a-zA-Z]+)(?:.*)/;
+			const ownerValidationRegex = getOwnerValidationRegex();
+			const repoValidationRegex = getRepositoryValidationRegex();
 
 			// Test URLs with extra paths
-			expect(validationOwnerPattern.test('https://github.com/user/settings')).toBe(true);
-			expect(validationRepoPattern.test('https://github.com/user/repo/issues/123')).toBe(true);
-			expect(validationRepoPattern.test('https://git.company.com/org/project/pulls')).toBe(true);
+			expect(ownerValidationRegex.test('https://github.com/user/settings')).toBe(true);
+			expect(repoValidationRegex.test('https://github.com/user/repo/issues/123')).toBe(true);
+			expect(repoValidationRegex.test('https://git.company.com/org/project/pulls')).toBe(true);
 		});
 	});
 });

--- a/packages/nodes-base/nodes/Github/__tests__/UrlPatterns.test.ts
+++ b/packages/nodes-base/nodes/Github/__tests__/UrlPatterns.test.ts
@@ -1,0 +1,241 @@
+import { Github } from '../Github.node';
+import { GithubTrigger } from '../GithubTrigger.node';
+
+describe('GitHub Node URL Pattern Tests', () => {
+	describe('GitHub Node Resource Locator Patterns', () => {
+		let githubNode: Github;
+
+		beforeEach(() => {
+			githubNode = new Github();
+		});
+
+		describe('Owner URL Pattern', () => {
+			const getOwnerUrlMode = () => {
+				const ownerParam = githubNode.description.properties.find((prop) => prop.name === 'owner');
+				return ownerParam?.modes?.find((mode) => mode.name === 'url');
+			};
+
+			it('should extract owner from github.com URL', () => {
+				const mode = getOwnerUrlMode();
+				const regex = new RegExp(mode?.extractValue?.regex || '');
+				const url = 'https://github.com/n8n-io';
+				const match = url.match(regex);
+				expect(match?.[2]).toBe('n8n-io');
+			});
+
+			it('should extract owner from custom GitHub URL', () => {
+				const mode = getOwnerUrlMode();
+				const regex = new RegExp(mode?.extractValue?.regex || '');
+				const url = 'https://github.company.com/acme-corp';
+				const match = url.match(regex);
+				expect(match?.[2]).toBe('acme-corp');
+			});
+
+			it('should validate github.com URL', () => {
+				const mode = getOwnerUrlMode();
+				const validation = mode?.validation?.[0] as any;
+				const validationRegex = new RegExp(validation?.properties?.regex ?? '');
+				const url = 'https://github.com/n8n-io';
+				expect(validationRegex.test(url)).toBe(true);
+			});
+
+			it('should validate custom GitHub URL', () => {
+				const mode = getOwnerUrlMode();
+				const validation = mode?.validation?.[0] as any;
+				const validationRegex = new RegExp(validation?.properties?.regex ?? '');
+				const url = 'https://github.company.com/acme-corp';
+				expect(validationRegex.test(url)).toBe(true);
+			});
+
+			it('should reject invalid URLs', () => {
+				const mode = getOwnerUrlMode();
+				const validation = mode?.validation?.[0] as any;
+				const validationRegex = new RegExp(validation?.properties?.regex ?? '');
+				expect(validationRegex.test('not-a-url')).toBe(false);
+				expect(validationRegex.test('http://github.com/user')).toBe(false);
+				expect(validationRegex.test('https://')).toBe(false);
+			});
+		});
+
+		describe('Repository URL Pattern', () => {
+			const getRepositoryUrlMode = () => {
+				const repoParam = githubNode.description.properties.find(
+					(prop) => prop.name === 'repository',
+				);
+				return repoParam?.modes?.find((mode) => mode.name === 'url');
+			};
+
+			it('should extract repository from github.com URL', () => {
+				const mode = getRepositoryUrlMode();
+				const regex = new RegExp(mode?.extractValue?.regex || '');
+				const url = 'https://github.com/n8n-io/n8n';
+				const match = url.match(regex);
+				expect(match?.[2]).toBe('n8n');
+			});
+
+			it('should extract repository from custom GitHub URL', () => {
+				const mode = getRepositoryUrlMode();
+				const regex = new RegExp(mode?.extractValue?.regex || '');
+				const url = 'https://github.company.com/acme-corp/my-repo';
+				const match = url.match(regex);
+				expect(match?.[2]).toBe('my-repo');
+			});
+
+			it('should validate github.com repository URL', () => {
+				const mode = getRepositoryUrlMode();
+				const validation = mode?.validation?.[0] as any;
+				const validationRegex = new RegExp(validation?.properties?.regex ?? '');
+				const url = 'https://github.com/n8n-io/n8n';
+				expect(validationRegex.test(url)).toBe(true);
+			});
+
+			it('should validate custom GitHub repository URL', () => {
+				const mode = getRepositoryUrlMode();
+				const validation = mode?.validation?.[0] as any;
+				const validationRegex = new RegExp(validation?.properties?.regex ?? '');
+				const url = 'https://github.company.com/acme-corp/my-repo';
+				expect(validationRegex.test(url)).toBe(true);
+			});
+
+			it('should validate URLs with additional paths', () => {
+				const mode = getRepositoryUrlMode();
+				const validation = mode?.validation?.[0] as any;
+				const validationRegex = new RegExp(validation?.properties?.regex ?? '');
+				expect(validationRegex.test('https://github.com/n8n-io/n8n/issues/123')).toBe(true);
+				expect(validationRegex.test('https://github.company.com/org/repo/pulls')).toBe(true);
+			});
+
+			it('should reject invalid repository URLs', () => {
+				const mode = getRepositoryUrlMode();
+				const validation = mode?.validation?.[0] as any;
+				const validationRegex = new RegExp(validation?.properties?.regex ?? '');
+				expect(validationRegex.test('https://github.com/user')).toBe(false);
+				expect(validationRegex.test('not-a-url')).toBe(false);
+				expect(validationRegex.test('https://')).toBe(false);
+			});
+		});
+	});
+
+	describe('GitHub Trigger Node Resource Locator Patterns', () => {
+		let githubTriggerNode: GithubTrigger;
+
+		beforeEach(() => {
+			githubTriggerNode = new GithubTrigger();
+		});
+
+		describe('Owner URL Pattern', () => {
+			const getOwnerUrlMode = () => {
+				const ownerParam = githubTriggerNode.description.properties.find(
+					(prop) => prop.name === 'owner',
+				);
+				return ownerParam?.modes?.find((mode) => mode.name === 'url');
+			};
+
+			it('should extract owner from github.com URL', () => {
+				const mode = getOwnerUrlMode();
+				const regex = new RegExp(mode?.extractValue?.regex || '');
+				const url = 'https://github.com/n8n-io';
+				const match = url.match(regex);
+				expect(match?.[2]).toBe('n8n-io');
+			});
+
+			it('should extract owner from custom GitHub URL', () => {
+				const mode = getOwnerUrlMode();
+				const regex = new RegExp(mode?.extractValue?.regex || '');
+				const url = 'https://github.company.com/my-org';
+				const match = url.match(regex);
+				expect(match?.[2]).toBe('my-org');
+			});
+
+			it('should validate github.com URL', () => {
+				const mode = getOwnerUrlMode();
+				const validation = mode?.validation?.[0] as any;
+				const validationRegex = new RegExp(validation?.properties?.regex ?? '');
+				const url = 'https://github.com/n8n-io';
+				expect(validationRegex.test(url)).toBe(true);
+			});
+
+			it('should validate custom GitHub URL', () => {
+				const mode = getOwnerUrlMode();
+				const validation = mode?.validation?.[0] as any;
+				const validationRegex = new RegExp(validation?.properties?.regex ?? '');
+				const url = 'https://github.company.com/my-org';
+				expect(validationRegex.test(url)).toBe(true);
+			});
+		});
+
+		describe('Repository URL Pattern', () => {
+			const getRepositoryUrlMode = () => {
+				const repoParam = githubTriggerNode.description.properties.find(
+					(prop) => prop.name === 'repository',
+				);
+				return repoParam?.modes?.find((mode) => mode.name === 'url');
+			};
+
+			it('should extract repository from github.com URL', () => {
+				const mode = getRepositoryUrlMode();
+				const regex = new RegExp(mode?.extractValue?.regex || '');
+				const url = 'https://github.com/n8n-io/n8n';
+				const match = url.match(regex);
+				expect(match?.[2]).toBe('n8n');
+			});
+
+			it('should extract repository from custom GitHub URL', () => {
+				const mode = getRepositoryUrlMode();
+				const regex = new RegExp(mode?.extractValue?.regex || '');
+				const url = 'https://github.company.com/my-org/my-repo';
+				const match = url.match(regex);
+				expect(match?.[2]).toBe('my-repo');
+			});
+
+			it('should validate github.com repository URL', () => {
+				const mode = getRepositoryUrlMode();
+				const validation = mode?.validation?.[0] as any;
+				const validationRegex = new RegExp(validation?.properties?.regex ?? '');
+				const url = 'https://github.com/n8n-io/n8n';
+				expect(validationRegex.test(url)).toBe(true);
+			});
+
+			it('should validate custom GitHub repository URL', () => {
+				const mode = getRepositoryUrlMode();
+				const validation = mode?.validation?.[0] as any;
+				const validationRegex = new RegExp(validation?.properties?.regex ?? '');
+				const url = 'https://github.company.com/my-org/my-repo';
+				expect(validationRegex.test(url)).toBe(true);
+			});
+		});
+	});
+
+	describe('URL Pattern Edge Cases', () => {
+		it('should handle URLs with subdomains', () => {
+			const ownerPattern = /https:\/\/([^/]+)\/([-_0-9a-zA-Z]+)/;
+			const repoPattern = /https:\/\/([^/]+)\/(?:[-_0-9a-zA-Z]+)\/([-_.0-9a-zA-Z]+)/;
+
+			// Test complex custom URLs
+			expect('https://git.internal.company.com/dev-team'.match(ownerPattern)?.[2]).toBe('dev-team');
+			expect('https://github.acme.corp/engineering/backend-api'.match(repoPattern)?.[2]).toBe(
+				'backend-api',
+			);
+		});
+
+		it('should handle URLs with ports', () => {
+			const ownerPattern = /https:\/\/([^/]+)\/([-_0-9a-zA-Z]+)/;
+			const repoPattern = /https:\/\/([^/]+)\/(?:[-_0-9a-zA-Z]+)\/([-_.0-9a-zA-Z]+)/;
+
+			// Test URLs with ports
+			expect('https://github.local:8080/testuser'.match(ownerPattern)?.[2]).toBe('testuser');
+			expect('https://git.company.com:443/org/project'.match(repoPattern)?.[2]).toBe('project');
+		});
+
+		it('should handle URLs with additional path segments', () => {
+			const validationOwnerPattern = /https:\/\/([^/]+)\/([-_0-9a-zA-Z]+)(?:.*)/;
+			const validationRepoPattern =
+				/https:\/\/([^/]+)\/(?:[-_0-9a-zA-Z]+)\/([-_.0-9a-zA-Z]+)(?:.*)/;
+
+			// Test URLs with extra paths
+			expect(validationOwnerPattern.test('https://github.com/user/settings')).toBe(true);
+			expect(validationRepoPattern.test('https://github.com/user/repo/issues/123')).toBe(true);
+			expect(validationRepoPattern.test('https://git.company.com/org/project/pulls')).toBe(true);
+		});
+	});
+});


### PR DESCRIPTION
## Summary
  • Fix GitHub and GitHub Trigger nodes to support custom GitHub instances (e.g., GitHub Enterprise)
  • Update RLC regex patterns from hardcoded github.com to accept any hostname
  • Add tests for URL pattern validation


## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-3546/github-node-update-rlc-to-support-custom-urls

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
