### PR TITLE
fix(ai-builder): Accept empty expressionValues in builder request

### DIFF
--- a/packages/@n8n/api-types/src/dto/ai/__tests__/ai-build-request.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/ai/__tests__/ai-build-request.dto.test.ts
@@ -1,0 +1,336 @@
+import { AiBuilderChatRequestDto } from '../ai-build-request.dto';
+
+describe('AiBuilderChatRequestDto', () => {
+	const validBasePayload = {
+		payload: {
+			role: 'user' as const,
+			type: 'message' as const,
+			text: 'Build me a workflow',
+			workflowContext: {
+				currentWorkflow: {
+					nodes: [],
+					connections: {},
+				},
+			},
+			useDeprecatedCredentials: false,
+		},
+	};
+
+	describe('expressionValues validation', () => {
+		it('should validate when expressionValues is an empty object', () => {
+			const validRequest = {
+				...validBasePayload,
+				payload: {
+					...validBasePayload.payload,
+					workflowContext: {
+						...validBasePayload.payload.workflowContext,
+						expressionValues: {},
+					},
+				},
+			};
+
+			const result = AiBuilderChatRequestDto.safeParse(validRequest);
+
+			expect(result.success).toBe(true);
+		});
+
+		it('should validate when expressionValues contains valid expression data', () => {
+			const validRequest = {
+				...validBasePayload,
+				payload: {
+					...validBasePayload.payload,
+					workflowContext: {
+						...validBasePayload.payload.workflowContext,
+						expressionValues: {
+							node1: [
+								{
+									expression: '{{ $json.field }}',
+									resolvedValue: 'test value',
+									nodeType: 'n8n-nodes-base.set',
+								},
+							],
+							node2: [
+								{
+									expression: '{{ $now }}',
+									resolvedValue: '2024-01-01',
+								},
+							],
+						},
+					},
+				},
+			};
+
+			const result = AiBuilderChatRequestDto.safeParse(validRequest);
+
+			expect(result.success).toBe(true);
+		});
+
+		it('should fail when expressionValues has items but all expressions are empty', () => {
+			const invalidRequest = {
+				...validBasePayload,
+				payload: {
+					...validBasePayload.payload,
+					workflowContext: {
+						...validBasePayload.payload.workflowContext,
+						expressionValues: {
+							node1: [
+								{
+									expression: '',
+									resolvedValue: 'test value',
+								},
+							],
+						},
+					},
+				},
+			};
+
+			const result = AiBuilderChatRequestDto.safeParse(invalidRequest);
+
+			expect(result.success).toBe(false);
+		});
+
+		it('should validate when expressionValues is not provided (optional field)', () => {
+			const validRequest = {
+				...validBasePayload,
+			};
+
+			const result = AiBuilderChatRequestDto.safeParse(validRequest);
+
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe('currentWorkflow validation', () => {
+		it('should validate when currentWorkflow has both nodes and connections', () => {
+			const validRequest = {
+				...validBasePayload,
+			};
+
+			const result = AiBuilderChatRequestDto.safeParse(validRequest);
+
+			expect(result.success).toBe(true);
+		});
+
+		it('should validate when currentWorkflow has only nodes', () => {
+			const validRequest = {
+				...validBasePayload,
+				payload: {
+					...validBasePayload.payload,
+					workflowContext: {
+						currentWorkflow: {
+							nodes: [],
+						},
+					},
+				},
+			};
+
+			const result = AiBuilderChatRequestDto.safeParse(validRequest);
+
+			expect(result.success).toBe(true);
+		});
+
+		it('should validate when currentWorkflow has only connections', () => {
+			const validRequest = {
+				...validBasePayload,
+				payload: {
+					...validBasePayload.payload,
+					workflowContext: {
+						currentWorkflow: {
+							connections: {},
+						},
+					},
+				},
+			};
+
+			const result = AiBuilderChatRequestDto.safeParse(validRequest);
+
+			expect(result.success).toBe(true);
+		});
+
+		it('should fail when currentWorkflow has neither nodes nor connections', () => {
+			const invalidRequest = {
+				...validBasePayload,
+				payload: {
+					...validBasePayload.payload,
+					workflowContext: {
+						currentWorkflow: {},
+					},
+				},
+			};
+
+			const result = AiBuilderChatRequestDto.safeParse(invalidRequest);
+
+			expect(result.success).toBe(false);
+		});
+	});
+
+	describe('executionData validation', () => {
+		it('should validate when executionData has runData', () => {
+			const validRequest = {
+				...validBasePayload,
+				payload: {
+					...validBasePayload.payload,
+					workflowContext: {
+						...validBasePayload.payload.workflowContext,
+						executionData: {
+							runData: {},
+						},
+					},
+				},
+			};
+
+			const result = AiBuilderChatRequestDto.safeParse(validRequest);
+
+			expect(result.success).toBe(true);
+		});
+
+		it('should validate when executionData has error', () => {
+			const validRequest = {
+				...validBasePayload,
+				payload: {
+					...validBasePayload.payload,
+					workflowContext: {
+						...validBasePayload.payload.workflowContext,
+						executionData: {
+							error: new Error('test error'),
+						},
+					},
+				},
+			};
+
+			const result = AiBuilderChatRequestDto.safeParse(validRequest);
+
+			expect(result.success).toBe(true);
+		});
+
+		it('should fail when executionData has neither runData nor error', () => {
+			const invalidRequest = {
+				...validBasePayload,
+				payload: {
+					...validBasePayload.payload,
+					workflowContext: {
+						...validBasePayload.payload.workflowContext,
+						executionData: {},
+					},
+				},
+			};
+
+			const result = AiBuilderChatRequestDto.safeParse(invalidRequest);
+
+			expect(result.success).toBe(false);
+		});
+	});
+
+	describe('executionSchema validation', () => {
+		it('should validate when executionSchema has valid items', () => {
+			const validRequest = {
+				...validBasePayload,
+				payload: {
+					...validBasePayload.payload,
+					workflowContext: {
+						...validBasePayload.payload.workflowContext,
+						executionSchema: [
+							{
+								nodeName: 'node1',
+								schema: {},
+							},
+						],
+					},
+				},
+			};
+
+			const result = AiBuilderChatRequestDto.safeParse(validRequest);
+
+			expect(result.success).toBe(true);
+		});
+
+		it('should fail when executionSchema has items without nodeName or schema', () => {
+			const invalidRequest = {
+				...validBasePayload,
+				payload: {
+					...validBasePayload.payload,
+					workflowContext: {
+						...validBasePayload.payload.workflowContext,
+						executionSchema: [
+							{
+								nodeName: '',
+								schema: {},
+							},
+						],
+					},
+				},
+			};
+
+			const result = AiBuilderChatRequestDto.safeParse(invalidRequest);
+
+			expect(result.success).toBe(false);
+		});
+	});
+
+	describe('basic payload validation', () => {
+		it('should validate a complete valid request', () => {
+			const result = AiBuilderChatRequestDto.safeParse(validBasePayload);
+
+			expect(result.success).toBe(true);
+		});
+
+		it('should fail when role is not "user"', () => {
+			const invalidRequest = {
+				...validBasePayload,
+				payload: {
+					...validBasePayload.payload,
+					role: 'assistant',
+				},
+			};
+
+			const result = AiBuilderChatRequestDto.safeParse(invalidRequest);
+
+			expect(result.success).toBe(false);
+		});
+
+		it('should fail when type is not "message"', () => {
+			const invalidRequest = {
+				...validBasePayload,
+				payload: {
+					...validBasePayload.payload,
+					type: 'system',
+				},
+			};
+
+			const result = AiBuilderChatRequestDto.safeParse(invalidRequest);
+
+			expect(result.success).toBe(false);
+		});
+
+		it('should fail when text is missing', () => {
+			const invalidRequest = {
+				...validBasePayload,
+				payload: {
+					role: 'user' as const,
+					type: 'message' as const,
+					workflowContext: validBasePayload.payload.workflowContext,
+				},
+			};
+
+			const result = AiBuilderChatRequestDto.safeParse(invalidRequest);
+
+			expect(result.success).toBe(false);
+		});
+
+		it('should validate when useDeprecatedCredentials is explicitly set', () => {
+			const requestWithFlag = {
+				payload: {
+					...validBasePayload.payload,
+					useDeprecatedCredentials: true,
+				},
+			};
+
+			const result = AiBuilderChatRequestDto.safeParse(requestWithFlag);
+
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.payload.useDeprecatedCredentials).toBe(true);
+			}
+		});
+	});
+});

--- a/packages/@n8n/api-types/src/dto/ai/ai-build-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/ai/ai-build-request.dto.ts
@@ -47,8 +47,9 @@ export class AiBuilderChatRequestDto extends Z.class({
 
 			expressionValues: z
 				.custom<Record<string, ExpressionValue[]>>((val: Record<string, ExpressionValue[]>) => {
+					const keys = Object.keys(val);
 					// Check if the array is empty or if all items have nodeName and schema properties
-					if (Object.keys(val).every((key) => val[key].every((v) => !v.expression))) {
+					if (keys.length > 0 && keys.every((key) => val[key].every((v) => !v.expression))) {
 						return false;
 					}
 


### PR DESCRIPTION
## Summary
This PR changes the schema validation of the builder request to accept empty objects for resolved expression values, which is happening if the workflow doesn't contain any expressions.
Also adds some tests for that dto.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-1590/bug-ai-builder-fails-when-workflow-have-no-expressions


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
