### PR TITLE
feat(AI Agent Node): Support reading only `maxTokensFromMemory` (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/description.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/description.ts
@@ -12,11 +12,25 @@ const enableStreaminOption: INodeProperties = {
 	description: 'Whether this agent will stream the response in real-time as it generates text',
 };
 
+const maxTokensFromMemoryOption: INodeProperties = {
+	displayName: 'Max Tokens To Read From Memory',
+	name: 'maxTokensFromMemory',
+	type: 'hidden',
+	default: 0,
+	description:
+		'The maximum number of tokens to read from the chat memory history. Set to 0 to read all history.',
+};
+
 export const toolsAgentProperties: INodeProperties = {
 	displayName: 'Options',
 	name: 'options',
 	type: 'collection',
 	default: {},
 	placeholder: 'Add Option',
-	options: [...commonOptions, enableStreaminOption, getBatchingOptionFields(undefined, 1)],
+	options: [
+		...commonOptions,
+		enableStreaminOption,
+		getBatchingOptionFields(undefined, 1),
+		maxTokensFromMemoryOption,
+	],
 };

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/execute.ts
@@ -1,15 +1,11 @@
 import type { StreamEvent } from '@langchain/core/dist/tracers/event_stream';
 import type { IterableReadableStream } from '@langchain/core/dist/utils/stream';
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
-import type { AIMessageChunk, MessageContentText } from '@langchain/core/messages';
-import { AIMessage } from '@langchain/core/messages';
+import type { AIMessageChunk, BaseMessage, MessageContentText } from '@langchain/core/messages';
+import { AIMessage, trimMessages } from '@langchain/core/messages';
+import type { ToolCall } from '@langchain/core/messages/tool';
 import type { ChatPromptTemplate } from '@langchain/core/prompts';
 import { RunnableSequence } from '@langchain/core/runnables';
-import { getPromptInputByType } from '@utils/helpers';
-import {
-	getOptionalOutputParser,
-	type N8nOutputParser,
-} from '@utils/output_parsers/N8nOutputParser';
 import { type AgentRunnableSequence, createToolCallingAgent } from 'langchain/agents';
 import type { BaseChatMemory } from 'langchain/memory';
 import type { DynamicStructuredTool, Tool } from 'langchain/tools';
@@ -32,6 +28,12 @@ import type {
 } from 'n8n-workflow';
 import assert from 'node:assert';
 
+import { getPromptInputByType } from '@utils/helpers';
+import {
+	getOptionalOutputParser,
+	type N8nOutputParser,
+} from '@utils/output_parsers/N8nOutputParser';
+
 import {
 	fixEmptyContentMessage,
 	getAgentStepsParser,
@@ -42,7 +44,6 @@ import {
 	preparePrompt,
 } from '../common';
 import { SYSTEM_MESSAGE } from '../prompt';
-import type { ToolCall } from '@langchain/core/messages/tool';
 
 type ToolCallRequest = {
 	tool: string;
@@ -405,6 +406,7 @@ export async function toolsAgentExecute(
 				returnIntermediateSteps?: boolean;
 				passthroughBinaryImages?: boolean;
 				enableStreaming?: boolean;
+				maxTokensFromMemory?: number;
 			};
 
 			if (options.enableStreaming === undefined) {
@@ -448,11 +450,10 @@ export async function toolsAgentExecute(
 				isStreamingAvailable &&
 				this.getNode().typeVersion >= 2.1
 			) {
-				let chatHistory = undefined;
+				let chatHistory: BaseMessage[] | undefined = undefined;
 				if (memory) {
 					// Load memory variables to respect context window length
-					const memoryVariables = await memory.loadMemoryVariables({});
-					chatHistory = memoryVariables['chat_history'];
+					chatHistory = await loadChatHistory(memory, model, options.maxTokensFromMemory);
 				}
 				const eventStream = executor.streamEvents(
 					{
@@ -487,11 +488,10 @@ export async function toolsAgentExecute(
 				return result;
 			} else {
 				// Handle regular execution
-				let chatHistory = undefined;
+				let chatHistory: BaseMessage[] | undefined = undefined;
 				if (memory) {
 					// Load memory variables to respect context window length
-					const memoryVariables = await memory.loadMemoryVariables({});
-					chatHistory = memoryVariables['chat_history'];
+					chatHistory = await loadChatHistory(memory, model, options.maxTokensFromMemory);
 				}
 				const modelResponse = await executor.invoke({
 					...invokeParams,
@@ -602,4 +602,25 @@ export async function toolsAgentExecute(
 
 	// Otherwise return execution data
 	return [returnData];
+}
+async function loadChatHistory(
+	memory: BaseChatMemory,
+	model: BaseChatModel,
+	maxTokensFromMemory?: number,
+): Promise<BaseMessage[]> {
+	const memoryVariables = await memory.loadMemoryVariables({});
+	let chatHistory = memoryVariables['chat_history'] as BaseMessage[];
+
+	if (maxTokensFromMemory) {
+		chatHistory = await trimMessages(chatHistory, {
+			strategy: 'last',
+			maxTokens: maxTokensFromMemory,
+			tokenCounter: model,
+			includeSystem: true,
+			startOn: 'human',
+			allowPartial: true,
+		});
+	}
+
+	return chatHistory;
 }

--- a/packages/frontend/editor-ui/src/components/CollectionParameter.vue
+++ b/packages/frontend/editor-ui/src/components/CollectionParameter.vue
@@ -19,7 +19,6 @@ import { useI18n } from '@n8n/i18n';
 import { storeToRefs } from 'pinia';
 
 import { N8nButton, N8nOption, N8nSelect, N8nText } from '@n8n/design-system';
-import { pa } from 'element-plus/es/locale/index.mjs';
 const selectedOption = ref<string | undefined>(undefined);
 export interface Props {
 	hideDelete?: boolean;

--- a/packages/frontend/editor-ui/src/components/CollectionParameter.vue
+++ b/packages/frontend/editor-ui/src/components/CollectionParameter.vue
@@ -19,6 +19,7 @@ import { useI18n } from '@n8n/i18n';
 import { storeToRefs } from 'pinia';
 
 import { N8nButton, N8nOption, N8nSelect, N8nText } from '@n8n/design-system';
+import { pa } from 'element-plus/es/locale/index.mjs';
 const selectedOption = ref<string | undefined>(undefined);
 export interface Props {
 	hideDelete?: boolean;
@@ -65,6 +66,9 @@ function getParameterOptionLabel(
 }
 
 function displayNodeParameter(parameter: INodeProperties) {
+	if (parameter.type === 'hidden') {
+		return false;
+	}
 	if (parameter.displayOptions === undefined) {
 		// If it is not defined no need to do a proper check
 		return true;


### PR DESCRIPTION
## Summary

Add support for `maxTokensFromMemory` option for reading only max desired amount of tokens from memory to stay within model limits, even if the connected memory contains large number or large messages beyond what the model is capable of supporting.

For now intended for internal use, and as such hidden. Whether or not this becomes an actual supported feature is to be decided.

Also made us hide `type: 'hidden'` options on 'collections', we seemed to lack that. DisplayOptions couldn't really be used here. With this, one can define this option on an agent manually and it works, despite not appearing on the list.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-27/context-window-length

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
