### PR TITLE
fix(editor): Fix UI being blocked from loading while data table limits are being fetched

### DIFF
--- a/packages/frontend/editor-ui/src/init.ts
+++ b/packages/frontend/editor-ui/src/init.ts
@@ -191,12 +191,13 @@ export async function initializeAuthenticatedFeatures(
 	}
 
 	if (settingsStore.isDataTableFeatureEnabled) {
-		const { quotaStatus } = await dataStoreStore.fetchDataStoreSize();
-		if (quotaStatus === 'error') {
-			uiStore.pushBannerToStack('DATA_STORE_STORAGE_LIMIT_ERROR');
-		} else if (quotaStatus === 'warn') {
-			uiStore.pushBannerToStack('DATA_STORE_STORAGE_LIMIT_WARNING');
-		}
+		void dataStoreStore.fetchDataStoreSize().then(({ quotaStatus }) => {
+			if (quotaStatus === 'error') {
+				uiStore.pushBannerToStack('DATA_STORE_STORAGE_LIMIT_ERROR');
+			} else if (quotaStatus === 'warn') {
+				uiStore.pushBannerToStack('DATA_STORE_STORAGE_LIMIT_WARNING');
+			}
+		});
 	}
 
 	if (insightsStore.isSummaryEnabled) {

--- a/packages/frontend/editor-ui/src/init.ts
+++ b/packages/frontend/editor-ui/src/init.ts
@@ -191,13 +191,18 @@ export async function initializeAuthenticatedFeatures(
 	}
 
 	if (settingsStore.isDataTableFeatureEnabled) {
-		void dataStoreStore.fetchDataStoreSize().then(({ quotaStatus }) => {
-			if (quotaStatus === 'error') {
-				uiStore.pushBannerToStack('DATA_STORE_STORAGE_LIMIT_ERROR');
-			} else if (quotaStatus === 'warn') {
-				uiStore.pushBannerToStack('DATA_STORE_STORAGE_LIMIT_WARNING');
-			}
-		});
+		void dataStoreStore
+			.fetchDataStoreSize()
+			.then(({ quotaStatus }) => {
+				if (quotaStatus === 'error') {
+					uiStore.pushBannerToStack('DATA_STORE_STORAGE_LIMIT_ERROR');
+				} else if (quotaStatus === 'warn') {
+					uiStore.pushBannerToStack('DATA_STORE_STORAGE_LIMIT_WARNING');
+				}
+			})
+			.catch((error) => {
+				console.error('Failed to fetch data table limits:', error);
+			});
 	}
 
 	if (insightsStore.isSummaryEnabled) {


### PR DESCRIPTION
## Summary

With data tables enabled at `1.113.0` UI's initialization was blocked by data table limits being fetched, which on cloud startup might take some time on startup to complete. This caused UI to show a blank page.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
