### PR TITLE
feat(core): Change dependency info column to json instead of string (no-changelog)

### DIFF
--- a/packages/@n8n/db/src/entities/workflow-dependency-entity.ts
+++ b/packages/@n8n/db/src/entities/workflow-dependency-entity.ts
@@ -52,8 +52,8 @@ export class WorkflowDependency extends WithCreatedAt {
 	 * Additional information about the dependency, interpreted based on the type.
 	 * E.g., for 'nodeType' it could be the node ID, for 'webhookPath' the webhook ID.
 	 */
-	@Column({ type: 'varchar', length: 255, nullable: true })
-	dependencyInfo: string | null;
+	@Column({ type: 'json', nullable: true })
+	dependencyInfo: Record<string, unknown> | null;
 
 	/**
 	 * The version of the index structure. Used for migrations and updates.

--- a/packages/@n8n/db/src/migrations/mysqldb/1761655473000-ChangeDependencyInfoToJson.ts
+++ b/packages/@n8n/db/src/migrations/mysqldb/1761655473000-ChangeDependencyInfoToJson.ts
@@ -1,0 +1,15 @@
+import type { IrreversibleMigration, MigrationContext } from '../migration-types';
+
+/**
+ * MySQL-specific migration to change the `dependencyInfo` column in `workflow_dependency` table from VARCHAR(255) to JSON.
+ * Handles both MySQL and MariaDB.
+ */
+export class ChangeDependencyInfoToJson1761655473000 implements IrreversibleMigration {
+	async up({ queryRunner, tablePrefix }: MigrationContext) {
+		const tableName = `${tablePrefix}workflow_dependency`;
+
+		await queryRunner.query(
+			`ALTER TABLE \`${tableName}\` MODIFY COLUMN \`dependencyInfo\` JSON NULL COMMENT 'Additional info about the dependency, interpreted based on type'`,
+		);
+	}
+}

--- a/packages/@n8n/db/src/migrations/mysqldb/index.ts
+++ b/packages/@n8n/db/src/migrations/mysqldb/index.ts
@@ -50,6 +50,7 @@ import { AddStatsColumnsToTestRun1736172058779 } from './1736172058779-AddStatsC
 import { FixTestDefinitionPrimaryKey1739873751194 } from './1739873751194-FixTestDefinitionPrimaryKey';
 import { AddProjectIdToVariableTable1758794506893 } from './1758794506893-AddProjectIdToVariableTable';
 import { AddWorkflowVersionColumn1761047826451 } from './1761047826451-AddWorkflowVersionColumn';
+import { ChangeDependencyInfoToJson1761655473000 } from './1761655473000-ChangeDependencyInfoToJson';
 import { CreateLdapEntities1674509946020 } from '../common/1674509946020-CreateLdapEntities';
 import { PurgeInvalidWorkflowConnections1675940580449 } from '../common/1675940580449-PurgeInvalidWorkflowConnections';
 import { RemoveResetPasswordColumns1690000000030 } from '../common/1690000000030-RemoveResetPasswordColumns';
@@ -219,4 +220,5 @@ export const mysqlMigrations: Migration[] = [
 	CreateWorkflowDependencyTable1760314000000,
 	DropUnusedChatHubColumns1760965142113,
 	AddWorkflowVersionColumn1761047826451,
+	ChangeDependencyInfoToJson1761655473000,
 ];

--- a/packages/@n8n/db/src/migrations/postgresdb/1761655473000-ChangeDependencyInfoToJson.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/1761655473000-ChangeDependencyInfoToJson.ts
@@ -1,0 +1,14 @@
+import type { IrreversibleMigration, MigrationContext } from '../migration-types';
+
+/**
+ * PostgreSQL-specific migration to change the `dependencyInfo` column in `workflow_dependency` table from VARCHAR(255) to JSON.
+ */
+export class ChangeDependencyInfoToJson1761655473000 implements IrreversibleMigration {
+	async up({ queryRunner, tablePrefix }: MigrationContext) {
+		const tableName = `${tablePrefix}workflow_dependency`;
+
+		await queryRunner.query(
+			`ALTER TABLE "${tableName}" ALTER COLUMN "dependencyInfo" TYPE JSON USING NULL`,
+		);
+	}
+}

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -47,6 +47,7 @@ import { MigrateTestDefinitionKeyToString1731582748663 } from './1731582748663-M
 import { UpdateParentFolderIdColumn1740445074052 } from './1740445074052-UpdateParentFolderIdColumn';
 import { AddProjectIdToVariableTable1758794506893 } from './1758794506893-AddProjectIdToVariableTable';
 import { AddWorkflowVersionColumn1761047826451 } from './1761047826451-AddWorkflowVersionColumn';
+import { ChangeDependencyInfoToJson1761655473000 } from './1761655473000-ChangeDependencyInfoToJson';
 import { CreateLdapEntities1674509946020 } from '../common/1674509946020-CreateLdapEntities';
 import { PurgeInvalidWorkflowConnections1675940580449 } from '../common/1675940580449-PurgeInvalidWorkflowConnections';
 import { RemoveResetPasswordColumns1690000000030 } from '../common/1690000000030-RemoveResetPasswordColumns';
@@ -217,4 +218,5 @@ export const postgresMigrations: Migration[] = [
 	CreateWorkflowDependencyTable1760314000000,
 	DropUnusedChatHubColumns1760965142113,
 	AddWorkflowVersionColumn1761047826451,
+	ChangeDependencyInfoToJson1761655473000,
 ];

--- a/packages/@n8n/db/src/migrations/sqlite/1761655473000-ChangeDependencyInfoToJson.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/1761655473000-ChangeDependencyInfoToJson.ts
@@ -12,7 +12,7 @@ export class ChangeDependencyInfoToJson1761655473000 implements IrreversibleMigr
 		// SQLite doesn't support ALTER COLUMN, so drop and recreate the column
 		await queryRunner.query(`ALTER TABLE "${tableName}" DROP COLUMN "dependencyInfo"`);
 		await queryRunner.query(
-			`ALTER TABLE "${tableName}" ADD COLUMN "dependencyInfo" TEXT CHECK("dependencyInfo" IS NULL OR json_valid("dependencyInfo"))`,
+			`ALTER TABLE "${tableName}" ADD COLUMN "dependencyInfo" TEXT CONSTRAINT workflow_dependency_chk_dependency_info_is_json CHECK("dependencyInfo" IS NULL OR json_valid("dependencyInfo"))`,
 		);
 	}
 }

