### PR TITLE
feat: Use SafePathJoin, Raw SQL queries for insertions

### DIFF
--- a/packages/cli/src/commands/export/entities.ts
+++ b/packages/cli/src/commands/export/entities.ts
@@ -1,16 +1,16 @@
 import { Command } from '@n8n/decorators';
 import { z } from 'zod';
-import path from 'path';
 import { Container } from '@n8n/di';
 
 import { BaseCommand } from '../base-command';
 import { ExportService } from '@/services/export.service';
+import { safeJoinPath } from '@n8n/backend-common';
 
 const flagsSchema = z.object({
 	outputDir: z
 		.string()
 		.describe('Output directory path')
-		.default(path.join(__dirname, './outputs')),
+		.default(safeJoinPath(__dirname, './outputs')),
 });
 
 @Command({

--- a/packages/cli/src/services/__tests__/import.service.test.ts
+++ b/packages/cli/src/services/__tests__/import.service.test.ts
@@ -1,4 +1,4 @@
-import { type Logger } from '@n8n/backend-common';
+import { safeJoinPath, type Logger } from '@n8n/backend-common';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { type DataSource, type EntityManager } from '@n8n/typeorm';
 import { mock } from 'jest-mock-extended';
@@ -12,6 +12,10 @@ import type { CredentialsRepository, TagRepository } from '@n8n/db';
 jest.mock('fs/promises');
 
 jest.mock('@/utils/compression.util');
+
+jest.mock('@n8n/backend-common', () => ({
+	safeJoinPath: jest.fn(),
+}));
 
 // Mock @n8n/db
 jest.mock('@n8n/db', () => ({
@@ -229,6 +233,10 @@ describe('ImportService', () => {
 			const mockFiles = ['user.jsonl', 'workflowentity.jsonl', 'migrations.jsonl'];
 
 			jest.mocked(readdir).mockResolvedValue(mockFiles as any);
+			jest
+				.mocked(safeJoinPath)
+				.mockReturnValueOnce('/test/input/user.jsonl')
+				.mockReturnValueOnce('/test/input/workflowentity.jsonl');
 
 			const result = await importService.getImportMetadata('/test/input');
 
@@ -245,6 +253,11 @@ describe('ImportService', () => {
 			const mockFiles = ['user.jsonl', 'user.2.jsonl', 'user.3.jsonl'];
 
 			jest.mocked(readdir).mockResolvedValue(mockFiles as any);
+			jest
+				.mocked(safeJoinPath)
+				.mockReturnValueOnce('/test/input/user.jsonl')
+				.mockReturnValueOnce('/test/input/user.2.jsonl')
+				.mockReturnValueOnce('/test/input/user.3.jsonl');
 
 			const result = await importService.getImportMetadata('/test/input');
 
@@ -297,6 +310,8 @@ describe('ImportService', () => {
 			const mockFiles = ['user.jsonl', 'migrations.jsonl'];
 
 			jest.mocked(readdir).mockResolvedValue(mockFiles as any);
+
+			jest.mocked(safeJoinPath).mockReturnValue('/test/input/user.jsonl');
 
 			const result = await importService.getImportMetadata('/test/input');
 
@@ -384,6 +399,10 @@ describe('ImportService', () => {
 				tableNames: ['user'],
 			};
 
+			mockDataSource.driver.escapeQueryWithParameters = jest
+				.fn()
+				.mockReturnValue(['INSERT COMMAND', { data: 'data' }]);
+
 			const mockEntities = [{ id: 1, name: 'Test User' }];
 			const mockContent = JSON.stringify(mockEntities[0]);
 			jest.mocked(readFile).mockResolvedValue(mockContent);
@@ -396,7 +415,7 @@ describe('ImportService', () => {
 			);
 
 			expect(readFile).toHaveBeenCalledWith('/test/input/user.jsonl', 'utf8');
-			expect(mockEntityManager.insert).toHaveBeenCalledWith('user', mockEntities);
+			expect(mockEntityManager.query).toHaveBeenCalledWith('INSERT COMMAND', { data: 'data' });
 		});
 
 		it('should handle empty input directory', async () => {
@@ -749,11 +768,7 @@ describe('ImportService', () => {
 				decompressFolder: mockDecompressFolder,
 			}));
 
-			// Mock path.join
-			const mockPathJoin = jest.fn().mockReturnValue(entitiesZipPath);
-			jest.doMock('path', () => ({
-				join: mockPathJoin,
-			}));
+			jest.mocked(safeJoinPath).mockReturnValue(entitiesZipPath);
 
 			// @ts-expect-error For testing purposes
 			await importService.decompressEntitiesZip(inputDir);

--- a/packages/cli/src/services/export.service.ts
+++ b/packages/cli/src/services/export.service.ts
@@ -1,6 +1,5 @@
-import { Logger } from '@n8n/backend-common';
+import { Logger, safeJoinPath } from '@n8n/backend-common';
 import { mkdir, rm, readdir, appendFile } from 'fs/promises';
-import path from 'path';
 
 import { Service } from '@n8n/di';
 
@@ -29,7 +28,7 @@ export class ExportService {
 				`   🗑️  Found ${entityFiles.length} existing file(s) for ${entityName}, deleting...`,
 			);
 			for (const file of entityFiles) {
-				await rm(path.join(outputDir, file));
+				await rm(safeJoinPath(outputDir, file));
 				this.logger.info(`      Deleted: ${file}`);
 			}
 		}
@@ -62,7 +61,7 @@ export class ExportService {
 			const allMigrations = await this.dataSource.query(`SELECT * FROM ${formattedTableName}`);
 
 			const fileName = 'migrations.jsonl';
-			const filePath = path.join(outputDir, fileName);
+			const filePath = safeJoinPath(outputDir, fileName);
 
 			const migrationsJsonl: string = allMigrations
 				.map((migration: unknown) => JSON.stringify(migration))
@@ -150,7 +149,7 @@ export class ExportService {
 				const targetFileIndex = Math.floor(totalEntityCount / entitiesPerFile) + 1;
 				const fileName =
 					targetFileIndex === 1 ? `${entityName}.jsonl` : `${entityName}.${targetFileIndex}.jsonl`;
-				const filePath = path.join(outputDir, fileName);
+				const filePath = safeJoinPath(outputDir, fileName);
 
 				// If we've moved to a new file, log the completion of the previous file
 				if (targetFileIndex > fileIndex) {
@@ -195,7 +194,7 @@ export class ExportService {
 		}
 
 		// Compress the output directory to entities.zip
-		const zipPath = path.join(outputDir, 'entities.zip');
+		const zipPath = safeJoinPath(outputDir, 'entities.zip');
 		this.logger.info(`\n🗜️  Compressing export to ${zipPath}...`);
 
 		await compressFolder(outputDir, zipPath, {
@@ -209,7 +208,7 @@ export class ExportService {
 		const files = await readdir(outputDir);
 		for (const file of files) {
 			if (file.endsWith('.jsonl') && file !== 'entities.zip') {
-				await rm(path.join(outputDir, file));
+				await rm(safeJoinPath(outputDir, file));
 			}
 		}
 

--- a/packages/cli/src/services/import.service.ts
+++ b/packages/cli/src/services/import.service.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@n8n/backend-common';
+import { Logger, safeJoinPath } from '@n8n/backend-common';
 import type { TagEntity, ICredentialsDb, IWorkflowDb } from '@n8n/db';
 import {
 	Project,
@@ -19,7 +19,7 @@ import { replaceInvalidCredentials } from '@/workflow-helpers';
 import { validateDbTypeForImportEntities } from '@/utils/validate-database-type';
 import { Cipher } from 'n8n-core';
 import { decompressFolder } from '@/utils/compression.util';
-import { safeJoinPath } from '@n8n/backend-common';
+import { z } from 'zod';
 
 @Service()
 export class ImportService {
@@ -256,7 +256,7 @@ export class ImportService {
 				if (!line) continue;
 
 				try {
-					entities.push(JSON.parse(line));
+					entities.push(z.record(z.string(), z.unknown()).parse(JSON.parse(line)));
 				} catch (error: unknown) {
 					// If parsing fails, it might be because the JSON spans multiple lines
 					// This shouldn't happen in proper JSONL, but let's handle it gracefully


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR fixes an issue where the typeorm query builder was not inferring values for default fields, causing sqlite to have null constraint issues, and postgres to insert default values, as opposed to the expected values.

This PR also replaces path.jion with the safe path join method to address aikido issues.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
