### PR TITLE
fix(core): Do not report security violations to Sentry in native Python runner (no-changelog)

### DIFF
--- a/packages/@n8n/task-runner-python/src/sentry.py
+++ b/packages/@n8n/task-runner-python/src/sentry.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Optional
 
-from src.errors import TaskCancelledError, TaskRuntimeError
+from src.errors import TaskCancelledError, TaskRuntimeError, SecurityViolationError
 from src.config.sentry_config import SentryConfig
 from src.constants import (
     EXECUTOR_FILENAMES,
@@ -9,6 +9,8 @@ from src.constants import (
     SENTRY_TAG_SERVER_TYPE_KEY,
     SENTRY_TAG_SERVER_TYPE_VALUE,
 )
+
+IGNORED_ERROR_TYPES = (TaskRuntimeError, TaskCancelledError, SecurityViolationError)
 
 
 class TaskRunnerSentry:
@@ -44,7 +46,7 @@ class TaskRunnerSentry:
     def _filter_out_ignored_errors(self, event: Any, hint: Any) -> Optional[Any]:
         if "exc_info" in hint:
             exc_type, _, _ = hint["exc_info"]
-            if exc_type in (TaskRuntimeError, TaskCancelledError):
+            if exc_type in IGNORED_ERROR_TYPES:
                 return None
 
         for exception in event.get("exception", {}).get("values", []):

--- a/packages/@n8n/task-runner-python/tests/unit/test_sentry.py
+++ b/packages/@n8n/task-runner-python/tests/unit/test_sentry.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from src.config.sentry_config import SentryConfig
-from src.errors.task_runtime_error import TaskRuntimeError
+from src.errors import TaskRuntimeError, TaskCancelledError, SecurityViolationError
 from src.sentry import TaskRunnerSentry, setup_sentry
 from src.constants import (
     EXECUTOR_ALL_ITEMS_FILENAME,
@@ -72,10 +72,18 @@ class TestTaskRunnerSentry:
 
             mock_flush.assert_called_once_with(timeout=2.0)
 
-    def test_filter_out_task_runtime_errors(self, sentry_config):
+    @pytest.mark.parametrize(
+        "error_type",
+        [
+            TaskRuntimeError,
+            TaskCancelledError,
+            SecurityViolationError,
+        ],
+    )
+    def test_filter_out_ignored_errors(self, sentry_config, error_type):
         sentry = TaskRunnerSentry(sentry_config)
         event = {"exception": {"values": []}}
-        hint = {"exc_info": (TaskRuntimeError, None, None)}
+        hint = {"exc_info": (error_type, None, None)}
 
         result = sentry._filter_out_ignored_errors(event, hint)
 


### PR DESCRIPTION
https://linear.app/n8n/issue/CAT-1450