### PR TITLE
fix(Notion Api Credentials): lowercase check version header

### DIFF
--- a/packages/nodes-base/credentials/NotionApi.credentials.ts
+++ b/packages/nodes-base/credentials/NotionApi.credentials.ts
@@ -42,7 +42,11 @@ export class NotionApi implements ICredentialType {
 		// if version it's not set, set it to last one
 		// version is only set when the request is made from
 		// the notion node, or was set explicitly in the http node
-		if (!requestOptions.headers['Notion-Version']) {
+		if (
+			!Object.keys(requestOptions.headers || {}).some(
+				(key) => key.toLowerCase() === 'notion-version',
+			)
+		) {
 			requestOptions.headers = {
 				...requestOptions.headers,
 				'Notion-Version': '2022-02-22',

--- a/packages/nodes-base/credentials/test/NotionApi.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/NotionApi.credentials.test.ts
@@ -1,0 +1,141 @@
+import type { ICredentialDataDecryptedObject, IHttpRequestOptions } from 'n8n-workflow';
+
+import { NotionApi } from '../NotionApi.credentials';
+
+describe('NotionApi Credential', () => {
+	const notionApi = new NotionApi();
+
+	it('should have correct properties', () => {
+		expect(notionApi.name).toBe('notionApi');
+		expect(notionApi.displayName).toBe('Notion API');
+		expect(notionApi.documentationUrl).toBe('notion');
+		expect(notionApi.properties).toHaveLength(1);
+		expect(notionApi.test.request.baseURL).toBe('https://api.notion.com/v1');
+		expect(notionApi.test.request.url).toBe('/users/me');
+	});
+
+	describe('authenticate', () => {
+		it('should add Authorization header and default Notion-Version', async () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				apiKey: 'secret_test123456789',
+			};
+
+			const requestOptions: IHttpRequestOptions = {
+				headers: {},
+				url: '/users/me',
+				baseURL: 'https://api.notion.com/v1',
+			};
+
+			const result = await notionApi.authenticate(credentials, requestOptions);
+
+			expect(result.headers).toEqual({
+				Authorization: 'Bearer secret_test123456789 ',
+				'Notion-Version': '2022-02-22',
+			});
+		});
+
+		it('should not override existing Notion-Version header (case-sensitive)', async () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				apiKey: 'secret_test123456789',
+			};
+
+			const requestOptions: IHttpRequestOptions = {
+				headers: {
+					'Notion-Version': '2021-08-16',
+				},
+				url: '/users/me',
+				baseURL: 'https://api.notion.com/v1',
+			};
+
+			const result = await notionApi.authenticate(credentials, requestOptions);
+
+			expect(result.headers).toEqual({
+				Authorization: 'Bearer secret_test123456789 ',
+				'Notion-Version': '2021-08-16',
+			});
+		});
+
+		it('should not override existing notion-version header (lowercase)', async () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				apiKey: 'secret_test123456789',
+			};
+
+			const requestOptions: IHttpRequestOptions = {
+				headers: {
+					'notion-version': '2021-08-16',
+				},
+				url: '/users/me',
+				baseURL: 'https://api.notion.com/v1',
+			};
+
+			const result = await notionApi.authenticate(credentials, requestOptions);
+
+			expect(result.headers).toEqual({
+				Authorization: 'Bearer secret_test123456789 ',
+				'notion-version': '2021-08-16',
+			});
+		});
+
+		it('should not override existing Notion-Version header (mixed case)', async () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				apiKey: 'secret_test123456789',
+			};
+
+			const requestOptions: IHttpRequestOptions = {
+				headers: {
+					'notion-Version': '2021-08-16',
+				},
+				url: '/users/me',
+				baseURL: 'https://api.notion.com/v1',
+			};
+
+			const result = await notionApi.authenticate(credentials, requestOptions);
+
+			expect(result.headers).toEqual({
+				Authorization: 'Bearer secret_test123456789 ',
+				'notion-Version': '2021-08-16',
+			});
+		});
+
+		it('should preserve existing headers', async () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				apiKey: 'secret_test123456789',
+			};
+
+			const requestOptions: IHttpRequestOptions = {
+				headers: {
+					'X-Custom-Header': 'custom-value',
+					'notion-version': '2021-08-16',
+				},
+				url: '/users/me',
+				baseURL: 'https://api.notion.com/v1',
+			};
+
+			const result = await notionApi.authenticate(credentials, requestOptions);
+
+			expect(result.headers).toEqual({
+				Authorization: 'Bearer secret_test123456789 ',
+				'X-Custom-Header': 'custom-value',
+				'notion-version': '2021-08-16',
+			});
+		});
+
+		it('should handle undefined headers object', async () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				apiKey: 'secret_test123456789',
+			};
+
+			const requestOptions: IHttpRequestOptions = {
+				url: '/users/me',
+				baseURL: 'https://api.notion.com/v1',
+			};
+
+			const result = await notionApi.authenticate(credentials, requestOptions);
+
+			expect(result.headers).toEqual({
+				Authorization: 'Bearer secret_test123456789 ',
+				'Notion-Version': '2022-02-22',
+			});
+		});
+	});
+});

