### PR TITLE
fix(frontend): add timezone-aware UI date formatting (formatDateForUI) — fixes #20330

### DIFF
--- a/.tmp-compile/dateFormatter.js
+++ b/.tmp-compile/dateFormatter.js
@@ -1,0 +1,106 @@
+import dateformat from 'dateformat';
+import { i18n } from '@n8n/i18n';
+export const convertToDisplayDateComponents = (fullDate) => {
+    const mask = `d mmm${new Date(fullDate).getFullYear() === new Date().getFullYear() ? '' : ', yyyy'}#HH:MM:ss`;
+    const formattedDate = dateformat(fullDate, mask);
+    const [date, time] = formattedDate.split('#');
+    return { date, time };
+};
+export function convertToDisplayDate(fullDate) {
+    const mask = `mmm d${new Date(fullDate).getFullYear() === new Date().getFullYear() ? '' : ', yyyy'}#HH:MM:ss`;
+    const formattedDate = dateformat(fullDate, mask);
+    const [date, time] = formattedDate.split('#');
+    return { date, time };
+}
+export const toDayMonth = (fullDate) => dateformat(fullDate, 'd mmm');
+export const toTime = (fullDate, includeMillis = false) => dateformat(fullDate, includeMillis ? 'HH:MM:ss.l' : 'HH:MM:ss');
+export const formatTimeAgo = (fullDate) => {
+    const now = new Date();
+    const date = new Date(fullDate);
+    const diffInMs = now.getTime() - date.getTime();
+    const diffInDays = Math.floor(diffInMs / (1000 * 60 * 60 * 24));
+    if (diffInDays === 0) {
+        return i18n.baseText('userActivity.today');
+    }
+    else if (diffInDays === 1) {
+        return i18n.baseText('userActivity.yesterday');
+    }
+    else if (diffInDays >= 2 && diffInDays <= 6) {
+        return dateformat(date, 'dddd');
+    }
+    else if (diffInDays >= 7 && diffInDays <= 13) {
+        return i18n.baseText('userActivity.lastTime', {
+            interpolate: { time: dateformat(date, 'dddd') },
+        });
+    }
+    else if (diffInDays >= 14 && diffInDays <= 30) {
+        return i18n.baseText('userActivity.daysAgo', { interpolate: { count: diffInDays.toString() } });
+    }
+    else {
+        return dateformat(date, 'mmmm d, yyyy');
+    }
+};
+export const formatDateForUI = (fullDate, timeZone, locale) => {
+    if (fullDate === null || fullDate === undefined || fullDate === '') {
+        return { date: '', time: '' };
+    }
+    // Narrow input first instead of using `as any`
+    if (typeof fullDate !== 'string' && typeof fullDate !== 'number' && !(fullDate instanceof Date)) {
+        return { date: 'Invalid Date', time: '' };
+    }
+    const d = new Date(fullDate);
+    if (Number.isNaN(d.getTime())) {
+        return { date: 'Invalid Date', time: '' };
+    }
+    // Helper to get year in a timezone (falls back to local year)
+    const getYearInTZ = (date, tz, loc) => {
+        if (!tz)
+            return date.getFullYear();
+        try {
+            const parts = new Intl.DateTimeFormat(loc ?? undefined, {
+                timeZone: tz,
+                year: 'numeric',
+            }).formatToParts(date);
+            const yearStr = parts.find((p) => p.type === 'year')?.value;
+            return yearStr ? Number(yearStr) : date.getFullYear();
+        }
+        catch {
+            // If Intl/timezone fails, fall back to local year
+            return date.getFullYear();
+        }
+    };
+    // If timezone provided, produce TZ-aware strings (Intl handles formatting)
+    if (timeZone) {
+        try {
+            // include year if the display year (in target timezone) differs from current year in that same timezone
+            const includeYear = getYearInTZ(d, timeZone, locale) !== getYearInTZ(new Date(), timeZone, locale);
+            const dateOpts = {
+                year: includeYear ? 'numeric' : undefined,
+                month: 'short',
+                day: 'numeric',
+            };
+            const timeOpts = {
+                hour: 'numeric',
+                minute: '2-digit',
+                hour12: true,
+            };
+            const dateStr = new Intl.DateTimeFormat(locale ?? undefined, {
+                ...dateOpts,
+                timeZone,
+            }).format(d);
+            const timeStr = new Intl.DateTimeFormat(locale ?? undefined, {
+                ...timeOpts,
+                timeZone,
+            }).format(d);
+            return { date: dateStr, time: timeStr };
+        }
+        catch (err) {
+            // fall through to fallback below
+        }
+    }
+    // Fallback: keep existing dateformat behaviour
+    const mask = `mmm d${d.getFullYear() === new Date().getFullYear() ? '' : ', yyyy'}#HH:MM:ss`;
+    const formattedDate = dateformat(d, mask);
+    const [date, time] = formattedDate.split('#');
+    return { date, time };
+};

