### PR TITLE
refactor(core): Complete backend config migration

### DIFF
--- a/packages/@n8n/config/src/configs/executions.config.ts
+++ b/packages/@n8n/config/src/configs/executions.config.ts
@@ -46,7 +46,7 @@ export type ExecutionMode = z.infer<typeof executionModeSchema>;
 @Config
 export class ExecutionsConfig {
 	/** Whether to run executions in regular mode (in-process) or scaling mode (in workers). */
-	@Env('EXECUTIONS_MODE')
+	@Env('EXECUTIONS_MODE', executionModeSchema)
 	mode: ExecutionMode = 'regular';
 
 	/**

--- a/packages/@n8n/config/src/configs/executions.config.ts
+++ b/packages/@n8n/config/src/configs/executions.config.ts
@@ -1,3 +1,5 @@
+import z from 'zod';
+
 import { Config, Env, Nested } from '../decorators';
 
 @Config
@@ -37,8 +39,16 @@ class QueueRecoveryConfig {
 	batchSize: number = 100;
 }
 
+const executionModeSchema = z.enum(['regular', 'queue']);
+
+export type ExecutionMode = z.infer<typeof executionModeSchema>;
+
 @Config
 export class ExecutionsConfig {
+	/** Whether to run executions in regular mode (in-process) or scaling mode (in workers). */
+	@Env('EXECUTIONS_MODE')
+	mode: ExecutionMode = 'regular';
+
 	/**
 	 * How long (seconds) a workflow execution may run for before timeout.
 	 * On timeout, the execution will be forcefully stopped. `-1` for unlimited.

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -312,6 +312,7 @@ describe('GlobalConfig', () => {
 			disableBareRepos: false,
 		},
 		executions: {
+			mode: 'regular',
 			timeout: -1,
 			maxTimeout: 3600,
 			pruneData: true,

--- a/packages/cli/src/__tests__/active-executions.test.ts
+++ b/packages/cli/src/__tests__/active-executions.test.ts
@@ -1,5 +1,6 @@
 import { Logger } from '@n8n/backend-common';
 import { mockInstance } from '@n8n/backend-test-utils';
+import { ExecutionsConfig } from '@n8n/config';
 import type { ExecutionRepository } from '@n8n/db';
 import type { Response } from 'express';
 import { captor, mock } from 'jest-mock-extended';
@@ -21,7 +22,6 @@ import { v4 as uuid } from 'uuid';
 
 import { ActiveExecutions } from '@/active-executions';
 import { ConcurrencyControlService } from '@/concurrency/concurrency-control.service';
-import config from '@/config';
 
 jest.mock('n8n-workflow', () => ({
 	...jest.requireActual('n8n-workflow'),
@@ -36,6 +36,10 @@ const executionRepository = mock<ExecutionRepository>();
 const concurrencyControl = mockInstance(ConcurrencyControlService, {
 	// @ts-expect-error Private property
 	isEnabled: false,
+});
+
+const executionsConfig = mockInstance(ExecutionsConfig, {
+	mode: 'regular',
 });
 
 describe('ActiveExecutions', () => {
@@ -76,6 +80,7 @@ describe('ActiveExecutions', () => {
 			executionRepository,
 			concurrencyControl,
 			mock(),
+			executionsConfig,
 		);
 
 		executionRepository.createNewExecution.mockResolvedValue(FAKE_EXECUTION_ID);
@@ -207,6 +212,7 @@ describe('ActiveExecutions', () => {
 				executionRepository,
 				concurrencyControl,
 				mock(),
+				executionsConfig,
 			);
 
 			executionData.httpResponse = mock<Response>();
@@ -305,8 +311,6 @@ describe('ActiveExecutions', () => {
 		let waitingExecutionId1: string, waitingExecutionId2: string;
 
 		beforeEach(async () => {
-			config.set('executions.mode', 'regular');
-
 			executionRepository.createNewExecution.mockImplementation(async () =>
 				randomInt(1000, 2000).toString(),
 			);

--- a/packages/cli/src/__tests__/workflow-runner.test.ts
+++ b/packages/cli/src/__tests__/workflow-runner.test.ts
@@ -27,7 +27,6 @@ import {
 import PCancelable from 'p-cancelable';
 
 import { ActiveExecutions } from '@/active-executions';
-import config from '@/config';
 import { ExecutionNotFoundError } from '@/errors/execution-not-found-error';
 import * as ExecutionLifecycleHooks from '@/execution-lifecycle/execution-lifecycle-hooks';
 import { CredentialsPermissionChecker } from '@/executions/pre-execution-checks';
@@ -39,6 +38,7 @@ import { WorkflowRunner } from '@/workflow-runner';
 
 let owner: User;
 let runner: WorkflowRunner;
+const globalConfig = Container.get(GlobalConfig);
 setupTestServer({ endpointGroups: [] });
 
 mockInstance(Telemetry);
@@ -71,6 +71,7 @@ describe('processError', () => {
 
 	beforeEach(async () => {
 		jest.clearAllMocks();
+		globalConfig.executions.mode = 'regular';
 		workflow = await createWorkflow({}, owner);
 		execution = await createExecution({ status: 'success', finished: true }, workflow);
 		hooks = new core.ExecutionLifecycleHooks('webhook', execution.id, workflow);
@@ -86,7 +87,7 @@ describe('processError', () => {
 			},
 			workflow,
 		);
-		config.set('executions.mode', 'queue');
+		globalConfig.executions.mode = 'queue';
 		await runner.processError(
 			new Error('test') as ExecutionError,
 			new Date(),
@@ -123,7 +124,7 @@ describe('processError', () => {
 			{ executionMode: 'webhook', workflowData: workflow },
 			execution.id,
 		);
-		config.set('executions.mode', 'regular');
+		globalConfig.executions.mode = 'regular';
 		await runner.processError(
 			new Error('test') as ExecutionError,
 			new Date(),

--- a/packages/cli/src/commands/base-command.ts
+++ b/packages/cli/src/commands/base-command.ts
@@ -22,7 +22,6 @@ import {
 import { ensureError, sleep, UnexpectedError, UserError } from 'n8n-workflow';
 
 import type { AbstractServer } from '@/abstract-server';
-import config from '@/config';
 import { N8N_VERSION, N8N_RELEASE_DATE } from '@/constants';
 import * as CrashJournal from '@/crash-journal';
 import { getDataDeduplicationService } from '@/deduplication';
@@ -126,7 +125,7 @@ export abstract class BaseCommand<F = never> {
 		if (process.env.EXECUTIONS_PROCESS === 'own') process.exit(-1);
 
 		if (
-			config.getEnv('executions.mode') === 'queue' &&
+			this.globalConfig.executions.mode === 'queue' &&
 			this.globalConfig.database.type === 'sqlite'
 		) {
 			this.logger.warn(

--- a/packages/cli/src/commands/execute-batch.ts
+++ b/packages/cli/src/commands/execute-batch.ts
@@ -17,7 +17,6 @@ import { findCliWorkflowStart } from '@/utils';
 import { WorkflowRunner } from '@/workflow-runner';
 
 import { BaseCommand } from './base-command';
-import config from '../config';
 import type {
 	IExecutionResult,
 	INodeSpecialCase,
@@ -638,9 +637,9 @@ export class ExecuteBatch extends BaseCommand<z.infer<typeof flagsSchema>> {
 
 		const workflowRunner = Container.get(WorkflowRunner);
 
-		if (config.getEnv('executions.mode') === 'queue') {
+		if (this.globalConfig.executions.mode === 'queue') {
 			this.logger.warn('`executeBatch` does not support queue mode. Falling back to regular mode.');
-			workflowRunner.setExecutionMode('regular');
+			this.globalConfig.executions.mode = 'regular';
 		}
 
 		return await new Promise(async (resolve) => {

--- a/packages/cli/src/commands/execute.ts
+++ b/packages/cli/src/commands/execute.ts
@@ -11,7 +11,6 @@ import { findCliWorkflowStart, isWorkflowIdValid } from '@/utils';
 import { WorkflowRunner } from '@/workflow-runner';
 
 import { BaseCommand } from './base-command';
-import config from '../config';
 
 const flagsSchema = z.object({
 	id: z.string().describe('id of the workflow to execute').optional(),
@@ -86,11 +85,11 @@ export class Execute extends BaseCommand<z.infer<typeof flagsSchema>> {
 
 		const workflowRunner = Container.get(WorkflowRunner);
 
-		if (config.getEnv('executions.mode') === 'queue') {
+		if (this.globalConfig.executions.mode === 'queue') {
 			this.logger.warn(
 				'CLI command `execute` does not support queue mode. Falling back to regular mode.',
 			);
-			workflowRunner.setExecutionMode('regular');
+			this.globalConfig.executions.mode = 'regular';
 		}
 
 		const executionId = await workflowRunner.run(runData);

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -101,7 +101,7 @@ export class Start extends BaseCommand<z.infer<typeof flagsSchema>> {
 				await Container.get(MultiMainSetup).shutdown();
 			}
 
-			if (config.getEnv('executions.mode') === 'queue') {
+			if (this.globalConfig.executions.mode === 'queue') {
 				Container.get(Publisher).shutdown();
 				Container.get(Subscriber).shutdown();
 			}
@@ -193,7 +193,7 @@ export class Start extends BaseCommand<z.infer<typeof flagsSchema>> {
 		await this.initCrashJournal();
 
 		this.logger.info('Initializing n8n process');
-		if (config.getEnv('executions.mode') === 'queue') {
+		if (this.globalConfig.executions.mode === 'queue') {
 			const scopedLogger = this.logger.scoped('scaling');
 			scopedLogger.debug('Starting main instance in scaling mode');
 			scopedLogger.debug(`Host ID: ${this.instanceSettings.hostId}`);
@@ -206,7 +206,7 @@ export class Start extends BaseCommand<z.infer<typeof flagsSchema>> {
 		this.activeWorkflowManager = Container.get(ActiveWorkflowManager);
 
 		const isMultiMainEnabled =
-			config.getEnv('executions.mode') === 'queue' && this.globalConfig.multiMainSetup.enabled;
+			this.globalConfig.executions.mode === 'queue' && this.globalConfig.multiMainSetup.enabled;
 
 		this.instanceSettings.setMultiMainEnabled(isMultiMainEnabled);
 
@@ -217,7 +217,7 @@ export class Start extends BaseCommand<z.infer<typeof flagsSchema>> {
 		 */
 		if (isMultiMainEnabled) this.instanceSettings.setMultiMainLicensed(true);
 
-		if (config.getEnv('executions.mode') === 'regular') {
+		if (this.globalConfig.executions.mode === 'regular') {
 			this.instanceSettings.markAsLeader();
 		} else {
 			await this.initOrchestration();
@@ -340,7 +340,7 @@ export class Start extends BaseCommand<z.infer<typeof flagsSchema>> {
 
 		Container.get(ExecutionsPruningService).init();
 
-		if (config.getEnv('executions.mode') === 'regular') {
+		if (this.globalConfig.executions.mode === 'regular') {
 			await this.runEnqueuedExecutions();
 		}
 

--- a/packages/cli/src/commands/webhook.ts
+++ b/packages/cli/src/commands/webhook.ts
@@ -2,16 +2,15 @@ import { Command } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 
 import { ActiveExecutions } from '@/active-executions';
-import config from '@/config';
+import { DeprecationService } from '@/deprecation/deprecation.service';
+import { MessageEventBus } from '@/eventbus/message-event-bus/message-event-bus';
+import { LogStreamingEventRelay } from '@/events/relays/log-streaming.event-relay';
 import { Publisher } from '@/scaling/pubsub/publisher.service';
 import { PubSubRegistry } from '@/scaling/pubsub/pubsub.registry';
 import { Subscriber } from '@/scaling/pubsub/subscriber.service';
 import { WebhookServer } from '@/webhooks/webhook-server';
-import { DeprecationService } from '@/deprecation/deprecation.service';
 
 import { BaseCommand } from './base-command';
-import { MessageEventBus } from '@/eventbus/message-event-bus/message-event-bus';
-import { LogStreamingEventRelay } from '@/events/relays/log-streaming.event-relay';
 
 @Command({
 	name: 'webhook',
@@ -42,7 +41,7 @@ export class Webhook extends BaseCommand {
 	}
 
 	async init() {
-		if (config.getEnv('executions.mode') !== 'queue') {
+		if (this.globalConfig.executions.mode !== 'queue') {
 			/**
 			 * It is technically possible to run without queues but
 			 * there are 2 known bugs when running in this mode:

--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -3,8 +3,9 @@ import { Command } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 import { z } from 'zod';
 
-import config from '@/config';
 import { N8N_VERSION } from '@/constants';
+import { CredentialsOverwrites } from '@/credentials-overwrites';
+import { DeprecationService } from '@/deprecation/deprecation.service';
 import { EventMessageGeneric } from '@/eventbus/event-message-classes/event-message-generic';
 import { MessageEventBus } from '@/eventbus/message-event-bus/message-event-bus';
 import { LogStreamingEventRelay } from '@/events/relays/log-streaming.event-relay';
@@ -16,8 +17,6 @@ import type { WorkerServerEndpointsConfig } from '@/scaling/worker-server';
 import { WorkerStatusService } from '@/scaling/worker-status.service.ee';
 
 import { BaseCommand } from './base-command';
-import { CredentialsOverwrites } from '@/credentials-overwrites';
-import { DeprecationService } from '@/deprecation/deprecation.service';
 
 const flagsSchema = z.object({
 	concurrency: z.number().int().default(10).describe('How many jobs can run in parallel.'),
@@ -62,11 +61,11 @@ export class Worker extends BaseCommand<z.infer<typeof flagsSchema>> {
 	}
 
 	constructor() {
-		if (config.getEnv('executions.mode') !== 'queue') {
-			config.set('executions.mode', 'queue');
-		}
-
 		super();
+
+		if (this.globalConfig.executions.mode !== 'queue') {
+			this.globalConfig.executions.mode = 'queue';
+		}
 
 		this.logger = this.logger.scoped('scaling');
 	}

--- a/packages/cli/src/concurrency/__tests__/concurrency-control.service.test.ts
+++ b/packages/cli/src/concurrency/__tests__/concurrency-control.service.test.ts
@@ -1,5 +1,5 @@
-import { mockLogger } from '@n8n/backend-test-utils';
-import type { GlobalConfig } from '@n8n/config';
+import { mockInstance, mockLogger } from '@n8n/backend-test-utils';
+import { GlobalConfig } from '@n8n/config';
 import type { ExecutionRepository } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
 import type { WorkflowExecuteMode as ExecutionMode } from 'n8n-workflow';
@@ -10,7 +10,6 @@ import {
 	CLOUD_TEMP_REPORTABLE_THRESHOLDS,
 	ConcurrencyControlService,
 } from '@/concurrency/concurrency-control.service';
-import config from '@/config';
 import { InvalidConcurrencyLimitError } from '@/errors/invalid-concurrency-limit.error';
 import type { EventService } from '@/events/event.service';
 import type { Telemetry } from '@/telemetry';
@@ -22,8 +21,9 @@ describe('ConcurrencyControlService', () => {
 	const executionRepository = mock<ExecutionRepository>();
 	const telemetry = mock<Telemetry>();
 	const eventService = mock<EventService>();
-	const globalConfig = mock<GlobalConfig>({
+	const globalConfig = mockInstance(GlobalConfig, {
 		executions: {
+			mode: 'regular',
 			concurrency: {
 				productionLimit: -1,
 				evaluationLimit: -1,
@@ -34,7 +34,7 @@ describe('ConcurrencyControlService', () => {
 	afterEach(() => {
 		globalConfig.executions.concurrency.productionLimit = -1;
 		globalConfig.executions.concurrency.evaluationLimit = -1;
-		config.set('executions.mode', 'integrated');
+		globalConfig.executions.mode = 'regular';
 
 		jest.clearAllMocks();
 	});
@@ -158,7 +158,7 @@ describe('ConcurrencyControlService', () => {
 			/**
 			 * Arrange
 			 */
-			config.set('executions.mode', 'queue');
+			globalConfig.executions.mode = 'queue';
 			globalConfig.executions.concurrency.productionLimit = 2;
 
 			/**

--- a/packages/cli/src/concurrency/concurrency-control.service.ts
+++ b/packages/cli/src/concurrency/concurrency-control.service.ts
@@ -5,7 +5,6 @@ import { Service } from '@n8n/di';
 import capitalize from 'lodash/capitalize';
 import type { WorkflowExecuteMode as ExecutionMode } from 'n8n-workflow';
 
-import config from '@/config';
 import { InvalidConcurrencyLimitError } from '@/errors/invalid-concurrency-limit.error';
 import { UnknownExecutionModeError } from '@/errors/unknown-execution-mode.error';
 import { EventService } from '@/events/event.service';
@@ -58,7 +57,7 @@ export class ConcurrencyControlService {
 
 		if (
 			Array.from(this.limits.values()).every((limit) => limit === -1) ||
-			config.getEnv('executions.mode') === 'queue'
+			this.globalConfig.executions.mode === 'queue'
 		) {
 			this.isEnabled = false;
 			return;

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -1,16 +1,10 @@
 import { GlobalConfig } from '@n8n/config';
 import { Container } from '@n8n/di';
 
+/**
+ * @deprecated Do not add new environment variables to this file. Please use the `@n8n/config` package instead.
+ */
 export const schema = {
-	executions: {
-		mode: {
-			doc: 'If it should run executions directly or via queue',
-			format: ['regular', 'queue'] as const,
-			default: 'regular',
-			env: 'EXECUTIONS_MODE',
-		},
-	},
-
 	userManagement: {
 		/**
 		 * @important Do not remove until after cloud hooks are updated to stop using convict config.
@@ -22,6 +16,9 @@ export const schema = {
 			default: false,
 		},
 
+		/**
+		 * @techdebt Refactor this to stop using the legacy config schema for internal state.
+		 */
 		authenticationMethod: {
 			doc: 'How to authenticate users (e.g. "email", "ldap", "saml")',
 			format: ['email', 'ldap', 'saml'] as const,

--- a/packages/cli/src/controllers/e2e.controller.ts
+++ b/packages/cli/src/controllers/e2e.controller.ts
@@ -25,6 +25,7 @@ import { Push } from '@/push';
 import { CacheService } from '@/services/cache/cache.service';
 import { FrontendService } from '@/services/frontend.service';
 import { PasswordUtility } from '@/services/password.utility';
+import { ExecutionsConfig } from '@n8n/config';
 
 if (!inE2ETests) {
 	Container.get(Logger).error('E2E endpoints only allowed during E2E tests');
@@ -165,6 +166,7 @@ export class E2EController {
 		private readonly eventBus: MessageEventBus,
 		private readonly userRepository: UserRepository,
 		private readonly frontendService: FrontendService,
+		private readonly executionsConfig: ExecutionsConfig,
 	) {
 		license.isLicensed = (feature: BooleanLicenseFeature) => this.enabledFeatures[feature] ?? false;
 
@@ -215,7 +217,7 @@ export class E2EController {
 	async setQueueMode(req: Request<{}, {}, { enabled: boolean }>) {
 		const { enabled } = req.body;
 		config.set('executions.mode', enabled ? 'queue' : 'regular');
-		return { success: true, message: `Queue mode set to ${config.getEnv('executions.mode')}` };
+		return { success: true, message: `Queue mode set to ${this.executionsConfig.mode}` };
 	}
 
 	@Get('/env-feature-flags', { skipAuth: true })

--- a/packages/cli/src/controllers/e2e.controller.ts
+++ b/packages/cli/src/controllers/e2e.controller.ts
@@ -215,8 +215,7 @@ export class E2EController {
 
 	@Patch('/queue-mode', { skipAuth: true })
 	async setQueueMode(req: Request<{}, {}, { enabled: boolean }>) {
-		const { enabled } = req.body;
-		config.set('executions.mode', enabled ? 'queue' : 'regular');
+		this.executionsConfig.mode = req.body.enabled ? 'queue' : 'regular';
 		return { success: true, message: `Queue mode set to ${this.executionsConfig.mode}` };
 	}
 

--- a/packages/cli/src/deprecation/__tests__/deprecation.service.test.ts
+++ b/packages/cli/src/deprecation/__tests__/deprecation.service.test.ts
@@ -11,7 +11,10 @@ import { DeprecationService } from '../deprecation.service';
 
 describe('DeprecationService', () => {
 	const logger = mock<Logger>();
-	const globalConfig = mockInstance(GlobalConfig, { nodes: { exclude: [] } });
+	const globalConfig = mockInstance(GlobalConfig, {
+		nodes: { exclude: [] },
+		executions: { mode: 'regular' },
+	});
 	const instanceSettings = mockInstance(InstanceSettings, { instanceType: 'main' });
 	const deprecationService = new DeprecationService(logger, globalConfig, instanceSettings);
 

--- a/packages/cli/src/deprecation/__tests__/deprecation.service.test.ts
+++ b/packages/cli/src/deprecation/__tests__/deprecation.service.test.ts
@@ -5,8 +5,6 @@ import type { InstanceType } from '@n8n/constants';
 import { mock } from 'jest-mock-extended';
 import { InstanceSettings } from 'n8n-core';
 
-import config from '@/config';
-
 import { DeprecationService } from '../deprecation.service';
 
 describe('DeprecationService', () => {
@@ -122,21 +120,12 @@ describe('DeprecationService', () => {
 				N8N_BLOCK_ENV_ACCESS_IN_NODE: 'false',
 				N8N_GIT_NODE_DISABLE_BARE_REPOS: 'false',
 			};
-
-			jest.spyOn(config, 'getEnv').mockImplementation((key) => {
-				if (key === 'executions.mode') return 'queue';
-				return undefined;
-			});
 		});
 
 		describe('when executions.mode is not queue', () => {
 			test.each([['main'], ['worker'], ['webhook']])(
 				'should not warn for instanceType %s',
 				(instanceType: InstanceType) => {
-					jest.spyOn(config, 'getEnv').mockImplementation((key) => {
-						if (key === 'executions.mode') return 'regular';
-						return;
-					});
 					process.env[envVar] = 'false';
 					const service = new DeprecationService(
 						logger,
@@ -150,6 +139,11 @@ describe('DeprecationService', () => {
 		});
 
 		describe('when executions.mode is queue', () => {
+			const globalConfig = mockInstance(GlobalConfig, {
+				nodes: { exclude: [] },
+				executions: { mode: 'queue' },
+			});
+
 			describe('when instanceType is worker', () => {
 				test.each([
 					['false', 'false'],

--- a/packages/cli/src/deprecation/deprecation.service.ts
+++ b/packages/cli/src/deprecation/deprecation.service.ts
@@ -3,8 +3,6 @@ import { GlobalConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
 import { InstanceSettings } from 'n8n-core';
 
-import config from '@/config';
-
 type EnvVarName = string;
 
 type Deprecation = {
@@ -71,7 +69,7 @@ export class DeprecationService {
 				'Running manual executions in the main instance in scaling mode is deprecated. Manual executions will be routed to workers in a future version. Please set `OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS=true` to offload manual executions to workers and avoid potential issues in the future. Consider increasing memory available to workers and reducing memory available to main.',
 			checkValue: (value?: string) => value?.toLowerCase() !== 'true' && value !== '1',
 			warnIfMissing: true,
-			matchConfig: config.getEnv('executions.mode') === 'queue',
+			matchConfig: this.globalConfig.executions.mode === 'queue',
 			disableIf: () => this.instanceSettings.instanceType !== 'main',
 		},
 		{

--- a/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
@@ -1,4 +1,5 @@
 import { Logger } from '@n8n/backend-common';
+import { ExecutionsConfig } from '@n8n/config';
 import type { User, TestRun } from '@n8n/db';
 import { TestCaseExecutionRepository, TestRunRepository, WorkflowRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
@@ -23,9 +24,9 @@ import type {
 	IExecuteData,
 } from 'n8n-workflow';
 import assert from 'node:assert';
+import { JsonObject } from 'openid-client';
 
 import { ActiveExecutions } from '@/active-executions';
-import config from '@/config';
 import { TestCaseExecutionError, TestRunError } from '@/evaluation.ee/test-runner/errors.ee';
 import {
 	checkNodeParameterNotEmpty,
@@ -35,7 +36,6 @@ import { Telemetry } from '@/telemetry';
 import { WorkflowRunner } from '@/workflow-runner';
 
 import { EvaluationMetrics } from './evaluation-metrics.ee';
-import { JsonObject } from 'openid-client';
 
 export interface TestRunMetadata {
 	testRunId: string;
@@ -69,6 +69,7 @@ export class TestRunnerService {
 		private readonly testRunRepository: TestRunRepository,
 		private readonly testCaseExecutionRepository: TestCaseExecutionRepository,
 		private readonly errorReporter: ErrorReporter,
+		private readonly executionsConfig: ExecutionsConfig,
 	) {}
 
 	/**
@@ -260,7 +261,7 @@ export class TestRunnerService {
 
 		// When in queue mode, we need to pass additional data to the execution
 		// the same way as it would be passed in manual mode
-		if (config.getEnv('executions.mode') === 'queue') {
+		if (this.executionsConfig.mode === 'queue') {
 			data.executionData = {
 				resultData: {
 					pinData,
@@ -352,7 +353,7 @@ export class TestRunnerService {
 
 		if (
 			!(
-				config.get('executions.mode') === 'queue' &&
+				this.executionsConfig.mode === 'queue' &&
 				process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS === 'true'
 			) &&
 			data.executionData

--- a/packages/cli/src/eventbus/message-event-bus/message-event-bus.ts
+++ b/packages/cli/src/eventbus/message-event-bus/message-event-bus.ts
@@ -11,7 +11,6 @@ import EventEmitter from 'events';
 import uniqby from 'lodash/uniqBy';
 import type { MessageEventBusDestinationOptions } from 'n8n-workflow';
 
-import config from '@/config';
 import { License } from '@/license';
 import { Publisher } from '@/scaling/pubsub/publisher.service';
 
@@ -150,7 +149,7 @@ export class MessageEventBus extends EventEmitter {
 
 			// if we are in queue mode, running jobs may still be running on a worker despite the main process
 			// crashing, so we can't just mark them as crashed
-			if (config.get('executions.mode') !== 'queue') {
+			if (this.globalConfig.executions.mode !== 'queue') {
 				const dbUnfinishedExecutionIds = (
 					await this.executionRepository.find({
 						where: {

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -846,7 +846,7 @@ export class TelemetryEventRelay extends EventRelay {
 				is_docker: this.instanceSettings.isDocker,
 			},
 			execution_variables: {
-				executions_mode: config.getEnv('executions.mode'),
+				executions_mode: this.globalConfig.executions.mode,
 				executions_timeout: this.globalConfig.executions.timeout,
 				executions_timeout_max: this.globalConfig.executions.maxTimeout,
 				executions_data_save_on_error: this.globalConfig.executions.saveDataOnError,

--- a/packages/cli/src/executions/__tests__/execution.service.test.ts
+++ b/packages/cli/src/executions/__tests__/execution.service.test.ts
@@ -1,11 +1,12 @@
 import { mockInstance } from '@n8n/backend-test-utils';
+import { GlobalConfig } from '@n8n/config';
 import type { IExecutionResponse, ExecutionRepository } from '@n8n/db';
+import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
 import { ManualExecutionCancelledError, WorkflowOperationError } from 'n8n-workflow';
 
 import type { ActiveExecutions } from '@/active-executions';
 import type { ConcurrencyControlService } from '@/concurrency/concurrency-control.service';
-import config from '@/config';
 import { AbortedExecutionRetryError } from '@/errors/aborted-execution-retry.error';
 import { MissingExecutionStopError } from '@/errors/missing-execution-stop.error';
 import { ExecutionService } from '@/executions/execution.service';
@@ -20,9 +21,10 @@ describe('ExecutionService', () => {
 	const executionRepository = mock<ExecutionRepository>();
 	const waitTracker = mock<WaitTracker>();
 	const concurrencyControl = mock<ConcurrencyControlService>();
+	const globalConfig = Container.get(GlobalConfig);
 
 	const executionService = new ExecutionService(
-		mock(),
+		globalConfig,
 		mock(),
 		activeExecutions,
 		mock(),
@@ -38,7 +40,7 @@ describe('ExecutionService', () => {
 	);
 
 	beforeEach(() => {
-		config.set('executions.mode', 'regular');
+		globalConfig.executions.mode = 'regular';
 		jest.clearAllMocks();
 	});
 
@@ -200,7 +202,7 @@ describe('ExecutionService', () => {
 					/**
 					 * Arrange
 					 */
-					config.set('executions.mode', 'queue');
+					globalConfig.executions.mode = 'queue';
 					const execution = mock<IExecutionResponse>({
 						id: '123',
 						mode: 'manual',
@@ -244,7 +246,7 @@ describe('ExecutionService', () => {
 					/**
 					 * Arrange
 					 */
-					config.set('executions.mode', 'queue');
+					globalConfig.executions.mode = 'queue';
 					const execution = mock<IExecutionResponse>({ id: '123', status: 'running' });
 					executionRepository.findWithUnflattenedData.mockResolvedValue(execution);
 					waitTracker.has.mockReturnValue(false);
@@ -273,7 +275,7 @@ describe('ExecutionService', () => {
 					/**
 					 * Arrange
 					 */
-					config.set('executions.mode', 'queue');
+					globalConfig.executions.mode = 'queue';
 					const execution = mock<IExecutionResponse>({ id: '123', status: 'waiting' });
 					executionRepository.findWithUnflattenedData.mockResolvedValue(execution);
 					waitTracker.has.mockReturnValue(true);

--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -35,7 +35,6 @@ import {
 
 import { ActiveExecutions } from '@/active-executions';
 import { ConcurrencyControlService } from '@/concurrency/concurrency-control.service';
-import config from '@/config';
 import { AbortedExecutionRetryError } from '@/errors/aborted-execution-retry.error';
 import { MissingExecutionStopError } from '@/errors/missing-execution-stop.error';
 import { QueuedExecutionRetryError } from '@/errors/queued-execution-retry.error';
@@ -439,7 +438,7 @@ export class ExecutionService {
 
 	private isConcurrentExecutionsCountSupported(): boolean {
 		const isConcurrencyEnabled = this.globalConfig.executions.concurrency.productionLimit !== -1;
-		const isInRegularMode = config.getEnv('executions.mode') === 'regular';
+		const isInRegularMode = this.globalConfig.executions.mode === 'regular';
 
 		if (!isConcurrencyEnabled || !isInRegularMode) {
 			return false;
@@ -499,7 +498,7 @@ export class ExecutionService {
 		this.assertStoppable(execution);
 
 		const { mode, startedAt, stoppedAt, finished, status } =
-			config.getEnv('executions.mode') === 'regular'
+			this.globalConfig.executions.mode === 'regular'
 				? await this.stopInRegularMode(execution)
 				: await this.stopInScalingMode(execution);
 

--- a/packages/cli/src/license.ts
+++ b/packages/cli/src/license.ts
@@ -16,7 +16,6 @@ import type { TEntitlement, TLicenseBlock } from '@n8n_io/license-sdk';
 import { LicenseManager } from '@n8n_io/license-sdk';
 import { InstanceSettings } from 'n8n-core';
 
-import config from '@/config';
 import { LicenseMetricsService } from '@/metrics/license-metrics.service';
 
 import { N8N_VERSION, SETTINGS_LICENSE_CERT_KEY } from './constants';
@@ -148,7 +147,7 @@ export class License implements LicenseProvider {
 	}
 
 	private async broadcastReloadLicenseCommand() {
-		if (config.getEnv('executions.mode') === 'queue' && this.instanceSettings.isLeader) {
+		if (this.globalConfig.executions.mode === 'queue' && this.instanceSettings.isLeader) {
 			const { Publisher } = await import('@/scaling/pubsub/publisher.service');
 			await Container.get(Publisher).publishCommand({ command: 'reload-license' });
 		}

--- a/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
+++ b/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
@@ -8,7 +8,6 @@ import type { InstanceSettings } from 'n8n-core';
 import { EventMessageTypeNames } from 'n8n-workflow';
 import promClient from 'prom-client';
 
-import config from '@/config';
 import type { MessageEventBus } from '@/eventbus/message-event-bus/message-event-bus';
 import type { EventService } from '@/events/event.service';
 
@@ -57,6 +56,9 @@ describe('PrometheusMetricsService', () => {
 				webhook: 'webhook',
 				webhookTest: 'webhook-test',
 				webhookWaiting: 'webhook-waiting',
+			},
+			executions: {
+				mode: 'regular',
 			},
 		});
 
@@ -202,7 +204,7 @@ describe('PrometheusMetricsService', () => {
 		});
 
 		it('should set up queue metrics if enabled', async () => {
-			config.set('executions.mode', 'queue');
+			globalConfig.executions.mode = 'queue';
 			prometheusMetricsService.enableMetric('queue');
 
 			await prometheusMetricsService.init(app);
@@ -233,7 +235,7 @@ describe('PrometheusMetricsService', () => {
 		});
 
 		it('should not set up queue metrics if enabled but not on scaling mode', async () => {
-			config.set('executions.mode', 'regular');
+			globalConfig.executions.mode = 'regular';
 			prometheusMetricsService.enableMetric('queue');
 
 			await prometheusMetricsService.init(app);
@@ -244,7 +246,7 @@ describe('PrometheusMetricsService', () => {
 		});
 
 		it('should not set up queue metrics if enabled and on scaling mode but instance is not main', async () => {
-			config.set('executions.mode', 'queue');
+			globalConfig.executions.mode = 'queue';
 			prometheusMetricsService.enableMetric('queue');
 			// @ts-expect-error private field
 			instanceSettings.instanceType = 'worker';

--- a/packages/cli/src/metrics/prometheus-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus-metrics.service.ts
@@ -11,7 +11,6 @@ import { EventMessageTypeNames } from 'n8n-workflow';
 import promClient, { type Counter, type Gauge } from 'prom-client';
 import semverParse from 'semver/functions/parse';
 
-import config from '@/config';
 import { N8N_VERSION } from '@/constants';
 import type { EventMessageTypes } from '@/eventbus';
 import { MessageEventBus } from '@/eventbus/message-event-bus/message-event-bus';
@@ -258,7 +257,7 @@ export class PrometheusMetricsService {
 	private initQueueMetrics() {
 		if (
 			!this.includes.metrics.queue ||
-			config.getEnv('executions.mode') !== 'queue' ||
+			this.globalConfig.executions.mode !== 'queue' ||
 			this.instanceSettings.instanceType !== 'main'
 		) {
 			return;

--- a/packages/cli/src/scaling/pubsub/__tests__/publisher.service.test.ts
+++ b/packages/cli/src/scaling/pubsub/__tests__/publisher.service.test.ts
@@ -1,35 +1,42 @@
-import { mockLogger } from '@n8n/backend-test-utils';
+import { mockInstance, mockLogger } from '@n8n/backend-test-utils';
+import { ExecutionsConfig } from '@n8n/config';
 import type { Redis as SingleNodeClient } from 'ioredis';
 import { mock } from 'jest-mock-extended';
 import type { InstanceSettings } from 'n8n-core';
 
-import config from '@/config';
 import type { RedisClientService } from '@/services/redis-client.service';
 
 import { Publisher } from '../publisher.service';
 import type { PubSub } from '../pubsub.types';
 
 describe('Publisher', () => {
-	beforeEach(() => {
-		config.set('executions.mode', 'queue');
-	});
-
 	const client = mock<SingleNodeClient>();
 	const logger = mockLogger();
 	const hostId = 'main-bnxa1riryKUNHtln';
 	const instanceSettings = mock<InstanceSettings>({ hostId });
 	const redisClientService = mock<RedisClientService>({ createClient: () => client });
+	const executionsConfig = mockInstance(ExecutionsConfig, { mode: 'queue' });
 
 	describe('constructor', () => {
 		it('should init Redis client in scaling mode', () => {
-			const publisher = new Publisher(logger, redisClientService, instanceSettings);
+			const publisher = new Publisher(
+				logger,
+				redisClientService,
+				instanceSettings,
+				executionsConfig,
+			);
 
 			expect(publisher.getClient()).toEqual(client);
 		});
 
 		it('should not init Redis client in regular mode', () => {
-			config.set('executions.mode', 'regular');
-			const publisher = new Publisher(logger, redisClientService, instanceSettings);
+			const regularModeConfig = mockInstance(ExecutionsConfig, { mode: 'regular' });
+			const publisher = new Publisher(
+				logger,
+				redisClientService,
+				instanceSettings,
+				regularModeConfig,
+			);
 
 			expect(publisher.getClient()).toBeUndefined();
 		});
@@ -37,7 +44,12 @@ describe('Publisher', () => {
 
 	describe('shutdown', () => {
 		it('should disconnect Redis client', () => {
-			const publisher = new Publisher(logger, redisClientService, instanceSettings);
+			const publisher = new Publisher(
+				logger,
+				redisClientService,
+				instanceSettings,
+				executionsConfig,
+			);
 			publisher.shutdown();
 			expect(client.disconnect).toHaveBeenCalled();
 		});
@@ -45,8 +57,13 @@ describe('Publisher', () => {
 
 	describe('publishCommand', () => {
 		it('should do nothing if not in scaling mode', async () => {
-			config.set('executions.mode', 'regular');
-			const publisher = new Publisher(logger, redisClientService, instanceSettings);
+			const regularModeConfig = mockInstance(ExecutionsConfig, { mode: 'regular' });
+			const publisher = new Publisher(
+				logger,
+				redisClientService,
+				instanceSettings,
+				regularModeConfig,
+			);
 			const msg = mock<PubSub.Command>({ command: 'reload-license' });
 
 			await publisher.publishCommand(msg);
@@ -55,7 +72,12 @@ describe('Publisher', () => {
 		});
 
 		it('should publish command into `n8n.commands` pubsub channel', async () => {
-			const publisher = new Publisher(logger, redisClientService, instanceSettings);
+			const publisher = new Publisher(
+				logger,
+				redisClientService,
+				instanceSettings,
+				executionsConfig,
+			);
 			const msg = mock<PubSub.Command>({ command: 'reload-license' });
 
 			await publisher.publishCommand(msg);
@@ -67,7 +89,12 @@ describe('Publisher', () => {
 		});
 
 		it('should not debounce `add-webhooks-triggers-and-pollers`', async () => {
-			const publisher = new Publisher(logger, redisClientService, instanceSettings);
+			const publisher = new Publisher(
+				logger,
+				redisClientService,
+				instanceSettings,
+				executionsConfig,
+			);
 			const msg = mock<PubSub.Command>({ command: 'add-webhooks-triggers-and-pollers' });
 
 			await publisher.publishCommand(msg);
@@ -85,7 +112,12 @@ describe('Publisher', () => {
 		});
 
 		it('should not debounce `remove-triggers-and-pollers`', async () => {
-			const publisher = new Publisher(logger, redisClientService, instanceSettings);
+			const publisher = new Publisher(
+				logger,
+				redisClientService,
+				instanceSettings,
+				executionsConfig,
+			);
 			const msg = mock<PubSub.Command>({ command: 'remove-triggers-and-pollers' });
 
 			await publisher.publishCommand(msg);
@@ -105,7 +137,12 @@ describe('Publisher', () => {
 
 	describe('publishWorkerResponse', () => {
 		it('should publish worker response into `n8n.worker-response` pubsub channel', async () => {
-			const publisher = new Publisher(logger, redisClientService, instanceSettings);
+			const publisher = new Publisher(
+				logger,
+				redisClientService,
+				instanceSettings,
+				executionsConfig,
+			);
 			const msg = mock<PubSub.WorkerResponse>({
 				response: 'response-to-get-worker-status',
 			});

--- a/packages/cli/src/scaling/pubsub/__tests__/subscriber.service.test.ts
+++ b/packages/cli/src/scaling/pubsub/__tests__/subscriber.service.test.ts
@@ -1,30 +1,43 @@
+import { mockInstance } from '@n8n/backend-test-utils';
+import { ExecutionsConfig } from '@n8n/config';
 import type { Redis as SingleNodeClient } from 'ioredis';
 import { mock } from 'jest-mock-extended';
 
-import config from '@/config';
 import type { RedisClientService } from '@/services/redis-client.service';
 
 import { Subscriber } from '../subscriber.service';
 
 describe('Subscriber', () => {
 	beforeEach(() => {
-		config.set('executions.mode', 'queue');
 		jest.restoreAllMocks();
 	});
 
 	const client = mock<SingleNodeClient>();
 	const redisClientService = mock<RedisClientService>({ createClient: () => client });
+	const executionsConfig = mockInstance(ExecutionsConfig, { mode: 'queue' });
 
 	describe('constructor', () => {
 		it('should init Redis client in scaling mode', () => {
-			const subscriber = new Subscriber(mock(), mock(), mock(), redisClientService);
+			const subscriber = new Subscriber(
+				mock(),
+				mock(),
+				mock(),
+				redisClientService,
+				executionsConfig,
+			);
 
 			expect(subscriber.getClient()).toEqual(client);
 		});
 
 		it('should not init Redis client in regular mode', () => {
-			config.set('executions.mode', 'regular');
-			const subscriber = new Subscriber(mock(), mock(), mock(), redisClientService);
+			const regularModeConfig = mockInstance(ExecutionsConfig, { mode: 'regular' });
+			const subscriber = new Subscriber(
+				mock(),
+				mock(),
+				mock(),
+				redisClientService,
+				regularModeConfig,
+			);
 
 			expect(subscriber.getClient()).toBeUndefined();
 		});
@@ -32,7 +45,13 @@ describe('Subscriber', () => {
 
 	describe('shutdown', () => {
 		it('should disconnect Redis client', () => {
-			const subscriber = new Subscriber(mock(), mock(), mock(), redisClientService);
+			const subscriber = new Subscriber(
+				mock(),
+				mock(),
+				mock(),
+				redisClientService,
+				executionsConfig,
+			);
 			subscriber.shutdown();
 			expect(client.disconnect).toHaveBeenCalled();
 		});
@@ -40,7 +59,13 @@ describe('Subscriber', () => {
 
 	describe('subscribe', () => {
 		it('should subscribe to pubsub channel', async () => {
-			const subscriber = new Subscriber(mock(), mock(), mock(), redisClientService);
+			const subscriber = new Subscriber(
+				mock(),
+				mock(),
+				mock(),
+				redisClientService,
+				executionsConfig,
+			);
 
 			await subscriber.subscribe('n8n.commands');
 

--- a/packages/cli/src/scaling/pubsub/publisher.service.ts
+++ b/packages/cli/src/scaling/pubsub/publisher.service.ts
@@ -1,10 +1,10 @@
 import { Logger } from '@n8n/backend-common';
+import { ExecutionsConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
 import type { Redis as SingleNodeClient, Cluster as MultiNodeClient } from 'ioredis';
 import { InstanceSettings } from 'n8n-core';
 import type { LogMetadata } from 'n8n-workflow';
 
-import config from '@/config';
 import { RedisClientService } from '@/services/redis-client.service';
 
 import type { PubSub } from './pubsub.types';
@@ -23,9 +23,10 @@ export class Publisher {
 		private readonly logger: Logger,
 		private readonly redisClientService: RedisClientService,
 		private readonly instanceSettings: InstanceSettings,
+		private readonly executionsConfig: ExecutionsConfig,
 	) {
 		// @TODO: Once this class is only ever initialized in scaling mode, assert in the next line.
-		if (config.getEnv('executions.mode') !== 'queue') return;
+		if (this.executionsConfig.mode !== 'queue') return;
 
 		this.logger = this.logger.scoped(['scaling', 'pubsub']);
 
@@ -48,7 +49,7 @@ export class Publisher {
 	/** Publish a command into the `n8n.commands` channel. */
 	async publishCommand(msg: PubSub.Command) {
 		// @TODO: Once this class is only ever used in scaling mode, remove next line.
-		if (config.getEnv('executions.mode') !== 'queue') return;
+		if (this.executionsConfig.mode !== 'queue') return;
 
 		await this.client.publish(
 			'n8n.commands',

--- a/packages/cli/src/scaling/pubsub/subscriber.service.ts
+++ b/packages/cli/src/scaling/pubsub/subscriber.service.ts
@@ -1,4 +1,5 @@
 import { Logger } from '@n8n/backend-common';
+import { ExecutionsConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
 import type { Redis as SingleNodeClient, Cluster as MultiNodeClient } from 'ioredis';
 import debounce from 'lodash/debounce';
@@ -6,7 +7,6 @@ import { InstanceSettings } from 'n8n-core';
 import { jsonParse } from 'n8n-workflow';
 import type { LogMetadata } from 'n8n-workflow';
 
-import config from '@/config';
 import { RedisClientService } from '@/services/redis-client.service';
 
 import { PubSubEventBus } from './pubsub.eventbus';
@@ -24,9 +24,10 @@ export class Subscriber {
 		private readonly instanceSettings: InstanceSettings,
 		private readonly pubsubEventBus: PubSubEventBus,
 		private readonly redisClientService: RedisClientService,
+		private readonly executionsConfig: ExecutionsConfig,
 	) {
 		// @TODO: Once this class is only ever initialized in scaling mode, throw in the next line instead.
-		if (config.getEnv('executions.mode') !== 'queue') return;
+		if (this.executionsConfig.mode !== 'queue') return;
 
 		this.logger = this.logger.scoped(['scaling', 'pubsub']);
 

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1,5 +1,3 @@
-import { CLI_DIR, EDITOR_UI_DIST_DIR, inE2ETests } from '@/constants';
-import type { ICredentialsOverwrite } from '@/interfaces';
 import { inDevelopment, inProduction } from '@n8n/backend-common';
 import { SecurityConfig } from '@n8n/config';
 import { Time } from '@n8n/constants';
@@ -16,12 +14,13 @@ import { resolve } from 'path';
 
 import { AbstractServer } from '@/abstract-server';
 import { AuthService } from '@/auth/auth.service';
-import config from '@/config';
+import { CLI_DIR, EDITOR_UI_DIST_DIR, inE2ETests } from '@/constants';
 import { ControllerRegistry } from '@/controller.registry';
 import { CredentialsOverwrites } from '@/credentials-overwrites';
 import { MessageEventBus } from '@/eventbus/message-event-bus/message-event-bus';
 import { EventService } from '@/events/event.service';
 import { LogStreamingEventRelay } from '@/events/relays/log-streaming.event-relay';
+import type { ICredentialsOverwrite } from '@/interfaces';
 import { isLdapEnabled } from '@/ldap.ee/helpers.ee';
 import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 import { handleMfaDisable, isMfaFeatureEnabled } from '@/mfa/helpers';
@@ -245,7 +244,7 @@ export class Server extends AbstractServer {
 			);
 		}
 
-		if (config.getEnv('executions.mode') === 'queue') {
+		if (this.globalConfig.executions.mode === 'queue') {
 			const { ScalingService } = await import('@/scaling/scaling.service');
 			await Container.get(ScalingService).setupQueue();
 		}

--- a/packages/cli/src/services/__tests__/workflow-statistics.service.integration.test.ts
+++ b/packages/cli/src/services/__tests__/workflow-statistics.service.integration.test.ts
@@ -9,6 +9,7 @@ import {
 	type EntityManager,
 	type EntityMetadata,
 } from '@n8n/typeorm';
+import { createUser } from '@test-integration/db/users';
 import { mocked } from 'jest-mock';
 import { mock } from 'jest-mock-extended';
 import {
@@ -18,12 +19,10 @@ import {
 	type WorkflowExecuteMode,
 } from 'n8n-workflow';
 
-import config from '@/config';
 import { EventService } from '@/events/event.service';
 import { OwnershipService } from '@/services/ownership.service';
 import { UserService } from '@/services/user.service';
 import { WorkflowStatisticsService } from '@/services/workflow-statistics.service';
-import { createUser } from '@test-integration/db/users';
 
 describe('WorkflowStatisticsService', () => {
 	describe('workflowExecutionCompleted', () => {
@@ -282,7 +281,7 @@ describe('WorkflowStatisticsService', () => {
 				eventService,
 			);
 			globalConfig.diagnostics.enabled = true;
-			config.set('deployment.type', 'n8n-testing');
+			globalConfig.deployment.type = 'n8n-testing';
 			mocked(ownershipService.getWorkflowProjectCached).mockResolvedValue(project);
 			mocked(ownershipService.getPersonalProjectOwnerCached).mockResolvedValue(user);
 		});

--- a/packages/cli/src/services/cache/__tests__/cache.service.test.ts
+++ b/packages/cli/src/services/cache/__tests__/cache.service.test.ts
@@ -38,7 +38,7 @@ for (const backend of ['memory', 'redis'] as const) {
 
 			if (backend === 'redis') {
 				test('with auto backend and queue mode, should select redis', async () => {
-					config.set('executions.mode', 'queue');
+					globalConfig.executions.mode = 'queue';
 
 					await cacheService.init();
 

--- a/packages/cli/src/services/cache/cache.service.ts
+++ b/packages/cli/src/services/cache/cache.service.ts
@@ -4,7 +4,6 @@ import { Container, Service } from '@n8n/di';
 import { caching } from 'cache-manager';
 import { jsonStringify, UserError } from 'n8n-workflow';
 
-import config from '@/config';
 import { MalformedRefreshValueError } from '@/errors/cache-errors/malformed-refresh-value.error';
 import { UncacheableValueError } from '@/errors/cache-errors/uncacheable-value.error';
 import type {
@@ -31,7 +30,7 @@ export class CacheService extends TypedEmitter<CacheEvents> {
 
 	async init() {
 		const { backend } = this.globalConfig.cache;
-		const mode = config.getEnv('executions.mode');
+		const { mode } = this.globalConfig.executions;
 
 		const useRedis = backend === 'redis' || (backend === 'auto' && mode === 'queue');
 

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -207,7 +207,7 @@ export class FrontendService {
 				enabled: this.globalConfig.templates.enabled,
 				host: this.globalConfig.templates.host,
 			},
-			executionMode: config.getEnv('executions.mode'),
+			executionMode: this.globalConfig.executions.mode,
 			isMultiMain: this.instanceSettings.isMultiMain,
 			pushBackend: this.pushConfig.backend,
 
@@ -437,7 +437,7 @@ export class FrontendService {
 		// TODO: read from settings
 		this.settings.mfa.enforced = this.mfaService.isMFAEnforced();
 
-		this.settings.executionMode = config.getEnv('executions.mode');
+		this.settings.executionMode = this.globalConfig.executions.mode;
 
 		this.settings.binaryDataMode = this.binaryDataConfig.mode;
 

--- a/packages/cli/src/telemetry/__tests__/telemetry.test.ts
+++ b/packages/cli/src/telemetry/__tests__/telemetry.test.ts
@@ -4,7 +4,6 @@ import type RudderStack from '@rudderstack/rudder-sdk-node';
 import { mock } from 'jest-mock-extended';
 import { InstanceSettings } from 'n8n-core';
 
-import config from '@/config';
 import { PostHogClient } from '@/posthog';
 import { Telemetry } from '@/telemetry';
 
@@ -32,7 +31,7 @@ describe('Telemetry', () => {
 
 		jest.useFakeTimers();
 		jest.setSystemTime(testDateTime);
-		config.set('deployment.type', 'n8n-testing');
+		globalConfig.deployment.type = 'n8n-testing';
 	});
 
 	afterAll(async () => {

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -26,7 +26,6 @@ import {
 import PCancelable from 'p-cancelable';
 
 import { ActiveExecutions } from '@/active-executions';
-import config from '@/config';
 import { ExecutionNotFoundError } from '@/errors/execution-not-found-error';
 import { MaxStalledCountError } from '@/errors/max-stalled-count.error';
 // eslint-disable-next-line import-x/no-cycle
@@ -50,8 +49,6 @@ import { EventService } from './events/event.service';
 export class WorkflowRunner {
 	private scalingService: ScalingService;
 
-	private executionsMode = config.getEnv('executions.mode');
-
 	constructor(
 		private readonly logger: Logger,
 		private readonly errorReporter: ErrorReporter,
@@ -66,10 +63,6 @@ export class WorkflowRunner {
 		private readonly eventService: EventService,
 		private readonly executionsConfig: ExecutionsConfig,
 	) {}
-
-	setExecutionMode(mode: 'regular' | 'queue') {
-		this.executionsMode = mode;
-	}
 
 	/** The process did error */
 	async processError(
@@ -95,7 +88,7 @@ export class WorkflowRunner {
 		this.logger.error(`Problem with execution ${executionId}: ${error.message}. Aborting.`);
 		this.errorReporter.error(error, { executionId });
 
-		const isQueueMode = config.getEnv('executions.mode') === 'queue';
+		const isQueueMode = this.executionsConfig.mode === 'queue';
 
 		// in queue mode, first do a sanity run for the edge case that the execution was not marked as stalled
 		// by Bull even though it executed successfully, see https://github.com/OptimalBits/bull/issues/1415
@@ -173,8 +166,8 @@ export class WorkflowRunner {
 		// @TODO: Reduce to true branch once feature is stable
 		const shouldEnqueue =
 			process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS === 'true'
-				? this.executionsMode === 'queue'
-				: this.executionsMode === 'queue' && data.executionMode !== 'manual';
+				? this.executionsConfig.mode === 'queue'
+				: this.executionsConfig.mode === 'queue' && data.executionMode !== 'manual';
 
 		if (shouldEnqueue) {
 			await this.enqueueExecution(executionId, workflowId, data, loadStaticData, realtime);
@@ -185,7 +178,7 @@ export class WorkflowRunner {
 		// only run these when not in queue mode or when the execution is manual,
 		// since these calls are now done by the worker directly
 		if (
-			this.executionsMode !== 'queue' ||
+			this.executionsConfig.mode !== 'queue' ||
 			this.instanceSettings.instanceType === 'worker' ||
 			data.executionMode === 'manual'
 		) {

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -20,7 +20,6 @@ import type {
 } from 'n8n-workflow';
 import { SubworkflowOperationError, Workflow } from 'n8n-workflow';
 
-import config from '@/config';
 import { ExecutionDataService } from '@/executions/execution-data.service';
 import { SubworkflowPolicyChecker } from '@/executions/pre-execution-checks';
 import type { IWorkflowErrorData } from '@/interfaces';
@@ -206,7 +205,7 @@ export class WorkflowExecutionService {
 		 * so we persist all details to give workers full access to them.
 		 */
 		if (
-			config.getEnv('executions.mode') === 'queue' &&
+			this.globalConfig.executions.mode === 'queue' &&
 			process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS === 'true'
 		) {
 			data.executionData = {

--- a/packages/cli/test/integration/commands/worker.cmd.test.ts
+++ b/packages/cli/test/integration/commands/worker.cmd.test.ts
@@ -1,7 +1,7 @@
 process.argv[2] = 'worker';
 
 import { mockInstance } from '@n8n/backend-test-utils';
-import { TaskRunnersConfig } from '@n8n/config';
+import { ExecutionsConfig, TaskRunnersConfig } from '@n8n/config';
 import { Container } from '@n8n/di';
 import { BinaryDataService } from 'n8n-core';
 
@@ -22,7 +22,7 @@ import { JsTaskRunnerProcess } from '@/task-runners/task-runner-process-js';
 import { Telemetry } from '@/telemetry';
 import { setupTestCommand } from '@test-integration/utils/test-command';
 
-config.set('executions.mode', 'queue');
+Container.get(ExecutionsConfig).mode = 'queue';
 config.set('binaryDataManager.availableModes', 'filesystem');
 Container.get(TaskRunnersConfig).enabled = true;
 mockInstance(LoadNodesAndCredentials);
@@ -43,7 +43,7 @@ mockInstance(Push);
 const command = setupTestCommand(Worker);
 
 test('worker initializes all its components', async () => {
-	config.set('executions.mode', 'regular'); // should be overridden
+	Container.get(ExecutionsConfig).mode = 'regular'; // should be overridden
 
 	await command.run();
 
@@ -59,5 +59,5 @@ test('worker initializes all its components', async () => {
 	expect(taskBrokerServer.start).toHaveBeenCalledTimes(1);
 	expect(taskRunnerProcess.start).toHaveBeenCalledTimes(1);
 
-	expect(config.getEnv('executions.mode')).toBe('queue');
+	expect(Container.get(ExecutionsConfig).mode).toBe('queue');
 });

--- a/packages/cli/test/integration/execution.service.integration.test.ts
+++ b/packages/cli/test/integration/execution.service.integration.test.ts
@@ -5,7 +5,6 @@ import { ExecutionMetadataRepository, ExecutionRepository, WorkflowRepository } 
 import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
 
-import config from '@/config';
 import { ExecutionService } from '@/executions/execution.service';
 
 import { annotateExecution, createAnnotationTags, createExecution } from './shared/db/executions';
@@ -39,7 +38,7 @@ describe('ExecutionService', () => {
 
 	beforeEach(() => {
 		globalConfig.executions.concurrency.productionLimit = -1;
-		config.set('executions.mode', 'regular');
+		globalConfig.executions.mode = 'regular';
 	});
 
 	afterEach(async () => {
@@ -553,7 +552,7 @@ describe('ExecutionService', () => {
 		});
 
 		test('should set concurrentExecutionsCount to -1 in queue mode', async () => {
-			config.set('executions.mode', 'queue');
+			globalConfig.executions.mode = 'queue';
 			globalConfig.executions.concurrency.productionLimit = 4;
 
 			const workflow = await createWorkflow();

--- a/packages/cli/test/integration/license.api.test.ts
+++ b/packages/cli/test/integration/license.api.test.ts
@@ -2,16 +2,13 @@ import { testDb } from '@n8n/backend-test-utils';
 import { GLOBAL_MEMBER_ROLE, GLOBAL_OWNER_ROLE, type User } from '@n8n/db';
 import nock from 'nock';
 
-import config from '@/config';
-import { RESPONSE_ERROR_MESSAGES } from '@/constants';
-import type { ILicensePostResponse, ILicenseReadResponse } from '@/interfaces';
-import { License } from '@/license';
-
 import { createUserShell } from './shared/db/users';
 import type { SuperAgentTest } from './shared/types';
 import * as utils from './shared/utils/';
 
-const MOCK_SERVER_URL = 'https://server.com/v1';
+import { RESPONSE_ERROR_MESSAGES } from '@/constants';
+import type { ILicensePostResponse, ILicenseReadResponse } from '@/interfaces';
+import { License } from '@/license';
 
 let owner: User;
 let member: User;
@@ -26,9 +23,6 @@ beforeAll(async () => {
 
 	authOwnerAgent = testServer.authAgentFor(owner);
 	authMemberAgent = testServer.authAgentFor(member);
-
-	config.set('license.serverUrl', MOCK_SERVER_URL);
-	config.set('license.autoRenewEnabled', true);
 });
 
 afterEach(async () => {

--- a/packages/cli/test/integration/prometheus-metrics.test.ts
+++ b/packages/cli/test/integration/prometheus-metrics.test.ts
@@ -6,7 +6,6 @@ import { DateTime } from 'luxon';
 import { parse as semverParse } from 'semver';
 import request, { type Response } from 'supertest';
 
-import config from '@/config';
 import { N8N_VERSION } from '@/constants';
 import { EventService } from '@/events/event.service';
 import { PrometheusMetricsService } from '@/metrics/prometheus-metrics.service';
@@ -297,7 +296,7 @@ describe('PrometheusMetricsService', () => {
 		 * Arrange
 		 */
 		prometheusService.enableMetric('queue');
-		config.set('executions.mode', 'queue');
+		globalConfig.executions.mode = 'queue';
 		await prometheusService.init(server.app);
 
 		/**
@@ -324,7 +323,7 @@ describe('PrometheusMetricsService', () => {
 		 * Arrange
 		 */
 		prometheusService.enableMetric('queue');
-		config.set('executions.mode', 'queue');
+		globalConfig.executions.mode = 'queue';
 		await prometheusService.init(server.app);
 
 		/**


### PR DESCRIPTION
## Summary

This completes my year-long migration of the legacy `convict` schema to `@n8n/config` introduced at #9325. Now all backend config is injectable, mockable, type-safe, and documented.

- #10082
- #10087
- #10094
- #10103
- #10111
- #10140
- #10169
- #10173
- #10223
- #10268
- #10321
- #11316
- #11428
- #11440
- #11507
- #11761
- #14689
- #16318
- #17044
- #17728
- #18205
- #18324
- #18396
- #18557
- #18722

Let's keep this PR as plain as possible to minimize the risk of human error. We can refine it later:

- Add getters `isRegular` and `isScaling`
- Flip the `!== 'queue'` comparisons, leftover from when we had `own` mode
- Narrow down usage from `GlobalConfig` to `ExecutionsConfig`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1596

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
