### PR TITLE
feat(Anthropic Node): Support custom headers for model requests

### DIFF
--- a/packages/@n8n/nodes-langchain/credentials/AnthropicApi.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/AnthropicApi.credentials.ts
@@ -1,7 +1,8 @@
 import type {
-	IAuthenticateGeneric,
+	ICredentialDataDecryptedObject,
 	ICredentialTestRequest,
 	ICredentialType,
+	IHttpRequestOptions,
 	INodeProperties,
 } from 'n8n-workflow';
 
@@ -28,16 +29,38 @@ export class AnthropicApi implements ICredentialType {
 			default: 'https://api.anthropic.com',
 			description: 'Override the default base URL for the API',
 		},
-	];
-
-	authenticate: IAuthenticateGeneric = {
-		type: 'generic',
-		properties: {
-			headers: {
-				'x-api-key': '={{$credentials.apiKey}}',
-			},
+		{
+			displayName: 'Add Custom Header',
+			name: 'header',
+			type: 'boolean',
+			default: false,
 		},
-	};
+		{
+			displayName: 'Header Name',
+			name: 'headerName',
+			type: 'string',
+			displayOptions: {
+				show: {
+					header: [true],
+				},
+			},
+			default: '',
+		},
+		{
+			displayName: 'Header Value',
+			name: 'headerValue',
+			type: 'string',
+			typeOptions: {
+				password: true,
+			},
+			displayOptions: {
+				show: {
+					header: [true],
+				},
+			},
+			default: '',
+		},
+	];
 
 	test: ICredentialTestRequest = {
 		request: {
@@ -54,4 +77,24 @@ export class AnthropicApi implements ICredentialType {
 			},
 		},
 	};
+
+	async authenticate(
+		credentials: ICredentialDataDecryptedObject,
+		requestOptions: IHttpRequestOptions,
+	): Promise<IHttpRequestOptions> {
+		requestOptions.headers ??= {};
+
+		requestOptions.headers['x-api-key'] = credentials.apiKey;
+
+		if (
+			credentials.header &&
+			typeof credentials.headerName === 'string' &&
+			credentials.headerName &&
+			typeof credentials.headerValue === 'string'
+		) {
+			requestOptions.headers[credentials.headerName] = credentials.headerValue;
+		}
+
+		return requestOptions;
+	}
 }

