### PR TITLE
feat: Add patch endpoint and reload mechanisms for sso provisioning configuration

### DIFF
--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -99,4 +99,4 @@ export { AddDataTableRowsDto } from './data-table/add-data-table-rows.dto';
 export { AddDataTableColumnDto } from './data-table/add-data-table-column.dto';
 export { MoveDataTableColumnDto } from './data-table/move-data-table-column.dto';
 
-export { ProvisioningConfigDto } from './provisioning/config.dto';
+export { ProvisioningConfigDto, ProvisioningConfigPatchDto } from './provisioning/config.dto';

--- a/packages/@n8n/api-types/src/dto/provisioning/config.dto.ts
+++ b/packages/@n8n/api-types/src/dto/provisioning/config.dto.ts
@@ -9,3 +9,15 @@ export class ProvisioningConfigDto extends Z.class({
 	scopesInstanceRoleClaimName: z.string(),
 	scopesProjectsRolesClaimName: z.string(),
 }) {}
+
+export class ProvisioningConfigPatchDto extends Z.class({
+	scopesProvisionInstanceRole: z.boolean().optional().nullable(),
+	scopesProvisionProjectRoles: z.boolean().optional().nullable(),
+	scopesProvisioningFrequency: z
+		.enum(['never', 'first_login', 'every_login'])
+		.optional()
+		.nullable(),
+	scopesName: z.string().optional().nullable(),
+	scopesInstanceRoleClaimName: z.string().optional().nullable(),
+	scopesProjectsRolesClaimName: z.string().optional().nullable(),
+}) {}

--- a/packages/@n8n/decorators/src/pubsub/pubsub-metadata.ts
+++ b/packages/@n8n/decorators/src/pubsub/pubsub-metadata.ts
@@ -21,7 +21,8 @@ export type PubSubEventName =
 	| 'reload-overwrite-credentials'
 	| 'response-to-get-worker-status'
 	| 'restart-event-bus'
-	| 'relay-execution-lifecycle-event';
+	| 'relay-execution-lifecycle-event'
+	| 'reload-sso-provisioning-configuration';
 
 export type PubSubEventFilter =
 	| {

--- a/packages/cli/src/modules/provisioning.ee/__tests__/provisioning.controller.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/provisioning.controller.ee.test.ts
@@ -49,4 +49,37 @@ describe('ProvisioningController', () => {
 			expect(config).toEqual(configResponse);
 		});
 	});
+
+	describe('patchConfig', () => {
+		const req = mock<AuthenticatedRequest>();
+		const res = mock<Response>({
+			json: jest.fn().mockReturnThis(),
+			status: jest.fn().mockReturnThis(),
+		});
+
+		it('should return 403 if provisioning is not licensed', async () => {
+			licenseState.isProvisioningLicensed.mockReturnValue(false);
+			await controller.patchConfig(req, res);
+
+			expect(res.status).toHaveBeenCalledWith(403);
+		});
+
+		it('should patch the provisioning config', async () => {
+			const configResponse: ProvisioningConfigDto = {
+				scopesProvisionInstanceRole: false,
+				scopesProvisionProjectRoles: false,
+				scopesProvisioningFrequency: 'never',
+				scopesName: 'n8n_test_scope',
+				scopesInstanceRoleClaimName: 'n8n_test_instance_role',
+				scopesProjectsRolesClaimName: 'n8n_test_projects_roles',
+			};
+
+			licenseState.isProvisioningLicensed.mockReturnValue(true);
+			provisioningService.patchConfig.mockResolvedValue(configResponse);
+
+			const config = await controller.patchConfig(req, res);
+
+			expect(config).toEqual(configResponse);
+		});
+	});
 });

--- a/packages/cli/src/modules/provisioning.ee/__tests__/provisioning.service.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/provisioning.service.ee.test.ts
@@ -140,26 +140,6 @@ describe('ProvisioningService', () => {
 		});
 	});
 
