### PR TITLE
feat: Add endpoint to get builder credits and quota (no-changelog)

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/ai-workflow-builder-agent.service.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/ai-workflow-builder-agent.service.ts
@@ -326,4 +326,9 @@ export class AiWorkflowBuilderService {
 
 		return { sessions };
 	}
+
+	async getBuilderInstanceCredits(user: IUser) {
+		assert(this.client, 'AI Assistant client is not setup');
+		return await this.client.getBuilderInstanceCredits(user);
+	}
 }

--- a/packages/@n8n/ai-workflow-builder.ee/src/ai-workflow-builder-agent.service.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/ai-workflow-builder-agent.service.ts
@@ -5,7 +5,7 @@ import { LangChainTracer } from '@langchain/core/tracers/tracer_langchain';
 import { MemorySaver } from '@langchain/langgraph';
 import { Logger } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
-import { AiAssistantClient } from '@n8n_io/ai-assistant-sdk';
+import { AiAssistantClient, AiAssistantSDK } from '@n8n_io/ai-assistant-sdk';
 import assert from 'assert';
 import { Client as TracingClient } from 'langsmith';
 import { INodeTypes } from 'n8n-workflow';
@@ -327,8 +327,17 @@ export class AiWorkflowBuilderService {
 		return { sessions };
 	}
 
-	async getBuilderInstanceCredits(user: IUser) {
-		assert(this.client, 'AI Assistant client is not setup');
-		return await this.client.getBuilderInstanceCredits(user);
+	async getBuilderInstanceCredits(
+		user: IUser,
+	): Promise<AiAssistantSDK.BuilderInstanceCreditsResponse> {
+		if (this.client) {
+			return await this.client.getBuilderInstanceCredits(user);
+		}
+
+		// if using env variables directly instead of ai proxy service
+		return {
+			creditsQuota: -1,
+			creditsClaimed: 0,
+		};
 	}
 }

--- a/packages/@n8n/ai-workflow-builder.ee/src/test/ai-workflow-builder-agent.service.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/test/ai-workflow-builder-agent.service.test.ts
@@ -678,12 +678,15 @@ describe('AiWorkflowBuilderService', () => {
 			expect(mockClient.getBuilderInstanceCredits).toHaveBeenCalledWith(mockUser);
 		});
 
-		it('should throw error when client is not configured', async () => {
+		it('should return default values when client is not configured', async () => {
 			const serviceWithoutClient = new AiWorkflowBuilderService(mockNodeTypes);
 
-			await expect(serviceWithoutClient.getBuilderInstanceCredits(mockUser)).rejects.toThrow(
-				'AI Assistant client is not setup',
-			);
+			const result = await serviceWithoutClient.getBuilderInstanceCredits(mockUser);
+
+			expect(result).toEqual({
+				creditsQuota: -1,
+				creditsClaimed: 0,
+			});
 		});
 	});
 });

--- a/packages/@n8n/ai-workflow-builder.ee/src/test/ai-workflow-builder-agent.service.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/test/ai-workflow-builder-agent.service.test.ts
@@ -662,4 +662,28 @@ describe('AiWorkflowBuilderService', () => {
 			expect(sessions.sessions[0].sessionId).toBe('test-thread-id');
 		});
 	});
+
+	describe('getBuilderInstanceCredits', () => {
+		it('should return builder instance credits when client is available', async () => {
+			const expectedCredits = {
+				creditsQuota: 100,
+				creditsClaimed: 25,
+			};
+
+			(mockClient.getBuilderInstanceCredits as jest.Mock).mockResolvedValue(expectedCredits);
+
+			const result = await service.getBuilderInstanceCredits(mockUser);
+
+			expect(result).toEqual(expectedCredits);
+			expect(mockClient.getBuilderInstanceCredits).toHaveBeenCalledWith(mockUser);
+		});
+
+		it('should throw error when client is not configured', async () => {
+			const serviceWithoutClient = new AiWorkflowBuilderService(mockNodeTypes);
+
+			await expect(serviceWithoutClient.getBuilderInstanceCredits(mockUser)).rejects.toThrow(
+				'AI Assistant client is not setup',
+			);
+		});
+	});
 });

