### PR TITLE
feat(core): Add @APIController decorator (no-changelog)

### DIFF
--- a/packages/@n8n/decorators/src/controller/__tests__/api-controller.test.ts
+++ b/packages/@n8n/decorators/src/controller/__tests__/api-controller.test.ts
@@ -1,0 +1,58 @@
+import { Container } from '@n8n/di';
+
+import { ApiController } from '../api-controller';
+import { ControllerRegistryMetadata } from '../controller-registry-metadata';
+import type { Controller } from '../types';
+
+describe('@ApiController Decorator', () => {
+	let controllerRegistryMetadata: ControllerRegistryMetadata;
+
+	beforeEach(() => {
+		jest.resetAllMocks();
+
+		controllerRegistryMetadata = new ControllerRegistryMetadata();
+		Container.set(ControllerRegistryMetadata, controllerRegistryMetadata);
+	});
+
+	it('should default base path to "/" when not provided', () => {
+		@ApiController()
+		class TestController {}
+
+		const metadata = controllerRegistryMetadata.getControllerMetadata(TestController as Controller);
+		expect(metadata.basePath).toBe('/');
+		expect(metadata.endpointGroup).toBe('api');
+		expect(Container.has(TestController)).toBe(true);
+	});
+
+	it('should set custom base path and endpoint group when provided', () => {
+		@ApiController('/integration')
+		class TestApiController {}
+
+		const metadata = controllerRegistryMetadata.getControllerMetadata(
+			TestApiController as Controller,
+		);
+
+		expect(metadata.basePath).toBe('/integration');
+		expect(metadata.endpointGroup).toBe('api');
+		expect(Container.has(TestApiController)).toBe(true);
+	});
+
+	it('should register the controller in the registry', () => {
+		@ApiController('/alpha')
+		class AlphaController {}
+
+		@ApiController('/beta')
+		class BetaController {}
+
+		const controllers = Array.from(controllerRegistryMetadata.controllerClasses);
+		expect(controllers).toEqual([AlphaController, BetaController]);
+		expect(Container.has(AlphaController)).toBe(true);
+		expect(Container.has(BetaController)).toBe(true);
+		expect(
+			controllerRegistryMetadata.getControllerMetadata(AlphaController as Controller).basePath,
+		).toBe('/alpha');
+		expect(
+			controllerRegistryMetadata.getControllerMetadata(BetaController as Controller).basePath,
+		).toBe('/beta');
+	});
+});

--- a/packages/@n8n/decorators/src/controller/__tests__/controller-registry-metadata.test.ts
+++ b/packages/@n8n/decorators/src/controller/__tests__/controller-registry-metadata.test.ts
@@ -26,6 +26,7 @@ describe('ControllerRegistryMetadata', () => {
 
 			expect(metadata).toEqual({
 				basePath: '/',
+				endpointGroup: 'rest',
 				middlewares: [],
 				routes: expect.any(Map),
 			});
@@ -43,6 +44,7 @@ describe('ControllerRegistryMetadata', () => {
 
 			expect(metadata).toBe(initialMetadata);
 			expect(metadata.basePath).toBe('/api');
+			expect(metadata.endpointGroup).toBe('rest');
 			expect(metadata.middlewares).toEqual(['auth']);
 		});
 	});
