### PR TITLE
ci: Split PR unit testing into frontend and backend (no-changelog)

### DIFF
--- a/.github/workflows/units-tests-reusable.yml
+++ b/.github/workflows/units-tests-reusable.yml
@@ -27,12 +27,8 @@ env:
 
 jobs:
   unit-test-backend:
-    name: Backend (shard ${{ matrix.shard }}/3)
+    name: Backend
     runs-on: blacksmith-4vcpu-ubuntu-2204
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [1, 2, 3]
     env:
       COVERAGE_ENABLED: ${{ inputs.collectCoverage }}
     steps:
@@ -46,32 +42,27 @@ jobs:
           node-version: ${{ inputs.nodeVersion }}
 
       - name: Test
-        run: pnpm test:ci:backend -- --shard=${{ matrix.shard }}/3
-        env:
-          JEST_SHARD: ${{ matrix.shard }}/3
-          VITEST_SHARD: ${{ matrix.shard }}/3
+        run: pnpm test:ci:backend
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/test-results-action@47f89e9acb64b76debcd5ea40642d25a4adced9f # v1.1.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          name: backend-shard-${{ matrix.shard }}
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: backend
-          name: backend-shard-${{ matrix.shard }}
 
   unit-test-frontend:
-    name: Frontend (shard ${{ matrix.shard }}/2)
+    name: Frontend (${{ matrix.shard }}/2)
     runs-on: blacksmith-4vcpu-ubuntu-2204
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
+        shard: [1, 2]
     env:
       COVERAGE_ENABLED: ${{ inputs.collectCoverage }}
     steps:
@@ -85,9 +76,9 @@ jobs:
           node-version: ${{ inputs.nodeVersion }}
 
       - name: Test
-        run: pnpm test:ci:frontend -- --shard=${{ matrix.shard }}/3
+        run: pnpm test:ci:frontend -- --shard=${{ matrix.shard }}/2
         env:
-          VITEST_SHARD: ${{ matrix.shard }}/3
+          VITEST_SHARD: ${{ matrix.shard }}/2
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}

--- a/.github/workflows/units-tests-reusable.yml
+++ b/.github/workflows/units-tests-reusable.yml
@@ -26,11 +26,9 @@ env:
   NODE_OPTIONS: --max-old-space-size=7168
 
 jobs:
-  unit-test:
-    name: Unit tests
+  build:
+    name: Build
     runs-on: blacksmith-4vcpu-ubuntu-2204
