### PR TITLE
fix: use chat_input field for HumanMessage content instead of content

### DIFF
--- a/packages/frontend/@n8n/chat/src/plugins/chat.ts
+++ b/packages/frontend/@n8n/chat/src/plugins/chat.ts
@@ -263,9 +263,11 @@ export const ChatPlugin: Plugin<ChatOptions> = {
 			const previousMessagesResponse = await api.loadPreviousSession(sessionId, options);
 
 			messages.value = (previousMessagesResponse?.data || []).map((message, index) => ({
-				id: `${index}`,
-				text: message.kwargs.content,
-				sender: message.id.includes('HumanMessage') ? 'user' : 'bot',
+			    id: `${index}`,
+			    text: message.id.includes('HumanMessage') 
+			        ? message.kwargs.chat_input 
+			        : message.kwargs.content,
+			    sender: message.id.includes('HumanMessage') ? 'user' : 'bot',
 			}));
 
 			if (messages.value.length) {


### PR DESCRIPTION
## Description
Fixed message mapping in chat history to correctly extract text content from HumanMessage objects.

## Problem
HumanMessage objects store their text content in `kwargs.chat_input`, while AIMessage objects use `kwargs.content`. The previous implementation only checked `kwargs.content` for all message types, causing human messages to display as undefined.

## Solution
Added conditional logic to check message type and extract text from the appropriate field:
- `HumanMessage`: use `kwargs.chat_input`
- `AIMessage`: use `kwargs.content`

## Changes
- Updated message mapping logic to handle different content field locations based on message type

## Proof - API Response Payload
The chat API returns messages with different structures for HumanMessage vs AIMessage:
```json
{
  "data": [
    {
      "lc": 1,
      "type": "constructor",
      "id": ["langchain_core", "messages", "HumanMessage"],
      "kwargs": {
        "action": "sendMessage",
        "metadata": {
          "page": "add-accomplishment",
          "source": "achevu-accomplishments",
          "userId": "7d05ace7-dfbb-48f5-b8a9-084d7a531028",
          "acompSessionId": ""
        },
        "chat_input": "hello",  // ← Human message content is here
        "session_id": "5fdd04d5-d0e7-4f2b-8f15-00105c2a2961",
        "additional_kwargs": {},
        "response_metadata": {}
      }
    },
    {
      "lc": 1,
      "type": "constructor",
      "id": ["langchain_core", "messages", "AIMessage"],
      "kwargs": {
        "content": "I'll help you transform...",  // ← AI message content is here
        "tool_calls": [],
        "additional_kwargs": {},
        "response_metadata": {},
        "invalid_tool_calls": []
      }
    }
  ]
}