### PR TITLE
fix(core): Handle rejected promises from Rudderstack SDK

### DIFF
--- a/packages/cli/src/telemetry/__tests__/telemetry.test.ts
+++ b/packages/cli/src/telemetry/__tests__/telemetry.test.ts
@@ -47,7 +47,15 @@ describe('Telemetry', () => {
 		const postHog = new PostHogClient(instanceSettings, mock());
 		await postHog.init();
 
-		telemetry = new Telemetry(mock(), postHog, mock(), instanceSettings, mock(), globalConfig);
+		telemetry = new Telemetry(
+			mock(),
+			postHog,
+			mock(),
+			instanceSettings,
+			mock(),
+			globalConfig,
+			mock(),
+		);
 		// @ts-expect-error Assigning to private property
 		telemetry.rudderStack = mockRudderStack;
 	});

--- a/packages/cli/src/telemetry/index.ts
+++ b/packages/cli/src/telemetry/index.ts
@@ -10,7 +10,7 @@ import { OnShutdown } from '@n8n/decorators';
 import { Container, Service } from '@n8n/di';
 import type RudderStack from '@rudderstack/rudder-sdk-node';
 import axios from 'axios';
-import { InstanceSettings } from 'n8n-core';
+import { ErrorReporter, InstanceSettings } from 'n8n-core';
 import type { ITelemetryTrackProperties } from 'n8n-workflow';
 
 import { LOWEST_SHUTDOWN_PRIORITY, N8N_VERSION } from '@/constants';
@@ -60,6 +60,7 @@ export class Telemetry {
 		private readonly instanceSettings: InstanceSettings,
 		private readonly workflowRepository: WorkflowRepository,
 		private readonly globalConfig: GlobalConfig,
+		private readonly errorReporter: ErrorReporter,
 	) {}
 
 	async init() {
@@ -86,7 +87,7 @@ export class Telemetry {
 				dataPlaneUrl,
 				gzip: false,
 				errorHandler: (error) => {
-					this.logger.error('Telemetry request failed', { error });
+					this.errorReporter.error(error);
 				},
 			});
 

--- a/packages/cli/src/telemetry/index.ts
+++ b/packages/cli/src/telemetry/index.ts
@@ -85,6 +85,9 @@ export class Telemetry {
 				logLevel,
 				dataPlaneUrl,
 				gzip: false,
+				errorHandler: (error) => {
+					this.logger.error('Telemetry request failed', { error });
+				},
 			});
 
 			this.startPulse();


### PR DESCRIPTION
## Summary

Oversized payloads are rejected with 403 by RS. We should handle rejected promises to allow us to identify the cause more easily. See docs: https://www.rudderstack.com/docs/sources/event-streams/sdks/rudderstack-node-sdk/

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.slack.com/archives/C035KBDA917/p1761214718764199


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
