### PR TITLE
fix(core): Update cached project association when moving a workflow

### DIFF
--- a/packages/cli/src/services/ownership.service.ts
+++ b/packages/cli/src/services/ownership.service.ts
@@ -94,6 +94,14 @@ export class OwnershipService {
 		return sharedWorkflow.project;
 	}
 
+	async setWorkflowProjectCacheEntry(workflowId: string, project: Project): Promise<Project> {
+		void this.cacheService.setHash('workflow-project', {
+			[workflowId]: this.copyProject(project),
+		});
+
+		return project;
+	}
+
 	/**
 	 * Retrieve the user who owns the personal project, or `null` if non-personal project.
 	 * Personal project ownership is **immutable**.

--- a/packages/cli/src/workflows/workflow.service.ee.ts
+++ b/packages/cli/src/workflows/workflow.service.ee.ts
@@ -344,7 +344,10 @@ export class EnterpriseWorkflowService {
 		// @ts-ignore CAT-957
 		await this.workflowRepository.update({ id: workflow.id }, { parentFolder });
 
-		// 10. try to activate it again if it was active
+		// 10. Update potential cached project association
+		await this.ownershipService.setWorkflowProjectCacheEntry(workflow.id, destinationProject);
+
+		// 11. try to activate it again if it was active
 		if (wasActive) {
 			return await this.attemptWorkflowReactivation(workflowId);
 		}


### PR DESCRIPTION
## Summary

Update cached project association for moved workflow.

Given how specific the reproduction steps are I feel this doesn't justify an e2e test.
Happy to add a unit test if you think this adds value.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-2667/community-issue-moving-a-sub-workflow-into-the-same-project-as-the
closes #13847 


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
