### PR TITLE
feat: Disable user invites on SSO systems

### DIFF
--- a/packages/cli/src/controllers/__tests__/invitation.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/invitation.controller.test.ts
@@ -6,15 +6,16 @@ import { AuthService } from '@/auth/auth.service';
 import { UserService } from '@/services/user.service';
 import { License } from '@/license';
 import { PasswordUtility } from '@/services/password.utility';
-import { User, UserRepository } from '@n8n/db';
+import type { User } from '@n8n/db';
+import { UserRepository } from '@n8n/db';
 import { Logger } from '@n8n/backend-common';
 import * as ssoHelpers from '@/sso.ee/sso-helpers';
 import { InvitationController } from '../invitation.controller';
 import { InviteUsersRequestDto } from '@n8n/api-types';
 import { mock } from 'jest-mock-extended';
 import { GLOBAL_OWNER_ROLE, GLOBAL_MEMBER_ROLE, GLOBAL_ADMIN_ROLE } from '@n8n/db';
-import { AuthenticatedRequest } from '@n8n/db';
-import { Response } from 'express';
+import type { AuthenticatedRequest } from '@n8n/db';
+import type { Response } from 'express';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { RESPONSE_ERROR_MESSAGES } from '@/constants';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
@@ -64,7 +65,7 @@ describe('InvitationController', () => {
 			const req = mock<AuthenticatedRequest>({ user });
 			const res = mock<Response>();
 
-			expect(invitationController.inviteUser(req, res, payload)).rejects.toThrow(
+			await expect(invitationController.inviteUser(req, res, payload)).rejects.toThrow(
 				new BadRequestError(
 					'SSO is enabled, so users are managed by the Identity Provider and cannot be added through invites',
 				),
@@ -100,7 +101,7 @@ describe('InvitationController', () => {
 			const req = mock<AuthenticatedRequest>({ user });
 			const res = mock<Response>();
 
-			expect(invitationController.inviteUser(req, res, payload)).rejects.toThrow(
+			await expect(invitationController.inviteUser(req, res, payload)).rejects.toThrow(
 				new ForbiddenError(RESPONSE_ERROR_MESSAGES.USERS_QUOTA_REACHED),
 			);
 		});
@@ -135,7 +136,7 @@ describe('InvitationController', () => {
 			const req = mock<AuthenticatedRequest>({ user });
 			const res = mock<Response>();
 
-			expect(invitationController.inviteUser(req, res, payload)).rejects.toThrow(
+			await expect(invitationController.inviteUser(req, res, payload)).rejects.toThrow(
 				new BadRequestError('You must set up your own account before inviting others'),
 			);
 		});
@@ -178,7 +179,7 @@ describe('InvitationController', () => {
 			const req = mock<AuthenticatedRequest>({ user });
 			const res = mock<Response>();
 
-			expect(invitationController.inviteUser(req, res, payload)).rejects.toThrow(
+			await expect(invitationController.inviteUser(req, res, payload)).rejects.toThrow(
 				new ForbiddenError(
 					'Cannot invite admin user without advanced permissions. Please upgrade to a license that includes this feature.',
 				),

--- a/packages/cli/src/controllers/__tests__/invitation.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/invitation.controller.test.ts
@@ -1,0 +1,251 @@
+import { EventService } from '@/events/event.service';
+import { mockInstance } from '@n8n/backend-test-utils';
+import { PostHogClient } from '@/posthog';
+import { ExternalHooks } from '@/external-hooks';
+import { AuthService } from '@/auth/auth.service';
+import { UserService } from '@/services/user.service';
+import { License } from '@/license';
+import { PasswordUtility } from '@/services/password.utility';
+import { User, UserRepository } from '@n8n/db';
+import { Logger } from '@n8n/backend-common';
+import * as ssoHelpers from '@/sso.ee/sso-helpers';
+import { InvitationController } from '../invitation.controller';
+import { InviteUsersRequestDto } from '@n8n/api-types';
+import { mock } from 'jest-mock-extended';
+import { GLOBAL_OWNER_ROLE, GLOBAL_MEMBER_ROLE, GLOBAL_ADMIN_ROLE } from '@n8n/db';
+import { AuthenticatedRequest } from '@n8n/db';
+import { Response } from 'express';
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { RESPONSE_ERROR_MESSAGES } from '@/constants';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import config from '@/config';
+
+describe('InvitationController', () => {
+	const logger: Logger = mockInstance(Logger);
+	const externalHooks: ExternalHooks = mockInstance(ExternalHooks);
+	const authService: AuthService = mockInstance(AuthService);
+	const userService: UserService = mockInstance(UserService);
+	const license: License = mockInstance(License);
+	const passwordUtility: PasswordUtility = mockInstance(PasswordUtility);
+	const userRepository: UserRepository = mockInstance(UserRepository);
+	const postHog: PostHogClient = mockInstance(PostHogClient);
+	const eventService: EventService = mockInstance(EventService);
+
+	describe('inviteUser', () => {
+		it('throws a BadRequestError if SSO is enabled', async () => {
+			jest.spyOn(ssoHelpers, 'isSsoCurrentAuthenticationMethod').mockReturnValue(true);
+
+			const invitationController = new InvitationController(
+				logger,
+				externalHooks,
+				authService,
+				userService,
+				license,
+				passwordUtility,
+				userRepository,
+				postHog,
+				eventService,
+			);
+
+			const user = mock<User>({
+				id: '123',
+				email: 'valid@email.com',
+				password: 'password',
+				authIdentities: [],
+				role: GLOBAL_OWNER_ROLE,
+				mfaEnabled: false,
+			});
+
+			const payload = new InviteUsersRequestDto({
+				email: 'valid@email.com',
+				role: 'global:member',
+			});
+
+			const req = mock<AuthenticatedRequest>({ user });
+			const res = mock<Response>();
+
+			expect(invitationController.inviteUser(req, res, payload)).rejects.toThrow(
+				new BadRequestError(
+					'SSO is enabled, so users are managed by the Identity Provider and cannot be added through invites',
+				),
+			);
+		});
+
+		it('throws a ForbiddenError if the user limit quota has been reached', async () => {
+			jest.spyOn(ssoHelpers, 'isSsoCurrentAuthenticationMethod').mockReturnValue(false);
+			jest.spyOn(license, 'isWithinUsersLimit').mockReturnValue(false);
+
+			const invitationController = new InvitationController(
+				logger,
+				externalHooks,
+				authService,
+				userService,
+				license,
+				passwordUtility,
+				userRepository,
+				postHog,
+				eventService,
+			);
+
+			const user = mock<User>({
+				id: '123',
+				email: 'valid@email.com',
+			});
+
+			const payload = new InviteUsersRequestDto({
+				email: 'valid@email.com',
+				role: 'global:member',
+			});
+
+			const req = mock<AuthenticatedRequest>({ user });
+			const res = mock<Response>();
+
+			expect(invitationController.inviteUser(req, res, payload)).rejects.toThrow(
+				new ForbiddenError(RESPONSE_ERROR_MESSAGES.USERS_QUOTA_REACHED),
+			);
+		});
+
+		it('throws a BadRequestError if the owner account is not set up', async () => {
+			jest.spyOn(ssoHelpers, 'isSsoCurrentAuthenticationMethod').mockReturnValue(false);
+			jest.spyOn(license, 'isWithinUsersLimit').mockReturnValue(true);
+			jest.spyOn(config, 'getEnv').mockReturnValue(false);
+
+			const invitationController = new InvitationController(
+				logger,
+				externalHooks,
+				authService,
+				userService,
+				license,
+				passwordUtility,
+				userRepository,
+				postHog,
+				eventService,
+			);
+
+			const user = mock<User>({
+				id: '123',
+				email: 'valid@email.com',
+			});
+
+			const payload = new InviteUsersRequestDto({
+				email: 'valid@email.com',
+				role: 'global:member',
+			});
+
+			const req = mock<AuthenticatedRequest>({ user });
+			const res = mock<Response>();
+
+			expect(invitationController.inviteUser(req, res, payload)).rejects.toThrow(
+				new BadRequestError('You must set up your own account before inviting others'),
+			);
+		});
+
+		it('throws a ForbiddenError if the user is an admin but advanced permissions is not licensed', async () => {
+			jest.spyOn(ssoHelpers, 'isSsoCurrentAuthenticationMethod').mockReturnValue(false);
+			jest.spyOn(license, 'isWithinUsersLimit').mockReturnValue(true);
+			jest.spyOn(config, 'getEnv').mockReturnValue(true);
+			jest.spyOn(license, 'isAdvancedPermissionsLicensed').mockReturnValue(false);
+
+			const invitationController = new InvitationController(
+				logger,
+				externalHooks,
+				authService,
+				userService,
+				license,
+				passwordUtility,
+				userRepository,
+				postHog,
+				eventService,
+			);
+
+			const user = mock<User>({
+				id: '123',
+				email: 'valid@email.com',
+				role: GLOBAL_ADMIN_ROLE,
+			});
+
+			const payload = new InviteUsersRequestDto(
+				{
+					email: 'valid@email.com',
+					role: 'global:admin',
+				},
+				{
+					email: 'valid@email.com',
+					role: 'global:admin',
+				},
+			);
+
+			const req = mock<AuthenticatedRequest>({ user });
+			const res = mock<Response>();
+
+			expect(invitationController.inviteUser(req, res, payload)).rejects.toThrow(
+				new ForbiddenError(
+					'Cannot invite admin user without advanced permissions. Please upgrade to a license that includes this feature.',
+				),
+			);
+		});
+
+		it('invites users successfully', async () => {
+			const inviteUsersResult = {
+				usersInvited: [
+					{
+						user: {
+							id: '123',
+							email: 'valid@email.com',
+							emailSent: false,
+							role: 'global:member',
+							inviteAcceptUrl: 'https://n8n.io/signup?inviterId=123&inviteeId=123',
+						},
+						error: '',
+					},
+				],
+				usersCreated: ['123'],
+			};
+			jest.spyOn(ssoHelpers, 'isSsoCurrentAuthenticationMethod').mockReturnValue(false);
+			jest.spyOn(license, 'isWithinUsersLimit').mockReturnValue(true);
+			jest.spyOn(config, 'getEnv').mockReturnValue(true);
+			jest.spyOn(license, 'isAdvancedPermissionsLicensed').mockReturnValue(true);
+			jest.spyOn(userService, 'inviteUsers').mockResolvedValue(inviteUsersResult);
+			const invitationController = new InvitationController(
+				logger,
+				externalHooks,
+				authService,
+				userService,
+				license,
+				passwordUtility,
+				userRepository,
+				postHog,
+				eventService,
+			);
+
+			const user = mock<User>({
+				id: '123',
+				email: 'valid@email.com',
+				role: GLOBAL_MEMBER_ROLE,
+			});
+
+			const payload = new InviteUsersRequestDto({
+				email: 'valid@email.com',
+				role: 'global:member',
+			});
+
+			const req = mock<AuthenticatedRequest>({ user });
+			const res = mock<Response>();
+
+			expect(await invitationController.inviteUser(req, res, payload)).toEqual(
+				inviteUsersResult.usersInvited,
+			);
+
+			expect(userService.inviteUsers).toHaveBeenCalledWith(user, [
+				{
+					email: 'valid@email.com',
+					role: 'global:member',
+				},
+			]);
+
+			expect(externalHooks.run).toHaveBeenCalledWith('user.invited', [
+				inviteUsersResult.usersCreated,
+			]);
+		});
+	});
+});

--- a/packages/cli/src/controllers/invitation.controller.ts
+++ b/packages/cli/src/controllers/invitation.controller.ts
@@ -17,7 +17,7 @@ import { PostHogClient } from '@/posthog';
 import { AuthlessRequest } from '@/requests';
 import { PasswordUtility } from '@/services/password.utility';
 import { UserService } from '@/services/user.service';
-import { isSamlLicensedAndEnabled } from '@/sso.ee/saml/saml-helpers';
+import { isSsoCurrentAuthenticationMethod } from '@/sso.ee/sso-helpers';
 
 @RestController('/invitations')
 export class InvitationController {
@@ -48,12 +48,12 @@ export class InvitationController {
 
 		const isWithinUsersLimit = this.license.isWithinUsersLimit();
 
-		if (isSamlLicensedAndEnabled()) {
+		if (isSsoCurrentAuthenticationMethod()) {
 			this.logger.debug(
-				'SAML is enabled, so users are managed by the Identity Provider and cannot be added through invites',
+				'SSO is enabled, so users are managed by the Identity Provider and cannot be added through invites',
 			);
 			throw new BadRequestError(
-				'SAML is enabled, so users are managed by the Identity Provider and cannot be added through invites',
+				'SSO is enabled, so users are managed by the Identity Provider and cannot be added through invites',
 			);
 		}
 

--- a/packages/cli/src/sso.ee/__tests__/sso-helpers.test.ts
+++ b/packages/cli/src/sso.ee/__tests__/sso-helpers.test.ts
@@ -4,7 +4,7 @@ import { mock } from 'jest-mock-extended';
 
 import config from '@/config';
 
-import { reloadAuthenticationMethod } from '../sso-helpers';
+import { isSsoCurrentAuthenticationMethod, reloadAuthenticationMethod } from '../sso-helpers';
 
 jest.mock('@/config');
 
@@ -90,6 +90,24 @@ describe('sso-helpers', () => {
 			await expect(reloadAuthenticationMethod()).rejects.toThrow('Database connection failed');
 
 			expect(mockConfig.set).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('isSsoCurrentAuthenticationMethod', () => {
+		it('should return true if the current authentication method is SAML, LDAP, or OIDC', () => {
+			config.set('userManagement.authenticationMethod', 'saml');
+			expect(isSsoCurrentAuthenticationMethod()).toBe(true);
+
+			config.set('userManagement.authenticationMethod', 'ldap');
+			expect(isSsoCurrentAuthenticationMethod()).toBe(true);
+
+			config.set('userManagement.authenticationMethod', 'oidc');
+			expect(isSsoCurrentAuthenticationMethod()).toBe(true);
+		});
+
+		it('should return false if the current authentication method is email', () => {
+			config.set('userManagement.authenticationMethod', 'email');
+			expect(isSsoCurrentAuthenticationMethod()).toBe(false);
 		});
 	});
 });

--- a/packages/cli/src/sso.ee/__tests__/sso-helpers.test.ts
+++ b/packages/cli/src/sso.ee/__tests__/sso-helpers.test.ts
@@ -95,18 +95,18 @@ describe('sso-helpers', () => {
 
 	describe('isSsoCurrentAuthenticationMethod', () => {
 		it('should return true if the current authentication method is SAML, LDAP, or OIDC', () => {
-			config.set('userManagement.authenticationMethod', 'saml');
+			jest.spyOn(config, 'getEnv').mockReturnValue('saml');
 			expect(isSsoCurrentAuthenticationMethod()).toBe(true);
 
-			config.set('userManagement.authenticationMethod', 'ldap');
+			jest.spyOn(config, 'getEnv').mockReturnValue('ldap');
 			expect(isSsoCurrentAuthenticationMethod()).toBe(true);
 
-			config.set('userManagement.authenticationMethod', 'oidc');
+			jest.spyOn(config, 'getEnv').mockReturnValue('oidc');
 			expect(isSsoCurrentAuthenticationMethod()).toBe(true);
 		});
 
 		it('should return false if the current authentication method is email', () => {
-			config.set('userManagement.authenticationMethod', 'email');
+			jest.spyOn(config, 'getEnv').mockReturnValue('email');
 			expect(isSsoCurrentAuthenticationMethod()).toBe(false);
 		});
 	});

--- a/packages/cli/src/sso.ee/sso-helpers.ts
+++ b/packages/cli/src/sso.ee/sso-helpers.ts
@@ -60,6 +60,14 @@ export function isOidcCurrentAuthenticationMethod(): boolean {
 	return getCurrentAuthenticationMethod() === 'oidc';
 }
 
+export function isSsoCurrentAuthenticationMethod(): boolean {
+	return (
+		isSamlCurrentAuthenticationMethod() ||
+		isLdapCurrentAuthenticationMethod() ||
+		isOidcCurrentAuthenticationMethod()
+	);
+}
+
 export function isEmailCurrentAuthenticationMethod(): boolean {
 	return getCurrentAuthenticationMethod() === 'email';
 }


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR expands the current logic that blocks invites on SAML systems, to include all SSO systems.

## Related Linear tickets, Github issues, and Community forum posts

PAY-4093

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Blocks user invitations when SSO (SAML/LDAP/OIDC) is the active authentication method and adds targeted tests and helper utilities.
> 
> - **Backend**:
>   - `InvitationController`: replace SAML-only guard with `isSsoCurrentAuthenticationMethod()`; unify error/log message to "SSO is enabled...".
>   - `sso-helpers`: add `isSsoCurrentAuthenticationMethod()` combining `saml`/`ldap`/`oidc` checks.
> - **Tests**:
>   - Add `invitation.controller.test.ts` covering SSO-blocking, users quota reached, owner not set, advanced permissions for admin, and successful invite flow.
>   - Extend `sso-helpers.test.ts` to validate `isSsoCurrentAuthenticationMethod()` behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35947c174bcd62604e192d3e98d36ea9a22c1ee6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->