### PR TITLE
feat(core): Throw customized error on assigned custom role deletion

### DIFF
--- a/packages/cli/src/services/role.service.ts
+++ b/packages/cli/src/services/role.service.ts
@@ -88,6 +88,13 @@ export class RoleService {
 		if (role.systemRole) {
 			throw new BadRequestError('Cannot delete system roles');
 		}
+
+		// Check if any users is globally or project assigned to the role
+		const usersWithRole = await this.roleRepository.countUsersWithRole(role);
+		if (usersWithRole > 0) {
+			throw new BadRequestError('Cannot delete role assigned to users');
+		}
+
 		await this.roleRepository.removeBySlug(slug);
 
 		// Invalidate cache after role deletion


### PR DESCRIPTION

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR handles the case when the user tries to remove a custom role that is assigned to some users, either globally or through a project. If that's the case, then we throw a bad request with explicit message

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-3852/improve-error-messages-when-user-try-to-delete-a-role-thats-assigned

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
