### PR TITLE
fix: Allow creation of vector search indexes in MongoDB node

### DIFF
--- a/packages/nodes-base/nodes/MongoDb/MongoDb.node.ts
+++ b/packages/nodes-base/nodes/MongoDb/MongoDb.node.ts
@@ -487,6 +487,7 @@ export class MongoDb implements INodeType {
 					try {
 						const collection = this.getNodeParameter('collection', i) as string;
 						const indexName = this.getNodeParameter('indexNameRequired', i) as string;
+						const indexType = this.getNodeParameter('indexType', i) as string;
 						const definition = JSON.parse(
 							this.getNodeParameter('indexDefinition', i) as string,
 						) as Record<string, unknown>;
@@ -494,6 +495,7 @@ export class MongoDb implements INodeType {
 						await mdb.collection(collection).createSearchIndex({
 							name: indexName,
 							definition,
+							type: indexType,
 						});
 
 						returnData.push({

--- a/packages/nodes-base/nodes/MongoDb/test/MongoDB.test.ts
+++ b/packages/nodes-base/nodes/MongoDb/test/MongoDB.test.ts
@@ -94,7 +94,11 @@ describe('MongoDB CRUD Node', () => {
 		);
 
 		it('calls the spy with the expected arguments', function () {
-			expect(spy).toBeCalledWith({ name: 'my-index', definition: { mappings: {} } });
+			expect(spy).toBeCalledWith({
+				name: 'my-index',
+				definition: { mappings: {} },
+				type: 'vectorSearch',
+			});
 		});
 	});
 


### PR DESCRIPTION
## Summary

The MongoDB node's createSearchIndex method doesn't allow for the creation of vector search indexes because the index type is not passed from the node into the MongoDB driver's `createSearchIndex()` helper.  This PR fixes that bug. 

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pass `indexType` through to MongoDB `createSearchIndex`, enabling vector search index creation, and update tests accordingly.
> 
> - **MongoDB node**:
>   - `createSearchIndex` now reads `indexType` and passes it as `type` to `collection.createSearchIndex(...)`.
> - **Tests**:
>   - Update `createSearchIndex` test to expect `{ name, definition, type }`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c314a852d7495b871c4e0d91ede3047ac91f0d92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->