### PR TITLE
fix: Disable Execute and Refine button if no credits remaining

### DIFF
--- a/packages/frontend/editor-ui/src/components/AskAssistant/Agent/ExecuteMessage.vue
+++ b/packages/frontend/editor-ui/src/components/AskAssistant/Agent/ExecuteMessage.vue
@@ -15,6 +15,7 @@ import { isChatNode } from '@/utils/aiUtils';
 import { useToast } from '@/composables/useToast';
 import { N8nTooltip } from '@n8n/design-system';
 import { nextTick } from 'vue';
+import { useBuilderStore } from '@/stores/builder.store';
 
 interface Emits {
 	/** Emitted when workflow execution completes */
@@ -30,6 +31,7 @@ const nodeTypesStore = useNodeTypesStore();
 const i18n = useI18n();
 const logsStore = useLogsStore();
 const toast = useToast();
+const builderStore = useBuilderStore();
 
 // Workflow execution composable
 const { runWorkflow } = useRunWorkflow({ router });
@@ -193,7 +195,7 @@ watch(workflowIssues, async () => {
 		<N8nTooltip :disabled="!hasValidationIssues" :content="executeButtonTooltip" placement="left">
 			<CanvasRunWorkflowButton
 				:class="$style.runButton"
-				:disabled="hasValidationIssues"
+				:disabled="hasValidationIssues || builderStore.hasNoCreditsRemaining"
 				:waiting-for-webhook="isExecutionWaitingForWebhook"
 				:hide-tooltip="true"
 				:label="i18n.baseText('aiAssistant.builder.executeMessage.execute')"


### PR DESCRIPTION
## Summary
If no credits remaining, disable button. 
<img width="393" height="349" alt="Screenshot 2025-10-01 at 11 04 37" src="https://github.com/user-attachments/assets/05c93b66-cb90-4137-9dc0-21d0aeef3641" />

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
