### PR TITLE
fix: Don't allow moving a readonly workflow

### DIFF
--- a/packages/cli/src/environments.ee/source-control/read-only-instance-checker.service.ts
+++ b/packages/cli/src/environments.ee/source-control/read-only-instance-checker.service.ts
@@ -1,0 +1,12 @@
+import { Service } from '@n8n/di';
+
+import { SourceControlPreferencesService } from '@/environments.ee/source-control/source-control-preferences.service.ee';
+
+@Service()
+export class ReadOnlyInstanceChecker {
+	constructor(private readonly sourceControlPreferences: SourceControlPreferencesService) {}
+
+	isEnvironmentReadOnly(): boolean {
+		return this.sourceControlPreferences.isBranchReadOnly();
+	}
+}

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -41,6 +41,7 @@ import * as WorkflowHelpers from '@/workflow-helpers';
 import { WorkflowFinderService } from './workflow-finder.service';
 import { WorkflowHistoryService } from './workflow-history.ee/workflow-history.service.ee';
 import { WorkflowSharingService } from './workflow-sharing.service';
+import { ReadOnlyInstanceChecker } from '@/environments.ee/source-control/read-only-instance-checker.service';
 
 @Service()
 export class WorkflowService {
@@ -63,6 +64,7 @@ export class WorkflowService {
 		private readonly globalConfig: GlobalConfig,
 		private readonly folderRepository: FolderRepository,
 		private readonly workflowFinderService: WorkflowFinderService,
+		private readonly protectedInstanceChecker: ReadOnlyInstanceChecker,
 	) {}
 
 	async getMany(
@@ -300,6 +302,15 @@ export class WorkflowService {
 		]);
 
 		if (parentFolderId) {
+			if (
+				this.protectedInstanceChecker.isEnvironmentReadOnly() &&
+				parentFolderId !== workflow.parentFolder?.id
+			) {
+				throw new BadRequestError(
+					'Environments: Cannot move workflow to a different folder on protected instance.',
+				);
+			}
+
 			const project = await this.sharedWorkflowRepository.getWorkflowOwningProject(workflow.id);
 			if (parentFolderId !== PROJECT_ROOT) {
 				try {
@@ -326,13 +337,22 @@ export class WorkflowService {
 			await this.workflowHistoryService.saveVersion(user, workflowUpdateData, workflowId);
 		}
 
-		const relations = tagsDisabled ? [] : ['tags'];
+		const getRelationsToFetchAfterUpdate = () => {
+			const relationsToFetch = [];
+			if (parentFolderId) {
+				relationsToFetch.push('parentFolder');
+			}
+			if (!tagsDisabled) {
+				relationsToFetch.push('tags');
+			}
+			return relationsToFetch;
+		};
 
 		// We sadly get nothing back from "update". Neither if it updated a record
 		// nor the new value. So query now the hopefully updated entry.
 		const updatedWorkflow = await this.workflowRepository.findOne({
 			where: { id: workflowId },
-			relations,
+			relations: getRelationsToFetchAfterUpdate(),
 		});
 
 		if (updatedWorkflow === null) {

--- a/packages/cli/test/integration/workflows/workflow.service.test.ts
+++ b/packages/cli/test/integration/workflows/workflow.service.test.ts
@@ -1,5 +1,10 @@
 import { createWorkflow, testDb, mockInstance } from '@n8n/backend-test-utils';
-import { SharedWorkflowRepository, WorkflowRepository } from '@n8n/db';
+import {
+	SharedWorkflowRepository,
+	WorkflowRepository,
+	FolderRepository,
+	ProjectRepository,
+} from '@n8n/db';
 import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
 
@@ -10,9 +15,12 @@ import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import { WorkflowService } from '@/workflows/workflow.service';
 
 import { createOwner } from '../shared/db/users';
+import { createFolder } from '../shared/db/folders';
+import { ReadOnlyInstanceChecker } from '@/environments.ee/source-control/read-only-instance-checker.service';
 
 let workflowService: WorkflowService;
 const activeWorkflowManager = mockInstance(ActiveWorkflowManager);
+const readOnlyInstanceChecker = mockInstance(ReadOnlyInstanceChecker);
 mockInstance(MessageEventBus);
 mockInstance(Telemetry);
 
@@ -36,8 +44,9 @@ beforeAll(async () => {
 		mock(),
 		mock(),
 		mock(),
-		mock(),
+		Container.get(FolderRepository),
 		Container.get(WorkflowFinderService),
+		readOnlyInstanceChecker,
 	);
 });
 
@@ -81,5 +90,39 @@ describe('update()', () => {
 		expect(removedWorkflowId).toBe(workflow.id);
 
 		expect(addSpy).not.toHaveBeenCalled();
+	});
+
+	it('should throw a BadRequest error when changing the parent folder of a workflow in a protected instance', async () => {
+		jest.spyOn(readOnlyInstanceChecker, 'isEnvironmentReadOnly').mockReturnValue(true);
+		const owner = await createOwner();
+		const workflow = await createWorkflow({}, owner);
+
+		const newParentFolderId = 'different-folder-id';
+
+		await expect(
+			workflowService.update(owner, workflow, workflow.id, undefined, newParentFolderId),
+		).rejects.toThrow(
+			'Environments: Cannot move workflow to a different folder on protected instance.',
+		);
+	});
+
+	it('updates workflow folder', async () => {
+		jest.spyOn(readOnlyInstanceChecker, 'isEnvironmentReadOnly').mockReturnValue(false);
+		const owner = await createOwner();
+		const workflow = await createWorkflow({}, owner);
+		const folder = await createFolder(
+			await Container.get(ProjectRepository).getPersonalProjectForUserOrFail(owner.id),
+			{ name: 'Test Folder' },
+		);
+
+		const updatedWorkflow = await workflowService.update(
+			owner,
+			workflow,
+			workflow.id,
+			undefined,
+			folder.id,
+		);
+
+		expect(updatedWorkflow.parentFolder?.id).toEqual(folder.id);
 	});
 });

--- a/packages/frontend/editor-ui/src/components/WorkflowCard.test.ts
+++ b/packages/frontend/editor-ui/src/components/WorkflowCard.test.ts
@@ -298,6 +298,37 @@ describe('WorkflowCard', () => {
 		expect(actions).not.toHaveTextContent('Move');
 	});
 
+	it("should not show 'Move' action on read only instance", async () => {
+		vi.spyOn(projectsStore, 'isTeamProjectFeatureEnabled', 'get').mockReturnValue(true);
+		vi.spyOn(settingsStore, 'isFoldersFeatureEnabled', 'get').mockReturnValue(true);
+		vi.spyOn(vueRouter, 'useRoute').mockReturnValueOnce({
+			name: VIEWS.PROJECTS,
+		} as vueRouter.RouteLocationNormalizedLoadedGeneric);
+
+		const data = createWorkflow({
+			scopes: ['workflow:update'],
+		});
+
+		const { getByTestId } = renderComponent({
+			props: { data, areFoldersEnabled: true, readOnly: true },
+		});
+		const cardActions = getByTestId('workflow-card-actions');
+
+		expect(cardActions).toBeInTheDocument();
+
+		const cardActionsOpener = within(cardActions).getByRole('button');
+		expect(cardActionsOpener).toBeInTheDocument();
+
+		const controllingId = cardActionsOpener.getAttribute('aria-controls');
+
+		await userEvent.click(cardActions);
+		const actions = document.querySelector<HTMLElement>(`#${controllingId}`);
+		if (!actions) {
+			throw new Error('Actions menu not found');
+		}
+		expect(actions).not.toHaveTextContent('Move');
+	});
+
 	it("should have 'Archive' action on non archived nonactive workflows", async () => {
 		const data = createWorkflow({
 			active: false,

--- a/packages/frontend/editor-ui/src/components/WorkflowCard.vue
+++ b/packages/frontend/editor-ui/src/components/WorkflowCard.vue
@@ -158,8 +158,10 @@ const actions = computed(() => {
 		});
 	}
 
+	// TODO: add test to verify that moving a readonly card is not possible
 	if (
-		((workflowPermissions.value.update && !props.readOnly) ||
+		!props.readOnly &&
+		(workflowPermissions.value.update ||
 			(workflowPermissions.value.move && projectsStore.isTeamProjectFeatureEnabled)) &&
 		showFolders.value &&
 		route.name !== VIEWS.SHARED_WORKFLOWS


### PR DESCRIPTION
## Summary

📹 Demo video demonstrating the Before & After: https://www.loom.com/share/04ab82f3401f4a919628a170e3f70ffe?sid=0f6798cd-722b-4ef5-a4da-25778d331184

In a readonly instance, no workflow should be moved to another folder. Believed to be a regression introduced in e860dd6d2eb6a2dac5126bc60006d53b53115a68

Also added backend validation to prevent moving a workflow folder on read-only instance in https://github.com/n8n-io/n8n/pull/20227/commits/24e7bed59a0090bbb21cd09c1da485bb0a66c98f

This is a screenshot of the backend error being shown in the case where a move action was triggered in the UI of a read-only instance (this will only appear if we ever have a gap in our frontend code again, that will end up showing the buttons to move a workflow):
<img width="1206" height="680" alt="image" src="https://github.com/user-attachments/assets/8389ad7e-aa1d-4bcb-ab04-5097eafe307c" />


## Related Linear tickets, Github issues, and Community forum posts

closes PAY-3883

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
