### PR TITLE
fix(editor): Mark Workflow Extraction Modal Submit Button as loading and show error toast on error 

### DIFF
--- a/packages/frontend/editor-ui/src/components/WorkflowExtractionNameModal.vue
+++ b/packages/frontend/editor-ui/src/components/WorkflowExtractionNameModal.vue
@@ -7,6 +7,7 @@ import { N8nFormInput } from '@n8n/design-system';
 import { createEventBus } from '@n8n/utils/event-bus';
 import type { ExtractableSubgraphData } from 'n8n-workflow';
 import { computed, onMounted, ref } from 'vue';
+import { useToast } from '@/composables/useToast';
 
 const props = defineProps<{
 	modalName: string;
@@ -19,10 +20,12 @@ const props = defineProps<{
 const DEFAULT_WORKFLOW_NAME = 'My Sub-workflow';
 
 const i18n = useI18n();
+const toast = useToast();
 const modalBus = createEventBus();
 
 const workflowExtraction = useWorkflowExtraction();
 const workflowName = ref(DEFAULT_WORKFLOW_NAME);
+const initiatedExtraction = ref(false);
 
 const workflowNameOrDefault = computed(() => {
 	if (workflowName.value) return workflowName.value;
@@ -31,13 +34,21 @@ const workflowNameOrDefault = computed(() => {
 });
 
 const onSubmit = async () => {
+	if (initiatedExtraction.value) return;
+
+	initiatedExtraction.value = true;
 	const { selection, subGraph } = props.data;
-	await workflowExtraction.extractNodesIntoSubworkflow(
-		selection,
-		subGraph,
-		workflowNameOrDefault.value,
-	);
-	modalBus.emit('close');
+	try {
+		await workflowExtraction.extractNodesIntoSubworkflow(
+			selection,
+			subGraph,
+			workflowNameOrDefault.value,
+		);
+	} catch (e) {
+		toast.showError(e, i18n.baseText('workflowExtraction.error.failure'));
+	} finally {
+		modalBus.emit('close');
+	}
 };
 
 const inputRef = ref<InstanceType<typeof N8nFormInput> | null>(null);


### PR DESCRIPTION
## Summary

Minor improvements to ensure we only create the sub-workflow once, and that we surface any thrown errors in the second part of extraction.

## Related Linear tickets, Github issues, and Community forum posts


https://linear.app/n8n/issue/ADO-4192



## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
