### PR TITLE
fix(ai-builder): Fixing canvas buttons - if workflow builder is enabled always show "build with AI" button

### DIFF
--- a/packages/frontend/editor-ui/src/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/views/NodeView.vue
@@ -1819,10 +1819,7 @@ watch(
 			draggable: false,
 		};
 
-		fallbackNodes.value =
-			builderStore.isAIBuilderEnabled && builderStore.assistantMessages.length === 0
-				? [choicePromptItem]
-				: [addNodesItem];
+		fallbackNodes.value = builderStore.isAIBuilderEnabled ? [choicePromptItem] : [addNodesItem];
 	},
 );
 


### PR DESCRIPTION
## Summary

Fixing an issue where the canvas wouldn't revert back to the correct view, with both the build with AI and first steps buttons. Previous to this PR if an error occurred during the initial generation or if you aborted the initial run it would revert to just the "Add first steps..." button.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
