### PR TITLE
fix: Flaky E2E test for the RLC (no-changelog)

### DIFF
--- a/packages/testing/playwright/pages/NodeDetailsViewPage.ts
+++ b/packages/testing/playwright/pages/NodeDetailsViewPage.ts
@@ -1013,7 +1013,7 @@ export class NodeDetailsViewPage extends BasePage {
 		await this.activateParameterExpressionEditor(fieldName);
 		const editor = this.getInlineExpressionEditorInput(fieldName);
 		await editor.click();
-		await this.page.keyboard.type(invalidExpression ?? '{{ invalid_expression');
+		await this.page.keyboard.type(invalidExpression ?? '{{ =()');
 	}
 
 	/**

--- a/packages/testing/playwright/tests/ui/26-resource-locator.spec.ts
+++ b/packages/testing/playwright/tests/ui/26-resource-locator.spec.ts
@@ -107,8 +107,7 @@ test.describe('Resource Locator', () => {
 	});
 
 	// unlike RMC and remote options, RLC does not support loadOptionDependsOn
-	// NODE-3720
-	test.skip('should retrieve list options when other params throw errors', async ({ n8n }) => {
+	test('should retrieve list options when other params throw errors', async ({ n8n }) => {
 		await n8n.canvas.addNode(E2E_TEST_NODE_NAME, { closeNDV: false, action: 'Resource Locator' });
 
 		await n8n.ndv.getResourceLocatorInput('rlc').click();
@@ -121,6 +120,9 @@ test.describe('Resource Locator', () => {
 		await n8n.ndv.setInvalidExpression({ fieldName: 'fieldId' });
 
 		await n8n.ndv.getInputPanel().click(); // remove focus from input, hide expression preview
+
+		// wait for the expression to be evaluated and show the error
+		await expect(n8n.ndv.getParameterInputHint()).toContainText('ERROR');
 
 		await n8n.ndv.getResourceLocatorInput('rlc').click();
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Fix a flaky test for the RLC. Sometimes it'd fail when trying to open the RLC for the second time and gets stuck loading indefinitely. I assume this was because the expression was not fully evaluated before clicking the RLC. The fix involves waiting for the expression to resolve and for the error message to show under the input field.

Ran it 200 times with (in `packages/testing/playwright`):
```bash
pnpm test:local --grep "should retrieve list options when other params throw errors" --repeat-each 200
```
with no failures 

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-3720/flaky-test-should-retrieve-list-options-when-other-params-throw-errors

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
