### PR TITLE
fix: required and not required parse schema logic for jwt

### DIFF
--- a/packages/cli/src/public-api/v1/handlers/credentials/__tests__/credentials.service.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/credentials/__tests__/credentials.service.test.ts
@@ -67,5 +67,81 @@ describe('CredentialsService', () => {
 				condition.else?.allOf.some((notReq: any) => notReq.not?.required?.includes('field3')),
 			).toBe(true);
 		});
+
+		it('should generate correct schema for JWT credential fields with proper required fields', () => {
+			const jwtProperties: INodeProperties[] = [
+				{
+					displayName: 'Key Type',
+					name: 'keyType',
+					type: 'options',
+					description: 'Choose either the secret passphrase or PEM encoded public keys',
+					options: [
+						{ name: 'Passphrase', value: 'passphrase' },
+						{ name: 'PEM Key', value: 'pemKey' },
+					],
+					default: 'passphrase',
+				},
+				{
+					displayName: 'Secret',
+					name: 'secret',
+					type: 'string',
+					typeOptions: { password: true },
+					default: '',
+					displayOptions: { show: { keyType: ['passphrase'] } },
+				},
+				{
+					displayName: 'Private Key',
+					name: 'privateKey',
+					type: 'string',
+					typeOptions: { password: true },
+					default: '',
+					displayOptions: { show: { keyType: ['pemKey'] } },
+				},
+				{
+					displayName: 'Public Key',
+					name: 'publicKey',
+					type: 'string',
+					typeOptions: { password: true },
+					default: '',
+					displayOptions: { show: { keyType: ['pemKey'] } },
+				},
+				{
+					displayName: 'Algorithm',
+					name: 'algorithm',
+					type: 'options',
+					default: 'HS256',
+					options: [
+						{ name: 'HS256', value: 'HS256' },
+						{ name: 'HS384', value: 'HS384' },
+						{ name: 'HS512', value: 'HS512' },
+						{ name: 'RS256', value: 'RS256' },
+						{ name: 'RS384', value: 'RS384' },
+						{ name: 'RS512', value: 'RS512' },
+						{ name: 'ES256', value: 'ES256' },
+						{ name: 'ES384', value: 'ES384' },
+						{ name: 'ES512', value: 'ES512' },
+						{ name: 'PS256', value: 'PS256' },
+						{ name: 'PS384', value: 'PS384' },
+						{ name: 'PS512', value: 'PS512' },
+						{ name: 'none', value: 'none' },
+					],
+				},
+			];
+
+			const schema = toJsonSchema(jwtProperties);
+			const allOf = schema.allOf as any[];
+
+			// Check passphrase condition
+			const passphraseCond = allOf.find((cond) =>
+				cond.if?.properties?.keyType?.enum?.includes('passphrase'),
+			);
+			expect(passphraseCond).toBeDefined();
+			expect(passphraseCond.then?.required).toEqual(['secret']);
+
+			// Check PEM key condition
+			const pemCond = allOf.find((cond) => cond.if?.properties?.keyType?.enum?.includes('pemKey'));
+			expect(pemCond).toBeDefined();
+			expect(pemCond.then?.required.sort()).toEqual(['privateKey', 'publicKey'].sort());
+		});
 	});
 });

--- a/packages/cli/src/public-api/v1/handlers/credentials/__tests__/credentials.service.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/credentials/__tests__/credentials.service.test.ts
@@ -60,12 +60,8 @@ describe('CredentialsService', () => {
 				enum: [false], // boolean false as dependant value
 			});
 
-			// then block requires field3 when field2 === false
-			expect(condition.then?.allOf.some((req: any) => req.required?.includes('field3'))).toBe(true);
-			// else block forbids field3 when field2 !== false
-			expect(
-				condition.else?.allOf.some((notReq: any) => notReq.not?.required?.includes('field3')),
-			).toBe(true);
+			expect((condition.then as any).required).toEqual(['field3']);
+			expect((condition.else as any).not.required).toEqual(['field3']);
 		});
 
 		it('should generate correct schema for JWT credential fields with proper required fields', () => {

--- a/packages/cli/src/public-api/v1/handlers/credentials/__tests__/credentials.service.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/credentials/__tests__/credentials.service.test.ts
@@ -136,12 +136,18 @@ describe('CredentialsService', () => {
 				cond.if?.properties?.keyType?.enum?.includes('passphrase'),
 			);
 			expect(passphraseCond).toBeDefined();
-			expect(passphraseCond.then?.required).toEqual(['secret']);
+			expect(passphraseCond.then?.allOf.some((r: any) => r.required?.includes('secret'))).toBe(
+				true,
+			);
 
 			// Check PEM key condition
 			const pemCond = allOf.find((cond) => cond.if?.properties?.keyType?.enum?.includes('pemKey'));
 			expect(pemCond).toBeDefined();
-			expect(pemCond.then?.required.sort()).toEqual(['privateKey', 'publicKey'].sort());
+			expect(
+				pemCond.then?.allOf.some((r: any) =>
+					['privateKey', 'publicKey'].every((key) => r.required?.includes(key)),
+				),
+			).toBe(true);
 		});
 	});
 });

