### PR TITLE
fix(core): Prevent duplicate nodeExecuteBefore events for agent nodes

### DIFF
--- a/packages/core/src/execution-engine/requests-response.ts
+++ b/packages/core/src/execution-engine/requests-response.ts
@@ -197,7 +197,7 @@ export function handleRequest({
 		parentOutputData: executionData.data.main as INodeExecutionData[][],
 		runIndex,
 		nodeRunIndex: runIndex,
-		metadata: { subNodeExecutionData },
+		metadata: { nodeWasResumed: true, subNodeExecutionData },
 	});
 
 	return { nodesToBeExecuted };

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2472,7 +2472,19 @@ export interface ITaskMetadata {
 		actions: SubNodeExecutionDataAction[];
 		metadata: object;
 	};
+	/**
+	 * When true, preserves sourceOverwrite information in pairedItem data during node execution.
+	 * This is used for AI tool nodes to maintain correct expression resolution context, allowing
+	 * tools to access data from nodes earlier in the workflow chain via $() expressions.
+	 */
 	preserveSourceOverwrite?: boolean;
+	/**
+	 * Indicates that this node execution is resuming from a previous pause (e.g., AI agent
+	 * resuming after tool execution). When true, the nodeExecuteBefore hook is skipped to
+	 * prevent duplicate event emissions that would cause UI state issues.
+	 * @see AI-1414
+	 */
+	nodeWasResumed?: boolean;
 }
 
 /** The data that gets returned when a node execution starts */


### PR DESCRIPTION
## Summary

Fixes agent nodes showing stuck spinner in the UI due to duplicate `nodeExecuteBefore` events. 

**Problem**: When AI agent nodes pause execution to run tool nodes and then resume with tool results, they were emitting `nodeExecuteBefore` twice (initial + resume) but `nodeExecuteAfter` only once. This caused the frontend's execution tracking queue to become unbalanced, leaving spinners stuck in "executing" state.


https://github.com/user-attachments/assets/9abc831c-0e68-499c-9286-6abf4903a3a1



**Solution**: Skip the `nodeExecuteBefore` hook when an agent node resumes execution after tool completion by setting and checking a `nodeWasResumed` metadata flag.

https://github.com/user-attachments/assets/3377fbef-2a94-4c13-ab8c-aaf9fc0e12b0




**Key changes**:
- Added `nodeWasResumed` flag to `ITaskMetadata` interface (optional for backward compatibility)
- Modified `handleRequest()` in `requests-response.ts` to set `nodeWasResumed: true` when re-scheduling agent node
- Updated `workflow-execute.ts` to skip `nodeExecuteBefore` hook if `nodeWasResumed` is true
- Added test verifying correct 1:1 pairing of before/after events
- Added JSDoc for both `nodeWasResumed` and `preserveSourceOverwrite` properties

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-1414
https://linear.app/n8n/issue/AI-1400/agent-v3-logs-not-correct-during-execution

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [ ] ~Docs updated or follow-up ticket created~
- [x] Tests included
- [ ] ~PR Labeled with `release/backport` (if urgent fix needed)~