### PR TITLE
fix(core): Prefer safer joins at directory paths (no-changelog)

### DIFF
--- a/packages/cli/src/controllers/translation.controller.ts
+++ b/packages/cli/src/controllers/translation.controller.ts
@@ -1,16 +1,16 @@
+import { NODES_BASE_DIR } from '@/constants';
+import { safeJoinPath } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import { Get, RestController } from '@n8n/decorators';
 import type { Request } from 'express';
 import { access } from 'fs/promises';
-import { join } from 'path';
 
-import { NODES_BASE_DIR } from '@/constants';
 import { CredentialTypes } from '@/credential-types';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { InternalServerError } from '@/errors/response-errors/internal-server.error';
 
 export const CREDENTIAL_TRANSLATIONS_DIR = 'n8n-nodes-base/dist/credentials/translations';
-export const NODE_HEADERS_PATH = join(NODES_BASE_DIR, 'dist/nodes/headers');
+export const NODE_HEADERS_PATH = safeJoinPath(NODES_BASE_DIR, 'dist/nodes/headers');
 
 export declare namespace TranslationRequest {
 	export type Credential = Request<{}, {}, {}, { credentialType: string }>;
@@ -31,7 +31,7 @@ export class TranslationController {
 			throw new BadRequestError(`Invalid Credential type: "${credentialType}"`);
 
 		const { defaultLocale } = this.globalConfig;
-		const translationPath = join(
+		const translationPath = safeJoinPath(
 			CREDENTIAL_TRANSLATIONS_DIR,
 			defaultLocale,
 			`${credentialType}.json`,

--- a/packages/cli/src/eventbus/message-event-bus-writer/message-event-bus-log-writer.ts
+++ b/packages/cli/src/eventbus/message-event-bus-writer/message-event-bus-log-writer.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
-import { inTest, Logger } from '@n8n/backend-common';
+import { inTest, Logger, safeJoinPath } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import { Container } from '@n8n/di';
 import { once as eventOnce } from 'events';
@@ -8,7 +8,7 @@ import { createReadStream, existsSync, rmSync } from 'fs';
 import remove from 'lodash/remove';
 import { InstanceSettings } from 'n8n-core';
 import { EventMessageTypeNames, jsonParse } from 'n8n-workflow';
-import path, { parse } from 'path';
+import { parse } from 'path';
 import readline from 'readline';
 import { Worker } from 'worker_threads';
 
@@ -84,7 +84,7 @@ export class MessageEventBusLogWriter {
 		if (!MessageEventBusLogWriter.instance) {
 			MessageEventBusLogWriter.instance = new MessageEventBusLogWriter();
 			MessageEventBusLogWriter.options = {
-				logFullBasePath: path.join(
+				logFullBasePath: safeJoinPath(
 					options?.logBasePath ?? Container.get(InstanceSettings).n8nFolder,
 					options?.logBaseName ?? Container.get(GlobalConfig).eventBus.logWriter.logBaseName,
 				),
@@ -142,7 +142,7 @@ export class MessageEventBusLogWriter {
 			workerFileName =
 				'./dist/eventbus/message-event-bus-writer/message-event-bus-log-writer-worker.js';
 		} else {
-			workerFileName = path.join(parsedName.dir, `${parsedName.name}-worker${parsedName.ext}`);
+			workerFileName = safeJoinPath(parsedName.dir, `${parsedName.name}-worker${parsedName.ext}`);
 		}
 		this._worker = new Worker(workerFileName);
 		if (this.worker) {


### PR DESCRIPTION
## Summary

Making Aikido happy by preferring safer path joins that check that the resulting path is inside that parent.
I don't think there really was anything exploit here, the translations controller was safe thanks to a check it does on the credentialType before using it, but lets add these anyways in case that check ever goes away.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/SEC-333/medium-out-of-sla-suspected-file-inclusion-attack-findings

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
