### PR TITLE
feat(core): Introduce distroless runners image

### DIFF
--- a/.github/scripts/determine-runners-tags.sh
+++ b/.github/scripts/determine-runners-tags.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+set -euo pipefail
+
+# Script to determine Docker tags for runners images (Alpine and distroless variants)
+#
+# Usage: determine-runners-tags.sh RELEASE_TYPE N8N_VERSION_TAG GHCR_BASE DOCKER_BASE PLATFORM GITHUB_OUTPUT
+#
+# Example:
+#   determine-runners-tags.sh \
+#     "stable" \
+#     "1.123.0" \
+#     "ghcr.io/n8n-io/runners" \
+#     "n8nio/runners" \
+#     "amd64" \
+#     "$GITHUB_OUTPUT"
+#
+# Output (written to GITHUB_OUTPUT):
+#   Alpine variant:
+#     tags=ghcr.io/n8n-io/runners:1.123.0-amd64, n8nio/runners:1.123.0-amd64
+#     ghcr_platform_tag=ghcr.io/n8n-io/runners:1.123.0-amd64
+#     dockerhub_platform_tag=n8nio/runners:1.123.0-amd64
+#     primary_ghcr_manifest_tag=ghcr.io/n8n-io/runners:1.123.0
+#
+#   Distroless variant:
+#     tags_distroless=ghcr.io/n8n-io/runners:1.123.0-distroless-amd64, n8nio/runners:1.123.0-distroless-amd64
+#     ghcr_platform_tag_distroless=ghcr.io/n8n-io/runners:1.123.0-distroless-amd64
+#     dockerhub_platform_tag_distroless=n8nio/runners:1.123.0-distroless-amd64
+#     primary_ghcr_manifest_tag_distroless=ghcr.io/n8n-io/runners:1.123.0-distroless
+
+RELEASE_TYPE="${1:?Missing RELEASE_TYPE argument}"
+N8N_VERSION_TAG="${2:?Missing N8N_VERSION_TAG argument}"
+GHCR_BASE="${3:?Missing GHCR_BASE argument}"
+DOCKER_BASE="${4:?Missing DOCKER_BASE argument}"
+PLATFORM="${5:?Missing PLATFORM argument}"
+GITHUB_OUTPUT="${6:?Missing GITHUB_OUTPUT argument}"
+
+generate_tags() {
+  local VARIANT_SUFFIX="$1"
+  local OUTPUT_FILE="$2"
+
+  local GHCR_TAGS_FOR_PUSH=""
+  local DOCKER_TAGS_FOR_PUSH=""
+  local PRIMARY_GHCR_MANIFEST_TAG_VALUE=""
+
+  case "$RELEASE_TYPE" in
+    "stable")
+      PRIMARY_GHCR_MANIFEST_TAG_VALUE="${GHCR_BASE}:${N8N_VERSION_TAG}${VARIANT_SUFFIX}"
+      GHCR_TAGS_FOR_PUSH="${PRIMARY_GHCR_MANIFEST_TAG_VALUE}-${PLATFORM}"
+      DOCKER_TAGS_FOR_PUSH="${DOCKER_BASE}:${N8N_VERSION_TAG}${VARIANT_SUFFIX}-${PLATFORM}"
+      ;;
+    "nightly")
+      PRIMARY_GHCR_MANIFEST_TAG_VALUE="${GHCR_BASE}:nightly${VARIANT_SUFFIX}"
+      GHCR_TAGS_FOR_PUSH="${PRIMARY_GHCR_MANIFEST_TAG_VALUE}-${PLATFORM}"
+      DOCKER_TAGS_FOR_PUSH="${DOCKER_BASE}:nightly${VARIANT_SUFFIX}-${PLATFORM}"
+      ;;
+    "branch")
+      PRIMARY_GHCR_MANIFEST_TAG_VALUE="${GHCR_BASE}:${N8N_VERSION_TAG}${VARIANT_SUFFIX}"
+      GHCR_TAGS_FOR_PUSH="${PRIMARY_GHCR_MANIFEST_TAG_VALUE}-${PLATFORM}"
+      DOCKER_TAGS_FOR_PUSH=""
+      ;;
+    "dev"|*)
+      if [[ "$N8N_VERSION_TAG" == pr-* ]]; then
+        PRIMARY_GHCR_MANIFEST_TAG_VALUE="${GHCR_BASE}:${N8N_VERSION_TAG}${VARIANT_SUFFIX}"
+        GHCR_TAGS_FOR_PUSH="${PRIMARY_GHCR_MANIFEST_TAG_VALUE}-${PLATFORM}"
+        DOCKER_TAGS_FOR_PUSH=""
+      else
+        PRIMARY_GHCR_MANIFEST_TAG_VALUE="${GHCR_BASE}:dev${VARIANT_SUFFIX}"
+        GHCR_TAGS_FOR_PUSH="${PRIMARY_GHCR_MANIFEST_TAG_VALUE}-${PLATFORM}"
+        DOCKER_TAGS_FOR_PUSH="${DOCKER_BASE}:dev${VARIANT_SUFFIX}-${PLATFORM}"
+      fi
+      ;;
+  esac
+
+  local ALL_TAGS="${GHCR_TAGS_FOR_PUSH}"
+  if [[ -n "$DOCKER_TAGS_FOR_PUSH" ]]; then
+    ALL_TAGS="${ALL_TAGS}\n${DOCKER_TAGS_FOR_PUSH}"
+  fi
+
+  {
+    echo "tags<<EOF"
+    echo -e "$ALL_TAGS"
+    echo "EOF"
+    echo "ghcr_platform_tag=${GHCR_TAGS_FOR_PUSH}"
+    echo "dockerhub_platform_tag=${DOCKER_TAGS_FOR_PUSH}"
+  } >> "$OUTPUT_FILE"
+
+  # Only output manifest tags from the first platform to avoid duplicates
+  if [[ "$PLATFORM" == "amd64" ]]; then
+    echo "primary_ghcr_manifest_tag=${PRIMARY_GHCR_MANIFEST_TAG_VALUE}" >> "$OUTPUT_FILE"
+  fi
+}
+
+# Reads outputs from a temp file and appends them to GITHUB_OUTPUT with _distroless suffix
+# Transforms variable names: tags -> tags_distroless, ghcr_platform_tag -> ghcr_platform_tag_distroless
+transform_and_append_distroless_outputs() {
+  local TEMP_FILE="$1"
+
+  while IFS= read -r line; do
+    if [[ "$line" == "tags<<EOF" ]]; then
+      echo "tags_distroless<<EOF" >> "$GITHUB_OUTPUT"
+    elif [[ "$line" =~ ^(ghcr_platform_tag|dockerhub_platform_tag|primary_ghcr_manifest_tag)= ]]; then
+      key="${line%%=*}"
+      value="${line#*=}"
+      echo "${key}_distroless=${value}" >> "$GITHUB_OUTPUT"
+    else
+      # Pass through EOF markers and tag content
+      echo "$line" >> "$GITHUB_OUTPUT"
+    fi
+  done < "$TEMP_FILE"
+}
+
+# Generate tags for Alpine variant (no suffix)
+generate_tags "" "$GITHUB_OUTPUT"
+
+# Generate tags for distroless variant
+DISTROLESS_OUTPUT=$(mktemp)
+generate_tags "-distroless" "$DISTROLESS_OUTPUT"
+transform_and_append_distroless_outputs "$DISTROLESS_OUTPUT"
+rm "$DISTROLESS_OUTPUT"

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -52,6 +52,7 @@ on:
       - '.github/workflows/docker-build-push.yml'
       - 'docker/images/n8n/Dockerfile'
       - 'docker/images/runners/Dockerfile'
