### PR TITLE
refactor(core): Minor leftover cleanups in native Python runner

### DIFF
--- a/packages/@n8n/task-runner-python/src/pipe_reader.py
+++ b/packages/@n8n/task-runner-python/src/pipe_reader.py
@@ -1,0 +1,88 @@
+import json
+import os
+import threading
+from typing import cast
+
+from multiprocessing.connection import Connection
+
+from src.errors import (
+    InvalidPipeMsgContentError,
+    InvalidPipeMsgLengthError,
+)
+from src.message_types.pipe import PipeMessage
+from src.constants import PIPE_MSG_PREFIX_LENGTH
+
+type PipeConnection = Connection
+
+
+class PipeReader(threading.Thread):
+    """Background thread that reads result from pipe."""
+
+    def __init__(self, read_fd: int, read_conn: PipeConnection):
+        super().__init__()
+        self.read_fd = read_fd
+        self.read_conn = read_conn
+        self.pipe_message: PipeMessage | None = None
+        self.message_size: int | None = None  # bytes
+        self.error: Exception | None = None
+
+    def run(self):
+        try:
+            length_bytes = PipeReader._read_exact_bytes(
+                self.read_fd, PIPE_MSG_PREFIX_LENGTH
+            )
+            length_int = int.from_bytes(length_bytes, "big")
+            if length_int <= 0:
+                raise InvalidPipeMsgLengthError(length_int)
+            self.message_size = length_int
+            data = PipeReader._read_exact_bytes(self.read_fd, length_int)
+            parsed_msg = json.loads(data.decode("utf-8"))
+            self.pipe_message = self._validate_pipe_message(parsed_msg)
+        except Exception as e:
+            self.error = e
+        finally:
+            self.read_conn.close()
+
+    @staticmethod
+    def _read_exact_bytes(fd: int, n: int) -> bytes:
+        """Read exactly n bytes from file descriptor.
+
+        Uses os.read() instead of Connection.recv() because recv() pickles.
+        Preallocates bytearray to avoid repeated reallocation.
+        """
+        result = bytearray(n)
+        offset = 0
+        while offset < n:
+            chunk = os.read(fd, n - offset)
+            if not chunk:
+                raise EOFError("Pipe closed before reading all data")
+            result[offset : offset + len(chunk)] = chunk
+            offset += len(chunk)
+        return bytes(result)
+
+    def _validate_pipe_message(self, msg) -> PipeMessage:
+        if not isinstance(msg, dict):
+            raise InvalidPipeMsgContentError(f"Expected dict, got {type(msg).__name__}")
+
+        if "print_args" not in msg:
+            raise InvalidPipeMsgContentError("Message missing 'print_args' key")
+
+        if not isinstance(msg["print_args"], list):
+            raise InvalidPipeMsgContentError("'print_args' must be a list")
+
+        has_result = "result" in msg
+        has_error = "error" in msg
+
+        if not has_result and not has_error:
+            raise InvalidPipeMsgContentError("Msg is missing 'result' or 'error' key")
+
+        if has_result and has_error:
+            raise InvalidPipeMsgContentError("Msg has both 'result' and 'error' keys")
+
+        if has_result and not isinstance(msg["result"], list):
+            raise InvalidPipeMsgContentError("'result' must be a list")
+
+        if has_error and not isinstance(msg["error"], dict):
+            raise InvalidPipeMsgContentError("'error' must be a dict")
+
+        return cast(PipeMessage, msg)

--- a/packages/@n8n/task-runner-python/src/task_executor.py
+++ b/packages/@n8n/task-runner-python/src/task_executor.py
@@ -6,12 +6,8 @@ import io
 import os
 import sys
 import logging
