### PR TITLE
feat(core): Add startDate and endDate filter query to insights endpoints

### DIFF
--- a/packages/@n8n/api-types/src/dto/insights/__tests__/date-filter.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/insights/__tests__/date-filter.dto.test.ts
@@ -74,14 +74,14 @@ describe('InsightsDateFilterDto', () => {
 					startDate: '2025-13-01', // Invalid month
 					endDate: '2025-13-31', // Invalid month
 				},
-				expectedErrorPath: ['startDate', 'endDate'],
+				expectedErrorPaths: ['startDate', 'endDate'],
 			},
 			{
 				name: 'startDate is an invalid timestamp',
 				request: {
 					startDate: NaN,
 				},
-				expectedErrorPath: ['startDate'],
+				expectedErrorPaths: ['startDate'],
 			},
 			{
 				name: 'endDate is an invalid timestamp',
@@ -89,14 +89,14 @@ describe('InsightsDateFilterDto', () => {
 					endDate: NaN,
 					projectId: 'validProjectId',
 				},
-				expectedErrorPath: ['endDate'],
+				expectedErrorPaths: ['endDate'],
 			},
 			{
 				name: 'startDate is an invalid ISO string',
 				request: {
 					startDate: 'invalid--date',
 				},
-				expectedErrorPath: ['startDate'],
+				expectedErrorPaths: ['startDate'],
 			},
 			{
 				name: 'endDate is an invalid ISO string',
@@ -104,21 +104,21 @@ describe('InsightsDateFilterDto', () => {
 					startDate: '2025-01-01',
 					endDate: 'not-a-date',
 				},
-				expectedErrorPath: ['endDate'],
+				expectedErrorPaths: ['endDate'],
 			},
 			{
 				name: 'invalid dateRange value',
 				request: {
 					dateRange: 'invalid-value',
 				},
-				expectedErrorPath: ['dateRange'],
+				expectedErrorPaths: ['dateRange'],
 			},
 			{
 				name: 'invalid projectId value',
 				request: {
 					projectId: 10,
 				},
-				expectedErrorPath: ['projectId'],
+				expectedErrorPaths: ['projectId'],
 			},
 			{
 				name: 'all fields invalid',
@@ -128,19 +128,14 @@ describe('InsightsDateFilterDto', () => {
 					endDate: 'not-a-date',
 					projectId: 10,
 				},
-				expectedErrorPath: ['dateRange', 'startDate', 'endDate', 'projectId'],
+				expectedErrorPaths: ['dateRange', 'startDate', 'endDate', 'projectId'],
 			},
-		])('should fail validation for $name', ({ request, expectedErrorPath }) => {
+		])('should fail validation for $name', ({ request, expectedErrorPaths }) => {
 			const result = InsightsDateFilterDto.safeParse(request);
+			const issuesPaths = new Set(result.error?.issues.map((issue) => issue.path[0]));
 
 			expect(result.success).toBe(false);
-
-			if (expectedErrorPath && !result.success) {
-				if (Array.isArray(expectedErrorPath)) {
-					const errorPaths = result.error.issues[0].path;
-					expect(errorPaths).toContain(expectedErrorPath[0]);
-				}
-			}
+			expect(new Set(issuesPaths)).toEqual(new Set(expectedErrorPaths));
 		});
 	});
 });

