### PR TITLE
fix(SendGrid Node): Use `/scopes` for credential testing

### DIFF
--- a/packages/nodes-base/credentials/SendGridApi.credentials.ts
+++ b/packages/nodes-base/credentials/SendGridApi.credentials.ts
@@ -34,7 +34,7 @@ export class SendGridApi implements ICredentialType {
 	test: ICredentialTestRequest = {
 		request: {
 			baseURL: 'https://api.sendgrid.com/v3',
-			url: '/marketing/contacts',
+			url: '/scopes',
 		},
 	};
 }


### PR DESCRIPTION
## Summary

This PR changes the endpoint for credential testing to a more robust one.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3782/community-issue-sendgrid-credential-claims-wrong-api-key

closes #17971

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
