### PR TITLE
fix: Add workflow saving logic check to workers to avoid saving under heavy load

### DIFF
--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -37,6 +37,7 @@ import {
 	getLifecycleHooksForRegularMain,
 	getLifecycleHooksForScalingWorker,
 	getLifecycleHooksForScalingMain,
+	handleExecutionSaveDecision,
 } from '../execution-lifecycle-hooks';
 
 describe('Execution Lifecycle Hooks', () => {
@@ -810,6 +811,66 @@ describe('Execution Lifecycle Hooks', () => {
 				);
 			});
 		});
+
+		describe('saving execution data', () => {
+			it('should delete successful executions when success saving is disabled', async () => {
+				workflowData.settings = {
+					saveDataSuccessExecution: 'none',
+					saveDataErrorExecution: 'all',
+				};
+				const lifecycleHooks = createHooks('webhook');
+
+				await lifecycleHooks.runHook('workflowExecuteAfter', [successfulRun, {}]);
+
+				expect(executionRepository.hardDelete).toHaveBeenCalledWith({
+					workflowId,
+					executionId,
+				});
+			});
+
+			it('should delete failed executions when error saving is disabled', async () => {
+				workflowData.settings = {
+					saveDataSuccessExecution: 'all',
+					saveDataErrorExecution: 'none',
+				};
+				const lifecycleHooks = createHooks('webhook');
+
+				await lifecycleHooks.runHook('workflowExecuteAfter', [failedRun, {}]);
+
+				expect(executionRepository.hardDelete).toHaveBeenCalledWith({
+					workflowId,
+					executionId,
+				});
+			});
+
+			it('should soft delete manual executions when manual saving is disabled', async () => {
+				workflowData.settings = { saveManualExecutions: false };
+				const lifecycleHooks = createHooks('manual');
+
+				await lifecycleHooks.runHook('workflowExecuteAfter', [successfulRun, {}]);
+
+				expect(executionRepository.softDelete).toHaveBeenCalledWith(executionId);
+			});
+
+			it('should update execution when saving is enabled', async () => {
+				workflowData.settings = {
+					saveDataSuccessExecution: 'all',
+					saveDataErrorExecution: 'all',
+				};
+				const lifecycleHooks = createHooks('webhook');
+
+				await lifecycleHooks.runHook('workflowExecuteAfter', [successfulRun, {}]);
+
+				expect(executionRepository.updateExistingExecution).toHaveBeenCalledWith(
+					executionId,
+					expect.objectContaining({
+						finished: true,
+						status: 'success',
+					}),
+				);
+				expect(executionRepository.hardDelete).not.toHaveBeenCalled();
+			});
+		});
 	});
 
 	describe('getLifecycleHooksForSubExecutions', () => {
@@ -841,6 +902,251 @@ describe('Execution Lifecycle Hooks', () => {
 			expect(handlers.nodeFetchedData).toHaveLength(1);
 			expect(handlers.sendResponse).toHaveLength(0);
 			expect(handlers.sendChunk).toHaveLength(0);
+		});
+	});
+
+	describe('handleExecutionSaveDecision', () => {
+		const createContext = (mode: WorkflowExecuteMode = 'manual') => ({
+			executionId,
+			workflowId,
+			mode,
+			workflowData,
+		});
+
+		const createSaveSettings = (overrides = {}) => ({
+			manual: true,
+			success: true,
+			error: true,
+			progress: false,
+			...overrides,
+		});
+
+		beforeEach(() => {
+			jest.clearAllMocks();
+		});
+
+		describe('manual executions', () => {
+			it('should soft delete manual executions when manual saving is disabled', async () => {
+				const saveSettings = createSaveSettings({ manual: false });
+				const context = createContext('manual');
+
+				const result = await handleExecutionSaveDecision(
+					successfulRun,
+					saveSettings,
+					context,
+					retryOf,
+				);
+
+				expect(result).toBe(false);
+				expect(executionRepository.softDelete).toHaveBeenCalledWith(executionId);
+			});
+
+			it('should not soft delete manual executions with waitTill', async () => {
+				const saveSettings = createSaveSettings({ manual: false });
+				const context = createContext('manual');
+
+				const result = await handleExecutionSaveDecision(
+					waitingRun,
+					saveSettings,
+					context,
+					retryOf,
+				);
+
+				expect(result).toBe(true);
+				expect(executionRepository.softDelete).not.toHaveBeenCalled();
+			});
+
+			it('should save manual executions when manual saving is enabled', async () => {
+				const saveSettings = createSaveSettings({ manual: true });
+				const context = createContext('manual');
+
+				const result = await handleExecutionSaveDecision(
+					successfulRun,
+					saveSettings,
+					context,
+					retryOf,
+				);
+
+				expect(result).toBe(true);
+				expect(executionRepository.softDelete).not.toHaveBeenCalled();
+				expect(executionRepository.hardDelete).not.toHaveBeenCalled();
+			});
+		});
+
+		describe('successful executions', () => {
+			it('should hard delete successful executions when success saving is disabled', async () => {
+				const saveSettings = createSaveSettings({ success: false });
+				const context = createContext('webhook');
+
+				const result = await handleExecutionSaveDecision(
+					successfulRun,
+					saveSettings,
+					context,
+					retryOf,
+				);
+
+				expect(result).toBe(false);
+				expect(executionRepository.hardDelete).toHaveBeenCalledWith({
+					workflowId,
+					executionId,
+				});
+			});
+
+			it('should save successful executions when success saving is enabled', async () => {
+				const saveSettings = createSaveSettings({ success: true });
+				const context = createContext('webhook');
+
+				const result = await handleExecutionSaveDecision(
+					successfulRun,
+					saveSettings,
+					context,
+					retryOf,
+				);
+
+				expect(result).toBe(true);
+				expect(executionRepository.hardDelete).not.toHaveBeenCalled();
+			});
+
+			it('should not hard delete successful executions with waitTill even when success saving is disabled', async () => {
+				const saveSettings = createSaveSettings({ success: false });
+				const context = createContext('webhook');
+				const waitingSuccessfulRun = mock<IRun>({
+					status: 'success',
+					finished: true,
+					waitTill: new Date(),
+				});
+
+				const result = await handleExecutionSaveDecision(
+					waitingSuccessfulRun,
+					saveSettings,
+					context,
+					retryOf,
+				);
+
+				expect(result).toBe(true);
+				expect(executionRepository.hardDelete).not.toHaveBeenCalled();
+			});
+		});
+
+		describe('failed executions', () => {
+			it('should hard delete failed executions when error saving is disabled', async () => {
+				const saveSettings = createSaveSettings({ error: false });
+				const context = createContext('webhook');
+
+				const result = await handleExecutionSaveDecision(failedRun, saveSettings, context, retryOf);
+
+				expect(result).toBe(false);
+				expect(executionRepository.hardDelete).toHaveBeenCalledWith({
+					workflowId,
+					executionId,
+				});
+			});
+
+			it('should save failed executions when error saving is enabled', async () => {
+				const saveSettings = createSaveSettings({ error: true });
+				const context = createContext('webhook');
+
+				const result = await handleExecutionSaveDecision(failedRun, saveSettings, context, retryOf);
+
+				expect(result).toBe(true);
+				expect(executionRepository.hardDelete).not.toHaveBeenCalled();
+			});
+
+			it('should not hard delete failed executions with waitTill even when error saving is disabled', async () => {
+				const saveSettings = createSaveSettings({ error: false });
+				const context = createContext('webhook');
+				const waitingFailedRun = mock<IRun>({
+					status: 'error',
+					finished: true,
+					waitTill: new Date(),
+				});
+
+				const result = await handleExecutionSaveDecision(
+					waitingFailedRun,
+					saveSettings,
+					context,
+					retryOf,
+				);
+
+				expect(result).toBe(true);
+				expect(executionRepository.hardDelete).not.toHaveBeenCalled();
+			});
+		});
+
+		describe('manual mode precedence', () => {
+			it('should prioritize manual mode logic over success/error settings for manual executions', async () => {
+				const saveSettings = createSaveSettings({ manual: false, success: true, error: true });
+				const context = createContext('manual');
+
+				const result = await handleExecutionSaveDecision(
+					successfulRun,
+					saveSettings,
+					context,
+					retryOf,
+				);
+
+				expect(result).toBe(false);
+				expect(executionRepository.softDelete).toHaveBeenCalledWith(executionId);
+				expect(executionRepository.hardDelete).not.toHaveBeenCalled();
+			});
+		});
+
+		describe('edge cases', () => {
+			it('should handle unknown execution status as error case', async () => {
+				const saveSettings = createSaveSettings({ error: false });
+				const context = createContext('webhook');
+				const unknownStatusRun = mock<IRun>({
+					status: 'unknown',
+					finished: true,
+					waitTill: undefined,
+					data: {
+						resultData: {
+							runData: {},
+						},
+					},
+				});
+
+				const result = await handleExecutionSaveDecision(
+					unknownStatusRun,
+					saveSettings,
+					context,
+					retryOf,
+				);
+
+				expect(result).toBe(false);
+				expect(executionRepository.hardDelete).toHaveBeenCalledWith({
+					workflowId,
+					executionId,
+				});
+			});
+
+			it('should handle null waitTill as undefined', async () => {
+				const saveSettings = createSaveSettings({ success: false });
+				const context = createContext('webhook');
+				const runWithNullWaitTill = mock<IRun>({
+					status: 'success',
+					finished: true,
+					waitTill: null,
+					data: {
+						resultData: {
+							runData: {},
+						},
+					},
+				});
+
+				const result = await handleExecutionSaveDecision(
+					runWithNullWaitTill,
+					saveSettings,
+					context,
+					retryOf,
+				);
+
+				expect(result).toBe(false);
+				expect(executionRepository.hardDelete).toHaveBeenCalledWith({
+					workflowId,
+					executionId,
+				});
+			});
 		});
 	});
 });

