### PR TITLE
fix(editor): Ensure license activation modal works when used without EULA

### DIFF
--- a/packages/frontend/editor-ui/src/features/settings/usage/views/SettingsUsageAndPlan.vue
+++ b/packages/frontend/editor-ui/src/features/settings/usage/views/SettingsUsageAndPlan.vue
@@ -321,7 +321,7 @@ const openCommunityRegisterModal = () => {
 					<N8nButton type="secondary" @click="activationKeyModal = false">
 						{{ locale.baseText('settings.usageAndPlan.dialog.activation.cancel') }}
 					</N8nButton>
-					<N8nButton :disabled="!activationKey" @click="onLicenseActivation">
+					<N8nButton :disabled="!activationKey" @click="() => onLicenseActivation()">
 						{{ locale.baseText('settings.usageAndPlan.dialog.activation.activate') }}
 					</N8nButton>
 				</template>

--- a/packages/frontend/editor-ui/src/features/settings/usage/views/SettingsUsageAndPlan.vue
+++ b/packages/frontend/editor-ui/src/features/settings/usage/views/SettingsUsageAndPlan.vue
@@ -103,7 +103,7 @@ const isEulaError = (error: unknown): error is EulaErrorResponse => {
 
 const onLicenseActivation = async (eulaUri?: string) => {
 	try {
-		await usageStore.activateLicense(activationKey.value, eulaUri);
+		await usageStore.activateLicense(activationKey.value.trim(), eulaUri?.trim());
 		activationKeyModal.value = false;
 		eulaModal.value = false;
 		activationKey.value = '';


### PR DESCRIPTION
## Summary

Avoid passing the click event as the eula string.

Also avoid issues with trailing whitespace. (Which the community issue was about)

## Related Linear tickets, Github issues, and Community forum posts

#21654 
https://linear.app/n8n/issue/ADO-4388/community-issue-activation-failed-when-entering-an-activation-key

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Trim activation inputs before calling `activateLicense`, and update/add tests for activation flows and error messaging.
> 
> - **Frontend**
>   - `SettingsUsageAndPlan.vue`: Trim `activationKey` and optional `eulaUri` before calling `usageStore.activateLicense`; adjust activation button to call `onLicenseActivation()` via arrow function.
> - **Tests**
>   - `SettingsUsageAndPlan.test.ts`: Add test for non‑EULA activation success path; update error toast expectation to use explicit 'Activation failed' message; retain EULA flow tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10db047e59f668abda5abc680476874ab873e048. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->