### PR TITLE
feat(editor): Hide trial banner on first visit (no-changelog)

### DIFF
--- a/cypress/e2e/27-cloud.cy.ts
+++ b/cypress/e2e/27-cloud.cy.ts
@@ -44,7 +44,21 @@ describe('Cloud', () => {
 	}
 
 	describe('BannerStack', () => {
-		it('should render trial banner for opt-in cloud user', () => {
+		it('should not render trial banner on first visit', () => {
+			// Clear localStorage to simulate first visit
+			cy.clearLocalStorage();
+
+			visitWorkflowPage();
+
+			cy.getByTestId('banner-stack').should('not.be.visible');
+		});
+
+		it('should render trial banner on subsequent visits', () => {
+			// Set visit count to simulate returning user
+			cy.window().then((win) => {
+				win.localStorage.setItem('n8n-trial-visit-count', '1');
+			});
+
 			visitWorkflowPage();
 
 			cy.getByTestId('banner-stack').should('be.visible');

--- a/packages/frontend/editor-ui/src/init.test.ts
+++ b/packages/frontend/editor-ui/src/init.test.ts
@@ -299,7 +299,7 @@ describe('Init', () => {
 
 				// Mock localStorage to simulate first visit
 				const getItemSpy = vi.spyOn(Storage.prototype, 'getItem').mockReturnValue(null);
-				const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
+				const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {});
 
 				const cloudStoreSpy = vi.spyOn(cloudPlanStore, 'initialize').mockResolvedValueOnce();
 
@@ -323,7 +323,7 @@ describe('Init', () => {
 
 				// Mock localStorage to simulate return visit
 				const getItemSpy = vi.spyOn(Storage.prototype, 'getItem').mockReturnValue('1');
-				const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
+				const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {});
 
 				const cloudStoreSpy = vi.spyOn(cloudPlanStore, 'initialize').mockResolvedValueOnce();
 

--- a/packages/frontend/editor-ui/src/init.test.ts
+++ b/packages/frontend/editor-ui/src/init.test.ts
@@ -298,7 +298,7 @@ describe('Init', () => {
 				cloudPlanStore.trialExpired = false;
 
 				// Mock localStorage to simulate first visit
-				vi.spyOn(Storage.prototype, 'getItem').mockReturnValue(null);
+				const getItemSpy = vi.spyOn(Storage.prototype, 'getItem').mockReturnValue(null);
 				const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
 
 				const cloudStoreSpy = vi.spyOn(cloudPlanStore, 'initialize').mockResolvedValueOnce();
@@ -308,6 +308,9 @@ describe('Init', () => {
 				expect(cloudStoreSpy).toHaveBeenCalled();
 				expect(setItemSpy).toHaveBeenCalledWith('n8n-trial-visit-count', '1');
 				expect(uiStore.pushBannerToStack).not.toHaveBeenCalledWith('TRIAL');
+
+				getItemSpy.mockRestore();
+				setItemSpy.mockRestore();
 			});
 
 			it('should push TRIAL banner if trial is active and user is returning', async () => {
@@ -319,7 +322,7 @@ describe('Init', () => {
 				cloudPlanStore.trialExpired = false;
 
 				// Mock localStorage to simulate return visit
-				vi.spyOn(Storage.prototype, 'getItem').mockReturnValue('1');
+				const getItemSpy = vi.spyOn(Storage.prototype, 'getItem').mockReturnValue('1');
 				const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
 
 				const cloudStoreSpy = vi.spyOn(cloudPlanStore, 'initialize').mockResolvedValueOnce();
@@ -329,6 +332,9 @@ describe('Init', () => {
 				expect(cloudStoreSpy).toHaveBeenCalled();
 				expect(setItemSpy).toHaveBeenCalledWith('n8n-trial-visit-count', '2');
 				expect(uiStore.pushBannerToStack).toHaveBeenCalledWith('TRIAL');
+
+				getItemSpy.mockRestore();
+				setItemSpy.mockRestore();
 			});
 
 			it('should push EMAIL_CONFIRMATION banner if user cloud info is not confirmed', async () => {

--- a/packages/frontend/editor-ui/src/init.ts
+++ b/packages/frontend/editor-ui/src/init.ts
@@ -35,6 +35,22 @@ export const state = {
 let authenticatedFeaturesInitialized = false;
 
 /**
+ * EXP: Ready to run V2
+ * Tracks user visits and determines if trial banner should show
+ * Returns true if this is not the user's first visit
+ */
+function shouldShowTrialBanner(): boolean {
+	const VISIT_COUNT_KEY = 'n8n-trial-visit-count';
+	const currentCount = parseInt(localStorage.getItem(VISIT_COUNT_KEY) ?? '0', 10);
+	const newCount = currentCount + 1;
+
+	localStorage.setItem(VISIT_COUNT_KEY, newCount.toString());
+
+	// Don't show banner on first visit
+	return newCount > 1;
+}
+
+/**
  * Initializes the core application stores and hooks
  * This is called once, when the first route is loaded.
  */
@@ -162,7 +178,7 @@ export async function initializeAuthenticatedFeatures(
 				if (cloudPlanStore.userIsTrialing) {
 					if (cloudPlanStore.trialExpired) {
 						uiStore.pushBannerToStack('TRIAL_OVER');
-					} else {
+					} else if (shouldShowTrialBanner()) {
 						uiStore.pushBannerToStack('TRIAL');
 					}
 				} else if (cloudPlanStore.currentUserCloudInfo?.confirmed === false) {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Hide trial banner on first visit in order to reduce chance of user being overwhelmed. Part of Ready to run V2 experiment.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

[GRO-123](https://linear.app/n8n/issue/GRO-123/implement-ready-to-run-v2-experiment)

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
