### PR TITLE
fix(core): Fix broken safeJoinPath implementation in community nodes scanner (no-changelog)

### DIFF
--- a/packages/@n8n/scan-community-package/scanner/scanner.mjs
+++ b/packages/@n8n/scan-community-package/scanner/scanner.mjs
@@ -46,6 +46,8 @@ export function safeJoinPath(parentPath, ...paths) {
 			`Path traversal detected, refusing to join paths: ${parentPath} and ${JSON.stringify(paths)}`,
 		);
 	}
+
+	return candidate;
 }
 
 export const resolvePackage = (packageSpec) => {


### PR DESCRIPTION
## Summary

I failed to copypaste the typescript helper into the .mjs file correctly on last PR.
Thanks Suguru for finding this mistake!

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
