### PR TITLE
ci: Include SBOM with release

### DIFF
--- a/.github/workflows/release-attach-sbom.yml
+++ b/.github/workflows/release-attach-sbom.yml
@@ -8,10 +8,11 @@ jobs:
   generate-and-attach-sbom:
     name: Generate and Attach SBOM to Release
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 10
     permissions:
       contents: write
       id-token: write
+      attestations: write
     steps:
       - name: Checkout release tag
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -27,53 +28,29 @@ jobs:
           npm i -g corepack@0.33
           corepack enable
 
-      - name: Install dependencies (pnpm)
-        run: pnpm install --frozen-lockfile
+      - name: Install dependencies and pack packages
+        run: |
+          pnpm install --frozen-lockfile
+          mkdir -p npm-packages
+          pnpm pack -r --pack-destination ./npm-packages
 
       - name: Generate CycloneDX SBOM with Syft
         uses: anchore/sbom-action@b9a8bc8d2c19e9396f663e53c7b55848e98cf17c # v0.17.6
         with:
-          path: .
+          path: ./npm-packages
           format: cyclonedx-json
           output-file: sbom-npm.cdx.json
 
-      - name: Validate SBOM
-        run: |
-          # Comprehensive SBOM validation
-          if [[ ! -f "sbom-npm.cdx.json" ]]; then
-            echo "Error: SBOM file 'sbom-npm.cdx.json' not found in workspace"
-            ls -la
-            exit 1
-          fi
-          
-          # Validate JSON structure
-          if ! jq empty sbom-npm.cdx.json 2>/dev/null; then
-            echo "Error: SBOM file contains invalid JSON syntax"
-            echo "File contents preview:"
-            head -10 sbom-npm.cdx.json
-            exit 1
-          fi
-          
-          # Check for required CycloneDX fields
-          COMPONENT_COUNT=$(jq '.components | length' sbom-npm.cdx.json 2>/dev/null || echo "0")
-          BOM_FORMAT=$(jq -r '.bomFormat // "unknown"' sbom-npm.cdx.json 2>/dev/null)
-          SPEC_VERSION=$(jq -r '.specVersion // "unknown"' sbom-npm.cdx.json 2>/dev/null)
-          
-          if [[ "$BOM_FORMAT" != "CycloneDX" ]]; then
-            echo "Error: Invalid bomFormat '$BOM_FORMAT', expected 'CycloneDX'"
-            exit 1
-          fi
-          
-          if [[ "$SPEC_VERSION" == "unknown" ]]; then
-            echo "Error: Missing required field 'specVersion' in CycloneDX SBOM"
-            exit 1
-          fi
-          
-          if [[ "$COMPONENT_COUNT" == "0" ]]; then
-            echo "Warning: SBOM contains no components, this may indicate an issue with generation"
-          fi
-          
-          echo "SBOM validation successful: $COMPONENT_COUNT components, format: $BOM_FORMAT, spec: $SPEC_VERSION"
+      - name: Attest build provenance for npm packages
+        uses: actions/attest-build-provenance@977bb37082e0bfde04bb18e63b0632b7b5a1c4a3 # v3.0.0
+        with:
+          subject-path: './npm-packages/*.tgz'
+
+      - name: Attest SBOM for npm packages
+        uses: actions/attest-sbom@4651f806c01d8637787e274ac3bdf724ef169f34 # v3.0.0
+        with:
+          subject-path: './npm-packages/*.tgz'
+          sbom-path: 'sbom-npm.cdx.json'
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@9e9de2292db7abb3f51b7f4808d98f0d347a8919 # v3.7.0
@@ -88,14 +65,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          COMPONENT_COUNT=$(jq '.components | length' sbom-npm.cdx.json)
-          
           # Upload SBOM files to the existing release
           gh release upload "${{ github.event.release.tag_name }}" \
             sbom-npm.cdx.json \
             sbom-npm.cdx.sig \
             sbom-npm.cdx.pem \
-            --clobber
-          
-          echo "✅ SBOM files attached to release ${{ github.event.release.tag_name }}"
+            --clobber || echo "⚠️ Failed to upload SBOM files to release"
+
+          COMPONENT_COUNT=$(jq '.components | length' sbom-npm.cdx.json 2>/dev/null || echo "unknown")
+          echo "✅ SBOM workflow completed"
           echo "📊 SBOM contains $COMPONENT_COUNT components"
