### PR TITLE
fix(editor): Load available resources for dynamic options

### DIFF
--- a/packages/frontend/editor-ui/src/components/ResourceLocator/ResourceLocatorDropdown.vue
+++ b/packages/frontend/editor-ui/src/components/ResourceLocator/ResourceLocatorDropdown.vue
@@ -197,7 +197,7 @@ function onItemHoverLeave() {
 }
 
 function onResultsEnd() {
-	if (props.loading || !props.loading) {
+	if (props.loading || !props.hasMore) {
 		return;
 	}
 


### PR DESCRIPTION
## Summary

The paged loading of dynamic resources in a list dropdown didn't honor the provided page token for loading more data using this token.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/ADO-3945/bug-resourcelocator-does-not-paginate-until-filter-is-entered

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
