### PR TITLE
feat(SendGrid): Add region selection for API requests and update vers…

### DIFF
--- a/packages/nodes-base/nodes/SendGrid/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/SendGrid/GenericFunctions.ts
@@ -16,7 +16,7 @@ export async function sendGridApiRequest(
 	qs: IDataObject = {},
 	option: IDataObject = {},
 ): Promise<any> {
-	const region = this.getNodeParameter('region', 'us') as string;
+	const region = this.getNodeParameter('region', 0, 'us') as string;
 	const host = region === 'us' ? 'api.sendgrid.com/v3' : 'api.eu.sendgrid.com/v3';
 
 	const options: IRequestOptions = {

--- a/packages/nodes-base/nodes/SendGrid/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/SendGrid/GenericFunctions.ts
@@ -16,7 +16,8 @@ export async function sendGridApiRequest(
 	qs: IDataObject = {},
 	option: IDataObject = {},
 ): Promise<any> {
-	const host = 'api.sendgrid.com/v3';
+	const region = this.getNodeParameter('region', 'us') as string;
+	const host = region === 'us' ? 'api.sendgrid.com/v3' : 'api.eu.sendgrid.com/v3';
 
 	const options: IRequestOptions = {
 		method,

--- a/packages/nodes-base/nodes/SendGrid/SendGrid.node.ts
+++ b/packages/nodes-base/nodes/SendGrid/SendGrid.node.ts
@@ -23,7 +23,7 @@ export class SendGrid implements INodeType {
 		name: 'sendGrid',
 		icon: 'file:sendGrid.svg',
 		group: ['transform'],
-		version: 1,
+		version: 2,
 		subtitle: '={{$parameter["operation"] + ":" + $parameter["resource"]}}',
 		description: 'Consume SendGrid API',
 		defaults: {
@@ -41,6 +41,23 @@ export class SendGrid implements INodeType {
 		properties: [
 			// Node properties which the user gets displayed and
 			// can change on the node.
+			{
+				displayName: 'Region',
+				name: 'region',
+				type: 'options',
+				options: [
+					{
+						name: 'US',
+						value: 'us',
+					},
+					{
+						name: 'EU',
+						value: 'eu',
+					},
+				],
+				default: 'us',
+				description: 'The regional API to use',
+			},
 			{
 				displayName: 'Resource',
 				name: 'resource',


### PR DESCRIPTION
## Summary

<img width="1687" height="845" alt="Image" src="https://github.com/user-attachments/assets/a499ee9e-d4b7-4a61-b254-ae79a9cd26b1" />

This PR adds configurable region selection for SendGrid API requests, allowing users to choose between US and EU endpoints. Previously, the SendGrid integration was hardcoded to use only the US API endpoint (`api.sendgrid.com`), which prevented users with European data residency requirements from using their EU SendGrid accounts.

### Changes Made:
- Added a "Region" parameter to the SendGrid node with options for US and EU
- Updated the `sendGridApiRequest` function to dynamically select the appropriate API endpoint based on the selected region:
  - US region: `api.sendgrid.com/v3`
  - EU region: `api.eu.sendgrid.com/v3`
- Bumped the SendGrid node version from 1 to 2 to reflect this breaking change

### Testing:
Users can now:
1. Select their preferred region (US or EU) in the SendGrid node
2. Use EU SendGrid accounts with the correct API endpoint
3. Continue using US SendGrid accounts as before

## Related Linear tickets, Github issues, and Community forum posts

Fixes #19657

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

---

**Additional Notes:**
- This is a breaking change since existing workflows will need to specify the region parameter
- The default region is set to 'us' to maintain backward compatibility for existing workflows
- The implementation follows the same pattern used by other nodes like Customer.io for region selection