### PR TITLE
refactor(core): Use transactions at chat hub (no-changelog)

### DIFF
--- a/packages/cli/src/modules/chat-hub/chat-hub.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.service.ts
@@ -933,8 +933,6 @@ export class ChatHubService {
 		title: string | null = null,
 		trx?: EntityManager,
 	) {
-		// TODO: Handle session ID conflicts better (different user, same ID)
-
 		const existing = await this.sessionRepository.getOneById(sessionId, user.id, trx);
 		if (existing) {
 			return existing;

--- a/packages/cli/src/modules/chat-hub/chat-message.repository.ts
+++ b/packages/cli/src/modules/chat-hub/chat-message.repository.ts
@@ -47,10 +47,17 @@ export class ChatHubMessageRepository extends Repository<ChatHubMessage> {
 		});
 	}
 
-	async getOneById(id: ChatMessageId, sessionId: ChatSessionId, relations: string[] = []) {
-		return await this.findOne({
-			where: { id, sessionId },
-			relations,
+	async getOneById(
+		id: ChatMessageId,
+		sessionId: ChatSessionId,
+		relations: string[] = [],
+		trx?: EntityManager,
+	) {
+		return await withTransaction(this.manager, trx, async (em) => {
+			return await em.findOne(ChatHubMessage, {
+				where: { id, sessionId },
+				relations,
+			});
 		});
 	}
 }

--- a/packages/cli/src/modules/chat-hub/chat-message.repository.ts
+++ b/packages/cli/src/modules/chat-hub/chat-message.repository.ts
@@ -17,8 +17,10 @@ export class ChatHubMessageRepository extends Repository<ChatHubMessage> {
 
 	async createChatMessage(message: Partial<ChatHubMessage>, trx?: EntityManager) {
 		return await withTransaction(this.manager, trx, async (em) => {
-			const chatMessage = em.create(ChatHubMessage, message);
-			const saved = await em.save(chatMessage);
+			await em.insert(ChatHubMessage, message);
+			const saved = await em.findOneOrFail(ChatHubMessage, {
+				where: { id: message.id },
+			});
 			await this.chatSessionRepository.updateLastMessageAt(saved.sessionId, saved.createdAt, em);
 			return saved;
 		});

--- a/packages/cli/src/modules/chat-hub/chat-session.repository.ts
+++ b/packages/cli/src/modules/chat-hub/chat-session.repository.ts
@@ -54,10 +54,12 @@ export class ChatHubSessionRepository extends Repository<ChatHubSession> {
 		});
 	}
 
-	async getOneById(id: string, userId: string) {
-		return await this.findOne({
-			where: { id, ownerId: userId },
-			relations: ['messages'],
+	async getOneById(id: string, userId: string, trx?: EntityManager) {
+		return await withTransaction(this.manager, trx, async (em) => {
+			return await em.findOne(ChatHubSession, {
+				where: { id, ownerId: userId },
+				relations: ['messages'],
+			});
 		});
 	}
 

--- a/packages/cli/src/modules/chat-hub/chat-session.repository.ts
+++ b/packages/cli/src/modules/chat-hub/chat-session.repository.ts
@@ -12,10 +12,9 @@ export class ChatHubSessionRepository extends Repository<ChatHubSession> {
 
 	async createChatSession(session: Partial<ChatHubSession>, trx?: EntityManager) {
 		return await withTransaction(this.manager, trx, async (em) => {
-			const chatHubSession = em.create(ChatHubSession, session);
-			const saved = await em.save(chatHubSession);
+			await em.insert(ChatHubSession, session);
 			return await em.findOneOrFail(ChatHubSession, {
-				where: { id: saved.id },
+				where: { id: session.id },
 				relations: ['messages'],
 			});
 		});


### PR DESCRIPTION
## Summary

Use transactions at handling chat hub messages, so that no session gets created if saving the initial human message fails for instance.

Also prevent same messageId and sessionId from being reused, we were mistakenly upserting sessions/messages with the IDs and not failing.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-22/use-transactions-at-chat-hub-service

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
