### PR TITLE
fix(OpenAI Node): Re-enable list of models for non-OpenAI providers

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/methods/loadModels.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/methods/loadModels.ts
@@ -1,6 +1,7 @@
 import type { ILoadOptionsFunctions, INodeListSearchResult } from 'n8n-workflow';
 import OpenAI from 'openai';
 
+import { shouldIncludeModel } from '../../../vendors/OpenAi/helpers/modelFiltering';
 import { getProxyAgent } from '@utils/httpProxyAgent';
 
 export async function searchModels(
@@ -22,25 +23,15 @@ export async function searchModels(
 	});
 	const { data: models = [] } = await openai.models.list();
 
+	const url = baseURL && new URL(baseURL);
+	const isCustomAPI = !!(url && url.hostname !== 'api.openai.com');
+
 	const filteredModels = models.filter((model: { id: string }) => {
-		const url = baseURL && new URL(baseURL);
-		const isCustomAPI = url && url.hostname !== 'api.openai.com';
-		// Filter out TTS, embedding, image generation, and other models
-		const isInvalidModel =
-			!isCustomAPI &&
-			(model.id.startsWith('babbage') ||
-				model.id.startsWith('davinci') ||
-				model.id.startsWith('computer-use') ||
-				model.id.startsWith('dall-e') ||
-				model.id.startsWith('text-embedding') ||
-				model.id.startsWith('tts') ||
-				model.id.startsWith('whisper') ||
-				model.id.startsWith('omni-moderation') ||
-				(model.id.startsWith('gpt-') && model.id.includes('instruct')));
+		const includeModel = shouldIncludeModel(model.id, isCustomAPI);
 
-		if (!filter) return !isInvalidModel;
+		if (!filter) return includeModel;
 
-		return !isInvalidModel && model.id.toLowerCase().includes(filter.toLowerCase());
+		return includeModel && model.id.toLowerCase().includes(filter.toLowerCase());
 	});
 
 	filteredModels.sort((a, b) => a.id.localeCompare(b.id));

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/helpers/__tests__/modelFiltering.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/helpers/__tests__/modelFiltering.test.ts
@@ -1,0 +1,40 @@
+import { shouldIncludeModel } from '../modelFiltering';
+
+describe('shouldIncludeModel', () => {
+	const testCases: Array<{ modelId: string; officialAPI: boolean }> = [
+		// Excluded model types
+		{ modelId: 'babbage-002', officialAPI: false },
+		{ modelId: 'davinci-002', officialAPI: false },
+		{ modelId: 'computer-use-preview', officialAPI: false },
+		{ modelId: 'dall-e-3', officialAPI: false },
+		{ modelId: 'text-embedding-ada-002', officialAPI: false },
+		{ modelId: 'tts-1', officialAPI: false },
+		{ modelId: 'whisper-1', officialAPI: false },
+		{ modelId: 'omni-moderation-latest', officialAPI: false },
+		{ modelId: 'sora-1', officialAPI: false },
+		{ modelId: 'gpt-4o-realtime-preview', officialAPI: false }, // infix check for -realtime
+		{ modelId: 'gpt-3.5-turbo-instruct', officialAPI: false }, // gpt-* with instruct
+
+		// Included models (standard chat models)
+		{ modelId: 'gpt-4', officialAPI: true },
+		{ modelId: 'gpt-4o', officialAPI: true },
+		{ modelId: 'o1-preview', officialAPI: true },
+		{ modelId: 'ft:gpt-3.5-turbo', officialAPI: true }, // fine-tuned models
+
+		// Edge cases
+		{ modelId: 'llama-3-70b-instruct', officialAPI: true }, // non-gpt instruct is allowed
+		{ modelId: 'custom-model', officialAPI: true }, // arbitrary custom model names
+	];
+
+	describe('Custom API behavior', () => {
+		it.each(testCases)('should include "$modelId"', ({ modelId }) => {
+			expect(shouldIncludeModel(modelId, true)).toBe(true);
+		});
+	});
+
+	describe('Official OpenAI API filtering', () => {
+		it.each(testCases)('$officialAPI: "$modelId"', ({ modelId, officialAPI }) => {
+			expect(shouldIncludeModel(modelId, false)).toBe(officialAPI);
+		});
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/helpers/modelFiltering.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/helpers/modelFiltering.ts
@@ -20,6 +20,7 @@ export function shouldIncludeModel(modelId: string, isCustomAPI: boolean): boole
 		modelId.startsWith('dall-e') ||
 		modelId.startsWith('text-embedding') ||
 		modelId.startsWith('tts') ||
+		modelId.includes('-tts') ||
 		modelId.startsWith('whisper') ||
 		modelId.startsWith('omni-moderation') ||
 		modelId.startsWith('sora') ||

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/helpers/modelFiltering.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/helpers/modelFiltering.ts
@@ -1,0 +1,29 @@
+/**
+ * Determines whether a model should be included in the model list based on
+ * whether it's a custom API and the model's ID.
+ *
+ * @param modelId - The ID of the model to check
+ * @param isCustomAPI - Whether this is a custom API (not official OpenAI)
+ * @returns true if the model should be included, false otherwise
+ */
+export function shouldIncludeModel(modelId: string, isCustomAPI: boolean): boolean {
+	// For custom APIs, include all models
+	if (isCustomAPI) {
+		return true;
+	}
+
+	// For official OpenAI API, exclude certain model types
+	return !(
+		modelId.startsWith('babbage') ||
+		modelId.startsWith('davinci') ||
+		modelId.startsWith('computer-use') ||
+		modelId.startsWith('dall-e') ||
+		modelId.startsWith('text-embedding') ||
+		modelId.startsWith('tts') ||
+		modelId.startsWith('whisper') ||
+		modelId.startsWith('omni-moderation') ||
+		modelId.startsWith('sora') ||
+		modelId.includes('-realtime') ||
+		(modelId.startsWith('gpt-') && modelId.includes('instruct'))
+	);
+}

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/methods/listSearch.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/methods/listSearch.ts
@@ -7,6 +7,7 @@ import type {
 import type { Assistant } from 'openai/resources/beta/assistants';
 import type { Model } from 'openai/resources/models';
 
+import { shouldIncludeModel } from '../helpers/modelFiltering';
 import { apiRequest } from '../transport';
 
 export async function fileSearch(
@@ -77,22 +78,8 @@ export async function modelSearch(
 ): Promise<INodeListSearchResult> {
 	const credentials = await this.getCredentials<{ url: string }>('openAiApi');
 	const url = credentials.url && new URL(credentials.url);
-	const isCustomAPI = url && !['api.openai.com', 'ai-assistant.n8n.io'].includes(url.hostname);
-	return await getModelSearch(
-		(model) =>
-			!isCustomAPI &&
-			!(
-				model.id.startsWith('babbage') ||
-				model.id.startsWith('davinci') ||
-				model.id.startsWith('computer-use') ||
-				model.id.startsWith('dall-e') ||
-				model.id.startsWith('text-embedding') ||
-				model.id.startsWith('tts') ||
-				model.id.startsWith('whisper') ||
-				model.id.startsWith('omni-moderation') ||
-				(model.id.startsWith('gpt-') && model.id.includes('instruct'))
-			),
-	)(this, filter);
+	const isCustomAPI = !!(url && !['api.openai.com', 'ai-assistant.n8n.io'].includes(url.hostname));
+	return await getModelSearch((model) => shouldIncludeModel(model.id, isCustomAPI))(this, filter);
 }
 
 export async function imageModelSearch(


### PR DESCRIPTION
## Summary

Somewhere the listSearch method for the standalone OpenAI Node got broken, and did not show any models for non-OpenAI providers anymore. This change moves the checking-logic for the models themselves to a separate helper-function s.t. we don't have to maintain the list in two places anymore.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-1512/openai-node-get-request-to-list-models-when-using-custom-baseurl-does

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
