### PR TITLE
fix(core): Update data table delete row endpoint to accept filter as string (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/dto/data-store/delete-data-table-rows.dto.ts
+++ b/packages/@n8n/api-types/src/dto/data-store/delete-data-table-rows.dto.ts
@@ -4,34 +4,47 @@ import { Z } from 'zod-class';
 
 import { dataTableFilterSchema } from '../../schemas/data-table-filter.schema';
 
-const dataTableFilterQueryValidator = z
-	.string()
-	.optional()
-	.transform((val, ctx) => {
-		if (!val) return undefined;
+const dataTableFilterQueryValidator = z.string().transform((val, ctx) => {
+	if (!val) {
+		ctx.addIssue({
+			code: z.ZodIssueCode.custom,
+			message: 'Filter is required for delete operations',
+			path: ['filter'],
+		});
+		return z.NEVER;
+	}
+	try {
+		const parsed: unknown = jsonParse(val);
 		try {
-			const parsed: unknown = jsonParse(val);
-			try {
-				// Parse with the schema which applies defaults
-				const result = dataTableFilterSchema.parse(parsed);
-				return result;
-			} catch (e) {
+			// Parse with the schema which applies defaults
+			const result = dataTableFilterSchema.parse(parsed);
+			// Ensure filters array is not empty
+			if (!result.filters || result.filters.length === 0) {
 				ctx.addIssue({
 					code: z.ZodIssueCode.custom,
-					message: 'Invalid filter fields',
+					message: 'At least one filter condition is required for delete operations',
 					path: ['filter'],
 				});
 				return z.NEVER;
 			}
+			return result;
 		} catch (e) {
 			ctx.addIssue({
 				code: z.ZodIssueCode.custom,
-				message: 'Invalid filter format',
+				message: 'Invalid filter fields',
 				path: ['filter'],
 			});
 			return z.NEVER;
 		}
-	});
+	} catch (e) {
+		ctx.addIssue({
+			code: z.ZodIssueCode.custom,
+			message: 'Invalid filter format',
+			path: ['filter'],
+		});
+		return z.NEVER;
+	}
+});
 
 const returnDataValidator = z
 	.union([z.string(), z.boolean()])

--- a/packages/@n8n/api-types/src/dto/data-store/delete-data-table-rows.dto.ts
+++ b/packages/@n8n/api-types/src/dto/data-store/delete-data-table-rows.dto.ts
@@ -1,11 +1,51 @@
+import { jsonParse } from 'n8n-workflow';
 import { z } from 'zod';
 import { Z } from 'zod-class';
 
 import { dataTableFilterSchema } from '../../schemas/data-table-filter.schema';
 
+const dataTableFilterQueryValidator = z
+	.string()
+	.optional()
+	.transform((val, ctx) => {
+		if (!val) return undefined;
+		try {
+			const parsed: unknown = jsonParse(val);
+			try {
+				// Parse with the schema which applies defaults
+				const result = dataTableFilterSchema.parse(parsed);
+				return result;
+			} catch (e) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					message: 'Invalid filter fields',
+					path: ['filter'],
+				});
+				return z.NEVER;
+			}
+		} catch (e) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: 'Invalid filter format',
+				path: ['filter'],
+			});
+			return z.NEVER;
+		}
+	});
+
+const returnDataValidator = z
+	.union([z.string(), z.boolean()])
+	.optional()
+	.transform((val) => {
+		if (typeof val === 'string') {
+			return val === 'true';
+		}
+		return val ?? false;
+	});
+
 const deleteDataTableRowsShape = {
-	filter: dataTableFilterSchema.optional(),
-	returnData: z.boolean().optional().default(false),
+	filter: dataTableFilterQueryValidator,
+	returnData: returnDataValidator,
 };
 
 export class DeleteDataTableRowsDto extends Z.class(deleteDataTableRowsShape) {}

