### PR TITLE
fix(Perplexity Node): Update model from 'r1-1776' to 'sonar' in API and tests

### DIFF
--- a/packages/nodes-base/credentials/PerplexityApi.credentials.ts
+++ b/packages/nodes-base/credentials/PerplexityApi.credentials.ts
@@ -39,7 +39,7 @@ export class PerplexityApi implements ICredentialType {
 			url: '/chat/completions',
 			method: 'POST',
 			body: {
-				model: 'r1-1776',
+				model: 'sonar',
 				messages: [{ role: 'user', content: 'test' }],
 			},
 			headers: {

--- a/packages/nodes-base/nodes/Perplexity/descriptions/chat/complete.operation.ts
+++ b/packages/nodes-base/nodes/Perplexity/descriptions/chat/complete.operation.ts
@@ -6,10 +6,9 @@ const properties: INodeProperties[] = [
 		displayName: 'Model',
 		name: 'model',
 		type: 'options',
-		default: 'r1-1776',
+		default: 'sonar',
 		required: true,
 		options: [
-			{ name: 'R1-1776', value: 'r1-1776' },
 			{ name: 'Sonar', value: 'sonar' },
 			{ name: 'Sonar Deep Research', value: 'sonar-deep-research' },
 			{ name: 'Sonar Pro', value: 'sonar-pro' },

--- a/packages/nodes-base/nodes/Perplexity/test/chat/complete.test.ts
+++ b/packages/nodes-base/nodes/Perplexity/test/chat/complete.test.ts
@@ -14,7 +14,7 @@ describe('Perplexity Node - Chat Completions', () => {
 		nock('https://api.perplexity.ai')
 			.post('/chat/completions', (body) => {
 				return (
-					body?.model?.value === 'r1-1776' &&
+					body?.model?.value === 'sonar' &&
 					body?.model?.mode === 'id' &&
 					Array.isArray(body?.messages) &&
 					body.messages.length === 3 &&
@@ -25,7 +25,7 @@ describe('Perplexity Node - Chat Completions', () => {
 			})
 			.reply(200, {
 				id: '6bb24c98-3071-4691-9a7b-dc4bc18c3c2c',
-				model: 'r1-1776',
+				model: 'sonar',
 				created: 1743161086,
 				object: 'chat.completion',
 				usage: {

--- a/packages/nodes-base/nodes/Perplexity/test/chat/complete.workflow.json
+++ b/packages/nodes-base/nodes/Perplexity/test/chat/complete.workflow.json
@@ -12,7 +12,7 @@
 			"parameters": {
 				"model": {
 					"__rl": true,
-					"value": "r1-1776",
+					"value": "sonar",
 					"mode": "id"
 				},
 				"messages": {
@@ -73,7 +73,7 @@
 			{
 				"json": {
 					"id": "6bb24c98-3071-4691-9a7b-dc4bc18c3c2c",
-					"model": "r1-1776",
+					"model": "sonar",
 					"created": 1743161086,
 					"usage": {
 						"prompt_tokens": 4,

--- a/packages/nodes-base/nodes/Perplexity/test/credentials/PerplexityApi.test.ts
+++ b/packages/nodes-base/nodes/Perplexity/test/credentials/PerplexityApi.test.ts
@@ -16,7 +16,7 @@ describe('Perplexity API Credentials', () => {
 				url: 'https://api.perplexity.ai/chat/completions',
 				method: 'POST',
 				body: {
-					model: 'r1-1776',
+					model: 'sonar',
 					messages: [{ role: 'user', content: 'test' }],
 				},
 				headers: {


### PR DESCRIPTION
## Summary

Perplexity [deprecated and removed](https://docs.perplexity.ai/changelog/changelog?utm_source=chatgpt.com#august-2025) `r1-1776` model. This PR updates the Perplexity node to use supported models - defaulting to sonar - so that:
- Credential tests succeed again.
- New Perplexity “Chat Completions” executions use a current model by default.
- The model dropdown reflects Perplexity’s currently available choices.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

Cross-ref to community topics:
https://community.n8n.io/t/perplexity-ai-credential-error-bad-request-please-check-your-parameters/178058
https://community.n8n.io/t/perplexity-node-credential-test-fails-but-node-executes-successfully/174721
https://community.n8n.io/t/perplexity-api-key-not-working-in-n8n/182053

fixes #19438


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created (no documents are affected).
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
