### PR TITLE
feat: Deprecate insights dateRange query filter

### DIFF
--- a/packages/@n8n/api-types/src/dto/insights/__tests__/date-filter.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/insights/__tests__/date-filter.dto.test.ts
@@ -9,13 +9,6 @@ describe('InsightsDateFilterDto', () => {
 				parsedResult: {},
 			},
 			{
-				name: 'valid dateRange',
-				request: {
-					dateRange: 'week', // Using a valid option from the provided list
-				},
-				parsedResult: {},
-			},
-			{
 				name: 'valid startDate and endDate (as strings)',
 				request: {
 					startDate: '2025-01-01',
@@ -129,13 +122,6 @@ describe('InsightsDateFilterDto', () => {
 				expectedErrorPaths: ['endDate'],
 			},
 			{
-				name: 'invalid dateRange value',
-				request: {
-					dateRange: 'invalid-value',
-				},
-				expectedErrorPaths: ['dateRange'],
-			},
-			{
 				name: 'invalid projectId value',
 				request: {
 					projectId: 10,
@@ -145,12 +131,11 @@ describe('InsightsDateFilterDto', () => {
 			{
 				name: 'all fields invalid',
 				request: {
-					dateRange: 'invalid-value',
 					startDate: '2025-13-01', // Invalid month
 					endDate: 'not-a-date',
 					projectId: 10,
 				},
-				expectedErrorPaths: ['dateRange', 'startDate', 'endDate', 'projectId'],
+				expectedErrorPaths: ['startDate', 'endDate', 'projectId'],
 			},
 		])('should fail validation for $name', ({ request, expectedErrorPaths }) => {
 			const result = InsightsDateFilterDto.safeParse(request);

--- a/packages/@n8n/api-types/src/dto/insights/date-filter.dto.ts
+++ b/packages/@n8n/api-types/src/dto/insights/date-filter.dto.ts
@@ -1,18 +1,7 @@
 import { z } from 'zod';
 import { Z } from 'zod-class';
 
-import { insightsDateRangeSchema } from '../../schemas/insights.schema';
-
-const VALID_DATE_RANGE_OPTIONS = insightsDateRangeSchema.shape.key.options;
-
-// Date range parameter validation
-const dateRange = z.enum(VALID_DATE_RANGE_OPTIONS).optional();
-
 export class InsightsDateFilterDto extends Z.class({
-	/**
-	 * @deprecated use startDate and endDate instead
-	 */
-	dateRange,
 	startDate: z.coerce.date().optional(),
 	endDate: z.coerce.date().optional(),
 	projectId: z.string().optional(),

--- a/packages/@n8n/api-types/src/dto/insights/list-workflow-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/insights/list-workflow-query.dto.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 import { Z } from 'zod-class';
 
-import { InsightsDateFilterDto } from './date-filter.dto';
 import { createTakeValidator, paginationSchema } from '../pagination/pagination.dto';
 
 export const MAX_ITEMS_PER_PAGE = 100;
@@ -36,10 +35,6 @@ const sortByValidator = z
 export class ListInsightsWorkflowQueryDto extends Z.class({
 	...paginationSchema,
 	take: createTakeValidator(MAX_ITEMS_PER_PAGE),
-	/**
-	 * @deprecated use startDate and endDate instead
-	 */
-	dateRange: InsightsDateFilterDto.shape.dateRange,
 	startDate: z.coerce.date().optional(),
 	endDate: z.coerce.date().optional(),
 	sortBy: sortByValidator,

--- a/packages/cli/src/modules/insights/__tests__/insights.controller.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.controller.test.ts
@@ -241,37 +241,6 @@ describe('InsightsController', () => {
 				expect(response).toEqual(expectedResponse);
 			});
 
-			it('should use the query dateRange filter in a backward compatible way', async () => {
-				const thirtyDaysAgo = DateTime.now().minus({ days: 30 }).toJSDate();
-
-				insightsByPeriodRepository.getPreviousAndCurrentPeriodTypeAggregates.mockResolvedValue(
-					mockRepositoryResponse,
-				);
-
-				const response = await controller.getInsightsSummary(
-					mock<AuthenticatedRequest>(),
-					mock<Response>(),
-					{ dateRange: 'month', projectId: 'test-project' },
-				);
-
-				expect(
-					insightsByPeriodRepository.getPreviousAndCurrentPeriodTypeAggregates,
-				).toHaveBeenCalledWith(
-					expect.objectContaining({
-						startDate: expect.any(Date),
-						endDate: expect.any(Date),
-						projectId: 'test-project',
-					}),
-				);
-
-				const callArgs =
-					insightsByPeriodRepository.getPreviousAndCurrentPeriodTypeAggregates.mock.calls[0][0];
-				expectDatesClose(callArgs.startDate, thirtyDaysAgo);
-				expectDatesClose(callArgs.endDate, today);
-
-				expect(response).toEqual(expectedResponse);
-			});
-
 			it('should throw a BadRequestError when endDate is before startDate', async () => {
 				await expect(
 					controller.getInsightsSummary(mock<AuthenticatedRequest>(), mock<Response>(), {
@@ -542,42 +511,6 @@ describe('InsightsController', () => {
 				expect(response).toEqual({ count: 3, data: mockRows });
 			});
 
-			it('should use the query dateRange filter in a backward compatible way', async () => {
-				// ARRANGE
-				const thirtyDaysAgo = DateTime.now().minus({ days: 30 }).toJSDate();
-				insightsByPeriodRepository.getInsightsByWorkflow.mockResolvedValue({
-					count: mockRows.length,
-					rows: mockRows,
-				});
-
-				// ACT
-				const response = await controller.getInsightsByWorkflow(
-					mock<AuthenticatedRequest>(),
-					mock<Response>(),
-					{
-						dateRange: 'month',
-						skip: 0,
-						take: 5,
-						sortBy: 'total:desc',
-					},
-				);
-
-				// ASSERT
-				expect(insightsByPeriodRepository.getInsightsByWorkflow).toHaveBeenCalledWith({
-					startDate: expect.any(Date),
-					endDate: expect.any(Date),
-					skip: 0,
-					take: 5,
-					sortBy: 'total:desc',
-				});
-
-				const callArgs = insightsByPeriodRepository.getInsightsByWorkflow.mock.calls[0][0];
-				expectDatesClose(callArgs.startDate, thirtyDaysAgo);
-				expectDatesClose(callArgs.endDate, today);
-
-				expect(response).toEqual({ count: 3, data: mockRows });
-			});
-
 			it('should throw a BadRequestError when endDate is before startDate', async () => {
 				const startDate = DateTime.now().startOf('day').minus({ days: 10 }).toJSDate();
 				const endDate = DateTime.now().startOf('day').minus({ days: 12 }).toJSDate();
@@ -836,30 +769,6 @@ describe('InsightsController', () => {
 				expect(response).toEqual(expectedResponse);
 			});
 
-			it('should use the query dateRange filter in a backward compatible way', async () => {
-				const fourteenDaysAgo = DateTime.now().minus({ days: 14 }).toJSDate();
-				insightsByPeriodRepository.getInsightsByTime.mockResolvedValue(mockData);
-
-				const response = await controller.getInsightsByTime(
-					mock<AuthenticatedRequest>(),
-					mock<Response>(),
-					{ dateRange: '2weeks', projectId: 'test-project' },
-				);
-
-				expect(insightsByPeriodRepository.getInsightsByTime).toHaveBeenCalledWith({
-					insightTypes: ['time_saved_min', 'runtime_ms', 'success', 'failure'],
-					startDate: expect.any(Date),
-					endDate: expect.any(Date),
-					periodUnit: 'day',
-					projectId: 'test-project',
-				});
-
-				const callArgs = insightsByPeriodRepository.getInsightsByTime.mock.calls[0][0];
-				expectDatesClose(callArgs.startDate, fourteenDaysAgo);
-				expectDatesClose(callArgs.endDate, today);
-				expect(response).toEqual(expectedResponse);
-			});
-
 			it('should throw a BadRequestError when endDate is before startDate', async () => {
 				await expect(
 					controller.getInsightsByTime(mock<AuthenticatedRequest>(), mock<Response>(), {
@@ -1026,34 +935,6 @@ describe('InsightsController', () => {
 					endDate,
 					periodUnit: 'week',
 				});
-
-				expect(response).toEqual(expectedResponse);
-			});
-
-			it('should use the query dateRange filter "quarter" in a backward compatible way', async () => {
-				// ARRANGE
-				const ninetyDaysAgo = DateTime.now().minus({ days: 90 }).toJSDate();
-				insightsByPeriodRepository.getInsightsByTime.mockResolvedValue(mockData);
-
-				// ACT
-				const response = await controller.getTimeSavedInsightsByTime(
-					mock<AuthenticatedRequest>(),
-					mock<Response>(),
-					{ dateRange: 'quarter', projectId: 'test-project' },
-				);
-
-				// ASSERT
-				expect(insightsByPeriodRepository.getInsightsByTime).toHaveBeenCalledWith({
-					insightTypes: ['time_saved_min'],
-					startDate: expect.any(Date),
-					endDate: expect.any(Date),
-					periodUnit: 'week',
-					projectId: 'test-project',
-				});
-
-				const callArgs = insightsByPeriodRepository.getInsightsByTime.mock.calls[0][0];
-				expectDatesClose(callArgs.startDate, ninetyDaysAgo);
-				expectDatesClose(callArgs.endDate, today);
 
 				expect(response).toEqual(expectedResponse);
 			});

--- a/packages/cli/src/modules/insights/__tests__/insights.service.integration.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.integration.test.ts
@@ -1095,6 +1095,16 @@ describe('InsightsService', () => {
 			);
 		});
 
+		test('returns correct summary and dashboard licenses', () => {
+			licenseMock.isInsightsSummaryLicensed.mockReturnValue(true);
+			licenseMock.isInsightsDashboardLicensed.mockReturnValue(true);
+
+			const result = insightsService.settings();
+
+			expect(result.summary).toBe(true);
+			expect(result.dashboard).toBe(true);
+		});
+
 		describe('dateRanges', () => {
 			test('returns correct ranges when hourly data is enabled and max history is unlimited', () => {
 				licenseMock.getInsightsMaxHistory.mockReturnValue(-1);

--- a/packages/cli/src/modules/insights/__tests__/insights.service.integration.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.integration.test.ts
@@ -1078,7 +1078,7 @@ describe('InsightsService', () => {
 		});
 	});
 
-	describe('getAvailableDateRanges', () => {
+	describe('settings', () => {
 		let licenseMock: jest.Mocked<LicenseState>;
 		let insightsService: InsightsService;
 
@@ -1095,89 +1095,91 @@ describe('InsightsService', () => {
 			);
 		});
 
-		test('returns correct ranges when hourly data is enabled and max history is unlimited', () => {
-			licenseMock.getInsightsMaxHistory.mockReturnValue(-1);
-			licenseMock.isInsightsHourlyDataLicensed.mockReturnValue(true);
+		describe('dateRanges', () => {
+			test('returns correct ranges when hourly data is enabled and max history is unlimited', () => {
+				licenseMock.getInsightsMaxHistory.mockReturnValue(-1);
+				licenseMock.isInsightsHourlyDataLicensed.mockReturnValue(true);
 
-			const result = insightsService.getAvailableDateRanges();
+				const result = insightsService.settings();
 
-			expect(result).toEqual([
-				{ key: 'day', licensed: true, granularity: 'hour' },
-				{ key: 'week', licensed: true, granularity: 'day' },
-				{ key: '2weeks', licensed: true, granularity: 'day' },
-				{ key: 'month', licensed: true, granularity: 'day' },
-				{ key: 'quarter', licensed: true, granularity: 'week' },
-				{ key: '6months', licensed: true, granularity: 'week' },
-				{ key: 'year', licensed: true, granularity: 'week' },
-			]);
-		});
+				expect(result.dateRanges).toEqual([
+					{ key: 'day', licensed: true, granularity: 'hour' },
+					{ key: 'week', licensed: true, granularity: 'day' },
+					{ key: '2weeks', licensed: true, granularity: 'day' },
+					{ key: 'month', licensed: true, granularity: 'day' },
+					{ key: 'quarter', licensed: true, granularity: 'week' },
+					{ key: '6months', licensed: true, granularity: 'week' },
+					{ key: 'year', licensed: true, granularity: 'week' },
+				]);
+			});
 
-		test('returns correct ranges when hourly data is enabled and max history is 365 days', () => {
-			licenseMock.getInsightsMaxHistory.mockReturnValue(365);
-			licenseMock.isInsightsHourlyDataLicensed.mockReturnValue(true);
+			test('returns correct ranges when hourly data is enabled and max history is 365 days', () => {
+				licenseMock.getInsightsMaxHistory.mockReturnValue(365);
+				licenseMock.isInsightsHourlyDataLicensed.mockReturnValue(true);
 
-			const result = insightsService.getAvailableDateRanges();
+				const result = insightsService.settings();
 
-			expect(result).toEqual([
-				{ key: 'day', licensed: true, granularity: 'hour' },
-				{ key: 'week', licensed: true, granularity: 'day' },
-				{ key: '2weeks', licensed: true, granularity: 'day' },
-				{ key: 'month', licensed: true, granularity: 'day' },
-				{ key: 'quarter', licensed: true, granularity: 'week' },
-				{ key: '6months', licensed: true, granularity: 'week' },
-				{ key: 'year', licensed: true, granularity: 'week' },
-			]);
-		});
+				expect(result.dateRanges).toEqual([
+					{ key: 'day', licensed: true, granularity: 'hour' },
+					{ key: 'week', licensed: true, granularity: 'day' },
+					{ key: '2weeks', licensed: true, granularity: 'day' },
+					{ key: 'month', licensed: true, granularity: 'day' },
+					{ key: 'quarter', licensed: true, granularity: 'week' },
+					{ key: '6months', licensed: true, granularity: 'week' },
+					{ key: 'year', licensed: true, granularity: 'week' },
+				]);
+			});
 
-		test('returns correct ranges when hourly data is disabled and max history is 30 days', () => {
-			licenseMock.getInsightsMaxHistory.mockReturnValue(30);
-			licenseMock.isInsightsHourlyDataLicensed.mockReturnValue(false);
+			test('returns correct ranges when hourly data is disabled and max history is 30 days', () => {
+				licenseMock.getInsightsMaxHistory.mockReturnValue(30);
+				licenseMock.isInsightsHourlyDataLicensed.mockReturnValue(false);
 
-			const result = insightsService.getAvailableDateRanges();
+				const result = insightsService.settings();
 
-			expect(result).toEqual([
-				{ key: 'day', licensed: false, granularity: 'hour' },
-				{ key: 'week', licensed: true, granularity: 'day' },
-				{ key: '2weeks', licensed: true, granularity: 'day' },
-				{ key: 'month', licensed: true, granularity: 'day' },
-				{ key: 'quarter', licensed: false, granularity: 'week' },
-				{ key: '6months', licensed: false, granularity: 'week' },
-				{ key: 'year', licensed: false, granularity: 'week' },
-			]);
-		});
+				expect(result.dateRanges).toEqual([
+					{ key: 'day', licensed: false, granularity: 'hour' },
+					{ key: 'week', licensed: true, granularity: 'day' },
+					{ key: '2weeks', licensed: true, granularity: 'day' },
+					{ key: 'month', licensed: true, granularity: 'day' },
+					{ key: 'quarter', licensed: false, granularity: 'week' },
+					{ key: '6months', licensed: false, granularity: 'week' },
+					{ key: 'year', licensed: false, granularity: 'week' },
+				]);
+			});
 
-		test('returns correct ranges when max history is less than 7 days', () => {
-			licenseMock.getInsightsMaxHistory.mockReturnValue(5);
-			licenseMock.isInsightsHourlyDataLicensed.mockReturnValue(false);
+			test('returns correct ranges when max history is less than 7 days', () => {
+				licenseMock.getInsightsMaxHistory.mockReturnValue(5);
+				licenseMock.isInsightsHourlyDataLicensed.mockReturnValue(false);
 
-			const result = insightsService.getAvailableDateRanges();
+				const result = insightsService.settings();
 
-			expect(result).toEqual([
-				{ key: 'day', licensed: false, granularity: 'hour' },
-				{ key: 'week', licensed: false, granularity: 'day' },
-				{ key: '2weeks', licensed: false, granularity: 'day' },
-				{ key: 'month', licensed: false, granularity: 'day' },
-				{ key: 'quarter', licensed: false, granularity: 'week' },
-				{ key: '6months', licensed: false, granularity: 'week' },
-				{ key: 'year', licensed: false, granularity: 'week' },
-			]);
-		});
+				expect(result.dateRanges).toEqual([
+					{ key: 'day', licensed: false, granularity: 'hour' },
+					{ key: 'week', licensed: false, granularity: 'day' },
+					{ key: '2weeks', licensed: false, granularity: 'day' },
+					{ key: 'month', licensed: false, granularity: 'day' },
+					{ key: 'quarter', licensed: false, granularity: 'week' },
+					{ key: '6months', licensed: false, granularity: 'week' },
+					{ key: 'year', licensed: false, granularity: 'week' },
+				]);
+			});
 
-		test('returns correct ranges when max history is 90 days and hourly data is enabled', () => {
-			licenseMock.getInsightsMaxHistory.mockReturnValue(90);
-			licenseMock.isInsightsHourlyDataLicensed.mockReturnValue(true);
+			test('returns correct ranges when max history is 90 days and hourly data is enabled', () => {
+				licenseMock.getInsightsMaxHistory.mockReturnValue(90);
+				licenseMock.isInsightsHourlyDataLicensed.mockReturnValue(true);
 
-			const result = insightsService.getAvailableDateRanges();
+				const result = insightsService.settings();
 
-			expect(result).toEqual([
-				{ key: 'day', licensed: true, granularity: 'hour' },
-				{ key: 'week', licensed: true, granularity: 'day' },
-				{ key: '2weeks', licensed: true, granularity: 'day' },
-				{ key: 'month', licensed: true, granularity: 'day' },
-				{ key: 'quarter', licensed: true, granularity: 'week' },
-				{ key: '6months', licensed: false, granularity: 'week' },
-				{ key: 'year', licensed: false, granularity: 'week' },
-			]);
+				expect(result.dateRanges).toEqual([
+					{ key: 'day', licensed: true, granularity: 'hour' },
+					{ key: 'week', licensed: true, granularity: 'day' },
+					{ key: '2weeks', licensed: true, granularity: 'day' },
+					{ key: 'month', licensed: true, granularity: 'day' },
+					{ key: 'quarter', licensed: true, granularity: 'week' },
+					{ key: '6months', licensed: false, granularity: 'week' },
+					{ key: 'year', licensed: false, granularity: 'week' },
+				]);
+			});
 		});
 	});
 

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -32,9 +32,6 @@ export class InsightsService {
 		return {
 			summary: this.licenseState.isInsightsSummaryLicensed(),
 			dashboard: this.licenseState.isInsightsDashboardLicensed(),
-			/**
-			 * @deprecated the frontend should not rely on this anymore since users can select custom ranges
-			 */
 			dateRanges: this.getAvailableDateRanges(),
 		};
 	}
@@ -286,12 +283,7 @@ export class InsightsService {
 		return 'week';
 	}
 
-	/**
-	 * @deprecated Users can now select custom date ranges
-	 * Returns the available date ranges with their license authorization and time granularity
-	 * when grouped by time.
-	 */
-	getAvailableDateRanges(): DateRange[] {
+	private getAvailableDateRanges(): DateRange[] {
 		const maxHistoryInDays =
 			this.licenseState.getInsightsMaxHistory() === -1
 				? Number.MAX_SAFE_INTEGER


### PR DESCRIPTION
## Summary

Removed the `dateRange` property from the insights queries because it's no longer used
 
<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

resolves PAY-3888

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
