### PR TITLE
add OPTIONS handling for CORS preflight to allow PUT/DELETE requests

### DIFF
--- a/packages/nodes-base/nodes/Webhook/Webhook.node.ts
+++ b/packages/nodes-base/nodes/Webhook/Webhook.node.ts
@@ -117,6 +117,10 @@ export class Webhook extends Node {
 						name: 'PUT',
 						value: 'PUT',
 					},
+					{
+						name: 'OPTIONS', // <-- Added OPTIONS
+						value: 'OPTIONS',
+					},
 				],
 				default: ['GET', 'POST'],
 				description: 'The HTTP methods to listen to',
@@ -207,6 +211,20 @@ export class Webhook extends Node {
 		const { typeVersion: nodeVersion, type: nodeType } = context.getNode();
 		const responseMode = context.getNodeParameter('responseMode', 'onReceived') as string;
 
+		const req = context.getRequestObject();
+		const resp = context.getResponseObject();
+		const requestMethod = req.method;
+
+		// Handle CORS preflight requests
+		if (requestMethod === 'OPTIONS') {
+			resp.setHeader('Access-Control-Allow-Origin', '*');
+			resp.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Requested-With');
+			resp.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD');
+			resp.writeHead(204); // No Content
+			resp.end();
+			return { noWebhookResponse: true };
+		}
+
 		if (nodeVersion >= 2 && nodeType === 'n8n-nodes-base.webhook') {
 			checkResponseModeConfiguration(context);
 		}
@@ -218,8 +236,6 @@ export class Webhook extends Node {
 			responseData?: string;
 			ipWhitelist?: string;
 		};
-		const req = context.getRequestObject();
-		const resp = context.getResponseObject();
 		const requestMethod = context.getRequestObject().method;
 
 		if (!isIpWhitelisted(options.ipWhitelist, req.ips, req.ip)) {


### PR DESCRIPTION
## Title:

<!--
fix(Webhook): add OPTIONS handling for CORS preflight to allow PUT/DELETE requests
-->

## Description:

<!--
This PR adds support for OPTIONS requests in the Webhook node to handle CORS preflight checks when using PUT and DELETE methods.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Changes

- [ ] Added OPTIONS to the list of allowed HTTP methods.
-->
- [ ] Updated Webhook.node.ts to handle OPTIONS requests gracefully.
-->


## Why
Currently, when using PUT or DELETE with a Webhook, the browser sends a preflight OPTIONS request which is not handled, causing CORS failures.
This fix ensures preflight requests succeed, allowing these methods to work properly.

## Related Issue
Closes #20095

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds OPTIONS support and CORS preflight handling to the Webhook node, enabling cross-origin PUT/DELETE/PATCH requests.
> 
> - **Webhook node (`packages/nodes-base/nodes/Webhook/Webhook.node.ts`)**:
>   - **CORS preflight handling**: In `webhook()`, detect `OPTIONS` and respond `204` with `Access-Control-Allow-*` headers.
>   - **HTTP methods**: Add `OPTIONS` to `httpMethod` multi-select for allowed methods.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e350b1361a42826485795180d33b90f5faece74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->