### PR TITLE
chore: Bump node-cli and create-node package versions to 0.4.0 (no-changelog)

### DIFF
--- a/packages/@n8n/create-node/package.json
+++ b/packages/@n8n/create-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@n8n/create-node",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Official CLI to create new community nodes for n8n",
   "bin": {
     "create-n8n-node": "bin/create.js"

--- a/packages/@n8n/node-cli/package.json
+++ b/packages/@n8n/node-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@n8n/node-cli",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Official CLI for developing community nodes for n8n",
   "bin": {
     "n8n-node": "bin/n8n-node.mjs"


### PR DESCRIPTION
## Summary

Bump node-cli and create-node package versions to 0.4.0