### PR TITLE
feat(core): Add automatic check if external webhooks are still regist…

### DIFF
--- a/packages/@n8n/config/src/configs/generic.config.ts
+++ b/packages/@n8n/config/src/configs/generic.config.ts
@@ -17,4 +17,8 @@ export class GenericConfig {
 	/** Grace period (in seconds) to wait for components to shut down before process exit. */
 	@Env('N8N_GRACEFUL_SHUTDOWN_TIMEOUT')
 	gracefulShutdownTimeout: number = 30;
+
+	/** Period (in seconds) in which n8n should whether an external webhook is still registerd. */
+	@Env('N8N_WEBHOOK_REGISTERED_CHECK')
+	webhookRegisteredCheck: number = 300;
 }

--- a/packages/@n8n/config/src/configs/generic.config.ts
+++ b/packages/@n8n/config/src/configs/generic.config.ts
@@ -18,7 +18,7 @@ export class GenericConfig {
 	@Env('N8N_GRACEFUL_SHUTDOWN_TIMEOUT')
 	gracefulShutdownTimeout: number = 30;
 
-	/** Period (in seconds) in which n8n should whether an external webhook is still registerd. */
+	/** Period (in seconds) in which n8n should whether an external webhook is still registered. */
 	@Env('N8N_WEBHOOK_REGISTERED_CHECK')
-	webhookRegisteredCheck: number = 300;
+	webhookRegisteredCheck: number = 300_000;
 }

--- a/packages/cli/src/active-workflow-manager.ts
+++ b/packages/cli/src/active-workflow-manager.ts
@@ -1005,7 +1005,6 @@ export class ActiveWorkflowManager {
 	 */
 	checkExternalWebhooksRegistered() {
 		setInterval(async () => {
-			console.log('Run Registration-Webhook check');
 			const webhooks = await this.webhookService.findAll();
 
 			// TODO: We should probably save in the DB if the webhook registers something externally
@@ -1057,7 +1056,7 @@ export class ActiveWorkflowManager {
 						workflowId: workflow.id,
 					});
 
-					const webhookDescription = nodeType.description.webhooks!.filter(
+					const webhookDescription = nodeType.description?.webhooks!.filter(
 						(value) => value.name === 'default',
 					)[0];
 					if (!webhookDescription) {
@@ -1095,6 +1094,24 @@ export class ActiveWorkflowManager {
 							mode,
 							activation,
 						);
+
+						this.logger.info(
+							`The webhook of node "${webhook.node}" in workflow "${workflow.name}" (${webhook.workflowId}) was not registered anymore and got reregistered`,
+							{
+								nodeName: node.name,
+								workflowId: workflow.id,
+								workflowName: workflow.name,
+							},
+						);
+
+						// TODO: We should probably also do something like this (but of different type) and run an
+						//       error workflow. After all is there a reasonable chance that webhook calls got missed
+						//       and we can so give them the opportunity to check for that
+						// const activationError = new WorkflowActivationError(
+						// 	`The webhook of node "${webhook.node}" in workflow "${workflow.name}" (${webhook.workflowId}) was not registered anymore and got reregistered`,
+						// 	{ node, workflowId: workflow.id },
+						// );
+						// this.executeErrorWorkflow(activationError, workflowData, mode);
 					} catch (error) {
 						this.errorReporter.error(error);
 						this.logger.error(
@@ -1106,25 +1123,6 @@ export class ActiveWorkflowManager {
 							},
 						);
 					}
-
-					// executeErrorWorkflow
-					this.logger.info(
-						`The webhook of node "${webhook.node}" in workflow "${workflow.name}" (${webhook.workflowId}) was not registered anymore and got reregistered`,
-						{
-							nodeName: node.name,
-							workflowId: workflow.id,
-							workflowName: workflow.name,
-						},
-					);
-
-					// TODO: We should probably also do something like this (but of different type) and run an
-					//       error workflow. After all is there a reasonable chance that webhook calls got missed
-					//       and we can so give them the opportunity to check for that
-					// const activationError = new WorkflowActivationError(
-					// 	`The webhook of node "${webhook.node}" in workflow "${workflow.name}" (${webhook.workflowId}) was not registered anymore and got reregistered`,
-					// 	{ node, workflowId: workflow.id },
-					// );
-					// this.executeErrorWorkflow(activationError, workflowData, mode);
 				} catch (error) {
 					// Ignore problems
 				}

--- a/packages/cli/src/webhooks/webhook.service.ts
+++ b/packages/cli/src/webhooks/webhook.service.ts
@@ -304,7 +304,7 @@ export class WebhookService {
 		await this.runWebhookMethod('delete', workflow, webhookData, mode, activation);
 	}
 
-	private async runWebhookMethod(
+	async runWebhookMethod(
 		method: WebhookSetupMethodNames,
 		workflow: Workflow,
 		webhookData: IWebhookData,


### PR DESCRIPTION
Checks periodically if all webhooks at external services like Typeform are still registered. If not it registers the webhook URL again.

## Summary

It check automatically all 5 minutes (can be configured via environment variable) all the active workflows which use Trigger nodes that depend on having an URL registered at a service.
If the URL is not registered anymore, it registers it again automatically.

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a periodic check to verify external webhook registrations and re-register missing ones, configurable via `N8N_WEBHOOK_REGISTERED_CHECK`.
> 
> - **Core**:
>   - `ActiveWorkflowManager`: On init, starts `checkExternalWebhooksRegistered()` to periodically iterate stored webhooks, reconstruct related workflows, run `checkExists` via `WebhookService.runWebhookMethod`, and call `create` if missing; logs outcomes.
>   - Injects `GlobalConfig` to read interval.
> - **Config**:
>   - `GenericConfig`: Adds `generic.webhookRegisteredCheck` (`N8N_WEBHOOK_REGISTERED_CHECK`) with default `300_000`.
> - **Webhooks**:
>   - `WebhookService`: Exposes `runWebhookMethod(...)` for external use.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 184b9dbafc45ea42eb82c50e524469486a65ca82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->