### PR TITLE
fix(DateRangePicker): Add type annotation for slots in DateRangePick (issue #21187)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/DateRangePicker/DateRangePicker.vue
+++ b/packages/frontend/@n8n/design-system/src/components/DateRangePicker/DateRangePicker.vue
@@ -17,7 +17,7 @@ import {
 	DateRangePickerTrigger,
 	useForwardPropsEmits,
 } from 'reka-ui';
-import { useSlots } from 'vue';
+import { useSlots, type Slots } from 'vue';
 
 import Button from '../N8nButton/Button.vue';
 import IconButton from '../N8nIconButton';
@@ -33,7 +33,7 @@ const props = withDefaults(defineProps<N8nDateRangePickerProps>(), {
 
 const emit = defineEmits<N8nDateRangePickerRootEmits>();
 const forwarded = useForwardPropsEmits(props, emit);
-const slots = useSlots();
+const slots: Slots = useSlots();
 </script>
 
 <template>


### PR DESCRIPTION
This pull request makes a minor type safety improvement to the `DateRangePicker` component by explicitly typing the `slots` variable as `Slots` from Vue. This helps with better type inference and IDE support when working with slots in the component.