### PR TITLE
feat: Expression editor - ability to preview HTML or Markdown in results pane

### DIFF
--- a/packages/frontend/editor-ui/src/components/ExpressionEditModal.vue
+++ b/packages/frontend/editor-ui/src/components/ExpressionEditModal.vue
@@ -71,7 +71,7 @@ const sidebarWidth = ref(DEFAULT_LEFT_SIDEBAR_WIDTH);
 const expressionInputRef = ref<InstanceType<typeof ExpressionEditorModalInput>>();
 const expressionResultRef = ref<InstanceType<typeof ExpressionOutput>>();
 const theme = outputTheme();
-const outputRenderMode = ref<'text' | 'html'>('text');
+const outputRenderMode = ref<'text' | 'html' | 'markdown'>('text');
 
 const activeNode = computed(() => ndvStore.activeNode);
 const inputEditor = computed(() => expressionInputRef.value?.editor);
@@ -231,7 +231,8 @@ const onResizeThrottle = useThrottleFn(onResize, 10);
 								size="small"
 								:options="[
 									{ label: 'Text', value: 'text' },
-									{ label: 'HTML', value: 'html' },
+									{ label: 'Html', value: 'html' },
+									{ label: 'Markdown', value: 'markdown' },
 								]"
 							/>
 						</div>

--- a/packages/frontend/editor-ui/src/components/ExpressionEditModal.vue
+++ b/packages/frontend/editor-ui/src/components/ExpressionEditModal.vue
@@ -25,7 +25,14 @@ import { APP_MODALS_ELEMENT_ID } from '@/constants';
 import { useThrottleFn } from '@vueuse/core';
 
 import { ElDialog } from 'element-plus';
-import { N8nIcon, N8nInput, N8nResizeWrapper, N8nText, type ResizeData } from '@n8n/design-system';
+import {
+	N8nIcon,
+	N8nInput,
+	N8nRadioButtons,
+	N8nResizeWrapper,
+	N8nText,
+	type ResizeData,
+} from '@n8n/design-system';
 const DEFAULT_LEFT_SIDEBAR_WIDTH = 360;
 
 type Props = {
@@ -64,6 +71,7 @@ const sidebarWidth = ref(DEFAULT_LEFT_SIDEBAR_WIDTH);
 const expressionInputRef = ref<InstanceType<typeof ExpressionEditorModalInput>>();
 const expressionResultRef = ref<InstanceType<typeof ExpressionOutput>>();
 const theme = outputTheme();
+const outputRenderMode = ref<'text' | 'html'>('text');
 
 const activeNode = computed(() => ndvStore.activeNode);
 const inputEditor = computed(() => expressionInputRef.value?.editor);
@@ -216,7 +224,17 @@ const onResizeThrottle = useThrottleFn(onResize, 10);
 						<N8nText bold size="large">
 							{{ i18n.baseText('parameterInput.result') }}
 						</N8nText>
-						<OutputItemSelect />
+						<div :class="$style.headerControls">
+							<OutputItemSelect />
+							<N8nRadioButtons
+								v-model="outputRenderMode"
+								size="small"
+								:options="[
+									{ label: 'Text', value: 'text' },
+									{ label: 'HTML', value: 'html' },
+								]"
+							/>
+						</div>
 					</div>
 
 					<div :class="[$style.editorContainer, { 'ph-no-capture': redactValues }]">
@@ -225,6 +243,7 @@ const onResizeThrottle = useThrottleFn(onResize, 10);
 							:class="$style.editor"
 							:segments="segments"
 							:extensions="theme"
+							:render="outputRenderMode"
 							data-test-id="expression-modal-output"
 						/>
 					</div>
@@ -316,6 +335,14 @@ const onResizeThrottle = useThrottleFn(onResize, 10);
 	flex-direction: column;
 
 	gap: var(--spacing--5xs);
