### PR TITLE
fix: Change unicode range to support more characters in expression parser

### DIFF
--- a/packages/@n8n/codemirror-lang/src/expressions/expressions.grammar
+++ b/packages/@n8n/codemirror-lang/src/expressions/expressions.grammar
@@ -15,7 +15,7 @@ entity { Plaintext | Resolvable }
 
   resolvableChar { unicodeChar | "}" ![}] | "\\}}" }
 
-  unicodeChar { $[\u0000-\u007C] | $[\u007E-\u20CF] | $[\u2700-\u27BF] | $[\u{1F300}-\u{1FAF8}] | $[\u4E00-\u9FFF] }
+	unicodeChar { $[\u0000-\u007C] | $[\u007E-\u{10FFFF}] }
 }
 
 @detectDelim

--- a/packages/@n8n/codemirror-lang/src/expressions/grammar.ts
+++ b/packages/@n8n/codemirror-lang/src/expressions/grammar.ts
@@ -10,7 +10,7 @@ export const parser = LRParser.deserialize({
 	skippedNodes: [0],
 	repeatNodeCount: 1,
 	tokenData:
-		"&h~RTO#ob#o#p!h#p;'Sb;'S;=`!]<%lOb~gTQ~O#ob#o#pv#p;'Sb;'S;=`!]<%lOb~yUO#ob#p;'Sb;'S;=`!]<%l~b~Ob~~!c~!`P;=`<%lb~!hOQ~~!kVO#ob#o#p#Q#p;'Sb;'S;=`!]<%l~b~Ob~~!c~#TYO#O#Q#O#P#s#P#q#Q#q#r%m#r$Ml#Q%BQ%FY#Q*5S41d#Q;(b;(c&[;(c;(d&U;(d;(e&b~#vYO#O#Q#O#P#s#P#q#Q#q#r$f#r$Ml#Q%BQ%FY#Q*5S41d#Q;(b;(c&[;(c;(d&U;(d;(e&b~$iTO#q#Q#q#r$x#r;'S#Q;'S;=`&U<%lO#Q~$}YR~O#O#Q#O#P#s#P#q#Q#q#r%m#r$Ml#Q%BQ%FY#Q*5S41d#Q;(b;(c&[;(c;(d&U;(d;(e&b~%pTO#q#Q#q#r&P#r;'S#Q;'S;=`&U<%lO#Q~&UOR~~&XP;=`<%l#Q~&_P;NQ<%l#Q~&eP;=`;My#Q",
+		"%o~RTO#ob#o#p!h#p;'Sb;'S;=`!]<%lOb~gTQ~O#ob#o#pv#p;'Sb;'S;=`!]<%lOb~yUO#ob#p;'Sb;'S;=`!]<%l~b~Ob~~!c~!`P;=`<%lb~!hOQ~~!kVO#ob#o#p#Q#p;'Sb;'S;=`!]<%l~b~Ob~~!c~#TVO#O#Q#O#P#j#P#q#Q#q#r%Q#r;'S#Q;'S;=`%i<%lO#Q~#mVO#O#Q#O#P#j#P#q#Q#q#r$S#r;'S#Q;'S;=`%i<%lO#Q~$VTO#q#Q#q#r$f#r;'S#Q;'S;=`%i<%lO#Q~$kVR~O#O#Q#O#P#j#P#q#Q#q#r%Q#r;'S#Q;'S;=`%i<%lO#Q~%TTO#q#Q#q#r%d#r;'S#Q;'S;=`%i<%lO#Q~%iOR~~%lP;=`<%l#Q",
 	tokenizers: [0],
 	topRules: { Program: [0, 1] },
 	tokenPrec: 0,

--- a/packages/@n8n/codemirror-lang/test/expressions/cases.txt
+++ b/packages/@n8n/codemirror-lang/test/expressions/cases.txt
@@ -309,3 +309,18 @@ Program(Resolvable)
 ==>
 
 Program(Resolvable)
+
+# Resolvable with zap emoji - U+26A1
+
+{{ '⚡' }}
+
+==>
+
+Program(Resolvable)
+
+# Resolvable with character near end of Unicode range U+10FFFD
+{{ '􏿽' }}
+
+==>
+
+Program(Resolvable)


### PR DESCRIPTION
## Summary

We have occasional issues with emoji characters breaking the expression parser (see #16498).
This PR changes the range of the Unicode characters to ensure we don't have to play whack-a-mole in the future. (Previous PR for a specific emoji as an example: #16545).

I've updated the tests to check near the end of the range of Unicode characters (U+10FFFD) as U+10FFFE and U+10FFFF are not assigned yet.

## Related Linear tickets, Github issues, and Community forum posts

Fixes: PAY-4043
Related: #16498 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- ~[ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- ~[ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
