### PR TITLE
fix(editor): Keep loading executions initially until they fill up the sidebar

### DIFF
--- a/packages/frontend/editor-ui/src/composables/useIntersectionObserver.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useIntersectionObserver.test.ts
@@ -28,8 +28,12 @@ describe('useIntersectionObserver()', () => {
 	let mockCallback: ReturnType<typeof vi.fn>;
 	let mockRoot: Element;
 	let mockConstructor: MockIntersectionObserverConstructor;
+	let originalIntersectionObserver: typeof IntersectionObserver;
 
 	beforeEach(() => {
+		// Cache original IntersectionObserver
+		originalIntersectionObserver = global.IntersectionObserver;
+
 		// Mock IntersectionObserver
 		mockIntersectionObserver = {
 			observe: vi.fn(),
@@ -50,6 +54,8 @@ describe('useIntersectionObserver()', () => {
 	});
 
 	afterEach(() => {
+		// Restore original IntersectionObserver
+		global.IntersectionObserver = originalIntersectionObserver;
 		vi.restoreAllMocks();
 	});
 

--- a/packages/frontend/editor-ui/src/composables/useIntersectionObserver.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useIntersectionObserver.test.ts
@@ -1,0 +1,245 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { useIntersectionObserver } from './useIntersectionObserver';
+import { ref } from 'vue';
+
+interface MockIntersectionObserverConstructor {
+	__callback?: IntersectionObserverCallback;
+	new (callback: IntersectionObserverCallback): IntersectionObserver;
+}
+
+describe('useIntersectionObserver()', () => {
+	let mockIntersectionObserver: {
+		observe: ReturnType<typeof vi.fn>;
+		disconnect: ReturnType<typeof vi.fn>;
+		unobserve: ReturnType<typeof vi.fn>;
+	};
+	let mockCallback: ReturnType<typeof vi.fn>;
+	let mockRoot: Element;
+	let mockConstructor: MockIntersectionObserverConstructor;
+
+	beforeEach(() => {
+		// Mock IntersectionObserver
+		mockIntersectionObserver = {
+			observe: vi.fn(),
+			disconnect: vi.fn(),
+			unobserve: vi.fn(),
+		};
+
+		mockConstructor = vi.fn((callback) => {
+			// Store callback for manual triggering
+			mockConstructor.__callback = callback;
+			return mockIntersectionObserver;
+		}) as unknown as MockIntersectionObserverConstructor;
+
+		global.IntersectionObserver = mockConstructor as unknown as typeof IntersectionObserver;
+
+		mockCallback = vi.fn();
+		mockRoot = document.createElement('div');
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('creates an IntersectionObserver when observe is called', () => {
+		const root = ref(mockRoot);
+		const { observe } = useIntersectionObserver({
+			root,
+			onIntersect: mockCallback,
+		});
+
+		const element = document.createElement('div');
+		observe(element);
+
+		expect(global.IntersectionObserver).toHaveBeenCalledWith(
+			expect.any(Function),
+			expect.objectContaining({
+				root: mockRoot,
+				threshold: 0.01,
+			}),
+		);
+		expect(mockIntersectionObserver.observe).toHaveBeenCalledWith(element);
+	});
+
+	it('executes callback when element intersects', () => {
+		const root = ref(mockRoot);
+		const { observe } = useIntersectionObserver({
+			root,
+			onIntersect: mockCallback,
+		});
+
+		const element = document.createElement('div');
+		observe(element);
+
+		// Simulate intersection
+		const callback = mockConstructor.__callback;
+		if (callback) {
+			callback(
+				[{ isIntersecting: true, target: element }] as IntersectionObserverEntry[],
+				{} as IntersectionObserver,
+			);
+		}
+
+		expect(mockCallback).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not execute callback when element does not intersect', () => {
+		const root = ref(mockRoot);
+		const { observe } = useIntersectionObserver({
+			root,
+			onIntersect: mockCallback,
+		});
+
+		const element = document.createElement('div');
+		observe(element);
+
+		// Simulate no intersection
+		const callback = mockConstructor.__callback;
+		if (callback) {
+			callback(
+				[{ isIntersecting: false, target: element }] as IntersectionObserverEntry[],
+				{} as IntersectionObserver,
+			);
+		}
+
+		expect(mockCallback).not.toHaveBeenCalled();
+	});
+
+	it('disconnects observer after first intersection by default', () => {
+		const root = ref(mockRoot);
+		const { observe } = useIntersectionObserver({
+			root,
+			onIntersect: mockCallback,
+		});
+
+		const element = document.createElement('div');
+		observe(element);
+
+		// Simulate intersection
+		const callback = mockConstructor.__callback;
+		if (callback) {
+			callback(
+				[{ isIntersecting: true, target: element }] as IntersectionObserverEntry[],
+				{} as IntersectionObserver,
+			);
+		}
+
+		expect(mockIntersectionObserver.disconnect).toHaveBeenCalledTimes(1);
+	});
+
+	it('continues observing when once is false', () => {
+		const root = ref(mockRoot);
+		const { observe } = useIntersectionObserver({
+			root,
+			onIntersect: mockCallback,
+			once: false,
+		});
+
+		const element = document.createElement('div');
+		observe(element);
+
+		// Simulate intersection
+		const callback = mockConstructor.__callback;
+		if (callback) {
+			callback(
+				[{ isIntersecting: true, target: element }] as IntersectionObserverEntry[],
+				{} as IntersectionObserver,
+			);
+		}
+
+		expect(mockIntersectionObserver.disconnect).not.toHaveBeenCalled();
+	});
+
+	it('uses custom threshold when provided', () => {
+		const root = ref(mockRoot);
+		const customThreshold = 0.5;
+		const { observe } = useIntersectionObserver({
+			root,
+			threshold: customThreshold,
+			onIntersect: mockCallback,
+		});
+
+		const element = document.createElement('div');
+		observe(element);
+
+		expect(global.IntersectionObserver).toHaveBeenCalledWith(
+			expect.any(Function),
+			expect.objectContaining({
+				threshold: customThreshold,
+			}),
+		);
+	});
+
+	it('cleans up existing observer when observing a new element', () => {
+		const root = ref(mockRoot);
+		const { observe } = useIntersectionObserver({
+			root,
+			onIntersect: mockCallback,
+		});
+
+		const element1 = document.createElement('div');
+		const element2 = document.createElement('div');
+
+		observe(element1);
+		const firstObserver = mockIntersectionObserver.disconnect;
+
+		observe(element2);
+
+		expect(firstObserver).toHaveBeenCalledTimes(1);
+	});
+
+	it('does nothing when observing null element', () => {
+		const root = ref(mockRoot);
+		const { observe } = useIntersectionObserver({
+			root,
+			onIntersect: mockCallback,
+		});
+
+		observe(null);
+
+		expect(global.IntersectionObserver).not.toHaveBeenCalled();
+	});
+
+	it('does nothing when observing undefined element', () => {
+		const root = ref(mockRoot);
+		const { observe } = useIntersectionObserver({
+			root,
+			onIntersect: mockCallback,
+		});
+
+		observe(undefined);
+
+		expect(global.IntersectionObserver).not.toHaveBeenCalled();
+	});
+
+	it('exposes disconnect method for manual cleanup', () => {
+		const root = ref(mockRoot);
+		const { observe, disconnect } = useIntersectionObserver({
+			root,
+			onIntersect: mockCallback,
+		});
+
+		const element = document.createElement('div');
+		observe(element);
+
+		disconnect();
+
+		expect(mockIntersectionObserver.disconnect).toHaveBeenCalledTimes(1);
+	});
+
+	it('safely handles multiple disconnect calls', () => {
+		const root = ref(mockRoot);
+		const { observe, disconnect } = useIntersectionObserver({
+			root,
+			onIntersect: mockCallback,
+		});
+
+		const element = document.createElement('div');
+		observe(element);
+
+		disconnect();
+		disconnect(); // Second call should not error
+
+		expect(mockIntersectionObserver.disconnect).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/frontend/editor-ui/src/composables/useIntersectionObserver.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useIntersectionObserver.test.ts
@@ -7,6 +7,18 @@ interface MockIntersectionObserverConstructor {
 	new (callback: IntersectionObserverCallback): IntersectionObserver;
 }
 
+function createMockEntry(element: Element, isIntersecting: boolean): IntersectionObserverEntry {
+	return {
+		isIntersecting,
+		target: element,
+		boundingClientRect: {} as DOMRectReadOnly,
+		intersectionRatio: isIntersecting ? 1 : 0,
+		intersectionRect: {} as DOMRectReadOnly,
+		rootBounds: null,
+		time: Date.now(),
+	};
+}
+
 describe('useIntersectionObserver()', () => {
 	let mockIntersectionObserver: {
 		observe: ReturnType<typeof vi.fn>;
@@ -74,10 +86,7 @@ describe('useIntersectionObserver()', () => {
 		// Simulate intersection
 		const callback = mockConstructor.__callback;
 		if (callback) {
-			callback(
-				[{ isIntersecting: true, target: element }] as IntersectionObserverEntry[],
-				{} as IntersectionObserver,
-			);
+			callback([createMockEntry(element, true)], {} as IntersectionObserver);
 		}
 
 		expect(mockCallback).toHaveBeenCalledTimes(1);
@@ -96,10 +105,7 @@ describe('useIntersectionObserver()', () => {
 		// Simulate no intersection
 		const callback = mockConstructor.__callback;
 		if (callback) {
-			callback(
-				[{ isIntersecting: false, target: element }] as IntersectionObserverEntry[],
-				{} as IntersectionObserver,
-			);
+			callback([createMockEntry(element, false)], {} as IntersectionObserver);
 		}
 
 		expect(mockCallback).not.toHaveBeenCalled();
@@ -118,10 +124,7 @@ describe('useIntersectionObserver()', () => {
 		// Simulate intersection
 		const callback = mockConstructor.__callback;
 		if (callback) {
-			callback(
-				[{ isIntersecting: true, target: element }] as IntersectionObserverEntry[],
-				{} as IntersectionObserver,
-			);
+			callback([createMockEntry(element, true)], {} as IntersectionObserver);
 		}
 
 		expect(mockIntersectionObserver.disconnect).toHaveBeenCalledTimes(1);
@@ -141,10 +144,7 @@ describe('useIntersectionObserver()', () => {
 		// Simulate intersection
 		const callback = mockConstructor.__callback;
 		if (callback) {
-			callback(
-				[{ isIntersecting: true, target: element }] as IntersectionObserverEntry[],
-				{} as IntersectionObserver,
-			);
+			callback([createMockEntry(element, true)], {} as IntersectionObserver);
 		}
 
 		expect(mockIntersectionObserver.disconnect).not.toHaveBeenCalled();

--- a/packages/frontend/editor-ui/src/composables/useIntersectionObserver.ts
+++ b/packages/frontend/editor-ui/src/composables/useIntersectionObserver.ts
@@ -1,0 +1,91 @@
+import { ref, onBeforeUnmount, type Ref } from 'vue';
+
+export interface UseIntersectionObserverOptions {
+	/**
+	 * The root element for intersection detection (scrollable container)
+	 */
+	root: Ref<Element | null>;
+
+	/**
+	 * Threshold for intersection (0.0 to 1.0)
+	 * @default 0.01
+	 */
+	threshold?: number;
+
+	/**
+	 * Callback to execute when element intersects
+	 */
+	onIntersect: () => void;
+
+	/**
+	 * Whether to disconnect observer after first intersection
+	 * @default true
+	 */
+	once?: boolean;
+}
+
+/**
+ * Composable for observing element intersections with automatic cleanup
+ *
+ * @example
+ * const { observe } = useIntersectionObserver({
+ *   root: containerRef,
+ *   onIntersect: () => loadMore(),
+ * });
+ *
+ * // Observe last item in list
+ * observe(lastItemElement);
+ */
+export function useIntersectionObserver(options: UseIntersectionObserverOptions) {
+	const observer = ref<IntersectionObserver | null>(null);
+
+	/**
+	 * Stop observing and clean up the observer
+	 */
+	const disconnect = () => {
+		if (observer.value) {
+			observer.value.disconnect();
+			observer.value = null;
+		}
+	};
+
+	/**
+	 * Start observing an element for intersection
+	 * Automatically cleans up any existing observer before creating a new one
+	 */
+	const observe = (element: Element | null | undefined) => {
+		if (!element) return;
+
+		// Clean up existing observer if any
+		disconnect();
+
+		observer.value = new IntersectionObserver(
+			([entry]) => {
+				if (entry.isIntersecting) {
+					options.onIntersect();
+
+					if (options.once !== false) {
+						disconnect();
+					}
+				}
+			},
+			{
+				root: options.root.value,
+				threshold: options.threshold ?? 0.01,
+			},
+		);
+
+		observer.value.observe(element);
+	};
+
+	// Cleanup observer when component unmounts
+	onBeforeUnmount(() => {
+		disconnect();
+	});
+
+	return {
+		observer,
+		observe,
+		disconnect,
+	};
+}

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsSidebar.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsSidebar.vue
@@ -21,7 +21,7 @@ import { useIntersectionObserver } from '@/composables/useIntersectionObserver';
 
 import { ElCheckbox } from 'element-plus';
 import { N8nHeading, N8nLoading, N8nText } from '@n8n/design-system';
-type AutoScrollDeps = { activeExecutionSet: boolean; scroll: boolean };
+type AutoScrollDeps = { activeExecutionSet: boolean; cardsMounted: boolean; scroll: boolean };
 
 const props = defineProps<{
 	workflow?: IWorkflowDb;
@@ -48,6 +48,7 @@ const pageRedirectionHelper = usePageRedirectionHelper();
 
 const autoScrollDeps = ref<AutoScrollDeps>({
 	activeExecutionSet: false,
+	cardsMounted: false,
 	scroll: true,
 });
 const currentWorkflowExecutionsCardRefs = ref<Record<string, ComponentPublicInstance>>({});
@@ -111,6 +112,7 @@ function onItemMounted(id: string): void {
 
 	if (executionsStore.activeExecution?.id === id) {
 		autoScrollDeps.value.activeExecutionSet = true;
+		autoScrollDeps.value.cardsMounted = true;
 	}
 
 	// Observe the last item to trigger loading more executions
@@ -139,6 +141,7 @@ function onRetryExecution(payload: { execution: ExecutionSummary; command: strin
 
 function onFilterChanged(filter: ExecutionFilterType) {
 	autoScrollDeps.value.activeExecutionSet = false;
+	autoScrollDeps.value.cardsMounted = false;
 	autoScrollDeps.value.scroll = true;
 	emit('filterUpdated', filter);
 }

--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryList.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryList.vue
@@ -11,6 +11,7 @@ import type {
 import WorkflowHistoryListItem from './WorkflowHistoryListItem.vue';
 import type { IUser } from 'n8n-workflow';
 import { I18nT } from 'vue-i18n';
+import { useIntersectionObserver } from '@/composables/useIntersectionObserver';
 
 import { N8nLoading } from '@n8n/design-system';
 const props = defineProps<{
@@ -41,29 +42,16 @@ const i18n = useI18n();
 
 const listElement = ref<Element | null>(null);
 const shouldAutoScroll = ref(true);
-const observer = ref<IntersectionObserver | null>(null);
+
+const { observe: observeForLoadMore } = useIntersectionObserver({
+	root: listElement,
+	threshold: 0.01,
+	onIntersect: () =>
+		emit('loadMore', { take: props.requestNumberOfItems, skip: props.items.length }),
+});
 
 const getActions = (index: number) =>
 	index === 0 ? props.actions.filter((action) => action.value !== 'restore') : props.actions;
-
-const observeElement = (element: Element) => {
-	observer.value = new IntersectionObserver(
-		([entry]) => {
-			if (entry.isIntersecting) {
-				observer.value?.unobserve(element);
-				observer.value?.disconnect();
-				observer.value = null;
-				emit('loadMore', { take: props.requestNumberOfItems, skip: props.items.length });
-			}
-		},
-		{
-			root: listElement.value,
-			threshold: 0.01,
-		},
-	);
-
-	observer.value.observe(element);
-};
 
 const onAction = ({
 	action,
@@ -101,7 +89,7 @@ const onItemMounted = ({
 		index === props.items.length - 1 &&
 		props.lastReceivedItemsLength === props.requestNumberOfItems
 	) {
-		observeElement(listElement.value?.children[index] as Element);
+		observeForLoadMore(listElement.value?.children[index] as Element);
 	}
 };
 </script>

--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryList.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryList.vue
@@ -89,7 +89,7 @@ const onItemMounted = ({
 		index === props.items.length - 1 &&
 		props.lastReceivedItemsLength === props.requestNumberOfItems
 	) {
-		observeForLoadMore(listElement.value?.children[index] as Element);
+		observeForLoadMore(listElement.value?.children[index]);
 	}
 };
 </script>


### PR DESCRIPTION
## Summary

The initial execution list load wasn't working correctly on very tall screens.
Now it uses the same intersection observer approach we have in the workflow history feature.

https://github.com/user-attachments/assets/8fc61cff-bb46-4d5e-a7d1-71c0cea9be31

## Related Linear tickets, Github issues, and Community forum posts

PAY-3825

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
