### PR TITLE
chore: Add eslint rule to prevent imports to enterprise code

### DIFF
--- a/packages/@n8n/eslint-config/src/rules/index.ts
+++ b/packages/@n8n/eslint-config/src/rules/index.ts
@@ -15,6 +15,7 @@ import { NoConstructorInBackendModuleRule } from './no-constructor-in-backend-mo
 import type { AnyRuleModule } from '@typescript-eslint/utils/ts-eslint';
 import { NoArgumentSpreadRule } from './no-argument-spread.js';
 import { NoInternalPackageImportRule } from './no-internal-package-import.js';
+import { NoImportEnterpriseEditionRule } from './no-import-enterprise-edition.js';
 
 export const rules = {
 	'no-uncaught-json-parse': NoUncaughtJsonParseRule,
@@ -33,4 +34,5 @@ export const rules = {
 	'no-constructor-in-backend-module': NoConstructorInBackendModuleRule,
 	'no-argument-spread': NoArgumentSpreadRule,
 	'no-internal-package-import': NoInternalPackageImportRule,
+	'no-import-enterprise-edition': NoImportEnterpriseEditionRule,
 } satisfies Record<string, AnyRuleModule>;

--- a/packages/@n8n/eslint-config/src/rules/no-import-enterprise-edition.test.ts
+++ b/packages/@n8n/eslint-config/src/rules/no-import-enterprise-edition.test.ts
@@ -1,0 +1,54 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { NoImportEnterpriseEditionRule } from './no-import-enterprise-edition.js';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-import-enterprise-edition', NoImportEnterpriseEditionRule, {
+	valid: [
+		// Non-enterprise code importing from non-enteprise directories
+		{
+			code: 'import { SomeService } from "./services/some-service"',
+			filename: '/Users/test/project/src/services/regular-service.ts',
+		},
+		{
+			code: 'import { Utils } from "../utils/helper"',
+			filename: '/Users/test/project/src/controllers/controller.ts',
+		},
+		{
+			code: 'import { Config } from "@n8n/config"',
+			filename: '/Users/test/project/src/services/service.ts',
+		},
+
+		// enterprise code importing from ee directories
+		{
+			code: 'import { EnterpriseService } from "../environments.ee/services/enterprise-service"',
+			filename: '/Users/test/project/src/environments.ee/controllers/enterprise-controller.ts',
+		},
+
+		// enterprise code importing from non-enterprise directories
+		{
+			code: 'import { RegularService } from "../services/regular-service"',
+			filename: '/Users/test/project/src/environments.ee/controllers/enterprise-controller.ts',
+		},
+		{
+			code: 'import { Config } from "@n8n/config"',
+			filename: '/Users/test/project/src/environments.ee/services/service.ts',
+		},
+	],
+
+	invalid: [
+		{
+			code: 'import { something } from "@n8n/package/environments.ee/file"',
+			filename: '/Users/test/project/src/index.ts',
+			errors: [{ messageId: 'noImportEnterpriseEdition' }],
+		},
+		{
+			code: `
+                import { RegularService } from "./regular-service";
+                import { EnterpriseService } from "environments.ee/enterprise-service";
+            `,
+			filename: '/Users/test/project/src/services/service.ts',
+			errors: [{ messageId: 'noImportEnterpriseEdition' }],
+		},
+	],
+});

