### PR TITLE
ci: Exclude n8n packages from minimum release age

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,8 @@ packages:
 minimumReleaseAge: 2880 # 2 days
 minimumReleaseAgeExclude:
   - eslint-plugin-storybook
+  - '@n8n/*'
+  - '@n8n_io/*'
 
 catalog:
   '@n8n/typeorm': 0.3.20-13


### PR DESCRIPTION
To solve:

```
ERR_PNPM_NO_MATCHING_VERSION  No matching version found for @n8n/typeorm@0.3.20-13 while fetching it from https://registry.npmjs.org/
This error happened while installing a direct dependency of /home/runner/_work/n8n/n8n/packages/cli
The latest release of @n8n/typeorm is "0.3.20-13".
```
