### PR TITLE
fix(editor): Fix minor style bugs around parameter input

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nActionToggle/ActionToggle.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nActionToggle/ActionToggle.vue
@@ -141,6 +141,8 @@ defineExpose({
 	cursor: pointer;
 	padding: var(--spacing-4xs);
 	border-radius: var(--border-radius-base);
+	display: flex;
+	align-items: center;
 
 	&:hover {
 		color: var(--color-primary);

--- a/packages/frontend/editor-ui/src/components/CodeNodeEditor/theme.ts
+++ b/packages/frontend/editor-ui/src/components/CodeNodeEditor/theme.ts
@@ -115,6 +115,7 @@ export const codeEditorTheme = ({ isReadOnly, minHeight, maxHeight, rows }: Them
 		'&.cm-editor': {
 			...(isReadOnly ? { backgroundColor: 'var(--color-code-background-readonly)' } : {}),
 			borderColor: 'var(--border-color-base)',
+			overflow: 'hidden',
 		},
 		'&.cm-editor.cm-focused': {
 			outline: 'none',

--- a/packages/frontend/editor-ui/src/components/ExpressionEditorModal/theme.ts
+++ b/packages/frontend/editor-ui/src/components/ExpressionEditorModal/theme.ts
@@ -12,6 +12,9 @@ const commonThemeProps = (isReadOnly = false) => ({
 	'.cm-cursor, .cm-dropCursor': {
 		borderLeftColor: 'var(--color-code-caret)',
 	},
+	'&.cm-editor': {
+		overflow: 'hidden',
+	},
 	'&.cm-focused': {
 		borderColor: 'var(--color-secondary)',
 		outline: '0 !important',

--- a/packages/frontend/editor-ui/src/components/FocusPanel.vue
+++ b/packages/frontend/editor-ui/src/components/FocusPanel.vue
@@ -715,8 +715,8 @@ function onOpenNdv() {
 		}
 
 		.editorContainer {
-			height: 100%;
-			overflow-y: auto;
+			height: 0;
+			flex-grow: 1;
 
 			.editor {
 				display: flex;

--- a/packages/frontend/editor-ui/src/components/InputTriple/InputTriple.vue
+++ b/packages/frontend/editor-ui/src/components/InputTriple/InputTriple.vue
@@ -71,10 +71,16 @@ withDefaults(defineProps<Props>(), { middleWidth: '160px' });
 	flex-shrink: 0;
 	flex-basis: 240px;
 	flex-grow: 1;
+	z-index: 0;
+
 	--input-border-radius: 0;
+
+	&:focus-within {
+		z-index: 1;
+	}
 }
 
-.default .item:not(:first-child):not(:focus-within + .item) {
+.default .item:not(:first-child) {
 	margin-left: -1px;
 }
 
@@ -102,12 +108,10 @@ withDefaults(defineProps<Props>(), { middleWidth: '160px' });
 	flex-wrap: wrap;
 
 	.middle {
+		margin-left: -1px;
+
 		--input-border-top-right-radius: var(--border-radius-base);
 		--input-border-bottom-right-radius: 0;
-
-		&:not(:focus-within + .item) {
-			margin-left: -1px;
-		}
 	}
 
 	.item:first-of-type {
@@ -118,15 +122,12 @@ withDefaults(defineProps<Props>(), { middleWidth: '160px' });
 
 	.item:last-of-type {
 		flex-basis: 400px;
+		margin-top: -1px;
 
 		--input-border-top-left-radius: 0;
 		--input-border-top-right-radius: 0;
 		--input-border-bottom-left-radius: var(--border-radius-base);
 		--input-border-bottom-right-radius: var(--border-radius-base);
-
-		&:not(:focus-within ~ .item) {
-			margin-top: -1px;
-		}
 	}
 }
 
@@ -149,7 +150,7 @@ withDefaults(defineProps<Props>(), { middleWidth: '160px' });
 		--input-border-bottom-right-radius: 0;
 	}
 
-	.item:not(:first-of-type):not(:focus-within + .item) {
+	.item:not(:first-of-type) {
 		margin-top: -1px;
 	}
 

--- a/packages/frontend/editor-ui/src/components/ParameterOptions.vue
+++ b/packages/frontend/editor-ui/src/components/ParameterOptions.vue
@@ -233,6 +233,9 @@ $container-height: 22px;
 }
 
 .focusButton {
+	outline: none;
+	color: var(--color-text-light);
+
 	&:hover {
 		cursor: pointer;
 		color: var(--color-primary);


### PR DESCRIPTION
## Summary

This PR fixes minor style bugs around parameter input.

### Bugs fixed

#### 1. Hover actions not aligned center vertically, the focus panel icon has different color
<img width="477" height="87" alt="Screenshot 2025-09-03 at 16 58 06" src="https://github.com/user-attachments/assets/6812bf4a-3d82-4bc2-9bf1-03f903a6fa1d" />

#### 2. Borders width becomes doubled in the input triple component when focused
<img width="481" height="145" alt="Screenshot 2025-09-03 at 16 59 17" src="https://github.com/user-attachments/assets/3c5f367a-c6a8-4c6b-8bb0-d51922f86a09" />

#### 3. Gutter's background overflows rounded corners, bottom of text editor is cut in focus panel
<img width="507" height="242" alt="Screenshot 2025-09-03 at 17 01 52" src="https://github.com/user-attachments/assets/af2c5771-7fdb-4d45-89a3-54cb83d8e0e6" />



## Related Linear tickets, Github issues, and Community forum posts

N/A


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
