### PR TITLE
ci: Guard publish-to-npm job behind merge check

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -26,6 +26,7 @@ jobs:
   publish-to-npm:
     name: Publish to NPM
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
     timeout-minutes: 20
     permissions:
       id-token: write


### PR DESCRIPTION
## Summary
- add github.event.pull_request.merged check to the publish-to-npm job in release-publish.yml
- ensure closing an unmerged release PR no longer runs the Publish to NPM job


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1720/prevent-release-publish-workflow-from-running-on-closed-prs


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Gate `publish-to-npm` job in `release-publish.yml` behind `github.event.pull_request.merged == true` to avoid running on unmerged PR closures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcccbb2d2a6ea579d6d39e8f1b296f078c62c9a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->