### PR TITLE
fix(benchmark): Autodiscover runners container

### DIFF
--- a/packages/@n8n/benchmark/scripts/run-for-n8n-setup.mjs
+++ b/packages/@n8n/benchmark/scripts/run-for-n8n-setup.mjs
@@ -15,6 +15,18 @@ const paths = {
 
 const N8N_ENCRYPTION_KEY = 'very-secret-encryption-key';
 
+/**
+ * Discovers runner services in the docker-compose setup, where the name matches exactly `runners` or ends with `_runners`
+ */
+async function discoverRunnerServices(dockerComposeClient) {
+	const result = await dockerComposeClient.$('config', '--services');
+
+	return result.stdout
+		.trim()
+		.split('\n')
+		.filter((service) => service === 'runners' || service.endsWith('_runners'));
+}
+
 async function main() {
 	const [n8nSetupToUse] = argv._;
 	validateN8nSetup(n8nSetupToUse);
@@ -83,7 +95,8 @@ async function main() {
 	}
 
 	try {
-		await dockerComposeClient.$('up', '-d', '--remove-orphans', 'n8n');
+		const runnerServices = await discoverRunnerServices(dockerComposeClient);
+		await dockerComposeClient.$('up', '-d', '--remove-orphans', 'n8n', ...runnerServices);
 
 		const tags = Object.entries({
 			Env: envTag,

--- a/packages/@n8n/benchmark/scripts/run-for-n8n-setup.mjs
+++ b/packages/@n8n/benchmark/scripts/run-for-n8n-setup.mjs
@@ -7,6 +7,7 @@ import path from 'path';
 import { $, argv, fs } from 'zx';
 import { DockerComposeClient } from './clients/docker-compose-client.mjs';
 import { flagsObjectToCliArgs } from './utils/flags.mjs';
+import { EOL } from 'os';
 
 const paths = {
 	n8nSetupsDir: path.join(__dirname, 'n8n-setups'),
@@ -23,7 +24,7 @@ async function discoverRunnerServices(dockerComposeClient) {
 
 	return result.stdout
 		.trim()
-		.split('\n')
+		.split(EOL)
 		.filter((service) => service === 'runners' || service.endsWith('_runners'));
 }
 


### PR DESCRIPTION
## Summary

We have multiple benchmarking docker composes where the n8n container defines its dependencies and we start them all up by [starting up only n8n](https://github.com/n8n-io/n8n/blob/a4264f077dfc412a4571e7fab5165411449c5ec0/packages/%40n8n/benchmark/scripts/run-for-n8n-setup.mjs#L86). 

But exceptionally, setups may have 1+ runners containers that depend on n8n (not the other way round), so the benchmarking docker composes are not starting up runners containers, breaking benchmarks that rely on Code nodes.

This fix auto-discovers runners containers and starts them up as well, if needed.

Tested via:

```sh
pnpm benchmark-locally \
	--n8nTag=1.115.3 \
	--scenarioFilter js-code-node \ # or py-code-node
	--runDir /tmp/n8n-data \
	postgres # or scaling-single-main, etc.
```

Notes: 
- If you don't pass in an n8n tag, you'll fall back to `latest` and get an error saying that there's no `latest` tag for the runners image. I addressed this at #20802 but we need to wait until next Monday for it to become available.
- This relies on the new `--scenarioFilter` flag which I added yesterday at #20804 which is now in `ghcr.io/n8n-io/n8n-benchmark:latest` so make sure to pull this first.
- I fixed worker initialization at #20495 so if you happen to test below 1.115.1 it's expected that benchmarks for scaling setups will fail.

## Related Linear tickets, Github issues, and Community forum posts

n/a

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
