### PR TITLE
fix(n8n Form Node): From trigger selection

### DIFF
--- a/packages/nodes-base/nodes/Form/Form.node.ts
+++ b/packages/nodes-base/nodes/Form/Form.node.ts
@@ -6,7 +6,6 @@ import type {
 	INodeTypeDescription,
 	IWebhookFunctions,
 	IWebhookResponseData,
-	NodeTypeAndVersion,
 } from 'n8n-workflow';
 import {
 	Node,
@@ -20,7 +19,7 @@ import {
 
 import { cssVariables } from './cssVariables';
 import { renderFormCompletion } from './utils/formCompletionUtils';
-import { renderFormNode } from './utils/formNodeUtils';
+import { getFormTriggerNode, renderFormNode } from './utils/formNodeUtils';
 import { prepareFormReturnItem, resolveRawData } from './utils/utils';
 import { configureWaitTillDate } from '../../utils/sendAndWait/configureWaitTillDate.util';
 import { limitWaitTimeProperties } from '../../utils/sendAndWait/descriptions';
@@ -333,12 +332,9 @@ export class Form extends Node {
 
 		const operation = context.getNodeParameter('operation', '') as string;
 
-		const parentNodes = context.getParentNodes(context.getNode().name);
-		const trigger = parentNodes.find(
-			(node) => node.type === 'n8n-nodes-base.formTrigger',
-		) as NodeTypeAndVersion;
+		const trigger = getFormTriggerNode(context);
 
-		const mode = context.evaluateExpression(`{{ $('${trigger?.name}').first().json.formMode }}`) as
+		const mode = context.evaluateExpression(`{{ $('${trigger.name}').first().json.formMode }}`) as
 			| 'test'
 			| 'production';
 
@@ -379,7 +375,7 @@ export class Form extends Node {
 		}
 
 		let useWorkflowTimezone = context.evaluateExpression(
-			`{{ $('${trigger?.name}').params.options?.useWorkflowTimezone }}`,
+			`{{ $('${trigger.name}').params.options?.useWorkflowTimezone }}`,
 		) as boolean;
 
 		if (useWorkflowTimezone === undefined && trigger?.typeVersion > 2) {

--- a/packages/nodes-base/nodes/Form/utils/formNodeUtils.ts
+++ b/packages/nodes-base/nodes/Form/utils/formNodeUtils.ts
@@ -4,6 +4,8 @@ import {
 	type IWebhookFunctions,
 	type FormFieldsParameter,
 	type IWebhookResponseData,
+	NodeOperationError,
+	FORM_TRIGGER_NODE_TYPE,
 } from 'n8n-workflow';
 
 import { renderForm } from './utils';
@@ -57,3 +59,37 @@ export const renderFormNode = async (
 		noWebhookResponse: true,
 	};
 };
+
+/**
+ * Retrieves the active Form Trigger node from the workflow's parent nodes.
+ *
+ * This function searches through the parent nodes to find Form Trigger nodes,
+ * then determines which one has been executed.
+ *
+ * @returns The NodeTypeAndVersion object representing the active Form Trigger node
+ * @throws {NodeOperationError} When no Form Trigger node is found in parent nodes
+ * @throws {NodeOperationError} When Form Trigger node exists but was not executed
+ */
+export function getFormTriggerNode(context: IWebhookFunctions): NodeTypeAndVersion {
+	const parentNodes = context.getParentNodes(context.getNode().name);
+
+	const formTriggers = parentNodes.filter((node) => node.type === FORM_TRIGGER_NODE_TYPE);
+
+	if (!formTriggers.length) {
+		throw new NodeOperationError(
+			context.getNode(),
+			'Form Trigger node must be set before this node',
+		);
+	}
+
+	for (const trigger of formTriggers) {
+		try {
+			context.evaluateExpression(`{{ $('${trigger.name}').first() }}`);
+		} catch (error) {
+			continue;
+		}
+		return trigger;
+	}
+
+	throw new NodeOperationError(context.getNode(), 'Form Trigger node was not executed');
+}


### PR DESCRIPTION
## Summary

When multiple form triggers exist in the workflow, select the one that has been executed.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-3487/community-issue-form-completion-node-throws-referenced-node-is
closes https://github.com/n8n-io/n8n/issues/18290

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
