### PR TITLE
fix: Show Builder's Ask Admin tooltip just for owner

### DIFF
--- a/packages/frontend/editor-ui/src/components/AskAssistant/Agent/AskAssistantBuild.test.ts
+++ b/packages/frontend/editor-ui/src/components/AskAssistant/Agent/AskAssistantBuild.test.ts
@@ -6,6 +6,7 @@ interface VueComponentInstance {
 	__vueParentComponent?: {
 		setupState?: {
 			onUserMessage?: (message: string) => Promise<void>;
+			showAskOwnerTooltip?: boolean;
 		};
 	};
 }
@@ -94,6 +95,7 @@ import { mockedStore } from '@/__tests__/utils';
 import { STORES } from '@n8n/stores';
 import { useWorkflowsStore } from '@/stores/workflows.store';
 import type { INodeUi } from '@/Interface';
+import { useUsersStore } from '@/stores/users.store';
 
 vi.mock('@/event-bus', () => ({
 	nodeViewEventBus: {
@@ -212,6 +214,32 @@ describe('AskAssistantBuild', () => {
 			// Basic verification that no methods were called on mount
 			expect(builderStore.sendChatMessage).not.toHaveBeenCalled();
 			expect(builderStore.addAssistantMessages).not.toHaveBeenCalled();
+		});
+
+		it('should show ask owner tooltip when user is not instance owner', () => {
+			const usersStore = mockedStore(useUsersStore);
+			usersStore.isInstanceOwner = false;
+
+			const { container } = renderComponent();
+
+			// Get the component instance
+			const vm = (container.firstElementChild as VueComponentInstance)?.__vueParentComponent;
+			const showAskOwnerTooltip = vm?.setupState?.showAskOwnerTooltip;
+
+			expect(showAskOwnerTooltip).toBe(true);
+		});
+
+		it('should not show ask owner tooltip when user is instance owner', () => {
+			const usersStore = mockedStore(useUsersStore);
+			usersStore.isInstanceOwner = true;
+
+			const { container } = renderComponent();
+
+			// Get the component instance
+			const vm = (container.firstElementChild as VueComponentInstance)?.__vueParentComponent;
+			const showAskOwnerTooltip = vm?.setupState?.showAskOwnerTooltip;
+
+			expect(showAskOwnerTooltip).toBe(false);
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/components/AskAssistant/Agent/AskAssistantBuild.vue
+++ b/packages/frontend/editor-ui/src/components/AskAssistant/Agent/AskAssistantBuild.vue
@@ -52,7 +52,7 @@ const showExecuteMessage = computed(() => {
 });
 const creditsQuota = computed(() => builderStore.creditsQuota);
 const creditsRemaining = computed(() => builderStore.creditsRemaining);
-const showAskOwnerTooltip = computed(() => usersStore.isInstanceOwner);
+const showAskOwnerTooltip = computed(() => !usersStore.isInstanceOwner);
 
 async function onUserMessage(content: string) {
 	const isNewWorkflow = workflowsStore.isNewWorkflow;


### PR DESCRIPTION
## Summary
Tooltip currently showing for owners, and not showing for non-owner users.
<img width="416" height="179" alt="Screenshot 2025-10-01 at 10 37 39" src="https://github.com/user-attachments/assets/7cb64bb7-13d2-4042-91ec-21fa357d4727" />

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
