### PR TITLE
fix(editor): Improve arrow key navigation in chat message panel

### DIFF
--- a/packages/frontend/@n8n/chat/src/components/Input.vue
+++ b/packages/frontend/@n8n/chat/src/components/Input.vue
@@ -25,9 +25,14 @@ export interface ArrowKeyDownPayload {
 	currentInputValue: string;
 }
 
+export interface EscapeKeyDownPayload {
+	currentInputValue: string;
+}
+
 const { t } = useI18n();
 const emit = defineEmits<{
 	arrowKeyDown: [value: ArrowKeyDownPayload];
+	escapeKeyDown: [value: EscapeKeyDownPayload];
 }>();
 
 const { options } = useOptions();
@@ -289,6 +294,12 @@ function onKeyDown(event: KeyboardEvent) {
 
 		emit('arrowKeyDown', {
 			key: event.key,
+			currentInputValue: input.value,
+		});
+	} else if (event.key === 'Escape') {
+		event.preventDefault();
+
+		emit('escapeKeyDown', {
 			currentInputValue: input.value,
 		});
 	}

--- a/packages/frontend/editor-ui/src/features/logs/components/ChatMessagesPanel.vue
+++ b/packages/frontend/editor-ui/src/features/logs/components/ChatMessagesPanel.vue
@@ -84,7 +84,7 @@ function onRefreshSession() {
 	emit('refreshSession');
 }
 