+      - 'docker/images/runners/Dockerfile.distroless'
 
 jobs:
   determine-build-context:
@@ -172,6 +173,7 @@ jobs:
       image_ref: ${{ steps.determine-tags.outputs.primary_ghcr_manifest_tag }}
       primary_ghcr_manifest_tag: ${{ steps.determine-tags.outputs.primary_ghcr_manifest_tag }}
       runners_primary_ghcr_manifest_tag: ${{ steps.determine-runners-tags.outputs.primary_ghcr_manifest_tag }}
+      runners_distroless_primary_ghcr_manifest_tag: ${{ steps.determine-runners-tags.outputs.primary_ghcr_manifest_tag_distroless }}
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -264,68 +266,16 @@ jobs:
             echo "primary_ghcr_manifest_tag=${PRIMARY_GHCR_MANIFEST_TAG_VALUE}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Determine Docker tags (runners)
+      - name: Determine Docker tags (runners variants)
         id: determine-runners-tags
         run: |
-          RELEASE_TYPE="${{ needs.determine-build-context.outputs.release_type }}"
-          N8N_VERSION_TAG="${{ needs.determine-build-context.outputs.n8n_version }}"
-          GHCR_BASE="ghcr.io/${{ github.repository_owner }}/runners"
-          DOCKER_BASE="${{ secrets.DOCKER_USERNAME }}/runners"
-          PLATFORM="${{ matrix.platform }}"
-
-          GHCR_TAGS_FOR_PUSH=""
-          DOCKER_TAGS_FOR_PUSH=""
-          PRIMARY_GHCR_MANIFEST_TAG_VALUE=""
-
-          case "$RELEASE_TYPE" in
-            "stable")
-              PRIMARY_GHCR_MANIFEST_TAG_VALUE="${GHCR_BASE}:${N8N_VERSION_TAG}"
-              GHCR_TAGS_FOR_PUSH="${PRIMARY_GHCR_MANIFEST_TAG_VALUE}-${PLATFORM}"
-              DOCKER_TAGS_FOR_PUSH="${DOCKER_BASE}:${N8N_VERSION_TAG}-${PLATFORM}"
-              ;;
-            "nightly")
-              PRIMARY_GHCR_MANIFEST_TAG_VALUE="${GHCR_BASE}:nightly"
-              GHCR_TAGS_FOR_PUSH="${PRIMARY_GHCR_MANIFEST_TAG_VALUE}-${PLATFORM}"
-              DOCKER_TAGS_FOR_PUSH="${DOCKER_BASE}:nightly-${PLATFORM}"
-              ;;
-            "branch")
-              PRIMARY_GHCR_MANIFEST_TAG_VALUE="${GHCR_BASE}:${N8N_VERSION_TAG}"
-              GHCR_TAGS_FOR_PUSH="${PRIMARY_GHCR_MANIFEST_TAG_VALUE}-${PLATFORM}"
-              DOCKER_TAGS_FOR_PUSH="" # mirror n8n logic: no Docker Hub for branch
-              ;;
-            "dev"|*)
-              if [[ "$N8N_VERSION_TAG" == pr-* ]]; then
-                PRIMARY_GHCR_MANIFEST_TAG_VALUE="${GHCR_BASE}:${N8N_VERSION_TAG}"
-                GHCR_TAGS_FOR_PUSH="${PRIMARY_GHCR_MANIFEST_TAG_VALUE}-${PLATFORM}"
-                DOCKER_TAGS_FOR_PUSH=""
-              else
-                PRIMARY_GHCR_MANIFEST_TAG_VALUE="${GHCR_BASE}:dev"
-                GHCR_TAGS_FOR_PUSH="${PRIMARY_GHCR_MANIFEST_TAG_VALUE}-${PLATFORM}"
-                DOCKER_TAGS_FOR_PUSH="${DOCKER_BASE}:dev-${PLATFORM}"
-              fi
-              ;;
-          esac
-
-          ALL_TAGS="${GHCR_TAGS_FOR_PUSH}"
-          if [[ -n "$DOCKER_TAGS_FOR_PUSH" ]]; then
-            ALL_TAGS="${ALL_TAGS}\n${DOCKER_TAGS_FOR_PUSH}"
-          fi
-
-          {
-            echo "tags<<EOF"
-            echo -e "$ALL_TAGS"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
-          {
-            echo "ghcr_platform_tag=${GHCR_TAGS_FOR_PUSH}"
-            echo "dockerhub_platform_tag=${DOCKER_TAGS_FOR_PUSH}"
-          } >> "$GITHUB_OUTPUT"
-
-          # Only output manifest tags from the first platform to avoid duplicates
-          if [[ "$PLATFORM" == "amd64" ]]; then
-            echo "primary_ghcr_manifest_tag=${PRIMARY_GHCR_MANIFEST_TAG_VALUE}" >> "$GITHUB_OUTPUT"
-          fi
+          .github/scripts/determine-runners-tags.sh \
+            "${{ needs.determine-build-context.outputs.release_type }}" \
+            "${{ needs.determine-build-context.outputs.n8n_version }}" \
+            "ghcr.io/${{ github.repository_owner }}/runners" \
+            "${{ secrets.DOCKER_USERNAME }}/runners" \
+            "${{ matrix.platform }}" \
+            "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
@@ -341,7 +291,8 @@ jobs:
       - name: Login to Docker Hub
         if: needs.determine-build-context.outputs.push_enabled == 'true' && (
           steps.determine-tags.outputs.dockerhub_platform_tag != '' ||
-          steps.determine-runners-tags.outputs.dockerhub_platform_tag != '')
+          steps.determine-runners-tags.outputs.dockerhub_platform_tag != '' ||
+          steps.determine-runners-tags.outputs.dockerhub_platform_tag_distroless != '')
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -362,7 +313,7 @@ jobs:
           push: ${{ needs.determine-build-context.outputs.push_enabled == 'true' }}
           tags: ${{ steps.determine-tags.outputs.tags }}
 
