### PR TITLE
fix(Merge Node): Fix possible stack overflow

### DIFF
--- a/packages/nodes-base/nodes/Merge/v2/MergeV2.node.ts
+++ b/packages/nodes-base/nodes/Merge/v2/MergeV2.node.ts
@@ -291,7 +291,7 @@ export class MergeV2 implements INodeType {
 	}
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
-		const returnData: INodeExecutionData[] = [];
+		let returnData: INodeExecutionData[] = [];
 
 		const mode = this.getNodeParameter('mode', 0) as string;
 
@@ -536,7 +536,7 @@ export class MergeV2 implements INodeType {
 						output = [...output, ...unmatched1, ...unmatched2];
 					}
 
-					returnData.push(...output);
+					returnData = returnData.concat(output);
 				}
 
 				if (joinMode === 'keepNonMatches') {
@@ -565,15 +565,21 @@ export class MergeV2 implements INodeType {
 
 					if (joinMode === 'enrichInput1') {
 						if (clashResolveOptions.resolveClash === 'addSuffix') {
-							returnData.push(...mergedEntries, ...addSuffixToEntriesKeys(matches.unmatched1, '1'));
+							returnData = returnData.concat(
+								mergedEntries,
+								addSuffixToEntriesKeys(matches.unmatched1, '1'),
+							);
 						} else {
-							returnData.push(...mergedEntries, ...matches.unmatched1);
+							returnData = returnData.concat(mergedEntries, matches.unmatched1);
 						}
 					} else {
 						if (clashResolveOptions.resolveClash === 'addSuffix') {
-							returnData.push(...mergedEntries, ...addSuffixToEntriesKeys(matches.unmatched2, '2'));
+							returnData = returnData.concat(
+								mergedEntries,
+								addSuffixToEntriesKeys(matches.unmatched2, '2'),
+							);
 						} else {
-							returnData.push(...mergedEntries, ...matches.unmatched2);
+							returnData = returnData.concat(mergedEntries, matches.unmatched2);
 						}
 					}
 				}

--- a/packages/nodes-base/nodes/Merge/v3/actions/mode/combineByFields.ts
+++ b/packages/nodes-base/nodes/Merge/v3/actions/mode/combineByFields.ts
@@ -262,7 +262,7 @@ export async function execute(
 	this: IExecuteFunctions,
 	inputsData: INodeExecutionData[][],
 ): Promise<INodeExecutionData[][]> {
-	const returnData: INodeExecutionData[] = [];
+	let returnData: INodeExecutionData[] = [];
 	const advanced = this.getNodeParameter('advanced', 0) as boolean;
 	let matchFields;
 
@@ -374,7 +374,7 @@ export async function execute(
 			output = [...output, ...unmatched1, ...unmatched2];
 		}
 
-		returnData.push(...output);
+		returnData = returnData.concat(output);
 	}
 
 	if (joinMode === 'keepNonMatches') {
@@ -403,15 +403,21 @@ export async function execute(
 
 		if (joinMode === 'enrichInput1') {
 			if (clashResolveOptions.resolveClash === 'addSuffix') {
-				returnData.push(...mergedEntries, ...addSuffixToEntriesKeys(matches.unmatched1, '1'));
+				returnData = returnData.concat(
+					mergedEntries,
+					addSuffixToEntriesKeys(matches.unmatched1, '1'),
+				);
 			} else {
-				returnData.push(...mergedEntries, ...matches.unmatched1);
+				returnData = returnData.concat(mergedEntries, matches.unmatched1);
 			}
 		} else {
 			if (clashResolveOptions.resolveClash === 'addSuffix') {
-				returnData.push(...mergedEntries, ...addSuffixToEntriesKeys(matches.unmatched2, '2'));
+				returnData = returnData.concat(
+					mergedEntries,
+					addSuffixToEntriesKeys(matches.unmatched2, '2'),
+				);
 			} else {
-				returnData.push(...mergedEntries, ...matches.unmatched2);
+				returnData = returnData.concat(mergedEntries, matches.unmatched2);
 			}
 		}
 	}

--- a/packages/nodes-base/nodes/Merge/v3/actions/mode/combineBySql.ts
+++ b/packages/nodes-base/nodes/Merge/v3/actions/mode/combineBySql.ts
@@ -98,7 +98,7 @@ async function executeSelectWithMappedPairedItems(
 	query: string,
 	returnSuccessItemIfEmpty: boolean,
 ): Promise<INodeExecutionData[][]> {
-	let returnData: INodeExecutionData[] = [];
+	const returnData: INodeExecutionData[] = [];
 
 	const db: typeof Database = new (alasql as any).Database(node.id);
 
@@ -125,7 +125,7 @@ async function executeSelectWithMappedPairedItems(
 
 		for (const item of result) {
 			if (Array.isArray(item)) {
-				returnData = returnData.concat(item.map(rowToExecutionData));
+				returnData.push.apply(returnData, item.map(rowToExecutionData));
 			} else if (typeof item === 'object') {
 				returnData.push(rowToExecutionData(item));
 			}
@@ -148,8 +148,8 @@ export async function execute(
 	inputsData: INodeExecutionData[][],
 ): Promise<INodeExecutionData[][]> {
 	const node = this.getNode();
-	let returnData: INodeExecutionData[] = [];
-	let pairedItem: IPairedItemData[] = [];
+	const returnData: INodeExecutionData[] = [];
+	const pairedItem: IPairedItemData[] = [];
 	const options = this.getNodeParameter('options', 0, {}) as OperationOptions;
 
 	let query = this.getNodeParameter('query', 0) as string;
@@ -211,7 +211,7 @@ export async function execute(
 								input: i,
 							};
 						});
-					pairedItem = pairedItem.concat(pairedItems);
+					pairedItem.push.apply(pairedItem, pairedItems);
 					return;
 				}
 
@@ -237,7 +237,10 @@ export async function execute(
 
 		for (const item of result) {
 			if (Array.isArray(item)) {
-				returnData = returnData.concat(item.map((json) => ({ json, pairedItem })));
+				returnData.push.apply(
+					returnData,
+					item.map((json) => ({ json, pairedItem })),
+				);
 			} else if (typeof item === 'object') {
 				returnData.push({ json: item, pairedItem });
 			}

--- a/packages/nodes-base/nodes/Merge/v3/actions/mode/combineBySql.ts
+++ b/packages/nodes-base/nodes/Merge/v3/actions/mode/combineBySql.ts
@@ -98,7 +98,7 @@ async function executeSelectWithMappedPairedItems(
 	query: string,
 	returnSuccessItemIfEmpty: boolean,
 ): Promise<INodeExecutionData[][]> {
-	const returnData: INodeExecutionData[] = [];
+	let returnData: INodeExecutionData[] = [];
 
 	const db: typeof Database = new (alasql as any).Database(node.id);
 
@@ -125,7 +125,7 @@ async function executeSelectWithMappedPairedItems(
 
 		for (const item of result) {
 			if (Array.isArray(item)) {
-				returnData.push(...item.map((entry) => rowToExecutionData(entry)));
+				returnData = returnData.concat(item.map(rowToExecutionData));
 			} else if (typeof item === 'object') {
 				returnData.push(rowToExecutionData(item));
 			}
@@ -148,8 +148,8 @@ export async function execute(
 	inputsData: INodeExecutionData[][],
 ): Promise<INodeExecutionData[][]> {
 	const node = this.getNode();
-	const returnData: INodeExecutionData[] = [];
-	const pairedItem: IPairedItemData[] = [];
+	let returnData: INodeExecutionData[] = [];
+	let pairedItem: IPairedItemData[] = [];
 	const options = this.getNodeParameter('options', 0, {}) as OperationOptions;
 
 	let query = this.getNodeParameter('query', 0) as string;
@@ -211,7 +211,7 @@ export async function execute(
 								input: i,
 							};
 						});
-					pairedItem.push(...pairedItems);
+					pairedItem = pairedItem.concat(pairedItems);
 					return;
 				}
 
@@ -237,7 +237,7 @@ export async function execute(
 
 		for (const item of result) {
 			if (Array.isArray(item)) {
-				returnData.push(...item.map((json) => ({ json, pairedItem })));
+				returnData = returnData.concat(item.map((json) => ({ json, pairedItem })));
 			} else if (typeof item === 'object') {
 				returnData.push({ json: item, pairedItem });
 			}


### PR DESCRIPTION

## Summary

If there are a lot of items, spreading can cause a stack overflow. Also use .concat() instead of .push() as it's way more performant on large arrays.

P.S. We have 800 results in 307 in the `nodes-base` package that might have the same issue. Didn't fix them, all just one I happened to notice in Sentry. Should go through all of them at some point

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1281/rangeerror-maximum-call-stack-size-exceeded


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
