### PR TITLE
fix(core): Stop task process correctly in native Python runner

### DIFF
--- a/packages/@n8n/task-runner-python/src/task_executor.py
+++ b/packages/@n8n/task-runner-python/src/task_executor.py
@@ -160,6 +160,7 @@ class TaskExecutor:
 
             if process.is_alive():
                 process.kill()
+                process.join()
         except (ProcessLookupError, ConnectionError, BrokenPipeError):
             # subprocess is dead or unreachable
             pass

--- a/packages/@n8n/task-runner-python/src/task_runner.py
+++ b/packages/@n8n/task-runner-python/src/task_runner.py
@@ -372,8 +372,7 @@ class TaskRunner:
 
         if task_state.status == TaskStatus.RUNNING:
             task_state.status = TaskStatus.ABORTING
-            self.executor.stop_process(task_state.process)
-
+            await asyncio.to_thread(self.executor.stop_process, task_state.process)
             self.logger.info(
                 LOG_TASK_CANCEL.format(task_id=task_id, **task_state.context())
             )


### PR DESCRIPTION
## Summary

Two fixes for task stopping:

- When canceling a running task, we call `stop_process()` which contains `process.join(timeout=1)` which blocks the event loop for up to 1 second. Follow-up to #19740
- We call `process.kill()`  but we never call `process.join()` to reap the zombie process. From what I'm [reading](https://stackoverflow.com/questions/19322129/how-to-kill-zombie-processes-created-by-multiprocessing-module), we need to `join()` after `kill()` to clean up the process entry.

## Related Linear tickets, Github issues, and Community forum posts

Found by chance.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
