### PR TITLE
fix(editor): Fix data tables id column sort icon (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/ColumnHeader.vue
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/ColumnHeader.vue
@@ -120,7 +120,6 @@ const onHeaderClick = () => {
 };
 const onShowFilter = (e: MouseEvent) => {
 	e.stopPropagation();
-	if (!isFilterable.value) return;
 	isFilterOpen.value = true;
 	props.params.showFilter(e.currentTarget as HTMLElement);
 };

--- a/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/ColumnHeader.vue
+++ b/packages/frontend/editor-ui/src/features/dataStore/components/dataGrid/ColumnHeader.vue
@@ -7,8 +7,9 @@ import { isAGGridCellType } from '@/features/dataStore/typeGuards';
 import { N8nActionDropdown } from '@n8n/design-system';
 
 type HeaderParamsWithDelete = IHeaderParams & {
-	onDelete: (columnId: string) => void;
+	onDelete?: (columnId: string) => void;
 	allowMenuActions: boolean;
+	showTypeIcon?: boolean;
 };
 
 const props = defineProps<{
@@ -23,6 +24,8 @@ const isDropdownOpen = ref(false);
 const isFilterOpen = ref(false);
 const hasActiveFilter = ref(false);
 const currentSort = ref<SortDirection>(null);
+const shouldShowTypeIcon = computed(() => props.params.showTypeIcon !== false);
+const isFilterable = computed(() => props.params.column.getColDef().filter !== false);
 
 const enum ItemAction {
 	Delete = 'delete',
@@ -31,7 +34,7 @@ const enum ItemAction {
 const onItemClick = (action: string) => {
 	const actionEnum = action as ItemAction;
 	if (actionEnum === ItemAction.Delete) {
-		props.params.onDelete(props.params.column.getColId());
+		props.params.onDelete?.(props.params.column.getColId());
 	}
 };
 
@@ -48,6 +51,10 @@ const onDropdownVisibleChange = (visible: boolean) => {
 };
 
 const checkFilterStatus = () => {
+	if (!isFilterable.value) {
+		hasActiveFilter.value = false;
+		return;
+	}
 	const columnId = props.params.column.getColId();
 	const filterModel = props.params.api.getFilterModel();
 	hasActiveFilter.value = filterModel && Boolean(filterModel[columnId]);
@@ -65,10 +72,14 @@ const isMenuButtonVisible = computed(() => {
 });
 
 const isFilterButtonVisible = computed(() => {
+	if (!isFilterable.value) return false;
 	return isHovered.value || isDropdownOpen.value || isFilterOpen.value || hasActiveFilter.value;
 });
 
 const typeIcon = computed(() => {
+	if (!shouldShowTypeIcon.value) {
+		return null;
+	}
 	const cellDataType = props.params.column.getColDef().cellDataType;
 	if (!isAGGridCellType(cellDataType)) {
 		return null;
@@ -109,6 +120,7 @@ const onHeaderClick = () => {
 };
 const onShowFilter = (e: MouseEvent) => {
 	e.stopPropagation();
+	if (!isFilterable.value) return;
 	isFilterOpen.value = true;
 	props.params.showFilter(e.currentTarget as HTMLElement);
 };

--- a/packages/frontend/editor-ui/src/features/dataStore/composables/useDataStoreGridBase.ts
+++ b/packages/frontend/editor-ui/src/features/dataStore/composables/useDataStoreGridBase.ts
@@ -229,12 +229,15 @@ export const useDataStoreGridBase = ({
 					sortable: true,
 					filter: false,
 					suppressMovable: true,
-					headerComponent: null,
 					lockPosition: true,
 					minWidth: DATA_STORE_ID_COLUMN_WIDTH,
 					maxWidth: DATA_STORE_ID_COLUMN_WIDTH,
 					resizable: false,
 					headerClass: 'system-column',
+					headerComponentParams: {
+						allowMenuActions: false,
+						showTypeIcon: false,
+					},
 					cellClass: (params) =>
 						params.data?.id === ADD_ROW_ROW_ID ? 'add-row-cell' : 'id-column',
 					cellRendererSelector: (params: ICellRendererParams) => {


### PR DESCRIPTION
## Summary

We were using the default ag grid column component for the id column which had different icon for sorting.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4170/id-column-sorting-icon-is-not-correct

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
