### PR TITLE
ci: Support adding custom JS and Python dependencies in the runners image

### DIFF
--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -11,13 +11,13 @@ WORKDIR /app/task-runner-javascript
 
 RUN node -v && npm -v && corepack --version && corepack enable pnpm && pnpm -v
 
-# Install extra runtime-only npm libraries. Allow usage in the Code node via
+# Install extra runtime-only npm packages. Allow usage in the Code node via
 # 'NODE_FUNCTION_ALLOW_EXTERNAL' env variable on n8n-task-runners.json.
 RUN rm -f node_modules/.modules.yaml
 RUN mv package.json package.json.bak
 COPY docker/images/runners/package.json /app/task-runner-javascript/package.json
 RUN pnpm install --no-lockfile --silent
-RUN mv package.json extra.json
+RUN mv package.json extras.json
 RUN mv package.json.bak package.json
 
 # ==============================================================================
@@ -61,6 +61,8 @@ RUN uv sync \
       --frozen \
       --no-editable
 
+# Install extra runtime-only Python packages. Allow usage in the Code node via
+# 'N8N_RUNNERS_EXTERNAL_ALLOW' env variable on n8n-task-runners.json.
 COPY docker/images/runners/extras.txt /app/task-runner-python/extras.txt
 RUN uv pip install -r /app/task-runner-python/extras.txt
 

--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -86,24 +86,36 @@ ENV NODE_ENV=production
 ENV N8N_RELEASE_TYPE=${N8N_RELEASE_TYPE}
 ENV SHELL=/bin/sh
 
-# Copy over node from node alpine
-COPY --from=node-alpine /usr/local/bin/node /usr/local/bin/node
-COPY --from=node-alpine /usr/local/bin/npm /usr/local/bin/npm
-COPY --from=node-alpine /usr/local/bin/npx /usr/local/bin/npx
-COPY --from=node-alpine /usr/local/lib/node_modules /usr/local/lib/node_modules
+# Copy over node, npm, npx and corepack enablers from node alpine
+COPY --from=node-alpine /usr/local/ /usr/local/
 
 # Node needs libstdc++
 RUN apk add --no-cache ca-certificates tini libstdc++
 
+RUN node -v && npm -v && corepack --version && corepack enable pnpm && pnpm -v
+
 RUN addgroup -g 1000 -S runner \
  && adduser -u 1000 -S -G runner -h /home/runner -D runner
