### PR TITLE
fix(Google Workspace Admin Node): Include `changePasswordAtNextLogin`, `password` in update

### DIFF
--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/GSuiteAdmin.node.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/GSuiteAdmin.node.ts
@@ -452,6 +452,10 @@ export class GSuiteAdmin implements INodeType {
 						const password = this.getNodeParameter('password', i) as string;
 						const username = this.getNodeParameter('username', i) as string;
 						const additionalFields = this.getNodeParameter('additionalFields', i);
+						const changePasswordAtNextLogin = this.getNodeParameter(
+							'changePasswordAtNextLogin',
+							i,
+						) as boolean | undefined;
 
 						const body: IDataObject = {
 							name: {
@@ -467,6 +471,10 @@ export class GSuiteAdmin implements INodeType {
 								itemIndex: i,
 								description: "Please fill in the 'Username' parameter to create the user",
 							});
+						}
+
+						if (changePasswordAtNextLogin !== undefined) {
+							body.changePasswordAtNextLogin = changePasswordAtNextLogin;
 						}
 
 						if (additionalFields.phoneUi) {
@@ -721,7 +729,17 @@ export class GSuiteAdmin implements INodeType {
 							suspended?: boolean;
 							roles?: { [key: string]: boolean };
 							customSchemas?: IDataObject;
+							password?: string;
+							changePasswordAtNextLogin?: boolean;
 						} = {};
+
+						if (updateFields.password) {
+							body.password = updateFields.password as string;
+						}
+
+						if (updateFields.changePasswordAtNextLogin !== undefined) {
+							body.changePasswordAtNextLogin = updateFields.changePasswordAtNextLogin as boolean;
+						}
 
 						if (updateFields.firstName) {
 							body.name ??= {};

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/GSuiteAdmin.node.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/GSuiteAdmin.node.ts
@@ -452,10 +452,6 @@ export class GSuiteAdmin implements INodeType {
 						const password = this.getNodeParameter('password', i) as string;
 						const username = this.getNodeParameter('username', i) as string;
 						const additionalFields = this.getNodeParameter('additionalFields', i);
-						const changePasswordAtNextLogin = this.getNodeParameter(
-							'changePasswordAtNextLogin',
-							i,
-						) as boolean | undefined;
 
 						const body: IDataObject = {
 							name: {
@@ -473,8 +469,9 @@ export class GSuiteAdmin implements INodeType {
 							});
 						}
 
-						if (changePasswordAtNextLogin !== undefined) {
-							body.changePasswordAtNextLogin = changePasswordAtNextLogin;
+						if (additionalFields.changePasswordAtNextLogin !== undefined) {
+							body.changePasswordAtNextLogin =
+								additionalFields.changePasswordAtNextLogin as boolean;
 						}
 
 						if (additionalFields.phoneUi) {

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/test/GSuiteAdmin.node.test.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/test/GSuiteAdmin.node.test.ts
@@ -320,6 +320,173 @@ describe('GSuiteAdmin Node - logic coverage', () => {
 	});
 });
 
+describe('GSuiteAdmin Node - user:create logic', () => {
+	it('should include changePasswordAtNextLogin when set to true in create operation', async () => {
+		const mockCall = jest
+			.fn()
+			.mockResolvedValue({ id: 'user-123', primaryEmail: 'test@example.com' });
+		(googleApiRequest as jest.Mock).mockImplementation(mockCall);
+
+		const mockContext = {
+			getNode: () => ({ name: 'GSuiteAdmin' }),
+			getNodeParameter: jest.fn((paramName: string, _index?: number) => {
+				switch (paramName) {
+					case 'resource':
+						return 'user';
+					case 'operation':
+						return 'create';
+					case 'domain':
+						return 'example.com';
+					case 'firstName':
+						return 'John';
+					case 'lastName':
+						return 'Doe';
+					case 'password':
+						return 'SecurePassword123!';
+					case 'username':
+						return 'johndoe';
+					case 'changePasswordAtNextLogin':
+						return true;
+					case 'additionalFields':
+						return {};
+					default:
+						return undefined;
+				}
+			}),
+			helpers: {
+				returnJsonArray: (data: any) => [data],
+				constructExecutionMetaData: (data: any) => data,
+			},
+			continueOnFail: () => false,
+			getInputData: () => [{ json: {} }],
+		} as unknown as IExecuteFunctions;
+
+		await new GSuiteAdmin().execute.call(mockContext);
+
+		expect(mockCall).toHaveBeenCalledWith(
+			'POST',
+			'/directory/v1/users',
+			expect.objectContaining({
+				changePasswordAtNextLogin: true,
+				password: 'SecurePassword123!',
+				primaryEmail: 'johndoe@example.com',
+				name: {
+					givenName: 'John',
+					familyName: 'Doe',
+				},
+			}),
+			{},
+		);
+	});
+
+	it('should include changePasswordAtNextLogin when set to false in create operation', async () => {
+		const mockCall = jest
+			.fn()
+			.mockResolvedValue({ id: 'user-124', primaryEmail: 'test2@example.com' });
+		(googleApiRequest as jest.Mock).mockImplementation(mockCall);
+
+		const mockContext = {
+			getNode: () => ({ name: 'GSuiteAdmin' }),
+			getNodeParameter: jest.fn((paramName: string, _index?: number) => {
+				switch (paramName) {
+					case 'resource':
+						return 'user';
+					case 'operation':
+						return 'create';
+					case 'domain':
+						return 'example.com';
+					case 'firstName':
+						return 'Jane';
+					case 'lastName':
+						return 'Smith';
+					case 'password':
+						return 'AnotherPassword456!';
+					case 'username':
+						return 'janesmith';
+					case 'changePasswordAtNextLogin':
+						return false;
+					case 'additionalFields':
+						return {};
+					default:
+						return undefined;
+				}
+			}),
+			helpers: {
+				returnJsonArray: (data: any) => [data],
+				constructExecutionMetaData: (data: any) => data,
+			},
+			continueOnFail: () => false,
+			getInputData: () => [{ json: {} }],
+		} as unknown as IExecuteFunctions;
+
+		await new GSuiteAdmin().execute.call(mockContext);
+
+		expect(mockCall).toHaveBeenCalledWith(
+			'POST',
+			'/directory/v1/users',
+			expect.objectContaining({
+				changePasswordAtNextLogin: false,
+				password: 'AnotherPassword456!',
+			}),
+			{},
+		);
+	});
+
+	it('should not include changePasswordAtNextLogin when undefined in create operation', async () => {
+		const mockCall = jest
+			.fn()
+			.mockResolvedValue({ id: 'user-125', primaryEmail: 'test3@example.com' });
+		(googleApiRequest as jest.Mock).mockImplementation(mockCall);
+
+		const mockContext = {
+			getNode: () => ({ name: 'GSuiteAdmin' }),
+			getNodeParameter: jest.fn((paramName: string, _index?: number) => {
+				switch (paramName) {
+					case 'resource':
+						return 'user';
+					case 'operation':
+						return 'create';
+					case 'domain':
+						return 'example.com';
+					case 'firstName':
+						return 'Bob';
+					case 'lastName':
+						return 'Johnson';
+					case 'password':
+						return 'Password789!';
+					case 'username':
+						return 'bjohnson';
+					case 'changePasswordAtNextLogin':
+						return undefined;
+					case 'additionalFields':
+						return {};
+					default:
+						return undefined;
+				}
+			}),
+			helpers: {
+				returnJsonArray: (data: any) => [data],
+				constructExecutionMetaData: (data: any) => data,
+			},
+			continueOnFail: () => false,
+			getInputData: () => [{ json: {} }],
+		} as unknown as IExecuteFunctions;
+
+		await new GSuiteAdmin().execute.call(mockContext);
+
+		expect(mockCall).toHaveBeenCalledWith(
+			'POST',
+			'/directory/v1/users',
+			{
+				name: { familyName: 'Johnson', givenName: 'Bob' },
+				password: 'Password789!',
+				primaryEmail: 'bjohnson@example.com',
+			},
+			{},
+		);
+	});
+});
+
 describe('GSuiteAdmin Node - user:update logic', () => {
 	it('should build suspended, roles, and customSchemas', async () => {
 		const mockCall = jest.fn().mockResolvedValue([{ success: true }]);
@@ -386,6 +553,94 @@ describe('GSuiteAdmin Node - user:update logic', () => {
 				fieldX: 'valueX',
 			},
 		});
+	});
+
+	it('should include password and changePasswordAtNextLogin in update operation', async () => {
+		const mockCall = jest.fn().mockResolvedValue({ id: 'user-id-456', success: true });
+		(googleApiRequest as jest.Mock).mockImplementation(mockCall);
+
+		const mockContext = {
+			getNode: () => ({ name: 'GSuiteAdmin' }),
+			getNodeParameter: jest.fn((paramName: string, _index?: number) => {
+				switch (paramName) {
+					case 'resource':
+						return 'user';
+					case 'operation':
+						return 'update';
+					case 'userId':
+						return 'user-id-456';
+					case 'updateFields':
+						return {
+							password: 'NewSecurePassword123!',
+							changePasswordAtNextLogin: true,
+						};
+					default:
+						return undefined;
+				}
+			}),
+			helpers: {
+				returnJsonArray: (data: any) => [data],
+				constructExecutionMetaData: (data: any) => data,
+			},
+			continueOnFail: () => false,
+			getInputData: () => [{ json: {} }],
+		} as unknown as IExecuteFunctions;
+
+		await new GSuiteAdmin().execute.call(mockContext);
+
+		expect(mockCall).toHaveBeenCalledWith(
+			'PUT',
+			'/directory/v1/users/user-id-456',
+			expect.objectContaining({
+				password: 'NewSecurePassword123!',
+				changePasswordAtNextLogin: true,
+			}),
+			{},
+		);
+	});
+
+	it('should include changePasswordAtNextLogin set to false in update operation', async () => {
+		const mockCall = jest.fn().mockResolvedValue({ id: 'user-id-999', success: true });
+		(googleApiRequest as jest.Mock).mockImplementation(mockCall);
+
+		const mockContext = {
+			getNode: () => ({ name: 'GSuiteAdmin' }),
+			getNodeParameter: jest.fn((paramName: string) => {
+				switch (paramName) {
+					case 'resource':
+						return 'user';
+					case 'operation':
+						return 'update';
+					case 'userId':
+						return 'user-id-999';
+					case 'updateFields':
+						return {
+							changePasswordAtNextLogin: false,
+							password: 'TestPassword!',
+						};
+					default:
+						return undefined;
+				}
+			}),
+			helpers: {
+				returnJsonArray: (data: any) => [data],
+				constructExecutionMetaData: (data: any) => data,
+			},
+			continueOnFail: () => false,
+			getInputData: () => [{ json: {} }],
+		} as unknown as IExecuteFunctions;
+
+		await new GSuiteAdmin().execute.call(mockContext);
+
+		expect(mockCall).toHaveBeenCalledWith(
+			'PUT',
+			'/directory/v1/users/user-id-999',
+			expect.objectContaining({
+				password: 'TestPassword!',
+				changePasswordAtNextLogin: false,
+			}),
+			{},
+		);
 	});
 
 	it('should throw error for invalid custom fields', async () => {

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/test/GSuiteAdmin.node.test.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/test/GSuiteAdmin.node.test.ts
@@ -345,10 +345,10 @@ describe('GSuiteAdmin Node - user:create logic', () => {
 						return 'SecurePassword123!';
 					case 'username':
 						return 'johndoe';
-					case 'changePasswordAtNextLogin':
-						return true;
 					case 'additionalFields':
-						return {};
+						return {
+							changePasswordAtNextLogin: true,
+						};
 					default:
 						return undefined;
 				}
@@ -403,10 +403,10 @@ describe('GSuiteAdmin Node - user:create logic', () => {
 						return 'AnotherPassword456!';
 					case 'username':
 						return 'janesmith';
-					case 'changePasswordAtNextLogin':
-						return false;
 					case 'additionalFields':
-						return {};
+						return {
+							changePasswordAtNextLogin: false,
+						};
 					default:
 						return undefined;
 				}
@@ -456,8 +456,6 @@ describe('GSuiteAdmin Node - user:create logic', () => {
 						return 'Password789!';
 					case 'username':
 						return 'bjohnson';
-					case 'changePasswordAtNextLogin':
-						return undefined;
 					case 'additionalFields':
 						return {};
 					default:


### PR DESCRIPTION
## Summary

This PR updates Google Workspace Admin Node to include `changePasswordAtNextLogin` in update/insert operations, and `password` in update operation

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-3284/community-issue-google-workspace-admin-not-reseting-password

closes #16242 
## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
