### PR TITLE
fix(editor): Workflow tags style issue

### DIFF
--- a/packages/frontend/editor-ui/src/features/shared/tags/components/TagsDropdown.vue
+++ b/packages/frontend/editor-ui/src/features/shared/tags/components/TagsDropdown.vue
@@ -284,7 +284,8 @@ onClickOutside(
 		}
 	}
 
-	.el-tag {
+	.el-tag,
+	.el-tag.el-tag--info {
 		padding: var(--spacing--5xs) var(--spacing--4xs);
 		color: var(--color--text);
 		background-color: var(--color--background);


### PR DESCRIPTION
## Summary

Fix CSS selector specificity conflict in workflow tags.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-1672/bug-tag-padding-is-off


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands tag CSS selector to include `.el-tag.el-tag--info` so info-variant tags get consistent padding and styling in the workflow tags dropdown.
> 
> - **Frontend (Editor UI)**
>   - **Tags styling**: In `packages/frontend/editor-ui/src/features/shared/tags/components/TagsDropdown.vue`, expands selector from `
>     .el-tag
>     ` to `
>     .el-tag, .el-tag.el-tag--info
>     ` to ensure consistent padding/color/border for info-variant tags in the dropdown.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8880529455a5b1f8649bc4893f8d2ba1b77ddcc6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->