-import threading
-from typing import cast
 
 from src.errors import (
-    InvalidPipeMsgContentError,
-    InvalidPipeMsgLengthError,
     TaskCancelledError,
     TaskKilledError,
     TaskResultMissingError,

--- a/packages/@n8n/task-runner-python/src/task_executor.py
+++ b/packages/@n8n/task-runner-python/src/task_executor.py
@@ -26,12 +26,12 @@ from src.config.security_config import SecurityConfig
 
 from src.message_types.broker import NodeMode, Items
 from src.message_types.pipe import (
-    PipeMessage,
     PipeResultMessage,
     PipeErrorMessage,
     TaskErrorInfo,
     PrintArgs,
 )
+from src.pipe_reader import PipeReader
 from src.constants import (
     EXECUTOR_CIRCULAR_REFERENCE_KEY,
     EXECUTOR_USER_OUTPUT_KEY,
@@ -100,7 +100,7 @@ class TaskExecutor:
 
         print_args: PrintArgs = []
 
-        pipe_reader = PipeReaderThread(read_conn.fileno(), read_conn)
+        pipe_reader = PipeReader(read_conn.fileno(), read_conn)
         pipe_reader.start()
 
         try:
@@ -496,23 +496,6 @@ class TaskExecutor:
     # ========== pipe I/O ==========
 
     @staticmethod
-    def _read_exact_bytes(fd: int, n: int) -> bytes:
-        """Read exactly n bytes from file descriptor.
-
-        Uses os.read() instead of Connection.recv() because recv() pickles.
-        Preallocates bytearray to avoid repeated reallocation.
-        """
-        result = bytearray(n)
-        offset = 0
-        while offset < n:
-            chunk = os.read(fd, n - offset)
-            if not chunk:
-                raise EOFError("Pipe closed before reading all data")
-            result[offset : offset + len(chunk)] = chunk
-            offset += len(chunk)
-        return bytes(result)
-
-    @staticmethod
     def _write_bytes(fd: int, data: bytes):
         total_written = 0
         while total_written < len(data):
@@ -520,59 +503,3 @@ class TaskExecutor:
             if written == 0:
                 raise OSError("Write failed")
             total_written += written
-
-
-class PipeReaderThread(threading.Thread):
-    """Background thread that reads result from pipe."""
-
-    def __init__(self, read_fd: int, read_conn: PipeConnection):
-        super().__init__()
-        self.read_fd = read_fd
-        self.read_conn = read_conn
-        self.pipe_message: PipeMessage | None = None
-        self.message_size: int | None = None  # bytes
-        self.error: Exception | None = None
-
-    def run(self):
-        try:
-            length_bytes = TaskExecutor._read_exact_bytes(
-                self.read_fd, PIPE_MSG_PREFIX_LENGTH
-            )
-            length_int = int.from_bytes(length_bytes, "big")
-            if length_int <= 0:
-                raise InvalidPipeMsgLengthError(length_int)
-            self.message_size = length_int
-            data = TaskExecutor._read_exact_bytes(self.read_fd, length_int)
-            parsed_msg = json.loads(data.decode("utf-8"))
-            self.pipe_message = self._validate_pipe_message(parsed_msg)
-        except Exception as e:
-            self.error = e
-        finally:
-            self.read_conn.close()
-
-    def _validate_pipe_message(self, msg) -> PipeMessage:
-        if not isinstance(msg, dict):
-            raise InvalidPipeMsgContentError(f"Expected dict, got {type(msg).__name__}")
-
-        if "print_args" not in msg:
-            raise InvalidPipeMsgContentError("Message missing 'print_args' key")
-
-        if not isinstance(msg["print_args"], list):
-            raise InvalidPipeMsgContentError("'print_args' must be a list")
-
-        has_result = "result" in msg
-        has_error = "error" in msg
-
-        if not has_result and not has_error:
-            raise InvalidPipeMsgContentError("Msg is missing 'result' or 'error' key")
-
-        if has_result and has_error:
-            raise InvalidPipeMsgContentError("Msg has both 'result' and 'error' keys")
-
-        if has_result and not isinstance(msg["result"], list):
-            raise InvalidPipeMsgContentError("'result' must be a list")
-
-        if has_error and not isinstance(msg["error"], dict):
-            raise InvalidPipeMsgContentError("'error' must be a dict")
-
-        return cast(PipeMessage, msg)

--- a/packages/@n8n/task-runner-python/src/task_runner.py
+++ b/packages/@n8n/task-runner-python/src/task_runner.py
@@ -1,10 +1,11 @@
 import asyncio
 import logging
 import time
-from typing import Any, Callable, Awaitable
+from typing import Callable, Awaitable
 from dataclasses import dataclass
 from urllib.parse import urlparse
 import websockets
+from websockets.asyncio.client import ClientConnection
 import random
 from src.errors import TaskCancelledError
 
@@ -77,7 +78,7 @@ class TaskRunner:
         self.name = RUNNER_NAME
         self.config = config
 
-        self.websocket_connection: Any | None = None
+        self.websocket_connection: ClientConnection | None = None
         self.can_send_offers = False
 
         self.open_offers: dict[str, TaskOffer] = {}

--- a/packages/@n8n/task-runner-python/tests/unit/test_sentry.py
+++ b/packages/@n8n/task-runner-python/tests/unit/test_sentry.py
@@ -3,6 +3,8 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+pytest.importorskip("sentry_sdk")
+
 from src.config.sentry_config import SentryConfig
 from src.sentry import TaskRunnerSentry, setup_sentry
 from src.constants import (

--- a/packages/@n8n/task-runner-python/tests/unit/test_task_executor.py
+++ b/packages/@n8n/task-runner-python/tests/unit/test_task_executor.py
@@ -3,6 +3,7 @@ import json
 from unittest.mock import MagicMock, patch
 
 from src.task_executor import TaskExecutor
+from src.pipe_reader import PipeReader
 from src.errors import TaskCancelledError, TaskKilledError, TaskSubprocessFailedError
 from src.constants import SIGTERM_EXIT_CODE, SIGKILL_EXIT_CODE, PIPE_MSG_PREFIX_LENGTH
 from src.message_types.pipe import (
@@ -174,7 +175,7 @@ class TestTaskExecutorLowLevelIO:
         data = b"test data"
         mock_os_read.return_value = data
 
-        result = TaskExecutor._read_exact_bytes(999, len(data))
+        result = PipeReader._read_exact_bytes(999, len(data))
 
         assert result == data
         mock_os_read.assert_called_once_with(999, len(data))
@@ -183,7 +184,7 @@ class TestTaskExecutorLowLevelIO:
     def test_read_exact_bytes_multiple_reads(self, mock_os_read):
         mock_os_read.side_effect = [b"test", b" ", b"data"]
 
-        result = TaskExecutor._read_exact_bytes(999, 9)
+        result = PipeReader._read_exact_bytes(999, 9)
 
         assert result == b"test data"
         assert mock_os_read.call_count == 3
@@ -193,7 +194,7 @@ class TestTaskExecutorLowLevelIO:
         mock_os_read.side_effect = [b"test", b""]  # empty for EOF
 
         with pytest.raises(EOFError, match="Pipe closed before reading all data"):
-            TaskExecutor._read_exact_bytes(999, 10)
+            PipeReader._read_exact_bytes(999, 10)
 
     @patch("os.write")
     def test_write_bytes_write_failure(self, mock_os_write):


### PR DESCRIPTION
## Summary

- Move `PipeReaderThread` to own file
- Type websocket connection correctly
- Skip Sentry tests when Sentry (optional dep) is not installed

## Related Linear tickets, Github issues, and Community forum posts

n/a

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
