### PR TITLE
fix(editor): Fix execution state race condition in AI Builder (no-changelog)

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/chains/parameter-updater.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/chains/parameter-updater.ts
@@ -88,6 +88,7 @@ export const createParameterUpdaterChain = (
 			{
 				type: 'text',
 				text: systemPromptContent,
+				cache_control: { type: 'ephemeral' },
 			},
 		],
 	});
@@ -98,6 +99,7 @@ export const createParameterUpdaterChain = (
 				{
 					type: 'text',
 					text: nodeDefinitionPrompt,
+					cache_control: { type: 'ephemeral' },
 				},
 				{
 					type: 'text',

--- a/packages/frontend/editor-ui/src/components/AskAssistant/Agent/ExecuteMessage.vue
+++ b/packages/frontend/editor-ui/src/components/AskAssistant/Agent/ExecuteMessage.vue
@@ -53,20 +53,20 @@ const stopExecutionWatcher = () => {
 const ensureExecutionWatcher = () => {
 	if (executionWatcherStop) return;
 
-	let wasRunning = workflowsStore.isWorkflowRunning;
+	const RUNNING_STATES = ['running', 'waiting'];
 
 	executionWatcherStop = watch(
-		() => workflowsStore.isWorkflowRunning,
-		(isRunning) => {
-			if (wasRunning && !isRunning) {
-				stopExecutionWatcher();
-				const wasCancelled = workflowsStore.workflowExecutionData?.status === 'canceled';
+		() => workflowsStore.workflowExecutionData?.status,
+		async (status) => {
+			await nextTick();
 
-				if (!wasCancelled) {
-					emit('workflowExecuted');
-				}
+			if (!status || RUNNING_STATES.includes(status)) return;
+
+			stopExecutionWatcher();
+
+			if (status !== 'canceled') {
+				emit('workflowExecuted');
 			}
-			wasRunning = isRunning;
 		},
 	);
 };


### PR DESCRIPTION
## Summary

Fixes a race condition in the AI Builder's workflow execution watcher where the execution state was incorrectly reported as "running" even after the workflow finished executing.

## Root Cause

The execution watcher in `ExecuteMessage.vue` was monitoring `isWorkflowRunning` to detect when a workflow execution completes. However, there was a race condition where:

1. `isWorkflowRunning` would change to `false`
2. But `workflowExecutionData.status` was still `"running"` (not yet updated)

This caused the component to emit the `workflowExecuted` event while the execution state was still showing as "running", leading to incorrect state reporting in the AI Builder.

## Changes

### ExecuteMessage.vue
- Changed execution watcher to monitor `workflowExecutionData.status` directly instead of `isWorkflowRunning`
- Now only emits completion event when status is not `'running'` or `'waiting'`

### ExecuteMessage.test.ts
- Updated all tests to mock `workflowExecutionData.status` instead of `isWorkflowRunning`
- Added proper async handling with `flushPromises()` to account for async watcher callbacks

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
