### PR TITLE
feat(editor): Data size warning in AI Logs input/output sections

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -1302,6 +1302,7 @@
 	"ndv.output.tooMuchData.message": "The node contains {size} MB of data. Displaying it may slow down your browser temporarily.",
 	"ndv.output.tooMuchData.showDataAnyway": "Show data",
 	"ndv.output.tooMuchData.title": "Display data?",
+	"ndv.output.logs.tooMuchData.message": "The {inOut} contains {size} MB of data. Displaying it may slow down your browser temporarily.",
 	"ndv.output.waitingToRun": "Waiting to execute...",
 	"ndv.output.noToolUsedInfo": "None of your tools were used in this run. Try giving your tools clearer names and descriptions to help the AI",
 	"ndv.title.cancel": "Cancel",

--- a/packages/frontend/editor-ui/src/app/constants/limits.ts
+++ b/packages/frontend/editor-ui/src/app/constants/limits.ts
@@ -3,4 +3,5 @@ export const MAX_EXPECTED_REQUEST_SIZE = 2048; // Expected maximum workflow requ
 export const MAX_PINNED_DATA_SIZE = 1024 * 1024 * 12; // 12 MB; Workflow pinned data size limit in bytes
 export const MAX_DISPLAY_DATA_SIZE = 1024 * 1024; // 1 MB
 export const MAX_DISPLAY_DATA_SIZE_SCHEMA_VIEW = 1024 * 1024 * 4; // 4 MB
+export const MAX_DISPLAY_DATA_SIZE_LOGS_VIEW = 1024 * 512; // 512 KB
 export const MAX_DISPLAY_ITEMS_AUTO_ALL = 250;

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/ai/AiRunContentBlock.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/ai/AiRunContentBlock.test.ts
@@ -1,0 +1,83 @@
+import { createComponentRenderer } from '@/__tests__/render';
+import AiRunContentBlock from './AiRunContentBlock.vue';
+import type { IAiDataContent } from '@/Interface';
+import { NodeConnectionTypes, type INodeExecutionData } from 'n8n-workflow';
+import { MAX_DISPLAY_DATA_SIZE_LOGS_VIEW } from '@/app/constants';
+import { fireEvent, screen } from '@testing-library/vue';
+
+const renderComponent = createComponentRenderer(AiRunContentBlock, {
+	global: {
+		stubs: {
+			RunDataAi: {
+				template: '<div data-test-id="ai-content">ai content</div>',
+			},
+		},
+	},
+});
+
+function createRunData(payload: unknown): IAiDataContent {
+	return {
+		data: [
+			{
+				json: {
+					value: payload,
+				},
+			} as unknown as INodeExecutionData,
+		],
+		inOut: 'output',
+		type: NodeConnectionTypes.AiLanguageModel,
+		metadata: {
+			executionTime: 0,
+			startTime: 0,
+		},
+	};
+}
+
+describe('AiRunContentBlock', () => {
+	const largePayload = 'x'.repeat(MAX_DISPLAY_DATA_SIZE_LOGS_VIEW + 1);
+
+	it('hides oversized data behind an explicit action', async () => {
+		renderComponent({
+			props: {
+				runData: createRunData(largePayload),
+			},
+		});
+
+		expect(await screen.findByText('Display data?')).toBeInTheDocument();
+		expect(await screen.findByRole('button', { name: 'Show data' })).toBeInTheDocument();
+		expect(screen.queryByTestId('ai-content')).not.toBeInTheDocument();
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Show data' }));
+
+		expect(await screen.findByTestId('ai-content')).toBeInTheDocument();
+	});
+
+	it('resets the view when run data changes', async () => {
+		const rendered = renderComponent({
+			props: {
+				runData: createRunData(largePayload),
+			},
+		});
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Show data' }));
+		expect(await screen.findByTestId('ai-content')).toBeInTheDocument();
+
+		await rendered.rerender({
+			runData: createRunData(`${largePayload}updated`),
+		});
+
+		expect(screen.queryByTestId('ai-content')).not.toBeInTheDocument();
+		expect(await screen.findByText('Display data?')).toBeInTheDocument();
+	});
+
+	it('shows small payloads automatically', async () => {
+		const rendered = renderComponent({
+			props: {
+				runData: createRunData('small payload'),
+			},
+		});
+
+		expect(await screen.findByTestId('ai-content')).toBeInTheDocument();
+		expect(rendered.queryByText('Display data?')).not.toBeInTheDocument();
+	});
+});

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/ai/AiRunContentBlock.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/ai/AiRunContentBlock.vue
@@ -2,8 +2,8 @@
 import type { IAiDataContent } from '@/Interface';
 import capitalize from 'lodash/capitalize';
 import { computed, onMounted, ref, watch } from 'vue';
-import { NodeConnectionTypes } from 'n8n-workflow';
 import type { NodeConnectionType, NodeError } from 'n8n-workflow';
+import { NodeConnectionTypes } from 'n8n-workflow';
 import RunDataAi from '../RunDataParsedAiContent.vue';
 import { parseAiContent } from '@/app/utils/aiUtils';
 import { N8nButton, N8nIcon, N8nRadioButtons } from '@n8n/design-system';
@@ -12,6 +12,7 @@ import { saveAs } from 'file-saver';
 import { MAX_DISPLAY_DATA_SIZE_LOGS_VIEW } from '@/app/constants';
 import { useI18n } from '@n8n/i18n';
 import NDVEmptyState from '@/features/ndv/panel/components/NDVEmptyState.vue';
+
 const props = defineProps<{
 	runData: IAiDataContent;
 	error?: NodeError;
@@ -29,7 +30,6 @@ const parsedRun = computed(() => parseAiContent(props.runData.data ?? [], props.
 const contentParsed = computed(() =>
 	parsedRun.value.some((item) => item.parsedContent?.parsed === true),
 );
-const isDataWithinDisplayLimit = computed(() => dataSize.value < MAX_DISPLAY_DATA_SIZE_LOGS_VIEW);
 
 function getInitialExpandedState() {
 	const collapsedTypes = {
@@ -56,17 +56,15 @@ function onRenderTypeChange(value: 'rendered' | 'json') {
 	renderType.value = value;
 }
 
+function updateShowData() {
+	showData.value = dataSize.value < MAX_DISPLAY_DATA_SIZE_LOGS_VIEW;
+}
+
 function refreshDataSize() {
-	// Hide by default the data from being displayed
 	showData.value = false;
-	const byteSize = new Blob([JSON.stringify(props.runData.data)]).size;
-	dataSize.value = byteSize;
+	dataSize.value = new Blob([JSON.stringify(props.runData.data)]).size;
 
 	updateShowData();
-}
-function updateShowData() {
-	// Display data if it is reasonably small (< 128KB)
-	showData.value = isDataWithinDisplayLimit.value;
 }
 
 function onShowDataAnyway() {


### PR DESCRIPTION
## Summary

If there is too much data to show in inputs/outputs of Log panel, browser may become too slow (was especially noticible on Firefox). This PR implements same data size warnings as we have in regular input/output sections of NDV.

Before (huge amount of data):
<img width="520" height="789" alt="image" src="https://github.com/user-attachments/assets/529d4bc4-9056-41a4-ac1b-bda9ce15ad72" />


After:
<img width="521" height="804" alt="image" src="https://github.com/user-attachments/assets/abf73677-5bd7-4914-a260-cf597b7aea08" />



## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
