### PR TITLE
feat: Add timestamp support for chat messages

### DIFF
--- a/packages/frontend/@n8n/chat/README.md
+++ b/packages/frontend/@n8n/chat/README.md
@@ -133,6 +133,7 @@ createChat({
 		},
 	},
 	enableStreaming: false,
+	showTimestamps: false,
 });
 ```
 
@@ -209,6 +210,11 @@ createChat({
 - Default: false
 - Description: Whether to enable streaming responses from the n8n workflow. If set to `true`, the chat will display responses as they are being generated, providing a more interactive experience. For this to work the workflow must be configured as well to return streaming responses.
 
+### `showTimestamps`
+- **Type**: `boolean`
+- **Default**: `false`
+- **Description**: Whether to display timestamps for each message. When enabled, each message will show a relative timestamp (e.g., "Just now", "5m ago", "2h ago") that indicates when the message was sent or received.
+
 ## Customization
 The Chat window is entirely customizable using CSS variables.
 
@@ -261,6 +267,11 @@ The Chat window is entirely customizable using CSS variables.
 	--chat--message--user--color: var(--chat--color-white);
 	--chat--message--user--border: none;
 	--chat--message--pre--background: rgba(0, 0, 0, 0.05);
+
+	/* Timestamp styling */
+	--chat--timestamp--font-size: 0.75rem;
+	--chat--timestamp--color: #888;
+	--chat--timestamp--opacity: 0.7;
 
 	--chat--toggle--background: var(--chat--color-primary);
 	--chat--toggle--hover--background: var(--chat--color-primary-shade-50);

--- a/packages/frontend/@n8n/chat/examples/timestamps.html
+++ b/packages/frontend/@n8n/chat/examples/timestamps.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>n8n Chat with Timestamps Example</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 20px;
+            background-color: #f5f5f5;
+        }
+
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+
+        .example {
+            background: white;
+            border-radius: 8px;
+            padding: 20px;
+            margin-bottom: 20px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+
+        .example h2 {
+            margin: 0 0 10px 0;
+            color: #333;
+        }
+
+        .example p {
+            color: #666;
+            margin-bottom: 15px;
+        }
+
+        #chat-with-timestamps, #chat-without-timestamps {
+            height: 500px;
+            width: 100%;
+            border: 1px solid #ddd;
+            border-radius: 8px;
+        }
+
+        .code-block {
+            background: #f8f9fa;
+            border: 1px solid #e9ecef;
+            border-radius: 4px;
+            padding: 15px;
+            margin: 15px 0;
+            font-family: 'Courier New', monospace;
+            font-size: 14px;
+            overflow-x: auto;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>n8n Chat Timestamp Examples</h1>
+        
+        <div class="example">
+            <h2>Chat with Timestamps (Default)</h2>
+            <p>This example shows the chat with timestamps enabled (default behavior). Each message displays a relative timestamp like "Just now", "5m ago", etc.</p>
+            <div class="code-block">
+createChat({
+    webhookUrl: 'YOUR_WEBHOOK_URL',
+    target: '#chat-with-timestamps',
+    mode: 'fullscreen',
+    showTimestamps: true, // This is the default
+    initialMessages: [
+        'Hi there! 👋',
+        'Timestamps are enabled in this chat.'
+    ]
+});
+            </div>
+            <div id="chat-with-timestamps"></div>
+        </div>
+
+        <div class="example">
+            <h2>Chat without Timestamps</h2>
+            <p>This example shows the chat with timestamps disabled for a cleaner look.</p>
+            <div class="code-block">
+createChat({
+    webhookUrl: 'YOUR_WEBHOOK_URL',
+    target: '#chat-without-timestamps',
+    mode: 'fullscreen',
+    showTimestamps: false,
+    initialMessages: [
+        'Hi there! 👋',
+        'No timestamps in this chat for a cleaner appearance.'
+    ]
+});
+            </div>
+            <div id="chat-without-timestamps"></div>
+        </div>
+
+        <div class="example">
+            <h2>Custom Timestamp Styling</h2>
+            <p>You can customize the appearance of timestamps using CSS variables:</p>
+            <div class="code-block">
+/* Custom timestamp styling */
+:root {
+    --chat--timestamp--font-size: 0.7rem;
+    --chat--timestamp--color: #999;
+    --chat--timestamp--opacity: 0.8;
+}
+
+/* Different styles for user vs bot timestamps */
+.chat-message-from-user .chat-message-timestamp {
+    text-align: right;
+    color: rgba(255, 255, 255, 0.8);
+    font-style: italic;
+}
+
+.chat-message-from-bot .chat-message-timestamp {
+    text-align: left;
+    color: #666;
+    font-style: italic;
+}
+            </div>
+        </div>
+    </div>
+
+    <!-- Note: This is just an example file. You would need to include the actual n8n chat library -->
+    <script>
+        // Mock implementation for demonstration
+        console.log('This is an example file. Include the actual @n8n/chat library to use these examples.');
+        
+        // Example of how you would actually use it:
+        // import '@n8n/chat/style.css';
+        // import { createChat } from '@n8n/chat';
+        //
+        // createChat({
+        //     webhookUrl: 'YOUR_PRODUCTION_WEBHOOK_URL',
+        //     target: '#chat-with-timestamps',
+        //     mode: 'fullscreen',
+        //     showTimestamps: true
+        // });
+    </script>
+</body>
+</html>

--- a/packages/frontend/@n8n/chat/src/__tests__/utils/streaming.spec.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/utils/streaming.spec.ts
@@ -117,6 +117,7 @@ describe('createBotMessage', () => {
 		expect(message.text).toBe('');
 		expect(message.sender).toBe('bot');
 		expect(message.id).toBeDefined();
+		expect(message.timestamp).toBeInstanceOf(Date);
 	});
 
 	it('should create a bot message with custom id', () => {
@@ -124,6 +125,7 @@ describe('createBotMessage', () => {
 		const message = createBotMessage(customId);
 
 		expect(message.id).toBe(customId);
+		expect(message.timestamp).toBeInstanceOf(Date);
 	});
 });
 

--- a/packages/frontend/@n8n/chat/src/constants/defaults.ts
+++ b/packages/frontend/@n8n/chat/src/constants/defaults.ts
@@ -26,6 +26,7 @@ export const defaultOptions: ChatOptions = {
 	},
 	theme: {},
 	enableStreaming: false,
+	showTimestamps: false,
 };
 
 export const defaultMountingTarget = '#n8n-chat';

--- a/packages/frontend/@n8n/chat/src/plugins/chat.ts
+++ b/packages/frontend/@n8n/chat/src/plugins/chat.ts
@@ -29,6 +29,7 @@ function createUserMessage(text: string, files: File[] = []): ChatMessage {
 		text,
 		sender: 'user',
 		files,
+		timestamp: new Date(),
 	};
 }
 
@@ -189,10 +190,12 @@ export const ChatPlugin: Plugin<ChatOptions> = {
 		const waitingForResponse = ref(false);
 
 		const initialMessages = computed<ChatMessage[]>(() =>
-			(options.initialMessages ?? []).map((text) => ({
+			(options.initialMessages ?? []).map((text, index) => ({
 				id: uuidv4(),
 				text,
 				sender: 'bot',
+				// Give initial messages older timestamps so they don't all show "Just now"
+				timestamp: new Date(Date.now() - (index + 1) * 60000), // Each message 1 minute older
 			})),
 		);
 
@@ -266,6 +269,7 @@ export const ChatPlugin: Plugin<ChatOptions> = {
 				id: `${index}`,
 				text: message.kwargs.content,
 				sender: message.id.includes('HumanMessage') ? 'user' : 'bot',
+				timestamp: new Date(),
 			}));
 
 			if (messages.value.length) {

--- a/packages/frontend/@n8n/chat/src/plugins/chat.ts
+++ b/packages/frontend/@n8n/chat/src/plugins/chat.ts
@@ -269,7 +269,7 @@ export const ChatPlugin: Plugin<ChatOptions> = {
 				id: `${index}`,
 				text: message.kwargs.content,
 				sender: message.id.includes('HumanMessage') ? 'user' : 'bot',
-				timestamp: new Date(),
+				// Don't add timestamps to loaded messages since we don't have real timestamp data
 			}));
 
 			if (messages.value.length) {

--- a/packages/frontend/@n8n/chat/src/types/messages.ts
+++ b/packages/frontend/@n8n/chat/src/types/messages.ts
@@ -16,4 +16,5 @@ interface ChatMessageBase {
 	transparent?: boolean;
 	sender: 'user' | 'bot';
 	files?: File[];
+	timestamp?: Date;
 }

--- a/packages/frontend/@n8n/chat/src/types/options.ts
+++ b/packages/frontend/@n8n/chat/src/types/options.ts
@@ -34,4 +34,5 @@ export interface ChatOptions {
 	allowFileUploads?: Ref<boolean> | boolean;
 	allowedFilesMimeTypes?: Ref<string> | string;
 	enableStreaming?: boolean;
+	showTimestamps?: boolean;
 }

--- a/packages/frontend/@n8n/chat/src/utils/streaming.ts
+++ b/packages/frontend/@n8n/chat/src/utils/streaming.ts
@@ -8,6 +8,16 @@ export interface NodeRunData {
 	message: ChatMessageText;
 }
 
+export function createBotMessage(id?: string): ChatMessageText {
+	return {
+		id: id ?? uuidv4(),
+		type: 'text',
+		text: '',
+		sender: 'bot',
+		timestamp: new Date(),
+	};
+}
+
 /**
  * Manages the state of streaming messages for nodes.
  * This class is responsible for tracking the state of each run of nodes,
@@ -108,15 +118,6 @@ export class StreamingMessageManager {
 		this.runOrder = [];
 		this.activeRuns.clear();
 	}
-}
-
-export function createBotMessage(id?: string): ChatMessageText {
-	return {
-		id: id ?? uuidv4(),
-		type: 'text',
-		text: '',
-		sender: 'bot',
-	};
 }
 
 export function updateMessageInArray(


### PR DESCRIPTION
## Add Timestamp Support to n8n Chat

This PR adds optional timestamp display functionality to the n8n chat widget, allowing users to see when messages were sent or received.

### ✨ Features Added

- **Relative timestamps**: Messages display relative time (e.g., "Just now", "5m ago", "2h ago", "Yesterday")
- **Reactive updates**: Timestamps automatically update every minute to show elapsed time
- **Configurable display**: Timestamps can be enabled/disabled via the `showTimestamps` option
- **Italic styling**: Timestamps use italic font to distinguish from message content
- **Customizable appearance**: Full CSS variable support for styling customization
- **Smart positioning**: Different alignment for user vs bot messages

### 🔧 Changes Made

#### Core Implementation
- **Types** (`src/types/messages.ts`): Added optional `timestamp?: Date` field to `ChatMessageBase`
- **Options** (`src/types/options.ts`): Added `showTimestamps?: boolean` configuration option
- **Defaults** (`src/constants/defaults.ts`): Set `showTimestamps: false` (disabled by default)
- **Message Creation** (`src/plugins/chat.ts`, `src/utils/streaming.ts`): Added timestamp assignment to all message types

#### UI Components
- **Message Display** (`src/components/Message.vue`):
  - Added reactive timestamp formatting with automatic updates
  - Implemented conditional rendering based on `showTimestamps` option

#### Documentation & Examples
- **README** (`README.md`): Added `showTimestamps` option documentation with usage examples
- **Examples** (`examples/timestamps.html`): Created comprehensive example showing enabled/disabled states
- **CSS Variables**: Added `--chat--timestamp--*` variables for full customization

<img width="551" height="433" alt="image" src="https://github.com/user-attachments/assets/90cf2b43-6bff-4d8a-9e02-cdb82973a9a9" />

#### ⚠️ Current Limitations
Historical Chat Timestamps: Timestamps are not displayed for previously loaded chat sessions. This is because the current n8n chat webhook doesn't provide timestamp data. Only new messages in the current session will show timestamps. When server-side timestamp support is added in the future, historical messages will automatically display their actual timestamps.

### 🎯 Usage

```javascript
// Enable timestamps
createChat({
    webhookUrl: 'YOUR_WEBHOOK_URL',
    showTimestamps: true
});

// Disable timestamps (default)
createChat({
    webhookUrl: 'YOUR_WEBHOOK_URL',
    showTimestamps: false
});

