### PR TITLE
chore: Remove telemetry debug logging (no-changelog)

### DIFF
--- a/packages/cli/src/posthog/index.ts
+++ b/packages/cli/src/posthog/index.ts
@@ -24,11 +24,6 @@ export class PostHogClient {
 		this.postHog = new PostHog(posthogConfig.apiKey, {
 			host: posthogConfig.apiHost,
 		});
-
-		const logLevel = this.globalConfig.logging.level;
-		if (logLevel === 'debug') {
-			this.postHog.debug(true);
-		}
 	}
 
 	async stop(): Promise<void> {

--- a/packages/frontend/editor-ui/src/plugins/telemetry/index.ts
+++ b/packages/frontend/editor-ui/src/plugins/telemetry/index.ts
@@ -51,18 +51,12 @@ export class Telemetry {
 			config: { key, proxy, sourceConfig },
 		} = telemetrySettings;
 
-		const settingsStore = useSettingsStore();
 		const rootStore = useRootStore();
-
-		const logLevel = settingsStore.logLevel;
-
-		const logging = logLevel === 'debug' ? { logLevel: 'DEBUG' } : {};
 
 		this.initRudderStack(key, proxy, {
 			integrations: { All: false },
 			loadIntegration: false,
 			configUrl: sourceConfig,
-			...logging,
 		});
 
 		this.identify(instanceId, userId, versionCli, projectId);


### PR DESCRIPTION
## Summary
Removes the automatic enabling of debug mode for telemetry libraries (PostHog and RudderStack) when `N8N_LOG_LEVEL=debug` is set.

## Changes
- **Backend (CLI)**: Removed code that calls `this.postHog.debug(true)` when log level is set to debug
- **Frontend**: Removed code that enables RudderStack debug logging when log level is set to debug

## Motivation
When `N8N_LOG_LEVEL=debug` is set, both PostHog and RudderStack debug modes were being enabled automatically, which outputs detailed logging about every telemetry operation (e.g., "PostHog Debug flush" messages). This adds unnecessary noise to debug logs when developers are trying to debug n8n itself, not the telemetry libraries.

## Test Plan
- Ran existing PostHog unit tests - all pass ✅
- Set `N8N_LOG_LEVEL=debug` and verify that telemetry debug logs no longer appear in console
- Verify that telemetry functionality still works correctly (events are still sent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)