### PR TITLE
fix: support “thinking” content blocks for Magistral models

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,8 @@
       "minifaker": "patches/minifaker.patch",
       "z-vue-scan": "patches/z-vue-scan.patch",
       "@lezer/highlight": "patches/@lezer__highlight.patch",
-      "v-code-diff": "patches/v-code-diff.patch"
+      "v-code-diff": "patches/v-code-diff.patch",
+      "@mistralai/mistralai": "patches/@mistralai__mistralai.patch"
     }
   }
 }

--- a/patches/@mistralai__mistralai.patch
+++ b/patches/@mistralai__mistralai.patch
@@ -1,0 +1,61 @@
+diff --git a/models/components/contentchunk.js b/models/components/contentchunk.js
+index c1ff8b21051f6ca96df8caf2d1564ebbd695327e..1a6b9205d429ef050741dfdada76a1e6fae6d60d 100644
+--- a/models/components/contentchunk.js
++++ b/models/components/contentchunk.js	
+@@ -40,6 +40,7 @@ exports.ContentChunk$inboundSchema = z.union([
+     referencechunk_js_1.ReferenceChunk$inboundSchema.and(z.object({ type: z.literal("reference") }).transform((v) => ({
+         type: v.type,
+     }))),
++     z.object({ type: z.literal("thinking") }).passthrough(),
+ ]);
+ /** @internal */
+ exports.ContentChunk$outboundSchema = z.union([
+@@ -50,6 +51,7 @@ exports.ContentChunk$outboundSchema = z.union([
+     referencechunk_js_1.ReferenceChunk$outboundSchema.and(z.object({ type: z.literal("reference") }).transform((v) => ({
+         type: v.type,
+     }))),
++     z.object({ type: z.literal("thinking") }).passthrough(),
+ ]);
+ /**
+  * @internal
+diff --git a/src/models/components/contentchunk.ts b/src/models/components/contentchunk.ts
+index 7825e9d8ba419fdc1d68704fc36f7d548f4e129c..d0053e2f514392f3b5904e525e64b411497de2e6 100644
+--- a/src/models/components/contentchunk.ts
++++ b/src/models/components/contentchunk.ts	
+@@ -25,7 +25,8 @@ import {
+ export type ContentChunk =
+   | (ImageURLChunk & { type: "image_url" })
+   | (TextChunk & { type: "text" })
+-  | (ReferenceChunk & { type: "reference" });
++  | (ReferenceChunk & { type: "reference" })
++  | ({ type: "thinking" } & Record<string, unknown>); 
+ 
+ /** @internal */
+ export const ContentChunk$inboundSchema: z.ZodType<
+@@ -46,13 +47,15 @@ export const ContentChunk$inboundSchema: z.ZodType<
+       type: v.type,
+     })),
+   ),
++  z.object({ type: z.literal("thinking") }).passthrough(),
+ ]);
+ 
+ /** @internal */
+ export type ContentChunk$Outbound =
+   | (ImageURLChunk$Outbound & { type: "image_url" })
+   | (TextChunk$Outbound & { type: "text" })
+-  | (ReferenceChunk$Outbound & { type: "reference" });
++  | (ReferenceChunk$Outbound & { type: "reference" })
++  | ({ type: "thinking" } & Record<string, unknown>); 
+ 
+ /** @internal */
+ export const ContentChunk$outboundSchema: z.ZodType<
+@@ -72,7 +75,9 @@ export const ContentChunk$outboundSchema: z.ZodType<
+     z.object({ type: z.literal("reference") }).transform((v) => ({
+       type: v.type,
+     })),
++    
+   ),
++  z.object({ type: z.literal("thinking") }).passthrough(),
+ ]);
+ 
+ /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,6 +214,9 @@ patchedDependencies:
   '@lezer/highlight':
     hash: 97f85e6fe46f23015ea0dd420e33d584bc2dc71633910cf131321da31b27ca8c
     path: patches/@lezer__highlight.patch
+  '@mistralai/mistralai':
+    hash: 3b2f0d598d51235411bc31d30808c6b88b5627a9ec03186a90c0e823445381cc
+    path: patches/@mistralai__mistralai.patch
   '@types/express-serve-static-core@5.0.6':
     hash: d602248fcd302cf5a794d1e85a411633ba9635ea5d566d6f2e0429c7ae0fa3eb
     path: patches/@types__express-serve-static-core@5.0.6.patch
@@ -20078,7 +20081,7 @@ snapshots:
   '@langchain/mistralai@0.2.1(@langchain/core@0.3.68(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(zod@3.25.67)':
     dependencies:
       '@langchain/core': 0.3.68(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))
-      '@mistralai/mistralai': 1.3.4(zod@3.25.67)
+      '@mistralai/mistralai': 1.3.4(patch_hash=3b2f0d598d51235411bc31d30808c6b88b5627a9ec03186a90c0e823445381cc)(zod@3.25.67)
       uuid: 10.0.0
     transitivePeerDependencies:
       - zod
@@ -20230,7 +20233,7 @@ snapshots:
 
   '@miragejs/pretender-node-polyfill@0.1.2': {}
 
-  '@mistralai/mistralai@1.3.4(zod@3.25.67)':
+  '@mistralai/mistralai@1.3.4(patch_hash=3b2f0d598d51235411bc31d30808c6b88b5627a9ec03186a90c0e823445381cc)(zod@3.25.67)':
     dependencies:
       zod: 3.25.67
 


### PR DESCRIPTION
## Summary

This PR addresses "Error in Agent node, when using Mistrals Magistral Thinking Models". The core problem is that some Mistral (Magistral) models emit streaming chunks with type: "thinking", which the existing Zod schema rejects, causing the stream to crash with invalid_union errors.




## Review / Merge checklist

- [x ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds support for Mistral Magistral "thinking" chunks by patching the SDK and flattening complex/streamed content to plain text while suppressing chain-of-thought.
> 
> - **AI Agents**:
>   - **Streaming/Output normalization**: In `ToolsAgent/V2/execute.ts`, flatten complex provider content (strings/blocks) to plain text via `flattenContentToText`, removing `<think>` tags and ignoring `thinking` blocks.
>   - **Streaming handling**: Update `on_chat_model_stream` to process `AIMessageChunk.content` when it's string or array of blocks; aggregate only textual content.
>   - **Non-streaming handling**: After `executor.invoke`, normalize `response.output` if it's an array/object/string to ensure plain text.
>   - **Types**: Import `MessageContentComplex` and support complex content blocks.
> - **Dependencies**:
>   - Patch `@mistralai/mistralai` schemas to accept `type: "thinking"` content chunks (TS/JS), and register the patch in `package.json` and `pnpm-lock.yaml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe72a2107790982a38df2a74c1993fad1a5fcd49. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->