### PR TITLE
fix(n8n Form Node): CSP headers should not be set on response with redirect

### DIFF
--- a/packages/nodes-base/nodes/Form/test/formCompletionUtils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/formCompletionUtils.test.ts
@@ -303,6 +303,26 @@ describe('formCompletionUtils', () => {
 			);
 			expect(mockResponse.render).toHaveBeenCalled();
 		});
+
+		it('should NOT set Content-Security-Policy header when respondWith is redirect', async () => {
+			mockWebhookFunctions.getNodeParameter.mockImplementation((parameterName: string) => {
+				const params: { [key: string]: any } = {
+					completionTitle: 'Form Completion',
+					completionMessage: 'Form has been submitted successfully',
+					options: { formTitle: 'Form Title' },
+					respondWith: 'redirect',
+				};
+				return params[parameterName];
+			});
+
+			await renderFormCompletion(mockWebhookFunctions, mockResponse, trigger);
+
+			expect(mockResponse.setHeader).not.toHaveBeenCalledWith(
+				'Content-Security-Policy',
+				expect.any(String),
+			);
+			expect(mockResponse.render).toHaveBeenCalled();
+		});
 	});
 
 	describe('binaryResponse', () => {

--- a/packages/nodes-base/nodes/Form/utils/formCompletionUtils.ts
+++ b/packages/nodes-base/nodes/Form/utils/formCompletionUtils.ts
@@ -56,10 +56,12 @@ export const renderFormCompletion = async (
 		customCss?: string;
 	};
 	const responseText = (context.getNodeParameter('responseText', '') as string) ?? '';
-	const binary =
-		context.getNodeParameter('respondWith', '') === 'returnBinary'
-			? await binaryResponse(context)
-			: '';
+	const respondWith = context.getNodeParameter('respondWith', '') as
+		| 'text'
+		| 'redirect'
+		| 'showText'
+		| 'returnBinary';
+	const binary = respondWith === 'returnBinary' ? await binaryResponse(context) : '';
 
 	let title = options.formTitle;
 	if (!title) {
@@ -69,7 +71,10 @@ export const renderFormCompletion = async (
 		`{{ $('${trigger?.name}').params.options?.appendAttribution === false ? false : true }}`,
 	) as boolean;
 
-	res.setHeader('Content-Security-Policy', SANDBOX_CSP);
+	if (respondWith !== 'redirect') {
+		res.setHeader('Content-Security-Policy', SANDBOX_CSP);
+	}
+
 	res.render('form-trigger-completion', {
 		title: completionTitle,
 		message: sanitizeHtml(completionMessage),


### PR DESCRIPTION
## Summary
CSP headers should not be set on response with redirect


## Related Linear tickets, Github issues, and Community forum posts
closes https://github.com/n8n-io/n8n/issues/20303
https://linear.app/n8n/issue/NODE-3765/community-issue-redirect-to-url-in-form-end-is-broken-in-1113

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
