### PR TITLE
fix(Data Table Node): Improve `No columns` warning (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/DataTable/DataTable.node.ts
+++ b/packages/nodes-base/nodes/DataTable/DataTable.node.ts
@@ -31,11 +31,12 @@ export class DataTable implements INodeType {
 		outputs: [NodeConnectionTypes.Main],
 		hints: [
 			{
-				message: 'The selected Data Table has no columns.',
-				displayCondition: '={{ $parameter.columns?.schema?.length === 0 }}',
-				whenToDisplay: 'always',
+				message: 'The selected data table has no columns.',
+				displayCondition:
+					'={{ $parameter.dataTableId !== "" && $parameter?.columns?.mappingMode === "defineBelow" && !$parameter?.columns?.schema?.length }}',
+				whenToDisplay: 'beforeExecution',
 				location: 'ndv',
-				type: 'warning',
+				type: 'info',
 			},
 		],
 		properties: [
@@ -53,6 +54,12 @@ export class DataTable implements INodeType {
 				default: 'row',
 			},
 			...row.description,
+			{
+				displayName: 'Test',
+				name: 'test',
+				type: 'string',
+				default: '',
+			},
 		],
 	};
 

--- a/packages/nodes-base/nodes/DataTable/DataTable.node.ts
+++ b/packages/nodes-base/nodes/DataTable/DataTable.node.ts
@@ -54,12 +54,6 @@ export class DataTable implements INodeType {
 				default: 'row',
 			},
 			...row.description,
-			{
-				displayName: 'Test',
-				name: 'test',
-				type: 'string',
-				default: '',
-			},
 		],
 	};
 


### PR DESCRIPTION
## Summary

Ensure this warning doesn't show up when no table is selected yet

## Related Linear tickets, Github issues, and Community forum posts

n/a


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