-    env:
-      COVERAGE_ENABLED: ${{ inputs.collectCoverage }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -41,8 +39,45 @@ jobs:
         with:
           node-version: ${{ inputs.nodeVersion }}
 
+      - name: Cache build artifacts
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: |
+            node_modules
+            packages/**/node_modules
+            packages/**/dist
+          key: build-${{ github.sha }}-${{ github.run_id }}
+
+  unit-test-backend:
+    name: Unit tests (Backend)
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    needs: build
+    env:
+      COVERAGE_ENABLED: ${{ inputs.collectCoverage }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca777af5130f47f0a85e7e84b7 # v4.2.0
+        with:
+          node-version: ${{ inputs.nodeVersion }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
+
+      - name: Restore build artifacts
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: |
+            node_modules
+            packages/**/node_modules
+            packages/**/dist
+          key: build-${{ github.sha }}-${{ github.run_id }}
+
       - name: Test
-        run: pnpm test:ci
+        run: pnpm test:ci:backend
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
@@ -54,3 +89,47 @@ jobs:
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: backend
+
+  unit-test-frontend:
+    name: Unit tests (Frontend)
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    needs: build
+    env:
+      COVERAGE_ENABLED: ${{ inputs.collectCoverage }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca777af5130f47f0a85e7e84b7 # v4.2.0
+        with:
+          node-version: ${{ inputs.nodeVersion }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
+
+      - name: Restore build artifacts
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: |
+            node_modules
+            packages/**/node_modules
+            packages/**/dist
+          key: build-${{ github.sha }}-${{ github.run_id }}
+
+      - name: Test
+        run: pnpm test:ci:frontend
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@47f89e9acb64b76debcd5ea40642d25a4adced9f # v1.1.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: frontend

--- a/.github/workflows/units-tests-reusable.yml
+++ b/.github/workflows/units-tests-reusable.yml
@@ -95,7 +95,7 @@ jobs:
           name: frontend-shard-${{ matrix.shard }}
 
   unit-test:
-    name: Unit Tests
+    name: Unit tests
     runs-on: ubuntu-latest
     needs: [unit-test-backend, unit-test-frontend]
     if: always()

--- a/.github/workflows/units-tests-reusable.yml
+++ b/.github/workflows/units-tests-reusable.yml
@@ -27,8 +27,12 @@ env:
 
 jobs:
   unit-test-backend:
-    name: Backend
+    name: Backend (shard ${{ matrix.shard }}/3)
     runs-on: blacksmith-4vcpu-ubuntu-2204
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
     env:
       COVERAGE_ENABLED: ${{ inputs.collectCoverage }}
     steps:
@@ -42,23 +46,31 @@ jobs:
           node-version: ${{ inputs.nodeVersion }}
 
       - name: Test
-        run: pnpm test:ci:backend
+        run: pnpm test:ci:backend --shard=${{ matrix.shard }}/3
+        env:
+          JEST_SHARD: ${{ matrix.shard }}/3
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/test-results-action@47f89e9acb64b76debcd5ea40642d25a4adced9f # v1.1.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          name: backend-shard-${{ matrix.shard }}
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: backend
+          name: backend-shard-${{ matrix.shard }}
 
   unit-test-frontend:
-    name: Frontend
+    name: Frontend (shard ${{ matrix.shard }}/2)
     runs-on: blacksmith-4vcpu-ubuntu-2204
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
     env:
       COVERAGE_ENABLED: ${{ inputs.collectCoverage }}
     steps:
@@ -72,16 +84,20 @@ jobs:
           node-version: ${{ inputs.nodeVersion }}
 
       - name: Test
-        run: pnpm test:ci:frontend
+        run: pnpm test:ci:frontend --shard=${{ matrix.shard }}/3
+        env:
+          VITEST_SHARD: ${{ matrix.shard }}/3
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/test-results-action@47f89e9acb64b76debcd5ea40642d25a4adced9f # v1.1.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          name: frontend-shard-${{ matrix.shard }}
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: frontend
+          name: frontend-shard-${{ matrix.shard }}

--- a/.github/workflows/units-tests-reusable.yml
+++ b/.github/workflows/units-tests-reusable.yml
@@ -93,3 +93,13 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: frontend
           name: frontend-shard-${{ matrix.shard }}
+
+  post-e2e-tests:
+    name: E2E - Checks
+    runs-on: ubuntu-latest
+    needs: [unit-test-backend, unit-test-frontend]
+    if: always()
+    steps:
+      - name: Fail if tests failed
+        if: needs.unit-test-backend.result == 'failure' || needs.unit-test-frontend.result == 'failure'
+        run: exit 1

--- a/.github/workflows/units-tests-reusable.yml
+++ b/.github/workflows/units-tests-reusable.yml
@@ -49,6 +49,7 @@ jobs:
         run: pnpm test:ci:backend -- --shard=${{ matrix.shard }}/3
         env:
           JEST_SHARD: ${{ matrix.shard }}/3
+          VITEST_SHARD: ${{ matrix.shard }}/3
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}

--- a/.github/workflows/units-tests-reusable.yml
+++ b/.github/workflows/units-tests-reusable.yml
@@ -40,7 +40,7 @@ jobs:
           node-version: ${{ inputs.nodeVersion }}
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@4d4dc2f3e3e6ded78c4f5a3dd29c2e65e0898357 # v4.5.0
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.5.0
         with:
           name: build-artifacts
           path: |
@@ -69,7 +69,7 @@ jobs:
         uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
 
       - name: Download build artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v4.1.8
         with:
           name: build-artifacts
 
@@ -108,7 +108,7 @@ jobs:
         uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
 
       - name: Download build artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v4.1.8
         with:
           name: build-artifacts
 

--- a/.github/workflows/units-tests-reusable.yml
+++ b/.github/workflows/units-tests-reusable.yml
@@ -26,9 +26,11 @@ env:
   NODE_OPTIONS: --max-old-space-size=7168
 
 jobs:
-  build:
-    name: Build
+  unit-test-backend:
+    name: Backend
     runs-on: blacksmith-4vcpu-ubuntu-2204
+    env:
+      COVERAGE_ENABLED: ${{ inputs.collectCoverage }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -38,40 +40,6 @@ jobs:
         uses: n8n-io/n8n/.github/actions/setup-nodejs-blacksmith@f5fbbbe0a28a886451c886cac6b49192a39b0eea # v1.104.1
         with:
           node-version: ${{ inputs.nodeVersion }}
-
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.5.0
-        with:
-          name: build-artifacts
-          path: |
-            node_modules
-            packages/**/node_modules
-            packages/**/dist
-          retention-days: 1
-
-  unit-test-backend:
-    name: Backend
-    runs-on: blacksmith-4vcpu-ubuntu-2204
-    needs: build
-    env:
-      COVERAGE_ENABLED: ${{ inputs.collectCoverage }}
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ inputs.ref }}
-
-      - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca777af5130f47f0a85e7e84b7 # v4.2.0
-        with:
-          node-version: ${{ inputs.nodeVersion }}
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v4.1.8
-        with:
-          name: build-artifacts
 
       - name: Test
         run: pnpm test:ci:backend
@@ -91,7 +59,6 @@ jobs:
   unit-test-frontend:
     name: Frontend
     runs-on: blacksmith-4vcpu-ubuntu-2204
-    needs: build
     env:
       COVERAGE_ENABLED: ${{ inputs.collectCoverage }}
     steps:
@@ -99,18 +66,10 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca777af5130f47f0a85e7e84b7 # v4.2.0
+      - name: Build
+        uses: n8n-io/n8n/.github/actions/setup-nodejs-blacksmith@f5fbbbe0a28a886451c886cac6b49192a39b0eea # v1.104.1
         with:
           node-version: ${{ inputs.nodeVersion }}
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v4.1.8
-        with:
-          name: build-artifacts
 
       - name: Test
         run: pnpm test:ci:frontend

--- a/.github/workflows/units-tests-reusable.yml
+++ b/.github/workflows/units-tests-reusable.yml
@@ -39,17 +39,18 @@ jobs:
         with:
           node-version: ${{ inputs.nodeVersion }}
 
-      - name: Cache build artifacts
-        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@4d4dc2f3e3e6ded78c4f5a3dd29c2e65e0898357 # v4.5.0
         with:
+          name: build-artifacts
           path: |
             node_modules
             packages/**/node_modules
             packages/**/dist
-          key: build-${{ github.sha }}-${{ github.run_id }}
+          retention-days: 1
 
   unit-test-backend:
-    name: Unit tests (Backend)
+    name: Backend
     runs-on: blacksmith-4vcpu-ubuntu-2204
     needs: build
     env:
@@ -67,14 +68,10 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
 
-      - name: Restore build artifacts
-        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+      - name: Download build artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
-          path: |
-            node_modules
-            packages/**/node_modules
-            packages/**/dist
-          key: build-${{ github.sha }}-${{ github.run_id }}
+          name: build-artifacts
 
       - name: Test
         run: pnpm test:ci:backend
@@ -92,7 +89,7 @@ jobs:
           flags: backend
 
   unit-test-frontend:
-    name: Unit tests (Frontend)
+    name: Frontend
     runs-on: blacksmith-4vcpu-ubuntu-2204
     needs: build
     env:
@@ -110,14 +107,10 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
 
-      - name: Restore build artifacts
-        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+      - name: Download build artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
-          path: |
-            node_modules
-            packages/**/node_modules
-            packages/**/dist
-          key: build-${{ github.sha }}-${{ github.run_id }}
+          name: build-artifacts
 
       - name: Test
         run: pnpm test:ci:frontend

--- a/.github/workflows/units-tests-reusable.yml
+++ b/.github/workflows/units-tests-reusable.yml
@@ -46,7 +46,7 @@ jobs:
           node-version: ${{ inputs.nodeVersion }}
 
       - name: Test
-        run: pnpm test:ci:backend --shard=${{ matrix.shard }}/3
+        run: pnpm test:ci:backend -- --shard=${{ matrix.shard }}/3
         env:
           JEST_SHARD: ${{ matrix.shard }}/3
 
@@ -84,7 +84,7 @@ jobs:
           node-version: ${{ inputs.nodeVersion }}
 
       - name: Test
-        run: pnpm test:ci:frontend --shard=${{ matrix.shard }}/3
+        run: pnpm test:ci:frontend -- --shard=${{ matrix.shard }}/3
         env:
           VITEST_SHARD: ${{ matrix.shard }}/3
 

--- a/.github/workflows/units-tests-reusable.yml
+++ b/.github/workflows/units-tests-reusable.yml
@@ -94,7 +94,7 @@ jobs:
           flags: frontend
           name: frontend-shard-${{ matrix.shard }}
 
-  unit-tests:
+  unit-test:
     name: Unit Tests
     runs-on: ubuntu-latest
     needs: [unit-test-backend, unit-test-frontend]

--- a/.github/workflows/units-tests-reusable.yml
+++ b/.github/workflows/units-tests-reusable.yml
@@ -94,8 +94,8 @@ jobs:
           flags: frontend
           name: frontend-shard-${{ matrix.shard }}
 
-  post-e2e-tests:
-    name: E2E - Checks
+  unit-tests:
+    name: Unit Tests
     runs-on: ubuntu-latest
     needs: [unit-test-backend, unit-test-frontend]
     if: always()

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "start:windows": "cd packages/cli/bin && n8n",
     "test": "JEST_JUNIT_CLASSNAME={filepath} turbo run test",
     "test:ci": "turbo run test --continue --concurrency=1",
+    "test:ci:frontend": "turbo run test --continue --concurrency=1 --filter='./packages/frontend/**'",
+    "test:ci:backend": "turbo run test --continue --concurrency=1 --filter='!./packages/frontend/**'",
     "test:affected": "turbo run test --affected --concurrency=1",
     "test:with:docker": "pnpm --filter=n8n-playwright test:container:standard",
     "test:show:report": "pnpm --filter=n8n-playwright exec playwright show-report",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "start:windows": "cd packages/cli/bin && n8n",
     "test": "JEST_JUNIT_CLASSNAME={filepath} turbo run test",
     "test:ci": "turbo run test --continue --concurrency=1",
-    "test:ci:frontend": "turbo run test --continue --concurrency=1 --filter='./packages/frontend/**'",
+    "test:ci:frontend": "turbo run test --continue --filter='./packages/frontend/**'",
     "test:ci:backend": "turbo run test --continue --concurrency=1 --filter='!./packages/frontend/**'",
     "test:affected": "turbo run test --affected --concurrency=1",
     "test:with:docker": "pnpm --filter=n8n-playwright test:container:standard",


### PR DESCRIPTION
## Summary

-Split PR unit testing into frontend and backend
- Add `test:ci:frontend` script
- Add `test:ci:backend` script

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1638/split-unit-tests-into-backend-and-frontend-in-ci


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
