### PR TITLE
Add conditional execution for formatting targets

### DIFF
--- a/scripts/format.mjs
+++ b/scripts/format.mjs
@@ -48,18 +48,22 @@ fs.readdirSync('.').forEach((cur) => {
 	if (isBiomeTarget(cur)) biomeTargets.push(cur);
 });
 
-execSync(
-	[
-		prettier,
-		'--config',
-		prettierConfig,
-		'--ignore-path',
-		ignore,
-		'--write',
-		prettierTargets.join(' '),
-	].join(' '),
-);
+if (prettierTargets.length > 0) {
+	execSync(
+		[
+			prettier,
+			'--config',
+			prettierConfig,
+			'--ignore-path',
+			ignore,
+			'--write',
+			prettierTargets.join(' '),
+		].join(' '),
+	);
+}
 
-execSync(
-	[biome, 'format', '--write', `--config-path=${biomeConfig}`, biomeTargets.join(' ')].join(' '),
-);
+if (biomeTargets.length > 0) {
+	execSync(
+		[biome, 'format', '--write', `--config-path=${biomeConfig}`, biomeTargets.join(' ')].join(' '),
+	);
+}


### PR DESCRIPTION
This pull request fixes an issue in the format.mjs script where formatting commands for Prettier and Biome could be executed with empty file targets, resulting in errors. The script now checks whether there are any files to process before running the corresponding formatting commands, preventing unnecessary command execution and improving script robustness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Guard Prettier and Biome execution to only run when non-empty target lists are found.
> 
> - **Scripts**:
>   - `scripts/format.mjs`: Add conditional checks to only execute `prettier` and `biome format` when `prettierTargets` or `biomeTargets` are non-empty, avoiding empty-target invocations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2db0eecdd97b2c49fd6a55a09774a297671e937b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->