### PR TITLE
feat(ai-builder): Properly separate system and user prompts in AI nodes 

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/programmatic/evaluators/agent-prompt.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/programmatic/evaluators/agent-prompt.ts
@@ -1,3 +1,5 @@
+import type { INodeParameters } from 'n8n-workflow';
+
 import type { SimpleWorkflow } from '@/types';
 
 import type { Violation } from '../../types/evaluation';
@@ -6,7 +8,23 @@ import { containsExpression } from '../../utils/expressions';
 import { calcSingleEvaluatorScore } from '../../utils/score';
 
 /**
- * Evaluates Agent nodes to ensure their prompts contain expressions.
+ * Type guard to check if a value is a valid options object with systemMessage
+ */
+function isOptionsWithSystemMessage(
+	value: unknown,
+): value is { systemMessage?: string } & INodeParameters {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		!Array.isArray(value) &&
+		('systemMessage' in value || Object.keys(value).length === 0)
+	);
+}
+
+/**
+ * Evaluates Agent nodes to ensure:
+ * 1. Their prompts contain expressions (for dynamic context)
+ * 2. They have a system message defined
  * Agent nodes without expressions in prompts (e.g., that failed to use chatInput
  * when there was a chat trigger) are most probably errors.
  */
@@ -25,15 +43,33 @@ export function evaluateAgentPrompt(workflow: SimpleWorkflow): SingleEvaluatorRe
 			// Check the text parameter for expressions
 			const textParam = node.parameters?.text;
 			const promptType = node.parameters?.promptType;
+			const options = node.parameters?.options;
+
+			// Use type guard to safely access systemMessage
+			let systemMessage: string | undefined;
+			if (isOptionsWithSystemMessage(options)) {
+				systemMessage = options.systemMessage;
+			}
 
 			// Only check when promptType is 'define' or undefined (default)
 			// 'auto' mode means it uses text from previous node
 			if (promptType !== 'auto') {
+				// Check 1: Text parameter should contain expressions for dynamic context
 				if (!textParam || !containsExpression(textParam)) {
 					violations.push({
 						type: 'minor',
-						description: `Agent node "${node.name}" has no expression in its prompt field. This likely means it failed to use chatInput`,
+						description: `Agent node "${node.name}" has no expression in its prompt field. This likely means it failed to use chatInput or dynamic context`,
 						pointsDeducted: 15,
+					});
+				}
+
+				// Check 2: Agent should have a system message
+				// If systemMessage is missing, it likely means all instructions are in the text field
+				if (!systemMessage || systemMessage.trim().length === 0) {
+					violations.push({
+						type: 'major',
+						description: `Agent node "${node.name}" has no system message. System-level instructions (role, tasks, behavior) should be in the system message field, not the text field`,
+						pointsDeducted: 25,
 					});
 				}
 			}

