### PR TITLE
perf(editor): Skip calculating log tree entirely when the panel is closed

### DIFF
--- a/packages/frontend/editor-ui/src/features/logs/components/LogsPanel.vue
+++ b/packages/frontend/editor-ui/src/features/logs/components/LogsPanel.vue
@@ -60,7 +60,7 @@ const {
 } = useChatState(props.isReadOnly);
 
 const { entries, execution, hasChat, latestNodeNameById, resetExecutionData, loadSubExecution } =
-	useLogsExecutionData();
+	useLogsExecutionData(isOpen);
 const { flatLogEntries, toggleExpanded } = useLogsTreeExpand(entries, loadSubExecution);
 const { selected, select, selectNext, selectPrev } = useLogsSelection(
 	execution,

--- a/packages/frontend/editor-ui/src/features/logs/composables/useLogsExecutionData.test.ts
+++ b/packages/frontend/editor-ui/src/features/logs/composables/useLogsExecutionData.test.ts
@@ -2,7 +2,7 @@ import { setActivePinia } from 'pinia';
 import { useLogsExecutionData } from './useLogsExecutionData';
 import { waitFor } from '@testing-library/vue';
 import { createTestingPinia } from '@pinia/testing';
-import { mockedStore } from '@/__tests__/utils';
+import { mockedStore, waitAllPromises } from '@/__tests__/utils';
 import { useWorkflowsStore } from '@/stores/workflows.store';
 import { useNodeTypesStore } from '@/stores/nodeTypes.store';
 import { nodeTypes } from '../__test__/data';
@@ -42,16 +42,18 @@ describe(useLogsExecutionData, () => {
 			);
 		});
 
