### PR TITLE
test: Add benchmark test for inserting data into data tables

### DIFF
--- a/packages/@n8n/benchmark/scenarios/data-table-node/data-table-node.json
+++ b/packages/@n8n/benchmark/scenarios/data-table-node/data-table-node.json
@@ -1,0 +1,168 @@
+{
+	"createdAt": "2025-09-24T12:19:51.268Z",
+	"updatedAt": "2025-09-24T12:20:45.000Z",
+	"name": "Data table node",
+	"active": true,
+	"nodes": [
+		{
+			"parameters": {
+				"respondWith": "allIncomingItems",
+				"options": {}
+			},
+			"type": "n8n-nodes-base.respondToWebhook",
+			"typeVersion": 1.4,
+			"position": [688, 0],
+			"id": "a7eeb256-a47e-4fe9-a0e1-b33015912b15",
+			"name": "Respond to Webhook"
+		},
+		{
+			"parameters": {
+				"httpMethod": "POST",
+				"path": "data-table-node-benchmark",
+				"responseMode": "responseNode",
+				"options": {}
+			},
+			"type": "n8n-nodes-base.webhook",
+			"typeVersion": 2.1,
+			"position": [-288, 0],
+			"id": "b54681a1-6cfc-4970-ad33-25cb8fec6936",
+			"name": "Webhook",
+			"webhookId": "4748ca75-3b3c-4e4a-8913-3590fdc1867d"
+		},
+		{
+			"parameters": {
+				"fieldToSplitOut": "body.items",
+				"options": {}
+			},
+			"type": "n8n-nodes-base.splitOut",
+			"typeVersion": 1,
+			"position": [96, 0],
+			"id": "019d451f-604f-4ed6-8f40-1beb86445061",
+			"name": "Split Out"
+		},
+		{
+			"parameters": {
+				"dataTableId": {
+					"__rl": true,
+					"value": "={{ $('Webhook').item.json.body.dataTableId }}",
+					"mode": "list"
+				},
+				"columns": {
+					"mappingMode": "defineBelow",
+					"value": {
+						"isActive": "={{ $json.isActive }}",
+						"firstName": "={{ $json.firstName }}",
+						"birthDate": "={{ $json.birthDate }}",
+						"age": "={{ $json.age }}"
+					},
+					"matchingColumns": [],
+					"schema": [
+						{
+							"id": "firstName",
+							"displayName": "firstName",
+							"required": false,
+							"defaultMatch": false,
+							"display": true,
+							"type": "string",
+							"readOnly": false,
+							"removed": false
+						},
+						{
+							"id": "age",
+							"displayName": "age",
+							"required": false,
+							"defaultMatch": false,
+							"display": true,
+							"type": "number",
+							"readOnly": false,
+							"removed": false
+						},
+						{
+							"id": "birthDate",
+							"displayName": "birthDate",
+							"required": false,
+							"defaultMatch": false,
+							"display": true,
+							"type": "dateTime",
+							"readOnly": false,
+							"removed": false
+						},
+						{
+							"id": "isActive",
+							"displayName": "isActive",
+							"required": false,
+							"defaultMatch": false,
+							"display": true,
+							"type": "boolean",
+							"readOnly": false,
+							"removed": false
+						},
+						{
+							"id": "empty",
+							"displayName": "empty",
+							"required": false,
+							"defaultMatch": false,
+							"display": true,
+							"type": "string",
+							"readOnly": false,
+							"removed": false
+						}
+					],
+					"attemptToConvertTypes": false,
+					"convertFieldsToString": false
+				},
+				"options": {}
+			},
+			"type": "n8n-nodes-base.dataTable",
+			"typeVersion": 1,
+			"position": [448, 0],
+			"id": "05a47403-6c7d-4aad-b0eb-ca726e7594c9",
+			"name": "Insert row"
+		}
+	],
+	"connections": {
+		"Webhook": {
+			"main": [
+				[
+					{
+						"node": "Split Out",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Insert row": {
+			"main": [
+				[
+					{
+						"node": "Respond to Webhook",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Split Out": {
+			"main": [
+				[
+					{
+						"node": "Insert row",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"pinData": {},
+	"settings": { "executionOrder": "v1" },
+	"staticData": null,
+	"versionId": "cdd59544-4b5d-42c0-a07f-8ab48a9d849c",
+	"triggerCount": 1,
+	"tags": [],
+	"meta": {
+		"responseMode": "lastNode",
+		"options": {}
+	}
+}

--- a/packages/@n8n/benchmark/scenarios/data-table-node/data-table-node.manifest.json
+++ b/packages/@n8n/benchmark/scenarios/data-table-node/data-table-node.manifest.json
@@ -1,0 +1,10 @@
+{
+	"$schema": "../scenario.schema.json",
+	"name": "DataTableNode",
+	"description": "A Data table node that first inserts 100 items and then reads them from the table. The data is returned with RespondToWebhook Node.",
+	"scenarioData": {
+		"workflowFiles": ["data-table-node.json"],
+		"dataTableFile": "data-table.json"
+	},
+	"scriptPath": "data-table-node.script.js"
+}

--- a/packages/@n8n/benchmark/scenarios/data-table-node/data-table-node.script.js
+++ b/packages/@n8n/benchmark/scenarios/data-table-node/data-table-node.script.js
@@ -1,0 +1,38 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+const apiBaseUrl = __ENV.API_BASE_URL;
+const dataTableId = __ENV.DATA_TABLE_ID;
+
+export default function () {
+	const res = http.post(`${apiBaseUrl}/webhook/data-table-node-benchmark`, {
+		dataTableId: dataTableId,
+		items: Array.from({ length: 100 }, (_, i) => ({
+			firstName: `Item ${i + 1}`,
+			age: Math.floor(Math.random() * 100),
+			birthDate: new Date(),
+			isActive: i % 2 === 0,
+		})),
+	});
+
+	if (res.status !== 200) {
+		console.error(
+			`Invalid response. Received status ${res.status}. Body: ${JSON.stringify(res.body)}`,
+		);
+	}
+
+	check(res, {
+		'is status 200': (r) => r.status === 200,
+		'has items in response': (r) => {
+			if (r.status !== 200) return false;
+
+			try {
+				const body = JSON.parse(r.body);
+				return Array.isArray(body) ? body.length === 100 : false;
+			} catch (error) {
+				console.error('Error parsing response body: ', error);
+				return false;
+			}
+		},
+	});
+}

--- a/packages/@n8n/benchmark/scenarios/data-table-node/data-table.json
+++ b/packages/@n8n/benchmark/scenarios/data-table-node/data-table.json
@@ -1,0 +1,25 @@
+{
+	"name": "data-table-node-benchmark",
+	"columns": [
+		{
+			"name": "firstName",
+			"type": "string"
+		},
+		{
+			"name": "age",
+			"type": "number"
+		},
+		{
+			"name": "birthDate",
+			"type": "date"
+		},
+		{
+			"name": "isActive",
+			"type": "boolean"
+		},
+		{
+			"name": "empty",
+			"type": "string"
+		}
+	]
+}

--- a/packages/@n8n/benchmark/scenarios/scenario.schema.json
+++ b/packages/@n8n/benchmark/scenarios/scenario.schema.json
@@ -14,6 +14,9 @@
 					"items": {
 						"type": "string"
 					}
+				},
+				"dataTableFile": {
+					"type": "string"
 				}
 			},
 			"required": [],

--- a/packages/@n8n/benchmark/src/n8n-api-client/data-table-api-client.ts
+++ b/packages/@n8n/benchmark/src/n8n-api-client/data-table-api-client.ts
@@ -1,0 +1,30 @@
+import type { AuthenticatedN8nApiClient } from './authenticated-n8n-api-client';
+
+import type { DataTable } from '@/n8n-api-client/n8n-api-client.types';
+
+export class DataTableApiClient {
+	constructor(private readonly apiClient: AuthenticatedN8nApiClient) {}
+
+	async getAllDataTables(): Promise<DataTable[]> {
+		const response = await this.apiClient.get<{ data: { count: number; data: DataTable[] } }>(
+			'/data-tables-global',
+		);
+
+		return response.data.data.data;
+	}
+
+	async deleteDataTable(projectId: string, dataTableId: DataTable['id']): Promise<void> {
+		await this.apiClient.delete(`/projects/${projectId}/data-tables/${dataTableId}`);
+	}
+
+	async createDataTable(projectId: string, dataTable: DataTable): Promise<DataTable> {
+		const response = await this.apiClient.post<{ data: DataTable }>(
+			`/projects/${projectId}/data-tables`,
+			{
+				...dataTable,
+			},
+		);
+
+		return response.data.data;
+	}
+}

--- a/packages/@n8n/benchmark/src/n8n-api-client/data-table-api-client.ts
+++ b/packages/@n8n/benchmark/src/n8n-api-client/data-table-api-client.ts
@@ -1,6 +1,6 @@
-import type { AuthenticatedN8nApiClient } from './authenticated-n8n-api-client';
-
 import type { DataTable } from '@/n8n-api-client/n8n-api-client.types';
+
+import type { AuthenticatedN8nApiClient } from './authenticated-n8n-api-client';
 
 export class DataTableApiClient {
 	constructor(private readonly apiClient: AuthenticatedN8nApiClient) {}

--- a/packages/@n8n/benchmark/src/n8n-api-client/n8n-api-client.types.ts
+++ b/packages/@n8n/benchmark/src/n8n-api-client/n8n-api-client.types.ts
@@ -12,3 +12,15 @@ export type Credential = {
 	name: string;
 	type: string;
 };
+
+export type DataTableColumn = {
+	name: string;
+	type: 'string' | 'number' | 'boolean' | 'date';
+};
+
+export type DataTable = {
+	id?: string;
+	projectId?: number;
+	name: string;
+	columns: DataTableColumn[];
+};

--- a/packages/@n8n/benchmark/src/n8n-api-client/project-api-client.ts
+++ b/packages/@n8n/benchmark/src/n8n-api-client/project-api-client.ts
@@ -1,0 +1,11 @@
+import type { AuthenticatedN8nApiClient } from './authenticated-n8n-api-client';
+
+export class ProjectApiClient {
+	constructor(private readonly apiClient: AuthenticatedN8nApiClient) {}
+
+	async getPersonalProject(): Promise<string> {
+		const response = await this.apiClient.get<{ data: { id: string } }>('/projects/personal');
+
+		return response.data.data.id;
+	}
+}

--- a/packages/@n8n/benchmark/src/n8n-api-client/workflows-api-client.ts
+++ b/packages/@n8n/benchmark/src/n8n-api-client/workflows-api-client.ts
@@ -1,6 +1,6 @@
-import type { Workflow } from '@/n8n-api-client/n8n-api-client.types';
-
 import type { AuthenticatedN8nApiClient } from './authenticated-n8n-api-client';
+
+import type { Workflow } from '@/n8n-api-client/n8n-api-client.types';
 
 export class WorkflowApiClient {
 	constructor(private readonly apiClient: AuthenticatedN8nApiClient) {}

--- a/packages/@n8n/benchmark/src/n8n-api-client/workflows-api-client.ts
+++ b/packages/@n8n/benchmark/src/n8n-api-client/workflows-api-client.ts
@@ -1,6 +1,6 @@
-import type { AuthenticatedN8nApiClient } from './authenticated-n8n-api-client';
-
 import type { Workflow } from '@/n8n-api-client/n8n-api-client.types';
+
+import type { AuthenticatedN8nApiClient } from './authenticated-n8n-api-client';
 
 export class WorkflowApiClient {
 	constructor(private readonly apiClient: AuthenticatedN8nApiClient) {}

--- a/packages/@n8n/benchmark/src/scenario/scenario-data-loader.ts
+++ b/packages/@n8n/benchmark/src/scenario/scenario-data-loader.ts
@@ -1,12 +1,13 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import type { Workflow, Credential } from '@/n8n-api-client/n8n-api-client.types';
+import type { Workflow, Credential, DataTable } from '@/n8n-api-client/n8n-api-client.types';
 import type { Scenario } from '@/types/scenario';
 
 export type LoadableScenarioData = {
 	workflows: Workflow[];
 	credentials: Credential[];
+	dataTable: DataTable | null;
 };
 
 /**
@@ -26,9 +27,16 @@ export class ScenarioDataFileLoader {
 			) ?? [],
 		);
 
+		const dataTable = scenario.scenarioData.dataTableFile
+			? this.loadSingleDataTableFromFile(
+					path.join(scenario.scenarioDirPath, scenario.scenarioData.dataTableFile),
+				)
+			: null;
+
 		return {
 			workflows,
 			credentials,
+			dataTable,
 		};
 	}
 
@@ -51,6 +59,17 @@ export class ScenarioDataFileLoader {
 		} catch (error) {
 			const e = error as Error;
 			throw new Error(`Failed to parse workflow file ${workflowFilePath}: ${e.message}`);
+		}
+	}
+
+	private loadSingleDataTableFromFile(dataTableFilePath: string): DataTable {
+		const fileContent = fs.readFileSync(dataTableFilePath, 'utf8');
+
+		try {
+			return JSON.parse(fileContent) as DataTable;
+		} catch (error) {
+			const e = error as Error;
+			throw new Error(`Failed to parse data table file ${dataTableFilePath}: ${e.message}`);
 		}
 	}
 }

--- a/packages/@n8n/benchmark/src/test-execution/k6-executor.ts
+++ b/packages/@n8n/benchmark/src/test-execution/k6-executor.ts
@@ -79,6 +79,7 @@ export function handleSummary(data) {
 			cwd: runDirPath,
 			env: {
 				API_BASE_URL: this.opts.n8nApiBaseUrl,
+				DATA_TABLE_ID: scenario.dataTableId,
 				K6_CLOUD_TOKEN: this.opts.k6ApiToken,
 			},
 			stdio: 'inherit',

--- a/packages/@n8n/benchmark/src/test-execution/scenario-runner.ts
+++ b/packages/@n8n/benchmark/src/test-execution/scenario-runner.ts
@@ -1,12 +1,12 @@
 import { sleep } from 'zx';
 
-import type { K6Executor } from './k6-executor';
-
 import { AuthenticatedN8nApiClient } from '@/n8n-api-client/authenticated-n8n-api-client';
 import type { N8nApiClient } from '@/n8n-api-client/n8n-api-client';
 import type { ScenarioDataFileLoader } from '@/scenario/scenario-data-loader';
 import { ScenarioDataImporter } from '@/test-execution/scenario-data-importer';
 import type { Scenario } from '@/types/scenario';
+
+import type { K6Executor } from './k6-executor';
 
 /**
  * Runs scenarios

--- a/packages/@n8n/benchmark/src/types/scenario.ts
+++ b/packages/@n8n/benchmark/src/types/scenario.ts
@@ -3,6 +3,8 @@ export type ScenarioData = {
 	workflowFiles?: string[];
 	/** Relative paths to the credential files */
 	credentialFiles?: string[];
+	/** Relative paths to the data table files */
+	dataTableFile?: string;
 };
 
 /**
@@ -26,4 +28,6 @@ export type Scenario = ScenarioManifest & {
 	id: string;
 	/** Path to the directory containing the scenario */
 	scenarioDirPath: string;
+	/** ID of the data table created for the scenario, if any */
+	dataTableId?: string;
 };


### PR DESCRIPTION
## Summary

Add benchmark test for inserting items into data table, to keep track of how that feature's performance progresses over time. We might add more later, but this is at least for the basic case.

The WF takes 100 items to insert from a webhook and inserts them into the datatable, returning the inserted items. I considered generating the items on n8n side, but generating the test data on the n8n workflow seemed to affect the performance numbers more than just passing them on the webhook and I didn't want to introduce a Code node there to measure just Data Table.

To enable this I built some rough enablers for including a data table schema & creating data tables for these test scenarios. Instead of creating multiple data tables the support is there just for creating one table for each test set to make passing the data table ID simple, but I might expand that later.

On my laptop with docker I'm able to execute around 9,6 executions/sec, meaning inserting ~900 items/sec

Note that these tests won't pass on sqlite without `DB_SQLITE_POOL_SIZE` setting and the pooling mode, on the legacy driver these break our transaction handling.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4126/feature-prep-work-before-releasing

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
