### PR TITLE
feat(editor): Improve community node tracking

### DIFF
--- a/packages/frontend/editor-ui/src/components/CommunityPackageCard.vue
+++ b/packages/frontend/editor-ui/src/components/CommunityPackageCard.vue
@@ -82,7 +82,7 @@ async function onAction(value: string) {
 
 function onUpdateClick() {
 	if (!props.communityPackage) return;
-	openCommunityPackageUpdateConfirmModal(props.communityPackage.packageName);
+	openCommunityPackageUpdateConfirmModal(props.communityPackage.packageName, 'instance settings');
 }
 
 watch(

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/Panel/CommunityNodeInfo.vue
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/Panel/CommunityNodeInfo.vue
@@ -119,6 +119,7 @@ onMounted(async () => {
 			v-if="isUpdateCheckAvailable && installedPackage?.updateAvailable"
 			data-test-id="update-available"
 			:package-name="communityNodeDetails?.packageName"
+			source="node creator panel"
 		/>
 		<div v-else :class="$style.separator"></div>
 		<div :class="$style.info">

--- a/packages/frontend/editor-ui/src/components/Node/NodeCreator/Panel/CommunityNodeUpdateInfo.vue
+++ b/packages/frontend/editor-ui/src/components/Node/NodeCreator/Panel/CommunityNodeUpdateInfo.vue
@@ -5,6 +5,7 @@ import { i18n } from '@n8n/i18n';
 import { N8nButton, N8nCallout } from '@n8n/design-system';
 interface Props {
 	packageName?: string;
+	source?: string;
 }
 
 const props = defineProps<Props>();
@@ -13,7 +14,7 @@ const { openCommunityPackageUpdateConfirmModal } = useUIStore();
 
 const onUpdate = () => {
 	if (!props.packageName) return;
-	openCommunityPackageUpdateConfirmModal(props.packageName);
+	openCommunityPackageUpdateConfirmModal(props.packageName, props.source);
 };
 </script>
 

--- a/packages/frontend/editor-ui/src/components/NodeSettings.vue
+++ b/packages/frontend/editor-ui/src/components/NodeSettings.vue
@@ -751,6 +751,7 @@ function handleSelectAction(params: INodeParameters) {
 					data-test-id="update-available"
 					:package-name="packageName"
 					style="margin-top: var(--spacing-s)"
+					source="node settings"
 				/>
 				<ParameterInputList
 					:parameters="parametersByTab.settings"

--- a/packages/frontend/editor-ui/src/stores/nodeCreator.store.test.ts
+++ b/packages/frontend/editor-ui/src/stores/nodeCreator.store.test.ts
@@ -205,7 +205,7 @@ describe('useNodeCreatorStore', () => {
 		const mockTrigger = {
 			key: 'n8n-node.exampleTrigger',
 			properties: {
-				name: 'n8n-node.exampleTrigge',
+				name: 'n8n-node.exampleTrigger',
 				displayName: 'Example Trigger',
 			},
 		} as INodeCreateElement;
@@ -222,6 +222,20 @@ describe('useNodeCreatorStore', () => {
 			properties: {},
 		} as INodeCreateElement;
 
+		const mockCommunity1 = {
+			key: 'community-node1.example',
+			properties: {
+				name: 'n8n-nodes-community-node1',
+			},
+		} as INodeCreateElement;
+
+		const mockCommunity2 = {
+			key: 'community-node2.example',
+			properties: {
+				name: '@author/n8n-nodes-community-node2',
+			},
+		} as INodeCreateElement;
+
 		nodeCreatorStore.onCreatorOpened({
 			source,
 			mode,
@@ -229,7 +243,7 @@ describe('useNodeCreatorStore', () => {
 		});
 		nodeCreatorStore.onNodeFilterChanged({
 			newValue,
-			filteredNodes: [mockCustom, mockRegular, mockTrigger],
+			filteredNodes: [mockCustom, mockRegular, mockTrigger, mockCommunity1, mockCommunity2],
 			filterMode: REGULAR_NODE_CREATOR_VIEW,
 			subcategory,
 			title,
@@ -239,9 +253,10 @@ describe('useNodeCreatorStore', () => {
 			search_string: newValue,
 			filter_mode: 'regular',
 			category_name: subcategory,
-			results_count: 2,
+			results_count: 4,
 			trigger_count: 1,
-			regular_count: 1,
+			regular_count: 3,
+			community_count: 2,
 			nodes_panel_session_id: getSessionId(now),
 			title,
 		});

--- a/packages/frontend/editor-ui/src/stores/ui.store.ts
+++ b/packages/frontend/editor-ui/src/stores/ui.store.ts
@@ -499,7 +499,7 @@ export const useUIStore = defineStore(STORES.UI, () => {
 	};
 
 	const openCommunityPackageUpdateConfirmModal = (packageName: string, source?: string) => {
-		telemetry.track('user clicked to open community node update modal', {
+		telemetry.track('User clicked to open community node update modal', {
 			source,
 			package_name: packageName,
 		});

--- a/packages/frontend/editor-ui/src/stores/ui.store.ts
+++ b/packages/frontend/editor-ui/src/stores/ui.store.ts
@@ -76,6 +76,7 @@ import type { EventBus } from '@n8n/utils/event-bus';
 import type { ProjectSharingData } from '@/types/projects.types';
 import identity from 'lodash/identity';
 import * as modalRegistry from '@/moduleInitializer/modalRegistry';
+import { useTelemetry } from '@/composables/useTelemetry';
 
 let savedTheme: ThemeOption = 'system';
 
@@ -90,6 +91,7 @@ try {
 type UiStore = ReturnType<typeof useUIStore>;
 
 export const useUIStore = defineStore(STORES.UI, () => {
+	const telemetry = useTelemetry();
 	const activeActions = ref<string[]>([]);
 	const activeCredentialType = ref<string | null>(null);
 	const theme = useLocalStorage<ThemeOption>(LOCAL_STORAGE_THEME, savedTheme, {
@@ -496,7 +498,11 @@ export const useUIStore = defineStore(STORES.UI, () => {
 		openModal(COMMUNITY_PACKAGE_CONFIRM_MODAL_KEY);
 	};
 
-	const openCommunityPackageUpdateConfirmModal = (packageName: string) => {
+	const openCommunityPackageUpdateConfirmModal = (packageName: string, source?: string) => {
+		telemetry.track('user clicked to open community node update modal', {
+			source,
+			package_name: packageName,
+		});
 		setMode(COMMUNITY_PACKAGE_CONFIRM_MODAL_KEY, COMMUNITY_PACKAGE_MANAGE_ACTIONS.UPDATE);
 		setActiveId(COMMUNITY_PACKAGE_CONFIRM_MODAL_KEY, packageName);
 		openModal(COMMUNITY_PACKAGE_CONFIRM_MODAL_KEY);


### PR DESCRIPTION
## Summary

This PR makes the following changes to tracking functionality:
- new event `User clicked to open community node update modal` to track where a user opened the update modal from
- update to `User entered nodes panel search term` to track how many community node a user sees in the search bar


## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-3473/telemetry-add-events-to-see-node-update-funnel
https://linear.app/n8n/issue/NODE-2367/basic-telemetry-count-of-verified-community-nodes-in-user-entered

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
