### PR TITLE
refactor(Xata Memory Node): Update Xata Memory integration to not rely on legacy API

### DIFF
--- a/packages/@n8n/nodes-langchain/credentials/XataApi.credentialTest.ts
+++ b/packages/@n8n/nodes-langchain/credentials/XataApi.credentialTest.ts
@@ -9,12 +9,27 @@ interface XataCredentials {
 	databaseConnectionString: string;
 }
 
+function isXataCredentials(data: unknown): data is XataCredentials {
+	return (
+		typeof data === 'object' &&
+		data !== null &&
+		'databaseConnectionString' in data &&
+		typeof (data as any).databaseConnectionString === 'string'
+	);
+}
+
 export async function xataConnectionTest(
 	this: ICredentialTestFunctions,
 	credential: ICredentialsDecrypted,
 ): Promise<INodeCredentialTestResult> {
-	const credentials = credential.data as unknown as XataCredentials;
-	const connectionString = credentials.databaseConnectionString;
+	if (!isXataCredentials(credential.data)) {
+		return {
+			status: 'Error',
+			message: 'Invalid credential data: databaseConnectionString is required',
+		};
+	}
+
+	const connectionString = credential.data.databaseConnectionString;
 
 	if (!connectionString) {
 		return {

--- a/packages/@n8n/nodes-langchain/credentials/XataApi.credentialTest.ts
+++ b/packages/@n8n/nodes-langchain/credentials/XataApi.credentialTest.ts
@@ -1,0 +1,85 @@
+import type {
+	ICredentialsDecrypted,
+	ICredentialTestFunctions,
+	INodeCredentialTestResult,
+} from 'n8n-workflow';
+import pgPromise from 'pg-promise';
+
+interface XataCredentials {
+	databaseConnectionString: string;
+}
+
+export async function xataConnectionTest(
+	this: ICredentialTestFunctions,
+	credential: ICredentialsDecrypted,
+): Promise<INodeCredentialTestResult> {
+	const credentials = credential.data as unknown as XataCredentials;
+	const connectionString = credentials.databaseConnectionString;
+
+	if (!connectionString) {
+		return {
+			status: 'Error',
+			message: 'Database connection string is required',
+		};
+	}
+
+	let connection: any = undefined;
+
+	try {
+		const url = new URL(connectionString);
+		if (url.protocol !== 'postgres:' && url.protocol !== 'postgresql:') {
+			return {
+				status: 'Error',
+				message: 'Connection string must use postgres:// or postgresql:// protocol',
+			};
+		}
+
+		const pgp = pgPromise({
+			noWarnings: true,
+		});
+
+		const db = pgp(connectionString);
+
+		connection = await db.connect();
+		if (connection && typeof connection.query === 'function') {
+			await connection.query('SELECT 1');
+		}
+
+		return {
+			status: 'OK',
+			message: 'Connection successful!',
+		};
+	} catch (error) {
+		const errorMessage = error instanceof Error ? error.message : String(error);
+		let message = errorMessage;
+
+		// Provide more user-friendly error messages
+		if (errorMessage.includes('ECONNREFUSED')) {
+			message = 'Connection refused. Please check your host and port.';
+		} else if (errorMessage.includes('ENOTFOUND')) {
+			message = 'Host not found. Please check your host name.';
+		} else if (errorMessage.includes('ETIMEDOUT')) {
+			message = 'Connection timed out. Please check your network connection.';
+		} else if (errorMessage.includes('authentication failed')) {
+			message = 'Authentication failed. Please check your username and password.';
+		} else if (errorMessage.includes('database') && errorMessage.includes('does not exist')) {
+			message = 'Database does not exist. Please check your database name.';
+		} else if (errorMessage.includes('Invalid connection string')) {
+			message = 'Invalid connection string format. Please check your connection string.';
+		}
+
+		return {
+			status: 'Error',
+			message,
+		};
+	} finally {
+		if (connection && typeof connection.done === 'function') {
+			try {
+				await connection.done();
+			} catch (cleanupError) {
+				// Ignore cleanup errors
+				this.logger?.debug('Error during connection cleanup', { error: cleanupError });
+			}
+		}
+	}
+}

--- a/packages/@n8n/nodes-langchain/credentials/XataApi.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/XataApi.credentials.ts
@@ -1,55 +1,20 @@
-import type {
-	IAuthenticateGeneric,
-	ICredentialTestRequest,
-	ICredentialType,
-	INodeProperties,
-} from 'n8n-workflow';
+import type { ICredentialType, INodeProperties } from 'n8n-workflow';
 
 export class XataApi implements ICredentialType {
 	name = 'xataApi';
 
-	displayName = 'Xata Api';
+	displayName = 'Xata PostgreSQL Direct Connection';
 
 	documentationUrl = 'xata';
 
 	properties: INodeProperties[] = [
 		{
-			displayName: 'Database Endpoint',
-			name: 'databaseEndpoint',
+			displayName: 'Database Connection String',
+			name: 'databaseConnectionString',
 			required: true,
 			type: 'string',
 			default: '',
-			placeholder: 'https://{workspace}.{region}.xata.sh/db/{database}',
-		},
-		{
-			displayName: 'Branch',
-			name: 'branch',
-			required: true,
-			type: 'string',
-			default: 'main',
-		},
-		{
-			displayName: 'API Key',
-			name: 'apiKey',
-			type: 'string',
-			typeOptions: { password: true },
-			required: true,
-			default: '',
+			placeholder: 'postgres://{username}:{password}@{host}:{port}/{database}',
 		},
 	];
-
-	authenticate: IAuthenticateGeneric = {
-		type: 'generic',
-		properties: {
-			headers: {
-				Authorization: '=Bearer {{$credentials.apiKey}}',
-			},
-		},
-	};
-
-	test: ICredentialTestRequest = {
-		request: {
-			baseURL: '={{$credentials.databaseEndpoint}}:{{$credentials.branch}}',
-		},
-	};
 }


### PR DESCRIPTION

## Summary

On the Xata side, we have created a new platform (which we call simply Xata), while the old platform is now being called Xata Lite. This updates the XataMemory node, which seems fairly popular, to work both with Xata and Xata Lite.

If this looks good, I can open a corresponding docs PR.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
