### PR TITLE
fix(editor): Fix newly introduced style issues after `rolldown-vite` migration (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.vue
@@ -1076,18 +1076,6 @@ defineExpose({
 		opacity: 1;
 	}
 
-	:global(.vue-flow__pane) {
-		cursor: grab;
-
-		&:global(.selection) {
-			cursor: default;
-		}
-
-		&:global(.dragging) {
-			cursor: grabbing;
-		}
-	}
-
 	&.isExperimentalNdvActive {
 		--canvas-zoom-compensation-factor: 0.5;
 	}

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/buttons/CanvasControlButtons.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/buttons/CanvasControlButtons.vue
@@ -171,11 +171,3 @@ function onTidyUp() {
 	}
 }
 </style>
-
-<style lang="scss">
-.vue-flow__controls {
-	display: flex;
-	gap: var(--spacing--xs);
-	box-shadow: none;
-}
-</style>

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/handles/render-types/CanvasHandleNonMainOutput.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/handles/render-types/CanvasHandleNonMainOutput.vue
@@ -45,9 +45,4 @@ const classes = computed(() => ({
 	content: '*';
 	color: var(--color--danger);
 }
-
-:global(.vue-flow__handle:not(.connectionindicator)) .plus {
-	display: none;
-	position: absolute;
-}
 </style>

--- a/packages/frontend/editor-ui/src/styles/plugins/_vueflow.scss
+++ b/packages/frontend/editor-ui/src/styles/plugins/_vueflow.scss
@@ -93,6 +93,17 @@
 }
 
 /**
+ * Handles
+ */
+
+.vue-flow__handle {
+	&:not(.connectionindicator) .plus {
+		display: none;
+		position: absolute;
+	}
+}
+
+/**
  * Selection
  */
 
@@ -113,11 +124,30 @@
 }
 
 /**
+ * Pane
+ */
+
+.vue-flow__pane {
+	cursor: grab;
+
+	&.selection {
+		cursor: default;
+	}
+
+	&.dragging {
+		cursor: grabbing;
+	}
+}
+
+/**
  * Controls
  */
 
 .vue-flow__controls {
 	margin: var(--spacing--sm);
+	display: flex;
+	gap: var(--spacing--xs);
+	box-shadow: none;
 
 	@include mixins.breakpoint('xs-only') {
 		max-width: calc(100% - 3 * var(--spacing--sm) - var(--spacing--2xs));


### PR DESCRIPTION
## Summary

Moved all relevant vueflow styles to be overriden in `_vueflow.scss`.

**Context:**
Apparently, when importing a Vue component with "side-effects" from an external package, the component's CSS takes priority over the place where it's being used. Unsure whether this is a bug or a feature that showed up after the Rolldown Vite migration.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1655/unexpected-box-shadow-around-canvas-controls


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
