### PR TITLE
Chat memory cleanup

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryBufferWindow/MemoryBufferWindow.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryBufferWindow/MemoryBufferWindow.node.ts
@@ -61,13 +61,12 @@ class MemoryChatBufferSingleton {
 	}
 
 	private async cleanupStaleBuffers(): Promise<void> {
-		// Clean up buffers that haven't been accessed in the last 30 seconds
-		// This aggressive cleanup ensures that when users refresh/reset their chat,
-		// they get a fresh session almost immediately without needing to wait
-		const thirtySecondsAgo = new Date(Date.now() - 30 * 1000);
+		// Clean up buffers that haven't been accessed in the last 5 minutes
+		// This balances session cleanup with supporting active conversations where users may pause
+		const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000);
 
 		for (const [key, memoryInstance] of this.memoryBuffer.entries()) {
-			if (memoryInstance.last_accessed < thirtySecondsAgo) {
+			if (memoryInstance.last_accessed < fiveMinutesAgo) {
 				await this.memoryBuffer.get(key)?.buffer.clear();
 				this.memoryBuffer.delete(key);
 			}

--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryBufferWindow/MemoryBufferWindow.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryBufferWindow/MemoryBufferWindow.node.ts
@@ -61,10 +61,13 @@ class MemoryChatBufferSingleton {
 	}
 
 	private async cleanupStaleBuffers(): Promise<void> {
-		const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+		// Clean up buffers that haven't been accessed in the last 30 seconds
+		// This aggressive cleanup ensures that when users refresh/reset their chat,
+		// they get a fresh session almost immediately without needing to wait
+		const thirtySecondsAgo = new Date(Date.now() - 30 * 1000);
 
 		for (const [key, memoryInstance] of this.memoryBuffer.entries()) {
-			if (memoryInstance.last_accessed < oneHourAgo) {
+			if (memoryInstance.last_accessed < thirtySecondsAgo) {
 				await this.memoryBuffer.get(key)?.buffer.clear();
 				this.memoryBuffer.delete(key);
 			}

--- a/packages/frontend/@n8n/design-system/src/components/DateRangePicker/DateRangePicker.vue
+++ b/packages/frontend/@n8n/design-system/src/components/DateRangePicker/DateRangePicker.vue
@@ -17,7 +17,7 @@ import {
 	DateRangePickerTrigger,
 	useForwardPropsEmits,
 } from 'reka-ui';
-import { useSlots } from 'vue';
+import { useSlots, type Slots } from 'vue';
 
 import Button from '../N8nButton/Button.vue';
 import IconButton from '../N8nIconButton';
@@ -33,7 +33,7 @@ const props = withDefaults(defineProps<N8nDateRangePickerProps>(), {
 
 const emit = defineEmits<N8nDateRangePickerRootEmits>();
 const forwarded = useForwardPropsEmits(props, emit);
-const slots = useSlots();
+const slots: Slots = useSlots();
 </script>
 
 <template>


### PR DESCRIPTION
#### **Fix Memory Node Session Persistence Issue** #21186

#**Description**

This PR fixes a bug where the Memory node (Simple Memory) was keeping old conversation data after users refreshed or reset their chat sessions. Users were seeing their AI respond with context from previous conversations even after starting a new session.

#**The Problem**

The Memory node uses a singleton pattern to cache conversation buffers. These buffers were being kept in memory for 1 hour before cleanup. When users clicked "refresh" in the chat UI and started a new conversation, the old buffer was still there and got reused, causing the LLM to have access to messages from the previous session.

#**What Changed**

Changed the cleanup threshold in [MemoryBufferWindow.node.ts](vscode-file://vscode-app/c:/Users/akcho/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) from 1 hour to 5 minutes.

Before:

`const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);`
After:

`const thirtySecondsAgo = new Date(Date.now() - 5*60 * 1000);`

**#Why 5 Minutes**
When a user refreshes their chat session and takes a break, the old memory is cleaned up within a reasonable timeframe
Active conversations where users pause to think or type longer responses (up to 5 minutes) still work normally
Balances cleanup of stale sessions with real-world conversation patterns where users may need time to compose thoughtful responses
Prevents memory buildup from abandoned sessions while protecting legitimate active conversations


Build passes successfully with no errors.
