### PR TITLE
fix(editor): Make the data table size cache longer by default

### DIFF
--- a/packages/@n8n/config/src/configs/data-table.config.ts
+++ b/packages/@n8n/config/src/configs/data-table.config.ts
@@ -18,5 +18,5 @@ export class DataTableConfig {
 	 * This prevents excessive database queries for size validation.
 	 */
 	@Env('N8N_DATA_TABLES_SIZE_CHECK_CACHE_DURATION_MS')
-	sizeCheckCacheDuration: number = 5 * 1000;
+	sizeCheckCacheDuration: number = 60 * 1000;
 }

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -55,7 +55,7 @@ describe('GlobalConfig', () => {
 		dataTable: {
 			maxSize: 50 * 1024 * 1024,
 			warningThreshold: 45 * 1024 * 1024,
-			sizeCheckCacheDuration: 5000,
+			sizeCheckCacheDuration: 60000,
 		},
 		database: {
 			logging: {


### PR DESCRIPTION
## Summary

It seems like some users are hitting 524 errors on the `GET /data-tables-global/limits` queries on `1.113.0`. There's a [separate issue](https://github.com/n8n-io/n8n/pull/19871) that we shouldn't block our UI while these limtis are being fetched (causing the users to see a white blank screen), but it also seems like the 5 second cache is a bit ambitious - the users who have faced this issue already have many gigabytes of execution data on their instance, perhaps that's enough to slow down this query even though it accesses only other tables? 

I'm not sure why those queries are so slow for those customers, but it seems like they're not able to recover from that situation, and the 5 second cache probably doesn't help. Lets change the default to one minute - this means that users might spike over the limit easier, but lets shorten the cache after we're more confident that this mechanism works on real life users.

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.slack.com/archives/C036AELNMV0/p1758544247579329

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
