### PR TITLE
ci: Revert blacksmith changes on release publish job

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   publish-to-npm:
     name: Publish to NPM
-    runs-on: blacksmith-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true
     timeout-minutes: 15
     permissions:
@@ -25,16 +25,23 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set release version in env
-        run: echo "RELEASE=$(node -e 'console.log(require("./package.json").version)')" >> "$GITHUB_ENV"
-
-      - name: Setup Node.js, install dependencies, and build
-        uses: ./.github/actions/setup-nodejs-blacksmith
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.x
 
-      # NOTE: Turborepo caching is handled by setup-nodejs-blacksmith action above
-      # This manual cache may be redundant but kept for safety
+      - name: Setup corepack and pnpm
+        run: |
+          npm i -g corepack@0.33
+          corepack enable
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Set release version in env
+        run: echo "RELEASE=$(node -e 'console.log(require("./package.json").version)')" >> "$GITHUB_ENV"
+
+      - name: Build
+        run: pnpm build
+
       - name: Cache build artifacts
         uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:


### PR DESCRIPTION
## Summary

We can't publish npm package with non github runners due to our need of still having npm provenance flag provided. Previous patch release job [failed](https://github.com/n8n-io/n8n/actions/runs/17426400963/job/49474355700#step:9:17 ) because of that, so I'm reverting a change.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1337/revert-the-blacksmith-runner-change-on-release-publish-job


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
