### PR TITLE
fix(editor): Respect project id and parent folder for callouts (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/composables/useCalloutHelpers.ts
+++ b/packages/frontend/editor-ui/src/composables/useCalloutHelpers.ts
@@ -29,6 +29,7 @@ import {
 } from '@/utils/templates/workflowSamples';
 import type { INodeCreateElement, OpenTemplateElement } from '@/Interface';
 import { useUIStore } from '@/stores/ui.store';
+import { useProjectsStore } from '@/stores/projects.store';
 
 export function useCalloutHelpers() {
 	const route = useRoute();
@@ -45,6 +46,7 @@ export function useCalloutHelpers() {
 	const viewStacks = useViewStacks();
 	const nodeTypesStore = useNodeTypesStore();
 	const uiStore = useUIStore();
+	const projectsStore = useProjectsStore();
 
 	const isRagStarterCalloutVisible = computed(() => {
 		const template = getRagStarterWorkflowJson();
@@ -200,7 +202,11 @@ export function useCalloutHelpers() {
 		const { href } = router.resolve({
 			name: VIEWS.TEMPLATE_IMPORT,
 			params: { id: template.meta.templateId },
-			query: { fromJson: 'true', parentFolderId: route.params.folderId },
+			query: {
+				fromJson: 'true',
+				parentFolderId: route.params.folderId,
+				projectId: projectsStore.currentProjectId,
+			},
 		});
 
 		window.open(href, '_blank');

--- a/packages/frontend/editor-ui/src/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/views/NodeView.vue
@@ -491,7 +491,7 @@ async function fetchAndSetParentFolder(folderId?: string) {
 }
 
 async function fetchAndSetProject(projectId: string) {
-	if (!projectsStore.currentProject) {
+	if (projectsStore.currentProject?.id !== projectId) {
 		const project = await projectsStore.fetchProject(projectId);
 		projectsStore.setCurrentProject(project);
 	}
@@ -614,9 +614,15 @@ async function openTemplateFromWorkflowJSON(workflow: WorkflowDataWithTemplateId
 	isBlankRedirect.value = true;
 	const templateId = workflow.meta.templateId;
 	const parentFolderId = route.query.parentFolderId as string | undefined;
+
+	if (projectsStore.currentProjectId) {
+		await fetchAndSetProject(projectsStore.currentProjectId);
+	}
+	await fetchAndSetParentFolder(parentFolderId);
+
 	await router.replace({
 		name: VIEWS.NEW_WORKFLOW,
-		query: { templateId, parentFolderId },
+		query: { templateId, parentFolderId, projectId: projectsStore.currentProjectId },
 	});
 
 	await importTemplate({


### PR DESCRIPTION
## Summary

When opening a pre-built agent from any project, it was always opened in a personal project and folders were not respected. Same with NDV callouts. Now project and folder information is passed.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4099/clicking-pre-built-agent-modal-adds-the-template-in-the-personal-space

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
