### PR TITLE
Fix input type mapping in FromAiParametersModal

### DIFF
--- a/packages/frontend/editor-ui/src/components/FromAiParametersModal.vue
+++ b/packages/frontend/editor-ui/src/components/FromAiParametersModal.vue
@@ -137,12 +137,13 @@ const getMCPTools = async (newNode: INode, newSelectedTool: string): Promise<IFo
 						? value.type
 						: 'text';
 
+				const mapType = mapTypes[type] ?? mapTypes['string'];
 				result.push({
 					name: 'query.' + propertyName,
 					initialValue: '',
 					properties: {
 						label: propertyName,
-						type: mapTypes[type].inputType,
+						type: mapType.inputType,
 						required: true,
 					},
 				});


### PR DESCRIPTION
Unsafe code since "text" is not in `mapTypes`.

It causes this error when I try to add my mcp tools: <img width="682" height="173" alt="Image" src="https://github.com/user-attachments/assets/e18924ba-a4e7-43d8-b0f7-9ca91cddd872" />

The server I'm trying to connect to is written in Python with FastMCP. This is the signature of my tool:
```
@mcp.tool
async def generate_qr_code(
    url: str,
    fill_color: str,
    ctx: Context,
    back_color: str = "transparent",
    box_size: int = 10,
    border: int = 4,
    ecc: str = "M",
    ) -> ImageContent:
...
```

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
