### PR TITLE
Fix typo in YouTube video privacy status value

### DIFF
--- a/packages/nodes-base/nodes/Google/YouTube/VideoDescription.ts
+++ b/packages/nodes-base/nodes/Google/YouTube/VideoDescription.ts
@@ -776,7 +776,7 @@ export const videoFields: INodeProperties[] = [
 					},
 					{
 						name: 'Unlisted',
-						value: 'unlistef',
+						value: 'unlisted',
 					},
 				],
 				default: '',


### PR DESCRIPTION
I was trying to set a video to unlisted using the YouTube update video node. There was a typo in the default values, where it would be "unlistef" instead of "unlisted." This caused an error on the YouTube API.

I went ahead and fixed the typo, so it should work with the YouTube API now.
<img width="1296" height="180" alt="Screenshot 2025-09-06 at 2 33 34 PM" src="https://github.com/user-attachments/assets/d2225238-9688-49e7-94e9-8f2844a27cac" />
