### PR TITLE
fix(core): Add timeout and recovery for database connection health checks

### DIFF
--- a/packages/@n8n/db/src/connection/db-connection.ts
+++ b/packages/@n8n/db/src/connection/db-connection.ts
@@ -1,4 +1,4 @@
-import { inTest } from '@n8n/backend-common';
+import { inTest, Logger } from '@n8n/backend-common';
 import { DatabaseConfig } from '@n8n/config';
 import { Time } from '@n8n/constants';
 import { Memoized } from '@n8n/decorators';
@@ -6,6 +6,7 @@ import { Container, Service } from '@n8n/di';
 import { DataSource } from '@n8n/typeorm';
 import { ErrorReporter } from 'n8n-core';
 import { DbConnectionTimeoutError, ensureError } from 'n8n-workflow';
+import { setTimeout as setTimeoutP } from 'timers/promises';
 
 import { DbConnectionOptions } from './db-connection-options';
 import { wrapMigration } from '../migrations/migration-helpers';
@@ -31,6 +32,7 @@ export class DbConnection {
 		private readonly errorReporter: ErrorReporter,
 		private readonly connectionOptions: DbConnectionOptions,
 		private readonly databaseConfig: DatabaseConfig,
+		private readonly logger: Logger,
 	) {
 		this.dataSource = new DataSource(this.options);
 		Container.set(DataSource, this.dataSource);
@@ -94,7 +96,17 @@ export class DbConnection {
 	private async ping() {
 		if (!this.dataSource.isInitialized) return;
 		try {
-			await this.dataSource.query('SELECT 1');
+			await Promise.race([
+				this.dataSource.query('SELECT 1'),
+				setTimeoutP(5000).then(() => {
+					throw new Error('Database connection timed out');
+				}),
+			]);
+
+			if (!this.connectionState.connected) {
+				this.logger.info('Database connection recovered');
+			}
+
 			this.connectionState.connected = true;
 			return;
 		} catch (error) {

--- a/packages/@n8n/db/src/connection/db-connection.ts
+++ b/packages/@n8n/db/src/connection/db-connection.ts
@@ -95,10 +95,12 @@ export class DbConnection {
 
 	private async ping() {
 		if (!this.dataSource.isInitialized) return;
+		const abortController = new AbortController();
+
 		try {
 			await Promise.race([
 				this.dataSource.query('SELECT 1'),
-				setTimeoutP(5000).then(() => {
+				setTimeoutP(5000, undefined, { signal: abortController.signal }).then(() => {
 					throw new OperationalError('Database connection timed out');
 				}),
 			]);
@@ -117,6 +119,7 @@ export class DbConnection {
 				this.errorReporter.error(error);
 			}
 		} finally {
+			abortController.abort();
 			this.scheduleNextPing();
 		}
 	}

--- a/packages/@n8n/db/src/connection/db-connection.ts
+++ b/packages/@n8n/db/src/connection/db-connection.ts
@@ -100,11 +100,9 @@ export class DbConnection {
 		try {
 			await Promise.race([
 				this.dataSource.query('SELECT 1'),
-				setTimeoutP(5000, undefined, { signal: abortController.signal })
-					.then(() => {
-						throw new OperationalError('Database connection timed out');
-					})
-					.catch(() => {}), // Handle abort when DB responds before timeout
+				setTimeoutP(5000, undefined, { signal: abortController.signal }).then(() => {
+					throw new OperationalError('Database connection timed out');
+				}),
 			]);
 
 			if (!this.connectionState.connected) {

--- a/packages/@n8n/db/src/connection/db-connection.ts
+++ b/packages/@n8n/db/src/connection/db-connection.ts
@@ -100,9 +100,11 @@ export class DbConnection {
 		try {
 			await Promise.race([
 				this.dataSource.query('SELECT 1'),
-				setTimeoutP(5000, undefined, { signal: abortController.signal }).then(() => {
-					throw new OperationalError('Database connection timed out');
-				}),
+				setTimeoutP(5000, undefined, { signal: abortController.signal })
+					.then(() => {
+						throw new OperationalError('Database connection timed out');
+					})
+					.catch(() => {}), // Handle abort when DB responds before timeout
 			]);
 
 			if (!this.connectionState.connected) {

--- a/packages/cli/src/abstract-server.ts
+++ b/packages/cli/src/abstract-server.ts
@@ -121,7 +121,7 @@ export abstract class AbstractServer {
 
 	protected setupPushServer() {}
 
-	private async setupHealthCheck() {
+	private setupHealthCheck() {
 		// main health check should not care about DB connections
 		this.app.get('/healthz', (_req, res) => {
 			res.send({ status: 'ok' });
@@ -200,7 +200,7 @@ export abstract class AbstractServer {
 
 		this.externalHooks = Container.get(ExternalHooks);
 
-		await this.setupHealthCheck();
+		this.setupHealthCheck();
 
 		this.logger.info(`n8n ready on ${address}, port ${port}`);
 	}
@@ -296,7 +296,7 @@ export abstract class AbstractServer {
 	 * then closes them forcefully.
 	 */
 	@OnShutdown()
-	async onShutdown(): Promise<void> {
+	onShutdown(): void {
 		if (!this.server) {
 			return;
 		}

--- a/packages/testing/containers/n8n-test-container-dependencies.ts
+++ b/packages/testing/containers/n8n-test-container-dependencies.ts
@@ -53,6 +53,7 @@ export async function setupPostgres({
 			'com.docker.compose.service': 'postgres',
 		})
 		.withName(`${projectName}-postgres`)
+		.withAddedCapabilities('NET_ADMIN') // Allows us to drop IP tables and block traffic
 		.withReuse()
 		.start();
 

--- a/packages/testing/playwright/package.json
+++ b/packages/testing/playwright/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@currents/playwright": "^1.15.3",
     "@n8n/api-types": "workspace:^",
+    "@n8n/constants": "workspace:^",
     "@n8n/db": "workspace:*",
     "@playwright/test": "1.56.0",
     "@types/lodash": "catalog:",

--- a/packages/testing/playwright/services/api-helper.ts
+++ b/packages/testing/playwright/services/api-helper.ts
@@ -225,8 +225,9 @@ export class ApiHelpers {
 	 * Check if n8n is healthy
 	 * @returns True if n8n is healthy, false otherwise
 	 */
-	async isHealthy(): Promise<boolean> {
-		const response = await this.request.get('/healthz');
+	async isHealthy(probe: 'liveness' | 'readiness' = 'liveness'): Promise<boolean> {
+		const url = probe === 'liveness' ? '/healthz' : '/healthz/readiness';
+		const response = await this.request.get(url);
 		const data = await response.json();
 		return data.status === 'ok';
 	}

--- a/packages/testing/playwright/services/api-helper.ts
+++ b/packages/testing/playwright/services/api-helper.ts
@@ -217,9 +217,18 @@ export class ApiHelpers {
 
 	async get(path: string, params?: URLSearchParams) {
 		const response = await this.request.get(path, { params });
-
 		const { data } = await response.json();
 		return data;
+	}
+
+	/**
+	 * Check if n8n is healthy
+	 * @returns True if n8n is healthy, false otherwise
+	 */
+	async isHealthy(): Promise<boolean> {
+		const response = await this.request.get('/healthz');
+		const data = await response.json();
+		return data.status === 'ok';
 	}
 
 	// ===== PRIVATE METHODS =====

--- a/packages/testing/playwright/tests/chaos/multimain.spec.ts
+++ b/packages/testing/playwright/tests/chaos/multimain.spec.ts
@@ -8,10 +8,10 @@ test('Leader election @mode:multi-main @chaostest', async ({ chaos }) => {
 		namePattern,
 	});
 
-	expect(findContainerByLog).toBeDefined();
-	const currentLeader = findContainerByLog.containerName;
+	expect(findContainerByLog, 'Leader should be found').toBeDefined();
+	const currentLeader = findContainerByLog?.containerName;
 	// Stop leader
-	await chaos.stopContainer(currentLeader);
+	await chaos.stopContainer(currentLeader!);
 
 	// Find new leader
 	const newLeader = await chaos.waitForLog('Leader is now this', {

--- a/packages/testing/playwright/tests/chaos/postgres.spec.ts
+++ b/packages/testing/playwright/tests/chaos/postgres.spec.ts
@@ -1,3 +1,5 @@
+import { Time } from '@n8n/constants';
+
 import { test, expect } from '../../fixtures/base';
 
 test(
@@ -13,102 +15,51 @@ test(
 
 		// ========== SETUP: Verify Initial Health ==========
 		// Ensure n8n starts in a healthy state before we begin chaos testing
-		const initialHealth = await api.isHealthy();
-		expect(initialHealth).toBe(true);
-		console.log('✓ n8n is initially healthy');
+		{
+			const isLive = await api.isHealthy('liveness');
+			const isReady = await api.isHealthy('readiness');
+			expect(isLive).toBe(true);
+			expect(isReady).toBe(true);
+		}
 
 		// ========== CHAOS INJECTION: Block Database Traffic ==========
 		// Find postgres container and install iptables to simulate network issues
 		const postgres = chaos.findContainers('postgres*')[0];
 
 		// Install iptables in the postgres container (Alpine Linux)
-		await postgres.exec(['apk', 'update']);
-		await postgres.exec(['apk', 'add', 'iptables']);
-
+		const apkUpdate = await postgres.exec(['apk', 'update']);
+		const apkInstall = await postgres.exec(['apk', 'add', 'iptables']);
 		// Block all incoming TCP traffic to PostgreSQL port 5432
 		// This simulates a network partition between n8n and the database
-		await postgres.exec(['iptables', '-A', 'INPUT', '-p', 'tcp', '--dport', '5432', '-j', 'DROP']);
-		console.log('✓ Database port 5432 is now blocked - simulating network partition');
+		const rule = ['INPUT', '-p', 'tcp', '--dport', '5432', '-j', 'DROP'];
+		const blockPostgresTraffic = await postgres.exec(['iptables', '-A', ...rule]);
+		expect(apkUpdate.exitCode).toBe(0);
+		expect(apkInstall.exitCode).toBe(0);
+		expect(blockPostgresTraffic.exitCode).toBe(0);
 
 		// ========== WAIT FOR CONNECTION ISSUES ==========
-		// First, wait for the connection pool to detect the timeout
-		// This message appears when the pg-pool library detects connection issues
-		await chaos.waitForLog('Connection terminated due to connection timeout', {
+		await chaos.waitForLog('Database connection timed out', {
 			namePattern: 'n8n-*',
-			timeoutMs: 180000, // 3 minutes - connection pools can take time to timeout
+			timeoutMs: 20 * Time.seconds.toMilliseconds,
 		});
 
-		// ========== TRIGGER ACTIVE DATABASE QUERY ==========
-		// The timeout error only appears when n8n tries to query the database
-		// We trigger this by calling an endpoint that requires DB access
-		console.log('Triggering database query to expose timeout errors...');
-		await api.get('/rest/settings');
-
-		// Now wait for the specific error from the bug report
-		const errorLog = await chaos.waitForLog('timeout exceeded when trying to connect', {
-			namePattern: 'n8n-*',
-			timeoutMs: 180000,
-			throwOnTimeout: false, // Don't fail if not found - we'll check later
-		});
-
-		// This doesn't always show up, it shows up when I manually interact with the UI/API
-		expect.soft(errorLog, 'n8n should be logging timeout errors').toBeDefined();
-		console.log('✓ n8n is logging timeout errors as expected');
-
-		// ========== BUG VERIFICATION: Health Check Should Fail But Doesn't ==========
-		// This is the core bug: health endpoint reports OK despite DB being unreachable
-		// In a properly functioning system, the health check should fail when the DB is down
-		console.log('Checking health endpoint during database outage...');
-		const healthDuringOutage = await api.isHealthy();
-
-		// Using soft assertion to continue test even if bug is fixed
-		expect.soft(healthDuringOutage).toBe(false);
-
-		expect
-			.soft(healthDuringOutage, 'Health endpoint should report unhealthy during database outage')
-			.toBe(false);
+		// ========== VERIFY: Health Checks ==========
+		{
+			const isLive = await api.isHealthy('liveness');
+			const isReady = await api.isHealthy('readiness');
+			expect(isLive).toBe(true);
+			expect(isReady).toBe(false);
+		}
 
 		// ========== RESTORE DATABASE CONNECTION ==========
 		// Remove the iptables rule to allow traffic again
-		console.log('Restoring database connectivity...');
-		await postgres.exec(['iptables', '-D', 'INPUT', '-p', 'tcp', '--dport', '5432', '-j', 'DROP']);
-		console.log('✓ Network partition removed - database should be reachable again');
+		const allowPostgresTraffic = await postgres.exec(['iptables', '-D', ...rule]);
+		expect(allowPostgresTraffic.exitCode).toBe(0);
 
-		// ========== BUG VERIFICATION: Recovery Should Happen But Doesn't ==========
-		// The second part of the bug: n8n doesn't automatically recover when DB comes back
-		console.log('Waiting for n8n to automatically recover...');
-		// Check we don't see this log anymore, we should replace this with a recovery log if we have one, I couldn't find one though
-		const recoveryLog = await chaos.waitForLog('Connection terminated due to connection timeout', {
+		// ========== VERIFY: Automatic Recovery ==========
+		await chaos.waitForLog('Database connection recovered', {
 			namePattern: 'n8n-*',
-			timeoutMs: 60000, // 1 minute should be enough for recovery
-			throwOnTimeout: false,
+			timeoutMs: 20 * Time.seconds.toMilliseconds,
 		});
-
-		expect
-			.soft(recoveryLog?.containerName, 'n8n should automatically reconnect to the database')
-			.toBeNull();
-
-		// ========== WORKAROUND: Manual Restart Required ==========
-		// Since n8n doesn't auto-recover, we need to restart the container
-		// This mimics what the bug reporter had to do in production
-		console.log('Performing manual restart as workaround...');
-		const n8nContainer = chaos.findContainers('n8n-*')[0];
-		await n8nContainer.restart();
-
-		// Wait for n8n to fully start up after restart
-		const n8nRecoveryLog = await chaos.waitForLog('Editor is now accessible via', {
-			namePattern: 'n8n-*',
-			timeoutMs: 60000,
-		});
-
-		expect(n8nRecoveryLog, 'n8n should start successfully after manual restart').toBeDefined();
-		console.log('✓ n8n recovered after manual restart');
-
-		// ========== SUMMARY ==========
-		console.log('\n=== Test Summary ===');
-		console.log('Bug reproduced successfully:');
-		console.log('1. Health check incorrectly reports healthy during DB outage');
-		console.log('2. n8n does not automatically recover when DB connection is restored');
-		console.log('3. Manual restart is required to restore functionality');
 	},
 );

--- a/packages/testing/playwright/tests/chaos/postgres.spec.ts
+++ b/packages/testing/playwright/tests/chaos/postgres.spec.ts
@@ -1,0 +1,114 @@
+import { test, expect } from '../../fixtures/base';
+
+test(
+	'Database connection timeout health check bug @mode:postgres @chaostest',
+	{
+		annotation: {
+			type: 'issue',
+			description: 'CAT-1018',
+		},
+	},
+	async ({ api, chaos }) => {
+		test.setTimeout(300000);
+
+		// ========== SETUP: Verify Initial Health ==========
+		// Ensure n8n starts in a healthy state before we begin chaos testing
+		const initialHealth = await api.isHealthy();
+		expect(initialHealth).toBe(true);
+		console.log('✓ n8n is initially healthy');
+
+		// ========== CHAOS INJECTION: Block Database Traffic ==========
+		// Find postgres container and install iptables to simulate network issues
+		const postgres = chaos.findContainers('postgres*')[0];
+
+		// Install iptables in the postgres container (Alpine Linux)
+		await postgres.exec(['apk', 'update']);
+		await postgres.exec(['apk', 'add', 'iptables']);
+
+		// Block all incoming TCP traffic to PostgreSQL port 5432
+		// This simulates a network partition between n8n and the database
+		await postgres.exec(['iptables', '-A', 'INPUT', '-p', 'tcp', '--dport', '5432', '-j', 'DROP']);
+		console.log('✓ Database port 5432 is now blocked - simulating network partition');
+
+		// ========== WAIT FOR CONNECTION ISSUES ==========
+		// First, wait for the connection pool to detect the timeout
+		// This message appears when the pg-pool library detects connection issues
+		await chaos.waitForLog('Connection terminated due to connection timeout', {
+			namePattern: 'n8n-*',
+			timeoutMs: 180000, // 3 minutes - connection pools can take time to timeout
+		});
+
+		// ========== TRIGGER ACTIVE DATABASE QUERY ==========
+		// The timeout error only appears when n8n tries to query the database
+		// We trigger this by calling an endpoint that requires DB access
+		console.log('Triggering database query to expose timeout errors...');
+		await api.get('/rest/settings');
+
+		// Now wait for the specific error from the bug report
+		const errorLog = await chaos.waitForLog('timeout exceeded when trying to connect', {
+			namePattern: 'n8n-*',
+			timeoutMs: 180000,
+			throwOnTimeout: false, // Don't fail if not found - we'll check later
+		});
+
+		// This doesn't always show up, it shows up when I manually interact with the UI/API
+		expect.soft(errorLog, 'n8n should be logging timeout errors').toBeDefined();
+		console.log('✓ n8n is logging timeout errors as expected');
+
+		// ========== BUG VERIFICATION: Health Check Should Fail But Doesn't ==========
+		// This is the core bug: health endpoint reports OK despite DB being unreachable
+		// In a properly functioning system, the health check should fail when the DB is down
+		console.log('Checking health endpoint during database outage...');
+		const healthDuringOutage = await api.isHealthy();
+
+		// Using soft assertion to continue test even if bug is fixed
+		expect.soft(healthDuringOutage).toBe(false);
+
+		expect
+			.soft(healthDuringOutage, 'Health endpoint should report unhealthy during database outage')
+			.toBe(false);
+
+		// ========== RESTORE DATABASE CONNECTION ==========
+		// Remove the iptables rule to allow traffic again
+		console.log('Restoring database connectivity...');
+		await postgres.exec(['iptables', '-D', 'INPUT', '-p', 'tcp', '--dport', '5432', '-j', 'DROP']);
+		console.log('✓ Network partition removed - database should be reachable again');
+
+		// ========== BUG VERIFICATION: Recovery Should Happen But Doesn't ==========
+		// The second part of the bug: n8n doesn't automatically recover when DB comes back
+		console.log('Waiting for n8n to automatically recover...');
+		// Check we don't see this log anymore, we should replace this with a recovery log if we have one, I couldn't find one though
+		const recoveryLog = await chaos.waitForLog('Connection terminated due to connection timeout', {
+			namePattern: 'n8n-*',
+			timeoutMs: 60000, // 1 minute should be enough for recovery
+			throwOnTimeout: false,
+		});
+
+		expect
+			.soft(recoveryLog?.containerName, 'n8n should automatically reconnect to the database')
+			.toBeNull();
+
+		// ========== WORKAROUND: Manual Restart Required ==========
+		// Since n8n doesn't auto-recover, we need to restart the container
+		// This mimics what the bug reporter had to do in production
+		console.log('Performing manual restart as workaround...');
+		const n8nContainer = chaos.findContainers('n8n-*')[0];
+		await n8nContainer.restart();
+
+		// Wait for n8n to fully start up after restart
+		const n8nRecoveryLog = await chaos.waitForLog('Editor is now accessible via', {
+			namePattern: 'n8n-*',
+			timeoutMs: 60000,
+		});
+
+		expect(n8nRecoveryLog, 'n8n should start successfully after manual restart').toBeDefined();
+		console.log('✓ n8n recovered after manual restart');
+
+		// ========== SUMMARY ==========
+		console.log('\n=== Test Summary ===');
+		console.log('Bug reproduced successfully:');
+		console.log('1. Health check incorrectly reports healthy during DB outage');
+		console.log('2. n8n does not automatically recover when DB connection is restored');
+		console.log('3. Manual restart is required to restore functionality');
+	},
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3208,6 +3208,9 @@ importers:
       '@n8n/api-types':
         specifier: workspace:^
         version: link:../../@n8n/api-types
+      '@n8n/constants':
+        specifier: workspace:^
+        version: link:../../@n8n/constants
       '@n8n/db':
         specifier: workspace:*
         version: link:../../@n8n/db
@@ -6548,19 +6551,15 @@ packages:
   '@otplib/preset-v11@12.0.1':
     resolution: {integrity: sha512-9hSetMI7ECqbFiKICrNa4w70deTUfArtwXykPUvSHWOdzOlfa9ajglu7mNCntlvxycTiOAXkQGwjQCzzDEMRMg==}
 
-  '@oxc-project/runtime@0.71.0':
-    resolution: {integrity: sha512-QwoF5WUXIGFQ+hSxWEib4U/aeLoiDN9JlP18MnBgx9LLPRDfn1iICtcow7Jgey6HLH4XFceWXQD5WBJ39dyJcw==}
-    engines: {node: '>=6.9.0'}
-
   '@oxc-project/runtime@0.92.0':
     resolution: {integrity: sha512-Z7x2dZOmznihvdvCvLKMl+nswtOSVxS2H2ocar+U9xx6iMfTp0VGIrX6a4xB1v80IwOPC7dT1LXIJrY70Xu3Jw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@oxc-project/types@0.71.0':
-    resolution: {integrity: sha512-5CwQ4MI+P4MQbjLWXgNurA+igGwu/opNetIE13LBs9+V93R64MLvDKOOLZIXSzEfovU3Zef3q3GjPnMTgJTn2w==}
-
   '@oxc-project/types@0.94.0':
     resolution: {integrity: sha512-+UgQT/4o59cZfH6Cp7G0hwmqEQ0wE+AdIwhikdwnhWI9Dp8CgSY081+Q3O67/wq3VJu8mgUEB93J9EHHn70fOw==}
+
+  '@oxc-project/types@0.96.0':
+    resolution: {integrity: sha512-r/xkmoXA0xEpU6UGtn18CNVjXH6erU3KCpCDbpLmbVxBFor1U9MqN5Z2uMmCHJuXjJzlnDR+hWY+yPoLo8oHDw==}
 
   '@paralleldrive/cuid2@2.2.2':
     resolution: {integrity: sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==}
@@ -6779,14 +6778,21 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@rolldown/binding-android-arm64@1.0.0-beta.47':
+    resolution: {integrity: sha512-vPP9/MZzESh9QtmvQYojXP/midjgkkc1E4AdnPPAzQXo668ncHJcVLKjJKzoBdsQmaIvNjrMdsCwES8vTQHRQw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
   '@rolldown/binding-darwin-arm64@1.0.0-beta.42':
     resolution: {integrity: sha512-abw/wtgJA8OCgaTlL+xJxnN/Z01BwV1rfzIp5Hh9x+IIO6xOBfPsQ0nzi0+rWx3TyZ9FZXyC7bbC+5NpQ9EaXQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-beta.9-commit.d91dfb5':
-    resolution: {integrity: sha512-Mp0/gqiPdepHjjVm7e0yL1acWvI0rJVVFQEADSezvAjon9sjQ7CEg9JnXICD4B1YrPmN9qV/e7cQZCp87tTV4w==}
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.47':
+    resolution: {integrity: sha512-Lc3nrkxeaDVCVl8qR3qoxh6ltDZfkQ98j5vwIr5ALPkgjZtDK4BGCrrBoLpGVMg+csWcaqUbwbKwH5yvVa0oOw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
@@ -6796,8 +6802,9 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-beta.9-commit.d91dfb5':
-    resolution: {integrity: sha512-40re4rMNrsi57oavRzIOpRGmg3QRlW6Ea8Q3znaqgOuJuKVrrm2bIQInTfkZJG7a4/5YMX7T951d0+toGLTdCA==}
+  '@rolldown/binding-darwin-x64@1.0.0-beta.47':
+    resolution: {integrity: sha512-eBYxQDwP0O33plqNVqOtUHqRiSYVneAknviM5XMawke3mwMuVlAsohtOqEjbCEl/Loi/FWdVeks5WkqAkzkYWQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
@@ -6807,8 +6814,9 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-beta.9-commit.d91dfb5':
-    resolution: {integrity: sha512-8BDM939bbMariZupiHp3OmP5N+LXPT4mULA0hZjDaq970PCxv4krZOSMG+HkWUUwmuQROtV+/00xw39EO0P+8g==}
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.47':
+    resolution: {integrity: sha512-Ns+kgp2+1Iq/44bY/Z30DETUSiHY7ZuqaOgD5bHVW++8vme9rdiWsN4yG4rRPXkdgzjvQ9TDHmZZKfY4/G11AA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
@@ -6818,8 +6826,9 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.9-commit.d91dfb5':
-    resolution: {integrity: sha512-sntsPaPgrECpBB/+2xrQzVUt0r493TMPI+4kWRMhvMsmrxOqH1Ep5lM0Wua/ZdbfZNwm1aVa5pcESQfNfM4Fhw==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.47':
+    resolution: {integrity: sha512-4PecgWCJhTA2EFOlptYJiNyVP2MrVP4cWdndpOu3WmXqWqZUmSubhb4YUAIxAxnXATlGjC1WjxNPhV7ZllNgdA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
@@ -6830,8 +6839,9 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.9-commit.d91dfb5':
-    resolution: {integrity: sha512-5clBW/I+er9F2uM1OFjJFWX86y7Lcy0M+NqsN4s3o07W+8467Zk8oQa4B45vdaXoNUF/yqIAgKkA/OEdQDxZqA==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.47':
+    resolution: {integrity: sha512-CyIunZ6D9U9Xg94roQI1INt/bLkOpPsZjZZkiaAZ0r6uccQdICmC99M9RUPlMLw/qg4yEWLlQhG73W/mG437NA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -6843,8 +6853,9 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.9-commit.d91dfb5':
-    resolution: {integrity: sha512-wv+rnAfQDk9p/CheX8/Kmqk2o1WaFa4xhWI9gOyDMk/ljvOX0u0ubeM8nI1Qfox7Tnh71eV5AjzSePXUhFOyOg==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.47':
+    resolution: {integrity: sha512-doozc/Goe7qRCSnzfJbFINTHsMktqmZQmweull6hsZZ9sjNWQ6BWQnbvOlfZJe4xE5NxM1NhPnY5Giqnl3ZrYQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
@@ -6856,8 +6867,9 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.9-commit.d91dfb5':
-    resolution: {integrity: sha512-gxD0/xhU4Py47IH3bKZbWtvB99tMkUPGPJFRfSc5UB9Osoje0l0j1PPbxpUtXIELurYCqwLBKXIMTQGifox1BQ==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.47':
+    resolution: {integrity: sha512-fodvSMf6Aqwa0wEUSTPewmmZOD44rc5Tpr5p9NkwQ6W1SSpUKzD3SwpJIgANDOhwiYhDuiIaYPGB7Ujkx1q0UQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -6869,8 +6881,9 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-beta.9-commit.d91dfb5':
-    resolution: {integrity: sha512-HotuVe3XUjDwqqEMbm3o3IRkP9gdm8raY/btd/6KE3JGLF/cv4+3ff1l6nOhAZI8wulWDPEXPtE7v+HQEaTXnA==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.47':
+    resolution: {integrity: sha512-Rxm5hYc0mGjwLh5sjlGmMygxAaV2gnsx7CNm2lsb47oyt5UQyPDZf3GP/ct8BEcwuikdqzsrrlIp8+kCSvMFNQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -6881,14 +6894,20 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@rolldown/binding-openharmony-arm64@1.0.0-beta.47':
+    resolution: {integrity: sha512-YakuVe+Gc87jjxazBL34hbr8RJpRuFBhun7NEqoChVDlH5FLhLXjAPHqZd990TVGVNkemourf817Z8u2fONS8w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@rolldown/binding-wasm32-wasi@1.0.0-beta.42':
     resolution: {integrity: sha512-2Ft32F7uiDTrGZUKws6CLNTlvTWHC33l4vpXrzUucf9rYtUThAdPCOt89Pmn13tNX6AulxjGEP2R0nZjTSW3eQ==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-beta.9-commit.d91dfb5':
-    resolution: {integrity: sha512-8Cx+ucbd8n2dIr21FqBh6rUvTVL0uTgEtKR7l+MUZ5BgY4dFh1e4mPVX8oqmoYwOxBiXrsD2JIOCz4AyKLKxWA==}
-    engines: {node: '>=14.21.3'}
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.47':
+    resolution: {integrity: sha512-ak2GvTFQz3UAOw8cuQq8pWE+TNygQB6O47rMhvevvTzETh7VkHRFtRUwJynX5hwzFvQMP6G0az5JrBGuwaMwYQ==}
+    engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.42':
@@ -6897,8 +6916,9 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.9-commit.d91dfb5':
-    resolution: {integrity: sha512-Vhq5vikrVDxAa75fxsyqj0c0Y/uti/TwshXI71Xb8IeUQJOBnmLUsn5dgYf5ljpYYkNa0z9BPAvUDIDMmyDi+w==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.47':
+    resolution: {integrity: sha512-o5BpmBnXU+Cj+9+ndMcdKjhZlPb79dVPBZnWwMnI4RlNSSq5yOvFZqvfPYbyacvnW03Na4n5XXQAPhu3RydZ0w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
@@ -6908,8 +6928,9 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.9-commit.d91dfb5':
-    resolution: {integrity: sha512-lN7RIg9Iugn08zP2aZN9y/MIdG8iOOCE93M1UrFlrxMTqPf8X+fDzmR/OKhTSd1A2pYNipZHjyTcb5H8kyQSow==}
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.47':
+    resolution: {integrity: sha512-FVOmfyYehNE92IfC9Kgs913UerDog2M1m+FADJypKz0gmRg3UyTt4o1cZMCAl7MiR89JpM9jegNO1nXuP1w1vw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
@@ -6919,16 +6940,17 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.9-commit.d91dfb5':
-    resolution: {integrity: sha512-7/7cLIn48Y+EpQ4CePvf8reFl63F15yPUlg4ZAhl+RXJIfydkdak1WD8Ir3AwAO+bJBXzrfNL+XQbxm0mcQZmw==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.47':
+    resolution: {integrity: sha512-by/70F13IUE101Bat0oeH8miwWX5mhMFPk1yjCdxoTNHTyTdLgb0THNaebRM6AP7Kz+O3O2qx87sruYuF5UxHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
   '@rolldown/pluginutils@1.0.0-beta.42':
     resolution: {integrity: sha512-N7pQzk9CyE7q0bBN/q0J8s6Db279r5kUZc6d7/wWRe9/zXqC52HQovVyu6iXPIDY4BEzzgbVLhVFXrOuGJ22ZQ==}
 
-  '@rolldown/pluginutils@1.0.0-beta.9-commit.d91dfb5':
-    resolution: {integrity: sha512-8sExkWRK+zVybw3+2/kBkYBFeLnEUWz1fT7BLHplpzmtqkOfTbAQ9gkt4pzwGIIZmg4Qn5US5ACjUBenrhezwQ==}
+  '@rolldown/pluginutils@1.0.0-beta.47':
+    resolution: {integrity: sha512-8QagwMH3kNCuzD8EWL8R2YPW5e4OrHNSAHRFDdmFqEwEaD/KcNKjVoumo+gP2vW5eKB2UPbM6vTYiGZX0ixLnw==}
 
   '@rollup/plugin-inject@5.0.5':
     resolution: {integrity: sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==}
@@ -15837,8 +15859,9 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rolldown@1.0.0-beta.9-commit.d91dfb5:
-    resolution: {integrity: sha512-FHkj6gGEiEgmAXQchglofvUUdwj2Oiw603Rs+zgFAnn9Cb7T7z3fiaEc0DbN3ja4wYkW6sF2rzMEtC1V4BGx/g==}
+  rolldown@1.0.0-beta.47:
+    resolution: {integrity: sha512-Mid74GckX1OeFAOYz9KuXeWYhq3xkXbMziYIC+ULVdUzPTG9y70OBSBQDQn9hQP8u/AfhuYw1R0BSg15nBI4Dg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
   rollup@4.49.0:
@@ -17593,8 +17616,8 @@ packages:
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
 
-  vue-component-type-helpers@3.1.2:
-    resolution: {integrity: sha512-ch3/SKBtxdZq18vsEntiGCdSszCRNfhX5QaTxjSacCAXLlNQRXfXo+ANjoQEYJMsJOJy1/vHF6Tkc4s85MS+zw==}
+  vue-component-type-helpers@3.1.3:
+    resolution: {integrity: sha512-V1dOD8XYfstOKCnXbWyEJIrhTBMwSyNjv271L1Jlx9ExpNlCSuqOs3OdWrGJ0V544zXufKbcYabi/o+gK8lyfQ==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -22498,13 +22521,11 @@ snapshots:
       '@otplib/plugin-crypto': 12.0.1
       '@otplib/plugin-thirty-two': 12.0.1
 
-  '@oxc-project/runtime@0.71.0': {}
-
   '@oxc-project/runtime@0.92.0': {}
 
-  '@oxc-project/types@0.71.0': {}
-
   '@oxc-project/types@0.94.0': {}
+
+  '@oxc-project/types@0.96.0': {}
 
   '@paralleldrive/cuid2@2.2.2':
     dependencies:
@@ -22717,55 +22738,61 @@ snapshots:
   '@rolldown/binding-android-arm64@1.0.0-beta.42':
     optional: true
 
+  '@rolldown/binding-android-arm64@1.0.0-beta.47':
+    optional: true
+
   '@rolldown/binding-darwin-arm64@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-beta.9-commit.d91dfb5':
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.47':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-beta.9-commit.d91dfb5':
+  '@rolldown/binding-darwin-x64@1.0.0-beta.47':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-beta.9-commit.d91dfb5':
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.47':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.9-commit.d91dfb5':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.47':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.9-commit.d91dfb5':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.47':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.9-commit.d91dfb5':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.47':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.9-commit.d91dfb5':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.47':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-beta.9-commit.d91dfb5':
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.47':
     optional: true
 
   '@rolldown/binding-openharmony-arm64@1.0.0-beta.42':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-beta.47':
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0-beta.42':
@@ -22773,32 +22800,32 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.0.7
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-beta.9-commit.d91dfb5':
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.47':
     dependencies:
-      '@napi-rs/wasm-runtime': 0.2.11
+      '@napi-rs/wasm-runtime': 1.0.7
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.9-commit.d91dfb5':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.47':
     optional: true
 
   '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.9-commit.d91dfb5':
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.47':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-beta.42':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.9-commit.d91dfb5':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.47':
     optional: true
 
   '@rolldown/pluginutils@1.0.0-beta.42': {}
 
-  '@rolldown/pluginutils@1.0.0-beta.9-commit.d91dfb5': {}
+  '@rolldown/pluginutils@1.0.0-beta.47': {}
 
   '@rollup/plugin-inject@5.0.5(rollup@4.52.4)':
     dependencies:
@@ -24004,7 +24031,7 @@ snapshots:
       storybook: 9.1.7(@testing-library/dom@10.4.0)(bufferutil@4.0.9)(prettier@3.6.2)(utf-8-validate@5.0.10)(vite@7.0.0(@types/node@20.19.21)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(terser@5.16.1)(tsx@4.19.3))
       type-fest: 2.19.0
       vue: 3.5.13(typescript@5.9.2)
-      vue-component-type-helpers: 3.1.2
+      vue-component-type-helpers: 3.1.3
 
   '@stylistic/eslint-plugin@5.0.0(eslint@9.29.0(jiti@2.6.1))':
     dependencies:
@@ -29326,7 +29353,7 @@ snapshots:
       '@types/debug': 4.1.12
       '@types/node': 20.19.21
       '@types/tough-cookie': 4.0.5
-      axios: 1.12.0(debug@4.3.6)
+      axios: 1.12.0(debug@4.4.3)
       camelcase: 6.3.0
       debug: 4.4.3
       dotenv: 16.6.1
@@ -29336,7 +29363,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.2
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.12.0(debug@4.4.1))
+      retry-axios: 2.6.0(axios@1.12.0)
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -33679,7 +33706,7 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
-  retry-axios@2.6.0(axios@1.12.0(debug@4.4.1)):
+  retry-axios@2.6.0(axios@1.12.0):
     dependencies:
       axios: 1.12.0(debug@4.4.1)
 
@@ -33742,7 +33769,7 @@ snapshots:
 
   rndm@1.2.0: {}
 
-  rolldown-plugin-dts@0.16.11(rolldown@1.0.0-beta.9-commit.d91dfb5)(typescript@5.9.2)(vue-tsc@2.2.8(patch_hash=e2aee939ccac8a57fe449bfd92bedd8117841579526217bc39aca26c6b8c317f)(typescript@5.9.2)):
+  rolldown-plugin-dts@0.16.11(rolldown@1.0.0-beta.47)(typescript@5.9.2)(vue-tsc@2.2.8(patch_hash=e2aee939ccac8a57fe449bfd92bedd8117841579526217bc39aca26c6b8c317f)(typescript@5.9.2)):
     dependencies:
       '@babel/generator': 7.28.3
       '@babel/parser': 7.28.4
@@ -33753,7 +33780,7 @@ snapshots:
       dts-resolver: 2.1.2
       get-tsconfig: 4.10.1
       magic-string: 0.30.19
-      rolldown: 1.0.0-beta.9-commit.d91dfb5
+      rolldown: 1.0.0-beta.47
     optionalDependencies:
       typescript: 5.9.2
       vue-tsc: 2.2.8(patch_hash=e2aee939ccac8a57fe449bfd92bedd8117841579526217bc39aca26c6b8c317f)(typescript@5.9.2)
@@ -33800,25 +33827,25 @@ snapshots:
       '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.42
       '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.42
 
-  rolldown@1.0.0-beta.9-commit.d91dfb5:
+  rolldown@1.0.0-beta.47:
     dependencies:
-      '@oxc-project/runtime': 0.71.0
-      '@oxc-project/types': 0.71.0
-      '@rolldown/pluginutils': 1.0.0-beta.9-commit.d91dfb5
-      ansis: 4.2.0
+      '@oxc-project/types': 0.96.0
+      '@rolldown/pluginutils': 1.0.0-beta.47
     optionalDependencies:
-      '@rolldown/binding-darwin-arm64': 1.0.0-beta.9-commit.d91dfb5
-      '@rolldown/binding-darwin-x64': 1.0.0-beta.9-commit.d91dfb5
-      '@rolldown/binding-freebsd-x64': 1.0.0-beta.9-commit.d91dfb5
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-beta.9-commit.d91dfb5
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-beta.9-commit.d91dfb5
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-beta.9-commit.d91dfb5
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.9-commit.d91dfb5
-      '@rolldown/binding-linux-x64-musl': 1.0.0-beta.9-commit.d91dfb5
-      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.9-commit.d91dfb5
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.9-commit.d91dfb5
-      '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.9-commit.d91dfb5
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.9-commit.d91dfb5
+      '@rolldown/binding-android-arm64': 1.0.0-beta.47
+      '@rolldown/binding-darwin-arm64': 1.0.0-beta.47
+      '@rolldown/binding-darwin-x64': 1.0.0-beta.47
+      '@rolldown/binding-freebsd-x64': 1.0.0-beta.47
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-beta.47
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-beta.47
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-beta.47
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.47
+      '@rolldown/binding-linux-x64-musl': 1.0.0-beta.47
+      '@rolldown/binding-openharmony-arm64': 1.0.0-beta.47
+      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.47
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.47
+      '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.47
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.47
 
   rollup@4.49.0:
     dependencies:
@@ -35342,8 +35369,8 @@ snapshots:
       diff: 8.0.2
       empathic: 2.0.0
       hookable: 5.5.3
-      rolldown: 1.0.0-beta.9-commit.d91dfb5
-      rolldown-plugin-dts: 0.16.11(rolldown@1.0.0-beta.9-commit.d91dfb5)(typescript@5.9.2)(vue-tsc@2.2.8(patch_hash=e2aee939ccac8a57fe449bfd92bedd8117841579526217bc39aca26c6b8c317f)(typescript@5.9.2))
+      rolldown: 1.0.0-beta.47
+      rolldown-plugin-dts: 0.16.11(rolldown@1.0.0-beta.47)(typescript@5.9.2)(vue-tsc@2.2.8(patch_hash=e2aee939ccac8a57fe449bfd92bedd8117841579526217bc39aca26c6b8c317f)(typescript@5.9.2))
       semver: 7.7.2
       tinyexec: 1.0.1
       tinyglobby: 0.2.15
@@ -36009,7 +36036,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.12: {}
 
-  vue-component-type-helpers@3.1.2: {}
+  vue-component-type-helpers@3.1.3: {}
 
   vue-demi@0.14.10(vue@3.5.13(typescript@5.9.2)):
     dependencies:


### PR DESCRIPTION
## Summary

This PR fixes an issue where n8n would not properly detect and recover from database connection timeouts. When the database becomes unreachable (e.g., network partition), n8n's health checks would hang indefinitely instead of reporting the issue.

**Why it hangs forever:**
When the database connection is interrupted, the pg connection pool returns stale connections that don't know they're broken (TCP doesn't detect network failures immediately). When TypeORM tries to query on these connections, the query hangs at the TCP layer waiting for a response that will never come. The promise never resolves or rejects - it just waits indefinitely.

**Changes:**
1. Added 5-second timeout to database ping queries using Promise.race to prevent indefinite hangs
2. Added automatic recovery detection and logging when database connection is restored
3. Updated health check to properly reflect database connection state in readiness probe
4. Added chaos test to verify timeout detection and automatic recovery

**Testing:**
The chaos test simulates a database network partition using iptables and verifies:
- Database connection timeout is detected within 5 seconds
- Liveness probe remains healthy (server is running)
- Readiness probe correctly reports unhealthy (database unavailable)
- Automatic recovery when database becomes reachable again

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1018

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [ ] Docs updated or follow-up ticket created
- [x] Tests included (chaos test added)
- [ ] PR Labeled with `release/backport` (if needed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a 5s timeout to DB ping with recovery/timeout logging, streamlines health checks, and introduces chaos tests and helpers to validate behavior.
> 
> - **DB connection (`packages/@n8n/db`)**:
>   - Add `Logger` to `DbConnection` and log on timeout (`warn`) and recovery (`info`).
>   - Implement 5s timeout for `ping()` via `Promise.race` with `timers/promises`, abortable via `AbortController`.
>   - Mark timeouts as `OperationalError`; keep scheduling next ping in `finally`.
>   - Update tests to inject `Logger`, assert scheduled pings, and adapt mocks.
> - **Server (`packages/cli/src/abstract-server.ts`)**:
>   - Make `setupHealthCheck` synchronous and call it without `await`.
>   - Make `onShutdown` synchronous.
> - **Testing**:
>   - Add chaos test `tests/chaos/postgres.spec.ts` to simulate DB network partition and verify timeout, readiness degradation, and recovery logs.
>   - Enable `NET_ADMIN` capability for Postgres test container to manipulate iptables.
>   - Extend container helpers: optional `throwOnTimeout` in `waitForLog`, return `null` on timeout.
>   - Add `api.isHealthy(probe)` helper for liveness/readiness checks.
>   - Minor test robustness updates in multi-main leader election.
>   - Add `@n8n/constants` dev dependency for Playwright tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef93307d4ea76e9b1b71959a8b0d762c1d9fe056. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->