### PR TITLE
test(editor): Fix flaky frontend inline expression editor test

### DIFF
--- a/packages/testing/playwright/tests/ui/11-inline-expression-editor.spec.ts
+++ b/packages/testing/playwright/tests/ui/11-inline-expression-editor.spec.ts
@@ -31,8 +31,7 @@ test.describe('Inline expression editor', () => {
 			await expect(n8n.ndv.getInlineExpressionEditorOutput()).toBeHidden();
 		});
 
-		// NODE-3721
-		test.skip('should switch between expression and fixed using keyboard', async ({ n8n }) => {
+		test('should switch between expression and fixed using keyboard', async ({ n8n }) => {
 			await n8n.canvas.addNode(EDIT_FIELDS_SET_NODE_NAME);
 
 			// Should switch to expression with =
@@ -46,12 +45,10 @@ test.describe('Inline expression editor', () => {
 
 			// Should switch back to fixed with backspace on empty expression
 			await n8n.ndv.clearExpressionEditor('value');
-			const parameterInput = n8n.ndv.getParameterInput('value');
+			const parameterInput = n8n.ndv.getParameterInput('value').getByRole('textbox');
 			await parameterInput.click();
 			await parameterInput.focus();
 			await parameterInput.press('Backspace');
-			// eslint-disable-next-line playwright/no-wait-for-timeout
-			await n8n.page.waitForTimeout(1000);
 			await expect(n8n.ndv.getInlineExpressionEditorInput()).toBeHidden();
 		});
 	});

--- a/packages/testing/playwright/tests/ui/26-resource-locator.spec.ts
+++ b/packages/testing/playwright/tests/ui/26-resource-locator.spec.ts
@@ -107,10 +107,11 @@ test.describe('Resource Locator', () => {
 	});
 
 	// unlike RMC and remote options, RLC does not support loadOptionDependsOn
+	// NODE-3720
 	test('should retrieve list options when other params throw errors', async ({ n8n }) => {
 		await n8n.canvas.addNode(E2E_TEST_NODE_NAME, { closeNDV: false, action: 'Resource Locator' });
 
-		await n8n.ndv.getResourceLocatorInput('rlc').getByTestId('rlc-input').focus();
+		await n8n.ndv.getResourceLocatorInput('rlc').click();
 
 		await expect(n8n.page.getByTestId('rlc-item').first()).toBeVisible();
 		const visiblePopper = n8n.ndv.getVisiblePopper();
@@ -121,7 +122,7 @@ test.describe('Resource Locator', () => {
 
 		await n8n.ndv.getInputPanel().click(); // remove focus from input, hide expression preview
 
-		await n8n.ndv.getResourceLocatorInput('rlc').getByTestId('rlc-input').focus();
+		await n8n.ndv.getResourceLocatorInput('rlc').click();
 
 		await expect(n8n.page.getByTestId('rlc-item').first()).toBeVisible();
 		const visiblePopperAfter = n8n.ndv.getVisiblePopper();

--- a/packages/testing/playwright/tests/ui/26-resource-locator.spec.ts
+++ b/packages/testing/playwright/tests/ui/26-resource-locator.spec.ts
@@ -107,11 +107,10 @@ test.describe('Resource Locator', () => {
 	});
 
 	// unlike RMC and remote options, RLC does not support loadOptionDependsOn
-	// NODE-3720
-	test.skip('should retrieve list options when other params throw errors', async ({ n8n }) => {
+	test('should retrieve list options when other params throw errors', async ({ n8n }) => {
 		await n8n.canvas.addNode(E2E_TEST_NODE_NAME, { closeNDV: false, action: 'Resource Locator' });
 
-		await n8n.ndv.getResourceLocatorInput('rlc').click();
+		await n8n.ndv.getResourceLocatorInput('rlc').getByTestId('rlc-input').focus();
 
 		await expect(n8n.page.getByTestId('rlc-item').first()).toBeVisible();
 		const visiblePopper = n8n.ndv.getVisiblePopper();
@@ -122,7 +121,7 @@ test.describe('Resource Locator', () => {
 
 		await n8n.ndv.getInputPanel().click(); // remove focus from input, hide expression preview
 
-		await n8n.ndv.getResourceLocatorInput('rlc').click();
+		await n8n.ndv.getResourceLocatorInput('rlc').getByTestId('rlc-input').focus();
 
 		await expect(n8n.page.getByTestId('rlc-item').first()).toBeVisible();
 		const visiblePopperAfter = n8n.ndv.getVisiblePopper();

--- a/packages/testing/playwright/tests/ui/26-resource-locator.spec.ts
+++ b/packages/testing/playwright/tests/ui/26-resource-locator.spec.ts
@@ -108,7 +108,7 @@ test.describe('Resource Locator', () => {
 
 	// unlike RMC and remote options, RLC does not support loadOptionDependsOn
 	// NODE-3720
-	test('should retrieve list options when other params throw errors', async ({ n8n }) => {
+	test.skip('should retrieve list options when other params throw errors', async ({ n8n }) => {
 		await n8n.canvas.addNode(E2E_TEST_NODE_NAME, { closeNDV: false, action: 'Resource Locator' });
 
 		await n8n.ndv.getResourceLocatorInput('rlc').click();


### PR DESCRIPTION
## Summary

This PR fixes flaky inline expression editor test

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3721/flaky-test-should-switch-between-expression-and-fixed-using-keyboard

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
