### PR TITLE
fix(core): Add index for executions list performance increase

### DIFF
--- a/packages/@n8n/db/src/migrations/postgresdb/1757105063613-CreateSortIndexForExecutions.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/1757105063613-CreateSortIndexForExecutions.ts
@@ -1,0 +1,21 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+export class CreateSortIndexForExecutions1757105063613 implements ReversibleMigration {
+	public async up({ queryRunner, tablePrefix }: MigrationContext): Promise<void> {
+		await queryRunner.query(`
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_${tablePrefix}executions_sort"
+        ON ${tablePrefix}execution_entity"
+        (
+          "workflowId",
+          (COALESCE("startedAt","createdAt")) DESC
+        )
+        WHERE "deletedAt" IS NULL
+      `);
+	}
+
+	public async down({ queryRunner, tablePrefix }: MigrationContext): Promise<void> {
+		await queryRunner.query(
+			`DROP INDEX CONCURRENTLY IF EXISTS "idx_${tablePrefix}executions_sort"`,
+		);
+	}
+}


### PR DESCRIPTION
## Summary

The query:

```
SELECT e.*, "ate"."id" AS "annotation_tags_id", "ate"."name" AS "annotation_tags_name" FROM (SELECT "execution"."id" AS "id", "execution"."workflowId" AS "workflowId", "execution"."mode" AS "mode", "execution"."retryOf" AS "retryOf", "execution"."status" AS "status", "execution"."createdAt" AS "createdAt", "execution"."startedAt" AS "startedAt", "execution"."stoppedAt" AS "stoppedAt", "execution"."waitTill" AS "waitTill", "execution"."retrySuccessId" AS "retrySuccessId", "workflow"."name" AS "workflowName", "annotation"."id" AS "annotation_id", "annotation"."vote" AS "annotation_vote" FROM "public"."execution_entity" "execution" INNER JOIN "public"."workflow_entity" "workflow" ON "workflow"."id"="execution"."workflowId"  INNER JOIN "public"."workflow_entity" "w" ON "w"."id" = "execution"."workflowId"  INNER JOIN "public"."shared_workflow" "sw" ON "sw"."workflowId" = "w"."id"  LEFT JOIN "public"."execution_annotations" "annotation" ON "annotation"."executionId"="execution"."id" WHERE ( "execution"."workflowId" IN ('6vF8uzVxVBnm0nAr', 'p3fd9rMmLKvPP') AND "execution"."status" IN ('canceled','crashed','error','success','unknown','waiting') AND "sw"."projectId" = 'iQzs6LCSkJ55EhLn' ) AND ( "execution"."deletedAt" IS NULL ) ORDER BY COALESCE("execution"."startedAt", "execution"."createdAt") DESC LIMIT 10) "e" LEFT JOIN "public"."execution_annotation_tags" "atm" ON "atm"."annotationId" = e.annotation_id  LEFT JOIN "public"."annotation_tag_entity" "ate" ON "ate"."id" = "atm"."tagId" ORDER BY COALESCE("e"."startedAt", "e"."createdAt") DESC
```
Was causing our n8n instance to reach 100% CPU usage making the system unusable during peak times.

Before adding the index: 
<img width="903" height="181" alt="before the index" src="https://github.com/user-attachments/assets/58bd35b7-cd14-4267-89a1-ad54e7388fcf" />

After adding the index:
<img width="903" height="181" alt="after the index" src="https://github.com/user-attachments/assets/7e5f4d0b-1431-4633-812b-b3faa9c9b0e9" />



## Related Linear tickets, Github issues, and Community forum posts

N/A


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
