### PR TITLE
fix(Discord Node): Handle undefined error.cause in parseDiscordError

### DIFF
--- a/packages/nodes-base/nodes/Discord/test/v2/utils.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/utils.test.ts
@@ -7,6 +7,7 @@ import {
 	prepareEmbeds,
 	checkAccessToGuild,
 	setupChannelGetter,
+	parseDiscordError,
 } from '../../v2/helpers/utils';
 
 const node: INode = {
@@ -152,5 +153,32 @@ describe('Test Discord > setupChannelGetter & checkAccessToChannel', () => {
 		const getChannel = await setupChannelGetter.call(fakeExecuteFunction('botToken'), userGuilds);
 		const channelId = await getChannel(0);
 		expect(channelId).toBe('42');
+	});
+});
+
+describe('Test Discord > parseDiscordError', () => {
+	const mockExecutionFunctions = {
+		getNode: () => node,
+	} as IExecuteFunctions;
+
+	it('should handle error with undefined cause without crashing', () => {
+		const error = {
+			message: 'Network error',
+		};
+
+		expect(() => {
+			parseDiscordError.call(mockExecutionFunctions, error, 0);
+		}).not.toThrow('Cannot read properties of undefined');
+	});
+
+	it('should handle error with null cause without crashing', () => {
+		const error = {
+			message: 'API error',
+			cause: null,
+		};
+
+		expect(() => {
+			parseDiscordError.call(mockExecutionFunctions, error, 0);
+		}).not.toThrow();
 	});
 });

--- a/packages/nodes-base/nodes/Discord/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Discord/v2/helpers/utils.ts
@@ -29,7 +29,7 @@ export const createSimplifyFunction =
 	};
 
 export function parseDiscordError(this: IExecuteFunctions, error: any, itemIndex = 0) {
-	let errorData = error.cause.error;
+	let errorData = error?.cause?.error;
 	const errorOptions: IDataObject = { itemIndex };
 
 	if (!errorData && error.description) {


### PR DESCRIPTION
## Summary
Fixes Discord node crash when `error.cause` is undefined in webhook error handling.

**Problem:** The `parseDiscordError` function attempts to access `error.cause.error` without checking if `error.cause` exists, causing "Cannot read properties of undefined (reading 'error')" crashes.

**Solution:** Added optional chaining (`error?.cause?.error`) to safely access the nested property.

**Testing:** Added unit tests to verify the fix handles undefined/null `cause` scenarios without crashing while maintaining existing error handling functionality.

## Related Linear tickets, Github issues, and Community forum posts
Fixes #19741

## Review / Merge checklist
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with release/backport (if the PR is an urgent fix that needs to be backported)