### PR TITLE
fix(core): Show error description in tools

### DIFF
--- a/packages/workflow/src/errors/node-operation.error.ts
+++ b/packages/workflow/src/errors/node-operation.error.ts
@@ -32,7 +32,11 @@ export class NodeOperationError extends NodeError {
 		this.level = options.level ?? 'warning';
 		if (options.functionality) this.functionality = options.functionality;
 		if (options.type) this.type = options.type;
-		this.description = options.description;
+
+		if (options.description) this.description = options.description;
+		else if ('description' in error && typeof error.description === 'string')
+			this.description = error.description;
+
 		this.context.runIndex = options.runIndex;
 		this.context.itemIndex = options.itemIndex;
 		this.context.metadata = options.metadata;

--- a/packages/workflow/test/node-errors.test.ts
+++ b/packages/workflow/test/node-errors.test.ts
@@ -1,5 +1,5 @@
 import { UNKNOWN_ERROR_DESCRIPTION, UNKNOWN_ERROR_MESSAGE } from '../src/constants';
-import { NodeOperationError } from '../src/errors';
+import { ExpressionError, NodeOperationError } from '../src/errors';
 import { NodeApiError } from '../src/errors/node-api.error';
 import type { INode, JsonObject } from '../src/interfaces';
 
@@ -121,6 +121,24 @@ describe('NodeErrors tests', () => {
 		expect(nodeOperationError.message).toEqual('some text');
 
 		expect(nodeOperationError.description).toEqual(undefined);
+	});
+
+	it('should use error description if no options do not provide one, NodeOperationError', () => {
+		const error = new ExpressionError('aMessage', { description: 'an error description' });
+		const nodeOperationError = new NodeOperationError(node, error);
+
+		expect(nodeOperationError.message).toEqual('aMessage');
+		expect(nodeOperationError.description).toEqual('an error description');
+	});
+
+	it('should use options description even if error provides one, NodeOperationError', () => {
+		const error = new ExpressionError('aMessage', { description: 'an error description' });
+		const nodeOperationError = new NodeOperationError(node, error, {
+			description: 'another description',
+		});
+
+		expect(nodeOperationError.message).toEqual('aMessage');
+		expect(nodeOperationError.description).toEqual('another description');
 	});
 
 	it('should remove description if it is equal to message, message provided in options take precedence over original, NodeApiError', () => {


### PR DESCRIPTION
## Summary

This enables tools to display the error description.

Before
<img width="618" height="277" alt="image" src="https://github.com/user-attachments/assets/3b9720de-0628-4729-aa1e-13eb20f0b6cc" />

After
<img width="614" height="285" alt="image" src="https://github.com/user-attachments/assets/bd0f5b88-c784-429d-a7e5-fe9fd205ce83" />

## Related Linear tickets, Github issues, and Community forum posts


https://linear.app/n8n/issue/ADO-4185

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
