### PR TITLE
fix(Wordpress Node): Handle `before` query parameter when getting many posts or pages

### DIFF
--- a/packages/nodes-base/nodes/Wordpress/Wordpress.node.ts
+++ b/packages/nodes-base/nodes/Wordpress/Wordpress.node.ts
@@ -275,6 +275,9 @@ export class Wordpress implements INodeType {
 						if (options.search) {
 							qs.search = options.search as string;
 						}
+						if (options.before) {
+							qs.before = options.before as string;
+						}
 						if (options.after) {
 							qs.after = options.after as string;
 						}
@@ -445,6 +448,9 @@ export class Wordpress implements INodeType {
 						}
 						if (options.search) {
 							qs.search = options.search as string;
+						}
+						if (options.before) {
+							qs.before = options.before as string;
 						}
 						if (options.after) {
 							qs.after = options.after as string;

--- a/packages/nodes-base/nodes/Wordpress/__tests__/workflow/page/page.test.ts
+++ b/packages/nodes-base/nodes/Wordpress/__tests__/workflow/page/page.test.ts
@@ -20,6 +20,10 @@ describe('Wordpress > Page Workflows', () => {
 		mock.get('/wp-json/wp/v2/pages/2').reply(200, pageGet);
 		mock.get('/wp-json/wp/v2/pages').query({ per_page: 1 }).reply(200, pageGetMany);
 		mock
+			.get('/wp-json/wp/v2/pages')
+			.query({ per_page: 1, before: '2026-01-01T00:00:00' })
+			.reply(200, pageGetMany);
+		mock
 			.post('/wp-json/wp/v2/pages/2', {
 				id: 2,
 				title: 'New Title',

--- a/packages/nodes-base/nodes/Wordpress/__tests__/workflow/page/page.workflow.json
+++ b/packages/nodes-base/nodes/Wordpress/__tests__/workflow/page/page.workflow.json
@@ -5,8 +5,8 @@
 			"parameters": {},
 			"type": "n8n-nodes-base.manualTrigger",
 			"typeVersion": 1,
-			"position": [0, 300],
-			"id": "5a1fb2b5-9262-4511-9247-727111edca0f",
+			"position": [176, 448],
+			"id": "a5e92a85-afca-47e8-a547-05b973674f93",
 			"name": "When clicking ‘Execute workflow’"
 		},
 		{
@@ -23,13 +23,13 @@
 			},
 			"type": "n8n-nodes-base.wordpress",
 			"typeVersion": 1,
-			"position": [220, 0],
-			"id": "28b998b4-0ff7-4abb-bd3f-e6d62eeacb51",
+			"position": [400, 64],
+			"id": "e435f9fd-16ee-4861-95b1-311d31d80007",
 			"name": "Page > Create",
 			"credentials": {
 				"wordpressApi": {
-					"id": "vNOAnwp9mSIq39cD",
-					"name": "nodeqa"
+					"id": "f5S0ZnKe8cDEPpjx",
+					"name": "Wordpress (localhost)"
 				}
 			}
 		},
@@ -42,13 +42,13 @@
 			},
 			"type": "n8n-nodes-base.wordpress",
 			"typeVersion": 1,
-			"position": [220, 200],
-			"id": "b32743c1-3f56-4ac0-8071-e3f4beb9af15",
+			"position": [400, 256],
+			"id": "b50e7cfd-c921-420e-9fa8-9c300411b5c4",
 			"name": "Page > Get",
 			"credentials": {
 				"wordpressApi": {
-					"id": "vNOAnwp9mSIq39cD",
-					"name": "nodeqa"
+					"id": "f5S0ZnKe8cDEPpjx",
+					"name": "Wordpress (localhost)"
 				}
 			}
 		},
@@ -61,13 +61,13 @@
 			},
 			"type": "n8n-nodes-base.wordpress",
 			"typeVersion": 1,
-			"position": [220, 400],
-			"id": "5e5eacfd-58cd-49e0-b129-46ae235ec139",
+			"position": [400, 448],
+			"id": "da3ffc22-ea1f-4fc2-bb77-9a2ef3f97cd5",
 			"name": "Page > Get Many",
 			"credentials": {
 				"wordpressApi": {
-					"id": "vNOAnwp9mSIq39cD",
-					"name": "nodeqa"
+					"id": "f5S0ZnKe8cDEPpjx",
+					"name": "Wordpress (localhost)"
 				}
 			}
 		},
@@ -84,13 +84,13 @@
 			},
 			"type": "n8n-nodes-base.wordpress",
 			"typeVersion": 1,
-			"position": [220, 600],
-			"id": "441a92ae-5c9f-411e-866c-dbb820950246",
+			"position": [400, 832],
+			"id": "73783471-a507-48ea-a8e0-39acad2cca8e",
 			"name": "Page > Update",
 			"credentials": {
 				"wordpressApi": {
-					"id": "vNOAnwp9mSIq39cD",
-					"name": "nodeqa"
+					"id": "f5S0ZnKe8cDEPpjx",
+					"name": "Wordpress (localhost)"
 				}
 			}
 		},
@@ -98,449 +98,64 @@
 			"parameters": {},
 			"type": "n8n-nodes-base.noOp",
 			"typeVersion": 1,
-			"position": [440, 0],
-			"id": "840c6389-3a8e-43a2-bf51-cb463896e907",
+			"position": [624, 64],
+			"id": "ae8881c8-cb74-4cd9-8338-56d8959f1819",
 			"name": "Create Response"
 		},
 		{
 			"parameters": {},
 			"type": "n8n-nodes-base.noOp",
 			"typeVersion": 1,
-			"position": [440, 200],
-			"id": "b659b27b-fa95-4cbf-b80e-5956ea03ac83",
+			"position": [624, 256],
+			"id": "591204fd-7b8d-4bfb-8aee-543174be3388",
 			"name": "Get Response"
 		},
 		{
 			"parameters": {},
 			"type": "n8n-nodes-base.noOp",
 			"typeVersion": 1,
-			"position": [440, 400],
-			"id": "d33fbb73-4204-43db-a88c-0b00cd65de3f",
+			"position": [624, 448],
+			"id": "7274d0e6-8a04-4ae1-901d-edfc4f3385e5",
 			"name": "Get Many Response"
 		},
 		{
 			"parameters": {},
 			"type": "n8n-nodes-base.noOp",
 			"typeVersion": 1,
-			"position": [440, 600],
-			"id": "a50396a0-8838-4051-afa8-8ea13e4e75e4",
+			"position": [624, 832],
+			"id": "b2d7676c-ff25-4a51-b9c5-b0559769f488",
 			"name": "Update Response"
+		},
+		{
+			"parameters": {
+				"resource": "page",
+				"operation": "getAll",
+				"limit": 1,
+				"options": {
+					"before": "2026-01-01T00:00:00"
+				}
+			},
+			"type": "n8n-nodes-base.wordpress",
+			"typeVersion": 1,
+			"position": [400, 640],
+			"id": "f0bece40-03a3-4c81-9c49-86d7c83679e8",
+			"name": "Page > Get Many (With Filters)",
+			"credentials": {
+				"wordpressApi": {
+					"id": "f5S0ZnKe8cDEPpjx",
+					"name": "Wordpress (localhost)"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [624, 640],
+			"id": "ad912385-2895-4319-8f3b-04a92e8cfe7d",
+			"name": "Get Many Response (With Filters)"
 		}
 	],
-	"pinData": {
-		"Create Response": [
-			{
-				"json": {
-					"id": 9,
-					"date": "2025-03-27T20:17:01",
-					"date_gmt": "2025-03-27T20:17:01",
-					"guid": {
-						"rendered": "https://myblog.com/?page_id=9",
-						"raw": "https://myblog.com/?page_id=9"
-					},
-					"modified": "2025-03-27T20:17:01",
-					"modified_gmt": "2025-03-27T20:17:01",
-					"password": "",
-					"slug": "",
-					"status": "draft",
-					"type": "page",
-					"link": "https://myblog.com/?page_id=9",
-					"title": {
-						"raw": "A new page",
-						"rendered": "A new page"
-					},
-					"content": {
-						"raw": "Some content",
-						"rendered": "<p>Some content</p>\n",
-						"protected": false,
-						"block_version": 0
-					},
-					"excerpt": {
-						"raw": "",
-						"rendered": "<p>Some content</p>\n",
-						"protected": false
-					},
-					"author": 1,
-					"featured_media": 0,
-					"parent": 0,
-					"menu_order": 1,
-					"comment_status": "closed",
-					"ping_status": "closed",
-					"template": "",
-					"meta": {
-						"footnotes": ""
-					},
-					"permalink_template": "https://myblog.com/%pagename%/",
-					"generated_slug": "a-new-page",
-					"class_list": ["post-9", "page", "type-page", "status-draft", "hentry"],
-					"_links": {
-						"self": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/pages/9",
-								"targetHints": {
-									"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
-								}
-							}
-						],
-						"collection": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/pages"
-							}
-						],
-						"about": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/types/page"
-							}
-						],
-						"author": [
-							{
-								"embeddable": true,
-								"href": "https://myblog.com/wp-json/wp/v2/users/1"
-							}
-						],
-						"replies": [
-							{
-								"embeddable": true,
-								"href": "https://myblog.com/wp-json/wp/v2/comments?post=9"
-							}
-						],
-						"version-history": [
-							{
-								"count": 0,
-								"href": "https://myblog.com/wp-json/wp/v2/pages/9/revisions"
-							}
-						],
-						"wp:attachment": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/media?parent=9"
-							}
-						],
-						"wp:action-publish": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/pages/9"
-							}
-						],
-						"wp:action-unfiltered-html": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/pages/9"
-							}
-						],
-						"wp:action-assign-author": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/pages/9"
-							}
-						],
-						"curies": [
-							{
-								"name": "wp",
-								"href": "https://api.w.org/{rel}",
-								"templated": true
-							}
-						]
-					}
-				}
-			}
-		],
-		"Get Response": [
-			{
-				"json": {
-					"id": 2,
-					"date": "2025-03-27T18:05:01",
-					"date_gmt": "2025-03-27T18:05:01",
-					"guid": {
-						"rendered": "https://myblog.com/?page_id=2"
-					},
-					"modified": "2025-03-27T18:05:01",
-					"modified_gmt": "2025-03-27T18:05:01",
-					"slug": "sample-page",
-					"status": "publish",
-					"type": "page",
-					"link": "https://myblog.com/sample-page/",
-					"title": {
-						"rendered": "Sample Page"
-					},
-					"content": {
-						"rendered": "\n<p>This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this:</p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>Hi there! I&#8217;m a bike messenger by day, aspiring actor by night, and this is my website. I live in Los Angeles, have a great dog named Jack, and I like pi&#241;a coladas. (And gettin&#8217; caught in the rain.)</p></blockquote>\n\n\n\n<p>&#8230;or something like this:</p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>The XYZ Doohickey Company was founded in 1971, and has been providing quality doohickeys to the public ever since. Located in Gotham City, XYZ employs over 2,000 people and does all kinds of awesome things for the Gotham community.</p></blockquote>\n\n\n\n<p>As a new WordPress user, you should go to <a href=\"https://myblog.com/wp-admin/\">your dashboard</a> to delete this page and create new pages for your content. Have fun!</p>\n",
-						"protected": false
-					},
-					"excerpt": {
-						"rendered": "<p>This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this: Hi there! I&#8217;m a bike messenger [&hellip;]</p>\n",
-						"protected": false
-					},
-					"author": 1,
-					"featured_media": 0,
-					"parent": 0,
-					"menu_order": 0,
-					"comment_status": "closed",
-					"ping_status": "open",
-					"template": "",
-					"meta": {
-						"footnotes": ""
-					},
-					"class_list": ["post-2", "page", "type-page", "status-publish", "hentry"],
-					"_links": {
-						"self": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/pages/2",
-								"targetHints": {
-									"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
-								}
-							}
-						],
-						"collection": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/pages"
-							}
-						],
-						"about": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/types/page"
-							}
-						],
-						"author": [
-							{
-								"embeddable": true,
-								"href": "https://myblog.com/wp-json/wp/v2/users/1"
-							}
-						],
-						"replies": [
-							{
-								"embeddable": true,
-								"href": "https://myblog.com/wp-json/wp/v2/comments?post=2"
-							}
-						],
-						"version-history": [
-							{
-								"count": 0,
-								"href": "https://myblog.com/wp-json/wp/v2/pages/2/revisions"
-							}
-						],
-						"wp:attachment": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/media?parent=2"
-							}
-						],
-						"curies": [
-							{
-								"name": "wp",
-								"href": "https://api.w.org/{rel}",
-								"templated": true
-							}
-						]
-					}
-				}
-			}
-		],
-		"Get Many Response": [
-			{
-				"json": {
-					"id": 2,
-					"date": "2025-03-27T18:05:01",
-					"date_gmt": "2025-03-27T18:05:01",
-					"guid": {
-						"rendered": "https://myblog.com/?page_id=2"
-					},
-					"modified": "2025-03-27T18:05:01",
-					"modified_gmt": "2025-03-27T18:05:01",
-					"slug": "sample-page",
-					"status": "publish",
-					"type": "page",
-					"link": "https://myblog.com/sample-page/",
-					"title": {
-						"rendered": "Sample Page"
-					},
-					"content": {
-						"rendered": "\n<p>This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this:</p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>Hi there! I&#8217;m a bike messenger by day, aspiring actor by night, and this is my website. I live in Los Angeles, have a great dog named Jack, and I like pi&#241;a coladas. (And gettin&#8217; caught in the rain.)</p></blockquote>\n\n\n\n<p>&#8230;or something like this:</p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>The XYZ Doohickey Company was founded in 1971, and has been providing quality doohickeys to the public ever since. Located in Gotham City, XYZ employs over 2,000 people and does all kinds of awesome things for the Gotham community.</p></blockquote>\n\n\n\n<p>As a new WordPress user, you should go to <a href=\"https://myblog.com/wp-admin/\">your dashboard</a> to delete this page and create new pages for your content. Have fun!</p>\n",
-						"protected": false
-					},
-					"excerpt": {
-						"rendered": "<p>This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this: Hi there! I&#8217;m a bike messenger [&hellip;]</p>\n",
-						"protected": false
-					},
-					"author": 1,
-					"featured_media": 0,
-					"parent": 0,
-					"menu_order": 0,
-					"comment_status": "closed",
-					"ping_status": "open",
-					"template": "",
-					"meta": {
-						"footnotes": ""
-					},
-					"class_list": ["post-2", "page", "type-page", "status-publish", "hentry"],
-					"_links": {
-						"self": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/pages/2",
-								"targetHints": {
-									"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
-								}
-							}
-						],
-						"collection": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/pages"
-							}
-						],
-						"about": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/types/page"
-							}
-						],
-						"author": [
-							{
-								"embeddable": true,
-								"href": "https://myblog.com/wp-json/wp/v2/users/1"
-							}
-						],
-						"replies": [
-							{
-								"embeddable": true,
-								"href": "https://myblog.com/wp-json/wp/v2/comments?post=2"
-							}
-						],
-						"version-history": [
-							{
-								"count": 0,
-								"href": "https://myblog.com/wp-json/wp/v2/pages/2/revisions"
-							}
-						],
-						"wp:attachment": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/media?parent=2"
-							}
-						],
-						"curies": [
-							{
-								"name": "wp",
-								"href": "https://api.w.org/{rel}",
-								"templated": true
-							}
-						]
-					}
-				}
-			}
-		],
-		"Update Response": [
-			{
-				"json": {
-					"id": 2,
-					"date": "2025-03-27T18:05:01",
-					"date_gmt": "2025-03-27T18:05:01",
-					"guid": {
-						"rendered": "https://myblog.com/?page_id=2",
-						"raw": "https://myblog.com/?page_id=2"
-					},
-					"modified": "2025-03-27T20:21:11",
-					"modified_gmt": "2025-03-27T20:21:11",
-					"password": "",
-					"slug": "new-slug",
-					"status": "publish",
-					"type": "page",
-					"link": "https://myblog.com/new-slug/",
-					"title": {
-						"raw": "New Title",
-						"rendered": "New Title"
-					},
-					"content": {
-						"raw": "Updated Content",
-						"rendered": "<p>Updated Content</p>\n",
-						"protected": false,
-						"block_version": 0
-					},
-					"excerpt": {
-						"raw": "",
-						"rendered": "<p>Updated Content</p>\n",
-						"protected": false
-					},
-					"author": 1,
-					"featured_media": 0,
-					"parent": 0,
-					"menu_order": 0,
-					"comment_status": "closed",
-					"ping_status": "open",
-					"template": "",
-					"meta": {
-						"footnotes": ""
-					},
-					"permalink_template": "https://myblog.com/%pagename%/",
-					"generated_slug": "new-title",
-					"class_list": ["post-2", "page", "type-page", "status-publish", "hentry"],
-					"_links": {
-						"self": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/pages/2",
-								"targetHints": {
-									"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
-								}
-							}
-						],
-						"collection": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/pages"
-							}
-						],
-						"about": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/types/page"
-							}
-						],
-						"author": [
-							{
-								"embeddable": true,
-								"href": "https://myblog.com/wp-json/wp/v2/users/1"
-							}
-						],
-						"replies": [
-							{
-								"embeddable": true,
-								"href": "https://myblog.com/wp-json/wp/v2/comments?post=2"
-							}
-						],
-						"version-history": [
-							{
-								"count": 1,
-								"href": "https://myblog.com/wp-json/wp/v2/pages/2/revisions"
-							}
-						],
-						"predecessor-version": [
-							{
-								"id": 10,
-								"href": "https://myblog.com/wp-json/wp/v2/pages/2/revisions/10"
-							}
-						],
-						"wp:attachment": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/media?parent=2"
-							}
-						],
-						"wp:action-publish": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/pages/2"
-							}
-						],
-						"wp:action-unfiltered-html": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/pages/2"
-							}
-						],
-						"wp:action-assign-author": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/pages/2"
-							}
-						],
-						"curies": [
-							{
-								"name": "wp",
-								"href": "https://api.w.org/{rel}",
-								"templated": true
-							}
-						]
-					}
-				}
-			}
-		]
-	},
 	"connections": {
 		"When clicking ‘Execute workflow’": {
 			"main": [
@@ -564,6 +179,11 @@
 						"node": "Page > Update",
 						"type": "main",
 						"index": 0
+					},
+					{
+						"node": "Page > Get Many (With Filters)",
+						"type": "main",
+						"index": 0
 					}
 				]
 			]
