### PR TITLE
Fix workflow name preview in editor

### DIFF
--- a/packages/frontend/editor-ui/src/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/stores/workflows.store.ts
@@ -721,6 +721,9 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		}
 		workflow.value.name = data.newName;
 
+		// Keep the runtime workflow object in sync so $workflow.name resolves in editor previews
+		workflowObject.value.name = data.newName;
+
 		if (
 			workflow.value.id !== PLACEHOLDER_EMPTY_WORKFLOW_ID &&
 			workflowsById.value[workflow.value.id]


### PR DESCRIPTION
## Summary

This PR restores the availability of `$workflow.name` in the node parameter expression preview within the editor.

Previously, in versions 1.109+, `$workflow.name` would display `[empty]` in the editor preview for named workflows, even though it was correctly populated at runtime. This was due to the `workflowObject.value.name` not being updated when the workflow name changed in the editor.

The fix ensures that when `setWorkflowName()` is called, `workflowObject.value.name` is also synchronized with the new workflow name. This allows the editor's expression context to correctly resolve `$workflow.name` before execution, matching the behavior of 1.103.x.

This change only affects the editor preview and does not alter the `$workflow` object shape or execution-time behavior. If a workflow has no name, the preview will remain empty as appropriate.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4115

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

---
<a href="https://cursor.com/background-agent?bcId=bc-025762fe-9787-4182-bbeb-1716a849ace4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-025762fe-9787-4182-bbeb-1716a849ace4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

