### PR TITLE
fix(core): Only resume the parent workflow if its actually waiting

### DIFF
--- a/packages/cli/src/__tests__/wait-tracker.test.ts
+++ b/packages/cli/src/__tests__/wait-tracker.test.ts
@@ -145,64 +145,108 @@ describe('WaitTracker', () => {
 			);
 		});
 
-		it('should also resume parent execution once sub-workflow finishes', async () => {
-			const parentExecution = mock<IExecutionResponse>({
-				id: 'parent_execution_id',
-				finished: false,
-			});
-			parentExecution.workflowData = mock<IWorkflowBase>({ id: 'parent_workflow_id' });
-			execution.data.parentExecution = {
-				executionId: parentExecution.id,
-				workflowId: parentExecution.workflowData.id,
-			};
-			executionRepository.findSingleExecution
-				.calledWith(parentExecution.id)
-				.mockResolvedValue(parentExecution);
-			const postExecutePromise = createDeferredPromise<IRun | undefined>();
-			activeExecutions.getPostExecutePromise
-				.calledWith(execution.id)
-				.mockReturnValue(postExecutePromise.promise);
+		describe('with parent execution', () => {
+			let parentExecution: IExecutionResponse;
+			let postExecutePromise: ReturnType<typeof createDeferredPromise<IRun | undefined>>;
 
-			await waitTracker.startExecution(execution.id);
-
-			expect(executionRepository.findSingleExecution).toHaveBeenNthCalledWith(1, execution.id, {
-				includeData: true,
-				unflattenData: true,
+			beforeEach(() => {
+				parentExecution = mock<IExecutionResponse>({
+					id: 'parent_execution_id',
+					finished: false,
+				});
+				parentExecution.workflowData = mock<IWorkflowBase>({ id: 'parent_workflow_id' });
+				execution.data.parentExecution = {
+					executionId: parentExecution.id,
+					workflowId: parentExecution.workflowData.id,
+				};
+				executionRepository.findSingleExecution
+					.calledWith(parentExecution.id)
+					.mockResolvedValue(parentExecution);
+				postExecutePromise = createDeferredPromise<IRun | undefined>();
+				activeExecutions.getPostExecutePromise
+					.calledWith(execution.id)
+					.mockReturnValue(postExecutePromise.promise);
 			});
 
-			expect(workflowRunner.run).toHaveBeenCalledTimes(1);
-			expect(workflowRunner.run).toHaveBeenNthCalledWith(
-				1,
-				{
-					executionMode: execution.mode,
-					executionData: execution.data,
-					workflowData: execution.workflowData,
-					projectId: project.id,
-					pushRef: execution.data.pushRef,
-				},
-				false,
-				false,
-				execution.id,
-			);
+			it('should resume parent execution once sub-workflow finishes if parent is waiting', async () => {
+				// Manually track the parent execution to simulate it waiting
+				const hasSpy = jest.spyOn(waitTracker, 'has');
+				hasSpy.mockReturnValue(true);
 
-			postExecutePromise.resolve(mock<IRun>());
-			await jest.advanceTimersByTimeAsync(100);
+				await waitTracker.startExecution(execution.id);
 
-			expect(workflowRunner.run).toHaveBeenCalledTimes(2);
-			expect(workflowRunner.run).toHaveBeenNthCalledWith(
-				2,
-				{
-					executionMode: parentExecution.mode,
-					executionData: parentExecution.data,
-					workflowData: parentExecution.workflowData,
-					projectId: project.id,
-					pushRef: parentExecution.data.pushRef,
-					startedAt: parentExecution.startedAt,
-				},
-				false,
-				false,
-				parentExecution.id,
-			);
+				expect(executionRepository.findSingleExecution).toHaveBeenNthCalledWith(1, execution.id, {
+					includeData: true,
+					unflattenData: true,
+				});
+
+				expect(workflowRunner.run).toHaveBeenCalledTimes(1);
+				expect(workflowRunner.run).toHaveBeenNthCalledWith(
+					1,
+					{
+						executionMode: execution.mode,
+						executionData: execution.data,
+						workflowData: execution.workflowData,
+						projectId: project.id,
+						pushRef: execution.data.pushRef,
+					},
+					false,
+					false,
+					execution.id,
+				);
+
+				postExecutePromise.resolve(mock<IRun>());
+				await jest.advanceTimersByTimeAsync(100);
+
+				expect(workflowRunner.run).toHaveBeenCalledTimes(2);
+				expect(workflowRunner.run).toHaveBeenNthCalledWith(
+					2,
+					{
+						executionMode: parentExecution.mode,
+						executionData: parentExecution.data,
+						workflowData: parentExecution.workflowData,
+						projectId: project.id,
+						pushRef: parentExecution.data.pushRef,
+						startedAt: parentExecution.startedAt,
+					},
+					false,
+					false,
+					parentExecution.id,
+				);
+			});
+
+			it('should not resume parent execution if parent is not waiting', async () => {
+				// Do not track the parent execution, simulating it not waiting
+				const hasSpy = jest.spyOn(waitTracker, 'has');
+				hasSpy.mockReturnValue(false);
+
+				await waitTracker.startExecution(execution.id);
+
+				expect(executionRepository.findSingleExecution).toHaveBeenCalledWith(execution.id, {
+					includeData: true,
+					unflattenData: true,
+				});
+
+				expect(workflowRunner.run).toHaveBeenCalledTimes(1);
+				expect(workflowRunner.run).toHaveBeenCalledWith(
+					{
+						executionMode: execution.mode,
+						executionData: execution.data,
+						workflowData: execution.workflowData,
+						projectId: project.id,
+						pushRef: execution.data.pushRef,
+					},
+					false,
+					false,
+					execution.id,
+				);
+
+				postExecutePromise.resolve(mock<IRun>());
+				await jest.advanceTimersByTimeAsync(100);
+
+				// Parent execution should not be resumed
+				expect(workflowRunner.run).toHaveBeenCalledTimes(1);
+			});
 		});
 	});
 

--- a/packages/cli/src/wait-tracker.ts
+++ b/packages/cli/src/wait-tracker.ts
@@ -90,7 +90,6 @@ export class WaitTracker {
 	}
 
 	async startExecution(executionId: string) {
-		this.logger.debug(`Resuming execution ${executionId}`, { executionId });
 		delete this.waitingExecutions[executionId];
 
 		// Get the data to execute
@@ -127,10 +126,12 @@ export class WaitTracker {
 
 		const { parentExecution } = fullExecutionData.data;
 		if (parentExecution) {
-			// on child execution completion, resume parent execution
-			void this.activeExecutions.getPostExecutePromise(executionId).then(() => {
-				void this.startExecution(parentExecution.executionId);
-			});
+			// On child execution completion, resume parent execution. Only try to resume parent if it is actually waiting.
+			if (this.has(parentExecution.executionId)) {
+				void this.activeExecutions.getPostExecutePromise(executionId).then(() => {
+					void this.startExecution(parentExecution.executionId);
+				});
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
Only resume the parent workflow if it's actually waiting.

Otherwise we get an error from the wait tracker that the workflow has already finished.

For some context: when we run a sub-workflow, the parent can be configured to block or not on the child. If the parent blocks, it remains running; until the child workflow goes into `waiting`, at which point we also put the parent into `waiting`. Therefore when the child wakes up we have to wake up the parent as well. **However** if the parent was configured not to block, then it was never waiting in the first place, and it never needed to be resumed.

Manually tested in two cases:
- The sub-workflow uses a webhook wait. Verify that there's no error when the webhook is called.
- The sub-workflow uses a 66-second wait. Verify that there's no error when the sub-workflow finishes. NOTE: 66s because for short waits under 65s we simply remain `running`. See the Wait node impl for the explanation.

TODO: look into automated testing. The webhook helper is not built to be very testable.

## Related Linear tickets, Github issues, and Community forum posts
Fixes https://linear.app/n8n/issue/CAT-1445

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
