### PR TITLE
feat(s3): add presigned url operation using AWS Signature V4 impl

### DIFF
--- a/packages/nodes-base/nodes/Aws/S3/V2/FileDescription.ts
+++ b/packages/nodes-base/nodes/Aws/S3/V2/FileDescription.ts
@@ -37,6 +37,12 @@ export const fileOperations: INodeProperties[] = [
 				action: 'Get many files',
 			},
 			{
+				name: 'Get Presigned URL',
+				value: 'getPresignedUrl',
+				description: 'Generate a presigned URL for temporary access to a file',
+				action: 'Get presigned URL for a file',
+			},
+			{
 				name: 'Upload',
 				value: 'upload',
 				description: 'Upload a file',
@@ -835,6 +841,85 @@ export const fileFields: INodeProperties[] = [
 				name: 'folderKey',
 				type: 'string',
 				default: '',
+			},
+		],
+	},
+	/* -------------------------------------------------------------------------- */
+	/*                          file:getPresignedUrl                              */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Bucket Name',
+		name: 'bucketName',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['file'],
+				operation: ['getPresignedUrl'],
+			},
+		},
+		description: 'Name of the S3 bucket',
+	},
+	{
+		displayName: 'File Key',
+		name: 'fileKey',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['file'],
+				operation: ['getPresignedUrl'],
+			},
+		},
+		description: 'Key (path) of the file in the bucket',
+	},
+	{
+		displayName: 'Expiration Time',
+		name: 'expirationTime',
+		type: 'number',
+		required: true,
+		default: 3600,
+		displayOptions: {
+			show: {
+				resource: ['file'],
+				operation: ['getPresignedUrl'],
+			},
+		},
+		description: 'Time in seconds until the presigned URL expires (default: 3600 = 1 hour)',
+		typeOptions: {
+			minValue: 1,
+			maxValue: 604800,
+		},
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		displayOptions: {
+			show: {
+				resource: ['file'],
+				operation: ['getPresignedUrl'],
+			},
+		},
+		default: {},
+		options: [
+			{
+				displayName: 'Response Content Type',
+				name: 'responseContentType',
+				type: 'string',
+				default: '',
+				description: 'Sets the Content-Type header of the response',
+			},
+			{
+				displayName: 'Response Content Disposition',
+				name: 'responseContentDisposition',
+				type: 'string',
+				default: '',
+				description:
+					'Sets the Content-Disposition header of the response (e.g., "attachment; filename=example.pdf")',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Aws/S3/V2/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/S3/V2/GenericFunctions.ts
@@ -1,3 +1,4 @@
+import { createHash, createHmac } from 'crypto';
 import get from 'lodash/get';
 import type {
 	IDataObject,
@@ -130,4 +131,105 @@ export async function awsApiRequestRESTAllItems(
 		get(responseData, [propertyName.split('.')[0], 'IsTruncated']) !== 'false'
 	);
 	return returnData;
+}
+
+function hmacSha256(key: Buffer | string, data: string): Buffer {
+	return createHmac('sha256', key).update(data).digest();
+}
+
+function getSignatureKey(
+	secretKey: string,
+	dateStamp: string,
+	regionName: string,
+	serviceName: string,
+): Buffer {
+	const kDate = hmacSha256('AWS4' + secretKey, dateStamp);
+	const kRegion = hmacSha256(kDate, regionName);
+	const kService = hmacSha256(kRegion, serviceName);
+	const kSigning = hmacSha256(kService, 'aws4_request');
+	return kSigning;
+}
+
+export async function generatePresignedUrl(
+	this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions | IWebhookFunctions,
+	bucketName: string,
+	fileKey: string,
+	expiresIn: number,
+	query: IDataObject = {},
+	region?: string,
+): Promise<string> {
+	const credentials = await this.getCredentials('aws');
+
+	const accessKeyId = `${credentials.accessKeyId}`.trim();
+	const secretAccessKey = `${credentials.secretAccessKey}`.trim();
+	const regionName = (region || credentials.region || 'us-east-1') as string;
+
+	// Determine the endpoint
+	let host: string;
+	let canonicalUri: string;
+
+	if (bucketName.includes('.')) {
+		// Bucket name contains dots, use path-style
+		host = `s3.${regionName}.amazonaws.com`;
+		canonicalUri = `/${bucketName}/${fileKey}`;
+	} else {
+		// Use virtual-hosted-style
+		host = `${bucketName}.s3.${regionName}.amazonaws.com`;
+		canonicalUri = `/${fileKey}`;
+	}
+
+	// Get current time
+	const now = new Date();
+	const amzDate = now
+		.toISOString()
+		.replace(/[-:]/g, '')
+		.replace(/\.\d{3}Z$/, 'Z');
+	const dateStamp = amzDate.substring(0, 8);
+	const credentialScope = `${dateStamp}/${regionName}/s3/aws4_request`;
+
+	// Build canonical query string
+	const queryParams: Record<string, string> = {
+		'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
+		'X-Amz-Credential': `${accessKeyId}/${credentialScope}`,
+		'X-Amz-Date': amzDate,
+		'X-Amz-Expires': expiresIn.toString(),
+		'X-Amz-SignedHeaders': 'host',
+	};
+
+	// Add session token if using temporary credentials
+	if (credentials.sessionToken) {
+		queryParams['X-Amz-Security-Token'] = `${credentials.sessionToken}`.trim();
+	}
+
+	// Add additional query parameters
+	Object.entries(query).forEach(([key, value]) => {
+		queryParams[key] = value as string;
+	});
+
+	// Sort query parameters
+	const sortedQueryParams = Object.keys(queryParams)
+		.sort()
+		.map((key) => `${encodeURIComponent(key)}=${encodeURIComponent(queryParams[key])}`)
+		.join('&');
+
+	// Build canonical request
+	const canonicalHeaders = `host:${host}\n`;
+	const signedHeaders = 'host';
+	const payloadHash = 'UNSIGNED-PAYLOAD';
+
+	const canonicalRequest = `GET\n${canonicalUri}\n${sortedQueryParams}\n${canonicalHeaders}\n${signedHeaders}\n${payloadHash}`;
+
+	// Create string to sign
+	const algorithm = 'AWS4-HMAC-SHA256';
+	const canonicalRequestHash = createHash('sha256').update(canonicalRequest).digest('hex');
+	const stringToSign = `${algorithm}\n${amzDate}\n${credentialScope}\n${canonicalRequestHash}`;
+
+	// Calculate signature
+	const signingKey = getSignatureKey(secretAccessKey, dateStamp, regionName, 's3');
+	const signature = hmacSha256(signingKey, stringToSign).toString('hex');
+
+	// Build final URL with signature
+	const finalUrl = `https://${host}${canonicalUri}?${sortedQueryParams}&X-Amz-Signature=${signature}`;
+
+	return finalUrl;
 }


### PR DESCRIPTION
## Summary

This PR adds a new `Get presigned URL for a file` operation to the AWS S3 Base Node.
It was very useful in my workflows for APIs that depend on presigned URLs and did not allow me to upload files directly.

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