--- a/packages/@n8n/db/src/migrations/sqlite/1761655473000-ChangeDependencyInfoToJson.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/1761655473000-ChangeDependencyInfoToJson.ts
@@ -1,0 +1,18 @@
+import type { IrreversibleMigration, MigrationContext } from '../migration-types';
+
+/**
+ * SQLite-specific migration to change the `dependencyInfo` column in `workflow_dependency` table from VARCHAR(255) to JSON.
+ * SQLite doesn't support ALTER COLUMN, so we drop and recreate the column.
+ * Since the table is empty at this point, this is safe.
+ */
+export class ChangeDependencyInfoToJson1761655473000 implements IrreversibleMigration {
+	async up({ queryRunner, tablePrefix }: MigrationContext) {
+		const tableName = `${tablePrefix}workflow_dependency`;
+
+		// SQLite doesn't support ALTER COLUMN, so drop and recreate the column
+		await queryRunner.query(`ALTER TABLE "${tableName}" DROP COLUMN "dependencyInfo"`);
+		await queryRunner.query(
+			`ALTER TABLE "${tableName}" ADD COLUMN "dependencyInfo" TEXT CHECK("dependencyInfo" IS NULL OR json_valid("dependencyInfo"))`,
+		);
+	}
+}

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -45,6 +45,7 @@ import { CreateFolderTable1738709609940 } from './1738709609940-CreateFolderTabl
 import { UpdateParentFolderIdColumn1740445074052 } from './1740445074052-UpdateParentFolderIdColumn';
 import { AddScopesColumnToApiKeys1742918400000 } from './1742918400000-AddScopesColumnToApiKeys';
 import { AddWorkflowVersionColumn1761047826451 } from './1761047826451-AddWorkflowVersionColumn';
+import { ChangeDependencyInfoToJson1761655473000 } from './1761655473000-ChangeDependencyInfoToJson';
 import { UniqueWorkflowNames1620821879465 } from '../common/1620821879465-UniqueWorkflowNames';
 import { UpdateWorkflowCredentials1630330987096 } from '../common/1630330987096-UpdateWorkflowCredentials';
 import { AddNodeIds1658930531669 } from '../common/1658930531669-AddNodeIds';
@@ -211,6 +212,7 @@ const sqliteMigrations: Migration[] = [
 	CreateWorkflowDependencyTable1760314000000,
 	DropUnusedChatHubColumns1760965142113,
 	AddWorkflowVersionColumn1761047826451,
+	ChangeDependencyInfoToJson1761655473000,
 ];
 
 export { sqliteMigrations };


### PR DESCRIPTION
## Summary

Add a database migration to change the type of the workflow dependency info column from string to JSON.

This column will be used to store useful metadata about the dependency info to enrich queries. Storing it as JSON provides slightly better query and validation.

This table is currently not in use, so we are directly altering the table and not migrating any existing data (because there is none).

Testing: manually started the instance, verified that the column was now JSON typed.

## Related Linear tickets, Github issues, and Community forum posts

Closes https://linear.app/n8n/issue/CAT-1670.


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
