### PR TITLE
fix(AI Agent Node): Track source node toolkit tools are executed from

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/ToolsAgentV3.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/ToolsAgentV3.test.ts
@@ -289,13 +289,18 @@ describe('toolsAgentExecute V3', () => {
 		};
 
 		mockRunnableSequence.streamEvents = jest.fn().mockReturnValue(mockStreamEvents());
+		const mockTool = mock<Tool>();
+		mockTool.name = 'TestTool';
+		mockTool.metadata = {
+			sourceNodeName: 'Test Tool',
+		};
 
 		(createToolCallingAgent as jest.Mock).mockReturnValue(mockAgent);
 		(RunnableSequence.from as jest.Mock).mockReturnValue(mockRunnableSequence);
 
 		jest.spyOn(commonHelpers, 'getChatModel').mockResolvedValue(mockModel);
 		jest.spyOn(commonHelpers, 'getOptionalMemory').mockResolvedValue(undefined);
-		jest.spyOn(commonHelpers, 'getTools').mockResolvedValue([mock<Tool>()]);
+		jest.spyOn(commonHelpers, 'getTools').mockResolvedValue([mockTool]);
 		jest.spyOn(commonHelpers, 'prepareMessages').mockResolvedValue([]);
 		jest.spyOn(commonHelpers, 'preparePrompt').mockReturnValue(mock<ChatPromptTemplate>());
 		jest.spyOn(helpers, 'getPromptInputByType').mockReturnValue('test input');
@@ -329,7 +334,7 @@ describe('toolsAgentExecute V3', () => {
 
 		expect(result.actions).toBeDefined();
 		expect(result.actions).toHaveLength(1);
-		expect(result.actions[0].nodeName).toBe('TestTool');
+		expect(result.actions[0].nodeName).toBe('Test Tool');
 		expect(result.actions[0].input).toEqual({ input: 'test data' });
 	});
 

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.test.ts
@@ -405,4 +405,325 @@ describe('McpClientTool', () => {
 			); // options
 		});
 	});
