### PR TITLE
test: Remove wait for spinner nodes

### DIFF
--- a/packages/testing/playwright/tests/ui/50-logs.spec.ts
+++ b/packages/testing/playwright/tests/ui/50-logs.spec.ts
@@ -230,19 +230,13 @@ test.describe('Logs', () => {
 		await expect(n8n.executions.logsPanel.getLogEntries().nth(2)).toContainText('E2E Chat Model');
 	});
 
-	test('should show logs for a workflow with a node that waits for webhook', async ({
-		n8n,
-		setupRequirements,
-	}) => {
-		await setupRequirements({ workflow: 'Workflow_wait_for_webhook.json' });
-
-		await n8n.canvas.canvasBody().click({ position: { x: 0, y: 0 } }); // click logs panel to deselect nodes in canvas
-		await n8n.canvas.clickZoomToFitButton();
+	test('should show logs for a workflow with a node that waits for webhook', async ({ n8n }) => {
+		await n8n.start.fromImportedWorkflow('Workflow_wait_for_webhook.json');
+		await n8n.canvas.deselectAll();
 		await n8n.canvas.logsPanel.open();
 
 		await n8n.canvas.clickExecuteWorkflowButton();
 
-		await expect(n8n.canvas.getNodesWithSpinner()).toContainText(NODES.WAIT_NODE);
 		await expect(n8n.canvas.getWaitingNodes()).toContainText(NODES.WAIT_NODE);
 		await expect(n8n.canvas.logsPanel.getLogEntries()).toHaveCount(2);
 		await expect(n8n.canvas.logsPanel.getLogEntries().nth(1)).toContainText(NODES.WAIT_NODE);
@@ -259,7 +253,6 @@ test.describe('Logs', () => {
 		const response = await n8n.page.request.get(webhookUrl!);
 		expect(response.status()).toBe(200);
 
-		await expect(n8n.canvas.getNodesWithSpinner()).toBeHidden();
 		await expect(n8n.canvas.getWaitingNodes()).toBeHidden();
 		await expect(
 			n8n.canvas.logsPanel.getOverviewStatus().filter({ hasText: /Success in [\d.]+m?s/ }),


### PR DESCRIPTION

## Summary

Spinner timing is difficult and only shows when node is in progress, not when waiting.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
