### PR TITLE
fix(LM Chat Azure OpenAI Node): Set model name to ensure correct internal logic

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/LmChatAzureOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/LmChatAzureOpenAi.node.ts
@@ -105,6 +105,9 @@ export class LmChatAzureOpenAi implements INodeType {
 
 			// Create and return the model
 			const model = new AzureChatOpenAI({
+				// Model name is required so logs are correct
+				// Also ensures internal logic (like mapping "maxTokens" to "maxCompletionTokens") is correct
+				model: modelName,
 				azureOpenAIApiDeploymentName: modelName,
 				...modelConfig,
 				...options,


### PR DESCRIPTION
## Summary

Fixes multiple issues with Azure OpenAI Chat Model node by setting the `model` parameter in addition to `azureOpenAIApiDeploymentName`.

### Root Cause
The `AzureChatOpenAI` class from LangChain requires the `model` parameter to properly handle internal logic. Previously, only `azureOpenAIApiDeploymentName` was set, which caused:
- Model name to default to `gpt-3.5-turbo` internally
- Incorrect parameter mapping (e.g., `maxTokens` not mapping to `maxCompletionTokens` for newer models)
- Inaccurate logging

### Changes
- Added `model: modelName` parameter to `AzureChatOpenAI` initialization
- This ensures the class uses the correct model for internal logic and logging

### Testing
- Verified that the model parameter is now correctly set
- Confirmed that parameter mapping works correctly for models requiring `maxCompletionTokens`

## Related Linear tickets

https://linear.app/n8n/issue/AI-931/community-issue-azureopenai-model-is-somehow-falling-into-gpt-35-turbo
https://linear.app/n8n/issue/AI-1436/community-issue-bug-azure-openai-chat-model-node-incompatible-with

## Related Github issue(s)

Fixes: https://github.com/n8n-io/n8n/issues/17724
Fixes: https://github.com/n8n-io/n8n/issues/15148

🤖 Generated with [Claude Code](https://claude.com/claude-code)