### PR TITLE
fix(core): Add support for .cn Amazon regions

### DIFF
--- a/packages/nodes-base/credentials/Aws.credentials.ts
+++ b/packages/nodes-base/credentials/Aws.credentials.ts
@@ -545,8 +545,8 @@ export class Aws implements ICredentialType {
 
 	test: ICredentialTestRequest = {
 		request: {
-			// eslint-disable-next-line n8n-local-rules/no-interpolation-in-regular-string
 			baseURL:
+				// eslint-disable-next-line n8n-local-rules/no-interpolation-in-regular-string
 				'={{$credentials.region.startsWith("cn-") ? `https://sts.${$credentials.region}.amazonaws.com.cn` : `https://sts.${$credentials.region}.amazonaws.com`}}',
 			url: '?Action=GetCallerIdentity&Version=2011-06-15',
 			method: 'POST',

--- a/packages/nodes-base/credentials/Aws.credentials.ts
+++ b/packages/nodes-base/credentials/Aws.credentials.ts
@@ -234,7 +234,6 @@ function parseAwsUrl(url: URL): { region: AWSRegion | null; service: string } {
 	const hostname = url.hostname;
 	// Handle both .amazonaws.com and .amazonaws.com.cn domains
 	const [service, region] = hostname.replace(/\.amazonaws\.com.*$/, '').split('.');
-	console.log('parse AwsUrl', { service, region, hostname });
 	return { service, region };
 }
 

--- a/packages/nodes-base/credentials/Aws.credentials.ts
+++ b/packages/nodes-base/credentials/Aws.credentials.ts
@@ -11,7 +11,17 @@ import type {
 } from 'n8n-workflow';
 import { isObjectEmpty } from 'n8n-workflow';
 
-export const regions = [
+type RegionData = {
+	name: string;
+	displayName: string;
+	location: string;
+	domain?: string;
+};
+
+const chinaDomain = 'amazonaws.com.cn';
+const globalDomain = 'amazonaws.com';
+
+export const regions: RegionData[] = [
 	{
 		name: 'af-south-1',
 		displayName: 'Africa',
@@ -91,11 +101,13 @@ export const regions = [
 		name: 'cn-north-1',
 		displayName: 'China',
 		location: 'Beijing',
+		domain: chinaDomain,
 	},
 	{
 		name: 'cn-northwest-1',
 		displayName: 'China',
 		location: 'Ningxia',
+		domain: chinaDomain,
 	},
 	{
 		name: 'eu-central-1',
@@ -211,12 +223,19 @@ export type AwsCredentialsType = {
 	ssmEndpoint?: string;
 };
 
+function getAwsDomain(region: AWSRegion): string {
+	return regions.find((r) => r.name === region)?.domain ?? globalDomain;
+}
+
 // Some AWS services are global and don't have a region
 // https://docs.aws.amazon.com/general/latest/gr/rande.html#global-endpoints
 // Example: iam.amazonaws.com (global), s3.us-east-1.amazonaws.com (regional)
 function parseAwsUrl(url: URL): { region: AWSRegion | null; service: string } {
-	const [service, region] = url.hostname.replace('amazonaws.com', '').split('.');
-	return { service, region: region as AWSRegion };
+	const hostname = url.hostname;
+	// Handle both .amazonaws.com and .amazonaws.com.cn domains
+	const [service, region] = hostname.replace(/\.amazonaws\.com.*$/, '').split('.');
+	console.log('parse AwsUrl', { service, region, hostname });
+	return { service, region };
 }
 
 export class Aws implements ICredentialType {
@@ -436,10 +455,11 @@ export class Aws implements ICredentialType {
 					endpointString = credentials.sesEndpoint;
 				} else if (service === 'rekognition' && credentials.rekognitionEndpoint) {
 					endpointString = credentials.rekognitionEndpoint;
-				} else if (service) {
-					endpointString = `https://${service}.${region}.amazonaws.com`;
 				} else if (service === 'ssm' && credentials.ssmEndpoint) {
 					endpointString = credentials.ssmEndpoint;
+				} else if (service) {
+					const domain = getAwsDomain(region);
+					endpointString = `https://${service}.${region}.${domain}`;
 				}
 				endpoint = new URL(endpointString!.replace('{region}', region) + path);
 			} else {
@@ -486,7 +506,6 @@ export class Aws implements ICredentialType {
 			bodyContent = params.toString();
 			contentTypeHeader = 'application/x-www-form-urlencoded';
 		}
-
 		const signOpts = {
 			...requestOptions,
 			headers: {
@@ -526,7 +545,9 @@ export class Aws implements ICredentialType {
 
 	test: ICredentialTestRequest = {
 		request: {
-			baseURL: '=https://sts.{{$credentials.region}}.amazonaws.com',
+			// eslint-disable-next-line n8n-local-rules/no-interpolation-in-regular-string
+			baseURL:
+				'={{$credentials.region.startsWith("cn-") ? `https://sts.${$credentials.region}.amazonaws.com.cn` : `https://sts.${$credentials.region}.amazonaws.com`}}',
 			url: '?Action=GetCallerIdentity&Version=2011-06-15',
 			method: 'POST',
 		},

--- a/packages/nodes-base/credentials/test/Aws.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/Aws.credentials.test.ts
@@ -25,8 +25,8 @@ describe('Aws Credential', () => {
 		expect(aws.documentationUrl).toBe('aws');
 		expect(aws.icon).toEqual({ light: 'file:icons/AWS.svg', dark: 'file:icons/AWS.dark.svg' });
 		expect(aws.properties.length).toBeGreaterThan(0);
-		// eslint-disable-next-line n8n-local-rules/no-interpolation-in-regular-string
 		expect(aws.test.request.baseURL).toBe(
+			// eslint-disable-next-line n8n-local-rules/no-interpolation-in-regular-string
 			'={{$credentials.region.startsWith("cn-") ? `https://sts.${$credentials.region}.amazonaws.com.cn` : `https://sts.${$credentials.region}.amazonaws.com`}}',
 		);
 		expect(aws.test.request.url).toBe('?Action=GetCallerIdentity&Version=2011-06-15');

--- a/packages/nodes-base/credentials/test/Aws.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/Aws.credentials.test.ts
@@ -25,7 +25,10 @@ describe('Aws Credential', () => {
 		expect(aws.documentationUrl).toBe('aws');
 		expect(aws.icon).toEqual({ light: 'file:icons/AWS.svg', dark: 'file:icons/AWS.dark.svg' });
 		expect(aws.properties.length).toBeGreaterThan(0);
-		expect(aws.test.request.baseURL).toBe('=https://sts.{{$credentials.region}}.amazonaws.com');
+		// eslint-disable-next-line n8n-local-rules/no-interpolation-in-regular-string
+		expect(aws.test.request.baseURL).toBe(
+			'={{$credentials.region.startsWith("cn-") ? `https://sts.${$credentials.region}.amazonaws.com.cn` : `https://sts.${$credentials.region}.amazonaws.com`}}',
+		);
 		expect(aws.test.request.url).toBe('?Action=GetCallerIdentity&Version=2011-06-15');
 		expect(aws.test.request.method).toBe('POST');
 	});
@@ -177,6 +180,104 @@ describe('Aws Credential', () => {
 			);
 			expect(result.method).toBe('POST');
 			expect(result.url).toBe('https://iam.amazonaws.com/');
+		});
+
+		describe('China regions', () => {
+			const chinaCredentials: AwsCredentialsType = {
+				region: 'cn-north-1',
+				accessKeyId: 'hakuna',
+				secretAccessKey: 'matata',
+				customEndpoints: false,
+				temporaryCredentials: false,
+			};
+
+			it('should use amazonaws.com.cn domain for cn-north-1 region', async () => {
+				const result = await aws.authenticate(chinaCredentials, {
+					...requestOptions,
+					url: '',
+					baseURL: '',
+					qs: { service: 's3' },
+				});
+
+				expect(mockSign).toHaveBeenCalledWith(
+					expect.objectContaining({
+						host: 's3.cn-north-1.amazonaws.com.cn',
+						region: 'cn-north-1',
+					}),
+					{
+						accessKeyId: 'hakuna',
+						secretAccessKey: 'matata',
+						sessionToken: undefined,
+					},
+				);
+				expect(result.url).toBe('https://s3.cn-north-1.amazonaws.com.cn/');
+			});
+
+			it('should handle custom endpoints for China regions', async () => {
+				const customEndpoint = 'https://custom.china.endpoint.com.cn';
+				const result = await aws.authenticate(
+					{ ...chinaCredentials, customEndpoints: true, s3Endpoint: customEndpoint },
+					{ ...requestOptions, url: '', baseURL: '', qs: { service: 's3' } },
+				);
+
+				expect(mockSign).toHaveBeenCalledWith(
+					expect.objectContaining({
+						host: 'custom.china.endpoint.com.cn',
+					}),
+					{
+						accessKeyId: 'hakuna',
+						secretAccessKey: 'matata',
+						sessionToken: undefined,
+					},
+				);
+				expect(result.url).toBe(`${customEndpoint}/`);
+			});
+
+			it('should parse China region URLs correctly', async () => {
+				const result = await aws.authenticate(chinaCredentials, {
+					...requestOptions,
+					url: 'https://s3.cn-north-1.amazonaws.com.cn/bucket/key',
+					baseURL: '',
+				});
+
+				expect(mockSign).toHaveBeenCalledWith(
+					expect.objectContaining({
+						host: 's3.cn-north-1.amazonaws.com.cn',
+						region: 'cn-north-1',
+						path: '/bucket/key',
+					}),
+					{
+						accessKeyId: 'hakuna',
+						secretAccessKey: 'matata',
+						sessionToken: undefined,
+					},
+				);
+				expect(result.url).toBe('https://s3.cn-north-1.amazonaws.com.cn/bucket/key');
+			});
+		});
+
+		describe('Regular regions (non-China)', () => {
+			it('should use amazonaws.com domain for regular regions', async () => {
+				const result = await aws.authenticate(credentials, {
+					...requestOptions,
+					url: '',
+					baseURL: '',
+					qs: { service: 's3' },
+				});
+
+				expect(mockSign).toHaveBeenCalledWith(
+					expect.objectContaining({
+						host: 's3.eu-central-1.amazonaws.com',
+						region: 'eu-central-1',
+					}),
+					{
+						accessKeyId: 'hakuna',
+						secretAccessKey: 'matata',
+						sessionToken: undefined,
+					},
+				);
+				expect(result.url).toBe('https://s3.eu-central-1.amazonaws.com/');
+			});
 		});
 	});
 });


### PR DESCRIPTION
## Summary

This PR adds support of AWS China credentials. The issue happened because AWS china used `.amazon.com.cn` instead of `amazon.com`

It also fixes invalid order of ifs. `service === 'ssm'` was condition was unreachable
```
else if (service) {
  endpointString = `https://${service}.${region}.amazonaws.com`;
} else if (service === 'ssm' && credentials.ssmEndpoint) {
  endpointString = credentials.ssmEndpoint;
}				
```
On master:
<img width="665" height="132" alt="image" src="https://github.com/user-attachments/assets/a939ec1b-3529-4898-adbb-896638f741f0" />


On current branch:
<img width="977" height="286" alt="image" src="https://github.com/user-attachments/assets/66f2b586-2a46-49de-9e88-f7cada8dace0" />


## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-2888/community-issue-credentials-aws-china-is-not-supported
closes #14764 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
