### PR TITLE
fix(Schedule Trigger Node): Show interval boundaries

### DIFF
--- a/packages/nodes-base/nodes/Schedule/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Schedule/GenericFunctions.ts
@@ -1,7 +1,36 @@
 import moment from 'moment-timezone';
-import { type CronExpression, randomInt } from 'n8n-workflow';
+import { type CronExpression, type INode, NodeOperationError, randomInt } from 'n8n-workflow';
 
 import type { IRecurrenceRule, ScheduleInterval } from './SchedulerInterface';
+
+export function validateInterval(node: INode, itemIndex: number, interval: ScheduleInterval): void {
+	let errorMessage = '';
+	if (
+		interval.field === 'seconds' &&
+		(interval.secondsInterval > 59 || interval.secondsInterval < 0)
+	) {
+		errorMessage = 'Seconds must be in range 0-59';
+	}
+	if (
+		interval.field === 'minutes' &&
+		(interval.minutesInterval > 59 || interval.minutesInterval < 0)
+	) {
+		errorMessage = 'Minutes must be in range 0-59';
+	}
+	if (interval.field === 'hours' && (interval.hoursInterval > 23 || interval.hoursInterval < 0)) {
+		errorMessage = 'Hours must be in range 0-23';
+	}
+	if (interval.field === 'days' && (interval.daysInterval > 31 || interval.daysInterval < 0)) {
+		errorMessage = 'Days must be in range 1-31';
+	}
+
+	if (errorMessage) {
+		throw new NodeOperationError(node, 'Invalid interval', {
+			itemIndex,
+			description: errorMessage,
+		});
+	}
+}
 
 export function recurrenceCheck(
 	recurrence: IRecurrenceRule,

--- a/packages/nodes-base/nodes/Schedule/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Schedule/GenericFunctions.ts
@@ -7,21 +7,25 @@ export function validateInterval(node: INode, itemIndex: number, interval: Sched
 	let errorMessage = '';
 	if (
 		interval.field === 'seconds' &&
-		(interval.secondsInterval > 59 || interval.secondsInterval < 0)
+		(interval.secondsInterval > 59 || interval.secondsInterval < 1)
 	) {
-		errorMessage = 'Seconds must be in range 0-59';
+		errorMessage = 'Seconds must be in range 1-59';
 	}
 	if (
 		interval.field === 'minutes' &&
-		(interval.minutesInterval > 59 || interval.minutesInterval < 0)
+		(interval.minutesInterval > 59 || interval.minutesInterval < 1)
 	) {
-		errorMessage = 'Minutes must be in range 0-59';
+		errorMessage = 'Minutes must be in range 1-59';
 	}
-	if (interval.field === 'hours' && (interval.hoursInterval > 23 || interval.hoursInterval < 0)) {
-		errorMessage = 'Hours must be in range 0-23';
+	if (interval.field === 'hours' && (interval.hoursInterval > 23 || interval.hoursInterval < 1)) {
+		errorMessage = 'Hours must be in range 1-23';
 	}
-	if (interval.field === 'days' && (interval.daysInterval > 31 || interval.daysInterval < 0)) {
+	if (interval.field === 'days' && (interval.daysInterval > 31 || interval.daysInterval < 1)) {
 		errorMessage = 'Days must be in range 1-31';
+	}
+
+	if (interval.field === 'months' && interval.monthsInterval < 1) {
+		errorMessage = 'Months must be larger than 0';
 	}
 
 	if (errorMessage) {

--- a/packages/nodes-base/nodes/Schedule/ScheduleTrigger.node.ts
+++ b/packages/nodes-base/nodes/Schedule/ScheduleTrigger.node.ts
@@ -111,7 +111,7 @@ export class ScheduleTrigger implements INodeType {
 									},
 								},
 								description: 'Number of seconds between each workflow trigger',
-								hint: 'Must be in range 0-59',
+								hint: 'Must be in range 1-59',
 							},
 							{
 								displayName: 'Minutes Between Triggers',
@@ -124,7 +124,7 @@ export class ScheduleTrigger implements INodeType {
 									},
 								},
 								description: 'Number of minutes between each workflow trigger',
-								hint: 'Must be in range 0-59',
+								hint: 'Must be in range 1-59',
 							},
 							{
 								displayName: 'Hours Between Triggers',
@@ -137,7 +137,7 @@ export class ScheduleTrigger implements INodeType {
 								},
 								default: 1,
 								description: 'Number of hours between each workflow trigger',
-								hint: 'Must be in range 0-23',
+								hint: 'Must be in range 1-23',
 							},
 							{
 								displayName: 'Days Between Triggers',
@@ -175,7 +175,6 @@ export class ScheduleTrigger implements INodeType {
 								},
 								default: 1,
 								description: 'Would run every month unless specified otherwise',
-								hint: 'Must be in range 1-12',
 							},
 							{
 								displayName: 'Trigger at Day of Month',

--- a/packages/nodes-base/nodes/Schedule/ScheduleTrigger.node.ts
+++ b/packages/nodes-base/nodes/Schedule/ScheduleTrigger.node.ts
@@ -9,7 +9,12 @@ import type {
 } from 'n8n-workflow';
 import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 
-import { intervalToRecurrence, recurrenceCheck, toCronExpression } from './GenericFunctions';
+import {
+	intervalToRecurrence,
+	recurrenceCheck,
+	toCronExpression,
+	validateInterval,
+} from './GenericFunctions';
 import type { IRecurrenceRule, Rule } from './SchedulerInterface';
 
 export class ScheduleTrigger implements INodeType {
@@ -18,7 +23,7 @@ export class ScheduleTrigger implements INodeType {
 		name: 'scheduleTrigger',
 		icon: 'fa:clock',
 		group: ['trigger', 'schedule'],
-		version: [1, 1.1, 1.2],
+		version: [1, 1.1, 1.2, 1.3],
 		description: 'Triggers the workflow on a given schedule',
 		eventTriggerDescription: '',
 		activationMessage:
@@ -106,6 +111,7 @@ export class ScheduleTrigger implements INodeType {
 									},
 								},
 								description: 'Number of seconds between each workflow trigger',
+								hint: 'Must be in range 0-59',
 							},
 							{
 								displayName: 'Minutes Between Triggers',
@@ -118,6 +124,7 @@ export class ScheduleTrigger implements INodeType {
 									},
 								},
 								description: 'Number of minutes between each workflow trigger',
+								hint: 'Must be in range 0-59',
 							},
 							{
 								displayName: 'Hours Between Triggers',
@@ -130,6 +137,7 @@ export class ScheduleTrigger implements INodeType {
 								},
 								default: 1,
 								description: 'Number of hours between each workflow trigger',
+								hint: 'Must be in range 0-23',
 							},
 							{
 								displayName: 'Days Between Triggers',
@@ -142,6 +150,7 @@ export class ScheduleTrigger implements INodeType {
 								},
 								default: 1,
 								description: 'Number of days between each workflow trigger',
+								hint: 'Must be in range 1-31',
 							},
 							{
 								displayName: 'Weeks Between Triggers',
@@ -166,6 +175,7 @@ export class ScheduleTrigger implements INodeType {
 								},
 								default: 1,
 								description: 'Would run every month unless specified otherwise',
+								hint: 'Must be in range 1-12',
 							},
 							{
 								displayName: 'Trigger at Day of Month',
@@ -412,6 +422,7 @@ export class ScheduleTrigger implements INodeType {
 	};
 
 	async trigger(this: ITriggerFunctions): Promise<ITriggerResponse> {
+		const version = this.getNode().typeVersion;
 		const { interval: intervals } = this.getNodeParameter('rule', []) as Rule;
 		const timezone = this.getTimezone();
 		const staticData = this.getWorkflowStaticData('node') as {
@@ -419,6 +430,12 @@ export class ScheduleTrigger implements INodeType {
 		};
 		if (!staticData.recurrenceRules) {
 			staticData.recurrenceRules = [];
+		}
+
+		if (version >= 1.3) {
+			for (let i = 0; i < intervals.length; i++) {
+				validateInterval(this.getNode(), i, intervals[i]);
+			}
 		}
 
 		const executeTrigger = (recurrence: IRecurrenceRule) => {

--- a/packages/nodes-base/nodes/Schedule/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Schedule/test/GenericFunctions.test.ts
@@ -1,7 +1,13 @@
+import type { INode } from 'n8n-workflow';
 import * as n8nWorkflow from 'n8n-workflow';
 
-import { intervalToRecurrence, recurrenceCheck, toCronExpression } from '../GenericFunctions';
-import type { IRecurrenceRule } from '../SchedulerInterface';
+import {
+	intervalToRecurrence,
+	recurrenceCheck,
+	toCronExpression,
+	validateInterval,
+} from '../GenericFunctions';
+import type { IRecurrenceRule, ScheduleInterval } from '../SchedulerInterface';
 
 describe('toCronExpression', () => {
 	Object.defineProperty(n8nWorkflow, 'randomInt', {
@@ -94,6 +100,66 @@ describe('toCronExpression', () => {
 			monthsInterval: 3,
 		});
 		expect(result1).toEqual('30 30 12 15 */3 *');
+	});
+});
+
+describe('validateInterval', () => {
+	const mockNode: INode = {
+		id: 'test-node',
+		name: 'Test Node',
+		type: 'n8n-nodes-base.scheduleTrigger',
+		typeVersion: 1,
+		position: [0, 0],
+		parameters: {},
+	};
+
+	describe('valid intervals', () => {
+		it.each<[string, ScheduleInterval]>([
+			['seconds', { field: 'seconds', secondsInterval: 0 }],
+			['seconds', { field: 'seconds', secondsInterval: 30 }],
+			['seconds', { field: 'seconds', secondsInterval: 59 }],
+			['minutes', { field: 'minutes', minutesInterval: 0 }],
+			['minutes', { field: 'minutes', minutesInterval: 30 }],
+			['minutes', { field: 'minutes', minutesInterval: 59 }],
+			['hours', { field: 'hours', hoursInterval: 0 }],
+			['hours', { field: 'hours', hoursInterval: 12 }],
+			['hours', { field: 'hours', hoursInterval: 23 }],
+			['days', { field: 'days', daysInterval: 0 }],
+			['days', { field: 'days', daysInterval: 15 }],
+			['days', { field: 'days', daysInterval: 31 }],
+		])('should not throw error for valid %s interval: %j', (_field, interval) => {
+			expect(() => {
+				validateInterval(mockNode, 0, interval);
+			}).not.toThrow();
+		});
+	});
+
+	describe('invalid intervals', () => {
+		it.each<[string, ScheduleInterval, string]>([
+			['seconds', { field: 'seconds', secondsInterval: 60 }, 'Seconds must be in range 0-59'],
+			['seconds', { field: 'seconds', secondsInterval: -1 }, 'Seconds must be in range 0-59'],
+			['seconds', { field: 'seconds', secondsInterval: 100 }, 'Seconds must be in range 0-59'],
+			['minutes', { field: 'minutes', minutesInterval: 60 }, 'Minutes must be in range 0-59'],
+			['minutes', { field: 'minutes', minutesInterval: -1 }, 'Minutes must be in range 0-59'],
+			['minutes', { field: 'minutes', minutesInterval: 100 }, 'Minutes must be in range 0-59'],
+			['hours', { field: 'hours', hoursInterval: 24 }, 'Hours must be in range 0-23'],
+			['hours', { field: 'hours', hoursInterval: -1 }, 'Hours must be in range 0-23'],
+			['hours', { field: 'hours', hoursInterval: 100 }, 'Hours must be in range 0-23'],
+			['days', { field: 'days', daysInterval: 32 }, 'Days must be in range 1-31'],
+			['days', { field: 'days', daysInterval: -1 }, 'Days must be in range 1-31'],
+			['days', { field: 'days', daysInterval: 100 }, 'Days must be in range 1-31'],
+		])(
+			'should throw error for invalid %s interval: %j',
+			(_field, interval, expectedDescription) => {
+				try {
+					validateInterval(mockNode, 0, interval);
+					fail('Expected validateInterval to throw an error');
+				} catch (error) {
+					expect(error.message).toBe('Invalid interval');
+					expect(error.description).toBe(expectedDescription);
+				}
+			},
+		);
 	});
 });
 

--- a/packages/nodes-base/nodes/Schedule/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Schedule/test/GenericFunctions.test.ts
@@ -115,16 +115,16 @@ describe('validateInterval', () => {
 
 	describe('valid intervals', () => {
 		it.each<[string, ScheduleInterval]>([
-			['seconds', { field: 'seconds', secondsInterval: 0 }],
+			['seconds', { field: 'seconds', secondsInterval: 1 }],
 			['seconds', { field: 'seconds', secondsInterval: 30 }],
 			['seconds', { field: 'seconds', secondsInterval: 59 }],
-			['minutes', { field: 'minutes', minutesInterval: 0 }],
+			['minutes', { field: 'minutes', minutesInterval: 1 }],
 			['minutes', { field: 'minutes', minutesInterval: 30 }],
 			['minutes', { field: 'minutes', minutesInterval: 59 }],
-			['hours', { field: 'hours', hoursInterval: 0 }],
+			['hours', { field: 'hours', hoursInterval: 1 }],
 			['hours', { field: 'hours', hoursInterval: 12 }],
 			['hours', { field: 'hours', hoursInterval: 23 }],
-			['days', { field: 'days', daysInterval: 0 }],
+			['days', { field: 'days', daysInterval: 1 }],
 			['days', { field: 'days', daysInterval: 15 }],
 			['days', { field: 'days', daysInterval: 31 }],
 		])('should not throw error for valid %s interval: %j', (_field, interval) => {
@@ -136,18 +136,23 @@ describe('validateInterval', () => {
 
 	describe('invalid intervals', () => {
 		it.each<[string, ScheduleInterval, string]>([
-			['seconds', { field: 'seconds', secondsInterval: 60 }, 'Seconds must be in range 0-59'],
-			['seconds', { field: 'seconds', secondsInterval: -1 }, 'Seconds must be in range 0-59'],
-			['seconds', { field: 'seconds', secondsInterval: 100 }, 'Seconds must be in range 0-59'],
-			['minutes', { field: 'minutes', minutesInterval: 60 }, 'Minutes must be in range 0-59'],
-			['minutes', { field: 'minutes', minutesInterval: -1 }, 'Minutes must be in range 0-59'],
-			['minutes', { field: 'minutes', minutesInterval: 100 }, 'Minutes must be in range 0-59'],
-			['hours', { field: 'hours', hoursInterval: 24 }, 'Hours must be in range 0-23'],
-			['hours', { field: 'hours', hoursInterval: -1 }, 'Hours must be in range 0-23'],
-			['hours', { field: 'hours', hoursInterval: 100 }, 'Hours must be in range 0-23'],
+			['seconds', { field: 'seconds', secondsInterval: 0 }, 'Seconds must be in range 1-59'],
+			['seconds', { field: 'seconds', secondsInterval: 60 }, 'Seconds must be in range 1-59'],
+			['seconds', { field: 'seconds', secondsInterval: -1 }, 'Seconds must be in range 1-59'],
+			['seconds', { field: 'seconds', secondsInterval: 100 }, 'Seconds must be in range 1-59'],
+			['minutes', { field: 'minutes', minutesInterval: 60 }, 'Minutes must be in range 1-59'],
+			['minutes', { field: 'minutes', minutesInterval: 0 }, 'Minutes must be in range 1-59'],
+			['minutes', { field: 'minutes', minutesInterval: -1 }, 'Minutes must be in range 1-59'],
+			['minutes', { field: 'minutes', minutesInterval: 100 }, 'Minutes must be in range 1-59'],
+			['hours', { field: 'hours', hoursInterval: 0 }, 'Hours must be in range 1-23'],
+			['hours', { field: 'hours', hoursInterval: 24 }, 'Hours must be in range 1-23'],
+			['hours', { field: 'hours', hoursInterval: -1 }, 'Hours must be in range 1-23'],
+			['hours', { field: 'hours', hoursInterval: 100 }, 'Hours must be in range 1-23'],
+			['days', { field: 'days', daysInterval: 0 }, 'Days must be in range 1-31'],
 			['days', { field: 'days', daysInterval: 32 }, 'Days must be in range 1-31'],
 			['days', { field: 'days', daysInterval: -1 }, 'Days must be in range 1-31'],
 			['days', { field: 'days', daysInterval: 100 }, 'Days must be in range 1-31'],
+			['months', { field: 'months', monthsInterval: 0 }, 'Months must be larger than 0'],
 		])(
 			'should throw error for invalid %s interval: %j',
 			(_field, interval, expectedDescription) => {


### PR DESCRIPTION
## Summary

This PR updates hints to specify boundaries and updates node version to throw in case of invalid interval.

<img width="676" height="759" alt="image" src="https://github.com/user-attachments/assets/ef139d93-af62-49d8-a481-05892953c3f7" />


## Related Linear tickets, Github issues, and Community forum posts

closes #14056

https://linear.app/n8n/issue/NODE-2594/community-issue-incorrect-schedule-behavior-for-intervals-over-60


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
