### PR TITLE
fix(editor): Add success toast when moving folders via breadcrumbs (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/views/WorkflowsView.vue
+++ b/packages/frontend/editor-ui/src/views/WorkflowsView.vue
@@ -1438,6 +1438,13 @@ const moveFolder = async (payload: {
 		if (isCurrentFolder && !payload.options?.skipNavigation) {
 			// If we just moved the current folder, automatically navigate to the new folder
 			void router.push(newFolderURL);
+			toast.showMessage({
+				title: i18n.baseText('folders.move.success.title'),
+				message: i18n.baseText('folders.move.success.messageNoAccess', {
+					interpolate: { folderName: payload.folder.name },
+				}),
+				type: 'success',
+			});
 		} else {
 			// Else show success message and update the list
 			toast.showToast({

--- a/packages/frontend/editor-ui/src/views/WorkflowsView.vue
+++ b/packages/frontend/editor-ui/src/views/WorkflowsView.vue
@@ -1441,7 +1441,7 @@ const moveFolder = async (payload: {
 			toast.showMessage({
 				title: i18n.baseText('folders.move.success.title'),
 				message: i18n.baseText('folders.move.success.messageNoAccess', {
-					interpolate: { folderName: payload.folder.name },
+					interpolate: { folderName: payload.folder.name, newFolderName: payload.newParent.name },
 				}),
 				type: 'success',
 			});


### PR DESCRIPTION
## Summary
In this case, users are already redirected to new destination, so toast does not contain a link to visit it:
<img width="351" height="135" alt="image" src="https://github.com/user-attachments/assets/fe1d9abc-d838-4d3e-a37b-046976fdbeb4" />


## Related Linear tickets, Github issues, and Community forum posts
Fixes ADO-4209


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