@@ -579,11 +199,11 @@
 				]
 			]
 		},
-		"Page > Update": {
+		"Page > Get": {
 			"main": [
 				[
 					{
-						"node": "Update Response",
+						"node": "Get Response",
 						"type": "main",
 						"index": 0
 					}
@@ -601,11 +221,22 @@
 				]
 			]
 		},
-		"Page > Get": {
+		"Page > Update": {
 			"main": [
 				[
 					{
-						"node": "Get Response",
+						"node": "Update Response",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Page > Get Many (With Filters)": {
+			"main": [
+				[
+					{
+						"node": "Get Many Response (With Filters)",
 						"type": "main",
 						"index": 0
 					}
@@ -613,15 +244,502 @@
 			]
 		}
 	},
-	"active": false,
-	"settings": {
-		"executionOrder": "v1"
+	"pinData": {
+		"Create Response": [
+			{
+				"id": 9,
+				"date": "2025-03-27T20:17:01",
+				"date_gmt": "2025-03-27T20:17:01",
+				"guid": {
+					"rendered": "https://myblog.com/?page_id=9",
+					"raw": "https://myblog.com/?page_id=9"
+				},
+				"modified": "2025-03-27T20:17:01",
+				"modified_gmt": "2025-03-27T20:17:01",
+				"password": "",
+				"slug": "",
+				"status": "draft",
+				"type": "page",
+				"link": "https://myblog.com/?page_id=9",
+				"title": {
+					"raw": "A new page",
+					"rendered": "A new page"
+				},
+				"content": {
+					"raw": "Some content",
+					"rendered": "<p>Some content</p>\n",
+					"protected": false,
+					"block_version": 0
+				},
+				"excerpt": {
+					"raw": "",
+					"rendered": "<p>Some content</p>\n",
+					"protected": false
+				},
+				"author": 1,
+				"featured_media": 0,
+				"parent": 0,
+				"menu_order": 1,
+				"comment_status": "closed",
+				"ping_status": "closed",
+				"template": "",
+				"meta": {
+					"footnotes": ""
+				},
+				"permalink_template": "https://myblog.com/%pagename%/",
+				"generated_slug": "a-new-page",
+				"class_list": ["post-9", "page", "type-page", "status-draft", "hentry"],
+				"_links": {
+					"self": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/pages/9",
+							"targetHints": {
+								"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+							}
+						}
+					],
+					"collection": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/pages"
+						}
+					],
+					"about": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/types/page"
+						}
+					],
+					"author": [
+						{
+							"embeddable": true,
+							"href": "https://myblog.com/wp-json/wp/v2/users/1"
+						}
+					],
+					"replies": [
+						{
+							"embeddable": true,
+							"href": "https://myblog.com/wp-json/wp/v2/comments?post=9"
+						}
+					],
+					"version-history": [
+						{
+							"count": 0,
+							"href": "https://myblog.com/wp-json/wp/v2/pages/9/revisions"
+						}
+					],
+					"wp:attachment": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/media?parent=9"
+						}
+					],
+					"wp:action-publish": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/pages/9"
+						}
+					],
+					"wp:action-unfiltered-html": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/pages/9"
+						}
+					],
+					"wp:action-assign-author": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/pages/9"
+						}
+					],
+					"curies": [
+						{
+							"name": "wp",
+							"href": "https://api.w.org/{rel}",
+							"templated": true
+						}
+					]
+				}
+			}
+		],
+		"Get Response": [
+			{
+				"id": 2,
+				"date": "2025-03-27T18:05:01",
+				"date_gmt": "2025-03-27T18:05:01",
+				"guid": {
+					"rendered": "https://myblog.com/?page_id=2"
+				},
+				"modified": "2025-03-27T18:05:01",
+				"modified_gmt": "2025-03-27T18:05:01",
+				"slug": "sample-page",
+				"status": "publish",
+				"type": "page",
+				"link": "https://myblog.com/sample-page/",
+				"title": {
+					"rendered": "Sample Page"
+				},
+				"content": {
+					"rendered": "\n<p>This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this:</p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>Hi there! I&#8217;m a bike messenger by day, aspiring actor by night, and this is my website. I live in Los Angeles, have a great dog named Jack, and I like pi&#241;a coladas. (And gettin&#8217; caught in the rain.)</p></blockquote>\n\n\n\n<p>&#8230;or something like this:</p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>The XYZ Doohickey Company was founded in 1971, and has been providing quality doohickeys to the public ever since. Located in Gotham City, XYZ employs over 2,000 people and does all kinds of awesome things for the Gotham community.</p></blockquote>\n\n\n\n<p>As a new WordPress user, you should go to <a href=\"https://myblog.com/wp-admin/\">your dashboard</a> to delete this page and create new pages for your content. Have fun!</p>\n",
+					"protected": false
+				},
+				"excerpt": {
+					"rendered": "<p>This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this: Hi there! I&#8217;m a bike messenger [&hellip;]</p>\n",
+					"protected": false
+				},
+				"author": 1,
+				"featured_media": 0,
+				"parent": 0,
+				"menu_order": 0,
+				"comment_status": "closed",
+				"ping_status": "open",
+				"template": "",
+				"meta": {
+					"footnotes": ""
+				},
+				"class_list": ["post-2", "page", "type-page", "status-publish", "hentry"],
+				"_links": {
+					"self": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/pages/2",
+							"targetHints": {
+								"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+							}
+						}
+					],
+					"collection": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/pages"
+						}
+					],
+					"about": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/types/page"
+						}
+					],
+					"author": [
+						{
+							"embeddable": true,
+							"href": "https://myblog.com/wp-json/wp/v2/users/1"
+						}
+					],
+					"replies": [
+						{
+							"embeddable": true,
+							"href": "https://myblog.com/wp-json/wp/v2/comments?post=2"
+						}
+					],
+					"version-history": [
+						{
+							"count": 0,
+							"href": "https://myblog.com/wp-json/wp/v2/pages/2/revisions"
+						}
+					],
+					"wp:attachment": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/media?parent=2"
+						}
+					],
+					"curies": [
+						{
+							"name": "wp",
+							"href": "https://api.w.org/{rel}",
+							"templated": true
+						}
+					]
+				}
+			}
+		],
+		"Get Many Response": [
+			{
+				"id": 2,
+				"date": "2025-03-27T18:05:01",
+				"date_gmt": "2025-03-27T18:05:01",
+				"guid": {
+					"rendered": "https://myblog.com/?page_id=2"
+				},
+				"modified": "2025-03-27T18:05:01",
+				"modified_gmt": "2025-03-27T18:05:01",
+				"slug": "sample-page",
+				"status": "publish",
+				"type": "page",
+				"link": "https://myblog.com/sample-page/",
+				"title": {
+					"rendered": "Sample Page"
+				},
+				"content": {
+					"rendered": "\n<p>This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this:</p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>Hi there! I&#8217;m a bike messenger by day, aspiring actor by night, and this is my website. I live in Los Angeles, have a great dog named Jack, and I like pi&#241;a coladas. (And gettin&#8217; caught in the rain.)</p></blockquote>\n\n\n\n<p>&#8230;or something like this:</p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>The XYZ Doohickey Company was founded in 1971, and has been providing quality doohickeys to the public ever since. Located in Gotham City, XYZ employs over 2,000 people and does all kinds of awesome things for the Gotham community.</p></blockquote>\n\n\n\n<p>As a new WordPress user, you should go to <a href=\"https://myblog.com/wp-admin/\">your dashboard</a> to delete this page and create new pages for your content. Have fun!</p>\n",
+					"protected": false
+				},
+				"excerpt": {
+					"rendered": "<p>This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this: Hi there! I&#8217;m a bike messenger [&hellip;]</p>\n",
+					"protected": false
+				},
+				"author": 1,
+				"featured_media": 0,
+				"parent": 0,
+				"menu_order": 0,
+				"comment_status": "closed",
+				"ping_status": "open",
+				"template": "",
+				"meta": {
+					"footnotes": ""
+				},
+				"class_list": ["post-2", "page", "type-page", "status-publish", "hentry"],
+				"_links": {
+					"self": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/pages/2",
+							"targetHints": {
+								"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+							}
+						}
+					],
+					"collection": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/pages"
+						}
+					],
+					"about": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/types/page"
+						}
+					],
+					"author": [
+						{
+							"embeddable": true,
+							"href": "https://myblog.com/wp-json/wp/v2/users/1"
+						}
+					],
+					"replies": [
+						{
+							"embeddable": true,
+							"href": "https://myblog.com/wp-json/wp/v2/comments?post=2"
+						}
+					],
+					"version-history": [
+						{
+							"count": 0,
+							"href": "https://myblog.com/wp-json/wp/v2/pages/2/revisions"
+						}
+					],
+					"wp:attachment": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/media?parent=2"
+						}
+					],
+					"curies": [
+						{
+							"name": "wp",
+							"href": "https://api.w.org/{rel}",
+							"templated": true
+						}
+					]
+				}
+			}
+		],
+		"Update Response": [
+			{
+				"id": 2,
+				"date": "2025-03-27T18:05:01",
+				"date_gmt": "2025-03-27T18:05:01",
+				"guid": {
+					"rendered": "https://myblog.com/?page_id=2",
+					"raw": "https://myblog.com/?page_id=2"
+				},
+				"modified": "2025-03-27T20:21:11",
+				"modified_gmt": "2025-03-27T20:21:11",
+				"password": "",
+				"slug": "new-slug",
+				"status": "publish",
+				"type": "page",
+				"link": "https://myblog.com/new-slug/",
+				"title": {
+					"raw": "New Title",
+					"rendered": "New Title"
+				},
+				"content": {
+					"raw": "Updated Content",
+					"rendered": "<p>Updated Content</p>\n",
+					"protected": false,
+					"block_version": 0
+				},
+				"excerpt": {
+					"raw": "",
+					"rendered": "<p>Updated Content</p>\n",
+					"protected": false
+				},
+				"author": 1,
+				"featured_media": 0,
+				"parent": 0,
+				"menu_order": 0,
+				"comment_status": "closed",
+				"ping_status": "open",
+				"template": "",
+				"meta": {
+					"footnotes": ""
+				},
+				"permalink_template": "https://myblog.com/%pagename%/",
+				"generated_slug": "new-title",
+				"class_list": ["post-2", "page", "type-page", "status-publish", "hentry"],
+				"_links": {
+					"self": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/pages/2",
+							"targetHints": {
+								"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+							}
+						}
+					],
+					"collection": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/pages"
+						}
+					],
+					"about": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/types/page"
+						}
+					],
+					"author": [
+						{
+							"embeddable": true,
+							"href": "https://myblog.com/wp-json/wp/v2/users/1"
+						}
+					],
+					"replies": [
+						{
+							"embeddable": true,
+							"href": "https://myblog.com/wp-json/wp/v2/comments?post=2"
+						}
+					],
+					"version-history": [
+						{
+							"count": 1,
+							"href": "https://myblog.com/wp-json/wp/v2/pages/2/revisions"
+						}
+					],
+					"predecessor-version": [
+						{
+							"id": 10,
+							"href": "https://myblog.com/wp-json/wp/v2/pages/2/revisions/10"
+						}
+					],
+					"wp:attachment": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/media?parent=2"
+						}
+					],
+					"wp:action-publish": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/pages/2"
+						}
+					],
+					"wp:action-unfiltered-html": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/pages/2"
+						}
+					],
+					"wp:action-assign-author": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/pages/2"
+						}
+					],
+					"curies": [
+						{
+							"name": "wp",
+							"href": "https://api.w.org/{rel}",
+							"templated": true
+						}
+					]
+				}
+			}
+		],
+		"Get Many Response (With Filters)": [
+			{
+				"id": 2,
+				"date": "2025-03-27T18:05:01",
+				"date_gmt": "2025-03-27T18:05:01",
+				"guid": {
+					"rendered": "https://myblog.com/?page_id=2"
+				},
+				"modified": "2025-03-27T18:05:01",
+				"modified_gmt": "2025-03-27T18:05:01",
+				"slug": "sample-page",
+				"status": "publish",
+				"type": "page",
+				"link": "https://myblog.com/sample-page/",
+				"title": {
+					"rendered": "Sample Page"
+				},
+				"content": {
+					"rendered": "\n<p>This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this:</p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>Hi there! I&#8217;m a bike messenger by day, aspiring actor by night, and this is my website. I live in Los Angeles, have a great dog named Jack, and I like pi&#241;a coladas. (And gettin&#8217; caught in the rain.)</p></blockquote>\n\n\n\n<p>&#8230;or something like this:</p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>The XYZ Doohickey Company was founded in 1971, and has been providing quality doohickeys to the public ever since. Located in Gotham City, XYZ employs over 2,000 people and does all kinds of awesome things for the Gotham community.</p></blockquote>\n\n\n\n<p>As a new WordPress user, you should go to <a href=\"https://myblog.com/wp-admin/\">your dashboard</a> to delete this page and create new pages for your content. Have fun!</p>\n",
+					"protected": false
+				},
+				"excerpt": {
+					"rendered": "<p>This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this: Hi there! I&#8217;m a bike messenger [&hellip;]</p>\n",
+					"protected": false
+				},
+				"author": 1,
+				"featured_media": 0,
+				"parent": 0,
+				"menu_order": 0,
+				"comment_status": "closed",
+				"ping_status": "open",
+				"template": "",
+				"meta": {
+					"footnotes": ""
+				},
+				"class_list": ["post-2", "page", "type-page", "status-publish", "hentry"],
+				"_links": {
+					"self": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/pages/2",
+							"targetHints": {
+								"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+							}
+						}
+					],
+					"collection": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/pages"
+						}
+					],
+					"about": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/types/page"
+						}
+					],
+					"author": [
+						{
+							"embeddable": true,
+							"href": "https://myblog.com/wp-json/wp/v2/users/1"
+						}
+					],
+					"replies": [
+						{
+							"embeddable": true,
+							"href": "https://myblog.com/wp-json/wp/v2/comments?post=2"
+						}
+					],
+					"version-history": [
+						{
+							"count": 0,
+							"href": "https://myblog.com/wp-json/wp/v2/pages/2/revisions"
+						}
+					],
+					"wp:attachment": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/media?parent=2"
+						}
+					],
+					"curies": [
+						{
+							"name": "wp",
+							"href": "https://api.w.org/{rel}",
+							"templated": true
+						}
+					]
+				}
+			}
+		]
 	},
-	"versionId": "b20521c7-44b4-430b-9dab-72488f7b2d02",
 	"meta": {
 		"templateCredsSetupCompleted": true,
-		"instanceId": "0fa937d34dcabeff4bd6480d3b42cc95edf3bc20e6810819086ef1ce2623639d"
-	},
-	"id": "QuWF8XwVEfFBCWjj",
-	"tags": []
+		"instanceId": "eeda9e3069aca300d1dfceeb64beb5b53d715db44a50461bbc5cb0cf6daa01e3"
+	}
 }

--- a/packages/nodes-base/nodes/Wordpress/__tests__/workflow/page/page.workflow.json
+++ b/packages/nodes-base/nodes/Wordpress/__tests__/workflow/page/page.workflow.json
@@ -5,8 +5,8 @@
 			"parameters": {},
 			"type": "n8n-nodes-base.manualTrigger",
 			"typeVersion": 1,
-			"position": [176, 448],
-			"id": "a5e92a85-afca-47e8-a547-05b973674f93",
+			"position": [-32, 464],
+			"id": "246376de-5cc4-4fd2-9671-0a45b8bff10d",
 			"name": "When clicking ‘Execute workflow’"
 		},
 		{
@@ -23,8 +23,8 @@
 			},
 			"type": "n8n-nodes-base.wordpress",
 			"typeVersion": 1,
