### PR TITLE
docs: Fix API docs for credential transfer

### DIFF
--- a/packages/cli/src/public-api/v1/handlers/credentials/spec/paths/credentials.id.transfer.yml
+++ b/packages/cli/src/public-api/v1/handlers/credentials/spec/paths/credentials.id.transfer.yml
@@ -2,7 +2,7 @@ put:
   x-eov-operation-id: transferCredential
   x-eov-operation-handler: v1/handlers/credentials/credentials.handler
   tags:
-    - Workflow
+    - Credential
   summary: Transfer a credential to another project.
   description: Transfer a credential to another project.
   parameters:

--- a/packages/cli/src/public-api/v1/openapi.yml
+++ b/packages/cli/src/public-api/v1/openapi.yml
@@ -44,6 +44,8 @@ paths:
     $ref: './handlers/credentials/spec/paths/credentials.id.yml'
   /credentials/schema/{credentialTypeName}:
     $ref: './handlers/credentials/spec/paths/credentials.schema.id.yml'
+  /credentials/{id}/transfer:
+    $ref: './handlers/credentials/spec/paths/credentials.id.transfer.yml'
   /executions:
     $ref: './handlers/executions/spec/paths/executions.yml'
   /executions/{id}:
@@ -64,8 +66,6 @@ paths:
     $ref: './handlers/workflows/spec/paths/workflows.id.deactivate.yml'
   /workflows/{id}/transfer:
     $ref: './handlers/workflows/spec/paths/workflows.id.transfer.yml'
-  /credentials/{id}/transfer:
-    $ref: './handlers/credentials/spec/paths/credentials.id.transfer.yml'
   /workflows/{id}/tags:
     $ref: './handlers/workflows/spec/paths/workflows.id.tags.yml'
   /users:


### PR DESCRIPTION
## Summary

This PR fixes the API docs for `/credentials/{id}/transfer`. It was incorrectly tagged and appears in `/workflows` section.

## Related Linear tickets, Github issues, and Community forum posts

PAY-3880

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- ~[ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- ~[ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->~
- ~[ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
