### PR TITLE
feat(Gemini Node): Edit Image Using Nano Banana

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/image/edit.operation.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/image/edit.operation.test.ts
@@ -1,0 +1,248 @@
+import { mock, mockDeep } from 'jest-mock-extended';
+import type { IBinaryData, ICredentialDataDecryptedObject, IExecuteFunctions } from 'n8n-workflow';
+
+import { execute } from './edit.operation';
+
+const getMockedExecuteFunctions = ({
+	prompt = 'add bananas',
+	outputProperty = 'edited',
+	images = { values: [{ binaryPropertyName: 'data' }] },
+	outputBuffer = Buffer.from('edited image'),
+	mimeType = 'image/png',
+	invalidApiResponse = false,
+}: {
+	prompt?: string;
+	outputProperty?: string;
+	images?: { values: Array<{ binaryPropertyName: string }> };
+	outputBuffer?: Buffer<ArrayBuffer>;
+	mimeType?: string;
+	invalidApiResponse?: boolean;
+} = {}): IExecuteFunctions => {
+	const executeFunctions = mockDeep<IExecuteFunctions>();
+
+	executeFunctions.getCredentials
+		.calledWith('googlePalmApi')
+		.mockResolvedValue(mock<ICredentialDataDecryptedObject>());
+	executeFunctions.getNodeParameter.calledWith('prompt', 0).mockReturnValue(prompt);
+	executeFunctions.getNodeParameter
+		.calledWith('options.binaryPropertyOutput', 0)
+		.mockReturnValue(outputProperty);
+	executeFunctions.getNodeParameter.calledWith('images', 0).mockReturnValue(images);
+	executeFunctions.helpers.assertBinaryData.mockReturnValue(mock<IBinaryData>({ mimeType }));
+	executeFunctions.helpers.getBinaryDataBuffer.mockImplementation(async (_index, propertyName) =>
+		Buffer.from(`${propertyName} data`),
+	);
+	executeFunctions.helpers.prepareBinaryData.mockImplementation(async (buffer, filename, mime) => ({
+		data: (buffer as Buffer).toString('base64'),
+		fileName: filename ?? 'image.png',
+		fileSize: (buffer as Buffer).length.toString(),
+		mimeType: mime ?? mimeType,
+	}));
+
+	executeFunctions.helpers.httpRequest
+		.calledWith(
+			expect.objectContaining({
+				url: expect.stringContaining('/upload/v1beta/files'),
+			}),
+		)
+		.mockResolvedValue({
+			headers: { 'x-goog-upload-url': 'https://mock-upload-url.com' },
+		});
+
+	executeFunctions.helpers.httpRequestWithAuthentication
+		.calledWith(
+			'googlePalmApi',
+			expect.objectContaining({
+				headers: expect.objectContaining({ 'X-Goog-Upload-Protocol': expect.any(String) }),
+			}),
+		)
+		.mockResolvedValue({
+			headers: { 'x-goog-upload-url': 'https://mock-upload-url.com' },
+		});
+
+	executeFunctions.helpers.httpRequestWithAuthentication
+		.calledWith(
+			'googlePalmApi',
+			expect.objectContaining({
+				url: expect.stringContaining('generateContent'),
+			}),
+		)
+		.mockResolvedValue(
+			invalidApiResponse
+				? { invalid: 'response' }
+				: {
+						candidates: [
+							{
+								content: {
+									parts: [{ inlineData: { data: outputBuffer.toString('base64'), mimeType } }],
+								},
+							},
+						],
+					},
+		);
+
+	executeFunctions.helpers.httpRequest
+		.calledWith(
+			expect.objectContaining({
+				method: 'POST',
+				url: expect.stringContaining('mock-upload-url'),
+			}),
+		)
+		.mockResolvedValue({
+			file: { name: 'files/test', uri: 'mockFileUri', mimeType, state: 'ACTIVE' },
+		});
+
+	return executeFunctions;
+};
+
+describe('Gemini Node image edit', () => {
+	it('should edit an image successfully', async () => {
+		const executeFunctions = getMockedExecuteFunctions();
+
+		const result = await execute.call(executeFunctions, 0);
+
+		expect(result).toEqual([
+			{
+				binary: {
+					edited: {
+						data: 'ZWRpdGVkIGltYWdl',
+						fileName: 'image.png',
+						fileSize: '12',
+						mimeType: 'image/png',
+					},
+				},
+				json: { fileName: 'image.png', fileSize: '12', mimeType: 'image/png', data: undefined },
+				pairedItem: { item: 0 },
+			},
+		]);
+	});
+
+	it('should handle custom output property name', async () => {
+		const executeFunctions = getMockedExecuteFunctions({
+			prompt: 'edit this image',
+			outputProperty: 'custom_output',
+		});
+
+		const result = await execute.call(executeFunctions, 0);
+
+		expect(result[0].binary).toHaveProperty('custom_output');
+		expect(result[0].binary).not.toHaveProperty('edited');
+	});
+
+	it('should handle multiple images', async () => {
+		const multiImageConfig = {
+			values: [{ binaryPropertyName: 'image1' }, { binaryPropertyName: 'image2' }],
+		};
+
+		const executeFunctions = getMockedExecuteFunctions({
+			prompt: 'combine images',
+			outputProperty: 'combined',
+			images: multiImageConfig,
+			outputBuffer: Buffer.from('combined image'),
+		});
+
+		const result = await execute.call(executeFunctions, 0);
+
+		expect(result[0].binary).toHaveProperty('combined');
+	});
+
+	it('should throw error for invalid images parameter', async () => {
+		const executeFunctions = getMockedExecuteFunctions(
+			{ prompt: 'test prompt', outputProperty: 'edited', images: { values: 'invalid' as never } }, // Invalid format
+		);
+
+		await expect(execute.call(executeFunctions, 0)).rejects.toThrow(
+			'Invalid images parameter format',
+		);
+	});
+
+	it('should throw error when no image data returned from API', async () => {
+		const executeFunctions = getMockedExecuteFunctions(
+			{
+				prompt: 'test prompt',
+				outputProperty: 'edited',
+				images: { values: [{ binaryPropertyName: 'data' }] },
+				outputBuffer: Buffer.from(''),
+			}, // Empty buffer to trigger error
+		);
+
+		await expect(execute.call(executeFunctions, 0)).rejects.toThrow(
+			'No image data returned from Gemini API',
+		);
+	});
+
+	it('should throw error for invalid API response format', async () => {
+		const executeFunctions = getMockedExecuteFunctions({
+			prompt: 'test prompt',
+			outputProperty: 'edited',
+			images: { values: [{ binaryPropertyName: 'data' }] },
+			invalidApiResponse: true,
+		});
+
+		await expect(execute.call(executeFunctions, 0)).rejects.toThrow(
+			'Invalid response format from Gemini API',
+		);
+	});
+
+	it('should handle empty prompt', async () => {
+		const executeFunctions = getMockedExecuteFunctions({ prompt: '' });
+
+		const result = await execute.call(executeFunctions, 0);
+
+		expect(result).toEqual([
+			{
+				binary: {
+					edited: {
+						data: 'ZWRpdGVkIGltYWdl',
+						fileName: 'image.png',
+						fileSize: '12',
+						mimeType: 'image/png',
+					},
+				},
+				json: { fileName: 'image.png', fileSize: '12', mimeType: 'image/png', data: undefined },
+				pairedItem: { item: 0 },
+			},
+		]);
+	});
+
+	it('should handle different MIME types', async () => {
+		const executeFunctions = getMockedExecuteFunctions({
+			prompt: 'enhance image',
+			outputProperty: 'enhanced',
+			images: { values: [{ binaryPropertyName: 'data' }] },
+			outputBuffer: Buffer.from('enhanced jpeg'),
+			mimeType: 'image/jpeg',
+		});
+
+		const result = await execute.call(executeFunctions, 0);
+
+		expect(result[0]?.binary?.enhanced?.mimeType).toBe('image/jpeg');
+		expect(result[0]?.json?.mimeType).toBe('image/jpeg');
+	});
+
+	it('should handle empty images array when no valid binary property names', async () => {
+		const executeFunctions = getMockedExecuteFunctions({
+			prompt: 'test prompt',
+			outputProperty: 'edited',
+			images: { values: [{ binaryPropertyName: '' }] },
+			outputBuffer: Buffer.from('no image response'),
+		});
+
+		const result = await execute.call(executeFunctions, 0);
+
+		expect(result).toEqual([
+			{
+				binary: {
+					edited: {
+						data: 'bm8gaW1hZ2UgcmVzcG9uc2U=',
+						fileName: 'image.png',
+						fileSize: '17',
+						mimeType: 'image/png',
+					},
+				},
+				json: { fileName: 'image.png', fileSize: '17', mimeType: 'image/png', data: undefined },
+				pairedItem: { item: 0 },
+			},
+		]);
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/image/edit.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/image/edit.operation.ts
@@ -1,0 +1,117 @@
+import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+import { updateDisplayOptions } from 'n8n-workflow';
+
+import type { GenerateContentResponse } from '../../helpers/interfaces';
+import { uploadFile } from '../../helpers/utils';
+import { apiRequest } from '../../transport';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Text Prompt',
+		name: 'prompt',
+		type: 'string',
+		placeholder: 'e.g. Make the sky more vibrant and add subtle sun rays',
+		description: 'Instruction describing how to edit the image',
+		default: '',
+		typeOptions: {
+			rows: 2,
+		},
+	},
+	{
+		displayName: 'Input Data Field Name',
+		name: 'binaryPropertyName',
+		type: 'string',
+		default: 'data',
+		placeholder: 'e.g. data',
+		hint: 'The name of the input field containing the binary file data to be processed',
+		description: 'Name of the binary field which contains the image to edit',
+	},
+	{
+		displayName: 'Options',
+		name: 'options',
+		placeholder: 'Add Option',
+		type: 'collection',
+		default: {},
+		options: [
+			{
+				displayName: 'Put Output in Field',
+				name: 'binaryPropertyOutput',
+				type: 'string',
+				default: 'edited',
+				hint: 'The name of the output field to put the binary file data in',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		operation: ['edit'],
+		resource: ['image'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(this: IExecuteFunctions, i: number): Promise<INodeExecutionData[]> {
+	const prompt = this.getNodeParameter('prompt', i, '');
+	const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i, 'data');
+	const binaryPropertyOutput = this.getNodeParameter('options.binaryPropertyOutput', i, 'data');
+	const outputKey = typeof binaryPropertyOutput === 'string' ? binaryPropertyOutput : 'data';
+
+	const promptLength = typeof prompt === 'string' ? prompt.length : 0;
+	console.log('[Gemini Edit Image] start', { promptLength, binaryPropertyName, outputKey });
+
+	const binaryData = this.helpers.assertBinaryData(i, binaryPropertyName);
+	const buffer = await this.helpers.getBinaryDataBuffer(i, binaryPropertyName);
+	const { fileUri, mimeType } = await uploadFile.call(this, buffer, binaryData.mimeType);
+	console.log('[Gemini Edit Image] uploaded', { fileUri, mimeType, inputSize: buffer.byteLength });
+
+	const model = 'models/gemini-2.5-flash-image-preview';
+	const generationConfig = {
+		responseModalities: ['IMAGE'],
+	};
+
+	const body = {
+		contents: [
+			{
+				role: 'user',
+				parts: [{ fileData: { fileUri, mimeType } }, { text: prompt }],
+			},
+		],
+		generationConfig,
+	};
+
+	console.log('[Gemini Edit Image] request', { model, parts: body.contents[0].parts.length });
+
+	const response = (await apiRequest.call(this, 'POST', `/v1beta/${model}:generateContent`, {
+		body,
+	})) as GenerateContentResponse;
+
+	console.log('[Gemini Edit Image] response', { candidates: response.candidates?.length ?? 0 });
+
+	const promises = response.candidates.map(async (candidate) => {
+		const imagePart = candidate.content.parts.find((part) => 'inlineData' in part);
+		console.log('[Gemini Edit Image] candidate', {
+			hasImage: Boolean(imagePart?.inlineData?.data),
+		});
+		const bufferOut = Buffer.from(imagePart?.inlineData.data ?? '', 'base64');
+		const binaryOut = await this.helpers.prepareBinaryData(
+			bufferOut,
+			'image.png',
+			imagePart?.inlineData.mimeType,
+		);
+		return {
+			binary: {
+				[outputKey]: binaryOut,
+			},
+			json: {
+				...binaryOut,
+				data: undefined,
+			},
+			pairedItem: { item: i },
+		};
+	});
+
+	return await Promise.all(promises);
+}

--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/image/index.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/image/index.ts
@@ -2,8 +2,9 @@ import type { INodeProperties } from 'n8n-workflow';
 
 import * as analyze from './analyze.operation';
 import * as generate from './generate.operation';
+import * as edit from './edit.operation';
 
-export { analyze, generate };
+export { analyze, generate, edit };
 
 export const description: INodeProperties[] = [
 	{
@@ -24,6 +25,12 @@ export const description: INodeProperties[] = [
 				action: 'Generate an image',
 				description: 'Creates an image from a text prompt',
 			},
+			{
+				name: 'Edit Image',
+				value: 'edit',
+				action: 'Edit an image',
+				description: 'Upload an image and apply edits based on the prompt',
+			},
 		],
 		default: 'generate',
 		displayOptions: {
@@ -34,4 +41,5 @@ export const description: INodeProperties[] = [
 	},
 	...analyze.description,
 	...generate.description,
+	...edit.description,
 ];

--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/image/index.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/image/index.ts
@@ -1,8 +1,8 @@
 import type { INodeProperties } from 'n8n-workflow';
 
 import * as analyze from './analyze.operation';
-import * as generate from './generate.operation';
 import * as edit from './edit.operation';
+import * as generate from './generate.operation';
 
 export { analyze, generate, edit };
 
@@ -16,7 +16,7 @@ export const description: INodeProperties[] = [
 			{
 				name: 'Analyze Image',
 				value: 'analyze',
-				action: 'Analyze image',
+				action: 'Analyze an image',
 				description: 'Take in images and answer questions about them',
 			},
 			{
@@ -29,7 +29,7 @@ export const description: INodeProperties[] = [
 				name: 'Edit Image',
 				value: 'edit',
 				action: 'Edit an image',
-				description: 'Upload an image and apply edits based on the prompt',
+				description: 'Upload one or more images and apply edits based on a prompt',
 			},
 		],
 		default: 'generate',
@@ -40,6 +40,6 @@ export const description: INodeProperties[] = [
 		},
 	},
 	...analyze.description,
-	...generate.description,
 	...edit.description,
+	...generate.description,
 ];


### PR DESCRIPTION
## Summary

- Adds new `Edit Image` operation to the Gemini node
- Uses the `models/gemini-2.5-flash-image-preview` to perform edits to provided images based on a prompt
- Accepts multiple images that the user can reference in the prompt using natural language

<img width="1490" height="675" alt="Screenshot 2025-09-02 152513" src="https://github.com/user-attachments/assets/b4f07762-c254-4b0c-829c-6b5bbe296cc5" />

## Related Linear tickets, Github issues, and Community forum posts

**Linear ticket** https://linear.app/n8n/issue/NODE-3565/add-bananas-to-gemini-node

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
