### PR TITLE
fix(core): Fix worker setup completion

### DIFF
--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -159,7 +159,7 @@ export class Worker extends BaseCommand<z.infer<typeof flagsSchema>> {
 
 		await this.scalingService.setupQueue();
 
-		await this.scalingService.setupWorker(this.concurrency);
+		this.scalingService.setupWorker(this.concurrency);
 	}
 
 	async run() {

--- a/packages/cli/src/scaling/__tests__/scaling.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/scaling.service.test.ts
@@ -171,7 +171,7 @@ describe('ScalingService', () => {
 			await scalingService.setupQueue();
 			const concurrency = 5;
 
-			await scalingService.setupWorker(concurrency);
+			scalingService.setupWorker(concurrency);
 
 			expect(queue.process).toHaveBeenCalledWith(JOB_TYPE_NAME, concurrency, expect.any(Function));
 		});
@@ -179,14 +179,14 @@ describe('ScalingService', () => {
 		it('should throw if called on a non-worker instance', async () => {
 			await scalingService.setupQueue();
 
-			await expect(scalingService.setupWorker(5)).rejects.toThrow();
+			expect(() => scalingService.setupWorker(5)).toThrow();
 		});
 
 		it('should throw if called before queue is ready', async () => {
 			// @ts-expect-error readonly property
 			instanceSettings.instanceType = 'worker';
 
-			await expect(scalingService.setupWorker(5)).rejects.toThrow();
+			expect(() => scalingService.setupWorker(5)).toThrow();
 		});
 	});
 

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -80,11 +80,11 @@ export class ScalingService {
 		this.logger.debug('Queue setup completed');
 	}
 
-	async setupWorker(concurrency: number) {
+	setupWorker(concurrency: number) {
 		this.assertWorker();
 		this.assertQueue();
 
-		await this.queue.process(JOB_TYPE_NAME, concurrency, async (job: Job) => {
+		void this.queue.process(JOB_TYPE_NAME, concurrency, async (job: Job) => {
 			try {
 				this.eventService.emit('job-dequeued', {
 					executionId: job.data.executionId,


### PR DESCRIPTION
## Summary

At #20219 I added an `await` when registering the job processing handler on the worker, in the understanding that the `Promise` returned by `Queue.prototype.process` represents registration completion, based on the [type definition](https://github.com/OptimalBits/bull/blob/489c6ab8466c1db122f92af3ddef12eacc54179e/index.d.ts#L583-L602).

This understanding was incorrect, as `Queue.prototype.process` triggers a chain of calls: `Queue.prototype.start` →  `Queue.prototype.run` → `Queue.prototype.processJobs` → `Queue.prototype._processJobOnNextTick` which eventually resolves [here](https://github.com/OptimalBits/bull/blob/489c6ab8466c1db122f92af3ddef12eacc54179e/lib/queue.js#L1140) only when the queue is closing, which means the `Promise` returned by `Queue.prototype.process` is intended for shutdown logic, not for registration completion.

This PR reverts the change at #20219.

## Related Linear tickets, Github issues, and Community forum posts

n/a

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
