### PR TITLE
fix(Evaluation Trigger Node): Await for getDataTableFilter which is now async (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Evaluation/EvaluationTrigger/EvaluationTrigger.node.ee.ts
+++ b/packages/nodes-base/nodes/Evaluation/EvaluationTrigger/EvaluationTrigger.node.ee.ts
@@ -207,7 +207,7 @@ export class EvaluationTrigger implements INodeType {
 			}) as string;
 			const dataTableProxy = await this.helpers.getDataStoreProxy(dataTableId);
 
-			const filter = getDataTableFilter(this, 0);
+			const filter = await getDataTableFilter(this, 0);
 
 			const { data, count } = await dataTableProxy.getManyRowsAndCount({
 				skip: currentIndex,
@@ -330,7 +330,7 @@ export class EvaluationTrigger implements INodeType {
 						}) as string;
 						const dataTableProxy = await this.helpers.getDataStoreProxy(dataTableId);
 
-						const filter = getDataTableFilter(this, 0);
+						const filter = await getDataTableFilter(this, 0);
 						const { data } = await dataTableProxy.getManyRowsAndCount({
 							skip: 0,
 							take: maxRows,

--- a/packages/nodes-base/nodes/Evaluation/test/EvaluationTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Evaluation/test/EvaluationTrigger.node.test.ts
@@ -14,7 +14,7 @@ describe('Evaluation Trigger Node', () => {
 		getNode: jest.fn().mockReturnValue({ typeVersion: 4.6 }),
 	});
 
-	let mockDataTable: { getManyRowsAndCount: jest.Mock };
+	let mockDataTable: { getManyRowsAndCount: jest.Mock; getColumns: jest.Mock };
 
 	describe('execute', () => {
 		describe('without filters', () => {
@@ -329,6 +329,10 @@ describe('Evaluation Trigger Node', () => {
 							{ id: 2, field1: 'value3', field2: 'value4' },
 						],
 					}),
+					getColumns: jest.fn().mockResolvedValue([
+						{ name: 'field1', type: 'string' },
+						{ name: 'field2', type: 'string' },
+					]),
 				};
 
 				mockExecuteFunctions = mockDeep<IExecuteFunctions>({


### PR DESCRIPTION
## Summary

My previous merge was still based on code where `getDataTableFilter` wasn't async.

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
