### PR TITLE
fix(Telegram Node): Use parameter index instead of 0 for binaryData

### DIFF
--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -2146,10 +2146,10 @@ export class Telegram implements INodeType {
 				let responseData;
 
 				if (binaryData) {
-					const binaryPropertyName = this.getNodeParameter('binaryPropertyName', 0);
+					const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i);
 					const itemBinaryData = items[i].binary![binaryPropertyName];
 					const propertyName = getPropertyName(operation);
-					const fileName = this.getNodeParameter('additionalFields.fileName', 0, '') as string;
+					const fileName = this.getNodeParameter('additionalFields.fileName', i, '') as string;
 
 					const filename = fileName || itemBinaryData.fileName?.toString();
 
@@ -2214,7 +2214,7 @@ export class Telegram implements INodeType {
 						);
 
 						const fileName = filePath.split('/').pop() as string;
-						const additionalFields = this.getNodeParameter('additionalFields', 0);
+						const additionalFields = this.getNodeParameter('additionalFields', i);
 						const providedMimeType = additionalFields?.mimeType as string | undefined;
 						const mimeType = providedMimeType ?? (lookup(fileName) || 'application/octet-stream');
 
@@ -2239,7 +2239,6 @@ export class Telegram implements INodeType {
 					returnData.push(...executionData);
 					continue;
 				}
-
 				const executionData = this.helpers.constructExecutionMetaData(
 					this.helpers.returnJsonArray(responseData as IDataObject[]),
 					{ itemData: { item: i } },

--- a/packages/nodes-base/nodes/Telegram/tests/Telegram.node.test.ts
+++ b/packages/nodes-base/nodes/Telegram/tests/Telegram.node.test.ts
@@ -4,7 +4,6 @@ import type {
 	INode,
 	INodeExecutionData,
 	NodeExecutionWithMetadata,
-	IDataObject,
 } from 'n8n-workflow';
 
 import * as GenericFunctions from '../GenericFunctions';
@@ -339,7 +338,6 @@ describe('Telegram node', () => {
 
 			expect(apiRequestSpy).toHaveBeenCalledTimes(2);
 
-			const firstCall = apiRequestSpy.mock.calls[0];
 			expect(apiRequestSpy).toHaveBeenNthCalledWith(
 				1,
 				'POST',
@@ -359,8 +357,6 @@ describe('Telegram node', () => {
 					}),
 				}),
 			);
-
-			const secondCall = apiRequestSpy.mock.calls[1];
 
 			expect(apiRequestSpy).toHaveBeenNthCalledWith(
 				2,
@@ -432,27 +428,27 @@ describe('Telegram node', () => {
 
 			await node.execute.call(executeFunctionsMock);
 
-			const firstCall = apiRequestSpy.mock.calls[0];
-			expect(firstCall[4]).toEqual({
-				formData: expect.objectContaining({
-					photo: expect.objectContaining({
-						options: expect.objectContaining({
-							filename: 'fallback-name.jpg',
+			const expectFileName = (index: number, filename: string) => {
+				expect(apiRequestSpy).toHaveBeenNthCalledWith(
+					index,
+					'POST',
+					'sendPhoto',
+					{},
+					{},
+					{
+						formData: expect.objectContaining({
+							photo: expect.objectContaining({
+								options: expect.objectContaining({
+									filename,
+								}),
+							}),
 						}),
-					}),
-				}),
-			});
+					},
+				);
+			};
 
-			const secondCall = apiRequestSpy.mock.calls[1];
-			expect(secondCall[4]).toEqual({
-				formData: expect.objectContaining({
-					photo: expect.objectContaining({
-						options: expect.objectContaining({
-							filename: 'custom-name.jpg',
-						}),
-					}),
-				}),
-			});
+			expectFileName(1, 'fallback-name.jpg');
+			expectFileName(2, 'custom-name.jpg');
 		});
 
 		it('should process different chat IDs for multiple items correctly', async () => {
@@ -499,10 +495,24 @@ describe('Telegram node', () => {
 
 			expect(apiRequestSpy).toHaveBeenCalledTimes(3);
 
-			const calls = apiRequestSpy.mock.calls;
-			expect((calls[0][4]?.formData as IDataObject)?.chat_id).toBe('chat-id-0');
-			expect((calls[1][4]?.formData as IDataObject)?.chat_id).toBe('chat-id-1');
-			expect((calls[2][4]?.formData as IDataObject)?.chat_id).toBe('chat-id-2');
+			const expectChatId = (n: number, chatId: string) => {
+				expect(apiRequestSpy).toHaveBeenNthCalledWith(
+					n,
+					'POST',
+					'sendPhoto',
+					{},
+					{},
+					{
+						formData: expect.objectContaining({
+							chat_id: chatId,
+						}),
+					},
+				);
+			};
+
+			expectChatId(1, 'chat-id-0');
+			expectChatId(2, 'chat-id-1');
+			expectChatId(3, 'chat-id-2');
 		});
 	});
 });

--- a/packages/nodes-base/nodes/Telegram/tests/Telegram.node.test.ts
+++ b/packages/nodes-base/nodes/Telegram/tests/Telegram.node.test.ts
@@ -4,6 +4,7 @@ import type {
 	INode,
 	INodeExecutionData,
 	NodeExecutionWithMetadata,
+	IDataObject,
 } from 'n8n-workflow';
 
 import * as GenericFunctions from '../GenericFunctions';
@@ -499,9 +500,9 @@ describe('Telegram node', () => {
 			expect(apiRequestSpy).toHaveBeenCalledTimes(3);
 
 			const calls = apiRequestSpy.mock.calls;
-			expect((calls[0][4]?.formData as any)?.chat_id).toBe('chat-id-0');
-			expect((calls[1][4]?.formData as any)?.chat_id).toBe('chat-id-1');
-			expect((calls[2][4]?.formData as any)?.chat_id).toBe('chat-id-2');
+			expect((calls[0][4]?.formData as IDataObject)?.chat_id).toBe('chat-id-0');
+			expect((calls[1][4]?.formData as IDataObject)?.chat_id).toBe('chat-id-1');
+			expect((calls[2][4]?.formData as IDataObject)?.chat_id).toBe('chat-id-2');
 		});
 	});
 });

