### PR TITLE
fix(MCP Client Tool Node): Respect the timeout option

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
@@ -1,3 +1,4 @@
+import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
 import {
 	type IDataObject,
 	type IExecuteFunctions,
@@ -394,7 +395,7 @@ export class McpClientTool implements INodeType {
 
 		this.logger.debug('McpClientTool: Successfully connected to MCP Server');
 
-		if (!mcpTools || !mcpTools.length) {
+		if (!mcpTools?.length) {
 			return setError(
 				'MCP Server returned no tools',
 				'Connected successfully to your MCP server but it returned an empty list of tools.',
@@ -461,7 +462,9 @@ export class McpClientTool implements INodeType {
 						name: tool.name,
 						arguments: toolArguments,
 					};
-					const result = await client.callTool(params);
+					const result = await client.callTool(params, CallToolResultSchema, {
+						timeout: config.timeout,
+					});
 					returnData.push({
 						json: {
 							response: result.content as IDataObject,


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
Make sure to pass the user-provided timeout to the tool call in `execute` function.

Workflow to test (make sure it's active):
```json
{
  "nodes": [
    {
      "parameters": {
        "promptType": "define",
        "text": "what is 6! ?",
        "options": {}
      },
      "type": "@n8n/n8n-nodes-langchain.agent",
      "typeVersion": 3,
      "position": [
        80,
        -96
      ],
      "id": "ec35cd6d-8cae-4da6-9e17-cab9042cd162",
      "name": "AI Agent"
    },
    {
      "parameters": {
        "endpointUrl": "http://localhost:5678/mcp/test-timeout",
        "options": {
          "timeout": 5000
        }
      },
      "type": "@n8n/n8n-nodes-langchain.mcpClientTool",
      "typeVersion": 1.2,
      "position": [
        416,
        176
      ],
      "id": "40b85ac2-53f4-4588-8e20-255d087299a4",
      "name": "MCP Client"
    },
    {
      "parameters": {
        "model": {
          "__rl": true,
          "mode": "list",
          "value": "gpt-4.1-mini"
        },
        "builtInTools": {},
        "options": {}
      },
      "type": "@n8n/n8n-nodes-langchain.lmChatOpenAi",
      "typeVersion": 1.3,
      "position": [
        96,
        128
      ],
      "id": "0e810945-f0fb-4ee2-bd44-d7f84eb2e024",
      "name": "OpenAI Chat Model",
      "credentials": {
        "openAiApi": {
          "id": "vqrg9eel6lRZNTPp",
          "name": "OpenAi (n8n)"
        }
      }
    },
    {
      "parameters": {
        "path": "test-timeout"
      },
      "type": "@n8n/n8n-nodes-langchain.mcpTrigger",
      "typeVersion": 2,
      "position": [
        -144,
        448
      ],
      "id": "c834e6c5-91f2-4702-b7e3-9e2d05db6996",
      "name": "MCP Server Trigger",
      "webhookId": "5aab9587-d6b9-43c3-9983-91aacbccb443"
    },
    {
      "parameters": {
        "content": "## Call the tool with 5 seconds timeout",
        "height": 256
      },
      "type": "n8n-nodes-base.stickyNote",
      "position": [
        336,
        64
      ],
      "typeVersion": 1,
      "id": "5f93983b-8dfa-4ce6-a202-e830189c146c",
      "name": "Sticky Note1"
    },
    {
      "parameters": {
        "description": "call this tool to get the factorial of a number",
        "jsCode": "const fact = (n) => {\n  if (n <= 1) {\n    return 1;\n  }\n\n  return fact(n - 1) * n;\n};\n\nawait new Promise((resolve, reject) => setTimeout(resolve, 10000));\nreturn fact(query.number);",
        "specifyInputSchema": true,
        "jsonSchemaExample": "{\n\t\"number\": 123\n}"
      },
      "type": "@n8n/n8n-nodes-langchain.toolCode",
      "typeVersion": 1.3,
      "position": [
        -80,
        672
      ],
      "id": "f92c6461-dc06-49d9-be28-73f8c5eba23a",
      "name": "factorial_tool"
    },
    {
      "parameters": {
        "content": "## Tool executes for 10 seconds",
        "height": 256,
        "width": 272
      },
      "type": "n8n-nodes-base.stickyNote",
      "position": [
        -176,
        560
      ],
      "typeVersion": 1,
      "id": "ab8ca429-da8b-4039-8ce1-46ce3998c1c9",
      "name": "Sticky Note"
    },
    {
      "parameters": {},
      "type": "n8n-nodes-base.manualTrigger",
      "typeVersion": 1,
      "position": [
        -144,
        16
      ],
      "id": "dab9699e-390d-4ab9-8d08-8228e6711c98",
      "name": "When clicking ‘Execute workflow’"
    }
  ],
  "connections": {
    "MCP Client": {
      "ai_tool": [
        [
          {
            "node": "AI Agent",
            "type": "ai_tool",
            "index": 0
          }
        ]
      ]
    },
    "OpenAI Chat Model": {
      "ai_languageModel": [
        [
          {
            "node": "AI Agent",
            "type": "ai_languageModel",
            "index": 0
          }
        ]
      ]
    },
    "factorial_tool": {
      "ai_tool": [
        [
          {
            "node": "MCP Server Trigger",
            "type": "ai_tool",
            "index": 0
          }
        ]
      ]
    },
    "When clicking ‘Execute workflow’": {
      "main": [
        [
          {
            "node": "AI Agent",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {},
  "meta": {
    "templateCredsSetupCompleted": true,
    "instanceId": "eeda9e3069aca300d1dfceeb64beb5b53d715db44a50461bbc5cb0cf6daa01e3"
  }
}
```

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
https://linear.app/n8n/issue/NODE-3833/mcp-client-tool-times-out-after-1-minute

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
