### PR TITLE
fix(editor): Fix empty variables notice indent in schema view (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchema.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchema.vue
@@ -259,7 +259,8 @@ const contextItems = computed(() => {
 				const variablesEmptyNotice: RenderNotice = {
 					type: 'notice',
 					id: 'notice-variablesEmpty',
-					level: renderItem.level ?? 0,
+					// Increase level to indent under $vars
+					level: (renderItem.level ?? 0) + 1,
 					message: i18n.baseText('dataMapping.schemaView.variablesEmpty'),
 				};
 				return [renderItem, variablesEmptyNotice];


### PR DESCRIPTION
## Summary
Updating empty vars notice indent in the schema view to render it under `$vars` item:

BEFORE:
<img width="452" height="565" alt="image" src="https://github.com/user-attachments/assets/3acbbbb1-4568-4ffe-8621-d03c5814c5ca" />

AFTER:
<img width="460" height="540" alt="image" src="https://github.com/user-attachments/assets/457a2c4a-4393-45f8-b0d7-b6a740f72751" />


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
