### PR TITLE
fix(nodes-base): SendGrid credentials test uses /scopes instead of marketing endpoint to avoid false 403 (credentials without Marketing scope)

### DIFF
--- a/packages/nodes-base/credentials/SendGridApi.credentials.ts
+++ b/packages/nodes-base/credentials/SendGridApi.credentials.ts
@@ -34,7 +34,7 @@ export class SendGridApi implements ICredentialType {
 	test: ICredentialTestRequest = {
 		request: {
 			baseURL: 'https://api.sendgrid.com/v3',
-			url: '/marketing/contacts',
+			url: '/scopes',
 		},
 	};
 }


### PR DESCRIPTION
Summary

Change SendGrid credentials test endpoint from /marketing/contacts to /scopes to avoid false 403 for API keys without Marketing Campaigns scope.

Problem
- The current credential test hits /marketing/contacts, which requires Marketing permissions. Many SendGrid API keys are scoped only for Mail Send, so the test returns 403 and n8n displays a misleading credentials error.

Change details
- Updated file: packages/nodes-base/credentials/SendGridApi.credentials.ts
- Changed test.request.url from /marketing/contacts to /scopes
- Authorization header remains Bearer <apiKey> via existing credentials config
- No runtime changes to SendGrid node requests or behavior

Rationale
- /scopes is a minimal, safe endpoint that returns the API key scopes and is accessible with any valid API key, independent of Marketing Campaigns scope. This avoids false negatives during credential testing.

Reproduction (before)
1) Create a SendGrid API key without Marketing Campaigns permissions (e.g., Mail Send only).
2) Configure SendGrid credentials in n8n and click Test.
3) Result: 403 Forbidden → n8n shows "Forbidden - perhaps check your credentials?" despite a valid key.

Expected (after)
- Testing the same credentials should succeed because /scopes doesn’t require Marketing permissions.

Testing
- Lint passes locally via pre-commit hook.
- Manual check: GET https://api.sendgrid.com/v3/scopes with a Bearer key returns 200 with scopes for valid keys.

Impact
- No breaking changes.
- Only the credential test endpoint is adjusted; actual node operations (Mail/Marketing) remain unchanged and still require appropriate SendGrid scopes at execution time.

Docs
- No docs changes needed. Existing docs remain accurate; this reduces confusion in the credentials test.

Checklist
- [x] Small, focused PR
- [x] Lint/format pass
- [x] Clear rationale and testing notes
- [ ] Additional automated tests (not applicable here; behavior unchanged at runtime)
