### PR TITLE
fix(editor): Show correct options in the NDV runs selector

### DIFF
--- a/packages/frontend/editor-ui/src/components/RunData.test.ts
+++ b/packages/frontend/editor-ui/src/components/RunData.test.ts
@@ -618,7 +618,7 @@ describe('RunData', () => {
 			expect(container.querySelector('.run-selector')).not.toBeInTheDocument();
 		});
 
-		it('Show run selector when branch switch is shown (with all runs)', () => {
+		it('Show run selector when branch switch is shown (with all runs)', async () => {
 			// Create multiple runs with data in different outputs
 			const multipleRuns = [
 				{
@@ -659,7 +659,7 @@ describe('RunData', () => {
 				},
 			];
 
-			const { getByTestId } = render({
+			const { getByTestId, findAllByTestId } = render({
 				displayMode: 'json',
 				runs: multipleRuns,
 			});
@@ -667,10 +667,12 @@ describe('RunData', () => {
 			// When there are multiple branches and outputs, the run selector should be visible
 			const runSelector = getByTestId('run-selector');
 			expect(runSelector).toBeInTheDocument();
-			// TODO: check number of options in run selector
+
+			const runSelectorOptionsCount = await findAllByTestId('run-selection-option');
+			expect(runSelectorOptionsCount.length).toBe(3);
 		});
 
-		it('Show run selector when there is no branch selector (only runs for branch with data)', () => {
+		it('Show run selector when there is no branch selector (only runs for branch with data)', async () => {
 			// Create multiple runs with data in different outputs
 			const multipleRuns = [
 				{
@@ -711,7 +713,7 @@ describe('RunData', () => {
 				},
 			];
 
-			const { getByTestId } = render({
+			const { getByTestId, findAllByTestId } = render({
 				displayMode: 'json',
 				runs: multipleRuns,
 				overrideOutputs: [1],
@@ -720,7 +722,9 @@ describe('RunData', () => {
 			// Should show run selector since there are multiple runs
 			const runSelector = getByTestId('run-selector');
 			expect(runSelector).toBeInTheDocument();
-			// TODO: check number of options in run selector
+
+			const runSelectorOptionsCount = await findAllByTestId('run-selection-option');
+			expect(runSelectorOptionsCount.length).toBe(2);
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/components/RunData.test.ts
+++ b/packages/frontend/editor-ui/src/components/RunData.test.ts
@@ -606,6 +606,124 @@ describe('RunData', () => {
 		expect(getByTestId('ndv-items-count')).toBeInTheDocument();
 	});
 
+	describe('computed properties for branch handling', () => {
+		it('no run selector when no run data exists', () => {
+			const { container } = render({
+				displayMode: 'json',
+				runs: [],
+			});
+
+			// Component instance checks would need to be done differently in Vue 3
+			// For now, we verify the behavior through the UI
+			expect(container.querySelector('.run-selector')).not.toBeInTheDocument();
+		});
+
+		it('Show run selector when branch switch is shown (with all runs)', () => {
+			// Create multiple runs with data in different outputs
+			const multipleRuns = [
+				{
+					startTime: Date.now(),
+					executionIndex: 0,
+					executionTime: 1,
+					data: {
+						main: [
+							[{ json: { value: 1 } }], // output 0
+							[{ json: { value: 2 } }], // output 1
+						],
+					},
+					source: [null],
+				},
+				{
+					startTime: Date.now(),
+					executionIndex: 1,
+					executionTime: 1,
+					data: {
+						main: [
+							[{ json: { value: 3 } }], // output 0
+							[], // output 1 empty
+						],
+					},
+					source: [null],
+				},
+				{
+					startTime: Date.now(),
+					executionIndex: 2,
+					executionTime: 1,
+					data: {
+						main: [
+							[], // output 0 empty
+							[{ json: { value: 4 } }], // output 1
+						],
+					},
+					source: [null],
+				},
+			];
+
+			const { getByTestId } = render({
+				displayMode: 'json',
+				runs: multipleRuns,
+			});
+
+			// When there are multiple branches and outputs, the run selector should be visible
+			const runSelector = getByTestId('run-selector');
+			expect(runSelector).toBeInTheDocument();
+			// TODO: check number of options in run selector
+		});
+
+		it('Show run selector when there is no branch selector (only runs for branch with data)', () => {
+			// Create multiple runs with data in different outputs
+			const multipleRuns = [
+				{
+					startTime: Date.now(),
+					executionIndex: 0,
+					executionTime: 1,
+					data: {
+						main: [
+							[{ json: { value: 1 } }], // output 0
+							[{ json: { value: 2 } }], // output 1
+						],
+					},
+					source: [null],
+				},
+				{
+					startTime: Date.now(),
+					executionIndex: 1,
+					executionTime: 1,
+					data: {
+						main: [
+							[{ json: { value: 3 } }], // output 0
+							[], // output 1 empty
+						],
+					},
+					source: [null],
+				},
+				{
+					startTime: Date.now(),
+					executionIndex: 2,
+					executionTime: 1,
+					data: {
+						main: [
+							[], // output 0 empty
+							[{ json: { value: 4 } }], // output 1
+						],
+					},
+					source: [null],
+				},
+			];
+
+			const { getByTestId } = render({
+				displayMode: 'json',
+				runs: multipleRuns,
+				overrideOutputs: [1],
+			});
+
+			// Should show run selector since there are multiple runs
+			const runSelector = getByTestId('run-selector');
+			expect(runSelector).toBeInTheDocument();
+			// TODO: check number of options in run selector
+		});
+	});
+
 	// Default values for the render function
 	const nodes = [
 		{
@@ -627,6 +745,7 @@ describe('RunData', () => {
 		paneType = 'output',
 		metadata,
 		runs,
+		overrideOutputs,
 	}: {
 		defaultRunItems?: INodeExecutionData[];
 		workflowId?: string;
@@ -636,6 +755,7 @@ describe('RunData', () => {
 		paneType?: NodePanelType;
 		metadata?: ITaskMetadata;
 		runs?: ITaskData[];
+		overrideOutputs?: number[];
 	}) => {
 		const defaultRun: ITaskData = {
 			startTime: Date.now(),
@@ -735,6 +855,7 @@ describe('RunData', () => {
 				tooMuchDataTitle: '',
 				executingMessage: '',
 				noDataInBranchMessage: '',
+				overrideOutputs,
 			},
 			pinia,
 		});

--- a/packages/frontend/editor-ui/src/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/components/RunData.vue
@@ -1540,6 +1540,7 @@ defineExpose({ enterEditMode });
 							:key="option"
 							:label="getRunLabel(option)"
 							:value="option - 1"
+							data-test-id="run-selection-option"
 						></N8nOption>
 					</N8nSelect>
 

--- a/packages/frontend/editor-ui/src/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/components/RunData.vue
@@ -388,6 +388,9 @@ const maxOutputIndex = computed(() => {
 	return 0;
 });
 const currentPageOffset = computed(() => pageSize.value * (currentPage.value - 1));
+const showBranchSwitch = computed(
+	() => maxOutputIndex.value > 0 && branches.value.length > 1 && !displaysMultipleNodes.value,
+);
 const maxRunIndex = computed(() => {
 	if (!node.value) {
 		return 0;
@@ -404,6 +407,29 @@ const maxRunIndex = computed(() => {
 	}
 
 	return 0;
+});
+
+const runSelectorOptionsCount = computed(() => {
+	if (!node.value) {
+		return 0;
+	}
+
+	const runData: IRunData | null = workflowRunData.value;
+
+	if (!runData?.hasOwnProperty(node.value.name)) {
+		return 0;
+	}
+
+	// If there is branch selector – we show all runs in the run selector
+	if (showBranchSwitch.value) {
+		return maxRunIndex.value + 1;
+	}
+
+	// If there is only one branch - we show only the runs containing the data in the connected branch
+	return runData[node.value.name].filter((nodeRun) => {
+		const nodeOutput = nodeRun?.data?.[connectionType.value]?.[currentOutputIndex.value];
+		return nodeOutput && nodeOutput?.length > 0;
+	}).length;
 });
 
 const rawInputData = computed(() =>
@@ -1136,7 +1162,7 @@ function getRunLabel(option: number) {
 		: '';
 
 	const itemsLabel = itemsCount > 0 ? ` (${items}${subexecutions})` : '';
-	return option + i18n.baseText('ndv.output.of') + (maxRunIndex.value + 1) + itemsLabel;
+	return option + i18n.baseText('ndv.output.of') + runSelectorOptionsCount.value + itemsLabel;
 }
 
 function getRawInputData(
@@ -1510,7 +1536,7 @@ defineExpose({ enterEditMode });
 					>
 						<template #prepend>{{ i18n.baseText('ndv.output.run') }}</template>
 						<N8nOption
-							v-for="option in maxRunIndex + 1"
+							v-for="option in runSelectorOptionsCount"
 							:key="option"
 							:label="getRunLabel(option)"
 							:value="option - 1"
@@ -1564,11 +1590,7 @@ defineExpose({ enterEditMode });
 				<N8nText v-n8n-html="hint.message" size="small"></N8nText>
 			</N8nCallout>
 
-			<div
-				v-if="maxOutputIndex > 0 && branches.length > 1 && !displaysMultipleNodes"
-				:class="$style.outputs"
-				data-test-id="branches"
-			>
+			<div v-if="showBranchSwitch" :class="$style.outputs" data-test-id="branches">
 				<slot v-if="inputSelectLocation === 'outputs'" name="input-select"></slot>
 				<ViewSubExecution
 					v-if="activeTaskMetadata && !(paneType === 'input' && hasInputOverwrite)"


### PR DESCRIPTION
## Summary

Fixes the run selector issue when nodes inside the loop showed a final run of the loop node as the last option.

Example workflow:
<img width="723" height="289" alt="image" src="https://github.com/user-attachments/assets/2ce29794-f3b0-4c51-955e-ea1906ec5659" />

Before (NDV of the node inside the loop):
<img width="1431" height="396" alt="image" src="https://github.com/user-attachments/assets/1269d59d-f50f-44f7-9315-c96c56a87049" />

After (NDV of the node inside the loop):
<img width="1432" height="399" alt="image" src="https://github.com/user-attachments/assets/7e959865-dabf-46a4-a0c3-e4fd6c69fea2" />

NDV outside the loop (run selector has all the runs, as the branch switch also present):
<img width="1453" height="431" alt="image" src="https://github.com/user-attachments/assets/87bf5151-1f01-44af-869b-ad48716d6435" />

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/ADO-3707/wrong-number-of-run-items-shown-within-a-set-fields-node-within-a-loop


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
