### PR TITLE
fix(ai-builder): Reduce "workflow state too big" errors

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/constants.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/constants.ts
@@ -35,4 +35,4 @@ export const MAX_WORKFLOW_LENGTH_TOKENS = 30_000;
  * Average character-to-token ratio for Anthropic models.
  * Used for rough token count estimation from character counts.
  */
-export const AVG_CHARS_PER_TOKEN_ANTHROPIC = 2.5;
+export const AVG_CHARS_PER_TOKEN_ANTHROPIC = 3.5;

--- a/packages/@n8n/ai-workflow-builder.ee/src/test/workflow-builder-agent.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/test/workflow-builder-agent.test.ts
@@ -354,6 +354,111 @@ describe('WorkflowBuilderAgent', () => {
 				const state = createMockState('Short message', 'Custom Name', 1);
 				expect(shouldModifyState(state, autoCompactThresholdTokens)).toBe('agent');
 			});
+
+			it('should return "auto_compact_messages" when messages with workflow context exceed threshold', () => {
+				// Use a smaller threshold for this test to make it easier to exceed
+				const smallThreshold = 5000; // tokens
+
+				// Create a long message that when combined with workflow context will exceed threshold
+				// With AVG_CHARS_PER_TOKEN_ANTHROPIC = 3.5, we need ~17500 characters to exceed 5000 tokens
+				const longMessage = 'x'.repeat(10000);
+				const state = createMockState(longMessage, 'Custom Name', 1, 10);
+
+				// Add substantial workflow data that will be included in context
+				state.workflowJSON = {
+					nodes: Array.from({ length: 50 }, (_, i) => ({
+						id: `node-${i}`,
+						name: `Node ${i}`,
+						type: 'n8n-nodes-base.testNode',
+						typeVersion: 1,
+						position: [i * 100, i * 100] as [number, number],
+						parameters: { data: 'x'.repeat(200) },
+					})),
+					connections: {},
+					name: 'Test Workflow',
+				};
+
+				expect(shouldModifyState(state, smallThreshold)).toBe('auto_compact_messages');
+			});
+
+			it('should return "agent" when messages with workflow context stay below threshold', () => {
+				const shortMessage = 'Create a simple workflow';
+				const state = createMockState(shortMessage, 'Custom Name', 1, 2);
+
+				// Small workflow that won't push us over threshold
+				state.workflowJSON = {
+					nodes: [
+						{
+							id: 'node-1',
+							name: 'Start',
+							type: 'n8n-nodes-base.start',
+							typeVersion: 1,
+							position: [0, 0] as [number, number],
+							parameters: {},
+						},
+					],
+					connections: {},
+					name: 'Simple Workflow',
+				};
+
+				expect(shouldModifyState(state, autoCompactThresholdTokens)).toBe('agent');
+			});
+
+			it('should consider execution data and schema in token estimation', () => {
+				// Use a smaller threshold for this test
+				const smallThreshold = 3000; // tokens
+
+				const message = 'x'.repeat(3000);
+				const state = createMockState(message, 'Custom Name', 1, 5);
+
+				// Add execution data and schema that contribute to token count
+				state.workflowContext = {
+					...state.workflowContext,
+					executionData: {
+						runData: {
+							'node-1': [
+								{
+									data: {
+										main: [[{ json: { data: 'x'.repeat(2000) } }]],
+									},
+									executionTime: 100,
+									startTime: Date.now(),
+									executionIndex: 0,
+									source: [],
+								},
+							],
+						},
+					},
+					executionSchema: [
+						{
+							nodeName: 'node-1',
+							schema: {
+								type: 'object',
+								value: [
+									{ key: 'field1', type: 'string', value: 'x'.repeat(1000), path: '.field1' },
+									{ key: 'field2', type: 'string', value: 'x'.repeat(1000), path: '.field2' },
+								],
+								path: '',
+							},
+						},
+					],
+				};
+
+				state.workflowJSON = {
+					nodes: Array.from({ length: 20 }, (_, i) => ({
+						id: `node-${i}`,
+						name: `Node ${i}`,
+						type: 'n8n-nodes-base.testNode',
+						typeVersion: 1,
+						position: [i * 100, i * 100] as [number, number],
+						parameters: { data: 'x'.repeat(100) },
+					})),
+					connections: {},
+					name: 'Complex Workflow',
+				};
+
+				expect(shouldModifyState(state, smallThreshold)).toBe('auto_compact_messages');
+			});
 		});
 	});
 });

