### PR TITLE
ci: Fix multi-runner image not running on cloud

### DIFF
--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -110,11 +110,9 @@ COPY --from=node-alpine /usr/local/bin/npm /usr/local/bin/npm
 COPY --from=node-alpine /usr/local/bin/npx /usr/local/bin/npx
 COPY --from=node-alpine /usr/local/lib/node_modules /usr/local/lib/node_modules
 
-# Node needs libstdc++
-RUN apk add --no-cache ca-certificates tini libstdc++
-
-# Debugging task runner launcher problems, TODO removeme
-RUN apk add --no-cache file binutils pax-utils
+# libstdc++ is required by Node
+# libc6-compat is required by task-runner-launcher
+RUN apk add --no-cache ca-certificates tini libstdc++ libc6-compat
 
 RUN addgroup -g 1000 -S runner \
  && adduser -u 1000 -S -G runner -h /home/runner -D runner

--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -113,6 +113,9 @@ COPY --from=node-alpine /usr/local/lib/node_modules /usr/local/lib/node_modules
 # Node needs libstdc++
 RUN apk add --no-cache ca-certificates tini libstdc++
 
+# Debugging task runner launcher problems, TODO removeme
+RUN apk add --no-cache file binutils pax-utils
+
 RUN addgroup -g 1000 -S runner \
  && adduser -u 1000 -S -G runner -h /home/runner -D runner
 WORKDIR /home/runner

--- a/docker/images/runners/README.md
+++ b/docker/images/runners/README.md
@@ -33,10 +33,10 @@ docker buildx build \
 N8N_RUNNERS_ENABLED=true \
 N8N_RUNNERS_MODE=external \
 N8N_RUNNERS_AUTH_TOKEN=test \
+N8N_NATIVE_PYTHON_RUNNER=true \
 N8N_LOG_LEVEL=debug \
 pnpm start
 ```
-
 
 ### 4) Start the task runner container
 


### PR DESCRIPTION
## Summary

Turns out the n8nio/runners image did't work on real cloud due to the `task-runner-launcher` being dynamically linked to glibc, which wasn't available on the alpine linux based image.

On current production we've been running `task-runner-launcher` in a similar environment with libc6-compat installed, lets install it on this image as well. The alternative could've been to change the go binary's build to a statically linked one, but this seems like an easier way to solve this.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1338/multi-runner-image-doesnt-run-on-real-cloud-amd64

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