--- a/packages/cli/src/modules/data-table/__tests__/data-store.controller.integration.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/data-store.controller.integration.test.ts
@@ -2609,14 +2609,14 @@ describe('DELETE /projects/:projectId/data-tables/:dataStoreId/rows', () => {
 
 		await authMemberAgent
 			.delete(`/projects/${project.id}/data-tables/${dataStore.id}/rows`)
-			.send({
-				filter: {
+			.query({
+				filter: JSON.stringify({
 					type: 'or',
 					filters: [
 						{ columnName: 'first', condition: 'eq', value: 'test value 1' },
 						{ columnName: 'first', condition: 'eq', value: 'test value 3' },
 					],
-				},
+				}),
 			})
 			.expect(200);
 
@@ -2657,11 +2657,11 @@ describe('DELETE /projects/:projectId/data-tables/:dataStoreId/rows', () => {
 
 		await authAdminAgent
 			.delete(`/projects/${project.id}/data-tables/${dataStore.id}/rows`)
-			.send({
-				filter: {
+			.query({
+				filter: JSON.stringify({
 					type: 'and',
 					filters: [{ columnName: 'first', condition: 'eq', value: 'test value 2' }],
-				},
+				}),
 			})
 			.expect(200);
 
@@ -2701,11 +2701,11 @@ describe('DELETE /projects/:projectId/data-tables/:dataStoreId/rows', () => {
 
 		await authOwnerAgent
 			.delete(`/projects/${project.id}/data-tables/${dataStore.id}/rows`)
-			.send({
-				filter: {
+			.query({
+				filter: JSON.stringify({
 					type: 'and',
 					filters: [{ columnName: 'first', condition: 'eq', value: 'test value 2' }],
-				},
+				}),
 			})
 			.expect(200);
 
@@ -2744,11 +2744,11 @@ describe('DELETE /projects/:projectId/data-tables/:dataStoreId/rows', () => {
 
 		await authMemberAgent
 			.delete(`/projects/${memberProject.id}/data-tables/${dataStore.id}/rows`)
-			.send({
-				filter: {
+			.query({
+				filter: JSON.stringify({
 					type: 'and',
 					filters: [{ columnName: 'first', condition: 'eq', value: 'test value 2' }],
-				},
+				}),
 			})
 			.expect(200);
 
@@ -2787,11 +2787,11 @@ describe('DELETE /projects/:projectId/data-tables/:dataStoreId/rows', () => {
 
 		const result = await authMemberAgent
 			.delete(`/projects/${memberProject.id}/data-tables/${dataStore.id}/rows`)
-			.send({
-				filter: {
+			.query({
+				filter: JSON.stringify({
 					type: 'and',
 					filters: [{ columnName: 'first', condition: 'eq', value: 'test value 3' }],
-				},
+				}),
 				returnData: true,
 			});
 

--- a/packages/cli/src/modules/data-table/__tests__/data-store.controller.integration.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/data-store.controller.integration.test.ts
@@ -2507,6 +2507,12 @@ describe('DELETE /projects/:projectId/data-tables/:dataStoreId/rows', () => {
 	test('should not delete rows when project does not exist', async () => {
 		await authOwnerAgent
 			.delete('/projects/non-existing-id/data-tables/some-data-store-id/rows')
+			.query({
+				filter: {
+					type: 'and',
+					filters: [{ columnName: 'first', condition: 'eq', value: 'test value' }],
+				},
+			})
 			.expect(403);
 	});
 
@@ -2515,7 +2521,51 @@ describe('DELETE /projects/:projectId/data-tables/:dataStoreId/rows', () => {
 
 		await authOwnerAgent
 			.delete(`/projects/${project.id}/data-tables/non-existing-id/rows`)
+			.query({
+				filter: JSON.stringify({
+					type: 'and',
+					filters: [{ columnName: 'first', condition: 'eq', value: 'test value' }],
+				}),
+			})
 			.expect(404);
+	});
+
+	test('should not delete rows when no filter is provided', async () => {
+		const project = await createTeamProject('test project', owner);
+		const dataStore = await createDataStore(project, {
+			columns: [
+				{
+					name: 'first',
+					type: 'string',
+				},
+			],
+		});
+
+		await authOwnerAgent
+			.delete(`/projects/${project.id}/data-tables/${dataStore.id}/rows`)
+			.expect(400);
+	});
+
+	test('should not delete rows when filter has empty filters array', async () => {
+		const project = await createTeamProject('test project', owner);
+		const dataStore = await createDataStore(project, {
+			columns: [
+				{
+					name: 'first',
+					type: 'string',
+				},
+			],
+		});
+
+		await authOwnerAgent
+			.delete(`/projects/${project.id}/data-tables/${dataStore.id}/rows`)
+			.query({
+				filter: {
+					type: 'and',
+					filters: [],
+				},
+			})
+			.expect(400);
 	});
 
 	test("should not delete rows in another user's personal project data store", async () => {
@@ -2540,6 +2590,12 @@ describe('DELETE /projects/:projectId/data-tables/:dataStoreId/rows', () => {
 
 		await authMemberAgent
 			.delete(`/projects/${ownerProject.id}/data-tables/${dataStore.id}/rows`)
+			.query({
+				filter: {
+					type: 'and',
+					filters: [{ columnName: 'first', condition: 'eq', value: 'test value' }],
+				},
+			})
 			.expect(403);
 
 		const rowsInDb = await dataStoreRowsRepository.getManyAndCount(dataStore.id, {});
@@ -2570,6 +2626,12 @@ describe('DELETE /projects/:projectId/data-tables/:dataStoreId/rows', () => {
 
 		await authMemberAgent
 			.delete(`/projects/${project.id}/data-tables/${dataStore.id}/rows`)
+			.query({
+				filter: {
+					type: 'and',
+					filters: [{ columnName: 'first', condition: 'eq', value: 'test value' }],
+				},
+			})
 			.expect(403);
 
 		const rowsInDb = await dataStoreRowsRepository.getManyAndCount(dataStore.id, {});

--- a/packages/cli/src/modules/data-table/__tests__/data-store.controller.integration.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/data-store.controller.integration.test.ts
@@ -2508,10 +2508,10 @@ describe('DELETE /projects/:projectId/data-tables/:dataStoreId/rows', () => {
 		await authOwnerAgent
 			.delete('/projects/non-existing-id/data-tables/some-data-store-id/rows')
 			.query({
-				filter: {
+				filter: JSON.stringify({
 					type: 'and',
 					filters: [{ columnName: 'first', condition: 'eq', value: 'test value' }],
-				},
+				}),
 			})
 			.expect(403);
 	});
@@ -2591,10 +2591,10 @@ describe('DELETE /projects/:projectId/data-tables/:dataStoreId/rows', () => {
 		await authMemberAgent
 			.delete(`/projects/${ownerProject.id}/data-tables/${dataStore.id}/rows`)
 			.query({
-				filter: {
+				filter: JSON.stringify({
 					type: 'and',
 					filters: [{ columnName: 'first', condition: 'eq', value: 'test value' }],
-				},
+				}),
 			})
 			.expect(403);
 
@@ -2627,10 +2627,10 @@ describe('DELETE /projects/:projectId/data-tables/:dataStoreId/rows', () => {
 		await authMemberAgent
 			.delete(`/projects/${project.id}/data-tables/${dataStore.id}/rows`)
 			.query({
-				filter: {
+				filter: JSON.stringify({
 					type: 'and',
 					filters: [{ columnName: 'first', condition: 'eq', value: 'test value' }],
-				},
+				}),
 			})
 			.expect(403);
 

--- a/packages/cli/src/modules/data-table/__tests__/data-store.service.integration.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/data-store.service.integration.test.ts
@@ -1813,7 +1813,7 @@ describe('dataStore', () => {
 			expect(count).toBe(1);
 		});
 
-		it('should delete all rows when no filter is provided', async () => {
+		it('should not delete all rows when no filter is provided', async () => {
 			// ARRANGE
 			const dataStore = await dataStoreService.createDataStore(project1.id, {
 				name: 'dataStore',
@@ -1828,13 +1828,42 @@ describe('dataStore', () => {
 			]);
 
 			// ACT
-			const result = await dataStoreService.deleteRows(dataStoreId, project1.id, {});
+			const result = dataStoreService.deleteRows(dataStoreId, project1.id, {
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				filter: undefined as any,
+			});
 
-			// ASSERT
-			expect(result).toBe(true);
+			await expect(result).rejects.toThrow(
+				new DataStoreValidationError(
+					'Filter is required for delete operations to prevent accidental deletion of all data',
+				),
+			);
+		});
 
-			const { count } = await dataStoreService.getManyRowsAndCount(dataStoreId, project1.id, {});
-			expect(count).toBe(0);
+		it('should not delete all rows when no filter is empty', async () => {
+			// ARRANGE
+			const dataStore = await dataStoreService.createDataStore(project1.id, {
+				name: 'dataStore',
+				columns: [{ name: 'name', type: 'string' }],
+			});
+			const { id: dataStoreId } = dataStore;
+
+			await dataStoreService.insertRows(dataStoreId, project1.id, [
+				{ name: 'Alice' },
+				{ name: 'Bob' },
+				{ name: 'Charlie' },
+			]);
+
+			// ACT
+			const result = dataStoreService.deleteRows(dataStoreId, project1.id, {
+				filter: { type: 'and', filters: [] },
+			});
+
+			await expect(result).rejects.toThrow(
+				new DataStoreValidationError(
+					'Filter is required for delete operations to prevent accidental deletion of all data',
+				),
+			);
 		});
 	});
 

--- a/packages/cli/src/modules/data-table/data-store.controller.ts
+++ b/packages/cli/src/modules/data-table/data-store.controller.ts
@@ -334,7 +334,7 @@ export class DataStoreController {
 		req: AuthenticatedRequest<{ projectId: string }>,
 		_res: Response,
 		@Param('dataTableId') dataTableId: string,
-		@Body dto: DeleteDataTableRowsDto,
+		@Query dto: DeleteDataTableRowsDto,
 	) {
 		try {
 			return await this.dataStoreService.deleteRows(

--- a/packages/cli/src/modules/data-table/data-store.service.ts
+++ b/packages/cli/src/modules/data-table/data-store.service.ts
@@ -288,9 +288,13 @@ export class DataStoreService {
 			);
 		}
 
-		if (dto.filter?.filters && dto.filter.filters.length !== 0) {
-			this.validateAndTransformFilters(dto.filter, columns);
+		if (!dto.filter?.filters || dto.filter.filters.length === 0) {
+			throw new DataStoreValidationError(
+				'Filter is required for delete operations to prevent accidental deletion of all data',
+			);
 		}
+
+		this.validateAndTransformFilters(dto.filter, columns);
 
 		const result = await this.dataStoreRowsRepository.deleteRows(
 			dataStoreId,

--- a/packages/nodes-base/nodes/DataTable/actions/row/delete.operation.ts
+++ b/packages/nodes-base/nodes/DataTable/actions/row/delete.operation.ts
@@ -50,6 +50,10 @@ export async function execute(
 
 	const filter = getSelectFilter(this, index);
 
+	if (filter.filters.length === 0) {
+		throw new NodeOperationError(this.getNode(), 'At least one condition is required');
+	}
+
 	if (dryRun) {
 		const { data: rowsToDelete } = await dataStoreProxy.getManyRowsAndCount({ filter });
 		return rowsToDelete.map((json) => ({ json }));

--- a/packages/workflow/src/data-store.types.ts
+++ b/packages/workflow/src/data-store.types.ts
@@ -68,7 +68,7 @@ export type UpsertDataStoreRowOptions = {
 };
 
 export type DeleteDataTableRowsOptions = {
-	filter?: DataTableFilter;
+	filter: DataTableFilter;
 };
 
 export type MoveDataStoreColumnOptions = {


### PR DESCRIPTION
## Summary

We had a problem with frontend sending filter as a stringified json and backend not accepting it and at the same time deleting all the rows thinking that no filter was provided.

- Update the delete row endpoint to accept JSON stringified filters
- Forbid providing no filters for delete rows

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4145/bug-data-table-delete-endpoint-expects-an-object

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
