### PR TITLE
fix(RabbitMQ trigger): properly parse and forward queue arguments to assertQueue

### DIFF
--- a/packages/nodes-base/nodes/RabbitMQ/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/GenericFunctions.ts
@@ -66,11 +66,13 @@ export const parseQueueArguments = (options: Options) => {
 	const args = options?.arguments?.argument ?? [];
 
 	if (!Array.isArray(args) || args.length === 0) {
-		return options?.arguments;
+		return {};
 	}
 
 	return args.reduce<IDataObject>((acc, { key, value }) => {
-		acc[key] = value;
+		if (key && value !== undefined) {
+			acc[key] = value;
+		}
 		return acc;
 	}, {});
 };
@@ -97,11 +99,6 @@ export async function rabbitmqConnectQueue(
 						"durable": true
 					}
 				 */
-
-				this.logger.info('🔍 [RabbitMQ] Assert options for queue', {
-					queue,
-					arguments: queueArguments,
-				});
 				await channel.assertQueue(queue, { ...options, arguments: queueArguments });
 			} else {
 				await channel.checkQueue(queue);

--- a/packages/nodes-base/nodes/RabbitMQ/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/test/GenericFunctions.test.ts
@@ -17,7 +17,7 @@ import {
 	MessageTracker,
 	handleMessage,
 } from '../GenericFunctions';
-import type { Options, TriggerOptions } from '../types';
+import type { TriggerOptions } from '../types';
 
 describe('RabbitMQ GenericFunctions', () => {
 	const credentials = {


### PR DESCRIPTION
## Summary
#### Key Changes Made

- Added a new `parseQueueArguments()` function to properly parse queue arguments from the options
- Fixed the argument format conversion from the n8n UI format to the amqplib expected format
- Previously, arguments like `x-queue-type: quorum` weren't being passed correctly to RabbitMQ
- Added test cases for quorum queue creation with `x-queue-type` argument

https://github.com/user-attachments/assets/d30d2e43-d781-4908-a050-44888063b1e2
<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->


## Related Linear tickets, Github issues, and Community forum posts
fixes https://github.com/n8n-io/n8n/issues/19820
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->


- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Maps UI-provided queue arguments to amqplib format in `assertQueue` and adds tests, including quorum (`x-queue-type`) support.
> 
> - **RabbitMQ**:
>   - **Queue assertion**: Parse and map `options.arguments` via new `parseQueueArguments()` and pass to `channel.assertQueue(queue, { ...options, arguments })`.
> - **Tests**:
>   - Update expectations for `assertQueue` options shape.
>   - Add cases for no arguments and quorum queue with `x-queue-type: quorum`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9bfc320e2ecddf4354e0569917637ed84fc16c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->