### PR TITLE
fix(set Node): Add tooltip to Duplicate Items (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Set/v2/SetV2.node.ts
+++ b/packages/nodes-base/nodes/Set/v2/SetV2.node.ts
@@ -56,6 +56,7 @@ const versionDescription: INodeTypeDescription = {
 			type: 'boolean',
 			default: false,
 			isNodeSetting: true,
+			description: 'Whether this item should be duplicated a set number of times',
 		},
 		{
 			displayName: 'Duplicate Item Count',


### PR DESCRIPTION
## Summary

Add tooltip for Duplicate Items

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3508/duplicate-item-on-edit-fields-node-does

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
