### PR TITLE
feat(Files Node): Add JSONL option for ConvertToFile/toJson

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/binary-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/binary-helper-functions.ts
@@ -225,6 +225,8 @@ export async function copyBinaryFile(
 	);
 }
 
+const RE_SANITISE_MIMETYPE = /^[^/]+\/(?:(?:vnd|prs)\.(?:[^.]+?\.)*)?([^-_+.]+).*$/i;
+
 /**
  * Takes a buffer and converts it into the format n8n uses. It encodes the binary data as
  * base64 and adds metadata.
@@ -308,6 +310,15 @@ export async function prepareBinaryData(
 		if (fileExtension) {
 			returnData.fileExtension = fileExtension;
 		}
+	}
+
+	// Still no fileExtension? Use sanitised second part of mimeType.
+	// NOTE: This is a last-resort. It won't be perfect and generally
+	// covers use-cases when the filePath doesn't contain the extension
+	// and when the mimeType is custom, or not registered/recognised.
+	// This is also limited to only `application/` mimeTypes.
+	if (!returnData.fileExtension && returnData.mimeType.startsWith('application')) {
+		returnData.fileExtension = returnData.mimeType.replace(RE_SANITISE_MIMETYPE, '$1');
 	}
 
 	return await setBinaryDataBuffer(returnData, binaryData, workflowId, executionId);

--- a/packages/nodes-base/nodes/Files/ConvertToFile/actions/toJson.operation.ts
+++ b/packages/nodes-base/nodes/Files/ConvertToFile/actions/toJson.operation.ts
@@ -110,7 +110,7 @@ export async function execute(this: IExecuteFunctions, items: INodeExecutionData
 				items.map((item) => item.json),
 				{
 					fileName: options.fileName as string,
-					mimeType: options.jsonl ? 'text/jsonl' : 'application/json',
+					mimeType: options.jsonl ? 'application/jsonl' : 'application/json',
 					encoding: options.encoding as string,
 					addBOM: options.addBOM as boolean,
 					format: options.format as boolean,
@@ -148,7 +148,7 @@ export async function execute(this: IExecuteFunctions, items: INodeExecutionData
 					encoding: options.encoding as string,
 					addBOM: options.addBOM as boolean,
 					format: options.format as boolean,
-					mimeType: options.jsonl ? 'text/jsonl' : 'application/json',
+					mimeType: options.jsonl ? 'application/jsonl' : 'application/json',
 					itemIndex: i,
 				});
 

--- a/packages/nodes-base/nodes/Files/ConvertToFile/actions/toJson.operation.ts
+++ b/packages/nodes-base/nodes/Files/ConvertToFile/actions/toJson.operation.ts
@@ -75,6 +75,14 @@ export const properties: INodeProperties[] = [
 				placeholder: 'e.g. myFile.json',
 				description: 'Name of the output file',
 			},
+			{
+				displayName: 'JSONL',
+				name: 'jsonl',
+				type: 'boolean',
+				default: false,
+				description:
+					'Whether to output data and comments formatted as JSONL or JSON. This option will also ignore the Format option.',
+			},
 		],
 	},
 ];
@@ -102,7 +110,7 @@ export async function execute(this: IExecuteFunctions, items: INodeExecutionData
 				items.map((item) => item.json),
 				{
 					fileName: options.fileName as string,
-					mimeType: 'application/json',
+					mimeType: options.jsonl ? 'text/jsonl' : 'application/json',
 					encoding: options.encoding as string,
 					addBOM: options.addBOM as boolean,
 					format: options.format as boolean,
@@ -140,7 +148,7 @@ export async function execute(this: IExecuteFunctions, items: INodeExecutionData
 					encoding: options.encoding as string,
 					addBOM: options.addBOM as boolean,
 					format: options.format as boolean,
-					mimeType: 'application/json',
+					mimeType: options.jsonl ? 'text/jsonl' : 'application/json',
 					itemIndex: i,
 				});
 

--- a/packages/nodes-base/nodes/Files/ConvertToFile/test/toText.workflow.json
+++ b/packages/nodes-base/nodes/Files/ConvertToFile/test/toText.workflow.json
@@ -3,11 +3,11 @@
 	"nodes": [
 		{
 			"parameters": {},
-			"id": "f2557b99-e65c-4136-9bc5-7cb328a62d30",
+			"id": "3db7daf5-19c4-4675-9d54-54f829c4e99c",
 			"name": "When clicking ‘Execute workflow’",
 			"type": "n8n-nodes-base.manualTrigger",
 			"typeVersion": 1,
-			"position": [300, 1040]
+			"position": [-576, 576]
 		},
 		{
 			"parameters": {
@@ -15,40 +15,40 @@
 				"sourceProperty": "base64",
 				"options": {}
 			},
-			"id": "71711ee7-9df5-456a-b1d0-def85b8d6669",
+			"id": "4127d3e9-c48c-4172-abec-6b350c224037",
 			"name": "Convert to File2",
 			"type": "n8n-nodes-base.convertToFile",
 			"typeVersion": 1.1,
-			"position": [880, 540]
+			"position": [-128, 0]
 		},
 		{
 			"parameters": {
 				"jsCode": "return   {\n    \"id\": \"23423532\",\n    \"name\": \"Jay Gatsby\",\n    \"email\": \"gatsby@west-egg.com\",\n    \"notes\": \"Keeps asking about a green light??\",\n    \"country\": \"US\",\n    \"created\": \"1925-04-10\",\n  \"base64\": \"VGhpcyBpcyBzb21lIHRleHQgZW5jb2RlZCBhcyBiYXNlNjQ=\"\n  }"
 			},
-			"id": "ff53ab4c-43dd-4c35-b066-59d59e4a8209",
+			"id": "503856e5-0de9-4eb0-b3b7-f9526372a7c0",
 			"name": "Code",
 			"type": "n8n-nodes-base.code",
 			"typeVersion": 2,
-			"position": [520, 1040]
+			"position": [-352, 576]
 		},
 		{
 			"parameters": {
 				"operation": "text",
 				"options": {}
 			},
-			"id": "6322369c-fef5-4172-bbd3-8738cbb67e05",
+			"id": "c520a74b-875a-4b28-b07a-1ad5b52cc9b8",
 			"name": "Extract From File",
 			"type": "n8n-nodes-base.extractFromFile",
 			"typeVersion": 1,
-			"position": [1100, 540]
+			"position": [96, 0]
 		},
 		{
 			"parameters": {},
-			"id": "b5aed50b-65d3-4356-b02d-cbeab7fb3d6e",
+			"id": "df73e5e3-5529-40a0-adad-6b790638cae3",
 			"name": "No Operation, do nothing",
 			"type": "n8n-nodes-base.noOp",
 			"typeVersion": 1,
-			"position": [1320, 540]
+			"position": [320, 0]
 		},
 		{
 			"parameters": {
@@ -56,30 +56,30 @@
 				"sourceProperty": "notes",
 				"options": {}
 			},
-			"id": "65c4c4ac-da33-4ba1-b337-51ee319a8652",
+			"id": "f0b06e3e-e7d1-40be-8d5c-f335dc529b4d",
 			"name": "Convert to Text File",
 			"type": "n8n-nodes-base.convertToFile",
 			"typeVersion": 1,
-			"position": [880, 740]
+			"position": [-128, 192]
 		},
 		{
 			"parameters": {
 				"operation": "text",
 				"options": {}
 			},
-			"id": "b2f49de3-5d0d-4eff-8156-89e5a2a0edae",
+			"id": "4eba0be6-4e70-4a0a-b85d-00fae9b640de",
 			"name": "Extract From Text File",
 			"type": "n8n-nodes-base.extractFromFile",
 			"typeVersion": 1,
-			"position": [1100, 740]
+			"position": [96, 192]
 		},
 		{
 			"parameters": {},
-			"id": "86d5e979-5ff0-4312-8b4f-7ff83f1eebd6",
+			"id": "5e1f25f0-91d8-4d3e-b994-ce209b4411b8",
 			"name": "Text File Result",
 			"type": "n8n-nodes-base.noOp",
 			"typeVersion": 1,
-			"position": [1320, 740]
+			"position": [320, 192]
 		},
 		{
 			"parameters": {
@@ -88,72 +88,72 @@
 					"format": true
 				}
 			},
-			"id": "a938ea30-3acb-4618-a80a-6e759ba7d8db",
+			"id": "9b536f15-849c-4e6d-bbf6-6cecdc1f7527",
 			"name": "Convert to JSON (with Formatting)",
 			"type": "n8n-nodes-base.convertToFile",
 			"typeVersion": 1.1,
-			"position": [880, 920]
+			"position": [-128, 384]
 		},
 		{
 			"parameters": {
 				"operation": "text",
 				"options": {}
 			},
-			"id": "fa35a5ed-4746-48c5-b260-314c517cdd45",
+			"id": "d340c492-c43a-4c37-ad66-47dc52a8eed2",
 			"name": "Extract From JSON (1)",
 			"type": "n8n-nodes-base.extractFromFile",
 			"typeVersion": 1,
-			"position": [1100, 920]
+			"position": [96, 384]
 		},
 		{
 			"parameters": {
 				"operation": "text",
 				"options": {}
 			},
-			"id": "4a3c5c68-6621-4463-8623-83a6572ae760",
+			"id": "417e3f16-ef0e-4749-bf30-42b12ff35731",
 			"name": "Extract From JSON (2)",
 			"type": "n8n-nodes-base.extractFromFile",
 			"typeVersion": 1,
-			"position": [1100, 1120]
+			"position": [96, 576]
 		},
 		{
 			"parameters": {},
-			"id": "dbd03dcb-435c-4af7-ada8-2492c69f1cd6",
+			"id": "04f0bb7d-312d-4a53-84a3-ede69f78c92a",
 			"name": "JSON Result (with Formatting)",
 			"type": "n8n-nodes-base.noOp",
 			"typeVersion": 1,
-			"position": [1320, 920]
+			"position": [320, 384]
 		},
 		{
 			"parameters": {
 				"operation": "toJson",
 				"options": {}
 			},
-			"id": "c461944d-3141-4a1d-abe1-a74e1f71615f",
+			"id": "39c25dc7-e2ae-4d4c-951e-a5fe01c6c36e",
 			"name": "Convert to JSON",
 			"type": "n8n-nodes-base.convertToFile",
 			"typeVersion": 1.1,
-			"position": [880, 1120]
+			"position": [-128, 576]
 		},
 		{
 			"parameters": {
 				"options": {}
 			},
-			"id": "c9ca03b3-0f01-49f5-ab9d-ed4497829a09",
+			"id": "47372f25-3d10-4aac-bf8a-93d4274a8f6c",
 			"name": "Convert to CSV",
 			"type": "n8n-nodes-base.convertToFile",
 			"typeVersion": 1.1,
-			"position": [880, 1320]
+			"position": [-128, 960]
 		},
 		{
 			"parameters": {
 				"options": {}
 			},
-			"id": "1ad12799-7916-4780-aca9-9a966f9e5820",
+			"id": "10fae4a6-c55b-45ba-9062-f6105489ecb8",
 			"name": "Extract From CSV",
 			"type": "n8n-nodes-base.extractFromFile",
 			"typeVersion": 1,
-			"position": [1100, 1320]
+			"position": [96, 960]
 		},
 		{
 			"parameters": {
@@ -161,35 +161,35 @@
 					"delimiter": "|"
 				}
 			},
-			"id": "58caeb17-7434-4808-b8c4-4ca443baecff",
+			"id": "b0731ab5-f389-4b97-b045-d5d9a1f9a454",
 			"name": "Convert to CSV (custom delimiter)",
 			"type": "n8n-nodes-base.convertToFile",
 			"typeVersion": 1.1,
-			"position": [880, 1520]
+			"position": [-128, 1152]
 		},
 		{
 			"parameters": {},
-			"id": "b113b6d9-7928-4de1-bf7f-e2984d124edf",
+			"id": "1b8f52aa-5ed2-4e6e-9035-e42d52dc16a7",
 			"name": "CSV Result",
 			"type": "n8n-nodes-base.noOp",
 			"typeVersion": 1,
-			"position": [1320, 1320]
+			"position": [320, 960]
 		},
 		{
 			"parameters": {},
-			"id": "12554f8d-592a-4500-80f7-42518840f718",
+			"id": "4ed76aea-2c1b-4337-9e8b-a6f74a62f72e",
 			"name": "JSON Result",
 			"type": "n8n-nodes-base.noOp",
 			"typeVersion": 1,
-			"position": [1320, 1120]
+			"position": [320, 576]
 		},
 		{
 			"parameters": {},
-			"id": "8a6ab018-9f38-4a5b-9483-769bf38f0b7c",
+			"id": "51271255-21b7-42e4-b7eb-a34e5302e56a",
 			"name": "CSV Result (custom delimiter)",
 			"type": "n8n-nodes-base.noOp",
 			"typeVersion": 1,
-			"position": [1320, 1520]
+			"position": [320, 1152]
 		},
 		{
 			"parameters": {
@@ -197,11 +197,43 @@
 					"delimiter": "|"
 				}
 			},
-			"id": "e8a4114f-5264-4255-982e-4690c950fb86",
+			"id": "53ec44fe-fb76-47d2-9ec2-07f666a83f9d",
 			"name": "Extract From Custom Delimiter",
 			"type": "n8n-nodes-base.extractFromFile",
 			"typeVersion": 1,
-			"position": [1100, 1520]
+			"position": [96, 1152]
+		},
+		{
+			"parameters": {
+				"operation": "toJson",
+				"options": {
+					"jsonl": true
+				}
+			},
+			"id": "d269607d-b451-47ca-a154-f9711de866f8",
+			"name": "Convert to JSONL",
+			"type": "n8n-nodes-base.convertToFile",
+			"typeVersion": 1.1,
+			"position": [-128, 768]
+		},
+		{
+			"parameters": {
+				"operation": "text",
+				"options": {}
+			},
+			"id": "186a87ba-47a9-4b78-839b-bb22d1497f7e",
+			"name": "Extract From JSONL",
+			"type": "n8n-nodes-base.extractFromFile",
+			"typeVersion": 1,
+			"position": [96, 768]
+		},
+		{
+			"parameters": {},
+			"id": "38c2e7a3-e698-47eb-a873-9a604474821d",
+			"name": "JSONL Result",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [320, 768]
 		}
 	],
 	"pinData": {
@@ -258,6 +290,13 @@
 					"base64": "VGhpcyBpcyBzb21lIHRleHQgZW5jb2RlZCBhcyBiYXNlNjQ="
 				}
 			}
+		],
+		"JSONL Result": [
+			{
+				"json": {
+					"data": "[{\"id\":\"23423532\",\"name\":\"Jay Gatsby\",\"email\":\"gatsby@west-egg.com\",\"notes\":\"Keeps asking about a green light??\",\"country\":\"US\",\"created\":\"1925-04-10\",\"base64\":\"VGhpcyBpcyBzb21lIHRleHQgZW5jb2RlZCBhcyBiYXNlNjQ=\"}]"
+				}
+			}
 		]
 	},
 	"connections": {
@@ -302,6 +341,11 @@
 					},
 					{
 						"node": "Convert to CSV (custom delimiter)",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "Convert to JSONL",
 						"type": "main",
 						"index": 0
 					}
@@ -439,17 +483,38 @@
 					}
 				]
 			]
+		},
+		"Convert to JSONL": {
+			"main": [
+				[
+					{
+						"node": "Extract From JSONL",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Extract From JSONL": {
+			"main": [
+				[
+					{
+						"node": "JSONL Result",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
 		}
 	},
 	"active": false,
 	"settings": {
 		"executionOrder": "v1"
 	},
-	"versionId": "6555e00a-2c20-46f2-9a2c-fb368d557035",
+	"versionId": "b3e23780-148b-4ef9-8861-15631ff46fd0",
 	"meta": {
-		"templateCredsSetupCompleted": true,
-		"instanceId": "be251a83c052a9862eeac953816fbb1464f89dfbf79d7ac490a8e336a8cc8bfd"
+		"instanceId": "fc0dc3f4ff4c3ad62dc9ef599d2c390b560016dab116d1923562d0e647fda9ea"
 	},
-	"id": "RSOCg1c3be66ZqVH",
+	"id": "OI4VJ4lVf6aXeiFW",
 	"tags": []
 }

--- a/packages/nodes-base/nodes/Files/ExtractFromFile/ExtractFromFile.node.ts
+++ b/packages/nodes-base/nodes/Files/ExtractFromFile/ExtractFromFile.node.ts
@@ -57,6 +57,12 @@ export class ExtractFromFile implements INodeType {
 						description: 'Transform a JSON file into output items',
 					},
 					{
+						name: 'Extract From JSONL',
+						value: 'fromJsonl',
+						action: 'Extract from JSONL',
+						description: 'Transform a JSONL file into output items',
+					},
+					{
 						name: 'Extract From ODS',
 						value: 'ods',
 						action: 'Extract from ODS',
@@ -125,7 +131,9 @@ export class ExtractFromFile implements INodeType {
 			});
 		}
 
-		if (['binaryToPropery', 'fromJson', 'text', 'fromIcs', 'xml'].includes(operation)) {
+		if (
+			['binaryToPropery', 'fromJson', 'fromJsonl', 'text', 'fromIcs', 'xml'].includes(operation)
+		) {
 			returnData = await moveTo.execute.call(this, items, operation);
 		}
 

--- a/packages/nodes-base/nodes/Files/ExtractFromFile/actions/moveTo.operation.ts
+++ b/packages/nodes-base/nodes/Files/ExtractFromFile/actions/moveTo.operation.ts
@@ -4,6 +4,7 @@ import set from 'lodash/set';
 import unset from 'lodash/unset';
 import type {
 	IDataObject,
+	IDataObjectMaybeArray,
 	IExecuteFunctions,
 	INodeExecutionData,
 	INodeProperties,
@@ -90,7 +91,7 @@ export const properties: INodeProperties[] = [
 
 const displayOptions = {
 	show: {
-		operation: ['binaryToPropery', 'fromJson', 'text', 'fromIcs', 'xml'],
+		operation: ['binaryToPropery', 'fromJson', 'fromJsonl', 'text', 'fromIcs', 'xml'],
 	},
 };
 
@@ -125,7 +126,7 @@ export async function execute(
 				newItem.json = deepCopy(item.json);
 			}
 
-			let convertedValue: string | IDataObject;
+			let convertedValue: string | IDataObjectMaybeArray;
 			if (operation !== 'binaryToPropery') {
 				convertedValue = iconv.decode(buffer, encoding, {
 					stripBOM: options.stripBOM as boolean,
@@ -138,7 +139,18 @@ export async function execute(
 				if (convertedValue === '') {
 					convertedValue = {};
 				} else {
-					convertedValue = jsonParse(convertedValue);
+					convertedValue = jsonParse<IDataObject>(convertedValue);
+				}
+			}
+
+			if (operation === 'fromJsonl') {
+				if (convertedValue === '') {
+					convertedValue = [];
+				} else {
+					convertedValue =
+						typeof convertedValue === 'string'
+							? convertedValue.split('\n').map((v: string) => jsonParse<IDataObject>(v))
+							: [];
 				}
 			}
 

--- a/packages/nodes-base/utils/binary.ts
+++ b/packages/nodes-base/utils/binary.ts
@@ -102,11 +102,20 @@ export async function createBinaryFromJson(
 		let valueAsString = value as unknown as string;
 
 		if (typeof value === 'object') {
-			options.mimeType = 'application/json';
-			if (options.format) {
-				valueAsString = JSON.stringify(value, null, 2);
+			options.mimeType = options.mimeType ?? 'application/json';
+
+			if (options.mimeType.indexOf('jsonl') > -1) {
+				if (Array.isArray(value)) {
+					valueAsString = value.map((v) => JSON.stringify(v)).join('\n');
+				} else {
+					valueAsString = JSON.stringify(value);
+				}
 			} else {
-				valueAsString = JSON.stringify(value);
+				if (options.format) {
+					valueAsString = JSON.stringify(value, null, 2);
+				} else {
+					valueAsString = JSON.stringify(value);
+				}
 			}
 		}
 
@@ -132,7 +141,7 @@ export async function createBinaryFromJson(
 }
 
 const parseText = (textContent: PdfTextContent) => {
-	let lastY = undefined;
+	let lastY;
 	const text = [];
 	for (const item of textContent.items) {
 		if ('str' in item) {

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -406,6 +406,8 @@ export interface IDataObject {
 	[key: string]: GenericValue | IDataObject | GenericValue[] | IDataObject[];
 }
 
+export type IDataObjectMaybeArray = IDataObject | IDataObject[];
+
 export type IExecuteResponsePromiseData = IDataObject | IN8nHttpFullResponse;
 
 export interface INodeTypeNameVersion {


### PR DESCRIPTION
## Summary

Enables outputting binary data file as newline-delimited JSONL files (see [jsonlines.org](https://jsonlines.org/)).

Please note that this is created as a proposal. I have need for an easy and convenient method to convert collections of objects to JSONL for data pipeline purposes (e.g. loading JSONL data into BigQuery via Cloud Storage). This PR does not yet read/interpret JSONL files, but it would likely be good if it could!

Additional note: there is no formal IANA/IEFT mime-type for JSONL yet. I've seen a wide variety of different ones used and decided on `application/jsonl` since it is the simplest/most intuitive.

## Related Linear tickets, Github issues, and Community forum posts

- Writing to JSONL: https://community.n8n.io/t/writing-jsonl-to-file/28909
- Reading from JSONL: https://community.n8n.io/t/reading-jsonl-file-from-s3-and-then-parsing-it/28096

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds JSONL output to ConvertToFile and JSONL parsing to ExtractFromFile, with utils updated for JSONL formatting and safer extension derivation from mime types.
> 
> - **Files**:
>   - **ConvertToFile/toJson**: Add `options.jsonl` to output JSONL (`application/jsonl`), bypassing formatting; wire through to binary creation.
>   - **ExtractFromFile**: Add `fromJsonl` operation to parse JSONL (newline-delimited) into items; include in routing/display.
> - **Utils**:
>   - `createBinaryFromJson`: Handle `application/jsonl` (arrays -> newline-delimited, single object -> one line).
>   - Binary helpers: Derive `fileExtension` from `mimeType` when missing via sanitizing regex; minor cleanup in PDF text parsing.
>   - Types: Introduce `IDataObjectMaybeArray` for JSON/JSONL parsing results.
> - **Tests/Workflows**:
>   - Update sample workflow to cover JSONL conversion and extraction paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d12282918c85a26de8a7e2ccd17b169afae6c92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->