### PR TITLE
chore(editor): Show workflows with caller policy any in list

### DIFF
--- a/packages/@n8n/db/src/repositories/workflow.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow.repository.ts
@@ -19,6 +19,7 @@ import type {
 	FolderWithWorkflowAndSubFolderCount,
 	ListQuery,
 } from '../entities/types-db';
+import { buildWorkflowsByCallerPolicyAny } from '../utils/build-workflows-by-any-caller-policy-query';
 import { buildWorkflowsByNodesQuery } from '../utils/build-workflows-by-nodes-query';
 import { isStringArray } from '../utils/is-string-array';
 import { TimedQuery } from '../utils/timed-query';
@@ -736,6 +737,21 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 			{ id: In(workflowIds) },
 			{ parentFolder: toFolderId === PROJECT_ROOT ? null : { id: toFolderId } },
 		);
+	}
+
+	async findWorkflowsWithCallerPolicyAny() {
+		const qb = this.createQueryBuilder('workflow');
+
+		const { whereClause, parameters } = buildWorkflowsByCallerPolicyAny(
+			this.globalConfig.database.type,
+		);
+
+		const workflows: Array<{ id: string; name: string; active: boolean }> = await qb
+			.select(['workflow.id', 'workflow.name', 'workflow.active'])
+			.where(whereClause, parameters)
+			.getMany();
+
+		return workflows;
 	}
 
 	async findWorkflowsWithNodeType(nodeTypes: string[]) {

--- a/packages/@n8n/db/src/utils/build-workflows-by-any-caller-policy-query.ts
+++ b/packages/@n8n/db/src/utils/build-workflows-by-any-caller-policy-query.ts
@@ -1,0 +1,31 @@
+/**
+ * Builds the WHERE clause and parameters for a query to find workflows which have a caller policy of 'any'
+ */
+export function buildWorkflowsByCallerPolicyAny(
+	dbType: 'postgresdb' | 'mysqldb' | 'mariadb' | 'sqlite',
+) {
+	let whereClause: string;
+
+	const parameters: Record<string, string> = {};
+
+	switch (dbType) {
+		case 'postgresdb':
+			whereClause = 'workflow.settings::jsonb @> \'{"callerPolicy": "any"}\'';
+			break;
+		case 'mysqldb':
+		case 'mariadb': {
+			whereClause = "JSON_EXTRACT(workflow.settings, '$callerPolicy') = :policy";
+			parameters['policy'] = 'any';
+			break;
+		}
+		case 'sqlite': {
+			whereClause = "json_extract(workflow.settings, '$.callerPolicy') = :policy";
+			parameters['policy'] = 'any';
+			break;
+		}
+		default:
+			throw new Error('Unsupported database type');
+	}
+
+	return { whereClause, parameters };
+}

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -71,6 +71,7 @@ export class WorkflowService {
 		includeScopes?: boolean,
 		includeFolders?: boolean,
 		onlySharedWithMe?: boolean,
+		withAnyWorkflowCallerPolicy?: boolean,
 	) {
 		let count;
 		let workflows;
@@ -94,6 +95,14 @@ export class WorkflowService {
 			sharedWorkflowIds = await this.workflowSharingService.getSharedWorkflowIds(user, {
 				scopes: ['workflow:read'],
 			});
+		}
+
+		if (withAnyWorkflowCallerPolicy) {
+			const workflowsForSubExecution =
+				await this.workflowRepository.findWorkflowsWithCallerPolicyAny();
+
+			sharedWorkflowIds.push(...workflowsForSubExecution.map((wf) => wf.id));
+			sharedWorkflowIds = [...new Set(sharedWorkflowIds)];
 		}
 
 		if (includeFolders) {

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -246,6 +246,26 @@ export class WorkflowsController {
 		}
 	}
 
+	@Get('/caller-policy-any', { middlewares: listQueryMiddleware })
+	async getAllCallerPolicyAny(req: WorkflowRequest.GetMany, res: express.Response) {
+		try {
+			const { workflows: data, count } = await this.workflowService.getMany(
+				req.user,
+				req.listQueryOptions,
+				!!req.query.includeScopes,
+				!!req.query.includeFolders,
+				!!req.query.onlySharedWithMe,
+				true,
+			);
+
+			res.json({ count, data });
+		} catch (maybeError) {
+			const error = utils.toError(maybeError);
+			ResponseHelper.reportError(error);
+			ResponseHelper.sendErrorResponse(res, error);
+		}
+	}
+
 	@Get('/new')
 	async getNewName(req: WorkflowRequest.NewName) {
 		const requestedName = req.query.name ?? this.globalConfig.workflows.defaultName;

--- a/packages/frontend/editor-ui/src/api/workflows.ts
+++ b/packages/frontend/editor-ui/src/api/workflows.ts
@@ -44,6 +44,18 @@ export async function getWorkflows(context: IRestApiContext, filter?: object, op
 	});
 }
 
+export async function getWorkflowsForSubworkflowExecution(
+	context: IRestApiContext,
+	filter?: object,
+	options?: object,
+) {
+	return await getFullApiResponse<IWorkflowDb[]>(context, 'GET', '/workflows/caller-policy-any', {
+		includeScopes: true,
+		...(filter ? { filter } : {}),
+		...(options ? options : {}),
+	});
+}
+
 export async function getWorkflowsWithNodesIncluded(context: IRestApiContext, nodeTypes: string[]) {
 	return await getFullApiResponse<WorkflowResource[]>(
 		context,

--- a/packages/frontend/editor-ui/src/components/WorkflowSelectorParameterInput/useWorkflowResourcesLocator.ts
+++ b/packages/frontend/editor-ui/src/components/WorkflowSelectorParameterInput/useWorkflowResourcesLocator.ts
@@ -20,23 +20,24 @@ export function useWorkflowResourcesLocator(router: Router) {
 	const PAGE_SIZE = 40;
 
 	const sortedWorkflows = computed(() =>
-		sortBy(workflowsStore.allWorkflows, (workflow) =>
+		sortBy(workflowsStore.allWorkflowsForSubworkflowSelection, (workflow) =>
 			new Date(workflow.updatedAt).valueOf(),
 		).reverse(),
 	);
 
 	const hasMoreWorkflowsToLoad = computed(
-		() => workflowsStore.allWorkflows.length > workflowsResources.value.length,
+		() =>
+			workflowsStore.allWorkflowsForSubworkflowSelection.length > workflowsResources.value.length,
 	);
 
 	const filteredResources = computed(() => {
-		return workflowsStore.allWorkflows
+		return workflowsStore.allWorkflowsForSubworkflowSelection
 			.filter((resource) => resource.name.toLowerCase().includes(searchFilter.value.toLowerCase()))
 			.map(workflowDbToResourceMapper);
 	});
 
 	async function populateNextWorkflowsPage() {
-		await workflowsStore.fetchAllWorkflows();
+		await workflowsStore.fetchAllWorkflowsForSubworkflowSelection();
 		const nextPage = sortedWorkflows.value.slice(
 			workflowsResources.value.length,
 			workflowsResources.value.length + PAGE_SIZE,
@@ -53,7 +54,7 @@ export function useWorkflowResourcesLocator(router: Router) {
 
 	async function reloadWorkflows() {
 		isLoadingResources.value = true;
-		await workflowsStore.fetchAllWorkflows();
+		await workflowsStore.fetchAllWorkflowsForSubworkflowSelection();
 		isLoadingResources.value = false;
 	}
 
@@ -72,7 +73,7 @@ export function useWorkflowResourcesLocator(router: Router) {
 	}
 
 	function getWorkflowName(id: string): string {
-		const workflow = workflowsStore.getWorkflowById(id);
+		const workflow = workflowsStore.getSubworkflowWorkflowById(id);
 		if (workflow) {
 			// Add the project name if it's not a personal project
 			if (workflow.homeProject && workflow.homeProject.type !== 'personal') {
@@ -84,7 +85,7 @@ export function useWorkflowResourcesLocator(router: Router) {
 	}
 
 	function getWorkflowBaseName(id: string): string | null {
-		const workflow = workflowsStore.getWorkflowById(id);
+		const workflow = workflowsStore.getSubworkflowWorkflowById(id);
 		if (workflow) {
 			return workflow.name;
 		}


### PR DESCRIPTION
## Summary

This allows to select workflows in the call subworkflow node list, even if the user has no project access to it, but the workflow has a caller policy set to `any`.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/ADO-3944/workflow-doesnt-appear-in-workflow-list-of-execute-workflow-tool-after

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
