### PR TITLE
fix(editor): Show claim free ai credits modal on credentials

### DIFF
--- a/packages/frontend/editor-ui/src/components/CredentialEdit/CredentialConfig.vue
+++ b/packages/frontend/editor-ui/src/components/CredentialEdit/CredentialConfig.vue
@@ -230,7 +230,7 @@ watch(showOAuthSuccessBanner, (newValue, oldValue) => {
 	</n8n-callout>
 	<div v-else>
 		<div :class="$style.config" data-test-id="node-credentials-config-container">
-			<FreeAiCreditsCallout />
+			<FreeAiCreditsCallout :credentialTypeName="credentialType.name" />
 			<Banner
 				v-show="showValidationWarning"
 				theme="danger"

--- a/packages/frontend/editor-ui/src/components/CredentialEdit/CredentialConfig.vue
+++ b/packages/frontend/editor-ui/src/components/CredentialEdit/CredentialConfig.vue
@@ -230,7 +230,7 @@ watch(showOAuthSuccessBanner, (newValue, oldValue) => {
 	</n8n-callout>
 	<div v-else>
 		<div :class="$style.config" data-test-id="node-credentials-config-container">
-			<FreeAiCreditsCallout :credentialTypeName="credentialType.name" />
+			<FreeAiCreditsCallout :credential-type-name="credentialType?.name" />
 			<Banner
 				v-show="showValidationWarning"
 				theme="danger"

--- a/packages/frontend/editor-ui/src/components/CredentialEdit/CredentialConfig.vue
+++ b/packages/frontend/editor-ui/src/components/CredentialEdit/CredentialConfig.vue
@@ -32,6 +32,7 @@ import GoogleAuthButton from './GoogleAuthButton.vue';
 import OauthButton from './OauthButton.vue';
 import { useAssistantStore } from '@/stores/assistant.store';
 import InlineAskAssistantButton from '@n8n/design-system/components/InlineAskAssistantButton/InlineAskAssistantButton.vue';
+import FreeAiCreditsCallout from '@/components/FreeAiCreditsCallout.vue';
 
 type Props = {
 	mode: string;
@@ -229,6 +230,7 @@ watch(showOAuthSuccessBanner, (newValue, oldValue) => {
 	</n8n-callout>
 	<div v-else>
 		<div :class="$style.config" data-test-id="node-credentials-config-container">
+			<FreeAiCreditsCallout />
 			<Banner
 				v-show="showValidationWarning"
 				theme="danger"

--- a/packages/frontend/editor-ui/src/components/FreeAiCreditsCallout.test.ts
+++ b/packages/frontend/editor-ui/src/components/FreeAiCreditsCallout.test.ts
@@ -183,4 +183,48 @@ describe('FreeAiCreditsCallout', () => {
 
 		assertUserCannotClaimCredits();
 	});
+
+	describe('credentialTypeName prop (credentials page)', () => {
+		it('should not show claim callout when editing a non-openapi credential', async () => {
+			(useNDVStore as any).mockReturnValue({
+				activeNode: null,
+			});
+
+			renderComponent(FreeAiCreditsCallout, {
+				props: {
+					credentialTypeName: 'googleSheetsOAuth2Api',
+				},
+			});
+
+			assertUserCannotClaimCredits();
+		});
+
+		it('should show claim callout editing openapi credential with no active node', async () => {
+			(useNDVStore as any).mockReturnValue({
+				activeNode: null,
+			});
+
+			renderComponent(FreeAiCreditsCallout, {
+				props: {
+					credentialTypeName: 'openAiApi',
+				},
+			});
+
+			assertUserCanClaimCredits();
+		});
+
+		it('should not show claim callout when credential type is undefined and no valid active node', async () => {
+			(useNDVStore as any).mockReturnValue({
+				activeNode: null,
+			});
+
+			renderComponent(FreeAiCreditsCallout, {
+				props: {
+					credentialTypeName: undefined,
+				},
+			});
+
+			assertUserCannotClaimCredits();
+		});
+	});
 });

--- a/packages/frontend/editor-ui/src/components/FreeAiCreditsCallout.vue
+++ b/packages/frontend/editor-ui/src/components/FreeAiCreditsCallout.vue
@@ -8,8 +8,14 @@ import { useProjectsStore } from '@/stores/projects.store';
 import { useSettingsStore } from '@/stores/settings.store';
 import { useUsersStore } from '@/stores/users.store';
 import { computed, ref } from 'vue';
-import { OPEN_AI_API_CREDENTIAL_TYPE } from 'n8n-workflow';
+import { type ICredentialType, OPEN_AI_API_CREDENTIAL_TYPE } from 'n8n-workflow';
 import { N8nCallout, N8nText } from '@n8n/design-system';
+
+type Props = {
+	credentialTypeName?: string;
+};
+
+const props = defineProps<Props>();
 
 const LANGCHAIN_NODES_PREFIX = '@n8n/n8n-nodes-langchain.';
 
@@ -42,6 +48,10 @@ const userHasOpenAiCredentialAlready = computed(
 		).length,
 );
 
+const isEditingOpenAiCredential = computed(
+	() => props.credentialTypeName && props.credentialTypeName === OPEN_AI_API_CREDENTIAL_TYPE,
+);
+
 const userHasClaimedAiCreditsAlready = computed(
 	() => !!usersStore.currentUser?.settings?.userClaimedAiCredits,
 );
@@ -55,7 +65,7 @@ const activeNodeHasOpenAiApiCredential = computed(
 const userCanClaimOpenAiCredits = computed(() => {
 	return (
 		settingsStore.isAiCreditsEnabled &&
-		activeNodeHasOpenAiApiCredential.value &&
+		(activeNodeHasOpenAiApiCredential.value || isEditingOpenAiCredential.value) &&
 		!userHasOpenAiCredentialAlready.value &&
 		!userHasClaimedAiCreditsAlready.value
 	);

--- a/packages/frontend/editor-ui/src/components/FreeAiCreditsCallout.vue
+++ b/packages/frontend/editor-ui/src/components/FreeAiCreditsCallout.vue
@@ -8,7 +8,7 @@ import { useProjectsStore } from '@/stores/projects.store';
 import { useSettingsStore } from '@/stores/settings.store';
 import { useUsersStore } from '@/stores/users.store';
 import { computed, ref } from 'vue';
-import { type ICredentialType, OPEN_AI_API_CREDENTIAL_TYPE } from 'n8n-workflow';
+import { OPEN_AI_API_CREDENTIAL_TYPE } from 'n8n-workflow';
 import { N8nCallout, N8nText } from '@n8n/design-system';
 
 type Props = {


### PR DESCRIPTION
## Summary
Show the `FreeAiCreditsCallout` on openAI related credentials and the create credentials page to make it easier to claim the free credits.

From the workflow editor:
<img width="1141" height="786" alt="image" src="https://github.com/user-attachments/assets/eb06d997-d044-47f1-98e7-c25168647b12" />

From create credentials:
<img width="1450" height="1272" alt="image" src="https://github.com/user-attachments/assets/cb22581f-02ef-4dfd-8e9e-32922aa0a74c" />


## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/ADO-3991/bug-claim-openai-creds-does-not-show-everywhere



## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
