### PR TITLE
fix(core): Prevent race condition on job processing handler registration

### DIFF
--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -159,7 +159,7 @@ export class Worker extends BaseCommand<z.infer<typeof flagsSchema>> {
 
 		await this.scalingService.setupQueue();
 
-		this.scalingService.setupWorker(this.concurrency);
+		await this.scalingService.setupWorker(this.concurrency);
 	}
 
 	async run() {

--- a/packages/cli/src/scaling/__tests__/scaling.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/scaling.service.test.ts
@@ -179,14 +179,14 @@ describe('ScalingService', () => {
 		it('should throw if called on a non-worker instance', async () => {
 			await scalingService.setupQueue();
 
-			expect(async () => await scalingService.setupWorker(5)).toThrow();
+			await expect(scalingService.setupWorker(5)).rejects.toThrow();
 		});
 
 		it('should throw if called before queue is ready', async () => {
 			// @ts-expect-error readonly property
 			instanceSettings.instanceType = 'worker';
 
-			expect(async () => await scalingService.setupWorker(5)).toThrow();
+			await expect(scalingService.setupWorker(5)).rejects.toThrow();
 		});
 	});
 

--- a/packages/cli/src/scaling/__tests__/scaling.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/scaling.service.test.ts
@@ -171,7 +171,7 @@ describe('ScalingService', () => {
 			await scalingService.setupQueue();
 			const concurrency = 5;
 
-			scalingService.setupWorker(concurrency);
+			await scalingService.setupWorker(concurrency);
 
 			expect(queue.process).toHaveBeenCalledWith(JOB_TYPE_NAME, concurrency, expect.any(Function));
 		});
@@ -179,14 +179,14 @@ describe('ScalingService', () => {
 		it('should throw if called on a non-worker instance', async () => {
 			await scalingService.setupQueue();
 
-			expect(() => scalingService.setupWorker(5)).toThrow();
+			expect(async () => await scalingService.setupWorker(5)).toThrow();
 		});
 
 		it('should throw if called before queue is ready', async () => {
 			// @ts-expect-error readonly property
 			instanceSettings.instanceType = 'worker';
 
-			expect(() => scalingService.setupWorker(5)).toThrow();
+			expect(async () => await scalingService.setupWorker(5)).toThrow();
 		});
 	});
 

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -80,11 +80,11 @@ export class ScalingService {
 		this.logger.debug('Queue setup completed');
 	}
 
-	setupWorker(concurrency: number) {
+	async setupWorker(concurrency: number) {
 		this.assertWorker();
 		this.assertQueue();
 
-		void this.queue.process(JOB_TYPE_NAME, concurrency, async (job: Job) => {
+		await this.queue.process(JOB_TYPE_NAME, concurrency, async (job: Job) => {
 			try {
 				this.eventService.emit('job-dequeued', {
 					executionId: job.data.executionId,


### PR DESCRIPTION
## Summary

When a worker starts up, it connects to the queue, registers a process handler, and starts listening for jobs, but currently it is possible for a worker to pick up a job without having completed handler registration, leading to [this error](https://github.com/OptimalBits/bull/blob/489c6ab8466c1db122f92af3ddef12eacc54179e/lib/queue.js#L1207) on pickup.

## Related Linear tickets, Github issues, and Community forum posts

fixes #17928

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
