### PR TITLE
Fixed query params

### DIFF
--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -384,6 +384,25 @@ export class HttpRequestV3 implements INodeType {
 					});
 				}
 
+				const parametersToKeyValueQuery = async (
+					accumulator: { [key: string]: any },
+					cur: { name: string; value: string; parameterType?: string; inputDataFieldName?: string },
+				) => {
+					const key = cur.name;
+					const isArray = key.endsWith('[]');
+					const normalizedKey = isArray ? key.slice(0, -2) : key;
+					if (accumulator[normalizedKey] === undefined) {
+						accumulator[normalizedKey] = isArray ? [cur.value] : cur.value;
+					} else {
+						if (Array.isArray(accumulator[normalizedKey])) {
+							accumulator[normalizedKey].push(cur.value);
+						} else {
+							accumulator[normalizedKey] = [accumulator[normalizedKey], cur.value];
+						}
+					}
+					return accumulator;
+				};
+
 				const parametersToKeyValue = async (
 					accumulator: { [key: string]: any },
 					cur: { name: string; value: string; parameterType?: string; inputDataFieldName?: string },
@@ -487,7 +506,7 @@ export class HttpRequestV3 implements INodeType {
 				// Get parameters defined in the UI
 				if (sendQuery && queryParameters) {
 					if (specifyQuery === 'keypair') {
-						requestOptions.qs = await reduceAsync(queryParameters, parametersToKeyValue);
+						requestOptions.qs = await reduceAsync(queryParameters, parametersToKeyValueQuery);
 					} else if (specifyQuery === 'json') {
 						// query is specified using JSON
 						try {


### PR DESCRIPTION
## Summary
fix(HttpRequestV3) : Support multiple query parameters with same name.
-Fixed an issue where only the last query parameter with the same name was sent, overwriting previous values.
Added fucntion "parametersToKeyValueFix" to correctly aggregate multiple parameters with the same name into arrays, ensuring all values are sent.

Request :
<img width="609" height="884" alt="Screenshot 2025-09-19 201423" src="https://github.com/user-attachments/assets/cec4269c-db70-43d6-b880-7d4afbd05020" />


Before:
<img width="1645" height="363" alt="Screenshot 2025-09-19 201114" src="https://github.com/user-attachments/assets/f8a59b9b-9b38-450c-973a-dc03a3649bcf" />


After : 
<img width="1608" height="288" alt="Screenshot 2025-09-19 201133" src="https://github.com/user-attachments/assets/d244e98c-6367-4a72-9c09-8056dd5d2f9e" />


Fixes #19727 


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
