### PR TITLE
fix(editor): Don't show archived only hint at empty folders

### DIFF
--- a/packages/frontend/editor-ui/src/stores/folders.store.ts
+++ b/packages/frontend/editor-ui/src/stores/folders.store.ts
@@ -97,10 +97,13 @@ export const useFoldersStore = defineStore(STORES.FOLDERS, () => {
 		return result;
 	}
 
-	async function fetchTotalWorkflowsAndFoldersCount(projectId?: string): Promise<number> {
+	async function fetchTotalWorkflowsAndFoldersCount(
+		projectId?: string,
+		parentFolderId?: string,
+	): Promise<number> {
 		const { count } = await workflowsApi.getWorkflowsAndFolders(
 			rootStore.restApiContext,
-			{ projectId },
+			{ projectId, parentFolderId },
 			{ skip: 0, take: 1 },
 			true,
 		);

--- a/packages/frontend/editor-ui/src/views/WorkflowsView.vue
+++ b/packages/frontend/editor-ui/src/views/WorkflowsView.vue
@@ -451,7 +451,13 @@ watch(
 		currentFolderId.value = newVal as string;
 		filters.value.search = '';
 		saveFiltersOnQueryString();
-		await fetchWorkflows();
+		await Promise.all([
+			fetchWorkflows(),
+			foldersStore.fetchTotalWorkflowsAndFoldersCount(
+				route.params.projectId as string | undefined,
+				currentFolderId.value ?? undefined,
+			),
+		]);
 	},
 );
 
@@ -463,7 +469,10 @@ sourceControlStore.$onAction(({ name, after }) => {
 const refreshWorkflows = async () => {
 	await Promise.all([
 		fetchWorkflows(),
-		foldersStore.fetchTotalWorkflowsAndFoldersCount(route.params.projectId as string | undefined),
+		foldersStore.fetchTotalWorkflowsAndFoldersCount(
+			route.params.projectId as string | undefined,
+			currentFolderId.value ?? undefined,
+		),
 	]);
 };
 
@@ -474,11 +483,17 @@ const onFolderDeleted = async (payload: {
 }) => {
 	const folderInfo = foldersStore.getCachedFolder(payload.folderId);
 	foldersStore.deleteFoldersFromCache([payload.folderId, folderInfo?.parentFolder ?? '']);
-	// If the deleted folder is the current folder, navigate to the parent folder
+
+	const nextFolderId =
+		currentFolderId.value === payload.folderId
+			? (folderInfo?.parentFolder ?? null)
+			: currentFolderId.value;
 	await foldersStore.fetchTotalWorkflowsAndFoldersCount(
 		route.params.projectId as string | undefined,
+		nextFolderId ?? undefined,
 	);
 
+	// If the deleted folder is the current folder, navigate to the parent folder
 	if (currentFolderId.value === payload.folderId) {
 		void router.push({
 			name: VIEWS.PROJECTS_FOLDERS,
@@ -548,7 +563,10 @@ const initialize = async () => {
 		fetchWorkflows(),
 		workflowsStore.fetchActiveWorkflows(),
 		usageStore.getLicenseInfo(),
-		foldersStore.fetchTotalWorkflowsAndFoldersCount(route.params.projectId as string | undefined),
+		foldersStore.fetchTotalWorkflowsAndFoldersCount(
+			route.params.projectId as string | undefined,
+			currentFolderId.value ?? undefined,
+		),
 	]);
 	breadcrumbsLoading.value = false;
 	workflowsAndFolders.value = resourcesPage;


### PR DESCRIPTION
## Summary

We recently introduced a hint to tell users that there may be archived workflows in the current folder. This wasn't supposed to be shown in actually empty folders, it was supposed to be only shown if the current folder is actually empty. This was caused by us expecting `foldersStore.totalWorkflowCount` to be zero when the current folder is empty, but it didn't update when current folder changed.

I changed this value to update when navigating between folders. This shouldn't break any current usage of that function / store value.

This was caused by us not getting the updated count when current folder changed, so this was always the full proejct level amount of workflows, 

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4044/bug-archived-messages-shows-even-when-folders-are-empty

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
