### PR TITLE
fix(core): Don't show license activation error message twice

### DIFF
--- a/packages/frontend/editor-ui/src/views/SettingsUsageAndPlan.vue
+++ b/packages/frontend/editor-ui/src/views/SettingsUsageAndPlan.vue
@@ -74,11 +74,7 @@ const showActivationSuccess = () => {
 };
 
 const showActivationError = (error: Error) => {
-	toast.showError(
-		error,
-		locale.baseText('settings.usageAndPlan.license.activation.error.title'),
-		error.message,
-	);
+	toast.showError(error, locale.baseText('settings.usageAndPlan.license.activation.error.title'));
 };
 
 const onLicenseActivation = async () => {


### PR DESCRIPTION
## Summary

Fixes duplicate error message:

It was shown twice because our `showError` implementation shows the `error.message` by default: https://github.com/n8n-io/n8n/blob/d68a776e5c336e2014948e5159f7fa6e59ee6075/packages/frontend/editor-ui/src/composables/useToast.ts#L154

### Before
<img width="5120" height="2656" alt="image" src="https://github.com/user-attachments/assets/976a2ed1-2c65-4978-b7e1-c3acc587e65d" />

### After
<img width="1045" height="619" alt="image" src="https://github.com/user-attachments/assets/bf84052c-37fd-482f-b39e-b2039f5050ba" />




## Related Linear tickets, Github issues, and Community forum posts


fixes pay-3844


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
