### PR TITLE
fix(editor): Show running edge with existing run data as green

### DIFF
--- a/packages/frontend/editor-ui/src/composables/useCanvasMapping.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasMapping.test.ts
@@ -2198,7 +2198,7 @@ describe('useCanvasMapping', () => {
 								source: [],
 								executionStatus: 'canceled',
 								data: {
-									[NodeConnectionTypes.Main]: [[{ json: {} }]],
+									[NodeConnectionTypes.Main]: [[]],
 								},
 							},
 						];
@@ -2723,6 +2723,458 @@ describe('useCanvasMapping', () => {
 
 				// Should show the count for output index 1 (3 items), not index 0 (1 item)
 				expect(mappedConnections.value[0]?.label).toBe('3 items');
+			});
+		});
+
+		describe('getConnectionData', () => {
+			it('should return running status when source node is executing and has no run data', () => {
+				const workflowsStore = mockedStore(useWorkflowsStore);
+				const [manualTriggerNode, setNode] = mockNodes.slice(0, 2);
+				const nodes = [manualTriggerNode, setNode];
+				const connections = {
+					[manualTriggerNode.name]: {
+						[NodeConnectionTypes.Main]: [
+							[{ node: setNode.name, type: NodeConnectionTypes.Main, index: 0 }],
+						],
+					},
+				};
+				const workflowObject = createTestWorkflowObject({
+					nodes,
+					connections,
+				});
+
+				workflowsStore.isNodeExecuting.mockImplementation((nodeName: string) => {
+					return nodeName === manualTriggerNode.name;
+				});
+				workflowsStore.getWorkflowResultDataByNodeName.mockReturnValue(null);
+
+				const { connections: mappedConnections } = useCanvasMapping({
+					nodes: ref(nodes),
+					connections: ref(connections),
+					workflowObject: ref(workflowObject) as Ref<Workflow>,
+				});
+
+				expect(mappedConnections.value[0]?.data?.status).toEqual('running');
+			});
+
+			it('should return pinned status when source has both pinned data and execution data', () => {
+				const workflowsStore = mockedStore(useWorkflowsStore);
+				const [manualTriggerNode, setNode] = mockNodes.slice(0, 2);
+				const nodes = [manualTriggerNode, setNode];
+				const connections = {
+					[manualTriggerNode.name]: {
+						[NodeConnectionTypes.Main]: [
+							[{ node: setNode.name, type: NodeConnectionTypes.Main, index: 0 }],
+						],
+					},
+				};
+				const workflowObject = createTestWorkflowObject({
+					nodes,
+					connections,
+				});
+
+				workflowsStore.pinDataByNodeName.mockImplementation((nodeName: string) => {
+					return nodeName === manualTriggerNode.name ? [{ json: {} }] : undefined;
+				});
+				workflowsStore.getWorkflowResultDataByNodeName.mockImplementation((nodeName: string) => {
+					if (nodeName === manualTriggerNode.name) {
+						return [
+							{
+								startTime: 0,
+								executionTime: 0,
+								executionIndex: 0,
+								source: [],
+								data: {
+									[NodeConnectionTypes.Main]: [[{ json: {} }]],
+								},
+							},
+						];
+					}
+					return null;
+				});
+
+				const { connections: mappedConnections } = useCanvasMapping({
+					nodes: ref(nodes),
+					connections: ref(connections),
+					workflowObject: ref(workflowObject) as Ref<Workflow>,
+				});
+
+				expect(mappedConnections.value[0]?.data?.status).toEqual('pinned');
+			});
+
+			it('should return error status when source node has issues', () => {
+				const workflowsStore = mockedStore(useWorkflowsStore);
+				const node = createTestNode({
+					name: 'Test Node',
+					issues: { typeUnknown: true },
+				} as Partial<INode>);
+				const setNode = createTestNode({ name: 'Set Node' });
+				const nodes = [node, setNode];
+				const connections = {
+					[node.name]: {
+						[NodeConnectionTypes.Main]: [
+							[{ node: setNode.name, type: NodeConnectionTypes.Main, index: 0 }],
+						],
+					},
+				};
+				const workflowObject = createTestWorkflowObject({ nodes, connections });
+
+				workflowsStore.getWorkflowRunData = {};
+
+				const { connections: mappedConnections } = useCanvasMapping({
+					nodes: ref(nodes),
+					connections: ref(connections),
+					workflowObject: ref(workflowObject) as Ref<Workflow>,
+				});
+
+				expect(mappedConnections.value[0]?.data?.status).toEqual('error');
+			});
+
+			it('should return success status when node has run data and no issues', () => {
+				const workflowsStore = mockedStore(useWorkflowsStore);
+				const [manualTriggerNode, setNode] = mockNodes.slice(0, 2);
+				const nodes = [manualTriggerNode, setNode];
+				const connections = {
+					[manualTriggerNode.name]: {
+						[NodeConnectionTypes.Main]: [
+							[{ node: setNode.name, type: NodeConnectionTypes.Main, index: 0 }],
+						],
+					},
+				};
+				const workflowObject = createTestWorkflowObject({
+					nodes,
+					connections,
+				});
+
+				workflowsStore.getWorkflowResultDataByNodeName.mockImplementation((nodeName: string) => {
+					if (nodeName === manualTriggerNode.name) {
+						return [
+							{
+								startTime: 0,
+								executionTime: 0,
+								executionIndex: 0,
+								source: [],
+								executionStatus: 'success',
+								data: {
+									[NodeConnectionTypes.Main]: [[{ json: {} }]],
+								},
+							},
+						];
+					}
+					return null;
+				});
+
+				const { connections: mappedConnections } = useCanvasMapping({
+					nodes: ref(nodes),
+					connections: ref(connections),
+					workflowObject: ref(workflowObject) as Ref<Workflow>,
+				});
+
+				expect(mappedConnections.value[0]?.data?.status).toEqual('success');
+			});
+
+			it('should return undefined status when no conditions are met', () => {
+				const workflowsStore = mockedStore(useWorkflowsStore);
+				const [manualTriggerNode, setNode] = mockNodes.slice(0, 2);
+				const nodes = [manualTriggerNode, setNode];
+				const connections = {
+					[manualTriggerNode.name]: {
+						[NodeConnectionTypes.Main]: [
+							[{ node: setNode.name, type: NodeConnectionTypes.Main, index: 0 }],
+						],
+					},
+				};
+				const workflowObject = createTestWorkflowObject({
+					nodes,
+					connections,
+				});
+
+				workflowsStore.getWorkflowResultDataByNodeName.mockReturnValue(null);
+				workflowsStore.pinDataByNodeName.mockReturnValue(undefined);
+
+				const { connections: mappedConnections } = useCanvasMapping({
+					nodes: ref(nodes),
+					connections: ref(connections),
+					workflowObject: ref(workflowObject) as Ref<Workflow>,
+				});
+
+				expect(mappedConnections.value[0]?.data?.status).toBeUndefined();
+			});
+
+			it('should include maxConnections when ports have connection limits', () => {
+				const workflowsStore = mockedStore(useWorkflowsStore);
+				const manualTriggerNode = mockNode({
+					name: 'Manual Trigger',
+					type: MANUAL_TRIGGER_NODE_TYPE,
+				});
+				const setNode = mockNode({
+					name: 'Set',
+					type: SET_NODE_TYPE,
+				});
+				const nodes = [manualTriggerNode, setNode];
+				const connections = {
+					[manualTriggerNode.name]: {
+						[NodeConnectionTypes.Main]: [
+							[{ node: setNode.name, type: NodeConnectionTypes.Main, index: 0 }],
+						],
+					},
+				};
+
+				// Mock node type with maxConnections
+				const nodeTypeWithMaxConnections = mockNodeTypeDescription({
+					name: SET_NODE_TYPE,
+					inputs: [
+						{
+							type: NodeConnectionTypes.Main,
+							maxConnections: 1,
+						},
+					],
+				});
+
+				const pinia = createTestingPinia({
+					initialState: {
+						[STORES.NODE_TYPES]: {
+							nodeTypes: {
+								[MANUAL_TRIGGER_NODE_TYPE]: {
+									1: mockNodeTypeDescription({
+										name: MANUAL_TRIGGER_NODE_TYPE,
+									}),
+								},
+								[SET_NODE_TYPE]: {
+									1: nodeTypeWithMaxConnections,
+								},
+							},
+						},
+					},
+				});
+				setActivePinia(pinia);
+
+				const workflowObject = createTestWorkflowObject({
+					nodes,
+					connections,
+				});
+
+				const { connections: mappedConnections } = useCanvasMapping({
+					nodes: ref(nodes),
+					connections: ref(connections),
+					workflowObject: ref(workflowObject) as Ref<Workflow>,
+				});
+
+				expect(mappedConnections.value[0]?.data?.maxConnections).toEqual(1);
+			});
+
+			it('should use minimum maxConnections when multiple ports have limits', () => {
+				const manualTriggerNode = mockNode({
+					name: 'Manual Trigger',
+					type: MANUAL_TRIGGER_NODE_TYPE,
+				});
+				const setNode = mockNode({
+					name: 'Set',
+					type: SET_NODE_TYPE,
+				});
+				const nodes = [manualTriggerNode, setNode];
+				const connections = {
+					[manualTriggerNode.name]: {
+						[NodeConnectionTypes.Main]: [
+							[{ node: setNode.name, type: NodeConnectionTypes.Main, index: 0 }],
+						],
+					},
+				};
+
+				// Mock node types with different maxConnections
+				const pinia = createTestingPinia({
+					initialState: {
+						[STORES.NODE_TYPES]: {
+							nodeTypes: {
+								[MANUAL_TRIGGER_NODE_TYPE]: {
+									1: mockNodeTypeDescription({
+										name: MANUAL_TRIGGER_NODE_TYPE,
+										outputs: [
+											{
+												type: NodeConnectionTypes.Main,
+												maxConnections: 3,
+											},
+										],
+									}),
+								},
+								[SET_NODE_TYPE]: {
+									1: mockNodeTypeDescription({
+										name: SET_NODE_TYPE,
+										inputs: [
+											{
+												type: NodeConnectionTypes.Main,
+												maxConnections: 2,
+											},
+										],
+									}),
+								},
+							},
+						},
+					},
+				});
+				setActivePinia(pinia);
+
+				const workflowObject = createTestWorkflowObject({
+					nodes,
+					connections,
+				});
+
+				const { connections: mappedConnections } = useCanvasMapping({
+					nodes: ref(nodes),
+					connections: ref(connections),
+					workflowObject: ref(workflowObject) as Ref<Workflow>,
+				});
+
+				expect(mappedConnections.value[0]?.data?.maxConnections).toEqual(2);
+			});
+
+			it('should not include maxConnections when no limits are set', () => {
+				const workflowsStore = mockedStore(useWorkflowsStore);
+				const [manualTriggerNode, setNode] = mockNodes.slice(0, 2);
+				const nodes = [manualTriggerNode, setNode];
+				const connections = {
+					[manualTriggerNode.name]: {
+						[NodeConnectionTypes.Main]: [
+							[{ node: setNode.name, type: NodeConnectionTypes.Main, index: 0 }],
+						],
+					},
+				};
+				const workflowObject = createTestWorkflowObject({
+					nodes,
+					connections,
+				});
+
+				const { connections: mappedConnections } = useCanvasMapping({
+					nodes: ref(nodes),
+					connections: ref(connections),
+					workflowObject: ref(workflowObject) as Ref<Workflow>,
+				});
+
+				expect(mappedConnections.value[0]?.data?.maxConnections).toBeUndefined();
+			});
+
+			it('should preserve existing connection data', () => {
+				const workflowsStore = mockedStore(useWorkflowsStore);
+				const [manualTriggerNode, setNode] = mockNodes.slice(0, 2);
+				const nodes = [manualTriggerNode, setNode];
+				const connections = {
+					[manualTriggerNode.name]: {
+						[NodeConnectionTypes.Main]: [
+							[
+								{
+									node: setNode.name,
+									type: NodeConnectionTypes.Main,
+									index: 0,
+									// Add custom data that should be preserved
+									customField: 'customValue',
+								},
+							],
+						],
+					},
+				};
+				const workflowObject = createTestWorkflowObject({
+					nodes,
+					connections,
+				});
+
+				const { connections: mappedConnections } = useCanvasMapping({
+					nodes: ref(nodes),
+					connections: ref(connections),
+					workflowObject: ref(workflowObject) as Ref<Workflow>,
+				});
+
+				expect(mappedConnections.value[0]?.data?.source.node).toEqual(manualTriggerNode.name);
+				expect(mappedConnections.value[0]?.data?.target.node).toEqual(setNode.name);
+			});
+
+			it('should handle connections with different output indices correctly', () => {
+				const workflowsStore = mockedStore(useWorkflowsStore);
+				const [manualTriggerNode, setNode] = mockNodes.slice(0, 2);
+				const nodes = [manualTriggerNode, setNode];
+				const connections = {
+					[manualTriggerNode.name]: {
+						[NodeConnectionTypes.Main]: [
+							[], // index 0 - empty
+							[{ node: setNode.name, type: NodeConnectionTypes.Main, index: 0 }], // index 1
+						],
+					},
+				};
+				const workflowObject = createTestWorkflowObject({
+					nodes,
+					connections,
+				});
+
+				workflowsStore.getWorkflowResultDataByNodeName.mockImplementation((nodeName: string) => {
+					if (nodeName === manualTriggerNode.name) {
+						return [
+							{
+								startTime: 0,
+								executionTime: 0,
+								executionIndex: 0,
+								source: [],
+								executionStatus: 'success',
+								data: {
+									[NodeConnectionTypes.Main]: [
+										[{ json: {} }], // index 0
+										[{ json: {} }, { json: {} }], // index 1
+									],
+								},
+							},
+						];
+					}
+					return null;
+				});
+
+				const { connections: mappedConnections } = useCanvasMapping({
+					nodes: ref(nodes),
+					connections: ref(connections),
+					workflowObject: ref(workflowObject) as Ref<Workflow>,
+				});
+
+				expect(mappedConnections.value[0]?.data?.status).toEqual('success');
+			});
+
+			it('should handle different connection types', () => {
+				const workflowsStore = mockedStore(useWorkflowsStore);
+				const [manualTriggerNode, setNode] = mockNodes.slice(0, 2);
+				const nodes = [manualTriggerNode, setNode];
+				const connections = {
+					[manualTriggerNode.name]: {
+						[NodeConnectionTypes.AiTool]: [
+							[{ node: setNode.name, type: NodeConnectionTypes.AiTool, index: 0 }],
+						],
+					},
+				};
+				const workflowObject = createTestWorkflowObject({
+					nodes,
+					connections,
+				});
+
+				workflowsStore.getWorkflowResultDataByNodeName.mockImplementation((nodeName: string) => {
+					if (nodeName === manualTriggerNode.name) {
+						return [
+							{
+								startTime: 0,
+								executionTime: 0,
+								executionIndex: 0,
+								source: [],
+								executionStatus: 'success',
+								data: {
+									[NodeConnectionTypes.AiTool]: [[{ json: {} }]],
+								},
+							},
+						];
+					}
+					return null;
+				});
+
+				const { connections: mappedConnections } = useCanvasMapping({
+					nodes: ref(nodes),
+					connections: ref(connections),
+					workflowObject: ref(workflowObject) as Ref<Workflow>,
+				});
+
+				expect(mappedConnections.value[0]?.data?.status).toEqual('success');
 			});
 		});
 	});

