### PR TITLE
fix: MongoDB connection string parameter marked as password

### DIFF
--- a/packages/nodes-base/credentials/MongoDb.credentials.ts
+++ b/packages/nodes-base/credentials/MongoDb.credentials.ts
@@ -30,6 +30,9 @@ export class MongoDb implements ICredentialType {
 			displayName: 'Connection String',
 			name: 'connectionString',
 			type: 'string',
+			typeOptions: {
+				password: true,
+			},
 			displayOptions: {
 				show: {
 					configurationType: ['connectionString'],


### PR DESCRIPTION
## Summary

Parameter marked as password since it is sensitive field

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-3784/exposing-password-on-mongodb-credentials-when-using-quey-string

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
