### PR TITLE
ci: Change node popularity endpoint

### DIFF
--- a/packages/frontend/editor-ui/scripts/fetch-node-popularity.mjs
+++ b/packages/frontend/editor-ui/scripts/fetch-node-popularity.mjs
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const POPULARITY_ENDPOINT =
 	process.env.NODE_POPULARITY_ENDPOINT ||
-	'https://internal.users.n8n.cloud/webhook/nodes-popularity-scores';
+	'https://internal-production.app.n8n.cloud/webhook/nodes-popularity-scores';
 const FAIL_ON_ERROR = process.env.N8N_FAIL_ON_POPULARITY_FETCH_ERROR === 'true';
 const BUILD_DIR = path.join(__dirname, '..', '.build');
 const OUTPUT_FILE = path.join(BUILD_DIR, 'node-popularity.json');


### PR DESCRIPTION
## Summary

Change node popularity endpoint to another instance.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-1572/tech-debt-move-nodes-popularity-workflow-to-internal-production


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
