### PR TITLE
fix(core): Fix broker websocket connection closure on runner heartbeat failure

### DIFF
--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -126,7 +126,6 @@ export const WsStatusCodes = {
 	CloseGoingAway: 1001,
 	CloseProtocolError: 1002,
 	CloseUnsupportedData: 1003,
-	CloseNoStatus: 1005,
 	CloseAbnormal: 1006,
 	CloseInvalidData: 1007,
 } as const;

--- a/packages/cli/src/task-runners/task-broker/task-broker-ws-server.ts
+++ b/packages/cli/src/task-runners/task-broker/task-broker-ws-server.ts
@@ -59,7 +59,7 @@ export class TaskBrokerWsServer {
 					void this.removeConnection(
 						runnerId,
 						'failed-heartbeat-check',
-						WsStatusCodes.CloseNoStatus,
+						WsStatusCodes.CloseProtocolError,
 					);
 					this.runnerLifecycleEvents.emit('runner:failed-heartbeat-check');
 					return;


### PR DESCRIPTION
## Summary

Came across [this high-frequency report](https://n8nio.sentry.io/issues/6386727022) on Sentry.

When the broker detects a runner heartbeat failure, the broker is currently sending status code 1005 in a ws close frame, which is causing the `ws` library to throw.

But [RFC 6455](https://datatracker.ietf.org/doc/html/rfc6455) says:

>1005 is a reserved value and MUST NOT be set as a status code in a Close control frame by an endpoint.  It is designated for use in applications expecting a status code to indicate that no status code was actually present.

So 1005 is a used to represent the absence of a status code. It's never sent over the wire, only exists at the application layer to distinguish between "no code sent" vs "code n sent"

Hence this PR switches to `CloseProtocolError` on heartbeat failure. From my reading of the RFC, heartbeat failure is a protocol violation error:

>1002 indicates that an endpoint is terminating the connection due to a protocol error. [...] Upon receipt of a Ping frame, an endpoint MUST send a Pong frame in response, unless it already received a Close frame.



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1565


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
