### PR TITLE
ci: Fail release build on node popularity data fetch error

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Setup and Build ARM64
         uses: ./.github/actions/setup-nodejs-blacksmith
+        env:
+          N8N_FAIL_ON_POPULARITY_FETCH_ERROR: true
 
   publish-to-npm:
     name: Publish to NPM
@@ -40,6 +42,8 @@ jobs:
 
       - name: Setup and Build
         uses: ./.github/actions/setup-nodejs-github
+        env:
+          N8N_FAIL_ON_POPULARITY_FETCH_ERROR: true
 
       - name: Dry-run publishing
         run: |

--- a/packages/frontend/editor-ui/scripts/fetch-node-popularity.mjs
+++ b/packages/frontend/editor-ui/scripts/fetch-node-popularity.mjs
@@ -7,6 +7,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const POPULARITY_ENDPOINT =
 	process.env.NODE_POPULARITY_ENDPOINT ||
 	'https://internal.users.n8n.cloud/webhook/nodes-popularity-scores';
+const FAIL_ON_ERROR = process.env.N8N_FAIL_ON_POPULARITY_FETCH_ERROR === 'true';
 const BUILD_DIR = path.join(__dirname, '..', '.build');
 const OUTPUT_FILE = path.join(BUILD_DIR, 'node-popularity.json');
 
@@ -76,12 +77,23 @@ async function main() {
 			// Save the fresh data
 			await savePopularityData(freshData);
 		} else {
-			// Fetching failed, check if we have existing data
+			// Fetching failed
+			if (FAIL_ON_ERROR) {
+				console.error('N8N_FAIL_ON_POPULARITY_FETCH_ERROR is set - failing build');
+				process.exit(1);
+			}
+
+			// Check if we have existing data
 			console.log('API unavailable, checking for existing cached data');
 			await fallbackToExistingData();
 		}
 	} catch (error) {
 		console.error('Error in fetch-node-popularity script:', error);
+
+		if (FAIL_ON_ERROR) {
+			console.error('N8N_FAIL_ON_POPULARITY_FETCH_ERROR is set - failing build');
+			process.exit(1);
+		}
 
 		await fallbackToExistingData();
 	}

--- a/packages/frontend/editor-ui/turbo.json
+++ b/packages/frontend/editor-ui/turbo.json
@@ -9,7 +9,8 @@
 			"dependsOn": ["popularity-cache-marker"],
 			"cache": true,
 			"outputs": [".build/node-popularity.json"],
-			"inputs": ["scripts/fetch-node-popularity.mjs", ".build/cache-marker"]
+			"inputs": ["scripts/fetch-node-popularity.mjs", ".build/cache-marker"],
+			"env": ["N8N_FAIL_ON_POPULARITY_FETCH_ERROR"]
 		},
 		"build": {
 			"dependsOn": ["^build", "fetch-popularity"],


### PR DESCRIPTION
## Summary

Node popularity data is being used to enhance node search ranking. It is fetched during the build process by the script `fetch-node-popularity.mjs`. When fetching up-to-date popularity data fails, fallback search ranking will be used, as this is not critical and we don't want to unnecessarily block CI pipelines and local dev builds when popularity data is unavailable for some reason.

Though, we want to make sure that **release builds** contain up-to-date popularity data.

This PR adds env variable that controls if the `fetch-node-popularity.mjs` script should fail in case of a fetch error, or silently ignore it.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-1513/bug-chat-trigger-is-not-the-first-result
- https://linear.app/n8n/issue/AI-1384/hackmation-follow-up-feature-sorting-of-nodes-in-the-node-creator
- https://github.com/n8n-io/n8n/pull/19561


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