+}
+
+.headerControls {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	width: 100%;
+	padding-right: var(--spacing--4xs);
 }
 
 .tip {

--- a/packages/frontend/editor-ui/src/features/ndv/components/runData/RunDataMarkdown.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/components/runData/RunDataMarkdown.vue
@@ -1,0 +1,184 @@
+<script lang="ts">
+import { defineComponent } from 'vue';
+import VueMarkdownRender from 'vue-markdown-render';
+
+export default defineComponent({
+	name: 'RunDataMarkdown',
+	components: {
+		VueMarkdownRender,
+	},
+	props: {
+		inputMarkdown: {
+			type: String,
+			required: true,
+		},
+	},
+});
+</script>
+
+<template>
+	<div :class="$style.markdown">
+		<VueMarkdownRender :source="inputMarkdown" />
+	</div>
+</template>
+
+<style lang="scss" module>
+.markdown {
+	white-space: pre-wrap;
+
+	width: 100%;
+	height: 100%;
+	overflow: auto;
+	border: 2px solid var(--border-color);
+	padding: var(--spacing--xs);
+	border-width: var(--border-width);
+	border-style: var(--input--border-style, var(--border-style));
+	border-color: var(--input--border-color, var(--border-color));
+	border-radius: var(--input--radius, var(--radius));
+
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6 {
+		font-weight: 600;
+	}
+
+	h1 {
+		font-size: var(--font-size--xl);
+	}
+
+	h2 {
+		font-size: var(--font-size--lg);
+	}
+
+	h3 {
+		font-size: var(--font-size--md);
+	}
+
+	h4 {
+		font-size: var(--font-size--sm);
+	}
+
+	h5 {
+		font-size: var(--font-size--xs);
+	}
+
+	h6 {
+		font-size: var(--font-size--2xs);
+	}
+
+	p {
+		word-wrap: break-word;
+	}
+
+	strong,
+	b {
+		font-weight: 600;
+	}
+
+	em,
+	i {
+		font-style: italic;
+	}
+
+	s,
+	del {
+		text-decoration: line-through;
+	}
+
+	code {
+		background: var(--color--background--light);
+		padding: 0.2em 0.4em;
+		border-radius: var(--border-radius--xs);
+		font-family: var(--font-family--monospace);
+		font-size: 0.9em;
+	}
+
+	pre {
+		background: var(--chat--message--pre--background);
+		border-radius: var(--radius);
+
+		padding: var(--spacing--xs);
+		font-size: var(--font-size--sm);
+		white-space: pre-wrap;
+		font-family: inherit;
+		margin: var(--spacing--4xs) 0;
+		overflow-x: auto;
+
+		code {
+			background: transparent;
+			padding: 0;
+			border-radius: 0;
+			font-family: var(--font-family--monospace);
+		}
+	}
+
+	ul,
+	ol {
+		padding-left: var(--spacing--lg);
+	}
+
+	li {
+		margin: 0;
+	}
+
+	li input[type='checkbox'] {
+		margin-right: var(--spacing--4xs);
+	}
+
+	blockquote {
+		padding-left: var(--spacing--xs);
+		border-left: 3px solid var(--border-color);
+
+		background: var(--color--background--light);
+		color: var(--color--text--base);
+	}
+
+	a {
+		color: var(--color--primary);
+		text-decoration: none;
+
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+
+	img {
+		max-width: 100%;
+		height: auto;
+		display: block;
+		margin: var(--spacing--4xs) 0;
+	}
+
+	table {
+		width: fit-content;
+		border-collapse: collapse;
+		border-top: 2px solid var(--color--text--shade-2);
+		border-bottom: 2px solid var(--color--text--shade-2);
+		font-size: var(--font-size--sm);
+	}
+
+	th,
+	td {
+		padding: var(--spacing--4xs) var(--spacing--xs);
+		text-align: left;
+	}
+
+	th {
+		font-weight: 600;
+		border-bottom: 1px solid var(--color--text--shade-2);
+	}
+
+	tr:not(:last-child) td {
+		border-bottom: 1px solid var(--color--border);
+	}
+
+	hr {
+		border: none;
+		border-top: 1px solid var(--border-color);
+		margin: var(--spacing--xs) var(--spacing--xs);
+	}
+}
+</style>

--- a/packages/frontend/editor-ui/src/features/ndv/components/runData/RunDataMarkdown.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/components/runData/RunDataMarkdown.vue
@@ -24,17 +24,16 @@ export default defineComponent({
 
 <style lang="scss" module>
 .markdown {
-	white-space: pre-wrap;
-
 	width: 100%;
 	height: 100%;
 	overflow: auto;
-	border: 2px solid var(--border-color);
-	padding: var(--spacing--xs);
-	border-width: var(--border-width);
-	border-style: var(--input--border-style, var(--border-style));
-	border-color: var(--input--border-color, var(--border-color));
-	border-radius: var(--input--radius, var(--radius));
+	padding: 1rem 1.25rem;
+	border: 1px solid var(--border-color);
+	border-radius: var(--radius);
+	background-color: var(--background, #fff);
+	color: var(--text-color, #24292e);
+	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+	line-height: 1.6;
 
 	h1,
 	h2,
@@ -42,102 +41,43 @@ export default defineComponent({
 	h4,
 	h5,
 	h6 {
+		margin-top: 1.5em;
+		margin-bottom: 0.75em;
 		font-weight: 600;
-	}
+		line-height: 1.25;
+		border-bottom: 1px solid #d8dee4;
 
-	h1 {
-		font-size: var(--font-size--xl);
-	}
-
-	h2 {
-		font-size: var(--font-size--lg);
-	}
-
-	h3 {
-		font-size: var(--font-size--md);
-	}
-
-	h4 {
-		font-size: var(--font-size--sm);
-	}
-
-	h5 {
-		font-size: var(--font-size--xs);
-	}
-
-	h6 {
-		font-size: var(--font-size--2xs);
-	}
-
-	p {
-		word-wrap: break-word;
-	}
-
-	strong,
-	b {
-		font-weight: 600;
-	}
-
-	em,
-	i {
-		font-style: italic;
-	}
-
-	s,
-	del {
-		text-decoration: line-through;
-	}
-
-	code {
-		background: var(--color--background--light);
-		padding: 0.2em 0.4em;
-		border-radius: var(--border-radius--xs);
-		font-family: var(--font-family--monospace);
-		font-size: 0.9em;
-	}
-
-	pre {
-		background: var(--chat--message--pre--background);
-		border-radius: var(--radius);
-
-		padding: var(--spacing--xs);
-		font-size: var(--font-size--sm);
-		white-space: pre-wrap;
-		font-family: inherit;
-		margin: var(--spacing--4xs) 0;
-		overflow-x: auto;
-
-		code {
-			background: transparent;
-			padding: 0;
-			border-radius: 0;
-			font-family: var(--font-family--monospace);
+		&:first-child {
+			margin-top: 0;
 		}
 	}
 
-	ul,
-	ol {
-		padding-left: var(--spacing--lg);
+	h1 {
+		font-size: 1.75rem;
+	}
+	h2 {
+		font-size: 1.5rem;
+	}
+	h3 {
+		font-size: 1.25rem;
+	}
+	h4 {
+		font-size: 1.1rem;
+	}
+	h5 {
+		font-size: 1rem;
+	}
+	h6 {
+		font-size: 0.9rem;
+		color: #6a737d;
 	}
 
-	li {
-		margin: 0;
-	}
-
-	li input[type='checkbox'] {
-		margin-right: var(--spacing--4xs);
-	}
-
-	blockquote {
-		padding-left: var(--spacing--xs);
-		border-left: 3px solid var(--border-color);
-
-		background: var(--color--background--light);
-		color: var(--color--text--base);
+	p {
+		margin: 0.75em 0;
 	}
 
 	a {
-		color: var(--color--primary);
+		color: #0969da;
 		text-decoration: none;
 
 		&:hover {
@@ -145,40 +85,85 @@ export default defineComponent({
 		}
 	}
 
-	img {
-		max-width: 100%;
-		height: auto;
-		display: block;
-		margin: var(--spacing--4xs) 0;
+	strong {
+		font-weight: 600;
+	}
+
+	em {
+		font-style: italic;
+	}
+
+	blockquote {
+		padding: 0.5em 1em;
+		margin: 0.75em 0;
+		color: #6a737d;
+		border-left: 0.25em solid #d0d7de;
+		background-color: #f6f8fa;
+		border-radius: 0.25rem;
+	}
+
+	code,
+	pre {
+		font-family: SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+		font-size: 0.9rem;
+	}
+
+	code {
+		background-color: #f6f8fa;
+		padding: 0.2em 0.4em;
+		border-radius: 0.25rem;
+	}
+
+	pre {
+		background-color: #f6f8fa;
+		padding: 1rem;
+		border-radius: 0.5rem;
+		overflow-x: auto;
+
+		code {
+			background: none;
+			padding: 0;
+		}
+	}
+
+	ul,
+	ol {
+		margin: 0.75em 0;
+		padding-left: 2em;
 	}
 
 	table {
-		width: fit-content;
 		border-collapse: collapse;
-		border-top: 2px solid var(--color--text--shade-2);
-		border-bottom: 2px solid var(--color--text--shade-2);
-		font-size: var(--font-size--sm);
-	}
+		width: 100%;
+		margin: 1em 0;
+		font-size: 0.95rem;
 
-	th,
-	td {
-		padding: var(--spacing--4xs) var(--spacing--xs);
-		text-align: left;
-	}
+		th,
+		td {
+			border: 1px solid #d0d7de;
+			padding: 0.5em 0.75em;
+			text-align: left;
+		}
 
-	th {
-		font-weight: 600;
-		border-bottom: 1px solid var(--color--text--shade-2);
-	}
-
-	tr:not(:last-child) td {
-		border-bottom: 1px solid var(--color--border);
+		th {
+			background-color: #f6f8fa;
+			font-weight: 600;
+		}
 	}
 
 	hr {
-		border: none;
-		border-top: 1px solid var(--border-color);
-		margin: var(--spacing--xs) var(--spacing--xs);
+		border: 0;
+		border-top: 1px solid #d8dee4;
+		margin: 1.5em 0;
+	}
+
+	img {
+		max-width: 100%;
+		border-radius: 0.25rem;
+	}
+
+	blockquote > :last-child {
+		margin-bottom: 0;
 	}
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/shared/editors/components/InlineExpressionEditor/ExpressionOutput.vue
+++ b/packages/frontend/editor-ui/src/features/shared/editors/components/InlineExpressionEditor/ExpressionOutput.vue
@@ -8,11 +8,12 @@ import type { Plaintext, Resolved, Segment } from '@/types/expressions';
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { forceParse } from '@/utils/forceParse';
 import RunDataHtml from '@/features/ndv/components/runData/RunDataHtml.vue';
+import RunDataMarkdown from '@/features/ndv/components/runData/RunDataMarkdown.vue';
 
 interface ExpressionOutputProps {
 	segments: Segment[];
 	extensions?: Extension[];
-	render?: 'text' | 'html';
+	render?: 'text' | 'html' | 'markdown';
 }
 
 const props = withDefaults(defineProps<ExpressionOutputProps>(), {
@@ -120,7 +121,7 @@ watch(
 		if (newMode === 'text' && !editor.value) {
 			await nextTick();
 			initializeEditor();
-		} else if (newMode === 'html' && editor.value) {
+		} else if ((newMode === 'html' || newMode === 'markdown') && editor.value) {
 			editor.value.destroy();
 			editor.value = null;
 		}
@@ -146,6 +147,12 @@ defineExpose({ getValue: () => '=' + resolvedExpression.value });
 		v-else-if="render === 'html'"
 		data-test-id="expression-output"
 		:input-html="resolvedExpression"
+	/>
+
+	<RunDataMarkdown
+		v-else-if="render === 'markdown'"
+		data-test-id="expression-output"
+		:input-markdown="resolvedExpression"
 	/>
 </template>
 

--- a/packages/frontend/editor-ui/src/features/shared/editors/components/InlineExpressionEditor/ExpressionOutput.vue
+++ b/packages/frontend/editor-ui/src/features/shared/editors/components/InlineExpressionEditor/ExpressionOutput.vue
@@ -5,15 +5,20 @@ import { EditorView } from '@codemirror/view';
 import { useI18n } from '@n8n/i18n';
 import { highlighter } from '../../plugins/codemirror/resolvableHighlighter';
 import type { Plaintext, Resolved, Segment } from '@/types/expressions';
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { forceParse } from '@/utils/forceParse';
+import RunDataHtml from '@/features/ndv/components/runData/RunDataHtml.vue';
 
 interface ExpressionOutputProps {
 	segments: Segment[];
 	extensions?: Extension[];
+	render?: 'text' | 'html';
 }
 
-const props = withDefaults(defineProps<ExpressionOutputProps>(), { extensions: () => [] });
+const props = withDefaults(defineProps<ExpressionOutputProps>(), {
+	extensions: () => [],
+	render: 'text',
+});
 
 const i18n = useI18n();
 
@@ -75,21 +80,9 @@ const resolvedSegments = computed<Resolved[]>(() => {
 		.filter((segment): segment is Resolved => segment.kind === 'resolvable');
 });
 
-watch(
-	() => props.segments,
-	() => {
-		if (!editor.value) return;
+function initializeEditor() {
+	if (!root.value) return;
 
-		editor.value.dispatch({
-			changes: { from: 0, to: editor.value.state.doc.length, insert: resolvedExpression.value },
-		});
-
-		highlighter.addColor(editor.value as EditorView, resolvedSegments.value);
-		highlighter.removeColor(editor.value as EditorView, plaintextSegments.value);
-	},
-);
-
-onMounted(() => {
 	editor.value = new EditorView({
 		parent: root.value as HTMLElement,
 		state: EditorState.create({
@@ -105,6 +98,38 @@ onMounted(() => {
 
 	highlighter.addColor(editor.value as EditorView, resolvedSegments.value);
 	highlighter.removeColor(editor.value as EditorView, plaintextSegments.value);
+}
+
+watch(
+	() => props.segments,
+	() => {
+		if (props.render !== 'text' || !editor.value) return;
+
+		editor.value.dispatch({
+			changes: { from: 0, to: editor.value.state.doc.length, insert: resolvedExpression.value },
+		});
+
+		highlighter.addColor(editor.value as EditorView, resolvedSegments.value);
+		highlighter.removeColor(editor.value as EditorView, plaintextSegments.value);
+	},
+);
+
+watch(
+	() => props.render,
+	async (newMode) => {
+		if (newMode === 'text' && !editor.value) {
+			await nextTick();
+			initializeEditor();
+		} else if (newMode === 'html' && editor.value) {
+			editor.value.destroy();
+			editor.value = null;
+		}
+	},
+);
+
+onMounted(() => {
+	if (props.render !== 'text') return;
+	initializeEditor();
 });
 
 onBeforeUnmount(() => {
@@ -115,5 +140,22 @@ defineExpose({ getValue: () => '=' + resolvedExpression.value });
 </script>
 
 <template>
-	<div ref="root" data-test-id="expression-output"></div>
+	<div v-if="render === 'text'" ref="root" data-test-id="expression-output"></div>
+
+	<RunDataHtml
+		v-else-if="render === 'html'"
+		data-test-id="expression-output"
+		:input-html="resolvedExpression"
+	/>
 </template>
+
+<style lang="scss">
+.__html-display {
+	border: 2px solid var(--border-color);
+	padding: var(--spacing--xs);
+	border-width: var(--border-width);
+	border-style: var(--input--border-style, var(--border-style));
+	border-color: var(--input--border-color, var(--border-color));
+	border-radius: var(--input--radius, var(--radius));
+}
+</style>


### PR DESCRIPTION
## Summary

HTML and Markdown preview mods
<img width="1823" height="862" alt="image" src="https://github.com/user-attachments/assets/4e65424d-8fff-45f6-9d59-ae7181c641ac" />
<img width="1823" height="862" alt="image" src="https://github.com/user-attachments/assets/9c5b4024-8c0e-4c92-ae16-4df78b4a9c1a" />
<img width="1823" height="862" alt="image" src="https://github.com/user-attachments/assets/f1729db3-3065-4c43-92fa-c9de4b6f018d" />


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
