### PR TITLE
fix(core): Correctly filter custom nodes when NODES_INCLUDE/EXCLUDE is set

### DIFF
--- a/packages/core/src/nodes-loader/__tests__/directory-loader.test.ts
+++ b/packages/core/src/nodes-loader/__tests__/directory-loader.test.ts
@@ -106,6 +106,58 @@ describe('DirectoryLoader', () => {
 
 			expect(mockFs.readFileSync).not.toHaveBeenCalled();
 		});
+
+		it('should load custom nodes when specified with CUSTOM prefix in includeNodes', async () => {
+			const loader = new CustomDirectoryLoader(directory, [], ['CUSTOM.node1', 'CUSTOM.node2']);
+
+			await loader.loadAll();
+
+			expect(loader.nodeTypes).toEqual({
+				node1: { sourcePath: 'dist/Node1/Node1.node.js', type: mockNode1 },
+				node2: { sourcePath: 'dist/Node2/Node2.node.js', type: mockNode2 },
+			});
+			expect(Object.keys(loader.nodeTypes)).toHaveLength(2);
+		});
+
+		it('should load only specified custom nodes when includeNodes contains mixed packages', async () => {
+			const loader = new CustomDirectoryLoader(
+				directory,
+				[],
+				['n8n-nodes-base.aggregate', 'CUSTOM.node1'],
+			);
+
+			await loader.loadAll();
+
+			expect(loader.nodeTypes).toEqual({
+				node1: { sourcePath: 'dist/Node1/Node1.node.js', type: mockNode1 },
+			});
+			expect(Object.keys(loader.nodeTypes)).toHaveLength(1);
+			// node2 should not be loaded
+		});
+
+		it('should not load any custom nodes when only built-in nodes are in includeNodes', async () => {
+			const loader = new CustomDirectoryLoader(
+				directory,
+				[],
+				['n8n-nodes-base.aggregate', 'n8n-nodes-base.httpRequest'],
+			);
+
+			await loader.loadAll();
+
+			expect(loader.nodeTypes).toEqual({});
+			expect(loader.types.nodes).toEqual([]);
+		});
+
+		it('should exclude custom nodes when specified with CUSTOM prefix in excludeNodes', async () => {
+			const loader = new CustomDirectoryLoader(directory, ['CUSTOM.node1'], []);
+
+			await loader.loadAll();
+
+			expect(loader.nodeTypes).toEqual({
+				node2: { sourcePath: 'dist/Node2/Node2.node.js', type: mockNode2 },
+			});
+			expect(Object.keys(loader.nodeTypes)).toHaveLength(1);
+		});
 	});
 
 	describe('PackageDirectoryLoader', () => {

--- a/packages/core/src/nodes-loader/custom-directory-loader.ts
+++ b/packages/core/src/nodes-loader/custom-directory-loader.ts
@@ -9,6 +9,13 @@ import { DirectoryLoader } from './directory-loader';
 export class CustomDirectoryLoader extends DirectoryLoader {
 	packageName = 'CUSTOM';
 
+	constructor(directory: string, excludeNodes: string[] = [], includeNodes: string[] = []) {
+		super(directory, excludeNodes, includeNodes);
+
+		this.excludeNodes = this.extractNodeTypes(excludeNodes, this.packageName);
+		this.includeNodes = this.extractNodeTypes(includeNodes, this.packageName);
+	}
+
 	override async loadAll() {
 		const nodes = await glob('**/*.node.js', {
 			cwd: this.directory,

--- a/packages/core/src/nodes-loader/directory-loader.ts
+++ b/packages/core/src/nodes-loader/directory-loader.ts
@@ -115,6 +115,13 @@ export abstract class DirectoryLoader {
 		return path.resolve(this.directory, file);
 	}
 
+	protected extractNodeTypes(fullNodeTypes: string[], packageName: string): string[] {
+		return fullNodeTypes
+			.map((fullNodeType) => fullNodeType.split('.'))
+			.filter(([pkg]) => pkg === packageName)
+			.map(([_, nodeType]) => nodeType);
+	}
+
 	private loadClass<T>(sourcePath: string) {
 		const filePath = this.resolvePath(sourcePath);
 		const [className] = path.parse(sourcePath).name.split('.');

--- a/packages/core/src/nodes-loader/package-directory-loader.ts
+++ b/packages/core/src/nodes-loader/package-directory-loader.ts
@@ -19,15 +19,9 @@ export class PackageDirectoryLoader extends DirectoryLoader {
 
 		this.packageJson = this.readJSONSync('package.json');
 		this.packageName = this.packageJson.name;
-		this.excludeNodes = this.extractNodeTypes(excludeNodes);
-		this.includeNodes = this.extractNodeTypes(includeNodes);
-	}
 
-	private extractNodeTypes(fullNodeTypes: string[]) {
-		return fullNodeTypes
-			.map((fullNodeType) => fullNodeType.split('.'))
-			.filter(([packageName]) => packageName === this.packageName)
-			.map(([_, nodeType]) => nodeType);
+		this.excludeNodes = this.extractNodeTypes(excludeNodes, this.packageName);
+		this.includeNodes = this.extractNodeTypes(includeNodes, this.packageName);
 	}
 
 	override async loadAll() {


### PR DESCRIPTION
## Summary

Fixes a bug where custom nodes from `N8N_CUSTOM_EXTENSIONS` are incorrectly filtered out when `NODES_INCLUDE` environment variable is set.

When `NODES_INCLUDE='["n8n-nodes-base.aggregate", "CUSTOM.oracleSql"]'` is specified, the built-in nodes load correctly but custom nodes were excluded even when properly listed with the `CUSTOM.` prefix.

## Related Linear tickets, Github issues, and Community forum posts

PAY-4091

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- ~[ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure includeNodes/excludeNodes correctly honor package prefixes (e.g., CUSTOM.*) for both custom and packaged loaders, with targeted tests added.
> 
> - **Loaders**:
>   - `DirectoryLoader`: add `extractNodeTypes(fullNodeTypes, packageName)` to parse `package.node` selectors.
>   - `CustomDirectoryLoader`: constructor now filters `excludeNodes`/`includeNodes` using `packageName = 'CUSTOM'`.
>   - `PackageDirectoryLoader`: replace local parsing with shared `extractNodeTypes(..., this.packageName)`.
> - **Tests** (`directory-loader.test.ts`):
>   - Add cases validating include/exclude behavior for `CUSTOM.*`, mixed packages, and non-matching includes; ensure correct nodes are loaded or skipped accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5480d9917d2c0f85092be5afedb69242df872bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->