### PR TITLE
fix(core): Remove logs skipping flag from native Python runner

### DIFF
--- a/packages/@n8n/task-runner-python/src/message_serde.py
+++ b/packages/@n8n/task-runner-python/src/message_serde.py
@@ -50,7 +50,6 @@ def _parse_task_settings(d: dict) -> BrokerTaskSettings:
         workflow_id = settings_dict.get("workflowId", "Unknown")
         node_name = settings_dict.get("nodeName", "Unknown")
         node_id = settings_dict.get("nodeId", "Unknown")
-        can_log = settings_dict.get("canLog", False)
     except KeyError as e:
         raise ValueError(f"Missing field in task settings message: {e}")
 
@@ -65,7 +64,6 @@ def _parse_task_settings(d: dict) -> BrokerTaskSettings:
             workflow_id=workflow_id,
             node_name=node_name,
             node_id=node_id,
-            can_log=can_log,
         ),
     )
 

--- a/packages/@n8n/task-runner-python/src/message_types/broker.py
+++ b/packages/@n8n/task-runner-python/src/message_types/broker.py
@@ -43,7 +43,6 @@ class TaskSettings:
     workflow_id: str
     node_name: str
     node_id: str
-    can_log: bool
 
 
 @dataclass

--- a/packages/@n8n/task-runner-python/src/task_executor.py
+++ b/packages/@n8n/task-runner-python/src/task_executor.py
@@ -48,7 +48,6 @@ class TaskExecutor:
         stdlib_allow: Set[str],
         external_allow: Set[str],
         builtins_deny: set[str],
-        can_log: bool,
     ):
         """Create a subprocess for executing a Python code task and a queue for communication."""
 
@@ -68,7 +67,6 @@ class TaskExecutor:
                 stdlib_allow,
                 external_allow,
                 builtins_deny,
-                can_log,
             ),
         )
 
@@ -170,7 +168,6 @@ class TaskExecutor:
         stdlib_allow: Set[str],
         external_allow: Set[str],
         builtins_deny: set[str],
-        can_log: bool,
     ):
         """Execute a Python code task in all-items mode."""
 
@@ -188,9 +185,7 @@ class TaskExecutor:
             globals = {
                 "__builtins__": TaskExecutor._filter_builtins(builtins_deny),
                 "_items": items,
-                "print": TaskExecutor._create_custom_print(print_args)
-                if can_log
-                else print,
+                "print": TaskExecutor._create_custom_print(print_args),
             }
 
             exec(compiled_code, globals)
@@ -209,7 +204,6 @@ class TaskExecutor:
         stdlib_allow: Set[str],
         external_allow: Set[str],
         builtins_deny: set[str],
-        can_log: bool,
     ):
         """Execute a Python code task in per-item mode."""
 
@@ -229,9 +223,7 @@ class TaskExecutor:
                 globals = {
                     "__builtins__": TaskExecutor._filter_builtins(builtins_deny),
                     "_item": item,
-                    "print": TaskExecutor._create_custom_print(print_args)
-                    if can_log
-                    else print,
+                    "print": TaskExecutor._create_custom_print(print_args),
                 }
 
                 exec(compiled_code, globals)

--- a/packages/@n8n/task-runner-python/src/task_runner.py
+++ b/packages/@n8n/task-runner-python/src/task_runner.py
@@ -300,7 +300,6 @@ class TaskRunner:
                 stdlib_allow=self.config.stdlib_allow,
                 external_allow=self.config.external_allow,
                 builtins_deny=self.config.builtins_deny,
-                can_log=task_settings.can_log,
             )
 
             task_state.process = process

--- a/packages/@n8n/task-runner-python/tests/integration/conftest.py
+++ b/packages/@n8n/task-runner-python/tests/integration/conftest.py
@@ -44,14 +44,12 @@ def create_task_settings(
     node_mode: str,
     items: Items | None = None,
     continue_on_fail: bool = False,
-    can_log: bool = False,
 ):
     return {
         "code": code,
         "nodeMode": NODE_MODE_TO_BROKER_STYLE[node_mode],
         "items": items if items is not None else [],
         "continueOnFail": continue_on_fail,
-        "canLog": can_log,
     }
 
 

--- a/packages/@n8n/task-runner-python/tests/integration/test_rpc.py
+++ b/packages/@n8n/task-runner-python/tests/integration/test_rpc.py
@@ -22,7 +22,7 @@ async def test_print_basic_types(broker, manager):
         print("Multiple", "args", 123, False)
         return [{"printed": "ok"}]
     """)
-    task_settings = create_task_settings(code=code, node_mode="all_items", can_log=True)
+    task_settings = create_task_settings(code=code, node_mode="all_items")
     await broker.send_task(task_id=task_id, task_settings=task_settings)
 
     done_msg = await wait_for_task_done(broker, task_id, timeout=5.0)
@@ -62,7 +62,7 @@ async def test_print_complex_types(broker, manager):
         print({"users": [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]})
         return [{"result": "success"}]
     """)
-    task_settings = create_task_settings(code=code, node_mode="all_items", can_log=True)
+    task_settings = create_task_settings(code=code, node_mode="all_items")
     await broker.send_task(task_id=task_id, task_settings=task_settings)
 
     result_msg = await wait_for_task_done(broker, task_id, timeout=5.0)
@@ -99,7 +99,7 @@ async def test_print_edge_cases(broker, manager):
         print("x" * 1_000)
         return [{"test": "complete"}]
     """)
-    task_settings = create_task_settings(code=code, node_mode="all_items", can_log=True)
+    task_settings = create_task_settings(code=code, node_mode="all_items")
 
     await broker.send_task(task_id=task_id, task_settings=task_settings)
 

--- a/packages/nodes-base/nodes/Code/PythonTaskRunnerSandbox.ts
+++ b/packages/nodes-base/nodes/Code/PythonTaskRunnerSandbox.ts
@@ -38,9 +38,6 @@ export class PythonTaskRunnerSandbox {
 			nodeName: node.name,
 			workflowId: workflow.id,
 			workflowName: workflow.name,
-
-			/** Whether this task can log to the browser console. */
-			canLog: this.executeFunctions.getMode() === 'manual',
 		};
 
 		const executionResult = await this.executeFunctions.startJob<INodeExecutionData[]>(


### PR DESCRIPTION
## Summary

At #19028 we added a `canLog` flag for the native Python runner to skip sending messages back when the execution is not manual, but it turns out that `CODE_ENABLE_STDOUT` supports relaying logs also from production executions, so this PR removes the `canLog` flag.

## Related Linear tickets, Github issues, and Community forum posts

n/a

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
