### PR TITLE
fix(Salesforce Trigger Node): Cleanup logic update

### DIFF
--- a/packages/nodes-base/nodes/Salesforce/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Salesforce/GenericFunctions.ts
@@ -274,13 +274,14 @@ export function filterAndManageProcessedItems(
 		if (!processedIdsSet.has(itemId)) {
 			newItems.push(item);
 			newItemIds.push(itemId);
-		} else {
-			processedIdsSet.delete(itemId);
 		}
 	}
 
 	const remainingProcessedIds = Array.from(processedIdsSet);
 	const updatedProcessedIds = remainingProcessedIds.concat(newItemIds);
 
-	return { newItems, updatedProcessedIds };
+	const MAX_IDS = 10000;
+	const trimmedProcessedIds = updatedProcessedIds.slice(-MAX_IDS);
+
+	return { newItems, updatedProcessedIds: trimmedProcessedIds };
 }


### PR DESCRIPTION
## Summary

`safetyMarginMinutes` could lead to duplicate events if entries deleted from `processedIdsSet`, keep 10000 latest processed ids instead

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-3435/salesforce-trigger-polling-logic-misses-objects
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
