### PR TITLE
fix(core): Check all parents of subnodes for expression resolution

### DIFF
--- a/packages/workflow/src/workflow-data-proxy.ts
+++ b/packages/workflow/src/workflow-data-proxy.ts
@@ -1145,15 +1145,16 @@ export class WorkflowDataProxy {
 									const parentMainInputNode = that.workflow.getParentMainInputNode(activeNode);
 									contextNode = parentMainInputNode?.name ?? contextNode;
 								}
-								// Check parent nodes via ALL connection types to handle cases where nodes
-								// are connected via non-main connections (e.g., AiTool, AiMemory)
+								// Check if the node has any children and check parents for them instead of the activeNodeName
 								const children = that.workflow.getChildNodes(that.activeNodeName, 'ALL_NON_MAIN');
 								if (children.length === 0) {
-									const parents = that.workflow.getParentNodes(that.activeNodeName, 'ALL');
+									// Node has no children, check parent of context node
+									const parents = that.workflow.getParentNodes(contextNode);
 									if (!parents.includes(nodeName)) {
 										throw createNoConnectionError(nodeName);
 									}
 								} else {
+									// Node has children, check parent of children
 									const parents = children.flatMap((child) =>
 										that.workflow.getParentNodes(child, 'ALL'),
 									);

--- a/packages/workflow/test/fixtures/WorkflowDataProxy/memory_with_disconnected_tool_run.json
+++ b/packages/workflow/test/fixtures/WorkflowDataProxy/memory_with_disconnected_tool_run.json
@@ -2,7 +2,23 @@
 	"data": {
 		"resultData": {
 			"runData": {
-				"Chat Trigger": [
+				"When clicking 'Execute Workflow'": [
+					{
+						"startTime": 1234567890000,
+						"executionTime": 0,
+						"data": {
+							"main": [
+								[
+									{
+										"json": {}
+									}
+								]
+							]
+						},
+						"source": []
+					}
+				],
+				"Edit Fields1": [
 					{
 						"startTime": 1234567890000,
 						"executionTime": 0,
@@ -11,8 +27,7 @@
 								[
 									{
 										"json": {
-											"sessionId": "test-session-123",
-											"chatInput": "Hello"
+											"sessionId": "test-session-123"
 										}
 									}
 								]
@@ -36,7 +51,7 @@
 						},
 						"source": [
 							{
-								"previousNode": "Chat Trigger"
+								"previousNode": "Edit Fields1"
 							}
 						]
 					}

--- a/packages/workflow/test/fixtures/WorkflowDataProxy/memory_with_disconnected_tool_run.json
+++ b/packages/workflow/test/fixtures/WorkflowDataProxy/memory_with_disconnected_tool_run.json
@@ -1,0 +1,47 @@
+{
+	"data": {
+		"resultData": {
+			"runData": {
+				"Chat Trigger": [
+					{
+						"startTime": 1234567890000,
+						"executionTime": 0,
+						"data": {
+							"main": [
+								[
+									{
+										"json": {
+											"sessionId": "test-session-123",
+											"chatInput": "Hello"
+										}
+									}
+								]
+							]
+						},
+						"source": []
+					}
+				],
+				"Memory Node": [
+					{
+						"startTime": 1234567890001,
+						"executionTime": 0,
+						"data": {
+							"main": [
+								[
+									{
+										"json": {}
+									}
+								]
+							]
+						},
+						"source": [
+							{
+								"previousNode": "Chat Trigger"
+							}
+						]
+					}
+				]
+			}
+		}
+	}
+}

--- a/packages/workflow/test/fixtures/WorkflowDataProxy/memory_with_disconnected_tool_workflow.json
+++ b/packages/workflow/test/fixtures/WorkflowDataProxy/memory_with_disconnected_tool_workflow.json
@@ -1,74 +1,199 @@
 {
-	"name": "Memory node with disconnected agent tool",
+	"name": "My workflow 16",
 	"nodes": [
 		{
 			"parameters": {
-				"options": {}
+				"promptType": "define",
+				"text": "Greet the user",
+				"options": {
+					"maxIterations": 1
+				}
 			},
-			"id": "chat-trigger-node",
-			"name": "Chat Trigger",
-			"type": "n8n-nodes-base.chatTrigger",
-			"typeVersion": 1,
-			"position": [0, 0]
+			"type": "@n8n/n8n-nodes-langchain.agent",
+			"typeVersion": 3,
+			"position": [416, 0],
+			"id": "c26a647a-58b2-4c10-9cc5-ac3ccb6c6219",
+			"name": "AI Agent"
 		},
 		{
 			"parameters": {
+				"model": {
+					"__rl": true,
+					"mode": "list",
+					"value": "gpt-4.1-mini"
+				},
 				"options": {}
 			},
-			"id": "parent-agent-node",
-			"name": "Parent Agent",
-			"type": "@n8n/n8n-nodes-langchain.agent",
-			"typeVersion": 1.8,
-			"position": [280, 0]
+			"type": "@n8n/n8n-nodes-langchain.lmChatOpenAi",
+			"typeVersion": 1.2,
+			"position": [288, 208],
+			"id": "4568addd-cc56-4e40-b462-e8c55383ff92",
+			"name": "OpenAI Chat Model",
+			"credentials": {
+				"openAiApi": {
+					"id": "Zak03cqeLUOsgkFI",
+					"name": "OpenAi account"
+				}
+			}
+		},
+		{
+			"parameters": {
+				"inputSource": "passthrough"
+			},
+			"type": "n8n-nodes-base.executeWorkflowTrigger",
+			"typeVersion": 1.1,
+			"position": [112, -352],
+			"id": "1c26bc07-8091-44ba-98b4-e93020bedb91",
+			"name": "When Executed by Another Workflow"
+		},
+		{
+			"parameters": {
+				"assignments": {
+					"assignments": [
+						{
+							"id": "ce088643-09fc-4cf0-a04a-a82bb973b8c8",
+							"name": "response",
+							"value": "banana",
+							"type": "string"
+						}
+					]
+				},
+				"options": {}
+			},
+			"type": "n8n-nodes-base.set",
+			"typeVersion": 3.4,
+			"position": [320, -352],
+			"id": "77b084e4-68bb-45c2-ae2f-76a67c859bcc",
+			"name": "Edit Fields"
+		},
+		{
+			"parameters": {
+				"text": "={{ /*n8n-auto-generated-fromAI-override*/ $fromAI('Prompt__User_Message_', ``, 'string') }}",
+				"options": {}
+			},
+			"type": "@n8n/n8n-nodes-langchain.agentTool",
+			"typeVersion": 2.2,
+			"position": [992, 160],
+			"id": "2b964f5c-46c7-4e6f-85c2-a3134b3bd223",
+			"name": "AI Agent Tool"
 		},
 		{
 			"parameters": {},
-			"id": "memory-node",
-			"name": "Memory Node",
 			"type": "@n8n/n8n-nodes-langchain.memoryBufferWindow",
 			"typeVersion": 1.3,
-			"position": [280, 200]
+			"position": [560, 320],
+			"id": "6eebeae8-5a25-4a79-8d6d-3fa2cb3fcfa5",
+			"name": "Simple Memory"
 		},
 		{
 			"parameters": {},
-			"id": "disconnected-tool-node",
-			"name": "Disconnected Tool",
-			"type": "@n8n/n8n-nodes-langchain.toolCalculator",
+			"type": "n8n-nodes-base.manualTrigger",
 			"typeVersion": 1,
-			"position": [500, 200]
+			"position": [-144, 0],
+			"id": "e1570d09-e91c-49a2-bd62-24ceb060ecd1",
+			"name": "When clicking ‘Execute workflow’"
+		},
+		{
+			"parameters": {
+				"assignments": {
+					"assignments": [
+						{
+							"id": "b4fca0ed-9032-43ad-8e10-8ca932c9f1a5",
+							"name": "sessionId",
+							"value": "1",
+							"type": "string"
+						}
+					]
+				},
+				"options": {}
+			},
+			"type": "n8n-nodes-base.set",
+			"typeVersion": 3.4,
+			"position": [64, 0],
+			"id": "4d04fe47-6af4-4440-b782-e9d8163f4cfa",
+			"name": "Edit Fields1"
 		}
 	],
+	"pinData": {},
 	"connections": {
-		"Chat Trigger": {
+		"OpenAI Chat Model": {
+			"ai_languageModel": [
+				[
+					{
+						"node": "AI Agent",
+						"type": "ai_languageModel",
+						"index": 0
+					},
+					{
+						"node": "AI Agent Tool",
+						"type": "ai_languageModel",
+						"index": 0
+					}
+				]
+			]
+		},
+		"When Executed by Another Workflow": {
 			"main": [
 				[
 					{
-						"node": "Parent Agent",
+						"node": "Edit Fields",
 						"type": "main",
 						"index": 0
 					}
 				]
 			]
 		},
-		"Memory Node": {
+		"AI Agent Tool": {
+			"ai_tool": [[]]
+		},
+		"Simple Memory": {
 			"ai_memory": [
 				[
 					{
-						"node": "Parent Agent",
+						"node": "AI Agent",
+						"type": "ai_memory",
+						"index": 0
+					},
+					{
+						"node": "AI Agent Tool",
 						"type": "ai_memory",
 						"index": 0
 					}
 				]
-			],
-			"ai_tool": [
+			]
+		},
+		"When clicking ‘Execute workflow’": {
+			"main": [
 				[
 					{
-						"node": "Disconnected Tool",
-						"type": "ai_tool",
+						"node": "Edit Fields1",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Edit Fields1": {
+			"main": [
+				[
+					{
+						"node": "AI Agent",
+						"type": "main",
 						"index": 0
 					}
 				]
 			]
 		}
-	}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "6c8d6680-cdd4-4ed0-b562-16d3b1d7d915",
+	"meta": {
+		"templateCredsSetupCompleted": true,
+		"instanceId": "27cc9b56542ad45b38725555722c50a1c3fee1670bbb67980558314ee08517c4"
+	},
+	"id": "exPkwOsVPRUPnV5V",
+	"tags": []
 }

--- a/packages/workflow/test/fixtures/WorkflowDataProxy/memory_with_disconnected_tool_workflow.json
+++ b/packages/workflow/test/fixtures/WorkflowDataProxy/memory_with_disconnected_tool_workflow.json
@@ -1,0 +1,74 @@
+{
+	"name": "Memory node with disconnected agent tool",
+	"nodes": [
+		{
+			"parameters": {
+				"options": {}
+			},
+			"id": "chat-trigger-node",
+			"name": "Chat Trigger",
+			"type": "n8n-nodes-base.chatTrigger",
+			"typeVersion": 1,
+			"position": [0, 0]
+		},
+		{
+			"parameters": {
+				"options": {}
+			},
+			"id": "parent-agent-node",
+			"name": "Parent Agent",
+			"type": "@n8n/n8n-nodes-langchain.agent",
+			"typeVersion": 1.8,
+			"position": [280, 0]
+		},
+		{
+			"parameters": {},
+			"id": "memory-node",
+			"name": "Memory Node",
+			"type": "@n8n/n8n-nodes-langchain.memoryBufferWindow",
+			"typeVersion": 1.3,
+			"position": [280, 200]
+		},
+		{
+			"parameters": {},
+			"id": "disconnected-tool-node",
+			"name": "Disconnected Tool",
+			"type": "@n8n/n8n-nodes-langchain.toolCalculator",
+			"typeVersion": 1,
+			"position": [500, 200]
+		}
+	],
+	"connections": {
+		"Chat Trigger": {
+			"main": [
+				[
+					{
+						"node": "Parent Agent",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Memory Node": {
+			"ai_memory": [
+				[
+					{
+						"node": "Parent Agent",
+						"type": "ai_memory",
+						"index": 0
+					}
+				]
+			],
+			"ai_tool": [
+				[
+					{
+						"node": "Disconnected Tool",
+						"type": "ai_tool",
+						"index": 0
+					}
+				]
+			]
+		}
+	}
+}

--- a/packages/workflow/test/workflow-data-proxy.test.ts
+++ b/packages/workflow/test/workflow-data-proxy.test.ts
@@ -962,16 +962,11 @@ describe('WorkflowDataProxy', () => {
 			// (via AiMemory) and an agent tool (via AiTool) where the tool is NOT connected
 			// to the parent agent. The memory node should still be able to resolve expressions
 			// that reference the Chat Trigger node.
-			const proxy = getProxyFromFixture(fixture.workflow, fixture.run, 'Memory Node');
+			const proxy = getProxyFromFixture(fixture.workflow, fixture.run, 'Simple Memory');
 
 			// This should not throw "No path back to node" error
-			expect(() => proxy.$('Chat Trigger').first().json.sessionId).not.toThrow();
-			expect(proxy.$('Chat Trigger').first().json.sessionId).toEqual('test-session-123');
-		});
-
-		test('should access chatInput from Chat Trigger', () => {
-			const proxy = getProxyFromFixture(fixture.workflow, fixture.run, 'Memory Node');
-			expect(proxy.$('Chat Trigger').first().json.chatInput).toEqual('Hello');
+			expect(() => proxy.$('Edit Fields1').first().json.sessionId).not.toThrow();
+			expect(proxy.$('Edit Fields1').first().json.sessionId).toEqual('test-session-123');
 		});
 	});
 

--- a/packages/workflow/test/workflow-data-proxy.test.ts
+++ b/packages/workflow/test/workflow-data-proxy.test.ts
@@ -954,6 +954,27 @@ describe('WorkflowDataProxy', () => {
 		});
 	});
 
+	describe('memory node with disconnected tool', () => {
+		const fixture = loadFixture('memory_with_disconnected_tool');
+
+		test('should resolve expressions referencing nodes connected via non-main connections', () => {
+			// This tests the fix for AI-1396: Memory node connected to both a parent agent
+			// (via AiMemory) and an agent tool (via AiTool) where the tool is NOT connected
+			// to the parent agent. The memory node should still be able to resolve expressions
+			// that reference the Chat Trigger node.
+			const proxy = getProxyFromFixture(fixture.workflow, fixture.run, 'Memory Node');
+
+			// This should not throw "No path back to node" error
+			expect(() => proxy.$('Chat Trigger').first().json.sessionId).not.toThrow();
+			expect(proxy.$('Chat Trigger').first().json.sessionId).toEqual('test-session-123');
+		});
+
+		test('should access chatInput from Chat Trigger', () => {
+			const proxy = getProxyFromFixture(fixture.workflow, fixture.run, 'Memory Node');
+			expect(proxy.$('Chat Trigger').first().json.chatInput).toEqual('Hello');
+		});
+	});
+
 	describe('multiple inputs', () => {
 		const fixture = loadFixture('multiple_inputs');
 


### PR DESCRIPTION
## Summary
Fixes a problem in expression resolution that occurs when a memory node has several connected agents and some of them are disconnected to the workflow.
The main problem is a check if a target node is an actual parent of the memory nodes connected agent. Before we only checked the last connected node which ended up to be the disconnected node failing that check. Now we check all connected nodes, 

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-1396/no-path-back-to-node-in-memory-node

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
