### PR TITLE
refactor(core): Make retry endpoint return full execution object over just the status string

### DIFF
--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -246,12 +246,22 @@ export class ExecutionService {
 			throw new UnexpectedError('The retry did not start for an unknown reason.');
 		}
 
-		// TODO: discuss wether we should add an additional this.executionRepository.findWithUnflattenedData(retriedExecutionId,sharedWorkflowIds)
-		// call in favor of manually creating the execution object
 		return {
-			...execution,
-			...executionData,
 			id: retriedExecutionId,
+			mode: executionData.mode,
+			createdAt: execution.createdAt,
+			startedAt: executionData.startedAt,
+			stoppedAt: executionData.stoppedAt,
+			workflowId: execution.workflowId,
+			finished: executionData.finished ?? false,
+			retryOf: execution.retryOf,
+			retrySuccessId: execution.retrySuccessId,
+			status: executionData.status,
+			waitTill: executionData.waitTill,
+			data: executionData.data,
+			workflowData: execution.workflowData,
+			customData: execution.customData,
+			annotation: execution.annotation,
 		};
 	}
 

--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -114,7 +114,7 @@ export class ExecutionService {
 	async findOne(
 		req: ExecutionRequest.GetOne | ExecutionRequest.Update,
 		sharedWorkflowIds: string[],
-	): Promise<IExecutionResponse | IExecutionFlattedResponse | undefined> {
+	): Promise<IExecutionFlattedResponse | undefined> {
 		if (!sharedWorkflowIds.length) return undefined;
 
 		const { id: executionId } = req.params;

--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -240,14 +240,14 @@ export class ExecutionService {
 
 		const retriedExecutionId = await this.workflowRunner.run(data);
 
-		// TODO: discuss wether this.executionRepository.findWithUnflattenedData(retriedExecutionId,sharedWorkflowIds) is preferred
-		// over using getPostExecutePromise and creating the complete response by merging execution, executionData and the retriedExecutionId
 		const executionData = await this.activeExecutions.getPostExecutePromise(retriedExecutionId);
 
 		if (!executionData) {
 			throw new UnexpectedError('The retry did not start for an unknown reason.');
 		}
 
+		// TODO: discuss wether we should add an additional this.executionRepository.findWithUnflattenedData(retriedExecutionId,sharedWorkflowIds)
+		// call in favor of manually creating the execution object
 		return {
 			...execution,
 			...executionData,

--- a/packages/cli/src/executions/execution.types.ts
+++ b/packages/cli/src/executions/execution.types.ts
@@ -14,8 +14,6 @@ export declare namespace ExecutionRequest {
 			lastId: string;
 			firstId: string;
 		};
-
-		type GetOne = { unflattedResponse: 'true' | 'false' };
 	}
 
 	namespace BodyParams {
@@ -41,7 +39,7 @@ export declare namespace ExecutionRequest {
 		rangeQuery: ExecutionSummaries.RangeQuery; // parsed from query params
 	};
 
-	type GetOne = AuthenticatedRequest<RouteParams.ExecutionId, {}, {}, QueryParams.GetOne>;
+	type GetOne = AuthenticatedRequest<RouteParams.ExecutionId>;
 
 	type Delete = AuthenticatedRequest<{}, {}, BodyParams.DeleteFilter>;
 

--- a/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts
@@ -165,14 +165,17 @@ export = {
 			}
 
 			try {
-				const retryResponse = await Container.get(ExecutionService).retry(req, sharedWorkflowsIds);
+				const retriedExecution = await Container.get(ExecutionService).retry(
+					req,
+					sharedWorkflowsIds,
+				);
 
 				Container.get(EventService).emit('user-retried-execution', {
 					userId: req.user.id,
 					publicApi: true,
 				});
 
-				return res.json({ status: retryResponse });
+				return res.json(replaceCircularReferences(retriedExecution));
 			} catch (error) {
 				if (
 					error instanceof QueuedExecutionRetryError ||

--- a/packages/cli/test/integration/public-api/executions.test.ts
+++ b/packages/cli/test/integration/public-api/executions.test.ts
@@ -246,9 +246,8 @@ describe('POST /executions/:id/retry', () => {
 
 	test('should retry an execution', async () => {
 		const mockedRetriedExecutionStatus = 'waiting';
-		jest
-			.spyOn(Container.get(ExecutionService), 'retry')
-			.mockResolvedValue(mockedRetriedExecutionStatus);
+		const mockedExecutionResponse = { status: mockedRetriedExecutionStatus } as any;
+		jest.spyOn(Container.get(ExecutionService), 'retry').mockResolvedValue(mockedExecutionResponse);
 
 		const workflow = await createWorkflow({}, user1);
 		const execution = await createSuccessfulExecution(workflow);

--- a/packages/frontend/editor-ui/src/components/executions/global/GlobalExecutionsList.vue
+++ b/packages/frontend/editor-ui/src/components/executions/global/GlobalExecutionsList.vue
@@ -245,8 +245,8 @@ async function retryOriginalExecution(execution: ExecutionSummary) {
 
 async function retryExecution(execution: ExecutionSummary, loadWorkflow?: boolean) {
 	try {
-		const retryStatus = await executionsStore.retryExecution(execution.id, loadWorkflow);
-		const retryMessage = executionRetryMessage(retryStatus);
+		const retriedExecution = await executionsStore.retryExecution(execution.id, loadWorkflow);
+		const retryMessage = executionRetryMessage(retriedExecution.status);
 
 		if (retryMessage) {
 			toast.showMessage(retryMessage);

--- a/packages/frontend/editor-ui/src/stores/executions.store.ts
+++ b/packages/frontend/editor-ui/src/stores/executions.store.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia';
 import { computed, ref } from 'vue';
-import type { IDataObject, ExecutionSummary, AnnotationVote, ExecutionStatus } from 'n8n-workflow';
+import type { IDataObject, ExecutionSummary, AnnotationVote } from 'n8n-workflow';
 import type {
 	ExecutionFilterType,
 	ExecutionsQueryFilter,
@@ -244,8 +244,8 @@ export const useExecutionsStore = defineStore('executions', () => {
 		);
 	}
 
-	async function retryExecution(id: string, loadWorkflow?: boolean): Promise<ExecutionStatus> {
-		return await makeRestApiRequest(
+	async function retryExecution(id: string, loadWorkflow?: boolean): Promise<IExecutionResponse> {
+		const retriedExecution = await makeRestApiRequest<IExecutionResponse>(
 			rootStore.restApiContext,
 			'POST',
 			`/executions/${id}/retry`,
@@ -255,6 +255,7 @@ export const useExecutionsStore = defineStore('executions', () => {
 					}
 				: undefined,
 		);
+		return retriedExecution;
 	}
 
 	async function deleteExecutions(sendData: IExecutionDeleteFilter): Promise<void> {

--- a/packages/frontend/editor-ui/src/views/WorkflowExecutionsView.vue
+++ b/packages/frontend/editor-ui/src/views/WorkflowExecutionsView.vue
@@ -283,9 +283,9 @@ async function onExecutionRetry(payload: { id: string; loadWorkflow: boolean }) 
 
 async function retryExecution(payload: { id: string; loadWorkflow: boolean }) {
 	try {
-		const retryStatus = await executionsStore.retryExecution(payload.id, payload.loadWorkflow);
+		const retriedExecution = await executionsStore.retryExecution(payload.id, payload.loadWorkflow);
 
-		const retryMessage = executionRetryMessage(retryStatus);
+		const retryMessage = executionRetryMessage(retriedExecution.status);
 
 		if (retryMessage) {
 			toast.showMessage(retryMessage);


### PR DESCRIPTION
## Summary

Sub-PR of https://github.com/n8n-io/n8n/pull/19132

Removed non implemented [unflattenResponse](https://github.com/n8n-io/n8n/blob/master/packages/cli/src/executions/execution.types.ts#L18) typing for `ExecutionService.findOne`.
Changed the `ExecutionService.retry` implementation to return a full Execution object, rather than just the updated status string.

In commit https://github.com/n8n-io/n8n/pull/19293/commits/4de8e2f2f191d9a78fdd13efc7937ef70312b3cc, we're adding one call to fetch the updated execution object at the end of the method.

Alternatively in the following commit https://github.com/n8n-io/n8n/pull/19293/commits/cb87eb5cbaa0c1a197bac892c24f65bf01e07f54 you can see an implementation that doesn't change any of the requests we send and returns an updated execution object from the results of three requests.

~I'm wondering, is activeExecutions.getPostExecutePromise a cheaper operation than executionRepository.findWithUnflattenedData, because it gets it from memory.
Generally, I think it'd be easier to reason about this code when using findWithUnflattenedData and just returning that object, rather than merging the complete execution object manually from various responses~

Update: We need the `activeExecutions.getPostExecutePromise` call either way, to be able to detect wether the execution was actually not retried.
So the remaining question is: do we add an additional call to `executionRepository.findWithUnflattenedData` at the end of the `retry` method, or is it fine to manually stitch together the execution object to return?

## Related Linear tickets, Github issues, and Community forum posts

[PAY-3649](https://linear.app/n8n/issue/PAY-3649)


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
