### PR TITLE
feat(core): Implement request-response logic in workflow execution engine

### DIFF
--- a/packages/cli/src/chat/chat-execution-manager.ts
+++ b/packages/cli/src/chat/chat-execution-manager.ts
@@ -1,21 +1,21 @@
 import { ExecutionRepository } from '@n8n/db';
 import type { IExecutionResponse, Project } from '@n8n/db';
 import { Service } from '@n8n/di';
-import { ExecuteContext } from 'n8n-core';
+import { ExecuteContext, isRequest } from 'n8n-core';
 import type {
 	IBinaryKeyData,
 	INodeExecutionData,
 	IWorkflowExecutionDataProcess,
 } from 'n8n-workflow';
-import { Workflow, BINARY_ENCODING } from 'n8n-workflow';
-
-import { NotFoundError } from '@/errors/response-errors/not-found.error';
-import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
-import { WorkflowRunner } from '@/workflow-runner';
+import { Workflow, BINARY_ENCODING, UnexpectedError } from 'n8n-workflow';
 
 import type { ChatMessage } from './chat-service.types';
 import { NodeTypes } from '../node-types';
 import { OwnershipService } from '../services/ownership.service';
+
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
+import { WorkflowRunner } from '@/workflow-runner';
 
 @Service()
 export class ChatExecutionManager {
@@ -130,10 +130,15 @@ export class ChatExecutionManager {
 	private async getRunData(execution: IExecutionResponse, message: ChatMessage) {
 		const { workflowData, mode: executionMode, data: runExecutionData } = execution;
 
-		runExecutionData.executionData!.nodeExecutionStack[0].data.main = (await this.runNode(
-			execution,
-			message,
-		)) ?? [[{ json: message }]];
+		const result = await this.runNode(execution, message);
+
+		if (isRequest(result)) {
+			throw new UnexpectedError("Can't handle actions inside the chat trigger.");
+		}
+
+		runExecutionData.executionData!.nodeExecutionStack[0].data.main = result ?? [
+			[{ json: message }],
+		];
 
 		let project: Project | undefined = undefined;
 		try {

--- a/packages/cli/src/chat/chat-execution-manager.ts
+++ b/packages/cli/src/chat/chat-execution-manager.ts
@@ -1,7 +1,7 @@
 import { ExecutionRepository } from '@n8n/db';
 import type { IExecutionResponse, Project } from '@n8n/db';
 import { Service } from '@n8n/di';
-import { ExecuteContext, isRequest } from 'n8n-core';
+import { ExecuteContext, isEngineRequest } from 'n8n-core';
 import type {
 	IBinaryKeyData,
 	INodeExecutionData,
@@ -132,7 +132,7 @@ export class ChatExecutionManager {
 
 		const result = await this.runNode(execution, message);
 
-		if (isRequest(result)) {
+		if (isEngineRequest(result)) {
 			throw new UnexpectedError("Can't handle actions inside the chat trigger.");
 		}
 

--- a/packages/cli/src/chat/chat-execution-manager.ts
+++ b/packages/cli/src/chat/chat-execution-manager.ts
@@ -9,13 +9,12 @@ import type {
 } from 'n8n-workflow';
 import { Workflow, BINARY_ENCODING, UnexpectedError } from 'n8n-workflow';
 
+import { NotFoundError } from '../errors/response-errors/not-found.error';
+import * as WorkflowExecuteAdditionalData from '../workflow-execute-additional-data';
+import { WorkflowRunner } from '../workflow-runner';
 import type { ChatMessage } from './chat-service.types';
 import { NodeTypes } from '../node-types';
 import { OwnershipService } from '../services/ownership.service';
-
-import { NotFoundError } from '@/errors/response-errors/not-found.error';
-import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
-import { WorkflowRunner } from '@/workflow-runner';
 
 @Service()
 export class ChatExecutionManager {

--- a/packages/core/src/execution-engine/__tests__/mock-node-types.ts
+++ b/packages/core/src/execution-engine/__tests__/mock-node-types.ts
@@ -1,12 +1,11 @@
+import { NodeTypes } from '@test/helpers';
 import type {
 	IExecuteFunctions,
 	INodeExecutionData,
 	INodeType,
-	Response,
-	Request,
+	EngineResponse,
+	EngineRequest,
 } from 'n8n-workflow';
-
-import { NodeTypes } from '@test/helpers';
 
 export const passThroughNode: INodeType = {
 	description: {
@@ -74,8 +73,8 @@ export const types: Record<keyof typeof nodeTypeArguments, string> = {
 
 type NodeExecuteResult =
 	| INodeExecutionData[][]
-	| Request
-	| ((response?: Response) => INodeExecutionData[][] | Request);
+	| EngineRequest
+	| ((response?: EngineResponse) => INodeExecutionData[][] | EngineRequest);
 
 interface NodeModifier {
 	return(result: NodeExecuteResult): NodeModifier;
@@ -97,8 +96,8 @@ export function modifyNode(originalNode: INodeType): NodeModifier {
 				...originalNode,
 				async execute(
 					this: IExecuteFunctions,
-					response?: Response,
-				): Promise<INodeExecutionData[][] | Request | null> {
+					response?: EngineResponse,
+				): Promise<INodeExecutionData[][] | EngineRequest | null> {
 					const currentCall = callCount++;
 
 					// If we have a predetermined response for this call, use it

--- a/packages/core/src/execution-engine/__tests__/mock-node-types.ts
+++ b/packages/core/src/execution-engine/__tests__/mock-node-types.ts
@@ -1,4 +1,3 @@
-import { NodeTypes } from '@test/helpers';
 import type {
 	IExecuteFunctions,
 	INodeExecutionData,
@@ -6,6 +5,8 @@ import type {
 	EngineResponse,
 	EngineRequest,
 } from 'n8n-workflow';
+
+import { NodeTypes } from '@test/helpers';
 
 export const passThroughNode: INodeType = {
 	description: {

--- a/packages/core/src/execution-engine/__tests__/mock-node-types.ts
+++ b/packages/core/src/execution-engine/__tests__/mock-node-types.ts
@@ -4,6 +4,7 @@ import type {
 	INodeType,
 	EngineResponse,
 	EngineRequest,
+	NodeOutput,
 } from 'n8n-workflow';
 
 import { NodeTypes } from '@test/helpers';
@@ -77,8 +78,7 @@ export const types: Record<keyof typeof nodeTypeArguments, string> = {
  * Can be execution data, an engine request, or a function that processes engine responses.
  */
 type NodeExecuteResult =
-	| INodeExecutionData[][]
-	| EngineRequest
+	| NodeOutput
 	| ((response?: EngineResponse) => INodeExecutionData[][] | EngineRequest);
 
 /**

--- a/packages/core/src/execution-engine/__tests__/mock-node-types.ts
+++ b/packages/core/src/execution-engine/__tests__/mock-node-types.ts
@@ -71,16 +71,49 @@ export const types: Record<keyof typeof nodeTypeArguments, string> = {
 	testNodeWithRequiredProperty: 'testNodeWithRequiredProperty',
 };
 
+/**
+ * Union type representing all possible return values from a node's execute method.
+ * Can be execution data, an engine request, or a function that processes engine responses.
+ */
 type NodeExecuteResult =
 	| INodeExecutionData[][]
 	| EngineRequest
 	| ((response?: EngineResponse) => INodeExecutionData[][] | EngineRequest);
 
+/**
+ * Interface for building modified node behavior through method chaining.
+ * Allows setting predetermined responses for sequential node executions.
+ */
 interface NodeModifier {
+	/**
+	 * Sets a predetermined result for the next node execution call.
+	 * @param result - The result to return on the next execution
+	 */
 	return(result: NodeExecuteResult): NodeModifier;
+
+	/**
+	 * Finalizes the node modification and returns the modified node.
+	 */
 	done(): INodeType;
 }
 
+/**
+ * Creates a modified version of a node with predetermined execution responses.
+ * Useful for testing scenarios where you need to control node execution results
+ * across multiple calls in a predictable sequence.
+ *
+ * @example
+ * ```typescript
+ * const modifiedNode = modifyNode(originalNode)
+ *   .return([mockData1])
+ *   .return(engineRequest)
+ *   .return((response) => processResponse(response))
+ *   .done();
+ * ```
+ *
+ * @param originalNode - The original node to modify
+ * @returns A NodeModifier instance for configuring predetermined responses
+ */
 export function modifyNode(originalNode: INodeType): NodeModifier {
 	const responses: NodeExecuteResult[] = [];
 	let callCount = 0;

--- a/packages/core/src/execution-engine/__tests__/requests-response.test.ts
+++ b/packages/core/src/execution-engine/__tests__/requests-response.test.ts
@@ -1,0 +1,45 @@
+import { mock } from 'jest-mock-extended';
+import type { IExecuteData, IRunData, LoggerProxy, Request } from 'n8n-workflow';
+
+import { DirectedGraph } from '../partial-execution-utils';
+import { createNodeData } from '../partial-execution-utils/__tests__/helpers';
+import { handleRequests } from '../requests-response';
+import { nodeTypes, types } from './mock-node-types';
+
+describe('handleRequests', () => {
+	test('throws if an action is mentions a node that does not exist in the workflow', async () => {
+		// ARRANGE
+		const request: Request = {
+			actions: [
+				{
+					actionType: 'ExecutionNodeAction',
+					nodeName: 'does not exist',
+					input: { data: 'first node input' },
+					type: 'ai_tool',
+					id: 'first_action',
+					metadata: {},
+				},
+			],
+			metadata: {},
+		};
+		const currentNode = createNodeData({ name: 'trigger', type: types.passThrough });
+
+		const workflow = new DirectedGraph()
+			.addNodes(currentNode)
+			.toWorkflow({ name: '', active: false, nodeTypes });
+		// ACT
+
+		// ASSERT
+		expect(() =>
+			handleRequests({
+				workflow,
+				currentNode,
+				request,
+				runIndex: 1,
+				executionData: mock<IExecuteData>(),
+				runData: mock<IRunData>(),
+				logger: mock<typeof LoggerProxy>(),
+			}),
+		).toThrowError('Workflow does not contain a node with the name of "does not exist".');
+	});
+});

--- a/packages/core/src/execution-engine/__tests__/requests-response.test.ts
+++ b/packages/core/src/execution-engine/__tests__/requests-response.test.ts
@@ -1,5 +1,5 @@
 import { mock } from 'jest-mock-extended';
-import type { IExecuteData, IRunData, LoggerProxy, Request } from 'n8n-workflow';
+import type { IExecuteData, IRunData, LoggerProxy, EngineRequest } from 'n8n-workflow';
 
 import { DirectedGraph } from '../partial-execution-utils';
 import { createNodeData } from '../partial-execution-utils/__tests__/helpers';
@@ -9,7 +9,7 @@ import { nodeTypes, types } from './mock-node-types';
 describe('handleRequests', () => {
 	test('throws if an action is mentions a node that does not exist in the workflow', async () => {
 		// ARRANGE
-		const request: Request = {
+		const request: EngineRequest = {
 			actions: [
 				{
 					actionType: 'ExecutionNodeAction',

--- a/packages/core/src/execution-engine/__tests__/requests-response.test.ts
+++ b/packages/core/src/execution-engine/__tests__/requests-response.test.ts
@@ -3,7 +3,7 @@ import type { IExecuteData, IRunData, LoggerProxy, EngineRequest } from 'n8n-wor
 
 import { DirectedGraph } from '../partial-execution-utils';
 import { createNodeData } from '../partial-execution-utils/__tests__/helpers';
-import { handleRequests } from '../requests-response';
+import { handleRequest } from '../requests-response';
 import { nodeTypes, types } from './mock-node-types';
 
 describe('handleRequests', () => {
@@ -31,7 +31,7 @@ describe('handleRequests', () => {
 
 		// ASSERT
 		expect(() =>
-			handleRequests({
+			handleRequest({
 				workflow,
 				currentNode,
 				request,

--- a/packages/core/src/execution-engine/__tests__/requests-response.test.ts
+++ b/packages/core/src/execution-engine/__tests__/requests-response.test.ts
@@ -1,5 +1,5 @@
 import { mock } from 'jest-mock-extended';
-import type { IExecuteData, IRunData, LoggerProxy, EngineRequest } from 'n8n-workflow';
+import type { IExecuteData, IRunData, EngineRequest } from 'n8n-workflow';
 
 import { DirectedGraph } from '../partial-execution-utils';
 import { createNodeData } from '../partial-execution-utils/__tests__/helpers';
@@ -38,7 +38,6 @@ describe('handleRequests', () => {
 				runIndex: 1,
 				executionData: mock<IExecuteData>(),
 				runData: mock<IRunData>(),
-				logger: mock<typeof LoggerProxy>(),
 			}),
 		).toThrowError('Workflow does not contain a node with the name of "does not exist".');
 	});

--- a/packages/core/src/execution-engine/__tests__/requests-response.test.ts
+++ b/packages/core/src/execution-engine/__tests__/requests-response.test.ts
@@ -7,7 +7,7 @@ import { handleRequest } from '../requests-response';
 import { nodeTypes, types } from './mock-node-types';
 
 describe('handleRequests', () => {
-	test('throws if an action mentions a node that does not exist in the workflow', async () => {
+	test('throws if an action mentions a node that does not exist in the workflow', () => {
 		// ARRANGE
 		const request: EngineRequest = {
 			actions: [

--- a/packages/core/src/execution-engine/__tests__/requests-response.test.ts
+++ b/packages/core/src/execution-engine/__tests__/requests-response.test.ts
@@ -7,7 +7,7 @@ import { handleRequests } from '../requests-response';
 import { nodeTypes, types } from './mock-node-types';
 
 describe('handleRequests', () => {
-	test('throws if an action is mentions a node that does not exist in the workflow', async () => {
+	test('throws if an action mentions a node that does not exist in the workflow', async () => {
 		// ARRANGE
 		const request: EngineRequest = {
 			actions: [

--- a/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
@@ -3,14 +3,23 @@ import type {
 	IDataObject,
 	IRunExecutionData,
 	IWorkflowExecuteAdditionalData,
+	Response,
 	WorkflowExecuteMode,
 } from 'n8n-workflow';
 import { ApplicationError } from 'n8n-workflow';
 
+import { NodeTypes } from '@test/helpers';
+
 import { DirectedGraph } from '../partial-execution-utils';
 import { createNodeData, toITaskData } from '../partial-execution-utils/__tests__/helpers';
 import { WorkflowExecute } from '../workflow-execute';
-import { types, nodeTypes } from './mock-node-types';
+import {
+	types,
+	nodeTypes,
+	passThroughNode,
+	nodeTypeArguments,
+	modifyNode,
+} from './mock-node-types';
 
 describe('processRunExecutionData', () => {
 	const runHook = jest.fn().mockResolvedValue(undefined);
@@ -216,6 +225,339 @@ describe('processRunExecutionData', () => {
 			// The function returns a Promise, but throws synchronously, so we can't await it.
 			// eslint-disable-next-line @typescript-eslint/promise-function-async
 			expect(() => workflowExecute.processRunExecutionData(workflow)).not.toThrowError();
+		});
+	});
+
+	describe('waiting tools', () => {
+		test('handles Request objects with actions correctly', async () => {
+			// ARRANGE
+			let response: Response | undefined;
+
+			const tool1Node = createNodeData({ name: 'tool1', type: types.passThrough });
+			const tool2Node = createNodeData({ name: 'tool2', type: types.passThrough });
+			const tool1Input = { query: 'test input' };
+			const tool2Input = { data: 'another input' };
+			const nodeTypeWithRequests = modifyNode(passThroughNode)
+				.return({
+					actions: [
+						{
+							actionType: 'ExecutionNodeAction',
+							nodeName: tool1Node.name,
+							input: tool1Input,
+							type: 'ai_tool',
+							id: 'action_1',
+							metadata: { step: 1 },
+						},
+						{
+							actionType: 'ExecutionNodeAction',
+							nodeName: tool2Node.name,
+							input: tool2Input,
+							type: 'ai_tool',
+							id: 'action_2',
+							metadata: { step: 1 },
+						},
+					],
+					metadata: { requestId: 'test_request_step1' },
+				})
+				.return((r) => {
+					response = r;
+					// Verify the response contains the expected action responses
+					expect(r).toBeDefined();
+					expect(r?.actionResponses).toHaveLength(2);
+
+					// Return final result incorporating the response data
+					return [
+						[
+							{
+								json: {
+									finalResult: 'Completed with response data',
+									responseMetadata: r?.metadata as IDataObject,
+									actionCount: r?.actionResponses?.length,
+								},
+							},
+						],
+					];
+				})
+				.done();
+			const nodeWithRequests = createNodeData({
+				name: 'nodeWithRequests',
+				type: 'nodeWithRequests',
+			});
+
+			const nodeTypes = NodeTypes({
+				...nodeTypeArguments,
+				nodeWithRequests: { type: nodeTypeWithRequests, sourcePath: '' },
+			});
+
+			const workflow = new DirectedGraph()
+				.addNodes(nodeWithRequests, tool1Node, tool2Node)
+				.addConnections({ from: tool1Node, to: nodeWithRequests, type: 'ai_tool' })
+				.addConnections({ from: tool2Node, to: nodeWithRequests, type: 'ai_tool' })
+				.toWorkflow({ name: '', active: false, nodeTypes, settings: { executionOrder: 'v1' } });
+
+			const taskDataConnection = { main: [[{ json: { prompt: 'test prompt' } }]] };
+			const executionData: IRunExecutionData = {
+				startData: { startNodes: [{ name: nodeWithRequests.name, sourceData: null }] },
+				resultData: { runData: {} },
+				executionData: {
+					contextData: {},
+					nodeExecutionStack: [
+						{
+							data: taskDataConnection,
+							node: nodeWithRequests,
+							source: { main: [{ previousNode: 'Start' }] },
+						},
+					],
+					metadata: {},
+					waitingExecution: {},
+					waitingExecutionSource: {},
+				},
+			};
+
+			const workflowExecute = new WorkflowExecute(additionalData, executionMode, executionData);
+
+			// ACT
+			const result = await workflowExecute.processRunExecutionData(workflow);
+
+			// ASSERT
+			const runData = result.data.resultData.runData;
+
+			// 1. Verify the Response object was passed to the second execution
+			expect(response).toBeDefined();
+			expect(response?.actionResponses).toHaveLength(2);
+			expect(response?.metadata).toEqual({ requestId: 'test_request_step1' });
+
+			// 2. Verify each action response contains the correct data and metadata
+			const actionResponses = response?.actionResponses ?? [];
+			const action1Response = actionResponses.find((r) => r.action.id === 'action_1');
+			const action2Response = actionResponses.find((r) => r.action.id === 'action_2');
+
+			expect(action1Response).toBeDefined();
+			expect(action1Response?.action.metadata).toEqual({ step: 1 });
+			expect(action1Response?.data.data?.ai_tool?.[0]?.[0]?.json).toMatchObject({
+				query: 'test input',
+				toolCallId: 'action_1',
+			});
+
+			expect(action2Response).toBeDefined();
+			expect(action2Response?.action.metadata).toEqual({ step: 1 });
+			expect(action2Response?.data.data?.ai_tool?.[0]?.[0]?.json).toMatchObject({
+				data: 'another input',
+				toolCallId: 'action_2',
+			});
+
+			// The agent should have been executed and returned a Request with actions
+			expect(runData[nodeWithRequests.name]).toHaveLength(1);
+			expect(runData[nodeWithRequests.name][0].metadata?.subNodeExecutionData).toBeDefined();
+
+			// Tool nodes should have been added to runData with inputOverride
+			expect(runData[tool1Node.name]).toHaveLength(1);
+			expect(runData[tool1Node.name][0].inputOverride).toEqual({
+				ai_tool: [[{ json: { query: 'test input', toolCallId: 'action_1' } }]],
+			});
+
+			expect(runData[tool2Node.name]).toHaveLength(1);
+			expect(runData[tool2Node.name][0].inputOverride).toEqual({
+				ai_tool: [[{ json: { data: 'another input', toolCallId: 'action_2' } }]],
+			});
+
+			// Tools should have executed successfully
+			expect(runData[tool1Node.name][0].data).toBeDefined();
+			expect(runData[tool1Node.name][0].executionStatus).toBe('success');
+			expect(runData[tool2Node.name][0].data).toBeDefined();
+			expect(runData[tool2Node.name][0].executionStatus).toBe('success');
+
+			// 3. Verify the final node output includes response data
+			expect(runData[nodeWithRequests.name][0].data).toBeDefined();
+			expect(runData[nodeWithRequests.name][0].executionStatus).toBe('success');
+			expect(runData[nodeWithRequests.name][0].data?.main?.[0]?.[0]?.json).toMatchObject({
+				finalResult: 'Completed with response data',
+				responseMetadata: { requestId: 'test_request_step1' },
+				actionCount: 2,
+			});
+		});
+
+		test('skips waiting tools processing when parent node cannot be found', async () => {
+			// ARRANGE
+			// This test simulates the scenario where executionData.source.main[0].previousNode
+			// is null/undefined (line 2037-2044 in workflow-execute.ts)
+			let response: Response | undefined;
+
+			const tool1Node = createNodeData({ name: 'tool1', type: types.passThrough });
+			const tool1Input = { query: 'test input' };
+			const nodeTypeWithRequests = modifyNode(passThroughNode)
+				.return({
+					actions: [
+						{
+							actionType: 'ExecutionNodeAction',
+							nodeName: tool1Node.name,
+							input: tool1Input,
+							type: 'ai_tool',
+							id: 'action_1',
+							metadata: {},
+						},
+					],
+					metadata: { requestId: 'test_request' },
+				})
+				.return((r) => {
+					response = r;
+					return [[{ json: { finalResult: 'Agent completed with tool results' } }]];
+				})
+				.done();
+			const nodeWithRequests = createNodeData({
+				name: 'nodeWithRequests',
+				type: 'nodeWithRequests',
+			});
+
+			const nodeTypes = NodeTypes({
+				...nodeTypeArguments,
+				nodeWithRequests: { type: nodeTypeWithRequests, sourcePath: '' },
+			});
+
+			const workflow = new DirectedGraph()
+				.addNodes(nodeWithRequests, tool1Node)
+				.toWorkflow({ name: '', active: false, nodeTypes, settings: { executionOrder: 'v1' } });
+
+			const taskDataConnection = { main: [[{ json: { prompt: 'test prompt' } }]] };
+			const executionData: IRunExecutionData = {
+				startData: { startNodes: [{ name: nodeWithRequests.name, sourceData: null }] },
+				resultData: { runData: {} },
+				executionData: {
+					contextData: {},
+					nodeExecutionStack: [
+						{
+							data: taskDataConnection,
+							node: nodeWithRequests,
+							// Setting source to null triggers the "Cannot find parent node" condition
+							source: null,
+						},
+					],
+					metadata: {},
+					waitingExecution: {},
+					waitingExecutionSource: {},
+				},
+			};
+
+			const workflowExecute = new WorkflowExecute(additionalData, executionMode, executionData);
+
+			// ACT
+			const result = await workflowExecute.processRunExecutionData(workflow);
+
+			// ASSERT
+			const runData = result.data.resultData.runData;
+
+			// When parent node cannot be found (line 2038-2044), the execution loop continues
+			// which means the waiting tools processing is skipped entirely:
+
+			// 1. The agent node never gets re-executed with the Response callback
+			expect(runData[nodeWithRequests.name]).toBeUndefined();
+
+			// 2. Tool nodes get added to runData with inputOverride but are never actually executed
+			expect(runData[tool1Node.name]).toHaveLength(1);
+			expect(runData[tool1Node.name][0].inputOverride).toEqual({
+				ai_tool: [[{ json: { query: 'test input', toolCallId: 'action_1' } }]],
+			});
+			// The tool node should not have execution data since it was never run
+			expect(runData[tool1Node.name][0].data).toBeUndefined();
+			expect(runData[tool1Node.name][0].executionStatus).toBeUndefined();
+
+			// 3. The response callback is never called since the agent's second execution is skipped
+			expect(response).toBeUndefined();
+		});
+
+		test('resets responses between different node executions', async () => {
+			// ARRANGE
+			let firstResponse: Response | undefined;
+			let secondResponse: Response | undefined;
+
+			// Create first node that returns Request with actions
+			const firstNodeWithRequests = modifyNode(passThroughNode)
+				.return({
+					actions: [
+						{
+							actionType: 'ExecutionNodeAction',
+							nodeName: 'tool1',
+							input: { data: 'first node input' },
+							type: 'ai_tool',
+							id: 'first_action',
+							metadata: {},
+						},
+					],
+					metadata: { requestId: 'first_request' },
+				})
+				.return((response?: Response) => {
+					firstResponse = response;
+					return [[{ json: { result: 'first node completed' } }]];
+				})
+				.done();
+
+			// Create second node that should NOT receive responses from the first node
+			const secondNodeWithRequests = modifyNode(passThroughNode)
+				.return((response?: Response) => {
+					secondResponse = response;
+					// This should receive an empty response, not the first node's responses
+					return [[{ json: { result: 'second node completed' } }]];
+				})
+				.done();
+
+			const tool1Node = createNodeData({ name: 'tool1', type: types.passThrough });
+			const firstNode = createNodeData({ name: 'firstNode', type: 'firstNodeType' });
+			const secondNode = createNodeData({ name: 'secondNode', type: 'secondNodeType' });
+
+			const customNodeTypes = NodeTypes({
+				...nodeTypeArguments,
+				firstNodeType: { type: firstNodeWithRequests, sourcePath: '' },
+				secondNodeType: { type: secondNodeWithRequests, sourcePath: '' },
+			});
+
+			const workflow = new DirectedGraph()
+				.addNodes(firstNode, tool1Node, secondNode)
+				.addConnections({ from: firstNode, to: secondNode })
+				.toWorkflow({
+					name: '',
+					active: false,
+					nodeTypes: customNodeTypes,
+					settings: { executionOrder: 'v1' },
+				});
+
+			const taskDataConnection = { main: [[{ json: { input: 'start' } }]] };
+			const executionData: IRunExecutionData = {
+				startData: { startNodes: [{ name: firstNode.name, sourceData: null }] },
+				resultData: { runData: {} },
+				executionData: {
+					contextData: {},
+					nodeExecutionStack: [
+						{
+							data: taskDataConnection,
+							node: firstNode,
+							source: { main: [{ previousNode: 'Start' }] },
+						},
+					],
+					metadata: {},
+					waitingExecution: {},
+					waitingExecutionSource: {},
+				},
+			};
+
+			const workflowExecute = new WorkflowExecute(additionalData, executionMode, executionData);
+
+			// ACT
+			const result = await workflowExecute.processRunExecutionData(workflow);
+
+			// ASSERT
+			// 1. First node should receive responses from its tool execution
+			expect(firstResponse).toBeDefined();
+			expect(firstResponse?.actionResponses).toHaveLength(1);
+
+			// 2. Second node should receive empty responses (not the first node's responses)
+			expect(secondResponse).toBeDefined();
+			expect(secondResponse?.actionResponses).toHaveLength(0); // This should be empty due to reset
+			expect(secondResponse?.metadata).toEqual({}); // Empty metadata
+
+			// 3. Both nodes should have completed successfully
+			const runData = result.data.resultData.runData;
+			expect(runData[firstNode.name]).toHaveLength(1);
+			expect(runData[secondNode.name]).toHaveLength(1);
 		});
 	});
 });

--- a/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
@@ -185,7 +185,7 @@ describe('processRunExecutionData', () => {
 			);
 		});
 
-		test('does not complain about nodes with issue past the destination node', async () => {
+		test('does not complain about nodes with issue past the destination node', () => {
 			// ARRANGE
 			const node1 = createNodeData({ name: 'node1', type: types.passThrough });
 			const node2 = createNodeData({ name: 'node2', type: types.testNodeWithRequiredProperty });

--- a/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
@@ -3,7 +3,7 @@ import type {
 	IDataObject,
 	IRunExecutionData,
 	IWorkflowExecuteAdditionalData,
-	Response,
+	EngineResponse,
 	WorkflowExecuteMode,
 } from 'n8n-workflow';
 import { ApplicationError } from 'n8n-workflow';
@@ -231,7 +231,7 @@ describe('processRunExecutionData', () => {
 	describe('waiting tools', () => {
 		test('handles Request objects with actions correctly', async () => {
 			// ARRANGE
-			let response: Response | undefined;
+			let response: EngineResponse | undefined;
 
 			const tool1Node = createNodeData({ name: 'tool1', type: types.passThrough });
 			const tool2Node = createNodeData({ name: 'tool2', type: types.passThrough });
@@ -381,7 +381,7 @@ describe('processRunExecutionData', () => {
 			// ARRANGE
 			// This test simulates the scenario where executionData.source.main[0].previousNode
 			// is null/undefined (line 2037-2044 in workflow-execute.ts)
-			let response: Response | undefined;
+			let response: EngineResponse | undefined;
 
 			const tool1Node = createNodeData({ name: 'tool1', type: types.passThrough });
 			const tool1Input = { query: 'test input' };
@@ -467,8 +467,8 @@ describe('processRunExecutionData', () => {
 
 		test('resets responses between different node executions', async () => {
 			// ARRANGE
-			let firstResponse: Response | undefined;
-			let secondResponse: Response | undefined;
+			let firstResponse: EngineResponse | undefined;
+			let secondResponse: EngineResponse | undefined;
 
 			// Create first node that returns Request with actions
 			const firstNodeWithRequests = modifyNode(passThroughNode)
@@ -485,7 +485,7 @@ describe('processRunExecutionData', () => {
 					],
 					metadata: { requestId: 'first_request' },
 				})
-				.return((response?: Response) => {
+				.return((response?: EngineResponse) => {
 					firstResponse = response;
 					return [[{ json: { result: 'first node completed' } }]];
 				})
@@ -493,7 +493,7 @@ describe('processRunExecutionData', () => {
 
 			// Create second node that should NOT receive responses from the first node
 			const secondNodeWithRequests = modifyNode(passThroughNode)
-				.return((response?: Response) => {
+				.return((response?: EngineResponse) => {
 					secondResponse = response;
 					// This should receive an empty response, not the first node's responses
 					return [[{ json: { result: 'second node completed' } }]];

--- a/packages/core/src/execution-engine/__tests__/workflow-execute-run-node.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute-run-node.test.ts
@@ -439,6 +439,7 @@ describe('WorkflowExecute.runNode - Real Implementation', () => {
 			);
 
 			const mockContextInstance = { hints: [] };
+			const mockSubNodeExecutionResults = undefined;
 			mockExecuteContext.mockImplementation(() => mockContextInstance as unknown as ExecuteContext);
 
 			const result = await workflowExecute.runNode(
@@ -450,7 +451,10 @@ describe('WorkflowExecute.runNode - Real Implementation', () => {
 				'manual',
 			);
 
-			expect(nodeInstance.execute).toHaveBeenCalledWith(mockContextInstance);
+			expect(nodeInstance.execute).toHaveBeenCalledWith(
+				mockContextInstance,
+				mockSubNodeExecutionResults,
+			);
 			expect(result).toEqual({ data: mockData, hints: [] });
 		});
 

--- a/packages/core/src/execution-engine/index.ts
+++ b/packages/core/src/execution-engine/index.ts
@@ -24,4 +24,4 @@ export * from './node-execution-context/utils/execution-metadata';
 export * from './workflow-execute';
 export { ExecutionLifecycleHooks } from './execution-lifecycle-hooks';
 export { ExternalSecretsProxy, type IExternalSecretsManager } from './external-secrets-proxy';
-export { isRequest } from './requests-response';
+export { isEngineRequest as isRequest } from './requests-response';

--- a/packages/core/src/execution-engine/index.ts
+++ b/packages/core/src/execution-engine/index.ts
@@ -24,4 +24,4 @@ export * from './node-execution-context/utils/execution-metadata';
 export * from './workflow-execute';
 export { ExecutionLifecycleHooks } from './execution-lifecycle-hooks';
 export { ExternalSecretsProxy, type IExternalSecretsManager } from './external-secrets-proxy';
-export { isEngineRequest as isRequest } from './requests-response';
+export { isEngineRequest } from './requests-response';

--- a/packages/core/src/execution-engine/index.ts
+++ b/packages/core/src/execution-engine/index.ts
@@ -24,3 +24,4 @@ export * from './node-execution-context/utils/execution-metadata';
 export * from './workflow-execute';
 export { ExecutionLifecycleHooks } from './execution-lifecycle-hooks';
 export { ExternalSecretsProxy, type IExternalSecretsManager } from './external-secrets-proxy';
+export { isRequest } from './requests-response';

--- a/packages/core/src/execution-engine/node-execution-context/execute-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/execute-context.ts
@@ -17,7 +17,7 @@ import type {
 	StructuredChunk,
 	Workflow,
 	WorkflowExecuteMode,
-	Response,
+	EngineResponse,
 } from 'n8n-workflow';
 import {
 	ApplicationError,
@@ -66,7 +66,7 @@ export class ExecuteContext extends BaseExecuteContext implements IExecuteFuncti
 		executeData: IExecuteData,
 		private readonly closeFunctions: CloseFunction[],
 		abortSignal?: AbortSignal,
-		public subNodeExecutionResults?: Response,
+		public subNodeExecutionResults?: EngineResponse,
 	) {
 		super(
 			workflow,

--- a/packages/core/src/execution-engine/node-execution-context/execute-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/execute-context.ts
@@ -17,6 +17,7 @@ import type {
 	StructuredChunk,
 	Workflow,
 	WorkflowExecuteMode,
+	Response,
 } from 'n8n-workflow';
 import {
 	ApplicationError,
@@ -65,6 +66,7 @@ export class ExecuteContext extends BaseExecuteContext implements IExecuteFuncti
 		executeData: IExecuteData,
 		private readonly closeFunctions: CloseFunction[],
 		abortSignal?: AbortSignal,
+		public subNodeExecutionResults?: Response,
 	) {
 		super(
 			workflow,

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-input-connection-data.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-input-connection-data.test.ts
@@ -13,6 +13,7 @@ import type {
 	IExecuteFunctions,
 	IRunData,
 	ITaskData,
+	EngineRequest,
 } from 'n8n-workflow';
 import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 
@@ -605,6 +606,35 @@ describe('makeHandleToolInvocation', () => {
 					json: {
 						response:
 							'Error: The Tool attempted to return binary data, which is not supported in Agents',
+					},
+				},
+			],
+		]);
+	});
+
+	it('should handle engine requests and return a warning message', async () => {
+		const mockContext = mock<IExecuteFunctions>();
+		contextFactory.mockReturnValue(mockContext);
+		const mockResult: EngineRequest = { actions: [], metadata: {} };
+		execute.mockResolvedValueOnce(mockResult);
+
+		const handleToolInvocation = makeHandleToolInvocation(
+			contextFactory,
+			connectedNode,
+			connectedNodeType,
+			runExecutionData,
+		);
+		const result = await handleToolInvocation(toolArgs);
+
+		expect(result).toBe(
+			'"Error: The Tool attempted to return an engine request, which is not supported in Agents"',
+		);
+		expect(mockContext.addOutputData).toHaveBeenCalledWith(NodeConnectionTypes.AiTool, 0, [
+			[
+				{
+					json: {
+						response:
+							'Error: The Tool attempted to return an engine request, which is not supported in Agents',
 					},
 				},
 			],

--- a/packages/core/src/execution-engine/node-execution-context/utils/get-input-connection-data.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/get-input-connection-data.ts
@@ -31,6 +31,7 @@ import { createNodeAsTool } from './create-node-as-tool';
 import type { ExecuteContext, WebhookContext } from '../../node-execution-context';
 // eslint-disable-next-line import-x/no-cycle
 import { SupplyDataContext } from '../../node-execution-context/supply-data-context';
+import { isRequest } from '../../requests-response';
 
 function getNextRunIndex(runExecutionData: IRunExecutionData, nodeName: string) {
 	return runExecutionData.resultData.runData[nodeName]?.length ?? 0;
@@ -50,6 +51,7 @@ export function makeHandleToolInvocation(
 	// of the same tool when the tool is used in a loop or in a parallel execution.
 	let runIndex = getNextRunIndex(runExecutionData, node.name);
 
+	// eslint-disable-next-line complexity
 	return async (toolArgs: IDataObject) => {
 		let maxTries = 1;
 		if (node.retryOnFail === true) {
@@ -95,18 +97,22 @@ export function makeHandleToolInvocation(
 				const result = await nodeType.execute?.call(context as unknown as IExecuteFunctions);
 
 				// Process and map the results
-				const mappedResults = result?.[0]?.flatMap((item) => item.json);
+				const mappedResults = isRequest(result)
+					? undefined
+					: result?.[0]?.flatMap((item) => item.json);
 				let response: string | typeof mappedResults = mappedResults;
 
-				// Warn if any (unusable) binary data was returned
-				if (result?.some((x) => x.some((y) => y.binary))) {
-					if (!mappedResults || mappedResults.flatMap((x) => Object.keys(x ?? {})).length === 0) {
-						response =
-							'Error: The Tool attempted to return binary data, which is not supported in Agents';
-					} else {
-						context.logger.warn(
-							`Response from Tool '${node.name}' included binary data, which is not supported in Agents. The binary data was omitted from the response.`,
-						);
+				if (!isRequest(result)) {
+					// Warn if any (unusable) binary data was returned
+					if (result?.some((x) => x.some((y) => y.binary))) {
+						if (!mappedResults || mappedResults.flatMap((x) => Object.keys(x ?? {})).length === 0) {
+							response =
+								'Error: The Tool attempted to return binary data, which is not supported in Agents';
+						} else {
+							context.logger.warn(
+								`Response from Tool '${node.name}' included binary data, which is not supported in Agents. The binary data was omitted from the response.`,
+							);
+						}
 					}
 				}
 

--- a/packages/core/src/execution-engine/node-execution-context/utils/get-input-connection-data.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/get-input-connection-data.ts
@@ -34,14 +34,14 @@ import { createNodeAsTool } from './create-node-as-tool';
 import type { ExecuteContext, WebhookContext } from '../../node-execution-context';
 // eslint-disable-next-line import-x/no-cycle
 import { SupplyDataContext } from '../../node-execution-context/supply-data-context';
-import { isRequest } from '../../requests-response';
+import { isEngineRequest } from '../../requests-response';
 
 function getNextRunIndex(runExecutionData: IRunExecutionData, nodeName: string) {
 	return runExecutionData.resultData.runData[nodeName]?.length ?? 0;
 }
 
 function containsBinaryData(nodeExecutionResult?: NodeOutput): boolean {
-	if (isRequest(nodeExecutionResult)) {
+	if (isEngineRequest(nodeExecutionResult)) {
 		return false;
 	}
 
@@ -53,7 +53,7 @@ function containsBinaryData(nodeExecutionResult?: NodeOutput): boolean {
 }
 
 function containsDataThatIsUsefulToTheAgent(nodeExecutionResult?: NodeOutput): boolean {
-	if (isRequest(nodeExecutionResult)) {
+	if (isEngineRequest(nodeExecutionResult)) {
 		return false;
 	}
 
@@ -79,7 +79,7 @@ function mapResult(result?: NodeOutput) {
 
 	if (result === undefined) {
 		response = undefined;
-	} else if (isRequest(result)) {
+	} else if (isEngineRequest(result)) {
 		response =
 			'Error: The Tool attempted to return an engine request, which is not supported in Agents';
 	} else if (containsBinaryData(result) && !containsDataThatIsUsefulToTheAgent(result)) {

--- a/packages/core/src/execution-engine/node-execution-context/utils/get-input-connection-data.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/get-input-connection-data.ts
@@ -19,7 +19,6 @@ import type {
 	NodeConnectionType,
 	NodeOutput,
 	GenericValue,
-	Logger,
 } from 'n8n-workflow';
 import {
 	NodeConnectionTypes,

--- a/packages/core/src/execution-engine/requests-response.ts
+++ b/packages/core/src/execution-engine/requests-response.ts
@@ -113,10 +113,15 @@ export function handleRequests({
 	// 2. create metadata for current node
 	const parentNode = executionData.source?.main?.[0]?.previousNode;
 	if (!parentNode) {
-		logger.warn('Cannot find parent node for subnode execution', {
+		logger.warn('Cannot find parent node for subnode execution - request will be ignored', {
 			executionNode: executionData.node.name,
 			sourceData: executionData.source,
 			workflowId: workflow.id,
+			requestActions: request.actions.map((a) => ({
+				nodeName: a.nodeName,
+				actionType: a.actionType,
+				id: a.id,
+			})),
 		});
 
 		return { nodesToBeExecuted: [] };

--- a/packages/core/src/execution-engine/requests-response.ts
+++ b/packages/core/src/execution-engine/requests-response.ts
@@ -1,14 +1,15 @@
-import type {
-	IConnection,
-	IExecuteData,
-	INode,
-	INodeExecutionData,
-	IRunData,
-	IRunNodeResponse,
-	ITaskMetadata,
-	Request,
-	Workflow,
-	LoggerProxy,
+import {
+	type IConnection,
+	type IExecuteData,
+	type INode,
+	type INodeExecutionData,
+	type IRunData,
+	type IRunNodeResponse,
+	type ITaskMetadata,
+	type Request,
+	type Workflow,
+	type LoggerProxy,
+	UnexpectedError,
 } from 'n8n-workflow';
 
 type NodeToBeExecuted = {
@@ -53,7 +54,14 @@ export function handleRequests({
 		metadata: request.metadata,
 	};
 	for (const action of request.actions) {
-		const node = workflow.getNode(action.nodeName)!;
+		const node = workflow.getNode(action.nodeName);
+
+		if (!node) {
+			throw new UnexpectedError(
+				`Workflow does not contain a node with the name of "${action.nodeName}".`,
+			);
+		}
+
 		node.rewireOutputLogTo = action.type;
 		const inputConnectionData: IConnection = {
 			// agents always have a main input

--- a/packages/core/src/execution-engine/requests-response.ts
+++ b/packages/core/src/execution-engine/requests-response.ts
@@ -22,12 +22,11 @@ type NodeToBeExecuted = {
 	metadata?: ITaskMetadata;
 };
 
-// if runNodeData is Request
-// 1. stop executing current node and put it as paused on the stack
-//	- do any clean up of execution variables
-// 2. put actions nodes on the stack, rewiring the graph potentially?
-// 3. continue executionLoop
-// 4. when hitting the paused node again, restore the state and call the execute method on the paused node again
+/**
+ * Processes a Request object by scheduling the requested tool nodes for execution
+ * and preparing the current node to resume after tools complete. The current node
+ * is paused and will be re-executed with tool results once all actions finish.
+ */
 export function handleRequests({
 	workflow,
 	currentNode,

--- a/packages/core/src/execution-engine/requests-response.ts
+++ b/packages/core/src/execution-engine/requests-response.ts
@@ -1,0 +1,143 @@
+import type {
+	IConnection,
+	IExecuteData,
+	INode,
+	INodeExecutionData,
+	IRunData,
+	IRunNodeResponse,
+	ITaskMetadata,
+	Request,
+	Workflow,
+	LoggerProxy,
+} from 'n8n-workflow';
+
+type NodeToBeExecuted = {
+	inputConnectionData: IConnection;
+	parentOutputIndex: number;
+	parentNode: string;
+	parentOutputData: INodeExecutionData[][];
+	runIndex: number;
+	nodeRunIndex: number;
+	metadata?: ITaskMetadata;
+};
+
+// if runNodeData is Request
+// 1. stop executing current node and put it as paused on the stack
+//	- do any clean up of execution variables
+// 2. put actions nodes on the stack, rewiring the graph potentially?
+// 3. continue executionLoop
+// 4. when hitting the paused node again, restore the state and call the execute method on the paused node again
+export function handleRequests({
+	workflow,
+	currentNode,
+	request,
+	runIndex,
+	executionData,
+	runData,
+	logger,
+}: {
+	workflow: Workflow;
+	currentNode: INode;
+	request: Request;
+	runIndex: number;
+	executionData: IExecuteData;
+	runData: IRunData;
+	logger: typeof LoggerProxy;
+}): {
+	nodesToBeExecuted: NodeToBeExecuted[];
+} {
+	// 1. collect nodes to be put on the stack
+	const nodesToBeExecuted: NodeToBeExecuted[] = [];
+	const subNodeExecutionData: ITaskMetadata['subNodeExecutionData'] = {
+		actions: [],
+		metadata: request.metadata,
+	};
+	for (const action of request.actions) {
+		const node = workflow.getNode(action.nodeName)!;
+		node.rewireOutputLogTo = action.type;
+		const inputConnectionData: IConnection = {
+			// agents always have a main input
+			type: action.type,
+			node: action.nodeName,
+			// tools always have only one input
+			index: 0,
+		};
+		const parentNode = currentNode.name;
+		const parentOutputData: INodeExecutionData[][] = [
+			[
+				{
+					json: {
+						...action.input,
+						toolCallId: action.id,
+					},
+				},
+			],
+		];
+		const parentOutputIndex = 0;
+
+		runData[node.name] ||= [];
+		const nodeRunData = runData[node.name];
+		const nodeRunIndex = nodeRunData.length;
+		// TODO: Remove when AI-723 lands.
+		nodeRunData.push({
+			// Necessary for the log on the canvas.
+			inputOverride: { ai_tool: parentOutputData },
+			source: [],
+			executionIndex: 0,
+			executionTime: 0,
+			startTime: 0,
+		});
+
+		nodesToBeExecuted.push({
+			inputConnectionData,
+			parentOutputIndex,
+			parentNode,
+			parentOutputData,
+			runIndex,
+			nodeRunIndex,
+		});
+		subNodeExecutionData.actions.push({
+			action,
+			nodeName: action.nodeName,
+			runIndex: nodeRunIndex,
+		});
+	}
+
+	// 2. create metadata for current node
+	const parentNode = executionData.source?.main?.[0]?.previousNode;
+	if (!parentNode) {
+		logger.warn('Cannot find parent node for subnode execution', {
+			executionNode: executionData.node.name,
+			sourceData: executionData.source,
+			workflowId: workflow.id,
+		});
+
+		return { nodesToBeExecuted: [] };
+	}
+	const connectionData: IConnection = {
+		// agents always have a main input
+		type: 'ai_tool',
+		node: executionData.node.name,
+		// agents always have only one input
+		index: 0,
+	};
+
+	// 3. add current node back to the bottom of the stack
+	nodesToBeExecuted.unshift({
+		inputConnectionData: connectionData,
+		parentOutputIndex: 0,
+		parentNode,
+		parentOutputData: executionData.data.main as INodeExecutionData[][],
+		runIndex,
+		nodeRunIndex: runIndex,
+		metadata: { subNodeExecutionData },
+	});
+
+	return { nodesToBeExecuted };
+}
+
+export function isRequest(
+	responseOrRequest: INodeExecutionData[][] | IRunNodeResponse | Request | null | undefined,
+): responseOrRequest is Request {
+	return !!responseOrRequest && 'actions' in responseOrRequest;
+}

--- a/packages/core/src/execution-engine/requests-response.ts
+++ b/packages/core/src/execution-engine/requests-response.ts
@@ -27,7 +27,7 @@ type NodeToBeExecuted = {
  * and preparing the current node to resume after tools complete. The current node
  * is paused and will be re-executed with tool results once all actions finish.
  */
-export function handleRequests({
+export function handleRequest({
 	workflow,
 	currentNode,
 	request,

--- a/packages/core/src/execution-engine/requests-response.ts
+++ b/packages/core/src/execution-engine/requests-response.ts
@@ -10,6 +10,7 @@ import {
 	type Workflow,
 	type LoggerProxy,
 	UnexpectedError,
+	EngineResponse,
 } from 'n8n-workflow';
 
 type NodeToBeExecuted = {
@@ -152,4 +153,8 @@ export function isEngineRequest(
 	responseOrRequest: INodeExecutionData[][] | IRunNodeResponse | EngineRequest | null | undefined,
 ): responseOrRequest is EngineRequest {
 	return !!responseOrRequest && 'actions' in responseOrRequest;
+}
+
+export function makeEngineResponse(): EngineResponse {
+	return { actionResponses: [], metadata: {} };
 }

--- a/packages/core/src/execution-engine/requests-response.ts
+++ b/packages/core/src/execution-engine/requests-response.ts
@@ -6,7 +6,7 @@ import {
 	type IRunData,
 	type IRunNodeResponse,
 	type ITaskMetadata,
-	type Request,
+	type EngineRequest,
 	type Workflow,
 	type LoggerProxy,
 	UnexpectedError,
@@ -38,7 +38,7 @@ export function handleRequests({
 }: {
 	workflow: Workflow;
 	currentNode: INode;
-	request: Request;
+	request: EngineRequest;
 	runIndex: number;
 	executionData: IExecuteData;
 	runData: IRunData;
@@ -149,7 +149,7 @@ export function handleRequests({
 }
 
 export function isRequest(
-	responseOrRequest: INodeExecutionData[][] | IRunNodeResponse | Request | null | undefined,
-): responseOrRequest is Request {
+	responseOrRequest: INodeExecutionData[][] | IRunNodeResponse | EngineRequest | null | undefined,
+): responseOrRequest is EngineRequest {
 	return !!responseOrRequest && 'actions' in responseOrRequest;
 }

--- a/packages/core/src/execution-engine/requests-response.ts
+++ b/packages/core/src/execution-engine/requests-response.ts
@@ -148,7 +148,7 @@ export function handleRequest({
 	return { nodesToBeExecuted };
 }
 
-export function isRequest(
+export function isEngineRequest(
 	responseOrRequest: INodeExecutionData[][] | IRunNodeResponse | EngineRequest | null | undefined,
 ): responseOrRequest is EngineRequest {
 	return !!responseOrRequest && 'actions' in responseOrRequest;

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -75,7 +75,7 @@ import {
 	rewireGraph,
 	getNextExecutionIndex,
 } from './partial-execution-utils';
-import { handleRequest, isRequest } from './requests-response';
+import { handleRequest, isEngineRequest } from './requests-response';
 import { RoutingNode } from './routing-node';
 import { TriggersAndPollers } from './triggers-and-pollers';
 
@@ -1267,7 +1267,7 @@ export class WorkflowExecute {
 			throw new Error();
 		}
 
-		if (isRequest(data)) {
+		if (isEngineRequest(data)) {
 			return data;
 		}
 
@@ -1809,7 +1809,8 @@ export class WorkflowExecute {
 								);
 
 								let didContinueOnFail =
-									!isRequest(runNodeData) && runNodeData.data?.[0]?.[0]?.json?.error !== undefined;
+									!isEngineRequest(runNodeData) &&
+									runNodeData.data?.[0]?.[0]?.json?.error !== undefined;
 
 								while (didContinueOnFail && tryIndex !== maxTries - 1) {
 									await sleep(waitBetweenTries);
@@ -1826,13 +1827,13 @@ export class WorkflowExecute {
 									);
 
 									didContinueOnFail =
-										!isRequest(runNodeData) &&
+										!isEngineRequest(runNodeData) &&
 										runNodeData.data?.[0]?.[0]?.json?.error !== undefined;
 									tryIndex++;
 								}
 
 								// if runNodeData is Request
-								if (isRequest(runNodeData)) {
+								if (isEngineRequest(runNodeData)) {
 									const { nodesToBeExecuted } = handleRequest({
 										workflow,
 										currentNode: executionNode,

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -44,8 +44,8 @@ import type {
 	ITaskStartedData,
 	AiAgentRequest,
 	IWorkflowExecutionDataProcess,
-	Request,
-	Response,
+	EngineRequest,
+	EngineResponse,
 } from 'n8n-workflow';
 import {
 	LoggerProxy as Logger,
@@ -60,11 +60,6 @@ import {
 	OperationalError,
 } from 'n8n-workflow';
 import PCancelable from 'p-cancelable';
-
-import { ErrorReporter } from '@/errors/error-reporter';
-import { WorkflowHasIssuesError } from '@/errors/workflow-has-issues.error';
-import * as NodeExecuteFunctions from '@/node-execute-functions';
-import { isJsonCompatible } from '@/utils/is-json-compatible';
 
 import type { ExecutionLifecycleHooks } from './execution-lifecycle-hooks';
 import { ExecuteContext, PollContext } from './node-execution-context';
@@ -83,6 +78,11 @@ import {
 import { handleRequests, isRequest } from './requests-response';
 import { RoutingNode } from './routing-node';
 import { TriggersAndPollers } from './triggers-and-pollers';
+
+import { ErrorReporter } from '@/errors/error-reporter';
+import { WorkflowHasIssuesError } from '@/errors/workflow-has-issues.error';
+import * as NodeExecuteFunctions from '@/node-execute-functions';
+import { isJsonCompatible } from '@/utils/is-json-compatible';
 
 export class WorkflowExecute {
 	private status: ExecutionStatus = 'new';
@@ -1236,8 +1236,8 @@ export class WorkflowExecute {
 		inputData: ITaskDataConnections,
 		executionData: IExecuteData,
 		abortSignal?: AbortSignal,
-		subNodeExecutionResults?: Response,
-	): Promise<IRunNodeResponse | Request> {
+		subNodeExecutionResults?: EngineResponse,
+	): Promise<IRunNodeResponse | EngineRequest> {
 		const closeFunctions: CloseFunction[] = [];
 		const context = new ExecuteContext(
 			workflow,
@@ -1254,7 +1254,7 @@ export class WorkflowExecute {
 			subNodeExecutionResults,
 		);
 
-		let data: INodeExecutionData[][] | Request | null;
+		let data: INodeExecutionData[][] | EngineRequest | null;
 
 		if (customOperation) {
 			data = await customOperation.call(context);
@@ -1413,8 +1413,8 @@ export class WorkflowExecute {
 		additionalData: IWorkflowExecuteAdditionalData,
 		mode: WorkflowExecuteMode,
 		abortSignal?: AbortSignal,
-		subNodeExecutionResults?: Response,
-	): Promise<IRunNodeResponse | Request> {
+		subNodeExecutionResults?: EngineResponse,
+	): Promise<IRunNodeResponse | EngineRequest> {
 		const { node } = executionData;
 		let inputData = executionData.data;
 
@@ -1588,7 +1588,7 @@ export class WorkflowExecute {
 
 		// Variables which hold temporary data for each node-execution
 		let executionData: IExecuteData;
-		let subNodeExecutionResults: Response = { actionResponses: [], metadata: {} };
+		let subNodeExecutionResults: EngineResponse = { actionResponses: [], metadata: {} };
 		let executionError: ExecutionBaseError | undefined;
 		let executionNode: INode;
 		let runIndex: number;

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -1264,7 +1264,9 @@ export class WorkflowExecute {
 					? await nodeType.execute(context, subNodeExecutionResults)
 					: await nodeType.execute.call(context, subNodeExecutionResults);
 		} else {
-			throw new Error();
+			throw new UnexpectedError(
+				"Can't execute node. There is no custom operation and the node has not execute function.",
+			);
 		}
 
 		if (isEngineRequest(data)) {

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -1603,7 +1603,6 @@ export class WorkflowExecute {
 			runIndex,
 			executionData,
 			runData,
-			logger: Logger,
 		});
 
 		for (const nodeData of nodesToBeExecuted) {

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -75,7 +75,7 @@ import {
 	rewireGraph,
 	getNextExecutionIndex,
 } from './partial-execution-utils';
-import { handleRequest, isEngineRequest } from './requests-response';
+import { handleRequest, isEngineRequest, makeEngineResponse } from './requests-response';
 import { RoutingNode } from './routing-node';
 import { TriggersAndPollers } from './triggers-and-pollers';
 
@@ -1590,7 +1590,7 @@ export class WorkflowExecute {
 
 		// Variables which hold temporary data for each node-execution
 		let executionData: IExecuteData;
-		let subNodeExecutionResults: EngineResponse = { actionResponses: [], metadata: {} };
+		let subNodeExecutionResults: EngineResponse = makeEngineResponse();
 		let executionError: ExecutionBaseError | undefined;
 		let executionNode: INode;
 		let runIndex: number;
@@ -1666,7 +1666,7 @@ export class WorkflowExecute {
 						return;
 					}
 
-					subNodeExecutionResults = { actionResponses: [], metadata: {} };
+					subNodeExecutionResults = makeEngineResponse();
 
 					let nodeSuccessData: INodeExecutionData[][] | null | undefined = null;
 					executionError = undefined;

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -1916,7 +1916,7 @@ export class WorkflowExecute {
 
 							nodeSuccessData = this.assignPairedItems(nodeSuccessData, executionData);
 
-							if (!nodeSuccessData) {
+							if (nodeSuccessData) {
 								this.runExecutionData.resultData.lastNodeExecuted = executionData.node.name;
 							}
 

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -1855,11 +1855,11 @@ export class WorkflowExecute {
 									subNodeExecutionResults,
 								);
 
-								let didContinueOnFail =
+								let nodeFailed =
 									!isEngineRequest(runNodeData) &&
 									runNodeData.data?.[0]?.[0]?.json?.error !== undefined;
 
-								while (didContinueOnFail && tryIndex !== maxTries - 1) {
+								while (nodeFailed && tryIndex !== maxTries - 1) {
 									await sleep(waitBetweenTries);
 
 									// retries for failure happen here
@@ -1873,7 +1873,7 @@ export class WorkflowExecute {
 										this.abortController.signal,
 									);
 
-									didContinueOnFail =
+									nodeFailed =
 										!isEngineRequest(runNodeData) &&
 										runNodeData.data?.[0]?.[0]?.json?.error !== undefined;
 									tryIndex++;

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -1862,7 +1862,6 @@ export class WorkflowExecute {
 								while (nodeFailed && tryIndex !== maxTries - 1) {
 									await sleep(waitBetweenTries);
 
-									// retries for failure happen here
 									runNodeData = await this.runNode(
 										workflow,
 										executionData,

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -75,7 +75,7 @@ import {
 	rewireGraph,
 	getNextExecutionIndex,
 } from './partial-execution-utils';
-import { handleRequests, isRequest } from './requests-response';
+import { handleRequest, isRequest } from './requests-response';
 import { RoutingNode } from './routing-node';
 import { TriggersAndPollers } from './triggers-and-pollers';
 
@@ -1833,7 +1833,7 @@ export class WorkflowExecute {
 
 								// if runNodeData is Request
 								if (isRequest(runNodeData)) {
-									const { nodesToBeExecuted } = handleRequests({
+									const { nodesToBeExecuted } = handleRequest({
 										workflow,
 										currentNode: executionNode,
 										request: runNodeData,

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -61,6 +61,11 @@ import {
 } from 'n8n-workflow';
 import PCancelable from 'p-cancelable';
 
+import { ErrorReporter } from '@/errors/error-reporter';
+import { WorkflowHasIssuesError } from '@/errors/workflow-has-issues.error';
+import * as NodeExecuteFunctions from '@/node-execute-functions';
+import { isJsonCompatible } from '@/utils/is-json-compatible';
+
 import type { ExecutionLifecycleHooks } from './execution-lifecycle-hooks';
 import { ExecuteContext, PollContext } from './node-execution-context';
 import {
@@ -78,11 +83,6 @@ import {
 import { handleRequest, isEngineRequest, makeEngineResponse } from './requests-response';
 import { RoutingNode } from './routing-node';
 import { TriggersAndPollers } from './triggers-and-pollers';
-
-import { ErrorReporter } from '@/errors/error-reporter';
-import { WorkflowHasIssuesError } from '@/errors/workflow-has-issues.error';
-import * as NodeExecuteFunctions from '@/node-execute-functions';
-import { isJsonCompatible } from '@/utils/is-json-compatible';
 
 export class WorkflowExecute {
 	private status: ExecutionStatus = 'new';

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -44,6 +44,8 @@ import type {
 	ITaskStartedData,
 	AiAgentRequest,
 	IWorkflowExecutionDataProcess,
+	Request,
+	Response,
 } from 'n8n-workflow';
 import {
 	LoggerProxy as Logger,
@@ -78,6 +80,7 @@ import {
 	rewireGraph,
 	getNextExecutionIndex,
 } from './partial-execution-utils';
+import { handleRequests, isRequest } from './requests-response';
 import { RoutingNode } from './routing-node';
 import { TriggersAndPollers } from './triggers-and-pollers';
 
@@ -607,6 +610,8 @@ export class WorkflowExecute {
 		parentNodeName: string,
 		nodeSuccessData: INodeExecutionData[][],
 		runIndex: number,
+		newRunIndex?: number,
+		metadata?: ITaskMetadata,
 	): void {
 		let stillDataMissing = false;
 		const enqueueFn = workflow.settings.executionOrder === 'v1' ? 'unshift' : 'push';
@@ -614,7 +619,9 @@ export class WorkflowExecute {
 
 		// Check if node has multiple inputs as then we have to wait for all input data
 		// to be present before we can add it to the node-execution-stack
-		if (workflow.connectionsByDestinationNode[connectionData.node].main.length > 1) {
+		const numberOfInputs =
+			workflow.connectionsByDestinationNode[connectionData.node]?.main?.length ?? 0;
+		if (numberOfInputs > 1) {
 			// Node has multiple inputs
 			let nodeWasWaiting = true;
 
@@ -1003,6 +1010,8 @@ export class WorkflowExecute {
 						},
 					],
 				},
+				runIndex: newRunIndex,
+				metadata,
 			});
 		}
 	}
@@ -1227,7 +1236,8 @@ export class WorkflowExecute {
 		inputData: ITaskDataConnections,
 		executionData: IExecuteData,
 		abortSignal?: AbortSignal,
-	): Promise<IRunNodeResponse> {
+		subNodeExecutionResults?: Response,
+	): Promise<IRunNodeResponse | Request> {
 		const closeFunctions: CloseFunction[] = [];
 		const context = new ExecuteContext(
 			workflow,
@@ -1241,17 +1251,24 @@ export class WorkflowExecute {
 			executionData,
 			closeFunctions,
 			abortSignal,
+			subNodeExecutionResults,
 		);
 
-		let data: INodeExecutionData[][] | null = null;
+		let data: INodeExecutionData[][] | Request | null;
 
 		if (customOperation) {
 			data = await customOperation.call(context);
 		} else if (nodeType.execute) {
 			data =
 				nodeType instanceof Node
-					? await nodeType.execute(context)
-					: await nodeType.execute.call(context);
+					? await nodeType.execute(context, subNodeExecutionResults)
+					: await nodeType.execute.call(context, subNodeExecutionResults);
+		} else {
+			throw new Error();
+		}
+
+		if (isRequest(data)) {
+			return data;
 		}
 
 		this.reportJsonIncompatibleOutput(data, workflow, node);
@@ -1396,7 +1413,8 @@ export class WorkflowExecute {
 		additionalData: IWorkflowExecuteAdditionalData,
 		mode: WorkflowExecuteMode,
 		abortSignal?: AbortSignal,
-	): Promise<IRunNodeResponse> {
+		subNodeExecutionResults?: Response,
+	): Promise<IRunNodeResponse | Request> {
 		const { node } = executionData;
 		let inputData = executionData.data;
 
@@ -1422,8 +1440,6 @@ export class WorkflowExecute {
 
 		inputData = this.handleExecuteOnce(node, inputData);
 
-		const isDeclarativeNode = nodeType.description.requestDefaults !== undefined;
-
 		if (nodeType.execute || customOperation) {
 			return await this.executeNode(
 				workflow,
@@ -1438,6 +1454,7 @@ export class WorkflowExecute {
 				inputData,
 				executionData,
 				abortSignal,
+				subNodeExecutionResults,
 			);
 		}
 
@@ -1456,6 +1473,7 @@ export class WorkflowExecute {
 			);
 		}
 
+		const isDeclarativeNode = nodeType.description.requestDefaults !== undefined;
 		if (nodeType.webhook && !isDeclarativeNode) {
 			// Check if the node have requestDefaults(Declarative Node),
 			// else for webhook nodes always simply pass the data through
@@ -1570,6 +1588,7 @@ export class WorkflowExecute {
 
 		// Variables which hold temporary data for each node-execution
 		let executionData: IExecuteData;
+		let subNodeExecutionResults: Response = { actionResponses: [], metadata: {} };
 		let executionError: ExecutionBaseError | undefined;
 		let executionNode: INode;
 		let runIndex: number;
@@ -1645,6 +1664,8 @@ export class WorkflowExecute {
 						return;
 					}
 
+					subNodeExecutionResults = { actionResponses: [], metadata: {} };
+
 					let nodeSuccessData: INodeExecutionData[][] | null | undefined = null;
 					executionError = undefined;
 					executionData =
@@ -1683,9 +1704,12 @@ export class WorkflowExecute {
 
 					// Get the index of the current run
 					runIndex = 0;
-					if (Object.hasOwn(this.runExecutionData.resultData.runData, executionNode.name)) {
+					if (executionData.runIndex !== undefined) {
+						runIndex = executionData.runIndex;
+					} else if (Object.hasOwn(this.runExecutionData.resultData.runData, executionNode.name)) {
 						runIndex = this.runExecutionData.resultData.runData[executionNode.name].length;
 					}
+
 					currentExecutionTry = `${executionNode.name}:${runIndex}`;
 					if (currentExecutionTry === lastExecutionTry) {
 						throw new ApplicationError(
@@ -1753,6 +1777,21 @@ export class WorkflowExecute {
 
 								nodeSuccessData = [nodePinData]; // always zeroth runIndex
 							} else {
+								if (executionData.metadata?.subNodeExecutionData) {
+									subNodeExecutionResults.metadata =
+										executionData.metadata.subNodeExecutionData.metadata;
+									for (const subNode of executionData.metadata.subNodeExecutionData.actions) {
+										const nodeRunData = this.runExecutionData.resultData.runData[subNode.nodeName];
+										if (nodeRunData && nodeRunData[subNode.runIndex]) {
+											const data = nodeRunData[subNode.runIndex];
+											subNodeExecutionResults.actionResponses.push({
+												data,
+												action: subNode.action,
+											});
+										}
+									}
+								}
+
 								Logger.debug(`Running node "${executionNode.name}" started`, {
 									node: executionNode.name,
 									workflowId: workflow.id,
@@ -1766,15 +1805,16 @@ export class WorkflowExecute {
 									this.additionalData,
 									this.mode,
 									this.abortController.signal,
+									subNodeExecutionResults,
 								);
 
-								nodeSuccessData = runNodeData.data;
-
-								let didContinueOnFail = nodeSuccessData?.[0]?.[0]?.json?.error !== undefined;
+								let didContinueOnFail =
+									!isRequest(runNodeData) && runNodeData.data?.[0]?.[0]?.json?.error !== undefined;
 
 								while (didContinueOnFail && tryIndex !== maxTries - 1) {
 									await sleep(waitBetweenTries);
 
+									// retries for failure happen here
 									runNodeData = await this.runNode(
 										workflow,
 										executionData,
@@ -1785,13 +1825,44 @@ export class WorkflowExecute {
 										this.abortController.signal,
 									);
 
-									nodeSuccessData = runNodeData.data;
-									didContinueOnFail = nodeSuccessData?.[0]?.[0]?.json?.error !== undefined;
+									didContinueOnFail =
+										!isRequest(runNodeData) &&
+										runNodeData.data?.[0]?.[0]?.json?.error !== undefined;
 									tryIndex++;
 								}
 
+								// if runNodeData is Request
+								if (isRequest(runNodeData)) {
+									const { nodesToBeExecuted } = handleRequests({
+										workflow,
+										currentNode: executionNode,
+										request: runNodeData,
+										runIndex,
+										executionData,
+										runData: this.runExecutionData.resultData.runData,
+										logger: Logger,
+									});
+
+									for (const nodeData of nodesToBeExecuted) {
+										this.addNodeToBeExecuted(
+											workflow,
+											nodeData.inputConnectionData,
+											nodeData.parentOutputIndex,
+											nodeData.parentNode,
+											nodeData.parentOutputData,
+											nodeData.runIndex,
+											nodeData.nodeRunIndex,
+											nodeData.metadata,
+										);
+									}
+
+									continue executionLoop;
+								}
+
+								nodeSuccessData = runNodeData.data;
+
 								if (runNodeData.hints?.length) {
-									taskStartedData.hints!.push(...runNodeData.hints);
+									taskStartedData.hints!.push.apply(taskStartedData.hints!, runNodeData.hints);
 								}
 
 								if (nodeSuccessData && executionData.node.onError === 'continueErrorOutput') {
@@ -1811,6 +1882,10 @@ export class WorkflowExecute {
 							});
 
 							nodeSuccessData = this.assignPairedItems(nodeSuccessData, executionData);
+
+							if (!nodeSuccessData) {
+								this.runExecutionData.resultData.lastNodeExecuted = executionData.node.name;
+							}
 
 							if (!nodeSuccessData?.[0]?.[0]) {
 								if (executionData.node.alwaysOutputData === true) {
@@ -1972,12 +2047,27 @@ export class WorkflowExecute {
 
 					// Rewire output data log to the given connectionType
 					if (executionNode.rewireOutputLogTo) {
+						// TODO: Remove when AI-723 lands.
+						taskData.inputOverride =
+							this.runExecutionData.resultData.runData[executionNode.name][runIndex]
+								?.inputOverride || {};
 						taskData.data = {
 							[executionNode.rewireOutputLogTo]: nodeSuccessData,
 						} as ITaskDataConnections;
 					}
 
-					this.runExecutionData.resultData.runData[executionNode.name].push(taskData);
+					const runDataAlreadyExists =
+						!!this.runExecutionData.resultData.runData[executionNode.name][runIndex];
+					if (runDataAlreadyExists) {
+						// TODO: Remove when AI-723 lands. There is no need to merge
+						// anymore, because the only reason to have this entry already is
+						// because of `inputOverride`.
+						const currentTaskData =
+							this.runExecutionData.resultData.runData[executionNode.name][runIndex];
+						Object.assign(currentTaskData, taskData);
+					} else {
+						this.runExecutionData.resultData.runData[executionNode.name].push(taskData);
+					}
 
 					if (this.runExecutionData.waitTill) {
 						await hooks.runHook('nodeExecuteAfter', [
@@ -2645,14 +2735,7 @@ export class WorkflowExecute {
 			}
 		}
 
-		if (nodeSuccessData === undefined) {
-			// Node did not get executed
-			nodeSuccessData = null;
-		} else {
-			this.runExecutionData.resultData.lastNodeExecuted = executionData.node.name;
-		}
-
-		return nodeSuccessData;
+		return nodeSuccessData ?? null;
 	}
 
 	private updateTaskStatusesToCancelled(): void {

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1699,7 +1699,11 @@ export interface SupplyData {
 	closeFunction?: CloseFunction;
 }
 
-type NodeOutput = INodeExecutionData[][] | NodeExecutionWithMetadata[][] | EngineRequest | null;
+export type NodeOutput =
+	| INodeExecutionData[][]
+	| NodeExecutionWithMetadata[][]
+	| EngineRequest
+	| null;
 
 export interface INodeType {
 	description: INodeTypeDescription;

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1699,12 +1699,12 @@ export interface SupplyData {
 	closeFunction?: CloseFunction;
 }
 
-type NodeOutput = INodeExecutionData[][] | NodeExecutionWithMetadata[][] | Request | null;
+type NodeOutput = INodeExecutionData[][] | NodeExecutionWithMetadata[][] | EngineRequest | null;
 
 export interface INodeType {
 	description: INodeTypeDescription;
 	supplyData?(this: ISupplyDataFunctions, itemIndex: number): Promise<SupplyData>;
-	execute?(this: IExecuteFunctions, response?: Response): Promise<NodeOutput>;
+	execute?(this: IExecuteFunctions, response?: EngineResponse): Promise<NodeOutput>;
 	/**
 	 * A function called when a node receives a chat message. Allows it to react
 	 * to the message before it gets executed.
@@ -1774,7 +1774,7 @@ type Action<T = unknown> = ExecutionNodeAction<T>;
 // lot of type errors in our tests.
 // The correct fix is to make a PR to jest-mock-extended and make it handle
 // `unknown` special, turning it into `unknown` instead of `Partial<unknown`.
-export type Request<T = object> = {
+export type EngineRequest<T = object> = {
 	actions: Array<Action<T>>;
 	metadata: T;
 };
@@ -1782,7 +1782,7 @@ export type SubNodeExecutionResult<T = unknown> = {
 	action: ExecutionNodeAction<T>;
 	data: ITaskData;
 };
-export type Response<T = unknown> = {
+export type EngineResponse<T = unknown> = {
 	actionResponses: Array<SubNodeExecutionResult<T>>;
 	metadata: T;
 };
@@ -1795,8 +1795,8 @@ export abstract class Node {
 	abstract description: INodeTypeDescription;
 	execute?(
 		context: IExecuteFunctions,
-		response?: Response,
-	): Promise<INodeExecutionData[][] | Request>;
+		response?: EngineResponse,
+	): Promise<INodeExecutionData[][] | EngineRequest>;
 	webhook?(context: IWebhookFunctions): Promise<IWebhookResponseData>;
 	poll?(context: IPollFunctions): Promise<INodeExecutionData[][] | null>;
 }
@@ -2388,7 +2388,7 @@ export interface ITaskMetadata {
 		actions: Array<{
 			nodeName: string;
 			runIndex: number;
-			action: Request['actions'][number];
+			action: EngineRequest['actions'][number];
 			response?: object;
 		}>;
 		metadata: object;

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2438,18 +2438,20 @@ export interface RelatedExecution {
 	workflowId: string;
 }
 
+type SubNodeExecutionDataAction = {
+	nodeName: string;
+	runIndex: number;
+	action: EngineRequest['actions'][number];
+	response?: object;
+};
+
 export interface ITaskMetadata {
 	subRun?: ITaskSubRunMetadata[];
 	parentExecution?: RelatedExecution;
 	subExecution?: RelatedExecution;
 	subExecutionsCount?: number;
 	subNodeExecutionData?: {
-		actions: Array<{
-			nodeName: string;
-			runIndex: number;
-			action: EngineRequest['actions'][number];
-			response?: object;
-		}>;
+		actions: SubNodeExecutionDataAction[];
 		metadata: object;
 	};
 }

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1760,30 +1760,89 @@ export interface INodeType {
 	};
 }
 
-type ExecutionNodeAction<T> = {
+/**
+ * Represents a request to execute a specific node and receive the result back.
+ * This action tells the engine to execute the specified node with the provided input
+ * and then call back the requesting node with the execution result.
+ *
+ * @template T - The type of metadata associated with this action
+ */
+type ExecuteNodeAction<T> = {
+	/** The type identifier for this action */
 	actionType: 'ExecutionNodeAction';
+	/** The name of the node to be executed */
 	nodeName: string;
+	/** Input data to be passed to the node for execution */
 	input: IDataObject;
+	/** The type of connection this execution request uses */
 	type: NodeConnectionType;
+	/** Unique identifier for this execution request */
 	id: string;
+	/** Additional metadata for this execution request */
 	metadata: T;
 };
-type Action<T = unknown> = ExecutionNodeAction<T>;
-// TODO: this should use `unknown`, but jest-mock-extended will turn this into
-// `Partial<unknown>` which `unknown` cannot be assigned to, which leads to a
-// lot of type errors in our tests.
-// The correct fix is to make a PR to jest-mock-extended and make it handle
-// `unknown` special, turning it into `unknown` instead of `Partial<unknown`.
+
+/**
+ * Union type of all possible actions that nodes can request from the workflow engine.
+ * Currently only contains ExecuteNodeAction, but will be extended with additional
+ * action types as they are implemented.
+ *
+ * @template T - The type of metadata associated with this action
+ */
+type EngineAction<T = unknown> = ExecuteNodeAction<T>;
+
+/**
+ * A collection of actions that a node wants the engine to fulfill and call back with results.
+ * The requesting node sends this to the engine and expects to receive an EngineResponse
+ * containing the results of all requested actions.
+ *
+ * @template T - The type of metadata associated with this request
+ *
+ * @todo This should use `unknown`, but jest-mock-extended will turn this into
+ * `Partial<unknown>` which `unknown` cannot be assigned to, which leads to a
+ * lot of type errors in our tests.
+ * The correct fix is to make a PR to jest-mock-extended and make it handle
+ * `unknown` special, turning it into `unknown` instead of `Partial<unknown>`.
+ */
 export type EngineRequest<T = object> = {
-	actions: Array<Action<T>>;
+	/** Array of actions that the requesting node wants the engine to fulfill */
+	actions: Array<EngineAction<T>>;
+	/** Metadata associated with this request */
 	metadata: T;
 };
-export type SubNodeExecutionResult<T = unknown> = {
-	action: ExecutionNodeAction<T>;
+
+/**
+ * Result of executing a single node action within the workflow engine.
+ * Contains the original action and the resulting task data.
+ *
+ * @template T - The type of metadata associated with this result
+ */
+export type ExecuteNodeResult<T = unknown> = {
+	/** The action that was executed */
+	action: ExecuteNodeAction<T>;
+	/** The resulting task data from the execution */
 	data: ITaskData;
 };
+
+/**
+ * Union type of all possible results from engine actions.
+ * Currently only contains ExecuteNodeResult, but will be extended with additional
+ * result types as new action types are implemented.
+ *
+ * @template T - The type of metadata associated with this result
+ */
+type EngineResult<T> = ExecuteNodeResult<T>;
+
+/**
+ * Response structure returned from the workflow engine after execution.
+ * Contains the results of all executed actions along with associated metadata.
+ *
+ * @template T - The type of metadata associated with this response
+ */
 export type EngineResponse<T = unknown> = {
-	actionResponses: Array<SubNodeExecutionResult<T>>;
+	/** Array of results from each executed action */
+	actionResponses: Array<EngineResult<T>>;
+	/** Metadata associated with this response */
 	metadata: T;
 };
 

--- a/packages/workflow/src/workflow-data-proxy.ts
+++ b/packages/workflow/src/workflow-data-proxy.ts
@@ -2,12 +2,12 @@
 /* eslint-disable @typescript-eslint/no-this-alias */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 
+import { ApplicationError } from '@n8n/errors';
 import * as jmespath from 'jmespath';
 import { DateTime, Duration, Interval, Settings } from 'luxon';
 
 import { augmentArray, augmentObject } from './augment-object';
 import { AGENT_LANGCHAIN_NODE_TYPE, SCRIPTING_NODE_TYPES } from './constants';
-import { ApplicationError } from '@n8n/errors';
 import { ExpressionError, type ExpressionErrorOptions } from './errors/expression.error';
 import { getGlobalState } from './global-state';
 import { NodeConnectionTypes } from './interfaces';


### PR DESCRIPTION
## Summary

- Implement request-response mechanism for workflow execution engine
- Add support for Request objects with actions in node execution
- Handle Response objects with action results in execution context
- Add comprehensive test coverage for request-response flow
- Enhance node execution to support waiting tool patterns

## Related Linear tickets, Github issues, and Community forum posts

<!-- Add Linear ticket and any related issues here -->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.ai/code)