### PR TITLE
fix(ai-builder): Submit AI workflow builder prompt on enter, newline on shift+enter

### DIFF
--- a/cypress/pages/features/ai-assistant.ts
+++ b/cypress/pages/features/ai-assistant.ts
@@ -48,7 +48,7 @@ export class AIAssistant extends BasePage {
 			cy.disableFeature('aiAssistant');
 		},
 		sendMessage: (message: string) => {
-			this.getters.chatInput().type(message).type('{shift+enter}');
+			this.getters.chatInput().type(message).type('{enter}');
 		},
 		closeChat: () => {
 			this.getters.closeChatButton().click();

--- a/packages/frontend/@n8n/design-system/src/components/N8nPromptInput/N8nPromptInput.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nPromptInput/N8nPromptInput.test.ts
@@ -220,39 +220,7 @@ describe('N8nPromptInput', () => {
 	});
 
 	describe('user interactions', () => {
-		it('should emit submit on Ctrl+Enter', async () => {
-			const render = renderComponent({
-				props: {
-					modelValue: 'Test message',
-				},
-				global: {
-					stubs: ['N8nCallout', 'N8nScrollArea', 'N8nSendStopButton'],
-				},
-			});
-
-			const textarea = render.container.querySelector('textarea') as HTMLTextAreaElement;
-			await fireEvent.keyDown(textarea, { key: 'Enter', ctrlKey: true });
-
-			expect(render.emitted('submit')).toBeTruthy();
-		});
-
-		it('should emit submit on Cmd+Enter', async () => {
-			const render = renderComponent({
-				props: {
-					modelValue: 'Test message',
-				},
-				global: {
-					stubs: ['N8nCallout', 'N8nScrollArea', 'N8nSendStopButton'],
-				},
-			});
-
-			const textarea = render.container.querySelector('textarea') as HTMLTextAreaElement;
-			await fireEvent.keyDown(textarea, { key: 'Enter', metaKey: true });
-
-			expect(render.emitted('submit')).toBeTruthy();
-		});
-
-		it('should not emit submit on plain Enter', async () => {
+		it('should emit submit on plain Enter', async () => {
 			const render = renderComponent({
 				props: {
 					modelValue: 'Test message',
@@ -265,7 +233,64 @@ describe('N8nPromptInput', () => {
 			const textarea = render.container.querySelector('textarea') as HTMLTextAreaElement;
 			await fireEvent.keyDown(textarea, { key: 'Enter' });
 
+			expect(render.emitted('submit')).toBeTruthy();
+		});
+
+		it('should insert newline on Shift+Enter', async () => {
+			const render = renderComponent({
+				props: {
+					modelValue: 'Test message',
+				},
+				global: {
+					stubs: ['N8nCallout', 'N8nScrollArea', 'N8nSendStopButton'],
+				},
+			});
+
+			const textarea = render.container.querySelector('textarea') as HTMLTextAreaElement;
+			await fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true });
+
+			// Should not emit submit
 			expect(render.emitted('submit')).toBeFalsy();
+			// Should have inserted a newline in the value
+			expect(render.emitted('update:modelValue')).toBeTruthy();
+		});
+
+		it('should insert newline on Ctrl+Enter', async () => {
+			const render = renderComponent({
+				props: {
+					modelValue: 'Test message',
+				},
+				global: {
+					stubs: ['N8nCallout', 'N8nScrollArea', 'N8nSendStopButton'],
+				},
+			});
+
+			const textarea = render.container.querySelector('textarea') as HTMLTextAreaElement;
+			await fireEvent.keyDown(textarea, { key: 'Enter', ctrlKey: true });
+
+			// Should not emit submit
+			expect(render.emitted('submit')).toBeFalsy();
+			// Should have inserted a newline in the value
+			expect(render.emitted('update:modelValue')).toBeTruthy();
+		});
+
+		it('should insert newline on Cmd+Enter', async () => {
+			const render = renderComponent({
+				props: {
+					modelValue: 'Test message',
+				},
+				global: {
+					stubs: ['N8nCallout', 'N8nScrollArea', 'N8nSendStopButton'],
+				},
+			});
+
+			const textarea = render.container.querySelector('textarea') as HTMLTextAreaElement;
+			await fireEvent.keyDown(textarea, { key: 'Enter', metaKey: true });
+
+			// Should not emit submit
+			expect(render.emitted('submit')).toBeFalsy();
+			// Should have inserted a newline in the value
+			expect(render.emitted('update:modelValue')).toBeTruthy();
 		});
 
 		it('should emit update:modelValue when typing', async () => {
@@ -817,8 +842,8 @@ describe('N8nPromptInput', () => {
 			const textarea = wrapper.find('textarea').element as HTMLTextAreaElement;
 			const focusSpy = vi.spyOn(textarea, 'focus');
 
-			// Trigger submit with Ctrl+Enter
-			await fireEvent.keyDown(textarea, { key: 'Enter', ctrlKey: true });
+			// Trigger submit with Enter
+			await fireEvent.keyDown(textarea, { key: 'Enter' });
 
 			// Wait for next tick and animation frame
 			await wrapper.vm.$nextTick();
@@ -842,8 +867,8 @@ describe('N8nPromptInput', () => {
 			const textarea = wrapper.find('textarea').element as HTMLTextAreaElement;
 			const focusSpy = vi.spyOn(textarea, 'focus');
 
-			// Trigger submit with Ctrl+Enter
-			await fireEvent.keyDown(textarea, { key: 'Enter', ctrlKey: true });
+			// Trigger submit with Enter
+			await fireEvent.keyDown(textarea, { key: 'Enter' });
 
 			// Wait for next tick
 			await wrapper.vm.$nextTick();
@@ -930,7 +955,7 @@ describe('N8nPromptInput', () => {
 			});
 
 			const textarea = render.container.querySelector('textarea') as HTMLTextAreaElement;
-			await fireEvent.keyDown(textarea, { key: 'Enter', ctrlKey: true });
+			await fireEvent.keyDown(textarea, { key: 'Enter' });
 
 			expect(render.emitted('submit')).toBeFalsy();
 		});

--- a/packages/frontend/@n8n/design-system/src/components/N8nPromptInput/N8nPromptInput.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nPromptInput/N8nPromptInput.test.ts
@@ -236,26 +236,7 @@ describe('N8nPromptInput', () => {
 			expect(render.emitted('submit')).toBeTruthy();
 		});
 
-		it('should insert newline on Shift+Enter', async () => {
-			const render = renderComponent({
-				props: {
-					modelValue: 'Test message',
-				},
-				global: {
-					stubs: ['N8nCallout', 'N8nScrollArea', 'N8nSendStopButton'],
-				},
-			});
-
-			const textarea = render.container.querySelector('textarea') as HTMLTextAreaElement;
-			await fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true });
-
-			// Should not emit submit
-			expect(render.emitted('submit')).toBeFalsy();
-			// Should have inserted a newline in the value
-			expect(render.emitted('update:modelValue')).toBeTruthy();
-		});
-
-		it('should insert newline on Ctrl+Enter', async () => {
+		it('should emit submit on Ctrl+Enter', async () => {
 			const render = renderComponent({
 				props: {
 					modelValue: 'Test message',
@@ -268,13 +249,10 @@ describe('N8nPromptInput', () => {
 			const textarea = render.container.querySelector('textarea') as HTMLTextAreaElement;
 			await fireEvent.keyDown(textarea, { key: 'Enter', ctrlKey: true });
 
-			// Should not emit submit
-			expect(render.emitted('submit')).toBeFalsy();
-			// Should have inserted a newline in the value
-			expect(render.emitted('update:modelValue')).toBeTruthy();
+			expect(render.emitted('submit')).toBeTruthy();
 		});
 
-		it('should insert newline on Cmd+Enter', async () => {
+		it('should emit submit on Cmd+Enter', async () => {
 			const render = renderComponent({
 				props: {
 					modelValue: 'Test message',
@@ -286,6 +264,22 @@ describe('N8nPromptInput', () => {
 
 			const textarea = render.container.querySelector('textarea') as HTMLTextAreaElement;
 			await fireEvent.keyDown(textarea, { key: 'Enter', metaKey: true });
+
+			expect(render.emitted('submit')).toBeTruthy();
+		});
+
+		it('should insert newline on Shift+Enter', async () => {
+			const render = renderComponent({
+				props: {
+					modelValue: 'Test message',
+				},
+				global: {
+					stubs: ['N8nCallout', 'N8nScrollArea', 'N8nSendStopButton'],
+				},
+			});
+
+			const textarea = render.container.querySelector('textarea') as HTMLTextAreaElement;
+			await fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true });
 
 			// Should not emit submit
 			expect(render.emitted('submit')).toBeFalsy();

--- a/packages/frontend/@n8n/design-system/src/components/N8nPromptInput/N8nPromptInput.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nPromptInput/N8nPromptInput.vue
@@ -242,8 +242,8 @@ async function handleKeyDown(event: KeyboardEvent) {
 	const isPrintableChar = event.key.length === 1 && !hasModifier;
 	const isDeletionKey = event.key === 'Backspace' || event.key === 'Delete';
 	const atMaxLength = characterCount.value >= props.maxLength;
-	const isSubmitKey = event.key === 'Enter' && !event.shiftKey && !event.ctrlKey && !event.metaKey;
-	const isNewlineKey = event.key === 'Enter' && (event.ctrlKey || event.metaKey || event.shiftKey);
+	const isSubmitKey = event.key === 'Enter' && !event.shiftKey;
+	const isNewlineKey = event.key === 'Enter' && event.shiftKey;
 
 	// Prevent adding characters if at max length (but allow deletions/navigation)
 	if (atMaxLength && isPrintableChar && !isDeletionKey) {
@@ -251,7 +251,7 @@ async function handleKeyDown(event: KeyboardEvent) {
 		return;
 	}
 
-	// Submit on plain Enter. If send disabled, don't submit.
+	// Submit on plain Enter - if send disabled, don't submit
 	if (isSubmitKey) {
 		event.preventDefault();
 		if (!sendDisabled.value) {
@@ -259,7 +259,7 @@ async function handleKeyDown(event: KeyboardEvent) {
 		}
 	}
 
-	// Insert newline on Shift/Ctrl/Cmd+Enter
+	// Insert newline on Shift+Enter
 	if (isNewlineKey) {
 		event.preventDefault();
 		const textarea = event.target as HTMLTextAreaElement;

--- a/packages/frontend/@n8n/design-system/src/components/N8nPromptInput/N8nPromptInput.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nPromptInput/N8nPromptInput.vue
@@ -268,7 +268,9 @@ async function handleKeyDown(event: KeyboardEvent) {
 		textValue.value = textValue.value.substring(0, start) + '\n' + textValue.value.substring(end);
 		// Set cursor position after the newline
 		await nextTick();
-		textarea.selectionStart = textarea.selectionEnd = start + 1;
+		if (textareaRef.value) {
+			textareaRef.value.selectionStart = textareaRef.value.selectionEnd = start + 1;
+		}
 	}
 }
 

--- a/packages/testing/playwright/pages/AIAssistantPage.ts
+++ b/packages/testing/playwright/pages/AIAssistantPage.ts
@@ -105,7 +105,7 @@ export class AIAssistantPage extends BasePage {
 	) {
 		await this.getChatInput().pressSequentially(message, { delay: 20 });
 		if (method === 'enter-key') {
-			await this.getChatInput().press('Shift+Enter');
+			await this.getChatInput().press('Enter');
 		} else {
 			await this.getSendMessageButton().click();
 		}


### PR DESCRIPTION
## Summary

As title, this was originally changed to shift+enter to submit as part of ticket AI-1430 - however we have decided to change the behaviour back to enter to submit - ticket: https://linear.app/n8n/issue/AI-1558/feature-pressing-enter-should-submit-the-prompt-ctrl-enter-and-shift

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