-function onArrowKey({ currentInputValue, key }: ArrowKeyDownPayload) {
+function onArrowKeyDown({ currentInputValue, key }: ArrowKeyDownPayload) {
 	const pastMessages = props.pastChatMessages;
 
 	// Exit if no messages
@@ -250,7 +250,7 @@ async function copySessionId() {
 			<ChatInput
 				data-test-id="lm-chat-inputs"
 				:placeholder="inputPlaceholder"
-				@arrow-key-down="onArrowKey"
+				@arrow-key-down="onArrowKeyDown"
 				@escape-key-down="onEscapeKey"
 			>
 				<template v-if="pastChatMessages.length > 0" #leftPanel>
@@ -262,7 +262,7 @@ async function copySessionId() {
 							text
 							size="mini"
 							:disabled="previousMessageIndex === 0"
-							@click="onArrowKey({ currentInputValue: '', key: 'ArrowUp' })"
+							@click="onArrowKeyDown({ currentInputValue: '', key: 'ArrowUp' })"
 						/>
 						<N8nButton
 							title="Navigate to next message"
@@ -271,7 +271,7 @@ async function copySessionId() {
 							text
 							size="mini"
 							:disabled="previousMessageIndex === -1"
-							@click="onArrowKey({ currentInputValue: '', key: 'ArrowDown' })"
+							@click="onArrowKeyDown({ currentInputValue: '', key: 'ArrowDown' })"
 						/>
 					</div>
 				</template>

--- a/packages/frontend/editor-ui/src/features/logs/components/ChatMessagesPanel.vue
+++ b/packages/frontend/editor-ui/src/features/logs/components/ChatMessagesPanel.vue
@@ -40,7 +40,12 @@ const clipboard = useClipboard();
 const locale = useI18n();
 const toast = useToast();
 
-const previousMessageIndex = ref(0);
+// -1 is a special value meaning we are not navigating history,
+// 0 is the oldest message, pastChatMessages.length - 1 is the most recent message
+const previousMessageIndex = ref(-1);
+
+// Buffer to hold current input when navigating history
+const currentInputBuffer = ref('');
 
 const sessionIdText = computed(() =>
 	locale.baseText('chat.window.session.id', {
@@ -70,7 +75,8 @@ function reuseMessage(message: ChatMessageText) {
 }
 
 function sendMessage(message: string) {
-	previousMessageIndex.value = 0;
+	previousMessageIndex.value = -1;
+	currentInputBuffer.value = '';
 	emit('sendMessage', message);
 }
 
@@ -78,39 +84,33 @@ function onRefreshSession() {
 	emit('refreshSession');
 }
 
-function onArrowKeyDown({ currentInputValue, key }: ArrowKeyDownPayload) {
+function onArrowKey({ currentInputValue, key }: ArrowKeyDownPayload) {
 	const pastMessages = props.pastChatMessages;
-	const isCurrentInputEmptyOrMatch =
-		currentInputValue.length === 0 || pastMessages.includes(currentInputValue);
 
-	if (isCurrentInputEmptyOrMatch && (key === 'ArrowUp' || key === 'ArrowDown')) {
-		// Exit if no messages
-		if (pastMessages.length === 0) return;
+	// Exit if no messages
+	if (pastMessages.length === 0) return;
 
+	// Reset navigation if input is empty (message was just sent)
+	if (currentInputValue.length === 0 && previousMessageIndex.value !== -1) {
+		previousMessageIndex.value = -1;
+		currentInputBuffer.value = '';
+	}
+
+	// Save current input if we're starting navigation
+	if (previousMessageIndex.value === -1 && currentInputValue.length > 0) {
+		currentInputBuffer.value = currentInputValue;
+	}
+
+	if (key === 'ArrowUp') {
 		// Temporarily blur to avoid cursor position issues
 		chatEventBus.emit('blurInput');
 
-		if (pastMessages.length === 1) {
-			previousMessageIndex.value = 0;
-		} else {
-			if (key === 'ArrowUp') {
-				if (currentInputValue.length === 0 && previousMessageIndex.value === 0) {
-					// Start with most recent message
-					previousMessageIndex.value = pastMessages.length - 1;
-				} else {
-					// Move backwards through history
-					previousMessageIndex.value =
-						previousMessageIndex.value === 0
-							? pastMessages.length - 1
-							: previousMessageIndex.value - 1;
-				}
-			} else if (key === 'ArrowDown') {
-				// Move forwards through history
-				previousMessageIndex.value =
-					previousMessageIndex.value === pastMessages.length - 1
-						? 0
-						: previousMessageIndex.value + 1;
-			}
+		if (previousMessageIndex.value === -1) {
+			// Start with most recent message (last in array)
+			previousMessageIndex.value = pastMessages.length - 1;
+		} else if (previousMessageIndex.value > 0) {
+			// Move backwards through history (older messages)
+			previousMessageIndex.value--;
 		}
 
 		// Get message at current index
@@ -119,12 +119,38 @@ function onArrowKeyDown({ currentInputValue, key }: ArrowKeyDownPayload) {
 
 		// Refocus and move cursor to end
 		chatEventBus.emit('focusInput');
-	}
+	} else if (key === 'ArrowDown') {
+		// Only navigate if we're in history mode
+		if (previousMessageIndex.value === -1) return;
 
-	// Reset history navigation when typing new content that doesn't match history
-	if (!isCurrentInputEmptyOrMatch) {
-		previousMessageIndex.value = 0;
+		// Temporarily blur to avoid cursor position issues
+		chatEventBus.emit('blurInput');
+
+		if (previousMessageIndex.value < pastMessages.length - 1) {
+			// Move forward through history (newer messages)
+			previousMessageIndex.value++;
+			const selectedMessage = pastMessages[previousMessageIndex.value];
+			chatEventBus.emit('setInputValue', selectedMessage);
+		} else {
+			// Reached the end - restore original input or clear
+			previousMessageIndex.value = -1;
+			chatEventBus.emit('setInputValue', currentInputBuffer.value);
+			currentInputBuffer.value = '';
+		}
+
+		// Refocus and move cursor to end
+		chatEventBus.emit('focusInput');
 	}
+}
+
+function onEscapeKey() {
+	// Only handle escape if we're in history navigation mode
+	if (previousMessageIndex.value === -1) return;
+
+	// Exit history mode and restore original input
+	previousMessageIndex.value = -1;
+	chatEventBus.emit('setInputValue', currentInputBuffer.value);
+	currentInputBuffer.value = '';
 }
 
 async function copySessionId() {
@@ -224,7 +250,8 @@ async function copySessionId() {
 			<ChatInput
 				data-test-id="lm-chat-inputs"
 				:placeholder="inputPlaceholder"
-				@arrow-key-down="onArrowKeyDown"
+				@arrow-key-down="onArrowKey"
+				@escape-key-down="onEscapeKey"
 			>
 				<template v-if="pastChatMessages.length > 0" #leftPanel>
 					<div :class="$style.messagesHistory">
@@ -234,7 +261,8 @@ async function copySessionId() {
 							type="tertiary"
 							text
 							size="mini"
-							@click="onArrowKeyDown({ currentInputValue: '', key: 'ArrowUp' })"
+							:disabled="previousMessageIndex === 0"
+							@click="onArrowKey({ currentInputValue: '', key: 'ArrowUp' })"
 						/>
 						<N8nButton
 							title="Navigate to next message"
@@ -242,7 +270,8 @@ async function copySessionId() {
 							type="tertiary"
 							text
 							size="mini"
-							@click="onArrowKeyDown({ currentInputValue: '', key: 'ArrowDown' })"
+							:disabled="previousMessageIndex === -1"
+							@click="onArrowKey({ currentInputValue: '', key: 'ArrowDown' })"
 						/>
 					</div>
 				</template>

--- a/packages/frontend/editor-ui/src/features/logs/components/LogsPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/logs/components/LogsPanel.test.ts
@@ -757,7 +757,7 @@ describe('LogsPanel', () => {
 		});
 
 		describe('message history handling', () => {
-			it('should properly navigate through message history with wrap-around', async () => {
+			it('should properly navigate through message history without wrap-around', async () => {
 				workflowsStore.resetChatMessages();
 				workflowsStore.appendChatMessage('Message 1');
 				workflowsStore.appendChatMessage('Message 2');
@@ -780,16 +780,24 @@ describe('LogsPanel', () => {
 				await userEvent.keyboard('{ArrowUp}');
 				expect(input).toHaveValue('Message 1');
 
-				// Fourth up should wrap around to most recent
+				// Fourth up should stay at oldest message (no wrap-around)
 				await userEvent.keyboard('{ArrowUp}');
+				expect(input).toHaveValue('Message 1');
+
+				// Down arrow should move forward through history
+				await userEvent.keyboard('{ArrowDown}');
+				expect(input).toHaveValue('Message 2');
+
+				// Continue forward
+				await userEvent.keyboard('{ArrowDown}');
 				expect(input).toHaveValue('Message 3');
 
-				// Down arrow should go in reverse
+				// Down at the end should clear input
 				await userEvent.keyboard('{ArrowDown}');
-				expect(input).toHaveValue('Message 1');
+				expect(input).toHaveValue('');
 			});
 
-			it('should reset message history navigation on new input', async () => {
+			it('should reset message history navigation when message is sent', async () => {
 				workflowsStore.resetChatMessages();
 				workflowsStore.appendChatMessage('Message 1');
 				workflowsStore.appendChatMessage('Message 2');
@@ -800,15 +808,40 @@ describe('LogsPanel', () => {
 				chatEventBus.emit('focusInput');
 
 				// Navigate to oldest message
-				await userEvent.keyboard('{ArrowUp}'); // Most recent
-				await userEvent.keyboard('{ArrowUp}'); // Oldest
+				await userEvent.keyboard('{ArrowUp}'); // Most recent (Message 2)
+				await userEvent.keyboard('{ArrowUp}'); // Oldest (Message 1)
 				expect(input).toHaveValue('Message 1');
 
+				// Clear and type new message
+				await userEvent.clear(input);
 				await userEvent.type(input, 'New message');
 				await userEvent.keyboard('{Enter}');
 
+				// After sending, pressing up should show most recent message
 				await userEvent.keyboard('{ArrowUp}');
 				expect(input).toHaveValue('Message 2');
+			});
+
+			it('should exit history mode and restore input on escape key', async () => {
+				workflowsStore.resetChatMessages();
+				workflowsStore.appendChatMessage('Message 1');
+				workflowsStore.appendChatMessage('Message 2');
+
+				const { findByTestId } = render();
+				const input = await findByTestId('chat-input');
+
+				chatEventBus.emit('focusInput');
+
+				// Type some text first
+				await userEvent.type(input, 'Current input');
+
+				// Navigate to a history message
+				await userEvent.keyboard('{ArrowUp}');
+				expect(input).toHaveValue('Message 2');
+
+				// Press escape to restore original input
+				await userEvent.keyboard('{Escape}');
+				expect(input).toHaveValue('Current input');
 			});
 		});
 

--- a/packages/frontend/editor-ui/src/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/stores/workflows.store.ts
@@ -289,7 +289,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 
 	const getWorkflowExecution = computed(() => workflowExecutionData.value);
 
-	const getPastChatMessages = computed(() => Array.from(new Set(chatMessages.value)));
+	const getPastChatMessages = computed(() => chatMessages.value);
 
 	/**
 	 * This section contains functions migrated from the workflow class


### PR DESCRIPTION
## Summary

This PR improves the arrow key navigation behavior in the ChatMessagesPanel.

### Changes:
- **Improved history navigation logic**: Arrow Up starts from the most recent message, Arrow Down moves forward in time
- **No wrap-around behavior**: Navigation stops at boundaries instead of cycling
- **Escape key support**: Press Escape to exit history mode and restore original input
- **Input preservation**: Current input is preserved when starting history navigation
- **Removed message de-duplication**: Navigating follows exact previous messages history, even if there are repetitive messages
- **Disable arrow buttons on message list edges**: Disable corresponding button when reached the end of history or current input

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-1384

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)