### PR TITLE
chore(core): Hide OIDC warning for default configuration

### DIFF
--- a/packages/cli/src/sso.ee/oidc/oidc.service.ee.ts
+++ b/packages/cli/src/sso.ee/oidc/oidc.service.ee.ts
@@ -340,9 +340,11 @@ export class OidcService {
 
 		if (configFromDB) {
 			try {
-				const oidcConfig = OidcConfigDto.parse(jsonParse<OidcConfigDto>(configFromDB.value));
+				const configValue = jsonParse<OidcConfigDto>(configFromDB.value);
 
-				if (oidcConfig.discoveryEndpoint === '') return undefined;
+				if (configValue.discoveryEndpoint === '') return undefined;
+
+				const oidcConfig = OidcConfigDto.parse(configValue);
 
 				const discoveryUrl = new URL(oidcConfig.discoveryEndpoint);
 


### PR DESCRIPTION
## Summary

This hides a warning message for the default OIDC configuration.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-3890/oidc-configuration-parsing-fails-on-startup-even-when-disabled


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
