### PR TITLE
feat: Parse and apply provisioned project role mappings

### DIFF
--- a/packages/cli/src/modules/provisioning.ee/__tests__/provisioning.service.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/provisioning.service.ee.test.ts
@@ -276,7 +276,7 @@ describe('ProvisioningService', () => {
 			);
 		});
 
-		it('should do nothing if projectIdToRole is not a valid JSON string', async () => {
+		it('should throw an error if projectIdToRole is not a valid JSON string', async () => {
 			const userId = 'user-id-123';
 			const projectIdToRole = 'invalid-json-string';
 

--- a/packages/cli/src/modules/provisioning.ee/__tests__/provisioning.service.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/provisioning.service.ee.test.ts
@@ -362,6 +362,23 @@ describe('ProvisioningService', () => {
 				role: 'project:editor',
 			});
 		});
+		it('should filter out non-project roles', async () => {
+			const userId = 'user-id-123';
+			const projectIdToRole = JSON.stringify({
+				project1: 'global:admin',
+			});
+
+			projectRepository.find.mockResolvedValue([mock<Project>({ id: 'project1' })]);
+			roleRepository.find.mockResolvedValue([]);
+
+			await provisioningService.provisionProjectRolesForUser(userId, projectIdToRole);
+
+			expect(projectService.addUser).not.toHaveBeenCalled();
+			expect(logger.warn).toHaveBeenCalledWith(
+				'Skipping project role provisioning. Role with slug global:admin not found or is not a project role.',
+				{ userId, projectId: 'project1', roleSlug: 'global:admin' },
+			);
+		});
 	});
 
 	describe('handleReloadSsoProvisioningConfiguration', () => {

--- a/packages/cli/src/modules/provisioning.ee/__tests__/provisioning.service.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/provisioning.service.ee.test.ts
@@ -276,15 +276,13 @@ describe('ProvisioningService', () => {
 			);
 		});
 
-		it('should throw an error if projectIdToRole is not a valid JSON string', async () => {
+		it('should do nothing if projectIdToRole is not a valid JSON string', async () => {
 			const userId = 'user-id-123';
 			const projectIdToRole = 'invalid-json-string';
 
-			await expect(
-				provisioningService.provisionProjectRolesForUser(userId, projectIdToRole),
-			).rejects.toThrow(
-				'Skipping project role provisioning. Invalid project to role mapping provided.',
-			);
+			await provisioningService.provisionProjectRolesForUser(userId, projectIdToRole);
+
+			expect(projectService.addUser).not.toHaveBeenCalled();
 			expect(logger.warn).toHaveBeenCalledTimes(1);
 			expect(logger.warn).toHaveBeenCalledWith(
 				'Skipping project role provisioning. Failed to parse project to role mapping.',
@@ -292,19 +290,17 @@ describe('ProvisioningService', () => {
 			);
 		});
 
-		it('should throw an error if projectIdToRole has an invalid structure', async () => {
+		it('should filter out entries where key:value is not a string', async () => {
 			const userId = 'user-id-123';
-			const projectIdToRole = JSON.stringify({ project_1: { nested: 'object' } }); // invalid key type
+			const projectIdToRole = JSON.stringify({ project_1: { nested: 'object' } }); // invalid value type
 
-			await expect(
-				provisioningService.provisionProjectRolesForUser(userId, projectIdToRole),
-			).rejects.toThrow(
-				'Skipping project role provisioning. Invalid project to role mapping provided.',
-			);
+			await provisioningService.provisionProjectRolesForUser(userId, projectIdToRole);
+
+			expect(projectService.addUser).not.toHaveBeenCalled();
 			expect(logger.warn).toHaveBeenCalledTimes(1);
 			expect(logger.warn).toHaveBeenCalledWith(
-				'Skipping project role provisioning. Failed to parse project to role mapping.',
-				{ userId, projectIdToRole },
+				'Skipping project role mapping for project_1:[object Object]. Invalid types: expected both key and value to be strings.',
+				{ userId },
 			);
 		});
 

--- a/packages/cli/src/modules/provisioning.ee/__tests__/provisioning.service.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/provisioning.service.ee.test.ts
@@ -275,6 +275,38 @@ describe('ProvisioningService', () => {
 			);
 		});
 
+		it('should throw an error if projectIdToRole is not a valid JSON string', async () => {
+			const userId = 'user-id-123';
+			const projectIdToRole = 'invalid-json-string';
+
+			await expect(
+				provisioningService.provisionProjectRolesForUser(userId, projectIdToRole),
+			).rejects.toThrow(
+				'Skipping project role provisioning. Invalid project to role mapping provided.',
+			);
+			expect(logger.warn).toHaveBeenCalledTimes(1);
+			expect(logger.warn).toHaveBeenCalledWith(
+				'Skipping project role provisioning. Failed to parse project to role mapping.',
+				{ userId, projectIdToRole },
+			);
+		});
+
+		it('should throw an error if projectIdToRole has an invalid structure', async () => {
+			const userId = 'user-id-123';
+			const projectIdToRole = JSON.stringify({ project_1: { nested: 'object' } }); // invalid key type
+
+			await expect(
+				provisioningService.provisionProjectRolesForUser(userId, projectIdToRole),
+			).rejects.toThrow(
+				'Skipping project role provisioning. Invalid project to role mapping provided.',
+			);
+			expect(logger.warn).toHaveBeenCalledTimes(1);
+			expect(logger.warn).toHaveBeenCalledWith(
+				'Skipping project role provisioning. Failed to parse project to role mapping.',
+				{ userId, projectIdToRole },
+			);
+		});
+
 		it('should do nothing if the project does not exist', async () => {
 			const userId = 'user-id-123';
 			const projectIdToRole = JSON.stringify({

--- a/packages/cli/src/modules/provisioning.ee/provisioning.service.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/provisioning.service.ee.ts
@@ -119,8 +119,17 @@ export class ProvisioningService {
 		let projectRoleMap: Record<string, string>;
 		try {
 			projectRoleMap = JSON.parse(projectIdToRole);
+			for (const [key, value] of Object.entries(projectRoleMap)) {
+				if (typeof key !== 'string' || typeof value !== 'string') {
+					throw new Error('Invalid project to role mapping structure');
+				}
+			}
 		} catch {
 			// TODO: clarify wether this should throw an error.
+			this.logger.warn(
+				'Skipping project role provisioning. Failed to parse project to role mapping.',
+				{ userId, projectIdToRole },
+			);
 			throw new Error(
 				'Skipping project role provisioning. Invalid project to role mapping provided.',
 			);
@@ -143,6 +152,7 @@ export class ProvisioningService {
 				);
 				continue;
 			}
+			// TODO: do we need to check for dbRole.roleType === 'project' or can global rules also be used?
 			await this.projectService.addUser(projectId, { userId, role: roleSlug });
 		}
 

--- a/packages/cli/src/modules/provisioning.ee/provisioning.service.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/provisioning.service.ee.ts
@@ -144,7 +144,7 @@ export class ProvisioningService {
 		}
 
 		const existingProjects = await this.projectRepository.find({
-			where: { id: In(projectIds) },
+			where: { id: In(projectIds), type: Not('personal') },
 			select: ['id'],
 		});
 		const existingProjectIds = new Set(existingProjects.map((project) => project.id));

--- a/packages/cli/src/modules/provisioning.ee/provisioning.service.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/provisioning.service.ee.ts
@@ -121,7 +121,11 @@ export class ProvisioningService {
 			projectRoleMap = JSON.parse(projectIdToRole);
 			for (const [key, value] of Object.entries(projectRoleMap)) {
 				if (typeof key !== 'string' || typeof value !== 'string') {
-					throw new Error('Invalid project to role mapping structure');
+					this.logger.warn(
+						`Skipping project role mapping for ${key}:${value}. Invalid types: expected both key and value to be strings.`,
+						{ userId },
+					);
+					delete projectRoleMap[key];
 				}
 			}
 		} catch (error) {
@@ -129,9 +133,7 @@ export class ProvisioningService {
 				'Skipping project role provisioning. Failed to parse project to role mapping.',
 				{ userId, projectIdToRole },
 			);
-			throw new Error(
-				'Skipping project role provisioning. Invalid project to role mapping provided.',
-			);
+			return;
 		}
 
 		const projectIds = Object.keys(projectRoleMap);
@@ -150,7 +152,7 @@ export class ProvisioningService {
 		const existingRoles = await this.roleRepository.find({
 			where: {
 				slug: In(roleSlugs),
-				roleType: 'project', // TODO: verify wheter we actually only support roles of type "project" here
+				roleType: 'project',
 			},
 			select: ['slug'],
 		});

--- a/packages/cli/src/modules/provisioning.ee/provisioning.service.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/provisioning.service.ee.ts
@@ -150,6 +150,7 @@ export class ProvisioningService {
 		const existingRoles = await this.roleRepository.find({
 			where: {
 				slug: In(roleSlugs),
+				roleType: 'project', // TODO: verify wheter we actually only support roles of type "project" here
 			},
 			select: ['slug'],
 		});

--- a/packages/cli/src/modules/provisioning.ee/provisioning.service.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/provisioning.service.ee.ts
@@ -182,6 +182,14 @@ export class ProvisioningService {
 			validProjectToRoleMappings.push({ projectId, roleSlug });
 		}
 
+		if (validProjectToRoleMappings.length === 0) {
+			this.logger.warn(
+				'Skipping project role provisioning altogether. No valid project to role mappings found.',
+				{ userId, projectRoleMap },
+			);
+			return;
+		}
+
 		const currentlyAccessibleProjects = await this.projectRepository.find({
 			where: {
 				type: Not('personal'),

--- a/packages/cli/src/modules/provisioning.ee/provisioning.service.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/provisioning.service.ee.ts
@@ -144,19 +144,20 @@ export class ProvisioningService {
 			return;
 		}
 
-		const existingProjects = await this.projectRepository.find({
-			where: { id: In(projectIds), type: Not('personal') },
-			select: ['id'],
-		});
+		const [existingProjects, existingRoles] = await Promise.all([
+			this.projectRepository.find({
+				where: { id: In(projectIds), type: Not('personal') },
+				select: ['id'],
+			}),
+			this.roleRepository.find({
+				where: {
+					slug: In(roleSlugs),
+					roleType: 'project',
+				},
+				select: ['slug'],
+			}),
+		]);
 		const existingProjectIds = new Set(existingProjects.map((project) => project.id));
-
-		const existingRoles = await this.roleRepository.find({
-			where: {
-				slug: In(roleSlugs),
-				roleType: 'project',
-			},
-			select: ['slug'],
-		});
 		const existingRoleSlugs = new Set(existingRoles.map((r) => r.slug));
 
 		const validProjectToRoleMappings: Array<{ projectId: string; roleSlug: string }> = [];


### PR DESCRIPTION
## Summary

Adds a method `provisionProjectRolesForUser` that we will use later on to pass in a strong for a key value map (project<>role) that's configured externally on the SSO provider.


## Related Linear tickets, Github issues, and Community forum posts

closes PAY-3959


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
