### PR TITLE
refactor(core): Unify transaction handling at data table

### DIFF
--- a/packages/@n8n/db/src/index.ts
+++ b/packages/@n8n/db/src/index.ts
@@ -15,6 +15,7 @@ export { isValidEmail } from './utils/is-valid-email';
 export { separate } from './utils/separate';
 export { sql } from './utils/sql';
 export { idStringifier, lowerCaser, objectRetriever, sqlite } from './utils/transformers';
+export { withTransaction } from './utils/transaction';
 
 export * from './constants';
 export * from './entities';

--- a/packages/@n8n/db/src/utils/transaction.ts
+++ b/packages/@n8n/db/src/utils/transaction.ts
@@ -1,0 +1,15 @@
+import type { EntityManager } from '@n8n/typeorm';
+
+type Tx = EntityManager | null | undefined;
+
+// Wraps a function in a transaction if no EntityManager is passed.
+// This allows to use the same function in and out of transactions
+// without creating a transaction when already in one.
+export async function withTransaction<T>(
+	manager: EntityManager,
+	trx: Tx,
+	run: (em: EntityManager) => Promise<T>,
+): Promise<T> {
+	if (trx) return await run(trx);
+	return await manager.transaction(run);
+}

--- a/packages/cli/src/modules/data-table/data-store-column.repository.ts
+++ b/packages/cli/src/modules/data-table/data-store-column.repository.ts
@@ -1,4 +1,5 @@
 import { DataStoreCreateColumnSchema } from '@n8n/api-types';
+import { withTransaction } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { DataSource, EntityManager, Repository } from '@n8n/typeorm';
 import { UnexpectedError } from 'n8n-workflow';
@@ -18,23 +19,23 @@ export class DataStoreColumnRepository extends Repository<DataTableColumn> {
 		super(DataTableColumn, dataSource.manager);
 	}
 
