### PR TITLE
chore(core): Restrict user properties returned based on global scope

### DIFF
--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -45,8 +45,8 @@ export {
 	type User,
 	type UsersList,
 	usersListSchema,
-	userMemberSchema,
-	userAdminSchema,
+	userBaseSchema,
+	userDetailSchema,
 } from './schemas/user.schema';
 
 export {

--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -45,6 +45,8 @@ export {
 	type User,
 	type UsersList,
 	usersListSchema,
+	userMemberSchema,
+	userAdminSchema,
 } from './schemas/user.schema';
 
 export {

--- a/packages/@n8n/api-types/src/schemas/__tests__/user.schema.test.ts
+++ b/packages/@n8n/api-types/src/schemas/__tests__/user.schema.test.ts
@@ -1,4 +1,4 @@
-import { roleSchema, userListItemSchema, usersListSchema } from '../user.schema';
+import { roleSchema, userAdminSchema, userMemberSchema, usersListSchema } from '../user.schema';
 
 describe('user.schema', () => {
 	describe('roleSchema', () => {
@@ -14,7 +14,7 @@ describe('user.schema', () => {
 		});
 	});
 
-	describe('userListItemSchema', () => {
+	describe('userAdminSchema', () => {
 		test.each([
 			{
 				name: 'valid user',
@@ -80,7 +80,78 @@ describe('user.schema', () => {
 				isValid: false,
 			},
 		])('should validate $name', ({ data, isValid }) => {
-			const result = userListItemSchema.safeParse(data);
+			const result = userAdminSchema.safeParse(data);
+			expect(result.success).toBe(isValid);
+		});
+	});
+
+	describe('userMemberSchema', () => {
+		test.each([
+			{
+				name: 'valid user',
+				data: {
+					id: '123',
+					firstName: 'John',
+					lastName: 'Doe',
+					email: 'johndoe@example.com',
+					role: 'global:member',
+					isPending: false,
+					lastActive: '2023-10-01T12:00:00Z',
+					projects: ['project1', 'project2'],
+				},
+				isValid: true,
+			},
+			{
+				name: 'user with undefined fields',
+				data: {
+					id: '123',
+					role: 'global:member',
+					isPending: false,
+				},
+				isValid: true,
+			},
+			{
+				name: 'invalid email',
+				data: {
+					id: '123',
+					firstName: 'John',
+					lastName: 'Doe',
+					email: 'not-an-email',
+					role: 'global:member',
+					isPending: false,
+					lastActive: '2023-10-01T12:00:00Z',
+					projects: ['project1', 'project2'],
+				},
+				isValid: false,
+			},
+			{
+				name: 'missing required fields',
+				data: {
+					firstName: 'John',
+					lastName: 'Doe',
+					email: null,
+					role: 'global:member',
+					isPending: false,
+					lastActive: '2023-10-01T12:00:00Z',
+				},
+				isValid: false,
+			},
+			{
+				name: 'invalid role',
+				data: {
+					id: '123',
+					firstName: 'John',
+					lastName: 'Doe',
+					email: 'johndoe@example.com',
+					role: 'invalid-role',
+					isPending: false,
+					lastActive: '2023-10-01T12:00:00Z',
+					projects: ['project1', 'project2'],
+				},
+				isValid: false,
+			},
+		])('should validate $name', ({ data, isValid }) => {
+			const result = userMemberSchema.safeParse(data);
 			expect(result.success).toBe(isValid);
 		});
 	});

--- a/packages/@n8n/api-types/src/schemas/__tests__/user.schema.test.ts
+++ b/packages/@n8n/api-types/src/schemas/__tests__/user.schema.test.ts
@@ -1,4 +1,4 @@
-import { roleSchema, userAdminSchema, userMemberSchema, usersListSchema } from '../user.schema';
+import { roleSchema, userDetailSchema, userBaseSchema, usersListSchema } from '../user.schema';
 
 describe('user.schema', () => {
 	describe('roleSchema', () => {
@@ -14,7 +14,7 @@ describe('user.schema', () => {
 		});
 	});
 
-	describe('userAdminSchema', () => {
+	describe('userDetailSchema', () => {
 		test.each([
 			{
 				name: 'valid user',
@@ -80,12 +80,12 @@ describe('user.schema', () => {
 				isValid: false,
 			},
 		])('should validate $name', ({ data, isValid }) => {
-			const result = userAdminSchema.safeParse(data);
+			const result = userDetailSchema.safeParse(data);
 			expect(result.success).toBe(isValid);
 		});
 	});
 
-	describe('userMemberSchema', () => {
+	describe('userBaseSchema', () => {
 		test.each([
 			{
 				name: 'valid user',
@@ -151,7 +151,7 @@ describe('user.schema', () => {
 				isValid: false,
 			},
 		])('should validate $name', ({ data, isValid }) => {
-			const result = userMemberSchema.safeParse(data);
+			const result = userBaseSchema.safeParse(data);
 			expect(result.success).toBe(isValid);
 		});
 	});

--- a/packages/@n8n/api-types/src/schemas/user.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/user.schema.ts
@@ -22,12 +22,15 @@ export const userProjectSchema = z.object({
 	name: z.string(),
 });
 
-export const userListItemSchema = z.object({
+export const userMemberSchema = z.object({
 	id: z.string(),
 	firstName: z.string().nullable().optional(),
 	lastName: z.string().nullable().optional(),
 	email: z.string().email().nullable().optional(),
 	role: roleSchema.optional(),
+});
+
+export const userAdminSchema = userMemberSchema.extend({
 	isPending: z.boolean().optional(),
 	isOwner: z.boolean().optional(),
 	signInType: z.string().optional(),
@@ -41,8 +44,8 @@ export const userListItemSchema = z.object({
 
 export const usersListSchema = z.object({
 	count: z.number(),
-	items: z.array(userListItemSchema),
+	items: z.array(z.union([userMemberSchema, userAdminSchema])),
 });
 
-export type User = z.infer<typeof userListItemSchema>;
+export type User = z.infer<typeof userMemberSchema> | z.infer<typeof userAdminSchema>;
 export type UsersList = z.infer<typeof usersListSchema>;

--- a/packages/@n8n/api-types/src/schemas/user.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/user.schema.ts
@@ -44,7 +44,7 @@ export const userAdminSchema = userMemberSchema.extend({
 
 export const usersListSchema = z.object({
 	count: z.number(),
-	items: z.array(z.union([userAdminSchema, userMemberSchema])),
+	items: z.array(userAdminSchema),
 });
 
 export type User = z.infer<typeof userAdminSchema>;

--- a/packages/@n8n/api-types/src/schemas/user.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/user.schema.ts
@@ -44,8 +44,8 @@ export const userAdminSchema = userMemberSchema.extend({
 
 export const usersListSchema = z.object({
 	count: z.number(),
-	items: z.array(z.union([userMemberSchema, userAdminSchema])),
+	items: z.array(z.union([userAdminSchema, userMemberSchema])),
 });
 
-export type User = z.infer<typeof userMemberSchema> | z.infer<typeof userAdminSchema>;
+export type User = z.infer<typeof userAdminSchema>;
 export type UsersList = z.infer<typeof usersListSchema>;

--- a/packages/@n8n/api-types/src/schemas/user.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/user.schema.ts
@@ -22,7 +22,7 @@ export const userProjectSchema = z.object({
 	name: z.string(),
 });
 
-export const userMemberSchema = z.object({
+export const userBaseSchema = z.object({
 	id: z.string(),
 	firstName: z.string().nullable().optional(),
 	lastName: z.string().nullable().optional(),
@@ -30,7 +30,7 @@ export const userMemberSchema = z.object({
 	role: roleSchema.optional(),
 });
 
-export const userAdminSchema = userMemberSchema.extend({
+export const userDetailSchema = userBaseSchema.extend({
 	isPending: z.boolean().optional(),
 	isOwner: z.boolean().optional(),
 	signInType: z.string().optional(),
@@ -44,8 +44,8 @@ export const userAdminSchema = userMemberSchema.extend({
 
 export const usersListSchema = z.object({
 	count: z.number(),
-	items: z.array(userAdminSchema),
+	items: z.array(userDetailSchema),
 });
 
-export type User = z.infer<typeof userAdminSchema>;
+export type User = z.infer<typeof userDetailSchema>;
 export type UsersList = z.infer<typeof usersListSchema>;

--- a/packages/cli/src/controllers/users.controller.ts
+++ b/packages/cli/src/controllers/users.controller.ts
@@ -1,6 +1,8 @@
 import {
 	RoleChangeRequestDto,
 	SettingsUpdateRequestDto,
+	userAdminSchema,
+	userMemberSchema,
 	UsersListFilterDto,
 	usersListSchema,
 } from '@n8n/api-types';
@@ -74,6 +76,7 @@ export class UsersController {
 	private removeSupplementaryFields(
 		publicUsers: Array<Partial<PublicUser>>,
 		listQueryOptions: UsersListFilterDto,
+		full: boolean,
 	) {
 		const { select } = listQueryOptions;
 
@@ -93,7 +96,11 @@ export class UsersController {
 			}
 		}
 
-		return publicUsers;
+		if (full) {
+			return publicUsers.map((user) => userAdminSchema.parse(user));
+		}
+
+		return publicUsers.map((user) => userMemberSchema.parse(user));
 	}
 
 	@Get('/')

--- a/packages/cli/src/controllers/users.controller.ts
+++ b/packages/cli/src/controllers/users.controller.ts
@@ -45,7 +45,7 @@ import { FolderService } from '@/services/folder.service';
 import { ProjectService } from '@/services/project.service.ee';
 import { UserService } from '@/services/user.service';
 import { WorkflowService } from '@/workflows/workflow.service';
-import { AuthPrincipal, hasGlobalScope } from '@n8n/permissions';
+import { hasGlobalScope } from '@n8n/permissions';
 
 @RestController('/users')
 export class UsersController {

--- a/packages/cli/src/controllers/users.controller.ts
+++ b/packages/cli/src/controllers/users.controller.ts
@@ -143,7 +143,7 @@ export class UsersController {
 			items: this.removeSupplementaryFields(
 				publicUsers,
 				listQueryOptions,
-				hasGlobalScope(req.user, 'user:create'),
+				hasGlobalScope(req.user, 'user:create'), // user:create allows to manage users
 			),
 		});
 	}

--- a/packages/cli/src/controllers/users.controller.ts
+++ b/packages/cli/src/controllers/users.controller.ts
@@ -1,8 +1,8 @@
 import {
 	RoleChangeRequestDto,
 	SettingsUpdateRequestDto,
-	userAdminSchema,
-	userMemberSchema,
+	userDetailSchema,
+	userBaseSchema,
 	UsersListFilterDto,
 	usersListSchema,
 } from '@n8n/api-types';
@@ -98,11 +98,9 @@ export class UsersController {
 
 		const usersSeesAllDetails = hasGlobalScope(currentUser, 'user:create');
 		return publicUsers.map((user) => {
-			if (usersSeesAllDetails || user.id === currentUser.id) {
-				return userAdminSchema.parse(user);
-			} else {
-				return userMemberSchema.parse(user);
-			}
+			return usersSeesAllDetails || user.id === currentUser.id
+				? userDetailSchema.parse(user)
+				: userBaseSchema.parse(user);
 		});
 	}
 

--- a/packages/cli/src/controllers/users.controller.ts
+++ b/packages/cli/src/controllers/users.controller.ts
@@ -140,7 +140,11 @@ export class UsersController {
 
 		return usersListSchema.parse({
 			count,
-			items: this.removeSupplementaryFields(publicUsers, listQueryOptions),
+			items: this.removeSupplementaryFields(
+				publicUsers,
+				listQueryOptions,
+				hasGlobalScope(req.user, 'user:create'),
+			),
 		});
 	}
 

--- a/packages/cli/test/integration/users.api.test.ts
+++ b/packages/cli/test/integration/users.api.test.ts
@@ -778,6 +778,18 @@ describe('GET /users', () => {
 
 				expect(users).toBeInstanceOf(Array);
 
+				// Fields that should be restricted for members without user:create scope
+				const restrictionsFields = [
+					'mfaEnabled',
+					'settings',
+					'personalizationAnswers',
+					'inviteAcceptUrl',
+					'lastActiveAt',
+					'isOwner',
+					'signInType',
+					'projectRelations',
+				];
+
 				// Verify that sensitive/admin fields are NOT present for members
 				users.forEach((user: any) => {
 					// Basic fields should be present
@@ -785,14 +797,9 @@ describe('GET /users', () => {
 
 					if (user.id !== member1.id) {
 						// Admin-only fields should NOT be present
-						expect(user).not.toHaveProperty('mfaEnabled');
-						expect(user).not.toHaveProperty('settings');
-						expect(user).not.toHaveProperty('personalizationAnswers');
-						expect(user).not.toHaveProperty('inviteAcceptUrl');
-						expect(user).not.toHaveProperty('lastActiveAt');
-						expect(user).not.toHaveProperty('isOwner');
-						expect(user).not.toHaveProperty('signInType');
-						expect(user).not.toHaveProperty('projectRelations');
+						restrictionsFields.forEach((field) => {
+							expect(user).not.toHaveProperty(field);
+						});
 					} else {
 						// Admin-only fields should be present for own user
 						expect(user).toHaveProperty('mfaEnabled');

--- a/packages/cli/test/integration/users.api.test.ts
+++ b/packages/cli/test/integration/users.api.test.ts
@@ -783,15 +783,25 @@ describe('GET /users', () => {
 					// Basic fields should be present
 					expect(user).toHaveProperty('id');
 
-					// Admin-only fields should NOT be present
-					expect(user).not.toHaveProperty('mfaEnabled');
-					expect(user).not.toHaveProperty('settings');
-					expect(user).not.toHaveProperty('personalizationAnswers');
-					expect(user).not.toHaveProperty('inviteAcceptUrl');
-					expect(user).not.toHaveProperty('lastActiveAt');
-					expect(user).not.toHaveProperty('isOwner');
-					expect(user).not.toHaveProperty('signInType');
-					expect(user).not.toHaveProperty('projectRelations');
+					if (user.id !== member1.id) {
+						// Admin-only fields should NOT be present
+						expect(user).not.toHaveProperty('mfaEnabled');
+						expect(user).not.toHaveProperty('settings');
+						expect(user).not.toHaveProperty('personalizationAnswers');
+						expect(user).not.toHaveProperty('inviteAcceptUrl');
+						expect(user).not.toHaveProperty('lastActiveAt');
+						expect(user).not.toHaveProperty('isOwner');
+						expect(user).not.toHaveProperty('signInType');
+						expect(user).not.toHaveProperty('projectRelations');
+					} else {
+						// Admin-only fields should be present for own user
+						expect(user).toHaveProperty('mfaEnabled');
+						expect(user).toHaveProperty('settings');
+						expect(user).toHaveProperty('personalizationAnswers');
+						expect(user).toHaveProperty('lastActiveAt');
+						expect(user).toHaveProperty('isOwner');
+						expect(user).toHaveProperty('signInType');
+					}
 				});
 			});
 

--- a/packages/cli/test/integration/users.api.test.ts
+++ b/packages/cli/test/integration/users.api.test.ts
@@ -776,8 +776,10 @@ describe('GET /users', () => {
 
 				const users = response.body.data.items;
 
+				expect(users).toBeInstanceOf(Array);
+
 				// Verify that sensitive/admin fields are NOT present for members
-				users.forEach((user) => {
+				users.forEach((user: any) => {
 					// Basic fields should be present
 					expect(user).toHaveProperty('id');
 
@@ -798,8 +800,10 @@ describe('GET /users', () => {
 
 				const users = response.body.data.items;
 
+				expect(users).toBeInstanceOf(Array);
+
 				// Verify that admin fields ARE present for owners
-				const userWithMfa = users.find((u) => u.email === 'member1@n8n.io');
+				const userWithMfa = users.find((u: any) => u.email === 'member1@n8n.io');
 				expect(userWithMfa).toHaveProperty('mfaEnabled', true);
 				expect(userWithMfa).toHaveProperty('isOwner');
 				expect(userWithMfa).toHaveProperty('signInType');

--- a/packages/cli/test/integration/users.api.test.ts
+++ b/packages/cli/test/integration/users.api.test.ts
@@ -630,7 +630,6 @@ describe('GET /users', () => {
 				const nonPendingUser = responseData.items.find((user) => user.id === member1.id);
 
 				expect(nonPendingUser).toBeDefined();
-				expect(nonPendingUser!.isPending).toBe(false);
 				expect(nonPendingUser!.inviteAcceptUrl).toBeUndefined();
 			});
 		});


### PR DESCRIPTION
## Summary

This restricts the fields returned by the user list based on the callers scope.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-3052/audit-scope-usage-and-information-leaks-in-the-api

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
