### PR TITLE
feat(editor): T2W minor visual chat improvements (line height, padding) (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.vue
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.vue
@@ -472,7 +472,7 @@ defineExpose({
 
 .chatTitle {
 	display: flex;
-	gap: var(--spacing-3xs);
+	gap: var(--spacing-xs);
 }
 
 .headerText {

--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/messages/TextMessage.vue
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/messages/TextMessage.vue
@@ -92,6 +92,7 @@ async function onCopyButtonClick(content: string, e: MouseEvent) {
 	flex-direction: column;
 	gap: var(--spacing-xs);
 	font-size: var(--font-size-2xs);
+	line-height: var(--font-line-height-xxloose);
 	word-break: break-word;
 }
 
@@ -161,6 +162,10 @@ async function onCopyButtonClick(content: string, e: MouseEvent) {
 	ul,
 	ol {
 		margin: var(--spacing-4xs) 0 var(--spacing-4xs) var(--spacing-l);
+
+		li {
+			margin-bottom: var(--spacing-5xs);
+		}
 
 		ul,
 		ol {

--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/messages/TextMessage.vue
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/messages/TextMessage.vue
@@ -92,7 +92,7 @@ async function onCopyButtonClick(content: string, e: MouseEvent) {
 	flex-direction: column;
 	gap: var(--spacing-xs);
 	font-size: var(--font-size-2xs);
-	line-height: var(--font-line-height-xxloose);
+	line-height: 1.6;
 	word-break: break-word;
 }
 

--- a/packages/frontend/@n8n/design-system/src/css/_tokens.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.scss
@@ -662,7 +662,6 @@
 	--font-line-height-regular: 1.3;
 	--font-line-height-loose: 1.35;
 	--font-line-height-xloose: 1.5;
-	--font-line-height-xxloose: 1.6;
 
 	--font-weight-regular: 400;
 	--font-weight-medium: 500;

--- a/packages/frontend/@n8n/design-system/src/css/_tokens.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.scss
@@ -662,6 +662,7 @@
 	--font-line-height-regular: 1.3;
 	--font-line-height-loose: 1.35;
 	--font-line-height-xloose: 1.5;
+	--font-line-height-xxloose: 1.6;
 
 	--font-weight-regular: 400;
 	--font-weight-medium: 500;

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -194,7 +194,6 @@
 	"aiAssistant.n8nAi": "n8n AI",
 	"aiAssistant.tabs.ask": "Ask",
 	"aiAssistant.tabs.build": "Build",
-	"aiAssistant.builder.name": "Builder",
 	"aiAssistant.builder.mode": "AI Builder",
 	"aiAssistant.builder.placeholder": "Ask n8n to build...",
 	"aiAssistant.builder.generateNew": "Generate new workflow",

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -192,6 +192,8 @@
 	"auth.signup.tokenValidationError": "Issue validating invite token",
 	"aiAssistant.name": "Assistant",
 	"aiAssistant.n8nAi": "n8n AI",
+	"aiAssistant.tabs.ask": "Ask",
+	"aiAssistant.tabs.build": "Build",
 	"aiAssistant.builder.name": "Builder",
 	"aiAssistant.builder.mode": "AI Builder",
 	"aiAssistant.builder.placeholder": "Ask n8n to build...",

--- a/packages/frontend/editor-ui/src/components/AskAssistant/HubSwitcher.vue
+++ b/packages/frontend/editor-ui/src/components/AskAssistant/HubSwitcher.vue
@@ -13,8 +13,8 @@ const emit = defineEmits<{
 const i18n = useI18n();
 
 const options = computed(() => [
-	{ label: i18n.baseText('aiAssistant.assistant'), value: false },
-	{ label: i18n.baseText('aiAssistant.builder.name'), value: true },
+	{ label: i18n.baseText('aiAssistant.tabs.ask'), value: false },
+	{ label: i18n.baseText('aiAssistant.tabs.build'), value: true },
 ]);
 
 function toggle(value: boolean) {


### PR DESCRIPTION


## Summary

- Updating line height to 1.6 for messages in the chat, added a CSS var as 1.5 was the loosest specified `--font-line-height-xxloose`.
- updating the tab names and updated locale
- adjusting spacing between n8n AI and switcher
- adjusting padding around lists

Before:
<img width="336" height="888" alt="image" src="https://github.com/user-attachments/assets/865917e3-5b63-4fa9-b41c-a19f15ea2c23" />

After: 
<img width="336" height="889" alt="image" src="https://github.com/user-attachments/assets/4b029c1a-0b7d-4f5b-a7d9-d087728733e8" />


Ticket: https://linear.app/n8n/issue/AI-1374/t2w-fix-the-line-height-of-the-messages-and-lists-rename-the-tabs

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