+          echo "🛡️ GitHub attestations created for packages"

--- a/.github/workflows/release-attach-sbom.yml
+++ b/.github/workflows/release-attach-sbom.yml
@@ -1,0 +1,86 @@
+name: 'Release: Attach SBOM'
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  generate-and-attach-sbom:
+    name: Generate and Attach SBOM to Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22.x
+
+      - name: Setup corepack and pnpm
+        run: |
+          npm i -g corepack@0.33
+          corepack enable
+
+      - name: Install dependencies (pnpm)
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate CycloneDX SBOM with Syft
+        uses: anchore/sbom-action@b9a8bc8d2c19e9396f663e53c7b55848e98cf17c # v0.17.6
+        with:
+          path: .
+          format: cyclonedx-json
+          output-file: sbom-npm.cdx.json
+
+      - name: Validate SBOM
+        run: |
+          # Comprehensive SBOM validation
+          if [[ ! -f "sbom-npm.cdx.json" ]]; then
+            echo "Error: SBOM file not found"
+            exit 1
+          fi
+          
+          # Validate JSON structure
+          if ! jq empty sbom-npm.cdx.json 2>/dev/null; then
+            echo "Error: SBOM is not valid JSON"
+            exit 1
+          fi
+          
+          # Check for required CycloneDX fields
+          COMPONENT_COUNT=$(jq '.components | length' sbom-npm.cdx.json 2>/dev/null || echo "0")
+          BOM_FORMAT=$(jq -r '.bomFormat // "unknown"' sbom-npm.cdx.json 2>/dev/null)
+          
+          if [[ "$BOM_FORMAT" != "CycloneDX" ]]; then
+            echo "Error: Invalid bomFormat: $BOM_FORMAT"
+            exit 1
+          fi
+          
+          echo "SBOM validation successful: $COMPONENT_COUNT components, format: $BOM_FORMAT"
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@9e9de2292db7abb3f51b7f4808d98f0d347a8919 # v3.7.0
+
+      - name: Sign SBOM (keyless)
+        run: cosign sign-blob --yes --output-signature sbom-npm.cdx.sig --output-certificate sbom-npm.cdx.pem sbom-npm.cdx.json
+
+      - name: Attach SBOM files to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Add descriptive comment to SBOM
+          COMPONENT_COUNT=$(jq '.components | length' sbom-npm.cdx.json)
+          
+          # Upload SBOM files to the existing release
+          gh release upload "${{ github.event.release.tag_name }}" \
+            sbom-npm.cdx.json \
+            sbom-npm.cdx.sig \
+            sbom-npm.cdx.pem \
+            --clobber
+          
+          echo "✅ SBOM files attached to release ${{ github.event.release.tag_name }}"
+          echo "📊 SBOM contains $COMPONENT_COUNT components"

--- a/.github/workflows/release-attach-sbom.yml
+++ b/.github/workflows/release-attach-sbom.yml
@@ -8,7 +8,7 @@ jobs:
   generate-and-attach-sbom:
     name: Generate and Attach SBOM to Release
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     permissions:
       contents: write
       id-token: write
@@ -27,6 +27,13 @@ jobs:
         run: |
           npm i -g corepack@0.33
           corepack enable
+
+      - name: Restore build artifacts from cache
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: ./packages/**/dist
+          key: ${{ github.event.release.tag_name }}-release:build
+          fail-on-cache-miss: true
 
       - name: Install dependencies and pack packages
         run: |

--- a/.github/workflows/release-attach-sbom.yml
+++ b/.github/workflows/release-attach-sbom.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ./packages/**/dist
-          key: ${{ github.event.release.tag_name }}-release:build
+          key: ${{ github.event.release.target_commitish }}-release:build
           fail-on-cache-miss: true
 
       - name: Install dependencies and pack packages
@@ -77,7 +77,7 @@ jobs:
             sbom-npm.cdx.json \
             sbom-npm.cdx.sig \
             sbom-npm.cdx.pem \
