### PR TITLE
ci: Generalize pattern for excluding minimum age packages

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,8 +8,8 @@ packages:
 
 minimumReleaseAge: 2880 # 2 days
 minimumReleaseAgeExclude:
-  - '@n8n/typeorm'
-  - '@n8n_io/ai-assistant-sdk'
+  - '@n8n/*'
+  - '@n8n_io/*'
   - eslint-plugin-storybook
 
 catalog:


### PR DESCRIPTION
Follow-up to #20622

We should trust _all_ our packages, else this will happen again with e.g. `@n8n_io/license-sdk`

https://pnpm.io/settings#minimumreleaseageexclude