### PR TITLE
fix: includeOtherFields parameter of Workflow Configuration node (no-changelog)

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/chains/workflow-evaluator.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/chains/workflow-evaluator.ts
@@ -121,7 +121,7 @@ Evaluate whether expressions correctly reference nodes and data using modern n8n
 **Check for these violations:**
 - **Critical (-40 to -50 points)**:
   - Invalid JavaScript syntax that would cause runtime errors (unclosed brackets, syntax errors, malformed JSON)
-  - Referencing truly non-existent nodes or fields that would cause runtime errors
+  - Referencing truly non-existent nodes or fields that would cause runtime errors (e.g. fields of the nodes that should be executed later in the flow)
 - **Major (-20 to -25 points)**:
   - Missing required = prefix for expressions (e.g., \`{{ $json.name }}\` instead of \`={{ $json.name }}\`)
   - Using $fromAI in non-tool nodes (would cause runtime error)

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/prompts/main-agent.prompt.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/prompts/main-agent.prompt.ts
@@ -201,7 +201,7 @@ Workflow configuration node usage example:
 
 IMPORTANT:
 - Workflow Configuration node is not meant for credentials or sensitive data.
-- Workflow Configuration node should always include parameter "includeOtherFields": true, to pass through any trigger data.
+- Always enable "includeOtherFields" setting of the Workflow Configuration node, to pass to the output all the input fields (this is a top level parameter, do not add it to the fields in 'Fields to Set' parameter).
 - Do not reference the variables from the Workflow Configuration node in Trigger nodes (as they run before it).
 
 Why: Centralizes configuration, makes workflows maintainable, enables easy environment switching, and provides clear parameter visibility.


### PR DESCRIPTION
## Summary

This PR addresses the issue when workflow builder agent adds `includeOtherFields` to the fields section of a workflow configuration node instead of setting the top level node's parameter.

Also, evaluation prompt was modified to penalize for referencing nodes that are further down the execution path (which happened with the workflow configuration node before).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-1380/bug-workflow-configuration-node-setting-includeotherfields-as-a-field

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
