### PR TITLE
fix(editor): Fix keyboard navigation in node creator with pre-built agents experiment

### DIFF
--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/__snapshots__/viewsData.spec.ts.snap
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/__snapshots__/viewsData.spec.ts.snap
@@ -17,6 +17,7 @@ exports[`viewsData > AIView > should return ai view with ai transform node 1`] =
         "url": "template-repository-url.n8n.io?test=value&utm_user_role=AdvancedAI",
       },
       "type": "link",
+      "uuid": "ai_templates_root",
     },
     {
       "key": "agent",
@@ -90,6 +91,7 @@ exports[`viewsData > AIView > should return ai view without ai transform node if
         "url": "template-repository-url.n8n.io?test=value&utm_user_role=AdvancedAI",
       },
       "type": "link",
+      "uuid": "ai_templates_root",
     },
     {
       "key": "agent",
@@ -150,6 +152,7 @@ exports[`viewsData > AIView > should return ai view without ai transform node if
         "url": "template-repository-url.n8n.io?test=value&utm_user_role=AdvancedAI",
       },
       "type": "link",
+      "uuid": "ai_templates_root",
     },
     {
       "key": "agent",

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/utils.ts
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/utils.ts
@@ -342,6 +342,7 @@ export function getRagStarterCallout(): OpenTemplateElement {
 // Callout without a divider
 export function getPreBuiltAgentsCallout(): ViewCreateElement {
 	return {
+		uuid: uuidv4(),
 		key: PRE_BUILT_AGENTS_COLLECTION,
 		type: 'view',
 		properties: {
@@ -360,6 +361,7 @@ export function getPreBuiltAgentsCallout(): ViewCreateElement {
 // Callout with divider after it
 export function getPreBuiltAgentsCalloutWithDivider(): LinkCreateElement {
 	return {
+		uuid: uuidv4(),
 		key: PRE_BUILT_AGENTS_COLLECTION,
 		type: 'link',
 		properties: {
@@ -378,6 +380,7 @@ export function getPreBuiltAgentsCalloutWithDivider(): LinkCreateElement {
 
 export function getAiTemplatesCallout(aiTemplatesURL: string): LinkCreateElement {
 	return {
+		uuid: uuidv4(),
 		key: 'ai_templates_root',
 		type: 'link',
 		properties: {

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/utils.ts
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/utils.ts
@@ -380,7 +380,7 @@ export function getPreBuiltAgentsCalloutWithDivider(): LinkCreateElement {
 
 export function getAiTemplatesCallout(aiTemplatesURL: string): LinkCreateElement {
 	return {
-		uuid: uuidv4(),
+		uuid: 'ai_templates_root',
 		key: 'ai_templates_root',
 		type: 'link',
 		properties: {


### PR DESCRIPTION
## Summary

Lack of uuid's on the experiment link callouts meant that in certain scnearios, such as when opening the node creator from Agent's `Chat Modal` connection keyboard navigation didn't work. This was caused by `useKeyboardNavigation` not finding the [correct elemeent](https://github.com/n8n-io/n8n/blob/master/packages/frontend/editor-ui/src/components/Node/NodeCreator/composables/useKeyboardNavigation.ts#L55) when setting active item when node creator was opened.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4125/bug-pre-built-agents-seems-to-have-broken-keyboard-navigation-of-nodes

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
