### PR TITLE
fix(API): Fix returning role as slug on the users api handler

### DIFF
--- a/packages/cli/src/public-api/v1/handlers/users/spec/schemas/user.yml
+++ b/packages/cli/src/public-api/v1/handlers/users/spec/schemas/user.yml
@@ -38,5 +38,5 @@ properties:
     readOnly: true
   role:
     type: string
-    example: owner
+    example: global:owner
     readOnly: true


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Since the merge of the custom roles, the role field was not returned by the Public API users handler (/users, /users/:id).
This PR fixes it by explicitly loading the role relation when fetching the users, and returning the role slug in the `role` field to keep retro compatibility

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

pay-4064-public-api-includerole-query-param-has-no-effect-for

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
