### PR TITLE
fix: properly handle receivedBefore query in Gmail node

### DIFF
--- a/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
@@ -370,24 +370,27 @@ export function prepareQuery(
 	}
 
 	if (qs.receivedAfter) {
-		qs.q = prepareTimestamp(
+		const timestampQuery = prepareTimestamp(
 			this.getNode(),
 			itemIndex,
 			qs.q as string,
 			qs.receivedAfter as string,
 			'after',
 		);
+		qs.q = timestampQuery;
 		delete qs.receivedAfter;
 	}
 
 	if (qs.receivedBefore) {
-		qs.q = prepareTimestamp(
+		const timestampQuery = prepareTimestamp(
 			this.getNode(),
 			itemIndex,
 			qs.q as string,
 			qs.receivedBefore as string,
 			'before',
 		);
+		// If query already exists, append to it, otherwise set it
+		qs.q = qs.q ? `${qs.q} ${timestampQuery}` : timestampQuery;
 		delete qs.receivedBefore;
 	}
 


### PR DESCRIPTION
**Overview**
This PR fixes an issue in the Google Gmail node where the `receivedBefore` query parameter was not properly appended to existing queries. Previously, when both `q` and `receivedBefore` parameters were provided, the `receivedBefore` condition would overwrite the existing query instead of appending to it.

**Checklist**
- [x] Code changes are present
- [x] No new tests needed (existing functionality updated)
- [x] No documentation changes needed

**Proof**
The fix modifies the `prepareQuery` function in `GenericFunctions.ts` to properly handle the combination of existing `q` parameter with `receivedBefore` parameter. Instead of overwriting `qs.q`, the code now checks if a query already exists and appends the timestamp query with a space separator when needed.

**Closes #21666**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure `receivedBefore` is appended to existing Gmail query `q` instead of overwriting it; minor refactor for `receivedAfter` handling.
> 
> - **Gmail node (`GenericFunctions.ts`)**:
>   - **Query building (`prepareQuery`)**:
>     - Append `before:<timestamp>` from `receivedBefore` to existing `q` instead of overwriting.
>     - Minor refactor: store `prepareTimestamp` result in `timestampQuery` for both `receivedAfter` and `receivedBefore`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff2e676d92f34ed2d1eb911fd45c32e7c5097a5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->