### PR TITLE
chore: Support podman container engine for building n8n image from source

### DIFF
--- a/packages/testing/containers/package.json
+++ b/packages/testing/containers/package.json
@@ -12,6 +12,7 @@
     "stack:queue": "TESTCONTAINERS_REUSE_ENABLE=true npm run stack -- --queue",
     "stack:multi-main": "TESTCONTAINERS_REUSE_ENABLE=true npm run stack -- --mains 2 --workers 1",
     "stack:starter": "TESTCONTAINERS_REUSE_ENABLE=true npm run stack -- --plan starter",
+    "stack:enterprise": "TESTCONTAINERS_REUSE_ENABLE=true npm run stack -- --plan enterprise",
     "stack:clean:containers": "docker ps -aq --filter 'name=n8n-stack-*' | xargs -r docker rm -f 2>/dev/null",
     "stack:clean:networks": "docker network ls --filter 'label=org.testcontainers=true' -q | xargs -r docker network rm 2>/dev/null",
     "stack:clean:all": "pnpm run stack:clean:containers && pnpm run stack:clean:networks",


### PR DESCRIPTION
## Summary

Fixes the issue that you can't run `pnpm run build:docker` or any commands that use the `dockerize-n8n.mjs` script when using `podman` as container engine.

Previously the build command would fail even with podman docker compatibility enabled, where any `docker` command is forwarded to podman, but podman doesn't know the `--load` flag.

## Related Linear tickets, Github issues, and Community forum posts

closes pay-3873


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
