### PR TITLE
Use efficient SQL subquery for pruning workflow history versions

### DIFF
--- a/packages/@n8n/db/src/repositories/workflow-history.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-history.repository.ts
@@ -30,7 +30,7 @@ export class WorkflowHistoryRepository extends Repository<WorkflowHistory> {
 			.delete()
 			.from(WorkflowHistory)
 			.where('createdAt < :date', { date })
-			.andWhere(`versionId NOT IN ${sub}`)
+			.andWhere(`versionId NOT IN (${sub})`)
 			.execute();
 	}
 }

--- a/packages/@n8n/db/src/repositories/workflow-history.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-history.repository.ts
@@ -25,7 +25,7 @@ export class WorkflowHistoryRepository extends Repository<WorkflowHistory> {
 			.where('w.versionId IS NOT NULL')
 			.getQuery();
 
-		return this.manager
+		return await this.manager
 			.createQueryBuilder()
 			.delete()
 			.from(WorkflowHistory)

--- a/packages/@n8n/db/src/repositories/workflow.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow.repository.ts
@@ -72,14 +72,6 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 		return result.map(({ id }) => id);
 	}
 
-	async getAllVersionIds(): Promise<string[]> {
-		const result = await this.find({
-			select: { versionId: true },
-		});
-
-		return result.map(({ versionId }) => versionId).filter((id) => id !== null);
-	}
-
 	async getActiveIds({ maxResults }: { maxResults?: number } = {}) {
 		const activeWorkflows = await this.find({
 			select: ['id'],

--- a/packages/cli/src/workflows/workflow-history.ee/workflow-history-manager.ee.ts
+++ b/packages/cli/src/workflows/workflow-history.ee/workflow-history-manager.ee.ts
@@ -1,5 +1,5 @@
 import { Time } from '@n8n/constants';
-import { WorkflowHistoryRepository, WorkflowRepository } from '@n8n/db';
+import { WorkflowHistoryRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { DateTime } from 'luxon';
 
@@ -9,10 +9,7 @@ import { getWorkflowHistoryPruneTime } from './workflow-history-helper.ee';
 export class WorkflowHistoryManager {
 	pruneTimer?: NodeJS.Timeout;
 
-	constructor(
-		private workflowHistoryRepo: WorkflowHistoryRepository,
-		private workflowRepo: WorkflowRepository,
-	) {}
+	constructor(private workflowHistoryRepo: WorkflowHistoryRepository) {}
 
 	init() {
 		if (this.pruneTimer !== undefined) {

--- a/packages/cli/src/workflows/workflow-history.ee/workflow-history-manager.ee.ts
+++ b/packages/cli/src/workflows/workflow-history.ee/workflow-history-manager.ee.ts
@@ -37,9 +37,6 @@ export class WorkflowHistoryManager {
 		}
 		const pruneDateTime = DateTime.now().minus({ hours: pruneHours }).toJSDate();
 
-		// Get all latest workflow versions to exclude from pruning
-		const currentVersionIds = await this.workflowRepo.getAllVersionIds();
-
-		await this.workflowHistoryRepo.deleteEarlierThanExcept(pruneDateTime, currentVersionIds);
+		await this.workflowHistoryRepo.deleteEarlierThanExceptCurrent(pruneDateTime);
 	}
 }

--- a/packages/cli/test/integration/workflow-history-manager.test.ts
+++ b/packages/cli/test/integration/workflow-history-manager.test.ts
@@ -139,7 +139,7 @@ describe('Workflow History Manager', () => {
 	const pruneAndAssertCount = async (finalCount = 10, initialCount = 10) => {
 		expect(await repo.count()).toBe(initialCount);
 
-		const deleteSpy = jest.spyOn(repo, 'delete');
+		const deleteSpy = jest.spyOn(repo, 'deleteEarlierThanExceptCurrent');
 		await manager.prune();
 
 		if (initialCount === finalCount) {


### PR DESCRIPTION
## Summary

Improve workflow history pruning logic by avoiding loading the workflow ids into memory.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