--- a/packages/cli/src/public-api/v1/handlers/credentials/__tests__/credentials.service.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/credentials/__tests__/credentials.service.test.ts
@@ -60,8 +60,12 @@ describe('CredentialsService', () => {
 				enum: [false], // boolean false as dependant value
 			});
 
-			expect((condition.then as any).required).toEqual(['field3']);
-			expect((condition.else as any).not.required).toEqual(['field3']);
+			expect(
+				(condition.then as any).allOf.some((req: any) => req.required?.includes('field3')),
+			).toBe(true);
+			expect(
+				(condition.else as any).allOf.some((req: any) => req.not?.required?.includes('field3')),
+			).toBe(true);
 		});
 
 		it('should generate correct schema for JWT credential fields with proper required fields', () => {

--- a/packages/cli/src/public-api/v1/handlers/credentials/credentials.service.ts
+++ b/packages/cli/src/public-api/v1/handlers/credentials/credentials.service.ts
@@ -19,7 +19,7 @@ import { EventService } from '@/events/event.service';
 import { ExternalHooks } from '@/external-hooks';
 import type { CredentialRequest } from '@/requests';
 
-import type { IDependency, IJsonSchema } from '../../../types';
+import type { IJsonSchema } from '../../../types';
 
 export async function getCredentials(credentialId: string): Promise<ICredentialsDb | null> {
 	return await Container.get(CredentialsRepository).findOneBy({ id: credentialId });

--- a/packages/cli/src/public-api/v1/handlers/credentials/credentials.service.ts
+++ b/packages/cli/src/public-api/v1/handlers/credentials/credentials.service.ts
@@ -220,8 +220,8 @@ export function toJsonSchema(properties: INodeProperties[]): IDataObject {
 
 			const valueKey =
 				typeof dependantValue === 'object' && dependantValue._cnd
-					? JSON.stringify(dependantValue._cnd)
-					: String(dependantValue);
+					? JSON.stringify(dependantValue)
+					: JSON.stringify(dependantValue);
 
 			if (!propertyRequiredDependencies[dependantName][valueKey]) {
 				propertyRequiredDependencies[dependantName][valueKey] = [];
@@ -310,14 +310,9 @@ export function toJsonSchema(properties: INodeProperties[]): IDataObject {
 				};
 			}
 			conditionalSchemas.push({
-				if: {
-					properties: {
-						[dependantName]: conditionalValue,
-					},
-				},
-				then: {
-					required: propertyNames,
-				},
+				if: { properties: { [dependantName]: conditionalValue } },
+				then: { allOf: propertyNames.map((name) => ({ required: [name] })) },
+				else: { allOf: propertyNames.map((name) => ({ not: { required: [name] } })) },
 			});
 		});
 	});


### PR DESCRIPTION
## Summary

Fixed the parsing of required value which used to add wrong values in required and not required sections. Now, grouped by dependent property + value to reduce redundancy. Before it was using only property which causes wrong fields which prevented requests from generating the correct schema.

These were wrong logic:

```
propertyRequiredDependencies[dependantName].then?.allOf.push({ required: [property.name] });
			propertyRequiredDependencies[dependantName].else?.allOf.push({
				not: { required: [property.name] },
			});
```

### Steps to reproduce the bug:
1. Create an API key
2. Create a key-pair and send this via postman or something else;
```
curl --location 'http://localhost:5678/api/v1/credentials/' \
--header 'Content-Type: application/json' \
--header 'X-N8N-API-KEY: $API_KEY' \
--data '{
  "name": "Test-JWT-Auth",
  "type": "jwtAuth",
  "data": {
    "keyType": "pemKey",
    "publicKey": "-----BEGIN PUBLIC KEY-----\n....-----END PUBLIC KEY-----\n",
    "privateKey":"",
    "algorithm": "RS256"
  }
}'
```

fixes #19869 

### Video demo of fix:
Loom:
https://www.loom.com/share/2bef01f482954c85acb9101163b68320?sid=e19c699d-ddd4-4eb4-88bd-3a20d9fb6649

## Related Community forum posts
https://community.n8n.io/t/creating-pem-credentials-through-api/52059/2

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