--- a/packages/@n8n/constants/src/index.ts
+++ b/packages/@n8n/constants/src/index.ts
@@ -37,6 +37,7 @@ export const LICENSE_FEATURES = {
 	API_KEY_SCOPES: 'feat:apiKeyScopes',
 	WORKFLOW_DIFFS: 'feat:workflowDiffs',
 	CUSTOM_ROLES: 'feat:customRoles',
+	AI_BUILDER: 'feat:aiBuilder',
 } as const;
 
 export const LICENSE_QUOTAS = {

--- a/packages/cli/src/controllers/__tests__/ai.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/ai.controller.test.ts
@@ -397,4 +397,30 @@ describe('AiController', () => {
 			});
 		});
 	});
+
+	describe('getBuilderCredits', () => {
+		it('should return builder instance credits successfully', async () => {
+			const expectedCredits: AiAssistantSDK.BuilderInstanceCreditsResponse = {
+				creditsQuota: 100,
+				creditsClaimed: 25,
+			};
+
+			workflowBuilderService.getBuilderInstanceCredits.mockResolvedValue(expectedCredits);
+
+			const result = await controller.getBuilderCredits(request, response);
+
+			expect(workflowBuilderService.getBuilderInstanceCredits).toHaveBeenCalledWith(request.user);
+			expect(result).toEqual(expectedCredits);
+		});
+
+		it('should throw InternalServerError if getting credits fails', async () => {
+			const mockError = new Error('Failed to get credits');
+			workflowBuilderService.getBuilderInstanceCredits.mockRejectedValue(mockError);
+
+			await expect(controller.getBuilderCredits(request, response)).rejects.toThrow(
+				InternalServerError,
+			);
+			expect(workflowBuilderService.getBuilderInstanceCredits).toHaveBeenCalledWith(request.user);
+		});
+	});
 });

--- a/packages/cli/src/controllers/ai.controller.ts
+++ b/packages/cli/src/controllers/ai.controller.ts
@@ -8,7 +8,7 @@ import {
 	AiSessionRetrievalRequestDto,
 } from '@n8n/api-types';
 import { AuthenticatedRequest } from '@n8n/db';
-import { Body, Get, Post, RestController } from '@n8n/decorators';
+import { Body, Get, Licensed, Post, RestController } from '@n8n/decorators';
 import { type AiAssistantSDK, APIResponseError } from '@n8n_io/ai-assistant-sdk';
 import { Response } from 'express';
 import { OPEN_AI_API_CREDENTIAL_TYPE } from 'n8n-workflow';