-		it('should not calculate entries isEnabled is false', () => {
+		it('should not calculate entries isEnabled is false', async () => {
 			const { entries } = useLogsExecutionData(computed(() => false));
 
+			await waitAllPromises();
 			expect(entries.value).toHaveLength(0);
 		});
 
 		it('should calculate entries if isEnabled is true', async () => {
 			const { entries } = useLogsExecutionData(computed(() => true));
 
-			await waitFor(() => expect(entries.value).toHaveLength(1));
+			await waitAllPromises();
+			expect(entries.value).toHaveLength(1);
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/logs/composables/useLogsExecutionData.test.ts
+++ b/packages/frontend/editor-ui/src/features/logs/composables/useLogsExecutionData.test.ts
@@ -48,10 +48,10 @@ describe(useLogsExecutionData, () => {
 			expect(entries.value).toHaveLength(0);
 		});
 
-		it('should calculate entries if isEnabled is true', () => {
+		it('should calculate entries if isEnabled is true', async () => {
 			const { entries } = useLogsExecutionData(computed(() => true));
 
-			expect(entries.value).toHaveLength(1);
+			await waitFor(() => expect(entries.value).toHaveLength(1));
 		});
 	});
 
@@ -102,7 +102,7 @@ describe(useLogsExecutionData, () => {
 
 			const { loadSubExecution, entries } = useLogsExecutionData(computed(() => true));
 
-			expect(entries.value).toHaveLength(2);
+			await waitFor(() => expect(entries.value).toHaveLength(2));
 			expect(entries.value[1].children).toHaveLength(0);
 
 			await loadSubExecution(entries.value[1]);
@@ -133,6 +133,7 @@ describe(useLogsExecutionData, () => {
 
 			const { loadSubExecution, entries } = useLogsExecutionData(computed(() => true));
 
+			await waitFor(() => expect(entries.value).toHaveLength(2));
 			await loadSubExecution(entries.value[1]);
 
 			vi.advanceTimersByTime(1000);

--- a/packages/frontend/editor-ui/src/features/logs/composables/useLogsExecutionData.test.ts
+++ b/packages/frontend/editor-ui/src/features/logs/composables/useLogsExecutionData.test.ts
@@ -15,6 +15,7 @@ import {
 import type { IRunExecutionData } from 'n8n-workflow';
 import { stringify } from 'flatted';
 import { useToast } from '@/composables/useToast';
+import { computed } from 'vue';
 
 vi.mock('@/composables/useToast');
 
@@ -29,6 +30,29 @@ describe(useLogsExecutionData, () => {
 
 		nodeTypeStore = mockedStore(useNodeTypesStore);
 		nodeTypeStore.setNodeTypes(nodeTypes);
+	});
+
+	describe('isEnabled', () => {
+		beforeEach(() => {
+			workflowsStore.setWorkflowExecutionData(
+				createTestWorkflowExecutionResponse({
+					data: { resultData: { runData: { n0: [createTestTaskData()] } } },
+					workflowData: createTestWorkflow({ nodes: [createTestNode({ name: 'n0' })] }),
+				}),
+			);
+		});
+
+		it('should not calculate entries isEnabled is false', () => {
+			const { entries } = useLogsExecutionData(computed(() => false));
+
+			expect(entries.value).toHaveLength(0);
+		});
+
+		it('should calculate entries if isEnabled is true', () => {
+			const { entries } = useLogsExecutionData(computed(() => true));
+
+			expect(entries.value).toHaveLength(1);
+		});
 	});
 
 	describe('loadSubExecution', () => {
@@ -76,7 +100,7 @@ describe(useLogsExecutionData, () => {
 				}),
 			);
 
-			const { loadSubExecution, entries } = useLogsExecutionData();
+			const { loadSubExecution, entries } = useLogsExecutionData(computed(() => true));
 
 			expect(entries.value).toHaveLength(2);
 			expect(entries.value[1].children).toHaveLength(0);
@@ -107,7 +131,7 @@ describe(useLogsExecutionData, () => {
 				new Error('test execution fetch fail'),
 			);
 
-			const { loadSubExecution, entries } = useLogsExecutionData();
+			const { loadSubExecution, entries } = useLogsExecutionData(computed(() => true));
 
 			await loadSubExecution(entries.value[1]);
 

--- a/packages/frontend/editor-ui/src/features/logs/composables/useLogsExecutionData.ts
+++ b/packages/frontend/editor-ui/src/features/logs/composables/useLogsExecutionData.ts
@@ -1,29 +1,55 @@
-import { watch, computed, ref, type ComputedRef } from 'vue';
+import { watch, computed, ref, type ComputedRef, type Ref, shallowRef } from 'vue';
 import { type IExecutionResponse } from '@/Interface';
-import { Workflow, type IRunExecutionData } from 'n8n-workflow';
+import { Workflow, type IRunExecutionData, type ITaskStartedData } from 'n8n-workflow';
 import { useWorkflowsStore } from '@/stores/workflows.store';
 import { useNodeHelpers } from '@/composables/useNodeHelpers';
-import { useThrottleFn } from '@vueuse/core';
-import { createLogTree, findSubExecutionLocator, mergeStartData } from '@/features/logs/logs.utils';
+import {
+	copyExecutionData,
+	createLogTree,
+	findSubExecutionLocator,
+	mergeStartData,
+} from '@/features/logs/logs.utils';
 import { parse } from 'flatted';
 import { useToast } from '@/composables/useToast';
 import type { LatestNodeInfo, LogEntry } from '../logs.types';
 import { isChatNode } from '@/utils/aiUtils';
 import { LOGS_EXECUTION_DATA_THROTTLE_DURATION, PLACEHOLDER_EMPTY_WORKFLOW_ID } from '@/constants';
+import { useThrottleFn } from '@vueuse/core';
+
+// useThrottle with reactive timeout support
+function useThrottle<T>(state: Ref<T>, timeout: ComputedRef<number>) {
+	const throttled = shallowRef(state.value);
+
+	watch(
+		state,
+		useThrottleFn(() => (throttled.value = state.value), timeout, true, true),
+	);
+
+	return throttled;
+}
 
 export function useLogsExecutionData(isEnabled: ComputedRef<boolean>) {
 	const nodeHelpers = useNodeHelpers();
 	const workflowsStore = useWorkflowsStore();
 	const toast = useToast();
 
-	const execData = ref<IExecutionResponse | undefined>();
+	const state = ref<
+		| { response: IExecutionResponse; startData: { [nodeName: string]: ITaskStartedData[] } }
+		| undefined
+	>();
+	const updateInterval = computed(() =>
+		Object.keys(state.value?.startData ?? {}).length > 1
+			? LOGS_EXECUTION_DATA_THROTTLE_DURATION
+			: 0,
+	);
+	const throttledState = useThrottle(state, updateInterval);
 	const subWorkflowExecData = ref<Record<string, IRunExecutionData>>({});
 	const subWorkflows = ref<Record<string, Workflow>>({});
 
 	const workflow = computed(() =>
-		execData.value
+		throttledState.value
 			? new Workflow({
-					...execData.value?.workflowData,
+					...throttledState.value.response.workflowData,
 					nodeTypes: workflowsStore.getNodeTypes(),
 				})
 			: undefined,
@@ -50,26 +76,25 @@ export function useLogsExecutionData(isEnabled: ComputedRef<boolean>) {
 	);
 
 	const entries = computed<LogEntry[]>(() => {
-		if (!isEnabled.value || !execData.value?.data || !workflow.value) {
+		if (!isEnabled.value || !throttledState.value || !workflow.value) {
 			return [];
 		}
 
+		const mergedExecutionData = mergeStartData(
+			throttledState.value.startData,
+			throttledState.value.response,
+		);
+
 		return createLogTree(
 			workflow.value,
-			execData.value,
+			mergedExecutionData,
 			subWorkflows.value,
 			subWorkflowExecData.value,
 		);
 	});
 
-	const updateInterval = computed(() =>
-		(Object.keys(execData.value?.data?.resultData.runData ?? {}).length ?? 0) > 1
-			? LOGS_EXECUTION_DATA_THROTTLE_DURATION
-			: 0,
-	);
-
 	function resetExecutionData() {
-		execData.value = undefined;
+		state.value = undefined;
 		workflowsStore.setWorkflowExecutionData(null);
 		nodeHelpers.updateNodesExecutionIssues();
 	}
@@ -77,7 +102,7 @@ export function useLogsExecutionData(isEnabled: ComputedRef<boolean>) {
 	async function loadSubExecution(logEntry: LogEntry) {
 		const locator = findSubExecutionLocator(logEntry);
 
-		if (!execData.value?.data || locator === undefined) {
+		if (!state.value || locator === undefined) {
 			return;
 		}
 
@@ -110,26 +135,21 @@ export function useLogsExecutionData(isEnabled: ComputedRef<boolean>) {
 			() => workflowsStore.workflowExecutionResultDataLastUpdate,
 			() => workflowsStore.workflowExecutionStartedData,
 		],
-		useThrottleFn(
-			([executionId], [previousExecutionId]) => {
-				execData.value =
-					workflowsStore.workflowExecutionData === null
-						? undefined
-						: mergeStartData(
-								workflowsStore.workflowExecutionStartedData?.[1] ?? {},
-								workflowsStore.workflowExecutionData,
-							);
+		([executionId], [previousExecutionId]) => {
+			state.value =
+				workflowsStore.workflowExecutionData === null
+					? undefined
+					: {
+							response: copyExecutionData(workflowsStore.workflowExecutionData),
+							startData: workflowsStore.workflowExecutionStartedData?.[1] ?? {},
+						};
 
-				if (executionId !== previousExecutionId) {
-					// Reset sub workflow data when top-level execution changes
-					subWorkflowExecData.value = {};
-					subWorkflows.value = {};
-				}
-			},
-			updateInterval,
-			true,
-			true,
-		),
+			if (executionId !== previousExecutionId) {
+				// Reset sub workflow data when top-level execution changes
+				subWorkflowExecData.value = {};
+				subWorkflows.value = {};
+			}
+		},
 		{ immediate: true },
 	);
 
@@ -143,7 +163,7 @@ export function useLogsExecutionData(isEnabled: ComputedRef<boolean>) {
 	);
 
 	return {
-		execution: computed(() => execData.value),
+		execution: computed(() => throttledState.value?.response),
 		entries,
 		hasChat,
 		latestNodeNameById,

--- a/packages/frontend/editor-ui/src/features/logs/composables/useLogsExecutionData.ts
+++ b/packages/frontend/editor-ui/src/features/logs/composables/useLogsExecutionData.ts
@@ -135,21 +135,26 @@ export function useLogsExecutionData(isEnabled: ComputedRef<boolean>) {
 			() => workflowsStore.workflowExecutionResultDataLastUpdate,
 			() => workflowsStore.workflowExecutionStartedData,
 		],
-		([executionId], [previousExecutionId]) => {
-			state.value =
-				workflowsStore.workflowExecutionData === null
-					? undefined
-					: {
-							response: copyExecutionData(workflowsStore.workflowExecutionData),
-							startData: workflowsStore.workflowExecutionStartedData?.[1] ?? {},
-						};
+		useThrottleFn(
+			([executionId], [previousExecutionId]) => {
+				state.value =
+					workflowsStore.workflowExecutionData === null
+						? undefined
+						: {
+								response: copyExecutionData(workflowsStore.workflowExecutionData),
+								startData: workflowsStore.workflowExecutionStartedData?.[1] ?? {},
+							};
 
-			if (executionId !== previousExecutionId) {
-				// Reset sub workflow data when top-level execution changes
-				subWorkflowExecData.value = {};
-				subWorkflows.value = {};
-			}
-		},
+				if (executionId !== previousExecutionId) {
+					// Reset sub workflow data when top-level execution changes
+					subWorkflowExecData.value = {};
+					subWorkflows.value = {};
+				}
+			},
+			updateInterval,
+			true,
+			true,
+		),
 		{ immediate: true },
 	);
 

--- a/packages/frontend/editor-ui/src/features/logs/composables/useLogsExecutionData.ts
+++ b/packages/frontend/editor-ui/src/features/logs/composables/useLogsExecutionData.ts
@@ -1,4 +1,4 @@
-import { watch, computed, ref } from 'vue';
+import { watch, computed, ref, type ComputedRef } from 'vue';
 import { type IExecutionResponse } from '@/Interface';
 import { Workflow, type IRunExecutionData } from 'n8n-workflow';
 import { useWorkflowsStore } from '@/stores/workflows.store';
@@ -11,7 +11,7 @@ import type { LatestNodeInfo, LogEntry } from '../logs.types';
 import { isChatNode } from '@/utils/aiUtils';
 import { LOGS_EXECUTION_DATA_THROTTLE_DURATION, PLACEHOLDER_EMPTY_WORKFLOW_ID } from '@/constants';
 
-export function useLogsExecutionData() {
+export function useLogsExecutionData(isEnabled: ComputedRef<boolean>) {
 	const nodeHelpers = useNodeHelpers();
 	const workflowsStore = useWorkflowsStore();
 	const toast = useToast();
@@ -50,7 +50,7 @@ export function useLogsExecutionData() {
 	);
 
 	const entries = computed<LogEntry[]>(() => {
-		if (!execData.value?.data || !workflow.value) {
+		if (!isEnabled.value || !execData.value?.data || !workflow.value) {
 			return [];
 		}
 

--- a/packages/frontend/editor-ui/src/features/logs/composables/useLogsExecutionData.ts
+++ b/packages/frontend/editor-ui/src/features/logs/composables/useLogsExecutionData.ts
@@ -63,7 +63,9 @@ export function useLogsExecutionData(isEnabled: ComputedRef<boolean>) {
 	});
 
 	const updateInterval = computed(() =>
-		(entries.value?.length ?? 0) > 1 ? LOGS_EXECUTION_DATA_THROTTLE_DURATION : 0,
+		(Object.keys(execData.value?.data?.resultData.runData ?? {}).length ?? 0) > 1
+			? LOGS_EXECUTION_DATA_THROTTLE_DURATION
+			: 0,
 	);
 
 	function resetExecutionData() {

--- a/packages/frontend/editor-ui/src/features/logs/logs.utils.ts
+++ b/packages/frontend/editor-ui/src/features/logs/logs.utils.ts
@@ -593,3 +593,24 @@ export function isSubNodeLog(logEntry: LogEntry): boolean {
 export function isPlaceholderLog(treeNode: LogEntry): boolean {
 	return treeNode.runData === undefined;
 }
+
+/**
+ * Creates a copy of execution data just deep enough to keeps logs immutable and not reactive.
+ * We deliberately avoid full deep copy here for performance reason.
+ *
+ * TODO: use shallowRef() for execution data in workflows store to make this unnecessary.
+ */
+export function copyExecutionData(executionData: IExecutionResponse): IExecutionResponse {
+	return {
+		...executionData,
+		data: {
+			...executionData.data,
+			resultData: {
+				...executionData.data?.resultData,
+				runData: Object.fromEntries(
+					Object.entries(executionData.data?.resultData.runData ?? {}).map(([k, v]) => [k, [...v]]),
+				),
+			},
+		},
+	};
+}


### PR DESCRIPTION
## Summary

This PR improves UI responsiveness in manual workflow executions where the workflow generates large number of node runs. As shown below, long main thread work that appear every one second (=log view update interval) is gone.

Note that this is only effective when the log view is closed.

| Before | After |
|--------|--------|
| <img width="1512" height="945" alt="Screenshot 2025-09-24 at 16 05 22" src="https://github.com/user-attachments/assets/9e0e1a87-2f10-46f7-86fc-591ed62e7d67" /> | <img width="1512" height="945" alt="Screenshot 2025-09-24 at 16 19 46" src="https://github.com/user-attachments/assets/aaee3a39-e4e3-4b50-bce9-9c95796678d5" /> | 




## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1461/memory-usage-still-high-on-workflow-with-a-big-loop-before-workflow


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
