### PR TITLE
fix(core): Enforce timeout for task requests

### DIFF
--- a/packages/@n8n/config/src/configs/runners.config.ts
+++ b/packages/@n8n/config/src/configs/runners.config.ts
@@ -59,6 +59,14 @@ export class TaskRunnersConfig {
 	@Env('N8N_RUNNERS_TASK_TIMEOUT')
 	taskTimeout: number = 300; // 5 minutes
 
+	/**
+	 * How long (in seconds) a task request can wait for a runner to become
+	 * available before timing out. This prevents workflows from hanging
+	 * indefinitely when no runners are available. Must be greater than 0.
+	 */
+	@Env('N8N_RUNNERS_TASK_REQUEST_TIMEOUT')
+	taskRequestTimeout: number = 20;
+
 	/** How often (in seconds) the runner must send a heartbeat to the broker, else the task will be aborted. (In internal mode, the runner will also  be restarted.) Must be greater than 0. */
 	@Env('N8N_RUNNERS_HEARTBEAT_INTERVAL')
 	heartbeatInterval: number = 30;

--- a/packages/@n8n/config/src/configs/runners.config.ts
+++ b/packages/@n8n/config/src/configs/runners.config.ts
@@ -65,7 +65,7 @@ export class TaskRunnersConfig {
 	 * indefinitely when no runners are available. Must be greater than 0.
 	 */
 	@Env('N8N_RUNNERS_TASK_REQUEST_TIMEOUT')
-	taskRequestTimeout: number = 20;
+	taskRequestTimeout: number = 60;
 
 	/** How often (in seconds) the runner must send a heartbeat to the broker, else the task will be aborted. (In internal mode, the runner will also  be restarted.) Must be greater than 0. */
 	@Env('N8N_RUNNERS_HEARTBEAT_INTERVAL')

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -265,6 +265,7 @@ describe('GlobalConfig', () => {
 			maxOldSpaceSize: '',
 			maxConcurrency: 10,
 			taskTimeout: 300,
+			taskRequestTimeout: 20,
 			heartbeatInterval: 30,
 			insecureMode: false,
 			isNativePythonRunnerEnabled: false,

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -265,7 +265,7 @@ describe('GlobalConfig', () => {
 			maxOldSpaceSize: '',
 			maxConcurrency: 10,
 			taskTimeout: 300,
-			taskRequestTimeout: 20,
+			taskRequestTimeout: 60,
 			heartbeatInterval: 30,
 			insecureMode: false,
 			isNativePythonRunnerEnabled: false,

--- a/packages/@n8n/task-runner/src/message-types.ts
+++ b/packages/@n8n/task-runner/src/message-types.ts
@@ -87,6 +87,12 @@ export namespace BrokerMessage {
 			error: unknown;
 		}
 
+		export interface RequestExpired {
+			type: 'broker:requestexpired';
+			requestId: string;
+			reason: 'timeout';
+		}
+
 		export interface TaskDataRequest {
 			type: 'broker:taskdatarequest';
 			taskId: string;
@@ -109,7 +115,14 @@ export namespace BrokerMessage {
 			params: unknown[];
 		}
 
-		export type All = TaskReady | TaskDone | TaskError | TaskDataRequest | NodeTypesRequest | RPC;
+		export type All =
+			| TaskReady
+			| TaskDone
+			| TaskError
+			| RequestExpired
+			| TaskDataRequest
+			| NodeTypesRequest
+			| RPC;
 	}
 }
 

--- a/packages/cli/src/task-runners/errors/task-request-timeout.error.ts
+++ b/packages/cli/src/task-runners/errors/task-request-timeout.error.ts
@@ -1,0 +1,22 @@
+import { OperationalError } from 'n8n-workflow';
+
+export class TaskRequestTimeoutError extends OperationalError {
+	description: string;
+
+	constructor({ timeout, isSelfHosted }: { timeout: number; isSelfHosted: boolean }) {
+		super(`Task request timed out after ${timeout} ${timeout === 1 ? 'second' : 'seconds'}`);
+
+		const description = [
+			'Your Code node task was not matched to a runner within the timeout period. This indicates that the task runner is currently down, or not ready, or at capacity, so it cannot service your task.',
+			'If you are repeatedly executing Code nodes with long-running tasks across your instance, please space them apart to give the runner time to catch up. If this does not describe your use case, please open a GitHub issue or reach out to support.',
+		];
+
+		if (isSelfHosted) {
+			description.push(
+				'If needed, you can increase the timeout using the N8N_RUNNERS_TASK_REQUEST_TIMEOUT environment variable.',
+			);
+		}
+
+		this.description = description.join('<br/><br/>');
+	}
+}

--- a/packages/cli/src/task-runners/task-broker/__tests__/task-broker.service.test.ts
+++ b/packages/cli/src/task-runners/task-broker/__tests__/task-broker.service.test.ts
@@ -951,7 +951,7 @@ describe('TaskBroker', () => {
 
 			expect(taskBroker.getPendingTaskRequests()).toHaveLength(1);
 
-			jest.advanceTimersByTime(20 * 1000);
+			jest.advanceTimersByTime(60 * 1000);
 
 			await Promise.resolve();
 
@@ -1003,7 +1003,7 @@ describe('TaskBroker', () => {
 
 			expect(taskBroker.getPendingTaskRequests()).toHaveLength(0);
 
-			jest.advanceTimersByTime(25 * 1000);
+			jest.advanceTimersByTime(65 * 1000);
 
 			await Promise.resolve();
 
@@ -1053,7 +1053,7 @@ describe('TaskBroker', () => {
 			const deferredRequest = taskBroker.getPendingTaskRequests()[0];
 			expect(deferredRequest.timeout).toBeDefined();
 
-			jest.advanceTimersByTime(20 * 1000);
+			jest.advanceTimersByTime(60 * 1000);
 
 			await Promise.resolve();
 

--- a/packages/cli/src/task-runners/task-broker/__tests__/task-broker.service.test.ts
+++ b/packages/cli/src/task-runners/task-broker/__tests__/task-broker.service.test.ts
@@ -989,7 +989,7 @@ describe('TaskBroker', () => {
 				taskType: 'taskType1',
 			};
 
-			jest.spyOn(taskBroker, 'acceptOffer').mockImplementation(async (offer, request) => {
+			jest.spyOn(taskBroker, 'acceptOffer').mockImplementation(async (_offer, request) => {
 				clearTimeout(request.timeout);
 				const requests = taskBroker.getPendingTaskRequests();
 				const filtered = requests.filter((r) => r.requestId !== request.requestId);
@@ -1041,7 +1041,7 @@ describe('TaskBroker', () => {
 
 			const handleTimeoutSpy = jest.spyOn(taskBroker as any, 'handleRequestTimeout');
 
-			jest.spyOn(taskBroker, 'acceptOffer').mockImplementation(async (offer, request) => {
+			jest.spyOn(taskBroker, 'acceptOffer').mockImplementation(async (_offer, request) => {
 				clearTimeout(request.timeout);
 				request.timeout = taskBroker['createRequestTimeout'](request.requestId);
 				taskBroker.setPendingTaskRequests([request]);

--- a/packages/cli/src/task-runners/task-broker/__tests__/task-broker.service.test.ts
+++ b/packages/cli/src/task-runners/task-broker/__tests__/task-broker.service.test.ts
@@ -930,4 +930,142 @@ describe('TaskBroker', () => {
 			jest.useRealTimers();
 		});
 	});
+
+	describe('request timeout', () => {
+		it('should time out request and send `broker:requestexpired` message', async () => {
+			jest.useFakeTimers();
+
+			const requesterId = 'requester1';
+			const requesterCallback = jest.fn();
+
+			taskBroker.registerRequester(requesterId, requesterCallback);
+
+			const request: TaskRequest = {
+				requestId: 'request1',
+				requesterId,
+				taskType: 'taskType1',
+				timeout: taskBroker['createRequestTimeout']('request1'),
+			};
+
+			taskBroker.taskRequested(request);
+
+			expect(taskBroker.getPendingTaskRequests()).toHaveLength(1);
+
+			jest.advanceTimersByTime(20 * 1000);
+
+			await Promise.resolve();
+
+			expect(taskBroker.getPendingTaskRequests()).toHaveLength(0);
+			expect(requesterCallback).toHaveBeenCalledWith({
+				type: 'broker:requestexpired',
+				requestId: 'request1',
+				reason: 'timeout',
+			});
+
+			jest.useRealTimers();
+		});
+
+		it('should clear timeout on request matched', async () => {
+			jest.useFakeTimers();
+
+			const requesterId = 'requester1';
+			const requesterCallback = jest.fn();
+
+			taskBroker.registerRequester(requesterId, requesterCallback);
+
+			const offer: TaskOffer = {
+				offerId: 'offer1',
+				runnerId: 'runner1',
+				taskType: 'taskType1',
+				validFor: 1000,
+				validUntil: createValidUntil(1000),
+			};
+
+			taskBroker.setPendingTaskOffers([offer]);
+
+			const request: TaskRequest = {
+				requestId: 'request1',
+				requesterId,
+				taskType: 'taskType1',
+			};
+
+			jest.spyOn(taskBroker, 'acceptOffer').mockImplementation(async (offer, request) => {
+				clearTimeout(request.timeout);
+				const requests = taskBroker.getPendingTaskRequests();
+				const filtered = requests.filter((r) => r.requestId !== request.requestId);
+				taskBroker.setPendingTaskRequests(filtered);
+			});
+
+			taskBroker.taskRequested(request);
+
+			await Promise.resolve();
+			await Promise.resolve();
+
+			expect(taskBroker.getPendingTaskRequests()).toHaveLength(0);
+
+			jest.advanceTimersByTime(25 * 1000);
+
+			await Promise.resolve();
+
+			expect(requesterCallback).not.toHaveBeenCalledWith(
+				expect.objectContaining({ type: 'broker:requestexpired' }),
+			);
+
+			jest.useRealTimers();
+		});
+
+		it('should reset timeout on request deferred', async () => {
+			jest.useFakeTimers();
+
+			const requesterId = 'requester1';
+			const requesterCallback = jest.fn();
+
+			taskBroker.registerRequester(requesterId, requesterCallback);
+
+			const offer: TaskOffer = {
+				offerId: 'offer1',
+				runnerId: 'runner1',
+				taskType: 'taskType1',
+				validFor: 1000,
+				validUntil: createValidUntil(1000),
+			};
+
+			const request: TaskRequest = {
+				requestId: 'request1',
+				requesterId,
+				taskType: 'taskType1',
+			};
+
+			taskBroker.setPendingTaskOffers([offer]);
+			taskBroker.setPendingTaskRequests([request]);
+
+			const handleTimeoutSpy = jest.spyOn(taskBroker as any, 'handleRequestTimeout');
+
+			jest.spyOn(taskBroker, 'acceptOffer').mockImplementation(async (offer, request) => {
+				clearTimeout(request.timeout);
+				request.timeout = taskBroker['createRequestTimeout'](request.requestId);
+				taskBroker.setPendingTaskRequests([request]);
+			});
+
+			taskBroker.settleTasks();
+
+			expect(taskBroker.getPendingTaskRequests()).toHaveLength(1);
+			const deferredRequest = taskBroker.getPendingTaskRequests()[0];
+			expect(deferredRequest.timeout).toBeDefined();
+
+			jest.advanceTimersByTime(20 * 1000);
+
+			await Promise.resolve();
+
+			expect(handleTimeoutSpy).toHaveBeenCalledWith('request1');
+			expect(requesterCallback).toHaveBeenCalledWith({
+				type: 'broker:requestexpired',
+				requestId: 'request1',
+				reason: 'timeout',
+			});
+
+			handleTimeoutSpy.mockRestore();
+			jest.useRealTimers();
+		});
+	});
 });

--- a/packages/cli/src/task-runners/task-broker/task-broker.service.ts
+++ b/packages/cli/src/task-runners/task-broker/task-broker.service.ts
@@ -550,13 +550,13 @@ export class TaskBroker {
 			await acceptPromise;
 		} catch (e) {
 			request.acceptInProgress = false;
-			clearTimeout(request.timeout);
 			if (e instanceof TaskRejectError) {
 				this.logger.info(`Task (${taskId}) rejected by Runner with reason "${e.reason}"`);
 				return;
 			}
 			if (e instanceof TaskDeferredError) {
 				this.logger.debug(`Task (${taskId}) deferred until runner is ready`);
+				clearTimeout(request.timeout);
 				request.timeout = this.createRequestTimeout(request.requestId);
 				this.pendingTaskRequests.push(request); // will settle on receiving task offer from runner
 				return;

--- a/packages/cli/src/task-runners/task-broker/task-broker.service.ts
+++ b/packages/cli/src/task-runners/task-broker/task-broker.service.ts
@@ -46,7 +46,7 @@ export interface TaskRequest {
 	requestId: string;
 	requesterId: string;
 	taskType: string;
-
+	timeout?: NodeJS.Timeout;
 	acceptInProgress?: boolean;
 }
 
@@ -95,6 +95,28 @@ export class TaskBroker {
 		if (this.taskRunnersConfig.taskTimeout <= 0) {
 			throw new UserError('Task timeout must be greater than 0');
 		}
+	}
+
+	private createRequestTimeout(requestId: string): NodeJS.Timeout {
+		return setTimeout(() => {
+			this.handleRequestTimeout(requestId);
+		}, this.taskRunnersConfig.taskRequestTimeout * Time.seconds.toMilliseconds);
+	}
+
+	private handleRequestTimeout(requestId: string) {
+		const requestIndex = this.pendingTaskRequests.findIndex((r) => r.requestId === requestId);
+		if (requestIndex === -1) return;
+
+		const request = this.pendingTaskRequests[requestIndex];
+		this.pendingTaskRequests.splice(requestIndex, 1);
+
+		clearTimeout(request.timeout);
+
+		void this.requesters.get(request.requesterId)?.({
+			type: 'broker:requestexpired',
+			requestId: request.requestId,
+			reason: 'timeout',
+		});
 	}
 
 	expireTasks() {
@@ -306,6 +328,7 @@ export class TaskBroker {
 					taskType: message.taskType,
 					requestId: message.requestId,
 					requesterId,
+					timeout: this.createRequestTimeout(message.requestId),
 				});
 				break;
 			case 'requester:taskdataresponse':
@@ -527,12 +550,14 @@ export class TaskBroker {
 			await acceptPromise;
 		} catch (e) {
 			request.acceptInProgress = false;
+			clearTimeout(request.timeout);
 			if (e instanceof TaskRejectError) {
 				this.logger.info(`Task (${taskId}) rejected by Runner with reason "${e.reason}"`);
 				return;
 			}
 			if (e instanceof TaskDeferredError) {
 				this.logger.debug(`Task (${taskId}) deferred until runner is ready`);
+				request.timeout = this.createRequestTimeout(request.requestId);
 				this.pendingTaskRequests.push(request); // will settle on receiving task offer from runner
 				return;
 			}
@@ -542,6 +567,8 @@ export class TaskBroker {
 			}
 			throw e;
 		}
+
+		clearTimeout(request.timeout);
 
 		const task: Task = {
 			id: taskId,

--- a/packages/cli/src/task-runners/task-managers/__tests__/task-manager.test.ts
+++ b/packages/cli/src/task-runners/task-managers/__tests__/task-manager.test.ts
@@ -2,6 +2,7 @@ import type { GlobalConfig, TaskRunnersConfig } from '@n8n/config';
 import { mock } from 'jest-mock-extended';
 import get from 'lodash/get';
 import set from 'lodash/set';
+import type { ErrorReporter } from 'n8n-core';
 
 import type { EventService } from '@/events/event.service';
 import type { NodeTypes } from '@/node-types';
@@ -22,6 +23,7 @@ describe('TaskRequester', () => {
 	const mockEventService = mock<EventService>();
 	const mockTaskRunnersConfig = mock<TaskRunnersConfig>();
 	const mockGlobalConfig = mock<GlobalConfig>();
+	const mockErrorReporter = mock<ErrorReporter>();
 
 	beforeEach(() => {
 		instance = new TestTaskRequester(
@@ -29,6 +31,7 @@ describe('TaskRequester', () => {
 			mockEventService,
 			mockTaskRunnersConfig,
 			mockGlobalConfig,
+			mockErrorReporter,
 		);
 	});
 

--- a/packages/cli/src/task-runners/task-managers/__tests__/task-manager.test.ts
+++ b/packages/cli/src/task-runners/task-managers/__tests__/task-manager.test.ts
@@ -1,3 +1,4 @@
+import type { GlobalConfig, TaskRunnersConfig } from '@n8n/config';
 import { mock } from 'jest-mock-extended';
 import get from 'lodash/get';
 import set from 'lodash/set';
@@ -19,9 +20,16 @@ describe('TaskRequester', () => {
 	let instance: TestTaskRequester;
 	const mockNodeTypes = mock<NodeTypes>();
 	const mockEventService = mock<EventService>();
+	const mockTaskRunnersConfig = mock<TaskRunnersConfig>();
+	const mockGlobalConfig = mock<GlobalConfig>();
 
 	beforeEach(() => {
-		instance = new TestTaskRequester(mockNodeTypes, mockEventService);
+		instance = new TestTaskRequester(
+			mockNodeTypes,
+			mockEventService,
+			mockTaskRunnersConfig,
+			mockGlobalConfig,
+		);
 	});
 
 	describe('handleRpc', () => {

--- a/packages/cli/src/task-runners/task-managers/local-task-requester.ts
+++ b/packages/cli/src/task-runners/task-managers/local-task-requester.ts
@@ -1,6 +1,7 @@
 import { GlobalConfig, TaskRunnersConfig } from '@n8n/config';
 import { Container, Service } from '@n8n/di';
 import type { RequesterMessage } from '@n8n/task-runner';
+import { ErrorReporter } from 'n8n-core';
 
 import { EventService } from '@/events/event.service';
 import { NodeTypes } from '@/node-types';
@@ -20,8 +21,9 @@ export class LocalTaskRequester extends TaskRequester {
 		eventService: EventService,
 		taskRunnersConfig: TaskRunnersConfig,
 		globalConfig: GlobalConfig,
+		errorReporter: ErrorReporter,
 	) {
-		super(nodeTypes, eventService, taskRunnersConfig, globalConfig);
+		super(nodeTypes, eventService, taskRunnersConfig, globalConfig, errorReporter);
 		this.registerRequester();
 	}
 

--- a/packages/cli/src/task-runners/task-managers/local-task-requester.ts
+++ b/packages/cli/src/task-runners/task-managers/local-task-requester.ts
@@ -1,3 +1,4 @@
+import { GlobalConfig, TaskRunnersConfig } from '@n8n/config';
 import { Container, Service } from '@n8n/di';
 import type { RequesterMessage } from '@n8n/task-runner';
 
@@ -14,8 +15,13 @@ export class LocalTaskRequester extends TaskRequester {
 
 	id = 'local-task-requester';
 
-	constructor(nodeTypes: NodeTypes, eventService: EventService) {
-		super(nodeTypes, eventService);
+	constructor(
+		nodeTypes: NodeTypes,
+		eventService: EventService,
+		taskRunnersConfig: TaskRunnersConfig,
+		globalConfig: GlobalConfig,
+	) {
+		super(nodeTypes, eventService, taskRunnersConfig, globalConfig);
 		this.registerRequester();
 	}
 


### PR DESCRIPTION
https://linear.app/n8n/issue/CAT-1700

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce configurable task request timeout, expiring unmatched requests in the broker and surfacing a structured timeout error to requesters.
> 
> - **Config**:
>   - Add `N8N_RUNNERS_TASK_REQUEST_TIMEOUT` (`taskRequestTimeout`, default `60`).
> - **Broker/Runner Messaging**:
>   - Add `broker:requestexpired` message and include in `BrokerMessage.ToRequester.All`.
> - **Task Broker** (`packages/cli/.../task-broker.service.ts`):
>   - Implement per-request timeout (`createRequestTimeout`, `handleRequestTimeout`).
>   - Start timeout on `requester:taskrequest`; clear on match; reset on defer; remove expired requests and notify requester.
>   - Extend `TaskRequest` with optional `timeout`.
> - **Requester** (`task-requester.ts`, `local-task-requester.ts`):
>   - Inject `TaskRunnersConfig`, `GlobalConfig`, `ErrorReporter`.
>   - Handle `broker:requestexpired` by rejecting with `TaskRequestTimeoutError` and reporting via `ErrorReporter`.
>   - Allow `RequestReject` to accept `Error`.
> - **Errors**:
>   - Add `TaskRequestTimeoutError` with user-facing description and self-host hint.
> - **Tests**:
>   - Add request-timeout unit tests for broker; update existing tests for new constructor deps and behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17a47db551686a4290357e50178af95e027daea1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->