### PR TITLE
fix(core): Fix AI Agent v3 Tool Execution Issues

### DIFF
--- a/packages/core/src/execution-engine/__tests__/requests-response.test.ts
+++ b/packages/core/src/execution-engine/__tests__/requests-response.test.ts
@@ -1,5 +1,5 @@
 import { mock } from 'jest-mock-extended';
-import type { IExecuteData, IRunData, EngineRequest } from 'n8n-workflow';
+import type { IExecuteData, IRunData, EngineRequest, INodeExecutionData } from 'n8n-workflow';
 
 import { DirectedGraph } from '../partial-execution-utils';
 import { createNodeData } from '../partial-execution-utils/__tests__/helpers';
@@ -40,5 +40,251 @@ describe('handleRequests', () => {
 				runData: mock<IRunData>(),
 			}),
 		).toThrowError('Workflow does not contain a node with the name of "does not exist".');
+	});
+
+	test('merges agent input data with tool parameters for expression resolution', () => {
+		// ARRANGE
+		const toolNode = createNodeData({ name: 'Gmail Tool', type: types.passThrough });
+		const agentNode = createNodeData({ name: 'AI Agent', type: types.passThrough });
+
+		const workflow = new DirectedGraph()
+			.addNodes(toolNode, agentNode)
+			.toWorkflow({ name: '', active: false, nodeTypes });
+
+		// Agent received data from previous nodes with workflow context
+		const agentInputData: INodeExecutionData[] = [
+			{
+				json: {
+					myNewField: 1,
+					price_total: '344.00',
+					existingData: 'from workflow',
+				},
+			},
+		];
+
+		const executionData: IExecuteData = {
+			data: {
+				main: [agentInputData], // Agent's main input at index 0
+			},
+			source: {
+				main: [
+					{
+						previousNode: 'Process Quotes',
+						previousNodeOutput: 0,
+						previousNodeRun: 0,
+					},
+				],
+			},
+			node: agentNode,
+		};
+
+		const request: EngineRequest = {
+			actions: [
+				{
+					actionType: 'ExecutionNodeAction',
+					nodeName: 'Gmail Tool',
+					input: { subject: 'Test Email', toolParam: 'from LLM' }, // LLM-provided parameters
+					type: 'ai_tool',
+					id: 'tool_call_123',
+					metadata: { itemIndex: 0 },
+				},
+			],
+			metadata: {},
+		};
+
+		const runData: IRunData = {};
+
+		// ACT
+		const result = handleRequest({
+			workflow,
+			currentNode: agentNode,
+			request,
+			runIndex: 0,
+			executionData,
+			runData,
+		});
+
+		// ASSERT
+		const toolNodeToExecute = result.nodesToBeExecuted.find((n) => n.parentNode === 'AI Agent');
+		expect(toolNodeToExecute).toBeDefined();
+
+		// Verify merged data contains both workflow data and tool parameters
+		const mergedJson = toolNodeToExecute!.parentOutputData[0][0].json;
+		expect(mergedJson).toEqual({
+			myNewField: 1,
+			price_total: '344.00',
+			existingData: 'from workflow',
+			subject: 'Test Email',
+			toolParam: 'from LLM',
+			toolCallId: 'tool_call_123',
+		});
+
+		// Verify tool parameters take precedence (override workflow data)
+		const requestWithOverride: EngineRequest = {
+			actions: [
+				{
+					actionType: 'ExecutionNodeAction',
+					nodeName: 'Gmail Tool',
+					input: { existingData: 'overridden by tool' }, // This should override workflow data
+					type: 'ai_tool',
+					id: 'tool_call_456',
+					metadata: { itemIndex: 0 },
+				},
+			],
+			metadata: {},
+		};
+
+		const runData2: IRunData = {};
+		const result2 = handleRequest({
+			workflow,
+			currentNode: agentNode,
+			request: requestWithOverride,
+			runIndex: 0,
+			executionData,
+			runData: runData2,
+		});
+
+		const toolNodeToExecute2 = result2.nodesToBeExecuted.find((n) => n.parentNode === 'AI Agent');
+		const mergedJson2 = toolNodeToExecute2!.parentOutputData[0][0].json;
+		expect(mergedJson2.existingData).toBe('overridden by tool');
+	});
+
+	test('uses output index 0 for tools regardless of agent input connection', () => {
+		// ARRANGE
+		const toolNode = createNodeData({ name: 'Gmail Tool', type: types.passThrough });
+		const agentNode = createNodeData({ name: 'AI Agent', type: types.passThrough });
+		const switchNode = createNodeData({ name: 'Switch', type: types.passThrough });
+
+		const workflow = new DirectedGraph()
+			.addNodes(toolNode, agentNode, switchNode)
+			.toWorkflow({ name: '', active: false, nodeTypes });
+
+		// Agent is connected to output 2 of the Switch node
+		const agentInputData: INodeExecutionData[] = [
+			{
+				json: {
+					data: 'from switch output 2',
+				},
+			},
+		];
+
+		const executionData: IExecuteData = {
+			data: {
+				main: [agentInputData],
+			},
+			source: {
+				main: [
+					{
+						previousNode: 'Switch',
+						previousNodeOutput: 2, // Connected to Switch output 2
+						previousNodeRun: 0,
+					},
+				],
+			},
+			node: agentNode,
+		};
+
+		const request: EngineRequest = {
+			actions: [
+				{
+					actionType: 'ExecutionNodeAction',
+					nodeName: 'Gmail Tool',
+					input: { message: 'test' },
+					type: 'ai_tool',
+					id: 'tool_call_789',
+					metadata: { itemIndex: 0 },
+				},
+			],
+			metadata: {},
+		};
+
+		const runData: IRunData = {};
+
+		// ACT
+		const result = handleRequest({
+			workflow,
+			currentNode: agentNode,
+			request,
+			runIndex: 0,
+			executionData,
+			runData,
+		});
+
+		// ASSERT
+		const toolNodeToExecute = result.nodesToBeExecuted.find((n) => n.parentNode === 'AI Agent');
+		expect(toolNodeToExecute).toBeDefined();
+
+		// Verify parentOutputIndex is always 0 for tools (agents have only one main output)
+		// This prevents "Cannot read properties of undefined (reading 'map')" error
+		expect(toolNodeToExecute!.parentOutputIndex).toBe(0);
+	});
+
+	test('handles multiple items correctly using itemIndex from metadata', () => {
+		// ARRANGE
+		const toolNode = createNodeData({ name: 'Gmail Tool', type: types.passThrough });
+		const agentNode = createNodeData({ name: 'AI Agent', type: types.passThrough });
+
+		const workflow = new DirectedGraph()
+			.addNodes(toolNode, agentNode)
+			.toWorkflow({ name: '', active: false, nodeTypes });
+
+		// Agent received multiple items from previous nodes
+		const agentInputData: INodeExecutionData[] = [
+			{ json: { id: 1, value: 'first item' } },
+			{ json: { id: 2, value: 'second item' } },
+			{ json: { id: 3, value: 'third item' } },
+		];
+
+		const executionData: IExecuteData = {
+			data: {
+				main: [agentInputData],
+			},
+			source: {
+				main: [
+					{
+						previousNode: 'Process Data',
+						previousNodeOutput: 0,
+						previousNodeRun: 0,
+					},
+				],
+			},
+			node: agentNode,
+		};
+
+		const request: EngineRequest = {
+			actions: [
+				{
+					actionType: 'ExecutionNodeAction',
+					nodeName: 'Gmail Tool',
+					input: { toolParam: 'for second item' },
+					type: 'ai_tool',
+					id: 'tool_call_abc',
+					metadata: { itemIndex: 1 }, // Processing second item
+				},
+			],
+			metadata: {},
+		};
+
+		const runData: IRunData = {};
+
+		// ACT
+		const result = handleRequest({
+			workflow,
+			currentNode: agentNode,
+			request,
+			runIndex: 0,
+			executionData,
+			runData,
+		});
+
+		// ASSERT
+		const toolNodeToExecute = result.nodesToBeExecuted.find((n) => n.parentNode === 'AI Agent');
+		expect(toolNodeToExecute).toBeDefined();
+
+		// Verify correct item data is merged (second item with id: 2)
+		const mergedJson = toolNodeToExecute!.parentOutputData[0][0].json;
+		expect(mergedJson.id).toBe(2);
+		expect(mergedJson.value).toBe('second item');
+		expect(mergedJson.toolParam).toBe('for second item');
 	});
 });

