### PR TITLE
fix(ai-builder): Clear prompt messages used in langsmith evals (no-changelog)

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/types/langsmith.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/types/langsmith.ts
@@ -1,5 +1,7 @@
 import type { BaseMessage } from '@langchain/core/messages';
 
+import { cleanContextTags } from '@/utils/stream-processor';
+
 import type { SimpleWorkflow } from '../../src/types/workflow';
 import type { AIMessageWithUsageMetadata } from '../../src/utils/token-usage';
 
@@ -121,7 +123,7 @@ export function extractMessageContent(message: BaseMessage | undefined): string 
 	const content = message.content ?? message.kwargs?.content;
 
 	if (typeof content === 'string') {
-		return content;
+		return cleanContextTags(content);
 	}
 
 	if (Array.isArray(content)) {
@@ -129,6 +131,7 @@ export function extractMessageContent(message: BaseMessage | undefined): string 
 		const textContent = content
 			.filter((item) => item?.type === 'text')
 			.map((item) => (item as { text: string }).text)
+			.map(cleanContextTags)
 			.join('\n');
 
 		if (textContent) {

--- a/packages/@n8n/ai-workflow-builder.ee/src/utils/stream-processor.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/utils/stream-processor.ts
@@ -150,7 +150,7 @@ export async function* createStreamProcessor(
  * Remove context tags from message content that are used for AI context
  * but shouldn't be displayed to users
  */
-function cleanContextTags(text: string): string {
+export function cleanContextTags(text: string): string {
 	return text.replace(/\n*<current_workflow_json>[\s\S]*?<\/current_execution_nodes_schemas>/, '');
 }
 


### PR DESCRIPTION
## Summary

After introducing changes to the prompt caching, langsmith traces may contain workflow context data automatically injected into first user message. Thus, after creating a dataset in langsmith out of traces, and running evaluations against this dataset, prompt extraction also contains the injected context. This PR cleans up prompts extracted from langsmith dataset examples, as we need original prompts.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-1564/create-real-life-prompts-evals-dataset


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