--- a/packages/testing/containers/n8n-test-container-creation.ts
+++ b/packages/testing/containers/n8n-test-container-creation.ts
@@ -26,7 +26,7 @@ import {
 	setupProxyServer,
 	setupTaskRunner,
 } from './n8n-test-container-dependencies';
-import { createSilentLogConsumer } from './n8n-test-container-utils';
+import { createSilentLogConsumer, getResourceQuotaFromEnv } from './n8n-test-container-utils';
 
 // --- Constants ---
 
@@ -120,7 +120,7 @@ export async function createN8NStack(config: N8NConfig = {}): Promise<N8NStack> 
 		env = {},
 		proxyServerEnabled = false,
 		projectName,
-		resourceQuota,
+		resourceQuota = getResourceQuotaFromEnv(),
 		taskRunner = false,
 	} = config;
 	const queueConfig = normalizeQueueConfig(queueMode);

--- a/packages/testing/containers/n8n-test-container-utils.ts
+++ b/packages/testing/containers/n8n-test-container-utils.ts
@@ -24,3 +24,28 @@ export function createSilentLogConsumer() {
 
 	return { consumer, throwWithLogs };
 }
+
+/**
+ * Parse resource quota from environment variables
+ * Returns undefined if no limits are set
+ */
+export function getResourceQuotaFromEnv(): { memory?: number; cpu?: number } | undefined {
+	const memoryLimit = process.env.N8N_MEMORY_LIMIT;
+	const cpuLimit = process.env.N8N_CPU_LIMIT;
+
+	if (!memoryLimit && !cpuLimit) {
+		return undefined;
+	}
+
+	const quota: { memory?: number; cpu?: number } = {};
+
+	if (memoryLimit) {
+		quota.memory = parseFloat(memoryLimit);
+	}
+
+	if (cpuLimit) {
+		quota.cpu = parseFloat(cpuLimit);
+	}
+
+	return quota;
+}

