### PR TITLE
fix(editor): Show correct project breadcrumbs for shared workflows (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/components/Folders/FolderBreadcrumbs.test.ts
+++ b/packages/frontend/editor-ui/src/components/Folders/FolderBreadcrumbs.test.ts
@@ -139,4 +139,64 @@ describe('FolderBreadcrumbs', () => {
 		expect(getByTestId('folder-breadcrumbs')).toBeVisible();
 		expect(getByTestId('home-project')).toBeVisible();
 	});
+
+	describe('Shared context', () => {
+		it('should render shared project breadcrumb when in shared context', () => {
+			projectsStore.currentProject = null;
+			projectsStore.projectNavActiveId = 'shared';
+
+			const { getByTestId } = renderComponent({
+				props: {
+					currentFolder: null,
+				},
+			});
+
+			expect(getByTestId('folder-breadcrumbs')).toBeVisible();
+			expect(getByTestId('home-project')).toBeVisible();
+		});
+
+		it('should render shared project breadcrumb with folder when in shared context', () => {
+			projectsStore.currentProject = null;
+			projectsStore.projectNavActiveId = 'shared';
+			foldersStore.getCachedFolder.mockReturnValue(TEST_FOLDER);
+
+			const { getByTestId, queryAllByTestId } = renderComponent({
+				props: {
+					currentFolder: TEST_FOLDER,
+				},
+			});
+
+			expect(getByTestId('folder-breadcrumbs')).toBeVisible();
+			expect(queryAllByTestId('breadcrumbs-item')).toHaveLength(1);
+		});
+
+		it('should not render personal project fallback when in shared context', () => {
+			projectsStore.currentProject = null;
+			projectsStore.personalProject = TEST_PROJECT;
+			projectsStore.projectNavActiveId = 'shared';
+
+			const { getByTestId } = renderComponent({
+				props: {
+					currentFolder: null,
+				},
+			});
+
+			expect(getByTestId('folder-breadcrumbs')).toBeVisible();
+			expect(getByTestId('home-project')).toBeVisible();
+		});
+
+		it('should render regular project when not in shared context', () => {
+			projectsStore.currentProject = TEST_PROJECT;
+			projectsStore.projectNavActiveId = TEST_PROJECT.id;
+
+			const { getByTestId } = renderComponent({
+				props: {
+					currentFolder: null,
+				},
+			});
+
+			expect(getByTestId('folder-breadcrumbs')).toBeVisible();
+			expect(getByTestId('home-project')).toBeVisible();
+		});
+	});
 });

--- a/packages/frontend/editor-ui/src/components/Folders/FolderBreadcrumbs.test.ts
+++ b/packages/frontend/editor-ui/src/components/Folders/FolderBreadcrumbs.test.ts
@@ -125,7 +125,7 @@ describe('FolderBreadcrumbs', () => {
 		expect(queryByTestId('ellipsis')).not.toBeInTheDocument();
 	});
 
