### PR TITLE
fix(core): Use different query to get sqlite data table sizes

### DIFF
--- a/packages/cli/src/modules/data-table/data-store.repository.ts
+++ b/packages/cli/src/modules/data-table/data-store.repository.ts
@@ -332,10 +332,13 @@ export class DataStoreRepository extends Repository<DataTable> {
 		switch (dbType) {
 			case 'sqlite':
 				sql = `
-        SELECT name AS table_name, SUM(pgsize) AS table_bytes
-         FROM dbstat
-        WHERE name LIKE '${tablePattern}'
-        GROUP BY name
+        WITH data_table_names(name) AS (
+          SELECT name
+          FROM sqlite_schema
+          WHERE type = 'table' AND name GLOB '${toTableName('*')}'
+        )
+        SELECT t.name AS table_name, (SELECT SUM(pgsize) FROM dbstat WHERE name = t.name) AS table_bytes
+        FROM data_table_names AS t
       `;
 				break;
 


### PR DESCRIPTION
## Summary

The query we used to determine data table sizes on sqlite was too slow on real life databases with unrelated execution/workflow data in other tables. The main reason seems to be the `LIKE data_table_user_%` part of the query, which forces a full table scan when getting just the data table's sizes.

With a subquery the query is way faster on instances with lots of other data, hopefully solving our `/data-tables-global/limits` endpoint's performance issues on `1.113.0` cloud.

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.slack.com/archives/C036AELNMV0/p1758544247579329

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
