### PR TITLE
fix(editor): Fix inputs when extracting sub-workflows with Split Out nodes

### DIFF
--- a/packages/frontend/editor-ui/src/composables/useWorkflowExtraction.ts
+++ b/packages/frontend/editor-ui/src/composables/useWorkflowExtraction.ts
@@ -89,7 +89,6 @@ export function useWorkflowExtraction() {
 		name: string,
 		position: [number, number],
 		variables: Map<string, string>,
-		forcePassthrough: boolean,
 	): Omit<INode, 'id'> {
 		return {
 			parameters: {
@@ -101,21 +100,19 @@ export function useWorkflowExtraction() {
 				workflowInputs: {
 					mappingMode: 'defineBelow',
 					value: Object.fromEntries(variables.entries().map(([k, v]) => [k, `={{ ${v} }}`])),
-					matchingColumns: forcePassthrough ? [] : [...variables.keys()],
-					schema: forcePassthrough
-						? []
-						: [
-								...variables.keys().map((x) => ({
-									id: x,
-									displayName: x,
-									required: false,
-									defaultMatch: false,
-									display: true,
-									canBeUsedToMatch: true,
-									removed: false,
-									// omitted type implicitly uses our `any` type
-								})),
-							],
+					matchingColumns: [...variables.keys()],
+					schema: [
+						...variables.keys().map((x) => ({
+							id: x,
+							displayName: x,
+							required: false,
+							defaultMatch: false,
+							display: true,
+							canBeUsedToMatch: true,
+							removed: false,
+							// omitted type implicitly uses our `any` type
+						})),
+					],
 					attemptToConvertTypes: false,
 					convertFieldsToString: true,
 				},
@@ -137,7 +134,6 @@ export function useWorkflowExtraction() {
 		selectionChildrenVariables: Map<string, string>,
 		startNodeName: string,
 		returnNodeName: string,
-		forcePassthrough: boolean,
 	): WorkflowDataCreate {
 		const newConnections = Object.fromEntries(
 			Object.entries(connections).filter(([k]) => nodes.some((x) => x.name === k)),
@@ -222,7 +218,7 @@ export function useWorkflowExtraction() {
 				]
 			: [];
 		const triggerParameters =
-			forcePassthrough || selectionVariables.size === 0
+			selectionVariables.size === 0
 				? {
 						inputSource: 'passthrough',
 					}
@@ -459,7 +455,7 @@ export function useWorkflowExtraction() {
 					.filter((x) => x !== null)
 			: [];
 
-		const { nodes, variables, forcePassthrough } = extractReferencesInNodeExpressions(
+		const { nodes, variables } = extractReferencesInNodeExpressions(
 			subGraph,
 			allNodeNames,
 			startNodeName,
@@ -487,7 +483,6 @@ export function useWorkflowExtraction() {
 			afterVariables,
 			startNodeName,
 			returnNodeName,
-			forcePassthrough,
 		);
 		const createdWorkflow = await tryCreateWorkflow(workflowData);
 		if (createdWorkflow === null) return false;
@@ -498,7 +493,6 @@ export function useWorkflowExtraction() {
 			executeWorkflowNodeName,
 			executeWorkflowPosition,
 			variables,
-			forcePassthrough,
 		);
 		await replaceSelectionWithNode(
 			executeWorkflowNode,

--- a/packages/frontend/editor-ui/src/composables/useWorkflowExtraction.ts
+++ b/packages/frontend/editor-ui/src/composables/useWorkflowExtraction.ts
@@ -89,6 +89,7 @@ export function useWorkflowExtraction() {
 		name: string,
 		position: [number, number],
 		variables: Map<string, string>,
+		forcePassthrough: boolean,
 	): Omit<INode, 'id'> {
 		return {
 			parameters: {
@@ -100,19 +101,21 @@ export function useWorkflowExtraction() {
 				workflowInputs: {
 					mappingMode: 'defineBelow',
 					value: Object.fromEntries(variables.entries().map(([k, v]) => [k, `={{ ${v} }}`])),
-					matchingColumns: [...variables.keys()],
-					schema: [
-						...variables.keys().map((x) => ({
-							id: x,
-							displayName: x,
-							required: false,
-							defaultMatch: false,
-							display: true,
-							canBeUsedToMatch: true,
-							removed: false,
-							// omitted type implicitly uses our `any` type
-						})),
-					],
+					matchingColumns: forcePassthrough ? [] : [...variables.keys()],
+					schema: forcePassthrough
+						? []
+						: [
+								...variables.keys().map((x) => ({
+									id: x,
+									displayName: x,
+									required: false,
+									defaultMatch: false,
+									display: true,
+									canBeUsedToMatch: true,
+									removed: false,
+									// omitted type implicitly uses our `any` type
+								})),
+							],
 					attemptToConvertTypes: false,
 					convertFieldsToString: true,
 				},
@@ -495,6 +498,7 @@ export function useWorkflowExtraction() {
 			executeWorkflowNodeName,
 			executeWorkflowPosition,
 			variables,
+			forcePassthrough,
 		);
 		await replaceSelectionWithNode(
 			executeWorkflowNode,

--- a/packages/frontend/editor-ui/src/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/views/NodeView.vue
@@ -717,7 +717,7 @@ function onTidyUp(event: CanvasLayoutEvent, options?: { trackEvents?: boolean })
 }
 
 function onExtractWorkflow(nodeIds: string[]) {
-	void extractWorkflow(nodeIds);
+	extractWorkflow(nodeIds);
 }
 
 function onUpdateNodesPosition(events: CanvasNodeMoveEvent[]) {

--- a/packages/workflow/src/node-reference-parser-utils.ts
+++ b/packages/workflow/src/node-reference-parser-utils.ts
@@ -494,6 +494,7 @@ export function extractReferencesInNodeExpressions(
 	insertedStartName: string,
 	graphInputNodeNames?: string[],
 ) {
+	const [start] = graphInputNodeNames ?? [];
 	////
 	// STEP 1 - Validate input invariants
 	////
@@ -550,7 +551,7 @@ export function extractReferencesInNodeExpressions(
 		parameterTreeMappingByNode.set(node.name, parameterMapping);
 		allData.push(...allMappings);
 
-		if (node.type === SPLIT_OUT_NODE_TYPE) {
+		if (node.name === start && node.type === SPLIT_OUT_NODE_TYPE) {
 			const raw = node.parameters?.fieldToSplitOut;
 			if (typeof raw === 'string' && raw.trim() !== '') {
 				const trimmed = raw.trim();

--- a/packages/workflow/test/node-reference-parser-utils.test.ts
+++ b/packages/workflow/test/node-reference-parser-utils.test.ts
@@ -742,5 +742,68 @@ describe('NodeReferenceParserUtils', () => {
 				},
 			]);
 		});
+
+		it('should extract "fieldToSplitOut" constant fields in n8n-nodes-base.splitOut', () => {
+			nodes = [
+				{
+					parameters: {
+						fieldToSplitOut: 'foo,bar',
+					},
+					type: 'n8n-nodes-base.splitOut',
+					typeVersion: 1,
+					position: [200, 200],
+					id: 'splitOutNodeId',
+					name: 'A',
+				},
+			];
+			nodeNames = ['A', 'B'];
+
+			const result = extractReferencesInNodeExpressions(nodes, nodeNames, startNodeName, ['A']);
+			expect([...result.variables.entries()]).toEqual([
+				['foo', '$json.foo'],
+				['bar', '$json.bar'],
+			]);
+			expect(result.forcePassthrough).toBe(false);
+		});
+
+		it('should extract "fieldToSplitOut" constant expression in n8n-nodes-base.splitOut', () => {
+			nodes = [
+				{
+					parameters: {
+						fieldToSplitOut: '={{ foo,bar }}',
+					},
+					type: 'n8n-nodes-base.splitOut',
+					typeVersion: 1,
+					position: [200, 200],
+					id: 'splitOutNodeId',
+					name: 'A',
+				},
+			];
+			nodeNames = ['A', 'B'];
+
+			const result = extractReferencesInNodeExpressions(nodes, nodeNames, startNodeName, ['A']);
+			expect([...result.variables.entries()]).toEqual([]);
+			expect(result.forcePassthrough).toBe(true);
+		});
+
+		it('should extract "fieldToSplitOut" expression in n8n-nodes-base.splitOut', () => {
+			nodes = [
+				{
+					parameters: {
+						fieldToSplitOut: "={{ $('B').item.json.foo }}",
+					},
+					type: 'n8n-nodes-base.splitOut',
+					typeVersion: 1,
+					position: [200, 200],
+					id: 'splitOutNodeId',
+					name: 'A',
+				},
+			];
+			nodeNames = ['A', 'B'];
+
+			const result = extractReferencesInNodeExpressions(nodes, nodeNames, startNodeName, ['A']);
+			expect([...result.variables.entries()]).toEqual([['foo', "$('B').item.json.foo"]]);
+			expect(result.forcePassthrough).toBe(true);
+		});
 	});
 });

--- a/packages/workflow/test/node-reference-parser-utils.test.ts
+++ b/packages/workflow/test/node-reference-parser-utils.test.ts
@@ -763,10 +763,9 @@ describe('NodeReferenceParserUtils', () => {
 				['foo', '$json.foo'],
 				['bar', '$json.bar'],
 			]);
-			expect(result.forcePassthrough).toBe(false);
 		});
 
-		it('should extract "fieldToSplitOut" constant expression in n8n-nodes-base.splitOut', () => {
+		it('should error at extracting "fieldToSplitOut" expression in n8n-nodes-base.splitOut', () => {
 			nodes = [
 				{
 					parameters: {
@@ -781,29 +780,9 @@ describe('NodeReferenceParserUtils', () => {
 			];
 			nodeNames = ['A', 'B'];
 
-			const result = extractReferencesInNodeExpressions(nodes, nodeNames, startNodeName, ['A']);
-			expect([...result.variables.entries()]).toEqual([]);
-			expect(result.forcePassthrough).toBe(true);
-		});
-
-		it('should extract "fieldToSplitOut" expression in n8n-nodes-base.splitOut', () => {
-			nodes = [
-				{
-					parameters: {
-						fieldToSplitOut: "={{ $('B').item.json.foo }}",
-					},
-					type: 'n8n-nodes-base.splitOut',
-					typeVersion: 1,
-					position: [200, 200],
-					id: 'splitOutNodeId',
-					name: 'A',
-				},
-			];
-			nodeNames = ['A', 'B'];
-
-			const result = extractReferencesInNodeExpressions(nodes, nodeNames, startNodeName, ['A']);
-			expect([...result.variables.entries()]).toEqual([['foo', "$('B').item.json.foo"]]);
-			expect(result.forcePassthrough).toBe(true);
+			expect(() =>
+				extractReferencesInNodeExpressions(nodes, nodeNames, startNodeName, ['A']),
+			).toThrow('not supported');
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Extract `Split Out` node's `fieldsToSplitOut` fields as input params to pass to the sub-workflow that gets exported. This fixes the exported WF incorrectly getting `Accept all input` mode in situations when we should be able to determine the required inputs from this field.

If `fieldToSplitOut` has an expression we must fall back to the `Accept all input` passThrough mode, as the expressions value determines which inputs to pick, and that value can be dynamic and only available at runtime when the expression is evaluated. I'm guessing this is pretty rare way to use the node.

The fix here is accomplished by acting as if the `fieldsToSplitOut` CSV columns were expressions like `$json.foobar`, and including those as synthetic variables.

The original ticket also reported odd set node at the end - this was unrelated and caused by a problem at that WF.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3836/converting-nodes-to-sub-wf-does-not-convert-params-correctly

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
