### PR TITLE
feat(core): Add telemetry to monitor project variables usage

### DIFF
--- a/packages/cli/src/environments.ee/variables/variables.service.ee.ts
+++ b/packages/cli/src/environments.ee/variables/variables.service.ee.ts
@@ -205,7 +205,6 @@ export class VariablesService {
 		// Check that variable key is unique (globally or in the project)
 		await this.validateUniqueVariable(variable.key, variable.projectId);
 
-		this.eventService.emit('variable-created');
 		const saveResult = await this.variablesRepository.save(
 			{
 				...variable,
@@ -214,6 +213,9 @@ export class VariablesService {
 			},
 			{ transaction: false },
 		);
+		this.eventService.emit('variable-created', {
+			projectId: variable.projectId,
+		});
 		await this.updateCache();
 		return saveResult;
 	}
@@ -267,6 +269,9 @@ export class VariablesService {
 			...(typeof variable.projectId !== 'undefined'
 				? { project: variable.projectId ? { id: variable.projectId } : null }
 				: {}),
+		});
+		this.eventService.emit('variable-updated', {
+			projectId: variable.projectId ?? undefined,
 		});
 		await this.updateCache();
 		return (await this.getCached(id))!;

--- a/packages/cli/src/environments.ee/variables/variables.service.ee.ts
+++ b/packages/cli/src/environments.ee/variables/variables.service.ee.ts
@@ -271,7 +271,7 @@ export class VariablesService {
 				: {}),
 		});
 		this.eventService.emit('variable-updated', {
-			projectId: variable.projectId ?? undefined,
+			projectId: newProjectId,
 		});
 		await this.updateCache();
 		return (await this.getCached(id))!;

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -333,7 +333,25 @@ describe('TelemetryEventRelay', () => {
 		it('should track on `variable-created` event', () => {
 			eventService.emit('variable-created', {});
 
-			expect(telemetry.track).toHaveBeenCalledWith('User created variable');
+			expect(telemetry.track).toHaveBeenCalledWith('User created variable', {});
+
+			eventService.emit('variable-created', { projectId: 'projectId' });
+
+			expect(telemetry.track).toHaveBeenCalledWith('User created variable', {
+				project_id: 'projectId',
+			});
+		});
+
+		it('should track on `variable-updated` event', () => {
+			eventService.emit('variable-updated', {});
+
+			expect(telemetry.track).toHaveBeenCalledWith('User updated variable', {});
+
+			eventService.emit('variable-updated', { projectId: 'projectId' });
+
+			expect(telemetry.track).toHaveBeenCalledWith('User updated variable', {
+				project_id: 'projectId',
+			});
 		});
 	});
 

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -463,7 +463,13 @@ export type RelayEventMap = {
 
 	// #region Variable
 
-	'variable-created': {};
+	'variable-created': {
+		projectId?: string;
+	};
+
+	'variable-updated': {
+		projectId?: string;
+	};
 
 	// #endregion
 

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -63,7 +63,8 @@ export class TelemetryEventRelay extends EventRelay {
 				this.sourceControlUserFinishedPushUi(event),
 			'license-renewal-attempted': (event) => this.licenseRenewalAttempted(event),
 			'license-community-plus-registered': (event) => this.licenseCommunityPlusRegistered(event),
-			'variable-created': () => this.variableCreated(),
+			'variable-created': (event) => this.variableCreated(event),
+			'variable-updated': (event) => this.variableUpdated(event),
 			'external-secrets-provider-settings-saved': (event) =>
 				this.externalSecretsProviderSettingsSaved(event),
 			'public-api-invoked': (event) => this.publicApiInvoked(event),
@@ -272,8 +273,16 @@ export class TelemetryEventRelay extends EventRelay {
 
 	// #region Variable
 
-	private variableCreated() {
-		this.telemetry.track('User created variable');
+	private variableCreated(event: RelayEventMap['variable-created']) {
+		this.telemetry.track('User created variable', {
+			project_id: event.projectId,
+		});
+	}
+
+	private variableUpdated(event: RelayEventMap['variable-updated']) {
+		this.telemetry.track('User updated variable', {
+			project_id: event.projectId,
+		});
 	}
 
 	// #endregion

--- a/packages/frontend/editor-ui/src/features/projects/components/ProjectTabs.vue
+++ b/packages/frontend/editor-ui/src/features/projects/components/ProjectTabs.vue
@@ -12,6 +12,7 @@ import { usePostHog } from '@/stores/posthog.store';
 import { N8nTabs } from '@n8n/design-system';
 import { useProjectsStore } from '../projects.store';
 import { ProjectTypes } from '../projects.types';
+import { useTelemetry } from '@/composables/useTelemetry';
 type Props = {
 	showSettings?: boolean;
 	showExecutions?: boolean;
@@ -30,6 +31,7 @@ const locale = useI18n();
 const route = useRoute();
 const posthogStore = usePostHog();
 const projectStore = useProjectsStore();
+const telemetry = useTelemetry();
 
 const isProjectVariablesEnabled = computed(() =>
 	posthogStore.isVariantEnabled(
@@ -148,6 +150,11 @@ watch(
 );
 
 function onSelectTab(value: string | number) {
+	if (selectedTab.value === 'variables') {
+		telemetry.track('User clicked project variables tab', {
+			project_id: projectId.value,
+		});
+	}
 	selectedTab.value = value as RouteRecordName;
 }
 </script>


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

THis PR adds some telemetry events for project variables, as well as additional context (the projectId) to existing events

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
