### PR TITLE
feat(editor): Make the main create resource button aware of the selected tab

### DIFF
--- a/cypress/pages/credentials.ts
+++ b/cypress/pages/credentials.ts
@@ -14,9 +14,7 @@ export class CredentialsPage extends BasePage {
 	getters = {
 		emptyListCreateCredentialButton: () => cy.getByTestId('empty-resources-list').find('button'),
 		createCredentialButton: () => {
-			cy.getByTestId('add-resource').should('be.visible').click();
-			cy.getByTestId('add-resource').getByTestId('action-credential').should('be.visible');
-			return cy.getByTestId('add-resource').getByTestId('action-credential');
+			return cy.getByTestId('add-resource-credential');
 		},
 		searchInput: () => cy.getByTestId('resources-list-search'),
 		emptyList: () => cy.getByTestId('resources-list-empty'),

--- a/packages/frontend/editor-ui/src/features/dataTable/DataTableView.vue
+++ b/packages/frontend/editor-ui/src/features/dataTable/DataTableView.vue
@@ -132,7 +132,7 @@ watch(
 		@update:pagination-and-sort="onPaginationUpdate"
 	>
 		<template #header>
-			<ProjectHeader>
+			<ProjectHeader main-button="dataTable">
 				<InsightsSummary
 					v-if="projectPages.isOverviewSubPage && insightsStore.isSummaryEnabled"
 					:loading="insightsStore.weeklySummary.isLoading"

--- a/packages/frontend/editor-ui/src/features/projects/components/ProjectHeader.test.ts
+++ b/packages/frontend/editor-ui/src/features/projects/components/ProjectHeader.test.ts
@@ -51,8 +51,10 @@ const ProjectCreateResourceStub = {
 	template: `
 		<div>
 			<div data-test-id="add-resource"><button role="button"></button></div>
-			<button data-test-id="add-resource-workflow" @click="$emit('action', 'workflow')">Workflow</button>
+			<slot></slot>
 			<button data-test-id="action-credential" @click="$emit('action', 'credential')">Credentials</button>
+			<button data-test-id="action-workflow" @click="$emit('action', 'workflow')">Workflow</button>
+			<button data-test-id="action-dataTable" @click="$emit('action', 'dataTable')">Data Table</button>
 			<div data-test-id="add-resource-actions" >
 				<button v-for="action in $props.actions" :key="action.value"></button>
 			</div>
@@ -479,6 +481,51 @@ describe('ProjectHeader', () => {
 			const actionsContainer = getByTestId('add-resource-actions');
 			expect(actionsContainer).toBeInTheDocument();
 			expect(actionsContainer.children).toHaveLength(1);
+		});
+	});
+
+	describe('mainButton prop', () => {
+		it('should render workflow button as main by default', () => {
+			const project = createTestProject({
+				scopes: ['workflow:create'],
+			});
+			projectsStore.currentProject = project;
+
+			const { getByTestId } = renderComponent();
+
+			expect(getByTestId('add-resource-workflow')).toBeInTheDocument();
+		});
+
+		it('should render dataTable button as main when mainButton is dataTable', () => {
+			const project = createTestProject({
+				scopes: ['dataTable:create'],
+			});
+			projectsStore.currentProject = project;
+
+			const { getByTestId } = renderComponent({ props: { mainButton: 'dataTable' } });
+
+			expect(getByTestId('add-resource-dataTable')).toBeInTheDocument();
+		});
+
+		it('should create credential when credential is main button', async () => {
+			const project = createTestProject({
+				scopes: ['credential:create'],
+			});
+			projectsStore.currentProject = project;
+
+			const { getByTestId } = renderComponent({ props: { mainButton: 'credential' } });
+
+			await userEvent.click(getByTestId('add-resource-credential'));
+
+			expect(mockPush).toHaveBeenCalledWith(
+				expect.objectContaining({
+					name: VIEWS.PROJECTS_CREDENTIALS,
+					params: {
+						projectId: project.id,
+						credentialId: 'create',
+					},
+				}),
+			);
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/views/CredentialsView.vue
+++ b/packages/frontend/editor-ui/src/views/CredentialsView.vue
@@ -258,7 +258,7 @@ onMounted(() => {
 		@update:search="onSearchUpdated"
 	>
 		<template #header>
-			<ProjectHeader>
+			<ProjectHeader main-button="credential">
 				<InsightsSummary
 					v-if="overview.isOverviewSubPage && insightsStore.isSummaryEnabled"
 					:loading="insightsStore.weeklySummary.isLoading"

--- a/packages/testing/playwright/composables/CredentialsComposer.ts
+++ b/packages/testing/playwright/composables/CredentialsComposer.ts
@@ -20,7 +20,6 @@ export class CredentialsComposer {
 			await this.n8n.navigate.toCredentials();
 		}
 
-		// Open the "new credential" chooser: open add resource -> credential
 		await this.n8n.credentials.addResource.credential();
 		await this.n8n.credentials.createCredentialFromCredentialPicker(credentialType, fields, {
 			name: options?.name,

--- a/packages/testing/playwright/composables/DataTablesComposer.ts
+++ b/packages/testing/playwright/composables/DataTablesComposer.ts
@@ -19,16 +19,21 @@ export class DataTableComposer {
 		projectName: string,
 		dataTableName: string,
 		source: 'empty-state' | 'header-dropdown',
+		fromDataTableTab: boolean = true,
 	) {
 		await this.n8n.projectComposer.createProject(projectName);
 		const { projectId } = await this.n8n.projectComposer.createProject();
-		await this.n8n.page.goto(`projects/${projectId}/datatables`);
 
-		await this.n8n.dataTable.clickDataTableProjectTab();
+		if (fromDataTableTab) {
+			await this.n8n.page.goto(`projects/${projectId}/datatables`);
+		} else {
+			await this.n8n.page.goto(`projects/${projectId}`);
+		}
+
 		if (source === 'empty-state') {
 			await this.n8n.dataTable.clickEmptyStateButton();
 		} else {
-			await this.n8n.dataTable.clickAddDataTableAction();
+			await this.n8n.dataTable.clickAddDataTableAction(fromDataTableTab);
 		}
 		await this.n8n.dataTableComposer.createNewDataTable(dataTableName);
 		await this.n8n.page.goto(`projects/${projectId}/datatables`);

--- a/packages/testing/playwright/pages/DataTableView.ts
+++ b/packages/testing/playwright/pages/DataTableView.ts
@@ -80,8 +80,8 @@ export class DataTableView extends BasePage {
 		await this.getEmptyStateActionBoxButton().click();
 	}
 
-	async clickAddDataTableAction() {
-		await this.addResource.dataTable();
+	async clickAddDataTableAction(fromDataTableTab: boolean = true) {
+		await this.addResource.dataTable(fromDataTableTab);
 	}
 
 	async clickDataTableCardActionsButton(dataTableName: string) {

--- a/packages/testing/playwright/pages/components/AddResource.ts
+++ b/packages/testing/playwright/pages/components/AddResource.ts
@@ -18,22 +18,6 @@ export class AddResource {
 		return this.page.getByTestId('add-resource-workflow');
 	}
 
-	getDropdownButton(): Locator {
-		return this.page.getByTestId('add-resource');
-	}
-
-	getCredentialAction(): Locator {
-		return this.page.getByTestId('action-credential');
-	}
-
-	getFolderAction(): Locator {
-		return this.page.getByTestId('action-folder');
-	}
-
-	getDataTableAction(): Locator {
-		return this.page.getByTestId('action-dataTable');
-	}
-
 	getAction(actionType: string): Locator {
 		return this.page.getByTestId(`action-${actionType}`);
 	}
@@ -43,17 +27,19 @@ export class AddResource {
 	}
 
 	async credential(): Promise<void> {
-		await this.getDropdownButton().click();
-		await this.getCredentialAction().click();
+		await this.page.getByTestId('add-resource-credential').click();
 	}
 
 	async folder(): Promise<void> {
-		await this.getDropdownButton().click();
-		await this.getFolderAction().click();
+		await this.page.getByTestId('add-resource-folder').click();
 	}
 
-	async dataTable(): Promise<void> {
-		await this.getDropdownButton().click();
-		await this.getDataTableAction().click();
+	async dataTable(fromDataTableTab: boolean = true): Promise<void> {
+		if (fromDataTableTab) {
+			await this.page.getByTestId('add-resource-dataTable').click();
+		} else {
+			await this.page.getByTestId('add-resource').click();
+			await this.page.getByTestId('action-dataTable').click();
+		}
 	}
 }

--- a/packages/testing/playwright/pages/components/AddResource.ts
+++ b/packages/testing/playwright/pages/components/AddResource.ts
@@ -31,7 +31,8 @@ export class AddResource {
 	}
 
 	async folder(): Promise<void> {
-		await this.page.getByTestId('add-resource-folder').click();
+		await this.page.getByTestId('add-resource').click();
+		await this.page.getByTestId('action-folder').click();
 	}
 
 	async dataTable(fromDataTableTab: boolean = true): Promise<void> {

--- a/packages/testing/playwright/tests/ui/data-tables.spec.ts
+++ b/packages/testing/playwright/tests/ui/data-tables.spec.ts
@@ -98,6 +98,20 @@ test.describe('Data Table list view', () => {
 		await expect(n8n.dataTable.getDataTableCardByName(TEST_DATA_TABLE_NAME)).toBeVisible();
 	});
 
+	test('Should create data table from workflows tab', async ({ n8n }) => {
+		const TEST_PROJECT_NAME = `Project ${nanoid(8)}`;
+		const TEST_DATA_TABLE_NAME = `Data Table ${nanoid(8)}`;
+
+		await n8n.dataTableComposer.createDataTableInNewProject(
+			TEST_PROJECT_NAME,
+			TEST_DATA_TABLE_NAME,
+			'header-dropdown',
+			false,
+		);
+
+		await expect(n8n.dataTable.getDataTableCardByName(TEST_DATA_TABLE_NAME)).toBeVisible();
+	});
+
 	test('Should delete data table from card actions', async ({ n8n }) => {
 		const TEST_PROJECT_NAME = `Project ${nanoid(8)}`;
 		const TEST_DATA_TABLE_NAME = `Data Table ${nanoid(8)}`;


### PR DESCRIPTION
## Summary

This has been requested multiple time as it's confusing to change tab and still have the main resource creation cta to be "Create workflow"

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4296/feature-make-the-top-right-create-button-contextual-to-the-page-it-is

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
