### PR TITLE
test: Update Posthog test

### DIFF
--- a/packages/testing/playwright/tests/cli-workflows/credentials.json
+++ b/packages/testing/playwright/tests/cli-workflows/credentials.json
@@ -1667,10 +1667,10 @@
 	},
 	{
 		"createdAt": "2021-03-24T13:18:39.585Z",
-		"updatedAt": "2021-03-24T13:21:09.217Z",
+		"updatedAt": "2025-09-08T09:04:51.618Z",
 		"id": "121",
 		"name": "PostHog API",
-		"data": "U2FsdGVkX1+dxVkGdcLhw/iwAZ6ZhsE/B5fcd2vpZQ7D4fzJCDCTOa42QLamab0a+76Z+B7qWIYwjAmJ2esTX/XXzwcSf3pmLF3BgFktOezmzBHZ0Pg13R2aMcXsNTq1IlNUvYnsLw8hURREdBE0DQ==",
+		"data": "U2FsdGVkX18BdzysyH/Waz+G5pOIRTztVQJVrsU4oAE18zHXdV/dC01lfk9ZJ0XTm/QguU7GOouRBidbXILM2isCX6sWHuuaI7dnExpn8WegKrQR230hMdGe8HC4HK50UjINLqC62YD7UgsaS2zRKw==",
 		"type": "postHogApi",
 		"nodesAccess": [
 			{

--- a/packages/testing/playwright/tests/cli-workflows/workflows/150.json
+++ b/packages/testing/playwright/tests/cli-workflows/workflows/150.json
@@ -71,6 +71,7 @@
 					"name": "PostHog API"
 				}
 			},
+			"disabled": true,
 			"id": "dd146375-b44f-445a-a2a4-fbaeb9028b0c"
 		},
 		{
@@ -100,6 +101,7 @@
 					"name": "PostHog API"
 				}
 			},
+			"disabled": true,
 			"id": "cb1f2644-f1a7-46b0-950e-de720819b2b7"
 		},
 		{
@@ -122,6 +124,7 @@
 					"name": "PostHog API"
 				}
 			},
+			"disabled": true,
 			"id": "88973d09-036b-41c3-a24c-d799ef0354e2"
 		},
 		{
@@ -145,6 +148,7 @@
 					"name": "PostHog API"
 				}
 			},
+			"disabled": true,
 			"id": "2677f5a4-9a15-41f2-a8c0-ea42f269f57b"
 		}
 	],


### PR DESCRIPTION
## Summary
This PR moves the Posthog node test from the self hosted instance to Posthog cloud so we can shutdown the self hosted service.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-3597/posthog-instance-not-correctly-configured


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
