### PR TITLE
fix(editor): Prevent search dialog from covering inline expression parameters

### DIFF
--- a/packages/frontend/editor-ui/src/components/InlineExpressionEditor/InlineExpressionEditorInput.vue
+++ b/packages/frontend/editor-ui/src/components/InlineExpressionEditor/InlineExpressionEditorInput.vue
@@ -71,6 +71,7 @@ const {
 	editorRef: root,
 	editorValue,
 	extensions,
+	disableSearchDialog: true,
 	isReadOnly: computed(() => props.isReadOnly),
 	autocompleteTelemetry: { enabled: true, parameterPath: props.path },
 	additionalData: props.additionalData,

--- a/packages/frontend/editor-ui/src/composables/useExpressionEditor.ts
+++ b/packages/frontend/editor-ui/src/composables/useExpressionEditor.ts
@@ -6,6 +6,7 @@ import {
 	ref,
 	toRef,
 	toValue,
+	unref,
 	watch,
 	watchEffect,
 	type MaybeRefOrGetter,
@@ -204,7 +205,7 @@ export const useExpressionEditor = ({
 
 	function onKeyDown(e: KeyboardEvent) {
 		if (
-			disableSearchDialog &&
+			unref(disableSearchDialog) &&
 			// Avoid blocking editor shortcuts like `ctrl+f` to go to next character on mac
 			((isMacOs && e.metaKey) || (!isMacOs && e.ctrlKey)) &&
 			e.key === 'f'

--- a/packages/frontend/editor-ui/src/composables/useExpressionEditor.ts
+++ b/packages/frontend/editor-ui/src/composables/useExpressionEditor.ts
@@ -205,7 +205,7 @@ export const useExpressionEditor = ({
 	function onKeyDown(e: KeyboardEvent) {
 		if (
 			disableSearchDialog &&
-			// Avoid blocking editor shortcuts like `ctrl+f` to skip to next character on mac
+			// Avoid blocking editor shortcuts like `ctrl+f` to go to next character on mac
 			((isMacOs && e.metaKey) || (!isMacOs && e.ctrlKey)) &&
 			e.key === 'f'
 		) {


### PR DESCRIPTION
## Summary

Prevent this widget from opening for inline editors. Don't think we can easily use `useKeybindings` for this unfortunately.

<img width="541" height="273" alt="image" src="https://github.com/user-attachments/assets/24635220-85aa-4f8e-9e15-95dee3c01243" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-2658


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
