### PR TITLE
fix(core): Harden security restrictions in native Python runner

### DIFF
--- a/packages/@n8n/task-runner-python/src/constants.py
+++ b/packages/@n8n/task-runner-python/src/constants.py
@@ -113,6 +113,8 @@ BLOCKED_NAMES = {
     "__loader__",
     "__builtins__",
     "__globals__",
+    "__spec__",
+    "__name__",
 }
 BLOCKED_ATTRIBUTES = {
     # runtime attributes


### PR DESCRIPTION
https://linear.app/n8n/issue/CAT-1668