### PR TITLE
fix(ai-builder): Do not show validation issues as tool errors

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/prompts/main-agent.prompt.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/prompts/main-agent.prompt.ts
@@ -60,7 +60,7 @@ Follow this proven sequence for creating robust workflows:
 6. **Validation Phase** (tool call) - MANDATORY
    - Run validate_workflow after applying changes to refresh the workflow validation report
    - Review <workflow_validation_report> and resolve any violations before finalizing
-   - Why: Ensures structural issues are surfaced early; rerun validation after major updates
+   - Why: Ensures structural issues are surfaced early; rerun validation after major updates 
 
 <parallel_node_creation_example>
 Example: Creating and configuring a workflow (complete process):
@@ -455,6 +455,11 @@ update_node_parameters({{
 }})
 </handling_uncertainty>
 
+<workflow_validation_note>
+When reviewing workflow validation results, if a warning or error doesn’t need a fix, say that the workflow was reviewed and no changes are required. 
+Use simple, reassuring language, for example: “Validation completed successfully. The ‘Get Menu Tool’ uses fixed inputs and doesn’t need dynamic expressions.” 
+Avoid technical terms like “false positive” or “expression binding.” Keep the message short, clear, and include details only if the user needs to act.
+</workflow_validation_note>
 `;
 
 const responsePatterns = `

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/prompts/main-agent.prompt.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/prompts/main-agent.prompt.ts
@@ -60,7 +60,7 @@ Follow this proven sequence for creating robust workflows:
 6. **Validation Phase** (tool call) - MANDATORY
    - Run validate_workflow after applying changes to refresh the workflow validation report
    - Review <workflow_validation_report> and resolve any violations before finalizing
-   - Why: Ensures structural issues are surfaced early; rerun validation after major updates 
+   - Why: Ensures structural issues are surfaced early; rerun validation after major updates
 
 <parallel_node_creation_example>
 Example: Creating and configuring a workflow (complete process):
@@ -455,11 +455,6 @@ update_node_parameters({{
 }})
 </handling_uncertainty>
 
-<workflow_validation_note>
-When reviewing workflow validation results, if a warning or error doesn’t need a fix, say that the workflow was reviewed and no changes are required. 
-Use simple, reassuring language, for example: “Validation completed successfully. The ‘Get Menu Tool’ uses fixed inputs and doesn’t need dynamic expressions.” 
-Avoid technical terms like “false positive” or “expression binding.” Keep the message short, clear, and include details only if the user needs to act.
-</workflow_validation_note>
 `;
 
 const responsePatterns = `

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/test/validate-workflow.tool.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/test/validate-workflow.tool.test.ts
@@ -110,11 +110,11 @@ describe('validateWorkflow tool', () => {
 		});
 	});
 
-	it('should return error when critical or major violations exist', async () => {
+	it('should return violations without triggering tool error when critical or major violations exist', async () => {
 		const workflow = createWorkflow([createNode()]);
 		setupWorkflowState(mockGetCurrentTaskInput, workflow);
 
-		const blockingEvaluation: ProgrammaticChecksResult = {
+		const validationResult: ProgrammaticChecksResult = {
 			...sampleValidationResult,
 			connections: [
 				{
@@ -125,33 +125,23 @@ describe('validateWorkflow tool', () => {
 			],
 		};
 
-		mockProgrammaticValidation.mockReturnValue(blockingEvaluation);
+		mockProgrammaticValidation.mockReturnValue(validationResult);
 
 		const config = createToolConfigWithWriter('validate_workflow', 'call-blocking');
 
 		const result = await validateWorkflowTool.invoke({}, config);
 		const content = parseToolResult<ParsedToolContent>(result);
 
-		expectToolError(
-			content,
-			/Error: Workflow validation failed due to critical or major violations./,
-		);
-		expect(content.update.workflowValidation).toBeUndefined();
+		expectToolSuccess(content, 'Workflow Validation Summary:');
+		expect(content.update.workflowValidation).toEqual(validationResult);
 
 		const progressMessages = extractProgressMessages(config.writer);
 		expect(findProgressMessage(progressMessages, 'running', 'input')).toBeDefined();
 		expect(findProgressMessage(progressMessages, 'running', 'progress')).toBeDefined();
-		const errorMessage = findProgressMessage(progressMessages, 'error');
-		expect(errorMessage).toBeDefined();
-		expect(errorMessage?.updates[0]?.data).toMatchObject({
-			message: expect.stringContaining('Workflow validation failed'),
+		const completedMessage = findProgressMessage(progressMessages, 'completed');
+		expect(completedMessage).toBeDefined();
+		expect(completedMessage?.updates[0]?.data).toMatchObject({
+			message: expect.stringContaining('Workflow Validation Summary:'),
 		});
-
-		expect(mockLogger.warn).toHaveBeenCalledWith(
-			'validate_workflow tool detected blocking violations',
-			expect.objectContaining({
-				violations: expect.arrayContaining([expect.objectContaining({ type: 'critical' })]),
-			}),
-		);
 	});
 });

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/validate-workflow.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/validate-workflow.tool.ts
@@ -5,7 +5,6 @@ import { z } from 'zod';
 
 import type { BuilderTool, BuilderToolBase } from '@/utils/stream-processor';
 import { programmaticValidation } from '@/validation/programmatic';
-import type { ProgrammaticViolation } from '@/validation/types';
 
 import { ToolExecutionError, ValidationError } from '../errors';
 import { formatWorkflowValidation } from '../utils/workflow-validation';
@@ -45,29 +44,6 @@ export function createValidateWorkflowTool(
 					},
 					parsedNodeTypes,
 				);
-
-				const blockingViolations: ProgrammaticViolation[] = [
-					...violations.connections,
-					...violations.trigger,
-					...violations.agentPrompt,
-					...violations.tools,
-					...violations.fromAi,
-				].filter((violation) => violation.type === 'critical' || violation.type === 'major');
-
-				if (blockingViolations.length > 0) {
-					const summary = formatWorkflowValidation(violations);
-					const validationError = new ValidationError(
-						`Workflow validation failed due to critical or major violations.\n${summary}`,
-						{ extra: { violations: blockingViolations } },
-					);
-
-					reporter.error(validationError);
-					logger?.debug('validate_workflow tool detected blocking violations', {
-						violations: blockingViolations,
-					});
-
-					return createErrorResponse(config, validationError);
-				}
 
 				const message = formatWorkflowValidation(violations);
 

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/validate-workflow.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/validate-workflow.tool.ts
@@ -62,7 +62,7 @@ export function createValidateWorkflowTool(
 					);
 
 					reporter.error(validationError);
-					logger?.warn('validate_workflow tool detected blocking violations', {
+					logger?.debug('validate_workflow tool detected blocking violations', {
 						violations: blockingViolations,
 					});
 


### PR DESCRIPTION
## Summary

This PR changes how `validate_workflow` works in case there are violations.
Before it triggered tool error, now it just returns violations back to the agent with a successful tool execution result.

This affects how `Validating workflow` step is being shown in the AI builder chat (now it always shows the green check mark).

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-1613/ai-builder-handle-false-negative-validation-checks

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
