### PR TITLE
ci: Migrate to artifact upload/download for builds

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -8,8 +8,7 @@ on:
       - 'release/*'
 
 env:
-  BUILD_CACHE_KEY: ${{ github.sha }}-release:build
-
+  BUILD_DIST_NAME: build-dist-${{ github.sha }}
 jobs:
   build-amd64:
     runs-on: blacksmith-4vcpu-ubuntu-2204
@@ -24,11 +23,13 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup-nodejs-blacksmith
 
-      - name: Cache to GH
-        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
+          name: ${{ env.BUILD_DIST_NAME }}
           path: ./packages/**/dist
-          key: ${{ env.BUILD_CACHE_KEY }}
+          if-no-files-found: error
+          retention-days: 7
 
   build-arm64:
     runs-on: blacksmith-4vcpu-ubuntu-2204-arm
@@ -73,12 +74,11 @@ jobs:
       - name: Set release version in env
         run: echo "RELEASE=$(node -e 'console.log(require("./package.json").version)')" >> "$GITHUB_ENV"
 
-      - name: Restore build artifacts
-        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+      - name: Download build artifacts
+        uses: actions/download-artifact@65d862660abb3549b588b37db4038d3fd1a05f8a # v4.1.8
         with:
-          fail-on-cache-miss: true
-          path: ./packages/**/dist
-          key: ${{ env.BUILD_CACHE_KEY }}
+          name: ${{ env.BUILD_DIST_NAME }}
+          path: .
 
       - name: Dry-run publishing
         run: |
@@ -148,11 +148,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: Restore cached build artifacts
-        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+      - name: Download build artifacts
+        uses: actions/download-artifact@65d862660abb3549b588b37db4038d3fd1a05f8a # v4.1.8
         with:
-          path: ./packages/**/dist
-          key: ${{ env.BUILD_CACHE_KEY }}
+          name: ${{ env.BUILD_DIST_NAME }}
+          path: .
 
       - name: Create a frontend release
         uses: getsentry/action-release@e769183448303de84c5a06aaaddf9da7be26d6c7 # v1.7.0

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -94,10 +94,14 @@ jobs:
           sed -i "s/default: 'dev'/default: 'stable'/g" packages/cli/dist/config/schema.js
 
       - name: Publish n8n to NPM with rc tag
-        run: pnpm --filter n8n publish --publish-branch ${{github.event.pull_request.base.ref}} --access public --tag rc --no-git-checks
+        env:
+          PUBLISH_BRANCH: ${{ github.event.pull_request.base.ref }}
+        run: pnpm --filter n8n publish --publish-branch "$PUBLISH_BRANCH" --access public --tag rc --no-git-checks
 
       - name: Publish other packages to NPM with latest tag
-        run: pnpm publish -r --filter '!n8n' --publish-branch ${{github.event.pull_request.base.ref}} --access public --no-git-checks
+        env:
+          PUBLISH_BRANCH: ${{ github.event.pull_request.base.ref }}
+        run: pnpm publish -r --filter '!n8n' --publish-branch "$PUBLISH_BRANCH" --access public --no-git-checks
 
       - name: Cleanup rc tag
         run: npm dist-tag rm n8n rc

--- a/.github/workflows/release-standalone-package.yml
+++ b/.github/workflows/release-standalone-package.yml
@@ -99,4 +99,5 @@ jobs:
       - name: Publish package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: pnpm --filter "${{ github.event.inputs.package }}" publish --access public --no-git-checks --publish-branch master
+          PACKAGE: ${{ github.event.inputs.package }}
+        run: pnpm --filter "$PACKAGE" publish --access public --no-git-checks --publish-branch master

--- a/.github/workflows/release-standalone-package.yml
+++ b/.github/workflows/release-standalone-package.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup-nodejs-blacksmith
         with:
-          build-command: 'pnpm --filter "${{ github.event.inputs.package }}" run --if-present build'
+          build-command: 'pnpm --filter "...${{ github.event.inputs.package }}" run --if-present build'
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/release-standalone-package.yml
+++ b/.github/workflows/release-standalone-package.yml
@@ -13,7 +13,7 @@ on:
           - '@n8n/scan-community-package'
 
 env:
-  BUILD_CACHE_KEY: ${{ github.sha }}-${{ github.event.inputs.package }}-build
+  BUILD_DIST_NAME: build-dist-${{ github.sha }}
 
 concurrency:
   group: release-package-${{ github.event.inputs.package }}
@@ -48,11 +48,13 @@ jobs:
         with:
           build-command: 'pnpm --filter "${{ github.event.inputs.package }}" run --if-present build'
 
-      - name: Cache build artifacts
-        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
+          name: ${{ env.BUILD_DIST_NAME }}
           path: ./packages/**/dist
-          key: ${{ env.BUILD_CACHE_KEY }}
+          if-no-files-found: error
+          retention-days: 7
 
   publish:
     name: Publish to NPM
@@ -83,12 +85,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Restore build artifacts
-        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+      - name: Download build artifacts
+        uses: actions/download-artifact@65d862660abb3549b588b37db4038d3fd1a05f8a # v4.1.8
         with:
-          fail-on-cache-miss: true
-          path: ./packages/**/dist
-          key: ${{ env.BUILD_CACHE_KEY }}
+          name: ${{ env.BUILD_DIST_NAME }}
+          path: .
 
       - name: Pre publishing changes
         run: |

--- a/.github/workflows/release-standalone-package.yml
+++ b/.github/workflows/release-standalone-package.yml
@@ -13,7 +13,7 @@ on:
           - '@n8n/scan-community-package'
 
 env:
-  BUILD_DIST_NAME: build-dist-${{ github.sha }}
+  BUILD_DIST_NAME: ${{ github.sha }}-${{ github.event.inputs.package }}-build
 
 concurrency:
   group: release-package-${{ github.event.inputs.package }}


### PR DESCRIPTION
## Summary

Replaces the caching mechanism with artifact upload and download in the release workflows which can work across jobs/runners

Fixes inconsistencies with cache restores and simplifies the workflow logic.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
