### PR TITLE
feat: Only publish provisioning config changes on multi-main

### DIFF
--- a/packages/cli/src/modules/provisioning.ee/__tests__/provisioning.service.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/provisioning.service.ee.test.ts
@@ -18,7 +18,7 @@ import { type ProvisioningConfigDto } from '@n8n/api-types';
 import { type Publisher } from '@/scaling/pubsub/publisher.service';
 import { type ProjectService } from '@/services/project.service.ee';
 import type { EntityManager } from '@n8n/typeorm';
-import { InstanceSettings } from 'n8n-core';
+import { type InstanceSettings } from 'n8n-core';
 
 const globalConfig = mock<GlobalConfig>();
 const settingsRepository = mock<SettingsRepository>();

--- a/packages/cli/src/modules/provisioning.ee/__tests__/provisioning.service.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/provisioning.service.ee.test.ts
@@ -18,6 +18,7 @@ import { type ProvisioningConfigDto } from '@n8n/api-types';
 import { type Publisher } from '@/scaling/pubsub/publisher.service';
 import { type ProjectService } from '@/services/project.service.ee';
 import type { EntityManager } from '@n8n/typeorm';
+import { InstanceSettings } from 'n8n-core';
 
 const globalConfig = mock<GlobalConfig>();
 const settingsRepository = mock<SettingsRepository>();
@@ -29,6 +30,7 @@ const projectService = mock<ProjectService>();
 const logger = mock<Logger>();
 const publisher = mock<Publisher>();
 const roleRepository = mock<RoleRepository>();
+const instanceSettings = mock<InstanceSettings>();
 
 const provisioningService = new ProvisioningService(
 	globalConfig,
@@ -39,6 +41,7 @@ const provisioningService = new ProvisioningService(
 	userRepository,
 	logger,
 	publisher,
+	instanceSettings,
 );
 
 describe('ProvisioningService', () => {
@@ -473,7 +476,8 @@ describe('ProvisioningService', () => {
 	});
 
 	describe('patchConfig', () => {
-		it('should patch the provisioning config, sending out pubsub updates for other nodes to reload', async () => {
+		it('should patch the provisioning config, sending out pubsub updates for other nodes to reload in multi-main setup', async () => {
+			(instanceSettings as any).isMultiMain = true;
 			const originStateLoadConfig = provisioningService.loadConfig;
 			const originStateGetConfig = provisioningService.getConfig;
 

--- a/packages/cli/src/modules/provisioning.ee/provisioning.service.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/provisioning.service.ee.ts
@@ -19,6 +19,7 @@ import { type Publisher } from '@/scaling/pubsub/publisher.service';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ZodError } from 'zod';
 import { ProjectService } from '@/services/project.service.ee';
+import { InstanceSettings } from 'n8n-core';
 
 @Service()
 export class ProvisioningService {
@@ -33,6 +34,7 @@ export class ProvisioningService {
 		private readonly userRepository: UserRepository,
 		private readonly logger: Logger,
 		private readonly publisher: Publisher,
+		private readonly instanceSettings: InstanceSettings,
 	) {}
 
 	async init() {
@@ -282,7 +284,10 @@ export class ProvisioningService {
 
 		this.provisioningConfig = await this.loadConfig();
 
-		await this.publisher.publishCommand({ command: 'reload-sso-provisioning-configuration' });
+		if (this.instanceSettings.isMultiMain) {
+			await this.publisher.publishCommand({ command: 'reload-sso-provisioning-configuration' });
+		}
+
 		return await this.getConfig();
 	}
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR fixes a bug where pub sub was attempted to be called on single main setups where pubsub doesn't exist.

Added a check and fixed the issue, saving provisioning config now succeeds

<img width="1831" height="942" alt="image" src="https://github.com/user-attachments/assets/7749463d-8094-4fb5-b9ff-6db7034d6704" />

To test this, enable provisioning by setting `provisioning: true` in `packages/cli/src/services/frontend.service.ts`, then visit the settings pages > provisioning, and update one of the settings and save.

This feature is only available on enterprise licenses

## Related Linear tickets, Github issues, and Community forum posts

PAY-4023

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
