### PR TITLE
fix(Postgres Node): Correct UPSERT parameterization to avoid duplicate placeholders

### DIFF
--- a/packages/nodes-base/nodes/Postgres/test/v2/operations.test.ts
+++ b/packages/nodes-base/nodes/Postgres/test/v2/operations.test.ts
@@ -1084,12 +1084,13 @@ describe('Test PostgresV2, upsert operation', () => {
 			[
 				{
 					query:
-						'INSERT INTO $1:name.$2:name($4:name) VALUES($4:csv) ON CONFLICT ($3:name) DO UPDATE  SET $5:name = $6, $7:name = $8 RETURNING $9:name',
+						'INSERT INTO $1:name.$2:name($3:name) VALUES($4:csv) ON CONFLICT ($5:name) DO UPDATE  SET $6:name = $7, $8:name = $9 RETURNING $10:name',
 					values: [
 						'public',
 						'my_table',
+						['id', 'json', 'foo'],
+						['5', '{ "test": 5 }', 'data 5'],
 						'id',
-						{ json: '{ "test": 5 }', foo: 'data 5', id: '5' },
 						'json',
 						'{ "test": 5 }',
 						'foo',
@@ -1170,12 +1171,13 @@ describe('Test PostgresV2, upsert operation', () => {
 			[
 				{
 					query:
-						'INSERT INTO $1:name.$2:name($4:name) VALUES($4:csv) ON CONFLICT ($3:name) DO UPDATE  SET $5:name = $6, $7:name = $8 RETURNING *',
+						'INSERT INTO $1:name.$2:name($3:name) VALUES($4:csv) ON CONFLICT ($5:name) DO UPDATE  SET $6:name = $7, $8:name = $9 RETURNING *',
 					values: [
 						'public',
 						'my_table',
+						['id', 'json', 'foo'],
+						[1, { test: 15 }, 'data 1'],
 						'id',
-						{ id: 1, json: { test: 15 }, foo: 'data 1' },
 						'json',
 						{ test: 15 },
 						'foo',
@@ -1184,12 +1186,13 @@ describe('Test PostgresV2, upsert operation', () => {
 				},
 				{
 					query:
-						'INSERT INTO $1:name.$2:name($4:name) VALUES($4:csv) ON CONFLICT ($3:name) DO UPDATE  SET $5:name = $6, $7:name = $8 RETURNING *',
+						'INSERT INTO $1:name.$2:name($3:name) VALUES($4:csv) ON CONFLICT ($5:name) DO UPDATE  SET $6:name = $7, $8:name = $9 RETURNING *',
 					values: [
 						'public',
 						'my_table',
+						['id', 'json', 'foo'],
+						[2, { test: 10 }, 'data 2'],
 						'id',
-						{ id: 2, json: { test: 10 }, foo: 'data 2' },
 						'json',
 						{ test: 10 },
 						'foo',
@@ -1198,12 +1201,13 @@ describe('Test PostgresV2, upsert operation', () => {
 				},
 				{
 					query:
-						'INSERT INTO $1:name.$2:name($4:name) VALUES($4:csv) ON CONFLICT ($3:name) DO UPDATE  SET $5:name = $6, $7:name = $8 RETURNING *',
+						'INSERT INTO $1:name.$2:name($3:name) VALUES($4:csv) ON CONFLICT ($5:name) DO UPDATE  SET $6:name = $7, $8:name = $9 RETURNING *',
 					values: [
 						'public',
 						'my_table',
+						['id', 'json', 'foo'],
+						[3, { test: 5 }, 'data 3'],
 						'id',
-						{ id: 3, json: { test: 5 }, foo: 'data 3' },
 						'json',
 						{ test: 5 },
 						'foo',
@@ -1271,14 +1275,15 @@ describe('When matching on all columns', () => {
 			[
 				{
 					query:
-						'INSERT INTO $1:name.$2:name($6:name) VALUES($6:csv) ON CONFLICT ($3:name,$4:name,$5:name) DO NOTHING  RETURNING $7:name',
+						'INSERT INTO $1:name.$2:name($3:name) VALUES($4:csv) ON CONFLICT ($5:name,$6:name,$7:name) DO NOTHING  RETURNING $8:name',
 					values: [
 						'public',
 						'my_table',
+						['id', 'json', 'foo'],
+						['5', '{ "test": 5 }', 'data 5'],
 						'id',
 						'json',
 						'foo',
-						{ id: '5', json: '{ "test": 5 }', foo: 'data 5' },
 						['json'],
 					],
 				},
@@ -1357,38 +1362,41 @@ describe('When matching on all columns', () => {
 			[
 				{
 					query:
-						'INSERT INTO $1:name.$2:name($6:name) VALUES($6:csv) ON CONFLICT ($3:name,$4:name,$5:name) DO NOTHING  RETURNING *',
+						'INSERT INTO $1:name.$2:name($3:name) VALUES($4:csv) ON CONFLICT ($5:name,$6:name,$7:name) DO NOTHING  RETURNING *',
 					values: [
 						'public',
 						'my_table',
+						['id', 'json', 'foo'],
+						[1, { test: 15 }, 'data 1'],
 						'id',
 						'json',
 						'foo',
-						{ id: 1, json: { test: 15 }, foo: 'data 1' },
 					],
 				},
 				{
 					query:
-						'INSERT INTO $1:name.$2:name($6:name) VALUES($6:csv) ON CONFLICT ($3:name,$4:name,$5:name) DO NOTHING  RETURNING *',
+						'INSERT INTO $1:name.$2:name($3:name) VALUES($4:csv) ON CONFLICT ($5:name,$6:name,$7:name) DO NOTHING  RETURNING *',
 					values: [
 						'public',
 						'my_table',
+						['id', 'json', 'foo'],
+						[2, { test: 10 }, 'data 2'],
 						'id',
 						'json',
 						'foo',
-						{ id: 2, json: { test: 10 }, foo: 'data 2' },
 					],
 				},
 				{
 					query:
-						'INSERT INTO $1:name.$2:name($6:name) VALUES($6:csv) ON CONFLICT ($3:name,$4:name,$5:name) DO NOTHING  RETURNING *',
+						'INSERT INTO $1:name.$2:name($3:name) VALUES($4:csv) ON CONFLICT ($5:name,$6:name,$7:name) DO NOTHING  RETURNING *',
 					values: [
 						'public',
 						'my_table',
+						['id', 'json', 'foo'],
+						[3, { test: 5 }, 'data 3'],
 						'id',
 						'json',
 						'foo',
-						{ id: 3, json: { test: 5 }, foo: 'data 3' },
 					],
 				},
 			],


### PR DESCRIPTION
## Summary

This PR fixes malformed SQL generation in the Postgres v2 upsert operation. The previous implementation reused the same placeholder index for different purposes, producing invalid parameterized queries that could cause protocol errors.

## Problem

The upsert builder generated queries like:

```sql
INSERT INTO $1:name.$2:name($4:name) VALUES($4:csv) 
ON CONFLICT ($3:name) DO UPDATE SET ...
```

**Issues:**
1. **Duplicate parameter index**: `$4` was used both as `:name` (for column identifiers) and `:csv` (for values), violating pg-promise formatting rules
2. **Non-sequential numbering**: Placeholders appeared out of order ($1, $2, $4, $3)
3. **Inconsistent column ordering**

This resulted in "invalid message format" or protocol errors in certain environments.

## Solution

The fix ensures:
- **Unique placeholders**: Each parameter gets a distinct index
  - `$3:name` → column identifiers
  - `$4:csv` → row values
  - `$5:name`, `$6:name`, ... → conflict columns and SET pairs
- **Sequential ordering**: Parameters are numbered in logical order (1, 2, 3, 4, ...)
- **Deterministic column order**: Matching columns appear first, then remaining columns

**After:**
```sql
INSERT INTO $1:name.$2:name($3:name) VALUES($4:csv)
ON CONFLICT ($5:name, $6:name) 
DO UPDATE SET $7:name = $8, $9:name = $10
RETURNING ...
```

## Changes

- Updated `packages/nodes-base/nodes/Postgres/v2/actions/database/upsert.operation.ts`
- Modified parameter array construction to maintain unique, sequential indices
- Ensured compliance with pg-promise formatting semantics (`:name` for identifiers, `:csv` for value lists)
- Updated test expectations in `packages/nodes-base/nodes/Postgres/v2/test/operations.test.ts`

## Testing

- ✅ All existing tests pass with updated expectations (using pnpm test)
- ✅ Verified correct placeholder numbering and separation
- ✅ Confirmed deterministic column ordering
- ✅ "Match on all columns" correctly generates `DO NOTHING` with proper conflict list

## Related Issues

Fixes #20122 (malformed parameterization in Postgres upsert)


## Backward Compatibility

- No changes to MySQL or SQLite code paths
- Upsert semantics (`INSERT ... ON CONFLICT ... DO UPDATE/DO NOTHING`) remain unchanged
- Query results are identical; only internal SQL generation is corrected


### Corrected SQL Query (from logs)

<img width="1470" height="74" alt="Screenshot 2025-10-09 at 8 03 13 PM" src="https://github.com/user-attachments/assets/6abe254c-8179-457e-b827-8e85b487522d" />

### Working n8n Workflow:
<img width="1398" height="767" alt="Screenshot 2025-10-09 at 8 04 34 PM" src="https://github.com/user-attachments/assets/a8e6e0a6-e7f0-4546-9219-90ccf0f6105c" />