--- a/packages/@n8n/ai-workflow-builder.ee/src/workflow-builder-agent.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/workflow-builder-agent.ts
@@ -78,13 +78,45 @@ export function shouldModifyState(
 		return 'create_workflow_name';
 	}
 
+	const workflowContextToAppend = getWorkflowContext(state);
+
 	// Check if we should auto-compact based on token count
-	const estimatedTokens = estimateTokenCountFromMessages(messages);
+	const estimatedTokens = estimateTokenCountFromMessages([
+		...messages,
+		// appended later to last message
+		new HumanMessage(workflowContextToAppend),
+	]);
 	if (estimatedTokens > autoCompactThresholdTokens) {
 		return 'auto_compact_messages';
 	}
 
 	return 'agent';
+}
+
+function getWorkflowContext(state: typeof WorkflowState.State) {
+	const trimmedWorkflow = trimWorkflowJSON(state.workflowJSON);
+	const executionData = state.workflowContext?.executionData ?? {};
+	const executionSchema = state.workflowContext?.executionSchema ?? [];
+	const workflowContext = [
+		'',
+		'<current_workflow_json>',
+		JSON.stringify(trimmedWorkflow),
+		'</current_workflow_json>',
+		'<trimmed_workflow_json_note>',
+		'Note: Large property values of the nodes in the workflow JSON above may be trimmed to fit within token limits.',
+		'Use get_node_parameter tool to get full details when needed.',
+		'</trimmed_workflow_json_note>',
+		'',
+		'<current_simplified_execution_data>',
+		JSON.stringify(executionData),
+		'</current_simplified_execution_data>',
+		'',
+		'<current_execution_nodes_schemas>',
+		JSON.stringify(executionSchema),
+		'</current_execution_nodes_schemas>',
+	].join('\n');
+
+	return workflowContext;
 }
 
 export interface WorkflowBuilderAgentConfig {
@@ -168,9 +200,6 @@ export class WorkflowBuilderAgent {
 			}
 
 			const hasPreviousSummary = state.previousSummary && state.previousSummary !== 'EMPTY';
-			const trimmedWorkflow = trimWorkflowJSON(state.workflowJSON);
-			const executionData = state.workflowContext?.executionData ?? {};
-			const executionSchema = state.workflowContext?.executionSchema ?? [];
 
 			const prompt = await mainAgentPrompt.invoke({
 				...state,
@@ -182,24 +211,7 @@ export class WorkflowBuilderAgent {
 				previousSummary: hasPreviousSummary ? state.previousSummary : '',
 			});
 
-			const workflowContext = [
-				'',
-				'<current_workflow_json>',
-				JSON.stringify(trimmedWorkflow),
-				'</current_workflow_json>',
-				'<trimmed_workflow_json_note>',
-				'Note: Large property values of the nodes in the workflow JSON above may be trimmed to fit within token limits.',
-				'Use get_node_parameter tool to get full details when needed.',
-				'</trimmed_workflow_json_note>',
-				'',
-				'<current_simplified_execution_data>',
-				JSON.stringify(executionData),
-				'</current_simplified_execution_data>',
-				'',
-				'<current_execution_nodes_schemas>',
-				JSON.stringify(executionSchema),
-				'</current_execution_nodes_schemas>',
-			].join('\n');
+			const workflowContext = getWorkflowContext(state);
 
 			// Optimize prompts for Anthropic's caching by:
 			// 1. Finding all user/tool message positions (cache breakpoints)

--- a/packages/@n8n/ai-workflow-builder.ee/src/workflow-builder-agent.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/workflow-builder-agent.ts
@@ -185,7 +185,7 @@ export class WorkflowBuilderAgent {
 			const workflowContext = [
 				'',
 				'<current_workflow_json>',
-				JSON.stringify(trimmedWorkflow, null, 2),
+				JSON.stringify(trimmedWorkflow),
 				'</current_workflow_json>',
 				'<trimmed_workflow_json_note>',
 				'Note: Large property values of the nodes in the workflow JSON above may be trimmed to fit within token limits.',
@@ -193,11 +193,11 @@ export class WorkflowBuilderAgent {
 				'</trimmed_workflow_json_note>',
 				'',
 				'<current_simplified_execution_data>',
-				JSON.stringify(executionData, null, 2),
+				JSON.stringify(executionData),
 				'</current_simplified_execution_data>',
 				'',
 				'<current_execution_nodes_schemas>',
-				JSON.stringify(executionSchema, null, 2),
+				JSON.stringify(executionSchema),
 				'</current_execution_nodes_schemas>',
 			].join('\n');
 

--- a/packages/frontend/editor-ui/src/app/composables/useDataSchema.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useDataSchema.test.ts
@@ -365,6 +365,148 @@ describe('useDataSchema', () => {
 			);
 			expect(pathData).toEqual([new Date('2022-11-22T00:00:00.000Z')]);
 		});
+
+		describe('with collapseArrays=true', () => {
+			it('should collapse simple arrays to first item only', () => {
+				const input = ['John', 'Jane', 'Joe'];
+				const schema = getSchema(input, '', false, true);
+				expect(schema).toEqual({
+					type: 'array',
+					value: [{ type: 'string', value: 'John', key: '0', path: '[0]' }],
+					path: '',
+				});
+			});
+
+			it('should collapse nested arrays recursively', () => {
+				const input = [
+					{ name: 'John', age: 22, hobbies: ['surfing', 'traveling', 'reading'] },
+					{ name: 'Joe', age: 33, hobbies: ['skateboarding', 'gaming', 'coding'] },
+					{ name: 'Jane', age: 28, hobbies: ['cooking', 'photography'] },
+				];
+				const schema = getSchema(input, '', false, true);
+				expect(schema).toEqual({
+					type: 'array',
+					value: [
+						{
+							type: 'object',
+							key: '0',
+							value: [
+								{ type: 'string', key: 'name', value: 'John', path: '[0].name' },
+								{ type: 'number', key: 'age', value: '22', path: '[0].age' },
+								{
+									type: 'array',
+									key: 'hobbies',
+									value: [{ type: 'string', key: '0', value: 'surfing', path: '[0].hobbies[0]' }],
+									path: '[0].hobbies',
+								},
+							],
+							path: '[0]',
+						},
+					],
+					path: '',
+				});
+			});
+
+			it('should handle empty arrays', () => {
+				const input: unknown[] = [];
+				const schema = getSchema(input, '', false, true);
+				expect(schema).toEqual({
+					type: 'array',
+					value: [],
+					path: '',
+				});
+			});
+
+			it('should collapse deeply nested arrays', () => {
+				const input = [
+					{
+						dates: [
+							[new Date('2022-11-22T00:00:00.000Z'), new Date('2022-11-23T00:00:00.000Z')],
+							[new Date('2022-12-22T00:00:00.000Z'), new Date('2022-12-23T00:00:00.000Z')],
+						],
+					},
+					{
+						dates: [[new Date('2023-01-01T00:00:00.000Z'), new Date('2023-01-02T00:00:00.000Z')]],
+					},
+				];
+				const schema = getSchema(input, '', false, true);
+				expect(schema).toEqual({
+					type: 'array',
+					value: [
+						{
+							type: 'object',
+							key: '0',
+							value: [
+								{
+									type: 'array',
+									key: 'dates',
+									value: [
+										{
+											type: 'array',
+											key: '0',
+											value: [
+												{
+													type: 'string',
+													key: '0',
+													value: '2022-11-22T00:00:00.000Z',
+													path: '[0].dates[0][0]',
+												},
+											],
+											path: '[0].dates[0]',
+										},
+									],
+									path: '[0].dates',
+								},
+							],
+							path: '[0]',
+						},
+					],
+					path: '',
+				});
+			});
+
+			it('should not affect objects, only arrays', () => {
+				const input = {
+					person1: { name: 'John', age: 22 },
+					person2: { name: 'Jane', age: 28 },
+					person3: { name: 'Joe', age: 33 },
+				};
+				const schema = getSchema(input, '', false, true);
+				expect(schema).toEqual({
+					type: 'object',
+					value: [
+						{
+							type: 'object',
+							key: 'person1',
+							value: [
+								{ type: 'string', key: 'name', value: 'John', path: '.person1.name' },
+								{ type: 'number', key: 'age', value: '22', path: '.person1.age' },
+							],
+							path: '.person1',
+						},
+						{
+							type: 'object',
+							key: 'person2',
+							value: [
+								{ type: 'string', key: 'name', value: 'Jane', path: '.person2.name' },
+								{ type: 'number', key: 'age', value: '28', path: '.person2.age' },
+							],
+							path: '.person2',
+						},
+						{
+							type: 'object',
+							key: 'person3',
+							value: [
+								{ type: 'string', key: 'name', value: 'Joe', path: '.person3.name' },
+								{ type: 'number', key: 'age', value: '33', path: '.person3.age' },
+							],
+							path: '.person3',
+						},
+					],
+					path: '',
+				});
+			});
+		});
 	});
 
 	describe('filterSchema', () => {

--- a/packages/frontend/editor-ui/src/app/composables/useDataSchema.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useDataSchema.test.ts
@@ -391,14 +391,51 @@ describe('useDataSchema', () => {
 							type: 'object',
 							key: '0',
 							value: [
-								{ type: 'string', key: 'name', value: 'John', path: '[0].name' },
-								{ type: 'number', key: 'age', value: '22', path: '[0].age' },
+								{ type: 'string', key: 'name', value: 'Jane', path: '[0].name' },
+								{ type: 'number', key: 'age', value: '28', path: '[0].age' },
 								{
 									type: 'array',
 									key: 'hobbies',
-									value: [{ type: 'string', key: '0', value: 'surfing', path: '[0].hobbies[0]' }],
+									value: [{ type: 'string', key: '0', value: 'cooking', path: '[0].hobbies[0]' }],
 									path: '[0].hobbies',
 								},
+							],
+							path: '[0]',
+						},
+					],
+					path: '',
+				});
+			});
+
+			it('should collapse nested arrays of objects with different keys recursively', () => {
+				const input = [
+					{
+						name: 'John',
+						age: 22,
+						createdAt: 193939,
+					},
+					{ name: 'Joe', age: 33, hobbies: ['skateboarding', 'gaming', 'coding'], test: true },
+					{ name: 'Jane', age: 28, hobbies: ['cooking', 'photography'], updatedAt: 199994 },
+				];
+				const schema = getSchema(input, '', false, true);
+				expect(schema).toEqual({
+					type: 'array',
+					value: [
+						{
+							type: 'object',
+							key: '0',
+							value: [
+								{ type: 'string', key: 'name', value: 'Jane', path: '[0].name' },
+								{ type: 'number', key: 'age', value: '28', path: '[0].age' },
+								{ type: 'number', key: 'createdAt', value: '193939', path: '[0].createdAt' },
+								{
+									type: 'array',
+									key: 'hobbies',
+									value: [{ type: 'string', key: '0', value: 'cooking', path: '[0].hobbies[0]' }],
+									path: '[0].hobbies',
+								},
+								{ type: 'boolean', key: 'test', value: 'true', path: '[0].test' },
+								{ type: 'number', key: 'updatedAt', value: '199994', path: '[0].updatedAt' },
 							],
 							path: '[0]',
 						},
@@ -448,7 +485,7 @@ describe('useDataSchema', () => {
 												{
 													type: 'string',
 													key: '0',
-													value: '2022-11-22T00:00:00.000Z',
+													value: '2023-01-01T00:00:00.000Z',
 													path: '[0].dates[0][0]',
 												},
 											],

--- a/packages/frontend/editor-ui/src/app/composables/useDataSchema.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useDataSchema.ts
@@ -40,7 +40,13 @@ export function useDataSchema() {
 								? [
 										{
 											key: '0',
-											...getSchema(input[0], `${path}[0]`, excludeValues, collapseArrays),
+											...getSchema(
+												// If array contains objects, merge all their keys into one
+												input.every((item) => isObj(item)) ? merge({}, ...input) : input[0],
+												`${path}[0]`,
+												excludeValues,
+												collapseArrays,
+											),
 										},
 									]
 								: input.map((item, index) => ({

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useAIAssistantHelpers.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useAIAssistantHelpers.ts
@@ -195,6 +195,7 @@ export const useAIAssistantHelpers = () => {
 			const schema = getSchemaForExecutionData(
 				executionDataToJson(getInputDataWithPinned(node)),
 				excludeValues,
+				true, // collapseArrays: true for AI assistant to avoid verbose array expansion
 			);
 			schemas.push({
 				nodeName: node.name,


### PR DESCRIPTION
## Summary

- Increase character/token ratio to 3.5
Ran a small script comparing different inputs to Anthropic's API. `3.9` would be most accurate. `3.5` would be a little conservative.
```
  📊 Empirical Data:
  - Average: 3.89 characters per token
  - Median: 3.97 characters per token
  - Range: 3.25 - 4.00 characters per token

  ⚖️ Comparison with Current Constant:
  - Current AVG_CHARS_PER_TOKEN_ANTHROPIC: 2.5
  - Empirical average: 3.89
  - Difference: 55.6% overestimation of token usage
  ```
- Add current workflow context to decision to auto compact messages. This ensures that new execution data is accounted for when deciding to compact messages or not. 
- Remove extra indentation from json data appended as context
- Collapse arrays in execution schemas into a single item

<img width="449" height="912" alt="Screenshot 2025-11-04 at 15 21 07" src="https://github.com/user-attachments/assets/ed5f2abe-e9dc-4310-a7d7-d392fe394821" />


<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
