### PR TITLE
fix(build):handle spaces in directory paths during OpenAPI bundling

### DIFF
--- a/packages/cli/scripts/build.mjs
+++ b/packages/cli/scripts/build.mjs
@@ -60,15 +60,17 @@ function copySwaggerTheme() {
 
 function bundleOpenApiSpecs() {
 	const publicApiDir = path.resolve(ROOT_DIR, 'src', 'public-api');
+	const srcDir = path.resolve(ROOT_DIR, 'src');
 
 	shell
 		.find(publicApiDir)
 		.reduce((acc, cur) => {
-			return cur.endsWith(SPEC_FILENAME) ? [...acc, path.relative('./src', cur)] : acc;
+			return cur.endsWith(SPEC_FILENAME) ? [...acc, path.relative(srcDir, cur)] : acc;
 		}, [])
 		.forEach((specPath) => {
+			const srcSpecPath = path.resolve(ROOT_DIR, 'src', specPath);
 			const distSpecPath = path.resolve(ROOT_DIR, 'dist', specPath);
-			const command = `pnpm openapi bundle src/${specPath} --output ${distSpecPath}`;
+			const command = `pnpm openapi bundle "${srcSpecPath}" --output "${distSpecPath}"`;
 
 			shell.exec(command, { silent: true });
 		});


### PR DESCRIPTION
## Summary

Problem:  
On Windows, the build process fails when the project path contains spaces (e.g., `D:/OSS Contributions/n8n`).  

- `pnpm build` reports multiple warnings:  
  *Command line error: No input files found*  
- `pnpm start` fails with:  
  `ENOENT: no such file or directory, open '.../dist/public-api/v1/openapi.yml'`

This happened because paths with spaces were not properly handled in the OpenAPI bundling step inside `packages/cli/build.mjs`.

Solution:  
- Quoted both source and destination paths in the bundling command.  
- Replaced hardcoded `'./src'` with a resolved `srcDir` for OS-independent path handling.  
- Introduced `srcSpecPath` alongside `distSpecPath` for clarity between input and output.  
- Ensured consistent use of `path.resolve` for readability and maintainability.  

Testing:  
1. Clone the project into a directory containing spaces (e.g., `D:/AB X/n8n`).  
2. Run `pnpm install`.  
3. Run `pnpm build`.  
   - Build completes successfully without “No input files found” warnings.  
4. Run `pnpm start`.  
   - Application runs correctly and finds `openapi.yml`.  
5. Verified again in a directory without spaces to ensure backward compatibility.  


## Related Linear tickets, Github issues, and Community forum posts

Fixes #20251  

---

## Review / Merge checklist

- [x] PR title and summary are descriptive. (conventions)  
- [ ] Docs updated or follow-up ticket created.  
- [x] Tests included (manual verification on Windows with/without spaces in paths).  
- [ ] PR labeled with release/backport (if the PR is an urgent fix that needs to be backported).  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Quote resolved source/destination paths and use a resolved `src` base to make OpenAPI bundling work when project paths contain spaces.
> 
> - **Build (CLI)**:
>   - **OpenAPI bundling**: 
>     - Use resolved `srcDir` (`path.resolve(ROOT_DIR, 'src')`) for path calculations.
>     - Quote full input/output paths in the `pnpm openapi bundle` command.
>     - Introduce `srcSpecPath` and use absolute paths for robust cross-OS handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93fff00ef2ad6a74a7f60a472699206a23ff9630. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->