### PR TITLE
fix(ChatTrigger): Remove 'Content-Type' header when sending files with custom headers

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/templates.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/templates.ts
@@ -151,7 +151,6 @@ export function createPage({
 						metadata: metadata,
 						webhookConfig: {
 							headers: {
-								'Content-Type': 'application/json',
 								'X-Instance-Id': '${instanceId}',
 							}
 						},

--- a/packages/frontend/@n8n/chat/src/api/message.ts
+++ b/packages/frontend/@n8n/chat/src/api/message.ts
@@ -188,12 +188,18 @@ async function sendWithFiles(
 		formData.append('files', file);
 	}
 
+	const headers: Record<string, string> = {
+		Accept: 'text/plain',
+		...options.webhookConfig?.headers,
+	};
+
+	const filteredHeaders = Object.fromEntries(
+		Object.entries(headers).filter(([key]) => key.toLowerCase() !== 'content-type'),
+	);
+
 	return await fetch(options.webhookUrl, {
 		method: 'POST',
-		headers: {
-			Accept: 'text/plain',
-			...options.webhookConfig?.headers,
-		},
+		headers: filteredHeaders,
 		body: formData,
 	});
 }


### PR DESCRIPTION


## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Dropped any forced Content-Type header before we send FormData in `packages/frontend/@n8n/chat/src/api/message.ts:198`, so the browser can supply the proper multipart boundary and file uploads work again without losing custom headers.

## Related Linear tickets, Github issues, and Community forum posts
https://github.com/n8n-io/n8n/issues/20527
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
