### PR TITLE
chore: Add NODE_ENV to debug info

### DIFF
--- a/packages/@n8n/api-types/src/frontend-settings.ts
+++ b/packages/@n8n/api-types/src/frontend-settings.ts
@@ -59,6 +59,7 @@ export interface FrontendSettings {
 	urlBaseEditor: string;
 	versionCli: string;
 	nodeJsVersion: string;
+	nodeEnv: string | undefined;
 	concurrency: number;
 	isNativePythonRunnerEnabled: boolean;
 	authCookie: {

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -129,6 +129,7 @@ export class FrontendService {
 			urlBaseEditor: instanceBaseUrl,
 			binaryDataMode: this.binaryDataConfig.mode,
 			nodeJsVersion: process.version.replace(/^v/, ''),
+			nodeEnv: process.env.NODE_ENV,
 			versionCli: N8N_VERSION,
 			concurrency: this.globalConfig.executions.concurrency.productionLimit,
 			isNativePythonRunnerEnabled:

--- a/packages/frontend/editor-ui/src/__tests__/defaults.ts
+++ b/packages/frontend/editor-ui/src/__tests__/defaults.ts
@@ -101,6 +101,7 @@ export const defaultSettings: FrontendSettings = {
 	},
 	versionCli: '',
 	nodeJsVersion: '',
+	nodeEnv: '',
 	concurrency: -1,
 	isNativePythonRunnerEnabled: false,
 	versionNotifications: {

--- a/packages/frontend/editor-ui/src/composables/__snapshots__/useDebugInfo.test.ts.snap
+++ b/packages/frontend/editor-ui/src/composables/__snapshots__/useDebugInfo.test.ts.snap
@@ -8,6 +8,7 @@ exports[`useDebugInfo > should generate debug info 1`] = `
 - n8nVersion: 0.123.0
 - platform: docker (cloud)
 - nodeJsVersion: 14.17.0
+- nodeEnv: production
 - database: postgres
 - executionMode: regular
 - concurrency: 10

--- a/packages/frontend/editor-ui/src/composables/useDebugInfo.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useDebugInfo.test.ts
@@ -14,6 +14,7 @@ const MOCK_BASE_SETTINGS: RecursivePartial<ReturnType<typeof useSettingsStoreTyp
 	isDocker: true,
 	deploymentType: 'cloud',
 	nodeJsVersion: '14.17.0',
+	nodeEnv: 'production',
 	databaseType: 'postgresdb',
 	isQueueModeEnabled: false,
 	settings: {

--- a/packages/frontend/editor-ui/src/composables/useDebugInfo.ts
+++ b/packages/frontend/editor-ui/src/composables/useDebugInfo.ts
@@ -8,6 +8,7 @@ type DebugInfo = {
 		n8nVersion: string;
 		platform: 'docker (cloud)' | 'docker (self-hosted)' | 'npm';
 		nodeJsVersion: string;
+		nodeEnv: string | undefined;
 		database: 'sqlite' | 'mysql' | 'mariadb' | 'postgres';
 		executionMode: 'regular' | 'scaling (single-main)' | 'scaling (multi-main)';
 		license: 'community' | 'enterprise (production)' | 'enterprise (sandbox)';
@@ -58,6 +59,7 @@ export function useDebugInfo() {
 						? 'docker (self-hosted)'
 						: 'npm',
 			nodeJsVersion: settingsStore.nodeJsVersion,
+			nodeEnv: settingsStore.nodeEnv,
 			database:
 				settingsStore.databaseType === 'postgresdb'
 					? 'postgres'

--- a/packages/frontend/editor-ui/src/stores/settings.store.ts
+++ b/packages/frontend/editor-ui/src/stores/settings.store.ts
@@ -68,6 +68,8 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 
 	const nodeJsVersion = computed(() => settings.value.nodeJsVersion);
 
+	const nodeEnv = computed(() => settings.value.nodeEnv);
+
 	const concurrency = computed(() => settings.value.concurrency);
 
 	const isNativePythonRunnerEnabled = computed(() => settings.value.isNativePythonRunnerEnabled);
@@ -331,6 +333,7 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 		pruning,
 		security,
 		nodeJsVersion,
+		nodeEnv,
 		concurrency,
 		isNativePythonRunnerEnabled,
 		isConcurrencyEnabled,


### PR DESCRIPTION
## Summary

To help with debugging, this adds the `NODE_ENV` variable to the FE settings so it can be added to the debug info if it's set.

## Related Linear tickets, Github issues, and Community forum posts

Related: PAY-3827

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- ~[ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- ~[ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
