### PR TITLE
fix(core): JSON schema validation for multiple displayOptions conditions

### DIFF
--- a/packages/cli/src/public-api/v1/handlers/credentials/credentials.service.ts
+++ b/packages/cli/src/public-api/v1/handlers/credentials/credentials.service.ts
@@ -296,12 +296,12 @@ export function toJsonSchema(properties: INodeProperties[]): IDataObject {
 					else: {
 						allOf: [],
 					},
-				} as IDependency;
+				} satisfies IDependency;
 				resolvedConditions.push(conditionKey);
 			}
 
-			(propertyRequiredDependencies[conditionKey] as IDependency).then?.allOf.push({ required: [property.name] });
-			(propertyRequiredDependencies[conditionKey] as IDependency).else?.allOf.push({
+			propertyRequiredDependencies[conditionKey].then?.allOf.push({ required: [property.name] });
+			propertyRequiredDependencies[conditionKey].else?.allOf.push({
 				not: { required: [property.name] },
 			});
 


### PR DESCRIPTION
## Summary

Fix bug in toJsonSchema function where multiple properties with displayOptions.show 
depending on the same field but different values were incorrectly merged into a 
single condition, causing validation failures.

Specifically for gristApi credential
The issue occurred when properties like customSubdomain (show when planType='paid') 
and selfHostedUrl (show when planType='selfHosted') were processed - both would be 
added to the same condition checking only the first encountered value.

Changes:
- Replace resolveProperties array with resolvedConditions for unique condition tracking
- Create separate conditions for each dependent field + value combination
- Use unique condition keys (dependantName:dependantValue) to prevent merging
- Add test case for the Grist API credentials scenario.

## Testing for Grist
Current Behavior
```bash
{{ n8n_endpoint }}/api/v1/credentials/schema/gristApi

{
  "additionalProperties": false,
  "type": "object",
  "properties": {
    "apiKey": {
      "type": "string"
    },
    "planType": {
      "type": "string",
      "enum": [
        "free",
        "paid",
        "selfHosted"
      ]
    },
    "customSubdomain": {
      "type": "string"
    },
    "selfHostedUrl": {
      "type": "string"
    }
  },
  "allOf": [
    {
      "if": {
        "properties": {
          "planType": {
            "enum": [
              "paid"
            ]
          }
        }
      },
      "then": {
        "allOf": [
          {
            "required": [
              "customSubdomain"
            ]
          },
          {
            "required": [
              "selfHostedUrl"
            ]
          }
        ]
      },
      "else": {
        "allOf": [
          {
            "not": {
              "required": [
                "customSubdomain"
              ]
            }
          },
          {
            "not": {
              "required": [
                "selfHostedUrl"
              ]
            }
          }
        ]
      }
    }
  ],
  "required": [
    "apiKey"
  ]
}
```

After the fix
```bash
{{ n8n_endpoint }}/api/v1/credentials/schema/gristApi

{
  "additionalProperties": false,
  "type": "object",
  "properties": {
    "apiKey": {
      "type": "string"
    },
    "planType": {
      "type": "string",
      "enum": [
        "free",
        "paid",
        "selfHosted"
      ]
    },
    "customSubdomain": {
      "type": "string"
    },
    "selfHostedUrl": {
      "type": "string"
    }
  },
  "allOf": [
    {
      "if": {
        "properties": {
          "planType": {
            "enum": [
              "paid"
            ]
          }
        }
      },
      "then": {
        "allOf": [
          {
            "required": [
              "customSubdomain"
            ]
          }
        ]
      },
      "else": {
        "allOf": [
          {
            "not": {
              "required": [
                "customSubdomain"
              ]
            }
          }
        ]
      }
    },
    {
      "if": {
        "properties": {
          "planType": {
            "enum": [
              "selfHosted"
            ]
          }
        }
      },
      "then": {
        "allOf": [
          {
            "required": [
              "selfHostedUrl"
            ]
          }
        ]
      },
      "else": {
        "allOf": [
          {
            "not": {
              "required": [
                "selfHostedUrl"
              ]
            }
          }
        ]
      }
    }
  ],
  "required": [
    "apiKey"
  ]
}
```

## Testing for Twillo
Current Behavior
```bash
{{ n8n_endpoint }}/api/v1/credentials/schema/twilioApi

{
  "additionalProperties": false,
  "type": "object",
  "properties": {
    "authType": {
      "type": "string",
      "enum": [
        "authToken",
        "apiKey"
      ]
    },
    "accountSid": {
      "type": "string"
    },
    "authToken": {
      "type": "string"
    },
    "apiKeySid": {
      "type": "string"
    },
    "apiKeySecret": {
      "type": "string"
    }
  },
  "allOf": [
    {
      "if": {
        "properties": {
          "authType": {
            "enum": [
              "authToken"
            ]
          }
        }
      },
      "then": {
        "allOf": [
          {
            "required": [
              "authToken"
            ]
          },
          {
            "required": [
              "apiKeySid"
            ]
          },
          {
            "required": [
              "apiKeySecret"
            ]
          }
        ]
      },
      "else": {
        "allOf": [
          {
            "not": {
              "required": [
                "authToken"
              ]
            }
          },
          {
            "not": {
              "required": [
                "apiKeySid"
              ]
            }
          },
          {
            "not": {
              "required": [
                "apiKeySecret"
              ]
            }
          }
        ]
      }
    }
  ],
  "required": []
}
```

After the fix
```bash
{{ n8n_endpoint }}/api/v1/credentials/schema/twilloApi

{
  "additionalProperties": false,
  "type": "object",
  "properties": {
    "authType": {
      "type": "string",
      "enum": [
        "authToken",
        "apiKey"
      ]
    },
    "accountSid": {
      "type": "string"
    },
    "authToken": {
      "type": "string"
    },
    "apiKeySid": {
      "type": "string"
    },
    "apiKeySecret": {
      "type": "string"
    }
  },
  "allOf": [
    {
      "if": {
        "properties": {
          "authType": {
            "enum": [
              "authToken"
            ]
          }
        }
      },
      "then": {
        "allOf": [
          {
            "required": [
              "authToken"
            ]
          }
        ]
      },
      "else": {
        "allOf": [
          {
            "not": {
              "required": [
                "authToken"
              ]
            }
          }
        ]
      }
    },
    {
      "if": {
        "properties": {
          "authType": {
            "enum": [
              "apiKey"
            ]
          }
        }
      },
      "then": {
        "allOf": [
          {
            "required": [
              "apiKeySid"
            ]
          },
          {
            "required": [
              "apiKeySecret"
            ]
          }
        ]
      },
      "else": {
        "allOf": [
          {
            "not": {
              "required": [
                "apiKeySid"
              ]
            }
          },
          {
            "not": {
              "required": [
                "apiKeySecret"
              ]
            }
          }
        ]
      }
    }
  ],
  "required": []
}
```

## Related Linear tickets, Github issues, and Community forum posts
resolves #8472 
resolves #10045 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
