### PR TITLE
feat: Improve backfill missing workflow history records migration (no-changelog)

### DIFF
--- a/packages/@n8n/db/src/migrations/common/1762763704614-BackfillMissingWorkflowHistoryRecords.ts
+++ b/packages/@n8n/db/src/migrations/common/1762763704614-BackfillMissingWorkflowHistoryRecords.ts
@@ -35,11 +35,11 @@ export class BackfillMissingWorkflowHistoryRecords1762763704614 implements Irrev
 			FROM ${workflowTable} w
 			LEFT JOIN ${historyTable} wh
 				ON wh.${versionIdColumn} = w.${versionIdColumn}
-			    AND wh.${workflowIdColumn} = w.${idColumn}
+				AND wh.${workflowIdColumn} = w.${idColumn}
 			LEFT JOIN dup_version d
 				ON d.${versionIdColumn} = w.${versionIdColumn}
 			WHERE
-			    -- missing or empty versionId
+				-- missing or empty versionId
 				w.${versionIdColumn} IS NULL OR w.${versionIdColumn} = ''
 				-- duplicate versionId without matching history entry by both versionId and workflowId
 				OR (


### PR DESCRIPTION
## Summary

It turns out that some users may have duplicate version IDs in the `workflow_entity` table. Although this edge case is extremely unlikely, I’ve updated the migration to regenerate version IDs for workflows that don't own their history record (no matching `versionId` AND `workflowId` in `workflow_history`). This ensures we never attempt to create workflow history records with duplicate version IDs.

#### Examples

- Workflow A (id=1, versionId='abc') → Has history record (versionId='abc', workflowId=1)
- Workflow B (id=2, versionId='xyz') → NO history record exists
- Workflow C (id=3, versionId='abc') → Duplicate versionId! No history for (versionId='abc', workflowId=3)
- Workflow D (id=4, versionId=null) → NO history record exists

**Expected result**: `versionId` regenerated for C and D

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Regenerates versionIds for null/empty or duplicate-without-matching-history workflows, backfills missing workflow_history entries, and enforces versionId NOT NULL.
> 
> - **DB Migration (`1762763704614-BackfillMissingWorkflowHistoryRecords`)**:
>   - **VersionId regeneration**: Detects workflows needing a new `versionId` (NULL/empty or duplicates lacking a matching `workflow_history` by `versionId` and `workflowId`) via CTE and joins; assigns new UUIDs.
>   - **Backfill history**: Inserts missing `workflow_history` rows from `workflow_entity`.
>   - **Constraint**: Sets `workflow_entity.versionId` to NOT NULL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1752e90c133d4bff7718ad6d4683c258901d5cd6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->