### PR TITLE
feat: Export projects as json files in source control folder

### DIFF
--- a/packages/@n8n/api-types/src/schemas/source-controlled-file.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/source-controlled-file.schema.ts
@@ -1,6 +1,14 @@
 import { z } from 'zod';
 
-const FileTypeSchema = z.enum(['credential', 'workflow', 'tags', 'variables', 'file', 'folders']);
+const FileTypeSchema = z.enum([
+	'credential',
+	'workflow',
+	'tags',
+	'variables',
+	'file',
+	'folders',
+	'project',
+]);
 export const SOURCE_CONTROL_FILE_TYPE = FileTypeSchema.Values;
 
 const FileStatusSchema = z.enum([

--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control-export.service.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control-export.service.test.ts
@@ -1,19 +1,23 @@
 import type { SourceControlledFile } from '@n8n/api-types';
-import { GLOBAL_ADMIN_ROLE, PROJECT_OWNER_ROLE, User } from '@n8n/db';
 import type {
-	SharedCredentials,
-	SharedWorkflow,
 	FolderRepository,
-	TagRepository,
-	WorkflowTagMappingRepository,
+	Project,
+	ProjectRepository,
+	Role,
+	SharedCredentials,
 	SharedCredentialsRepository,
+	SharedWorkflow,
 	SharedWorkflowRepository,
-	WorkflowRepository,
 	TagEntity,
+	TagRepository,
+	WorkflowRepository,
 	WorkflowTagMapping,
+	WorkflowTagMappingRepository,
 } from '@n8n/db';
+import { GLOBAL_ADMIN_ROLE, PROJECT_OWNER_ROLE, User } from '@n8n/db';
 import { Container } from '@n8n/di';
-import { mock, captor } from 'jest-mock-extended';
+import { PROJECT_ADMIN_ROLE_SLUG, PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
+import { captor, mock } from 'jest-mock-extended';
 import { Cipher, type InstanceSettings } from 'n8n-core';
 import fsp from 'node:fs/promises';
 
@@ -34,6 +38,7 @@ describe('SourceControlExportService', () => {
 	const sharedWorkflowRepository = mock<SharedWorkflowRepository>();
 	const workflowRepository = mock<WorkflowRepository>();
 	const tagRepository = mock<TagRepository>();
+	const projectRepository = mock<ProjectRepository>();
 	const workflowTagMappingRepository = mock<WorkflowTagMappingRepository>();
 	const variablesService = mock<VariablesService>();
 	const folderRepository = mock<FolderRepository>();
@@ -43,6 +48,7 @@ describe('SourceControlExportService', () => {
 		mock(),
 		variablesService,
 		tagRepository,
+		projectRepository,
 		sharedCredentialsRepository,
 		sharedWorkflowRepository,
 		workflowRepository,
@@ -337,6 +343,90 @@ describe('SourceControlExportService', () => {
 			// Act & Assert
 			await expect(service.exportWorkflowsToWorkFolder([mock()])).rejects.toThrow(
 				'Workflow "TestWorkflow" (ID: test-workflow-id) has no owner',
+			);
+		});
+	});
+
+	describe('exportProjectsToWorkFolder', () => {
+		it('should export projects to work folder', async () => {
+			// Arrange
+			const candidates = [
+				mock<SourceControlledFile>({ id: 'project-id-1' }),
+				mock<SourceControlledFile>({ id: 'project-id-2' }),
+			];
+
+			projectRepository.find.mockResolvedValue([
+				mock<Project>({
+					id: 'project-id-1',
+					name: 'Project 1',
+					icon: { type: 'icon', value: 'icon.png' },
+					description: 'A test project',
+					type: 'personal',
+					projectRelations: [
+						{
+							role: mock<Role>({
+								slug: PROJECT_OWNER_ROLE_SLUG,
+							}),
+							user: mock<User>({ email: 'owner@example.com' }),
+						},
+					],
+				}),
+				mock<Project>({
+					id: 'project-id-2',
+					name: 'Team Project',
+					icon: { type: 'icon', value: 'team-icon.png' },
+					description: 'A team project',
+					type: 'team',
+					projectRelations: [
+						{
+							role: mock<Role>({
+								slug: PROJECT_ADMIN_ROLE_SLUG,
+							}),
+							user: mock<User>({ email: 'admin@example.com' }),
+						},
+					],
+				}),
+			]);
+
+			// Act
+			const result = await service.exportProjectsToWorkFolder(candidates);
+
+			console.log(result.files);
+
+			// Assert
+			expect(result.count).toBe(2);
+			expect(result.files).toHaveLength(2);
+			expect(result.files).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						id: 'project-id-1',
+						name: expect.stringContaining('project-id-1.json'),
+					}),
+					expect.objectContaining({
+						id: 'project-id-2',
+						name: expect.stringContaining('project-id-2.json'),
+					}),
+				]),
+			);
+		});
+
+		it('should throw an error if personal project has no owner', async () => {
+			// Arrange
+			const mockProject = mock<Project>({
+				id: 'project-id-2',
+				name: 'Project 2',
+				icon: { type: 'icon', value: 'icon2.png' },
+				description: 'A test project without owner',
+				type: 'personal',
+				projectRelations: [],
+			});
+			const candidates = [mock<SourceControlledFile>({ id: 'project-id-2' })];
+
+			projectRepository.find.mockResolvedValue([mockProject]);
+
+			// Act & Assert
+			await expect(service.exportProjectsToWorkFolder(candidates)).rejects.toThrow(
+				'Project Project 2 has no owner',
 			);
 		});
 	});

