### PR TITLE
ci: Reduce workers to 2

### DIFF
--- a/.github/workflows/playwright-test-reusable.yml
+++ b/.github/workflows/playwright-test-reusable.yml
@@ -44,7 +44,7 @@ env:
   NODE_OPTIONS: --max-old-space-size=3072
   # Disable Ryuk to avoid issues with Docker since it needs privileged access, containers are cleaned on teardown anyway
   TESTCONTAINERS_RYUK_DISABLED: true
-  PLAYWRIGHT_WORKERS: ${{ inputs.workers || (inputs.test-mode == 'docker-pull' && '2' || '3') }} # Configurable workers, defaults: 1 for docker-pull, 3 for others
+  PLAYWRIGHT_WORKERS: ${{ inputs.workers || '2' }} # Configurable workers, defaults to 2 to reduce resource contention
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

There is still some flake happening which seems to be due to resource contention e.g api calls failing due to server underload. Reducing to 2 workers instead of 3 for CI should help.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
