### PR TITLE
fix(editor): Don't add `z-index` to edges

### DIFF
--- a/packages/frontend/editor-ui/src/app/styles/plugins/_vueflow.scss
+++ b/packages/frontend/editor-ui/src/app/styles/plugins/_vueflow.scss
@@ -88,10 +88,6 @@
 	}
 }
 
-.vue-flow__nodes:has(.bring-to-front) {
-	z-index: 2 !important;
-}
-
 /**
  * Handles
  */
@@ -117,8 +113,6 @@
 /**
  * Edges
  */
-
-.vue-flow__edges:has(.bring-to-front),
 .vue-flow__edge-label.selected {
 	z-index: 1 !important;
 }

--- a/packages/frontend/editor-ui/src/app/styles/plugins/_vueflow.scss
+++ b/packages/frontend/editor-ui/src/app/styles/plugins/_vueflow.scss
@@ -88,6 +88,10 @@
 	}
 }
 
+.vue-flow__nodes:has(.bring-to-front) {
+	z-index: 2 !important;
+}
+
 /**
  * Handles
  */
@@ -113,6 +117,8 @@
 /**
  * Edges
  */
+
+.vue-flow__edges:has(.bring-to-front),
 .vue-flow__edge-label.selected {
 	z-index: 1 !important;
 }

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/utils/getEdgeRenderData.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/utils/getEdgeRenderData.ts
@@ -5,6 +5,7 @@ import type { NodeConnectionType } from 'n8n-workflow';
 
 const EDGE_PADDING_BOTTOM = 130;
 const EDGE_PADDING_X = 40;
+const EDGE_OFFSET_X = 4; // Required to not overlap with node handles
 const EDGE_BORDER_RADIUS = 16;
 const HANDLE_SIZE = 20; // Required to avoid connection line glitching when initially interacting with the handle
 
@@ -22,10 +23,15 @@ export function getEdgeRenderData(
 	} = {},
 ) {
 	const { targetX, targetY, sourceX, sourceY, sourcePosition, targetPosition } = props;
+	const lineStartX = sourceX + EDGE_OFFSET_X;
 	const isConnectorStraight = sourceY === targetY;
 
 	if (!isRightOfSourceHandle(sourceX, targetX) || connectionType !== NodeConnectionTypes.Main) {
-		const segment = getBezierPath(props);
+		const segment = getBezierPath({
+			...props,
+			sourceX: lineStartX,
+		});
+		console.log(sourceX, sourceY, 'segment', segment);
 		return {
 			segments: [segment],
 			labelPosition: [segment[1], segment[2]],
@@ -38,7 +44,7 @@ export function getEdgeRenderData(
 	const firstSegmentTargetX = (sourceX + targetX) / 2;
 	const firstSegmentTargetY = sourceY + EDGE_PADDING_BOTTOM;
 	const firstSegment = getSmoothStepPath({
-		sourceX,
+		sourceX: lineStartX,
 		sourceY,
 		targetX: firstSegmentTargetX,
 		targetY: firstSegmentTargetY,


### PR DESCRIPTION
## Summary

This bug seems to have been introduced between 1.116.0 and 1.117.0 when Rolldown was introduced. The issue is not reproducible in dev mode, only when the app is bundled. I suspect it's somehow related to order of css styles and tree shaking differences between rollup and rolldown.

Previously, Node.vue and Edge.vue had `bringToFront` applied to them simultaneously on edge hover, but Node had `z-index:2` and Edge had `z-index:1`. Then `z-index:2` was removed from Node, but somehow it didn't introduce the visual regression. Then, after migration to rolldown it became visible, because `z-index:1` was still applied to Edge, while Node had `z-index:0`.


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3813/connector-line-appears-above-node-output-circle-after-hovering

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
