### PR TITLE
refactor(editor): Extract `useBuilderMessages` into features/assistant (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/assistant/builder.store.ts
+++ b/packages/frontend/editor-ui/src/features/assistant/builder.store.ts
@@ -19,7 +19,7 @@ import { useI18n } from '@n8n/i18n';
 import { useTelemetry } from '@/composables/useTelemetry';
 import { usePostHog } from '@/stores/posthog.store';
 import { useWorkflowsStore } from '@/stores/workflows.store';
-import { useBuilderMessages } from '@/composables/useBuilderMessages';
+import { useBuilderMessages } from './composables/useBuilderMessages';
 import { chatWithBuilder, getAiSessions, getBuilderCredits, getSessionsMetadata } from '@/api/ai';
 import { generateMessageId, createBuilderPayload } from '@/helpers/builderHelpers';
 import { useRootStore } from '@n8n/stores/useRootStore';

--- a/packages/frontend/editor-ui/src/features/assistant/composables/useBuilderMessages.test.ts
+++ b/packages/frontend/editor-ui/src/features/assistant/composables/useBuilderMessages.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { useBuilderMessages } from '@/composables/useBuilderMessages';
+import { useBuilderMessages } from './useBuilderMessages';
 import type { ChatUI } from '@n8n/design-system/types/assistant';
-import type { ChatRequest } from '@/features/assistant/assistant.types';
+import type { ChatRequest } from '../assistant.types';
 
 // Mock useI18n to return the keys instead of translations
 vi.mock('@n8n/i18n', () => ({

--- a/packages/frontend/editor-ui/src/features/assistant/composables/useBuilderMessages.ts
+++ b/packages/frontend/editor-ui/src/features/assistant/composables/useBuilderMessages.ts
@@ -1,11 +1,7 @@
 import type { ChatUI } from '@n8n/design-system/types/assistant';
-import type { ChatRequest } from '@/features/assistant/assistant.types';
+import type { ChatRequest } from '../assistant.types';
 import { useI18n } from '@n8n/i18n';
-import {
-	isTextMessage,
-	isWorkflowUpdatedMessage,
-	isToolMessage,
-} from '@/features/assistant/assistant.types';
+import { isTextMessage, isWorkflowUpdatedMessage, isToolMessage } from '../assistant.types';
 
 export interface MessageProcessingResult {
 	messages: ChatUI.AssistantMessage[];


### PR DESCRIPTION
## Summary

 Extract useBuilderMessages into features/assistant 

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1618/extract-usebuildermessages-code-into-features

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
