### PR TITLE
fix(core): Add workflow cancellation reasons

### DIFF
--- a/packages/@n8n/db/src/repositories/execution.repository.ts
+++ b/packages/@n8n/db/src/repositories/execution.repository.ts
@@ -796,7 +796,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 	}
 
 	async stopDuringRun(execution: IExecutionResponse) {
-		const error = new ExecutionCancelledError(execution.id);
+		const error = new ExecutionCancelledError(execution.id, 'manual');
 
 		execution.data ??= { resultData: { runData: {} } };
 		execution.data.resultData.error = {

--- a/packages/cli/src/__tests__/active-executions.test.ts
+++ b/packages/cli/src/__tests__/active-executions.test.ts
@@ -275,7 +275,7 @@ describe('ActiveExecutions', () => {
 		});
 
 		test('Should cancel ongoing executions', async () => {
-			activeExecutions.stopExecution(executionId);
+			activeExecutions.stopExecution(executionId, 'manual');
 
 			expect(responsePromise.reject).toHaveBeenCalledWith(expect.any(ExecutionCancelledError));
 			expect(workflowExecution.cancel).toHaveBeenCalledTimes(1);
@@ -284,7 +284,7 @@ describe('ActiveExecutions', () => {
 
 		test('Should cancel waiting executions', async () => {
 			activeExecutions.setStatus(executionId, 'waiting');
-			activeExecutions.stopExecution(executionId);
+			activeExecutions.stopExecution(executionId, 'manual');
 
 			expect(responsePromise.reject).toHaveBeenCalledWith(expect.any(ExecutionCancelledError));
 			expect(workflowExecution.cancel).not.toHaveBeenCalled();
@@ -336,8 +336,8 @@ describe('ActiveExecutions', () => {
 			expect(removeAllCaptor.value.sort()).toEqual([newExecutionId1, waitingExecutionId1].sort());
 
 			expect(stopExecutionSpy).toHaveBeenCalledTimes(2);
-			expect(stopExecutionSpy).toHaveBeenCalledWith(newExecutionId1);
-			expect(stopExecutionSpy).toHaveBeenCalledWith(waitingExecutionId1);
+			expect(stopExecutionSpy).toHaveBeenCalledWith(newExecutionId1, 'system');
+			expect(stopExecutionSpy).toHaveBeenCalledWith(waitingExecutionId1, 'system');
 			expect(stopExecutionSpy).not.toHaveBeenCalledWith(newExecutionId2);
 			expect(stopExecutionSpy).not.toHaveBeenCalledWith(waitingExecutionId2);
 
@@ -362,10 +362,10 @@ describe('ActiveExecutions', () => {
 			);
 
 			expect(stopExecutionSpy).toHaveBeenCalledTimes(4);
-			expect(stopExecutionSpy).toHaveBeenCalledWith(newExecutionId1);
-			expect(stopExecutionSpy).toHaveBeenCalledWith(waitingExecutionId1);
-			expect(stopExecutionSpy).toHaveBeenCalledWith(newExecutionId2);
-			expect(stopExecutionSpy).toHaveBeenCalledWith(waitingExecutionId2);
+			expect(stopExecutionSpy).toHaveBeenCalledWith(newExecutionId1, 'system');
+			expect(stopExecutionSpy).toHaveBeenCalledWith(waitingExecutionId1, 'system');
+			expect(stopExecutionSpy).toHaveBeenCalledWith(newExecutionId2, 'system');
+			expect(stopExecutionSpy).toHaveBeenCalledWith(waitingExecutionId2, 'system');
 		});
 	});
 });

--- a/packages/cli/src/__tests__/workflow-runner.test.ts
+++ b/packages/cli/src/__tests__/workflow-runner.test.ts
@@ -424,7 +424,7 @@ describe('workflow timeout with startedAt', () => {
 
 		// ASSERT
 		// The execution should be stopped immediately because the timeout has already elapsed
-		expect(mockStopExecution).toHaveBeenCalledWith('1');
+		expect(mockStopExecution).toHaveBeenCalledWith('1', 'timeout');
 	});
 
 	it('should use original timeout logic when startedAt is not provided', async () => {

--- a/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
@@ -280,7 +280,7 @@ export class TestRunnerService {
 
 		// Listen to the abort signal to stop the execution in case test run is cancelled
 		abortSignal.addEventListener('abort', () => {
-			this.activeExecutions.stopExecution(executionId);
+			this.activeExecutions.stopExecution(executionId, 'manual');
 		});
 
 		// Wait for the execution to finish

--- a/packages/cli/src/executions/__tests__/execution.service.test.ts
+++ b/packages/cli/src/executions/__tests__/execution.service.test.ts
@@ -125,7 +125,7 @@ describe('ExecutionService', () => {
 				 * Assert
 				 */
 				expect(concurrencyControl.remove).not.toHaveBeenCalled();
-				expect(activeExecutions.stopExecution).toHaveBeenCalledWith(execution.id);
+				expect(activeExecutions.stopExecution).toHaveBeenCalledWith(execution.id, 'manual');
 				expect(waitTracker.stopExecution).not.toHaveBeenCalled();
 				expect(executionRepository.stopDuringRun).toHaveBeenCalledWith(execution);
 			});
@@ -152,7 +152,7 @@ describe('ExecutionService', () => {
 				 * Assert
 				 */
 				expect(concurrencyControl.remove).not.toHaveBeenCalled();
-				expect(activeExecutions.stopExecution).toHaveBeenCalledWith(execution.id);
+				expect(activeExecutions.stopExecution).toHaveBeenCalledWith(execution.id, 'manual');
 				expect(waitTracker.stopExecution).toHaveBeenCalledWith(execution.id);
 				expect(executionRepository.stopDuringRun).toHaveBeenCalledWith(execution);
 			});
@@ -221,7 +221,7 @@ describe('ExecutionService', () => {
 					 * Assert
 					 */
 					expect(stopInRegularModeSpy).not.toHaveBeenCalled();
-					expect(activeExecutions.stopExecution).toHaveBeenCalledWith(execution.id);
+					expect(activeExecutions.stopExecution).toHaveBeenCalledWith(execution.id, 'manual');
 					expect(executionRepository.stopDuringRun).toHaveBeenCalledWith(execution);
 
 					expect(concurrencyControl.remove).not.toHaveBeenCalled();

--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -528,7 +528,7 @@ export class ExecutionService {
 		}
 
 		if (this.activeExecutions.has(execution.id)) {
-			this.activeExecutions.stopExecution(execution.id);
+			this.activeExecutions.stopExecution(execution.id, 'manual');
 		}
 
 		if (this.waitTracker.has(execution.id)) {
@@ -540,7 +540,7 @@ export class ExecutionService {
 
 	private async stopInScalingMode(execution: IExecutionResponse) {
 		if (this.activeExecutions.has(execution.id)) {
-			this.activeExecutions.stopExecution(execution.id);
+			this.activeExecutions.stopExecution(execution.id, 'manual');
 		}
 
 		if (this.waitTracker.has(execution.id)) {

--- a/packages/cli/src/scaling/__tests__/scaling.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/scaling.service.test.ts
@@ -296,7 +296,10 @@ describe('ScalingService', () => {
 
 			expect(job.progress).toHaveBeenCalledWith({ kind: 'abort-job' });
 			expect(job.discard).toHaveBeenCalled();
-			expect(job.moveToFailed).toHaveBeenCalledWith(new ExecutionCancelledError('123'), true);
+			expect(job.moveToFailed).toHaveBeenCalledWith(
+				new ExecutionCancelledError('123', 'manual'),
+				true,
+			);
 			expect(result).toBe(true);
 		});
 

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -230,7 +230,7 @@ export class ScalingService {
 			if (await job.isActive()) {
 				await job.progress({ kind: 'abort-job' }); // being processed by worker
 				await job.discard(); // prevent retries
-				await job.moveToFailed(new ExecutionCancelledError(job.data.executionId), true); // remove from queue
+				await job.moveToFailed(new ExecutionCancelledError(job.data.executionId, 'manual'), true); // remove from queue
 				return true;
 			}
 

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -316,10 +316,10 @@ export class WorkflowRunner {
 					timeout = Math.max(timeout - (now - data.startedAt.getTime()), 0);
 				}
 				if (timeout === 0) {
-					this.activeExecutions.stopExecution(executionId);
+					this.activeExecutions.stopExecution(executionId, 'timeout');
 				} else {
 					executionTimeout = setTimeout(() => {
-						void this.activeExecutions.stopExecution(executionId);
+						void this.activeExecutions.stopExecution(executionId, 'timeout');
 					}, timeout);
 				}
 			}
@@ -407,7 +407,7 @@ export class WorkflowRunner {
 					// We use "getLifecycleHooksForScalingWorker" as "getLifecycleHooksForScalingMain" does not contain the
 					// "workflowExecuteAfter" which we require.
 					const lifecycleHooks = getLifecycleHooksForScalingWorker(data, executionId);
-					const error = new ExecutionCancelledError(executionId);
+					const error = new ExecutionCancelledError(executionId, 'manual');
 					await this.processError(
 						error,
 						new Date(),

--- a/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
@@ -2568,5 +2568,74 @@ describe('WorkflowExecute', () => {
 			);
 			expect(runHook.mock.lastCall[1][0].status).toEqual('canceled');
 		});
+
+		test('should set status to canceled when execution timeout is reached', async () => {
+			// Arrange - create a workflow with multiple nodes
+			const trigger = createNodeData({ name: 'trigger', type: 'n8n-nodes-base.manualTrigger' });
+			const node1 = createNodeData({ name: 'node1' });
+			const node2 = createNodeData({ name: 'node2' });
+
+			const workflow = new DirectedGraph()
+				.addNodes(trigger, node1, node2)
+				.addConnections({ from: trigger, to: node1 }, { from: node1, to: node2 })
+				.toWorkflow({
+					name: 'test-workflow',
+					nodeTypes,
+					active: false,
+				});
+
+			const waitPromise = createDeferredPromise<IRun>();
+			const additionalData = Helpers.WorkflowExecuteAdditionalData(waitPromise);
+
+			const workflowExecute = new WorkflowExecute(additionalData, 'manual');
+
+			// Create initial execution data with nodes queued to execute
+			const runExecutionData: IRunExecutionData = {
+				startData: {},
+				resultData: {
+					runData: {},
+				},
+				executionData: {
+					contextData: {},
+					nodeExecutionStack: [
+						{
+							node: node1,
+							data: {
+								main: [[{ json: { value: 1 } }]],
+							},
+							source: null,
+						},
+						{
+							node: node2,
+							data: {
+								main: [[{ json: { value: 2 } }]],
+							},
+							source: null,
+						},
+					],
+					metadata: {},
+					waitingExecution: {},
+					waitingExecutionSource: {},
+				},
+			};
+
+			// @ts-expect-error private data
+			workflowExecute.runExecutionData = runExecutionData;
+
+			// Set execution timeout to a time in the past to trigger immediate timeout on first loop iteration
+			additionalData.executionTimeoutTimestamp = Date.now() - 1000;
+
+			// Act - run the workflow
+			const promise = workflowExecute.processRunExecutionData(workflow);
+			const result = await promise;
+
+			// Assert - verify status was set to canceled and timedOut flag was set
+			// @ts-expect-error private data
+			expect(workflowExecute.status).toBe('canceled');
+			// @ts-expect-error private data
+			expect(workflowExecute.timedOut).toBe(true);
+			expect(result.status).toBe('canceled');
+			expect(result.data.resultData.error?.extra?.reason).toContain('timeout');
+		});
 	});
 });

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/supply-data-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/supply-data-context.test.ts
@@ -256,7 +256,7 @@ describe('SupplyDataContext', () => {
 
 	describe('addExecutionDataFunctions', () => {
 		it('should preserve canceled status when execution is aborted and output has error', async () => {
-			const errorData = new ExecutionCancelledError('Execution was aborted');
+			const errorData = new ExecutionCancelledError('Execution was aborted', 'manual');
 			const abortedSignal = mock<AbortSignal>({ aborted: true });
 			const mockHooks = {
 				runHook: jest.fn().mockResolvedValue(undefined),

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -80,6 +80,7 @@ import { TriggersAndPollers } from './triggers-and-pollers';
 
 export class WorkflowExecute {
 	private status: ExecutionStatus = 'new';
+	private timedOut: boolean = false;
 
 	private readonly abortController = new AbortController();
 
@@ -1531,6 +1532,7 @@ export class WorkflowExecute {
 						Date.now() >= this.additionalData.executionTimeoutTimestamp
 					) {
 						this.status = 'canceled';
+						this.timedOut = true;
 					}
 
 					if (this.status === 'canceled') {
@@ -2249,7 +2251,10 @@ export class WorkflowExecute {
 						return await this.processSuccessExecution(
 							startedAt,
 							workflow,
-							new ExecutionCancelledError(this.additionalData.executionId ?? 'unknown'),
+							new ExecutionCancelledError(
+								this.additionalData.executionId ?? 'unknown',
+								this.timedOut ? 'timeout' : 'manual',
+							),
 							closeFunction,
 						);
 					}

--- a/packages/workflow/src/errors/execution-cancelled.error.ts
+++ b/packages/workflow/src/errors/execution-cancelled.error.ts
@@ -1,10 +1,12 @@
 import { ExecutionBaseError } from './abstract/execution-base.error';
 
+export type ExecutionCancellationReason = 'timeout' | 'manual' | 'system' | 'unknown';
+
 export class ExecutionCancelledError extends ExecutionBaseError {
-	constructor(executionId: string) {
+	constructor(executionId: string, reason: ExecutionCancellationReason) {
 		super('The execution was cancelled', {
 			level: 'warning',
-			extra: { executionId },
+			extra: { executionId, reason },
 		});
 	}
 }

--- a/packages/workflow/src/errors/index.ts
+++ b/packages/workflow/src/errors/index.ts
@@ -5,6 +5,7 @@ export { UserError, type UserErrorOptions } from './base/user.error';
 export { ApplicationError } from '@n8n/errors';
 export { ExpressionError } from './expression.error';
 export { ExecutionCancelledError } from './execution-cancelled.error';
+export type { ExecutionCancellationReason } from './execution-cancelled.error';
 export { NodeApiError } from './node-api.error';
 export { NodeOperationError } from './node-operation.error';
 export { WorkflowConfigurationError } from './workflow-configuration.error';

--- a/packages/workflow/src/utils.ts
+++ b/packages/workflow/src/utils.ts
@@ -211,7 +211,7 @@ export const sleep = async (ms: number): Promise<void> =>
 export const sleepWithAbort = async (ms: number, abortSignal?: AbortSignal): Promise<void> =>
 	await new Promise((resolve, reject) => {
 		if (abortSignal?.aborted) {
-			reject(new ExecutionCancelledError(''));
+			reject(new ExecutionCancelledError('', 'manual'));
 			return;
 		}
 
@@ -219,7 +219,7 @@ export const sleepWithAbort = async (ms: number, abortSignal?: AbortSignal): Pro
 
 		const abortHandler = () => {
 			clearTimeout(timeout);
-			reject(new ExecutionCancelledError(''));
+			reject(new ExecutionCancelledError('', 'manual'));
 		};
 
 		abortSignal?.addEventListener('abort', abortHandler, { once: true });


### PR DESCRIPTION
## Summary

Add workflow cancellation reasons.

This will make it easier to know why a given workflow was cancelled - e.g., system (shutdown), timeout, manually requested.

TODO: manually verify that the reason actually shows up in the database as expected, additional unit test coverage.

## Related Linear tickets, Github issues, and Community forum posts

Closes [CAT-603](https://linear.app/n8n/issue/CAT-603).


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
