### PR TITLE
chore(editor): Adjust "No Data" message styles

### DIFF
--- a/packages/frontend/editor-ui/src/components/InputPanel.vue
+++ b/packages/frontend/editor-ui/src/components/InputPanel.vue
@@ -30,6 +30,8 @@ import WireMeUp from './WireMeUp.vue';
 import { usePostHog } from '@/stores/posthog.store';
 import { type IRunDataDisplayMode } from '@/Interface';
 import { I18nT } from 'vue-i18n';
+import { useRouter } from 'vue-router';
+import { useRunWorkflow } from '@/composables/useRunWorkflow';
 
 type MappingMode = 'debugging' | 'mapping';
 
@@ -99,6 +101,8 @@ const inputModes = [
 const nodeTypesStore = useNodeTypesStore();
 const workflowsStore = useWorkflowsStore();
 const posthogStore = usePostHog();
+const router = useRouter();
+const { runWorkflow } = useRunWorkflow({ router });
 
 const activeNode = computed(() => workflowsStore.getNodeByName(props.activeNodeName));
 
@@ -478,50 +482,38 @@ function handleChangeCollapsingColumn(columnName: string | null) {
 				:class="$style.noOutputData"
 			>
 				<NDVEmptyState v-if="nodeNotRunMessageVariant === 'simple'">
-					<template #description>
-						<I18nT scope="global" keypath="ndv.input.noOutputData.embeddedNdv.description">
-							<template #link>
-								<NodeExecuteButton
-									:class="$style.executeButton"
-									size="large"
-									:node-name="nodeNameToExecute"
-									:label="i18n.baseText('ndv.input.noOutputData.embeddedNdv.link')"
-									text
-									telemetry-source="inputs"
-									hide-icon
-								/>
-							</template>
-						</I18nT>
-					</template>
+					<I18nT scope="global" keypath="ndv.input.noOutputData.embeddedNdv.description">
+						<template #link>
+							<a href="#" @click="runWorkflow({ destinationNode: activeNodeName })">
+								{{ i18n.baseText('ndv.input.noOutputData.embeddedNdv.link') }}
+							</a>
+						</template>
+					</I18nT>
 				</NDVEmptyState>
 
 				<template v-else-if="isNDVV2">
 					<NDVEmptyState
 						v-if="isMappingEnabled || hasRootNodeRun"
 						:title="i18n.baseText('ndv.input.noOutputData.v2.title')"
+						icon="arrow-right-to-line"
 					>
-						<template #icon>
-							<N8nIcon icon="arrow-right-to-line" size="xlarge" />
-						</template>
-						<template #description>
-							<I18nT tag="span" keypath="ndv.input.noOutputData.v2.description" scope="global">
-								<template #link>
-									<NodeExecuteButton
-										hide-icon
-										transparent
-										type="secondary"
-										:node-name="nodeNameToExecute"
-										:label="i18n.baseText('ndv.input.noOutputData.v2.action')"
-										:tooltip="i18n.baseText('ndv.input.noOutputData.v2.tooltip')"
-										tooltip-placement="bottom"
-										telemetry-source="inputs"
-										data-test-id="execute-previous-node"
-										@execute="onNodeExecute"
-									/>
-									<br />
-								</template>
-							</I18nT>
-						</template>
+						<I18nT tag="span" keypath="ndv.input.noOutputData.v2.description" scope="global">
+							<template #link>
+								<NodeExecuteButton
+									hide-icon
+									transparent
+									type="secondary"
+									:node-name="nodeNameToExecute"
+									:label="i18n.baseText('ndv.input.noOutputData.v2.action')"
+									:tooltip="i18n.baseText('ndv.input.noOutputData.v2.tooltip')"
+									tooltip-placement="bottom"
+									telemetry-source="inputs"
+									data-test-id="execute-previous-node"
+									@execute="onNodeExecute"
+								/>
+								<br />
+							</template>
+						</I18nT>
 					</NDVEmptyState>
 					<NDVEmptyState v-else :title="i18n.baseText('ndv.input.rootNodeHasNotRun.title')">
 						<template #icon>
@@ -533,7 +525,7 @@ function handleChangeCollapsingColumn(columnName: string | null) {
 							</svg>
 						</template>
 
-						<template #description>
+						<template #default>
 							<I18nT tag="span" keypath="ndv.input.rootNodeHasNotRun.description" scope="global">
 								<template #link>
 									<a
@@ -551,15 +543,10 @@ function handleChangeCollapsingColumn(columnName: string | null) {
 
 				<template v-else>
 					<template v-if="isMappingEnabled || hasRootNodeRun">
-						<N8nText tag="div" :bold="true" color="text-dark" size="large">{{
-							i18n.baseText('ndv.input.noOutputData.title')
-						}}</N8nText>
+						<NDVEmptyState :title="i18n.baseText('ndv.input.noOutputData.title')" />
 					</template>
 					<template v-else>
-						<N8nText tag="div" :bold="true" color="text-dark" size="large">{{
-							i18n.baseText('ndv.input.rootNodeHasNotRun.title')
-						}}</N8nText>
-						<N8nText tag="div" color="text-dark" size="medium">
+						<NDVEmptyState :title="i18n.baseText('ndv.input.rootNodeHasNotRun.title')">
 							<I18nT tag="span" keypath="ndv.input.rootNodeHasNotRun.description" scope="global">
 								<template #link>
 									<a
@@ -570,7 +557,7 @@ function handleChangeCollapsingColumn(columnName: string | null) {
 									>
 								</template>
 							</I18nT>
-						</N8nText>
+						</NDVEmptyState>
 					</template>
 					<NodeExecuteButton
 						v-if="!readOnly"
@@ -654,27 +641,19 @@ function handleChangeCollapsingColumn(columnName: string | null) {
 		</template>
 
 		<template #node-waiting>
-			<N8nText :bold="true" color="text-dark" size="large">
-				{{ i18n.baseText('ndv.output.waitNodeWaiting.title') }}
-			</N8nText>
-			<N8nText v-n8n-html="waitingMessage"></N8nText>
+			<NDVEmptyState :title="i18n.baseText('ndv.output.waitNodeWaiting.title')" wide>
+				<span v-n8n-html="waitingMessage"></span>
+			</NDVEmptyState>
 		</template>
 
 		<template #no-output-data>
-			<N8nText tag="div" :bold="true" color="text-dark" size="large">{{
-				i18n.baseText('ndv.input.noOutputData')
-			}}</N8nText>
+			<NDVEmptyState :title="i18n.baseText('ndv.input.noOutputData')" />
 		</template>
 
 		<template #recovered-artificial-output-data>
-			<div :class="$style.recoveredOutputData">
-				<N8nText tag="div" :bold="true" color="text-dark" size="large">{{
-					i18n.baseText('executionDetails.executionFailed.recoveredNodeTitle')
-				}}</N8nText>
-				<N8nText>
-					{{ i18n.baseText('executionDetails.executionFailed.recoveredNodeMessage') }}
-				</N8nText>
-			</div>
+			<NDVEmptyState :title="i18n.baseText('executionDetails.executionFailed.recoveredNodeTitle')">
+				{{ i18n.baseText('executionDetails.executionFailed.recoveredNodeMessage') }}
+			</NDVEmptyState>
 		</template>
 	</RunData>
 </template>
@@ -713,16 +692,6 @@ function handleChangeCollapsingColumn(columnName: string | null) {
 
 	> * {
 		margin-bottom: var(--spacing-2xs);
-	}
-}
-
-.recoveredOutputData {
-	margin: auto;
-	max-width: 250px;
-	text-align: center;
-
-	> *:first-child {
-		margin-bottom: var(--spacing-m);
 	}
 }
 

--- a/packages/frontend/editor-ui/src/components/InputPanel.vue
+++ b/packages/frontend/editor-ui/src/components/InputPanel.vue
@@ -484,7 +484,7 @@ function handleChangeCollapsingColumn(columnName: string | null) {
 				<NDVEmptyState v-if="nodeNotRunMessageVariant === 'simple'">
 					<I18nT scope="global" keypath="ndv.input.noOutputData.embeddedNdv.description">
 						<template #link>
-							<a href="#" @click="runWorkflow({ destinationNode: activeNodeName })">
+							<a href="#" @click.prevent="runWorkflow({ destinationNode: activeNodeName })">
 								{{ i18n.baseText('ndv.input.noOutputData.embeddedNdv.link') }}
 							</a>
 						</template>

--- a/packages/frontend/editor-ui/src/components/NDVEmptyState.vue
+++ b/packages/frontend/editor-ui/src/components/NDVEmptyState.vue
@@ -1,17 +1,22 @@
 <script setup lang="ts">
-defineProps<{ title?: string }>();
+import { N8nIcon } from '@n8n/design-system';
+import type { IconName } from '@n8n/design-system/components/N8nIcon/icons';
+
+const { icon } = defineProps<{ title?: string; wide?: boolean; icon?: IconName }>();
 
 defineSlots<{
 	icon(): unknown;
-	description(): unknown;
+	default(): unknown;
 }>();
 </script>
 
 <template>
-	<article :class="$style.empty">
-		<slot name="icon" />
+	<article :class="[$style.empty, { [$style.wide]: wide }]">
+		<slot name="icon">
+			<N8nIcon v-if="icon" :icon="icon" size="xlarge" />
+		</slot>
 		<h1 v-if="title" :class="$style.title">{{ title }}</h1>
-		<p :class="$style.description"><slot name="description" /></p>
+		<p :class="$style.description"><slot /></p>
 	</article>
 </template>
 
@@ -36,8 +41,12 @@ defineSlots<{
 
 .description {
 	font-size: var(--font-size-s);
-	max-width: 240px;
 	margin: 0;
 	text-align: center;
+	max-width: 240px;
+
+	.wide & {
+		max-width: none;
+	}
 }
 </style>

--- a/packages/frontend/editor-ui/src/components/OutputPanel.vue
+++ b/packages/frontend/editor-ui/src/components/OutputPanel.vue
@@ -22,6 +22,7 @@ import { usePostHog } from '@/stores/posthog.store';
 import { type IRunDataDisplayMode } from '@/Interface';
 import { I18nT } from 'vue-i18n';
 import { useExecutionData } from '@/composables/useExecutionData';
+import NDVEmptyState from '@/components/NDVEmptyState.vue';
 
 // Types
 
@@ -386,7 +387,7 @@ function handleChangeCollapsingColumn(columnName: string | null) {
 					<template v-else #icon>
 						<N8nIcon icon="arrow-right-from-line" size="xlarge" />
 					</template>
-					<template #description>
+					<template #default>
 						<I18nT
 							tag="span"
 							:keypath="
@@ -442,21 +443,17 @@ function handleChangeCollapsingColumn(columnName: string | null) {
 		</template>
 
 		<template #node-waiting>
-			<N8nText :bold="true" color="text-dark" size="large">
-				{{ i18n.baseText('ndv.output.waitNodeWaiting.title') }}
-			</N8nText>
-			<N8nText v-n8n-html="waitingNodeTooltip(node)"></N8nText>
+			<NDVEmptyState :title="i18n.baseText('ndv.output.waitNodeWaiting.title')" wide>
+				<span v-n8n-html="waitingNodeTooltip(node)" />
+			</NDVEmptyState>
 		</template>
 
 		<template #no-output-data>
-			<N8nText :bold="true" color="text-dark" size="large">{{
-				i18n.baseText('ndv.output.noOutputData.title')
-			}}</N8nText>
-			<N8nText>
+			<NDVEmptyState :title="i18n.baseText('ndv.output.noOutputData.title')">
 				{{ i18n.baseText('ndv.output.noOutputData.message') }}
 				<a @click="openSettings">{{ i18n.baseText('ndv.output.noOutputData.message.settings') }}</a>
 				{{ i18n.baseText('ndv.output.noOutputData.message.settingsOption') }}
-			</N8nText>
+			</NDVEmptyState>
 		</template>
 
 		<template v-if="outputMode === 'logs' && node" #content>
@@ -464,14 +461,9 @@ function handleChangeCollapsingColumn(columnName: string | null) {
 		</template>
 
 		<template #recovered-artificial-output-data>
-			<div :class="$style.recoveredOutputData">
-				<N8nText tag="div" :bold="true" color="text-dark" size="large">{{
-					i18n.baseText('executionDetails.executionFailed.recoveredNodeTitle')
-				}}</N8nText>
-				<N8nText>
-					{{ i18n.baseText('executionDetails.executionFailed.recoveredNodeMessage') }}
-				</N8nText>
-			</div>
+			<NDVEmptyState :title="i18n.baseText('executionDetails.executionFailed.recoveredNodeTitle')">
+				{{ i18n.baseText('executionDetails.executionFailed.recoveredNodeMessage') }}
+			</NDVEmptyState>
 		</template>
 
 		<template v-if="!pinnedData.hasData.value && runsCount > 1" #run-info>
@@ -533,16 +525,6 @@ function handleChangeCollapsingColumn(columnName: string | null) {
 
 	> * {
 		margin-bottom: var(--spacing-2xs);
-	}
-}
-
-.recoveredOutputData {
-	margin: auto;
-	max-width: 250px;
-	text-align: center;
-
-	> *:first-child {
-		margin-bottom: var(--spacing-m);
 	}
 }
 

--- a/packages/frontend/editor-ui/src/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/components/RunData.vue
@@ -1727,27 +1727,28 @@ defineExpose({ enterEditMode });
 				</N8nText>
 			</div>
 
-			<div v-else-if="isTrimmedManualExecutionDataItem" :class="$style.center">
-				<N8nText bold color="text-dark" size="large">
-					{{ i18n.baseText('runData.trimmedData.title') }}
-				</N8nText>
-				<N8nText>
-					{{ i18n.baseText('runData.trimmedData.message') }}
-				</N8nText>
-			</div>
+			<NDVEmptyState
+				v-else-if="isTrimmedManualExecutionDataItem"
+				:class="$style.center"
+				:title="i18n.baseText('runData.trimmedData.title')"
+			>
+				{{ i18n.baseText('runData.trimmedData.message') }}
+			</NDVEmptyState>
 
 			<div v-else-if="hasNodeRun && isArtificialRecoveredEventItem" :class="$style.center">
 				<slot name="recovered-artificial-output-data"></slot>
 			</div>
 
 			<div v-else-if="hasNodeRun && hasRunError" :class="$style.stretchVertically">
-				<N8nText v-if="isPaneTypeInput" :class="$style.center" size="large" tag="p" bold>
-					{{
+				<NDVEmptyState
+					v-if="isPaneTypeInput"
+					:class="$style.center"
+					:title="
 						i18n.baseText('nodeErrorView.inputPanel.previousNodeError.title', {
 							interpolate: { nodeName: node?.name ?? '' },
 						})
-					}}
-				</N8nText>
+					"
+				/>
 				<div v-else-if="$slots['content']">
 					<NodeErrorView
 						v-if="workflowRunErrorAsNodeError"
@@ -1776,15 +1777,13 @@ defineExpose({ enterEditMode });
 				:class="$style.center"
 			>
 				<NDVEmptyState v-if="search" :title="i18n.baseText('ndv.search.noMatch.title')">
-					<template #description>
-						<I18nT keypath="ndv.search.noMatch.description" tag="span" scope="global">
-							<template #link>
-								<a href="#" @click="onSearchClear">
-									{{ i18n.baseText('ndv.search.noMatch.description.link') }}
-								</a>
-							</template>
-						</I18nT>
-					</template>
+					<I18nT keypath="ndv.search.noMatch.description" tag="span" scope="global">
+						<template #link>
+							<a href="#" @click="onSearchClear">
+								{{ i18n.baseText('ndv.search.noMatch.description.link') }}
+							</a>
+						</template>
+					</I18nT>
 				</NDVEmptyState>
 				<N8nText v-else>
 					{{ noDataInBranchMessage }}
@@ -1803,16 +1802,15 @@ defineExpose({ enterEditMode });
 				data-test-id="ndv-data-size-warning"
 				:class="$style.center"
 			>
-				<N8nText :bold="true" color="text-dark" size="large">{{ tooMuchDataTitle }}</N8nText>
-				<N8nText align="center" tag="div"
-					><span
+				<NDVEmptyState :title="tooMuchDataTitle">
+					<span
 						v-n8n-html="
 							i18n.baseText('ndv.output.tooMuchData.message', {
 								interpolate: { size: dataSizeInMB },
 							})
 						"
-					></span
-				></N8nText>
+					/>
+				</NDVEmptyState>
 
 				<N8nButton
 					outline
@@ -1853,15 +1851,13 @@ defineExpose({ enterEditMode });
 				:class="$style.center"
 				:title="i18n.baseText('ndv.search.noMatch.title')"
 			>
-				<template #description>
-					<I18nT keypath="ndv.search.noMatch.description" tag="span" scope="global">
-						<template #link>
-							<a href="#" @click="onSearchClear">
-								{{ i18n.baseText('ndv.search.noMatch.description.link') }}
-							</a>
-						</template>
-					</I18nT>
-				</template>
+				<I18nT keypath="ndv.search.noMatch.description" tag="span" scope="global">
+					<template #link>
+						<a href="#" @click="onSearchClear">
+							{{ i18n.baseText('ndv.search.noMatch.description.link') }}
+						</a>
+					</template>
+				</I18nT>
 			</NDVEmptyState>
 
 			<Suspense v-else-if="hasNodeRun && displayMode === 'table' && node">

--- a/packages/frontend/editor-ui/src/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/components/RunData.vue
@@ -1779,7 +1779,7 @@ defineExpose({ enterEditMode });
 				<NDVEmptyState v-if="search" :title="i18n.baseText('ndv.search.noMatch.title')">
 					<I18nT keypath="ndv.search.noMatch.description" tag="span" scope="global">
 						<template #link>
-							<a href="#" @click="onSearchClear">
+							<a href="#" @click.prevent="onSearchClear">
 								{{ i18n.baseText('ndv.search.noMatch.description.link') }}
 							</a>
 						</template>

--- a/packages/frontend/editor-ui/src/components/VirtualSchema.vue
+++ b/packages/frontend/editor-ui/src/components/VirtualSchema.vue
@@ -439,15 +439,13 @@ const onDragEnd = (el: HTMLElement) => {
 		]"
 	>
 		<NDVEmptyState v-if="noSearchResults" :title="i18n.baseText('ndv.search.noNodeMatch.title')">
-			<template #description>
-				<I18nT keypath="ndv.search.noMatchSchema.description" tag="span" scope="global">
-					<template #link>
-						<a href="#" @click="emit('clear:search')">
-							{{ i18n.baseText('ndv.search.noMatchSchema.description.link') }}
-						</a>
-					</template>
-				</I18nT>
-			</template>
+			<I18nT keypath="ndv.search.noMatchSchema.description" tag="span" scope="global">
+				<template #link>
+					<a href="#" @click="emit('clear:search')">
+						{{ i18n.baseText('ndv.search.noMatchSchema.description.link') }}
+					</a>
+				</template>
+			</I18nT>
 		</NDVEmptyState>
 
 		<Draggable

--- a/packages/frontend/editor-ui/src/components/VirtualSchema.vue
+++ b/packages/frontend/editor-ui/src/components/VirtualSchema.vue
@@ -441,7 +441,7 @@ const onDragEnd = (el: HTMLElement) => {
 		<NDVEmptyState v-if="noSearchResults" :title="i18n.baseText('ndv.search.noNodeMatch.title')">
 			<I18nT keypath="ndv.search.noMatchSchema.description" tag="span" scope="global">
 				<template #link>
-					<a href="#" @click="emit('clear:search')">
+					<a href="#" @click.prevent="emit('clear:search')">
 						{{ i18n.baseText('ndv.search.noMatchSchema.description.link') }}
 					</a>
 				</template>

--- a/packages/frontend/editor-ui/src/features/logs/components/LogsViewRunData.vue
+++ b/packages/frontend/editor-ui/src/features/logs/components/LogsViewRunData.vue
@@ -109,16 +109,13 @@ function handleChangeDisplayMode(value: IRunDataDisplayMode) {
 		</template>
 
 		<template #no-output-data>
-			<N8nText :bold="true" color="text-dark" size="large">
-				{{ locale.baseText('ndv.output.noOutputData.title') }}
-			</N8nText>
+			<NDVEmptyState :title="locale.baseText('ndv.output.noOutputData.title')" />
 		</template>
 
 		<template #node-waiting>
-			<N8nText :bold="true" color="text-dark" size="large">
-				{{ locale.baseText('ndv.output.waitNodeWaiting.title') }}
-			</N8nText>
-			<N8nText v-n8n-html="waitingNodeTooltip(logEntry.node)"></N8nText>
+			<NDVEmptyState :title="locale.baseText('ndv.output.waitNodeWaiting.title')" wide>
+				<span v-n8n-html="waitingNodeTooltip(logEntry.node)" />
+			</NDVEmptyState>
 		</template>
 
 		<template v-if="isMultipleInput" #content>

--- a/packages/frontend/editor-ui/src/features/logs/components/LogsViewRunData.vue
+++ b/packages/frontend/editor-ui/src/features/logs/components/LogsViewRunData.vue
@@ -11,6 +11,7 @@ import { I18nT } from 'vue-i18n';
 import { PopOutWindowKey } from '@/constants';
 import { isSubNodeLog } from '../logs.utils';
 import RunDataItemCount from '@/components/RunDataItemCount.vue';
+import NDVEmptyState from '@/components/NDVEmptyState.vue';
 
 const { title, logEntry, paneType, collapsingTableColumnName } = defineProps<{
 	title: string;


### PR DESCRIPTION
## Summary

This PR makes adjustments to styling of messages in input/output panel when data is not shown for whatever reason, by consistently using NDVEmptyState component.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/CAT-1440/feature-ndv-in-focus-panel-review-batch-21

| | Before | After |
|---|--------|--------|
| Waiting for input | <img width="535" height="792" alt="Screenshot 2025-09-19 at 14 07 11" src="https://github.com/user-attachments/assets/36199a63-1c0d-4c2b-be62-1e70d2ced35c" /> | <img width="536" height="806" alt="Screenshot 2025-09-19 at 14 07 22" src="https://github.com/user-attachments/assets/4f8d11d2-8e32-45f4-b1b6-e1d8f4dd5131" /> | 


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
