### PR TITLE
feat: Add memory usage monitoring to execution context

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/get-additional-keys.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/get-additional-keys.ts
@@ -4,7 +4,7 @@ import type {
 	IWorkflowExecuteAdditionalData,
 	WorkflowExecuteMode,
 } from 'n8n-workflow';
-import { LoggerProxy } from 'n8n-workflow';
+import { LoggerProxy, MemoryMonitor } from 'n8n-workflow';
 
 import { PLACEHOLDER_EMPTY_EXECUTION_ID } from '@/constants';
 
@@ -26,12 +26,15 @@ export function getAdditionalKeys(
 	const executionId = additionalData.executionId ?? PLACEHOLDER_EMPTY_EXECUTION_ID;
 	const resumeUrl = `${additionalData.webhookWaitingBaseUrl}/${executionId}`;
 	const resumeFormUrl = `${additionalData.formWaitingBaseUrl}/${executionId}`;
+	const currentMemory = MemoryMonitor.getMemoryUsage();
+
 	return {
 		$execution: {
 			id: executionId,
 			mode: mode === 'manual' ? 'test' : 'production',
 			resumeUrl,
 			resumeFormUrl,
+			memoryUsage: currentMemory,
 			customData: runExecutionData
 				? {
 						set(key: string, value: string): void {

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
@@ -41,7 +41,7 @@ import type { WorkflowData, WorkflowDataUpdate } from '@n8n/rest-api-client/api/
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 
 import get from 'lodash/get';
-
+import { MemoryMonitor } from 'n8n-workflow';
 import { useEnvironmentsStore } from '@/features/settings/environments.ee/environments.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
@@ -117,13 +117,14 @@ function resolveParameterImpl<T = IDataObject>(
 	opts: ResolveParameterOptions = {},
 ): T | null {
 	let itemIndex = opts?.targetItem?.itemIndex || 0;
-
+	const currentMemory = MemoryMonitor.getMemoryUsage();
 	const additionalKeys: IWorkflowDataProxyAdditionalKeys = {
 		$execution: {
 			id: PLACEHOLDER_FILLED_AT_EXECUTION_TIME,
 			mode: 'test',
 			resumeUrl: PLACEHOLDER_FILLED_AT_EXECUTION_TIME,
 			resumeFormUrl: PLACEHOLDER_FILLED_AT_EXECUTION_TIME,
+			memoryUsage: currentMemory,
 		},
 		$vars: envVars,
 

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
@@ -117,14 +117,20 @@ function resolveParameterImpl<T = IDataObject>(
 	opts: ResolveParameterOptions = {},
 ): T | null {
 	let itemIndex = opts?.targetItem?.itemIndex || 0;
-	const currentMemory = MemoryMonitor.getMemoryUsage();
 	const additionalKeys: IWorkflowDataProxyAdditionalKeys = {
 		$execution: {
 			id: PLACEHOLDER_FILLED_AT_EXECUTION_TIME,
 			mode: 'test',
 			resumeUrl: PLACEHOLDER_FILLED_AT_EXECUTION_TIME,
 			resumeFormUrl: PLACEHOLDER_FILLED_AT_EXECUTION_TIME,
-			memoryUsage: currentMemory,
+			memoryUsage: {
+				heapUsedMb: PLACEHOLDER_FILLED_AT_EXECUTION_TIME,
+				heapTotalMb: PLACEHOLDER_FILLED_AT_EXECUTION_TIME,
+				externalMb: PLACEHOLDER_FILLED_AT_EXECUTION_TIME,
+				rssMb: PLACEHOLDER_FILLED_AT_EXECUTION_TIME,
+				arrayBuffersMb: PLACEHOLDER_FILLED_AT_EXECUTION_TIME,
+				heapUsedPercentage: PLACEHOLDER_FILLED_AT_EXECUTION_TIME,
+			},
 		},
 		$vars: envVars,
 

--- a/packages/frontend/editor-ui/src/features/execution/executions/executions.utils.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/executions.utils.ts
@@ -1,4 +1,8 @@
-import { MANUAL_TRIGGER_NODE_TYPE, TRIMMED_TASK_DATA_CONNECTIONS_KEY } from 'n8n-workflow';
+import {
+	MANUAL_TRIGGER_NODE_TYPE,
+	MemoryMonitor,
+	TRIMMED_TASK_DATA_CONNECTIONS_KEY,
+} from 'n8n-workflow';
 import type {
 	ITaskData,
 	ExecutionStatus,
@@ -35,6 +39,7 @@ import { h } from 'vue';
 import NodeExecutionErrorMessage from '@/app/components/NodeExecutionErrorMessage.vue';
 import { parse } from 'flatted';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
+import { currentsReporter } from '@currents/playwright';
 
 export function getDefaultExecutionFilters(): ExecutionFilterType {
 	return {
@@ -179,12 +184,14 @@ export const waitingNodeTooltip = (node: INodeUi | null | undefined, workflow?: 
 		const waitingNodeTooltip = useNodeTypesStore().getNodeType(node.type)?.waitingNodeTooltip;
 		if (waitingNodeTooltip) {
 			const activeExecutionId = useWorkflowsStore().activeExecutionId as string;
+			const currentMemory = MemoryMonitor.getMemoryUsage();
 			const additionalData: IWorkflowDataProxyAdditionalKeys = {
 				$execution: {
 					id: activeExecutionId,
 					mode: 'test',
 					resumeUrl: `${useRootStore().webhookWaitingUrl}/${activeExecutionId}`,
 					resumeFormUrl: `${useRootStore().formWaitingUrl}/${activeExecutionId}`,
+					memoryUsage: currentMemory,
 				},
 			};
 			if (workflow) {

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -76,6 +76,7 @@ export * from './node-parameters/parameter-type-validation';
 export * from './node-parameters/path-utils';
 export * from './evaluation-helpers';
 export * from './workflow-diff';
+export * from './memory-monitor';
 
 export type {
 	DocMetadata,

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2295,6 +2295,14 @@ export type IWorkflowDataProxyAdditionalKeys = IDataObject & {
 		mode: 'test' | 'production';
 		resumeUrl: string;
 		resumeFormUrl: string;
+		memoryUsage?: {
+			heapUsed: number;
+			heapTotal: number;
+			external: number;
+			rss: number;
+			arrayBuffers: number;
+			heapUsedPercentage: number;
+		};
 		customData?: {
 			set(key: string, value: string): void;
 			setAll(obj: Record<string, string>): void;

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2295,13 +2295,13 @@ export type IWorkflowDataProxyAdditionalKeys = IDataObject & {
 		mode: 'test' | 'production';
 		resumeUrl: string;
 		resumeFormUrl: string;
-		memoryUsage?: {
-			heapUsed: number;
-			heapTotal: number;
-			external: number;
-			rss: number;
-			arrayBuffers: number;
-			heapUsedPercentage: number;
+		memoryUsage: {
+			heapUsedMb: string | number;
+			heapTotalMb: string | number;
+			externalMb: string | number;
+			rssMb: string | number;
+			arrayBuffersMb: string | number;
+			heapUsedPercentage: string | number;
 		};
 		customData?: {
 			set(key: string, value: string): void;

--- a/packages/workflow/src/memory-monitor.ts
+++ b/packages/workflow/src/memory-monitor.ts
@@ -1,0 +1,13 @@
+export class MemoryMonitor {
+	static getMemoryUsage() {
+		const usage = process.memoryUsage();
+		return {
+			heapUsed: Math.round((usage.heapUsed / 1024 / 1024) * 100) / 100, // MB
+			heapTotal: Math.round((usage.heapTotal / 1024 / 1024) * 100) / 100, // MB
+			external: Math.round((usage.external / 1024 / 1024) * 100) / 100, // MB
+			rss: Math.round((usage.rss / 1024 / 1024) * 100) / 100, // MB
+			arrayBuffers: Math.round((usage.arrayBuffers / 1024 / 1024) * 100) / 100, // MB
+			heapUsedPercentage: Math.round((usage.heapUsed / usage.heapTotal) * 100),
+		};
+	}
+}

--- a/packages/workflow/src/memory-monitor.ts
+++ b/packages/workflow/src/memory-monitor.ts
@@ -2,11 +2,11 @@ export class MemoryMonitor {
 	static getMemoryUsage() {
 		const usage = process.memoryUsage();
 		return {
-			heapUsed: Math.round((usage.heapUsed / 1024 / 1024) * 100) / 100, // MB
-			heapTotal: Math.round((usage.heapTotal / 1024 / 1024) * 100) / 100, // MB
-			external: Math.round((usage.external / 1024 / 1024) * 100) / 100, // MB
-			rss: Math.round((usage.rss / 1024 / 1024) * 100) / 100, // MB
-			arrayBuffers: Math.round((usage.arrayBuffers / 1024 / 1024) * 100) / 100, // MB
+			heapUsedMb: Math.round((usage.heapUsed / 1024 / 1024) * 100) / 100, // MB
+			heapTotalMb: Math.round((usage.heapTotal / 1024 / 1024) * 100) / 100, // MB
+			externalMb: Math.round((usage.external / 1024 / 1024) * 100) / 100, // MB
+			rssMb: Math.round((usage.rss / 1024 / 1024) * 100) / 100, // MB
+			arrayBuffersMb: Math.round((usage.arrayBuffers / 1024 / 1024) * 100) / 100, // MB
 			heapUsedPercentage: Math.round((usage.heapUsed / usage.heapTotal) * 100),
 		};
 	}


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce MemoryMonitor and populate `$execution.memoryUsage` for expressions and tooltips in both engine and editor.
> 
> - **Workflow**:
>   - Add `MemoryMonitor` (`memory-monitor.ts`) and export from `index.ts`.
>   - Extend `IWorkflowDataProxyAdditionalKeys` to support `$execution.memoryUsage` with detailed stats.
> - **Core (execution engine)**:
>   - Populate `$execution.memoryUsage` in `getAdditionalKeys()` using `MemoryMonitor.getMemoryUsage()`.
> - **Frontend (Editor UI)**:
>   - Inject `$execution.memoryUsage` into additional keys during expression resolution in `useWorkflowHelpers.ts`.
>   - Include `$execution.memoryUsage` in `waitingNodeTooltip` evaluation in `executions.utils.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5d1a2ec265fed58503c6cf7b3d60e2a8d85a9f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->