--- a/packages/cli/src/environments.ee/source-control/constants.ts
+++ b/packages/cli/src/environments.ee/source-control/constants.ts
@@ -2,6 +2,7 @@ export const SOURCE_CONTROL_PREFERENCES_DB_KEY = 'features.sourceControl';
 export const SOURCE_CONTROL_GIT_FOLDER = 'git';
 export const SOURCE_CONTROL_GIT_KEY_COMMENT = 'n8n deploy key';
 export const SOURCE_CONTROL_WORKFLOW_EXPORT_FOLDER = 'workflows';
+export const SOURCE_CONTROL_PROJECT_EXPORT_FOLDER = 'projects';
 export const SOURCE_CONTROL_CREDENTIAL_EXPORT_FOLDER = 'credential_stubs';
 export const SOURCE_CONTROL_VARIABLES_EXPORT_FILE = 'variable_stubs.json';
 export const SOURCE_CONTROL_TAGS_EXPORT_FILE = 'tags.json';

--- a/packages/cli/src/environments.ee/source-control/source-control-export.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-export.service.ee.ts
@@ -3,11 +3,12 @@ import { Logger } from '@n8n/backend-common';
 import type { IWorkflowDb } from '@n8n/db';
 import {
 	FolderRepository,
-	TagRepository,
-	WorkflowTagMappingRepository,
+	ProjectRepository,
 	SharedCredentialsRepository,
 	SharedWorkflowRepository,
+	TagRepository,
 	WorkflowRepository,
+	WorkflowTagMappingRepository,
 } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
@@ -16,18 +17,21 @@ import { In } from '@n8n/typeorm';
 import { rmSync } from 'fs';
 import { Credentials, InstanceSettings } from 'n8n-core';
 import { UnexpectedError, type ICredentialDataDecryptedObject } from 'n8n-workflow';
-import { writeFile as fsWriteFile, rm as fsRm } from 'node:fs/promises';
+import { rm as fsRm, writeFile as fsWriteFile } from 'node:fs/promises';
 import path from 'path';
 
