### PR TITLE
feat(core): Capture the stream chunks and save partial messages (no-changelog)

### DIFF
--- a/packages/cli/src/modules/chat-hub/chat-message.repository.ts
+++ b/packages/cli/src/modules/chat-hub/chat-message.repository.ts
@@ -26,7 +26,7 @@ export class ChatHubMessageRepository extends Repository<ChatHubMessage> {
 
 	async updateChatMessage(
 		id: ChatMessageId,
-		fields: Partial<{ status: ChatHubMessageStatus; content: string }>,
+		fields: { status?: ChatHubMessageStatus; content?: string },
 		trx?: EntityManager,
 	) {
 		return await withTransaction(this.manager, trx, async (em) => {

--- a/packages/cli/src/modules/chat-hub/stream-capturer.ts
+++ b/packages/cli/src/modules/chat-hub/stream-capturer.ts
@@ -1,0 +1,49 @@
+import type { Response } from 'express';
+import type { ServerResponse } from 'http';
+
+type Write = ServerResponse['write'];
+
+export type ChunkListenerCb = (chunk: string) => void;
+
+export function captureResponseWrites<T extends Response>(res: T, onChunk: ChunkListenerCb): T {
+	const originalWrite = res.write.bind(res) as Write;
+
+	const writeListener = (chunk: string | Buffer, enc?: BufferEncoding) => {
+		try {
+			const text = Buffer.isBuffer(chunk) ? chunk.toString(enc ?? 'utf8') : String(chunk);
+			void onChunk(text);
+		} catch {
+			// Don't break the stream on listener errors
+		}
+	};
+
+	function write(chunk: string | Buffer, callbackFn?: (e?: Error | null) => void): boolean;
+	function write(
+		chunk: string | Buffer,
+		encoding: BufferEncoding,
+		callbackFn?: (e?: Error | null) => void,
+	): boolean;
+	function write(
+		chunk: string | Buffer,
+		encodingOrCallbackFn?: BufferEncoding | ((e?: Error | null) => void),
+		callbackFn?: (e?: Error | null) => void,
+	): boolean {
+		// TODO: We could also change the output that gets streamed from execution engine here,
+		// perhaps injecting the messageId or other metadata into the chunks. That could make
+		// AI responding with multiple messages (tools, multiple agents etc) easier to handle?
+		if (!encodingOrCallbackFn) {
+			writeListener(chunk);
+			return originalWrite(chunk);
+		} else if (typeof encodingOrCallbackFn === 'function') {
+			writeListener(chunk);
+			return originalWrite(chunk, encodingOrCallbackFn);
+		} else {
+			writeListener(chunk, encodingOrCallbackFn);
+			return originalWrite(chunk, encodingOrCallbackFn, callbackFn);
+		}
+	}
+
+	res.write = write;
+
+	return res;
+}

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/chat.api.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/chat.api.ts
@@ -11,7 +11,7 @@ import type {
 	ChatSessionId,
 	ChatMessageId,
 } from '@n8n/api-types';
-import type { StructuredChunk } from './chat.types';
+import type { StructuredChunk } from 'n8n-workflow';
 
 // Workflows stream data as newline separated JSON objects (jsonl)
 const STREAM_SEPARATOR = '\n';

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/chat.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/chat.store.ts
@@ -23,7 +23,8 @@ import type {
 	ChatSessionId,
 	ChatHubMessageDto,
 } from '@n8n/api-types';
-import type { StructuredChunk, CredentialsMap, ChatMessage, ChatConversation } from './chat.types';
+import type { CredentialsMap, ChatMessage, ChatConversation } from './chat.types';
+import type { StructuredChunk } from 'n8n-workflow';
 
 export const useChatStore = defineStore(CHAT_STORE, () => {
 	const rootStore = useRootStore();

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/chat.types.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/chat.types.ts
@@ -47,20 +47,6 @@ export interface StreamOutput {
 	messages: StreamChunk[];
 }
 
-// From @n8n/chat
-export type ChunkType = 'begin' | 'item' | 'end' | 'error';
-export interface StructuredChunk {
-	type: ChunkType;
-	content?: string;
-	metadata: {
-		nodeId: string;
-		nodeName: string;
-		timestamp: number;
-		runIndex: number;
-		itemIndex: number;
-	};
-}
-
 export interface NodeStreamingState {
 	nodeId: string;
 	chunks: string[];


### PR DESCRIPTION
## Summary

Save AI message chunks as they're being streamed from execution engine to the frontend by wrapping the `res` object into a helper that captures the chunks. Construct the partial message and save it on cancel - we might want to save our full message saving to use this mechanism instead of parsing it from executions later on too 🤔 

But for now the goal was just to save the partial messages.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-34/saving-partial-messages

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
