### PR TITLE
fix(editor): Fix reka popover issue when uncontrolled

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nPopoverReka/N8nPopoverReka.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nPopoverReka/N8nPopoverReka.vue
@@ -53,6 +53,7 @@ interface Emits {
 }
 
 const props = withDefaults(defineProps<Props>(), {
+	open: undefined,
 	maxHeight: undefined,
 	width: undefined,
 	enableScrolling: true,


### PR DESCRIPTION
## Summary

For some reason removing the default value for the `open` prop of the reka popover was making it resolve as false instead of undefined which was breaking the popover uncontrolled mode behavior which is how we're using it in the `TableHeaderControlsButton`

The issue comes from a weird behavior of `withDefaults` where if an option boolean prop doesn't have a default provided it will be initialized as false instead of as undefined. There's a going on discussion about it [here](https://github.com/vuejs/core/issues/8576)


https://github.com/user-attachments/assets/d1bf5617-43a7-4c49-be01-07145614c46e



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4191/evaluations-column-picker-button-is-not-working


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
