### PR TITLE
refactor(core): Switch `SyntaxError` to warning level

### DIFF
--- a/packages/@n8n/task-runner-python/src/task_runner.py
+++ b/packages/@n8n/task-runner-python/src/task_runner.py
@@ -337,6 +337,12 @@ class TaskRunner:
             response = RunnerTaskError(task_id=task_id, error={"message": str(e)})
             await self._send_message(response)
 
+        except SyntaxError as e:
+            self.logger.warning(f"Task {task_id} failed syntax validation")
+            error = {"message": str(e)}
+            response = RunnerTaskError(task_id=task_id, error=error)
+            await self._send_message(response)
+
         except Exception as e:
             self.logger.error(f"Task {task_id} failed", exc_info=True)
             error = {


### PR DESCRIPTION
## Summary

`SyntaxError` keeps being reported to Sentry despite being [ignored](https://github.com/n8n-io/n8n/pull/20031) and further [filtering](https://github.com/n8n-io/n8n/pull/20500) had no effect on this specific case. Locally the filter works fine, so I cannot reproduce yet. 

This PR insists by making `SyntaxError` generate only a warning so that `SyntaxError` never even reaches Sentry via `LoggingIntegration` which is set to report errors only.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1451

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
