### PR TITLE
feat(API): Add project and projectId fields to get and update a variable project

### DIFF
--- a/packages/cli/src/environments.ee/variables/variables.service.ee.ts
+++ b/packages/cli/src/environments.ee/variables/variables.service.ee.ts
@@ -261,7 +261,12 @@ export class VariablesService {
 		await this.variablesRepository.update(id, {
 			key: variable.key,
 			value: variable.value,
-			project: variable.projectId ? { id: variable.projectId } : null,
+			// Only update the project if it was explicitly set in the update
+			// If project id is undefined, keep the existing
+			// If project id is null, move to global (no project)
+			...(typeof variable.projectId !== 'undefined'
+				? { project: variable.projectId ? { id: variable.projectId } : null }
+				: {}),
 		});
 		await this.updateCache();
 		return (await this.getCached(id))!;

--- a/packages/cli/src/public-api/v1/handlers/variables/spec/paths/variables.id.yml
+++ b/packages/cli/src/public-api/v1/handlers/variables/spec/paths/variables.id.yml
@@ -29,7 +29,7 @@ put:
     content:
       application/json:
         schema:
-          $ref: '../schemas/variable.yml'
+          $ref: '../schemas/variable.create.yml'
     required: true
   responses:
     '204':

--- a/packages/cli/src/public-api/v1/handlers/variables/spec/paths/variables.yml
+++ b/packages/cli/src/public-api/v1/handlers/variables/spec/paths/variables.yml
@@ -10,7 +10,7 @@ post:
     content:
       application/json:
         schema:
-          $ref: '../schemas/variable.yml'
+          $ref: '../schemas/variable.create.yml'
     required: true
   responses:
     '201':
@@ -29,6 +29,14 @@ get:
   parameters:
     - $ref: '../../../../shared/spec/parameters/limit.yml'
     - $ref: '../../../../shared/spec/parameters/cursor.yml'
+    - name: projectId
+      in: query
+      required: false
+      explode: false
+      allowReserved: true
+      schema:
+        type: string
+        example: VmwOO9HeTEj20kxM
   responses:
     '200':
       description: Operation successful.

--- a/packages/cli/src/public-api/v1/handlers/variables/spec/paths/variables.yml
+++ b/packages/cli/src/public-api/v1/handlers/variables/spec/paths/variables.yml
@@ -37,6 +37,12 @@ get:
       schema:
         type: string
         example: VmwOO9HeTEj20kxM
+    - name: state
+      in: query
+      required: false
+      schema:
+        type: string
+        enum: [empty]
   responses:
     '200':
       description: Operation successful.

--- a/packages/cli/src/public-api/v1/handlers/variables/spec/schemas/variable.create.yml
+++ b/packages/cli/src/public-api/v1/handlers/variables/spec/schemas/variable.create.yml
@@ -15,14 +15,7 @@ properties:
   type:
     type: string
     readOnly: true
-  project:
-    type: object
-    properties:
-      id:
-        type: string
-        readOnly: true
-      name:
-        type: string
-      type:
-        type: string
-        readOnly: true
+  projectId:
+    type: string
+    example: VmwOO9HeTEj20kxM
+    nullable: true

--- a/packages/cli/src/public-api/v1/handlers/variables/spec/schemas/variable.yml
+++ b/packages/cli/src/public-api/v1/handlers/variables/spec/schemas/variable.yml
@@ -16,13 +16,4 @@ properties:
     type: string
     readOnly: true
   project:
-    type: object
-    properties:
-      id:
-        type: string
-        readOnly: true
-      name:
-        type: string
-      type:
-        type: string
-        readOnly: true
+    $ref: '../../../projects/spec/schemas/project.yml'

--- a/packages/cli/src/public-api/v1/handlers/variables/variables.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/variables/variables.handler.ts
@@ -57,12 +57,15 @@ export = {
 		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'variable:list' }),
 		validCursor,
 		async (req: VariablesRequest.GetAll, res: Response) => {
-			const { offset = 0, limit = 100, projectId } = req.query;
+			const { offset = 0, limit = 100, projectId, state } = req.query;
 
 			const [variables, count] = await Container.get(VariablesRepository).findAndCount({
 				skip: offset,
 				take: limit,
-				where: { project: projectId === 'null' ? IsNull() : { id: projectId } },
+				where: {
+					project: projectId === 'null' ? IsNull() : { id: projectId },
+					value: state === 'empty' ? '' : undefined,
+				},
 				relations: ['project'],
 			});
 

--- a/packages/cli/src/public-api/v1/handlers/variables/variables.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/variables/variables.handler.ts
@@ -2,6 +2,8 @@ import { CreateVariableRequestDto } from '@n8n/api-types';
 import type { AuthenticatedRequest } from '@n8n/db';
 import { VariablesRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
+import { IsNull } from '@n8n/typeorm';
 import type { Response } from 'express';
 
 import {
@@ -12,11 +14,7 @@ import {
 import { encodeNextCursor } from '../../shared/services/pagination.service';
 
 import { VariablesController } from '@/environments.ee/variables/variables.controller.ee';
-import type { PaginatedRequest } from '@/public-api/types';
 import type { VariablesRequest } from '@/requests';
-
-type Delete = VariablesRequest.Delete;
-type GetAll = PaginatedRequest;
 
 export = {
 	createVariable: [
@@ -48,7 +46,7 @@ export = {
 	deleteVariable: [
 		isLicensed('feat:variables'),
 		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'variable:delete' }),
-		async (req: Delete, res: Response) => {
+		async (req: AuthenticatedRequest<{ id: string }>, res: Response) => {
 			await Container.get(VariablesController).deleteVariable(req);
 
 			return res.status(204).send();
@@ -58,12 +56,14 @@ export = {
 		isLicensed('feat:variables'),
 		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'variable:list' }),
 		validCursor,
-		async (req: GetAll, res: Response) => {
-			const { offset = 0, limit = 100 } = req.query;
+		async (req: VariablesRequest.GetAll, res: Response) => {
+			const { offset = 0, limit = 100, projectId } = req.query;
 
 			const [variables, count] = await Container.get(VariablesRepository).findAndCount({
 				skip: offset,
 				take: limit,
+				where: { project: projectId === 'null' ? IsNull() : { id: projectId } },
+				relations: ['project'],
 			});
 
 			return res.json({

--- a/packages/cli/src/requests.ts
+++ b/packages/cli/src/requests.ts
@@ -235,7 +235,18 @@ export declare namespace LicenseRequest {
 export declare namespace VariablesRequest {
 	type CreateUpdatePayload = Omit<Variables, 'id'> & { id?: unknown };
 
-	type GetAll = AuthenticatedRequest;
+	type GetAll = AuthenticatedRequest<
+		{},
+		{},
+		{},
+		{
+			limit?: number;
+			cursor?: string;
+			offset?: number;
+			lastId?: string;
+			projectId?: string;
+		}
+	>;
 	type Get = AuthenticatedRequest<{ id: string }, {}, {}, {}>;
 	type Create = AuthenticatedRequest<{}, {}, CreateUpdatePayload, {}>;
 	type Update = AuthenticatedRequest<{ id: string }, {}, CreateUpdatePayload, {}>;

--- a/packages/cli/src/requests.ts
+++ b/packages/cli/src/requests.ts
@@ -245,6 +245,7 @@ export declare namespace VariablesRequest {
 			offset?: number;
 			lastId?: string;
 			projectId?: string;
+			state?: 'empty';
 		}
 	>;
 	type Get = AuthenticatedRequest<{ id: string }, {}, {}, {}>;

--- a/packages/cli/test/integration/public-api/variables.test.ts
+++ b/packages/cli/test/integration/public-api/variables.test.ts
@@ -1,13 +1,18 @@
-import { testDb } from '@n8n/backend-test-utils';
-import type { User, Variables } from '@n8n/db';
+import { createTeamProject, testDb } from '@n8n/backend-test-utils';
+import type { Project, User, Variables } from '@n8n/db';
+import { createOwnerWithApiKey } from '@test-integration/db/users';
+import {
+	createProjectVariable,
+	createVariable,
+	getVariableByIdOrFail,
+} from '@test-integration/db/variables';
+import { setupTestServer } from '@test-integration/utils';
 
 import { FeatureNotLicensedError } from '@/errors/feature-not-licensed.error';
-import { createOwnerWithApiKey } from '@test-integration/db/users';
-import { createVariable, getVariableByIdOrFail } from '@test-integration/db/variables';
-import { setupTestServer } from '@test-integration/utils';
 
 describe('Variables in Public API', () => {
 	let owner: User;
+	let project: Project;
 	const testServer = setupTestServer({ endpointGroups: ['publicApi'] });
 	const licenseErrorMessage = new FeatureNotLicensedError('feat:variables').message;
 
@@ -19,6 +24,7 @@ describe('Variables in Public API', () => {
 		await testDb.truncate(['Variables', 'User']);
 
 		owner = await createOwnerWithApiKey();
+		project = await createTeamProject();
 	});
 
 	describe('GET /variables', () => {
@@ -27,7 +33,12 @@ describe('Variables in Public API', () => {
 			 * Arrange
 			 */
 			testServer.license.enable('feat:variables');
-			const variables = await Promise.all([createVariable(), createVariable(), createVariable()]);
+			const variables = await Promise.all([
+				createVariable(),
+				createVariable(),
+				createVariable(),
+				createProjectVariable('projectKey', 'projectValue', project),
+			]);
 
 			/**
 			 * Act
@@ -43,8 +54,15 @@ describe('Variables in Public API', () => {
 			expect(Array.isArray(response.body.data)).toBe(true);
 			expect(response.body.data.length).toBe(variables.length);
 
-			variables.forEach(({ id, key, value }) => {
+			variables.forEach(({ id, key, value, project }) => {
 				expect(response.body.data).toContainEqual(expect.objectContaining({ id, key, value }));
+				if (project) {
+					const projectResponse = response.body.data.find((v: Variables) => v.id === id).project;
+					expect(projectResponse).toBeDefined();
+					expect(projectResponse).toEqual(
+						expect.objectContaining({ id: project.id, name: project.name }),
+					);
+				}
 			});
 		});
 
@@ -84,6 +102,34 @@ describe('Variables in Public API', () => {
 			expect(response.status).toBe(201);
 			await expect(getVariableByIdOrFail(response.body.id)).resolves.toEqual(
 				expect.objectContaining(variablePayload),
+			);
+		});
+
+		it('if licensed, should create a variable linked to a project', async () => {
+			/**
+			 * Arrange
+			 */
+			testServer.license.enable('feat:variables');
+			const variablePayload = { key: 'key', value: 'value', projectId: project.id };
+
+			/**
+			 * Act
+			 */
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.post('/variables')
+				.send(variablePayload);
+
+			/**
+			 * Assert
+			 */
+			expect(response.status).toBe(201);
+			await expect(getVariableByIdOrFail(response.body.id)).resolves.toEqual(
+				expect.objectContaining({
+					key: 'key',
+					value: 'value',
+					project: expect.objectContaining({ id: project.id }),
+				}),
 			);
 		});
 
@@ -127,6 +173,24 @@ describe('Variables in Public API', () => {
 			expect(response.status).toBe(204);
 			const updatedVariable = await getVariableByIdOrFail(variable.id);
 			expect(updatedVariable).toEqual(expect.objectContaining(variablePayload));
+		});
+
+		it('if licensed, should update a variable to link it to a project', async () => {
+			testServer.license.enable('feat:variables');
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.put(`/variables/${variable.id}`)
+				.send({ ...variablePayload, projectId: project.id });
+
+			expect(response.status).toBe(204);
+			const updatedVariable = await getVariableByIdOrFail(variable.id);
+			expect(updatedVariable).toEqual(
+				expect.objectContaining({
+					...variablePayload,
+					project: expect.objectContaining({ id: project.id }),
+				}),
+			);
 		});
 
 		it('if not licensed, should reject', async () => {

--- a/packages/cli/test/integration/shared/db/variables.ts
+++ b/packages/cli/test/integration/shared/db/variables.ts
@@ -32,7 +32,10 @@ export async function createProjectVariable(
 }
 
 export async function getVariableByIdOrFail(id: string) {
-	return await Container.get(VariablesRepository).findOneOrFail({ where: { id } });
+	return await Container.get(VariablesRepository).findOneOrFail({
+		where: { id },
+		relations: ['project'],
+	});
 }
 
 export async function getVariableByKey(key: string) {

--- a/packages/cli/test/integration/variables.test.ts
+++ b/packages/cli/test/integration/variables.test.ts
@@ -1,9 +1,14 @@
-import { testDb } from '@n8n/backend-test-utils';
-import type { Variables } from '@n8n/db';
+import { createTeamProject, linkUserToProject, testDb } from '@n8n/backend-test-utils';
+import type { Project, Variables } from '@n8n/db';
 import { Container } from '@n8n/di';
 
 import { CacheService } from '@/services/cache/cache.service';
-import { createVariable, getVariableById, getVariableByKey } from '@test-integration/db/variables';
+import {
+	createProjectVariable,
+	createVariable,
+	getVariableById,
+	getVariableByKey,
+} from '@test-integration/db/variables';
 
 import { createOwner, createUser } from './shared/db/users';
 import type { SuperAgentTest } from './shared/types';
@@ -11,6 +16,7 @@ import * as utils from './shared/utils/';
 
 let authOwnerAgent: SuperAgentTest;
 let authMemberAgent: SuperAgentTest;
+let project: Project;
 
 const testServer = utils.setupTestServer({ endpointGroups: ['variables'] });
 const license = testServer.license;
@@ -20,6 +26,9 @@ beforeAll(async () => {
 	authOwnerAgent = testServer.authAgentFor(owner);
 	const member = await createUser();
 	authMemberAgent = testServer.authAgentFor(member);
+
+	project = await createTeamProject();
+	await linkUserToProject(member, project, 'project:editor');
 
 	license.setDefaults({
 		features: ['feat:variables'],
@@ -42,6 +51,7 @@ describe('GET /variables', () => {
 			createVariable('test1', 'value1'),
 			createVariable('test2', 'value2'),
 			createVariable('empty', ''),
+			createProjectVariable('testProject1', 'projectValue1', project),
 		]);
 	});
 
@@ -57,13 +67,13 @@ describe('GET /variables', () => {
 	test('should return all variables for an owner', async () => {
 		const response = await authOwnerAgent.get('/variables');
 		expect(response.statusCode).toBe(200);
-		expect(response.body.data.length).toBe(3);
+		expect(response.body.data.length).toBe(4);
 	});
 
 	test('should return all variables for a member', async () => {
 		const response = await authMemberAgent.get('/variables');
 		expect(response.statusCode).toBe(200);
-		expect(response.body.data.length).toBe(3);
+		expect(response.body.data.length).toBe(4);
 	});
 
 	describe('state:empty', () => {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Handles the new project field in the Variables public API:
- enable specifying the project id when creating / updating a variable
- return project if exists when listing variables
- add projectId nullable filter to filter variables by project id or global only (projectId = null)

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-1880/update-variables-public-api-to-support-projects

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
