### PR TITLE
fix(Default Data Loader Node): Use text loader for text/markdown mime-types

### DIFF
--- a/packages/@n8n/nodes-langchain/utils/N8nBinaryLoader.ts
+++ b/packages/@n8n/nodes-langchain/utils/N8nBinaryLoader.ts
@@ -25,7 +25,7 @@ const SUPPORTED_MIME_TYPES = {
 	csvLoader: ['text/csv'],
 	epubLoader: ['application/epub+zip'],
 	docxLoader: ['application/vnd.openxmlformats-officedocument.wordprocessingml.document'],
-	textLoader: ['text/plain', 'text/mdx', 'text/md'],
+	textLoader: ['text/plain', 'text/mdx', 'text/md', 'text/markdown'],
 	jsonLoader: ['application/json'],
 };
 


### PR DESCRIPTION
## Summary

Use text loader for text/markdown mime-types when using binary mode of Default Data Loader

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
