### PR TITLE
chore(core): Add authentication for credential overwrite endpoint

### DIFF
--- a/packages/@n8n/config/src/configs/credentials.config.ts
+++ b/packages/@n8n/config/src/configs/credentials.config.ts
@@ -12,6 +12,10 @@ class CredentialsOverwrite {
 	/** Internal API endpoint to fetch overwritten credential types from. */
 	@Env('CREDENTIALS_OVERWRITE_ENDPOINT')
 	endpoint: string = '';
+
+	/** Internal API endpoint to fetch overwritten credential types from. */
+	@Env('CREDENTIALS_OVERWRITE_ENDPOINT_AUTH_TOKEN')
+	endpointAuthToken: string = '';
 }
 
 @Config

--- a/packages/@n8n/config/src/configs/credentials.config.ts
+++ b/packages/@n8n/config/src/configs/credentials.config.ts
@@ -13,7 +13,7 @@ class CredentialsOverwrite {
 	@Env('CREDENTIALS_OVERWRITE_ENDPOINT')
 	endpoint: string = '';
 
-	/** Internal API endpoint to fetch overwritten credential types from. */
+	/** Authentication token for the credentials overwrite endpoint. */
 	@Env('CREDENTIALS_OVERWRITE_ENDPOINT_AUTH_TOKEN')
 	endpointAuthToken: string = '';
 }

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -105,6 +105,7 @@ describe('GlobalConfig', () => {
 			overwrite: {
 				data: '{}',
 				endpoint: '',
+				endpointAuthToken: '',
 			},
 		},
 		userManagement: {

--- a/packages/cli/src/__tests__/credentials-overwrites.test.ts
+++ b/packages/cli/src/__tests__/credentials-overwrites.test.ts
@@ -1,5 +1,6 @@
 import type { Logger } from '@n8n/backend-common';
 import type { GlobalConfig } from '@n8n/config';
+import type { NextFunction, Request, Response } from 'express';
 import { mock } from 'jest-mock-extended';
 import { UnrecognizedCredentialTypeError } from 'n8n-core';
 import type { ICredentialType } from 'n8n-workflow';
@@ -44,6 +45,105 @@ describe('CredentialsOverwrites', () => {
 					password: 'pass',
 					username: 'user',
 				},
+			});
+		});
+	});
+
+	describe('getOverwriteEndpointMiddleware', () => {
+		it('should return null if endpointAuthToken is not provided', () => {
+			globalConfig.credentials.overwrite.endpointAuthToken = '';
+			const localCredentialsOverwrites = new CredentialsOverwrites(
+				globalConfig,
+				credentialTypes,
+				logger,
+			);
+			const middleware = localCredentialsOverwrites.getOverwriteEndpointMiddleware();
+			expect(middleware).toBeNull();
+		});
+
+		it('should return a middleware function, if endpointAuthToken is provided', () => {
+			globalConfig.credentials.overwrite.endpointAuthToken = 'test-token';
+			const localCredentialsOverwrites = new CredentialsOverwrites(
+				globalConfig,
+				credentialTypes,
+				logger,
+			);
+			const middleware = localCredentialsOverwrites.getOverwriteEndpointMiddleware();
+			expect(typeof middleware).toBe('function');
+		});
+
+		describe('middleware', () => {
+			let next: () => void;
+			let send: () => void;
+			let status: () => {
+				send: () => void;
+			};
+			let middleware: (req: Request, res: Response, next: NextFunction) => void;
+			beforeEach(() => {
+				globalConfig.credentials.overwrite.endpointAuthToken = 'test-token';
+				next = jest.fn();
+				send = jest.fn();
+				status = jest.fn().mockImplementation(() => {
+					return {
+						send,
+					};
+				});
+
+				const localCredentialsOverwrites = new CredentialsOverwrites(
+					globalConfig,
+					credentialTypes,
+					logger,
+				);
+				middleware = localCredentialsOverwrites.getOverwriteEndpointMiddleware();
+			});
+
+			it('should call next with correct credentials', () => {
+				middleware!(
+					{
+						headers: {
+							authorization: `Bearer ${globalConfig.credentials.overwrite.endpointAuthToken}`,
+						},
+					} as any as Request,
+					{
+						status,
+					} as any as Response,
+					next,
+				);
+				expect(next).toHaveBeenCalled();
+				expect(status).not.toHaveBeenCalled();
+				expect(send).not.toHaveBeenCalled();
+			});
+
+			it('should respond with 401 with invalid token', () => {
+				middleware!(
+					{
+						headers: {
+							Authorization: 'Bearer invalid-token',
+						},
+					} as any as Request,
+					{
+						status,
+					} as any as Response,
+					next,
+				);
+				expect(next).not.toHaveBeenCalled();
+				expect(status).toHaveBeenCalledWith(401);
+				expect(send).toHaveBeenCalled();
+			});
+
+			it('should respond with 401 without token', () => {
+				middleware!(
+					{
+						headers: {},
+					} as any as Request,
+					{
+						status,
+					} as any as Response,
+					next,
+				);
+				expect(next).not.toHaveBeenCalled();
+				expect(status).toHaveBeenCalledWith(401);
+				expect(send).toHaveBeenCalled();
 			});
 		});
 	});

