### PR TITLE
refactor(core): Switch native Python task runner to `forkserver`

### DIFF
--- a/packages/@n8n/task-runner-python/src/constants.py
+++ b/packages/@n8n/task-runner-python/src/constants.py
@@ -144,3 +144,7 @@ ERROR_DANGEROUS_ATTRIBUTE = "Access to attribute '{attr}' is disallowed, because
 ERROR_DYNAMIC_IMPORT = (
     "Dynamic __import__() calls are not allowed for security reasons."
 )
+ERROR_WINDOWS_NOT_SUPPORTED = (
+    "Error: This task runner is not supported on Windows. "
+    "Please use a Unix-like system (Linux or macOS)."
+)

--- a/packages/@n8n/task-runner-python/src/main.py
+++ b/packages/@n8n/task-runner-python/src/main.py
@@ -1,8 +1,10 @@
 import asyncio
 import logging
 import sys
+import platform
 from typing import Optional
 
+from src.constants import ERROR_WINDOWS_NOT_SUPPORTED
 from src.config.health_check_config import HealthCheckConfig
 from src.config.sentry_config import SentryConfig
 from src.config.task_runner_config import TaskRunnerConfig
@@ -63,4 +65,8 @@ async def main():
 
 
 if __name__ == "__main__":
+    if platform.system() == "Windows":
+        print(ERROR_WINDOWS_NOT_SUPPORTED, file=sys.stderr)
+        sys.exit(1)
+
     asyncio.run(main())

--- a/packages/@n8n/task-runner-python/src/task_state.py
+++ b/packages/@n8n/task-runner-python/src/task_state.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from dataclasses import dataclass
-from multiprocessing.context import SpawnProcess
+from multiprocessing.context import ForkServerProcess
 from typing import Optional
 
 
@@ -14,7 +14,7 @@ class TaskStatus(Enum):
 class TaskState:
     task_id: str
     status: TaskStatus
-    process: Optional[SpawnProcess] = None
+    process: Optional[ForkServerProcess] = None
     workflow_name: Optional[str] = None
     workflow_id: Optional[str] = None
     node_name: Optional[str] = None


### PR DESCRIPTION
## Summary

Switch from `fork` to `forkserver` as a middle ground between the isolation of `spawn` and the performance of `fork`.

```mermaid
sequenceDiagram
    participant TB as Task Broker
    participant TR as Task Runner
    participant FS as Forkserver
    participant CP as Child Process

    TB->>TR: Send task settings
    TR->>FS: Request child process creation
    FS->>CP: Spawn child process
    TR->>CP: Send user code
    CP->>CP: Execute user code
    CP-->>TR: Return execution results (via multiprocessing queue)
    TR-->>TB: Send task completion/error
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1359


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
