### PR TITLE
fix: WooCommerce query authentication causing HPE_HEADER_OVERFLOW

### DIFF
--- a/packages/nodes-base/credentials/WooCommerceApi.credentials.ts
+++ b/packages/nodes-base/credentials/WooCommerceApi.credentials.ts
@@ -44,22 +44,25 @@ export class WooCommerceApi implements ICredentialType {
 				'Whether credentials should be included in the query. Occasionally, some servers may not parse the Authorization header correctly (if you see a “Consumer key is missing” error when authenticating over SSL, you have a server issue). In this case, you may provide the consumer key/secret as query string parameters instead.',
 		},
 	];
-
 	async authenticate(
 		credentials: ICredentialDataDecryptedObject,
 		requestOptions: IHttpRequestOptions,
 	): Promise<IHttpRequestOptions> {
-		requestOptions.auth = {
-			// @ts-ignore
-			user: credentials.consumerKey as string,
-			password: credentials.consumerSecret as string,
-		};
-		if (credentials.includeCredentialsInQuery === true && requestOptions.qs) {
-			delete requestOptions.auth;
+		if (credentials.includeCredentialsInQuery === true) {
+			// Use query parameters for authentication
+			if (!requestOptions.qs) {
+				requestOptions.qs = {};
+			}
 			Object.assign(requestOptions.qs, {
 				consumer_key: credentials.consumerKey,
 				consumer_secret: credentials.consumerSecret,
 			});
+		} else {
+			// Use HTTP Basic Auth
+			requestOptions.auth = {
+				user: credentials.consumerKey as string,
+				password: credentials.consumerSecret as string,
+			};
 		}
 		return requestOptions;
 	}

--- a/packages/nodes-base/credentials/WooCommerceApi.credentials.ts
+++ b/packages/nodes-base/credentials/WooCommerceApi.credentials.ts
@@ -54,14 +54,14 @@ export class WooCommerceApi implements ICredentialType {
 				requestOptions.qs = {};
 			}
 			Object.assign(requestOptions.qs, {
-				consumer_key: credentials.consumerKey,
-				consumer_secret: credentials.consumerSecret,
+				consumer_key: String(credentials.consumerKey || ''),
+				consumer_secret: String(credentials.consumerSecret || ''),
 			});
 		} else {
 			// Use HTTP Basic Auth
 			requestOptions.auth = {
-				user: credentials.consumerKey as string,
-				password: credentials.consumerSecret as string,
+				user: String(credentials.consumerKey || ''),
+				password: String(credentials.consumerSecret || ''),
 			};
 		}
 		return requestOptions;

--- a/packages/nodes-base/credentials/WooCommerceApi.test.ts
+++ b/packages/nodes-base/credentials/WooCommerceApi.test.ts
@@ -1,0 +1,92 @@
+import { WooCommerceApi } from './WooCommerceApi.credentials';
+import type { ICredentialDataDecryptedObject, IHttpRequestOptions } from 'n8n-workflow';
+
+describe('WooCommerceApi', () => {
+	let wooCommerceApi: WooCommerceApi;
+
+	beforeEach(() => {
+		wooCommerceApi = new WooCommerceApi();
+	});
+
+	describe('authenticate', () => {
+		it('should use Basic Auth by default', async () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				consumerKey: 'test_key',
+				consumerSecret: 'test_secret',
+				includeCredentialsInQuery: false,
+			};
+
+			const requestOptions: IHttpRequestOptions = {
+				url: 'https://example.com/api',
+			};
+
+			const result = await wooCommerceApi.authenticate(credentials, requestOptions);
+
+			expect(result.auth).toEqual({
+				user: 'test_key',
+				password: 'test_secret',
+			});
+			expect(result.qs).toBeUndefined();
+		});
+
+		it('should use query parameters when includeCredentialsInQuery is true', async () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				consumerKey: 'test_key',
+				consumerSecret: 'test_secret',
+				includeCredentialsInQuery: true,
+			};
+
+			const requestOptions: IHttpRequestOptions = {
+				url: 'https://example.com/api',
+			};
+
+			const result = await wooCommerceApi.authenticate(credentials, requestOptions);
+
+			expect(result.qs).toEqual({
+				consumer_key: 'test_key',
+				consumer_secret: 'test_secret',
+			});
+			expect(result.auth).toBeUndefined();
+		});
+
+		it('should handle existing query parameters', async () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				consumerKey: 'test_key',
+				consumerSecret: 'test_secret',
+				includeCredentialsInQuery: true,
+			};
+
+			const requestOptions: IHttpRequestOptions = {
+				url: 'https://example.com/api',
+				qs: { existing: 'param' },
+			};
+
+			const result = await wooCommerceApi.authenticate(credentials, requestOptions);
+
+			expect(result.qs).toEqual({
+				existing: 'param',
+				consumer_key: 'test_key',
+				consumer_secret: 'test_secret',
+			});
+		});
+
+		it('should handle non-string credentials gracefully', async () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				consumerKey: null,
+				consumerSecret: undefined,
+				includeCredentialsInQuery: false,
+			};
+
+			const requestOptions: IHttpRequestOptions = {
+				url: 'https://example.com/api',
+			};
+
+			const result = await wooCommerceApi.authenticate(credentials, requestOptions);
+
+			expect(result.auth).toEqual({
+				user: '',
+				password: '',
+			});
+		});
+	});
+});


### PR DESCRIPTION
Fix WooCommerce API credential issue when using Include Credentials in Query

Problem
Include Credentials in Query option was adding basic auth and query auth together This caused header overflow errors

Solution
Clean if else logic
Make sure qs exists before adding query params
Do not mix basic auth and query auth

Result
Query auth works fine
Basic auth works fine
No more header overflow

Change
Updated authenticate method in WooCommerceApi credentials ts