### PR TITLE
fix(editor): Previous nodes' outputs aren't available in expression editor for sub-nodes

### DIFF
--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -433,6 +433,21 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		return workflow.value.nodes.find((node) => node.id === nodeId);
 	}
 
+	function findRootWithMainConnection(nodeName: string): string | null {
+		const children = workflowObject.value.getChildNodes(nodeName, 'ALL');
+
+		for (let i = children.length - 1; i >= 0; i--) {
+			const childName = children[i];
+			const parentNodes = workflowObject.value.getParentNodes(childName, NodeConnectionTypes.Main);
+
+			if (parentNodes.length > 0) {
+				return childName;
+			}
+		}
+
+		return null;
+	}
+
 	// Finds the full id for a given partial id for a node, relying on order for uniqueness in edge cases
 	function findNodeByPartialId(partialId: string): INodeUi | undefined {
 		return workflow.value.nodes.find((node) => node.id.startsWith(partialId));
@@ -1869,6 +1884,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		isNodeInOutgoingNodeConnections,
 		getWorkflowById,
 		getNodeByName,
+		findRootWithMainConnection,
 		getNodeById,
 		getNodesByIds,
 		getParametersLastUpdate,

--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/InputPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/InputPanel.vue
@@ -114,23 +114,7 @@ const activeNode = computed(() => workflowsStore.getNodeByName(props.activeNodeN
 const rootNode = computed(() => {
 	if (!activeNode.value) return null;
 
-	// Find the first child that has a main input connection to account for nested subnodes
-	const findRootWithMainConnection = (nodeName: string): string | null => {
-		const children = props.workflowObject.getChildNodes(nodeName, 'ALL');
-
-		for (let i = children.length - 1; i >= 0; i--) {
-			const childName = children[i];
-			// Check if this child has main input connections
-			const parentNodes = props.workflowObject.getParentNodes(childName, NodeConnectionTypes.Main);
-			if (parentNodes.length > 0) {
-				return childName;
-			}
-		}
-
-		return null;
-	};
-
-	return findRootWithMainConnection(activeNode.value.name);
+	return workflowsStore.findRootWithMainConnection(activeNode.value.name);
 });
 
 const hasRootNodeRun = computed(() => {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ExpressionEditModal.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ExpressionEditModal.vue
@@ -75,6 +75,17 @@ const parentNodes = computed(() => {
 	return nodes.filter(({ name }) => name !== node.name);
 });
 
+const rootNode = computed(() => {
+	if (!activeNode.value) return null;
+
+	return workflowsStore.findRootWithMainConnection(activeNode.value.name);
+});
+
+const rootNodesParents = computed(() => {
+	if (!rootNode.value) return [];
+	return workflowsStore.workflowObject.getParentNodesByDepth(rootNode.value);
+});
+
 watch(
 	() => props.dialogVisible,
 	(newValue) => {
@@ -169,7 +180,7 @@ const onResizeThrottle = useThrottleFn(onResize, 10);
 					<VirtualSchema
 						:class="$style.schema"
 						:search="appliedSearch"
-						:nodes="parentNodes"
+						:nodes="parentNodes.length > 0 ? parentNodes : rootNodesParents"
 						:mapping-enabled="!isReadOnly"
 						:connection-type="NodeConnectionTypes.Main"
 						pane-type="input"


### PR DESCRIPTION
## Summary

This PR fixes the issue with previous nodes' outputs not being available in expression editor modal, when opened for sub-nodes.

Before:
<img width="1441" height="230" alt="image" src="https://github.com/user-attachments/assets/e7ae7ff5-7c04-42e9-9780-d2c048e50740" />

After:
<img width="1449" height="372" alt="image" src="https://github.com/user-attachments/assets/1b7e5e6b-8cc1-4809-9191-ffe6e3c3974d" />


## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-1655/previous-nodes-execution-data-not-available-in-expression-editor-of-ai


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `findRootWithMainConnection` to the workflows store and uses it in NDV InputPanel and Expression Editor to correctly surface previous nodes for sub-nodes, with accompanying tests.
> 
> - **Store (`workflows.store`)**
>   - Add `findRootWithMainConnection(nodeName)` to resolve the first child with a `main` input among all descendants (uses `NodeConnectionTypes` and `workflowObject`).
>   - Expose the method via the store API.
> - **NDV UI**
>   - `features/ndv/panel/components/InputPanel.vue`:
>     - Replace local root resolution with `workflowsStore.findRootWithMainConnection`.
>   - `features/ndv/parameters/components/ExpressionEditModal.vue`:
>     - Use `workflowsStore.findRootWithMainConnection` and fallback to `rootNodesParents` when no direct parents, ensuring previous nodes' outputs appear for sub-nodes.
> - **Tests** (`workflows.store.test.ts`)
>   - Import `NodeConnectionTypes`.
>   - Add tests for `findRootWithMainConnection` covering AI tool chains, deep vector tool chains, and no-main-connection cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9df99576ac67feba6e7b7c31fe04398ba395c232. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->