### PR TITLE
fix(core): Prevent re-imported scheduled workflow to execute twice 

### DIFF
--- a/packages/cli/src/services/__tests__/import.service.test.ts
+++ b/packages/cli/src/services/__tests__/import.service.test.ts
@@ -5,6 +5,7 @@ import { mock } from 'jest-mock-extended';
 import { readdir, readFile } from 'fs/promises';
 import type { Cipher } from 'n8n-core';
 
+import { ImportService } from '../import.service';
 import type { CredentialsRepository, TagRepository } from '@n8n/db';
 import type { ActiveWorkflowManager } from '@/active-workflow-manager';
 
@@ -24,12 +25,9 @@ jest.mock('@n8n/db', () => ({
 	DataSource: mock<DataSource>(),
 }));
 
-// Mock ActiveWorkflowManager to prevent loading its dependencies
 jest.mock('@/active-workflow-manager', () => ({
 	ActiveWorkflowManager: mock<ActiveWorkflowManager>(),
 }));
-
-import { ImportService } from '../import.service';
 
 describe('ImportService', () => {
 	let importService: ImportService;

--- a/packages/cli/src/services/import.service.ts
+++ b/packages/cli/src/services/import.service.ts
@@ -20,7 +20,7 @@ import { validateDbTypeForImportEntities } from '@/utils/validate-database-type'
 import { Cipher } from 'n8n-core';
 import { decompressFolder } from '@/utils/compression.util';
 import { z } from 'zod';
-import type { ActiveWorkflowManager } from '@/active-workflow-manager';
+import { ActiveWorkflowManager } from '@/active-workflow-manager';
 
 @Service()
 export class ImportService {

--- a/packages/cli/src/services/import.service.ts
+++ b/packages/cli/src/services/import.service.ts
@@ -72,11 +72,8 @@ export class ImportService {
 			const hasInvalidCreds = workflow.nodes.some((node) => !node.credentials?.id);
 
 			if (hasInvalidCreds) await this.replaceInvalidCreds(workflow);
-		}
 
-		// Remove workflows from ActiveWorkflowManager BEFORE transaction to prevent orphaned trigger listeners
-		// This must be done outside the transaction to avoid inconsistent state on rollback
-		for (const workflow of workflows) {
+			// Remove workflows from ActiveWorkflowManager BEFORE transaction to prevent orphaned trigger listeners
 			if (workflow.id) {
 				await this.activeWorkflowManager.remove(workflow.id);
 			}

--- a/packages/cli/test/integration/commands/import.cmd.test.ts
+++ b/packages/cli/test/integration/commands/import.cmd.test.ts
@@ -5,16 +5,23 @@ import {
 	getAllSharedWorkflows,
 	getAllWorkflows,
 } from '@n8n/backend-test-utils';
+import { Container } from '@n8n/di';
 import { nanoid } from 'nanoid';
 
 import '@/zod-alias-support';
 import { ImportWorkflowsCommand } from '@/commands/import/workflow';
 import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
+import { ActiveWorkflowManager } from '@/active-workflow-manager';
+import { ImportService } from '@/services/import.service';
 import { setupTestCommand } from '@test-integration/utils/test-command';
 
 import { createMember, createOwner } from '../shared/db/users';
 
 mockInstance(LoadNodesAndCredentials);
+mockInstance(ActiveWorkflowManager, {
+	remove: jest.fn().mockResolvedValue(undefined),
+});
+
 const command = setupTestCommand(ImportWorkflowsCommand);
 
 beforeEach(async () => {

--- a/packages/cli/test/integration/commands/import.cmd.test.ts
+++ b/packages/cli/test/integration/commands/import.cmd.test.ts
@@ -5,14 +5,12 @@ import {
 	getAllSharedWorkflows,
 	getAllWorkflows,
 } from '@n8n/backend-test-utils';
-import { Container } from '@n8n/di';
 import { nanoid } from 'nanoid';
 
 import '@/zod-alias-support';
 import { ImportWorkflowsCommand } from '@/commands/import/workflow';
 import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 import { ActiveWorkflowManager } from '@/active-workflow-manager';
-import { ImportService } from '@/services/import.service';
 import { setupTestCommand } from '@test-integration/utils/test-command';
 
 import { createMember, createOwner } from '../shared/db/users';

--- a/packages/cli/test/integration/commands/import.cmd.test.ts
+++ b/packages/cli/test/integration/commands/import.cmd.test.ts
@@ -8,17 +8,15 @@ import {
 import { nanoid } from 'nanoid';
 
 import '@/zod-alias-support';
+import { ActiveWorkflowManager } from '@/active-workflow-manager';
 import { ImportWorkflowsCommand } from '@/commands/import/workflow';
 import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
-import { ActiveWorkflowManager } from '@/active-workflow-manager';
 import { setupTestCommand } from '@test-integration/utils/test-command';
 
 import { createMember, createOwner } from '../shared/db/users';
 
 mockInstance(LoadNodesAndCredentials);
-mockInstance(ActiveWorkflowManager, {
-	remove: jest.fn().mockResolvedValue(undefined),
-});
+mockInstance(ActiveWorkflowManager);
 
 const command = setupTestCommand(ImportWorkflowsCommand);
 

--- a/packages/cli/test/integration/import.service.test.ts
+++ b/packages/cli/test/integration/import.service.test.ts
@@ -39,7 +39,14 @@ describe('ImportService', () => {
 
 		const credentialsRepository = Container.get(CredentialsRepository);
 
-		importService = new ImportService(mock(), credentialsRepository, tagRepository, mock(), mock());
+		importService = new ImportService(
+			mock(),
+			credentialsRepository,
+			tagRepository,
+			mock(),
+			mock(),
+			mock(),
+		);
 	});
 
 	afterEach(async () => {

--- a/packages/cli/test/integration/import.service.test.ts
+++ b/packages/cli/test/integration/import.service.test.ts
@@ -19,6 +19,7 @@ import { mock } from 'jest-mock-extended';
 import type { INode } from 'n8n-workflow';
 import { v4 as uuid } from 'uuid';
 
+import type { ActiveWorkflowManager } from '@/active-workflow-manager';
 import { ImportService } from '@/services/import.service';
 
 import { createMember, createOwner } from './shared/db/users';
@@ -28,6 +29,7 @@ describe('ImportService', () => {
 	let tagRepository: TagRepository;
 	let owner: User;
 	let ownerPersonalProject: Project;
+	let mockActiveWorkflowManager: ActiveWorkflowManager;
 
 	beforeAll(async () => {
 		await testDb.init();
@@ -39,13 +41,15 @@ describe('ImportService', () => {
 
 		const credentialsRepository = Container.get(CredentialsRepository);
 
+		mockActiveWorkflowManager = mock<ActiveWorkflowManager>();
+
 		importService = new ImportService(
 			mock(),
 			credentialsRepository,
 			tagRepository,
 			mock(),
 			mock(),
-			mock(),
+			mockActiveWorkflowManager,
 		);
 	});
 
@@ -208,5 +212,12 @@ describe('ImportService', () => {
 		const dbTag = await tagRepository.findOneOrFail({ where: { name: tag.name } });
 
 		expect(dbTag.name).toBe(tag.name); // tag created
+	});
+
+	test('should remove workflow from ActiveWorkflowManager when workflow has ID', async () => {
+		const workflowWithId = await createWorkflow({ active: true });
+		await importService.importWorkflows([workflowWithId], ownerPersonalProject.id);
+
+		expect(mockActiveWorkflowManager.remove).toHaveBeenCalledWith(workflowWithId.id);
 	});
 });


### PR DESCRIPTION
## Summary

Unregister the scheduled active workflow when imported again to prevent double execution.

## Related Linear tickets, Github issues, and Community forum posts

PAY-3921

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
