### PR TITLE
fix: Include third party licenses in the docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 # We want to include the THIRD_PARTY_LICENSES.md file in the Docker image,
 # but not other .md files
-**/README.md
+**/*.md
+!**/THIRD_PARTY_LICENSES.md
 **/.env
 .cache
 assets

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
-**/*.md
+# We want to include the THIRD_PARTY_LICENSES.md file in the Docker image,
+# but not other .md files
+**/README.md
 **/.env
 .cache
 assets

--- a/scripts/build-n8n.mjs
+++ b/scripts/build-n8n.mjs
@@ -246,10 +246,11 @@ const buildManifest = {
 	},
 };
 
-await fs.copy(
-	path.join(config.cliDir, 'THIRD_PARTY_LICENSES.md'),
-	path.join(config.compiledAppDir, 'THIRD_PARTY_LICENSES.md'),
-);
+// Copy third-party licenses if they exist
+const licensesSourcePath = path.join(config.cliDir, 'THIRD_PARTY_LICENSES.md');
+if (await fs.pathExists(licensesSourcePath)) {
+	await fs.copy(licensesSourcePath, path.join(config.compiledAppDir, 'THIRD_PARTY_LICENSES.md'));
+}
 
 await fs.writeJson(path.join(config.compiledAppDir, 'build-manifest.json'), buildManifest, {
 	spaces: 2,

--- a/scripts/build-n8n.mjs
+++ b/scripts/build-n8n.mjs
@@ -30,6 +30,7 @@ const rootDir = isInScriptsDir ? path.join(scriptDir, '..') : scriptDir;
 const config = {
 	compiledAppDir: path.join(rootDir, 'compiled'),
 	compiledTaskRunnerDir: path.join(rootDir, 'dist', 'task-runner-javascript'),
+	cliDir: path.join(rootDir, 'packages', 'cli'),
 	rootDir: rootDir,
 };
 
@@ -117,7 +118,6 @@ try {
 	}
 
 	echo(chalk.green('✅ pnpm install and build completed'));
-
 } catch (error) {
 	console.error(chalk.red('\n🛑 BUILD PROCESS FAILED!'));
 	console.error(chalk.red('An error occurred during the build process:'));
@@ -245,6 +245,11 @@ const buildManifest = {
 		total: getElapsedTime('total_build'),
 	},
 };
+
+await fs.copy(
+	path.join(config.cliDir, 'THIRD_PARTY_LICENSES.md'),
+	path.join(config.compiledAppDir, 'THIRD_PARTY_LICENSES.md'),
+);
 
 await fs.writeJson(path.join(config.compiledAppDir, 'build-manifest.json'), buildManifest, {
 	spaces: 2,


### PR DESCRIPTION
## Summary

The third party license file was not included in the docker image so it didn't work 

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1286/fix-availability-for-third-party-licensemd-file-in-about-n8n-modal


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
