### PR TITLE
feat(core): Add endpoints for reading conversations (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/chat-hub.ts
+++ b/packages/@n8n/api-types/src/chat-hub.ts
@@ -79,8 +79,8 @@ export type ChatHubMessage = z.infer<typeof chatHubMessageSchema>;
 export const chatHubConversationSchema = z.object({
 	id: z.string().uuid(),
 	title: z.string(),
-	createdAt: z.string().datetime(),
-	updatedAt: z.string().datetime(),
+	createdAt: z.date(),
+	updatedAt: z.date(),
 });
 
 export type ChatHubConversation = z.infer<typeof chatHubConversationSchema>;

--- a/packages/@n8n/api-types/src/chat-hub.ts
+++ b/packages/@n8n/api-types/src/chat-hub.ts
@@ -49,6 +49,7 @@ export type ChatModelsResponse = Record<
 export class ChatHubSendMessageRequest extends Z.class({
 	messageId: z.string().uuid(),
 	sessionId: z.string().uuid(),
+	replyId: z.string().uuid(),
 	message: z.string(),
 	model: chatHubConversationModelSchema,
 	previousMessageId: z.string().uuid().nullable(),
@@ -104,25 +105,14 @@ export interface ChatHubMessageDto {
 	revisionIds: ChatMessageId[];
 }
 
-export interface ChatHubMessageTurnDto {
-	id: ChatMessageId;
-	rootMessageId: ChatMessageId;
-	messages: ChatMessageId[];
-	branches: Record<string, ChatMessageId[]>;
-}
-
 export type ChatHubConversationsResponse = ChatHubSesssionDto[];
 
 export interface ChatHubConversationResponse {
 	session: ChatHubSesssionDto;
 
-	graph?: {
+	conversation: {
 		messages: Record<string, ChatHubMessageDto>;
 		rootIds: string[];
-		turnRootIds: string[];
-	};
-
-	timeline?: {
-		turns: ChatHubMessageTurnDto[];
+		activeThread: string[];
 	};
 }

--- a/packages/@n8n/api-types/src/chat-hub.ts
+++ b/packages/@n8n/api-types/src/chat-hub.ts
@@ -60,41 +60,69 @@ export class ChatHubSendMessageRequest extends Z.class({
 	),
 }) {}
 
-/**
- * Chat message schema
- */
-export const chatHubMessageSchema = z.object({
-	id: z.string().uuid(),
-	conversationId: z.string().uuid(),
-	role: z.enum(['user', 'assistant']),
-	content: z.string(),
-	createdAt: z.string().datetime(),
-});
+export type ChatHubMessageType = 'human' | 'ai' | 'system' | 'tool' | 'generic';
+export type ChatHubMessageState = 'active' | 'superseded' | 'hidden' | 'deleted';
 
-export type ChatHubMessage = z.infer<typeof chatHubMessageSchema>;
+export type ChatSessionid = string; // UUID
+export type ChatMessageId = string; // UUID
 
-/**
- * Chat conversation schema
- */
-export const chatHubConversationSchema = z.object({
-	id: z.string().uuid(),
-	title: z.string(),
-	createdAt: z.date(),
-	updatedAt: z.date(),
-});
+export interface ChatHubSesssionDto {
+	id: ChatSessionid;
+	title: string;
+	ownerId: string;
+	lastMessageAt: string | null;
+	credentialId: string | null;
+	provider: ChatHubProvider | null;
+	model: string | null;
+	workflowId: string | null;
+	createdAt: string;
+	updatedAt: string;
+}
 
-export type ChatHubConversation = z.infer<typeof chatHubConversationSchema>;
+export interface ChatHubMessageDto {
+	id: ChatMessageId;
+	sessionId: ChatSessionid;
+	type: ChatHubMessageType;
+	name: string;
+	content: string;
+	provider: ChatHubProvider | null;
+	model: string | null;
+	workflowId: string | null;
+	executionId: number | null;
+	state: ChatHubMessageState;
+	createdAt: string;
+	updatedAt: string;
 
-/**
- * Response schema for GET /conversations
- */
-export const chatHubConversationsResponseSchema = z.array(chatHubConversationSchema);
+	previousMessageId: ChatMessageId | null;
+	turnId: ChatMessageId | null;
+	retryOfMessageId: ChatMessageId | null;
+	revisionOfMessageId: ChatMessageId | null;
+	runIndex: number;
 
-export type ChatHubConversationsResponse = z.infer<typeof chatHubConversationsResponseSchema>;
+	responseIds: ChatMessageId[];
+	retryIds: ChatMessageId[];
+	revisionIds: ChatMessageId[];
+}
 
-/**
- * Response schema for GET /conversations/:id/messages
- */
-export const chatHubMessagesResponseSchema = z.array(chatHubMessageSchema);
+export interface ChatHubMessageTurnDto {
+	id: ChatMessageId;
+	rootMessageId: ChatMessageId;
+	messages: ChatMessageId[];
+	branches: Record<string, ChatMessageId[]>;
+}
 
-export type ChatHubMessagesResponse = z.infer<typeof chatHubMessagesResponseSchema>;
+export type ChatHubConversationsResponse = ChatHubSesssionDto[];
+
+export interface ChatHubConversationResponse {
+	session: ChatHubSesssionDto;
+
+	graph?: {
+		messages: Record<string, ChatHubMessageDto>;
+		rootIds: string[];
+		turnRootIds: string[];
+	};
+
+	timeline?: {
+		turns: ChatHubMessageTurnDto[];
+	};
+}

--- a/packages/@n8n/api-types/src/chat-hub.ts
+++ b/packages/@n8n/api-types/src/chat-hub.ts
@@ -113,6 +113,6 @@ export interface ChatHubConversationResponse {
 	conversation: {
 		messages: Record<string, ChatHubMessageDto>;
 		rootIds: string[];
-		activeThread: string[];
+		activeMessageChain: string[];
 	};
 }

--- a/packages/@n8n/api-types/src/chat-hub.ts
+++ b/packages/@n8n/api-types/src/chat-hub.ts
@@ -64,11 +64,11 @@ export class ChatHubSendMessageRequest extends Z.class({
 export type ChatHubMessageType = 'human' | 'ai' | 'system' | 'tool' | 'generic';
 export type ChatHubMessageState = 'active' | 'superseded' | 'hidden' | 'deleted';
 
-export type ChatSessionid = string; // UUID
+export type ChatSessionId = string; // UUID
 export type ChatMessageId = string; // UUID
 
-export interface ChatHubSesssionDto {
-	id: ChatSessionid;
+export interface ChatHubSessionDto {
+	id: ChatSessionId;
 	title: string;
 	ownerId: string;
 	lastMessageAt: string | null;
@@ -82,7 +82,7 @@ export interface ChatHubSesssionDto {
 
 export interface ChatHubMessageDto {
 	id: ChatMessageId;
-	sessionId: ChatSessionid;
+	sessionId: ChatSessionId;
 	type: ChatHubMessageType;
 	name: string;
 	content: string;
@@ -105,10 +105,10 @@ export interface ChatHubMessageDto {
 	revisionIds: ChatMessageId[];
 }
 
-export type ChatHubConversationsResponse = ChatHubSesssionDto[];
+export type ChatHubConversationsResponse = ChatHubSessionDto[];
 
 export interface ChatHubConversationResponse {
-	session: ChatHubSesssionDto;
+	session: ChatHubSessionDto;
 
 	conversation: {
 		messages: Record<string, ChatHubMessageDto>;

--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -11,15 +11,19 @@ export {
 	type ChatHubConversationModel,
 	chatHubProviderSchema,
 	type ChatHubProvider,
+	type ChatHubMessageType,
+	type ChatHubMessageState,
 	PROVIDER_CREDENTIAL_TYPE_MAP,
 	chatModelsRequestSchema,
 	type ChatModelsRequest,
 	type ChatModelsResponse,
 	ChatHubSendMessageRequest,
+	type ChatMessageId,
+	type ChatHubMessageDto,
+	type ChatHubSesssionDto,
+	type ChatHubMessageTurnDto,
+	type ChatHubConversationResponse,
 	type ChatHubConversationsResponse,
-	type ChatHubMessagesResponse,
-	type ChatHubConversation,
-	type ChatHubMessage,
 } from './chat-hub';
 
 export type { Collaborator } from './push/collaboration';

--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -21,7 +21,6 @@ export {
 	type ChatMessageId,
 	type ChatHubMessageDto,
 	type ChatHubSesssionDto,
-	type ChatHubMessageTurnDto,
 	type ChatHubConversationResponse,
 	type ChatHubConversationsResponse,
 } from './chat-hub';

--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -20,7 +20,7 @@ export {
 	ChatHubSendMessageRequest,
 	type ChatMessageId,
 	type ChatHubMessageDto,
-	type ChatHubSesssionDto,
+	type ChatHubSessionDto,
 	type ChatHubConversationResponse,
 	type ChatHubConversationsResponse,
 } from './chat-hub';

--- a/packages/@n8n/backend-test-utils/src/test-db.ts
+++ b/packages/@n8n/backend-test-utils/src/test-db.ts
@@ -80,7 +80,9 @@ type EntityName =
 	| 'InsightsByPeriod'
 	| 'InsightsMetadata'
 	| 'DataTable'
-	| 'DataTableColumn';
+	| 'DataTableColumn'
+	| 'ChatHubSession'
+	| 'ChatHubMessage';
 
 /**
  * Truncate specific DB tables in a test DB.

--- a/packages/cli/src/modules/chat-hub/__tests__/chat-hub.service.integration.test.ts
+++ b/packages/cli/src/modules/chat-hub/__tests__/chat-hub.service.integration.test.ts
@@ -1,0 +1,625 @@
+import { testDb, testModules } from '@n8n/backend-test-utils';
+import type { User } from '@n8n/db';
+import { Container } from '@n8n/di';
+
+import { createAdmin, createMember } from '@test-integration/db/users';
+
+import { ChatHubService } from '../chat-hub.service';
+import { ChatHubMessageRepository } from '../chat-message.repository';
+import { ChatHubSessionRepository } from '../chat-session.repository';
+
+beforeAll(async () => {
+	await testModules.loadModules(['chat-hub']);
+	await testDb.init();
+});
+
+beforeEach(async () => {
+	await testDb.truncate(['ChatHubMessage', 'ChatHubSession']);
+});
+
+afterAll(async () => {
+	await testDb.terminate();
+});
+
+describe('chatHub', () => {
+	let chatHubService: ChatHubService;
+	let messagesRepository: ChatHubMessageRepository;
+	let sessionsRepository: ChatHubSessionRepository;
+
+	let admin: User;
+	let member: User;
+
+	beforeAll(() => {
+		chatHubService = Container.get(ChatHubService);
+		messagesRepository = Container.get(ChatHubMessageRepository);
+		sessionsRepository = Container.get(ChatHubSessionRepository);
+	});
+
+	beforeEach(async () => {
+		admin = await createAdmin();
+		member = await createMember();
+	});
+
+	afterEach(async () => {
+		await chatHubService.deleteAllSessions();
+	});
+
+	describe('getConversations', () => {
+		it('should list empty conversations', async () => {
+			const conversations = await chatHubService.getConversations(member.id);
+			expect(conversations).toBeDefined();
+			expect(conversations).toHaveLength(0);
+		});
+
+		it("should list user's own conversations in expected order", async () => {
+			const session1 = await sessionsRepository.createChatSession({
+				ownerId: member.id,
+				title: 'session 1',
+				lastMessageAt: new Date('2025-01-03T00:00:00Z'),
+			});
+			const session2 = await sessionsRepository.createChatSession({
+				ownerId: member.id,
+				title: 'session 2',
+				lastMessageAt: new Date('2025-01-02T00:00:00Z'),
+			});
+			const session3 = await sessionsRepository.createChatSession({
+				ownerId: member.id,
+				title: 'session 3',
+				lastMessageAt: new Date('2025-01-01T00:00:00Z'),
+			});
+			await sessionsRepository.createChatSession({
+				ownerId: admin.id,
+				title: 'admin session',
+				lastMessageAt: new Date('2025-01-01T00:00:00Z'),
+			});
+
+			const conversations = await chatHubService.getConversations(member.id);
+			expect(conversations).toHaveLength(3);
+			expect(conversations[0].id).toBe(session1.id);
+			expect(conversations[1].id).toBe(session2.id);
+			expect(conversations[2].id).toBe(session3.id);
+		});
+	});
+
+	describe('getConversation', () => {
+		it('should fail to get non-existing conversation', async () => {
+			await expect(chatHubService.getConversation(member.id, 'non-existing')).rejects.toThrow(
+				'Chat session not found',
+			);
+		});
+
+		it("should fail to get another user's conversation", async () => {
+			const session = await sessionsRepository.createChatSession({
+				ownerId: admin.id,
+				title: 'admin session',
+				lastMessageAt: new Date('2025-01-01T00:00:00Z'),
+			});
+			await expect(chatHubService.getConversation(member.id, session.id)).rejects.toThrow(
+				'Chat session not found',
+			);
+		});
+
+		it('should get conversation with no messages', async () => {
+			const session = await sessionsRepository.createChatSession({
+				ownerId: member.id,
+				title: 'session 1',
+				lastMessageAt: new Date('2025-01-03T00:00:00Z'),
+			});
+			const conversation = await chatHubService.getConversation(member.id, session.id);
+			expect(conversation).toBeDefined();
+			expect(conversation.session.id).toBe(session.id);
+			expect(conversation.conversation.messages).toEqual({});
+		});
+
+		it('should get conversation with messages in expected order', async () => {
+			const session = await sessionsRepository.createChatSession({
+				ownerId: member.id,
+				title: 'session 1',
+				lastMessageAt: new Date('2025-01-03T00:00:00Z'),
+			});
+			const ids = [
+				crypto.randomUUID(),
+				crypto.randomUUID(),
+				crypto.randomUUID(),
+				crypto.randomUUID(),
+			];
+
+			const msg1 = await messagesRepository.createChatMessage({
+				id: ids[0],
+				sessionId: session.id,
+				name: 'Nathan',
+				type: 'human',
+				content: 'message 1',
+				turnId: ids[0],
+				createdAt: new Date('2025-01-03T00:00:00Z'),
+			});
+			const msg2 = await messagesRepository.createChatMessage({
+				id: ids[1],
+				sessionId: session.id,
+				name: 'ChatGPT',
+				type: 'ai',
+				content: 'message 2',
+				previousMessageId: msg1.id,
+				turnId: ids[0],
+				createdAt: new Date('2025-01-03T00:05:00Z'),
+			});
+			const msg3 = await messagesRepository.createChatMessage({
+				id: ids[2],
+				sessionId: session.id,
+				name: 'Nathan',
+				type: 'human',
+				content: 'message 3',
+				previousMessageId: msg2.id,
+				turnId: ids[2],
+				createdAt: new Date('2025-01-03T00:10:00Z'),
+			});
+			const msg4 = await messagesRepository.createChatMessage({
+				id: ids[3],
+				sessionId: session.id,
+				name: 'ChatGPT',
+				type: 'ai',
+				content: 'message 4',
+				previousMessageId: msg3.id,
+				turnId: ids[2],
+				createdAt: new Date('2025-01-03T00:15:00Z'),
+			});
+
+			const response = await chatHubService.getConversation(member.id, session.id);
+			expect(response.session.id).toBe(session.id);
+			expect(response).toBeDefined();
+
+			const {
+				conversation: { rootIds, messages, activeThread },
+			} = response;
+
+			expect(rootIds).toEqual([msg1.id]);
+			expect(Object.keys(messages)).toHaveLength(4);
+			expect(activeThread).toHaveLength(4);
+			expect(activeThread[0]).toBe(msg1.id);
+			expect(activeThread[1]).toBe(msg2.id);
+			expect(activeThread[2]).toBe(msg3.id);
+			expect(activeThread[3]).toBe(msg4.id);
+			expect(messages[msg1.id].content).toBe('message 1');
+			expect(messages[msg1.id].type).toBe('human');
+			expect(messages[msg1.id].turnId).toBe(msg1.id);
+			expect(messages[msg2.id].content).toBe('message 2');
+			expect(messages[msg2.id].type).toBe('ai');
+			expect(messages[msg2.id].turnId).toBe(msg1.id);
+			expect(messages[msg3.id].content).toBe('message 3');
+			expect(messages[msg3.id].type).toBe('human');
+			expect(messages[msg3.id].turnId).toBe(msg3.id);
+			expect(messages[msg4.id].content).toBe('message 4');
+			expect(messages[msg4.id].type).toBe('ai');
+			expect(messages[msg4.id].turnId).toBe(msg3.id);
+		});
+
+		it('should get conversation with a edit branch', async () => {
+			const ids = [
+				crypto.randomUUID(),
+				crypto.randomUUID(),
+				crypto.randomUUID(),
+				crypto.randomUUID(),
+				crypto.randomUUID(),
+				crypto.randomUUID(),
+			];
+
+			const session = await sessionsRepository.createChatSession({
+				ownerId: member.id,
+				title: 'session 1',
+				lastMessageAt: new Date('2025-01-03T00:00:00Z'),
+			});
+			const msg1 = await messagesRepository.createChatMessage({
+				id: ids[0],
+				sessionId: session.id,
+				name: 'Nathan',
+				type: 'human',
+				content: 'message 1',
+				turnId: ids[0],
+				createdAt: new Date('2025-01-03T00:00:00Z'),
+			});
+			const msg2 = await messagesRepository.createChatMessage({
+				id: ids[1],
+				sessionId: session.id,
+				name: 'ChatGPT',
+				type: 'ai',
+				content: 'message 2',
+				previousMessageId: msg1.id,
+				turnId: ids[0],
+				createdAt: new Date('2025-01-03T00:05:00Z'),
+			});
+			const msg3 = await messagesRepository.createChatMessage({
+				id: ids[2],
+				sessionId: session.id,
+				name: 'Nathan',
+				type: 'human',
+				content: 'message 3a',
+				previousMessageId: msg2.id,
+				turnId: ids[2],
+				createdAt: new Date('2025-01-03T00:10:00Z'),
+			});
+			const msg4 = await messagesRepository.createChatMessage({
+				id: ids[3],
+				sessionId: session.id,
+				name: 'ChatGPT',
+				type: 'ai',
+				content: 'message 4a',
+				previousMessageId: msg3.id,
+				turnId: ids[2],
+				createdAt: new Date('2025-01-03T00:15:00Z'),
+			});
+			// Edit message 3 to create a branch
+			const msg5 = await messagesRepository.createChatMessage({
+				id: ids[4],
+				sessionId: session.id,
+				name: 'Nathan',
+				type: 'human',
+				content: 'message 3b',
+				previousMessageId: msg2.id,
+				revisionOfMessageId: msg3.id,
+				turnId: ids[4],
+				createdAt: new Date('2025-01-03T00:20:00Z'),
+			});
+			const msg6 = await messagesRepository.createChatMessage({
+				id: ids[5],
+				sessionId: session.id,
+				name: 'ChatGPT',
+				type: 'ai',
+				content: 'message 4b',
+				previousMessageId: msg5.id,
+				turnId: ids[4],
+				createdAt: new Date('2025-01-03T00:25:00Z'),
+			});
+
+			const response = await chatHubService.getConversation(member.id, session.id);
+			expect(response.session.id).toBe(session.id);
+			expect(response).toBeDefined();
+
+			const {
+				conversation: { rootIds, messages, activeThread },
+			} = response;
+
+			expect(rootIds).toEqual([msg1.id]);
+			expect(Object.keys(messages)).toHaveLength(6);
+			expect(activeThread).toHaveLength(4);
+			expect(activeThread[0]).toBe(msg1.id);
+			expect(activeThread[1]).toBe(msg2.id);
+			expect(activeThread[2]).toBe(msg5.id);
+			expect(activeThread[3]).toBe(msg6.id);
+			expect(messages[msg1.id].content).toBe('message 1');
+			expect(messages[msg2.id].content).toBe('message 2');
+			expect(messages[msg3.id].content).toBe('message 3a');
+			expect(messages[msg4.id].content).toBe('message 4a');
+			expect(messages[msg5.id].content).toBe('message 3b');
+			expect(messages[msg6.id].content).toBe('message 4b');
+			expect(messages[msg3.id].revisionIds).toEqual([msg5.id]);
+			expect(messages[msg3.id].responseIds).toEqual([msg4.id]);
+			expect(messages[msg3.id].retryIds).toEqual([]);
+			expect(messages[msg5.id].previousMessageId).toBe(msg2.id);
+		});
+
+		it('should get conversation with a edit branch at first message', async () => {
+			const ids = [
+				crypto.randomUUID(),
+				crypto.randomUUID(),
+				crypto.randomUUID(),
+				crypto.randomUUID(),
+			];
+			const session = await sessionsRepository.createChatSession({
+				ownerId: member.id,
+				title: 'session 1',
+				lastMessageAt: new Date('2025-01-03T00:00:00Z'),
+			});
+
+			const msg1 = await messagesRepository.createChatMessage({
+				id: ids[0],
+				sessionId: session.id,
+				name: 'Nathan',
+				type: 'human',
+				content: 'message 1a',
+				turnId: ids[0],
+				createdAt: new Date('2025-01-03T00:00:00Z'),
+			});
+			await messagesRepository.createChatMessage({
+				id: ids[1],
+				sessionId: session.id,
+				name: 'ChatGPT',
+				type: 'ai',
+				content: 'message 2a',
+				previousMessageId: msg1.id,
+				turnId: ids[1],
+				createdAt: new Date('2025-01-03T00:05:00Z'),
+			});
+			// Edit message 1 to create a branch
+			const msg3 = await messagesRepository.createChatMessage({
+				id: ids[2],
+				sessionId: session.id,
+				name: 'Nathan',
+				type: 'human',
+				content: 'message 1b',
+				revisionOfMessageId: msg1.id,
+				turnId: ids[2],
+				createdAt: new Date('2025-01-03T00:10:00Z'),
+			});
+			const msg4 = await messagesRepository.createChatMessage({
+				id: ids[3],
+				sessionId: session.id,
+				name: 'ChatGPT',
+				type: 'ai',
+				content: 'message 2b',
+				previousMessageId: msg3.id,
+				turnId: ids[2],
+				createdAt: new Date('2025-01-03T00:15:00Z'),
+			});
+
+			const response = await chatHubService.getConversation(member.id, session.id);
+			expect(response.session.id).toBe(session.id);
+			expect(response).toBeDefined();
+
+			const {
+				conversation: { rootIds, messages, activeThread },
+			} = response;
+
+			expect(rootIds).toEqual([msg1.id, msg3.id]);
+			expect(Object.keys(messages)).toHaveLength(4);
+			expect(activeThread).toHaveLength(2);
+			expect(activeThread[0]).toBe(msg3.id);
+			expect(activeThread[1]).toBe(msg4.id);
+		});
+
+		it('should get conversation with a retry branch at last message', async () => {
+			const ids = [
+				crypto.randomUUID(),
+				crypto.randomUUID(),
+				crypto.randomUUID(),
+				crypto.randomUUID(),
+				crypto.randomUUID(),
+				crypto.randomUUID(),
+			];
+
+			const session = await sessionsRepository.createChatSession({
+				ownerId: member.id,
+				title: 'session 1',
+				lastMessageAt: new Date('2025-01-03T00:00:00Z'),
+			});
+			const msg1 = await messagesRepository.createChatMessage({
+				id: ids[0],
+				sessionId: session.id,
+				name: 'Nathan',
+				type: 'human',
+				content: 'message 1',
+				turnId: ids[0],
+				createdAt: new Date('2025-01-03T00:00:00Z'),
+			});
+			const msg2 = await messagesRepository.createChatMessage({
+				id: ids[1],
+				sessionId: session.id,
+				name: 'ChatGPT',
+				type: 'ai',
+				content: 'message 2',
+				previousMessageId: msg1.id,
+				turnId: ids[0],
+				createdAt: new Date('2025-01-03T00:05:00Z'),
+			});
+			const msg3 = await messagesRepository.createChatMessage({
+				id: ids[2],
+				sessionId: session.id,
+				name: 'Nathan',
+				type: 'human',
+				content: 'message 3',
+				previousMessageId: msg2.id,
+				turnId: ids[2],
+				createdAt: new Date('2025-01-03T00:10:00Z'),
+			});
+			const msg4 = await messagesRepository.createChatMessage({
+				id: ids[3],
+				sessionId: session.id,
+				name: 'ChatGPT',
+				type: 'ai',
+				content: 'message 4a',
+				previousMessageId: msg3.id,
+				turnId: ids[2],
+				createdAt: new Date('2025-01-03T00:15:00Z'),
+			});
+			// Retry message 4 to create a branch
+			const msg5 = await messagesRepository.createChatMessage({
+				id: ids[4],
+				sessionId: session.id,
+				name: 'ChatGPT',
+				type: 'ai',
+				content: 'message 4b',
+				previousMessageId: msg3.id,
+				retryOfMessageId: msg4.id,
+				turnId: ids[2],
+				createdAt: new Date('2025-01-03T00:20:00Z'),
+			});
+
+			const response = await chatHubService.getConversation(member.id, session.id);
+			expect(response).toBeDefined();
+			expect(response.session.id).toBe(session.id);
+
+			const {
+				conversation: { rootIds, messages, activeThread },
+			} = response;
+
+			expect(rootIds).toEqual([msg1.id]);
+			expect(Object.keys(messages)).toHaveLength(5);
+			expect(activeThread).toHaveLength(4);
+			expect(activeThread[0]).toBe(msg1.id);
+			expect(activeThread[1]).toBe(msg2.id);
+			expect(activeThread[2]).toBe(msg3.id);
+			expect(activeThread[3]).toBe(msg5.id);
+			expect(messages[msg4.id].revisionIds).toEqual([]);
+			expect(messages[msg4.id].responseIds).toEqual([]);
+			expect(messages[msg4.id].retryIds).toEqual([msg5.id]);
+			expect(messages[msg5.id].previousMessageId).toBe(msg3.id);
+			expect(messages[msg5.id].retryOfMessageId).toBe(msg4.id);
+		});
+
+		it('should get a complex conversation with multiple branches', async () => {
+			// This test creates a complex conversation with multiple edits and retries to ensure
+			// the conversation tree is built correctly in all cases.
+
+			// The structure created is as follows:
+			// msg1 -> msg2 -> msg3a -> msg4a
+			//              -> msg3b (edit of msg3a) -> msg4b
+			// msg1b (edit of msg1) -> nothing
+			// msg1 -> msg2r (retry of msg2) -> msg3d -> msg4c
+
+			const ids = [
+				crypto.randomUUID(),
+				crypto.randomUUID(),
+				crypto.randomUUID(),
+				crypto.randomUUID(),
+				crypto.randomUUID(),
+				crypto.randomUUID(),
+				crypto.randomUUID(),
+				crypto.randomUUID(),
+				crypto.randomUUID(),
+				crypto.randomUUID(),
+			];
+
+			const session = await sessionsRepository.createChatSession({
+				ownerId: member.id,
+				title: 'session 1',
+				lastMessageAt: new Date('2025-01-03T00:00:00Z'),
+			});
+			const msg1 = await messagesRepository.createChatMessage({
+				id: ids[0],
+				sessionId: session.id,
+				name: 'Nathan',
+				type: 'human',
+				content: 'message 1',
+				turnId: ids[0],
+				createdAt: new Date('2025-01-03T00:00:00Z'),
+			});
+			const msg2 = await messagesRepository.createChatMessage({
+				id: ids[1],
+				sessionId: session.id,
+				name: 'ChatGPT',
+				type: 'ai',
+				content: 'message 2a',
+				previousMessageId: msg1.id,
+				turnId: ids[0],
+				createdAt: new Date('2025-01-03T00:05:00Z'),
+			});
+			const msg3a = await messagesRepository.createChatMessage({
+				id: ids[2],
+				sessionId: session.id,
+				name: 'Nathan',
+				type: 'human',
+				content: 'message 3a',
+				previousMessageId: msg2.id,
+				turnId: ids[2],
+				createdAt: new Date('2025-01-03T00:10:00Z'),
+			});
+			const msg4a = await messagesRepository.createChatMessage({
+				id: ids[3],
+				sessionId: session.id,
+				name: 'ChatGPT',
+				type: 'ai',
+				content: 'message 4a',
+				previousMessageId: msg3a.id,
+				turnId: ids[2],
+				createdAt: new Date('2025-01-03T00:15:00Z'),
+			});
+			const msg3b = await messagesRepository.createChatMessage({
+				id: ids[4],
+				sessionId: session.id,
+				name: 'Nathan',
+				type: 'human',
+				content: 'message 3b',
+				revisionOfMessageId: msg3a.id,
+				previousMessageId: msg2.id,
+				turnId: ids[4],
+				createdAt: new Date('2025-01-03T00:20:00Z'),
+			});
+			const msg4b = await messagesRepository.createChatMessage({
+				id: ids[5],
+				sessionId: session.id,
+				name: 'ChatGPT',
+				type: 'ai',
+				content: 'message 4b',
+				previousMessageId: msg3b.id,
+				turnId: ids[4],
+				createdAt: new Date('2025-01-03T00:25:00Z'),
+			});
+			const msg1b = await messagesRepository.createChatMessage({
+				id: ids[6],
+				sessionId: session.id,
+				name: 'Nathan',
+				type: 'human',
+				content: 'message 1b',
+				revisionOfMessageId: msg1.id,
+				turnId: ids[6],
+				createdAt: new Date('2025-01-03T00:30:00Z'),
+			});
+			const msg2r = await messagesRepository.createChatMessage({
+				id: ids[7],
+				sessionId: session.id,
+				name: 'ChatGPT',
+				type: 'ai',
+				content: 'message 2b',
+				previousMessageId: msg1.id,
+				retryOfMessageId: msg2.id,
+				turnId: ids[0],
+				createdAt: new Date('2025-01-03T00:35:00Z'),
+			});
+			const msg3d = await messagesRepository.createChatMessage({
+				id: ids[8],
+				sessionId: session.id,
+				name: 'Nathan',
+				type: 'human',
+				content: 'message 3d',
+				previousMessageId: msg2r.id,
+				turnId: ids[8],
+				createdAt: new Date('2025-01-03T00:40:00Z'),
+			});
+			const msg4c = await messagesRepository.createChatMessage({
+				id: crypto.randomUUID(),
+				sessionId: session.id,
+				name: 'ChatGPT',
+				type: 'ai',
+				content: 'message 4c',
+				previousMessageId: msg3d.id,
+				turnId: ids[8],
+				createdAt: new Date('2025-01-03T00:45:00Z'),
+			});
+
+			const response = await chatHubService.getConversation(member.id, session.id);
+			expect(response).toBeDefined();
+			expect(response.session.id).toBe(session.id);
+
+			const {
+				conversation: { rootIds, messages, activeThread },
+			} = response;
+
+			expect(rootIds).toEqual([msg1.id, msg1b.id]);
+			expect(Object.keys(messages)).toHaveLength(10);
+
+			expect(activeThread).toHaveLength(4);
+			expect(activeThread[0]).toBe(msg1.id);
+			expect(activeThread[1]).toBe(msg2r.id);
+			expect(activeThread[2]).toBe(msg3d.id);
+			expect(activeThread[3]).toBe(msg4c.id);
+
+			expect(messages[msg1.id].revisionIds).toEqual([msg1b.id]);
+			expect(messages[msg1b.id].responseIds).toEqual([]);
+			expect(messages[msg1b.id].retryIds).toEqual([]);
+
+			expect(messages[msg2.id].revisionIds).toEqual([]);
+			expect(messages[msg2.id].responseIds).toEqual([msg3a.id, msg3b.id]);
+			expect(messages[msg2.id].retryIds).toEqual([msg2r.id]);
+
+			expect(messages[msg3b.id].revisionIds).toEqual([]);
+			expect(messages[msg3b.id].responseIds).toEqual([msg4b.id]);
+			expect(messages[msg3b.id].retryIds).toEqual([]);
+
+			expect(messages[msg4a.id].revisionIds).toEqual([]);
+			expect(messages[msg4a.id].responseIds).toEqual([]);
+			expect(messages[msg4a.id].retryIds).toEqual([]);
+
+			expect(messages[msg2r.id].previousMessageId).toBe(msg1.id);
+			expect(messages[msg2r.id].retryOfMessageId).toBe(msg2.id);
+		});
+	});
+});

--- a/packages/cli/src/modules/chat-hub/__tests__/chat-hub.service.integration.test.ts
+++ b/packages/cli/src/modules/chat-hub/__tests__/chat-hub.service.integration.test.ts
@@ -53,21 +53,25 @@ describe('chatHub', () => {
 
 		it("should list user's own conversations in expected order", async () => {
 			const session1 = await sessionsRepository.createChatSession({
+				id: crypto.randomUUID(),
 				ownerId: member.id,
 				title: 'session 1',
 				lastMessageAt: new Date('2025-01-03T00:00:00Z'),
 			});
 			const session2 = await sessionsRepository.createChatSession({
+				id: crypto.randomUUID(),
 				ownerId: member.id,
 				title: 'session 2',
 				lastMessageAt: new Date('2025-01-02T00:00:00Z'),
 			});
 			const session3 = await sessionsRepository.createChatSession({
+				id: crypto.randomUUID(),
 				ownerId: member.id,
 				title: 'session 3',
 				lastMessageAt: new Date('2025-01-01T00:00:00Z'),
 			});
 			await sessionsRepository.createChatSession({
+				id: crypto.randomUUID(),
 				ownerId: admin.id,
 				title: 'admin session',
 				lastMessageAt: new Date('2025-01-01T00:00:00Z'),
@@ -83,13 +87,14 @@ describe('chatHub', () => {
 
 	describe('getConversation', () => {
 		it('should fail to get non-existing conversation', async () => {
-			await expect(chatHubService.getConversation(member.id, 'non-existing')).rejects.toThrow(
-				'Chat session not found',
-			);
+			await expect(
+				chatHubService.getConversation(member.id, '00000000-4040-4040-4040-000000000000'),
+			).rejects.toThrow('Chat session not found');
 		});
 
 		it("should fail to get another user's conversation", async () => {
 			const session = await sessionsRepository.createChatSession({
+				id: crypto.randomUUID(),
 				ownerId: admin.id,
 				title: 'admin session',
 				lastMessageAt: new Date('2025-01-01T00:00:00Z'),
@@ -101,6 +106,7 @@ describe('chatHub', () => {
 
 		it('should get conversation with no messages', async () => {
 			const session = await sessionsRepository.createChatSession({
+				id: crypto.randomUUID(),
 				ownerId: member.id,
 				title: 'session 1',
 				lastMessageAt: new Date('2025-01-03T00:00:00Z'),
@@ -113,6 +119,7 @@ describe('chatHub', () => {
 
 		it('should get conversation with messages in expected order', async () => {
 			const session = await sessionsRepository.createChatSession({
+				id: crypto.randomUUID(),
 				ownerId: member.id,
 				title: 'session 1',
 				lastMessageAt: new Date('2025-01-03T00:00:00Z'),
@@ -204,6 +211,7 @@ describe('chatHub', () => {
 			];
 
 			const session = await sessionsRepository.createChatSession({
+				id: crypto.randomUUID(),
 				ownerId: member.id,
 				title: 'session 1',
 				lastMessageAt: new Date('2025-01-03T00:00:00Z'),
@@ -305,6 +313,7 @@ describe('chatHub', () => {
 				crypto.randomUUID(),
 			];
 			const session = await sessionsRepository.createChatSession({
+				id: crypto.randomUUID(),
 				ownerId: member.id,
 				title: 'session 1',
 				lastMessageAt: new Date('2025-01-03T00:00:00Z'),
@@ -377,6 +386,7 @@ describe('chatHub', () => {
 			];
 
 			const session = await sessionsRepository.createChatSession({
+				id: crypto.randomUUID(),
 				ownerId: member.id,
 				title: 'session 1',
 				lastMessageAt: new Date('2025-01-03T00:00:00Z'),
@@ -479,6 +489,7 @@ describe('chatHub', () => {
 			];
 
 			const session = await sessionsRepository.createChatSession({
+				id: crypto.randomUUID(),
 				ownerId: member.id,
 				title: 'session 1',
 				lastMessageAt: new Date('2025-01-03T00:00:00Z'),

--- a/packages/cli/src/modules/chat-hub/__tests__/chat-hub.service.integration.test.ts
+++ b/packages/cli/src/modules/chat-hub/__tests__/chat-hub.service.integration.test.ts
@@ -169,16 +169,16 @@ describe('chatHub', () => {
 			expect(response).toBeDefined();
 
 			const {
-				conversation: { rootIds, messages, activeThread },
+				conversation: { rootIds, messages, activeMessageChain },
 			} = response;
 
 			expect(rootIds).toEqual([msg1.id]);
 			expect(Object.keys(messages)).toHaveLength(4);
-			expect(activeThread).toHaveLength(4);
-			expect(activeThread[0]).toBe(msg1.id);
-			expect(activeThread[1]).toBe(msg2.id);
-			expect(activeThread[2]).toBe(msg3.id);
-			expect(activeThread[3]).toBe(msg4.id);
+			expect(activeMessageChain).toHaveLength(4);
+			expect(activeMessageChain[0]).toBe(msg1.id);
+			expect(activeMessageChain[1]).toBe(msg2.id);
+			expect(activeMessageChain[2]).toBe(msg3.id);
+			expect(activeMessageChain[3]).toBe(msg4.id);
 			expect(messages[msg1.id].content).toBe('message 1');
 			expect(messages[msg1.id].type).toBe('human');
 			expect(messages[msg1.id].turnId).toBe(msg1.id);
@@ -275,16 +275,16 @@ describe('chatHub', () => {
 			expect(response).toBeDefined();
 
 			const {
-				conversation: { rootIds, messages, activeThread },
+				conversation: { rootIds, messages, activeMessageChain },
 			} = response;
 
 			expect(rootIds).toEqual([msg1.id]);
 			expect(Object.keys(messages)).toHaveLength(6);
-			expect(activeThread).toHaveLength(4);
-			expect(activeThread[0]).toBe(msg1.id);
-			expect(activeThread[1]).toBe(msg2.id);
-			expect(activeThread[2]).toBe(msg5.id);
-			expect(activeThread[3]).toBe(msg6.id);
+			expect(activeMessageChain).toHaveLength(4);
+			expect(activeMessageChain[0]).toBe(msg1.id);
+			expect(activeMessageChain[1]).toBe(msg2.id);
+			expect(activeMessageChain[2]).toBe(msg5.id);
+			expect(activeMessageChain[3]).toBe(msg6.id);
 			expect(messages[msg1.id].content).toBe('message 1');
 			expect(messages[msg2.id].content).toBe('message 2');
 			expect(messages[msg3.id].content).toBe('message 3a');
@@ -356,14 +356,14 @@ describe('chatHub', () => {
 			expect(response).toBeDefined();
 
 			const {
-				conversation: { rootIds, messages, activeThread },
+				conversation: { rootIds, messages, activeMessageChain },
 			} = response;
 
 			expect(rootIds).toEqual([msg1.id, msg3.id]);
 			expect(Object.keys(messages)).toHaveLength(4);
-			expect(activeThread).toHaveLength(2);
-			expect(activeThread[0]).toBe(msg3.id);
-			expect(activeThread[1]).toBe(msg4.id);
+			expect(activeMessageChain).toHaveLength(2);
+			expect(activeMessageChain[0]).toBe(msg3.id);
+			expect(activeMessageChain[1]).toBe(msg4.id);
 		});
 
 		it('should get conversation with a retry branch at last message', async () => {
@@ -438,16 +438,16 @@ describe('chatHub', () => {
 			expect(response.session.id).toBe(session.id);
 
 			const {
-				conversation: { rootIds, messages, activeThread },
+				conversation: { rootIds, messages, activeMessageChain },
 			} = response;
 
 			expect(rootIds).toEqual([msg1.id]);
 			expect(Object.keys(messages)).toHaveLength(5);
-			expect(activeThread).toHaveLength(4);
-			expect(activeThread[0]).toBe(msg1.id);
-			expect(activeThread[1]).toBe(msg2.id);
-			expect(activeThread[2]).toBe(msg3.id);
-			expect(activeThread[3]).toBe(msg5.id);
+			expect(activeMessageChain).toHaveLength(4);
+			expect(activeMessageChain[0]).toBe(msg1.id);
+			expect(activeMessageChain[1]).toBe(msg2.id);
+			expect(activeMessageChain[2]).toBe(msg3.id);
+			expect(activeMessageChain[3]).toBe(msg5.id);
 			expect(messages[msg4.id].revisionIds).toEqual([]);
 			expect(messages[msg4.id].responseIds).toEqual([]);
 			expect(messages[msg4.id].retryIds).toEqual([msg5.id]);
@@ -590,17 +590,17 @@ describe('chatHub', () => {
 			expect(response.session.id).toBe(session.id);
 
 			const {
-				conversation: { rootIds, messages, activeThread },
+				conversation: { rootIds, messages, activeMessageChain },
 			} = response;
 
 			expect(rootIds).toEqual([msg1.id, msg1b.id]);
 			expect(Object.keys(messages)).toHaveLength(10);
 
-			expect(activeThread).toHaveLength(4);
-			expect(activeThread[0]).toBe(msg1.id);
-			expect(activeThread[1]).toBe(msg2r.id);
-			expect(activeThread[2]).toBe(msg3d.id);
-			expect(activeThread[3]).toBe(msg4c.id);
+			expect(activeMessageChain).toHaveLength(4);
+			expect(activeMessageChain[0]).toBe(msg1.id);
+			expect(activeMessageChain[1]).toBe(msg2r.id);
+			expect(activeMessageChain[2]).toBe(msg3d.id);
+			expect(activeMessageChain[3]).toBe(msg4c.id);
 
 			expect(messages[msg1.id].revisionIds).toEqual([msg1b.id]);
 			expect(messages[msg1b.id].responseIds).toEqual([]);

--- a/packages/cli/src/modules/chat-hub/chat-hub-message.entity.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-message.entity.ts
@@ -1,11 +1,8 @@
-import type { ChatHubProvider } from '@n8n/api-types';
+import type { ChatHubProvider, ChatHubMessageType, ChatHubMessageState } from '@n8n/api-types';
 import { ExecutionEntity, WithTimestampsAndStringId, WorkflowEntity } from '@n8n/db';
 import { Column, Entity, ManyToOne, JoinColumn, OneToMany, type Relation } from '@n8n/typeorm';
 
 import type { ChatHubSession } from './chat-hub-session.entity';
-import type { ChatHubMessageState } from './chat-hub.types';
-
-export type ChatHubMessageType = 'human' | 'ai' | 'system' | 'tool' | 'generic';
 
 @Entity({ name: 'chat_hub_messages' })
 export class ChatHubMessage extends WithTimestampsAndStringId {

--- a/packages/cli/src/modules/chat-hub/chat-hub-message.entity.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-message.entity.ts
@@ -103,8 +103,8 @@ export class ChatHubMessage extends WithTimestampsAndStringId {
 	/**
 	 * Root message of a conversation turn (Human message + AI responses)
 	 */
-	@Column({ type: 'varchar', length: 36, nullable: true })
-	turnId: string | null;
+	@Column({ type: 'varchar', length: 36 })
+	turnId: string;
 
 	/**
 	 * Message that began the turn, probably from the human/user.

--- a/packages/cli/src/modules/chat-hub/chat-hub-message.entity.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-message.entity.ts
@@ -1,15 +1,26 @@
 import type { ChatHubProvider, ChatHubMessageType, ChatHubMessageState } from '@n8n/api-types';
-import { ExecutionEntity, WithTimestampsAndStringId, WorkflowEntity } from '@n8n/db';
-import { Column, Entity, ManyToOne, JoinColumn, OneToMany, type Relation } from '@n8n/typeorm';
+import { ExecutionEntity, WithTimestamps, WorkflowEntity } from '@n8n/db';
+import {
+	Column,
+	Entity,
+	ManyToOne,
+	JoinColumn,
+	OneToMany,
+	type Relation,
+	PrimaryGeneratedColumn,
+} from '@n8n/typeorm';
 
 import type { ChatHubSession } from './chat-hub-session.entity';
 
 @Entity({ name: 'chat_hub_messages' })
-export class ChatHubMessage extends WithTimestampsAndStringId {
+export class ChatHubMessage extends WithTimestamps {
+	@PrimaryGeneratedColumn('uuid')
+	id: string;
+
 	/**
 	 * ID of the chat session/conversation this message belongs to.
 	 */
-	@Column({ type: 'varchar', length: 36 })
+	@Column({ type: String })
 	sessionId: string;
 
 	/**
@@ -81,7 +92,7 @@ export class ChatHubMessage extends WithTimestampsAndStringId {
 	/**
 	 * ID of the previous message this message is a response to, NULL on the initial message.
 	 */
-	@Column({ type: 'varchar', length: 36, nullable: true })
+	@Column({ type: String, nullable: true })
 	previousMessageId: string | null;
 
 	/**
@@ -103,7 +114,7 @@ export class ChatHubMessage extends WithTimestampsAndStringId {
 	/**
 	 * Root message of a conversation turn (Human message + AI responses)
 	 */
-	@Column({ type: 'varchar', length: 36 })
+	@Column({ type: String })
 	turnId: string;
 
 	/**
@@ -125,7 +136,7 @@ export class ChatHubMessage extends WithTimestampsAndStringId {
 	/**
 	 * ID of the message that this message is a retry of (if applicable).
 	 */
-	@Column({ type: 'varchar', length: 36, nullable: true })
+	@Column({ type: String, nullable: true })
 	retryOfMessageId: string | null;
 
 	/**
@@ -153,7 +164,7 @@ export class ChatHubMessage extends WithTimestampsAndStringId {
 	/**
 	 * ID of the message that this message is a revision/edit of (if applicable).
 	 */
-	@Column({ type: 'varchar', length: 36, nullable: true })
+	@Column({ type: String, nullable: true })
 	revisionOfMessageId: string | null;
 
 	/**

--- a/packages/cli/src/modules/chat-hub/chat-hub-session.entity.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-session.entity.ts
@@ -1,17 +1,21 @@
 import { ChatHubProvider } from '@n8n/api-types';
+import { WithTimestamps, DateTimeColumn, User, CredentialsEntity, WorkflowEntity } from '@n8n/db';
 import {
-	WithTimestampsAndStringId,
-	DateTimeColumn,
-	User,
-	CredentialsEntity,
-	WorkflowEntity,
-} from '@n8n/db';
-import { Column, Entity, ManyToOne, OneToMany, JoinColumn } from '@n8n/typeorm';
+	Column,
+	Entity,
+	ManyToOne,
+	OneToMany,
+	JoinColumn,
+	PrimaryGeneratedColumn,
+} from '@n8n/typeorm';
 
 import type { ChatHubMessage } from './chat-hub-message.entity';
 
 @Entity({ name: 'chat_hub_sessions' })
-export class ChatHubSession extends WithTimestampsAndStringId {
+export class ChatHubSession extends WithTimestamps {
+	@PrimaryGeneratedColumn('uuid')
+	id: string;
+
 	/**
 	 * The title of the chat session/conversation.
 	 * Auto-generated if not provided by the user after the initial AI responses.
@@ -22,7 +26,7 @@ export class ChatHubSession extends WithTimestampsAndStringId {
 	/**
 	 * ID of the user that owns this chat session.
 	 */
-	@Column({ type: 'varchar', length: 36 })
+	@Column({ type: String })
 	ownerId: string;
 
 	/**

--- a/packages/cli/src/modules/chat-hub/chat-hub.controller.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.controller.ts
@@ -2,7 +2,7 @@ import {
 	ChatHubSendMessageRequest,
 	ChatModelsResponse,
 	ChatHubConversationsResponse,
-	ChatHubMessagesResponse,
+	ChatHubConversationResponse,
 } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import { AuthenticatedRequest } from '@n8n/db';
@@ -94,7 +94,7 @@ export class ChatHubController {
 	async getConversationMessages(
 		req: AuthenticatedRequest<{ id: string }>,
 		_res: Response,
-	): Promise<ChatHubMessagesResponse> {
-		return await this.chatService.getConversationMessages(req.params.id);
+	): Promise<ChatHubConversationResponse> {
+		return await this.chatService.getConversation(req.user.id, req.params.id);
 	}
 }

--- a/packages/cli/src/modules/chat-hub/chat-hub.controller.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.controller.ts
@@ -43,17 +43,12 @@ export class ChatHubController {
 		res.header('Cache-Control', 'no-cache');
 		res.flushHeaders();
 
-		// TODO: Save human message to DB
-
-		const replyId = crypto.randomUUID();
-
 		this.logger.info(`Chat send request received: ${JSON.stringify(payload)}`);
 
 		try {
 			await this.chatService.respondMessage(res, req.user, {
 				...payload,
 				userId: req.user.id,
-				replyId,
 			});
 		} catch (executionError: unknown) {
 			assert(executionError instanceof Error);
@@ -70,7 +65,7 @@ export class ChatHubController {
 					JSON.stringify({
 						type: 'error',
 						content: executionError.message,
-						id: replyId,
+						id: payload.replyId,
 					}) + '\n',
 				);
 				res.flush();

--- a/packages/cli/src/modules/chat-hub/chat-hub.controller.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.controller.ts
@@ -84,7 +84,7 @@ export class ChatHubController {
 		return await this.chatService.getConversations(req.user.id);
 	}
 
-	@Get('/conversations/:id/messages')
+	@Get('/conversations/:id')
 	@GlobalScope('chatHub:message')
 	async getConversationMessages(
 		req: AuthenticatedRequest<{ id: string }>,

--- a/packages/cli/src/modules/chat-hub/chat-hub.controller.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.controller.ts
@@ -21,6 +21,7 @@ export class ChatHubController {
 	) {}
 
 	@Post('/models')
+	@GlobalScope('chatHub:message')
 	async getModels(
 		req: AuthenticatedRequest,
 		_res: Response,
@@ -80,14 +81,16 @@ export class ChatHubController {
 	}
 
 	@Get('/conversations')
+	@GlobalScope('chatHub:message')
 	async getConversations(
-		_req: AuthenticatedRequest,
+		req: AuthenticatedRequest,
 		_res: Response,
 	): Promise<ChatHubConversationsResponse> {
-		return await this.chatService.getConversations();
+		return await this.chatService.getConversations(req.user.id);
 	}
 
 	@Get('/conversations/:id/messages')
+	@GlobalScope('chatHub:message')
 	async getConversationMessages(
 		req: AuthenticatedRequest<{ id: string }>,
 		_res: Response,

--- a/packages/cli/src/modules/chat-hub/chat-hub.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.service.ts
@@ -572,16 +572,14 @@ export class ChatHubService {
 	async getConversation(userId: string, sessionId: string): Promise<ChatHubConversationResponse> {
 		const session = await this.sessionRepository.getOneById(sessionId, userId);
 		if (!session) {
-			throw new NotFoundError(`Could not find chat session with ID ${sessionId}`);
+			throw new NotFoundError('Chat session not found');
 		}
 
 		const messages = await this.messageRepository.getManyBySessionId(sessionId);
-
 		const messagesGraph: Record<ChatMessageId, ChatHubMessageDto> =
 			this.buildMessagesGraph(messages);
 
 		const rootIds = messages.filter((r) => r.previousMessageId === null).map((r) => r.id);
-
 		const activeThread = this.buildActiveThread(messages);
 
 		return {
@@ -687,5 +685,11 @@ export class ChatHubService {
 		}
 
 		return activeThread;
+	}
+
+	async deleteAllSessions() {
+		const result = await this.sessionRepository.deleteAll();
+
+		return result;
 	}
 }

--- a/packages/cli/src/modules/chat-hub/chat-hub.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.service.ts
@@ -545,53 +545,16 @@ export class ChatHubService {
 
 	/**
 	 * Get all conversations for a user
-	 * TODO: Replace with actual database queries
 	 */
-	async getConversations(): Promise<ChatHubConversationsResponse> {
-		// Mock data for now with diverse dates to demonstrate grouping
-		const now = new Date();
-		const today = new Date(now);
-		const yesterday = new Date(now);
-		yesterday.setDate(yesterday.getDate() - 1);
-		const threeDaysAgo = new Date(now);
-		threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
-		const twoWeeksAgo = new Date(now);
-		twoWeeksAgo.setDate(twoWeeksAgo.getDate() - 14);
-		const twoMonthsAgo = new Date(now);
-		twoMonthsAgo.setMonth(twoMonthsAgo.getMonth() - 2);
+	async getConversations(userId: string): Promise<ChatHubConversationsResponse> {
+		const sessions = await this.sessionRepository.getManyByUserId(userId);
 
-		return [
-			{
-				id: '7f3e2a91-8c4d-4b5a-9e1f-2d6c8a4b5e7f',
-				title: 'Getting Started with n8n',
-				createdAt: today.toISOString(),
-				updatedAt: today.toISOString(),
-			},
-			{
-				id: '3a8f5c2d-1e9b-4d7a-8c3e-6f2a9b4d8e1c',
-				title: 'Workflow Automation Ideas',
-				createdAt: yesterday.toISOString(),
-				updatedAt: yesterday.toISOString(),
-			},
-			{
-				id: '9b2e4f6a-7d1c-4a8b-9e3f-5c7d2a8b4e6f',
-				title: 'API Integration Help',
-				createdAt: threeDaysAgo.toISOString(),
-				updatedAt: threeDaysAgo.toISOString(),
-			},
-			{
-				id: '5c8a1d3e-4b9f-4e2a-8d6c-7f3a9b2e4c8d',
-				title: 'Database Schema Design',
-				createdAt: twoWeeksAgo.toISOString(),
-				updatedAt: twoWeeksAgo.toISOString(),
-			},
-			{
-				id: '2f6d9a4c-8e1b-4d7a-9c3e-6a8f2b5d4e9c',
-				title: 'Docker Deployment Questions',
-				createdAt: twoMonthsAgo.toISOString(),
-				updatedAt: twoMonthsAgo.toISOString(),
-			},
-		];
+		return sessions.map((session) => ({
+			id: session.id,
+			title: session.title,
+			createdAt: session.createdAt,
+			updatedAt: session.updatedAt,
+		}));
 	}
 
 	/**

--- a/packages/cli/src/modules/chat-hub/chat-hub.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.service.ts
@@ -3,8 +3,11 @@ import {
 	type ChatHubProvider,
 	type ChatModelsResponse,
 	type ChatHubConversationsResponse,
-	type ChatHubMessagesResponse,
+	type ChatHubConversationResponse,
 	chatHubProviderSchema,
+	ChatHubMessageDto,
+	type ChatHubMessageTurnDto,
+	type ChatMessageId,
 } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import {
@@ -39,8 +42,8 @@ import { ChatHubSessionRepository } from './chat-session.repository';
 import { ActiveExecutions } from '@/active-executions';
 import { CredentialsService } from '@/credentials/credentials.service';
 import { CredentialsHelper } from '@/credentials-helper';
-import { getBase } from '@/workflow-execute-additional-data';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { getBase } from '@/workflow-execute-additional-data';
 import { WorkflowExecutionService } from '@/workflows/workflow-execution.service';
 
 @Service()
@@ -552,127 +555,179 @@ export class ChatHubService {
 		return sessions.map((session) => ({
 			id: session.id,
 			title: session.title,
-			createdAt: session.createdAt,
-			updatedAt: session.updatedAt,
+			ownerId: session.ownerId,
+			lastMessageAt: session.lastMessageAt?.toISOString() ?? null,
+			credentialId: session.credentialId,
+			provider: session.provider,
+			model: session.model,
+			workflowId: session.workflowId,
+			createdAt: session.createdAt.toISOString(),
+			updatedAt: session.updatedAt.toISOString(),
 		}));
 	}
 
-	/**
-	 * Get all messages for a specific conversation
-	 * TODO: Replace with actual database queries
-	 */
-	async getConversationMessages(conversationId: string): Promise<ChatHubMessagesResponse> {
-		// Mock data for now - in a real implementation, we'd query by conversationId
-		this.logger.debug(`Fetching messages for conversation ${conversationId}`);
-
-		// Return different mock data based on conversation ID
-		const mockConversations: Record<string, ChatHubMessagesResponse> = {
-			'7f3e2a91-8c4d-4b5a-9e1f-2d6c8a4b5e7f': [
-				{
-					id: '650e8400-e29b-41d4-a716-446655440001',
-					conversationId,
-					role: 'user',
-					content: 'How do I create my first workflow in n8n?',
-					createdAt: new Date('2025-01-08T10:00:00Z').toISOString(),
-				},
-				{
-					id: '650e8400-e29b-41d4-a716-446655440002',
-					conversationId,
-					role: 'assistant',
-					content:
-						"To create your first workflow in n8n:\n\n1. Click the '+' button in the top left\n2. Select 'Create New Workflow'\n3. Add nodes by clicking the '+' on the canvas\n4. Configure each node\n5. Connect nodes by dragging from one to another\n6. Test and activate your workflow\n\nWould you like help with a specific type of workflow?",
-					createdAt: new Date('2025-01-08T10:00:30Z').toISOString(),
-				},
-				{
-					id: '650e8400-e29b-41d4-a716-446655440003',
-					conversationId,
-					role: 'user',
-					content:
-						'Yes, I want to automate sending emails when a new row is added to a Google Sheet.',
-					createdAt: new Date('2025-01-08T10:05:00Z').toISOString(),
-				},
-				{
-					id: '650e8400-e29b-41d4-a716-446655440004',
-					conversationId,
-					role: 'assistant',
-					content:
-						"Perfect! Here's how to set that up:\n\n1. Add a **Google Sheets Trigger** node\n   - Select 'On Row Added'\n   - Connect your Google account\n   - Choose your spreadsheet\n\n2. Add a **Gmail** node\n   - Connect your Gmail account\n   - Set the recipient email\n   - Use expressions to include data from the sheet\n\n3. Activate the workflow\n\nWould you like more details on any of these steps?",
-					createdAt: new Date('2025-01-08T10:05:45Z').toISOString(),
-				},
-			],
-			'3a8f5c2d-1e9b-4d7a-8c3e-6f2a9b4d8e1c': [
-				{
-					id: '650e8400-e29b-41d4-a716-446655440011',
-					conversationId,
-					role: 'user',
-					content: 'What are some creative workflow automation ideas?',
-					createdAt: new Date('2025-01-07T14:30:00Z').toISOString(),
-				},
-				{
-					id: '650e8400-e29b-41d4-a716-446655440012',
-					conversationId,
-					role: 'assistant',
-					content:
-						'Here are some creative workflow automation ideas:\n\n**Social Media Automation:**\n- Auto-post blog content to multiple platforms\n- Monitor mentions and send notifications\n- Generate reports on engagement metrics\n\n**Business Operations:**\n- Sync data between CRM and accounting software\n- Auto-generate invoices from project completion\n- Send weekly team reports\n\n**Personal Productivity:**\n- Save email attachments to cloud storage\n- Create calendar events from emails\n- Track expenses from receipts\n\nWhich area interests you most?',
-					createdAt: new Date('2025-01-07T14:32:00Z').toISOString(),
-				},
-				{
-					id: '650e8400-e29b-41d4-a716-446655440013',
-					conversationId,
-					role: 'user',
-					content: 'The social media automation sounds great! How complex is it to set up?',
-					createdAt: new Date('2025-01-07T14:45:00Z').toISOString(),
-				},
-				{
-					id: '650e8400-e29b-41d4-a716-446655440014',
-					conversationId,
-					role: 'assistant',
-					content:
-						"It's actually quite straightforward! For auto-posting to multiple platforms:\n\n**Difficulty: Beginner-friendly**\n\n1. Use an **RSS** trigger to monitor your blog\n2. Add **Twitter**, **LinkedIn**, and **Facebook** nodes\n3. Format your message with expressions\n4. Add conditions to customize per platform\n\nMost of the work is just connecting your accounts. The actual workflow can be set up in under 30 minutes!\n\nWant me to walk you through the specific nodes you'll need?",
-					createdAt: new Date('2025-01-07T14:47:00Z').toISOString(),
-				},
-			],
-			'9b2e4f6a-7d1c-4a8b-9e3f-5c7d2a8b4e6f': [
-				{
-					id: '650e8400-e29b-41d4-a716-446655440021',
-					conversationId,
-					role: 'user',
-					content: "I'm having trouble integrating with the Stripe API. Any tips?",
-					createdAt: new Date('2025-01-06T09:00:00Z').toISOString(),
-				},
-				{
-					id: '650e8400-e29b-41d4-a716-446655440022',
-					conversationId,
-					role: 'assistant',
-					content:
-						"I'd be happy to help with Stripe integration! What specific issue are you encountering?\n\n**Common Stripe integration patterns in n8n:**\n\n1. **Webhook-based** (Recommended)\n   - Stripe sends events to n8n\n   - Great for payment notifications\n   - Real-time updates\n\n2. **Polling-based**\n   - Check for new data periodically\n   - Good for reports and syncing\n\n3. **Manual trigger**\n   - Run on-demand operations\n   - Create customers, charges, etc.\n\nWhat's your use case?",
-					createdAt: new Date('2025-01-06T09:02:00Z').toISOString(),
-				},
-				{
-					id: '650e8400-e29b-41d4-a716-446655440023',
-					conversationId,
-					role: 'user',
-					content:
-						'I want to receive notifications when a payment succeeds and create an invoice in my accounting software.',
-					createdAt: new Date('2025-01-06T09:15:00Z').toISOString(),
-				},
-				{
-					id: '650e8400-e29b-41d4-a716-446655440024',
-					conversationId,
-					role: 'assistant',
-					content:
-						"Perfect use case for webhooks! Here's the setup:\n\n**Step 1: n8n Webhook**\n- Add a Webhook node\n- Set method to POST\n- Copy the webhook URL\n\n**Step 2: Stripe Dashboard**\n- Go to Developers → Webhooks\n- Add endpoint with your n8n URL\n- Select `payment_intent.succeeded` event\n\n**Step 3: Process Payment Data**\n- Add a **Function** node to extract payment details\n- Parse customer, amount, currency\n\n**Step 4: Create Invoice**\n- Add your accounting software node (QuickBooks, Xero, etc.)\n- Map payment data to invoice fields\n\n**Step 5: Send Notification**\n- Add Email/Slack node for confirmation\n\nWant the specific code for the Function node?",
-					createdAt: new Date('2025-01-06T09:18:00Z').toISOString(),
-				},
-			],
-		};
-
-		const messages = mockConversations[conversationId];
-
-		if (messages) {
-			return messages;
+	// eslint-disable-next-line complexity
+	async getConversation(userId: string, sessionId: string): Promise<ChatHubConversationResponse> {
+		const session = await this.sessionRepository.getOneById(sessionId, userId);
+		if (!session) {
+			throw new NotFoundError(`Could not find chat session with ID ${sessionId}`);
 		}
 
-		throw new NotFoundError(`Conversation not found. ID: ${conversationId}`);
+		const messages = await this.messageRepository.getManyBySessionId(sessionId);
+
+		const messagesGraph: Record<string, ChatHubMessageDto> = {};
+		for (const message of messages) {
+			messagesGraph[message.id] = {
+				id: message.id,
+				sessionId: message.sessionId,
+				type: message.type,
+				name: message.name,
+				content: message.content,
+				provider: message.provider ?? null,
+				model: message.model ?? null,
+				workflowId: message.workflowId ?? null,
+				executionId: message.executionId ?? null,
+				state: message.state,
+				createdAt: message.createdAt.toISOString(),
+				updatedAt: message.updatedAt.toISOString(),
+
+				previousMessageId: message.previousMessageId ?? null,
+				turnId: message.turnId ?? null,
+				retryOfMessageId: message.retryOfMessageId ?? null,
+				revisionOfMessageId: message.revisionOfMessageId ?? null,
+				runIndex: message.runIndex ?? 0,
+
+				responseIds: [],
+				retryIds: [],
+				revisionIds: [],
+			};
+		}
+
+		for (const node of Object.values(messagesGraph)) {
+			if (node.previousMessageId && messagesGraph[node.previousMessageId]) {
+				messagesGraph[node.previousMessageId].responseIds.push(node.id);
+			}
+			if (node.retryOfMessageId && messagesGraph[node.retryOfMessageId]) {
+				messagesGraph[node.retryOfMessageId].retryIds.push(node.id);
+			}
+			if (node.revisionOfMessageId && messagesGraph[node.revisionOfMessageId]) {
+				messagesGraph[node.revisionOfMessageId].revisionIds.push(node.id);
+			}
+		}
+
+		const sortByRunThenTime = (first: ChatMessageId, second: ChatMessageId) => {
+			const a = messagesGraph[first];
+			const b = messagesGraph[second];
+
+			if (a.runIndex !== b.runIndex) {
+				return a.runIndex - b.runIndex;
+			}
+
+			if (a.createdAt !== b.createdAt) {
+				return a.createdAt < b.createdAt ? -1 : 1;
+			}
+
+			return a.id < b.id ? -1 : 1;
+		};
+
+		for (const node of Object.values(messagesGraph)) {
+			node.responseIds.sort(sortByRunThenTime);
+			node.retryIds.sort(sortByRunThenTime);
+			node.revisionIds.sort(sortByRunThenTime);
+		}
+
+		const rootIds = messages.filter((r) => r.previousMessageId === null).map((r) => r.id);
+		const turnRootIds = messages.filter((r) => r.turnId && r.turnId === r.id).map((r) => r.id);
+
+		const byTurn: Record<ChatMessageId, ChatMessageId[]> = {};
+		for (const id of Object.keys(messagesGraph)) {
+			const node = messagesGraph[id];
+			const t =
+				node.turnId ??
+				(node.previousMessageId
+					? (messagesGraph[node.previousMessageId].turnId ?? node.id)
+					: node.id);
+
+			byTurn[t] ??= [];
+			byTurn[t].push(id);
+		}
+
+		const turns: ChatHubMessageTurnDto[] = [];
+		for (const turnRootId of Object.keys(byTurn)) {
+			const root = messagesGraph[turnRootId];
+
+			const messages: string[] = [];
+			const branches: Record<string, string[]> = {};
+
+			// Walk down the main reply chain, choosing the latest runIndex among retries at each step
+			let cursor: ChatHubMessageDto | undefined = root;
+			while (cursor) {
+				messages.push(cursor.id);
+
+				const retries = cursor.retryIds.filter((id) => messagesGraph[id].state === 'active');
+				if (retries.length > 0) {
+					const latestRun = Math.max(...retries.map((id) => messagesGraph[id].runIndex ?? 0));
+					const canonical = retries.find((id) => messagesGraph[id].runIndex === latestRun)!;
+
+					branches[cursor.id] = retries.filter((id) => id !== canonical);
+				}
+
+				// Pick the latest runIndex among responses
+				const [nextId]: ChatMessageId[] = cursor.responseIds
+					.filter((id) => messagesGraph[id].state === 'active')
+					.sort((a, b) => (messagesGraph[b].runIndex ?? 0) - (messagesGraph[a].runIndex ?? 0));
+
+				if (!nextId) break;
+
+				cursor = messagesGraph[nextId];
+			}
+
+			turns.push({
+				id: turnRootId,
+				rootMessageId: root.id,
+				messages,
+				branches,
+			});
+		}
+
+		const sortByTime = (first: ChatHubMessageTurnDto, second: ChatHubMessageTurnDto) => {
+			const a = messagesGraph[first.rootMessageId];
+			const b = messagesGraph[second.rootMessageId];
+
+			if (a.createdAt !== b.createdAt) {
+				return a.createdAt < b.createdAt ? -1 : 1;
+			}
+
+			return first.id < second.id ? -1 : 1;
+		};
+
+		turns.sort(sortByTime);
+
+		const dto: ChatHubConversationResponse = {
+			session: {
+				id: session.id,
+				title: session.title,
+				ownerId: session.ownerId,
+				lastMessageAt: session.lastMessageAt?.toISOString() ?? null,
+				credentialId: session.credentialId,
+				provider: session.provider,
+				model: session.model,
+				workflowId: session.workflowId,
+				createdAt: session.createdAt.toISOString(),
+				updatedAt: session.updatedAt.toISOString(),
+			},
+
+			graph: {
+				messages: messagesGraph,
+				rootIds,
+				turnRootIds,
+			},
+
+			timeline: {
+				turns,
+			},
+		};
+
+		return dto;
 	}
 }

--- a/packages/cli/src/modules/chat-hub/chat-hub.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.service.ts
@@ -602,7 +602,7 @@ export class ChatHubService {
 			this.buildMessagesGraph(messages);
 
 		const rootIds = messages.filter((r) => r.previousMessageId === null).map((r) => r.id);
-		const activeThread = this.buildActiveThread(messages);
+		const activeMessageChain = this.buildactiveMessageChain(messages);
 
 		return {
 			session: {
@@ -620,7 +620,7 @@ export class ChatHubService {
 			conversation: {
 				messages: messagesGraph,
 				rootIds,
-				activeThread,
+				activeMessageChain,
 			},
 		};
 	}
@@ -690,23 +690,23 @@ export class ChatHubService {
 		return messagesGraph;
 	}
 
-	private buildActiveThread(messages: ChatHubMessage[]) {
+	private buildactiveMessageChain(messages: ChatHubMessage[]) {
 		const nodes = new Map(messages.map((m) => [m.id, m]));
 		const activeMessages = messages.filter((m) => m.state === 'active');
 
 		const visited = new Set<string>();
-		const activeThread = [];
+		const activeMessageChain = [];
 		const latest = activeMessages[activeMessages.length - 1]; // Messages are sorted by createdAt
 
 		let current = latest ? latest.id : null;
 
 		while (current && !visited.has(current)) {
-			activeThread.unshift(current);
+			activeMessageChain.unshift(current);
 			visited.add(current);
 			current = nodes.get(current)?.previousMessageId ?? null;
 		}
 
-		return activeThread;
+		return activeMessageChain;
 	}
 
 	async deleteAllSessions() {

--- a/packages/cli/src/modules/chat-hub/chat-hub.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.service.ts
@@ -602,7 +602,7 @@ export class ChatHubService {
 			this.buildMessagesGraph(messages);
 
 		const rootIds = messages.filter((r) => r.previousMessageId === null).map((r) => r.id);
-		const activeMessageChain = this.buildactiveMessageChain(messages);
+		const activeMessageChain = this.buildActiveMessageChain(messages);
 
 		return {
 			session: {
@@ -690,7 +690,7 @@ export class ChatHubService {
 		return messagesGraph;
 	}
 
-	private buildactiveMessageChain(messages: ChatHubMessage[]) {
+	private buildActiveMessageChain(messages: ChatHubMessage[]) {
 		const nodes = new Map(messages.map((m) => [m.id, m]));
 		const activeMessages = messages.filter((m) => m.state === 'active');
 

--- a/packages/cli/src/modules/chat-hub/chat-hub.types.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.types.ts
@@ -19,8 +19,6 @@ export type ChatMessage = {
 	createdAt: Date;
 };
 
-export type ChatHubMessageState = 'active' | 'superseded' | 'hidden' | 'deleted';
-
 // From packages/@n8n/nodes-langchain/nodes/memory/MemoryManager/MemoryManager.node.ts
 export type MessageRole = 'ai' | 'system' | 'user';
 export interface MessageRecord {

--- a/packages/cli/src/modules/chat-hub/chat-message.repository.ts
+++ b/packages/cli/src/modules/chat-hub/chat-message.repository.ts
@@ -32,7 +32,7 @@ export class ChatHubMessageRepository extends Repository<ChatHubMessage> {
 	async getManyBySessionId(sessionId: string) {
 		return await this.find({
 			where: { sessionId },
-			order: { createdAt: 'ASC' },
+			order: { createdAt: 'ASC', id: 'DESC' },
 		});
 	}
 }

--- a/packages/cli/src/modules/chat-hub/chat-session.repository.ts
+++ b/packages/cli/src/modules/chat-hub/chat-session.repository.ts
@@ -50,7 +50,7 @@ export class ChatHubSessionRepository extends Repository<ChatHubSession> {
 	async getManyByUserId(userId: string) {
 		return await this.find({
 			where: { ownerId: userId },
-			order: { lastMessageAt: 'DESC' },
+			order: { lastMessageAt: 'DESC', id: 'ASC' },
 		});
 	}
 

--- a/packages/cli/src/modules/chat-hub/chat-session.repository.ts
+++ b/packages/cli/src/modules/chat-hub/chat-session.repository.ts
@@ -60,4 +60,10 @@ export class ChatHubSessionRepository extends Repository<ChatHubSession> {
 			relations: ['messages'],
 		});
 	}
+
+	async deleteAll(trx?: EntityManager) {
+		return await withTransaction(this.manager, trx, async (em) => {
+			return await em.createQueryBuilder().delete().from(ChatHubSession).execute();
+		});
+	}
 }

--- a/packages/frontend/editor-ui/src/features/chatHub/chat.api.ts
+++ b/packages/frontend/editor-ui/src/features/chatHub/chat.api.ts
@@ -5,7 +5,7 @@ import type {
 	ChatModelsRequest,
 	ChatModelsResponse,
 	ChatHubConversationsResponse,
-	ChatHubMessagesResponse,
+	ChatHubConversationResponse,
 } from '@n8n/api-types';
 import type { StructuredChunk } from './chat.types';
 
@@ -42,10 +42,10 @@ export const fetchConversationsApi = async (
 	return await makeRestApiRequest<ChatHubConversationsResponse>(context, 'GET', apiEndpoint);
 };
 
-export const fetchConversationMessagesApi = async (
+export const fetchSingleConversationApi = async (
 	context: IRestApiContext,
 	conversationId: string,
-): Promise<ChatHubMessagesResponse> => {
-	const apiEndpoint = `/chat/conversations/${conversationId}/messages`;
-	return await makeRestApiRequest<ChatHubMessagesResponse>(context, 'GET', apiEndpoint);
+): Promise<ChatHubConversationResponse> => {
+	const apiEndpoint = `/chat/conversations/${conversationId}`;
+	return await makeRestApiRequest<ChatHubConversationResponse>(context, 'GET', apiEndpoint);
 };

--- a/packages/frontend/editor-ui/src/features/chatHub/chat.store.ts
+++ b/packages/frontend/editor-ui/src/features/chatHub/chat.store.ts
@@ -171,6 +171,7 @@ export const useChatStore = defineStore(CHAT_STORE, () => {
 		credentials: ChatHubSendMessageRequest['credentials'],
 	) {
 		const messageId = uuidv4();
+		const replyId = uuidv4();
 		const previousMessageId = getLastMessage(sessionId)?.id ?? null;
 
 		addUserMessage(sessionId, message, messageId);
@@ -181,11 +182,12 @@ export const useChatStore = defineStore(CHAT_STORE, () => {
 				model,
 				messageId,
 				sessionId,
+				replyId,
 				message,
 				credentials,
 				previousMessageId,
 			},
-			(chunk: StructuredChunk) => onStreamMessage(sessionId, chunk, messageId),
+			(chunk: StructuredChunk) => onStreamMessage(sessionId, chunk, replyId),
 			onStreamDone,
 			onStreamError,
 		);

--- a/packages/frontend/editor-ui/src/features/chatHub/chat.store.ts
+++ b/packages/frontend/editor-ui/src/features/chatHub/chat.store.ts
@@ -46,11 +46,11 @@ export const useChatStore = defineStore(CHAT_STORE, () => {
 
 	async function fetchMessages(sessionId: string) {
 		const { conversation } = await fetchMessagesApi(rootStore.restApiContext, sessionId);
-		const { messages, activeThread } = conversation;
+		const { messages, activeMessageChain } = conversation;
 
 		messagesBySession.value = {
 			...messagesBySession.value,
-			[sessionId]: activeThread.map((id) => ({
+			[sessionId]: activeMessageChain.map((id) => ({
 				id: messages[id].id,
 				role: messages[id].type === 'ai' ? 'assistant' : 'user',
 				type: 'message' as const,

--- a/packages/frontend/editor-ui/src/features/chatHub/chat.store.ts
+++ b/packages/frontend/editor-ui/src/features/chatHub/chat.store.ts
@@ -13,7 +13,7 @@ import type {
 	ChatHubConversationModel,
 	ChatHubSendMessageRequest,
 	ChatModelsResponse,
-	ChatHubSesssionDto,
+	ChatHubSessionDto,
 } from '@n8n/api-types';
 import type { StructuredChunk, ChatMessage, CredentialsMap } from './chat.types';
 
@@ -23,7 +23,7 @@ export const useChatStore = defineStore(CHAT_STORE, () => {
 	const loadingModels = ref(false);
 	const isResponding = ref(false);
 	const messagesBySession = ref<Partial<Record<string, ChatMessage[]>>>({});
-	const sessions = ref<ChatHubSesssionDto[]>([]);
+	const sessions = ref<ChatHubSessionDto[]>([]);
 
 	const getLastMessage = (sessionId: string) => {
 		const msgs = messagesBySession.value[sessionId];

--- a/packages/frontend/editor-ui/src/features/chatHub/chat.utils.ts
+++ b/packages/frontend/editor-ui/src/features/chatHub/chat.utils.ts
@@ -2,7 +2,7 @@ import {
 	chatHubProviderSchema,
 	type ChatHubConversationModel,
 	type ChatModelsResponse,
-	type ChatHubConversation,
+	type ChatHubSesssionDto,
 } from '@n8n/api-types';
 import type { GroupedConversations } from './chat.types';
 
@@ -40,8 +40,8 @@ export function getRelativeDate(dateString: string): string {
 	}
 }
 
-export function groupConversationsByDate(sessions: ChatHubConversation[]): GroupedConversations[] {
-	const groups = new Map<string, ChatHubConversation[]>();
+export function groupConversationsByDate(sessions: ChatHubSesssionDto[]): GroupedConversations[] {
+	const groups = new Map<string, ChatHubSesssionDto[]>();
 
 	// Group sessions by relative date
 	sessions.forEach((session) => {

--- a/packages/frontend/editor-ui/src/features/chatHub/chat.utils.ts
+++ b/packages/frontend/editor-ui/src/features/chatHub/chat.utils.ts
@@ -40,8 +40,8 @@ export function getRelativeDate(dateString: string): string {
 	}
 }
 
-export function groupConversationsByDate(sessions: ChatHubSesssionDto[]): GroupedConversations[] {
-	const groups = new Map<string, ChatHubSesssionDto[]>();
+export function groupConversationsByDate(sessions: ChatHubSessionDto[]): GroupedConversations[] {
+	const groups = new Map<string, ChatHubSessionDto[]>();
 
 	// Group sessions by relative date
 	sessions.forEach((session) => {

--- a/packages/frontend/editor-ui/src/features/chatHub/chat.utils.ts
+++ b/packages/frontend/editor-ui/src/features/chatHub/chat.utils.ts
@@ -2,7 +2,7 @@ import {
 	chatHubProviderSchema,
 	type ChatHubConversationModel,
 	type ChatModelsResponse,
-	type ChatHubSesssionDto,
+	type ChatHubSessionDto,
 } from '@n8n/api-types';
 import type { GroupedConversations } from './chat.types';
 


### PR DESCRIPTION
## Summary

This PR implements endpoints for listing conversations and reading conversation messages from the backend db.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-15/add-endpoint-that-returns-all-users-conversations
https://linear.app/n8n/issue/CHA-16/add-endpoint-that-returns-single-conversation-by-id-with-full-message

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
