### PR TITLE
fix(editor): Fix static banner props being overwritten (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/shared/banners/components/BannerStack.vue
+++ b/packages/frontend/editor-ui/src/features/shared/banners/components/BannerStack.vue
@@ -47,6 +47,10 @@ const getBannerForName = (bannerName: BannerName) => {
 	return N8N_BANNERS[bannerName] || bannersStore.dynamicBannersMap[bannerName];
 };
 
+const removeUndefinedValues = (obj: Record<string, unknown>) => {
+	return Object.fromEntries(Object.entries(obj).filter(([_, value]) => value !== undefined));
+};
+
 const currentlyShownBanner = computed(() => {
 	void updateCurrentBannerHeight();
 	if (bannersStore.bannerStack.length === 0) return null;
@@ -64,15 +68,13 @@ const currentlyShownBanner = computed(() => {
 
 	return {
 		component: currentBanner.component,
-		props: Object.fromEntries(
-			Object.entries({
-				name: currentBannerName,
-				content: currentBanner.content,
-				theme: currentBanner.theme,
-				isDismissible: currentBanner.isDismissible,
-				dismissPermanently: currentBanner.dismissPermanently,
-			}).filter(([_, value]) => value !== undefined),
-		),
+		props: removeUndefinedValues({
+			name: currentBannerName,
+			content: currentBanner.content,
+			theme: currentBanner.theme,
+			isDismissible: currentBanner.isDismissible,
+			dismissPermanently: currentBanner.dismissPermanently,
+		}),
 	};
 });
 

--- a/packages/frontend/editor-ui/src/features/shared/banners/components/BannerStack.vue
+++ b/packages/frontend/editor-ui/src/features/shared/banners/components/BannerStack.vue
@@ -64,13 +64,15 @@ const currentlyShownBanner = computed(() => {
 
 	return {
 		component: currentBanner.component,
-		props: {
-			name: currentBannerName,
-			content: currentBanner.content,
-			theme: currentBanner.theme,
-			isDismissible: currentBanner.isDismissible,
-			dismissPermanently: currentBanner.dismissPermanently,
-		},
+		props: Object.fromEntries(
+			Object.entries({
+				name: currentBannerName,
+				content: currentBanner.content,
+				theme: currentBanner.theme,
+				isDismissible: currentBanner.isDismissible,
+				dismissPermanently: currentBanner.dismissPermanently,
+			}).filter(([_, value]) => value !== undefined),
+		),
 	};
 });
 


### PR DESCRIPTION
## Summary

Using v-bind with theme value of undefined was overwriting the value set in the child component eg in the `DataTableStorageLimitWarningBanner`. That happens because the child `DataTableStorageLimitWarningBanner` is not using the theme prop explicitly and therefor it's passed to it's root component which is the `BaseBanner` which overrides the value we pass there explicitly..

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4396/banner-colors-are-incorrect


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Filters out undefined props before v-bind in BannerStack so child banner defaults (e.g., theme) are preserved.
> 
> - **Editor UI – Banners**
>   - Update `packages/frontend/editor-ui/src/features/shared/banners/components/BannerStack.vue`:
>     - Add `removeUndefinedValues()` helper and apply it to `currentlyShownBanner.props` before `v-bind`.
>     - Prevents undefined banner props (e.g., `theme`) from overriding defaults in child components.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d74b141431a3f36575edc3186808b09b39979f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->