### PR TITLE
fix(Embeddings AWS Bedrock Node, AWS Bedrock Chat Model Node): Fix HTTP proxy

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/LmChatAwsBedrock.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/LmChatAwsBedrock.node.ts
@@ -1,4 +1,9 @@
+import type { BedrockRuntimeClientConfig } from '@aws-sdk/client-bedrock-runtime';
+import { BedrockRuntimeClient } from '@aws-sdk/client-bedrock-runtime';
 import { ChatBedrockConverse } from '@langchain/aws';
+import { NodeHttpHandler } from '@smithy/node-http-handler';
+import { getNodeProxyAgent } from '@utils/httpProxyAgent';
+import { getConnectionHintNoticeField } from '@utils/sharedFields';
 import {
 	NodeConnectionTypes,
 	type INodeType,
@@ -6,9 +11,6 @@ import {
 	type ISupplyDataFunctions,
 	type SupplyData,
 } from 'n8n-workflow';
-
-import { getProxyAgent } from '@utils/httpProxyAgent';
-import { getConnectionHintNoticeField } from '@utils/sharedFields';
 
 import { makeN8nLlmFailedAttemptHandler } from '../n8nLlmFailedAttemptHandler';
 import { N8nLlmTracing } from '../N8nLlmTracing';
@@ -229,19 +231,34 @@ export class LmChatAwsBedrock implements INodeType {
 			maxTokensToSample: number;
 		};
 
-		const model = new ChatBedrockConverse({
+		// Create BedrockRuntimeClient with proxy support
+		// AWS SDK v3 requires requestHandler with NodeHttpHandler for proxy support
+		const proxyAgent = getNodeProxyAgent();
+		const clientConfig: BedrockRuntimeClientConfig = {
 			region: credentials.region as string,
-			model: modelName,
-			temperature: options.temperature,
-			maxTokens: options.maxTokensToSample,
-			clientConfig: {
-				httpAgent: getProxyAgent(),
-			},
 			credentials: {
 				secretAccessKey: credentials.secretAccessKey as string,
 				accessKeyId: credentials.accessKeyId as string,
-				sessionToken: credentials.sessionToken as string,
+				...(credentials.sessionToken && { sessionToken: credentials.sessionToken as string }),
 			},
+		};
+
+		if (proxyAgent) {
+			clientConfig.requestHandler = new NodeHttpHandler({
+				httpAgent: proxyAgent,
+				httpsAgent: proxyAgent,
+			});
+		}
+
+		// Pass the pre-configured client to avoid credential resolution proxy issues
+		const client = new BedrockRuntimeClient(clientConfig);
+
+		const model = new ChatBedrockConverse({
+			client,
+			model: modelName,
+			region: credentials.region as string,
+			temperature: options.temperature,
+			maxTokens: options.maxTokensToSample,
 			callbacks: [new N8nLlmTracing(this)],
 			onFailedAttempt: makeN8nLlmFailedAttemptHandler(this),
 		});

--- a/packages/@n8n/nodes-langchain/utils/httpProxyAgent.ts
+++ b/packages/@n8n/nodes-langchain/utils/httpProxyAgent.ts
@@ -3,14 +3,26 @@ import proxyFromEnv from 'proxy-from-env';
 import { ProxyAgent } from 'undici';
 
 /**
+ * Resolves the proxy URL from environment variables for a given target URL.
+ *
+ * @param targetUrl - The target URL to check proxy configuration for (optional)
+ * @returns The proxy URL string or undefined if no proxy is configured
+ *
+ * @remarks
+ * There are cases where we don't know the target URL in advance (e.g. when we need to provide a proxy agent to ChatAwsBedrock).
+ * In such case we use a dummy URL.
+ * This will lead to `NO_PROXY` environment variable not being respected, but it is better than not having a proxy agent at all.
+ */
+function getProxyUrlFromEnv(targetUrl?: string): string {
+	return proxyFromEnv.getProxyForUrl(targetUrl ?? 'https://example.nonexistent/');
+}
+
+/**
  * Returns a ProxyAgent or undefined based on the environment variables and target URL.
  * When target URL is not provided, NO_PROXY environment variable is not respected.
  */
 export function getProxyAgent(targetUrl?: string) {
-	// There are cases where we don't know the target URL in advance (e.g. when we need to provide a proxy agent to ChatAwsBedrock)
-	// In such case we use a dummy URL.
-	// This will lead to `NO_PROXY` environment variable not being respected, but it is better than not having a proxy agent at all.
-	const proxyUrl = proxyFromEnv.getProxyForUrl(targetUrl ?? 'https://example.nonexistent/');
+	const proxyUrl = getProxyUrlFromEnv(targetUrl);
 
 	if (!proxyUrl) {
 		return undefined;
@@ -27,12 +39,11 @@ export function getProxyAgent(targetUrl?: string) {
  * @returns HttpsProxyAgent instance or undefined if no proxy is configured
  */
 export function getNodeProxyAgent(targetUrl?: string) {
-	const proxyUrl = proxyFromEnv.getProxyForUrl(targetUrl ?? 'https://example.nonexistent/');
+	const proxyUrl = getProxyUrlFromEnv(targetUrl);
 
 	if (!proxyUrl) {
 		return undefined;
 	}
 
-	// AWS SDK v3 needs Node.js http.Agent/https.Agent, not undici ProxyAgent
 	return new HttpsProxyAgent(proxyUrl);
 }

--- a/packages/@n8n/nodes-langchain/utils/httpProxyAgent.ts
+++ b/packages/@n8n/nodes-langchain/utils/httpProxyAgent.ts
@@ -1,3 +1,4 @@
+import { HttpsProxyAgent } from 'https-proxy-agent';
 import proxyFromEnv from 'proxy-from-env';
 import { ProxyAgent } from 'undici';
 
@@ -16,4 +17,22 @@ export function getProxyAgent(targetUrl?: string) {
 	}
 
 	return new ProxyAgent(proxyUrl);
+}
+
+/**
+ * Returns a Node.js HTTP/HTTPS proxy agent for use with AWS SDK v3 clients.
+ * AWS SDK v3 requires Node.js http.Agent/https.Agent instances (not undici ProxyAgent).
+ *
+ * @param targetUrl - The target URL to check proxy configuration for
+ * @returns HttpsProxyAgent instance or undefined if no proxy is configured
+ */
+export function getNodeProxyAgent(targetUrl?: string) {
+	const proxyUrl = proxyFromEnv.getProxyForUrl(targetUrl ?? 'https://example.nonexistent/');
+
+	if (!proxyUrl) {
+		return undefined;
+	}
+
+	// AWS SDK v3 needs Node.js http.Agent/https.Agent, not undici ProxyAgent
+	return new HttpsProxyAgent(proxyUrl);
 }


### PR DESCRIPTION
## Summary

Fixes AWS Bedrock Chat Model and Embeddings nodes to properly use HTTP/HTTPS proxy configuration from environment variables during chat/invoke operations.

## Problem
AWS Bedrock nodes ignored `HTTP_PROXY`/`HTTPS_PROXY` environment variables for LLM inference requests, while credential testing and model listing worked correctly. This caused connection failures for customers behind corporate proxies.

## Solution
When passing `credentials` and `clientConfig` separately to LangChain's Bedrock classes, AWS SDK's credential resolution creates internal clients that bypass proxy settings. By creating `BedrockRuntimeClient` ourselves with credentials + proxy in one config object, we ensure proxy is applied before credential resolution.


### Changes:
1. **`httpProxyAgent.ts`**: Added `getNodeProxyAgent()` that returns `HttpsProxyAgent` (Node.js http.Agent) instead of undici's `ProxyAgent`, as required by AWS SDK v3
2. **`LmChatAwsBedrock.node.ts`**: Create `BedrockRuntimeClient` with proxy `requestHandler` (using `NodeHttpHandler` with both `httpAgent` and `httpsAgent`), then pass to `ChatBedrockConverse`
3. **`EmbeddingsAwsBedrock.node.ts`**: Same approach as Chat Model

<img width="474" height="612" alt="CleanShot 2025-11-03 at 21 58 47" src="https://github.com/user-attachments/assets/52424198-94f0-4fa8-b226-939b9ab902ea" />
<img width="472" height="255" alt="CleanShot 2025-11-03 at 21 58 28" src="https://github.com/user-attachments/assets/57f97e38-3fc9-4119-ad3c-5a850594f996" />

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
