### PR TITLE
fix(Google Cloud Firestore Node): Make the description for the Update Key for Upsert operation more clear (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/DocumentDescription.ts
+++ b/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/DocumentDescription.ts
@@ -558,7 +558,7 @@ export const documentFields: INodeProperties[] = [
 			},
 		},
 		default: '',
-		description: 'Must correspond to a document ID',
+		description: 'Name of the field in an input item that contains the document ID',
 		required: true,
 		placeholder: 'documentId',
 	},


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Update the description for `Update Key` parameter for `Upsert` operation to better explain what to put in there. A few people where confused and used it in the wrong way (see attached issue)

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-3664/community-issue-firestore-update-upsert-operation-creating-a-new
Closes #19042 

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies the `Update Key` parameter in the document upsert operation to specify it should reference the input field containing the document ID.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48836887597bcc595d76414992bd5484681948ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->