### PR TITLE
fix(core): Don't execute the current node itself when executing previous nodes

### DIFF
--- a/packages/cli/src/__tests__/manual-execution.service.test.ts
+++ b/packages/cli/src/__tests__/manual-execution.service.test.ts
@@ -185,7 +185,7 @@ describe('ManualExecutionService', () => {
 			);
 		});
 
-		it('should correctly include destinationNode in executionData when provided', async () => {
+		it.only('should correctly include destinationNode in executionData when provided', async () => {
 			const mockTriggerData = mock<ITaskData>();
 			const startNodeName = 'startNode';
 			const triggerNodeName = 'triggerNode';
@@ -198,7 +198,7 @@ describe('ManualExecutionService', () => {
 				},
 				startNodes: [{ name: startNodeName }],
 				executionMode: 'manual',
-				destinationNode: destinationNodeName,
+				destinationNode: { nodeName: destinationNodeName, mode: 'exclusive' },
 			});
 
 			const startNode = mock<INode>({ name: startNodeName });
@@ -226,7 +226,7 @@ describe('ManualExecutionService', () => {
 				data.executionMode,
 				expect.objectContaining({
 					startData: {
-						destinationNode: destinationNodeName,
+						destinationNode: { nodeName: destinationNodeName, mode: 'exclusive' },
 					},
 					resultData: expect.any(Object),
 					executionData: expect.any(Object),
@@ -384,7 +384,7 @@ describe('ManualExecutionService', () => {
 				runData: mockRunData,
 				startNodes: [{ name: 'node1' }],
 				dirtyNodeNames,
-				destinationNode: destinationNodeName,
+				destinationNode: { nodeName: destinationNodeName, mode: 'exclusive' },
 			});
 
 			const workflow = mock<Workflow>({
@@ -493,7 +493,7 @@ describe('ManualExecutionService', () => {
 				executionMode: 'manual',
 				runData: mockRunData,
 				startNodes: [],
-				destinationNode: destinationNodeName,
+				destinationNode: { nodeName: destinationNodeName, mode: 'exclusive' },
 				pinData: {},
 				dirtyNodeNames: [],
 				agentRequest: undefined,

--- a/packages/cli/src/__tests__/manual-execution.service.test.ts
+++ b/packages/cli/src/__tests__/manual-execution.service.test.ts
@@ -13,6 +13,7 @@ import type {
 	IWaitingForExecution,
 	IWaitingForExecutionSource,
 	INodeExecutionData,
+	DestinationNode,
 } from 'n8n-workflow';
 import type PCancelable from 'p-cancelable';
 
@@ -190,6 +191,7 @@ describe('ManualExecutionService', () => {
 			const startNodeName = 'startNode';
 			const triggerNodeName = 'triggerNode';
 			const destinationNodeName = 'destinationNode';
+			const destinationNode: DestinationNode = { nodeName: destinationNodeName, mode: 'exclusive' };
 
 			const data = mock<IWorkflowExecutionDataProcess>({
 				triggerToStartFrom: {
@@ -198,7 +200,7 @@ describe('ManualExecutionService', () => {
 				},
 				startNodes: [{ name: startNodeName }],
 				executionMode: 'manual',
-				destinationNode: { nodeName: destinationNodeName, mode: 'exclusive' },
+				destinationNode,
 			});
 
 			const startNode = mock<INode>({ name: startNodeName });
@@ -226,7 +228,7 @@ describe('ManualExecutionService', () => {
 				data.executionMode,
 				expect.objectContaining({
 					startData: {
-						destinationNode: { nodeName: destinationNodeName, mode: 'exclusive' },
+						destinationNode,
 					},
 					resultData: expect.any(Object),
 					executionData: expect.any(Object),
@@ -379,12 +381,13 @@ describe('ManualExecutionService', () => {
 			const mockRunData = { node1: [{ data: { main: [[{ json: {} }]] } }] };
 			const dirtyNodeNames = ['node2', 'node3'];
 			const destinationNodeName = 'destinationNode';
+			const destinationNode: DestinationNode = { nodeName: destinationNodeName, mode: 'exclusive' };
 			const data = mock<IWorkflowExecutionDataProcess>({
 				executionMode: 'manual',
 				runData: mockRunData,
 				startNodes: [{ name: 'node1' }],
 				dirtyNodeNames,
-				destinationNode: { nodeName: destinationNodeName, mode: 'exclusive' },
+				destinationNode,
 			});
 
 			const workflow = mock<Workflow>({
@@ -411,7 +414,7 @@ describe('ManualExecutionService', () => {
 
 			expect(mockRunPartialWorkflow2).toHaveBeenCalled();
 			expect(mockRunPartialWorkflow2.mock.calls[0][0]).toBe(workflow);
-			expect(mockRunPartialWorkflow2.mock.calls[0][4]).toBe(destinationNodeName);
+			expect(mockRunPartialWorkflow2.mock.calls[0][4]).toBe(data.destinationNode);
 		});
 
 		it('should validate nodes exist before execution', async () => {
@@ -489,11 +492,12 @@ describe('ManualExecutionService', () => {
 		it('should call runPartialWorkflow2 with runData and empty startNodes', async () => {
 			const mockRunData = { nodeA: [{ data: { main: [[{ json: { value: 'test' } }]] } }] };
 			const destinationNodeName = 'nodeB';
+			const destinationNode: DestinationNode = { nodeName: destinationNodeName, mode: 'exclusive' };
 			const data = mock<IWorkflowExecutionDataProcess>({
 				executionMode: 'manual',
 				runData: mockRunData,
 				startNodes: [],
-				destinationNode: { nodeName: destinationNodeName, mode: 'exclusive' },
+				destinationNode,
 				pinData: {},
 				dirtyNodeNames: [],
 				agentRequest: undefined,
@@ -526,7 +530,7 @@ describe('ManualExecutionService', () => {
 				mockRunData,
 				data.pinData,
 				data.dirtyNodeNames,
-				destinationNodeName,
+				destinationNode,
 				data.agentRequest,
 			);
 		});

--- a/packages/cli/src/__tests__/manual-execution.service.test.ts
+++ b/packages/cli/src/__tests__/manual-execution.service.test.ts
@@ -185,7 +185,7 @@ describe('ManualExecutionService', () => {
 			);
 		});
 
-		it.only('should correctly include destinationNode in executionData when provided', async () => {
+		it('should correctly include destinationNode in executionData when provided', async () => {
 			const mockTriggerData = mock<ITaskData>();
 			const startNodeName = 'startNode';
 			const triggerNodeName = 'triggerNode';

--- a/packages/cli/src/evaluation.ee/test-runner/__tests__/test-runner.service.ee.test.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/__tests__/test-runner.service.ee.test.ts
@@ -457,7 +457,8 @@ describe('TestRunnerService', () => {
 			const runCallArg = workflowRunner.run.mock.calls[0][0];
 
 			// Verify it has the correct structure
-			expect(runCallArg).toHaveProperty('destinationNode', triggerNodeName);
+			expect(runCallArg).toHaveProperty('destinationNode.nodeName', triggerNodeName);
+			expect(runCallArg).toHaveProperty('destinationNode.mode', 'inclusive');
 			expect(runCallArg).toHaveProperty('executionMode', 'manual');
 			expect(runCallArg).toHaveProperty('workflowData.settings.saveManualExecutions', false);
 			expect(runCallArg).toHaveProperty('workflowData.settings.saveDataErrorExecution', 'none');
@@ -530,7 +531,8 @@ describe('TestRunnerService', () => {
 			const runCallArg = workflowRunner.run.mock.calls[0][0];
 
 			// Verify it has the correct structure
-			expect(runCallArg).toHaveProperty('destinationNode', triggerNodeName);
+			expect(runCallArg).toHaveProperty('destinationNode.nodeName', triggerNodeName);
+			expect(runCallArg).toHaveProperty('destinationNode.mode', 'inclusive');
 			expect(runCallArg).toHaveProperty('executionMode', 'manual');
 			expect(runCallArg).toHaveProperty('workflowData.settings.saveManualExecutions', false);
 			expect(runCallArg).toHaveProperty('workflowData.settings.saveDataErrorExecution', 'none');

--- a/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
@@ -318,7 +318,7 @@ export class TestRunnerService {
 		};
 
 		const data: IWorkflowExecutionDataProcess = {
-			destinationNode: triggerNode.name,
+			destinationNode: { nodeName: triggerNode.name, mode: 'inclusive' },
 			executionMode: 'manual',
 			runData: {},
 			workflowData: {
@@ -334,7 +334,7 @@ export class TestRunnerService {
 			userId: metadata.userId,
 			executionData: {
 				startData: {
-					destinationNode: triggerNode.name,
+					destinationNode: { nodeName: triggerNode.name, mode: 'inclusive' },
 				},
 				resultData: {
 					runData: {},

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -1285,7 +1285,7 @@ describe('TelemetryEventRelay', () => {
 				mode: 'manual',
 				data: {
 					startData: {
-						destinationNode: 'OpenAI',
+						destinationNode: { nodeName: 'OpenAI', mode: 'exclusive' },
 						runNodeFilter: ['OpenAI'],
 					},
 					resultData: {
@@ -1387,7 +1387,7 @@ describe('TelemetryEventRelay', () => {
 				mode: 'manual',
 				data: {
 					startData: {
-						destinationNode: 'OpenAI',
+						destinationNode: { nodeName: 'OpenAI', mode: 'exclusive' },
 						runNodeFilter: ['OpenAI'],
 					},
 					resultData: {
@@ -1597,7 +1597,7 @@ describe('TelemetryEventRelay', () => {
 						nodeExecutionStack: [{ node: { credentials: { openAiApi: { id: 'nhu-l8E4hX' } } } }],
 					},
 					startData: {
-						destinationNode: 'OpenAI',
+						destinationNode: { nodeName: 'OpenAI', mode: 'exclusive' },
 						runNodeFilter: ['OpenAI'],
 					},
 					resultData: {
@@ -1707,7 +1707,7 @@ describe('TelemetryEventRelay', () => {
 				mode: 'trigger',
 				data: {
 					startData: {
-						destinationNode: 'OpenAI',
+						destinationNode: { nodeName: 'OpenAI', mode: 'exclusive' },
 						runNodeFilter: ['OpenAI'],
 					},
 					executionData: {

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -792,9 +792,9 @@ export class TelemetryEventRelay extends EventRelay {
 						...manualExecEventProperties,
 						node_type: TelemetryHelpers.getNodeTypeForName(
 							workflow,
-							runData.data.startData?.destinationNode,
+							runData.data.startData?.destinationNode?.nodeName,
 						)?.type,
-						node_id: nodeGraphResult.nameIndices[runData.data.startData?.destinationNode],
+						node_id: nodeGraphResult.nameIndices[runData.data.startData?.destinationNode?.nodeName],
 					};
 
 					this.telemetry.track('Manual node exec finished', telemetryPayload);

--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -130,8 +130,8 @@ describe('Execution Lifecycle Hooks', () => {
 		};
 		successfulRunWithRewiredDestination.data = {
 			startData: {
-				destinationNode: 'PartialExecutionToolExecutor',
-				originalDestinationNode: nodeName,
+				destinationNode: { nodeName: 'PartialExecutionToolExecutor', mode: 'exclusive' },
+				originalDestinationNode: { nodeName: nodeName, mode: 'exclusive' },
 			},
 			resultData: {
 				runData: {},
@@ -182,7 +182,10 @@ describe('Execution Lifecycle Hooks', () => {
 					userId: expectedUserId,
 				});
 
-				expect(successfulRunWithRewiredDestination.data.startData?.destinationNode).toBe(nodeName);
+				expect(successfulRunWithRewiredDestination.data.startData?.destinationNode).toEqual({
+					nodeName,
+					mode: 'exclusive',
+				});
 				expect(
 					successfulRunWithRewiredDestination.data.startData?.originalDestinationNode,
 				).toBeUndefined();

--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -131,7 +131,7 @@ describe('Execution Lifecycle Hooks', () => {
 		successfulRunWithRewiredDestination.data = {
 			startData: {
 				destinationNode: { nodeName: 'PartialExecutionToolExecutor', mode: 'exclusive' },
-				originalDestinationNode: { nodeName: nodeName, mode: 'exclusive' },
+				originalDestinationNode: { nodeName, mode: 'exclusive' },
 			},
 			resultData: {
 				runData: {},

--- a/packages/cli/src/executions/execution-data.service.ts
+++ b/packages/cli/src/executions/execution-data.service.ts
@@ -30,7 +30,7 @@ export class ExecutionDataService {
 
 		if (node) {
 			returnData.data.startData = {
-				destinationNode: node.name,
+				destinationNode: { nodeName: node.name, mode: 'inclusive' },
 				runNodeFilter: [node.name],
 			};
 			returnData.data.resultData.lastNodeExecuted = node.name;

--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -322,7 +322,7 @@ export class ExecutionService {
 
 		const executionData: IRunExecutionData = {
 			startData: {
-				destinationNode: node.name,
+				destinationNode: { nodeName: node.name, mode: 'inclusive' },
 				runNodeFilter: [node.name],
 			},
 			executionData: {

--- a/packages/cli/src/manual-execution.service.ts
+++ b/packages/cli/src/manual-execution.service.ts
@@ -94,7 +94,7 @@ export class ManualExecutionService {
 			};
 
 			if (data.destinationNode) {
-				executionData.startData = { destinationNode: { ...data.destinationNode } };
+				executionData.startData = { destinationNode: data.destinationNode };
 			}
 
 			const workflowExecute = new WorkflowExecute(

--- a/packages/cli/src/manual-execution.service.ts
+++ b/packages/cli/src/manual-execution.service.ts
@@ -70,7 +70,7 @@ export class ManualExecutionService {
 			let waitingExecution: IWaitingForExecution = {};
 			let waitingExecutionSource: IWaitingForExecutionSource = {};
 
-			if (data.destinationNode !== data.triggerToStartFrom.name) {
+			if (data.destinationNode?.nodeName !== data.triggerToStartFrom.name) {
 				const recreatedStack = recreateNodeExecutionStack(
 					filterDisabledNodes(DirectedGraph.fromWorkflow(workflow)),
 					new Set(startNodes),
@@ -94,7 +94,7 @@ export class ManualExecutionService {
 			};
 
 			if (data.destinationNode) {
-				executionData.startData = { destinationNode: data.destinationNode };
+				executionData.startData = { destinationNode: { ...data.destinationNode } };
 			}
 
 			const workflowExecute = new WorkflowExecute(
@@ -119,10 +119,10 @@ export class ManualExecutionService {
 			const startNode = this.getExecutionStartNode(data, workflow);
 
 			if (data.destinationNode) {
-				const destinationNode = workflow.getNode(data.destinationNode);
+				const destinationNode = workflow.getNode(data.destinationNode.nodeName);
 				a.ok(
 					destinationNode,
-					`Could not find a node named "${data.destinationNode}" in the workflow.`,
+					`Could not find a node named "${data.destinationNode.nodeName}" in the workflow.`,
 				);
 
 				const destinationNodeType = workflow.nodeTypes.getByNameAndVersion(
@@ -147,7 +147,10 @@ export class ManualExecutionService {
 						data.executionData.startData.originalDestinationNode = data.destinationNode;
 					}
 					// Set destination to Tool Executor
-					data.destinationNode = TOOL_EXECUTOR_NODE_NAME;
+					data.destinationNode = {
+						nodeName: TOOL_EXECUTOR_NODE_NAME,
+						mode: data.destinationNode.mode,
+					};
 				}
 			}
 

--- a/packages/cli/src/task-runners/task-managers/__tests__/data-request-response-stripper.test.ts
+++ b/packages/cli/src/task-runners/task-managers/__tests__/data-request-response-stripper.test.ts
@@ -100,7 +100,7 @@ const taskData: DataRequestResponse = {
 	node: codeNode,
 	runExecutionData: {
 		startData: {
-			destinationNode: codeNode.name,
+			destinationNode: { nodeName: codeNode.name, mode: 'exclusive' },
 			runNodeFilter: [triggerNode.name, debugHelperNode.name, codeNode.name],
 		},
 		resultData: {

--- a/packages/cli/src/webhooks/__tests__/webhook-helpers.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-helpers.test.ts
@@ -396,10 +396,13 @@ describe('prepareExecutionData', () => {
 			webhookResultData,
 			undefined,
 			{},
-			'targetNode',
+			{ nodeName: 'targetNode', mode: 'exclusive' },
 		);
 
-		expect(runExecutionData.startData?.destinationNode).toBe('targetNode');
+		expect(runExecutionData.startData?.destinationNode).toEqual({
+			nodeName: 'targetNode',
+			mode: 'exclusive',
+		});
 	});
 
 	test('should update execution data with execution data merge', () => {

--- a/packages/cli/src/webhooks/test-webhooks.ts
+++ b/packages/cli/src/webhooks/test-webhooks.ts
@@ -10,6 +10,7 @@ import type {
 	IHttpRequestMethods,
 	IRunData,
 	IWorkflowBase,
+	DestinationNode,
 } from 'n8n-workflow';
 
 import { authAllowlistedNodes } from './constants';
@@ -138,7 +139,7 @@ export class TestWebhooks implements IWebhookManager {
 						if (error !== null) reject(error);
 						else resolve(data);
 					},
-					destinationNode,
+					destinationNode ? { nodeName: destinationNode, mode: 'exclusive' as const } : undefined,
 				);
 
 				// The workflow did not run as the request was probably setup related
@@ -269,7 +270,7 @@ export class TestWebhooks implements IWebhookManager {
 		additionalData: IWorkflowExecuteAdditionalData;
 		runData?: IRunData;
 		pushRef?: string;
-		destinationNode?: string;
+		destinationNode?: DestinationNode;
 		triggerToStartFrom?: WorkflowRequest.ManualRunPayload['triggerToStartFrom'];
 	}) {
 		const {
@@ -289,7 +290,7 @@ export class TestWebhooks implements IWebhookManager {
 		let webhooks = WebhookHelpers.getWorkflowWebhooks(
 			workflow,
 			additionalData,
-			destinationNode,
+			destinationNode?.nodeName,
 			true,
 		);
 
@@ -347,7 +348,7 @@ export class TestWebhooks implements IWebhookManager {
 			const registration: TestWebhookRegistration = {
 				pushRef,
 				workflowEntity,
-				destinationNode,
+				destinationNode: destinationNode?.nodeName,
 				webhook: cacheableWebhook as IWebhookData,
 			};
 

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -29,6 +29,7 @@ import type {
 	IWorkflowExecutionDataProcess,
 	IWorkflowBase,
 	WebhookResponseData,
+	DestinationNode,
 } from 'n8n-workflow';
 import {
 	CHAT_TRIGGER_NODE_TYPE,
@@ -296,7 +297,7 @@ export function prepareExecutionData(
 	webhookResultData: IWebhookResponseData,
 	runExecutionData: IRunExecutionData | undefined,
 	runExecutionDataMerge: object = {},
-	destinationNode?: string,
+	destinationNode?: DestinationNode,
 	executionId?: string,
 	workflowData?: IWorkflowBase,
 ): { runExecutionData: IRunExecutionData; pinData: IPinData | undefined } {
@@ -368,7 +369,7 @@ export async function executeWebhook(
 		error: Error | null,
 		data: IWebhookResponseCallbackData | WebhookResponse,
 	) => void,
-	destinationNode?: string,
+	destinationNode?: DestinationNode,
 ): Promise<string | undefined> {
 	// Get the nodeType to know which responseMode is set
 	const nodeType = workflow.nodeTypes.getByNameAndVersion(

--- a/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
@@ -141,7 +141,7 @@ describe('WorkflowExecutionService', () => {
 			const runPayload = mock<WorkflowRequest.ManualRunPayload>({
 				workflowData: { nodes: [node] },
 				startNodes: [],
-				destinationNode: node.name,
+				destinationNode: { nodeName: node.name, mode: 'exclusive' },
 				agentRequest: undefined,
 			});
 

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -119,7 +119,7 @@ export class WorkflowExecutionService {
 			workflowData,
 			startNodes?.map((nodeData) => nodeData.name),
 			pinData,
-			destinationNode,
+			destinationNode?.nodeName,
 		);
 
 		// TODO: Reverse the order of events, first find out if the execution is
@@ -134,7 +134,7 @@ export class WorkflowExecutionService {
 		// here and either create the runData (e.g. scheduler trigger) or wait for
 		// a webhook or event.
 		if (destinationNode) {
-			if (this.isDestinationNodeATrigger(destinationNode, workflowData)) {
+			if (this.isDestinationNodeATrigger(destinationNode.nodeName, workflowData)) {
 				runData = undefined;
 			}
 		}

--- a/packages/cli/src/workflows/workflow.request.ts
+++ b/packages/cli/src/workflows/workflow.request.ts
@@ -8,6 +8,7 @@ import type {
 	ITaskData,
 	IWorkflowBase,
 	AiAgentRequest,
+	DestinationNode,
 } from 'n8n-workflow';
 
 import type { ListQuery } from '@/requests';
@@ -33,7 +34,7 @@ export declare namespace WorkflowRequest {
 		workflowData: IWorkflowBase;
 		runData?: IRunData;
 		startNodes?: StartNodeData[];
-		destinationNode?: string;
+		destinationNode?: DestinationNode;
 		dirtyNodeNames?: string[];
 		triggerToStartFrom?: {
 			name: string;

--- a/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
@@ -283,7 +283,7 @@ describe('processRunExecutionData', () => {
 			const executionData: IRunExecutionData = {
 				startData: {
 					startNodes: [{ name: node1.name, sourceData: null }],
-					destinationNode: node1.name,
+					destinationNode: { nodeName: node1.name, mode: 'exclusive' },
 				},
 				resultData: { runData: {} },
 				executionData: {

--- a/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
@@ -216,7 +216,10 @@ describe('WorkflowExecute', () => {
 			const workflowExecute = new WorkflowExecute(additionalData, executionMode);
 
 			// ACT
-			await workflowExecute.run(workflowInstance, trigger, 'node1');
+			await workflowExecute.run(workflowInstance, trigger, {
+				nodeName: 'node1',
+				mode: 'exclusive',
+			});
 
 			// ASSERT
 			const workflowHooks = runHookSpy.mock.calls.filter(
@@ -234,8 +237,6 @@ describe('WorkflowExecute', () => {
 			expect(nodeHooks.map((hook) => ({ name: hook[0], node: hook[1][0] }))).toEqual([
 				{ name: 'nodeExecuteBefore', node: 'trigger' },
 				{ name: 'nodeExecuteAfter', node: 'trigger' },
-				{ name: 'nodeExecuteBefore', node: 'node1' },
-				{ name: 'nodeExecuteAfter', node: 'node1' },
 			]);
 		});
 
@@ -293,7 +294,10 @@ describe('WorkflowExecute', () => {
 			const workflowExecute = new WorkflowExecute(additionalData, executionMode);
 
 			// ACT
-			await workflowExecute.run(workflowInstance, trigger, 'node1');
+			await workflowExecute.run(workflowInstance, trigger, {
+				nodeName: 'node1',
+				mode: 'exclusive',
+			});
 
 			// ASSERT
 			const workflowHooks = runHookSpy.mock.calls.filter(
@@ -311,8 +315,6 @@ describe('WorkflowExecute', () => {
 			expect(nodeHooks.map((hook) => ({ name: hook[0], node: hook[1][0] }))).toEqual([
 				{ name: 'nodeExecuteBefore', node: 'trigger' },
 				{ name: 'nodeExecuteAfter', node: 'trigger' },
-				{ name: 'nodeExecuteBefore', node: 'node1' },
-				{ name: 'nodeExecuteAfter', node: 'node1' },
 			]);
 		});
 
@@ -434,7 +436,7 @@ describe('WorkflowExecute', () => {
 				[node2.name]: [toITaskData([{ data: { name: node2.name } }])],
 			};
 			const dirtyNodeNames = [node1.name];
-			const destinationNode = node2.name;
+			const destinationNode = { nodeName: node2.name, mode: 'exclusive' as const };
 
 			jest.spyOn(workflowExecute, 'processRunExecutionData').mockImplementationOnce(jest.fn());
 
@@ -497,7 +499,7 @@ describe('WorkflowExecute', () => {
 				[destination.name]: [toITaskData([{ data: { node: 'destination' } }])],
 			};
 			const dirtyNodeNames = [set2.name];
-			const destinationNode = destination.name;
+			const destinationNode = { nodeName: destination.name, mode: 'exclusive' as const };
 
 			// ACT
 			await workflowExecute.runPartialWorkflow2(
@@ -542,7 +544,7 @@ describe('WorkflowExecute', () => {
 				[node2.name]: [toITaskData([{ data: { name: node2.name } }])],
 			};
 			const dirtyNodeNames: string[] = [];
-			const destinationNode = node2.name;
+			const destinationNode = { nodeName: node2.name, mode: 'exclusive' as const };
 
 			const processRunExecutionDataSpy = jest
 				.spyOn(workflowExecute, 'processRunExecutionData')
@@ -616,13 +618,10 @@ describe('WorkflowExecute', () => {
 			);
 
 			// ACT
-			await workflowExecute.runPartialWorkflow2(
-				workflow,
-				runData,
-				pinData,
-				dirtyNodeNames,
-				afterLoop.name,
-			);
+			await workflowExecute.runPartialWorkflow2(workflow, runData, pinData, dirtyNodeNames, {
+				nodeName: afterLoop.name,
+				mode: 'exclusive',
+			});
 
 			// ASSERT
 			expect(recreateNodeExecutionStackSpy).toHaveBeenNthCalledWith(
@@ -669,13 +668,10 @@ describe('WorkflowExecute', () => {
 			const cleanRunDataSpy = jest.spyOn(partialExecutionUtils, 'cleanRunData');
 
 			// ACT
-			await workflowExecute.runPartialWorkflow2(
-				workflow,
-				runData,
-				pinData,
-				dirtyNodeNames,
-				node1.name,
-			);
+			await workflowExecute.runPartialWorkflow2(workflow, runData, pinData, dirtyNodeNames, {
+				nodeName: node1.name,
+				mode: 'exclusive',
+			});
 
 			// ASSERT
 			const subgraph = new DirectedGraph()
@@ -725,13 +721,10 @@ describe('WorkflowExecute', () => {
 			const cleanRunDataSpy = jest.spyOn(partialExecutionUtils, 'cleanRunData');
 
 			// ACT
-			await workflowExecute.runPartialWorkflow2(
-				workflow,
-				runData,
-				pinData,
-				dirtyNodeNames,
-				destination.name,
-			);
+			await workflowExecute.runPartialWorkflow2(workflow, runData, pinData, dirtyNodeNames, {
+				nodeName: destination.name,
+				mode: 'exclusive',
+			});
 
 			// ASSERT
 			const subgraph = new DirectedGraph()
@@ -781,13 +774,10 @@ describe('WorkflowExecute', () => {
 				.mockImplementationOnce(jest.fn());
 
 			// ACT
-			await workflowExecute.runPartialWorkflow2(
-				workflow,
-				runData,
-				pinData,
-				dirtyNodeNames,
-				orphan.name,
-			);
+			await workflowExecute.runPartialWorkflow2(workflow, runData, pinData, dirtyNodeNames, {
+				nodeName: orphan.name,
+				mode: 'exclusive',
+			});
 
 			// ASSERT
 			expect(processRunExecutionDataSpy).toHaveBeenCalledTimes(1);
@@ -859,13 +849,10 @@ describe('WorkflowExecute', () => {
 				.toWorkflow({ ...workflow });
 
 			// ACT
-			await workflowExecute.runPartialWorkflow2(
-				workflow,
-				runData,
-				pinData,
-				dirtyNodeNames,
-				tool.name,
-			);
+			await workflowExecute.runPartialWorkflow2(workflow, runData, pinData, dirtyNodeNames, {
+				nodeName: tool.name,
+				mode: 'exclusive',
+			});
 
 			// ASSERT
 			expect(processRunExecutionDataSpy).toHaveBeenCalledTimes(1);
@@ -902,7 +889,7 @@ describe('WorkflowExecute', () => {
 				[node2.name]: [toITaskData([{ data: { name: node2.name } }], { executionIndex: 2 })],
 			};
 			const dirtyNodeNames: string[] = [];
-			const destinationNode = node2.name;
+			const destinationNode = { nodeName: node2.name, mode: 'exclusive' as const };
 
 			const processRunExecutionDataSpy = jest.spyOn(workflowExecute, 'processRunExecutionData');
 
@@ -951,7 +938,7 @@ describe('WorkflowExecute', () => {
 				],
 			};
 			const dirtyNodeNames: string[] = [];
-			const destinationNode = node1.name;
+			const destinationNode = { nodeName: node1.name, mode: 'exclusive' as const };
 
 			const processRunExecutionDataSpy = jest.spyOn(workflowExecute, 'processRunExecutionData');
 
@@ -967,7 +954,7 @@ describe('WorkflowExecute', () => {
 			// ASSERT
 			expect(processRunExecutionDataSpy).toHaveBeenCalledTimes(1);
 			expect(additionalData.hooks?.runHook).toHaveBeenCalledWith('nodeExecuteBefore', [
-				node1.name,
+				{ nodeName: node1.name, mode: 'exclusive' },
 				expect.objectContaining({ executionIndex: 1 }),
 			]);
 		});
@@ -994,7 +981,7 @@ describe('WorkflowExecute', () => {
 				[node1.name]: [toITaskData([{ data: { name: node1.name } }])],
 			};
 			const dirtyNodeNames: string[] = [];
-			const destinationNode = node2.name;
+			const destinationNode = { nodeName: node2.name, mode: 'exclusive' as const };
 
 			const processRunExecutionDataSpy = jest
 				.spyOn(workflowExecute, 'processRunExecutionData')

--- a/packages/frontend/editor-ui/src/Interface.ts
+++ b/packages/frontend/editor-ui/src/Interface.ts
@@ -32,6 +32,7 @@ import type {
 	ITaskData,
 	ISourceData,
 	PublicInstalledPackage,
+	DestinationNode,
 } from 'n8n-workflow';
 import type { Version } from '@n8n/rest-api-client/api/versions';
 import type { Cloud, InstanceUsage } from '@n8n/rest-api-client/api/cloudPlans';
@@ -183,7 +184,7 @@ export interface IAiDataContent {
 export interface IStartRunData {
 	workflowData: WorkflowData;
 	startNodes?: StartNodeData[];
-	destinationNode?: string;
+	destinationNode?: DestinationNode;
 	runData?: IRunData;
 	dirtyNodeNames?: string[];
 	triggerToStartFrom?: {

--- a/packages/frontend/editor-ui/src/app/components/FromAiParametersModal.vue
+++ b/packages/frontend/editor-ui/src/app/components/FromAiParametersModal.vue
@@ -265,7 +265,7 @@ const onExecute = async () => {
 	telemetry.track('User clicked execute node button in modal', telemetryPayload);
 
 	await runWorkflow({
-		destinationNode: node.value.name,
+		destinationNode: { nodeName: node.value.name, mode: 'inclusive' },
 	});
 
 	onClose();

--- a/packages/frontend/editor-ui/src/app/components/NodeExecuteButton.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/NodeExecuteButton.test.ts
@@ -318,7 +318,10 @@ describe('NodeExecuteButton', () => {
 
 		expect(externalHooks.run).toHaveBeenCalledWith('nodeExecuteButton.onClick', expect.any(Object));
 		expect(runWorkflow.runWorkflow).toHaveBeenCalledWith({
-			destinationNode: node.name,
+			destinationNode: {
+				nodeName: node.name,
+				mode: 'inclusive',
+			},
 			source: 'RunData.ExecuteNodeButton',
 		});
 		expect(emitted().execute).toBeTruthy();

--- a/packages/frontend/editor-ui/src/app/components/NodeExecuteButton.vue
+++ b/packages/frontend/editor-ui/src/app/components/NodeExecuteButton.vue
@@ -55,12 +55,14 @@ const props = withDefaults(
 		tooltip?: string;
 		tooltipPlacement?: 'top' | 'bottom' | 'left' | 'right';
 		showLoadingSpinner?: boolean;
+		executionMode?: 'inclusive' | 'exclusive';
 	}>(),
 	{
 		disabled: false,
 		transparent: false,
 		square: false,
 		showLoadingSpinner: true,
+		executionMode: 'inclusive',
 	},
 );
 
@@ -384,7 +386,7 @@ async function onClick() {
 				await externalHooks.run('nodeExecuteButton.onClick', telemetryPayload);
 
 				await runWorkflow({
-					destinationNode: props.nodeName,
+					destinationNode: { nodeName: props.nodeName, mode: props.executionMode },
 					source: 'RunData.ExecuteNodeButton',
 				});
 

--- a/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.test.ts
@@ -519,7 +519,7 @@ describe('useRunWorkflow({ router })', () => {
 			vi.mocked(workflowsStore).incomingConnectionsByNodeName.mockReturnValue({});
 
 			// ACT
-			await runWorkflow({ destinationNode: destinationNodeName });
+			await runWorkflow({ destinationNode: { nodeName: destinationNodeName, mode: 'inclusive' } });
 
 			// ASSERT
 			expect(workflowsStore.runWorkflow).toHaveBeenCalledTimes(1);
@@ -593,7 +593,10 @@ describe('useRunWorkflow({ router })', () => {
 
 			const { runWorkflow } = composable;
 
-			await runWorkflow({ destinationNode: 'Code 1', source: 'Node.executeNode' });
+			await runWorkflow({
+				destinationNode: { nodeName: 'Code 1', mode: 'inclusive' },
+				source: 'Node.executeNode',
+			});
 
 			expect(workflowsStore.runWorkflow).toHaveBeenCalledWith(
 				expect.objectContaining({ dirtyNodeNames: [executeName] }),
@@ -774,7 +777,9 @@ describe('useRunWorkflow({ router })', () => {
 			const setWorkflowExecutionData = vi.spyOn(workflowState, 'setWorkflowExecutionData');
 
 			// ACT
-			const result = await runWorkflow({ destinationNode: 'Test node' });
+			const result = await runWorkflow({
+				destinationNode: { nodeName: 'Test node', mode: 'inclusive' },
+			});
 
 			// ASSERT
 			expect(agentRequestStore.getAgentRequest).toHaveBeenCalledWith('WorkflowId', 'Test id');
@@ -785,7 +790,7 @@ describe('useRunWorkflow({ router })', () => {
 						name: 'tool',
 					},
 				},
-				destinationNode: 'Test node',
+				destinationNode: { nodeName: 'Test node', mode: 'inclusive' },
 				dirtyNodeNames: undefined,
 				runData: mockRunData,
 				startNodes: [
@@ -824,7 +829,9 @@ describe('useRunWorkflow({ router })', () => {
 			const setWorkflowExecutionData = vi.spyOn(workflowState, 'setWorkflowExecutionData');
 
 			// ACT
-			const result = await runWorkflow({ destinationNode: 'some node name' });
+			const result = await runWorkflow({
+				destinationNode: { nodeName: 'some node name', mode: 'inclusive' },
+			});
 
 			// ASSERT
 			expect(result).toEqual(mockExecutionResponse);

--- a/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.ts
@@ -15,6 +15,7 @@ import type {
 	INode,
 	IDataObject,
 	IWorkflowBase,
+	DestinationNode,
 } from 'n8n-workflow';
 import { NodeConnectionTypes, TelemetryHelpers } from 'n8n-workflow';
 import { retry } from '@n8n/utils/retry';
@@ -130,7 +131,7 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 	}
 
 	async function runWorkflow(options: {
-		destinationNode?: string;
+		destinationNode?: DestinationNode;
 		triggerNode?: string;
 		rerunTriggerNode?: boolean;
 		nodeData?: ITaskData;
@@ -147,7 +148,7 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 			let directParentNodes: string[] = [];
 			if (options.destinationNode !== undefined) {
 				directParentNodes = workflowObject.value.getParentNodes(
-					options.destinationNode,
+					options.destinationNode.nodeName,
 					NodeConnectionTypes.Main,
 					-1,
 				);
@@ -170,7 +171,7 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 
 			const { startNodeNames } = consolidatedData;
 			const destinationNodeType = options.destinationNode
-				? workflowsStore.getNodeByName(options.destinationNode)?.type
+				? workflowsStore.getNodeByName(options.destinationNode.nodeName)?.type
 				: '';
 
 			let executedNode: string | undefined;
@@ -181,15 +182,15 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 				'destinationNode' in options &&
 				options.destinationNode !== undefined
 			) {
-				executedNode = options.destinationNode;
-				startNodeNames.push(options.destinationNode);
+				executedNode = options.destinationNode.nodeName;
+				startNodeNames.push(options.destinationNode.nodeName);
 			} else if (options.triggerNode && options.nodeData && !options.rerunTriggerNode) {
 				// starts execution from downstream nodes of trigger node
 				startNodeNames.push(
 					...workflowObject.value.getChildNodes(options.triggerNode, NodeConnectionTypes.Main, 1),
 				);
 			} else if (options.destinationNode) {
-				executedNode = options.destinationNode;
+				executedNode = options.destinationNode.nodeName;
 			}
 
 			if (options.triggerNode) {
@@ -202,11 +203,11 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 			// If the destination node is specified, check if it is a chat node or has a chat parent
 			if (
 				options.destinationNode &&
-				(workflowsStore.checkIfNodeHasChatParent(options.destinationNode) ||
+				(workflowsStore.checkIfNodeHasChatParent(options.destinationNode.nodeName) ||
 					destinationNodeType === CHAT_TRIGGER_NODE_TYPE) &&
 				options.source !== 'RunData.ManualChatMessage'
 			) {
-				const startNode = workflowObject.value.getStartNode(options.destinationNode);
+				const startNode = workflowObject.value.getStartNode(options.destinationNode.nodeName);
 				if (startNode && startNode.type === CHAT_TRIGGER_NODE_TYPE) {
 					// Check if the chat node has input data or pin data
 					const chatHasInputData =
@@ -216,7 +217,7 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 					// If the chat node has no input data or pin data, open the chat modal
 					// and halt the execution
 					if (!chatHasInputData && !chatHasPinData) {
-						workflowsStore.chatPartialExecutionDestinationNode = options.destinationNode;
+						workflowsStore.chatPartialExecutionDestinationNode = options.destinationNode.nodeName;
 						startChat();
 						return;
 					}
@@ -280,9 +281,9 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 				.filter((node) => {
 					if (
 						options.destinationNode &&
-						workflowsStore.checkIfNodeHasChatParent(options.destinationNode)
+						workflowsStore.checkIfNodeHasChatParent(options.destinationNode.nodeName)
 					) {
-						return node.name !== options.destinationNode;
+						return node.name !== options.destinationNode.nodeName;
 					}
 					return true;
 				});
@@ -323,7 +324,7 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 
 			if ('destinationNode' in options) {
 				startRunData.destinationNode = options.destinationNode;
-				const nodeId = workflowsStore.getNodeByName(options.destinationNode as string)?.id;
+				const nodeId = workflowsStore.getNodeByName(options.destinationNode!.nodeName)?.id;
 				if (workflowObject.value.id && nodeId) {
 					const agentRequest = agentRequestStore.getAgentRequest(workflowObject.value.id, nodeId);
 
@@ -397,7 +398,7 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 				await displayForm({
 					nodes: workflowData.nodes,
 					runData: workflowsStore.getWorkflowExecution?.data?.resultData?.runData,
-					destinationNode: options.destinationNode,
+					destinationNode: options.destinationNode?.nodeName,
 					triggerNode: options.triggerNode,
 					pinData,
 					directParentNodes,
@@ -407,7 +408,7 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 			} catch (error) {}
 
 			await externalHooks.run('workflowRun.runWorkflow', {
-				nodeName: options.destinationNode,
+				nodeName: options.destinationNode?.nodeName,
 				source: options.source,
 			});
 

--- a/packages/frontend/editor-ui/src/app/types/externalHooks.ts
+++ b/packages/frontend/editor-ui/src/app/types/externalHooks.ts
@@ -9,6 +9,8 @@ import type {
 	NodeConnectionType,
 	NodeParameterValue,
 	NodeParameterValueType,
+	DestinationNode,
+	StartNodeData,
 } from 'n8n-workflow';
 import type { RouteLocation } from 'vue-router';
 import type {
@@ -64,7 +66,12 @@ interface OutputModeChangedEventData {
 }
 interface ExecutionFinishedEventData {
 	runDataExecutedStartData:
-		| { destinationNode?: string | undefined; runNodeFilter?: string[] | undefined }
+		| {
+				startNodes?: StartNodeData[];
+				destinationNode?: DestinationNode | undefined;
+				originalDestinationNode?: DestinationNode | undefined;
+				runNodeFilter?: string[] | undefined;
+		  }
 		| undefined;
 	nodeName?: string;
 	errorMessage: string;

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -1258,7 +1258,10 @@ async function onRunWorkflowToNode(id: string) {
 		trackRunWorkflowToNode(node);
 		agentRequestStore.clearAgentRequests(workflowsStore.workflowId, node.id);
 
-		void runWorkflow({ destinationNode: node.name, source: 'Node.executeNode' });
+		void runWorkflow({
+			destinationNode: { nodeName: node.name, mode: 'inclusive' },
+			source: 'Node.executeNode',
+		});
 	}
 }
 

--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogsOverviewPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogsOverviewPanel.test.ts
@@ -124,7 +124,9 @@ describe('LogsOverviewPanel', () => {
 
 		await fireEvent.click(within(aiAgentRow).getAllByLabelText('Execute step')[0]);
 		await waitFor(() =>
-			expect(spyRun).toHaveBeenCalledWith(expect.objectContaining({ destinationNode: 'AI Agent' })),
+			expect(spyRun).toHaveBeenCalledWith(
+				expect.objectContaining({ destinationNode: { nodeName: 'AI Agent', mode: 'inclusive' } }),
+			),
 		);
 	});
 });

--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogsOverviewRows.vue
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogsOverviewRows.vue
@@ -52,7 +52,9 @@ async function handleTriggerPartialExecution(treeNode: LogEntry) {
 	const latestName = latestNodeInfo[treeNode.node.id]?.name ?? treeNode.node.name;
 
 	if (latestName) {
-		await runWorkflow.runWorkflow({ destinationNode: latestName });
+		await runWorkflow.runWorkflow({
+			destinationNode: { nodeName: latestName, mode: 'inclusive' },
+		});
 	}
 }
 

--- a/packages/frontend/editor-ui/src/features/execution/logs/composables/useChatState.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/composables/useChatState.ts
@@ -164,7 +164,10 @@ export function useChatState(isReadOnly: boolean): ChatState {
 		};
 
 		if (workflowsStore.chatPartialExecutionDestinationNode) {
-			runWorkflowOptions.destinationNode = workflowsStore.chatPartialExecutionDestinationNode;
+			runWorkflowOptions.destinationNode = {
+				nodeName: workflowsStore.chatPartialExecutionDestinationNode,
+				mode: 'inclusive',
+			};
 			workflowsStore.chatPartialExecutionDestinationNode = null;
 		}
 

--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/InputPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/InputPanel.vue
@@ -494,7 +494,12 @@ function handleChangeCollapsingColumn(columnName: string | null) {
 				<NDVEmptyState v-if="nodeNotRunMessageVariant === 'simple'">
 					<I18nT scope="global" keypath="ndv.input.noOutputData.embeddedNdv.description">
 						<template #link>
-							<a href="#" @click.prevent="runWorkflow({ destinationNode: activeNodeName })">
+							<a
+								href="#"
+								@click.prevent="
+									runWorkflow({ destinationNode: { nodeName: activeNodeName, mode: 'exclusive' } })
+								"
+							>
 								{{ i18n.baseText('ndv.input.noOutputData.embeddedNdv.link') }}
 							</a>
 						</template>
@@ -585,6 +590,7 @@ function handleChangeCollapsingColumn(columnName: string | null) {
 						data-test-id="execute-previous-node"
 						tooltip-placement="bottom"
 						:show-loading-spinner="false"
+						execution-mode="exclusive"
 						@execute="onNodeExecute"
 					>
 						<template

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
@@ -1420,7 +1420,7 @@ function onSearchClear() {
 
 function executeNode(nodeName: string) {
 	void runWorkflow({
-		destinationNode: nodeName,
+		destinationNode: { nodeName, mode: 'inclusive' },
 		source: 'schema-preview',
 	});
 }

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchema.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchema.vue
@@ -557,6 +557,7 @@ const onDragEnd = (el: HTMLElement) => {
 											size="small"
 											type="secondary"
 											hide-icon
+											execution-mode="exclusive"
 										/>
 									</template>
 								</I18nT>

--- a/packages/testing/playwright/tests/ui/execute-previous-nodes.spec.ts
+++ b/packages/testing/playwright/tests/ui/execute-previous-nodes.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '../../fixtures/base';
+
+test.describe('Execute previous nodes', () => {
+	test('should execute only previous nodes and not the current node', async ({ n8n }) => {
+		// Import workflow with Manual Trigger -> Code1 -> Code2
+		await n8n.start.fromImportedWorkflow('execute-previous-nodes.json');
+
+		// Open the second Code node (Code2)
+		await n8n.canvas.openNode('Code2');
+
+		// Click "Execute previous nodes" - this should execute Manual Trigger and Code1, but NOT Code2
+		await n8n.ndv.executePrevious();
+
+		// Wait for execution to complete by checking that input panel has data
+		await expect(n8n.ndv.inputPanel.getDataContainer()).toBeVisible({ timeout: 15000 });
+
+		// Verify that the input panel has data from Code1 (which was executed)
+		await expect(n8n.ndv.inputPanel.get()).toContainText('myNewField');
+
+		// Verify Code2 (current node) was NOT executed.
+		// The output panel should show the placeholder text, not execution results
+		await expect(n8n.ndv.outputPanel.get()).toContainText('Execute this node to view data');
+
+		// Close the NDV
+		await n8n.ndv.close();
+
+		// Open Code1 to verify it WAS executed
+		await n8n.canvas.openNode('Code1');
+
+		// Verify Code1 has execution success indicator and output data
+		await expect(n8n.ndv.getNodeRunSuccessIndicator()).toBeVisible();
+		await expect(n8n.ndv.outputPanel.getItemsCount()).toBeVisible();
+
+		// Close and verify Manual Trigger was also executed
+		await n8n.ndv.close();
+		await n8n.canvas.openNode('Manual Trigger');
+		await expect(n8n.ndv.getNodeRunSuccessIndicator()).toBeVisible();
+	});
+});

--- a/packages/testing/playwright/workflows/execute-previous-nodes.json
+++ b/packages/testing/playwright/workflows/execute-previous-nodes.json
@@ -1,0 +1,58 @@
+{
+	"name": "Execute Previous Nodes Test",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "manual-trigger-node",
+			"name": "Manual Trigger",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [250, 300]
+		},
+		{
+			"parameters": {
+				"jsCode": "for (const item of $input.all()) {\n  item.json.myNewField = 1;\n}\n\nreturn $input.all();"
+			},
+			"id": "code-node-1",
+			"name": "Code1",
+			"type": "n8n-nodes-base.code",
+			"typeVersion": 2,
+			"position": [470, 300]
+		},
+		{
+			"parameters": {
+				"jsCode": "for (const item of $input.all()) {\n  item.json.myNewField = 1;\n}\n\nreturn $input.all();"
+			},
+			"id": "code-node-2",
+			"name": "Code2",
+			"type": "n8n-nodes-base.code",
+			"typeVersion": 2,
+			"position": [690, 300]
+		}
+	],
+	"connections": {
+		"Manual Trigger": {
+			"main": [
+				[
+					{
+						"node": "Code1",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Code1": {
+			"main": [
+				[
+					{
+						"node": "Code2",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"pinData": {}
+}

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2407,8 +2407,8 @@ export interface IRun {
 export interface IRunExecutionData {
 	startData?: {
 		startNodes?: StartNodeData[];
-		destinationNode?: string;
-		originalDestinationNode?: string;
+		destinationNode?: DestinationNode;
+		originalDestinationNode?: DestinationNode;
 		runNodeFilter?: string[];
 	};
 	resultData: {
@@ -2599,8 +2599,13 @@ export interface IWorkflowCredentials {
 	};
 }
 
+export interface DestinationNode {
+	nodeName: string;
+	mode: 'inclusive' | 'exclusive';
+}
+
 export interface IWorkflowExecutionDataProcess {
-	destinationNode?: string;
+	destinationNode?: DestinationNode;
 	restartExecutionId?: string;
 	executionMode: WorkflowExecuteMode;
 	/**

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -868,28 +868,29 @@ export class Workflow {
 	 *
 	 */
 	getStartNode(destinationNode?: string): INode | undefined {
-		if (destinationNode) {
-			// Find the highest parent nodes of the given one
-			const nodeNames = this.getHighestNode(destinationNode);
-
-			if (nodeNames.length === 0) {
-				// If no parent nodes have been found then only the destination-node
-				// is in the tree so add that one
-				nodeNames.push(destinationNode);
-			}
-
-			// Check which node to return as start node
-			const node = this.__getStartNode(nodeNames);
-			if (node !== undefined) {
-				return node;
-			}
-
-			// If none of the above did find anything simply return the
-			// first parent node in the list
-			return this.nodes[nodeNames[0]];
+		if (!destinationNode) {
+			// If there's no destination, we consider all nodes.
+			return this.__getStartNode(Object.keys(this.nodes));
 		}
 
-		return this.__getStartNode(Object.keys(this.nodes));
+		// Find the highest parent nodes of the given one
+		const nodeNames = this.getHighestNode(destinationNode);
+
+		if (nodeNames.length === 0) {
+			// If no parent nodes have been found then only the destination-node
+			// is in the tree so add that one
+			nodeNames.push(destinationNode);
+		}
+
+		// Check which node to return as start node
+		const node = this.__getStartNode(nodeNames);
+		if (node !== undefined) {
+			return node;
+		}
+
+		// If none of the above did find anything simply return the
+		// first parent node in the list
+		return this.nodes[nodeNames[0]];
 	}
 
 	getConnectionsBetweenNodes(


### PR DESCRIPTION
## Summary

Don't execute the node itself when we try to `Execute previous nodes`.

It seems like this bug _may_ have existed in partial execution v1, was fixed in v2, and was re-introduced in September when the code paths were merged.

## Related Linear tickets, Github issues, and Community forum posts

Closes https://linear.app/n8n/issue/CAT-1265.


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adopts `DestinationNode { nodeName, mode }` (inclusive/exclusive) end-to-end and updates partial execution to exclude the current node in exclusive mode, with UI, API, telemetry, and tests adjusted accordingly.
> 
> - **Core/Workflow Engine**:
>   - Introduce `DestinationNode` (`{ nodeName, mode: 'inclusive'|'exclusive' }`) and plumb through `WorkflowExecute.run`/`runPartialWorkflow2` and `IRunExecutionData.startData`.
>   - Update run filtering: only include destination in `runNodeFilter` for `inclusive`; `exclusive` executes predecessors only.
>   - Tweak `Workflow.getStartNode()` logic to handle absent `destinationNode` and compute proper start node.
> - **CLI/Backend**:
>   - Replace string `destinationNode` with `DestinationNode` across manual runs, webhooks, evaluation test runner, execution/telemetry services.
>   - Preserve/restore `originalDestinationNode` when rewiring tool executions.
> - **Frontend**:
>   - Send `destinationNode` object; add `executionMode` to `NodeExecuteButton` (default `inclusive`); use `exclusive` for "Execute previous nodes" and similar flows.
>   - Update composables (`useRunWorkflow`), chat/logs triggers, and NDV panels to use the new shape.
> - **Telemetry**:
>   - Read destination via `destinationNode.nodeName`.
> - **Tests**:
>   - Adjust unit tests for new shape and behavior; add Playwright test verifying "Execute previous nodes" does not run the current node.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aba60ff725435bfd8fa30cd5a39bd1dc08f2f611. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->