### PR TITLE
refactor(ai-builder): Use sublime-search utility for nodes search (no-changelog)

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/package.json
+++ b/packages/@n8n/ai-workflow-builder.ee/package.json
@@ -46,6 +46,7 @@
     "@n8n/backend-common": "workspace:^",
     "@n8n/config": "workspace:*",
     "@n8n/di": "workspace:*",
+    "@n8n/utils": "workspace:*",
     "@n8n_io/ai-assistant-sdk": "catalog:",
     "langsmith": "^0.3.45",
     "lodash": "catalog:",

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/engines/node-search-engine.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/engines/node-search-engine.ts
@@ -1,18 +1,24 @@
+import { sublimeSearch } from '@n8n/utils/dist/search/sublimeSearch';
 import type { INodeTypeDescription, NodeConnectionType } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
 
 import type { NodeSearchResult } from '../../types/nodes';
 
 /**
- * Scoring weights for different match types
+ * Search keys configuration for sublimeSearch
+ * Keys are ordered by importance with corresponding weights
+ */
+const NODE_SEARCH_KEYS = [
+	{ key: 'displayName', weight: 1.5 },
+	{ key: 'name', weight: 1.3 },
+	{ key: 'codex.alias', weight: 1.0 },
+	{ key: 'description', weight: 0.7 },
+];
+
+/**
+ * Scoring weights for connection type matching
  */
 export const SCORE_WEIGHTS = {
-	NAME_CONTAINS: 10,
-	DISPLAY_NAME_CONTAINS: 8,
-	DESCRIPTION_CONTAINS: 5,
-	ALIAS_CONTAINS: 8,
-	NAME_EXACT: 20,
-	DISPLAY_NAME_EXACT: 15,
 	CONNECTION_EXACT: 100,
 	CONNECTION_IN_EXPRESSION: 50,
 } as const;
