### PR TITLE
feat: Add unit tests for getAttributesFromLoginResponse and handleSamlLogin

### DIFF
--- a/packages/cli/src/sso.ee/saml/__tests__/saml-helpers.test.ts
+++ b/packages/cli/src/sso.ee/saml/__tests__/saml-helpers.test.ts
@@ -205,4 +205,44 @@ describe('sso/saml/samlHelpers', () => {
 			missingAttributes: [],
 		});
 	});
+
+	test('maps single projectRoles string to array', () => {
+		const flowResult = {
+			extract: {
+				attributes: {
+					email: 'test@test.com',
+					firstName: 'test',
+					lastName: 'test',
+					userPrincipalName: 'test',
+					projectRoles: 'projectRole1',
+				},
+			},
+		} as any;
+		const attributeMapping = {
+			email: 'email',
+			instanceRole: 'instanceRole',
+			firstName: 'firstName',
+			lastName: 'lastName',
+			userPrincipalName: 'userPrincipalName',
+		};
+		const jitClaimNames = {
+			instanceRole: 'instanceRole',
+			projectRoles: 'projectRoles',
+		};
+		const result = helpers.getMappedSamlAttributesFromFlowResult(
+			flowResult,
+			attributeMapping,
+			jitClaimNames,
+		);
+		expect(result).toEqual({
+			attributes: {
+				email: 'test@test.com',
+				firstName: 'test',
+				lastName: 'test',
+				userPrincipalName: 'test',
+				n8nProjectRoles: ['projectRole1'],
+			},
+			missingAttributes: [],
+		});
+	});
 });

--- a/packages/cli/src/sso.ee/saml/__tests__/saml-helpers.test.ts
+++ b/packages/cli/src/sso.ee/saml/__tests__/saml-helpers.test.ts
@@ -133,7 +133,6 @@ describe('sso/saml/samlHelpers', () => {
 						firstName: 'test',
 						lastName: 'test',
 						userPrincipalName: 'test',
-						projectRoles: ['projectRole1', 'projectRole2'],
 						instanceRole: 'instanceRole',
 					},
 				},
@@ -161,10 +160,49 @@ describe('sso/saml/samlHelpers', () => {
 					firstName: 'test',
 					lastName: 'test',
 					userPrincipalName: 'test',
-					n8nProjectRoles: ['projectRole1', 'projectRole2'],
 				},
 				missingAttributes: [],
 			});
+		});
+	});
+
+	test('returns the attributes from the flow result with project roles', () => {
+		const flowResult = {
+			extract: {
+				attributes: {
+					email: 'test@test.com',
+					firstName: 'test',
+					lastName: 'test',
+					userPrincipalName: 'test',
+					projectRoles: ['projectRole1', 'projectRole2'],
+				},
+			},
+		} as any;
+		const attributeMapping = {
+			email: 'email',
+			instanceRole: 'instanceRole',
+			firstName: 'firstName',
+			lastName: 'lastName',
+			userPrincipalName: 'userPrincipalName',
+		};
+		const jitClaimNames = {
+			instanceRole: 'instanceRole',
+			projectRoles: 'projectRoles',
+		};
+		const result = helpers.getMappedSamlAttributesFromFlowResult(
+			flowResult,
+			attributeMapping,
+			jitClaimNames,
+		);
+		expect(result).toEqual({
+			attributes: {
+				email: 'test@test.com',
+				firstName: 'test',
+				lastName: 'test',
+				userPrincipalName: 'test',
+				n8nProjectRoles: ['projectRole1', 'projectRole2'],
+			},
+			missingAttributes: [],
 		});
 	});
 });

--- a/packages/cli/src/sso.ee/saml/__tests__/saml.service.ee.test.ts
+++ b/packages/cli/src/sso.ee/saml/__tests__/saml.service.ee.test.ts
@@ -421,7 +421,7 @@ describe('SamlService', () => {
 			});
 		});
 
