### PR TITLE
fix(editor): Fix main button create variable disable state based on scopes

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -3062,7 +3062,7 @@
 	"variables.empty.button": "Add first variable",
 	"variables.empty.button.disabled.tooltip": "Your current role in the project does not allow you to create variables",
 	"variables.empty.notAllowedToCreate.heading": "{name}, start using variables",
-	"variables.empty.notAllowedToCreate.description": "Ask your n8n instance owner to create the variables you need. Once configured, you can utilize them in your workflows using the syntax $vars.MY_VAR.",
+	"variables.empty.notAllowedToCreate.description": "Ask project editors or instance admin to create the variables you need. Once configured, you can utilize them in your workflows using the syntax $vars.MY_VAR.",
 	"variables.filters.active": "Some variables may be hidden since filters are applied.",
 	"variables.filters.active.reset": "Remove filters",
 	"variables.noResults": "No variables found",

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectHeader.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectHeader.vue
@@ -77,7 +77,10 @@ const projectName = computed(() => {
 const projectPermissions = computed(
 	() => getResourcePermissions(projectsStore.currentProject?.scopes).project,
 );
-const globalPermissions = computed(
+const projectVariablePermissions = computed(
+	() => getResourcePermissions(projectsStore.currentProject?.scopes).projectVariable,
+);
+const globalVariablesPermissions = computed(
 	() => getResourcePermissions(usersStore.currentUser?.globalScopes).variable,
 );
 
@@ -164,7 +167,7 @@ const createVariableButton = computed(() => ({
 	size: 'mini' as const,
 	disabled:
 		sourceControlStore.preferences.branchReadOnly ||
-		(!projectPermissions.value.create && !globalPermissions.value.create),
+		(!projectVariablePermissions.value.create && !globalVariablesPermissions.value.create),
 }));
 
 const selectedMainButtonType = computed(() => props.mainButton ?? ACTION_TYPES.WORKFLOW);


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR fixes how we set the disabled state on the project header main button create variable, depending on scopes.
The button is enabled if:
- project scopes contain `projectVariable:create`
- global scopes contain `variable:create`

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-4072/non-adminowner-user-can-create-first-variable-in-a-project

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
