### PR TITLE
test: Fix flaky code node e2e test

### DIFF
--- a/packages/testing/playwright/tests/ui/6-code-node.spec.ts
+++ b/packages/testing/playwright/tests/ui/6-code-node.spec.ts
@@ -83,7 +83,9 @@ for (const item of $input.all()) {
 
 return
 `);
-			await expect(n8n.ndv.getLintErrors()).toHaveCount(6);
+			await expect
+				.poll(async () => (await n8n.ndv.getLintErrors().allTextContents()).join(''))
+				.toBe(['itemMatching()', 'item', 'item', 'first', 'item.foo', 'return'].join(''));
 			await n8n.ndv.getParameterInput('jsCode').getByText('itemMatching').hover();
 			await expect(n8n.ndv.getLintTooltip()).toContainText(
 				'`.itemMatching()` expects an item index to be passed in as its argument.',
@@ -107,7 +109,9 @@ $input.item()
 
 return []
 `);
-				await expect(n8n.ndv.getLintErrors()).toHaveCount(7);
+				await expect
+					.poll(async () => (await n8n.ndv.getLintErrors().allTextContents()).join(''))
+					.toBe(['itemMatching', 'all', 'first', '$input.item()', 'return []'].join(''));
 				await n8n.ndv.getParameterInput('jsCode').getByText('all').hover();
 				await expect(n8n.ndv.getLintTooltip()).toContainText(
 					"Method `$input.all()` is only available in the 'Run Once for All Items' mode.",


### PR DESCRIPTION
## Summary

This PR fixes a flaky e2e test for the code node UI.

An example failure: https://app.currents.dev/i/owDb9oXUbKss73U7/test/f941882fe516d31181e2-8bc1208bfe7ad1e86548

As shown in the screenshot, it looks like the DOM structure is affected by how cursor position ends up after `.fill(...)`, causing flakiness. Also tried to replace `fill` with `pressSequentially` but didn't help, so updated the assertion to not be affected by the DOM structure.

<img width="40%"  alt="Screenshot 2025-10-29 at 19 36 03" src="https://github.com/user-attachments/assets/04072d66-a031-4f33-9563-d8f16d3d58e3" />
<img width="40%" alt="Screenshot 2025-10-29 at 19 35 25" src="https://github.com/user-attachments/assets/d2120fba-72e1-43ac-9543-285bf3b32c8f" />

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