-			"position": [400, 64],
-			"id": "e435f9fd-16ee-4861-95b1-311d31d80007",
+			"position": [192, 80],
+			"id": "36cf31d4-ad52-4bbc-8abf-bd384b6968f7",
 			"name": "Page > Create",
 			"credentials": {
 				"wordpressApi": {
@@ -42,8 +42,8 @@
 			},
 			"type": "n8n-nodes-base.wordpress",
 			"typeVersion": 1,
-			"position": [400, 256],
-			"id": "b50e7cfd-c921-420e-9fa8-9c300411b5c4",
+			"position": [192, 272],
+			"id": "236d9c67-319b-435f-94e1-1719f2752a72",
 			"name": "Page > Get",
 			"credentials": {
 				"wordpressApi": {
@@ -61,8 +61,8 @@
 			},
 			"type": "n8n-nodes-base.wordpress",
 			"typeVersion": 1,
-			"position": [400, 448],
-			"id": "da3ffc22-ea1f-4fc2-bb77-9a2ef3f97cd5",
+			"position": [192, 464],
+			"id": "b1a3788f-9c81-4591-8a4c-e138612d3fb2",
 			"name": "Page > Get Many",
 			"credentials": {
 				"wordpressApi": {
@@ -84,8 +84,8 @@
 			},
 			"type": "n8n-nodes-base.wordpress",
 			"typeVersion": 1,
-			"position": [400, 832],
-			"id": "73783471-a507-48ea-a8e0-39acad2cca8e",
+			"position": [192, 848],
+			"id": "cac71c1a-3367-4d5b-ba8d-d2285934be4e",
 			"name": "Page > Update",
 			"credentials": {
 				"wordpressApi": {
@@ -98,32 +98,32 @@
 			"parameters": {},
 			"type": "n8n-nodes-base.noOp",
 			"typeVersion": 1,
-			"position": [624, 64],
-			"id": "ae8881c8-cb74-4cd9-8338-56d8959f1819",
+			"position": [416, 80],
+			"id": "bb846050-d39c-4e34-ad64-a97ccbbef256",
 			"name": "Create Response"
 		},
 		{
 			"parameters": {},
 			"type": "n8n-nodes-base.noOp",
 			"typeVersion": 1,
-			"position": [624, 256],
-			"id": "591204fd-7b8d-4bfb-8aee-543174be3388",
+			"position": [416, 272],
+			"id": "9634f881-592c-4165-8f9c-5a1aad5f76ee",
 			"name": "Get Response"
 		},
 		{
 			"parameters": {},
 			"type": "n8n-nodes-base.noOp",
 			"typeVersion": 1,
-			"position": [624, 448],
-			"id": "7274d0e6-8a04-4ae1-901d-edfc4f3385e5",
+			"position": [416, 464],
+			"id": "4343c931-3ded-4505-950c-43ba56929692",
 			"name": "Get Many Response"
 		},
 		{
 			"parameters": {},
 			"type": "n8n-nodes-base.noOp",
 			"typeVersion": 1,
-			"position": [624, 832],
-			"id": "b2d7676c-ff25-4a51-b9c5-b0559769f488",
+			"position": [416, 848],
+			"id": "e159e8fa-a9c9-4f54-a941-29dc7983fd3a",
 			"name": "Update Response"
 		},
 		{
@@ -137,8 +137,8 @@
 			},
 			"type": "n8n-nodes-base.wordpress",
 			"typeVersion": 1,
-			"position": [400, 640],
-			"id": "f0bece40-03a3-4c81-9c49-86d7c83679e8",
+			"position": [192, 656],
+			"id": "a08d9d51-e97f-4ea7-b189-d109b77e9f57",
 			"name": "Page > Get Many (With Filters)",
 			"credentials": {
 				"wordpressApi": {
@@ -151,11 +151,515 @@
 			"parameters": {},
 			"type": "n8n-nodes-base.noOp",
 			"typeVersion": 1,
-			"position": [624, 640],
-			"id": "ad912385-2895-4319-8f3b-04a92e8cfe7d",
+			"position": [416, 656],
+			"id": "18c8cd20-de15-4ceb-9d6f-e4279532fe3c",
 			"name": "Get Many Response (With Filters)"
 		}
 	],
+	"pinData": {
+		"Create Response": [
+			{
+				"json": {
+					"id": 9,
+					"date": "2025-03-27T20:17:01",
+					"date_gmt": "2025-03-27T20:17:01",
+					"guid": {
+						"rendered": "https://myblog.com/?page_id=9",
+						"raw": "https://myblog.com/?page_id=9"
+					},
+					"modified": "2025-03-27T20:17:01",
+					"modified_gmt": "2025-03-27T20:17:01",
+					"password": "",
+					"slug": "",
+					"status": "draft",
+					"type": "page",
+					"link": "https://myblog.com/?page_id=9",
+					"title": {
+						"raw": "A new page",
+						"rendered": "A new page"
+					},
+					"content": {
+						"raw": "Some content",
+						"rendered": "<p>Some content</p>\n",
+						"protected": false,
+						"block_version": 0
+					},
+					"excerpt": {
+						"raw": "",
+						"rendered": "<p>Some content</p>\n",
+						"protected": false
+					},
+					"author": 1,
+					"featured_media": 0,
+					"parent": 0,
+					"menu_order": 1,
+					"comment_status": "closed",
+					"ping_status": "closed",
+					"template": "",
+					"meta": {
+						"footnotes": ""
+					},
+					"permalink_template": "https://myblog.com/%pagename%/",
+					"generated_slug": "a-new-page",
+					"class_list": ["post-9", "page", "type-page", "status-draft", "hentry"],
+					"_links": {
+						"self": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/pages/9",
+								"targetHints": {
+									"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+								}
+							}
+						],
+						"collection": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/pages"
+							}
+						],
+						"about": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/types/page"
+							}
+						],
+						"author": [
+							{
+								"embeddable": true,
+								"href": "https://myblog.com/wp-json/wp/v2/users/1"
+							}
+						],
+						"replies": [
+							{
+								"embeddable": true,
+								"href": "https://myblog.com/wp-json/wp/v2/comments?post=9"
+							}
+						],
+						"version-history": [
+							{
+								"count": 0,
+								"href": "https://myblog.com/wp-json/wp/v2/pages/9/revisions"
+							}
+						],
+						"wp:attachment": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/media?parent=9"
+							}
+						],
+						"wp:action-publish": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/pages/9"
+							}
+						],
+						"wp:action-unfiltered-html": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/pages/9"
+							}
+						],
+						"wp:action-assign-author": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/pages/9"
+							}
+						],
+						"curies": [
+							{
+								"name": "wp",
+								"href": "https://api.w.org/{rel}",
+								"templated": true
+							}
+						]
+					}
+				}
+			}
+		],
+		"Get Response": [
+			{
+				"json": {
+					"id": 2,
+					"date": "2025-03-27T18:05:01",
+					"date_gmt": "2025-03-27T18:05:01",
+					"guid": {
+						"rendered": "https://myblog.com/?page_id=2"
+					},
+					"modified": "2025-03-27T18:05:01",
+					"modified_gmt": "2025-03-27T18:05:01",
+					"slug": "sample-page",
+					"status": "publish",
+					"type": "page",
+					"link": "https://myblog.com/sample-page/",
+					"title": {
+						"rendered": "Sample Page"
+					},
+					"content": {
+						"rendered": "\n<p>This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this:</p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>Hi there! I&#8217;m a bike messenger by day, aspiring actor by night, and this is my website. I live in Los Angeles, have a great dog named Jack, and I like pi&#241;a coladas. (And gettin&#8217; caught in the rain.)</p></blockquote>\n\n\n\n<p>&#8230;or something like this:</p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>The XYZ Doohickey Company was founded in 1971, and has been providing quality doohickeys to the public ever since. Located in Gotham City, XYZ employs over 2,000 people and does all kinds of awesome things for the Gotham community.</p></blockquote>\n\n\n\n<p>As a new WordPress user, you should go to <a href=\"https://myblog.com/wp-admin/\">your dashboard</a> to delete this page and create new pages for your content. Have fun!</p>\n",
+						"protected": false
+					},
+					"excerpt": {
+						"rendered": "<p>This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this: Hi there! I&#8217;m a bike messenger [&hellip;]</p>\n",
+						"protected": false
+					},
+					"author": 1,
+					"featured_media": 0,
+					"parent": 0,
+					"menu_order": 0,
+					"comment_status": "closed",
+					"ping_status": "open",
+					"template": "",
+					"meta": {
+						"footnotes": ""
+					},
+					"class_list": ["post-2", "page", "type-page", "status-publish", "hentry"],
+					"_links": {
+						"self": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/pages/2",
+								"targetHints": {
+									"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+								}
+							}
+						],
+						"collection": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/pages"
+							}
+						],
+						"about": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/types/page"
+							}
+						],
+						"author": [
+							{
+								"embeddable": true,
+								"href": "https://myblog.com/wp-json/wp/v2/users/1"
+							}
+						],
+						"replies": [
+							{
+								"embeddable": true,
+								"href": "https://myblog.com/wp-json/wp/v2/comments?post=2"
+							}
+						],
+						"version-history": [
+							{
+								"count": 0,
+								"href": "https://myblog.com/wp-json/wp/v2/pages/2/revisions"
+							}
+						],
+						"wp:attachment": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/media?parent=2"
+							}
+						],
+						"curies": [
+							{
+								"name": "wp",
+								"href": "https://api.w.org/{rel}",
+								"templated": true
+							}
+						]
+					}
+				}
+			}
+		],
+		"Get Many Response": [
+			{
+				"json": {
+					"id": 2,
+					"date": "2025-03-27T18:05:01",
+					"date_gmt": "2025-03-27T18:05:01",
+					"guid": {
+						"rendered": "https://myblog.com/?page_id=2"
+					},
+					"modified": "2025-03-27T18:05:01",
+					"modified_gmt": "2025-03-27T18:05:01",
+					"slug": "sample-page",
+					"status": "publish",
+					"type": "page",
+					"link": "https://myblog.com/sample-page/",
+					"title": {
+						"rendered": "Sample Page"
+					},
+					"content": {
+						"rendered": "\n<p>This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this:</p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>Hi there! I&#8217;m a bike messenger by day, aspiring actor by night, and this is my website. I live in Los Angeles, have a great dog named Jack, and I like pi&#241;a coladas. (And gettin&#8217; caught in the rain.)</p></blockquote>\n\n\n\n<p>&#8230;or something like this:</p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>The XYZ Doohickey Company was founded in 1971, and has been providing quality doohickeys to the public ever since. Located in Gotham City, XYZ employs over 2,000 people and does all kinds of awesome things for the Gotham community.</p></blockquote>\n\n\n\n<p>As a new WordPress user, you should go to <a href=\"https://myblog.com/wp-admin/\">your dashboard</a> to delete this page and create new pages for your content. Have fun!</p>\n",
+						"protected": false
+					},
+					"excerpt": {
+						"rendered": "<p>This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this: Hi there! I&#8217;m a bike messenger [&hellip;]</p>\n",
+						"protected": false
+					},
+					"author": 1,
+					"featured_media": 0,
+					"parent": 0,
+					"menu_order": 0,
+					"comment_status": "closed",
+					"ping_status": "open",
+					"template": "",
+					"meta": {
+						"footnotes": ""
+					},
+					"class_list": ["post-2", "page", "type-page", "status-publish", "hentry"],
+					"_links": {
+						"self": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/pages/2",
+								"targetHints": {
+									"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+								}
+							}
+						],
+						"collection": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/pages"
+							}
+						],
+						"about": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/types/page"
+							}
+						],
+						"author": [
+							{
+								"embeddable": true,
+								"href": "https://myblog.com/wp-json/wp/v2/users/1"
+							}
+						],
+						"replies": [
+							{
+								"embeddable": true,
+								"href": "https://myblog.com/wp-json/wp/v2/comments?post=2"
+							}
+						],
+						"version-history": [
+							{
+								"count": 0,
+								"href": "https://myblog.com/wp-json/wp/v2/pages/2/revisions"
+							}
+						],
+						"wp:attachment": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/media?parent=2"
+							}
+						],
+						"curies": [
+							{
+								"name": "wp",
+								"href": "https://api.w.org/{rel}",
+								"templated": true
+							}
+						]
+					}
+				}
+			}
+		],
+		"Update Response": [
+			{
+				"json": {
+					"id": 2,
+					"date": "2025-03-27T18:05:01",
+					"date_gmt": "2025-03-27T18:05:01",
+					"guid": {
+						"rendered": "https://myblog.com/?page_id=2",
+						"raw": "https://myblog.com/?page_id=2"
+					},
+					"modified": "2025-03-27T20:21:11",
+					"modified_gmt": "2025-03-27T20:21:11",
+					"password": "",
+					"slug": "new-slug",
+					"status": "publish",
+					"type": "page",
+					"link": "https://myblog.com/new-slug/",
+					"title": {
+						"raw": "New Title",
+						"rendered": "New Title"
+					},
+					"content": {
+						"raw": "Updated Content",
+						"rendered": "<p>Updated Content</p>\n",
+						"protected": false,
+						"block_version": 0
+					},
+					"excerpt": {
+						"raw": "",
+						"rendered": "<p>Updated Content</p>\n",
+						"protected": false
+					},
+					"author": 1,
+					"featured_media": 0,
+					"parent": 0,
+					"menu_order": 0,
+					"comment_status": "closed",
+					"ping_status": "open",
+					"template": "",
+					"meta": {
+						"footnotes": ""
+					},
+					"permalink_template": "https://myblog.com/%pagename%/",
+					"generated_slug": "new-title",
+					"class_list": ["post-2", "page", "type-page", "status-publish", "hentry"],
+					"_links": {
+						"self": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/pages/2",
+								"targetHints": {
+									"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+								}
+							}
+						],
+						"collection": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/pages"
+							}
+						],
+						"about": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/types/page"
+							}
+						],
+						"author": [
+							{
+								"embeddable": true,
+								"href": "https://myblog.com/wp-json/wp/v2/users/1"
+							}
+						],
+						"replies": [
+							{
+								"embeddable": true,
+								"href": "https://myblog.com/wp-json/wp/v2/comments?post=2"
+							}
+						],
+						"version-history": [
+							{
+								"count": 1,
+								"href": "https://myblog.com/wp-json/wp/v2/pages/2/revisions"
+							}
+						],
+						"predecessor-version": [
+							{
+								"id": 10,
+								"href": "https://myblog.com/wp-json/wp/v2/pages/2/revisions/10"
+							}
+						],
+						"wp:attachment": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/media?parent=2"
+							}
+						],
+						"wp:action-publish": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/pages/2"
+							}
+						],
+						"wp:action-unfiltered-html": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/pages/2"
+							}
+						],
+						"wp:action-assign-author": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/pages/2"
+							}
+						],
+						"curies": [
+							{
+								"name": "wp",
+								"href": "https://api.w.org/{rel}",
+								"templated": true
+							}
+						]
+					}
+				}
+			}
+		],
+		"Get Many Response (With Filters)": [
+			{
+				"json": {
+					"id": 2,
+					"date": "2025-03-27T18:05:01",
+					"date_gmt": "2025-03-27T18:05:01",
+					"guid": {
+						"rendered": "https://myblog.com/?page_id=2"
+					},
+					"modified": "2025-03-27T18:05:01",
+					"modified_gmt": "2025-03-27T18:05:01",
+					"slug": "sample-page",
+					"status": "publish",
+					"type": "page",
+					"link": "https://myblog.com/sample-page/",
+					"title": {
+						"rendered": "Sample Page"
+					},
+					"content": {
+						"rendered": "\n<p>This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this:</p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>Hi there! I&#8217;m a bike messenger by day, aspiring actor by night, and this is my website. I live in Los Angeles, have a great dog named Jack, and I like pi&#241;a coladas. (And gettin&#8217; caught in the rain.)</p></blockquote>\n\n\n\n<p>&#8230;or something like this:</p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>The XYZ Doohickey Company was founded in 1971, and has been providing quality doohickeys to the public ever since. Located in Gotham City, XYZ employs over 2,000 people and does all kinds of awesome things for the Gotham community.</p></blockquote>\n\n\n\n<p>As a new WordPress user, you should go to <a href=\"https://myblog.com/wp-admin/\">your dashboard</a> to delete this page and create new pages for your content. Have fun!</p>\n",
+						"protected": false
+					},
+					"excerpt": {
+						"rendered": "<p>This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this: Hi there! I&#8217;m a bike messenger [&hellip;]</p>\n",
+						"protected": false
+					},
+					"author": 1,
+					"featured_media": 0,
+					"parent": 0,
+					"menu_order": 0,
+					"comment_status": "closed",
+					"ping_status": "open",
+					"template": "",
+					"meta": {
+						"footnotes": ""
+					},
+					"class_list": ["post-2", "page", "type-page", "status-publish", "hentry"],
+					"_links": {
+						"self": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/pages/2",
+								"targetHints": {
+									"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+								}
+							}
+						],
+						"collection": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/pages"
+							}
+						],
+						"about": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/types/page"
+							}
+						],
+						"author": [
+							{
+								"embeddable": true,
+								"href": "https://myblog.com/wp-json/wp/v2/users/1"
+							}
+						],
+						"replies": [
+							{
+								"embeddable": true,
+								"href": "https://myblog.com/wp-json/wp/v2/comments?post=2"
+							}
+						],
+						"version-history": [
+							{
+								"count": 0,
+								"href": "https://myblog.com/wp-json/wp/v2/pages/2/revisions"
+							}
+						],
+						"wp:attachment": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/media?parent=2"
+							}
+						],
+						"curies": [
+							{
+								"name": "wp",
+								"href": "https://api.w.org/{rel}",
+								"templated": true
+							}
+						]
+					}
+				}
+			}
+		]
+	},
 	"connections": {
 		"When clicking ‘Execute workflow’": {
 			"main": [
@@ -199,11 +703,11 @@
 				]
 			]
 		},
