### PR TITLE
fix(editor): Fix empty credential translation

### DIFF
--- a/packages/frontend/editor-ui/src/components/CredentialConfig.test.ts
+++ b/packages/frontend/editor-ui/src/components/CredentialConfig.test.ts
@@ -5,6 +5,17 @@ import { createTestingPinia } from '@pinia/testing';
 import type { RenderOptions } from '@/__tests__/render';
 import { createComponentRenderer } from '@/__tests__/render';
 import { STORES } from '@n8n/stores';
+import { vi } from 'vitest';
+import { useCredentialsStore } from '@/stores/credentials.store';
+import { addCredentialTranslation } from '@n8n/i18n';
+
+vi.mock('@n8n/i18n', async () => {
+	const actual = await vi.importActual('@n8n/i18n');
+	return {
+		...actual,
+		addCredentialTranslation: vi.fn(),
+	};
+});
 
 const defaultRenderOptions: RenderOptions = {
 	pinia: createTestingPinia({
@@ -52,5 +63,99 @@ describe('CredentialConfig', () => {
 		expect(
 			screen.queryByText('This is a managed credential and cannot be edited.'),
 		).not.toBeInTheDocument();
+	});
+
+	it('should not call addCredentialTranslation when getCredentialTranslation returns null', async () => {
+		const mockCredentialType = {
+			name: 'testCredential',
+			displayName: 'Test Credential',
+		} as ICredentialType;
+
+		const pinia = createTestingPinia({
+			initialState: {
+				[STORES.SETTINGS]: {
+					settings: {
+						enterprise: {
+							sharing: false,
+							externalSecrets: false,
+						},
+					},
+				},
+				[STORES.ROOT]: {
+					defaultLocale: 'de', // Non-English locale to trigger translation loading
+				},
+			},
+			stubActions: false,
+		});
+
+		// Mock the getCredentialTranslation method to return null
+		const credentialsStore = useCredentialsStore();
+		credentialsStore.getCredentialTranslation = vi.fn().mockResolvedValue(null);
+
+		// Clear any previous calls to addCredentialTranslation
+		vi.mocked(addCredentialTranslation).mockClear();
+
+		renderComponent(
+			{
+				props: {
+					credentialType: mockCredentialType,
+				},
+				pinia,
+			},
+			{ merge: true },
+		);
+
+		// Wait for the component to mount and onBeforeMount to complete
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		// Verify that addCredentialTranslation was not called
+		expect(addCredentialTranslation).not.toHaveBeenCalled();
+	});
+
+	it('should not call addCredentialTranslation when getCredentialTranslation returns undefined', async () => {
+		const mockCredentialType = {
+			name: 'testCredential',
+			displayName: 'Test Credential',
+		} as ICredentialType;
+
+		const pinia = createTestingPinia({
+			initialState: {
+				[STORES.SETTINGS]: {
+					settings: {
+						enterprise: {
+							sharing: false,
+							externalSecrets: false,
+						},
+					},
+				},
+				[STORES.ROOT]: {
+					defaultLocale: 'de', // Non-English locale to trigger translation loading
+				},
+			},
+			stubActions: false,
+		});
+
+		// Mock the getCredentialTranslation method to return undefined
+		const credentialsStore = useCredentialsStore();
+		credentialsStore.getCredentialTranslation = vi.fn().mockResolvedValue(undefined);
+
+		// Clear any previous calls to addCredentialTranslation
+		vi.mocked(addCredentialTranslation).mockClear();
+
+		renderComponent(
+			{
+				props: {
+					credentialType: mockCredentialType,
+				},
+				pinia,
+			},
+			{ merge: true },
+		);
+
+		// Wait for the component to mount and onBeforeMount to complete
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		// Verify that addCredentialTranslation was not called
+		expect(addCredentialTranslation).not.toHaveBeenCalled();
 	});
 });

--- a/packages/frontend/editor-ui/src/components/CredentialEdit/CredentialConfig.vue
+++ b/packages/frontend/editor-ui/src/components/CredentialEdit/CredentialConfig.vue
@@ -92,6 +92,8 @@ onBeforeMount(async () => {
 		props.credentialType.name,
 	);
 
+	if (!credTranslation) return;
+
 	addCredentialTranslation(
 		{ [props.credentialType.name]: credTranslation },
 		rootStore.defaultLocale,


### PR DESCRIPTION
## Summary

When n8n executed with locale different to `en` we support translating the credential fields in the UI. If these translations are missing, a null reference in the i18n module leads to credential fields not being shown. This avoid overwriting the credential field names with a null value if these are not available.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-3865/community-issue-n8n-api-credential-missing-fields-like-base-url-api
closes https://github.com/n8n-io/n8n/issues/19625

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