--- a/packages/cli/src/__tests__/credentials-overwrites.test.ts
+++ b/packages/cli/src/__tests__/credentials-overwrites.test.ts
@@ -78,7 +78,7 @@ describe('CredentialsOverwrites', () => {
 			let status: () => {
 				send: () => void;
 			};
-			let middleware: (req: Request, res: Response, next: NextFunction) => void;
+			let middleware: null | ((req: Request, res: Response, next: NextFunction) => void);
 			beforeEach(() => {
 				globalConfig.credentials.overwrite.endpointAuthToken = 'test-token';
 				next = jest.fn();

--- a/packages/cli/src/__tests__/credentials-overwrites.test.ts
+++ b/packages/cli/src/__tests__/credentials-overwrites.test.ts
@@ -118,7 +118,7 @@ describe('CredentialsOverwrites', () => {
 				middleware!(
 					{
 						headers: {
-							Authorization: 'Bearer invalid-token',
+							authorization: 'Bearer invalid-token',
 						},
 					} as any as Request,
 					{

--- a/packages/cli/src/credentials-overwrites.ts
+++ b/packages/cli/src/credentials-overwrites.ts
@@ -38,7 +38,8 @@ export class CredentialsOverwrites {
 
 		return (req: Request, res: Response, next: NextFunction) => {
 			if (req.headers.authorization !== expectedAuthorizationHeaderValue) {
-				return res.status(401).send('Unauthorized');
+				res.status(401).send('Unauthorized');
+				return;
 			}
 			next();
 		};

--- a/packages/cli/src/credentials-overwrites.ts
+++ b/packages/cli/src/credentials-overwrites.ts
@@ -34,12 +34,13 @@ export class CredentialsOverwrites {
 			return null;
 		}
 
+		const expectedAuthorizationHeaderValue = `Bearer ${endpointAuthToken.trim()}`;
+
 		return (req: Request, res: Response, next: NextFunction) => {
-			if (req.headers.authorization === `Bearer ${endpointAuthToken.trim()}`) {
-				next();
-			} else {
-				res.status(401).send('Unauthorized');
+			if (req.headers.authorization !== expectedAuthorizationHeaderValue) {
+				return res.status(401).send('Unauthorized');
 			}
+			next();
 		};
 	}
 

--- a/packages/cli/src/credentials-overwrites.ts
+++ b/packages/cli/src/credentials-overwrites.ts
@@ -30,12 +30,12 @@ export class CredentialsOverwrites {
 	getOverwriteEndpointMiddleware() {
 		const { endpointAuthToken } = this.globalConfig.credentials.overwrite;
 
-		if (!endpointAuthToken) {
+		if (!endpointAuthToken?.trim()) {
 			return null;
 		}
 
 		return (req: Request, res: Response, next: NextFunction) => {
-			if (req.headers.authorization === `Bearer ${endpointAuthToken}`) {
+			if (req.headers.authorization === `Bearer ${endpointAuthToken.trim()}`) {
 				next();
 			} else {
 				res.status(401).send('Unauthorized');

--- a/packages/cli/src/scaling/__tests__/worker-server.test.ts
+++ b/packages/cli/src/scaling/__tests__/worker-server.test.ts
@@ -12,6 +12,8 @@ import type { PrometheusMetricsService } from '@/metrics/prometheus-metrics.serv
 import { bodyParser, rawBodyReader } from '@/middlewares';
 
 import { WorkerServer } from '../worker-server';
+import { CredentialsOverwrites } from '@/credentials-overwrites';
+import { NextFunction, Request, Response } from 'express';
 
 const app = mock<express.Application>();
 
@@ -32,13 +34,14 @@ describe('WorkerServer', () => {
 	const instanceSettings = mock<InstanceSettings>({ instanceType: 'worker' });
 	const prometheusMetricsService = mock<PrometheusMetricsService>();
 	const dbConnection = mock<DbConnection>();
+	const credentialsOverwriteService = mock<CredentialsOverwrites>();
 
 	const newWorkerServer = () =>
 		new WorkerServer(
 			globalConfig,
 			mockLogger(),
 			dbConnection,
-			mock(),
+			credentialsOverwriteService,
 			externalHooks,
 			instanceSettings,
 			prometheusMetricsService,
@@ -121,6 +124,36 @@ describe('WorkerServer', () => {
 				expect.any(Function),
 			);
 			expect(prometheusMetricsService.init).toHaveBeenCalledWith(app);
+		});
+
+		it('should mount credential overwrite middleware if configured', async () => {
+			const server = mock<http.Server>();
+			jest.spyOn(http, 'createServer').mockReturnValue(server);
+
+			server.listen.mockImplementation((...args: unknown[]) => {
+				const callback = args.find((arg) => typeof arg === 'function');
+				if (callback) callback();
+				return server;
+			});
+
+			const workerServer = newWorkerServer();
+
+			const CREDENTIALS_OVERWRITE_ENDPOINT = 'credentials/overwrites';
+			globalConfig.credentials.overwrite.endpoint = CREDENTIALS_OVERWRITE_ENDPOINT;
+			globalConfig.credentials.overwrite.endpointAuthToken = 'test-token';
+
+			const middleware = (_req: Request, _res: Response, next: NextFunction) => next();
+			credentialsOverwriteService.getOverwriteEndpointMiddleware.mockReturnValue(middleware);
+
+			await workerServer.init({ health: true, overwrites: true, metrics: true });
+
+			expect(app.use).toHaveBeenCalledWith(`/${CREDENTIALS_OVERWRITE_ENDPOINT}`, middleware);
+			expect(app.post).toHaveBeenCalledWith(
+				`/${CREDENTIALS_OVERWRITE_ENDPOINT}`,
+				rawBodyReader,
+				bodyParser,
+				expect.any(Function),
+			);
 		});
 
 		it('should mount only health and overwrites endpoints if only those are enabled', async () => {

--- a/packages/cli/src/scaling/__tests__/worker-server.test.ts
+++ b/packages/cli/src/scaling/__tests__/worker-server.test.ts
@@ -12,8 +12,8 @@ import type { PrometheusMetricsService } from '@/metrics/prometheus-metrics.serv
 import { bodyParser, rawBodyReader } from '@/middlewares';
 
 import { WorkerServer } from '../worker-server';
-import { CredentialsOverwrites } from '@/credentials-overwrites';
-import { NextFunction, Request, Response } from 'express';
+import type { CredentialsOverwrites } from '@/credentials-overwrites';
+import type { NextFunction, Request, Response } from 'express';
 
 const app = mock<express.Application>();
 

--- a/packages/cli/src/scaling/worker-server.ts
+++ b/packages/cli/src/scaling/worker-server.ts
@@ -113,6 +113,13 @@ export class WorkerServer {
 		if (overwrites) {
 			const { endpoint } = this.globalConfig.credentials.overwrite;
 
+			const overwriteEndpointMiddleware =
+				this.credentialsOverwrites.getOverwriteEndpointMiddleware();
+
+			if (overwriteEndpointMiddleware) {
+				this.app.use(`/${endpoint}`, overwriteEndpointMiddleware);
+			}
+
 			this.app.post(`/${endpoint}`, rawBodyReader, bodyParser, (req, res) =>
 				this.handleOverwrites(req, res),
 			);

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -290,6 +290,13 @@ export class Server extends AbstractServer {
 
 		if (this.endpointPresetCredentials !== '') {
 			// POST endpoint to set preset credentials
+			const overwriteEndpointMiddleware =
+				Container.get(CredentialsOverwrites).getOverwriteEndpointMiddleware();
+
+			if (overwriteEndpointMiddleware) {
+				this.app.use(`/${this.endpointPresetCredentials}`, overwriteEndpointMiddleware);
+			}
+
 			this.app.post(
 				`/${this.endpointPresetCredentials}`,
 				async (req: express.Request, res: express.Response) => {


### PR DESCRIPTION
## Summary

This adds a configuration option to require authentication for the credential overwrite endpoint.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-3785/add-authentication-for-credentials-overwrite-endpoint

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
