### PR TITLE
ci: Add manual dispatch for base image

### DIFF
--- a/.github/workflows/docker-base-image.yml
+++ b/.github/workflows/docker-base-image.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     paths:
       - 'docker/images/n8n-base/Dockerfile'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

Allows manual triggering of base docker image, useful when there are updated packages available but we don't need to make changes to the base image file.

## Related Linear tickets, Github issues, and Community forum posts



## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
