### PR TITLE
fix(core): Improve Websocket connection setup for custom headers

### DIFF
--- a/packages/cli/src/push/__tests__/index.test.ts
+++ b/packages/cli/src/push/__tests__/index.test.ts
@@ -120,12 +120,16 @@ describe('Push', () => {
 	});
 
 	describe('handleRequest', () => {
-		const req = mock<SSEPushRequest | WebSocketPushRequest>({ user });
-		const res = mock<PushResponse>();
-		const ws = mock<WebSocket>();
 		const backendNames = ['sse', 'websocket'] as const;
+		let req: ReturnType<typeof mock<SSEPushRequest | WebSocketPushRequest>>;
+		let res: ReturnType<typeof mock<PushResponse>>;
+		let ws: ReturnType<typeof mock<WebSocket>>;
 
 		beforeEach(() => {
+			req = mock<SSEPushRequest | WebSocketPushRequest>({ user });
+			res = mock<PushResponse>();
+			ws = mock<WebSocket>();
+
 			res.status.mockReturnThis();
 
 			req.headers.host = host;
@@ -140,13 +144,6 @@ describe('Push', () => {
 				config.backend = backendName;
 				push = new Push(config, mock(), logger, mock(), mock());
 				req.ws = backendName === 'sse' ? undefined : ws;
-
-				// Reset headers for each test to prevent pollution
-				req.headers.host = host;
-				req.headers.origin = `https://${host}`;
-				delete req.headers['x-forwarded-host'];
-				delete req.headers['x-forwarded-proto'];
-				delete req.headers.forwarded;
 			});
 
 			describe('should throw on invalid origin', () => {

--- a/packages/cli/src/push/__tests__/index.test.ts
+++ b/packages/cli/src/push/__tests__/index.test.ts
@@ -42,187 +42,6 @@ describe('Push', () => {
 		logger.scoped.mockReturnValue(logger);
 	});
 
-	describe('normalizeHost', () => {
-		beforeEach(() => {
-			config.backend = 'sse';
-			push = new Push(config, mock(), logger, mock(), mock());
-		});
-
-		test('should return original host if empty', () => {
-			// @ts-expect-error accessing private method for testing
-			expect(push.normalizeHost('', 'https')).toBe('');
-			// @ts-expect-error accessing private method for testing
-			expect(push.normalizeHost('', 'http')).toBe('');
-		});
-
-		test('should normalize HTTPS hosts by removing default port 443', () => {
-			// @ts-expect-error accessing private method for testing
-			expect(push.normalizeHost('example.com:443', 'https')).toBe('example.com');
-			// @ts-expect-error accessing private method for testing
-			expect(push.normalizeHost('example.com', 'https')).toBe('example.com');
-		});
-
-		test('should normalize HTTP hosts by removing default port 80', () => {
-			// @ts-expect-error accessing private method for testing
-			expect(push.normalizeHost('example.com:80', 'http')).toBe('example.com');
-			// @ts-expect-error accessing private method for testing
-			expect(push.normalizeHost('example.com', 'http')).toBe('example.com');
-		});
-
-		test('should preserve non-default ports', () => {
-			// @ts-expect-error accessing private method for testing
-			expect(push.normalizeHost('example.com:8080', 'https')).toBe('example.com:8080');
-			// @ts-expect-error accessing private method for testing
-			expect(push.normalizeHost('example.com:3000', 'http')).toBe('example.com:3000');
-		});
-
-		test('should handle IPv6 hosts correctly', () => {
-			// IPv6 hosts should have brackets stripped for consistency
-			// @ts-expect-error accessing private method for testing
-			expect(push.normalizeHost('[::1]:443', 'https')).toBe('::1');
-			// @ts-expect-error accessing private method for testing
-			expect(push.normalizeHost('[::1]:80', 'http')).toBe('::1');
-			// Non-default ports preserve the full format but strip brackets
-			// @ts-expect-error accessing private method for testing
-			expect(push.normalizeHost('[::1]:8080', 'https')).toBe('::1:8080');
-		});
-
-		test('should handle complex domain names', () => {
-			// @ts-expect-error accessing private method for testing
-			expect(push.normalizeHost('sub.domain.example-site.com:443', 'https')).toBe(
-				'sub.domain.example-site.com',
-			);
-			// @ts-expect-error accessing private method for testing
-			expect(push.normalizeHost('test-server.local:3000', 'http')).toBe('test-server.local:3000');
-		});
-
-		test('should fallback to original host on invalid URL', () => {
-			// Invalid host formats that would cause URL constructor to throw
-			// @ts-expect-error accessing private method for testing
-			expect(push.normalizeHost('invalid[host', 'https')).toBe('invalid[host');
-			// @ts-expect-error accessing private method for testing
-			expect(push.normalizeHost('://malformed', 'http')).toBe('://malformed');
-			// @ts-expect-error accessing private method for testing
-			expect(push.normalizeHost('space host.com', 'https')).toBe('space host.com');
-		});
-	});
-
-	describe('parseOrigin', () => {
-		beforeEach(() => {
-			config.backend = 'sse';
-			push = new Push(config, mock(), logger, mock(), mock());
-		});
-
-		test('should return null for invalid origins', () => {
-			// @ts-expect-error accessing private method for testing
-			expect(push.parseOrigin('')).toBeNull();
-			// @ts-expect-error accessing private method for testing
-			expect(push.parseOrigin(null as any)).toBeNull();
-			// @ts-expect-error accessing private method for testing
-			expect(push.parseOrigin(undefined as any)).toBeNull();
-			// @ts-expect-error accessing private method for testing
-			expect(push.parseOrigin(123 as any)).toBeNull();
-		});
-
-		test('should return null for non-HTTP/HTTPS protocols', () => {
-			// @ts-expect-error accessing private method for testing
-			expect(push.parseOrigin('ftp://example.com')).toBeNull();
-			// @ts-expect-error accessing private method for testing
-			expect(push.parseOrigin('ws://example.com')).toBeNull();
-			// @ts-expect-error accessing private method for testing
-			expect(push.parseOrigin('file://example.com')).toBeNull();
-			// @ts-expect-error accessing private method for testing
-			expect(push.parseOrigin('chrome-extension://example.com')).toBeNull();
-		});
-
-		test('should return null for malformed URLs', () => {
-			// @ts-expect-error accessing private method for testing
-			expect(push.parseOrigin('not-a-url')).toBeNull();
-			// @ts-expect-error accessing private method for testing
-			expect(push.parseOrigin('://malformed')).toBeNull();
-			// @ts-expect-error accessing private method for testing
-			expect(push.parseOrigin('https://')).toBeNull();
-			// @ts-expect-error accessing private method for testing
-			expect(push.parseOrigin('https://[invalid')).toBeNull();
-		});
-
-		test('should parse valid HTTP origins', () => {
-			// @ts-expect-error accessing private method for testing
-			const result = push.parseOrigin('http://example.com');
-			expect(result).toEqual({
-				protocol: 'http',
-				host: 'example.com',
-			});
-		});
-
-		test('should parse valid HTTPS origins', () => {
-			// @ts-expect-error accessing private method for testing
-			const result = push.parseOrigin('https://example.com');
-			expect(result).toEqual({
-				protocol: 'https',
-				host: 'example.com',
-			});
-		});
-
-		test('should normalize ports in origins', () => {
-			// Default ports should be removed
-			// @ts-expect-error accessing private method for testing
-			expect(push.parseOrigin('https://example.com:443')).toEqual({
-				protocol: 'https',
-				host: 'example.com',
-			});
-
-			// @ts-expect-error accessing private method for testing
-			expect(push.parseOrigin('http://example.com:80')).toEqual({
-				protocol: 'http',
-				host: 'example.com',
-			});
-
-			// Non-default ports should be preserved
-			// @ts-expect-error accessing private method for testing
-			expect(push.parseOrigin('https://example.com:8080')).toEqual({
-				protocol: 'https',
-				host: 'example.com:8080',
-			});
-
-			// @ts-expect-error accessing private method for testing
-			expect(push.parseOrigin('http://example.com:3000')).toEqual({
-				protocol: 'http',
-				host: 'example.com:3000',
-			});
-		});
-
-		test('should handle IPv6 origins', () => {
-			// IPv6 with default port: brackets should be stripped for consistency
-			// @ts-expect-error accessing private method for testing
-			expect(push.parseOrigin('https://[::1]:443')).toEqual({
-				protocol: 'https',
-				host: '::1',
-			});
-
-			// IPv6 with non-default port: brackets should be stripped but port preserved
-			// @ts-expect-error accessing private method for testing
-			expect(push.parseOrigin('http://[2001:db8::1]:8080')).toEqual({
-				protocol: 'http',
-				host: '2001:db8::1:8080',
-			});
-		});
-
-		test('should handle mixed case protocols', () => {
-			// @ts-expect-error accessing private method for testing
-			expect(push.parseOrigin('HTTPS://example.com')).toEqual({
-				protocol: 'https',
-				host: 'example.com',
-			});
-
-			// @ts-expect-error accessing private method for testing
-			expect(push.parseOrigin('Http://example.com')).toEqual({
-				protocol: 'http',
-				host: 'example.com',
-			});
-		});
-	});
-
 	describe('setupPushServer', () => {
 		const restEndpoint = 'rest';
 		const app = mock<Application>();
@@ -326,6 +145,8 @@ describe('Push', () => {
 				req.headers.host = host;
 				req.headers.origin = `https://${host}`;
 				delete req.headers['x-forwarded-host'];
+				delete req.headers['x-forwarded-proto'];
+				delete req.headers.forwarded;
 			});
 
 			describe('should throw on invalid origin', () => {
@@ -348,12 +169,12 @@ describe('Push', () => {
 					{
 						name: 'origin does not match x-forwarded-host',
 						origin: `https://${host}`, // this is correct
-						xForwardedHost: 'https://123example.com', // this is not
+						xForwardedHost: '123example.com', // this is not
 					},
 					{
 						name: 'origin does not match x-forwarded-host (subdomain)',
 						origin: `https://${host}`, // this is correct
-						xForwardedHost: `https://subdomain.${host}`, // this is not
+						xForwardedHost: `subdomain.${host}`, // this is not
 					},
 				])('$name', ({ origin, xForwardedHost }) => {
 					req.headers.origin = origin;
@@ -505,196 +326,8 @@ describe('Push', () => {
 					expect(backend.add).not.toHaveBeenCalled();
 				});
 			}
-		});
 
-		describe('additional edge cases', () => {
-			describe.each(backendNames)('%s backend - additional cases', (backendName) => {
-				const backend = backendName === 'sse' ? sseBackend : wsBackend;
-
-				beforeEach(() => {
-					config.backend = backendName;
-					push = new Push(config, mock(), logger, mock(), mock());
-					req.ws = backendName === 'sse' ? undefined : ws;
-
-					// Reset headers
-					req.headers.host = host;
-					req.headers.origin = `https://${host}`;
-					req.query = { pushRef };
-					delete req.headers['x-forwarded-host'];
-				});
-
-				test('should handle malformed origin URLs that throw during parsing', () => {
-					// Set an origin that parseOrigin will return null for
-					req.headers.origin = 'invalid-protocol://example.com';
-
-					if (backendName === 'sse') {
-						expect(() => push.handleRequest(req, res)).toThrow(
-							new BadRequestError('Invalid origin!'),
-						);
-					} else {
-						push.handleRequest(req, res);
-						expect(ws.send).toHaveBeenCalledWith('Invalid origin!');
-						expect(ws.close).toHaveBeenCalledWith(1008);
-					}
-					expect(backend.add).not.toHaveBeenCalled();
-				});
-
-				test('should allow origins with query parameters and fragments when host matches', () => {
-					// Test with an origin that has additional components but correct host
-					const queryOrigin = `https://${host}?query=param#fragment`;
-					req.headers.origin = queryOrigin;
-
-					// This should pass because the host extraction ignores query/fragment
-					const emitSpy = jest.spyOn(push, 'emit');
-					const connection = backendName === 'sse' ? { req, res } : ws;
-
-					push.handleRequest(req, res);
-
-					expect(backend.add).toHaveBeenCalledWith(pushRef, user.id, connection);
-					expect(emitSpy).toHaveBeenCalledWith('editorUiConnected', pushRef);
-				});
-
-				test('should allow origin with path component when host matches', () => {
-					// Origins with path components should be parsed correctly
-					const pathOrigin = `https://${host}/path`;
-					req.headers.origin = pathOrigin;
-
-					// This should pass because the host extraction ignores the path
-					const emitSpy = jest.spyOn(push, 'emit');
-					const connection = backendName === 'sse' ? { req, res } : ws;
-
-					push.handleRequest(req, res);
-
-					expect(backend.add).toHaveBeenCalledWith(pushRef, user.id, connection);
-					expect(emitSpy).toHaveBeenCalledWith('editorUiConnected', pushRef);
-				});
-
-				test('should handle numeric IP addresses correctly', () => {
-					const ipHost = '192.168.1.100';
-					req.headers.host = `${ipHost}:3000`;
-					req.headers.origin = `https://${ipHost}:3000`;
-
-					const emitSpy = jest.spyOn(push, 'emit');
-					const connection = backendName === 'sse' ? { req, res } : ws;
-
-					push.handleRequest(req, res);
-
-					expect(backend.add).toHaveBeenCalledWith(pushRef, user.id, connection);
-					expect(emitSpy).toHaveBeenCalledWith('editorUiConnected', pushRef);
-				});
-
-				test('should handle localhost correctly', () => {
-					const localhostHost = 'localhost:8080';
-					req.headers.host = localhostHost;
-					req.headers.origin = `http://${localhostHost}`;
-
-					const emitSpy = jest.spyOn(push, 'emit');
-					const connection = backendName === 'sse' ? { req, res } : ws;
-
-					push.handleRequest(req, res);
-
-					expect(backend.add).toHaveBeenCalledWith(pushRef, user.id, connection);
-					expect(emitSpy).toHaveBeenCalledWith('editorUiConnected', pushRef);
-				});
-			});
-		});
-
-		describe('edge cases in handleRequest', () => {
-			describe.each(backendNames)('%s backend - edge cases', (backendName) => {
-				const backend = backendName === 'sse' ? sseBackend : wsBackend;
-
-				beforeEach(() => {
-					config.backend = backendName;
-					push = new Push(config, mock(), logger, mock(), mock());
-					req.ws = backendName === 'sse' ? undefined : ws;
-
-					// Reset headers
-					req.headers.host = host;
-					req.headers.origin = `https://${host}`;
-					req.query = { pushRef };
-					delete req.headers['x-forwarded-host'];
-				});
-
-				test('should handle missing pushRef query parameter', () => {
-					req.query = { pushRef: '' };
-
-					if (backendName === 'sse') {
-						expect(() => push.handleRequest(req, res)).toThrow(
-							new BadRequestError('The query parameter "pushRef" is missing!'),
-						);
-					} else {
-						push.handleRequest(req, res);
-						expect(ws.send).toHaveBeenCalledWith('The query parameter "pushRef" is missing!');
-						expect(ws.close).toHaveBeenCalledWith(1008);
-					}
-					expect(backend.add).not.toHaveBeenCalled();
-				});
-
-				test('should handle null pushRef', () => {
-					req.query = { pushRef: null as any };
-
-					if (backendName === 'sse') {
-						expect(() => push.handleRequest(req, res)).toThrow(
-							new BadRequestError('The query parameter "pushRef" is missing!'),
-						);
-					} else {
-						push.handleRequest(req, res);
-						expect(ws.send).toHaveBeenCalledWith('The query parameter "pushRef" is missing!');
-						expect(ws.close).toHaveBeenCalledWith(1008);
-					}
-					expect(backend.add).not.toHaveBeenCalled();
-				});
-
-				test('should handle missing origin header completely', () => {
-					delete req.headers.origin;
-
-					if (backendName === 'sse') {
-						expect(() => push.handleRequest(req, res)).toThrow(
-							new BadRequestError('Invalid origin!'),
-						);
-					} else {
-						push.handleRequest(req, res);
-						expect(ws.send).toHaveBeenCalledWith('Invalid origin!');
-						expect(ws.close).toHaveBeenCalledWith(1008);
-					}
-					expect(backend.add).not.toHaveBeenCalled();
-				});
-
-				test('should handle empty string origin header', () => {
-					req.headers.origin = '';
-
-					if (backendName === 'sse') {
-						expect(() => push.handleRequest(req, res)).toThrow(
-							new BadRequestError('Invalid origin!'),
-						);
-					} else {
-						push.handleRequest(req, res);
-						expect(ws.send).toHaveBeenCalledWith('Invalid origin!');
-						expect(ws.close).toHaveBeenCalledWith(1008);
-					}
-					expect(backend.add).not.toHaveBeenCalled();
-				});
-
-				test('should handle missing host header when no x-forwarded-host', () => {
-					// Explicitly remove host header after beforeEach setup
-					delete req.headers.host;
-					req.headers.origin = `https://${host}`;
-					// Make sure no proxy headers exist
-					delete req.headers['x-forwarded-host'];
-					delete req.headers.forwarded;
-
-					if (backendName === 'sse') {
-						expect(() => push.handleRequest(req, res)).toThrow(
-							new BadRequestError('Invalid origin!'),
-						);
-					} else {
-						push.handleRequest(req, res);
-						expect(ws.send).toHaveBeenCalledWith('Invalid origin!');
-						expect(ws.close).toHaveBeenCalledWith(1008);
-					}
-					expect(backend.add).not.toHaveBeenCalled();
-				});
-
+			describe('additional edge cases', () => {
 				test('should handle array x-forwarded-host header (use first)', () => {
 					req.headers['x-forwarded-host'] = [host, 'other-host.com'] as any;
 					req.headers.origin = `https://${host}`;
@@ -708,365 +341,44 @@ describe('Push', () => {
 					expect(emitSpy).toHaveBeenCalledWith('editorUiConnected', pushRef);
 				});
 
-				describe('Forwarded header support', () => {
-					beforeEach(() => {
-						// Clean proxy headers for each test
-						delete req.headers.forwarded;
-						delete req.headers['x-forwarded-host'];
-						delete req.headers['x-forwarded-proto'];
-						// Explicitly set headers for forwarded tests
-						req.headers.host = host;
-						req.headers.origin = `https://${host}`;
-					});
+				test('should handle Forwarded header with precedence over x-forwarded-*', () => {
+					req.headers.forwarded = `proto=https;host=${host}`;
+					req.headers['x-forwarded-host'] = 'wrong-host.com'; // Should be ignored
+					req.headers.origin = `https://${host}`;
 
-					test('should parse RFC 7239 Forwarded header with host and proto', () => {
-						req.headers.forwarded = `for=192.0.2.60;proto=https;host=${host}`;
-						req.headers.origin = `https://${host}`;
+					const emitSpy = jest.spyOn(push, 'emit');
+					const connection = backendName === 'sse' ? { req, res } : ws;
 
-						const emitSpy = jest.spyOn(push, 'emit');
-						const connection = backendName === 'sse' ? { req, res } : ws;
+					push.handleRequest(req, res);
 
-						push.handleRequest(req, res);
-
-						expect(backend.add).toHaveBeenCalledWith(pushRef, user.id, connection);
-						expect(emitSpy).toHaveBeenCalledWith('editorUiConnected', pushRef);
-					});
-
-					test('should handle Forwarded header with quoted values', () => {
-						req.headers.forwarded = `for="192.0.2.60";proto="https";host="${host}"`;
-						req.headers.origin = `https://${host}`;
-
-						const emitSpy = jest.spyOn(push, 'emit');
-						const connection = backendName === 'sse' ? { req, res } : ws;
-
-						push.handleRequest(req, res);
-
-						expect(backend.add).toHaveBeenCalledWith(pushRef, user.id, connection);
-						expect(emitSpy).toHaveBeenCalledWith('editorUiConnected', pushRef);
-					});
-
-					test('should prioritize Forwarded header over X-Forwarded-* headers', () => {
-						req.headers.forwarded = `proto=https;host=${host}`;
-						req.headers['x-forwarded-host'] = 'wrong-host.com';
-						req.headers['x-forwarded-proto'] = 'http';
-						req.headers.origin = `https://${host}`;
-
-						const emitSpy = jest.spyOn(push, 'emit');
-						const connection = backendName === 'sse' ? { req, res } : ws;
-
-						push.handleRequest(req, res);
-
-						expect(backend.add).toHaveBeenCalledWith(pushRef, user.id, connection);
-						expect(emitSpy).toHaveBeenCalledWith('editorUiConnected', pushRef);
-					});
-
-					test('should fallback to X-Forwarded-* when Forwarded header incomplete', () => {
-						req.headers.forwarded = 'for=192.0.2.60'; // Missing host and proto
-						req.headers['x-forwarded-host'] = host;
-						req.headers['x-forwarded-proto'] = 'https';
-						req.headers.origin = `https://${host}`;
-
-						const emitSpy = jest.spyOn(push, 'emit');
-						const connection = backendName === 'sse' ? { req, res } : ws;
-
-						push.handleRequest(req, res);
-
-						expect(backend.add).toHaveBeenCalledWith(pushRef, user.id, connection);
-						expect(emitSpy).toHaveBeenCalledWith('editorUiConnected', pushRef);
-					});
-
-					test('should handle multiple Forwarded entries (use first)', () => {
-						req.headers.forwarded = `proto=https;host=${host}, proto=http;host=other.com`;
-						req.headers.origin = `https://${host}`;
-
-						const emitSpy = jest.spyOn(push, 'emit');
-						const connection = backendName === 'sse' ? { req, res } : ws;
-
-						push.handleRequest(req, res);
-
-						expect(backend.add).toHaveBeenCalledWith(pushRef, user.id, connection);
-						expect(emitSpy).toHaveBeenCalledWith('editorUiConnected', pushRef);
-					});
-
-					test('should handle comma-separated X-Forwarded-Proto (use first)', () => {
-						req.headers['x-forwarded-host'] = host;
-						req.headers['x-forwarded-proto'] = 'https, http';
-						req.headers.origin = `https://${host}`;
-
-						const emitSpy = jest.spyOn(push, 'emit');
-						const connection = backendName === 'sse' ? { req, res } : ws;
-
-						push.handleRequest(req, res);
-
-						expect(backend.add).toHaveBeenCalledWith(pushRef, user.id, connection);
-						expect(emitSpy).toHaveBeenCalledWith('editorUiConnected', pushRef);
-					});
-
-					test('should normalize default ports in Forwarded header', () => {
-						req.headers.forwarded = `proto=https;host=${host}:443`;
-						req.headers.origin = `https://${host}`;
-
-						const emitSpy = jest.spyOn(push, 'emit');
-						const connection = backendName === 'sse' ? { req, res } : ws;
-
-						push.handleRequest(req, res);
-
-						expect(backend.add).toHaveBeenCalledWith(pushRef, user.id, connection);
-						expect(emitSpy).toHaveBeenCalledWith('editorUiConnected', pushRef);
-					});
-
-					test('should reject mismatched host in Forwarded header', () => {
-						req.headers.forwarded = 'proto=https;host=wrong-host.com';
-						req.headers.origin = `https://${host}`;
-
-						if (backendName === 'sse') {
-							expect(() => push.handleRequest(req, res)).toThrow(
-								new BadRequestError('Invalid origin!'),
-							);
-						} else {
-							push.handleRequest(req, res);
-							expect(ws.send).toHaveBeenCalledWith('Invalid origin!');
-							expect(ws.close).toHaveBeenCalledWith(1008);
-						}
-						expect(backend.add).not.toHaveBeenCalled();
-					});
-
-					test('should allow invalid protocol in Forwarded header if host matches', () => {
-						req.headers.forwarded = `proto=ftp;host=${host}`;
-						req.headers.origin = `https://${host}`;
-
-						const emitSpy = jest.spyOn(push, 'emit');
-						const connection = backendName === 'sse' ? { req, res } : ws;
-
-						push.handleRequest(req, res);
-
-						expect(backend.add).toHaveBeenCalledWith(pushRef, user.id, connection);
-						expect(emitSpy).toHaveBeenCalledWith('editorUiConnected', pushRef);
-					});
+					expect(backend.add).toHaveBeenCalledWith(pushRef, user.id, connection);
+					expect(emitSpy).toHaveBeenCalledWith('editorUiConnected', pushRef);
 				});
 
-				describe('Array header parsing', () => {
-					test('should handle X-Forwarded-Host as array', () => {
-						req.headers['x-forwarded-host'] = [`${host}:443`, 'backup.example.com'];
-						req.headers.origin = `https://${host}`;
+				test('should normalize default ports in Forwarded header', () => {
+					req.headers.forwarded = `proto=https;host=${host}:443`;
+					req.headers.origin = `https://${host}`;
 
-						const emitSpy = jest.spyOn(push, 'emit');
-						const connection = backendName === 'sse' ? { req, res } : ws;
+					const emitSpy = jest.spyOn(push, 'emit');
+					const connection = backendName === 'sse' ? { req, res } : ws;
 
-						push.handleRequest(req, res);
+					push.handleRequest(req, res);
 
-						expect(backend.add).toHaveBeenCalledWith(pushRef, user.id, connection);
-						expect(emitSpy).toHaveBeenCalledWith('editorUiConnected', pushRef);
-					});
-
-					test('should handle X-Forwarded-Proto as array', () => {
-						req.headers['x-forwarded-host'] = host;
-						req.headers['x-forwarded-proto'] = ['https', 'http'];
-						req.headers.origin = `https://${host}`;
-
-						const emitSpy = jest.spyOn(push, 'emit');
-						const connection = backendName === 'sse' ? { req, res } : ws;
-
-						push.handleRequest(req, res);
-
-						expect(backend.add).toHaveBeenCalledWith(pushRef, user.id, connection);
-						expect(emitSpy).toHaveBeenCalledWith('editorUiConnected', pushRef);
-					});
+					expect(backend.add).toHaveBeenCalledWith(pushRef, user.id, connection);
+					expect(emitSpy).toHaveBeenCalledWith('editorUiConnected', pushRef);
 				});
 
-				describe('Protocol validation', () => {
-					test('should reject invalid protocol in Forwarded header', () => {
-						// Invalid protocol should fallback to origin protocol
-						req.headers.forwarded = `proto=ftp;host=${host}`;
-						req.headers.origin = `https://${host}`;
+				test('should handle IPv6 addresses correctly', () => {
+					req.headers.origin = 'https://[::1]:443';
+					req.headers['x-forwarded-host'] = '[::1]:443';
 
-						const emitSpy = jest.spyOn(push, 'emit');
-						const connection = backendName === 'sse' ? { req, res } : ws;
+					const emitSpy = jest.spyOn(push, 'emit');
+					const connection = backendName === 'sse' ? { req, res } : ws;
 
-						push.handleRequest(req, res);
+					push.handleRequest(req, res);
 
-						expect(backend.add).toHaveBeenCalledWith(pushRef, user.id, connection);
-						expect(emitSpy).toHaveBeenCalledWith('editorUiConnected', pushRef);
-					});
-
-					test('should reject invalid protocol in X-Forwarded-Proto header', () => {
-						// Invalid protocol should fallback to origin protocol
-						req.headers['x-forwarded-host'] = host;
-						req.headers['x-forwarded-proto'] = 'websocket';
-						req.headers.origin = `https://${host}`;
-
-						const emitSpy = jest.spyOn(push, 'emit');
-						const connection = backendName === 'sse' ? { req, res } : ws;
-
-						push.handleRequest(req, res);
-
-						expect(backend.add).toHaveBeenCalledWith(pushRef, user.id, connection);
-						expect(emitSpy).toHaveBeenCalledWith('editorUiConnected', pushRef);
-					});
-
-					test('should handle comma-separated X-Forwarded-Proto with invalid first value', () => {
-						req.headers['x-forwarded-host'] = host;
-						req.headers['x-forwarded-proto'] = 'ftp,https';
-						req.headers.origin = `https://${host}`;
-
-						const emitSpy = jest.spyOn(push, 'emit');
-						const connection = backendName === 'sse' ? { req, res } : ws;
-
-						push.handleRequest(req, res);
-
-						expect(backend.add).toHaveBeenCalledWith(pushRef, user.id, connection);
-						expect(emitSpy).toHaveBeenCalledWith('editorUiConnected', pushRef);
-					});
-				});
-			});
-
-			describe('parseForwardedHeader method', () => {
-				test('should parse simple forwarded header', () => {
-					// @ts-expect-error accessing private method for testing
-					const result = push.parseForwardedHeader('proto=https;host=example.com');
-					expect(result).toEqual({ proto: 'https', host: 'example.com' });
-				});
-
-				test('should parse forwarded header with quoted values', () => {
-					// @ts-expect-error accessing private method for testing
-					const result = push.parseForwardedHeader('proto="https";host="example.com"');
-					expect(result).toEqual({ proto: 'https', host: 'example.com' });
-				});
-
-				test('should parse forwarded header with single quotes', () => {
-					// @ts-expect-error accessing private method for testing
-					const result = push.parseForwardedHeader("proto='https';host='example.com'");
-					expect(result).toEqual({ proto: 'https', host: 'example.com' });
-				});
-
-				test('should handle multiple entries (use first)', () => {
-					// @ts-expect-error accessing private method for testing
-					const result = push.parseForwardedHeader(
-						'proto=https;host=example.com, proto=http;host=other.com',
-					);
-					expect(result).toEqual({ proto: 'https', host: 'example.com' });
-				});
-
-				test('should handle spaces around values', () => {
-					// @ts-expect-error accessing private method for testing
-					const result = push.parseForwardedHeader('  proto = https ; host = example.com  ');
-					expect(result).toEqual({ proto: 'https', host: 'example.com' });
-				});
-
-				test('should ignore unknown parameters', () => {
-					// @ts-expect-error accessing private method for testing
-					const result = push.parseForwardedHeader(
-						'for=192.0.2.60;proto=https;host=example.com;by=proxy.com',
-					);
-					expect(result).toEqual({ proto: 'https', host: 'example.com' });
-				});
-
-				test('should return null for invalid header', () => {
-					// @ts-expect-error accessing private method for testing
-					expect(push.parseForwardedHeader('')).toBeNull();
-					// @ts-expect-error accessing private method for testing
-					expect(push.parseForwardedHeader('invalid')).toEqual({});
-				});
-
-				test('should return null for non-string input', () => {
-					// @ts-expect-error accessing private method for testing
-					expect(push.parseForwardedHeader(null as any)).toBeNull();
-					// @ts-expect-error accessing private method for testing
-					expect(push.parseForwardedHeader(undefined as any)).toBeNull();
-				});
-
-				test('should handle partial parameters', () => {
-					// @ts-expect-error accessing private method for testing
-					expect(push.parseForwardedHeader('proto=https')).toEqual({ proto: 'https' });
-					// @ts-expect-error accessing private method for testing
-					expect(push.parseForwardedHeader('host=example.com')).toEqual({ host: 'example.com' });
-				});
-			});
-
-			describe('getFirstHeaderValue method', () => {
-				test('should return string as-is', () => {
-					// @ts-expect-error accessing private method for testing
-					expect(push.getFirstHeaderValue('test')).toBe('test');
-				});
-
-				test('should return first element from array', () => {
-					// @ts-expect-error accessing private method for testing
-					expect(push.getFirstHeaderValue(['first', 'second'])).toBe('first');
-				});
-
-				test('should return undefined for undefined input', () => {
-					// @ts-expect-error accessing private method for testing
-					expect(push.getFirstHeaderValue(undefined)).toBe(undefined);
-				});
-
-				test('should return undefined for empty array', () => {
-					// @ts-expect-error accessing private method for testing
-					expect(push.getFirstHeaderValue([])).toBe(undefined);
-				});
-			});
-
-			describe('stripIPv6Brackets method', () => {
-				test('should strip brackets from IPv6 addresses', () => {
-					// @ts-expect-error accessing private method for testing
-					expect(push.stripIPv6Brackets('[::1]')).toBe('::1');
-					// @ts-expect-error accessing private method for testing
-					expect(push.stripIPv6Brackets('[2001:db8::1]')).toBe('2001:db8::1');
-				});
-
-				test('should strip brackets from IPv6 addresses with ports', () => {
-					// @ts-expect-error accessing private method for testing
-					expect(push.stripIPv6Brackets('[::1]:8080')).toBe('::1:8080');
-					// @ts-expect-error accessing private method for testing
-					expect(push.stripIPv6Brackets('[2001:db8::1]:443')).toBe('2001:db8::1:443');
-				});
-
-				test('should leave non-bracketed strings unchanged', () => {
-					// @ts-expect-error accessing private method for testing
-					expect(push.stripIPv6Brackets('example.com')).toBe('example.com');
-					// @ts-expect-error accessing private method for testing
-					expect(push.stripIPv6Brackets('192.168.1.1')).toBe('192.168.1.1');
-					// @ts-expect-error accessing private method for testing
-					expect(push.stripIPv6Brackets('::1')).toBe('::1');
-					// @ts-expect-error accessing private method for testing
-					expect(push.stripIPv6Brackets('example.com:8080')).toBe('example.com:8080');
-				});
-
-				test('should handle partial brackets', () => {
-					// @ts-expect-error accessing private method for testing
-					expect(push.stripIPv6Brackets('[incomplete')).toBe('[incomplete');
-					// @ts-expect-error accessing private method for testing
-					expect(push.stripIPv6Brackets('incomplete]')).toBe('incomplete]');
-				});
-			});
-
-			describe('validateProtocol method', () => {
-				test('should return http for valid http', () => {
-					// @ts-expect-error accessing private method for testing
-					expect(push.validateProtocol('http')).toBe('http');
-					// @ts-expect-error accessing private method for testing
-					expect(push.validateProtocol('HTTP')).toBe('http');
-					// @ts-expect-error accessing private method for testing
-					expect(push.validateProtocol('  http  ')).toBe('http');
-				});
-
-				test('should return https for valid https', () => {
-					// @ts-expect-error accessing private method for testing
-					expect(push.validateProtocol('https')).toBe('https');
-					// @ts-expect-error accessing private method for testing
-					expect(push.validateProtocol('HTTPS')).toBe('https');
-					// @ts-expect-error accessing private method for testing
-					expect(push.validateProtocol('  https  ')).toBe('https');
-				});
-
-				test('should return undefined for invalid protocols', () => {
-					// @ts-expect-error accessing private method for testing
-					expect(push.validateProtocol('ftp')).toBe(undefined);
-					// @ts-expect-error accessing private method for testing
-					expect(push.validateProtocol('websocket')).toBe(undefined);
-					// @ts-expect-error accessing private method for testing
-					expect(push.validateProtocol('')).toBe(undefined);
-					// @ts-expect-error accessing private method for testing
-					expect(push.validateProtocol(undefined)).toBe(undefined);
+					expect(backend.add).toHaveBeenCalledWith(pushRef, user.id, connection);
+					expect(emitSpy).toHaveBeenCalledWith('editorUiConnected', pushRef);
 				});
 			});
 		});

--- a/packages/cli/src/push/__tests__/index.test.ts
+++ b/packages/cli/src/push/__tests__/index.test.ts
@@ -42,6 +42,187 @@ describe('Push', () => {
 		logger.scoped.mockReturnValue(logger);
 	});
 
+	describe('normalizeHost', () => {
+		beforeEach(() => {
+			config.backend = 'sse';
+			push = new Push(config, mock(), logger, mock(), mock());
+		});
+
+		test('should return original host if empty', () => {
+			// @ts-expect-error accessing private method for testing
+			expect(push.normalizeHost('', 'https')).toBe('');
+			// @ts-expect-error accessing private method for testing
+			expect(push.normalizeHost('', 'http')).toBe('');
+		});
+
+		test('should normalize HTTPS hosts by removing default port 443', () => {
+			// @ts-expect-error accessing private method for testing
+			expect(push.normalizeHost('example.com:443', 'https')).toBe('example.com');
+			// @ts-expect-error accessing private method for testing
+			expect(push.normalizeHost('example.com', 'https')).toBe('example.com');
+		});
+
+		test('should normalize HTTP hosts by removing default port 80', () => {
+			// @ts-expect-error accessing private method for testing
+			expect(push.normalizeHost('example.com:80', 'http')).toBe('example.com');
+			// @ts-expect-error accessing private method for testing
+			expect(push.normalizeHost('example.com', 'http')).toBe('example.com');
+		});
+
+		test('should preserve non-default ports', () => {
+			// @ts-expect-error accessing private method for testing
+			expect(push.normalizeHost('example.com:8080', 'https')).toBe('example.com:8080');
+			// @ts-expect-error accessing private method for testing
+			expect(push.normalizeHost('example.com:3000', 'http')).toBe('example.com:3000');
+		});
+
+		test('should handle IPv6 hosts correctly', () => {
+			// IPv6 hosts are returned with brackets by the URL constructor when port is removed
+			// @ts-expect-error accessing private method for testing
+			expect(push.normalizeHost('[::1]:443', 'https')).toBe('[::1]');
+			// @ts-expect-error accessing private method for testing
+			expect(push.normalizeHost('[::1]:80', 'http')).toBe('[::1]');
+			// Non-default ports preserve the full format
+			// @ts-expect-error accessing private method for testing
+			expect(push.normalizeHost('[::1]:8080', 'https')).toBe('[::1]:8080');
+		});
+
+		test('should handle complex domain names', () => {
+			// @ts-expect-error accessing private method for testing
+			expect(push.normalizeHost('sub.domain.example-site.com:443', 'https')).toBe(
+				'sub.domain.example-site.com',
+			);
+			// @ts-expect-error accessing private method for testing
+			expect(push.normalizeHost('test-server.local:3000', 'http')).toBe('test-server.local:3000');
+		});
+
+		test('should fallback to original host on invalid URL', () => {
+			// Invalid host formats that would cause URL constructor to throw
+			// @ts-expect-error accessing private method for testing
+			expect(push.normalizeHost('invalid[host', 'https')).toBe('invalid[host');
+			// @ts-expect-error accessing private method for testing
+			expect(push.normalizeHost('://malformed', 'http')).toBe('://malformed');
+			// @ts-expect-error accessing private method for testing
+			expect(push.normalizeHost('space host.com', 'https')).toBe('space host.com');
+		});
+	});
+
+	describe('parseOrigin', () => {
+		beforeEach(() => {
+			config.backend = 'sse';
+			push = new Push(config, mock(), logger, mock(), mock());
+		});
+
+		test('should return null for invalid origins', () => {
+			// @ts-expect-error accessing private method for testing
+			expect(push.parseOrigin('')).toBeNull();
+			// @ts-expect-error accessing private method for testing
+			expect(push.parseOrigin(null as any)).toBeNull();
+			// @ts-expect-error accessing private method for testing
+			expect(push.parseOrigin(undefined as any)).toBeNull();
+			// @ts-expect-error accessing private method for testing
+			expect(push.parseOrigin(123 as any)).toBeNull();
+		});
+
+		test('should return null for non-HTTP/HTTPS protocols', () => {
+			// @ts-expect-error accessing private method for testing
+			expect(push.parseOrigin('ftp://example.com')).toBeNull();
+			// @ts-expect-error accessing private method for testing
+			expect(push.parseOrigin('ws://example.com')).toBeNull();
+			// @ts-expect-error accessing private method for testing
+			expect(push.parseOrigin('file://example.com')).toBeNull();
+			// @ts-expect-error accessing private method for testing
+			expect(push.parseOrigin('chrome-extension://example.com')).toBeNull();
+		});
+
+		test('should return null for malformed URLs', () => {
+			// @ts-expect-error accessing private method for testing
+			expect(push.parseOrigin('not-a-url')).toBeNull();
+			// @ts-expect-error accessing private method for testing
+			expect(push.parseOrigin('://malformed')).toBeNull();
+			// @ts-expect-error accessing private method for testing
+			expect(push.parseOrigin('https://')).toBeNull();
+			// @ts-expect-error accessing private method for testing
+			expect(push.parseOrigin('https://[invalid')).toBeNull();
+		});
+
+		test('should parse valid HTTP origins', () => {
+			// @ts-expect-error accessing private method for testing
+			const result = push.parseOrigin('http://example.com');
+			expect(result).toEqual({
+				protocol: 'http',
+				host: 'example.com',
+			});
+		});
+
+		test('should parse valid HTTPS origins', () => {
+			// @ts-expect-error accessing private method for testing
+			const result = push.parseOrigin('https://example.com');
+			expect(result).toEqual({
+				protocol: 'https',
+				host: 'example.com',
+			});
+		});
+
+		test('should normalize ports in origins', () => {
+			// Default ports should be removed
+			// @ts-expect-error accessing private method for testing
+			expect(push.parseOrigin('https://example.com:443')).toEqual({
+				protocol: 'https',
+				host: 'example.com',
+			});
+
+			// @ts-expect-error accessing private method for testing
+			expect(push.parseOrigin('http://example.com:80')).toEqual({
+				protocol: 'http',
+				host: 'example.com',
+			});
+
+			// Non-default ports should be preserved
+			// @ts-expect-error accessing private method for testing
+			expect(push.parseOrigin('https://example.com:8080')).toEqual({
+				protocol: 'https',
+				host: 'example.com:8080',
+			});
+
+			// @ts-expect-error accessing private method for testing
+			expect(push.parseOrigin('http://example.com:3000')).toEqual({
+				protocol: 'http',
+				host: 'example.com:3000',
+			});
+		});
+
+		test('should handle IPv6 origins', () => {
+			// IPv6 with default port: hostname should remove brackets but host keeps them
+			// @ts-expect-error accessing private method for testing
+			expect(push.parseOrigin('https://[::1]:443')).toEqual({
+				protocol: 'https',
+				host: '[::1]',
+			});
+
+			// IPv6 with non-default port: should preserve format
+			// @ts-expect-error accessing private method for testing
+			expect(push.parseOrigin('http://[2001:db8::1]:8080')).toEqual({
+				protocol: 'http',
+				host: '[2001:db8::1]:8080',
+			});
+		});
+
+		test('should handle mixed case protocols', () => {
+			// @ts-expect-error accessing private method for testing
+			expect(push.parseOrigin('HTTPS://example.com')).toEqual({
+				protocol: 'https',
+				host: 'example.com',
+			});
+
+			// @ts-expect-error accessing private method for testing
+			expect(push.parseOrigin('Http://example.com')).toEqual({
+				protocol: 'http',
+				host: 'example.com',
+			});
+		});
+	});
+
 	describe('setupPushServer', () => {
 		const restEndpoint = 'rest';
 		const app = mock<Application>();
@@ -324,6 +505,205 @@ describe('Push', () => {
 					expect(backend.add).not.toHaveBeenCalled();
 				});
 			}
+		});
+
+		describe('additional edge cases', () => {
+			describe.each(backendNames)('%s backend - additional cases', (backendName) => {
+				const backend = backendName === 'sse' ? sseBackend : wsBackend;
+
+				beforeEach(() => {
+					config.backend = backendName;
+					push = new Push(config, mock(), logger, mock(), mock());
+					req.ws = backendName === 'sse' ? undefined : ws;
+
+					// Reset headers
+					req.headers.host = host;
+					req.headers.origin = `https://${host}`;
+					req.query = { pushRef };
+					delete req.headers['x-forwarded-host'];
+				});
+
+				test('should handle malformed origin URLs that throw during parsing', () => {
+					// Set an origin that parseOrigin will return null for
+					req.headers.origin = 'invalid-protocol://example.com';
+
+					if (backendName === 'sse') {
+						expect(() => push.handleRequest(req, res)).toThrow(
+							new BadRequestError('Invalid origin!'),
+						);
+					} else {
+						push.handleRequest(req, res);
+						expect(ws.send).toHaveBeenCalledWith('Invalid origin!');
+						expect(ws.close).toHaveBeenCalledWith(1008);
+					}
+					expect(backend.add).not.toHaveBeenCalled();
+				});
+
+				test('should allow origins with query parameters and fragments when host matches', () => {
+					// Test with an origin that has additional components but correct host
+					const queryOrigin = `https://${host}?query=param#fragment`;
+					req.headers.origin = queryOrigin;
+
+					// This should pass because the host extraction ignores query/fragment
+					const emitSpy = jest.spyOn(push, 'emit');
+					const connection = backendName === 'sse' ? { req, res } : ws;
+
+					push.handleRequest(req, res);
+
+					expect(backend.add).toHaveBeenCalledWith(pushRef, user.id, connection);
+					expect(emitSpy).toHaveBeenCalledWith('editorUiConnected', pushRef);
+				});
+
+				test('should allow origin with path component when host matches', () => {
+					// Origins with path components should be parsed correctly
+					const pathOrigin = `https://${host}/path`;
+					req.headers.origin = pathOrigin;
+
+					// This should pass because the host extraction ignores the path
+					const emitSpy = jest.spyOn(push, 'emit');
+					const connection = backendName === 'sse' ? { req, res } : ws;
+
+					push.handleRequest(req, res);
+
+					expect(backend.add).toHaveBeenCalledWith(pushRef, user.id, connection);
+					expect(emitSpy).toHaveBeenCalledWith('editorUiConnected', pushRef);
+				});
+
+				test('should handle numeric IP addresses correctly', () => {
+					const ipHost = '192.168.1.100';
+					req.headers.host = `${ipHost}:3000`;
+					req.headers.origin = `https://${ipHost}:3000`;
+
+					const emitSpy = jest.spyOn(push, 'emit');
+					const connection = backendName === 'sse' ? { req, res } : ws;
+
+					push.handleRequest(req, res);
+
+					expect(backend.add).toHaveBeenCalledWith(pushRef, user.id, connection);
+					expect(emitSpy).toHaveBeenCalledWith('editorUiConnected', pushRef);
+				});
+
+				test('should handle localhost correctly', () => {
+					const localhostHost = 'localhost:8080';
+					req.headers.host = localhostHost;
+					req.headers.origin = `http://${localhostHost}`;
+
+					const emitSpy = jest.spyOn(push, 'emit');
+					const connection = backendName === 'sse' ? { req, res } : ws;
+
+					push.handleRequest(req, res);
+
+					expect(backend.add).toHaveBeenCalledWith(pushRef, user.id, connection);
+					expect(emitSpy).toHaveBeenCalledWith('editorUiConnected', pushRef);
+				});
+			});
+		});
+
+		describe('edge cases in handleRequest', () => {
+			describe.each(backendNames)('%s backend - edge cases', (backendName) => {
+				const backend = backendName === 'sse' ? sseBackend : wsBackend;
+
+				beforeEach(() => {
+					config.backend = backendName;
+					push = new Push(config, mock(), logger, mock(), mock());
+					req.ws = backendName === 'sse' ? undefined : ws;
+
+					// Reset headers
+					req.headers.host = host;
+					req.headers.origin = `https://${host}`;
+					req.query = { pushRef };
+					delete req.headers['x-forwarded-host'];
+				});
+
+				test('should handle missing pushRef query parameter', () => {
+					req.query = { pushRef: '' };
+
+					if (backendName === 'sse') {
+						expect(() => push.handleRequest(req, res)).toThrow(
+							new BadRequestError('The query parameter "pushRef" is missing!'),
+						);
+					} else {
+						push.handleRequest(req, res);
+						expect(ws.send).toHaveBeenCalledWith('The query parameter "pushRef" is missing!');
+						expect(ws.close).toHaveBeenCalledWith(1008);
+					}
+					expect(backend.add).not.toHaveBeenCalled();
+				});
+
+				test('should handle null pushRef', () => {
+					req.query = { pushRef: null as any };
+
+					if (backendName === 'sse') {
+						expect(() => push.handleRequest(req, res)).toThrow(
+							new BadRequestError('The query parameter "pushRef" is missing!'),
+						);
+					} else {
+						push.handleRequest(req, res);
+						expect(ws.send).toHaveBeenCalledWith('The query parameter "pushRef" is missing!');
+						expect(ws.close).toHaveBeenCalledWith(1008);
+					}
+					expect(backend.add).not.toHaveBeenCalled();
+				});
+
+				test('should handle missing origin header completely', () => {
+					delete req.headers.origin;
+
+					if (backendName === 'sse') {
+						expect(() => push.handleRequest(req, res)).toThrow(
+							new BadRequestError('Invalid origin!'),
+						);
+					} else {
+						push.handleRequest(req, res);
+						expect(ws.send).toHaveBeenCalledWith('Invalid origin!');
+						expect(ws.close).toHaveBeenCalledWith(1008);
+					}
+					expect(backend.add).not.toHaveBeenCalled();
+				});
+
+				test('should handle empty string origin header', () => {
+					req.headers.origin = '';
+
+					if (backendName === 'sse') {
+						expect(() => push.handleRequest(req, res)).toThrow(
+							new BadRequestError('Invalid origin!'),
+						);
+					} else {
+						push.handleRequest(req, res);
+						expect(ws.send).toHaveBeenCalledWith('Invalid origin!');
+						expect(ws.close).toHaveBeenCalledWith(1008);
+					}
+					expect(backend.add).not.toHaveBeenCalled();
+				});
+
+				test('should handle missing host header when no x-forwarded-host', () => {
+					delete req.headers.host;
+					req.headers.origin = `https://${host}`;
+
+					if (backendName === 'sse') {
+						expect(() => push.handleRequest(req, res)).toThrow(
+							new BadRequestError('Invalid origin!'),
+						);
+					} else {
+						push.handleRequest(req, res);
+						expect(ws.send).toHaveBeenCalledWith('Invalid origin!');
+						expect(ws.close).toHaveBeenCalledWith(1008);
+					}
+					expect(backend.add).not.toHaveBeenCalled();
+				});
+
+				test('should handle array x-forwarded-host header (use first)', () => {
+					req.headers['x-forwarded-host'] = [host, 'other-host.com'] as any;
+					req.headers.origin = `https://${host}`;
+
+					const emitSpy = jest.spyOn(push, 'emit');
+					const connection = backendName === 'sse' ? { req, res } : ws;
+
+					push.handleRequest(req, res);
+
+					expect(backend.add).toHaveBeenCalledWith(pushRef, user.id, connection);
+					expect(emitSpy).toHaveBeenCalledWith('editorUiConnected', pushRef);
+				});
+			});
 		});
 	});
 });

--- a/packages/cli/src/push/__tests__/origin-validator.test.ts
+++ b/packages/cli/src/push/__tests__/origin-validator.test.ts
@@ -1,0 +1,379 @@
+import {
+	validateOriginHeaders,
+	normalizeHost,
+	parseOrigin,
+	parseForwardedHeader,
+	getFirstHeaderValue,
+	stripIPv6Brackets,
+	validateProtocol,
+} from '../origin-validator';
+
+describe('origin-validator', () => {
+	describe('normalizeHost', () => {
+		test('should return original host if empty', () => {
+			expect(normalizeHost('', 'https')).toBe('');
+			expect(normalizeHost('', 'http')).toBe('');
+		});
+
+		test('should normalize HTTPS hosts by removing default port 443', () => {
+			expect(normalizeHost('example.com:443', 'https')).toBe('example.com');
+			expect(normalizeHost('example.com', 'https')).toBe('example.com');
+		});
+
+		test('should normalize HTTP hosts by removing default port 80', () => {
+			expect(normalizeHost('example.com:80', 'http')).toBe('example.com');
+			expect(normalizeHost('example.com', 'http')).toBe('example.com');
+		});
+
+		test('should preserve non-default ports', () => {
+			expect(normalizeHost('example.com:8080', 'https')).toBe('example.com:8080');
+			expect(normalizeHost('example.com:3000', 'http')).toBe('example.com:3000');
+		});
+
+		test('should handle IPv6 hosts correctly', () => {
+			// IPv6 hosts should have brackets stripped for consistency
+			expect(normalizeHost('[::1]:443', 'https')).toBe('::1');
+			expect(normalizeHost('[::1]:80', 'http')).toBe('::1');
+			// Non-default ports preserve the full format but strip brackets
+			expect(normalizeHost('[::1]:8080', 'https')).toBe('::1:8080');
+		});
+
+		test('should handle complex domain names', () => {
+			expect(normalizeHost('sub.domain.example-site.com:443', 'https')).toBe(
+				'sub.domain.example-site.com',
+			);
+			expect(normalizeHost('test-server.local:3000', 'http')).toBe('test-server.local:3000');
+		});
+
+		test('should fallback to original host on invalid URL', () => {
+			// Invalid host formats that would cause URL constructor to throw
+			expect(normalizeHost('invalid[host', 'https')).toBe('invalid[host');
+			expect(normalizeHost('://malformed', 'http')).toBe('://malformed');
+			expect(normalizeHost('space host.com', 'https')).toBe('space host.com');
+		});
+	});
+
+	describe('parseOrigin', () => {
+		test('should return null for invalid origins', () => {
+			expect(parseOrigin('')).toBeNull();
+			expect(parseOrigin(null as any)).toBeNull();
+			expect(parseOrigin(undefined as any)).toBeNull();
+			expect(parseOrigin(123 as any)).toBeNull();
+		});
+
+		test('should return null for non-HTTP/HTTPS protocols', () => {
+			expect(parseOrigin('ftp://example.com')).toBeNull();
+			expect(parseOrigin('ws://example.com')).toBeNull();
+			expect(parseOrigin('file://example.com')).toBeNull();
+			expect(parseOrigin('chrome-extension://example.com')).toBeNull();
+		});
+
+		test('should return null for malformed URLs', () => {
+			expect(parseOrigin('not-a-url')).toBeNull();
+			expect(parseOrigin('://malformed')).toBeNull();
+			expect(parseOrigin('https://')).toBeNull();
+			expect(parseOrigin('https://[invalid')).toBeNull();
+		});
+
+		test('should parse valid HTTP origins', () => {
+			const result = parseOrigin('http://example.com');
+			expect(result).toEqual({
+				protocol: 'http',
+				host: 'example.com',
+			});
+		});
+
+		test('should parse valid HTTPS origins', () => {
+			const result = parseOrigin('https://example.com');
+			expect(result).toEqual({
+				protocol: 'https',
+				host: 'example.com',
+			});
+		});
+
+		test('should normalize ports in origins', () => {
+			// Default ports should be removed
+			expect(parseOrigin('https://example.com:443')).toEqual({
+				protocol: 'https',
+				host: 'example.com',
+			});
+
+			expect(parseOrigin('http://example.com:80')).toEqual({
+				protocol: 'http',
+				host: 'example.com',
+			});
+
+			// Non-default ports should be preserved
+			expect(parseOrigin('https://example.com:8080')).toEqual({
+				protocol: 'https',
+				host: 'example.com:8080',
+			});
+
+			expect(parseOrigin('http://example.com:3000')).toEqual({
+				protocol: 'http',
+				host: 'example.com:3000',
+			});
+		});
+
+		test('should handle IPv6 origins', () => {
+			// IPv6 with default port: brackets should be stripped for consistency
+			expect(parseOrigin('https://[::1]:443')).toEqual({
+				protocol: 'https',
+				host: '::1',
+			});
+
+			// IPv6 with non-default port: brackets should be stripped but port preserved
+			expect(parseOrigin('http://[2001:db8::1]:8080')).toEqual({
+				protocol: 'http',
+				host: '2001:db8::1:8080',
+			});
+		});
+
+		test('should handle mixed case protocols', () => {
+			expect(parseOrigin('HTTPS://example.com')).toEqual({
+				protocol: 'https',
+				host: 'example.com',
+			});
+
+			expect(parseOrigin('Http://example.com')).toEqual({
+				protocol: 'http',
+				host: 'example.com',
+			});
+		});
+	});
+
+	describe('parseForwardedHeader', () => {
+		test('should parse simple forwarded header', () => {
+			const result = parseForwardedHeader('proto=https;host=example.com');
+			expect(result).toEqual({ proto: 'https', host: 'example.com' });
+		});
+
+		test('should parse forwarded header with quoted values', () => {
+			const result = parseForwardedHeader('proto="https";host="example.com"');
+			expect(result).toEqual({ proto: 'https', host: 'example.com' });
+		});
+
+		test('should parse forwarded header with single quotes', () => {
+			const result = parseForwardedHeader("proto='https';host='example.com'");
+			expect(result).toEqual({ proto: 'https', host: 'example.com' });
+		});
+
+		test('should handle multiple entries (use first)', () => {
+			const result = parseForwardedHeader(
+				'proto=https;host=example.com, proto=http;host=other.com',
+			);
+			expect(result).toEqual({ proto: 'https', host: 'example.com' });
+		});
+
+		test('should handle spaces around values', () => {
+			const result = parseForwardedHeader('  proto = https ; host = example.com  ');
+			expect(result).toEqual({ proto: 'https', host: 'example.com' });
+		});
+
+		test('should ignore unknown parameters', () => {
+			const result = parseForwardedHeader(
+				'for=192.0.2.60;proto=https;host=example.com;by=proxy.com',
+			);
+			expect(result).toEqual({ proto: 'https', host: 'example.com' });
+		});
+
+		test('should return null for invalid header', () => {
+			expect(parseForwardedHeader('')).toBeNull();
+			expect(parseForwardedHeader('invalid')).toEqual({});
+		});
+
+		test('should return null for non-string input', () => {
+			expect(parseForwardedHeader(null as any)).toBeNull();
+			expect(parseForwardedHeader(undefined as any)).toBeNull();
+		});
+
+		test('should handle partial parameters', () => {
+			expect(parseForwardedHeader('proto=https')).toEqual({ proto: 'https' });
+			expect(parseForwardedHeader('host=example.com')).toEqual({ host: 'example.com' });
+		});
+	});
+
+	describe('getFirstHeaderValue', () => {
+		test('should return string as-is', () => {
+			expect(getFirstHeaderValue('test')).toBe('test');
+		});
+
+		test('should return first element from array', () => {
+			expect(getFirstHeaderValue(['first', 'second'])).toBe('first');
+		});
+
+		test('should return undefined for undefined input', () => {
+			expect(getFirstHeaderValue(undefined)).toBe(undefined);
+		});
+
+		test('should return undefined for empty array', () => {
+			expect(getFirstHeaderValue([])).toBe(undefined);
+		});
+	});
+
+	describe('stripIPv6Brackets', () => {
+		test('should strip brackets from IPv6 addresses', () => {
+			expect(stripIPv6Brackets('[::1]')).toBe('::1');
+			expect(stripIPv6Brackets('[2001:db8::1]')).toBe('2001:db8::1');
+		});
+
+		test('should strip brackets from IPv6 addresses with ports', () => {
+			expect(stripIPv6Brackets('[::1]:8080')).toBe('::1:8080');
+			expect(stripIPv6Brackets('[2001:db8::1]:443')).toBe('2001:db8::1:443');
+		});
+
+		test('should leave non-bracketed strings unchanged', () => {
+			expect(stripIPv6Brackets('example.com')).toBe('example.com');
+			expect(stripIPv6Brackets('192.168.1.1')).toBe('192.168.1.1');
+			expect(stripIPv6Brackets('::1')).toBe('::1');
+			expect(stripIPv6Brackets('example.com:8080')).toBe('example.com:8080');
+		});
+
+		test('should handle partial brackets', () => {
+			expect(stripIPv6Brackets('[incomplete')).toBe('[incomplete');
+			expect(stripIPv6Brackets('incomplete]')).toBe('incomplete]');
+		});
+	});
+
+	describe('validateProtocol', () => {
+		test('should return http for valid http', () => {
+			expect(validateProtocol('http')).toBe('http');
+			expect(validateProtocol('HTTP')).toBe('http');
+			expect(validateProtocol('  http  ')).toBe('http');
+		});
+
+		test('should return https for valid https', () => {
+			expect(validateProtocol('https')).toBe('https');
+			expect(validateProtocol('HTTPS')).toBe('https');
+			expect(validateProtocol('  https  ')).toBe('https');
+		});
+
+		test('should return undefined for invalid protocols', () => {
+			expect(validateProtocol('ftp')).toBe(undefined);
+			expect(validateProtocol('websocket')).toBe(undefined);
+			expect(validateProtocol('')).toBe(undefined);
+			expect(validateProtocol(undefined)).toBe(undefined);
+		});
+	});
+
+	describe('validateOriginHeaders', () => {
+		const host = 'example.com';
+
+		test('should return invalid for missing origin', () => {
+			const result = validateOriginHeaders({});
+			expect(result.isValid).toBe(false);
+			expect(result.error).toBe('Origin header is missing or malformed');
+		});
+
+		test('should return invalid for malformed origin', () => {
+			const result = validateOriginHeaders({ origin: 'invalid-origin' });
+			expect(result.isValid).toBe(false);
+			expect(result.error).toBe('Origin header is missing or malformed');
+		});
+
+		test('should validate matching hosts with host header', () => {
+			const result = validateOriginHeaders({
+				origin: `https://${host}`,
+				host,
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.originInfo).toEqual({ protocol: 'https', host });
+			expect(result.expectedHost).toBe(host);
+			expect(result.expectedProtocol).toBe('https');
+		});
+
+		test('should validate matching hosts with x-forwarded-host header', () => {
+			const result = validateOriginHeaders({
+				origin: `https://${host}`,
+				'x-forwarded-host': host,
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.expectedHost).toBe(host);
+		});
+
+		test('should handle default port normalization with x-forwarded-host', () => {
+			const result = validateOriginHeaders({
+				origin: `https://${host}`,
+				'x-forwarded-host': `${host}:443`,
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.expectedHost).toBe(host);
+		});
+
+		test('should handle non-default ports', () => {
+			const result = validateOriginHeaders({
+				origin: `https://${host}:8080`,
+				'x-forwarded-host': `${host}:8080`,
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.expectedHost).toBe(`${host}:8080`);
+		});
+
+		test('should reject mismatched hosts', () => {
+			const result = validateOriginHeaders({
+				origin: `https://${host}`,
+				'x-forwarded-host': 'wrong-host.com',
+			});
+			expect(result.isValid).toBe(false);
+			expect(result.error).toBe('Origin header does not match expected host');
+		});
+
+		test('should handle Forwarded header with precedence over x-forwarded-*', () => {
+			const result = validateOriginHeaders({
+				origin: `https://${host}`,
+				forwarded: `proto=https;host=${host}`,
+				'x-forwarded-host': 'wrong-host.com', // Should be ignored
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.expectedHost).toBe(host);
+		});
+
+		test('should handle Forwarded header with protocol change', () => {
+			const result = validateOriginHeaders({
+				origin: `http://${host}`,
+				forwarded: `proto=http;host=${host}:80`,
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.expectedHost).toBe(host);
+			expect(result.expectedProtocol).toBe('http');
+		});
+
+		test('should handle array headers', () => {
+			const result = validateOriginHeaders({
+				origin: `https://${host}`,
+				'x-forwarded-host': [host, 'other-host.com'],
+				'x-forwarded-proto': ['https', 'http'],
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.expectedHost).toBe(host);
+		});
+
+		test('should handle comma-separated x-forwarded-proto', () => {
+			const result = validateOriginHeaders({
+				origin: `https://${host}`,
+				'x-forwarded-host': host,
+				'x-forwarded-proto': 'https, http',
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.expectedProtocol).toBe('https');
+		});
+
+		test('should handle IPv6 addresses', () => {
+			const result = validateOriginHeaders({
+				origin: 'https://[::1]:443',
+				'x-forwarded-host': '[::1]:443',
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.expectedHost).toBe('::1');
+		});
+
+		test('should fallback protocol validation gracefully', () => {
+			const result = validateOriginHeaders({
+				origin: `https://${host}`,
+				forwarded: `proto=ftp;host=${host}`, // Invalid protocol should be ignored
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.expectedProtocol).toBe('https'); // Falls back to origin protocol
+		});
+	});
+});

--- a/packages/cli/src/push/__tests__/origin-validator.test.ts
+++ b/packages/cli/src/push/__tests__/origin-validator.test.ts
@@ -1,266 +1,17 @@
-import {
-	validateOriginHeaders,
-	normalizeHost,
-	parseOrigin,
-	parseForwardedHeader,
-	getFirstHeaderValue,
-	stripIPv6Brackets,
-	validateProtocol,
-} from '../origin-validator';
+import { validateOriginHeaders } from '../origin-validator';
 
-describe('origin-validator', () => {
-	describe('normalizeHost', () => {
-		test('should return original host if empty', () => {
-			expect(normalizeHost('', 'https')).toBe('');
-			expect(normalizeHost('', 'http')).toBe('');
-		});
+describe('validateOriginHeaders', () => {
+	const host = 'example.com';
 
-		test('should normalize HTTPS hosts by removing default port 443', () => {
-			expect(normalizeHost('example.com:443', 'https')).toBe('example.com');
-			expect(normalizeHost('example.com', 'https')).toBe('example.com');
-		});
-
-		test('should normalize HTTP hosts by removing default port 80', () => {
-			expect(normalizeHost('example.com:80', 'http')).toBe('example.com');
-			expect(normalizeHost('example.com', 'http')).toBe('example.com');
-		});
-
-		test('should preserve non-default ports', () => {
-			expect(normalizeHost('example.com:8080', 'https')).toBe('example.com:8080');
-			expect(normalizeHost('example.com:3000', 'http')).toBe('example.com:3000');
-		});
-
-		test('should handle IPv6 hosts correctly', () => {
-			// IPv6 hosts should have brackets stripped for consistency
-			expect(normalizeHost('[::1]:443', 'https')).toBe('::1');
-			expect(normalizeHost('[::1]:80', 'http')).toBe('::1');
-			// Non-default ports preserve the full format but strip brackets
-			expect(normalizeHost('[::1]:8080', 'https')).toBe('::1:8080');
-		});
-
-		test('should handle complex domain names', () => {
-			expect(normalizeHost('sub.domain.example-site.com:443', 'https')).toBe(
-				'sub.domain.example-site.com',
-			);
-			expect(normalizeHost('test-server.local:3000', 'http')).toBe('test-server.local:3000');
-		});
-
-		test('should fallback to original host on invalid URL', () => {
-			// Invalid host formats that would cause URL constructor to throw
-			expect(normalizeHost('invalid[host', 'https')).toBe('invalid[host');
-			expect(normalizeHost('://malformed', 'http')).toBe('://malformed');
-			expect(normalizeHost('space host.com', 'https')).toBe('space host.com');
-		});
-	});
-
-	describe('parseOrigin', () => {
-		test('should return null for invalid origins', () => {
-			expect(parseOrigin('')).toBeNull();
-			expect(parseOrigin(null as any)).toBeNull();
-			expect(parseOrigin(undefined as any)).toBeNull();
-			expect(parseOrigin(123 as any)).toBeNull();
-		});
-
-		test('should return null for non-HTTP/HTTPS protocols', () => {
-			expect(parseOrigin('ftp://example.com')).toBeNull();
-			expect(parseOrigin('ws://example.com')).toBeNull();
-			expect(parseOrigin('file://example.com')).toBeNull();
-			expect(parseOrigin('chrome-extension://example.com')).toBeNull();
-		});
-
-		test('should return null for malformed URLs', () => {
-			expect(parseOrigin('not-a-url')).toBeNull();
-			expect(parseOrigin('://malformed')).toBeNull();
-			expect(parseOrigin('https://')).toBeNull();
-			expect(parseOrigin('https://[invalid')).toBeNull();
-		});
-
-		test('should parse valid HTTP origins', () => {
-			const result = parseOrigin('http://example.com');
-			expect(result).toEqual({
-				protocol: 'http',
-				host: 'example.com',
-			});
-		});
-
-		test('should parse valid HTTPS origins', () => {
-			const result = parseOrigin('https://example.com');
-			expect(result).toEqual({
-				protocol: 'https',
-				host: 'example.com',
-			});
-		});
-
-		test('should normalize ports in origins', () => {
-			// Default ports should be removed
-			expect(parseOrigin('https://example.com:443')).toEqual({
-				protocol: 'https',
-				host: 'example.com',
-			});
-
-			expect(parseOrigin('http://example.com:80')).toEqual({
-				protocol: 'http',
-				host: 'example.com',
-			});
-
-			// Non-default ports should be preserved
-			expect(parseOrigin('https://example.com:8080')).toEqual({
-				protocol: 'https',
-				host: 'example.com:8080',
-			});
-
-			expect(parseOrigin('http://example.com:3000')).toEqual({
-				protocol: 'http',
-				host: 'example.com:3000',
-			});
-		});
-
-		test('should handle IPv6 origins', () => {
-			// IPv6 with default port: brackets should be stripped for consistency
-			expect(parseOrigin('https://[::1]:443')).toEqual({
-				protocol: 'https',
-				host: '::1',
-			});
-
-			// IPv6 with non-default port: brackets should be stripped but port preserved
-			expect(parseOrigin('http://[2001:db8::1]:8080')).toEqual({
-				protocol: 'http',
-				host: '2001:db8::1:8080',
-			});
-		});
-
-		test('should handle mixed case protocols', () => {
-			expect(parseOrigin('HTTPS://example.com')).toEqual({
-				protocol: 'https',
-				host: 'example.com',
-			});
-
-			expect(parseOrigin('Http://example.com')).toEqual({
-				protocol: 'http',
-				host: 'example.com',
-			});
-		});
-	});
-
-	describe('parseForwardedHeader', () => {
-		test('should parse simple forwarded header', () => {
-			const result = parseForwardedHeader('proto=https;host=example.com');
-			expect(result).toEqual({ proto: 'https', host: 'example.com' });
-		});
-
-		test('should parse forwarded header with quoted values', () => {
-			const result = parseForwardedHeader('proto="https";host="example.com"');
-			expect(result).toEqual({ proto: 'https', host: 'example.com' });
-		});
-
-		test('should parse forwarded header with single quotes', () => {
-			const result = parseForwardedHeader("proto='https';host='example.com'");
-			expect(result).toEqual({ proto: 'https', host: 'example.com' });
-		});
-
-		test('should handle multiple entries (use first)', () => {
-			const result = parseForwardedHeader(
-				'proto=https;host=example.com, proto=http;host=other.com',
-			);
-			expect(result).toEqual({ proto: 'https', host: 'example.com' });
-		});
-
-		test('should handle spaces around values', () => {
-			const result = parseForwardedHeader('  proto = https ; host = example.com  ');
-			expect(result).toEqual({ proto: 'https', host: 'example.com' });
-		});
-
-		test('should ignore unknown parameters', () => {
-			const result = parseForwardedHeader(
-				'for=192.0.2.60;proto=https;host=example.com;by=proxy.com',
-			);
-			expect(result).toEqual({ proto: 'https', host: 'example.com' });
-		});
-
-		test('should return null for invalid header', () => {
-			expect(parseForwardedHeader('')).toBeNull();
-			expect(parseForwardedHeader('invalid')).toEqual({});
-		});
-
-		test('should return null for non-string input', () => {
-			expect(parseForwardedHeader(null as any)).toBeNull();
-			expect(parseForwardedHeader(undefined as any)).toBeNull();
-		});
-
-		test('should handle partial parameters', () => {
-			expect(parseForwardedHeader('proto=https')).toEqual({ proto: 'https' });
-			expect(parseForwardedHeader('host=example.com')).toEqual({ host: 'example.com' });
-		});
-	});
-
-	describe('getFirstHeaderValue', () => {
-		test('should return string as-is', () => {
-			expect(getFirstHeaderValue('test')).toBe('test');
-		});
-
-		test('should return first element from array', () => {
-			expect(getFirstHeaderValue(['first', 'second'])).toBe('first');
-		});
-
-		test('should return undefined for undefined input', () => {
-			expect(getFirstHeaderValue(undefined)).toBe(undefined);
-		});
-
-		test('should return undefined for empty array', () => {
-			expect(getFirstHeaderValue([])).toBe(undefined);
-		});
-	});
-
-	describe('stripIPv6Brackets', () => {
-		test('should strip brackets from IPv6 addresses', () => {
-			expect(stripIPv6Brackets('[::1]')).toBe('::1');
-			expect(stripIPv6Brackets('[2001:db8::1]')).toBe('2001:db8::1');
-		});
-
-		test('should strip brackets from IPv6 addresses with ports', () => {
-			expect(stripIPv6Brackets('[::1]:8080')).toBe('::1:8080');
-			expect(stripIPv6Brackets('[2001:db8::1]:443')).toBe('2001:db8::1:443');
-		});
-
-		test('should leave non-bracketed strings unchanged', () => {
-			expect(stripIPv6Brackets('example.com')).toBe('example.com');
-			expect(stripIPv6Brackets('192.168.1.1')).toBe('192.168.1.1');
-			expect(stripIPv6Brackets('::1')).toBe('::1');
-			expect(stripIPv6Brackets('example.com:8080')).toBe('example.com:8080');
-		});
-
-		test('should handle partial brackets', () => {
-			expect(stripIPv6Brackets('[incomplete')).toBe('[incomplete');
-			expect(stripIPv6Brackets('incomplete]')).toBe('incomplete]');
-		});
-	});
-
-	describe('validateProtocol', () => {
-		test('should return http for valid http', () => {
-			expect(validateProtocol('http')).toBe('http');
-			expect(validateProtocol('HTTP')).toBe('http');
-			expect(validateProtocol('  http  ')).toBe('http');
-		});
-
-		test('should return https for valid https', () => {
-			expect(validateProtocol('https')).toBe('https');
-			expect(validateProtocol('HTTPS')).toBe('https');
-			expect(validateProtocol('  https  ')).toBe('https');
-		});
-
-		test('should return undefined for invalid protocols', () => {
-			expect(validateProtocol('ftp')).toBe(undefined);
-			expect(validateProtocol('websocket')).toBe(undefined);
-			expect(validateProtocol('')).toBe(undefined);
-			expect(validateProtocol(undefined)).toBe(undefined);
-		});
-	});
-
-	describe('validateOriginHeaders', () => {
-		const host = 'example.com';
-
+	describe('basic validation', () => {
 		test('should return invalid for missing origin', () => {
 			const result = validateOriginHeaders({});
+			expect(result.isValid).toBe(false);
+			expect(result.error).toBe('Origin header is missing or malformed');
+		});
+
+		test('should return invalid for empty origin', () => {
+			const result = validateOriginHeaders({ origin: '' });
 			expect(result.isValid).toBe(false);
 			expect(result.error).toBe('Origin header is missing or malformed');
 		});
@@ -291,24 +42,6 @@ describe('origin-validator', () => {
 			expect(result.expectedHost).toBe(host);
 		});
 
-		test('should handle default port normalization with x-forwarded-host', () => {
-			const result = validateOriginHeaders({
-				origin: `https://${host}`,
-				'x-forwarded-host': `${host}:443`,
-			});
-			expect(result.isValid).toBe(true);
-			expect(result.expectedHost).toBe(host);
-		});
-
-		test('should handle non-default ports', () => {
-			const result = validateOriginHeaders({
-				origin: `https://${host}:8080`,
-				'x-forwarded-host': `${host}:8080`,
-			});
-			expect(result.isValid).toBe(true);
-			expect(result.expectedHost).toBe(`${host}:8080`);
-		});
-
 		test('should reject mismatched hosts', () => {
 			const result = validateOriginHeaders({
 				origin: `https://${host}`,
@@ -317,7 +50,151 @@ describe('origin-validator', () => {
 			expect(result.isValid).toBe(false);
 			expect(result.error).toBe('Origin header does not match expected host');
 		});
+	});
 
+	describe('host normalization behavior', () => {
+		test('should normalize HTTPS default ports (443)', () => {
+			const result = validateOriginHeaders({
+				origin: `https://${host}`,
+				'x-forwarded-host': `${host}:443`,
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.expectedHost).toBe(host);
+		});
+
+		test('should normalize HTTP default ports (80)', () => {
+			const result = validateOriginHeaders({
+				origin: `http://${host}`,
+				'x-forwarded-host': `${host}:80`,
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.expectedHost).toBe(host);
+		});
+
+		test('should preserve non-default ports', () => {
+			const result = validateOriginHeaders({
+				origin: `https://${host}:8080`,
+				'x-forwarded-host': `${host}:8080`,
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.expectedHost).toBe(`${host}:8080`);
+		});
+
+		test('should reject mismatched ports', () => {
+			const result = validateOriginHeaders({
+				origin: `https://${host}:8080`,
+				'x-forwarded-host': `${host}:9000`,
+			});
+			expect(result.isValid).toBe(false);
+		});
+
+		test('should handle IPv6 addresses correctly', () => {
+			const result = validateOriginHeaders({
+				origin: 'https://[::1]:443',
+				'x-forwarded-host': '[::1]:443',
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.expectedHost).toBe('::1');
+		});
+
+		test('should handle IPv6 with non-default ports', () => {
+			const result = validateOriginHeaders({
+				origin: 'http://[2001:db8::1]:8080',
+				'x-forwarded-host': '[2001:db8::1]:8080',
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.expectedHost).toBe('2001:db8::1:8080');
+		});
+
+		test('should handle complex domain names', () => {
+			const complexHost = 'sub.domain.example-site.com';
+			const result = validateOriginHeaders({
+				origin: `https://${complexHost}:443`,
+				'x-forwarded-host': `${complexHost}:443`,
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.expectedHost).toBe(complexHost);
+		});
+
+		test('should handle invalid URL formats gracefully', () => {
+			const result = validateOriginHeaders({
+				origin: 'https://example.com',
+				'x-forwarded-host': 'invalid[host',
+			});
+			expect(result.isValid).toBe(false);
+			expect(result.expectedHost).toBe('invalid[host');
+		});
+	});
+
+	describe('origin parsing behavior', () => {
+		test('should reject non-HTTP/HTTPS protocols', () => {
+			const result = validateOriginHeaders({
+				origin: 'ftp://example.com',
+				host: 'example.com',
+			});
+			expect(result.isValid).toBe(false);
+			expect(result.error).toBe('Origin header is missing or malformed');
+		});
+
+		test('should reject websocket protocols', () => {
+			const result = validateOriginHeaders({
+				origin: 'ws://example.com',
+				host: 'example.com',
+			});
+			expect(result.isValid).toBe(false);
+		});
+
+		test('should reject chrome-extension protocols', () => {
+			const result = validateOriginHeaders({
+				origin: 'chrome-extension://example.com',
+				host: 'example.com',
+			});
+			expect(result.isValid).toBe(false);
+		});
+
+		test('should handle mixed case protocols', () => {
+			const result = validateOriginHeaders({
+				origin: `HTTPS://${host}`,
+				host,
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.originInfo?.protocol).toBe('https');
+		});
+
+		test('should parse HTTP origins correctly', () => {
+			const result = validateOriginHeaders({
+				origin: `http://${host}`,
+				host,
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.originInfo).toEqual({
+				protocol: 'http',
+				host,
+			});
+		});
+
+		test('should parse HTTPS origins correctly', () => {
+			const result = validateOriginHeaders({
+				origin: `https://${host}`,
+				host,
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.originInfo).toEqual({
+				protocol: 'https',
+				host,
+			});
+		});
+
+		test('should reject malformed URLs that throw during parsing', () => {
+			const result = validateOriginHeaders({
+				origin: '://malformed',
+				host: 'example.com',
+			});
+			expect(result.isValid).toBe(false);
+		});
+	});
+
+	describe('header precedence and processing', () => {
 		test('should handle Forwarded header with precedence over x-forwarded-*', () => {
 			const result = validateOriginHeaders({
 				origin: `https://${host}`,
@@ -328,27 +205,82 @@ describe('origin-validator', () => {
 			expect(result.expectedHost).toBe(host);
 		});
 
-		test('should handle Forwarded header with protocol change', () => {
-			const result = validateOriginHeaders({
-				origin: `http://${host}`,
-				forwarded: `proto=http;host=${host}:80`,
-			});
-			expect(result.isValid).toBe(true);
-			expect(result.expectedHost).toBe(host);
-			expect(result.expectedProtocol).toBe('http');
-		});
-
-		test('should handle array headers', () => {
+		test('should parse RFC 7239 Forwarded header with quoted values', () => {
 			const result = validateOriginHeaders({
 				origin: `https://${host}`,
-				'x-forwarded-host': [host, 'other-host.com'],
-				'x-forwarded-proto': ['https', 'http'],
+				forwarded: `proto="https";host="${host}"`,
 			});
 			expect(result.isValid).toBe(true);
 			expect(result.expectedHost).toBe(host);
 		});
 
-		test('should handle comma-separated x-forwarded-proto', () => {
+		test('should parse Forwarded header with single quotes', () => {
+			const result = validateOriginHeaders({
+				origin: `https://${host}`,
+				forwarded: `proto='https';host='${host}'`,
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.expectedHost).toBe(host);
+		});
+
+		test('should handle multiple Forwarded entries (use first)', () => {
+			const result = validateOriginHeaders({
+				origin: `https://${host}`,
+				forwarded: `proto=https;host=${host}, proto=http;host=other.com`,
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.expectedHost).toBe(host);
+		});
+
+		test('should handle Forwarded header with spaces around values', () => {
+			const result = validateOriginHeaders({
+				origin: `https://${host}`,
+				forwarded: `  proto = https ; host = ${host}  `,
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.expectedHost).toBe(host);
+		});
+
+		test('should ignore unknown parameters in Forwarded header', () => {
+			const result = validateOriginHeaders({
+				origin: `https://${host}`,
+				forwarded: `for=192.0.2.60;proto=https;host=${host};by=proxy.com`,
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.expectedHost).toBe(host);
+		});
+
+		test('should fallback to X-Forwarded-* when Forwarded header incomplete', () => {
+			const result = validateOriginHeaders({
+				origin: `https://${host}`,
+				forwarded: 'for=192.0.2.60', // Missing host and proto
+				'x-forwarded-host': host,
+				'x-forwarded-proto': 'https',
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.expectedHost).toBe(host);
+		});
+
+		test('should handle array x-forwarded-host headers (use first)', () => {
+			const result = validateOriginHeaders({
+				origin: `https://${host}`,
+				'x-forwarded-host': [host, 'other-host.com'] as any,
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.expectedHost).toBe(host);
+		});
+
+		test('should handle array x-forwarded-proto headers (use first)', () => {
+			const result = validateOriginHeaders({
+				origin: `https://${host}`,
+				'x-forwarded-host': host,
+				'x-forwarded-proto': ['https', 'http'] as any,
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.expectedProtocol).toBe('https');
+		});
+
+		test('should handle comma-separated x-forwarded-proto (use first)', () => {
 			const result = validateOriginHeaders({
 				origin: `https://${host}`,
 				'x-forwarded-host': host,
@@ -358,22 +290,144 @@ describe('origin-validator', () => {
 			expect(result.expectedProtocol).toBe('https');
 		});
 
-		test('should handle IPv6 addresses', () => {
+		test('should fallback to Host header when no proxy headers exist', () => {
 			const result = validateOriginHeaders({
-				origin: 'https://[::1]:443',
-				'x-forwarded-host': '[::1]:443',
+				origin: `https://${host}`,
+				host,
 			});
 			expect(result.isValid).toBe(true);
-			expect(result.expectedHost).toBe('::1');
+			expect(result.expectedHost).toBe(host);
+		});
+	});
+
+	describe('protocol validation behavior', () => {
+		test('should handle valid protocols in Forwarded header', () => {
+			const result = validateOriginHeaders({
+				origin: `https://${host}`,
+				forwarded: `proto=https;host=${host}`,
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.expectedProtocol).toBe('https');
 		});
 
-		test('should fallback protocol validation gracefully', () => {
+		test('should ignore invalid protocols in Forwarded header', () => {
 			const result = validateOriginHeaders({
 				origin: `https://${host}`,
 				forwarded: `proto=ftp;host=${host}`, // Invalid protocol should be ignored
 			});
 			expect(result.isValid).toBe(true);
 			expect(result.expectedProtocol).toBe('https'); // Falls back to origin protocol
+		});
+
+		test('should ignore invalid protocols in X-Forwarded-Proto header', () => {
+			const result = validateOriginHeaders({
+				origin: `https://${host}`,
+				'x-forwarded-host': host,
+				'x-forwarded-proto': 'websocket', // Invalid protocol
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.expectedProtocol).toBe('https'); // Falls back to origin protocol
+		});
+
+		test('should handle comma-separated X-Forwarded-Proto with invalid first value', () => {
+			const result = validateOriginHeaders({
+				origin: `https://${host}`,
+				'x-forwarded-host': host,
+				'x-forwarded-proto': 'ftp,https', // Invalid first, valid second
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.expectedProtocol).toBe('https'); // Falls back to origin protocol
+		});
+
+		test('should handle protocol change via Forwarded header', () => {
+			const result = validateOriginHeaders({
+				origin: `http://${host}`,
+				forwarded: `proto=http;host=${host}:80`,
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.expectedHost).toBe(host);
+			expect(result.expectedProtocol).toBe('http');
+		});
+	});
+
+	describe('edge cases and error handling', () => {
+		test('should handle missing host header when no proxy headers exist', () => {
+			const result = validateOriginHeaders({
+				origin: `https://${host}`,
+				// No host, x-forwarded-host, or forwarded headers
+			});
+			expect(result.isValid).toBe(false);
+			expect(result.expectedHost).toBe('');
+		});
+
+		test('should handle empty forwarded header gracefully', () => {
+			const result = validateOriginHeaders({
+				origin: `https://${host}`,
+				forwarded: '',
+				'x-forwarded-host': host,
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.expectedHost).toBe(host);
+		});
+
+		test('should handle invalid forwarded header format', () => {
+			const result = validateOriginHeaders({
+				origin: `https://${host}`,
+				forwarded: 'invalid-format',
+				'x-forwarded-host': host,
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.expectedHost).toBe(host);
+		});
+
+		test('should handle empty x-forwarded-host array', () => {
+			const result = validateOriginHeaders({
+				origin: `https://${host}`,
+				'x-forwarded-host': [] as any,
+				host,
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.expectedHost).toBe(host); // Falls back to host header
+		});
+
+		test('should handle numeric IP addresses correctly', () => {
+			const ipHost = '192.168.1.100:3000';
+			const result = validateOriginHeaders({
+				origin: `https://${ipHost}`,
+				'x-forwarded-host': ipHost,
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.expectedHost).toBe(ipHost);
+		});
+
+		test('should handle localhost correctly', () => {
+			const localhostHost = 'localhost:8080';
+			const result = validateOriginHeaders({
+				origin: `http://${localhostHost}`,
+				'x-forwarded-host': localhostHost,
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.expectedHost).toBe(localhostHost);
+		});
+
+		test('should allow origins with query parameters when host matches', () => {
+			const queryOrigin = `https://${host}?query=param#fragment`;
+			const result = validateOriginHeaders({
+				origin: queryOrigin,
+				host,
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.originInfo?.host).toBe(host);
+		});
+
+		test('should allow origins with path components when host matches', () => {
+			const pathOrigin = `https://${host}/path/to/resource`;
+			const result = validateOriginHeaders({
+				origin: pathOrigin,
+				host,
+			});
+			expect(result.isValid).toBe(true);
+			expect(result.originInfo?.host).toBe(host);
 		});
 	});
 });

--- a/packages/cli/src/push/__tests__/origin-validator.test.ts
+++ b/packages/cli/src/push/__tests__/origin-validator.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
 import { validateOriginHeaders } from '../origin-validator';
 
 describe('validateOriginHeaders', () => {
@@ -264,7 +266,7 @@ describe('validateOriginHeaders', () => {
 		test('should handle array x-forwarded-host headers (use first)', () => {
 			const result = validateOriginHeaders({
 				origin: `https://${host}`,
-				'x-forwarded-host': [host, 'other-host.com'] as any,
+				'x-forwarded-host': [host, 'other-host.com'],
 			});
 			expect(result.isValid).toBe(true);
 			expect(result.expectedHost).toBe(host);
@@ -274,7 +276,7 @@ describe('validateOriginHeaders', () => {
 			const result = validateOriginHeaders({
 				origin: `https://${host}`,
 				'x-forwarded-host': host,
-				'x-forwarded-proto': ['https', 'http'] as any,
+				'x-forwarded-proto': ['https', 'http'],
 			});
 			expect(result.isValid).toBe(true);
 			expect(result.expectedProtocol).toBe('https');
@@ -383,7 +385,7 @@ describe('validateOriginHeaders', () => {
 		test('should handle empty x-forwarded-host array', () => {
 			const result = validateOriginHeaders({
 				origin: `https://${host}`,
-				'x-forwarded-host': [] as any,
+				'x-forwarded-host': [],
 				host,
 			});
 			expect(result.isValid).toBe(true);

--- a/packages/cli/src/push/index.ts
+++ b/packages/cli/src/push/index.ts
@@ -18,6 +18,7 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { Publisher } from '@/scaling/pubsub/publisher.service';
 import { TypedEmitter } from '@/typed-emitter';
 
+import { validateOriginHeaders } from './origin-validator';
 import { PushConfig } from './push.config';
 import { SSEPush } from './sse.push';
 import type { OnPushMessage, PushResponse, SSEPushRequest, WebSocketPushRequest } from './types';
@@ -101,165 +102,6 @@ export class Push extends TypedEmitter<PushEvents> {
 		);
 	}
 
-	/**
-	 * Normalizes a host by removing default ports for the given protocol.
-	 * Uses native URL class for robust parsing of hosts and ports.
-	 *
-	 * @param host The host string (e.g., "example.com:80", "example.com", "[::1]:8080")
-	 * @param protocol The protocol ('http' or 'https')
-	 * @returns The normalized host string with default ports removed
-	 */
-	private normalizeHost(host: string, protocol: 'http' | 'https'): string {
-		if (!host) return host;
-
-		try {
-			// Use URL constructor to parse the host properly
-			// We need to prepend a protocol to make it a valid URL
-			const url = new URL(`${protocol}://${host}`);
-
-			// URL.host includes port, URL.hostname excludes port
-			// If the port is default for the protocol, URL.host will exclude it
-			// Otherwise, it will include it
-			const defaultPort = protocol === 'https' ? '443' : '80';
-			const actualPort = url.port || defaultPort;
-
-			// If the port matches the default, return hostname only (strip IPv6 brackets)
-			if (actualPort === defaultPort) {
-				return this.stripIPv6Brackets(url.hostname);
-			}
-
-			// Return hostname:port for non-default ports (strip IPv6 brackets)
-			return this.stripIPv6Brackets(url.host);
-		} catch {
-			// If URL parsing fails, fall back to original host
-			return host;
-		}
-	}
-
-	/**
-	 * Strips brackets from IPv6 addresses for consistency.
-	 * IPv6 brackets are URL syntax and should be removed when comparing hosts.
-	 *
-	 * @param hostname The hostname that may contain IPv6 brackets (e.g., "[::1]" or "[::1]:8080")
-	 * @returns Hostname with IPv6 brackets removed if present (e.g., "::1" or "::1:8080")
-	 */
-	private stripIPv6Brackets(hostname: string): string {
-		// Handle IPv6 with port: [::1]:8080 -> ::1:8080
-		if (hostname.startsWith('[') && hostname.includes(']:')) {
-			const closingBracket = hostname.indexOf(']:');
-			const ipv6 = hostname.slice(1, closingBracket); // Extract ::1
-			const port = hostname.slice(closingBracket + 2); // Extract 8080
-			return `${ipv6}:${port}`;
-		}
-		// Handle IPv6 without port: [::1] -> ::1
-		if (hostname.startsWith('[') && hostname.endsWith(']')) {
-			return hostname.slice(1, -1);
-		}
-		return hostname;
-	}
-
-	/**
-	 * Safely extracts the first value from a header that could be string or string[].
-	 *
-	 * @param header The header value (string or string[])
-	 * @returns First header value or undefined
-	 */
-	private getFirstHeaderValue(header: string | string[] | undefined): string | undefined {
-		if (!header) return undefined;
-		if (typeof header === 'string') return header;
-		return header[0]; // Take first value from array
-	}
-
-	/**
-	 * Validates and normalizes a protocol value to ensure it's http or https.
-	 *
-	 * @param proto Protocol value from headers
-	 * @returns 'http' or 'https' if valid, undefined if invalid
-	 */
-	private validateProtocol(proto: string | undefined): 'http' | 'https' | undefined {
-		if (!proto) return undefined;
-		const normalized = proto.toLowerCase().trim();
-		return normalized === 'http' || normalized === 'https' ? normalized : undefined;
-	}
-
-	/**
-	 * Parses the RFC 7239 Forwarded header to extract host and proto values.
-	 *
-	 * @param forwardedHeader The Forwarded header value (e.g., "for=192.0.2.60;proto=http;host=example.com")
-	 * @returns Object with host and proto, or null if parsing fails
-	 */
-	private parseForwardedHeader(forwardedHeader: string): { host?: string; proto?: string } | null {
-		if (!forwardedHeader || typeof forwardedHeader !== 'string') {
-			return null;
-		}
-
-		try {
-			// Parse the first forwarded entry (comma-separated list)
-			const firstEntry = forwardedHeader.split(',')[0]?.trim();
-			if (!firstEntry) return null;
-
-			const result: { host?: string; proto?: string } = {};
-
-			// Parse semicolon-separated key=value pairs
-			const pairs = firstEntry.split(';');
-			for (const pair of pairs) {
-				const [key, value] = pair.split('=', 2);
-				if (!key || !value) continue;
-
-				const cleanKey = key.trim().toLowerCase();
-				const cleanValue = value.trim().replace(/^["']|["']$/g, ''); // Remove quotes
-
-				if (cleanKey === 'host') {
-					result.host = cleanValue;
-				} else if (cleanKey === 'proto') {
-					result.proto = cleanValue;
-				}
-			}
-
-			return result;
-		} catch {
-			return null;
-		}
-	}
-
-	/**
-	 * Extracts protocol and normalized host from an origin URL using native URL class.
-	 *
-	 * @param origin The origin URL (e.g., "https://example.com", "http://localhost:3000")
-	 * @returns Object with protocol and normalized host, or null if invalid
-	 */
-	private parseOrigin(origin: string): { protocol: 'http' | 'https'; host: string } | null {
-		if (!origin || typeof origin !== 'string') {
-			return null;
-		}
-
-		try {
-			const url = new URL(origin);
-			const protocol = url.protocol.toLowerCase();
-
-			if (protocol !== 'http:' && protocol !== 'https:') {
-				return null;
-			}
-
-			const protocolName = protocol === 'https:' ? 'https' : 'http';
-
-			// Use the same normalization logic - remove default ports and IPv6 brackets
-			const defaultPort = protocolName === 'https' ? '443' : '80';
-			const actualPort = url.port || defaultPort;
-
-			const rawHost = actualPort === defaultPort ? url.hostname : url.host;
-			const normalizedHost = this.stripIPv6Brackets(rawHost);
-
-			return {
-				protocol: protocolName,
-				host: normalizedHost,
-			};
-		} catch {
-			// Invalid URL format
-			return null;
-		}
-	}
-
 	handleRequest(req: SSEPushRequest | WebSocketPushRequest, res: PushResponse) {
 		const {
 			ws,
@@ -270,64 +112,16 @@ export class Push extends TypedEmitter<PushEvents> {
 
 		let connectionError = '';
 
-		// Parse and normalize the origin using native URL class
-		const originInfo = this.parseOrigin(headers.origin ?? '');
-
 		if (!pushRef) {
 			connectionError = 'The query parameter "pushRef" is missing!';
-		} else if (!originInfo) {
-			this.logger.warn('Origin header is missing or malformed', {
-				origin: headers.origin,
-				forwarded: headers.forwarded,
-				'x-forwarded-host': headers['x-forwarded-host'],
-				'x-forwarded-proto': headers['x-forwarded-proto'],
-			});
-
-			connectionError = 'Invalid origin!';
 		} else if (inProduction) {
-			// Extract expected host from proxy headers using same precedence logic
-			let rawExpectedHost: string | undefined;
-			let expectedProtocol = originInfo.protocol;
-
-			// 1. Try RFC 7239 Forwarded header first
-			const forwarded = this.parseForwardedHeader(headers.forwarded ?? '');
-			if (forwarded?.host) {
-				rawExpectedHost = forwarded.host;
-				if (forwarded.proto) {
-					const validatedProto = this.validateProtocol(forwarded.proto);
-					if (validatedProto) {
-						expectedProtocol = validatedProto;
-					}
-				}
-			}
-			// 2. Try X-Forwarded-Host
-			else {
-				const xForwardedHost = this.getFirstHeaderValue(headers['x-forwarded-host']);
-				if (xForwardedHost) {
-					rawExpectedHost = xForwardedHost;
-					const xForwardedProto = this.getFirstHeaderValue(headers['x-forwarded-proto']);
-					if (xForwardedProto) {
-						const validatedProto = this.validateProtocol(xForwardedProto.split(',')[0]?.trim());
-						if (validatedProto) {
-							expectedProtocol = validatedProto;
-						}
-					}
-				}
-				// 3. Fallback to Host header
-				else {
-					rawExpectedHost = headers.host;
-				}
-			}
-
-			// Normalize expected host using the determined protocol
-			const normalizedExpectedHost = this.normalizeHost(rawExpectedHost ?? '', expectedProtocol);
-
-			if (normalizedExpectedHost !== originInfo.host) {
+			const validation = validateOriginHeaders(headers);
+			if (!validation.isValid) {
 				this.logger.warn(
 					'Origin header does NOT match the expected origin. ' +
-						`(Origin: "${headers.origin}" -> "${originInfo.host}", ` +
-						`Expected: "${rawExpectedHost}" -> "${normalizedExpectedHost}", ` +
-						`Protocol: "${expectedProtocol}")`,
+						`(Origin: "${headers.origin}" -> "${validation.originInfo?.host || 'N/A'}", ` +
+						`Expected: "${validation.rawExpectedHost}" -> "${validation.expectedHost}", ` +
+						`Protocol: "${validation.expectedProtocol}")`,
 					{
 						headers: pick(headers, [
 							'host',

--- a/packages/cli/src/push/origin-validator.ts
+++ b/packages/cli/src/push/origin-validator.ts
@@ -1,0 +1,238 @@
+import type { Request } from 'express';
+
+export interface OriginValidationResult {
+	isValid: boolean;
+	originInfo?: { protocol: 'http' | 'https'; host: string };
+	expectedHost?: string;
+	expectedProtocol?: 'http' | 'https';
+	rawExpectedHost?: string;
+	error?: string;
+}
+
+/**
+ * Validates origin headers against expected host from proxy headers.
+ * Handles X-Forwarded-Host, X-Forwarded-Proto, and RFC 7239 Forwarded headers.
+ *
+ * @param headers HTTP request headers
+ * @returns Validation result with details about the origin check
+ */
+export function validateOriginHeaders(headers: Request['headers']): OriginValidationResult {
+	// Parse and normalize the origin using native URL class
+	const originInfo = parseOrigin(headers.origin ?? '');
+
+	if (!originInfo) {
+		return {
+			isValid: false,
+			error: 'Origin header is missing or malformed',
+		};
+	}
+
+	// Extract expected host from proxy headers using same precedence logic
+	let rawExpectedHost: string | undefined;
+	let expectedProtocol = originInfo.protocol;
+
+	// 1. Try RFC 7239 Forwarded header first
+	const forwarded = parseForwardedHeader(headers.forwarded ?? '');
+	if (forwarded?.host) {
+		rawExpectedHost = forwarded.host;
+		if (forwarded.proto) {
+			const validatedProto = validateProtocol(forwarded.proto);
+			if (validatedProto) {
+				expectedProtocol = validatedProto;
+			}
+		}
+	}
+	// 2. Try X-Forwarded-Host
+	else {
+		const xForwardedHost = getFirstHeaderValue(headers['x-forwarded-host']);
+		if (xForwardedHost) {
+			rawExpectedHost = xForwardedHost;
+			const xForwardedProto = getFirstHeaderValue(headers['x-forwarded-proto']);
+			if (xForwardedProto) {
+				const validatedProto = validateProtocol(xForwardedProto.split(',')[0]?.trim());
+				if (validatedProto) {
+					expectedProtocol = validatedProto;
+				}
+			}
+		}
+		// 3. Fallback to Host header
+		else {
+			rawExpectedHost = headers.host;
+		}
+	}
+
+	// Normalize expected host using the determined protocol
+	const normalizedExpectedHost = normalizeHost(rawExpectedHost ?? '', expectedProtocol);
+
+	const isValid = normalizedExpectedHost === originInfo.host;
+
+	return {
+		isValid,
+		originInfo,
+		expectedHost: normalizedExpectedHost,
+		expectedProtocol,
+		rawExpectedHost,
+		error: isValid ? undefined : 'Origin header does not match expected host',
+	};
+}
+
+/**
+ * Normalizes a host by removing default ports for the given protocol.
+ * Uses native URL class for robust parsing of hosts and ports.
+ *
+ * @param host The host string (e.g., "example.com:80", "example.com", "[::1]:8080")
+ * @param protocol The protocol ('http' or 'https')
+ * @returns The normalized host string with default ports removed
+ */
+export function normalizeHost(host: string, protocol: 'http' | 'https'): string {
+	if (!host) return host;
+
+	try {
+		// Use URL constructor to parse the host properly
+		// We need to prepend a protocol to make it a valid URL
+		const url = new URL(`${protocol}://${host}`);
+
+		// URL.host includes port, URL.hostname excludes port
+		// If the port is default for the protocol, URL.host will exclude it
+		// Otherwise, it will include it
+		const defaultPort = protocol === 'https' ? '443' : '80';
+		const actualPort = url.port || defaultPort;
+
+		// If the port matches the default, return hostname only (strip IPv6 brackets)
+		if (actualPort === defaultPort) {
+			return stripIPv6Brackets(url.hostname);
+		}
+
+		// Return hostname:port for non-default ports (strip IPv6 brackets)
+		return stripIPv6Brackets(url.host);
+	} catch {
+		// If URL parsing fails, fall back to original host
+		return host;
+	}
+}
+
+/**
+ * Strips brackets from IPv6 addresses for consistency.
+ * IPv6 brackets are URL syntax and should be removed when comparing hosts.
+ *
+ * @param hostname The hostname that may contain IPv6 brackets (e.g., "[::1]" or "[::1]:8080")
+ * @returns Hostname with IPv6 brackets removed if present (e.g., "::1" or "::1:8080")
+ */
+export function stripIPv6Brackets(hostname: string): string {
+	// Handle IPv6 with port: [::1]:8080 -> ::1:8080
+	if (hostname.startsWith('[') && hostname.includes(']:')) {
+		const closingBracket = hostname.indexOf(']:');
+		const ipv6 = hostname.slice(1, closingBracket); // Extract ::1
+		const port = hostname.slice(closingBracket + 2); // Extract 8080
+		return `${ipv6}:${port}`;
+	}
+	// Handle IPv6 without port: [::1] -> ::1
+	if (hostname.startsWith('[') && hostname.endsWith(']')) {
+		return hostname.slice(1, -1);
+	}
+	return hostname;
+}
+
+/**
+ * Safely extracts the first value from a header that could be string or string[].
+ *
+ * @param header The header value (string or string[])
+ * @returns First header value or undefined
+ */
+export function getFirstHeaderValue(header: string | string[] | undefined): string | undefined {
+	if (!header) return undefined;
+	if (typeof header === 'string') return header;
+	return header[0]; // Take first value from array
+}
+
+/**
+ * Validates and normalizes a protocol value to ensure it's http or https.
+ *
+ * @param proto Protocol value from headers
+ * @returns 'http' or 'https' if valid, undefined if invalid
+ */
+export function validateProtocol(proto: string | undefined): 'http' | 'https' | undefined {
+	if (!proto) return undefined;
+	const normalized = proto.toLowerCase().trim();
+	return normalized === 'http' || normalized === 'https' ? normalized : undefined;
+}
+
+/**
+ * Parses the RFC 7239 Forwarded header to extract host and proto values.
+ *
+ * @param forwardedHeader The Forwarded header value (e.g., "for=192.0.2.60;proto=http;host=example.com")
+ * @returns Object with host and proto, or null if parsing fails
+ */
+export function parseForwardedHeader(
+	forwardedHeader: string,
+): { host?: string; proto?: string } | null {
+	if (!forwardedHeader || typeof forwardedHeader !== 'string') {
+		return null;
+	}
+
+	try {
+		// Parse the first forwarded entry (comma-separated list)
+		const firstEntry = forwardedHeader.split(',')[0]?.trim();
+		if (!firstEntry) return null;
+
+		const result: { host?: string; proto?: string } = {};
+
+		// Parse semicolon-separated key=value pairs
+		const pairs = firstEntry.split(';');
+		for (const pair of pairs) {
+			const [key, value] = pair.split('=', 2);
+			if (!key || !value) continue;
+
+			const cleanKey = key.trim().toLowerCase();
+			const cleanValue = value.trim().replace(/^["']|["']$/g, ''); // Remove quotes
+
+			if (cleanKey === 'host') {
+				result.host = cleanValue;
+			} else if (cleanKey === 'proto') {
+				result.proto = cleanValue;
+			}
+		}
+
+		return result;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Extracts protocol and normalized host from an origin URL using native URL class.
+ *
+ * @param origin The origin URL (e.g., "https://example.com", "http://localhost:3000")
+ * @returns Object with protocol and normalized host, or null if invalid
+ */
+export function parseOrigin(origin: string): { protocol: 'http' | 'https'; host: string } | null {
+	if (!origin || typeof origin !== 'string') {
+		return null;
+	}
+
+	try {
+		const url = new URL(origin);
+		const protocol = url.protocol.toLowerCase();
+
+		if (protocol !== 'http:' && protocol !== 'https:') {
+			return null;
+		}
+
+		const protocolName = protocol === 'https:' ? 'https' : 'http';
+
+		// Use the same normalization logic - remove default ports and IPv6 brackets
+		const defaultPort = protocolName === 'https' ? '443' : '80';
+		const actualPort = url.port || defaultPort;
+
+		const rawHost = actualPort === defaultPort ? url.hostname : url.host;
+		const normalizedHost = stripIPv6Brackets(rawHost);
+
+		return {
+			protocol: protocolName,
+			host: normalizedHost,
+		};
+	} catch {
+		// Invalid URL format
+		return null;
+	}
+}

--- a/packages/cli/src/push/origin-validator.ts
+++ b/packages/cli/src/push/origin-validator.ts
@@ -84,7 +84,7 @@ export function validateOriginHeaders(headers: Request['headers']): OriginValida
  * @param protocol The protocol ('http' or 'https')
  * @returns The normalized host string with default ports removed
  */
-export function normalizeHost(host: string, protocol: 'http' | 'https'): string {
+function normalizeHost(host: string, protocol: 'http' | 'https'): string {
 	if (!host) return host;
 
 	try {
@@ -118,7 +118,7 @@ export function normalizeHost(host: string, protocol: 'http' | 'https'): string 
  * @param hostname The hostname that may contain IPv6 brackets (e.g., "[::1]" or "[::1]:8080")
  * @returns Hostname with IPv6 brackets removed if present (e.g., "::1" or "::1:8080")
  */
-export function stripIPv6Brackets(hostname: string): string {
+function stripIPv6Brackets(hostname: string): string {
 	// Handle IPv6 with port: [::1]:8080 -> ::1:8080
 	if (hostname.startsWith('[') && hostname.includes(']:')) {
 		const closingBracket = hostname.indexOf(']:');
@@ -139,7 +139,7 @@ export function stripIPv6Brackets(hostname: string): string {
  * @param header The header value (string or string[])
  * @returns First header value or undefined
  */
-export function getFirstHeaderValue(header: string | string[] | undefined): string | undefined {
+function getFirstHeaderValue(header: string | string[] | undefined): string | undefined {
 	if (!header) return undefined;
 	if (typeof header === 'string') return header;
 	return header[0]; // Take first value from array
@@ -151,7 +151,7 @@ export function getFirstHeaderValue(header: string | string[] | undefined): stri
  * @param proto Protocol value from headers
  * @returns 'http' or 'https' if valid, undefined if invalid
  */
-export function validateProtocol(proto: string | undefined): 'http' | 'https' | undefined {
+function validateProtocol(proto: string | undefined): 'http' | 'https' | undefined {
 	if (!proto) return undefined;
 	const normalized = proto.toLowerCase().trim();
 	return normalized === 'http' || normalized === 'https' ? normalized : undefined;
@@ -163,9 +163,7 @@ export function validateProtocol(proto: string | undefined): 'http' | 'https' | 
  * @param forwardedHeader The Forwarded header value (e.g., "for=192.0.2.60;proto=http;host=example.com")
  * @returns Object with host and proto, or null if parsing fails
  */
-export function parseForwardedHeader(
-	forwardedHeader: string,
-): { host?: string; proto?: string } | null {
+function parseForwardedHeader(forwardedHeader: string): { host?: string; proto?: string } | null {
 	if (!forwardedHeader || typeof forwardedHeader !== 'string') {
 		return null;
 	}
@@ -205,7 +203,7 @@ export function parseForwardedHeader(
  * @param origin The origin URL (e.g., "https://example.com", "http://localhost:3000")
  * @returns Object with protocol and normalized host, or null if invalid
  */
-export function parseOrigin(origin: string): { protocol: 'http' | 'https'; host: string } | null {
+function parseOrigin(origin: string): { protocol: 'http' | 'https'; host: string } | null {
 	if (!origin || typeof origin !== 'string') {
 		return null;
 	}


### PR DESCRIPTION
## Summary

Websocket connections fail when x-forwarded-host has a port and origin doesn't

## Related Linear tickets, Github issues, and Community forum posts

[CAT-1027](https://linear.app/n8n/issue/CAT-1027/websocket-connections-fail-when-x-forwarded-host-has-a-port-and-origin)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
