### PR TITLE
ci: Add GitHub action to release @n8n/node-cli

### DIFF
--- a/.github/workflows/release-node-cli.yml
+++ b/.github/workflows/release-node-cli.yml
@@ -1,0 +1,44 @@
+name: 'Release: Node CLI Tools'
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'packages/@n8n/node-cli/package.json'
+      - 'packages/@n8n/create-node/package.json'
+  workflow_dispatch:
+
+concurrency:
+  group: release-node-cli
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    timeout-minutes: 15
+    permissions:
+      id-token: write
+    env:
+      NPM_CONFIG_PROVENANCE: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-nodejs-blacksmith
+        with:
+          build-command: 'pnpm --filter "@n8n/node-cli" --filter "@n8n/create-node" build'
+
+      - name: Pre publishing changes
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+          node .github/scripts/ensure-provenance-fields.mjs
+
+      - name: Publish packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: pnpm --filter "@n8n/node-cli" --filter "@n8n/create-node" publish --access public --no-git-checks --publish-branch master

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -81,7 +81,9 @@ jobs:
           key: ${{ env.BUILD_CACHE_KEY }}
 
       - name: Dry-run publishing
-        run: pnpm publish -r --no-git-checks --dry-run
+        run: |
+          pnpm --filter n8n publish --no-git-checks --dry-run
+          pnpm publish -r --filter '!n8n' --no-git-checks --dry-run
 
       - name: Pre publishing changes
         run: |
@@ -91,8 +93,11 @@ jobs:
           cp README.md packages/cli/README.md
           sed -i "s/default: 'dev'/default: 'stable'/g" packages/cli/dist/config/schema.js
 
-      - name: Publish to NPM
-        run: pnpm publish -r --publish-branch ${{github.event.pull_request.base.ref}} --access public --tag rc --no-git-checks
+      - name: Publish n8n to NPM with rc tag
+        run: pnpm --filter n8n publish --publish-branch ${{github.event.pull_request.base.ref}} --access public --tag rc --no-git-checks
+
+      - name: Publish other packages to NPM with latest tag
+        run: pnpm publish -r --filter '!n8n' --publish-branch ${{github.event.pull_request.base.ref}} --access public --no-git-checks
 
       - name: Cleanup rc tag
         run: npm dist-tag rm n8n rc


### PR DESCRIPTION
## Summary

- Add workflow to release `@n8n/node-cli` and `@n8n/create-node`
  - Trigger for:
    - Any push on master that changes their `package.json`
    - Manual `workflow_dispatch`
  - pnpm publish will skip packages where the version is already published
- Only publish the main `n8n` package as `rc` as part of the release flow, publish others as latest
  - except for the main `n8n` package, `rc` tagged releases are currently never set as latest
     example: https://www.npmjs.com/package/n8n-editor-ui?activeTab=versions

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3646/add-github-action-to-release-node-cli-packages

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
