### PR TITLE
fix(editor): Log view doesn't scroll in manual execution

### DIFF
--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogsOverviewPanel.vue
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogsOverviewPanel.vue
@@ -142,6 +142,7 @@ function handleSwitchView(value: 'overview' | 'details') {
 					:latest-node-info="latestNodeInfo"
 					:flat-log-entries="flatLogEntries"
 					:can-open-ndv="true"
+					:execution="execution"
 					@toggle-expanded="emit('toggleExpanded', $event)"
 					@open-ndv="emit('openNdv', $event)"
 					@select="emit('select', $event)"


### PR DESCRIPTION
## Summary

Refactoring in #20261 broke auto scrolling of the log view.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1708/bug-logs-panel-doesnt-scroll-on-execution


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
