### PR TITLE
fix(editor): Frontend housekeeping

### DIFF
--- a/packages/frontend/editor-ui/src/__tests__/render.ts
+++ b/packages/frontend/editor-ui/src/__tests__/render.ts
@@ -3,6 +3,7 @@ import { render, type RenderOptions as TestingLibraryRenderOptions } from '@test
 import { i18nInstance } from '@n8n/i18n';
 import { GlobalDirectivesPlugin } from '@/plugins/directives';
 import { FontAwesomePlugin } from '@/plugins/icons';
+import { N8nPlugin } from '@n8n/design-system';
 import type { Pinia } from 'pinia';
 import { PiniaVuePlugin } from 'pinia';
 import type { Telemetry } from '@/plugins/telemetry';
@@ -36,6 +37,7 @@ const defaultOptions = {
 			i18nInstance,
 			PiniaVuePlugin,
 			FontAwesomePlugin,
+			N8nPlugin,
 			GlobalDirectivesPlugin,
 			TelemetryPlugin,
 		],

--- a/packages/frontend/editor-ui/src/plugins/components.ts
+++ b/packages/frontend/editor-ui/src/plugins/components.ts
@@ -2,7 +2,7 @@ import type { Plugin } from 'vue';
 
 import 'regenerator-runtime/runtime';
 
-import { ElLoading, ElMessageBox } from 'element-plus';
+import { ElLoading, ElNotification, ElMessageBox } from 'element-plus';
 import { N8nPlugin } from '@n8n/design-system';
 import { useMessage } from '@/composables/useMessage';
 
@@ -12,8 +12,8 @@ export const GlobalComponentsPlugin: Plugin = {
 
 		app.use(N8nPlugin, {});
 
-		// app.use(ElLoading);
-		// app.use(ElNotification);
+		app.use(ElLoading);
+		app.use(ElNotification);
 
 		app.config.globalProperties.$loading = ElLoading.service;
 		app.config.globalProperties.$msgbox = ElMessageBox;

--- a/packages/frontend/editor-ui/src/plugins/components.ts
+++ b/packages/frontend/editor-ui/src/plugins/components.ts
@@ -2,7 +2,7 @@ import type { Plugin } from 'vue';
 
 import 'regenerator-runtime/runtime';
 
-import { ElLoading, ElNotification, ElMessageBox } from 'element-plus';
+import { ElLoading, ElMessageBox } from 'element-plus';
 import { N8nPlugin } from '@n8n/design-system';
 import { useMessage } from '@/composables/useMessage';
 
@@ -13,7 +13,6 @@ export const GlobalComponentsPlugin: Plugin = {
 		app.use(N8nPlugin, {});
 
 		app.use(ElLoading);
-		app.use(ElNotification);
 
 		app.config.globalProperties.$loading = ElLoading.service;
 		app.config.globalProperties.$msgbox = ElMessageBox;

--- a/packages/frontend/editor-ui/src/plugins/components.ts
+++ b/packages/frontend/editor-ui/src/plugins/components.ts
@@ -5,15 +5,10 @@ import 'regenerator-runtime/runtime';
 import { ElLoading, ElMessageBox } from 'element-plus';
 import { N8nPlugin } from '@n8n/design-system';
 import { useMessage } from '@/composables/useMessage';
-import EnterpriseEdition from '@/components/EnterpriseEdition.ee.vue';
-import ParameterInputList from '@/components/ParameterInputList.vue';
 
 export const GlobalComponentsPlugin: Plugin = {
 	install(app) {
 		const messageService = useMessage();
-
-		app.component('EnterpriseEdition', EnterpriseEdition);
-		app.component('ParameterInputList', ParameterInputList);
 
 		app.use(N8nPlugin, {});
 

--- a/packages/frontend/editor-ui/src/plugins/directives.ts
+++ b/packages/frontend/editor-ui/src/plugins/directives.ts
@@ -1,11 +1,8 @@
 import type { Plugin } from 'vue';
 import VueTouchEvents from 'vue3-touch-events';
-import { n8nTruncate, n8nHtml } from '@n8n/design-system/directives';
 
 export const GlobalDirectivesPlugin: Plugin = {
 	install(app) {
 		app.use(VueTouchEvents);
-		app.directive('n8nTruncate', n8nTruncate);
-		app.directive('n8nHtml', n8nHtml);
 	},
 };

--- a/packages/frontend/editor-ui/vite.config.mts
+++ b/packages/frontend/editor-ui/vite.config.mts
@@ -105,10 +105,6 @@ const plugins: UserConfig['plugins'] = [
 				src: pathPosix.resolve('node_modules/curlconverter/dist/tree-sitter-bash.wasm'),
 				dest: resolve(__dirname, 'dist'),
 			},
-			{
-				src: pathPosix.resolve('../@n8n/design-system/src/css/fonts/InterVariable*.woff2'),
-				dest: resolve(__dirname, 'dist/assets'),
-			},
 		],
 	}),
 	vue(),

--- a/packages/frontend/editor-ui/vite.config.mts
+++ b/packages/frontend/editor-ui/vite.config.mts
@@ -105,6 +105,10 @@ const plugins: UserConfig['plugins'] = [
 				src: pathPosix.resolve('node_modules/curlconverter/dist/tree-sitter-bash.wasm'),
 				dest: resolve(__dirname, 'dist'),
 			},
+			{
+				src: pathPosix.resolve('../@n8n/design-system/src/css/fonts/InterVariable*.woff2'),
+				dest: resolve(__dirname, 'dist/assets'),
+			},
 		],
 	}),
 	vue(),

