### PR TITLE
fix(editor): Hide Execute and refine section when error occurs after workflow update

### DIFF
--- a/packages/frontend/editor-ui/src/features/assistant/components/Agent/AskAssistantBuild.vue
+++ b/packages/frontend/editor-ui/src/features/assistant/components/Agent/AskAssistantBuild.vue
@@ -60,10 +60,17 @@ const showExecuteMessage = computed(() => {
 			msg.type === 'workflow-updated' ||
 			(msg.type === 'tool' && msg.toolName === 'update_node_parameters'),
 	);
+
+	// Check if there's an error message after the last workflow update
+	const hasErrorAfterUpdate = builderStore.chatMessages
+		.slice(builderUpdatedWorkflowMessageIndex + 1)
+		.some((msg) => msg.type === 'error');
+
 	return (
 		!builderStore.streaming &&
 		workflowsStore.workflow.nodes.length > 0 &&
-		builderUpdatedWorkflowMessageIndex > -1
+		builderUpdatedWorkflowMessageIndex > -1 &&
+		!hasErrorAfterUpdate
 	);
 });
 const creditsQuota = computed(() => builderStore.creditsQuota);


### PR DESCRIPTION
## Summary
Fixes an issue where the "Execute and refine" button section was still shown when the AI builder encountered an error after updating a workflow. The section should be hidden since the workflow is in an error state and shouldn't be executed until the error is resolved.

**Before**
<img width="528" height="1116" alt="Screenshot 2025-10-16 at 16 33 12" src="https://github.com/user-attachments/assets/6c5c91d9-e6dd-4b9b-a1e5-7f77be564204" />

**After**
<img width="608" height="1096" alt="Screenshot 2025-10-16 at 16 33 15" src="https://github.com/user-attachments/assets/3d9063a4-9eb4-4de4-9f91-ff279a4a50c4" />

## Related Linear ticket
https://linear.app/n8n/issue/AI-1571

## What changed
- Modified `showExecuteMessage` computed property in `AskAssistantBuild.vue` to check if any error messages exist after the last workflow update
- The section now hides when an error occurs after either:
  - A `workflow-updated` message
  - An `update_node_parameters` tool call
- Added comprehensive test coverage with 4 test cases verifying the ExecuteMessage component rendering behavior

## Test plan
All tests pass (27/27):
- ✅ Hides when error occurs after workflow update
- ✅ Shows when no error after workflow update  
- ✅ Shows when error occurs before workflow update (system recovered)
- ✅ Hides when error occurs after update_node_parameters tool call

## Review notes
The fix is minimal and focused - it only adds logic to check for errors after the last workflow/parameter update. Tests now properly verify component DOM presence rather than internal state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)