-      - name: Build and push task runners Docker image
+      - name: Build and push task runners Docker image (Alpine)
         uses: useblacksmith/build-push-action@574eb0ee0b59c6a687ace24192f0727dfb65d6d7 # v1.2
         with:
           context: .
@@ -376,6 +327,21 @@ jobs:
           sbom: true
           push: ${{ needs.determine-build-context.outputs.push_enabled == 'true' }}
           tags: ${{ steps.determine-runners-tags.outputs.tags }}
+
+      - name: Build and push task runners Docker image (distroless)
+        uses: useblacksmith/build-push-action@574eb0ee0b59c6a687ace24192f0727dfb65d6d7 # v1.2
+        with:
+          context: .
+          file: ./docker/images/runners/Dockerfile.distroless
+          build-args: |
+            NODE_VERSION=${{ env.NODE_VERSION }}
+            N8N_VERSION=${{ needs.determine-build-context.outputs.n8n_version }}
+            N8N_RELEASE_TYPE=${{ needs.determine-build-context.outputs.release_type }}
+          platforms: ${{ matrix.docker_platform }}
+          provenance: true
+          sbom: true
+          push: ${{ needs.determine-build-context.outputs.push_enabled == 'true' }}
+          tags: ${{ steps.determine-runners-tags.outputs.tags_distroless }}
 
   create_multi_arch_manifest:
     name: Create Multi-Arch Manifest