-		"Page > Get": {
+		"Page > Update": {
 			"main": [
 				[
 					{
-						"node": "Get Response",
+						"node": "Update Response",
 						"type": "main",
 						"index": 0
 					}
@@ -221,11 +725,11 @@
 				]
 			]
 		},
-		"Page > Update": {
+		"Page > Get": {
 			"main": [
 				[
 					{
-						"node": "Update Response",
+						"node": "Get Response",
 						"type": "main",
 						"index": 0
 					}
@@ -244,502 +748,15 @@
 			]
 		}
 	},
-	"pinData": {
-		"Create Response": [
-			{
-				"id": 9,
-				"date": "2025-03-27T20:17:01",
-				"date_gmt": "2025-03-27T20:17:01",
-				"guid": {
-					"rendered": "https://myblog.com/?page_id=9",
-					"raw": "https://myblog.com/?page_id=9"
-				},
-				"modified": "2025-03-27T20:17:01",
-				"modified_gmt": "2025-03-27T20:17:01",
-				"password": "",
-				"slug": "",
-				"status": "draft",
-				"type": "page",
-				"link": "https://myblog.com/?page_id=9",
-				"title": {
-					"raw": "A new page",
-					"rendered": "A new page"
-				},
-				"content": {
-					"raw": "Some content",
-					"rendered": "<p>Some content</p>\n",
-					"protected": false,
-					"block_version": 0
-				},
-				"excerpt": {
-					"raw": "",
-					"rendered": "<p>Some content</p>\n",
-					"protected": false
-				},
-				"author": 1,
-				"featured_media": 0,
-				"parent": 0,
-				"menu_order": 1,
-				"comment_status": "closed",
-				"ping_status": "closed",
-				"template": "",
-				"meta": {
-					"footnotes": ""
-				},
-				"permalink_template": "https://myblog.com/%pagename%/",
-				"generated_slug": "a-new-page",
-				"class_list": ["post-9", "page", "type-page", "status-draft", "hentry"],
-				"_links": {
-					"self": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/pages/9",
-							"targetHints": {
-								"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
-							}
-						}
-					],
-					"collection": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/pages"
-						}
-					],
-					"about": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/types/page"
-						}
-					],
-					"author": [
-						{
-							"embeddable": true,
-							"href": "https://myblog.com/wp-json/wp/v2/users/1"
-						}
-					],
-					"replies": [
-						{
-							"embeddable": true,
-							"href": "https://myblog.com/wp-json/wp/v2/comments?post=9"
-						}
-					],
-					"version-history": [
-						{
-							"count": 0,
-							"href": "https://myblog.com/wp-json/wp/v2/pages/9/revisions"
-						}
-					],
-					"wp:attachment": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/media?parent=9"
-						}
-					],
-					"wp:action-publish": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/pages/9"
-						}
-					],
-					"wp:action-unfiltered-html": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/pages/9"
-						}
-					],
-					"wp:action-assign-author": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/pages/9"
-						}
-					],
-					"curies": [
-						{
-							"name": "wp",
-							"href": "https://api.w.org/{rel}",
-							"templated": true
-						}
-					]
-				}
-			}
-		],
-		"Get Response": [
-			{
-				"id": 2,
-				"date": "2025-03-27T18:05:01",
-				"date_gmt": "2025-03-27T18:05:01",
-				"guid": {
-					"rendered": "https://myblog.com/?page_id=2"
-				},
-				"modified": "2025-03-27T18:05:01",
-				"modified_gmt": "2025-03-27T18:05:01",
-				"slug": "sample-page",
-				"status": "publish",
-				"type": "page",
-				"link": "https://myblog.com/sample-page/",
-				"title": {
-					"rendered": "Sample Page"
-				},
-				"content": {
-					"rendered": "\n<p>This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this:</p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>Hi there! I&#8217;m a bike messenger by day, aspiring actor by night, and this is my website. I live in Los Angeles, have a great dog named Jack, and I like pi&#241;a coladas. (And gettin&#8217; caught in the rain.)</p></blockquote>\n\n\n\n<p>&#8230;or something like this:</p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>The XYZ Doohickey Company was founded in 1971, and has been providing quality doohickeys to the public ever since. Located in Gotham City, XYZ employs over 2,000 people and does all kinds of awesome things for the Gotham community.</p></blockquote>\n\n\n\n<p>As a new WordPress user, you should go to <a href=\"https://myblog.com/wp-admin/\">your dashboard</a> to delete this page and create new pages for your content. Have fun!</p>\n",
-					"protected": false
-				},
-				"excerpt": {
-					"rendered": "<p>This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this: Hi there! I&#8217;m a bike messenger [&hellip;]</p>\n",
-					"protected": false
-				},
-				"author": 1,
-				"featured_media": 0,
-				"parent": 0,
-				"menu_order": 0,
-				"comment_status": "closed",
-				"ping_status": "open",
-				"template": "",
-				"meta": {
-					"footnotes": ""
-				},
-				"class_list": ["post-2", "page", "type-page", "status-publish", "hentry"],
-				"_links": {
-					"self": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/pages/2",
-							"targetHints": {
-								"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
-							}
-						}
-					],
-					"collection": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/pages"
-						}
-					],
-					"about": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/types/page"
-						}
-					],
-					"author": [
-						{
-							"embeddable": true,
-							"href": "https://myblog.com/wp-json/wp/v2/users/1"
-						}
-					],
-					"replies": [
-						{
-							"embeddable": true,
-							"href": "https://myblog.com/wp-json/wp/v2/comments?post=2"
-						}
-					],
-					"version-history": [
-						{
-							"count": 0,
-							"href": "https://myblog.com/wp-json/wp/v2/pages/2/revisions"
-						}
-					],
-					"wp:attachment": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/media?parent=2"
-						}
-					],
-					"curies": [
-						{
-							"name": "wp",
-							"href": "https://api.w.org/{rel}",
-							"templated": true
-						}
-					]
-				}
-			}
-		],
-		"Get Many Response": [
-			{
-				"id": 2,
-				"date": "2025-03-27T18:05:01",
-				"date_gmt": "2025-03-27T18:05:01",
-				"guid": {
-					"rendered": "https://myblog.com/?page_id=2"
-				},
-				"modified": "2025-03-27T18:05:01",
-				"modified_gmt": "2025-03-27T18:05:01",
-				"slug": "sample-page",
-				"status": "publish",
-				"type": "page",
-				"link": "https://myblog.com/sample-page/",
-				"title": {
-					"rendered": "Sample Page"
-				},
-				"content": {
-					"rendered": "\n<p>This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this:</p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>Hi there! I&#8217;m a bike messenger by day, aspiring actor by night, and this is my website. I live in Los Angeles, have a great dog named Jack, and I like pi&#241;a coladas. (And gettin&#8217; caught in the rain.)</p></blockquote>\n\n\n\n<p>&#8230;or something like this:</p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>The XYZ Doohickey Company was founded in 1971, and has been providing quality doohickeys to the public ever since. Located in Gotham City, XYZ employs over 2,000 people and does all kinds of awesome things for the Gotham community.</p></blockquote>\n\n\n\n<p>As a new WordPress user, you should go to <a href=\"https://myblog.com/wp-admin/\">your dashboard</a> to delete this page and create new pages for your content. Have fun!</p>\n",
-					"protected": false
-				},
-				"excerpt": {
-					"rendered": "<p>This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this: Hi there! I&#8217;m a bike messenger [&hellip;]</p>\n",
-					"protected": false
-				},
-				"author": 1,
-				"featured_media": 0,
-				"parent": 0,
-				"menu_order": 0,
-				"comment_status": "closed",
-				"ping_status": "open",
-				"template": "",
-				"meta": {
-					"footnotes": ""
-				},
-				"class_list": ["post-2", "page", "type-page", "status-publish", "hentry"],
-				"_links": {
-					"self": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/pages/2",
-							"targetHints": {
-								"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
-							}
-						}
-					],
-					"collection": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/pages"
-						}
-					],
-					"about": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/types/page"
-						}
-					],
-					"author": [
-						{
-							"embeddable": true,
-							"href": "https://myblog.com/wp-json/wp/v2/users/1"
-						}
-					],
-					"replies": [
-						{
-							"embeddable": true,
-							"href": "https://myblog.com/wp-json/wp/v2/comments?post=2"
-						}
-					],
-					"version-history": [
-						{
-							"count": 0,
-							"href": "https://myblog.com/wp-json/wp/v2/pages/2/revisions"
-						}
-					],
-					"wp:attachment": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/media?parent=2"
-						}
-					],
-					"curies": [
-						{
-							"name": "wp",
-							"href": "https://api.w.org/{rel}",
-							"templated": true
-						}
-					]
-				}
-			}
-		],
-		"Update Response": [
-			{
-				"id": 2,
-				"date": "2025-03-27T18:05:01",
-				"date_gmt": "2025-03-27T18:05:01",
-				"guid": {
-					"rendered": "https://myblog.com/?page_id=2",
-					"raw": "https://myblog.com/?page_id=2"
-				},
-				"modified": "2025-03-27T20:21:11",
-				"modified_gmt": "2025-03-27T20:21:11",
-				"password": "",
-				"slug": "new-slug",
-				"status": "publish",
-				"type": "page",
-				"link": "https://myblog.com/new-slug/",
-				"title": {
-					"raw": "New Title",
-					"rendered": "New Title"
-				},
-				"content": {
-					"raw": "Updated Content",
-					"rendered": "<p>Updated Content</p>\n",
-					"protected": false,
-					"block_version": 0
-				},
-				"excerpt": {
-					"raw": "",
-					"rendered": "<p>Updated Content</p>\n",
-					"protected": false
-				},
-				"author": 1,
-				"featured_media": 0,
-				"parent": 0,
-				"menu_order": 0,
-				"comment_status": "closed",
-				"ping_status": "open",
-				"template": "",
-				"meta": {
-					"footnotes": ""
-				},
-				"permalink_template": "https://myblog.com/%pagename%/",
-				"generated_slug": "new-title",
-				"class_list": ["post-2", "page", "type-page", "status-publish", "hentry"],
-				"_links": {
-					"self": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/pages/2",
-							"targetHints": {
-								"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
-							}
-						}
-					],
-					"collection": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/pages"
-						}
-					],
-					"about": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/types/page"
-						}
-					],
-					"author": [
-						{
-							"embeddable": true,
-							"href": "https://myblog.com/wp-json/wp/v2/users/1"
-						}
-					],
-					"replies": [
-						{
-							"embeddable": true,
-							"href": "https://myblog.com/wp-json/wp/v2/comments?post=2"
-						}
-					],
-					"version-history": [
-						{
-							"count": 1,
-							"href": "https://myblog.com/wp-json/wp/v2/pages/2/revisions"
-						}
-					],
-					"predecessor-version": [
-						{
-							"id": 10,
-							"href": "https://myblog.com/wp-json/wp/v2/pages/2/revisions/10"
-						}
-					],
-					"wp:attachment": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/media?parent=2"
-						}
-					],
-					"wp:action-publish": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/pages/2"
-						}
-					],
-					"wp:action-unfiltered-html": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/pages/2"
-						}
-					],
-					"wp:action-assign-author": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/pages/2"
-						}
-					],
-					"curies": [
-						{
-							"name": "wp",
-							"href": "https://api.w.org/{rel}",
-							"templated": true
-						}
-					]
-				}
-			}
-		],
-		"Get Many Response (With Filters)": [
-			{
-				"id": 2,
-				"date": "2025-03-27T18:05:01",
-				"date_gmt": "2025-03-27T18:05:01",
-				"guid": {
-					"rendered": "https://myblog.com/?page_id=2"
-				},
-				"modified": "2025-03-27T18:05:01",
-				"modified_gmt": "2025-03-27T18:05:01",
-				"slug": "sample-page",
-				"status": "publish",
-				"type": "page",
-				"link": "https://myblog.com/sample-page/",
-				"title": {
-					"rendered": "Sample Page"
-				},
-				"content": {
-					"rendered": "\n<p>This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this:</p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>Hi there! I&#8217;m a bike messenger by day, aspiring actor by night, and this is my website. I live in Los Angeles, have a great dog named Jack, and I like pi&#241;a coladas. (And gettin&#8217; caught in the rain.)</p></blockquote>\n\n\n\n<p>&#8230;or something like this:</p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>The XYZ Doohickey Company was founded in 1971, and has been providing quality doohickeys to the public ever since. Located in Gotham City, XYZ employs over 2,000 people and does all kinds of awesome things for the Gotham community.</p></blockquote>\n\n\n\n<p>As a new WordPress user, you should go to <a href=\"https://myblog.com/wp-admin/\">your dashboard</a> to delete this page and create new pages for your content. Have fun!</p>\n",
-					"protected": false
-				},
-				"excerpt": {
-					"rendered": "<p>This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this: Hi there! I&#8217;m a bike messenger [&hellip;]</p>\n",
-					"protected": false
-				},
-				"author": 1,
-				"featured_media": 0,
-				"parent": 0,
-				"menu_order": 0,
-				"comment_status": "closed",
-				"ping_status": "open",
-				"template": "",
-				"meta": {
-					"footnotes": ""
-				},
-				"class_list": ["post-2", "page", "type-page", "status-publish", "hentry"],
-				"_links": {
-					"self": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/pages/2",
-							"targetHints": {
-								"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
-							}
-						}
-					],
-					"collection": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/pages"
-						}
-					],
-					"about": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/types/page"
-						}
-					],
-					"author": [
-						{
-							"embeddable": true,
-							"href": "https://myblog.com/wp-json/wp/v2/users/1"
-						}
-					],
-					"replies": [
-						{
-							"embeddable": true,
-							"href": "https://myblog.com/wp-json/wp/v2/comments?post=2"
-						}
-					],
-					"version-history": [
-						{
-							"count": 0,
-							"href": "https://myblog.com/wp-json/wp/v2/pages/2/revisions"
-						}
-					],
-					"wp:attachment": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/media?parent=2"
-						}
-					],
-					"curies": [
-						{
-							"name": "wp",
-							"href": "https://api.w.org/{rel}",
-							"templated": true
-						}
-					]
-				}
-			}
-		]
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
 	},
+	"versionId": "b76bf6d6-3a62-4e01-938a-f63e55ef236b",
 	"meta": {
 		"templateCredsSetupCompleted": true,
 		"instanceId": "eeda9e3069aca300d1dfceeb64beb5b53d715db44a50461bbc5cb0cf6daa01e3"
-	}
+	},
+	"id": "W7kWl5BZvsrmZeVw",
+	"tags": []
 }

