### PR TITLE
fix(editor): Input/output panel in log view shows "N of N item(s)" when nothing matched

### DIFF
--- a/packages/frontend/editor-ui/src/components/RunDataItemCount.vue
+++ b/packages/frontend/editor-ui/src/components/RunDataItemCount.vue
@@ -18,7 +18,7 @@ const i18n = useI18n();
 </script>
 
 <template>
-	<N8nText v-if="search" :class="$style.itemsText">
+	<N8nText v-if="search" :class="$style.itemsText" data-test-id="run-data-item-count">
 		{{
 			i18n.baseText('ndv.search.items', {
 				adjustToNumber: unfilteredDataCount,
@@ -26,7 +26,7 @@ const i18n = useI18n();
 			})
 		}}
 	</N8nText>
-	<N8nText v-else :class="$style.itemsText">
+	<N8nText v-else :class="$style.itemsText" data-test-id="run-data-item-count">
 		<span>
 			{{
 				i18n.baseText('ndv.output.items', {

--- a/packages/frontend/editor-ui/src/features/logs/components/LogsViewRunData.test.ts
+++ b/packages/frontend/editor-ui/src/features/logs/components/LogsViewRunData.test.ts
@@ -1,0 +1,60 @@
+import { createTestNode, createTestTaskData, createTestWorkflowObject } from '@/__tests__/mocks';
+import { createTestLogEntry } from '../__test__/mocks';
+import { fireEvent, render, waitFor } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import LogsViewRunData from './LogsViewRunData.vue';
+import { createTestingPinia, type TestingPinia } from '@pinia/testing';
+
+describe('LogViewRunData', () => {
+	let pinia: TestingPinia;
+
+	const nodeB = createTestNode({ name: 'B' });
+	const runDataB = createTestTaskData({
+		data: {
+			main: [
+				[{ json: { p: '0' } }, { json: { p: '1' } }, { json: { p: '2' } }, { json: { p: '3' } }],
+			],
+		},
+	});
+	const workflow = createTestWorkflowObject({ nodes: [nodeB] });
+	const logEntry = createTestLogEntry({
+		node: nodeB,
+		runIndex: 0,
+		runData: runDataB,
+		workflow,
+		execution: { resultData: { runData: { B: [runDataB] } } },
+	});
+
+	beforeEach(() => {
+		pinia = createTestingPinia({ stubActions: false, fakeApp: true });
+	});
+
+	it('should display item count', async () => {
+		const rendered = render(LogsViewRunData, {
+			global: { plugins: [pinia] },
+			props: { title: '', logEntry, collapsingTableColumnName: null, paneType: 'output' },
+		});
+
+		expect(rendered.getByTestId('run-data-item-count')).toHaveTextContent('4 items');
+	});
+
+	it('should display matched and total item count unless display mode is schema', async () => {
+		const rendered = render(LogsViewRunData, {
+			global: { plugins: [pinia] },
+			props: { title: '', logEntry, collapsingTableColumnName: null, paneType: 'output' },
+		});
+
+		await fireEvent.click(await rendered.findByTestId('radio-button-table'));
+		await userEvent.type(await rendered.findByTestId('ndv-search'), '0');
+
+		await waitFor(() => {
+			expect(rendered.getByTestId('run-data-item-count')).toHaveTextContent('1 of 4 items');
+		});
+
+		await fireEvent.click(await rendered.findByTestId('radio-button-schema'));
+
+		await waitFor(() => {
+			expect(rendered.getByTestId('run-data-item-count')).toHaveTextContent('4 items');
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/features/logs/components/LogsViewRunData.vue
+++ b/packages/frontend/editor-ui/src/features/logs/components/LogsViewRunData.vue
@@ -110,12 +110,8 @@ function handleChangeDisplayMode(value: IRunDataDisplayMode) {
 
 		<template #header-end="itemCountProps">
 			<RunDataItemCount
-				v-bind="{
-					...itemCountProps,
-					...(displayMode === 'schema'
-						? { search: '', itemCount: itemCountProps.unfilteredDataCount }
-						: {}),
-				}"
+				v-bind="itemCountProps"
+				:search="displayMode === 'schema' ? '' : itemCountProps.search"
 			/>
 		</template>
 

--- a/packages/frontend/editor-ui/src/features/logs/components/LogsViewRunData.vue
+++ b/packages/frontend/editor-ui/src/features/logs/components/LogsViewRunData.vue
@@ -109,7 +109,14 @@ function handleChangeDisplayMode(value: IRunDataDisplayMode) {
 		</template>
 
 		<template #header-end="itemCountProps">
-			<RunDataItemCount v-bind="itemCountProps" />
+			<RunDataItemCount
+				v-bind="{
+					...itemCountProps,
+					...(displayMode === 'schema'
+						? { search: '', itemCount: itemCountProps.unfilteredDataCount }
+						: {}),
+				}"
+			/>
 		</template>
 
 		<template #no-output-data>


### PR DESCRIPTION
## Summary

This PR fixes the item count displayed in input/output panel in log view when search keyword is entered. The fix is implemented by not showing matched item count when the display mode is schema. This behavior makes sense because we show object structure of an item rather than all items in schema mode.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1380/bug-inputoutput-panel-in-log-view-shows-n-of-n-items-when-nothing


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
