### PR TITLE
fix: handle query params with [] correctly for http request (fixes #1…

### DIFF
--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -389,6 +389,7 @@ export class HttpRequestV3 implements INodeType {
 				) => {
 					const isQueryArrayType = cur.name.endsWith('[]');
 					const name = isQueryArrayType ? cur.name.slice(0, -2) : cur.name;
+					if (name === '') return accumulator;
 					if (cur.parameterType === 'formBinaryData') {
 						if (!cur.inputDataFieldName) return accumulator;
 						const binaryData = this.helpers.assertBinaryData(itemIndex, cur.inputDataFieldName);

--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -388,6 +388,7 @@ export class HttpRequestV3 implements INodeType {
 					accumulator: { [key: string]: any },
 					cur: { name: string; value: string; parameterType?: string; inputDataFieldName?: string },
 				) => {
+					const name = cur.name.endsWith('[]') ? cur.name.slice(0, -2) : cur.name;
 					if (cur.parameterType === 'formBinaryData') {
 						if (!cur.inputDataFieldName) return accumulator;
 						const binaryData = this.helpers.assertBinaryData(itemIndex, cur.inputDataFieldName);
@@ -399,7 +400,7 @@ export class HttpRequestV3 implements INodeType {
 							uploadData = Buffer.from(itemBinaryData.data, BINARY_ENCODING);
 						}
 
-						accumulator[cur.name] = {
+						accumulator[name] = {
 							value: uploadData,
 							options: {
 								filename: binaryData.fileName,
@@ -408,7 +409,13 @@ export class HttpRequestV3 implements INodeType {
 						};
 						return accumulator;
 					}
-					accumulator[cur.name] = cur.value;
+					if (Array.isArray(accumulator[name])) {
+						accumulator[name].push(cur.value);
+						return accumulator;
+					}
+					accumulator[name]
+						? (accumulator[name] = [accumulator[name], cur.value])
+						: (accumulator[name] = cur.value);
 					return accumulator;
 				};
 

--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -26,9 +26,8 @@ import {
 } from 'n8n-workflow';
 import type { Readable } from 'stream';
 
-import { keysToLowercase } from '@utils/utilities';
-
 import { mainProperties } from './Description';
+import { keysToLowercase } from '../../../utils/utilities';
 import type { BodyParameter, IAuthDataSanitizeKeys } from '../GenericFunctions';
 import {
 	binaryContentTypes,

--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -413,7 +413,7 @@ export class HttpRequestV3 implements INodeType {
 						accumulator[name].push(cur.value);
 						return accumulator;
 					}
-					accumulator[name]
+					accumulator[name] !== undefined
 						? (accumulator[name] = [accumulator[name], cur.value])
 						: (accumulator[name] = cur.value);
 					return accumulator;

--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -388,7 +388,8 @@ export class HttpRequestV3 implements INodeType {
 					accumulator: { [key: string]: any },
 					cur: { name: string; value: string; parameterType?: string; inputDataFieldName?: string },
 				) => {
-					const name = cur.name.endsWith('[]') ? cur.name.slice(0, -2) : cur.name;
+					const isQueryArrayType = cur.name.endsWith('[]');
+					const name = isQueryArrayType ? cur.name.slice(0, -2) : cur.name;
 					if (cur.parameterType === 'formBinaryData') {
 						if (!cur.inputDataFieldName) return accumulator;
 						const binaryData = this.helpers.assertBinaryData(itemIndex, cur.inputDataFieldName);
@@ -409,13 +410,13 @@ export class HttpRequestV3 implements INodeType {
 						};
 						return accumulator;
 					}
-					if (Array.isArray(accumulator[name])) {
-						accumulator[name].push(cur.value);
+					if (isQueryArrayType) {
+						Array.isArray(accumulator[name])
+							? accumulator[name].push(cur.value)
+							: (accumulator[name] = [cur.value]);
 						return accumulator;
 					}
-					accumulator[name] !== undefined
-						? (accumulator[name] = [accumulator[name], cur.value])
-						: (accumulator[name] = cur.value);
+					accumulator[name] = cur.value;
 					return accumulator;
 				};
 


### PR DESCRIPTION
…9727)

## Summary


fix: handle query parameters with same name and suffix []    (#19727 )
<img width="392" height="766" alt="Screenshot 2025-09-19 at 11 31 54 PM" src="https://github.com/user-attachments/assets/bd454634-e287-4637-ac15-162ed2131562" />
<img width="478" height="116" alt="Screenshot 2025-09-19 at 11 32 14 PM" src="https://github.com/user-attachments/assets/9071b8c4-f46f-4fc7-a17b-87424ba0e808" />



<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
