### PR TITLE
fix(core): Make transition self-healing on `SIGTERM`

### DIFF
--- a/packages/cli/src/__tests__/active-workflow-manager.test.ts
+++ b/packages/cli/src/__tests__/active-workflow-manager.test.ts
@@ -98,9 +98,9 @@ describe('ActiveWorkflowManager', () => {
 				expect(result).toBe(true);
 			});
 
-			test('should return `false` for `leadershipChange`', () => {
+			test('should return `true` for `leadershipChange`', () => {
 				const result = activeWorkflowManager.shouldAddWebhooks('leadershipChange');
-				expect(result).toBe(false);
+				expect(result).toBe(true);
 			});
 
 			test('should return `true` for `update` or `activate`', () => {

--- a/packages/cli/src/active-workflow-manager.ts
+++ b/packages/cli/src/active-workflow-manager.ts
@@ -195,7 +195,10 @@ export class ActiveWorkflowManager {
 				await this.webhookService.storeWebhook(webhook);
 				await this.webhookService.createWebhookIfNotExists(workflow, webhookData, mode, activation);
 			} catch (error) {
-				if (activation === 'init' && error.name === 'QueryFailedError') {
+				if (
+					['init', 'leadershipChange'].includes(activation) &&
+					error.name === 'QueryFailedError'
+				) {
 					// n8n does not remove the registered webhooks on exit.
 					// This means that further initializations will always fail
 					// when inserting to database. This is why we ignore this error
@@ -972,9 +975,7 @@ export class ActiveWorkflowManager {
 		// to prevent issues with users upgrading from a version < 1.15, where the webhook entity
 		// was cleared on shutdown to anything past 1.28.0, where we stopped populating it on init,
 		// causing all webhooks to break
-		if (activationMode === 'init') return true;
-
-		if (activationMode === 'leadershipChange') return false;
+		if (['init', 'leadershipChange'].includes(activationMode)) return true;
 
 		return this.instanceSettings.isLeader; // 'update' or 'activate'
 	}


### PR DESCRIPTION
## Summary

If a user with two instances activates a workflow, that instance who receives the request writes the active status to the DB and publishes a command to activate the workflow. The leader then receives the command and adds webhooks, triggers and pollers for that workflow. 

But if the leader is interrupted while processing this command by `SIGTERM` and winds down, then the new leader on takeover will fetch all active workflows from the DB and add triggers and polllers but not webhooks, because they don't need to be re-registered because they aren't de-registered on shutdown. But this assumes webhook registration succeeded by the time of leader stepdown, leading to a scenario where if `SIGTERM` prevented webhook registration, the new leader will assume it registered and so do nothing about its registration.

This PR changes it so that on leader takeover the new leader now attempts to add webhooks as well. If the webhook happens to be missing, then we write it to the DB and register it with the third-party service. But if the webhook already exists, we ignore the duplicate insertion error and skip third-party registration.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1446
