### PR TITLE
fix(core): Read chat project from credential (no-changelog)

### DIFF
--- a/packages/cli/src/modules/chat-hub/chat-hub.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.service.ts
@@ -328,11 +328,7 @@ export class ChatHubService {
 
 	private async ensureCredentials(
 		user: User,
-		model: {
-			provider: 'openai' | 'anthropic' | 'google';
-			model: string;
-			workflowId: string | null;
-		},
+		model: ChatHubConversationModel,
 		credentials: INodeCredentials,
 		trx?: EntityManager,
 	) {


### PR DESCRIPTION
## Summary

Ensure that the user has at least `credential:read` permissions to the credentials passed to chat endpoints & read the project under which to create the temporary WF from the credential - this way chats using credentials shared to you from projects (for instance on viewer users) will work, and viewer users will be able to chat.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-35/fix-issue-at-credentials-on-project-viewer-users

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