-            --clobber || echo "⚠️ Failed to upload SBOM files to release"
+            --clobber
 
           COMPONENT_COUNT=$(jq '.components | length' sbom-npm.cdx.json 2>/dev/null || echo "unknown")
           echo "✅ SBOM workflow completed"

--- a/.github/workflows/release-attach-sbom.yml
+++ b/.github/workflows/release-attach-sbom.yml
@@ -73,3 +73,13 @@ jobs:
           echo "✅ SBOM workflow completed"
           echo "📊 SBOM contains $COMPONENT_COUNT components"
           echo "🛡️ GitHub attestations created for source release"
+
+      - name: Notify Slack on failure
+        if: failure()
+        uses: act10ns/slack@44541246747a30eb3102d87f7a4cc5471b0ffb7d # v2.1.0
+        with:
+          status: ${{ job.status }}
+          channel: '#alerts-build'
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          message: |
+            <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}| SBOM generation and attachment failed for release ${{ github.event.release.tag_name }} >

--- a/.github/workflows/release-attach-sbom.yml
+++ b/.github/workflows/release-attach-sbom.yml
@@ -8,7 +8,7 @@ jobs:
   generate-and-attach-sbom:
     name: Generate and Attach SBOM to Release
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     permissions:
       contents: write
       id-token: write
@@ -41,38 +41,53 @@ jobs:
         run: |
           # Comprehensive SBOM validation
           if [[ ! -f "sbom-npm.cdx.json" ]]; then
-            echo "Error: SBOM file not found"
+            echo "Error: SBOM file 'sbom-npm.cdx.json' not found in workspace"
+            ls -la
             exit 1
           fi
           
           # Validate JSON structure
           if ! jq empty sbom-npm.cdx.json 2>/dev/null; then
-            echo "Error: SBOM is not valid JSON"
+            echo "Error: SBOM file contains invalid JSON syntax"
+            echo "File contents preview:"
+            head -10 sbom-npm.cdx.json
             exit 1
           fi
           
           # Check for required CycloneDX fields
           COMPONENT_COUNT=$(jq '.components | length' sbom-npm.cdx.json 2>/dev/null || echo "0")
           BOM_FORMAT=$(jq -r '.bomFormat // "unknown"' sbom-npm.cdx.json 2>/dev/null)
+          SPEC_VERSION=$(jq -r '.specVersion // "unknown"' sbom-npm.cdx.json 2>/dev/null)
           
           if [[ "$BOM_FORMAT" != "CycloneDX" ]]; then
-            echo "Error: Invalid bomFormat: $BOM_FORMAT"
+            echo "Error: Invalid bomFormat '$BOM_FORMAT', expected 'CycloneDX'"
             exit 1
           fi
           
-          echo "SBOM validation successful: $COMPONENT_COUNT components, format: $BOM_FORMAT"
+          if [[ "$SPEC_VERSION" == "unknown" ]]; then
+            echo "Error: Missing required field 'specVersion' in CycloneDX SBOM"
+            exit 1
+          fi
+          
+          if [[ "$COMPONENT_COUNT" == "0" ]]; then
+            echo "Warning: SBOM contains no components, this may indicate an issue with generation"
+          fi
+          
+          echo "SBOM validation successful: $COMPONENT_COUNT components, format: $BOM_FORMAT, spec: $SPEC_VERSION"
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@9e9de2292db7abb3f51b7f4808d98f0d347a8919 # v3.7.0
 
       - name: Sign SBOM (keyless)
-        run: cosign sign-blob --yes --output-signature sbom-npm.cdx.sig --output-certificate sbom-npm.cdx.pem sbom-npm.cdx.json
+        run: |
+          # Sign SBOM using Cosign keyless signing with GitHub OIDC
+          # This provides cryptographic proof of authenticity and integrity
+          cosign sign-blob --yes --output-signature sbom-npm.cdx.sig --output-certificate sbom-npm.cdx.pem sbom-npm.cdx.json
 
       - name: Attach SBOM files to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Add descriptive comment to SBOM
           COMPONENT_COUNT=$(jq '.components | length' sbom-npm.cdx.json)
           
           # Upload SBOM files to the existing release

