### PR TITLE
ci: Update design system path in chromatic workflow (no-changelog)

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           filters: |
             design_system:
-              - packages/design-system/**
+              - packages/frontend/@n8n/design-system/**
               - .github/workflows/chromatic.yml
 
     outputs:
@@ -72,7 +72,7 @@ jobs:
         id: chromatic_tests
         continue-on-error: true
         with:
-          workingDir: packages/design-system
+          workingDir: packages/frontend/@n8n/design-system
           onlyChanged: true
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           exitZeroOnChanges: false


### PR DESCRIPTION
## Summary

This pull request updates the Chromatic GitHub Actions workflow to reflect the new location of the design system package. The changes ensure that Chromatic runs only when relevant files in the updated path are changed and that it operates from the correct working directory.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DS-212/eng-bring-back-visual-regression-testing-tool


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
