### PR TITLE
fix: Changes The heading title for the “Overview” page to "All resources"

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
       "chokidar": "4.0.3",
       "esbuild": "^0.25.0",
       "multer": "^2.0.2",
-      "ts-essentials": "10.0.2",
       "prebuild-install": "7.1.3",
       "pug": "^3.0.3",
       "semver": "^7.5.4",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
       "chokidar": "4.0.3",
       "esbuild": "^0.25.0",
       "multer": "^2.0.2",
+      "ts-essentials": "10.0.2",
       "prebuild-install": "7.1.3",
       "pug": "^3.0.3",
       "semver": "^7.5.4",

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -2908,7 +2908,7 @@
 	"workflowSettings.timezone": "Timezone",
 	"workflowSettings.timeSavedPerExecution": "Estimated time saved",
 	"workflowSettings.timeSavedPerExecution.hint": "Minutes per production execution",
-	"workflowSettings.timeSavedPerExecution.tooltip": "Total time savings are summarised in the Overview page.",
+	"workflowSettings.timeSavedPerExecution.tooltip": "Total time savings are summarised in the All resources page.",
 	"workflowSettings.availableInMCP": "Available in MCP",
 	"workflowSettings.availableInMCP.tooltip": "Make this workflow visible to AI Agents through n8n MCP",
 	"workflowSettings.toggleMCP.error.title": "Error updating MCP settings",

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -3350,7 +3350,7 @@
 	"projects.create": "Create",
 	"projects.create.personal": "Create in personal",
 	"projects.create.team": "Create in project",
-	"projects.menu.overview": "Overview",
+	"projects.menu.overview": "All resources",
 	"projects.menu.shared": "Shared with you",
 	"projects.menu.title": "Projects",
 	"projects.menu.personal": "Personal",

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectHeader.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectHeader.test.ts
@@ -137,7 +137,7 @@ describe('ProjectHeader', () => {
 
 		await rerender({});
 
-		expect(getByTestId('project-name')).toHaveTextContent('Overview');
+		expect(getByTestId('project-name')).toHaveTextContent('All resources');
 		expect(getByTestId('project-subtitle')).toHaveTextContent(overviewSubtitle);
 	});
 


### PR DESCRIPTION
## Summary

This PR refers to the issue Translation issue #21632.

Changes The heading title for the “Overview” page to "All resources" and do the same in ProjectHeader.test.ts to make sure correct title is returned while testing.

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Rename “Overview” to “All resources” across UI strings and tests, and update a tooltip reference accordingly.
> 
> - **UI copy/i18n**:
>   - Update `projects.menu.overview` label from `"Overview"` to `"All resources"` in `packages/frontend/@n8n/i18n/src/locales/en.json`.
>   - Change `workflowSettings.timeSavedPerExecution.tooltip` to reference the “All resources” page instead of “Overview”.
> - **Tests**:
>   - Adjust `ProjectHeader` overview title expectation from `"Overview"` to `"All resources"` in `editor-ui/src/features/collaboration/projects/components/ProjectHeader.test.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72540a7b8c534cc61a9d169230a2ed531aa85353. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->