### PR TITLE
fix(Merge Node): Show node icon in V1

### DIFF
--- a/packages/nodes-base/nodes/Merge/v1/MergeV1.node.ts
+++ b/packages/nodes-base/nodes/Merge/v1/MergeV1.node.ts
@@ -20,7 +20,6 @@ export class MergeV1 implements INodeType {
 	constructor(baseDescription: INodeTypeBaseDescription) {
 		this.description = {
 			...baseDescription,
-			icon: 'fa:code-branch',
 			version: 1,
 			defaults: {
 				name: 'Merge',


### PR DESCRIPTION
## Summary

Fix issues when in V1 the icon was not resolved correctly

<img width="657" height="356" alt="изображение" src="https://github.com/user-attachments/assets/fc459faf-4c41-4a75-bc40-12134d3fa324" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3863/bug-merge-node-showing-as-unknown

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