@@ -115,6 +117,7 @@ describe('ControllerRegistryMetadata', () => {
 
 		const retrievedMetadata = registry.getControllerMetadata(TestController);
 		expect(retrievedMetadata.basePath).toBe('/test-api');
+		expect(retrievedMetadata.endpointGroup).toBe('rest');
 		expect(retrievedMetadata.middlewares).toEqual(['global']);
 
 		expect(retrievedMetadata.routes.size).toBe(2);

--- a/packages/@n8n/decorators/src/controller/__tests__/rest-controller.test.ts
+++ b/packages/@n8n/decorators/src/controller/__tests__/rest-controller.test.ts
@@ -20,6 +20,7 @@ describe('@RestController Decorator', () => {
 
 		const metadata = controllerRegistryMetadata.getControllerMetadata(TestController as Controller);
 		expect(metadata.basePath).toBe('/');
+		expect(metadata.endpointGroup).toBe('rest');
 		expect(Container.has(TestController)).toBe(true);
 	});
 
@@ -29,6 +30,7 @@ describe('@RestController Decorator', () => {
 
 		const metadata = controllerRegistryMetadata.getControllerMetadata(TestController as Controller);
 		expect(metadata.basePath).toBe('/test');
+		expect(metadata.endpointGroup).toBe('rest');
 		expect(Container.has(TestController)).toBe(true);
 	});
 

--- a/packages/@n8n/decorators/src/controller/api-controller.ts
+++ b/packages/@n8n/decorators/src/controller/api-controller.ts
@@ -3,14 +3,14 @@ import { Container, Service } from '@n8n/di';
 import { ControllerRegistryMetadata } from './controller-registry-metadata';
 import type { Controller } from './types';
 
-export const RestController =
+export const ApiController =
 	(basePath: `/${string}` = '/'): ClassDecorator =>
 	(target) => {
 		const metadata = Container.get(ControllerRegistryMetadata).getControllerMetadata(
 			target as unknown as Controller,
 		);
 		metadata.basePath = basePath;
-		metadata.endpointGroup = 'rest';
+		metadata.endpointGroup = 'api';
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 		return Service()(target);
 	};

--- a/packages/@n8n/decorators/src/controller/controller-registry-metadata.ts
+++ b/packages/@n8n/decorators/src/controller/controller-registry-metadata.ts
@@ -11,6 +11,7 @@ export class ControllerRegistryMetadata {
 		if (!metadata) {
 			metadata = {
 				basePath: '/',
+				endpointGroup: 'rest',
 				middlewares: [],
 				routes: new Map(),
 			};

--- a/packages/@n8n/decorators/src/controller/index.ts
+++ b/packages/@n8n/decorators/src/controller/index.ts
@@ -1,8 +1,9 @@
 export { Body, Query, Param } from './args';
+export { ApiController } from './api-controller';
 export { RestController } from './rest-controller';
 export { Get, Post, Put, Patch, Delete } from './route';
 export { Middleware } from './middleware';
 export { ControllerRegistryMetadata } from './controller-registry-metadata';
 export { Licensed } from './licensed';
 export { GlobalScope, ProjectScope } from './scoped';
-export type { AccessScope, Controller, RateLimit } from './types';
+export type { AccessScope, Controller, EndpointGroup, RateLimit } from './types';

--- a/packages/@n8n/decorators/src/controller/types.ts
+++ b/packages/@n8n/decorators/src/controller/types.ts
@@ -40,8 +40,11 @@ export interface RouteMetadata {
 	args: Arg[];
 }
 
+export type EndpointGroup = 'rest' | 'api';
+
 export interface ControllerMetadata {
 	basePath: `/${string}`;
+	endpointGroup: EndpointGroup;
 	middlewares: HandlerName[];
 	routes: Map<HandlerName, RouteMetadata>;
 }

--- a/packages/cli/src/controller.registry.ts
+++ b/packages/cli/src/controller.registry.ts
@@ -41,7 +41,11 @@ export class ControllerRegistry {
 		const metadata = this.metadata.getControllerMetadata(controllerClass);
 
 		const router = Router({ mergeParams: true });
-		const prefix = `/${this.globalConfig.endpoints.rest}/${metadata.basePath}`
+		const endpointSegment =
+			metadata.endpointGroup === 'api'
+				? this.globalConfig.publicApi.path
+				: this.globalConfig.endpoints.rest;
+		const prefix = `/${endpointSegment}${metadata.basePath}`
 			.replace(/\/+/g, '/')
 			.replace(/\/$/, '');
 		app.use(prefix, router);


### PR DESCRIPTION
## Summary
Introduces new controller decorator, @ApiController that registers controllers under `N8N_PUBLIC_API_ENDPOINT` prefix but keeping them out of the current public API versioning scheme.
Will be used for MCP server module at first, but not limited to that use-case.


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
