### PR TITLE
fix: Fix font paths in design system

### DIFF
--- a/packages/frontend/@n8n/design-system/src/css/fonts/fonts.scss
+++ b/packages/frontend/@n8n/design-system/src/css/fonts/fonts.scss
@@ -3,19 +3,19 @@
 	font-style: normal;
 	font-weight: 100 900;
 	font-display: swap;
-	src: url('fonts/InterVariable.woff2') format('woff2');
+	src: url('./InterVariable.woff2') format('woff2');
 }
 @font-face {
 	font-family: InterVariable;
 	font-style: italic;
 	font-weight: 100 900;
 	font-display: swap;
-	src: url('fonts/InterVariable-Italic.woff2') format('woff2');
+	src: url('./InterVariable-Italic.woff2') format('woff2');
 }
 @font-face {
 	font-family: CommitMono;
 	font-style: italic;
 	font-weight: 100 900;
 	font-display: swap;
-	src: url('fonts/CommitMonoVariable.woff2') format('woff2');
+	src: url('./CommitMonoVariable.woff2') format('woff2');
 }


### PR DESCRIPTION
## Summary

Fix for Chromatic error: 
<img width="768" height="316" alt="image" src="https://github.com/user-attachments/assets/b5113614-260c-49ca-93cc-8c3243c5b108" />


## Related Linear tickets, Github issues, and Community forum posts

N/A


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
