### PR TITLE
fix(Gmail Trigger Node): Show warning about multiple items returned

### DIFF
--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -63,6 +63,15 @@ export class GmailTrigger implements INodeType {
 		polling: true,
 		inputs: [],
 		outputs: [NodeConnectionTypes.Main],
+		hints: [
+			{
+				type: 'info',
+				message:
+					'Multiple items will be returned if multiple messages are received within the polling interval. Make sure your workflow can handle multiple items.',
+				whenToDisplay: 'beforeExecution',
+				location: 'outputPane',
+			},
+		],
 		properties: [
 			{
 				displayName: 'Authentication',


### PR DESCRIPTION
## Summary
This PR adds a warning message to let user know that the trigger can return multiple items

<img width="1500" height="567" alt="image" src="https://github.com/user-attachments/assets/6530d388-278d-4a4f-80cc-16f255672c03" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3588/gmail-trigger-multiple-items-returned-when-multiple-messages-received

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
