### PR TITLE
fix the problem that axios don't use the http proxy #21199

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helper-functions.ts
@@ -268,6 +268,16 @@ export async function invokeAxios(
 	axiosConfig: AxiosRequestConfig,
 	authOptions: IRequestOptions['auth'] = {},
 ) {
+	// axios not apply the http.globalAgent, need set it manually
+	const url = process.env.HTTP_PROXY ?? process.env.HTTPS_PROXY ?? process.env.ALL_PROXY;
+	if (url) {
+		const parsedUrl = new URL(url);
+		axiosConfig.proxy = {
+			host: parsedUrl.hostname,
+			port: parseInt(parsedUrl.port) || (parsedUrl.protocol === 'https:' ? 443 : 80),
+			protocol: parsedUrl.protocol.replace(':', ''),
+		};
+	}
 	try {
 		return await axios(axiosConfig);
 	} catch (error) {


### PR DESCRIPTION
# problem
The function `invokeAxiosdoes` do not use the global proxy configured in `installGlobalProxyAgent`.

# issue
https://github.com/n8n-io/n8n/issues/21199

# fix
I have set it in axios's config manually instead.

# result
Now the request can be successfully routed through the proxy.
<img width="404" height="89" alt="image" src="https://github.com/user-attachments/assets/a99767e0-c2ab-4dbe-b0c4-73fa76535e2b" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure axios requests respect HTTP_PROXY/HTTPS_PROXY/ALL_PROXY by mapping env vars to `axiosConfig.proxy` in `invokeAxios`.
> 
> - **Core HTTP requests**:
>   - Map `HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY` env vars to `axiosConfig.proxy` inside `invokeAxios` so axios routes requests via the configured proxy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 496a43e02bee98d334d260ac4e35af9eddff57f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->