--- a/packages/@n8n/api-types/src/dto/insights/__tests__/date-filter.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/insights/__tests__/date-filter.dto.test.ts
@@ -13,8 +13,39 @@ describe('InsightsDateFilterDto', () => {
 				request: {
 					dateRange: 'week', // Using a valid option from the provided list
 				},
+				parsedResult: {},
+			},
+			{
+				name: 'valid startDate and endDate (as strings)',
+				request: {
+					startDate: '2025-01-01',
+					endDate: '2025-01-31',
+				},
 				parsedResult: {
-					dateRange: 'week',
+					startDate: new Date('2025-01-01'),
+					endDate: new Date('2025-01-31'),
+				},
+			},
+			{
+				name: 'valid startDate and endDate (as ISO strings)',
+				request: {
+					startDate: '2025-01-01T00:00:00Z',
+					endDate: '2025-01-31T23:59:59Z',
+				},
+				parsedResult: {
+					startDate: new Date('2025-01-01T00:00:00Z'),
+					endDate: new Date('2025-01-31T23:59:59Z'),
+				},
+			},
+			{
+				name: 'valid startDate and endDate (as timestamps)',
+				request: {
+					startDate: new Date('2025-01-01').getTime(),
+					endDate: new Date('2025-01-31').getTime(),
+				},
+				parsedResult: {
+					startDate: new Date('2025-01-01'),
+					endDate: new Date('2025-01-31'),
 				},
 			},
 			{
@@ -38,6 +69,44 @@ describe('InsightsDateFilterDto', () => {
 	describe('Invalid requests', () => {
 		test.each([
 			{
+				name: 'invalid startDate format',
+				request: {
+					startDate: '2025-13-01', // Invalid month
+					endDate: '2025-13-31', // Invalid month
+				},
+				expectedErrorPath: ['startDate', 'endDate'],
+			},
+			{
+				name: 'startDate is an invalid timestamp',
+				request: {
+					startDate: NaN,
+				},
+				expectedErrorPath: ['startDate'],
+			},
+			{
+				name: 'endDate is an invalid timestamp',
+				request: {
+					endDate: NaN,
+					projectId: 'validProjectId',
+				},
+				expectedErrorPath: ['endDate'],
+			},
+			{
+				name: 'startDate is an invalid ISO string',
+				request: {
+					startDate: 'invalid--date',
+				},
+				expectedErrorPath: ['startDate'],
+			},
+			{
+				name: 'endDate is an invalid ISO string',
+				request: {
+					startDate: '2025-01-01',
+					endDate: 'not-a-date',
+				},
+				expectedErrorPath: ['endDate'],
+			},
+			{
 				name: 'invalid dateRange value',
 				request: {
 					dateRange: 'invalid-value',
@@ -50,6 +119,16 @@ describe('InsightsDateFilterDto', () => {
 					projectId: 10,
 				},
 				expectedErrorPath: ['projectId'],
+			},
+			{
+				name: 'all fields invalid',
+				request: {
+					dateRange: 'invalid-value',
+					startDate: '2025-13-01', // Invalid month
+					endDate: 'not-a-date',
+					projectId: 10,
+				},
+				expectedErrorPath: ['dateRange', 'startDate', 'endDate', 'projectId'],
 			},
 		])('should fail validation for $name', ({ request, expectedErrorPath }) => {
 			const result = InsightsDateFilterDto.safeParse(request);

--- a/packages/@n8n/api-types/src/dto/insights/__tests__/list-workflow-query.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/insights/__tests__/list-workflow-query.dto.test.ts
@@ -86,6 +86,39 @@ describe('ListInsightsWorkflowQueryDto', () => {
 					projectId: '2gQLpmP5V4wOY627',
 				},
 			},
+			{
+				name: 'valid startDate and endDate (as strings)',
+				request: {
+					startDate: '2025-01-01',
+					endDate: '2025-01-31',
+				},
+				parsedResult: {
+					startDate: new Date('2025-01-01'),
+					endDate: new Date('2025-01-31'),
+				},
+			},
+			{
+				name: 'valid startDate and endDate (as ISO strings)',
+				request: {
+					startDate: '2025-01-01T00:00:00Z',
+					endDate: '2025-01-31T23:59:59Z',
+				},
+				parsedResult: {
+					startDate: new Date('2025-01-01T00:00:00Z'),
+					endDate: new Date('2025-01-31T23:59:59Z'),
+				},
+			},
+			{
+				name: 'valid startDate and endDate (as timestamps)',
+				request: {
+					startDate: new Date('2025-01-01').getTime(),
+					endDate: new Date('2025-01-31').getTime(),
+				},
+				parsedResult: {
+					startDate: new Date('2025-01-01'),
+					endDate: new Date('2025-01-31'),
+				},
+			},
 		])('should validate $name', ({ request, parsedResult }) => {
 			const result = ListInsightsWorkflowQueryDto.safeParse(request);
 			expect(result.success).toBe(true);
@@ -103,7 +136,7 @@ describe('ListInsightsWorkflowQueryDto', () => {
 					skip: 'not-a-number',
 					take: '10',
 				},
-				expectedErrorPath: ['skip'],
+				expectedErrorPaths: ['skip'],
 			},
 			{
 				name: 'invalid take format',
@@ -111,33 +144,77 @@ describe('ListInsightsWorkflowQueryDto', () => {
 					skip: '0',
 					take: 'not-a-number',
 				},
-				expectedErrorPath: ['take'],
+				expectedErrorPaths: ['take'],
 			},
 			{
 				name: 'invalid sortBy value',
 				request: {
 					sortBy: 'invalid-value',
 				},
-				expectedErrorPath: ['sortBy'],
+				expectedErrorPaths: ['sortBy'],
 			},
 			{
 				name: 'invalid projectId value',
 				request: {
 					projectId: 10,
 				},
-				expectedErrorPath: ['projectId'],
+				expectedErrorPaths: ['projectId'],
 			},
-		])('should fail validation for $name', ({ request, expectedErrorPath }) => {
+			{
+				name: 'invalid startDate format',
+				request: {
+					startDate: '2025-13-01', // Invalid month
+					endDate: '2025-13-31', // Invalid month
+				},
+				expectedErrorPaths: ['startDate', 'endDate'],
+			},
+			{
+				name: 'startDate is an invalid timestamp',
+				request: {
+					startDate: NaN,
+				},
+				expectedErrorPaths: ['startDate'],
+			},
+			{
+				name: 'endDate is an invalid timestamp',
+				request: {
+					endDate: NaN,
+					projectId: 'validProjectId',
+				},
+				expectedErrorPaths: ['endDate'],
+			},
+			{
+				name: 'startDate is an invalid ISO string',
+				request: {
+					startDate: 'invalid--date',
+				},
+				expectedErrorPaths: ['startDate'],
+			},
+			{
+				name: 'endDate is an invalid ISO string',
+				request: {
+					startDate: '2025-01-01',
+					endDate: 'not-a-date',
+				},
+				expectedErrorPaths: ['endDate'],
+			},
+			{
+				name: 'all fields invalid',
+				request: {
+					sortBy: 'invalid-value',
+					startDate: '2025-13-01', // Invalid month
+					endDate: 'not-a-date',
+					projectId: 10,
+				},
+				expectedErrorPaths: ['sortBy', 'startDate', 'endDate', 'projectId'],
+			},
+		])('should fail validation for $name', ({ request, expectedErrorPaths }) => {
 			const result = ListInsightsWorkflowQueryDto.safeParse(request);
 
-			expect(result.success).toBe(false);
+			const issuesPaths = new Set(result.error?.issues.map((issue) => issue.path[0]));
 
-			if (expectedErrorPath && !result.success) {
-				if (Array.isArray(expectedErrorPath)) {
-					const errorPaths = result.error.issues[0].path;
-					expect(errorPaths).toContain(expectedErrorPath[0]);
-				}
-			}
+			expect(result.success).toBe(false);
+			expect(new Set(issuesPaths)).toEqual(new Set(expectedErrorPaths));
 		});
 	});
 });

--- a/packages/@n8n/api-types/src/dto/insights/date-filter.dto.ts
+++ b/packages/@n8n/api-types/src/dto/insights/date-filter.dto.ts
@@ -9,6 +9,11 @@ const VALID_DATE_RANGE_OPTIONS = insightsDateRangeSchema.shape.key.options;
 const dateRange = z.enum(VALID_DATE_RANGE_OPTIONS).optional();
 
 export class InsightsDateFilterDto extends Z.class({
+	/**
+	 * @deprecated use startDate and endDate instead
+	 */
 	dateRange,
+	startDate: z.coerce.date().optional(),
+	endDate: z.coerce.date().optional(),
 	projectId: z.string().optional(),
 }) {}

--- a/packages/@n8n/api-types/src/dto/insights/date-filter.dto.ts
+++ b/packages/@n8n/api-types/src/dto/insights/date-filter.dto.ts
@@ -9,9 +9,6 @@ const VALID_DATE_RANGE_OPTIONS = insightsDateRangeSchema.shape.key.options;
 const dateRange = z.enum(VALID_DATE_RANGE_OPTIONS).optional();
 
 export class InsightsDateFilterDto extends Z.class({
-	/**
-	 * @deprecated use startDate and endDate instead
-	 */
 	dateRange,
 	startDate: z.coerce.date().optional(),
 	endDate: z.coerce.date().optional(),

--- a/packages/@n8n/api-types/src/dto/insights/list-workflow-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/insights/list-workflow-query.dto.ts
@@ -36,7 +36,12 @@ const sortByValidator = z
 export class ListInsightsWorkflowQueryDto extends Z.class({
 	...paginationSchema,
 	take: createTakeValidator(MAX_ITEMS_PER_PAGE),
+	/**
+	 * @deprecated use startDate and endDate instead
+	 */
 	dateRange: InsightsDateFilterDto.shape.dateRange,
+	startDate: z.coerce.date().optional(),
+	endDate: z.coerce.date().optional(),
 	sortBy: sortByValidator,
 	projectId: z.string().optional(),
 }) {}

--- a/packages/@n8n/api-types/src/dto/insights/list-workflow-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/insights/list-workflow-query.dto.ts
@@ -36,9 +36,6 @@ const sortByValidator = z
 export class ListInsightsWorkflowQueryDto extends Z.class({
 	...paginationSchema,
 	take: createTakeValidator(MAX_ITEMS_PER_PAGE),
-	/**
-	 * @deprecated use startDate and endDate instead
-	 */
 	dateRange: InsightsDateFilterDto.shape.dateRange,
 	startDate: z.coerce.date().optional(),
 	endDate: z.coerce.date().optional(),


### PR DESCRIPTION
## Summary

Add `startDate` and `endDate` filter query to insights endpoints.
This changes only affects the API contract but those filter are not implemented yet



## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
