### PR TITLE
chore: Fix Data table name case (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/DataTable/actions/row/insert.operation.ts
+++ b/packages/nodes-base/nodes/DataTable/actions/row/insert.operation.ts
@@ -52,7 +52,7 @@ export async function execute(
 	if (optimizeBulkEnabled) {
 		// This function is always called by index, so we inherently cannot operate in bulk
 		this.addExecutionHints({
-			message: 'Unable to optimize bulk insert due to expression in Data Table ID ',
+			message: 'Unable to optimize bulk insert due to expression in Data table ID ',
 			location: 'outputPane',
 		});
 		const json = await dataStoreProxy.insertRows([row], 'count');

--- a/packages/nodes-base/nodes/Evaluation/Evaluation/Description.node.ts
+++ b/packages/nodes-base/nodes/Evaluation/Evaluation/Description.node.ts
@@ -483,9 +483,10 @@ export const sourcePicker: INodeProperties = {
 	type: 'options',
 	options: [
 		{
-			name: 'Data Table',
+			// eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased
+			name: 'Data table',
 			value: 'dataTable',
-			description: 'Load the test dataset from a local Data Table',
+			description: 'Load the test dataset from a local Data table',
 		},
 		{
 			name: 'Google Sheets',


### PR DESCRIPTION
## Summary

There was some discussion on how `Data table` should be written in the UI - seems like `Data Table` was wrong so lets not use that as the source picker's value.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
