### PR TITLE
Fix displayParameterPath undefined handling and Google Calendar Issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+.history/
 .DS_Store
 .tmp
 tmp

--- a/packages/frontend/editor-ui/src/components/ExpressionParameterInput.vue
+++ b/packages/frontend/editor-ui/src/components/ExpressionParameterInput.vue
@@ -47,6 +47,15 @@ const props = withDefaults(defineProps<Props>(), {
 	additionalExpressionData: () => ({}),
 	eventBus: () => createEventBus(),
 });
+const safeValue = (value: unknown) => {
+	if (value == null || value === undefined) return '';
+	if (typeof value === 'string') return value;
+	try {
+		return String(value);
+	} catch {
+		return '';
+	}
+};
 
 const emit = defineEmits<{
 	'modal-opener-click': [];
@@ -105,7 +114,7 @@ function onBlur(event?: FocusEvent | KeyboardEvent) {
 
 		const telemetryPayload = createExpressionTelemetryPayload(
 			segments.value,
-			props.modelValue,
+			safeValue(props.modelValue),
 			workflowsStore.workflowId,
 			ndvStore.pushRef,
 			ndvStore.activeNode?.type ?? '',
@@ -116,10 +125,10 @@ function onBlur(event?: FocusEvent | KeyboardEvent) {
 }
 
 function onValueChange({ value, segments: newSegments }: { value: string; segments: Segment[] }) {
-	segments.value = newSegments;
+	segments.value = Array.isArray(newSegments) ? newSegments : [];
 
 	if (isDragging.value) return;
-	if (value === '=' + props.modelValue) return; // prevent report on change of target item
+	if (value === '=' + safeValue(props.modelValue)) return; // prevent report on change of target item
 
 	emit('update:model-value', value);
 }
@@ -204,7 +213,7 @@ defineExpose({ focus, select });
 				<template #default="{ activeDrop, droppable }">
 					<InlineExpressionEditorInput
 						ref="inlineInput"
-						:model-value="modelValue"
+						:model-value="safeValue(props.modelValue)"
 						:path="path"
 						:is-read-only="isReadOnly"
 						:rows="rows"
@@ -233,7 +242,7 @@ defineExpose({ focus, select });
 		<InlineExpressionEditorOutput
 			ref="outputPopover"
 			:visible="isOutputPopoverVisible"
-			:unresolved-expression="modelValue"
+			:unresolved-expression="safeValue(props.modelValue)"
 			:selection="selection"
 			:editor-state="editorState"
 			:segments="segments"

--- a/packages/frontend/editor-ui/src/composables/useNodeHelpers.ts
+++ b/packages/frontend/editor-ui/src/composables/useNodeHelpers.ts
@@ -171,6 +171,7 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 		const nodeTypeDescription = node?.type
 			? nodeTypesStore.getNodeType(node.type, node.typeVersion)
 			: null;
+		if (!parameter) return false;
 		return NodeHelpers.displayParameterPath(
 			nodeValues,
 			parameter,

--- a/packages/nodes-base/nodes/Google/Calendar/GoogleCalendar.node.ts
+++ b/packages/nodes-base/nodes/Google/Calendar/GoogleCalendar.node.ts
@@ -598,7 +598,11 @@ export class GoogleCalendar implements INodeType {
 						const calendarId = encodeURIComponentOnce(
 							this.getNodeParameter('calendar', i, '', { extractValue: true }) as string,
 						);
-						let eventId = this.getNodeParameter('eventId', i) as string;
+						let eventId = this.getNodeParameter('eventId', i);
+						if (typeof eventId !== 'string') {
+							// Only at runtime, resolve expression to string
+							eventId = this.getNodeParameter('eventId', i, '', { extractValue: true }) as string;
+						}
 
 						if (nodeVersion >= 1.3) {
 							const modifyTarget = this.getNodeParameter('modifyTarget', i, 'instance') as string;

--- a/packages/workflow/src/node-helpers.ts
+++ b/packages/workflow/src/node-helpers.ts
@@ -429,10 +429,12 @@ export function displayParameterPath(
 	}
 
 	// Get the root parameter data
-	let nodeValuesRoot = nodeValues;
-	if (path && path.split('.').indexOf('parameters') === 0) {
-		nodeValuesRoot = get(nodeValues, 'parameters') as INodeParameters;
+	let nodeValuesRoot = nodeValues ?? {};
+	if (path && path.split('.')[0] === 'parameters') {
+		nodeValuesRoot = (get(nodeValues, 'parameters') as INodeParameters) ?? {};
 	}
+
+	if (!parameter) return false;
 
 	return displayParameter(
 		resolvedNodeValues,


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
This PR fixes TypeError: Cannot read properties of undefined errors in the Expression Editor when expressions return undefined.
It modifies NodeHelpers.displayParameterPath and the inline expression editor to safely handle null and undefined values.



## Related Linear tickets, Github issues, and Community forum posts
Fixes:

Fixes #21067

Fixes #21053

Fixes #20781

Fixes #20938

Fixes #21030 and identical Google Calendar freeze issues

These issues were related to the Expression Editor freezing or throwing errors when evaluating certain expressions.
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ✅] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
