### PR TITLE
feat(devcontainer): Update devcontainer to allow docker build & gpg commit signature

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM n8nio/base:22
 
-RUN apk add --no-cache --update openssh sudo shadow bash
+RUN apk add --no-cache --update openssh sudo shadow bash docker-cli docker-cli-buildx gnupg
 RUN echo node ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/node && chmod 0440 /etc/sudoers.d/node
 RUN mkdir /workspaces && chown node:node /workspaces
 RUN npm install -g pnpm

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,10 +6,12 @@
 	"mounts": [
 		"type=bind,source=${localWorkspaceFolder},target=/workspaces,consistency=cached",
 		"type=bind,source=${localEnv:HOME}/.ssh,target=/home/node/.ssh,consistency=cached",
-		"type=bind,source=${localEnv:HOME}/.n8n,target=/home/node/.n8n,consistency=cached"
+		"type=bind,source=${localEnv:HOME}/.gnupg,target=/home/node/.gnupg,consistency=cached",
+		"type=bind,source=${localEnv:HOME}/.n8n,target=/home/node/.n8n,consistency=cached",
+		"type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock"
 	],
 	"forwardPorts": [8080, 5678],
-	"postCreateCommand": "corepack prepare --activate && pnpm install",
+	"postCreateCommand": "corepack prepare --activate && pnpm install && sudo chmod a+rwx /var/run/docker.sock",
 	"postAttachCommand": "pnpm build",
 	"customizations": {
 		"codespaces": {


### PR DESCRIPTION
## Summary

Following a try to build the task runners image, I had difficulties with the devcontainer. So I improve it to have the possibility to:

- do a docker build inside the container (pretty useful to test docker images)
- sign my commit with GPG

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update devcontainer to support in-container Docker builds and GPG commit signing via added packages, mounts, and permissions.
> 
> - **Devcontainer**:
>   - **Docker support**:
>     - Add `docker-cli` and `docker-cli-buildx` in `.devcontainer/Dockerfile`.
>     - Mount `/var/run/docker.sock` and set permissions in `postCreateCommand`.
>   - **GPG signing**:
>     - Install `gnupg` and bind-mount host `~/.gnupg` to `/home/node/.gnupg`.
>   - **Config tweaks**:
>     - Preserve existing SSH and `~/.n8n` mounts; keep build steps and ports unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c60d1eb719d5485e3555f952ab64180d7acae8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->