### PR TITLE
refactor(editor): Move NodeView template operations on useCanvasOperations for reusability (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/composables/useParentFolder.ts
+++ b/packages/frontend/editor-ui/src/composables/useParentFolder.ts
@@ -1,0 +1,32 @@
+import { useFoldersStore } from '@/stores/folders.store';
+import { useProjectsStore } from '@/stores/projects.store';
+import { useWorkflowsStore } from '@/stores/workflows.store';
+
+export function useParentFolder() {
+	const foldersStore = useFoldersStore();
+	const projectsStore = useProjectsStore();
+	const workflowsStore = useWorkflowsStore();
+
+	// This loads user's home project and parent folder data if they are not already loaded.
+	// This happens when user lands straight on the new workflow page and we have nothing in the store.
+	const fetchAndSetParentFolder = async (folderId?: string) => {
+		if (!folderId) return;
+
+		let parentFolder = foldersStore.getCachedFolder(folderId);
+		if (!parentFolder && projectsStore.currentProjectId) {
+			await foldersStore.getFolderPath(projectsStore.currentProjectId, folderId);
+			parentFolder = foldersStore.getCachedFolder(folderId);
+		}
+
+		if (parentFolder) {
+			workflowsStore.setParentFolder({
+				...parentFolder,
+				parentFolderId: parentFolder.parentFolder ?? null,
+			});
+		}
+
+		return parentFolder ?? null;
+	};
+
+	return { fetchAndSetParentFolder };
+}

--- a/packages/frontend/editor-ui/src/stores/projects.store.ts
+++ b/packages/frontend/editor-ui/src/stores/projects.store.ts
@@ -117,6 +117,19 @@ export const useProjectsStore = defineStore(STORES.PROJECTS, () => {
 		currentProject.value = await fetchProject(id);
 	};
 
+	async function fetchAndSetProject(projectId: string) {
+		if (projectId && currentProject.value?.id !== projectId) {
+			const project = await fetchProject(projectId);
+			setCurrentProject(project);
+		}
+	}
+
+	async function refreshCurrentProject() {
+		if (currentProjectId.value && currentProject.value?.id !== currentProjectId.value) {
+			await fetchAndSetProject(currentProjectId.value);
+		}
+	}
+
 	const createProject = async (project: CreateProjectDto): Promise<Project> => {
 		const newProject = await projectsApi.createProject(rootStore.restApiContext, project);
 		await getProjectsCount();
@@ -282,8 +295,10 @@ export const useProjectsStore = defineStore(STORES.PROJECTS, () => {
 		getMyProjects,
 		getPersonalProject,
 		getAvailableProjects,
-		fetchProject,
 		getProject,
+		fetchProject,
+		fetchAndSetProject,
+		refreshCurrentProject,
 		createProject,
 		updateProject,
 		deleteProject,

--- a/packages/frontend/editor-ui/src/stores/ui.store.ts
+++ b/packages/frontend/editor-ui/src/stores/ui.store.ts
@@ -245,6 +245,7 @@ export const useUIStore = defineStore(STORES.UI, () => {
 	const bannerStack = ref<BannerName[]>([]);
 	const pendingNotificationsForViews = ref<{ [key in VIEWS]?: NotificationOptions[] }>({});
 	const processingExecutionResults = ref<boolean>(false);
+	const isBlankRedirect = ref<boolean>(false);
 
 	/**
 	 * Modules can register their ProjectHeader tabs here
@@ -669,6 +670,7 @@ export const useUIStore = defineStore(STORES.UI, () => {
 		activeActions,
 		headerHeight,
 		stateIsDirty,
+		isBlankRedirect,
 		activeCredentialType,
 		lastSelectedNode,
 		bannersHeight,

--- a/packages/frontend/editor-ui/src/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/views/NodeView.vue
@@ -32,10 +32,8 @@ import type {
 	NodeCreatorOpenSource,
 	NodeFilterType,
 	ToggleNodeCreatorOptions,
-	WorkflowDataWithTemplateId,
 	XYPosition,
 } from '@/Interface';
-import type { IWorkflowTemplate } from '@n8n/rest-api-client/api/templates';
 import type { WorkflowDataUpdate } from '@n8n/rest-api-client/api/workflows';
 import type {
 	Connection,
@@ -89,7 +87,7 @@ import type {
 import { useToast } from '@/composables/useToast';
 import { useSettingsStore } from '@/stores/settings.store';
 import { useCredentialsStore } from '@/stores/credentials.store';
-import useEnvironmentsStore from '@/stores/environments.ee.store';
+import { useEnvironmentsStore } from '@/stores/environments.ee.store';
 import { useExternalSecretsStore } from '@/stores/externalSecrets.ee.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { historyBus } from '@/models/history';
@@ -115,8 +113,6 @@ import CanvasStopCurrentExecutionButton from '@/components/canvas/elements/butto
 import CanvasStopWaitingForWebhookButton from '@/components/canvas/elements/buttons/CanvasStopWaitingForWebhookButton.vue';
 import CanvasThinkingPill from '@n8n/design-system/components/CanvasThinkingPill/CanvasThinkingPill.vue';
 import { nodeViewEventBus } from '@/event-bus';
-import { tryToParseNumber } from '@/utils/typesUtils';
-import { useTemplatesStore } from '@/stores/templates.store';
 import { N8nCallout } from '@n8n/design-system';
 import type { PinDataSource } from '@/composables/usePinnedData';
 import { useClipboard } from '@/composables/useClipboard';
@@ -132,7 +128,6 @@ import { getSampleWorkflowByTemplateId } from '@/utils/templates/workflowSamples
 import type { CanvasLayoutEvent } from '@/composables/useCanvasLayout';
 import { useWorkflowSaving } from '@/composables/useWorkflowSaving';
 import { useBuilderStore } from '@/stores/builder.store';
-import { useFoldersStore } from '@/stores/folders.store';
 import { usePostHog } from '@/stores/posthog.store';
 import KeyboardShortcutTooltip from '@/components/KeyboardShortcutTooltip.vue';
 import { useWorkflowExtraction } from '@/composables/useWorkflowExtraction';
@@ -147,6 +142,7 @@ import { useReadyToRunWorkflowsStore } from '@/experiments/readyToRunWorkflows/s
 import { useKeybindings } from '@/composables/useKeybindings';
 import { type ContextMenuAction } from '@/composables/useContextMenuItems';
 import { useExperimentalNdvStore } from '@/components/canvas/experimental/experimentalNdv.store';
+import { useParentFolder } from '@/composables/useParentFolder';
 
 defineOptions({
 	name: 'NodeView',
@@ -201,9 +197,7 @@ const tagsStore = useTagsStore();
 const pushConnectionStore = usePushConnectionStore();
 const ndvStore = useNDVStore();
 const focusPanelStore = useFocusPanelStore();
-const templatesStore = useTemplatesStore();
 const builderStore = useBuilderStore();
-const foldersStore = useFoldersStore();
 const posthogStore = usePostHog();
 const agentRequestStore = useAgentRequestStore();
 const logsStore = useLogsStore();
@@ -238,7 +232,6 @@ const {
 	duplicateNodes,
 	revertDeleteNode,
 	addNodes,
-	importTemplate,
 	revertAddNode,
 	createConnection,
 	revertCreateConnection,
@@ -259,9 +252,14 @@ const {
 	editableWorkflowObject,
 	lastClickPosition,
 	startChat,
+	fitView,
+	openWorkflowTemplate,
+	openWorkflowTemplateFromJSON,
 } = useCanvasOperations();
 const { extractWorkflow } = useWorkflowExtraction();
 const { applyExecutionData } = useExecutionDebugging();
+const { fetchAndSetParentFolder } = useParentFolder();
+
 useClipboard({ onPaste: onClipboardPaste });
 useKeybindings({
 	ctrl_alt_o: () => uiStore.openModal(ABOUT_MODAL_KEY),
@@ -269,7 +267,6 @@ useKeybindings({
 
 const canvasRef = useTemplateRef('canvas');
 const isLoading = ref(true);
-const isBlankRedirect = ref(false);
 const readOnlyNotification = ref<null | { visible: boolean }>(null);
 
 const isProductionExecutionPreview = ref(false);
@@ -401,8 +398,8 @@ async function initializeRoute(force = false) {
 	// - if the redirect is blank, then do nothing
 	// - if the route is the template import view, then open the template
 	// - if the user is leaving the current view without saving the changes, then show a confirmation modal
-	if (isBlankRedirect.value) {
-		isBlankRedirect.value = false;
+	if (uiStore.isBlankRedirect) {
+		uiStore.isBlankRedirect = false;
 	} else if (route.name === VIEWS.TEMPLATE_IMPORT) {
 		const loadWorkflowFromJSON = route.query.fromJson === 'true';
 		const templateId = route.params.id;
@@ -421,7 +418,7 @@ async function initializeRoute(force = false) {
 				return;
 			}
 
-			await openTemplateFromWorkflowJSON(workflow);
+			await openWorkflowTemplateFromJSON(workflow);
 		} else {
 			await openWorkflowTemplate(templateId.toString());
 		}
@@ -465,38 +462,11 @@ async function initializeWorkspaceForNewWorkflow() {
 		parentFolderId,
 	);
 
-	if (projectsStore.currentProjectId) {
-		await fetchAndSetProject(projectsStore.currentProjectId);
-	}
+	await projectsStore.refreshCurrentProject();
 	await fetchAndSetParentFolder(parentFolderId);
 
 	uiStore.nodeViewInitialized = true;
 	initializedWorkflowId.value = NEW_WORKFLOW_ID;
-}
-
-// These two methods load home project and parent folder data if they are not already loaded
-// This happens when user lands straight on the new workflow page and we have nothing in the store
-async function fetchAndSetParentFolder(folderId?: string) {
-	if (folderId) {
-		let parentFolder = foldersStore.getCachedFolder(folderId);
-		if (!parentFolder && projectsStore.currentProjectId) {
-			await foldersStore.getFolderPath(projectsStore.currentProjectId, folderId);
-			parentFolder = foldersStore.getCachedFolder(folderId);
-		}
-		if (parentFolder) {
-			workflowsStore.setParentFolder({
-				...parentFolder,
-				parentFolderId: parentFolder.parentFolder ?? null,
-			});
-		}
-	}
-}
-
-async function fetchAndSetProject(projectId: string) {
-	if (projectsStore.currentProject?.id !== projectId) {
-		const project = await projectsStore.fetchProject(projectId);
-		projectsStore.setCurrentProject(project);
-	}
 }
 
 async function initializeWorkspaceForExistingWorkflow(id: string) {
@@ -593,109 +563,6 @@ function trackOpenWorkflowFromOnboardingTemplate() {
 			workflow_id: workflowId.value,
 		},
 	);
-}
-
-/**
- * Templates
- */
-
-async function openTemplateFromWorkflowJSON(workflow: WorkflowDataWithTemplateId) {
-	if (!workflow.nodes || !workflow.connections) {
-		toast.showError(
-			new Error(i18n.baseText('nodeView.couldntLoadWorkflow.invalidWorkflowObject')),
-			i18n.baseText('nodeView.couldntImportWorkflow'),
-		);
-		await router.replace({ name: VIEWS.NEW_WORKFLOW });
-		return;
-	}
-	resetWorkspace();
-
-	canvasStore.startLoading();
-	canvasStore.setLoadingText(i18n.baseText('nodeView.loadingTemplate'));
-
-	workflowsStore.currentWorkflowExecutions = [];
-	executionsStore.activeExecution = null;
-
-	isBlankRedirect.value = true;
-	const templateId = workflow.meta.templateId;
-	const parentFolderId = route.query.parentFolderId as string | undefined;
-
-	if (projectsStore.currentProjectId) {
-		await fetchAndSetProject(projectsStore.currentProjectId);
-	}
-	await fetchAndSetParentFolder(parentFolderId);
-
-	await router.replace({
-		name: VIEWS.NEW_WORKFLOW,
-		query: { templateId, parentFolderId, projectId: projectsStore.currentProjectId },
-	});
-
-	await importTemplate({
-		id: templateId,
-		name: workflow.name,
-		workflow,
-	});
-
-	uiStore.stateIsDirty = true;
-
-	canvasStore.stopLoading();
-
-	fitView();
-}
-
-async function openWorkflowTemplate(templateId: string) {
-	resetWorkspace();
-
-	canvasStore.startLoading();
-	canvasStore.setLoadingText(i18n.baseText('nodeView.loadingTemplate'));
-
-	workflowsStore.currentWorkflowExecutions = [];
-	executionsStore.activeExecution = null;
-
-	let data: IWorkflowTemplate | undefined;
-	try {
-		void externalHooks.run('template.requested', { templateId });
-
-		data = await templatesStore.getFixedWorkflowTemplate(templateId);
-		if (!data) {
-			throw new Error(
-				i18n.baseText('nodeView.workflowTemplateWithIdCouldNotBeFound', {
-					interpolate: { templateId },
-				}),
-			);
-		}
-	} catch (error) {
-		toast.showError(error, i18n.baseText('nodeView.couldntImportWorkflow'));
-		await router.replace({ name: VIEWS.NEW_WORKFLOW });
-		return;
-	}
-
-	trackOpenWorkflowTemplate(templateId);
-
-	isBlankRedirect.value = true;
-	await router.replace({ name: VIEWS.NEW_WORKFLOW, query: { templateId } });
-
-	await importTemplate({ id: templateId, name: data.name, workflow: data.workflow });
-
-	uiStore.stateIsDirty = true;
-
-	canvasStore.stopLoading();
-
-	void externalHooks.run('template.open', {
-		templateId,
-		templateName: data.name,
-		workflow: data.workflow,
-	});
-
-	fitView();
-}
-
-function trackOpenWorkflowTemplate(templateId: string) {
-	telemetry.track('User inserted workflow template', {
-		source: 'workflow',
-		template_id: tryToParseNumber(templateId),
-		wf_template_repo_session_id: templatesStore.previousSessionId,
-	});
 }
 
 /**
@@ -1607,7 +1474,7 @@ async function onPostMessageReceived(messageEvent: MessageEvent) {
 			try {
 				// Set the project if provided from the parent window
 				if (json.projectId) {
-					await fetchAndSetProject(json.projectId);
+					await projectsStore.fetchAndSetProject(json.projectId);
 				}
 				await importWorkflowExact(json);
 				canOpenNDV.value = json.canOpenNDV ?? true;
@@ -1629,7 +1496,7 @@ async function onPostMessageReceived(messageEvent: MessageEvent) {
 			try {
 				// Set the project if provided from the parent window
 				if (json.projectId) {
-					await fetchAndSetProject(json.projectId);
+					await projectsStore.fetchAndSetProject(json.projectId);
 				}
 				// If this NodeView is used in preview mode (in iframe) it will not have access to the main app store
 				// so everything it needs has to be sent using post messages and passed down to child components
@@ -1752,10 +1619,6 @@ function onViewportChange(viewport: ViewportTransform, dimensions: Dimensions) {
 	viewportTransform.value = viewport;
 	viewportDimensions.value = dimensions;
 	uiStore.nodeViewOffsetPosition = [viewport.x, viewport.y];
-}
-
-function fitView() {
-	setTimeout(() => canvasEventBus.emit('fitView'));
 }
 
 function selectNodes(ids: string[]) {


### PR DESCRIPTION
## Summary

We're working with Command Bar feature this week, and the feature needs access to certain node view operations, such as loading templates & workflows. In order to avoid a too large PR I'm splitting some of the refatoring work to enable command bar functionality into refactoring PRs, this being the first one.

Move `openWorkflowTemplate` and `openWorkflowTemplateFromJSON` from nodeView component to a composable - I've chosen to move them on the (pretty massive) useCanvasOperations for now, I guess opening a workflow on the canvas counts as a canvas operation?

I'm also moving `fetchAndSetProject` and `fetchAndSetParentFolder` to be able to use them from `useCanvasOperations` and possibly elsewhere soon too.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4206/refactor-template-opening-from-nodeview-to-usecanvasoperations-for

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
