### PR TITLE
fix: typeError in displayParameter when using invalid expressions

### DIFF
--- a/packages/frontend/editor-ui/src/composables/useNodeSettingsParameters.ts
+++ b/packages/frontend/editor-ui/src/composables/useNodeSettingsParameters.ts
@@ -234,10 +234,12 @@ export function useNodeSettingsParameters() {
 				} else {
 					// Contains probably no expression with a missing parameter so resolve
 					try {
-						nodeParams[key] = workflowHelpers.resolveExpression(
+						const resolved = workflowHelpers.resolveExpression(
 							value,
 							nodeParams,
 						) as NodeParameterValue;
+						// Ensure we never pass undefined/null to displayParameter
+						nodeParams[key] = resolved ?? '';
 					} catch {
 						// If expression is invalid ignore
 						nodeParams[key] = '';

--- a/packages/workflow/src/node-helpers.ts
+++ b/packages/workflow/src/node-helpers.ts
@@ -318,9 +318,9 @@ const checkConditions = (
 					const { from, to } = targetValue as { from: number; to: number };
 					return (propertyValue as number) >= from && (propertyValue as number) <= to;
 				}
-				if (key === 'includes') {
+				if (key === 'includes' && typeof propertyValue === 'string') {
 					// return false if propertyValue is undefined or null
-					return propertyValue && (propertyValue as string).includes(targetValue);
+					return propertyValue.includes(targetValue);
 				}
 				if (key === 'startsWith') {
 					return (propertyValue as string).startsWith(targetValue);

--- a/packages/workflow/src/node-helpers.ts
+++ b/packages/workflow/src/node-helpers.ts
@@ -319,7 +319,8 @@ const checkConditions = (
 					return (propertyValue as number) >= from && (propertyValue as number) <= to;
 				}
 				if (key === 'includes') {
-					return (propertyValue as string).includes(targetValue);
+					// return false if propertyValue is undefined or null
+					return propertyValue && (propertyValue as string).includes(targetValue);
 				}
 				if (key === 'startsWith') {
 					return (propertyValue as string).startsWith(targetValue);


### PR DESCRIPTION
## Summary

### Root Cause

1. **Expression evaluation failure**: When users enter invalid expressions like `{{ $json.invalid.path }}`, the expression evaluation fails and returns `undefined` instead of a valid value.

2. **Unsafe type assumptions**: The `checkConditions()` function assumes that `propertyValue` is always a string when checking display conditions, but doesn't validate for undefined values before calling string method `.includes()`.


https://github.com/user-attachments/assets/10913bf4-f26d-48f4-9d2f-bed0e83eacc3

### What's Fixed
**Expression resolution safety**: Added null/undefined checks after expression resolution in `useNodeSettingsParameters.ts` to ensure `undefined` or `null` values are converted to empty strings before being passed to `displayParameter`. 


https://github.com/user-attachments/assets/06073fea-6655-4960-a589-af1bf39f09da


<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
Fixes https://github.com/n8n-io/n8n/issues/20118


<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents TypeErrors by coercing undefined/null expression results to empty strings and only running `includes` on strings; adds tests for both cases.
> 
> - **Frontend (editor-ui)**
>   - Safeguard expression resolution in `useNodeSettingsParameters.ts`: coerce `undefined`/`null` to `''` before calling `displayParameter`.
>   - Tests: add cases validating undefined resolution handled gracefully and valid resolution passes resolved string.
> - **Workflow**
>   - `node-helpers.ts` `checkConditions`: run `_cnd.includes` only when the value is a string, avoiding errors on `undefined`/`null`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8d10f3749b26733f6fbfbeaf8e6e87ec5bb45ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->