### PR TITLE
test: Create history for workflows with activation logic

### DIFF
--- a/packages/@n8n/backend-test-utils/src/db/workflows.ts
+++ b/packages/@n8n/backend-test-utils/src/db/workflows.ts
@@ -5,6 +5,7 @@ import {
 	ProjectRepository,
 	SharedWorkflowRepository,
 	WorkflowRepository,
+	WorkflowHistoryRepository,
 } from '@n8n/db';
 import { Container } from '@n8n/di';
 import type { WorkflowSharingRole } from '@n8n/permissions';
@@ -175,6 +176,41 @@ export async function createWorkflowWithTrigger(
 	return workflow;
 }
 
+/**
+ * Store a workflow in the DB and create its workflow history.
+ * @param attributes workflow attributes
+ * @param userOrProject user or project to assign the workflow to
+ */
+export async function createWorkflowWithHistory(
+	attributes: Partial<IWorkflowDb> = {},
+	userOrProject?: User | Project,
+) {
+	const workflow = await createWorkflow(attributes, userOrProject);
+
+	// Create workflow history for the initial version
+	const user = userOrProject instanceof User ? userOrProject : undefined;
+	await createWorkflowHistory(workflow, user);
+
+	return workflow;
+}
+
+/**
+ * Store a workflow with trigger in the DB and create its workflow history.
+ * @param attributes workflow attributes
+ * @param user user to assign the workflow to
+ */
+export async function createWorkflowWithTriggerAndHistory(
+	attributes: Partial<IWorkflowDb> = {},
+	user?: User,
+) {
+	const workflow = await createWorkflowWithTrigger(attributes, user);
+
+	// Create workflow history for the initial version
+	await createWorkflowHistory(workflow, user);
+
+	return workflow;
+}
+
 export async function getAllWorkflows() {
 	return await Container.get(WorkflowRepository).find();
 }
