### PR TITLE
Shinforce patch 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# Start from the official n8n image
+FROM n8nio/n8n:latest
+
+# Switch to root user to install packages
+USER root
+
+# Install Python and basic tools
+RUN apk update && \
+    apk add --no-cache \
+    python3 \
+    py3-pip \
+    && rm -rf /var/cache/apk/*
+
+# Create a virtual environment
+RUN python3 -m venv /opt/venv
+
+# Install packages in the virtual environment
+COPY requirements.txt .
+RUN if [ -f requirements.txt ]; then \
+    /opt/venv/bin/pip install --upgrade pip && \
+    /opt/venv/bin/pip install --no-cache-dir -r requirements.txt; \
+    fi
+
+# Create a symlink to make the virtual environment Python available system-wide
+RUN ln -sf /opt/venv/bin/python /usr/local/bin/python && \
+    ln -sf /opt/venv/bin/pip /usr/local/bin/pip
+
+# Switch back to n8n user for security
+USER node
+
+# Set PATH to include the virtual environment (optional but helpful)
+ENV PATH="/opt/venv/bin:${PATH}"
+
+# n8n will start automatically (from the base image)

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,58 @@
+services:
+  # n8n Web Service (your existing paid service)
+  - type: web
+    name: n8n-with-python  
+    env: docker
+    dockerfile: Dockerfile
+    plan: starter  
+    envVars:
+      # BASIC AUTHENTICATION
+      - key: N8N_BASIC_AUTH_ACTIVE
+        value: true
+      - key: N8N_BASIC_AUTH_USER
+        generateValue: true
+      - key: N8N_BASIC_AUTH_PASSWORD
+        generateValue: true
+      
+      # DATABASE CONFIGURATION 
+      - key: DB_TYPE
+        value: postgresdb
+      - key: DB_POSTGRESDB_HOST
+        fromService:
+          name: n8n-database  
+          type: postgres
+          property: host
+      - key: DB_POSTGRESDB_USER
+        fromService:
+          name: n8n-database
+          type: postgres
+          property: user
+      - key: DB_POSTGRESDB_PASSWORD
+        fromService:
+          name: n8n-database
+          type: postgres
+          property: password
+      - key: DB_POSTGRESDB_DATABASE
+        fromService:
+          name: n8n-database
+          type: postgres
+          property: database
+      - key: DB_POSTGRESDB_PORT
+        value: 5432
+      
+      # ADDITIONAL SETTINGS
+      - key: N8N_HOST
+        value: n8n-with-python.onrender.com  
+      - key: NODE_ENV
+        value: production
+      - key: N8N_ENCRYPTION_KEY
+        generateValue: true
+    
+    numInstances: 1
+
+  # NEW PostgreSQL Database Service 
+  - type: postgres
+    name: n8n-database  
+    plan: free  
+    databaseName: n8n
+    user: n8n_user

--- a/render.yaml
+++ b/render.yaml
@@ -1,58 +1,32 @@
 services:
-  # n8n Web Service (your existing paid service)
   - type: web
-    name: n8n-with-python  
+    name: n8n-with-python
     env: docker
     dockerfile: Dockerfile
-    plan: starter  
+    plan: starter  # or free
     envVars:
-      # BASIC AUTHENTICATION
       - key: N8N_BASIC_AUTH_ACTIVE
         value: true
       - key: N8N_BASIC_AUTH_USER
         generateValue: true
       - key: N8N_BASIC_AUTH_PASSWORD
         generateValue: true
-      
-      # DATABASE CONFIGURATION 
+      - key: N8N_ENCRYPTION_KEY
+        generateValue: true
+      - key: N8N_HOST
+        value: n8n-with-python.onrender.com
+      - key: NODE_ENV
+        value: production
+      # DATABASE CONFIGURATION (manual values)
       - key: DB_TYPE
         value: postgresdb
       - key: DB_POSTGRESDB_HOST
-        fromService:
-          name: n8n-database  
-          type: postgres
-          property: host
-      - key: DB_POSTGRESDB_USER
-        fromService:
-          name: n8n-database
-          type: postgres
-          property: user
-      - key: DB_POSTGRESDB_PASSWORD
-        fromService:
-          name: n8n-database
-          type: postgres
-          property: password
+        value: [paste-host-from-step-2]
       - key: DB_POSTGRESDB_DATABASE
-        fromService:
-          name: n8n-database
-          type: postgres
-          property: database
+        value: n8n
+      - key: DB_POSTGRESDB_USER
+        value: n8n_user
+      - key: DB_POSTGRESDB_PASSWORD
+        value: [paste-password-from-step-2]
       - key: DB_POSTGRESDB_PORT
         value: 5432
-      
-      # ADDITIONAL SETTINGS
-      - key: N8N_HOST
-        value: n8n-with-python.onrender.com  
-      - key: NODE_ENV
-        value: production
-      - key: N8N_ENCRYPTION_KEY
-        generateValue: true
-    
-    numInstances: 1
-
-  # NEW PostgreSQL Database Service 
-  - type: postgres
-    name: n8n-database  
-    plan: free  
-    databaseName: n8n
-    user: n8n_user

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+google-api-python-client>=2.108.0
+openai>=1.3.0
+gspread>=5.11.0
+google-auth-httplib2>=0.1.1
+google-auth-oauthlib>=1.0.0
+pydantic>=2.5.0
+python-dotenv>=1.0.0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add Dockerfile extending n8n with a Python venv and requirements plus Render deployment config and Python package list.
> 
> - **Infrastructure/Deployment**:
>   - **Docker**: New `Dockerfile` extending `n8n` to install Python, create a venv, install `requirements.txt`, symlink binaries, set `PATH`, and run as `node`.
>   - **Render**: Add `render.yaml` defining a web service using the `Dockerfile`, configuring auth/env vars and Postgres (`DB_*`) settings.
> - **Dependencies**:
>   - Add `requirements.txt` with `google-api-python-client`, `openai`, `gspread`, `google-auth-*`, `pydantic`, and `python-dotenv`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba48ed2bfb62b7fd32b4c21e838a2e35b741b9fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->