### PR TITLE
fix(Grist Node): Allow filtering for numbers <= 0

### DIFF
--- a/packages/nodes-base/nodes/Grist/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Grist/GenericFunctions.ts
@@ -77,7 +77,6 @@ export function parseFilterProperties(filterProperties: GristFilterProperties) {
 		acc[cur.field] = acc[cur.field] ?? [];
 		const values = isSafeInteger(Number(cur.values)) ? Number(cur.values) : cur.values;
 		acc[cur.field].push(values);
-
 		return acc;
 	}, {});
 }

--- a/packages/nodes-base/nodes/Grist/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Grist/GenericFunctions.ts
@@ -68,19 +68,15 @@ export function parseSortProperties(sortProperties: GristSortProperties) {
 }
 
 export function isSafeInteger(val: number) {
-	return !isNaN(val) && val > Number.MIN_VALUE && val < Number.MAX_VALUE;
+	//used MIN_SAFE_INTEGER and MAX_SAFE_INTEGER instead of MIN_VALUE and MAX_VALUE to avoid edge cases
+	return !isNaN(val) && val > Number.MIN_SAFE_INTEGER && val < Number.MAX_SAFE_INTEGER;
 }
 
 export function parseFilterProperties(filterProperties: GristFilterProperties) {
 	return filterProperties.reduce<{ [key: string]: Array<string | number> }>((acc, cur) => {
 		acc[cur.field] = acc[cur.field] ?? [];
-
-		// Instead of using a custom function to check for safe integers, we can use Number.isSafeInteger directly along with checking for NaN
-		if (cur.values !== '' && cur.values !== null && cur.values !== undefined) {
-			const values = Number.isSafeInteger(Number(cur.values)) ? Number(cur.values) : cur.values;
-
-			acc[cur.field].push(values);
-		}
+		const values = isSafeInteger(Number(cur.values)) ? Number(cur.values) : cur.values;
+		acc[cur.field].push(values);
 
 		return acc;
 	}, {});

--- a/packages/nodes-base/nodes/Grist/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Grist/GenericFunctions.ts
@@ -74,7 +74,10 @@ export function isSafeInteger(val: number) {
 export function parseFilterProperties(filterProperties: GristFilterProperties) {
 	return filterProperties.reduce<{ [key: string]: Array<string | number> }>((acc, cur) => {
 		acc[cur.field] = acc[cur.field] ?? [];
-		const values = isSafeInteger(Number(cur.values)) ? Number(cur.values) : cur.values;
+
+		// Instead of using a custom function to check for safe integers, we can use Number.isSafeInteger directly
+		const values = Number.isSafeInteger(Number(cur.values)) ? Number(cur.values) : cur.values;
+
 		acc[cur.field].push(values);
 		return acc;
 	}, {});

--- a/packages/nodes-base/nodes/Grist/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Grist/GenericFunctions.ts
@@ -75,10 +75,13 @@ export function parseFilterProperties(filterProperties: GristFilterProperties) {
 	return filterProperties.reduce<{ [key: string]: Array<string | number> }>((acc, cur) => {
 		acc[cur.field] = acc[cur.field] ?? [];
 
-		// Instead of using a custom function to check for safe integers, we can use Number.isSafeInteger directly
-		const values = Number.isSafeInteger(Number(cur.values)) ? Number(cur.values) : cur.values;
+		// Instead of using a custom function to check for safe integers, we can use Number.isSafeInteger directly along with checking for NaN
+		if (cur.values !== '' && cur.values !== null && cur.values !== undefined) {
+			const values = Number.isSafeInteger(Number(cur.values)) ? Number(cur.values) : cur.values;
 
-		acc[cur.field].push(values);
+			acc[cur.field].push(values);
+		}
+
 		return acc;
 	}, {});
 }


### PR DESCRIPTION
## Summary

This PR fixes Grist Node: cannot filter for numbers <= 0 anymore issue (#20039 ) where the filter was not working properly

## Related Linear tickets, Github issues, and Community forum posts
Linear Ticket: GHC-4647
Github issue: #20039 
Closes #20039 
## Key Changes: Used a inbuilt isSafeInteger method of Number instead of the custom fn as it was only considering values greater than 0.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
