### PR TITLE
fix(core): Add a signature to webhook's resume url

### DIFF
--- a/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
@@ -288,7 +288,7 @@ describe('JsTaskRunner', () => {
 						id: 'exec-id',
 						mode: 'test',
 						resumeFormUrl: 'http://formWaitingBaseUrl/exec-id',
-						resumeUrl: 'http://webhookWaitingBaseUrl/exec-id',
+						resumeUrl: 'http://webhookResumeUrl',
 						customData: {
 							get: expect.any(Function),
 							getAll: expect.any(Function),

--- a/packages/@n8n/task-runner/src/js-task-runner/__tests__/test-data.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/__tests__/test-data.ts
@@ -126,6 +126,7 @@ export const newDataRequestResponse = (
 			isEnvAccessBlocked: true,
 			isProcessAvailable: true,
 		},
+		resumeUrl: 'http://webhookResumeUrl',
 		additionalData: {
 			executionId: 'exec-id',
 			instanceBaseUrl: '',

--- a/packages/@n8n/task-runner/src/js-task-runner/built-ins-parser/__tests__/built-ins-parser.test.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/built-ins-parser/__tests__/built-ins-parser.test.ts
@@ -236,6 +236,7 @@ describe('BuiltInsParser', () => {
 					data.additionalData as IWorkflowExecuteAdditionalData,
 					data.mode,
 					data.runExecutionData,
+					'http://webhookResumeUrl',
 				),
 				executeData,
 				data.defaultReturnRunIndex,

--- a/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
@@ -81,6 +81,7 @@ export interface JsTaskData {
 	selfData: IDataObject;
 	contextNodeName: string;
 	additionalData: PartialAdditionalData;
+	resumeUrl: string;
 }
 
 type CustomConsole = {
@@ -402,6 +403,7 @@ export class JsTaskRunner extends TaskRunner {
 				data.additionalData as IWorkflowExecuteAdditionalData,
 				data.mode,
 				data.runExecutionData,
+				data.resumeUrl,
 			),
 			data.executeData,
 			data.defaultReturnRunIndex,

--- a/packages/@n8n/task-runner/src/runner-types.ts
+++ b/packages/@n8n/task-runner/src/runner-types.ts
@@ -56,6 +56,7 @@ export interface DataRequestResponse {
 	selfData: IDataObject;
 	contextNodeName: string;
 	additionalData: PartialAdditionalData;
+	resumeUrl: string;
 }
 
 export interface TaskResultData {
@@ -84,6 +85,7 @@ export interface TaskData {
 	selfData: IDataObject;
 	contextNodeName: string;
 	additionalData: IWorkflowExecuteAdditionalData;
+	resumeUrl: string;
 }
 
 export interface PartialAdditionalData {

--- a/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
+++ b/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
@@ -215,6 +215,7 @@ describe('WorkflowExecuteAdditionalData', () => {
 		it('should return default data', async () => {
 			expect(await getRunData(workflow)).toEqual({
 				executionData: {
+					version: 1,
 					executionData: {
 						contextData: {},
 						metadata: {},
@@ -245,6 +246,7 @@ describe('WorkflowExecuteAdditionalData', () => {
 			};
 			expect(await getRunData(workflow, data, parentExecution)).toEqual({
 				executionData: {
+					version: 1,
 					executionData: {
 						contextData: {},
 						metadata: {},

--- a/packages/cli/src/credentials-helper.ts
+++ b/packages/cli/src/credentials-helper.ts
@@ -404,7 +404,10 @@ export class CredentialsHelper extends ICredentialsHelper {
 		}
 
 		const canUseExternalSecrets = await this.credentialCanUseExternalSecrets(credential);
-		const additionalKeys = getAdditionalKeys(additionalData, mode, null, {
+		// There is no workflow execution at this point so resume URL won't be
+		// available either
+		const resumeUrl = undefined;
+		const additionalKeys = getAdditionalKeys(additionalData, mode, null, resumeUrl, {
 			secretsEnabled: canUseExternalSecrets,
 		});
 

--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -285,6 +285,7 @@ export class ExecutionService {
 		if (saveDataErrorExecutionDisabled) return;
 
 		const executionData: IRunExecutionData = {
+			version: 1,
 			startData: {
 				destinationNode: node.name,
 				runNodeFilter: [node.name],

--- a/packages/cli/src/manual-execution.service.ts
+++ b/packages/cli/src/manual-execution.service.ts
@@ -83,6 +83,7 @@ export class ManualExecutionService {
 			}
 
 			const executionData: IRunExecutionData = {
+				version: 1,
 				resultData: { runData, pinData },
 				executionData: {
 					contextData: {},

--- a/packages/cli/src/services/credentials-tester.service.ts
+++ b/packages/cli/src/services/credentials-tester.service.ts
@@ -319,6 +319,7 @@ export class CredentialsTester {
 		};
 		const connectionInputData: INodeExecutionData[] = [];
 		const runExecutionData: IRunExecutionData = {
+			version: 1,
 			resultData: {
 				runData: {},
 			},

--- a/packages/cli/src/task-runners/task-managers/__tests__/data-request-response-stripper.test.ts
+++ b/packages/cli/src/task-runners/task-managers/__tests__/data-request-response-stripper.test.ts
@@ -158,6 +158,7 @@ const taskData: DataRequestResponse = {
 		],
 	},
 	additionalData,
+	resumeUrl: 'http://webhookResumeUrl',
 } as const;
 
 describe('DataRequestResponseStripper', () => {

--- a/packages/cli/src/task-runners/task-managers/data-request-response-builder.ts
+++ b/packages/cli/src/task-runners/task-managers/data-request-response-builder.ts
@@ -30,6 +30,7 @@ export class DataRequestResponseBuilder {
 			selfData: taskData.selfData,
 			siblingParameters: taskData.siblingParameters,
 			additionalData: this.buildAdditionalData(taskData.additionalData),
+			resumeUrl: taskData.resumeUrl,
 		};
 	}
 

--- a/packages/cli/src/task-runners/task-managers/data-request-response-stripper.ts
+++ b/packages/cli/src/task-runners/task-managers/data-request-response-stripper.ts
@@ -45,6 +45,7 @@ export class DataRequestResponseStripper {
 		}
 
 		return {
+			version: runExecutionData.version,
 			startData: runExecutionData.startData,
 			resultData: {
 				error: runExecutionData.resultData.error,

--- a/packages/cli/src/task-runners/task-managers/task-requester.ts
+++ b/packages/cli/src/task-runners/task-managers/task-requester.ts
@@ -80,6 +80,7 @@ export abstract class TaskRequester {
 		siblingParameters: INodeParameters,
 		mode: WorkflowExecuteMode,
 		envProviderState: EnvProviderState,
+		resumeUrl: string,
 		executeData?: IExecuteData,
 		defaultReturnRunIndex = -1,
 		selfData: IDataObject = {},
@@ -103,6 +104,7 @@ export abstract class TaskRequester {
 			contextNodeName,
 			activeNodeName,
 			additionalData,
+			resumeUrl,
 		};
 
 		const request: TaskRequest = {

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -311,6 +311,7 @@ export function prepareExecutionData(
 	];
 
 	runExecutionData ??= {
+		version: 1,
 		startData: {},
 		resultData: {
 			runData: {},
@@ -448,8 +449,9 @@ export async function executeWebhook(
 				source: null,
 			});
 			runExecutionData =
-				runExecutionData ||
+				runExecutionData ??
 				({
+					version: 1,
 					startData: {},
 					resultData: {
 						runData: {},

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -80,6 +80,7 @@ export async function getRunData(
 	});
 
 	const runExecutionData: IRunExecutionData = {
+		version: 1,
 		startData: {},
 		resultData: {
 			runData: {},
@@ -418,6 +419,7 @@ export async function getBase(
 			siblingParameters: INodeParameters,
 			mode: WorkflowExecuteMode,
 			envProviderState: EnvProviderState,
+			resumeUrl: string,
 			executeData?: IExecuteData,
 		) {
 			return await Container.get(TaskRequester).startTask(
@@ -436,6 +438,7 @@ export async function getBase(
 				siblingParameters,
 				mode,
 				envProviderState,
+				resumeUrl,
 				executeData,
 			);
 		},

--- a/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
@@ -563,6 +563,7 @@ describe('WorkflowExecutionService', () => {
 			expect(workflowRunnerMock.run).toHaveBeenCalledWith({
 				executionMode: 'error',
 				executionData: {
+					version: 1,
 					executionData: {
 						contextData: {},
 						metadata: {},

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -63,6 +63,7 @@ export class WorkflowExecutionService {
 		];
 
 		const executionData: IRunExecutionData = {
+			version: 1,
 			startData: {},
 			resultData: {
 				runData: {},
@@ -351,6 +352,7 @@ export class WorkflowExecutionService {
 			});
 
 			const runExecutionData: IRunExecutionData = {
+				version: 1,
 				startData: {},
 				resultData: {
 					runData: {},

--- a/packages/cli/test/integration/task-runners/js-task-runner-execution.integration.test.ts
+++ b/packages/cli/test/integration/task-runners/js-task-runner-execution.integration.test.ts
@@ -102,6 +102,7 @@ describe('JS TaskRunner execution on internal mode', () => {
 		};
 
 		const runExecutionData: IRunExecutionData = {
+			version: 1,
 			startData: {},
 			resultData: {
 				runData: {
@@ -139,6 +140,7 @@ describe('JS TaskRunner execution on internal mode', () => {
 			inputConnections,
 			runExecutionData,
 			envProviderState: createEnvProviderState(),
+			resumeUrl: 'http://webhookResumeUrl',
 		};
 	};
 
@@ -153,6 +155,7 @@ describe('JS TaskRunner execution on internal mode', () => {
 			runExecutionData,
 			executeFunctions,
 			envProviderState,
+			resumeUrl,
 		} = newTaskData(jsCode);
 
 		return await taskRequester.startTask<INodeExecutionData[], Error>(
@@ -171,6 +174,7 @@ describe('JS TaskRunner execution on internal mode', () => {
 			mock<INodeParameters>(),
 			mock<WorkflowExecuteMode>(),
 			envProviderState,
+			resumeUrl,
 		);
 	};
 

--- a/packages/core/nodes-testing/node-test-harness.ts
+++ b/packages/core/nodes-testing/node-test-harness.ts
@@ -220,6 +220,7 @@ export class NodeTestHarness {
 
 		let executionData: IRun;
 		const runExecutionData: IRunExecutionData = {
+			version: 1,
 			resultData: {
 				runData: {},
 			},

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,5 +1,6 @@
 export const CUSTOM_EXTENSION_ENV = 'N8N_CUSTOM_EXTENSIONS';
 export const PLACEHOLDER_EMPTY_EXECUTION_ID = '__UNKNOWN__';
+export const PLACEHOLDER_EMPTY_RESUME_URL = '__UNAVAILABLE__';
 export const PLACEHOLDER_EMPTY_WORKFLOW_ID = '__EMPTY__';
 export const HTTP_REQUEST_NODE_TYPE = 'n8n-nodes-base.httpRequest';
 export const HTTP_REQUEST_AS_TOOL_NODE_TYPE = 'n8n-nodes-base.httpRequestTool';

--- a/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
@@ -1244,7 +1244,14 @@ describe('WorkflowExecute', () => {
 
 			nodeTypes.getByNameAndVersion.mockReturnValue(nodeType);
 
-			workflowExecute = new WorkflowExecute(mock(), 'manual', runExecutionData);
+			workflowExecute = new WorkflowExecute(
+				mock<IWorkflowExecuteAdditionalData>({
+					executionId: '123',
+					webhookWaitingBaseUrl: 'http://webhookWaitingBaseUrl',
+				}),
+				'manual',
+				runExecutionData,
+			);
 		});
 
 		test('should handle undefined error data input correctly', () => {

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/execute-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/execute-context.test.ts
@@ -62,7 +62,11 @@ describe('ExecuteContext', () => {
 		nullParameter: null,
 	};
 	const credentialsHelper = mock<ICredentialsHelper>();
-	const additionalData = mock<IWorkflowExecuteAdditionalData>({ credentialsHelper });
+	const additionalData = mock<IWorkflowExecuteAdditionalData>({
+		executionId: '123',
+		credentialsHelper,
+		webhookWaitingBaseUrl: 'http://webhookWaitingBaseUrl',
+	});
 	const mode: WorkflowExecuteMode = 'manual';
 	const runExecutionData = mock<IRunExecutionData>();
 	const connectionInputData: INodeExecutionData[] = [];

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/execute-single-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/execute-single-context.test.ts
@@ -52,7 +52,11 @@ describe('ExecuteSingleContext', () => {
 		testParameter: 'testValue',
 	};
 	const credentialsHelper = mock<ICredentialsHelper>();
-	const additionalData = mock<IWorkflowExecuteAdditionalData>({ credentialsHelper });
+	const additionalData = mock<IWorkflowExecuteAdditionalData>({
+		executionId: '123',
+		webhookWaitingBaseUrl: 'http://webhookWaitingBaseUrl',
+		credentialsHelper,
+	});
 	const mode: WorkflowExecuteMode = 'manual';
 	const runExecutionData = mock<IRunExecutionData>();
 	const connectionInputData: INodeExecutionData[] = [];

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/hook-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/hook-context.test.ts
@@ -56,7 +56,11 @@ describe('HookContext', () => {
 		testParameter: 'testValue',
 	};
 	const credentialsHelper = mock<ICredentialsHelper>();
-	const additionalData = mock<IWorkflowExecuteAdditionalData>({ credentialsHelper });
+	const additionalData = mock<IWorkflowExecuteAdditionalData>({
+		executionId: '123',
+		webhookWaitingBaseUrl: 'http://webhookWaitingBaseUrl',
+		credentialsHelper,
+	});
 	const mode: WorkflowExecuteMode = 'manual';
 	const activation: WorkflowActivateMode = 'init';
 	const webhookData = mock<IWebhookData>({

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/load-options-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/load-options-context.test.ts
@@ -44,7 +44,11 @@ describe('LoadOptionsContext', () => {
 		testParameter: 'testValue',
 	};
 	const credentialsHelper = mock<ICredentialsHelper>();
-	const additionalData = mock<IWorkflowExecuteAdditionalData>({ credentialsHelper });
+	const additionalData = mock<IWorkflowExecuteAdditionalData>({
+		executionId: '123',
+		webhookWaitingBaseUrl: 'http://webhookWaitingBaseUrl',
+		credentialsHelper,
+	});
 	const path = 'testPath';
 
 	const loadOptionsContext = new LoadOptionsContext(workflow, node, additionalData, path);

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/poll-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/poll-context.test.ts
@@ -46,7 +46,11 @@ describe('PollContext', () => {
 		testParameter: 'testValue',
 	};
 	const credentialsHelper = mock<ICredentialsHelper>();
-	const additionalData = mock<IWorkflowExecuteAdditionalData>({ credentialsHelper });
+	const additionalData = mock<IWorkflowExecuteAdditionalData>({
+		executionId: '123',
+		webhookWaitingBaseUrl: 'http://webhookWaitingBaseUrl',
+		credentialsHelper,
+	});
 	const mode: WorkflowExecuteMode = 'manual';
 	const activation: WorkflowActivateMode = 'init';
 

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/supply-data-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/supply-data-context.test.ts
@@ -54,7 +54,11 @@ describe('SupplyDataContext', () => {
 		testParameter: 'testValue',
 	};
 	const credentialsHelper = mock<ICredentialsHelper>();
-	const additionalData = mock<IWorkflowExecuteAdditionalData>({ credentialsHelper });
+	const additionalData = mock<IWorkflowExecuteAdditionalData>({
+		executionId: '123',
+		webhookWaitingBaseUrl: 'http://webhookWaitingBaseUrl',
+		credentialsHelper,
+	});
 	const mode: WorkflowExecuteMode = 'manual';
 	const runExecutionData = mock<IRunExecutionData>({
 		resultData: { runData: {} },

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/trigger-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/trigger-context.test.ts
@@ -46,7 +46,11 @@ describe('TriggerContext', () => {
 		testParameter: 'testValue',
 	};
 	const credentialsHelper = mock<ICredentialsHelper>();
-	const additionalData = mock<IWorkflowExecuteAdditionalData>({ credentialsHelper });
+	const additionalData = mock<IWorkflowExecuteAdditionalData>({
+		executionId: '123',
+		webhookWaitingBaseUrl: 'http://webhookWaitingBaseUrl',
+		credentialsHelper,
+	});
 	const mode: WorkflowExecuteMode = 'manual';
 	const activation: WorkflowActivateMode = 'init';
 

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/webhook-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/webhook-context.test.ts
@@ -48,6 +48,8 @@ describe('WebhookContext', () => {
 	};
 	const credentialsHelper = mock<ICredentialsHelper>();
 	const additionalData = mock<IWorkflowExecuteAdditionalData>({
+		executionId: '123',
+		webhookWaitingBaseUrl: 'http://webhookWaitingBaseUrl',
 		credentialsHelper,
 	});
 	additionalData.httpRequest = {

--- a/packages/core/src/execution-engine/node-execution-context/execute-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/execute-context.ts
@@ -178,6 +178,8 @@ export class ExecuteContext extends BaseExecuteContext implements IExecuteFuncti
 		settings: unknown,
 		itemIndex: number,
 	): Promise<Result<T, E>> {
+		const resumeUrl = this.getSignedResumeUrlWithoutNodeId();
+
 		return await this.additionalData.startRunnerTask<T, E>(
 			this.additionalData,
 			jobType,
@@ -194,6 +196,7 @@ export class ExecuteContext extends BaseExecuteContext implements IExecuteFuncti
 			{},
 			this.mode,
 			createEnvProviderState(),
+			resumeUrl,
 			this.executeData,
 		);
 	}

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-additional-keys.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-additional-keys.test.ts
@@ -2,7 +2,7 @@ import { mock } from 'jest-mock-extended';
 import { LoggerProxy } from 'n8n-workflow';
 import type { IDataObject, IRunExecutionData, IWorkflowExecuteAdditionalData } from 'n8n-workflow';
 
-import { PLACEHOLDER_EMPTY_EXECUTION_ID } from '@/constants';
+import { PLACEHOLDER_EMPTY_EXECUTION_ID, PLACEHOLDER_EMPTY_RESUME_URL } from '@/constants';
 import type { ExternalSecretsProxy } from '@/execution-engine/external-secrets-proxy';
 
 import { getAdditionalKeys } from '../get-additional-keys';
@@ -35,19 +35,19 @@ describe('getAdditionalKeys', () => {
 
 	it('should use placeholder execution ID when none provided', () => {
 		const noIdData = { ...additionalData, executionId: undefined };
-		const result = getAdditionalKeys(noIdData, 'manual', null);
+		const result = getAdditionalKeys(noIdData, 'manual', null, undefined);
 
 		expect(result.$execution?.id).toBe(PLACEHOLDER_EMPTY_EXECUTION_ID);
 	});
 
 	it('should return production mode when not manual', () => {
-		const result = getAdditionalKeys(additionalData, 'internal', null);
+		const result = getAdditionalKeys(additionalData, 'internal', null, undefined);
 
 		expect(result.$execution?.mode).toBe('production');
 	});
 
 	it('should include customData methods when runExecutionData is provided', () => {
-		const result = getAdditionalKeys(additionalData, 'manual', runExecutionData);
+		const result = getAdditionalKeys(additionalData, 'manual', runExecutionData, undefined);
 
 		expect(result.$execution?.customData).toBeDefined();
 		expect(typeof result.$execution?.customData?.set).toBe('function');
@@ -57,7 +57,7 @@ describe('getAdditionalKeys', () => {
 	});
 
 	it('should handle customData operations correctly', () => {
-		const result = getAdditionalKeys(additionalData, 'manual', runExecutionData);
+		const result = getAdditionalKeys(additionalData, 'manual', runExecutionData, undefined);
 		const customData = result.$execution?.customData;
 
 		customData?.set('testKey', 'testValue');
@@ -73,20 +73,24 @@ describe('getAdditionalKeys', () => {
 	});
 
 	it('should include secrets when enabled', () => {
-		const result = getAdditionalKeys(additionalData, 'manual', null, { secretsEnabled: true });
+		const result = getAdditionalKeys(additionalData, 'manual', null, undefined, {
+			secretsEnabled: true,
+		});
 
 		expect(result.$secrets).toBeDefined();
 		expect((result.$secrets?.provider1 as IDataObject).secret1).toEqual('secret-value');
 	});
 
 	it('should not include secrets when disabled', () => {
-		const result = getAdditionalKeys(additionalData, 'manual', null, { secretsEnabled: false });
+		const result = getAdditionalKeys(additionalData, 'manual', null, undefined, {
+			secretsEnabled: false,
+		});
 
 		expect(result.$secrets).toBeUndefined();
 	});
 
 	it('should throw errors in manual mode', () => {
-		const result = getAdditionalKeys(additionalData, 'manual', runExecutionData);
+		const result = getAdditionalKeys(additionalData, 'manual', runExecutionData, undefined);
 
 		expect(() => {
 			result.$execution?.customData?.set('invalid*key', 'value');
@@ -94,26 +98,35 @@ describe('getAdditionalKeys', () => {
 	});
 
 	it('should correctly set resume URLs', () => {
-		const result = getAdditionalKeys(additionalData, 'manual', null);
+		const resumeUrl = 'http://webhook.test/resumeUrl';
+		const result = getAdditionalKeys(additionalData, 'manual', null, resumeUrl);
 
-		expect(result.$execution?.resumeUrl).toBe('https://webhook.test/123');
+		expect(result.$execution?.resumeUrl).toBe(resumeUrl);
 		expect(result.$execution?.resumeFormUrl).toBe('https://form.test/123');
-		expect(result.$resumeWebhookUrl).toBe('https://webhook.test/123'); // Test deprecated property
+		expect(result.$resumeWebhookUrl).toBe(resumeUrl); // Test deprecated property
+	});
+
+	it('should correctly set placeholder resume URL if not given', () => {
+		const resumeUrl = undefined;
+		const result = getAdditionalKeys(additionalData, 'manual', null, resumeUrl);
+
+		expect(result.$execution?.resumeUrl).toBe(PLACEHOLDER_EMPTY_RESUME_URL);
+		expect(result.$resumeWebhookUrl).toBe(PLACEHOLDER_EMPTY_RESUME_URL); // Test deprecated property
 	});
 
 	it('should return test mode when manual', () => {
-		const result = getAdditionalKeys(additionalData, 'manual', null);
+		const result = getAdditionalKeys(additionalData, 'manual', null, undefined);
 
 		expect(result.$execution?.mode).toBe('test');
 	});
 
 	it('should return variables from additionalData', () => {
-		const result = getAdditionalKeys(additionalData, 'manual', null);
+		const result = getAdditionalKeys(additionalData, 'manual', null, undefined);
 		expect(result.$vars?.testVar).toEqual('value');
 	});
 
 	it('should handle errors in non-manual mode without throwing', () => {
-		const result = getAdditionalKeys(additionalData, 'internal', runExecutionData);
+		const result = getAdditionalKeys(additionalData, 'internal', runExecutionData, undefined);
 		const customData = result.$execution?.customData;
 
 		expect(() => {
@@ -122,13 +135,13 @@ describe('getAdditionalKeys', () => {
 	});
 
 	it('should return undefined customData when runExecutionData is null', () => {
-		const result = getAdditionalKeys(additionalData, 'manual', null);
+		const result = getAdditionalKeys(additionalData, 'manual', null, undefined);
 
 		expect(result.$execution?.customData).toBeUndefined();
 	});
 
 	it('should respect metadata KV limit', () => {
-		const result = getAdditionalKeys(additionalData, 'manual', runExecutionData);
+		const result = getAdditionalKeys(additionalData, 'manual', runExecutionData, undefined);
 		const customData = result.$execution?.customData;
 
 		// Add 11 key-value pairs (exceeding the limit of 10)

--- a/packages/core/src/execution-engine/node-execution-context/utils/get-additional-keys.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/get-additional-keys.ts
@@ -6,7 +6,7 @@ import type {
 } from 'n8n-workflow';
 import { LoggerProxy } from 'n8n-workflow';
 
-import { PLACEHOLDER_EMPTY_EXECUTION_ID } from '@/constants';
+import { PLACEHOLDER_EMPTY_EXECUTION_ID, PLACEHOLDER_EMPTY_RESUME_URL } from '@/constants';
 
 import {
 	setWorkflowExecutionMetadata,
@@ -16,16 +16,21 @@ import {
 } from './execution-metadata';
 import { getSecretsProxy } from './get-secrets-proxy';
 
-/** Returns the additional keys for Expressions and Function-Nodes */
+/**
+ * Returns the additional keys for Expressions and Function-Nodes
+ */
 export function getAdditionalKeys(
 	additionalData: IWorkflowExecuteAdditionalData,
 	mode: WorkflowExecuteMode,
 	runExecutionData: IRunExecutionData | null,
+	resumeUrl?: string,
 	options?: { secretsEnabled?: boolean },
 ): IWorkflowDataProxyAdditionalKeys {
 	const executionId = additionalData.executionId ?? PLACEHOLDER_EMPTY_EXECUTION_ID;
-	const resumeUrl = `${additionalData.webhookWaitingBaseUrl}/${executionId}`;
+
+	resumeUrl ??= PLACEHOLDER_EMPTY_RESUME_URL;
 	const resumeFormUrl = `${additionalData.formWaitingBaseUrl}/${executionId}`;
+
 	return {
 		$execution: {
 			id: executionId,

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -90,6 +90,7 @@ export class WorkflowExecute {
 		private readonly additionalData: IWorkflowExecuteAdditionalData,
 		private readonly mode: WorkflowExecuteMode,
 		private runExecutionData: IRunExecutionData = {
+			version: 1,
 			startData: {},
 			resultData: {
 				runData: {},

--- a/packages/core/test/helpers/index.ts
+++ b/packages/core/test/helpers/index.ts
@@ -55,6 +55,8 @@ export function WorkflowExecuteAdditionalData(
 	const hooks = new ExecutionLifecycleHooks('trigger', '1', mock());
 	hooks.addHandler('workflowExecuteAfter', (fullRunData) => waitPromise.resolve(fullRunData));
 	return mock<IWorkflowExecuteAdditionalData>({
+		executionId: '123',
+		webhookWaitingBaseUrl: 'http://webhookWaitingBaseUrl',
 		hooks,
 		currentNodeExecutionIndex: 0,
 		// Not setting this to undefined would set it to a mock which would trigger

--- a/packages/nodes-base/utils/sendAndWait/utils.ts
+++ b/packages/nodes-base/utils/sendAndWait/utils.ts
@@ -498,7 +498,6 @@ export function getSendAndWaitConfig(context: IExecuteFunctions): SendAndWaitCon
 
 	const responseType = context.getNodeParameter('responseType', 0, 'approval') as string;
 
-	context.setSignatureValidationRequired();
 	const approvedSignedResumeUrl = context.getSignedResumeUrl({ approved: 'true' });
 
 	if (responseType === 'freeText' || responseType === 'customForm') {

--- a/packages/testing/playwright/tests/ui/wait-webhook.spec.ts
+++ b/packages/testing/playwright/tests/ui/wait-webhook.spec.ts
@@ -23,9 +23,17 @@ test.describe('Wait node with resume on webhook call', () => {
 		const execution = await api.workflowApi.getExecution(body.executionId.toString());
 		expect(execution.status).toBe('waiting');
 
+		expect(body.resumeUrl).toContain('signature=');
+		const resumeUrlWoSignature = new URL(body.resumeUrl);
+		resumeUrlWoSignature.searchParams.delete('signature');
+
+		const unsignedWaitWebhookResponse = await api.request.get(resumeUrlWoSignature.toString());
+		expect(unsignedWaitWebhookResponse.status()).toBe(401);
+
 		const waitWebhookResponse = await api.request.get(body.resumeUrl);
 		expect(waitWebhookResponse.ok()).toBe(true);
 
-		await api.workflowApi.waitForExecution(workflowId);
+		const continuedExecution = await api.workflowApi.waitForExecution(workflowId);
+		expect(continuedExecution.status).toBe('success');
 	});
 });

--- a/packages/testing/playwright/tests/ui/wait-webhook.spec.ts
+++ b/packages/testing/playwright/tests/ui/wait-webhook.spec.ts
@@ -27,6 +27,7 @@ test.describe('Wait node with resume on webhook call', () => {
 		const resumeUrlWoSignature = new URL(body.resumeUrl);
 		resumeUrlWoSignature.searchParams.delete('signature');
 
+		// Should reject the request if signature is missing
 		const unsignedWaitWebhookResponse = await api.request.get(resumeUrlWoSignature.toString());
 		expect(unsignedWaitWebhookResponse.status()).toBe(401);
 

--- a/packages/testing/playwright/tests/ui/wait-webhook.spec.ts
+++ b/packages/testing/playwright/tests/ui/wait-webhook.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '../../fixtures/base';
+
+test.describe('Wait node with resume on webhook call', () => {
+	test('should continue when the resume URL is called', async ({ api }) => {
+		const { webhookPath, workflowId } = await api.workflowApi.importWorkflow(
+			'wait-node-resume-from-webhook.json',
+		);
+
+		const startWebhookResponse = await api.request.post(`/webhook/${webhookPath}`);
+		expect(startWebhookResponse.ok()).toBe(true);
+
+		const body = (await startWebhookResponse.json()) as {
+			executionId: number;
+			resumeUrl: string;
+		};
+		expect(body).toEqual(
+			expect.objectContaining({
+				executionId: expect.any(Number),
+				resumeUrl: expect.any(String),
+			}),
+		);
+
+		const execution = await api.workflowApi.getExecution(body.executionId.toString());
+		expect(execution.status).toBe('waiting');
+
+		const waitWebhookResponse = await api.request.get(body.resumeUrl);
+		expect(waitWebhookResponse.ok()).toBe(true);
+
+		await api.workflowApi.waitForExecution(workflowId);
+	});
+});

--- a/packages/testing/playwright/workflows/wait-node-resume-from-webhook.json
+++ b/packages/testing/playwright/workflows/wait-node-resume-from-webhook.json
@@ -1,0 +1,71 @@
+{
+	"nodes": [
+		{
+			"parameters": {
+				"httpMethod": "POST",
+				"path": "test-wait-node-resume-from-webhook",
+				"responseMode": "responseNode",
+				"options": {}
+			},
+			"type": "n8n-nodes-base.webhook",
+			"typeVersion": 2.1,
+			"position": [-144, 0],
+			"id": "adb8d849-fa9f-4ed0-97c5-429c56e255b3",
+			"name": "Webhook",
+			"webhookId": "165885c7-b73e-432c-8003-58eb23591e03"
+		},
+		{
+			"parameters": {
+				"resume": "webhook",
+				"options": {}
+			},
+			"type": "n8n-nodes-base.wait",
+			"typeVersion": 1.1,
+			"position": [256, 0],
+			"id": "ac326147-f7c4-45f4-8278-3cba7da67075",
+			"name": "Wait",
+			"webhookId": "bf3a3ada-abd5-4494-8627-6e6e8fe57d39"
+		},
+		{
+			"parameters": {
+				"respondWith": "json",
+				"responseBody": "={\n  \"executionId\": {{ $execution.id }},\n  \"resumeUrl\": \"{{ $execution.resumeUrl }}\"\n}",
+				"options": {}
+			},
+			"type": "n8n-nodes-base.respondToWebhook",
+			"typeVersion": 1.4,
+			"position": [64, 0],
+			"id": "43d3259d-68e2-480e-9474-20be7aa1f9cd",
+			"name": "Respond to Webhook"
+		}
+	],
+	"connections": {
+		"Webhook": {
+			"main": [
+				[
+					{
+						"node": "Respond to Webhook",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Wait": {
+			"main": [[]]
+		},
+		"Respond to Webhook": {
+			"main": [
+				[
+					{
+						"node": "Wait",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": true,
+	"pinData": {}
+}

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2311,7 +2311,7 @@ export interface IRunExecutionDataV0 {
 	/**
 	 * This is used to prevent breaking change
 	 * for waiting executions started before signature validation was added
-	 * @deprecated Left only so we can still the presence of this. Should be removed some time later
+	 * @deprecated Left only so we can still detect the presence of this. Should be removed some time later
 	 */
 	validateSignature?: boolean;
 	waitTill?: Date;


### PR DESCRIPTION
## Summary

Generate and include a signature for the workflow's resume URL. This is to secure the URL from sniffing. Also version the `IRunExecutionData` interface, so we know if the execution was created with an n8n version that includes the signature in the URL. That way we can keep this backwards compatible.


<details>

<summary>Tested that the backward compatibility works with this workflow</summary>

1. Start an execution from `master`
2. Switch to this branch, build and call the `resumeUrl`

```json
{
  "nodes": [
    {
      "parameters": {
        "path": "165885c7-b73e-432c-8003-58eb23591e03",
        "responseMode": "responseNode",
        "options": {}
      },
      "type": "n8n-nodes-base.webhook",
      "typeVersion": 2.1,
      "position": [
        -144,
        0
      ],
      "id": "adb8d849-fa9f-4ed0-97c5-429c56e255b3",
      "name": "Webhook",
      "webhookId": "165885c7-b73e-432c-8003-58eb23591e03"
    },
    {
      "parameters": {
        "resume": "webhook",
        "options": {}
      },
      "type": "n8n-nodes-base.wait",
      "typeVersion": 1.1,
      "position": [
        256,
        0
      ],
      "id": "ac326147-f7c4-45f4-8278-3cba7da67075",
      "name": "Wait",
      "webhookId": "bf3a3ada-abd5-4494-8627-6e6e8fe57d39"
    },
    {
      "parameters": {
        "respondWith": "json",
        "responseBody": "={\n  \"executionId\": {{ $execution.id }},\n  \"resumeUrl\": \"{{ $execution.resumeUrl }}\"\n}",
        "options": {}
      },
      "type": "n8n-nodes-base.respondToWebhook",
      "typeVersion": 1.4,
      "position": [
        64,
        0
      ],
      "id": "43d3259d-68e2-480e-9474-20be7aa1f9cd",
      "name": "Respond to Webhook"
    }
  ],
  "connections": {
    "Webhook": {
      "main": [
        [
          {
            "node": "Respond to Webhook",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Wait": {
      "main": [
        []
      ]
    },
    "Respond to Webhook": {
      "main": [
        [
          {
            "node": "Wait",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {},
  "meta": {
    "instanceId": "897d757b32bd9bc5194c9f59ea56adec6d0dd785643699c07c14789f75f9f22e"
  }
}
```

</details>

Also tested couple cases that the HITL loop nodes still work. 

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1292


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
