### PR TITLE
feat(editor): Update workflows list endpoint to support filter by node type (no-changelog)

### DIFF
--- a/packages/@n8n/db/src/repositories/workflow.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow.repository.ts
@@ -435,6 +435,7 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 		this.applyTagsFilter(qb, filter);
 		this.applyProjectFilter(qb, filter);
 		this.applyParentFolderFilter(qb, filter);
+		this.applyNodeTypesFilter(qb, filter);
 		this.applyAvailableInMCPFilter(qb, filter);
 	}
 
@@ -543,6 +544,22 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 		}
 	}
 
+	private applyNodeTypesFilter(
+		qb: SelectQueryBuilder<WorkflowEntity>,
+		filter: ListQuery.Options['filter'],
+	): void {
+		const nodeTypes = isStringArray(filter?.nodeTypes) ? filter.nodeTypes : [];
+
+		if (!nodeTypes.length) return;
+
+		const { whereClause, parameters } = buildWorkflowsByNodesQuery(
+			nodeTypes,
+			this.globalConfig.database.type,
+		);
+
+		qb.andWhere(whereClause, parameters);
+	}
+
 	private applyOwnedByRelation(qb: SelectQueryBuilder<WorkflowEntity>): void {
 		// Check if 'shared' join already exists from project filter
 		if (!qb.expressionMap.aliases.find((alias) => alias.name === 'shared')) {
@@ -583,6 +600,7 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 				'workflow.createdAt',
 				'workflow.updatedAt',
 				'workflow.versionId',
+				'workflow.nodes',
 			]);
 			return;
 		}

--- a/packages/@n8n/db/src/repositories/workflow.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow.repository.ts
@@ -600,7 +600,6 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 				'workflow.createdAt',
 				'workflow.updatedAt',
 				'workflow.versionId',
-				'workflow.nodes',
 			]);
 			return;
 		}

--- a/packages/cli/src/middlewares/list-query/dtos/workflow.filter.dto.ts
+++ b/packages/cli/src/middlewares/list-query/dtos/workflow.filter.dto.ts
@@ -40,6 +40,12 @@ export class WorkflowFilter extends BaseFilter {
 	@Expose()
 	availableInMCP?: boolean;
 
+	@IsArray()
+	@IsString({ each: true })
+	@IsOptional()
+	@Expose()
+	nodeTypes?: string[];
+
 	static async fromString(rawFilter: string) {
 		return await this.toFilter(rawFilter, WorkflowFilter);
 	}

--- a/packages/cli/src/middlewares/list-query/dtos/workflow.select.dto.ts
+++ b/packages/cli/src/middlewares/list-query/dtos/workflow.select.dto.ts
@@ -12,6 +12,7 @@ export class WorkflowSelect extends BaseSelect {
 			'versionId',
 			'ownedBy', // non-entity field
 			'parentFolder',
+			'nodes',
 		]);
 	}
 

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -2037,7 +2037,6 @@ describe('GET /workflows?includeFolders=true', () => {
 
 			const folder = await createFolder(pp, { name: 'Test Folder' });
 
-			// Filter by node type should only return workflows, not folders
 			const response = await authOwnerAgent
 				.get('/workflows')
 				.query('filter={ "nodeTypes": ["n8n-nodes-base.httpRequest"] }&includeFolders=true')


### PR DESCRIPTION
## Summary

Added the option to filter workflows by node type and added the workflow nodes as part of the response data.

Will be used for the command bar to allow finding workflows that are using given node

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4215/update-workflows-list-endpoint-to-support-search-by-nodes


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
