### PR TITLE
fix(Anthropic Chat Model Node): Fix Sonnet 4.5 not working with default topP

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
@@ -339,12 +339,12 @@ export class LmChatAnthropic implements INodeType {
 		});
 
 		// Some Anthropic models do not support Langchain default of -1 for topP so we need to unset it
-		if (!options.topP) {
+		if (options.topP === undefined) {
 			delete model.topP;
 		}
 
 		// If topP is set to a value and temperature is not, unset default Langchain temperature
-		if (options.topP && !options.temperature) {
+		if (options.topP !== undefined && options.temperature === undefined) {
 			delete model.temperature;
 		}
 

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
@@ -1,5 +1,7 @@
 import { ChatAnthropic } from '@langchain/anthropic';
 import type { LLMResult } from '@langchain/core/outputs';
+import { getProxyAgent } from '@utils/httpProxyAgent';
+import { getConnectionHintNoticeField } from '@utils/sharedFields';
 import {
 	NodeConnectionTypes,
 	type INodePropertyOptions,
@@ -9,9 +11,6 @@ import {
 	type INodeTypeDescription,
 	type SupplyData,
 } from 'n8n-workflow';
-
-import { getProxyAgent } from '@utils/httpProxyAgent';
-import { getConnectionHintNoticeField } from '@utils/sharedFields';
 
 import { makeN8nLlmFailedAttemptHandler } from '../n8nLlmFailedAttemptHandler';
 import { N8nLlmTracing } from '../N8nLlmTracing';

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
@@ -338,6 +338,16 @@ export class LmChatAnthropic implements INodeType {
 			},
 		});
 
+		// Some Anthropic models do not support Langchain default of -1 for topP so we need to unset it
+		if (!options.topP) {
+			delete model.topP;
+		}
+
+		// If topP is set to a value and temperature is not, unset default Langchain temperature
+		if (options.topP && !options.temperature) {
+			delete model.temperature;
+		}
+
 		return {
 			response: model,
 		};

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/test/LmChatAnthropic.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/test/LmChatAnthropic.test.ts
@@ -1,0 +1,447 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { ChatAnthropic } from '@langchain/anthropic';
+import { createMockExecuteFunction } from 'n8n-nodes-base/test/nodes/Helpers';
+import type { INode, ISupplyDataFunctions } from 'n8n-workflow';
+
+import { makeN8nLlmFailedAttemptHandler } from '../../n8nLlmFailedAttemptHandler';
+import { N8nLlmTracing } from '../../N8nLlmTracing';
+import { LmChatAnthropic } from '../LmChatAnthropic.node';
+
+jest.mock('@langchain/anthropic');
+jest.mock('../../N8nLlmTracing');
+jest.mock('../../n8nLlmFailedAttemptHandler');
+jest.mock('@utils/httpProxyAgent', () => ({
+	getProxyAgent: jest.fn().mockReturnValue({}),
+}));
+
+const MockedChatAnthropic = jest.mocked(ChatAnthropic);
+const MockedN8nLlmTracing = jest.mocked(N8nLlmTracing);
+const mockedMakeN8nLlmFailedAttemptHandler = jest.mocked(makeN8nLlmFailedAttemptHandler);
+
+describe('LmChatAnthropic', () => {
+	let lmChatAnthropic: LmChatAnthropic;
+	let mockContext: jest.Mocked<ISupplyDataFunctions>;
+
+	const mockNode: INode = {
+		id: '1',
+		name: 'Anthropic Chat Model',
+		typeVersion: 1.3,
+		type: 'n8n-nodes-langchain.lmChatAnthropic',
+		position: [0, 0],
+		parameters: {},
+	};
+
+	const setupMockContext = (nodeOverrides: Partial<INode> = {}) => {
+		const node = { ...mockNode, ...nodeOverrides };
+		mockContext = createMockExecuteFunction<ISupplyDataFunctions>(
+			{},
+			node,
+		) as jest.Mocked<ISupplyDataFunctions>;
+
+		// Setup default mocks
+		mockContext.getCredentials = jest.fn().mockResolvedValue({
+			apiKey: 'test-api-key',
+		});
+		mockContext.getNode = jest.fn().mockReturnValue(node);
+		mockContext.getNodeParameter = jest.fn();
+
+		// Mock the constructors/functions properly
+		MockedN8nLlmTracing.mockImplementation(() => ({}) as N8nLlmTracing);
+		mockedMakeN8nLlmFailedAttemptHandler.mockReturnValue(jest.fn());
+
+		return mockContext;
+	};
+
+	const createMockModel = (properties: Partial<ChatAnthropic>): ChatAnthropic => {
+		const mockModel = properties as ChatAnthropic;
+		MockedChatAnthropic.mockImplementation(() => mockModel);
+		return mockModel;
+	};
+
+	beforeEach(() => {
+		lmChatAnthropic = new LmChatAnthropic();
+		jest.clearAllMocks();
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('node description', () => {
+		it('should have correct node properties', () => {
+			expect(lmChatAnthropic.description).toMatchObject({
+				displayName: 'Anthropic Chat Model',
+				name: 'lmChatAnthropic',
+				group: ['transform'],
+				version: [1, 1.1, 1.2, 1.3],
+				description: 'Language Model Anthropic',
+			});
+		});
+
+		it('should have correct credentials configuration', () => {
+			expect(lmChatAnthropic.description.credentials).toEqual([
+				{
+					name: 'anthropicApi',
+					required: true,
+				},
+			]);
+		});
+
+		it('should have correct output configuration', () => {
+			expect(lmChatAnthropic.description.outputs).toEqual(['ai_languageModel']);
+			expect(lmChatAnthropic.description.outputNames).toEqual(['Model']);
+		});
+	});
+
+	describe('supplyData', () => {
+		it('should create ChatAnthropic instance with basic configuration (version >= 1.3)', async () => {
+			const mockContext = setupMockContext({ typeVersion: 1.3 });
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-20250514';
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			const result = await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			expect(mockContext.getCredentials).toHaveBeenCalledWith('anthropicApi');
+			expect(mockContext.getNodeParameter).toHaveBeenCalledWith('model.value', 0);
+			expect(mockContext.getNodeParameter).toHaveBeenCalledWith('options', 0, {});
+			expect(MockedChatAnthropic).toHaveBeenCalledWith(
+				expect.objectContaining({
+					anthropicApiKey: 'test-api-key',
+					model: 'claude-sonnet-4-20250514',
+					anthropicApiUrl: 'https://api.anthropic.com',
+					maxTokens: undefined,
+					temperature: undefined,
+					topK: undefined,
+					topP: undefined,
+					callbacks: expect.arrayContaining([expect.any(Object)]),
+					onFailedAttempt: expect.any(Function),
+					invocationKwargs: {},
+					clientOptions: {
+						fetchOptions: {
+							dispatcher: {},
+						},
+					},
+				}),
+			);
+
+			expect(result).toEqual({
+				response: expect.any(Object),
+			});
+		});
+
+		it('should create ChatAnthropic instance with basic configuration (version < 1.3)', async () => {
+			const mockContext = setupMockContext({ typeVersion: 1.2 });
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model') return 'claude-3-5-sonnet-20241022';
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			expect(mockContext.getNodeParameter).toHaveBeenCalledWith('model', 0);
+			expect(mockContext.getNodeParameter).toHaveBeenCalledWith('options', 0, {});
+			expect(MockedChatAnthropic).toHaveBeenCalledWith(
+				expect.objectContaining({
+					anthropicApiKey: 'test-api-key',
+					model: 'claude-3-5-sonnet-20241022',
+					anthropicApiUrl: 'https://api.anthropic.com',
+				}),
+			);
+		});
+
+		it('should handle custom baseURL from credentials', async () => {
+			const customURL = 'https://custom-anthropic.example.com';
+			const mockContext = setupMockContext();
+
+			mockContext.getCredentials.mockResolvedValue({
+				apiKey: 'test-api-key',
+				url: customURL,
+			});
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-20250514';
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			expect(MockedChatAnthropic).toHaveBeenCalledWith(
+				expect.objectContaining({
+					anthropicApiKey: 'test-api-key',
+					model: 'claude-sonnet-4-20250514',
+					anthropicApiUrl: customURL,
+				}),
+			);
+		});
+
+		it('should handle all available options', async () => {
+			const mockContext = setupMockContext();
+			const options = {
+				maxTokensToSample: 2048,
+				temperature: 0.8,
+				topK: 40,
+				topP: 0.9,
+			};
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-20250514';
+				if (paramName === 'options') return options;
+				return undefined;
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			expect(MockedChatAnthropic).toHaveBeenCalledWith(
+				expect.objectContaining({
+					anthropicApiKey: 'test-api-key',
+					model: 'claude-sonnet-4-20250514',
+					anthropicApiUrl: 'https://api.anthropic.com',
+					maxTokens: 2048,
+					temperature: 0.8,
+					topK: 40,
+					topP: 0.9,
+					callbacks: expect.arrayContaining([expect.any(Object)]),
+					onFailedAttempt: expect.any(Function),
+					invocationKwargs: {},
+				}),
+			);
+		});
+
+		it('should remove topP from model when not explicitly set', async () => {
+			const mockContext = setupMockContext();
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-20250514';
+				if (paramName === 'options') return { temperature: 0.7 };
+				return undefined;
+			});
+
+			const mockModel = createMockModel({
+				topP: -1,
+				temperature: 0.7,
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			// Verify topP was deleted from the model instance
+			expect(mockModel).not.toHaveProperty('topP');
+		});
+
+		it('should keep topP on model when explicitly set', async () => {
+			const mockContext = setupMockContext();
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-20250514';
+				if (paramName === 'options') return { topP: 0.9 };
+				return undefined;
+			});
+
+			const mockModel = createMockModel({
+				topP: 0.9,
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			// Verify topP was not deleted from the model instance
+			expect(mockModel).toHaveProperty('topP', 0.9);
+		});
+
+		it('should remove temperature when topP is set but temperature is not', async () => {
+			const mockContext = setupMockContext();
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-20250514';
+				if (paramName === 'options') return { topP: 0.9 };
+				return undefined;
+			});
+
+			const mockModel = createMockModel({
+				topP: 0.9,
+				temperature: 0.7,
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			// Verify temperature was deleted from the model instance
+			expect(mockModel).not.toHaveProperty('temperature');
+			expect(mockModel).toHaveProperty('topP', 0.9);
+		});
+
+		it('should keep temperature when both topP and temperature are set', async () => {
+			const mockContext = setupMockContext();
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-20250514';
+				if (paramName === 'options') return { topP: 0.9, temperature: 0.8 };
+				return undefined;
+			});
+
+			const mockModel = createMockModel({
+				topP: 0.9,
+				temperature: 0.8,
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			// Verify both properties remain
+			expect(mockModel).toHaveProperty('topP', 0.9);
+			expect(mockModel).toHaveProperty('temperature', 0.8);
+		});
+
+		it('should configure thinking mode correctly when enabled', async () => {
+			const mockContext = setupMockContext();
+			const options = {
+				thinking: true,
+				thinkingBudget: 2048,
+				maxTokensToSample: 4096,
+			};
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-20250514';
+				if (paramName === 'options') return options;
+				return undefined;
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			expect(MockedChatAnthropic).toHaveBeenCalledWith(
+				expect.objectContaining({
+					anthropicApiKey: 'test-api-key',
+					model: 'claude-sonnet-4-20250514',
+					maxTokens: 4096,
+					invocationKwargs: {
+						thinking: {
+							type: 'enabled',
+							budget_tokens: 2048,
+						},
+						max_tokens: 4096,
+						top_k: undefined,
+						top_p: undefined,
+						temperature: undefined,
+					},
+				}),
+			);
+		});
+
+		it('should use default thinking budget when not specified', async () => {
+			const mockContext = setupMockContext();
+			const options = {
+				thinking: true,
+			};
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-20250514';
+				if (paramName === 'options') return options;
+				return undefined;
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			expect(MockedChatAnthropic).toHaveBeenCalledWith(
+				expect.objectContaining({
+					invocationKwargs: {
+						thinking: {
+							type: 'enabled',
+							budget_tokens: 1024, // MIN_THINKING_BUDGET
+						},
+						max_tokens: 4096, // DEFAULT_MAX_TOKENS
+						top_k: undefined,
+						top_p: undefined,
+						temperature: undefined,
+					},
+				}),
+			);
+		});
+
+		it('should unset sampling parameters when thinking mode is enabled', async () => {
+			const mockContext = setupMockContext();
+			const options = {
+				thinking: true,
+				thinkingBudget: 2048,
+				maxTokensToSample: 4096,
+				temperature: 0.8,
+				topK: 40,
+				topP: 0.9,
+			};
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-20250514';
+				if (paramName === 'options') return options;
+				return undefined;
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			expect(MockedChatAnthropic).toHaveBeenCalledWith(
+				expect.objectContaining({
+					// These are set initially but will be overridden by invocationKwargs
+					temperature: 0.8,
+					topK: 40,
+					topP: 0.9,
+					invocationKwargs: {
+						thinking: {
+							type: 'enabled',
+							budget_tokens: 2048,
+						},
+						max_tokens: 4096,
+						// These override the model options
+						top_k: undefined,
+						top_p: undefined,
+						temperature: undefined,
+					},
+				}),
+			);
+		});
+
+		it('should create N8nLlmTracing callback with tokens usage parser', async () => {
+			const mockContext = setupMockContext();
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-20250514';
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			expect(MockedN8nLlmTracing).toHaveBeenCalledWith(
+				mockContext,
+				expect.objectContaining({
+					tokensUsageParser: expect.any(Function),
+				}),
+			);
+		});
+
+		it('should create failed attempt handler', async () => {
+			const mockContext = setupMockContext();
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-20250514';
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			expect(mockedMakeN8nLlmFailedAttemptHandler).toHaveBeenCalledWith(mockContext);
+		});
+	});
+
+	describe('methods', () => {
+		it('should have searchModels method', () => {
+			expect(lmChatAnthropic.methods).toEqual({
+				listSearch: {
+					searchModels: expect.any(Function),
+				},
+			});
+		});
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/test/LmChatAnthropic.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/test/LmChatAnthropic.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable n8n-nodes-base/node-filename-against-convention */
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { ChatAnthropic } from '@langchain/anthropic';


### PR DESCRIPTION
## Summary

This PR fixes compatibility issues with latest Anthropic models by handling LangChain's default parameter values that conflict with Anthropic's API requirements:
  - Removes topP when not explicitly set (LangChain defaults to -1, which some models reject)
  - Removes temperature when topP is set but temperature is not (Langchain defaults to 0.7)

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
- fixes #20240
- fixes #18304


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
