### PR TITLE
fix(core): Delegate blocking wait to worker thread in native Python runner (no-changelog)

### DIFF
--- a/packages/@n8n/task-runner-python/src/task_runner.py
+++ b/packages/@n8n/task-runner-python/src/task_runner.py
@@ -302,7 +302,8 @@ class TaskRunner:
 
             task_state.process = process
 
-            result, print_args = self.executor.execute_process(
+            result, print_args = await asyncio.to_thread(
+                self.executor.execute_process,
                 process=process,
                 queue=queue,
                 task_timeout=self.config.task_timeout,


### PR DESCRIPTION
## Summary

A runner can run multiple tasks concurrently because each `_execute_task` call is meant to yield while waiting for task completion. But if anything inside this call blocks, it will prevent all other async operations from running: concurrent tasks, handling of websocket messages, sending of task offers, etc.

It turns out that in Python `process.join()` blocks, so the runner's event loop currently freezes while waiting for the child process to finish. By contrast, in Node.js the child process API is by default async and event-driven, so blocking on a child is rarely an issue.

```
Main process (event loop)
└── _execute_task()
    ├── create_process()
    ├── execute_process() - blocks
    │   ├── process.start()
    │   ├── process.join() - blocks
    │   └── queue.get_nowait()
    └── ...continues after child is done
```

Hence this PR moves the blocking wait from the event loop thread to a worker thread:

```mermaid
sequenceDiagram
    participant MT as Main thread<br /> (event loop)
    participant FS as Forkserver
    participant WT as Worker thread<br/>(thread pool)
    participant CP as Child process

    Note over MT: Startup
    MT->>FS: Init forkserver
    FS->>FS: Listen for requests
    
    Note over MT: Task received
    MT->>FS: Request new child process
    FS->>CP: Fork new child process
    FS-->>MT: Return new child process handle
    
    MT->>WT: Yield via asyncio.to_thread
    Note over MT: Event loop continues<br/>processing other tasks
    
    WT->>CP: process.start()
    WT->>CP: process.join()
    Note over WT: Worker thread blocks here<br/>until child process exit
    
    CP->>CP: Execute user code
    CP->>CP: Put result in queue
    CP->>CP: Exit
    
    WT->>WT: Get result from queue
    
    WT-->>MT: Return result
```




## Related Linear tickets, Github issues, and Community forum posts

n/a<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