--- a/packages/frontend/editor-ui/vite.config.mts
+++ b/packages/frontend/editor-ui/vite.config.mts
@@ -139,6 +139,7 @@ const plugins: UserConfig['plugins'] = [
 				? html
 						.replace('%CONFIG_TAGS%', '')
 						.replaceAll('/{{BASE_PATH}}', '//localhost:5678')
+						.replaceAll('/%7B%7BBASE_PATH%7D%7D', '//localhost:5678')
 						.replaceAll('/{{REST_ENDPOINT}}', '/rest')
 				: html;
 		},

--- a/packages/frontend/editor-ui/vite.config.mts
+++ b/packages/frontend/editor-ui/vite.config.mts
@@ -135,23 +135,12 @@ const plugins: UserConfig['plugins'] = [
 		transformIndexHtml: (html, ctx) => {
 			// Skip config tags when using Vite dev server. Otherwise the BE
 			// will replace it with the actual config script in cli/src/commands/start.ts.
-			if (!ctx.server) return html;
-
-			let result = html.replace('%CONFIG_TAGS%', '');
-
-			// Replace placeholders (both regular and URL-encoded versions)
-			const replacements = {
-				BASE_PATH: '//localhost:5678',
-				REST_ENDPOINT: '/rest',
-			};
-
-			for (const [placeholder, value] of Object.entries(replacements)) {
-				result = result
-					.replaceAll(`/{{${placeholder}}}`, value)
-					.replaceAll(`/%7B%7B${placeholder}%7D%7D`, value);
-			}
-
-			return result;
+			return ctx.server
+				? html
+						.replace('%CONFIG_TAGS%', '')
+						.replaceAll('/{{BASE_PATH}}', '//localhost:5678')
+						.replaceAll('/{{REST_ENDPOINT}}', '/rest')
+				: html;
 		},
 	},
 	// For sanitize-html

--- a/packages/frontend/editor-ui/vite.config.mts
+++ b/packages/frontend/editor-ui/vite.config.mts
@@ -135,13 +135,23 @@ const plugins: UserConfig['plugins'] = [
 		transformIndexHtml: (html, ctx) => {
 			// Skip config tags when using Vite dev server. Otherwise the BE
 			// will replace it with the actual config script in cli/src/commands/start.ts.
-			return ctx.server
-				? html
-						.replace('%CONFIG_TAGS%', '')
-						.replaceAll('/{{BASE_PATH}}', '//localhost:5678')
-						.replaceAll('/%7B%7BBASE_PATH%7D%7D', '//localhost:5678')
-						.replaceAll('/{{REST_ENDPOINT}}', '/rest')
-				: html;
+			if (!ctx.server) return html;
+
+			let result = html.replace('%CONFIG_TAGS%', '');
+
+			// Replace placeholders (both regular and URL-encoded versions)
+			const replacements = {
+				BASE_PATH: '//localhost:5678',
+				REST_ENDPOINT: '/rest',
+			};
+
+			for (const [placeholder, value] of Object.entries(replacements)) {
+				result = result
+					.replaceAll(`/{{${placeholder}}}`, value)
+					.replaceAll(`/%7B%7B${placeholder}%7D%7D`, value);
+			}
+
+			return result;
 		},
 	},
 	// For sanitize-html


### PR DESCRIPTION
## Summary

Vue warns about duplicate directive registrations for n8nTruncate and n8nHtml

Global component registrations exist for components that already have explicit imports

## Related Linear tickets, Github issues, and Community forum posts

PAY-3918

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
