### PR TITLE
fix(editor): Fix alignment of back to canvas icon (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/components/NodeDetailsView.vue
+++ b/packages/frontend/editor-ui/src/components/NodeDetailsView.vue
@@ -891,6 +891,9 @@ $main-panel-width: 360px;
 	position: fixed;
 	top: var(--spacing-xs);
 	left: var(--spacing-l);
+	display: flex;
+	align-items: center;
+	gap: var(--spacing-3xs);
 
 	span {
 		color: var(--color-ndv-back-font);
@@ -898,10 +901,6 @@ $main-panel-width: 360px;
 
 	&:hover {
 		cursor: pointer;
-	}
-
-	> * {
-		margin-right: var(--spacing-3xs);
 	}
 }
 


### PR DESCRIPTION
## Summary

Before the fix:
<img width="220" alt="image" src="https://github.com/user-attachments/assets/402e5eee-8f13-4abb-98c9-ce6c1d736c46" />

After the fix:
<img width="200" alt="image" src="https://github.com/user-attachments/assets/8cb027e5-f28d-411b-b750-6dcf6cbc6ec9" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4101/back-to-canvas-and-icon-not-aligned-in-ndv-modal-overlay

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
