### PR TITLE
feat(core): Support stopping AI message generation on chat hub (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/chat-hub.ts
+++ b/packages/@n8n/api-types/src/chat-hub.ts
@@ -62,8 +62,6 @@ export class ChatHubSendMessageRequest extends Z.class({
 }) {}
 
 export class ChatHubRegenerateMessageRequest extends Z.class({
-	retryId: z.string().uuid(),
-	sessionId: z.string().uuid(),
 	replyId: z.string().uuid(),
 	model: chatHubConversationModelSchema,
 	credentials: z.record(
@@ -75,10 +73,8 @@ export class ChatHubRegenerateMessageRequest extends Z.class({
 }) {}
 
 export class ChatHubEditMessageRequest extends Z.class({
-	editId: z.string().uuid(),
 	message: z.string(),
 	messageId: z.string().uuid(),
-	sessionId: z.string().uuid(),
 	replyId: z.string().uuid(),
 	model: chatHubConversationModelSchema,
 	credentials: z.record(

--- a/packages/cli/src/modules/chat-hub/chat-hub.controller.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.controller.ts
@@ -6,10 +6,12 @@ import {
 	ChatHubEditMessageRequest,
 	ChatHubRegenerateMessageRequest,
 	ChatHubChangeConversationTitleRequest,
+	ChatSessionId,
+	ChatMessageId,
 } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import { AuthenticatedRequest } from '@n8n/db';
-import { RestController, Post, Body, GlobalScope, Get, Delete } from '@n8n/decorators';
+import { RestController, Post, Body, GlobalScope, Get, Delete, Param } from '@n8n/decorators';
 import type { Response } from 'express';
 import { strict as assert } from 'node:assert';
 
@@ -51,13 +53,14 @@ export class ChatHubController {
 		return await this.chatService.getConversations(req.user.id);
 	}
 
-	@Get('/conversations/:id')
+	@Get('/conversations/:sessionId')
 	@GlobalScope('chatHub:message')
 	async getConversationMessages(
-		req: AuthenticatedRequest<{ id: string }>,
+		req: AuthenticatedRequest,
 		_res: Response,
+		@Param('sessionId') sessionId: ChatSessionId,
 	): Promise<ChatHubConversationResponse> {
-		return await this.chatService.getConversation(req.user.id, req.params.id);
+		return await this.chatService.getConversation(req.user.id, sessionId);
 	}
 
 	@GlobalScope('chatHub:message')
@@ -102,10 +105,12 @@ export class ChatHubController {
 	}
 
 	@GlobalScope('chatHub:message')
-	@Post('/conversations/edit')
+	@Post('/conversations/:sessionId/messages/:messageId/edit')
 	async editMessage(
 		req: AuthenticatedRequest,
 		res: Response,
+		@Param('sessionId') sessionId: ChatSessionId,
+		@Param('messageId') editId: ChatMessageId,
 		@Body payload: ChatHubEditMessageRequest,
 	) {
 		res.writeHead(200, JSONL_STREAM_HEADERS);
@@ -116,6 +121,8 @@ export class ChatHubController {
 		try {
 			await this.chatService.editHumanMessage(res, req.user, {
 				...payload,
+				sessionId,
+				editId,
 				userId: req.user.id,
 			});
 		} catch (executionError: unknown) {
@@ -144,10 +151,12 @@ export class ChatHubController {
 	}
 
 	@GlobalScope('chatHub:message')
-	@Post('/conversations/regenerate')
+	@Post('/conversations/:sessionId/messages/:messageId/regenerate')
 	async regenerateMessage(
 		req: AuthenticatedRequest,
 		res: Response,
+		@Param('sessionId') sessionId: ChatSessionId,
+		@Param('messageId') retryId: ChatMessageId,
 		@Body payload: ChatHubRegenerateMessageRequest,
 	) {
 		res.writeHead(200, JSONL_STREAM_HEADERS);
@@ -158,6 +167,8 @@ export class ChatHubController {
 		try {
 			await this.chatService.regenerateAIMessage(res, req.user, {
 				...payload,
+				sessionId,
+				retryId,
 				userId: req.user.id,
 			});
 		} catch (executionError: unknown) {
@@ -185,24 +196,26 @@ export class ChatHubController {
 		}
 	}
 
-	@Post('/conversations/:id/rename')
+	@Post('/conversations/:sessionId/rename')
 	@GlobalScope('chatHub:message')
 	async updateConversationTitle(
-		req: AuthenticatedRequest<{ id: string }>,
+		req: AuthenticatedRequest,
 		_res: Response,
+		@Param('sessionId') sessionId: ChatSessionId,
 		@Body payload: ChatHubChangeConversationTitleRequest,
 	): Promise<ChatHubConversationResponse> {
-		await this.chatService.updateSessionTitle(req.user.id, req.params.id, payload.title);
+		await this.chatService.updateSessionTitle(req.user.id, sessionId, payload.title);
 
-		return await this.chatService.getConversation(req.user.id, req.params.id);
+		return await this.chatService.getConversation(req.user.id, sessionId);
 	}
 
-	@Delete('/conversations/:id')
+	@Delete('/conversations/:sessionId')
 	@GlobalScope('chatHub:message')
 	async deleteConversation(
-		req: AuthenticatedRequest<{ id: string }>,
+		req: AuthenticatedRequest,
 		_res: Response,
+		@Param('sessionId') sessionId: ChatSessionId,
 	): Promise<void> {
-		await this.chatService.deleteSession(req.user.id, req.params.id);
+		await this.chatService.deleteSession(req.user.id, sessionId);
 	}
 }

--- a/packages/cli/src/modules/chat-hub/chat-hub.controller.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.controller.ts
@@ -196,6 +196,19 @@ export class ChatHubController {
 		}
 	}
 
+	@GlobalScope('chatHub:message')
+	@Post('/conversations/:sessionId/messages/:messageId/stop')
+	async stopMessage(
+		req: AuthenticatedRequest,
+		res: Response,
+		@Param('sessionId') sessionId: ChatSessionId,
+		@Param('messageId') messageId: ChatMessageId,
+	) {
+		this.logger.debug(`Chat stop request received: ${JSON.stringify({ sessionId, messageId })}`);
+
+		await this.chatService.stopAIMessage(req.user, sessionId, messageId);
+	}
+
 	@Post('/conversations/:sessionId/rename')
 	@GlobalScope('chatHub:message')
 	async updateConversationTitle(

--- a/packages/cli/src/modules/chat-hub/chat-hub.controller.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.controller.ts
@@ -198,7 +198,7 @@ export class ChatHubController {
 
 	@GlobalScope('chatHub:message')
 	@Post('/conversations/:sessionId/messages/:messageId/stop')
-	async stopMessage(
+	async stopGeneration(
 		req: AuthenticatedRequest,
 		res: Response,
 		@Param('sessionId') sessionId: ChatSessionId,
@@ -206,7 +206,8 @@ export class ChatHubController {
 	) {
 		this.logger.debug(`Chat stop request received: ${JSON.stringify({ sessionId, messageId })}`);
 
-		await this.chatService.stopAIMessage(req.user, sessionId, messageId);
+		await this.chatService.stopGeneration(req.user, sessionId, messageId);
+		res.status(204).send();
 	}
 
 	@Post('/conversations/:sessionId/rename')
@@ -226,9 +227,11 @@ export class ChatHubController {
 	@GlobalScope('chatHub:message')
 	async deleteConversation(
 		req: AuthenticatedRequest,
-		_res: Response,
+		res: Response,
 		@Param('sessionId') sessionId: ChatSessionId,
 	): Promise<void> {
 		await this.chatService.deleteSession(req.user.id, sessionId);
+
+		res.status(204).send();
 	}
 }

--- a/packages/cli/src/modules/chat-hub/chat-message.repository.ts
+++ b/packages/cli/src/modules/chat-hub/chat-message.repository.ts
@@ -26,7 +26,7 @@ export class ChatHubMessageRepository extends Repository<ChatHubMessage> {
 
 	async updateChatMessage(
 		id: ChatMessageId,
-		fields: { status: ChatHubMessageStatus },
+		fields: { status: ChatHubMessageStatus; content?: string },
 		trx?: EntityManager,
 	) {
 		return await withTransaction(this.manager, trx, async (em) => {

--- a/packages/cli/src/modules/chat-hub/chat-message.repository.ts
+++ b/packages/cli/src/modules/chat-hub/chat-message.repository.ts
@@ -47,9 +47,10 @@ export class ChatHubMessageRepository extends Repository<ChatHubMessage> {
 		});
 	}
 
-	async getOneById(id: ChatMessageId, sessionId: ChatSessionId) {
+	async getOneById(id: ChatMessageId, sessionId: ChatSessionId, relations: string[] = []) {
 		return await this.findOne({
 			where: { id, sessionId },
+			relations,
 		});
 	}
 }

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.vue
@@ -250,6 +250,10 @@ function onSubmit(message: string) {
 	}
 }
 
+async function onStop() {
+	await chatStore.stopStreamingMessage(sessionId.value);
+}
+
 function onSuggestionClick(s: Suggestion) {
 	inputRef.value?.setText(`${s.title} ${s.subtitle}`);
 }
@@ -388,8 +392,10 @@ function handleSwitchAlternative(messageId: string) {
 						ref="inputRef"
 						:class="$style.prompt"
 						:placeholder="inputPlaceholder"
+						:is-responding="chatStore.isResponding"
 						:disabled="chatStore.isResponding"
 						@submit="onSubmit"
+						@stop="onStop"
 					/>
 				</div>
 			</div>

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/chat.api.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/chat.api.ts
@@ -9,6 +9,7 @@ import type {
 	ChatHubRegenerateMessageRequest,
 	ChatHubEditMessageRequest,
 	ChatSessionId,
+	ChatMessageId,
 } from '@n8n/api-types';
 import type { StructuredChunk } from './chat.types';
 
@@ -43,6 +44,8 @@ export function sendMessageApi(
 
 export function editMessageApi(
 	ctx: IRestApiContext,
+	sessionId: ChatSessionId,
+	editId: ChatMessageId,
 	payload: ChatHubEditMessageRequest,
 	onMessageUpdated: (data: StructuredChunk) => void,
 	onDone: () => void,
@@ -50,7 +53,7 @@ export function editMessageApi(
 ) {
 	void streamRequest<StructuredChunk>(
 		ctx,
-		'/chat/conversations/edit',
+		`/chat/conversations/${sessionId}/messages/${editId}/edit`,
 		payload,
 		onMessageUpdated,
 		onDone,
@@ -61,6 +64,8 @@ export function editMessageApi(
 
 export function regenerateMessageApi(
 	ctx: IRestApiContext,
+	sessionId: ChatSessionId,
+	retryId: ChatMessageId,
 	payload: ChatHubRegenerateMessageRequest,
 	onMessageUpdated: (data: StructuredChunk) => void,
 	onDone: () => void,
@@ -68,7 +73,7 @@ export function regenerateMessageApi(
 ) {
 	void streamRequest<StructuredChunk>(
 		ctx,
-		'/chat/conversations/regenerate',
+		`/chat/conversations/${sessionId}/messages/${retryId}/regenerate`,
 		payload,
 		onMessageUpdated,
 		onDone,
@@ -86,10 +91,10 @@ export const fetchConversationsApi = async (
 
 export const updateConversationTitleApi = async (
 	context: IRestApiContext,
-	conversationId: ChatSessionId,
+	sessionId: ChatSessionId,
 	title: string,
 ): Promise<ChatHubConversationResponse> => {
-	const apiEndpoint = `/chat/conversations/${conversationId}/rename`;
+	const apiEndpoint = `/chat/conversations/${sessionId}/rename`;
 	return await makeRestApiRequest<ChatHubConversationResponse>(context, 'POST', apiEndpoint, {
 		title,
 	});
@@ -97,16 +102,16 @@ export const updateConversationTitleApi = async (
 
 export const deleteConversationApi = async (
 	context: IRestApiContext,
-	conversationId: ChatSessionId,
+	sessionId: ChatSessionId,
 ): Promise<void> => {
-	const apiEndpoint = `/chat/conversations/${conversationId}`;
+	const apiEndpoint = `/chat/conversations/${sessionId}`;
 	await makeRestApiRequest(context, 'DELETE', apiEndpoint);
 };
 
 export const fetchSingleConversationApi = async (
 	context: IRestApiContext,
-	conversationId: ChatSessionId,
+	sessionId: ChatSessionId,
 ): Promise<ChatHubConversationResponse> => {
-	const apiEndpoint = `/chat/conversations/${conversationId}`;
+	const apiEndpoint = `/chat/conversations/${sessionId}`;
 	return await makeRestApiRequest<ChatHubConversationResponse>(context, 'GET', apiEndpoint);
 };

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/chat.api.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/chat.api.ts
@@ -82,6 +82,15 @@ export function regenerateMessageApi(
 	);
 }
 
+export const stopMessageApi = async (
+	context: IRestApiContext,
+	sessionId: ChatSessionId,
+	messageId: ChatMessageId,
+): Promise<void> => {
+	const apiEndpoint = `/chat/conversations/${sessionId}/messages/${messageId}/stop`;
+	await makeRestApiRequest(context, 'POST', apiEndpoint);
+};
+
 export const fetchConversationsApi = async (
 	context: IRestApiContext,
 ): Promise<ChatHubConversationsResponse> => {

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/chat.api.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/chat.api.ts
@@ -82,7 +82,7 @@ export function regenerateMessageApi(
 	);
 }
 
-export const stopMessageApi = async (
+export const stopGenerationApi = async (
 	context: IRestApiContext,
 	sessionId: ChatSessionId,
 	messageId: ChatMessageId,

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/chat.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/chat.store.ts
@@ -422,12 +422,12 @@ export const useChatStore = defineStore(CHAT_STORE, () => {
 
 		editMessageApi(
 			rootStore.restApiContext,
+			sessionId,
+			editId,
 			{
 				model,
 				messageId,
-				sessionId,
 				replyId,
-				editId,
 				message,
 				credentials,
 			},
@@ -453,10 +453,10 @@ export const useChatStore = defineStore(CHAT_STORE, () => {
 
 		regenerateMessageApi(
 			rootStore.restApiContext,
+			sessionId,
+			retryId,
 			{
 				model,
-				sessionId,
-				retryId,
 				replyId,
 				credentials,
 			},

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/chat.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/chat.store.ts
@@ -11,6 +11,7 @@ import {
 	fetchSingleConversationApi as fetchMessagesApi,
 	updateConversationTitleApi,
 	deleteConversationApi,
+	stopMessageApi,
 } from './chat.api';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import type {
@@ -467,6 +468,12 @@ export const useChatStore = defineStore(CHAT_STORE, () => {
 		);
 	}
 
+	async function stopStreamingMessage(sessionId: ChatSessionId) {
+		if (streamingMessageId.value) {
+			await stopMessageApi(rootStore.restApiContext, sessionId, streamingMessageId.value);
+		}
+	}
+
 	async function renameSession(sessionId: ChatSessionId, title: string) {
 		const updated = await updateConversationTitleApi(rootStore.restApiContext, sessionId, title);
 
@@ -504,6 +511,7 @@ export const useChatStore = defineStore(CHAT_STORE, () => {
 		sendMessage,
 		editMessage,
 		regenerateMessage,
+		stopStreamingMessage,
 		fetchSessions,
 		fetchMessages,
 		renameSession,

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatPrompt.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatPrompt.vue
@@ -7,10 +7,12 @@ import { ref, useTemplateRef, watch } from 'vue';
 const { disabled } = defineProps<{
 	placeholder: string;
 	disabled: boolean;
+	isResponding: boolean;
 }>();
 
 const emit = defineEmits<{
 	submit: [string];
+	stop: [];
 }>();
 
 const inputRef = useTemplateRef('inputRef');
@@ -28,6 +30,10 @@ function onAttach() {}
 
 function onMic() {
 	speechInput.isListening.value ? speechInput.stop() : speechInput.start();
+}
+
+function onStop() {
+	emit('stop');
 }
 
 function handleSubmitForm() {
@@ -118,11 +124,20 @@ defineExpose({
 					@click="onMic"
 				/>
 				<N8nIconButton
+					v-if="!isResponding"
 					native-type="submit"
 					:disabled="disabled || !message.trim()"
 					title="Send"
 					icon="arrow-up"
 					icon-size="large"
+				/>
+				<N8nIconButton
+					v-else
+					native-type="button"
+					title="Stop generating"
+					icon="square"
+					icon-size="large"
+					@click="onStop"
 				/>
 			</div>
 		</div>


### PR DESCRIPTION
## Summary

This PR adds endpoint for stopping AI message generation by `messageId` + `sessionId` on the backend.  The execution is cancelled and stops immediately, and the code handling the execution marks it as cancelled.

To support this we now save AI messages in `"running"` state (renamed from pending) as soon as they're created, with empty contents. This links the message to the execution, and this way we can find it with messageId + sessionId and stop it.

This solution lacks the capability to save the partial message - the partially generated response isn't available on the execution data. I'm considering some hacky way to observer the streamed messages that execution engine is sending to the FE on the backend, but I'll explore that in a followup.

On the UI I made the send button change to a stop button while streaming is in progress. On cancel the stream reports an error, so I made UI to not do that if there's no streaming message anymore - essentially ignoring any errors that happen after we stop streaming.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-32/stopping-generation-of-messages

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