-WORKDIR /home/runner
 
 COPY --from=app-artifact-processor /app/task-runner-javascript /opt/runners/task-runner-javascript
 COPY --from=python-runner-builder /app/task-runner-python /opt/runners/task-runner-python
 COPY --from=launcher-downloader /launcher-bin/* /usr/local/bin/
 
 COPY docker/images/runners/n8n-task-runners.json /etc/n8n-task-runners.json
+
+WORKDIR /opt/runners/task-runner-javascript
+
+# Install additional npm libraries
+RUN rm -f node_modules/.modules.yaml && rm -rf node_modules/.pnpm
+RUN mv package.json package.json.bak \
+ && printf '{ "name":"runtime-addons", "private": true }' > package.json
+
+RUN pnpm add moment@2.30.1 --no-lockfile
+
+RUN mv package.json runtime-addons.json
+RUN mv package.json.bak package.json
+
+WORKDIR /home/runner
 
 RUN chown -R runner:runner /opt/runners /home/runner
 USER runner

--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -16,7 +16,7 @@ RUN node -v && npm -v && corepack --version && corepack enable pnpm && pnpm -v
 RUN rm -f node_modules/.modules.yaml
 RUN mv package.json package.json.bak
 COPY docker/images/runners/package.json /app/task-runner-javascript/package.json
-RUN pnpm install --no-lockfile
+RUN pnpm install --no-lockfile --silent
 RUN mv package.json extra.json
 RUN mv package.json.bak package.json
 

--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -61,6 +61,9 @@ RUN uv sync \
       --frozen \
       --no-editable
 
+COPY docker/images/runners/extras.txt /app/task-runner-python/extras.txt
+RUN uv pip install -r /app/task-runner-python/extras.txt
+
 # ==============================================================================
 # STAGE 3: Task Runner Launcher download
 # ==============================================================================

--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -4,8 +4,21 @@ ARG PYTHON_VERSION=3.13
 # ==============================================================================
 # STAGE 1: JavaScript runner (@n8n/task-runner) artifact from CI
 # ==============================================================================
-FROM alpine:3.22.1 AS app-artifact-processor
+FROM node:${NODE_VERSION}-alpine AS javascript-runner-builder
 COPY ./dist/task-runner-javascript /app/task-runner-javascript
+
+WORKDIR /app/task-runner-javascript
+
+RUN node -v && npm -v && corepack --version && corepack enable pnpm && pnpm -v
+
+# Install extra runtime-only npm libraries. Allow usage in the Code node via
+# 'NODE_FUNCTION_ALLOW_EXTERNAL' env variable on n8n-task-runners.json.
+RUN rm -f node_modules/.modules.yaml
+RUN mv package.json package.json.bak
+COPY docker/images/runners/package.json /app/task-runner-javascript/package.json
+RUN pnpm install --no-lockfile
+RUN mv package.json extra.json
+RUN mv package.json.bak package.json
 
 # ==============================================================================
 # STAGE 2: Python runner build (@n8n/task-runner-python) with uv
@@ -87,33 +100,22 @@ ENV N8N_RELEASE_TYPE=${N8N_RELEASE_TYPE}
 ENV SHELL=/bin/sh
 
 # Copy over node, npm, npx and corepack enablers from node alpine
-COPY --from=node-alpine /usr/local/ /usr/local/
+COPY --from=node-alpine /usr/local/bin/node /usr/local/bin/node
+COPY --from=node-alpine /usr/local/bin/npm /usr/local/bin/npm
+COPY --from=node-alpine /usr/local/bin/npx /usr/local/bin/npx
+COPY --from=node-alpine /usr/local/lib/node_modules /usr/local/lib/node_modules
 
 # Node needs libstdc++
 RUN apk add --no-cache ca-certificates tini libstdc++
 
-RUN node -v && npm -v && corepack --version && corepack enable pnpm && pnpm -v
-
 RUN addgroup -g 1000 -S runner \
  && adduser -u 1000 -S -G runner -h /home/runner -D runner
 
-COPY --from=app-artifact-processor /app/task-runner-javascript /opt/runners/task-runner-javascript
+COPY --from=javascript-runner-builder /app/task-runner-javascript /opt/runners/task-runner-javascript
 COPY --from=python-runner-builder /app/task-runner-python /opt/runners/task-runner-python
 COPY --from=launcher-downloader /launcher-bin/* /usr/local/bin/
 
 COPY docker/images/runners/n8n-task-runners.json /etc/n8n-task-runners.json
-
-WORKDIR /opt/runners/task-runner-javascript
-
-# Install additional npm libraries
-RUN rm -f node_modules/.modules.yaml && rm -rf node_modules/.pnpm
-RUN mv package.json package.json.bak \
- && printf '{ "name":"runtime-addons", "private": true }' > package.json
-
-RUN pnpm add moment@2.30.1 --no-lockfile
-
-RUN mv package.json runtime-addons.json
-RUN mv package.json.bak package.json
 
 WORKDIR /home/runner
 

--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -9,7 +9,7 @@ COPY ./dist/task-runner-javascript /app/task-runner-javascript
 
 WORKDIR /app/task-runner-javascript
 
-RUN node -v && npm -v && corepack --version && corepack enable pnpm && pnpm -v
+RUN corepack enable pnpm
 
 # Install extra runtime-only npm packages. Allow usage in the Code node via
 # 'NODE_FUNCTION_ALLOW_EXTERNAL' env variable on n8n-task-runners.json.
@@ -104,7 +104,7 @@ ENV NODE_ENV=production
 ENV N8N_RELEASE_TYPE=${N8N_RELEASE_TYPE}
 ENV SHELL=/bin/sh
 
-# Copy over node, npm, npx and corepack enablers from node alpine
+# Copy over node from node alpine
 COPY --from=node-alpine /usr/local/bin/node /usr/local/bin/node
 COPY --from=node-alpine /usr/local/bin/npm /usr/local/bin/npm
 COPY --from=node-alpine /usr/local/bin/npx /usr/local/bin/npx
@@ -115,14 +115,13 @@ RUN apk add --no-cache ca-certificates tini libstdc++
 
 RUN addgroup -g 1000 -S runner \
  && adduser -u 1000 -S -G runner -h /home/runner -D runner
+WORKDIR /home/runner
 
 COPY --from=javascript-runner-builder /app/task-runner-javascript /opt/runners/task-runner-javascript
 COPY --from=python-runner-builder /app/task-runner-python /opt/runners/task-runner-python
 COPY --from=launcher-downloader /launcher-bin/* /usr/local/bin/
 
 COPY docker/images/runners/n8n-task-runners.json /etc/n8n-task-runners.json
-
-WORKDIR /home/runner
 
 RUN chown -R runner:runner /opt/runners /home/runner
 USER runner

--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -16,7 +16,7 @@ RUN corepack enable pnpm
 RUN rm -f node_modules/.modules.yaml
 RUN mv package.json package.json.bak
 COPY docker/images/runners/package.json /app/task-runner-javascript/package.json
-RUN pnpm install --no-lockfile --silent
+RUN pnpm install --prod --no-lockfile --silent
 RUN mv package.json extras.json
 RUN mv package.json.bak package.json
 

--- a/docker/images/runners/README.md
+++ b/docker/images/runners/README.md
@@ -70,7 +70,7 @@ Edit the runtime extras manifest `docker/images/runners/package.json`:
   "description": "Runtime-only deps for the JS task-runner image, installed at image build.",
   "private": true,
   "dependencies": {
-    "moment": "^2.30.1"
+    "moment": "2.30.1"
   }
 }
 ```
@@ -79,8 +79,8 @@ Add any packages you want under `"dependencies"` (pin them for reproducibility),
 
 ```json
 "dependencies": {
-  "moment": "^2.30.1",
-  "uuid": "^9.0.0"
+  "moment": "2.30.1",
+  "uuid": "9.0.0"
 }
 ```
 

--- a/docker/images/runners/README.md
+++ b/docker/images/runners/README.md
@@ -12,22 +12,22 @@ in the [Code Node](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes
 
 ## Testing locally
 
-1. Make a production build of n8n
+### 1) Make a production build of n8n
 
 ```
 pnpm run build:n8n
 ```
 
-2. Build the task runners image
+### 2) Build the task runners image
 
 ```
-docker buildx build --no-cache \
+docker buildx build \
   -f docker/images/runners/Dockerfile \
   -t n8nio/runners \
   .
 ```
 
-3. Start n8n on your host machine with Task Broker enabled
+### 3) Start n8n on your host machine with Task Broker enabled
 
 ```
 N8N_RUNNERS_ENABLED=true \
@@ -38,7 +38,7 @@ pnpm start
 ```
 
 
-4. Start the task runner container
+### 4) Start the task runner container
 
 ```
 docker run --rm -it \
@@ -47,4 +47,107 @@ docker run --rm -it \
 -e N8N_RUNNERS_TASK_BROKER_URI=http://host.docker.internal:5679 \
 -p 5680:5680 \
 n8nio/runners
+```
+
+## Adding extra dependencies (custom image)
+
+To make additional packages available on the Code node you can bake extra packages into your custom runners image at build time.
+
+* **JavaScript** — edit `docker/images/runners/package.json`
+  (package.json manifest used to install runtime-only deps into the JS runner)
+* **Python (Native)** — edit `docker/images/runners/extras.txt`
+  (requirements.txt-style list installed into the Python runner venv)
+
+> Important: for security, any external libraries must be explicitly allowed for Code node use. Update `n8n-task-runners.json` to allowlist what you add.
+
+### 1) JavaScript packages
+
+Edit the runtime extras manifest `docker/images/runners/package.json`:
+
+```json
+{
+  "name": "task-runner-runtime-extras",
+  "description": "Runtime-only deps for the JS task-runner image, installed at image build.",
+  "private": true,
+  "dependencies": {
+    "moment": "^2.30.1"
+  }
+}
+```
+
+Add any packages you want under `"dependencies"` (pin them for reproducibility), e.g.:
+
+```json
+"dependencies": {
+  "moment": "^2.30.1",
+  "uuid": "^9.0.0"
+}
+```
+
+### 2) Python packages
+
+Edit the requirements file `docker/images/runners/extras.txt`:
+
+```
+# Runtime-only extras for the Python task runner (installed at image build)
+numpy==2.3.2
+# add more, one per line, e.g.:
+# pandas==2.2.2
+```
+
+> Tip: pin versions (e.g., `==2.3.2`) for deterministic builds.
+
+### 3) Allowlist packages for the Code node
+
+Open `docker/images/runners/n8n-task-runners.json` and add your packages to the env overrides:
+
+```json
+{
+  "task-runners": [
+    {
+      "runner-type": "javascript",
+      "env-overrides": {
+        "NODE_FUNCTION_ALLOW_BUILTIN": "crypto",
+        "NODE_FUNCTION_ALLOW_EXTERNAL": "moment,uuid",   // <-- add JS packages here
+      }
+    },
+    {
+      "runner-type": "python",
+      "env-overrides": {
+        "PYTHONPATH": "/opt/runners/task-runner-python",
+        "N8N_RUNNERS_STDLIB_ALLOW": "json",
+        "N8N_RUNNERS_EXTERNAL_ALLOW": "numpy,pandas"     // <-- add Python packages here
+      }
+    }
+  ]
+}
+```
+
+* `NODE_FUNCTION_ALLOW_BUILTIN` — comma-separated list of allowed node builtin modules.
+* `NODE_FUNCTION_ALLOW_EXTERNAL` — comma-separated list of allowed JS packages.
+* `N8N_RUNNERS_STDLIB_ALLOW` — comma-separated list of allowed Python standard library packages.
+* `N8N_RUNNERS_EXTERNAL_ALLOW` — comma-separated list of allowed Python packages.
+
+### 4) Build your custom image
+
+From the repo root:
+
+```bash
+docker buildx build \
+  -f docker/images/runners/Dockerfile \
+  -t n8nio/runners:custom \
+  .
+```
+
+### 5) Run it
+
+Same as before, but use your custom image's tag:
+
+```bash
+docker run --rm -it \
+  -e N8N_RUNNERS_AUTH_TOKEN=test \
+  -e N8N_RUNNERS_LAUNCHER_LOG_LEVEL=debug \
+  -e N8N_RUNNERS_TASK_BROKER_URI=http://host.docker.internal:5679 \
+  -p 5680:5680 \
+  n8nio/runners:custom
 ```

--- a/docker/images/runners/extras.txt
+++ b/docker/images/runners/extras.txt
@@ -1,4 +1,4 @@
-# Runtime-only extra Requirements File for installing depenedncies in the Python task runner image.
+# Runtime-only extra Requirements File for installing dependencies in the Python task runner image.
 # Installed at Docker image build time. Allow usage in the Code node
 # via 'N8N_RUNNERS_EXTERNAL_ALLOW' env variable on n8n-task-runners.json.
 

--- a/docker/images/runners/extras.txt
+++ b/docker/images/runners/extras.txt
@@ -1,0 +1,4 @@
+# Runtime-only extra dependencies for the Python task runner image.
+# Installed at Docker image build time. Allow usage in the Code node
+# via 'N8N_RUNNERS_EXTERNAL_ALLOW' env variable on n8n-task-runners.json.
+numpy==2.3.2

--- a/docker/images/runners/extras.txt
+++ b/docker/images/runners/extras.txt
@@ -1,4 +1,5 @@
-# Runtime-only extra dependencies for the Python task runner image.
+# Runtime-only extra Requirements File for installing depenedncies in the Python task runner image.
 # Installed at Docker image build time. Allow usage in the Code node
 # via 'N8N_RUNNERS_EXTERNAL_ALLOW' env variable on n8n-task-runners.json.
-numpy==2.3.2
+
+# numpy==2.3.2

--- a/docker/images/runners/n8n-task-runners.json
+++ b/docker/images/runners/n8n-task-runners.json
@@ -47,8 +47,8 @@
 			],
 			"env-overrides": {
 				"PYTHONPATH": "/opt/runners/task-runner-python",
-				"N8N_RUNNERS_STDLIB_ALLOW": "",
-				"N8N_RUNNERS_EXTERNAL_ALLOW": ""
+				"N8N_RUNNERS_STDLIB_ALLOW": "json",
+				"N8N_RUNNERS_EXTERNAL_ALLOW": "numpy"
 			}
 		}
 	]

--- a/docker/images/runners/n8n-task-runners.json
+++ b/docker/images/runners/n8n-task-runners.json
@@ -47,8 +47,8 @@
 			],
 			"env-overrides": {
 				"PYTHONPATH": "/opt/runners/task-runner-python",
-				"N8N_RUNNERS_STDLIB_ALLOW": "json",
-				"N8N_RUNNERS_EXTERNAL_ALLOW": "numpy"
+				"N8N_RUNNERS_STDLIB_ALLOW": "",
+				"N8N_RUNNERS_EXTERNAL_ALLOW": ""
 			}
 		}
 	]

--- a/docker/images/runners/package.json
+++ b/docker/images/runners/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "task-runner-runtime-extras",
+  "description": "Runtime-only extra dependencies for the JavaScript task runner image. Installed at Docker image build time. Allow usage in the Code node via 'NODE_FUNCTION_ALLOW_EXTERNAL' env variable on n8n-task-runners.json.",
+  "private": true,
+  "dependencies": {
+    "moment": "^2.30.1"
+  }
+}

--- a/docker/images/runners/package.json
+++ b/docker/images/runners/package.json
@@ -3,6 +3,6 @@
   "description": "Runtime-only extra dependencies for installing packages in the JavaScript task runner image. Installed at Docker image build time. Allow usage in the Code node via 'NODE_FUNCTION_ALLOW_EXTERNAL' env variable on n8n-task-runners.json.",
   "private": true,
   "dependencies": {
-    "moment": "^2.30.1"
+    "moment": "2.30.1"
   }
 }

--- a/docker/images/runners/package.json
+++ b/docker/images/runners/package.json
@@ -1,6 +1,6 @@
 {
   "name": "task-runner-runtime-extras",
-  "description": "Runtime-only extra dependencies for the JavaScript task runner image. Installed at Docker image build time. Allow usage in the Code node via 'NODE_FUNCTION_ALLOW_EXTERNAL' env variable on n8n-task-runners.json.",
+  "description": "Runtime-only extra dependencies for installing packages in the JavaScript task runner image. Installed at Docker image build time. Allow usage in the Code node via 'NODE_FUNCTION_ALLOW_EXTERNAL' env variable on n8n-task-runners.json.",
   "private": true,
   "dependencies": {
     "moment": "^2.30.1"

--- a/packages/@n8n/task-runner/package.json
+++ b/packages/@n8n/task-runner/package.json
@@ -42,7 +42,6 @@
     "acorn-walk": "8.3.4",
     "lodash": "catalog:",
     "luxon": "catalog:",
-    "moment": "2.30.1",
     "n8n-core": "workspace:*",
     "n8n-workflow": "workspace:*",
     "nanoid": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1372,9 +1372,6 @@ importers:
       luxon:
         specifier: 'catalog:'
         version: 3.4.4
-      moment:
-        specifier: 2.30.1
-        version: 2.30.1
       n8n-core:
         specifier: workspace:*
         version: link:../../core


### PR DESCRIPTION
## Summary

To make adding custom dependencies into the task runners image easier introduce a mechanism to easily make custom docker images with extra packages installed. Extra packages can be added into a package.json / requirements.txt file and dependencies from them are installed at docker image build time.

To make these packages available on the Code node they also need to be allowlisted on the `NODE_FUNCTION_ALLOW_EXTERNAL` / `N8N_RUNNERS_EXTERNAL_ALLOW` env variables.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1296/enable-self-hosters-to-add-js-and-python-dependencies-to-the

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