-		it('logs in the user if just-in-time provisioning is disabled', async () => {
+		it('logs in the user if just-in-time provisioning is enabled', async () => {
 			const samlAttributes = {
 				email: 'foo@bar.com',
 				firstName: '',

--- a/packages/cli/src/sso.ee/saml/__tests__/saml.service.ee.test.ts
+++ b/packages/cli/src/sso.ee/saml/__tests__/saml.service.ee.test.ts
@@ -400,7 +400,32 @@ describe('SamlService', () => {
 			});
 		});
 
-		it('does not log in the user if just-in-time provisioning is disabled', async () => {
+		it('logs in user that has not completed onboarding', async () => {
+			const samlAttributes = {
+				email: 'foo@bar.com',
+				firstName: '',
+				lastName: '',
+				userPrincipalName: 'foo@bar.com',
+			};
+			const mockUser = {
+				id: '123',
+				email: samlAttributes.email,
+				authIdentities: [],
+			} as any;
+			jest.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue(samlAttributes);
+			jest.spyOn(userRepository, 'findOne').mockResolvedValue(mockUser);
+			jest.spyOn(samlHelpers, 'updateUserFromSamlAttributes').mockResolvedValue(mockUser);
+
+			const loginResult = await samlService.handleSamlLogin(mock<express.Request>(), 'post');
+
+			expect(loginResult).toEqual({
+				authenticatedUser: mockUser,
+				attributes: samlAttributes,
+				onboardingRequired: true,
+			});
+		});
+
+		it('does not log in the user if sso just-in-time provisioning is disabled', async () => {
 			const samlAttributes = {
 				email: 'foo@bar.com',
 				firstName: '',

--- a/packages/cli/src/sso.ee/saml/__tests__/saml.service.ee.test.ts
+++ b/packages/cli/src/sso.ee/saml/__tests__/saml.service.ee.test.ts
@@ -2,7 +2,7 @@ import type { SamlPreferences } from '@n8n/api-types';
 import { mockInstance, mockLogger } from '@n8n/backend-test-utils';
 import type { GlobalConfig } from '@n8n/config';
 import { SettingsRepository } from '@n8n/db';
-import type { UserRepository, Settings } from '@n8n/db';
+import type { UserRepository, Settings, User } from '@n8n/db';
 import { Container } from '@n8n/di';
 import axios from 'axios';
 import type express from 'express';
@@ -251,6 +251,46 @@ describe('SamlService', () => {
 				'SAML Authentication failed. Invalid SAML response (missing attributes: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress, http://schemas.xmlsoap.org/ws/2005/05/identity/claims/firstname, http://schemas.xmlsoap.org/ws/2005/05/identity/claims/lastname, http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn).',
 			);
 		});
+
+		test('returns the attributes when they are present', async () => {
+			jest
+				.spyOn(samlService, 'getIdentityProviderInstance')
+				.mockReturnValue(mock<IdentityProviderInstance>());
+			const serviceProviderInstance = mock<ServiceProviderInstance>();
+			serviceProviderInstance.parseLoginResponse.mockResolvedValue({
+				samlContent: '',
+				extract: {},
+			});
+			jest
+				.spyOn(samlService, 'getServiceProviderInstance')
+				.mockReturnValue(serviceProviderInstance);
+
+			jest.spyOn(samlHelpers, 'getMappedSamlAttributesFromFlowResult').mockReturnValue({
+				attributes: {
+					email: 'test@test.com',
+					firstName: 'test',
+					lastName: 'test',
+					userPrincipalName: 'test',
+					n8nInstanceRole: 'global:admin',
+					n8nProjectRoles: ['projectRole1', 'projectRole2'],
+				},
+				missingAttributes: [],
+			});
+
+			const attributes = await samlService.getAttributesFromLoginResponse(
+				mock<express.Request>(),
+				'post',
+			);
+
+			expect(attributes).toEqual({
+				email: 'test@test.com',
+				firstName: 'test',
+				lastName: 'test',
+				userPrincipalName: 'test',
+				n8nInstanceRole: 'global:admin',
+				n8nProjectRoles: ['projectRole1', 'projectRole2'],
+			});
+		});
 	});
 
 	describe('init', () => {
@@ -320,10 +360,7 @@ describe('SamlService', () => {
 		});
 	});
 
-	// TODO: add tests for getAttributesFromLoginResponse
-
 	describe('handleSamlLogin', () => {
-		// TODO: add test cases for remaining logic (so far only for onboarding user)
 		it('throws error for invalid email', async () => {
 			jest.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue({
 				email: 'invalid',
@@ -360,6 +397,50 @@ describe('SamlService', () => {
 				authenticatedUser: mockUser,
 				attributes: samlAttributes,
 				onboardingRequired: false,
+			});
+		});
+
+		it('does not log in the user if just-in-time provisioning is disabled', async () => {
+			const samlAttributes = {
+				email: 'foo@bar.com',
+				firstName: '',
+				lastName: '',
+				userPrincipalName: 'foo@bar.com',
+			};
+
+			jest.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue(samlAttributes);
+			jest.spyOn(userRepository, 'findOne').mockResolvedValue(null);
+			jest.spyOn(ssoHelpers, 'isSsoJustInTimeProvisioningEnabled').mockReturnValue(false);
+
+			const loginResult = await samlService.handleSamlLogin(mock<express.Request>(), 'post');
+
+			expect(loginResult).toEqual({
+				authenticatedUser: undefined,
+				attributes: samlAttributes,
+				onboardingRequired: false,
+			});
+		});
+
+		it('logs in the user if just-in-time provisioning is disabled', async () => {
+			const samlAttributes = {
+				email: 'foo@bar.com',
+				firstName: '',
+				lastName: '',
+				userPrincipalName: 'foo@bar.com',
+			};
+			const mockUser = mock<User>();
+
+			jest.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue(samlAttributes);
+			jest.spyOn(userRepository, 'findOne').mockResolvedValue(null);
+			jest.spyOn(samlHelpers, 'createUserFromSamlAttributes').mockResolvedValue(mockUser);
+			jest.spyOn(ssoHelpers, 'isSsoJustInTimeProvisioningEnabled').mockReturnValue(true);
+
+			const loginResult = await samlService.handleSamlLogin(mock<express.Request>(), 'post');
+
+			expect(loginResult).toEqual({
+				authenticatedUser: mockUser,
+				attributes: samlAttributes,
+				onboardingRequired: true,
 			});
 		});
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR adds additional branching unit tests cases for SAML attribute parsing, and SAML login branches

## Related Linear tickets, Github issues, and Community forum posts

PAY-4066

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add comprehensive unit tests for SAML attribute extraction (including project roles) and handleSamlLogin branches, including JIT provisioning and role provisioning paths.
> 
> - **Tests**:
>   - **SAML helpers (`saml-helpers.test.ts`)**:
>     - Add coverage for `projectRoles` mapping, including single-string to array conversion (`n8nProjectRoles`).
>     - Adjust instance-role-only case to exclude `n8nProjectRoles`.
>   - **SAML service (`saml.service.ee.test.ts`)**:
>     - Add success-path test for `getAttributesFromLoginResponse` with mapped roles.
>     - Extend `handleSamlLogin` tests: invalid email, existing user (onboarded), existing user (not onboarded), JIT disabled (no login), JIT enabled (user creation), and provisioning of instance/project roles.
>     - Minor import update to include `User` and remove TODO comments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6372bc2c6d22e8344cc6de59e91f59ce241318fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->