### PR TITLE
feat(Azure OpenAI Chat Model Node): Add maxCompletionTokens parameter

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/properties.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/properties.ts
@@ -66,11 +66,19 @@ export const properties: INodeProperties[] = [
 				name: 'maxTokens',
 				default: -1,
 				description:
-					'The maximum number of tokens to generate in the completion. Most models have a context length of 2048 tokens (except for the newest models, which support 32,768). Use -1 for default.',
+					'The maximum number of tokens to generate in the completion. Most models have a context length of 2048 tokens (except for the newest models, which support 32,768). This value is now deprecated in favor of max_completion_tokens, and is not compatible with o-series models. Use -1 for default.',
 				type: 'number',
 				typeOptions: {
 					maxValue: 128000,
 				},
+			},
+			{
+				displayName: 'Maximum Number of Completion Tokens',
+				name: 'maxCompletionTokens',
+				default: -1,
+				description:
+					'The maximum number of tokens that can be generated for a completion, including visible output tokens and reasoning tokens',
+				type: 'number',
 			},
 			{
 				displayName: 'Response Format',

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/types.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/types.ts
@@ -25,6 +25,7 @@ export interface AzureOpenAIApiKeyConfig extends AzureOpenAIConfig {
 export interface AzureOpenAIOptions {
 	frequencyPenalty?: number;
 	maxTokens?: number;
+	maxCompletionTokens?: number;
 	maxRetries?: number;
 	timeout?: number;
 	presencePenalty?: number;


### PR DESCRIPTION
## Summary
Added support for the `maxCompletionTokens` parameter to the Azure OpenAI Chat Model node, providing users with control over the maximum number of tokens generated in chat completions.

## Changes
- Added `maxCompletionTokens` option to the Azure OpenAI Chat Model node properties
- Updated the `AzureOpenAIOptions` interface to include the new parameter
- Updated the description of the existing `maxTokens` parameter to indicate it's deprecated in favor of `max_completion_tokens`

## Related tickets and issues
<!-- Link to Linear ticket or GitHub issue if applicable -->

## Review checklist
- [x] Code follows project conventions
- [x] Changes are typed correctly
- [ ] Tests are added/updated (if applicable)
- [ ] Documentation is updated (if applicable)