### PR TITLE
Fix workflow name display in editor preview

### DIFF
--- a/packages/frontend/editor-ui/src/composables/useResolvedExpression.ts
+++ b/packages/frontend/editor-ui/src/composables/useResolvedExpression.ts
@@ -107,6 +107,7 @@ export function useResolvedExpression({
 			toRef(expression),
 			() => workflowsStore.getWorkflowExecution,
 			() => workflowsStore.getWorkflowRunData,
+			() => workflowsStore.workflow.name,
 			targetItem,
 		],
 		debouncedUpdateExpression,

--- a/packages/frontend/editor-ui/src/stores/workflows.store.test.ts
+++ b/packages/frontend/editor-ui/src/stores/workflows.store.test.ts
@@ -466,6 +466,11 @@ describe('useWorkflowsStore', () => {
 			workflowsStore.setWorkflowName({ newName: 'New Workflow Name', setStateDirty: false });
 			expect(workflowsStore.workflow.name).toBe('New Workflow Name');
 		});
+
+		it('should propagate name to workflowObject for pre-exec expressions', () => {
+			workflowsStore.setWorkflowName({ newName: 'WF Title', setStateDirty: false });
+			expect(workflowsStore.workflowObject.name).toBe('WF Title');
+		});
 	});
 
 	describe('setWorkflowActive()', () => {

--- a/packages/frontend/editor-ui/src/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/stores/workflows.store.ts
@@ -721,6 +721,9 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		}
 		workflow.value.name = data.newName;
 
+		// Keep the pre-execution expression context in sync so $workflow.name resolves in editor
+		workflowObject.value.name = data.newName;
+
 		if (
 			workflow.value.id !== PLACEHOLDER_EMPTY_WORKFLOW_ID &&
 			workflowsById.value[workflow.value.id]


### PR DESCRIPTION
## Summary

This PR fixes an issue where `{{$workflow.name}}` displayed `[empty]` in the editor's expression preview (e.g., in node parameter fields or the expression editor) for saved, named workflows in versions 1.109+, despite resolving correctly at runtime.

The fix ensures the pre-execution expression context used by the editor includes the workflow's saved name. It also adds a watcher to re-resolve expressions when the workflow name changes, so previews update dynamically.

**To test:**
1.  Open a saved, named workflow.
2.  Add a node and use the expression `{{$workflow.name}}` in any text field (e.g., a Set node's value).
3.  Verify that the actual workflow name is displayed in the field preview, expression editor, and tooltips *before* executing the workflow.
4.  Change the workflow's name via the workflow settings.
5.  Observe that the expression preview for `{{$workflow.name}}` updates immediately to the new name without needing to run the workflow.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4115

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport`

---
<a href="https://cursor.com/background-agent?bcId=bc-74445e1d-a0a3-4a18-bfaa-8050a9d7d131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-74445e1d-a0a3-4a18-bfaa-8050a9d7d131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

