### PR TITLE
fix(AI Agent Node): Only use ai-tool output when reconstructing steps

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/execute.ts
@@ -326,7 +326,7 @@ function buildSteps(
 					toolCallId: toolInput?.id,
 					type: toolInput.type || 'tool_call',
 				},
-				observation: JSON.stringify(tool.data),
+				observation: JSON.stringify(tool.data?.data?.ai_tool?.[0]?.[0]?.json ?? ''),
 			};
 
 			steps.push(toolResult);

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/ToolsAgentV3.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/ToolsAgentV3.test.ts
@@ -540,7 +540,15 @@ describe('toolsAgentExecute V3', () => {
 						actionType: 'ExecutionNodeAction',
 						type: 'ai_tool',
 					},
-					data: [{ json: { result: 'tool result' } }] as any,
+					data: {
+						data: {
+							ai_tool: [[{ json: { result: 'tool result' } }]],
+						},
+						executionTime: 0,
+						startTime: 0,
+						executionIndex: 0,
+						source: [],
+					},
 				},
 			],
 			metadata: { itemIndex: 999, previousRequests: [] }, // Different itemIndex so it doesn't skip
@@ -557,7 +565,7 @@ describe('toolsAgentExecute V3', () => {
 		expect(invokeCall.steps).toBeDefined();
 		expect(invokeCall.steps).toHaveLength(1);
 		expect(invokeCall.steps[0].action.tool).toBe('TestTool');
-		expect(invokeCall.steps[0].observation).toBe('[{"json":{"result":"tool result"}}]');
+		expect(invokeCall.steps[0].observation).toBe('{"result":"tool result"}');
 	});
 
 	it('should handle memory save with tool call context', async () => {
@@ -619,7 +627,15 @@ describe('toolsAgentExecute V3', () => {
 						actionType: 'ExecutionNodeAction' as const,
 						type: 'ai_tool' as const,
 					},
-					data: [{ json: { result: 'tool result' } }] as any,
+					data: {
+						data: {
+							ai_tool: [[{ json: { result: 'tool result' } }]],
+						},
+						executionTime: 0,
+						startTime: 0,
+						executionIndex: 0,
+						source: [],
+					},
 				},
 			],
 			metadata: { itemIndex: 999, previousRequests: [] }, // Different itemIndex so it doesn't skip
@@ -631,7 +647,7 @@ describe('toolsAgentExecute V3', () => {
 			{ input: 'test input' },
 			{
 				output:
-					'[Used tools: Tool: TestTool, Input: "test data", Result: [{"json":{"result":"tool result"}}]] success',
+					'[Used tools: Tool: TestTool, Input: "test data", Result: {"result":"tool result"}] success',
 			},
 		);
 	});


### PR DESCRIPTION
## Summary
Fixes an issue with returning too much data to the LLM after executing a tool in the engine. 
We now only return the actual data not the full TaskData entry. 


## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-1608/agenttoolv3-includes-redundant-information-in-tool-results


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
