### PR TITLE
fix(core): Do not report `SyntaxError` to Sentry in native Python runner (no-changelog)

### DIFF
--- a/packages/@n8n/task-runner-python/src/constants.py
+++ b/packages/@n8n/task-runner-python/src/constants.py
@@ -1,3 +1,5 @@
+from src.errors import TaskCancelledError, TaskRuntimeError, SecurityViolationError
+
 # Messages
 BROKER_INFO_REQUEST = "broker:inforequest"
 BROKER_RUNNER_REGISTERED = "broker:runnerregistered"
@@ -65,6 +67,12 @@ ENV_DEPLOYMENT_NAME = "DEPLOYMENT_NAME"
 # Sentry
 SENTRY_TAG_SERVER_TYPE_KEY = "server_type"
 SENTRY_TAG_SERVER_TYPE_VALUE = "task_runner_python"
+IGNORED_ERROR_TYPES = (
+    TaskRuntimeError,
+    TaskCancelledError,
+    SecurityViolationError,
+    SyntaxError,
+)
 
 # Logging
 LOG_FORMAT = "%(asctime)s.%(msecs)03d\t%(levelname)s\t%(message)s"

--- a/packages/@n8n/task-runner-python/src/sentry.py
+++ b/packages/@n8n/task-runner-python/src/sentry.py
@@ -1,16 +1,14 @@
 import logging
 from typing import Any, Optional
 
-from src.errors import TaskCancelledError, TaskRuntimeError, SecurityViolationError
 from src.config.sentry_config import SentryConfig
 from src.constants import (
     EXECUTOR_FILENAMES,
+    IGNORED_ERROR_TYPES,
     LOG_SENTRY_MISSING,
     SENTRY_TAG_SERVER_TYPE_KEY,
     SENTRY_TAG_SERVER_TYPE_VALUE,
 )
-
-IGNORED_ERROR_TYPES = (TaskRuntimeError, TaskCancelledError, SecurityViolationError)
 
 
 class TaskRunnerSentry:

--- a/packages/@n8n/task-runner-python/tests/unit/test_sentry.py
+++ b/packages/@n8n/task-runner-python/tests/unit/test_sentry.py
@@ -4,11 +4,11 @@ from unittest.mock import Mock, patch
 import pytest
 
 from src.config.sentry_config import SentryConfig
-from src.errors import TaskRuntimeError, TaskCancelledError, SecurityViolationError
 from src.sentry import TaskRunnerSentry, setup_sentry
 from src.constants import (
     EXECUTOR_ALL_ITEMS_FILENAME,
     EXECUTOR_PER_ITEM_FILENAME,
+    IGNORED_ERROR_TYPES,
     LOG_SENTRY_MISSING,
     SENTRY_TAG_SERVER_TYPE_KEY,
     SENTRY_TAG_SERVER_TYPE_VALUE,
@@ -74,11 +74,7 @@ class TestTaskRunnerSentry:
 
     @pytest.mark.parametrize(
         "error_type",
-        [
-            TaskRuntimeError,
-            TaskCancelledError,
-            SecurityViolationError,
-        ],
+        list(IGNORED_ERROR_TYPES),
     )
     def test_filter_out_ignored_errors(self, sentry_config, error_type):
         sentry = TaskRunnerSentry(sentry_config)

--- a/packages/@n8n/task-runner-python/tests/unit/test_sentry.py
+++ b/packages/@n8n/task-runner-python/tests/unit/test_sentry.py
@@ -74,7 +74,7 @@ class TestTaskRunnerSentry:
 
     @pytest.mark.parametrize(
         "error_type",
-        list(IGNORED_ERROR_TYPES),
+        IGNORED_ERROR_TYPES,
     )
     def test_filter_out_ignored_errors(self, sentry_config, error_type):
         sentry = TaskRunnerSentry(sentry_config)


### PR DESCRIPTION
https://linear.app/n8n/issue/CAT-1451/syntaxerror-cannot-assign-to-expression-unknown-line-5