### PR TITLE
fix(Notion Node): Fix typo in Notion 'Operation' options

### DIFF
--- a/packages/nodes-base/nodes/Notion/shared/descriptions/DatabasePageDescription.ts
+++ b/packages/nodes-base/nodes/Notion/shared/descriptions/DatabasePageDescription.ts
@@ -30,7 +30,7 @@ export const databasePageOperations: INodeProperties[] = [
 			{
 				name: 'Create',
 				value: 'create',
-				description: 'Create a pages in a database',
+				description: 'Create a page in a database',
 				action: 'Create a database page',
 			},
 			{


### PR DESCRIPTION
Removed an s so that "Create a pages in a database" now reads correctly as "Create a page in a database".

Issue:

<img width="722" height="774" alt="image" src="https://github.com/user-attachments/assets/86ffb009-d548-478e-97a3-b88d14211bb9" />


## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
