### PR TITLE
chore: Add environment connection type to telemetry data

### DIFF
--- a/packages/cli/src/environments.ee/source-control/source-control.controller.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control.controller.ee.ts
@@ -96,6 +96,7 @@ export class SourceControlController {
 				connected: resultingPreferences.connected,
 				readOnlyInstance: resultingPreferences.branchReadOnly,
 				repoType: getRepoType(resultingPreferences.repositoryUrl),
+				connectionType: resultingPreferences.connectionType!,
 			});
 			// #endregion
 			return resultingPreferences;
@@ -141,6 +142,7 @@ export class SourceControlController {
 				connected: resultingPreferences.connected,
 				readOnlyInstance: resultingPreferences.branchReadOnly,
 				repoType: getRepoType(resultingPreferences.repositoryUrl),
+				connectionType: resultingPreferences.connectionType!,
 			});
 			return resultingPreferences;
 		} catch (error) {

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -214,6 +214,7 @@ describe('TelemetryEventRelay', () => {
 				readOnlyInstance: false,
 				repoType: 'github',
 				connected: true,
+				connectionType: 'ssh',
 			};
 
 			eventService.emit('source-control-settings-updated', event);
@@ -223,6 +224,7 @@ describe('TelemetryEventRelay', () => {
 				read_only_instance: false,
 				repo_type: 'github',
 				connected: true,
+				connection_type: 'ssh',
 			});
 		});
 

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -408,6 +408,7 @@ export type RelayEventMap = {
 		readOnlyInstance: boolean;
 		repoType: 'github' | 'gitlab' | 'other';
 		connected: boolean;
+		connectionType: 'ssh' | 'https';
 	};
 
 	'source-control-user-started-pull-ui': {

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -167,12 +167,14 @@ export class TelemetryEventRelay extends EventRelay {
 		readOnlyInstance,
 		repoType,
 		connected,
+		connectionType,
 	}: RelayEventMap['source-control-settings-updated']) {
 		this.telemetry.track('User updated source control settings', {
 			branch_name: branchName,
 			read_only_instance: readOnlyInstance,
 			repo_type: repoType,
 			connected,
+			connection_type: connectionType,
 		});
 	}
 


### PR DESCRIPTION
## Summary

To help us track adoption.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-1754/feature-add-support-for-https-for-environments-source-control#comment-2fd9f8c3


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
