### PR TITLE
fix(editor): Icon picker always on top

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nIconPicker/IconPicker.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nIconPicker/IconPicker.vue
@@ -160,7 +160,7 @@ const togglePopup = () => {
 }
 .popup {
 	position: absolute;
-	z-index: 1;
+	z-index: 9999;
 	width: 426px;
 	max-height: 300px;
 	display: flex;


### PR DESCRIPTION
## Summary

Make sure icon picker always stays on top
[
<img width="902" height="727" alt="Screenshot 2025-10-23 at 21 06 07" src="https://github.com/user-attachments/assets/4f64f179-1eaf-46d5-af80-a16b3ea161c7" />
](url)

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/ADO-4328/project-icon-picker-goes-behind-table-header
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
