### PR TITLE
refactor(core): Don't begin transactions on data table read operations

### DIFF
--- a/packages/@n8n/db/src/utils/transaction.ts
+++ b/packages/@n8n/db/src/utils/transaction.ts
@@ -9,7 +9,10 @@ export async function withTransaction<T>(
 	manager: EntityManager,
 	trx: Tx,
 	run: (em: EntityManager) => Promise<T>,
+	beginTransaction: boolean = true,
 ): Promise<T> {
 	if (trx) return await run(trx);
-	return await manager.transaction(run);
+	if (beginTransaction) return await manager.transaction(run);
+
+	return await run(manager);
 }

--- a/packages/cli/src/modules/data-table/data-store-column.repository.ts
+++ b/packages/cli/src/modules/data-table/data-store-column.repository.ts
@@ -20,18 +20,23 @@ export class DataStoreColumnRepository extends Repository<DataTableColumn> {
 	}
 
 	async getColumns(dataTableId: string, trx?: EntityManager) {
-		return await withTransaction(this.manager, trx, async (em) => {
-			const columns = await em
-				.createQueryBuilder(DataTableColumn, 'dsc')
-				.where('dsc.dataTableId = :dataTableId', { dataTableId })
-				.getMany();
+		return await withTransaction(
+			this.manager,
+			trx,
+			async (em) => {
+				const columns = await em
+					.createQueryBuilder(DataTableColumn, 'dsc')
+					.where('dsc.dataTableId = :dataTableId', { dataTableId })
+					.getMany();
 
-			// Ensure columns are always returned in the correct order by index,
-			// since the database does not guarantee ordering and TypeORM does not preserve
-			// join order in @OneToMany relations.
-			columns.sort((a, b) => a.index - b.index);
-			return columns;
-		});
+				// Ensure columns are always returned in the correct order by index,
+				// since the database does not guarantee ordering and TypeORM does not preserve
+				// join order in @OneToMany relations.
+				columns.sort((a, b) => a.index - b.index);
+				return columns;
+			},
+			false,
+		);
 	}
 
 	async addColumn(dataTableId: string, schema: DataStoreCreateColumnSchema, trx?: EntityManager) {


### PR DESCRIPTION
## Summary

Turns out my previous refactoring introducing unified transaction handling to data tables had the side effect that it now caused reads like `getColumns` to start new transactions when called outside a transaction. Normally this shouldn't really matter, but in the case of the legacy `sqlite` driver with problems on concurrent transactions bookkeeping this caused data tables to error with transactions related errors in some cases when not using the `DB_SQLITE_POOL_SIZE` setting (and the new driver).

Given that `sqlite` driver is still the default before v2 I changed withTransactions to allow passing in a flag that causes it to skip beginning new transactions if no current transaction is provided, and using that mechanism to not create "unnecessary" transactions on reads.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
