### PR TITLE
fix(editor): Focus on selection when clicking 'tidy up'

### DIFF
--- a/packages/frontend/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/Canvas.vue
@@ -35,7 +35,7 @@ import type {
 	ViewportTransform,
 	XYPosition,
 } from '@vue-flow/core';
-import { MarkerType, PanelPosition, useVueFlow, VueFlow } from '@vue-flow/core';
+import { getRectOfNodes, MarkerType, PanelPosition, useVueFlow, VueFlow } from '@vue-flow/core';
 import { MiniMap } from '@vue-flow/minimap';
 import { onKeyDown, onKeyUp, useThrottleFn } from '@vueuse/core';
 import { NodeConnectionTypes } from 'n8n-workflow';
@@ -149,6 +149,7 @@ const {
 	removeSelectedNodes,
 	viewportRef,
 	fitView,
+	fitBounds,
 	zoomIn,
 	zoomOut,
 	zoomTo,
@@ -635,6 +636,10 @@ function onClickPane(event: MouseEvent) {
 	emit('click:pane', getProjectedPosition(event));
 }
 
+async function onFitBounds(nodes: GraphNode[]) {
+	await fitBounds(getRectOfNodes(nodes), { padding: 2 });
+}
+
 async function onFitView() {
 	await fitView({ maxZoom: defaultZoom, padding: 0.2 });
 }
@@ -769,7 +774,11 @@ async function onTidyUp(payload: { source: CanvasLayoutSource; nodeIdsFilter?: s
 	emit('tidy-up', { result, target, source: payload.source });
 
 	await nextTick();
-	await onFitView();
+	if (applyOnSelection) {
+		await onFitBounds(selectedNodes.value);
+	} else {
+		await onFitView();
+	}
 }
 
 /**

--- a/packages/frontend/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/frontend/editor-ui/src/components/canvas/Canvas.vue
@@ -768,10 +768,8 @@ async function onTidyUp(payload: { source: CanvasLayoutSource; nodeIdsFilter?: s
 
 	emit('tidy-up', { result, target, source: payload.source });
 
-	if (!applyOnSelection) {
-		await nextTick();
-		await onFitView();
-	}
+	await nextTick();
+	await onFitView();
 }
 
 /**


### PR DESCRIPTION
## Summary
This fixes an issue when tidying up the selection would seemingly do nothing after pasting nodes. It happened because the selection wasn't centered after clicking the button.

Before:

https://github.com/user-attachments/assets/55118e37-2b84-445f-b284-bb931ae2a534

After:


https://github.com/user-attachments/assets/fa2189a6-442c-4fc1-a0b8-d4d41a980cc8


@elsmr, do you remember why it was implemented in a way that the view doesn't get focused when selection is enabled?

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3590/tidy-up-button-doesnt-work-unless-you-click-on-the-canvas-first


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
