### PR TITLE
fix(editor): Fix node name tooltip in NDV header

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/NodeTitle.vue
+++ b/packages/frontend/editor-ui/src/app/components/NodeTitle.vue
@@ -47,6 +47,7 @@ const { width } = useElementSize(wrapperRef);
 			<NodeIcon
 				v-else
 				:icon-source="iconSource"
+				:node-type="nodeType"
 				:size="18"
 				:show-tooltip="true"
 				tooltip-position="left"

--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/NDVHeader.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/NDVHeader.vue
@@ -31,7 +31,14 @@ function onRename(newNodeName: string) {
 <template>
 	<header :class="$style.ndvHeader">
 		<div :class="$style.content">
-			<NodeIcon v-if="icon" :class="$style.icon" :size="20" :icon-source="icon" />
+			<NodeIcon
+				v-if="icon"
+				:class="$style.icon"
+				:size="20"
+				:icon-source="icon"
+				:node-name="props.nodeTypeName"
+				:show-tooltip="true"
+			/>
 			<div :class="$style.title">
 				<N8nInlineTextEdit
 					:model-value="nodeName"

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
@@ -632,6 +632,7 @@ function handleSelectAction(params: INodeParameters) {
 					:model-value="node.name"
 					:icon-source="iconSource"
 					:read-only="isReadOnly"
+					:node-type="nodeType"
 					@update:model-value="nameChanged"
 				/>
 				<NodeExecuteButton


### PR DESCRIPTION
## Summary
Adds back missing property for `NodeIcon` component that caused empty tooltips to render in NDV header.

BEFORE:
<img width="263" height="115" alt="image" src="https://github.com/user-attachments/assets/35c5430e-5f6d-4be5-8e2b-da0241875ce3" />


AFTER:
<img width="375" height="103" alt="image" src="https://github.com/user-attachments/assets/8f500ea2-991b-4bbb-ad9e-23cd2d6b325a" />


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
