### PR TITLE
feat(HTTP Request Node): Send and Wait support

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.ts
@@ -491,6 +491,11 @@ export function useCanvasMapping({
 						return acc;
 					}
 
+					if (node?.parameters.sendAndWaitMode) {
+						acc[node.id] = i18n.baseText('node.theNodeIsWaitingUserInput');
+						return acc;
+					}
+
 					if (node?.type === FORM_NODE_TYPE) {
 						acc[node.id] = i18n.baseText('node.theNodeIsWaitingFormCall');
 						return acc;

--- a/packages/frontend/editor-ui/src/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/stores/workflows.store.ts
@@ -199,6 +199,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		return (
 			(node.type === WAIT_NODE_TYPE ||
 				node.type === FORM_NODE_TYPE ||
+				node.parameters?.sendAndWaitMode === true ||
 				node.parameters?.operation === SEND_AND_WAIT_OPERATION) &&
 			node.disabled !== true
 		);

--- a/packages/frontend/editor-ui/src/utils/nodeViewUtils.ts
+++ b/packages/frontend/editor-ui/src/utils/nodeViewUtils.ts
@@ -432,7 +432,11 @@ export function getGenericHints({
 	}
 
 	// add sendAndWait hint
-	if (hasMultipleInputItems && workflowNode.parameters.operation === SEND_AND_WAIT_OPERATION) {
+	if (
+		hasMultipleInputItems &&
+		(workflowNode.parameters.operation === SEND_AND_WAIT_OPERATION ||
+			workflowNode.parameters.sendAndWaitMode)
+	) {
 		const executeOnce = workflowUtils.getNodeByName(nodes, node.name)?.executeOnce;
 		if (!executeOnce) {
 			nodeHints.push({

--- a/packages/nodes-base/nodes/HttpRequest/V3/Description.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/Description.ts
@@ -8,6 +8,8 @@ const sendAndWaitProperties: INodeProperties[] = getSendAndWaitProperties(
 	undefined,
 	undefined,
 	{
+		noButtonStyle: true,
+		noUiOptions: true,
 		displayOptions: {
 			show: {
 				sendAndWaitMode: [true],

--- a/packages/nodes-base/nodes/HttpRequest/V3/Description.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/Description.ts
@@ -1,6 +1,20 @@
-import type { INodeProperties } from 'n8n-workflow';
+import { type INodeProperties } from 'n8n-workflow';
 
 import { optimizeResponseProperties } from '../shared/optimizeResponse';
+import { getSendAndWaitProperties } from '../../../utils/sendAndWait/utils';
+
+const sendAndWaitProperties: INodeProperties[] = getSendAndWaitProperties(
+	[],
+	undefined,
+	undefined,
+	{
+		displayOptions: {
+			show: {
+				sendAndWaitMode: [true],
+			},
+		},
+	},
+).filter((p) => !['subject', 'message'].includes(p.name));
 
 const preBuiltAgentsCallout: INodeProperties = {
 	// eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased
@@ -162,6 +176,30 @@ export const mainProperties: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				provideSslCertificates: [true],
+			},
+		},
+	},
+	{
+		displayName: 'Send and Wait for Response',
+		name: 'sendAndWaitMode',
+		type: 'boolean',
+		default: false,
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				method: ['POST', 'PUT', 'PATCH'],
+			},
+		},
+	},
+	{
+		displayName:
+			'Use <strong>{n8n_send_and_wait_url}</strong> placeholder to indicate where the waiting <em>url</em> should be inserted in your request <em>body</em><br>In case <em>Approve adn Disprove</em> approval type is selected you will also need to insert <strong>{n8n_send_and_wait_decline_url}</strong><br>Lear more about how <em>Send and Wait</em> works <a href="https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.wait" target="_blank">here</a>',
+		name: 'sendAndWaitNotice',
+		type: 'notice',
+		default: '',
+		displayOptions: {
+			show: {
+				sendAndWaitMode: [true],
 			},
 		},
 	},
@@ -663,6 +701,7 @@ export const mainProperties: INodeProperties[] = [
 		default: '',
 		placeholder: '',
 	},
+	...sendAndWaitProperties,
 	{
 		displayName: 'Options',
 		name: 'options',
@@ -1185,12 +1224,20 @@ export const mainProperties: INodeProperties[] = [
 					'Time in ms to wait for the server to send response headers (and start the response body) before aborting the request',
 			},
 		],
+		displayOptions: {
+			hide: {
+				sendAndWaitMode: [true],
+			},
+		},
 	},
 	...optimizeResponseProperties.map((prop) => ({
 		...prop,
 		displayOptions: {
 			...prop.displayOptions,
 			show: { ...prop.displayOptions?.show, '@tool': [true] },
+			hide: {
+				sendAndWaitMode: [true],
+			},
 		},
 	})),
 	{

--- a/packages/nodes-base/nodes/HttpRequest/V3/Description.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/Description.ts
@@ -195,7 +195,7 @@ export const mainProperties: INodeProperties[] = [
 	},
 	{
 		displayName:
-			'Use <strong>{n8n_send_and_wait_url}</strong> placeholder to indicate where the waiting <em>url</em> should be inserted in your request <em>body</em><br>In case <em>Approve adn Disprove</em> approval type is selected you will also need to insert <strong>{n8n_send_and_wait_decline_url}</strong><br>Lear more about how <em>Send and Wait</em> works <a href="https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.wait" target="_blank">here</a>',
+			'Use <strong>{n8n_send_and_wait_url}</strong> placeholder to indicate where the waiting <em>URL</em> should be inserted in your request <em>body</em>.<br>In case the <em>Approve and Disapprove</em> approval type is selected, you will also need to insert <strong>{n8n_send_and_wait_decline_url}</strong>.<br>Learn more about how <em>Send and Wait</em> works <a href="https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.wait" target="_blank">here</a>.',
 		name: 'sendAndWaitNotice',
 		type: 'notice',
 		default: '',

--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -866,7 +866,7 @@ export class HttpRequestV3 implements INodeType {
 		);
 
 		let responseData: any;
-		for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
+		for (let itemIndex = 0; itemIndex < itemsLength; itemIndex++) {
 			try {
 				responseData = promisesResponses.shift();
 

--- a/packages/nodes-base/utils/sendAndWait/utils.ts
+++ b/packages/nodes-base/utils/sendAndWait/utils.ts
@@ -65,15 +65,6 @@ const limitWaitTimeOption: INodeProperties = {
 	],
 };
 
-const appendAttributionOption: INodeProperties = {
-	displayName: 'Append n8n Attribution',
-	name: 'appendAttribution',
-	type: 'boolean',
-	default: true,
-	description:
-		'Whether to include the phrase "This message was sent automatically with n8n" to the end of the message',
-};
-
 // Operation Properties ----------------------------------------------------------
 export function getSendAndWaitProperties(
 	targetProperties: INodeProperties[],
@@ -81,11 +72,20 @@ export function getSendAndWaitProperties(
 	additionalProperties: INodeProperties[] = [],
 	options?: {
 		noButtonStyle?: boolean;
+		noUiOptions?: boolean;
 		defaultApproveLabel?: string;
 		defaultDisapproveLabel?: string;
 		displayOptions?: IDisplayOptions;
 	},
 ) {
+	const appendAttributionOption: INodeProperties = {
+		displayName: 'Append n8n Attribution',
+		name: 'appendAttribution',
+		type: options?.noUiOptions ? 'hidden' : 'boolean',
+		default: true,
+		description:
+			'Whether to include the phrase "This message was sent automatically with n8n" to the end of the message',
+	};
 	const buttonStyle: INodeProperties = {
 		displayName: 'Button Style',
 		name: 'buttonStyle',
@@ -120,17 +120,21 @@ export function getSendAndWaitProperties(
 				},
 			],
 		},
-		{
-			displayName: 'Approve Button Label',
-			name: 'approveLabel',
-			type: 'string',
-			default: options?.defaultApproveLabel || 'Approve',
-			displayOptions: {
-				show: {
-					approvalType: ['single', 'double'],
-				},
-			},
-		},
+		...[
+			options?.noUiOptions
+				? ({} as INodeProperties)
+				: {
+						displayName: 'Approve Button Label',
+						name: 'approveLabel',
+						type: 'string',
+						default: options?.defaultApproveLabel || 'Approve',
+						displayOptions: {
+							show: {
+								approvalType: ['single', 'double'],
+							},
+						},
+					},
+		],
 		...[
 			options?.noButtonStyle
 				? ({} as INodeProperties)
@@ -145,17 +149,21 @@ export function getSendAndWaitProperties(
 						},
 					},
 		],
-		{
-			displayName: 'Disapprove Button Label',
-			name: 'disapproveLabel',
-			type: 'string',
-			default: options?.defaultDisapproveLabel || 'Decline',
-			displayOptions: {
-				show: {
-					approvalType: ['double'],
-				},
-			},
-		},
+		...[
+			options?.noUiOptions
+				? ({} as INodeProperties)
+				: {
+						displayName: 'Disapprove Button Label',
+						name: 'disapproveLabel',
+						type: 'string',
+						default: options?.defaultDisapproveLabel || 'Decline',
+						displayOptions: {
+							show: {
+								approvalType: ['double'],
+							},
+						},
+					},
+		],
 		...[
 			options?.noButtonStyle
 				? ({} as INodeProperties)
@@ -267,7 +275,7 @@ export function getSendAndWaitProperties(
 				{
 					displayName: 'Message Button Label',
 					name: 'messageButtonLabel',
-					type: 'string',
+					type: options?.noUiOptions ? 'hidden' : 'string',
 					default: 'Respond',
 				},
 				{

--- a/packages/nodes-base/utils/sendAndWait/utils.ts
+++ b/packages/nodes-base/utils/sendAndWait/utils.ts
@@ -11,6 +11,7 @@ import type {
 	IWebhookFunctions,
 	IDataObject,
 	FormFieldsParameter,
+	IDisplayOptions,
 } from 'n8n-workflow';
 
 import { limitWaitTimeProperties } from './descriptions';
@@ -82,6 +83,7 @@ export function getSendAndWaitProperties(
 		noButtonStyle?: boolean;
 		defaultApproveLabel?: string;
 		defaultDisapproveLabel?: string;
+		displayOptions?: IDisplayOptions;
 	},
 ) {
 	const buttonStyle: INodeProperties = {
@@ -312,7 +314,7 @@ export function getSendAndWaitProperties(
 	];
 
 	return updateDisplayOptions(
-		{
+		options?.displayOptions ?? {
 			show: {
 				resource: [resource],
 				operation: [SEND_AND_WAIT_OPERATION],


### PR DESCRIPTION
## Summary

This PR adds an option for HTTP Request node when POST, PUT, PATCH method is selected
This will allow users to use Send and Wait functionality with arbitrary service

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-3819/http-request-send-and-wait-support

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
