### PR TITLE
fix: Open form popup for Form Trigger even if it has execution data

### DIFF
--- a/packages/frontend/editor-ui/src/utils/executionUtils.test.ts
+++ b/packages/frontend/editor-ui/src/utils/executionUtils.test.ts
@@ -113,6 +113,69 @@ describe('displayForm', () => {
 		expect(windowOpenSpy).not.toHaveBeenCalled();
 	});
 
+	it('should not call openPopUpWindow if node has run data and is not a form trigger node', async () => {
+		const nodes: INode[] = [
+			{
+				id: '1',
+				name: 'RegularNode',
+				typeVersion: 1,
+				type: 'n8n-nodes-base.httpRequest',
+				position: [0, 0],
+				parameters: {},
+			},
+		];
+
+		const runData: IRunData = { RegularNode: [] };
+		const pinData: IPinData = {};
+
+		fetchMock.mockResolvedValue(successResponse);
+
+		await displayForm({
+			nodes,
+			runData,
+			pinData,
+			destinationNode: undefined,
+			triggerNode: undefined,
+			directParentNodes: [],
+			source: undefined,
+			getTestUrl: getTestUrlMock,
+		});
+
+		expect(windowOpenSpy).not.toHaveBeenCalled();
+	});
+
+	it('should call openPopUpWindow for form trigger node even if it has run data', async () => {
+		const nodes: INode[] = [
+			{
+				id: '1',
+				name: 'FormTrigger',
+				typeVersion: 1,
+				type: FORM_TRIGGER_NODE_TYPE,
+				position: [0, 0],
+				parameters: {},
+			},
+		];
+
+		const runData: IRunData = { FormTrigger: [] };
+		const pinData: IPinData = {};
+
+		getTestUrlMock.mockReturnValue('http://test-url.com');
+		fetchMock.mockResolvedValue(successResponse);
+
+		await displayForm({
+			nodes,
+			runData,
+			pinData,
+			destinationNode: undefined,
+			triggerNode: undefined,
+			directParentNodes: [],
+			source: undefined,
+			getTestUrl: getTestUrlMock,
+		});
+
+		expect(windowOpenSpy).toHaveBeenCalled();
+	});
+
 	it('should skip nodes if destinationNode does not match and node is not a directParentNode', async () => {
 		const nodes: INode[] = [
 			{

--- a/packages/frontend/editor-ui/src/utils/executionUtils.ts
+++ b/packages/frontend/editor-ui/src/utils/executionUtils.ts
@@ -146,9 +146,10 @@ export async function displayForm({
 	for (const node of nodes) {
 		if (triggerNode !== undefined && triggerNode !== node.name) continue;
 
-		const hasNodeRun = runData?.hasOwnProperty(node.name);
+		const hasNodeRunAndIsNotFormTrigger =
+			runData?.hasOwnProperty(node.name) && node.type !== FORM_TRIGGER_NODE_TYPE;
 
-		if (hasNodeRun || pinData[node.name]) continue;
+		if (hasNodeRunAndIsNotFormTrigger || pinData[node.name]) continue;
 
 		if (![FORM_TRIGGER_NODE_TYPE].includes(node.type)) continue;
 


### PR DESCRIPTION
## Summary

Open form popup for Form Trigger even if it has execution data
## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-3608/form-node-test-execution-pop-up-does-not-appear-when-using-the-partial
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
