### PR TITLE
feat(core): Add `delete` mode to clear embedded documents from vector stores

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/__snapshots__/createVectorStoreNode.test.ts.snap
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/__snapshots__/createVectorStoreNode.test.ts.snap
@@ -52,7 +52,7 @@ exports[`createVectorStoreNode retrieve mode supplies vector store as data 1`] =
 					return inputs;
 				}
 
-				if (['insert', 'load', 'update'].includes(mode)) {
+				if (['insert', 'load', 'update', 'delete'].includes(mode)) {
 					inputs.push({ displayName: "", type: "main"})
 				}
 

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/constants.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/constants.ts
@@ -18,6 +18,12 @@ export const OPERATION_MODE_DESCRIPTIONS: INodePropertyOptions[] = [
 		action: 'Get ranked documents from vector store',
 	},
 	{
+		name: 'Delete Documents',
+		value: 'delete',
+		description: 'Delete documents from a vector store',
+		action: 'Delete documents from a vector store',
+	},
+	{
 		name: 'Insert Documents',
 		value: 'insert',
 		description: 'Insert documents into vector store',

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/createVectorStoreNode.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/createVectorStoreNode.ts
@@ -20,6 +20,7 @@ import {
 	handleUpdateOperation,
 	handleRetrieveOperation,
 	handleRetrieveAsToolOperation,
+	handleDeleteOperation,
 } from './operations';
 import type { NodeOperationMode, VectorStoreNodeConstructorArgs } from './types';
 // Import utility functions
@@ -91,7 +92,7 @@ export const createVectorStoreNode = <T extends VectorStore = VectorStore>(
 					return inputs;
 				}
 
-				if (['insert', 'load', 'update'].includes(mode)) {
+				if (['insert', 'load', 'update', 'delete'].includes(mode)) {
 					inputs.push({ displayName: "", type: "${NodeConnectionTypes.Main}"})
 				}
 
@@ -286,6 +287,11 @@ export const createVectorStoreNode = <T extends VectorStore = VectorStore>(
 				return [resultData];
 			}
 
+			if (mode === 'delete') {
+				const resultData = await handleDeleteOperation(this, args, embeddings);
+				return [resultData];
+			}
+
 			if (mode === 'update') {
 				const resultData = await handleUpdateOperation(this, args, embeddings);
 				return [resultData];
@@ -293,7 +299,7 @@ export const createVectorStoreNode = <T extends VectorStore = VectorStore>(
 
 			throw new NodeOperationError(
 				this.getNode(),
-				'Only the "load", "update" and "insert" operation modes are supported with execute',
+				'Only the "load", "update", "delete" and "insert" operation modes are supported with execute',
 			);
 		}
 

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/operations/deleteOperation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/operations/deleteOperation.ts
@@ -1,0 +1,28 @@
+import type { Embeddings } from '@langchain/core/embeddings';
+import type { VectorStore } from '@langchain/core/vectorstores';
+import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+
+import type { VectorStoreNodeConstructorArgs } from '../types';
+
+/**
+ * Handles the 'delete' operation mode
+ * Deletes documents from the vector store
+ */
+export async function handleDeleteOperation<T extends VectorStore = VectorStore>(
+	context: IExecuteFunctions,
+	args: VectorStoreNodeConstructorArgs<T>,
+	embeddings: Embeddings,
+): Promise<INodeExecutionData[]> {
+	const items = context.getInputData();
+	const resultData: INodeExecutionData[] = [];
+
+	const ids: string[] = items.map(({ json }) => json.id as string);
+
+	await args.deleteEmbeddedDocuments?.(context, embeddings, ids, 0);
+
+	// TODO: what (if any analytics) should we use here?
+	// Log the AI event for analytics
+	// logAiEvent(context, 'ai-vector-store-populated');
+
+	return resultData;
+}

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/operations/index.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/operations/index.ts
@@ -3,3 +3,4 @@ export * from './insertOperation';
 export * from './updateOperation';
 export * from './retrieveOperation';
 export * from './retrieveAsToolOperation';
+export * from './deleteOperation';

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/types.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/types.ts
@@ -14,7 +14,13 @@ import type {
 	NodeParameterValueType,
 } from 'n8n-workflow';
 
-export type NodeOperationMode = 'insert' | 'load' | 'retrieve' | 'update' | 'retrieve-as-tool';
+export type NodeOperationMode =
+	| 'insert'
+	| 'load'
+	| 'retrieve'
+	| 'update'
+	| 'retrieve-as-tool'
+	| 'delete';
 
 export interface NodeMeta {
 	displayName: string;
@@ -75,6 +81,16 @@ export interface VectorStoreNodeConstructorArgs<T extends VectorStore = VectorSt
 		embeddings: Embeddings,
 		itemIndex: number,
 	) => Promise<T>;
+
+	/**
+	 * Optional method to enable deleting embedded documents (`VectorStore.delete()`).
+	 */
+	deleteEmbeddedDocuments?: (
+		context: IExecuteFunctions | ISupplyDataFunctions,
+		embeddings: Embeddings,
+		ids: string[],
+		itemIndex: number,
+	) => Promise<void>;
 
 	/**
 	 * Optional function to release resources associated with the vector store client


### PR DESCRIPTION
## Summary

This PR adds an optional deletion method to the createVectorStore factory to support deletion of embedded documents.

I expect that this PR might need work, but I'm not familiar enough with n8n to know exactly what is missing.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