--- a/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
@@ -433,7 +433,7 @@ describe('processRunExecutionData', () => {
 				ai_tool: [
 					[
 						{
-							json: { query: 'test input', toolCallId: 'action_1' },
+							json: { prompt: 'test prompt', query: 'test input', toolCallId: 'action_1' },
 							pairedItem: {
 								input: 0,
 								item: 0,
@@ -453,7 +453,7 @@ describe('processRunExecutionData', () => {
 				ai_tool: [
 					[
 						{
-							json: { data: 'another input', toolCallId: 'action_2' },
+							json: { prompt: 'test prompt', data: 'another input', toolCallId: 'action_2' },
 							pairedItem: {
 								input: 0,
 								item: 0,
@@ -565,7 +565,7 @@ describe('processRunExecutionData', () => {
 				ai_tool: [
 					[
 						{
-							json: { query: 'test input', toolCallId: 'action_1' },
+							json: { prompt: 'test prompt', query: 'test input', toolCallId: 'action_1' },
 							pairedItem: {
 								input: 0,
 								item: 0,

--- a/packages/core/src/execution-engine/requests-response.ts
+++ b/packages/core/src/execution-engine/requests-response.ts
@@ -61,13 +61,23 @@ function prepareRequestedNodesForExecution(
 		const parentOutputIndex = parentSourceData?.previousNodeOutput ?? 0;
 		const parentRunIndex = parentSourceData?.previousNodeRun ?? 0;
 		const parentSourceNode = parentSourceData?.previousNode ?? currentNode.name;
+
+		// Get the item index from action metadata to access the correct agent input data
+		const itemIndex = (action.metadata as { itemIndex?: number })?.itemIndex ?? 0;
+		const agentInputData = executionData.data.main?.[runIndex]?.[itemIndex];
+
+		// Merge agent's input data with action.input so tools have access to workflow data
+		// action.input takes precedence to allow tool-specific parameters to override
+		const mergedJson = {
+			...(agentInputData?.json ?? {}),
+			...action.input,
+			toolCallId: action.id,
+		};
+
 		const parentOutputData: INodeExecutionData[][] = [
 			[
 				{
-					json: {
-						...action.input,
-						toolCallId: action.id,
-					},
+					json: mergedJson,
 					pairedItem: {
 						item: parentRunIndex,
 						input: parentOutputIndex,

--- a/packages/core/src/execution-engine/requests-response.ts
+++ b/packages/core/src/execution-engine/requests-response.ts
@@ -64,7 +64,8 @@ function prepareRequestedNodesForExecution(
 
 		// Get the item index from action metadata to access the correct agent input data
 		const itemIndex = (action.metadata as { itemIndex?: number })?.itemIndex ?? 0;
-		const agentInputData = executionData.data.main?.[runIndex]?.[itemIndex];
+		// Use index 0 for main input as agents have only one main input connection
+		const agentInputData = executionData.data.main?.[0]?.[itemIndex];
 
 		// Merge agent's input data with action.input so tools have access to workflow data
 		// action.input takes precedence to allow tool-specific parameters to override
@@ -106,7 +107,7 @@ function prepareRequestedNodesForExecution(
 
 		nodesToBeExecuted.push({
 			inputConnectionData,
-			parentOutputIndex,
+			parentOutputIndex: 0, // Tools connect to agent's output 0 (agents have only one main output)
 			parentNode,
 			parentOutputData,
 			runIndex,


### PR DESCRIPTION
## Summary

This PR fixes 2 issues:

### 1. Expression Resolution in Tools
Expressions like `{{ $json.myNewField }}` in tool nodes resolve to `undefined` when using AI Agent v3.

### 2. Agent Connected to Non-Zero Outputs
Execution fails with `"Cannot read properties of undefined (reading 'map')"` when AI Agent is connected to outputs other than 0 (e.g., Switch output 2).

## Root Causes

### Issue 1: Missing Workflow Context
When AI Agent v3 queues tools using the execution engine, tools only received LLM-provided parameters (`action.input`), not the workflow data from previous nodes. This broke expression resolution.

### Issue 2: Incorrect Output Index
Tools were incorrectly using the agent's input connection index (e.g., Switch output 2) instead of the agent's output index (always 0), causing `parentOutputData[2]` to be undefined.


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
fixes #21334

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
