### PR TITLE
fix(GitlabTrigger Node): Correctly access httpCode from error object

### DIFF
--- a/packages/nodes-base/nodes/Gitlab/GitlabTrigger.node.ts
+++ b/packages/nodes-base/nodes/Gitlab/GitlabTrigger.node.ts
@@ -195,7 +195,7 @@ export class GitlabTrigger implements INodeType {
 				try {
 					await gitlabApiRequest.call(this, 'GET', endpoint, {});
 				} catch (error) {
-					if (error.cause.httpCode === '404' || error.description.includes('404')) {
+					if (error.httpCode === '404' || error.description.includes('404')) {
 						// Webhook does not exist
 						delete webhookData.webhookId;
 						delete webhookData.webhookEvents;

--- a/packages/nodes-base/nodes/Gitlab/__tests__/node/GitlabTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Gitlab/__tests__/node/GitlabTrigger.node.test.ts
@@ -1,0 +1,95 @@
+import { GitlabTrigger } from '../../GitlabTrigger.node';
+import * as GenericFunctions from '../../GenericFunctions';
+import { NodeApiError } from 'n8n-workflow';
+
+describe('GitlabTrigger Node', () => {
+	describe('checkExists webhook method', () => {
+		let webhookData: Record<string, any>;
+		let mockThis: any;
+
+		beforeEach(() => {
+			webhookData = {
+				webhookId: '123456',
+				webhookEvents: ['push'],
+			};
+
+			mockThis = {
+				getWorkflowStaticData: () => webhookData,
+				getNodeParameter: jest.fn().mockImplementation((name: string) => {
+					if (name === 'owner') return 'some-owner';
+					if (name === 'repository') return 'some-repo';
+				}),
+			};
+		});
+
+		it('should delete webhook data and return false when webhook is not found (404)', async () => {
+			jest.spyOn(GenericFunctions, 'gitlabApiRequest').mockRejectedValue({ httpCode: '404' });
+
+			const trigger = new GitlabTrigger();
+			const result = await trigger.webhookMethods.default.checkExists.call(mockThis);
+
+			expect(result).toBe(false);
+			expect(webhookData.webhookId).toBeUndefined();
+			expect(webhookData.webhookEvents).toBeUndefined();
+		});
+
+		it('should delete webhook data and return false when webhook description contains 404', async () => {
+			jest
+				.spyOn(GenericFunctions, 'gitlabApiRequest')
+				.mockRejectedValue({ description: 'Gitlab answered with a status code of 404.' });
+
+			const trigger = new GitlabTrigger();
+			const result = await trigger.webhookMethods.default.checkExists.call(mockThis);
+
+			expect(result).toBe(false);
+			expect(webhookData.webhookId).toBeUndefined();
+			expect(webhookData.webhookEvents).toBeUndefined();
+		});
+	});
+
+	describe('create webhook method', () => {
+		let mockThis: any;
+		let webhookData: Record<string, any>;
+
+		beforeEach(() => {
+			webhookData = {};
+			mockThis = {
+				getNodeWebhookUrl: () => 'https://example.com/webhook',
+				getNodeParameter: jest.fn().mockImplementation((name: string) => {
+					if (name === 'owner') return 'some-owner';
+					if (name === 'repository') return 'some-repo';
+					if (name === 'events') return ['push'];
+					if (name === 'options') return { insecureSSL: false };
+				}),
+				getWorkflowStaticData: () => webhookData,
+				getNode: () => ({}),
+			};
+		});
+
+		it('should return true and set webhookId when creation succeeds', async () => {
+			const createdWebhook = { id: '789', active: true };
+
+			jest.spyOn(GenericFunctions, 'gitlabApiRequest').mockResolvedValueOnce(createdWebhook); // Simulate successful POST
+
+			const trigger = new GitlabTrigger();
+			const result = await trigger.webhookMethods.default.create.call(mockThis);
+
+			expect(result).toBe(true);
+			expect(webhookData.webhookId).toBe('789');
+		});
+
+		it('should throw NodeApiError if repo is not found (404)', async () => {
+			jest.spyOn(GenericFunctions, 'gitlabApiRequest').mockRejectedValue({ httpCode: '404' });
+
+			const trigger = new GitlabTrigger();
+
+			await expect(trigger.webhookMethods.default.create.call(mockThis)).rejects.toThrow(
+				NodeApiError,
+			);
+
+			await expect(trigger.webhookMethods.default.create.call(mockThis)).rejects.toThrow(
+				/The resource you are requesting could not be found/,
+			);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Fixes a runtime crash in the Gitlab Trigger node when re‑activating a workflow whose webhook was manually deleted on Gitlab.
Instead of trying to read error.cause.httpCode (which is undefined), this change reads error.httpCode directly.

## Related Linear tickets, Github issues, and Community forum posts
This happened the same way in GithubTrigger Node: https://github.com/n8n-io/n8n/pull/17697

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. 
- [ ] PR Labeled with `release/backport`
