### PR TITLE
fix(http-request): accumulate duplicate query params instead of overwrite (#19727)

### DIFF
--- a/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequestV3.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequestV3.test.ts
@@ -71,6 +71,46 @@ describe('HttpRequestV3', () => {
 		} as unknown as IExecuteFunctions;
 	});
 
+	it('should accumulate duplicate query parameter names into arrays', async () => {
+		(executeFunctions.getInputData as jest.Mock).mockReturnValue([{ json: {} }]);
+		(executeFunctions.getNodeParameter as jest.Mock).mockImplementation((paramName: string) => {
+			switch (paramName) {
+				case 'method':
+					return 'GET';
+				case 'url':
+					return baseUrl;
+				case 'authentication':
+					return 'none';
+				case 'sendQuery':
+					return true;
+				case 'queryParameters.parameters':
+					return [
+						{ name: 'q_organization_keyword_tags[]', value: 'financial' },
+						{ name: 'q_organization_keyword_tags[]', value: 'investment' },
+					];
+				case 'specifyQuery':
+					return 'keypair';
+				case 'options':
+					return { ...options, queryParameterArrays: 'repeat' };
+				default:
+					return undefined;
+			}
+		});
+
+		const response = {
+			headers: { 'content-type': 'application/json' },
+			body: Buffer.from(JSON.stringify({ success: true })),
+		};
+		(executeFunctions.helpers.request as jest.Mock).mockImplementation(async (opts: any) => {
+			// Ensure qs object has array values for repeated keys
+			expect(opts.qs['q_organization_keyword_tags[]']).toEqual(['financial', 'investment']);
+			return response;
+		});
+
+		const result = await node.execute.call(executeFunctions);
+		expect(result).toEqual([[{ json: { success: true }, pairedItem: { item: 0 } }]]);
+	});
+
 	it('should make a GET request', async () => {
 		(executeFunctions.getInputData as jest.Mock).mockReturnValue([{ json: {} }]);
 		(executeFunctions.getNodeParameter as jest.Mock).mockImplementation((paramName: string) => {


### PR DESCRIPTION
Fixes n8n-io/n8n#19727

## Problem
The HTTP Request node collapsed multiple query parameters with the same name, so only the last value was sent.  
Example that failed before:
  ?q_organization_keyword_tags[]=financial&q_organization_keyword_tags[]=investment

Root cause: during reduction we assigned `accumulator[cur.name] = cur.value`, overwriting prior values.

## Solution
For query parameters, accumulate repeated names into arrays:
- first occurrence → `qs[name] = value`
- second occurrence → `qs[name] = [oldValue, value]`
- subsequent → `qs[name].push(value)`

This preserves duplicates and lets serialization respect the selected **Array Format in Query Parameters** (Repeat, Brackets Only, etc.).

## Scope
- [V3] Updated `packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts`
- Added a focused test in `packages/nodes-base/nodes/HttpRequest/test/node/HttpRequestV3.test.ts`
  - Asserts repeated keys produce array values in `requestOptions.qs`

> If desired, I can port the same change to V4 in this PR or a follow-up.

## How to test (UI)
1. HTTP Request (V3)  
2. URL: `https://httpbin.org/anything` or a `https://httpdump.app/dumps/<id>` link  
3. Send Query Parameters: **ON**  
4. Try both:
   - **Array Format = Repeat** with keys `q_organization_keyword_tags` (two rows: `financial`, `investment`)
   - **Array Format = Brackets Only** with keys `q_organization_keyword_tags[]` (two rows)
5. Execute → Confirm the full request URL shows both values for the same key.

## Screenshots
<img width="1440" height="754" alt="Screenshot 2025-09-19 at 4 40 14 PM" src="https://github.com/user-attachments/assets/a20776d6-32da-4642-9be3-d1c81a7283c9" />
<img width="1440" height="751" alt="Screenshot 2025-09-19 at 4 49 23 PM" src="https://github.com/user-attachments/assets/450fcb98-8cc3-4fbd-8635-64edce326912" />

## Notes
- Backward compatible for single-value params.
- Headers/body behavior unchanged.
- Happy to adjust typing or move the reducer to a shared helper if preferred.
