### PR TITLE
fix(editor): Fix box shadow format (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/chatHub/components/ChatPrompt.vue
+++ b/packages/frontend/editor-ui/src/features/chatHub/components/ChatPrompt.vue
@@ -110,7 +110,7 @@ defineExpose({
 		border-radius: 16px !important;
 		resize: none;
 		padding: 16px;
-		box-shadow: 0px 10px 24px 0px #0000002e;
+		box-shadow: 0 10px 24px 0 #0000002e;
 	}
 }
 


### PR DESCRIPTION
## Summary

Format keeps getting changed by biome post-commit. It's annoying.

## Related Linear tickets, Github issues, and Community forum posts

N/A


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
