### PR TITLE
fix(editor): Limit telemetry event size to 32kb

### DIFF
--- a/packages/cli/src/telemetry/index.ts
+++ b/packages/cli/src/telemetry/index.ts
@@ -235,6 +235,27 @@ export class Telemetry {
 			context: {},
 		};
 
+		// Check payload size (32 KB limit)
+		const payloadSize = Buffer.byteLength(JSON.stringify(payload), 'utf8');
+		const maxPayloadSize = 32 * 1024; // 32 KB in bytes
+
+		if (payloadSize > maxPayloadSize) {
+			this.errorReporter.error(
+				new Error(
+					`Telemetry event "${eventName}" payload size (${payloadSize} bytes) exceeds limit (${maxPayloadSize} bytes)`,
+				),
+				{
+					extra: {
+						eventName,
+						payloadSize,
+						maxPayloadSize,
+						userId: payload.userId,
+					},
+				},
+			);
+			return;
+		}
+
 		this.postHog?.track(payload);
 
 		return this.rudderStack.track({

--- a/packages/cli/src/telemetry/index.ts
+++ b/packages/cli/src/telemetry/index.ts
@@ -235,14 +235,14 @@ export class Telemetry {
 			context: {},
 		};
 
-		// Check payload size (32 KB limit)
+		// Limiting payload size to 32 KB
 		const payloadSize = Buffer.byteLength(JSON.stringify(payload), 'utf8');
-		const maxPayloadSize = 32 * 1024; // 32 KB in bytes
+		const maxPayloadSize = 32 << 10; // 32 KB
 
 		if (payloadSize > maxPayloadSize) {
-			this.errorReporter.error(
+			this.errorReporter.warn(
 				new Error(
-					`Telemetry event "${eventName}" payload size (${payloadSize} bytes) exceeds limit (${maxPayloadSize} bytes)`,
+					`Telemetry event "${eventName}" payload size (${payloadSize} bytes) exceeds limit (${maxPayloadSize} bytes). Skipping event.`,
 				),
 				{
 					extra: {

--- a/packages/cli/src/telemetry/index.ts
+++ b/packages/cli/src/telemetry/index.ts
@@ -235,8 +235,15 @@ export class Telemetry {
 			context: {},
 		};
 
-		// Limiting payload size to 32 KB
-		const payloadSize = Buffer.byteLength(JSON.stringify(payload), 'utf8');
+		// Build the actual payload that will be sent to RudderStack (with fake IP)
+		const rudderStackPayload = {
+			...payload,
+			// provide a fake IP address to instruct RudderStack to not use the user's IP address
+			context: { ...payload.context, ip: '0.0.0.0' },
+		};
+
+		// Limiting payload size to 32 KB - measure the actual payload sent to RudderStack
+		const payloadSize = Buffer.byteLength(JSON.stringify(rudderStackPayload), 'utf8');
 		const maxPayloadSize = 32 << 10; // 32 KB
 
 		if (payloadSize > maxPayloadSize) {
@@ -258,11 +265,7 @@ export class Telemetry {
 
 		this.postHog?.track(payload);
 
-		return this.rudderStack.track({
-			...payload,
-			// provide a fake IP address to instruct RudderStack to not use the user's IP address
-			context: { ...payload.context, ip: '0.0.0.0' },
-		});
+		return this.rudderStack.track(rudderStackPayload);
 	}
 
 	// test helpers


### PR DESCRIPTION
## Summary

Rudderstack events can fail if it goes beyond 32KB. 
With this PR, events with large payload are skipped and logged into sentry

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