-	describe('applyPatchField', () => {
-		it('should apply the patch field to the provisioning config', () => {
-			const config = provisioningService.applyPatchField(
-				{ ...provisioningConfigDto },
-				'scopesProvisionInstanceRole',
-				false,
-			);
-			expect(config).toEqual({ ...provisioningConfigDto, scopesProvisionInstanceRole: false });
-		});
-
-		it('should remove the field if the value is null', () => {
-			const config = provisioningService.applyPatchField(
-				{ ...provisioningConfigDto },
-				'scopesProvisionInstanceRole',
-				null,
-			);
-			expect(config).toEqual({ ...provisioningConfigDto, scopesProvisionInstanceRole: undefined });
-		});
-	});
-
 	describe('handleReloadSsoProvisioningConfiguration', () => {
 		it('should reload the provisioning config', async () => {
 			const originStateLoadConfig = provisioningService.loadConfig;

--- a/packages/cli/src/modules/provisioning.ee/__tests__/provisioning.service.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/provisioning.service.ee.test.ts
@@ -6,7 +6,7 @@ import { type SettingsRepository } from '@n8n/db';
 import { type GlobalConfig } from '@n8n/config';
 import { PROVISIONING_PREFERENCES_DB_KEY } from '../constants';
 import { type ProvisioningConfigDto } from '@n8n/api-types';
-import { Publisher } from '@/scaling/pubsub/publisher.service';
+import { type Publisher } from '@/scaling/pubsub/publisher.service';
 
 const globalConfig = mock<GlobalConfig>();
 const settingsRepository = mock<SettingsRepository>();

--- a/packages/cli/src/modules/provisioning.ee/provisioning.controller.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/provisioning.controller.ee.ts
@@ -1,5 +1,5 @@
 import { AuthenticatedRequest } from '@n8n/db';
-import { Get, GlobalScope, RestController } from '@n8n/decorators';
+import { Get, GlobalScope, Patch, RestController } from '@n8n/decorators';
 import { LicenseState } from '@n8n/backend-common';
 import { ProvisioningService } from './provisioning.service.ee';
 import { Response } from 'express';
@@ -19,5 +19,15 @@ export class ProvisioningController {
 		}
 
 		return await this.provisioningService.getConfig();
+	}
+
+	@Patch('/config')
+	@GlobalScope('provisioning:manage')
+	async patchConfig(req: AuthenticatedRequest, res: Response) {
+		if (!this.licenseState.isProvisioningLicensed()) {
+			return res.status(403).json({ message: 'Provisioning is not licensed' });
+		}
+
+		return await this.provisioningService.patchConfig(req.body);
 	}
 }

--- a/packages/cli/src/modules/provisioning.ee/provisioning.service.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/provisioning.service.ee.ts
@@ -1,4 +1,4 @@
-import { ProvisioningConfigDto } from '@n8n/api-types';
+import { ProvisioningConfigDto, ProvisioningConfigPatchDto } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import { SettingsRepository } from '@n8n/db';
@@ -6,9 +6,8 @@ import { Service } from '@n8n/di';
 import { jsonParse } from 'n8n-workflow';
 
 import { PROVISIONING_PREFERENCES_DB_KEY } from './constants';
-import { ProvisioningConfigPatchDto } from '@n8n/api-types/src/dto/provisioning/config.dto';
 import { OnPubSubEvent } from '@n8n/decorators';
-import { Publisher } from '@/scaling/pubsub/publisher.service';
+import { type Publisher } from '@/scaling/pubsub/publisher.service';
 
 @Service()
 export class ProvisioningService {
@@ -63,7 +62,7 @@ export class ProvisioningService {
 
 		await this.publisher.publishCommand({ command: 'reload-sso-provisioning-configuration' });
 		this.provisioningConfig = await this.loadConfig();
-		return this.getConfig();
+		return await this.getConfig();
 	}
 
 	applyPatchField(

--- a/packages/cli/src/scaling/pubsub/pubsub.event-map.ts
+++ b/packages/cli/src/scaling/pubsub/pubsub.event-map.ts
@@ -21,6 +21,9 @@ export type PubSubCommandMap = {
 	'reload-oidc-config': never;
 	'reload-saml-config': never;
 
+	// # sso provisioning
+	'reload-sso-provisioning-configuration': never;
+
 	// #endregion
 
 	// #region Community packages

--- a/packages/cli/src/scaling/pubsub/pubsub.types.ts
+++ b/packages/cli/src/scaling/pubsub/pubsub.types.ts
@@ -57,6 +57,8 @@ export namespace PubSub {
 		export type DisplayWorkflowActivationError = ToCommand<'display-workflow-activation-error'>;
 		export type RelayExecutionLifecycleEvent = ToCommand<'relay-execution-lifecycle-event'>;
 		export type ClearTestWebhooks = ToCommand<'clear-test-webhooks'>;
+		export type ReloadSsoProvisioningConfiguration =
+			ToCommand<'reload-sso-provisioning-configuration'>;
 	}
 
 	/** Command sent via the `n8n.commands` pubsub channel. */
@@ -78,7 +80,8 @@ export namespace PubSub {
 		| Commands.ClearTestWebhooks
 		| Commands.ReloadOIDCConfiguration
 		| Commands.ReloadSamlConfiguration
-		| Commands.ReloadCredentialsOverwrites;
+		| Commands.ReloadCredentialsOverwrites
+		| Commands.ReloadSsoProvisioningConfiguration;
 
 	// ----------------------------------
 	//         worker responses


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR adds a new patch endpoint for sso provisioning configuration. The endpoint allows you to override values that are inferred from ENV vars, but also nullify those overrides if desired.

## Related Linear tickets, Github issues, and Community forum posts

PAY-3952

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
