### PR TITLE
fix: Remove conditional rendering from Build with AI button

### DIFF
--- a/packages/frontend/editor-ui/src/features/canvas/components/elements/nodes/render-types/CanvasNodeChoicePrompt.vue
+++ b/packages/frontend/editor-ui/src/features/canvas/components/elements/nodes/render-types/CanvasNodeChoicePrompt.vue
@@ -3,17 +3,12 @@ import { NODE_CREATOR_OPEN_SOURCES } from '@/constants';
 import { useNodeCreatorStore } from '@/stores/nodeCreator.store';
 import { useChatPanelStore } from '@/features/assistant/chatPanel.store';
 import { useI18n } from '@n8n/i18n';
-import { computed } from 'vue';
 
 import { N8nIcon } from '@n8n/design-system';
 
 const nodeCreatorStore = useNodeCreatorStore();
 const chatPanelStore = useChatPanelStore();
 const i18n = useI18n();
-
-const isChatWindowOpen = computed(
-	() => chatPanelStore.isOpen && chatPanelStore.isBuilderModeActive,
-);
 
 const onAddFirstStepClick = () => {
 	if (nodeCreatorStore.isCreateNodeActive) {
@@ -60,7 +55,7 @@ async function onBuildWithAIClick() {
 
 		<!-- Build with AI Button -->
 		<div :class="$style.option">
-			<div :class="[$style.selectedButtonHighlight, { [$style.highlighted]: isChatWindowOpen }]">
+			<div :class="$style.selectedButtonHighlight">
 				<button
 					:class="[$style.button]"
 					data-test-id="canvas-build-with-ai-button"


### PR DESCRIPTION
## Summary

This PR removes the conditional highlighting logic from the "Build with AI" button in the canvas choice prompt, making it render consistently without depending on the chat window state.

## Changes Made

1. **Removed unnecessary imports**: Removed the `computed` import from Vue since it's no longer needed
2. **Removed conditional logic**: Removed the `isChatWindowOpen` computed property that was tracking chat panel state
3. **Simplified template**: Changed the Build with AI button's class binding from `[$style.selectedButtonHighlight, { [$style.highlighted]: isChatWindowOpen }]` to just `$style.selectedButtonHighlight`

## Benefits

- The "Build with AI" button now renders consistently without any conditional visual states
- Simplified code by removing unnecessary computed property and reactive dependencies
- Button functionality remains unchanged - it still opens the AI chat panel when clicked
- Maintains the same visual appearance as before, just without conditional highlighting

## Testing

- The button still functions correctly when clicked
- No conditional highlighting based on chat window state
- Consistent rendering across different application states

## File Changed

- `packages/frontend/editor-ui/src/features/canvas/components/elements/nodes/render-types/CanvasNodeChoicePrompt.vue`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update