### PR TITLE
fix(editor): Improve datetime handling in Data table UI

### DIFF
--- a/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/AddColumnButton.test.ts
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/AddColumnButton.test.ts
@@ -294,7 +294,31 @@ describe('AddColumnButton', () => {
 			expect(getByText('string')).toBeInTheDocument();
 			expect(getByText('number')).toBeInTheDocument();
 			expect(getByText('boolean')).toBeInTheDocument();
-			expect(getByText('date')).toBeInTheDocument();
+			expect(getByText('datetime')).toBeInTheDocument();
+		});
+	});
+
+	it('should set value to "date" when selecting "datetime" option', async () => {
+		const { getByTestId, getByRole, getByText, getByPlaceholderText } = renderComponent();
+		const addButton = getByTestId('data-store-add-column-trigger-button');
+
+		await fireEvent.click(addButton);
+
+		const nameInput = getByPlaceholderText('Enter column name');
+		await fireEvent.update(nameInput, 'dateColumn');
+
+		const selectElement = getByRole('combobox');
+		await fireEvent.click(selectElement);
+
+		const dateOption = getByText('datetime');
+		await fireEvent.click(dateOption);
+
+		const submitButton = getByTestId('data-store-add-column-submit-button');
+		await fireEvent.click(submitButton);
+
+		expect(addColumnHandler).toHaveBeenCalledWith({
+			name: 'dateColumn',
+			type: 'date',
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/AddColumnButton.vue
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/AddColumnButton.vue
@@ -44,6 +44,15 @@ const isSelectOpen = ref(false);
 
 const popoverId = computed(() => props.popoverId ?? 'add-column-popover');
 
+const columnTypeOptions = computed(() => {
+	// Renaming 'date' to 'datetime' but only in UI label
+	// we still want to use 'date' as value so nothing breaks
+	return columnTypes.map((type) => ({
+		label: type === 'date' ? 'datetime' : type,
+		value: type,
+	}));
+});
+
 const onAddButtonClicked = async () => {
 	validateName();
 	if (!columnName.value || !columnType.value || error.value) {
@@ -178,10 +187,15 @@ const onInput = debounce(validateName, { debounceTime: 100 });
 									:append-to="`#${popoverId}`"
 									@visible-change="isSelectOpen = $event"
 								>
-									<N8nOption v-for="type in columnTypes" :key="type" :value="type">
+									<N8nOption
+										v-for="option in columnTypeOptions"
+										:key="option.value"
+										:label="option.label"
+										:value="option.value"
+									>
 										<div class="add-column-option-content">
-											<N8nIcon :icon="getIconForType(type)" />
-											<N8nText>{{ type }}</N8nText>
+											<N8nIcon :icon="getIconForType(option.value)" />
+											<N8nText>{{ option.label }}</N8nText>
 										</div>
 									</N8nOption>
 								</N8nSelect>

--- a/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/AddColumnButton.vue
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/AddColumnButton.vue
@@ -5,6 +5,7 @@ import type {
 	DataStoreColumnCreatePayload,
 	DataStoreColumnType,
 } from '@/features/dataStore/datastore.types';
+import { DATA_STORE_COLUMN_TYPES } from '@/features/dataStore/datastore.types';
 import { useI18n } from '@n8n/i18n';
 import { useDataStoreTypes } from '@/features/dataStore/composables/useDataStoreTypes';
 import { COLUMN_NAME_REGEX, MAX_COLUMN_NAME_LENGTH } from '@/features/dataStore/constants';
@@ -34,7 +35,7 @@ const nameInputRef = ref<HTMLInputElement | null>(null);
 const columnName = ref('');
 const columnType = ref<DataStoreColumnType>('string');
 
-const columnTypes: DataStoreColumnType[] = ['string', 'number', 'boolean', 'date'];
+const columnTypes: DataStoreColumnType[] = [...DATA_STORE_COLUMN_TYPES];
 
 const error = ref<FormError | null>(null);
 

--- a/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/DataStoreTable.vue
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/DataStoreTable.vue
@@ -395,5 +395,13 @@ defineExpose({
 			width: var(--spacing-m);
 		}
 	}
+
+	// A hacky solution for element ui bug where clicking svg inside .more button does not work
+	:global(.el-pager .more) {
+		background: transparent !important;
+		svg {
+			z-index: -1;
+		}
+	}
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/ElDatePickerCellEditor.vue
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/ElDatePickerCellEditor.vue
@@ -192,7 +192,7 @@ defineExpose({
 }
 
 .datastore-datepicker-popper {
-	// Hide the date input because in the popper, we only want to show the time picker
+	// Hide the date input because in the popper
 	.el-date-picker__time-header .el-date-picker__editor-wrap:first-child {
 		display: none;
 	}

--- a/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/ElDatePickerCellEditor.vue
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/ElDatePickerCellEditor.vue
@@ -123,7 +123,7 @@ defineExpose({
 			:editable="true"
 			:teleported="false"
 			:default-time="defaultMidnight"
-			popper-class="datastore-datepicker-popper"
+			popper-class="ag-custom-component-popup datastore-datepicker-popper"
 			placeholder="YYYY-MM-DD (HH:mm:ss)"
 			size="small"
 			@change="onChange"

--- a/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/ElDatePickerCellEditor.vue
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/ElDatePickerCellEditor.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { onMounted, ref, nextTick } from 'vue';
 import type { ICellEditorParams } from 'ag-grid-community';
-import { DateTime } from 'luxon';
 
 const props = defineProps<{
 	params: ICellEditorParams;
@@ -18,9 +17,8 @@ onMounted(async () => {
 	if (initial === null || initial === undefined) {
 		dateValue.value = null;
 	} else if (initial instanceof Date) {
-		const dt = DateTime.fromJSDate(initial);
-		// the date editor shows local time but we want the UTC so we need to offset the value here
-		dateValue.value = dt.minus({ minutes: dt.offset }).toJSDate();
+		// Use the provided Date as-is (local time)
+		dateValue.value = initial;
 	}
 	initialValue.value = dateValue.value;
 
@@ -56,9 +54,8 @@ function onKeydown(e: KeyboardEvent) {
 defineExpose({
 	getValue: () => {
 		if (dateValue.value === null) return null;
-		const dt = DateTime.fromJSDate(dateValue.value);
-		// the editor returns local time but we initially offset the value to UTC so we need to add the offset back here
-		return dt.plus({ minutes: dt.offset }).toJSDate();
+		// Return the selected date in the user's local timezone
+		return dateValue.value;
 	},
 	isPopup: () => true,
 });

--- a/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/ElDatePickerCellEditor.vue
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/ElDatePickerCellEditor.vue
@@ -12,6 +12,9 @@ const initialValue = ref<Date | null>(null);
 
 const inputWidth = ref(props.params.column.getActualWidth() - 4); // -4 for the border
 
+const defaultMidnight = new Date();
+defaultMidnight.setHours(0, 0, 0, 0);
+
 onMounted(async () => {
 	const initial = props.params.value as unknown;
 	if (initial === null || initial === undefined) {
@@ -40,15 +43,63 @@ function onClear() {
 	props.params.stopEditing();
 }
 
+// Accepts the following loose formats and constructs a local Date:
+// - YYYY-MM-DD -> 00:00:00
+// - YYYY-MM-DD HH:mm -> seconds default to 00
+// - YYYY-MM-DDTHH:mm -> seconds default to 00
+// - YYYY-MM-DD HH:mm:ss (also accepted, though typically handled by the picker)
+function parseLooseLocalDate(text: string): Date | null {
+	const trimmed = text.trim();
+	const m = /^([0-9]{4})-([0-9]{2})-([0-9]{2})(?:[ T]([0-9]{2}):([0-9]{2})(?::([0-9]{2}))?)?$/.exec(
+		trimmed,
+	);
+	if (!m) return null;
+	const y = Number(m[1]);
+	const mo = Number(m[2]);
+	const d = Number(m[3]);
+	const hh = m[4] !== undefined ? Number(m[4]) : 0;
+	const mm = m[5] !== undefined ? Number(m[5]) : 0;
+	const ss = m[6] !== undefined ? Number(m[6]) : 0;
+
+	if (mo < 1 || mo > 12) return null;
+	if (d < 1 || d > 31) return null;
+	if (hh < 0 || hh > 23) return null;
+	if (mm < 0 || mm > 59) return null;
+	if (ss < 0 || ss > 59) return null;
+
+	return new Date(y, mo - 1, d, hh, mm, ss, 0);
+}
+
+function commitIfParsedFromInput(target?: EventTarget | null) {
+	const input = target as HTMLInputElement | null;
+	const value = input?.value ?? '';
+	const parsed = parseLooseLocalDate(value);
+	if (parsed) {
+		dateValue.value = parsed;
+		props.params.stopEditing();
+		return true;
+	}
+	return false;
+}
+
 function onKeydown(e: KeyboardEvent) {
 	if (e.key === 'Escape') {
 		e.stopPropagation();
 		dateValue.value = initialValue.value;
 		props.params.stopEditing();
-	} else if (e.key === 'Enter') {
-		e.stopPropagation();
-		props.params.stopEditing();
+		return;
 	}
+	if (e.key === 'Enter') {
+		const committed = commitIfParsedFromInput(e.target);
+		if (committed) {
+			e.preventDefault();
+			e.stopPropagation();
+		}
+	}
+}
+
+function onBlur(e: FocusEvent) {
+	if (commitIfParsedFromInput(e.target)) return;
 }
 
 defineExpose({
@@ -69,13 +120,15 @@ defineExpose({
 			type="datetime"
 			:style="{ width: `${inputWidth}px` }"
 			:clearable="true"
-			:editable="false"
+			:editable="true"
 			:teleported="false"
-			:placeholder="''"
+			:default-time="defaultMidnight"
+			placeholder="YYYY-MM-DD (HH:mm:ss)"
 			size="small"
 			@change="onChange"
 			@clear="onClear"
 			@keydown="onKeydown"
+			@blur="onBlur"
 		/>
 	</div>
 </template>

--- a/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/ElDatePickerCellEditor.vue
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/ElDatePickerCellEditor.vue
@@ -72,7 +72,19 @@ function parseLooseLocalDate(text: string): Date | null {
 	if (mm < 0 || mm > 59) return null;
 	if (ss < 0 || ss > 59) return null;
 
-	return new Date(y, mo - 1, d, hh, mm, ss, 0);
+	const dt = new Date(y, mo - 1, d, hh, mm, ss, 0);
+	if (
+		dt.getFullYear() !== y ||
+		dt.getMonth() !== mo - 1 ||
+		dt.getDate() !== d ||
+		dt.getHours() !== hh ||
+		dt.getMinutes() !== mm ||
+		dt.getSeconds() !== ss
+	) {
+		return null;
+	}
+
+	return dt;
 }
 
 function commitIfParsedFromInput(target?: EventTarget | null) {

--- a/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/ElDatePickerCellEditor.vue
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/ElDatePickerCellEditor.vue
@@ -123,6 +123,7 @@ defineExpose({
 			:editable="true"
 			:teleported="false"
 			:default-time="defaultMidnight"
+			popper-class="datastore-datepicker-popper"
 			placeholder="YYYY-MM-DD (HH:mm:ss)"
 			size="small"
 			@change="onChange"
@@ -156,6 +157,13 @@ defineExpose({
 	&:where(:focus-within, :active) {
 		box-shadow: none;
 		border: var(--grid-cell-editing-border);
+	}
+}
+
+.datastore-datepicker-popper {
+	// Hide the date input because in the popper, we only want to show the time picker
+	.el-date-picker__time-header .el-date-picker__editor-wrap:first-child {
+		display: none;
 	}
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/ElDatePickerCellEditor.vue
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/ElDatePickerCellEditor.vue
@@ -138,7 +138,7 @@ defineExpose({
 }
 
 .datastore-datepicker-popper {
-	// Hide the date input because in the popper
+	// Hide the date input in the popper
 	.el-date-picker__time-header .el-date-picker__editor-wrap:first-child {
 		display: none;
 	}

--- a/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/ElDatePickerCellEditor.vue
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/ElDatePickerCellEditor.vue
@@ -76,7 +76,7 @@ function parseLooseLocalDate(text: string): Date | null {
 }
 
 function commitIfParsedFromInput(target?: EventTarget | null) {
-	const input = target as HTMLInputElement | null;
+	const input = target instanceof HTMLInputElement ? target : null;
 	const value = input?.value ?? '';
 	const parsed = parseLooseLocalDate(value);
 	if (parsed) {

--- a/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/ElDatePickerCellEditor.vue
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/ElDatePickerCellEditor.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { onMounted, ref, nextTick, useTemplateRef } from 'vue';
 import type { ICellEditorParams } from 'ag-grid-community';
+import { LOOSE_DATE_REGEX } from '@/features/dataStore/constants';
 
 const props = defineProps<{
 	params: ICellEditorParams;
@@ -55,9 +56,7 @@ function onClear() {
 // - YYYY-MM-DD HH:mm:ss (also accepted, though typically handled by the picker)
 function parseLooseLocalDate(text: string): Date | null {
 	const trimmed = text.trim();
-	const m = /^([0-9]{4})-([0-9]{2})-([0-9]{2})(?:[ T]([0-9]{2}):([0-9]{2})(?::([0-9]{2}))?)?$/.exec(
-		trimmed,
-	);
+	const m = LOOSE_DATE_REGEX.exec(trimmed);
 	if (!m) return null;
 	const y = Number(m[1]);
 	const mo = Number(m[2]);

--- a/packages/frontend/editor-ui/src/features/dataStore/composables/useDataStoreGridBase.ts
+++ b/packages/frontend/editor-ui/src/features/dataStore/composables/useDataStoreGridBase.ts
@@ -20,6 +20,7 @@ import type {
 import {
 	ADD_ROW_ROW_ID,
 	DATA_STORE_ID_COLUMN_WIDTH,
+	DEFAULT_COLUMN_WIDTH,
 	DEFAULT_ID_COLUMN_NAME,
 } from '@/features/dataStore/constants';
 import { useDataStoreTypes } from '@/features/dataStore/composables/useDataStoreTypes';
@@ -124,7 +125,6 @@ export const useDataStoreGridBase = ({
 			field: col.name,
 			headerName: col.name,
 			sortable: true,
-			flex: 1,
 			editable: (params) => params.data?.id !== ADD_ROW_ROW_ID,
 			resizable: true,
 			lockPinned: true,
@@ -135,6 +135,7 @@ export const useDataStoreGridBase = ({
 			cellClass: getCellClass,
 			valueGetter: createValueGetter(col),
 			cellRendererSelector: createCellRendererSelector(col),
+			width: DEFAULT_COLUMN_WIDTH,
 		};
 
 		if (col.type === 'string') {
@@ -184,6 +185,7 @@ export const useDataStoreGridBase = ({
 			},
 			cellClass: (params) => (params.data?.id === ADD_ROW_ROW_ID ? 'add-row-cell' : 'system-cell'),
 			headerClass: 'system-column',
+			width: DEFAULT_COLUMN_WIDTH,
 		};
 		return [
 			// Always add the ID column, it's not returned by the back-end but all data stores have it
@@ -251,6 +253,7 @@ export const useDataStoreGridBase = ({
 					lockPinned: true,
 					lockPosition: 'right',
 					resizable: false,
+					flex: 1,
 					headerComponent: AddColumnButton,
 					headerComponentParams: { onAddColumn },
 				},

--- a/packages/frontend/editor-ui/src/features/dataStore/composables/useDataStoreGridBase.ts
+++ b/packages/frontend/editor-ui/src/features/dataStore/composables/useDataStoreGridBase.ts
@@ -103,9 +103,15 @@ export const useDataStoreGridBase = ({
 		if (rowNode?.rowIndex === null) return;
 		const rowIndex = rowNode!.rowIndex;
 
-		const firstEditableCol = colDefs.value[1];
-		if (!firstEditableCol?.colId) return;
-		const columnId = firstEditableCol.colId;
+		const displayed = initializedGridApi.value.getAllDisplayedColumns();
+		const firstEditable = displayed.find((col) => {
+			const def = col.getColDef();
+			if (!def) return false;
+			if (def.colId === DEFAULT_ID_COLUMN_NAME) return false;
+			return !!def.editable;
+		});
+		if (!firstEditable) return;
+		const columnId = firstEditable.getColId();
 
 		requestAnimationFrame(() => {
 			initializedGridApi.value.ensureIndexVisible(rowIndex);

--- a/packages/frontend/editor-ui/src/features/dataStore/composables/useDataStoreGridBase.ts
+++ b/packages/frontend/editor-ui/src/features/dataStore/composables/useDataStoreGridBase.ts
@@ -148,6 +148,7 @@ export const useDataStoreGridBase = ({
 				component: ElDatePickerCellEditor,
 			});
 			columnDef.valueFormatter = dateValueFormatter;
+			columnDef.cellEditorPopup = true;
 		} else if (col.type === 'number') {
 			columnDef.valueFormatter = numberValueFormatter;
 		}

--- a/packages/frontend/editor-ui/src/features/dataStore/composables/useDataStoreOperations.ts
+++ b/packages/frontend/editor-ui/src/features/dataStore/composables/useDataStoreOperations.ts
@@ -197,8 +197,23 @@ export const useDataStoreOperations = ({
 		const { data, api, oldValue, colDef } = params;
 		const value = params.data[colDef.field!];
 
-		if (value === undefined || value === oldValue) {
-			return;
+		const cellType = colDef.cellDataType;
+
+		if (cellType === 'date') {
+			if (value instanceof Date && oldValue instanceof Date) {
+				// Compare time values for Date objects
+				if (value.getTime() === oldValue.getTime()) {
+					return;
+				}
+			} else if (value === null && oldValue === null) {
+				// Both are null, no change
+				return;
+			}
+		} else {
+			// Primitive strict equality check for non-date types
+			if (value === undefined || value === oldValue) {
+				return;
+			}
 		}
 
 		if (typeof data.id !== 'number') {

--- a/packages/frontend/editor-ui/src/features/dataStore/composables/useDataStoreOperations.ts
+++ b/packages/frontend/editor-ui/src/features/dataStore/composables/useDataStoreOperations.ts
@@ -213,7 +213,7 @@ export const useDataStoreOperations = ({
 
 		const cellType = isDataStoreColumnType(colDef.cellDataType) ? colDef.cellDataType : undefined;
 
-		if (areValuesEqual(oldValue, value, cellType)) {
+		if (value === undefined || areValuesEqual(oldValue, value, cellType)) {
 			return;
 		}
 

--- a/packages/frontend/editor-ui/src/features/dataStore/composables/useDataStoreOperations.ts
+++ b/packages/frontend/editor-ui/src/features/dataStore/composables/useDataStoreOperations.ts
@@ -18,7 +18,7 @@ import type {
 } from 'ag-grid-community';
 import { useDataStoreStore } from '@/features/dataStore/dataStore.store';
 import { MODAL_CONFIRM } from '@/constants';
-import { isDataStoreValue, isDataStoreColumnType } from '@/features/dataStore/typeGuards';
+import { isDataStoreValue, isAGGridCellType } from '@/features/dataStore/typeGuards';
 import { useDataStoreTypes } from '@/features/dataStore/composables/useDataStoreTypes';
 import { areValuesEqual } from '@/features/dataStore/utils/typeUtils';
 
@@ -198,7 +198,9 @@ export const useDataStoreOperations = ({
 		const { data, api, oldValue, colDef } = params;
 		const value = params.data[colDef.field!];
 
-		const cellType = isDataStoreColumnType(colDef.cellDataType) ? colDef.cellDataType : undefined;
+		const cellType = isAGGridCellType(colDef.cellDataType)
+			? dataStoreTypes.mapToDataStoreColumnType(colDef.cellDataType)
+			: undefined;
 
 		if (value === undefined || areValuesEqual(oldValue, value, cellType)) {
 			return;

--- a/packages/frontend/editor-ui/src/features/dataStore/composables/useDataStoreOperations.ts
+++ b/packages/frontend/editor-ui/src/features/dataStore/composables/useDataStoreOperations.ts
@@ -6,7 +6,6 @@ import type {
 	DataStoreColumn,
 	DataStoreColumnCreatePayload,
 	DataStoreRow,
-	DataStoreColumnType,
 } from '@/features/dataStore/datastore.types';
 import { ref, type Ref } from 'vue';
 import { useI18n } from '@n8n/i18n';
@@ -21,6 +20,7 @@ import { useDataStoreStore } from '@/features/dataStore/dataStore.store';
 import { MODAL_CONFIRM } from '@/constants';
 import { isDataStoreValue, isDataStoreColumnType } from '@/features/dataStore/typeGuards';
 import { useDataStoreTypes } from '@/features/dataStore/composables/useDataStoreTypes';
+import { areValuesEqual } from '@/features/dataStore/utils/typeUtils';
 
 export type UseDataStoreOperationsParams = {
 	colDefs: Ref<ColDef[]>;
@@ -193,19 +193,6 @@ export const useDataStoreOperations = ({
 			contentLoading.value = false;
 		}
 	}
-
-	const areValuesEqual = (
-		oldValue: unknown,
-		newValue: unknown,
-		type: DataStoreColumnType | undefined,
-	) => {
-		if (type && type === 'date') {
-			if (oldValue instanceof Date && newValue instanceof Date) {
-				return oldValue.getTime() === newValue.getTime();
-			}
-		}
-		return oldValue === newValue;
-	};
 
 	const onCellValueChanged = async (params: CellValueChangedEvent<DataStoreRow>) => {
 		const { data, api, oldValue, colDef } = params;

--- a/packages/frontend/editor-ui/src/features/dataStore/constants.ts
+++ b/packages/frontend/editor-ui/src/features/dataStore/constants.ts
@@ -39,3 +39,7 @@ export const DATA_STORE_MODULE_NAME = 'data-table';
 export const NUMBER_WITH_SPACES_REGEX = /\B(?=(\d{3})+(?!\d))/g;
 export const NUMBER_THOUSAND_SEPARATOR = ' ';
 export const NUMBER_DECIMAL_SEPARATOR = '.';
+
+// Allows 1-2 digit month/day/time parts (e.g., 2025-1-1 2:3:4)
+export const LOOSE_DATE_REGEX =
+	/^([0-9]{4})-([0-9]{1,2})-([0-9]{1,2})(?:[ T]([0-9]{1,2}):([0-9]{1,2})(?::([0-9]{1,2}))?)?$/;

--- a/packages/frontend/editor-ui/src/features/dataStore/constants.ts
+++ b/packages/frontend/editor-ui/src/features/dataStore/constants.ts
@@ -10,6 +10,8 @@ export const DEFAULT_DATA_STORE_PAGE_SIZE = 10;
 
 export const DATA_STORE_ID_COLUMN_WIDTH = 60;
 
+export const DEFAULT_COLUMN_WIDTH = 250;
+
 export const DATA_STORE_HEADER_HEIGHT = 36;
 export const DATA_STORE_ROW_HEIGHT = 33;
 

--- a/packages/frontend/editor-ui/src/features/dataStore/datastore.types.ts
+++ b/packages/frontend/editor-ui/src/features/dataStore/datastore.types.ts
@@ -11,9 +11,19 @@ export type DataStore = {
 	project?: Project;
 };
 
-export type DataStoreColumnType = 'string' | 'number' | 'boolean' | 'date';
+// Single sources of truth for supported types
+export const DATA_STORE_COLUMN_TYPES = ['string', 'number', 'boolean', 'date'] as const;
+export type DataStoreColumnType = (typeof DATA_STORE_COLUMN_TYPES)[number];
 
-export type AGGridCellType = 'text' | 'number' | 'boolean' | 'date' | 'dateString' | 'object';
+export const AG_GRID_CELL_TYPES = [
+	'text',
+	'number',
+	'boolean',
+	'date',
+	'dateString',
+	'object',
+] as const;
+export type AGGridCellType = (typeof AG_GRID_CELL_TYPES)[number];
 
 export type DataStoreColumn = {
 	id: string;

--- a/packages/frontend/editor-ui/src/features/dataStore/typeGuards.ts
+++ b/packages/frontend/editor-ui/src/features/dataStore/typeGuards.ts
@@ -3,6 +3,7 @@ import type {
 	DataStoreValue,
 	DataStoreColumnType,
 } from '@/features/dataStore/datastore.types';
+import { AG_GRID_CELL_TYPES, DATA_STORE_COLUMN_TYPES } from '@/features/dataStore/datastore.types';
 
 export const isDataStoreValue = (value: unknown): value is DataStoreValue => {
 	return (
@@ -15,12 +16,9 @@ export const isDataStoreValue = (value: unknown): value is DataStoreValue => {
 };
 
 export const isAGGridCellType = (value: unknown): value is AGGridCellType => {
-	return (
-		typeof value === 'string' &&
-		['text', 'number', 'boolean', 'date', 'dateString', 'object'].includes(value)
-	);
+	return typeof value === 'string' && (AG_GRID_CELL_TYPES as readonly string[]).includes(value);
 };
 
 export const isDataStoreColumnType = (type: unknown): type is DataStoreColumnType => {
-	return type === 'string' || type === 'number' || type === 'boolean' || type === 'date';
+	return typeof type === 'string' && (DATA_STORE_COLUMN_TYPES as readonly string[]).includes(type);
 };

--- a/packages/frontend/editor-ui/src/features/dataStore/typeGuards.ts
+++ b/packages/frontend/editor-ui/src/features/dataStore/typeGuards.ts
@@ -1,4 +1,8 @@
-import type { AGGridCellType, DataStoreValue } from '@/features/dataStore/datastore.types';
+import type {
+	AGGridCellType,
+	DataStoreValue,
+	DataStoreColumnType,
+} from '@/features/dataStore/datastore.types';
 
 export const isDataStoreValue = (value: unknown): value is DataStoreValue => {
 	return (
@@ -15,4 +19,8 @@ export const isAGGridCellType = (value: unknown): value is AGGridCellType => {
 		typeof value === 'string' &&
 		['text', 'number', 'boolean', 'date', 'dateString', 'object'].includes(value)
 	);
+};
+
+export const isDataStoreColumnType = (type: unknown): type is DataStoreColumnType => {
+	return type === 'string' || type === 'number' || type === 'boolean' || type === 'date';
 };

--- a/packages/frontend/editor-ui/src/features/dataStore/utils/columnUtils.ts
+++ b/packages/frontend/editor-ui/src/features/dataStore/utils/columnUtils.ts
@@ -7,6 +7,7 @@ import type {
 	ValueFormatterParams,
 } from 'ag-grid-community';
 import type { Ref } from 'vue';
+import { DateTime } from 'luxon';
 import type { DataStoreColumn, DataStoreRow } from '@/features/dataStore/datastore.types';
 import {
 	ADD_ROW_ROW_ID,
@@ -98,7 +99,8 @@ export const dateValueFormatter = (
 ): string => {
 	const value = params.value;
 	if (value === null || value === undefined) return '';
-	return value.toISOString();
+	// Format using user's local timezone (includes offset)
+	return DateTime.fromJSDate(value).toISO() ?? '';
 };
 
 const numberWithSpaces = (num: number) => {

--- a/packages/frontend/editor-ui/src/features/dataStore/utils/typeUtils.test.ts
+++ b/packages/frontend/editor-ui/src/features/dataStore/utils/typeUtils.test.ts
@@ -47,25 +47,57 @@ describe('Loose Date Parsing', () => {
 		expect(d?.getSeconds()).toBe(5);
 	});
 
+	it('accepts T separator without seconds and defaults seconds to 00', () => {
+		const d = parseLooseDateInput('2023-01-02T3:4');
+		expect(d).not.toBeNull();
+		expect(d?.getFullYear()).toBe(2023);
+		expect(d?.getMonth()).toBe(0);
+		expect(d?.getDate()).toBe(2);
+		expect(d?.getHours()).toBe(3);
+		expect(d?.getMinutes()).toBe(4);
+		expect(d?.getSeconds()).toBe(0);
+	});
+
 	it('validates real calendar dates (e.g., leap day)', () => {
 		expect(parseLooseDateInput('2024-02-29')).not.toBeNull();
 		expect(parseLooseDateInput('2023-02-29')).toBeNull();
 	});
 
-	it('returns null for invalid ranges', () => {
-		expect(parseLooseDateInput('2023-13-01')).toBeNull();
-		expect(parseLooseDateInput('2023-00-10')).toBeNull();
-		expect(parseLooseDateInput('2023-01-32')).toBeNull();
-		expect(parseLooseDateInput('2023-01-00')).toBeNull();
-		expect(parseLooseDateInput('2023-01-01 24:00:00')).toBeNull();
-		expect(parseLooseDateInput('2023-01-01 23:60:00')).toBeNull();
-		expect(parseLooseDateInput('2023-01-01 23:59:60')).toBeNull();
+	it('accepts single-digit date-only input', () => {
+		const d = parseLooseDateInput('2023-7-9');
+		expect(d).not.toBeNull();
+		expect(d?.getFullYear()).toBe(2023);
+		expect(d?.getMonth()).toBe(6);
+		expect(d?.getDate()).toBe(9);
+		expect(d?.getHours()).toBe(0);
+		expect(d?.getMinutes()).toBe(0);
+		expect(d?.getSeconds()).toBe(0);
 	});
 
-	it('returns null for non-matching strings', () => {
-		expect(parseLooseDateInput('not a date')).toBeNull();
-		expect(parseLooseDateInput('2023/07/09')).toBeNull();
-		expect(parseLooseDateInput('07-09-2023')).toBeNull();
+	it('returns null for invalid inputs', () => {
+		const invalidInputs = [
+			// Invalid ranges
+			'2023-13-01',
+			'2023-00-10',
+			'2023-01-32',
+			'2023-01-00',
+			'2023-01-01 24:00:00',
+			'2023-01-01 23:60:00',
+			'2023-01-01 23:59:60',
+			// Invalid calendar dates
+			'2023-02-30',
+			'2023-04-31',
+			// Invalid separators/spacing
+			'2023-01-02  3:4:5',
+			// Non-matching strings
+			'not a date',
+			'2023/07/09',
+			'07-09-2023',
+		];
+
+		invalidInputs.forEach((input) => {
+			expect(parseLooseDateInput(input)).toBeNull();
+		});
 	});
 });
 

--- a/packages/frontend/editor-ui/src/features/dataStore/utils/typeUtils.test.ts
+++ b/packages/frontend/editor-ui/src/features/dataStore/utils/typeUtils.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+
+import { parseLooseDateInput, areValuesEqual } from '@/features/dataStore/utils/typeUtils';
+
+describe('Loose Date Parsing', () => {
+	it('parses full loose datetime with single-digit parts', () => {
+		const d = parseLooseDateInput('2023-7-9 5:6:7');
+		expect(d).not.toBeNull();
+		expect(d?.getFullYear()).toBe(2023);
+		expect(d?.getMonth()).toBe(6); // July is 6 (0-indexed)
+		expect(d?.getDate()).toBe(9);
+		expect(d?.getHours()).toBe(5);
+		expect(d?.getMinutes()).toBe(6);
+		expect(d?.getSeconds()).toBe(7);
+	});
+
+	it('parses date-only and defaults time to 00:00:00', () => {
+		const d = parseLooseDateInput('2023-07-09');
+		expect(d).not.toBeNull();
+		expect(d?.getHours()).toBe(0);
+		expect(d?.getMinutes()).toBe(0);
+		expect(d?.getSeconds()).toBe(0);
+	});
+
+	it('parses without seconds and defaults seconds to 00', () => {
+		const d = parseLooseDateInput('2023-07-09 05:06');
+		expect(d).not.toBeNull();
+		expect(d?.getHours()).toBe(5);
+		expect(d?.getMinutes()).toBe(6);
+		expect(d?.getSeconds()).toBe(0);
+	});
+
+	it('trims surrounding whitespace', () => {
+		const d = parseLooseDateInput('   2023-07-09 05:06:07   ');
+		expect(d).not.toBeNull();
+		expect(d?.getFullYear()).toBe(2023);
+	});
+
+	it('accepts T separator between date and time', () => {
+		const d = parseLooseDateInput('2023-01-02T3:4:5');
+		expect(d).not.toBeNull();
+		expect(d?.getFullYear()).toBe(2023);
+		expect(d?.getMonth()).toBe(0);
+		expect(d?.getDate()).toBe(2);
+		expect(d?.getHours()).toBe(3);
+		expect(d?.getMinutes()).toBe(4);
+		expect(d?.getSeconds()).toBe(5);
+	});
+
+	it('validates real calendar dates (e.g., leap day)', () => {
+		expect(parseLooseDateInput('2024-02-29')).not.toBeNull();
+		expect(parseLooseDateInput('2023-02-29')).toBeNull();
+	});
+
+	it('returns null for invalid ranges', () => {
+		expect(parseLooseDateInput('2023-13-01')).toBeNull();
+		expect(parseLooseDateInput('2023-00-10')).toBeNull();
+		expect(parseLooseDateInput('2023-01-32')).toBeNull();
+		expect(parseLooseDateInput('2023-01-00')).toBeNull();
+		expect(parseLooseDateInput('2023-01-01 24:00:00')).toBeNull();
+		expect(parseLooseDateInput('2023-01-01 23:60:00')).toBeNull();
+		expect(parseLooseDateInput('2023-01-01 23:59:60')).toBeNull();
+	});
+
+	it('returns null for non-matching strings', () => {
+		expect(parseLooseDateInput('not a date')).toBeNull();
+		expect(parseLooseDateInput('2023/07/09')).toBeNull();
+		expect(parseLooseDateInput('07-09-2023')).toBeNull();
+	});
+});
+
+describe('Cell value comparison', () => {
+	it('compares Date values by timestamp when type is date', () => {
+		const a = new Date(2023, 6, 9, 5, 6, 7);
+		const b = new Date(2023, 6, 9, 5, 6, 7);
+		const c = new Date(2023, 6, 9, 5, 6, 8);
+
+		expect(areValuesEqual(a, b, 'date')).toBe(true);
+		expect(areValuesEqual(a, c, 'date')).toBe(false);
+	});
+
+	it('falls back to strict equality for non-date types', () => {
+		expect(areValuesEqual(1, 1, 'number')).toBe(true);
+		expect(areValuesEqual(1, 2, 'number')).toBe(false);
+		const obj = { a: 1 };
+		expect(areValuesEqual(obj, obj, 'string')).toBe(true);
+		expect(areValuesEqual({ a: 1 }, { a: 1 }, 'string')).toBe(false);
+	});
+
+	it('when type is date but values are not Date instances, uses strict equality', () => {
+		const date = new Date(2023, 6, 9);
+		expect(areValuesEqual(date, date.toISOString(), 'date')).toBe(false);
+		const sameRef: unknown = { when: date };
+		expect(areValuesEqual(sameRef, sameRef, 'date')).toBe(true);
+	});
+});

--- a/packages/frontend/editor-ui/src/features/dataStore/utils/typeUtils.ts
+++ b/packages/frontend/editor-ui/src/features/dataStore/utils/typeUtils.ts
@@ -1,0 +1,43 @@
+import { LOOSE_DATE_REGEX } from '@/features/dataStore/constants';
+
+/**
+ * Parses a loose date string into a Date object.
+ * Allows:
+ * 	- Missing leading zeros (e.g., 2023-7-9 5:6:7)
+ * 	- Optional time part (e.g., 2023-07-09), defaulting to 00:00:00
+ *  - Optional seconds part (e.g., 2023-07-09 05:06), defaulting to 00
+ * 	- Extra whitespace around the date
+ * @param text The loose date string to parse
+ * @returns The parsed Date object, or null if parsing failed
+ */
+export function parseLooseDateInput(text: string): Date | null {
+	const trimmed = text.trim();
+	const m = LOOSE_DATE_REGEX.exec(trimmed);
+	if (!m) return null;
+	const y = Number(m[1]);
+	const mo = Number(m[2]);
+	const d = Number(m[3]);
+	const hh = m[4] !== undefined ? Number(m[4]) : 0;
+	const mm = m[5] !== undefined ? Number(m[5]) : 0;
+	const ss = m[6] !== undefined ? Number(m[6]) : 0;
+
+	if (mo < 1 || mo > 12) return null;
+	if (d < 1 || d > 31) return null;
+	if (hh < 0 || hh > 23) return null;
+	if (mm < 0 || mm > 59) return null;
+	if (ss < 0 || ss > 59) return null;
+
+	const dt = new Date(y, mo - 1, d, hh, mm, ss, 0);
+	if (
+		dt.getFullYear() !== y ||
+		dt.getMonth() !== mo - 1 ||
+		dt.getDate() !== d ||
+		dt.getHours() !== hh ||
+		dt.getMinutes() !== mm ||
+		dt.getSeconds() !== ss
+	) {
+		return null;
+	}
+
+	return dt;
+}

--- a/packages/frontend/editor-ui/src/features/dataStore/utils/typeUtils.ts
+++ b/packages/frontend/editor-ui/src/features/dataStore/utils/typeUtils.ts
@@ -1,4 +1,5 @@
 import { LOOSE_DATE_REGEX } from '@/features/dataStore/constants';
+import type { DataStoreColumnType } from '@/features/dataStore/datastore.types';
 
 /**
  * Parses a loose date string into a Date object.
@@ -10,7 +11,7 @@ import { LOOSE_DATE_REGEX } from '@/features/dataStore/constants';
  * @param text The loose date string to parse
  * @returns The parsed Date object, or null if parsing failed
  */
-export function parseLooseDateInput(text: string): Date | null {
+export const parseLooseDateInput = (text: string): Date | null => {
 	const trimmed = text.trim();
 	const m = LOOSE_DATE_REGEX.exec(trimmed);
 	if (!m) return null;
@@ -40,4 +41,24 @@ export function parseLooseDateInput(text: string): Date | null {
 	}
 
 	return dt;
-}
+};
+
+/**
+ * Check if two column values are equal, with special handling for date types.
+ * @param oldValue unknown
+ * @param newValue unknown
+ * @param type DataStoreColumnType | undefined
+ * @returns boolean
+ */
+export const areValuesEqual = (
+	oldValue: unknown,
+	newValue: unknown,
+	type: DataStoreColumnType | undefined,
+) => {
+	if (type && type === 'date') {
+		if (oldValue instanceof Date && newValue instanceof Date) {
+			return oldValue.getTime() === newValue.getTime();
+		}
+	}
+	return oldValue === newValue;
+};

--- a/packages/frontend/editor-ui/src/features/dataStore/utils/typeUtils.ts
+++ b/packages/frontend/editor-ui/src/features/dataStore/utils/typeUtils.ts
@@ -7,12 +7,12 @@ import type { DataStoreColumnType } from '@/features/dataStore/datastore.types';
  * 	- Missing leading zeros (e.g., 2023-7-9 5:6:7)
  * 	- Optional time part (e.g., 2023-07-09), defaulting to 00:00:00
  *  - Optional seconds part (e.g., 2023-07-09 05:06), defaulting to 00
- * 	- Extra whitespace around the date
  * @param text The loose date string to parse
- * @returns The parsed Date object, or null if parsing failed
+ * @returns Date | null
  */
 export const parseLooseDateInput = (text: string): Date | null => {
 	const trimmed = text.trim();
+	// Validate shape and extract parts
 	const m = LOOSE_DATE_REGEX.exec(trimmed);
 	if (!m) return null;
 	const y = Number(m[1]);
@@ -22,12 +22,8 @@ export const parseLooseDateInput = (text: string): Date | null => {
 	const mm = m[5] !== undefined ? Number(m[5]) : 0;
 	const ss = m[6] !== undefined ? Number(m[6]) : 0;
 
-	if (mo < 1 || mo > 12) return null;
-	if (d < 1 || d > 31) return null;
-	if (hh < 0 || hh > 23) return null;
-	if (mm < 0 || mm > 59) return null;
-	if (ss < 0 || ss > 59) return null;
-
+	// Check if constructed date matches input parts
+	// this ensures Date constructor didn't auto-correct invalid dates
 	const dt = new Date(y, mo - 1, d, hh, mm, ss, 0);
 	if (
 		dt.getFullYear() !== y ||


### PR DESCRIPTION
## Summary
**Datetime updates** (ADO-4084):
- Renamed type `date` --> `datetime` (only in UI)
- Allowed typing directly in table cell + loose date formats parsing
- Using current browser timezone when showing dates

**Layout changes** (ADO-4078):
- Table wrapper no longer adjusts to page width
- Added default width (250px) for table columns

## Related Linear tickets, Github issues, and Community forum posts
Closes ADO-4084
Closes ADO-4078

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