+
+	describe('execute', () => {
+		beforeEach(() => {
+			jest.resetAllMocks();
+		});
+
+		it('should execute tool when tool name is in item.json.tool (from agent)', async () => {
+			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({
+				content: [{ type: 'text', text: 'Weather is sunny' }],
+			});
+			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({
+				tools: [
+					{
+						name: 'get_weather',
+						description: 'Gets the weather',
+						inputSchema: { type: 'object', properties: { location: { type: 'string' } } },
+					},
+				],
+			});
+
+			const mockNode = mock<INode>({ typeVersion: 1, type: 'mcpClientTool' });
+			const mockExecuteFunctions = mock<any>({
+				getNode: jest.fn(() => mockNode),
+				getInputData: jest.fn(() => [
+					{
+						json: {
+							tool: 'get_weather',
+							location: 'Berlin',
+						},
+					},
+				]),
+				getNodeParameter: jest.fn((key) => {
+					const params: Record<string, any> = {
+						include: 'all',
+						includeTools: [],
+						excludeTools: [],
+						authentication: 'none',
+						sseEndpoint: 'https://test.com/sse',
+						'options.timeout': 60000,
+					};
+					return params[key];
+				}),
+			});
+
+			const result = await new McpClientTool().execute.call(mockExecuteFunctions);
+
+			expect(result).toEqual([
+				[
+					{
+						json: {
+							response: [{ type: 'text', text: 'Weather is sunny' }],
+						},
+						pairedItem: { item: 0 },
+					},
+				],
+			]);
+
+			expect(Client.prototype.callTool).toHaveBeenCalledWith({
+				name: 'get_weather',
+				arguments: { location: 'Berlin' },
+			});
+		});
+
+		it('should execute tool when tool name is in item.tool (direct execution)', async () => {
+			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({
+				content: [{ type: 'text', text: 'Weather is rainy' }],
+			});
+			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({
+				tools: [
+					{
+						name: 'get_weather',
+						description: 'Gets the weather',
+						inputSchema: { type: 'object', properties: { location: { type: 'string' } } },
+					},
+				],
+			});
+
+			const mockNode = mock<INode>({ typeVersion: 1, type: 'mcpClientTool' });
+			const mockExecuteFunctions = mock<any>({
+				getNode: jest.fn(() => mockNode),
+				getInputData: jest.fn(() => [
+					{
+						tool: 'get_weather',
+						json: {
+							location: 'London',
+						},
+					},
+				]),
+				getNodeParameter: jest.fn((key) => {
+					const params: Record<string, any> = {
+						include: 'all',
+						includeTools: [],
+						excludeTools: [],
+						authentication: 'none',
+						sseEndpoint: 'https://test.com/sse',
+						'options.timeout': 60000,
+					};
+					return params[key];
+				}),
+			});
+
+			const result = await new McpClientTool().execute.call(mockExecuteFunctions);
+
+			expect(result).toEqual([
+				[
+					{
+						json: {
+							response: [{ type: 'text', text: 'Weather is rainy' }],
+						},
+						pairedItem: { item: 0 },
+					},
+				],
+			]);
+
+			expect(Client.prototype.callTool).toHaveBeenCalledWith({
+				name: 'get_weather',
+				arguments: { location: 'London' },
+			});
+		});
+
+		it('should not execute if tool name does not match', async () => {
+			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({
+				content: [{ type: 'text', text: 'Should not be called' }],
+			});
+			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({
+				tools: [
+					{
+						name: 'get_weather',
+						description: 'Gets the weather',
+						inputSchema: { type: 'object', properties: { location: { type: 'string' } } },
+					},
+				],
+			});
+
+			const mockNode = mock<INode>({ typeVersion: 1, type: 'mcpClientTool' });
+			const mockExecuteFunctions = mock<any>({
+				getNode: jest.fn(() => mockNode),
+				getInputData: jest.fn(() => [
+					{
+						json: {
+							tool: 'different_tool',
+							location: 'Berlin',
+						},
+					},
+				]),
+				getNodeParameter: jest.fn((key) => {
+					const params: Record<string, any> = {
+						include: 'all',
+						includeTools: [],
+						excludeTools: [],
+						authentication: 'none',
+						sseEndpoint: 'https://test.com/sse',
+						'options.timeout': 60000,
+					};
+					return params[key];
+				}),
+			});
+
+			const result = await new McpClientTool().execute.call(mockExecuteFunctions);
+
+			expect(result).toEqual([[]]);
+			expect(Client.prototype.callTool).not.toHaveBeenCalled();
+		});
+
+		it('should throw error when MCP server connection fails', async () => {
+			jest.spyOn(Client.prototype, 'connect').mockRejectedValue(new Error('Connection failed'));
+
+			const mockNode = mock<INode>({ typeVersion: 1, type: 'mcpClientTool' });
+			const mockExecuteFunctions = mock<any>({
+				getNode: jest.fn(() => mockNode),
+				getInputData: jest.fn(() => [
+					{
+						json: {
+							tool: 'get_weather',
+							location: 'Berlin',
+						},
+					},
+				]),
+				getNodeParameter: jest.fn((key) => {
+					const params: Record<string, any> = {
+						include: 'all',
+						includeTools: [],
+						excludeTools: [],
+						authentication: 'none',
+						sseEndpoint: 'https://test.com/sse',
+						'options.timeout': 60000,
+					};
+					return params[key];
+				}),
+			});
+
+			await expect(new McpClientTool().execute.call(mockExecuteFunctions)).rejects.toThrow(
+				NodeOperationError,
+			);
+		});
+
+		it('should handle multiple items', async () => {
+			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			jest
+				.spyOn(Client.prototype, 'callTool')
+				.mockResolvedValueOnce({
+					content: [{ type: 'text', text: 'Weather in Berlin is sunny' }],
+				})
+				.mockResolvedValueOnce({
+					content: [{ type: 'text', text: 'Weather in London is rainy' }],
+				});
+			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({
+				tools: [
+					{
+						name: 'get_weather',
+						description: 'Gets the weather',
+						inputSchema: { type: 'object', properties: { location: { type: 'string' } } },
+					},
+				],
+			});
+
+			const mockNode = mock<INode>({ typeVersion: 1, type: 'mcpClientTool' });
+			const mockExecuteFunctions = mock<any>({
+				getNode: jest.fn(() => mockNode),
+				getInputData: jest.fn(() => [
+					{
+						json: {
+							tool: 'get_weather',
+							location: 'Berlin',
+						},
+					},
+					{
+						json: {
+							tool: 'get_weather',
+							location: 'London',
+						},
+					},
+				]),
+				getNodeParameter: jest.fn((key) => {
+					const params: Record<string, any> = {
+						include: 'all',
+						includeTools: [],
+						excludeTools: [],
+						authentication: 'none',
+						sseEndpoint: 'https://test.com/sse',
+						'options.timeout': 60000,
+					};
+					return params[key];
+				}),
+			});
+
+			const result = await new McpClientTool().execute.call(mockExecuteFunctions);
+
+			expect(result).toEqual([
+				[
+					{
+						json: {
+							response: [{ type: 'text', text: 'Weather in Berlin is sunny' }],
+						},
+						pairedItem: { item: 0 },
+					},
+					{
+						json: {
+							response: [{ type: 'text', text: 'Weather in London is rainy' }],
+						},
+						pairedItem: { item: 1 },
+					},
+				],
+			]);
+
+			expect(Client.prototype.callTool).toHaveBeenCalledTimes(2);
+		});
+
+		it('should respect tool filtering (selected tools)', async () => {
+			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({
+				content: [{ type: 'text', text: 'Weather is sunny' }],
+			});
+			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({
+				tools: [
+					{
+						name: 'get_weather',
+						description: 'Gets the weather',
+						inputSchema: { type: 'object', properties: { location: { type: 'string' } } },
+					},
+					{
+						name: 'get_time',
+						description: 'Gets the time',
+						inputSchema: { type: 'object', properties: {} },
+					},
+				],
+			});
+
+			const mockNode = mock<INode>({ typeVersion: 1, type: 'mcpClientTool' });
+			const mockExecuteFunctions = mock<any>({
+				getNode: jest.fn(() => mockNode),
+				getInputData: jest.fn(() => [
+					{
+						json: {
+							tool: 'get_weather',
+							location: 'Berlin',
+						},
+					},
+				]),
+				getNodeParameter: jest.fn((key) => {
+					const params: Record<string, any> = {
+						include: 'selected',
+						includeTools: ['get_weather'],
+						excludeTools: [],
+						authentication: 'none',
+						sseEndpoint: 'https://test.com/sse',
+						'options.timeout': 60000,
+					};
+					return params[key];
+				}),
+			});
+
+			const result = await new McpClientTool().execute.call(mockExecuteFunctions);
+
+			expect(result[0]).toHaveLength(1);
+			expect(result[0][0].json.response).toEqual([{ type: 'text', text: 'Weather is sunny' }]);
+		});
+	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.test.ts
@@ -469,64 +469,6 @@ describe('McpClientTool', () => {
 			});
 		});
 