--- a/packages/testing/playwright/playwright-projects.ts
+++ b/packages/testing/playwright/playwright-projects.ts
@@ -21,16 +21,7 @@ const SERIAL_EXECUTION = /@db:reset/;
 const CONTAINER_CONFIGS: Array<{ name: string; config: N8NConfig }> = [
 	{ name: 'standard', config: { proxyServerEnabled: true, taskRunner: true } },
 	{ name: 'postgres', config: { postgres: true } },
-	{
-		name: 'queue',
-		config: {
-			queueMode: true,
-			resourceQuota: {
-				memory: 0.5, // 500MB (very constrained)
-				cpu: 0.5, // Half a CPU core
-			},
-		},
-	},
+	{ name: 'queue', config: { queueMode: true } },
 	{ name: 'multi-main', config: { queueMode: { mains: 2, workers: 1 } } },
 ];
 

--- a/packages/testing/playwright/playwright-projects.ts
+++ b/packages/testing/playwright/playwright-projects.ts
@@ -21,7 +21,16 @@ const SERIAL_EXECUTION = /@db:reset/;
 const CONTAINER_CONFIGS: Array<{ name: string; config: N8NConfig }> = [
 	{ name: 'standard', config: { proxyServerEnabled: true, taskRunner: true } },
 	{ name: 'postgres', config: { postgres: true } },
-	{ name: 'queue', config: { queueMode: true } },
+	{
+		name: 'queue',
+		config: {
+			queueMode: true,
+			resourceQuota: {
+				memory: 0.5, // 500MB (very constrained)
+				cpu: 0.5, // Half a CPU core
+			},
+		},
+	},
 	{ name: 'multi-main', config: { queueMode: { mains: 2, workers: 1 } } },
 ];
 

