### PR TITLE
fix(Gmail Trigger Node): Prevent missing emails between polling intervals

### DIFF
--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -269,13 +269,17 @@ export class GmailTrigger implements INodeType {
 		}
 
 		const now = Math.floor(DateTime.now().toSeconds()).toString();
+
+		if (this.getMode() !== 'manual') {
+			nodeStaticData.lastTimeChecked ??= +now;
+		}
 		const startDate = nodeStaticData.lastTimeChecked ?? +now;
-		const endDate = +now;
 
 		const options = this.getNodeParameter('options', {}) as GmailTriggerOptions;
 		const filters = this.getNodeParameter('filters', {}) as GmailTriggerFilters;
 
 		let responseData: INodeExecutionData[] = [];
+		const allFetchedMessages: Message[] = [];
 
 		try {
 			const qs: IDataObject = {};
@@ -299,7 +303,6 @@ export class GmailTrigger implements INodeType {
 			const messages = messagesResponse.messages ?? [];
 
 			if (!messages.length) {
-				nodeStaticData.lastTimeChecked = endDate;
 				return null;
 			}
 
@@ -329,6 +332,8 @@ export class GmailTrigger implements INodeType {
 					{},
 					qs,
 				)) as Message;
+
+				allFetchedMessages.push(fullMessage);
 
 				if (!includeDrafts) {
 					if (fullMessage.labelIds?.includes('DRAFT')) {
@@ -376,8 +381,8 @@ export class GmailTrigger implements INodeType {
 				},
 			);
 		}
-		if (!responseData.length) {
-			nodeStaticData.lastTimeChecked = endDate;
+
+		if (!allFetchedMessages.length) {
 			return null;
 		}
 
@@ -402,17 +407,15 @@ export class GmailTrigger implements INodeType {
 			return date;
 		};
 
-		const lastEmailDate = responseData.reduce((lastDate, { json }) => {
-			const emailDate = getEmailDateAsSeconds(json as Message);
+		const lastEmailDate = allFetchedMessages.reduce((lastDate, message) => {
+			const emailDate = getEmailDateAsSeconds(message);
 			return emailDate > lastDate ? emailDate : lastDate;
 		}, 0);
 
-		const nextPollPossibleDuplicates = responseData
-			.filter((item) => item.json)
-			.reduce((duplicates, { json }) => {
-				const emailDate = getEmailDateAsSeconds(json as Message);
-				return emailDate <= lastEmailDate ? duplicates.concat((json as Message).id) : duplicates;
-			}, Array.from(emailsWithInvalidDate));
+		const nextPollPossibleDuplicates = allFetchedMessages.reduce((duplicates, message) => {
+			const emailDate = getEmailDateAsSeconds(message);
+			return emailDate <= lastEmailDate ? duplicates.concat(message.id) : duplicates;
+		}, Array.from(emailsWithInvalidDate));
 
 		const possibleDuplicates = new Set(nodeStaticData.possibleDuplicates ?? []);
 		if (possibleDuplicates.size > 0) {
@@ -423,7 +426,7 @@ export class GmailTrigger implements INodeType {
 		}
 
 		nodeStaticData.possibleDuplicates = nextPollPossibleDuplicates;
-		nodeStaticData.lastTimeChecked = lastEmailDate || endDate;
+		nodeStaticData.lastTimeChecked = lastEmailDate ?? +startDate;
 
 		if (Array.isArray(responseData) && responseData.length) {
 			return [responseData];


### PR DESCRIPTION
## Summary

Fixed Gmail trigger node missing emails in certain edge cases by improving timestamp tracking and handling of filtered messages.

- Updated `lastTimeChecked` to use last email timestamp instead of current time to prevent gaps between polls
- Track all fetched messages separately from filtered results to ensure proper timestamp updates
- Skip timestamp initialization in manual mode to prevent state corruption during testing
- Improved duplicate detection to work with all fetched messages
- Added tests

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3555/bug-gmail-trigger-doesnt-fire-sometimes

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
