### PR TITLE
ci: Rebalance e2e runners

### DIFF
--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -30,7 +30,7 @@ on:
       containers:
         description: 'Number of containers to run tests in.'
         required: false
-        default: '[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]'
+        default: '[1, 2, 3, 4, 5, 6, 7, 8, 9]'
         type: string
       pr_number:
         description: 'PR number to run tests for.'

--- a/.github/workflows/playwright-test-reusable.yml
+++ b/.github/workflows/playwright-test-reusable.yml
@@ -16,7 +16,7 @@ on:
       shards:
         description: 'Shards for parallel execution'
         required: false
-        default: '[1, 2]'
+        default: '[1, 2, 3, 4]'
         type: string
       docker-image:
         description: 'Docker image to use (for docker-pull mode)'
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: ${{ fromJSON(inputs.shards || '[1, 2]') }}
+        shard: ${{ fromJSON(inputs.shards || '[1, 2, 3, 4]') }}
     name: Test (Shard ${{ matrix.shard }}/${{ strategy.job-total }})
 
     steps:


### PR DESCRIPTION
## Summary

Adds more Playwright runners, removes Cypress ones to account for test shift.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
