### PR TITLE
fix(core): Resolve Python multiprocessing queue deadlock

### DIFF
--- a/packages/@n8n/task-runner-python/src/task_executor.py
+++ b/packages/@n8n/task-runner-python/src/task_executor.py
@@ -239,22 +239,6 @@ class TaskExecutor:
             }
         )
 
-    @staticmethod
-    def _truncate_print_args(print_args: PrintArgs) -> PrintArgs:
-        """Truncate print_args to prevent pipe buffer overflow."""
-
-        if not print_args or len(print_args) <= MAX_PRINT_STATEMENTS_ALLOWED:
-            return print_args
-
-        truncated = print_args[:MAX_PRINT_STATEMENTS_ALLOWED]
-        truncated.append(
-            [
-                f"[Output truncated - {len(print_args) - MAX_PRINT_STATEMENTS_ALLOWED} more print statements]"
-            ]
-        )
-
-        return truncated
-
     # ========== print() ==========
 
     @staticmethod
@@ -307,6 +291,22 @@ class TaskExecutor:
                 formatted.append(json.dumps(arg, default=str, ensure_ascii=False))
 
         return formatted
+
+    @staticmethod
+    def _truncate_print_args(print_args: PrintArgs) -> PrintArgs:
+        """Truncate print_args to prevent pipe buffer overflow."""
+
+        if not print_args or len(print_args) <= MAX_PRINT_STATEMENTS_ALLOWED:
+            return print_args
+
+        truncated = print_args[:MAX_PRINT_STATEMENTS_ALLOWED]
+        truncated.append(
+            [
+                f"[Output truncated - {len(print_args) - MAX_PRINT_STATEMENTS_ALLOWED} more print statements]"
+            ]
+        )
+
+        return truncated
 
     # ========== security ==========
 

--- a/packages/@n8n/task-runner-python/src/task_executor.py
+++ b/packages/@n8n/task-runner-python/src/task_executor.py
@@ -99,9 +99,11 @@ class TaskExecutor:
                 raise TaskResultMissingError()
 
             result_file = returned["result_file"]
-            with open(result_file, "rb") as f:
-                result = pickle.load(f)
-            os.unlink(result_file)
+            try:
+                with open(result_file, "rb") as f:
+                    result = pickle.load(f)
+            finally:
+                os.unlink(result_file)
 
             print_args = returned.get("print_args", [])
 

--- a/packages/@n8n/task-runner-python/src/task_executor.py
+++ b/packages/@n8n/task-runner-python/src/task_executor.py
@@ -232,10 +232,12 @@ class TaskExecutor:
     @staticmethod
     def _put_error(queue: multiprocessing.Queue, e: Exception, print_args: PrintArgs):
         print_args_to_send = TaskExecutor._truncate_print_args(print_args)
-        queue.put({
-            "error": {"message": str(e), "stack": traceback.format_exc()},
-            "print_args": print_args_to_send
-        })
+        queue.put(
+            {
+                "error": {"message": str(e), "stack": traceback.format_exc()},
+                "print_args": print_args_to_send,
+            }
+        )
 
     @staticmethod
     def _truncate_print_args(print_args: PrintArgs) -> PrintArgs:
@@ -243,9 +245,13 @@ class TaskExecutor:
 
         if not print_args or len(print_args) <= MAX_PRINT_STATEMENTS_ALLOWED:
             return print_args
-        
+
         truncated = print_args[:MAX_PRINT_STATEMENTS_ALLOWED]
-        truncated.append([f"[Output truncated - {len(print_args) - MAX_PRINT_STATEMENTS_ALLOWED} more print statements]"])
+        truncated.append(
+            [
+                f"[Output truncated - {len(print_args) - MAX_PRINT_STATEMENTS_ALLOWED} more print statements]"
+            ]
+        )
 
         return truncated
 


### PR DESCRIPTION
## Summary

Found that the native Python runner goes unresponsive at 64 KB of data, because this is the OS pipe buffer limit. The child process calls `queue.put`, its background thread unsuccessfully tries to write to the pipe, and so the child blocks until the parent reads, but the parent is waiting for the subprocess to exit via `process.join` and the child cannot exit because its background thread is blocked.

Chunking is not viable because a single item can be >64 KB. Hence I opted for file-based transfer. After we've set up benchmarking, we can explore performance optimizations, e.g. spool in memory and only spill to disk above the cap.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1285

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