--- a/packages/frontend/editor-ui/src/utils/formatters/dateFormatter.test.ts
+++ b/packages/frontend/editor-ui/src/utils/formatters/dateFormatter.test.ts
@@ -73,3 +73,33 @@ describe('formatTimeAgo', () => {
 		expect(formatTimeAgo(exactlyThirtyOneDaysAgo)).toBe('June 14, 2023');
 	});
 });
+
+import { formatDateForUI } from './dateFormatter';
+
+describe('formatDateForUI', () => {
+	test('returns empty strings for null/undefined/empty input', () => {
+		expect(formatDateForUI(null as any)).toEqual({ date: '', time: '' });
+		expect(formatDateForUI(undefined as any)).toEqual({ date: '', time: '' });
+		expect(formatDateForUI('' as any)).toEqual({ date: '', time: '' });
+	});
+
+	test('returns Invalid Date for unparsable input', () => {
+		const res = formatDateForUI('not-a-date');
+		expect(res.date).toBe('Invalid Date');
+		expect(res.time).toBe('');
+	});
+
+	test('returns non-empty date and time for a valid ISO string (no timezone param)', () => {
+		const res = formatDateForUI('2025-10-02T14:00:00Z');
+		expect(typeof res).toBe('object');
+		expect(res.date.length).toBeGreaterThan(0);
+		expect(res.time.length).toBeGreaterThan(0);
+	});
+
+	test('when timeZone provided, returns time that looks like a time (contains a colon)', () => {
+		const res = formatDateForUI('2025-10-02T14:00:00Z', 'UTC');
+		expect(res.date.length).toBeGreaterThan(0);
+		expect(res.time.length).toBeGreaterThan(0);
+		expect(res.time.includes(':')).toBe(true);
+	});
+});

--- a/packages/frontend/editor-ui/src/utils/formatters/dateFormatter.ts
+++ b/packages/frontend/editor-ui/src/utils/formatters/dateFormatter.ts
@@ -51,3 +51,69 @@ export const formatTimeAgo = (fullDate: Date | string): string => {
 		return dateformat(date, 'mmmm d, yyyy');
 	}
 };