-		it('should execute tool when tool name is in item.tool (direct execution)', async () => {
-			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
-			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({
-				content: [{ type: 'text', text: 'Weather is rainy' }],
-			});
-			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({
-				tools: [
-					{
-						name: 'get_weather',
-						description: 'Gets the weather',
-						inputSchema: { type: 'object', properties: { location: { type: 'string' } } },
-					},
-				],
-			});
-
-			const mockNode = mock<INode>({ typeVersion: 1, type: 'mcpClientTool' });
-			const mockExecuteFunctions = mock<any>({
-				getNode: jest.fn(() => mockNode),
-				getInputData: jest.fn(() => [
-					{
-						tool: 'get_weather',
-						json: {
-							location: 'London',
-						},
-					},
-				]),
-				getNodeParameter: jest.fn((key) => {
-					const params: Record<string, any> = {
-						include: 'all',
-						includeTools: [],
-						excludeTools: [],
-						authentication: 'none',
-						sseEndpoint: 'https://test.com/sse',
-						'options.timeout': 60000,
-					};
-					return params[key];
-				}),
-			});
-
-			const result = await new McpClientTool().execute.call(mockExecuteFunctions);
-
-			expect(result).toEqual([
-				[
-					{
-						json: {
-							response: [{ type: 'text', text: 'Weather is rainy' }],
-						},
-						pairedItem: { item: 0 },
-					},
-				],
-			]);
-
-			expect(Client.prototype.callTool).toHaveBeenCalledWith({
-				name: 'get_weather',
-				arguments: { location: 'London' },
-			});
-		});
-
 		it('should not execute if tool name does not match', async () => {
 			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
 			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
@@ -390,14 +390,20 @@ export class McpClientTool implements INodeType {
 				throw new NodeOperationError(node, error.error, { itemIndex });
 			}
 
-			if (!mcpTools || !mcpTools.length) {
+			if (!mcpTools?.length) {
 				throw new NodeOperationError(node, 'MCP Server returned no tools', { itemIndex });
 			}
 
 			for (const tool of mcpTools) {
 				// Check for tool name in item.json.tool (for toolkit execution from agent)
 				// or item.tool (for direct execution)
-				const toolName = (item.json.tool as string) ?? item.tool;
+				if (!item.json.tool || typeof item.json.tool !== 'string') {
+					throw new NodeOperationError(node, 'Tool name not found in item.json.tool or item.tool', {
+						itemIndex,
+					});
+				}
+
+				const toolName = item.json.tool;
 				if (toolName === tool.name) {
 					// Extract the tool name from arguments before passing to MCP
 					const { tool: _, ...toolArguments } = item.json;

--- a/packages/@n8n/nodes-langchain/utils/helpers.ts
+++ b/packages/@n8n/nodes-langchain/utils/helpers.ts
@@ -216,20 +216,20 @@ export const getConnectedTools = async (
 	});
 
 	const connectedTools = (toolkitConnections ?? []).flatMap((toolOrToolkit, index) => {
+		const sourceNode = parentNodes[index];
 		if (toolOrToolkit instanceof Toolkit) {
 			const tools = toolOrToolkit.getTools() as Tool[];
-			// Get the source node for this toolkit
-			const sourceNode = parentNodes[index];
-
 			// Add metadata to each tool from the toolkit
 			return tools.map((tool) => {
-				if (!tool.metadata) {
-					tool.metadata = {};
-				}
+				tool.metadata ??= {};
 				tool.metadata.isFromToolkit = true;
 				tool.metadata.sourceNodeName = sourceNode?.name;
 				return tool;
 			});
+		} else {
+			toolOrToolkit.metadata ??= {};
+			toolOrToolkit.metadata.isFromToolkit = false;
+			toolOrToolkit.metadata.sourceNodeName = sourceNode?.name;
 		}
 
 		return toolOrToolkit;

--- a/packages/@n8n/nodes-langchain/utils/helpers.ts
+++ b/packages/@n8n/nodes-langchain/utils/helpers.ts
@@ -210,23 +210,28 @@ export const getConnectedTools = async (
 	)) as Array<Toolkit | Tool>;
 
 	// Get parent nodes to map toolkits to their source nodes
-	const parentNodes = ctx.getParentNodes(ctx.getNode().name, {
-		connectionType: NodeConnectionTypes.AiTool,
-		depth: 1,
-	});
+	const parentNodes =
+		'getParentNodes' in ctx
+			? ctx.getParentNodes(ctx.getNode().name, {
+					connectionType: NodeConnectionTypes.AiTool,
+					depth: 1,
+				})
+			: [];
 
 	const connectedTools = (toolkitConnections ?? []).flatMap((toolOrToolkit, index) => {
-		const sourceNode = parentNodes[index];
 		if (toolOrToolkit instanceof Toolkit) {
 			const tools = toolOrToolkit.getTools() as Tool[];
 			// Add metadata to each tool from the toolkit
 			return tools.map((tool) => {
+				const sourceNode = parentNodes[index] ?? tool.name;
+
 				tool.metadata ??= {};
 				tool.metadata.isFromToolkit = true;
 				tool.metadata.sourceNodeName = sourceNode?.name;
 				return tool;
 			});
 		} else {
+			const sourceNode = parentNodes[index] ?? toolOrToolkit.name;
 			toolOrToolkit.metadata ??= {};
 			toolOrToolkit.metadata.isFromToolkit = false;
 			toolOrToolkit.metadata.sourceNodeName = sourceNode?.name;

--- a/packages/@n8n/nodes-langchain/utils/tests/helpers.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/tests/helpers.test.ts
@@ -177,6 +177,8 @@ describe('getConnectedTools', () => {
 		};
 
 		mockExecuteFunctions = createMockExecuteFunction({}, mockNode);
+		// Add getParentNodes mock for metadata functionality
+		mockExecuteFunctions.getParentNodes = jest.fn().mockReturnValue([]);
 
 		mockN8nTool = new N8nTool(mockExecuteFunctions as unknown as ISupplyDataFunctions, {
 			name: 'Dummy Tool',
@@ -272,10 +274,96 @@ describe('getConnectedTools', () => {
 
 		const tools = await getConnectedTools(mockExecuteFunctions, false);
 		expect(tools).toEqual([
-			{ name: 'tool1', description: 'desc1' },
-			{ name: 'toolkitTool1', description: 'toolkitToolDesc1' },
-			{ name: 'toolkitTool2', description: 'toolkitToolDesc2' },
+			{
+				name: 'tool1',
+				description: 'desc1',
+				metadata: { isFromToolkit: false, sourceNodeName: undefined },
+			},
+			{
+				name: 'toolkitTool1',
+				description: 'toolkitToolDesc1',
+				metadata: { isFromToolkit: true, sourceNodeName: undefined },
+			},
+			{
+				name: 'toolkitTool2',
+				description: 'toolkitToolDesc2',
+				metadata: { isFromToolkit: true, sourceNodeName: undefined },
+			},
 		]);
+	});
+
+	it('should add metadata to all tools with source node information', async () => {
+		class MockToolkit extends Toolkit {
+			tools: Tool[];
+
+			constructor(tools: unknown[]) {
+				super();
+				this.tools = tools as Tool[];
+			}
+		}
+		const mockParentNodes = [{ name: 'RegularTool' }, { name: 'MCP Client Tool' }];
+		const mockTools = [
+			{ name: 'tool1', description: 'desc1' },
+			new MockToolkit([
+				{ name: 'toolkitTool1', description: 'toolkitToolDesc1' },
+				{ name: 'toolkitTool2', description: 'toolkitToolDesc2' },
+			]),
+		];
+
+		mockExecuteFunctions.getInputConnectionData = jest.fn().mockResolvedValue(mockTools);
+		mockExecuteFunctions.getParentNodes = jest.fn().mockReturnValue(mockParentNodes);
+
+		const tools = await getConnectedTools(mockExecuteFunctions, false);
+
+		expect(tools).toHaveLength(3);
+
+		// Regular tool should have metadata with isFromToolkit: false
+		expect(tools[0].name).toBe('tool1');
+		expect(tools[0].metadata).toEqual({
+			isFromToolkit: false,
+			sourceNodeName: 'RegularTool',
+		});
+
+		// Toolkit tools should have metadata with isFromToolkit: true
+		expect(tools[1].name).toBe('toolkitTool1');
+		expect(tools[1].metadata).toEqual({
+			isFromToolkit: true,
+			sourceNodeName: 'MCP Client Tool',
+		});
+
+		expect(tools[2].name).toBe('toolkitTool2');
+		expect(tools[2].metadata).toEqual({
+			isFromToolkit: true,
+			sourceNodeName: 'MCP Client Tool',
+		});
+	});
+
+	it('should preserve existing metadata when adding toolkit metadata', async () => {
+		class MockToolkit extends Toolkit {
+			tools: Tool[];
+
+			constructor(tools: unknown[]) {
+				super();
+				this.tools = tools as Tool[];
+			}
+		}
+		const mockParentNodes = [{ name: 'MCP Client Tool' }];
+		const mockTools = [
+			new MockToolkit([
+				{ name: 'toolkitTool1', description: 'desc1', metadata: { customField: 'value' } },
+			]),
+		];
+
+		mockExecuteFunctions.getInputConnectionData = jest.fn().mockResolvedValue(mockTools);
+		mockExecuteFunctions.getParentNodes = jest.fn().mockReturnValue(mockParentNodes);
+
+		const tools = await getConnectedTools(mockExecuteFunctions, false);
+
+		expect(tools[0].metadata).toEqual({
+			customField: 'value',
+			isFromToolkit: true,
+			sourceNodeName: 'MCP Client Tool',
+		});
 	});
 });
 


### PR DESCRIPTION
## Summary
This uses tool metadata to track the origin of toolkit tools. This enables us to call for example the MCPClient node with the right parameters. So far the engine got a request to execute a non existing subnode.


## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-1540/bug-agent-3-does-not-support-mcp-tools


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
