### PR TITLE
feat(editor): Add dynamic banner text support (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/rest-api-client/src/api/cloudPlans.ts
+++ b/packages/frontend/@n8n/rest-api-client/src/api/cloudPlans.ts
@@ -35,6 +35,9 @@ export declare namespace Cloud {
 		information?: {
 			[key: string]: string | string[];
 		};
+		trialBannerData?: {
+			bannerText: string;
+		};
 	};
 }
 

--- a/packages/frontend/editor-ui/src/app/stores/cloudPlan.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/cloudPlan.store.ts
@@ -22,12 +22,17 @@ const DEFAULT_STATE: CloudPlanState = {
 	loadingPlan: false,
 };
 
+const DYNAMIC_TRIAL_BANNER_DISMISSED_KEY = 'n8n-dynamic-trial-banner-dismissed';
+
 export const useCloudPlanStore = defineStore(STORES.CLOUD_PLAN, () => {
 	const rootStore = useRootStore();
 	const settingsStore = useSettingsStore();
 
 	const state = reactive<CloudPlanState>(DEFAULT_STATE);
 	const currentUserCloudInfo = ref<Cloud.UserAccount | null>(null);
+	const isDynamicTrialBannerDismissed = ref<boolean>(
+		localStorage.getItem(DYNAMIC_TRIAL_BANNER_DISMISSED_KEY) === 'true',
+	);
 
 	const reset = () => {
 		currentUserCloudInfo.value = null;
@@ -60,6 +65,23 @@ export const useCloudPlanStore = defineStore(STORES.CLOUD_PLAN, () => {
 
 		return information.which_of_these_do_you_feel_comfortable_doing.length;
 	});
+
+	const dynamicTrialBannerText = computed(() => {
+		return currentUserCloudInfo.value?.trialBannerData?.bannerText;
+	});
+
+	const shouldShowDynamicTrialBanner = computed(() => {
+		return (
+			dynamicTrialBannerText.value !== undefined &&
+			dynamicTrialBannerText.value !== '' &&
+			!isDynamicTrialBannerDismissed.value
+		);
+	});
+
+	const dismissDynamicTrialBanner = () => {
+		isDynamicTrialBannerDismissed.value = true;
+		localStorage.setItem(DYNAMIC_TRIAL_BANNER_DISMISSED_KEY, 'true');
+	};
 
 	const trialExpired = computed(
 		() =>
@@ -217,5 +239,8 @@ export const useCloudPlanStore = defineStore(STORES.CLOUD_PLAN, () => {
 		getAutoLoginCode,
 		selectedApps,
 		codingSkill,
+		dynamicTrialBannerText,
+		shouldShowDynamicTrialBanner,
+		dismissDynamicTrialBanner,
 	};
 });

--- a/packages/frontend/editor-ui/src/features/shared/banners/components/banners/TrialBanner.vue
+++ b/packages/frontend/editor-ui/src/features/shared/banners/components/banners/TrialBanner.vue
@@ -6,12 +6,15 @@ import { computed } from 'vue';
 import type { CloudPlanAndUsageData } from '@/Interface';
 import { usePageRedirectionHelper } from '@/app/composables/usePageRedirectionHelper';
 
-import { N8nButton, N8nText } from '@n8n/design-system';
+import { N8nBadge, N8nButton, N8nText } from '@n8n/design-system';
 const PROGRESS_BAR_MINIMUM_THRESHOLD = 8;
 
 const cloudPlanStore = useCloudPlanStore();
 
 const pageRedirectionHelper = usePageRedirectionHelper();
+
+const shouldShowTrialBanner = computed(() => cloudPlanStore.shouldShowDynamicTrialBanner);
+const trialBannerText = computed(() => cloudPlanStore.dynamicTrialBannerText);
 
 const trialDaysLeft = computed(() => -1 * cloudPlanStore.trialDaysLeft);
 const messageText = computed(() => {
@@ -52,6 +55,10 @@ const currentExecutions = computed(() => {
 });
 
 function onUpdatePlanClick() {
+	if (shouldShowTrialBanner.value) {
+		cloudPlanStore.dismissDynamicTrialBanner();
+	}
+
 	void pageRedirectionHelper.goToUpgrade('canvas-nav', 'upgrade-canvas-nav', 'redirect');
 }
 </script>
@@ -86,9 +93,19 @@ function onUpdatePlanClick() {
 			</div>
 		</template>
 		<template #trailingContent>
-			<N8nButton type="success" icon="gem" size="small" @click="onUpdatePlanClick">{{
-				locale.baseText('generic.upgradeNow')
-			}}</N8nButton>
+			<div :class="$style.trailingContentWrapper">
+				<N8nBadge
+					v-if="shouldShowTrialBanner"
+					:class="$style.dynamicBanner"
+					size="small"
+					:show-border="false"
+					:bold="true"
+					>{{ trialBannerText }}</N8nBadge
+				>
+				<N8nButton type="success" icon="gem" size="small" @click="onUpdatePlanClick">{{
+					locale.baseText('generic.upgradeNow')
+				}}</N8nButton>
+			</div>
 		</template>
 	</BaseBanner>
 </template>
@@ -173,5 +190,19 @@ function onUpdatePlanClick() {
 
 .executionsCountSection {
 	margin-left: var(--spacing--xs);
+}
+
+.trailingContentWrapper {
+	display: flex;
+	align-items: center;
+	gap: var(--spacing--2xs);
+}
+
+.dynamicBanner {
+	color: var(--color--foreground--tint-2);
+	border: none;
+	background: var(--color--foreground--shade-2);
+	border-radius: var(--radius);
+	padding: var(--spacing--5xs) var(--spacing--3xs);
 }
 </style>


### PR DESCRIPTION
## Summary

Adds dynamic banner text support in the trial banner.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/GRO-167

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds dynamic, dismissible trial banner text surfaced from user account data, wired through store and shown as a badge in the Trial banner.
> 
> - **UI (TrialBanner.vue)**
>   - Show dynamic trial message as a `N8nBadge` next to Upgrade button (`shouldShowDynamicTrialBanner`, `dynamicTrialBannerText`).
>   - Dismiss banner on Upgrade click via store method.
>   - Add styles for trailing content wrapper and dynamic badge.
> - **Store (`cloudPlan.store.ts`)**
>   - Track and expose `dynamicTrialBannerText`, `shouldShowDynamicTrialBanner`, and `dismissDynamicTrialBanner`.
>   - Persist dismissal in `localStorage` using key `n8n-dynamic-trial-banner-dismissed`.
> - **API Types (`rest-api-client/src/api/cloudPlans.ts`)**
>   - Extend `Cloud.UserAccount` with `trialBannerData.bannerText`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0f5ba35a2a10eada4b277168fcf5b090e6c29f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->