### PR TITLE
fix(editor): Make shortcuts for toggling input/output panel work in the popped out log view

### DIFF
--- a/packages/frontend/editor-ui/src/features/logs/components/LogsPanel.vue
+++ b/packages/frontend/editor-ui/src/features/logs/components/LogsPanel.vue
@@ -104,6 +104,14 @@ const keyMap = computed<KeyMap>(() => ({
 	ArrowUp: selectPrev,
 	Space: () => selected.value && toggleExpanded(selected.value),
 	Enter: () => selected.value && handleOpenNdv(selected.value),
+	...(isPoppedOut.value
+		? {
+				// We need shortcuts for toggling input/output panel in the pop-out window only
+				// because these are also implemented in the canvas
+				i: () => logsStore.toggleInputOpen(),
+				o: () => logsStore.toggleOutputOpen(),
+			}
+		: {}),
 }));
 
 function handleResizeOverviewPanelEnd() {


### PR DESCRIPTION
## Summary

This PR fixes the bug where keyboard shortcuts for toggling input/output panel doesn't work when the log view is shown in the pop-out window.

https://github.com/user-attachments/assets/dd715447-abb7-4c49-9481-b725be28f31c

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1379/bug-keyboard-shortcut-keys-for-inputoutput-ignored-when-in-log-view


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
