### PR TITLE
ci: Include `uv` on the n8nio/runners image

### DIFF
--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -107,6 +107,9 @@ ENV NODE_ENV=production \
     N8N_RELEASE_TYPE=${N8N_RELEASE_TYPE} \
     SHELL=/bin/sh
 
+# Bring `uv` over from python-runner-builder
+COPY --from=python-runner-builder /usr/local/bin/uv /usr/local/bin/uv
+
 # Bring node over from node-alpine
 COPY --from=node-alpine /usr/local/bin/node /usr/local/bin/node
 


### PR DESCRIPTION
## Summary

To better support extending our `n8nio/runners` image add `uv` on it, even though our current cloud runtime strictly doesn't need it. This adds 40MB binary and one more dependency on the image, which might trigger security alerts in the future but lets hope not - and we anyways use `uv` while building the image so being more aware of any `uv` vulnerabilities will still be good.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1465/add-uv-to-the-runners-image

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
