### PR TITLE
Fix node panel navigation and selection

### DIFF
--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/Panel/NodesListPanel.vue
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/Panel/NodesListPanel.vue
@@ -33,7 +33,8 @@ const { callDebounced } = useDebounce();
 
 const { mergedNodes } = useNodeCreatorStore();
 const { pushViewStack, popViewStack, updateCurrentViewStack } = useViewStacks();
-const { setActiveItemIndex, attachKeydownEvent, detachKeydownEvent } = useKeyboardNavigation();
+const { activeItemId, setActiveItemIndex, attachKeydownEvent, detachKeydownEvent } =
+	useKeyboardNavigation();
 const nodeCreatorStore = useNodeCreatorStore();
 
 const { isInstanceOwner } = useUsersStore();
@@ -152,6 +153,17 @@ watch(
 		});
 	},
 	{ immediate: true },
+);
+
+// Ensure active item is initialized once items are rendered (e.g. when opening via NDV + flows)
+watch(
+	() => activeViewStack.value.items,
+	(items) => {
+		if (!activeItemId || !('value' in activeItemId)) return;
+		if (!activeItemId.value && (items?.length ?? 0) > 0) {
+			void setActiveItemIndex(getDefaultActiveIndex(activeViewStack.value.search ?? ''));
+		}
+	},
 );
 
 function onBackButton() {

--- a/packages/testing/playwright/tests/ui/30-langchain.spec.ts
+++ b/packages/testing/playwright/tests/ui/30-langchain.spec.ts
@@ -550,3 +550,32 @@ test.describe('Langchain Integration @capability:proxy', () => {
 		await expect(n8n.canvas.getManualChatMessages()).not.toBeAttached();
 	});
 });
+
+test('Nodes panel navigation works from global plus and NDV AI sub-connection', async ({ n8n }) => {
+	await n8n.canvas.openNewWorkflow();
+
+	// Open via global canvas plus
+	await n8n.canvas.clickNodeCreatorPlusButton();
+	const nodeCreator = n8n.page.getByTestId('node-creator');
+	await expect(nodeCreator).toBeVisible();
+
+	// Move selection with ArrowDown and verify selection marker (.active)
+	await n8n.page.keyboard.press('ArrowDown');
+	await expect(n8n.page.locator('[data-test-id="item-iterator-item"].active').first()).toBeVisible();
+
+	// Close node creator
+	await n8n.page.keyboard.press('Escape');
+	await expect(nodeCreator).toBeHidden();
+
+	// Add Agent node to open AI sub-connection + and then open node creator from it
+	await n8n.canvas.addNode(AGENT_NODE_NAME, { closeNDV: false });
+    // Click the plus to open the node creator but don't select an item
+    await n8n.ndv.getAddSubNodeButton('ai_languageModel', 0).click();
+	await expect(nodeCreator).toBeVisible();
+
+	// Arrow navigation should work and active marker should be visible
+	await n8n.page.keyboard.press('ArrowDown');
+	await expect(n8n.page.locator('[data-test-id="item-iterator-item"].active').first()).toBeVisible();
+	await n8n.page.keyboard.press('ArrowUp');
+	await expect(n8n.page.locator('[data-test-id="item-iterator-item"].active').first()).toBeVisible();
+});


### PR DESCRIPTION
## Summary

This PR restores keyboard up/down arrow navigation and the visible selection marker in the node creator panel. Previously, these features were broken when the panel was opened via an Agent's "Chat Model" + button (especially when "pre-built agents" were present), due to the initial active item not being set correctly on render.

The fix ensures consistent navigation and visual feedback across all entry points to the node creator.

**To test:**
1.  Open a workflow containing an Agent node.
2.  Click the global '+' button on the canvas to open the node creator. Use `ArrowDown`/`ArrowUp` keys and observe the selection marker.
3.  Close the node creator.
4.  Click the Agent node's 'Chat Model' '+' button to open the node creator. Use `ArrowDown`/`ArrowUp` keys and observe the selection marker.
5.  Confirm that keyboard navigation and the selection marker work consistently in both scenarios.

## Related Linear tickets, Github issues, and Community forum posts

<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

---
<a href="https://cursor.com/background-agent?bcId=bc-c44915a8-e003-42ae-ab2f-dbf92c5cfd54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c44915a8-e003-42ae-ab2f-dbf92c5cfd54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

