### PR TITLE
fix(Discord Node): Add test to Discord Webhook credential

### DIFF
--- a/packages/nodes-base/credentials/DiscordWebhookApi.credentials.ts
+++ b/packages/nodes-base/credentials/DiscordWebhookApi.credentials.ts
@@ -1,4 +1,4 @@
-import type { ICredentialType, INodeProperties } from 'n8n-workflow';
+import type { ICredentialTestRequest, ICredentialType, INodeProperties } from 'n8n-workflow';
 
 export class DiscordWebhookApi implements ICredentialType {
 	name = 'discordWebhookApi';
@@ -20,4 +20,10 @@ export class DiscordWebhookApi implements ICredentialType {
 			},
 		},
 	];
+
+	test: ICredentialTestRequest = {
+		request: {
+			baseURL: '={{ $credentials.webhookUri }}',
+		},
+	};
 }


### PR DESCRIPTION
## Summary
This PR adds a credential test to Discord Webhook type.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2776/discord-webhook-credential-update

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