--- a/packages/@n8n/ai-workflow-builder.ee/src/chains/prompts/parameter-types/system-message.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/chains/prompts/parameter-types/system-message.ts
@@ -1,0 +1,72 @@
+export const SYSTEM_MESSAGE_GUIDE = `
+## CRITICAL: System Message vs User Prompt Separation
+
+AI nodes (AI Agent, LLM Chain, Anthropic, OpenAI, etc.) have TWO distinct prompt fields that MUST be used correctly:
+
+### Field Separation
+1. **System Message** - Model's persistent identity, role, and instructions
+2. **User Message/Text** - Dynamic user context and data references per execution
+
+**Node-specific field names:**
+- AI Agent: \`options.systemMessage\` and \`text\`
+- LLM Chain: \`messages.messageValues[]\` with system role and \`text\`
+- Anthropic: \`options.system\` and \`messages.values[]\`
+- OpenAI: \`messages.values[]\` with role "system" vs "user"
+
+### System Message
+Use for STATIC, ROLE-DEFINING content:
+- Agent identity: "You are a [role] agent..."
+- Task description: "Your task is to..."
+- Step-by-step instructions: "1. Do X, 2. Do Y, 3. Do Z"
+- Behavioral guidelines: "Always...", "Never..."
+- Output format requirements: "Return ONLY...", "Format as..."
+- Tool coordination: "Call the Research Tool to..., then call..."
+
+### Text Parameter
+Use for DYNAMIC, EXECUTION-SPECIFIC content:
+- User input: "={{ $json.chatInput }}"
+- Workflow context: "=The research topic is: {{ $json.topic }}"
+- Data from previous nodes: "=Process this data: {{ $json.data }}"
+- Variable context: "=Analyze for user: {{ $json.userId }}"
+
+### Common Mistakes to Avoid
+
+❌ **WRONG - Everything in text field:**
+{
+  "text": "=You are an orchestrator agent that coordinates specialized agents. Your task is to: 1) Call Research Agent Tool, 2) Call Fact-Check Agent Tool, 3) Generate report. Research topic: {{ $json.researchTopic }}"
+}
+
+✅ **CORRECT - Properly separated:**
+{
+  "text": "=The research topic is: {{ $json.researchTopic }}",
+  "options": {
+    "systemMessage": "You are an orchestrator agent that coordinates specialized agents.\\n\\nYour task is to:\\n1. Call the Research Agent Tool to gather information\\n2. Call the Fact-Check Agent Tool to verify findings\\n3. Generate a comprehensive report\\n\\nReturn ONLY the final report."
+  }
+}
+
+### Update Pattern Examples
+
+Example 1 - AI Agent with orchestration:
+Instructions: [
+  "Set text to '=Research topic: {{ $json.researchTopic }}'",
+  "Set system message to 'You are an orchestrator coordinating research tasks.\\n\\nSteps:\\n1. Call Research Agent Tool\\n2. Call Fact-Check Agent Tool\\n3. Call Report Writer Agent Tool\\n4. Return final HTML report'"
+]
+
+Example 2 - Chat-based AI node:
+Instructions: [
+  "Set text to '=User question: {{ $json.chatInput }}'",
+  "Set system message to 'You are a helpful customer support assistant. Answer questions clearly and professionally. Escalate to human if needed.'"
+]
+
+Example 3 - Data processing with AI:
+Instructions: [
+  "Set text to '=Process this data: {{ $json.inputData }}'",
+  "Set system message to 'You are a data analysis assistant.\\n\\nTasks:\\n1. Validate data structure\\n2. Calculate statistics\\n3. Identify anomalies\\n4. Return JSON with findings'"
+]
+
+### Why This Matters
+- **Consistency**: System message stays the same across executions
+- **Maintainability**: Easy to update AI behavior without touching data flow
+- **Best Practice**: Follows standard AI prompt engineering patterns
+- **Clarity**: Separates "what the AI model is" from "what data to process"
+`;

--- a/packages/@n8n/ai-workflow-builder.ee/src/chains/prompts/parameter-types/system-message.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/chains/prompts/parameter-types/system-message.ts
@@ -19,7 +19,6 @@ Use for STATIC, ROLE-DEFINING content:
 - Task description: "Your task is to..."
 - Step-by-step instructions: "1. Do X, 2. Do Y, 3. Do Z"
 - Behavioral guidelines: "Always...", "Never..."
-- Output format requirements: "Return ONLY...", "Format as..."
 - Tool coordination: "Call the Research Tool to..., then call..."
 
 ### Text Parameter

--- a/packages/@n8n/ai-workflow-builder.ee/src/chains/prompts/prompt-builder.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/chains/prompts/prompt-builder.ts
@@ -1,4 +1,4 @@
-import type { INodeTypeDescription, INodeProperties, INodePropertyCollection } from 'n8n-workflow';
+import type { INodeTypeDescription, INodeProperties } from 'n8n-workflow';
 
 import { COMMON_PATTERNS } from './base/common-patterns';
 import { CORE_INSTRUCTIONS } from './base/core-instructions';
@@ -12,9 +12,9 @@ import { SIMPLE_UPDATE_EXAMPLES } from './examples/basic/simple-updates';
 import { HTTP_REQUEST_GUIDE } from './node-types/http-request';
 import { IF_NODE_GUIDE } from './node-types/if-node';
 import { SET_NODE_GUIDE } from './node-types/set-node';
-import { SYSTEM_MESSAGE_GUIDE } from './parameter-types/system-message';
 import { TOOL_NODES_GUIDE } from './node-types/tool-nodes';
 import { RESOURCE_LOCATOR_GUIDE } from './parameter-types/resource-locator';
