### PR TITLE
fix(HTTP Request Node): Handle URLs with leading/trailing whitespace

### DIFF
--- a/packages/nodes-base/nodes/HttpRequest/V1/HttpRequestV1.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V1/HttpRequestV1.node.ts
@@ -678,10 +678,12 @@ export class HttpRequestV1 implements INodeType {
 			const options = this.getNodeParameter('options', itemIndex, {});
 			const url = this.getNodeParameter('url', itemIndex) as string;
 
-			if (!url.startsWith('http://') && !url.startsWith('https://')) {
+			const trimmedUrl = url.trim();
+
+			if (!trimmedUrl.startsWith('http://') && !trimmedUrl.startsWith('https://')) {
 				throw new NodeOperationError(
 					this.getNode(),
-					`Invalid URL: ${url}. URL must start with "http" or "https".`,
+					`Invalid URL: ${trimmedUrl}. URL must start with "http" or "https".`,
 				);
 			}
 
@@ -716,12 +718,12 @@ export class HttpRequestV1 implements INodeType {
 				}
 			};
 
-			if (httpBasicAuth) await checkDomainRestrictions(httpBasicAuth, url);
-			if (httpDigestAuth) await checkDomainRestrictions(httpDigestAuth, url);
-			if (httpHeaderAuth) await checkDomainRestrictions(httpHeaderAuth, url);
-			if (httpQueryAuth) await checkDomainRestrictions(httpQueryAuth, url);
-			if (oAuth1Api) await checkDomainRestrictions(oAuth1Api, url);
-			if (oAuth2Api) await checkDomainRestrictions(oAuth2Api, url);
+			if (httpBasicAuth) await checkDomainRestrictions(httpBasicAuth, trimmedUrl);
+			if (httpDigestAuth) await checkDomainRestrictions(httpDigestAuth, trimmedUrl);
+			if (httpHeaderAuth) await checkDomainRestrictions(httpHeaderAuth, trimmedUrl);
+			if (httpQueryAuth) await checkDomainRestrictions(httpQueryAuth, trimmedUrl);
+			if (oAuth1Api) await checkDomainRestrictions(oAuth1Api, trimmedUrl);
+			if (oAuth2Api) await checkDomainRestrictions(oAuth2Api, trimmedUrl);
 
 			if (
 				itemIndex > 0 &&
@@ -741,7 +743,7 @@ export class HttpRequestV1 implements INodeType {
 			requestOptions = {
 				headers: {},
 				method: requestMethod,
-				uri: url,
+				uri: trimmedUrl,
 				gzip: true,
 				rejectUnauthorized: !this.getNodeParameter('allowUnauthorizedCerts', itemIndex, false),
 			} satisfies IRequestOptions;

--- a/packages/nodes-base/nodes/HttpRequest/V2/HttpRequestV2.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V2/HttpRequestV2.node.ts
@@ -723,10 +723,12 @@ export class HttpRequestV2 implements INodeType {
 			const options = this.getNodeParameter('options', itemIndex, {});
 			const url = this.getNodeParameter('url', itemIndex) as string;
 
-			if (!url.startsWith('http://') && !url.startsWith('https://')) {
+			const trimmedUrl = url.trim();
+
+			if (!trimmedUrl.startsWith('http://') && !trimmedUrl.startsWith('https://')) {
 				throw new NodeOperationError(
 					this.getNode(),
-					`Invalid URL: ${url}. URL must start with "http" or "https".`,
+					`Invalid URL: ${trimmedUrl}. URL must start with "http" or "https".`,
 				);
 			}
 
@@ -761,18 +763,18 @@ export class HttpRequestV2 implements INodeType {
 				}
 			};
 
-			if (httpBasicAuth) await checkDomainRestrictions(httpBasicAuth, url);
-			if (httpBearerAuth) await checkDomainRestrictions(httpBearerAuth, url);
-			if (httpDigestAuth) await checkDomainRestrictions(httpDigestAuth, url);
-			if (httpHeaderAuth) await checkDomainRestrictions(httpHeaderAuth, url);
-			if (httpQueryAuth) await checkDomainRestrictions(httpQueryAuth, url);
-			if (oAuth1Api) await checkDomainRestrictions(oAuth1Api, url);
-			if (oAuth2Api) await checkDomainRestrictions(oAuth2Api, url);
+			if (httpBasicAuth) await checkDomainRestrictions(httpBasicAuth, trimmedUrl);
+			if (httpBearerAuth) await checkDomainRestrictions(httpBearerAuth, trimmedUrl);
+			if (httpDigestAuth) await checkDomainRestrictions(httpDigestAuth, trimmedUrl);
+			if (httpHeaderAuth) await checkDomainRestrictions(httpHeaderAuth, trimmedUrl);
+			if (httpQueryAuth) await checkDomainRestrictions(httpQueryAuth, trimmedUrl);
+			if (oAuth1Api) await checkDomainRestrictions(oAuth1Api, trimmedUrl);
+			if (oAuth2Api) await checkDomainRestrictions(oAuth2Api, trimmedUrl);
 
 			if (nodeCredentialType) {
 				try {
 					const credentialData = await this.getCredentials(nodeCredentialType, itemIndex);
-					await checkDomainRestrictions(credentialData, url, nodeCredentialType);
+					await checkDomainRestrictions(credentialData, trimmedUrl, nodeCredentialType);
 				} catch (error) {
 					if (
 						error.message?.includes('Domain not allowed') ||
@@ -802,7 +804,7 @@ export class HttpRequestV2 implements INodeType {
 			requestOptions = {
 				headers: {},
 				method: requestMethod,
-				uri: url,
+				uri: trimmedUrl,
 				gzip: true,
 				rejectUnauthorized: !this.getNodeParameter('allowUnauthorizedCerts', itemIndex, false),
 			};

--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -184,10 +184,12 @@ export class HttpRequestV3 implements INodeType {
 
 				const url = this.getNodeParameter('url', itemIndex) as string;
 
-				if (!url.startsWith('http://') && !url.startsWith('https://')) {
+				const trimmedUrl = url.trim();
+
+				if (!trimmedUrl.startsWith('http://') && !trimmedUrl.startsWith('https://')) {
 					throw new NodeOperationError(
 						this.getNode(),
-						`Invalid URL: ${url}. URL must start with "http" or "https".`,
+						`Invalid URL: ${trimmedUrl}. URL must start with "http" or "https".`,
 					);
 				}
 
@@ -222,19 +224,19 @@ export class HttpRequestV3 implements INodeType {
 					}
 				};
 
-				if (httpBasicAuth) await checkDomainRestrictions(httpBasicAuth, url);
-				if (httpBearerAuth) await checkDomainRestrictions(httpBearerAuth, url);
-				if (httpDigestAuth) await checkDomainRestrictions(httpDigestAuth, url);
-				if (httpHeaderAuth) await checkDomainRestrictions(httpHeaderAuth, url);
-				if (httpQueryAuth) await checkDomainRestrictions(httpQueryAuth, url);
-				if (httpCustomAuth) await checkDomainRestrictions(httpCustomAuth, url);
-				if (oAuth1Api) await checkDomainRestrictions(oAuth1Api, url);
-				if (oAuth2Api) await checkDomainRestrictions(oAuth2Api, url);
+				if (httpBasicAuth) await checkDomainRestrictions(httpBasicAuth, trimmedUrl);
+				if (httpBearerAuth) await checkDomainRestrictions(httpBearerAuth, trimmedUrl);
+				if (httpDigestAuth) await checkDomainRestrictions(httpDigestAuth, trimmedUrl);
+				if (httpHeaderAuth) await checkDomainRestrictions(httpHeaderAuth, trimmedUrl);
+				if (httpQueryAuth) await checkDomainRestrictions(httpQueryAuth, trimmedUrl);
+				if (httpCustomAuth) await checkDomainRestrictions(httpCustomAuth, trimmedUrl);
+				if (oAuth1Api) await checkDomainRestrictions(oAuth1Api, trimmedUrl);
+				if (oAuth2Api) await checkDomainRestrictions(oAuth2Api, trimmedUrl);
 
 				if (nodeCredentialType) {
 					try {
 						const credentialData = await this.getCredentials(nodeCredentialType, itemIndex);
-						await checkDomainRestrictions(credentialData, url, nodeCredentialType);
+						await checkDomainRestrictions(credentialData, trimmedUrl, nodeCredentialType);
 					} catch (error) {
 						if (
 							error.message?.includes('Domain not allowed') ||
@@ -342,7 +344,7 @@ export class HttpRequestV3 implements INodeType {
 				requestOptions = {
 					headers: {},
 					method: requestMethod,
-					uri: url,
+					uri: trimmedUrl,
 					gzip: true,
 					rejectUnauthorized: !allowUnauthorizedCerts || false,
 					followRedirect: false,


### PR DESCRIPTION
Fixes #19817.

URLs with leading or trailing whitespace failed validation in the HTTP Request node even though trimming them produces a valid URL. This commonly happens when expressions resolve with extra whitespace. Added a trim before the URL validation check.