### PR TITLE
fix: Always generate tags.json file when using environments

### DIFF
--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control-export.service.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control-export.service.test.ts
@@ -223,7 +223,7 @@ describe('SourceControlExportService', () => {
 			expect(result.files[0]).toMatchObject({ id: '', name: fileName });
 		});
 
-		it('clear tags file when there are no tags', async () => {
+		it('should clear tags file and export it when there are no tags', async () => {
 			// Arrange
 			tagRepository.find.mockResolvedValue([]);
 			const fileName = '/mock/n8n/git/tags.json';

--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control-export.service.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control-export.service.test.ts
@@ -9,6 +9,8 @@ import type {
 	SharedCredentialsRepository,
 	SharedWorkflowRepository,
 	WorkflowRepository,
+	TagEntity,
+	WorkflowTagMapping,
 } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { mock, captor } from 'jest-mock-extended';
@@ -181,27 +183,62 @@ describe('SourceControlExportService', () => {
 	describe('exportTagsToWorkFolder', () => {
 		it('should export tags to work folder', async () => {
 			// Arrange
-			tagRepository.find.mockResolvedValue([mock()]);
-			workflowTagMappingRepository.find.mockResolvedValue([mock()]);
+			const mockTag = mock<TagEntity>({
+				id: 'tag1',
+				name: 'Tag 1',
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			});
+
+			const mockWorkflow = mock<WorkflowTagMapping>({
+				tagId: 'tag1',
+				workflowId: 'workflow1',
+			});
+			tagRepository.find.mockResolvedValue([mockTag]);
+			workflowTagMappingRepository.find.mockResolvedValue([mockWorkflow]);
+			const fileName = '/mock/n8n/git/tags.json';
 
 			// Act
 			const result = await service.exportTagsToWorkFolder(globalAdminContext);
 
 			// Assert
+			expect(fsWriteFile).toHaveBeenCalledWith(
+				fileName,
+				JSON.stringify(
+					{
+						tags: [
+							{
+								id: mockTag.id,
+								name: mockTag.name,
+							},
+						],
+						mappings: [mockWorkflow],
+					},
+					null,
+					2,
+				),
+			);
 			expect(result.count).toBe(1);
 			expect(result.files).toHaveLength(1);
+			expect(result.files[0]).toMatchObject({ id: '', name: fileName });
 		});
 
-		it('should not export empty tags', async () => {
+		it('clear tags file when there are no tags', async () => {
 			// Arrange
 			tagRepository.find.mockResolvedValue([]);
+			const fileName = '/mock/n8n/git/tags.json';
 
 			// Act
 			const result = await service.exportTagsToWorkFolder(globalAdminContext);
 
 			// Assert
+			expect(fsWriteFile).toHaveBeenCalledWith(
+				fileName,
+				JSON.stringify({ tags: [], mappings: [] }, null, 2),
+			);
 			expect(result.count).toBe(0);
-			expect(result.files).toHaveLength(0);
+			expect(result.files).toHaveLength(1);
+			expect(result.files[0]).toMatchObject({ id: '', name: fileName });
 		});
 	});
 

--- a/packages/cli/src/environments.ee/source-control/source-control-export.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-export.service.ee.ts
@@ -310,20 +310,12 @@ export class SourceControlExportService {
 			const tags = await this.tagRepository.find();
 
 			if (tags.length === 0) {
-				await fsWriteFile(
-					path.join(this.gitFolder, SOURCE_CONTROL_TAGS_EXPORT_FILE),
-					JSON.stringify({ tags: [], mappings: [] }, null, 2),
-				);
+				await fsWriteFile(fileName, JSON.stringify({ tags: [], mappings: [] }, null, 2));
 
 				return {
 					count: 0,
 					folder: this.gitFolder,
-					files: [
-						{
-							id: '',
-							name: fileName,
-						},
-					],
+					files: [{ id: '', name: fileName }],
 				};
 			}
 			const mappingsOfAllowedWorkflows = await this.workflowTagMappingRepository.find({
@@ -362,12 +354,7 @@ export class SourceControlExportService {
 			return {
 				count: tags.length,
 				folder: this.gitFolder,
-				files: [
-					{
-						id: '',
-						name: fileName,
-					},
-				],
+				files: [{ id: '', name: fileName }],
 			};
 		} catch (error) {
 			this.logger.error('Failed to export tags to work folder', { error });

--- a/packages/cli/src/environments.ee/source-control/source-control-export.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-export.service.ee.ts
@@ -308,7 +308,7 @@ export class SourceControlExportService {
 			const fileName = path.join(this.gitFolder, SOURCE_CONTROL_TAGS_EXPORT_FILE);
 			sourceControlFoldersExistCheck([this.gitFolder]);
 			const tags = await this.tagRepository.find();
-			// clear tags if there are none to export
+
 			if (tags.length === 0) {
 				await fsWriteFile(
 					path.join(this.gitFolder, SOURCE_CONTROL_TAGS_EXPORT_FILE),
@@ -333,7 +333,6 @@ export class SourceControlExportService {
 					),
 			});
 
-			console.log(mappingsOfAllowedWorkflows);
 			const allowedWorkflows = await this.workflowRepository.find({
 				where:
 					this.sourceControlScopedService.getWorkflowsInAdminProjectsFromContextFilter(context),


### PR DESCRIPTION
## Summary

Generate `tags.json` file even when no tags are present to avoid issue with environments.

## Related Linear tickets, Github issues, and Community forum posts

fixes PAY-3836
Fixes issues introduced with: #19332

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
