### PR TITLE
fix(editor): Fix tool params schema for object and array fields

### DIFF
--- a/packages/frontend/editor-ui/src/components/ResourceMapper/MappingFields.vue
+++ b/packages/frontend/editor-ui/src/components/ResourceMapper/MappingFields.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import type { IUpdateInformation } from '@/Interface';
 import type {
-	FieldType,
 	INodeIssues,
 	INodeParameters,
 	INodeProperties,
@@ -51,7 +50,6 @@ const props = withDefaults(defineProps<Props>(), {
 	isReadOnly: false,
 	isDataStale: false,
 });
-const FORCE_TEXT_INPUT_FOR_TYPES: FieldType[] = ['time', 'object', 'array'];
 
 const {
 	resourceMapperTypeOptions,
@@ -254,10 +252,15 @@ function getFieldIssues(field: INodeProperties): string[] {
 }
 
 function getParamType(field: ResourceMapperField): NodePropertyTypes {
-	if (field.type && !FORCE_TEXT_INPUT_FOR_TYPES.includes(field.type)) {
-		return field.type as NodePropertyTypes;
+	switch (field.type) {
+		case 'object':
+		case 'array':
+			return 'json';
+		case 'time':
+			return 'string';
+		default:
+			return (field.type as NodePropertyTypes) ?? 'string';
 	}
-	return 'string';
 }
 
 function getParsedFieldName(fullName: string): string {


### PR DESCRIPTION
## Summary

The object and array were incorrectly mapped to string and that type was also used when building the schema for the tool. This was causing the model to invoke the tool with incorrect params.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4286/object-parameters-are-not-working-in-the-workflow-tools


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
