### PR TITLE
fix: Detect resource owner change in source control

### DIFF
--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control-helper.ee.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control-helper.ee.test.ts
@@ -335,6 +335,31 @@ describe('isWorkflowModified', () => {
 });
 
 describe('areOwnersDifferent', () => {
+	it('should return true if the owners are different', () => {
+		const owner1 = {
+			type: 'personal' as const,
+			projectId: 'personal1',
+			projectName: 'Personal 1',
+		};
+		const owner2 = {
+			type: 'team' as const,
+			projectId: 'team1',
+			projectName: 'Team 1',
+		};
+
+		expect(areOwnersDifferent(owner1, owner2)).toBe(true);
+	});
+
+	it('should return false if the owners are the same', () => {
+		const owner = {
+			type: 'personal' as const,
+			projectId: 'personal1',
+			projectName: 'Personal 1',
+		};
+
+		expect(areOwnersDifferent(owner, { ...owner })).toBe(false);
+	});
+
 	describe('both owners undefined/null', () => {
 		it('should return false when both owners are undefined', () => {
 			expect(areOwnersDifferent(undefined, undefined)).toBe(false);
@@ -356,132 +381,6 @@ describe('areOwnersDifferent', () => {
 
 		it('should return true when owner1 is defined and owner2 is undefined', () => {
 			expect(areOwnersDifferent(owner, undefined)).toBe(true);
-		});
-	});
-
-	describe('different types', () => {
-		it('should return true when owner1 is personal and owner2 is team', () => {
-			const owner1 = {
-				type: 'personal' as const,
-				projectId: 'project1',
-				projectName: 'Project 1',
-			};
-			const owner2 = {
-				type: 'team' as const,
-				projectId: 'project1',
-				projectName: 'Team 1',
-			};
-
-			expect(areOwnersDifferent(owner1, owner2)).toBe(true);
-		});
-
-		it('should return true when owner1 is team and owner2 is personal', () => {
-			const owner1 = {
-				type: 'team' as const,
-				projectId: 'project1',
-				projectName: 'Team 1',
-			};
-			const owner2 = {
-				type: 'personal' as const,
-				projectId: 'project1',
-				projectName: 'Project 1',
-			};
-
-			expect(areOwnersDifferent(owner1, owner2)).toBe(true);
-		});
-	});
-
-	describe('both personal type', () => {
-		it('should return false when both are personal with same projectId', () => {
-			const owner1 = {
-				type: 'personal' as const,
-				projectId: 'project1',
-				projectName: 'Project 1',
-			};
-			const owner2 = {
-				type: 'personal' as const,
-				projectId: 'project1',
-				projectName: 'Project 1',
-			};
-
-			expect(areOwnersDifferent(owner1, owner2)).toBe(false);
-		});
-
-		it('should return true when both are personal with different projectId', () => {
-			const owner1 = {
-				type: 'personal' as const,
-				projectId: 'project1',
-				projectName: 'Project 1',
-			};
-			const owner2 = {
-				type: 'personal' as const,
-				projectId: 'project2',
-				projectName: 'Project 2',
-			};
-
-			expect(areOwnersDifferent(owner1, owner2)).toBe(true);
-		});
-
-		it('should return false when both are personal with same projectId but different projectName', () => {
-			const owner1 = {
-				type: 'personal' as const,
-				projectId: 'project1',
-				projectName: 'Project 1',
-			};
-			const owner2 = {
-				type: 'personal' as const,
-				projectId: 'project1',
-				projectName: 'Different Name',
-			};
-
-			expect(areOwnersDifferent(owner1, owner2)).toBe(false);
-		});
-	});
-
-	describe('both team type', () => {
-		it('should return false when both are team with same projectId', () => {
-			const owner1 = {
-				type: 'team' as const,
-				projectId: 'team1',
-				projectName: 'Team 1',
-			};
-			const owner2 = {
-				type: 'team' as const,
-				projectId: 'team1',
-				projectName: 'Team 1',
-			};
-
-			expect(areOwnersDifferent(owner1, owner2)).toBe(false);
-		});
-
-		it('should return true when both are team with different projectId', () => {
-			const owner1 = {
-				type: 'team' as const,
-				projectId: 'team1',
-				projectName: 'Team 1',
-			};
-			const owner2 = {
-				type: 'team' as const,
-				projectId: 'team2',
-				projectName: 'Team 2',
-			};
-
-			expect(areOwnersDifferent(owner1, owner2)).toBe(true);
-		});
-
-		it('should return false when both are team with same projectId but different projectName', () => {
-			const owner1 = {
-				type: 'team' as const,
-				projectId: 'team1',
-				projectName: 'Team 1',
-			};
-			const owner2 = {
-				type: 'team' as const,
-				projectId: 'team1',
-				projectName: 'Different Team Name',
-			};
-
-			expect(areOwnersDifferent(owner1, owner2)).toBe(false);
 		});
 	});
 });

--- a/packages/cli/src/environments.ee/source-control/source-control-helper.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-helper.ee.ts
@@ -253,19 +253,7 @@ export function areOwnersDifferent(
 ): boolean {
 	if (!owner1 && !owner2) return false;
 
-	if (!owner1 || !owner2) return true;
-
-	if (owner1.type !== owner2.type) return true;
-
-	if (owner1.type === 'personal' && owner2.type === 'personal') {
-		return owner1.projectId !== owner2.projectId;
-	}
-
-	if (owner1.type === 'team' && owner2.type === 'team') {
-		return owner1.projectId !== owner2.projectId;
-	}
-
-	return false;
+	return owner1?.projectId !== owner2?.projectId;
 }
 
 /**

--- a/packages/cli/src/environments.ee/source-control/source-control-helper.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-helper.ee.ts
@@ -21,6 +21,7 @@ import type { ExportedFolders } from './types/exportable-folders';
 import type { KeyPair } from './types/key-pair';
 import type { KeyPairType } from './types/key-pair-type';
 import type { SourceControlWorkflowVersionId } from './types/source-control-workflow-version-id';
+import type { StatusResourceOwner } from './types/resource-owner';
 
 export function stringContainsExpression(testString: string): boolean {
 	return /^=.*\{\{.*\}\}/.test(testString);
@@ -246,6 +247,33 @@ export function normalizeAndValidateSourceControlledFilePath(
 	return normalizedPath;
 }
 
+function areOwnersDifferent(
+	owner1: StatusResourceOwner | undefined,
+	owner2: StatusResourceOwner | undefined,
+): boolean {
+	// Both undefined/null - not different
+	if (!owner1 && !owner2) return false;
+
+	// One is undefined/null - different
+	if (!owner1 || !owner2) return true;
+
+	// Different types - different
+	if (owner1.type !== owner2.type) return true;
+
+	// Compare based on type
+	if (owner1.type === 'personal' && owner2.type === 'personal') {
+		// For personal projects, compare projectId
+		return owner1.projectId !== owner2.projectId;
+	}
+
+	if (owner1.type === 'team' && owner2.type === 'team') {
+		// For team projects, compare projectId
+		return owner1.projectId !== owner2.projectId;
+	}
+
+	return false;
+}
+
 /**
  * Checks if a workflow has been modified by comparing version IDs and parent folder IDs
  * between local and remote versions
@@ -254,8 +282,10 @@ export function isWorkflowModified(
 	local: SourceControlWorkflowVersionId,
 	remote: SourceControlWorkflowVersionId,
 ): boolean {
-	return (
-		remote.versionId !== local.versionId ||
-		(remote.parentFolderId !== undefined && remote.parentFolderId !== local.parentFolderId)
-	);
+	const hasVersionIdChanged = remote.versionId !== local.versionId;
+	const hasParentFolderIdChanged =
+		remote.parentFolderId !== undefined && remote.parentFolderId !== local.parentFolderId;
+	const hasOwnerChanged = areOwnersDifferent(remote.owner, local.owner);
+
+	return hasVersionIdChanged || hasParentFolderIdChanged || hasOwnerChanged;
 }

--- a/packages/cli/src/environments.ee/source-control/source-control-helper.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-helper.ee.ts
@@ -251,23 +251,17 @@ export function areOwnersDifferent(
 	owner1?: StatusResourceOwner,
 	owner2?: StatusResourceOwner,
 ): boolean {
-	// Both undefined/null - not different
 	if (!owner1 && !owner2) return false;
 
-	// One is undefined/null - different
 	if (!owner1 || !owner2) return true;
 
-	// Different types - different
 	if (owner1.type !== owner2.type) return true;
 
-	// Compare based on type
 	if (owner1.type === 'personal' && owner2.type === 'personal') {
-		// For personal projects, compare projectId
 		return owner1.projectId !== owner2.projectId;
 	}
 
 	if (owner1.type === 'team' && owner2.type === 'team') {
-		// For team projects, compare projectId
 		return owner1.projectId !== owner2.projectId;
 	}
 

--- a/packages/cli/src/environments.ee/source-control/source-control-helper.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-helper.ee.ts
@@ -247,7 +247,7 @@ export function normalizeAndValidateSourceControlledFilePath(
 	return normalizedPath;
 }
 
-function areOwnersDifferent(
+export function areOwnersDifferent(
 	owner1: StatusResourceOwner | undefined,
 	owner2: StatusResourceOwner | undefined,
 ): boolean {

--- a/packages/cli/src/environments.ee/source-control/source-control-helper.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-helper.ee.ts
@@ -248,8 +248,8 @@ export function normalizeAndValidateSourceControlledFilePath(
 }
 
 export function areOwnersDifferent(
-	owner1: StatusResourceOwner | undefined,
-	owner2: StatusResourceOwner | undefined,
+	owner1?: StatusResourceOwner,
+	owner2?: StatusResourceOwner,
 ): boolean {
 	// Both undefined/null - not different
 	if (!owner1 && !owner2) return false;

--- a/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
@@ -267,6 +267,7 @@ export class SourceControlImportService {
 						name: true,
 						type: true,
 						projectRelations: {
+							// Even if the userId is not used, it seems that this is needed to get the other nested properties populated
 							userId: true,
 							role: {
 								slug: true,
@@ -389,6 +390,7 @@ export class SourceControlImportService {
 						name: true,
 						type: true,
 						projectRelations: {
+							// Even if the userId is not used, it seems that this is needed to get the other nested properties populated
 							userId: true,
 							role: {
 								slug: true,

--- a/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
@@ -248,6 +248,7 @@ export class SourceControlImportService {
 					project: {
 						projectRelations: {
 							user: true,
+							role: true,
 						},
 					},
 				},
@@ -266,6 +267,7 @@ export class SourceControlImportService {
 						name: true,
 						type: true,
 						projectRelations: {
+							userId: true,
 							role: {
 								slug: true,
 							},
@@ -293,6 +295,7 @@ export class SourceControlImportService {
 				});
 				updatedAt = isNaN(Date.parse(local.updatedAt)) ? new Date() : new Date(local.updatedAt);
 			}
+
 			const remoteOwnerProject = local.shared?.find((s) => s.role === 'workflow:owner')?.project;
 
 			return {

--- a/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
@@ -374,6 +374,7 @@ export class SourceControlImportService {
 					project: {
 						projectRelations: {
 							user: true,
+							role: true,
 						},
 					},
 				},
@@ -388,6 +389,7 @@ export class SourceControlImportService {
 						name: true,
 						type: true,
 						projectRelations: {
+							userId: true,
 							role: {
 								slug: true,
 							},

--- a/packages/cli/src/environments.ee/source-control/source-control-status.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-status.service.ee.ts
@@ -10,6 +10,7 @@ import { EventService } from '@/events/event.service';
 
 import { SourceControlGitService } from './source-control-git.service.ee';
 import {
+	areOwnersDifferent,
 	getFoldersPath,
 	getTagsPath,
 	getTrackingInformationFromPrePushResult,
@@ -303,12 +304,18 @@ export class SourceControlStatusService {
 			(local) => credRemoteIds.findIndex((remote) => remote.id === local.id) === -1,
 		);
 
-		// only compares the name, since that is the only change synced for credentials
 		const credModifiedInEither: StatusExportableCredential[] = [];
 		credLocalIds.forEach((local) => {
+			// Compare name, type and owner since those are the synced properties for credentials
 			const mismatchingCreds = credRemoteIds.find((remote) => {
-				return remote.id === local.id && (remote.name !== local.name || remote.type !== local.type);
+				return (
+					remote.id === local.id &&
+					(remote.name !== local.name ||
+						remote.type !== local.type ||
+						areOwnersDifferent(remote.ownedBy, local.ownedBy))
+				);
 			});
+
 			if (mismatchingCreds) {
 				credModifiedInEither.push({
 					...local,
@@ -358,6 +365,9 @@ export class SourceControlStatusService {
 				owner: item.ownedBy,
 			});
 		});
+
+		console.log({ credModifiedInEither });
+
 		return {
 			credMissingInLocal,
 			credMissingInRemote,

--- a/packages/cli/src/environments.ee/source-control/source-control-status.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-status.service.ee.ts
@@ -577,12 +577,15 @@ export class SourceControlStatusService {
 			const mismatchingIds = foldersMappingsRemote.folders.find(
 				(remote) =>
 					remote.id === local.id &&
-					(remote.name !== local.name || remote.parentFolderId !== local.parentFolderId),
+					(remote.name !== local.name ||
+						remote.parentFolderId !== local.parentFolderId ||
+						remote.homeProjectId !== local.homeProjectId),
 			);
 
 			if (!mismatchingIds) {
 				return;
 			}
+
 			foldersModifiedInEither.push(options.preferLocalVersion ? local : mismatchingIds);
 		});
 

--- a/packages/cli/src/environments.ee/source-control/source-control-status.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-status.service.ee.ts
@@ -366,8 +366,6 @@ export class SourceControlStatusService {
 			});
 		});
 
-		console.log({ credModifiedInEither });
-
 		return {
 			credMissingInLocal,
 			credMissingInRemote,


### PR DESCRIPTION
## Summary

Detect that a resource (workflow, credential, folder) has changed when the owner (project) changes

### Steps to test

#### Scenario 1: move resource

- Create a resource (workflow, credential, folder) inside a project at the root of a project
- Move the resource in a different project
- Push the changes

You should be able to push the resource    



### Scenario 2: delete and transfer resource

- Create a project and add some resources to it (workflow, credentials, folders) at the root
- Push the new resources
- Delete the project and transfer the resoucres to the root of an existing project
- Push the changes

You should be able to push the resources


## Related Linear tickets, Github issues, and Community forum posts

fixes PAY-3985

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
