### PR TITLE
fix: Fix issue with graphql workflow test (no-changelog)

### DIFF
--- a/packages/testing/playwright/tests/cli-workflows/workflowConfig.json
+++ b/packages/testing/playwright/tests/cli-workflows/workflowConfig.json
@@ -222,12 +222,6 @@
 		"status": "SKIPPED"
 	},
 	{
-		"workflowId": "110",
-		"status": "SKIPPED",
-		"skipReason": "Error thrown in VM2, bug created for nodes team",
-		"ticketReference": "NODE-3692"
-	},
-	{
 		"workflowId": "112",
 		"status": "SKIPPED"
 	},

--- a/packages/testing/playwright/tests/cli-workflows/workflows/110.json
+++ b/packages/testing/playwright/tests/cli-workflows/workflows/110.json
@@ -27,7 +27,7 @@
 		},
 		{
 			"parameters": {
-				"functionCode": "testData = JSON.stringify({ country: { name: \"Germany\", code: \"DE\", capital: \"Berlin\", currency: \"EUR\" } })\n\nif(JSON.stringify($node['GraphQL'].json.data) !== testData){\n  throw new Error('Error in GraphQL node');\n}\nreturn items;"
+				"functionCode": "testData = JSON.stringify({ country: { code: \"DE\", capital: \"Berlin\", currency: \"EUR\", name: \"Germany\" } })\n\nif(JSON.stringify($node['GraphQL'].json.data) !== testData){\n  throw new Error('Function node data is not equal to GraphQL output');\n}\nreturn items;"
 			},
 			"name": "Function",
 			"type": "n8n-nodes-base.function",


### PR DESCRIPTION
## Summary
Updated failing graphql cli test.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-3692/graphql-node-execution-error-in-cli-workflow-tests

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
