### PR TITLE
feat(core): Return WWW-Authenticate header in `/mcp-server/http` endpoint

### DIFF
--- a/packages/@n8n/decorators/src/controller/index.ts
+++ b/packages/@n8n/decorators/src/controller/index.ts
@@ -1,7 +1,7 @@
 export { Body, Query, Param } from './args';
 export { RestController } from './rest-controller';
 export { RootLevelController } from './root-level-controller';
-export { Get, Post, Put, Patch, Delete, Options } from './route';
+export { Get, Post, Put, Patch, Delete, Head, Options } from './route';
 export { Middleware } from './middleware';
 export { ControllerRegistryMetadata } from './controller-registry-metadata';
 export { Licensed } from './licensed';

--- a/packages/@n8n/decorators/src/controller/route.ts
+++ b/packages/@n8n/decorators/src/controller/route.ts
@@ -42,4 +42,5 @@ export const Post = RouteFactory('post');
 export const Put = RouteFactory('put');
 export const Patch = RouteFactory('patch');
 export const Delete = RouteFactory('delete');
+export const Head = RouteFactory('head');
 export const Options = RouteFactory('options');

--- a/packages/@n8n/decorators/src/controller/types.ts
+++ b/packages/@n8n/decorators/src/controller/types.ts
@@ -3,7 +3,7 @@ import type { Constructable } from '@n8n/di';
 import type { Scope } from '@n8n/permissions';
 import type { RequestHandler, Router } from 'express';
 
-export type Method = 'get' | 'post' | 'put' | 'patch' | 'delete' | 'options';
+export type Method = 'get' | 'post' | 'put' | 'patch' | 'delete' | 'head' | 'options';
 
 export type Arg = { type: 'body' | 'query' } | { type: 'param'; key: string };
 

