### PR TITLE
chore(editor): Add falsely removed datepicker styles again

### DIFF
--- a/packages/frontend/@n8n/design-system/src/css/date-picker.scss
+++ b/packages/frontend/@n8n/design-system/src/css/date-picker.scss
@@ -1,0 +1,21 @@
+@use './date-picker/date-table.scss';
+@use './date-picker/month-table.scss';
+@use './date-picker/year-table.scss';
+@use './date-picker/time-spinner.scss';
+@use './date-picker/picker.scss';
+@use './date-picker/date-picker.scss';
+@use './date-picker/date-range-picker.scss';
+@use './date-picker/time-range-picker.scss';
+@use './date-picker/time-picker.scss';
+@use './input.scss';
+@use './scrollbar.scss';
+@use './popper';
+
+.el-picker-panel__footer {
+	.el-picker-panel__link-btn {
+		&:last-child {
+			background: var(--color-primary);
+			color: var(--color-foreground-xlight);
+		}
+	}
+}

--- a/packages/frontend/@n8n/design-system/src/css/index.scss
+++ b/packages/frontend/@n8n/design-system/src/css/index.scss
@@ -17,6 +17,7 @@
 @use './skeleton.scss';
 @use './table.scss';
 @use './table-column.scss';
+@use './date-picker.scss';
 @use './popover.scss';
 @use './tooltip.scss';
 @use './message-box.scss';


### PR DESCRIPTION
## Summary

Fixes this: 
<img width="776" height="760" alt="image" src="https://github.com/user-attachments/assets/f3f34a82-8b19-4f44-8777-54d3bab1837f" />

Regression from https://github.com/n8n-io/n8n/pull/19895

## Related Linear tickets, Github issues, and Community forum posts

closes PAY-3904


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
