### PR TITLE
test: Reduce DB operations during data store tests

### DIFF
--- a/packages/@n8n/backend-test-utils/src/test-db.ts
+++ b/packages/@n8n/backend-test-utils/src/test-db.ts
@@ -7,6 +7,7 @@ import { DataSource as Connection } from '@n8n/typeorm';
 import { randomString } from 'n8n-workflow';
 
 export const testDbPrefix = 'n8n_test_';
+let isInitialized = false;
 
 /**
  * Generate options for a bootstrap DB connection, to create and drop test databases.
@@ -27,6 +28,8 @@ export const getBootstrapDBOptions = (dbType: 'postgresdb' | 'mysqldb'): DataSou
  * Initialize one test DB per suite run, with bootstrap connection if needed.
  */
 export async function init() {
+	if (isInitialized) return;
+
 	const globalConfig = Container.get(GlobalConfig);
 	const dbType = globalConfig.database.type;
 	const testDbName = `${testDbPrefix}${randomString(6, 10).toLowerCase()}_${Date.now()}`;
@@ -52,6 +55,8 @@ export async function init() {
 	await dbConnection.migrate();
 
 	await Container.get(AuthRolesService).init();
+
+	isInitialized = true;
 }
 
 export function isReady() {
@@ -66,6 +71,7 @@ export async function terminate() {
 	const dbConnection = Container.get(DbConnection);
 	await dbConnection.close();
 	dbConnection.connectionState.connected = false;
+	isInitialized = false;
 }
 
 type EntityName =

--- a/packages/cli/src/modules/data-table/__tests__/data-store.controller.integration.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/data-store.controller.integration.test.ts
@@ -44,10 +44,6 @@ let dataStoreRowsRepository: DataStoreRowsRepository;
 beforeAll(async () => {
 	await testDb.init();
 	mockDataStoreSizeValidator();
-});
-
-beforeEach(async () => {
-	await testDb.truncate(['DataTable', 'DataTableColumn', 'Project', 'ProjectRelation']);
 
 	projectRepository = Container.get(ProjectRepository);
 	dataStoreRepository = Container.get(DataStoreRepository);
@@ -64,6 +60,10 @@ beforeEach(async () => {
 
 	ownerProject = await getPersonalProject(owner);
 	memberProject = await getPersonalProject(member);
+});
+
+beforeEach(async () => {
+	await testDb.truncate(['DataTable', 'DataTableColumn']);
 });
 
 afterAll(async () => {

--- a/packages/cli/src/modules/data-table/__tests__/data-store.controller.integration.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/data-store.controller.integration.test.ts
@@ -42,7 +42,6 @@ let dataStoreColumnRepository: DataStoreColumnRepository;
 let dataStoreRowsRepository: DataStoreRowsRepository;
 
 beforeAll(async () => {
-	await testDb.init();
 	mockDataStoreSizeValidator();
 
 	projectRepository = Container.get(ProjectRepository);
@@ -71,6 +70,10 @@ afterAll(async () => {
 });
 
 describe('POST /projects/:projectId/data-tables', () => {
+	beforeEach(async () => {
+		await testDb.truncate(['DataTable', 'DataTableColumn']);
+	});
+
 	test('should not create data store when project does not exist', async () => {
 		const payload = {
 			name: 'Test Data Store',


### PR DESCRIPTION
## Summary

Create owner, member and admin users only once in the beginning of the test. There's no need to recreate for each test.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
