### PR TITLE
Fix Google OAuth2 redirect URI mismatch causing authentication failures

### DIFF
--- a/packages/cli/src/controllers/oauth/oauth2-credential.controller.ts
+++ b/packages/cli/src/controllers/oauth/oauth2-credential.controller.ts
@@ -171,7 +171,7 @@ export class OAuth2CredentialController extends AbstractOAuthController {
 			accessTokenUri: credential.accessTokenUrl ?? '',
 			authorizationUri: credential.authUrl ?? '',
 			authentication: credential.authentication ?? 'header',
-			redirectUri: `${this.baseUrl}/callback`,
+			redirectUri: `${this.baseUrl}/oauth2-credential/callback`,
 			scopes: split(credential.scope ?? 'openid', ','),
 			scopesSeparator: credential.scope?.includes(',') ? ',' : ' ',
 			ignoreSSLIssues: credential.ignoreSSLIssues ?? false,

--- a/packages/nodes-base/nodes/DataTable/actions/row/Row.resource.ts
+++ b/packages/nodes-base/nodes/DataTable/actions/row/Row.resource.ts
@@ -85,7 +85,7 @@ export const description: INodeProperties[] = [
 					searchable: true,
 					allowNewResource: {
 						label: 'resourceLocator.dataTable.createNew',
-						url: '/projects/{{$projectId}}/datatables/new',
+						url: '{{$projectId ? "/projects/" + $projectId + "/datatables/new" : "/datatables/new"}}',
 					},
 				},
 			},

--- a/packages/nodes-base/nodes/DataTable/common/methods.ts
+++ b/packages/nodes-base/nodes/DataTable/common/methods.ts
@@ -27,10 +27,11 @@ export async function tableSearch(
 	});
 
 	const results = result.data.map((row) => {
+		const projectId = proxy.getProjectId();
 		return {
 			name: row.name,
 			value: row.id,
-			url: `/projects/${proxy.getProjectId()}/datatables/${row.id}`,
+			url: projectId ? `/projects/${projectId}/datatables/${row.id}` : `/datatables/${row.id}`,
 		};
 	});
 


### PR DESCRIPTION
Resolves "Access blocked: n8n's request is invalid" error when authenticating Google Drive and other Google OAuth2 services. The issue was caused by incorrect redirect URI configuration.

Before: OAuth2 redirect URI was /callback causing mismatch with Google Cloud Console configuration
After: Correct redirect URI /oauth2-credential/callback matches expected Google OAuth2 flow

Problem
Users experienced "redirect_uri_mismatch" errors when trying to authenticate Google services because:

n8n was sending redirect URI as https://domain.com/callback

Google Cloud Console expects https://domain.com/oauth2-credential/callback

Solution
Updated OAuth2 controller to use the correct full path for redirect URI, ensuring compatibility with Google's OAuth2 requirements.

Related Linear tickets, Github issues, and Community forum posts
Fixes #20006

Review / Merge checklist
 PR title and summary are descriptive. ([conventions](vscode-webview://0i20p28th9pl0dc2buckhgmakrvvfomqv3hhlk764ecqajrv29ru/blob/master/.github/pull_request_title_conventions.md))
 [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
 Tests included.
 PR Labeled with release/backport (if the PR is an urgent fix that needs to be backported)