### PR TITLE
fix: Ensure workflows and folders updatedAt/createdAt aren't mixed up in project sorting

### DIFF
--- a/packages/@n8n/db/src/repositories/workflow.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow.repository.ts
@@ -149,8 +149,14 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 	private buildBaseUnionQuery(workflowIds: string[], options: ListQuery.Options = {}) {
 		const subQueryParameters: ListQuery.Options = {
 			select: {
-				createdAt: true,
+				// For some reason the order of updatedAt and createdAt here is load-bearing
+				// and the generated sql queries below risk switching up the order otherwise
+				// depending on whether this code is called for a project or the overview
+				// A proper fix would sort the columnNames here and in the folder and workflow queries
+				// but that risks breaking other use cases
+				// https://linear.app/n8n/issue/ADO-4376/tech-debt-investigate-and-fix-root-cause-of-incorrect-sql-column
 				updatedAt: true,
+				createdAt: true,
 				id: true,
 				name: true,
 			},


### PR DESCRIPTION
## Summary

This fixes the issue of createdAt/updatedAt being mixed up in project sorting.

Not a great fix but don't really have the time to investigate deeper right now. Manually verified existing correct cases didn't change order.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4367

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
