### PR TITLE
docs(editor): Create Tree component API spec

### DIFF
--- a/packages/frontend/@n8n/design-system/src/v2/components/Tree/component-tree.md
+++ b/packages/frontend/@n8n/design-system/src/v2/components/Tree/component-tree.md
@@ -1,0 +1,220 @@
+# Component specification
+
+A generic tree component that displays hierarchical data in a collapsible structure. It supports virtualization for performance with large datasets, provides flexible rendering through slots, and can work with any data type that implements the `TreeItem` interface.
+
+- **Component Name:** N8nTree
+- **Figma Component:** [Tree](https://www.figma.com/design/8zib7Trf2D2CHYXrEGPHkg/n8n-Design-System-V3?m=auto&node-id=2536-2108)
+- **Reka UI Component:** [Tree](https://reka-ui.com/docs/components/tree)
+
+## Generic Type Support
+
+The Tree component is generic and can work with any data type that extends the base `TreeItem` interface:
+
+```typescript
+interface TreeItem {
+  id: string;
+  children?: TreeItem[];
+}
+```
+
+By default, it uses `IMenuItem` but can be used with custom types for different use cases.
+
+## Public API Definition
+
+**Props**
+
+- `items: T[]` - Tree data structure using generic type T (defaults to IMenuItem)
+- `estimateSize?: number` - Estimated height of each tree item (in px) - used for virtualization | `default: 32`
+- `getKey?: (item: T) => string` - Optional function to get unique key from each item | `default: item.id`
+- `modelValue?: string[]` - The controlled selected values of the Tree. Can be bind as `v-model`
+- `expanded?: string[]` - The controlled expanded state of tree items. Can be bind as `v-model:expanded`
+- `defaultExpanded?: string[]` - The expanded state when initially rendered
+- `multiple?: boolean` - Whether multiple items can be selected
+- `disabled?: boolean` - When `true`, prevents user interaction with the Tree
+
+**Events**
+
+- `update:modelValue(value: string[])` - Emitted when selection changes
+- `update:expanded(value: string[])` - Emitted when expanded items change
+
+**Slots**
+
+- `default`: `{ item: FlattenedItem<T>; handleToggle: () => void; isExpanded: boolean }` - Main content for each tree item.
+### Template usage example
+
+#### Basic Usage (with IMenuItem - default)
+
+```vue
+<script setup lang="ts">
+import type { IMenuItem } from '@n8n/design-system/types'
+
+const items = ref<IMenuItem[]>([
+  {
+    id: 'folder-1',
+    label: 'Documents',
+    icon: 'folder',
+    children: [
+      {
+        id: 'file-1',
+        label: 'README.md',
+        icon: 'file-text',
+      },
+      {
+        id: 'file-2',
+        label: 'package.json',
+        icon: 'file-code',
+      }
+    ]
+  },
+  {
+    id: 'folder-2',
+    label: 'Images',
+    icon: 'image',
+    children: [
+      {
+        id: 'file-3',
+        label: 'logo.png',
+        icon: 'image',
+      }
+    ]
+  }
+])
+
+const expanded = ref(['folder-1'])
+const selected = ref<string[]>([])
+</script>
+
+<template>
+  <N8nTree
+    v-model="selected"
+    v-model:expanded="expanded"
+    :items="items"
+  >
+    <template #default="{ item, handleToggle, isExpanded }">
+      <div class="tree-item">
+        <N8nIconButton
+          v-if="item.value.children?.length"
+          size="mini"
+          type="highlight"
+          :icon="isExpanded ? 'chevron-down' : 'chevron-right'"
+          @click="handleToggle"
+        />
+        <N8nIcon :icon="item.value.icon" />
+        <span>{{ item.value.label }}</span>
+      </div>
+    </template>
+  </N8nTree>
+</template>
+```
+
+#### Generic Usage (with custom types)
+
+```vue
+<script setup lang="ts">
+import type { TreeItem } from '@n8n/design-system/components/Tree'
+
+// Define a custom tree item type
+interface FileSystemItem extends TreeItem {
+  name: string
+  type: 'folder' | 'file'
+  size?: number
+  children?: FileSystemItem[]
+}
+
+const items = ref<FileSystemItem[]>([
+  {
+    id: 'folder-1',
+    name: 'Documents',
+    type: 'folder',
+    children: [
+      {
+        id: 'file-1',
+        name: 'README.md',
+        type: 'file',
+        size: 1024,
+      },
+      {
+        id: 'file-2',
+        name: 'package.json',
+        type: 'file',
+        size: 2048,
+      }
+    ]
+  },
+  {
+    id: 'file-3',
+    name: 'config.json',
+    type: 'file',
+    size: 512,
+  }
+])
+
+const expanded = ref<string[]>([])
+const selected = ref<string[]>([])
+</script>
+
+<template>
+  <N8nTree
+    v-model="selected"
+    v-model:expanded="expanded"
+    :items="items"
+  >
+    <template #default="{ item, handleToggle, isExpanded }">
+      <div class="tree-item">
+        <N8nIconButton
+          v-if="item.value.children?.length"
+          size="mini"
+          type="highlight"
+          :icon="isExpanded ? 'chevron-down' : 'chevron-right'"
+          @click="handleToggle"
+        />
+        <N8nIcon :icon="item.value.type === 'folder' ? 'folder' : 'file'" />
+        <span>{{ item.value.name }}</span>
+        <span v-if="item.value.size" class="file-size">({{ item.value.size }} bytes)</span>
+      </div>
+    </template>
+  </N8nTree>
+</template>
+```
+
+#### With custom getKey function
+
+```vue
+<script setup lang="ts">
+interface CustomItem extends TreeItem {
+  uuid: string
+  name: string
+  children?: CustomItem[]
+}
+
+const customItems = ref<CustomItem[]>([
+  {
+    id: 'should-not-be-used',
+    uuid: 'abc-123',
+    name: 'Custom Item',
+    children: [
+      {
+        id: 'should-not-be-used',
+        uuid: 'def-456',
+        name: 'Child Item'
+      }
+    ]
+  }
+])
+
+function getCustomKey(item: CustomItem) {
+  return item.uuid
+}
+</script>
+
+<template>
+  <N8nTree
+    :items="customItems"
+    :get-key="getCustomKey"
+  >
+    <template #default="{ item }">
+      <span>{{ item.value.name }} ({{ item.value.uuid }})</span>
+    </template>
+  </N8nTree>
+</template>
+```

--- a/packages/frontend/@n8n/design-system/src/v2/components/Tree/component-tree.md
+++ b/packages/frontend/@n8n/design-system/src/v2/components/Tree/component-tree.md
@@ -17,7 +17,6 @@ interface TreeItem {
 }
 ```
 
-By default, it uses `IMenuItem` but can be used with custom types for different use cases.
 
 ## Public API Definition
 
@@ -42,7 +41,7 @@ By default, it uses `IMenuItem` but can be used with custom types for different 
 - `default`: `{ item: FlattenedItem<T>; handleToggle: () => void; handleSelect: () => void; isExpanded: boolean, hasChildren: boolean }` - Main content for each tree item.
 ### Template usage example
 
-#### Basic Usage (with IMenuItem - and MenuItem component)
+#### Basic Usage
 
 ```vue
 <script setup lang="ts">
@@ -53,23 +52,11 @@ const items = ref<IMenuItem[]>([...])
 </script>
 
 <template>
-  <N8nTree :items="items">
-		<template #default="{ item, handleToggle, isExpanded, hasChildren }">
-			<MenuItem :key="item.value.id" :item="item.value">
-				<template v-if="hasChildren" #toggle>
-					<N8nIconButton
-						size="mini"
-						type="highlight"
-						:icon="isExpanded ? 'chevron-down' : 'chevron-right'"
-						icon-size="medium"
-						aria-label="Expand"
-						@click="handleToggle"
-					/>
-				</template>
-			</MenuItem>
-  </N8nTree>
+  <N8nTree :items="items" />
 </template>
 ```
+
+#### Custom slot and key
 
 ```vue
 <script setup lang="ts">
@@ -104,8 +91,11 @@ function getCustomKey(item: CustomItem) {
     :items="customItems"
     :get-key="getCustomKey"
   >
-    <template #default="{ item }">
-      <span>{{ item.value.name }} ({{ item.value.uuid }})</span>
+    <template #default="{ item, handleToggle, isExpanded, hasChildren }">
+			<div>
+				<N8nIconButton v-if="hasChildren" :icon="isExpanded ? 'chevron-down' : 'chevron-right'" @click="handleToggle" />
+				<span>{{ item.value.name }} ({{ item.value.uuid }})</span>
+			</div>
     </template>
   </N8nTree>
 </template>

--- a/packages/frontend/@n8n/design-system/src/v2/components/Tree/component-tree.md
+++ b/packages/frontend/@n8n/design-system/src/v2/components/Tree/component-tree.md
@@ -39,7 +39,7 @@ By default, it uses `IMenuItem` but can be used with custom types for different 
 
 **Slots**
 
-- `default`: `{ item: FlattenedItem<T>; handleToggle: () => void; isExpanded: boolean }` - Main content for each tree item.
+- `default`: `{ item: FlattenedItem<T>; handleToggle: () => void; isExpanded: boolean, hasChildren: boolean }` - Main content for each tree item.
 ### Template usage example
 
 #### Basic Usage (with IMenuItem - and MenuItem component)
@@ -54,9 +54,9 @@ const items = ref<IMenuItem[]>([...])
 
 <template>
   <N8nTree :items="items">
-		<template #default="{ item, handleToggle, isExpanded }">
+		<template #default="{ item, handleToggle, isExpanded, hasChildren }">
 			<MenuItem :key="item.value.id" :item="item.value">
-				<template v-if="item.value.children && item.value.children.length > 0" #toggle>
+				<template v-if="hasChildren" #toggle>
 					<N8nIconButton
 						size="mini"
 						type="highlight"

--- a/packages/frontend/@n8n/design-system/src/v2/components/Tree/component-tree.md
+++ b/packages/frontend/@n8n/design-system/src/v2/components/Tree/component-tree.md
@@ -39,6 +39,8 @@ interface TreeItem {
 **Slots**
 
 - `default`: `{ item: FlattenedItem<T>; handleToggle: () => void; handleSelect: () => void; isExpanded: boolean, hasChildren: boolean }` - Main content for each tree item.
+- `empty`: - Slot for empty state.
+
 ### Template usage example
 
 #### Basic Usage
@@ -97,6 +99,9 @@ function getCustomKey(item: CustomItem) {
 				<span>{{ item.value.name }} ({{ item.value.uuid }})</span>
 			</div>
     </template>
+		<template #empty>
+			<p>No custom items to display</p>
+		</template>
   </N8nTree>
 </template>
 ```

--- a/packages/frontend/@n8n/design-system/src/v2/components/Tree/component-tree.md
+++ b/packages/frontend/@n8n/design-system/src/v2/components/Tree/component-tree.md
@@ -39,7 +39,7 @@ By default, it uses `IMenuItem` but can be used with custom types for different 
 
 **Slots**
 
-- `default`: `{ item: FlattenedItem<T>; handleToggle: () => void; isExpanded: boolean, hasChildren: boolean }` - Main content for each tree item.
+- `default`: `{ item: FlattenedItem<T>; handleToggle: () => void; handleSelect: () => void; isExpanded: boolean, hasChildren: boolean }` - Main content for each tree item.
 ### Template usage example
 
 #### Basic Usage (with IMenuItem - and MenuItem component)

--- a/packages/frontend/@n8n/design-system/src/v2/components/Tree/component-tree.md
+++ b/packages/frontend/@n8n/design-system/src/v2/components/Tree/component-tree.md
@@ -35,7 +35,7 @@ By default, it uses `IMenuItem` but can be used with custom types for different 
 **Events**
 
 - `update:modelValue(value: string[])` - Emitted when selection changes
-- `update:expanded(value: string[])` - Emitted when expanded items change
+- `update:expanded([val: Record<string, any> | Record<string, any>[]])` - Emitted when expanded items change
 
 **Slots**
 

--- a/packages/frontend/@n8n/design-system/src/v2/components/Tree/component-tree.md
+++ b/packages/frontend/@n8n/design-system/src/v2/components/Tree/component-tree.md
@@ -42,142 +42,34 @@ By default, it uses `IMenuItem` but can be used with custom types for different 
 - `default`: `{ item: FlattenedItem<T>; handleToggle: () => void; isExpanded: boolean }` - Main content for each tree item.
 ### Template usage example
 
-#### Basic Usage (with IMenuItem - default)
+#### Basic Usage (with IMenuItem - and MenuItem component)
 
 ```vue
 <script setup lang="ts">
 import type { IMenuItem } from '@n8n/design-system/types'
 
-const items = ref<IMenuItem[]>([
-  {
-    id: 'folder-1',
-    label: 'Documents',
-    icon: 'folder',
-    children: [
-      {
-        id: 'file-1',
-        label: 'README.md',
-        icon: 'file-text',
-      },
-      {
-        id: 'file-2',
-        label: 'package.json',
-        icon: 'file-code',
-      }
-    ]
-  },
-  {
-    id: 'folder-2',
-    label: 'Images',
-    icon: 'image',
-    children: [
-      {
-        id: 'file-3',
-        label: 'logo.png',
-        icon: 'image',
-      }
-    ]
-  }
-])
+const items = ref<IMenuItem[]>([...])
 
-const expanded = ref(['folder-1'])
-const selected = ref<string[]>([])
 </script>
 
 <template>
-  <N8nTree
-    v-model="selected"
-    v-model:expanded="expanded"
-    :items="items"
-  >
-    <template #default="{ item, handleToggle, isExpanded }">
-      <div class="tree-item">
-        <N8nIconButton
-          v-if="item.value.children?.length"
-          size="mini"
-          type="highlight"
-          :icon="isExpanded ? 'chevron-down' : 'chevron-right'"
-          @click="handleToggle"
-        />
-        <N8nIcon :icon="item.value.icon" />
-        <span>{{ item.value.label }}</span>
-      </div>
-    </template>
+  <N8nTree :items="items">
+		<template #default="{ item, handleToggle, isExpanded }">
+			<MenuItem :key="item.value.id" :item="item.value">
+				<template v-if="item.value.children && item.value.children.length > 0" #toggle>
+					<N8nIconButton
+						size="mini"
+						type="highlight"
+						:icon="isExpanded ? 'chevron-down' : 'chevron-right'"
+						icon-size="medium"
+						aria-label="Expand"
+						@click="handleToggle"
+					/>
+				</template>
+			</MenuItem>
   </N8nTree>
 </template>
 ```
-
-#### Generic Usage (with custom types)
-
-```vue
-<script setup lang="ts">
-import type { TreeItem } from '@n8n/design-system/components/Tree'
-
-// Define a custom tree item type
-interface FileSystemItem extends TreeItem {
-  name: string
-  type: 'folder' | 'file'
-  size?: number
-  children?: FileSystemItem[]
-}
-
-const items = ref<FileSystemItem[]>([
-  {
-    id: 'folder-1',
-    name: 'Documents',
-    type: 'folder',
-    children: [
-      {
-        id: 'file-1',
-        name: 'README.md',
-        type: 'file',
-        size: 1024,
-      },
-      {
-        id: 'file-2',
-        name: 'package.json',
-        type: 'file',
-        size: 2048,
-      }
-    ]
-  },
-  {
-    id: 'file-3',
-    name: 'config.json',
-    type: 'file',
-    size: 512,
-  }
-])
-
-const expanded = ref<string[]>([])
-const selected = ref<string[]>([])
-</script>
-
-<template>
-  <N8nTree
-    v-model="selected"
-    v-model:expanded="expanded"
-    :items="items"
-  >
-    <template #default="{ item, handleToggle, isExpanded }">
-      <div class="tree-item">
-        <N8nIconButton
-          v-if="item.value.children?.length"
-          size="mini"
-          type="highlight"
-          :icon="isExpanded ? 'chevron-down' : 'chevron-right'"
-          @click="handleToggle"
-        />
-        <N8nIcon :icon="item.value.type === 'folder' ? 'folder' : 'file'" />
-        <span>{{ item.value.name }}</span>
-        <span v-if="item.value.size" class="file-size">({{ item.value.size }} bytes)</span>
-      </div>
-    </template>
-  </N8nTree>
-</template>
-```
-
-#### With custom getKey function
 
 ```vue
 <script setup lang="ts">


### PR DESCRIPTION
## Summary
Spec for the tree component, intended to be used for the new sidedbar and logs panel.
Takes a generic item, as long as it has an `id: string` and optional `children: array`.
Mainly to be used with MenuItem component but can support custom components as well.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds documentation/spec for generic `N8nTree` with API, typing, and usage examples.
> 
> - **Docs**:
>   - **New spec** for `packages/frontend/@n8n/design-system/src/v2/components/Tree/component-tree.md` describing generic `N8nTree`.
>     - Covers generic `TreeItem` support and custom keying via `getKey`.
>     - Defines props (`items`, `estimateSize`, `modelValue`, `expanded`, `defaultExpanded`, `multiple`, `disabled`), events, and default slot API.
>     - Notes virtualization (`estimateSize`) and selection/expansion control.
>     - Includes usage examples with `IMenuItem` and a custom item type using `:get-key`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5e08a195a113eeb3ed43894f76dd2e246c50f77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->