### PR TITLE
fix(editor): Remove workflowState non-provided warning for now (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/composables/usePushConnection/usePushConnection.ts
+++ b/packages/frontend/editor-ui/src/composables/usePushConnection/usePushConnection.ts
@@ -21,7 +21,7 @@ import {
 	workflowActivated,
 	workflowDeactivated,
 } from '@/composables/usePushConnection/handlers';
-import { useWorkflowState, type WorkflowState } from '@/composables/useWorkflowState';
+import { injectWorkflowState, type WorkflowState } from '@/composables/useWorkflowState';
 import { createEventQueue } from '@n8n/utils/event-queue';
 import type { useRouter } from 'vue-router';
 
@@ -35,7 +35,7 @@ export function usePushConnection({
 	const pushStore = usePushConnectionStore();
 	const options = {
 		router,
-		workflowState: workflowState ?? useWorkflowState(),
+		workflowState: workflowState ?? injectWorkflowState(),
 	};
 
 	const { enqueue } = createEventQueue<PushMessage>(processEvent);

--- a/packages/frontend/editor-ui/src/composables/useWorkflowSaving.ts
+++ b/packages/frontend/editor-ui/src/composables/useWorkflowSaving.ts
@@ -27,7 +27,7 @@ import { useNodeHelpers } from './useNodeHelpers';
 import { tryToParseNumber } from '@/utils/typesUtils';
 import { useTemplatesStore } from '@/stores/templates.store';
 import { useFocusPanelStore } from '@/stores/focusPanel.store';
-import { useWorkflowState } from './useWorkflowState';
+import { injectWorkflowState } from './useWorkflowState';
 
 export function useWorkflowSaving({ router }: { router: ReturnType<typeof useRouter> }) {
 	const uiStore = useUIStore();
@@ -35,7 +35,7 @@ export function useWorkflowSaving({ router }: { router: ReturnType<typeof useRou
 	const message = useMessage();
 	const i18n = useI18n();
 	const workflowsStore = useWorkflowsStore();
-	const workflowState = useWorkflowState();
+	const workflowState = injectWorkflowState();
 	const focusPanelStore = useFocusPanelStore();
 	const nodeTypesStore = useNodeTypesStore();
 	const toast = useToast();

--- a/packages/frontend/editor-ui/src/composables/useWorkflowState.ts
+++ b/packages/frontend/editor-ui/src/composables/useWorkflowState.ts
@@ -184,7 +184,11 @@ export function injectWorkflowState() {
 	return inject(
 		WorkflowStateKey,
 		() => {
-			console.error('Attempted to inject workflowState outside of NodeView tree');
+			// While we're migrating we're happy to fall back onto a separate instance since
+			// all data is still stored in the workflowsStore
+			// Once we're ready to move the actual refs to `useWorkflowState` we should error here
+			// to track down remaining usages that would break
+			// console.error('Attempted to inject workflowState outside of NodeView tree');
 			return useWorkflowState();
 		},
 		true,


### PR DESCRIPTION
## Summary

This is too noisy while we we're in a single-workflow world. Will reenable later when moving multi-workflow is in sight.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
