### PR TITLE
Fix: Prevent workflow crash caused by missing fields in execution data

### DIFF
--- a/packages/cli/src/modules/insights/insights-collection.service.ts
+++ b/packages/cli/src/modules/insights/insights-collection.service.ts
@@ -139,7 +139,7 @@ export class InsightsCollectionService {
 		});
 
 		// run time event
-		if (ctx.runData.stoppedAt) {
+		if (ctx.runData.stoppedAt && ctx.runData.startedAt) {
 			const runtimeMs = ctx.runData.stoppedAt.getTime() - ctx.runData.startedAt.getTime();
 			if (runtimeMs < MIN_RUNTIME || runtimeMs > MAX_RUNTIME) {
 				this.logger.warn(`Invalid runtime detected: ${runtimeMs}ms, clamping to safe range`);


### PR DESCRIPTION
## Summary

This PR prevents a runtime calculation error that can occur when ```ctx.runData.startedAt``` is missing.
In production, this issue caused a TypeError: Cannot read properties of null (reading 'getTime') when the system attempted to process incomplete run data (in my case, during initialization, but it can happen at any point where unfinished executions are recovered or processed).

Previously, the condition only verified ```ctx.runData.stoppedAt```, which allowed ```startedAt``` to be ```null``` and led to the crash.
The fix adds a safeguard to ensure both values are defined before calculating runtime:

```ts
if (ctx.runData.stoppedAt && ctx.runData.startedAt) {
///
```

Logs on my production real case:
```
2025-10-08T08:32:12.988-03:00 Permissions 0644 for n8n settings file /home/node/.n8n/config are too wide. This is ignored for now, but in the future n8n will attempt to change the permissions automatically. To automatically enforce correct permissions now set N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS=true (recommended), or turn this check off set N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS=false.
2025-10-08T08:32:15.843-03:00 Initializing n8n process
2025-10-08T08:32:18.304-03:00 n8n ready on 0.0.0.0, port 5678
2025-10-08T08:32:18.390-03:00 n8n detected that some packages are missing. For more information, visit https://docs.n8n.io/integrations/community-nodes/troubleshooting/
2025-10-08T08:32:18.415-03:00 n8n Task Broker ready on 127.0.0.1, port 5679
2025-10-08T08:32:18.977-03:00 [license SDK] Skipping renewal on init because renewal is not due yet or cert is not initialized
2025-10-08T08:32:28.989-03:00 Cannot set LDAP login enabled state when an authentication method other than email or ldap is active (current: saml)
2025-10-08T08:32:32.774-03:00 Registered runner "JS Task Runner" (z7HYnmlrcb_vKJG1X4_ik)
2025-10-08T08:32:35.683-03:00 Found unfinished executions: 1380457, 1357807, 1357933, 1357948, 1357865, 1357868, 1380526, 1380542, 1380642, 1357871, 1357887, 1357903, 1357934, 1380518, 1380787, 1380701, 1380746, 1380791, 1380813, 1380814, 1380605, 1380606, 1380636, 1380607, 1380623, 1380608, 1380610, 1380611, 1380625, 1380615, 1380614, 1380620, 1380621, 1380626, 1380629, 1380730, 1380716, 1380764, 1380738, 1380768, 1380769, 1380804, 1380832, 1380842, 1380062, 1380063, 1380547, 1380579, 1380548, 1380581, 1380602, 1380624, 1380612, 1357946, 1380585, 1380582, 1380604, 1380843, 1380147, 1380054, 1380091, 1380065
2025-10-08T08:32:35.683-03:00 This could be due to a crash of an active workflow or a restart of n8n.
2025-10-08T08:32:35.789-03:00 Currently active workflows:
2025-10-08T08:32:35.790-03:00    - [redacted]
2025-10-08T08:32:35.977-03:00 Marked executions as `crashed`
2025-10-08T08:32:35.992-03:00 [Recovery] Logs available, amended execution
2025-10-08T08:32:36.070-03:00 Marked executions as `crashed`
2025-10-08T08:32:36.080-03:00 [Recovery] Logs available, amended execution
2025-10-08T08:32:36.115-03:00 TypeError: Cannot read properties of null (reading 'getTime')
2025-10-08T08:32:36.116-03:00     at InsightsCollectionService.handleWorkflowExecuteAfter (/usr/local/lib/node_modules/n8n/src/modules/insights/insights-collection.service.ts:130:74)
2025-10-08T08:32:36.116-03:00     at ExecutionLifecycleHooks.<anonymous> (/usr/local/lib/node_modules/n8n/src/modules/module-registry.ts:50:42)
2025-10-08T08:32:36.116-03:00     at ExecutionLifecycleHooks.runHook (/usr/local/lib/node_modules/n8n/node_modules/.pnpm/n8n-core@file+packages+core_openai@4.78.1_encoding@0.1.13_zod@3.24.1_/node_modules/n8n-core/src/execution-engine/execution-lifecycle-hooks.ts:115:28)
2025-10-08T08:32:36.116-03:00     at processTicksAndRejections (node:internal/process/task_queues:95:5)
2025-10-08T08:32:36.116-03:00     at ExecutionRecoveryService.runHooks (/usr/local/lib/node_modules/n8n/src/executions/execution-recovery.service.ts:200:3)
2025-10-08T08:32:36.116-03:00     at ExecutionRecoveryService.recoverFromLogs (/usr/local/lib/node_modules/n8n/src/executions/execution-recovery.service.ts:45:3)
2025-10-08T08:32:36.116-03:00     at MessageEventBus.initialize (/usr/local/lib/node_modules/n8n/src/eventbus/message-event-bus/message-event-bus.ts:185:7)
2025-10-08T08:32:36.116-03:00     at Server.configure (/usr/local/lib/node_modules/n8n/src/server.ts:270:3)
2025-10-08T08:32:36.116-03:00     at Server.start (/usr/local/lib/node_modules/n8n/src/abstract-server.ts:259:3)
2025-10-08T08:32:36.116-03:00     at Server.start (/usr/local/lib/node_modules/n8n/src/server.ts:96:3)
2025-10-08T08:32:36.116-03:00 Exiting due to an error.
2025-10-08T08:32:36.116-03:00 Cannot read properties of null (reading 'getTime')
```