### PR TITLE
ci(core): Increase mariadb test timeout

### DIFF
--- a/.github/workflows/ci-postgres-mysql.yml
+++ b/.github/workflows/ci-postgres-mysql.yml
@@ -59,7 +59,7 @@ jobs:
     name: MariaDB
     needs: build
     runs-on: blacksmith-2vcpu-ubuntu-2204
-    timeout-minutes: 20
+    timeout-minutes: 30
     env:
       DB_MYSQLDB_PASSWORD: password
     steps:


### PR DESCRIPTION
## Summary

MariaDB is slow currently the unit tests executing against MariaDB keep timing out at 20 minutes. If they pass they pass barely. Looking at the MySQL tests, which run the same code, these finish in roughly half the time that MariaDB does, so the bottleneck seems to be the MariaDB system itself.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
