### PR TITLE
fix(GoogleTasks): Ensure dueDate and completed fields are in RFC 3339 format

### DIFF
--- a/packages/nodes-base/nodes/Google/Task/GoogleTasks.node.ts
+++ b/packages/nodes-base/nodes/Google/Task/GoogleTasks.node.ts
@@ -12,6 +12,19 @@ import { NodeConnectionTypes } from 'n8n-workflow';
 import { googleApiRequest, googleApiRequestAllItems } from './GenericFunctions';
 import { taskFields, taskOperations } from './TaskDescription';
 
+// Helper to enforce RFC 3339 format (YYYY-MM-DDTHH:mm:ssZ)
+function toRFC3339(dateValue: string | undefined): string | undefined {
+	if (!dateValue) return undefined;
+	// If already in RFC 3339 format, return as is
+	if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(dateValue)) {
+		return dateValue;
+	}
+	// Try to parse and convert
+	const d = new Date(dateValue);
+	if (isNaN(d.getTime())) return dateValue; // fallback: return as is
+	return d.toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
 export class GoogleTasks implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'Google Tasks',
@@ -112,11 +125,11 @@ export class GoogleTasks implements INodeType {
 							body.notes = additionalFields.notes as string;
 						}
 						if (additionalFields.dueDate) {
-							body.due = additionalFields.dueDate as string;
+							body.due = toRFC3339(additionalFields.dueDate as string);
 						}
 
 						if (additionalFields.completed) {
-							body.completed = additionalFields.completed as string;
+							body.completed = toRFC3339(additionalFields.completed as string);
 						}
 
 						if (additionalFields.deleted) {
@@ -232,11 +245,11 @@ export class GoogleTasks implements INodeType {
 						}
 
 						if (updateFields.dueDate) {
-							body.due = updateFields.dueDate as string;
+							body.due = toRFC3339(updateFields.dueDate as string);
 						}
 
 						if (updateFields.completed) {
-							body.completed = updateFields.completed as string;
+							body.completed = toRFC3339(updateFields.completed as string);
 						}
 
 						if (updateFields.deleted) {


### PR DESCRIPTION

## Summary

It adds a function to convert completed and dueDate field in Google tasks create and update node to required RFC 3339 format by tasks api

## Related Linear tickets, Github issues, and Community forum posts

Fixes #20274
<img width="1850" height="783" alt="image" src="https://github.com/user-attachments/assets/8174d1e4-1467-49a6-aa0c-d58bda5454bd" />



## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalize `dueDate` and `completed` to RFC 3339 using a helper when creating/updating Google Tasks.
> 
> - **Google Tasks node (`packages/nodes-base/nodes/Google/Task/GoogleTasks.node.ts`)**:
>   - Add `toRFC3339` helper to normalize timestamps.
>   - Apply to `body.due` and `body.completed` in `task` `create` and `update` operations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32e0fcb7a36f2295604baa22b61bc87a148c1622. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->