--- a/packages/nodes-base/nodes/Wordpress/__tests__/workflow/post/post.test.ts
+++ b/packages/nodes-base/nodes/Wordpress/__tests__/workflow/post/post.test.ts
@@ -10,6 +10,10 @@ describe('Wordpress > Post Workflows', () => {
 		mock.get('/wp-json/wp/v2/posts/1').reply(200, postGet);
 		mock.get('/wp-json/wp/v2/posts').query({ per_page: 10, page: 1 }).reply(200, postGetMany);
 		mock
+			.get('/wp-json/wp/v2/posts')
+			.query({ per_page: 10, page: 1, before: '2026-01-01T00:00:00' })
+			.reply(200, postGetMany);
+		mock
 			.post('/wp-json/wp/v2/posts', {
 				title: 'New Post',
 				author: 1,

--- a/packages/nodes-base/nodes/Wordpress/__tests__/workflow/post/post.workflow.json
+++ b/packages/nodes-base/nodes/Wordpress/__tests__/workflow/post/post.workflow.json
@@ -5,16 +5,16 @@
 			"parameters": {},
 			"type": "n8n-nodes-base.manualTrigger",
 			"typeVersion": 1,
-			"position": [128, 208],
-			"id": "f66ad9bf-b1d4-4ba7-b3e2-e11abad0d84f",
+			"position": [-32, 688],
+			"id": "d9528df2-82cb-47fe-8176-238283d1827e",
 			"name": "When clicking ‘Execute workflow’"
 		},
 		{
 			"parameters": {},
 			"type": "n8n-nodes-base.noOp",
 			"typeVersion": 1,
-			"position": [576, 208],
-			"id": "4b61be50-9737-456c-8256-c6697c91ebf4",
+			"position": [416, 688],
+			"id": "1f61c57c-8bf3-44bd-86a7-651906c1b06d",
 			"name": "Update Response"
 		},
 		{
@@ -30,8 +30,8 @@
 			},
 			"type": "n8n-nodes-base.wordpress",
 			"typeVersion": 1,
-			"position": [352, 208],
-			"id": "855801e6-c026-499e-b68b-ecc3ee84e8da",
+			"position": [192, 688],
+			"id": "eb2e2d7a-48e9-49fb-a808-e2546ce14a2b",
 			"name": "Post > Update",
 			"credentials": {
 				"wordpressApi": {
@@ -48,8 +48,8 @@
 			},
 			"type": "n8n-nodes-base.wordpress",
 			"typeVersion": 1,
-			"position": [352, -176],
-			"id": "4b012296-0a91-42bb-bd40-4b2d739d8563",
+			"position": [192, 304],
+			"id": "72a59773-a15a-4e58-8bed-be1108449550",
 			"name": "Post > Get Many",
 			"credentials": {
 				"wordpressApi": {
@@ -62,8 +62,8 @@
 			"parameters": {},
 			"type": "n8n-nodes-base.noOp",
 			"typeVersion": 1,
-			"position": [576, -176],
-			"id": "79140504-162e-4623-b2f1-7502f7e7ce44",
+			"position": [416, 304],
+			"id": "11b128da-9b78-4f02-93a7-c3db1bc3363a",
 			"name": "Get Many"
 		},
 		{
@@ -74,8 +74,8 @@
 			},
 			"type": "n8n-nodes-base.wordpress",
 			"typeVersion": 1,
-			"position": [352, 400],
-			"id": "824dd2e5-70ad-4b66-b0f8-23de739bf998",
+			"position": [192, 880],
+			"id": "3ff21988-4d92-4c87-831f-4e684248c761",
 			"name": "Post > Get",
 			"credentials": {
 				"wordpressApi": {
@@ -88,8 +88,8 @@
 			"parameters": {},
 			"type": "n8n-nodes-base.noOp",
 			"typeVersion": 1,
-			"position": [576, 400],
-			"id": "604b1b7c-d69b-4032-bc49-3c70aabab8ad",
+			"position": [416, 880],
+			"id": "dc730fc9-a28d-4eb4-aa8d-a1b85ff45ef9",
 			"name": "Get Response"
 		},
 		{
@@ -110,8 +110,8 @@
 			},
 			"type": "n8n-nodes-base.wordpress",
 			"typeVersion": 1,
-			"position": [352, 592],
-			"id": "d6765ba2-85e5-4f00-92e6-7d51d61415d1",
+			"position": [192, 1072],
+			"id": "f2e1c5f0-fbfa-419e-ba7a-ef60c8853304",
 			"name": "Post > Create",
 			"credentials": {
 				"wordpressApi": {
@@ -124,17 +124,9 @@
 			"parameters": {},
 			"type": "n8n-nodes-base.noOp",
 			"typeVersion": 1,
-			"position": [576, 592],
-			"id": "e9d92bb0-4bd5-4461-a78b-2184bb6a2e20",
+			"position": [416, 1072],
+			"id": "c386bee8-4bb9-4a1e-b4bc-4f8689722729",
 			"name": "Create Response"
-		},
-		{
-			"parameters": {},
-			"type": "n8n-nodes-base.noOp",
-			"typeVersion": 1,
-			"position": [576, 16],
-			"id": "f9bbda89-7fc6-482d-af95-81d4092ce24a",
-			"name": "Get Many (With Filters)"
 		},
 		{
 			"parameters": {
@@ -146,8 +138,8 @@
 			},
 			"type": "n8n-nodes-base.wordpress",
 			"typeVersion": 1,
-			"position": [352, 16],
-			"id": "1324d218-2c0b-442b-bcd1-5ec11b803c28",
+			"position": [192, 496],
+			"id": "cc61993a-ac13-42d7-aace-c501da128361",
 			"name": "Post > Get Many (With Filters)",
 			"credentials": {
 				"wordpressApi": {
@@ -155,8 +147,698 @@
 					"name": "Wordpress (localhost)"
 				}
 			}
+		},
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [416, 496],
+			"id": "770a6cf9-93ca-4b56-a23b-b1d9904de993",
+			"name": "Get Many (With Filters)"
 		}
 	],
+	"pinData": {
+		"Update Response": [
+			{
+				"json": {
+					"id": 1,
+					"date": "2025-03-27T18:05:01",
+					"date_gmt": "2025-03-27T18:05:01",
+					"guid": {
+						"rendered": "https://myblog.com/?p=1",
+						"raw": "https://myblog.com/?p=1"
+					},
+					"modified": "2025-03-27T18:22:36",
+					"modified_gmt": "2025-03-27T18:22:36",
+					"password": "",
+					"slug": "hello-world",
+					"status": "publish",
+					"type": "post",
+					"link": "https://myblog.com/2025/03/27/hello-world/",
+					"title": {
+						"raw": "New Title",
+						"rendered": "New Title"
+					},
+					"content": {
+						"raw": "Some new content",
+						"rendered": "<p>Some new content</p>\n",
+						"protected": false,
+						"block_version": 0
+					},
+					"excerpt": {
+						"raw": "",
+						"rendered": "<p>Some new content</p>\n",
+						"protected": false
+					},
+					"author": 1,
+					"featured_media": 0,
+					"comment_status": "open",
+					"ping_status": "open",
+					"sticky": false,
+					"template": "",
+					"format": "standard",
+					"meta": {
+						"footnotes": ""
+					},
+					"categories": [1],
+					"tags": [],
+					"permalink_template": "https://myblog.com/2025/03/27/%postname%/",
+					"generated_slug": "new-title",
+					"class_list": [
+						"post-1",
+						"post",
+						"type-post",
+						"status-publish",
+						"format-standard",
+						"hentry",
+						"category-uncategorised"
+					],
+					"_links": {
+						"self": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/posts/1",
+								"targetHints": {
+									"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+								}
+							}
+						],
+						"collection": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/posts"
+							}
+						],
+						"about": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/types/post"
+							}
+						],
+						"author": [
+							{
+								"embeddable": true,
+								"href": "https://myblog.com/wp-json/wp/v2/users/1"
+							}
+						],
+						"replies": [
+							{
+								"embeddable": true,
+								"href": "https://myblog.com/wp-json/wp/v2/comments?post=1"
+							}
+						],
+						"version-history": [
+							{
+								"count": 1,
+								"href": "https://myblog.com/wp-json/wp/v2/posts/1/revisions"
+							}
+						],
+						"predecessor-version": [
+							{
+								"id": 6,
+								"href": "https://myblog.com/wp-json/wp/v2/posts/1/revisions/6"
+							}
+						],
+						"wp:attachment": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/media?parent=1"
+							}
+						],
+						"wp:term": [
+							{
+								"taxonomy": "category",
+								"embeddable": true,
+								"href": "https://myblog.com/wp-json/wp/v2/categories?post=1"
+							},
+							{
+								"taxonomy": "post_tag",
+								"embeddable": true,
+								"href": "https://myblog.com/wp-json/wp/v2/tags?post=1"
+							}
+						],
+						"wp:action-publish": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/posts/1"
+							}
+						],
+						"wp:action-unfiltered-html": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/posts/1"
+							}
+						],
+						"wp:action-sticky": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/posts/1"
+							}
+						],
+						"wp:action-assign-author": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/posts/1"
+							}
+						],
+						"wp:action-create-categories": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/posts/1"
+							}
+						],
+						"wp:action-assign-categories": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/posts/1"
+							}
+						],
+						"wp:action-create-tags": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/posts/1"
+							}
+						],
+						"wp:action-assign-tags": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/posts/1"
+							}
+						],
+						"curies": [
+							{
+								"name": "wp",
+								"href": "https://api.w.org/{rel}",
+								"templated": true
+							}
+						]
+					}
+				}
+			}
+		],
+		"Get Many": [
+			{
+				"json": {
+					"id": 1,
+					"date": "2025-03-27T18:05:01",
+					"date_gmt": "2025-03-27T18:05:01",
+					"guid": {
+						"rendered": "https://myblog.com/?p=1"
+					},
+					"modified": "2025-03-27T18:22:36",
+					"modified_gmt": "2025-03-27T18:22:36",
+					"slug": "hello-world",
+					"status": "publish",
+					"type": "post",
+					"link": "https://myblog.com/2025/03/27/hello-world/",
+					"title": {
+						"rendered": "Hello world!"
+					},
+					"content": {
+						"rendered": "\n<p>Welcome to WordPress. This is your first post. Edit or delete it, then start writing!</p>\n",
+						"protected": false
+					},
+					"excerpt": {
+						"rendered": "<p>Welcome to WordPress. This is your first post. Edit or delete it, then start writing!</p>\n",
+						"protected": false
+					},
+					"author": 1,
+					"featured_media": 0,
+					"comment_status": "open",
+					"ping_status": "open",
+					"sticky": false,
+					"template": "",
+					"format": "standard",
+					"meta": {
+						"footnotes": ""
+					},
+					"categories": [1],
+					"tags": [],
+					"class_list": [
+						"post-1",
+						"post",
+						"type-post",
+						"status-publish",
+						"format-standard",
+						"hentry",
+						"category-uncategorised"
+					],
+					"_links": {
+						"self": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/posts/1",
+								"targetHints": {
+									"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+								}
+							}
+						],
+						"collection": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/posts"
+							}
+						],
+						"about": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/types/post"
+							}
+						],
+						"author": [
+							{
+								"embeddable": true,
+								"href": "https://myblog.com/wp-json/wp/v2/users/1"
+							}
+						],
+						"replies": [
+							{
+								"embeddable": true,
+								"href": "https://myblog.com/wp-json/wp/v2/comments?post=1"
+							}
+						],
+						"version-history": [
+							{
+								"count": 1,
+								"href": "https://myblog.com/wp-json/wp/v2/posts/1/revisions"
+							}
+						],
+						"predecessor-version": [
+							{
+								"id": 6,
+								"href": "https://myblog.com/wp-json/wp/v2/posts/1/revisions/6"
+							}
+						],
+						"wp:attachment": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/media?parent=1"
+							}
+						],
+						"wp:term": [
+							{
+								"taxonomy": "category",
+								"embeddable": true,
+								"href": "https://myblog.com/wp-json/wp/v2/categories?post=1"
+							},
+							{
+								"taxonomy": "post_tag",
+								"embeddable": true,
+								"href": "https://myblog.com/wp-json/wp/v2/tags?post=1"
+							}
+						],
+						"curies": [
+							{
+								"name": "wp",
+								"href": "https://api.w.org/{rel}",
+								"templated": true
+							}
+						]
+					}
+				}
+			}
+		],
+		"Get Response": [
+			{
+				"json": {
+					"id": 1,
+					"date": "2025-03-27T18:05:01",
+					"date_gmt": "2025-03-27T18:05:01",
+					"guid": {
+						"rendered": "https://myblog.com/?p=1"
+					},
+					"modified": "2025-03-27T18:22:36",
+					"modified_gmt": "2025-03-27T18:22:36",
+					"slug": "hello-world",
+					"status": "publish",
+					"type": "post",
+					"link": "https://myblog.com/2025/03/27/hello-world/",
+					"title": {
+						"rendered": "New Title"
+					},
+					"content": {
+						"rendered": "<p>Some new content</p>\n",
+						"protected": false
+					},
+					"excerpt": {
+						"rendered": "<p>Some new content</p>\n",
+						"protected": false
+					},
+					"author": 1,
+					"featured_media": 0,
+					"comment_status": "open",
+					"ping_status": "open",
+					"sticky": false,
+					"template": "",
+					"format": "standard",
+					"meta": {
+						"footnotes": ""
+					},
+					"categories": [1],
+					"tags": [],
+					"class_list": [
+						"post-1",
+						"post",
+						"type-post",
+						"status-publish",
+						"format-standard",
+						"hentry",
+						"category-uncategorised"
+					],
+					"_links": {
+						"self": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/posts/1",
+								"targetHints": {
+									"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+								}
+							}
+						],
+						"collection": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/posts"
+							}
+						],
+						"about": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/types/post"
+							}
+						],
+						"author": [
+							{
+								"embeddable": true,
+								"href": "https://myblog.com/wp-json/wp/v2/users/1"
+							}
+						],
+						"replies": [
+							{
+								"embeddable": true,
+								"href": "https://myblog.com/wp-json/wp/v2/comments?post=1"
+							}
+						],
+						"version-history": [
+							{
+								"count": 1,
+								"href": "https://myblog.com/wp-json/wp/v2/posts/1/revisions"
+							}
+						],
+						"predecessor-version": [
+							{
+								"id": 6,
+								"href": "https://myblog.com/wp-json/wp/v2/posts/1/revisions/6"
+							}
+						],
+						"wp:attachment": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/media?parent=1"
+							}
+						],
+						"wp:term": [
+							{
+								"taxonomy": "category",
+								"embeddable": true,
+								"href": "https://myblog.com/wp-json/wp/v2/categories?post=1"
+							},
+							{
+								"taxonomy": "post_tag",
+								"embeddable": true,
+								"href": "https://myblog.com/wp-json/wp/v2/tags?post=1"
+							}
+						],
+						"curies": [
+							{
+								"name": "wp",
+								"href": "https://api.w.org/{rel}",
+								"templated": true
+							}
+						]
+					}
+				}
+			}
+		],
+		"Create Response": [
+			{
+				"json": {
+					"id": 7,
+					"date": "2025-03-27T18:30:04",
+					"date_gmt": "2025-03-27T18:30:04",
+					"guid": {
+						"rendered": "https://myblog.com/2025/03/27/new-post/",
+						"raw": "https://myblog.com/2025/03/27/new-post/"
+					},
+					"modified": "2025-03-27T18:30:04",
+					"modified_gmt": "2025-03-27T18:30:04",
+					"password": "",
+					"slug": "new-post",
+					"status": "publish",
+					"type": "post",
+					"link": "https://myblog.com/2025/03/27/new-post/",
+					"title": {
+						"raw": "New Post",
+						"rendered": "New Post"
+					},
+					"content": {
+						"raw": "This is my content",
+						"rendered": "<p>This is my content</p>\n",
+						"protected": false,
+						"block_version": 0
+					},
+					"excerpt": {
+						"raw": "",
+						"rendered": "<p>This is my content</p>\n",
+						"protected": false
+					},
+					"author": 1,
+					"featured_media": 0,
+					"comment_status": "closed",
+					"ping_status": "closed",
+					"sticky": true,
+					"template": "",
+					"format": "standard",
+					"meta": {
+						"footnotes": ""
+					},
+					"categories": [1],
+					"tags": [],
+					"permalink_template": "https://myblog.com/2025/03/27/%postname%/",
+					"generated_slug": "new-post",
+					"class_list": [
+						"post-7",
+						"post",
+						"type-post",
+						"status-publish",
+						"format-standard",
+						"hentry",
+						"category-uncategorised"
+					],
+					"_links": {
+						"self": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/posts/7",
+								"targetHints": {
+									"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+								}
+							}
+						],
+						"collection": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/posts"
+							}
+						],
+						"about": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/types/post"
+							}
+						],
+						"author": [
+							{
+								"embeddable": true,
+								"href": "https://myblog.com/wp-json/wp/v2/users/1"
+							}
+						],
+						"replies": [
+							{
+								"embeddable": true,
+								"href": "https://myblog.com/wp-json/wp/v2/comments?post=7"
+							}
+						],
+						"version-history": [
+							{
+								"count": 0,
+								"href": "https://myblog.com/wp-json/wp/v2/posts/7/revisions"
+							}
+						],
+						"wp:attachment": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/media?parent=7"
+							}
+						],
+						"wp:term": [
+							{
+								"taxonomy": "category",
+								"embeddable": true,
+								"href": "https://myblog.com/wp-json/wp/v2/categories?post=7"
+							},
+							{
+								"taxonomy": "post_tag",
+								"embeddable": true,
+								"href": "https://myblog.com/wp-json/wp/v2/tags?post=7"
+							}
+						],
+						"wp:action-publish": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/posts/7"
+							}
+						],
+						"wp:action-unfiltered-html": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/posts/7"
+							}
+						],
+						"wp:action-sticky": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/posts/7"
+							}
+						],
+						"wp:action-assign-author": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/posts/7"
+							}
+						],
+						"wp:action-create-categories": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/posts/7"
+							}
+						],
+						"wp:action-assign-categories": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/posts/7"
+							}
+						],
+						"wp:action-create-tags": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/posts/7"
+							}
+						],
+						"wp:action-assign-tags": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/posts/7"
+							}
+						],
+						"curies": [
+							{
+								"name": "wp",
+								"href": "https://api.w.org/{rel}",
+								"templated": true
+							}
+						]
+					}
+				}
+			}
+		],
+		"Get Many (With Filters)": [
+			{
+				"json": {
+					"id": 1,
+					"date": "2025-03-27T18:05:01",
+					"date_gmt": "2025-03-27T18:05:01",
+					"guid": {
+						"rendered": "https://myblog.com/?p=1"
+					},
+					"modified": "2025-03-27T18:22:36",
+					"modified_gmt": "2025-03-27T18:22:36",
+					"slug": "hello-world",
+					"status": "publish",
+					"type": "post",
+					"link": "https://myblog.com/2025/03/27/hello-world/",
+					"title": {
+						"rendered": "Hello world!"
+					},
+					"content": {
+						"rendered": "\n<p>Welcome to WordPress. This is your first post. Edit or delete it, then start writing!</p>\n",
+						"protected": false
+					},
+					"excerpt": {
+						"rendered": "<p>Welcome to WordPress. This is your first post. Edit or delete it, then start writing!</p>\n",
+						"protected": false
+					},
+					"author": 1,
+					"featured_media": 0,
+					"comment_status": "open",
+					"ping_status": "open",
+					"sticky": false,
+					"template": "",
+					"format": "standard",
+					"meta": {
+						"footnotes": ""
+					},
+					"categories": [1],
+					"tags": [],
+					"class_list": [
+						"post-1",
+						"post",
+						"type-post",
+						"status-publish",
+						"format-standard",
+						"hentry",
+						"category-uncategorised"
+					],
+					"_links": {
+						"self": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/posts/1",
+								"targetHints": {
+									"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+								}
+							}
+						],
+						"collection": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/posts"
+							}
+						],
+						"about": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/types/post"
+							}
+						],
+						"author": [
+							{
+								"embeddable": true,
+								"href": "https://myblog.com/wp-json/wp/v2/users/1"
+							}
+						],
+						"replies": [
+							{
+								"embeddable": true,
+								"href": "https://myblog.com/wp-json/wp/v2/comments?post=1"
+							}
+						],
+						"version-history": [
+							{
+								"count": 1,
+								"href": "https://myblog.com/wp-json/wp/v2/posts/1/revisions"
+							}
+						],
+						"predecessor-version": [
+							{
+								"id": 6,
+								"href": "https://myblog.com/wp-json/wp/v2/posts/1/revisions/6"
+							}
+						],
+						"wp:attachment": [
+							{
+								"href": "https://myblog.com/wp-json/wp/v2/media?parent=1"
+							}
+						],
+						"wp:term": [
+							{
+								"taxonomy": "category",
+								"embeddable": true,
+								"href": "https://myblog.com/wp-json/wp/v2/categories?post=1"
+							},
+							{
+								"taxonomy": "post_tag",
+								"embeddable": true,
+								"href": "https://myblog.com/wp-json/wp/v2/tags?post=1"
+							}
+						],
+						"curies": [
+							{
+								"name": "wp",
+								"href": "https://api.w.org/{rel}",
+								"templated": true
+							}
+						]
+					}
+				}
+			}
+		]
+	},
 	"connections": {
 		"When clicking ‘Execute workflow’": {
 			"main": [
@@ -245,680 +927,15 @@
 			]
 		}
 	},
