### PR TITLE
fix: Recover message history after interrupted tool executions (no-changelog)

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/utils/cleanup-dangling-tool-call-messages.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/utils/cleanup-dangling-tool-call-messages.ts
@@ -1,0 +1,24 @@
+import type { BaseMessage } from '@langchain/core/messages';
+import { AIMessage, RemoveMessage, ToolMessage } from '@langchain/core/messages';
+
+/**
+ * In cases where the request was interrupted while a tool call was in progress
+ * (e.g. network error), we might end up with dangling tool calls in the state.
+ * This function identifies AI messages that have tool calls without corresponding
+ * ToolMessage responses and returns RemoveMessage instances to clean them up.
+ */
+export function cleanupDanglingToolCallMessages(messages: BaseMessage[]): RemoveMessage[] {
+	// First we collect all tool call IDs from ToolMessages
+	const toolCallIds = new Set(
+		messages.filter((m): m is ToolMessage => m instanceof ToolMessage).map((m) => m.tool_call_id),
+	);
+
+	// Then we look for AI messages which reference tool calls, but the tool call ID is not in the set
+	// (this means the tool call was never completed)
+	const danglingToolCalls = messages.filter(
+		(m) => m instanceof AIMessage && m.tool_calls?.some(({ id }) => id && !toolCallIds.has(id)),
+	);
+
+	// Remove dangling tool calls, as otherwise it will block agent execution
+	return danglingToolCalls.map((m) => new RemoveMessage({ id: m.id! }));
+}

--- a/packages/@n8n/ai-workflow-builder.ee/src/utils/test/cleanup-dangling-tool-call-messages.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/utils/test/cleanup-dangling-tool-call-messages.test.ts
@@ -1,0 +1,123 @@
+import type { BaseMessage } from '@langchain/core/messages';
+import { AIMessage, HumanMessage, RemoveMessage, ToolMessage } from '@langchain/core/messages';
+
+import { cleanupDanglingToolCallMessages } from '../cleanup-dangling-tool-call-messages';
+
+describe('cleanupDanglingToolCallMessages', () => {
+	it('should remove AI messages with dangling tool calls', () => {
+		const messages = [
+			new AIMessage({
+				id: 'ai-1',
+				content: 'Calling tool',
+				tool_calls: [{ id: 'dangling-1', name: 'test_tool', args: {} }],
+			}),
+		];
+
+		const result = cleanupDanglingToolCallMessages(messages);
+
+		expect(result).toHaveLength(1);
+		expect(result[0]).toBeInstanceOf(RemoveMessage);
+		expect(result[0].id).toBe('ai-1');
+	});
+
+	it('should not remove AI messages when tool calls are completed', () => {
+		const messages = [
+			new AIMessage({
+				id: 'ai-1',
+				content: 'Calling tool',
+				tool_calls: [{ id: 'completed-1', name: 'test_tool', args: {} }],
+			}),
+			new ToolMessage({ id: 'tool-1', content: 'Result', tool_call_id: 'completed-1' }),
+		];
+
+		const result = cleanupDanglingToolCallMessages(messages);
+
+		expect(result).toHaveLength(0);
+	});
+
+	it('should handle AI messages with multiple tool calls where some are dangling', () => {
+		const messages = [
+			new AIMessage({
+				id: 'ai-1',
+				content: 'Multiple calls',
+				tool_calls: [
+					{ id: 'completed-1', name: 'tool1', args: {} },
+					{ id: 'dangling-1', name: 'tool2', args: {} },
+					{ id: 'dangling-2', name: 'tool3', args: {} },
+				],
+			}),
+			new ToolMessage({ id: 'tool-1', content: 'Result', tool_call_id: 'completed-1' }),
+		];
+
+		const result = cleanupDanglingToolCallMessages(messages);
+
+		expect(result).toHaveLength(1);
+		expect(result[0]).toBeInstanceOf(RemoveMessage);
+		expect(result[0].id).toBe('ai-1');
+	});
+
+	it('should handle empty message history', () => {
+		const messages: BaseMessage[] = [];
+
+		const result = cleanupDanglingToolCallMessages(messages);
+
+		expect(result).toHaveLength(0);
+	});
+
+	it('should handle messages without tool calls', () => {
+		const messages = [
+			new HumanMessage({ id: 'human-1', content: 'Hello' }),
+			new AIMessage({ id: 'ai-1', content: 'Response' }),
+		];
+
+		const result = cleanupDanglingToolCallMessages(messages);
+
+		expect(result).toHaveLength(0);
+	});
+
+	it('should handle multiple AI messages with mixed dangling/completed tool calls', () => {
+		const messages = [
+			new AIMessage({
+				id: 'ai-1',
+				content: 'First call',
+				tool_calls: [{ id: 'completed-1', name: 'tool1', args: {} }],
+			}),
+			new ToolMessage({ id: 'tool-1', content: 'Result 1', tool_call_id: 'completed-1' }),
+			new AIMessage({
+				id: 'ai-2',
+				content: 'Second call',
+				tool_calls: [{ id: 'dangling-1', name: 'tool2', args: {} }],
+			}),
+			new HumanMessage({ id: 'human-1', content: 'Continue' }),
+		];
+
+		const result = cleanupDanglingToolCallMessages(messages);
+
+		expect(result).toHaveLength(1);
+		expect(result[0]).toBeInstanceOf(RemoveMessage);
+		expect(result[0].id).toBe('ai-2');
+	});
+
+	it('should remove all AI messages with dangling tool calls', () => {
+		const messages = [
+			new AIMessage({
+				id: 'ai-1',
+				content: 'First dangling',
+				tool_calls: [{ id: 'dangling-1', name: 'tool1', args: {} }],
+			}),
+			new AIMessage({
+				id: 'ai-2',
+				content: 'Second dangling',
+				tool_calls: [{ id: 'dangling-2', name: 'tool2', args: {} }],
+			}),
+		];
+
+		const result = cleanupDanglingToolCallMessages(messages);
+
+		expect(result).toHaveLength(2);
+		expect(result[0]).toBeInstanceOf(RemoveMessage);
+		expect(result[0].id).toBe('ai-1');
+		expect(result[1]).toBeInstanceOf(RemoveMessage);
+		expect(result[1].id).toBe('ai-2');
+	});
+});


### PR DESCRIPTION
## Summary

There is a chance that message history in AI workflow builder's state gets corrupted:
there might be `AIMessage` with tool calls, but no corresponding `ToolMessage`.

Workflow builder can not handle any new messages if it contains this issue – all LLM call will fail.

To avoid breaking the session, this PR adds an additional check before running the normal flow:
- Find AI messages with tool calls which were not fulfilled
- Remove these messages

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-1518/bug-t2w-failed-with-error-after-ai-assistant-service-issues


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
