### PR TITLE
feat(Openrouter Node): Support reasoning effort in openrouter node

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/LmChatOpenRouter.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/LmChatOpenRouter.node.ts
@@ -265,15 +265,13 @@ export class LmChatOpenRouter implements INodeType {
 			'temperature',
 			'topP',
 			'responseFormat',
+			'reasoningEffort',
 		]);
 
 		const model = new ChatOpenAI({
 			apiKey: credentials.apiKey,
 			model: modelName,
 			...includedOptions,
-			reasoning: {
-				effort: options.reasoningEffort,
-			},
 			timeout: options.timeout ?? 60000,
 			maxRetries: options.maxRetries ?? 2,
 			configuration,

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/LmChatOpenRouter.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/LmChatOpenRouter.node.ts
@@ -146,6 +146,30 @@ export class LmChatOpenRouter implements INodeType {
 						},
 					},
 					{
+						displayName: 'Reasoning Effort',
+						name: 'reasoningEffort',
+						default: '',
+						type: 'options',
+						options: [
+							{
+								name: 'High',
+								value: 'high',
+							},
+							{
+								name: 'Medium',
+								value: 'medium',
+							},
+							{
+								name: 'Low',
+								value: 'low',
+							},
+							{
+								name: 'Minimal',
+								value: 'minimal',
+							},
+						],
+					},
+					{
 						displayName: 'Response Format',
 						name: 'responseFormat',
 						default: 'text',
@@ -204,30 +228,6 @@ export class LmChatOpenRouter implements INodeType {
 						description:
 							'Controls diversity via nucleus sampling: 0.5 means half of all likelihood-weighted options are considered. We generally recommend altering this or temperature but not both.',
 						type: 'number',
-					},
-					{
-						displayName: 'Reasoning Effort',
-						name: 'reasoningEffort',
-						default: '',
-						type: 'options',
-						options: [
-							{
-								name: 'High',
-								value: 'high',
-							},
-							{
-								name: 'Medium',
-								value: 'medium',
-							},
-							{
-								name: 'Low',
-								value: 'low',
-							},
-							{
-								name: 'Minimal',
-								value: 'minimal',
-							},
-						],
 					},
 				],
 			},

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/LmChatOpenRouter.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/LmChatOpenRouter.node.ts
@@ -149,6 +149,8 @@ export class LmChatOpenRouter implements INodeType {
 						displayName: 'Reasoning Effort',
 						name: 'reasoningEffort',
 						default: '',
+						description:
+							'Controls the amount of reasoning tokens to use. A value of "low" will favor speed and economical token usage, "high" will favor more complete reasoning at the cost of more tokens generated and slower responses. Not all reasoning models support "minimal".',
 						type: 'options',
 						options: [
 							{

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/LmChatOpenRouter.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/LmChatOpenRouter.node.ts
@@ -1,4 +1,5 @@
 import { ChatOpenAI, type ClientOptions } from '@langchain/openai';
+import pick from 'lodash/pick';
 import {
 	NodeConnectionTypes,
 	type INodeType,
@@ -204,6 +205,30 @@ export class LmChatOpenRouter implements INodeType {
 							'Controls diversity via nucleus sampling: 0.5 means half of all likelihood-weighted options are considered. We generally recommend altering this or temperature but not both.',
 						type: 'number',
 					},
+					{
+						displayName: 'Reasoning Effort',
+						name: 'reasoningEffort',
+						default: '',
+						type: 'options',
+						options: [
+							{
+								name: 'High',
+								value: 'high',
+							},
+							{
+								name: 'Medium',
+								value: 'medium',
+							},
+							{
+								name: 'Low',
+								value: 'low',
+							},
+							{
+								name: 'Minimal',
+								value: 'minimal',
+							},
+						],
+					},
 				],
 			},
 		],
@@ -223,6 +248,7 @@ export class LmChatOpenRouter implements INodeType {
 			temperature?: number;
 			topP?: number;
 			responseFormat?: 'text' | 'json_object';
+			reasoningEffort?: 'minimal' | 'low' | 'medium' | 'high';
 		};
 
 		const configuration: ClientOptions = {
@@ -232,10 +258,22 @@ export class LmChatOpenRouter implements INodeType {
 			},
 		};
 
+		const includedOptions = pick(options, [
+			'frequencyPenalty',
+			'maxTokens',
+			'presencePenalty',
+			'temperature',
+			'topP',
+			'responseFormat',
+		]);
+
 		const model = new ChatOpenAI({
 			apiKey: credentials.apiKey,
 			model: modelName,
-			...options,
+			...includedOptions,
+			reasoning: {
+				effort: options.reasoningEffort,
+			},
 			timeout: options.timeout ?? 60000,
 			maxRetries: options.maxRetries ?? 2,
 			configuration,

--- a/packages/@n8n/nodes-langchain/nodes/llms/test/LmChatOpenRouter.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/test/LmChatOpenRouter.test.ts
@@ -1,0 +1,89 @@
+import { ChatOpenAI } from '@langchain/openai';
+import { createMockExecuteFunction } from 'n8n-nodes-base/test/nodes/Helpers';
+import type { INode, ISupplyDataFunctions } from 'n8n-workflow';
+
+import { LmChatOpenRouter } from '../LmChatOpenRouter/LmChatOpenRouter.node';
+import { makeN8nLlmFailedAttemptHandler } from '../n8nLlmFailedAttemptHandler';
+import { N8nLlmTracing } from '../N8nLlmTracing';
+
+jest.mock('@langchain/openai');
+jest.mock('../N8nLlmTracing');
+jest.mock('../n8nLlmFailedAttemptHandler');
+jest.mock('@utils/httpProxyAgent', () => ({
+	getProxyAgent: jest.fn().mockReturnValue({}),
+}));
+
+const MockedChatOpenAI = jest.mocked(ChatOpenAI);
+const MockedN8nLlmTracing = jest.mocked(N8nLlmTracing);
+const mockedMakeN8nLlmFailedAttemptHandler = jest.mocked(makeN8nLlmFailedAttemptHandler);
+
+describe('LmChatOpenRouter', () => {
+	let lmChatOpenRouter: LmChatOpenRouter;
+	let mockContext: jest.Mocked<ISupplyDataFunctions>;
+
+	const mockNode: INode = {
+		id: '1',
+		name: 'OpenRouter Chat Model',
+		typeVersion: 1.2,
+		type: 'n8n-nodes-langchain.lmChatOpenRouter',
+		position: [0, 0],
+		parameters: {},
+	};
+
+	const setupMockContext = (nodeOverrides: Partial<INode> = {}) => {
+		const node = { ...mockNode, ...nodeOverrides };
+		mockContext = createMockExecuteFunction<ISupplyDataFunctions>(
+			{},
+			node,
+		) as jest.Mocked<ISupplyDataFunctions>;
+
+		// Setup default mocks
+		mockContext.getCredentials = jest.fn().mockResolvedValue({
+			apiKey: 'test-api-key',
+		});
+		mockContext.getNode = jest.fn().mockReturnValue(node);
+		mockContext.getNodeParameter = jest.fn();
+
+		// Mock the constructors/functions properly
+		MockedN8nLlmTracing.mockImplementation(() => ({}) as any);
+		mockedMakeN8nLlmFailedAttemptHandler.mockReturnValue(jest.fn());
+
+		return mockContext;
+	};
+
+	beforeEach(() => {
+		lmChatOpenRouter = new LmChatOpenRouter();
+		jest.clearAllMocks();
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('supplyData', () => {
+		it('should handle reasoningEffort chat model option', async () => {
+			const mockContext = setupMockContext();
+			const options = {
+				reasoningEffort: 'high',
+			};
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'gpt-4o-mini';
+				if (paramName === 'options') return options;
+				return undefined;
+			});
+
+			await lmChatOpenRouter.supplyData.call(mockContext, 0);
+
+			expect(MockedChatOpenAI).toHaveBeenCalledWith(
+				expect.objectContaining({
+					apiKey: 'test-api-key',
+					reasoningEffort: options.reasoningEffort,
+					timeout: 60000,
+					maxRetries: 2,
+					onFailedAttempt: expect.any(Function),
+				}),
+			);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds a new option "Reasoning Effort" to OpenRouter chat models

<img width="1512" height="820" alt="image" src="https://github.com/user-attachments/assets/f8966138-1b50-4b7c-8a10-6ece61a8ed95" />


### Review notes

Remember to run `pnpm run build` from root or just rebuild the `@n8n/n8n-nodes-langchain` package, otherwise the latest node code will not be used.

One thing we weren't able to verify yet, is whether the reasoning parameter is properly sent to OpenRouter.

curl request for local testing of reasoningeffort option:
```
curl --location 'https://openrouter.ai/api/v1/chat/completions' \
--header 'Content-Type: application/json' \
--header 'Authorization: ••••••' \
--data '{
  "model": "openai/o4-mini",
  "messages": [
    {
      "role": "user",
      "content": "Was 1995 30 years ago? Please show your reasoning."
    }
  ],
  "reasoning": {
    "effort": "high"
  }
}'
```

It needs to be an "o-model" to be able to do reasoning.

The challenge for testing in n8n: we only see the "message content" from the response using the chat trigger. We couldn't figure out how to inspect the reasoning response data in n8n yet.

In order to see the `reasoningEffort` being set successfully in the langchain `ChatOpenAi` instance, set a breakpoint in `node_modules/.pnpm/@langchain+openai@0.6.16_@langchain+core@0.3.68_@opentelemetry+api@1.9.0_@opentelemetry_cdc683f1374ade3c415e900cf09238c9/node_modules/@langchain/openai/dist/chat_models.cjs` line 607




## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

- https://community.n8n.io/t/custom-parameters-for-llm-chat-models/198826
- https://community.n8n.io/t/add-custom-parameters-support-to-openrouter-model-node-and-other-ai-nodes/218260
- https://community.n8n.io/t/enable-reasoning-parameters-across-all-compatible-models-in-ai-agent-node/164505

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
