### PR TITLE
fix(Data Table Node): Validate filters on data table id switch (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/DataTable/actions/row/delete.operation.ts
+++ b/packages/nodes-base/nodes/DataTable/actions/row/delete.operation.ts
@@ -48,7 +48,7 @@ export async function execute(
 		);
 	}
 
-	const filter = getSelectFilter(this, index);
+	const filter = await getSelectFilter(this, index);
 
 	if (filter.filters.length === 0) {
 		throw new NodeOperationError(this.getNode(), 'At least one condition is required');

--- a/packages/nodes-base/nodes/DataTable/actions/row/update.operation.ts
+++ b/packages/nodes-base/nodes/DataTable/actions/row/update.operation.ts
@@ -31,7 +31,7 @@ export async function execute(
 	const dataStoreProxy = await getDataTableProxyExecute(this, index);
 
 	const row = getAddRow(this, index);
-	const filter = getSelectFilter(this, index);
+	const filter = await getSelectFilter(this, index);
 
 	if (filter.filters.length === 0) {
 		throw new NodeOperationError(this.getNode(), 'At least one condition is required');

--- a/packages/nodes-base/nodes/DataTable/actions/row/upsert.operation.ts
+++ b/packages/nodes-base/nodes/DataTable/actions/row/upsert.operation.ts
@@ -32,7 +32,7 @@ export async function execute(
 
 	const row = getAddRow(this, index);
 
-	const filter = getSelectFilter(this, index);
+	const filter = await getSelectFilter(this, index);
 
 	if (filter.filters.length === 0) {
 		throw new NodeOperationError(this.getNode(), 'At least one condition is required');

--- a/packages/nodes-base/nodes/DataTable/common/constants.ts
+++ b/packages/nodes-base/nodes/DataTable/common/constants.ts
@@ -5,6 +5,14 @@ export const ALL_CONDITIONS = 'allConditions';
 
 export const ROWS_LIMIT_DEFAULT = 50;
 
+export const SYSTEM_COLUMNS = [
+	{ name: 'id', type: 'number' },
+	{ name: 'createdAt', type: 'date' },
+	{ name: 'updatedAt', type: 'date' },
+] as const;
+
+export const SYSTEM_COLUMN_NAMES = SYSTEM_COLUMNS.map((col) => col.name);
+
 export type FilterType = typeof ANY_CONDITION | typeof ALL_CONDITIONS;
 
 export type FieldEntry =

--- a/packages/nodes-base/nodes/DataTable/common/constants.ts
+++ b/packages/nodes-base/nodes/DataTable/common/constants.ts
@@ -5,14 +5,6 @@ export const ALL_CONDITIONS = 'allConditions';
 
 export const ROWS_LIMIT_DEFAULT = 50;
 
-export const SYSTEM_COLUMNS = [
-	{ name: 'id', type: 'number' },
-	{ name: 'createdAt', type: 'date' },
-	{ name: 'updatedAt', type: 'date' },
-] as const;
-
-export const SYSTEM_COLUMN_NAMES = SYSTEM_COLUMNS.map((col) => col.name);
-
 export type FilterType = typeof ANY_CONDITION | typeof ALL_CONDITIONS;
 
 export type FieldEntry =

--- a/packages/nodes-base/nodes/DataTable/common/methods.ts
+++ b/packages/nodes-base/nodes/DataTable/common/methods.ts
@@ -1,4 +1,5 @@
 import {
+	DATA_TABLE_SYSTEM_COLUMN_TYPE_MAP,
 	type ILoadOptionsFunctions,
 	type INodeListSearchResult,
 	type INodePropertyOptions,
@@ -6,7 +7,6 @@ import {
 	type ResourceMapperFields,
 } from 'n8n-workflow';
 
-import { SYSTEM_COLUMNS } from './constants';
 import { getDataTableAggregateProxy, getDataTableProxyLoadOptions } from './utils';
 
 // @ADO-3904: Pagination here does not work until a filter is entered or removed, suspected bug in ResourceLocator
@@ -43,10 +43,12 @@ export async function tableSearch(
 }
 
 export async function getDataTableColumns(this: ILoadOptionsFunctions) {
-	const returnData: Array<INodePropertyOptions & { type: string }> = SYSTEM_COLUMNS.map((col) => ({
-		name: `${col.name} (${col.type})`,
-		value: col.name,
-		type: col.type,
+	const returnData: Array<INodePropertyOptions & { type: string }> = Object.entries(
+		DATA_TABLE_SYSTEM_COLUMN_TYPE_MAP,
+	).map(([name, type]) => ({
+		name: `${name} (${type})`,
+		value: name,
+		type,
 	}));
 
 	const proxy = await getDataTableProxyLoadOptions(this);
@@ -113,28 +115,28 @@ export async function getConditionsForColumn(this: ILoadOptionsFunctions) {
 	}
 
 	// Get column type to determine available conditions
-	const column =
-		SYSTEM_COLUMNS.find((col) => col.name === keyName) ??
-		(await proxy.getColumns()).find((col) => col.name === keyName);
+	const type =
+		DATA_TABLE_SYSTEM_COLUMN_TYPE_MAP[keyName] ??
+		(await proxy.getColumns()).find((col) => col.name === keyName)?.type;
 
-	if (!column) {
+	if (!type) {
 		return [...equalsConditions, ...nullConditions];
 	}
 
 	const conditions: INodePropertyOptions[] = [];
 
-	if (column.type === 'boolean') {
+	if (type === 'boolean') {
 		conditions.push.apply(conditions, booleanConditions);
 	}
 
 	// String columns get LIKE operators
-	if (column.type === 'string') {
+	if (type === 'string') {
 		conditions.push.apply(conditions, equalsConditions);
 		conditions.push.apply(conditions, stringConditions);
 		conditions.push.apply(conditions, comparableConditions);
 	}
 
-	if (['number', 'date'].includes(column.type)) {
+	if (['number', 'date'].includes(type)) {
 		conditions.push.apply(conditions, equalsConditions);
 		conditions.push.apply(conditions, comparableConditions);
 	}

--- a/packages/nodes-base/nodes/DataTable/common/methods.ts
+++ b/packages/nodes-base/nodes/DataTable/common/methods.ts
@@ -6,6 +6,7 @@ import {
 	type ResourceMapperFields,
 } from 'n8n-workflow';
 
+import { SYSTEM_COLUMNS } from './constants';
 import { getDataTableAggregateProxy, getDataTableProxyLoadOptions } from './utils';
 
 // @ADO-3904: Pagination here does not work until a filter is entered or removed, suspected bug in ResourceLocator
@@ -42,14 +43,11 @@ export async function tableSearch(
 }
 
 export async function getDataTableColumns(this: ILoadOptionsFunctions) {
-	const returnData: Array<INodePropertyOptions & { type: string }> = [
-		// eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased-id, n8n-nodes-base/node-param-display-name-miscased
-		{ name: 'id (number)', value: 'id', type: 'number' },
-		// eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased
-		{ name: 'createdAt (date)', value: 'createdAt', type: 'date' },
-		// eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased
-		{ name: 'updatedAt (date)', value: 'updatedAt', type: 'date' },
-	];
+	const returnData: Array<INodePropertyOptions & { type: string }> = SYSTEM_COLUMNS.map((col) => ({
+		name: `${col.name} (${col.type})`,
+		value: col.name,
+		type: col.type,
+	}));
 
 	const proxy = await getDataTableProxyLoadOptions(this);
 	if (!proxy) {
@@ -66,12 +64,6 @@ export async function getDataTableColumns(this: ILoadOptionsFunctions) {
 	}
 	return returnData;
 }
-
-const systemColumns = [
-	{ name: 'id', type: 'number' },
-	{ name: 'createdAt', type: 'date' },
-	{ name: 'updatedAt', type: 'date' },
-] as const;
 
 export async function getConditionsForColumn(this: ILoadOptionsFunctions) {
 	const proxy = await getDataTableProxyLoadOptions(this);
@@ -122,7 +114,7 @@ export async function getConditionsForColumn(this: ILoadOptionsFunctions) {
 
 	// Get column type to determine available conditions
 	const column =
-		systemColumns.find((col) => col.name === keyName) ??
+		SYSTEM_COLUMNS.find((col) => col.name === keyName) ??
 		(await proxy.getColumns()).find((col) => col.name === keyName);
 
 	if (!column) {

--- a/packages/nodes-base/nodes/DataTable/common/selectMany.ts
+++ b/packages/nodes-base/nodes/DataTable/common/selectMany.ts
@@ -125,7 +125,7 @@ export async function getSelectFilter(
 				node,
 				`Filter validation failed: Column(s) "${invalidColumnNames}" do not exist in the selected table. ` +
 					'This often happens when switching between tables with different schemas. ' +
-					'Please try deleting this condition and then adding it again.',
+					'Please update your filter conditions.',
 			);
 		}
 	}

--- a/packages/nodes-base/nodes/DataTable/common/selectMany.ts
+++ b/packages/nodes-base/nodes/DataTable/common/selectMany.ts
@@ -8,7 +8,13 @@ import type {
 	INodeProperties,
 } from 'n8n-workflow';
 
-import { ALL_CONDITIONS, ANY_CONDITION, ROWS_LIMIT_DEFAULT, type FilterType } from './constants';
+import {
+	ALL_CONDITIONS,
+	ANY_CONDITION,
+	ROWS_LIMIT_DEFAULT,
+	SYSTEM_COLUMN_NAMES,
+	type FilterType,
+} from './constants';
 import { DATA_TABLE_ID_FIELD } from './fields';
 import { buildGetManyFilter, isFieldArray, isMatchType, getDataTableProxyExecute } from './utils';
 
@@ -114,8 +120,10 @@ export async function getSelectFilter(
 	if (fields.length > 0) {
 		const dataStoreProxy = await getDataTableProxyExecute(ctx, index);
 		const availableColumns = await dataStoreProxy.getColumns();
-		const systemColumns = ['id', 'createdAt', 'updatedAt'];
-		const allColumns = new Set([...systemColumns, ...availableColumns.map((col) => col.name)]);
+		const allColumns = new Set([
+			...SYSTEM_COLUMN_NAMES,
+			...availableColumns.map((col) => col.name),
+		]);
 
 		const invalidConditions = fields.filter((field) => !allColumns.has(field.keyName));
 

--- a/packages/nodes-base/nodes/DataTable/common/selectMany.ts
+++ b/packages/nodes-base/nodes/DataTable/common/selectMany.ts
@@ -59,7 +59,7 @@ export function getSelectFields(
 							description:
 								'Choose from the list, or specify using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
 							typeOptions: {
-								loadOptionsDependsOn: [DATA_TABLE_ID_FIELD],
+								loadOptionsDependsOn: [`${DATA_TABLE_ID_FIELD}.value`],
 								loadOptionsMethod: 'getDataTableColumns',
 							},
 							default: 'id',

--- a/packages/nodes-base/nodes/DataTable/common/selectMany.ts
+++ b/packages/nodes-base/nodes/DataTable/common/selectMany.ts
@@ -10,7 +10,7 @@ import type {
 
 import { ALL_CONDITIONS, ANY_CONDITION, ROWS_LIMIT_DEFAULT, type FilterType } from './constants';
 import { DATA_TABLE_ID_FIELD } from './fields';
-import { buildGetManyFilter, isFieldArray, isMatchType } from './utils';
+import { buildGetManyFilter, isFieldArray, isMatchType, getDataTableProxyExecute } from './utils';
 
 export function getSelectFields(
 	displayOptions: IDisplayOptions,
@@ -95,7 +95,10 @@ export function getSelectFields(
 	];
 }
 
-export function getSelectFilter(ctx: IExecuteFunctions, index: number): DataTableFilter {
+export async function getSelectFilter(
+	ctx: IExecuteFunctions,
+	index: number,
+): Promise<DataTableFilter> {
 	const fields = ctx.getNodeParameter('filters.conditions', index, []);
 	const matchType = ctx.getNodeParameter('matchType', index, ANY_CONDITION);
 	const node = ctx.getNode();
@@ -107,6 +110,26 @@ export function getSelectFilter(ctx: IExecuteFunctions, index: number): DataTabl
 		throw new NodeOperationError(node, 'unexpected fields input');
 	}
 
+	// Validate filter conditions against current table schema
+	if (fields.length > 0) {
+		const dataStoreProxy = await getDataTableProxyExecute(ctx, index);
+		const availableColumns = await dataStoreProxy.getColumns();
+		const systemColumns = ['id', 'createdAt', 'updatedAt'];
+		const allColumns = new Set([...systemColumns, ...availableColumns.map((col) => col.name)]);
+
+		const invalidConditions = fields.filter((field) => !allColumns.has(field.keyName));
+
+		if (invalidConditions.length > 0) {
+			const invalidColumnNames = invalidConditions.map((c) => c.keyName).join(', ');
+			throw new NodeOperationError(
+				node,
+				`Filter validation failed: Column(s) "${invalidColumnNames}" do not exist in the selected table. ` +
+					'This often happens when switching between tables with different schemas. ' +
+					'Please try deleting this condition and then adding it again.',
+			);
+		}
+	}
+
 	return buildGetManyFilter(fields, matchType);
 }
 
@@ -116,7 +139,7 @@ export async function executeSelectMany(
 	dataStoreProxy: IDataStoreProjectService,
 	rejectEmpty = false,
 ): Promise<Array<{ json: DataStoreRowReturn }>> {
-	const filter = getSelectFilter(ctx, index);
+	const filter = await getSelectFilter(ctx, index);
 
 	if (rejectEmpty && filter.filters.length === 0) {
 		throw new NodeOperationError(ctx.getNode(), 'At least one condition is required');

--- a/packages/nodes-base/nodes/DataTable/common/selectMany.ts
+++ b/packages/nodes-base/nodes/DataTable/common/selectMany.ts
@@ -1,4 +1,4 @@
-import { NodeOperationError } from 'n8n-workflow';
+import { DATA_TABLE_SYSTEM_COLUMNS, NodeOperationError } from 'n8n-workflow';
 import type {
 	DataTableFilter,
 	DataStoreRowReturn,
@@ -8,13 +8,7 @@ import type {
 	INodeProperties,
 } from 'n8n-workflow';
 
-import {
-	ALL_CONDITIONS,
-	ANY_CONDITION,
-	ROWS_LIMIT_DEFAULT,
-	SYSTEM_COLUMN_NAMES,
-	type FilterType,
-} from './constants';
+import { ALL_CONDITIONS, ANY_CONDITION, ROWS_LIMIT_DEFAULT, type FilterType } from './constants';
 import { DATA_TABLE_ID_FIELD } from './fields';
 import { buildGetManyFilter, isFieldArray, isMatchType, getDataTableProxyExecute } from './utils';
 
@@ -121,7 +115,7 @@ export async function getSelectFilter(
 		const dataStoreProxy = await getDataTableProxyExecute(ctx, index);
 		const availableColumns = await dataStoreProxy.getColumns();
 		const allColumns = new Set([
-			...SYSTEM_COLUMN_NAMES,
+			...DATA_TABLE_SYSTEM_COLUMNS,
 			...availableColumns.map((col) => col.name),
 		]);
 

--- a/packages/workflow/src/data-store.types.ts
+++ b/packages/workflow/src/data-store.types.ts
@@ -80,7 +80,13 @@ export type AddDataStoreColumnOptions = Pick<DataStoreColumn, 'name' | 'type'> &
 
 export type DataStoreColumnJsType = string | number | boolean | Date | null;
 
-export const DATA_TABLE_SYSTEM_COLUMNS = ['id', 'createdAt', 'updatedAt'] as const;
+export const DATA_TABLE_SYSTEM_COLUMN_TYPE_MAP: Record<string, DataStoreColumnType> = {
+	id: 'number',
+	createdAt: 'date',
+	updatedAt: 'date',
+};
+
+export const DATA_TABLE_SYSTEM_COLUMNS = Object.keys(DATA_TABLE_SYSTEM_COLUMN_TYPE_MAP);
 
 export type DataStoreRowReturnBase = {
 	id: number;


### PR DESCRIPTION
## Summary

Before, when selecting another data table, there was no warning when the condition filter is no longer available for that schema. Now, you see a warning:
<img height="500" alt="image" src="https://github.com/user-attachments/assets/74c661ed-8ad6-4096-b0ce-62f47154bfae" />

At the same time, I added validation after clicking on "Execute":
<img height="550" alt="image" src="https://github.com/user-attachments/assets/88156795-2b9a-43e4-a381-5527d3d46080" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4161/data-table-node-filter-condition-fields-are-not-refreshed-when-the

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
