### PR TITLE
feat: Use safer joins in scan-community-package (no-changelog)

### DIFF
--- a/packages/@n8n/scan-community-package/scanner/scanner.mjs
+++ b/packages/@n8n/scan-community-package/scanner/scanner.mjs
@@ -16,6 +16,38 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TEMP_DIR = tmp.dirSync({ unsafeCleanup: true }).name;
 const registry = 'https://registry.npmjs.org/';
 
+/**
+ * Checks if the given childPath is contained within the parentPath. Resolves
+ * the paths before comparing them, so that relative paths are also supported.
+ */
+export function isContainedWithin(parentPath, childPath) {
+	parentPath = path.resolve(parentPath);
+	childPath = path.resolve(childPath);
+
+	if (parentPath === childPath) {
+		return true;
+	}
+
+	return childPath.startsWith(parentPath + path.sep);
+}
+
+/**
+ * Joins the given paths to the parentPath, ensuring that the resulting path
+ * is still contained within the parentPath. If not, it throws an error to
+ * prevent path traversal vulnerabilities.
+ *
+ * @throws {UnexpectedError} If the resulting path is not contained within the parentPath.
+ */
+export function safeJoinPath(parentPath, ...paths) {
+	const candidate = path.join(parentPath, ...paths);
+
+	if (!isContainedWithin(parentPath, candidate)) {
+		throw new Error(
+			`Path traversal detected, refusing to join paths: ${parentPath} and ${JSON.stringify(paths)}`,
+		);
+	}
+}
+
 export const resolvePackage = (packageSpec) => {
 	// Validate input to prevent command injection
 	if (!/^[a-zA-Z0-9@/_.-]+$/.test(packageSpec)) {
@@ -57,7 +89,7 @@ const downloadAndExtractPackage = async (packageName, version) => {
 		}
 
 		// Unpack the tarball
-		const packageDir = path.join(TEMP_DIR, `${packageName}-${version}`);
+		const packageDir = safeJoinPath(TEMP_DIR, `${packageName}-${version}`);
 		fs.mkdirSync(packageDir, { recursive: true });
 		const tarResult = spawnSync(
 			'tar',
@@ -70,7 +102,7 @@ const downloadAndExtractPackage = async (packageName, version) => {
 		if (tarResult.status !== 0) {
 			throw new Error(`tar extraction failed: ${tarResult.stderr?.toString()}`);
 		}
-		fs.unlinkSync(path.join(TEMP_DIR, tarballName));
+		fs.unlinkSync(safeJoinPath(TEMP_DIR, tarballName));
 
 		return packageDir;
 	} catch (error) {


### PR DESCRIPTION
## Summary

Addressing Aikido findings, use safer joins that can't escape the root folder on scan-community-package tool. This didn't really seem exploitable, but why not.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/SEC-332/packagesn8nscan-community-packagescannerscannermjs-has-suspected-file

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