@@ -431,45 +397,45 @@ jobs:
               ;;
           esac
 
-      - name: Determine Docker Hub manifest tag (runners)
+      - name: Determine Docker Hub manifest tags (runners variants)
         id: dockerhub_runners_check
         run: |
           RELEASE_TYPE="${{ needs.determine-build-context.outputs.release_type }}"
           N8N_VERSION="${{ needs.determine-build-context.outputs.n8n_version }}"
           DOCKER_BASE="${{ secrets.DOCKER_USERNAME }}/runners"
 
-          # Determine if Docker Hub manifest is needed and construct the tag
-          case "$RELEASE_TYPE" in
-            "stable")
-              {
-                echo "DOCKER_MANIFEST_TAG=${DOCKER_BASE}:${N8N_VERSION}"
-                echo "CREATE_DOCKERHUB_MANIFEST=true"
-              } >> "$GITHUB_OUTPUT"
-              ;;
-            "nightly")
-              {
-                echo "DOCKER_MANIFEST_TAG=${DOCKER_BASE}:nightly"
-                echo "CREATE_DOCKERHUB_MANIFEST=true"
-              } >> "$GITHUB_OUTPUT"
-              ;;
-            "dev")
-              if [[ "$N8N_VERSION" != pr-* ]]; then
-                {
-                  echo "DOCKER_MANIFEST_TAG=${DOCKER_BASE}:dev"
-                  echo "CREATE_DOCKERHUB_MANIFEST=true"
-                } >> "$GITHUB_OUTPUT"
-              else
-                echo "CREATE_DOCKERHUB_MANIFEST=false" >> "$GITHUB_OUTPUT"
-              fi
-              ;;
-            *)
-              echo "CREATE_DOCKERHUB_MANIFEST=false" >> "$GITHUB_OUTPUT"
-              ;;
-          esac
+          # Generate manifest tags for both Alpine and distroless variants
+          for VARIANT in "" "_distroless"; do
+            SUFFIX="${VARIANT//_/-}"  # Convert _distroless to -distroless for tag
+            OUTPUT_SUFFIX="${VARIANT}"  # Keep underscore for output var names
+
+            case "$RELEASE_TYPE" in
+              "stable")
+                echo "DOCKER_MANIFEST_TAG${OUTPUT_SUFFIX}=${DOCKER_BASE}:${N8N_VERSION}${SUFFIX}" >> "$GITHUB_OUTPUT"
+                echo "CREATE_DOCKERHUB_MANIFEST${OUTPUT_SUFFIX}=true" >> "$GITHUB_OUTPUT"
+                ;;
+              "nightly")
+                echo "DOCKER_MANIFEST_TAG${OUTPUT_SUFFIX}=${DOCKER_BASE}:nightly${SUFFIX}" >> "$GITHUB_OUTPUT"
+                echo "CREATE_DOCKERHUB_MANIFEST${OUTPUT_SUFFIX}=true" >> "$GITHUB_OUTPUT"
+                ;;
+              "dev")
+                if [[ "$N8N_VERSION" != pr-* ]]; then
+                  echo "DOCKER_MANIFEST_TAG${OUTPUT_SUFFIX}=${DOCKER_BASE}:dev${SUFFIX}" >> "$GITHUB_OUTPUT"
+                  echo "CREATE_DOCKERHUB_MANIFEST${OUTPUT_SUFFIX}=true" >> "$GITHUB_OUTPUT"
+                else
+                  echo "CREATE_DOCKERHUB_MANIFEST${OUTPUT_SUFFIX}=false" >> "$GITHUB_OUTPUT"
+                fi
+                ;;
+              *)
+                echo "CREATE_DOCKERHUB_MANIFEST${OUTPUT_SUFFIX}=false" >> "$GITHUB_OUTPUT"
+                ;;
+            esac
+          done
 
       - name: Login to Docker Hub
         if: steps.dockerhub_check.outputs.CREATE_DOCKERHUB_MANIFEST == 'true' ||
