### PR TITLE
fix: `n8n-node` not working on Windows

### DIFF
--- a/packages/@n8n/node-cli/src/commands/dev/utils.ts
+++ b/packages/@n8n/node-cli/src/commands/dev/utils.ts
@@ -115,7 +115,7 @@ export function commands() {
 			cwd: opts.cwd,
 			env: { ...process.env, ...opts.env },
 			stdio: ['inherit', 'pipe', 'pipe'],
-			shell: true,
+			shell: process.platform === 'win32',
 		});
 
 		registerChild(child);

--- a/packages/@n8n/node-cli/src/commands/dev/utils.ts
+++ b/packages/@n8n/node-cli/src/commands/dev/utils.ts
@@ -115,6 +115,7 @@ export function commands() {
 			cwd: opts.cwd,
 			env: { ...process.env, ...opts.env },
 			stdio: ['inherit', 'pipe', 'pipe'],
+			shell: true,
 		});
 
 		registerChild(child);

--- a/packages/@n8n/node-cli/src/utils/child-process.ts
+++ b/packages/@n8n/node-cli/src/utils/child-process.ts
@@ -30,6 +30,7 @@ export async function runCommand(
 			cwd: opts.cwd,
 			env: { ...process.env, ...opts.env },
 			stdio: opts.stdio ?? ['ignore', 'pipe', 'pipe'],
+			shell: true,
 		};
 		const child =
 			opts.context === 'local'

--- a/packages/@n8n/node-cli/src/utils/child-process.ts
+++ b/packages/@n8n/node-cli/src/utils/child-process.ts
@@ -30,7 +30,7 @@ export async function runCommand(
 			cwd: opts.cwd,
 			env: { ...process.env, ...opts.env },
 			stdio: opts.stdio ?? ['ignore', 'pipe', 'pipe'],
-			shell: true,
+			shell: process.platform === 'win32',
 		};
 		const child =
 			opts.context === 'local'


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Fix `n8n-node` not working on Windows when trying to execute commands via `spawn` from `child_process`. Adding `shell: true` resolves the issue for Windows

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-3695/community-issue-n8nnode-cli-error-spawn-npm-enoent-windows
Closes #19885 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
