### PR TITLE
fix(editor): Fix `SaveButton` event emission (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/components/SaveButton.test.ts
+++ b/packages/frontend/editor-ui/src/components/SaveButton.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import SaveButton from '@/components/SaveButton.vue';
+import { createComponentRenderer } from '@/__tests__/render';
+import { createTestingPinia } from '@pinia/testing';
+
+vi.mock('@n8n/i18n', async (importActual) => ({
+	...(await importActual()),
+	useI18n: () => ({
+		baseText: (key: string) => key,
+	}),
+}));
+
+// Create the renderer for SaveButton
+const renderComponent = createComponentRenderer(SaveButton);
+
+describe('SaveButton.vue', () => {
+	let pinia: ReturnType<typeof createTestingPinia>;
+
+	beforeEach(() => {
+		pinia = createTestingPinia();
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('Rendering states', () => {
+		it('should render the save button with default props', () => {
+			const { getByTestId, getByRole } = renderComponent({
+				props: {
+					saved: false,
+				},
+				pinia,
+			});
+
+			const container = getByTestId('save-button');
+			expect(container).toBeInTheDocument();
+
+			const button = getByRole('button');
+			expect(button).toBeInTheDocument();
+			expect(button).toHaveTextContent('saveButton.save');
+		});
+
+		it('should render "Saved" text when saved prop is true', () => {
+			const { getByTestId, getByText, queryByRole } = renderComponent({
+				props: {
+					saved: true,
+				},
+				pinia,
+			});
+
+			const container = getByTestId('save-button');
+			expect(container).toBeInTheDocument();
+			expect(getByText('saveButton.saved')).toBeInTheDocument();
+			expect(queryByRole('button')).not.toBeInTheDocument();
+		});
+
+		it('should render saving state when isSaving prop is true', () => {
+			const { getByRole } = renderComponent({
+				props: {
+					saved: false,
+					isSaving: true,
+				},
+				pinia,
+			});
+
+			const button = getByRole('button');
+			expect(button).toBeInTheDocument();
+			expect(button).toHaveTextContent('saveButton.saving');
+		});
+
+		it('should render custom saving label when provided', () => {
+			const customLabel = 'Please wait...';
+			const { getByRole } = renderComponent({
+				props: {
+					saved: false,
+					isSaving: true,
+					savingLabel: customLabel,
+				},
+				pinia,
+			});
+
+			const button = getByRole('button');
+			expect(button).toHaveTextContent(customLabel);
+		});
+
+		it('should render disabled button when disabled prop is true', () => {
+			const { getByRole } = renderComponent({
+				props: {
+					saved: false,
+					disabled: true,
+				},
+				pinia,
+			});
+
+			const button = getByRole('button');
+			expect(button).toBeDisabled();
+		});
+	});
+
+	describe('Button states and interactions', () => {
+		it('should show loading state on button when isSaving is true', () => {
+			const { getByRole } = renderComponent({
+				props: {
+					saved: false,
+					isSaving: true,
+				},
+				pinia,
+			});
+
+			const button = getByRole('button');
+			expect(button).toHaveAttribute('aria-busy', 'true');
+			expect(button).toHaveTextContent('saveButton.saving');
+		});
+
+		it('should not show loading state when isSaving is false', () => {
+			const { getByRole } = renderComponent({
+				props: {
+					saved: false,
+					isSaving: false,
+				},
+				pinia,
+			});
+
+			const button = getByRole('button');
+			expect(button).not.toHaveAttribute('aria-busy', 'true');
+			expect(button).toHaveTextContent('saveButton.save');
+		});
+
+		it('should disable button when disabled is true', () => {
+			const { getByRole } = renderComponent({
+				props: {
+					saved: false,
+					disabled: true,
+					isSaving: false,
+				},
+				pinia,
+			});
+
+			const button = getByRole('button');
+			expect(button).toBeDisabled();
+		});
+
+		it('should handle multiple state changes correctly', async () => {
+			const { getByRole, getByText, queryByRole, rerender } = renderComponent({
+				props: {
+					saved: false,
+					isSaving: false,
+					disabled: false,
+				},
+				pinia,
+			});
+
+			// Initial state - Save button visible
+			let button = getByRole('button');
+			expect(button).toHaveTextContent('saveButton.save');
+			expect(button).not.toBeDisabled();
+
+			// Change to saving state
+			await rerender({
+				saved: false,
+				isSaving: true,
+				disabled: false,
+			});
+			button = getByRole('button');
+			expect(button).toHaveTextContent('saveButton.saving');
+			expect(button).toHaveAttribute('aria-busy', 'true');
+
+			// Change to saved state
+			await rerender({
+				saved: true,
+				isSaving: false,
+				disabled: false,
+			});
+			expect(getByText('saveButton.saved')).toBeInTheDocument();
+			expect(queryByRole('button')).not.toBeInTheDocument();
+
+			// Back to initial state
+			await rerender({
+				saved: false,
+				isSaving: false,
+				disabled: false,
+			});
+			button = getByRole('button');
+			expect(button).toHaveTextContent('saveButton.save');
+			expect(button).not.toBeDisabled();
+		});
+
+		it('should emit click event when button is clicked', async () => {
+			const user = userEvent.setup();
+			const { getByRole, emitted } = renderComponent({
+				props: {
+					saved: false,
+				},
+				pinia,
+			});
+
+			const button = getByRole('button');
+			await user.click(button);
+
+			expect(emitted()).toHaveProperty('click');
+			expect(emitted().click).toHaveLength(1);
+		});
+
+		it('should not emit click event when button is disabled', async () => {
+			const user = userEvent.setup();
+			const { getByRole, emitted } = renderComponent({
+				props: {
+					saved: false,
+					disabled: true,
+				},
+				pinia,
+			});
+
+			const button = getByRole('button');
+			await user.click(button);
+
+			expect(emitted()).not.toHaveProperty('click');
+		});
+	});
+
+	describe('Click prevention on saved state', () => {
+		it('should prevent click propagation when showing saved text', async () => {
+			const user = userEvent.setup();
+			const { getByText } = renderComponent({
+				props: {
+					saved: true,
+				},
+				pinia,
+			});
+
+			const savedText = getByText('saveButton.saved');
+			await user.click(savedText);
+
+			// The click should be prevented by @click.stop.prevent
+			// Testing that the element is still in the document after click
+			expect(savedText).toBeInTheDocument();
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/components/SaveButton.test.ts
+++ b/packages/frontend/editor-ui/src/components/SaveButton.test.ts
@@ -223,7 +223,7 @@ describe('SaveButton.vue', () => {
 	describe('Click prevention on saved state', () => {
 		it('should prevent click propagation when showing saved text', async () => {
 			const user = userEvent.setup();
-			const { getByText } = renderComponent({
+			const { getByText, emitted } = renderComponent({
 				props: {
 					saved: true,
 				},
@@ -233,9 +233,10 @@ describe('SaveButton.vue', () => {
 			const savedText = getByText('saveButton.saved');
 			await user.click(savedText);
 
-			// The click should be prevented by @click.stop.prevent
-			// Testing that the element is still in the document after click
 			expect(savedText).toBeInTheDocument();
+
+			// The click should be prevented by @click.stop.prevent
+			expect(emitted()).not.toHaveProperty('click');
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/components/SaveButton.vue
+++ b/packages/frontend/editor-ui/src/components/SaveButton.vue
@@ -38,7 +38,9 @@ const shortcutTooltipLabel = computed(() => {
 
 <template>
 	<span :class="$style.container" data-test-id="save-button">
-		<span v-if="saved" :class="$style.saved">{{ i18n.baseText('saveButton.saved') }}</span>
+		<span v-if="saved" :class="$style.saved" @click.prevent.stop>{{
+			i18n.baseText('saveButton.saved')
+		}}</span>
 		<template v-else>
 			<KeyboardShortcutTooltip
 				v-if="withShortcut"


### PR DESCRIPTION
## Summary

Before: You were able to click the "Saved" text, emitting an onSave event every time.
After: You cannot click the "Saved" text to trigger an event

Also added tests for the Button itself and the behavior.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1641/clicking-save-button-when-disabled-can-toggle-activation-switch


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
