### PR TITLE
fix: Fix source control pull information toast

### DIFF
--- a/packages/frontend/editor-ui/src/features/sourceControl.ee/components/SourceControlPullModal.vue
+++ b/packages/frontend/editor-ui/src/features/sourceControl.ee/components/SourceControlPullModal.vue
@@ -73,7 +73,7 @@ async function loadSourceControlStatus() {
 
 	try {
 		const freshStatus = await sourceControlStore.pullWorkfolder(false);
-		await notifyUserAboutPullWorkFolderOutcome(freshStatus, toast);
+		await notifyUserAboutPullWorkFolderOutcome(freshStatus, toast, router);
 		sourceControlEventBus.emit('pull');
 		close();
 	} catch (error) {
@@ -209,7 +209,7 @@ async function pullWorkfolder() {
 	try {
 		const pullStatus = await sourceControlStore.pullWorkfolder(true);
 
-		await notifyUserAboutPullWorkFolderOutcome(pullStatus, toast);
+		await notifyUserAboutPullWorkFolderOutcome(pullStatus, toast, router);
 
 		sourceControlEventBus.emit('pull');
 	} catch (error) {

--- a/packages/frontend/editor-ui/src/features/sourceControl.ee/sourceControl.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/sourceControl.ee/sourceControl.utils.test.ts
@@ -6,9 +6,9 @@ import {
 	notifyUserAboutPullWorkFolderOutcome,
 } from './sourceControl.utils';
 import type { useToast } from '@/composables/useToast';
+import type { Router } from 'vue-router';
 
 import { SOURCE_CONTROL_FILE_STATUS } from '@n8n/api-types';
-import { Router } from 'vue-router';
 
 describe('source control utils', () => {
 	describe('getStatusText()', () => {

--- a/packages/frontend/editor-ui/src/features/sourceControl.ee/sourceControl.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/sourceControl.ee/sourceControl.utils.test.ts
@@ -8,6 +8,7 @@ import {
 import type { useToast } from '@/composables/useToast';
 
 import { SOURCE_CONTROL_FILE_STATUS } from '@n8n/api-types';
+import { Router } from 'vue-router';
 
 describe('source control utils', () => {
 	describe('getStatusText()', () => {
@@ -39,7 +40,11 @@ describe('source control utils', () => {
 	describe('notifyUserAboutPullWorkFolderOutcome()', () => {
 		it('should show up to date notification when there are no changes', async () => {
 			const toast = { showMessage: vi.fn() } as unknown as ReturnType<typeof useToast>;
-			await notifyUserAboutPullWorkFolderOutcome([], toast);
+			const router = {
+				push: vi.fn(),
+				resolve: vi.fn().mockReturnValue({ href: '/test' }),
+			} as unknown as Router;
+			await notifyUserAboutPullWorkFolderOutcome([], toast, router);
 
 			expect(toast.showMessage).toHaveBeenCalledWith(
 				expect.objectContaining({
@@ -50,6 +55,10 @@ describe('source control utils', () => {
 
 		it('should show granular feedback', async () => {
 			const toast = { showToast: vi.fn() } as unknown as ReturnType<typeof useToast>;
+			const router = {
+				push: vi.fn(),
+				resolve: vi.fn().mockReturnValue({ href: '/test' }),
+			} as unknown as Router;
 			await notifyUserAboutPullWorkFolderOutcome(
 				[
 					{
@@ -94,6 +103,7 @@ describe('source control utils', () => {
 					},
 				],
 				toast,
+				router,
 			);
 
 			expect(toast.showToast).toHaveBeenNthCalledWith(

--- a/packages/frontend/editor-ui/src/features/sourceControl.ee/sourceControl.utils.ts
+++ b/packages/frontend/editor-ui/src/features/sourceControl.ee/sourceControl.utils.ts
@@ -47,7 +47,8 @@ export const getPushPriorityByStatus = (status: SourceControlledFileStatus) =>
 	pushStatusPriority[status] ?? 0;
 
 const createVariablesToast = (router: Router) => {
-	const { href } = router.resolve({ name: VIEWS.VARIABLES, query: { incomplete: 'true' } });
+	const route = { name: VIEWS.VARIABLES, query: { incomplete: 'true' } };
+	const { href } = router.resolve(route);
 
 	return {
 		title: i18n.baseText('settings.sourceControl.pull.upToDate.variables.title'),
@@ -55,8 +56,10 @@ const createVariablesToast = (router: Router) => {
 			'a',
 			{
 				href,
-				onClick: () => {
+				onClick: (e: MouseEvent) => {
+					e.preventDefault();
 					telemetry.track('User clicked review variables');
+					void router.push(route);
 				},
 			},
 			i18n.baseText('settings.sourceControl.pull.upToDate.variables.description'),
@@ -67,7 +70,8 @@ const createVariablesToast = (router: Router) => {
 };
 
 const createCredentialsToast = (router: Router) => {
-	const { href } = router.resolve({ name: VIEWS.CREDENTIALS, query: { setupNeeded: 'true' } });
+	const route = { name: VIEWS.CREDENTIALS, query: { setupNeeded: 'true' } };
+	const { href } = router.resolve(route);
 
 	return {
 		title: i18n.baseText('settings.sourceControl.pull.upToDate.credentials.title'),
@@ -75,8 +79,10 @@ const createCredentialsToast = (router: Router) => {
 			'a',
 			{
 				href,
-				onClick: () => {
+				onClick: (e: MouseEvent) => {
+					e.preventDefault();
 					telemetry.track('User clicked review credentials');
+					void router.push(route);
 				},
 			},
 			i18n.baseText('settings.sourceControl.pull.upToDate.credentials.description'),

--- a/packages/frontend/editor-ui/src/features/sourceControl.ee/sourceControl.utils.ts
+++ b/packages/frontend/editor-ui/src/features/sourceControl.ee/sourceControl.utils.ts
@@ -1,5 +1,5 @@
 import { h, nextTick } from 'vue';
-import { RouterLink } from 'vue-router';
+import type { Router } from 'vue-router';
 import { useI18n } from '@n8n/i18n';
 import { type SourceControlledFile, SOURCE_CONTROL_FILE_STATUS } from '@n8n/api-types';
 import type { BaseTextKey } from '@n8n/i18n';
@@ -46,36 +46,44 @@ const pushStatusPriority: StatusPriority = {
 export const getPushPriorityByStatus = (status: SourceControlledFileStatus) =>
 	pushStatusPriority[status] ?? 0;
 
-const variablesToast = {
-	title: i18n.baseText('settings.sourceControl.pull.upToDate.variables.title'),
-	message: h(
-		RouterLink,
-		{
-			to: { name: VIEWS.VARIABLES, query: { incomplete: 'true' } },
-			onClick: () => {
-				telemetry.track('User clicked review variables');
+const createVariablesToast = (router: Router) => {
+	const { href } = router.resolve({ name: VIEWS.VARIABLES, query: { incomplete: 'true' } });
+
+	return {
+		title: i18n.baseText('settings.sourceControl.pull.upToDate.variables.title'),
+		message: h(
+			'a',
+			{
+				href,
+				onClick: () => {
+					telemetry.track('User clicked review variables');
+				},
 			},
-		},
-		() => i18n.baseText('settings.sourceControl.pull.upToDate.variables.description'),
-	),
-	type: 'info' as const,
-	duration: 0,
+			i18n.baseText('settings.sourceControl.pull.upToDate.variables.description'),
+		),
+		type: 'info' as const,
+		duration: 0,
+	};
 };
 
-const credentialsToast = {
-	title: i18n.baseText('settings.sourceControl.pull.upToDate.credentials.title'),
-	message: h(
-		RouterLink,
-		{
-			to: { name: VIEWS.CREDENTIALS, query: { setupNeeded: 'true' } },
-			onClick: () => {
-				telemetry.track('User clicked review credentials');
+const createCredentialsToast = (router: Router) => {
+	const { href } = router.resolve({ name: VIEWS.CREDENTIALS, query: { setupNeeded: 'true' } });
+
+	return {
+		title: i18n.baseText('settings.sourceControl.pull.upToDate.credentials.title'),
+		message: h(
+			'a',
+			{
+				href,
+				onClick: () => {
+					telemetry.track('User clicked review credentials');
+				},
 			},
-		},
-		() => i18n.baseText('settings.sourceControl.pull.upToDate.credentials.description'),
-	),
-	type: 'info' as const,
-	duration: 0,
+			i18n.baseText('settings.sourceControl.pull.upToDate.credentials.description'),
+		),
+		type: 'info' as const,
+		duration: 0,
+	};
 };
 
 const pullMessage = ({
@@ -126,6 +134,7 @@ const pullMessage = ({
 export const notifyUserAboutPullWorkFolderOutcome = async (
 	files: SourceControlledFile[],
 	toast: ReturnType<typeof useToast>,
+	router: Router,
 ) => {
 	if (!files?.length) {
 		toast.showMessage({
@@ -139,8 +148,8 @@ export const notifyUserAboutPullWorkFolderOutcome = async (
 	const { credential, tags, variables, workflow, folders } = groupBy(files, 'type');
 
 	const toastMessages = [
-		...(variables?.length ? [variablesToast] : []),
-		...(credential?.length ? [credentialsToast] : []),
+		...(variables?.length ? [createVariablesToast(router)] : []),
+		...(credential?.length ? [createCredentialsToast(router)] : []),
 		{
 			title: i18n.baseText('settings.sourceControl.pull.success.title'),
 			message: pullMessage({ credential, tags, variables, workflow, folders }),
@@ -155,7 +164,6 @@ export const notifyUserAboutPullWorkFolderOutcome = async (
 		 * Credentials
 		 * Variables
 		 */
-		//
 		toast.showToast(message);
 		await nextTick();
 	}


### PR DESCRIPTION
## Summary

Use `<a>` component instead of `RouterLink` for the toast information message.  


Before
<img width="1483" height="681" alt="image" src="https://github.com/user-attachments/assets/ab10cc22-fad2-438d-bb1a-c0ffab6ec5fe" />

After
<img width="1476" height="739" alt="image" src="https://github.com/user-attachments/assets/dca4cdac-3808-4578-88d0-46c5bb1e6ba8" />



## Related Linear tickets, Github issues, and Community forum posts

fixes PAY-3981

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
