### PR TITLE
fix: resolve build warnings and improve telemetry error handling

### DIFF
--- a/packages/cli/src/posthog/index.ts
+++ b/packages/cli/src/posthog/index.ts
@@ -43,14 +43,20 @@ export class PostHogClient {
 	async getFeatureFlags(user: Pick<PublicUser, 'id' | 'createdAt'>): Promise<FeatureFlags> {
 		if (!this.postHog) return {};
 
-		const fullId = [this.instanceSettings.instanceId, user.id].join('#');
+		try {
+			const fullId = [this.instanceSettings.instanceId, user.id].join('#');
 
-		// cannot use local evaluation because that requires PostHog personal api key with org-wide
-		// https://github.com/PostHog/posthog/issues/4849
-		return await this.postHog.getAllFlags(fullId, {
-			personProperties: {
-				created_at_timestamp: user.createdAt.getTime().toString(),
-			},
-		});
+			// cannot use local evaluation because that requires PostHog personal api key with org-wide
+			// https://github.com/PostHog/posthog/issues/4849
+			return await this.postHog.getAllFlags(fullId, {
+				personProperties: {
+					created_at_timestamp: user.createdAt.getTime().toString(),
+				},
+			});
+		} catch (error) {
+			// Silently handle network errors (timeout, ENOTFOUND, etc.)
+			// Return empty flags to allow the app to continue functioning
+			return {};
+		}
 	}
 }

--- a/packages/frontend/editor-ui/src/dev/i18nHmr.ts
+++ b/packages/frontend/editor-ui/src/dev/i18nHmr.ts
@@ -7,7 +7,8 @@ const DEFAULT_LOCALE = 'en';
 
 if (hot) {
 	// Eagerly import locale JSONs so this module becomes their HMR owner
-	const localeModules = import.meta.glob('@n8n/i18n/locales/*.json', { eager: true }) as Record<
+	// Use relative path: from src/dev/ go up to frontend/, then into @n8n/i18n/src/locales/
+	const localeModules = import.meta.glob('@n8n/i18n/src/locales/*.json', { eager: true }) as Record<
 		string,
 		{ default?: LocaleMessages }
 	>;


### PR DESCRIPTION
- Fix Vite build warnings for scripts with template variables in index.html
  * Remove scripts with {{BASE_PATH}} during build (backend injects at runtime)
  * Prevent Vite from trying to bundle runtime-injected scripts

- Fix invalid glob pattern in i18nHmr.ts
  * Change from alias pattern to relative path for import.meta.glob
  * Use correct path: @n8n/i18n/src/locales/*.json (resolved via alias)

- Improve error handling for telemetry services
  * Add try-catch and timeout (5s) to TelemetryController.sourceConfig
  * Add error handling to PostHogClient.getFeatureFlags
  * Return empty config/flags on network errors instead of throwing
  * Prevent console spam from network timeouts and connection errors

- Maintain app functionality when telemetry services are unavailable
  * Gracefully handle ENOTFOUND, timeout, and other network errors
  * Allow app to continue functioning without telemetry connectivity

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Harden telemetry (timeouts, silent failures) and adjust Vite/i18n dev-build config to fix glob path and suppress web-tree-sitter eval warnings, removing runtime-injected scripts during build.
> 
> - **Telemetry/Backend**:
>   - Add 5s timeout and try-catch in `TelemetryController.sourceConfig`; return `{}` on non-OK/Errors.
>   - Wrap `PostHogClient.getFeatureFlags` in try-catch; return `{}` on errors.
> - **Frontend Build**:
>   - Update `vite.config.mts` `transformIndexHtml` to pre-transform, skip config tags in dev, and strip `{{BASE_PATH}}` script tags during build.
>   - Suppress `web-tree-sitter` eval warnings via `rollupOptions.onwarn` and `optimizeDeps` configuration; exclude `web-tree-sitter` from optimization.
> - **Dev i18n**:
>   - Fix HMR glob to `@n8n/i18n/src/locales/*.json` in `src/dev/i18nHmr.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b2ee2ed8eda78f8bf2958b071972bcf8fb3e260. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->