### PR TITLE
fix(SplitInBatchesNode): correct 404 documentation links

### DIFF
--- a/packages/nodes-base/nodes/SplitInBatches/v1/SplitInBatchesV1.node.ts
+++ b/packages/nodes-base/nodes/SplitInBatches/v1/SplitInBatchesV1.node.ts
@@ -24,7 +24,7 @@ export class SplitInBatchesV1 implements INodeType {
 		properties: [
 			{
 				displayName:
-					'You may not need this node — n8n nodes automatically run once for each input item. <a href="https://docs.n8n.io/getting-started/key-concepts/looping.html#using-loops-in-n8n" target="_blank">More info</a>',
+					'You may not need this node — n8n nodes automatically run once for each input item. <a href="https://docs.n8n.io/flow-logic/looping/#using-loops-in-n8n" target="_blank">More info</a>',
 				name: 'splitInBatchesNotice',
 				type: 'notice',
 				default: '',

--- a/packages/nodes-base/nodes/SplitInBatches/v2/SplitInBatchesV2.node.ts
+++ b/packages/nodes-base/nodes/SplitInBatches/v2/SplitInBatchesV2.node.ts
@@ -26,7 +26,7 @@ export class SplitInBatchesV2 implements INodeType {
 		properties: [
 			{
 				displayName:
-					'You may not need this node — n8n nodes automatically run once for each input item. <a href="https://docs.n8n.io/getting-started/key-concepts/looping.html#using-loops-in-n8n" target="_blank">More info</a>',
+					'You may not need this node — n8n nodes automatically run once for each input item. <a href="https://docs.n8n.io/flow-logic/looping/#using-loops-in-n8n" target="_blank">More info</a>',
 				name: 'splitInBatchesNotice',
 				type: 'notice',
 				default: '',

--- a/packages/nodes-base/nodes/SplitInBatches/v3/SplitInBatchesV3.node.ts
+++ b/packages/nodes-base/nodes/SplitInBatches/v3/SplitInBatchesV3.node.ts
@@ -27,7 +27,7 @@ export class SplitInBatchesV3 implements INodeType {
 		properties: [
 			{
 				displayName:
-					'You may not need this node — n8n nodes automatically run once for each input item. <a href="https://docs.n8n.io/getting-started/key-concepts/looping.html#using-loops-in-n8n" target="_blank">More info</a>',
+					'You may not need this node — n8n nodes automatically run once for each input item. <a href="https://docs.n8n.io/flow-logic/looping/#using-loops-in-n8n" target="_blank">More info</a>',
 				name: 'splitInBatchesNotice',
 				type: 'notice',
 				default: '',


### PR DESCRIPTION
## Summary

This PR fixes broken documentation links in the `SplitInBatches` node.
- Old link: `https://docs.n8n.io/getting-started/key-concepts/looping.html#using-loops-in-n8n`
- New link: `https://docs.n8n.io/flow-logic/looping/#using-loops-in-n8n`

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
