### PR TITLE
feat(core): Add `getN8nVersion` helper to `FunctionsBase`

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/__tests__/node-execution-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/node-execution-context.test.ts
@@ -13,9 +13,9 @@ import type {
 } from 'n8n-workflow';
 import { CHAT_TRIGGER_NODE_TYPE, NodeConnectionTypes } from 'n8n-workflow';
 
-import { NodeExecutionContext } from '../node-execution-context';
-
 import { InstanceSettings } from '@/instance-settings';
+
+import { NodeExecutionContext } from '../node-execution-context';
 
 class TestContext extends NodeExecutionContext {}
 

--- a/packages/core/src/execution-engine/node-execution-context/node-execution-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/node-execution-context.ts
@@ -36,13 +36,6 @@ import {
 } from 'n8n-workflow';
 import { join, resolve } from 'path';
 
-import { cleanupParameterData } from './utils/cleanup-parameter-data';
-import { ensureType } from './utils/ensure-type';
-import { extractValue } from './utils/extract-value';
-import { getAdditionalKeys } from './utils/get-additional-keys';
-import { validateValueAgainstSchema } from './utils/validate-value-against-schema';
-import { generateUrlSignature, prepareUrlForSigning } from '../../utils/signature-helpers';
-
 import {
 	HTTP_REQUEST_AS_TOOL_NODE_TYPE,
 	HTTP_REQUEST_NODE_TYPE,
@@ -50,6 +43,13 @@ import {
 	WAITING_TOKEN_QUERY_PARAM,
 } from '@/constants';
 import { InstanceSettings } from '@/instance-settings';
+
+import { cleanupParameterData } from './utils/cleanup-parameter-data';
+import { ensureType } from './utils/ensure-type';
+import { extractValue } from './utils/extract-value';
+import { getAdditionalKeys } from './utils/get-additional-keys';
+import { validateValueAgainstSchema } from './utils/validate-value-against-schema';
+import { generateUrlSignature, prepareUrlForSigning } from '../../utils/signature-helpers';
 
 export abstract class NodeExecutionContext implements Omit<FunctionsBase, 'getCredentials'> {
 	protected readonly instanceSettings = Container.get(InstanceSettings);

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -894,6 +894,7 @@ export interface FunctionsBase {
 	getRestApiUrl(): string;
 	getInstanceBaseUrl(): string;
 	getInstanceId(): string;
+	getN8nVersion(): string;
 	/** Get the waiting resume url signed with the signature token */
 	getSignedResumeUrl(parameters?: Record<string, string>): string;
 	/** Set requirement in the execution for signature token validation */

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -894,7 +894,7 @@ export interface FunctionsBase {
 	getRestApiUrl(): string;
 	getInstanceBaseUrl(): string;
 	getInstanceId(): string;
-	getN8nVersion(): string;
+	getN8nVersion(): Promise<string>;
 	/** Get the waiting resume url signed with the signature token */
 	getSignedResumeUrl(parameters?: Record<string, string>): string;
 	/** Set requirement in the execution for signature token validation */


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Add `getN8nVersion` helper to `FunctionsBase` so it's available in `IExecuteFunctions`, `IWebhookFunctions`, etc. The logic is very similar to what there is in the `cli` package, see [here](https://github.com/n8n-io/n8n/blob/efc2b5589ae1f88b9f9ff494ea04347ac8612bf3/packages/cli/src/constants.ts#L21). Except here the root `package.json` is used, since the `package.json` in `core` package can have a different version, for some reason. Perhaps we could somehow extract this so the logic is not duplicated between packages, but I'm not sure what's the best place to do that

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-3549/add-n8n-version-helper-to-n8n-workflow

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
