### PR TITLE
feat(editor): Auto-select all credentials by default in push modal

### DIFF
--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.test.ts
@@ -368,7 +368,8 @@ describe('SourceControlPushModal', () => {
 		expect(sourceControlStore.pushWorkfolder).toHaveBeenCalledWith(
 			expect.objectContaining({
 				commitMessage,
-				fileNames: expect.arrayContaining(status.filter((file) => file.type !== 'credential')),
+				// All files including credentials should be pushed (credentials now selected by default)
+				fileNames: expect.arrayContaining(status),
 				force: true,
 			}),
 		);
@@ -432,6 +433,82 @@ describe('SourceControlPushModal', () => {
 		await userEvent.type(getByTestId('source-control-push-modal-commit'), 'message');
 		const submitButton = getByTestId('source-control-push-modal-submit');
 		expect(submitButton).not.toBeDisabled();
+	});
+
+	it('should have all credentials selected by default', async () => {
+		const status: SourceControlledFile[] = [
+			{
+				id: 'workflow-1',
+				name: 'My workflow',
+				type: 'workflow',
+				status: 'created',
+				location: 'local',
+				conflict: false,
+				file: '/home/user/.n8n/git/workflows/workflow-1.json',
+				updatedAt: '2024-09-20T10:30:00.000Z',
+			},
+			{
+				id: 'cred-1',
+				name: 'My credential 1',
+				type: 'credential',
+				status: 'created',
+				location: 'local',
+				conflict: false,
+				file: '/home/user/.n8n/git/credentials/cred-1.json',
+				updatedAt: '2024-09-20T10:31:40.000Z',
+			},
+			{
+				id: 'cred-2',
+				name: 'My credential 2',
+				type: 'credential',
+				status: 'modified',
+				location: 'local',
+				conflict: false,
+				file: '/home/user/.n8n/git/credentials/cred-2.json',
+				updatedAt: '2024-09-20T14:42:51.968Z',
+			},
+		];
+
+		sourceControlStore.getAggregatedStatus.mockResolvedValue(status);
+
+		const { getAllByTestId, getByText } = renderModal({
+			pinia,
+			props: {
+				data: {
+					eventBus,
+					status,
+				},
+			},
+		});
+
+		// Wait for modal content to be visible
+		await waitFor(() => {
+			expect(getByText('Commit and push changes')).toBeInTheDocument();
+		});
+
+		await waitFor(() => {
+			const workflows = getAllByTestId('source-control-push-modal-file-checkbox');
+			expect(workflows).toHaveLength(1);
+		});
+
+		// Switch to credentials tab
+		const tabs = getAllByTestId('source-control-push-modal-tab');
+		const credentialsTab = tabs.find((tab) => tab.textContent?.includes('Credentials'));
+		await userEvent.click(credentialsTab!);
+
+		await waitFor(() => {
+			const credentials = getAllByTestId('source-control-push-modal-file-checkbox');
+			expect(credentials).toHaveLength(2);
+		});
+
+		const credentials = getAllByTestId('source-control-push-modal-file-checkbox');
+
+		// All credentials should be selected by default
+		expect(within(credentials[0]).getByRole('checkbox')).toBeChecked();
+		expect(within(credentials[1]).getByRole('checkbox')).toBeChecked();
+
+		// Verify the tab shows correct count
+		expect(credentialsTab?.textContent).toContain('2 / 2 selected');
 	});
 
 	it('should show credentials in a different tab', async () => {
@@ -499,6 +576,8 @@ describe('SourceControlPushModal', () => {
 		const credentials = getAllByTestId('source-control-push-modal-file-checkbox');
 		expect(credentials).toHaveLength(1);
 		expect(within(credentials[0]).getByText('My credential')).toBeInTheDocument();
+		// Credentials should be selected by default
+		expect(within(credentials[0]).getByRole('checkbox')).toBeChecked();
 	});
 
 	describe('filters', () => {

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
@@ -97,6 +97,13 @@ async function loadSourceControlStatus() {
 		}
 
 		status.value = freshStatus;
+
+		// Auto-select all credentials by default (only once on load)
+		freshStatus.forEach((file) => {
+			if (file.type === 'credential') {
+				selectedCredentials.add(file.id);
+			}
+		});
 	} catch (error) {
 		toast.showError(error, i18n.baseText('error'));
 		close();
@@ -677,17 +684,6 @@ function openDiffModal(id: string) {
 watchEffect(() => {
 	if (changes.value.currentWorkflow && !selectedWorkflows.has(changes.value.currentWorkflow.id)) {
 		maybeSelectCurrentWorkflow(changes.value.currentWorkflow);
-	}
-});
-
-// Auto-select all credentials by default
-watchEffect(() => {
-	if (changes.value.credential.length > 0) {
-		changes.value.credential.forEach((credential) => {
-			if (!selectedCredentials.has(credential.id)) {
-				selectedCredentials.add(credential.id);
-			}
-		});
 	}
 });
 

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
@@ -680,6 +680,17 @@ watchEffect(() => {
 	}
 });
 
+// Auto-select all credentials by default
+watchEffect(() => {
+	if (changes.value.credential.length > 0) {
+		changes.value.credential.forEach((credential) => {
+			if (!selectedCredentials.has(credential.id)) {
+				selectedCredentials.add(credential.id);
+			}
+		});
+	}
+});
+
 // Load data when modal opens
 onMounted(async () => {
 	// Always load fresh data to ensure workflow names are populated


### PR DESCRIPTION
## Summary

Have all credentials selected by default when pushing up changes

## Related Linear tickets, Github issues, and Community forum posts

PAY-4021

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
