### PR TITLE
fix(Data Table Node): Date handling (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/DataTable/common/selectMany.ts
+++ b/packages/nodes-base/nodes/DataTable/common/selectMany.ts
@@ -1,4 +1,4 @@
-import { DATA_TABLE_SYSTEM_COLUMNS, NodeOperationError } from 'n8n-workflow';
+import { DATA_TABLE_SYSTEM_COLUMN_TYPE_MAP, NodeOperationError } from 'n8n-workflow';
 import type {
 	DataTableFilter,
 	DataTableRowReturn,
@@ -6,6 +6,7 @@ import type {
 	IDisplayOptions,
 	IExecuteFunctions,
 	INodeProperties,
+	DataTableColumnType,
 } from 'n8n-workflow';
 
 import { ALL_CONDITIONS, ANY_CONDITION, ROWS_LIMIT_DEFAULT, type FilterType } from './constants';
@@ -117,15 +118,19 @@ export async function getSelectFilter(
 	}
 
 	// Validate filter conditions against current table schema
+	let allColumnsWithTypes: Record<string, DataTableColumnType> = DATA_TABLE_SYSTEM_COLUMN_TYPE_MAP;
+
 	if (fields.length > 0) {
 		const dataTableProxy = await getDataTableProxyExecute(ctx, index);
 		const availableColumns = await dataTableProxy.getColumns();
-		const allColumns = new Set([
-			...DATA_TABLE_SYSTEM_COLUMNS,
-			...availableColumns.map((col) => col.name),
-		]);
 
-		const invalidConditions = fields.filter((field) => !allColumns.has(field.keyName));
+		// Add system columns with their types
+		allColumnsWithTypes = {
+			...DATA_TABLE_SYSTEM_COLUMN_TYPE_MAP,
+			...Object.fromEntries(availableColumns.map((col) => [col.name, col.type])),
+		};
+
+		const invalidConditions = fields.filter((field) => !allColumnsWithTypes[field.keyName]);
 
 		if (invalidConditions.length > 0) {
 			const invalidColumnNames = invalidConditions.map((c) => c.keyName).join(', ');
@@ -138,7 +143,7 @@ export async function getSelectFilter(
 		}
 	}
 
-	return buildGetManyFilter(fields, matchType);
+	return buildGetManyFilter(fields, matchType, allColumnsWithTypes);
 }
 
 export async function executeSelectMany(

--- a/packages/nodes-base/nodes/DataTable/common/selectMany.ts
+++ b/packages/nodes-base/nodes/DataTable/common/selectMany.ts
@@ -143,7 +143,7 @@ export async function getSelectFilter(
 		}
 	}
 
-	return buildGetManyFilter(fields, matchType, allColumnsWithTypes);
+	return buildGetManyFilter(fields, matchType, allColumnsWithTypes, node);
 }
 
 export async function executeSelectMany(

--- a/packages/nodes-base/nodes/DataTable/common/utils.ts
+++ b/packages/nodes-base/nodes/DataTable/common/utils.ts
@@ -8,6 +8,7 @@ import type {
 	IExecuteFunctions,
 	ILoadOptionsFunctions,
 	DataTableColumnJsType,
+	DataTableColumnType,
 } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 
@@ -86,6 +87,7 @@ export function isMatchType(obj: unknown): obj is FilterType {
 export function buildGetManyFilter(
 	fieldEntries: FieldEntry[],
 	matchType: FilterType,
+	columnTypeMap: Record<string, DataTableColumnType>,
 ): DataTableFilter {
 	const filters = fieldEntries.map((x) => {
 		switch (x.condition) {
@@ -113,12 +115,24 @@ export function buildGetManyFilter(
 					condition: 'eq' as const,
 					value: false,
 				};
-			default:
+			default: {
+				let value = x.keyValue;
+				const columnType = columnTypeMap[x.keyName];
+
+				// Convert ISO date strings to Date objects for date columns
+				if (columnType === 'date' && typeof value === 'string') {
+					const parsed = new Date(value);
+					if (isNaN(parsed.getTime())) {
+						throw new Error(`Invalid date string '${value}' for column '${x.keyName}'`);
+					}
+					value = parsed;
+				}
 				return {
 					columnName: x.keyName,
 					condition: x.condition ?? 'eq',
-					value: x.keyValue,
+					value,
 				};
+			}
 		}
 	});
 	return { type: matchType === ALL_CONDITIONS ? 'and' : 'or', filters };

--- a/packages/nodes-base/nodes/DataTable/common/utils.ts
+++ b/packages/nodes-base/nodes/DataTable/common/utils.ts
@@ -88,6 +88,7 @@ export function buildGetManyFilter(
 	fieldEntries: FieldEntry[],
 	matchType: FilterType,
 	columnTypeMap: Record<string, DataTableColumnType>,
+	node: INode,
 ): DataTableFilter {
 	const filters = fieldEntries.map((x) => {
 		switch (x.condition) {
@@ -123,7 +124,10 @@ export function buildGetManyFilter(
 				if (columnType === 'date' && typeof value === 'string') {
 					const parsed = new Date(value);
 					if (isNaN(parsed.getTime())) {
-						throw new Error(`Invalid date string '${value}' for column '${x.keyName}'`);
+						throw new NodeOperationError(
+							node,
+							`Invalid date string '${value}' for column '${x.keyName}'`,
+						);
 					}
 					value = parsed;
 				}

--- a/packages/nodes-base/nodes/DataTable/test/common/utils.test.ts
+++ b/packages/nodes-base/nodes/DataTable/test/common/utils.test.ts
@@ -210,7 +210,7 @@ describe('buildGetManyFilter', () => {
 				{ keyName: 'name', condition: 'isEmpty' as const, keyValue: 'ignored' },
 			];
 
-			const result = buildGetManyFilter(fieldEntries, ALL_CONDITIONS, { name: 'string' });
+			const result = buildGetManyFilter(fieldEntries, ALL_CONDITIONS, { name: 'string' }, mockNode);
 
 			expect(result).toEqual({
 				type: 'and',
@@ -229,7 +229,7 @@ describe('buildGetManyFilter', () => {
 				{ keyName: 'email', condition: 'isNotEmpty' as const, keyValue: 'ignored' },
 			];
 
-			const result = buildGetManyFilter(fieldEntries, ANY_CONDITION, { email: 'string' });
+			const result = buildGetManyFilter(fieldEntries, ANY_CONDITION, { email: 'string' }, mockNode);
 
 			expect(result).toEqual({
 				type: 'or',
@@ -250,11 +250,16 @@ describe('buildGetManyFilter', () => {
 				{ keyName: 'phone', condition: 'isNotEmpty' as const, keyValue: 'ignored' },
 			];
 
-			const result = buildGetManyFilter(fieldEntries, ALL_CONDITIONS, {
-				name: 'string',
-				email: 'string',
-				phone: 'string',
-			});
+			const result = buildGetManyFilter(
+				fieldEntries,
+				ALL_CONDITIONS,
+				{
+					name: 'string',
+					email: 'string',
+					phone: 'string',
+				},
+				mockNode,
+			);
 
 			expect(result).toEqual({
 				type: 'and',
@@ -285,7 +290,12 @@ describe('buildGetManyFilter', () => {
 				{ keyName: 'isActive', condition: 'isTrue' as const, keyValue: 'ignored' },
 			];
 
-			const result = buildGetManyFilter(fieldEntries, ALL_CONDITIONS, { isActive: 'boolean' });
+			const result = buildGetManyFilter(
+				fieldEntries,
+				ALL_CONDITIONS,
+				{ isActive: 'boolean' },
+				mockNode,
+			);
 
 			expect(result).toEqual({
 				type: 'and',
@@ -304,7 +314,12 @@ describe('buildGetManyFilter', () => {
 				{ keyName: 'email', condition: 'isFalse' as const, keyValue: 'ignored' },
 			];
 
-			const result = buildGetManyFilter(fieldEntries, ANY_CONDITION, { email: 'boolean' });
+			const result = buildGetManyFilter(
+				fieldEntries,
+				ANY_CONDITION,
+				{ email: 'boolean' },
+				mockNode,
+			);
 
 			expect(result).toEqual({
 				type: 'or',
@@ -325,11 +340,16 @@ describe('buildGetManyFilter', () => {
 				{ keyName: 'isDeleted', condition: 'isFalse' as const, keyValue: 'ignored' },
 			];
 
-			const result = buildGetManyFilter(fieldEntries, ALL_CONDITIONS, {
-				name: 'string',
-				isActive: 'boolean',
-				isDeleted: 'boolean',
-			});
+			const result = buildGetManyFilter(
+				fieldEntries,
+				ALL_CONDITIONS,
+				{
+					name: 'string',
+					isActive: 'boolean',
+					isDeleted: 'boolean',
+				},
+				mockNode,
+			);
 
 			expect(result).toEqual({
 				type: 'and',
@@ -360,10 +380,15 @@ describe('buildGetManyFilter', () => {
 			{ keyName: 'name', condition: 'like' as const, keyValue: '%john%' },
 		];
 
-		const result = buildGetManyFilter(fieldEntries, ANY_CONDITION, {
-			age: 'number',
-			name: 'string',
-		});
+		const result = buildGetManyFilter(
+			fieldEntries,
+			ANY_CONDITION,
+			{
+				age: 'number',
+				name: 'string',
+			},
+			mockNode,
+		);
 
 		expect(result).toEqual({
 			type: 'or',
@@ -389,7 +414,12 @@ describe('buildGetManyFilter', () => {
 				{ keyName: 'createdAt', condition: 'lte', keyValue: testDate },
 			];
 
-			const result = buildGetManyFilter(fieldEntries, ALL_CONDITIONS, { createdAt: 'date' });
+			const result = buildGetManyFilter(
+				fieldEntries,
+				ALL_CONDITIONS,
+				{ createdAt: 'date' },
+				mockNode,
+			);
 
 			expect(result).toEqual({
 				type: 'and',
@@ -409,7 +439,12 @@ describe('buildGetManyFilter', () => {
 				{ keyName: 'createdAt', condition: 'lte', keyValue: dateString },
 			];
 
-			const result = buildGetManyFilter(fieldEntries, ALL_CONDITIONS, { createdAt: 'date' });
+			const result = buildGetManyFilter(
+				fieldEntries,
+				ALL_CONDITIONS,
+				{ createdAt: 'date' },
+				mockNode,
+			);
 
 			expect(result.filters[0].value).toBeInstanceOf(Date);
 			expect((result.filters[0].value as Date).toISOString()).toBe(dateString);
@@ -422,7 +457,7 @@ describe('buildGetManyFilter', () => {
 			];
 
 			expect(() =>
-				buildGetManyFilter(fieldEntries, ALL_CONDITIONS, { createdAt: 'date' }),
+				buildGetManyFilter(fieldEntries, ALL_CONDITIONS, { createdAt: 'date' }, mockNode),
 			).toThrowError(`Invalid date string '${invalidDateString}' for column 'createdAt'`);
 		});
 	});

--- a/packages/nodes-base/nodes/DataTable/test/common/utils.test.ts
+++ b/packages/nodes-base/nodes/DataTable/test/common/utils.test.ts
@@ -2,7 +2,7 @@ import { DateTime } from 'luxon';
 import type { INode } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 
-import { ANY_CONDITION, ALL_CONDITIONS } from '../../common/constants';
+import { ANY_CONDITION, ALL_CONDITIONS, type FieldEntry } from '../../common/constants';
 import { dataObjectToApiInput, buildGetManyFilter } from '../../common/utils';
 
 const mockNode: INode = {
@@ -210,7 +210,7 @@ describe('buildGetManyFilter', () => {
 				{ keyName: 'name', condition: 'isEmpty' as const, keyValue: 'ignored' },
 			];
 
-			const result = buildGetManyFilter(fieldEntries, ALL_CONDITIONS);
+			const result = buildGetManyFilter(fieldEntries, ALL_CONDITIONS, { name: 'string' });
 
 			expect(result).toEqual({
 				type: 'and',
@@ -229,7 +229,7 @@ describe('buildGetManyFilter', () => {
 				{ keyName: 'email', condition: 'isNotEmpty' as const, keyValue: 'ignored' },
 			];
 
-			const result = buildGetManyFilter(fieldEntries, ANY_CONDITION);
+			const result = buildGetManyFilter(fieldEntries, ANY_CONDITION, { email: 'string' });
 
 			expect(result).toEqual({
 				type: 'or',
@@ -250,7 +250,11 @@ describe('buildGetManyFilter', () => {
 				{ keyName: 'phone', condition: 'isNotEmpty' as const, keyValue: 'ignored' },
 			];
 
-			const result = buildGetManyFilter(fieldEntries, ALL_CONDITIONS);
+			const result = buildGetManyFilter(fieldEntries, ALL_CONDITIONS, {
+				name: 'string',
+				email: 'string',
+				phone: 'string',
+			});
 
 			expect(result).toEqual({
 				type: 'and',
@@ -281,7 +285,7 @@ describe('buildGetManyFilter', () => {
 				{ keyName: 'isActive', condition: 'isTrue' as const, keyValue: 'ignored' },
 			];
 
-			const result = buildGetManyFilter(fieldEntries, ALL_CONDITIONS);
+			const result = buildGetManyFilter(fieldEntries, ALL_CONDITIONS, { isActive: 'boolean' });
 
 			expect(result).toEqual({
 				type: 'and',
@@ -300,7 +304,7 @@ describe('buildGetManyFilter', () => {
 				{ keyName: 'email', condition: 'isFalse' as const, keyValue: 'ignored' },
 			];
 
-			const result = buildGetManyFilter(fieldEntries, ANY_CONDITION);
+			const result = buildGetManyFilter(fieldEntries, ANY_CONDITION, { email: 'boolean' });
 
 			expect(result).toEqual({
 				type: 'or',
@@ -321,7 +325,11 @@ describe('buildGetManyFilter', () => {
 				{ keyName: 'isDeleted', condition: 'isFalse' as const, keyValue: 'ignored' },
 			];
 
-			const result = buildGetManyFilter(fieldEntries, ALL_CONDITIONS);
+			const result = buildGetManyFilter(fieldEntries, ALL_CONDITIONS, {
+				name: 'string',
+				isActive: 'boolean',
+				isDeleted: 'boolean',
+			});
 
 			expect(result).toEqual({
 				type: 'and',
@@ -352,7 +360,10 @@ describe('buildGetManyFilter', () => {
 			{ keyName: 'name', condition: 'like' as const, keyValue: '%john%' },
 		];
 
-		const result = buildGetManyFilter(fieldEntries, ANY_CONDITION);
+		const result = buildGetManyFilter(fieldEntries, ANY_CONDITION, {
+			age: 'number',
+			name: 'string',
+		});
 
 		expect(result).toEqual({
 			type: 'or',
@@ -368,6 +379,51 @@ describe('buildGetManyFilter', () => {
 					value: '%john%',
 				},
 			],
+		});
+	});
+
+	describe('date handling in filters', () => {
+		it('should pass Date objects through unchanged', () => {
+			const testDate = new Date('2025-10-06T08:14:42.274Z');
+			const fieldEntries: FieldEntry[] = [
+				{ keyName: 'createdAt', condition: 'lte', keyValue: testDate },
+			];
+
+			const result = buildGetManyFilter(fieldEntries, ALL_CONDITIONS, { createdAt: 'date' });
+
+			expect(result).toEqual({
+				type: 'and',
+				filters: [
+					{
+						columnName: 'createdAt',
+						condition: 'lte',
+						value: testDate,
+					},
+				],
+			});
+		});
+
+		it('should convert ISO date strings to Date objects', () => {
+			const dateString = '2025-10-06T08:14:42.274Z';
+			const fieldEntries: FieldEntry[] = [
+				{ keyName: 'createdAt', condition: 'lte', keyValue: dateString },
+			];
+
+			const result = buildGetManyFilter(fieldEntries, ALL_CONDITIONS, { createdAt: 'date' });
+
+			expect(result.filters[0].value).toBeInstanceOf(Date);
+			expect((result.filters[0].value as Date).toISOString()).toBe(dateString);
+		});
+
+		it('should throw an Error for invalid date strings', () => {
+			const invalidDateString = 'invalid-date';
+			const fieldEntries: FieldEntry[] = [
+				{ keyName: 'createdAt', condition: 'lte', keyValue: invalidDateString },
+			];
+
+			expect(() =>
+				buildGetManyFilter(fieldEntries, ALL_CONDITIONS, { createdAt: 'date' }),
+			).toThrowError(`Invalid date string '${invalidDateString}' for column 'createdAt'`);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Previously, we were sending dates as strings, which was incorrect since our service expects date columns as JS Date objects. Interestingly, the filtering issue appeared only for the `createdAt` column in SQLite, because it’s stored in a different format. I’ll look into addressing that separately.

I also improved the backend tests to confirm and illustrate that the issue wasn’t occurring on the backend side.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4250/data-table-node-createdat-filter-works-incorrectly

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
