### PR TITLE
feat(core): Make multiple replies to a single message work (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/chat-hub.ts
+++ b/packages/@n8n/api-types/src/chat-hub.ts
@@ -1,3 +1,4 @@
+import type { StructuredChunk } from 'n8n-workflow';
 import { z } from 'zod';
 import { Z } from 'zod-class';
 
@@ -94,7 +95,6 @@ export type ChatModelsResponse = Record<
 export class ChatHubSendMessageRequest extends Z.class({
 	messageId: z.string().uuid(),
 	sessionId: z.string().uuid(),
-	replyId: z.string().uuid(),
 	message: z.string(),
 	model: chatHubConversationModelSchema,
 	previousMessageId: z.string().uuid().nullable(),
@@ -107,7 +107,6 @@ export class ChatHubSendMessageRequest extends Z.class({
 }) {}
 
 export class ChatHubRegenerateMessageRequest extends Z.class({
-	replyId: z.string().uuid(),
 	model: chatHubConversationModelSchema,
 	credentials: z.record(
 		z.object({
@@ -120,7 +119,6 @@ export class ChatHubRegenerateMessageRequest extends Z.class({
 export class ChatHubEditMessageRequest extends Z.class({
 	message: z.string(),
 	messageId: z.string().uuid(),
-	replyId: z.string().uuid(),
 	model: chatHubConversationModelSchema,
 	credentials: z.record(
 		z.object({
@@ -222,3 +220,11 @@ export class ChatHubUpdateAgentRequest extends Z.class({
 	provider: chatHubProviderSchema.optional(),
 	model: z.string().max(64).optional(),
 }) {}
+
+export interface EnrichedStructuredChunk extends StructuredChunk {
+	metadata: StructuredChunk['metadata'] & {
+		messageId: ChatMessageId;
+		previousMessageId: ChatMessageId | null;
+		retryOfMessageId: ChatMessageId | null;
+	};
+}

--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -32,6 +32,7 @@ export {
 	type ChatHubAgentDto,
 	ChatHubCreateAgentRequest,
 	ChatHubUpdateAgentRequest,
+	type EnrichedStructuredChunk,
 } from './chat-hub';
 
 export type { Collaborator } from './push/collaboration';

--- a/packages/cli/src/modules/chat-hub/chat-hub.controller.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.controller.ts
@@ -26,11 +26,11 @@ import {
 import type { Response } from 'express';
 import { strict as assert } from 'node:assert';
 
+import { ResponseError } from '@/errors/response-errors/abstract/response.error';
+
 import { ChatHubService } from './chat-hub.service';
 import { ChatHubAgentService } from './chat-hub-agent.service';
 import { ChatModelsRequestDto } from './dto/chat-models-request.dto';
-
-import { ResponseError } from '@/errors/response-errors/abstract/response.error';
 
 @RestController('/chat')
 export class ChatHubController {

--- a/packages/cli/src/modules/chat-hub/chat-hub.types.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.types.ts
@@ -19,7 +19,6 @@ export interface ModelWithCredentials {
 export interface BaseMessagePayload {
 	userId: string;
 	sessionId: ChatSessionId;
-	replyId: ChatMessageId;
 	model: ChatHubConversationModel;
 	credentials: INodeCredentials;
 }

--- a/packages/cli/src/modules/chat-hub/chat-message.repository.ts
+++ b/packages/cli/src/modules/chat-hub/chat-message.repository.ts
@@ -16,14 +16,19 @@ export class ChatHubMessageRepository extends Repository<ChatHubMessage> {
 	}
 
 	async createChatMessage(message: Partial<ChatHubMessage>, trx?: EntityManager) {
-		return await withTransaction(this.manager, trx, async (em) => {
-			await em.insert(ChatHubMessage, message);
-			const saved = await em.findOneOrFail(ChatHubMessage, {
-				where: { id: message.id },
-			});
-			await this.chatSessionRepository.updateLastMessageAt(saved.sessionId, saved.createdAt, em);
-			return saved;
-		});
+		return await withTransaction(
+			this.manager,
+			trx,
+			async (em) => {
+				await em.insert(ChatHubMessage, message);
+				const saved = await em.findOneOrFail(ChatHubMessage, {
+					where: { id: message.id },
+				});
+				await this.chatSessionRepository.updateLastMessageAt(saved.sessionId, saved.createdAt, em);
+				return saved;
+			},
+			false,
+		);
 	}
 
 	async updateChatMessage(
@@ -31,15 +36,25 @@ export class ChatHubMessageRepository extends Repository<ChatHubMessage> {
 		fields: { status?: ChatHubMessageStatus; content?: string },
 		trx?: EntityManager,
 	) {
-		return await withTransaction(this.manager, trx, async (em) => {
-			return await em.update(ChatHubMessage, { id }, fields);
-		});
+		return await withTransaction(
+			this.manager,
+			trx,
+			async (em) => {
+				return await em.update(ChatHubMessage, { id }, fields);
+			},
+			false,
+		);
 	}
 
 	async deleteChatMessage(id: ChatMessageId, trx?: EntityManager) {
-		return await withTransaction(this.manager, trx, async (em) => {
-			return await em.delete(ChatHubMessage, { id });
-		});
+		return await withTransaction(
+			this.manager,
+			trx,
+			async (em) => {
+				return await em.delete(ChatHubMessage, { id });
+			},
+			false,
+		);
 	}
 
 	async getManyBySessionId(sessionId: string, trx?: EntityManager) {

--- a/packages/cli/src/modules/chat-hub/stream-capturer.ts
+++ b/packages/cli/src/modules/chat-hub/stream-capturer.ts
@@ -1,21 +1,24 @@
+import type { ChatMessageId } from '@n8n/api-types';
 import type { Response } from 'express';
 import type { ServerResponse } from 'http';
+import type { StructuredChunk } from 'n8n-workflow';
+import { v4 as uuidv4 } from 'uuid';
+
+import type { ChatHubMessage } from './chat-hub-message.entity';
 
 type Write = ServerResponse['write'];
 
-export type ChunkListenerCb = (chunk: string) => void;
+export type ChunkTransformer = (chunk: string) => void;
 
-export function captureResponseWrites<T extends Response>(res: T, onChunk: ChunkListenerCb): T {
+export function interceptResponseWrites<T extends Response>(
+	res: T,
+	transform: ChunkTransformer,
+): T {
 	const originalWrite = res.write.bind(res) as Write;
+	const defaultEncoding = 'utf8';
 
-	const writeListener = (chunk: string | Buffer, enc?: BufferEncoding) => {
-		try {
-			const text = Buffer.isBuffer(chunk) ? chunk.toString(enc ?? 'utf8') : String(chunk);
-			void onChunk(text);
-		} catch {
-			// Don't break the stream on listener errors
-		}
-	};
+	const toText = (data: string | Buffer, enc?: BufferEncoding) =>
+		Buffer.isBuffer(data) ? data.toString(enc ?? defaultEncoding) : String(data);
 
 	function write(chunk: string | Buffer, callbackFn?: (e?: Error | null) => void): boolean;
 	function write(
@@ -25,25 +28,135 @@ export function captureResponseWrites<T extends Response>(res: T, onChunk: Chunk
 	): boolean;
 	function write(
 		chunk: string | Buffer,
-		encodingOrCallbackFn?: BufferEncoding | ((e?: Error | null) => void),
+		encodingOrCallback?: BufferEncoding | ((e?: Error | null) => void),
 		callbackFn?: (e?: Error | null) => void,
 	): boolean {
-		// TODO: We could also change the output that gets streamed from execution engine here,
-		// perhaps injecting the messageId or other metadata into the chunks. That could make
-		// AI responding with multiple messages (tools, multiple agents etc) easier to handle?
-		if (!encodingOrCallbackFn) {
-			writeListener(chunk);
-			return originalWrite(chunk);
-		} else if (typeof encodingOrCallbackFn === 'function') {
-			writeListener(chunk);
-			return originalWrite(chunk, encodingOrCallbackFn);
+		const inputText = toText(
+			chunk,
+			typeof encodingOrCallback === 'string' ? encodingOrCallback : undefined,
+		);
+
+		const outputText = transform(inputText);
+
+		if (!encodingOrCallback) {
+			return originalWrite(outputText);
+		} else if (typeof encodingOrCallback === 'function') {
+			return originalWrite(outputText, encodingOrCallback);
 		} else {
-			writeListener(chunk, encodingOrCallbackFn);
-			return originalWrite(chunk, encodingOrCallbackFn, callbackFn);
+			return originalWrite(outputText, encodingOrCallback, callbackFn);
 		}
 	}
 
 	res.write = write;
 
 	return res;
+}
+
+type MessageKey = string;
+const keyOf = (m: StructuredChunk['metadata']): MessageKey =>
+	`${m.nodeId}|${m.runIndex}|${m.itemIndex}`;
+
+export type AggregatedMessage = Pick<
+	ChatHubMessage,
+	'id' | 'previousMessageId' | 'retryOfMessageId' | 'content' | 'createdAt' | 'updatedAt' | 'status'
+>;
+
+type Handlers = {
+	onBegin?: (message: AggregatedMessage) => void;
+	onItem?: (message: AggregatedMessage, delta: string) => void;
+	onEnd?: (message: AggregatedMessage) => void;
+	onError?: (message: AggregatedMessage, errText?: string) => void;
+};
+
+export function createStructuredChunkAggregator(
+	initialPreviousMessageId: ChatMessageId,
+	retryOfMessageId: ChatMessageId | null,
+	handlers: Handlers = {},
+) {
+	const { onBegin, onItem, onEnd, onError } = handlers;
+
+	const active = new Map<MessageKey, AggregatedMessage>();
+	const activeByKey = new Map<MessageKey, AggregatedMessage>();
+
+	let previousMessageId: ChatMessageId | null = initialPreviousMessageId;
+
+	const startNew = (): AggregatedMessage => {
+		const message: AggregatedMessage = {
+			id: uuidv4(),
+			previousMessageId,
+			retryOfMessageId:
+				retryOfMessageId && previousMessageId === initialPreviousMessageId
+					? retryOfMessageId
+					: null,
+			content: '',
+			createdAt: new Date(),
+			updatedAt: new Date(),
+			status: 'running',
+		};
+		previousMessageId = message.id;
+		onBegin?.(message);
+		return message;
+	};
+
+	const ensureMessage = (key: MessageKey): AggregatedMessage => {
+		let message = activeByKey.get(key);
+		if (!message) {
+			message = startNew();
+			activeByKey.set(key, message);
+		}
+		return message;
+	};
+
+	const ingest = (chunk: StructuredChunk): AggregatedMessage => {
+		const { type, content, metadata } = chunk;
+		const key = keyOf(metadata);
+
+		if (type === 'begin') {
+			if (activeByKey.has(key)) {
+				throw new Error(`Duplicate begin for key ${key}`);
+			}
+			const message = startNew();
+			activeByKey.set(key, message);
+			return message;
+		}
+
+		if (type === 'item') {
+			const message = ensureMessage(key);
+			if (typeof content === 'string' && content.length) {
+				message.content += content;
+				onItem?.(message, content);
+			}
+			return message;
+		}
+
+		if (type === 'end') {
+			const message = ensureMessage(key);
+			message.status = 'success';
+			message.updatedAt = new Date();
+			activeByKey.delete(key);
+			onEnd?.(message);
+			return message;
+		}
+
+		const message = ensureMessage(key);
+		message.status = 'error';
+		message.updatedAt = new Date();
+		if (typeof content === 'string') {
+			message.content = (message.content ? message.content + '\n\n' : '') + content;
+		}
+
+		activeByKey.delete(key);
+		onError?.(message, content);
+		return message;
+	};
+
+	const finalizeAll = () => {
+		for (const message of active.values()) {
+			message.status = 'cancelled';
+			message.updatedAt = new Date();
+		}
+		active.clear();
+	};
+
+	return { ingest, finalizeAll };
 }

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/chat.api.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/chat.api.ts
@@ -14,8 +14,8 @@ import type {
 	ChatHubCreateAgentRequest,
 	ChatHubUpdateAgentRequest,
 	ChatHubUpdateConversationRequest,
+	EnrichedStructuredChunk,
 } from '@n8n/api-types';
-import type { StructuredChunk } from 'n8n-workflow';
 
 // Workflows stream data as newline separated JSON objects (jsonl)
 const STREAM_SEPARATOR = '\n';
@@ -31,11 +31,11 @@ export const fetchChatModelsApi = async (
 export function sendMessageApi(
 	ctx: IRestApiContext,
 	payload: ChatHubSendMessageRequest,
-	onMessageUpdated: (data: StructuredChunk) => void,
+	onMessageUpdated: (data: EnrichedStructuredChunk) => void,
 	onDone: () => void,
 	onError: (e: Error) => void,
 ) {
-	void streamRequest<StructuredChunk>(
+	void streamRequest<EnrichedStructuredChunk>(
 		ctx,
 		'/chat/conversations/send',
 		payload,
@@ -51,11 +51,11 @@ export function editMessageApi(
 	sessionId: ChatSessionId,
 	editId: ChatMessageId,
 	payload: ChatHubEditMessageRequest,
-	onMessageUpdated: (data: StructuredChunk) => void,
+	onMessageUpdated: (data: EnrichedStructuredChunk) => void,
 	onDone: () => void,
 	onError: (e: Error) => void,
 ) {
-	void streamRequest<StructuredChunk>(
+	void streamRequest<EnrichedStructuredChunk>(
 		ctx,
 		`/chat/conversations/${sessionId}/messages/${editId}/edit`,
 		payload,
@@ -71,11 +71,11 @@ export function regenerateMessageApi(
 	sessionId: ChatSessionId,
 	retryId: ChatMessageId,
 	payload: ChatHubRegenerateMessageRequest,
-	onMessageUpdated: (data: StructuredChunk) => void,
+	onMessageUpdated: (data: EnrichedStructuredChunk) => void,
 	onDone: () => void,
 	onError: (e: Error) => void,
 ) {
-	void streamRequest<StructuredChunk>(
+	void streamRequest<EnrichedStructuredChunk>(
 		ctx,
 		`/chat/conversations/${sessionId}/messages/${retryId}/regenerate`,
 		payload,

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.vue
@@ -199,7 +199,11 @@ onBeforeMount(() => {
 					<VueMarkdown
 						:key="forceReRenderKey"
 						:class="[$style.chatMessageMarkdown, 'chat-message-markdown']"
-						:source="message.content"
+						:source="
+							message.status === 'error' && !message.content
+								? 'Error: Unknown error occurred'
+								: message.content
+						"
 						:options="markdownOptions"
 						:plugins="[linksNewTabPlugin]"
 					/>


### PR DESCRIPTION
## Summary

If agent replies with multiple messages or if there's an error on the WF after the first one handle those cases. This moves the generation of `messageId` of the replies on the backend and includes those IDs on the streamed messages.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-42/make-multiple-streamed-replies-to-a-single-message-work

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
