### PR TITLE
fix(editor): Match user pagination options with API limits

### DIFF
--- a/packages/frontend/editor-ui/src/features/settings/users/components/SettingsUsersTable.vue
+++ b/packages/frontend/editor-ui/src/features/settings/users/components/SettingsUsersTable.vue
@@ -147,6 +147,7 @@ const onRoleChange = ({ role, userId }: { role: string; userId: string }) => {
 			:headers="headers"
 			:items="rows"
 			:items-length="data.count"
+			:page-sizes="[10, 25, 50]"
 			@update:options="emit('update:options', $event)"
 		>
 			<template #[`item.name`]="{ value }">


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

The users API is caped at 50, removed 100 as on option from the users settings UI

## Related Linear tickets, Github issues, and Community forum posts
[PAY-4018](https://linear.app/n8n/issue/PAY-4018/bug-users-page-showing-50-instead-of-100-users)


<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
