### PR TITLE
Fixed markdown to html node

### DIFF
--- a/packages/nodes-base/nodes/Markdown/Markdown.node.ts
+++ b/packages/nodes-base/nodes/Markdown/Markdown.node.ts
@@ -591,8 +591,11 @@ export class Markdown implements INodeType {
 
 				if (mode === 'markdownToHtml') {
 					let markdown = this.getNodeParameter('markdown', i) as string;
-					// fixed markdown indentation to get expected results for lists and sublists
-					markdown = markdown.replaceAll('  ', '    ');
+					// only changes 2 space indentation for lists and sublists for expected results
+					markdown = markdown.replace(/^(\s*)- /gm, (match, leadingSpaces: string) => {
+    				const normalizedSpaces = leadingSpaces.replace(/ {2}/g, '    ');
+    				return normalizedSpaces + '- ';
+					});
 					const destinationKey = this.getNodeParameter('destinationKey', i) as string;
 					const options = this.getNodeParameter('options', i);
 

--- a/packages/nodes-base/nodes/Markdown/Markdown.node.ts
+++ b/packages/nodes-base/nodes/Markdown/Markdown.node.ts
@@ -591,22 +591,32 @@ export class Markdown implements INodeType {
 
 				if (mode === 'markdownToHtml') {
 					let markdown = this.getNodeParameter('markdown', i) as string;
-					// changes 2 space indentation to 4 space for lists and sublists
-					const lines = markdown.split('\n');
+										const lines = markdown.split('\n');
+					let inCodeBlock = false;
+
 					const normalizedLines = lines.map(line => {
-						const match = line.match(/^(\s*)([-*+]|[0-9]+\.)\s+/);
-						if (!match) return line;
+						// Detect fenced code blocks to skip normalization inside them
+						if (/^```/.test(line)) {
+							inCodeBlock = !inCodeBlock;
+							return line;
+						}
+						if (inCodeBlock) return line;
+
+						// Match list items: leading whitespace + marker + at least one space
+						const match = line.match(/^(\s*)([-*+]|[0-9]+[.)])(\s+)(.*)$/);
+						if (!match) return line; // not a list item
 
 						const leadingSpaces = match[1].length;
-						const listMarker = match[2];
+						const marker = match[2];
+						const content = match[4];
 
-						// Calculate nesting level based on 2-space indent
+						// Determine nesting level based on 2-space indent
 						const level = Math.floor(leadingSpaces / 2);
 
 						// Normalize to 4 spaces per level
 						const normalizedIndent = '    '.repeat(level);
 
-						return normalizedIndent + listMarker + line.slice(match[0].length);
+						return normalizedIndent + marker + ' ' + content;
 					});
 
 					const normalizedMarkdown = normalizedLines.join('\n');

--- a/packages/nodes-base/nodes/Markdown/Markdown.node.ts
+++ b/packages/nodes-base/nodes/Markdown/Markdown.node.ts
@@ -591,6 +591,8 @@ export class Markdown implements INodeType {
 
 				if (mode === 'markdownToHtml') {
 					const markdown = this.getNodeParameter('markdown', i) as string;
+					// fixed markdown indentation to get expected results for lists and sublists
+					markdown.replaceAll('  ', '    ');
 					const destinationKey = this.getNodeParameter('destinationKey', i) as string;
 					const options = this.getNodeParameter('options', i);
 

--- a/packages/nodes-base/nodes/Markdown/Markdown.node.ts
+++ b/packages/nodes-base/nodes/Markdown/Markdown.node.ts
@@ -590,9 +590,9 @@ export class Markdown implements INodeType {
 				}
 
 				if (mode === 'markdownToHtml') {
-					const markdown = this.getNodeParameter('markdown', i) as string;
+					let markdown = this.getNodeParameter('markdown', i) as string;
 					// fixed markdown indentation to get expected results for lists and sublists
-					markdown.replaceAll('  ', '    ');
+					markdown = markdown.replaceAll('  ', '    ');
 					const destinationKey = this.getNodeParameter('destinationKey', i) as string;
 					const options = this.getNodeParameter('options', i);
 


### PR DESCRIPTION
## Summary

Fixed an issue in the Markdown → HTML converter where list indentation wasn’t being parsed correctly.
The bug was caused by inconsistent spacing in Markdown lists.
Solution: replaced double spaces with 4 spaces to properly render lists and sublists.

```ts
if (mode === 'markdownToHtml') {
	let markdown = this.getNodeParameter('markdown', i) as string;
	const lines = markdown.split('\n');

	let inFencedCodeBlock = false;

	const normalizedLines = lines.map((line) => {
		// Detect fenced code blocks, allowing leading indentation
		if (/^(\s*)```/.test(line)) {
			inFencedCodeBlock = !inFencedCodeBlock;
			return line;
		}

		// Detect indented code blocks (4+ spaces) outside fenced blocks
		const isIndentedCodeBlock = !inFencedCodeBlock && line.startsWith('    ');
		if (inFencedCodeBlock || isIndentedCodeBlock) {
			return line; // skip normalization inside code blocks
		}

		// Match all list types: -, *, +, numbered (1. or 1))
		const match = line.match(/^(\s*)([-*+]|[0-9]+[.)])(\s+)(.*)$/);
		if (!match) return line;

		const leadingSpaces = match[1].length;
		const marker = match[2];
		const content = match[4];

		// Calculate nesting level based on 2-space indent
		const level = Math.floor(leadingSpaces / 2);

		// Normalize to 4 spaces per level
		const normalizedIndent = '    '.repeat(level);

		return normalizedIndent + marker + ' ' + content;
	});

	const normalizedMarkdown = normalizedLines.join('\n');
	const destinationKey = this.getNodeParameter('destinationKey', i) as string;
	const options = this.getNodeParameter('options', i);

	const converter = new Converter();

	Object.keys(options).forEach((key) => converter.setOption(key, options[key]));
	const htmlFromMarkdown = converter.makeHtml(normalizedMarkdown);

	const newItem = deepCopy(items[i].json);
	set(newItem, destinationKey, htmlFromMarkdown);

	returnData.push(newItem);
}
```

- **How to test:**
    - Create a Markdown list with nested sublists using 2 spaces for indentation.
    - Verify that after conversion, the lists and sublists render correctly in HTML.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #19414


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
