### PR TITLE
fix(core): Update `N8N_DATA_TABLES_MAX_SIZE_BYTES` default to 50mb (no-changelog)

### DIFF
--- a/packages/@n8n/config/src/configs/data-table.config.ts
+++ b/packages/@n8n/config/src/configs/data-table.config.ts
@@ -4,7 +4,7 @@ import { Config, Env } from '../decorators';
 export class DataTableConfig {
 	/** Specifies the maximum allowed size (in bytes) for data tables. */
 	@Env('N8N_DATA_TABLES_MAX_SIZE_BYTES')
-	maxSize: number = 100 * 1024 * 1024;
+	maxSize: number = 50 * 1024 * 1024;
 
 	/**
 	 * The percentage threshold at which a warning is triggered for data tables.

--- a/packages/@n8n/config/src/configs/data-table.config.ts
+++ b/packages/@n8n/config/src/configs/data-table.config.ts
@@ -11,7 +11,7 @@ export class DataTableConfig {
 	 * When the usage of a data table reaches or exceeds this value, a warning is issued.
 	 */
 	@Env('N8N_DATA_TABLES_WARNING_THRESHOLD_BYTES')
-	warningThreshold: number = 95 * 1024 * 1024;
+	warningThreshold: number = 45 * 1024 * 1024;
 
 	/**
 	 * The duration in milliseconds for which the data table size is cached.

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -53,8 +53,8 @@ describe('GlobalConfig', () => {
 		ssl_cert: '',
 		editorBaseUrl: '',
 		dataTable: {
-			maxSize: 100 * 1024 * 1024,
-			warningThreshold: 95 * 1024 * 1024,
+			maxSize: 50 * 1024 * 1024,
+			warningThreshold: 45 * 1024 * 1024,
 			sizeCheckCacheDuration: 5000,
 		},
 		database: {


### PR DESCRIPTION
## Summary

Title self explanatory

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4142/feature-make-n8n-data-tables-max-size-bytes50mbs

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
