### PR TITLE
fix: required and not required parse schema logic for jwt

### DIFF
--- a/packages/cli/src/public-api/v1/handlers/credentials/credentials.service.ts
+++ b/packages/cli/src/public-api/v1/handlers/credentials/credentials.service.ts
@@ -19,7 +19,7 @@ import { EventService } from '@/events/event.service';
 import { ExternalHooks } from '@/external-hooks';
 import type { CredentialRequest } from '@/requests';
 
-import type { IDependency, IJsonSchema } from '../../../types';
+import type { IJsonSchema } from '../../../types';
 
 export async function getCredentials(credentialId: string): Promise<ICredentialsDb | null> {
 	return await Container.get(CredentialsRepository).findOneBy({ id: credentialId });
@@ -155,7 +155,6 @@ export function toJsonSchema(properties: INodeProperties[]): IDataObject {
 	};
 
 	const optionsValues: { [key: string]: string[] } = {};
-	const resolveProperties: string[] = [];
 
 	// get all possible values of properties type "options"
 	// so we can later resolve the displayOptions dependencies
@@ -169,7 +168,7 @@ export function toJsonSchema(properties: INodeProperties[]): IDataObject {
 
 	let requiredFields: string[] = [];
 
-	const propertyRequiredDependencies: { [key: string]: IDependency } = {};
+	const propertyRequiredDependencies: { [key: string]: { [value: string]: string[] } } = {};
 
 	// add all credential's properties to the properties
 	// object in the JSON Schema definition. This allows us
@@ -219,100 +218,107 @@ export function toJsonSchema(properties: INodeProperties[]): IDataObject {
 				propertyRequiredDependencies[dependantName] = {};
 			}
 
-			if (!resolveProperties.includes(dependantName)) {
-				let conditionalValue;
-				if (typeof dependantValue === 'object' && dependantValue._cnd) {
-					// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-					const [key, targetValue] = Object.entries(dependantValue._cnd)[0];
+			const valueKey =
+				typeof dependantValue === 'object' && dependantValue._cnd
+					? JSON.stringify(dependantValue)
+					: JSON.stringify(dependantValue);
 
-					if (key === 'eq') {
-						conditionalValue = {
-							const: [targetValue],
-						};
-					} else if (key === 'not') {
-						conditionalValue = {
-							not: {
-								const: [targetValue],
-							},
-						};
-					} else if (key === 'gt') {
-						conditionalValue = {
-							type: 'number',
-							exclusiveMinimum: [targetValue],
-						};
-					} else if (key === 'gte') {
-						conditionalValue = {
-							type: 'number',
-							minimum: [targetValue],
-						};
-					} else if (key === 'lt') {
-						conditionalValue = {
-							type: 'number',
-							exclusiveMaximum: [targetValue],
-						};
-					} else if (key === 'lte') {
-						conditionalValue = {
-							type: 'number',
-							maximum: [targetValue],
-						};
-					} else if (key === 'startsWith') {
-						conditionalValue = {
-							type: 'string',
-							pattern: `^${targetValue}`,
-						};
-					} else if (key === 'endsWith') {
-						conditionalValue = {
-							type: 'string',
-							pattern: `${targetValue}$`,
-						};
-					} else if (key === 'includes') {
-						conditionalValue = {
-							type: 'string',
-							pattern: `${targetValue}`,
-						};
-					} else if (key === 'regex') {
-						conditionalValue = {
-							type: 'string',
-							pattern: `${targetValue}`,
-						};
-					} else {
-						conditionalValue = {
-							enum: [dependantValue],
-						};
-					}
+			if (!propertyRequiredDependencies[dependantName][valueKey]) {
+				propertyRequiredDependencies[dependantName][valueKey] = [];
+			}
+
+			propertyRequiredDependencies[dependantName][valueKey].push(property.name);
+
+			requiredFields = requiredFields.filter((field) => field !== property.name);
+		}
+	});
+
+	const conditionalSchemas: any[] = [];
+
+	Object.entries(propertyRequiredDependencies).forEach(([dependantName, valueGroups]) => {
+		Object.entries(valueGroups).forEach(([valueKey, propertyNames]) => {
+			let dependantValue: any;
+
+			try {
+				dependantValue = JSON.parse(valueKey);
+			} catch {
+				dependantValue = valueKey;
+			}
+			let conditionalValue;
+			if (typeof dependantValue === 'object' && dependantValue._cnd) {
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+				const [key, targetValue] = Object.entries(dependantValue._cnd)[0];
+
+				if (key === 'eq') {
+					conditionalValue = {
+						const: targetValue,
+					};
+				} else if (key === 'not') {
+					conditionalValue = {
+						not: {
+							const: targetValue,
+						},
+					};
+				} else if (key === 'gt') {
+					conditionalValue = {
+						type: 'number',
+						exclusiveMinimum: targetValue,
+					};
+				} else if (key === 'gte') {
+					conditionalValue = {
+						type: 'number',
+						minimum: targetValue,
+					};
+				} else if (key === 'lt') {
+					conditionalValue = {
+						type: 'number',
+						exclusiveMaximum: targetValue,
+					};
+				} else if (key === 'lte') {
+					conditionalValue = {
+						type: 'number',
+						maximum: targetValue,
+					};
+				} else if (key === 'startsWith') {
+					conditionalValue = {
+						type: 'string',
+						pattern: `^${targetValue}`,
+					};
+				} else if (key === 'endsWith') {
+					conditionalValue = {
+						type: 'string',
+						pattern: `${targetValue}$`,
+					};
+				} else if (key === 'includes') {
+					conditionalValue = {
+						type: 'string',
+						pattern: `${targetValue}`,
+					};
+				} else if (key === 'regex') {
+					conditionalValue = {
+						type: 'string',
+						pattern: `${targetValue}`,
+					};
 				} else {
 					conditionalValue = {
 						enum: [dependantValue],
 					};
 				}
-				propertyRequiredDependencies[dependantName] = {
-					if: {
-						properties: {
-							[dependantName]: conditionalValue,
-						},
-					},
-					then: {
-						allOf: [],
-					},
-					else: {
-						allOf: [],
-					},
+			} else {
+				conditionalValue = {
+					enum: [dependantValue],
 				};
 			}
-
-			propertyRequiredDependencies[dependantName].then?.allOf.push({ required: [property.name] });
-			propertyRequiredDependencies[dependantName].else?.allOf.push({
-				not: { required: [property.name] },
+			conditionalSchemas.push({
+				if: { properties: { [dependantName]: conditionalValue } },
+				then: { allOf: propertyNames.map((name) => ({ required: [name] })) },
+				else: { allOf: propertyNames.map((name) => ({ not: { required: [name] } })) },
 			});
-
-			resolveProperties.push(dependantName);
-			// remove global required
-			requiredFields = requiredFields.filter((field) => field !== property.name);
-		}
+		});
 	});
 	Object.assign(jsonSchema, { required: requiredFields });
 
-	jsonSchema.allOf = Object.values(propertyRequiredDependencies);
+	jsonSchema.allOf = conditionalSchemas;
 
 	if (!jsonSchema.allOf.length) {
 		delete jsonSchema.allOf;


### PR DESCRIPTION
## Summary

Fixed the parsing of required value which used to add wrong values in required and not required sections. Now, grouped by dependent property + value to reduce redundancy. Before it was using only property which causes wrong fields which prevented requests from generating the correct schema.

These were wrong logic:

```
propertyRequiredDependencies[dependantName].then?.allOf.push({ required: [property.name] });
			propertyRequiredDependencies[dependantName].else?.allOf.push({
				not: { required: [property.name] },
			});
```

### Steps to reproduce the bug:
1. Create an API key
2. Create a key-pair and send this via postman or something else;
```
curl --location 'http://localhost:5678/api/v1/credentials/' \
--header 'Content-Type: application/json' \
--header 'X-N8N-API-KEY: $API_KEY' \
--data '{
  "name": "Test-JWT-Auth",
  "type": "jwtAuth",
  "data": {
    "keyType": "pemKey",
    "publicKey": "-----BEGIN PUBLIC KEY-----\n....-----END PUBLIC KEY-----\n",
    "privateKey":"",
    "algorithm": "RS256"
  }
}'
```

fixes #19869 

### Video demo of fix:
Loom:
https://www.loom.com/share/2bef01f482954c85acb9101163b68320?sid=e19c699d-ddd4-4eb4-88bd-3a20d9fb6649

## Related Community forum posts
https://community.n8n.io/t/creating-pem-credentials-through-api/52059/2

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
