### PR TITLE
fix(OpenAI Node): Add proxy agent for Message an assistant operation

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/message.operation.ts
@@ -24,6 +24,7 @@ import { getTracingConfig } from '@utils/tracing';
 
 import { formatToOpenAIAssistantTool, getChatMessages } from '../../helpers/utils';
 import { assistantRLC } from '../descriptions';
+import { getProxyAgent } from '@utils/httpProxyAgent';
 
 const properties: INodeProperties[] = [
 	assistantRLC,
@@ -193,6 +194,9 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 		maxRetries: options.maxRetries ?? 2,
 		timeout: options.timeout ?? 10000,
 		baseURL,
+		fetchOptions: {
+			dispatcher: getProxyAgent(baseURL),
+		},
 	});
 
 	const agent = new OpenAIAssistantRunnable({ assistantId, client, asAgent: true });


### PR DESCRIPTION
## Summary
Add missing proxy agent to `Message an assistant` operation on the OpenAI node. This uses langchain classes and needs to be handled explicitely like the other langchain nodes. Other operations use direct requests and work with the core proxy agent.


## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-1372/community-issue-regression-message-an-assistant-in-openai-node-doesnt
fixes #18836


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
