### PR TITLE
fix(ChatMessagesPanel): Rendering JSON data correctly in messages panel. Fixes #19580.

### DIFF
--- a/packages/frontend/@n8n/chat/src/components/Message.vue
+++ b/packages/frontend/@n8n/chat/src/components/Message.vue
@@ -37,7 +37,15 @@ const messageContainer = ref<HTMLElement | null>(null);
 const fileSources = ref<Record<string, string>>({});
 
 const messageText = computed(() => {
-	return (message.value as ChatMessageText).text || '&lt;Empty response&gt;';
+	// Check if the text looks like JSON
+	const text = (message.value as ChatMessageText).text || '&lt;Empty response&gt;';
+	try {
+		JSON.parse(text);
+		const escapedText = text.replace(/```/g, '\\`\\`\\`');
+		return `\`\`\`json\n${escapedText}\n\`\`\``;
+	} catch {
+		return text;
+	}
 });
 
 const classes = computed(() => {


### PR DESCRIPTION
## Summary
This PR fixes #19580. The issue was related to how `VueMarkdown` processes the text. The backslashes (\\) in JSON string are being interpreted as escape characters by the markdown parser, which then removes them when rendering.

This is how json data is rendered now:
<img width="752" height="409" alt="image" src="https://github.com/user-attachments/assets/b4b5c042-1ef6-4035-923d-4a027b8a1d62" />

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