--- a/packages/cli/src/modules/mcp/__tests__/mcp-server-middleware.service.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp-server-middleware.service.test.ts
@@ -139,17 +139,19 @@ describe('McpServerMiddlewareService', () => {
 	});
 
 	describe('getAuthMiddleware', () => {
-		it('should return 401 when authorization header is missing', async () => {
+		it('should return 401 with WWW-Authenticate header when authorization header is missing', async () => {
 			const req = mockReqWith(undefined);
 			const res = mockDeep<Response>();
 			res.status.mockReturnThis();
 			res.send.mockReturnThis();
+			res.header.mockReturnThis();
 			const next = jest.fn() as NextFunction;
 
 			const middleware = service.getAuthMiddleware();
 
 			await middleware(req, res, next);
 
+			expect(res.header).toHaveBeenCalledWith('WWW-Authenticate', 'Bearer realm="n8n MCP Server"');
 			expect(res.status).toHaveBeenCalledWith(401);
 			expect(res.send).toHaveBeenCalledWith({ message: 'Unauthorized' });
 			expect(next).not.toHaveBeenCalled();
@@ -234,7 +236,7 @@ describe('McpServerMiddlewareService', () => {
 			expect(res.status).not.toHaveBeenCalled();
 		});
 
-		it('should return 401 when token validation fails', async () => {
+		it('should return 401 with WWW-Authenticate header when token validation fails', async () => {
 			const invalidToken = jwtService.sign({
 				sub: 'user-123',
 				aud: 'mcp-server-api',
@@ -245,6 +247,7 @@ describe('McpServerMiddlewareService', () => {
 			const res = mockDeep<Response>();
 			res.status.mockReturnThis();
 			res.send.mockReturnThis();
+			res.header.mockReturnThis();
 			const next = jest.fn() as NextFunction;
 
 			oauthTokenService.verifyOAuthAccessToken.mockResolvedValue(null);
@@ -253,6 +256,7 @@ describe('McpServerMiddlewareService', () => {
 
 			await middleware(req, res, next);
 
+			expect(res.header).toHaveBeenCalledWith('WWW-Authenticate', 'Bearer realm="n8n MCP Server"');
 			expect(res.status).toHaveBeenCalledWith(401);
 			expect(res.send).toHaveBeenCalledWith({ message: 'Unauthorized' });
 			expect(next).not.toHaveBeenCalled();
@@ -270,12 +274,14 @@ describe('McpServerMiddlewareService', () => {
 			const res = mockDeep<Response>();
 			res.status.mockReturnThis();
 			res.send.mockReturnThis();
+			res.header.mockReturnThis();
 			const next = jest.fn() as NextFunction;
 
 			const middleware = service.getAuthMiddleware();
 
 			await middleware(req, res, next);
 
+			expect(res.header).toHaveBeenCalledWith('WWW-Authenticate', 'Bearer realm="n8n MCP Server"');
 			expect(telemetry.track).toHaveBeenCalledWith('User connected to MCP server', {
 				mcp_connection_status: 'error',
 				error: 'Unauthorized',
@@ -284,11 +290,12 @@ describe('McpServerMiddlewareService', () => {
 			});
 		});
 
-		it('should handle invalid token format gracefully', async () => {
+		it('should handle invalid token format gracefully with WWW-Authenticate header', async () => {
 			const req = mockReqWith('Bearer invalid-token-format');
 			const res = mockDeep<Response>();
 			res.status.mockReturnThis();
 			res.send.mockReturnThis();
+			res.header.mockReturnThis();
 			const next = jest.fn() as NextFunction;
 
 			mcpServerApiKeyService.verifyApiKey.mockResolvedValue(null);
@@ -297,6 +304,7 @@ describe('McpServerMiddlewareService', () => {
 
 			await middleware(req, res, next);
 
+			expect(res.header).toHaveBeenCalledWith('WWW-Authenticate', 'Bearer realm="n8n MCP Server"');
 			expect(res.status).toHaveBeenCalledWith(401);
 			expect(res.send).toHaveBeenCalledWith({ message: 'Unauthorized' });
 			expect(next).not.toHaveBeenCalled();

--- a/packages/cli/src/modules/mcp/__tests__/mcp.controller.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp.controller.test.ts
@@ -1,6 +1,7 @@
 import { Logger } from '@n8n/backend-common';
 import { type AuthenticatedRequest } from '@n8n/db';
 import { Container } from '@n8n/di';
+import type { Request } from 'express';
 import { mock, mockDeep } from 'jest-mock-extended';
 
 // eslint-disable-next-line import-x/order
@@ -71,5 +72,17 @@ describe('McpController', () => {
 		const res = createRes();
 		await controller.build(createReq(), res);
 		expect(mcpService.getServer as unknown as jest.Mock).toHaveBeenCalled();
+	});
+
+	test('GET /http returns 401 with WWW-Authenticate header for auth scheme discovery', async () => {
+		const req = {} as Request;
+		const res = createRes();
+		res.header = jest.fn().mockReturnThis();
+
+		await controller.discoverAuthScheme(req, res);
+
+		expect(res.header).toHaveBeenCalledWith('WWW-Authenticate', 'Bearer realm="n8n MCP Server"');
+		expect(res.status).toHaveBeenCalledWith(401);
+		expect(res.json).toHaveBeenCalledWith({ message: 'Unauthorized' });
 	});
 });

--- a/packages/cli/src/modules/mcp/__tests__/mcp.controller.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp.controller.test.ts
@@ -74,15 +74,16 @@ describe('McpController', () => {
 		expect(mcpService.getServer as unknown as jest.Mock).toHaveBeenCalled();
 	});
 
-	test('GET /http returns 401 with WWW-Authenticate header for auth scheme discovery', async () => {
+	test('HEAD /http returns 401 with WWW-Authenticate header for auth scheme discovery', async () => {
 		const req = {} as Request;
 		const res = createRes();
 		res.header = jest.fn().mockReturnThis();
+		res.end = jest.fn().mockReturnThis();
 
-		await controller.discoverAuthScheme(req, res);
+		await controller.discoverAuthSchemeHead(req, res);
 
 		expect(res.header).toHaveBeenCalledWith('WWW-Authenticate', 'Bearer realm="n8n MCP Server"');
 		expect(res.status).toHaveBeenCalledWith(401);
-		expect(res.json).toHaveBeenCalledWith({ message: 'Unauthorized' });
+		expect(res.end).toHaveBeenCalled();
 	});
 });

--- a/packages/cli/src/modules/mcp/mcp-server-middleware.service.ts
+++ b/packages/cli/src/modules/mcp/mcp-server-middleware.service.ts
@@ -92,6 +92,8 @@ export class McpServerMiddlewareService {
 
 	private responseWithUnauthorized(res: Response, req: Request) {
 		this.trackUnauthorizedEvent(req);
+		// RFC 6750 Section 3: Include WWW-Authenticate header for 401 responses
+		res.header('WWW-Authenticate', 'Bearer realm="n8n MCP Server"');
 		res.status(401).send({ message: UNAUTHORIZED_ERROR_MESSAGE });
 	}
 

--- a/packages/cli/src/modules/mcp/mcp.controller.ts
+++ b/packages/cli/src/modules/mcp/mcp.controller.ts
@@ -12,7 +12,6 @@ import {
 	USER_CONNECTED_TO_MCP_EVENT,
 	MCP_ACCESS_DISABLED_ERROR_MESSAGE,
 	INTERNAL_SERVER_ERROR_MESSAGE,
-	UNAUTHORIZED_ERROR_MESSAGE,
 } from './mcp.constants';
 import { McpService } from './mcp.service';
 import { McpSettingsService } from './mcp.settings.service';

--- a/packages/cli/src/modules/mcp/mcp.controller.ts
+++ b/packages/cli/src/modules/mcp/mcp.controller.ts
@@ -1,6 +1,6 @@
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { AuthenticatedRequest } from '@n8n/db';
-import { Get, Post, RootLevelController } from '@n8n/decorators';
+import { Head, Post, RootLevelController } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 import type { Request, Response } from 'express';
 import { ErrorReporter } from 'n8n-core';
@@ -53,18 +53,18 @@ export class McpController {
 	// }
 
 	/**
-	 * GET endpoint for authentication scheme discovery
+	 * HEAD endpoint for authentication scheme discovery
 	 * Per RFC 6750 Section 3, returns 401 with WWW-Authenticate header
 	 * This allows MCP clients to probe the endpoint and discover Bearer token authentication
 	 */
-	@Get('/http', {
+	@Head('/http', {
 		skipAuth: true,
+		usesTemplates: true,
 	})
-	async discoverAuthScheme(_req: Request, res: Response) {
+	async discoverAuthSchemeHead(_req: Request, res: Response) {
 		this.setCorsHeaders(res);
-		// RFC 6750 Section 3: Return WWW-Authenticate header with 401
 		res.header('WWW-Authenticate', 'Bearer realm="n8n MCP Server"');
-		res.status(401).json({ message: UNAUTHORIZED_ERROR_MESSAGE });
+		res.status(401).end();
 	}
 
 	@Post('/http', {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `HEAD /mcp-server/http` for auth scheme discovery and returns `WWW-Authenticate` on 401 responses; introduces `Head` route decorator support.
> 
> - **MCP HTTP endpoint**:
>   - Add `HEAD /mcp-server/http` for auth discovery; responds `401` with `WWW-Authenticate: Bearer realm="n8n MCP Server"` and CORS headers.
>   - Auth middleware now includes `WWW-Authenticate` header on 401 responses.
>   - Tests updated and added to assert header behavior and new HEAD route.
> - **Decorators**:
>   - Introduce `Head` route decorator: export from `index.ts`, implement via `RouteFactory('head')`, and extend `Method` type to include `"head"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f90cde4def28a1e6ba510f5faf5995d3ce7a8311. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->