+
+/**
+ * Format a date for UI display, with optional IANA timezone.
+ * If timeZone is provided we'll use Intl.DateTimeFormat to ensure the displayed time
+ * matches that timezone (e.g. 'Asia/Beirut'). If not provided, we fall back to the
+ * existing `dateformat` behaviour so other parts of the app are unaffected.
+ *
+ * @param fullDate Date | string | number
+ * @param timeZone optional IANA timezone e.g. 'Asia/Beirut'
+ * @param locale optional locale string e.g. 'en-US'
+ * @returns { date: string, time: string } similar to convertToDisplayDateComponents
+ */
+export const formatDateForUI = (
+	fullDate: Date | string | number | null | undefined,
+	timeZone?: string,
+	locale?: string,
+): { date: string; time: string } => {
+	if (fullDate === null || fullDate === undefined || fullDate === '') {
+		return { date: '', time: '' };
+	}
+
+	const d = new Date(fullDate as any);
+	if (Number.isNaN(d.getTime())) {
+		return { date: 'Invalid Date', time: '' };
+	}
+
+	// If timezone is provided, use Intl.DateTimeFormat for consistent TZ-aware formatting
+	if (timeZone) {
+		try {
+			// date part (short month + day [+ year if not current year])
+			const includeYear = d.getFullYear() !== new Date().getFullYear();
+			const dateOpts: Intl.DateTimeFormatOptions = {
+				year: includeYear ? 'numeric' : undefined,
+				month: 'short',
+				day: 'numeric',
+			};
+
+			// time part (hour & minute, 12-hour with AM/PM)
+			const timeOpts: Intl.DateTimeFormatOptions = {
+				hour: 'numeric',
+				minute: '2-digit',
+				hour12: true,
+			};
+
+			const dateStr = new Intl.DateTimeFormat(locale ?? undefined, {
+				...dateOpts,
+				timeZone,
+			}).format(d);
+
+			const timeStr = new Intl.DateTimeFormat(locale ?? undefined, {
+				...timeOpts,
+				timeZone,
+			}).format(d);
+
+			return { date: dateStr, time: timeStr };
+		} catch (err) {
+			// fall through to fallback formatting if Intl fails for any reason
+		}
+	}
+
+	// Fallback: reuse existing dateformat masks (keeps previous behaviours intact)
+	const mask = `mmm d${d.getFullYear() === new Date().getFullYear() ? '' : ', yyyy'}#HH:MM:ss`;
+	const formattedDate = dateformat(d, mask);
+	const [date, time] = formattedDate.split('#');
+	return { date, time };
+};

--- a/scripts/run-compiled.mjs
+++ b/scripts/run-compiled.mjs
@@ -1,0 +1,24 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const file = path.resolve(__dirname, "../.tmp-compile/dateFormatter.js");
+
+console.log("🔹 Importing from:", file);
+
+const mod = await import(file);
+
+const samples = [
+  "2025-10-02T14:00:00Z",
+  "2025-12-25T00:00:00Z",
+  new Date().toISOString(),
+];
+
+for (const s of samples) {
+  const formatted = mod.formatDateForUI(s, "Asia/Beirut");
+  console.log(`INPUT: ${s}`);
+  console.log("OUTPUT:", formatted);
+  console.log("----------------------------");
+}

--- a/scripts/test-format.ts
+++ b/scripts/test-format.ts
@@ -1,0 +1,14 @@
+import { formatDateForUI } from '../packages/frontend/editor-ui/src/utils/formatters/dateFormatter.js';
+
+const samples = [
+  '2025-10-02T14:00:00Z',
+  '2025-12-25T00:00:00Z',
+  new Date().toISOString(),
+];
+
+for (const s of samples) {
+  const formatted = formatDateForUI(s, 'Asia/Beirut');
+  console.log(`INPUT: ${s}`);
+  console.log('OUTPUT:', formatted);
+  console.log('----------------------------');
+}

--- a/tsconfig.local.json
+++ b/tsconfig.local.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": ".tmp-compile",
+    "baseUrl": ".",
+    "paths": {
+      "@n8n/i18n": ["node_modules/@n8n/i18n"]
+    }
+  },
+  "include": [
+    "packages/frontend/editor-ui/src/utils/formatters/dateFormatter.ts"
+  ]
+}


### PR DESCRIPTION
…fixes #20330

# Summary :-

Adds `formatDateForUI`, a timezone-aware UI date formatter used by the frontend.  
If a `timeZone` (IANA) is provided, the function uses `Intl.DateTimeFormat` to render the date and time in that zone (e.g. `Asia/Beirut`). When no timezone is provided the code falls back to the existing `dateformat` behavior to remain backwards-compatible.

This fixes the display mismatch where stored UTC timestamps were being shown in the wrong local time in the UI.

# How to test its working :-

1. Run the frontend (or compile the single file) and call `formatDateForUI('2025-10-02T14:00:00Z', 'Asia/Beirut')`.
   - Expected: date `Oct 2` and time `5:00 PM` (Beirut)
2. Call without a timezone to ensure legacy behavior is unchanged:
   - `formatDateForUI('2025-10-02T14:00:00Z')` should use the existing formatting (no TZ conversion).
3. Try invalid/empty inputs: `null`, `''`, `invalid-string` — should return safe results (`{date:'', time:''}` or `Invalid Date` as appropriate).

# Related Linear tickets, Github issues, and Community forum posts :-

- Fixes: #20330
