### PR TITLE
fix(core): Fix data table name filters not all applying, take option and add more tests (no-changelog)

### DIFF
--- a/packages/cli/src/modules/data-table/__tests__/data-store.service.integration.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/data-store.service.integration.test.ts
@@ -815,6 +815,136 @@ describe('dataStore', () => {
 				expect(updatedDesc.data.map((x) => x.name)).toEqual(['ds1Updated', 'ds2']);
 			});
 		});
+
+		describe('filters as expected', () => {
+			it('filters by name', async () => {
+				// ARRANGE
+				await dataStoreService.createDataStore(project1.id, {
+					name: 'dataStore1',
+					columns: [],
+				});
+
+				await dataStoreService.createDataStore(project1.id, {
+					name: 'dataStore2',
+					columns: [],
+				});
+
+				await dataStoreService.createDataStore(project1.id, {
+					name: 'dataStore3',
+					columns: [],
+				});
+
+				// ACT
+				const filtered = await dataStoreService.getManyAndCount({
+					filter: { projectId: project1.id, name: 'dataStore2' },
+				});
+
+				// ASSERT
+				expect(filtered.count).toBe(1);
+				expect(filtered.data[0].name).toBe('dataStore2');
+			});
+
+			it('filters by multiple names (AND)', async () => {
+				// ARRANGE
+				await dataStoreService.createDataStore(project1.id, {
+					name: 'dataStore1',
+					columns: [],
+				});
+
+				await dataStoreService.createDataStore(project1.id, {
+					name: 'dataStore2',
+					columns: [],
+				});
+
+				await dataStoreService.createDataStore(project1.id, {
+					name: 'dataStore3',
+					columns: [],
+				});
+
+				// ACT
+				const filtered = await dataStoreService.getManyAndCount({
+					filter: { projectId: project1.id, name: ['Store3', 'data'] },
+				});
+
+				// ASSERT
+				expect(filtered.count).toBe(1);
+				expect(filtered.data.map((x) => x.name).sort()).toEqual(['dataStore3']);
+			});
+
+			it('filters by id', async () => {
+				// ARRANGE
+				const { id: ds1Id } = await dataStoreService.createDataStore(project1.id, {
+					name: 'dataStore1',
+					columns: [],
+				});
+
+				await dataStoreService.createDataStore(project1.id, {
+					name: 'dataStore2',
+					columns: [],
+				});
+
+				// ACT
+				const filtered = await dataStoreService.getManyAndCount({
+					filter: { projectId: project1.id, id: ds1Id },
+				});
+
+				// ASSERT
+				expect(filtered.count).toBe(1);
+				expect(filtered.data[0].id).toBe(ds1Id);
+			});
+
+			it('filters by multiple ids (OR)', async () => {
+				// ARRANGE
+				const { id: ds1Id } = await dataStoreService.createDataStore(project1.id, {
+					name: 'dataStore1',
+					columns: [],
+				});
+				const { id: ds2Id } = await dataStoreService.createDataStore(project1.id, {
+					name: 'dataStore2',
+					columns: [],
+				});
+				await dataStoreService.createDataStore(project1.id, {
+					name: 'dataStore3',
+					columns: [],
+				});
+
+				// ACT
+				const filtered = await dataStoreService.getManyAndCount({
+					filter: { projectId: project1.id, id: [ds1Id, ds2Id] },
+				});
+
+				// ASSERT
+				expect(filtered.count).toBe(2);
+				expect(filtered.data.map((x) => x.id).sort()).toEqual([ds1Id, ds2Id].sort());
+			});
+
+			it('filters by projectId', async () => {
+				// ARRANGE
+				await dataStoreService.createDataStore(project1.id, {
+					name: 'dataStore1',
+					columns: [],
+				});
+
+				await dataStoreService.createDataStore(project2.id, {
+					name: 'dataStore2',
+					columns: [],
+				});
+
+				// ACT
+				const filtered1 = await dataStoreService.getManyAndCount({
+					filter: { projectId: project1.id },
+				});
+				const filtered2 = await dataStoreService.getManyAndCount({
+					filter: { projectId: project2.id },
+				});
+
+				// ASSERT
+				expect(filtered1.count).toBe(1);
+				expect(filtered1.data[0].name).toBe('dataStore1');
+				expect(filtered2.count).toBe(1);
+				expect(filtered2.data[0].name).toBe('dataStore2');
+			});
+		});
 	});
 
 	describe('insertRows', () => {

--- a/packages/cli/src/modules/data-table/data-store.repository.ts
+++ b/packages/cli/src/modules/data-table/data-store.repository.ts
@@ -215,12 +215,13 @@ export class DataStoreRepository extends Repository<DataTable> {
 		}
 
 		if (filter?.name) {
-			const nameFilters = typeof filter.name === 'string' ? [filter.name] : filter.name;
-			for (const name of nameFilters) {
-				query.andWhere('LOWER(dataStore.name) LIKE LOWER(:name)', {
-					name: `%${name}%`,
+			const nameFilters = Array.isArray(filter.name) ? filter.name : [filter.name];
+
+			nameFilters.forEach((name, i) => {
+				query.andWhere(`LOWER(dataStore.name) LIKE LOWER(:name${i})`, {
+					['name' + i]: `%${name}%`,
 				});
-			}
+			});
 		}
 	}
 
@@ -258,7 +259,7 @@ export class DataStoreRepository extends Repository<DataTable> {
 		options: Partial<ListDataStoreQueryDto>,
 	): void {
 		query.skip(options.skip ?? 0);
-		if (query.take) query.take(options.take);
+		if (options.take !== undefined) query.take(options.take);
 	}
 
 	private applyDefaultSelect(query: SelectQueryBuilder<DataTable>): void {

--- a/packages/cli/src/modules/data-table/data-store.service.ts
+++ b/packages/cli/src/modules/data-table/data-store.service.ts
@@ -27,6 +27,8 @@ import type {
 } from 'n8n-workflow';
 import { DATA_TABLE_SYSTEM_COLUMN_TYPE_MAP, validateFieldType } from 'n8n-workflow';
 
+import { RoleService } from '@/services/role.service';
+
 import { DataStoreColumnRepository } from './data-store-column.repository';
 import { DataStoreRowsRepository } from './data-store-rows.repository';
 import { DataStoreSizeValidator } from './data-store-size-validator.service';
@@ -38,8 +40,6 @@ import { DataStoreNameConflictError } from './errors/data-store-name-conflict.er
 import { DataStoreNotFoundError } from './errors/data-store-not-found.error';
 import { DataStoreValidationError } from './errors/data-store-validation.error';
 import { normalizeRows } from './utils/sql-utils';
-
-import { RoleService } from '@/services/role.service';
 
 @Service()
 export class DataStoreService {


### PR DESCRIPTION
## Summary

Some last minute fixes, fixing the take option's default handling & making all name filters apply if multiple are given.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
