### PR TITLE
fix(editor): Handle `executionFinished` event correctly for non-persisted executions

### DIFF
--- a/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/executionFinished.ts
+++ b/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/executionFinished.ts
@@ -114,13 +114,19 @@ export async function executionFinished(
 	let successToastAlreadyShown = false;
 
 	if (data.status === 'success') {
-		handleExecutionFinishedWithOther(options.workflowState, successToastAlreadyShown);
+		handleExecutionFinishedWithSuccessOrOther(options.workflowState, successToastAlreadyShown);
 		successToastAlreadyShown = true;
 	}
 
 	const execution = await fetchExecutionData(data.executionId);
 
+	/**
+	 * This accounts for the case where the execution is not stored.
+	 * We clear the active execution id and set processing to false and return early.
+	 * Returning early presists existing run data up to this point.
+	 */
 	if (!execution) {
+		options.workflowState.setActiveExecutionId(undefined);
 		uiStore.setProcessingExecutionResults(false);
 		return;
 	}
@@ -133,7 +139,7 @@ export async function executionFinished(
 	} else if (execution.status === 'error' || execution.status === 'canceled') {
 		handleExecutionFinishedWithErrorOrCanceled(execution, runExecutionData);
 	} else {
-		handleExecutionFinishedWithOther(options.workflowState, successToastAlreadyShown);
+		handleExecutionFinishedWithSuccessOrOther(options.workflowState, successToastAlreadyShown);
 	}
 
 	setRunExecutionData(execution, runExecutionData, options.workflowState);
@@ -372,7 +378,7 @@ function handleExecutionFinishedSuccessfully(
 /**
  * Handle the case when the workflow execution finished successfully.
  */
-export function handleExecutionFinishedWithOther(
+export function handleExecutionFinishedWithSuccessOrOther(
 	workflowState: WorkflowState,
 	successToastAlreadyShown: boolean,
 ) {

--- a/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/executionRecovered.ts
+++ b/packages/frontend/editor-ui/src/composables/usePushConnection/handlers/executionRecovered.ts
@@ -3,7 +3,7 @@ import { useUIStore } from '@/stores/ui.store';
 import {
 	fetchExecutionData,
 	getRunExecutionData,
-	handleExecutionFinishedWithOther,
+	handleExecutionFinishedWithSuccessOrOther,
 	handleExecutionFinishedWithErrorOrCanceled,
 	handleExecutionFinishedWithWaitTill,
 	setRunExecutionData,
@@ -40,7 +40,7 @@ export async function executionRecovered(
 	} else if (execution.status === 'error' || execution.status === 'canceled') {
 		handleExecutionFinishedWithErrorOrCanceled(execution, runExecutionData);
 	} else {
-		handleExecutionFinishedWithOther(options.workflowState, false);
+		handleExecutionFinishedWithSuccessOrOther(options.workflowState, false);
 	}
 
 	setRunExecutionData(execution, runExecutionData, options.workflowState);


### PR DESCRIPTION
## Summary

- Handle `executionFinished` event correctly for non-persisted executions

Looks like a long-living bug that hasn't been reported until now. There was no execution to be retrieved, therefore the event returned early without unsetting the active execution id.

https://github.com/user-attachments/assets/46bb7bb5-0b6b-46f5-95ca-79b1659a740e



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1676/extract-tags-code-into-featuresshared


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
