### PR TITLE
fix(OpenAI Node): Missing header for assistant API calls

### DIFF
--- a/packages/nodes-base/credentials/OpenAiApi.credentials.ts
+++ b/packages/nodes-base/credentials/OpenAiApi.credentials.ts
@@ -82,10 +82,11 @@ export class OpenAiApi implements ICredentialType {
 		credentials: ICredentialDataDecryptedObject,
 		requestOptions: IHttpRequestOptions,
 	): Promise<IHttpRequestOptions> {
-		requestOptions.headers = {
-			Authorization: 'Bearer ' + credentials.apiKey,
-			'OpenAI-Organization': credentials.organizationId,
-		};
+		requestOptions.headers ??= {};
+
+		requestOptions.headers['Authorization'] = `Bearer ${credentials.apiKey}`;
+		requestOptions.headers['OpenAI-Organization'] = credentials.organizationId;
+
 		if (
 			credentials.header &&
 			typeof credentials.headerName === 'string' &&
@@ -94,6 +95,7 @@ export class OpenAiApi implements ICredentialType {
 		) {
 			requestOptions.headers[credentials.headerName] = credentials.headerValue;
 		}
+
 		return requestOptions;
 	}
 }

--- a/packages/nodes-base/credentials/test/OpenAiApi.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/OpenAiApi.credentials.test.ts
@@ -151,5 +151,53 @@ describe('OpenAiApi Credential', () => {
 				'OpenAI-Organization': '',
 			});
 		});
+
+		it('should preserve existing headers when adding auth headers', async () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				apiKey: 'sk-test123456789',
+			};
+
+			const requestOptions: IHttpRequestOptions = {
+				headers: {
+					'OpenAI-Beta': 'assistants=v2',
+				},
+				url: '/assistants',
+				baseURL: 'https://api.openai.com/v1',
+			};
+
+			const result = await openAiApi.authenticate(credentials, requestOptions);
+
+			expect(result.headers).toEqual({
+				'OpenAI-Beta': 'assistants=v2',
+				Authorization: 'Bearer sk-test123456789',
+			});
+		});
+
+		it('should preserve existing headers even with custom header option enabled', async () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				apiKey: 'sk-test123456789',
+				header: true,
+				headerName: 'X-Additional-Header',
+				headerValue: 'additional-value',
+			};
+
+			const requestOptions: IHttpRequestOptions = {
+				headers: {
+					'OpenAI-Beta': 'assistants=v2',
+					'X-Existing-Header': 'existing-value',
+				},
+				url: '/assistants/asst_123',
+				baseURL: 'https://api.openai.com/v1',
+			};
+
+			const result = await openAiApi.authenticate(credentials, requestOptions);
+
+			expect(result.headers).toEqual({
+				'OpenAI-Beta': 'assistants=v2',
+				'X-Existing-Header': 'existing-value',
+				Authorization: 'Bearer sk-test123456789',
+				'X-Additional-Header': 'additional-value',
+			});
+		});
 	});
 });


### PR DESCRIPTION
## Summary

Fix missing `OpenAI-Beta: assistants=v2` header which is required for assistant-related API endpoints.
The header was overwritten by the `authenticate` function.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-1466/community-issue-all-openai-assistant-nodes-stoped-working-they-require
- https://github.com/n8n-io/n8n/pull/17835
- https://github.com/n8n-io/n8n/issues/19960


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