+import { VariablesService } from '../variables/variables.service.ee';
 import {
 	SOURCE_CONTROL_CREDENTIAL_EXPORT_FOLDER,
 	SOURCE_CONTROL_GIT_FOLDER,
+	SOURCE_CONTROL_PROJECT_EXPORT_FOLDER,
 	SOURCE_CONTROL_TAGS_EXPORT_FILE,
 	SOURCE_CONTROL_WORKFLOW_EXPORT_FOLDER,
 } from './constants';
 import {
 	getCredentialExportPath,
 	getFoldersPath,
+	getProjectExportPath,
 	getVariablesPath,
 	getWorkflowExportPath,
 	readFoldersFromSourceControlFile,
@@ -41,9 +45,9 @@ import type { ExportableCredential } from './types/exportable-credential';
 import type { ExportableWorkflow } from './types/exportable-workflow';
 import type { RemoteResourceOwner } from './types/resource-owner';
 import type { SourceControlContext } from './types/source-control-context';
-import { VariablesService } from '../variables/variables.service.ee';
 
 import { formatWorkflow } from '@/workflows/workflow.formatter';
+import { ExportableProject } from './types/exportable-project';
 
 @Service()
 export class SourceControlExportService {
@@ -51,12 +55,15 @@ export class SourceControlExportService {
 
 	private workflowExportFolder: string;
 
+	private projectExportFolder: string;
+
 	private credentialExportFolder: string;
 
 	constructor(
 		private readonly logger: Logger,
 		private readonly variablesService: VariablesService,
 		private readonly tagRepository: TagRepository,
+		private readonly projectRepository: ProjectRepository,
 		private readonly sharedCredentialsRepository: SharedCredentialsRepository,
 		private readonly sharedWorkflowRepository: SharedWorkflowRepository,
 		private readonly workflowRepository: WorkflowRepository,
@@ -67,6 +74,7 @@ export class SourceControlExportService {
 	) {
 		this.gitFolder = path.join(instanceSettings.n8nFolder, SOURCE_CONTROL_GIT_FOLDER);
 		this.workflowExportFolder = path.join(this.gitFolder, SOURCE_CONTROL_WORKFLOW_EXPORT_FOLDER);
+		this.projectExportFolder = path.join(this.gitFolder, SOURCE_CONTROL_PROJECT_EXPORT_FOLDER);
 		this.credentialExportFolder = path.join(
 			this.gitFolder,
 			SOURCE_CONTROL_CREDENTIAL_EXPORT_FOLDER,
@@ -461,6 +469,71 @@ export class SourceControlExportService {
 		} catch (error) {
 			this.logger.error('Failed to export credentials to work folder', { error });
 			throw new UnexpectedError('Failed to export credentials to work folder', { cause: error });
+		}
+	}
+
+	async exportProjectsToWorkFolder(candidates: SourceControlledFile[]): Promise<ExportResult> {
+		try {
+			sourceControlFoldersExistCheck([this.projectExportFolder], true);
+
+			const projectIds = candidates.map((e) => e.id);
+			const projects = await this.projectRepository.find({
+				where: { id: In(projectIds) },
+				relations: { projectRelations: { user: true, role: true } },
+			});
+
+			await Promise.all(
+				projects.map(async (project) => {
+					const fileName = getProjectExportPath(project.id, this.projectExportFolder);
+
+					let owner: RemoteResourceOwner;
+
+					if (project.type === 'personal') {
+						const personalOwner = project.projectRelations.find(
+							(r) => r.role.slug === PROJECT_OWNER_ROLE_SLUG,
+						);
+
+						if (!personalOwner) {
+							throw new UnexpectedError(`Project ${project.name} has no owner`);
+						}
+
+						owner = {
+							type: 'personal',
+							projectId: project.id,
+							projectName: project.name,
+							personalEmail: personalOwner.user.email,
+						};
+					} else {
+						owner = {
+							type: 'team',
+							teamId: project.id,
+							teamName: project.name,
+						};
+					}
+					const sanitizedProject: ExportableProject = {
+						id: project.id,
+						name: project.name,
+						icon: project.icon,
+						description: project.description,
+						owner,
+					};
+
+					this.logger.debug(`Writing project ${project.id} to ${fileName}`);
+					return await fsWriteFile(fileName, JSON.stringify(sanitizedProject, null, 2));
+				}),
+			);
+
+			return {
+				count: projects.length,
+				folder: this.projectExportFolder,
+				files: projects.map((project) => ({
+					id: project.id,
+					name: getProjectExportPath(project.id, this.projectExportFolder),
+				})),
+			};
+		} catch (error) {
+			this.logger.error('Failed to export projects to work folder', { error });
+			throw new UnexpectedError('Failed to export projects to work folder', { cause: error });
 		}
 	}
 }

--- a/packages/cli/src/environments.ee/source-control/source-control-export.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-export.service.ee.ts
@@ -532,7 +532,7 @@ export class SourceControlExportService {
 				})),
 			};
 		} catch (error) {
-			this.logger.error('Failed to export projects to work folder', { error });
+			if (error instanceof UnexpectedError) throw error;
 			throw new UnexpectedError('Failed to export projects to work folder', { cause: error });
 		}
 	}

--- a/packages/cli/src/environments.ee/source-control/source-control-helper.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-helper.ee.ts
@@ -30,6 +30,10 @@ export function getWorkflowExportPath(workflowId: string, workflowExportFolder: 
 	return safeJoinPath(workflowExportFolder, `${workflowId}.json`);
 }
 
+export function getProjectExportPath(projectId: string, projectExportFolder: string): string {
+	return safeJoinPath(projectExportFolder, `${projectId}.json`);
+}
+
 export function getCredentialExportPath(
 	credentialId: string,
 	credentialExportFolder: string,

--- a/packages/cli/src/environments.ee/source-control/types/exportable-project.ts
+++ b/packages/cli/src/environments.ee/source-control/types/exportable-project.ts
@@ -3,7 +3,7 @@ import type { RemoteResourceOwner } from './resource-owner';
 export interface ExportableProject {
 	id: string;
 	name: string;
-	icon: { type: 'emoji' | 'icon'; value: string };
-	description: string;
+	icon: { type: 'emoji' | 'icon'; value: string } | null;
+	description: string | null;
 	owner: RemoteResourceOwner;
 }

--- a/packages/cli/src/environments.ee/source-control/types/exportable-project.ts
+++ b/packages/cli/src/environments.ee/source-control/types/exportable-project.ts
@@ -1,0 +1,9 @@
+import type { RemoteResourceOwner } from './resource-owner';
+
+export interface ExportableProject {
+	id: string;
+	name: string;
+	icon: { type: 'emoji' | 'icon'; value: string };
+	description: string;
+	owner: RemoteResourceOwner;
+}


### PR DESCRIPTION
## Summary

Add logic to export a project to a json file inside the source control folder

Out of scope: Triggering the export on push is out of scope for this ticket

## Related Linear tickets, Github issues, and Community forum posts

resolves PAY-3895

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
