### PR TITLE
feat(Data Table Node): Show 'Is False' / 'Is True' condition on boolean columns (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/DataTable/common/constants.ts
+++ b/packages/nodes-base/nodes/DataTable/common/constants.ts
@@ -10,7 +10,7 @@ export type FilterType = typeof ANY_CONDITION | typeof ALL_CONDITIONS;
 export type FieldEntry =
 	| {
 			keyName: string;
-			condition: 'isEmpty' | 'isNotEmpty';
+			condition: 'isEmpty' | 'isNotEmpty' | 'isTrue' | 'isFalse';
 	  }
 	| {
 			keyName: string;

--- a/packages/nodes-base/nodes/DataTable/common/selectMany.ts
+++ b/packages/nodes-base/nodes/DataTable/common/selectMany.ts
@@ -83,7 +83,7 @@ export function getSelectFields(
 							default: '',
 							displayOptions: {
 								hide: {
-									condition: ['isEmpty', 'isNotEmpty'],
+									condition: ['isEmpty', 'isNotEmpty', 'isTrue', 'isFalse'],
 								},
 							},
 						},

--- a/packages/nodes-base/nodes/DataTable/common/utils.ts
+++ b/packages/nodes-base/nodes/DataTable/common/utils.ts
@@ -101,6 +101,18 @@ export function buildGetManyFilter(
 					condition: 'neq' as const,
 					value: null,
 				};
+			case 'isTrue':
+				return {
+					columnName: x.keyName,
+					condition: 'eq' as const,
+					value: true,
+				};
+			case 'isFalse':
+				return {
+					columnName: x.keyName,
+					condition: 'eq' as const,
+					value: false,
+				};
 			default:
 				return {
 					columnName: x.keyName,


### PR DESCRIPTION
## Summary

This PR drops `Equals` and `Not Equals` filter conditions from boolean columns, replacing them with `Is True` and `Is False` options that are easier to use (Equals would only really work with boolean typed data with an expression)

<img width="552" height="485" alt="image" src="https://github.com/user-attachments/assets/86235142-1323-429b-a4dd-bf775bbad58e" />

<img width="581" height="269" alt="image" src="https://github.com/user-attachments/assets/d798299d-2c44-42a0-b6b8-6a89ead3c53b" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4083/feature-better-filtering-for-boolean

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
