### PR TITLE
fix(editor): Make JSON highlight color different from background on light theme

### DIFF
--- a/packages/frontend/@n8n/design-system/src/css/_tokens.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.scss
@@ -219,7 +219,7 @@
 	--color-json-brackets: var(--p-gray-670);
 	--color-json-brackets-hover: var(--p-color-alt-e-430);
 	--color-json-line: var(--p-gray-200);
-	--color-json-highlight: var(--p-gray-070);
+	--color-json-highlight: var(--color-background-base);
 	--color-code-background: var(--p-white);
 	--color-code-background-readonly: var(--p-gray-040);
 	--color-code-lineHighlight: var(--p-gray-320-a-010);


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/88ee553b-388a-42ea-8aa3-29d282d51b89

JSON highlight background color had become the same as the background color of the view.
Change it to use the same variable as on dark mode. The contrast isn't the greatest and the highlight is pretty subtle, but as this is now the same variable as on dark mode I think using this here makes the most sense anyways.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3998/json-data-in-light-mode-is-not-highlighted-anymore

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
