### PR TITLE
Fix(editor): Data Table does not auto-refresh dependent columns (e.g., updated_at) after update

### DIFF
--- a/packages/frontend/editor-ui/src/features/dataTable/composables/useDataTableOperations.ts
+++ b/packages/frontend/editor-ui/src/features/dataTable/composables/useDataTableOperations.ts
@@ -247,6 +247,14 @@ export const useDataTableOperations = ({
 			await dataTableStore.updateRow(dataTableId, projectId, id, {
 				[fieldName]: value,
 			});
+			const updatedRow = await dataTableStore.fetchRowById(dataTableId, projectId, id);
+			if (updatedRow) {
+				const rowIndex = rowData.value.findIndex((row) => row.id === id);
+				if (rowIndex !== -1) {
+					rowData.value[rowIndex] = updatedRow;
+					setGridData({ rowData: rowData.value });
+				}
+			}
 			telemetry.track('User edited data table content', {
 				data_table_id: dataTableId,
 				column_id: colDef.colId,

--- a/packages/frontend/editor-ui/src/features/dataTable/composables/useDataTableOperations.ts
+++ b/packages/frontend/editor-ui/src/features/dataTable/composables/useDataTableOperations.ts
@@ -247,19 +247,6 @@ export const useDataTableOperations = ({
 			await dataTableStore.updateRow(dataTableId, projectId, id, {
 				[fieldName]: value,
 			});
-			const updatedRow = await dataTableStore.fetchRowById(dataTableId, projectId, id);
-			if (updatedRow) {
-				const rowIndex = rowData.value.findIndex((row) => row.id === id);
-				if (rowIndex !== -1) {
-					rowData.value[rowIndex] = updatedRow;
-					setGridData({ rowData: rowData.value });
-				}
-			}
-			telemetry.track('User edited data table content', {
-				data_table_id: dataTableId,
-				column_id: colDef.colId,
-				column_type: colDef.cellDataType,
-			});
 		} catch (error) {
 			// Revert cell to original value if the update fails
 			const validOldValue = isDataTableValue(oldValue) ? oldValue : null;
@@ -271,9 +258,30 @@ export const useDataTableOperations = ({
 				update: [revertedData],
 			});
 			toast.showError(error, i18n.baseText('dataTable.updateRow.error'));
+			return;
 		} finally {
 			toggleSave(false);
 		}
+
+		// Fetch the updated row, but do not revert if fetch fails
+		try {
+			const updatedRow = await dataTableStore.fetchRowById(dataTableId, projectId, id);
+			if (updatedRow) {
+				const rowIndex = rowData.value.findIndex((row) => row.id === id);
+				if (rowIndex !== -1) {
+					rowData.value[rowIndex] = updatedRow;
+					setGridData({ rowData: rowData.value });
+				}
+			}
+		} catch (fetchError) {
+			toast.showError(fetchError, i18n.baseText('dataTable.fetchRow.error'));
+		}
+
+		telemetry.track('User edited data table content', {
+			data_table_id: dataTableId,
+			column_id: colDef.colId,
+			column_type: colDef.cellDataType,
+		});
 	};
 
 	async function fetchDataTableRows() {

--- a/packages/frontend/editor-ui/src/features/dataTable/dataTable.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/dataTable/dataTable.store.test.ts
@@ -423,4 +423,33 @@ describe('dataTable.store', () => {
 			expect(dataTableStore.maxSizeMB).toBe(10);
 		});
 	});
+	describe('fetchRowById', () => {
+		it('should fetch a single row by id', async () => {
+			const mockRow = { id: 42, name: 'Test Row', updatedAt: '2025-10-14T12:00:00Z' };
+			const mockResponse = { count: 1, data: [mockRow] };
+			const getDataTableRowsApiSpy = vi
+				.spyOn(dataTableApi, 'getDataTableRowsApi')
+				.mockResolvedValue(mockResponse);
+
+			const result = await dataTableStore.fetchRowById('dt-1', 'p1', 42);
+
+			expect(getDataTableRowsApiSpy).toHaveBeenCalledWith(rootStore.restApiContext, 'dt-1', 'p1', {
+				filter: JSON.stringify({
+					type: 'and',
+					filters: [{ columnName: 'id', condition: 'eq', value: 42 }],
+				}),
+				take: 1,
+			});
+			expect(result).toEqual(mockRow);
+		});
+
+		it('should return null if no row is found', async () => {
+			const mockResponse = { count: 0, data: [] };
+			vi.spyOn(dataTableApi, 'getDataTableRowsApi').mockResolvedValue(mockResponse);
+
+			const result = await dataTableStore.fetchRowById('dt-1', 'p1', 99);
+
+			expect(result).toBeNull();
+		});
+	});
 });

--- a/packages/frontend/editor-ui/src/features/dataTable/dataTable.store.ts
+++ b/packages/frontend/editor-ui/src/features/dataTable/dataTable.store.ts
@@ -245,6 +245,16 @@ export const useDataTableStore = defineStore(DATA_TABLE_STORE, () => {
 
 		return result;
 	};
+	const fetchRowById = async (dataStoreId: string, projectId: string, rowId: number) => {
+		const response = await getDataTableRowsApi(rootStore.restApiContext, dataStoreId, projectId, {
+			filter: JSON.stringify({
+				type: 'and',
+				filters: [{ columnName: 'id', condition: 'eq', value: rowId }],
+			}),
+			take: 1,
+		});
+		return response.data?.[0] ?? null;
+	};
 
 	return {
 		dataTables,
@@ -267,5 +277,6 @@ export const useDataTableStore = defineStore(DATA_TABLE_STORE, () => {
 		insertEmptyRow,
 		updateRow,
 		deleteRows,
+		fetchRowById,
 	};
 });


### PR DESCRIPTION
## Summary
Fixes the issue where editing a cell in the Data Table only updates the edited field, leaving dependent columns like `updated_at` stale until page reload.

After a cell value change:
- Calls `updateRow` with the new data.
- Immediately fetches the full updated row via `fetchRowById` to get server-generated fields (e.g., new `updatedAt` timestamp).
- Replaces the local row in `rowData` with the fresh data.
- Triggers `setGridData` to refresh the AG Grid view.

This ensures the UI reflects backend changes without requiring a full page reload.

https://github.com/user-attachments/assets/bf995254-83e6-46c9-bb48-6344eca9d416


## Related Linear tickets, Github issues, and Community forum posts
fixes #20740


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

## Additional Notes
- Backend already updates `updated_at` correctly—this is purely a frontend refresh fix.
- No new dependencies added.
- Tested in self-hosted mode (n8n v1.116.0).