--- a/packages/nodes-base/credentials/test/NotionApi.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/NotionApi.credentials.test.ts
@@ -29,7 +29,7 @@ describe('NotionApi Credential', () => {
 			const result = await notionApi.authenticate(credentials, requestOptions);
 
 			expect(result.headers).toEqual({
-				Authorization: 'Bearer secret_test123456789 ',
+				Authorization: 'Bearer secret_test123456789',
 				'Notion-Version': '2022-02-22',
 			});
 		});
@@ -50,7 +50,7 @@ describe('NotionApi Credential', () => {
 			const result = await notionApi.authenticate(credentials, requestOptions);
 
 			expect(result.headers).toEqual({
-				Authorization: 'Bearer secret_test123456789 ',
+				Authorization: 'Bearer secret_test123456789',
 				'Notion-Version': '2021-08-16',
 			});
 		});
@@ -71,7 +71,7 @@ describe('NotionApi Credential', () => {
 			const result = await notionApi.authenticate(credentials, requestOptions);
 
 			expect(result.headers).toEqual({
-				Authorization: 'Bearer secret_test123456789 ',
+				Authorization: 'Bearer secret_test123456789',
 				'notion-version': '2021-08-16',
 			});
 		});
@@ -92,7 +92,7 @@ describe('NotionApi Credential', () => {
 			const result = await notionApi.authenticate(credentials, requestOptions);
 
 			expect(result.headers).toEqual({
-				Authorization: 'Bearer secret_test123456789 ',
+				Authorization: 'Bearer secret_test123456789',
 				'notion-Version': '2021-08-16',
 			});
 		});
@@ -114,7 +114,7 @@ describe('NotionApi Credential', () => {
 			const result = await notionApi.authenticate(credentials, requestOptions);
 
 			expect(result.headers).toEqual({
-				Authorization: 'Bearer secret_test123456789 ',
+				Authorization: 'Bearer secret_test123456789',
 				'X-Custom-Header': 'custom-value',
 				'notion-version': '2021-08-16',
 			});
@@ -133,7 +133,7 @@ describe('NotionApi Credential', () => {
 			const result = await notionApi.authenticate(credentials, requestOptions);
 
 			expect(result.headers).toEqual({
-				Authorization: 'Bearer secret_test123456789 ',
+				Authorization: 'Bearer secret_test123456789',
 				'Notion-Version': '2022-02-22',
 			});
 		});


### PR DESCRIPTION
## Summary

Fix case-sensitive header check that was causing `Notion-Version` header to be overridden even when provided by HTTP Request node while using the Notion Api credentials.
The header check now properly handles case-insensitive HTTP header comparison.

This is important due to Notion having released a new Api version (`2025-09-03`) and deprecating the old one.

## Related Linear tickets, Github issues, and Community forum posts

https://community.n8n.io/t/unable-to-override-request-header-in-http-request-node/182368 (not posted by me, but same issue)

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. _(not concerned)_
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
