### PR TITLE
fix(core): Batch markAsCrashed updates to avoid oversized queries

### DIFF
--- a/packages/@n8n/db/src/repositories/__tests__/execution.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/execution.repository.test.ts
@@ -5,7 +5,7 @@ import { ExecutionEntity } from '../../entities';
 import { mockEntityManager } from '../../utils/test-utils/mock-entity-manager';
 import { ExecutionRepository } from '../execution.repository';
 
-const GREATER_THAN_MAX_UPDATE_THRESHOLD = 32001;
+const GREATER_THAN_MAX_UPDATE_THRESHOLD = 901;
 
 /**
  * TODO: add tests for all the other methods

--- a/packages/@n8n/db/src/repositories/__tests__/execution.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/execution.repository.test.ts
@@ -5,6 +5,8 @@ import { ExecutionEntity } from '../../entities';
 import { mockEntityManager } from '../../utils/test-utils/mock-entity-manager';
 import { ExecutionRepository } from '../execution.repository';
 
+const GREATER_THAN_MAX_UPDATE_THRESHOLD = 32001;
+
 /**
  * TODO: add tests for all the other methods
  * TODO: getExecutionsForPublicApi -> add test cases for the `includeData` toggle
@@ -303,6 +305,18 @@ describe('ExecutionRepository', () => {
 				where: { status: 'running', mode: In(['webhook', 'trigger']) },
 			});
 			expect(result).toBe(mockCount);
+		});
+	});
+
+	describe('markAsCrashed', () => {
+		test('should batch updates above a threshold', async () => {
+			// Generates a list of many execution ids.
+			// NOTE: GREATER_THAN_MAX_UPDATE_THRESHOLD is selected to be just above the default threshold.
+			const manyExecutionsToMarkAsCrashed: string[] = Array(GREATER_THAN_MAX_UPDATE_THRESHOLD)
+				.fill(undefined)
+				.map((_, i) => i.toString());
+			await executionRepository.markAsCrashed(manyExecutionsToMarkAsCrashed);
+			expect(entityManager.update).toBeCalledTimes(2);
 		});
 	});
 });

--- a/packages/@n8n/db/src/repositories/execution.repository.ts
+++ b/packages/@n8n/db/src/repositories/execution.repository.ts
@@ -125,8 +125,8 @@ const moreThanOrEqual = (date: string): unknown => {
 };
 
 // This is the max number of elements in an IN-clause.
-// It's picked to work with the defaults for SQLite/Postgres/MySQL as of September 2025.
-const MAX_UPDATE_BATCH_SIZE = 32000;
+// It's a conservative value, as some databases indicate limits around 1000.
+const MAX_UPDATE_BATCH_SIZE = 900;
 
 @Service()
 export class ExecutionRepository extends Repository<ExecutionEntity> {

--- a/packages/@n8n/db/src/repositories/execution.repository.ts
+++ b/packages/@n8n/db/src/repositories/execution.repository.ts
@@ -398,7 +398,6 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 				},
 			);
 			this.logger.info('Marked executions as `crashed`', { executionIds });
-			// Updated processed count
 			processed += batch.length;
 		}
 	}


### PR DESCRIPTION
## Summary
Batch database updates during crash recovery to avoid failing during recovery.

When the instance crashes, we perform some recovery steps on the next start. In some cases, this means executions database updates. We use an `IN` to update many executions at once. In some cases, the number of executions to update exceeds the max size allowed in the `IN`-clause. This change breaks the updates into batches to avoid this.

NOTE: probably there are some general improvements around the crash recovery process that could be made. This change only addresses this particular symptom.

This change was manually tested as follows:
- Build `master`, start n8n.
- Create a workflow that calls itself then waits.
- This leads to a crash (out-of-memory).
- Set `N8N_EVENTBUS_RECOVERY_MODE=simple` in the `.env` file.
    - This is important to reproduce the issue because the `extensive` recovery mode already solves this by updating each execution id individually. This takes a really long time, but it works (eventually).
- Start again.
- Verify that we get a SQL error. <-- thus the issue is reproduced
- Checkout and build this branch.
- Start again.
- Verify that many database updates are executed (via existing debug logs) and that the instance starts up.

## Related Linear tickets, Github issues, and Community forum posts

fixes [CAT-1344](https://linear.app/n8n/issue/CAT-1344)


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
