### PR TITLE
fix(core): Add fileno() support to Python runner stderr capture

### DIFF
--- a/packages/@n8n/task-runner-python/src/task_executor.py
+++ b/packages/@n8n/task-runner-python/src/task_executor.py
@@ -50,6 +50,21 @@ MAX_PRINT_ARGS_ALLOWED = 100
 type PipeConnection = Connection
 
 
+class StringIOWithFileno(io.StringIO):
+    """
+    StringIO subclass that provides a fileno() method to prevent errors
+    when external libraries (e.g., database drivers, Prisma) attempt to
+    call fileno() on sys.stderr.
+
+    Returns stderr's file descriptor (2) to maintain compatibility with
+    code expecting a real file-like object with a file descriptor.
+    """
+
+    def fileno(self) -> int:
+        """Return stderr's file descriptor."""
+        return 2
+
+
 class TaskExecutor:
     """Responsible for executing Python code tasks in isolated subprocesses."""
 
@@ -195,7 +210,7 @@ class TaskExecutor:
         TaskExecutor._sanitize_sys_modules(security_config)
 
         print_args: PrintArgs = []
-        sys.stderr = stderr_capture = io.StringIO()
+        sys.stderr = stderr_capture = StringIOWithFileno()
 
         try:
             wrapped_code = TaskExecutor._wrap_code(raw_code)
@@ -232,7 +247,7 @@ class TaskExecutor:
         TaskExecutor._sanitize_sys_modules(security_config)
 
         print_args: PrintArgs = []
-        sys.stderr = stderr_capture = io.StringIO()
+        sys.stderr = stderr_capture = StringIOWithFileno()
 
         try:
             wrapped_code = TaskExecutor._wrap_code(raw_code)

--- a/packages/@n8n/task-runner-python/tests/unit/test_task_executor.py
+++ b/packages/@n8n/task-runner-python/tests/unit/test_task_executor.py
@@ -2,7 +2,7 @@ import pytest
 import json
 from unittest.mock import MagicMock, patch
 
-from src.task_executor import TaskExecutor
+from src.task_executor import TaskExecutor, StringIOWithFileno
 from src.pipe_reader import PipeReader
 from src.errors import TaskCancelledError, TaskKilledError, TaskSubprocessFailedError
 from src.constants import SIGTERM_EXIT_CODE, SIGKILL_EXIT_CODE, PIPE_MSG_PREFIX_LENGTH
@@ -202,3 +202,45 @@ class TestTaskExecutorLowLevelIO:
 
         with pytest.raises(OSError, match="Write failed"):
             TaskExecutor._write_bytes(999, b"test data")
+
+
+class TestStringIOWithFileno:
+    """Tests for StringIOWithFileno class to ensure fileno() method compatibility."""
+
+    def test_fileno_returns_stderr_file_descriptor(self):
+        """Verify that fileno() returns stderr's file descriptor (2)."""
+        string_io = StringIOWithFileno()
+
+        # Should return 2 (stderr's file descriptor)
+        assert string_io.fileno() == 2
+
+    def test_stringio_functionality_preserved(self):
+        """Verify that StringIO functionality is not affected."""
+        string_io = StringIOWithFileno()
+
+        # Write and read should work normally
+        string_io.write("test error message")
+        result = string_io.getvalue()
+
+        assert result == "test error message"
+
+    def test_compatible_with_libraries_expecting_fileno(self):
+        """Verify compatibility with code that calls fileno() on stderr."""
+        import sys
+        original_stderr = sys.stderr
+
+        try:
+            # Replace stderr with StringIOWithFileno
+            sys.stderr = StringIOWithFileno()
+
+            # Code that calls fileno() should not raise
+            try:
+                fd = sys.stderr.fileno()
+                assert fd == 2
+            except AttributeError:
+                pytest.fail("fileno() should not raise AttributeError")
+            except OSError:
+                pytest.fail("fileno() should not raise OSError")
+        finally:
+            # Restore original stderr
+            sys.stderr = original_stderr


### PR DESCRIPTION
## Summary
Fixes compatibility issues with database libraries (Prisma, psycopg2, SQLAlchemy) and other external packages that call `fileno()` on `sys.stderr`.

## Problem
The Python task runner replaces `sys.stderr` with `io.StringIO()` to capture error output. However, `StringIO` does not implement the `fileno()` method, causing `OSError: fileno` when libraries attempt to access the file descriptor.

This breaks compatibility with:
- Prisma (Python ORM)
- psycopg2 (PostgreSQL driver)
- SQLAlchemy (certain backends)
- asyncio subprocess operations
- Various logging frameworks that check for TTY

## Solution
Created `StringIOWithFileno` class that extends `io.StringIO` and implements `fileno()` to return stderr's file descriptor (2). This maintains full compatibility with external libraries while preserving error capture functionality.

## Changes
- **Added `StringIOWithFileno` class** with `fileno()` method returning file descriptor 2
- **Updated both execution modes** (`_all_items` and `_per_item`) to use `StringIOWithFileno`
- **Added comprehensive unit tests** verifying:
  - `fileno()` returns correct file descriptor
  - StringIO functionality (write/read) is preserved
  - Compatibility with libraries expecting `fileno()`

## Testing
- Added 3 new unit tests in `test_task_executor.py`
- All tests verify the class works correctly and maintains backward compatibility
- Existing tests continue to pass

## Related Issue
Fixes #21304

---

**Note**: This is a minimal, focused fix that solves the reported issue without introducing breaking changes or modifying the error capture behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `StringIOWithFileno` to provide `fileno()` on `sys.stderr` and update task execution paths to use it, with new unit tests.
> 
> - **Python Runner**:
>   - Add `StringIOWithFileno` subclass implementing `fileno()` returning `2`.
>   - Replace `io.StringIO` with `StringIOWithFileno` for `sys.stderr` in `TaskExecutor._all_items` and `_per_item`.
> - **Tests**:
>   - Add unit tests validating `fileno()` behavior, preserved `StringIO` functionality, and compatibility with code expecting `fileno()`.
>   - Update test imports accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4221ea370f40e2e737976529b30eb5eb642130db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->