### PR TITLE
fix: Update path.join -> safeJoinPath for compression utils

### DIFF
--- a/packages/cli/src/utils/compression.util.ts
+++ b/packages/cli/src/utils/compression.util.ts
@@ -2,6 +2,7 @@ import * as fflate from 'fflate';
 import { readFile, readdir, writeFile, mkdir } from 'fs/promises';
 import * as path from 'path';
 import { createWriteStream, createReadStream } from 'fs';
+import { safeJoinPath } from '@n8n/backend-common';
 
 // Reuse the same compression levels as the Compression node
 const ALREADY_COMPRESSED = [
@@ -221,7 +222,7 @@ async function addDirectoryToZipStreaming(
 			continue;
 		}
 
-		const fullPath = path.join(dirPath, entry.name);
+		const fullPath = safeJoinPath(dirPath, entry.name);
 		const zipEntryPath = zipPath ? `${zipPath}/${entry.name}` : entry.name;
 
 		if (entry.isDirectory()) {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR fixes the usage of path.join to avoid traversing outside of the expected directory.

## Related Linear tickets, Github issues, and Community forum posts

https://app.aikido.dev/queue?sidebarIssue=11876652&sidebarIssueTask=650730

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
