### PR TITLE
fix(Notion Node): Fix regex for getMany operation

### DIFF
--- a/packages/nodes-base/nodes/Notion/shared/descriptions/BlockDescription.ts
+++ b/packages/nodes-base/nodes/Notion/shared/descriptions/BlockDescription.ts
@@ -45,7 +45,7 @@ const blockIdRLC: INodeProperties = {
 				{
 					type: 'regex',
 					properties: {
-						regex: '[a-f0-9]{2,}',
+						regex: idValidationRegexp,
 						errorMessage: 'Not a valid Notion Block ID',
 					},
 				},


### PR DESCRIPTION
## Summary

This PR fixes an issue when some notion block IDs were not recognized as valid

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-3306/notion-n8n-rejects-valid-id-in-notion-get-child-blocks

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
