### PR TITLE
fix(Execute Workflow Node): Fix 'Continue (using error output)' mode to output errors correctly

### DIFF
--- a/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow/ExecuteWorkflow.node.test.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow/ExecuteWorkflow.node.test.ts
@@ -1,5 +1,5 @@
 import { mock } from 'jest-mock-extended';
-import type { IExecuteFunctions, IWorkflowDataProxyData } from 'n8n-workflow';
+import type { IExecuteFunctions, IWorkflowDataProxyData, INode } from 'n8n-workflow';
 
 import { ExecuteWorkflow } from './ExecuteWorkflow.node';
 import { getWorkflowInfo } from './GenericFunctions';
@@ -88,7 +88,7 @@ describe('ExecuteWorkflow', () => {
 			.mockReturnValueOnce(true) // waitForSubWorkflow
 			.mockReturnValueOnce([]); // workflowInputs.schema
 
-		executeFunctions.getNode.mockReturnValue({ typeVersion: 1.2 });
+		executeFunctions.getNode.mockReturnValue({ typeVersion: 1.2 } as INode);
 
 		(getWorkflowInfo as jest.Mock).mockRejectedValue(new Error('Test error'));
 		(executeFunctions.continueOnFail as jest.Mock).mockReturnValue(true);
@@ -105,7 +105,7 @@ describe('ExecuteWorkflow', () => {
 			.mockReturnValueOnce(true) // waitForSubWorkflow
 			.mockReturnValue([]); // workflowInputs.schema
 
-		executeFunctions.getNode.mockReturnValue({ typeVersion: 1.2 });
+		executeFunctions.getNode.mockReturnValue({ typeVersion: 1.2 } as INode);
 		executeFunctions.getInputData.mockReturnValueOnce([
 			{ json: { key: '1' } },
 			{ json: { key: '2' } },
@@ -131,7 +131,7 @@ describe('ExecuteWorkflow', () => {
 			.mockReturnValueOnce(true) // waitForSubWorkflow
 			.mockReturnValueOnce([]); // workflowInputs.schema
 
-		executeFunctions.getNode.mockReturnValue({ typeVersion: 1.3 });
+		executeFunctions.getNode.mockReturnValue({ typeVersion: 1.3 } as INode);
 
 		(getWorkflowInfo as jest.Mock).mockRejectedValue(new Error('Test error'));
 		(executeFunctions.continueOnFail as jest.Mock).mockReturnValue(true);
@@ -148,7 +148,7 @@ describe('ExecuteWorkflow', () => {
 			.mockReturnValueOnce(true) // waitForSubWorkflow
 			.mockReturnValueOnce([]); // workflowInputs.schema
 
-		executeFunctions.getNode.mockReturnValue({ typeVersion: 1.3 });
+		executeFunctions.getNode.mockReturnValue({ typeVersion: 1.3 } as INode);
 		executeFunctions.getInputData.mockReturnValueOnce([
 			{ json: { key: '1' } },
 			{ json: { key: '2' } },

--- a/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow/ExecuteWorkflow.node.test.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow/ExecuteWorkflow.node.test.ts
@@ -81,12 +81,14 @@ describe('ExecuteWorkflow', () => {
 		expect(result).toEqual([[{ json: { key: 'value' }, index: 0, pairedItem: { item: 0 } }]]);
 	});
 
-	test('should handle errors and continue on fail', async () => {
+	test('should handle errors and continue on fail, no items, < 1.3 version', async () => {
 		executeFunctions.getNodeParameter
 			.mockReturnValueOnce('database') // source
 			.mockReturnValueOnce('each') // mode
 			.mockReturnValueOnce(true) // waitForSubWorkflow
 			.mockReturnValueOnce([]); // workflowInputs.schema
+
+		executeFunctions.getNode.mockReturnValue({ typeVersion: 1.2 });
 
 		(getWorkflowInfo as jest.Mock).mockRejectedValue(new Error('Test error'));
 		(executeFunctions.continueOnFail as jest.Mock).mockReturnValue(true);
@@ -94,6 +96,77 @@ describe('ExecuteWorkflow', () => {
 		const result = await executeWorkflow.execute.call(executeFunctions);
 
 		expect(result).toEqual([[{ json: { error: 'Test error' }, pairedItem: { item: 0 } }]]);
+	});
+
+	test('should handle errors and continue on fail, multiple items, < 1.3 version', async () => {
+		executeFunctions.getNodeParameter
+			.mockReturnValueOnce('database') // source
+			.mockReturnValueOnce('each') // mode
+			.mockReturnValueOnce(true) // waitForSubWorkflow
+			.mockReturnValue([]); // workflowInputs.schema
+
+		executeFunctions.getNode.mockReturnValue({ typeVersion: 1.2 });
+		executeFunctions.getInputData.mockReturnValueOnce([
+			{ json: { key: '1' } },
+			{ json: { key: '2' } },
+			{ json: { key: '3' } },
+		]);
+
+		(getWorkflowInfo as jest.Mock).mockRejectedValue(new Error('Test error'));
+		(executeFunctions.continueOnFail as jest.Mock).mockReturnValue(true);
+
+		const result = await executeWorkflow.execute.call(executeFunctions);
+
+		expect(result).toEqual([
+			[{ json: { error: 'Test error' }, pairedItem: { item: 0 }, metadata: undefined }],
+			[{ json: { error: 'Test error' }, pairedItem: { item: 1 }, metadata: undefined }],
+			[{ json: { error: 'Test error' }, pairedItem: { item: 2 }, metadata: undefined }],
+		]);
+	});
+
+	test('should handle errors and continue on fail, no items, >= 1.3 version', async () => {
+		executeFunctions.getNodeParameter
+			.mockReturnValueOnce('database') // source
+			.mockReturnValueOnce('each') // mode
+			.mockReturnValueOnce(true) // waitForSubWorkflow
+			.mockReturnValueOnce([]); // workflowInputs.schema
+
+		executeFunctions.getNode.mockReturnValue({ typeVersion: 1.3 });
+
+		(getWorkflowInfo as jest.Mock).mockRejectedValue(new Error('Test error'));
+		(executeFunctions.continueOnFail as jest.Mock).mockReturnValue(true);
+
+		const result = await executeWorkflow.execute.call(executeFunctions);
+
+		expect(result).toEqual([[{ json: { error: 'Test error' }, pairedItem: { item: 0 } }]]);
+	});
+
+	test('should handle errors and continue on fail, multiple items, >= 1.3 version', async () => {
+		executeFunctions.getNodeParameter
+			.mockReturnValueOnce('database') // source
+			.mockReturnValueOnce('each') // mode
+			.mockReturnValueOnce(true) // waitForSubWorkflow
+			.mockReturnValueOnce([]); // workflowInputs.schema
+
+		executeFunctions.getNode.mockReturnValue({ typeVersion: 1.3 });
+		executeFunctions.getInputData.mockReturnValueOnce([
+			{ json: { key: '1' } },
+			{ json: { key: '2' } },
+			{ json: { key: '3' } },
+		]);
+
+		(getWorkflowInfo as jest.Mock).mockRejectedValue(new Error('Test error'));
+		(executeFunctions.continueOnFail as jest.Mock).mockReturnValue(true);
+
+		const result = await executeWorkflow.execute.call(executeFunctions);
+
+		expect(result).toEqual([
+			[
+				{ json: { error: 'Test error' }, pairedItem: { item: 0 }, metadata: undefined },
+				{ json: { error: 'Test error' }, pairedItem: { item: 1 }, metadata: undefined },
+				{ json: { error: 'Test error' }, pairedItem: { item: 2 }, metadata: undefined },
+			],
+		]);
 	});
 
 	test('should throw error if not continuing on fail', async () => {

--- a/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow/ExecuteWorkflow.node.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow/ExecuteWorkflow.node.ts
@@ -20,7 +20,7 @@ export class ExecuteWorkflow implements INodeType {
 		icon: 'fa:sign-in-alt',
 		iconColor: 'orange-red',
 		group: ['transform'],
-		version: [1, 1.1, 1.2],
+		version: [1, 1.1, 1.2, 1.3],
 		subtitle: '={{"Workflow: " + $parameter["workflowId"]}}',
 		description: 'Execute another workflow',
 		defaults: {
@@ -369,11 +369,16 @@ export class ExecuteWorkflow implements INodeType {
 					}
 				} catch (error) {
 					if (this.continueOnFail()) {
-						if (returnData[i] === undefined) {
-							returnData[i] = [];
-						}
+						const nodeVersion = this.getNode().typeVersion;
+						// In versions < 1.3 using the "Continue (using error output)" mode
+						// the node would return items in extra "error branches" instead of
+						// returning an array of items on the error output. These branches weren't really shown correctly on the UI.
+						// In the fixed >= 1.3 versions the errors are now all output into the single error output as an array of error items.
+						const outputIndex = nodeVersion >= 1.3 ? 0 : i;
+
+						returnData[outputIndex] ??= [];
 						const metadata = parseErrorMetadata(error);
-						returnData[i].push({
+						returnData[outputIndex].push({
 							json: { error: error.message },
 							pairedItem: { item: i },
 							metadata,


### PR DESCRIPTION
## Summary

Execute sub-workflow node had an issue in the `Continue (using error output)` mode with `Run once for each item`, where instead of returning all the errored sub workflow runs on the Error output it would instead map each of them as extra outputs on the node, so they would show up as single items on extra unnamed branches of the node that couldn't be connected to any other nodes.

This PR fixes that bug at the error handling, but since this could be a breaking change for user's workflows working around this issue it has been fixed only on the >=1.3 version of the Execute Workflow node, so only new workflows using the fixed version of this node will be affected.

In a situation where 5 sub workflow executions succeed and 5 fail:

<img width="1066" height="634" alt="image" src="https://github.com/user-attachments/assets/b491417a-982e-4420-8fac-1bee22e1fe54" />

Before fix:

<img width="752" height="612" alt="image" src="https://github.com/user-attachments/assets/bfcf296d-c5ea-43f5-b97e-c528213733e8" />

<img width="763" height="402" alt="image" src="https://github.com/user-attachments/assets/77d142dc-7408-4f67-8caf-63f108a8f400" />

<img width="749" height="364" alt="image" src="https://github.com/user-attachments/assets/bfbf9ed8-b533-4541-8912-3bf997b09b4e" />


After:

<img width="758" height="698" alt="image" src="https://github.com/user-attachments/assets/3c056e8f-a93c-4902-ac2c-99e59f874fd1" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3959/community-issue-execute-workflow-branch-has-a-3rd-unusable-output
Fixes https://github.com/n8n-io/n8n/issues/18555

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
