### PR TITLE
fix(editor): Additional style tweaks around parameter input (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/components/InputTriple/InputTriple.vue
+++ b/packages/frontend/editor-ui/src/components/InputTriple/InputTriple.vue
@@ -68,6 +68,7 @@ withDefaults(defineProps<Props>(), { middleWidth: '160px' });
 }
 
 .item {
+	position: relative;
 	flex-shrink: 0;
 	flex-basis: 240px;
 	flex-grow: 1;

--- a/packages/frontend/editor-ui/src/components/ParameterOptions.vue
+++ b/packages/frontend/editor-ui/src/components/ParameterOptions.vue
@@ -225,8 +225,6 @@ $container-height: 22px;
 }
 
 .noExpressionSelector {
-	margin-bottom: var(--spacing-4xs);
-
 	span {
 		padding-right: 0 !important;
 	}


### PR DESCRIPTION
## Summary

Turns out #19150 is incomplete and needs some more tweaks:

| | :bug: | Fix |
|--------|--------|--------|
| z-index ignored when `InputTriple` has stacked layout | <img width="364" height="157" alt="Screenshot 2025-09-04 at 15 50 24" src="https://github.com/user-attachments/assets/358a630f-8747-4874-aca2-19cd172ea852" /> | <img width="364" height="143" alt="Screenshot 2025-09-04 at 15 51 26" src="https://github.com/user-attachments/assets/c08213bd-e3fb-4a26-8f79-67da7d91576f" /> |
| Actions still not aligned when radio buttons are missing | <img width="481" height="83" alt="Screenshot 2025-09-04 at 15 49 34" src="https://github.com/user-attachments/assets/c9d7122f-9dab-4342-9d67-b2a30ab27f95" /> | <img width="490" height="87" alt="Screenshot 2025-09-04 at 15 47 51" src="https://github.com/user-attachments/assets/38e0e2ea-6e92-4f0d-94e3-dc6f4bfa76b6" /> | 







## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
