### PR TITLE
ci: Add build-unit-test slash command

### DIFF
--- a/.github/workflows/build-unit-test-pr-comment.yml
+++ b/.github/workflows/build-unit-test-pr-comment.yml
@@ -41,9 +41,13 @@ jobs:
               }
             }
 
+            core.setOutput('proceed', 'false');
+            core.setOutput('headSha', '');
+            core.setOutput('prNumber', '');
+
             if (!context.payload.issue.pull_request || !isCommand) {
               console.log('Comment is not /build-unit-test on a pull request. Skipping.');
-              return { proceed: 'false' };
+              return;
             }
 
             let permission;
@@ -57,13 +61,13 @@ jobs:
             } catch (error) {
               console.log(`Could not verify permissions for @${commenter}: ${error.message}`);
               await react('confused');
-              return { proceed: 'false' };
+              return;
             }
 
             if (!allowedPermissions.includes(permission)) {
               console.log(`User @${commenter} has '${permission}' permission; requires admin/write/maintain.`);
               await react('-1');
-              return { proceed: 'false' };
+              return;
             }
 
             try {
@@ -74,15 +78,12 @@ jobs:
                 pull_number: prNumber,
               });
               await react('+1');
-              return {
-                proceed: 'true',
-                headSha: pr.head.sha,
-                prNumber: String(prNumber),
-              };
+              core.setOutput('proceed', 'true');
+              core.setOutput('headSha', pr.head.sha);
+              core.setOutput('prNumber', String(prNumber));
             } catch (error) {
               console.log(`Failed to fetch PR details for PR #${context.issue.number}: ${error.message}`);
               await react('confused');
-              return { proceed: 'false' };
             }
 
       - name: Dispatch build/unit test workflow

--- a/.github/workflows/build-unit-test-pr-comment.yml
+++ b/.github/workflows/build-unit-test-pr-comment.yml
@@ -1,0 +1,96 @@
+name: Trigger build/unit tests on PR comment
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  pull-requests: read
+  contents: read
+  actions: write
+
+jobs:
+  validate_and_dispatch:
+    name: Validate user and dispatch CI workflow
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/build-unit-test')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate user permissions and collect PR data
+        id: check_permissions
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const commenter = context.actor;
+            const body = (context.payload.comment.body || '').trim();
+            const isCommand = body.startsWith('/build-unit-test');
+            const allowedPermissions = ['admin', 'write', 'maintain'];
+            const commentId = context.payload.comment.id;
+            const { owner, repo } = context.repo;
+
+            async function react(content) {
+              try {
+                await github.rest.reactions.createForIssueComment({
+                  owner,
+                  repo,
+                  comment_id: commentId,
+                  content,
+                });
+              } catch (error) {
+                console.log(`Failed to add reaction '${content}': ${error.message}`);
+              }
+            }
+
+            if (!context.payload.issue.pull_request || !isCommand) {
+              console.log('Comment is not /build-unit-test on a pull request. Skipping.');
+              return { proceed: 'false' };
+            }
+
+            let permission;
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner,
+                repo,
+                username: commenter,
+              });
+              permission = data.permission;
+            } catch (error) {
+              console.log(`Could not verify permissions for @${commenter}: ${error.message}`);
+              await react('confused');
+              return { proceed: 'false' };
+            }
+
+            if (!allowedPermissions.includes(permission)) {
+              console.log(`User @${commenter} has '${permission}' permission; requires admin/write/maintain.`);
+              await react('-1');
+              return { proceed: 'false' };
+            }
+
+            try {
+              const prNumber = context.issue.number;
+              const { data: pr } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: prNumber,
+              });
+              await react('+1');
+              return {
+                proceed: 'true',
+                headSha: pr.head.sha,
+                prNumber: String(prNumber),
+              };
+            } catch (error) {
+              console.log(`Failed to fetch PR details for PR #${context.issue.number}: ${error.message}`);
+              await react('confused');
+              return { proceed: 'false' };
+            }
+
+      - name: Dispatch build/unit test workflow
+        if: ${{ steps.check_permissions.outputs.proceed == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ steps.check_permissions.outputs.headSha }}
+        run: |
+          gh workflow run ci-manual-build-unit-tests.yml \
+            --repo "${{ github.repository }}" \
+            -f ref="${HEAD_SHA}"

--- a/.github/workflows/ci-manual-build-unit-tests.yml
+++ b/.github/workflows/ci-manual-build-unit-tests.yml
@@ -43,3 +43,13 @@ jobs:
     uses: ./.github/workflows/linting-reusable.yml
     with:
       ref: ${{ inputs.ref }}
+
+  post-build-unit-tests:
+    name: Build & Unit Tests - Checks
+    runs-on: ubuntu-latest
+    needs: [install-and-build, unit-tests, lint]
+    if: always()
+    steps:
+      - name: Fail if any job failed
+        if: needs.install-and-build.result == 'failure' || needs.unit-tests.result == 'failure' || needs.lint.result == 'failure'
+        run: exit 1

--- a/.github/workflows/ci-manual-build-unit-tests.yml
+++ b/.github/workflows/ci-manual-build-unit-tests.yml
@@ -1,0 +1,45 @@
+name: Build, unit test and lint (manual trigger)
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Commit SHA or ref to check out
+        required: true
+
+jobs:
+  install-and-build:
+    name: Install & Build
+    runs-on: blacksmith-2vcpu-ubuntu-2204
+    env:
+      NODE_OPTIONS: '--max-old-space-size=6144'
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Setup and Build
+        uses: n8n-io/n8n/.github/actions/setup-nodejs-blacksmith@f5fbbbe0a28a886451c886cac6b49192a39b0eea # v1.104.1
+
+      - name: Run format check
+        run: pnpm format:check
+
+      - name: Run typecheck
+        run: pnpm typecheck
+
+  unit-tests:
+    name: Unit tests
+    needs: install-and-build
+    uses: ./.github/workflows/units-tests-reusable.yml
+    with:
+      ref: ${{ inputs.ref }}
+      collectCoverage: true
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  lint:
+    name: Lint
+    needs: install-and-build
+    uses: ./.github/workflows/linting-reusable.yml
+    with:
+      ref: ${{ inputs.ref }}


### PR DESCRIPTION
## Summary
- add a PR comment workflow that dispatches build/unit/lint when someone posts /build-unit-test
- introduce a manual workflow to run the standard build/typecheck/unit/lint sequence against a supplied ref

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1721/add-build-unit-test-pr-comment-trigger

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a slash-command-triggered and a manual GitHub Actions workflow to run build, typecheck, unit tests (with coverage), and lint against a specified ref with permission checks.
> 
> - **CI/Workflows**:
>   - **PR comment trigger** (`.github/workflows/build-unit-test-pr-comment.yml`):
>     - Listens for `/build-unit-test` on PRs, validates commenter permissions, reacts, and dispatches `ci-manual-build-unit-tests.yml` with the PR head `sha`.
>   - **Manual CI workflow** (`.github/workflows/ci-manual-build-unit-tests.yml`):
>     - `workflow_dispatch` with `ref` input; checks out ref, runs setup, `format:check`, `typecheck`.
>     - Reuses `units-tests-reusable.yml` (with coverage) and `linting-reusable.yml`; final gate job fails if any dependency job failed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e48912cdc350d4cc19f13615912c72312dc723b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->