### PR TITLE
fix(core): Fix expression resolution in tools when parent's input has multiple items

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
@@ -219,7 +219,7 @@ export async function toolsAgentExecute(
 				throw new NodeOperationError(this.getNode(), 'The "text" parameter is empty.');
 			}
 			const outputParser = await getOptionalOutputParser(this, itemIndex);
-			const tools = await getTools(this, outputParser);
+			const tools = await getTools(this, outputParser, itemIndex);
 			const options = this.getNodeParameter('options', itemIndex, {}) as {
 				systemMessage?: string;
 				maxIterations?: number;

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/common.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/common.ts
@@ -327,8 +327,11 @@ export async function getOptionalMemory(
 export async function getTools(
 	ctx: IExecuteFunctions | ISupplyDataFunctions,
 	outputParser?: N8nOutputParser,
+	itemIndex: number = 0,
 ): Promise<Array<DynamicStructuredTool | Tool>> {
-	const tools = (await getConnectedTools(ctx, true, false)) as Array<DynamicStructuredTool | Tool>;
+	const tools = (await getConnectedTools(ctx, true, false, undefined, itemIndex)) as Array<
+		DynamicStructuredTool | Tool
+	>;
 
 	// If an output parser is available, create a dynamic tool to validate the final output.
 	if (outputParser) {

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/ToolsAgentV2.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/ToolsAgentV2.test.ts
@@ -347,8 +347,8 @@ describe('toolsAgentExecute', () => {
 
 		// Verify getTools was called with different parsers
 		expect(getToolsSpy).toHaveBeenCalledTimes(2);
-		expect(getToolsSpy).toHaveBeenNthCalledWith(1, mockContext, true, false);
-		expect(getToolsSpy).toHaveBeenNthCalledWith(2, mockContext, true, false);
+		expect(getToolsSpy).toHaveBeenNthCalledWith(1, mockContext, true, false, undefined, 0);
+		expect(getToolsSpy).toHaveBeenNthCalledWith(2, mockContext, true, false, undefined, 1);
 	});
 
 	it('should maintain correct parser-item mapping in batch processing', async () => {

--- a/packages/@n8n/nodes-langchain/utils/helpers.ts
+++ b/packages/@n8n/nodes-langchain/utils/helpers.ts
@@ -203,10 +203,12 @@ export const getConnectedTools = async (
 	enforceUniqueNames: boolean,
 	convertStructuredTool: boolean = true,
 	escapeCurlyBrackets: boolean = false,
+	itemIndex = 0,
 ) => {
 	const connectedTools = (
-		((await ctx.getInputConnectionData(NodeConnectionTypes.AiTool, 0)) as Array<Toolkit | Tool>) ??
-		[]
+		((await ctx.getInputConnectionData(NodeConnectionTypes.AiTool, itemIndex)) as Array<
+			Toolkit | Tool
+		>) ?? []
 	).flatMap((toolOrToolkit) => {
 		if (toolOrToolkit instanceof Toolkit) {
 			return toolOrToolkit.getTools() as Tool[];

--- a/packages/core/src/execution-engine/node-execution-context/supply-data-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/supply-data-context.ts
@@ -60,6 +60,7 @@ export class SupplyDataContext extends BaseExecuteContext implements ISupplyData
 		private readonly closeFunctions: CloseFunction[],
 		abortSignal?: AbortSignal,
 		parentNode?: INode,
+		itemIndexOverride?: number,
 	) {
 		super(
 			workflow,
@@ -92,9 +93,9 @@ export class SupplyDataContext extends BaseExecuteContext implements ISupplyData
 			...getDataStoreHelperFunctions(additionalData, workflow, node),
 			...getDeduplicationHelperFunctions(workflow, node),
 			assertBinaryData: (itemIndex, propertyName) =>
-				assertBinaryData(inputData, node, itemIndex, propertyName, 0),
+				assertBinaryData(inputData, node, itemIndexOverride ?? itemIndex, propertyName, 0),
 			getBinaryDataBuffer: async (itemIndex, propertyName) =>
-				await getBinaryDataBuffer(inputData, itemIndex, propertyName, 0),
+				await getBinaryDataBuffer(inputData, itemIndexOverride ?? itemIndex, propertyName, 0),
 			detectBinaryEncoding: (buffer: Buffer) => detectBinaryEncoding(buffer),
 
 			returnJsonArray,
@@ -111,7 +112,7 @@ export class SupplyDataContext extends BaseExecuteContext implements ISupplyData
 		) =>
 			this._getNodeParameter(
 				parameterName,
-				itemIndex,
+				itemIndexOverride ?? itemIndex,
 				fallbackValue,
 				options,
 			)) as ISupplyDataFunctions['getNodeParameter'];

--- a/packages/core/src/execution-engine/node-execution-context/supply-data-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/supply-data-context.ts
@@ -60,7 +60,7 @@ export class SupplyDataContext extends BaseExecuteContext implements ISupplyData
 		private readonly closeFunctions: CloseFunction[],
 		abortSignal?: AbortSignal,
 		parentNode?: INode,
-		itemIndexOverride?: number,
+		private readonly itemIndexOverride?: number,
 	) {
 		super(
 			workflow,
@@ -93,9 +93,9 @@ export class SupplyDataContext extends BaseExecuteContext implements ISupplyData
 			...getDataStoreHelperFunctions(additionalData, workflow, node),
 			...getDeduplicationHelperFunctions(workflow, node),
 			assertBinaryData: (itemIndex, propertyName) =>
-				assertBinaryData(inputData, node, itemIndexOverride ?? itemIndex, propertyName, 0),
+				assertBinaryData(inputData, node, itemIndex, propertyName, 0),
 			getBinaryDataBuffer: async (itemIndex, propertyName) =>
-				await getBinaryDataBuffer(inputData, itemIndexOverride ?? itemIndex, propertyName, 0),
+				await getBinaryDataBuffer(inputData, itemIndex, propertyName, 0),
 			detectBinaryEncoding: (buffer: Buffer) => detectBinaryEncoding(buffer),
 
 			returnJsonArray,
@@ -112,7 +112,7 @@ export class SupplyDataContext extends BaseExecuteContext implements ISupplyData
 		) =>
 			this._getNodeParameter(
 				parameterName,
-				itemIndexOverride ?? itemIndex,
+				this.itemIndexOverride ?? itemIndex,
 				fallbackValue,
 				options,
 			)) as ISupplyDataFunctions['getNodeParameter'];
@@ -157,7 +157,7 @@ export class SupplyDataContext extends BaseExecuteContext implements ISupplyData
 			this.mode,
 			this.closeFunctions,
 			connectionType,
-			itemIndex,
+			this.itemIndexOverride ?? itemIndex,
 			this.abortSignal,
 		);
 	}

--- a/packages/core/src/execution-engine/node-execution-context/utils/get-input-connection-data.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/get-input-connection-data.ts
@@ -231,7 +231,11 @@ export async function getInputConnectionData(
 			connectedNode.type,
 			connectedNode.typeVersion,
 		);
-		const contextFactory = (runIndex: number, inputData: ITaskDataConnections) =>
+		const contextFactory = (
+			runIndex: number,
+			inputData: ITaskDataConnections,
+			itemIndexOverride?: number,
+		) =>
 			new SupplyDataContext(
 				workflow,
 				connectedNode,
@@ -246,6 +250,7 @@ export async function getInputConnectionData(
 				closeFunctions,
 				abortSignal,
 				parentNode,
+				itemIndexOverride,
 			);
 
 		if (!connectedNodeType.supplyData) {
@@ -254,7 +259,7 @@ export async function getInputConnectionData(
 					node: connectedNode,
 					nodeType: connectedNodeType,
 					handleToolInvocation: makeHandleToolInvocation(
-						(i) => contextFactory(i, {}),
+						(i) => contextFactory(i, {}, itemIndex),
 						connectedNode,
 						connectedNodeType,
 						runExecutionData,

--- a/packages/workflow/src/workflow-data-proxy.ts
+++ b/packages/workflow/src/workflow-data-proxy.ts
@@ -1042,16 +1042,20 @@ export class WorkflowDataProxy {
 			}
 			const inputData =
 				that.runExecutionData?.resultData.runData[that.activeNodeName]?.[runIndex].inputOverride;
-			const placeholdersDataInputData =
-				inputData?.[NodeConnectionTypes.AiTool]?.[0]?.[itemIndex].json;
+
+			// IMPORTANT: We use itemIndex = 0 here, because tools always run with one item on AiTool input.
+			// This is different from external context, where current itemIndex might be > 0.
+			const placeholdersDataInputData = inputData?.[NodeConnectionTypes.AiTool]?.[0]?.[0].json;
 
 			if (!placeholdersDataInputData) {
 				throw new ExpressionError('No execution data available', {
 					runIndex,
+					// Real itemIndex (from a parent context) to indicate where the error happened
 					itemIndex,
 					type: 'no_execution_data',
 				});
 			}
+
 			return (
 				// TS does not know that the key exists, we need to address this in refactor
 				(placeholdersDataInputData?.query as Record<string, unknown>)?.[name] ??


### PR DESCRIPTION
## Summary

This PR makes it possible to access other node's output from the tool, when parent node's input has multiple items.
For example, now the Agent Tool Node can reference `$('DebugHelper').item.json` via expression in parameters, and it will be resolved to a correct item, as parent Agent Node iterating over all input items.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-1371/community-issue-ai-agent-tools-always-receive-first-item-when-multiple


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
