### PR TITLE
feat: Add Source Contorl env variable

### DIFF
--- a/packages/cli/src/environments.ee/source-control/source-control.config.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control.config.ts
@@ -5,4 +5,36 @@ export class SourceControlConfig {
 	/** Default SSH key type to use when generating SSH keys. */
 	@Env('N8N_SOURCECONTROL_DEFAULT_SSH_KEY_TYPE')
 	defaultKeyPairType: 'ed25519' | 'rsa' = 'ed25519';
+
+	/**
+	 * Git repository URL for source control.
+	 */
+	@Env('N8N_SOURCECONTROL_REPOSITORY_URL')
+	repositoryUrl: string = '';
+
+	/**
+	 * Username for HTTPS authentication.
+	 */
+	@Env('N8N_SOURCECONTROL_HTTPS_USERNAME')
+	httpsUsername: string = '';
+
+	/**
+	 * Password or Personal Access Token for HTTPS authentication.
+	 */
+	@Env('N8N_SOURCECONTROL_HTTPS_PASSWORD')
+	httpsPassword: string = '';
+
+	/**
+	 * Git branch name to use for source control.
+	 * Defaults to 'main' if not specified.
+	 */
+	@Env('N8N_SOURCECONTROL_BRANCH_NAME')
+	branchName: string = 'main';
+
+	/**
+	 * Whether the source control branch should be read-only.
+	 * When true, prevents pushing changes to the remote repository.
+	 */
+	@Env('N8N_SOURCECONTROL_BRANCH_READONLY')
+	branchReadOnly: boolean = false;
 }


### PR DESCRIPTION
## Summary
<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported) 

## Summary

  This PR adds support for configuring n8n's Source Control feature via environment variables, enabling easier deployment in containerized environments where configuration through environment variables is
  preferred over database settings.

  ### New Environment Variables

  - `N8N_SOURCECONTROL_REPOSITORY_URL` - Git repository URL (supports both SSH and HTTPS)
  - `N8N_SOURCECONTROL_HTTPS_USERNAME` - Username for HTTPS authentication
  - `N8N_SOURCECONTROL_HTTPS_PASSWORD` - Password or Personal Access Token for HTTPS authentication
  - `N8N_SOURCECONTROL_BRANCH_NAME` - Git branch name (defaults to 'main')
  - `N8N_SOURCECONTROL_BRANCH_READONLY` - Whether the branch should be read-only (defaults to false)

  ### Behavior

  - Environment variables are only used when **no database configuration exists**
  - Database settings take priority over environment variables once configured through the UI
  - When HTTPS credentials are provided via env vars, the connection type is automatically set to HTTPS
  - Source control is automatically initialized on startup when credentials are provided
  - SSH key loading is skipped when using HTTPS to avoid unnecessary errors

  ### Example Usage

  ```bash
  N8N_SOURCECONTROL_REPOSITORY_URL=https://github.com/user/repo.git \
  N8N_SOURCECONTROL_HTTPS_USERNAME=myusername \
  N8N_SOURCECONTROL_HTTPS_PASSWORD=ghp_myPersonalAccessToken \
  N8N_SOURCECONTROL_BRANCH_NAME=main \
  pnpm start

  Testing

  1. Start n8n with the environment variables set (ensure no existing source control configuration in database)
  2. Verify source control settings appear in UI under Settings > Source Control
  3. Verify connection type is set to HTTPS
  4. Verify repository operations (pull/push) work correctly
  5. Modify settings through UI and restart - verify database settings take precedence over env vars

  Related Linear tickets, Github issues, and Community forum posts

  Review / Merge checklist

  - PR title and summary are descriptive. (../blob/master/.github/pull_request_title_conventions.md)
  - https://github.com/n8n-io/n8n-docs or follow-up ticket created.
  - Tests included.
  - PR Labeled with release/backport (if the PR is an urgent fix that needs to be backported)
