### PR TITLE
Update ci-master.yml

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -1,11 +1,12 @@
+on: [workflow_dispatch]
 name: Test Master
 
-on:
-  push:
-    branches:
-      - master
-    paths-ignore:
-      - packages/@n8n/task-runner-python/**
+# on:
+#   push:
+#     branches:
+#       - master
+#     paths-ignore:
+#       - packages/@n8n/task-runner-python/**
 
 jobs:
   build-github:


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `ci-master.yml` to run via manual dispatch, adds unit tests (matrix + coverage), linting, and Slack failure notifications.
> 
> - **CI (GitHub Actions)**:
>   - **Trigger**: Switch `on` from push to `workflow_dispatch` in `/.github/workflows/ci-master.yml`.
>   - **Jobs**:
>     - `unit-test`: Reusable workflow with Node matrix (`20.x`, `22.x`, `24.3.x`), coverage on `22.x`, uses `CODECOV_TOKEN`.
>     - `lint`: Reusable linting workflow.
>     - `notify-on-failure`: Slack alert via `act10ns/slack` if any of `[unit-test, lint, build-github]` fails.
>     - `build-github`: Keep cache build step using local `setup-nodejs-github` action.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ce6fa3fd6f226c62a1bfe4be7c0ec857d5b10e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->