### PR TITLE
feat(core): Use project variable in executions

### DIFF
--- a/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
+++ b/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
@@ -105,7 +105,7 @@ describe('WorkflowExecuteAdditionalData', () => {
 	Container.set(UrlService, urlService);
 
 	test('logAiEvent should call MessageEventBus', async () => {
-		const additionalData = await getBase('user-id');
+		const additionalData = await getBase({ userId: 'user-id', workflowId: 'workflow-id' });
 
 		const eventName = 'ai-messages-retrieved-from-memory';
 		const payload = {
@@ -315,21 +315,23 @@ describe('WorkflowExecuteAdditionalData', () => {
 
 		it('should include userId when provided', async () => {
 			const userId = 'test-user-id';
-			const additionalData = await getBase(userId);
+			const additionalData = await getBase({ userId });
 
 			expect(additionalData.userId).toBe(userId);
 		});
 
 		it('should include currentNodeParameters when provided', async () => {
 			const currentNodeParameters = { param1: 'value1' };
-			const additionalData = await getBase(undefined, currentNodeParameters);
+			const additionalData = await getBase({ currentNodeParameters });
 
 			expect(additionalData.currentNodeParameters).toBe(currentNodeParameters);
 		});
 
 		it('should include executionTimeoutTimestamp when provided', async () => {
 			const executionTimeoutTimestamp = Date.now() + 1000;
-			const additionalData = await getBase(undefined, undefined, executionTimeoutTimestamp);
+			const additionalData = await getBase({
+				executionTimeoutTimestamp,
+			});
 
 			expect(additionalData.executionTimeoutTimestamp).toBe(executionTimeoutTimestamp);
 		});

--- a/packages/cli/src/__tests__/workflow-helpers.test.ts
+++ b/packages/cli/src/__tests__/workflow-helpers.test.ts
@@ -1,0 +1,65 @@
+import { mockInstance } from '@n8n/backend-test-utils';
+import type { Project, Variables } from '@n8n/db';
+
+import { VariablesService } from '@/environments.ee/variables/variables.service.ee';
+import { OwnershipService } from '@/services/ownership.service';
+import { getVariables } from '@/workflow-helpers';
+
+describe('workflow-helpers', () => {
+	beforeAll(() => {
+		mockInstance(VariablesService, {
+			async getAllCached() {
+				return [
+					{ id: '1', key: 'VAR1', value: 'value1' },
+					{ id: '2', key: 'VAR2', value: 'value2' },
+					{
+						id: '3',
+						key: 'VAR2',
+						value: 'value1Project',
+						project: { id: '1', name: 'project1' } as Project,
+					},
+					{
+						id: '4',
+						key: 'VAR4',
+						value: 'value4',
+						project: { id: '1', name: 'project1' } as Project,
+					},
+					{
+						id: '5',
+						key: 'VAR5',
+						value: 'value5',
+						project: { id: '2', name: 'project2' } as Project,
+					},
+				] as Variables[];
+			},
+		});
+
+		mockInstance(OwnershipService, {
+			async getWorkflowProjectCached(_workflowId: string) {
+				return { id: '1', name: 'project' } as unknown as Project;
+			},
+		});
+	});
+
+	describe('getVariables', () => {
+		it('should return all variables as key-value pairs if no parameters are given', async () => {
+			const variables = await getVariables();
+			expect(variables).toEqual({ VAR1: 'value1', VAR2: 'value2' });
+		});
+
+		it('should return global and project variables if projectId is given', async () => {
+			const variables = await getVariables(undefined, '1');
+			expect(variables).toEqual({ VAR1: 'value1', VAR2: 'value1Project', VAR4: 'value4' });
+		});
+
+		it('should return global and project variables if workflowId is given', async () => {
+			const variables = await getVariables('1');
+			expect(variables).toEqual({ VAR1: 'value1', VAR2: 'value1Project', VAR4: 'value4' });
+		});
+
+		it('should prioritize passed of projectId over workflowId', async () => {
+			const variables = await getVariables('1', '2');
+			expect(variables).toEqual({ VAR1: 'value1', VAR2: 'value2', VAR5: 'value5' });
+		});
+	});
+});

--- a/packages/cli/src/active-workflow-manager.ts
+++ b/packages/cli/src/active-workflow-manager.ts
@@ -1,4 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import {
+	STARTING_NODES,
+	WORKFLOW_REACTIVATE_INITIAL_TIMEOUT,
+	WORKFLOW_REACTIVATE_MAX_TIMEOUT,
+} from '@/constants';
 import { Logger } from '@n8n/backend-common';
 import { WorkflowsConfig } from '@n8n/config';
 import type { WorkflowEntity, IWorkflowDb } from '@n8n/db';
@@ -40,11 +45,6 @@ import { strict } from 'node:assert';
 
 import { ActivationErrorsService } from '@/activation-errors.service';
 import { ActiveExecutions } from '@/active-executions';
-import {
-	STARTING_NODES,
-	WORKFLOW_REACTIVATE_INITIAL_TIMEOUT,
-	WORKFLOW_REACTIVATE_MAX_TIMEOUT,
-} from '@/constants';
 import { executeErrorWorkflow } from '@/execution-lifecycle/execute-error-workflow';
 import { ExecutionService } from '@/executions/execution.service';
 import { ExternalHooks } from '@/external-hooks';
@@ -267,7 +267,7 @@ export class ActiveWorkflowManager {
 
 		const mode = 'internal';
 
-		const additionalData = await WorkflowExecuteAdditionalData.getBase();
+		const additionalData = await WorkflowExecuteAdditionalData.getBase({ workflowId: workflow.id });
 
 		const webhooks = WebhookHelpers.getWorkflowWebhooks(workflow, additionalData, undefined, true);
 
@@ -597,7 +597,9 @@ export class ActiveWorkflowManager {
 				);
 			}
 
-			const additionalData = await WorkflowExecuteAdditionalData.getBase();
+			const additionalData = await WorkflowExecuteAdditionalData.getBase({
+				workflowId: workflow.id,
+			});
 
 			if (shouldAddWebhooks) {
 				added.webhooks = await this.addWebhooks(
@@ -651,7 +653,10 @@ export class ActiveWorkflowManager {
 	handleDisplayWorkflowActivationError({
 		workflowId,
 		errorMessage,
-	}: { workflowId: string; errorMessage: string }) {
+	}: {
+		workflowId: string;
+		errorMessage: string;
+	}) {
 		this.push.broadcast({
 			type: 'workflowFailedToActivate',
 			data: { workflowId, errorMessage },

--- a/packages/cli/src/chat/chat-execution-manager.ts
+++ b/packages/cli/src/chat/chat-execution-manager.ts
@@ -90,7 +90,7 @@ export class ChatExecutionManager {
 		const workflow = this.getWorkflow(execution);
 		const lastNodeExecuted = execution.data.resultData.lastNodeExecuted as string;
 		const node = workflow.getNode(lastNodeExecuted);
-		const additionalData = await WorkflowExecuteAdditionalData.getBase();
+		const additionalData = await WorkflowExecuteAdditionalData.getBase({ workflowId: workflow.id });
 		const executionData = execution.data.executionData?.nodeExecutionStack[0];
 
 		if (!node || !executionData) return null;

--- a/packages/cli/src/controllers/dynamic-node-parameters.controller.ts
+++ b/packages/cli/src/controllers/dynamic-node-parameters.controller.ts
@@ -33,7 +33,11 @@ export class DynamicNodeParametersController {
 			projectId,
 		} = payload;
 
-		const additionalData = await getBase(req.user.id, currentNodeParameters);
+		const additionalData = await getBase({
+			userId: req.user.id,
+			projectId,
+			currentNodeParameters,
+		});
 		additionalData.dataTableProjectId = projectId;
 
 		if (methodName) {
@@ -79,7 +83,11 @@ export class DynamicNodeParametersController {
 			projectId,
 		} = payload;
 
-		const additionalData = await getBase(req.user.id, currentNodeParameters);
+		const additionalData = await getBase({
+			userId: req.user.id,
+			projectId,
+			currentNodeParameters,
+		});
 		additionalData.dataTableProjectId = projectId;
 
 		return await this.service.getResourceLocatorResults(
@@ -105,7 +113,11 @@ export class DynamicNodeParametersController {
 		const { path, methodName, credentials, currentNodeParameters, nodeTypeAndVersion, projectId } =
 			payload;
 
-		const additionalData = await getBase(req.user.id, currentNodeParameters);
+		const additionalData = await getBase({
+			userId: req.user.id,
+			projectId,
+			currentNodeParameters,
+		});
 		additionalData.dataTableProjectId = projectId;
 
 		return await this.service.getResourceMappingFields(
@@ -124,9 +136,15 @@ export class DynamicNodeParametersController {
 		_res: Response,
 		@Body payload: ResourceMapperFieldsRequestDto,
 	) {
-		const { path, methodName, currentNodeParameters, nodeTypeAndVersion } = payload;
+		await this.service.scrubInaccessibleProjectId(req.user, payload);
 
-		const additionalData = await getBase(req.user.id, currentNodeParameters);
+		const { path, methodName, currentNodeParameters, nodeTypeAndVersion, projectId } = payload;
+
+		const additionalData = await getBase({
+			userId: req.user.id,
+			currentNodeParameters,
+			projectId,
+		});
 
 		return await this.service.getLocalResourceMappingFields(
 			methodName,
@@ -142,6 +160,8 @@ export class DynamicNodeParametersController {
 		_res: Response,
 		@Body payload: ActionResultRequestDto,
 	): Promise<NodeParameterValueType> {
+		await this.service.scrubInaccessibleProjectId(req.user, payload);
+
 		const {
 			currentNodeParameters,
 			nodeTypeAndVersion,
@@ -149,9 +169,14 @@ export class DynamicNodeParametersController {
 			credentials,
 			handler,
 			payload: actionPayload,
+			projectId,
 		} = payload;
 
-		const additionalData = await getBase(req.user.id, currentNodeParameters);
+		const additionalData = await getBase({
+			userId: req.user.id,
+			projectId,
+			currentNodeParameters,
+		});
 
 		return await this.service.getActionResult(
 			handler,

--- a/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
@@ -1,6 +1,6 @@
 import type { Logger } from '@n8n/backend-common';
 import type { ExecutionsConfig } from '@n8n/config';
-import type { IExecutionResponse, ExecutionRepository } from '@n8n/db';
+import type { IExecutionResponse, ExecutionRepository, Project } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
 import type { WorkflowExecute as ActualWorkflowExecute } from 'n8n-core';
 import { ExternalSecretsProxy } from 'n8n-core';
@@ -22,6 +22,7 @@ import { VariablesService } from '@/environments.ee/variables/variables.service.
 import { ExternalHooks } from '@/external-hooks';
 import type { ManualExecutionService } from '@/manual-execution.service';
 import { DataTableProxyService } from '@/modules/data-table/data-table-proxy.service';
+import { OwnershipService } from '@/services/ownership.service';
 import { WorkflowStatisticsService } from '@/services/workflow-statistics.service';
 import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
 import { WorkflowStaticDataService } from '@/workflows/workflow-static-data.service';
@@ -35,6 +36,9 @@ mockInstance(WorkflowStaticDataService);
 mockInstance(WorkflowStatisticsService);
 mockInstance(ExternalHooks);
 mockInstance(DataTableProxyService);
+mockInstance(OwnershipService, {
+	getWorkflowProjectCached: jest.fn().mockResolvedValue(mock<Project>({ id: 'project-id' })),
+});
 
 const processRunExecutionDataMock = jest.fn();
 jest.mock('n8n-core', () => {
@@ -117,7 +121,7 @@ describe('JobProcessor', () => {
 		const pinData: IPinData = { pinned: [] };
 		const execution = mock<IExecutionResponse>({
 			mode: 'manual',
-			workflowData: { nodes: [], pinData },
+			workflowData: { id: 'workflow-id', nodes: [], pinData },
 			data: mock<IRunExecutionData>({
 				resultData: {
 					runData: {
@@ -149,11 +153,10 @@ describe('JobProcessor', () => {
 		const executionId = 'execution-id';
 		await jobProcessor.processJob(mock<Job>({ data: { executionId, loadStaticData: false } }));
 
-		expect(WorkflowExecuteAdditionalData.getBase).toHaveBeenCalledWith(
-			undefined,
-			undefined,
-			undefined,
-		);
+		expect(WorkflowExecuteAdditionalData.getBase).toHaveBeenCalledWith({
+			workflowId: execution.workflowData.id,
+			executionTimeoutTimestamp: undefined,
+		});
 
 		expect(manualExecutionService.runManually).toHaveBeenCalledWith(
 			expect.objectContaining({

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -14,12 +14,6 @@ import type {
 import { BINARY_ENCODING, Workflow, UnexpectedError } from 'n8n-workflow';
 import type PCancelable from 'p-cancelable';
 
-import { EventService } from '@/events/event.service';
-import { getLifecycleHooksForScalingWorker } from '@/execution-lifecycle/execution-lifecycle-hooks';
-import { ManualExecutionService } from '@/manual-execution.service';
-import { NodeTypes } from '@/node-types';
-import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
-
 import type {
 	Job,
 	JobFinishedMessage,
@@ -29,6 +23,12 @@ import type {
 	RunningJob,
 	SendChunkMessage,
 } from './scaling.types';
+
+import { EventService } from '@/events/event.service';
+import { getLifecycleHooksForScalingWorker } from '@/execution-lifecycle/execution-lifecycle-hooks';
+import { ManualExecutionService } from '@/manual-execution.service';
+import { NodeTypes } from '@/node-types';
+import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
 
 /**
  * Responsible for processing jobs from the queue, i.e. running enqueued executions.
@@ -120,11 +120,10 @@ export class JobProcessor {
 			settings: execution.workflowData.settings,
 		});
 
-		const additionalData = await WorkflowExecuteAdditionalData.getBase(
-			undefined,
-			undefined,
+		const additionalData = await WorkflowExecuteAdditionalData.getBase({
+			workflowId,
 			executionTimeoutTimestamp,
-		);
+		});
 		additionalData.streamingEnabled = job.data.streamingEnabled;
 
 		const { pushRef } = job.data;

--- a/packages/cli/src/services/credentials-tester.service.ts
+++ b/packages/cli/src/services/credentials-tester.service.ts
@@ -29,13 +29,13 @@ import type {
 } from 'n8n-workflow';
 import { VersionedNodeType, NodeHelpers, Workflow, UnexpectedError } from 'n8n-workflow';
 
+import { RESPONSE_ERROR_MESSAGES } from '../constants';
+import { CredentialsHelper } from '../credentials-helper';
+
 import { CredentialTypes } from '@/credential-types';
 import { NodeTypes } from '@/node-types';
 import { getAllKeyPaths } from '@/utils';
 import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
-
-import { RESPONSE_ERROR_MESSAGES } from '../constants';
-import { CredentialsHelper } from '../credentials-helper';
 
 const { OAUTH2_CREDENTIAL_TEST_SUCCEEDED, OAUTH2_CREDENTIAL_TEST_FAILED } = RESPONSE_ERROR_MESSAGES;
 
@@ -200,7 +200,10 @@ export class CredentialsTester {
 		let credentialsDataSecretKeys: string[] = [];
 		if (credentialsDecrypted.data) {
 			try {
-				const additionalData = await WorkflowExecuteAdditionalData.getBase(userId);
+				const additionalData = await WorkflowExecuteAdditionalData.getBase({
+					userId,
+					projectId: credentialsDecrypted.homeProject?.id,
+				});
 
 				// Keep all credentials data keys which have a secret value
 				credentialsDataSecretKeys = getAllKeyPaths(credentialsDecrypted.data, '', [], (value) =>
@@ -324,7 +327,11 @@ export class CredentialsTester {
 			},
 		};
 
-		const additionalData = await WorkflowExecuteAdditionalData.getBase(userId, node.parameters);
+		const additionalData = await WorkflowExecuteAdditionalData.getBase({
+			userId,
+			projectId: credentialsDecrypted.homeProject?.id,
+			currentNodeParameters: node.parameters,
+		});
 
 		const executeData: IExecuteData = { node, data: {}, source: null };
 		const executeFunctions = new ExecuteContext(

--- a/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
@@ -192,7 +192,10 @@ describe('TestWebhooks', () => {
 
 			await testWebhooks.deactivateWebhooks(workflow);
 
-			expect(mockedAdditionalData.getBase).toHaveBeenCalledWith(userId);
+			expect(mockedAdditionalData.getBase).toHaveBeenCalledWith({
+				userId,
+				workflowId: workflowEntity.id,
+			});
 		});
 	});
 

--- a/packages/cli/src/webhooks/live-webhooks.ts
+++ b/packages/cli/src/webhooks/live-webhooks.ts
@@ -5,14 +5,6 @@ import type { Response } from 'express';
 import { Workflow, CHAT_TRIGGER_NODE_TYPE } from 'n8n-workflow';
 import type { INode, IWebhookData, IHttpRequestMethods } from 'n8n-workflow';
 
-import { NotFoundError } from '@/errors/response-errors/not-found.error';
-import { WebhookNotFoundError } from '@/errors/response-errors/webhook-not-found.error';
-import { NodeTypes } from '@/node-types';
-import * as WebhookHelpers from '@/webhooks/webhook-helpers';
-import { WebhookService } from '@/webhooks/webhook.service';
-import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
-import { WorkflowStaticDataService } from '@/workflows/workflow-static-data.service';
-
 import { authAllowlistedNodes } from './constants';
 import { sanitizeWebhookRequest } from './webhook-request-sanitizer';
 import type {
@@ -21,6 +13,14 @@ import type {
 	WebhookAccessControlOptions,
 	WebhookRequest,
 } from './webhook.types';
+
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { WebhookNotFoundError } from '@/errors/response-errors/webhook-not-found.error';
+import { NodeTypes } from '@/node-types';
+import * as WebhookHelpers from '@/webhooks/webhook-helpers';
+import { WebhookService } from '@/webhooks/webhook.service';
+import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
+import { WorkflowStaticDataService } from '@/workflows/workflow-static-data.service';
 
 /**
  * Service for handling the execution of live webhooks, i.e. webhooks
@@ -114,7 +114,11 @@ export class LiveWebhooks implements IWebhookManager {
 			settings: workflowData.settings,
 		});
 
-		const additionalData = await WorkflowExecuteAdditionalData.getBase();
+		const ownerProjectId = workflowData.shared.find((share) => share.role === 'workflow:owner')
+			?.project.id;
+		const additionalData = await WorkflowExecuteAdditionalData.getBase({
+			projectId: ownerProjectId,
+		});
 
 		const webhookData = this.webhookService
 			.getNodeWebhooks(workflow, workflow.getNode(webhook.node) as INode, additionalData)

--- a/packages/cli/src/webhooks/waiting-webhooks.ts
+++ b/packages/cli/src/webhooks/waiting-webhooks.ts
@@ -19,12 +19,6 @@ import {
 	Workflow,
 } from 'n8n-workflow';
 
-import { ConflictError } from '@/errors/response-errors/conflict.error';
-import { NotFoundError } from '@/errors/response-errors/not-found.error';
-import { NodeTypes } from '@/node-types';
-import * as WebhookHelpers from '@/webhooks/webhook-helpers';
-import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
-
 import { sanitizeWebhookRequest } from './webhook-request-sanitizer';
 import { WebhookService } from './webhook.service';
 import type {
@@ -32,6 +26,12 @@ import type {
 	IWebhookManager,
 	WaitingWebhookRequest,
 } from './webhook.types';
+
+import { ConflictError } from '@/errors/response-errors/conflict.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { NodeTypes } from '@/node-types';
+import * as WebhookHelpers from '@/webhooks/webhook-helpers';
+import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
 
 /**
  * Service for handling the execution of webhooks of Wait nodes that use the
@@ -211,7 +211,9 @@ export class WaitingWebhooks implements IWebhookManager {
 			throw new NotFoundError('Could not find node to process webhook.');
 		}
 
-		const additionalData = await WorkflowExecuteAdditionalData.getBase();
+		const additionalData = await WorkflowExecuteAdditionalData.getBase({
+			workflowId: workflow.id,
+		});
 		const webhookData = this.webhookService
 			.getNodeWebhooks(workflow, workflowStartNode, additionalData)
 			.find(

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -396,7 +396,9 @@ export async function executeWebhook(
 	}
 
 	// Prepare everything that is needed to run the workflow
-	const additionalData = await WorkflowExecuteAdditionalData.getBase();
+	const additionalData = await WorkflowExecuteAdditionalData.getBase({
+		projectId: project?.id,
+	});
 
 	if (executionId) {
 		additionalData.executionId = executionId;

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -36,7 +36,6 @@ import { ActiveExecutions } from '@/active-executions';
 import { CredentialsHelper } from '@/credentials-helper';
 import { EventService } from '@/events/event.service';
 import type { AiEventMap, AiEventPayload } from '@/events/maps/ai.event-map';
-// eslint-disable-next-line import-x/no-cycle
 import { getLifecycleHooksForSubExecutions } from '@/execution-lifecycle/execution-lifecycle-hooks';
 import { ExecutionDataService } from '@/executions/execution-data.service';
 import {
@@ -363,17 +362,31 @@ export function sendDataToUI(type: PushType, data: IDataObject | IDataObject[]) 
 
 /**
  * Returns the base additional data without webhooks
+ * @returns {IWorkflowExecuteAdditionalData}
+ * param userId - The ID of the user executing the workflow, if available
+ * param workflowId - The ID of the workflow being executed, if available
+ * param projectId - The ID of the project the workflow is owned by, if available
+ * param currentNodeParameters - The parameters of the currently executing node
+ * param executionTimeoutTimestamp - The timestamp (in ms) when the execution should time out
  */
-export async function getBase(
-	userId?: string,
-	currentNodeParameters?: INodeParameters,
-	executionTimeoutTimestamp?: number,
-): Promise<IWorkflowExecuteAdditionalData> {
+export async function getBase({
+	userId,
+	workflowId,
+	projectId,
+	currentNodeParameters,
+	executionTimeoutTimestamp,
+}: {
+	userId?: string;
+	workflowId?: string;
+	projectId?: string;
+	currentNodeParameters?: INodeParameters;
+	executionTimeoutTimestamp?: number;
+} = {}): Promise<IWorkflowExecuteAdditionalData> {
 	const urlBaseWebhook = Container.get(UrlService).getWebhookBaseUrl();
 
 	const globalConfig = Container.get(GlobalConfig);
 
-	const variables = await WorkflowHelpers.getVariables();
+	const variables = await WorkflowHelpers.getVariables(workflowId, projectId);
 
 	const eventService = Container.get(EventService);
 

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -248,11 +248,12 @@ export class WorkflowRunner {
 			pinData,
 		});
 
-		const additionalData = await WorkflowExecuteAdditionalData.getBase(
-			data.userId,
-			undefined,
-			workflowTimeout <= 0 ? undefined : Date.now() + workflowTimeout * 1000,
-		);
+		const additionalData = await WorkflowExecuteAdditionalData.getBase({
+			userId: data.userId,
+			workflowId: workflow.id,
+			executionTimeoutTimestamp:
+				workflowTimeout <= 0 ? undefined : Date.now() + workflowTimeout * 1000,
+		});
 		// TODO: set this in queue mode as well
 		additionalData.restartExecutionId = restartExecutionId;
 		additionalData.streamingEnabled = data.streamingEnabled;

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -151,7 +151,10 @@ export class WorkflowExecutionService {
 				startNodes.length === 0 ||
 				destinationNode === undefined)
 		) {
-			const additionalData = await WorkflowExecuteAdditionalData.getBase(user.id);
+			const additionalData = await WorkflowExecuteAdditionalData.getBase({
+				userId: user.id,
+				workflowId: workflowData.id,
+			});
 
 			const needsWebhook = await this.testWebhooks.needsWebhook({
 				userId: user.id,


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR introduce project variables for executions. It adds `workflowId` and `projectId` as optional parameter to the workflow helper `getVariables` function.
This function now uses the projectId of the execution context to override global variables with execution project variables if exists.
The PR then tries to provide this projectId / workflowId everywhere the getBase function of the workflow-execute-additional-data.ts is called, so that the variables are contextualized

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2105/use-project-variable-in-executions
https://linear.app/n8n/issue/PAY-2107/use-project-variables-in-credentials

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
