### PR TITLE
fix(core): Only select executionData from DB when requested

### DIFF
--- a/packages/@n8n/db/src/repositories/__tests__/execution.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/execution.repository.test.ts
@@ -12,7 +12,6 @@ const GREATER_THAN_MAX_UPDATE_THRESHOLD = 901;
 
 /**
  * TODO: add tests for all the other methods
- * TODO: getExecutionsForPublicApi -> add test cases for the `includeData` toggle
  */
 describe('ExecutionRepository', () => {
 	const entityManager = mockEntityManager(ExecutionEntity);
@@ -40,7 +39,6 @@ describe('ExecutionRepository', () => {
 			where: {},
 			order: { id: 'DESC' },
 			take: defaultLimit,
-			relations: ['executionData'],
 		};
 
 		test('should get executions matching all filter parameters', async () => {
@@ -167,6 +165,54 @@ describe('ExecutionRepository', () => {
 					expect(result[0].id).toEqual(mockEntities[0].id);
 				},
 			);
+		});
+
+		describe('with includeData parameter', () => {
+			test('should not fetch executionData and metadata relations when includeData is false', async () => {
+				const params = {
+					limit: defaultLimit,
+					includeData: false,
+				};
+				const mockEntities = [{ id: '1' }, { id: '2' }];
+
+				entityManager.find.mockResolvedValueOnce(mockEntities);
+				const result = await executionRepository.getExecutionsForPublicApi(params);
+
+				expect(entityManager.find).toHaveBeenCalledWith(ExecutionEntity, {
+					...defaultQuery,
+					where: {},
+				});
+				expect(result.length).toBe(mockEntities.length);
+			});
+
+			test('should fetch executionData and metadata relations when includeData is true', async () => {
+				const params = {
+					limit: defaultLimit,
+					includeData: true,
+				};
+				const mockEntities = [
+					{
+						id: '1',
+						executionData: { data: '[]' },
+						metadata: [],
+					},
+					{
+						id: '2',
+						executionData: { data: '[]' },
+						metadata: [],
+					},
+				];
+
+				entityManager.find.mockResolvedValueOnce(mockEntities);
+				const result = await executionRepository.getExecutionsForPublicApi(params);
+
+				expect(entityManager.find).toHaveBeenCalledWith(ExecutionEntity, {
+					...defaultQuery,
+					where: {},
+					relations: ['executionData', 'metadata'],
+				});
+				expect(result.length).toBe(mockEntities.length);
+			});
 		});
 	});
 

--- a/packages/@n8n/db/src/repositories/execution.repository.ts
+++ b/packages/@n8n/db/src/repositories/execution.repository.ts
@@ -730,7 +730,6 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 				where,
 				order: { id: 'DESC' },
 				take: params.limit,
-				relations: ['executionData'],
 			},
 			{
 				includeData: params.includeData,


### PR DESCRIPTION
## Summary

In the public api if executions are requested, and includeData is set to false, we still fetch the execution data from the database.

This leads to high memory consumption for such requests even if not necessary, especially if customers have large execution data.

## Related Linear tickets, Github issues, and Community forum posts

closes PAY-4020


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