-          steps.dockerhub_runners_check.outputs.CREATE_DOCKERHUB_MANIFEST == 'true'
+          steps.dockerhub_runners_check.outputs.CREATE_DOCKERHUB_MANIFEST == 'true' ||
+          steps.dockerhub_runners_check.outputs.CREATE_DOCKERHUB_MANIFEST_distroless == 'true'
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -495,13 +461,33 @@ jobs:
               ${MANIFEST_TAG}-arm64
           fi
 
-      - name: Create GHCR multi-arch manifest (runners)
+      - name: Create GHCR multi-arch manifest for runners (Alpine)
         if: needs.build-and-push-docker.outputs.runners_primary_ghcr_manifest_tag != ''
         run: |
           MANIFEST_TAG="${{ needs.build-and-push-docker.outputs.runners_primary_ghcr_manifest_tag }}"
           RELEASE_TYPE="${{ needs.determine-build-context.outputs.release_type }}"
 
           echo "Creating GHCR runners manifest: $MANIFEST_TAG"
+
+          # For branch builds, only AMD64 is built
+          if [[ "$RELEASE_TYPE" == "branch" ]]; then
+            docker buildx imagetools create \
+              --tag $MANIFEST_TAG \
+              ${MANIFEST_TAG}-amd64
+          else
+            docker buildx imagetools create \
+              --tag $MANIFEST_TAG \
+              ${MANIFEST_TAG}-amd64 \
+              ${MANIFEST_TAG}-arm64
+          fi
+
+      - name: Create GHCR multi-arch manifest for runners (distroless)
+        if: needs.build-and-push-docker.outputs.runners_distroless_primary_ghcr_manifest_tag != ''
+        run: |
+          MANIFEST_TAG="${{ needs.build-and-push-docker.outputs.runners_distroless_primary_ghcr_manifest_tag }}"
+          RELEASE_TYPE="${{ needs.determine-build-context.outputs.release_type }}"
+
+          echo "Creating GHCR runners distroless manifest: $MANIFEST_TAG"
 
           # For branch builds, only AMD64 is built
           if [[ "$RELEASE_TYPE" == "branch" ]]; then
@@ -527,12 +513,24 @@ jobs:
             ${MANIFEST_TAG}-amd64 \
             ${MANIFEST_TAG}-arm64
 
