### PR TITLE
fix(ErrorTrigger): point help link to new docs

### DIFF
--- a/packages/nodes-base/nodes/ErrorTrigger/ErrorTrigger.node.ts
+++ b/packages/nodes-base/nodes/ErrorTrigger/ErrorTrigger.node.ts
@@ -27,7 +27,7 @@ export class ErrorTrigger implements INodeType {
 		properties: [
 			{
 				displayName:
-					'This node will trigger when there is an error in another workflow, as long as that workflow is set up to do so. <a href="https://docs.n8n.io/integrations/core-nodes/n8n-nodes-base.errortrigger" target="_blank">More info</a>',
+					'This node will trigger when there is an error in another workflow, as long as that workflow is set up to do so. <a href="https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.errortrigger/" target="_blank">More info</a>',
 				name: 'notice',
 				type: 'notice',
 				default: '',


### PR DESCRIPTION
## Summary
Hey n8n team! I spotted the Error Trigger callout still sending folks to the old docs, so this just updates the link to the `/integrations/builtin/` page so the help link opens the right article again.

## Related Linear tickets, Github issues, and Community forum posts
Fixes n8n-io/n8n#20302.

## Review / Merge checklist
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] Docs updated (https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
