### PR TITLE
fix(n8n Form Node): Allow undefined formatDate

### DIFF
--- a/packages/nodes-base/nodes/Form/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/utils.test.ts
@@ -1422,6 +1422,20 @@ describe('prepareFormReturnItem', () => {
 		expect(DateTime.fromFormat).toHaveBeenCalledWith('2023-04-01', 'yyyy-mm-dd');
 	});
 
+	it('should not format date fields when formatDate is undefined', async () => {
+		mockContext.getBodyData.mockReturnValue({
+			data: { 'field-0': '2023-04-01' },
+			files: {},
+		});
+
+		const formFields = [{ fieldLabel: 'Date Field', fieldType: 'date', formatDate: undefined }];
+		const result = await prepareFormReturnItem(mockContext, formFields, 'test');
+
+		expect(DateTime.fromFormat).not.toHaveBeenCalled();
+		expect(result.json['Date Field']).toBe('2023-04-01');
+		expect(DateTime.fromFormat).toHaveBeenCalledWith('2023-04-01', 'yyyy-mm-dd');
+	});
+
 	it('should handle multiselect fields', async () => {
 		mockContext.getBodyData.mockReturnValue({
 			data: { 'field-0': '["option1", "option2"]' },

--- a/packages/nodes-base/nodes/Form/utils/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils/utils.ts
@@ -335,8 +335,9 @@ export function addFormResponseDataToReturnItem(
 				value = value[0];
 			}
 		}
-		if (field.fieldType === 'date' && value && field.formatDate !== '') {
-			value = DateTime.fromFormat(String(value), 'yyyy-mm-dd').toFormat(field.formatDate as string);
+		if (field.fieldType === 'date' && value && field.formatDate) {
+			const datetime = DateTime.fromFormat(String(value), 'yyyy-mm-dd');
+			value = datetime.toFormat(field.formatDate as string);
 		}
 		if (field.fieldType === 'file' && field.multipleFiles && !Array.isArray(value)) {
 			value = [value];


### PR DESCRIPTION
## Summary

This PR fixes an issue when a date field was defined in JSON format in Form node without `formatDate` field
```
 {
    "fieldLabel": "Date",
    "fieldType": "date",
    "placeholder": "placeholder"
 }
```
<img width="644" height="716" alt="изображение" src="https://github.com/user-attachments/assets/6f2ff20b-812a-414c-a1a0-5b7a5afc1830" />



## Related Linear tickets, Github issues, and Community forum posts
closes #20464
https://linear.app/n8n/issue/NODE-3766/community-issue-n8n-hosted-plan-on-hostinger-form-fields


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
