### PR TITLE
feat(core): Switch between different attempts at FE (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/chat-hub.ts
+++ b/packages/@n8n/api-types/src/chat-hub.ts
@@ -133,8 +133,6 @@ export type ChatHubConversationsResponse = ChatHubSessionDto[];
 
 export interface ChatHubConversationDto {
 	messages: Record<ChatMessageId, ChatHubMessageDto>;
-	rootIds: ChatMessageId[];
-	activeMessageChain: ChatMessageId[];
 }
 
 export interface ChatHubConversationResponse {

--- a/packages/cli/src/modules/chat-hub/__tests__/chat-hub.service.integration.test.ts
+++ b/packages/cli/src/modules/chat-hub/__tests__/chat-hub.service.integration.test.ts
@@ -1,7 +1,6 @@
 import { testDb, testModules } from '@n8n/backend-test-utils';
 import type { User } from '@n8n/db';
 import { Container } from '@n8n/di';
-
 import { createAdmin, createMember } from '@test-integration/db/users';
 
 import { ChatHubService } from '../chat-hub.service';
@@ -176,16 +175,10 @@ describe('chatHub', () => {
 			expect(response).toBeDefined();
 
 			const {
-				conversation: { rootIds, messages, activeMessageChain },
+				conversation: { messages },
 			} = response;
 
-			expect(rootIds).toEqual([msg1.id]);
 			expect(Object.keys(messages)).toHaveLength(4);
-			expect(activeMessageChain).toHaveLength(4);
-			expect(activeMessageChain[0]).toBe(msg1.id);
-			expect(activeMessageChain[1]).toBe(msg2.id);
-			expect(activeMessageChain[2]).toBe(msg3.id);
-			expect(activeMessageChain[3]).toBe(msg4.id);
 			expect(messages[msg1.id].content).toBe('message 1');
 			expect(messages[msg1.id].type).toBe('human');
 			expect(messages[msg1.id].turnId).toBe(msg1.id);
@@ -283,16 +276,10 @@ describe('chatHub', () => {
 			expect(response).toBeDefined();
 
 			const {
-				conversation: { rootIds, messages, activeMessageChain },
+				conversation: { messages },
 			} = response;
 
-			expect(rootIds).toEqual([msg1.id]);
 			expect(Object.keys(messages)).toHaveLength(6);
-			expect(activeMessageChain).toHaveLength(4);
-			expect(activeMessageChain[0]).toBe(msg1.id);
-			expect(activeMessageChain[1]).toBe(msg2.id);
-			expect(activeMessageChain[2]).toBe(msg5.id);
-			expect(activeMessageChain[3]).toBe(msg6.id);
 			expect(messages[msg1.id].content).toBe('message 1');
 			expect(messages[msg2.id].content).toBe('message 2');
 			expect(messages[msg3.id].content).toBe('message 3a');
@@ -346,7 +333,7 @@ describe('chatHub', () => {
 				turnId: ids[2],
 				createdAt: new Date('2025-01-03T00:10:00Z'),
 			});
-			const msg4 = await messagesRepository.createChatMessage({
+			await messagesRepository.createChatMessage({
 				id: ids[3],
 				sessionId: session.id,
 				name: 'ChatGPT',
@@ -362,14 +349,10 @@ describe('chatHub', () => {
 			expect(response).toBeDefined();
 
 			const {
-				conversation: { rootIds, messages, activeMessageChain },
+				conversation: { messages },
 			} = response;
 
-			expect(rootIds).toEqual([msg1.id, msg3.id]);
 			expect(Object.keys(messages)).toHaveLength(4);
-			expect(activeMessageChain).toHaveLength(2);
-			expect(activeMessageChain[0]).toBe(msg3.id);
-			expect(activeMessageChain[1]).toBe(msg4.id);
 		});
 
 		it('should get conversation with a retry branch at last message', async () => {
@@ -445,16 +428,10 @@ describe('chatHub', () => {
 			expect(response.session.id).toBe(session.id);
 
 			const {
-				conversation: { rootIds, messages, activeMessageChain },
+				conversation: { messages },
 			} = response;
 
-			expect(rootIds).toEqual([msg1.id]);
 			expect(Object.keys(messages)).toHaveLength(5);
-			expect(activeMessageChain).toHaveLength(4);
-			expect(activeMessageChain[0]).toBe(msg1.id);
-			expect(activeMessageChain[1]).toBe(msg2.id);
-			expect(activeMessageChain[2]).toBe(msg3.id);
-			expect(activeMessageChain[3]).toBe(msg5.id);
 			expect(messages[msg5.id].previousMessageId).toBe(msg3.id);
 			expect(messages[msg5.id].retryOfMessageId).toBe(msg4.id);
 		});
@@ -548,7 +525,7 @@ describe('chatHub', () => {
 				turnId: ids[4],
 				createdAt: new Date('2025-01-03T00:25:00Z'),
 			});
-			const msg1b = await messagesRepository.createChatMessage({
+			await messagesRepository.createChatMessage({
 				id: ids[6],
 				sessionId: session.id,
 				name: 'Nathan',
@@ -579,7 +556,7 @@ describe('chatHub', () => {
 				turnId: ids[8],
 				createdAt: new Date('2025-01-03T00:40:00Z'),
 			});
-			const msg4c = await messagesRepository.createChatMessage({
+			await messagesRepository.createChatMessage({
 				id: crypto.randomUUID(),
 				sessionId: session.id,
 				name: 'ChatGPT',
@@ -595,17 +572,10 @@ describe('chatHub', () => {
 			expect(response.session.id).toBe(session.id);
 
 			const {
-				conversation: { rootIds, messages, activeMessageChain },
+				conversation: { messages },
 			} = response;
 
-			expect(rootIds).toEqual([msg1.id, msg1b.id]);
 			expect(Object.keys(messages)).toHaveLength(10);
-
-			expect(activeMessageChain).toHaveLength(4);
-			expect(activeMessageChain[0]).toBe(msg1.id);
-			expect(activeMessageChain[1]).toBe(msg2r.id);
-			expect(activeMessageChain[2]).toBe(msg3d.id);
-			expect(activeMessageChain[3]).toBe(msg4c.id);
 
 			expect(messages[msg2r.id].previousMessageId).toBe(msg1.id);
 			expect(messages[msg2r.id].retryOfMessageId).toBe(msg2.id);

--- a/packages/frontend/editor-ui/src/features/chatHub/ChatView.vue
+++ b/packages/frontend/editor-ui/src/features/chatHub/ChatView.vue
@@ -284,7 +284,9 @@ function handleEditMessage(message: ChatHubMessageDto) {
 		return;
 	}
 
-	chatStore.editMessage(sessionId.value, message.id, message.content, selectedModel.value, {
+	const mesasgeToEdit = message.revisionOfMessageId ?? message.id;
+
+	chatStore.editMessage(sessionId.value, mesasgeToEdit, message.content, selectedModel.value, {
 		[PROVIDER_CREDENTIAL_TYPE_MAP[selectedModel.value.provider]]: {
 			id: credentialsId,
 			name: '',
@@ -304,12 +306,18 @@ function handleRegenerateMessage(message: ChatHubMessageDto) {
 		return;
 	}
 
-	chatStore.regenerateMessage(sessionId.value, message.id, selectedModel.value, {
+	const messageToRetry = message.retryOfMessageId ?? message.id;
+
+	chatStore.regenerateMessage(sessionId.value, messageToRetry, selectedModel.value, {
 		[PROVIDER_CREDENTIAL_TYPE_MAP[selectedModel.value.provider]]: {
 			id: credentialsId,
 			name: '',
 		},
 	});
+}
+
+function handleSwitchAlternative(messageId: string) {
+	chatStore.switchAlternative(sessionId.value, messageId);
 }
 </script>
 
@@ -377,6 +385,7 @@ function handleRegenerateMessage(message: ChatHubMessageDto) {
 						@cancel-edit="handleCancelEditMessage"
 						@regenerate="handleRegenerateMessage"
 						@update="handleEditMessage"
+						@switch-alternative="handleSwitchAlternative"
 					/>
 				</div>
 

--- a/packages/frontend/editor-ui/src/features/chatHub/chat.types.ts
+++ b/packages/frontend/editor-ui/src/features/chatHub/chat.types.ts
@@ -40,6 +40,7 @@ export interface ChatMessage extends ChatHubMessageDto {
 
 export interface ChatConversation extends ChatHubConversationDto {
 	messages: Record<ChatMessageId, ChatMessage>;
+	activeMessageChain: ChatMessageId[];
 }
 
 export interface StreamOutput {

--- a/packages/frontend/editor-ui/src/features/chatHub/components/ChatMessage.vue
+++ b/packages/frontend/editor-ui/src/features/chatHub/components/ChatMessage.vue
@@ -8,10 +8,11 @@ import ChatMessageActions from './ChatMessageActions.vue';
 import { useClipboard } from '@/composables/useClipboard';
 import { ref, nextTick, watch, useTemplateRef } from 'vue';
 import ChatTypingIndicator from '@/features/chatHub/components/ChatTypingIndicator.vue';
-import type { ChatHubMessageDto } from '@n8n/api-types';
+import type { ChatMessage } from '../chat.types';
+import type { ChatMessageId } from '@n8n/api-types';
 
 const { message, compact, isEditing, isStreaming } = defineProps<{
-	message: ChatHubMessageDto;
+	message: ChatMessage;
 	compact: boolean;
 	isEditing: boolean;
 	isStreaming: boolean;
@@ -20,8 +21,9 @@ const { message, compact, isEditing, isStreaming } = defineProps<{
 const emit = defineEmits<{
 	startEdit: [];
 	cancelEdit: [];
-	update: [message: ChatHubMessageDto];
-	regenerate: [message: ChatHubMessageDto];
+	update: [message: ChatMessage];
+	regenerate: [message: ChatMessage];
+	switchAlternative: [messageId: ChatMessageId];
 }>();
 
 const clipboard = useClipboard();
@@ -57,6 +59,10 @@ function handleConfirmEdit() {
 
 function handleRegenerate() {
 	emit('regenerate', message);
+}
+
+function handleSwitchAlternative(messageId: ChatMessageId) {
+	emit('switchAlternative', messageId);
 }
 
 const markdownOptions = {
@@ -146,9 +152,12 @@ watch(
 					:type="message.type"
 					:just-copied="justCopied"
 					:class="$style.actions"
+					:message-id="message.id"
+					:alternatives="message.alternatives"
 					@copy="handleCopy"
 					@edit="handleEdit"
 					@regenerate="handleRegenerate"
+					@switchAlternative="handleSwitchAlternative"
 				/>
 			</template>
 		</div>

--- a/packages/frontend/editor-ui/src/features/chatHub/components/ChatMessageActions.vue
+++ b/packages/frontend/editor-ui/src/features/chatHub/components/ChatMessageActions.vue
@@ -1,24 +1,31 @@
 <script setup lang="ts">
-import type { ChatHubMessageType } from '@n8n/api-types';
-import { N8nIconButton, N8nTooltip } from '@n8n/design-system';
+import type { ChatHubMessageType, ChatMessageId } from '@n8n/api-types';
+import { N8nIconButton, N8nText, N8nTooltip } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
 import { computed } from 'vue';
 
 const i18n = useI18n();
 
-const { type, justCopied } = defineProps<{
+const { type, justCopied, messageId, alternatives } = defineProps<{
 	type: ChatHubMessageType;
 	justCopied: boolean;
+	messageId: ChatMessageId;
+	alternatives: ChatMessageId[];
 }>();
 
 const emit = defineEmits<{
 	copy: [];
 	edit: [];
 	regenerate: [];
+	switchAlternative: [messageId: ChatMessageId];
 }>();
 
 const copyTooltip = computed(() => {
 	return justCopied ? i18n.baseText('generic.copied') : i18n.baseText('generic.copy');
+});
+
+const currentAlternativeIndex = computed(() => {
+	return alternatives.findIndex((id) => id === messageId);
 });
 
 function handleCopy() {
@@ -63,6 +70,27 @@ function handleRegenerate() {
 			/>
 			<template #content>Regenerate</template>
 		</N8nTooltip>
+		<template v-if="alternatives.length > 1">
+			<N8nIconButton
+				icon="chevron-left"
+				type="tertiary"
+				size="medium"
+				text
+				:disabled="currentAlternativeIndex === 0"
+				@click="$emit('switchAlternative', alternatives[currentAlternativeIndex - 1])"
+			/>
+			<N8nText size="medium" color="text-base">
+				{{ `${currentAlternativeIndex + 1}/${alternatives.length}` }}
+			</N8nText>
+			<N8nIconButton
+				icon="chevron-right"
+				type="tertiary"
+				size="medium"
+				text
+				:disabled="currentAlternativeIndex === alternatives.length - 1"
+				@click="$emit('switchAlternative', alternatives[currentAlternativeIndex + 1])"
+			/>
+		</template>
 	</div>
 </template>
 


### PR DESCRIPTION
## Summary

Makes switching between different attempts possible at FE.
Moved rest of the active message chain calculation to the FE, it needs to also resolve the latest message from current message when switching between attempts "midway" a chain so the logic needed differs on BE and FE.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
