### PR TITLE
chore(core): Support state and nonce parameter for OIDC

### DIFF
--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -53,6 +53,7 @@ export const RESPONSE_ERROR_MESSAGES = {
 
 export const AUTH_COOKIE_NAME = 'n8n-auth';
 export const OIDC_STATE_COOKIE_NAME = 'n8n-oidc-state';
+export const OIDC_NONCE_COOKIE_NAME = 'n8n-oidc-nonce';
 
 export const NPM_COMMAND_TOKENS = {
 	NPM_PACKAGE_NOT_FOUND_ERROR: '404 Not Found',

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -52,6 +52,7 @@ export const RESPONSE_ERROR_MESSAGES = {
 } as const;
 
 export const AUTH_COOKIE_NAME = 'n8n-auth';
+export const OIDC_STATE_COOKIE_NAME = 'n8n-oidc-state';
 
 export const NPM_COMMAND_TOKENS = {
 	NPM_PACKAGE_NOT_FOUND_ERROR: '404 Not Found',

--- a/packages/cli/src/sso.ee/oidc/oidc.service.ee.ts
+++ b/packages/cli/src/sso.ee/oidc/oidc.service.ee.ts
@@ -11,6 +11,7 @@ import {
 	UserRepository,
 } from '@n8n/db';
 import { Container, Service } from '@n8n/di';
+import { randomUUID } from 'crypto';
 import { Cipher } from 'n8n-core';
 import { jsonParse, UserError } from 'n8n-workflow';
 import * as client from 'openid-client';
@@ -18,16 +19,16 @@ import * as client from 'openid-client';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { InternalServerError } from '@/errors/response-errors/internal-server.error';
+import { JwtService } from '@/services/jwt.service';
 import { UrlService } from '@/services/url.service';
 
-import { OIDC_CLIENT_SECRET_REDACTED_VALUE, OIDC_PREFERENCES_DB_KEY } from './constants';
 import {
 	getCurrentAuthenticationMethod,
 	isEmailCurrentAuthenticationMethod,
 	isOidcCurrentAuthenticationMethod,
 	setCurrentAuthenticationMethod,
 } from '../sso-helpers';
-import { randomUUID } from 'crypto';
+import { OIDC_CLIENT_SECRET_REDACTED_VALUE, OIDC_PREFERENCES_DB_KEY } from './constants';
 
 const DEFAULT_OIDC_CONFIG: OidcConfigDto = {
 	clientId: '',
@@ -57,6 +58,7 @@ export class OidcService {
 		private readonly userRepository: UserRepository,
 		private readonly cipher: Cipher,
 		private readonly logger: Logger,
+		private readonly jwtService: JwtService,
 	) {}
 
 	async init() {
@@ -77,12 +79,86 @@ export class OidcService {
 		};
 	}
 
-	generateState(): string {
-		return `n8n_state:${randomUUID()}`;
+	generateState() {
+		const state = `n8n_state:${randomUUID()}`;
+		return {
+			signed: this.jwtService.sign({ state }, { expiresIn: '15m' }),
+			plaintext: state,
+		};
 	}
 
-	generateNonce(): string {
-		return `n8n_nonce:${randomUUID()}`;
+	verifyState(signedState: string) {
+		let state: string;
+		try {
+			const decodedState = this.jwtService.verify(signedState);
+			state = decodedState?.state;
+		} catch (error) {
+			this.logger.error('Failed to verify state', { error });
+			throw new BadRequestError('Invalid state');
+		}
+
+		if (typeof state !== 'string') {
+			this.logger.error('Provided state has an invalid format');
+			throw new BadRequestError('Invalid state');
+		}
+
+		const splitState = state.split(':');
+
+		if (splitState.length !== 2 || splitState[0] !== 'n8n_state') {
+			this.logger.error('Provided state is missing the well-known prefix');
+			throw new BadRequestError('Invalid state');
+		}
+
+		if (
+			!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+				splitState[1],
+			)
+		) {
+			this.logger.error('Provided state is not formatted correctly');
+			throw new BadRequestError('Invalid state');
+		}
+		return state;
+	}
+
+	generateNonce() {
+		const nonce = `n8n_nonce:${randomUUID()}`;
+		return {
+			signed: this.jwtService.sign({ nonce }, { expiresIn: '15m' }),
+			plaintext: nonce,
+		};
+	}
+
+	verifyNonce(signedNonce: string) {
+		let nonce: string;
+		try {
+			const decodedNonce = this.jwtService.verify(signedNonce);
+			nonce = decodedNonce?.nonce;
+		} catch (error) {
+			this.logger.error('Failed to verify nonce', { error });
+			throw new BadRequestError('Invalid nonce');
+		}
+
+		if (typeof nonce !== 'string') {
+			this.logger.error('Provided nonce has an invalid format');
+			throw new BadRequestError('Invalid nonce');
+		}
+
+		const splitNonce = nonce.split(':');
+
+		if (splitNonce.length !== 2 || splitNonce[0] !== 'n8n_nonce') {
+			this.logger.error('Provided nonce is missing the well-known prefix');
+			throw new BadRequestError('Invalid nonce');
+		}
+
+		if (
+			!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+				splitNonce[1],
+			)
+		) {
+			this.logger.error('Provided nonce is not formatted correctly');
+			throw new BadRequestError('Invalid nonce');
+		}
+		return nonce;
 	}
 
 	async generateLoginUrl(): Promise<{ url: URL; state: string; nonce: string }> {
@@ -96,23 +172,22 @@ export class OidcService {
 			response_type: 'code',
 			scope: 'openid email profile',
 			prompt: 'select_account',
-			state,
-			nonce,
+			state: state.plaintext,
+			nonce: nonce.plaintext,
 		});
 
-		return { url: authorizationURL, state, nonce };
+		return { url: authorizationURL, state: state.signed, nonce: nonce.signed };
 	}
 
-	async loginUser(
-		callbackUrl: URL,
-		storedState: string | undefined,
-		storedNonce: string | undefined,
-	): Promise<User> {
+	async loginUser(callbackUrl: URL, storedState: string, storedNonce: string): Promise<User> {
 		const configuration = await this.getOidcConfiguration();
 
+		const expectedState = this.verifyState(storedState);
+		const expectedNonce = this.verifyNonce(storedNonce);
+
 		const tokens = await client.authorizationCodeGrant(configuration, callbackUrl, {
-			expectedState: storedState,
-			expectedNonce: storedNonce,
+			expectedState,
+			expectedNonce,
 		});
 
 		const claims = tokens.claims();

--- a/packages/cli/src/sso.ee/oidc/oidc.service.ee.ts
+++ b/packages/cli/src/sso.ee/oidc/oidc.service.ee.ts
@@ -27,6 +27,8 @@ import {
 	isOidcCurrentAuthenticationMethod,
 	setCurrentAuthenticationMethod,
 } from '../sso-helpers';
+import { JwtService } from '@/services/jwt.service';
+import { randomUUID } from 'crypto';
 
 const DEFAULT_OIDC_CONFIG: OidcConfigDto = {
 	clientId: '',
@@ -56,6 +58,7 @@ export class OidcService {
 		private readonly userRepository: UserRepository,
 		private readonly cipher: Cipher,
 		private readonly logger: Logger,
+		private readonly jwtService: JwtService,
 	) {}
 
 	async init() {
@@ -76,23 +79,86 @@ export class OidcService {
 		};
 	}
 
-	async generateLoginUrl(): Promise<URL> {
+	generateState(): {
+		signed: string;
+		plaintext: string;
+	} {
+		const state = `n8n_state:${randomUUID()}`;
+		return {
+			signed: this.jwtService.sign({ state }, { expiresIn: '15m' }),
+			plaintext: state,
+		};
+	}
+
+	verifyState(signedState: string): string {
+		let state: string;
+		try {
+			const decodedState = this.jwtService.verify(signedState);
+			state = decodedState?.state;
+		} catch (error) {
+			this.logger.error('Failed to verify state', { error });
+			throw new BadRequestError('Invalid state');
+		}
+
+		if (typeof state !== 'string') {
+			this.logger.error('Provided state has an invalid format');
+			throw new BadRequestError('Invalid state');
+		}
+
+		const splitState = state.split(':');
+
+		if (splitState.length !== 2 || splitState[0] !== 'n8n_state') {
+			this.logger.error('Provided state is missing the well-known prefix');
+			throw new BadRequestError('Invalid state');
+		}
+
+		if (
+			!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+				splitState[1],
+			)
+		) {
+			this.logger.error('Provided state is not formatted correctly');
+			throw new BadRequestError('Invalid state');
+		}
+		return state;
+	}
+
+	async generateLoginUrl(): Promise<{ url: URL; state: string }> {
 		const configuration = await this.getOidcConfiguration();
+
+		const state = this.generateState();
 
 		const authorizationURL = client.buildAuthorizationUrl(configuration, {
 			redirect_uri: this.getCallbackUrl(),
 			response_type: 'code',
 			scope: 'openid email profile',
 			prompt: 'select_account',
+			state: state.signed,
 		});
 
-		return authorizationURL;
+		return { url: authorizationURL, state: state.plaintext };
 	}
 
-	async loginUser(callbackUrl: URL): Promise<User> {
+	async loginUser(callbackUrl: URL, storedState: string | undefined): Promise<User> {
 		const configuration = await this.getOidcConfiguration();
 
-		const tokens = await client.authorizationCodeGrant(configuration, callbackUrl);
+		const state = callbackUrl.searchParams.get('state');
+
+		if (!state) {
+			this.logger.error('State is missing');
+			throw new BadRequestError('Invalid state');
+		}
+
+		const plaintext = this.verifyState(state);
+
+		if (plaintext !== storedState) {
+			this.logger.error('State does not match');
+			throw new BadRequestError('Invalid state');
+		}
+
+		const tokens = await client.authorizationCodeGrant(configuration, callbackUrl, {
+			expectedState: state,
+		});
 
 		const claims = tokens.claims();
 

--- a/packages/cli/src/sso.ee/oidc/oidc.service.ee.ts
+++ b/packages/cli/src/sso.ee/oidc/oidc.service.ee.ts
@@ -27,7 +27,6 @@ import {
 	isOidcCurrentAuthenticationMethod,
 	setCurrentAuthenticationMethod,
 } from '../sso-helpers';
-import { JwtService } from '@/services/jwt.service';
 import { randomUUID } from 'crypto';
 
 const DEFAULT_OIDC_CONFIG: OidcConfigDto = {
@@ -58,7 +57,6 @@ export class OidcService {
 		private readonly userRepository: UserRepository,
 		private readonly cipher: Cipher,
 		private readonly logger: Logger,
-		private readonly jwtService: JwtService,
 	) {}
 
 	async init() {

--- a/packages/cli/src/sso.ee/oidc/routes/__tests__/oidc.controller.ee.test.ts
+++ b/packages/cli/src/sso.ee/oidc/routes/__tests__/oidc.controller.ee.test.ts
@@ -8,11 +8,17 @@ import { OidcController } from '../oidc.controller.ee';
 import type { AuthService } from '@/auth/auth.service';
 import type { AuthlessRequest } from '@/requests';
 import type { UrlService } from '@/services/url.service';
+import type { GlobalConfig } from '@n8n/config';
+import { OIDC_STATE_COOKIE_NAME } from '@/constants';
+import { max } from 'lodash';
+import { Time } from '@n8n/constants';
 
 const authService = mock<AuthService>();
 const oidcService = mock<OidcService>();
 const urlService = mock<UrlService>();
-const controller = new OidcController(oidcService, authService, urlService);
+const globalConfig = mock<GlobalConfig>();
+const logger = mock<Logger>();
+const controller = new OidcController(oidcService, authService, urlService, globalConfig, logger);
 
 const user = mock<User>({
 	id: '456',
@@ -37,6 +43,9 @@ describe('OidcController', () => {
 			const req = mock<AuthlessRequest>({
 				originalUrl: '/sso/oidc/callback?code=auth_code&state=state_value',
 				browserId: 'browser-id-123',
+				cookies: {
+					[OIDC_STATE_COOKIE_NAME]: 'state_value',
+				},
 			});
 			const res = mock<Response>();
 
@@ -50,7 +59,7 @@ describe('OidcController', () => {
 			await controller.callbackHandler(req, res);
 
 			// Verify that loginUser was called with the correct callback URL
-			expect(oidcService.loginUser).toHaveBeenCalledWith(expectedCallbackUrl);
+			expect(oidcService.loginUser).toHaveBeenCalledWith(expectedCallbackUrl, 'state_value');
 
 			// Verify that issueCookie was called with MFA flag set to true
 			expect(authService.issueCookie).toHaveBeenCalledWith(res, user, true, req.browserId);
@@ -64,6 +73,9 @@ describe('OidcController', () => {
 				originalUrl:
 					'/sso/oidc/callback?code=different_code&state=different_state&session_state=session123',
 				browserId: 'browser-id-123',
+				cookies: {
+					[OIDC_STATE_COOKIE_NAME]: 'state_value',
+				},
 			});
 			const res = mock<Response>();
 
@@ -75,7 +87,7 @@ describe('OidcController', () => {
 
 			await controller.callbackHandler(req, res);
 
-			expect(oidcService.loginUser).toHaveBeenCalledWith(expectedCallbackUrl);
+			expect(oidcService.loginUser).toHaveBeenCalledWith(expectedCallbackUrl, 'state_value');
 			expect(authService.issueCookie).toHaveBeenCalledWith(res, user, true, req.browserId);
 			expect(res.redirect).toHaveBeenCalledWith('/');
 		});
@@ -84,6 +96,9 @@ describe('OidcController', () => {
 			const req = mock<AuthlessRequest>({
 				originalUrl: '/sso/oidc/callback',
 				browserId: undefined,
+				cookies: {
+					[OIDC_STATE_COOKIE_NAME]: 'state_value',
+				},
 			});
 			const res = mock<Response>();
 
@@ -93,7 +108,7 @@ describe('OidcController', () => {
 
 			await controller.callbackHandler(req, res);
 
-			expect(oidcService.loginUser).toHaveBeenCalledWith(expectedCallbackUrl);
+			expect(oidcService.loginUser).toHaveBeenCalledWith(expectedCallbackUrl, 'state_value');
 			expect(authService.issueCookie).toHaveBeenCalledWith(res, user, true, undefined);
 			expect(res.redirect).toHaveBeenCalledWith('/');
 		});
@@ -101,6 +116,9 @@ describe('OidcController', () => {
 		test('Should propagate errors from OIDC service', async () => {
 			const req = mock<Request>({
 				originalUrl: '/sso/oidc/callback?code=auth_code&state=state_value',
+				cookies: {
+					[OIDC_STATE_COOKIE_NAME]: 'state_value',
+				},
 			});
 			const res = mock<Response>();
 
@@ -119,11 +137,15 @@ describe('OidcController', () => {
 		test('Should redirect to generated authorization URL', async () => {
 			const req = mock<Request>();
 			const res = mock<Response>();
+			globalConfig.auth.cookie = { samesite: 'lax', secure: true };
 
 			const mockAuthUrl = new URL(
 				'https://provider.com/auth?client_id=123&redirect_uri=http://localhost:5678/callback',
 			);
-			oidcService.generateLoginUrl.mockResolvedValueOnce(mockAuthUrl);
+			oidcService.generateLoginUrl.mockResolvedValueOnce({
+				url: mockAuthUrl,
+				state: 'state_value',
+			});
 
 			await controller.redirectToAuthProvider(req, res);
 
@@ -131,6 +153,12 @@ describe('OidcController', () => {
 			expect(res.redirect).toHaveBeenCalledWith(
 				'https://provider.com/auth?client_id=123&redirect_uri=http://localhost:5678/callback',
 			);
+			expect(res.cookie).toHaveBeenCalledWith(OIDC_STATE_COOKIE_NAME, 'state_value', {
+				httpOnly: true,
+				sameSite: 'lax',
+				secure: true,
+				maxAge: 15 * Time.minutes.toMilliseconds,
+			});
 		});
 
 		test('Should propagate errors from OIDC service during URL generation', async () => {

--- a/packages/cli/test/integration/oidc/oidc.service.ee.test.ts
+++ b/packages/cli/test/integration/oidc/oidc.service.ee.test.ts
@@ -263,8 +263,9 @@ describe('OIDC service', () => {
 	describe('loginUser', () => {
 		it('should handle new user login with valid callback URL', async () => {
 			const state = oidcService.generateState();
+			const nonce = oidcService.generateNonce();
 			const callbackUrl = new URL(
-				`http://localhost:5678/rest/sso/oidc/callback?code=valid-code&state=${state.signed}`,
+				`http://localhost:5678/rest/sso/oidc/callback?code=valid-code&state=${state}`,
 			);
 
 			const mockTokens: mocked_oidc_client.TokenEndpointResponse &
@@ -292,7 +293,7 @@ describe('OIDC service', () => {
 				email: 'user2@example.com',
 			});
 
-			const user = await oidcService.loginUser(callbackUrl, state.plaintext);
+			const user = await oidcService.loginUser(callbackUrl, state, nonce);
 			expect(user).toBeDefined();
 			expect(user.email).toEqual('user2@example.com');
 
@@ -308,8 +309,9 @@ describe('OIDC service', () => {
 
 		it('should handle existing user login with valid callback URL', async () => {
 			const state = oidcService.generateState();
+			const nonce = oidcService.generateNonce();
 			const callbackUrl = new URL(
-				`http://localhost:5678/rest/sso/oidc/callback?code=valid-code&state=${state.signed}`,
+				`http://localhost:5678/rest/sso/oidc/callback?code=valid-code&state=${state}`,
 			);
 
 			const mockTokens: mocked_oidc_client.TokenEndpointResponse &
@@ -337,7 +339,7 @@ describe('OIDC service', () => {
 				email: 'user2@example.com',
 			});
 
-			const user = await oidcService.loginUser(callbackUrl, state.plaintext);
+			const user = await oidcService.loginUser(callbackUrl, state, nonce);
 			expect(user).toBeDefined();
 			expect(user.email).toEqual('user2@example.com');
 			expect(user.id).toEqual(createdUser.id);
@@ -345,8 +347,9 @@ describe('OIDC service', () => {
 
 		it('should sign up the user if user already exists out of OIDC system', async () => {
 			const state = oidcService.generateState();
+			const nonce = oidcService.generateNonce();
 			const callbackUrl = new URL(
-				`http://localhost:5678/rest/sso/oidc/callback?code=valid-code&state=${state.signed}`,
+				`http://localhost:5678/rest/sso/oidc/callback?code=valid-code&state=${state}`,
 			);
 
 			const mockTokens: mocked_oidc_client.TokenEndpointResponse &
@@ -375,15 +378,16 @@ describe('OIDC service', () => {
 				email: 'user1@example.com',
 			});
 
-			const user = await oidcService.loginUser(callbackUrl, state.plaintext);
+			const user = await oidcService.loginUser(callbackUrl, state, nonce);
 			expect(user).toBeDefined();
 			expect(user.email).toEqual('user1@example.com');
 		});
 
 		it('should sign in user if OIDC Idp does not have email verified', async () => {
 			const state = oidcService.generateState();
+			const nonce = oidcService.generateNonce();
 			const callbackUrl = new URL(
-				`http://localhost:5678/rest/sso/oidc/callback?code=valid-code&state=${state.signed}`,
+				`http://localhost:5678/rest/sso/oidc/callback?code=valid-code&state=${state}`,
 			);
 
 			const mockTokens: mocked_oidc_client.TokenEndpointResponse &
@@ -412,15 +416,16 @@ describe('OIDC service', () => {
 				email: 'user3@example.com',
 			});
 
-			const user = await oidcService.loginUser(callbackUrl, state.plaintext);
+			const user = await oidcService.loginUser(callbackUrl, state, nonce);
 			expect(user).toBeDefined();
 			expect(user.email).toEqual('user3@example.com');
 		});
 
 		it('should throw `BadRequestError` if OIDC Idp does not provide an email', async () => {
 			const state = oidcService.generateState();
+			const nonce = oidcService.generateNonce();
 			const callbackUrl = new URL(
-				`http://localhost:5678/rest/sso/oidc/callback?code=valid-code&state=${state.signed}`,
+				`http://localhost:5678/rest/sso/oidc/callback?code=valid-code&state=${state}`,
 			);
 
 			const mockTokens: mocked_oidc_client.TokenEndpointResponse &
@@ -448,15 +453,16 @@ describe('OIDC service', () => {
 				email_verified: true,
 			});
 
-			await expect(oidcService.loginUser(callbackUrl, state.plaintext)).rejects.toThrowError(
+			await expect(oidcService.loginUser(callbackUrl, state, nonce)).rejects.toThrowError(
 				BadRequestError,
 			);
 		});
 
 		it('should throw `BadRequestError` if OIDC Idp provides an invalid email format', async () => {
 			const state = oidcService.generateState();
+			const nonce = oidcService.generateNonce();
 			const callbackUrl = new URL(
-				`http://localhost:5678/rest/sso/oidc/callback?code=valid-code&state=${state.signed}`,
+				`http://localhost:5678/rest/sso/oidc/callback?code=valid-code&state=${state}`,
 			);
 
 			const mockTokens: mocked_oidc_client.TokenEndpointResponse &
@@ -485,7 +491,7 @@ describe('OIDC service', () => {
 				email: 'invalid-email-format',
 			});
 
-			const error = await oidcService.loginUser(callbackUrl, state.plaintext).catch((e) => e);
+			const error = await oidcService.loginUser(callbackUrl, state, nonce).catch((e) => e);
 			expect(error.message).toBe('Invalid email format');
 		});
 
@@ -497,8 +503,9 @@ describe('OIDC service', () => {
 			['double@@domain.com'],
 		])('should throw `BadRequestError` for invalid email <%s>', async (invalidEmail) => {
 			const state = oidcService.generateState();
+			const nonce = oidcService.generateNonce();
 			const callbackUrl = new URL(
-				`http://localhost:5678/rest/sso/oidc/callback?code=valid-code&state=${state.signed}`,
+				`http://localhost:5678/rest/sso/oidc/callback?code=valid-code&state=${state}`,
 			);
 
 			const mockTokens: mocked_oidc_client.TokenEndpointResponse &
@@ -525,15 +532,16 @@ describe('OIDC service', () => {
 				email: invalidEmail,
 			});
 
-			await expect(oidcService.loginUser(callbackUrl, state.plaintext)).rejects.toThrowError(
+			await expect(oidcService.loginUser(callbackUrl, state, nonce)).rejects.toThrowError(
 				BadRequestError,
 			);
 		});
 
 		it('should throw `ForbiddenError` if OIDC token does not provide claims', async () => {
 			const state = oidcService.generateState();
+			const nonce = oidcService.generateNonce();
 			const callbackUrl = new URL(
-				`http://localhost:5678/rest/sso/oidc/callback?code=valid-code&state=${state.signed}`,
+				`http://localhost:5678/rest/sso/oidc/callback?code=valid-code&state=${state}`,
 			);
 
 			const mockTokens: mocked_oidc_client.TokenEndpointResponse &
@@ -555,49 +563,21 @@ describe('OIDC service', () => {
 				email_verified: true,
 			});
 
-			await expect(oidcService.loginUser(callbackUrl, state.plaintext)).rejects.toThrowError(
+			await expect(oidcService.loginUser(callbackUrl, state, nonce)).rejects.toThrowError(
 				ForbiddenError,
 			);
-		});
-
-		it("should throw `BadRequestError` if the callback doesn't include a state", async () => {
-			const callbackUrl = new URL('http://localhost:5678/rest/sso/oidc/callback?code=valid-code');
-
-			await expect(
-				oidcService.loginUser(callbackUrl, 'n8n_state:some-random-state'),
-			).rejects.toThrowError(BadRequestError);
-		});
-
-		it("should throw `BadRequestError` if the callback doesn't include a valid state", async () => {
-			const callbackUrl = new URL(
-				'http://localhost:5678/rest/sso/oidc/callback?code=valid-code&state=invalid-state',
-			);
-
-			await expect(
-				oidcService.loginUser(callbackUrl, 'n8n_state:some-random-state'),
-			).rejects.toThrowError(BadRequestError);
 		});
 	});
 
 	describe('State', () => {
 		it('should generate and verify a valid state', () => {
 			const state = oidcService.generateState();
-			const decoded = oidcService.verifyState(state.signed);
-			expect(decoded).toBe(state.plaintext);
+			expect(state.startsWith('n8n_state:')).toBe(true);
 		});
 
-		it('should throw an error for an invalid state', () => {
-			expect(() => oidcService.verifyState('invalid_state')).toThrow(BadRequestError);
-		});
-
-		it('should throw an error for an invalid formatted state', () => {
-			const invalid = Container.get(JwtService).sign({ state: 'invalid_state' });
-			expect(() => oidcService.verifyState(invalid)).toThrow(BadRequestError);
-		});
-
-		it('should throw an error for an invalid random part of the state', () => {
-			const invalid = Container.get(JwtService).sign({ state: 'n8n_state:invalid-state' });
-			expect(() => oidcService.verifyState(invalid)).toThrow(BadRequestError);
+		it('should generate and verify a valid nonce', () => {
+			const nonce = oidcService.generateNonce();
+			expect(nonce.startsWith('n8n_nonce:')).toBe(true);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

This improves the OIDC integration, by making use of the state and nonce parameter. The state value is stored in a cookie in the browser and validated when the response is handled. 

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-3103/community-issue-cannot-use-oidc-on-a-server-that-enforces-the-use-of

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
