### PR TITLE
feat: Enabling data tables as a default module

### DIFF
--- a/packages/@n8n/backend-common/src/modules/__tests__/module-registry.test.ts
+++ b/packages/@n8n/backend-common/src/modules/__tests__/module-registry.test.ts
@@ -15,9 +15,7 @@ beforeEach(() => {
 
 describe('eligibleModules', () => {
 	it('should consider all default modules eligible', () => {
-		// 'data-table' isn't (yet) eligible module by default
-		const expectedModules = MODULE_NAMES.filter((name) => name !== 'data-table');
-		expect(Container.get(ModuleRegistry).eligibleModules).toEqual(expectedModules);
+		expect(Container.get(ModuleRegistry).eligibleModules).toEqual(MODULE_NAMES);
 	});
 
 	it('should consider a module ineligible if it was disabled via env var', () => {
@@ -25,6 +23,7 @@ describe('eligibleModules', () => {
 		expect(Container.get(ModuleRegistry).eligibleModules).toEqual([
 			'external-secrets',
 			'community-packages',
+			'data-table',
 		]);
 	});
 

--- a/packages/@n8n/backend-common/src/modules/module-registry.ts
+++ b/packages/@n8n/backend-common/src/modules/module-registry.ts
@@ -32,6 +32,7 @@ export class ModuleRegistry {
 		'insights',
 		'external-secrets',
 		'community-packages',
+		'data-table',
 	];
 
 	private readonly activeModules: string[] = [];


### PR DESCRIPTION
## Summary

Adding data tables as a default module

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
