### PR TITLE
fix(Postgres Node): Fix citext and user defined field type mapping

### DIFF
--- a/packages/nodes-base/nodes/Postgres/test/v2/resourceMapping.test.ts
+++ b/packages/nodes-base/nodes/Postgres/test/v2/resourceMapping.test.ts
@@ -2,6 +2,8 @@ import type { MockProxy } from 'jest-mock-extended';
 import { mock } from 'jest-mock-extended';
 import type { ILoadOptionsFunctions } from 'n8n-workflow';
 
+import type { ColumnInfo } from '../../v2/helpers/interfaces';
+import { getEnums, getTableSchema } from '../../v2/helpers/utils';
 import { getMappingColumns } from '../../v2/methods/resourceMapping';
 
 jest.mock('../../transport', () => {
@@ -16,73 +18,184 @@ jest.mock('../../v2/helpers/utils', () => {
 	const originalModule = jest.requireActual('../../v2/helpers/utils');
 	return {
 		...originalModule,
-		getEnums: jest.fn(() => []),
+		getEnums: jest.fn(() => ({})),
 		getEnumValues: jest.fn(),
-		getTableSchema: jest.fn(() => [
-			{
-				column_name: 'id',
-				data_type: 'bigint',
-				is_nullable: 'NO',
-				udt_name: 'int8',
-				column_default: null,
-				identity_generation: 'BY DEFAULT',
-				is_generated: 'NEVER',
-			},
-			{
-				column_name: 'name',
-				data_type: 'text',
-				is_nullable: 'YES',
-				udt_name: 'text',
-				column_default: null,
-				identity_generation: null,
-				is_generated: 'NEVER',
-			},
-		]),
+		getTableSchema: jest.fn(),
 	};
 });
 
 describe('Postgres, resourceMapping', () => {
 	let loadOptionsFunctions: MockProxy<ILoadOptionsFunctions>;
 
+	const createColumnData = (
+		columnName: string,
+		dataType: string,
+		overrides: Partial<ColumnInfo> = {},
+	): ColumnInfo => ({
+		column_name: columnName,
+		data_type: dataType,
+		is_nullable: 'NO',
+		udt_name: dataType,
+		column_default: null,
+		is_generated: 'NEVER',
+		...overrides,
+	});
+
 	beforeEach(() => {
 		loadOptionsFunctions = mock<ILoadOptionsFunctions>();
-	});
-
-	afterEach(() => {
-		jest.resetAllMocks();
-	});
-
-	it('should mark id as not required if identity_generation is "BY_DEFAULT"', async () => {
 		loadOptionsFunctions.getCredentials.mockResolvedValue({});
 		loadOptionsFunctions.getNodeParameter.mockReturnValueOnce('public');
 		loadOptionsFunctions.getNodeParameter.mockReturnValueOnce('test_table');
 		loadOptionsFunctions.getNodeParameter.mockReturnValueOnce('insert');
-
-		const fields = await getMappingColumns.call(loadOptionsFunctions);
-
-		expect(fields).toEqual({
-			fields: [
-				{
-					canBeUsedToMatch: true,
-					defaultMatch: true,
-					display: true,
-					displayName: 'id',
-					id: 'id',
-					options: undefined,
-					required: false,
-					type: 'number',
-				},
-				{
-					canBeUsedToMatch: true,
-					defaultMatch: false,
-					display: true,
-					displayName: 'name',
-					id: 'name',
-					options: undefined,
-					required: false,
-					type: 'string',
-				},
-			],
-		});
 	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	test.each([
+		{
+			name: 'should mark id as not required if identity_generation is "BY_DEFAULT"',
+			columnData: createColumnData('id', 'bigint', {
+				udt_name: 'int8',
+				identity_generation: 'BY DEFAULT',
+			}),
+			expectedType: 'number',
+			expectedRequired: false,
+			expectedDefaultMatch: true,
+		},
+		{
+			name: 'should map citext to string type',
+			columnData: createColumnData('email', 'citext'),
+			expectedType: 'string',
+			expectedRequired: true,
+			expectedDefaultMatch: false,
+		},
+		{
+			name: 'should map varchar to string type',
+			columnData: createColumnData('name', 'varchar', { is_nullable: 'YES' }),
+			expectedType: 'string',
+			expectedRequired: false,
+			expectedDefaultMatch: false,
+		},
+		{
+			name: 'should map integer to number type',
+			columnData: createColumnData('count', 'integer', { udt_name: 'int4' }),
+			expectedType: 'number',
+			expectedRequired: true,
+			expectedDefaultMatch: false,
+		},
+		{
+			name: 'should map boolean to boolean type',
+			columnData: createColumnData('is_active', 'boolean', {
+				udt_name: 'bool',
+				column_default: 'false',
+			}),
+			expectedType: 'boolean',
+			expectedRequired: false, // has default
+			expectedDefaultMatch: false,
+		},
+		{
+			name: 'should map timestamp to dateTime type',
+			columnData: createColumnData('created_at', 'timestamp'),
+			expectedType: 'dateTime',
+			expectedRequired: true,
+			expectedDefaultMatch: false,
+		},
+		{
+			name: 'should map json to object type',
+			columnData: createColumnData('metadata', 'json', { is_nullable: 'YES' }),
+			expectedType: 'object',
+			expectedRequired: false,
+			expectedDefaultMatch: false,
+		},
+		{
+			name: 'should map USER-DEFINED enum to options type',
+			columnData: createColumnData('status', 'USER-DEFINED', { udt_name: 'status_enum' }),
+			expectedType: 'options',
+			expectedRequired: true,
+			expectedDefaultMatch: false,
+			isEnum: true,
+		},
+		{
+			name: 'should map unknown USER-DEFINED type to string by default',
+			columnData: createColumnData('custom_field', 'USER-DEFINED', { udt_name: 'unknown_type' }),
+			expectedType: 'string',
+			expectedRequired: true,
+			expectedDefaultMatch: false,
+		},
+		{
+			name: 'should map uuid to string type',
+			columnData: createColumnData('user_id', 'uuid'),
+			expectedType: 'string',
+			expectedRequired: true,
+			expectedDefaultMatch: false,
+		},
+		{
+			name: 'should map PostGIS geometry to string type',
+			columnData: createColumnData('location', 'USER-DEFINED', { udt_name: 'geometry' }),
+			expectedType: 'string',
+			expectedRequired: true,
+			expectedDefaultMatch: false,
+		},
+		{
+			name: 'should map inet address to string type',
+			columnData: createColumnData('ip_address', 'inet'),
+			expectedType: 'string',
+			expectedRequired: true,
+			expectedDefaultMatch: false,
+		},
+		{
+			name: 'should map hstore to object type',
+			columnData: createColumnData('attributes', 'USER-DEFINED', { udt_name: 'hstore' }),
+			expectedType: 'object',
+			expectedRequired: true,
+			expectedDefaultMatch: false,
+		},
+		{
+			name: 'should map range types to string type',
+			columnData: createColumnData('price_range', 'USER-DEFINED', { udt_name: 'numrange' }),
+			expectedType: 'string',
+			expectedRequired: true,
+			expectedDefaultMatch: false,
+		},
+		{
+			name: 'should map unknown data type to string by default',
+			columnData: createColumnData('unknown_field', 'unknown_postgres_type', {
+				udt_name: 'unknown',
+			}),
+			expectedType: 'string',
+			expectedRequired: true,
+			expectedDefaultMatch: false,
+		},
+	])(
+		'$name',
+		async ({ columnData, expectedType, expectedRequired, expectedDefaultMatch, isEnum }) => {
+			jest.mocked(getTableSchema).mockResolvedValueOnce([columnData]);
+
+			// Mock enum data if this test case represents an enum
+			if (isEnum && columnData.udt_name) {
+				jest
+					.mocked(getEnums)
+					.mockResolvedValueOnce({ [columnData.udt_name]: ['active', 'inactive'] });
+			}
+
+			const fields = await getMappingColumns.call(loadOptionsFunctions);
+
+			expect(fields).toEqual({
+				fields: [
+					{
+						canBeUsedToMatch: true,
+						defaultMatch: expectedDefaultMatch,
+						display: true,
+						displayName: columnData.column_name,
+						id: columnData.column_name,
+						options: undefined,
+						required: expectedRequired,
+						type: expectedType,
+					},
+				],
+			});
+		},
+	);
 });

--- a/packages/nodes-base/nodes/Postgres/v2/helpers/interfaces.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/helpers/interfaces.ts
@@ -18,7 +18,7 @@ export type ColumnInfo = {
 	udt_name?: string;
 	column_default?: string | null;
 	is_generated?: 'ALWAYS' | 'NEVER';
-	identity_generation?: 'ALWAYS' | 'NEVER';
+	identity_generation?: 'ALWAYS' | 'NEVER' | 'BY DEFAULT';
 };
 export type EnumInfo = {
 	typname: string;


### PR DESCRIPTION
## Summary

  - Fix `citext` columns showing as dropdowns instead of text inputs
  - Add support for common PostgreSQL extensions
  - Improve user defined type and enum detection
  - Optimize type mapping performance, reduce loops

## Related Linear tickets, Github issues, and Community forum posts

fixes #19670

https://linear.app/n8n/issue/NODE-3659/community-issue-postgres-node-definies-citext-type-as-list-instead-of

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
