### PR TITLE
chore(editor-ui): guard randomUUID polyfill via globalThis.crypto and avoid direct crypto reference

### DIFF
--- a/packages/frontend/editor-ui/src/polyfills.ts
+++ b/packages/frontend/editor-ui/src/polyfills.ts
@@ -2,6 +2,7 @@ import 'array.prototype.tosorted';
 import { v4 as uuid } from 'uuid';
 
 // Polyfill crypto.randomUUID
-if (!('randomUUID' in crypto)) {
-	Object.defineProperty(crypto, 'randomUUID', { value: uuid });
+const globalCrypto = globalThis.crypto as Crypto | undefined;
+if (globalCrypto && !('randomUUID' in globalCrypto)) {
+	Object.defineProperty(globalCrypto, 'randomUUID', { value: uuid });
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Guard `crypto.randomUUID` polyfill by referencing `globalThis.crypto` and only defining when available, avoiding direct `crypto` access.
> 
> - **Editor UI polyfills**:
>   - Update `crypto.randomUUID` polyfill to use `globalThis.crypto` and define only when present, avoiding direct `crypto` reference.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a158e43f4011861b6c20aa79f0e9538fbdb09a73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->