### PR TITLE
feat(editor): Allow duplicate and import in workflow menu if user has update permission

### DIFF
--- a/packages/frontend/editor-ui/src/components/MainHeader/WorkflowDetails.test.ts
+++ b/packages/frontend/editor-ui/src/components/MainHeader/WorkflowDetails.test.ts
@@ -211,6 +211,43 @@ describe('WorkflowDetails', () => {
 			});
 		});
 
+		it('should not have workflow duplicate and import without update permission', async () => {
+			const { getByTestId, queryByTestId } = renderComponent({
+				props: {
+					...workflow,
+					readOnly: false,
+					isArchived: false,
+					scopes: ['workflow:read'],
+				},
+			});
+
+			await userEvent.click(getByTestId('workflow-menu'));
+
+			expect(queryByTestId('workflow-menu-item-duplicate')).not.toBeInTheDocument();
+			expect(queryByTestId('workflow-menu-item-import-from-url')).not.toBeInTheDocument();
+			expect(queryByTestId('workflow-menu-item-import-from-file')).not.toBeInTheDocument();
+		});
+
+		it('should have workflow duplicate and import options if permission update is true', async () => {
+			const { getByTestId, queryByTestId } = renderComponent({
+				props: {
+					...workflow,
+					readOnly: false,
+					isArchived: false,
+					scopes: ['workflow:update'],
+				},
+			});
+
+			await userEvent.click(getByTestId('workflow-menu'));
+
+			expect(getByTestId('workflow-menu-item-duplicate')).toBeInTheDocument();
+			expect(getByTestId('workflow-menu-item-import-from-url')).toBeInTheDocument();
+			expect(getByTestId('workflow-menu-item-import-from-file')).toBeInTheDocument();
+			expect(queryByTestId('workflow-menu-item-delete')).not.toBeInTheDocument();
+			expect(queryByTestId('workflow-menu-item-archive')).not.toBeInTheDocument();
+			expect(queryByTestId('workflow-menu-item-unarchive')).not.toBeInTheDocument();
+		});
+
 		it("should have disabled 'Archive' option on new workflow", async () => {
 			const { getByTestId, queryByTestId } = renderComponent({
 				props: {

--- a/packages/frontend/editor-ui/src/components/MainHeader/WorkflowDetails.vue
+++ b/packages/frontend/editor-ui/src/components/MainHeader/WorkflowDetails.vue
@@ -189,7 +189,7 @@ const workflowMenuItems = computed<Array<ActionDropdownItem<WORKFLOW_MENU_ACTION
 	}
 
 	if (
-		(workflowPermissions.value.delete === true && !props.readOnly && !props.isArchived) ||
+		(workflowPermissions.value.update === true && !props.readOnly && !props.isArchived) ||
 		isNewWorkflow.value
 	) {
 		actions.unshift({


### PR DESCRIPTION

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Currently, users require 'workflow:delete' permission to be able to duplicate or import from file / url a workflow in the workflow detail view. 
This PR changes the required scope to be workflow:update

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-4032/bug-editor-non-owner-cant-duplicate-workflow

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
