### PR TITLE
chore(core): Remove md5 usage for user id generation in postgres

### DIFF
--- a/packages/@n8n/db/src/migrations/postgresdb/1762771264000-ChangeDefaultForIdInUserTable.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/1762771264000-ChangeDefaultForIdInUserTable.ts
@@ -10,7 +10,7 @@ export class ChangeDefaultForIdInUserTable1762771264000 implements IrreversibleM
 		const idColumnName = escape.columnName('id');
 
 		await queryRunner.query(
-			`ALTER TABLE "${tableName}" ALTER COLUMN "${idColumnName}" SET DEFAULT gen_random_uuid()`,
+			`ALTER TABLE ${tableName} ALTER COLUMN ${idColumnName} SET DEFAULT gen_random_uuid()`,
 		);
 	}
 }

--- a/packages/@n8n/db/src/migrations/postgresdb/1762771264000-ChangeDefaultForIdInUserTable.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/1762771264000-ChangeDefaultForIdInUserTable.ts
@@ -1,0 +1,16 @@
+import type { IrreversibleMigration, MigrationContext } from '../migration-types';
+
+/**
+ * PostgreSQL-specific migration to change the default value for the `id` column in `user` table from a custom implementation to generate
+ * a uuid to a build in function.
+ */
+export class ChangeDefaultForIdInUserTable1762771264000 implements IrreversibleMigration {
+	async up({ queryRunner, escape }: MigrationContext) {
+		const tableName = escape.tableName('user');
+		const idColumnName = escape.columnName('id');
+
+		await queryRunner.query(
+			`ALTER TABLE "${tableName}" ALTER COLUMN "${idColumnName}" SET DEFAULT gen_random_uuid()`,
+		);
+	}
+}

--- a/packages/@n8n/db/src/migrations/postgresdb/1762771264000-ChangeDefaultForIdInUserTable.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/1762771264000-ChangeDefaultForIdInUserTable.ts
@@ -1,8 +1,13 @@
 import type { IrreversibleMigration, MigrationContext } from '../migration-types';
 
 /**
- * PostgreSQL-specific migration to change the default value for the `id` column in `user` table from a custom implementation to generate
- * a uuid to a build in function.
+ * PostgreSQL-specific migration to change the default value for the `id` column in `user` table.
+ * The previous default implementation was based on MD5 hashing to produce a random UUID, but
+ * MD5 is not supported in FIPS compliant postgres environments. SHA256 is used instead.
+ *
+ * An easier approach would be to use the `gen_random_uuid()` function provided by PostgreSQL, but
+ * it is not supported in versions of PostgreSQL lower than 13. Therefore, we use the `uuid_in()` function
+ * with a SHA256 hash of a random string and the current timestamp.
  */
 export class ChangeDefaultForIdInUserTable1762771264000 implements IrreversibleMigration {
 	async up({ queryRunner, escape }: MigrationContext) {
@@ -10,7 +15,7 @@ export class ChangeDefaultForIdInUserTable1762771264000 implements IrreversibleM
 		const idColumnName = escape.columnName('id');
 
 		await queryRunner.query(
-			`ALTER TABLE ${tableName} ALTER COLUMN ${idColumnName} SET DEFAULT gen_random_uuid()`,
+			`ALTER TABLE ${tableName} ALTER COLUMN ${idColumnName} SET DEFAULT uuid_in(overlay(overlay(left(encode(sha256((random()::text || ':' || clock_timestamp()::text)::bytea), 'hex'), 32) placing '4' from 13) placing to_hex(floor(random()*(11-8+1) + 8)::int)::text from 17)::cstring)`,
 		);
 	}
 }

--- a/packages/@n8n/db/src/migrations/postgresdb/1762771264000-ChangeDefaultForIdInUserTable.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/1762771264000-ChangeDefaultForIdInUserTable.ts
@@ -3,11 +3,8 @@ import type { IrreversibleMigration, MigrationContext } from '../migration-types
 /**
  * PostgreSQL-specific migration to change the default value for the `id` column in `user` table.
  * The previous default implementation was based on MD5 hashing to produce a random UUID, but
- * MD5 is not supported in FIPS compliant postgres environments. SHA256 is used instead.
- *
- * An easier approach would be to use the `gen_random_uuid()` function provided by PostgreSQL, but
- * it is not supported in versions of PostgreSQL lower than 13. Therefore, we use the `uuid_in()` function
- * with a SHA256 hash of a random string and the current timestamp.
+ * MD5 is not supported in FIPS compliant postgres environments. We are switching to `gen_random_uuid()`
+ * which is supported in versions of PostgreSQL since 13.
  */
 export class ChangeDefaultForIdInUserTable1762771264000 implements IrreversibleMigration {
 	async up({ queryRunner, escape }: MigrationContext) {
@@ -15,7 +12,7 @@ export class ChangeDefaultForIdInUserTable1762771264000 implements IrreversibleM
 		const idColumnName = escape.columnName('id');
 
 		await queryRunner.query(
-			`ALTER TABLE ${tableName} ALTER COLUMN ${idColumnName} SET DEFAULT uuid_in(overlay(overlay(left(encode(sha256((random()::text || ':' || clock_timestamp()::text)::bytea), 'hex'), 32) placing '4' from 13) placing to_hex(floor(random()*(11-8+1) + 8)::int)::text from 17)::cstring)`,
+			`ALTER TABLE ${tableName} ALTER COLUMN ${idColumnName} SET DEFAULT gen_random_uuid()`,
 		);
 	}
 }

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -111,6 +111,7 @@ import { DropUnusedChatHubColumns1760965142113 } from '../common/1760965142113-D
 import { AddWorkflowDescriptionColumn1762177736257 } from '../common/1762177736257-AddWorkflowDescriptionColumn';
 import { BackfillMissingWorkflowHistoryRecords1762763704614 } from '../common/1762763704614-BackfillMissingWorkflowHistoryRecords';
 import type { Migration } from '../migration-types';
+import { ChangeDefaultForIdInUserTable1762771264000 } from './1762771264000-ChangeDefaultForIdInUserTable';
 
 export const postgresMigrations: Migration[] = [
 	InitialMigration1587669153312,
@@ -225,4 +226,5 @@ export const postgresMigrations: Migration[] = [
 	AddWorkflowDescriptionColumn1762177736257,
 	CreateOAuthEntities1760116750277,
 	BackfillMissingWorkflowHistoryRecords1762763704614,
+	ChangeDefaultForIdInUserTable1762771264000,
 ];


### PR DESCRIPTION
## Summary

Updating the default value generation for user id to not use md5 anymore, but `gen_random_uuid`. This enables support for FIPS compliant postgres servers. This means that we don't support Postgres version < 13 anymore.

Manually tested with Postgres 13, Postgres 18 (FIPS)

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-3991/md5-unsupported-in-fips-enabled-postgresql

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
