### PR TITLE
fix(core): Insights use time aware range when end date is today, and start of day for past ranges

### DIFF
--- a/packages/cli/src/modules/insights/__tests__/insights.controller.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.controller.test.ts
@@ -28,7 +28,7 @@ afterAll(async () => {
 describe('InsightsController', () => {
 	const insightsByPeriodRepository = mockInstance(InsightsByPeriodRepository);
 	let controller: InsightsController;
-	const sixDaysAgo = DateTime.now().minus({ days: 6 }).toJSDate();
+	const sevenDaysAgo = DateTime.now().minus({ days: 7 }).toJSDate();
 	const today = DateTime.now().toJSDate();
 	const licenseState = mock<LicenseState>();
 
@@ -62,7 +62,7 @@ describe('InsightsController', () => {
 
 			const callArgs =
 				insightsByPeriodRepository.getPreviousAndCurrentPeriodTypeAggregates.mock.calls[0][0];
-			expectDatesClose(callArgs.startDate, sixDaysAgo);
+			expectDatesClose(callArgs.startDate, sevenDaysAgo);
 			expectDatesClose(callArgs.endDate, today);
 
 			expect(response).toEqual({
@@ -102,7 +102,7 @@ describe('InsightsController', () => {
 
 			const callArgs =
 				insightsByPeriodRepository.getPreviousAndCurrentPeriodTypeAggregates.mock.calls[0][0];
-			expectDatesClose(callArgs.startDate, sixDaysAgo);
+			expectDatesClose(callArgs.startDate, sevenDaysAgo);
 			expectDatesClose(callArgs.endDate, today);
 
 			expect(response).toEqual({
@@ -146,7 +146,7 @@ describe('InsightsController', () => {
 
 			const callArgs =
 				insightsByPeriodRepository.getPreviousAndCurrentPeriodTypeAggregates.mock.calls[0][0];
-			expectDatesClose(callArgs.startDate, sixDaysAgo);
+			expectDatesClose(callArgs.startDate, sevenDaysAgo);
 			expectDatesClose(callArgs.endDate, today);
 
 			expect(response).toEqual({
@@ -399,7 +399,7 @@ describe('InsightsController', () => {
 			});
 
 			const callArgs = insightsByPeriodRepository.getInsightsByWorkflow.mock.calls[0][0];
-			expectDatesClose(callArgs.startDate, sixDaysAgo);
+			expectDatesClose(callArgs.startDate, sevenDaysAgo);
 			expectDatesClose(callArgs.endDate, today);
 
 			expect(response).toEqual({ count: 0, data: [] });
@@ -433,7 +433,7 @@ describe('InsightsController', () => {
 			});
 
 			const callArgs = insightsByPeriodRepository.getInsightsByWorkflow.mock.calls[0][0];
-			expectDatesClose(callArgs.startDate, sixDaysAgo);
+			expectDatesClose(callArgs.startDate, sevenDaysAgo);
 			expectDatesClose(callArgs.endDate, today);
 
 			expect(response).toEqual({ count: 3, data: mockRows });
@@ -671,7 +671,7 @@ describe('InsightsController', () => {
 			});
 
 			const callArgs = insightsByPeriodRepository.getInsightsByTime.mock.calls[0][0];
-			expectDatesClose(callArgs.startDate, sixDaysAgo);
+			expectDatesClose(callArgs.startDate, sevenDaysAgo);
 			expectDatesClose(callArgs.endDate, today);
 
 			expect(response).toEqual([]);
@@ -694,7 +694,7 @@ describe('InsightsController', () => {
 			});
 
 			const callArgs = insightsByPeriodRepository.getInsightsByTime.mock.calls[0][0];
-			expectDatesClose(callArgs.startDate, sixDaysAgo);
+			expectDatesClose(callArgs.startDate, sevenDaysAgo);
 			expectDatesClose(callArgs.endDate, today);
 
 			expect(response).toEqual(expectedResponse);
@@ -740,7 +740,7 @@ describe('InsightsController', () => {
 				});
 
 				const callArgs = insightsByPeriodRepository.getInsightsByTime.mock.calls[0][0];
-				expectDatesClose(callArgs.startDate, sixDaysAgo);
+				expectDatesClose(callArgs.startDate, sevenDaysAgo);
 				expectDatesClose(callArgs.endDate, today);
 
 				expect(response).toEqual(expectedResponse);
@@ -887,7 +887,7 @@ describe('InsightsController', () => {
 			});
 
 			const callArgs = insightsByPeriodRepository.getInsightsByTime.mock.calls[0][0];
-			expectDatesClose(callArgs.startDate, sixDaysAgo);
+			expectDatesClose(callArgs.startDate, sevenDaysAgo);
 			expectDatesClose(callArgs.endDate, today);
 
 			expect(response).toEqual(expectedResponse);
@@ -912,7 +912,7 @@ describe('InsightsController', () => {
 				});
 
 				const callArgs = insightsByPeriodRepository.getInsightsByTime.mock.calls[0][0];
-				expectDatesClose(callArgs.startDate, sixDaysAgo);
+				expectDatesClose(callArgs.startDate, sevenDaysAgo);
 				expectDatesClose(callArgs.endDate, today);
 
 				expect(response).toEqual(expectedResponse);

--- a/packages/cli/src/modules/insights/__tests__/insights.service.integration.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.integration.test.ts
@@ -375,7 +375,7 @@ describe('InsightsService (Integration)', () => {
 					type: 'success',
 					value: 1,
 					periodUnit: 'hour',
-					periodStart: now.minus({ days: 1 }),
+					periodStart: now.minus({ days: 2 }),
 				});
 
 				// Out of date range insight (should not be included)
@@ -553,7 +553,7 @@ describe('InsightsService (Integration)', () => {
 					type: 'success',
 					value: 1,
 					periodUnit: 'hour',
-					periodStart: now.minus({ days: 14 }).startOf('day'),
+					periodStart: now.minus({ days: 14 }).endOf('day'),
 				});
 
 				// Out of date range insight (should not be included)
@@ -714,7 +714,7 @@ describe('InsightsService (Integration)', () => {
 					type: workflow === workflow1 ? 'success' : 'failure',
 					value: 1,
 					periodUnit: 'hour',
-					periodStart: now.minus({ days: 14 }).startOf('day'),
+					periodStart: now.minus({ days: 14 }).endOf('day'),
 				});
 
 				// Out of date range insight (should not be included)
@@ -872,7 +872,7 @@ describe('InsightsService (Integration)', () => {
 					type: workflow === workflow1 ? 'success' : 'failure',
 					value: 1,
 					periodUnit: 'hour',
-					periodStart: now.minus({ days: 14 }).startOf('day'),
+					periodStart: now.minus({ days: 14 }).endOf('day'),
 				});
 
 				// Out of date range insight (should not be included)

--- a/packages/cli/src/modules/insights/database/repositories/__tests__/insights-by-period-query.helper.test.ts
+++ b/packages/cli/src/modules/insights/database/repositories/__tests__/insights-by-period-query.helper.test.ts
@@ -12,18 +12,40 @@ function expectLastXDaysDateRangeQuery(params: {
 	const { result, dbType, prevStartDateOffset: prev, startDateOffset: start } = params;
 
 	if (dbType === 'sqlite') {
-		expect(result).toContain(`datetime('now', '-${prev} days', 'start of day') AS prev_start_date`);
-		expect(result).toContain(`datetime('now', '-${start} days', 'start of day') AS start_date`);
+		if (prev === 0) {
+			expect(result).toContain("datetime('now') AS prev_start_date");
+		} else {
+			expect(result).toContain(`datetime('now', '-${prev} days') AS prev_start_date`);
+		}
+		if (start === 0) {
+			expect(result).toContain("datetime('now') AS start_date");
+		} else {
+			expect(result).toContain(`datetime('now', '-${start} days') AS start_date`);
+		}
 		expect(result).toContain("datetime('now') AS end_date");
 	} else if (dbType === 'postgresdb') {
-		expect(result).toContain(
-			`DATE_TRUNC('day', NOW() - INTERVAL '${prev} days') AS prev_start_date`,
-		);
-		expect(result).toContain(`DATE_TRUNC('day', NOW() - INTERVAL '${start} days') AS start_date`);
+		if (prev === 0) {
+			expect(result).toContain('NOW() AS prev_start_date');
+		} else {
+			expect(result).toContain(`NOW() - INTERVAL '${prev} days' AS prev_start_date`);
+		}
+		if (start === 0) {
+			expect(result).toContain('NOW() AS start_date');
+		} else {
+			expect(result).toContain(`NOW() - INTERVAL '${start} days' AS start_date`);
+		}
 		expect(result).toContain('NOW() AS end_date');
 	} else {
-		expect(result).toContain(`DATE(DATE_SUB(NOW(), INTERVAL ${prev} DAY)) AS prev_start_date`);
-		expect(result).toContain(`DATE(DATE_SUB(NOW(), INTERVAL ${start} DAY)) AS start_date`);
+		if (prev === 0) {
+			expect(result).toContain('NOW() AS prev_start_date');
+		} else {
+			expect(result).toContain(`DATE_SUB(NOW(), INTERVAL ${prev} DAY) AS prev_start_date`);
+		}
+		if (start === 0) {
+			expect(result).toContain('NOW() AS start_date');
+		} else {
+			expect(result).toContain(`DATE_SUB(NOW(), INTERVAL ${start} DAY) AS start_date`);
+		}
 		expect(result).toContain('NOW() AS end_date');
 	}
 }
@@ -46,29 +68,17 @@ function expectStartOfDayDateRangeQuery(params: {
 	if (dbType === 'sqlite') {
 		expect(result).toContain(`datetime('now', '-${prev} days', 'start of day') AS prev_start_date`);
 		expect(result).toContain(`datetime('now', '-${start} days', 'start of day') AS start_date`);
-		if (end !== 0) {
-			expect(result).toContain(`datetime('now', '-${end} days', 'start of day') AS end_date`);
-		} else {
-			expect(result).toContain("datetime('now', 'start of day') AS end_date");
-		}
+		expect(result).toContain(`datetime('now', '-${end} days', 'start of day') AS end_date`);
 	} else if (dbType === 'postgresdb') {
 		expect(result).toContain(
 			`DATE_TRUNC('day', NOW() - INTERVAL '${prev} days') AS prev_start_date`,
 		);
 		expect(result).toContain(`DATE_TRUNC('day', NOW() - INTERVAL '${start} days') AS start_date`);
-		if (end !== 0) {
-			expect(result).toContain(`DATE_TRUNC('day', NOW() - INTERVAL '${end} days') AS end_date`);
-		} else {
-			expect(result).toContain("DATE_TRUNC('day', NOW()) AS end_date");
-		}
+		expect(result).toContain(`DATE_TRUNC('day', NOW() - INTERVAL '${end} days') AS end_date`);
 	} else {
 		expect(result).toContain(`DATE(DATE_SUB(NOW(), INTERVAL ${prev} DAY)) AS prev_start_date`);
 		expect(result).toContain(`DATE(DATE_SUB(NOW(), INTERVAL ${start} DAY)) AS start_date`);
-		if (end !== 0) {
-			expect(result).toContain(`DATE(DATE_SUB(NOW(), INTERVAL ${end} DAY)) AS end_date`);
-		} else {
-			expect(result).toContain('DATE(NOW()) AS end_date');
-		}
+		expect(result).toContain(`DATE(DATE_SUB(NOW(), INTERVAL ${end} DAY)) AS end_date`);
 	}
 }
 
@@ -92,7 +102,7 @@ describe('getDateRangesCommonTableExpressionQuery', () => {
 	])('%s', (dbType: DatabaseConfig['type']) => {
 		describe('hour periodicity (1 day - startDate == endDate)', () => {
 			test('last 24 hours (endDate is today)', () => {
-				const startDate = now.startOf('day').toJSDate();
+				const startDate = now.minus({ days: 1 }).startOf('day').toJSDate();
 				const endDate = now.startOf('day').toJSDate();
 
 				const result = getDateRangesCommonTableExpressionQuery({ dbType, startDate, endDate });
@@ -112,23 +122,23 @@ describe('getDateRangesCommonTableExpressionQuery', () => {
 				}
 			});
 
-			test('yesterday (specific day)', () => {
-				const startDate = now.minus({ days: 1 }).startOf('day').toJSDate();
+			test('day before yesterday (specific day)', () => {
+				const startDate = now.minus({ days: 2 }).startOf('day').toJSDate();
 				const endDate = now.minus({ days: 1 }).startOf('day').toJSDate();
 
 				const result = getDateRangesCommonTableExpressionQuery({ dbType, startDate, endDate });
 				expectStartOfDayDateRangeQuery({
 					result,
 					dbType,
-					prevStartDateOffset: 2,
-					startDateOffset: 1,
-					endDateOffset: 0, // the end of the range is the start of the next day
+					prevStartDateOffset: 3,
+					startDateOffset: 2,
+					endDateOffset: 1,
 				});
 			});
 
 			test('7 days ago (specific day)', () => {
 				const startDate = now.minus({ days: 7 }).startOf('day').toJSDate();
-				const endDate = now.minus({ days: 7 }).startOf('day').toJSDate();
+				const endDate = now.minus({ days: 6 }).startOf('day').toJSDate();
 
 				const result = getDateRangesCommonTableExpressionQuery({ dbType, startDate, endDate });
 				expectStartOfDayDateRangeQuery({
@@ -142,7 +152,7 @@ describe('getDateRangesCommonTableExpressionQuery', () => {
 
 			test('14 days ago (specific day)', () => {
 				const startDate = now.minus({ days: 14 }).startOf('day').toJSDate();
-				const endDate = now.minus({ days: 14 }).startOf('day').toJSDate();
+				const endDate = now.minus({ days: 13 }).startOf('day').toJSDate();
 
 				const result = getDateRangesCommonTableExpressionQuery({ dbType, startDate, endDate });
 				expectStartOfDayDateRangeQuery({
@@ -157,7 +167,7 @@ describe('getDateRangesCommonTableExpressionQuery', () => {
 			test('X days ago (specific day far in the past)', () => {
 				// 109 days ago (2025-06-21)
 				const startDate = now.minus({ days: 109 }).startOf('day').toJSDate();
-				const endDate = now.minus({ days: 109 }).startOf('day').toJSDate();
+				const endDate = now.minus({ days: 108 }).startOf('day').toJSDate();
 
 				const result = getDateRangesCommonTableExpressionQuery({ dbType, startDate, endDate });
 				expectStartOfDayDateRangeQuery({
@@ -165,7 +175,7 @@ describe('getDateRangesCommonTableExpressionQuery', () => {
 					dbType,
 					prevStartDateOffset: 110,
 					startDateOffset: 109,
-					endDateOffset: 108, // the end of the range is the start of the next day
+					endDateOffset: 108,
 				});
 			});
 		});
@@ -173,113 +183,113 @@ describe('getDateRangesCommonTableExpressionQuery', () => {
 		describe('day periodicity (2-30 days)', () => {
 			describe('last X days (endDate is today)', () => {
 				test('last 7 days', () => {
-					const startDate = now.minus({ days: 6 }).startOf('day').toJSDate();
+					const startDate = now.minus({ days: 7 }).startOf('day').toJSDate();
 					const endDate = now.startOf('day').toJSDate();
 
 					const result = getDateRangesCommonTableExpressionQuery({ dbType, startDate, endDate });
 					expectLastXDaysDateRangeQuery({
 						result,
 						dbType,
-						prevStartDateOffset: 13, // 6 + 7
-						startDateOffset: 6, // today - 6 days ago = 7 days range
+						prevStartDateOffset: 14, // 7 + 7
+						startDateOffset: 7,
 					});
 				});
 
 				test('last 14 days', () => {
-					const startDate = now.minus({ days: 13 }).startOf('day').toJSDate();
+					const startDate = now.minus({ days: 14 }).startOf('day').toJSDate();
 					const endDate = now.startOf('day').toJSDate();
 
 					const result = getDateRangesCommonTableExpressionQuery({ dbType, startDate, endDate });
 					expectLastXDaysDateRangeQuery({
 						result,
 						dbType,
-						prevStartDateOffset: 27, // 13 + 14
-						startDateOffset: 13, // today - 13 days ago = 14 days range
+						prevStartDateOffset: 28, // 14 + 14
+						startDateOffset: 14,
 					});
 				});
 
 				test('last 30 days', () => {
-					const startDate = now.minus({ days: 29 }).startOf('day').toJSDate();
+					const startDate = now.minus({ days: 30 }).startOf('day').toJSDate();
 					const endDate = now.startOf('day').toJSDate();
 
 					const result = getDateRangesCommonTableExpressionQuery({ dbType, startDate, endDate });
 					expectLastXDaysDateRangeQuery({
 						result,
 						dbType,
-						prevStartDateOffset: 59, // 29 + 30
-						startDateOffset: 29, // today - 29 days ago = 30 days range
+						prevStartDateOffset: 60, // 30 + 30
+						startDateOffset: 30,
 					});
 				});
 			});
 
 			describe('specific historical range', () => {
 				test('2 day range', () => {
-					const startDate = now.minus({ days: 2 }).startOf('day').toJSDate();
+					const startDate = now.minus({ days: 3 }).startOf('day').toJSDate();
 					const endDate = now.minus({ days: 1 }).startOf('day').toJSDate();
 
 					const result = getDateRangesCommonTableExpressionQuery({ dbType, startDate, endDate });
 					expectStartOfDayDateRangeQuery({
 						result,
 						dbType,
-						prevStartDateOffset: 4, // 2 + 2
-						startDateOffset: 2,
-						endDateOffset: 0, // the end of the range is the start of the next day
+						prevStartDateOffset: 5,
+						startDateOffset: 3,
+						endDateOffset: 1,
 					});
 				});
 
 				test('5 days range', () => {
 					const startDate = now.minus({ days: 10 }).startOf('day').toJSDate();
-					const endDate = now.minus({ days: 6 }).startOf('day').toJSDate();
+					const endDate = now.minus({ days: 5 }).startOf('day').toJSDate();
 
 					const result = getDateRangesCommonTableExpressionQuery({ dbType, startDate, endDate });
 					expectStartOfDayDateRangeQuery({
 						result,
 						dbType,
-						prevStartDateOffset: 15, // 10 + 5
+						prevStartDateOffset: 15,
 						startDateOffset: 10,
-						endDateOffset: 5, // the end of the range is the start of the next day
+						endDateOffset: 5,
 					});
 				});
 
 				test('7 days range', () => {
-					const startDate = now.minus({ days: 12 }).startOf('day').toJSDate();
-					const endDate = now.minus({ days: 6 }).startOf('day').toJSDate();
+					const startDate = now.minus({ days: 14 }).startOf('day').toJSDate();
+					const endDate = now.minus({ days: 7 }).startOf('day').toJSDate();
 
 					const result = getDateRangesCommonTableExpressionQuery({ dbType, startDate, endDate });
 					expectStartOfDayDateRangeQuery({
 						result,
 						dbType,
-						prevStartDateOffset: 19, // 12 + 7
-						startDateOffset: 12,
-						endDateOffset: 5, // the end of the range is the start of the next day
+						prevStartDateOffset: 21,
+						startDateOffset: 14,
+						endDateOffset: 7,
 					});
 				});
 
 				test('14 days range', () => {
-					const startDate = now.minus({ days: 14 }).startOf('day').toJSDate();
+					const startDate = now.minus({ days: 15 }).startOf('day').toJSDate();
 					const endDate = now.minus({ days: 1 }).startOf('day').toJSDate();
 
 					const result = getDateRangesCommonTableExpressionQuery({ dbType, startDate, endDate });
 					expectStartOfDayDateRangeQuery({
 						result,
 						dbType,
-						prevStartDateOffset: 28, // 14 + 14
-						startDateOffset: 14,
-						endDateOffset: 0, // the end of the range is the start of the next day
+						prevStartDateOffset: 29,
+						startDateOffset: 15,
+						endDateOffset: 1,
 					});
 				});
 
 				test('30 days range', () => {
-					const startDate = now.minus({ days: 52 }).startOf('day').toJSDate();
+					const startDate = now.minus({ days: 53 }).startOf('day').toJSDate();
 					const endDate = now.minus({ days: 23 }).startOf('day').toJSDate();
 
 					const result = getDateRangesCommonTableExpressionQuery({ dbType, startDate, endDate });
 					expectStartOfDayDateRangeQuery({
 						result,
 						dbType,
-						prevStartDateOffset: 82, // 52 + 30
-						startDateOffset: 52,
-						endDateOffset: 22, // the end of the range is the start of the next day
+						prevStartDateOffset: 83,
+						startDateOffset: 53,
+						endDateOffset: 23,
 					});
 				});
 			});
@@ -288,15 +298,15 @@ describe('getDateRangesCommonTableExpressionQuery', () => {
 		describe('week periodicity (31+ days)', () => {
 			describe('last X days (endDate is today)', () => {
 				test('last 90 days', () => {
-					const startDate = now.minus({ days: 89 }).startOf('day').toJSDate();
+					const startDate = now.minus({ days: 90 }).startOf('day').toJSDate();
 					const endDate = now.startOf('day').toJSDate();
 
 					const result = getDateRangesCommonTableExpressionQuery({ dbType, startDate, endDate });
 					expectLastXDaysDateRangeQuery({
 						result,
 						dbType,
-						prevStartDateOffset: 179, // 89 + 90
-						startDateOffset: 89,
+						prevStartDateOffset: 180,
+						startDateOffset: 90,
 					});
 				});
 
@@ -306,7 +316,7 @@ describe('getDateRangesCommonTableExpressionQuery', () => {
 
 					const result = getDateRangesCommonTableExpressionQuery({ dbType, startDate, endDate });
 					const daysBack = Math.floor(now.diff(DateTime.fromJSDate(startDate), 'days').days);
-					const prevDaysBack = daysBack * 2 + 1;
+					const prevDaysBack = daysBack * 2;
 					expectLastXDaysDateRangeQuery({
 						result,
 						dbType,
@@ -321,7 +331,7 @@ describe('getDateRangesCommonTableExpressionQuery', () => {
 
 					const result = getDateRangesCommonTableExpressionQuery({ dbType, startDate, endDate });
 					const daysBack = Math.floor(now.diff(DateTime.fromJSDate(startDate), 'days').days);
-					const prevDaysBack = daysBack * 2 + 1;
+					const prevDaysBack = daysBack * 2;
 					expectLastXDaysDateRangeQuery({
 						result,
 						dbType,
@@ -333,58 +343,58 @@ describe('getDateRangesCommonTableExpressionQuery', () => {
 
 			describe('specific historical range', () => {
 				test('31 days range (specific historical range)', () => {
-					const startDate = now.minus({ days: 31 }).startOf('day').toJSDate();
+					const startDate = now.minus({ days: 32 }).startOf('day').toJSDate();
 					const endDate = now.minus({ days: 1 }).startOf('day').toJSDate();
 
 					const result = getDateRangesCommonTableExpressionQuery({ dbType, startDate, endDate });
 					expectStartOfDayDateRangeQuery({
 						result,
 						dbType,
-						prevStartDateOffset: 62, // 31 + 31
-						startDateOffset: 31,
-						endDateOffset: 0, // the end of the range is the start of the next day
+						prevStartDateOffset: 63,
+						startDateOffset: 32,
+						endDateOffset: 1,
 					});
 				});
 
 				test('90 days range (specific historical range)', () => {
-					const startDate = now.minus({ days: 97 }).startOf('day').toJSDate();
+					const startDate = now.minus({ days: 98 }).startOf('day').toJSDate();
 					const endDate = now.minus({ days: 8 }).startOf('day').toJSDate();
 
 					const result = getDateRangesCommonTableExpressionQuery({ dbType, startDate, endDate });
 					expectStartOfDayDateRangeQuery({
 						result,
 						dbType,
-						prevStartDateOffset: 187, // 97 + 90
-						startDateOffset: 97,
-						endDateOffset: 7, // the end of the range is the start of the next day
+						prevStartDateOffset: 188,
+						startDateOffset: 98,
+						endDateOffset: 8,
 					});
 				});
 
 				test('180 days range (specific historical range)', () => {
-					const startDate = now.minus({ days: 180 }).startOf('day').toJSDate();
+					const startDate = now.minus({ days: 181 }).startOf('day').toJSDate();
 					const endDate = now.minus({ days: 1 }).startOf('day').toJSDate();
 
 					const result = getDateRangesCommonTableExpressionQuery({ dbType, startDate, endDate });
 					expectStartOfDayDateRangeQuery({
 						result,
 						dbType,
-						prevStartDateOffset: 360, // 180 + 180
-						startDateOffset: 180,
-						endDateOffset: 0, // the end of the range is the start of the next day
+						prevStartDateOffset: 361,
+						startDateOffset: 181,
+						endDateOffset: 1,
 					});
 				});
 
 				test('360 days range (specific historical range)', () => {
-					const startDate = now.minus({ days: 360 }).startOf('day').toJSDate();
+					const startDate = now.minus({ days: 361 }).startOf('day').toJSDate();
 					const endDate = now.minus({ days: 1 }).startOf('day').toJSDate();
 
 					const result = getDateRangesCommonTableExpressionQuery({ dbType, startDate, endDate });
 					expectStartOfDayDateRangeQuery({
 						result,
 						dbType,
-						prevStartDateOffset: 720, // 360 + 360
-						startDateOffset: 360,
-						endDateOffset: 0, // the end of the range is the start of the next day
+						prevStartDateOffset: 721,
+						startDateOffset: 361,
+						endDateOffset: 1,
 					});
 				});
 			});
@@ -392,33 +402,91 @@ describe('getDateRangesCommonTableExpressionQuery', () => {
 
 		describe('edge cases', () => {
 			test('handles date with time component correctly', () => {
-				// Date with time should be treated as start of day
+				// Oct 6 14:30 to Oct 7 18:45
+				// Now is Oct 8 8:51:27, so Oct 7 18:45 is less than 1 full day ago
+				// Therefore useStartOfDay = false (not yet a full day in the past)
+				// daysFromEndDateToToday = Math.round(0.58) = 1
+				// daysDiff = Math.round(1.18) = 1
+				// daysFromStartDateToToday = Math.floor(1.76) = 1
+				// prevStartDaysFromToday = 1 + 1 = 2
 				const startDate = DateTime.utc(2025, 10, 6, 14, 30, 0).toJSDate();
 				const endDate = DateTime.utc(2025, 10, 7, 18, 45, 30).toJSDate();
 
 				const result = getDateRangesCommonTableExpressionQuery({ dbType, startDate, endDate });
-				// 2-day range
-				expectStartOfDayDateRangeQuery({
-					result,
-					dbType,
-					prevStartDateOffset: 4, // 2 + 2
-					startDateOffset: 2,
-					endDateOffset: 0, // the end of the range is the start of the next day
-				});
+
+				// Verify the actual output based on the calculation
+				if (dbType === 'sqlite') {
+					expect(result).toContain("datetime('now', '-2 days') AS prev_start_date");
+					expect(result).toContain("datetime('now', '-1 days') AS start_date");
+					expect(result).toContain("datetime('now', '-1 days') AS end_date");
+				} else if (dbType === 'postgresdb') {
+					expect(result).toContain("NOW() - INTERVAL '2 days' AS prev_start_date");
+					expect(result).toContain("NOW() - INTERVAL '1 days' AS start_date");
+					expect(result).toContain("NOW() - INTERVAL '1 days' AS end_date");
+				} else {
+					expect(result).toContain('DATE_SUB(NOW(), INTERVAL 2 DAY) AS prev_start_date');
+					expect(result).toContain('DATE_SUB(NOW(), INTERVAL 1 DAY) AS start_date');
+					expect(result).toContain('DATE_SUB(NOW(), INTERVAL 1 DAY) AS end_date');
+				}
 			});
 
 			test('handles same day with different times correctly (hour periodicity)', () => {
+				// Oct 7 9:00 to Oct 7 17:00 (same day)
+				// Now is Oct 8 8:51:27, so Oct 7 17:00 is less than 1 full day ago
+				// useStartOfDay = false
+				// daysDiff = 0 (same day), daysFromEndDateToToday = 1 (rounded)
+				// daysFromStartDateToToday = 0 (floored), prevStartDaysFromToday = 0 + 0 = 0
 				const startDate = DateTime.utc(2025, 10, 7, 9, 0, 0).toJSDate();
 				const endDate = DateTime.utc(2025, 10, 7, 17, 0, 0).toJSDate();
 
 				const result = getDateRangesCommonTableExpressionQuery({ dbType, startDate, endDate });
-				expectStartOfDayDateRangeQuery({
+
+				// Verify the actual output based on the calculation
+				if (dbType === 'sqlite') {
+					expect(result).toContain("datetime('now') AS prev_start_date");
+					expect(result).toContain("datetime('now') AS start_date");
+					expect(result).toContain("datetime('now', '-1 days') AS end_date");
+				} else if (dbType === 'postgresdb') {
+					expect(result).toContain('NOW() AS prev_start_date');
+					expect(result).toContain('NOW() AS start_date');
+					expect(result).toContain("NOW() - INTERVAL '1 days' AS end_date");
+				} else {
+					expect(result).toContain('NOW() AS prev_start_date');
+					expect(result).toContain('NOW() AS start_date');
+					expect(result).toContain('DATE_SUB(NOW(), INTERVAL 1 DAY) AS end_date');
+				}
+			});
+
+			test('handles daylight saving time transition correctly', () => {
+				// Simulate DST transition: Oct 22 (GMT+0200) to Nov 5 (GMT+0100)
+				// Same wall-clock time but different timezone offset
+				// Oct 26 2025 is when DST ends in Europe (clocks go back 1 hour)
+				const startDate = DateTime.fromObject(
+					{ year: 2025, month: 10, day: 22, hour: 12, minute: 37, second: 56 },
+					{ zone: 'Europe/Paris' },
+				).toJSDate();
+				const endDate = DateTime.fromObject(
+					{ year: 2025, month: 11, day: 5, hour: 12, minute: 37, second: 56 },
+					{ zone: 'Europe/Paris' },
+				).toJSDate();
+
+				// Mock current time to be Nov 5
+				jest.setSystemTime(endDate);
+
+				const result = getDateRangesCommonTableExpressionQuery({ dbType, startDate, endDate });
+
+				// With DST normalization: Oct 22 to Nov 5 is 14 calendar days
+				// The function detects same wall-clock time but different timezone offset
+				// and normalizes to calculate correct calendar days
+				expectLastXDaysDateRangeQuery({
 					result,
 					dbType,
-					prevStartDateOffset: 2, // 1 + 1
-					startDateOffset: 1,
-					endDateOffset: 0, // the end of the range is the start of the next day
+					prevStartDateOffset: 28, // 14 + 14
+					startDateOffset: 14,
 				});
+
+				// Restore original mock time
+				jest.setSystemTime(now.toJSDate());
 			});
 		});
 	});

--- a/packages/cli/src/modules/insights/insights.controller.ts
+++ b/packages/cli/src/modules/insights/insights.controller.ts
@@ -152,7 +152,7 @@ export class InsightsController {
 
 		if (!query.startDate) {
 			return {
-				startDate: DateTime.now().minus({ days: 6 }).toJSDate(),
+				startDate: DateTime.now().minus({ days: 7 }).toJSDate(),
 				endDate: today,
 			};
 		}

--- a/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsDashboard.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsDashboard.test.ts
@@ -207,16 +207,16 @@ let projectsStore: MockedStore<typeof useProjectsStore>;
 const personalProject = createProjectListItem('personal');
 const teamProjects = Array.from({ length: 2 }, () => createProjectListItem('team'));
 const projects = [personalProject, ...teamProjects];
-const date = new Date(2000, 11, 19);
+const date = new Date('2000-12-19T00:00:00.000Z');
 
 // Test helper constants
 const DEFAULT_DATE_RANGE = {
-	startDate: new Date('2000-12-13T00:00:00.000Z'),
+	startDate: new Date('2000-12-12T00:00:00.000Z'),
 	endDate: new Date('2000-12-19T00:00:00.000Z'),
 };
 
 const SINGLE_DAY_RANGE = {
-	startDate: new Date('2000-12-19T00:00:00.000Z'),
+	startDate: new Date('2000-12-18T00:00:00.000Z'),
 	endDate: new Date('2000-12-19T00:00:00.000Z'),
 };
 
@@ -243,7 +243,7 @@ const expectStoreExecutions = (params: {
 };
 
 const openDatePicker = async (getByText: (text: string, options?: object) => HTMLElement) => {
-	const trigger = getByText('13 Dec - 19 Dec, 2000', { selector: 'button' });
+	const trigger = getByText('12 Dec - 19 Dec, 2000', { selector: 'button' });
 	expect(trigger).toBeInTheDocument();
 	await userEvent.click(trigger);
 

--- a/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsDashboard.vue
+++ b/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsDashboard.vue
@@ -118,7 +118,7 @@ const range = shallowRef<{
 	start: DateValue;
 	end: DateValue;
 }>({
-	start: maxDate.copy().subtract({ days: 6 }),
+	start: maxDate.copy().subtract({ days: 7 }),
 	end: maxDate.copy(),
 });
 

--- a/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsDataRangePicker.vue
+++ b/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsDataRangePicker.vue
@@ -41,7 +41,7 @@ function getDaysDiff({ start, end }: DateRange) {
 	if (!start) return 0;
 	if (!end) return 0;
 
-	return end.compare(start) + 1;
+	return end.compare(start);
 }
 
 function isBeforeOrSame(dateToCompare: DateValue, referenceDate: DateValue): boolean {

--- a/packages/frontend/editor-ui/src/features/execution/insights/insights.utils.ts
+++ b/packages/frontend/editor-ui/src/features/execution/insights/insights.utils.ts
@@ -60,13 +60,13 @@ export const transformInsightsSummary = (data: InsightsSummary | null): Insights
 		: [];
 
 export const timeRangeMappings = {
-	day: 0,
-	week: 6,
-	'2weeks': 13,
-	month: 29,
-	quarter: 89,
+	day: 1,
+	week: 7,
+	'2weeks': 14,
+	month: 30,
+	quarter: 90,
 	'6months': 180,
-	year: 364,
+	year: 365,
 };
 
 export const getTimeRangeLabels = () => {


### PR DESCRIPTION

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR changes the way date range filtering works for insights:
Previously:
- We used start of day for the start day, and now (time aware) for the end date, when end date is today

Now:
- if end date is today, we use time aware range (start date and end date at the same now time)
- if end date is before today, use start of day to start of day filtering

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
