### PR TITLE
feat(API): Add route to public-api to stop execution

### DIFF
--- a/packages/cli/src/public-api/types.ts
+++ b/packages/cli/src/public-api/types.ts
@@ -35,6 +35,7 @@ export declare namespace ExecutionRequest {
 	type Get = AuthenticatedRequest<{ id: string }, {}, {}, { includeData?: boolean }>;
 	type Delete = Get;
 	type Retry = AuthenticatedRequest<{ id: string }, {}, { loadWorkflow?: boolean }, {}>;
+	type Stop = Retry;
 }
 
 export declare namespace TagRequest {

--- a/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts
@@ -196,9 +196,9 @@ export = {
 		},
 	],
 	stopExecution: [
-		apiKeyHasScope('execution:delete'),
+		apiKeyHasScope('execution:read'),
 		async (req: ExecutionRequest.Stop, res: express.Response): Promise<express.Response> => {
-			const sharedWorkflowsIds = await getSharedWorkflowIds(req.user, ['workflow:delete']);
+			const sharedWorkflowsIds = await getSharedWorkflowIds(req.user, ['workflow:execute']);
 
 			// user does not have workflows hence no executions
 			// or the execution they are trying to access belongs to a workflow they do not own

--- a/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts
@@ -222,9 +222,15 @@ export = {
 				});
 			}
 
-			const result = await Container.get(ExecutionService).stop(id, sharedWorkflowsIds);
+			const stopResult = await Container.get(ExecutionService).stop(id, sharedWorkflowsIds);
+			const updatedExecution = {
+				...execution,
+				status: stopResult.status,
+				finished: stopResult.finished,
+				stoppedAt: stopResult.stoppedAt,
+			};
 
-			return res.json({ result });
+			return res.json(replaceCircularReferences(updatedExecution));
 		},
 	],
 };

--- a/packages/cli/src/public-api/v1/handlers/executions/spec/paths/executions.id.stop.yml
+++ b/packages/cli/src/public-api/v1/handlers/executions/spec/paths/executions.id.stop.yml
@@ -1,0 +1,32 @@
+post:
+  x-eov-operation-id: stopExecution
+  x-eov-operation-handler: v1/handlers/executions/executions.handler
+  tags:
+    - Execution
+  summary: Stop an execution
+  description: Stop an execution from your instance.
+  parameters:
+    - $ref: '../schemas/parameters/executionId.yml'
+  requestBody:
+    required: false
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            loadWorkflow:
+              type: boolean
+              description: Stop the execution with given Id.
+  responses:
+    '200':
+      description: Operation successful.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/execution.yml'
+    '401':
+      $ref: '../../../../shared/spec/responses/unauthorized.yml'
+    '404':
+      $ref: '../../../../shared/spec/responses/notFound.yml'
+    '409':
+      $ref: '../../../../shared/spec/responses/conflict.yml'

--- a/packages/cli/src/public-api/v1/openapi.yml
+++ b/packages/cli/src/public-api/v1/openapi.yml
@@ -50,6 +50,8 @@ paths:
     $ref: './handlers/executions/spec/paths/executions.id.yml'
   /executions/{id}/retry:
     $ref: './handlers/executions/spec/paths/executions.id.retry.yml'
+  /executions/{id}/stop:
+    $ref: './handlers/executions/spec/paths/executions.id.stop.yml'
   /tags:
     $ref: './handlers/tags/spec/paths/tags.yml'
   /tags/{id}:


### PR DESCRIPTION
## Summary

This change adds new route to public REST API to stop running execution: `POST executions/:id/stop`

Tests are absent because of no examples of public api routes tests are present in repository

## Related Linear tickets, Github issues, and Community forum posts

15 upvotes summary in two Community feature request posts 

[Cancel Running Workflow Execution via n8n API](https://community.n8n.io/t/cancel-running-workflow-execution-via-n8n-api/114286)
[N8n API | Stop/cancel execution](https://community.n8n.io/t/n8n-api-stop-cancel-execution/133701)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