--- a/packages/testing/playwright/tests/ui/webhook-external-trigger.spec.ts
+++ b/packages/testing/playwright/tests/ui/webhook-external-trigger.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from '../../fixtures/base';
 
 test.describe('External Webhook Triggering', () => {
+	// Marked as serial to avoid race conditions with importing workflows and ID's being returned
+	test.describe.configure({ mode: 'serial' });
 	test('should create workflow via API, activate it, trigger webhook externally, and verify execution', async ({
 		api,
 	}) => {
@@ -21,5 +23,127 @@ test.describe('External Webhook Triggering', () => {
 
 		const executionDetails = await api.workflowApi.getExecution(execution.id);
 		expect(executionDetails.data).toContain('Hello from Playwright test');
+	});
+
+	test('should save successful webhook executions when workflow configured to save (default behavior)', async ({
+		api,
+	}) => {
+		const { webhookPath, workflowId, createdWorkflow } = await api.workflowApi.importWorkflow(
+			'simple-webhook-test.json',
+		);
+
+		const testPayload = { message: 'Test execution saving - should save' };
+
+		const webhookResponse = await api.request.post(`/webhook/${webhookPath}`, {
+			data: testPayload,
+		});
+		expect(webhookResponse.ok()).toBe(true);
+
+		const execution = await api.workflowApi.waitForExecution(workflowId, 5000);
+		expect(execution.status).toBe('success');
+
+		const allExecutions = await api.workflowApi.getExecutions();
+		const filteredExecutions = allExecutions.filter(
+			(exec) => exec.workflowName === createdWorkflow.name,
+		);
+		expect(filteredExecutions).toHaveLength(1);
+		expect(filteredExecutions[0].status).toBe('success');
+		expect(filteredExecutions[0].workflowId).toBe(workflowId);
+	});
+
+	test('should not save successful webhook executions when workflow configured not to save', async ({
+		api,
+	}) => {
+		const { webhookPath, createdWorkflow } = await api.workflowApi.importWorkflow(
+			'webhook-no-save-executions.json',
+		);
+
+		const testPayload = { message: 'Test execution saving - should not save' };
+
+		const webhookResponse = await api.request.post(`/webhook/${webhookPath}`, {
+			data: testPayload,
+		});
+		expect(webhookResponse.ok()).toBe(true);
+		await new Promise((resolve) => setTimeout(resolve, 2000));
+
+		const allExecutions = await api.workflowApi.getExecutions();
+
+		const filteredExecutions = allExecutions.filter(
+			(exec) => exec.workflowName === createdWorkflow.name,
+		);
+
+		expect(filteredExecutions).toHaveLength(0);
+	});
+
+	test('should not save executions under concurrent load when workflow configured not to save @capability:queue', async ({
+		api,
+	}) => {
+		const { webhookPath, createdWorkflow } = await api.workflowApi.importWorkflow(
+			'webhook-no-save-executions.json',
+		);
+
+		const concurrentRequests = 100;
+		const testPayload = { message: 'Concurrent load test - should not save' };
+
+		// Fire multiple webhook requests concurrently to create race conditions
+		const requests = Array.from({ length: concurrentRequests }, (_, i) =>
+			api.request.post(`/webhook/${webhookPath}`, {
+				data: { ...testPayload, requestId: i },
+			}),
+		);
+
+		const responses = await Promise.all(requests);
+
+		for (const response of responses) {
+			expect(response.ok()).toBe(true);
+		}
+
+		await new Promise((resolve) => setTimeout(resolve, 20000));
+
+		const allExecutions = await api.workflowApi.getExecutions();
+		const filteredExecutions = allExecutions.filter(
+			(exec) => exec.workflowName === createdWorkflow.name,
+		);
+
+		// Critical: Even under concurrent load, NO executions should be saved
+		// This test specifically targets the PAY-3823 race condition bug
+		expect(filteredExecutions).toHaveLength(0);
+	});
+
+	test('should save all executions under concurrent load when workflow configured to save @capability:queue', async ({
+		api,
+	}) => {
+		const { webhookPath, createdWorkflow } = await api.workflowApi.importWorkflow(
+			'simple-webhook-test.json',
+		);
+
+		const concurrentRequests = 20;
+		const testPayload = { message: 'Concurrent load test - should save all' };
+
+		// Fire multiple webhook requests concurrently
+		const requests = Array.from({ length: concurrentRequests }, (_, i) =>
+			api.request.post(`/webhook/${webhookPath}`, {
+				data: { ...testPayload, requestId: i },
+			}),
+		);
+
+		const responses = await Promise.all(requests);
+
+		for (const response of responses) {
+			expect(response.ok()).toBe(true);
+		}
+
+		await new Promise((resolve) => setTimeout(resolve, 5000));
+
+		const allExecutions = await api.workflowApi.getExecutions();
+		const filteredExecutions = allExecutions.filter(
+			(exec) => exec.workflowName === createdWorkflow.name,
+		);
+
+		expect(filteredExecutions).toHaveLength(concurrentRequests);
+
+		for (const execution of filteredExecutions) {
+			expect(execution.status).toBe('success');
+		}
 	});
 });

--- a/packages/testing/playwright/workflows/webhook-no-save-executions.json
+++ b/packages/testing/playwright/workflows/webhook-no-save-executions.json
@@ -1,0 +1,68 @@
+{
+	"name": "Webhook Test - No Save Executions",
+	"active": true,
+	"nodes": [
+		{
+			"parameters": {
+				"httpMethod": "POST",
+				"path": "test-webhook-no-save",
+				"options": {}
+			},
+			"id": "webhook-trigger-no-save",
+			"name": "Webhook",
+			"type": "n8n-nodes-base.webhook",
+			"typeVersion": 1,
+			"position": [300, 300],
+			"webhookId": "test-webhook-no-save-id"
+		},
+		{
+			"parameters": {
+				"assignments": {
+					"assignments": [
+						{
+							"id": "result-field",
+							"name": "result",
+							"value": "=Webhook received: {{ $json.body }}",
+							"type": "string"
+						},
+						{
+							"id": "timestamp-field",
+							"name": "timestamp",
+							"value": "={{ new Date().toISOString() }}",
+							"type": "string"
+						}
+					]
+				},
+				"options": {}
+			},
+			"id": "set-response-no-save",
+			"name": "Set Response",
+			"type": "n8n-nodes-base.set",
+			"typeVersion": 3.3,
+			"position": [500, 300]
+		}
+	],
+	"connections": {
+		"Webhook": {
+			"main": [
+				[
+					{
+						"node": "Set Response",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"settings": {
+		"executionOrder": "v1",
+		"saveDataSuccessExecution": "none"
+	},
+	"staticData": null,
+	"meta": null,
+	"pinData": {},
+	"versionId": null,
+	"triggerCount": 0,
+	"tags": []
+}


### PR DESCRIPTION
## Summary

Add workflow saving logic to Workers to avoid issue where workers were saving executions under heavy load.

Added unit tests
Added e2e test

Added resource limits to containers to allow for testing:

N8N_MEMORY_LIMIT=0.5 N8N_CPU_LIMIT=0.5 pnpm --filter n8n-playwright test:container:queue --grep "External Webhook Triggering"

When run against older version this should fail consistently.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1437/bug-exec-view-saving-prod-execs-when-settings-say-it-shouldnt#comment-3ccee865

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