--- a/packages/frontend/editor-ui/src/composables/useCanvasMapping.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasMapping.test.ts
@@ -28,6 +28,7 @@ import { useRootStore } from '@n8n/stores/useRootStore';
 import { createTestingPinia } from '@pinia/testing';
 import { MarkerType } from '@vue-flow/core';
 import { mock } from 'vitest-mock-extended';
+import { useNodeTypesStore } from '@/stores/nodeTypes.store';
 
 vi.mock('@n8n/i18n', async (importOriginal) => ({
 	...(await importOriginal()),
@@ -2902,7 +2903,7 @@ describe('useCanvasMapping', () => {
 			});
 
 			it('should include maxConnections when ports have connection limits', () => {
-				const workflowsStore = mockedStore(useWorkflowsStore);
+				const nodeTypesStore = mockedStore(useNodeTypesStore);
 				const manualTriggerNode = mockNode({
 					name: 'Manual Trigger',
 					type: MANUAL_TRIGGER_NODE_TYPE,
@@ -2931,23 +2932,16 @@ describe('useCanvasMapping', () => {
 					],
 				});
 
-				const pinia = createTestingPinia({
-					initialState: {
-						[STORES.NODE_TYPES]: {
-							nodeTypes: {
-								[MANUAL_TRIGGER_NODE_TYPE]: {
-									1: mockNodeTypeDescription({
-										name: MANUAL_TRIGGER_NODE_TYPE,
-									}),
-								},
-								[SET_NODE_TYPE]: {
-									1: nodeTypeWithMaxConnections,
-								},
-							},
-						},
+				nodeTypesStore.nodeTypes = {
+					[MANUAL_TRIGGER_NODE_TYPE]: {
+						1: mockNodeTypeDescription({
+							name: MANUAL_TRIGGER_NODE_TYPE,
+						}),
 					},
-				});
-				setActivePinia(pinia);
+					[SET_NODE_TYPE]: {
+						1: nodeTypeWithMaxConnections,
+					},
+				};
 
 				const workflowObject = createTestWorkflowObject({
 					nodes,
@@ -2964,6 +2958,7 @@ describe('useCanvasMapping', () => {
 			});
 
 			it('should use minimum maxConnections when multiple ports have limits', () => {
+				const nodeTypesStore = mockedStore(useNodeTypesStore);
 				const manualTriggerNode = mockNode({
 					name: 'Manual Trigger',
 					type: MANUAL_TRIGGER_NODE_TYPE,
@@ -2981,38 +2976,30 @@ describe('useCanvasMapping', () => {
 					},
 				};
 
-				// Mock node types with different maxConnections
-				const pinia = createTestingPinia({
-					initialState: {
-						[STORES.NODE_TYPES]: {
-							nodeTypes: {
-								[MANUAL_TRIGGER_NODE_TYPE]: {
-									1: mockNodeTypeDescription({
-										name: MANUAL_TRIGGER_NODE_TYPE,
-										outputs: [
-											{
-												type: NodeConnectionTypes.Main,
-												maxConnections: 3,
-											},
-										],
-									}),
+				nodeTypesStore.nodeTypes = {
+					[MANUAL_TRIGGER_NODE_TYPE]: {
+						1: mockNodeTypeDescription({
+							name: MANUAL_TRIGGER_NODE_TYPE,
+							outputs: [
+								{
+									type: NodeConnectionTypes.Main,
+									maxConnections: 3,
 								},
-								[SET_NODE_TYPE]: {
-									1: mockNodeTypeDescription({
-										name: SET_NODE_TYPE,
-										inputs: [
-											{
-												type: NodeConnectionTypes.Main,
-												maxConnections: 2,
-											},
-										],
-									}),
-								},
-							},
-						},
+							],
+						}),
 					},
-				});
-				setActivePinia(pinia);
+					[SET_NODE_TYPE]: {
+						1: mockNodeTypeDescription({
+							name: SET_NODE_TYPE,
+							inputs: [
+								{
+									type: NodeConnectionTypes.Main,
+									maxConnections: 2,
+								},
+							],
+						}),
+					},
+				};
 
 				const workflowObject = createTestWorkflowObject({
 					nodes,
@@ -3029,7 +3016,6 @@ describe('useCanvasMapping', () => {
 			});
 
 			it('should not include maxConnections when no limits are set', () => {
-				const workflowsStore = mockedStore(useWorkflowsStore);
 				const [manualTriggerNode, setNode] = mockNodes.slice(0, 2);
 				const nodes = [manualTriggerNode, setNode];
 				const connections = {
@@ -3054,7 +3040,6 @@ describe('useCanvasMapping', () => {
 			});
 
 			it('should preserve existing connection data', () => {
-				const workflowsStore = mockedStore(useWorkflowsStore);
 				const [manualTriggerNode, setNode] = mockNodes.slice(0, 2);
 				const nodes = [manualTriggerNode, setNode];
 				const connections = {

--- a/packages/frontend/editor-ui/src/composables/useCanvasMapping.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasMapping.ts
@@ -689,8 +689,8 @@ export function useCanvasMapping({
 
 	function getConnectionData(connection: CanvasConnection): CanvasConnectionData {
 		const { type, index } = parseCanvasConnectionHandleString(connection.sourceHandle);
-		const runDataTotal =
-			nodeExecutionRunDataOutputMapById.value[connection.source]?.[type]?.[index]?.total ?? 0;
+		const runData = nodeExecutionRunDataOutputMapById.value[connection.source]?.[type]?.[index];
+		const runDataTotal = runData?.total ?? 0;
 
 		const sourceTasks = nodeExecutionRunDataById.value[connection.source] ?? [];
 		let lastSourceTask: ITaskData | undefined = sourceTasks[sourceTasks.length - 1];
@@ -699,7 +699,7 @@ export function useCanvasMapping({
 		}
 
 		let status: CanvasConnectionData['status'];
-		if (nodeExecutionRunningById.value[connection.source]) {
+		if (nodeExecutionRunningById.value[connection.source] && runDataTotal === 0) {
 			status = 'running';
 		} else if (
 			nodePinnedDataById.value[connection.source] &&


### PR DESCRIPTION
## Summary

The edge would previously turn gray while running even if run data was present from another loop iteration. Now it shows up as green.

Also added unit tests for `getConnectionData`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-602/canvas-connector-with-run-data-in-loop-isnt-green

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
