### PR TITLE
chore(core): Send custom n8n scope in OIDC for provisioning if configured

### DIFF
--- a/packages/cli/src/sso.ee/oidc/oidc.service.ee.ts
+++ b/packages/cli/src/sso.ee/oidc/oidc.service.ee.ts
@@ -176,10 +176,19 @@ export class OidcService {
 
 		const prompt = this.oidcConfig.prompt;
 
+		const provisioning = this.globalConfig.sso.provisioning;
+		const provisioningEnabled =
+			provisioning.scopesProvisionInstanceRole || provisioning.scopesProvisionProjectRoles;
+
+		// Include the custom n8n scope if provisioning is enabled
+		const scope = provisioningEnabled
+			? `openid email profile ${provisioning.scopesName}`
+			: 'openid email profile';
+
 		const authorizationURL = client.buildAuthorizationUrl(configuration, {
 			redirect_uri: this.getCallbackUrl(),
 			response_type: 'code',
-			scope: 'openid email profile',
+			scope,
 			prompt,
 			state: state.plaintext,
 			nonce: nonce.plaintext,


### PR DESCRIPTION
## Summary

If provisioning is enabled for project or instance roles, request the scope name from the IdP.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-3955/support-scopes-claims-within-oidc-logins

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
