### PR TITLE
feat(core): Support nonlinear conversation model on the FE (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/chat-hub.ts
+++ b/packages/@n8n/api-types/src/chat-hub.ts
@@ -135,12 +135,13 @@ export interface ChatHubMessageDto {
 
 export type ChatHubConversationsResponse = ChatHubSessionDto[];
 
+export interface ChatHubConversationDto {
+	messages: Record<string, ChatHubMessageDto>;
+	rootIds: string[];
+	activeMessageChain: string[];
+}
+
 export interface ChatHubConversationResponse {
 	session: ChatHubSessionDto;
-
-	conversation: {
-		messages: Record<string, ChatHubMessageDto>;
-		rootIds: string[];
-		activeMessageChain: string[];
-	};
+	conversation: ChatHubConversationDto;
 }

--- a/packages/@n8n/api-types/src/chat-hub.ts
+++ b/packages/@n8n/api-types/src/chat-hub.ts
@@ -127,18 +127,14 @@ export interface ChatHubMessageDto {
 	retryOfMessageId: ChatMessageId | null;
 	revisionOfMessageId: ChatMessageId | null;
 	runIndex: number;
-
-	responseIds: ChatMessageId[];
-	retryIds: ChatMessageId[];
-	revisionIds: ChatMessageId[];
 }
 
 export type ChatHubConversationsResponse = ChatHubSessionDto[];
 
 export interface ChatHubConversationDto {
-	messages: Record<string, ChatHubMessageDto>;
-	rootIds: string[];
-	activeMessageChain: string[];
+	messages: Record<ChatMessageId, ChatHubMessageDto>;
+	rootIds: ChatMessageId[];
+	activeMessageChain: ChatMessageId[];
 }
 
 export interface ChatHubConversationResponse {

--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -24,6 +24,7 @@ export {
 	type ChatSessionId,
 	type ChatHubMessageDto,
 	type ChatHubSessionDto,
+	type ChatHubConversationDto,
 	type ChatHubConversationResponse,
 	type ChatHubConversationsResponse,
 } from './chat-hub';

--- a/packages/cli/src/modules/chat-hub/__tests__/chat-hub.service.integration.test.ts
+++ b/packages/cli/src/modules/chat-hub/__tests__/chat-hub.service.integration.test.ts
@@ -299,9 +299,6 @@ describe('chatHub', () => {
 			expect(messages[msg4.id].content).toBe('message 4a');
 			expect(messages[msg5.id].content).toBe('message 3b');
 			expect(messages[msg6.id].content).toBe('message 4b');
-			expect(messages[msg3.id].revisionIds).toEqual([msg5.id]);
-			expect(messages[msg3.id].responseIds).toEqual([msg4.id]);
-			expect(messages[msg3.id].retryIds).toEqual([]);
 			expect(messages[msg5.id].previousMessageId).toBe(msg2.id);
 		});
 
@@ -458,9 +455,6 @@ describe('chatHub', () => {
 			expect(activeMessageChain[1]).toBe(msg2.id);
 			expect(activeMessageChain[2]).toBe(msg3.id);
 			expect(activeMessageChain[3]).toBe(msg5.id);
-			expect(messages[msg4.id].revisionIds).toEqual([]);
-			expect(messages[msg4.id].responseIds).toEqual([]);
-			expect(messages[msg4.id].retryIds).toEqual([msg5.id]);
 			expect(messages[msg5.id].previousMessageId).toBe(msg3.id);
 			expect(messages[msg5.id].retryOfMessageId).toBe(msg4.id);
 		});
@@ -523,7 +517,7 @@ describe('chatHub', () => {
 				turnId: ids[2],
 				createdAt: new Date('2025-01-03T00:10:00Z'),
 			});
-			const msg4a = await messagesRepository.createChatMessage({
+			await messagesRepository.createChatMessage({
 				id: ids[3],
 				sessionId: session.id,
 				name: 'ChatGPT',
@@ -544,7 +538,7 @@ describe('chatHub', () => {
 				turnId: ids[4],
 				createdAt: new Date('2025-01-03T00:20:00Z'),
 			});
-			const msg4b = await messagesRepository.createChatMessage({
+			await messagesRepository.createChatMessage({
 				id: ids[5],
 				sessionId: session.id,
 				name: 'ChatGPT',
@@ -612,22 +606,6 @@ describe('chatHub', () => {
 			expect(activeMessageChain[1]).toBe(msg2r.id);
 			expect(activeMessageChain[2]).toBe(msg3d.id);
 			expect(activeMessageChain[3]).toBe(msg4c.id);
-
-			expect(messages[msg1.id].revisionIds).toEqual([msg1b.id]);
-			expect(messages[msg1b.id].responseIds).toEqual([]);
-			expect(messages[msg1b.id].retryIds).toEqual([]);
-
-			expect(messages[msg2.id].revisionIds).toEqual([]);
-			expect(messages[msg2.id].responseIds).toEqual([msg3a.id, msg3b.id]);
-			expect(messages[msg2.id].retryIds).toEqual([msg2r.id]);
-
-			expect(messages[msg3b.id].revisionIds).toEqual([]);
-			expect(messages[msg3b.id].responseIds).toEqual([msg4b.id]);
-			expect(messages[msg3b.id].retryIds).toEqual([]);
-
-			expect(messages[msg4a.id].revisionIds).toEqual([]);
-			expect(messages[msg4a.id].responseIds).toEqual([]);
-			expect(messages[msg4a.id].retryIds).toEqual([]);
 
 			expect(messages[msg2r.id].previousMessageId).toBe(msg1.id);
 			expect(messages[msg2r.id].retryOfMessageId).toBe(msg2.id);

--- a/packages/cli/src/modules/chat-hub/chat-hub.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.service.ts
@@ -867,8 +867,9 @@ export class ChatHubService {
 		}
 
 		const messages = await this.messageRepository.getManyBySessionId(sessionId);
-		const messagesGraph: Record<ChatMessageId, ChatHubMessageDto> =
-			this.buildMessagesGraph(messages);
+		const messagesGraph: Record<ChatMessageId, ChatHubMessageDto> = Object.fromEntries(
+			messages.map((m) => [m.id, this.convertToDto(m)]),
+		);
 
 		const rootIds = messages.filter((r) => r.previousMessageId === null).map((r) => r.id);
 		const activeMessages = messages.filter((m) => m.state === 'active');
@@ -897,33 +898,27 @@ export class ChatHubService {
 		};
 	}
 
-	buildMessagesGraph(messages: ChatHubMessage[]) {
-		const messagesGraph: Record<ChatMessageId, ChatHubMessageDto> = {};
+	convertToDto(message: ChatHubMessage): ChatHubMessageDto {
+		return {
+			id: message.id,
+			sessionId: message.sessionId,
+			type: message.type,
+			name: message.name,
+			content: message.content,
+			provider: message.provider,
+			model: message.model,
+			workflowId: message.workflowId,
+			executionId: message.executionId,
+			state: message.state,
+			createdAt: message.createdAt.toISOString(),
+			updatedAt: message.updatedAt.toISOString(),
 
-		for (const message of messages) {
-			messagesGraph[message.id] = {
-				id: message.id,
-				sessionId: message.sessionId,
-				type: message.type,
-				name: message.name,
-				content: message.content,
-				provider: message.provider,
-				model: message.model,
-				workflowId: message.workflowId,
-				executionId: message.executionId,
-				state: message.state,
-				createdAt: message.createdAt.toISOString(),
-				updatedAt: message.updatedAt.toISOString(),
-
-				previousMessageId: message.previousMessageId,
-				turnId: message.turnId,
-				retryOfMessageId: message.retryOfMessageId,
-				revisionOfMessageId: message.revisionOfMessageId,
-				runIndex: message.runIndex,
-			};
-		}
-
-		return messagesGraph;
+			previousMessageId: message.previousMessageId,
+			turnId: message.turnId,
+			retryOfMessageId: message.retryOfMessageId,
+			revisionOfMessageId: message.revisionOfMessageId,
+			runIndex: message.runIndex,
+		};
 	}
 
 	/**

--- a/packages/cli/src/modules/chat-hub/chat-hub.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.service.ts
@@ -868,7 +868,7 @@ export class ChatHubService {
 
 		const messages = await this.messageRepository.getManyBySessionId(sessionId);
 		const messagesGraph: Record<ChatMessageId, ChatHubMessageDto> = Object.fromEntries(
-			messages.map((m) => [m.id, this.convertToDto(m)]),
+			messages.map((m) => [m.id, this.convertMessageToDto(m)]),
 		);
 
 		const rootIds = messages.filter((r) => r.previousMessageId === null).map((r) => r.id);
@@ -898,7 +898,7 @@ export class ChatHubService {
 		};
 	}
 
-	convertToDto(message: ChatHubMessage): ChatHubMessageDto {
+	private convertMessageToDto(message: ChatHubMessage): ChatHubMessageDto {
 		return {
 			id: message.id,
 			sessionId: message.sessionId,

--- a/packages/cli/src/modules/chat-hub/chat-hub.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.service.ts
@@ -897,7 +897,7 @@ export class ChatHubService {
 		};
 	}
 
-	private buildMessagesGraph(messages: ChatHubMessage[]) {
+	buildMessagesGraph(messages: ChatHubMessage[]) {
 		const messagesGraph: Record<ChatMessageId, ChatHubMessageDto> = {};
 
 		for (const message of messages) {
@@ -920,45 +920,9 @@ export class ChatHubService {
 				retryOfMessageId: message.retryOfMessageId,
 				revisionOfMessageId: message.revisionOfMessageId,
 				runIndex: message.runIndex,
-
-				responseIds: [],
-				retryIds: [],
-				revisionIds: [],
 			};
 		}
 
-		for (const node of Object.values(messagesGraph)) {
-			if (node.previousMessageId && messagesGraph[node.previousMessageId]) {
-				messagesGraph[node.previousMessageId].responseIds.push(node.id);
-			}
-			if (node.retryOfMessageId && messagesGraph[node.retryOfMessageId]) {
-				messagesGraph[node.retryOfMessageId].retryIds.push(node.id);
-			}
-			if (node.revisionOfMessageId && messagesGraph[node.revisionOfMessageId]) {
-				messagesGraph[node.revisionOfMessageId].revisionIds.push(node.id);
-			}
-		}
-
-		const sortByRunThenTime = (first: ChatMessageId, second: ChatMessageId) => {
-			const a = messagesGraph[first];
-			const b = messagesGraph[second];
-
-			if (a.runIndex !== b.runIndex) {
-				return a.runIndex - b.runIndex;
-			}
-
-			if (a.createdAt !== b.createdAt) {
-				return a.createdAt < b.createdAt ? -1 : 1;
-			}
-
-			return a.id < b.id ? -1 : 1;
-		};
-
-		for (const node of Object.values(messagesGraph)) {
-			node.responseIds.sort(sortByRunThenTime);
-			node.retryIds.sort(sortByRunThenTime);
-			node.revisionIds.sort(sortByRunThenTime);
-		}
 		return messagesGraph;
 	}
 

--- a/packages/frontend/editor-ui/src/features/chatHub/ChatView.vue
+++ b/packages/frontend/editor-ui/src/features/chatHub/ChatView.vue
@@ -10,18 +10,14 @@ import CredentialSelectorModal from './components/CredentialSelectorModal.vue';
 import { useChatStore } from './chat.store';
 import { useCredentialsStore } from '@/stores/credentials.store';
 import { useUIStore } from '@/stores/ui.store';
-import {
-	type ChatMessage as ChatMessageType,
-	credentialsMapSchema,
-	type CredentialsMap,
-	type Suggestion,
-} from './chat.types';
+import { credentialsMapSchema, type CredentialsMap, type Suggestion } from './chat.types';
 import {
 	chatHubConversationModelSchema,
 	type ChatHubProvider,
 	PROVIDER_CREDENTIAL_TYPE_MAP,
 	type ChatHubConversationModel,
 	chatHubProviderSchema,
+	type ChatHubMessageDto,
 } from '@n8n/api-types';
 import { useLocalStorage, useMediaQuery } from '@vueuse/core';
 import {
@@ -113,7 +109,7 @@ const mergedCredentials = computed(() => ({
 	...selectedCredentials.value,
 }));
 
-const chatMessages = computed(() => chatStore.messagesBySession[sessionId.value] ?? []);
+const chatMessages = computed(() => chatStore.getActiveMessages(sessionId.value));
 const isNewChat = computed(() => route.name === CHAT_VIEW);
 const inputPlaceholder = computed(() => {
 	if (!selectedModel.value) {
@@ -192,7 +188,7 @@ watch(
 	async ([id, isNew]) => {
 		didSubmitInCurrentSession.value = false;
 
-		if (!isNew && !chatStore.messagesBySession[id]) {
+		if (!isNew && !chatStore.getConversation(id)) {
 			try {
 				await chatStore.fetchMessages(id);
 			} catch (error) {
@@ -277,8 +273,8 @@ function handleCancelEditMessage() {
 	editingMessageId.value = undefined;
 }
 
-function handleEditMessage(message: ChatMessageType) {
-	if (chatStore.isResponding || message.type === 'error' || !selectedModel.value) {
+function handleEditMessage(message: ChatHubMessageDto) {
+	if (chatStore.isResponding || message.type !== 'human' || !selectedModel.value) {
 		return;
 	}
 
@@ -288,7 +284,7 @@ function handleEditMessage(message: ChatMessageType) {
 		return;
 	}
 
-	chatStore.editMessage(sessionId.value, message.id, message.text, selectedModel.value, {
+	chatStore.editMessage(sessionId.value, message.id, message.content, selectedModel.value, {
 		[PROVIDER_CREDENTIAL_TYPE_MAP[selectedModel.value.provider]]: {
 			id: credentialsId,
 			name: '',
@@ -297,8 +293,8 @@ function handleEditMessage(message: ChatMessageType) {
 	editingMessageId.value = undefined;
 }
 
-function handleRegenerateMessage(message: ChatMessageType) {
-	if (chatStore.isResponding || message.type === 'error' || !selectedModel.value) {
+function handleRegenerateMessage(message: ChatHubMessageDto) {
+	if (chatStore.isResponding || message.type !== 'ai' || !selectedModel.value) {
 		return;
 	}
 

--- a/packages/frontend/editor-ui/src/features/chatHub/chat.store.ts
+++ b/packages/frontend/editor-ui/src/features/chatHub/chat.store.ts
@@ -257,8 +257,8 @@ export const useChatStore = defineStore(CHAT_STORE, () => {
 		sessionId: string,
 		messageId: string,
 		chunk: string,
-		nodeId?: string,
-		runIndex?: number,
+		_nodeId?: string,
+		_runIndex?: number,
 	) {
 		// appendMessage(sessionId, chunk, `${messageId}-${nodeId}-${runIndex ?? 0}`);
 		appendMessage(sessionId, messageId, chunk);

--- a/packages/frontend/editor-ui/src/features/chatHub/chat.store.ts
+++ b/packages/frontend/editor-ui/src/features/chatHub/chat.store.ts
@@ -95,11 +95,9 @@ export const useChatStore = defineStore(CHAT_STORE, () => {
 				messagesGraph[node.previousMessageId].responses.push(node.id);
 			}
 			if (node.retryOfMessageId && messagesGraph[node.retryOfMessageId]) {
-				// Add current node as an alternative to the original message
 				messagesGraph[node.retryOfMessageId].alternatives.push(node.id);
 			}
 			if (node.revisionOfMessageId && messagesGraph[node.revisionOfMessageId]) {
-				// Add current node as an alternative to the original message
 				messagesGraph[node.revisionOfMessageId].alternatives.push(node.id);
 			}
 		}
@@ -153,31 +151,6 @@ export const useChatStore = defineStore(CHAT_STORE, () => {
 	function addMessage(sessionId: ChatSessionId, message: ChatMessage) {
 		const conversation = ensureConversation(sessionId);
 
-		// if (message.previousMessageId) {
-		// 	if (!conversation.messages[message.previousMessageId].responses.includes(message.id)) {
-		// 		conversation.messages[message.previousMessageId].responses.push(message.id);
-		// 	}
-		// }
-
-		// if (message.retryOfMessageId) {
-		// 	if (!conversation.messages[message.retryOfMessageId].alternatives.includes(message.id)) {
-		// 		conversation.messages[message.retryOfMessageId].alternatives.push(message.id);
-		// 	}
-
-		// 	for (const other of Object.values(conversation.messages)) {
-		// 		if (other.retryOfMessageId === message.retryOfMessageId && other.id !== message.id) {
-		// 			other.state = 'replaced';
-		// 			message.alternatives.push(other.id);
-		// 		}
-		// 	}
-		// }
-
-		// if (message.revisionOfMessageId) {
-		// 	if (!conversation.messages[message.revisionOfMessageId].alternatives.includes(message.id)) {
-		// 		conversation.messages[message.revisionOfMessageId].alternatives.push(message.id);
-		// 	}
-		// }
-
 		conversation.messages[message.id] = message;
 
 		// TODO: Recomputing the entire graph shouldn't be needed here, we could just
@@ -229,7 +202,6 @@ export const useChatStore = defineStore(CHAT_STORE, () => {
 		_runIndex?: number,
 	) {
 		ongoingStreaming.value = { messageId, replyToMessageId };
-		// addAiMessage(sessionId, '', messageId, `${messageId}-${nodeId}-${runIndex ?? 0}`);
 		addMessage(sessionId, {
 			id: messageId,
 			sessionId,
@@ -260,7 +232,6 @@ export const useChatStore = defineStore(CHAT_STORE, () => {
 		_nodeId?: string,
 		_runIndex?: number,
 	) {
-		// appendMessage(sessionId, chunk, `${messageId}-${nodeId}-${runIndex ?? 0}`);
 		appendMessage(sessionId, messageId, chunk);
 	}
 
@@ -300,8 +271,6 @@ export const useChatStore = defineStore(CHAT_STORE, () => {
 				onEndMessage(messageId, nodeId, runIndex);
 				break;
 		}
-
-		// addAssistantMessages(response.messages);
 	}
 
 	async function onStreamDone() {
@@ -431,10 +400,6 @@ export const useChatStore = defineStore(CHAT_STORE, () => {
 		if (!previousMessageId) {
 			throw new Error('No previous message to base regeneration on');
 		}
-
-		// TODO: remove descendants of the message being retried
-		// or better yet, turn the frontend chat into a graph and
-		// maintain the visible active chain, and this would just switch to that branch.
 
 		regenerateMessageApi(
 			rootStore.restApiContext,

--- a/packages/frontend/editor-ui/src/features/chatHub/chat.types.ts
+++ b/packages/frontend/editor-ui/src/features/chatHub/chat.types.ts
@@ -1,4 +1,10 @@
-import { chatHubProviderSchema, type ChatHubSessionDto } from '@n8n/api-types';
+import {
+	chatHubProviderSchema,
+	type ChatHubMessageDto,
+	type ChatMessageId,
+	type ChatHubSessionDto,
+	type ChatHubConversationDto,
+} from '@n8n/api-types';
 import { z } from 'zod';
 
 export interface UserMessage {
@@ -26,7 +32,15 @@ export interface ErrorMessage {
 }
 
 export type StreamChunk = AssistantMessage | ErrorMessage;
-export type ChatMessage = UserMessage | AssistantMessage | ErrorMessage;
+
+export interface ChatMessage extends ChatHubMessageDto {
+	responses: ChatMessageId[];
+	alternatives: ChatMessageId[];
+}
+
+export interface ChatConversation extends ChatHubConversationDto {
+	messages: Record<ChatMessageId, ChatMessage>;
+}
 
 export interface StreamOutput {
 	messages: StreamChunk[];

--- a/packages/frontend/editor-ui/src/features/chatHub/components/ChatMessage.vue
+++ b/packages/frontend/editor-ui/src/features/chatHub/components/ChatMessage.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import type { ChatMessage } from '@/features/chatHub/chat.types';
 import { N8nIcon, N8nInput, N8nButton } from '@n8n/design-system';
 import VueMarkdown from 'vue-markdown-render';
 import hljs from 'highlight.js/lib/core';
@@ -58,10 +57,6 @@ function handleConfirmEdit() {
 
 function handleRegenerate() {
 	emit('regenerate', message);
-}
-
-function messageText(msg: ChatMessage) {
-	return msg.type === 'message' ? msg.text : `**Error:** ${msg.content}`;
 }
 
 const markdownOptions = {

--- a/packages/frontend/editor-ui/src/features/chatHub/components/ChatMessage.vue
+++ b/packages/frontend/editor-ui/src/features/chatHub/components/ChatMessage.vue
@@ -7,12 +7,12 @@ import markdownLink from 'markdown-it-link-attributes';
 import type MarkdownIt from 'markdown-it';
 import ChatMessageActions from './ChatMessageActions.vue';
 import { useClipboard } from '@/composables/useClipboard';
-import { ref, nextTick, watch } from 'vue';
-import { useTemplateRef } from 'vue';
+import { ref, nextTick, watch, useTemplateRef } from 'vue';
 import ChatTypingIndicator from '@/features/chatHub/components/ChatTypingIndicator.vue';
+import type { ChatHubMessageDto } from '@n8n/api-types';
 
 const { message, compact, isEditing, isStreaming } = defineProps<{
-	message: ChatMessage;
+	message: ChatHubMessageDto;
 	compact: boolean;
 	isEditing: boolean;
 	isStreaming: boolean;
@@ -21,8 +21,8 @@ const { message, compact, isEditing, isStreaming } = defineProps<{
 const emit = defineEmits<{
 	startEdit: [];
 	cancelEdit: [];
-	update: [message: ChatMessage];
-	regenerate: [message: ChatMessage];
+	update: [message: ChatHubMessageDto];
+	regenerate: [message: ChatHubMessageDto];
 }>();
 
 const clipboard = useClipboard();
@@ -32,7 +32,7 @@ const textareaRef = useTemplateRef('textarea');
 const justCopied = ref(false);
 
 async function handleCopy() {
-	const text = messageText(message);
+	const text = message.content;
 	await clipboard.copy(text);
 	justCopied.value = true;
 	setTimeout(() => {
@@ -49,11 +49,11 @@ function handleCancelEdit() {
 }
 
 function handleConfirmEdit() {
-	if (message.type === 'error' || !editedText.value.trim()) {
+	if (message.type === 'ai' || !editedText.value.trim()) {
 		return;
 	}
 
-	emit('update', { ...message, text: editedText.value });
+	emit('update', { ...message, content: editedText.value });
 }
 
 function handleRegenerate() {
@@ -90,7 +90,7 @@ watch(
 	() => isEditing,
 	async (editing) => {
 		if (editing) {
-			editedText.value = messageText(message);
+			editedText.value = message.content;
 			await nextTick();
 			textareaRef.value?.focus();
 		} else {
@@ -105,7 +105,7 @@ watch(
 	<div
 		:class="[
 			$style.message,
-			message.role === 'user' ? $style.user : $style.assistant,
+			message.type === 'human' ? $style.user : $style.assistant,
 			{
 				[$style.compact]: compact,
 			},
@@ -113,7 +113,7 @@ watch(
 		:data-message-id="message.id"
 	>
 		<div :class="$style.avatar">
-			<N8nIcon :icon="message.role === 'user' ? 'user' : 'sparkles'" width="20" height="20" />
+			<N8nIcon :icon="message.type === 'human' ? 'user' : 'sparkles'" width="20" height="20" />
 		</div>
 		<div :class="$style.content">
 			<div v-if="isEditing" :class="$style.editContainer">
@@ -140,7 +140,7 @@ watch(
 				<div :class="$style.chatMessage">
 					<VueMarkdown
 						:class="[$style.chatMessageMarkdown, 'chat-message-markdown']"
-						:source="messageText(message)"
+						:source="message.content"
 						:options="markdownOptions"
 						:plugins="[linksNewTabPlugin]"
 					/>
@@ -148,7 +148,7 @@ watch(
 				<ChatTypingIndicator v-if="isStreaming" :class="$style.typingIndicator" />
 				<ChatMessageActions
 					v-else
-					:role="message.role"
+					:type="message.type"
 					:just-copied="justCopied"
 					:class="$style.actions"
 					@copy="handleCopy"

--- a/packages/frontend/editor-ui/src/features/chatHub/components/ChatMessageActions.vue
+++ b/packages/frontend/editor-ui/src/features/chatHub/components/ChatMessageActions.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
+import type { ChatHubMessageType } from '@n8n/api-types';
 import { N8nIconButton, N8nTooltip } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
 import { computed } from 'vue';
 
 const i18n = useI18n();
 
-const { role, justCopied } = defineProps<{
-	role: 'user' | 'assistant';
+const { type, justCopied } = defineProps<{
+	type: ChatHubMessageType;
 	justCopied: boolean;
 }>();
 
@@ -52,7 +53,7 @@ function handleRegenerate() {
 			<N8nIconButton icon="pen" type="tertiary" size="medium" text @click="handleEdit" />
 			<template #content>Edit</template>
 		</N8nTooltip>
-		<N8nTooltip v-if="role === 'assistant'" placement="bottom" :show-after="300">
+		<N8nTooltip v-if="type === 'ai'" placement="bottom" :show-after="300">
 			<N8nIconButton
 				icon="refresh-cw"
 				type="tertiary"


### PR DESCRIPTION
## Summary

Support retries & edits changing the conversation history active chain on the FE.
Change the `ChatMessageDto` to not include the precalculated `responses` and `alternatives` arrays,
and instead calculate them on the UI.
Support computing the active message chain on the UI (too, also computed on the backend as we need that on the retries / edist logic anyways).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-25/support-nonlinear-conversation-model-on-the-fe

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
