### PR TITLE
feat(Openrouter Node): Support setting chat model options as JSON

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/LmChatOpenRouter.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/LmChatOpenRouter.node.ts
@@ -139,6 +139,8 @@ export class LmChatOpenRouter implements INodeType {
 				displayName: 'Options',
 				name: 'jsonOutput',
 				type: 'json',
+				noDataExpression: true,
+				hint: 'See the <a href="https://openrouter.ai/docs/api-reference/chat/send-chat-completion-request" target="_blank">OpenRouter API documentation</a> for available options',
 				typeOptions: {
 					rows: 5,
 				},

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/LmChatOpenRouter.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/LmChatOpenRouter.node.ts
@@ -1,5 +1,6 @@
 import { ChatOpenAI, type ClientOptions } from '@langchain/openai';
 import {
+	jsonParse,
 	NodeConnectionTypes,
 	NodeOperationError,
 	type INodeType,
@@ -272,7 +273,7 @@ export class LmChatOpenRouter implements INodeType {
 				}) as string;
 
 				// TODO: support expressions in json, maybe with resolveRawData(jsonOutput)
-				jsonOptions = jsonOutput;
+				jsonOptions = jsonParse(jsonOutput);
 			} catch (error) {
 				throw new NodeOperationError(this.getNode(), error.message, {
 					description: error.message,

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/LmChatOpenRouter.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/LmChatOpenRouter.node.ts
@@ -272,13 +272,15 @@ export class LmChatOpenRouter implements INodeType {
 
 					// TODO: support expressions in json, maybe with resolveRawData(jsonOutput)
 					const parsedOptions: any = jsonParse(optionsDefinedAsJson);
-					const maxRetries = parseInt(
-						parsedOptions.max_retries || parsedOptions.maxRetries || '',
-						10,
-					);
+					const maxRetries = parsedOptions.max_retries || parsedOptions.maxRetries;
+					// without these mappings, langchain will overwrite max_tokens and reasoning from modelKwargs with undefined
+					const maxTokens = parsedOptions.max_tokens ?? undefined;
+					const reasoning = parsedOptions.reasoning ?? undefined;
 					return {
 						timeout: parsedOptions.timeout ?? 60000,
-						maxRetries: maxRetries && !isNaN(maxRetries) ? maxRetries : 2,
+						maxRetries: maxRetries && typeof maxRetries === 'number' ? maxRetries : 2,
+						maxTokens,
+						reasoning,
 						modelKwargs: parsedOptions,
 					};
 				} catch (error) {

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/LmChatOpenRouter.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/LmChatOpenRouter.node.ts
@@ -278,11 +278,14 @@ export class LmChatOpenRouter implements INodeType {
 					// without these mappings, langchain will overwrite max_tokens and reasoning from modelKwargs with undefined
 					const maxTokens = parsedOptions.max_tokens ?? undefined;
 					const reasoning = parsedOptions.reasoning ?? undefined;
+					// needs to be set because of broken logic for parsing reasoning options in langchain in https://github.com/konstantintieber/langchainjs/commit/02bfa2c6b869fba1cd193842557486f07a8624c2 (was removed in newer version)
+					const reasoningEffort = parsedOptions.reasoning?.effort ?? undefined;
 					return {
 						timeout: parsedOptions.timeout ?? 60000,
 						maxRetries: maxRetries && typeof maxRetries === 'number' ? maxRetries : 2,
 						maxTokens,
 						reasoning,
+						reasoningEffort,
 						modelKwargs: parsedOptions,
 					};
 				} catch (error) {


### PR DESCRIPTION
## Summary

Same UX as the "Next form page" node.

UX demo video:


https://github.com/user-attachments/assets/f101ba93-2491-42f4-b07f-c8a0adf63d8d




Supported options by OpenRouter: https://openrouter.ai/docs/api-reference/chat/send-chat-completion-request

Learning: the fact that we're using langchain's OpenAiChat under the hood is making this more complex, because they have special logic to set the max_tokens option among others: https://github.com/langchain-ai/langchainjs/blob/langchain%3D%3D0.3.33/libs/langchain-openai/src/chat_models.ts#L2334-L2356
In order for "openrouter chat model options as JSON" to work reliably for users of the openrouter node, we need to implement hardcoded mappings of "openrouter option -> langchain option name used in parsing".
This is attempted here: https://github.com/n8n-io/n8n/pull/21780/commits/0621349e92424419b59bb5c2e78ffd52c3c6ad5d

### Review notes

Remember to run `pnpm run build` from root or just rebuild the `@n8n/n8n-nodes-langchain` package, otherwise the latest node code will not be used.

## Related Linear tickets, Github issues, and Community forum posts

- https://community.n8n.io/t/custom-parameters-for-llm-chat-models/198826
- https://community.n8n.io/t/add-custom-parameters-support-to-openrouter-model-node-and-other-ai-nodes/218260
- https://community.n8n.io/t/enable-reasoning-parameters-across-all-compatible-models-in-ai-agent-node/164505

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
