### PR TITLE
fix(editor): Sync workflow active state to expression resolver

### DIFF
--- a/packages/frontend/editor-ui/src/stores/workflows.store.test.ts
+++ b/packages/frontend/editor-ui/src/stores/workflows.store.test.ts
@@ -465,7 +465,6 @@ describe('useWorkflowsStore', () => {
 		it('should set the workflow name correctly', () => {
 			workflowsStore.setWorkflowName({ newName: 'New Workflow Name', setStateDirty: false });
 			expect(workflowsStore.workflow.name).toBe('New Workflow Name');
-			expect(workflowsStore.workflowObject.name).toBe('New Workflow Name');
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/stores/workflows.store.test.ts
+++ b/packages/frontend/editor-ui/src/stores/workflows.store.test.ts
@@ -465,6 +465,7 @@ describe('useWorkflowsStore', () => {
 		it('should set the workflow name correctly', () => {
 			workflowsStore.setWorkflowName({ newName: 'New Workflow Name', setStateDirty: false });
 			expect(workflowsStore.workflow.name).toBe('New Workflow Name');
+			expect(workflowsStore.workflowObject.name).toBe('New Workflow Name');
 		});
 	});
 
@@ -479,6 +480,7 @@ describe('useWorkflowsStore', () => {
 			expect(workflowsStore.activeWorkflows).toContain('1');
 			expect(workflowsStore.workflowsById['1'].active).toBe(true);
 			expect(workflowsStore.workflow.active).toBe(true);
+			expect(workflowsStore.workflowObject.active).toBe(true);
 			expect(uiStore.stateIsDirty).toBe(false);
 		});
 
@@ -526,6 +528,7 @@ describe('useWorkflowsStore', () => {
 			workflowsStore.workflow.active = true;
 			workflowsStore.setWorkflowInactive('1');
 			expect(workflowsStore.workflow.active).toBe(false);
+			expect(workflowsStore.workflowObject.active).toBe(false);
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/stores/workflows.store.ts
@@ -721,6 +721,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 			uiStore.stateIsDirty = true;
 		}
 		workflow.value.name = data.newName;
+		workflowObject.value.name = workflow.value.name;
 
 		if (
 			workflow.value.id !== PLACEHOLDER_EMPTY_WORKFLOW_ID &&
@@ -865,6 +866,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 
 	function setActive(active: boolean) {
 		workflow.value.active = active;
+		workflowObject.value.active = workflow.value.active;
 	}
 
 	function setIsArchived(isArchived: boolean) {

--- a/packages/frontend/editor-ui/src/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/stores/workflows.store.ts
@@ -721,7 +721,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 			uiStore.stateIsDirty = true;
 		}
 		workflow.value.name = data.newName;
-		workflowObject.value.name = workflow.value.name;
 
 		if (
 			workflow.value.id !== PLACEHOLDER_EMPTY_WORKFLOW_ID &&


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
This PR fixes an issue where `$workflow.active` always returns false when used in expression fields, while working correctly in Code node. The problem was due to the missing synchronization between workflow data and the `workflowObject` used by the expression resolver. When `setActive()` updated the workflow properties, they didn't update the corresponding `workflowObject` properties, causing expressions to return stale values. 

<img width="752" height="616" alt="image" src="https://github.com/user-attachments/assets/eba479c0-6271-45c3-b156-beb091beff7a" />


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
Closes #19868 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
