### PR TITLE
fix (expressions) : stringify json inputs correctly in interpolation

### DIFF
--- a/packages/workflow/src/expression.ts
+++ b/packages/workflow/src/expression.ts
@@ -26,6 +26,7 @@ import type {
 } from './interfaces';
 import type { Workflow } from './workflow';
 import { WorkflowDataProxy } from './workflow-data-proxy';
+import { object } from 'zod/v4';
 
 const IS_FRONTEND_IN_DEV_MODE =
 	typeof process === 'object' &&
@@ -76,6 +77,13 @@ export class Expression {
 		}
 
 		let result = '';
+		if (value instanceof Object) {
+			try {
+				result = JSON.stringify(value, null, 2);
+			} catch {
+				return '[Unserializable Object]';
+			}
+		}
 		if (value instanceof Date) {
 			// We don't want to use JSON.stringify for dates since it disregards workflow timezone
 			result = DateTime.fromJSDate(value, {

--- a/packages/workflow/src/expressions/expression-helpers.ts
+++ b/packages/workflow/src/expressions/expression-helpers.ts
@@ -3,7 +3,9 @@
  * starts with '='.
  */
 export const isExpression = (expr: unknown): expr is string => {
-	if (typeof expr !== 'string') return false;
+	if (typeof expr !== 'string') {
+		return false;
+	}
 
 	return expr.charAt(0) === '=';
 };


### PR DESCRIPTION
## Summary

Fixes the issue where non-primitive JSON inputs referenced in the expression editor are displayed as `[object Object]` instead of a proper string representation.  

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
