### PR TITLE
chore(ai-builder): Adding telemetry for categorization in the workflow builder

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/AskAssistantBuild.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/AskAssistantBuild.test.ts
@@ -1351,6 +1351,11 @@ describe('AskAssistantBuild', () => {
 	it('should track categorization telemetry when categorize_prompt tool completes', async () => {
 		renderComponent();
 
+		// Simulate streaming starts
+		builderStore.$patch({ streaming: true });
+		await flushPromises();
+
+		// Add categorization tool message
 		builderStore.toolMessages = [
 			{
 				id: faker.string.uuid(),
@@ -1373,6 +1378,8 @@ describe('AskAssistantBuild', () => {
 			},
 		];
 
+		// Simulate streaming stops (this triggers trackWorkflowModifications)
+		builderStore.$patch({ streaming: false });
 		await flushPromises();
 
 		expect(trackMock).toHaveBeenCalledWith('Classifier labels user prompt', {

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/AskAssistantBuild.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/AskAssistantBuild.test.ts
@@ -1348,6 +1348,43 @@ describe('AskAssistantBuild', () => {
 		});
 	});
 
+	it('should track categorization telemetry when categorize_prompt tool completes', async () => {
+		renderComponent();
+
+		builderStore.toolMessages = [
+			{
+				id: faker.string.uuid(),
+				role: 'assistant' as const,
+				type: 'tool' as const,
+				toolName: 'categorize_prompt',
+				toolCallId: faker.string.uuid(),
+				status: 'completed',
+				updates: [
+					{
+						type: 'output',
+						data: {
+							categorization: {
+								techniques: ['chatbot', 'notification'],
+								confidence: 0.85,
+							},
+						},
+					},
+				],
+			},
+		];
+
+		await flushPromises();
+
+		expect(trackMock).toHaveBeenCalledWith('Classifier labels user prompt', {
+			user_id: undefined,
+			workflow_id: 'abc123',
+			classifier_labels: ['chatbot', 'notification'],
+			confidence: 0.85,
+			session_id: 'app_session_id',
+			timestamp: expect.any(String),
+		});
+	});
+
 	it('should handle multiple canvas generations correctly', async () => {
 		const originalWorkflow = {
 			nodes: [],

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/AskAssistantBuild.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/AskAssistantBuild.vue
@@ -141,7 +141,7 @@ function isCategorizationData(
 	);
 }
 
-function trackWorkflowModifications() {
+function trackWorkflowCategorization() {
 	// Track categorization telemetry
 	builderStore.toolMessages.forEach((toolMsg) => {
 		if (toolMsg.toolName !== 'categorize_prompt') return;
@@ -165,7 +165,9 @@ function trackWorkflowModifications() {
 			timestamp: new Date().toISOString(),
 		});
 	});
+}
 
+function trackWorkflowModifications() {
 	if (workflowUpdated.value) {
 		// Track tool usage for telemetry
 		const newToolMessages = builderStore.toolMessages.filter(
@@ -282,6 +284,7 @@ watch(
 	async (isStreaming) => {
 		if (!isStreaming) {
 			trackWorkflowModifications();
+			trackWorkflowCategorization();
 		}
 
 		if (


### PR DESCRIPTION
## Summary

For the purposes of the best practices we categorize the user prompt for the workflow builder into one of 15 categories - this sends a telemetry event when this occurs and the tool call is resolved so that we can query for it.

@harshalnpatil has updated the telemetry database to include this event.

Addresses: https://linear.app/n8n/issue/AI-1650/feature-pipe-prompt-classifiers-output-to-bigquery

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
