### PR TITLE
fix(editor): Change css priority for CanvasEdge (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/CanvasEdge.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/CanvasEdge.vue
@@ -181,6 +181,8 @@ function onEdgeLabelMouseLeave() {
 	transition:
 		stroke 0.3s ease,
 		fill 0.3s ease;
+	// @bugfix cat-1639-connection-colors-not-rendering-correctly
+	// Using !important here to override BaseEdge styles after Rolldown Vite migration
 	stroke: var(--canvas-edge-color, v-bind(edgeStroke)) !important;
 	stroke-width: calc(2 * var(--canvas-zoom-compensation-factor, 1)) !important;
 	stroke-linecap: square;

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/CanvasEdge.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/CanvasEdge.vue
@@ -181,8 +181,8 @@ function onEdgeLabelMouseLeave() {
 	transition:
 		stroke 0.3s ease,
 		fill 0.3s ease;
-	stroke: var(--canvas-edge-color, v-bind(edgeStroke));
-	stroke-width: calc(2 * var(--canvas-zoom-compensation-factor, 1));
+	stroke: var(--canvas-edge-color, v-bind(edgeStroke)) !important;
+	stroke-width: calc(2 * var(--canvas-zoom-compensation-factor, 1)) !important;
 	stroke-linecap: square;
 }
 


### PR DESCRIPTION
## Summary

Apparently, when importing a Vue component with "side-effects" from an external package, the component's CSS takes priority over the place where it's being used. Unsure whether this is a bug or a feature that showed up after the Rolldown Vite migration.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1639/connection-colors-not-rendering-correctly


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
