### PR TITLE
fix(form):fixes the form end node not redirecting properly

### DIFF
--- a/packages/cli/templates/form-trigger-completion.handlebars
+++ b/packages/cli/templates/form-trigger-completion.handlebars
@@ -160,6 +160,7 @@
 	<script>
 		let interval = 1000;
 		let timeoutId;
+		const redirectUrl = "{{redirectUrl}}";
 		const checkExecutionStatus = async () => {
 			if (!interval) return;
 
@@ -186,62 +187,74 @@
 		};
 
 		document.addEventListener('DOMContentLoaded', function () {
-			const binary = "{{{responseBinary}}}"
-				?	JSON.parse(decodeURIComponent("{{{responseBinary}}}"))
-				: '';
+			try {
+			const rawBinary = "{{{responseBinary}}}";
 
-			const byteArray = binary.data.type === 'Buffer'
-				? new Uint8Array(binary.data.data)
-				: Uint8Array.from(binary.data, c => c.charCodeAt(0));
+			if (rawBinary) {
+				let binary = JSON.parse(decodeURIComponent(rawBinary));
 
-			if (binary) {
-				const blob = new Blob(
-					[byteArray],
-					{ type: binary.type }
-				);
+				if (binary && binary.data) {
 
-				const link = document.createElement("a");
-				link.href = URL.createObjectURL(blob);
-				link.download = binary.fileName;
-				document.body.appendChild(link);
+					const byteArray = binary.data.type === 'Buffer'
+						? new Uint8Array(binary.data.data)
+						: Uint8Array.from(binary.data, c => c.charCodeAt(0));
 
-				link.click();
-				document.body.removeChild(link);
+					const blob = new Blob([byteArray], { type: binary.type });
+					const link = document.createElement("a");
+					link.href = URL.createObjectURL(blob);
+					link.download = binary.fileName;
+					document.body.appendChild(link);
+					link.click();
+					document.body.removeChild(link);
+
+				}
 			}
-		});
+		} catch (err) {
+			console.error("[Binary] failed to parse or download:", err);
+		}
 
+		if (redirectUrl) {
 			fetch('', {
-					method: 'POST',
-					body: {}
+				method: 'POST',
+				body: {}
 			})
-			.then(async function (response) {
+			.then(() => {
+				window.location.replace(redirectUrl);
+			})
+			.catch((error) => {
+				console.error("[Redirect] POST failed:", error);
+				window.location.replace(redirectUrl);
+			});
+		} else {
+
+			fetch('', { method: 'POST', body: {} })
+				.then(async function (response) {
 					if (response.status === 200) {
-						const redirectUrl = document.getElementById("redirectUrl");
-						if (redirectUrl) {
-							window.location.replace(redirectUrl.href);
+
+						const text = await response.text();
+
+						try {
+							const json = JSON.parse(text);
+							if (json?.redirectUrl) {
+								const url = json.redirectUrl.includes("://")
+									? json.redirectUrl
+									: "https://" + json.redirectUrl;
+								window.location.replace(url);
+							}
+						} catch (e) {
+							console.warn("[Redirect Fallback] response not JSON");
 						}
 					}
+				})
+				.catch((error) => {
+					console.error("[Redirect Fallback] fetch error:", error);
+				})
+				.finally(() => {
+					timeoutId = setTimeout(checkExecutionStatus, interval);
+				});
+		}
+	});
 
-					const text = await response.text();
-					let json;
-
-					try {
-							json = JSON.parse(text);
-					} catch (e) {}
-
-					if (json?.redirectURL) {
-							const url = json.redirectURL.includes("://")
-									? json.redirectURL
-									: "https://" + json.redirectURL;
-							window.location.replace(url);
-					}
-			})
-			.catch(function (error) {
-					console.error('Error:', error);
-			})
-			.finally(() => {
-				timeoutId = setTimeout(checkExecutionStatus, interval);
-			});
 	</script>
 	</body>
 

--- a/packages/cli/templates/form-trigger-completion.handlebars
+++ b/packages/cli/templates/form-trigger-completion.handlebars
@@ -160,7 +160,8 @@
 	<script>
 		let interval = 1000;
 		let timeoutId;
-		const redirectUrl = "{{redirectUrl}}";
+		const anchor = document.getElementById("redirectUrl");
+		const redirectUrl = anchor ? anchor.href : "";
 		const checkExecutionStatus = async () => {
 			if (!interval) return;
 

--- a/packages/cli/templates/form-trigger-completion.handlebars
+++ b/packages/cli/templates/form-trigger-completion.handlebars
@@ -236,10 +236,9 @@
 
 						try {
 							const json = JSON.parse(text);
-							if (json?.redirectURL) {
-								const url = json.redirectURL.includes("://")
-									? json.redirectURL
-									: "https://" + json.redirectURL;
+							const target = json?.redirectUrl || json?.redirectURL;
+							if (target) {
+								const url = target.includes("://") ? target : "https://" + target;
 								window.location.replace(url);
 							}
 						} catch (e) {

--- a/packages/cli/templates/form-trigger-completion.handlebars
+++ b/packages/cli/templates/form-trigger-completion.handlebars
@@ -235,10 +235,10 @@
 
 						try {
 							const json = JSON.parse(text);
-							if (json?.redirectUrl) {
-								const url = json.redirectUrl.includes("://")
-									? json.redirectUrl
-									: "https://" + json.redirectUrl;
+							if (json?.redirectURL) {
+								const url = json.redirectURL.includes("://")
+									? json.redirectURL
+									: "https://" + json.redirectURL;
 								window.location.replace(url);
 							}
 						} catch (e) {


### PR DESCRIPTION

## Summary

Problem:  
In version 1.113, redirecting to a URL at the end of a Form no longer works.  
The page displays *“Redirecting to …”* but the browser never actually navigates to the target.  
This regression was reported in [#20303](https://github.com/n8n-io/n8n/issues/20303).

Solution:  
- Refactored the Form End template to properly parse and handle `redirectUrl`.  
- Added error handling for binary parsing and redirect fallbacks.  
- Improved redirect logic to ensure the browser navigates reliably, whether `redirectUrl` is provided directly or returned from a JSON response.  
- Consolidated code for readability and added safe fallbacks for malformed data.  

Testing:  
1. Add a **Form node** and a **Form End node** with a redirect URL.  
2. Execute the workflow.  
3. Confirm that the browser redirects to the specified URL.  
4. Tested with both valid URLs and malformed/binary responses to ensure no crashes.  

📹 **Screen Recording:**  
_Attached video demonstrates the redirect working after the fix._  
https://github.com/user-attachments/assets/e4fa9a29-7198-4cba-831f-d090e083f00b

---

## Related Linear tickets, Github issues, and Community forum posts
### Fixes #20303  
### Related Linear Ticket: GHC-4790
---

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))  
- [ ] Docs updated or follow-up ticket created.  
- [x] Tests included (manual verification with Form End redirect).  
- [ ] PR labeled with `release/backport` (if the PR is an urgent fix that needs to be backported).  
