### PR TITLE
refactor(core): Ensure `debug` command waits for broker in native Python runner

### DIFF
--- a/packages/@n8n/task-runner-python/justfile
+++ b/packages/@n8n/task-runner-python/justfile
@@ -36,6 +36,17 @@ test-v:
 typecheck:
     uv run ty check src/
 
-# For debugging only, start the runner with a manually fetched grant token.
+# For debugging only, start the runner with a manually fetched grant token. If no broker, wait until available.
 debug:
-    GRANT_TOKEN=$(curl -s -X POST http://127.0.0.1:5679/runners/auth -H "Content-Type: application/json" -d '{"token":"test"}' | jq -r '.data.token') && N8N_RUNNERS_GRANT_TOKEN="$GRANT_TOKEN" just run
+    #!/usr/bin/env bash
+    for i in {1..30}; do
+        GRANT_TOKEN=$(curl -s -X POST http://127.0.0.1:5679/runners/auth -H "Content-Type: application/json" -d '{"token":"test"}' | jq -r '.data.token')
+        if [ -n "$GRANT_TOKEN" ] && [ "$GRANT_TOKEN" != "null" ]; then
+            N8N_RUNNERS_GRANT_TOKEN="$GRANT_TOKEN" just run
+            exit 0
+        fi
+        [ $i -eq 1 ] && echo "Waiting for n8n task broker server at http://127.0.0.1:5679..."
+        sleep 1
+    done
+    echo "Error: Could not connect to n8n task broker server after 30 seconds"
+    exit 1


### PR DESCRIPTION
When starting a Python runner using the `just debug` command without an active task broker, the command fails immediately with a misleading message `Environment variable N8N_RUNNERS_GRANT_TOKEN is required` because `curl` fails leading `jq` to misparse. This change makes it so the debug runner waits for 30s until there's an active task broker.

Smalll DX improvement as I keep running into this.