### PR TITLE
Fix NIM incompatibility with empty content

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
@@ -24,6 +24,7 @@ import {
 
 import {
 	fixEmptyContentMessage,
+	fixChatHistoryMessages,
 	getAgentStepsParser,
 	getChatModel,
 	getOptionalMemory,
@@ -271,6 +272,10 @@ export async function toolsAgentExecute(
 					// Load memory variables to respect context window length
 					const memoryVariables = await memory.loadMemoryVariables({});
 					chatHistory = memoryVariables['chat_history'];
+					// Fix empty content in AIMessages with tool_calls (required for some APIs like NVIDIA)
+					if (chatHistory) {
+						chatHistory = fixChatHistoryMessages(chatHistory);
+					}
 				}
 				const eventStream = executor.streamEvents(
 					{

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/execute.ts
@@ -36,6 +36,7 @@ import {
 
 import {
 	fixEmptyContentMessage,
+	fixChatHistoryMessages,
 	getAgentStepsParser,
 	getChatModel,
 	getOptionalMemory,
@@ -622,5 +623,6 @@ async function loadChatHistory(
 		});
 	}
 
-	return chatHistory;
+	// Fix empty content in AIMessages with tool_calls (required for some APIs like NVIDIA)
+	return fixChatHistoryMessages(chatHistory);
 }

--- a/packages/@n8n/nodes-langchain/nodes/llms/N8nNonEstimatingTracing.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/N8nNonEstimatingTracing.ts
@@ -104,6 +104,49 @@ export class N8nNonEstimatingTracing extends BaseCallbackHandler {
 		});
 	}
 
+	async handleChatModelStart(
+		llm: Serialized,
+		messages: BaseMessage[][],
+		runId: string,
+		_parentRunId?: string,
+		_extraParams?: Record<string, unknown>,
+		_tags?: string[],
+		_metadata?: Record<string, unknown>,
+		_name?: string,
+	) {
+		// Flatten the messages array (it's an array of arrays for batch processing)
+		const flatMessages = messages.reduce((acc, val) => acc.concat(val), []);
+		const estimatedTokens = 0;
+		const sourceNodeRunIndex =
+			this.#parentRunIndex !== undefined
+				? this.#parentRunIndex + this.executionFunctions.getNextRunIndex()
+				: undefined;
+
+		const options = llm.type === 'constructor' ? llm.kwargs : llm;
+		const { index } = this.executionFunctions.addInputData(
+			this.connectionType,
+			[
+				[
+					{
+						json: {
+							messages: flatMessages,
+							estimatedTokens,
+							options,
+						},
+					},
+				],
+			],
+			sourceNodeRunIndex,
+		);
+
+		// Save the run details for later use when processing `handleLLMEnd` event
+		this.runsMap[runId] = {
+			index,
+			options,
+			messages: flatMessages,
+		};
+	}
+
 	async handleLLMStart(llm: Serialized, prompts: string[], runId: string) {
 		const estimatedTokens = 0;
 		const sourceNodeRunIndex =


### PR DESCRIPTION
## Summary

### Problem
n8n AI Agents fail when using NVIDIA's OpenAI-compatible API (and potentially other strict APIs) with tool calling enabled. The workflow fails with a `400 Bad Request` error after the LLM decides to call a tool.

**Root Cause:** When LangChain creates an `AIMessage` with `tool_calls`, it sets the `content` field to an empty string `""`. While OpenAI's API accepts this, NVIDIA's API strictly validates and requires `content` to have at least 1 character, returning:
```
"String should have at least 1 character"
```

### Solution
This PR adds two fixes:

1. **HTTP-level content fix in `LmChatOpenAi.node.ts`**: Intercepts fetch requests and replaces empty `content: ""` with a single space `content: " "` in assistant messages that contain `tool_calls`. This happens at the HTTP level, ensuring compatibility regardless of which LangChain method is invoked.

2. **Proper message formatting in `N8nLlmTracing.ts`**: Adds `handleChatModelStart` method to correctly process `BaseMessage[][]` from LangChain's chat models, ensuring messages are logged as structured objects rather than concatenated strings.

### Testing
1. Set up an AI Agent (v2.2+) with NVIDIA API endpoint
2. Add an HTTP Request Tool to the agent
3. Execute workflow that triggers tool calling
4. **Before fix**: Fails with 400 error
5. **After fix**: Successfully completes with tool calls

**Example curl to test directly:**
```bash
# ❌ Fails with empty content
curl -X POST "https://<nvidia-endpoint>/v1/chat/completions" \
  -H "Authorization: Bearer <api-key>" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "nvidia/llama-3-3-nemotron-super-49b-v1-5",
    "messages": [
      {
        "role": "assistant",
        "content": "",
        "tool_calls": [
          {
            "id": "test",
            "type": "function",
            "function": {
              "name": "test",
              "arguments": "{}"
            }
          }
        ]
      },
      {
        "role": "tool",
        "content": "result",
        "tool_call_id": "test"
      }
    ]
  }'

# ✅ Works with space in content
curl -X POST "https://<nvidia-endpoint>/v1/chat/completions" \
  -H "Authorization: Bearer <api-key>" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "nvidia/llama-3-3-nemotron-super-49b-v1-5",
    "messages": [
      {
        "role": "assistant",
        "content": " ",
        "tool_calls": [
          {
            "id": "test",
            "type": "function",
            "function": {
              "name": "test",
              "arguments": "{}"
            }
          }
        ]
      },
      {
        "role": "tool",
        "content": "result",
        "tool_call_id": "test"
      }
    ]
  }'
```

### Files Changed
- `packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts` - HTTP-level content fix
- `packages/@n8n/nodes-langchain/nodes/llms/N8nLlmTracing.ts` - Message formatting fix
- `packages/@n8n/nodes-langchain/nodes/llms/N8nNonEstimatingTracing.ts` - Message formatting fix
- `packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/common.ts` - Helper functions
- `packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts` - Apply fix in agent execution
- `packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/execute.ts` - Apply fix in agent execution

## Related Linear tickets, Github issues, and Community forum posts

This fixes compatibility with NVIDIA API and other OpenAI-compatible APIs that have strict content validation.
No existing issue found - discovered during testing with NVIDIA's LLM endpoints.

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created. (May need documentation update for NVIDIA API compatibility)
- [ ] Tests included. (Integration tests recommended for OpenAI-compatible APIs with strict validation)
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

**Note:** This fix maintains backward compatibility with OpenAI's API while adding support for stricter OpenAI-compatible implementations.