-	"pinData": {
-		"Update Response": [
-			{
-				"id": 1,
-				"date": "2025-03-27T18:05:01",
-				"date_gmt": "2025-03-27T18:05:01",
-				"guid": {
-					"rendered": "https://myblog.com/?p=1",
-					"raw": "https://myblog.com/?p=1"
-				},
-				"modified": "2025-03-27T18:22:36",
-				"modified_gmt": "2025-03-27T18:22:36",
-				"password": "",
-				"slug": "hello-world",
-				"status": "publish",
-				"type": "post",
-				"link": "https://myblog.com/2025/03/27/hello-world/",
-				"title": {
-					"raw": "New Title",
-					"rendered": "New Title"
-				},
-				"content": {
-					"raw": "Some new content",
-					"rendered": "<p>Some new content</p>\n",
-					"protected": false,
-					"block_version": 0
-				},
-				"excerpt": {
-					"raw": "",
-					"rendered": "<p>Some new content</p>\n",
-					"protected": false
-				},
-				"author": 1,
-				"featured_media": 0,
-				"comment_status": "open",
-				"ping_status": "open",
-				"sticky": false,
-				"template": "",
-				"format": "standard",
-				"meta": {
-					"footnotes": ""
-				},
-				"categories": [1],
-				"tags": [],
-				"permalink_template": "https://myblog.com/2025/03/27/%postname%/",
-				"generated_slug": "new-title",
-				"class_list": [
-					"post-1",
-					"post",
-					"type-post",
-					"status-publish",
-					"format-standard",
-					"hentry",
-					"category-uncategorised"
-				],
-				"_links": {
-					"self": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/posts/1",
-							"targetHints": {
-								"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
-							}
-						}
-					],
-					"collection": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/posts"
-						}
-					],
-					"about": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/types/post"
-						}
-					],
-					"author": [
-						{
-							"embeddable": true,
-							"href": "https://myblog.com/wp-json/wp/v2/users/1"
-						}
-					],
-					"replies": [
-						{
-							"embeddable": true,
-							"href": "https://myblog.com/wp-json/wp/v2/comments?post=1"
-						}
-					],
-					"version-history": [
-						{
-							"count": 1,
-							"href": "https://myblog.com/wp-json/wp/v2/posts/1/revisions"
-						}
-					],
-					"predecessor-version": [
-						{
-							"id": 6,
-							"href": "https://myblog.com/wp-json/wp/v2/posts/1/revisions/6"
-						}
-					],
-					"wp:attachment": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/media?parent=1"
-						}
-					],
-					"wp:term": [
-						{
-							"taxonomy": "category",
-							"embeddable": true,
-							"href": "https://myblog.com/wp-json/wp/v2/categories?post=1"
-						},
-						{
-							"taxonomy": "post_tag",
-							"embeddable": true,
-							"href": "https://myblog.com/wp-json/wp/v2/tags?post=1"
-						}
-					],
-					"wp:action-publish": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/posts/1"
-						}
-					],
-					"wp:action-unfiltered-html": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/posts/1"
-						}
-					],
-					"wp:action-sticky": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/posts/1"
-						}
-					],
-					"wp:action-assign-author": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/posts/1"
-						}
-					],
-					"wp:action-create-categories": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/posts/1"
-						}
-					],
-					"wp:action-assign-categories": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/posts/1"
-						}
-					],
-					"wp:action-create-tags": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/posts/1"
-						}
-					],
-					"wp:action-assign-tags": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/posts/1"
-						}
-					],
-					"curies": [
-						{
-							"name": "wp",
-							"href": "https://api.w.org/{rel}",
-							"templated": true
-						}
-					]
-				}
-			}
-		],
-		"Get Many": [
-			{
-				"id": 1,
-				"date": "2025-03-27T18:05:01",
-				"date_gmt": "2025-03-27T18:05:01",
-				"guid": {
-					"rendered": "https://myblog.com/?p=1"
-				},
-				"modified": "2025-03-27T18:22:36",
-				"modified_gmt": "2025-03-27T18:22:36",
-				"slug": "hello-world",
-				"status": "publish",
-				"type": "post",
-				"link": "https://myblog.com/2025/03/27/hello-world/",
-				"title": {
-					"rendered": "Hello world!"
-				},
-				"content": {
-					"rendered": "\n<p>Welcome to WordPress. This is your first post. Edit or delete it, then start writing!</p>\n",
-					"protected": false
-				},
-				"excerpt": {
-					"rendered": "<p>Welcome to WordPress. This is your first post. Edit or delete it, then start writing!</p>\n",
-					"protected": false
-				},
-				"author": 1,
-				"featured_media": 0,
-				"comment_status": "open",
-				"ping_status": "open",
-				"sticky": false,
-				"template": "",
-				"format": "standard",
-				"meta": {
-					"footnotes": ""
-				},
-				"categories": [1],
-				"tags": [],
-				"class_list": [
-					"post-1",
-					"post",
-					"type-post",
-					"status-publish",
-					"format-standard",
-					"hentry",
-					"category-uncategorised"
-				],
-				"_links": {
-					"self": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/posts/1",
-							"targetHints": {
-								"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
-							}
-						}
-					],
-					"collection": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/posts"
-						}
-					],
-					"about": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/types/post"
-						}
-					],
-					"author": [
-						{
-							"embeddable": true,
-							"href": "https://myblog.com/wp-json/wp/v2/users/1"
-						}
-					],
-					"replies": [
-						{
-							"embeddable": true,
-							"href": "https://myblog.com/wp-json/wp/v2/comments?post=1"
-						}
-					],
-					"version-history": [
-						{
-							"count": 1,
-							"href": "https://myblog.com/wp-json/wp/v2/posts/1/revisions"
-						}
-					],
-					"predecessor-version": [
-						{
-							"id": 6,
-							"href": "https://myblog.com/wp-json/wp/v2/posts/1/revisions/6"
-						}
-					],
-					"wp:attachment": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/media?parent=1"
-						}
-					],
-					"wp:term": [
-						{
-							"taxonomy": "category",
-							"embeddable": true,
-							"href": "https://myblog.com/wp-json/wp/v2/categories?post=1"
-						},
-						{
-							"taxonomy": "post_tag",
-							"embeddable": true,
-							"href": "https://myblog.com/wp-json/wp/v2/tags?post=1"
-						}
-					],
-					"curies": [
-						{
-							"name": "wp",
-							"href": "https://api.w.org/{rel}",
-							"templated": true
-						}
-					]
-				}
-			}
-		],
-		"Get Response": [
-			{
-				"id": 1,
-				"date": "2025-03-27T18:05:01",
-				"date_gmt": "2025-03-27T18:05:01",
-				"guid": {
-					"rendered": "https://myblog.com/?p=1"
-				},
-				"modified": "2025-03-27T18:22:36",
-				"modified_gmt": "2025-03-27T18:22:36",
-				"slug": "hello-world",
-				"status": "publish",
-				"type": "post",
-				"link": "https://myblog.com/2025/03/27/hello-world/",
-				"title": {
-					"rendered": "New Title"
-				},
-				"content": {
-					"rendered": "<p>Some new content</p>\n",
-					"protected": false
-				},
-				"excerpt": {
-					"rendered": "<p>Some new content</p>\n",
-					"protected": false
-				},
-				"author": 1,
-				"featured_media": 0,
-				"comment_status": "open",
-				"ping_status": "open",
-				"sticky": false,
-				"template": "",
-				"format": "standard",
-				"meta": {
-					"footnotes": ""
-				},
-				"categories": [1],
-				"tags": [],
-				"class_list": [
-					"post-1",
-					"post",
-					"type-post",
-					"status-publish",
-					"format-standard",
-					"hentry",
-					"category-uncategorised"
-				],
-				"_links": {
-					"self": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/posts/1",
-							"targetHints": {
-								"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
-							}
-						}
-					],
-					"collection": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/posts"
-						}
-					],
-					"about": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/types/post"
-						}
-					],
-					"author": [
-						{
-							"embeddable": true,
-							"href": "https://myblog.com/wp-json/wp/v2/users/1"
-						}
-					],
-					"replies": [
-						{
-							"embeddable": true,
-							"href": "https://myblog.com/wp-json/wp/v2/comments?post=1"
-						}
-					],
-					"version-history": [
-						{
-							"count": 1,
-							"href": "https://myblog.com/wp-json/wp/v2/posts/1/revisions"
-						}
-					],
-					"predecessor-version": [
-						{
-							"id": 6,
-							"href": "https://myblog.com/wp-json/wp/v2/posts/1/revisions/6"
-						}
-					],
-					"wp:attachment": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/media?parent=1"
-						}
-					],
-					"wp:term": [
-						{
-							"taxonomy": "category",
-							"embeddable": true,
-							"href": "https://myblog.com/wp-json/wp/v2/categories?post=1"
-						},
-						{
-							"taxonomy": "post_tag",
-							"embeddable": true,
-							"href": "https://myblog.com/wp-json/wp/v2/tags?post=1"
-						}
-					],
-					"curies": [
-						{
-							"name": "wp",
-							"href": "https://api.w.org/{rel}",
-							"templated": true
-						}
-					]
-				}
-			}
-		],
-		"Create Response": [
-			{
-				"id": 7,
-				"date": "2025-03-27T18:30:04",
-				"date_gmt": "2025-03-27T18:30:04",
-				"guid": {
-					"rendered": "https://myblog.com/2025/03/27/new-post/",
-					"raw": "https://myblog.com/2025/03/27/new-post/"
-				},
-				"modified": "2025-03-27T18:30:04",
-				"modified_gmt": "2025-03-27T18:30:04",
-				"password": "",
-				"slug": "new-post",
-				"status": "publish",
-				"type": "post",
-				"link": "https://myblog.com/2025/03/27/new-post/",
-				"title": {
-					"raw": "New Post",
-					"rendered": "New Post"
-				},
-				"content": {
-					"raw": "This is my content",
-					"rendered": "<p>This is my content</p>\n",
-					"protected": false,
-					"block_version": 0
-				},
-				"excerpt": {
-					"raw": "",
-					"rendered": "<p>This is my content</p>\n",
-					"protected": false
-				},
-				"author": 1,
-				"featured_media": 0,
-				"comment_status": "closed",
-				"ping_status": "closed",
-				"sticky": true,
-				"template": "",
-				"format": "standard",
-				"meta": {
-					"footnotes": ""
-				},
-				"categories": [1],
-				"tags": [],
-				"permalink_template": "https://myblog.com/2025/03/27/%postname%/",
-				"generated_slug": "new-post",
-				"class_list": [
-					"post-7",
-					"post",
-					"type-post",
-					"status-publish",
-					"format-standard",
-					"hentry",
-					"category-uncategorised"
-				],
-				"_links": {
-					"self": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/posts/7",
-							"targetHints": {
-								"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
-							}
-						}
-					],
-					"collection": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/posts"
-						}
-					],
-					"about": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/types/post"
-						}
-					],
-					"author": [
-						{
-							"embeddable": true,
-							"href": "https://myblog.com/wp-json/wp/v2/users/1"
-						}
-					],
-					"replies": [
-						{
-							"embeddable": true,
-							"href": "https://myblog.com/wp-json/wp/v2/comments?post=7"
-						}
-					],
-					"version-history": [
-						{
-							"count": 0,
-							"href": "https://myblog.com/wp-json/wp/v2/posts/7/revisions"
-						}
-					],
-					"wp:attachment": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/media?parent=7"
-						}
-					],
-					"wp:term": [
-						{
-							"taxonomy": "category",
-							"embeddable": true,
-							"href": "https://myblog.com/wp-json/wp/v2/categories?post=7"
-						},
-						{
-							"taxonomy": "post_tag",
-							"embeddable": true,
-							"href": "https://myblog.com/wp-json/wp/v2/tags?post=7"
-						}
-					],
-					"wp:action-publish": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/posts/7"
-						}
-					],
-					"wp:action-unfiltered-html": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/posts/7"
-						}
-					],
-					"wp:action-sticky": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/posts/7"
-						}
-					],
-					"wp:action-assign-author": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/posts/7"
-						}
-					],
-					"wp:action-create-categories": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/posts/7"
-						}
-					],
-					"wp:action-assign-categories": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/posts/7"
-						}
-					],
-					"wp:action-create-tags": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/posts/7"
-						}
-					],
-					"wp:action-assign-tags": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/posts/7"
-						}
-					],
-					"curies": [
-						{
-							"name": "wp",
-							"href": "https://api.w.org/{rel}",
-							"templated": true
-						}
-					]
-				}
-			}
-		],
-		"Get Many (With Filters)": [
-			{
-				"id": 1,
-				"date": "2025-03-27T18:05:01",
-				"date_gmt": "2025-03-27T18:05:01",
-				"guid": {
-					"rendered": "https://myblog.com/?p=1"
-				},
-				"modified": "2025-03-27T18:22:36",
-				"modified_gmt": "2025-03-27T18:22:36",
-				"slug": "hello-world",
-				"status": "publish",
-				"type": "post",
-				"link": "https://myblog.com/2025/03/27/hello-world/",
-				"title": {
-					"rendered": "Hello world!"
-				},
-				"content": {
-					"rendered": "\n<p>Welcome to WordPress. This is your first post. Edit or delete it, then start writing!</p>\n",
-					"protected": false
-				},
-				"excerpt": {
-					"rendered": "<p>Welcome to WordPress. This is your first post. Edit or delete it, then start writing!</p>\n",
-					"protected": false
-				},
-				"author": 1,
-				"featured_media": 0,
-				"comment_status": "open",
-				"ping_status": "open",
-				"sticky": false,
-				"template": "",
-				"format": "standard",
-				"meta": {
-					"footnotes": ""
-				},
-				"categories": [1],
-				"tags": [],
-				"class_list": [
-					"post-1",
-					"post",
-					"type-post",
-					"status-publish",
-					"format-standard",
-					"hentry",
-					"category-uncategorised"
-				],
-				"_links": {
-					"self": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/posts/1",
-							"targetHints": {
-								"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
-							}
-						}
-					],
-					"collection": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/posts"
-						}
-					],
-					"about": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/types/post"
-						}
-					],
-					"author": [
-						{
-							"embeddable": true,
-							"href": "https://myblog.com/wp-json/wp/v2/users/1"
-						}
-					],
-					"replies": [
-						{
-							"embeddable": true,
-							"href": "https://myblog.com/wp-json/wp/v2/comments?post=1"
-						}
-					],
-					"version-history": [
-						{
-							"count": 1,
-							"href": "https://myblog.com/wp-json/wp/v2/posts/1/revisions"
-						}
-					],
-					"predecessor-version": [
-						{
-							"id": 6,
-							"href": "https://myblog.com/wp-json/wp/v2/posts/1/revisions/6"
-						}
-					],
-					"wp:attachment": [
-						{
-							"href": "https://myblog.com/wp-json/wp/v2/media?parent=1"
-						}
-					],
-					"wp:term": [
-						{
-							"taxonomy": "category",
-							"embeddable": true,
-							"href": "https://myblog.com/wp-json/wp/v2/categories?post=1"
-						},
-						{
-							"taxonomy": "post_tag",
-							"embeddable": true,
-							"href": "https://myblog.com/wp-json/wp/v2/tags?post=1"
-						}
-					],
-					"curies": [
-						{
-							"name": "wp",
-							"href": "https://api.w.org/{rel}",
-							"templated": true
-						}
-					]
-				}
-			}
-		]
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
 	},
+	"versionId": "15a2bfaf-cdca-4010-81ee-e589d6fddc1e",
 	"meta": {
 		"templateCredsSetupCompleted": true,
 		"instanceId": "eeda9e3069aca300d1dfceeb64beb5b53d715db44a50461bbc5cb0cf6daa01e3"
-	}
+	},
+	"id": "W7kWl5BZvsrmZeVw",
+	"tags": []
 }

--- a/packages/nodes-base/nodes/Wordpress/__tests__/workflow/post/post.workflow.json
+++ b/packages/nodes-base/nodes/Wordpress/__tests__/workflow/post/post.workflow.json
@@ -5,16 +5,16 @@
 			"parameters": {},
 			"type": "n8n-nodes-base.manualTrigger",
 			"typeVersion": 1,
