### PR TITLE
fix(public-api): Enable type coercion for boolean query parameters

### DIFF
--- a/packages/cli/src/public-api/index.ts
+++ b/packages/cli/src/public-api/index.ts
@@ -59,6 +59,7 @@ async function createApiRouter(
 			operationHandlers: handlersDirectory,
 			validateRequests: true,
 			validateApiSpec: true,
+			coerceTypes: true,
 			formats: {
 				email: {
 					type: 'string',

--- a/packages/cli/test/integration/public-api/users.test.ts
+++ b/packages/cli/test/integration/public-api/users.test.ts
@@ -79,6 +79,48 @@ describe('Users in Public API', () => {
 			const owners = users.filter((user: any) => user.role === 'global:owner');
 			expect(owners).toHaveLength(1);
 		});
+
+		it('should return users with roles when includeRole is passed as string', async () => {
+			/**
+			 * Arrange
+			 */
+			const owner = await createOwnerWithApiKey();
+
+			await createMember();
+			await createMember();
+			await createMember();
+
+			/**
+			 * Act
+			 * Pass includeRole as string 'true' to mimic how query params come from HTTP requests
+			 */
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.get('/users?includeRole=true');
+
+			/**
+			 * Assert
+			 */
+			expect(response.status).toBe(200);
+			const { data: users } = response.body;
+
+			expect(users).toHaveLength(4);
+			users.forEach((user: any) => {
+				expect(user).toHaveProperty('id');
+				expect(user).toHaveProperty('email');
+				expect(user).toHaveProperty('firstName');
+				expect(user).toHaveProperty('lastName');
+				expect(user).toHaveProperty('createdAt');
+				expect(user).toHaveProperty('updatedAt');
+				expect(user).toHaveProperty('isPending');
+				expect(user).toHaveProperty('role');
+			});
+
+			const members = users.filter((user: any) => user.role === 'global:member');
+			expect(members).toHaveLength(3);
+			const owners = users.filter((user: any) => user.role === 'global:owner');
+			expect(owners).toHaveLength(1);
+		});
 	});
 
 	describe('GET /users/:id', () => {
@@ -114,6 +156,37 @@ describe('Users in Public API', () => {
 				.publicApiAgentFor(owner)
 				.get(`/users/${member.id}`)
 				.query({ includeRole });
+
+			/**
+			 * Assert
+			 */
+			expect(response.status).toBe(200);
+			const returnedUser = response.body;
+
+			expect(returnedUser).toHaveProperty('id', member.id);
+			expect(returnedUser).toHaveProperty('email', member.email);
+			expect(returnedUser).toHaveProperty('firstName', member.firstName);
+			expect(returnedUser).toHaveProperty('lastName', member.lastName);
+			expect(returnedUser).toHaveProperty('createdAt');
+			expect(returnedUser).toHaveProperty('updatedAt');
+			expect(returnedUser).toHaveProperty('isPending', member.isPending);
+			expect(returnedUser).toHaveProperty('role', 'global:member');
+		});
+
+		it('should return a user with role when includeRole is passed as string', async () => {
+			/**
+			 * Arrange
+			 */
+			const owner = await createOwnerWithApiKey();
+			const member = await createMember();
+
+			/**
+			 * Act
+			 * Pass includeRole as string 'true' to mimic how query params come from HTTP requests
+			 */
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.get(`/users/${member.id}?includeRole=true`);
 
 			/**
 			 * Assert


### PR DESCRIPTION
## Summary
Boolean query parameters like 'includeRole' were not working correctly because express-openapi-validator was not converting string values (e.g., 'true') to actual booleans.

Added coerceTypes: true to the validator configuration to automatically convert query parameter strings to their OpenAPI-specified types.

This fixes the issue where GET /api/v1/users?includeRole=true would not return the role field in the response.

Changes:
- Add coerceTypes: true to express-openapi-validator config
- Add tests for string-based boolean query parameters

**Before (v1.118.2):**

<img width="905" height="661" alt="before" src="https://github.com/user-attachments/assets/629d14aa-6270-4973-aa98-5729f6aa406f" />


**After:**

<img width="905" height="757" alt="after" src="https://github.com/user-attachments/assets/e0e75499-fe3b-4032-b01d-c549da0fa1f1" />


<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [X] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable type coercion in the public API validator and add tests to ensure `includeRole` works when passed as a string.
> 
> - **Public API**:
>   - Enable `coerceTypes: true` in `packages/cli/src/public-api/index.ts` to coerce query params (e.g., string booleans) per OpenAPI types.
> - **Tests**:
>   - Add integration tests in `packages/cli/test/integration/public-api/users.test.ts` to verify `includeRole` works when sent as `'true'` for `GET /users` and `GET /users/:id`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d9fdfeacc2f6557f78034a8c32b1405467a00f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->