### PR TITLE
test: Fix insights service integration test race condition

### DIFF
--- a/packages/cli/src/modules/insights/__tests__/insights.service.integration.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.integration.test.ts
@@ -503,7 +503,7 @@ describe('InsightsService', () => {
 					type: 'success',
 					value: 1,
 					periodUnit: 'hour',
-					periodStart: now.minus({ days: 13, hours: 23, minutes: 59 }),
+					periodStart: now.minus({ days: 13, hours: 23 }),
 				});
 				await createCompactedInsightsEvent(workflow, {
 					type: 'success',
@@ -553,28 +553,28 @@ describe('InsightsService', () => {
 				workflowName: workflow2.name,
 				projectId: project.id,
 				projectName: project.name,
-				total: 7,
+				total: 8,
 				failed: 2,
 				runTime: 123,
-				succeeded: 5,
+				succeeded: 6,
 				timeSaved: 0,
 			});
-			expect(byWorkflow.data[0].failureRate).toBeCloseTo(2 / 7);
-			expect(byWorkflow.data[0].averageRunTime).toBeCloseTo(123 / 7);
+			expect(byWorkflow.data[0].failureRate).toBeCloseTo(2 / 8);
+			expect(byWorkflow.data[0].averageRunTime).toBeCloseTo(123 / 8);
 
 			expect(byWorkflow.data[1]).toMatchObject({
 				workflowId: workflow1.id,
 				workflowName: workflow1.name,
 				projectId: project.id,
 				projectName: project.name,
-				total: 6,
+				total: 7,
 				failed: 2,
 				runTime: 123,
-				succeeded: 4,
+				succeeded: 5,
 				timeSaved: 0,
 			});
-			expect(byWorkflow.data[1].failureRate).toBeCloseTo(2 / 6);
-			expect(byWorkflow.data[1].averageRunTime).toBeCloseTo(123 / 6);
+			expect(byWorkflow.data[1].failureRate).toBeCloseTo(2 / 7);
+			expect(byWorkflow.data[1].averageRunTime).toBeCloseTo(123 / 7);
 		});
 
 		test('compacted data are grouped by workflow correctly with sorting', async () => {


### PR DESCRIPTION
## Summary

Fix the race condition caused by test dates on the cusp of range limit 

See failing [job](https://github.com/n8n-io/n8n/actions/runs/18122885877/job/51572579249?pr=20058)

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

fixes PAY-3902

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
