### PR TITLE
fix(Call n8n Sub-Workflow Tool Node): Fix return format for execute path

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/ToolWorkflow.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/ToolWorkflow.node.test.ts
@@ -1,9 +1,15 @@
 import { mock } from 'jest-mock-extended';
 import { DynamicTool } from 'langchain/tools';
-import { type INode, type ISupplyDataFunctions } from 'n8n-workflow';
+import {
+	type INode,
+	type ISupplyDataFunctions,
+	type IExecuteFunctions,
+	type INodeExecutionData,
+} from 'n8n-workflow';
 
 import { ToolWorkflow } from './ToolWorkflow.node';
 import type { ToolWorkflowV2 } from './v2/ToolWorkflowV2.node';
+import { WorkflowToolService } from './v2/utils/WorkflowToolService';
 
 describe('ToolWorkflowV2', () => {
 	describe('supplyData', () => {
@@ -67,6 +73,145 @@ describe('ToolWorkflowV2', () => {
 			expect(tool.name).toBe('test_tool');
 			expect(tool.description).toBe('description text');
 			expect(tool.func).toBeInstanceOf(Function);
+		});
+	});
+
+	describe('execute', () => {
+		beforeEach(() => {
+			jest.resetAllMocks();
+		});
+
+		it('should properly spread INodeExecutionData array from tool.invoke', async () => {
+			const toolWorkflowNode = new ToolWorkflow();
+			const node = toolWorkflowNode.nodeVersions[2.2] as ToolWorkflowV2;
+
+			// Mock the tool that returns INodeExecutionData[]
+			const mockToolResponse: INodeExecutionData[] = [{ json: { response: 'pikachu' } }];
+
+			const mockTool = {
+				invoke: jest.fn().mockResolvedValue(mockToolResponse),
+			} as any;
+
+			// Mock WorkflowToolService.createTool to return our mock tool
+			jest.spyOn(WorkflowToolService.prototype, 'createTool').mockResolvedValue(mockTool);
+
+			const inputData: INodeExecutionData[] = [{ json: { query: 'what is a pokemon?' } }];
+
+			const executeResult = await node.execute.call(
+				mock<IExecuteFunctions>({
+					getInputData: jest.fn(() => inputData),
+					getNode: jest.fn(() =>
+						mock<INode>({
+							typeVersion: 2.2,
+							name: 'test tool',
+							parameters: { workflowInputs: { schema: [] } },
+						}),
+					),
+					getNodeParameter: jest.fn().mockImplementation((paramName) => {
+						switch (paramName) {
+							case 'description':
+								return 'description text';
+							default:
+								return;
+						}
+					}),
+				}),
+			);
+
+			// Verify the result is properly formatted
+			expect(executeResult).toHaveLength(1);
+			expect(executeResult[0]).toHaveLength(1);
+			expect(executeResult[0][0]).toEqual({ json: { response: 'pikachu' } });
+			expect(mockTool.invoke).toHaveBeenCalledWith({ query: 'what is a pokemon?' });
+		});
+
+		it('should handle multiple items in the response', async () => {
+			const toolWorkflowNode = new ToolWorkflow();
+			const node = toolWorkflowNode.nodeVersions[2.2] as ToolWorkflowV2;
+
+			// Mock the tool that returns multiple INodeExecutionData items
+			const mockToolResponse: INodeExecutionData[] = [
+				{ json: { id: 1, name: 'pikachu' } },
+				{ json: { id: 2, name: 'charizard' } },
+			];
+
+			const mockTool = {
+				invoke: jest.fn().mockResolvedValue(mockToolResponse),
+			} as any;
+
+			jest.spyOn(WorkflowToolService.prototype, 'createTool').mockResolvedValue(mockTool);
+
+			const inputData: INodeExecutionData[] = [{ json: { query: 'list pokemon' } }];
+
+			const executeResult = await node.execute.call(
+				mock<IExecuteFunctions>({
+					getInputData: jest.fn(() => inputData),
+					getNode: jest.fn(() =>
+						mock<INode>({
+							typeVersion: 2.2,
+							name: 'test tool',
+							parameters: { workflowInputs: { schema: [] } },
+						}),
+					),
+					getNodeParameter: jest.fn().mockImplementation((paramName) => {
+						switch (paramName) {
+							case 'description':
+								return 'description text';
+							default:
+								return;
+						}
+					}),
+				}),
+			);
+
+			// Verify all items are properly spread into the response
+			expect(executeResult).toHaveLength(1);
+			expect(executeResult[0]).toHaveLength(2);
+			expect(executeResult[0][0]).toEqual({ json: { id: 1, name: 'pikachu' } });
+			expect(executeResult[0][1]).toEqual({ json: { id: 2, name: 'charizard' } });
+		});
+
+		it('should handle fallback for non-array responses', async () => {
+			const toolWorkflowNode = new ToolWorkflow();
+			const node = toolWorkflowNode.nodeVersions[2.2] as ToolWorkflowV2;
+
+			// Mock the tool that returns a string (edge case)
+			const mockTool = {
+				invoke: jest.fn().mockResolvedValue('plain string response'),
+			} as any;
+
+			jest.spyOn(WorkflowToolService.prototype, 'createTool').mockResolvedValue(mockTool);
+
+			const inputData: INodeExecutionData[] = [{ json: { query: 'test query' } }];
+
+			const executeResult = await node.execute.call(
+				mock<IExecuteFunctions>({
+					getInputData: jest.fn(() => inputData),
+					getNode: jest.fn(() =>
+						mock<INode>({
+							typeVersion: 2.2,
+							name: 'test tool',
+							parameters: { workflowInputs: { schema: [] } },
+						}),
+					),
+					getNodeParameter: jest.fn().mockImplementation((paramName) => {
+						switch (paramName) {
+							case 'description':
+								return 'description text';
+							default:
+								return;
+						}
+					}),
+				}),
+			);
+
+			// Verify the fallback wraps it properly
+			expect(executeResult).toHaveLength(1);
+			expect(executeResult[0]).toHaveLength(1);
+			expect(executeResult[0][0]).toEqual({
+				json: { response: 'plain string response' },
+				pairedItem: { item: 0 },
+			});
 		});
 	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/ToolWorkflowV2.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/ToolWorkflowV2.node.ts
@@ -68,7 +68,18 @@ export class ToolWorkflowV2 implements INodeType {
 				continue;
 			}
 			const result = await tool.invoke(item.json);
-			response.push(result);
+
+			// When manualLogging is false, tool.invoke returns INodeExecutionData[]
+			// We need to spread these into the response array
+			if (Array.isArray(result)) {
+				response.push(...result);
+			} else {
+				// Fallback for unexpected types (shouldn't happen with manualLogging=false)
+				response.push({
+					json: { response: result },
+					pairedItem: { item: itemIndex },
+				});
+			}
 		}
 
 		return [response];


### PR DESCRIPTION
## Summary
This PR corrects the output format of the call workflow tool for the execution via the engine. This should fix the output logs when using this tool. 
Also adds tests for the execute-method.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-1597/ai-agent-logs-dont-show-output-of-subworkflow-as-a-tool-making-it-hard


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
