### PR TITLE
fix(GraphQL Node): Prevent duplicate error items in error output routing

### DIFF
--- a/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
+++ b/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
@@ -515,47 +515,39 @@ export class GraphQL implements INodeType {
 					response = await this.helpers.request(requestOptions);
 				}
 
-				// Parse string responses if needed
-				if (typeof response === 'string') {
-					// Try to parse string responses to check for GraphQL errors
-					if (response.startsWith('{"errors":') || response.includes('"errors"')) {
-						try {
-							const parsedResponse = JSON.parse(response);
-							if (parsedResponse.errors) {
-								response = parsedResponse;
-							}
-						} catch (e) {
-							// If parsing fails and responseFormat is not 'string', throw error
-							if (responseFormat !== 'string') {
-								throw new NodeOperationError(
-									this.getNode(),
-									'Response body is not valid JSON. Change "Response Format" to "String"',
-									{ itemIndex },
-								);
-							}
-						}
-					} else if (responseFormat !== 'string') {
-						// For non-string format, all responses must be valid JSON
-						try {
-							response = JSON.parse(response);
-						} catch (error) {
-							throw new NodeOperationError(
-								this.getNode(),
-								'Response body is not valid JSON. Change "Response Format" to "String"',
-								{ itemIndex },
-							);
-						}
+				// Parse string responses
+				if (typeof response === 'string' && responseFormat !== 'string') {
+					try {
+						response = JSON.parse(response);
+					} catch (error) {
+						throw new NodeOperationError(
+							this.getNode(),
+							'Response body is not valid JSON. Change "Response Format" to "String"',
+							{ itemIndex },
+						);
 					}
 				}
 
 				// Check for GraphQL errors BEFORE adding to returnItems
-				if (typeof response === 'object' && response !== null && 'errors' in response) {
-					const errors = response.errors;
-					// Validate that errors is an array
+				let parsedForErrorCheck = response;
+				if (typeof response === 'string') {
+					try {
+						parsedForErrorCheck = JSON.parse(response);
+					} catch {
+						// Not JSON, no errors to check
+						parsedForErrorCheck = response;
+					}
+				}
+
+				if (
+					typeof parsedForErrorCheck === 'object' &&
+					parsedForErrorCheck !== null &&
+					'errors' in parsedForErrorCheck
+				) {
+					const errors = parsedForErrorCheck.errors;
 					if (Array.isArray(errors) && errors.length > 0) {
 						const message =
 							errors.map((error: IDataObject) => error.message).join(', ') || 'Unexpected error';
-						// Wrap errors array in a JsonObject for NodeApiError
 						const errorPayload: JsonObject = { errors };
 						throw new NodeApiError(this.getNode(), errorPayload, { message });
 					}

--- a/packages/nodes-base/nodes/GraphQL/test/workflow.error_output_routing.json
+++ b/packages/nodes-base/nodes/GraphQL/test/workflow.error_output_routing.json
@@ -1,0 +1,119 @@
+{
+	"name": "Test GraphQL Error Output Routing",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "manual-trigger",
+			"name": "Manual Trigger",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0]
+		},
+		{
+			"parameters": {
+				"jsCode": "return [\n  // This query will fail with a GraphQL error\n  {\n    query: 'INVALID_QUERY'\n  },\n  // This query will succeed\n  {\n    query: 'query { users { id name email } }'\n  }\n]"
+			},
+			"id": "code-node",
+			"name": "Generate Queries",
+			"type": "n8n-nodes-base.code",
+			"typeVersion": 2,
+			"position": [200, 0]
+		},
+		{
+			"parameters": {
+				"endpoint": "http://test.example.com/graphql",
+				"query": "={{ $json.query }}"
+			},
+			"id": "graphql-node",
+			"name": "GraphQL",
+			"type": "n8n-nodes-base.graphql",
+			"typeVersion": 1.1,
+			"position": [400, 0],
+			"onError": "continueErrorOutput"
+		},
+		{
+			"parameters": {},
+			"id": "success-output",
+			"name": "Success Output",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [600, -100]
+		},
+		{
+			"parameters": {},
+			"id": "error-output",
+			"name": "Error Output",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [600, 100]
+		}
+	],
+	"connections": {
+		"Manual Trigger": {
+			"main": [
+				[
+					{
+						"node": "Generate Queries",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Generate Queries": {
+			"main": [
+				[
+					{
+						"node": "GraphQL",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"GraphQL": {
+			"main": [
+				[
+					{
+						"node": "Success Output",
+						"type": "main",
+						"index": 0
+					}
+				],
+				[
+					{
+						"node": "Error Output",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"pinData": {
+		"Success Output": [
+			{
+				"data": {
+					"users": [
+						{
+							"id": "1",
+							"name": "John Doe",
+							"email": "john@example.com"
+						},
+						{
+							"id": "2",
+							"name": "Jane Smith",
+							"email": "jane@example.com"
+						}
+					]
+				}
+			}
+		],
+		"Error Output": [
+			{
+				"query": "INVALID_QUERY",
+				"error": "Syntax Error: Invalid query syntax"
+			}
+		]
+	}
+}


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
This PR fixes an issue where `GraphQL` errors would appear in both the success and error outputs when using the _"Continue using error output"_ setting. The problem occurred because the node was adding the `GraphQL` response to `returnItems` before checking for errors. This fix moves the error checking logic before adding items to `returnItems`, ensuring that `GraphQL` errors are only routed to the error output and successful responses only go to the success output.

### Screenshot
<img width="1244" height="594" alt="image" src="https://github.com/user-attachments/assets/b5d7f953-0e9e-4dc7-8bbf-712635690f12" />
<img width="1244" height="594" alt="image" src="https://github.com/user-attachments/assets/36441e4b-a06b-4b2c-addd-f14b471a75c2" />


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
Closes #20321 


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
