### PR TITLE
chore(editor): Bump Reka UI version to 2.5.0

### DIFF
--- a/cypress/e2e/10-settings-log-streaming.cy.ts
+++ b/cypress/e2e/10-settings-log-streaming.cy.ts
@@ -58,7 +58,7 @@ describe('Log Streaming Settings', () => {
 		settingsLogStreamingPage.getters
 			.getDestinationNameInput()
 			.find('span[data-test-id=inline-edit-preview]')
-			.click();
+			.click({ force: true });
 		cy.getByTestId('inline-edit-input').type('Destination 0');
 		settingsLogStreamingPage.getters.getDestinationSaveButton().click();
 		cy.wait(100);
@@ -85,7 +85,7 @@ describe('Log Streaming Settings', () => {
 		settingsLogStreamingPage.getters
 			.getDestinationNameInput()
 			.find('span[data-test-id=inline-edit-preview]')
-			.click();
+			.click({ force: true });
 		cy.getByTestId('inline-edit-input').type('Destination 1');
 		settingsLogStreamingPage.getters.getDestinationSaveButton().should('not.have.attr', 'disabled');
 		settingsLogStreamingPage.getters.getDestinationSaveButton().click();

--- a/packages/frontend/@n8n/design-system/package.json
+++ b/packages/frontend/@n8n/design-system/package.json
@@ -64,7 +64,7 @@
     "markdown-it-link-attributes": "^4.0.1",
     "markdown-it-task-lists": "^2.1.1",
     "parse-diff": "^0.11.1",
-    "reka-ui": "^2.2.1",
+    "reka-ui": "^2.5.0",
     "sanitize-html": "2.12.1",
     "vue": "catalog:frontend",
     "vue-boring-avatars": "^1.3.0",

--- a/packages/frontend/@n8n/design-system/src/components/N8nInlineTextEdit/__snapshots__/InlineTextEdit.test.ts.snap
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInlineTextEdit/__snapshots__/InlineTextEdit.test.ts.snap
@@ -3,6 +3,6 @@
 exports[`N8nInlineTextEdit > should render correctly 1`] = `
 "<div class="inlineRenameRoot" title="Test Value" dir="ltr" data-dismissable-layer="">
   <div data-placeholder-shown="" style="display: inline-grid; width: 64px; max-width: 200px; z-index: 1;" class="inlineRenameArea" data-test-id="inline-editable-area"><span class="measureSpan">Test Value</span><span tabindex="0" data-placeholder-shown="" style="white-space: pre; user-select: none; grid-area: 1 / 1 / auto / auto; overflow: hidden; text-overflow: ellipsis; width: 64px; max-width: 200px; z-index: 1;" data-test-id="inline-edit-preview" class="inlineRenamePreview">Test Value</span><input placeholder="Enter text..." maxlength="100" aria-label="editable input" style="all: unset; grid-area: 1 / 1 / auto / auto; visibility: hidden; width: 64px; max-width: 200px; z-index: 1;" class="inlineRenameInput" data-test-id="inline-edit-input" value="Test Value"></div>
-  <!---->
+  <!--v-if-->
 </div>"
 `;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2213,8 +2213,8 @@ importers:
         specifier: ^0.11.1
         version: 0.11.1
       reka-ui:
-        specifier: ^2.2.1
-        version: 2.2.1(typescript@5.9.2)(vue@3.5.13(typescript@5.9.2))
+        specifier: ^2.5.0
+        version: 2.5.0(typescript@5.9.2)(vue@3.5.13(typescript@5.9.2))
       sanitize-html:
         specifier: 2.12.1
         version: 2.12.1
@@ -14529,8 +14529,8 @@ packages:
   reinterval@1.1.0:
     resolution: {integrity: sha512-QIRet3SYrGp0HUHO88jVskiG6seqUGC5iAG7AwI/BV4ypGcuqk9Du6YQBUOUqm9c8pw1eyLoIaONifRua1lsEQ==}
 
-  reka-ui@2.2.1:
-    resolution: {integrity: sha512-oLHiyBn6gTIQGnTnv8G5LQuFp9j8HuUNl0qdnW3XPhFb/07hrxzFpjo2kt/jxOZive+n/XWDbOjSj2h9Hih3qA==}
+  reka-ui@2.5.0:
+    resolution: {integrity: sha512-81aMAmJeVCy2k0E6x7n1kypDY6aM1ldLis5+zcdV1/JtoAlSDck5OBsyLRJU9CfgbrQp1ImnRnBSmC4fZ2fkZQ==}
     peerDependencies:
       vue: '>= 3.2.0'
 
@@ -31157,7 +31157,7 @@ snapshots:
 
   reinterval@1.1.0: {}
 
-  reka-ui@2.2.1(typescript@5.9.2)(vue@3.5.13(typescript@5.9.2)):
+  reka-ui@2.5.0(typescript@5.9.2)(vue@3.5.13(typescript@5.9.2)):
     dependencies:
       '@floating-ui/dom': 1.7.0
       '@floating-ui/vue': 1.1.6(vue@3.5.13(typescript@5.9.2))


### PR DESCRIPTION
## Summary

According to the [releases info](https://github.com/unovue/reka-ui/releases) there's no breaking changes to components we're already using.

## Related Linear tickets, Github issues, and Community forum posts

N/A


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
