### PR TITLE
chore: Avoid command injection in https environment

### DIFF
--- a/packages/cli/src/environments.ee/source-control/source-control-git.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-git.service.ee.ts
@@ -113,7 +113,8 @@ export class SourceControlGitService {
 
 		if (preferences.connectionType === 'https') {
 			const credentials = await this.sourceControlPreferencesService.getDecryptedHttpsCredentials();
-			const credentialScript = `!f() { echo "username=${credentials.username}"; echo "password=${credentials.password}"; }; f`;
+			const escapeShellArg = (arg: string) => `'${arg.replace(/'/g, "'\"'\"'")}'`;
+			const credentialScript = `!f() { echo username=${escapeShellArg(credentials.username)}; echo password=${escapeShellArg(credentials.password)}; }; f`;
 
 			const httpsGitOptions = {
 				...this.gitOptions,


### PR DESCRIPTION
## Summary

This is a follow-up to https://github.com/n8n-io/n8n/pull/19482 to add that extra security.

Verified that authentication works as expected still in a local docker container.

## Related Linear tickets, Github issues, and Community forum posts

closes PAY-1754

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
