### PR TITLE
fix(API): Fix broken Terms of Service link in Swagger documentation (no-changelog)

### DIFF
--- a/packages/cli/src/public-api/v1/openapi.yml
+++ b/packages/cli/src/public-api/v1/openapi.yml
@@ -3,7 +3,7 @@ openapi: 3.0.0
 info:
   title: n8n Public API
   description: n8n Public API
-  termsOfService: https://n8n.io/legal/terms
+  termsOfService: https://n8n.io/legal/#terms
   contact:
     email: hello@n8n.io
   license:


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
The Terms of Service link in the Swagger UI documentation was pointing to a non-existent URL that returned a 404 error. This fix updates the `OpenAPI` specification to use the correct URL with the proper anchor to the terms section. 

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
Closes #19187 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
