### PR TITLE
ci: Update Chromatic workflow to auto-accept changes on master (no-changelog)

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -30,6 +30,7 @@ jobs:
   chromatic:
     needs: [changeset]
     if: |
+      github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'pull_request_review' &&
@@ -54,6 +55,8 @@ jobs:
         continue-on-error: true
         with:
           workingDir: packages/frontend/@n8n/design-system
+          autoAcceptChanges: 'master'
+          skip: 'release/**'
           onlyChanged: true
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           exitZeroOnChanges: false


### PR DESCRIPTION
## Summary

Update chromatic workflow to auto-accept changes on master

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1621/ci-fix-chromatic-snapshots-baseline


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