-	async getColumns(dataTableId: string, em?: EntityManager) {
-		const executor = em ?? this.manager;
-		const columns = await executor
-			.createQueryBuilder(DataTableColumn, 'dsc')
-			.where('dsc.dataTableId = :dataTableId', { dataTableId })
-			.getMany();
+	async getColumns(dataTableId: string, trx?: EntityManager) {
+		return await withTransaction(this.manager, trx, async (em) => {
+			const columns = await em
+				.createQueryBuilder(DataTableColumn, 'dsc')
+				.where('dsc.dataTableId = :dataTableId', { dataTableId })
+				.getMany();
 
-		// Ensure columns are always returned in the correct order by index,
-		// since the database does not guarantee ordering and TypeORM does not preserve
-		// join order in @OneToMany relations.
-		columns.sort((a, b) => a.index - b.index);
-
-		return columns;
+			// Ensure columns are always returned in the correct order by index,
+			// since the database does not guarantee ordering and TypeORM does not preserve
+			// join order in @OneToMany relations.
+			columns.sort((a, b) => a.index - b.index);
+			return columns;
+		});
 	}
 
-	async addColumn(dataTableId: string, schema: DataStoreCreateColumnSchema) {
-		return await this.manager.transaction(async (em) => {
+	async addColumn(dataTableId: string, schema: DataStoreCreateColumnSchema, trx?: EntityManager) {
+		return await withTransaction(this.manager, trx, async (em) => {
 			const existingColumnMatch = await em.existsBy(DataTableColumn, {
 				name: schema.name,
 				dataTableId,
@@ -63,43 +64,38 @@ export class DataStoreColumnRepository extends Repository<DataTableColumn> {
 			// @ts-ignore Workaround for intermittent typecheck issue with _QueryDeepPartialEntity
 			await em.insert(DataTableColumn, column);
 
-			const queryRunner = em.queryRunner;
-			if (!queryRunner) {
-				throw new UnexpectedError('QueryRunner is not available');
-			}
-
 			await this.dataStoreRowsRepository.addColumn(
 				dataTableId,
 				column,
-				queryRunner,
 				em.connection.options.type,
+				em,
 			);
 
 			return column;
 		});
 	}
 
-	async deleteColumn(dataStoreId: string, column: DataTableColumn) {
-		await this.manager.transaction(async (em) => {
+	async deleteColumn(dataStoreId: string, column: DataTableColumn, trx?: EntityManager) {
+		await withTransaction(this.manager, trx, async (em) => {
 			await em.remove(DataTableColumn, column);
-
-			const queryRunner = em.queryRunner;
-			if (!queryRunner) {
-				throw new UnexpectedError('QueryRunner is not available');
-			}
 
 			await this.dataStoreRowsRepository.dropColumnFromTable(
 				dataStoreId,
 				column.name,
-				queryRunner,
 				em.connection.options.type,
+				em,
 			);
 			await this.shiftColumns(dataStoreId, column.index, -1, em);
 		});
 	}
 
-	async moveColumn(dataTableId: string, column: DataTableColumn, targetIndex: number) {
-		await this.manager.transaction(async (em) => {
+	async moveColumn(
+		dataTableId: string,
+		column: DataTableColumn,
+		targetIndex: number,
+		trx?: EntityManager,
+	) {
+		await withTransaction(this.manager, trx, async (em) => {
 			const columnCount = await em.countBy(DataTableColumn, { dataTableId });
 
 			if (targetIndex < 0) {
@@ -118,18 +114,19 @@ export class DataStoreColumnRepository extends Repository<DataTableColumn> {
 		});
 	}
 
-	async shiftColumns(dataTableId: string, lowestIndex: number, delta: -1 | 1, em?: EntityManager) {
-		const executor = em ?? this.manager;
-		await executor
-			.createQueryBuilder()
-			.update(DataTableColumn)
-			.set({
-				index: () => `index + ${delta}`,
-			})
-			.where('dataTableId = :dataTableId AND index >= :thresholdValue', {
-				dataTableId,
-				thresholdValue: lowestIndex,
-			})
-			.execute();
+	async shiftColumns(dataTableId: string, lowestIndex: number, delta: -1 | 1, trx?: EntityManager) {
+		await withTransaction(this.manager, trx, async (em) => {
+			await em
+				.createQueryBuilder()
+				.update(DataTableColumn)
+				.set({
+					index: () => `index + ${delta}`,
+				})
+				.where('dataTableId = :dataTableId AND index >= :thresholdValue', {
+					dataTableId,
+					thresholdValue: lowestIndex,
+				})
+				.execute();
+		});
 	}
 }

--- a/packages/cli/src/modules/data-table/data-store.repository.ts
+++ b/packages/cli/src/modules/data-table/data-store.repository.ts
@@ -4,7 +4,7 @@ import {
 	type ListDataStoreQueryDto,
 } from '@n8n/api-types';
 import { GlobalConfig } from '@n8n/config';
-import { Project } from '@n8n/db';
+import { Project, withTransaction } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { DataSource, EntityManager, Repository, SelectQueryBuilder } from '@n8n/typeorm';
 import { UnexpectedError } from 'n8n-workflow';
@@ -28,22 +28,22 @@ export class DataStoreRepository extends Repository<DataTable> {
 		super(DataTable, dataSource.manager);
 	}
 
-	async createDataStore(projectId: string, name: string, columns: DataStoreCreateColumnSchema[]) {
-		if (columns.some((c) => !isValidColumnName(c.name))) {
-			throw new DataStoreValidationError(DATA_STORE_COLUMN_ERROR_MESSAGE);
-		}
+	async createDataStore(
+		projectId: string,
+		name: string,
+		columns: DataStoreCreateColumnSchema[],
+		trx?: EntityManager,
+	) {
+		return await withTransaction(this.manager, trx, async (em) => {
+			if (columns.some((c) => !isValidColumnName(c.name))) {
+				throw new DataStoreValidationError(DATA_STORE_COLUMN_ERROR_MESSAGE);
+			}
 
-		let dataTableId: string | undefined;
-		await this.manager.transaction(async (em) => {
 			const dataStore = em.create(DataTable, { name, columns, projectId });
+
 			// @ts-ignore Workaround for intermittent typecheck issue with _QueryDeepPartialEntity
 			await em.insert(DataTable, dataStore);
-			dataTableId = dataStore.id;
-
-			const queryRunner = em.queryRunner;
-			if (!queryRunner) {
-				throw new UnexpectedError('QueryRunner is not available');
-			}
+			const dataTableId = dataStore.id;
 
 			// insert columns
 			const columnEntities = columns.map((col, index) =>
@@ -61,48 +61,37 @@ export class DataStoreRepository extends Repository<DataTable> {
 			}
 
 			// create user table (will create empty table with just id column if no columns)
-			await this.dataStoreRowsRepository.createTableWithColumns(
-				dataTableId,
-				columnEntities,
-				queryRunner,
-			);
-		});
+			await this.dataStoreRowsRepository.createTableWithColumns(dataTableId, columnEntities, em);
 
-		if (!dataTableId) {
-			throw new UnexpectedError('Data store creation failed');
-		}
-
-		const createdDataStore = await this.findOneOrFail({
-			where: { id: dataTableId },
-			relations: ['project', 'columns'],
-		});
-
-		return createdDataStore;
-	}
-
-	async deleteDataStore(dataStoreId: string, tx?: EntityManager) {
-		const run = async (em: EntityManager) => {
-			const queryRunner = em.queryRunner;
-			if (!queryRunner) {
-				throw new UnexpectedError('QueryRunner is not available');
+			if (!dataTableId) {
+				throw new UnexpectedError('Data store creation failed');
 			}
 
-			await em.delete(DataTable, { id: dataStoreId });
-			await this.dataStoreRowsRepository.dropTable(dataStoreId, queryRunner);
-			return true;
-		};
+			const createdDataStore = await this.findOneOrFail({
+				where: { id: dataTableId },
+				relations: ['project', 'columns'],
+			});
 
-		if (tx) {
-			return await run(tx);
-		}
-
-		return await this.manager.transaction(run);
+			return createdDataStore;
+		});
 	}
 
-	async transferDataStoreByProjectId(fromProjectId: string, toProjectId: string) {
+	async deleteDataStore(dataStoreId: string, trx?: EntityManager) {
+		return await withTransaction(this.manager, trx, async (em) => {
+			await em.delete(DataTable, { id: dataStoreId });
+			await this.dataStoreRowsRepository.dropTable(dataStoreId, em);
+			return true;
+		});
+	}
+
+	async transferDataStoreByProjectId(
+		fromProjectId: string,
+		toProjectId: string,
+		trx?: EntityManager,
+	) {
 		if (fromProjectId === toProjectId) return false;
 
-		return await this.manager.transaction(async (em) => {
+		return await withTransaction(this.manager, trx, async (em) => {
 			const existingTables = await em.findBy(DataTable, { projectId: fromProjectId });
 
 			let transferred = false;
@@ -137,8 +126,8 @@ export class DataStoreRepository extends Repository<DataTable> {
 		});
 	}
 
-	async deleteDataStoreByProjectId(projectId: string) {
-		return await this.manager.transaction(async (em) => {
+	async deleteDataStoreByProjectId(projectId: string, trx?: EntityManager) {
+		return await withTransaction(this.manager, trx, async (em) => {
 			const existingTables = await em.findBy(DataTable, { projectId });
 
 			let changed = false;
@@ -151,19 +140,14 @@ export class DataStoreRepository extends Repository<DataTable> {
 		});
 	}
 
-	async deleteDataStoreAll() {
-		return await this.manager.transaction(async (em) => {
-			const queryRunner = em.queryRunner;
-			if (!queryRunner) {
-				throw new UnexpectedError('QueryRunner is not available');
-			}
-
+	async deleteDataStoreAll(trx?: EntityManager) {
+		return await withTransaction(this.manager, trx, async (em) => {
 			const existingTables = await em.findBy(DataTable, {});
 
 			let changed = false;
 			for (const match of existingTables) {
 				const result = await em.delete(DataTable, { id: match.id });
-				await this.dataStoreRowsRepository.dropTable(match.id, queryRunner);
+				await this.dataStoreRowsRepository.dropTable(match.id, em);
 				changed = changed || (result.affected ?? 0) > 0;
 			}
 

--- a/packages/cli/src/modules/data-table/data-store.repository.ts
+++ b/packages/cli/src/modules/data-table/data-store.repository.ts
@@ -67,7 +67,7 @@ export class DataStoreRepository extends Repository<DataTable> {
 				throw new UnexpectedError('Data store creation failed');
 			}
 
-			const createdDataStore = await this.findOneOrFail({
+			const createdDataStore = await em.findOneOrFail(DataTable, {
 				where: { id: dataTableId },
 				relations: ['project', 'columns'],
 			});


### PR DESCRIPTION
## Summary

This PR introduces a small `withTransaction` helper and unifies how we do (nested) transactions on data tables.
Now most of the repository functions take an optional `trx?: EntityManager` parameter and use that or start a new transaction.

As a followup to this I would like to expand the `validateUniqueName` and `validateDataStoreExists` checks to run within the same transaction, but that's not within this PR.

I started testing this kind of refactoring while investigating why our transactions break on the non-pooled sqlite driver under concurrent calls, but our transaction code wasn't the issue - but I still finished this refactor

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
