### PR TITLE
test: Fix flaky workflow-data-proxy-env-provider test

### DIFF
--- a/packages/workflow/test/workflow-data-proxy-env-provider.test.ts
+++ b/packages/workflow/test/workflow-data-proxy-env-provider.test.ts
@@ -57,9 +57,9 @@ describe('createEnvProvider', () => {
 		vi.useFakeTimers({ now: new Date() });
 
 		const originalProcess = global.process;
-		// @ts-expect-error process is read-only
-		global.process = undefined;
 		try {
+			// @ts-expect-error process is read-only
+			global.process = undefined;
 			const proxy = createEnvProvider(1, 1, createEnvProviderState());
 
 			expect(() => proxy.someEnvVar).toThrowError(
@@ -70,26 +70,27 @@ describe('createEnvProvider', () => {
 			);
 		} finally {
 			global.process = originalProcess;
+			vi.useRealTimers();
 		}
-
-		vi.useRealTimers();
 	});
 
 	it('should throw ExpressionError when env access is blocked', () => {
 		vi.useFakeTimers({ now: new Date() });
 
-		process.env.N8N_BLOCK_ENV_ACCESS_IN_NODE = 'true';
-		const proxy = createEnvProvider(1, 1, createEnvProviderState());
+		try {
+			process.env.N8N_BLOCK_ENV_ACCESS_IN_NODE = 'true';
+			const proxy = createEnvProvider(1, 1, createEnvProviderState());
 
-		expect(() => proxy.someEnvVar).toThrowError(
-			new ExpressionError('access to env vars denied', {
-				causeDetailed:
-					'If you need access please contact the administrator to remove the environment variable ‘N8N_BLOCK_ENV_ACCESS_IN_NODE‘',
-				runIndex: 1,
-				itemIndex: 1,
-			}),
-		);
-
-		vi.useRealTimers();
+			expect(() => proxy.someEnvVar).toThrowError(
+				new ExpressionError('access to env vars denied', {
+					causeDetailed:
+						'If you need access please contact the administrator to remove the environment variable ‘N8N_BLOCK_ENV_ACCESS_IN_NODE‘',
+					runIndex: 1,
+					itemIndex: 1,
+				}),
+			);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 });

--- a/packages/workflow/test/workflow-data-proxy-env-provider.test.ts
+++ b/packages/workflow/test/workflow-data-proxy-env-provider.test.ts
@@ -76,6 +76,8 @@ describe('createEnvProvider', () => {
 	});
 
 	it('should throw ExpressionError when env access is blocked', () => {
+		vi.useFakeTimers({ now: new Date() });
+
 		process.env.N8N_BLOCK_ENV_ACCESS_IN_NODE = 'true';
 		const proxy = createEnvProvider(1, 1, createEnvProviderState());
 
@@ -87,5 +89,7 @@ describe('createEnvProvider', () => {
 				itemIndex: 1,
 			}),
 		);
+
+		vi.useRealTimers();
 	});
 });


### PR DESCRIPTION
## Summary
Fix flaky test by adding `vi.useFakeTimers()` mock to ensure deterministic timestamps in error comparison. The test was flaking due to 1ms differences in `ExpressionError.timestamp`.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/CAT-1522/flaky-workflowdataproxy-env-provider-unit-test-in



## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
