### PR TITLE
feat: Exclude large data tables by default, allow inclusion with override flag

### DIFF
--- a/packages/cli/src/commands/export/__tests__/entities.test.ts
+++ b/packages/cli/src/commands/export/__tests__/entities.test.ts
@@ -9,7 +9,7 @@ describe('ExportEntitiesCommand', () => {
 	const mockExportService = mockInstance(ExportService);
 
 	describe('run', () => {
-		it('should export entities', async () => {
+		it('should export entities without large data tables', async () => {
 			const command = new ExportEntitiesCommand();
 			// @ts-expect-error Protected property
 			command.flags = {
@@ -22,7 +22,33 @@ describe('ExportEntitiesCommand', () => {
 			};
 			await command.run();
 
-			expect(mockExportService.exportEntities).toHaveBeenCalledWith('./exports');
+			expect(mockExportService.exportEntities).toHaveBeenCalledWith(
+				'./exports',
+				new Set<string>([
+					'execution_annotation_tags',
+					'execution_annotations',
+					'execution_data',
+					'execution_entity',
+					'execution_metadata',
+				]),
+			);
+		});
+
+		it('should export entities with large data tables', async () => {
+			const command = new ExportEntitiesCommand();
+			// @ts-expect-error Protected property
+			command.flags = {
+				outputDir: './exports',
+				includeLargeDataTables: true,
+			};
+			// @ts-expect-error Protected property
+			command.logger = {
+				info: jest.fn(),
+				error: jest.fn(),
+			};
+			await command.run();
+
+			expect(mockExportService.exportEntities).toHaveBeenCalledWith('./exports', new Set<string>());
 		});
 	});
 

--- a/packages/cli/src/commands/export/__tests__/entities.test.ts
+++ b/packages/cli/src/commands/export/__tests__/entities.test.ts
@@ -39,7 +39,7 @@ describe('ExportEntitiesCommand', () => {
 			// @ts-expect-error Protected property
 			command.flags = {
 				outputDir: './exports',
-				includeLargeDataTables: true,
+				includeExecutionHistoryDataTables: true,
 			};
 			// @ts-expect-error Protected property
 			command.logger = {

--- a/packages/cli/src/commands/export/entities.ts
+++ b/packages/cli/src/commands/export/entities.ts
@@ -11,7 +11,12 @@ const flagsSchema = z.object({
 		.string()
 		.describe('Output directory path')
 		.default(safeJoinPath(__dirname, './outputs')),
-	includeLargeDataTables: z.boolean().describe('Include large data tables').default(false),
+	includeExecutionHistoryDataTables: z
+		.boolean()
+		.describe(
+			'Include execution history data tables, these are excluded by default as they can be very large',
+		)
+		.default(false),
 });
 
 @Command({
@@ -21,7 +26,7 @@ const flagsSchema = z.object({
 		'',
 		'--outputDir=./exports',
 		'--outputDir=/path/to/backup',
-		'--includeLargeDataTables=true',
+		'--includeExecutionHistoryDataTables=true',
 	],
 	flagsSchema,
 })
@@ -29,17 +34,17 @@ export class ExportEntitiesCommand extends BaseCommand<z.infer<typeof flagsSchem
 	async run() {
 		const outputDir = this.flags.outputDir;
 
-		const excludedLargeDataTables = new Set<string>();
+		const excludedDataTables = new Set<string>();
 
-		if (!this.flags.includeLargeDataTables) {
-			excludedLargeDataTables.add('execution_annotation_tags');
-			excludedLargeDataTables.add('execution_annotations');
-			excludedLargeDataTables.add('execution_data');
-			excludedLargeDataTables.add('execution_entity');
-			excludedLargeDataTables.add('execution_metadata');
+		if (!this.flags.includeExecutionHistoryDataTables) {
+			excludedDataTables.add('execution_annotation_tags');
+			excludedDataTables.add('execution_annotations');
+			excludedDataTables.add('execution_data');
+			excludedDataTables.add('execution_entity');
+			excludedDataTables.add('execution_metadata');
 		}
 
-		await Container.get(ExportService).exportEntities(outputDir, excludedLargeDataTables);
+		await Container.get(ExportService).exportEntities(outputDir, excludedDataTables);
 	}
 
 	catch(error: Error) {

--- a/packages/cli/src/commands/export/entities.ts
+++ b/packages/cli/src/commands/export/entities.ts
@@ -11,19 +11,35 @@ const flagsSchema = z.object({
 		.string()
 		.describe('Output directory path')
 		.default(safeJoinPath(__dirname, './outputs')),
+	includeLargeDataTables: z.boolean().describe('Include large data tables').default(false),
 });
 
 @Command({
 	name: 'export:entities',
 	description: 'Export database entities to JSON files',
-	examples: ['', '--outputDir=./exports', '--outputDir=/path/to/backup'],
+	examples: [
+		'',
+		'--outputDir=./exports',
+		'--outputDir=/path/to/backup',
+		'--includeLargeDataTables=true',
+	],
 	flagsSchema,
 })
 export class ExportEntitiesCommand extends BaseCommand<z.infer<typeof flagsSchema>> {
 	async run() {
 		const outputDir = this.flags.outputDir;
 
-		await Container.get(ExportService).exportEntities(outputDir);
+		const excludedLargeDataTables = new Set<string>();
+
+		if (!this.flags.includeLargeDataTables) {
+			excludedLargeDataTables.add('execution_annotation_tags');
+			excludedLargeDataTables.add('execution_annotations');
+			excludedLargeDataTables.add('execution_data');
+			excludedLargeDataTables.add('execution_entity');
+			excludedLargeDataTables.add('execution_metadata');
+		}
+
+		await Container.get(ExportService).exportEntities(outputDir, excludedLargeDataTables);
 	}
 
 	catch(error: Error) {

--- a/packages/cli/src/services/__tests__/export.service.test.ts
+++ b/packages/cli/src/services/__tests__/export.service.test.ts
@@ -47,6 +47,11 @@ describe('ExportService', () => {
 				tableName: 'workflow_entity',
 				columns: [{ databaseName: 'id' }, { databaseName: 'name' }, { databaseName: 'active' }],
 			},
+			{
+				name: 'Execution Data',
+				tableName: 'execution_data',
+				columns: [{ databaseName: 'id' }],
+			},
 		];
 		// @ts-expect-error Accessing private property for testing
 		mockDataSource.options = { type: 'sqlite' };
@@ -122,6 +127,34 @@ describe('ExportService', () => {
 			jest.mocked(readdir).mockResolvedValue([]);
 
 			await exportService.exportEntities(outputDir);
+
+			expect(mockDataSource.query).toHaveBeenCalledTimes(5); // 1 migrations + 3 entity queries
+			expect(appendFile).toHaveBeenCalled();
+		});
+
+		it('should handle multiple pages of data, excluding execution_data', async () => {
+			const outputDir = '/test/output';
+			const mockEntities = Array.from({ length: 500 }, (_, i) => ({
+				id: i + 1,
+				email: `test${i + 1}@example.com`,
+				firstName: `User${i + 1}`,
+			}));
+
+			// Mock the migrations table query to fail (table doesn't exist)
+			jest
+				.mocked(mockDataSource.query)
+				.mockImplementationOnce(async (query: string) => {
+					if (query.includes('migrations') && query.includes('COUNT')) {
+						throw new Error('Table not found');
+					}
+					return [];
+				})
+				.mockResolvedValueOnce(mockEntities) // First page for User
+				.mockResolvedValueOnce([]) // Second page for User (empty, end of data)
+				.mockResolvedValueOnce([]); // Workflow entities
+			jest.mocked(readdir).mockResolvedValue([]);
+
+			await exportService.exportEntities(outputDir, new Set(['execution_data']));
 
 			expect(mockDataSource.query).toHaveBeenCalledTimes(4); // 1 migrations + 3 entity queries
 			expect(appendFile).toHaveBeenCalled();

--- a/packages/cli/src/services/export.service.ts
+++ b/packages/cli/src/services/export.service.ts
@@ -83,7 +83,7 @@ export class ExportService {
 		return systemTablesExported;
 	}
 
-	async exportEntities(outputDir: string) {
+	async exportEntities(outputDir: string, excludedTables: Set<string> = new Set()) {
 		this.logger.info('\n⚠️⚠️ This feature is currently under development. ⚠️⚠️');
 
 		validateDbTypeForExportEntities(this.dataSource.options.type);
@@ -110,6 +110,14 @@ export class ExportService {
 		for (const metadata of entityMetadatas) {
 			// Get table name and entity name
 			const tableName = metadata.tableName;
+
+			if (excludedTables.has(tableName)) {
+				this.logger.info(
+					`   💭 Skipping table: ${tableName} (${metadata.name}) as it exists as an exclusion`,
+				);
+				continue;
+			}
+
 			const entityName = metadata.name.toLowerCase();
 
 			this.logger.info(`\n📊 Processing table: ${tableName} (${entityName})`);


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR adds a flag to entity exports to allow including large data tables in exports, by default, large data tables are excluded.

## Related Linear tickets, Github issues, and Community forum posts

PAY-3911

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
