### PR TITLE
chore(core): Extend FunctionsBase for easy access to execution context

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/__tests__/hook-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/hook-context.test.ts
@@ -144,4 +144,10 @@ describe('HookContext', () => {
 			expect(description).toEqual<IWebhookDescription>(webhookDescription);
 		});
 	});
+
+	describe('getExecutionContext', () => {
+		it('should return undefined', () => {
+			expect(hookContext.getExecutionContext()).toBeUndefined();
+		});
+	});
 });

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/load-options-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/load-options-context.test.ts
@@ -99,4 +99,10 @@ describe('LoadOptionsContext', () => {
 			expect(parameter).toBe('fallback');
 		});
 	});
+
+	describe('getExecutionContext', () => {
+		it('should return undefined', () => {
+			expect(loadOptionsContext.getExecutionContext()).toBeUndefined();
+		});
+	});
 });

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/poll-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/poll-context.test.ts
@@ -93,4 +93,10 @@ describe('PollContext', () => {
 			expect(parameter).toBe('fallback');
 		});
 	});
+
+	describe('getExecutionContext', () => {
+		it('should return undefined', () => {
+			expect(pollContext.getExecutionContext()).toBeUndefined();
+		});
+	});
 });

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/shared-tests.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/shared-tests.ts
@@ -14,6 +14,7 @@ import type {
 	ExecuteWorkflowData,
 	RelatedExecution,
 	IExecuteWorkflowInfo,
+	IExecutionContext,
 } from 'n8n-workflow';
 import { ApplicationError, NodeHelpers, WAIT_INDEFINITELY } from 'n8n-workflow';
 
@@ -45,6 +46,71 @@ export const describeCommonTests = (
 	describe('getExecutionCancelSignal', () => {
 		it('should return the abort signal', () => {
 			expect(context.getExecutionCancelSignal()).toBe(abortSignal);
+		});
+	});
+
+	describe('getExecutionContext', () => {
+		it('should return execution context when runtimeData exists', () => {
+			const mockContext: IExecutionContext = {
+				version: 1,
+				establishedAt: Date.now(),
+				credentials: 'encrypted-credential-data',
+			};
+
+			runExecutionData.executionData = {
+				contextData: {},
+				runtimeData: mockContext,
+				nodeExecutionStack: [],
+				metadata: {},
+				waitingExecution: {},
+				waitingExecutionSource: null,
+			};
+
+			const result = context.getExecutionContext();
+
+			expect(result).toEqual(mockContext);
+			expect(result?.version).toBe(1);
+			expect(result?.establishedAt).toBeDefined();
+		});
+
+		it('should return undefined when executionData is not set', () => {
+			runExecutionData.executionData = undefined;
+
+			expect(context.getExecutionContext()).toBeUndefined();
+		});
+
+		it('should return undefined when runtimeData is not set', () => {
+			runExecutionData.executionData = {
+				contextData: {},
+				runtimeData: undefined,
+				nodeExecutionStack: [],
+				metadata: {},
+				waitingExecution: {},
+				waitingExecutionSource: null,
+			};
+
+			expect(context.getExecutionContext()).toBeUndefined();
+		});
+
+		it('should handle optional credentials field', () => {
+			const contextWithoutCredentials: IExecutionContext = {
+				version: 1,
+				establishedAt: Date.now(),
+			};
+
+			runExecutionData.executionData = {
+				contextData: {},
+				runtimeData: contextWithoutCredentials,
+				nodeExecutionStack: [],
+				metadata: {},
+				waitingExecution: {},
+				waitingExecutionSource: null,
+			};
+
+			const result = context.getExecutionContext();
+
+			expect(result).toEqual(contextWithoutCredentials);
+			expect(result?.credentials).toBeUndefined();
 		});
 	});
 

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/trigger-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/trigger-context.test.ts
@@ -93,4 +93,10 @@ describe('TriggerContext', () => {
 			expect(parameter).toBe('fallback');
 		});
 	});
+
+	describe('getExecutionContext', () => {
+		it('should return undefined', () => {
+			expect(triggerContext.getExecutionContext()).toBeUndefined();
+		});
+	});
 });

--- a/packages/core/src/execution-engine/node-execution-context/base-execute-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/base-execute-context.ts
@@ -55,6 +55,10 @@ export class BaseExecuteContext extends NodeExecutionContext {
 		super(workflow, node, additionalData, mode, runExecutionData, runIndex);
 	}
 
+	getExecutionContext() {
+		return this.runExecutionData.executionData?.runtimeData;
+	}
+
 	getExecutionCancelSignal() {
 		return this.abortSignal;
 	}

--- a/packages/core/src/execution-engine/node-execution-context/hook-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/hook-context.ts
@@ -31,6 +31,10 @@ export class HookContext extends NodeExecutionContext implements IHookFunctions 
 		this.helpers = getRequestHelperFunctions(workflow, node, additionalData);
 	}
 
+	getExecutionContext() {
+		return undefined;
+	}
+
 	getActivationMode() {
 		return this.activation;
 	}

--- a/packages/core/src/execution-engine/node-execution-context/load-options-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/load-options-context.ts
@@ -33,6 +33,10 @@ export class LoadOptionsContext extends NodeExecutionContext implements ILoadOpt
 		};
 	}
 
+	getExecutionContext() {
+		return undefined;
+	}
+
 	async getCredentials<T extends object = ICredentialDataDecryptedObject>(type: string) {
 		return await this._getCredentials<T>(type);
 	}

--- a/packages/core/src/execution-engine/node-execution-context/node-execution-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/node-execution-context.ts
@@ -67,6 +67,10 @@ export abstract class NodeExecutionContext implements Omit<FunctionsBase, 'getCr
 		return Container.get(Logger);
 	}
 
+	getExecutionContext() {
+		return this.runExecutionData?.executionData?.runtimeData;
+	}
+
 	getExecutionId() {
 		return this.additionalData.executionId!;
 	}

--- a/packages/core/src/execution-engine/node-execution-context/poll-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/poll-context.ts
@@ -46,6 +46,10 @@ export class PollContext extends NodeExecutionContext implements IPollFunctions 
 		};
 	}
 
+	getExecutionContext() {
+		return undefined;
+	}
+
 	getActivationMode() {
 		return this.activation;
 	}

--- a/packages/core/src/execution-engine/node-execution-context/trigger-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/trigger-context.ts
@@ -48,6 +48,10 @@ export class TriggerContext extends NodeExecutionContext implements ITriggerFunc
 		};
 	}
 
+	getExecutionContext() {
+		return undefined;
+	}
+
 	getActivationMode() {
 		return this.activation;
 	}

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -927,6 +927,8 @@ export interface FunctionsBase {
 	getActivationMode?: () => WorkflowActivateMode;
 	getChatTrigger: () => INode | null;
 
+	getExecutionContext: () => IExecutionContext | undefined;
+
 	/** @deprecated */
 	prepareOutputData(outputData: INodeExecutionData[]): Promise<INodeExecutionData[][]>;
 }


### PR DESCRIPTION
## Summary

Allow easy access to the execution context by extending the FunctionBase interface.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-4080/research-and-implement-node-access-to-context

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
