### PR TITLE
fix(core): Replace actual root when manually running tools of Agent Tools

### DIFF
--- a/packages/core/src/execution-engine/partial-execution-utils/rewire-graph.ts
+++ b/packages/core/src/execution-engine/partial-execution-utils/rewire-graph.ts
@@ -16,7 +16,7 @@ export function rewireGraph(
 		return graph;
 	}
 
-	const rootNode = [...children][0];
+	const rootNode = [...children][children.size - 1];
 
 	a.ok(rootNode);
 


### PR DESCRIPTION
## Summary

When manually testing a tool of an Agent Tool, the node that would be replaced was the Agent Tool, not the root Agent. This change fixes that and finds the lowest root node that has the main connection to the trigger.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-1240/bug-manual-partial-execution-of-a-tool-nested-behind-agent-tool-fails

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
