### PR TITLE
test: Fix flakiness of project settings e2e tests

### DIFF
--- a/packages/testing/playwright/pages/ProjectSettingsPage.ts
+++ b/packages/testing/playwright/pages/ProjectSettingsPage.ts
@@ -53,6 +53,10 @@ export class ProjectSettingsPage extends BasePage {
 		await expect(searchInput).toHaveValue(expectedValue);
 	}
 
+	getTitle() {
+		return this.page.getByTestId('project-name');
+	}
+
 	// Robust value assertions on inner form controls
 	getNameInput() {
 		return this.page.locator('#projectName input');
@@ -78,9 +82,5 @@ export class ProjectSettingsPage extends BasePage {
 	async expectMembersSelectIsVisible() {
 		const select = this.page.getByTestId('project-members-select');
 		await expect(select).toBeVisible();
-	}
-
-	async waitForProjectSettingsRestResponse() {
-		await this.waitForRestResponse(/\/rest\/projects\/[^/]+$/, 'GET');
 	}
 }

--- a/packages/testing/playwright/tests/ui/39-projects.spec.ts
+++ b/packages/testing/playwright/tests/ui/39-projects.spec.ts
@@ -113,7 +113,7 @@ test.describe('Projects', () => {
 
 			// Navigate to project settings
 			await n8n.page.goto(`/projects/${projectId}/settings`);
-			await n8n.projectSettings.waitForProjectSettingsRestResponse();
+			await expect(n8n.projectSettings.getTitle()).toHaveText('UI Test Project');
 
 			// Verify basic project settings form elements are visible (inner controls)
 			await expect(n8n.projectSettings.getNameInput()).toBeVisible();
@@ -138,7 +138,7 @@ test.describe('Projects', () => {
 
 			// Navigate to project settings
 			await n8n.page.goto(`/projects/${projectId}/settings`);
-			await n8n.projectSettings.waitForProjectSettingsRestResponse();
+			await expect(n8n.projectSettings.getTitle()).toHaveText('Edit Test Project');
 
 			// Update project name
 			const newName = 'Updated Project Name';
@@ -167,7 +167,7 @@ test.describe('Projects', () => {
 
 			// Navigate to project settings
 			await n8n.page.goto(`/projects/${projectId}/settings`);
-			await n8n.projectSettings.waitForProjectSettingsRestResponse();
+			await expect(n8n.projectSettings.getTitle()).toHaveText('Table Structure Test');
 
 			const table = n8n.projectSettings.getMembersTable();
 
@@ -193,7 +193,7 @@ test.describe('Projects', () => {
 
 			// Navigate to project settings
 			await n8n.page.goto(`/projects/${projectId}/settings`);
-			await n8n.projectSettings.waitForProjectSettingsRestResponse();
+			await expect(n8n.projectSettings.getTitle()).toHaveText('Role Dropdown Test');
 
 			// Current user (owner) should not have a role dropdown
 			const currentUserRow = n8n.page.locator('tbody tr').first();
@@ -209,7 +209,7 @@ test.describe('Projects', () => {
 
 			// Navigate to project settings
 			await n8n.page.goto(`/projects/${projectId}/settings`);
-			await n8n.projectSettings.waitForProjectSettingsRestResponse();
+			await expect(n8n.projectSettings.getTitle()).toHaveText('Search Test Project');
 
 			// Verify search input is visible
 			const searchInput = n8n.page.getByTestId('project-members-search');
@@ -233,7 +233,7 @@ test.describe('Projects', () => {
 
 			// Navigate to project settings
 			await n8n.page.goto(`/projects/${projectId}/settings`);
-			await n8n.projectSettings.waitForProjectSettingsRestResponse();
+			await expect(n8n.projectSettings.getTitle()).toHaveText('Validation Test');
 
 			// Clear the project name (required field)
 			await n8n.projectSettings.fillProjectName('');
@@ -255,7 +255,7 @@ test.describe('Projects', () => {
 
 			// Navigate to project settings
 			await n8n.page.goto(`/projects/${projectId}/settings`);
-			await n8n.projectSettings.waitForProjectSettingsRestResponse();
+			await expect(n8n.projectSettings.getTitle()).toHaveText('Unsaved Changes Test');
 
 			// Initially, save and cancel buttons should be disabled (no changes)
 			await expect(n8n.page.getByTestId('project-settings-save-button')).toBeDisabled();
@@ -285,7 +285,7 @@ test.describe('Projects', () => {
 
 			// Navigate to project settings
 			await n8n.page.goto(`/projects/${projectId}/settings`);
-			await n8n.projectSettings.waitForProjectSettingsRestResponse();
+			await expect(n8n.projectSettings.getTitle()).toHaveText('Delete Test Project');
 
 			// Scroll to bottom to see delete section
 			await n8n.page
@@ -309,7 +309,7 @@ test.describe('Projects', () => {
 
 			// Navigate to project settings
 			await n8n.page.goto(`/projects/${projectId}/settings`);
-			await n8n.projectSettings.waitForProjectSettingsRestResponse();
+			await expect(n8n.projectSettings.getTitle()).toHaveText('Persistence Test');
 
 			// Update project details
 			const projectName = 'Persisted Project Name';
@@ -326,7 +326,7 @@ test.describe('Projects', () => {
 
 			// Reload the page
 			await n8n.page.reload();
-			await n8n.projectSettings.waitForProjectSettingsRestResponse();
+			await expect(n8n.projectSettings.getTitle()).toHaveText('Persisted Project Name');
 
 			// Verify data persisted
 			await n8n.projectSettings.expectProjectNameValue(projectName);


### PR DESCRIPTION
## Summary

This PR fixes flakiness of project settings e2e tests by ensuring interactions to happen after page content is loaded.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
