### PR TITLE
feat(Data Table Node): Add returnAll for get all rows (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/DataTable/actions/row/get.operation.ts
+++ b/packages/nodes-base/nodes/DataTable/actions/row/get.operation.ts
@@ -33,6 +33,7 @@ export const description: INodeProperties[] = [
 		name: 'limit',
 		type: 'number',
 		displayOptions: {
+			...displayOptions,
 			show: {
 				...displayOptions.show,
 				returnAll: [false],

--- a/packages/nodes-base/nodes/DataTable/actions/row/get.operation.ts
+++ b/packages/nodes-base/nodes/DataTable/actions/row/get.operation.ts
@@ -20,14 +20,27 @@ const displayOptions: IDisplayOptions = {
 export const description: INodeProperties[] = [
 	...getSelectFields(displayOptions),
 	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		displayOptions,
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
 		displayName: 'Limit',
 		name: 'limit',
 		type: 'number',
+		displayOptions: {
+			show: {
+				...displayOptions.show,
+				returnAll: [false],
+			},
+		},
 		typeOptions: {
 			minValue: 1,
 		},
-		displayOptions,
-		default: null,
+		default: 50,
 		description: 'Max number of results to return',
 	},
 ];

--- a/packages/nodes-base/nodes/DataTable/actions/row/get.operation.ts
+++ b/packages/nodes-base/nodes/DataTable/actions/row/get.operation.ts
@@ -5,6 +5,7 @@ import type {
 	INodeProperties,
 } from 'n8n-workflow';
 
+import { ROWS_LIMIT_DEFAULT } from '../../common/constants';
 import { executeSelectMany, getSelectFields } from '../../common/selectMany';
 import { getDataTableProxyExecute } from '../../common/utils';
 
@@ -40,7 +41,7 @@ export const description: INodeProperties[] = [
 		typeOptions: {
 			minValue: 1,
 		},
-		default: 50,
+		default: ROWS_LIMIT_DEFAULT,
 		description: 'Max number of results to return',
 	},
 ];

--- a/packages/nodes-base/nodes/DataTable/common/constants.ts
+++ b/packages/nodes-base/nodes/DataTable/common/constants.ts
@@ -3,6 +3,8 @@ import type { DataStoreColumnJsType } from 'n8n-workflow';
 export const ANY_CONDITION = 'anyCondition';
 export const ALL_CONDITIONS = 'allConditions';
 
+export const ROWS_LIMIT_DEFAULT = 50;
+
 export type FilterType = typeof ANY_CONDITION | typeof ALL_CONDITIONS;
 
 export type FieldEntry =

--- a/packages/nodes-base/nodes/DataTable/common/selectMany.ts
+++ b/packages/nodes-base/nodes/DataTable/common/selectMany.ts
@@ -8,7 +8,7 @@ import type {
 	INodeProperties,
 } from 'n8n-workflow';
 
-import { ALL_CONDITIONS, ANY_CONDITION, type FilterType } from './constants';
+import { ALL_CONDITIONS, ANY_CONDITION, ROWS_LIMIT_DEFAULT, type FilterType } from './constants';
 import { DATA_TABLE_ID_FIELD } from './fields';
 import { buildGetManyFilter, isFieldArray, isMatchType } from './utils';
 
@@ -126,7 +126,7 @@ export async function executeSelectMany(
 	const result: Array<{ json: DataStoreRowReturn }> = [];
 
 	const returnAll = ctx.getNodeParameter('returnAll', index, false);
-	const limit = !returnAll ? ctx.getNodeParameter('limit', index, 0) : undefined;
+	const limit = !returnAll ? ctx.getNodeParameter('limit', index, ROWS_LIMIT_DEFAULT) : 0;
 
 	let expectedTotal: number | undefined;
 	let skip = 0;

--- a/packages/nodes-base/nodes/DataTable/common/selectMany.ts
+++ b/packages/nodes-base/nodes/DataTable/common/selectMany.ts
@@ -125,7 +125,8 @@ export async function executeSelectMany(
 	const PAGE_SIZE = 1000;
 	const result: Array<{ json: DataStoreRowReturn }> = [];
 
-	const limit = ctx.getNodeParameter('limit', index, 0);
+	const returnAll = ctx.getNodeParameter('returnAll', index, false);
+	const limit = !returnAll ? ctx.getNodeParameter('limit', index, 0) : undefined;
 
 	let expectedTotal: number | undefined;
 	let skip = 0;


### PR DESCRIPTION
## Summary

- Add `returnAll` boolean with `false` as default
- Show `limit` if `returnAll` is `false` and set its default to `50`
<img height="400" alt="image" src="https://github.com/user-attachments/assets/cd52a013-ebf3-4b53-aa56-c9b7590f9460" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4128/feature-add-returnall-on-the-data-table-node

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