@@ -31,21 +37,24 @@ export class NodeSearchEngine {
 	 * @returns Array of matching nodes sorted by relevance
 	 */
 	searchByName(query: string, limit: number = 20): NodeSearchResult[] {
-		const normalizedQuery = query.toLowerCase();
-		const results: NodeSearchResult[] = [];
+		// Use sublimeSearch for fuzzy matching
+		const searchResults = sublimeSearch<INodeTypeDescription>(
+			query,
+			this.nodeTypes,
+			NODE_SEARCH_KEYS,
+		);
 
-		for (const nodeType of this.nodeTypes) {
-			try {
-				const score = this.calculateNameScore(nodeType, normalizedQuery);
-				if (score > 0) {
-					results.push(this.createSearchResult(nodeType, score));
-				}
-			} catch (error) {
-				// Ignore errors for now
-			}
-		}
-
-		return this.sortAndLimit(results, limit);
+		// Map results to NodeSearchResult format and apply limit
+		return searchResults
+			.slice(0, limit)
+			.map(({ item, score }: { item: INodeTypeDescription; score: number }) => ({
+				name: item.name,
+				displayName: item.displayName,
+				description: item.description ?? 'No description available',
+				inputs: item.inputs,
+				outputs: item.outputs,
+				score,
+			}));
 	}
 
 	/**
@@ -60,29 +69,53 @@ export class NodeSearchEngine {
 		limit: number = 20,
 		nameFilter?: string,
 	): NodeSearchResult[] {
-		const results: NodeSearchResult[] = [];
-		const normalizedFilter = nameFilter?.toLowerCase();
-
-		for (const nodeType of this.nodeTypes) {
-			try {
+		// First, filter by connection type
+		const nodesWithConnectionType = this.nodeTypes
+			.map((nodeType) => {
 				const connectionScore = this.getConnectionScore(nodeType, connectionType);
-				if (connectionScore > 0) {
-					// Apply name filter if provided
-					const nameScore = normalizedFilter
-						? this.calculateNameScore(nodeType, normalizedFilter)
-						: 0;
+				return connectionScore > 0 ? { nodeType, connectionScore } : null;
+			})
+			.filter((result): result is { nodeType: INodeTypeDescription; connectionScore: number } =>
+				Boolean(result),
+			);
 
-					if (!normalizedFilter || nameScore > 0) {
-						const totalScore = connectionScore + nameScore;
-						results.push(this.createSearchResult(nodeType, totalScore));
-					}
-				}
-			} catch (error) {
-				// Ignore errors for now
-			}
+		// If no name filter, return connection matches sorted by score
+		if (!nameFilter) {
+			return nodesWithConnectionType
+				.sort((a, b) => b.connectionScore - a.connectionScore)
+				.slice(0, limit)
+				.map(({ nodeType, connectionScore }) => ({
+					name: nodeType.name,
+					displayName: nodeType.displayName,
+					description: nodeType.description ?? 'No description available',
+					inputs: nodeType.inputs,
+					outputs: nodeType.outputs,
+					score: connectionScore,
+				}));
 		}
 
-		return this.sortAndLimit(results, limit);
+		// Apply name filter using sublimeSearch
+		const nodeTypesOnly = nodesWithConnectionType.map((result) => result.nodeType);
+		const nameFilteredResults = sublimeSearch(nameFilter, nodeTypesOnly, NODE_SEARCH_KEYS);
+
+		// Combine connection score with name score
+		return nameFilteredResults
+			.slice(0, limit)
+			.map(({ item, score: nameScore }: { item: INodeTypeDescription; score: number }) => {
+				const connectionResult = nodesWithConnectionType.find(
+					(result) => result.nodeType.name === item.name,
+				);
+				const connectionScore = connectionResult?.connectionScore ?? 0;
+
+				return {
+					name: item.name,
+					displayName: item.displayName,
+					description: item.description ?? 'No description available',
+					inputs: item.inputs,
+					outputs: item.outputs,
+					score: connectionScore + nameScore,
+				};
+			});
 	}
 
 	/**
@@ -98,46 +131,6 @@ export class NodeSearchEngine {
 			<node_inputs>${typeof result.inputs === 'object' ? JSON.stringify(result.inputs) : result.inputs}</node_inputs>
 			<node_outputs>${typeof result.outputs === 'object' ? JSON.stringify(result.outputs) : result.outputs}</node_outputs>
 		</node>`;
-	}
-
-	/**
-	 * Calculate score based on name matches
-	 * @param nodeType - Node type to score
-	 * @param normalizedQuery - Lowercase search query
-	 * @returns Numeric score
-	 */
-	private calculateNameScore(nodeType: INodeTypeDescription, normalizedQuery: string): number {
-		let score = 0;
-
-		// Check name match
-		if (nodeType.name.toLowerCase().includes(normalizedQuery)) {
-			score += SCORE_WEIGHTS.NAME_CONTAINS;
-		}
-
-		// Check display name match
-		if (nodeType.displayName.toLowerCase().includes(normalizedQuery)) {
-			score += SCORE_WEIGHTS.DISPLAY_NAME_CONTAINS;
-		}
-
-		// Check description match
-		if (nodeType.description?.toLowerCase().includes(normalizedQuery)) {
-			score += SCORE_WEIGHTS.DESCRIPTION_CONTAINS;
-		}
-
-		// Check alias match
-		if (nodeType.codex?.alias?.some((alias) => alias.toLowerCase().includes(normalizedQuery))) {
-			score += SCORE_WEIGHTS.ALIAS_CONTAINS;
-		}
-
-		// Check exact matches (boost score)
-		if (nodeType.name.toLowerCase() === normalizedQuery) {
-			score += SCORE_WEIGHTS.NAME_EXACT;
-		}
-		if (nodeType.displayName.toLowerCase() === normalizedQuery) {
-			score += SCORE_WEIGHTS.DISPLAY_NAME_EXACT;
-		}
-
-		return score;
 	}
 
 	/**
@@ -165,33 +158,6 @@ export class NodeSearchEngine {
 		}
 
 		return 0;
-	}
-
-	/**
-	 * Create a search result object
-	 * @param nodeType - Node type description
-	 * @param score - Calculated score
-	 * @returns Search result object
-	 */
-	private createSearchResult(nodeType: INodeTypeDescription, score: number): NodeSearchResult {
-		return {
-			name: nodeType.name,
-			displayName: nodeType.displayName,
-			description: nodeType.description ?? 'No description available',
-			inputs: nodeType.inputs,
-			outputs: nodeType.outputs,
-			score,
-		};
-	}
-
-	/**
-	 * Sort and limit search results
-	 * @param results - Array of results
-	 * @param limit - Maximum number to return
-	 * @returns Sorted and limited results
-	 */
-	private sortAndLimit(results: NodeSearchResult[], limit: number): NodeSearchResult[] {
-		return results.sort((a, b) => b.score - a.score).slice(0, limit);
 	}
 
 	/**

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/engines/test/node-search-engine.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/engines/test/node-search-engine.test.ts
@@ -76,17 +76,12 @@ describe('NodeSearchEngine', () => {
 		it('should find nodes by exact name match', () => {
 			const results = searchEngine.searchByName('Code');
 
-			expect(results).toHaveLength(1);
+			expect(results.length).toBeGreaterThanOrEqual(1);
+			// First result should be the Code node with highest score
 			expect(results[0].name).toBe('n8n-nodes-base.code');
 			expect(results[0].displayName).toBe('Code');
-			// Should have display name exact match, display name contains, name contains (code is in the name),
-			// and description contains ("Run custom JavaScript code")
-			const expectedScore =
-				SCORE_WEIGHTS.DISPLAY_NAME_EXACT +
-				SCORE_WEIGHTS.DISPLAY_NAME_CONTAINS +
-				SCORE_WEIGHTS.NAME_CONTAINS +
-				SCORE_WEIGHTS.DESCRIPTION_CONTAINS;
-			expect(results[0].score).toBe(expectedScore);
+			// Should have a positive score from sublimeSearch fuzzy matching
+			expect(results[0].score).toBeGreaterThan(0);
 		});
 
 		it('should find nodes by partial name match', () => {
@@ -104,7 +99,7 @@ describe('NodeSearchEngine', () => {
 
 			expect(results).toHaveLength(1);
 			expect(results[0].name).toBe('n8n-nodes-base.code');
-			expect(results[0].score).toBe(SCORE_WEIGHTS.DESCRIPTION_CONTAINS);
+			expect(results[0].score).toBeGreaterThan(0);
 		});
 
 		it('should find nodes by alias match', () => {
@@ -112,7 +107,7 @@ describe('NodeSearchEngine', () => {
 
 			expect(results).toHaveLength(1);
 			expect(results[0].name).toBe('n8n-nodes-base.httpBin');
-			expect(results[0].score).toBeGreaterThanOrEqual(SCORE_WEIGHTS.ALIAS_CONTAINS);
+			expect(results[0].score).toBeGreaterThan(0);
 		});
 
 		it('should handle case-insensitive search', () => {
@@ -144,11 +139,7 @@ describe('NodeSearchEngine', () => {
 
 			// HTTP Request should have highest score (name + display name + description)
 			expect(results[0].name).toBe('n8n-nodes-base.httpRequest');
-			expect(results[0].score).toBe(
-				SCORE_WEIGHTS.NAME_CONTAINS +
-					SCORE_WEIGHTS.DISPLAY_NAME_CONTAINS +
-					SCORE_WEIGHTS.DESCRIPTION_CONTAINS,
-			);
+			expect(results[0].score).toBeGreaterThan(0);
 		});
 
 		it('should handle nodes without description', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -426,6 +426,9 @@ importers:
       '@n8n/di':
         specifier: workspace:*
         version: link:../di
+      '@n8n/utils':
+        specifier: workspace:*
+        version: link:../utils
       '@n8n_io/ai-assistant-sdk':
         specifier: 'catalog:'
         version: 1.17.0
@@ -27614,7 +27617,7 @@ snapshots:
 
   eslint-import-resolver-node@0.3.9:
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
       is-core-module: 2.16.1
       resolve: 1.22.10
     transitivePeerDependencies:
@@ -27638,7 +27641,7 @@ snapshots:
 
   eslint-module-utils@2.12.1(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.3)(eslint@9.29.0(jiti@2.6.1)):
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
     optionalDependencies:
       '@typescript-eslint/parser': 8.35.0(eslint@9.29.0(jiti@2.6.1))(typescript@5.9.2)
       eslint: 9.29.0(jiti@2.6.1)
@@ -27683,7 +27686,7 @@ snapshots:
       array.prototype.findlastindex: 1.2.6
       array.prototype.flat: 1.3.3
       array.prototype.flatmap: 1.3.3
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
       doctrine: 2.1.0
       eslint: 9.29.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
@@ -28691,7 +28694,7 @@ snapshots:
       array-parallel: 0.1.3
       array-series: 0.1.5
       cross-spawn: 7.0.6
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -30698,7 +30701,7 @@ snapshots:
   license-checker@25.0.1:
     dependencies:
       chalk: 2.4.2
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
       mkdirp: 0.5.6
       nopt: 4.0.3
       read-installed: 4.0.3
@@ -32498,7 +32501,7 @@ snapshots:
 
   pdf-parse@1.1.1:
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
       node-ensure: 0.0.0
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
## Summary

Refactor node search tool to use common n8n utility for nodes search. 


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