-			"position": [-100, 100],
-			"id": "da734910-1187-408a-bfa9-1f38cd8faf73",
+			"position": [128, 208],
+			"id": "f66ad9bf-b1d4-4ba7-b3e2-e11abad0d84f",
 			"name": "When clicking ‘Execute workflow’"
 		},
 		{
 			"parameters": {},
 			"type": "n8n-nodes-base.noOp",
 			"typeVersion": 1,
-			"position": [340, 0],
-			"id": "086a9b07-77ee-4c99-9d4e-05fdb63914a4",
+			"position": [576, 208],
+			"id": "4b61be50-9737-456c-8256-c6697c91ebf4",
 			"name": "Update Response"
 		},
 		{
@@ -30,13 +30,13 @@
 			},
 			"type": "n8n-nodes-base.wordpress",
 			"typeVersion": 1,
-			"position": [120, 0],
-			"id": "11bb21ca-d2c2-4ac8-8559-a0f44adcb9a4",
+			"position": [352, 208],
+			"id": "855801e6-c026-499e-b68b-ecc3ee84e8da",
 			"name": "Post > Update",
 			"credentials": {
 				"wordpressApi": {
-					"id": "vNOAnwp9mSIq39cD",
-					"name": "nodeqa"
+					"id": "f5S0ZnKe8cDEPpjx",
+					"name": "Wordpress (localhost)"
 				}
 			}
 		},
@@ -48,13 +48,13 @@
 			},
 			"type": "n8n-nodes-base.wordpress",
 			"typeVersion": 1,
-			"position": [120, -200],
-			"id": "01a19b2c-c0e6-49dc-9deb-4f1a52fbe9d4",
+			"position": [352, -176],
+			"id": "4b012296-0a91-42bb-bd40-4b2d739d8563",
 			"name": "Post > Get Many",
 			"credentials": {
 				"wordpressApi": {
-					"id": "vNOAnwp9mSIq39cD",
-					"name": "nodeqa"
+					"id": "f5S0ZnKe8cDEPpjx",
+					"name": "Wordpress (localhost)"
 				}
 			}
 		},
@@ -62,8 +62,8 @@
 			"parameters": {},
 			"type": "n8n-nodes-base.noOp",
 			"typeVersion": 1,
-			"position": [340, -200],
-			"id": "7353362c-e6dd-4812-b8e8-cc52044b0cf3",
+			"position": [576, -176],
+			"id": "79140504-162e-4623-b2f1-7502f7e7ce44",
 			"name": "Get Many"
 		},
 		{
@@ -74,13 +74,13 @@
 			},
 			"type": "n8n-nodes-base.wordpress",
 			"typeVersion": 1,
-			"position": [120, 200],
-			"id": "702ca685-91f4-416d-8f91-9a75409b8460",
+			"position": [352, 400],
+			"id": "824dd2e5-70ad-4b66-b0f8-23de739bf998",
 			"name": "Post > Get",
 			"credentials": {
 				"wordpressApi": {
-					"id": "vNOAnwp9mSIq39cD",
-					"name": "nodeqa"
+					"id": "f5S0ZnKe8cDEPpjx",
+					"name": "Wordpress (localhost)"
 				}
 			}
 		},
@@ -88,8 +88,8 @@
 			"parameters": {},
 			"type": "n8n-nodes-base.noOp",
 			"typeVersion": 1,
-			"position": [340, 200],
-			"id": "ca376415-c336-40ab-8ed7-7ddcf0d180cd",
+			"position": [576, 400],
+			"id": "604b1b7c-d69b-4032-bc49-3c70aabab8ad",
 			"name": "Get Response"
 		},
 		{
@@ -100,23 +100,23 @@
 					"content": "This is my content",
 					"slug": "new-post",
 					"status": "future",
+					"date": "2025-03-27T18:30:04",
 					"commentStatus": "closed",
 					"pingStatus": "closed",
 					"format": "standard",
 					"sticky": true,
-					"categories": [1],
-					"date": "2025-03-27T18:30:04"
+					"categories": [1]
 				}
 			},
 			"type": "n8n-nodes-base.wordpress",
 			"typeVersion": 1,
-			"position": [120, 400],
-			"id": "3a022ad5-8ce7-4ff2-988f-a449c7f1466e",
+			"position": [352, 592],
+			"id": "d6765ba2-85e5-4f00-92e6-7d51d61415d1",
 			"name": "Post > Create",
 			"credentials": {
 				"wordpressApi": {
-					"id": "vNOAnwp9mSIq39cD",
-					"name": "nodeqa"
+					"id": "f5S0ZnKe8cDEPpjx",
+					"name": "Wordpress (localhost)"
 				}
 			}
 		},
@@ -124,575 +124,39 @@
 			"parameters": {},
 			"type": "n8n-nodes-base.noOp",
 			"typeVersion": 1,
-			"position": [340, 400],
-			"id": "54e3d212-9d19-4aa1-ad32-1ca0cc64c32b",
+			"position": [576, 592],
+			"id": "e9d92bb0-4bd5-4461-a78b-2184bb6a2e20",
 			"name": "Create Response"
+		},
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [576, 16],
+			"id": "f9bbda89-7fc6-482d-af95-81d4092ce24a",
+			"name": "Get Many (With Filters)"
+		},
+		{
+			"parameters": {
+				"operation": "getAll",
+				"returnAll": true,
+				"options": {
+					"before": "2026-01-01T00:00:00"
+				}
+			},
+			"type": "n8n-nodes-base.wordpress",
+			"typeVersion": 1,
+			"position": [352, 16],
+			"id": "1324d218-2c0b-442b-bcd1-5ec11b803c28",
+			"name": "Post > Get Many (With Filters)",
+			"credentials": {
+				"wordpressApi": {
+					"id": "f5S0ZnKe8cDEPpjx",
+					"name": "Wordpress (localhost)"
+				}
+			}
 		}
 	],
-	"pinData": {
-		"Update Response": [
-			{
-				"json": {
-					"id": 1,
-					"date": "2025-03-27T18:05:01",
-					"date_gmt": "2025-03-27T18:05:01",
-					"guid": {
-						"rendered": "https://myblog.com/?p=1",
-						"raw": "https://myblog.com/?p=1"
-					},
-					"modified": "2025-03-27T18:22:36",
-					"modified_gmt": "2025-03-27T18:22:36",
-					"password": "",
-					"slug": "hello-world",
-					"status": "publish",
-					"type": "post",
-					"link": "https://myblog.com/2025/03/27/hello-world/",
-					"title": {
-						"raw": "New Title",
-						"rendered": "New Title"
-					},
-					"content": {
-						"raw": "Some new content",
-						"rendered": "<p>Some new content</p>\n",
-						"protected": false,
-						"block_version": 0
-					},
-					"excerpt": {
-						"raw": "",
-						"rendered": "<p>Some new content</p>\n",
-						"protected": false
-					},
-					"author": 1,
-					"featured_media": 0,
-					"comment_status": "open",
-					"ping_status": "open",
-					"sticky": false,
-					"template": "",
-					"format": "standard",
-					"meta": {
-						"footnotes": ""
-					},
-					"categories": [1],
-					"tags": [],
-					"permalink_template": "https://myblog.com/2025/03/27/%postname%/",
-					"generated_slug": "new-title",
-					"class_list": [
-						"post-1",
-						"post",
-						"type-post",
-						"status-publish",
-						"format-standard",
-						"hentry",
-						"category-uncategorised"
-					],
-					"_links": {
-						"self": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/posts/1",
-								"targetHints": {
-									"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
-								}
-							}
-						],
-						"collection": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/posts"
-							}
-						],
-						"about": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/types/post"
-							}
-						],
-						"author": [
-							{
-								"embeddable": true,
-								"href": "https://myblog.com/wp-json/wp/v2/users/1"
-							}
-						],
-						"replies": [
-							{
-								"embeddable": true,
-								"href": "https://myblog.com/wp-json/wp/v2/comments?post=1"
-							}
-						],
-						"version-history": [
-							{
-								"count": 1,
-								"href": "https://myblog.com/wp-json/wp/v2/posts/1/revisions"
-							}
-						],
-						"predecessor-version": [
-							{
-								"id": 6,
-								"href": "https://myblog.com/wp-json/wp/v2/posts/1/revisions/6"
-							}
-						],
-						"wp:attachment": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/media?parent=1"
-							}
-						],
-						"wp:term": [
-							{
-								"taxonomy": "category",
-								"embeddable": true,
-								"href": "https://myblog.com/wp-json/wp/v2/categories?post=1"
-							},
-							{
-								"taxonomy": "post_tag",
-								"embeddable": true,
-								"href": "https://myblog.com/wp-json/wp/v2/tags?post=1"
-							}
-						],
-						"wp:action-publish": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/posts/1"
-							}
-						],
-						"wp:action-unfiltered-html": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/posts/1"
-							}
-						],
-						"wp:action-sticky": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/posts/1"
-							}
-						],
-						"wp:action-assign-author": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/posts/1"
-							}
-						],
-						"wp:action-create-categories": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/posts/1"
-							}
-						],
-						"wp:action-assign-categories": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/posts/1"
-							}
-						],
-						"wp:action-create-tags": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/posts/1"
-							}
-						],
-						"wp:action-assign-tags": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/posts/1"
-							}
-						],
-						"curies": [
-							{
-								"name": "wp",
-								"href": "https://api.w.org/{rel}",
-								"templated": true
-							}
-						]
-					}
-				}
-			}
-		],
-		"Get Many": [
-			{
-				"json": {
-					"id": 1,
-					"date": "2025-03-27T18:05:01",
-					"date_gmt": "2025-03-27T18:05:01",
-					"guid": {
-						"rendered": "https://myblog.com/?p=1"
-					},
-					"modified": "2025-03-27T18:22:36",
-					"modified_gmt": "2025-03-27T18:22:36",
-					"slug": "hello-world",
-					"status": "publish",
-					"type": "post",
-					"link": "https://myblog.com/2025/03/27/hello-world/",
-					"title": {
-						"rendered": "Hello world!"
-					},
-					"content": {
-						"rendered": "\n<p>Welcome to WordPress. This is your first post. Edit or delete it, then start writing!</p>\n",
-						"protected": false
-					},
-					"excerpt": {
-						"rendered": "<p>Welcome to WordPress. This is your first post. Edit or delete it, then start writing!</p>\n",
-						"protected": false
-					},
-					"author": 1,
-					"featured_media": 0,
-					"comment_status": "open",
-					"ping_status": "open",
-					"sticky": false,
-					"template": "",
-					"format": "standard",
-					"meta": {
-						"footnotes": ""
-					},
-					"categories": [1],
-					"tags": [],
-					"class_list": [
-						"post-1",
-						"post",
-						"type-post",
-						"status-publish",
-						"format-standard",
-						"hentry",
-						"category-uncategorised"
-					],
-					"_links": {
-						"self": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/posts/1",
-								"targetHints": {
-									"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
-								}
-							}
-						],
-						"collection": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/posts"
-							}
-						],
-						"about": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/types/post"
-							}
-						],
-						"author": [
-							{
-								"embeddable": true,
-								"href": "https://myblog.com/wp-json/wp/v2/users/1"
-							}
-						],
-						"replies": [
-							{
-								"embeddable": true,
-								"href": "https://myblog.com/wp-json/wp/v2/comments?post=1"
-							}
-						],
-						"version-history": [
-							{
-								"count": 1,
-								"href": "https://myblog.com/wp-json/wp/v2/posts/1/revisions"
-							}
-						],
-						"predecessor-version": [
-							{
-								"id": 6,
-								"href": "https://myblog.com/wp-json/wp/v2/posts/1/revisions/6"
-							}
-						],
-						"wp:attachment": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/media?parent=1"
-							}
-						],
-						"wp:term": [
-							{
-								"taxonomy": "category",
-								"embeddable": true,
-								"href": "https://myblog.com/wp-json/wp/v2/categories?post=1"
-							},
-							{
-								"taxonomy": "post_tag",
-								"embeddable": true,
-								"href": "https://myblog.com/wp-json/wp/v2/tags?post=1"
-							}
-						],
-						"curies": [
-							{
-								"name": "wp",
-								"href": "https://api.w.org/{rel}",
-								"templated": true
-							}
-						]
-					}
-				}
-			}
-		],
-		"Get Response": [
-			{
-				"json": {
-					"id": 1,
-					"date": "2025-03-27T18:05:01",
-					"date_gmt": "2025-03-27T18:05:01",
-					"guid": {
-						"rendered": "https://myblog.com/?p=1"
-					},
-					"modified": "2025-03-27T18:22:36",
-					"modified_gmt": "2025-03-27T18:22:36",
-					"slug": "hello-world",
-					"status": "publish",
-					"type": "post",
-					"link": "https://myblog.com/2025/03/27/hello-world/",
-					"title": {
-						"rendered": "New Title"
-					},
-					"content": {
-						"rendered": "<p>Some new content</p>\n",
-						"protected": false
-					},
-					"excerpt": {
-						"rendered": "<p>Some new content</p>\n",
-						"protected": false
-					},
-					"author": 1,
-					"featured_media": 0,
-					"comment_status": "open",
-					"ping_status": "open",
-					"sticky": false,
-					"template": "",
-					"format": "standard",
-					"meta": {
-						"footnotes": ""
-					},
-					"categories": [1],
-					"tags": [],
-					"class_list": [
-						"post-1",
-						"post",
-						"type-post",
-						"status-publish",
-						"format-standard",
-						"hentry",
-						"category-uncategorised"
-					],
-					"_links": {
-						"self": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/posts/1",
-								"targetHints": {
-									"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
-								}
-							}
-						],
-						"collection": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/posts"
-							}
-						],
-						"about": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/types/post"
-							}
-						],
-						"author": [
-							{
-								"embeddable": true,
-								"href": "https://myblog.com/wp-json/wp/v2/users/1"
-							}
-						],
-						"replies": [
-							{
-								"embeddable": true,
-								"href": "https://myblog.com/wp-json/wp/v2/comments?post=1"
-							}
-						],
-						"version-history": [
-							{
-								"count": 1,
-								"href": "https://myblog.com/wp-json/wp/v2/posts/1/revisions"
-							}
-						],
-						"predecessor-version": [
-							{
-								"id": 6,
-								"href": "https://myblog.com/wp-json/wp/v2/posts/1/revisions/6"
-							}
-						],
-						"wp:attachment": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/media?parent=1"
-							}
-						],
-						"wp:term": [
-							{
-								"taxonomy": "category",
-								"embeddable": true,
-								"href": "https://myblog.com/wp-json/wp/v2/categories?post=1"
-							},
-							{
-								"taxonomy": "post_tag",
-								"embeddable": true,
-								"href": "https://myblog.com/wp-json/wp/v2/tags?post=1"
-							}
-						],
-						"curies": [
-							{
-								"name": "wp",
-								"href": "https://api.w.org/{rel}",
-								"templated": true
-							}
-						]
-					}
-				}
-			}
-		],
-		"Create Response": [
-			{
-				"json": {
-					"id": 7,
-					"date": "2025-03-27T18:30:04",
-					"date_gmt": "2025-03-27T18:30:04",
-					"guid": {
-						"rendered": "https://myblog.com/2025/03/27/new-post/",
-						"raw": "https://myblog.com/2025/03/27/new-post/"
-					},
-					"modified": "2025-03-27T18:30:04",
-					"modified_gmt": "2025-03-27T18:30:04",
-					"password": "",
-					"slug": "new-post",
-					"status": "publish",
-					"type": "post",
-					"link": "https://myblog.com/2025/03/27/new-post/",
-					"title": {
-						"raw": "New Post",
-						"rendered": "New Post"
-					},
-					"content": {
-						"raw": "This is my content",
-						"rendered": "<p>This is my content</p>\n",
-						"protected": false,
-						"block_version": 0
-					},
-					"excerpt": {
-						"raw": "",
-						"rendered": "<p>This is my content</p>\n",
-						"protected": false
-					},
-					"author": 1,
-					"featured_media": 0,
-					"comment_status": "closed",
-					"ping_status": "closed",
-					"sticky": true,
-					"template": "",
-					"format": "standard",
-					"meta": {
-						"footnotes": ""
-					},
-					"categories": [1],
-					"tags": [],
-					"permalink_template": "https://myblog.com/2025/03/27/%postname%/",
-					"generated_slug": "new-post",
-					"class_list": [
-						"post-7",
-						"post",
-						"type-post",
-						"status-publish",
-						"format-standard",
-						"hentry",
-						"category-uncategorised"
-					],
-					"_links": {
-						"self": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/posts/7",
-								"targetHints": {
-									"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
-								}
-							}
-						],
-						"collection": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/posts"
-							}
-						],
-						"about": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/types/post"
-							}
-						],
-						"author": [
-							{
-								"embeddable": true,
-								"href": "https://myblog.com/wp-json/wp/v2/users/1"
-							}
-						],
-						"replies": [
-							{
-								"embeddable": true,
-								"href": "https://myblog.com/wp-json/wp/v2/comments?post=7"
-							}
-						],
-						"version-history": [
-							{
-								"count": 0,
-								"href": "https://myblog.com/wp-json/wp/v2/posts/7/revisions"
-							}
-						],
-						"wp:attachment": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/media?parent=7"
-							}
-						],
-						"wp:term": [
-							{
-								"taxonomy": "category",
-								"embeddable": true,
-								"href": "https://myblog.com/wp-json/wp/v2/categories?post=7"
-							},
-							{
-								"taxonomy": "post_tag",
-								"embeddable": true,
-								"href": "https://myblog.com/wp-json/wp/v2/tags?post=7"
-							}
-						],
-						"wp:action-publish": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/posts/7"
-							}
-						],
-						"wp:action-unfiltered-html": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/posts/7"
-							}
-						],
-						"wp:action-sticky": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/posts/7"
-							}
-						],
-						"wp:action-assign-author": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/posts/7"
-							}
-						],
-						"wp:action-create-categories": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/posts/7"
-							}
-						],
-						"wp:action-assign-categories": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/posts/7"
-							}
-						],
-						"wp:action-create-tags": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/posts/7"
-							}
-						],
-						"wp:action-assign-tags": [
-							{
-								"href": "https://myblog.com/wp-json/wp/v2/posts/7"
-							}
-						],
-						"curies": [
-							{
-								"name": "wp",
-								"href": "https://api.w.org/{rel}",
-								"templated": true
-							}
-						]
-					}
-				}
-			}
-		]
-	},
 	"connections": {
 		"When clicking ‘Execute workflow’": {
 			"main": [
@@ -714,6 +178,11 @@
 					},
 					{
 						"node": "Post > Create",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "Post > Get Many (With Filters)",
 						"type": "main",
 						"index": 0
 					}
@@ -763,17 +232,693 @@
 					}
 				]
 			]
