### PR TITLE
fix(core): Do not allow API usage when user is disabled (no-changelog)

### DIFF
--- a/packages/cli/src/services/__tests__/public-api-key.service.test.ts
+++ b/packages/cli/src/services/__tests__/public-api-key.service.test.ts
@@ -233,6 +233,30 @@ describe('PublicApiKeyService', () => {
 				);
 			});
 		});
+
+		it('should return false if user is disabled', async () => {
+			//Arrange
+
+			const path = '/test';
+			const method = 'GET';
+			const apiVersion = 'v1';
+
+			const owner = await createOwnerWithApiKey();
+
+			await userRepository.update({ id: owner.id }, { disabled: true });
+
+			const [{ apiKey }] = owner.apiKeys;
+
+			const middleware = publicApiKeyService.getAuthMiddleware(apiVersion);
+
+			//Act
+
+			const response = await middleware(mockReqWith(apiKey, path, method), {}, securitySchema);
+
+			//Assert
+
+			expect(response).toBe(false);
+		});
 	});
 
 	describe('redactApiKey', () => {

--- a/packages/cli/src/services/public-api-key.service.ts
+++ b/packages/cli/src/services/public-api-key.service.ts
@@ -119,6 +119,8 @@ export class PublicApiKeyService {
 
 			if (!user) return false;
 
+			if (user.disabled) return false;
+
 			// Legacy API keys are not JWTs and do not need to be verified.
 			if (!providedApiKey.startsWith(PREFIX_LEGACY_API_KEY)) {
 				try {


### PR DESCRIPTION
## Summary

Title self explanatory

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4127/disabled-accounts-retain-api-access

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
