### PR TITLE
ci: Sleep before starting MySQL tests

### DIFF
--- a/.github/workflows/ci-postgres-mysql.yml
+++ b/.github/workflows/ci-postgres-mysql.yml
@@ -109,7 +109,8 @@ jobs:
 
       - name: Test MySQL
         working-directory: packages/cli
-        run: pnpm test:mysql --testTimeout 120000
+        # We sleep here due to flakiness with DB tests if we connect to the database too soon
+        run: sleep 2s && pnpm test:mysql --testTimeout 120000
 
   postgres:
     name: Postgres

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -20,3 +20,9 @@ pre-commit:
       skip:
         - merge
         - rebase
+    actionlint_check:
+      glob: '.github/workflows/*.{yml,yaml}'
+      run: actionlint {staged_files}
+      skip:
+        - merge
+        - rebase

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -20,9 +20,3 @@ pre-commit:
       skip:
         - merge
         - rebase
-    actionlint_check:
-      glob: '.github/workflows/*.{yml,yaml}'
-      run: actionlint {staged_files}
-      skip:
-        - merge
-        - rebase


### PR DESCRIPTION
## Summary

This proved the preferred workaround after https://github.com/n8n-io/n8n/pull/20008 and https://github.com/n8n-io/n8n/pull/20026



## Related Linear tickets, Github issues, and Community forum posts


https://linear.app/n8n/issue/ADO-4070


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