+		},
+		"Post > Get Many (With Filters)": {
+			"main": [
+				[
+					{
+						"node": "Get Many (With Filters)",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
 		}
 	},
-	"active": false,
-	"settings": {
-		"executionOrder": "v1"
+	"pinData": {
+		"Update Response": [
+			{
+				"id": 1,
+				"date": "2025-03-27T18:05:01",
+				"date_gmt": "2025-03-27T18:05:01",
+				"guid": {
+					"rendered": "https://myblog.com/?p=1",
+					"raw": "https://myblog.com/?p=1"
+				},
+				"modified": "2025-03-27T18:22:36",
+				"modified_gmt": "2025-03-27T18:22:36",
+				"password": "",
+				"slug": "hello-world",
+				"status": "publish",
+				"type": "post",
+				"link": "https://myblog.com/2025/03/27/hello-world/",
+				"title": {
+					"raw": "New Title",
+					"rendered": "New Title"
+				},
+				"content": {
+					"raw": "Some new content",
+					"rendered": "<p>Some new content</p>\n",
+					"protected": false,
+					"block_version": 0
+				},
+				"excerpt": {
+					"raw": "",
+					"rendered": "<p>Some new content</p>\n",
+					"protected": false
+				},
+				"author": 1,
+				"featured_media": 0,
+				"comment_status": "open",
+				"ping_status": "open",
+				"sticky": false,
+				"template": "",
+				"format": "standard",
+				"meta": {
+					"footnotes": ""
+				},
+				"categories": [1],
+				"tags": [],
+				"permalink_template": "https://myblog.com/2025/03/27/%postname%/",
+				"generated_slug": "new-title",
+				"class_list": [
+					"post-1",
+					"post",
+					"type-post",
+					"status-publish",
+					"format-standard",
+					"hentry",
+					"category-uncategorised"
+				],
+				"_links": {
+					"self": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/posts/1",
+							"targetHints": {
+								"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+							}
+						}
+					],
+					"collection": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/posts"
+						}
+					],
+					"about": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/types/post"
+						}
+					],
+					"author": [
+						{
+							"embeddable": true,
+							"href": "https://myblog.com/wp-json/wp/v2/users/1"
+						}
+					],
+					"replies": [
+						{
+							"embeddable": true,
+							"href": "https://myblog.com/wp-json/wp/v2/comments?post=1"
+						}
+					],
+					"version-history": [
+						{
+							"count": 1,
+							"href": "https://myblog.com/wp-json/wp/v2/posts/1/revisions"
+						}
+					],
+					"predecessor-version": [
+						{
+							"id": 6,
+							"href": "https://myblog.com/wp-json/wp/v2/posts/1/revisions/6"
+						}
+					],
+					"wp:attachment": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/media?parent=1"
+						}
+					],
+					"wp:term": [
+						{
+							"taxonomy": "category",
+							"embeddable": true,
+							"href": "https://myblog.com/wp-json/wp/v2/categories?post=1"
+						},
+						{
+							"taxonomy": "post_tag",
+							"embeddable": true,
+							"href": "https://myblog.com/wp-json/wp/v2/tags?post=1"
+						}
+					],
+					"wp:action-publish": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/posts/1"
+						}
+					],
+					"wp:action-unfiltered-html": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/posts/1"
+						}
+					],
+					"wp:action-sticky": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/posts/1"
+						}
+					],
+					"wp:action-assign-author": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/posts/1"
+						}
+					],
+					"wp:action-create-categories": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/posts/1"
+						}
+					],
+					"wp:action-assign-categories": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/posts/1"
+						}
+					],
+					"wp:action-create-tags": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/posts/1"
+						}
+					],
+					"wp:action-assign-tags": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/posts/1"
+						}
+					],
+					"curies": [
+						{
+							"name": "wp",
+							"href": "https://api.w.org/{rel}",
+							"templated": true
+						}
+					]
+				}
+			}
+		],
+		"Get Many": [
+			{
+				"id": 1,
+				"date": "2025-03-27T18:05:01",
+				"date_gmt": "2025-03-27T18:05:01",
+				"guid": {
+					"rendered": "https://myblog.com/?p=1"
+				},
+				"modified": "2025-03-27T18:22:36",
+				"modified_gmt": "2025-03-27T18:22:36",
+				"slug": "hello-world",
+				"status": "publish",
+				"type": "post",
+				"link": "https://myblog.com/2025/03/27/hello-world/",
+				"title": {
+					"rendered": "Hello world!"
+				},
+				"content": {
+					"rendered": "\n<p>Welcome to WordPress. This is your first post. Edit or delete it, then start writing!</p>\n",
+					"protected": false
+				},
+				"excerpt": {
+					"rendered": "<p>Welcome to WordPress. This is your first post. Edit or delete it, then start writing!</p>\n",
+					"protected": false
+				},
+				"author": 1,
+				"featured_media": 0,
+				"comment_status": "open",
+				"ping_status": "open",
+				"sticky": false,
+				"template": "",
+				"format": "standard",
+				"meta": {
+					"footnotes": ""
+				},
+				"categories": [1],
+				"tags": [],
+				"class_list": [
+					"post-1",
+					"post",
+					"type-post",
+					"status-publish",
+					"format-standard",
+					"hentry",
+					"category-uncategorised"
+				],
+				"_links": {
+					"self": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/posts/1",
+							"targetHints": {
+								"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+							}
+						}
+					],
+					"collection": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/posts"
+						}
+					],
+					"about": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/types/post"
+						}
+					],
+					"author": [
+						{
+							"embeddable": true,
+							"href": "https://myblog.com/wp-json/wp/v2/users/1"
+						}
+					],
+					"replies": [
+						{
+							"embeddable": true,
+							"href": "https://myblog.com/wp-json/wp/v2/comments?post=1"
+						}
+					],
+					"version-history": [
+						{
+							"count": 1,
+							"href": "https://myblog.com/wp-json/wp/v2/posts/1/revisions"
+						}
+					],
+					"predecessor-version": [
+						{
+							"id": 6,
+							"href": "https://myblog.com/wp-json/wp/v2/posts/1/revisions/6"
+						}
+					],
+					"wp:attachment": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/media?parent=1"
+						}
+					],
+					"wp:term": [
+						{
+							"taxonomy": "category",
+							"embeddable": true,
+							"href": "https://myblog.com/wp-json/wp/v2/categories?post=1"
+						},
+						{
+							"taxonomy": "post_tag",
+							"embeddable": true,
+							"href": "https://myblog.com/wp-json/wp/v2/tags?post=1"
+						}
+					],
+					"curies": [
+						{
+							"name": "wp",
+							"href": "https://api.w.org/{rel}",
+							"templated": true
+						}
+					]
+				}
+			}
+		],
+		"Get Response": [
+			{
+				"id": 1,
+				"date": "2025-03-27T18:05:01",
+				"date_gmt": "2025-03-27T18:05:01",
+				"guid": {
+					"rendered": "https://myblog.com/?p=1"
+				},
+				"modified": "2025-03-27T18:22:36",
+				"modified_gmt": "2025-03-27T18:22:36",
+				"slug": "hello-world",
+				"status": "publish",
+				"type": "post",
+				"link": "https://myblog.com/2025/03/27/hello-world/",
+				"title": {
+					"rendered": "New Title"
+				},
+				"content": {
+					"rendered": "<p>Some new content</p>\n",
+					"protected": false
+				},
+				"excerpt": {
+					"rendered": "<p>Some new content</p>\n",
+					"protected": false
+				},
+				"author": 1,
+				"featured_media": 0,
+				"comment_status": "open",
+				"ping_status": "open",
+				"sticky": false,
+				"template": "",
+				"format": "standard",
+				"meta": {
+					"footnotes": ""
+				},
+				"categories": [1],
+				"tags": [],
+				"class_list": [
+					"post-1",
+					"post",
+					"type-post",
+					"status-publish",
+					"format-standard",
+					"hentry",
+					"category-uncategorised"
+				],
+				"_links": {
+					"self": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/posts/1",
+							"targetHints": {
+								"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+							}
+						}
+					],
+					"collection": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/posts"
+						}
+					],
+					"about": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/types/post"
+						}
+					],
+					"author": [
+						{
+							"embeddable": true,
+							"href": "https://myblog.com/wp-json/wp/v2/users/1"
+						}
+					],
+					"replies": [
+						{
+							"embeddable": true,
+							"href": "https://myblog.com/wp-json/wp/v2/comments?post=1"
+						}
+					],
+					"version-history": [
+						{
+							"count": 1,
+							"href": "https://myblog.com/wp-json/wp/v2/posts/1/revisions"
+						}
+					],
+					"predecessor-version": [
+						{
+							"id": 6,
+							"href": "https://myblog.com/wp-json/wp/v2/posts/1/revisions/6"
+						}
+					],
+					"wp:attachment": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/media?parent=1"
+						}
+					],
+					"wp:term": [
+						{
+							"taxonomy": "category",
+							"embeddable": true,
+							"href": "https://myblog.com/wp-json/wp/v2/categories?post=1"
+						},
+						{
+							"taxonomy": "post_tag",
+							"embeddable": true,
+							"href": "https://myblog.com/wp-json/wp/v2/tags?post=1"
+						}
+					],
+					"curies": [
+						{
+							"name": "wp",
+							"href": "https://api.w.org/{rel}",
+							"templated": true
+						}
+					]
+				}
+			}
+		],
+		"Create Response": [
+			{
+				"id": 7,
+				"date": "2025-03-27T18:30:04",
+				"date_gmt": "2025-03-27T18:30:04",
+				"guid": {
+					"rendered": "https://myblog.com/2025/03/27/new-post/",
+					"raw": "https://myblog.com/2025/03/27/new-post/"
+				},
+				"modified": "2025-03-27T18:30:04",
+				"modified_gmt": "2025-03-27T18:30:04",
+				"password": "",
+				"slug": "new-post",
+				"status": "publish",
+				"type": "post",
+				"link": "https://myblog.com/2025/03/27/new-post/",
+				"title": {
+					"raw": "New Post",
+					"rendered": "New Post"
+				},
+				"content": {
+					"raw": "This is my content",
+					"rendered": "<p>This is my content</p>\n",
+					"protected": false,
+					"block_version": 0
+				},
+				"excerpt": {
+					"raw": "",
+					"rendered": "<p>This is my content</p>\n",
+					"protected": false
+				},
+				"author": 1,
+				"featured_media": 0,
+				"comment_status": "closed",
+				"ping_status": "closed",
+				"sticky": true,
+				"template": "",
+				"format": "standard",
+				"meta": {
+					"footnotes": ""
+				},
+				"categories": [1],
+				"tags": [],
+				"permalink_template": "https://myblog.com/2025/03/27/%postname%/",
+				"generated_slug": "new-post",
+				"class_list": [
+					"post-7",
+					"post",
+					"type-post",
+					"status-publish",
+					"format-standard",
+					"hentry",
+					"category-uncategorised"
+				],
+				"_links": {
+					"self": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/posts/7",
+							"targetHints": {
+								"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+							}
+						}
+					],
+					"collection": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/posts"
+						}
+					],
+					"about": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/types/post"
+						}
+					],
+					"author": [
+						{
+							"embeddable": true,
+							"href": "https://myblog.com/wp-json/wp/v2/users/1"
+						}
+					],
+					"replies": [
+						{
+							"embeddable": true,
+							"href": "https://myblog.com/wp-json/wp/v2/comments?post=7"
+						}
+					],
+					"version-history": [
+						{
+							"count": 0,
+							"href": "https://myblog.com/wp-json/wp/v2/posts/7/revisions"
+						}
+					],
+					"wp:attachment": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/media?parent=7"
+						}
+					],
+					"wp:term": [
+						{
+							"taxonomy": "category",
+							"embeddable": true,
+							"href": "https://myblog.com/wp-json/wp/v2/categories?post=7"
+						},
+						{
+							"taxonomy": "post_tag",
+							"embeddable": true,
+							"href": "https://myblog.com/wp-json/wp/v2/tags?post=7"
+						}
+					],
+					"wp:action-publish": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/posts/7"
+						}
+					],
+					"wp:action-unfiltered-html": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/posts/7"
+						}
+					],
+					"wp:action-sticky": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/posts/7"
+						}
+					],
+					"wp:action-assign-author": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/posts/7"
+						}
+					],
+					"wp:action-create-categories": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/posts/7"
+						}
+					],
+					"wp:action-assign-categories": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/posts/7"
+						}
+					],
+					"wp:action-create-tags": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/posts/7"
+						}
+					],
+					"wp:action-assign-tags": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/posts/7"
+						}
+					],
+					"curies": [
+						{
+							"name": "wp",
+							"href": "https://api.w.org/{rel}",
+							"templated": true
+						}
+					]
+				}
+			}
+		],
+		"Get Many (With Filters)": [
+			{
+				"id": 1,
+				"date": "2025-03-27T18:05:01",
+				"date_gmt": "2025-03-27T18:05:01",
+				"guid": {
+					"rendered": "https://myblog.com/?p=1"
+				},
+				"modified": "2025-03-27T18:22:36",
+				"modified_gmt": "2025-03-27T18:22:36",
+				"slug": "hello-world",
+				"status": "publish",
+				"type": "post",
+				"link": "https://myblog.com/2025/03/27/hello-world/",
+				"title": {
+					"rendered": "Hello world!"
+				},
+				"content": {
+					"rendered": "\n<p>Welcome to WordPress. This is your first post. Edit or delete it, then start writing!</p>\n",
+					"protected": false
+				},
+				"excerpt": {
+					"rendered": "<p>Welcome to WordPress. This is your first post. Edit or delete it, then start writing!</p>\n",
+					"protected": false
+				},
+				"author": 1,
+				"featured_media": 0,
+				"comment_status": "open",
+				"ping_status": "open",
+				"sticky": false,
+				"template": "",
+				"format": "standard",
+				"meta": {
+					"footnotes": ""
+				},
+				"categories": [1],
+				"tags": [],
+				"class_list": [
+					"post-1",
+					"post",
+					"type-post",
+					"status-publish",
+					"format-standard",
+					"hentry",
+					"category-uncategorised"
+				],
+				"_links": {
+					"self": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/posts/1",
+							"targetHints": {
+								"allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+							}
+						}
+					],
+					"collection": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/posts"
+						}
+					],
+					"about": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/types/post"
+						}
+					],
+					"author": [
+						{
+							"embeddable": true,
+							"href": "https://myblog.com/wp-json/wp/v2/users/1"
+						}
+					],
+					"replies": [
+						{
+							"embeddable": true,
+							"href": "https://myblog.com/wp-json/wp/v2/comments?post=1"
+						}
+					],
+					"version-history": [
+						{
+							"count": 1,
+							"href": "https://myblog.com/wp-json/wp/v2/posts/1/revisions"
+						}
+					],
+					"predecessor-version": [
+						{
+							"id": 6,
+							"href": "https://myblog.com/wp-json/wp/v2/posts/1/revisions/6"
+						}
+					],
+					"wp:attachment": [
+						{
+							"href": "https://myblog.com/wp-json/wp/v2/media?parent=1"
+						}
+					],
+					"wp:term": [
+						{
+							"taxonomy": "category",
+							"embeddable": true,
+							"href": "https://myblog.com/wp-json/wp/v2/categories?post=1"
+						},
+						{
+							"taxonomy": "post_tag",
+							"embeddable": true,
+							"href": "https://myblog.com/wp-json/wp/v2/tags?post=1"
+						}
+					],
+					"curies": [
+						{
+							"name": "wp",
+							"href": "https://api.w.org/{rel}",
+							"templated": true
+						}
+					]
+				}
+			}
+		]
 	},
-	"versionId": "2665dd64-c5ba-429b-a96d-c9ef88d22f35",
 	"meta": {
 		"templateCredsSetupCompleted": true,
-		"instanceId": "0fa937d34dcabeff4bd6480d3b42cc95edf3bc20e6810819086ef1ce2623639d"
-	},
-	"id": "TJ2kzGNKbZt6fvPV",
-	"tags": []
+		"instanceId": "eeda9e3069aca300d1dfceeb64beb5b53d715db44a50461bbc5cb0cf6daa01e3"
+	}
 }


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Pass the `before` query parameter to the Wordpress API to ensure pages or posts are properly filtered

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-3678/community-issue-wordpress-node-before-parameter-not-working-in-date
Closes #19761

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
