### PR TITLE
build: Fix dependencies in eslint-plugin-community-nodes package

### DIFF
--- a/.github/workflows/release-standalone-package.yml
+++ b/.github/workflows/release-standalone-package.yml
@@ -11,6 +11,7 @@ on:
           - '@n8n/node-cli'
           - '@n8n/create-node'
           - '@n8n/scan-community-package'
+          - '@n8n/eslint-plugin-community-nodes'
 
 concurrency:
   group: release-package-${{ github.event.inputs.package }}

--- a/packages/@n8n/eslint-plugin-community-nodes/package.json
+++ b/packages/@n8n/eslint-plugin-community-nodes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@n8n/eslint-plugin-community-nodes",
   "type": "module",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "exports": {
     ".": {
       "types": "./dist/plugin.d.ts",
@@ -19,14 +19,14 @@
     "typecheck": "tsc --noEmit",
     "watch": "tsc --watch"
   },
+  "dependencies": {
+    "@typescript-eslint/utils": "^8.35.0"
+  },
   "devDependencies": {
     "@n8n/typescript-config": "workspace:*",
     "@n8n/vitest-config": "workspace:*",
     "@typescript-eslint/rule-tester": "^8.35.0",
-    "@typescript-eslint/utils": "^8.35.0",
-    "@typescript-eslint/typescript-estree": "^8.35.0",
     "rimraf": "catalog:",
-    "tsup": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/@n8n/scan-community-package/package.json
+++ b/packages/@n8n/scan-community-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@n8n/scan-community-package",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Static code analyser for n8n community packages",
   "license": "none",
   "bin": "scanner/cli.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -883,6 +883,9 @@ importers:
 
   packages/@n8n/eslint-plugin-community-nodes:
     dependencies:
+      '@typescript-eslint/utils':
+        specifier: ^8.35.0
+        version: 8.35.0(eslint@9.29.0(jiti@1.21.7))(typescript@5.9.2)
       eslint:
         specifier: '>= 9'
         version: 9.29.0(jiti@1.21.7)
@@ -896,18 +899,9 @@ importers:
       '@typescript-eslint/rule-tester':
         specifier: ^8.35.0
         version: 8.35.0(eslint@9.29.0(jiti@1.21.7))(typescript@5.9.2)
-      '@typescript-eslint/typescript-estree':
-        specifier: ^8.35.0
-        version: 8.35.0(typescript@5.9.2)
-      '@typescript-eslint/utils':
-        specifier: ^8.35.0
-        version: 8.35.0(eslint@9.29.0(jiti@1.21.7))(typescript@5.9.2)
       rimraf:
         specifier: 'catalog:'
         version: 6.0.1
-      tsup:
-        specifier: 'catalog:'
-        version: 8.5.0(@microsoft/api-extractor@7.52.1(@types/node@20.19.11))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.19.3)(typescript@5.9.2)
       typescript:
         specifier: 5.9.2
         version: 5.9.2
@@ -16405,8 +16399,8 @@ packages:
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
 
-  vue-component-type-helpers@3.0.8:
-    resolution: {integrity: sha512-WyR30Eq15Y/+odrUUMax6FmPbZwAp/HnC7qgR1r3lVFAcqwQ4wUoV79Mbh4SxDy3NiqDa+G4TOKD5xXSgBHo5A==}
+  vue-component-type-helpers@3.1.0-alpha.0:
+    resolution: {integrity: sha512-K1guwS1Oy0gNfBdIdIn8JMkUV+S38sriR1zf5dP+KkPS7/r5nHnPZUL74meY2CYlxYBH4qSQ+k7bpHfwiRvaMg==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -21830,7 +21824,7 @@ snapshots:
       storybook: 9.1.7(@testing-library/dom@10.4.0)(bufferutil@4.0.9)(prettier@3.6.2)(utf-8-validate@5.0.10)(vite@7.0.0(@types/node@20.19.11)(jiti@1.21.7)(sass@1.89.2)(terser@5.16.1)(tsx@4.19.3))
       type-fest: 2.19.0
       vue: 3.5.13(typescript@5.9.2)
-      vue-component-type-helpers: 3.0.8
+      vue-component-type-helpers: 3.1.0-alpha.0
 
   '@stylistic/eslint-plugin@5.0.0(eslint@9.29.0(jiti@1.21.7))':
     dependencies:
@@ -33307,7 +33301,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.12: {}
 
-  vue-component-type-helpers@3.0.8: {}
+  vue-component-type-helpers@3.1.0-alpha.0: {}
 
   vue-demi@0.14.10(vue@3.5.13(typescript@5.9.2)):
     dependencies:


### PR DESCRIPTION
## Summary

- `@typescript-eslint/utils` was listed as `devDependency` while it is used in the source of a rule. Moved to `dependencies`.
- Removed unused dependencies
- Made the plugin manually releasable

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
