### PR TITLE
chore(core): Define execution context interfaces

### DIFF
--- a/packages/workflow/src/execution-context.ts
+++ b/packages/workflow/src/execution-context.ts
@@ -1,0 +1,102 @@
+import z, { type ZodType } from 'zod/v4';
+
+import { jsonParse } from './utils';
+
+const CredentialContextSchemaV1 = z.object({
+	version: z.literal(1),
+	/**
+	 * Identity token/value used for credential resolution
+	 * Could be JWT, API key, session token, user ID, etc.
+	 */
+	identity: z.string(),
+
+	/**
+	 * Optional metadata for credential resolution
+	 */
+	metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type ICredentialContextV1 = z.output<typeof CredentialContextSchemaV1>;
+
+export const CredentialContextSchema = z
+	.discriminatedUnion('version', [CredentialContextSchemaV1])
+	.meta({
+		title: 'ICredentialContext',
+	});
+
+/**
+ * Decrypted structure of credentials field
+ * Never stored in this form - always encrypted in IExecutionContext
+ */
+export type ICredentialContext = z.output<typeof CredentialContextSchema>;
+
+const ExecutionContextSchemaV1 = z.object({
+	version: z.literal(1),
+	/**
+	 * When the context was established (Unix timestamp in milliseconds)
+	 */
+	establishedAt: z.number(),
+	/**
+	 * Encrypted credential context for dynamic credential resolution
+	 * Always encrypted when stored, decrypted on-demand by credential resolver
+	 * @see ICredentialContext for decrypted structure
+	 */
+	credentials: z.string().optional().meta({
+		description:
+			'Encrypted credential context for dynamic credential resolution Always encrypted when stored, decrypted on-demand by credential resolver @see ICredentialContext for decrypted structure',
+	}),
+});
+
+export type IExecutionContextV1 = z.output<typeof ExecutionContextSchemaV1>;
+
+export const ExecutionContextSchema = z
+	.discriminatedUnion('version', [ExecutionContextSchemaV1])
+	.meta({
+		title: 'IExecutionContext',
+	});
+
+/**
+ * Execution context carries per-execution metadata throughout workflow lifecycle
+ * Established at execution start and propagated to sub-workflows/error workflows
+ */
+export type IExecutionContext = z.output<typeof ExecutionContextSchema>;
+
+const safeParse = <T extends ZodType>(value: string | object, schema: T) => {
+	const typeName = schema.meta()?.title ?? 'Object';
+	try {
+		const normalizedObject = typeof value === 'string' ? jsonParse(value) : value;
+		const parseResult = schema.safeParse(normalizedObject);
+		if (parseResult.error) {
+			throw parseResult.error;
+		}
+		// here we could implement a mgiration policy for migrating old execution context versions to newer ones
+		return parseResult.data;
+	} catch (error) {
+		throw new Error(`Failed to parse to valid ${typeName}`, {
+			cause: error,
+		});
+	}
+};
+
+/**
+ * Safely parses an execution context from an
+ * @param obj
+ * @returns
+ */
+export const toExecutionContext = (value: string | object): IExecutionContext => {
+	// here we could implement a mgiration policy for migrating old execution context versions to newer ones
+	return safeParse(value, ExecutionContextSchema);
+};
+
+/**
+ * Safely parses a credential context from either an object or a string to an
+ * ICredentialContext. This can be used to safely parse a decrypted context for
+ * example.
+ * @param value The object or string to be parsed
+ * @returns ICredentialContext
+ * @throws Error in case parsing fails for any reason
+ */
+export const toCredentialContext = (value: string | object): ICredentialContext => {
+	// here we could implement a mgiration policy for migrating old credential context versions to newer ones
+	return safeParse(value, CredentialContextSchema);
+};

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -9,6 +9,7 @@ export * from './common';
 export * from './cron';
 export * from './data-table.types';
 export * from './deferred-promise';
+export * from './execution-context';
 export * from './global-state';
 export * from './interfaces';
 export * from './message-event-bus';

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -28,6 +28,7 @@ import type { ExecutionStatus } from './execution-status';
 import type { Result } from './result';
 import type { Workflow } from './workflow';
 import type { EnvProviderState } from './workflow-data-proxy-env-provider';
+import type { IExecutionContext } from './execution-context';
 
 export interface IAdditionalCredentialOptions {
 	oauth2?: IOAuth2Options;
@@ -2420,6 +2421,7 @@ export interface IRunExecutionData {
 	};
 	executionData?: {
 		contextData: IExecuteContextData;
+		runtimeData?: IExecutionContext;
 		nodeExecutionStack: IExecuteData[];
 		metadata: {
 			// node-name: metadata by runIndex


### PR DESCRIPTION
## Summary

This defines execution context interfaces. These will be used to carry execution metadata through the lifecycle of the workflow.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-4077/define-iexecutioncontext-interface
closes https://linear.app/n8n/issue/PAY-4078/add-context-field-to-irunexecutiondata

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce zod-based execution/credential context schemas with safe parsers, export them, and add `executionData.runtimeData` to carry runtime context.
> 
> - **Workflow**:
>   - **New schemas/types**: Add `execution-context.ts` defining `ICredentialContext` and `IExecutionContext` (v1) with zod schemas and `toExecutionContext`/`toCredentialContext` safe parsers.
>   - **Exports**: Re-export `execution-context` from `index.ts`.
>   - **Execution data**: Extend `IRunExecutionData.executionData` with optional `runtimeData?: IExecutionContext`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5227715092af2c4a841ec61729633760e8680d4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->