### PR TITLE
fix(core)!: Type coercion of $fromAI default values

### DIFF
--- a/packages/workflow/src/from-ai-parse-utils.ts
+++ b/packages/workflow/src/from-ai-parse-utils.ts
@@ -104,19 +104,32 @@ export function generateZodSchema(placeholder: FromAIArgument): z.ZodTypeAny {
 	return schema;
 }
 
+function isFromAIArgumentType(value: string): value is FromAIArgumentType {
+	return ['string', 'number', 'boolean', 'json'].includes(value.toLowerCase());
+}
+
 /**
  * Parses the default value, preserving its original type.
  * @param value The default value as a string.
+ * @param type The expected type of the default value.
  * @returns The parsed default value in its appropriate type.
  */
 function parseDefaultValue(
 	value: string | undefined,
+	type: FromAIArgumentType = 'string',
 ): string | number | boolean | Record<string, unknown> | undefined {
-	if (value === undefined || value === '') return undefined;
+	if (value === undefined) return value;
+
 	const lowerValue = value.toLowerCase();
-	if (lowerValue === 'true') return true;
-	if (lowerValue === 'false') return false;
-	if (!isNaN(Number(value))) return Number(value);
+	if (type === 'string') {
+		return value.toString();
+	}
+
+	if (type === 'boolean' && (lowerValue === 'true' || lowerValue === 'false'))
+		return lowerValue === 'true';
+	if (type === 'number' && !isNaN(Number(value))) return Number(value);
+
+	// For type 'json' or any other case, attempt to parse as JSON
 	try {
 		return jsonParse(value);
 	} catch {
@@ -197,17 +210,17 @@ function parseArguments(argsString: string): FromAIArgument {
 		return trimmed;
 	});
 
-	const type = cleanArgs?.[2] || 'string';
+	const type = cleanArgs?.[2] ?? 'string';
 
-	if (!['string', 'number', 'boolean', 'json'].includes(type.toLowerCase())) {
+	if (!isFromAIArgumentType(type)) {
 		throw new ParseError(`Invalid type: ${type}`);
 	}
 
 	return {
 		key: cleanArgs[0] || '',
 		description: cleanArgs[1],
-		type: (cleanArgs?.[2] ?? 'string') as FromAIArgumentType,
-		defaultValue: parseDefaultValue(cleanArgs[3]),
+		type,
+		defaultValue: parseDefaultValue(cleanArgs[3], type),
 	};
 }
 

--- a/packages/workflow/test/from-ai-parse-utils.test.ts
+++ b/packages/workflow/test/from-ai-parse-utils.test.ts
@@ -11,10 +11,19 @@ describe('extractFromAICalls', () => {
 	test.each<[string, [unknown, unknown, unknown, unknown]]>([
 		['$fromAI("a", "b", "string")', ['a', 'b', 'string', undefined]],
 		['$fromAI("a", "b", "number", 5)', ['a', 'b', 'number', 5]],
+		['$fromAI("a", "b", "number", "5")', ['a', 'b', 'number', 5]],
 		['$fromAI("a", "`", "number", 5)', ['a', '`', 'number', 5]],
 		['$fromAI("a", "\\`", "number", 5)', ['a', '`', 'number', 5]], // this is a bit surprising, but intended
 		['$fromAI("a", "\\n", "number", 5)', ['a', 'n', 'number', 5]], // this is a bit surprising, but intended
 		['{{ $fromAI("a", "b", "boolean") }}', ['a', 'b', 'boolean', undefined]],
+		['{{ $fromAI("a", "b", "boolean", "true") }}', ['a', 'b', 'boolean', true]],
+		['{{ $fromAI("a", "b", "boolean", "false") }}', ['a', 'b', 'boolean', false]],
+		['{{ $fromAI("a", "b", "boolean", true) }}', ['a', 'b', 'boolean', true]],
+		['{{ $fromAI("a", "b", "string", "") }}', ['a', 'b', 'string', '']],
+		['{{ $fromAI("a", "b", "string", "null") }}', ['a', 'b', 'string', 'null']],
+		['{{ $fromAI("a", "b", "string", "5") }}', ['a', 'b', 'string', '5']],
+		['{{ $fromAI("a", "b", "string", "true") }}', ['a', 'b', 'string', 'true']],
+		['{{ $fromAI("a", "b", "string", "{}") }}', ['a', 'b', 'string', '{}']],
 	])('should parse args as expected for %s', (formula, [key, description, type, defaultValue]) => {
 		expect(extractFromAICalls(formula)).toEqual([
 			{


### PR DESCRIPTION
## Summary

This PR fixes an issue where AI agent tools would fail validation when optional `$fromAI` parameters were omitted, even though they had default values specified.

### The Problem
When using nodes as AI tools with `$fromAI()` parameters that include default values (e.g., `$fromAI('param', 'Optional', 'string', '')`), the AI agent correctly identifies these as optional but the schema validation incorrectly treats them as required, causing validation errors.

### The Solution
1. **Fixed `parseDefaultValue` function** to properly handle empty strings as valid default values (previously treated empty string as undefined)
2. **Improved type-aware parsing** by passing the expected type to `parseDefaultValue` for more accurate type coercion

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-1214/bug-agent-throwing-weird-error

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)