### PR TITLE
N8n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [1.80.1](https://github.com/n8n-io/n8n/compare/n8n@1.80.0...n8n@1.80.1) (2025-02-20)
+
+
+### Bug Fixes
+
+* Always clear popupWindowState  before showing popup from form trigger ([#13363](https://github.com/n8n-io/n8n/issues/13363)) ([44e583b](https://github.com/n8n-io/n8n/commit/44e583bbb79c328ee9b8a69afb7b059106cb1613))
+* **Code Node:** Fix `$items` in Code node when using task runner ([#13368](https://github.com/n8n-io/n8n/issues/13368)) ([da5afd0](https://github.com/n8n-io/n8n/commit/da5afd06a943d29c6a57e590aa8a2d91264329dc))
+* **core:** Ensure that 'workflow-post-execute' event has userId whenever it's available ([#13326](https://github.com/n8n-io/n8n/issues/13326)) ([088872b](https://github.com/n8n-io/n8n/commit/088872b086d5d794e7a19af5e52ae75d2b220f17))
+* **core:** Handle connections for missing nodes in a workflow ([#13362](https://github.com/n8n-io/n8n/issues/13362)) ([4da7ed7](https://github.com/n8n-io/n8n/commit/4da7ed7ebc4e206d4a1a35c968b9dbbded72eb81))
+
+
+
 # [1.80.0](https://github.com/n8n-io/n8n/compare/n8n@1.79.0...n8n@1.80.0) (2025-02-17)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [1.80.2](https://github.com/n8n-io/n8n/compare/n8n@1.80.1...n8n@1.80.2) (2025-02-21)
+
+
+### Bug Fixes
+
+* **core:** Make sure middleware works with legacy API Keys ([#13390](https://github.com/n8n-io/n8n/issues/13390)) ([c4fe0b5](https://github.com/n8n-io/n8n/commit/c4fe0b550cda96b288ce17d5d46d2fa7b6e72eb5))
+
+
+
 ## [1.80.1](https://github.com/n8n-io/n8n/compare/n8n@1.80.0...n8n@1.80.1) (2025-02-20)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.80.3](https://github.com/n8n-io/n8n/compare/n8n@1.80.2...n8n@1.80.3) (2025-02-21)
+
+
+
 ## [1.80.2](https://github.com/n8n-io/n8n/compare/n8n@1.80.1...n8n@1.80.2) (2025-02-21)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-monorepo",
-  "version": "1.80.0",
+  "version": "1.80.1",
   "private": true,
   "engines": {
     "node": ">=20.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-monorepo",
-  "version": "1.80.2",
+  "version": "1.80.3",
   "private": true,
   "engines": {
     "node": ">=20.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-monorepo",
-  "version": "1.80.1",
+  "version": "1.80.2",
   "private": true,
   "engines": {
     "node": ">=20.15",

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/execute.ts
@@ -392,13 +392,14 @@ export async function toolsAgentExecute(this: IExecuteFunctions): Promise<INodeE
 
 	const returnData: INodeExecutionData[] = [];
 	const items = this.getInputData();
+	const outputParsers = await getOptionalOutputParsers(this);
+	const outputParser = outputParsers?.[0];
+	const tools = await getTools(this, outputParser);
+
 	for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
 		try {
 			const model = await getChatModel(this);
 			const memory = await getOptionalMemory(this);
-			const outputParsers = await getOptionalOutputParsers(this);
-			const outputParser = outputParsers?.[0];
-			const tools = await getTools(this, outputParser);
 
 			const input = getPromptInputByType({
 				ctx: this,

--- a/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserAutofixing/test/OutputParserAutofixing.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserAutofixing/test/OutputParserAutofixing.node.test.ts
@@ -5,7 +5,7 @@ import { OutputParserException } from '@langchain/core/output_parsers';
 import type { MockProxy } from 'jest-mock-extended';
 import { mock } from 'jest-mock-extended';
 import { normalizeItems } from 'n8n-core';
-import type { IExecuteFunctions, IWorkflowDataProxyData } from 'n8n-workflow';
+import type { ISupplyDataFunctions, IWorkflowDataProxyData } from 'n8n-workflow';
 import { ApplicationError, NodeConnectionType, NodeOperationError } from 'n8n-workflow';
 
 import type {
@@ -18,13 +18,13 @@ import { NAIVE_FIX_PROMPT } from '../prompt';
 
 describe('OutputParserAutofixing', () => {
 	let outputParser: OutputParserAutofixing;
-	let thisArg: MockProxy<IExecuteFunctions>;
+	let thisArg: MockProxy<ISupplyDataFunctions>;
 	let mockModel: MockProxy<BaseLanguageModel>;
 	let mockStructuredOutputParser: MockProxy<N8nStructuredOutputParser>;
 
 	beforeEach(() => {
 		outputParser = new OutputParserAutofixing();
-		thisArg = mock<IExecuteFunctions>({
+		thisArg = mock<ISupplyDataFunctions>({
 			helpers: { normalizeItems },
 		});
 		mockModel = mock<BaseLanguageModel>();

--- a/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserItemList/test/OutputParserItemList.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserItemList/test/OutputParserItemList.node.test.ts
@@ -2,7 +2,7 @@ import { mock } from 'jest-mock-extended';
 import { normalizeItems } from 'n8n-core';
 import {
 	ApplicationError,
-	type IExecuteFunctions,
+	type ISupplyDataFunctions,
 	type IWorkflowDataProxyData,
 } from 'n8n-workflow';
 
@@ -12,7 +12,7 @@ import { OutputParserItemList } from '../OutputParserItemList.node';
 
 describe('OutputParserItemList', () => {
 	let outputParser: OutputParserItemList;
-	const thisArg = mock<IExecuteFunctions>({
+	const thisArg = mock<ISupplyDataFunctions>({
 		helpers: { normalizeItems },
 	});
 	const workflowDataProxy = mock<IWorkflowDataProxyData>({ $input: mock() });

--- a/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/test/OutputParserStructured.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/test/OutputParserStructured.node.test.ts
@@ -2,8 +2,8 @@ import { mock } from 'jest-mock-extended';
 import { normalizeItems } from 'n8n-core';
 import {
 	jsonParse,
-	type IExecuteFunctions,
 	type INode,
+	type ISupplyDataFunctions,
 	type IWorkflowDataProxyData,
 } from 'n8n-workflow';
 
@@ -13,7 +13,7 @@ import { OutputParserStructured } from '../OutputParserStructured.node';
 
 describe('OutputParserStructured', () => {
 	let outputParser: OutputParserStructured;
-	const thisArg = mock<IExecuteFunctions>({
+	const thisArg = mock<ISupplyDataFunctions>({
 		helpers: { normalizeItems },
 	});
 	const workflowDataProxy = mock<IWorkflowDataProxyData>({ $input: mock() });

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/test/ToolHttpRequest.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/test/ToolHttpRequest.node.test.ts
@@ -1,5 +1,5 @@
 import { mock } from 'jest-mock-extended';
-import type { IExecuteFunctions, INode } from 'n8n-workflow';
+import type { INode, ISupplyDataFunctions } from 'n8n-workflow';
 import { jsonParse } from 'n8n-workflow';
 
 import type { N8nTool } from '@utils/N8nTool';
@@ -8,8 +8,8 @@ import { ToolHttpRequest } from '../ToolHttpRequest.node';
 
 describe('ToolHttpRequest', () => {
 	const httpTool = new ToolHttpRequest();
-	const helpers = mock<IExecuteFunctions['helpers']>();
-	const executeFunctions = mock<IExecuteFunctions>({ helpers });
+	const helpers = mock<ISupplyDataFunctions['helpers']>();
+	const executeFunctions = mock<ISupplyDataFunctions>({ helpers });
 
 	beforeEach(() => {
 		jest.resetAllMocks();

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/ToolWorkflowV2.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/ToolWorkflowV2.test.ts
@@ -11,12 +11,8 @@ import type {
 
 import { WorkflowToolService } from './utils/WorkflowToolService';
 
-type ISupplyDataFunctionsWithRunIndex = ISupplyDataFunctions & { runIndex: number };
-
 // Mock ISupplyDataFunctions interface
-function createMockContext(
-	overrides?: Partial<ISupplyDataFunctions>,
-): ISupplyDataFunctionsWithRunIndex {
+function createMockContext(overrides?: Partial<ISupplyDataFunctions>): ISupplyDataFunctions {
 	return {
 		runIndex: 0,
 		getNodeParameter: jest.fn(),
@@ -33,6 +29,7 @@ function createMockContext(
 		getTimezone: jest.fn(),
 		getWorkflow: jest.fn(),
 		getWorkflowStaticData: jest.fn(),
+		cloneWith: jest.fn(),
 		logger: {
 			debug: jest.fn(),
 			error: jest.fn(),
@@ -40,11 +37,11 @@ function createMockContext(
 			warn: jest.fn(),
 		},
 		...overrides,
-	} as ISupplyDataFunctionsWithRunIndex;
+	} as ISupplyDataFunctions;
 }
 
 describe('WorkflowTool::WorkflowToolService', () => {
-	let context: ISupplyDataFunctionsWithRunIndex;
+	let context: ISupplyDataFunctions;
 	let service: WorkflowToolService;
 
 	beforeEach(() => {
@@ -92,13 +89,25 @@ describe('WorkflowTool::WorkflowToolService', () => {
 				$execution: { id: 'exec-id' },
 				$workflow: { id: 'workflow-id' },
 			} as unknown as IWorkflowDataProxyData);
+			jest.spyOn(context, 'cloneWith').mockReturnValue(context);
 
 			const tool = await service.createTool(toolParams);
 			const result = await tool.func('test query');
 
 			expect(result).toBe(JSON.stringify(TEST_RESPONSE, null, 2));
 			expect(context.addOutputData).toHaveBeenCalled();
-			expect(context.runIndex).toBe(1);
+
+			// Here we validate that the runIndex is correctly updated
+			expect(context.cloneWith).toHaveBeenCalledWith({
+				runIndex: 0,
+				inputData: [[{ json: { query: 'test query' } }]],
+			});
+
+			await tool.func('another query');
+			expect(context.cloneWith).toHaveBeenCalledWith({
+				runIndex: 1,
+				inputData: [[{ json: { query: 'another query' } }]],
+			});
 		});
 
 		it('should handle errors during tool execution', async () => {
@@ -113,6 +122,7 @@ describe('WorkflowTool::WorkflowToolService', () => {
 				.mockRejectedValueOnce(new Error('Workflow execution failed'));
 			jest.spyOn(context, 'addInputData').mockReturnValue({ index: 0 });
 			jest.spyOn(context, 'getNodeParameter').mockReturnValue('database');
+			jest.spyOn(context, 'cloneWith').mockReturnValue(context);
 
 			const tool = await service.createTool(toolParams);
 			const result = await tool.func('test query');
@@ -166,7 +176,12 @@ describe('WorkflowTool::WorkflowToolService', () => {
 
 			jest.spyOn(context, 'executeWorkflow').mockResolvedValueOnce(mockResponse);
 
-			const result = await service['executeSubWorkflow'](workflowInfo, items, workflowProxyMock);
+			const result = await service['executeSubWorkflow'](
+				context,
+				workflowInfo,
+				items,
+				workflowProxyMock,
+			);
 
 			expect(result.response).toBe(TEST_RESPONSE);
 			expect(result.subExecutionId).toBe('test-execution');
@@ -175,7 +190,7 @@ describe('WorkflowTool::WorkflowToolService', () => {
 		it('should throw error when workflow execution fails', async () => {
 			jest.spyOn(context, 'executeWorkflow').mockRejectedValueOnce(new Error('Execution failed'));
 
-			await expect(service['executeSubWorkflow']({}, [], {} as never)).rejects.toThrow(
+			await expect(service['executeSubWorkflow'](context, {}, [], {} as never)).rejects.toThrow(
 				NodeOperationError,
 			);
 		});
@@ -188,7 +203,7 @@ describe('WorkflowTool::WorkflowToolService', () => {
 
 			jest.spyOn(context, 'executeWorkflow').mockResolvedValueOnce(mockResponse);
 
-			await expect(service['executeSubWorkflow']({}, [], {} as never)).rejects.toThrow();
+			await expect(service['executeSubWorkflow'](context, {}, [], {} as never)).rejects.toThrow();
 		});
 	});
 
@@ -202,7 +217,12 @@ describe('WorkflowTool::WorkflowToolService', () => {
 
 			jest.spyOn(context, 'getNodeParameter').mockReturnValueOnce({ value: 'workflow-id' });
 
-			const result = await service['getSubWorkflowInfo'](source, itemIndex, workflowProxyMock);
+			const result = await service['getSubWorkflowInfo'](
+				context,
+				source,
+				itemIndex,
+				workflowProxyMock,
+			);
 
 			expect(result.workflowInfo).toHaveProperty('id', 'workflow-id');
 			expect(result.subWorkflowId).toBe('workflow-id');
@@ -218,7 +238,12 @@ describe('WorkflowTool::WorkflowToolService', () => {
 
 			jest.spyOn(context, 'getNodeParameter').mockReturnValueOnce(JSON.stringify(mockWorkflow));
 
-			const result = await service['getSubWorkflowInfo'](source, itemIndex, workflowProxyMock);
+			const result = await service['getSubWorkflowInfo'](
+				context,
+				source,
+				itemIndex,
+				workflowProxyMock,
+			);
 
 			expect(result.workflowInfo.code).toEqual(mockWorkflow);
 			expect(result.subWorkflowId).toBe('proxy-id');
@@ -234,7 +259,7 @@ describe('WorkflowTool::WorkflowToolService', () => {
 			jest.spyOn(context, 'getNodeParameter').mockReturnValueOnce('invalid json');
 
 			await expect(
-				service['getSubWorkflowInfo'](source, itemIndex, workflowProxyMock),
+				service['getSubWorkflowInfo'](context, source, itemIndex, workflowProxyMock),
 			).rejects.toThrow(NodeOperationError);
 		});
 	});

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode.ts
@@ -67,13 +67,13 @@ export interface VectorStoreNodeConstructorArgs<T extends VectorStore = VectorSt
 	retrieveFields?: INodeProperties[];
 	updateFields?: INodeProperties[];
 	populateVectorStore: (
-		context: ISupplyDataFunctions,
+		context: IExecuteFunctions | ISupplyDataFunctions,
 		embeddings: Embeddings,
 		documents: Array<Document<Record<string, unknown>>>,
 		itemIndex: number,
 	) => Promise<void>;
 	getVectorStoreClient: (
-		context: ISupplyDataFunctions,
+		context: IExecuteFunctions | ISupplyDataFunctions,
 		filter: Record<string, never> | undefined,
 		embeddings: Embeddings,
 		itemIndex: number,

--- a/packages/@n8n/nodes-langchain/package.json
+++ b/packages/@n8n/nodes-langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@n8n/n8n-nodes-langchain",
-  "version": "1.80.0",
+  "version": "1.80.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/@n8n/nodes-langchain/package.json
+++ b/packages/@n8n/nodes-langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@n8n/n8n-nodes-langchain",
-  "version": "1.80.1",
+  "version": "1.80.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/@n8n/nodes-langchain/utils/N8nTool.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/N8nTool.test.ts
@@ -1,6 +1,6 @@
 import { DynamicStructuredTool, DynamicTool } from '@langchain/core/tools';
 import { createMockExecuteFunction } from 'n8n-nodes-base/test/nodes/Helpers';
-import type { INode } from 'n8n-workflow';
+import type { INode, ISupplyDataFunctions } from 'n8n-workflow';
 import { z } from 'zod';
 
 import { N8nTool } from './N8nTool';
@@ -20,7 +20,7 @@ describe('Test N8nTool wrapper as DynamicStructuredTool', () => {
 	it('should wrap a tool', () => {
 		const func = jest.fn();
 
-		const ctx = createMockExecuteFunction({}, mockNode);
+		const ctx = createMockExecuteFunction<ISupplyDataFunctions>({}, mockNode);
 
 		const tool = new N8nTool(ctx, {
 			name: 'Dummy Tool',
@@ -39,7 +39,7 @@ describe('Test N8nTool wrapper - DynamicTool fallback', () => {
 	it('should convert the tool to a dynamic tool', () => {
 		const func = jest.fn();
 
-		const ctx = createMockExecuteFunction({}, mockNode);
+		const ctx = createMockExecuteFunction<ISupplyDataFunctions>({}, mockNode);
 
 		const tool = new N8nTool(ctx, {
 			name: 'Dummy Tool',
@@ -58,7 +58,7 @@ describe('Test N8nTool wrapper - DynamicTool fallback', () => {
 	it('should format fallback description correctly', () => {
 		const func = jest.fn();
 
-		const ctx = createMockExecuteFunction({}, mockNode);
+		const ctx = createMockExecuteFunction<ISupplyDataFunctions>({}, mockNode);
 
 		const tool = new N8nTool(ctx, {
 			name: 'Dummy Tool',
@@ -86,7 +86,7 @@ describe('Test N8nTool wrapper - DynamicTool fallback', () => {
 	it('should handle empty parameter list correctly', () => {
 		const func = jest.fn();
 
-		const ctx = createMockExecuteFunction({}, mockNode);
+		const ctx = createMockExecuteFunction<ISupplyDataFunctions>({}, mockNode);
 
 		const tool = new N8nTool(ctx, {
 			name: 'Dummy Tool',
@@ -103,7 +103,7 @@ describe('Test N8nTool wrapper - DynamicTool fallback', () => {
 	it('should parse correct parameters', async () => {
 		const func = jest.fn();
 
-		const ctx = createMockExecuteFunction({}, mockNode);
+		const ctx = createMockExecuteFunction<ISupplyDataFunctions>({}, mockNode);
 
 		const tool = new N8nTool(ctx, {
 			name: 'Dummy Tool',
@@ -127,7 +127,7 @@ describe('Test N8nTool wrapper - DynamicTool fallback', () => {
 	it('should recover when 1 parameter is passed directly', async () => {
 		const func = jest.fn();
 
-		const ctx = createMockExecuteFunction({}, mockNode);
+		const ctx = createMockExecuteFunction<ISupplyDataFunctions>({}, mockNode);
 
 		const tool = new N8nTool(ctx, {
 			name: 'Dummy Tool',
@@ -150,7 +150,7 @@ describe('Test N8nTool wrapper - DynamicTool fallback', () => {
 	it('should recover when JS object is passed instead of JSON', async () => {
 		const func = jest.fn();
 
-		const ctx = createMockExecuteFunction({}, mockNode);
+		const ctx = createMockExecuteFunction<ISupplyDataFunctions>({}, mockNode);
 
 		const tool = new N8nTool(ctx, {
 			name: 'Dummy Tool',

--- a/packages/@n8n/nodes-langchain/utils/tests/helpers.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/tests/helpers.test.ts
@@ -1,7 +1,7 @@
 import { DynamicTool, type Tool } from '@langchain/core/tools';
 import { createMockExecuteFunction } from 'n8n-nodes-base/test/nodes/Helpers';
 import { NodeOperationError } from 'n8n-workflow';
-import type { IExecuteFunctions, INode } from 'n8n-workflow';
+import type { ISupplyDataFunctions, IExecuteFunctions, INode } from 'n8n-workflow';
 import { z } from 'zod';
 
 import { escapeSingleCurlyBrackets, getConnectedTools } from '../helpers';
@@ -171,7 +171,7 @@ describe('getConnectedTools', () => {
 
 		mockExecuteFunctions = createMockExecuteFunction({}, mockNode);
 
-		mockN8nTool = new N8nTool(mockExecuteFunctions, {
+		mockN8nTool = new N8nTool(mockExecuteFunctions as unknown as ISupplyDataFunctions, {
 			name: 'Dummy Tool',
 			description: 'A dummy tool for testing',
 			func: jest.fn(),

--- a/packages/@n8n/task-runner/package.json
+++ b/packages/@n8n/task-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@n8n/task-runner",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "scripts": {
     "clean": "rimraf dist .turbo",
     "start": "node dist/start.js",

--- a/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
@@ -850,7 +850,7 @@ describe('JsTaskRunner', () => {
 			});
 		});
 
-		test.each([['items'], ['$input.all()'], ["$('Trigger').all()"]])(
+		test.each([['items'], ['$input.all()'], ["$('Trigger').all()"], ['$items()']])(
 			'should have all input items in the context as %s',
 			async (expression) => {
 				const outcome = await executeForAllItems({

--- a/packages/@n8n/task-runner/src/js-task-runner/built-ins-parser/__tests__/built-ins-parser.test.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/built-ins-parser/__tests__/built-ins-parser.test.ts
@@ -144,6 +144,23 @@ describe('BuiltInsParser', () => {
 		);
 	});
 
+	describe('$items(...)', () => {
+		it('should mark input as needed when $items() is used without arguments', () => {
+			const state = parseAndExpectOk('$items()');
+			expect(state).toEqual(new BuiltInsParserState({ needs$input: true }));
+		});
+
+		it('should require the given node when $items() is used with a static value', () => {
+			const state = parseAndExpectOk('$items("nodeName")');
+			expect(state).toEqual(new BuiltInsParserState({ neededNodeNames: new Set(['nodeName']) }));
+		});
+
+		it('should require all nodes when $items() is used with a variable', () => {
+			const state = parseAndExpectOk('var n = "name"; $items(n)');
+			expect(state).toEqual(new BuiltInsParserState({ needsAllNodes: true, needs$input: true }));
+		});
+	});
+
 	describe('$node', () => {
 		it('should require all nodes when $node is used', () => {
 			const state = parseAndExpectOk('return $node["name"];');

--- a/packages/@n8n/task-runner/src/js-task-runner/built-ins-parser/built-ins-parser.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/built-ins-parser/built-ins-parser.ts
@@ -54,8 +54,22 @@ export class BuiltInsParser {
 	) => {
 		// $(...)
 		const isDollar = node.callee.type === 'Identifier' && node.callee.name === '$';
-		if (!isDollar) return;
+		const isItems = node.callee.type === 'Identifier' && node.callee.name === '$items';
+		if (isDollar) {
+			this.visitDollarCallExpression(node, state, ancestors);
+		} else if (isItems) {
+			// $items(...) is a legacy syntax that is not documented but we still
+			// need to support it for backwards compatibility
+			this.visitDollarItemsCallExpression(node, state);
+		}
+	};
 
+	/** $(...) */
+	private visitDollarCallExpression(
+		node: CallExpression,
+		state: BuiltInsParserState,
+		ancestors: Node[],
+	) {
 		// $(): This is not valid, ignore
 		if (node.arguments.length === 0) {
 			return;
@@ -78,7 +92,31 @@ export class BuiltInsParser {
 
 		// Determine how $("node") is used
 		this.handlePrevNodeCall(node, state, ancestors);
-	};
+	}
+
+	/** $items(...) */
+	private visitDollarItemsCallExpression(node: CallExpression, state: BuiltInsParserState) {
+		// $items(): This gets items from the previous node
+		if (node.arguments.length === 0) {
+			state.markInputAsNeeded();
+			return;
+		}
+
+		const firstArg = node.arguments[0];
+		if (!isLiteral(firstArg)) {
+			// $items(variable): Can't easily determine statically, mark all nodes as needed
+			state.markNeedsAllNodes();
+			return;
+		}
+
+		if (typeof firstArg.value !== 'string') {
+			// $items(123): Static value, but not a string --> unsupported code --> ignore
+			return;
+		}
+
+		// $items(nodeName): Static value, mark 'nodeName' as needed
+		state.markNodeAsNeeded(firstArg.value);
+	}
 
 	private handlePrevNodeCall(_node: CallExpression, state: BuiltInsParserState, ancestors: Node[]) {
 		// $("node").item, .pairedItem or .itemMatching: In a case like this, the execution

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n",
-  "version": "1.80.0",
+  "version": "1.80.1",
   "description": "n8n Workflow Automation Tool",
   "main": "dist/index",
   "types": "dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n",
-  "version": "1.80.1",
+  "version": "1.80.2",
   "description": "n8n Workflow Automation Tool",
   "main": "dist/index",
   "types": "dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n",
-  "version": "1.80.2",
+  "version": "1.80.3",
   "description": "n8n Workflow Automation Tool",
   "main": "dist/index",
   "types": "dist/index.d.ts",

--- a/packages/cli/src/databases/repositories/workflow.repository.ts
+++ b/packages/cli/src/databases/repositories/workflow.repository.ts
@@ -1,22 +1,22 @@
 import { GlobalConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
-import {
-	DataSource,
-	Repository,
-	In,
-	Like,
-	type UpdateResult,
-	type FindOptionsWhere,
-	type FindOptionsSelect,
-	type FindManyOptions,
-	type FindOptionsRelations,
+import { DataSource, Repository, In, Like } from '@n8n/typeorm';
+import type {
+	SelectQueryBuilder,
+	UpdateResult,
+	FindOptionsWhere,
+	FindOptionsSelect,
+	FindManyOptions,
+	FindOptionsRelations,
 } from '@n8n/typeorm';
 
 import type { ListQuery } from '@/requests';
 import { isStringArray } from '@/utils';
 
+import { TagEntity } from '../entities/tag-entity';
 import { WebhookEntity } from '../entities/webhook-entity';
 import { WorkflowEntity } from '../entities/workflow-entity';
+import { WorkflowTagMapping } from '../entities/workflow-tag-mapping';
 
 @Service()
 export class WorkflowRepository extends Repository<WorkflowEntity> {
@@ -99,88 +99,220 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 			.execute();
 	}
 
-	async getMany(sharedWorkflowIds: string[], originalOptions: ListQuery.Options = {}) {
-		const options = structuredClone(originalOptions);
-		if (sharedWorkflowIds.length === 0) return { workflows: [], count: 0 };
-
-		if (typeof options?.filter?.projectId === 'string' && options.filter.projectId !== '') {
-			options.filter.shared = { projectId: options.filter.projectId };
-			delete options.filter.projectId;
+	async getMany(sharedWorkflowIds: string[], options: ListQuery.Options = {}) {
+		if (sharedWorkflowIds.length === 0) {
+			return { workflows: [], count: 0 };
 		}
 
-		const where: FindOptionsWhere<WorkflowEntity> = {
-			...options?.filter,
-			id: In(sharedWorkflowIds),
-		};
+		const qb = this.createBaseQuery(sharedWorkflowIds);
 
-		const reqTags = options?.filter?.tags;
+		this.applyFilters(qb, options.filter);
+		this.applySelect(qb, options.select);
+		this.applyRelations(qb, options.select);
+		this.applySorting(qb, options.sortBy);
+		this.applyPagination(qb, options);
 
-		if (isStringArray(reqTags)) {
-			where.tags = reqTags.map((tag) => ({ name: tag }));
-		}
-
-		type Select = FindOptionsSelect<WorkflowEntity> & { ownedBy?: true };
-
-		const select: Select = options?.select
-			? { ...options.select } // copy to enable field removal without affecting original
-			: {
-					name: true,
-					active: true,
-					createdAt: true,
-					updatedAt: true,
-					versionId: true,
-					shared: { role: true },
-				};
-
-		delete select?.ownedBy; // remove non-entity field, handled after query
-
-		const relations: string[] = [];
-
-		const areTagsEnabled = !this.globalConfig.tags.disabled;
-		const isDefaultSelect = options?.select === undefined;
-		const areTagsRequested = isDefaultSelect || options?.select?.tags === true;
-		const isOwnedByIncluded = isDefaultSelect || options?.select?.ownedBy === true;
-
-		if (areTagsEnabled && areTagsRequested) {
-			relations.push('tags');
-			select.tags = { id: true, name: true };
-		}
-
-		if (isOwnedByIncluded) relations.push('shared', 'shared.project');
-
-		if (typeof where.name === 'string' && where.name !== '') {
-			where.name = Like(`%${where.name}%`);
-		}
-
-		const findManyOptions: FindManyOptions<WorkflowEntity> = {
-			select: { ...select, id: true },
-			where,
-		};
-
-		if (isDefaultSelect || options?.select?.updatedAt === true) {
-			findManyOptions.order = { updatedAt: 'ASC' };
-		}
-
-		if (options.sortBy) {
-			const [column, order] = options.sortBy.split(':');
-			findManyOptions.order = { [column]: order };
-		}
-
-		if (relations.length > 0) {
-			findManyOptions.relations = relations;
-		}
-
-		if (options?.take) {
-			findManyOptions.skip = options.skip;
-			findManyOptions.take = options.take;
-		}
-
-		const [workflows, count] = (await this.findAndCount(findManyOptions)) as [
+		const [workflows, count] = (await qb.getManyAndCount()) as [
 			ListQuery.Workflow.Plain[] | ListQuery.Workflow.WithSharing[],
 			number,
 		];
 
 		return { workflows, count };
+	}
+
+	private createBaseQuery(sharedWorkflowIds: string[]): SelectQueryBuilder<WorkflowEntity> {
+		return this.createQueryBuilder('workflow').where('workflow.id IN (:...sharedWorkflowIds)', {
+			sharedWorkflowIds,
+		});
+	}
+
+	private applyFilters(
+		qb: SelectQueryBuilder<WorkflowEntity>,
+		filter?: ListQuery.Options['filter'],
+	): void {
+		if (!filter) return;
+
+		this.applyNameFilter(qb, filter);
+		this.applyActiveFilter(qb, filter);
+		this.applyTagsFilter(qb, filter);
+		this.applyProjectFilter(qb, filter);
+	}
+
+	private applyNameFilter(
+		qb: SelectQueryBuilder<WorkflowEntity>,
+		filter: ListQuery.Options['filter'],
+	): void {
+		if (typeof filter?.name === 'string' && filter.name !== '') {
+			qb.andWhere('LOWER(workflow.name) LIKE :name', {
+				name: `%${filter.name.toLowerCase()}%`,
+			});
+		}
+	}
+
+	private applyActiveFilter(
+		qb: SelectQueryBuilder<WorkflowEntity>,
+		filter: ListQuery.Options['filter'],
+	): void {
+		if (typeof filter?.active === 'boolean') {
+			qb.andWhere('workflow.active = :active', { active: filter.active });
+		}
+	}
+
+	private applyTagsFilter(
+		qb: SelectQueryBuilder<WorkflowEntity>,
+		filter: ListQuery.Options['filter'],
+	): void {
+		if (isStringArray(filter?.tags) && filter.tags.length > 0) {
+			const subQuery = qb
+				.subQuery()
+				.select('wt.workflowId')
+				.from(WorkflowTagMapping, 'wt')
+				.innerJoin(TagEntity, 'filter_tags', 'filter_tags.id = wt.tagId')
+				.where('filter_tags.name IN (:...tagNames)', { tagNames: filter.tags })
+				.groupBy('wt.workflowId')
+				.having('COUNT(DISTINCT filter_tags.name) = :tagCount', { tagCount: filter.tags.length });
+
+			qb.andWhere(`workflow.id IN (${subQuery.getQuery()})`).setParameters({
+				tagNames: filter.tags,
+				tagCount: filter.tags.length,
+			});
+		}
+	}
+
+	private applyProjectFilter(
+		qb: SelectQueryBuilder<WorkflowEntity>,
+		filter: ListQuery.Options['filter'],
+	): void {
+		if (typeof filter?.projectId === 'string' && filter.projectId !== '') {
+			qb.innerJoin('workflow.shared', 'shared').andWhere('shared.projectId = :projectId', {
+				projectId: filter.projectId,
+			});
+		}
+	}
+
+	private applyOwnedByRelation(qb: SelectQueryBuilder<WorkflowEntity>): void {
+		// Check if 'shared' join already exists from project filter
+		if (!qb.expressionMap.aliases.find((alias) => alias.name === 'shared')) {
+			qb.leftJoin('workflow.shared', 'shared');
+		}
+
+		// Add the necessary selects
+		qb.addSelect([
+			'shared.role',
+			'shared.createdAt',
+			'shared.updatedAt',
+			'shared.workflowId',
+			'shared.projectId',
+		])
+			.leftJoin('shared.project', 'project')
+			.addSelect([
+				'project.id',
+				'project.name',
+				'project.type',
+				'project.icon',
+				'project.createdAt',
+				'project.updatedAt',
+			]);
+	}
+
+	private applySelect(
+		qb: SelectQueryBuilder<WorkflowEntity>,
+		select?: Record<string, boolean>,
+	): void {
+		// Always start with workflow.id
+		qb.select(['workflow.id']);
+
+		if (!select) {
+			// Default select fields when no select option provided
+			qb.addSelect([
+				'workflow.name',
+				'workflow.active',
+				'workflow.createdAt',
+				'workflow.updatedAt',
+				'workflow.versionId',
+			]);
+			return;
+		}
+
+		// Handle special fields separately
+		const regularFields = Object.entries(select).filter(
+			([field]) => !['ownedBy', 'tags'].includes(field),
+		);
+
+		// Add regular fields
+		regularFields.forEach(([field, include]) => {
+			if (include) {
+				qb.addSelect(`workflow.${field}`);
+			}
+		});
+	}
+
+	private applyRelations(
+		qb: SelectQueryBuilder<WorkflowEntity>,
+		select?: Record<string, boolean>,
+	): void {
+		const areTagsEnabled = !this.globalConfig.tags.disabled;
+		const isDefaultSelect = select === undefined;
+		const areTagsRequested = isDefaultSelect || select?.tags;
+		const isOwnedByIncluded = isDefaultSelect || select?.ownedBy;
+
+		if (areTagsEnabled && areTagsRequested) {
+			this.applyTagsRelation(qb);
+		}
+
+		if (isOwnedByIncluded) {
+			this.applyOwnedByRelation(qb);
+		}
+	}
+
+	private applyTagsRelation(qb: SelectQueryBuilder<WorkflowEntity>): void {
+		qb.leftJoin('workflow.tags', 'tags')
+			.addSelect(['tags.id', 'tags.name'])
+			.addOrderBy('tags.createdAt', 'ASC');
+	}
+
+	private applySorting(qb: SelectQueryBuilder<WorkflowEntity>, sortBy?: string): void {
+		if (!sortBy) {
+			this.applyDefaultSorting(qb);
+			return;
+		}
+
+		const [column, direction] = this.parseSortingParams(sortBy);
+		this.applySortingByColumn(qb, column, direction);
+	}
+
+	private parseSortingParams(sortBy: string): [string, 'ASC' | 'DESC'] {
+		const [column, order] = sortBy.split(':');
+		return [column, order.toUpperCase() as 'ASC' | 'DESC'];
+	}
+
+	private applyDefaultSorting(qb: SelectQueryBuilder<WorkflowEntity>): void {
+		qb.orderBy('workflow.updatedAt', 'ASC');
+	}
+
+	private applySortingByColumn(
+		qb: SelectQueryBuilder<WorkflowEntity>,
+		column: string,
+		direction: 'ASC' | 'DESC',
+	): void {
+		if (column === 'name') {
+			qb.addSelect('LOWER(workflow.name)', 'workflow_name_lower').orderBy(
+				'workflow_name_lower',
+				direction,
+			);
+			return;
+		}
+
+		qb.orderBy(`workflow.${column}`, direction);
+	}
+
+	private applyPagination(
+		qb: SelectQueryBuilder<WorkflowEntity>,
+		options: ListQuery.Options,
+	): void {
+		if (options?.take) {
+			qb.skip(options.skip ?? 0).take(options.take);
+		}
 	}
 
 	async findStartingWith(workflowName: string): Promise<Array<{ name: string }>> {

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -376,14 +376,13 @@ export function getLifecycleHooksForSubExecutions(
  * Returns ExecutionLifecycleHooks instance for worker in scaling mode.
  */
 export function getLifecycleHooksForScalingWorker(
-	mode: WorkflowExecuteMode,
+	data: IWorkflowExecutionDataProcess,
 	executionId: string,
-	workflowData: IWorkflowBase,
-	{ pushRef, retryOf }: Omit<HooksSetupParameters, 'saveSettings'> = {},
 ): ExecutionLifecycleHooks {
-	const hooks = new ExecutionLifecycleHooks(mode, executionId, workflowData);
+	const { pushRef, retryOf, executionMode, workflowData } = data;
+	const hooks = new ExecutionLifecycleHooks(executionMode, executionId, workflowData);
 	const saveSettings = toSaveSettings(workflowData.settings);
-	const optionalParameters = { pushRef, retryOf, saveSettings };
+	const optionalParameters = { pushRef, retryOf: retryOf ?? undefined, saveSettings };
 	hookFunctionsNodeEvents(hooks);
 	hookFunctionsFinalizeExecutionStatus(hooks);
 	hookFunctionsSaveWorker(hooks, optionalParameters);
@@ -391,7 +390,7 @@ export function getLifecycleHooksForScalingWorker(
 	hookFunctionsStatistics(hooks);
 	hookFunctionsExternalHooks(hooks);
 
-	if (mode === 'manual' && Container.get(InstanceSettings).isWorker) {
+	if (executionMode === 'manual' && Container.get(InstanceSettings).isWorker) {
 		hookFunctionsPush(hooks, optionalParameters);
 	}
 
@@ -402,17 +401,16 @@ export function getLifecycleHooksForScalingWorker(
  * Returns ExecutionLifecycleHooks instance for main process if workflow runs via worker
  */
 export function getLifecycleHooksForScalingMain(
-	mode: WorkflowExecuteMode,
+	data: IWorkflowExecutionDataProcess,
 	executionId: string,
-	workflowData: IWorkflowBase,
-	{ pushRef, retryOf }: Omit<HooksSetupParameters, 'saveSettings'> = {},
 ): ExecutionLifecycleHooks {
-	const hooks = new ExecutionLifecycleHooks(mode, executionId, workflowData);
+	const { pushRef, retryOf, executionMode, workflowData, userId } = data;
+	const hooks = new ExecutionLifecycleHooks(executionMode, executionId, workflowData);
 	const saveSettings = toSaveSettings(workflowData.settings);
-	const optionalParameters = { pushRef, retryOf, saveSettings };
+	const optionalParameters = { pushRef, retryOf: retryOf ?? undefined, saveSettings };
 	const executionRepository = Container.get(ExecutionRepository);
 
-	hookFunctionsWorkflowEvents(hooks);
+	hookFunctionsWorkflowEvents(hooks, userId);
 	hookFunctionsSaveProgress(hooks, optionalParameters);
 	hookFunctionsExternalHooks(hooks);
 	hookFunctionsFinalizeExecutionStatus(hooks);
@@ -466,11 +464,11 @@ export function getLifecycleHooksForRegularMain(
 	data: IWorkflowExecutionDataProcess,
 	executionId: string,
 ): ExecutionLifecycleHooks {
-	const { pushRef, retryOf, executionMode, workflowData } = data;
+	const { pushRef, retryOf, executionMode, workflowData, userId } = data;
 	const hooks = new ExecutionLifecycleHooks(executionMode, executionId, workflowData);
 	const saveSettings = toSaveSettings(workflowData.settings);
 	const optionalParameters = { pushRef, retryOf: retryOf ?? undefined, saveSettings };
-	hookFunctionsWorkflowEvents(hooks);
+	hookFunctionsWorkflowEvents(hooks, userId);
 	hookFunctionsNodeEvents(hooks);
 	hookFunctionsFinalizeExecutionStatus(hooks);
 	hookFunctionsSave(hooks, optionalParameters);

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -132,10 +132,13 @@ export class JobProcessor {
 		const { pushRef } = job.data;
 
 		const lifecycleHooks = getLifecycleHooksForScalingWorker(
-			execution.mode,
-			job.data.executionId,
-			execution.workflowData,
-			{ retryOf: execution.retryOf ?? undefined, pushRef },
+			{
+				executionMode: execution.mode,
+				workflowData: execution.workflowData,
+				retryOf: execution.retryOf,
+				pushRef,
+			},
+			executionId,
 		);
 		additionalData.hooks = lifecycleHooks;
 

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -345,14 +345,7 @@ export class WorkflowRunner {
 		try {
 			job = await this.scalingService.addJob(jobData, { priority: realtime ? 50 : 100 });
 
-			lifecycleHooks = getLifecycleHooksForScalingMain(
-				data.executionMode,
-				executionId,
-				data.workflowData,
-				{
-					retryOf: data.retryOf ?? undefined,
-				},
-			);
+			lifecycleHooks = getLifecycleHooksForScalingMain(data, executionId);
 
 			// Normally also workflow should be supplied here but as it only used for sending
 			// data to editor-UI is not needed.
@@ -360,12 +353,7 @@ export class WorkflowRunner {
 		} catch (error) {
 			// We use "getLifecycleHooksForScalingWorker" as "getLifecycleHooksForScalingMain" does not contain the
 			// "workflowExecuteAfter" which we require.
-			const lifecycleHooks = getLifecycleHooksForScalingWorker(
-				data.executionMode,
-				executionId,
-				data.workflowData,
-				{ retryOf: data.retryOf ?? undefined },
-			);
+			const lifecycleHooks = getLifecycleHooksForScalingWorker(data, executionId);
 			await this.processError(error, new Date(), data.executionMode, executionId, lifecycleHooks);
 			throw error;
 		}
@@ -378,13 +366,7 @@ export class WorkflowRunner {
 
 					// We use "getLifecycleHooksForScalingWorker" as "getLifecycleHooksForScalingMain" does not contain the
 					// "workflowExecuteAfter" which we require.
-					const lifecycleHooks = getLifecycleHooksForScalingWorker(
-						data.executionMode,
-						executionId,
-						data.workflowData,
-						{ retryOf: data.retryOf ?? undefined },
-					);
-
+					const lifecycleHooks = getLifecycleHooksForScalingWorker(data, executionId);
 					const error = new ExecutionCancelledError(executionId);
 					await this.processError(
 						error,
@@ -409,12 +391,7 @@ export class WorkflowRunner {
 
 					// We use "getLifecycleHooksForScalingWorker" as "getLifecycleHooksForScalingMain" does not contain the
 					// "workflowExecuteAfter" which we require.
-					const lifecycleHooks = getLifecycleHooksForScalingWorker(
-						data.executionMode,
-						executionId,
-						data.workflowData,
-						{ retryOf: data.retryOf ?? undefined },
-					);
+					const lifecycleHooks = getLifecycleHooksForScalingWorker(data, executionId);
 
 					await this.processError(
 						error,

--- a/packages/cli/test/integration/shared/db/tags.ts
+++ b/packages/cli/test/integration/shared/db/tags.ts
@@ -2,6 +2,7 @@ import { Container } from '@n8n/di';
 import type { IWorkflowBase } from 'n8n-workflow';
 
 import type { TagEntity } from '@/databases/entities/tag-entity';
+import type { WorkflowEntity } from '@/databases/entities/workflow-entity';
 import { TagRepository } from '@/databases/repositories/tag.repository';
 import { WorkflowTagMappingRepository } from '@/databases/repositories/workflow-tag-mapping.repository';
 import { generateNanoId } from '@/databases/utils/generators';
@@ -24,4 +25,28 @@ export async function createTag(attributes: Partial<TagEntity> = {}, workflow?: 
 	}
 
 	return tag;
+}
+
+export async function assignTagToWorkflow(tag: TagEntity, workflow: WorkflowEntity) {
+	const mappingRepository = Container.get(WorkflowTagMappingRepository);
+
+	// Check if mapping already exists
+	const existingMapping = await mappingRepository.findOne({
+		where: {
+			tagId: tag.id,
+			workflowId: workflow.id,
+		},
+	});
+
+	if (existingMapping) {
+		return existingMapping;
+	}
+
+	// Create new mapping
+	const mapping = mappingRepository.create({
+		tagId: tag.id,
+		workflowId: workflow.id,
+	});
+
+	return await mappingRepository.save(mapping);
 }

--- a/packages/cli/test/integration/shared/db/users.ts
+++ b/packages/cli/test/integration/shared/db/users.ts
@@ -80,23 +80,30 @@ export async function createUserWithMfaEnabled(
 	};
 }
 
-export const addApiKey = async (user: User) => {
+export const addApiKey = async (
+	user: User,
+	{ expiresAt = null }: { expiresAt?: number | null } = {},
+) => {
 	return await Container.get(PublicApiKeyService).createPublicApiKeyForUser(user, {
 		label: randomName(),
-		expiresAt: null,
+		expiresAt,
 	});
 };
 
-export async function createOwnerWithApiKey() {
+export async function createOwnerWithApiKey({
+	expiresAt = null,
+}: { expiresAt?: number | null } = {}) {
 	const owner = await createOwner();
-	const apiKey = await addApiKey(owner);
+	const apiKey = await addApiKey(owner, { expiresAt });
 	owner.apiKeys = [apiKey];
 	return owner;
 }
 
-export async function createMemberWithApiKey() {
+export async function createMemberWithApiKey({
+	expiresAt = null,
+}: { expiresAt?: number | null } = {}) {
 	const member = await createMember();
-	const apiKey = await addApiKey(member);
+	const apiKey = await addApiKey(member, { expiresAt });
 	member.apiKeys = [apiKey];
 	return member;
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-core",
-  "version": "1.79.0",
+  "version": "1.79.1",
   "description": "Core functionality of n8n",
   "main": "dist/index",
   "types": "dist/index.d.ts",

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/supply-data-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/supply-data-context.test.ts
@@ -54,7 +54,9 @@ describe('SupplyDataContext', () => {
 	const credentialsHelper = mock<ICredentialsHelper>();
 	const additionalData = mock<IWorkflowExecuteAdditionalData>({ credentialsHelper });
 	const mode: WorkflowExecuteMode = 'manual';
-	const runExecutionData = mock<IRunExecutionData>();
+	const runExecutionData = mock<IRunExecutionData>({
+		resultData: { runData: {} },
+	});
 	const connectionInputData: INodeExecutionData[] = [];
 	const connectionType = NodeConnectionType.Main;
 	const inputData: ITaskDataConnections = { [connectionType]: [[{ json: { test: 'data' } }]] };
@@ -173,6 +175,14 @@ describe('SupplyDataContext', () => {
 				'last',
 				'params',
 			]);
+		});
+	});
+
+	describe('cloneWith', () => {
+		it('should return a new copy', () => {
+			const clone = supplyDataContext.cloneWith({ runIndex: 12, inputData: [[{ json: {} }]] });
+			expect(clone.runIndex).toBe(12);
+			expect(clone).not.toBe(supplyDataContext);
 		});
 	});
 });

--- a/packages/core/src/execution-engine/node-execution-context/supply-data-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/supply-data-context.ts
@@ -13,11 +13,10 @@ import type {
 	ITaskDataConnections,
 	ITaskMetadata,
 	IWorkflowExecuteAdditionalData,
-	NodeConnectionType,
 	Workflow,
 	WorkflowExecuteMode,
 } from 'n8n-workflow';
-import { createDeferredPromise } from 'n8n-workflow';
+import { createDeferredPromise, NodeConnectionType } from 'n8n-workflow';
 
 import { BaseExecuteContext } from './base-execute-context';
 import {
@@ -107,6 +106,28 @@ export class SupplyDataContext extends BaseExecuteContext implements ISupplyData
 				fallbackValue,
 				options,
 			)) as ISupplyDataFunctions['getNodeParameter'];
+	}
+
+	cloneWith(replacements: {
+		runIndex: number;
+		inputData: INodeExecutionData[][];
+	}): SupplyDataContext {
+		const context = new SupplyDataContext(
+			this.workflow,
+			this.node,
+			this.additionalData,
+			this.mode,
+			this.runExecutionData,
+			replacements.runIndex,
+			this.connectionInputData,
+			{},
+			this.connectionType,
+			this.executeData,
+			this.closeFunctions,
+			this.abortSignal,
+		);
+		context.addInputData(NodeConnectionType.AiTool, replacements.inputData);
+		return context;
 	}
 
 	async getInputConnectionData(

--- a/packages/editor-ui/package.json
+++ b/packages/editor-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-editor-ui",
-  "version": "1.80.0",
+  "version": "1.80.1",
   "description": "Workflow Editor UI for n8n",
   "main": "index.js",
   "scripts": {

--- a/packages/editor-ui/src/utils/executionUtils.ts
+++ b/packages/editor-ui/src/utils/executionUtils.ts
@@ -130,7 +130,10 @@ export function displayForm({
 		if (node.name === destinationNode || !node.disabled) {
 			let testUrl = '';
 			if (node.type === FORM_TRIGGER_NODE_TYPE) testUrl = getTestUrl(node);
-			if (testUrl && source !== 'RunData.ManualChatMessage') openFormPopupWindow(testUrl);
+			if (testUrl && source !== 'RunData.ManualChatMessage') {
+				clearPopupWindowState();
+				openFormPopupWindow(testUrl);
+			}
 		}
 	}
 }

--- a/packages/node-dev/package.json
+++ b/packages/node-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-node-dev",
-  "version": "1.79.0",
+  "version": "1.79.1",
   "description": "CLI to simplify n8n credentials/node development",
   "main": "dist/src/index",
   "types": "dist/src/index.d.ts",

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/base/getMany.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/base/getMany.test.ts
@@ -49,6 +49,11 @@ describe('Test AirtableV2, base => getMany', () => {
 					name: 'base 1',
 					permissionLevel: 'create',
 				},
+				pairedItem: [
+					{
+						item: 0,
+					},
+				],
 			},
 			{
 				json: {
@@ -56,6 +61,11 @@ describe('Test AirtableV2, base => getMany', () => {
 					name: 'base 2',
 					permissionLevel: 'edit',
 				},
+				pairedItem: [
+					{
+						item: 0,
+					},
+				],
 			},
 			{
 				json: {
@@ -63,6 +73,11 @@ describe('Test AirtableV2, base => getMany', () => {
 					name: 'base 3',
 					permissionLevel: 'create',
 				},
+				pairedItem: [
+					{
+						item: 0,
+					},
+				],
 			},
 		]);
 	});
@@ -86,6 +101,11 @@ describe('Test AirtableV2, base => getMany', () => {
 					name: 'base 2',
 					permissionLevel: 'edit',
 				},
+				pairedItem: [
+					{
+						item: 0,
+					},
+				],
 			},
 		]);
 	});

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/record/search.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/record/search.test.ts
@@ -98,7 +98,11 @@ describe('Test AirtableV2, search operation', () => {
 		expect(result).toHaveLength(2);
 		expect(result[0]).toEqual({
 			json: { id: 'recYYY', foo: 'foo 2', bar: 'bar 2' },
-			pairedItem: [],
+			pairedItem: [
+				{
+					item: 0,
+				},
+			],
 		});
 	});
 
@@ -138,7 +142,11 @@ describe('Test AirtableV2, search operation', () => {
 		expect(result).toHaveLength(1);
 		expect(result[0]).toEqual({
 			json: { id: 'recYYY', foo: 'foo 2', bar: 'bar 2' },
-			pairedItem: [],
+			pairedItem: [
+				{
+					item: 0,
+				},
+			],
 		});
 	});
 });

--- a/packages/nodes-base/nodes/Airtable/v2/actions/base/getMany.operation.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/actions/base/getMany.operation.ts
@@ -5,7 +5,11 @@ import type {
 	IExecuteFunctions,
 } from 'n8n-workflow';
 
-import { updateDisplayOptions, wrapData } from '../../../../../utils/utilities';
+import {
+	generatePairedItemData,
+	updateDisplayOptions,
+	wrapData,
+} from '../../../../../utils/utilities';
 import { apiRequest } from '../../transport';
 
 const properties: INodeProperties[] = [
@@ -108,7 +112,11 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 		bases = bases.filter((base) => permissionLevel.includes(base.permissionLevel as string));
 	}
 
-	const returnData = wrapData(bases);
+	const itemData = generatePairedItemData(this.getInputData().length);
+
+	const returnData = this.helpers.constructExecutionMetaData(wrapData(bases), {
+		itemData,
+	});
 
 	return returnData;
 }

--- a/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow/ExecuteWorkflow.node.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow/ExecuteWorkflow.node.ts
@@ -9,6 +9,7 @@ import type {
 
 import { getWorkflowInfo } from './GenericFunctions';
 import { localResourceMapping } from './methods';
+import { generatePairedItemData } from '../../../utils/utilities';
 import { getCurrentWorkflowInputData } from '../../../utils/workflowInputsResourceMapping/GenericFunctions';
 export class ExecuteWorkflow implements INodeType {
 	description: INodeTypeDescription = {
@@ -426,6 +427,8 @@ export class ExecuteWorkflow implements INodeType {
 
 				const workflowResult = executionResult.data as INodeExecutionData[][];
 
+				const fallbackPairedItemData = generatePairedItemData(items.length);
+
 				for (const output of workflowResult) {
 					const sameLength = output.length === items.length;
 
@@ -434,12 +437,15 @@ export class ExecuteWorkflow implements INodeType {
 
 						if (sameLength) {
 							item.pairedItem = { item: itemIndex };
+						} else {
+							item.pairedItem = fallbackPairedItemData;
 						}
 					}
 				}
 
 				return workflowResult;
 			} catch (error) {
+				const pairedItem = generatePairedItemData(items.length);
 				if (this.continueOnFail()) {
 					const metadata = parseErrorMetadata(error);
 					return [
@@ -447,6 +453,7 @@ export class ExecuteWorkflow implements INodeType {
 							{
 								json: { error: error.message },
 								metadata,
+								pairedItem,
 							},
 						],
 					];

--- a/packages/nodes-base/nodes/Files/ConvertToFile/actions/spreadsheet.operation.ts
+++ b/packages/nodes-base/nodes/Files/ConvertToFile/actions/spreadsheet.operation.ts
@@ -7,7 +7,7 @@ import {
 
 import type { JsonToSpreadsheetBinaryOptions, JsonToSpreadsheetBinaryFormat } from '@utils/binary';
 import { convertJsonToSpreadsheetBinary } from '@utils/binary';
-import { updateDisplayOptions } from '@utils/utilities';
+import { generatePairedItemData, updateDisplayOptions } from '@utils/utilities';
 
 export const operations = ['csv', 'html', 'rtf', 'ods', 'xls', 'xlsx'];
 
@@ -98,6 +98,7 @@ export async function execute(
 ) {
 	let returnData: INodeExecutionData[] = [];
 
+	const pairedItem = generatePairedItemData(items.length);
 	try {
 		const options = this.getNodeParameter('options', 0, {}) as JsonToSpreadsheetBinaryOptions;
 		const binaryPropertyName = this.getNodeParameter('binaryPropertyName', 0, 'data');
@@ -115,6 +116,7 @@ export async function execute(
 			binary: {
 				[binaryPropertyName]: binaryData,
 			},
+			pairedItem,
 		};
 
 		returnData = [newItem];
@@ -124,6 +126,7 @@ export async function execute(
 				json: {
 					error: error.message,
 				},
+				pairedItem,
 			});
 		} else {
 			throw new NodeOperationError(this.getNode(), error);

--- a/packages/nodes-base/nodes/Files/ConvertToFile/actions/toJson.operation.ts
+++ b/packages/nodes-base/nodes/Files/ConvertToFile/actions/toJson.operation.ts
@@ -3,7 +3,7 @@ import { NodeOperationError } from 'n8n-workflow';
 
 import { createBinaryFromJson } from '@utils/binary';
 import { encodeDecodeOptions } from '@utils/descriptions';
-import { updateDisplayOptions } from '@utils/utilities';
+import { generatePairedItemData, updateDisplayOptions } from '@utils/utilities';
 
 export const properties: INodeProperties[] = [
 	{
@@ -92,6 +92,7 @@ export async function execute(this: IExecuteFunctions, items: INodeExecutionData
 
 	const mode = this.getNodeParameter('mode', 0, 'once') as string;
 	if (mode === 'once') {
+		const pairedItem = generatePairedItemData(items.length);
 		try {
 			const options = this.getNodeParameter('options', 0, {});
 			const binaryPropertyName = this.getNodeParameter('binaryPropertyName', 0, 'data');
@@ -113,6 +114,7 @@ export async function execute(this: IExecuteFunctions, items: INodeExecutionData
 				binary: {
 					[binaryPropertyName]: binaryData,
 				},
+				pairedItem,
 			};
 
 			returnData = [newItem];
@@ -122,6 +124,7 @@ export async function execute(this: IExecuteFunctions, items: INodeExecutionData
 					json: {
 						error: error.message,
 					},
+					pairedItem,
 				});
 			}
 			throw new NodeOperationError(this.getNode(), error);

--- a/packages/nodes-base/nodes/Ftp/Ftp.node.ts
+++ b/packages/nodes-base/nodes/Ftp/Ftp.node.ts
@@ -19,7 +19,7 @@ import type { Readable } from 'stream';
 import { pipeline } from 'stream/promises';
 import { file as tmpFile } from 'tmp-promise';
 
-import { formatPrivateKey } from '@utils/utilities';
+import { formatPrivateKey, generatePairedItemData } from '@utils/utilities';
 
 interface ReturnFtpItem {
 	type: string;
@@ -550,7 +550,9 @@ export class Ftp implements INodeType {
 				}
 			} catch (error) {
 				if (this.continueOnFail()) {
-					return [[{ json: { error: error.message } }]];
+					const pairedItem = generatePairedItemData(items.length);
+
+					return [[{ json: { error: error.message }, pairedItem }]];
 				}
 				throw error;
 			}

--- a/packages/nodes-base/nodes/Google/BigQuery/v1/GoogleBigQueryV1.node.ts
+++ b/packages/nodes-base/nodes/Google/BigQuery/v1/GoogleBigQueryV1.node.ts
@@ -16,6 +16,7 @@ import { oldVersionNotice } from '@utils/descriptions';
 
 import { googleApiRequest, googleApiRequestAllItems, simplify } from './GenericFunctions';
 import { recordFields, recordOperations } from './RecordDescription';
+import { generatePairedItemData } from '../../../../utils/utilities';
 
 const versionDescription: INodeTypeDescription = {
 	displayName: 'Google BigQuery',
@@ -194,6 +195,8 @@ export class GoogleBigQueryV1 implements INodeType {
 
 				body.rows = rows;
 
+				const itemData = generatePairedItemData(items.length);
+
 				try {
 					responseData = await googleApiRequest.call(
 						this,
@@ -202,11 +205,17 @@ export class GoogleBigQueryV1 implements INodeType {
 						body,
 					);
 
-					const executionData = this.helpers.returnJsonArray(responseData as IDataObject[]);
+					const executionData = this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray(responseData as IDataObject[]),
+						{ itemData },
+					);
 					returnData.push(...executionData);
 				} catch (error) {
 					if (this.continueOnFail()) {
-						const executionErrorData = this.helpers.returnJsonArray({ error: error.message });
+						const executionErrorData = this.helpers.constructExecutionMetaData(
+							this.helpers.returnJsonArray({ error: error.message }),
+							{ itemData },
+						);
 						returnData.push(...executionErrorData);
 					}
 					throw new NodeApiError(this.getNode(), error as JsonObject, { itemIndex: 0 });

--- a/packages/nodes-base/nodes/Google/BigQuery/v2/actions/database/insert.operation.ts
+++ b/packages/nodes-base/nodes/Google/BigQuery/v2/actions/database/insert.operation.ts
@@ -7,7 +7,7 @@ import type {
 import { NodeOperationError } from 'n8n-workflow';
 import { v4 as uuid } from 'uuid';
 
-import { updateDisplayOptions } from '@utils/utilities';
+import { generatePairedItemData, updateDisplayOptions } from '@utils/utilities';
 
 import type { TableSchema } from '../../helpers/interfaces';
 import { checkSchema, wrapData } from '../../helpers/utils';
@@ -227,6 +227,7 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 		}
 	}
 
+	const itemData = generatePairedItemData(items.length);
 	for (let i = 0; i < rows.length; i += batchSize) {
 		const batch = rows.slice(i, i + batchSize);
 		body.rows = batch;
@@ -280,7 +281,10 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 			});
 		}
 
-		const executionData = wrapData(responseData as IDataObject[]);
+		const executionData = this.helpers.constructExecutionMetaData(
+			wrapData(responseData as IDataObject[]),
+			{ itemData },
+		);
 
 		returnData.push(...executionData);
 	}

--- a/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GoogleFirebaseCloudFirestore.node.ts
+++ b/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GoogleFirebaseCloudFirestore.node.ts
@@ -17,6 +17,7 @@ import {
 	googleApiRequestAllItems,
 	jsonToDocument,
 } from './GenericFunctions';
+import { generatePairedItemData } from '../../../../utils/utilities';
 
 export class GoogleFirebaseCloudFirestore implements INodeType {
 	description: INodeTypeDescription = {
@@ -120,7 +121,7 @@ export class GoogleFirebaseCloudFirestore implements INodeType {
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
-
+		const itemData = generatePairedItemData(items.length);
 		const returnData: INodeExecutionData[] = [];
 		let responseData;
 
@@ -135,7 +136,7 @@ export class GoogleFirebaseCloudFirestore implements INodeType {
 		if (nodeVersion >= 1.1) {
 			itemsLength = items.length;
 		} else {
-			fallbackPairedItems = [];
+			fallbackPairedItems = generatePairedItemData(items.length);
 		}
 
 		if (resource === 'document') {
@@ -171,7 +172,10 @@ export class GoogleFirebaseCloudFirestore implements INodeType {
 						.filter((el: IDataObject) => !!el);
 				}
 
-				const executionData = this.helpers.returnJsonArray(responseData as IDataObject[]);
+				const executionData = this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray(responseData as IDataObject[]),
+					{ itemData },
+				);
 
 				returnData.push(...executionData);
 			} else if (operation === 'create') {

--- a/packages/nodes-base/nodes/Google/Sheet/test/v2/node/delete.test.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/test/v2/node/delete.test.ts
@@ -1,0 +1,154 @@
+import type { IExecuteFunctions } from 'n8n-workflow';
+
+import { execute } from '../../../v2/actions/sheet/delete.operation';
+import type { GoogleSheet } from '../../../v2/helpers/GoogleSheet';
+
+describe('Google Sheet - Delete', () => {
+	let mockExecuteFunctions: Partial<IExecuteFunctions>;
+	let mockSheet: Partial<GoogleSheet>;
+
+	beforeEach(() => {
+		mockExecuteFunctions = {
+			getInputData: jest.fn().mockReturnValue([{ json: {} }]),
+			getNodeParameter: jest.fn(),
+			helpers: {
+				constructExecutionMetaData: jest.fn((data) => ({ json: data })),
+			},
+		} as unknown as Partial<IExecuteFunctions>;
+
+		mockSheet = {
+			spreadsheetBatchUpdate: jest.fn(),
+		} as Partial<GoogleSheet>;
+	});
+
+	test('should delete a single row', async () => {
+		mockExecuteFunctions.getNodeParameter = jest.fn((param: string) => {
+			if (param === 'toDelete') return 'rows';
+			if (param === 'startIndex') return 2;
+			if (param === 'numberToDelete') return 1;
+			return null;
+		}) as unknown as IExecuteFunctions['getNodeParameter'];
+
+		await execute.call(
+			mockExecuteFunctions as IExecuteFunctions,
+			mockSheet as GoogleSheet,
+			'Sheet1',
+		);
+
+		expect(mockSheet.spreadsheetBatchUpdate).toHaveBeenCalledWith([
+			{
+				deleteDimension: {
+					range: {
+						sheetId: 'Sheet1',
+						dimension: 'ROWS',
+						startIndex: 1, // Adjusted for zero-based index
+						endIndex: 2,
+					},
+				},
+			},
+		]);
+	});
+
+	test('should delete multiple rows', async () => {
+		mockExecuteFunctions.getNodeParameter = jest.fn((param: string) => {
+			if (param === 'toDelete') return 'rows';
+			if (param === 'startIndex') return 3;
+			if (param === 'numberToDelete') return 2;
+			return null;
+		}) as unknown as IExecuteFunctions['getNodeParameter'];
+
+		await execute.call(
+			mockExecuteFunctions as IExecuteFunctions,
+			mockSheet as GoogleSheet,
+			'Sheet1',
+		);
+
+		expect(mockSheet.spreadsheetBatchUpdate).toHaveBeenCalledWith([
+			{
+				deleteDimension: {
+					range: {
+						sheetId: 'Sheet1',
+						dimension: 'ROWS',
+						startIndex: 2,
+						endIndex: 4,
+					},
+				},
+			},
+		]);
+	});
+
+	test('should delete a single column', async () => {
+		mockExecuteFunctions.getNodeParameter = jest.fn((param: string) => {
+			if (param === 'toDelete') return 'columns';
+			if (param === 'startIndex') return 'B';
+			if (param === 'numberToDelete') return 1;
+			return null;
+		}) as unknown as IExecuteFunctions['getNodeParameter'];
+
+		await execute.call(
+			mockExecuteFunctions as IExecuteFunctions,
+			mockSheet as GoogleSheet,
+			'Sheet1',
+		);
+
+		expect(mockSheet.spreadsheetBatchUpdate).toHaveBeenCalledWith([
+			{
+				deleteDimension: {
+					range: {
+						sheetId: 'Sheet1',
+						dimension: 'COLUMNS',
+						startIndex: 1, // 'B' corresponds to index 1 (zero-based)
+						endIndex: 2,
+					},
+				},
+			},
+		]);
+	});
+
+	test('should delete multiple columns', async () => {
+		mockExecuteFunctions.getNodeParameter = jest.fn((param: string) => {
+			if (param === 'toDelete') return 'columns';
+			if (param === 'startIndex') return 'C';
+			if (param === 'numberToDelete') return 3;
+			return null;
+		}) as unknown as IExecuteFunctions['getNodeParameter'];
+
+		await execute.call(
+			mockExecuteFunctions as IExecuteFunctions,
+			mockSheet as GoogleSheet,
+			'Sheet1',
+		);
+
+		expect(mockSheet.spreadsheetBatchUpdate).toHaveBeenCalledWith([
+			{
+				deleteDimension: {
+					range: {
+						sheetId: 'Sheet1',
+						dimension: 'COLUMNS',
+						startIndex: 2, // 'C' corresponds to index 2 (zero-based)
+						endIndex: 5,
+					},
+				},
+			},
+		]);
+	});
+
+	test('should return wrapped success response', async () => {
+		mockExecuteFunctions.getNodeParameter = jest.fn((param: string) => {
+			if (param === 'toDelete') return 'rows';
+			if (param === 'startIndex') return 2;
+			if (param === 'numberToDelete') return 1;
+			return null;
+		}) as unknown as IExecuteFunctions['getNodeParameter'];
+		mockExecuteFunctions.helpers = {
+			constructExecutionMetaData: jest.fn((data) => data),
+		} as unknown as IExecuteFunctions['helpers'];
+
+		const result = await execute.call(
+			mockExecuteFunctions as IExecuteFunctions,
+			mockSheet as GoogleSheet,
+			'Sheet1',
+		);
+		expect(result).toEqual([{ json: { success: true } }]);
+	});
+});

--- a/packages/nodes-base/nodes/Google/Sheet/v1/GoogleSheetsV1.node.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v1/GoogleSheetsV1.node.ts
@@ -23,6 +23,7 @@ import type {
 } from './GoogleSheet';
 import { GoogleSheet } from './GoogleSheet';
 import { versionDescription } from './versionDescription';
+import { generatePairedItemData } from '../../../../utils/utilities';
 import { getGoogleAccessToken } from '../../GenericFunctions';
 
 export class GoogleSheetsV1 implements INodeType {
@@ -293,9 +294,12 @@ export class GoogleSheetsV1 implements INodeType {
 						returnData = [];
 					}
 
+					const pairedItem = generatePairedItemData(items.length);
+
 					const lookupOutput = returnData.map((item) => {
 						return {
 							json: item,
+							pairedItem,
 						};
 					});
 

--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/delete.operation.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/delete.operation.ts
@@ -1,6 +1,6 @@
 import type { IExecuteFunctions, IDataObject, INodeExecutionData } from 'n8n-workflow';
 
-import { wrapData } from '../../../../../../utils/utilities';
+import { generatePairedItemData, wrapData } from '../../../../../../utils/utilities';
 import type { GoogleSheet } from '../../helpers/GoogleSheet';
 import type { SheetProperties } from '../../helpers/GoogleSheets.types';
 import { getColumnNumber, untilSheetSelected } from '../../helpers/GoogleSheets.utils';
@@ -166,7 +166,10 @@ export async function execute(
 		await sheet.spreadsheetBatchUpdate(requests);
 	}
 
-	const returnData = wrapData({ success: true });
+	const itemData = generatePairedItemData(this.getInputData().length);
+	const returnData = this.helpers.constructExecutionMetaData(wrapData({ success: true }), {
+		itemData,
+	});
 
 	return returnData;
 }

--- a/packages/nodes-base/nodes/Hubspot/V2/HubspotV2.node.ts
+++ b/packages/nodes-base/nodes/Hubspot/V2/HubspotV2.node.ts
@@ -38,6 +38,7 @@ import {
 	validateCredentials,
 } from './GenericFunctions';
 import { ticketFields, ticketOperations } from './TicketDescription';
+import { generatePairedItemData } from '../../../utils/utilities';
 
 export class HubspotV2 implements INodeType {
 	description: INodeTypeDescription;
@@ -1184,7 +1185,12 @@ export class HubspotV2 implements INodeType {
 					);
 				}
 
-				const executionData = this.helpers.returnJsonArray(responseData as IDataObject[]);
+				const itemData = generatePairedItemData(items.length);
+
+				const executionData = this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray(responseData as IDataObject[]),
+					{ itemData },
+				);
 				returnData.push(...executionData);
 			} catch (error) {
 				if (this.continueOnFail()) {

--- a/packages/nodes-base/nodes/Microsoft/Excel/v1/MicrosoftExcelV1.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v1/MicrosoftExcelV1.node.ts
@@ -21,6 +21,7 @@ import {
 import { tableFields, tableOperations } from './TableDescription';
 import { workbookFields, workbookOperations } from './WorkbookDescription';
 import { worksheetFields, worksheetOperations } from './WorksheetDescription';
+import { generatePairedItemData } from '../../../../utils/utilities';
 
 const versionDescription: INodeTypeDescription = {
 	displayName: 'Microsoft Excel',
@@ -172,6 +173,7 @@ export class MicrosoftExcelV1 implements INodeType {
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
+		const itemData = generatePairedItemData(items.length);
 		const returnData: INodeExecutionData[] = [];
 		const length = items.length;
 		let qs: IDataObject = {};
@@ -243,12 +245,18 @@ export class MicrosoftExcelV1 implements INodeType {
 						{ 'workbook-session-id': id },
 					);
 
-					const executionData = this.helpers.returnJsonArray(responseData as IDataObject[]);
+					const executionData = this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray(responseData as IDataObject[]),
+						{ itemData },
+					);
 
 					returnData.push(...executionData);
 				} catch (error) {
 					if (this.continueOnFail()) {
-						const executionErrorData = this.helpers.returnJsonArray({ error: error.message });
+						const executionErrorData = this.helpers.constructExecutionMetaData(
+							this.helpers.returnJsonArray({ error: error.message }),
+							{ itemData },
+						);
 						returnData.push(...executionErrorData);
 					} else {
 						throw error;

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/table/append.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/table/append.operation.ts
@@ -5,7 +5,7 @@ import type {
 	INodeProperties,
 } from 'n8n-workflow';
 
-import { processJsonInput, updateDisplayOptions } from '@utils/utilities';
+import { generatePairedItemData, processJsonInput, updateDisplayOptions } from '@utils/utilities';
 
 import type { ExcelResponse } from '../../helpers/interfaces';
 import { prepareOutput } from '../../helpers/utils';
@@ -274,7 +274,11 @@ export async function execute(
 		);
 	} catch (error) {
 		if (this.continueOnFail()) {
-			const executionErrorData = this.helpers.returnJsonArray({ error: error.message });
+			const itemData = generatePairedItemData(this.getInputData().length);
+			const executionErrorData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray({ error: error.message }),
+				{ itemData },
+			);
 			returnData.push(...executionErrorData);
 		} else {
 			throw error;

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/worksheet/update.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/worksheet/update.operation.ts
@@ -6,7 +6,7 @@ import type {
 } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 
-import { processJsonInput, updateDisplayOptions } from '@utils/utilities';
+import { generatePairedItemData, processJsonInput, updateDisplayOptions } from '@utils/utilities';
 
 import type { ExcelResponse, UpdateSummary } from '../../helpers/interfaces';
 import {
@@ -375,7 +375,11 @@ export async function execute(
 		}
 	} catch (error) {
 		if (this.continueOnFail()) {
-			const executionErrorData = this.helpers.returnJsonArray({ error: error.message });
+			const itemData = generatePairedItemData(this.getInputData().length);
+			const executionErrorData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray({ error: error.message }),
+				{ itemData },
+			);
 			returnData.push(...executionErrorData);
 		} else {
 			throw error;

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/worksheet/upsert.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/worksheet/upsert.operation.ts
@@ -6,7 +6,7 @@ import type {
 } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 
-import { processJsonInput, updateDisplayOptions } from '@utils/utilities';
+import { generatePairedItemData, processJsonInput, updateDisplayOptions } from '@utils/utilities';
 
 import type { ExcelResponse, UpdateSummary } from '../../helpers/interfaces';
 import {
@@ -382,7 +382,11 @@ export async function execute(
 		);
 	} catch (error) {
 		if (this.continueOnFail()) {
-			const executionErrorData = this.helpers.returnJsonArray({ error: error.message });
+			const itemData = generatePairedItemData(this.getInputData().length);
+			const executionErrorData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray({ error: error.message }),
+				{ itemData },
+			);
 			returnData.push(...executionErrorData);
 		} else {
 			throw error;

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/helpers/utils.ts
@@ -1,7 +1,7 @@
 import type { IDataObject, IExecuteFunctions, INode, INodeExecutionData } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 
-import { wrapData } from '@utils/utilities';
+import { generatePairedItemData, wrapData } from '@utils/utilities';
 
 import type { ExcelResponse, SheetData, UpdateSummary } from './interfaces';
 
@@ -62,7 +62,11 @@ export function prepareOutput(
 			returnData.push(...executionData);
 		}
 	} else {
-		const executionData = wrapData({ [config.dataProperty || 'data']: responseData });
+		const itemData = generatePairedItemData(this.getInputData().length);
+		const executionData = this.helpers.constructExecutionMetaData(
+			wrapData({ [config.dataProperty || 'data']: responseData }),
+			{ itemData },
+		);
 
 		returnData.push(...executionData);
 	}

--- a/packages/nodes-base/nodes/Microsoft/Sql/MicrosoftSql.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Sql/MicrosoftSql.node.ts
@@ -12,7 +12,7 @@ import {
 	NodeConnectionType,
 } from 'n8n-workflow';
 
-import { flatten, getResolvables } from '@utils/utilities';
+import { flatten, generatePairedItemData, getResolvables } from '@utils/utilities';
 
 import {
 	configurePool,
@@ -343,7 +343,12 @@ export class MicrosoftSql implements INodeType {
 				responseData = await deleteOperation(tables, pool);
 			}
 
-			returnData = this.helpers.returnJsonArray(responseData);
+			const itemData = generatePairedItemData(items.length);
+
+			returnData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(responseData),
+				{ itemData },
+			);
 		} catch (error) {
 			if (this.continueOnFail()) {
 				responseData = items;

--- a/packages/nodes-base/nodes/MongoDb/MongoDb.node.ts
+++ b/packages/nodes-base/nodes/MongoDb/MongoDb.node.ts
@@ -28,6 +28,7 @@ import {
 } from './GenericFunctions';
 import type { IMongoParametricCredentials } from './mongoDb.types';
 import { nodeProperties } from './MongoDbProperties';
+import { generatePairedItemData } from '../../utils/utilities';
 
 export class MongoDb implements INodeType {
 	description: INodeTypeDescription = {
@@ -117,7 +118,7 @@ export class MongoDb implements INodeType {
 		if (nodeVersion >= 1.1) {
 			itemsLength = items.length;
 		} else {
-			fallbackPairedItems = [];
+			fallbackPairedItems = generatePairedItemData(items.length);
 		}
 
 		if (operation === 'aggregate') {
@@ -234,6 +235,7 @@ export class MongoDb implements INodeType {
 		}
 
 		if (operation === 'findOneAndReplace') {
+			fallbackPairedItems = fallbackPairedItems ?? generatePairedItemData(items.length);
 			const fields = prepareFields(this.getNodeParameter('fields', 0) as string);
 			const useDotNotation = this.getNodeParameter('options.useDotNotation', 0, false) as boolean;
 			const dateFields = prepareFields(
@@ -268,10 +270,14 @@ export class MongoDb implements INodeType {
 				}
 			}
 
-			returnData = this.helpers.returnJsonArray(updateItems);
+			returnData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(updateItems),
+				{ itemData: fallbackPairedItems },
+			);
 		}
 
 		if (operation === 'findOneAndUpdate') {
+			fallbackPairedItems = fallbackPairedItems ?? generatePairedItemData(items.length);
 			const fields = prepareFields(this.getNodeParameter('fields', 0) as string);
 			const useDotNotation = this.getNodeParameter('options.useDotNotation', 0, false) as boolean;
 			const dateFields = prepareFields(
@@ -306,10 +312,14 @@ export class MongoDb implements INodeType {
 				}
 			}
 
-			returnData = this.helpers.returnJsonArray(updateItems);
+			returnData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(updateItems),
+				{ itemData: fallbackPairedItems },
+			);
 		}
 
 		if (operation === 'insert') {
+			fallbackPairedItems = fallbackPairedItems ?? generatePairedItemData(items.length);
 			let responseData: IDataObject[] = [];
 			try {
 				// Prepare the data to insert and copy it to be returned
@@ -340,10 +350,14 @@ export class MongoDb implements INodeType {
 				}
 			}
 
-			returnData = this.helpers.returnJsonArray(responseData);
+			returnData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(responseData),
+				{ itemData: fallbackPairedItems },
+			);
 		}
 
 		if (operation === 'update') {
+			fallbackPairedItems = fallbackPairedItems ?? generatePairedItemData(items.length);
 			const fields = prepareFields(this.getNodeParameter('fields', 0) as string);
 			const useDotNotation = this.getNodeParameter('options.useDotNotation', 0, false) as boolean;
 			const dateFields = prepareFields(
@@ -378,7 +392,10 @@ export class MongoDb implements INodeType {
 				}
 			}
 
-			returnData = this.helpers.returnJsonArray(updateItems);
+			returnData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(updateItems),
+				{ itemData: fallbackPairedItems },
+			);
 		}
 
 		await client.close();

--- a/packages/nodes-base/nodes/Postgres/test/v2/runQueries.test.ts
+++ b/packages/nodes-base/nodes/Postgres/test/v2/runQueries.test.ts
@@ -49,7 +49,7 @@ describe('Test PostgresV2, runQueries', () => {
 
 		expect(result).toBeDefined();
 		expect(result).toHaveLength(1);
-		expect(result).toEqual([{ json: { success: true }, pairedItem: undefined }]);
+		expect(result).toEqual([{ json: { success: true }, pairedItem: [{ item: 0 }] }]);
 		expect(dbMultiSpy).toHaveBeenCalledWith('SELECT * FROM table');
 	});
 });

--- a/packages/nodes-base/nodes/Postgres/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/helpers/utils.ts
@@ -19,6 +19,7 @@ import type {
 	SortRule,
 	WhereClause,
 } from './interfaces';
+import { generatePairedItemData } from '../../../../utils/utilities';
 
 export function isJSON(str: string) {
 	try {
@@ -251,15 +252,17 @@ export function configureQueryRunner(
 					.flat();
 
 				if (!returnData.length) {
+					const pairedItem = generatePairedItemData(queries.length);
+
 					if ((options?.nodeVersion as number) < 2.3) {
 						if (emptyReturnData.length) {
-							emptyReturnData[0].pairedItem = undefined;
+							emptyReturnData[0].pairedItem = pairedItem;
 						}
 						returnData = emptyReturnData;
 					} else {
 						returnData = queries.every((query) => isSelectQuery(query.query))
 							? []
-							: [{ json: { success: true } }];
+							: [{ json: { success: true }, pairedItem }];
 					}
 				}
 			} catch (err) {

--- a/packages/nodes-base/nodes/QuickBase/QuickBase.node.ts
+++ b/packages/nodes-base/nodes/QuickBase/QuickBase.node.ts
@@ -19,6 +19,7 @@ import {
 } from './GenericFunctions';
 import { recordFields, recordOperations } from './RecordDescription';
 import { reportFields, reportOperations } from './ReportDescription';
+import { generatePairedItemData } from '../../utils/utilities';
 
 export class QuickBase implements INodeType {
 	description: INodeTypeDescription = {
@@ -113,6 +114,7 @@ export class QuickBase implements INodeType {
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
+		const itemData = generatePairedItemData(items.length);
 		const returnData: INodeExecutionData[] = [];
 		const length = items.length;
 		const qs: IDataObject = {};
@@ -290,7 +292,10 @@ export class QuickBase implements INodeType {
 					}
 				}
 
-				const executionData = this.helpers.returnJsonArray(responseData as IDataObject[]);
+				const executionData = this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray(responseData as IDataObject[]),
+					{ itemData },
+				);
 
 				returnData.push(...executionData);
 			}
@@ -457,7 +462,10 @@ export class QuickBase implements INodeType {
 					}
 				}
 
-				const executionData = this.helpers.returnJsonArray(responseData as IDataObject[]);
+				const executionData = this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray(responseData as IDataObject[]),
+					{ itemData },
+				);
 
 				returnData.push(...executionData);
 			}
@@ -537,7 +545,10 @@ export class QuickBase implements INodeType {
 					}
 				}
 
-				const executionData = this.helpers.returnJsonArray(responseData as IDataObject[]);
+				const executionData = this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray(responseData as IDataObject[]),
+					{ itemData },
+				);
 
 				returnData.push(...executionData);
 			}

--- a/packages/nodes-base/nodes/ReadBinaryFiles/ReadBinaryFiles.node.ts
+++ b/packages/nodes-base/nodes/ReadBinaryFiles/ReadBinaryFiles.node.ts
@@ -7,6 +7,8 @@ import {
 	type INodeTypeDescription,
 } from 'n8n-workflow';
 
+import { generatePairedItemData } from '../../utils/utilities';
+
 export class ReadBinaryFiles implements INodeType {
 	description: INodeTypeDescription = {
 		hidden: true,
@@ -46,6 +48,7 @@ export class ReadBinaryFiles implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const fileSelector = this.getNodeParameter('fileSelector', 0) as string;
 		const dataPropertyName = this.getNodeParameter('dataPropertyName', 0);
+		const pairedItem = generatePairedItemData(this.getInputData().length);
 
 		const files = await glob(fileSelector);
 
@@ -57,6 +60,7 @@ export class ReadBinaryFiles implements INodeType {
 					[dataPropertyName]: await this.helpers.prepareBinaryData(stream, filePath),
 				},
 				json: {},
+				pairedItem,
 			});
 		}
 

--- a/packages/nodes-base/nodes/RespondToWebhook/RespondToWebhook.node.ts
+++ b/packages/nodes-base/nodes/RespondToWebhook/RespondToWebhook.node.ts
@@ -21,7 +21,7 @@ import {
 } from 'n8n-workflow';
 import type { Readable } from 'stream';
 
-import { formatPrivateKey } from '../../utils/utilities';
+import { formatPrivateKey, generatePairedItemData } from '../../utils/utilities';
 
 export class RespondToWebhook implements INodeType {
 	description: INodeTypeDescription = {
@@ -443,7 +443,11 @@ export class RespondToWebhook implements INodeType {
 			this.sendResponse(response);
 		} catch (error) {
 			if (this.continueOnFail()) {
-				const returnData = [{ json: { error: error.message } }];
+				const itemData = generatePairedItemData(items.length);
+				const returnData = this.helpers.constructExecutionMetaData(
+					[{ json: { error: error.message } }],
+					{ itemData },
+				);
 				return [returnData];
 			}
 

--- a/packages/nodes-base/nodes/RespondToWebhook/test/RespondToWebhook.test.ts
+++ b/packages/nodes-base/nodes/RespondToWebhook/test/RespondToWebhook.test.ts
@@ -253,6 +253,7 @@ describe('RespondToWebhook Node', () => {
 				[
 					{
 						json: { error: 'The Response Data option "notSupportedRespondWith" is not supported!' },
+						pairedItem: [{ item: 0 }],
 					},
 				],
 			]);

--- a/packages/nodes-base/nodes/RssFeedRead/RssFeedRead.node.ts
+++ b/packages/nodes-base/nodes/RssFeedRead/RssFeedRead.node.ts
@@ -4,11 +4,12 @@ import type {
 	INodeExecutionData,
 	INodeType,
 	INodeTypeDescription,
-	IPairedItemData,
 } from 'n8n-workflow';
 import { NodeConnectionType, NodeOperationError } from 'n8n-workflow';
 import Parser from 'rss-parser';
 import { URL } from 'url';
+
+import { generatePairedItemData } from '../../utils/utilities';
 
 // Utility function
 
@@ -76,7 +77,7 @@ export class RssFeedRead implements INodeType {
 		if (nodeVersion >= 1.1) {
 			itemsLength = items.length;
 		} else {
-			fallbackPairedItems = [] as IPairedItemData[];
+			fallbackPairedItems = generatePairedItemData(items.length);
 		}
 
 		for (let i = 0; i < itemsLength; i++) {

--- a/packages/nodes-base/nodes/SpreadsheetFile/v1/SpreadsheetFileV1.node.ts
+++ b/packages/nodes-base/nodes/SpreadsheetFile/v1/SpreadsheetFileV1.node.ts
@@ -22,7 +22,7 @@ import {
 } from 'xlsx';
 
 import { oldVersionNotice } from '@utils/descriptions';
-import { flattenObject } from '@utils/utilities';
+import { flattenObject, generatePairedItemData } from '@utils/utilities';
 
 import {
 	operationProperty,
@@ -58,6 +58,7 @@ export class SpreadsheetFileV1 implements INodeType {
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
+		const pairedItem = generatePairedItemData(items.length);
 
 		const operation = this.getNodeParameter('operation', 0);
 
@@ -229,6 +230,7 @@ export class SpreadsheetFileV1 implements INodeType {
 				const newItem: INodeExecutionData = {
 					json: {},
 					binary: {},
+					pairedItem,
 				};
 
 				let fileName = `spreadsheet.${fileFormat}`;
@@ -245,6 +247,7 @@ export class SpreadsheetFileV1 implements INodeType {
 						json: {
 							error: error.message,
 						},
+						pairedItem,
 					});
 				} else {
 					throw error;

--- a/packages/nodes-base/nodes/SpreadsheetFile/v2/toFile.operation.ts
+++ b/packages/nodes-base/nodes/SpreadsheetFile/v2/toFile.operation.ts
@@ -2,6 +2,7 @@ import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n
 
 import type { JsonToSpreadsheetBinaryFormat, JsonToSpreadsheetBinaryOptions } from '@utils/binary';
 import { convertJsonToSpreadsheetBinary } from '@utils/binary';
+import { generatePairedItemData } from '@utils/utilities';
 
 import { toFileOptions, toFileProperties } from '../description';
 
@@ -9,6 +10,8 @@ export const description: INodeProperties[] = [...toFileProperties, toFileOption
 
 export async function execute(this: IExecuteFunctions, items: INodeExecutionData[]) {
 	const returnData: INodeExecutionData[] = [];
+
+	const pairedItem = generatePairedItemData(items.length);
 
 	try {
 		const binaryPropertyName = this.getNodeParameter('binaryPropertyName', 0);
@@ -22,6 +25,7 @@ export async function execute(this: IExecuteFunctions, items: INodeExecutionData
 			binary: {
 				[binaryPropertyName]: binaryData,
 			},
+			pairedItem,
 		};
 
 		returnData.push(newItem);
@@ -31,6 +35,7 @@ export async function execute(this: IExecuteFunctions, items: INodeExecutionData
 				json: {
 					error: error.message,
 				},
+				pairedItem,
 			});
 		} else {
 			throw error;

--- a/packages/nodes-base/nodes/Stackby/Stackby.node.ts
+++ b/packages/nodes-base/nodes/Stackby/Stackby.node.ts
@@ -9,6 +9,7 @@ import { NodeConnectionType, NodeOperationError } from 'n8n-workflow';
 
 import type { IRecord } from './GenericFunction';
 import { apiRequest, apiRequestAllItems } from './GenericFunction';
+import { generatePairedItemData } from '../../utils/utilities';
 
 export class Stackby implements INodeType {
 	description: INodeTypeDescription = {
@@ -283,7 +284,11 @@ export class Stackby implements INodeType {
 				);
 			} catch (error) {
 				if (this.continueOnFail()) {
-					const executionErrorData = this.helpers.returnJsonArray({ error: error.message });
+					const itemData = generatePairedItemData(items.length);
+					const executionErrorData = this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: error.message }),
+						{ itemData },
+					);
 					returnData.push(...executionErrorData);
 				} else {
 					throw error;

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-base",
-  "version": "1.79.0",
+  "version": "1.79.1",
   "description": "Base nodes of n8n",
   "main": "index.js",
   "scripts": {

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-base",
-  "version": "1.79.1",
+  "version": "1.79.2",
   "description": "Base nodes of n8n",
   "main": "index.js",
   "scripts": {

--- a/packages/nodes-base/test/nodes/Helpers.ts
+++ b/packages/nodes-base/test/nodes/Helpers.ts
@@ -386,7 +386,7 @@ export const getWorkflowFilenames = (dirname: string) => {
 	return workflows;
 };
 
-export const createMockExecuteFunction = (
+export const createMockExecuteFunction = <T = IExecuteFunctions>(
 	nodeParameters: IDataObject,
 	nodeMock: INode,
 	continueBool = false,
@@ -410,6 +410,6 @@ export const createMockExecuteFunction = (
 		helpers: {
 			constructExecutionMetaData,
 		},
-	} as unknown as IExecuteFunctions;
+	} as unknown as T;
 	return fakeExecuteFunction;
 };

--- a/packages/nodes-base/utils/workflowInputsResourceMapping/GenericFunctions.ts
+++ b/packages/nodes-base/utils/workflowInputsResourceMapping/GenericFunctions.ts
@@ -9,8 +9,9 @@ import type {
 	IDataObject,
 	ResourceMapperField,
 	ILocalLoadOptionsFunctions,
-	ISupplyDataFunctions,
 	WorkflowInputsData,
+	IExecuteFunctions,
+	ISupplyDataFunctions,
 } from 'n8n-workflow';
 import { jsonParse, NodeOperationError, EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE } from 'n8n-workflow';
 
@@ -100,7 +101,9 @@ export function getFieldEntries(context: IWorkflowNodeContext): {
 	throw new NodeOperationError(context.getNode(), result);
 }
 
-export function getWorkflowInputValues(this: ISupplyDataFunctions): INodeExecutionData[] {
+export function getWorkflowInputValues(
+	this: IExecuteFunctions | ISupplyDataFunctions,
+): INodeExecutionData[] {
 	const inputData = this.getInputData();
 
 	return inputData.map(({ json, binary }, itemIndex) => {
@@ -124,7 +127,7 @@ export function getWorkflowInputValues(this: ISupplyDataFunctions): INodeExecuti
 	});
 }
 
-export function getCurrentWorkflowInputData(this: ISupplyDataFunctions) {
+export function getCurrentWorkflowInputData(this: IExecuteFunctions | ISupplyDataFunctions) {
 	const inputData: INodeExecutionData[] = getWorkflowInputValues.call(this);
 
 	const schema = this.getNodeParameter('workflowInputs.schema', 0, []) as ResourceMapperField[];

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-workflow",
-  "version": "1.78.0",
+  "version": "1.78.1",
   "description": "Workflow base code of n8n",
   "main": "dist/index.js",
   "module": "src/index.ts",

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -985,6 +985,10 @@ export type ISupplyDataFunctions = ExecuteFunctions.GetNodeParameterFn &
 		getExecutionCancelSignal(): AbortSignal | undefined;
 		onExecutionCancellation(handler: () => unknown): void;
 		logAiEvent(eventName: AiEvent, msg?: string | undefined): void;
+		cloneWith(replacements: {
+			runIndex: number;
+			inputData: INodeExecutionData[][];
+		}): ISupplyDataFunctions;
 	};
 
 export interface IExecutePaginationFunctions extends IExecuteSingleFunctions {

--- a/packages/workflow/src/Workflow.ts
+++ b/packages/workflow/src/Workflow.ts
@@ -508,6 +508,9 @@ export class Workflow {
 					return;
 				}
 
+				// Ignore connections for nodes that don't exist in this workflow
+				if (!(connection.node in this.nodes)) return;
+
 				addNodes = this.getHighestNode(connection.node, type, undefined, checkedNodes);
 
 				if (addNodes.length === 0) {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Propagates pairedItem metadata across many nodes, overhauls workflow listing (filters, sorting, pagination), enriches lifecycle events with userId, adds legacy `$items()` and legacy public API key support, and refactors tool execution context handling.
> 
> - **Core/Execution Engine**
>   - Add `SupplyDataContext.cloneWith()` and use `NodeConnectionType` directly; tests added.
>   - Built-ins parser: support legacy `$items(...)` detection.
>   - `Workflow.getHighestNode()` skips non-existent nodes when traversing connections.
> - **CLI/Backend**
>   - Rewrite `WorkflowRepository.getMany()` using query builder: name/active/project filters, ANDed tag filtering, case-insensitive name sort, pagination, and relation selects.
>   - Lifecycle hooks now accept a single data object; include `userId` in `workflow-post-execute` events; update scaling main/worker, job processor, runner.
>   - Public API: accept legacy (non-JWT) API keys; expired JWTs rejected.
> - **LangChain/Agents & Tools**
>   - Refactor `WorkflowToolService` to clone execution context per tool call and manage `runIndex`; update tests to use `ISupplyDataFunctions` and new signatures.
>   - `ToolsAgent`: move parser/tool retrieval outside the item loop.
>   - Vector store helpers accept `IExecuteFunctions | ISupplyDataFunctions`.
> - **Nodes (pairedItem propagation and error handling)**
>   - Add consistent `pairedItem` and use `constructExecutionMetaData` across Airtable, Google Sheets/BigQuery/Firebase, Microsoft Excel/SQL, MongoDB, Postgres, Kafka, QuickBase, ReadBinaryFiles, RespondToWebhook, RSS, SpreadsheetFile, Files Convert actions.
> - **Editor UI**
>   - Clear popup state before showing Form Trigger popup.
> - **Tests**
>   - Extensive updates/coverage for new behaviors: `$items()`, workflow listing (tags AND, pagination, name sort), lifecycle events with `userId`, legacy/expired API keys, node outputs with `pairedItem`.
> - **Version bumps**
>   - Bump versions across packages (n8n 1.80.3, nodes-langchain 1.80.2, task-runner 1.17.1, core/workflow/node-dev patch).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de4d26dc5f42ee572a509bdd5932e9564f5a4aee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->