### PR TITLE
fix(HTTP Request Node): Fix expression value handling in `url` parameter

### DIFF
--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -185,7 +185,14 @@ export class HttpRequestV3 implements INodeType {
 					nodeCredentialType = this.getNodeParameter('nodeCredentialType', itemIndex) as string;
 				}
 
-				const url = this.getNodeParameter('url', itemIndex) as string;
+				const url = this.getNodeParameter('url', itemIndex);
+
+				if (typeof url !== 'string') {
+					throw new NodeOperationError(
+						this.getNode(),
+						`URL parameter must be a string, got ${typeof url}`,
+					);
+				}
 
 				if (!url.startsWith('http://') && !url.startsWith('https://')) {
 					throw new NodeOperationError(

--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -188,9 +188,10 @@ export class HttpRequestV3 implements INodeType {
 				const url = this.getNodeParameter('url', itemIndex);
 
 				if (typeof url !== 'string') {
+					const actualType = url === null ? 'null' : typeof url;
 					throw new NodeOperationError(
 						this.getNode(),
-						`URL parameter must be a string, got ${typeof url}`,
+						`URL parameter must be a string, got ${actualType}`,
 					);
 				}
 

--- a/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequestV3.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequestV3.test.ts
@@ -231,4 +231,72 @@ describe('HttpRequestV3', () => {
 			},
 		);
 	});
+
+	describe('URL Parameter Validation', () => {
+		it('should throw error when URL is undefined', async () => {
+			(executeFunctions.getInputData as jest.Mock).mockReturnValue([{ json: {} }]);
+			(executeFunctions.getNodeParameter as jest.Mock).mockImplementation((paramName: string) => {
+				switch (paramName) {
+					case 'method':
+						return 'GET';
+					case 'url':
+						return undefined;
+					case 'authentication':
+						return 'none';
+					case 'options':
+						return options;
+					default:
+						return undefined;
+				}
+			});
+
+			await expect(node.execute.call(executeFunctions)).rejects.toThrow(
+				'URL parameter must be a string, got undefined',
+			);
+		});
+
+		it('should throw error when URL is null', async () => {
+			(executeFunctions.getInputData as jest.Mock).mockReturnValue([{ json: {} }]);
+			(executeFunctions.getNodeParameter as jest.Mock).mockImplementation((paramName: string) => {
+				switch (paramName) {
+					case 'method':
+						return 'GET';
+					case 'url':
+						return null;
+					case 'authentication':
+						return 'none';
+					case 'options':
+						return options;
+					default:
+						return undefined;
+				}
+			});
+
+			await expect(node.execute.call(executeFunctions)).rejects.toThrow(
+				'URL parameter must be a string, got object',
+			);
+		});
+
+		it('should throw error when URL is a number', async () => {
+			(executeFunctions.getInputData as jest.Mock).mockReturnValue([{ json: {} }]);
+			(executeFunctions.getNodeParameter as jest.Mock).mockImplementation((paramName: string) => {
+				switch (paramName) {
+					case 'method':
+						return 'GET';
+					case 'url':
+						return 42;
+					case 'authentication':
+						return 'none';
+					case 'options':
+						return options;
+					default:
+						return undefined;
+				}
+			});
+
+			await expect(node.execute.call(executeFunctions)).rejects.toThrow(
+				'URL parameter must be a string, got number',
+			);
+		});
+	});
 });

--- a/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequestV3.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequestV3.test.ts
@@ -273,7 +273,7 @@ describe('HttpRequestV3', () => {
 			});
 
 			await expect(node.execute.call(executeFunctions)).rejects.toThrow(
-				'URL parameter must be a string, got object',
+				'URL parameter must be a string, got null',
 			);
 		});
 


### PR DESCRIPTION
## Summary

> Came across this while building a workflow and found it is a [high frequency issue](https://n8nio.sentry.io/issues/6617359110/?project=4503924908883968) in Sentry.

Param `url` in the HTTPRN v3 is required and defaults to `''` but like most other node params it can be set to an expression that evaluates to virtually anything, so we cannot trust what the node type definition says.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3812

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
