### PR TITLE
 fix(editor): Show schema view when some upstream nodes are executed

### DIFF
--- a/packages/frontend/editor-ui/src/composables/useDataSchema.test.ts
+++ b/packages/frontend/editor-ui/src/composables/useDataSchema.test.ts
@@ -888,6 +888,7 @@ describe('useFlattenSchema', () => {
 					mock<SchemaNode>({
 						node: { name: 'Test Node' },
 						isNodeExecuted: false,
+						lastSuccessfulPreview: false,
 						schema: { type: 'object', value: [] },
 					}),
 				],
@@ -898,6 +899,36 @@ describe('useFlattenSchema', () => {
 			expect(result[0]).toEqual(expect.objectContaining({ type: 'header', title: 'Test Node' }));
 			expect(result[1]).toEqual(
 				expect.objectContaining({ type: 'empty', key: 'executeSchema', level: 1 }),
+			);
+		});
+
+		it('should not show executeSchema empty item when node is unexecuted but has lastSuccessfulPreview', () => {
+			const { flattenMultipleSchemas } = useFlattenSchema();
+
+			const result = flattenMultipleSchemas(
+				[
+					mock<SchemaNode>({
+						node: { name: 'Test Node' },
+						isNodeExecuted: false,
+						lastSuccessfulPreview: true,
+						isDataEmpty: false,
+						hasBinary: false,
+						schema: { type: 'object', value: [] },
+					}),
+				],
+				vi.fn(),
+				600,
+			);
+			expect(result).toHaveLength(2);
+			expect(result[0]).toEqual(
+				expect.objectContaining({
+					type: 'header',
+					title: 'Test Node',
+					lastSuccessfulPreview: true,
+				}),
+			);
+			expect(result[1]).toEqual(
+				expect.objectContaining({ type: 'empty', key: 'emptySchema', level: 1 }),
 			);
 		});
 

--- a/packages/frontend/editor-ui/src/composables/useDataSchema.ts
+++ b/packages/frontend/editor-ui/src/composables/useDataSchema.ts
@@ -474,7 +474,7 @@ export const useFlattenSchema = () => {
 			}
 
 			if (isEmptySchema(item.schema)) {
-				if (!item.isNodeExecuted) {
+				if (!item.isNodeExecuted && !item.lastSuccessfulPreview) {
 					acc.push(emptyItem('executeSchema', { level: 1 }));
 					return acc;
 				}

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
@@ -459,7 +459,7 @@ const runSelectorOptionsCount = computed(() => {
 	// If there is only one branch - we show only the runs containing the data in the connected branch
 	return nodeRunData.filter((nodeRun) => {
 		const nodeOutput = nodeRun?.data?.[connectionType.value]?.[currentOutputIndex.value];
-		return nodeOutput?.length > 0;
+		return nodeOutput && nodeOutput.length > 0;
 	}).length;
 });
 


### PR DESCRIPTION
## Summary

Fixes the schema view to display properly when there are both executed and unexecuted upstream nodes in the NDV.

- Schema view now shows when any upstream node has executed
- Executed nodes display their data in the schema view
- Empty state only appears when all upstream nodes are unexecuted
- Refactored render conditions in RunData

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1940/schema-view-still-show-when-there-are-unexecuted-upstream-nodes-but

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
