### PR TITLE
fix(credentials): update Facebook Graph API to v24.0

### DIFF
--- a/packages/nodes-base/credentials/FacebookGraphApi.credentials.ts
+++ b/packages/nodes-base/credentials/FacebookGraphApi.credentials.ts
@@ -33,7 +33,7 @@ export class FacebookGraphApi implements ICredentialType {
 
 	test: ICredentialTestRequest = {
 		request: {
-			baseURL: 'https://graph.facebook.com/v8.0',
+			baseURL: 'https://graph.facebook.com/v24.0',
 			url: '/me',
 		},
 	};


### PR DESCRIPTION
## Summary

This PR updates the hardcoded version of the Facebook Graph API used for credential testing from the deprecated `v8.0` to the current `v24.0`.

The previous version (`v8.0`) has been discontinued by Meta, causing the credential validation request to fail. This prevented users from successfully connecting new Facebook Graph API credentials, even with a valid access token. Updating the API version in the `test` request to a supported version resolves this issue.

**To Test:**
1. Create a new **node** and search for "Facebook Graph API".
2. Click the credential to connect with and create new credential.
3. Fill in the personal access token and click **save** button.
5. The connection should be tested successfully.

**Result:**
<img width="1438" height="827" alt="Screenshot 2025-10-12 at 11 24 06 PM" src="https://github.com/user-attachments/assets/84c07d37-8f84-4b4d-a488-cd3583ef3913" />


## Related Linear tickets, Github issues, and Community forum posts

Closes #20683


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
