### PR TITLE
fix(editor): Fix workflow name not resolving in node expressions preview

### DIFF
--- a/packages/frontend/editor-ui/src/composables/useResolvedExpression.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useResolvedExpression.test.ts
@@ -1,6 +1,7 @@
 import { defineComponent, h, nextTick, ref, toValue } from 'vue';
 import { useResolvedExpression } from './useResolvedExpression';
-import * as workflowHelpers from '@/composables/useWorkflowHelpers';
+import { useWorkflowsStore } from '@/stores/workflows.store';
+import * as workflowHelpers from './useWorkflowHelpers';
 import { renderComponent } from '../__tests__/render';
 import { setActivePinia } from 'pinia';
 import { createTestingPinia } from '@pinia/testing';
@@ -33,7 +34,7 @@ const mockResolveExpression = () => {
 
 describe('useResolvedExpression', () => {
 	beforeEach(() => {
-		setActivePinia(createTestingPinia());
+		setActivePinia(createTestingPinia({ stubActions: false }));
 		vi.useFakeTimers();
 	});
 
@@ -41,6 +42,7 @@ describe('useResolvedExpression', () => {
 		vi.clearAllMocks();
 		vi.clearAllTimers();
 		vi.useRealTimers();
+		vi.restoreAllMocks();
 	});
 
 	it('should resolve a simple expression', async () => {
@@ -97,5 +99,27 @@ describe('useResolvedExpression', () => {
 		expect(resolveExpressionSpy).toHaveBeenCalledTimes(1);
 		vi.advanceTimersByTime(200);
 		expect(resolveExpressionSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it('should re-resolve when workflow name changes', async () => {
+		const workflowsStore = useWorkflowsStore();
+		const resolveExpressionSpy = mockResolveExpression();
+		resolveExpressionSpy.mockImplementation(() => workflowsStore.workflow.name);
+
+		workflowsStore.setWorkflowName({ newName: 'Old Name', setStateDirty: false });
+
+		const { resolvedExpressionString } = await renderTestComponent({
+			expression: '={{ $workflow.name }}',
+		});
+
+		// Initial resolve
+		vi.advanceTimersByTime(200);
+		expect(toValue(resolvedExpressionString)).toBe('Old Name');
+
+		// Update name and expect re-resolution
+		workflowsStore.setWorkflowName({ newName: 'New Name', setStateDirty: false });
+		await nextTick();
+		vi.advanceTimersByTime(200);
+		expect(toValue(resolvedExpressionString)).toBe('New Name');
 	});
 });

--- a/packages/frontend/editor-ui/src/composables/useResolvedExpression.ts
+++ b/packages/frontend/editor-ui/src/composables/useResolvedExpression.ts
@@ -107,6 +107,7 @@ export function useResolvedExpression({
 			toRef(expression),
 			() => workflowsStore.getWorkflowExecution,
 			() => workflowsStore.getWorkflowRunData,
+			() => workflowsStore.workflow.name,
 			targetItem,
 		],
 		debouncedUpdateExpression,

--- a/packages/frontend/editor-ui/src/stores/workflows.store.test.ts
+++ b/packages/frontend/editor-ui/src/stores/workflows.store.test.ts
@@ -466,6 +466,11 @@ describe('useWorkflowsStore', () => {
 			workflowsStore.setWorkflowName({ newName: 'New Workflow Name', setStateDirty: false });
 			expect(workflowsStore.workflow.name).toBe('New Workflow Name');
 		});
+
+		it('should propagate name to workflowObject for pre-exec expressions', () => {
+			workflowsStore.setWorkflowName({ newName: 'WF Title', setStateDirty: false });
+			expect(workflowsStore.workflowObject.name).toBe('WF Title');
+		});
 	});
 
 	describe('setWorkflowActive()', () => {

--- a/packages/frontend/editor-ui/src/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/stores/workflows.store.ts
@@ -721,6 +721,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 			uiStore.stateIsDirty = true;
 		}
 		workflow.value.name = data.newName;
+		workflowObject.value.name = data.newName;
 
 		if (
 			workflow.value.id !== PLACEHOLDER_EMPTY_WORKFLOW_ID &&
@@ -1034,7 +1035,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 			workflow.value.pinData = {};
 		}
 
-		const { [nodeName]: _, ...pinData } = workflow.value.pinData as IPinData;
+		const { [nodeName]: _, ...pinData } = workflow.value.pinData;
 		workflow.value.pinData = pinData;
 		workflowObject.value.setPinData(pinData);
 
@@ -1570,7 +1571,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 			workflowExecutionData.value.data.resultData.runData[nodeName] = [];
 		}
 
-		const tasksData = workflowExecutionData.value.data!.resultData.runData[nodeName];
+		const tasksData = workflowExecutionData.value.data.resultData.runData[nodeName];
 		if (isNodeWaiting) {
 			tasksData.push(data);
 			workflowExecutionResultDataLastUpdate.value = Date.now();


### PR DESCRIPTION
## Summary

The workflowObject value was not being updated when the wf name is being set.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4115/value-of-dollarworkflowname-displayed-as-empty-in-node-ui


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
