### PR TITLE
fix: Use monospace for param preview

### DIFF
--- a/packages/frontend/editor-ui/src/components/AssignmentCollection/Assignment.vue
+++ b/packages/frontend/editor-ui/src/components/AssignmentCollection/Assignment.vue
@@ -257,6 +257,7 @@ const onValueInputHoverChange = (hovered: boolean): void => {
 		bottom: calc(var(--spacing-s) * -1);
 		left: 0;
 		right: 0;
+		font-family: monospace;
 	}
 
 	.optionsPadding {

--- a/packages/frontend/editor-ui/src/components/ParameterInputHint.vue
+++ b/packages/frontend/editor-ui/src/components/ParameterInputHint.vue
@@ -62,6 +62,7 @@ const simplyText = computed(() => {
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
+	font-family: monospace;
 }
 .highlight {
 	color: var(--color-secondary);


### PR DESCRIPTION
## Summary

In the rendered params, upper and lower case i and l looked similar 
<img width="399" height="337" alt="Screenshot 2025-09-24 at 14 55 44" src="https://github.com/user-attachments/assets/89ae02d7-120a-498a-b39c-b0c59e95fbee" />

<img width="410" height="573" alt="Screenshot 2025-09-29 at 17 08 30" src="https://github.com/user-attachments/assets/53cb3220-d21a-435c-81c9-b7d1d7cda5ee" />

Making the font monospace helps the readability 
<img width="403" height="336" alt="Screenshot 2025-09-24 at 14 56 08" src="https://github.com/user-attachments/assets/42a39d32-1ce1-4c1a-beeb-1d4b7f6279dc" />

<img width="418" height="637" alt="Screenshot 2025-09-29 at 17 07 57" src="https://github.com/user-attachments/assets/5398f650-1847-4ed2-991d-e6c139c6ec3b" />




<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
