### PR TITLE
fix(core): Normalize Data Table return on update and allow string returns from DB (no-changelog)

### DIFF
--- a/packages/cli/src/modules/data-table/data-store-rows.repository.ts
+++ b/packages/cli/src/modules/data-table/data-store-rows.repository.ts
@@ -268,7 +268,7 @@ export class DataStoreRowsRepository {
 		}
 
 		if (useReturning) {
-			return extractReturningData(result.raw);
+			return normalizeRows(extractReturningData(result.raw), columns);
 		}
 
 		const ids = affectedRows.map((row) => row.id);

--- a/packages/cli/src/modules/data-table/utils/sql-utils.ts
+++ b/packages/cli/src/modules/data-table/utils/sql-utils.ts
@@ -163,9 +163,9 @@ function hasRowReturnData(data: unknown): data is DataStoreRowReturn {
 		'id' in data &&
 		isNumber(data.id) &&
 		'createdAt' in data &&
-		isDate(data.createdAt) &&
+		(isDate(data.createdAt) || typeof data.createdAt === 'string') &&
 		'updatedAt' in data &&
-		isDate(data.updatedAt)
+		(isDate(data.updatedAt) || typeof data.updatedAt === 'string')
 	);
 }
 


### PR DESCRIPTION
## Summary

On the internal instance we receive strings instead of dates when returning data from insert and update, which was failing a strict type check. Our normalization will handle this fine though, so relaxing this condition will unblock our internal launch.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
