### PR TITLE
fix(AI Agent Node): Ignore non-text chunks

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
@@ -104,7 +104,9 @@ async function processEventStream(
 					let chunkText = '';
 					if (Array.isArray(chunkContent)) {
 						for (const message of chunkContent) {
-							chunkText += (message as MessageContentText)?.text;
+							if (message?.type === 'text') {
+								chunkText += (message as MessageContentText)?.text;
+							}
 						}
 					} else if (typeof chunkContent === 'string') {
 						chunkText = chunkContent;


### PR DESCRIPTION
## Summary
Streaming mode should (for now) ignore non text chunks to avoid sending invalid chunks to the response. This happens for example in Anthropics thinking mode. 

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-1416/community-issue-ai-agent-streaming-bug
fixes #[17993](https://github.com/n8n-io/n8n/issues/17993)


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
