### PR TITLE
feat(outlook): Ensure Outlook Send Message node properly handles HTML

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/message/send.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/message/send.operation.ts
@@ -216,6 +216,7 @@ export async function execute(this: IExecuteFunctions, index: number, items: INo
 	additionalFields.subject = subject;
 	additionalFields.bodyContent = bodyContent || ' ';
 	additionalFields.toRecipients = toRecipients;
+	additionalFields.bodyContentType = 'html';
 
 	const saveToSentItems =
 		additionalFields.saveToSentItems === undefined ? true : additionalFields.saveToSentItems;


### PR DESCRIPTION
## Summary

This PR addresses an issue with the Outlook **Send Message** node where putting HTML into the message body caused the HTML to appear as plain text in the sent email. The problem does not occur with the **Send and Wait** node, which correctly interprets HTML in the message body. This PR ensures that the **Send Message** node properly handles HTML content in the email body.


## Related Linear tickets, Github issues, and Community forum posts

Fixes #19781

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
