### PR TITLE
ci: Use cache instead of artifacts

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -7,9 +7,6 @@ on:
     branches:
       - 'release/*'
 
-env:
-  BUILD_DIST_NAME: ${{ github.sha }}-release-build
-
 jobs:
   build-arm64:
     runs-on: blacksmith-4vcpu-ubuntu-2204-arm
@@ -43,13 +40,6 @@ jobs:
 
       - name: Setup and Build
         uses: ./.github/actions/setup-nodejs-github
-
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: ${{ env.BUILD_DIST_NAME }}
-          path: ./packages/**/dist
-          retention-days: 7
 
       - name: Dry-run publishing
         run: |
@@ -124,11 +114,8 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Download build artifacts
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
-        with:
-          name: ${{ env.BUILD_DIST_NAME }}
-          path: .
+      - name: Restore Turbo Cache
+        uses: ./.github/actions/setup-nodejs-github
 
       - name: Create a frontend release
         uses: getsentry/action-release@e769183448303de84c5a06aaaddf9da7be26d6c7 # v1.7.0

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -8,12 +8,14 @@ on:
       - 'release/*'
 
 env:
-  BUILD_DIST_NAME: ${{ github.sha }}-release:build
+  BUILD_DIST_NAME: ${{ github.sha }}-release-build
 
 jobs:
   build-arm64:
     runs-on: blacksmith-4vcpu-ubuntu-2204-arm
     if: github.event.pull_request.merged == true
+    env:
+      NODE_OPTIONS: --max-old-space-size=6144
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Cache will be faster to restore instead of artifacts

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
