### PR TITLE
fix(MCP Client Tool Node): Use proxy for MCP calls

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/utils.ts
@@ -8,16 +8,17 @@ import { Toolkit } from 'langchain/agents';
 import {
 	createResultError,
 	createResultOk,
-	type ILoadOptionsFunctions,
-	type ISupplyDataFunctions,
 	type IDataObject,
 	type IExecuteFunctions,
+	type ILoadOptionsFunctions,
+	type ISupplyDataFunctions,
 	type Result,
 } from 'n8n-workflow';
 import { z } from 'zod';
 
 import { convertJsonSchemaToZod } from '@utils/schemaParsing';
 
+import { proxyFetch } from '@utils/httpProxyAgent';
 import type {
 	McpAuthenticationOption,
 	McpServerTransport,
@@ -203,6 +204,7 @@ export async function connectMcpClient({
 		try {
 			const transport = new StreamableHTTPClientTransport(endpoint.result, {
 				requestInit: { headers },
+				fetch: proxyFetch,
 			});
 			await client.connect(transport);
 			return createResultOk(client);
@@ -229,7 +231,7 @@ export async function connectMcpClient({
 		const sseTransport = new SSEClientTransport(endpoint.result, {
 			eventSourceInit: {
 				fetch: async (url, init) =>
-					await fetch(url, {
+					await proxyFetch(url, {
 						...init,
 						headers: {
 							...headers,
@@ -237,6 +239,7 @@ export async function connectMcpClient({
 						},
 					}),
 			},
+			fetch: proxyFetch,
 			requestInit: { headers },
 		});
 		await client.connect(sseTransport);

--- a/packages/@n8n/nodes-langchain/utils/httpProxyAgent.ts
+++ b/packages/@n8n/nodes-langchain/utils/httpProxyAgent.ts
@@ -31,6 +31,14 @@ export function getProxyAgent(targetUrl?: string) {
 	return new ProxyAgent(proxyUrl);
 }
 
+export async function proxyFetch(input: string | URL, init?: RequestInit): Promise<Response> {
+	return await fetch(input, {
+		...init,
+		// @ts-expect-error - dispatcher is an undici-specific option not in standard fetch
+		dispatcher: getProxyAgent(input.toString()),
+	});
+}
+
 /**
  * Returns a Node.js HTTP/HTTPS proxy agent for use with AWS SDK v3 clients.
  * AWS SDK v3 requires Node.js http.Agent/https.Agent instances (not undici ProxyAgent).

--- a/packages/@n8n/nodes-langchain/utils/httpProxyAgent.ts
+++ b/packages/@n8n/nodes-langchain/utils/httpProxyAgent.ts
@@ -31,6 +31,10 @@ export function getProxyAgent(targetUrl?: string) {
 	return new ProxyAgent(proxyUrl);
 }
 
+/**
+ * Make a fetch() request with a ProxyAgent if proxy environment variables are set.
+ * If no proxy is configured, use the default fetch().
+ */
 export async function proxyFetch(input: string | URL, init?: RequestInit): Promise<Response> {
 	return await fetch(input, {
 		...init,

--- a/packages/core/src/http-proxy.ts
+++ b/packages/core/src/http-proxy.ts
@@ -4,7 +4,6 @@ import https from 'https';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { LoggerProxy } from 'n8n-workflow';
 import proxyFromEnv from 'proxy-from-env';
-import { Agent as UndiciAgent, ProxyAgent, setGlobalDispatcher, type Dispatcher } from 'undici';
 
 type ProxyRequestParameters = Parameters<HttpProxyAgent<string>['addRequest']>;
 type ProxyClientRequest = ProxyRequestParameters[0];
@@ -93,48 +92,6 @@ class HttpsProxyManager extends https.Agent {
 	}
 }
 
-/**
- * Custom dispatcher for fetch that conditionally uses proxy based on target URL
- * Similar to HttpProxyManager and HttpsProxyManager
- */
-class FetchProxyManager extends UndiciAgent {
-	private readonly proxyAgentCache = new Map<string, ProxyAgent>();
-
-	dispatch(options: Dispatcher.DispatchOptions, handler: Dispatcher.DispatchHandlers): boolean {
-		const targetUrl = options.origin?.toString() ?? '';
-		const proxyUrl = proxyFromEnv.getProxyForUrl(targetUrl);
-
-		if (proxyUrl) {
-			let proxyAgent = this.proxyAgentCache.get(proxyUrl);
-			if (!proxyAgent) {
-				proxyAgent = new ProxyAgent(proxyUrl);
-				this.proxyAgentCache.set(proxyUrl, proxyAgent);
-			}
-			return proxyAgent.dispatch(options, handler);
-		}
-
-		return super.dispatch(options, handler);
-	}
-
-	async close(): Promise<void> {
-		const promises: Array<Promise<void>> = [];
-		for (const agent of this.proxyAgentCache.values()) {
-			promises.push(agent.close());
-		}
-		promises.push(super.close());
-		await Promise.all(promises);
-	}
-
-	async destroy(): Promise<void> {
-		const promises: Array<Promise<void>> = [];
-		for (const agent of this.proxyAgentCache.values()) {
-			promises.push(agent.destroy());
-		}
-		promises.push(super.destroy());
-		await Promise.all(promises);
-	}
-}
-
 export function createHttpProxyAgent(
 	customProxyUrl: string | null = null,
 	targetUrl: string,
@@ -178,16 +135,10 @@ export function installGlobalProxyAgent(): void {
 
 		http.globalAgent = new HttpProxyManager();
 		https.globalAgent = new HttpsProxyManager();
-
-		// Configure proxy for fetch requests (undici)
-		// Uses FetchProxyManager to conditionally proxy based on target URL
-		setGlobalDispatcher(new FetchProxyManager());
 	}
 }
 
 export function uninstallGlobalProxyAgent(): void {
 	http.globalAgent = new http.Agent();
 	https.globalAgent = new https.Agent();
-	// Reset fetch global dispatcher to default
-	setGlobalDispatcher(new UndiciAgent());
 }


### PR DESCRIPTION
## Summary
This PR enables proxy support for MCP Client Tool. It updates fetch method in MCPClient constructor with a custom fetch that uses ProxyAgent

### Testing

1. Set up local proxy (e.g., tinyproxy)
2. Test with various combinations of HTTP_PROXY, HTTPS_PROXY, ALL_PROXY, NO_PROXY
3. Verify MCP client tool makes requests through proxy
4. Confirm NO_PROXY patterns work correctly

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3754/mcp-client-tool-proxy-support

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
