### PR TITLE
feat(API): Add cancel status filters to the public api executions endpoint

### DIFF
--- a/packages/@n8n/db/src/entities/execution-entity.ts
+++ b/packages/@n8n/db/src/entities/execution-entity.ts
@@ -32,7 +32,7 @@ export class ExecutionEntity {
 	id: string;
 
 	/**
-	 * Whether the execution finished sucessfully.
+	 * Whether the execution finished successfully.
 	 *
 	 * @deprecated Use `status` instead
 	 */

--- a/packages/@n8n/db/src/repositories/__tests__/execution.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/execution.repository.test.ts
@@ -1,0 +1,233 @@
+import { Container, type Constructable } from '@n8n/di';
+import { DataSource, EntityManager, In, LessThan, type EntityMetadata } from '@n8n/typeorm';
+import { mock } from 'jest-mock-extended';
+import type { Class } from 'n8n-core';
+import type { DeepPartial } from 'ts-essentials';
+
+import { ExecutionEntity } from '../../entities';
+import { ExecutionRepository } from '../execution.repository';
+
+export const mockInstance = <T>(
+	serviceClass: Constructable<T>,
+	data: DeepPartial<T> | undefined = undefined,
+) => {
+	const instance = mock<T>(data);
+	Container.set(serviceClass, instance);
+	return instance;
+};
+
+const mockEntityManager = (entityClass: Class) => {
+	const entityManager = mockInstance(EntityManager);
+	const dataSource = mockInstance(DataSource, {
+		manager: entityManager,
+		getMetadata: () => mock<EntityMetadata>({ target: entityClass }),
+	});
+	Object.assign(entityManager, { connection: dataSource });
+	return entityManager;
+};
+
+describe('ExecutionRepository', () => {
+	const entityManager = mockEntityManager(ExecutionEntity);
+	const executionRepository = Container.get(ExecutionRepository);
+
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
+	describe('getExecutionsForPublicApi', () => {
+		test('should get executions matching the filter parameters', async () => {
+			const limit = 10;
+			const params = {
+				limit: 10,
+				lastId: '3',
+				workflowIds: ['3', '4'],
+			};
+			const mockEntities = [{ id: '1' }, { id: '2' }];
+
+			entityManager.find.mockResolvedValueOnce(mockEntities);
+			const result = await executionRepository.getExecutionsForPublicApi(params);
+
+			expect(entityManager.find).toHaveBeenCalledWith(ExecutionEntity, {
+				select: [
+					'id',
+					'mode',
+					'retryOf',
+					'retrySuccessId',
+					'startedAt',
+					'stoppedAt',
+					'workflowId',
+					'waitTill',
+					'finished',
+					'status',
+				],
+				where: {
+					id: LessThan(params.lastId),
+					workflowId: In(params.workflowIds),
+				},
+				order: { id: 'DESC' },
+				take: limit,
+				relations: ['executionData'],
+			});
+			expect(result.length).toBe(mockEntities.length);
+			expect(result[0].id).toEqual(mockEntities[0].id);
+		});
+
+		describe('with status filter', () => {
+			test.each`
+				filterStatus  | entityStatus
+				${'canceled'} | ${'canceled'}
+				${'error'}    | ${In(['error', 'crashed'])}
+				${'success'}  | ${'success'}
+				${'waiting'}  | ${'waiting'}
+			`('should find all "$filterStatus" executions', async ({ filterStatus, entityStatus }) => {
+				const limit = 10;
+				const mockEntities = [{ id: '1' }, { id: '2' }];
+
+				entityManager.find.mockResolvedValueOnce(mockEntities);
+				const result = await executionRepository.getExecutionsForPublicApi({
+					limit,
+					status: filterStatus,
+				});
+
+				expect(entityManager.find).toHaveBeenCalledWith(ExecutionEntity, {
+					select: [
+						'id',
+						'mode',
+						'retryOf',
+						'retrySuccessId',
+						'startedAt',
+						'stoppedAt',
+						'workflowId',
+						'waitTill',
+						'finished',
+						'status',
+					],
+					where: { status: entityStatus },
+					order: { id: 'DESC' },
+					take: limit,
+					relations: ['executionData'],
+				});
+				expect(result.length).toBe(mockEntities.length);
+				expect(result[0].id).toEqual(mockEntities[0].id);
+			});
+
+			test.each`
+				filterStatus
+				${'crashed'}
+				${'new'}
+				${'running'}
+				${'unknown'}
+			`(
+				'should find all executions and ignore status filter "$filterStatus"',
+				async ({ filterStatus }) => {
+					const limit = 10;
+					const mockEntities = [{ id: '1' }, { id: '2' }];
+
+					entityManager.find.mockResolvedValueOnce(mockEntities);
+					const result = await executionRepository.getExecutionsForPublicApi({
+						limit,
+						status: filterStatus,
+					});
+
+					expect(entityManager.find).toHaveBeenCalledWith(ExecutionEntity, {
+						select: [
+							'id',
+							'mode',
+							'retryOf',
+							'retrySuccessId',
+							'startedAt',
+							'stoppedAt',
+							'workflowId',
+							'waitTill',
+							'finished',
+							'status',
+						],
+						where: {},
+						order: { id: 'DESC' },
+						take: limit,
+						relations: ['executionData'],
+					});
+					expect(result.length).toBe(mockEntities.length);
+					expect(result[0].id).toEqual(mockEntities[0].id);
+				},
+			);
+		});
+	});
+
+	describe('getExecutionsCountForPublicApi', () => {
+		test('should get executions matching the filter parameters', async () => {
+			const limit = 10;
+			const mockCount = 20;
+			const params = {
+				limit: 10,
+				lastId: '3',
+				workflowIds: ['3', '4'],
+			};
+
+			entityManager.count.mockResolvedValueOnce(mockCount);
+			const result = await executionRepository.getExecutionsCountForPublicApi(params);
+
+			expect(entityManager.count).toHaveBeenCalledWith(ExecutionEntity, {
+				where: {
+					id: LessThan(params.lastId),
+					workflowId: In(params.workflowIds),
+				},
+				take: limit,
+			});
+			expect(result).toBe(mockCount);
+		});
+
+		describe('with status filter', () => {
+			test.each`
+				filterStatus  | entityStatus
+				${'canceled'} | ${'canceled'}
+				${'error'}    | ${In(['error', 'crashed'])}
+				${'success'}  | ${'success'}
+				${'waiting'}  | ${'waiting'}
+			`('should retrieve all $filterStatus executions', async ({ filterStatus, entityStatus }) => {
+				const limit = 10;
+				const mockCount = 20;
+
+				entityManager.count.mockResolvedValueOnce(mockCount);
+				const result = await executionRepository.getExecutionsCountForPublicApi({
+					limit,
+					status: filterStatus,
+				});
+
+				expect(entityManager.count).toHaveBeenCalledWith(ExecutionEntity, {
+					where: { status: entityStatus },
+					take: limit,
+				});
+
+				expect(result).toBe(mockCount);
+			});
+
+			test.each`
+				filterStatus
+				${'crashed'}
+				${'new'}
+				${'running'}
+				${'unknown'}
+			`(
+				'should find all executions and ignore status filter "$filterStatus"',
+				async ({ filterStatus }) => {
+					const limit = 10;
+					const mockCount = 20;
+
+					entityManager.count.mockResolvedValueOnce(mockCount);
+					const result = await executionRepository.getExecutionsCountForPublicApi({
+						limit,
+						status: filterStatus,
+					});
+
+					expect(entityManager.count).toHaveBeenCalledWith(ExecutionEntity, {
+						where: {},
+						take: limit,
+					});
+
+					expect(result).toBe(mockCount);
+				},
+			);
+		});
+	});
+});

--- a/packages/@n8n/db/src/repositories/__tests__/execution.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/execution.repository.test.ts
@@ -7,7 +7,7 @@ import type { DeepPartial } from 'ts-essentials';
 import { ExecutionEntity } from '../../entities';
 import { ExecutionRepository } from '../execution.repository';
 
-export const mockInstance = <T>(
+const mockInstance = <T>(
 	serviceClass: Constructable<T>,
 	data: DeepPartial<T> | undefined = undefined,
 ) => {

--- a/packages/@n8n/db/src/repositories/execution.repository.ts
+++ b/packages/@n8n/db/src/repositories/execution.repository.ts
@@ -660,6 +660,10 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 			condition.status = 'waiting';
 		} else if (status === 'error') {
 			condition.status = In(['error', 'crashed']);
+		} else if (status === 'canceled') {
+			condition.status = 'canceled';
+		} else if (status === 'running') {
+			condition.status = 'running';
 		}
 
 		return condition;

--- a/packages/@n8n/db/src/repositories/execution.repository.ts
+++ b/packages/@n8n/db/src/repositories/execution.repository.ts
@@ -638,7 +638,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 		status?: ExecutionStatus;
 		excludedWorkflowIds?: string[];
 	}): Promise<number> {
-		const executions = await this.count({
+		const executionsCount = await this.count({
 			where: {
 				...(data.lastId && { id: LessThan(data.lastId) }),
 				...(data.status && { ...this.getStatusCondition(data.status) }),
@@ -648,7 +648,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 			take: data.limit,
 		});
 
-		return executions;
+		return executionsCount;
 	}
 
 	private getStatusCondition(status: ExecutionStatus) {
@@ -662,8 +662,6 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 			condition.status = In(['error', 'crashed']);
 		} else if (status === 'canceled') {
 			condition.status = 'canceled';
-		} else if (status === 'running') {
-			condition.status = 'running';
 		}
 
 		return condition;

--- a/packages/cli/src/public-api/v1/handlers/executions/spec/paths/executions.yml
+++ b/packages/cli/src/public-api/v1/handlers/executions/spec/paths/executions.yml
@@ -13,7 +13,7 @@ get:
       required: false
       schema:
         type: string
-        enum: ['error', 'success', 'waiting']
+        enum: ['canceled', 'error', 'running', 'success', 'waiting']
     - name: workflowId
       in: query
       description: Workflow to filter the executions by.

--- a/packages/cli/src/public-api/v1/handlers/executions/spec/paths/executions.yml
+++ b/packages/cli/src/public-api/v1/handlers/executions/spec/paths/executions.yml
@@ -13,7 +13,7 @@ get:
       required: false
       schema:
         type: string
-        enum: ['canceled', 'error', 'running', 'success', 'waiting']
+        enum: ['canceled', 'error', 'success', 'waiting']
     - name: workflowId
       in: query
       description: Workflow to filter the executions by.

--- a/packages/cli/test/integration/public-api/executions.test.ts
+++ b/packages/cli/test/integration/public-api/executions.test.ts
@@ -297,6 +297,7 @@ describe('GET /executions', () => {
 	});
 
 	describe('with query status', () => {
+		type AllowedQueryStatus = 'success' | 'error' | 'canceled' | 'waiting';
 		test.each`
 			queryStatus   | entityStatus
 			${'canceled'} | ${'canceled'}
@@ -309,7 +310,7 @@ describe('GET /executions', () => {
 			async ({
 				queryStatus,
 				entityStatus,
-			}: { queryStatus: ExecutionStatus; entityStatus: ExecutionStatus }) => {
+			}: { queryStatus: AllowedQueryStatus; entityStatus: ExecutionStatus }) => {
 				const workflow = await createWorkflow({}, owner);
 
 				await createdExecutionWithStatus(workflow, queryStatus === 'success' ? 'error' : 'success');

--- a/packages/cli/test/integration/public-api/executions.test.ts
+++ b/packages/cli/test/integration/public-api/executions.test.ts
@@ -7,18 +7,17 @@ import {
 	testDb,
 } from '@n8n/backend-test-utils';
 import type { ExecutionEntity, User } from '@n8n/db';
+import type { ExecutionStatus } from 'n8n-workflow';
 
 import type { ActiveWorkflowManager } from '@/active-workflow-manager';
 import { Telemetry } from '@/telemetry';
 
 import {
-	createCanceledExecution,
+	createdExecutionWithStatus,
 	createErrorExecution,
 	createExecution,
 	createManyExecutions,
-	createRunningExecution,
 	createSuccessfulExecution,
-	createWaitingExecution,
 } from '../shared/db/executions';
 import { createMemberWithApiKey, createOwnerWithApiKey } from '../shared/db/users';
 import type { SuperAgentTest } from '../shared/types';
@@ -240,46 +239,6 @@ describe('GET /executions', () => {
 
 	test('should fail due to invalid API Key', testWithAPIKey('get', '/executions', 'abcXYZ'));
 
-	test('should retrieve all successful executions', async () => {
-		const workflow = await createWorkflow({}, owner);
-
-		const successfulExecution = await createSuccessfulExecution(workflow);
-
-		await createErrorExecution(workflow);
-
-		const response = await authOwnerAgent.get('/executions').query({
-			status: 'success',
-		});
-
-		expect(response.statusCode).toBe(200);
-		expect(response.body.data.length).toBe(1);
-		expect(response.body.nextCursor).toBe(null);
-
-		const {
-			id,
-			finished,
-			mode,
-			retryOf,
-			retrySuccessId,
-			startedAt,
-			stoppedAt,
-			workflowId,
-			waitTill,
-			status,
-		} = response.body.data[0];
-
-		expect(id).toBeDefined();
-		expect(finished).toBe(true);
-		expect(mode).toEqual(successfulExecution.mode);
-		expect(retrySuccessId).toBeNull();
-		expect(retryOf).toBeNull();
-		expect(startedAt).not.toBeNull();
-		expect(stoppedAt).not.toBeNull();
-		expect(workflowId).toBe(successfulExecution.workflowId);
-		expect(waitTill).toBeNull();
-		expect(status).toBe(successfulExecution.status);
-	});
-
 	test('should paginate two executions', async () => {
 		const workflow = await createWorkflow({}, owner);
 
@@ -337,166 +296,41 @@ describe('GET /executions', () => {
 		}
 	});
 
-	test('should retrieve all error executions', async () => {
-		const workflow = await createWorkflow({}, owner);
+	describe('with query status', () => {
+		test.each`
+			queryStatus   | entityStatus
+			${'canceled'} | ${'canceled'}
+			${'error'}    | ${'error'}
+			${'error'}    | ${'crashed'}
+			${'running'}  | ${'running'}
+			${'success'}  | ${'success'}
+			${'waiting'}  | ${'waiting'}
+		`(
+			'should retrieve all $queryStatus executions',
+			async ({
+				queryStatus,
+				entityStatus,
+			}: { queryStatus: ExecutionStatus; entityStatus: ExecutionStatus }) => {
+				const workflow = await createWorkflow({}, owner);
 
-		await createSuccessfulExecution(workflow);
+				await createdExecutionWithStatus(workflow, queryStatus === 'success' ? 'error' : 'success');
 
-		const errorExecution = await createErrorExecution(workflow);
+				const expectedExecution = await createdExecutionWithStatus(workflow, entityStatus);
 
-		const response = await authOwnerAgent.get('/executions').query({
-			status: 'error',
-		});
+				const response = await authOwnerAgent.get('/executions').query({
+					status: queryStatus,
+				});
 
-		expect(response.statusCode).toBe(200);
-		expect(response.body.data.length).toBe(1);
-		expect(response.body.nextCursor).toBe(null);
+				expect(response.statusCode).toBe(200);
+				expect(response.body.data.length).toBe(1);
+				expect(response.body.nextCursor).toBe(null);
 
-		const {
-			id,
-			finished,
-			mode,
-			retryOf,
-			retrySuccessId,
-			startedAt,
-			stoppedAt,
-			workflowId,
-			waitTill,
-			status,
-		} = response.body.data[0];
+				const { id, status } = response.body.data[0];
 
-		expect(id).toBeDefined();
-		expect(finished).toBe(false);
-		expect(mode).toEqual(errorExecution.mode);
-		expect(retrySuccessId).toBeNull();
-		expect(retryOf).toBeNull();
-		expect(startedAt).not.toBeNull();
-		expect(stoppedAt).not.toBeNull();
-		expect(workflowId).toBe(errorExecution.workflowId);
-		expect(waitTill).toBeNull();
-		expect(status).toBe(errorExecution.status);
-	});
-
-	test('should retrieve all canceled executions', async () => {
-		const workflow = await createWorkflow({}, owner);
-
-		await createSuccessfulExecution(workflow);
-
-		const errorExecution = await createCanceledExecution(workflow);
-
-		const response = await authOwnerAgent.get('/executions').query({
-			status: 'canceled',
-		});
-
-		expect(response.statusCode).toBe(200);
-		expect(response.body.data.length).toBe(1);
-		expect(response.body.nextCursor).toBe(null);
-
-		const {
-			id,
-			finished,
-			mode,
-			retryOf,
-			retrySuccessId,
-			startedAt,
-			stoppedAt,
-			workflowId,
-			waitTill,
-			status,
-		} = response.body.data[0];
-
-		expect(id).toBeDefined();
-		expect(finished).toBe(false);
-		expect(mode).toEqual(errorExecution.mode);
-		expect(retrySuccessId).toBeNull();
-		expect(retryOf).toBeNull();
-		expect(startedAt).not.toBeNull();
-		expect(stoppedAt).not.toBeNull();
-		expect(workflowId).toBe(errorExecution.workflowId);
-		expect(waitTill).toBeNull();
-		expect(status).toBe(errorExecution.status);
-	});
-
-	test('should retrieve all running executions', async () => {
-		const workflow = await createWorkflow({}, owner);
-
-		await createSuccessfulExecution(workflow);
-
-		const errorExecution = await createRunningExecution(workflow);
-
-		const response = await authOwnerAgent.get('/executions').query({
-			status: 'running',
-		});
-
-		expect(response.statusCode).toBe(200);
-		expect(response.body.data.length).toBe(1);
-		expect(response.body.nextCursor).toBe(null);
-
-		const {
-			id,
-			finished,
-			mode,
-			retryOf,
-			retrySuccessId,
-			startedAt,
-			stoppedAt,
-			workflowId,
-			waitTill,
-			status,
-		} = response.body.data[0];
-
-		expect(id).toBeDefined();
-		expect(finished).toBe(false);
-		expect(mode).toEqual(errorExecution.mode);
-		expect(retrySuccessId).toBeNull();
-		expect(retryOf).toBeNull();
-		expect(startedAt).not.toBeNull();
-		expect(stoppedAt).not.toBeNull();
-		expect(workflowId).toBe(errorExecution.workflowId);
-		expect(waitTill).toBeNull();
-		expect(status).toBe(errorExecution.status);
-	});
-
-	test('should return all waiting executions', async () => {
-		const workflow = await createWorkflow({}, owner);
-
-		await createSuccessfulExecution(workflow);
-
-		await createErrorExecution(workflow);
-
-		const waitingExecution = await createWaitingExecution(workflow);
-
-		const response = await authOwnerAgent.get('/executions').query({
-			status: 'waiting',
-		});
-
-		expect(response.statusCode).toBe(200);
-		expect(response.body.data.length).toBe(1);
-		expect(response.body.nextCursor).toBe(null);
-
-		const {
-			id,
-			finished,
-			mode,
-			retryOf,
-			retrySuccessId,
-			startedAt,
-			stoppedAt,
-			workflowId,
-			waitTill,
-			status,
-		} = response.body.data[0];
-
-		expect(id).toBeDefined();
-		expect(finished).toBe(false);
-		expect(mode).toEqual(waitingExecution.mode);
-		expect(retrySuccessId).toBeNull();
-		expect(retryOf).toBeNull();
-		expect(startedAt).not.toBeNull();
-		expect(stoppedAt).not.toBeNull();
-		expect(workflowId).toBe(waitingExecution.workflowId);
-		expect(new Date(waitTill).getTime()).toBeGreaterThan(Date.now() - 1000);
-		expect(status).toBe(waitingExecution.status);
+				expect(id).toBeDefined();
+				expect(status).toBe(expectedExecution.status);
+			},
+		);
 	});
 
 	test('should retrieve all executions of specific workflow', async () => {

--- a/packages/cli/test/integration/public-api/executions.test.ts
+++ b/packages/cli/test/integration/public-api/executions.test.ts
@@ -302,7 +302,6 @@ describe('GET /executions', () => {
 			${'canceled'} | ${'canceled'}
 			${'error'}    | ${'error'}
 			${'error'}    | ${'crashed'}
-			${'running'}  | ${'running'}
 			${'success'}  | ${'success'}
 			${'waiting'}  | ${'waiting'}
 		`(

--- a/packages/cli/test/integration/shared/db/executions.ts
+++ b/packages/cli/test/integration/shared/db/executions.ts
@@ -7,7 +7,7 @@ import {
 	AnnotationTagRepository,
 } from '@n8n/db';
 import { Container } from '@n8n/di';
-import type { AnnotationVote, IWorkflowBase } from 'n8n-workflow';
+import type { AnnotationVote, ExecutionStatus, IWorkflowBase } from 'n8n-workflow';
 
 import { ExecutionService } from '@/executions/execution.service';
 import { Telemetry } from '@/telemetry';
@@ -105,17 +105,17 @@ export async function createWaitingExecution(workflow: IWorkflowBase) {
 }
 
 /**
- * Store a canceled execution in the DB and assign it to a workflow.
+ * Store an execution with a given status in the DB and assign it to a workflow.
  */
-export async function createCanceledExecution(workflow: IWorkflowBase) {
-	return await createExecution({ finished: false, status: 'canceled' }, workflow);
-}
+export async function createdExecutionWithStatus(workflow: IWorkflowBase, status: ExecutionStatus) {
+	const execution: Partial<ExecutionEntity> = {
+		status,
+		finished: status === 'success' ? true : false,
+		stoppedAt: ['crashed', 'error'].includes(status) ? new Date() : undefined,
+		waitTill: status === 'waiting' ? new Date() : undefined,
+	};
 
-/**
- * Store a canceled execution in the DB and assign it to a workflow.
- */
-export async function createRunningExecution(workflow: IWorkflowBase) {
-	return await createExecution({ finished: false, status: 'running' }, workflow);
+	return await createExecution(execution, workflow);
 }
 
 export async function annotateExecution(

--- a/packages/cli/test/integration/shared/db/executions.ts
+++ b/packages/cli/test/integration/shared/db/executions.ts
@@ -104,6 +104,20 @@ export async function createWaitingExecution(workflow: IWorkflowBase) {
 	);
 }
 
+/**
+ * Store a canceled execution in the DB and assign it to a workflow.
+ */
+export async function createCanceledExecution(workflow: IWorkflowBase) {
+	return await createExecution({ finished: false, status: 'canceled' }, workflow);
+}
+
+/**
+ * Store a canceled execution in the DB and assign it to a workflow.
+ */
+export async function createRunningExecution(workflow: IWorkflowBase) {
+	return await createExecution({ finished: false, status: 'running' }, workflow);
+}
+
 export async function annotateExecution(
 	executionId: string,
 	annotation: { vote?: AnnotationVote | null; tags?: string[] },


### PR DESCRIPTION
## Summary

Add a `canceled` and filter to the public api executions endpoint

> ⚠️ I did not add the `running` status to the filter as it clashes with the the behaviour in [executions.handler](https://github.com/n8n-io/n8n/blob/master/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts#L114)

## Related Linear tickets, Github issues, and Community forum posts

Closes PAY-2835

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
