### PR TITLE
fix(core): Prevent worker instance from running insights collection

### DIFF
--- a/packages/cli/src/modules/insights/__tests__/insights-collection.service.integration.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights-collection.service.integration.test.ts
@@ -53,6 +53,7 @@ describe('workflowExecuteAfterHandler', () => {
 		insightsCollectionService = Container.get(InsightsCollectionService);
 		insightsRawRepository = Container.get(InsightsRawRepository);
 		insightsMetadataRepository = Container.get(InsightsMetadataRepository);
+		insightsCollectionService.init();
 	});
 
 	let project: Project;
@@ -281,6 +282,7 @@ describe('workflowExecuteAfterHandler - cacheMetadata', () => {
 			Container.get(InsightsConfig),
 			mockLogger(),
 		);
+		insightsCollectionService.init();
 	});
 
 	let project: Project;
@@ -424,6 +426,7 @@ describe('workflowExecuteAfterHandler - flushEvents', () => {
 			Container.get(InsightsConfig),
 			mockLogger(),
 		);
+		insightsCollectionService.init();
 	});
 
 	beforeEach(async () => {
@@ -477,7 +480,7 @@ describe('workflowExecuteAfterHandler - flushEvents', () => {
 		// ARRANGE
 		jest.useFakeTimers();
 		repoMocks.insertInsightsRaw.mockClear();
-		insightsCollectionService.startFlushingTimer();
+		insightsCollectionService.init();
 		const ctx = mock<WorkflowExecuteAfterContext>({ workflow, runData });
 
 		try {
@@ -502,7 +505,7 @@ describe('workflowExecuteAfterHandler - flushEvents', () => {
 		// ARRANGE
 		jest.useFakeTimers();
 		repoMocks.insertInsightsRaw.mockClear();
-		insightsCollectionService.startFlushingTimer();
+		insightsCollectionService.init();
 		const ctx = mock<WorkflowExecuteAfterContext>({ workflow });
 
 		try {
@@ -527,7 +530,7 @@ describe('workflowExecuteAfterHandler - flushEvents', () => {
 		// ARRANGE
 		jest.useFakeTimers();
 		repoMocks.insertInsightsRaw.mockClear();
-		insightsCollectionService.startFlushingTimer();
+		insightsCollectionService.init();
 		const flushEventsSpy = jest.spyOn(insightsCollectionService, 'flushEvents');
 
 		try {
@@ -568,7 +571,7 @@ describe('workflowExecuteAfterHandler - flushEvents', () => {
 	test('flushes events synchronously while shutting down', async () => {
 		// ARRANGE
 		// reset insights async flushing
-		insightsCollectionService.startFlushingTimer();
+		insightsCollectionService.init();
 		repoMocks.insertInsightsRaw.mockClear();
 		const ctx = mock<WorkflowExecuteAfterContext>({ workflow, runData });
 
@@ -601,7 +604,7 @@ describe('workflowExecuteAfterHandler - flushEvents', () => {
 		jest.useFakeTimers();
 		repoMocks.insertInsightsRaw.mockClear();
 		repoMocks.insertInsightsRaw.mockRejectedValueOnce(new Error('Test error'));
-		insightsCollectionService.startFlushingTimer();
+		insightsCollectionService.init();
 		const ctx = mock<WorkflowExecuteAfterContext>({ workflow, runData });
 
 		try {
@@ -630,7 +633,7 @@ describe('workflowExecuteAfterHandler - flushEvents', () => {
 		// ARRANGE
 		const config = Container.get(InsightsConfig);
 		config.flushBatchSize = 10;
-		insightsCollectionService.startFlushingTimer();
+		insightsCollectionService.init();
 		repoMocks.insertInsightsRaw.mockClear();
 
 		const ctx = mock<WorkflowExecuteAfterContext>({ workflow, runData });

--- a/packages/cli/src/modules/insights/__tests__/insights-collection.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights-collection.service.test.ts
@@ -1,0 +1,91 @@
+import { mockLogger } from '@n8n/backend-test-utils';
+import type { SharedWorkflowRepository, IWorkflowDb, WorkflowEntity } from '@n8n/db';
+import type { WorkflowExecuteAfterContext } from '@n8n/decorators';
+import { mock } from 'jest-mock-extended';
+import { DateTime } from 'luxon';
+import type { IRun } from 'n8n-workflow';
+
+import type { InsightsMetadataRepository } from '../database/repositories/insights-metadata.repository';
+import type { InsightsRawRepository } from '../database/repositories/insights-raw.repository';
+import { InsightsCollectionService } from '../insights-collection.service';
+import type { InsightsConfig } from '../insights.config';
+
+describe('initialization safeguards', () => {
+	let insightsCollectionService: InsightsCollectionService;
+	let insightsRawRepository: InsightsRawRepository;
+	let insightsMetadataRepository: InsightsMetadataRepository;
+
+	const workflow = mock<WorkflowEntity & IWorkflowDb>({
+		id: 'workflow-id',
+		name: 'Test Workflow',
+	});
+
+	beforeAll(async () => {
+		insightsRawRepository = mock<InsightsRawRepository>();
+		insightsMetadataRepository = mock<InsightsMetadataRepository>();
+		insightsCollectionService = new InsightsCollectionService(
+			mock<SharedWorkflowRepository>(),
+			insightsRawRepository,
+			insightsMetadataRepository,
+			mock<InsightsConfig>(),
+			mockLogger(),
+		);
+	});
+
+	beforeEach(() => {
+		jest.useFakeTimers();
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	test('does not collect events when not initialized', async () => {
+		// ARRANGE
+		const ctx = mock<WorkflowExecuteAfterContext>({ workflow });
+		const startedAt = DateTime.utc();
+		const stoppedAt = startedAt.plus({ seconds: 5 });
+		ctx.runData = mock<IRun>({
+			mode: 'webhook',
+			status: 'success',
+			startedAt: startedAt.toJSDate(),
+			stoppedAt: stoppedAt.toJSDate(),
+		});
+
+		// ACT - Call handler without init()
+		await insightsCollectionService.handleWorkflowExecuteAfter(ctx);
+		await insightsCollectionService.flushEvents();
+
+		// ASSERT - no insights in the buffer should have been saved
+		expect(insightsMetadataRepository.upsert).not.toHaveBeenCalled();
+		expect(insightsRawRepository.insert).not.toHaveBeenCalled();
+	});
+
+	test('does not flush events when not initialized', async () => {
+		// ARRANGE - manually create some test context
+		const ctx = mock<WorkflowExecuteAfterContext>({ workflow });
+		const startedAt = DateTime.utc();
+		const stoppedAt = startedAt.plus({ seconds: 5 });
+		ctx.runData = mock<IRun>({
+			mode: 'webhook',
+			status: 'success',
+			startedAt: startedAt.toJSDate(),
+			stoppedAt: stoppedAt.toJSDate(),
+		});
+
+		// ACT - Try to flush without initialization
+		await insightsCollectionService.flushEvents();
+
+		// ASSERT - no insights in the buffer should have been saved
+		expect(insightsMetadataRepository.upsert).not.toHaveBeenCalled();
+		expect(insightsRawRepository.insert).not.toHaveBeenCalled();
+	});
+
+	test('does not schedule flushing when not initialized', async () => {
+		// ACT - Try to schedule flushing without initialization
+		insightsCollectionService.scheduleFlushing();
+
+		// ASSERT - setTimeout should not have been called
+		expect(jest.getTimerCount()).toBe(0);
+	});
+});

--- a/packages/cli/src/modules/insights/__tests__/insights-collection.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights-collection.service.test.ts
@@ -74,6 +74,7 @@ describe('initialization safeguards', () => {
 		});
 
 		// ACT - Try to flush without initialization
+		await insightsCollectionService.handleWorkflowExecuteAfter(ctx);
 		await insightsCollectionService.flushEvents();
 
 		// ASSERT - no insights in the buffer should have been saved

--- a/packages/cli/src/modules/insights/__tests__/insights-collection.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights-collection.service.test.ts
@@ -11,6 +11,7 @@ import { mock } from 'jest-mock-extended';
 import { DateTime } from 'luxon';
 import type { IRun } from 'n8n-workflow';
 
+import type { InsightsMetadata } from '../database/entities/insights-metadata';
 import type { InsightsMetadataRepository } from '../database/repositories/insights-metadata.repository';
 import type { InsightsRawRepository } from '../database/repositories/insights-raw.repository';
 import { InsightsCollectionService } from '../insights-collection.service';
@@ -19,7 +20,7 @@ import type { InsightsConfig } from '../insights.config';
 describe('initialization safeguards', () => {
 	let insightsCollectionService: InsightsCollectionService;
 	let insightsRawRepository: InsightsRawRepository;
-	let insightsMetadataRepository: InsightsMetadataRepository;
+	let insightsMetadataRepository: ReturnType<typeof mock<InsightsMetadataRepository>>;
 	let sharedWorkflowRepository: ReturnType<typeof mock<SharedWorkflowRepository>>;
 
 	const workflow = mock<WorkflowEntity & IWorkflowDb>({
@@ -78,6 +79,17 @@ describe('initialization safeguards', () => {
 			startedAt: startedAt.toJSDate(),
 			stoppedAt: stoppedAt.toJSDate(),
 		});
+
+		// simulate events in the buffer
+		insightsCollectionService['bufferedInsights'].add({
+			workflowId: ctx.workflow.id,
+			workflowName: ctx.workflow.name,
+			timestamp: DateTime.utc().toJSDate(),
+			type: 'success',
+			value: 1,
+		});
+
+		// mock shared workflow repository for the flushing process
 		sharedWorkflowRepository.find.mockResolvedValueOnce([
 			mock<SharedWorkflow>({
 				workflow,
@@ -85,12 +97,15 @@ describe('initialization safeguards', () => {
 				role: 'workflow:editor',
 			}),
 		]);
+		// mock insights metadata repository for the flushing process
+		insightsMetadataRepository.findBy.mockResolvedValueOnce([
+			mock<InsightsMetadata>({ workflowId: ctx.workflow.id, metaId: 1 }),
+		]);
 
 		// ACT - Try to flush without initialization
-		await insightsCollectionService.handleWorkflowExecuteAfter(ctx);
 		await insightsCollectionService.flushEvents();
 
-		// ASSERT - no insights in the buffer should have been saved
+		// ASSERT - no insights raw and metadata in the buffer should have been saved
 		expect(insightsMetadataRepository.upsert).not.toHaveBeenCalled();
 		expect(insightsRawRepository.insert).not.toHaveBeenCalled();
 	});

--- a/packages/cli/src/modules/insights/__tests__/insights.module.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.module.test.ts
@@ -1,0 +1,76 @@
+import { LicenseState, Logger } from '@n8n/backend-common';
+import { createTeamProject, mockLogger, testDb } from '@n8n/backend-test-utils';
+import type { InstanceType } from '@n8n/constants';
+import { Container } from '@n8n/di';
+import type { MockProxy } from 'jest-mock-extended';
+import { mock } from 'jest-mock-extended';
+import { InstanceSettings } from 'n8n-core';
+
+import { InsightsModule } from '../insights.module';
+
+describe('InsightsModule', () => {
+	let insightsModule: InsightsModule;
+	let mockInstanceSettings: MockProxy<InstanceSettings>;
+
+	beforeAll(async () => {
+		await testDb.init();
+	});
+
+	afterAll(async () => {
+		await testDb.terminate();
+	});
+
+	beforeEach(async () => {
+		jest.clearAllMocks();
+		await testDb.truncate(['Project']);
+		insightsModule = Container.get(InsightsModule);
+		mockInstanceSettings = mock<InstanceSettings>();
+		Container.set(InstanceSettings, mockInstanceSettings);
+		Container.set(Logger, mockLogger());
+		Container.set(LicenseState, mock<LicenseState>());
+		await createTeamProject();
+	});
+
+	describe('Dynamic conditional import of InsightsCollectionService', () => {
+		it('should not import InsightsCollectionService for worker instances', async () => {
+			// ARRANGE
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+			(mockInstanceSettings as any).instanceType = 'worker';
+
+			// Get the path to InsightsCollectionService
+			const collectionServicePath = require.resolve('../insights-collection.service');
+			expect(collectionServicePath).not.toBeNull();
+
+			// Clear it from cache to ensure a clean test
+			delete require.cache[collectionServicePath];
+
+			// ACT - Call init which should NOT load InsightsCollectionService for workers
+			await insightsModule.init();
+
+			// ASSERT - Module should not be loaded
+			expect(require.cache[collectionServicePath]).toBeUndefined();
+		});
+
+		it.each<InstanceType>(['main', 'webhook'])(
+			'should import InsightsCollectionService for non-worker instances',
+			async (instanceType) => {
+				// ARRANGE
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+				(mockInstanceSettings as any).instanceType = instanceType;
+
+				// Get the path to InsightsCollectionService
+				const collectionServicePath = require.resolve('../insights-collection.service');
+				expect(collectionServicePath).not.toBeNull();
+
+				// Clear it from cache if it's there to ensure a clean test
+				delete require.cache[collectionServicePath];
+
+				// ACT - Call init which should load InsightsCollectionService for non-workers
+				await insightsModule.init();
+
+				// ASSERT - Module should now be loaded
+				expect(require.cache[collectionServicePath]).toBeDefined();
+			},
+		);
+	});
+});

--- a/packages/cli/src/modules/insights/__tests__/insights.module.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.module.test.ts
@@ -44,8 +44,9 @@ describe('InsightsModule', () => {
 			// Clear it from cache to ensure a clean test
 			delete require.cache[collectionServicePath];
 
-			// ACT - Call init which should NOT load InsightsCollectionService for workers
+			// ACT - Call init AND setttings which should NOT load InsightsCollectionService for workers
 			await insightsModule.init();
+			await insightsModule.settings();
 
 			// ASSERT - Module should not be loaded
 			expect(require.cache[collectionServicePath]).toBeUndefined();

--- a/packages/cli/src/modules/insights/__tests__/insights.service.integration.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.integration.test.ts
@@ -84,7 +84,9 @@ describe('InsightsService (Integration)', () => {
 			jest.clearAllMocks();
 		});
 
-		afterEach(() => {
+		afterEach(async () => {
+			// Shutdown the service to clear timers
+			await insightsService.shutdown();
 			// Clean up spies
 			initSpy.mockRestore();
 			shutdownSpy.mockRestore();

--- a/packages/cli/src/modules/insights/__tests__/insights.service.integration.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.integration.test.ts
@@ -6,6 +6,7 @@ import {
 	testDb,
 	testModules,
 } from '@n8n/backend-test-utils';
+import type { InstanceType } from '@n8n/constants';
 import type { IWorkflowDb, Project, WorkflowEntity } from '@n8n/db';
 import type { WorkflowExecuteAfterContext } from '@n8n/decorators';
 import { Container } from '@n8n/di';
@@ -54,13 +55,14 @@ describe('InsightsService (Integration)', () => {
 	describe('startTimers', () => {
 		let insightsService: InsightsService;
 		let compactionService: InsightsCompactionService;
-		let collectionService: InsightsCollectionService;
 		let pruningService: InsightsPruningService;
 		let instanceSettings: MockProxy<InstanceSettings>;
+		let realCollectionService: InsightsCollectionService;
+		let initSpy: jest.SpyInstance;
+		let shutdownSpy: jest.SpyInstance;
 
 		beforeEach(() => {
 			compactionService = mock<InsightsCompactionService>();
-			collectionService = mock<InsightsCollectionService>();
 			pruningService = mock<InsightsPruningService>();
 			instanceSettings = mock<InstanceSettings>({
 				instanceType: 'main',
@@ -68,18 +70,28 @@ describe('InsightsService (Integration)', () => {
 			insightsService = new InsightsService(
 				mock<InsightsByPeriodRepository>(),
 				compactionService,
-				collectionService,
 				pruningService,
 				mock<LicenseState>(),
 				instanceSettings,
 				mockLogger(),
 			);
 
+			// Get the real service from the container and spy on it
+			realCollectionService = Container.get(InsightsCollectionService);
+			initSpy = jest.spyOn(realCollectionService, 'init');
+			shutdownSpy = jest.spyOn(realCollectionService, 'shutdown');
+
 			jest.clearAllMocks();
 		});
 
+		afterEach(() => {
+			// Clean up spies
+			initSpy.mockRestore();
+			shutdownSpy.mockRestore();
+		});
+
 		const setupMocks = (
-			instanceType: string,
+			instanceType: InstanceType,
 			isLeader: boolean = false,
 			isPruningEnabled: boolean = false,
 		) => {
@@ -92,38 +104,52 @@ describe('InsightsService (Integration)', () => {
 			});
 		};
 
-		test('starts flushing timer for main instance', () => {
+		test('starts flushing timer for main instance', async () => {
 			setupMocks('main', false, false);
-			insightsService.startTimers();
 
-			expect(collectionService.startFlushingTimer).toHaveBeenCalled();
+			await insightsService.init();
+
+			expect(initSpy).toHaveBeenCalled();
 			expect(compactionService.startCompactionTimer).not.toHaveBeenCalled();
 			expect(pruningService.startPruningTimer).not.toHaveBeenCalled();
 		});
 
-		test('starts compaction and flushing timers for main leader instances', () => {
+		test('starts compaction and flushing timers for main leader instances', async () => {
 			setupMocks('main', true, false);
-			insightsService.startTimers();
 
-			expect(collectionService.startFlushingTimer).toHaveBeenCalled();
+			await insightsService.init();
+
+			expect(initSpy).toHaveBeenCalled();
 			expect(compactionService.startCompactionTimer).toHaveBeenCalled();
 			expect(pruningService.startPruningTimer).not.toHaveBeenCalled();
 		});
 
-		test('starts compaction, flushing and pruning timers for main leader instance with pruning enabled', () => {
+		test('starts compaction, flushing and pruning timers for main leader instance with pruning enabled', async () => {
 			setupMocks('main', true, true);
-			insightsService.startTimers();
 
-			expect(collectionService.startFlushingTimer).toHaveBeenCalled();
+			await insightsService.init();
+
+			expect(initSpy).toHaveBeenCalled();
 			expect(compactionService.startCompactionTimer).toHaveBeenCalled();
 			expect(pruningService.startPruningTimer).toHaveBeenCalled();
 		});
 
-		test('starts only collection flushing timer for webhook instance', () => {
+		test('starts only collection flushing timer for webhook instance', async () => {
 			setupMocks('webhook', false, false);
-			insightsService.startTimers();
 
-			expect(collectionService.startFlushingTimer).toHaveBeenCalled();
+			await insightsService.init();
+
+			expect(initSpy).toHaveBeenCalled();
+			expect(compactionService.startCompactionTimer).not.toHaveBeenCalled();
+			expect(pruningService.startPruningTimer).not.toHaveBeenCalled();
+		});
+
+		test('do no start any timers for non-main instances', async () => {
+			setupMocks('worker', false, false);
+
+			await insightsService.init();
+
+			expect(initSpy).not.toHaveBeenCalled();
 			expect(compactionService.startCompactionTimer).not.toHaveBeenCalled();
 			expect(pruningService.startPruningTimer).not.toHaveBeenCalled();
 		});
@@ -289,8 +315,6 @@ describe('InsightsService (Integration)', () => {
 				endDate: endDate.toJSDate(),
 				projectId: project.id,
 			});
-
-			console.log(summary);
 
 			// ASSERT
 			expect(summary).toEqual({
@@ -941,121 +965,6 @@ describe('InsightsService (Integration)', () => {
 		});
 	});
 
-	describe('settings', () => {
-		let licenseMock: jest.Mocked<LicenseState>;
-		let insightsService: InsightsService;
-
-		beforeAll(() => {
-			licenseMock = mock<LicenseState>();
-			insightsService = new InsightsService(
-				mock(),
-				mock(),
-				mock(),
-				mock(),
-				licenseMock,
-				mock(),
-				mockLogger(),
-			);
-		});
-
-		test('returns correct summary and dashboard licenses', () => {
-			licenseMock.isInsightsSummaryLicensed.mockReturnValue(true);
-			licenseMock.isInsightsDashboardLicensed.mockReturnValue(true);
-
-			const result = insightsService.settings();
-
-			expect(result.summary).toBe(true);
-			expect(result.dashboard).toBe(true);
-		});
-
-		describe('dateRanges', () => {
-			test('returns correct ranges when hourly data is enabled and max history is unlimited', () => {
-				licenseMock.getInsightsMaxHistory.mockReturnValue(-1);
-				licenseMock.isInsightsHourlyDataLicensed.mockReturnValue(true);
-
-				const result = insightsService.settings();
-
-				expect(result.dateRanges).toEqual([
-					{ key: 'day', licensed: true, granularity: 'hour' },
-					{ key: 'week', licensed: true, granularity: 'day' },
-					{ key: '2weeks', licensed: true, granularity: 'day' },
-					{ key: 'month', licensed: true, granularity: 'day' },
-					{ key: 'quarter', licensed: true, granularity: 'week' },
-					{ key: '6months', licensed: true, granularity: 'week' },
-					{ key: 'year', licensed: true, granularity: 'week' },
-				]);
-			});
-
-			test('returns correct ranges when hourly data is enabled and max history is 365 days', () => {
-				licenseMock.getInsightsMaxHistory.mockReturnValue(365);
-				licenseMock.isInsightsHourlyDataLicensed.mockReturnValue(true);
-
-				const result = insightsService.settings();
-
-				expect(result.dateRanges).toEqual([
-					{ key: 'day', licensed: true, granularity: 'hour' },
-					{ key: 'week', licensed: true, granularity: 'day' },
-					{ key: '2weeks', licensed: true, granularity: 'day' },
-					{ key: 'month', licensed: true, granularity: 'day' },
-					{ key: 'quarter', licensed: true, granularity: 'week' },
-					{ key: '6months', licensed: true, granularity: 'week' },
-					{ key: 'year', licensed: true, granularity: 'week' },
-				]);
-			});
-
-			test('returns correct ranges when hourly data is disabled and max history is 30 days', () => {
-				licenseMock.getInsightsMaxHistory.mockReturnValue(30);
-				licenseMock.isInsightsHourlyDataLicensed.mockReturnValue(false);
-
-				const result = insightsService.settings();
-
-				expect(result.dateRanges).toEqual([
-					{ key: 'day', licensed: false, granularity: 'hour' },
-					{ key: 'week', licensed: true, granularity: 'day' },
-					{ key: '2weeks', licensed: true, granularity: 'day' },
-					{ key: 'month', licensed: true, granularity: 'day' },
-					{ key: 'quarter', licensed: false, granularity: 'week' },
-					{ key: '6months', licensed: false, granularity: 'week' },
-					{ key: 'year', licensed: false, granularity: 'week' },
-				]);
-			});
-
-			test('returns correct ranges when max history is less than 7 days', () => {
-				licenseMock.getInsightsMaxHistory.mockReturnValue(5);
-				licenseMock.isInsightsHourlyDataLicensed.mockReturnValue(false);
-
-				const result = insightsService.settings();
-
-				expect(result.dateRanges).toEqual([
-					{ key: 'day', licensed: false, granularity: 'hour' },
-					{ key: 'week', licensed: false, granularity: 'day' },
-					{ key: '2weeks', licensed: false, granularity: 'day' },
-					{ key: 'month', licensed: false, granularity: 'day' },
-					{ key: 'quarter', licensed: false, granularity: 'week' },
-					{ key: '6months', licensed: false, granularity: 'week' },
-					{ key: 'year', licensed: false, granularity: 'week' },
-				]);
-			});
-
-			test('returns correct ranges when max history is 90 days and hourly data is enabled', () => {
-				licenseMock.getInsightsMaxHistory.mockReturnValue(90);
-				licenseMock.isInsightsHourlyDataLicensed.mockReturnValue(true);
-
-				const result = insightsService.settings();
-
-				expect(result.dateRanges).toEqual([
-					{ key: 'day', licensed: true, granularity: 'hour' },
-					{ key: 'week', licensed: true, granularity: 'day' },
-					{ key: '2weeks', licensed: true, granularity: 'day' },
-					{ key: 'month', licensed: true, granularity: 'day' },
-					{ key: 'quarter', licensed: true, granularity: 'week' },
-					{ key: '6months', licensed: false, granularity: 'week' },
-					{ key: 'year', licensed: false, granularity: 'week' },
-				]);
-			});
-		});
-	});
-
 	describe('validateDateFiltersLicense', () => {
 		let licenseStateMock: jest.Mocked<LicenseState>;
 		let insightsService: InsightsService;
@@ -1065,7 +974,6 @@ describe('InsightsService (Integration)', () => {
 			insightsService = new InsightsService(
 				mock<InsightsByPeriodRepository>(),
 				mock<InsightsCompactionService>(),
-				mock<InsightsCollectionService>(),
 				mock<InsightsPruningService>(),
 				licenseStateMock,
 				mock<InstanceSettings>(),
@@ -1161,11 +1069,6 @@ describe('InsightsService (Integration)', () => {
 	describe('shutdown', () => {
 		let insightsService: InsightsService;
 
-		const mockCollectionService = mock<InsightsCollectionService>({
-			shutdown: jest.fn().mockResolvedValue(undefined),
-			stopFlushingTimer: jest.fn(),
-		});
-
 		const mockCompactionService = mock<InsightsCompactionService>({
 			stopCompactionTimer: jest.fn(),
 		});
@@ -1178,7 +1081,6 @@ describe('InsightsService (Integration)', () => {
 			insightsService = new InsightsService(
 				mock<InsightsByPeriodRepository>(),
 				mockCompactionService,
-				mockCollectionService,
 				mockPruningService,
 				mock<LicenseState>(),
 				mock<InstanceSettings>(),
@@ -1187,11 +1089,16 @@ describe('InsightsService (Integration)', () => {
 		});
 
 		test('shutdown stops timers and shuts down services', async () => {
+			// ARRANGE
+			// Get the real service from the container and spy on it
+			const realCollectionService = Container.get(InsightsCollectionService);
+			const shutdownSpy = jest.spyOn(realCollectionService, 'shutdown');
+
 			// ACT
 			await insightsService.shutdown();
 
 			// ASSERT
-			expect(mockCollectionService.shutdown).toHaveBeenCalled();
+			expect(shutdownSpy).toHaveBeenCalled();
 			expect(mockCompactionService.stopCompactionTimer).toHaveBeenCalled();
 			expect(mockPruningService.stopPruningTimer).toHaveBeenCalled();
 		});

--- a/packages/cli/src/modules/insights/__tests__/insights.service.integration.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.integration.test.ts
@@ -1085,7 +1085,7 @@ describe('InsightsService (Integration)', () => {
 				mockCompactionService,
 				mockPruningService,
 				mock<LicenseState>(),
-				mock<InstanceSettings>(),
+				mock<InstanceSettings>({ instanceType: 'main' }),
 				mockLogger(),
 			);
 		});

--- a/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.test.ts
@@ -6,7 +6,6 @@ import type { InstanceSettings } from 'n8n-core';
 
 import { TypeToNumber } from '../database/entities/insights-shared';
 import type { InsightsByPeriodRepository } from '../database/repositories/insights-by-period.repository';
-import type { InsightsCollectionService } from '../insights-collection.service';
 import type { InsightsCompactionService } from '../insights-compaction.service';
 import type { InsightsPruningService } from '../insights-pruning.service';
 import { InsightsService } from '../insights.service';
@@ -16,7 +15,6 @@ describe('InsightsService', () => {
 
 	let mockInsightsByPeriodRepository: MockProxy<InsightsByPeriodRepository>;
 	let mockCompactionService: MockProxy<InsightsCompactionService>;
-	let mockCollectionService: MockProxy<InsightsCollectionService>;
 	let mockPruningService: MockProxy<InsightsPruningService>;
 	let mockLicenseState: MockProxy<LicenseState>;
 	let mockInstanceSettings: MockProxy<InstanceSettings>;
@@ -26,7 +24,6 @@ describe('InsightsService', () => {
 
 		mockInsightsByPeriodRepository = mock<InsightsByPeriodRepository>();
 		mockCompactionService = mock<InsightsCompactionService>();
-		mockCollectionService = mock<InsightsCollectionService>();
 		mockPruningService = mock<InsightsPruningService>();
 		mockLicenseState = mock<LicenseState>();
 		mockInstanceSettings = mock<InstanceSettings>();
@@ -34,7 +31,6 @@ describe('InsightsService', () => {
 		insightsService = new InsightsService(
 			mockInsightsByPeriodRepository,
 			mockCompactionService,
-			mockCollectionService,
 			mockPruningService,
 			mockLicenseState,
 			mockInstanceSettings,

--- a/packages/cli/src/modules/insights/__tests__/insights.settings.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.settings.test.ts
@@ -1,0 +1,111 @@
+import type { LicenseState } from '@n8n/backend-common';
+import { mock } from 'jest-mock-extended';
+
+import { InsightsSettings } from '../insights.settings';
+
+describe('InsightsSettings', () => {
+	let licenseMock: jest.Mocked<LicenseState>;
+	let insightsSettings: InsightsSettings;
+
+	beforeAll(() => {
+		licenseMock = mock<LicenseState>();
+		insightsSettings = new InsightsSettings(licenseMock);
+	});
+
+	test('returns correct summary and dashboard licenses', () => {
+		licenseMock.isInsightsSummaryLicensed.mockReturnValue(true);
+		licenseMock.isInsightsDashboardLicensed.mockReturnValue(true);
+
+		const result = insightsSettings.settings();
+
+		expect(result.summary).toBe(true);
+		expect(result.dashboard).toBe(true);
+	});
+
+	describe('dateRanges', () => {
+		test('returns correct ranges when hourly data is enabled and max history is unlimited', () => {
+			licenseMock.getInsightsMaxHistory.mockReturnValue(-1);
+			licenseMock.isInsightsHourlyDataLicensed.mockReturnValue(true);
+
+			const result = insightsSettings.settings();
+
+			expect(result.dateRanges).toEqual([
+				{ key: 'day', licensed: true, granularity: 'hour' },
+				{ key: 'week', licensed: true, granularity: 'day' },
+				{ key: '2weeks', licensed: true, granularity: 'day' },
+				{ key: 'month', licensed: true, granularity: 'day' },
+				{ key: 'quarter', licensed: true, granularity: 'week' },
+				{ key: '6months', licensed: true, granularity: 'week' },
+				{ key: 'year', licensed: true, granularity: 'week' },
+			]);
+		});
+
+		test('returns correct ranges when hourly data is enabled and max history is 365 days', () => {
+			licenseMock.getInsightsMaxHistory.mockReturnValue(365);
+			licenseMock.isInsightsHourlyDataLicensed.mockReturnValue(true);
+
+			const result = insightsSettings.settings();
+
+			expect(result.dateRanges).toEqual([
+				{ key: 'day', licensed: true, granularity: 'hour' },
+				{ key: 'week', licensed: true, granularity: 'day' },
+				{ key: '2weeks', licensed: true, granularity: 'day' },
+				{ key: 'month', licensed: true, granularity: 'day' },
+				{ key: 'quarter', licensed: true, granularity: 'week' },
+				{ key: '6months', licensed: true, granularity: 'week' },
+				{ key: 'year', licensed: true, granularity: 'week' },
+			]);
+		});
+
+		test('returns correct ranges when hourly data is disabled and max history is 30 days', () => {
+			licenseMock.getInsightsMaxHistory.mockReturnValue(30);
+			licenseMock.isInsightsHourlyDataLicensed.mockReturnValue(false);
+
+			const result = insightsSettings.settings();
+
+			expect(result.dateRanges).toEqual([
+				{ key: 'day', licensed: false, granularity: 'hour' },
+				{ key: 'week', licensed: true, granularity: 'day' },
+				{ key: '2weeks', licensed: true, granularity: 'day' },
+				{ key: 'month', licensed: true, granularity: 'day' },
+				{ key: 'quarter', licensed: false, granularity: 'week' },
+				{ key: '6months', licensed: false, granularity: 'week' },
+				{ key: 'year', licensed: false, granularity: 'week' },
+			]);
+		});
+
+		test('returns correct ranges when max history is less than 7 days', () => {
+			licenseMock.getInsightsMaxHistory.mockReturnValue(5);
+			licenseMock.isInsightsHourlyDataLicensed.mockReturnValue(false);
+
+			const result = insightsSettings.settings();
+
+			expect(result.dateRanges).toEqual([
+				{ key: 'day', licensed: false, granularity: 'hour' },
+				{ key: 'week', licensed: false, granularity: 'day' },
+				{ key: '2weeks', licensed: false, granularity: 'day' },
+				{ key: 'month', licensed: false, granularity: 'day' },
+				{ key: 'quarter', licensed: false, granularity: 'week' },
+				{ key: '6months', licensed: false, granularity: 'week' },
+				{ key: 'year', licensed: false, granularity: 'week' },
+			]);
+		});
+
+		test('returns correct ranges when max history is 90 days and hourly data is enabled', () => {
+			licenseMock.getInsightsMaxHistory.mockReturnValue(90);
+			licenseMock.isInsightsHourlyDataLicensed.mockReturnValue(true);
+
+			const result = insightsSettings.settings();
+
+			expect(result.dateRanges).toEqual([
+				{ key: 'day', licensed: true, granularity: 'hour' },
+				{ key: 'week', licensed: true, granularity: 'day' },
+				{ key: '2weeks', licensed: true, granularity: 'day' },
+				{ key: 'month', licensed: true, granularity: 'day' },
+				{ key: 'quarter', licensed: true, granularity: 'week' },
+				{ key: '6months', licensed: false, granularity: 'week' },
+				{ key: 'year', licensed: false, granularity: 'week' },
+			]);
+		});
+	});
+});

--- a/packages/cli/src/modules/insights/insights-collection.service.ts
+++ b/packages/cli/src/modules/insights/insights-collection.service.ts
@@ -125,6 +125,8 @@ export class InsightsCollectionService {
 		// Flush any remaining events
 		this.logger.debug('Flushing remaining insights before shutdown');
 		await Promise.all([...this.flushesInProgress, this.flushEvents()]);
+
+		this.isInitialized = false;
 	}
 
 	@OnLifecycleEvent('workflowExecuteAfter')

--- a/packages/cli/src/modules/insights/insights.module.ts
+++ b/packages/cli/src/modules/insights/insights.module.ts
@@ -15,7 +15,7 @@ export class InsightsModule implements ModuleInterface {
 		await import('./insights.controller');
 
 		const { InsightsService } = await import('./insights.service');
-		Container.get(InsightsService).startTimers();
+		await Container.get(InsightsService).init();
 	}
 
 	async entities() {
@@ -27,9 +27,9 @@ export class InsightsModule implements ModuleInterface {
 	}
 
 	async settings() {
-		const { InsightsService } = await import('./insights.service');
+		const { InsightsSettings } = await import('./insights.settings');
 
-		return Container.get(InsightsService).settings();
+		return Container.get(InsightsSettings).settings();
 	}
 
 	@OnShutdown()

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -1,7 +1,7 @@
 import { type InsightsSummary } from '@n8n/api-types';
 import { LicenseState, Logger } from '@n8n/backend-common';
 import { OnLeaderStepdown, OnLeaderTakeover } from '@n8n/decorators';
-import { Service } from '@n8n/di';
+import { Container, Service } from '@n8n/di';
 import { DateTime } from 'luxon';
 import { InstanceSettings } from 'n8n-core';
 import { UserError } from 'n8n-workflow';
@@ -9,17 +9,14 @@ import { UserError } from 'n8n-workflow';
 import type { PeriodUnit, TypeUnit } from './database/entities/insights-shared';
 import { NumberToType, TypeToNumber } from './database/entities/insights-shared';
 import { InsightsByPeriodRepository } from './database/repositories/insights-by-period.repository';
-import { InsightsCollectionService } from './insights-collection.service';
 import { InsightsCompactionService } from './insights-compaction.service';
 import { InsightsPruningService } from './insights-pruning.service';
-import { INSIGHTS_DATE_RANGE_KEYS, keyRangeToDays } from './insights.constants';
 
 @Service()
 export class InsightsService {
 	constructor(
 		private readonly insightsByPeriodRepository: InsightsByPeriodRepository,
 		private readonly compactionService: InsightsCompactionService,
-		private readonly collectionService: InsightsCollectionService,
 		private readonly pruningService: InsightsPruningService,
 		private readonly licenseState: LicenseState,
 		private readonly instanceSettings: InstanceSettings,
@@ -28,16 +25,22 @@ export class InsightsService {
 		this.logger = this.logger.scoped('insights');
 	}
 
-	settings() {
-		return {
-			summary: this.licenseState.isInsightsSummaryLicensed(),
-			dashboard: this.licenseState.isInsightsDashboardLicensed(),
-			dateRanges: this.getAvailableDateRanges(),
-		};
+	private async toggleCollectionService(enable: boolean) {
+		if (this.instanceSettings.instanceType === 'worker') {
+			return;
+		}
+
+		const { InsightsCollectionService } = await import('./insights-collection.service');
+		const collectionService = Container.get(InsightsCollectionService);
+		if (enable) {
+			collectionService.init();
+		} else {
+			await collectionService.shutdown();
+		}
 	}
 
-	startTimers() {
-		this.collectionService.startFlushingTimer();
+	async init() {
+		await this.toggleCollectionService(true);
 
 		if (this.instanceSettings.isLeader) this.startCompactionAndPruningTimers();
 	}
@@ -57,7 +60,7 @@ export class InsightsService {
 	}
 
 	async shutdown() {
-		await this.collectionService.shutdown();
+		await this.toggleCollectionService(false);
 		this.stopCompactionAndPruningTimers();
 	}
 
@@ -282,25 +285,4 @@ export class InsightsService {
 
 		return 'week';
 	}
-
-	private getAvailableDateRanges(): DateRange[] {
-		const maxHistoryInDays =
-			this.licenseState.getInsightsMaxHistory() === -1
-				? Number.MAX_SAFE_INTEGER
-				: this.licenseState.getInsightsMaxHistory();
-		const isHourlyDateLicensed = this.licenseState.isInsightsHourlyDataLicensed();
-
-		return INSIGHTS_DATE_RANGE_KEYS.map((key) => ({
-			key,
-			licensed:
-				key === 'day' ? (isHourlyDateLicensed ?? false) : maxHistoryInDays >= keyRangeToDays[key],
-			granularity: key === 'day' ? 'hour' : keyRangeToDays[key] <= 30 ? 'day' : 'week',
-		}));
-	}
 }
-
-type DateRange = {
-	key: 'day' | 'week' | '2weeks' | 'month' | 'quarter' | '6months' | 'year';
-	licensed: boolean;
-	granularity: 'hour' | 'day' | 'week';
-};

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -26,7 +26,11 @@ export class InsightsService {
 	}
 
 	private async toggleCollectionService(enable: boolean) {
-		if (this.instanceSettings.instanceType === 'worker') {
+		if (
+			this.instanceSettings.instanceType !== 'main' &&
+			this.instanceSettings.instanceType !== 'webhook'
+		) {
+			this.logger.debug('Instance is not main or webhook, skipping collection');
 			return;
 		}
 

--- a/packages/cli/src/modules/insights/insights.settings.ts
+++ b/packages/cli/src/modules/insights/insights.settings.ts
@@ -1,0 +1,38 @@
+import { LicenseState } from '@n8n/backend-common';
+import { Service } from '@n8n/di';
+
+import { INSIGHTS_DATE_RANGE_KEYS, keyRangeToDays } from './insights.constants';
+
+@Service()
+export class InsightsSettings {
+	constructor(private readonly licenseState: LicenseState) {}
+
+	settings() {
+		return {
+			summary: this.licenseState.isInsightsSummaryLicensed(),
+			dashboard: this.licenseState.isInsightsDashboardLicensed(),
+			dateRanges: this.getAvailableDateRanges(),
+		};
+	}
+
+	private getAvailableDateRanges(): DateRange[] {
+		const maxHistoryInDays =
+			this.licenseState.getInsightsMaxHistory() === -1
+				? Number.MAX_SAFE_INTEGER
+				: this.licenseState.getInsightsMaxHistory();
+		const isHourlyDateLicensed = this.licenseState.isInsightsHourlyDataLicensed();
+
+		return INSIGHTS_DATE_RANGE_KEYS.map((key) => ({
+			key,
+			licensed:
+				key === 'day' ? (isHourlyDateLicensed ?? false) : maxHistoryInDays >= keyRangeToDays[key],
+			granularity: key === 'day' ? 'hour' : keyRangeToDays[key] <= 30 ? 'day' : 'week',
+		}));
+	}
+}
+
+type DateRange = {
+	key: 'day' | 'week' | '2weeks' | 'month' | 'quarter' | '6months' | 'year';
+	licensed: boolean;
+	granularity: 'hour' | 'day' | 'week';
+};


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

### The Issue

Root Cause: Worker instances were inadvertently collecting and persisting insights data, causing inflated counts:
- Lazy Service Instantiation: When the insights module's settings() method was called on module registry init, i[t would instantiate InsightsService](http://github.com/n8n-io/n8n/blob/master/packages/cli/src/modules/insights/insights.module.ts#L30), which in turn would instantiate InsightsCollectionService via dependency injection - even on worker instances.
- The @OnLifecycleEvent('workflowExecuteAfter') decorator InsightsCollectionService was being triggered even for workers.
- Once instantiated on a worker: the collection service would start buffering events from workflow executions. When the buffer reached flushBatchSize, [it would automatically trigger flushEvents()](https://github.com/n8n-io/n8n/blob/master/packages/cli/src/modules/insights/insights-collection.service.ts#L177), which in turn triggered regular scheduled flushes 

This resulted in duplicate data being written to the database from both main/webhook instances AND workers once the buffer start being full.

### Key Changes 
This PR introduces architectural improvements to the Insights module to prevent worker instances from unnecessarily loading the insights collection functionality, addressing a bug where insights counts could be inflated due to workers collecting duplicate data.

1. Extracted Settings into Dedicated Service
Created new InsightsSettings service to handle license-based settings calculation
Moved settings logic out of InsightsService for better separation of concerns and more granular imports

2. Conditional Dynamic Import of Collection Service
Modified InsightsModule to conditionally import InsightsCollectionService only for non-worker instances (main/webhook)
Prevents worker instances from loading unnecessary collection code and inadvertently collecting insights

3. Added Initialization Safeguards
Added isInitialized flag to InsightsCollectionService
Added safeguards in:
handleWorkflowExecuteAfter() - prevents event collection when not initialized
flushEvents() - prevents flushing when not initialized
scheduleFlushing() - prevents timer scheduling when not initialized

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-3838/bug-insights-count-larger-than-executions-volume

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents workers from collecting insights by conditionally enabling collection only on main/webhook and adding initialization safeguards, while extracting license-based settings into a dedicated service.
> 
> - **Backend/Architecture**
>   - `InsightsCollectionService`: Add `isInitialized` flag and guards in `handleWorkflowExecuteAfter()`, `flushEvents()`, and `scheduleFlushing()`; replace `startFlushingTimer()` with `init()`; update `shutdown()`.
>   - `InsightsService`: Dynamically enable/disable collection via import based on `InstanceSettings`; new `init()`/`shutdown()` flow; leader-only compaction/pruning timers.
>   - `InsightsModule`: Load collection only for non-worker instances; `settings()` now uses new `InsightsSettings` service.
>   - New `InsightsSettings` service for license-based settings.
> - **Tests**
>   - Add tests for initialization safeguards and conditional module import.
>   - Update integration/unit tests to use `init()` and spy on real collection service.
>   - Add tests for `InsightsSettings`; remove settings tests from `InsightsService`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b429aadebd68a63ab44adc310ad8f4d43c35e71. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->