--- a/packages/nodes-base/nodes/Telegram/tests/Telegram.node.test.ts
+++ b/packages/nodes-base/nodes/Telegram/tests/Telegram.node.test.ts
@@ -200,13 +200,10 @@ describe('Telegram node', () => {
 					case 'binaryData':
 						return true;
 					case 'chatId':
-						// Different chat IDs for different indices to test proper indexing
 						return index === 0 ? 'chat-id-0' : index === 1 ? 'chat-id-1' : 'chat-id-2';
 					case 'binaryPropertyName':
-						// Different binary property names for different indices
 						return index === 0 ? 'data0' : index === 1 ? 'data1' : 'data2';
 					case 'additionalFields.fileName':
-						// Different file names for different indices
 						return index === 0 ? 'photo0.jpg' : index === 1 ? 'photo1.png' : 'photo2.gif';
 					case 'additionalFields':
 						return {};
@@ -217,7 +214,6 @@ describe('Telegram node', () => {
 		});
 
 		it('should use correct index for binaryPropertyName parameter', async () => {
-			// Setup multiple input items
 			executeFunctionsMock.getInputData.mockReturnValue([
 				{
 					json: {},
@@ -245,7 +241,6 @@ describe('Telegram node', () => {
 
 			await node.execute.call(executeFunctionsMock);
 
-			// Verify that binaryPropertyName was called with correct indices
 			expect(executeFunctionsMock.getNodeParameter).toHaveBeenCalledWith('binaryPropertyName', 0);
 			expect(executeFunctionsMock.getNodeParameter).toHaveBeenCalledWith('binaryPropertyName', 1);
 			expect(executeFunctionsMock.getNodeParameter).not.toHaveBeenCalledWith(
@@ -261,7 +256,6 @@ describe('Telegram node', () => {
 		});
 
 		it('should use correct index for additionalFields.fileName parameter', async () => {
-			// Setup multiple input items
 			executeFunctionsMock.getInputData.mockReturnValue([
 				{
 					json: {},
@@ -287,7 +281,6 @@ describe('Telegram node', () => {
 
 			await node.execute.call(executeFunctionsMock);
 
-			// Verify that additionalFields.fileName was called with correct indices
 			expect(executeFunctionsMock.getNodeParameter).toHaveBeenCalledWith(
 				'additionalFields.fileName',
 				0,
@@ -301,7 +294,6 @@ describe('Telegram node', () => {
 		});
 
 		it('should use correct binary data for each item based on binaryPropertyName index', async () => {
-			// Setup multiple input items with different binary property names
 			executeFunctionsMock.getInputData.mockReturnValue([
 				{
 					json: {},
@@ -337,10 +329,8 @@ describe('Telegram node', () => {
 
 			await node.execute.call(executeFunctionsMock);
 
-			// Verify API was called twice with correct data
 			expect(apiRequestSpy).toHaveBeenCalledTimes(2);
 
-			// Check first call
 			const firstCall = apiRequestSpy.mock.calls[0];
 			expect(firstCall[0]).toBe('POST');
 			expect(firstCall[1]).toBe('sendPhoto');
@@ -357,7 +347,6 @@ describe('Telegram node', () => {
 				}),
 			});
 
-			// Check second call
 			const secondCall = apiRequestSpy.mock.calls[1];
 			expect(secondCall[0]).toBe('POST');
 			expect(secondCall[1]).toBe('sendPhoto');
@@ -389,7 +378,6 @@ describe('Telegram node', () => {
 					case 'binaryPropertyName':
 						return index === 0 ? 'data0' : 'data1';
 					case 'additionalFields.fileName':
-						// Empty fileName for first item, provided for second
 						return index === 0 ? '' : 'custom-name.jpg';
 					case 'additionalFields':
 						return {};
@@ -425,7 +413,6 @@ describe('Telegram node', () => {
 
 			await node.execute.call(executeFunctionsMock);
 
-			// Check first call uses fallback fileName from binary data
 			const firstCall = apiRequestSpy.mock.calls[0];
 			expect(firstCall[4]).toEqual({
 				formData: expect.objectContaining({
@@ -437,7 +424,6 @@ describe('Telegram node', () => {
 				}),
 			});
 
-			// Check second call uses custom fileName from additionalFields
 			const secondCall = apiRequestSpy.mock.calls[1];
 			expect(secondCall[4]).toEqual({
 				formData: expect.objectContaining({
@@ -488,12 +474,10 @@ describe('Telegram node', () => {
 
 			await node.execute.call(executeFunctionsMock);
 
-			// Verify chatId parameter was called with correct indices
 			expect(executeFunctionsMock.getNodeParameter).toHaveBeenCalledWith('chatId', 0);
 			expect(executeFunctionsMock.getNodeParameter).toHaveBeenCalledWith('chatId', 1);
 			expect(executeFunctionsMock.getNodeParameter).toHaveBeenCalledWith('chatId', 2);
 
-			// Verify correct chat IDs were used in API calls
 			expect(apiRequestSpy).toHaveBeenCalledTimes(3);
 
 			const calls = apiRequestSpy.mock.calls;

--- a/packages/nodes-base/nodes/Telegram/tests/Telegram.node.test.ts
+++ b/packages/nodes-base/nodes/Telegram/tests/Telegram.node.test.ts
@@ -1,5 +1,10 @@
 import { mockDeep } from 'jest-mock-extended';
-import type { IExecuteFunctions, INode } from 'n8n-workflow';
+import type {
+	IExecuteFunctions,
+	INode,
+	INodeExecutionData,
+	NodeExecutionWithMetadata,
+} from 'n8n-workflow';
 
 import * as GenericFunctions from '../GenericFunctions';
 import { Telegram } from '../Telegram.node';
@@ -19,9 +24,11 @@ describe('Telegram node', () => {
 			typeVersion: 1.2,
 		} as INode);
 		executeFunctionsMock.getInputData.mockReturnValue([{ json: {} }]);
-		executeFunctionsMock.helpers.returnJsonArray.mockImplementation((input) => input as any[]);
+		executeFunctionsMock.helpers.returnJsonArray.mockImplementation(
+			(input) => input as INodeExecutionData[],
+		);
 		executeFunctionsMock.helpers.constructExecutionMetaData.mockImplementation(
-			(input) => input as any[],
+			(input) => input as NodeExecutionWithMetadata[],
 		);
 	});
 
@@ -332,36 +339,47 @@ describe('Telegram node', () => {
 			expect(apiRequestSpy).toHaveBeenCalledTimes(2);
 
 			const firstCall = apiRequestSpy.mock.calls[0];
-			expect(firstCall[0]).toBe('POST');
-			expect(firstCall[1]).toBe('sendPhoto');
-			expect(firstCall[4]).toEqual({
-				formData: expect.objectContaining({
-					chat_id: 'chat-id-0',
-					photo: expect.objectContaining({
-						value: expect.any(Buffer),
-						options: expect.objectContaining({
-							filename: 'photo0.jpg',
-							contentType: 'image/jpeg',
+			expect(apiRequestSpy).toHaveBeenNthCalledWith(
+				1,
+				'POST',
+				'sendPhoto',
+				{},
+				{},
+				expect.objectContaining({
+					formData: expect.objectContaining({
+						chat_id: 'chat-id-0',
+						photo: expect.objectContaining({
+							value: expect.any(Buffer),
+							options: expect.objectContaining({
+								filename: 'photo0.jpg',
+								contentType: 'image/jpeg',
+							}),
 						}),
 					}),
 				}),
-			});
+			);
 
 			const secondCall = apiRequestSpy.mock.calls[1];
-			expect(secondCall[0]).toBe('POST');
-			expect(secondCall[1]).toBe('sendPhoto');
-			expect(secondCall[4]).toEqual({
-				formData: expect.objectContaining({
-					chat_id: 'chat-id-1',
-					photo: expect.objectContaining({
-						value: expect.any(Buffer),
-						options: expect.objectContaining({
-							filename: 'photo1.png',
-							contentType: 'image/png',
+
+			expect(apiRequestSpy).toHaveBeenNthCalledWith(
+				2,
+				'POST',
+				'sendPhoto',
+				{},
+				{},
+				expect.objectContaining({
+					formData: expect.objectContaining({
+						chat_id: 'chat-id-1',
+						photo: expect.objectContaining({
+							value: expect.any(Buffer),
+							options: expect.objectContaining({
+								filename: 'photo1.png',
+								contentType: 'image/png',
+							}),
 						}),
 					}),
 				}),
-			});
+			);
 		});
 
 		it('should fallback to binary fileName when additionalFields.fileName is empty', async () => {

--- a/packages/nodes-base/nodes/Telegram/tests/Telegram.node.test.ts
+++ b/packages/nodes-base/nodes/Telegram/tests/Telegram.node.test.ts
@@ -19,6 +19,10 @@ describe('Telegram node', () => {
 			typeVersion: 1.2,
 		} as INode);
 		executeFunctionsMock.getInputData.mockReturnValue([{ json: {} }]);
+		executeFunctionsMock.helpers.returnJsonArray.mockImplementation((input) => input as any[]);
+		executeFunctionsMock.helpers.constructExecutionMetaData.mockImplementation(
+			(input) => input as any[],
+		);
 	});
 
 	describe('file:get', () => {
@@ -182,6 +186,320 @@ describe('Telegram node', () => {
 				'file_1.pdf',
 				'image/jpeg',
 			);
+		});
+	});
+
+	describe('message:sendPhoto with binary data', () => {
+		beforeEach(() => {
+			executeFunctionsMock.getNodeParameter.mockImplementation((paramName, index) => {
+				switch (paramName) {
+					case 'resource':
+						return 'message';
+					case 'operation':
+						return 'sendPhoto';
+					case 'binaryData':
+						return true;
+					case 'chatId':
+						// Different chat IDs for different indices to test proper indexing
+						return index === 0 ? 'chat-id-0' : index === 1 ? 'chat-id-1' : 'chat-id-2';
+					case 'binaryPropertyName':
+						// Different binary property names for different indices
+						return index === 0 ? 'data0' : index === 1 ? 'data1' : 'data2';
+					case 'additionalFields.fileName':
+						// Different file names for different indices
+						return index === 0 ? 'photo0.jpg' : index === 1 ? 'photo1.png' : 'photo2.gif';
+					case 'additionalFields':
+						return {};
+					default:
+						return undefined;
+				}
+			});
+		});
+
+		it('should use correct index for binaryPropertyName parameter', async () => {
+			// Setup multiple input items
+			executeFunctionsMock.getInputData.mockReturnValue([
+				{
+					json: {},
+					binary: {
+						data0: {
+							data: 'binary-data-0',
+							mimeType: 'image/jpeg',
+							fileName: 'original0.jpg',
+						},
+					},
+				},
+				{
+					json: {},
+					binary: {
+						data1: {
+							data: 'binary-data-1',
+							mimeType: 'image/png',
+							fileName: 'original1.png',
+						},
+					},
+				},
+			]);
+
+			apiRequestSpy.mockResolvedValue([{ result: { message_id: 123 } }]);
+
+			await node.execute.call(executeFunctionsMock);
+
+			// Verify that binaryPropertyName was called with correct indices
+			expect(executeFunctionsMock.getNodeParameter).toHaveBeenCalledWith('binaryPropertyName', 0);
+			expect(executeFunctionsMock.getNodeParameter).toHaveBeenCalledWith('binaryPropertyName', 1);
+			expect(executeFunctionsMock.getNodeParameter).not.toHaveBeenCalledWith(
+				'binaryPropertyName',
+				0,
+				expect.anything(),
+			);
+			expect(executeFunctionsMock.getNodeParameter).not.toHaveBeenCalledWith(
+				'binaryPropertyName',
+				1,
+				expect.anything(),
+			);
+		});
+
+		it('should use correct index for additionalFields.fileName parameter', async () => {
+			// Setup multiple input items
+			executeFunctionsMock.getInputData.mockReturnValue([
+				{
+					json: {},
+					binary: {
+						data0: {
+							data: 'binary-data-0',
+							mimeType: 'image/jpeg',
+						},
+					},
+				},
+				{
+					json: {},
+					binary: {
+						data1: {
+							data: 'binary-data-1',
+							mimeType: 'image/png',
+						},
+					},
+				},
+			]);
+
+			apiRequestSpy.mockResolvedValue([{ result: { message_id: 123 } }]);
+
+			await node.execute.call(executeFunctionsMock);
+
+			// Verify that additionalFields.fileName was called with correct indices
+			expect(executeFunctionsMock.getNodeParameter).toHaveBeenCalledWith(
+				'additionalFields.fileName',
+				0,
+				'',
+			);
+			expect(executeFunctionsMock.getNodeParameter).toHaveBeenCalledWith(
+				'additionalFields.fileName',
+				1,
+				'',
+			);
+		});
+
+		it('should use correct binary data for each item based on binaryPropertyName index', async () => {
+			// Setup multiple input items with different binary property names
+			executeFunctionsMock.getInputData.mockReturnValue([
+				{
+					json: {},
+					binary: {
+						data0: {
+							data: 'binary-data-0',
+							mimeType: 'image/jpeg',
+							fileName: 'original0.jpg',
+						},
+						wrongData: {
+							data: 'wrong-binary-data',
+							mimeType: 'image/gif',
+						},
+					},
+				},
+				{
+					json: {},
+					binary: {
+						data1: {
+							data: 'binary-data-1',
+							mimeType: 'image/png',
+							fileName: 'original1.png',
+						},
+						wrongData: {
+							data: 'wrong-binary-data',
+							mimeType: 'image/gif',
+						},
+					},
+				},
+			]);
+
+			apiRequestSpy.mockResolvedValue([{ result: { message_id: 123 } }]);
+
+			await node.execute.call(executeFunctionsMock);
+
+			// Verify API was called twice with correct data
+			expect(apiRequestSpy).toHaveBeenCalledTimes(2);
+
+			// Check first call
+			const firstCall = apiRequestSpy.mock.calls[0];
+			expect(firstCall[0]).toBe('POST');
+			expect(firstCall[1]).toBe('sendPhoto');
+			expect(firstCall[4]).toEqual({
+				formData: expect.objectContaining({
+					chat_id: 'chat-id-0',
+					photo: expect.objectContaining({
+						value: expect.any(Buffer),
+						options: expect.objectContaining({
+							filename: 'photo0.jpg',
+							contentType: 'image/jpeg',
+						}),
+					}),
+				}),
+			});
+
+			// Check second call
+			const secondCall = apiRequestSpy.mock.calls[1];
+			expect(secondCall[0]).toBe('POST');
+			expect(secondCall[1]).toBe('sendPhoto');
+			expect(secondCall[4]).toEqual({
+				formData: expect.objectContaining({
+					chat_id: 'chat-id-1',
+					photo: expect.objectContaining({
+						value: expect.any(Buffer),
+						options: expect.objectContaining({
+							filename: 'photo1.png',
+							contentType: 'image/png',
+						}),
+					}),
+				}),
+			});
+		});
+
+		it('should fallback to binary fileName when additionalFields.fileName is empty', async () => {
+			executeFunctionsMock.getNodeParameter.mockImplementation((paramName, index) => {
+				switch (paramName) {
+					case 'resource':
+						return 'message';
+					case 'operation':
+						return 'sendPhoto';
+					case 'binaryData':
+						return true;
+					case 'chatId':
+						return index === 0 ? 'chat-id-0' : 'chat-id-1';
+					case 'binaryPropertyName':
+						return index === 0 ? 'data0' : 'data1';
+					case 'additionalFields.fileName':
+						// Empty fileName for first item, provided for second
+						return index === 0 ? '' : 'custom-name.jpg';
+					case 'additionalFields':
+						return {};
+					default:
+						return undefined;
+				}
+			});
+
+			executeFunctionsMock.getInputData.mockReturnValue([
+				{
+					json: {},
+					binary: {
+						data0: {
+							data: 'binary-data-0',
+							mimeType: 'image/jpeg',
+							fileName: 'fallback-name.jpg',
+						},
+					},
+				},
+				{
+					json: {},
+					binary: {
+						data1: {
+							data: 'binary-data-1',
+							mimeType: 'image/png',
+							fileName: 'original-name.png',
+						},
+					},
+				},
+			]);
+
+			apiRequestSpy.mockResolvedValue([{ result: { message_id: 123 } }]);
+
+			await node.execute.call(executeFunctionsMock);
+
+			// Check first call uses fallback fileName from binary data
+			const firstCall = apiRequestSpy.mock.calls[0];
+			expect(firstCall[4]).toEqual({
+				formData: expect.objectContaining({
+					photo: expect.objectContaining({
+						options: expect.objectContaining({
+							filename: 'fallback-name.jpg',
+						}),
+					}),
+				}),
+			});
+
+			// Check second call uses custom fileName from additionalFields
+			const secondCall = apiRequestSpy.mock.calls[1];
+			expect(secondCall[4]).toEqual({
+				formData: expect.objectContaining({
+					photo: expect.objectContaining({
+						options: expect.objectContaining({
+							filename: 'custom-name.jpg',
+						}),
+					}),
+				}),
+			});
+		});
+
+		it('should process different chat IDs for multiple items correctly', async () => {
+			executeFunctionsMock.getInputData.mockReturnValue([
+				{
+					json: {},
+					binary: {
+						data0: {
+							data: 'binary-data-0',
+							mimeType: 'image/jpeg',
+							fileName: 'photo0.jpg',
+						},
+					},
+				},
+				{
+					json: {},
+					binary: {
+						data1: {
+							data: 'binary-data-1',
+							mimeType: 'image/png',
+							fileName: 'photo1.png',
+						},
+					},
+				},
+				{
+					json: {},
+					binary: {
+						data2: {
+							data: 'binary-data-2',
+							mimeType: 'image/gif',
+							fileName: 'photo2.gif',
+						},
+					},
+				},
+			]);
+
+			apiRequestSpy.mockResolvedValue([{ result: { message_id: 123 } }]);
+
+			await node.execute.call(executeFunctionsMock);
+
+			// Verify chatId parameter was called with correct indices
+			expect(executeFunctionsMock.getNodeParameter).toHaveBeenCalledWith('chatId', 0);
+			expect(executeFunctionsMock.getNodeParameter).toHaveBeenCalledWith('chatId', 1);
+			expect(executeFunctionsMock.getNodeParameter).toHaveBeenCalledWith('chatId', 2);
+
+			// Verify correct chat IDs were used in API calls
+			expect(apiRequestSpy).toHaveBeenCalledTimes(3);
+
+			const calls = apiRequestSpy.mock.calls;
+			expect((calls[0][4]?.formData as any)?.chat_id).toBe('chat-id-0');
+			expect((calls[1][4]?.formData as any)?.chat_id).toBe('chat-id-1');
+			expect((calls[2][4]?.formData as any)?.chat_id).toBe('chat-id-2');
 		});
 	});
 });


### PR DESCRIPTION
## Summary

This PR fixes typos in Telegram node, which made the node look for parameters in the wrong place

<details>

You need to set your credentials and chatId manually

To get chatId, write a message to your bot and make a request to `https://api.telegram.org/botYOUR_TOKEN/getUpdates`

<summary>Reproducible workflow</summary>

```
{
  "nodes": [
    {
      "parameters": {
        "operation": "sendPhoto",
        "chatId": "",
        "binaryData": true,
        "binaryPropertyName": "=data_{{ $itemIndex }}",
        "additionalFields": {}
      },
      "id": "fe05bd08-3afc-4523-9f5d-9002fc888717",
      "name": "Send Photos to Telegram",
      "type": "n8n-nodes-base.telegram",
      "typeVersion": 1.2,
      "position": [
        480,
        0
      ],
      "webhookId": "8b363927-b729-4c38-90d2-1f50da33b591",
      "credentials": {
        "telegramApi": {
          "id": "A03HnmidGpnmNs2d",
          "name": "Telegram account"
        }
      }
    },
    {
      "parameters": {},
      "type": "n8n-nodes-base.manualTrigger",
      "typeVersion": 1,
      "position": [
        0,
        0
      ],
      "id": "8eaa9cd3-1c55-43c1-b360-75cca4cffa9d",
      "name": "When clicking ‘Execute workflow’"
    },
    {
      "parameters": {
        "operation": "toBinary",
        "sourceProperty": "code",
        "binaryPropertyName": "=data_{{ $itemIndex }}",
        "options": {
          "mimeType": "image/png"
        }
      },
      "type": "n8n-nodes-base.convertToFile",
      "typeVersion": 1.1,
      "position": [
        208,
        0
      ],
      "id": "d3e30867-0f4b-4c2b-a1a3-4b024875b387",
      "name": "Convert to File"
    }
  ],
  "connections": {
    "When clicking ‘Execute workflow’": {
      "main": [
        [
          {
            "node": "Convert to File",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Convert to File": {
      "main": [
        [
          {
            "node": "Send Photos to Telegram",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {
    "When clicking ‘Execute workflow’": [
      {
        "name": "First item",
        "code": "iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII="
      },
      {
        "name": "Second item",
        "code": "iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII="
      }
    ]
  },
  "meta": {
    "instanceId": "869de6ef8ff5644147e5589ff5c9f86171de90b2c3bb7db31c1025ea70eaa896"
  }
}
```

</details>

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3584/community-issue-telegram-node-doesnt-update-parameters-for-subsequent
closes #19174 
https://github.com/n8n-io/n8n/issues/13954
## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