--- a/.github/workflows/release-attach-sbom.yml
+++ b/.github/workflows/release-attach-sbom.yml
@@ -28,36 +28,26 @@ jobs:
           npm i -g corepack@0.33
           corepack enable
 
-      - name: Restore build artifacts from cache
-        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
-        with:
-          path: ./packages/**/dist
-          key: ${{ github.event.release.target_commitish }}-release:build
-          fail-on-cache-miss: true
+      - name: Install dependencies for SBOM generation
+        run: pnpm install --frozen-lockfile
 
-      - name: Install dependencies and pack packages
-        run: |
-          pnpm install --frozen-lockfile
-          mkdir -p npm-packages
-          pnpm pack -r --pack-destination ./npm-packages
-
-      - name: Generate CycloneDX SBOM with Syft
+      - name: Generate CycloneDX SBOM for source code
         uses: anchore/sbom-action@b9a8bc8d2c19e9396f663e53c7b55848e98cf17c # v0.17.6
         with:
-          path: ./npm-packages
+          path: ./
           format: cyclonedx-json
-          output-file: sbom-npm.cdx.json
+          output-file: sbom-source.cdx.json
 
-      - name: Attest build provenance for npm packages
+      - name: Attest build provenance for source release
         uses: actions/attest-build-provenance@977bb37082e0bfde04bb18e63b0632b7b5a1c4a3 # v3.0.0
         with:
-          subject-path: './npm-packages/*.tgz'
+          subject-path: './package.json'
 
-      - name: Attest SBOM for npm packages
+      - name: Attest SBOM for source release
         uses: actions/attest-sbom@4651f806c01d8637787e274ac3bdf724ef169f34 # v3.0.0
         with:
-          subject-path: './npm-packages/*.tgz'
-          sbom-path: 'sbom-npm.cdx.json'
+          subject-path: './package.json'
+          sbom-path: 'sbom-source.cdx.json'
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@9e9de2292db7abb3f51b7f4808d98f0d347a8919 # v3.7.0
@@ -66,7 +56,7 @@ jobs:
         run: |
           # Sign SBOM using Cosign keyless signing with GitHub OIDC
           # This provides cryptographic proof of authenticity and integrity
-          cosign sign-blob --yes --output-signature sbom-npm.cdx.sig --output-certificate sbom-npm.cdx.pem sbom-npm.cdx.json
+          cosign sign-blob --yes --output-signature sbom-source.cdx.sig --output-certificate sbom-source.cdx.pem sbom-source.cdx.json
 
       - name: Attach SBOM files to release
         env:
@@ -74,12 +64,12 @@ jobs:
         run: |
           # Upload SBOM files to the existing release
           gh release upload "${{ github.event.release.tag_name }}" \
-            sbom-npm.cdx.json \
-            sbom-npm.cdx.sig \
-            sbom-npm.cdx.pem \
+            sbom-source.cdx.json \
+            sbom-source.cdx.sig \
+            sbom-source.cdx.pem \
             --clobber
 
-          COMPONENT_COUNT=$(jq '.components | length' sbom-npm.cdx.json 2>/dev/null || echo "unknown")
+          COMPONENT_COUNT=$(jq '.components | length' sbom-source.cdx.json 2>/dev/null || echo "unknown")
           echo "✅ SBOM workflow completed"
           echo "📊 SBOM contains $COMPONENT_COUNT components"
-          echo "🛡️ GitHub attestations created for packages"
+          echo "🛡️ GitHub attestations created for source release"


### PR DESCRIPTION
## Summary
Process:
1. Checks out the exact release tag
2. Installs dependencies to build complete dependency tree
3. Generates CycloneDX SBOM for the entire source codebase
4. Creates GitHub attestations for build provenance and SBOM verification
5. Signs SBOM using Cosign keyless signing with GitHub OIDC
6. Attaches all security artifacts to the release

New release assets:
  - sbom-source.cdx.json - Complete dependency inventory (JSON format)
  - sbom-source.cdx.sig - Cryptographic signature of the SBOM
  - sbom-source.cdx.pem - Certificate for signature verification

GitHub attestations:
- Build provenance - Cryptographic proof of how the release was built
- SBOM attestation - Links the dependency inventory to the release

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/CAT-1126/include-a-signed-sbom-software-bill-of-materials-with-every-release-of


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
