### PR TITLE
ci: Slim down the `n8nio/runners` image

### DIFF
--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -109,9 +109,6 @@ ENV NODE_ENV=production \
 
 # Bring node over from node-alpine
 COPY --from=node-alpine /usr/local/bin/node /usr/local/bin/node
-COPY --from=node-alpine /usr/local/bin/npm /usr/local/bin/npm
-COPY --from=node-alpine /usr/local/bin/npx /usr/local/bin/npx
-COPY --from=node-alpine /usr/local/lib/node_modules /usr/local/lib/node_modules
 
 # libstdc++ is required by Node
 # libc6-compat is required by task-runner-launcher

--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -100,11 +100,11 @@ FROM python:${PYTHON_VERSION}-alpine AS runtime
 ARG N8N_VERSION=snapshot
 ARG N8N_RELEASE_TYPE=dev
 
-ENV NODE_ENV=production
-ENV N8N_RELEASE_TYPE=${N8N_RELEASE_TYPE}
-ENV SHELL=/bin/sh
+ENV NODE_ENV=production \
+    N8N_RELEASE_TYPE=${N8N_RELEASE_TYPE} \
+    SHELL=/bin/sh
 
-# Copy over node from node alpine
+# Bring node over from node-alpine
 COPY --from=node-alpine /usr/local/bin/node /usr/local/bin/node
 COPY --from=node-alpine /usr/local/bin/npm /usr/local/bin/npm
 COPY --from=node-alpine /usr/local/bin/npx /usr/local/bin/npx
@@ -115,16 +115,16 @@ COPY --from=node-alpine /usr/local/lib/node_modules /usr/local/lib/node_modules
 RUN apk add --no-cache ca-certificates tini libstdc++ libc6-compat
 
 RUN addgroup -g 1000 -S runner \
- && adduser -u 1000 -S -G runner -h /home/runner -D runner
+ && adduser  -u 1000 -S -G runner -h /home/runner -D runner \
+ && install -d -o runner -g runner /opt/runners
+
 WORKDIR /home/runner
 
-COPY --from=javascript-runner-builder /app/task-runner-javascript /opt/runners/task-runner-javascript
-COPY --from=python-runner-builder /app/task-runner-python /opt/runners/task-runner-python
+COPY --from=javascript-runner-builder --chown=runner:runner /app/task-runner-javascript /opt/runners/task-runner-javascript
+COPY --from=python-runner-builder --chown=runner:runner /app/task-runner-python /opt/runners/task-runner-python
 COPY --from=launcher-downloader /launcher-bin/* /usr/local/bin/
+COPY --chown=root:root docker/images/runners/n8n-task-runners.json /etc/n8n-task-runners.json
 
-COPY docker/images/runners/n8n-task-runners.json /etc/n8n-task-runners.json
-
-RUN chown -R runner:runner /opt/runners /home/runner
 USER runner
 
 EXPOSE 5680/tcp

--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -54,11 +54,14 @@ RUN uv sync \
 			--frozen \
 			--no-editable \
 			--no-install-project \
+			--no-dev \
 			--all-extras
 
 COPY packages/@n8n/task-runner-python/ ./
 RUN uv sync \
       --frozen \
+			--no-dev \
+			--all-extras \
       --no-editable
 
 # Install extra runtime-only Python packages. Allow usage in the Code node via


### PR DESCRIPTION
## Summary

This brings down the image size from ~501MB to ~287MB. Biggest saving is changing how the ownership of /opt/runners is passed - previous way lead to the files being copied into the new layer.

I also noticed that python's dev dependencies were being installed, which saves additional 60MB.

Trimming `npm`, `npx` and `corepack` from the image saves 13MB. I don't see a need for them now as we just invoke node directly, but if we see the need for them the cost isn't high.

With those issues fixed the image is starting to be pretty slim.

<img width="798" height="227" alt="image" src="https://github.com/user-attachments/assets/53ef508e-9361-49fb-acae-91c60c858f0a" />

<img width="398" height="158" alt="image" src="https://github.com/user-attachments/assets/8eae26cd-8e10-431c-bdb6-a35b1e3b3180" />

To get down from here the biggest savings would be at cutting down the javascript dependencies of task-runner javascript, which currently brings in 99MB of node_modules to import large parts of n8n. 

<img width="471" height="1074" alt="image" src="https://github.com/user-attachments/assets/cdb7d246-e775-4112-b18f-f0e594d0fc93" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1289/slim-down-n8niorunners-image

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
