### PR TITLE
fix(core): Include role in user-invite-email-click

### DIFF
--- a/packages/@n8n/db/src/repositories/user.repository.ts
+++ b/packages/@n8n/db/src/repositories/user.repository.ts
@@ -12,10 +12,15 @@ export class UserRepository extends Repository<User> {
 		super(User, dataSource.manager);
 	}
 
-	async findManyByIds(userIds: string[], includeRole: boolean = false) {
+	async findManyByIds(
+		userIds: string[],
+		options?: {
+			includeRole: boolean;
+		},
+	) {
 		return await this.find({
 			where: { id: In(userIds) },
-			relations: includeRole ? ['role'] : undefined,
+			relations: options?.includeRole ? ['role'] : undefined,
 		});
 	}
 

--- a/packages/@n8n/db/src/repositories/user.repository.ts
+++ b/packages/@n8n/db/src/repositories/user.repository.ts
@@ -12,9 +12,10 @@ export class UserRepository extends Repository<User> {
 		super(User, dataSource.manager);
 	}
 
-	async findManyByIds(userIds: string[]) {
+	async findManyByIds(userIds: string[], includeRole: boolean = false) {
 		return await this.find({
 			where: { id: In(userIds) },
+			relations: includeRole ? ['role'] : undefined,
 		});
 	}
 

--- a/packages/@n8n/decorators/src/redactable.ts
+++ b/packages/@n8n/decorators/src/redactable.ts
@@ -5,7 +5,7 @@ type UserLike = {
 	email?: string;
 	firstName?: string;
 	lastName?: string;
-	role: {
+	role?: {
 		slug: string;
 	};
 };
@@ -24,7 +24,7 @@ function toRedactable(userLike: UserLike) {
 		_email: userLike.email,
 		_firstName: userLike.firstName,
 		_lastName: userLike.lastName,
-		globalRole: userLike.role.slug,
+		globalRole: userLike.role?.slug,
 	};
 }
 

--- a/packages/cli/src/controllers/auth.controller.ts
+++ b/packages/cli/src/controllers/auth.controller.ts
@@ -150,7 +150,7 @@ export class AuthController {
 			throw new ForbiddenError(RESPONSE_ERROR_MESSAGES.USERS_QUOTA_REACHED);
 		}
 
-		const users = await this.userRepository.findManyByIds([inviterId, inviteeId]);
+		const users = await this.userRepository.findManyByIds([inviterId, inviteeId], true);
 
 		if (users.length !== 2) {
 			this.logger.debug(

--- a/packages/cli/src/controllers/auth.controller.ts
+++ b/packages/cli/src/controllers/auth.controller.ts
@@ -150,7 +150,9 @@ export class AuthController {
 			throw new ForbiddenError(RESPONSE_ERROR_MESSAGES.USERS_QUOTA_REACHED);
 		}
 
-		const users = await this.userRepository.findManyByIds([inviterId, inviteeId], true);
+		const users = await this.userRepository.findManyByIds([inviterId, inviteeId], {
+			includeRole: true,
+		});
 
 		if (users.length !== 2) {
 			this.logger.debug(

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -16,7 +16,7 @@ export type UserLike = {
 	email?: string;
 	firstName?: string;
 	lastName?: string;
-	role: {
+	role?: {
 		slug: string;
 	};
 };


### PR DESCRIPTION
## Summary

When custom roles where introduced the structure of the user entity changed. This includes the role in the user-invite-email-click event again. It also changes the UserLike type to make the role optional, this enforces all usages to handle the case where the role is not available.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-4065/typeerror-cannot-read-properties-of-undefined-reading-slug#comment-8c1b6295


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
