### PR TITLE
perf(editor): Optimize usersById updates in user store

### DIFF
--- a/packages/frontend/editor-ui/src/stores/users.store.ts
+++ b/packages/frontend/editor-ui/src/stores/users.store.ts
@@ -8,18 +8,18 @@ import {
 	ROLE,
 	type UsersListFilterDto,
 } from '@n8n/api-types';
-import type { UpdateGlobalRolePayload } from '@n8n/rest-api-client/api/users';
+import type {
+	UpdateGlobalRolePayload,
+	IUserResponse,
+	IUser,
+	CurrentUserResponse,
+	IPersonalizationLatestVersion,
+} from '@n8n/rest-api-client/api/users';
 import * as usersApi from '@n8n/rest-api-client/api/users';
 import { BROWSER_ID_STORAGE_KEY } from '@n8n/constants';
 import { PERSONALIZATION_MODAL_KEY } from '@/constants';
 import { STORES } from '@n8n/stores';
 import type { InvitableRoleName } from '@/Interface';
-import type { IUserResponse } from '@n8n/rest-api-client/api/users';
-import type {
-	IUser,
-	CurrentUserResponse,
-	IPersonalizationLatestVersion,
-} from '@n8n/rest-api-client/api/users';
 import { getPersonalizedNodeTypes } from '@/utils/userUtils';
 import { defineStore } from 'pinia';
 import { useRootStore } from '@n8n/stores/useRootStore';
@@ -122,7 +122,7 @@ export const useUsersStore = defineStore(STORES.USERS, () => {
 	// Methods
 
 	const addUsers = (newUsers: User[]) => {
-		newUsers.forEach((userResponse) => {
+		for (const userResponse of newUsers) {
 			const prevUser = usersById.value[userResponse.id] || {};
 			const updatedUser = {
 				...prevUser,
@@ -137,11 +137,8 @@ export const useUsersStore = defineStore(STORES.USERS, () => {
 				isPendingUser: _isPendingUser(updatedUser),
 			};
 
-			usersById.value = {
-				...usersById.value,
-				[user.id]: user,
-			};
-		});
+			usersById.value[user.id] = user;
+		}
 	};
 
 	const setCurrentUser = (user: CurrentUserResponse) => {


### PR DESCRIPTION
## Summary

- Replaced forEach with a for...of loop in addUsers, making the performance more predictable.
- Simplified usersById updates by directly assigning usersById.value[user.id] = user instead of recreating the object with the spread operator to mitigate copying the object.

## Related Linear tickets, Github issues, and Community forum posts

-

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [X] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
