### PR TITLE
feat: GCP secrets with no latest version no longer breaks secret sync

### DIFF
--- a/packages/cli/src/modules/external-secrets.ee/providers/__tests__/gcp-secrets-manager.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/__tests__/gcp-secrets-manager.test.ts
@@ -86,7 +86,7 @@ describe('GCP Secrets Manager', () => {
 		expect(gcpSecretsManager.getSecret('#@&')).toBeUndefined(); // unsupported name
 	});
 
-	it('should handle errors when accessing secret versions', async () => {
+	it('should throw a generic error when accessing secret versions', async () => {
 		/**
 		 * Arrange
 		 */
@@ -132,6 +132,63 @@ describe('GCP Secrets Manager', () => {
 		/**
 		 * Act
 		 */
+		try {
+			await gcpSecretsManager.connect();
+			await gcpSecretsManager.update();
+		} catch (error) {
+			expect(error).toBeInstanceOf(Error);
+			expect(error.message).toBe('test error');
+		}
+	});
+
+	it('should handle errors when accessing secret versions (NOT_FOUND)', async () => {
+		/**
+		 * Arrange
+		 */
+		const PROJECT_ID = 'my-project-id';
+
+		const SECRETS: Record<string, string> = {
+			secret1: 'value1',
+			secret2: 'value2',
+			secret3: '', // no value
+			'#@&': 'value', // unsupported name
+		};
+
+		await gcpSecretsManager.init(
+			mock<GcpSecretsManagerContext>({
+				settings: { serviceAccountKey: `{ "project_id": "${PROJECT_ID}" }` },
+			}),
+		);
+
+		const listSpy = jest
+			.spyOn(SecretManagerServiceClient.prototype, 'listSecrets')
+			// @ts-expect-error Partial mock
+			.mockResolvedValue([
+				[
+					{ name: `projects/${PROJECT_ID}/secrets/secret1` },
+					{ name: `projects/${PROJECT_ID}/secrets/secret2` },
+					{ name: `projects/${PROJECT_ID}/secrets/secret3` },
+					{ name: `projects/${PROJECT_ID}/secrets/#@&` },
+				],
+			]);
+
+		const getSpy = jest
+			.spyOn(SecretManagerServiceClient.prototype, 'accessSecretVersion')
+			.mockImplementationOnce(() => {
+				const error = new Error('NOT_FOUND') as any;
+				error.code = 5;
+				throw error;
+			})
+			.mockImplementation(async ({ name }: { name: string }) => {
+				const secretName = name.split('/')[3];
+				return [
+					{ payload: { data: Buffer.from(SECRETS[secretName]) } },
+				] as GcpSecretVersionResponse[];
+			});
+
+		/**
+		 * Act
+		 */
 		await gcpSecretsManager.connect();
 		await gcpSecretsManager.update();
 
@@ -147,6 +204,157 @@ describe('GCP Secrets Manager', () => {
 		});
 		expect(getSpy).toHaveBeenCalledWith({
 			name: `projects/${PROJECT_ID}/secrets/secret3/versions/latest`,
+		});
+		expect(getSpy).not.toHaveBeenCalledWith({
+			name: `projects/${PROJECT_ID}/secrets/#@&/versions/latest`,
+		});
+
+		expect(gcpSecretsManager.getSecret('secret1')).toBeUndefined(); // error case
+		expect(gcpSecretsManager.getSecret('secret2')).toBe('value2');
+		expect(gcpSecretsManager.getSecret('secret3')).toBeUndefined(); // no value
+		expect(gcpSecretsManager.getSecret('#@&')).toBeUndefined(); // unsupported name
+	});
+
+	it('should handle errors when accessing secret versions (PERMISSION_DENIED)', async () => {
+		/**
+		 * Arrange
+		 */
+		const PROJECT_ID = 'my-project-id';
+
+		const SECRETS: Record<string, string> = {
+			secret1: 'value1',
+			secret2: 'value2',
+			secret3: '', // no value
+			'#@&': 'value', // unsupported name
+		};
+
+		await gcpSecretsManager.init(
+			mock<GcpSecretsManagerContext>({
+				settings: { serviceAccountKey: `{ "project_id": "${PROJECT_ID}" }` },
+			}),
+		);
+
+		const listSpy = jest
+			.spyOn(SecretManagerServiceClient.prototype, 'listSecrets')
+			// @ts-expect-error Partial mock
+			.mockResolvedValue([
+				[
+					{ name: `projects/${PROJECT_ID}/secrets/secret1` },
+					{ name: `projects/${PROJECT_ID}/secrets/secret2` },
+					{ name: `projects/${PROJECT_ID}/secrets/secret3` },
+					{ name: `projects/${PROJECT_ID}/secrets/#@&` },
+				],
+			]);
+
+		const getSpy = jest
+			.spyOn(SecretManagerServiceClient.prototype, 'accessSecretVersion')
+			.mockImplementationOnce(() => {
+				const error = new Error('PERMISSION_DENIED') as any;
+				error.code = 7;
+				throw error;
+			})
+			.mockImplementation(async ({ name }: { name: string }) => {
+				const secretName = name.split('/')[3];
+				return [
+					{ payload: { data: Buffer.from(SECRETS[secretName]) } },
+				] as GcpSecretVersionResponse[];
+			});
+
+		/**
+		 * Act
+		 */
+		await gcpSecretsManager.connect();
+		await gcpSecretsManager.update();
+
+		/**
+		 * Assert
+		 */
+		expect(listSpy).toHaveBeenCalled();
+		expect(getSpy).toHaveBeenCalledWith({
+			name: `projects/${PROJECT_ID}/secrets/secret1/versions/latest`,
+		});
+		expect(getSpy).toHaveBeenCalledWith({
+			name: `projects/${PROJECT_ID}/secrets/secret2/versions/latest`,
+		});
+		expect(getSpy).toHaveBeenCalledWith({
+			name: `projects/${PROJECT_ID}/secrets/secret3/versions/latest`,
+		});
+		expect(getSpy).not.toHaveBeenCalledWith({
+			name: `projects/${PROJECT_ID}/secrets/#@&/versions/latest`,
+		});
+
+		expect(gcpSecretsManager.getSecret('secret1')).toBeUndefined(); // error case
+		expect(gcpSecretsManager.getSecret('secret2')).toBe('value2');
+		expect(gcpSecretsManager.getSecret('secret3')).toBeUndefined(); // no value
+		expect(gcpSecretsManager.getSecret('#@&')).toBeUndefined(); // unsupported name
+	});
+
+	it('should handle errors when accessing secret versions (UNAVAILABLE)', async () => {
+		/**
+		 * Arrange
+		 */
+		const PROJECT_ID = 'my-project-id';
+
+		const SECRETS: Record<string, string> = {
+			secret1: 'value1',
+			secret2: 'value2',
+			secret3: '', // no value
+			'#@&': 'value', // unsupported name
+		};
+
+		await gcpSecretsManager.init(
+			mock<GcpSecretsManagerContext>({
+				settings: { serviceAccountKey: `{ "project_id": "${PROJECT_ID}" }` },
+			}),
+		);
+
+		const listSpy = jest
+			.spyOn(SecretManagerServiceClient.prototype, 'listSecrets')
+			// @ts-expect-error Partial mock
+			.mockResolvedValue([
+				[
+					{ name: `projects/${PROJECT_ID}/secrets/secret1` },
+					{ name: `projects/${PROJECT_ID}/secrets/secret2` },
+					{ name: `projects/${PROJECT_ID}/secrets/secret3` },
+					{ name: `projects/${PROJECT_ID}/secrets/#@&` },
+				],
+			]);
+
+		const getSpy = jest
+			.spyOn(SecretManagerServiceClient.prototype, 'accessSecretVersion')
+			.mockImplementationOnce(() => {
+				const error = new Error('PERMISSION_DENIED') as any;
+				error.code = 14;
+				throw error;
+			})
+			.mockImplementation(async ({ name }: { name: string }) => {
+				const secretName = name.split('/')[3];
+				return [
+					{ payload: { data: Buffer.from(SECRETS[secretName]) } },
+				] as GcpSecretVersionResponse[];
+			});
+
+		/**
+		 * Act
+		 */
+		await gcpSecretsManager.connect();
+		await gcpSecretsManager.update();
+
+		/**
+		 * Assert
+		 */
+		expect(listSpy).toHaveBeenCalled();
+		expect(getSpy).toHaveBeenCalledWith({
+			name: `projects/${PROJECT_ID}/secrets/secret1/versions/latest`,
+		});
+		expect(getSpy).toHaveBeenCalledWith({
+			name: `projects/${PROJECT_ID}/secrets/secret2/versions/latest`,
+		});
+		expect(getSpy).toHaveBeenCalledWith({
+			name: `projects/${PROJECT_ID}/secrets/secret3/versions/latest`,
+		});
+		expect(getSpy).not.toHaveBeenCalledWith({
+			name: `projects/${PROJECT_ID}/secrets/#@&/versions/latest`,
 		});
 
 		expect(gcpSecretsManager.getSecret('secret1')).toBeUndefined(); // error case

--- a/packages/cli/src/modules/external-secrets.ee/providers/__tests__/gcp-secrets-manager.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/__tests__/gcp-secrets-manager.test.ts
@@ -105,7 +105,7 @@ describe('GCP Secrets Manager', () => {
 			}),
 		);
 
-		const listSpy = jest
+		jest
 			.spyOn(SecretManagerServiceClient.prototype, 'listSecrets')
 			// @ts-expect-error Partial mock
 			.mockResolvedValue([
@@ -117,7 +117,7 @@ describe('GCP Secrets Manager', () => {
 				],
 			]);
 
-		const getSpy = jest
+		jest
 			.spyOn(SecretManagerServiceClient.prototype, 'accessSecretVersion')
 			.mockImplementationOnce(() => {
 				throw new Error('test error');

--- a/packages/cli/src/modules/external-secrets.ee/providers/gcp-secrets-manager/gcp-secrets-manager.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/gcp-secrets-manager/gcp-secrets-manager.ts
@@ -112,11 +112,11 @@ export class GcpSecretsManager implements SecretsProvider {
 				versions = await this.client.accessSecretVersion({
 					name: `projects/${projectId}/secrets/${name}/versions/latest`,
 				});
-			} catch (err) {
+			} catch (error) {
 				this.logger.info(
 					`Skipping GCP secret: ${name}, version: latest as the version is not accessible`,
 					{
-						error: ensureError(err),
+						error: ensureError(error),
 					},
 				);
 			}

--- a/packages/cli/src/modules/external-secrets.ee/providers/gcp-secrets-manager/gcp-secrets-manager.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/gcp-secrets-manager/gcp-secrets-manager.ts
@@ -113,8 +113,8 @@ export class GcpSecretsManager implements SecretsProvider {
 					name: `projects/${projectId}/secrets/${name}/versions/latest`,
 				});
 			} catch (err) {
-				this.logger.error(
-					`GCP Secrets Manager provider failed to access secret: ${name}, version: latest`,
+				this.logger.info(
+					`Skipping GCP secret: ${name}, version: latest as the version is not accessible`,
 					{
 						error: ensureError(err),
 					},


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR introduces a fix that swallows errors accessing a single secret by their version, discarding the inaccessible secret version

Before fix:

<img width="1852" height="935" alt="image" src="https://github.com/user-attachments/assets/a0724280-be4e-4b86-9cfb-d429656bc690" />

After fix:

<img width="1852" height="935" alt="image" src="https://github.com/user-attachments/assets/c827589a-c0cd-4366-bd36-f64a40ee1415" />


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
