### PR TITLE
Fix message data insertion in chat

### DIFF
--- a/packages/cli/src/modules/chat-hub/chat-message.repository.ts
+++ b/packages/cli/src/modules/chat-hub/chat-message.repository.ts
@@ -20,7 +20,8 @@ export class ChatHubMessageRepository extends Repository<ChatHubMessage> {
 			this.manager,
 			trx,
 			async (em) => {
-				await em.insert(ChatHubMessage, message);
+				const messageData = { ...message };
+				await em.insert(ChatHubMessage, messageData);
 				const saved = await em.findOneOrFail(ChatHubMessage, {
 					where: { id: message.id },
 				});


### PR DESCRIPTION
Clone message data before insertion to prevent unintended mutations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clone the `message` object before database insert in `createChatMessage` to avoid unintended mutations.
> 
> - **Chat Hub**
>   - `packages/cli/src/modules/chat-hub/chat-message.repository.ts`:
>     - In `createChatMessage`, clone input into `messageData` before `em.insert` to prevent mutation side effects.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8fd8ac51fa8a83dd2938f36725c71ba8a91225df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->