### PR TITLE
feat(core): Handle project variables sync on source control

### DIFF
--- a/packages/@n8n/db/src/entities/project.ts
+++ b/packages/@n8n/db/src/entities/project.ts
@@ -4,6 +4,7 @@ import { WithTimestampsAndStringId } from './abstract-entity';
 import type { ProjectRelation } from './project-relation';
 import type { SharedCredentials } from './shared-credentials';
 import type { SharedWorkflow } from './shared-workflow';
+import type { Variables } from './variables';
 
 @Entity()
 export class Project extends WithTimestampsAndStringId {
@@ -27,4 +28,7 @@ export class Project extends WithTimestampsAndStringId {
 
 	@OneToMany('SharedWorkflow', 'project')
 	sharedWorkflows: SharedWorkflow[];
+
+	@OneToMany('Variables', 'project')
+	variables: Variables[];
 }

--- a/packages/@n8n/db/src/entities/variables.ts
+++ b/packages/@n8n/db/src/entities/variables.ts
@@ -1,7 +1,7 @@
 import { Column, Entity, ManyToOne } from '@n8n/typeorm';
 
 import { WithStringId } from './abstract-entity';
-import { Project } from './project';
+import type { Project } from './project';
 
 @Entity()
 export class Variables extends WithStringId {

--- a/packages/@n8n/db/src/repositories/variables.repository.ts
+++ b/packages/@n8n/db/src/repositories/variables.repository.ts
@@ -1,5 +1,5 @@
 import { Service } from '@n8n/di';
-import { DataSource, Repository } from '@n8n/typeorm';
+import { DataSource, In, Repository } from '@n8n/typeorm';
 
 import { Variables } from '../entities';
 
@@ -7,5 +7,9 @@ import { Variables } from '../entities';
 export class VariablesRepository extends Repository<Variables> {
 	constructor(dataSource: DataSource) {
 		super(Variables, dataSource.manager);
+	}
+
+	async deleteByIds(ids: string[]): Promise<void> {
+		await this.delete({ id: In(ids) });
 	}
 }

--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control-export.service.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control-export.service.test.ts
@@ -340,7 +340,7 @@ describe('SourceControlExportService', () => {
 			variablesService.getAllCached.mockResolvedValue([mock()]);
 
 			// Act
-			const result = await service.exportVariablesToWorkFolder();
+			const result = await service.exportGlobalVariablesToWorkFolder();
 
 			// Assert
 			expect(result.count).toBe(1);
@@ -352,7 +352,7 @@ describe('SourceControlExportService', () => {
 			variablesService.getAllCached.mockResolvedValue([]);
 
 			// Act
-			const result = await service.exportVariablesToWorkFolder();
+			const result = await service.exportGlobalVariablesToWorkFolder();
 
 			// Assert
 			expect(result.count).toBe(0);

--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control-export.service.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control-export.service.test.ts
@@ -13,6 +13,7 @@ import type {
 	WorkflowRepository,
 	WorkflowTagMapping,
 	WorkflowTagMappingRepository,
+	Variables,
 } from '@n8n/db';
 import { GLOBAL_ADMIN_ROLE, In, PROJECT_OWNER_ROLE, User } from '@n8n/db';
 import { Container } from '@n8n/di';
@@ -418,6 +419,7 @@ describe('SourceControlExportService', () => {
 				icon: { type: 'icon', value: 'icon.png' },
 				description: 'Project 1',
 				type: 'team',
+				variables: [],
 			});
 			const project2 = mock<Project>({
 				id: 'project-id-2',
@@ -425,6 +427,7 @@ describe('SourceControlExportService', () => {
 				icon: null,
 				description: 'Team Project',
 				type: 'team',
+				variables: [mock<Variables>({ key: 'VAR1', value: 'value1' })],
 			});
 
 			const expectedProject1Json = JSON.stringify(
@@ -439,6 +442,7 @@ describe('SourceControlExportService', () => {
 						teamId: project1.id,
 						teamName: project1.name,
 					},
+					variableStubs: [],
 				},
 				null,
 				2,
@@ -455,6 +459,12 @@ describe('SourceControlExportService', () => {
 						teamId: project2.id,
 						teamName: project2.name,
 					},
+					variableStubs: [
+						{
+							key: 'VAR1',
+							value: '',
+						},
+					],
 				},
 				null,
 				2,
@@ -468,6 +478,7 @@ describe('SourceControlExportService', () => {
 			// Assert
 			expect(projectRepository.find).toHaveBeenCalledWith({
 				where: { id: In([project1.id, project2.id]), type: 'team' },
+				relations: ['variables'],
 			});
 			expect(fsWriteFile).toHaveBeenCalledWith(
 				'/mock/n8n/git/projects/project-id-1.json',

--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control.service.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control.service.test.ts
@@ -181,11 +181,11 @@ describe('SourceControlService', () => {
 			);
 			sourceControlExportService.exportTagsToWorkFolder.mockResolvedValueOnce(mockExportResult);
 			sourceControlExportService.exportFoldersToWorkFolder.mockResolvedValueOnce(mockExportResult);
-			sourceControlExportService.exportVariablesToWorkFolder.mockResolvedValueOnce(
+			sourceControlExportService.exportGlobalVariablesToWorkFolder.mockResolvedValueOnce(
 				mockExportResult,
 			);
 			sourceControlExportService.exportFoldersToWorkFolder.mockResolvedValueOnce(mockExportResult);
-			sourceControlExportService.exportVariablesToWorkFolder.mockResolvedValueOnce(
+			sourceControlExportService.exportGlobalVariablesToWorkFolder.mockResolvedValueOnce(
 				mockExportResult,
 			);
 
@@ -223,7 +223,7 @@ describe('SourceControlService', () => {
 			);
 			expect(sourceControlExportService.exportTagsToWorkFolder).toHaveBeenCalled();
 			expect(sourceControlExportService.exportFoldersToWorkFolder).toHaveBeenCalled();
-			expect(sourceControlExportService.exportVariablesToWorkFolder).toHaveBeenCalled();
+			expect(sourceControlExportService.exportGlobalVariablesToWorkFolder).toHaveBeenCalled();
 
 			// Deleted resources should be passed to rmFilesFromExportFolder
 			expect(sourceControlExportService.rmFilesFromExportFolder).toHaveBeenCalledWith(

--- a/packages/cli/src/environments.ee/source-control/source-control-export.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-export.service.ee.ts
@@ -20,6 +20,8 @@ import { UnexpectedError, type ICredentialDataDecryptedObject } from 'n8n-workfl
 import { rm as fsRm, writeFile as fsWriteFile } from 'node:fs/promises';
 import path from 'path';
 
+import { formatWorkflow } from '@/workflows/workflow.formatter';
+
 import {
 	SOURCE_CONTROL_CREDENTIAL_EXPORT_FOLDER,
 	SOURCE_CONTROL_GIT_FOLDER,
@@ -46,8 +48,6 @@ import { ExportableProject } from './types/exportable-project';
 import type { ExportableWorkflow } from './types/exportable-workflow';
 import type { RemoteResourceOwner } from './types/resource-owner';
 import type { SourceControlContext } from './types/source-control-context';
-
-import { formatWorkflow } from '@/workflows/workflow.formatter';
 
 @Service()
 export class SourceControlExportService {
@@ -198,10 +198,10 @@ export class SourceControlExportService {
 		}
 	}
 
-	async exportVariablesToWorkFolder(): Promise<ExportResult> {
+	async exportGlobalVariablesToWorkFolder(): Promise<ExportResult> {
 		try {
 			sourceControlFoldersExistCheck([this.gitFolder]);
-			const variables = await this.variablesService.getAllCached();
+			const variables = await this.variablesService.getAllCached({ globalOnly: true });
 			// do not export empty variables
 			if (variables.length === 0) {
 				return {
@@ -211,7 +211,12 @@ export class SourceControlExportService {
 				};
 			}
 			const fileName = getVariablesPath(this.gitFolder);
-			const sanitizedVariables = variables.map((e) => ({ ...e, value: '' }));
+			const sanitizedVariables = variables.map((e) => ({
+				id: e.id,
+				key: e.key,
+				type: e.type,
+				value: '',
+			}));
 			await fsWriteFile(fileName, JSON.stringify(sanitizedVariables, null, 2));
 			return {
 				count: sanitizedVariables.length,
@@ -487,6 +492,7 @@ export class SourceControlExportService {
 			const projectIds = candidates.map((e) => e.id);
 			const projects = await this.projectRepository.find({
 				where: { id: In(projectIds), type: 'team' },
+				relations: ['variables'],
 			});
 
 			await Promise.all(
@@ -504,6 +510,12 @@ export class SourceControlExportService {
 							teamId: project.id,
 							teamName: project.name,
 						},
+						variableStubs: project.variables.map((variable) => ({
+							id: variable.id,
+							key: variable.key,
+							type: variable.type,
+							value: '',
+						})),
 					};
 
 					this.logger.debug(`Writing project ${project.id} to ${fileName}`);

--- a/packages/cli/src/environments.ee/source-control/source-control-export.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-export.service.ee.ts
@@ -48,6 +48,7 @@ import { ExportableProject } from './types/exportable-project';
 import type { ExportableWorkflow } from './types/exportable-workflow';
 import type { RemoteResourceOwner } from './types/resource-owner';
 import type { SourceControlContext } from './types/source-control-context';
+import { ExportableVariable } from './types/exportable-variable';
 
 @Service()
 export class SourceControlExportService {
@@ -211,7 +212,7 @@ export class SourceControlExportService {
 				};
 			}
 			const fileName = getVariablesPath(this.gitFolder);
-			const sanitizedVariables = variables.map((e) => ({
+			const sanitizedVariables: ExportableVariable[] = variables.map((e) => ({
 				id: e.id,
 				key: e.key,
 				type: e.type,

--- a/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
@@ -39,7 +39,6 @@ import { TagService } from '@/services/tag.service';
 import { assertNever } from '@/utils';
 import { WorkflowService } from '@/workflows/workflow.service';
 
-import { VariablesService } from '../variables/variables.service.ee';
 import {
 	SOURCE_CONTROL_CREDENTIAL_EXPORT_FOLDER,
 	SOURCE_CONTROL_FOLDERS_EXPORT_FILE,
@@ -55,6 +54,7 @@ import {
 	getWorkflowExportPath,
 } from './source-control-helper.ee';
 import { SourceControlScopedService } from './source-control-scoped.service';
+import { VariablesService } from '../variables/variables.service.ee';
 import type {
 	ExportableCredential,
 	StatusExportableCredential,
@@ -62,6 +62,7 @@ import type {
 import type { ExportableFolder } from './types/exportable-folders';
 import type { ExportableProject, ExportableProjectWithFileName } from './types/exportable-project';
 import type { ExportableTags } from './types/exportable-tags';
+import { ExportableVariable } from './types/exportable-variable';
 import type {
 	RemoteResourceOwner,
 	StatusResourceOwner,
@@ -421,22 +422,25 @@ export class SourceControlImportService {
 		}) as StatusExportableCredential[];
 	}
 
-	async getRemoteVariablesFromFile(): Promise<Variables[]> {
+	async getRemoteVariablesFromFile(): Promise<ExportableVariable[]> {
 		const variablesFile = await glob(SOURCE_CONTROL_VARIABLES_EXPORT_FILE, {
 			cwd: this.gitFolder,
 			absolute: true,
 		});
 		if (variablesFile.length > 0) {
 			this.logger.debug(`Importing variables from file ${variablesFile[0]}`);
-			return jsonParse<Variables[]>(await fsReadFile(variablesFile[0], { encoding: 'utf8' }), {
-				fallbackValue: [],
-			});
+			return jsonParse<ExportableVariable[]>(
+				await fsReadFile(variablesFile[0], { encoding: 'utf8' }),
+				{
+					fallbackValue: [],
+				},
+			);
 		}
 		return [];
 	}
 
-	async getLocalVariablesFromDb(): Promise<Variables[]> {
-		return await this.variablesService.getAllCached();
+	async getLocalGlobalVariablesFromDb(): Promise<Variables[]> {
+		return await this.variablesService.getAllCached({ globalOnly: true });
 	}
 
 	async getRemoteFoldersAndMappingsFromFile(context: SourceControlContext): Promise<{
@@ -593,6 +597,7 @@ export class SourceControlImportService {
 
 		const localProjects = await this.projectRepository.find({
 			select: ['id', 'name', 'description', 'icon', 'type'],
+			relations: ['variables'],
 			where,
 		});
 
@@ -616,6 +621,12 @@ export class SourceControlImportService {
 				teamId: project.id,
 				teamName: project.name,
 			},
+			variableStubs: project.variables.map((variable) => ({
+				id: variable.id,
+				key: variable.key,
+				type: variable.type,
+				value: '',
+			})),
 		};
 	}
 
@@ -923,41 +934,33 @@ export class SourceControlImportService {
 		return mappedFolders;
 	}
 
-	async importVariablesFromWorkFolder(
-		candidate: SourceControlledFile,
+	async importVariables(
+		variables: ExportableVariable[],
 		valueOverrides?: {
 			[key: string]: string;
 		},
 	) {
 		const result: { imported: string[] } = { imported: [] };
-		let importedVariables;
-		try {
-			this.logger.debug(`Importing variables from file ${candidate.file}`);
-			importedVariables = jsonParse<Array<Partial<Variables>>>(
-				await fsReadFile(candidate.file, { encoding: 'utf8' }),
-				{ fallbackValue: [] },
-			);
-		} catch (e) {
-			this.logger.error(`Failed to import tags from file ${candidate.file}`, { error: e });
-			return;
-		}
 		const overriddenKeys = Object.keys(valueOverrides ?? {});
 
-		for (const variable of importedVariables) {
+		for (const variable of variables) {
 			if (!variable.key) {
 				continue;
-			}
-			// by default no value is stored remotely, so an empty string is returned
-			// it must be changed to undefined so as to not overwrite existing values!
-			if (variable.value === '') {
-				variable.value = undefined;
 			}
 			if (overriddenKeys.includes(variable.key) && valueOverrides) {
 				variable.value = valueOverrides[variable.key];
 				overriddenKeys.splice(overriddenKeys.indexOf(variable.key), 1);
 			}
 			try {
-				await this.variablesRepository.upsert({ ...variable }, ['id']);
+				// by default no value is stored remotely, so an empty string is returned
+				// it must be changed to undefined so as to not overwrite existing values!
+				const variableToUpsert = {
+					...variable,
+					value: variable.value === '' ? undefined : variable.value,
+					project: variable.projectId ? { id: variable.projectId } : null,
+				};
+
+				await this.variablesRepository.upsert(variableToUpsert, ['id']);
 			} catch (errorUpsert) {
 				if (isUniqueConstraintError(errorUpsert as Error)) {
 					this.logger.debug(`Variable ${variable.key} already exists, updating instead`);
@@ -988,6 +991,27 @@ export class SourceControlImportService {
 		await this.variablesService.updateCache();
 
 		return result;
+	}
+
+	async importVariablesFromWorkFolder(
+		candidate: SourceControlledFile,
+		valueOverrides?: {
+			[key: string]: string;
+		},
+	) {
+		let importedVariables;
+		try {
+			this.logger.debug(`Importing variables from file ${candidate.file}`);
+			importedVariables = jsonParse<ExportableVariable[]>(
+				await fsReadFile(candidate.file, { encoding: 'utf8' }),
+				{ fallbackValue: [] },
+			);
+		} catch (e) {
+			this.logger.error(`Failed to import tags from file ${candidate.file}`, { error: e });
+			return;
+		}
+
+		return await this.importVariables(importedVariables, valueOverrides);
 	}
 
 	/**
@@ -1028,6 +1052,10 @@ export class SourceControlImportService {
 						type: 'team',
 					},
 					['id'],
+				);
+
+				await this.importVariables(
+					project.variableStubs?.map((v) => ({ ...v, projectId: project.id })) ?? [],
 				);
 
 				this.logger.info(`Imported team project: ${project.name}`);

--- a/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
@@ -1064,7 +1064,7 @@ export class SourceControlImportService {
 				// Delete variables that existed before but are no longer present in the imported project
 				const deletedVariables = existingProjectVariables.filter(
 					(v) =>
-						v.project!.id === project.id && !project.variableStubs?.some((vs) => vs.key === v.key),
+						v.project!.id === project.id && !project.variableStubs?.some((vs) => vs.id === v.id),
 				);
 				await this.variablesService.deleteByIds(deletedVariables.map((v) => v.id));
 

--- a/packages/cli/src/environments.ee/source-control/source-control-status.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-status.service.ee.ts
@@ -1,6 +1,6 @@
 import type { SourceControlledFile } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
-import { FolderRepository, type TagEntity, TagRepository, type User, Variables } from '@n8n/db';
+import { FolderRepository, type TagEntity, TagRepository, type User } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { hasGlobalScope } from '@n8n/permissions';
 import { UserError } from 'n8n-workflow';
@@ -23,6 +23,7 @@ import { SourceControlPreferencesService } from './source-control-preferences.se
 import type { StatusExportableCredential } from './types/exportable-credential';
 import type { ExportableFolder } from './types/exportable-folders';
 import type { ExportableProjectWithFileName } from './types/exportable-project';
+import { ExportableVariable } from './types/exportable-variable';
 import { SourceControlContext } from './types/source-control-context';
 import type { SourceControlGetStatus } from './types/source-control-get-status';
 import type { SourceControlWorkflowVersionId } from './types/source-control-workflow-version-id';
@@ -378,7 +379,7 @@ export class SourceControlStatusService {
 		sourceControlledFiles: SourceControlledFile[],
 	) {
 		const varRemoteIds = await this.sourceControlImportService.getRemoteVariablesFromFile();
-		const varLocalIds = await this.sourceControlImportService.getLocalVariablesFromDb();
+		const varLocalIds = await this.sourceControlImportService.getLocalGlobalVariablesFromDb();
 
 		const varMissingInLocal = varRemoteIds.filter(
 			(remote) => varLocalIds.findIndex((local) => local.id === remote.id) === -1,
@@ -388,7 +389,7 @@ export class SourceControlStatusService {
 			(local) => varRemoteIds.findIndex((remote) => remote.id === local.id) === -1,
 		);
 
-		const varModifiedInEither: Variables[] = [];
+		const varModifiedInEither: ExportableVariable[] = [];
 		varLocalIds.forEach((local) => {
 			const mismatchingIds = varRemoteIds.find(
 				(remote) =>
@@ -806,6 +807,29 @@ export class SourceControlStatusService {
 		};
 	}
 
+	private areVariablesEqual(
+		localVariables: ExportableProjectWithFileName['variableStubs'],
+		remoteVariables: ExportableProjectWithFileName['variableStubs'],
+	): boolean {
+		if (Array.isArray(localVariables) !== Array.isArray(remoteVariables)) {
+			return false;
+		}
+
+		if (localVariables?.length !== remoteVariables?.length) {
+			return false;
+		}
+
+		const sortedLocalVars = [...(localVariables ?? [])].sort((a, b) => a.key.localeCompare(b.key));
+		const sortedRemoteVars = [...(remoteVariables ?? [])].sort((a, b) =>
+			a.key.localeCompare(b.key),
+		);
+
+		return sortedLocalVars.every((localVar, index) => {
+			const remoteVar = sortedRemoteVars[index];
+			return localVar.key === remoteVar.key && localVar.type === remoteVar.type;
+		});
+	}
+
 	private isProjectModified(
 		local: ExportableProjectWithFileName,
 		remote: ExportableProjectWithFileName,
@@ -819,7 +843,8 @@ export class SourceControlStatusService {
 			isIconModified ||
 			remote.type !== local.type ||
 			remote.name !== local.name ||
-			remote.description !== local.description
+			remote.description !== local.description ||
+			!this.areVariablesEqual(local.variableStubs, remote.variableStubs)
 		);
 	}
 

--- a/packages/cli/src/environments.ee/source-control/source-control-status.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-status.service.ee.ts
@@ -738,6 +738,9 @@ export class SourceControlStatusService {
 						? localProject.description
 						: remoteProjectWithSameId.description,
 					icon: options.preferLocalVersion ? localProject.icon : remoteProjectWithSameId.icon,
+					variableStubs: options.preferLocalVersion
+						? localProject.variableStubs
+						: remoteProjectWithSameId.variableStubs,
 				});
 			}
 		});

--- a/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
@@ -337,7 +337,7 @@ export class SourceControlService {
 		const variablesChanges = filterByType(filesToPush, 'variables')[0];
 		if (variablesChanges) {
 			filesToBePushed.add(variablesChanges.file);
-			await this.sourceControlExportService.exportVariablesToWorkFolder();
+			await this.sourceControlExportService.exportGlobalVariablesToWorkFolder();
 		}
 
 		await this.gitService.stage(filesToBePushed, filesToBeDeleted);

--- a/packages/cli/src/environments.ee/source-control/types/exportable-project.ts
+++ b/packages/cli/src/environments.ee/source-control/types/exportable-project.ts
@@ -1,3 +1,4 @@
+import type { ExportableVariable } from './exportable-variable';
 import type { TeamResourceOwner } from './resource-owner';
 
 export interface ExportableProject {
@@ -10,6 +11,7 @@ export interface ExportableProject {
 	 */
 	type: 'team';
 	owner: TeamResourceOwner;
+	variableStubs?: ExportableVariable[];
 }
 
 export type ExportableProjectWithFileName = ExportableProject & {

--- a/packages/cli/src/environments.ee/source-control/types/exportable-variable.ts
+++ b/packages/cli/src/environments.ee/source-control/types/exportable-variable.ts
@@ -1,0 +1,7 @@
+export interface ExportableVariable {
+	id: string;
+	key: string;
+	type: string;
+	value: string;
+	projectId?: string;
+}

--- a/packages/cli/src/environments.ee/variables/variables.service.ee.ts
+++ b/packages/cli/src/environments.ee/variables/variables.service.ee.ts
@@ -61,11 +61,19 @@ export class VariablesService {
 		return !!project;
 	}
 
-	async getAllCached(): Promise<Variables[]> {
-		const variables = await this.cacheService.get('variables', {
-			refreshFn: async () => await this.findAll(),
-		});
-		return variables ?? [];
+	async getAllCached(
+		filters: { globalOnly: boolean } = { globalOnly: false },
+	): Promise<Variables[]> {
+		const variables =
+			(await this.cacheService.get('variables', {
+				refreshFn: async () => await this.findAll(),
+			})) ?? [];
+
+		if (filters.globalOnly) {
+			return variables.filter((v) => !v.project);
+		}
+
+		return variables;
 	}
 
 	async getCached(id: string): Promise<Variables | null> {

--- a/packages/cli/src/environments.ee/variables/variables.service.ee.ts
+++ b/packages/cli/src/environments.ee/variables/variables.service.ee.ts
@@ -159,7 +159,7 @@ export class VariablesService {
 	}
 
 	async deleteByIds(ids: string[]): Promise<void> {
-		await this.variablesRepository.delete(ids);
+		await this.variablesRepository.deleteByIds(ids);
 		await this.updateCache();
 	}
 

--- a/packages/cli/src/environments.ee/variables/variables.service.ee.ts
+++ b/packages/cli/src/environments.ee/variables/variables.service.ee.ts
@@ -158,6 +158,11 @@ export class VariablesService {
 		await this.updateCache();
 	}
 
+	async deleteByIds(ids: string[]): Promise<void> {
+		await this.variablesRepository.delete(ids);
+		await this.updateCache();
+	}
+
 	private async canCreateNewVariable() {
 		if (!this.licenseState.isVariablesLicensed()) {
 			throw new FeatureNotLicensedError('feat:variables');


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR adds project variable to be exported in the project files on the remote repository if source control is setup.
- It pushes the project variables stubs inside the project files, if they have changed
- It creates the missing project variables on pull of the project files
- It deletes unused project variables on pull 

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2150/support-project-variables-in-source-control-variables-stubs


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
