### PR TITLE
feat(core): Include null values for neq operator (no-changelog)

### DIFF
--- a/packages/cli/src/modules/data-table/__tests__/data-store-filters.integration.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/data-store-filters.integration.test.ts
@@ -329,6 +329,45 @@ describe('dataStore filters', () => {
 				]);
 			});
 
+			it('includes null values when using neq with specific value', async () => {
+				// ARRANGE
+				const { id: dataStoreId } = await dataStoreService.createDataStore(project.id, {
+					name: 'dataStore',
+					columns: [
+						{ name: 'name', type: 'string' },
+						{ name: 'category', type: 'string' },
+					],
+				});
+
+				const rows = [
+					{ name: 'John', category: 'A' },
+					{ name: 'Mary', category: 'B' },
+					{ name: 'Jack', category: null },
+					{ name: 'Alice', category: 'A' },
+					{ name: 'Bob', category: null },
+				];
+
+				await dataStoreService.insertRows(dataStoreId, project.id, rows);
+
+				// ACT
+				const result = await dataStoreService.getManyRowsAndCount(dataStoreId, project.id, {
+					filter: {
+						type: 'and',
+						filters: [{ columnName: 'category', condition: 'neq', value: 'A' }],
+					},
+				});
+
+				// ASSERT
+				expect(result.count).toEqual(3);
+				expect(result.data).toEqual(
+					expect.arrayContaining([
+						expect.objectContaining({ name: 'Mary', category: 'B' }),
+						expect.objectContaining({ name: 'Jack', category: null }),
+						expect.objectContaining({ name: 'Bob', category: null }),
+					]),
+				);
+			});
+
 			it('should accept a valid numeric string', async () => {
 				const { id: dataStoreId } = await dataStoreService.createDataStore(project.id, {
 					name: 'dataStore',

--- a/packages/cli/src/modules/data-table/data-store-rows.repository.ts
+++ b/packages/cli/src/modules/data-table/data-store-rows.repository.ts
@@ -82,7 +82,6 @@ function getConditionAndParams(
 	// Handle operators that map directly to SQL operators
 	const operators: Record<string, string> = {
 		eq: '=',
-		neq: '!=',
 		gt: '>',
 		gte: '>=',
 		lt: '<',
@@ -91,6 +90,11 @@ function getConditionAndParams(
 
 	if (operators[filter.condition]) {
 		return [`${columnRef} ${operators[filter.condition]} :${paramName}`, { [paramName]: value }];
+	}
+
+	// Special handling for neq to include NULL values (only if value is not null!)
+	if (filter.condition === 'neq') {
+		return [`(${columnRef} != :${paramName} OR ${columnRef} IS NULL)`, { [paramName]: value }];
 	}
 
 	switch (filter.condition) {


### PR DESCRIPTION
## Summary

The "!=" db operator doesn't include null values. With this improvement, when using `neq` operator with a non-null value, `null` is also included.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4162/node-not-equal-operator-always-excludes-null-values

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
