### PR TITLE
fix: Add missing `test` and `authenticate` to OpenWeatherMap, Azure Storage and Netlify credentials

### DIFF
--- a/packages/nodes-base/credentials/AzureStorageSharedKeyApi.credentials.ts
+++ b/packages/nodes-base/credentials/AzureStorageSharedKeyApi.credentials.ts
@@ -1,5 +1,6 @@
 import type {
 	ICredentialDataDecryptedObject,
+	ICredentialTestRequest,
 	ICredentialType,
 	IHttpRequestOptions,
 	INodeProperties,
@@ -93,4 +94,18 @@ export class AzureStorageSharedKeyApi implements ICredentialType {
 
 		return requestOptions;
 	}
+
+	test: ICredentialTestRequest = {
+		request: {
+			baseURL: '={{$credentials.baseUrl}}',
+			url: '/',
+			headers: {
+				'x-ms-date': '={{ new Date().toUTCString() }}',
+				'x-ms-version': '2021-12-02',
+			},
+			qs: {
+				comp: 'list',
+			},
+		},
+	};
 }

--- a/packages/nodes-base/credentials/NetlifyApi.credentials.ts
+++ b/packages/nodes-base/credentials/NetlifyApi.credentials.ts
@@ -1,4 +1,9 @@
-import type { ICredentialType, INodeProperties } from 'n8n-workflow';
+import type {
+	IAuthenticate,
+	ICredentialTestRequest,
+	ICredentialType,
+	INodeProperties,
+} from 'n8n-workflow';
 
 export class NetlifyApi implements ICredentialType {
 	name = 'netlifyApi';
@@ -16,4 +21,20 @@ export class NetlifyApi implements ICredentialType {
 			default: '',
 		},
 	];
+
+	authenticate: IAuthenticate = {
+		type: 'generic',
+		properties: {
+			headers: {
+				Authorization: '=Bearer {{$credentials.accessToken}}',
+			},
+		},
+	};
+
+	test: ICredentialTestRequest = {
+		request: {
+			baseURL: 'https://api.netlify.com',
+			url: '/api/v1/sites',
+		},
+	};
 }

--- a/packages/nodes-base/credentials/OpenWeatherMapApi.credentials.ts
+++ b/packages/nodes-base/credentials/OpenWeatherMapApi.credentials.ts
@@ -1,4 +1,9 @@
-import type { ICredentialType, INodeProperties } from 'n8n-workflow';
+import type {
+	IAuthenticate,
+	ICredentialTestRequest,
+	ICredentialType,
+	INodeProperties,
+} from 'n8n-workflow';
 
 export class OpenWeatherMapApi implements ICredentialType {
 	name = 'openWeatherMapApi';
@@ -16,4 +21,23 @@ export class OpenWeatherMapApi implements ICredentialType {
 			default: '',
 		},
 	];
+
+	authenticate: IAuthenticate = {
+		type: 'generic',
+		properties: {
+			qs: {
+				appid: '={{$credentials.accessToken}}',
+			},
+		},
+	};
+
+	test: ICredentialTestRequest = {
+		request: {
+			baseURL: 'https://api.openweathermap.org/data/2.5',
+			url: '/weather',
+			qs: {
+				q: 'London',
+			},
+		},
+	};
 }


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Add missing `test` and `authenticate` to OpenWeatherMap, Azure Storage and Netlify credentials

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-2685/azure-storage-shared-key-api-credential-update
https://linear.app/n8n/issue/NODE-2799/netlify-api-credential-update
https://linear.app/n8n/issue/NODE-2690/openweathermap-api-credential-update

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