--- a/packages/@n8n/nodes-langchain/credentials/test/AnthropicApi.credentials.test.ts
+++ b/packages/@n8n/nodes-langchain/credentials/test/AnthropicApi.credentials.test.ts
@@ -1,0 +1,158 @@
+import type { ICredentialDataDecryptedObject, IHttpRequestOptions } from 'n8n-workflow';
+
+import { AnthropicApi } from '../AnthropicApi.credentials';
+
+describe('AnthropicApi Credential', () => {
+	const anthropicApi = new AnthropicApi();
+
+	it('should have correct properties', () => {
+		expect(anthropicApi.name).toBe('anthropicApi');
+		expect(anthropicApi.displayName).toBe('Anthropic');
+		expect(anthropicApi.documentationUrl).toBe('anthropic');
+		expect(anthropicApi.properties).toHaveLength(5);
+		expect(anthropicApi.test.request.baseURL).toBe('={{$credentials?.url}}');
+		expect(anthropicApi.test.request.url).toBe('/v1/messages');
+	});
+
+	describe('authenticate', () => {
+		it('should add x-api-key header with API key only', async () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				apiKey: 'sk-ant-test123456789',
+			};
+
+			const requestOptions: IHttpRequestOptions = {
+				headers: {},
+				url: '/v1/messages',
+				baseURL: 'https://api.anthropic.com',
+			};
+
+			const result = await anthropicApi.authenticate(credentials, requestOptions);
+
+			expect(result.headers).toEqual({
+				'x-api-key': 'sk-ant-test123456789',
+			});
+		});
+
+		it('should add custom header when header toggle is enabled', async () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				apiKey: 'sk-ant-test123456789',
+				header: true,
+				headerName: 'X-Custom-Header',
+				headerValue: 'custom-value-123',
+			};
+
+			const requestOptions: IHttpRequestOptions = {
+				headers: {},
+				url: '/v1/messages',
+				baseURL: 'https://api.anthropic.com',
+			};
+
+			const result = await anthropicApi.authenticate(credentials, requestOptions);
+
+			expect(result.headers).toEqual({
+				'x-api-key': 'sk-ant-test123456789',
+				'X-Custom-Header': 'custom-value-123',
+			});
+		});
+
+		it('should not add custom header when header toggle is disabled', async () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				apiKey: 'sk-ant-test123456789',
+				header: false,
+				headerName: 'X-Custom-Header',
+				headerValue: 'custom-value-123',
+			};
+
+			const requestOptions: IHttpRequestOptions = {
+				headers: {},
+				url: '/v1/messages',
+				baseURL: 'https://api.anthropic.com',
+			};
+
+			const result = await anthropicApi.authenticate(credentials, requestOptions);
+
+			expect(result.headers).toEqual({
+				'x-api-key': 'sk-ant-test123456789',
+			});
+			expect(result.headers?.['X-Custom-Header']).toBeUndefined();
+		});
+
+		it('should preserve existing headers', async () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				apiKey: 'sk-ant-test123456789',
+				header: true,
+				headerName: 'X-Custom-Header',
+				headerValue: 'custom-value-123',
+			};
+
+			const requestOptions: IHttpRequestOptions = {
+				url: '/v1/messages',
+				baseURL: 'https://api.anthropic.com',
+			};
+
+			const result = await anthropicApi.authenticate(credentials, requestOptions);
+
+			const raw =
+				typeof (result.headers as any)?.get === 'function'
+					? Object.fromEntries((result.headers as unknown as Headers).entries())
+					: (result.headers as Record<string, string | undefined>);
+
+			const headers = Object.fromEntries(Object.entries(raw).map(([k, v]) => [k.toLowerCase(), v]));
+
+			expect(headers).toEqual(
+				expect.objectContaining({
+					'x-api-key': 'sk-ant-test123456789',
+					'x-custom-header': 'custom-value-123',
+				}),
+			);
+		});
+
+		it('should preserve existing headers when adding auth headers', async () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				apiKey: 'sk-ant-test123456789',
+			};
+
+			const requestOptions: IHttpRequestOptions = {
+				headers: {
+					'anthropic-version': '2023-06-01',
+				},
+				url: '/v1/messages',
+				baseURL: 'https://api.anthropic.com',
+			};
+
+			const result = await anthropicApi.authenticate(credentials, requestOptions);
+
+			expect(result.headers).toEqual({
+				'anthropic-version': '2023-06-01',
+				'x-api-key': 'sk-ant-test123456789',
+			});
+		});
+
+		it('should preserve existing headers even with custom header option enabled', async () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				apiKey: 'sk-ant-test123456789',
+				header: true,
+				headerName: 'X-Additional-Header',
+				headerValue: 'additional-value',
+			};
+
+			const requestOptions: IHttpRequestOptions = {
+				headers: {
+					'anthropic-version': '2023-06-01',
+					'X-Existing-Header': 'existing-value',
+				},
+				url: '/v1/messages',
+				baseURL: 'https://api.anthropic.com',
+			};
+
+			const result = await anthropicApi.authenticate(credentials, requestOptions);
+
+			expect(result.headers).toEqual({
+				'anthropic-version': '2023-06-01',
+				'X-Existing-Header': 'existing-value',
+				'x-api-key': 'sk-ant-test123456789',
+				'X-Additional-Header': 'additional-value',
+			});
+		});
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/llms/test/LmChatAnthropic.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/test/LmChatAnthropic.test.ts
@@ -1,0 +1,427 @@
+/* eslint-disable n8n-nodes-base/node-filename-against-convention */
+/* eslint-disable @typescript-eslint/unbound-method */
+import { ChatAnthropic } from '@langchain/anthropic';
+import { createMockExecuteFunction } from 'n8n-nodes-base/test/nodes/Helpers';
+import type { INode, ISupplyDataFunctions } from 'n8n-workflow';
+
+import { LmChatAnthropic } from '../LMChatAnthropic/LmChatAnthropic.node';
+import { N8nLlmTracing } from '../N8nLlmTracing';
+import { makeN8nLlmFailedAttemptHandler } from '../n8nLlmFailedAttemptHandler';
+
+jest.mock('@langchain/anthropic');
+jest.mock('../N8nLlmTracing');
+jest.mock('../n8nLlmFailedAttemptHandler');
+jest.mock('@utils/httpProxyAgent', () => ({
+	getProxyAgent: jest.fn().mockReturnValue({}),
+}));
+
+const MockedChatAnthropic = jest.mocked(ChatAnthropic);
+const MockedN8nLlmTracing = jest.mocked(N8nLlmTracing);
+const mockedMakeN8nLlmFailedAttemptHandler = jest.mocked(makeN8nLlmFailedAttemptHandler);
+
+describe('LmChatAnthropic', () => {
+	let lmChatAnthropic: LmChatAnthropic;
+	let mockContext: jest.Mocked<ISupplyDataFunctions>;
+
+	const mockNode: INode = {
+		id: '1',
+		name: 'Anthropic Chat Model',
+		typeVersion: 1.3,
+		type: 'n8n-nodes-langchain.lmChatAnthropic',
+		position: [0, 0],
+		parameters: {},
+	};
+
+	const setupMockContext = (nodeOverrides: Partial<INode> = {}) => {
+		const node = { ...mockNode, ...nodeOverrides };
+		mockContext = createMockExecuteFunction<ISupplyDataFunctions>(
+			{},
+			node,
+		) as jest.Mocked<ISupplyDataFunctions>;
+
+		// Setup default mocks
+		mockContext.getCredentials = jest.fn().mockResolvedValue({
+			apiKey: 'test-api-key',
+		});
+		mockContext.getNode = jest.fn().mockReturnValue(node);
+		mockContext.getNodeParameter = jest.fn();
+
+		// Mock the constructors/functions properly
+		MockedN8nLlmTracing.mockImplementation(() => ({}) as any);
+		mockedMakeN8nLlmFailedAttemptHandler.mockReturnValue(jest.fn());
+
+		return mockContext;
+	};
+
+	beforeEach(() => {
+		lmChatAnthropic = new LmChatAnthropic();
+		jest.clearAllMocks();
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('node description', () => {
+		it('should have correct node properties', () => {
+			expect(lmChatAnthropic.description).toMatchObject({
+				displayName: 'Anthropic Chat Model',
+				name: 'lmChatAnthropic',
+				group: ['transform'],
+				version: [1, 1.1, 1.2, 1.3],
+				description: 'Language Model Anthropic',
+			});
+		});
+
+		it('should have correct credentials configuration', () => {
+			expect(lmChatAnthropic.description.credentials).toEqual([
+				{
+					name: 'anthropicApi',
+					required: true,
+				},
+			]);
+		});
+
+		it('should have correct output configuration', () => {
+			expect(lmChatAnthropic.description.outputs).toEqual(['ai_languageModel']);
+			expect(lmChatAnthropic.description.outputNames).toEqual(['Model']);
+		});
+	});
+
+	describe('supplyData', () => {
+		it('should create ChatAnthropic instance with basic configuration (version >= 1.3)', async () => {
+			const mockContext = setupMockContext({ typeVersion: 1.3 });
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-20250514';
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			const result = await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			expect(mockContext.getCredentials).toHaveBeenCalledWith('anthropicApi');
+			expect(mockContext.getNodeParameter).toHaveBeenCalledWith('model.value', 0);
+			expect(mockContext.getNodeParameter).toHaveBeenCalledWith('options', 0, {});
+			expect(MockedChatAnthropic).toHaveBeenCalledWith(
+				expect.objectContaining({
+					anthropicApiKey: 'test-api-key',
+					model: 'claude-sonnet-4-20250514',
+					anthropicApiUrl: 'https://api.anthropic.com',
+					callbacks: expect.arrayContaining([expect.any(Object)]),
+					onFailedAttempt: expect.any(Function),
+					invocationKwargs: {},
+					clientOptions: {
+						fetchOptions: {
+							dispatcher: {},
+						},
+					},
+				}),
+			);
+
+			expect(result).toEqual({
+				response: expect.any(Object),
+			});
+		});
+
+		it('should create ChatAnthropic instance with basic configuration (version < 1.3)', async () => {
+			const mockContext = setupMockContext({ typeVersion: 1.2 });
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model') return 'claude-3-5-sonnet-20240620';
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			expect(mockContext.getNodeParameter).toHaveBeenCalledWith('model', 0);
+			expect(mockContext.getNodeParameter).toHaveBeenCalledWith('options', 0, {});
+			expect(MockedChatAnthropic).toHaveBeenCalledWith(
+				expect.objectContaining({
+					anthropicApiKey: 'test-api-key',
+					model: 'claude-3-5-sonnet-20240620',
+					anthropicApiUrl: 'https://api.anthropic.com',
+					callbacks: expect.arrayContaining([expect.any(Object)]),
+					onFailedAttempt: expect.any(Function),
+					invocationKwargs: {},
+					clientOptions: {
+						fetchOptions: {
+							dispatcher: {},
+						},
+					},
+				}),
+			);
+		});
+
+		it('should handle custom baseURL from credentials', async () => {
+			const customURL = 'https://custom-anthropic.example.com';
+			const mockContext = setupMockContext();
+
+			mockContext.getCredentials.mockResolvedValue({
+				apiKey: 'test-api-key',
+				url: customURL,
+			});
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-20250514';
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			expect(MockedChatAnthropic).toHaveBeenCalledWith(
+				expect.objectContaining({
+					anthropicApiKey: 'test-api-key',
+					model: 'claude-sonnet-4-20250514',
+					anthropicApiUrl: customURL,
+					callbacks: expect.arrayContaining([expect.any(Object)]),
+					onFailedAttempt: expect.any(Function),
+					invocationKwargs: {},
+					clientOptions: {
+						fetchOptions: {
+							dispatcher: {},
+						},
+					},
+				}),
+			);
+		});
+
+		it('should handle custom headers from credentials', async () => {
+			const mockContext = setupMockContext();
+
+			mockContext.getCredentials.mockResolvedValue({
+				apiKey: 'test-api-key',
+				header: true,
+				headerName: 'X-Custom-Header',
+				headerValue: 'custom-value',
+			});
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-20250514';
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			expect(MockedChatAnthropic).toHaveBeenCalledWith(
+				expect.objectContaining({
+					anthropicApiKey: 'test-api-key',
+					model: 'claude-sonnet-4-20250514',
+					anthropicApiUrl: 'https://api.anthropic.com',
+					callbacks: expect.arrayContaining([expect.any(Object)]),
+					onFailedAttempt: expect.any(Function),
+					invocationKwargs: {},
+					clientOptions: {
+						fetchOptions: {
+							dispatcher: {},
+						},
+						defaultHeaders: {
+							'X-Custom-Header': 'custom-value',
+						},
+					},
+				}),
+			);
+		});
+
+		it('should handle all available options', async () => {
+			const mockContext = setupMockContext();
+			const options = {
+				maxTokensToSample: 1000,
+				temperature: 0.8,
+				topK: 5,
+				topP: 0.9,
+			};
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-20250514';
+				if (paramName === 'options') return options;
+				return undefined;
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			expect(MockedChatAnthropic).toHaveBeenCalledWith(
+				expect.objectContaining({
+					anthropicApiKey: 'test-api-key',
+					model: 'claude-sonnet-4-20250514',
+					maxTokens: 1000,
+					temperature: 0.8,
+					topK: 5,
+					topP: 0.9,
+					anthropicApiUrl: 'https://api.anthropic.com',
+					callbacks: expect.arrayContaining([expect.any(Object)]),
+					onFailedAttempt: expect.any(Function),
+					invocationKwargs: {},
+					clientOptions: {
+						fetchOptions: {
+							dispatcher: {},
+						},
+					},
+				}),
+			);
+		});
+
+		it('should handle thinking mode', async () => {
+			const mockContext = setupMockContext();
+			const options = {
+				thinking: true,
+				thinkingBudget: 2048,
+				maxTokensToSample: 4096,
+			};
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-20250514';
+				if (paramName === 'options') return options;
+				return undefined;
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			expect(MockedChatAnthropic).toHaveBeenCalledWith(
+				expect.objectContaining({
+					anthropicApiKey: 'test-api-key',
+					model: 'claude-sonnet-4-20250514',
+					maxTokens: 4096,
+					anthropicApiUrl: 'https://api.anthropic.com',
+					callbacks: expect.arrayContaining([expect.any(Object)]),
+					onFailedAttempt: expect.any(Function),
+					invocationKwargs: {
+						thinking: {
+							type: 'enabled',
+							budget_tokens: 2048,
+						},
+						max_tokens: 4096,
+						top_k: undefined,
+						top_p: undefined,
+						temperature: undefined,
+					},
+					clientOptions: {
+						fetchOptions: {
+							dispatcher: {},
+						},
+					},
+				}),
+			);
+		});
+
+		it('should create N8nLlmTracing callback', async () => {
+			const mockContext = setupMockContext();
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-20250514';
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			expect(MockedN8nLlmTracing).toHaveBeenCalledWith(mockContext, {
+				tokensUsageParser: expect.any(Function),
+			});
+		});
+
+		it('should create failed attempt handler', async () => {
+			const mockContext = setupMockContext();
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-20250514';
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			expect(mockedMakeN8nLlmFailedAttemptHandler).toHaveBeenCalledWith(mockContext);
+		});
+
+		it('should not add custom headers when header toggle is disabled', async () => {
+			const mockContext = setupMockContext();
+
+			mockContext.getCredentials.mockResolvedValue({
+				apiKey: 'test-api-key',
+				header: false,
+				headerName: 'X-Custom-Header',
+				headerValue: 'custom-value',
+			});
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-20250514';
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			expect(MockedChatAnthropic).toHaveBeenCalledWith(
+				expect.objectContaining({
+					clientOptions: {
+						fetchOptions: {
+							dispatcher: {},
+						},
+					},
+				}),
+			);
+
+			// Verify that defaultHeaders is not set
+			const callArgs = MockedChatAnthropic.mock.calls[0]?.[0];
+			expect(callArgs?.clientOptions?.defaultHeaders).toBeUndefined();
+		});
+
+		it('should handle custom headers and custom URL together', async () => {
+			const customURL = 'https://custom-anthropic.example.com';
+			const mockContext = setupMockContext();
+
+			mockContext.getCredentials.mockResolvedValue({
+				apiKey: 'test-api-key',
+				url: customURL,
+				header: true,
+				headerName: 'X-Custom-Header',
+				headerValue: 'custom-value',
+			});
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-20250514';
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			expect(MockedChatAnthropic).toHaveBeenCalledWith(
+				expect.objectContaining({
+					anthropicApiKey: 'test-api-key',
+					model: 'claude-sonnet-4-20250514',
+					anthropicApiUrl: customURL,
+					callbacks: expect.arrayContaining([expect.any(Object)]),
+					onFailedAttempt: expect.any(Function),
+					invocationKwargs: {},
+					clientOptions: {
+						fetchOptions: {
+							dispatcher: {},
+						},
+						defaultHeaders: {
+							'X-Custom-Header': 'custom-value',
+						},
+					},
+				}),
+			);
+		});
+	});
+
+	describe('methods', () => {
+		beforeEach(() => {
+			setupMockContext();
+		});
+
+		it('should have searchModels method', () => {
+			expect(lmChatAnthropic.methods).toEqual({
+				listSearch: {
+					searchModels: expect.any(Function),
+				},
+			});
+		});
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/transport/index.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/transport/index.test.ts
@@ -163,4 +163,105 @@ describe('Anthropic transport', () => {
 			},
 		);
 	});
+
+	it('should add custom header when header toggle is enabled', async () => {
+		executeFunctionsMock.getCredentials.mockResolvedValue({
+			header: true,
+			headerName: 'X-Custom-Header',
+			headerValue: 'custom-value-123',
+		});
+
+		await apiRequest.call(executeFunctionsMock, 'POST', '/v1/messages');
+
+		expect(executeFunctionsMock.helpers.httpRequestWithAuthentication).toHaveBeenCalledWith(
+			'anthropicApi',
+			{
+				method: 'POST',
+				url: 'https://api.anthropic.com/v1/messages',
+				json: true,
+				headers: {
+					'anthropic-version': '2023-06-01',
+					'anthropic-beta': 'files-api-2025-04-14',
+					'X-Custom-Header': 'custom-value-123',
+				},
+			},
+		);
+	});
+
+	it('should not add custom header when header toggle is disabled', async () => {
+		executeFunctionsMock.getCredentials.mockResolvedValue({
+			header: false,
+			headerName: 'X-Custom-Header',
+			headerValue: 'custom-value-123',
+		});
+
+		await apiRequest.call(executeFunctionsMock, 'POST', '/v1/messages');
+
+		expect(executeFunctionsMock.helpers.httpRequestWithAuthentication).toHaveBeenCalledWith(
+			'anthropicApi',
+			{
+				method: 'POST',
+				url: 'https://api.anthropic.com/v1/messages',
+				json: true,
+				headers: {
+					'anthropic-version': '2023-06-01',
+					'anthropic-beta': 'files-api-2025-04-14',
+				},
+			},
+		);
+	});
+
+	it('should add custom header along with other headers', async () => {
+		executeFunctionsMock.getCredentials.mockResolvedValue({
+			header: true,
+			headerName: 'X-Custom-Header',
+			headerValue: 'custom-value-123',
+		});
+
+		await apiRequest.call(executeFunctionsMock, 'POST', '/v1/messages', {
+			headers: {
+				'Content-Type': 'application/json',
+			},
+		});
+
+		expect(executeFunctionsMock.helpers.httpRequestWithAuthentication).toHaveBeenCalledWith(
+			'anthropicApi',
+			{
+				method: 'POST',
+				url: 'https://api.anthropic.com/v1/messages',
+				json: true,
+				headers: {
+					'anthropic-version': '2023-06-01',
+					'anthropic-beta': 'files-api-2025-04-14',
+					'Content-Type': 'application/json',
+					'X-Custom-Header': 'custom-value-123',
+				},
+			},
+		);
+	});
+
+	it('should handle custom header with custom URL', async () => {
+		executeFunctionsMock.getCredentials.mockResolvedValue({
+			url: 'https://custom-url.com',
+			header: true,
+			headerName: 'X-Custom-Header',
+			headerValue: 'custom-value-123',
+		});
+
+		await apiRequest.call(executeFunctionsMock, 'POST', '/v1/messages');
+
+		expect(executeFunctionsMock.helpers.httpRequestWithAuthentication).toHaveBeenCalledWith(
+			'anthropicApi',
+			{
+				method: 'POST',
+				url: 'https://custom-url.com/v1/messages',
+				json: true,
+				headers: {
+					'anthropic-version': '2023-06-01',
+					'anthropic-beta': 'files-api-2025-04-14',
+					'X-Custom-Header': 'custom-value-123',
+				},
+			},
+		);
+	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/transport/index.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/transport/index.ts
@@ -38,12 +38,23 @@ export async function apiRequest(
 		betas.push('code-execution-2025-05-22');
 	}
 
+	const requestHeaders: IDataObject = {
+		'anthropic-version': '2023-06-01',
+		'anthropic-beta': betas.join(','),
+		...headers,
+	};
+
+	if (
+		credentials.header &&
+		typeof credentials.headerName === 'string' &&
+		credentials.headerName &&
+		typeof credentials.headerValue === 'string'
+	) {
+		requestHeaders[credentials.headerName] = credentials.headerValue;
+	}
+
 	const options = {
-		headers: {
-			'anthropic-version': '2023-06-01',
-			'anthropic-beta': betas.join(','),
-			...headers,
-		},
+		headers: requestHeaders,
 		method,
 		body,
 		qs,


### PR DESCRIPTION
Adds ability to define custom HTTP headers in Anthropic credentials, similar to existing OpenAI implementation. Headers are applied across chat model and vendor transport requests.

  ## Summary

  This PR adds support for custom HTTP headers in Anthropic API credentials, matching the functionality already available for OpenAI.

  **Changes:**
  - Added three new credential fields: toggle for custom headers, header name, and header value
  - Updated `AnthropicApi.credentials.ts` to use programmatic authentication for conditional header injection
  - Modified `LmChatAnthropic` node to pass custom headers via `clientOptions.defaultHeaders`
  - Updated Anthropic transport layer to include custom headers in all API requests
  - Added comprehensive test coverage across credentials, chat model, and transport layers

  **Use case:**
  Users can now add custom headers for scenarios like:
  - Routing through proxy servers that require custom authentication
  - Adding trace/correlation IDs for debugging
  - Custom CDN or gateway configurations

  **Testing:**
  All existing tests pass, plus 26 new tests added covering:
  - Custom header injection when enabled
  - Header omission when disabled
  - Interaction with existing headers and custom URLs

<img width="1196" height="749" alt="image" src="https://github.com/user-attachments/assets/96036300-dd5d-491e-a2fa-e5d31e8e65d5" />

  ## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-1495/support-custom-headers-for-model-requests-anthropic

  ## Review / Merge checklist

  - [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
  - [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
  - [x] Tests included.
  - [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)