### PR TITLE
chore(core): Only allow owners to log in during oidc SSO

### DIFF
--- a/packages/cli/src/controllers/__tests__/auth.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/auth.controller.test.ts
@@ -19,7 +19,6 @@ import { UserService } from '@/services/user.service';
 
 import { AuthController } from '../auth.controller';
 import { AuthError } from '@/errors/response-errors/auth.error';
-import { before } from 'node:test';
 
 jest.mock('@/auth');
 

--- a/packages/cli/src/controllers/__tests__/auth.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/auth.controller.test.ts
@@ -18,6 +18,8 @@ import { PostHogClient } from '@/posthog';
 import { UserService } from '@/services/user.service';
 
 import { AuthController } from '../auth.controller';
+import { AuthError } from '@/errors/response-errors/auth.error';
+import { before } from 'node:test';
 
 jest.mock('@/auth');
 
@@ -40,6 +42,10 @@ describe('AuthController', () => {
 	const postHog = Container.get(PostHogClient);
 
 	describe('login', () => {
+		beforeEach(() => {
+			jest.resetAllMocks();
+		});
+
 		it('should not validate email in "emailOrLdapLoginId" if LDAP is enabled', async () => {
 			// Arrange
 
@@ -97,6 +103,79 @@ describe('AuthController', () => {
 				posthog: postHog,
 				withScopes: true,
 			});
+		});
+
+		it('should not login members if "OIDC" is the authentication method', async () => {
+			const member = mock<User>({
+				id: '123',
+				role: { slug: 'global:member' },
+				mfaEnabled: false,
+			});
+
+			const body = mock<LoginRequestDto>({
+				emailOrLdapLoginId: 'user@example.com',
+				password: 'password',
+			});
+
+			const req = mock<AuthenticatedRequest>({
+				user: member,
+				body,
+				browserId: '1',
+			});
+
+			const res = mock<Response>();
+
+			mockedAuth.handleEmailLogin.mockResolvedValue(member);
+			config.set('userManagement.authenticationMethod', 'oidc');
+
+			// Act
+
+			await expect(controller.login(req, res, body)).rejects.toThrowError(
+				new AuthError('SSO is enabled, please log in with SSO'),
+			);
+
+			// Assert
+
+			expect(mockedAuth.handleEmailLogin).toHaveBeenCalledWith(
+				body.emailOrLdapLoginId,
+				body.password,
+			);
+			expect(authService.issueCookie).not.toHaveBeenCalled();
+		});
+
+		it('should login owners if "OIDC" is the authentication method', async () => {
+			config.set('userManagement.authenticationMethod', 'oidc');
+
+			const member = mock<User>({
+				id: '123',
+				role: { slug: 'global:owner' },
+				mfaEnabled: false,
+			});
+
+			const body = mock<LoginRequestDto>({
+				emailOrLdapLoginId: 'user@example.com',
+				password: 'password',
+			});
+
+			const req = mock<AuthenticatedRequest>({
+				user: member,
+				body,
+				browserId: '1',
+			});
+
+			const res = mock<Response>();
+
+			mockedAuth.handleEmailLogin.mockResolvedValue(member); // Act
+
+			await controller.login(req, res, body);
+
+			// Assert
+
+			expect(mockedAuth.handleEmailLogin).toHaveBeenCalledWith(
+				body.emailOrLdapLoginId,
+				body.password,
+			);
+			expect(authService.issueCookie).toHaveBeenCalledWith(res, member, false, '1');
 		});
 	});
 });

--- a/packages/cli/src/controllers/__tests__/auth.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/auth.controller.test.ts
@@ -104,7 +104,7 @@ describe('AuthController', () => {
 			});
 		});
 
-		it('should not login members if "OIDC" is the authentication method', async () => {
+		it('should not allow members to login with email if "OIDC" is the authentication method', async () => {
 			const member = mock<User>({
 				id: '123',
 				role: { slug: 'global:member' },
@@ -142,7 +142,7 @@ describe('AuthController', () => {
 			expect(authService.issueCookie).not.toHaveBeenCalled();
 		});
 
-		it('should login owners if "OIDC" is the authentication method', async () => {
+		it('should allow owners to login with email if "OIDC" is the authentication method', async () => {
 			config.set('userManagement.authenticationMethod', 'oidc');
 
 			const member = mock<User>({

--- a/packages/cli/src/controllers/auth.controller.ts
+++ b/packages/cli/src/controllers/auth.controller.ts
@@ -22,6 +22,7 @@ import { UserService } from '@/services/user.service';
 import {
 	getCurrentAuthenticationMethod,
 	isLdapCurrentAuthenticationMethod,
+	isOidcCurrentAuthenticationMethod,
 	isSamlCurrentAuthenticationMethod,
 } from '@/sso.ee/sso-helpers';
 
@@ -55,7 +56,7 @@ export class AuthController {
 			throw new BadRequestError('Invalid email address');
 		}
 
-		if (isSamlCurrentAuthenticationMethod()) {
+		if (isSamlCurrentAuthenticationMethod() || isOidcCurrentAuthenticationMethod()) {
 			// attempt to fetch user data with the credentials, but don't log in yet
 			const preliminaryUser = await handleEmailLogin(emailOrLdapLoginId, password);
 			// if the user is an owner, continue with the login


### PR DESCRIPTION
## Summary

We should only allow email logins for the owner if OIDC is the authentication method.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-3866/prevent-email-login-except-or-owner-when-oidc-is-current

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
