### PR TITLE
feat(editor): Remove flag for project variables

### DIFF
--- a/packages/frontend/editor-ui/src/components/MainSidebar.vue
+++ b/packages/frontend/editor-ui/src/components/MainSidebar.vue
@@ -22,7 +22,6 @@ import {
 	ABOUT_MODAL_KEY,
 	EXPERIMENT_TEMPLATE_RECO_V2_KEY,
 	EXPERIMENT_TEMPLATE_RECO_V3_KEY,
-	PROJECT_VARIABLES_EXPERIMENT,
 	RELEASE_NOTES_URL,
 	VIEWS,
 	WHATS_NEW_MODAL_KEY,
@@ -58,7 +57,6 @@ import { useCalloutHelpers } from '@/composables/useCalloutHelpers';
 import ProjectNavigation from '@/features/collaboration/projects/components/ProjectNavigation.vue';
 import MainSidebarSourceControl from './MainSidebarSourceControl.vue';
 import MainSidebarUserArea from '@/components/MainSidebarUserArea.vue';
-import { usePostHog } from '@/stores/posthog.store';
 
 const becomeTemplateCreatorStore = useBecomeTemplateCreatorStore();
 const cloudPlanStore = useCloudPlanStore();
@@ -80,7 +78,6 @@ const telemetry = useTelemetry();
 const pageRedirectionHelper = usePageRedirectionHelper();
 const { getReportingURL } = useBugReporting();
 const calloutHelpers = useCalloutHelpers();
-const posthogStore = usePostHog();
 
 useKeybindings({
 	ctrl_alt_o: () => handleSelect('about'),
@@ -99,13 +96,6 @@ const showWhatsNewNotification = computed(
 		versionsStore.whatsNewArticles.some(
 			(article) => !versionsStore.isWhatsNewArticleRead(article.id),
 		),
-);
-
-const isProjectVariablesEnabled = computed(() =>
-	posthogStore.isVariantEnabled(
-		PROJECT_VARIABLES_EXPERIMENT.name,
-		PROJECT_VARIABLES_EXPERIMENT.variant,
-	),
 );
 
 const mainMenuItems = computed<IMenuItem[]>(() => [
@@ -186,14 +176,6 @@ const mainMenuItems = computed<IMenuItem[]>(() => [
 			href: templatesStore.websiteTemplateRepositoryURL,
 			target: '_blank',
 		},
-	},
-	{
-		id: 'variables',
-		icon: 'variable',
-		label: i18n.baseText('mainSidebar.variables'),
-		position: 'bottom',
-		route: { to: { name: VIEWS.VARIABLES } },
-		available: !isProjectVariablesEnabled.value,
 	},
 	{
 		id: 'insights',

--- a/packages/frontend/editor-ui/src/constants/experiments.ts
+++ b/packages/frontend/editor-ui/src/constants/experiments.ts
@@ -87,12 +87,6 @@ export const PERSONALIZED_TEMPLATES_V3 = {
 	variant: 'variant',
 };
 
-export const PROJECT_VARIABLES_EXPERIMENT = {
-	name: '046_project_variables',
-	control: 'control',
-	variant: 'variant',
-};
-
 export const EXPERIMENTS_TO_TRACK = [
 	WORKFLOW_BUILDER_DEPRECATED_EXPERIMENT.name,
 	WORKFLOW_BUILDER_RELEASE_EXPERIMENT.name,
@@ -102,5 +96,4 @@ export const EXPERIMENTS_TO_TRACK = [
 	BATCH_11AUG_EXPERIMENT.name,
 	PRE_BUILT_AGENTS_EXPERIMENT.name,
 	TEMPLATE_RECO_V2.name,
-	PROJECT_VARIABLES_EXPERIMENT.name,
 ];

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectTabs.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectTabs.test.ts
@@ -2,7 +2,6 @@ import { createComponentRenderer } from '@/__tests__/render';
 import type { MockedStore } from '@/__tests__/utils';
 import { mockedStore } from '@/__tests__/utils';
 import ProjectTabs from './ProjectTabs.vue';
-import { usePostHog } from '@/stores/posthog.store';
 import { createPinia, setActivePinia } from 'pinia';
 import { useProjectsStore } from '../projects.store';
 import type { Project } from '../projects.types';
@@ -29,11 +28,9 @@ const renderComponent = createComponentRenderer(ProjectTabs, {
 
 describe('ProjectTabs', () => {
 	let projectsStore: MockedStore<typeof useProjectsStore>;
-	let postHogStore: MockedStore<typeof usePostHog>;
 	beforeEach(() => {
 		setActivePinia(createPinia());
 		projectsStore = mockedStore(useProjectsStore);
-		postHogStore = mockedStore(usePostHog);
 		vi.spyOn(projectsStore, 'currentProject', 'get').mockReturnValue(null);
 	});
 
@@ -57,8 +54,12 @@ describe('ProjectTabs', () => {
 		expect(queryByText('Variables')).not.toBeInTheDocument();
 	});
 
+	it('should render overview project tabs with variables', () => {
+		const { getByText } = renderComponent({ props: { pageType: 'overview' } });
+		expect(getByText('Variables')).toBeInTheDocument();
+	});
+
 	it('should render team project tabs with variables', () => {
-		vi.spyOn(postHogStore, 'isVariantEnabled').mockReturnValue(true);
 		vi.spyOn(projectsStore, 'currentProject', 'get').mockReturnValue({
 			id: '1',
 			name: 'default',

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectTabs.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectTabs.vue
@@ -2,12 +2,11 @@
 import { ref, watch, computed } from 'vue';
 import type { RouteRecordName } from 'vue-router';
 import { useRoute } from 'vue-router';
-import { PROJECT_VARIABLES_EXPERIMENT, VIEWS } from '@/constants';
+import { VIEWS } from '@/constants';
 import { useI18n } from '@n8n/i18n';
 import type { BaseTextKey } from '@n8n/i18n';
 import type { TabOptions } from '@n8n/design-system';
 import { processDynamicTabs, type DynamicTabOptions } from '@/utils/modules/tabUtils';
-import { usePostHog } from '@/stores/posthog.store';
 
 import { N8nTabs } from '@n8n/design-system';
 import { useProjectsStore } from '../projects.store';
@@ -29,16 +28,8 @@ const props = withDefaults(defineProps<Props>(), {
 
 const locale = useI18n();
 const route = useRoute();
-const posthogStore = usePostHog();
 const projectStore = useProjectsStore();
 const telemetry = useTelemetry();
-
-const isProjectVariablesEnabled = computed(() =>
-	posthogStore.isVariantEnabled(
-		PROJECT_VARIABLES_EXPERIMENT.name,
-		PROJECT_VARIABLES_EXPERIMENT.variant,
-	),
-);
 
 const selectedTab = ref<RouteRecordName | null | undefined>('');
 
@@ -119,7 +110,7 @@ const options = computed<Array<TabOptions<string>>>(() => {
 		tabs.push(createTab('mainSidebar.executions', 'executions', routes));
 	}
 
-	if ((props.pageType === 'overview' || isTeamProject.value) && isProjectVariablesEnabled.value) {
+	if (props.pageType === 'overview' || isTeamProject.value) {
 		tabs.push(createTab('mainSidebar.variables', 'variables', routes));
 	}
 


### PR DESCRIPTION

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR removes the feature flagging mechanism for project variables, because we want to enable it by default now

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-4005/remove-feature-flag

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