-	it('should render personal project as fallback', () => {
+	it('should render personal project as fallback when not in shared context', () => {
 		foldersStore.getCachedFolder.mockReturnValue(TEST_FOLDER);
 		projectsStore.currentProject = null;
 		projectsStore.personalProject = TEST_PROJECT;
@@ -140,63 +140,18 @@ describe('FolderBreadcrumbs', () => {
 		expect(getByTestId('home-project')).toBeVisible();
 	});
 
-	describe('Shared context', () => {
-		it('should render shared project breadcrumb when in shared context', () => {
-			projectsStore.currentProject = null;
-			projectsStore.projectNavActiveId = 'shared';
+	it('should not render folder breadcrumbs in shared context', () => {
+		projectsStore.currentProject = null;
+		projectsStore.projectNavActiveId = 'shared';
+		foldersStore.getCachedFolder.mockReturnValue(TEST_FOLDER);
 
-			const { getByTestId } = renderComponent({
-				props: {
-					currentFolder: null,
-				},
-			});
-
-			expect(getByTestId('folder-breadcrumbs')).toBeVisible();
-			expect(getByTestId('home-project')).toBeVisible();
+		const { getByTestId, queryAllByTestId } = renderComponent({
+			props: {
+				currentFolder: TEST_FOLDER,
+			},
 		});
 
-		it('should render shared project breadcrumb with folder when in shared context', () => {
-			projectsStore.currentProject = null;
-			projectsStore.projectNavActiveId = 'shared';
-			foldersStore.getCachedFolder.mockReturnValue(TEST_FOLDER);
-
-			const { getByTestId, queryAllByTestId } = renderComponent({
-				props: {
-					currentFolder: TEST_FOLDER,
-				},
-			});
-
-			expect(getByTestId('folder-breadcrumbs')).toBeVisible();
-			expect(queryAllByTestId('breadcrumbs-item')).toHaveLength(1);
-		});
-
-		it('should not render personal project fallback when in shared context', () => {
-			projectsStore.currentProject = null;
-			projectsStore.personalProject = TEST_PROJECT;
-			projectsStore.projectNavActiveId = 'shared';
-
-			const { getByTestId } = renderComponent({
-				props: {
-					currentFolder: null,
-				},
-			});
-
-			expect(getByTestId('folder-breadcrumbs')).toBeVisible();
-			expect(getByTestId('home-project')).toBeVisible();
-		});
-
-		it('should render regular project when not in shared context', () => {
-			projectsStore.currentProject = TEST_PROJECT;
-			projectsStore.projectNavActiveId = TEST_PROJECT.id;
-
-			const { getByTestId } = renderComponent({
-				props: {
-					currentFolder: null,
-				},
-			});
-
-			expect(getByTestId('folder-breadcrumbs')).toBeVisible();
-			expect(getByTestId('home-project')).toBeVisible();
-		});
+		expect(getByTestId('folder-breadcrumbs')).toBeVisible();
+		expect(queryAllByTestId('breadcrumbs-item')).toHaveLength(0);
 	});
 });

--- a/packages/frontend/editor-ui/src/components/Folders/FolderBreadcrumbs.test.ts
+++ b/packages/frontend/editor-ui/src/components/Folders/FolderBreadcrumbs.test.ts
@@ -125,33 +125,40 @@ describe('FolderBreadcrumbs', () => {
 		expect(queryByTestId('ellipsis')).not.toBeInTheDocument();
 	});
 
-	it('should render personal project as fallback when not in shared context', () => {
+	it('should use personal project as fallback and show folder breadcrumbs when currentProject is null', () => {
 		foldersStore.getCachedFolder.mockReturnValue(TEST_FOLDER);
 		projectsStore.currentProject = null;
 		projectsStore.personalProject = TEST_PROJECT;
 
-		const { getByTestId } = renderComponent({
+		const { getByTestId, queryAllByTestId } = renderComponent({
+			props: {
+				currentFolder: TEST_FOLDER_CHILD,
+				visibleLevels: 2,
+			},
+		});
+
+		expect(getByTestId('folder-breadcrumbs')).toBeVisible();
+		expect(getByTestId('home-project')).toBeVisible();
+		// Should show folder breadcrumbs (parent + current folder)
+		expect(queryAllByTestId('breadcrumbs-item')).toHaveLength(2);
+	});
+
+	it('should not show folder breadcrumbs in shared context even with personal project available', () => {
+		foldersStore.getCachedFolder.mockReturnValue(TEST_FOLDER);
+		projectsStore.currentProject = null;
+		projectsStore.personalProject = TEST_PROJECT; // Should be ignored
+		projectsStore.projectNavActiveId = 'shared';
+
+		const { getByTestId, queryAllByTestId } = renderComponent({
 			props: {
 				currentFolder: TEST_FOLDER_CHILD,
 			},
 		});
-		// Now, parent folder should also be visible
+
+		// Should render project breadcrumb (shows "Shared with you")
 		expect(getByTestId('folder-breadcrumbs')).toBeVisible();
 		expect(getByTestId('home-project')).toBeVisible();
-	});
-
-	it('should not render folder breadcrumbs in shared context', () => {
-		projectsStore.currentProject = null;
-		projectsStore.projectNavActiveId = 'shared';
-		foldersStore.getCachedFolder.mockReturnValue(TEST_FOLDER);
-
-		const { getByTestId, queryAllByTestId } = renderComponent({
-			props: {
-				currentFolder: TEST_FOLDER,
-			},
-		});
-
-		expect(getByTestId('folder-breadcrumbs')).toBeVisible();
+		// Should NOT show any folder breadcrumbs in shared context (even though folder has parent)
 		expect(queryAllByTestId('breadcrumbs-item')).toHaveLength(0);
 	});
 });

--- a/packages/frontend/editor-ui/src/components/Folders/FolderBreadcrumbs.vue
+++ b/packages/frontend/editor-ui/src/components/Folders/FolderBreadcrumbs.vue
@@ -43,6 +43,7 @@ const hiddenBreadcrumbsItemsAsync = ref<Promise<PathItem[]>>(new Promise(() => {
 // This will be used to filter out items that are already visible in the breadcrumbs
 const visibleIds = ref<Set<string>>(new Set());
 
+// For shared context we do not show any folder breadcrumbs, only project badge
 const isSharedContext = computed(() => projectsStore.projectNavActiveId === 'shared');
 
 const currentProject = computed(() => {
@@ -76,7 +77,7 @@ const hasMoreItems = computed(() => {
 
 const visibleBreadcrumbsItems = computed<FolderPathItem[]>(() => {
 	visibleIds.value.clear();
-	if (!props.currentFolder) return [];
+	if (!props.currentFolder || isSharedContext.value) return [];
 
 	const items: FolderPathItem[] = [];
 	// Only show parent folder if we are showing 2 levels of visible breadcrumbs
@@ -111,7 +112,12 @@ const visibleBreadcrumbsItems = computed<FolderPathItem[]>(() => {
 });
 
 const fetchHiddenBreadCrumbsItems = async () => {
-	if (!projectName.value || !props.currentFolder?.parentFolder || !currentProject.value) {
+	if (
+		!projectName.value ||
+		!props.currentFolder?.parentFolder ||
+		isSharedContext.value ||
+		!currentProject.value
+	) {
 		hiddenBreadcrumbsItemsAsync.value = Promise.resolve([]);
 	} else {
 		try {
@@ -199,10 +205,9 @@ onBeforeUnmount(() => {
 			@item-hover="onItemHover"
 			@item-drop="emit('itemDrop', $event)"
 		>
-			<template v-if="currentProject || isSharedContext" #prepend>
+			<template v-if="currentProject" #prepend>
 				<ProjectBreadcrumb
 					:current-project="currentProject"
-					:is-shared="isSharedContext"
 					:is-dragging="isDragging"
 					@project-drop="onProjectDrop"
 					@project-hover="onProjectHover"

--- a/packages/frontend/editor-ui/src/components/Folders/ProjectBreadcrumb.test.ts
+++ b/packages/frontend/editor-ui/src/components/Folders/ProjectBreadcrumb.test.ts
@@ -9,6 +9,7 @@ vi.mock('@n8n/i18n', async (importOriginal) => ({
 	useI18n: () => ({
 		baseText: vi.fn((key) => {
 			if (key === 'projects.menu.personal') return 'Personal';
+			if (key === 'projects.menu.shared') return 'Shared with you';
 			return key;
 		}),
 	}),
@@ -123,5 +124,67 @@ describe('ProjectBreadcrumb', () => {
 		});
 		await fireEvent.mouseUp(getByTestId('home-project'));
 		expect(emitted('projectDrop')).toBeFalsy();
+	});
+
+	describe('Shared context', () => {
+		it('renders shared project with share icon when isShared is true', () => {
+			const { getByTestId } = renderComponent({
+				props: {
+					isShared: true,
+				},
+			});
+			expect(getByTestId('project-icon')).toHaveAttribute('data-icon', 'share');
+			expect(getByTestId('project-label')).toHaveTextContent('Shared with you');
+		});
+
+		it('renders shared project even with currentProject provided when isShared is true', () => {
+			const { getByTestId } = renderComponent({
+				props: {
+					isShared: true,
+					currentProject: {
+						id: '1',
+						name: 'Some Project',
+						type: ProjectTypes.Personal,
+					} satisfies Partial<Project>,
+				},
+			});
+			expect(getByTestId('project-icon')).toHaveAttribute('data-icon', 'share');
+			expect(getByTestId('project-label')).toHaveTextContent('Shared with you');
+		});
+
+		it('generates correct link for shared project', () => {
+			const { container } = renderComponent({
+				props: {
+					isShared: true,
+				},
+			});
+			const link = container.querySelector('a');
+			expect(link).toHaveAttribute('href', '/projects/shared');
+		});
+
+		it('generates project link when not shared and currentProject exists', () => {
+			const { container } = renderComponent({
+				props: {
+					isShared: false,
+					currentProject: {
+						id: 'project-123',
+						name: 'My Project',
+						type: ProjectTypes.Team,
+					} satisfies Partial<Project>,
+				},
+			});
+			const link = container.querySelector('a');
+			expect(link).toHaveAttribute('href', '/projects/project-123');
+		});
+
+		it('generates home link when not shared and no currentProject', () => {
+			const { container } = renderComponent({
+				props: {
+					isShared: false,
+				},
+			});
+			const link = container.querySelector('a');
+			expect(link).toHaveAttribute('href', '/home');
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/components/Folders/ProjectBreadcrumb.test.ts
+++ b/packages/frontend/editor-ui/src/components/Folders/ProjectBreadcrumb.test.ts
@@ -159,7 +159,7 @@ describe('ProjectBreadcrumb', () => {
 				},
 			});
 			const link = container.querySelector('a');
-			expect(link).toHaveAttribute('href', '/projects/shared');
+			expect(link).toHaveAttribute('href', '/shared');
 		});
 
 		it('generates project link when not shared and currentProject exists', () => {

--- a/packages/frontend/editor-ui/src/components/Folders/ProjectBreadcrumb.vue
+++ b/packages/frontend/editor-ui/src/components/Folders/ProjectBreadcrumb.vue
@@ -54,7 +54,7 @@ const projectName = computed(() => {
 
 const projectLink = computed(() => {
 	if (props.isShared) {
-		return '/projects/shared';
+		return '/shared';
 	}
 
 	if (props.currentProject) {

--- a/packages/frontend/editor-ui/src/components/Folders/ProjectBreadcrumb.vue
+++ b/packages/frontend/editor-ui/src/components/Folders/ProjectBreadcrumb.vue
@@ -5,12 +5,15 @@ import { type Project, ProjectTypes } from '@/types/projects.types';
 import { isIconOrEmoji, type IconOrEmoji } from '@n8n/design-system/components/N8nIconPicker/types';
 
 type Props = {
-	currentProject: Project;
+	currentProject?: Project;
 	isDragging?: boolean;
+	isShared?: boolean;
 };
 
 const props = withDefaults(defineProps<Props>(), {
+	currentProject: undefined,
 	isDragging: false,
+	isShared: false,
 });
 
 const emit = defineEmits<{
@@ -21,22 +24,44 @@ const emit = defineEmits<{
 const i18n = useI18n();
 
 const projectIcon = computed((): IconOrEmoji => {
+	if (props.isShared) {
+		return { type: 'icon', value: 'share' };
+	}
+
 	if (props.currentProject?.type === ProjectTypes.Personal) {
 		return { type: 'icon', value: 'user' };
-	} else if (props.currentProject?.name) {
+	}
+
+	if (props.currentProject?.name) {
 		return isIconOrEmoji(props.currentProject.icon)
 			? props.currentProject.icon
 			: { type: 'icon', value: 'layers' };
-	} else {
-		return { type: 'icon', value: 'house' };
 	}
+
+	return { type: 'icon', value: 'house' };
 });
 
 const projectName = computed(() => {
-	if (props.currentProject.type === ProjectTypes.Personal) {
+	if (props.isShared) {
+		return i18n.baseText('projects.menu.shared');
+	}
+
+	if (props.currentProject?.type === ProjectTypes.Personal) {
 		return i18n.baseText('projects.menu.personal');
 	}
-	return props.currentProject.name;
+	return props.currentProject?.name;
+});
+
+const projectLink = computed(() => {
+	if (props.isShared) {
+		return '/projects/shared';
+	}
+
+	if (props.currentProject) {
+		return `/projects/${props.currentProject.id}`;
+	}
+
+	return '/home';
 });
 
 const onHover = () => {
@@ -56,7 +81,7 @@ const onProjectMouseUp = () => {
 		@mouseenter="onHover"
 		@mouseup="isDragging ? onProjectMouseUp() : null"
 	>
-		<n8n-link :to="`/projects/${currentProject.id}`" :class="[$style['project-link']]">
+		<n8n-link :to="projectLink" :class="[$style['project-link']]">
 			<ProjectIcon :icon="projectIcon" :border-less="true" size="mini" :title="projectName" />
 			<N8nText size="medium" color="text-base" :class="$style['project-label']">
 				{{ projectName }}

--- a/packages/frontend/editor-ui/src/stores/projects.store.ts
+++ b/packages/frontend/editor-ui/src/stores/projects.store.ts
@@ -155,25 +155,40 @@ export const useProjectsStore = defineStore(STORES.PROJECTS, () => {
 	};
 
 	const setProjectNavActiveIdByWorkflowHomeProject = async (
-		homeProject?: IWorkflowDb['homeProject'],
+		workflowHomeProject?: IWorkflowDb['homeProject'],
+		sharedWithProjects?: IWorkflowDb['sharedWithProjects'],
 	) => {
-		// Handle personal projects
-		if (homeProject?.type === ProjectTypes.Personal) {
-			const isOwnPersonalProject = personalProject.value?.id === homeProject?.id;
+		// For personal shared workflows, we need to show "Shared with you"
+		const isSharedWithMe =
+			personalProject.value?.id !== workflowHomeProject?.id &&
+			workflowHomeProject?.type === ProjectTypes.Personal &&
+			sharedWithProjects?.some((project) => project.id === personalProject.value?.id);
+
+		if (isSharedWithMe) {
+			projectNavActiveId.value = 'shared';
+			setCurrentProject(null);
+			return;
+		}
+
+		if (workflowHomeProject?.type === ProjectTypes.Personal) {
+			// Handle personal projects
+			const isOwnPersonalProject = personalProject.value?.id === workflowHomeProject?.id;
 			// If it's current user's personal project, set it as current project
 			if (isOwnPersonalProject) {
-				projectNavActiveId.value = homeProject?.id ?? null;
+				projectNavActiveId.value = workflowHomeProject?.id ?? null;
 				currentProject.value = personalProject.value;
+				return;
 			} else {
 				// Else default to overview page
 				projectNavActiveId.value = 'home';
+				return;
 			}
-		} else {
-			// Handle team projects
-			projectNavActiveId.value = homeProject?.id ?? null;
-			if (homeProject?.id && !currentProjectId.value) {
-				await getProject(homeProject?.id);
-			}
+		}
+
+		// Handle team projects
+		projectNavActiveId.value = workflowHomeProject?.id ?? null;
+		if (workflowHomeProject?.id && !currentProjectId.value) {
+			await getProject(workflowHomeProject?.id);
 		}
 	};
 

--- a/packages/frontend/editor-ui/src/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/views/NodeView.vue
@@ -525,7 +525,10 @@ async function initializeWorkspaceForExistingWorkflow(id: string) {
 			);
 		}
 
-		await projectsStore.setProjectNavActiveIdByWorkflowHomeProject(workflowData.homeProject);
+		await projectsStore.setProjectNavActiveIdByWorkflowHomeProject(
+			workflowData.homeProject,
+			workflowData.sharedWithProjects,
+		);
 	} catch (error) {
 		if (error.httpStatusCode === 404) {
 			return await router.replace({


### PR DESCRIPTION
## Summary

Before:
<img height="200" alt="image" src="https://github.com/user-attachments/assets/dc58a135-985b-417e-bf6f-bb7d0feb8a8f" />

After:
<img height="200" alt="image" src="https://github.com/user-attachments/assets/7daa6e79-e0c3-4f3a-bd3a-58a4c0715fba" />

What changed:
- For shared contexts, we no longer fall back to a personal project. Instead, we now set `currentProject` in the store to `null`.
- We no longer construct folder breadcrumbs for shared contexts. Since a shared "project" is not a real project and doesn’t support links with `/folders`, we only display the project badge. (Previously, breadcrumbs weren’t shown either because we were falling back to the personal project, which has no parent folder.)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4045/bug-shared-workflows-show-incorrect-breadcrumbs

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
