### PR TITLE
fix(Xero Node): Fix currency dropdown sending wrong value to API

### DIFF
--- a/packages/nodes-base/nodes/Xero/Xero.node.ts
+++ b/packages/nodes-base/nodes/Xero/Xero.node.ts
@@ -145,7 +145,7 @@ export class Xero implements INodeType {
 				}
 				return returnData;
 			},
-			// Get all the brading themes to display them to user so that they can
+			// Get all the currencies to display them to user so that they can
 			// select them easily
 			async getCurrencies(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const organizationId = this.getCurrentNodeParameter('organizationId');
@@ -154,11 +154,9 @@ export class Xero implements INodeType {
 					organizationId,
 				});
 				for (const currency of currencies) {
-					const currencyName = currency.Code;
-					const currencyId = currency.Description;
 					returnData.push({
-						name: currencyName,
-						value: currencyId,
+						name: currency.Description, // e.g. "Euro"
+						value: currency.Code, // e.g. "EUR"
 					});
 				}
 				return returnData;

--- a/packages/nodes-base/nodes/Xero/test/Xero.node.test.ts
+++ b/packages/nodes-base/nodes/Xero/test/Xero.node.test.ts
@@ -1,0 +1,79 @@
+import { mock, mockDeep } from 'jest-mock-extended';
+import type { ILoadOptionsFunctions, INode } from 'n8n-workflow';
+
+import { Xero } from '../Xero.node';
+
+describe('Xero Node', () => {
+	describe('loadOptions', () => {
+		describe('getCurrencies', () => {
+			it('should return currencies with description as display name and code as value', async () => {
+				// Setup mock
+				const xero = new Xero();
+				const loadOptionsFunctions = mockDeep<ILoadOptionsFunctions>();
+
+				loadOptionsFunctions.getNode.mockReturnValue(mock<INode>());
+				loadOptionsFunctions.getCurrentNodeParameter.mockReturnValue('test-org-id');
+
+				// Mock Xero API response via requestOAuth2
+				loadOptionsFunctions.helpers.requestOAuth2.mockResolvedValue({
+					Currencies: [
+						{
+							Code: 'EUR',
+							Description: 'Euro',
+						},
+						{
+							Code: 'GBP',
+							Description: 'British Pound',
+						},
+						{
+							Code: 'USD',
+							Description: 'US Dollar',
+						},
+					],
+				});
+
+				// Call getCurrencies
+				const result = await xero.methods.loadOptions.getCurrencies.call(loadOptionsFunctions);
+
+				// Verify dropdown shows description but sends code
+				expect(result).toEqual([
+					{ name: 'Euro', value: 'EUR' },
+					{ name: 'British Pound', value: 'GBP' },
+					{ name: 'US Dollar', value: 'USD' },
+				]);
+
+				// Verify API was called correctly
+				expect(loadOptionsFunctions.helpers.requestOAuth2).toHaveBeenCalledWith(
+					'xeroOAuth2Api',
+					expect.objectContaining({
+						method: 'GET',
+						uri: 'https://api.xero.com/api.xro/2.0/Currencies',
+						headers: expect.objectContaining({
+							'Xero-tenant-id': 'test-org-id',
+						}),
+					}),
+				);
+			});
+
+			it('should handle empty currency list', async () => {
+				// Setup mock
+				const xero = new Xero();
+				const loadOptionsFunctions = mockDeep<ILoadOptionsFunctions>();
+
+				loadOptionsFunctions.getNode.mockReturnValue(mock<INode>());
+				loadOptionsFunctions.getCurrentNodeParameter.mockReturnValue('test-org-id');
+
+				// Mock empty response via requestOAuth2
+				loadOptionsFunctions.helpers.requestOAuth2.mockResolvedValue({
+					Currencies: [],
+				});
+
+				// Call getCurrencies
+				const result = await xero.methods.loadOptions.getCurrencies.call(loadOptionsFunctions);
+
+				// Verify returns empty array
+				expect(result).toEqual([]);
+			});
+		});
+	});
+});


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
The Xero node's currency dropdown was incorrectly sending currency descriptions instead of currency codes to the Xero API, causing invoice creation to fail.

### Problem
When users selected a currency like "British Pound" from the dropdown, the node was sending the literal text "British Pound" to Xero's API instead of the ISO currency code "GBP". This resulted in the error "Organisation is not subscribed to currency British Pound" even when GBP was properly configured in Xero.

### Solution
This PR fixes the `getCurrencies` method to correctly map currency descriptions to the display name and currency codes to the value field. The dropdown now shows user-friendly names like "British Pound" while properly sending "GBP" to Xero.

### Screenshot
<img width="738" height="596" alt="image" src="https://github.com/user-attachments/assets/64be02b6-4463-4a14-9fa4-797a381546d5" />


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
Closes #19441 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
