### PR TITLE
fix(OpenAI Node): Remove `local shell`, update `simplify output` logic

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/test/v2/actions/text/responses.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/test/v2/actions/text/responses.test.ts
@@ -1057,45 +1057,6 @@ describe('OpenAI Responses Helper Functions', () => {
 			});
 		});
 
-		it('should handle built-in tools - local shell', async () => {
-			const executeFunctions = createExecuteFunctionsMock({});
-			const options = {
-				model: 'gpt-4',
-				messages: [
-					{
-						role: 'user',
-						type: 'text',
-						content: 'Hello',
-					},
-				],
-				options: {},
-				builtInTools: {
-					localShell: true,
-				},
-				tools: undefined,
-			};
-
-			const result = await createRequest.call(executeFunctions, 0, options);
-
-			expect(result).toEqual({
-				model: 'gpt-4',
-				input: [
-					{
-						role: 'user',
-						content: [{ type: 'input_text', text: 'Hello' }],
-					},
-				],
-				parallel_tool_calls: true,
-				store: true,
-				tools: [
-					{
-						type: 'local_shell',
-					},
-				],
-				background: false,
-			});
-		});
-
 		it('should handle built-in tools - file search', async () => {
 			const executeFunctions = createExecuteFunctionsMock({});
 			const options = {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v2/actions/text/helpers/responses.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v2/actions/text/helpers/responses.ts
@@ -274,12 +274,6 @@ export async function createRequest(
 			});
 		}
 
-		if (builtInTools.localShell) {
-			newTools.push({
-				type: 'local_shell',
-			});
-		}
-
 		if (builtInTools.fileSearch) {
 			const vectorStoreIds = get(builtInTools.fileSearch, 'vectorStoreIds', '[]') as string;
 			const filters = get(builtInTools.fileSearch, 'filters', '{}') as string;

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v2/actions/text/response.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v2/actions/text/response.operation.ts
@@ -243,13 +243,6 @@ const properties: INodeProperties[] = [
 				],
 			},
 			{
-				displayName: 'Local Shell',
-				name: 'localShell',
-				type: 'boolean',
-				default: true,
-				description: 'Whether to allow the model to execute shell commands in a local environment',
-			},
-			{
 				displayName: 'Code Interpreter',
 				name: 'codeInterpreter',
 				type: 'boolean',
@@ -787,8 +780,11 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 	const returnData: INodeExecutionData[] = [];
 
 	if (simplify) {
+		const messages = response.output.filter((item) => item.type === 'message');
 		returnData.push({
-			json: response.output as unknown as IDataObject,
+			json: {
+				output: messages as unknown as IDataObject,
+			},
 			pairedItem: { item: i },
 		});
 	} else {


### PR DESCRIPTION
## Summary

This PR makes some changes requested [here](https://linear.app/n8n/issue/NODE-3699/openai-node-overhaul-leverage-openai-responses-api#comment-4c7fb1ff):
 - removes `local shell`, because there aren't many use cases in n8n ecosystem
 - changes simplify output behavior

## Related Linear tickets, Github issues, and Community forum posts

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
