### PR TITLE
fix(Wait Node): Allow 0 wait times

### DIFF
--- a/packages/nodes-base/nodes/Wait/Wait.node.ts
+++ b/packages/nodes-base/nodes/Wait/Wait.node.ts
@@ -503,7 +503,7 @@ export class Wait extends Webhook {
 			if (!validateWaitAmount(waitAmount)) {
 				throw new NodeOperationError(
 					context.getNode(),
-					'Invalid wait amount. It must be a positive number.',
+					'Invalid wait amount. Please enter a number that is 0 or greater.',
 				);
 			}
 

--- a/packages/nodes-base/nodes/Wait/validation.ts
+++ b/packages/nodes-base/nodes/Wait/validation.ts
@@ -1,5 +1,5 @@
 export function validateWaitAmount(amount: unknown): amount is number {
-	return typeof amount === 'number' && amount > 0;
+	return typeof amount === 'number' && amount >= 0;
 }
 
 export type WaitUnit = 'seconds' | 'minutes' | 'hours' | 'days';


### PR DESCRIPTION
## Summary
This PR fixes a regression introduced in https://github.com/n8n-io/n8n/pull/18239 by updating the Wait node to accept 0 as a valid wait amount


## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-3576/community-issue-wait-node-no-longer-accepts-0-input
fixes https://github.com/n8n-io/n8n/issues/19124
## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