-      - name: Create Docker Hub multi-arch manifest (runners)
+      - name: Create Docker Hub multi-arch manifest for runners (Alpine)
         if: steps.dockerhub_runners_check.outputs.CREATE_DOCKERHUB_MANIFEST == 'true'
         run: |
           MANIFEST_TAG="${{ steps.dockerhub_runners_check.outputs.DOCKER_MANIFEST_TAG }}"
 
           echo "Creating Docker Hub manifest: $MANIFEST_TAG"
+
+          docker buildx imagetools create \
+            --tag $MANIFEST_TAG \
+            ${MANIFEST_TAG}-amd64 \
+            ${MANIFEST_TAG}-arm64
+
+      - name: Create Docker Hub multi-arch manifest for runners (distroless)
+        if: steps.dockerhub_runners_check.outputs.CREATE_DOCKERHUB_MANIFEST_distroless == 'true'
+        run: |
+          MANIFEST_TAG="${{ steps.dockerhub_runners_check.outputs.DOCKER_MANIFEST_TAG_distroless }}"
+
+          echo "Creating Docker Hub distroless manifest: $MANIFEST_TAG"
 
           docker buildx imagetools create \
             --tag $MANIFEST_TAG \

--- a/docker/images/runners/Dockerfile.distroless
+++ b/docker/images/runners/Dockerfile.distroless
@@ -1,0 +1,193 @@
+# ==============================================================================
+# DISTROLESS RUNNERS IMAGE
+# ==============================================================================
+# This is a distroless variant of docker/images/runners/Dockerfile, intended
+# for cloud deployments. It removes all shell, package managers, and system
+# utilities for security hardening.
+#
+# Key differences:
+# - Uses Debian-based builders (glibc instead of musl)
+# - Final image is Google's distroless/cc-debian12
+# - Extra runtime-prep stage to organize filesystem
+# - Uses distroless nonroot user (UID 65532)
+# ==============================================================================
+
+ARG NODE_VERSION=22.21.0
+ARG PYTHON_VERSION=3.13
+
+
+# ==============================================================================
+# STAGE 1: JavaScript runner (@n8n/task-runner) artifact from CI
+# ==============================================================================
+FROM node:${NODE_VERSION}-bookworm-slim AS javascript-runner-builder
+COPY ./dist/task-runner-javascript /app/task-runner-javascript
+
+WORKDIR /app/task-runner-javascript
+
+RUN corepack enable pnpm
+
+# Install extra runtime-only npm packages. Allow usage in the Code node via
+# 'NODE_FUNCTION_ALLOW_EXTERNAL' env variable on n8n-task-runners.json.
+RUN rm -f node_modules/.modules.yaml
+RUN mv package.json package.json.bak
+COPY docker/images/runners/package.json /app/task-runner-javascript/package.json
+RUN pnpm install --prod --no-lockfile --silent
+RUN mv package.json extras.json
+RUN mv package.json.bak package.json
+
+# ==============================================================================
+# STAGE 2: Python runner build (@n8n/task-runner-python) with uv
+# Produces a relocatable venv tied to the python version used
+# ==============================================================================
+FROM python:${PYTHON_VERSION}-slim-bookworm AS python-runner-builder
+ARG TARGETPLATFORM
+ARG UV_VERSION=0.8.14
+
+RUN set -e; \
+  apt-get update && apt-get install -y --no-install-recommends wget ca-certificates && \
+  case "$TARGETPLATFORM" in \
+    "linux/amd64") UV_ARCH="x86_64-unknown-linux-gnu" ;; \
+    "linux/arm64") UV_ARCH="aarch64-unknown-linux-gnu" ;; \
+    *) echo "Unsupported platform: $TARGETPLATFORM" >&2; exit 1 ;; \
+  esac; \
+  mkdir -p /tmp/uv && cd /tmp/uv; \
+  wget -q "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-${UV_ARCH}.tar.gz"; \
+  wget -q "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-${UV_ARCH}.tar.gz.sha256"; \
+  sha256sum -c "uv-${UV_ARCH}.tar.gz.sha256"; \
+  tar -xzf "uv-${UV_ARCH}.tar.gz"; \
+  install -m 0755 "uv-${UV_ARCH}/uv" /usr/local/bin/uv; \
+  cd / && rm -rf /tmp/uv && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app/task-runner-python
+
+COPY packages/@n8n/task-runner-python/pyproject.toml \
+     packages/@n8n/task-runner-python/uv.lock** \
+     packages/@n8n/task-runner-python/.python-version** \
+     ./
+
+RUN uv venv
+RUN uv sync \
+			--frozen \
+			--no-editable \
+			--no-install-project \
+			--no-dev \
+			--all-extras
+
+COPY packages/@n8n/task-runner-python/ ./
+RUN uv sync \
+      --frozen \
+			--no-dev \
+			--all-extras \
+      --no-editable
+
+# Install extra runtime-only Python packages. Allow usage in the Code node via
+# 'N8N_RUNNERS_EXTERNAL_ALLOW' env variable on n8n-task-runners.json.
+COPY docker/images/runners/extras.txt /app/task-runner-python/extras.txt
+RUN uv pip install -r /app/task-runner-python/extras.txt
+
+# ==============================================================================
+# STAGE 3: Task Runner Launcher download
+# ==============================================================================
+FROM debian:bookworm-slim AS launcher-downloader
+ARG TARGETPLATFORM
+ARG LAUNCHER_VERSION=1.4.0
+
+RUN set -e; \
+    apt-get update && apt-get install -y --no-install-recommends wget ca-certificates && \
+    case "$TARGETPLATFORM" in \
+        "linux/amd64") ARCH_NAME="amd64" ;; \
+        "linux/arm64") ARCH_NAME="arm64" ;; \
+        *) echo "Unsupported platform: $TARGETPLATFORM" && exit 1 ;; \
+    esac; \
+    mkdir /launcher-temp && cd /launcher-temp; \
+    wget -q "https://github.com/n8n-io/task-runner-launcher/releases/download/${LAUNCHER_VERSION}/task-runner-launcher-${LAUNCHER_VERSION}-linux-${ARCH_NAME}.tar.gz"; \
+    wget -q "https://github.com/n8n-io/task-runner-launcher/releases/download/${LAUNCHER_VERSION}/task-runner-launcher-${LAUNCHER_VERSION}-linux-${ARCH_NAME}.tar.gz.sha256"; \
+    echo "$(cat task-runner-launcher-${LAUNCHER_VERSION}-linux-${ARCH_NAME}.tar.gz.sha256) task-runner-launcher-${LAUNCHER_VERSION}-linux-${ARCH_NAME}.tar.gz" > checksum.sha256; \
+    sha256sum -c checksum.sha256; \
+    mkdir -p /launcher-bin; \
+    tar xzf task-runner-launcher-${LAUNCHER_VERSION}-linux-${ARCH_NAME}.tar.gz -C /launcher-bin; \
+    cd / && rm -rf /launcher-temp && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# ==============================================================================
+# STAGE 4: Node Debian base for JS task runner
+# ==============================================================================
+FROM node:${NODE_VERSION}-bookworm-slim AS node-debian
+
+# ==============================================================================
+# STAGE 5: Runtime preparation
+# ==============================================================================
+# Prepare a clean filesystem structure with all necessary files before
+# copying to the distroless base. This stage runs with a shell so we can
+# create symlinks and organize files properly.
+# ==============================================================================
+FROM debian:bookworm-slim AS runtime-prep
+
+# Copy Python runtime
+COPY --from=python-runner-builder /usr/local/bin/python3.13 /runtime/usr/local/bin/python3.13
+COPY --from=python-runner-builder /usr/local/lib/python3.13 /runtime/usr/local/lib/python3.13
+COPY --from=python-runner-builder /usr/local/lib/libpython3.13.so* /runtime/usr/local/lib/
+
+# Copy Python dependencies (architecture-specific directories)
+# The /* glob will match x86_64-linux-gnu or aarch64-linux-gnu
+COPY --from=python-runner-builder /lib/*-linux-gnu* /runtime/lib/
+COPY --from=python-runner-builder /usr/lib/*-linux-gnu* /runtime/usr/lib/
+
+# Copy Node.js runtime
+COPY --from=node-debian /usr/local/bin/node /runtime/usr/local/bin/node
+
+# Copy uv
+COPY --from=python-runner-builder /usr/local/bin/uv /runtime/usr/local/bin/uv
+
+# Copy task runners
+COPY --from=javascript-runner-builder /app/task-runner-javascript /runtime/opt/runners/task-runner-javascript
+COPY --from=python-runner-builder /app/task-runner-python /runtime/opt/runners/task-runner-python
+
+# Copy launcher
+COPY --from=launcher-downloader /launcher-bin/* /runtime/usr/local/bin/
+
+# Copy configuration
+COPY docker/images/runners/n8n-task-runners.json /runtime/etc/n8n-task-runners.json
+
+# Create necessary directories with proper permissions
+RUN mkdir -p /runtime/home/runner && \
+    chmod 755 /runtime/home/runner && \
+    chmod +x /runtime/usr/local/bin/*
+
+# ==============================================================================
+# STAGE 6: Distroless Runtime
+# ==============================================================================
+# Uses Google's distroless/cc-debian12 which provides:
+# - glibc, libgcc, libstdc++
+# - CA certificates
+# - Timezone data
+# - nonroot user (UID 65532)
+# - NO shell, NO package manager, NO system utilities
+# ==============================================================================
+FROM gcr.io/distroless/cc-debian12:latest AS runtime
+ARG N8N_VERSION=snapshot
+ARG N8N_RELEASE_TYPE=dev
+
+ENV NODE_ENV=production \
+    N8N_RELEASE_TYPE=${N8N_RELEASE_TYPE}
+
+# Copy everything from the prepared runtime filesystem
+COPY --from=runtime-prep --chown=root:root /runtime/ /
+
+WORKDIR /home/runner
+
+# Switch to nonroot user (UID 65532)
+USER 65532:65532
+
+EXPOSE 5680/tcp
+
+# No tini in distroless - task-runner-launcher must handle signals directly
+ENTRYPOINT ["/usr/local/bin/task-runner-launcher"]
+CMD ["javascript", "python"]
+
+LABEL org.opencontainers.image.title="n8n task runners (distroless)" \
+      org.opencontainers.image.description="Distroless sidecar image providing n8n task runners for JavaScript and Python code execution" \
+      org.opencontainers.image.source="https://github.com/n8n-io/n8n" \
+      org.opencontainers.image.url="https://n8n.io" \
+      org.opencontainers.image.version="${N8N_VERSION}"

--- a/docker/images/runners/Dockerfile.distroless
+++ b/docker/images/runners/Dockerfile.distroless
@@ -182,7 +182,6 @@ USER 65532:65532
 
 EXPOSE 5680/tcp
 
-# No tini in distroless - task-runner-launcher must handle signals directly
 ENTRYPOINT ["/usr/local/bin/task-runner-launcher"]
 CMD ["javascript", "python"]
 

--- a/docker/images/runners/README.md
+++ b/docker/images/runners/README.md
@@ -11,6 +11,8 @@ in the [Code Node](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes
 
 For official documentation, please see [here](https://docs.n8n.io/hosting/configuration/task-runners/).
 
+For a distroless variant of this image, see [here](./Dockerfile.distroless).
+
 For development purposes only, see below.
 
 ## Testing locally


### PR DESCRIPTION
## Summary

Add distroless variant for the `n8nio/runners` image:

  - Alpine: `n8nio/runners:1.119.0` or `n8nio/runners:nightly`
  - Distroless: `n8nio/runners:1.119.0-distroless` or `n8nio/runners:nightly-distroless`


To test:

```sh
# 1. build production artifacts
pnpm run build:n8n

# 2. build distroless runners image
docker buildx build \
  -f docker/images/runners/Dockerfile.distroless \
  -t n8nio/runners:local-distroless \
  .

# 3. run distroless runners container
docker run --rm -it --name n8n-runners \
	-e N8N_RUNNERS_AUTH_TOKEN=test \
	-e N8N_RUNNERS_LAUNCHER_LOG_LEVEL=debug \
	-e N8N_RUNNERS_TASK_BROKER_URI=http://host.docker.internal:5679 \
	-p 5680:5680 \
	n8nio/runners:local-distroless

# 4. run n8n
N8N_RUNNERS_ENABLED=true \
N8N_RUNNERS_MODE=external \
N8N_RUNNERS_AUTH_TOKEN=test \
N8N_LOG_LEVEL=debug \
N8N_NATIVE_PYTHON_RUNNER=true \
pnpm start
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1575

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
