### PR TITLE
fix: When a workflow is waiting indefinitely, it now show the correct message

### DIFF
--- a/packages/frontend/editor-ui/src/composables/useCanvasMapping.ts
+++ b/packages/frontend/editor-ui/src/composables/useCanvasMapping.ts
@@ -500,6 +500,8 @@ export function useCanvasMapping({
 						acc[node.id] = i18n.baseText(
 							'node.theNodeIsWaitingIndefinitelyForAnIncomingWebhookCall',
 						);
+
+						return acc;
 					}
 
 					acc[node.id] = i18n.baseText('node.nodeIsWaitingTill', {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR fixes an issue where a check for the indefinite time matching the wait time did not provide the right message on the UI.

Before:

<img width="1282" height="737" alt="image" src="https://github.com/user-attachments/assets/a5fc9453-37bc-4607-b71f-75a9ce589fc2" />

After: 

<img width="1282" height="737" alt="image" src="https://github.com/user-attachments/assets/f9bab98f-57a3-4352-a82e-4c824290c485" />

## Related Linear tickets, Github issues, and Community forum posts

PAY-3907

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
