### PR TITLE
fix(editor): Replace icon for null in schema view

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nIcon/icons.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nIcon/icons.ts
@@ -188,6 +188,7 @@ import IconLucideSmile from '~icons/lucide/smile';
 import IconLucideSparkles from '~icons/lucide/sparkles';
 import IconLucideSquare from '~icons/lucide/square';
 import IconLucideSquareCheck from '~icons/lucide/square-check';
+import IconLucideSquareMinus from '~icons/lucide/square-minus';
 import IconLucideSquarePen from '~icons/lucide/square-pen';
 import IconLucideSquarePlus from '~icons/lucide/square-plus';
 import IconLucideStickyNote from '~icons/lucide/sticky-note';
@@ -626,6 +627,7 @@ export const updatedIconSet = {
 	sparkles: IconLucideSparkles,
 	square: IconLucideSquare,
 	'square-check': IconLucideSquareCheck,
+	'square-minus': IconLucideSquareMinus,
 	'square-pen': IconLucideSquarePen,
 	'square-plus': IconLucideSquarePlus,
 	'sticky-note': IconLucideStickyNote,

--- a/packages/frontend/editor-ui/src/app/composables/useDataSchema.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useDataSchema.ts
@@ -319,7 +319,7 @@ const icons = {
 	object: DATA_TYPE_ICON_MAP.object,
 	array: DATA_TYPE_ICON_MAP.array,
 	['string']: DATA_TYPE_ICON_MAP.string,
-	null: 'case-upper',
+	null: 'circle-minus',
 	['number']: DATA_TYPE_ICON_MAP.number,
 	['boolean']: DATA_TYPE_ICON_MAP.boolean,
 	function: 'code',

--- a/packages/frontend/editor-ui/src/app/composables/useDataSchema.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useDataSchema.ts
@@ -319,7 +319,7 @@ const icons = {
 	object: DATA_TYPE_ICON_MAP.object,
 	array: DATA_TYPE_ICON_MAP.array,
 	['string']: DATA_TYPE_ICON_MAP.string,
-	null: 'circle-minus',
+	null: 'square-minus',
 	['number']: DATA_TYPE_ICON_MAP.number,
 	['boolean']: DATA_TYPE_ICON_MAP.boolean,
 	function: 'code',


### PR DESCRIPTION
## Summary

Replacing the icon used to show null values in schema view
<img width="1511" height="830" alt="Screenshot 2025-10-31 at 10 03 45" src="https://github.com/user-attachments/assets/4f7fbe02-79de-4066-a690-bacecf240eb9" />

Fixed with
<img width="430" height="449" alt="Screenshot 2025-11-19 at 14 20 44" src="https://github.com/user-attachments/assets/5587224c-da20-4308-9dab-0497001fa218" />



<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
https://linear.app/n8n/issue/ADO-4349/wrong-type-icons-on-data-table-schema-view
## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
