### PR TITLE
fix(editor): Canvas connections show `X items total` label when multiple run iterations

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -1197,6 +1197,7 @@
 	"ndv.output.branch": "Branch",
 	"ndv.output.executing": "Executing node...",
 	"ndv.output.items": "{count} item | {count} items",
+	"ndv.output.itemsTotal": "{count} item total | {count} items total",
 	"ndv.output.andSubExecutions": ", {count} sub-execution | , {count} sub-executions",
 	"ndv.output.noOutputData.message": "n8n stops executing the workflow when a node has no output data. You can change this default behaviour via",
 	"ndv.output.noOutputData.message.settings": "Settings",

--- a/packages/frontend/editor-ui/src/composables/useCanvasMapping.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasMapping.ts
@@ -754,12 +754,18 @@ export function useCanvasMapping({
 			const { type, index } = parseCanvasConnectionHandleString(connection.sourceHandle);
 			const runDataTotal =
 				nodeExecutionRunDataOutputMapById.value[fromNode.id]?.[type]?.[index]?.total ?? 0;
+			const hasMultipleRunDataIterations =
+				(nodeExecutionRunDataOutputMapById.value[fromNode.id]?.[type]?.[index]?.iterations ?? 1) >
+				1;
 
 			return runDataTotal > 0
-				? i18n.baseText('ndv.output.items', {
-						adjustToNumber: runDataTotal,
-						interpolate: { count: String(runDataTotal) },
-					})
+				? i18n.baseText(
+						hasMultipleRunDataIterations ? 'ndv.output.itemsTotal' : 'ndv.output.items',
+						{
+							adjustToNumber: runDataTotal,
+							interpolate: { count: String(runDataTotal) },
+						},
+					)
 				: '';
 		}
 


### PR DESCRIPTION
## Summary

This pull request updates the way item counts are displayed on the canvas.

<img width="1240" height="782" alt="image" src="https://github.com/user-attachments/assets/7dd850d7-3b15-43e5-ab5a-218ed4f1449b" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1442/canvas-connections-should-say-x-items-total-if-multiple-iterations


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
