### PR TITLE
fix(core): Fix N8N_ENCRYPTION_KEY_FILE environment variable not working

### DIFF
--- a/packages/@n8n/config/src/configs/instance-settings-config.ts
+++ b/packages/@n8n/config/src/configs/instance-settings-config.ts
@@ -13,6 +13,14 @@ export class InstanceSettingsConfig {
 	enforceSettingsFilePermissions: boolean = false;
 
 	/**
+	 * Encryption key to use for encrypting and decrypting credentials.
+	 * If none is provided, a random key will be generated and saved to the settings file on the first launch.
+	 * Can be provided directly via N8N_ENCRYPTION_KEY or via a file path using N8N_ENCRYPTION_KEY_FILE.
+	 */
+	@Env('N8N_ENCRYPTION_KEY')
+	encryptionKey: string = '';
+
+	/**
 	 * The home folder path of the user.
 	 * If none can be found it falls back to the current working directory
 	 */

--- a/packages/core/src/instance-settings/__tests__/instance-settings.test.ts
+++ b/packages/core/src/instance-settings/__tests__/instance-settings.test.ts
@@ -51,15 +51,13 @@ describe('InstanceSettings', () => {
 
 		it('should throw if the env and file keys do not match', () => {
 			mockFs.readFileSync.mockReturnValue(JSON.stringify({ encryptionKey: 'key_1' }));
-			process.env.N8N_ENCRYPTION_KEY = 'key_2';
-			expect(() => createInstanceSettings()).toThrowError();
+			expect(() => createInstanceSettings({ encryptionKey: 'key_2' })).toThrowError();
 		});
 
 		it('should check if the settings file has the correct permissions', () => {
-			process.env.N8N_ENCRYPTION_KEY = 'test_key';
 			mockFs.readFileSync.mockReturnValueOnce(JSON.stringify({ encryptionKey: 'test_key' }));
 			mockFs.statSync.mockReturnValueOnce({ mode: 0o600 } as fs.Stats);
-			const settings = createInstanceSettings();
+			const settings = createInstanceSettings({ encryptionKey: 'test_key' });
 			expect(settings.encryptionKey).toEqual('test_key');
 			expect(settings.instanceId).toEqual(
 				'6ce26c63596f0cc4323563c529acfca0cccb0e57f6533d79a60a42c9ff862ae7',
@@ -103,8 +101,7 @@ describe('InstanceSettings', () => {
 		});
 
 		it('should create a new settings file without explicit permissions if N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS is not set', () => {
-			process.env.N8N_ENCRYPTION_KEY = 'key_2';
-			const settings = createInstanceSettings();
+			const settings = createInstanceSettings({ encryptionKey: 'key_2' });
 			expect(settings.encryptionKey).not.toEqual('test_key');
 			expect(mockFs.mkdirSync).toHaveBeenCalledWith('/test/.n8n', { recursive: true });
 			expect(mockFs.writeFileSync).toHaveBeenCalledWith(
@@ -119,8 +116,7 @@ describe('InstanceSettings', () => {
 
 		it('should create a new settings file without explicit permissions if N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS=false', () => {
 			process.env.N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS = 'false';
-			process.env.N8N_ENCRYPTION_KEY = 'key_2';
-			const settings = createInstanceSettings();
+			const settings = createInstanceSettings({ encryptionKey: 'key_2' });
 			expect(settings.encryptionKey).not.toEqual('test_key');
 			expect(mockFs.mkdirSync).toHaveBeenCalledWith('/test/.n8n', { recursive: true });
 			expect(mockFs.writeFileSync).toHaveBeenCalledWith(
@@ -135,9 +131,9 @@ describe('InstanceSettings', () => {
 
 		it('should create a new settings file with explicit permissions if N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS=true', () => {
 			process.env.N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS = 'true';
-			process.env.N8N_ENCRYPTION_KEY = 'key_2';
 			const settings = createInstanceSettings({
 				enforceSettingsFilePermissions: true,
+				encryptionKey: 'key_2',
 			});
 			expect(settings.encryptionKey).not.toEqual('test_key');
 			expect(mockFs.mkdirSync).toHaveBeenCalledWith('/test/.n8n', { recursive: true });
@@ -151,9 +147,8 @@ describe('InstanceSettings', () => {
 			);
 		});
 
-		it('should pick up the encryption key from env var N8N_ENCRYPTION_KEY', () => {
-			process.env.N8N_ENCRYPTION_KEY = 'env_key';
-			const settings = createInstanceSettings();
+		it('should pick up the encryption key from config', () => {
+			const settings = createInstanceSettings({ encryptionKey: 'env_key' });
 			expect(settings.encryptionKey).toEqual('env_key');
 			expect(settings.instanceId).toEqual(
 				'2c70e12b7a0646f92279f427c7b38e7334d8e5389cff167a1dc30e73f826b683',
@@ -171,9 +166,8 @@ describe('InstanceSettings', () => {
 		});
 
 		it("should not set the permissions of the settings file if 'N8N_IGNORE_SETTINGS_FILE_PERMISSIONS' is true", () => {
-			process.env.N8N_ENCRYPTION_KEY = 'key_2';
 			process.env.N8N_IGNORE_SETTINGS_FILE_PERMISSIONS = 'true';
-			const settings = createInstanceSettings();
+			const settings = createInstanceSettings({ encryptionKey: 'key_2' });
 			expect(settings.encryptionKey).not.toEqual('test_key');
 			expect(mockFs.mkdirSync).toHaveBeenCalledWith('/test/.n8n', { recursive: true });
 			expect(mockFs.writeFileSync).toHaveBeenCalledWith(
@@ -195,11 +189,10 @@ describe('InstanceSettings', () => {
 	describe('constructor', () => {
 		it('should generate a `hostId`', () => {
 			const encryptionKey = 'test_key';
-			process.env.N8N_ENCRYPTION_KEY = encryptionKey;
 			mockFs.existsSync.mockReturnValueOnce(true);
 			mockFs.readFileSync.mockReturnValueOnce(JSON.stringify({ encryptionKey }));
 
-			const settings = createInstanceSettings();
+			const settings = createInstanceSettings({ encryptionKey });
 
 			const [instanceType, hostId] = settings.hostId.split('-');
 			expect(instanceType).toEqual('main');

--- a/packages/core/src/instance-settings/instance-settings.ts
+++ b/packages/core/src/instance-settings/instance-settings.ts
@@ -175,7 +175,7 @@ export class InstanceSettings {
 	 * settings file with an auto-generated encryption key.
 	 */
 	private loadOrCreate(): Settings {
-		const encryptionKeyFromEnv = process.env.N8N_ENCRYPTION_KEY;
+		const encryptionKeyFromEnv = this.config.encryptionKey || undefined;
 		if (existsSync(this.settingsFile)) {
 			const content = readFileSync(this.settingsFile, 'utf8');
 			this.ensureSettingsFilePermissions();


### PR DESCRIPTION
## Summary

This PR fixes the issue that `N8N_ENCRYTION_KEY` didn't function like other sensitive environment variables, which [the documentation](https://docs.n8n.io/hosting/configuration/configuration-methods/#keeping-sensitive-data-in-separate-files) recommends saving in a file in the filesystem and providing their path by adding a suffix to the environment variable name with `_FILE`.

With this fix, the code that reads the environment variable now uses the already existing mechanism of the `@Env` decorator to load the value of the `N8N_ENCRYPTION_KEY`.

This was tested by creating a file with an encryption key and a non-existing `config` file within the `.n8n` folder, and providing the path to that file with the encryption key while running n8n with `N8N_ENCRYPTION_KEY_FILE=/home/node/.n8n/encryptionKey pnpm start`. The process started correctly and saved the provided encryption key in the `/home/node/.n8n/config` file. Providing the encryption key through the environment variable `N8N_ENCRYPTION_KEY` continues to work as expected.

## Related Linear tickets, Github issues, and Community forum posts

fixes #20175


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) 
- [X] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Load encryption key from config via @Env (supporting N8N_ENCRYPTION_KEY and _FILE) and refactor instance settings/tests to use it.
> 
> - **Core**:
>   - **Config**: Add `encryptionKey` to `InstanceSettingsConfig` via `@Env('N8N_ENCRYPTION_KEY')`, enabling `_FILE` support.
>   - **InstanceSettings**: Read encryption key from `config.encryptionKey` instead of `process.env`, keeping existing validations and behavior.
> - **Tests**:
>   - Update tests to pass `encryptionKey` via config and adjust related expectations; keep permission flag env tests unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c57f5fbc9fcb8adde9e5f8f2fc303b6fb26170d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->