### PR TITLE
test: Fix credentials loading for evaluations spec

### DIFF
--- a/packages/testing/playwright/tests/ui/evaluations.spec.ts
+++ b/packages/testing/playwright/tests/ui/evaluations.spec.ts
@@ -11,7 +11,6 @@ test.describe('Evaluations @capability:proxy', () => {
 		await proxyServer.clearAllExpectations();
 
 		await n8n.goHome();
-		await n8n.workflows.addResource.workflow();
 	});
 
 	test('should load evaluations workflow and execute twice', async ({ n8n, proxyServer }) => {
@@ -54,6 +53,7 @@ m82JpEptTfAxFHtd8+Sb0U2G
 			},
 		});
 
+		await n8n.workflows.addResource.workflow();
 		// Import the evaluations workflow
 		await n8n.canvas.importWorkflow('evaluations_loop.json', 'Evaluations');
 


### PR DESCRIPTION
## Summary

Fix timing issue in evaluations Playwright test where credentials were being created after the workflow resource was initialized, causing the imported workflow nodes to not properly reference the credentials.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
