### PR TITLE
fix(benchmark): Use correct webhook endpoint for credential benchmark (no-changelog)

### DIFF
--- a/packages/@n8n/benchmark/scenarios/credential-http-node/credential-http-node.script.js
+++ b/packages/@n8n/benchmark/scenarios/credential-http-node/credential-http-node.script.js
@@ -4,7 +4,7 @@ import { check } from 'k6';
 const apiBaseUrl = __ENV.API_BASE_URL;
 
 export default function () {
-	const res = http.post(`${apiBaseUrl}/webhook/benchmark-http-node`);
+	const res = http.post(`${apiBaseUrl}/webhook/benchmark-credential-http-node`);
 
 	if (res.status !== 200) {
 		console.error(


### PR DESCRIPTION
## Summary

The credential using benchmark was using the wrong webhook endpoint.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-3954/credential-http-node-benchmark-is-not-working

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
