### PR TITLE
fix(editor): Render last item on markdown task lists correctly

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nMarkdown/Markdown.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMarkdown/Markdown.vue
@@ -58,7 +58,7 @@ const props = withDefaults(defineProps<MarkdownProps>(), {
 		tasklists: {
 			enabled: true,
 			label: true,
-			labelAfter: true,
+			labelAfter: false,
 		},
 		youtube: {},
 	}),


### PR DESCRIPTION
## Summary

Last item on task lists was rendering its label twice for unknown reason, probably a bug in the task list library we use.
The bug doesn't occur when `labelAfter` is set to false - this slightly changes the HTML we render but the end result looks like the same, so lets just not use that mode.

With the fix
<img width="739" height="673" alt="image" src="https://github.com/user-attachments/assets/483f0a13-6a51-4f5b-ba8d-de9baa782b42" />

Before
<img width="672" height="555" alt="image" src="https://github.com/user-attachments/assets/679a9e05-8807-4a24-9d6c-4c4f3799028a" />

As a workaround some users had found that they could put a horizontal bar `---` after the last item to hide the bug 😅 


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4035/community-issue-sticky-note-renders-duplicated-lines-when-using

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
