### PR TITLE
feat(Brevo Node): Enhance filtering options for the "Get Many Contacts" operation

### DIFF
--- a/packages/nodes-base/nodes/Brevo/ContactDescription.ts
+++ b/packages/nodes-base/nodes/Brevo/ContactDescription.ts
@@ -293,6 +293,20 @@ const getAllOperations: INodeProperties[] = [
 		default: {},
 		options: [
 			{
+				displayName: 'Created Since',
+				name: 'createdSince',
+				type: 'dateTime',
+				routing: {
+					send: {
+						type: 'query',
+						property: 'createdSince',
+					},
+				},
+				default: '',
+				description:
+					'Filter (urlencoded) the contacts created after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ)',
+			},
+			{
 				displayName: 'Modified Since',
 				name: 'modifiedSince',
 				type: 'dateTime',
@@ -305,6 +319,37 @@ const getAllOperations: INodeProperties[] = [
 				default: '',
 				description:
 					'Filter (urlencoded) the contacts modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ)',
+			},
+			{
+				displayName: 'List IDs',
+				name: 'listIds',
+				type: 'number',
+				routing: {
+					send: {
+						type: 'query',
+						property: 'listIds',
+					},
+				},
+				default: {},
+				typeOptions: {
+					multipleValues: true,
+				},
+				description: 'Ids of the list. Either listIds or segmentId can be passed.',
+			},
+			{
+				displayName: 'Filter',
+				name: 'filter',
+				type: 'string',
+				routing: {
+					send: {
+						type: 'query',
+						property: 'filter',
+					},
+				},
+				default: '',
+				placeholder: 'equals(ATTRIBUTE,"value")',
+				description:
+					'Filter the contacts on the basis of attributes. Allowed operator: equals. For multiple-choice options, the filter will apply an AND condition between the options. For category attributes, the filter will work with both id and value. (e.g. filter=equals(FIRSTNAME,"Antoine"), filter=equals(B1, true), filter=equals(DOB, "1989-11-23"), filter=equals(GENDER, "1"), filter=equals(GENDER, "MALE"), filter=equals(COUNTRY,"USA, INDIA")',
 			},
 		],
 	},


### PR DESCRIPTION

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
This PR adds following filters to the "Get many contacts" action :
- Created Since (createdSince)
- List IDs (listIds)
- Filter (filter)

This allows for adding more granularity to contacts retrieval action.

<img width="400" height="771" alt="brevo-getmanycontacts-newfilters" src="https://github.com/user-attachments/assets/7cae2ec5-82f3-4dff-a743-44ce27ca61c2" />



The Brevo's documentation corresponding to the options can be found here:
https://developers.brevo.com/reference/getcontacts-1

"segmentId" filter was not added because "listids" also includes "segmentId" and allows for adding multiple ones.


Tests have been updated as they didn't exist for this node.


Docs have not been updated as they don't describe the existing filter option.




## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
