### PR TITLE
fix(core): Allow accessing nodes.json in preview mode

### DIFF
--- a/packages/@n8n/decorators/src/controller/route.ts
+++ b/packages/@n8n/decorators/src/controller/route.ts
@@ -9,6 +9,7 @@ interface RouteOptions {
 	usesTemplates?: boolean;
 	/** When this flag is set to true, auth cookie isn't validated, and req.user will not be set */
 	skipAuth?: boolean;
+	allowSkipPreviewAuth?: boolean;
 	/** When this flag is set to true, the auth cookie does not enforce MFA to be used in the token */
 	allowSkipMFA?: boolean;
 	/** When these options are set, calls to this endpoint are rate limited using the options */
@@ -28,6 +29,7 @@ const RouteFactory =
 		routeMetadata.middlewares = options.middlewares ?? [];
 		routeMetadata.usesTemplates = options.usesTemplates ?? false;
 		routeMetadata.skipAuth = options.skipAuth ?? false;
+		routeMetadata.allowSkipPreviewAuth = options.allowSkipPreviewAuth ?? false;
 		routeMetadata.allowSkipMFA = options.allowSkipMFA ?? false;
 		routeMetadata.rateLimit = options.rateLimit;
 	};

--- a/packages/@n8n/decorators/src/controller/types.ts
+++ b/packages/@n8n/decorators/src/controller/types.ts
@@ -33,6 +33,7 @@ export interface RouteMetadata {
 	middlewares: RequestHandler[];
 	usesTemplates: boolean;
 	skipAuth: boolean;
+	allowSkipPreviewAuth: boolean;
 	allowSkipMFA: boolean;
 	rateLimit?: boolean | RateLimit;
 	licenseFeature?: BooleanLicenseFeature;

--- a/packages/cli/src/controller.registry.ts
+++ b/packages/cli/src/controller.registry.ts
@@ -87,7 +87,10 @@ export class ControllerRegistry {
 				...(route.skipAuth
 					? []
 					: ([
-							this.authService.createAuthMiddleware(route.allowSkipMFA),
+							this.authService.createAuthMiddleware({
+								allowSkipMFA: route.allowSkipMFA,
+								allowSkipPreviewAuth: route.allowSkipPreviewAuth,
+							}),
 							this.lastActiveAtService.middleware.bind(this.lastActiveAtService),
 						] as RequestHandler[])),
 				...(route.licenseFeature ? [this.createLicenseMiddleware(route.licenseFeature)] : []),

--- a/packages/cli/src/push/index.ts
+++ b/packages/cli/src/push/index.ts
@@ -95,7 +95,7 @@ export class Push extends TypedEmitter<PushEvents> {
 		app.use(
 			`/${restEndpoint}/push`,
 
-			this.authService.createAuthMiddleware(false),
+			this.authService.createAuthMiddleware({ allowSkipMFA: false }),
 			(req: SSEPushRequest | WebSocketPushRequest, res: PushResponse) =>
 				this.handleRequest(req, res),
 		);

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -337,7 +337,7 @@ export class Server extends AbstractServer {
 		protectedTypeFiles.forEach((path) => {
 			this.app.get(
 				path,
-				authService.createAuthMiddleware(true),
+				authService.createAuthMiddleware({ allowSkipMFA: true, allowSkipPreviewAuth: true }),
 				async (_, res: express.Response) => {
 					res.setHeader('Cache-Control', 'no-cache, must-revalidate');
 					res.sendFile(path.substring(1), {

--- a/packages/cli/src/services/hooks.service.ts
+++ b/packages/cli/src/services/hooks.service.ts
@@ -42,7 +42,7 @@ export class HooksService {
 		private readonly workflowRepository: WorkflowRepository,
 		private readonly credentialsRepository: CredentialsRepository,
 	) {
-		this.innerAuthMiddleware = authService.createAuthMiddleware(false);
+		this.innerAuthMiddleware = authService.createAuthMiddleware({ allowSkipMFA: false });
 	}
 
 	/**

--- a/packages/cli/src/services/last-active-at.service.ts
+++ b/packages/cli/src/services/last-active-at.service.ts
@@ -14,15 +14,13 @@ export class LastActiveAtService {
 		private readonly logger: Logger,
 	) {}
 
-	async middleware(req: AuthenticatedRequest, res: Response, next: NextFunction) {
+	async middleware(req: AuthenticatedRequest, _res: Response, next: NextFunction) {
 		if (req.user) {
 			this.updateLastActiveIfStale(req.user.id).catch((error: unknown) => {
 				this.logger.error('Failed to update last active timestamp', { error });
 			});
-			next();
-		} else {
-			res.status(401).json({ status: 'error', message: 'Unauthorized' });
 		}
+		next();
 	}
 
 	async updateLastActiveIfStale(userId: string) {


### PR DESCRIPTION
## Summary

This PR updates cli packages and adds a new `allowSkipPreviewAuth` option to `authService.createAuthMiddleware`.
When this option is set to true for a route and the instance is in preview mode, the authentication will be attempted if cookies are present, but otherwise it will be skipped.

I've created a [simple app](https://github.com/yehorkardash/n8n-preview-test) to test iframe integration which can be used to test the fix

allowSkipPreviewAuth is disabled:

<img width="1026" height="569" alt="image" src="https://github.com/user-attachments/assets/2bf654b0-3aa0-4e9f-8abe-9a00594b0f19" />

allowSkipPreviewAuth is enabled:

<img width="710" height="374" alt="image" src="https://github.com/user-attachments/assets/2b697220-7dd7-486f-9e9c-cfbe98be4eca" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3685/preview-instance-does-not-render-nodes-properly

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
