### PR TITLE
chore: Add local development docs for environments feature

### DIFF
--- a/packages/cli/src/environments.ee/README.md
+++ b/packages/cli/src/environments.ee/README.md
@@ -1,0 +1,20 @@
+## Environments
+
+Environments enable enterprise users of n8n to effectively manage multiple deployments of n8n by synchronizing them using a shared git repostiory.
+
+[Link to docs](https://docs.n8n.io/source-control-environments/understand/environments/)
+
+### Local development
+
+When using the "usual" `pnpm run dev` scripts to start a local n8n instance, your local git settings and credentials will be picked up by the git repository that is cloned within n8n.
+
+This is why you should start n8n in a docker container when doing any kind of manual testing of this feature.
+
+Building a local docker image from your local checkout:
+`pnpm build:docker`
+
+Starting a local container using that image:
+`pnpm --filter n8n-containers stack:enterprise`
+
+The development experience of running n8n from source in a docker container still leaves a lot to be desired (lots of waiting for building and running the container).
+We should improve on this in the future.

--- a/packages/cli/src/environments.ee/source-control/source-control-git.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-git.service.ee.ts
@@ -27,6 +27,15 @@ import { sourceControlFoldersExistCheck } from './source-control-helper.ee';
 import { SourceControlPreferencesService } from './source-control-preferences.service.ee';
 import type { SourceControlPreferences } from './types/source-control-preferences';
 
+/**
+ * Service for interacting with locally cloned git repositories.
+ *
+ * For local development:
+ * Keep in mind that when running n8n locally using a pnpm dev script,
+ * the git credentials on your machine will be picked up by the git client
+ * used in this service.
+ * See the README for the environments feature for instructions to run n8n in a docker container.
+ */
 @Service()
 export class SourceControlGitService {
 	git: SimpleGit | null = null;


### PR DESCRIPTION
## Summary

Added docs that explain how to run n8n from source in docker to be able to manually test the environments feature reliably.
It's important that people who contribute to this service are aware that their local git credentials will affect their local n8n dev server.


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
