### PR TITLE
chore(core): Exposure of invite url configurable

### DIFF
--- a/packages/@n8n/config/src/configs/user-management.config.ts
+++ b/packages/@n8n/config/src/configs/user-management.config.ts
@@ -102,6 +102,10 @@ export class UserManagementConfig {
 	@Env('N8N_USER_MANAGEMENT_JWT_DURATION_HOURS')
 	jwtSessionDurationHours: number = 168;
 
+	/** Whether to hide the user invite link for admins */
+	@Env('N8N_HIDE_INVITE_LINK_FOR_ADMINS')
+	hideInviteLinkForAdmins: boolean = false;
+
 	/**
 	 * How long (in hours) before expiration to automatically refresh it.
 	 * - `0` means 25% of `N8N_USER_MANAGEMENT_JWT_DURATION_HOURS`.

--- a/packages/@n8n/config/src/configs/user-management.config.ts
+++ b/packages/@n8n/config/src/configs/user-management.config.ts
@@ -102,9 +102,15 @@ export class UserManagementConfig {
 	@Env('N8N_USER_MANAGEMENT_JWT_DURATION_HOURS')
 	jwtSessionDurationHours: number = 168;
 
-	/** Whether to hide the user invite link for admins */
-	@Env('N8N_HIDE_INVITE_LINK_FOR_ADMINS')
-	hideInviteLinkForAdmins: boolean = false;
+	/**
+	 * Security Control: Invite Link Exposure Prevention
+	 *
+	 * When enabled, prevents exposure of invite URLs in API responses to users
+	 * with 'user:create' permission, mitigating account takeover risks via
+	 * invite link leakage (e.g., compromised admin accounts, network interception).
+	 */
+	@Env('N8N_DISABLE_INVITE_LINK_EXPOSURE')
+	disableInviteLinkExposure: boolean = false;
 
 	/**
 	 * How long (in hours) before expiration to automatically refresh it.

--- a/packages/@n8n/config/src/configs/user-management.config.ts
+++ b/packages/@n8n/config/src/configs/user-management.config.ts
@@ -109,8 +109,8 @@ export class UserManagementConfig {
 	 * with 'user:create' permission, mitigating account takeover risks via
 	 * invite link leakage (e.g., compromised admin accounts, network interception).
 	 */
-	@Env('N8N_DISABLE_INVITE_LINK_EXPOSURE')
-	disableInviteLinkExposure: boolean = false;
+	@Env('N8N_INVITE_LINKS_EMAIL_ONLY')
+	inviteLinksEmailOnly: boolean = false;
 
 	/**
 	 * How long (in hours) before expiration to automatically refresh it.

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -109,6 +109,7 @@ describe('GlobalConfig', () => {
 			},
 		},
 		userManagement: {
+			disableInviteLinkExposure: false,
 			jwtSecret: '',
 			jwtSessionDurationHours: 168,
 			jwtRefreshTimeoutHours: 0,

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -109,7 +109,7 @@ describe('GlobalConfig', () => {
 			},
 		},
 		userManagement: {
-			disableInviteLinkExposure: false,
+			inviteLinksEmailOnly: false,
 			jwtSecret: '',
 			jwtSessionDurationHours: 168,
 			jwtRefreshTimeoutHours: 0,

--- a/packages/cli/src/controllers/__tests__/users.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/users.controller.test.ts
@@ -1,15 +1,21 @@
 import type { AuthenticatedRequest, User, UserRepository } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
 
+import { UsersController } from '../users.controller';
+
 import type { EventService } from '@/events/event.service';
 import type { ProjectService } from '@/services/project.service.ee';
-
-import { UsersController } from '../users.controller';
+import type { UserService } from '@/services/user.service';
+import type { GlobalConfig } from '@n8n/config';
+import type { PublicUser } from '@n8n/db';
 
 describe('UsersController', () => {
 	const eventService = mock<EventService>();
 	const userRepository = mock<UserRepository>();
 	const projectService = mock<ProjectService>();
+	const userService = mock<UserService>();
+	const globalConfig = mock<GlobalConfig>();
+
 	const controller = new UsersController(
 		mock(),
 		mock(),
@@ -17,17 +23,19 @@ describe('UsersController', () => {
 		mock(),
 		userRepository,
 		mock(),
-		mock(),
+		userService,
 		mock(),
 		mock(),
 		mock(),
 		projectService,
 		eventService,
 		mock(),
+		globalConfig,
 	);
 
 	beforeEach(() => {
 		jest.restoreAllMocks();
+		jest.clearAllMocks();
 	});
 
 	describe('changeGlobalRole', () => {
@@ -50,6 +58,215 @@ describe('UsersController', () => {
 				targetUserId: '456',
 				targetUserNewRole: 'global:member',
 				publicApi: false,
+			});
+		});
+	});
+
+	describe('listUsers - inviteUrl visibility', () => {
+		const createMockUser = (id: string, isPending = false, canCreateUsers = false): User => {
+			return mock<User>({
+				id,
+				email: `user${id}@example.com`,
+				isPending,
+				role: {
+					slug: 'global:member',
+					scopes: canCreateUsers ? [{ slug: 'user:create' }] : [],
+				} as any,
+				projectRelations: [],
+			});
+		};
+
+		const createPublicUser = (id: string, withInviteUrl = false, isPending = false): PublicUser => {
+			const publicUser: PublicUser = {
+				id,
+				email: `user${id}@example.com`,
+				firstName: 'Test',
+				lastName: 'User',
+				isPending,
+				role: 'global:member',
+				signInType: 'email',
+				isOwner: false,
+				mfaAuthenticated: false,
+				createdAt: new Date(),
+				disabled: false,
+			};
+
+			if (withInviteUrl && isPending) {
+				publicUser.inviteAcceptUrl = `http://localhost:5678/signup?inviterId=admin&inviteeId=${id}`;
+			}
+
+			return publicUser;
+		};
+
+		beforeEach(() => {
+			// Setup default mock behavior for userRepository.buildUserQuery
+			const mockQueryBuilder = {
+				getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+			};
+			userRepository.buildUserQuery.mockReturnValue(mockQueryBuilder as any);
+		});
+
+		describe('when disableInviteLinkExposure = false', () => {
+			beforeEach(() => {
+				globalConfig.userManagement = {
+					disableInviteLinkExposure: false,
+				} as any;
+			});
+
+			it('should include inviteAcceptUrl for users with scope user:create', async () => {
+				// Arrange
+				const adminUser = createMockUser('admin-id', false, true);
+				const pendingUser = createMockUser('pending-id', true);
+
+				const request = mock<AuthenticatedRequest>({
+					user: adminUser,
+				});
+
+				const mockQueryBuilder = {
+					getManyAndCount: jest.fn().mockResolvedValue([[pendingUser], 1]),
+				};
+				userRepository.buildUserQuery.mockReturnValue(mockQueryBuilder as any);
+
+				userService.toPublic.mockImplementation(async (user: User, options?: any) => {
+					return createPublicUser(user.id, options?.withInviteUrl === true, user.isPending);
+				});
+
+				// Act
+				const result = await controller.listUsers(request, mock(), {
+					skip: 0,
+					take: 10,
+				});
+
+				// Assert
+				expect(userService.toPublic).toHaveBeenCalledWith(
+					pendingUser,
+					expect.objectContaining({
+						withInviteUrl: true,
+						inviterId: 'admin-id',
+					}),
+				);
+
+				// Verify inviteAcceptUrl is present in the result
+				expect(result.items[0]).toHaveProperty('inviteAcceptUrl');
+			});
+
+			it('should NOT include inviteAcceptUrl for users without the user:create scope', async () => {
+				// Arrange
+				const memberUser = createMockUser('member-id');
+				const pendingUser = createMockUser('pending-id', true);
+
+				const request = mock<AuthenticatedRequest>({
+					user: memberUser,
+				});
+
+				const mockQueryBuilder = {
+					getManyAndCount: jest.fn().mockResolvedValue([[pendingUser], 1]),
+				};
+				userRepository.buildUserQuery.mockReturnValue(mockQueryBuilder as any);
+
+				userService.toPublic.mockImplementation(async (user: User, options?: any) => {
+					return createPublicUser(user.id, options?.withInviteUrl === true, user.isPending);
+				});
+
+				// Act
+				const result = await controller.listUsers(request, mock(), {
+					skip: 0,
+					take: 10,
+				});
+
+				// Assert
+				expect(userService.toPublic).toHaveBeenCalledWith(
+					pendingUser,
+					expect.objectContaining({
+						withInviteUrl: false,
+						inviterId: 'member-id',
+					}),
+				);
+
+				// Verify inviteAcceptUrl is NOT present in the result
+				expect(result.items[0]).not.toHaveProperty('inviteAcceptUrl');
+			});
+		});
+
+		describe('when disableInviteLinkExposure = true', () => {
+			beforeEach(() => {
+				globalConfig.userManagement = {
+					disableInviteLinkExposure: true,
+				} as any;
+			});
+
+			it('should NOT include inviteAcceptUrl for user with user:create scope', async () => {
+				// Arrange
+				const adminUser = createMockUser('admin-id', false, true);
+				const pendingUser = createMockUser('pending-id', true);
+
+				const request = mock<AuthenticatedRequest>({
+					user: adminUser,
+				});
+
+				const mockQueryBuilder = {
+					getManyAndCount: jest.fn().mockResolvedValue([[pendingUser], 1]),
+				};
+				userRepository.buildUserQuery.mockReturnValue(mockQueryBuilder as any);
+
+				userService.toPublic.mockImplementation(async (user: User, options?: any) => {
+					return createPublicUser(user.id, options?.withInviteUrl === true, user.isPending);
+				});
+
+				// Act
+				const result = await controller.listUsers(request, mock(), {
+					skip: 0,
+					take: 10,
+				});
+
+				// Assert
+				expect(userService.toPublic).toHaveBeenCalledWith(
+					pendingUser,
+					expect.objectContaining({
+						withInviteUrl: false, // Config overrides scope permission
+						inviterId: 'admin-id',
+					}),
+				);
+
+				// Verify inviteAcceptUrl is NOT present in the result
+				expect(result.items[0]).not.toHaveProperty('inviteAcceptUrl');
+			});
+
+			it('should NOT include inviteAcceptUrl for users without the user:create scope', async () => {
+				// Arrange
+				const memberUser = createMockUser('member-id');
+				const pendingUser = createMockUser('pending-id', true);
+
+				const request = mock<AuthenticatedRequest>({
+					user: memberUser,
+				});
+
+				const mockQueryBuilder = {
+					getManyAndCount: jest.fn().mockResolvedValue([[pendingUser], 1]),
+				};
+				userRepository.buildUserQuery.mockReturnValue(mockQueryBuilder as any);
+
+				userService.toPublic.mockImplementation(async (user: User, options?: any) => {
+					return createPublicUser(user.id, options?.withInviteUrl === true, user.isPending);
+				});
+
+				// Act
+				const result = await controller.listUsers(request, mock(), {
+					skip: 0,
+					take: 10,
+				});
+
+				// Assert
+				expect(userService.toPublic).toHaveBeenCalledWith(
+					pendingUser,
+					expect.objectContaining({
+						withInviteUrl: false,
+						inviterId: 'member-id',
+					}),
+				);
+
+				// Verify inviteAcceptUrl is NOT present in the result
+				expect(result.items[0]).not.toHaveProperty('inviteAcceptUrl');
 			});
 		});
 	});

--- a/packages/cli/src/controllers/__tests__/users.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/users.controller.test.ts
@@ -106,10 +106,10 @@ describe('UsersController', () => {
 			userRepository.buildUserQuery.mockReturnValue(mockQueryBuilder as any);
 		});
 
-		describe('when disableInviteLinkExposure = false', () => {
+		describe('when inviteLinksEmailOnly = false', () => {
 			beforeEach(() => {
 				globalConfig.userManagement = {
-					disableInviteLinkExposure: false,
+					inviteLinksEmailOnly: false,
 				} as any;
 			});
 
@@ -188,10 +188,10 @@ describe('UsersController', () => {
 			});
 		});
 
-		describe('when disableInviteLinkExposure = true', () => {
+		describe('when inviteLinksEmailOnly = true', () => {
 			beforeEach(() => {
 				globalConfig.userManagement = {
-					disableInviteLinkExposure: true,
+					inviteLinksEmailOnly: true,
 				} as any;
 			});
 

--- a/packages/cli/src/controllers/__tests__/users.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/users.controller.test.ts
@@ -1,20 +1,17 @@
 import type { AuthenticatedRequest, User, UserRepository } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
 
-import { UsersController } from '../users.controller';
-
 import type { EventService } from '@/events/event.service';
 import type { ProjectService } from '@/services/project.service.ee';
 import type { UserService } from '@/services/user.service';
-import type { GlobalConfig } from '@n8n/config';
-import type { PublicUser } from '@n8n/db';
+
+import { UsersController } from '../users.controller';
 
 describe('UsersController', () => {
 	const eventService = mock<EventService>();
 	const userRepository = mock<UserRepository>();
 	const projectService = mock<ProjectService>();
 	const userService = mock<UserService>();
-	const globalConfig = mock<GlobalConfig>();
 
 	const controller = new UsersController(
 		mock(),
@@ -30,7 +27,6 @@ describe('UsersController', () => {
 		projectService,
 		eventService,
 		mock(),
-		globalConfig,
 	);
 
 	beforeEach(() => {
@@ -58,215 +54,6 @@ describe('UsersController', () => {
 				targetUserId: '456',
 				targetUserNewRole: 'global:member',
 				publicApi: false,
-			});
-		});
-	});
-
-	describe('listUsers - inviteUrl visibility', () => {
-		const createMockUser = (id: string, isPending = false, canCreateUsers = false): User => {
-			return mock<User>({
-				id,
-				email: `user${id}@example.com`,
-				isPending,
-				role: {
-					slug: 'global:member',
-					scopes: canCreateUsers ? [{ slug: 'user:create' }] : [],
-				} as any,
-				projectRelations: [],
-			});
-		};
-
-		const createPublicUser = (id: string, withInviteUrl = false, isPending = false): PublicUser => {
-			const publicUser: PublicUser = {
-				id,
-				email: `user${id}@example.com`,
-				firstName: 'Test',
-				lastName: 'User',
-				isPending,
-				role: 'global:member',
-				signInType: 'email',
-				isOwner: false,
-				mfaAuthenticated: false,
-				createdAt: new Date(),
-				disabled: false,
-			};
-
-			if (withInviteUrl && isPending) {
-				publicUser.inviteAcceptUrl = `http://localhost:5678/signup?inviterId=admin&inviteeId=${id}`;
-			}
-
-			return publicUser;
-		};
-
-		beforeEach(() => {
-			// Setup default mock behavior for userRepository.buildUserQuery
-			const mockQueryBuilder = {
-				getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
-			};
-			userRepository.buildUserQuery.mockReturnValue(mockQueryBuilder as any);
-		});
-
-		describe('when inviteLinksEmailOnly = false', () => {
-			beforeEach(() => {
-				globalConfig.userManagement = {
-					inviteLinksEmailOnly: false,
-				} as any;
-			});
-
-			it('should include inviteAcceptUrl for users with scope user:create', async () => {
-				// Arrange
-				const adminUser = createMockUser('admin-id', false, true);
-				const pendingUser = createMockUser('pending-id', true);
-
-				const request = mock<AuthenticatedRequest>({
-					user: adminUser,
-				});
-
-				const mockQueryBuilder = {
-					getManyAndCount: jest.fn().mockResolvedValue([[pendingUser], 1]),
-				};
-				userRepository.buildUserQuery.mockReturnValue(mockQueryBuilder as any);
-
-				userService.toPublic.mockImplementation(async (user: User, options?: any) => {
-					return createPublicUser(user.id, options?.withInviteUrl === true, user.isPending);
-				});
-
-				// Act
-				const result = await controller.listUsers(request, mock(), {
-					skip: 0,
-					take: 10,
-				});
-
-				// Assert
-				expect(userService.toPublic).toHaveBeenCalledWith(
-					pendingUser,
-					expect.objectContaining({
-						withInviteUrl: true,
-						inviterId: 'admin-id',
-					}),
-				);
-
-				// Verify inviteAcceptUrl is present in the result
-				expect(result.items[0]).toHaveProperty('inviteAcceptUrl');
-			});
-
-			it('should NOT include inviteAcceptUrl for users without the user:create scope', async () => {
-				// Arrange
-				const memberUser = createMockUser('member-id');
-				const pendingUser = createMockUser('pending-id', true);
-
-				const request = mock<AuthenticatedRequest>({
-					user: memberUser,
-				});
-
-				const mockQueryBuilder = {
-					getManyAndCount: jest.fn().mockResolvedValue([[pendingUser], 1]),
-				};
-				userRepository.buildUserQuery.mockReturnValue(mockQueryBuilder as any);
-
-				userService.toPublic.mockImplementation(async (user: User, options?: any) => {
-					return createPublicUser(user.id, options?.withInviteUrl === true, user.isPending);
-				});
-
-				// Act
-				const result = await controller.listUsers(request, mock(), {
-					skip: 0,
-					take: 10,
-				});
-
-				// Assert
-				expect(userService.toPublic).toHaveBeenCalledWith(
-					pendingUser,
-					expect.objectContaining({
-						withInviteUrl: false,
-						inviterId: 'member-id',
-					}),
-				);
-
-				// Verify inviteAcceptUrl is NOT present in the result
-				expect(result.items[0]).not.toHaveProperty('inviteAcceptUrl');
-			});
-		});
-
-		describe('when inviteLinksEmailOnly = true', () => {
-			beforeEach(() => {
-				globalConfig.userManagement = {
-					inviteLinksEmailOnly: true,
-				} as any;
-			});
-
-			it('should NOT include inviteAcceptUrl for user with user:create scope', async () => {
-				// Arrange
-				const adminUser = createMockUser('admin-id', false, true);
-				const pendingUser = createMockUser('pending-id', true);
-
-				const request = mock<AuthenticatedRequest>({
-					user: adminUser,
-				});
-
-				const mockQueryBuilder = {
-					getManyAndCount: jest.fn().mockResolvedValue([[pendingUser], 1]),
-				};
-				userRepository.buildUserQuery.mockReturnValue(mockQueryBuilder as any);
-
-				userService.toPublic.mockImplementation(async (user: User, options?: any) => {
-					return createPublicUser(user.id, options?.withInviteUrl === true, user.isPending);
-				});
-
-				// Act
-				const result = await controller.listUsers(request, mock(), {
-					skip: 0,
-					take: 10,
-				});
-
-				// Assert
-				expect(userService.toPublic).toHaveBeenCalledWith(
-					pendingUser,
-					expect.objectContaining({
-						withInviteUrl: false, // Config overrides scope permission
-						inviterId: 'admin-id',
-					}),
-				);
-
-				// Verify inviteAcceptUrl is NOT present in the result
-				expect(result.items[0]).not.toHaveProperty('inviteAcceptUrl');
-			});
-
-			it('should NOT include inviteAcceptUrl for users without the user:create scope', async () => {
-				// Arrange
-				const memberUser = createMockUser('member-id');
-				const pendingUser = createMockUser('pending-id', true);
-
-				const request = mock<AuthenticatedRequest>({
-					user: memberUser,
-				});
-
-				const mockQueryBuilder = {
-					getManyAndCount: jest.fn().mockResolvedValue([[pendingUser], 1]),
-				};
-				userRepository.buildUserQuery.mockReturnValue(mockQueryBuilder as any);
-
-				userService.toPublic.mockImplementation(async (user: User, options?: any) => {
-					return createPublicUser(user.id, options?.withInviteUrl === true, user.isPending);
-				});
-
-				// Act
-				const result = await controller.listUsers(request, mock(), {
-					skip: 0,
-					take: 10,
-				});
-
-				// Assert
-				expect(userService.toPublic).toHaveBeenCalledWith(
-					pendingUser,
-					expect.objectContaining({
-						withInviteUrl: false,
-						inviterId: 'member-id',
-					}),
-				);
-
-				// Verify inviteAcceptUrl is NOT present in the result
-				expect(result.items[0]).not.toHaveProperty('inviteAcceptUrl');
 			});
 		});
 	});

--- a/packages/cli/src/controllers/__tests__/users.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/users.controller.test.ts
@@ -3,7 +3,6 @@ import { mock } from 'jest-mock-extended';
 
 import type { EventService } from '@/events/event.service';
 import type { ProjectService } from '@/services/project.service.ee';
-import type { UserService } from '@/services/user.service';
 
 import { UsersController } from '../users.controller';
 
@@ -11,7 +10,6 @@ describe('UsersController', () => {
 	const eventService = mock<EventService>();
 	const userRepository = mock<UserRepository>();
 	const projectService = mock<ProjectService>();
-	const userService = mock<UserService>();
 
 	const controller = new UsersController(
 		mock(),
@@ -20,7 +18,7 @@ describe('UsersController', () => {
 		mock(),
 		userRepository,
 		mock(),
-		userService,
+		mock(),
 		mock(),
 		mock(),
 		mock(),
@@ -31,7 +29,6 @@ describe('UsersController', () => {
 
 	beforeEach(() => {
 		jest.restoreAllMocks();
-		jest.clearAllMocks();
 	});
 
 	describe('changeGlobalRole', () => {

--- a/packages/cli/src/controllers/users.controller.ts
+++ b/packages/cli/src/controllers/users.controller.ts
@@ -7,6 +7,7 @@ import {
 	usersListSchema,
 } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
+import { GlobalConfig } from '@n8n/config';
 import type { PublicUser } from '@n8n/db';
 import {
 	Project,
@@ -31,6 +32,7 @@ import {
 	Param,
 	Query,
 } from '@n8n/decorators';
+import { hasGlobalScope } from '@n8n/permissions';
 import { Response } from 'express';
 
 import { AuthService } from '@/auth/auth.service';
@@ -45,9 +47,6 @@ import { FolderService } from '@/services/folder.service';
 import { ProjectService } from '@/services/project.service.ee';
 import { UserService } from '@/services/user.service';
 import { WorkflowService } from '@/workflows/workflow.service';
-import { hasGlobalScope } from '@n8n/permissions';
-import { GlobalConfig } from '@n8n/config';
-import { Container } from '@n8n/di';
 
 @RestController('/users')
 export class UsersController {
@@ -65,6 +64,7 @@ export class UsersController {
 		private readonly projectService: ProjectService,
 		private readonly eventService: EventService,
 		private readonly folderService: FolderService,
+		private readonly globalConfig: GlobalConfig,
 	) {}
 
 	static ERROR_MESSAGES = {
@@ -119,10 +119,9 @@ export class UsersController {
 
 		const [users, count] = response;
 
-		const hideInviteLinkForAdmins =
-			Container.get(GlobalConfig).userManagement.hideInviteLinkForAdmins;
+		const disableInviteLinkExposure = this.globalConfig.userManagement.disableInviteLinkExposure;
 
-		const withInviteUrl = !hideInviteLinkForAdmins && hasGlobalScope(req.user, 'user:create');
+		const withInviteUrl = !disableInviteLinkExposure && hasGlobalScope(req.user, 'user:create');
 
 		const publicUsers = await Promise.all(
 			users.map(async (u) => {

--- a/packages/cli/src/controllers/users.controller.ts
+++ b/packages/cli/src/controllers/users.controller.ts
@@ -46,6 +46,8 @@ import { ProjectService } from '@/services/project.service.ee';
 import { UserService } from '@/services/user.service';
 import { WorkflowService } from '@/workflows/workflow.service';
 import { hasGlobalScope } from '@n8n/permissions';
+import { GlobalConfig } from '@n8n/config';
+import { Container } from '@n8n/di';
 
 @RestController('/users')
 export class UsersController {
@@ -117,7 +119,10 @@ export class UsersController {
 
 		const [users, count] = response;
 
-		const withInviteUrl = hasGlobalScope(req.user, 'user:create');
+		const hideInviteLinkForAdmins =
+			Container.get(GlobalConfig).userManagement.hideInviteLinkForAdmins;
+
+		const withInviteUrl = !hideInviteLinkForAdmins && hasGlobalScope(req.user, 'user:create');
 
 		const publicUsers = await Promise.all(
 			users.map(async (u) => {

--- a/packages/cli/src/controllers/users.controller.ts
+++ b/packages/cli/src/controllers/users.controller.ts
@@ -119,9 +119,9 @@ export class UsersController {
 
 		const [users, count] = response;
 
-		const disableInviteLinkExposure = this.globalConfig.userManagement.disableInviteLinkExposure;
+		const inviteLinksEmailOnly = this.globalConfig.userManagement.inviteLinksEmailOnly;
 
-		const withInviteUrl = !disableInviteLinkExposure && hasGlobalScope(req.user, 'user:create');
+		const withInviteUrl = !inviteLinksEmailOnly && hasGlobalScope(req.user, 'user:create');
 
 		const publicUsers = await Promise.all(
 			users.map(async (u) => {

--- a/packages/cli/src/controllers/users.controller.ts
+++ b/packages/cli/src/controllers/users.controller.ts
@@ -7,7 +7,6 @@ import {
 	usersListSchema,
 } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
-import { GlobalConfig } from '@n8n/config';
 import type { PublicUser } from '@n8n/db';
 import {
 	Project,
@@ -64,7 +63,6 @@ export class UsersController {
 		private readonly projectService: ProjectService,
 		private readonly eventService: EventService,
 		private readonly folderService: FolderService,
-		private readonly globalConfig: GlobalConfig,
 	) {}
 
 	static ERROR_MESSAGES = {
@@ -119,9 +117,7 @@ export class UsersController {
 
 		const [users, count] = response;
 
-		const inviteLinksEmailOnly = this.globalConfig.userManagement.inviteLinksEmailOnly;
-
-		const withInviteUrl = !inviteLinksEmailOnly && hasGlobalScope(req.user, 'user:create');
+		const withInviteUrl = hasGlobalScope(req.user, 'user:create');
 
 		const publicUsers = await Promise.all(
 			users.map(async (u) => {

--- a/packages/cli/src/services/__tests__/user.service.test.ts
+++ b/packages/cli/src/services/__tests__/user.service.test.ts
@@ -9,6 +9,7 @@ import { v4 as uuid } from 'uuid';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { UrlService } from '@/services/url.service';
 import { UserService } from '@/services/user.service';
+import type { UserManagementMailer } from '@/user-management/email';
 
 import type { RoleService } from '../role.service';
 
@@ -29,10 +30,11 @@ describe('UserService', () => {
 		}),
 	});
 	const roleService = mock<RoleService>();
+	const mailer = mock<UserManagementMailer>();
 	const userService = new UserService(
 		mock(),
 		userRepository,
-		mock(),
+		mailer,
 		urlService,
 		mock(),
 		mock(),
@@ -44,6 +46,10 @@ describe('UserService', () => {
 		id: uuid(),
 		password: 'passwordHash',
 		role: GLOBAL_MEMBER_ROLE,
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
 	});
 
 	describe('toPublic', () => {
@@ -106,26 +112,145 @@ describe('UserService', () => {
 
 	describe('inviteUrl visibility', () => {
 		describe('when inviteLinksEmailOnly = false', () => {
+			beforeEach(() => {
+				globalConfig.userManagement.inviteLinksEmailOnly = false;
+			});
+
 			describe('toPublic', () => {
-				it('should include inviteAcceptUrl if requested', async () => {});
-				it('should not include inviteAcceptUrl if not requested', async () => {});
+				it('should include inviteAcceptUrl if requested', async () => {
+					const inviter = Object.assign(new User(), { id: uuid(), role: GLOBAL_MEMBER_ROLE });
+					const pendingUser = Object.assign(new User(), {
+						id: uuid(),
+						role: GLOBAL_MEMBER_ROLE,
+						isPending: true,
+					});
+
+					const result = await userService.toPublic(pendingUser, {
+						withInviteUrl: true,
+						inviterId: inviter.id,
+					});
+
+					expect(result.inviteAcceptUrl).toBeDefined();
+					const url = new URL(result.inviteAcceptUrl ?? '');
+					expect(url.searchParams.get('inviterId')).toBe(inviter.id);
+					expect(url.searchParams.get('inviteeId')).toBe(pendingUser.id);
+				});
+
+				it('should not include inviteAcceptUrl if not requested', async () => {
+					const pendingUser = Object.assign(new User(), {
+						id: uuid(),
+						role: GLOBAL_MEMBER_ROLE,
+						isPending: true,
+					});
+
+					const result = await userService.toPublic(pendingUser);
+
+					expect(result.inviteAcceptUrl).toBeUndefined();
+				});
 			});
 
 			describe('inviteUsers', () => {
-				it('should include inviteAcceptUrl if email was not sent', async () => {});
-				it('should not include inviteAcceptUrl if email was sent', async () => {});
+				it('should include inviteAcceptUrl if email was not sent', async () => {
+					const owner = Object.assign(new User(), { id: uuid(), role: GLOBAL_ADMIN_ROLE });
+					const invitations = [{ email: 'test@example.com', role: GLOBAL_MEMBER_ROLE.slug }];
+
+					roleService.checkRolesExist.mockResolvedValue();
+					userRepository.findManyByEmail.mockResolvedValue([]);
+					userRepository.createUserWithProject.mockImplementation(async (userData) => {
+						return { user: { ...userData, id: uuid() } as User, project: mock<Project>() };
+					});
+					mailer.invite.mockResolvedValue({ emailSent: false });
+
+					const result = await userService.inviteUsers(owner, invitations);
+
+					expect(result.usersInvited[0].user.inviteAcceptUrl).toBeDefined();
+				});
+
+				it('should not include inviteAcceptUrl if email was sent', async () => {
+					const owner = Object.assign(new User(), { id: uuid(), role: GLOBAL_ADMIN_ROLE });
+					const invitations = [{ email: 'test@example.com', role: GLOBAL_MEMBER_ROLE.slug }];
+
+					roleService.checkRolesExist.mockResolvedValue();
+					userRepository.findManyByEmail.mockResolvedValue([]);
+					userRepository.createUserWithProject.mockImplementation(async (userData) => {
+						return { user: { ...userData, id: uuid() } as User, project: mock<Project>() };
+					});
+					mailer.invite.mockResolvedValue({ emailSent: true });
+
+					const result = await userService.inviteUsers(owner, invitations);
+
+					expect(result.usersInvited[0].user.inviteAcceptUrl).toBeUndefined();
+				});
 			});
 		});
 
 		describe('when inviteLinksEmailOnly = true', () => {
+			beforeEach(() => {
+				globalConfig.userManagement.inviteLinksEmailOnly = true;
+			});
+
 			describe('toPublic', () => {
-				it('should not include inviteAcceptUrl if requested', async () => {});
-				it('should not include inviteAcceptUrl if not requested', async () => {});
+				it('should not include inviteAcceptUrl if requested', async () => {
+					const inviter = Object.assign(new User(), { id: uuid(), role: GLOBAL_MEMBER_ROLE });
+					const pendingUser = Object.assign(new User(), {
+						id: uuid(),
+						role: GLOBAL_MEMBER_ROLE,
+						isPending: true,
+					});
+
+					const result = await userService.toPublic(pendingUser, {
+						withInviteUrl: true,
+						inviterId: inviter.id,
+					});
+
+					expect(result.inviteAcceptUrl).toBeUndefined();
+				});
+
+				it('should not include inviteAcceptUrl if not requested', async () => {
+					const pendingUser = Object.assign(new User(), {
+						id: uuid(),
+						role: GLOBAL_MEMBER_ROLE,
+						isPending: true,
+					});
+
+					const result = await userService.toPublic(pendingUser);
+
+					expect(result.inviteAcceptUrl).toBeUndefined();
+				});
 			});
 
 			describe('inviteUsers', () => {
-				it('should not include inviteAcceptUrl if email was not sent', async () => {});
-				it('should not include inviteAcceptUrl if email was sent', async () => {});
+				it('should not include inviteAcceptUrl if email was not sent', async () => {
+					const owner = Object.assign(new User(), { id: uuid(), role: GLOBAL_ADMIN_ROLE });
+					const invitations = [{ email: 'test@example.com', role: GLOBAL_MEMBER_ROLE.slug }];
+
+					roleService.checkRolesExist.mockResolvedValue();
+					userRepository.findManyByEmail.mockResolvedValue([]);
+					userRepository.createUserWithProject.mockImplementation(async (userData) => {
+						return { user: { ...userData, id: uuid() } as User, project: mock<Project>() };
+					});
+					mailer.invite.mockResolvedValue({ emailSent: false });
+
+					const result = await userService.inviteUsers(owner, invitations);
+
+					expect(result.usersInvited[0].user.inviteAcceptUrl).toBeUndefined();
+				});
+
+				it('should not include inviteAcceptUrl if email was sent', async () => {
+					const owner = Object.assign(new User(), { id: uuid(), role: GLOBAL_ADMIN_ROLE });
+					const invitations = [{ email: 'test@example.com', role: GLOBAL_MEMBER_ROLE.slug }];
+
+					roleService.checkRolesExist.mockResolvedValue();
+					userRepository.findManyByEmail.mockResolvedValue([]);
+					userRepository.createUserWithProject.mockImplementation(async (userData) => {
+						return { user: { ...userData, id: uuid() } as User, project: mock<Project>() };
+					});
+					mailer.invite.mockResolvedValue({ emailSent: true });
+
+					const result = await userService.inviteUsers(owner, invitations);
+
+					expect(result.usersInvited[0].user.inviteAcceptUrl).toBeUndefined();
+				});
 			});
 		});
 	});

--- a/packages/cli/src/services/__tests__/user.service.test.ts
+++ b/packages/cli/src/services/__tests__/user.service.test.ts
@@ -37,6 +37,7 @@ describe('UserService', () => {
 		mock(),
 		mock(),
 		roleService,
+		globalConfig,
 	);
 
 	const commonMockUser = Object.assign(new User(), {
@@ -100,6 +101,32 @@ describe('UserService', () => {
 
 			expect(url.searchParams.get('inviterId')).toBe(firstUser.id);
 			expect(url.searchParams.get('inviteeId')).toBe(secondUser.id);
+		});
+	});
+
+	describe('inviteUrl visibility', () => {
+		describe('when inviteLinksEmailOnly = false', () => {
+			describe('toPublic', () => {
+				it('should include inviteAcceptUrl if requested', async () => {});
+				it('should not include inviteAcceptUrl if not requested', async () => {});
+			});
+
+			describe('inviteUsers', () => {
+				it('should include inviteAcceptUrl if email was not sent', async () => {});
+				it('should not include inviteAcceptUrl if email was sent', async () => {});
+			});
+		});
+
+		describe('when inviteLinksEmailOnly = true', () => {
+			describe('toPublic', () => {
+				it('should not include inviteAcceptUrl if requested', async () => {});
+				it('should not include inviteAcceptUrl if not requested', async () => {});
+			});
+
+			describe('inviteUsers', () => {
+				it('should not include inviteAcceptUrl if email was not sent', async () => {});
+				it('should not include inviteAcceptUrl if email was sent', async () => {});
+			});
 		});
 	});
 

--- a/packages/cli/src/services/__tests__/user.service.test.ts
+++ b/packages/cli/src/services/__tests__/user.service.test.ts
@@ -118,7 +118,7 @@ describe('UserService', () => {
 
 			describe('toPublic', () => {
 				it('should include inviteAcceptUrl if requested', async () => {
-					const inviter = Object.assign(new User(), { id: uuid(), role: GLOBAL_MEMBER_ROLE });
+					const inviter = Object.assign(new User(), { id: uuid(), role: GLOBAL_ADMIN_ROLE });
 					const pendingUser = Object.assign(new User(), {
 						id: uuid(),
 						role: GLOBAL_MEMBER_ROLE,
@@ -137,13 +137,16 @@ describe('UserService', () => {
 				});
 
 				it('should not include inviteAcceptUrl if not requested', async () => {
+					const inviter = Object.assign(new User(), { id: uuid(), role: GLOBAL_ADMIN_ROLE });
 					const pendingUser = Object.assign(new User(), {
 						id: uuid(),
 						role: GLOBAL_MEMBER_ROLE,
 						isPending: true,
 					});
 
-					const result = await userService.toPublic(pendingUser);
+					const result = await userService.toPublic(pendingUser, {
+						inviterId: inviter.id,
+					});
 
 					expect(result.inviteAcceptUrl).toBeUndefined();
 				});
@@ -191,7 +194,7 @@ describe('UserService', () => {
 
 			describe('toPublic', () => {
 				it('should not include inviteAcceptUrl if requested', async () => {
-					const inviter = Object.assign(new User(), { id: uuid(), role: GLOBAL_MEMBER_ROLE });
+					const inviter = Object.assign(new User(), { id: uuid(), role: GLOBAL_ADMIN_ROLE });
 					const pendingUser = Object.assign(new User(), {
 						id: uuid(),
 						role: GLOBAL_MEMBER_ROLE,
@@ -207,13 +210,16 @@ describe('UserService', () => {
 				});
 
 				it('should not include inviteAcceptUrl if not requested', async () => {
+					const inviter = Object.assign(new User(), { id: uuid(), role: GLOBAL_ADMIN_ROLE });
 					const pendingUser = Object.assign(new User(), {
 						id: uuid(),
 						role: GLOBAL_MEMBER_ROLE,
 						isPending: true,
 					});
 
-					const result = await userService.toPublic(pendingUser);
+					const result = await userService.toPublic(pendingUser, {
+						inviterId: inviter.id,
+					});
 
 					expect(result.inviteAcceptUrl).toBeUndefined();
 				});

--- a/packages/cli/src/services/user.service.ts
+++ b/packages/cli/src/services/user.service.ts
@@ -17,6 +17,7 @@ import { UserManagementMailer } from '@/user-management/email';
 
 import { PublicApiKeyService } from './public-api-key.service';
 import { RoleService } from './role.service';
+import { GlobalConfig } from '@n8n/config';
 
 @Service()
 export class UserService {
@@ -28,6 +29,7 @@ export class UserService {
 		private readonly eventService: EventService,
 		private readonly publicApiKeyService: PublicApiKeyService,
 		private readonly roleService: RoleService,
+		private readonly globalConfig: GlobalConfig,
 	) {}
 
 	async update(userId: string, data: Partial<User>) {
@@ -78,11 +80,17 @@ export class UserService {
 			isOwner: user.role.slug === 'global:owner',
 		};
 
-		if (options?.withInviteUrl && !options?.inviterId) {
-			throw new UnexpectedError('Inviter ID is required to generate invite URL');
-		}
+		const inviteLinksEmailOnly = this.globalConfig.userManagement.inviteLinksEmailOnly;
 
-		if (options?.withInviteUrl && options?.inviterId && publicUser.isPending) {
+		if (
+			!inviteLinksEmailOnly &&
+			options?.withInviteUrl &&
+			options?.inviterId &&
+			publicUser.isPending
+		) {
+			if (options?.withInviteUrl && !options?.inviterId) {
+				throw new UnexpectedError('Inviter ID is required to generate invite URL');
+			}
 			publicUser = this.addInviteUrl(options.inviterId, publicUser);
 		}
 
@@ -135,6 +143,8 @@ export class UserService {
 	) {
 		const domain = this.urlService.getInstanceBaseUrl();
 
+		const inviteLinksEmailOnly = this.globalConfig.userManagement.inviteLinksEmailOnly;
+
 		return await Promise.all(
 			Object.entries(toInviteUsers).map(async ([email, id]) => {
 				const inviteAcceptUrl = `${domain}/signup?inviterId=${owner.id}&inviteeId=${id}`;
@@ -142,7 +152,6 @@ export class UserService {
 					user: {
 						id,
 						email,
-						inviteAcceptUrl,
 						emailSent: false,
 						role,
 					},
@@ -156,13 +165,19 @@ export class UserService {
 					});
 					if (result.emailSent) {
 						invitedUser.user.emailSent = true;
-						delete invitedUser.user?.inviteAcceptUrl;
 
 						this.eventService.emit('user-transactional-email-sent', {
 							userId: id,
 							messageType: 'New user invite',
 							publicApi: false,
 						});
+					}
+
+					// Only include the invite URL in the response if
+					// the users configuration allows it
+					// and the email was not sent (to allow manual copy-paste)
+					if (!inviteLinksEmailOnly && !result.emailSent) {
+						invitedUser.user.inviteAcceptUrl = inviteAcceptUrl;
 					}
 
 					this.eventService.emit('user-invited', {

--- a/packages/cli/src/services/user.service.ts
+++ b/packages/cli/src/services/user.service.ts
@@ -80,6 +80,10 @@ export class UserService {
 			isOwner: user.role.slug === 'global:owner',
 		};
 
+		if (options?.withInviteUrl && !options?.inviterId) {
+			throw new UnexpectedError('Inviter ID is required to generate invite URL');
+		}
+
 		const inviteLinksEmailOnly = this.globalConfig.userManagement.inviteLinksEmailOnly;
 
 		if (
@@ -88,9 +92,6 @@ export class UserService {
 			options?.inviterId &&
 			publicUser.isPending
 		) {
-			if (options?.withInviteUrl && !options?.inviterId) {
-				throw new UnexpectedError('Inviter ID is required to generate invite URL');
-			}
 			publicUser = this.addInviteUrl(options.inviterId, publicUser);
 		}
 


### PR DESCRIPTION
## Summary

Introduces a new setting `N8N_INVITE_LINKS_EMAIL_ONLY`, which prevents the exposure of invite links to accounts that are allowed to create new users. This is a security hardening setting. Once SMTP settings are set up, this can be activated so that each new user receives their invite link only via email.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-3966/zero-click-account-takeover

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
