### PR TITLE
fix(core): Do not report transient `WebsocketConnectionError` to Sentry in native Python runner (no-changelog)

### DIFF
--- a/packages/@n8n/task-runner-python/src/constants.py
+++ b/packages/@n8n/task-runner-python/src/constants.py
@@ -3,6 +3,7 @@ from src.errors import (
     TaskRuntimeError,
     TaskTimeoutError,
     SecurityViolationError,
+    WebsocketConnectionError,
 )
 
 # Messages
@@ -77,6 +78,7 @@ IGNORED_ERROR_TYPES = (
     TaskCancelledError,
     TaskTimeoutError,
     SecurityViolationError,
+    WebsocketConnectionError,
     SyntaxError,
 )
 


### PR DESCRIPTION
https://linear.app/n8n/issue/CAT-1516