### PR TITLE
fix: Save workflow history on archive and unarchive (no-changelog)

### DIFF
--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -493,18 +493,20 @@ export class WorkflowService {
 		}
 
 		const versionId = uuid();
+		workflow.versionId = versionId;
+		workflow.isArchived = true;
+		workflow.active = false;
+
 		await this.workflowRepository.update(workflowId, {
 			isArchived: true,
 			active: false,
 			versionId,
 		});
 
+		await this.workflowHistoryService.saveVersion(user, workflow, workflowId);
+
 		this.eventService.emit('workflow-archived', { user, workflowId, publicApi: false });
 		await this.externalHooks.run('workflow.afterArchive', [workflowId]);
-
-		workflow.isArchived = true;
-		workflow.active = false;
-		workflow.versionId = versionId;
 
 		return workflow;
 	}
@@ -523,13 +525,15 @@ export class WorkflowService {
 		}
 
 		const versionId = uuid();
+		workflow.versionId = versionId;
+		workflow.isArchived = false;
+
 		await this.workflowRepository.update(workflowId, { isArchived: false, versionId });
+
+		await this.workflowHistoryService.saveVersion(user, workflow, workflowId);
 
 		this.eventService.emit('workflow-unarchived', { user, workflowId, publicApi: false });
 		await this.externalHooks.run('workflow.afterUnarchive', [workflowId]);
-
-		workflow.isArchived = false;
-		workflow.versionId = versionId;
 
 		return workflow;
 	}


### PR DESCRIPTION
## Summary

This PR fixes a bug where archiving and unarchiving workflows would generate new version IDs without creating corresponding `workflow_history` records.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4399/bug-workflow-version-is-not-saved-on-archive-and-unarchive

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
