### PR TITLE
feat(slack): add support for channel replies metadata

### DIFF
--- a/packages/nodes-base/nodes/Slack/V2/ChannelDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V2/ChannelDescription.ts
@@ -1216,6 +1216,19 @@ export const channelFields: INodeProperties[] = [
 		description: 'Whether to return all results or only up to a given limit',
 	},
 	{
+		displayName: 'Include All Metadata',
+		name: 'includeAllMetadata',
+		type: 'boolean',
+		displayOptions: {
+			show: {
+				resource: ['channel'],
+				operation: ['replies'],
+			},
+		},
+		default: false,
+		description: 'Whether to return all metadata associated with returned messages',
+	},
+	{
 		displayName: 'Limit',
 		name: 'limit',
 		type: 'number',

--- a/packages/nodes-base/nodes/Slack/V2/SlackV2.node.ts
+++ b/packages/nodes-base/nodes/Slack/V2/SlackV2.node.ts
@@ -729,6 +729,12 @@ export class SlackV2 implements INodeType {
 						if (filters.oldest) {
 							qs.oldest = new Date(filters.oldest as string).getTime() / 1000;
 						}
+
+						const includeAllMetadata = this.getNodeParameter('includeAllMetadata', i);
+						if (includeAllMetadata) {
+							qs.include_all_metadata = includeAllMetadata as boolean;
+						}
+
 						if (returnAll) {
 							responseData = await slackApiRequestAllItems.call(
 								this,

--- a/packages/nodes-base/nodes/Slack/test/v2/node/channel/replies.includeAllMetadata.workflow.json
+++ b/packages/nodes-base/nodes/Slack/test/v2/node/channel/replies.includeAllMetadata.workflow.json
@@ -1,0 +1,106 @@
+{
+	"name": "slack replies metadata test",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "e679c883-1839-47dc-9511-8f7dc370e6b0",
+			"name": "When clicking ‘Execute workflow’",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [820, 360]
+		},
+		{
+			"parameters": {
+				"resource": "channel",
+				"operation": "replies",
+				"channelId": {
+					"__rl": true,
+					"value": "C08514ZPKB8",
+					"mode": "list",
+					"cachedResultName": "test-002"
+				},
+				"ts": "1734322597.935429",
+				"returnAll": false,
+				"limit": 50,
+				"includeAllMetadata": true,
+				"filters": {
+					"inclusive": true
+				}
+			},
+			"id": "2e1937a6-4c8f-4cd1-ae42-11b2bd12cc4c",
+			"name": "Slack",
+			"type": "n8n-nodes-base.slack",
+			"typeVersion": 2.3,
+			"position": [1040, 360],
+			"webhookId": "04c5e584-45f4-48d0-bcd2-0ecacecb0f53",
+			"credentials": {
+				"slackApi": {
+					"id": "Bg0bWXf8apAimCqJ",
+					"name": "Slack account 2"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "06652908-6b8e-443a-9508-ab229b011b73",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1260, 360]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"type": "message",
+					"text": "Original message",
+					"ts": "1734322597.935429"
+				}
+			},
+			{
+				"json": {
+					"type": "message",
+					"text": "Reply 1",
+					"ts": "1734322600.000001",
+					"thread_ts": "1734322597.935429"
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking ‘Execute workflow’": {
+			"main": [
+				[
+					{
+						"node": "Slack",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Slack": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "6b7102c7-d3c5-4b88-b67d-4ee6ae51b581",
+	"meta": {
+		"templateCredsSetupCompleted": true,
+		"instanceId": "be251a83c052a9862eeac953816fbb1464f89dfbf79d7ac490a8e336a8cc8bfd"
+	},
+	"id": "qJdEfiBgYLdfYOTs",
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Slack/test/v2/node/channel/replies.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/node/channel/replies.test.ts
@@ -1,0 +1,30 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+const API_RESPONSE = {
+	ok: true,
+	messages: [
+		{ type: 'message', text: 'Original message', ts: '1734322597.935429' },
+		{ type: 'message', text: 'Reply 1', ts: '1734322600.000001', thread_ts: '1734322597.935429' },
+	],
+};
+
+describe('Test SlackV2, channel => replies', () => {
+	// Basic replies request
+	nock('https://slack.com')
+		.get(
+			'/api/conversations.replies?channel=C08514ZPKB8&ts=1734322597.935429&inclusive=true&limit=100',
+		)
+		.reply(200, API_RESPONSE);
+
+	// Replies including all metadata (include_all_metadata should be present)
+	nock('https://slack.com')
+		.get(
+			'/api/conversations.replies?channel=C08514ZPKB8&ts=1734322597.935429&inclusive=true&include_all_metadata=true&limit=50',
+		)
+		.reply(200, API_RESPONSE);
+
+	new NodeTestHarness().setupTests({
+		workflowFiles: ['replies.workflow.json', 'replies.includeAllMetadata.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Slack/test/v2/node/channel/replies.workflow.json
+++ b/packages/nodes-base/nodes/Slack/test/v2/node/channel/replies.workflow.json
@@ -1,0 +1,105 @@
+{
+	"name": "slack replies test",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "e679c883-1839-47dc-9511-8f7dc370e6b0",
+			"name": "When clicking ‘Execute workflow’",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [820, 360]
+		},
+		{
+			"parameters": {
+				"resource": "channel",
+				"operation": "replies",
+				"channelId": {
+					"__rl": true,
+					"value": "C08514ZPKB8",
+					"mode": "list",
+					"cachedResultName": "test-002"
+				},
+				"ts": "1734322597.935429",
+				"returnAll": false,
+				"limit": 100,
+				"filters": {
+					"inclusive": true
+				}
+			},
+			"id": "2e1937a6-4c8f-4cd1-ae42-11b2bd12cc4c",
+			"name": "Slack",
+			"type": "n8n-nodes-base.slack",
+			"typeVersion": 2.3,
+			"position": [1040, 360],
+			"webhookId": "04c5e584-45f4-48d0-bcd2-0ecacecb0f53",
+			"credentials": {
+				"slackApi": {
+					"id": "Bg0bWXf8apAimCqJ",
+					"name": "Slack account 2"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "06652908-6b8e-443a-9508-ab229b011b73",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1260, 360]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"type": "message",
+					"text": "Original message",
+					"ts": "1734322597.935429"
+				}
+			},
+			{
+				"json": {
+					"type": "message",
+					"text": "Reply 1",
+					"ts": "1734322600.000001",
+					"thread_ts": "1734322597.935429"
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking ‘Execute workflow’": {
+			"main": [
+				[
+					{
+						"node": "Slack",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Slack": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "6b7102c7-d3c5-4b88-b67d-4ee6ae51b581",
+	"meta": {
+		"templateCredsSetupCompleted": true,
+		"instanceId": "be251a83c052a9862eeac953816fbb1464f89dfbf79d7ac490a8e336a8cc8bfd"
+	},
+	"id": "qJdEfiBgYLdfYOTs",
+	"tags": []
+}


### PR DESCRIPTION
## Summary

Add support for retrieving metadata related to channel replies in Slack node.

## Related Linear tickets, Github issues, and Community forum posts

Fixes: #21773

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an `includeAllMetadata` flag to Slack channel replies to request full message metadata and includes tests/workflows verifying the query parameter.
> 
> - **Slack V2 – Channel `replies`**:
>   - Add boolean param `includeAllMetadata` in `ChannelDescription.ts` for `channel` → `replies`.
>   - Wire to API by setting `qs.include_all_metadata` in `SlackV2.node.ts` when enabled.
> - **Tests**:
>   - Add `replies.test.ts` asserting requests with and without `include_all_metadata`.
>   - Add example workflows `replies.workflow.json` and `replies.includeAllMetadata.workflow.json` used by tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d6b8a2f3e48acf97dc73da94b5d5a2c8a38421b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->