### PR TITLE
fix(AI Agent Node): Respect context window length in streaming mode

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
@@ -9,7 +9,7 @@ import {
 	type AgentRunnableSequence,
 	createToolCallingAgent,
 } from 'langchain/agents';
-import type { BaseChatMemory, BufferWindowMemory } from 'langchain/memory';
+import type { BaseChatMemory } from 'langchain/memory';
 import type { DynamicStructuredTool, Tool } from 'langchain/tools';
 import omit from 'lodash/omit';
 import { jsonParse, NodeOperationError, sleep } from 'n8n-workflow';

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/ToolsAgentV2.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/ToolsAgentV2.test.ts
@@ -6,11 +6,17 @@ import type { ISupplyDataFunctions, IExecuteFunctions, INode } from 'n8n-workflo
 
 import * as helpers from '../../../../../utils/helpers';
 import * as outputParserModule from '../../../../../utils/output_parsers/N8nOutputParser';
+import * as commonModule from '../../agents/ToolsAgent/common';
 import { toolsAgentExecute } from '../../agents/ToolsAgent/V2/execute';
 
 jest.mock('../../../../../utils/output_parsers/N8nOutputParser', () => ({
 	getOptionalOutputParser: jest.fn(),
 	N8nStructuredOutputParser: jest.fn(),
+}));
+
+jest.mock('../../agents/ToolsAgent/common', () => ({
+	...jest.requireActual('../../agents/ToolsAgent/common'),
+	getOptionalMemory: jest.fn(),
 }));
 
 const mockHelpers = mock<IExecuteFunctions['helpers']>();
@@ -618,6 +624,65 @@ describe('toolsAgentExecute', () => {
 			expect(mockExecutor.invoke).toHaveBeenCalledTimes(1);
 			expect(mockExecutor.streamEvents).not.toHaveBeenCalled();
 			expect(result[0][0].json.output).toBe('Regular response');
+		});
+
+		it('should respect context window length from memory in streaming mode', async () => {
+			const mockMemory = {
+				loadMemoryVariables: jest.fn().mockResolvedValue({
+					chat_history: [
+						{ role: 'human', content: 'Message 1' },
+						{ role: 'ai', content: 'Response 1' },
+					],
+				}),
+				chatHistory: {
+					getMessages: jest.fn().mockResolvedValue([
+						{ role: 'human', content: 'Message 1' },
+						{ role: 'ai', content: 'Response 1' },
+						{ role: 'human', content: 'Message 2' },
+						{ role: 'ai', content: 'Response 2' },
+					]),
+				},
+			};
+
+			jest.spyOn(commonModule, 'getOptionalMemory').mockResolvedValue(mockMemory as any);
+
+			jest.spyOn(helpers, 'getConnectedTools').mockResolvedValue([mock<Tool>()]);
+			jest.spyOn(outputParserModule, 'getOptionalOutputParser').mockResolvedValue(undefined);
+			mockContext.isStreaming.mockReturnValue(true);
+
+			const mockStreamEvents = async function* () {
+				yield {
+					event: 'on_chat_model_stream',
+					data: {
+						chunk: {
+							content: 'Response',
+						},
+					},
+				};
+			};
+
+			const mockExecutor = {
+				streamEvents: jest.fn().mockReturnValue(mockStreamEvents()),
+			};
+
+			jest.spyOn(AgentExecutor, 'fromAgentAndTools').mockReturnValue(mockExecutor as any);
+
+			await toolsAgentExecute.call(mockContext);
+
+			// Verify that memory.loadMemoryVariables was called instead of chatHistory.getMessages
+			expect(mockMemory.loadMemoryVariables).toHaveBeenCalledWith({});
+			expect(mockMemory.chatHistory.getMessages).not.toHaveBeenCalled();
+
+			// Verify that streamEvents was called with the filtered chat history from loadMemoryVariables
+			expect(mockExecutor.streamEvents).toHaveBeenCalledWith(
+				expect.objectContaining({
+					chat_history: [
+						{ role: 'human', content: 'Message 1' },
+						{ role: 'ai', content: 'Response 1' },
+					],
+				}),
+				expect.any(Object),
+			);
 		});
 
 		it('should handle mixed message content types in streaming', async () => {


### PR DESCRIPTION
## Summary
This PR uses memory correctly and respects the settings in the memory node, especially the context window. 

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-1417/community-issue-ai-agent-streaming-bug-postgres-chat-memory-ignores
fixes #18024 
## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
