### PR TITLE
chore(core): Put https environment sync behind feature flag until stable

### DIFF
--- a/packages/frontend/editor-ui/src/views/SettingsSourceControl.test.ts
+++ b/packages/frontend/editor-ui/src/views/SettingsSourceControl.test.ts
@@ -153,6 +153,26 @@ describe('SettingsSourceControl', () => {
 	describe('Protocol Selection', () => {
 		beforeEach(() => {
 			settingsStore.settings.enterprise[EnterpriseEditionFeature.SourceControl] = true;
+			settingsStore.settings.envFeatureFlags = { N8N_ENV_FEAT_HTTPS_SYNC: true };
+		});
+
+		it('should ssh connection settings if frontend feature flag is disabled', async () => {
+			settingsStore.settings.envFeatureFlags = { N8N_ENV_FEAT_HTTPS_SYNC: false };
+			await nextTick();
+			const { container, getByTestId } = renderComponent({
+				pinia,
+			});
+
+			await waitFor(() => expect(sourceControlStore.preferences.publicKey).not.toEqual(''));
+
+			// SSH-specific fields should be visible
+			expect(getByTestId('source-control-ssh-key-type-select')).toBeInTheDocument();
+			expect(getByTestId('source-control-refresh-ssh-key-button')).toBeInTheDocument();
+			expect(container.querySelector('input[name="repoUrl"]')).toBeInTheDocument();
+
+			// HTTPS-specific fields should not be visible
+			expect(container.querySelector('input[name="httpsUsername"]')).not.toBeInTheDocument();
+			expect(container.querySelector('input[name="httpsPassword"]')).not.toBeInTheDocument();
 		});
 
 		it('should show SSH-specific fields when SSH protocol is selected', async () => {

--- a/packages/frontend/editor-ui/src/views/SettingsSourceControl.vue
+++ b/packages/frontend/editor-ui/src/views/SettingsSourceControl.vue
@@ -14,6 +14,7 @@ import { useI18n } from '@n8n/i18n';
 import type { Validatable } from '@n8n/design-system';
 import { computed, onMounted, reactive, ref, watch } from 'vue';
 import { I18nT } from 'vue-i18n';
+import EnvFeatureFlag from '@/features/env-feature-flag/EnvFeatureFlag.vue';
 
 const locale = useI18n();
 const sourceControlStore = useSourceControlStore();
@@ -279,20 +280,22 @@ watch(connectionType, () => {
 			}}</n8n-heading>
 
 			<form @submit="onSubmitConnectionForm">
-				<div v-if="!isConnected" :class="$style.group">
-					<label for="connectionType">{{
-						locale.baseText('settings.sourceControl.connectionType')
-					}}</label>
-					<n8n-form-input
-						id="connectionType"
-						v-model="connectionType"
-						label=""
-						type="select"
-						name="connectionType"
-						:options="connectionTypeOptions"
-						data-test-id="source-control-connection-type-select"
-					/>
-				</div>
+				<EnvFeatureFlag name="HTTPS_SYNC">
+					<div v-if="!isConnected" :class="$style.group">
+						<label for="connectionType">{{
+							locale.baseText('settings.sourceControl.connectionType')
+						}}</label>
+						<n8n-form-input
+							id="connectionType"
+							v-model="connectionType"
+							label=""
+							type="select"
+							name="connectionType"
+							:options="connectionTypeOptions"
+							data-test-id="source-control-connection-type-select"
+						/>
+					</div>
+				</EnvFeatureFlag>
 
 				<!-- Repository URL -->
 				<div :class="$style.group">


### PR DESCRIPTION
## Summary

As we're testing out https sync for environments, we don't want this to be available to users just yet.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-1754/feature-add-support-for-https-for-environments-source-control


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
