### PR TITLE
fix(core): Fix race condition in workflow history pruning

### DIFF
--- a/packages/cli/src/workflows/workflow-history/workflow-history-manager.ts
+++ b/packages/cli/src/workflows/workflow-history/workflow-history-manager.ts
@@ -1,6 +1,7 @@
 import { Logger } from '@n8n/backend-common';
 import { Time } from '@n8n/constants';
 import { WorkflowHistoryRepository } from '@n8n/db';
+import { OnShutdown } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 import { DateTime } from 'luxon';
 
@@ -15,18 +16,21 @@ export class WorkflowHistoryManager {
 		private readonly logger: Logger,
 		private workflowHistoryRepo: WorkflowHistoryRepository,
 	) {
-		this.logger = this.logger.scoped('workflow-history-manager');
+		this.logger = this.logger.scoped('pruning');
 	}
 
 	init() {
 		if (this.pruneTimer !== undefined) {
-			this.logger.warn('WorkflowHistoryManager.init() called multiple times. Restarting prune timer.');
+			this.logger.warn(
+				'WorkflowHistoryManager.init() called multiple times. Restarting prune timer.',
+			);
 			clearInterval(this.pruneTimer);
 		}
 
 		this.pruneTimer = setInterval(async () => await this.prune(), 1 * Time.hours.toMilliseconds);
 	}
 
+	@OnShutdown()
 	shutdown() {
 		if (this.pruneTimer !== undefined) {
 			clearInterval(this.pruneTimer);


### PR DESCRIPTION
## Summary

This PR fixes a potential race condition in `WorkflowHistoryManager` where overlapping prune operations could occur if `prune()` was called while another prune operation was already in progress. This could happen if the interval timer fired while a previous prune operation was still executing, potentially causing database conflicts or inconsistent state.

**Changes made:**
- Added `isPruning` flag to prevent concurrent prune operations
- Added Logger injection with scoped logger (`workflow-history-manager`) for better debugging and observability
- Added warning log when `init()` is called multiple times to help identify unexpected re-initialization
- Improved error handling with proper logging and guaranteed flag reset using try/finally block
- Ensured `isPruning` flag is always reset, even on early returns (`pruneHours === -1`) or errors

**Testing:**
- Race condition prevention (overlapping operations are skipped)
- Multiple `init()` call detection and logging
- Error handling and flag reset after errors
- Early return flag reset (`pruneHours === -1`)
- Sequential operations work correctly
- Resource cleanup on shutdown

## Related Linear tickets, Github issues, and Community forum posts

No related issue. I found this when playing around with the history manager.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevent overlapping workflow history pruning and add scoped logging, error handling, and tests.
> 
> - **Core: `WorkflowHistoryManager`**
>   - Add `isPruning` flag to prevent overlapping `prune()` executions with debug skip log.
>   - Inject `Logger` and use scoped logger (`pruning`); warn on repeated `init()` calls.
>   - Improve `prune()` with try/catch/finally for error logging and guaranteed flag reset, including early return when `pruneHours === -1`.
>   - Annotate `shutdown()` with `@OnShutdown` and ensure interval cleanup.
> - **Tests: `packages/cli/test/integration/workflow-history-manager.test.ts`**
>   - Add coverage for race prevention, repeated `init()` warning, error handling and flag reset, early-return behavior, sequential pruning, and interval cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e168a5353c2b767ecdf1ef05c8ce3f56e9a622b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->