+import { SYSTEM_MESSAGE_GUIDE } from './parameter-types/system-message';
 import { TEXT_FIELDS_GUIDE } from './parameter-types/text-fields';
 import {
 	DEFAULT_PROMPT_CONFIG,

--- a/packages/@n8n/ai-workflow-builder.ee/src/chains/prompts/prompt-builder.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/chains/prompts/prompt-builder.ts
@@ -1,4 +1,4 @@
-import type { INodeTypeDescription, INodeProperties } from 'n8n-workflow';
+import type { INodeTypeDescription, INodeProperties, INodePropertyCollection } from 'n8n-workflow';
 
 import { COMMON_PATTERNS } from './base/common-patterns';
 import { CORE_INSTRUCTIONS } from './base/core-instructions';
@@ -92,14 +92,10 @@ export class ParameterUpdatePromptBuilder {
 		const hasSystemMessageParam = nodeDefinition.properties.some((prop) => {
 			// Pattern 1 & 2: options.systemMessage (AI Agent) or options.system (Anthropic)
 			if (prop.name === 'options' && prop.type === 'collection') {
-				// Type-safe check for options
-				interface CollectionProperty {
-					options?: INodeProperties[];
-				}
-				const collectionProp = prop as INodeProperties & CollectionProperty;
+				const collectionProp = prop;
 				if (Array.isArray(collectionProp.options)) {
 					return collectionProp.options.some(
-						(opt: INodeProperties) => opt.name === 'systemMessage' || opt.name === 'system',
+						(opt) => opt.name === 'systemMessage' || opt.name === 'system',
 					);
 				}
 			}

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/prompts/main-agent.prompt.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/prompts/main-agent.prompt.ts
@@ -277,7 +277,21 @@ update_node_parameters({{
   ]
 }})
 
-Example 2 - Chat-based AI node:
+Example 2 - AI Agent Tool (sub-agent):
+update_node_parameters({{
+  nodeId: "subAgentTool",
+  instructions: [
+    "Set text to '=Process this input: {{ $fromAI(\\'input\\') }}'",
+    "Set system message to 'You are a specialized assistant. Process the provided input and return the results in the requested format.'"
+  ]
+}})
+
+CRITICAL: AI Agent Tools MUST have BOTH system message AND text field configured:
+- System message: Define the tool's role and capabilities
+- Text field: Pass the context/input using $fromAI() to receive parameters from the parent agent
+- Never leave text field empty - the tool needs to know what to process
+
+Example 3 - Chat-based AI node:
 update_node_parameters({{
   nodeId: "chatAssistant",
   instructions: [
@@ -286,7 +300,7 @@ update_node_parameters({{
   ]
 }})
 
-Example 3 - Data processing AI:
+Example 4 - Data processing AI:
 update_node_parameters({{
   nodeId: "analysisNode",
   instructions: [

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/prompts/main-agent.prompt.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/prompts/main-agent.prompt.ts
@@ -231,6 +231,76 @@ Configure multiple nodes in parallel:
 - update_node_parameters({{ nodeId: "documentLoader1", instructions: ["Set dataType to 'binary' for processing PDF files", "Set loader to 'pdfLoader'", "Enable splitPages option"] }})
 
 Why: Unconfigured nodes WILL fail at runtime
+
+<system_message_configuration>
+CRITICAL: For AI nodes (AI Agent, LLM Chain, Anthropic, OpenAI, etc.), you MUST separate system-level instructions from user context.
+
+**System Message vs User Prompt:**
+- **System Message** = AI's ROLE, CAPABILITIES, TASK DESCRIPTION, and BEHAVIORAL INSTRUCTIONS
+- **User Message/Text** = DYNAMIC USER INPUT, CONTEXT VARIABLES, and DATA REFERENCES
+
+**Node-specific field names:**
+- AI Agent: system message goes in options.systemMessage, user context in text
+- LLM Chain: system message in messages.messageValues[] with system role, user context in text
+- Anthropic: system message in options.system, user context in messages.values[]
+- OpenAI: system message in messages.values[] with role "system", user in messages.values[] with role "user"
+
+**System Message** should contain:
+- AI identity and role ("You are a...")
+- Task description ("Your task is to...")
+- Step-by-step instructions
+- Behavioral guidelines
+- Expected output format
+- Coordination instructions
+
+**User Message/Text** should contain:
+- Dynamic data from workflow (expressions like {{ $json.field }})
+- User input references ({{ $json.chatInput }})
+- Context variables from previous nodes
+- Minimal instruction (just what varies per execution)
+
+**WRONG - Everything in text/user message field:**
+❌ text: "=You are an orchestrator that coordinates specialized AI tasks. Your task is to: 1) Call Research Tool 2) Call Fact-Check Tool 3) Return HTML. The research topic is: {{ $json.researchTopic }}"
+
+**RIGHT - Properly separated:**
+✅ text: "=The research topic is: {{ $json.researchTopic }}"
+✅ System message: "You are an orchestrator that coordinates specialized AI tasks.\n\nYour task is to:\n1. Call the Research Agent Tool to gather information\n2. Call the Fact-Check Agent Tool to verify findings\n3. Call the Report Writer Agent Tool to create a report\n4. Return ONLY the final result"
+
+**Configuration Examples:**
+
+Example 1 - AI Agent with orchestration:
+update_node_parameters({{
+  nodeId: "orchestratorAgent",
+  instructions: [
+    "Set text to '=The research topic is: {{ $json.researchTopic }}'",
+    "Set system message to 'You are an orchestrator coordinating AI tasks to research topics and generate reports.\\n\\nYour task is to:\\n1. Call the Research Agent Tool to gather information\\n2. Call the Fact-Check Agent Tool to verify findings (require 2+ sources)\\n3. Call the Report Writer Agent Tool to create a report under 1,000 words\\n4. Call the HTML Editor Agent Tool to format as HTML\\n5. Return ONLY the final HTML content'"
+  ]
+}})
+
+Example 2 - Chat-based AI node:
+update_node_parameters({{
+  nodeId: "chatAssistant",
+  instructions: [
+    "Set text to '=User question: {{ $json.chatInput }}'",
+    "Set system message to 'You are a helpful customer service assistant. Answer questions clearly and concisely. If you don\\'t know the answer, say so and offer to escalate to a human.'"
+  ]
+}})
+
+Example 3 - Data processing AI:
+update_node_parameters({{
+  nodeId: "analysisNode",
+  instructions: [
+    "Set text to '=Analyze this data: {{ $json.data }}'",
+    "Set system message to 'You are a data analysis assistant. Examine the provided data and:\\n1. Identify key patterns and trends\\n2. Calculate relevant statistics\\n3. Highlight anomalies or outliers\\n4. Provide actionable insights\\n\\nReturn your analysis in structured JSON format.'"
+  ]
+}})
+
+**Why this matters:**
+- Keeps AI behavior consistent (system message) while allowing dynamic context (user message)
+- Makes workflows more maintainable and reusable
+- Follows AI best practices for prompt engineering
+- Prevents mixing static instructions with dynamic data
+</system_message_configuration>
 </configuration_requirements>
 
 <data_parsing_strategy>


### PR DESCRIPTION
## Summary


The AI workflow builder tends to put all instructions (system-level role definitions, task descriptions, AND dynamic user context) into a single `text`/user message field in AI nodes. This makes prompts:
- Hard to maintain (changing behavior requires editing data references)
- Not reusable (static instructions mixed with dynamic data)
- Against AI prompt engineering best practices

**Example of the problem:**
```json
{
  "text": "=You are an orchestrator agent that coordinates specialized agents. Your task is to: 1) Call Research Agent Tool 2) Call Fact-Check Agent Tool. The research topic is: {{ $json.researchTopic }}"
}
```
## Solution

Implemented guidance and validation to ensure AI nodes properly separate:
- **System Message**: Static role, capabilities, task descriptions, behavioral instructions
- **User Message/Text**: Dynamic user input, context variables, data references

**After the fix:**
```json
{
  "text": "=The research topic is: {{ $json.researchTopic }}",
  "options": {
    "systemMessage": "You are an orchestrator agent that coordinates specialized agents.\n\nYour task is to:\n1. Call the Research Agent Tool to gather information\n2. Call the Fact-Check Agent Tool to verify findings\n3. Call the Report Writer Agent Tool to create a report\n4. Return ONLY the final result"
  }
}
```

Clean separation: static instructions in system message, dynamic data in text field.

## Key Changes

### 1. Multi-Node Support
The solution applies to **all AI nodes with system message support**:
- **AI Agent**: `options.systemMessage` + `text`
- **LLM Chain**: `messages.messageValues[]` (system role) + `text`
- **Anthropic**: `options.system` + `messages.values[]`
- **OpenAI**: `messages.values[]` (role: system vs user)

### 2. Updated Main Agent Prompt
**File**: `packages/@n8n/ai-workflow-builder.ee/src/tools/prompts/main-agent.prompt.ts`

Added `<system_message_configuration>` section with:
- Explanation of system message vs user prompt
- Node-specific field mappings
- Examples showing WRONG vs RIGHT patterns
- **Special emphasis on AI Agent Tools (sub-agents)**: Must configure BOTH system message AND text field with `$fromAI()`

### 3. Generic Detection in Parameter Updater
**File**: `packages/@n8n/ai-workflow-builder.ee/src/chains/prompts/prompt-builder.ts`

Added `hasSystemMessageParameters()` method that detects nodes with system message support by checking for:
- `options.systemMessage` (AI Agent)
- `options.system` (Anthropic)
- `messages` parameter (OpenAI, LLM Chain)

### 4. New Parameter Guide
**File**: `packages/@n8n/ai-workflow-builder.ee/src/chains/prompts/parameter-types/system-message.ts`

Created `SYSTEM_MESSAGE_GUIDE` with:
- Multi-node field mappings
- Practical examples for different use cases
- Guidance for both main agents and sub-agents

### 5. Programmatic Evaluation
**File**: `packages/@n8n/ai-workflow-builder.ee/evaluations/programmatic/evaluators/agent-prompt.ts`

- Enhanced evaluator to flag violations

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
