### PR TITLE
fix(editor): Keep source control and user area fixed to bottom of sidebar

### DIFF
--- a/packages/frontend/editor-ui/src/components/BecomeTemplateCreatorCta/BecomeTemplateCreatorCta.vue
+++ b/packages/frontend/editor-ui/src/components/BecomeTemplateCreatorCta/BecomeTemplateCreatorCta.vue
@@ -14,7 +14,11 @@ const onClick = () => {
 </script>
 
 <template>
-	<div v-if="true" :class="$style.container" data-test-id="become-template-creator-cta">
+	<div
+		v-if="store.showBecomeCreatorCta"
+		:class="$style.container"
+		data-test-id="become-template-creator-cta"
+	>
 		<div :class="$style.textAndCloseButton">
 			<p :class="$style.text">
 				{{ i18n.baseText('becomeCreator.text') }}

--- a/packages/frontend/editor-ui/src/components/BecomeTemplateCreatorCta/BecomeTemplateCreatorCta.vue
+++ b/packages/frontend/editor-ui/src/components/BecomeTemplateCreatorCta/BecomeTemplateCreatorCta.vue
@@ -14,11 +14,7 @@ const onClick = () => {
 </script>
 
 <template>
-	<div
-		v-if="store.showBecomeCreatorCta"
-		:class="$style.container"
-		data-test-id="become-template-creator-cta"
-	>
+	<div v-if="true" :class="$style.container" data-test-id="become-template-creator-cta">
 		<div :class="$style.textAndCloseButton">
 			<p :class="$style.text">
 				{{ i18n.baseText('becomeCreator.text') }}

--- a/packages/frontend/editor-ui/src/components/MainSidebar.vue
+++ b/packages/frontend/editor-ui/src/components/MainSidebar.vue
@@ -573,7 +573,6 @@ onClickOutside(createBtn as Ref<VueInstance>, () => {
 
 				<div :class="$style.bottomMenu">
 					<BecomeTemplateCreatorCta v-if="fullyExpanded && !userIsTrialing" />
-					<MainSidebarSourceControl :is-collapsed="isCollapsed" />
 					<div :class="$style.bottomMenuItems">
 						<template v-for="item in visibleMenuItems" :key="item.id">
 							<N8nPopoverReka
@@ -615,57 +614,59 @@ onClickOutside(createBtn as Ref<VueInstance>, () => {
 						</template>
 					</div>
 				</div>
-
-				<div v-if="showUserArea">
-					<div ref="user" :class="$style.userArea">
-						<N8nPopoverReka side="right" align="end" :side-offset="16">
-							<template #content>
-								<div :class="$style.popover">
-									<N8nMenuItem
-										v-for="action in userMenuItems"
-										:key="action.id"
-										:item="action"
-										:data-test-id="`user-menu-item-${action.id}`"
-										@click="() => onUserActionToggle(action.id)"
-									/>
-								</div>
-							</template>
-							<template #trigger>
-								<div :class="$style.userAreaInner">
-									<div class="ml-3xs" data-test-id="main-sidebar-user-menu">
-										<!-- This dropdown is only enabled when sidebar is collapsed -->
-										<div :class="{ [$style.avatar]: true, ['clickable']: isCollapsed }">
-											<N8nAvatar
-												:first-name="usersStore.currentUser?.firstName"
-												:last-name="usersStore.currentUser?.lastName"
-												size="small"
-											/>
-										</div>
-									</div>
-									<div
-										:class="{
-											['ml-2xs']: true,
-											[$style.userName]: true,
-											[$style.expanded]: fullyExpanded,
-										}"
-									>
-										<N8nText size="small" color="text-dark">{{
-											usersStore.currentUser?.fullName
-										}}</N8nText>
-									</div>
-									<div
-										data-test-id="user-menu"
-										:class="{ [$style.userActions]: true, [$style.expanded]: fullyExpanded }"
-									>
-										<N8nIconButton icon="ellipsis" text square type="tertiary" />
-									</div>
-								</div>
-							</template>
-						</N8nPopoverReka>
-					</div>
-				</div>
 			</div>
 		</N8nScrollArea>
+
+		<MainSidebarSourceControl :is-collapsed="isCollapsed" />
+		<div v-if="showUserArea">
+			<div ref="user" :class="$style.userArea">
+				<N8nPopoverReka side="right" align="end" :side-offset="16">
+					<template #content>
+						<div :class="$style.popover">
+							<N8nMenuItem
+								v-for="action in userMenuItems"
+								:key="action.id"
+								:item="action"
+								:data-test-id="`user-menu-item-${action.id}`"
+								@click="() => onUserActionToggle(action.id)"
+							/>
+						</div>
+					</template>
+					<template #trigger>
+						<div :class="$style.userAreaInner">
+							<div class="ml-3xs" data-test-id="main-sidebar-user-menu">
+								<!-- This dropdown is only enabled when sidebar is collapsed -->
+								<div :class="{ [$style.avatar]: true, ['clickable']: isCollapsed }">
+									<N8nAvatar
+										:first-name="usersStore.currentUser?.firstName"
+										:last-name="usersStore.currentUser?.lastName"
+										size="small"
+									/>
+								</div>
+							</div>
+							<div
+								:class="{
+									['ml-2xs']: true,
+									[$style.userName]: true,
+									[$style.expanded]: fullyExpanded,
+								}"
+							>
+								<N8nText size="small" color="text-dark">{{
+									usersStore.currentUser?.fullName
+								}}</N8nText>
+							</div>
+							<div
+								data-test-id="user-menu"
+								:class="{ [$style.userActions]: true, [$style.expanded]: fullyExpanded }"
+							>
+								<N8nIconButton icon="ellipsis" text square type="tertiary" />
+							</div>
+						</div>
+					</template>
+				</N8nPopoverReka>
+			</div>
+		</div>
+
 		<TemplateTooltip />
 	</div>
 </template>

--- a/packages/frontend/editor-ui/src/components/MainSidebarSourceControl.vue
+++ b/packages/frontend/editor-ui/src/components/MainSidebarSourceControl.vue
@@ -150,7 +150,6 @@ function pullWorkfolder() {
 <style lang="scss" module>
 .sync {
 	padding: var(--spacing-s) var(--spacing-s) var(--spacing-s) var(--spacing-l);
-	margin: var(--spacing-2xs) 0 calc(var(--spacing-2xs) * -1);
 	background: var(--color-background-light);
 	border-top: var(--border-width-base) var(--border-style-base) var(--color-foreground-base);
 	font-size: var(--font-size-2xs);


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Reverts to old behaviour of source control and user area being fixed to the bottom when sidebar scrolls.

Scroll area now only wraps MenuItems.

## Related Linear tickets, Github issues, and Community forum posts

Fixes https://linear.app/n8n/issue/ADO-4260/the-new-side-menu-scrolls-which-means-pushpull-for-environments-is#comment-3224a0df
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
