### PR TITLE
feat: Add support for mysql / mariadb

### DIFF
--- a/packages/cli/src/services/__tests__/import.service.test.ts
+++ b/packages/cli/src/services/__tests__/import.service.test.ts
@@ -673,18 +673,6 @@ describe('ImportService', () => {
 			);
 		});
 
-		it('should throw error when migration IDs do not match', async () => {
-			const migrationsContent = '{"id":"001","timestamp":"1000","name":"TestMigration"}';
-			const dbMigrations = [{ id: '002', timestamp: '1000', name: 'TestMigration' }];
-
-			jest.mocked(readFile).mockResolvedValue(migrationsContent);
-			jest.mocked(mockDataSource.query).mockResolvedValue(dbMigrations);
-
-			await expect(importService.validateMigrations('/test/input')).rejects.toThrow(
-				'Migration ID mismatch. Import data: TestMigration (id: 001) does not match target database TestMigration (id: 002). Cannot import data from different migration states.',
-			);
-		});
-
 		it('should pass validation when migrations match exactly', async () => {
 			const migrationsContent = '{"id":"1","timestamp":"1000","name":"TestMigration"}';
 			const dbMigrations = [{ id: '1', timestamp: '1000', name: 'TestMigration' }];

--- a/packages/cli/src/services/__tests__/import.service.test.ts
+++ b/packages/cli/src/services/__tests__/import.service.test.ts
@@ -695,18 +695,6 @@ describe('ImportService', () => {
 			await expect(importService.validateMigrations('/test/input')).resolves.not.toThrow();
 		});
 
-		it('should throw error when migration IDs have different formats', async () => {
-			const migrationsContent = '{"id":"001","timestamp":"1000","name":"TestMigration"}';
-			const dbMigrations = [{ id: '1', timestamp: '1000', name: 'TestMigration' }];
-
-			jest.mocked(readFile).mockResolvedValue(migrationsContent);
-			jest.mocked(mockDataSource.query).mockResolvedValue(dbMigrations);
-
-			await expect(importService.validateMigrations('/test/input')).rejects.toThrow(
-				'Migration ID mismatch. Import data: TestMigration (id: 001) does not match target database TestMigration (id: 1). Cannot import data from different migration states.',
-			);
-		});
-
 		it('should handle multiple migrations and find the latest one', async () => {
 			const migrationsContent = '{"id":"2","timestamp":"2000","name":"LatestMigration"}';
 			const dbMigrations = [

--- a/packages/cli/src/services/import.service.ts
+++ b/packages/cli/src/services/import.service.ts
@@ -551,8 +551,6 @@ export class ImportService {
 		const dbTimestamp = parseInt(String(latestDbMigration.timestamp || '0'));
 		const importName = latestImportMigration.name;
 		const dbName = latestDbMigration.name;
-		const importId = latestImportMigration.id;
-		const dbId = latestDbMigration.id;
 
 		// Check timestamp match
 		if (importTimestamp !== dbTimestamp) {

--- a/packages/cli/src/services/import.service.ts
+++ b/packages/cli/src/services/import.service.ts
@@ -568,13 +568,6 @@ export class ImportService {
 			);
 		}
 
-		// Check ID match (if both have IDs)
-		if (importId && dbId && importId !== dbId) {
-			throw new Error(
-				`Migration ID mismatch. Import data: ${String(importName)} (id: ${String(importId)}) does not match target database ${String(dbName)} (id: ${String(dbId)}). Cannot import data from different migration states.`,
-			);
-		}
-
 		this.logger.info(
 			'✅ Migration validation passed - import data matches target database migration state',
 		);

--- a/packages/cli/src/utils/__tests__/validate-database-type.test.ts
+++ b/packages/cli/src/utils/__tests__/validate-database-type.test.ts
@@ -1,14 +1,20 @@
-import { validateDbTypeForExportEntities } from '../validate-database-type';
+import { supportedTypes, validateDbTypeForExportEntities } from '../validate-database-type';
 
 describe('validateDbTypeForExportEntities', () => {
 	it('should throw an error if the database type is not supported', () => {
 		expect(() => validateDbTypeForExportEntities('invalid')).toThrow(
-			'Unsupported database type: invalid. Supported types: sqlite, postgres',
+			'Unsupported database type: invalid. Supported types: ' + supportedTypes.join(', '),
 		);
 	});
 
 	it('should not throw an error if the database type is supported', () => {
 		expect(() => validateDbTypeForExportEntities('sqlite')).not.toThrow();
 		expect(() => validateDbTypeForExportEntities('postgres')).not.toThrow();
+		expect(() => validateDbTypeForExportEntities('mysql')).not.toThrow();
+		expect(() => validateDbTypeForExportEntities('mariadb')).not.toThrow();
+		expect(() => validateDbTypeForExportEntities('mysqldb')).not.toThrow();
+		expect(() => validateDbTypeForExportEntities('sqlite-pooled')).not.toThrow();
+		expect(() => validateDbTypeForExportEntities('sqlite-memory')).not.toThrow();
+		expect(() => validateDbTypeForExportEntities('postgresql')).not.toThrow();
 	});
 });

--- a/packages/cli/src/utils/__tests__/validate-database-type.test.ts
+++ b/packages/cli/src/utils/__tests__/validate-database-type.test.ts
@@ -1,9 +1,14 @@
-import { supportedTypes, validateDbTypeForExportEntities } from '../validate-database-type';
+import {
+	supportedTypesForExport,
+	supportedTypesForImport,
+	validateDbTypeForExportEntities,
+	validateDbTypeForImportEntities,
+} from '../validate-database-type';
 
 describe('validateDbTypeForExportEntities', () => {
 	it('should throw an error if the database type is not supported', () => {
 		expect(() => validateDbTypeForExportEntities('invalid')).toThrow(
-			'Unsupported database type: invalid. Supported types: ' + supportedTypes.join(', '),
+			'Unsupported database type: invalid. Supported types: ' + supportedTypesForExport.join(', '),
 		);
 	});
 
@@ -16,5 +21,27 @@ describe('validateDbTypeForExportEntities', () => {
 		expect(() => validateDbTypeForExportEntities('sqlite-pooled')).not.toThrow();
 		expect(() => validateDbTypeForExportEntities('sqlite-memory')).not.toThrow();
 		expect(() => validateDbTypeForExportEntities('postgresql')).not.toThrow();
+	});
+});
+
+describe('validateDbTypeForImportEntities', () => {
+	it('should throw an error if the database type is not supported', () => {
+		expect(() => validateDbTypeForImportEntities('invalid')).toThrow(
+			'Unsupported database type: invalid. Supported types: ' + supportedTypesForImport.join(', '),
+		);
+	});
+
+	it('should throw an error for MySQL/MariaDB (not supported for imports)', () => {
+		expect(() => validateDbTypeForImportEntities('mysql')).toThrow();
+		expect(() => validateDbTypeForImportEntities('mariadb')).toThrow();
+		expect(() => validateDbTypeForImportEntities('mysqldb')).toThrow();
+	});
+
+	it('should not throw an error if the database type is supported', () => {
+		expect(() => validateDbTypeForImportEntities('sqlite')).not.toThrow();
+		expect(() => validateDbTypeForImportEntities('postgres')).not.toThrow();
+		expect(() => validateDbTypeForImportEntities('sqlite-pooled')).not.toThrow();
+		expect(() => validateDbTypeForImportEntities('sqlite-memory')).not.toThrow();
+		expect(() => validateDbTypeForImportEntities('postgresql')).not.toThrow();
 	});
 });

--- a/packages/cli/src/utils/validate-database-type.ts
+++ b/packages/cli/src/utils/validate-database-type.ts
@@ -1,10 +1,19 @@
+export const supportedTypes = [
+	'sqlite',
+	'sqlite-pooled',
+	'sqlite-memory',
+	'postgres',
+	'postgresql',
+	'mysql',
+	'mariadb',
+	'mysqldb',
+];
+
 export function validateDbTypeForExportEntities(dbType: string) {
-	if (
-		!['sqlite', 'sqlite-pooled', 'sqlite-memory', 'postgres', 'postgresql'].includes(
-			dbType.toLowerCase(),
-		)
-	) {
-		throw new Error(`Unsupported database type: ${dbType}. Supported types: sqlite, postgres`);
+	if (!supportedTypes.includes(dbType.toLowerCase())) {
+		throw new Error(
+			`Unsupported database type: ${dbType}. Supported types: ${supportedTypes.join(', ')}`,
+		);
 	}
 }
 

--- a/packages/cli/src/utils/validate-database-type.ts
+++ b/packages/cli/src/utils/validate-database-type.ts
@@ -1,4 +1,4 @@
-export const supportedTypes = [
+export const supportedTypesForExport = [
 	'sqlite',
 	'sqlite-pooled',
 	'sqlite-memory',
@@ -9,12 +9,26 @@ export const supportedTypes = [
 	'mysqldb',
 ];
 
+export const supportedTypesForImport = [
+	'sqlite',
+	'sqlite-pooled',
+	'sqlite-memory',
+	'postgres',
+	'postgresql',
+];
+
 export function validateDbTypeForExportEntities(dbType: string) {
-	if (!supportedTypes.includes(dbType.toLowerCase())) {
+	if (!supportedTypesForExport.includes(dbType.toLowerCase())) {
 		throw new Error(
-			`Unsupported database type: ${dbType}. Supported types: ${supportedTypes.join(', ')}`,
+			`Unsupported database type: ${dbType}. Supported types: ${supportedTypesForExport.join(', ')}`,
 		);
 	}
 }
 
-export const validateDbTypeForImportEntities = validateDbTypeForExportEntities;
+export function validateDbTypeForImportEntities(dbType: string) {
+	if (!supportedTypesForImport.includes(dbType.toLowerCase())) {
+		throw new Error(
+			`Unsupported database type: ${dbType}. Supported types: ${supportedTypesForImport.join(', ')}`,
+		);
+	}
+}


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR adds support for mariadb and mysql entity exports, we do not currently support importing in to those db types.

## Related Linear tickets, Github issues, and Community forum posts

closes: PAY-3970
closes: PAY-3969

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