@@ -185,3 +221,18 @@ export async function getAllSharedWorkflows() {
 
 export const getWorkflowById = async (id: string) =>
 	await Container.get(WorkflowRepository).findOneBy({ id });
+
+/**
+ * Create a workflow history record for a workflow
+ * @param workflow workflow to create history for
+ * @param user user who created the version (optional)
+ */
+export async function createWorkflowHistory(workflow: IWorkflowDb, user?: User): Promise<void> {
+	await Container.get(WorkflowHistoryRepository).insert({
+		workflowId: workflow.id,
+		versionId: workflow.versionId,
+		nodes: workflow.nodes,
+		connections: workflow.connections,
+		authors: user?.email ?? 'test@example.com',
+	});
+}

--- a/packages/cli/test/integration/public-api/workflows.test.ts
+++ b/packages/cli/test/integration/public-api/workflows.test.ts
@@ -1,7 +1,7 @@
 import {
 	createTeamProject,
 	createWorkflow,
-	createWorkflowWithTrigger,
+	createWorkflowWithTriggerAndHistory,
 	testDb,
 	mockInstance,
 } from '@n8n/backend-test-utils';
@@ -624,7 +624,7 @@ describe('POST /workflows/:id/activate', () => {
 	});
 
 	test('should set workflow as active', async () => {
-		const workflow = await createWorkflowWithTrigger({}, member);
+		const workflow = await createWorkflowWithTriggerAndHistory({}, member);
 
 		const response = await authMemberAgent.post(`/workflows/${workflow.id}/activate`);
 
@@ -659,7 +659,7 @@ describe('POST /workflows/:id/activate', () => {
 	});
 
 	test('should set non-owned workflow as active when owner', async () => {
-		const workflow = await createWorkflowWithTrigger({}, member);
+		const workflow = await createWorkflowWithTriggerAndHistory({}, member);
 
 		const response = await authMemberAgent.post(`/workflows/${workflow.id}/activate`).expect(200);
 
@@ -718,7 +718,7 @@ describe('POST /workflows/:id/deactivate', () => {
 	});
 
 	test('should deactivate workflow', async () => {
-		const workflow = await createWorkflowWithTrigger({}, member);
+		const workflow = await createWorkflowWithTriggerAndHistory({}, member);
 
 		await authMemberAgent.post(`/workflows/${workflow.id}/activate`);
 
@@ -755,7 +755,7 @@ describe('POST /workflows/:id/deactivate', () => {
 	});
 
 	test('should deactivate non-owned workflow when owner', async () => {
-		const workflow = await createWorkflowWithTrigger({}, member);
+		const workflow = await createWorkflowWithTriggerAndHistory({}, member);
 
 		await authMemberAgent.post(`/workflows/${workflow.id}/activate`);
 

--- a/packages/cli/test/integration/workflows/workflow.service.test.ts
+++ b/packages/cli/test/integration/workflows/workflow.service.test.ts
@@ -1,4 +1,4 @@
-import { createWorkflow, testDb, mockInstance } from '@n8n/backend-test-utils';
+import { createWorkflowWithHistory, testDb, mockInstance } from '@n8n/backend-test-utils';
 import { SharedWorkflowRepository, type WorkflowEntity, WorkflowRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
@@ -51,7 +51,7 @@ afterEach(async () => {
 describe('update()', () => {
 	test('should remove and re-add to active workflows on `active: true` payload', async () => {
 		const owner = await createOwner();
-		const workflow = await createWorkflow({ active: true }, owner);
+		const workflow = await createWorkflowWithHistory({ active: true }, owner);
 
 		const removeSpy = jest.spyOn(activeWorkflowManager, 'remove');
 		const addSpy = jest.spyOn(activeWorkflowManager, 'add');
@@ -70,7 +70,7 @@ describe('update()', () => {
 
 	test('should remove from active workflows on `active: false` payload', async () => {
 		const owner = await createOwner();
-		const workflow = await createWorkflow({ active: true }, owner);
+		const workflow = await createWorkflowWithHistory({ active: true }, owner);
 
 		const removeSpy = jest.spyOn(activeWorkflowManager, 'remove');
 		const addSpy = jest.spyOn(activeWorkflowManager, 'add');
@@ -87,7 +87,7 @@ describe('update()', () => {
 
 	test('should fetch missing connections from DB when updating nodes', async () => {
 		const owner = await createOwner();
-		const workflow = await createWorkflow({}, owner);
+		const workflow = await createWorkflowWithHistory({}, owner);
 
 		const updateData: Partial<WorkflowEntity> = {
 			nodes: [
@@ -116,7 +116,7 @@ describe('update()', () => {
 
 	test('should not save workflow history version when updating only active status', async () => {
 		const owner = await createOwner();
-		const workflow = await createWorkflow({ active: false }, owner);
+		const workflow = await createWorkflowWithHistory({ active: false }, owner);
 
 		const saveVersionSpy = jest.spyOn(workflowHistoryService, 'saveVersion');
 
@@ -132,7 +132,7 @@ describe('update()', () => {
 
 	test('should save workflow history version with backfilled data when versionId changes', async () => {
 		const owner = await createOwner();
-		const workflow = await createWorkflow({ active: false }, owner);
+		const workflow = await createWorkflowWithHistory({ active: false }, owner);
 
 		const saveVersionSpy = jest.spyOn(workflowHistoryService, 'saveVersion');
 

--- a/packages/cli/test/integration/workflows/workflows.controller-with-active-workflow-manager.ee.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller-with-active-workflow-manager.ee.test.ts
@@ -1,6 +1,6 @@
 import {
 	createTeamProject,
-	createWorkflowWithTrigger,
+	createWorkflowWithTriggerAndHistory,
 	testDb,
 	mockInstance,
 } from '@n8n/backend-test-utils';
@@ -39,7 +39,7 @@ describe('PUT /:workflowId/transfer', () => {
 		//
 		const destinationProject = await createTeamProject('Team Project', member);
 
-		const workflow = await createWorkflowWithTrigger({ active: true }, member);
+		const workflow = await createWorkflowWithTriggerAndHistory({ active: true }, member);
 
 		//
 		// ACT


### PR DESCRIPTION
## Summary

Now workflow history is enabled to all users.
This PR adds workflow history to tests for active workflows and workflow updates, preparing for the `activeVersion` feature that requires history to track the currently active workflow version.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce workflow-history-aware workflow creators and update integration tests to use them, adding assertions for history/version behavior and activation flows.
> 
> - **Backend test utils (`packages/@n8n/backend-test-utils/src/db/workflows.ts`)**
>   - Add `WorkflowHistoryRepository` import.
>   - New helpers: `createWorkflowWithHistory()`, `createWorkflowWithTriggerAndHistory()`, `createWorkflowHistory()`.
> - **Integration tests**
>   - Replace `createWorkflow`/`createWorkflowWithTrigger` with `createWorkflowWithHistory`/`createWorkflowWithTriggerAndHistory` across active workflow manager, public API, and workflows controller/service tests.
>   - Add/adjust assertions:
>     - Workflow history counts (`WorkflowHistoryRepository.count`) increment (e.g., from 1 to 2 after updates) and match `versionId`.
>     - Preserve `versionId` on activate/deactivate; ensure active workflow manager add/remove calls.
>     - New test: activate an initially inactive workflow in memory.
>   - Ensure trigger counting and transfer flows still verified with updated creators.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e9539b47b6a72a6372db76bf72a14ca3506a2d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->