### PR TITLE
feat: Prevent ldap email based account when there are deplicate emails

### DIFF
--- a/packages/@n8n/constants/src/index.ts
+++ b/packages/@n8n/constants/src/index.ts
@@ -82,6 +82,12 @@ export interface LdapConfig {
 	synchronizationInterval: number; // minutes
 	searchPageSize: number;
 	searchTimeout: number;
+	/**
+	 * Enforce email uniqueness in LDAP directory.
+	 * When enabled, blocks login if multiple LDAP accounts share the same email.
+	 * Prevents privilege escalation via email-based account linking.
+	 */
+	enforceEmailUniqueness: boolean;
 }
 
 export const LDAP_DEFAULT_CONFIGURATION: LdapConfig = {
@@ -104,6 +110,7 @@ export const LDAP_DEFAULT_CONFIGURATION: LdapConfig = {
 	synchronizationInterval: 60,
 	searchPageSize: 0,
 	searchTimeout: 60,
+	enforceEmailUniqueness: true,
 };
 
 export { Time } from './time';

--- a/packages/cli/src/ldap.ee/__tests__/ldap.service.test.ts
+++ b/packages/cli/src/ldap.ee/__tests__/ldap.service.test.ts
@@ -1391,24 +1391,22 @@ describe('LdapService', () => {
 			});
 
 			beforeEach(() => {
-				Client.prototype.search = jest.fn().mockImplementation(async () => {
-					return Promise.resolve({
-						searchEntries: [
-							{
-								dn: 'uid:duplicate,ou=users,dc=example,dc=com',
-								cn: 'Duplicate',
-								mail: 'jdoe@example.com', // same email as jdoe
-								uid: 'duplicate',
-							},
-							{
-								dn: 'uid=jdoe,ou=users,dc=example,dc=com',
-								cn: 'John Doe',
-								mail: 'jdoe@example.com',
-								uid: 'jdoe',
-							},
-						],
-					});
-				});
+				Client.prototype.search = jest.fn().mockImplementation(async () => ({
+					searchEntries: [
+						{
+							dn: 'uid:duplicate,ou=users,dc=example,dc=com',
+							cn: 'Duplicate',
+							mail: 'jdoe@example.com', // same email as jdoe
+							uid: 'duplicate',
+						},
+						{
+							dn: 'uid=jdoe,ou=users,dc=example,dc=com',
+							cn: 'John Doe',
+							mail: 'jdoe@example.com',
+							uid: 'jdoe',
+						},
+					],
+				}));
 
 				const mockedGetAuthIdentity = getAuthIdentityByLdapId as jest.Mock;
 				mockedGetAuthIdentity.mockResolvedValue(null);

--- a/packages/cli/src/ldap.ee/__tests__/ldap.service.test.ts
+++ b/packages/cli/src/ldap.ee/__tests__/ldap.service.test.ts
@@ -1433,7 +1433,7 @@ describe('LdapService', () => {
 				expect(result).toEqual(mockUser);
 			});
 
-			it('should not check duplicates for existing users with AuthIdentity', async () => {
+			it('should not allow login when duplicates exist and enforcement is enabled', async () => {
 				const ldapService = createDefaultLdapService({
 					...ldapConfig,
 					enforceEmailUniqueness: true,
@@ -1442,7 +1442,6 @@ describe('LdapService', () => {
 				await ldapService.init();
 
 				const result = await ldapService.handleLdapLogin('jdoe', 'password');
-				console.log('result', result);
 				expect(result).toBeUndefined();
 			});
 		});

--- a/packages/cli/src/ldap.ee/__tests__/ldap.service.test.ts
+++ b/packages/cli/src/ldap.ee/__tests__/ldap.service.test.ts
@@ -1,7 +1,7 @@
 import { mockLogger, mockInstance } from '@n8n/backend-test-utils';
 import { GlobalConfig } from '@n8n/config';
 import { LDAP_FEATURE_NAME, type LdapConfig } from '@n8n/constants';
-import type { Settings } from '@n8n/db';
+import type { Settings, User } from '@n8n/db';
 import { AuthIdentityRepository, SettingsRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { QueryFailedError } from '@n8n/typeorm';
@@ -23,6 +23,10 @@ import {
 	mapLdapUserToDbUser,
 	saveLdapSynchronization,
 	resolveEntryBinaryAttributes,
+	getAuthIdentityByLdapId,
+	getUserByEmail,
+	isLdapEnabled,
+	createLdapUserOnLocalDb,
 } from '../helpers.ee';
 import { LdapService } from '../ldap.service.ee';
 
@@ -45,6 +49,10 @@ jest.mock('../helpers.ee', () => ({
 	resolveBinaryAttributes: jest.fn(),
 	processUsers: jest.fn(),
 	resolveEntryBinaryAttributes: jest.fn(),
+	isLdapEnabled: jest.fn(() => true),
+	getAuthIdentityByLdapId: jest.fn(),
+	getUserByEmail: jest.fn(),
+	createLdapUserOnLocalDb: jest.fn(),
 }));
 
 jest.mock('n8n-workflow', () => ({
@@ -103,10 +111,10 @@ describe('LdapService', () => {
 		} as Settings);
 	};
 
-	const createDefaultLdapService = (config: LdapConfig) => {
+	const createDefaultLdapService = (config: LdapConfig, eventService?: EventService) => {
 		mockSettingsRespositoryFindOneByOrFail(config);
 
-		return new LdapService(mockLogger(), settingsRepository, mock(), mock());
+		return new LdapService(mockLogger(), settingsRepository, mock(), eventService ?? mock());
 	};
 
 	describe('init()', () => {
@@ -1371,6 +1379,74 @@ describe('LdapService', () => {
 			ldapService.stopSync();
 
 			expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('handleLdapLogin()', () => {
+		describe('enforceEmailUniqueness', () => {
+			const mockUser: User = mock<User>({
+				email: 'jdoe@example.com',
+				firstName: 'John',
+				lastName: 'Doe',
+			});
+
+			beforeEach(() => {
+				Client.prototype.search = jest.fn().mockImplementation(() => {
+					return Promise.resolve({
+						searchEntries: [
+							{
+								dn: 'uid:duplicate,ou=users,dc=example,dc=com',
+								cn: 'Duplicate',
+								mail: 'jdoe@example.com', // same email as jdoe
+								uid: 'duplicate',
+							},
+							{
+								dn: 'uid=jdoe,ou=users,dc=example,dc=com',
+								cn: 'John Doe',
+								mail: 'jdoe@example.com',
+								uid: 'jdoe',
+							},
+						],
+					});
+				});
+
+				const mockedGetAuthIdentity = getAuthIdentityByLdapId as jest.Mock;
+				mockedGetAuthIdentity.mockResolvedValue(null);
+
+				const mockIsLdapEnabled = isLdapEnabled as jest.Mock;
+				mockIsLdapEnabled.mockReturnValue(true);
+
+				const mockedCreateLdapUserOnLocalDb = createLdapUserOnLocalDb as jest.Mock;
+				mockedCreateLdapUserOnLocalDb.mockResolvedValue(mockUser);
+
+				const mockedGetUserByEmail = getUserByEmail as jest.Mock;
+				mockedGetUserByEmail.mockResolvedValue(null);
+			});
+
+			it('should allow login when duplicates exist but enforcement is disabled', async () => {
+				const ldapService = createDefaultLdapService({
+					...ldapConfig,
+					enforceEmailUniqueness: false,
+				});
+
+				await ldapService.init();
+
+				const result = await ldapService.handleLdapLogin('jdoe', 'password');
+				expect(result).toEqual(mockUser);
+			});
+
+			it.only('should not check duplicates for existing users with AuthIdentity', async () => {
+				const ldapService = createDefaultLdapService({
+					...ldapConfig,
+					enforceEmailUniqueness: true,
+				});
+
+				await ldapService.init();
+
+				const result = await ldapService.handleLdapLogin('jdoe', 'password');
+				console.log('result', result);
+				expect(result).toBeUndefined();
+			});
 		});
 	});
 });

--- a/packages/cli/src/ldap.ee/__tests__/ldap.service.test.ts
+++ b/packages/cli/src/ldap.ee/__tests__/ldap.service.test.ts
@@ -1391,7 +1391,7 @@ describe('LdapService', () => {
 			});
 
 			beforeEach(() => {
-				Client.prototype.search = jest.fn().mockImplementation(() => {
+				Client.prototype.search = jest.fn().mockImplementation(async () => {
 					return Promise.resolve({
 						searchEntries: [
 							{

--- a/packages/cli/src/ldap.ee/__tests__/ldap.service.test.ts
+++ b/packages/cli/src/ldap.ee/__tests__/ldap.service.test.ts
@@ -1435,7 +1435,7 @@ describe('LdapService', () => {
 				expect(result).toEqual(mockUser);
 			});
 
-			it.only('should not check duplicates for existing users with AuthIdentity', async () => {
+			it('should not check duplicates for existing users with AuthIdentity', async () => {
 				const ldapService = createDefaultLdapService({
 					...ldapConfig,
 					enforceEmailUniqueness: true,

--- a/packages/cli/src/ldap.ee/__tests__/ldap.service.test.ts
+++ b/packages/cli/src/ldap.ee/__tests__/ldap.service.test.ts
@@ -82,6 +82,7 @@ describe('LdapService', () => {
 		synchronizationInterval: 60,
 		searchPageSize: 1,
 		searchTimeout: 6,
+		enforceEmailUniqueness: true,
 	};
 
 	const settingsRepository = mockInstance(SettingsRepository);

--- a/packages/cli/src/ldap.ee/constants.ts
+++ b/packages/cli/src/ldap.ee/constants.ts
@@ -67,6 +67,9 @@ export const LDAP_CONFIG_SCHEMA = {
 		searchTimeout: {
 			type: 'number',
 		},
+		enforceEmailUniqueness: {
+			type: 'boolean',
+		},
 	},
 	required: [
 		'loginEnabled',
@@ -104,4 +107,5 @@ export const NON_SENSIBLE_LDAP_CONFIG_PROPERTIES: Array<keyof LdapConfig> = [
 	'searchPageSize',
 	'searchTimeout',
 	'loginLabel',
+	'enforceEmailUniqueness',
 ];

--- a/packages/cli/src/ldap.ee/ldap.service.ee.ts
+++ b/packages/cli/src/ldap.ee/ldap.service.ee.ts
@@ -85,6 +85,12 @@ export class LdapService {
 			key: LDAP_FEATURE_NAME,
 		});
 		const ldapConfig = jsonParse<LdapConfig>(value);
+
+		// Apply secure default for new security field on existing instances
+		if (ldapConfig.enforceEmailUniqueness === undefined) {
+			ldapConfig.enforceEmailUniqueness = true;
+		}
+
 		ldapConfig.bindingAdminPassword = this.cipher.decrypt(ldapConfig.bindingAdminPassword);
 		return ldapConfig;
 	}

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -3313,7 +3313,7 @@
 	"settings.ldap.form.searchTimeout.label": "Search Timeout (Seconds)",
 	"settings.ldap.form.searchTimeout.infoText": "The timeout value for queries to the AD/LDAP server. Increase if you are getting timeout errors caused by a slow AD/LDAP server",
 	"settings.ldap.form.enforceEmailUniqueness.label": "Enforce Email Uniqueness",
-	"settings.ldap.form.enforceEmailUniqueness.tooltip": "When enabled, prevents login if multiple LDAP accounts share the same email address. This security feature prevents privilege escalation attacks via email-based account linking.",
+	"settings.ldap.form.enforceEmailUniqueness.tooltip": "Prevents login if multiple LDAP accounts use the same email, blocking account linking attacks.",
 	"settings.ldap.section.synchronization.title": "Synchronization",
 	"settings.sso": "SSO",
 	"settings.sso.title": "Single Sign On",

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -3312,6 +3312,8 @@
 	"settings.ldap.form.pageSize.infoText": "Max number of records to return per page during synchronization. 0 for unlimited",
 	"settings.ldap.form.searchTimeout.label": "Search Timeout (Seconds)",
 	"settings.ldap.form.searchTimeout.infoText": "The timeout value for queries to the AD/LDAP server. Increase if you are getting timeout errors caused by a slow AD/LDAP server",
+	"settings.ldap.form.enforceEmailUniqueness.label": "Enforce Email Uniqueness",
+	"settings.ldap.form.enforceEmailUniqueness.tooltip": "When enabled, prevents login if multiple LDAP accounts share the same email address. This security feature prevents privilege escalation attacks via email-based account linking.",
 	"settings.ldap.section.synchronization.title": "Synchronization",
 	"settings.sso": "SSO",
 	"settings.sso.title": "Single Sign On",

--- a/packages/frontend/@n8n/rest-api-client/src/api/ldap.ts
+++ b/packages/frontend/@n8n/rest-api-client/src/api/ldap.ts
@@ -44,6 +44,7 @@ export interface LdapConfig {
 	synchronizationInterval: number; // minutes
 	searchPageSize: number;
 	searchTimeout: number;
+	enforceEmailUniqueness: boolean;
 }
 
 export async function getLdapConfig(context: IRestApiContext): Promise<LdapConfig> {

--- a/packages/frontend/editor-ui/src/features/settings/sso/views/SettingsLdapView.vue
+++ b/packages/frontend/editor-ui/src/features/settings/sso/views/SettingsLdapView.vue
@@ -51,6 +51,7 @@ type LDAPConfigForm = {
 	synchronizationInterval: string;
 	pageSize: string;
 	searchTimeout: string;
+	enforceEmailUniqueness: boolean;
 };
 
 type CellClassStyleMethodParams<T> = {
@@ -167,6 +168,7 @@ const onSubmit = async () => {
 		synchronizationInterval: +formValues.synchronizationInterval,
 		searchPageSize: +formValues.pageSize,
 		searchTimeout: +formValues.searchTimeout,
+		enforceEmailUniqueness: formValues.enforceEmailUniqueness,
 	};
 
 	let saveForm = true;
@@ -547,6 +549,17 @@ const getLdapConfig = async () => {
 					infoText: i18n.baseText('settings.ldap.form.searchTimeout.infoText'),
 				},
 				shouldDisplay: whenSyncAndLoginEnabled,
+			},
+			{
+				name: 'enforceEmailUniqueness',
+				initialValue: adConfig.value.enforceEmailUniqueness,
+				properties: {
+					type: 'toggle',
+					label: i18n.baseText('settings.ldap.form.enforceEmailUniqueness.label'),
+					tooltipText: i18n.baseText('settings.ldap.form.enforceEmailUniqueness.tooltip'),
+					required: false,
+				},
+				shouldDisplay: whenLoginEnabled,
 			},
 		];
 	} catch (error) {


### PR DESCRIPTION
## Summary

Prevent account take over and privilege escalation via attacker changing LDAP email to match victims account.
This is done by preventing auto-linking of account when the LDAP records has multiple users with the same email 

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

Resolves PAY-4089

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `enforceEmailUniqueness` to LDAP config (default true) and blocks LDAP login when multiple directory entries share the same email; exposes toggle in settings UI and updates tests.
> 
> - **Backend**:
>   - Add `enforceEmailUniqueness: boolean` to `LdapConfig` with secure defaulting in `loadConfig()` and `LDAP_DEFAULT_CONFIGURATION`.
>   - Implement duplicate-email check `hasEmailDuplicatesInLdap()` and enforce in `handleLdapLogin()` to block auto-linking when duplicates detected.
>   - Update validation schema (`ldap.ee/constants.ts`) and non-sensitive config list to include `enforceEmailUniqueness`.
>   - Extend REST API client `LdapConfig` to include `enforceEmailUniqueness`.
> - **Frontend**:
>   - Add settings toggle `enforceEmailUniqueness` in `SettingsLdapView.vue` with i18n strings, and persist via `updateLdapConfig()`.
> - **Tests**:
>   - Add unit tests for login behavior with duplicate emails when enforcement is enabled/disabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8cf9f0b58041f5962ed4772839d3a6d932bc919f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->