### PR TITLE
ci: Make `n8nio/runners` image easier to extend

### DIFF
--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -92,9 +92,10 @@ RUN set -e; \
     cd / && rm -rf /launcher-temp
 
 # ==============================================================================
-# STAGE 4: Node alpine base for JS task runner
+# STAGE 4: Node alpine base with pnpm enabled
 # ==============================================================================
 FROM node:${NODE_VERSION}-alpine AS node-alpine
+RUN corepack enable pnpm && corepack install -g pnpm@latest
 
 # ==============================================================================
 # STAGE 5: Runtime
@@ -107,7 +108,7 @@ ENV NODE_ENV=production \
     N8N_RELEASE_TYPE=${N8N_RELEASE_TYPE} \
     SHELL=/bin/sh
 
-# Bring `uv` over from python-runner-builder
+# Bring `uv` over from python-runner-builder, to make the image easier to extend
 COPY --from=python-runner-builder /usr/local/bin/uv /usr/local/bin/uv
 
 # Bring node over from node-alpine
@@ -116,6 +117,11 @@ COPY --from=node-alpine /usr/local/bin/node /usr/local/bin/node
 # libstdc++ is required by Node
 # libc6-compat is required by task-runner-launcher
 RUN apk add --no-cache ca-certificates tini libstdc++ libc6-compat
+
+# Bring corepack and pnpm over, to make the image easier to extend
+COPY --from=node-alpine /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -s ../lib/node_modules/corepack/dist/corepack.js /usr/local/bin/corepack && \
+    ln -s ../lib/node_modules/corepack/dist/pnpm.js /usr/local/bin/pnpm
 
 RUN addgroup -g 1000 -S runner \
  && adduser  -u 1000 -S -G runner -h /home/runner -D runner

--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -110,7 +110,6 @@ RUN set -e; \
 # STAGE 4: Node alpine base for JS task runner
 # ==============================================================================
 FROM node:${NODE_VERSION}-alpine AS node-alpine
-RUN corepack enable pnpm && corepack install -g pnpm@latest
 
 # ==============================================================================
 # STAGE 5: Runtime

--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -20,6 +20,21 @@ RUN pnpm install --prod --no-lockfile --silent
 RUN mv package.json extras.json
 RUN mv package.json.bak package.json
 
+# Remove `catalog` and `workspace` references from package.json to allow `pnpm add` in extended images
+RUN node -e "const pkg = require('./package.json'); \
+    Object.keys(pkg.dependencies || {}).forEach(k => { \
+        const val = pkg.dependencies[k]; \
+        if (val === 'catalog:' || val.startsWith('catalog:') || val.startsWith('workspace:')) \
+            delete pkg.dependencies[k]; \
+    }); \
+    Object.keys(pkg.devDependencies || {}).forEach(k => { \
+        const val = pkg.devDependencies[k]; \
+        if (val === 'catalog:' || val.startsWith('catalog:') || val.startsWith('workspace:')) \
+            delete pkg.devDependencies[k]; \
+    }); \
+    delete pkg.devDependencies; \
+    require('fs').writeFileSync('./package.json', JSON.stringify(pkg, null, 2));"
+
 # ==============================================================================
 # STAGE 2: Python runner build (@n8n/task-runner-python) with uv
 # Produces a relocatable venv tied to the python version used

--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -92,7 +92,7 @@ RUN set -e; \
     cd / && rm -rf /launcher-temp
 
 # ==============================================================================
-# STAGE 4: Node alpine base with pnpm enabled
+# STAGE 4: Node alpine base for JS task runner
 # ==============================================================================
 FROM node:${NODE_VERSION}-alpine AS node-alpine
 RUN corepack enable pnpm && corepack install -g pnpm@latest


### PR DESCRIPTION
## Summary

Make it easier to extend the `n8nio/runners` so users don't have to build it themselves:

```dockerfile
FROM n8nio/runners:test
USER root
RUN cd /opt/runners/task-runner-javascript && pnpm add moment
RUN cd /opt/runners/task-runner-python && uv pip install pandas
USER runner
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1732
closes #21781

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
