### PR TITLE
fix(editor): Incorrect toast when starting workflow manually via chat trigger

### DIFF
--- a/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/executionFinished.ts
+++ b/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/executionFinished.ts
@@ -390,8 +390,8 @@ export function handleExecutionFinishedWithOther(successToastAlreadyShown: boole
 		const node = workflowsStore.getNodeByName(workflowExecution.executedNode);
 		const nodeType = node && nodeTypesStore.getNodeType(node.type, node.typeVersion);
 		const nodeOutput =
-			workflowExecution?.executedNode &&
 			workflowExecution.data?.resultData?.runData?.[workflowExecution.executedNode];
+
 		if (nodeType?.polling && !nodeOutput) {
 			toast.showMessage({
 				title: i18n.baseText('pushConnection.pollingNode.dataNotFound', {

--- a/packages/frontend/editor-ui/src/composables/useRunWorkflow.ts
+++ b/packages/frontend/editor-ui/src/composables/useRunWorkflow.ts
@@ -180,7 +180,6 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 				startNodeNames.push(
 					...workflowObject.value.getChildNodes(options.triggerNode, NodeConnectionTypes.Main, 1),
 				);
-				executedNode = options.triggerNode;
 			} else if (options.destinationNode) {
 				executedNode = options.destinationNode;
 			}


### PR DESCRIPTION
## Summary

This PR fixes incorrect toast notification after successful manual execution of a workflow when execution starts from the chat trigger. Toast notification "Node executed successfully" appeared, instead of "Workflow executed successfully".

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-1465/success-toast-shows-node-executed-successfully-in-a-full-execution

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