@@ -39,6 +39,7 @@ export class AiController {
 	// Use usesTemplates flag to bypass the send() wrapper which would cause
 	// "Cannot set headers after they are sent" error for streaming responses.
 	// This ensures errors during streaming are handled within the stream itself.
+	@Licensed('feat:aiBuilder')
 	@Post('/build', { rateLimit: { limit: 100 }, usesTemplates: true })
 	async build(
 		req: AuthenticatedRequest,
@@ -208,6 +209,7 @@ export class AiController {
 		}
 	}
 
+	@Licensed('feat:aiBuilder')
 	@Post('/sessions', { rateLimit: { limit: 100 } })
 	async getSessions(
 		req: AuthenticatedRequest,
@@ -223,6 +225,7 @@ export class AiController {
 		}
 	}
 
+	@Licensed('feat:aiBuilder')
 	@Get('/build/credits')
 	async getBuilderCredits(
 		req: AuthenticatedRequest,

--- a/packages/cli/src/controllers/ai.controller.ts
+++ b/packages/cli/src/controllers/ai.controller.ts
@@ -8,7 +8,7 @@ import {
 	AiSessionRetrievalRequestDto,
 } from '@n8n/api-types';
 import { AuthenticatedRequest } from '@n8n/db';
-import { Body, Post, RestController } from '@n8n/decorators';
+import { Body, Get, Post, RestController } from '@n8n/decorators';
 import { type AiAssistantSDK, APIResponseError } from '@n8n_io/ai-assistant-sdk';
 import { Response } from 'express';
 import { OPEN_AI_API_CREDENTIAL_TYPE } from 'n8n-workflow';
@@ -217,6 +217,19 @@ export class AiController {
 		try {
 			const sessions = await this.workflowBuilderService.getSessions(payload.workflowId, req.user);
 			return sessions;
+		} catch (e) {
+			assert(e instanceof Error);
+			throw new InternalServerError(e.message, e);
+		}
+	}
+
+	@Get('/build/credits')
+	async getBuilderCredits(
+		req: AuthenticatedRequest,
+		_: Response,
+	): Promise<AiAssistantSDK.BuilderInstanceCreditsResponse> {
+		try {
+			return await this.workflowBuilderService.getBuilderInstanceCredits(req.user);
 		} catch (e) {
 			assert(e instanceof Error);
 			throw new InternalServerError(e.message, e);

--- a/packages/cli/src/controllers/e2e.controller.ts
+++ b/packages/cli/src/controllers/e2e.controller.ts
@@ -116,6 +116,7 @@ export class E2EController {
 		[LICENSE_FEATURES.MFA_ENFORCEMENT]: false,
 		[LICENSE_FEATURES.WORKFLOW_DIFFS]: false,
 		[LICENSE_FEATURES.CUSTOM_ROLES]: false,
+		[LICENSE_FEATURES.AI_BUILDER]: false,
 	};
 
 	private static readonly numericFeaturesDefaults: Record<NumericLicenseFeature, number> = {

--- a/packages/cli/src/services/__tests__/ai-workflow-builder.service.test.ts
+++ b/packages/cli/src/services/__tests__/ai-workflow-builder.service.test.ts
@@ -330,4 +330,43 @@ describe('WorkflowBuilderService', () => {
 			);
 		});
 	});
+
+	describe('getBuilderInstanceCredits', () => {
+		it('should return builder instance credits', async () => {
+			const expectedCredits = {
+				creditsQuota: 100,
+				creditsClaimed: 25,
+			};
+
+			const mockAiService = mock<AiWorkflowBuilderService>();
+			(mockAiService.getBuilderInstanceCredits as jest.Mock).mockResolvedValue(expectedCredits);
+			MockedAiWorkflowBuilderService.mockImplementation(() => mockAiService);
+
+			const result = await service.getBuilderInstanceCredits(mockUser);
+
+			expect(MockedAiWorkflowBuilderService).toHaveBeenCalledTimes(1);
+			expect(mockAiService.getBuilderInstanceCredits).toHaveBeenCalledWith(mockUser);
+			expect(result).toEqual(expectedCredits);
+		});
+
+		it('should reuse existing service instance', async () => {
+			const expectedCredits = {
+				creditsQuota: 50,
+				creditsClaimed: 10,
+			};
+
+			const mockAiService = mock<AiWorkflowBuilderService>();
+			(mockAiService.getBuilderInstanceCredits as jest.Mock).mockResolvedValue(expectedCredits);
+			MockedAiWorkflowBuilderService.mockImplementation(() => mockAiService);
+
+			// Call twice to test service reuse
+			await service.getBuilderInstanceCredits(mockUser);
+			const result = await service.getBuilderInstanceCredits(mockUser);
+
+			// Should only create the service once
+			expect(MockedAiWorkflowBuilderService).toHaveBeenCalledTimes(1);
+			expect(mockAiService.getBuilderInstanceCredits).toHaveBeenCalledTimes(2);
+			expect(result).toEqual(expectedCredits);
+		});
+	});
 });

--- a/packages/cli/src/services/ai-workflow-builder.service.ts
+++ b/packages/cli/src/services/ai-workflow-builder.service.ts
@@ -82,4 +82,9 @@ export class WorkflowBuilderService {
 		const sessions = await service.getSessions(workflowId, user);
 		return sessions;
 	}
+
+	async getBuilderInstanceCredits(user: IUser) {
+		const service = await this.getService();
+		return await service.getBuilderInstanceCredits(user);
+	}
 }


### PR DESCRIPTION
## Summary

- Add endpoint to CLI that allows users to get number of builder credits remaining  from ai-assistant service.
- Add license checks for builder endpoints

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
