### PR TITLE
ci: Run evals on changes

### DIFF
--- a/.github/workflows/ci-evals.yml
+++ b/.github/workflows/ci-evals.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Export Node Types
         run: |
-          ./packages/cli/n8n export:nodes --output ./packages/@n8n/ai-workflow-builder.ee/evaluations/nodes.json
+          ./packages/cli/bin/n8n export:nodes --output ./packages/@n8n/ai-workflow-builder.ee/evaluations/nodes.json
 
       - name: Run Evaluations
         working-directory: packages/@n8n/ai-workflow-builder.ee/evaluations

--- a/.github/workflows/ci-evals.yml
+++ b/.github/workflows/ci-evals.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - ai-1492-feature-set-up-running-evaluations-in-ci
     paths:
       - 'packages/@n8n/ai-workflow-builder.ee/**'
       - '.github/workflows/ci-evals.yml'
@@ -28,7 +29,6 @@ jobs:
         uses: ./.github/actions/setup-nodejs-github
 
       - name: Run Evaluations
-        continue-on-error: true
         working-directory: packages/@n8n/ai-workflow-builder.ee/evaluations
         run: |
           pnpm eval:langsmith

--- a/.github/workflows/ci-evals.yml
+++ b/.github/workflows/ci-evals.yml
@@ -28,6 +28,10 @@ jobs:
       - name: Setup and Build
         uses: ./.github/actions/setup-nodejs-blacksmith
 
+      - name: Export Node Types
+        run: |
+          ./packages/cli/n8n export:nodes --output ./packages/@n8n/ai-workflow-builder.ee/evaluations/nodes.json
+
       - name: Run Evaluations
         working-directory: packages/@n8n/ai-workflow-builder.ee/evaluations
         run: |

--- a/.github/workflows/ci-evals.yml
+++ b/.github/workflows/ci-evals.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   evals:
     name: Run Evaluations
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     env:
       N8N_AI_ANTHROPIC_KEY: ${{ secrets.EVALS_ANTHROPIC_KEY }}
       LANGSMITH_TRACING: true
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup and Build
-        uses: ./.github/actions/setup-nodejs-github
+        uses: ./.github/actions/setup-nodejs-blacksmith
 
       - name: Run Evaluations
         working-directory: packages/@n8n/ai-workflow-builder.ee/evaluations

--- a/.github/workflows/ci-evals.yml
+++ b/.github/workflows/ci-evals.yml
@@ -1,0 +1,34 @@
+name: Run Workflow Builder Evals
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'packages/@n8n/ai-workflow-builder.ee/**'
+      - '.github/workflows/ci-evals.yml'
+  pull_request:
+    paths:
+      - 'packages/@n8n/ai-workflow-builder.ee/**'
+      - '.github/workflows/ci-evals.yml'
+
+jobs:
+  evals:
+    name: Run Evaluations
+    runs-on: ubuntu-latest
+    env:
+      N8N_AI_ANTHROPIC_KEY: ${{ secrets.EVALS_ANTHROPIC_KEY }}
+      LANGSMITH_TRACING: true
+      LANGSMITH_ENDPOINT: ${{ secrets.EVALS_LANGSMITH_ENDPOINT }}
+      LANGSMITH_API_KEY: ${{ secrets.EVALS_LANGSMITH_API_KEY }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup and Build
+        uses: ./.github/actions/setup-nodejs-github
+
+      - name: Run Evaluations
+        continue-on-error: true
+        working-directory: packages/@n8n/ai-workflow-builder.ee/evaluations
+        run: |
+          pnpm eval:langsmith

--- a/.github/workflows/ci-evals.yml
+++ b/.github/workflows/ci-evals.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches:
       - master
-      - ai-1492-feature-set-up-running-evaluations-in-ci
-    paths:
-      - 'packages/@n8n/ai-workflow-builder.ee/**'
-      - '.github/workflows/ci-evals.yml'
-  pull_request:
     paths:
       - 'packages/@n8n/ai-workflow-builder.ee/**'
       - '.github/workflows/ci-evals.yml'

--- a/packages/cli/src/commands/export/nodes.ts
+++ b/packages/cli/src/commands/export/nodes.ts
@@ -20,7 +20,7 @@ const flagsSchema = z.object({
 @Command({
 	name: 'export:nodes',
 	description: 'Export all node types to a JSON file',
-	examples: ['', '--output=./custom-nodes.json', '--output=/tmp/nodes.json'],
+	examples: ['', '--output=/tmp/nodes.json'],
 	flagsSchema,
 })
 export class ExportNodes extends BaseCommand<z.infer<typeof flagsSchema>> {
@@ -33,7 +33,6 @@ export class ExportNodes extends BaseCommand<z.infer<typeof flagsSchema>> {
 		// Ensure output directory exists
 		await mkdir(outputDir, { recursive: true });
 
-		// Access LoadNodesAndCredentials directly from DI container
 		const loadNodesAndCredentials = Container.get(LoadNodesAndCredentials);
 		const { nodes } = loadNodesAndCredentials.types;
 

--- a/packages/cli/src/commands/export/nodes.ts
+++ b/packages/cli/src/commands/export/nodes.ts
@@ -1,0 +1,59 @@
+import { Command } from '@n8n/decorators';
+import { Container } from '@n8n/di';
+import { createWriteStream } from 'fs';
+import { mkdir } from 'fs/promises';
+import type { INodeTypeBaseDescription } from 'n8n-workflow';
+import path from 'path';
+import z from 'zod';
+
+import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
+
+import { BaseCommand } from '../base-command';
+
+const flagsSchema = z.object({
+	output: z
+		.string()
+		.default('./nodes.json')
+		.describe('Path to the output file for node types JSON'),
+});
+
+@Command({
+	name: 'export:nodes',
+	description: 'Export all node types to a JSON file',
+	examples: ['', '--output=./custom-nodes.json', '--output=/tmp/nodes.json'],
+	flagsSchema,
+})
+export class ExportNodes extends BaseCommand<z.infer<typeof flagsSchema>> {
+	async run() {
+		const outputPath = path.resolve(this.flags.output);
+		const outputDir = path.dirname(outputPath);
+
+		this.logger.info(`Exporting node types to ${outputPath}...`);
+
+		// Ensure output directory exists
+		await mkdir(outputDir, { recursive: true });
+
+		// Access LoadNodesAndCredentials directly from DI container
+		const loadNodesAndCredentials = Container.get(LoadNodesAndCredentials);
+		const { nodes } = loadNodesAndCredentials.types;
+
+		this.logger.info(`Found ${nodes.length} node types`);
+
+		// Write nodes to JSON file using streaming
+		this.writeNodesJSON(outputPath, nodes);
+
+		this.logger.info(`Successfully exported ${nodes.length} node types to ${outputPath}`);
+	}
+
+	private writeNodesJSON(filePath: string, nodes: INodeTypeBaseDescription[]) {
+		const stream = createWriteStream(filePath, 'utf-8');
+		stream.write('[\n');
+		nodes.forEach((entry, index) => {
+			stream.write(JSON.stringify(entry));
+			if (index !== nodes.length - 1) stream.write(',');
+			stream.write('\n');
+		});
+		stream.write(']\n');
+		stream.end();
+	}
+}


### PR DESCRIPTION
## Summary

Run evaluations for the AI workflow builder in CI.
Also the new `export:nodes` command was added to use in CI.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-1492/feature-set-up-running-evaluations-in-ci


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
