### PR TITLE
fix(ChatTrigger Node): Chat submit button, fix disabled state coloring

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/constants.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/constants.ts
@@ -13,7 +13,7 @@ export const cssVariables = `
   --chat--color-light-shade-100: #c2c5cc;
   --chat--color-medium: #d2d4d9;
   --chat--color-dark: #101330;
-  --chat--color-disabled: #777980;
+  --chat--color-disabled: #d2d4d9;
   --chat--color-typing: #404040;
 
   /* Base Layout */
@@ -105,7 +105,7 @@ export const cssVariables = `
 
   /* Send and File Buttons */
   --chat--input--send--button--background: var(--chat--color-white);
-  --chat--input--send--button--color: var(--chat--color-light);
+  --chat--input--send--button--color: var(--chat--color-dark);
   --chat--input--send--button--background-hover: var(--chat--color-primary-shade-50);
   --chat--input--send--button--color-hover: var(--chat--color-secondary-shade-50);
   --chat--input--file--button--background: var(--chat--color-white);

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/constants.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/constants.ts
@@ -105,7 +105,7 @@ export const cssVariables = `
 
   /* Send and File Buttons */
   --chat--input--send--button--background: var(--chat--color-white);
-  --chat--input--send--button--color: var(--chat--color-dark);
+  --chat--input--send--button--color: var(--chat--color-secondary);
   --chat--input--send--button--background-hover: var(--chat--color-primary-shade-50);
   --chat--input--send--button--color-hover: var(--chat--color-secondary-shade-50);
   --chat--input--file--button--background: var(--chat--color-white);

--- a/packages/frontend/@n8n/chat/src/__stories__/App.stories.ts
+++ b/packages/frontend/@n8n/chat/src/__stories__/App.stories.ts
@@ -33,6 +33,7 @@ export const Fullscreen: Story = {
 		webhookUrl,
 		mode: 'fullscreen',
 		enableStreaming: false,
+		loadPreviousSession: false,
 	} satisfies Partial<ChatOptions>,
 };
 
@@ -41,6 +42,7 @@ export const Windowed: Story = {
 		webhookUrl,
 		mode: 'window',
 		enableStreaming: false,
+		loadPreviousSession: false,
 	} satisfies Partial<ChatOptions>,
 };
 
@@ -54,5 +56,6 @@ export const WorkflowChat: Story = {
 		showWelcomeScreen: false,
 		initialMessages: [],
 		enableStreaming: false,
+		loadPreviousSession: false,
 	} satisfies Partial<ChatOptions>,
 };

--- a/packages/frontend/@n8n/chat/src/css/_tokens.scss
+++ b/packages/frontend/@n8n/chat/src/css/_tokens.scss
@@ -103,7 +103,7 @@
 
 	/* Send and File Buttons */
 	--chat--input--send--button--background: var(--chat--color-white);
-	--chat--input--send--button--color: var(--chat--color-dark);
+	--chat--input--send--button--color: var(--chat--color-secondary);
 	--chat--input--send--button--background-hover: var(--chat--color-primary-shade-50);
 	--chat--input--send--button--color-hover: var(--chat--color-secondary-shade-50);
 	--chat--input--file--button--background: var(--chat--color-white);

--- a/packages/frontend/@n8n/chat/src/css/_tokens.scss
+++ b/packages/frontend/@n8n/chat/src/css/_tokens.scss
@@ -11,7 +11,7 @@
 	--chat--color-light-shade-100: #c2c5cc;
 	--chat--color-medium: #d2d4d9;
 	--chat--color-dark: #101330;
-	--chat--color-disabled: #777980;
+	--chat--color-disabled: #d2d4d9;
 	--chat--color-typing: #404040;
 
 	/* Base Layout */
@@ -103,7 +103,7 @@
 
 	/* Send and File Buttons */
 	--chat--input--send--button--background: var(--chat--color-white);
-	--chat--input--send--button--color: var(--chat--color-light);
+	--chat--input--send--button--color: var(--chat--color-dark);
 	--chat--input--send--button--background-hover: var(--chat--color-primary-shade-50);
 	--chat--input--send--button--color-hover: var(--chat--color-secondary-shade-50);
 	--chat--input--file--button--background: var(--chat--color-white);


### PR DESCRIPTION
## Summary

As title, the button previously was the incorrect colors/inverted compared to what you would expect when disabled, it was visible when disabled and invisible when enabled.

I've switched it to use the same color scheme as the attachment icon button, using the `secondary` color and disabling to a light color but still visible. I've also updated the storybook as it was not correctly rendering the chat inputs - it required disabling the loading of previous session (since there will not be a session).

GIF of new look:
![chat-button](https://github.com/user-attachments/assets/5c4cf1b0-f23e-46fb-a440-afa4745304f0)

fixes: https://linear.app/n8n/issue/AI-1428/chat-ui-icon-shows-as-disabled-when-active-and-vice-versa

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
