### PR TITLE
Potential Issue In zx

### DIFF
--- a/scripts/build-n8n.mjs
+++ b/scripts/build-n8n.mjs
@@ -98,7 +98,6 @@ startTimer('package_build');
 echo(chalk.yellow('INFO: Running pnpm install and build...'));
 try {
 	const installProcess = $`cd ${config.rootDir} && pnpm install --frozen-lockfile`;
-	installProcess.pipe(process.stdout);
 	await installProcess;
 
 	const buildProcess = $`cd ${config.rootDir} && pnpm build`;


### PR DESCRIPTION
In zx, the $ tagged template returns a Promise, not a stream. Therefore, installProcess.pipe(process.stdout) does not actually work as intended and will throw an error. 