### PR TITLE
feat(editor): Update command bar wf search to match by any query term

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nCommandBar/CommandBar.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nCommandBar/CommandBar.test.ts
@@ -139,5 +139,171 @@ describe('components', () => {
 				expect(screen.queryByPlaceholderText('Type a command...')).not.toBeInTheDocument(),
 			);
 		});
+
+		describe('matchAnySearchTerm', () => {
+			it('should match entire query string when matchAnySearchTerm is false', async () => {
+				const items = [
+					{
+						id: 'workflow-1',
+						title: 'Customer Data Sync',
+						matchAnySearchTerm: false,
+					},
+					{
+						id: 'workflow-2',
+						title: 'Email Marketing Campaign',
+						matchAnySearchTerm: false,
+					},
+				];
+
+				render(N8nCommandBar, { props: { items } });
+				await openCommandBar();
+
+				const input = screen.getByPlaceholderText('Type a command...');
+
+				await fireEvent.update(input, 'customer data');
+				await nextTick();
+
+				expect(screen.getByText('Customer Data Sync')).toBeInTheDocument();
+				expect(screen.queryByText('Email Marketing Campaign')).not.toBeInTheDocument();
+			});
+
+			it('should match any word when matchAnySearchTerm is true', async () => {
+				const items = [
+					{
+						id: 'workflow-1',
+						title: 'Customer Data Sync',
+						matchAnySearchTerm: true,
+					},
+					{
+						id: 'workflow-2',
+						title: 'Email Marketing Campaign',
+						matchAnySearchTerm: true,
+					},
+					{
+						id: 'workflow-3',
+						title: 'Sales Report Generator',
+						matchAnySearchTerm: true,
+					},
+				];
+
+				render(N8nCommandBar, { props: { items } });
+				await openCommandBar();
+
+				const input = screen.getByPlaceholderText('Type a command...');
+
+				await fireEvent.update(input, 'customer email');
+				await nextTick();
+
+				expect(screen.getByText('Customer Data Sync')).toBeInTheDocument();
+				expect(screen.getByText('Email Marketing Campaign')).toBeInTheDocument();
+				expect(screen.queryByText('Sales Report Generator')).not.toBeInTheDocument();
+			});
+
+			it('should match keywords with matchAnySearchTerm', async () => {
+				const items = [
+					{
+						id: 'workflow-1',
+						title: 'Data Processor',
+						keywords: ['excel', 'spreadsheet', 'csv'],
+						matchAnySearchTerm: true,
+					},
+					{
+						id: 'workflow-2',
+						title: 'Email Handler',
+						keywords: ['gmail', 'outlook', 'mail'],
+						matchAnySearchTerm: true,
+					},
+				];
+
+				render(N8nCommandBar, { props: { items } });
+				await openCommandBar();
+
+				const input = screen.getByPlaceholderText('Type a command...');
+
+				await fireEvent.update(input, 'excel gmail');
+				await nextTick();
+
+				expect(screen.getByText('Data Processor')).toBeInTheDocument();
+				expect(screen.getByText('Email Handler')).toBeInTheDocument();
+			});
+
+			it('should handle multiple spaces in search query', async () => {
+				const items = [
+					{
+						id: 'workflow-1',
+						title: 'Customer Sync',
+						matchAnySearchTerm: true,
+					},
+					{
+						id: 'workflow-2',
+						title: 'Email Campaign',
+						matchAnySearchTerm: true,
+					},
+				];
+
+				render(N8nCommandBar, { props: { items } });
+				await openCommandBar();
+
+				const input = screen.getByPlaceholderText('Type a command...');
+
+				await fireEvent.update(input, 'customer  email   ');
+				await nextTick();
+
+				expect(screen.getByText('Customer Sync')).toBeInTheDocument();
+				expect(screen.getByText('Email Campaign')).toBeInTheDocument();
+			});
+
+			it('should match single word with matchAnySearchTerm', async () => {
+				const items = [
+					{
+						id: 'workflow-1',
+						title: 'Customer Data Sync',
+						matchAnySearchTerm: true,
+					},
+					{
+						id: 'workflow-2',
+						title: 'Email Marketing',
+						matchAnySearchTerm: true,
+					},
+				];
+
+				render(N8nCommandBar, { props: { items } });
+				await openCommandBar();
+
+				const input = screen.getByPlaceholderText('Type a command...');
+
+				await fireEvent.update(input, 'customer');
+				await nextTick();
+
+				expect(screen.getByText('Customer Data Sync')).toBeInTheDocument();
+				expect(screen.queryByText('Email Marketing')).not.toBeInTheDocument();
+			});
+
+			it('should work with mixed matchAnySearchTerm settings', async () => {
+				const items = [
+					{
+						id: 'workflow-1',
+						title: 'Customer Data Sync',
+						matchAnySearchTerm: true,
+					},
+					{
+						id: 'workflow-2',
+						title: 'Customer Email Setup',
+						matchAnySearchTerm: false,
+					},
+				];
+
+				render(N8nCommandBar, { props: { items } });
+				await openCommandBar();
+
+				const input = screen.getByPlaceholderText('Type a command...');
+
+				await fireEvent.update(input, 'data email');
+				await nextTick();
+
+				expect(screen.getByText('Customer Data Sync')).toBeInTheDocument();
+				expect(screen.queryByText('Customer Email Setup')).not.toBeInTheDocument();
+			});
+		});
 	});
 });

--- a/packages/frontend/@n8n/design-system/src/components/N8nCommandBar/CommandBar.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nCommandBar/CommandBar.vue
@@ -67,6 +67,13 @@ const filteredItems = computed(() => {
 				.join(' ')
 				.toLowerCase();
 
+			if (item.matchAnySearchTerm) {
+				return query
+					.split(' ')
+					.filter(Boolean)
+					.some((word) => searchText.includes(word));
+			}
+
 			return searchText.includes(query);
 		});
 	}

--- a/packages/frontend/@n8n/design-system/src/components/N8nCommandBar/types.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nCommandBar/types.ts
@@ -10,4 +10,5 @@ export interface CommandBarItem {
 	children?: CommandBarItem[];
 	placeholder?: string;
 	hasMoreChildren?: boolean;
+	matchAnySearchTerm?: boolean;
 }

--- a/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useWorkflowNavigationCommands.ts
+++ b/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useWorkflowNavigationCommands.ts
@@ -285,6 +285,7 @@ export function useWorkflowNavigationCommands(options: {
 
 		return {
 			id: workflow.id,
+			matchAnySearchTerm: !isRoot,
 			title: {
 				component: CommandBarItemTitle,
 				props: {


### PR DESCRIPTION
## Summary

The API endpoint and the table search has been update to work this way so the command bar needs to be adjusted as well

Added the behavior as an explicit option which is disabled by default as in context where there are many items/commands  eg in the root of the command bar it's more useful to be able to precisely define your search term.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4404/feature-update-command-bar-to-find-workflows-by-any-query-term-matched

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit d6df39b10376db01b04fe7b46fb6057db8b16da3. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->