### PR TITLE
fix(OpenAI Node): Don't include function calls when conversation id is used

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v2/actions/text/response.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v2/actions/text/response.operation.ts
@@ -706,7 +706,6 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 
 	const hasFunctionCall = () => toolCalls.some((item) => item.type === 'function_call');
 
-	const answeredToolCalls = new Set<string>();
 	let currentIteration = 1;
 	// make sure there's actually a function call to answer
 	while (toolCalls.length && hasFunctionCall()) {
@@ -714,13 +713,16 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 			break;
 		}
 
+		// if there's conversation, we don't need to include function_call or reasoning items in the request
+		// if we include them, OpenAI will throw "Duplicate item with id" error
+		if (!body.conversation) {
+			body.input.push.apply(body.input, toolCalls);
+		}
+
 		for (const item of toolCalls) {
-			if (item.type === 'function_call' && answeredToolCalls.has(item.call_id)) {
+			if (item.type !== 'function_call') {
 				continue;
 			}
-
-			// include function_call or reasoning items in the request
-			body.input.push(item);
 
 			if (item.type === 'function_call') {
 				const functionName = item.name;
@@ -745,8 +747,6 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 					call_id: callId,
 					output: functionResponse,
 				});
-
-				answeredToolCalls.add(callId);
 			}
 		}
 

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v2/actions/text/response.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v2/actions/text/response.operation.ts
@@ -720,10 +720,6 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 		}
 
 		for (const item of toolCalls) {
-			if (item.type !== 'function_call') {
-				continue;
-			}
-
 			if (item.type === 'function_call') {
 				const functionName = item.name;
 				const functionArgs = item.arguments;


### PR DESCRIPTION
## Summary

This PR fixes an issue when Conversation ID is used together with tools, which leads to an execution error

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3804/openai-generate-response-fails-when-using-conversation-id-tools
https://github.com/n8n-io/n8n/pull/20657#issuecomment-3430459823


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
