### PR TITLE
Adjust not equal operator for null values

### DIFF
--- a/packages/cli/src/modules/data-table/__tests__/data-store-filters.integration.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/data-store-filters.integration.test.ts
@@ -259,6 +259,60 @@ describe('dataStore filters', () => {
 				]);
 			});
 
+			it("retrieves rows with 'not equals' filter including NULL values", async () => {
+				// ARRANGE
+				const { id: dataStoreId } = await dataStoreService.createDataStore(project.id, {
+					name: 'dataStore',
+					columns: [{ name: 'field', type: 'string' }],
+				});
+
+				const rows = [{ field: 'foo' }, { field: 'bar' }, { field: null }];
+
+				await dataStoreService.insertRows(dataStoreId, project.id, rows);
+
+				// ACT
+				const result = await dataStoreService.getManyRowsAndCount(dataStoreId, project.id, {
+					filter: {
+						type: 'and',
+						filters: [{ columnName: 'field', value: 'foo', condition: 'neq' }],
+					},
+				});
+
+				// ASSERT
+				expect(result.count).toEqual(2);
+				expect(result.data).toEqual([
+					expect.objectContaining({ field: 'bar' }),
+					expect.objectContaining({ field: null }),
+				]);
+			});
+
+			it("retrieves only non-null rows when 'not equals null'", async () => {
+				// ARRANGE
+				const { id: dataStoreId } = await dataStoreService.createDataStore(project.id, {
+					name: 'dataStore',
+					columns: [{ name: 'field', type: 'string' }],
+				});
+
+				const rows = [{ field: 'foo' }, { field: 'bar' }, { field: null }];
+
+				await dataStoreService.insertRows(dataStoreId, project.id, rows);
+
+				// ACT
+				const result = await dataStoreService.getManyRowsAndCount(dataStoreId, project.id, {
+					filter: {
+						type: 'and',
+						filters: [{ columnName: 'field', value: null, condition: 'neq' }],
+					},
+				});
+
+				// ASSERT
+				expect(result.count).toEqual(2);
+				expect(result.data).toEqual([
+					expect.objectContaining({ field: 'foo' }),
+					expect.objectContaining({ field: 'bar' }),
+				]);
+			});
+
 			it('supports filter by null', async () => {
 				// ARRANGE
 				const { id: dataStoreId } = await dataStoreService.createDataStore(project.id, {

--- a/packages/cli/src/modules/data-table/data-store-rows.repository.ts
+++ b/packages/cli/src/modules/data-table/data-store-rows.repository.ts
@@ -82,7 +82,6 @@ function getConditionAndParams(
 	// Handle operators that map directly to SQL operators
 	const operators: Record<string, string> = {
 		eq: '=',
-		neq: '!=',
 		gt: '>',
 		gte: '>=',
 		lt: '<',
@@ -91,6 +90,11 @@ function getConditionAndParams(
 
 	if (operators[filter.condition]) {
 		return [`${columnRef} ${operators[filter.condition]} :${paramName}`, { [paramName]: value }];
+	}
+
+	// Special handling for 'not equal' operator to include NULL rows
+	if (filter.condition === 'neq') {
+		return [`(${columnRef} <> :${paramName} OR ${columnRef} IS NULL)`, { [paramName]: value }];
 	}
 
 	switch (filter.condition) {


### PR DESCRIPTION
## Summary

This PR updates the backend condition builder for the "Not equal (≠)" operator to align with user expectations regarding NULL values.

Previously, `field ≠ value` (where `value` is non-null) behaved like standard SQL, excluding rows where `field` was NULL. This change modifies the generated SQL to explicitly include NULL rows, treating NULL as "not equal" to any non-null value.

Specifically:
- For non-null comparisons (`field ≠ 'foo'`): The generated logic is now equivalent to `(field <> :value OR field IS NULL)`.
- For null comparisons (`field ≠ null`): The behavior remains `field IS NOT NULL`.
- Other operators (e.g., `=`, `>`, `<`) are unaffected.

Unit tests have been added to verify:
- `field ≠ 'foo'` correctly returns `['bar', null]` for input `['foo', 'bar', null]`.
- `field ≠ null` correctly returns only non-null rows.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/ADO-4162

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

---
<a href="https://cursor.com/background-agent?bcId=bc-b601964d-fe4b-4351-b08f-92c2ceceb79a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b601964d-fe4b-4351-b08f-92c2ceceb79a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