--- a/packages/@n8n/eslint-config/src/rules/no-import-enterprise-edition.test.ts
+++ b/packages/@n8n/eslint-config/src/rules/no-import-enterprise-edition.test.ts
@@ -34,6 +34,13 @@ ruleTester.run('no-import-enterprise-edition', NoImportEnterpriseEditionRule, {
 			code: 'import { Config } from "@n8n/config"',
 			filename: '/Users/test/project/src/environments.ee/services/service.ts',
 		},
+
+		// integration test files can import from .ee directories
+		{
+			code: 'import { EnterpriseService } from "../environments.ee/services/enterprise-service"',
+			filename:
+				'/Users/test/project/packages/cli/test/integration/services/enterprise.integration.test.ts',
+		},
 	],
 
 	invalid: [

--- a/packages/@n8n/eslint-config/src/rules/no-import-enterprise-edition.test.ts
+++ b/packages/@n8n/eslint-config/src/rules/no-import-enterprise-edition.test.ts
@@ -5,7 +5,8 @@ const ruleTester = new RuleTester();
 
 ruleTester.run('no-import-enterprise-edition', NoImportEnterpriseEditionRule, {
 	valid: [
-		// Non-enterprise code importing from non-enterprise directories
+		{
+			// Non-enterprise code importing from non-enterprise directories
 			code: 'import { SomeService } from "./services/some-service"',
 			filename: '/Users/test/project/src/services/regular-service.ts',
 		},
@@ -41,7 +42,6 @@ ruleTester.run('no-import-enterprise-edition', NoImportEnterpriseEditionRule, {
 				'/Users/test/project/packages/cli/test/integration/services/enterprise.integration.test.ts',
 		},
 	],
-
 	invalid: [
 		{
 			code: 'import { something } from "@n8n/package/environments.ee/file"',

--- a/packages/@n8n/eslint-config/src/rules/no-import-enterprise-edition.test.ts
+++ b/packages/@n8n/eslint-config/src/rules/no-import-enterprise-edition.test.ts
@@ -5,8 +5,7 @@ const ruleTester = new RuleTester();
 
 ruleTester.run('no-import-enterprise-edition', NoImportEnterpriseEditionRule, {
 	valid: [
-		// Non-enterprise code importing from non-enteprise directories
-		{
+		// Non-enterprise code importing from non-enterprise directories
 			code: 'import { SomeService } from "./services/some-service"',
 			filename: '/Users/test/project/src/services/regular-service.ts',
 		},

--- a/packages/@n8n/eslint-config/src/rules/no-import-enterprise-edition.ts
+++ b/packages/@n8n/eslint-config/src/rules/no-import-enterprise-edition.ts
@@ -18,9 +18,8 @@ export const NoImportEnterpriseEditionRule = ESLintUtils.RuleCreator.withoutDocs
 		const filename = context.filename;
 		const isEnterpriseEditionFile = filename.includes('.ee/');
 		const isIntegrationTestFile = filename.includes('packages/cli/test/integration/');
-		const isPublicApiFile = filename.includes('packages/cli/src/public-api/');
 
-		if (isEnterpriseEditionFile || isIntegrationTestFile || isPublicApiFile) {
+		if (isEnterpriseEditionFile || isIntegrationTestFile) {
 			return {};
 		}
 

--- a/packages/@n8n/eslint-config/src/rules/no-import-enterprise-edition.ts
+++ b/packages/@n8n/eslint-config/src/rules/no-import-enterprise-edition.ts
@@ -1,0 +1,42 @@
+import { ESLintUtils } from '@typescript-eslint/utils';
+
+export const NoImportEnterpriseEditionRule = ESLintUtils.RuleCreator.withoutDocs({
+	meta: {
+		type: 'problem',
+		docs: {
+			description:
+				'Disallow imports from .ee directories in non-enteprise code. Only code in .ee directories can import from other .ee directories.',
+		},
+		messages: {
+			noImportEnterpriseEdition:
+				'Non-enterprise code cannot import from .ee directories. Only code in .ee directories can import from other .ee directories.',
+		},
+		schema: [],
+	},
+	defaultOptions: [],
+	create(context) {
+		const filename = context.filename;
+		const isEnterpriseEditionFile = filename.includes('.ee/');
+		const isIntegrationTestFile = filename.includes('packages/cli/test/integration/');
+		const isPublicApiFile = filename.includes('packages/cli/src/public-api/');
+
+		if (isEnterpriseEditionFile || isIntegrationTestFile || isPublicApiFile) {
+			return {};
+		}
+
+		return {
+			ImportDeclaration(node) {
+				const importPath = node.source.value;
+
+				const isEnterpriseEditionImport = importPath.includes('.ee/');
+
+				if (isEnterpriseEditionImport) {
+					context.report({
+						node: node.source,
+						messageId: 'noImportEnterpriseEdition',
+					});
+				}
+			},
+		};
+	},
+});

--- a/packages/@n8n/eslint-config/src/rules/no-import-enterprise-edition.ts
+++ b/packages/@n8n/eslint-config/src/rules/no-import-enterprise-edition.ts
@@ -5,7 +5,7 @@ export const NoImportEnterpriseEditionRule = ESLintUtils.RuleCreator.withoutDocs
 		type: 'problem',
 		docs: {
 			description:
-				'Disallow imports from .ee directories in non-enteprise code. Only code in .ee directories can import from other .ee directories.',
+				'Disallow imports from .ee directories in non-enterprise code. Only code in .ee directories can import from other .ee directories.',
 		},
 		messages: {
 			noImportEnterpriseEdition:

--- a/packages/cli/eslint.config.mjs
+++ b/packages/cli/eslint.config.mjs
@@ -11,7 +11,8 @@ export default defineConfig(
 			'n8n-local-rules/no-dynamic-import-template': 'error',
 			'n8n-local-rules/misplaced-n8n-typeorm-import': 'error',
 			'n8n-local-rules/no-type-unsafe-event-emitter': 'error',
-			'n8n-local-rules/no-import-enterprise-edition': 'error',
+			// Disabled until we have a plan on how to fix these issues long term
+			'n8n-local-rules/no-import-enterprise-edition': 'off',
 
 			// TODO: Remove this
 			'@typescript-eslint/ban-ts-comment': ['warn', { 'ts-ignore': true }],

--- a/packages/cli/eslint.config.mjs
+++ b/packages/cli/eslint.config.mjs
@@ -11,6 +11,7 @@ export default defineConfig(
 			'n8n-local-rules/no-dynamic-import-template': 'error',
 			'n8n-local-rules/misplaced-n8n-typeorm-import': 'error',
 			'n8n-local-rules/no-type-unsafe-event-emitter': 'error',
+			'n8n-local-rules/no-import-enterprise-edition': 'error',
 
 			// TODO: Remove this
 			'@typescript-eslint/ban-ts-comment': ['warn', { 'ts-ignore': true }],


### PR DESCRIPTION
## Summary

Our license states that one is not allowed to use any code from an `.ee` suffixed directory without an enterprise license. [Link to license](https://github.com/n8n-io/n8n/blob/master/LICENSE.md)


This PR adds a new eslint rule `noImportEnterpriseEdition` which will error out if any code that does not have a parent folder with the `.ee` suffix, does import code from a folder that has the `.ee` suffix.

For now, this rule will not be enabled.

Violations in the codebase today (36, 31 when not considering the __tests__ dir):
```
packages/cli/src/__tests__/workflow-execute-additional-data.test.ts:20:34
packages/cli/src/auth/methods/email.ts:7:36
packages/cli/src/commands/base-command.ts:29:39
packages/cli/src/commands/base-command.ts:39:40
packages/cli/src/controller.registry.ts:21:31
packages/cli/src/controllers/__tests__/auth.controller.test.ts:14:29
packages/cli/src/controllers/auth.controller.ts:27:8
packages/cli/src/controllers/invitation.controller.ts:20:42
packages/cli/src/controllers/me.controller.ts:26:42
packages/cli/src/controllers/me.controller.ts:31:8
packages/cli/src/controllers/oauth/__tests__/oauth1-credential.controller.test.ts:17:34
packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts:18:34
packages/cli/src/controllers/password-reset.controller.ts:29:8
packages/cli/src/credentials/credentials.service.ts:39:31
packages/cli/src/public-api/v1/handlers/source-control/source-control.handler.ts:10:8
packages/cli/src/public-api/v1/handlers/source-control/source-control.handler.ts:11:49
packages/cli/src/public-api/v1/handlers/source-control/source-control.handler.ts:12:38
packages/cli/src/public-api/v1/handlers/source-control/source-control.handler.ts:13:35
packages/cli/src/public-api/v1/handlers/variables/variables.handler.ts:14:37
packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts:17:40
packages/cli/src/public-api/v1/shared/middlewares/global.middleware.ts:12:31
packages/cli/src/scaling/__tests__/job-processor.service.test.ts:21:34
packages/cli/src/server.ts:25:31
packages/cli/src/server.ts:62:8
packages/cli/src/server.ts:63:8
packages/cli/src/services/dynamic-node-parameters.service.ts:30:31
packages/cli/src/services/frontend.service.ts:17:35
packages/cli/src/services/frontend.service.ts:25:35
packages/cli/src/services/frontend.service.ts:26:48
packages/cli/src/services/frontend.service.ts:31:8
packages/cli/src/telemetry/index.ts:21:49
packages/cli/src/workflow-helpers.ts:12:34
packages/cli/src/workflows/workflow.service.ts:42:40
packages/cli/src/workflows/workflows.controller.ts:38:40
packages/cli/test/shared/external-secrets/utils.ts:3:33
packages/cli/test/shared/external-secrets/utils.ts:7:8
```

In `me.controller.ts`:
```ts
import {
	getCurrentAuthenticationMethod,
	isLdapCurrentAuthenticationMethod,
	isOidcCurrentAuthenticationMethod,
} from '@/sso.ee/sso-helpers';
```

In `frontend.controller.ts`:
```ts
import { getLdapLoginLabel } from '@/ldap.ee/helpers.ee';
import { getSamlLoginLabel } from '@/sso.ee/saml/saml-helpers';
import { getCurrentAuthenticationMethod } from '@/sso.ee/sso-helpers';
import {
	getWorkflowHistoryLicensePruneTime,
	getWorkflowHistoryPruneTime,
} from '@/workflows/workflow-history.ee/workflow-history-helper.ee';
```

In `workflow.service.ts`:
```ts
import { WorkflowHistoryService } from './workflow-history.ee/workflow-history.service.ee';
// Only uses the saveVersion method on that service
```

In `password-reset.controller.ts`:
```ts
import {
	isOidcCurrentAuthenticationMethod,
	isSamlCurrentAuthenticationMethod,
} from '@/sso.ee/sso-helpers';
````

In `credentials.service.ts`:
```ts
import { userHasScopes } from '@/permissions.ee/check-access';
import { ProjectService } from '@/services/project.service.ee';
// Uses only the following methods from ProjectService: getProjectWithScope, getProjectRelationsForUser, getProject
```

In `packages/cli/src/telemetry/index.ts`:
```ts
import { SourceControlPreferencesService } from '../environments.ee/source-control/source-control-preferences.service.ee';

```

## Related Linear tickets, Github issues, and Community forum posts

PAY-3928


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
