### PR TITLE
fix(core): Force synchronize tag mappings also when no tag was updated

### DIFF
--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control.service.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control.service.test.ts
@@ -1,28 +1,45 @@
 import type { SourceControlledFile } from '@n8n/api-types';
+import { isContainedWithin } from '@n8n/backend-common';
 import {
-	type Variables,
+	type FolderRepository,
 	type FolderWithWorkflowAndSubFolderCount,
 	type TagEntity,
-	type User,
-	type FolderRepository,
 	type TagRepository,
+	type User,
+	type Variables,
 	type WorkflowEntity,
-	GLOBAL_MEMBER_ROLE,
 	GLOBAL_ADMIN_ROLE,
+	GLOBAL_MEMBER_ROLE,
 } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
 import { InstanceSettings } from 'n8n-core';
+import type { PushResult } from 'simple-git';
 
-import { SourceControlPreferencesService } from '@/environments.ee/source-control/source-control-preferences.service.ee';
-import { SourceControlService } from '@/environments.ee/source-control/source-control.service.ee';
-import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
-
+import type { SourceControlExportService } from '../source-control-export.service.ee';
 import type { SourceControlGitService } from '../source-control-git.service.ee';
 import type { SourceControlImportService } from '../source-control-import.service.ee';
 import type { SourceControlScopedService } from '../source-control-scoped.service';
 import type { StatusExportableCredential } from '../types/exportable-credential';
 import type { SourceControlWorkflowVersionId } from '../types/source-control-workflow-version-id';
+
+import { SourceControlPreferencesService } from '@/environments.ee/source-control/source-control-preferences.service.ee';
+import { SourceControlService } from '@/environments.ee/source-control/source-control.service.ee';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import type { EventService } from '@/events/event.service';
+
+jest.mock('../source-control-helper.ee', () => ({
+	...jest.requireActual('../source-control-helper.ee'),
+	getTrackingInformationFromPostPushResult: jest.fn(() => ({
+		userId: 'mocked-user-id',
+	})),
+	getTagsPath: jest.fn(() => 'tags.json'),
+}));
+
+jest.mock('@n8n/backend-common', () => ({
+	...jest.requireActual('@n8n/backend-common'),
+	isContainedWithin: jest.fn(() => true),
+}));
 
 describe('SourceControlService', () => {
 	const preferencesService = new SourceControlPreferencesService(
@@ -33,20 +50,22 @@ describe('SourceControlService', () => {
 		mock(),
 	);
 	const sourceControlImportService = mock<SourceControlImportService>();
+	const sourceControlExportService = mock<SourceControlExportService>();
 	const sourceControlScopedService = mock<SourceControlScopedService>();
 	const tagRepository = mock<TagRepository>();
 	const folderRepository = mock<FolderRepository>();
 	const gitService = mock<SourceControlGitService>();
+	const eventService = mock<EventService>();
 	const sourceControlService = new SourceControlService(
 		mock(),
 		gitService,
 		preferencesService,
-		mock(),
+		sourceControlExportService,
 		sourceControlImportService,
 		sourceControlScopedService,
 		tagRepository,
 		folderRepository,
-		mock(),
+		eventService,
 	);
 
 	beforeEach(() => {
@@ -55,8 +74,10 @@ describe('SourceControlService', () => {
 	});
 
 	describe('pushWorkfolder', () => {
-		it('should throw an error if a file is given that is not in the workfolder', async () => {
+		it('should throw an error if file path validation fails', async () => {
 			const user = mock<User>();
+			(isContainedWithin as jest.Mock).mockReturnValueOnce(false);
+
 			await expect(
 				sourceControlService.pushWorkfolder(user, {
 					fileNames: [
@@ -74,6 +95,51 @@ describe('SourceControlService', () => {
 					],
 				}),
 			).rejects.toThrow('File path /etc/passwd is invalid');
+		});
+
+		it('should include the tags file even if not explicitly specified', async () => {
+			// ARRANGE
+			const user = mock<User>();
+			const mockPushResult = mock<PushResult>();
+			const mockFile: SourceControlledFile = {
+				file: '/Users/my-user/.n8n/git/workflows/some-workflow.json',
+				id: 'test',
+				name: 'some-workflow',
+				type: 'workflow',
+				status: 'modified',
+				location: 'local',
+				conflict: false,
+				updatedAt: new Date().toISOString(),
+			};
+
+			jest.spyOn(sourceControlService, 'getStatus').mockResolvedValueOnce([mockFile]);
+			sourceControlExportService.exportCredentialsToWorkFolder.mockResolvedValueOnce({
+				count: 0,
+				missingIds: [],
+				folder: '',
+				files: [],
+			});
+			eventService.emit.mockReturnValueOnce(true);
+			gitService.push.mockResolvedValueOnce(mockPushResult);
+			(isContainedWithin as jest.Mock).mockReturnValueOnce(true);
+
+			// ACT
+			const result = await sourceControlService.pushWorkfolder(user, {
+				fileNames: [mockFile],
+				commitMessage: 'A commit message',
+			});
+
+			// ASSERT
+			expect(gitService.stage).toHaveBeenCalledWith(
+				expect.objectContaining(new Set(['tags.json', mockFile.file])),
+				new Set(),
+			);
+			expect(gitService.commit).toHaveBeenCalledWith('A commit message');
+			expect(gitService.push).toHaveBeenCalledWith({
+				branch: 'main', // default branch
+				force: false,
+			});
+			expect(result).toHaveProperty('statusCode', 200);
 		});
 	});
 

--- a/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
@@ -326,11 +326,9 @@ export class SourceControlService {
 			});
 		}
 
-		const tagChanges = filesToPush.find((e) => e.type === 'tags');
-		if (tagChanges) {
-			filesToBePushed.add(tagChanges.file);
-			await this.sourceControlExportService.exportTagsToWorkFolder(context);
-		}
+		// The tags file is always re-generated and exported to make sure the workflow-tag mappings are up to date
+		filesToBePushed.add(getTagsPath(this.gitFolder));
+		await this.sourceControlExportService.exportTagsToWorkFolder(context);
 
 		const folderChanges = filesToPush.find((e) => e.type === 'folders');
 		if (folderChanges) {


### PR DESCRIPTION
## Summary

Forces the `tags.json` to be regenerated and pushed whenever the user wants to push a new version to git

## Related Linear tickets, Github issues, and Community forum posts

fixes PAY-2858

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
