### PR TITLE
feat: Block invite acceptance on SSO systems

### DIFF
--- a/packages/cli/src/controllers/__tests__/auth.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/auth.controller.test.ts
@@ -21,7 +21,7 @@ import { AuthController } from '../auth.controller';
 import { AuthError } from '@/errors/response-errors/auth.error';
 import { v4 as uuidv4 } from 'uuid';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
-import { AuthlessRequest } from '@/requests';
+import type { AuthlessRequest } from '@/requests';
 import * as ssoHelpers from '@/sso.ee/sso-helpers';
 import { ResolveSignupTokenQueryDto } from '@n8n/api-types';
 import { RESPONSE_ERROR_MESSAGES } from '@/constants';
@@ -320,11 +320,11 @@ describe('AuthController', () => {
 			jest.spyOn(license, 'isWithinUsersLimit').mockReturnValue(true);
 			jest.spyOn(userRepository, 'findManyByIds').mockResolvedValue([
 				mock<User>({
-					id: id,
+					id,
 					password: 'Password123!',
 				}),
 				mock<User>({
-					id: id,
+					id,
 					password: null,
 				}),
 			]);
@@ -362,12 +362,12 @@ describe('AuthController', () => {
 			jest.spyOn(license, 'isWithinUsersLimit').mockReturnValue(true);
 			jest.spyOn(userRepository, 'findManyByIds').mockResolvedValue([
 				mock<User>({
-					id: id,
+					id,
 					email: undefined,
 					password: null,
 				}),
 				mock<User>({
-					id: id,
+					id,
 					email: undefined,
 					password: null,
 				}),
@@ -406,14 +406,14 @@ describe('AuthController', () => {
 			jest.spyOn(license, 'isWithinUsersLimit').mockReturnValue(true);
 			jest.spyOn(userRepository, 'findManyByIds').mockResolvedValue([
 				mock<User>({
-					id: id,
+					id,
 					email: 'inviter@example.com',
 					firstName: 'Inviter first name',
 					lastName: 'Inviter last name',
 					password: null,
 				}),
 				mock<User>({
-					id: id,
+					id,
 					email: 'invitee@example.com',
 					firstName: 'Invitee first name',
 					lastName: 'Invitee last name',

--- a/packages/cli/src/controllers/__tests__/auth.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/auth.controller.test.ts
@@ -19,6 +19,13 @@ import { UserService } from '@/services/user.service';
 
 import { AuthController } from '../auth.controller';
 import { AuthError } from '@/errors/response-errors/auth.error';
+import { v4 as uuidv4 } from 'uuid';
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { AuthlessRequest } from '@/requests';
+import * as ssoHelpers from '@/sso.ee/sso-helpers';
+import { ResolveSignupTokenQueryDto } from '@n8n/api-types';
+import { RESPONSE_ERROR_MESSAGES } from '@/constants';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 
 jest.mock('@/auth');
 
@@ -175,6 +182,251 @@ describe('AuthController', () => {
 				body.password,
 			);
 			expect(authService.issueCookie).toHaveBeenCalledWith(res, member, false, '1');
+		});
+	});
+
+	describe('resolveSignupToken', () => {
+		const logger: Logger = mockInstance(Logger);
+		const mfaService: MfaService = mockInstance(MfaService);
+		const authService: AuthService = mockInstance(AuthService);
+		const userService: UserService = mockInstance(UserService);
+		const license: License = mockInstance(License);
+		const userRepository: UserRepository = mockInstance(UserRepository);
+		const postHog: PostHogClient = mockInstance(PostHogClient);
+		const eventService: EventService = mockInstance(EventService);
+
+		it('throws a BadRequestError if SSO is enabled', async () => {
+			jest.spyOn(ssoHelpers, 'isSsoCurrentAuthenticationMethod').mockReturnValue(true);
+			const id = uuidv4();
+
+			const authController = new AuthController(
+				logger,
+				authService,
+				mfaService,
+				userService,
+				license,
+				userRepository,
+				eventService,
+				postHog,
+			);
+
+			const payload = new ResolveSignupTokenQueryDto({
+				inviterId: id,
+				inviteeId: id,
+			});
+
+			const req = mock<AuthlessRequest>({
+				body: payload,
+			});
+			const res = mock<Response>();
+
+			await expect(authController.resolveSignupToken(req, res, payload)).rejects.toThrow(
+				new BadRequestError(
+					'Invite links are not supported on this system, please use single sign on instead.',
+				),
+			);
+		});
+
+		it('throws a ForbiddenError if the users quota is reached', async () => {
+			jest.spyOn(ssoHelpers, 'isSsoCurrentAuthenticationMethod').mockReturnValue(false);
+			const id = uuidv4();
+
+			const authController = new AuthController(
+				logger,
+				authService,
+				mfaService,
+				userService,
+				license,
+				userRepository,
+				eventService,
+				postHog,
+			);
+
+			const payload = new ResolveSignupTokenQueryDto({
+				inviterId: id,
+				inviteeId: id,
+			});
+
+			const req = mock<AuthlessRequest>({
+				body: payload,
+			});
+			const res = mock<Response>();
+
+			jest.spyOn(license, 'isWithinUsersLimit').mockReturnValue(false);
+
+			await expect(authController.resolveSignupToken(req, res, payload)).rejects.toThrow(
+				new ForbiddenError(RESPONSE_ERROR_MESSAGES.USERS_QUOTA_REACHED),
+			);
+		});
+
+		it('throws a BadRequestError if the users are not found', async () => {
+			jest.spyOn(ssoHelpers, 'isSsoCurrentAuthenticationMethod').mockReturnValue(false);
+			const id = uuidv4();
+
+			const authController = new AuthController(
+				logger,
+				authService,
+				mfaService,
+				userService,
+				license,
+				userRepository,
+				eventService,
+				postHog,
+			);
+
+			const payload = new ResolveSignupTokenQueryDto({
+				inviterId: id,
+				inviteeId: id,
+			});
+
+			const req = mock<AuthlessRequest>({
+				body: payload,
+			});
+			const res = mock<Response>();
+
+			jest.spyOn(license, 'isWithinUsersLimit').mockReturnValue(true);
+			jest.spyOn(userRepository, 'findManyByIds').mockResolvedValue([]);
+
+			await expect(authController.resolveSignupToken(req, res, payload)).rejects.toThrow(
+				new BadRequestError('Invalid invite URL'),
+			);
+		});
+
+		it('throws a BadRequestError if the invitee already has a password', async () => {
+			jest.spyOn(ssoHelpers, 'isSsoCurrentAuthenticationMethod').mockReturnValue(false);
+			const id = uuidv4();
+
+			const authController = new AuthController(
+				logger,
+				authService,
+				mfaService,
+				userService,
+				license,
+				userRepository,
+				eventService,
+				postHog,
+			);
+
+			const payload = new ResolveSignupTokenQueryDto({
+				inviterId: id,
+				inviteeId: id,
+			});
+
+			const req = mock<AuthlessRequest>({
+				body: payload,
+			});
+			const res = mock<Response>();
+
+			jest.spyOn(license, 'isWithinUsersLimit').mockReturnValue(true);
+			jest.spyOn(userRepository, 'findManyByIds').mockResolvedValue([
+				mock<User>({
+					id: id,
+					password: 'Password123!',
+				}),
+				mock<User>({
+					id: id,
+					password: null,
+				}),
+			]);
+
+			await expect(authController.resolveSignupToken(req, res, payload)).rejects.toThrow(
+				new BadRequestError('The invitation was likely either deleted or already claimed'),
+			);
+		});
+
+		it('throws a BadRequestError if the inviter does not exist or is not set up', async () => {
+			jest.spyOn(ssoHelpers, 'isSsoCurrentAuthenticationMethod').mockReturnValue(false);
+			const id = uuidv4();
+
+			const authController = new AuthController(
+				logger,
+				authService,
+				mfaService,
+				userService,
+				license,
+				userRepository,
+				eventService,
+				postHog,
+			);
+
+			const payload = new ResolveSignupTokenQueryDto({
+				inviterId: id,
+				inviteeId: id,
+			});
+
+			const req = mock<AuthlessRequest>({
+				body: payload,
+			});
+			const res = mock<Response>();
+
+			jest.spyOn(license, 'isWithinUsersLimit').mockReturnValue(true);
+			jest.spyOn(userRepository, 'findManyByIds').mockResolvedValue([
+				mock<User>({
+					id: id,
+					email: undefined,
+					password: null,
+				}),
+				mock<User>({
+					id: id,
+					email: undefined,
+					password: null,
+				}),
+			]);
+
+			await expect(authController.resolveSignupToken(req, res, payload)).rejects.toThrow(
+				new BadRequestError('Invalid request'),
+			);
+		});
+
+		it('returns the inviter if the invitation is valid', async () => {
+			jest.spyOn(ssoHelpers, 'isSsoCurrentAuthenticationMethod').mockReturnValue(false);
+			const id = uuidv4();
+
+			const authController = new AuthController(
+				logger,
+				authService,
+				mfaService,
+				userService,
+				license,
+				userRepository,
+				eventService,
+				postHog,
+			);
+
+			const payload = new ResolveSignupTokenQueryDto({
+				inviterId: id,
+				inviteeId: id,
+			});
+
+			const req = mock<AuthlessRequest>({
+				body: payload,
+			});
+			const res = mock<Response>();
+
+			jest.spyOn(license, 'isWithinUsersLimit').mockReturnValue(true);
+			jest.spyOn(userRepository, 'findManyByIds').mockResolvedValue([
+				mock<User>({
+					id: id,
+					email: 'inviter@example.com',
+					firstName: 'Inviter first name',
+					lastName: 'Inviter last name',
+					password: null,
+				}),
+				mock<User>({
+					id: id,
+					email: 'invitee@example.com',
+					firstName: 'Invitee first name',
+					lastName: 'Invitee last name',
+					password: null,
+				}),
+			]);
+
+			await expect(authController.resolveSignupToken(req, res, payload)).resolves.toEqual({
+				inviter: {
+					firstName: 'Inviter first name',
+					lastName: 'Inviter last name',
+				},
+			});
 		});
 	});
 });

--- a/packages/cli/src/controllers/__tests__/invitation.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/invitation.controller.test.ts
@@ -20,7 +20,7 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { RESPONSE_ERROR_MESSAGES } from '@/constants';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import config from '@/config';
-import { AuthlessRequest } from '@/requests';
+import type { AuthlessRequest } from '@/requests';
 import { v4 as uuidv4 } from 'uuid';
 
 describe('InvitationController', () => {
@@ -325,7 +325,7 @@ describe('InvitationController', () => {
 			);
 
 			expect(userRepository.find).toHaveBeenCalledWith({
-				where: [{ id: id }, { id: '123' }],
+				where: [{ id }, { id: '123' }],
 				relations: ['role'],
 			});
 		});

--- a/packages/cli/src/controllers/__tests__/invitation.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/invitation.controller.test.ts
@@ -6,12 +6,12 @@ import { AuthService } from '@/auth/auth.service';
 import { UserService } from '@/services/user.service';
 import { License } from '@/license';
 import { PasswordUtility } from '@/services/password.utility';
-import type { User } from '@n8n/db';
+import type { User, PublicUser } from '@n8n/db';
 import { UserRepository } from '@n8n/db';
 import { Logger } from '@n8n/backend-common';
 import * as ssoHelpers from '@/sso.ee/sso-helpers';
 import { InvitationController } from '../invitation.controller';
-import { InviteUsersRequestDto } from '@n8n/api-types';
+import { AcceptInvitationRequestDto, InviteUsersRequestDto } from '@n8n/api-types';
 import { mock } from 'jest-mock-extended';
 import { GLOBAL_OWNER_ROLE, GLOBAL_MEMBER_ROLE, GLOBAL_ADMIN_ROLE } from '@n8n/db';
 import type { AuthenticatedRequest } from '@n8n/db';
@@ -20,6 +20,8 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { RESPONSE_ERROR_MESSAGES } from '@/constants';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import config from '@/config';
+import { AuthlessRequest } from '@/requests';
+import { v4 as uuidv4 } from 'uuid';
 
 describe('InvitationController', () => {
 	const logger: Logger = mockInstance(Logger);
@@ -247,6 +249,185 @@ describe('InvitationController', () => {
 			expect(externalHooks.run).toHaveBeenCalledWith('user.invited', [
 				inviteUsersResult.usersCreated,
 			]);
+		});
+	});
+
+	describe('acceptInvitation', () => {
+		it('throws a BadRequestError if SSO is enabled', async () => {
+			jest.spyOn(ssoHelpers, 'isSsoCurrentAuthenticationMethod').mockReturnValue(true);
+			const id = uuidv4();
+
+			const invitationController = new InvitationController(
+				logger,
+				externalHooks,
+				authService,
+				userService,
+				license,
+				passwordUtility,
+				userRepository,
+				postHog,
+				eventService,
+			);
+
+			const payload = new AcceptInvitationRequestDto({
+				inviterId: id,
+				firstName: 'John',
+				lastName: 'Doe',
+				password: 'Password123!',
+			});
+
+			const req = mock<AuthlessRequest<{ id: string }>>({
+				body: payload,
+				params: { id },
+			});
+			const res = mock<Response>();
+
+			await expect(invitationController.acceptInvitation(req, res, payload, '123')).rejects.toThrow(
+				new BadRequestError(
+					'Invite links are not supported on this system, please use single sign on instead.',
+				),
+			);
+		});
+
+		it('throws a BadRequestError if the inviter ID and invitee ID are not found in the database', async () => {
+			jest.spyOn(ssoHelpers, 'isSsoCurrentAuthenticationMethod').mockReturnValue(false);
+			const id = uuidv4();
+
+			const invitationController = new InvitationController(
+				logger,
+				externalHooks,
+				authService,
+				userService,
+				license,
+				passwordUtility,
+				userRepository,
+				postHog,
+				eventService,
+			);
+
+			const payload = new AcceptInvitationRequestDto({
+				inviterId: id,
+				firstName: 'John',
+				lastName: 'Doe',
+				password: 'Password123!',
+			});
+
+			const req = mock<AuthlessRequest<{ id: string }>>({
+				body: payload,
+				params: { id },
+			});
+			const res = mock<Response>();
+
+			jest.spyOn(userRepository, 'find').mockResolvedValue([]);
+
+			await expect(invitationController.acceptInvitation(req, res, payload, '123')).rejects.toThrow(
+				new BadRequestError('Invalid payload or URL'),
+			);
+
+			expect(userRepository.find).toHaveBeenCalledWith({
+				where: [{ id: id }, { id: '123' }],
+				relations: ['role'],
+			});
+		});
+
+		it('throws a BadRequestError if the invitee already has a password', async () => {
+			jest.spyOn(ssoHelpers, 'isSsoCurrentAuthenticationMethod').mockReturnValue(false);
+			const invitee = mock<User>({
+				id: '123',
+				email: 'valid@email.com',
+				password: 'Password123!',
+				role: GLOBAL_MEMBER_ROLE,
+			});
+			const inviter = mock<User>({
+				id: '124',
+				email: 'valid@email.com',
+				role: GLOBAL_OWNER_ROLE,
+			});
+			jest.spyOn(userRepository, 'find').mockResolvedValue([inviter, invitee]);
+			const id = uuidv4();
+
+			const invitationController = new InvitationController(
+				logger,
+				externalHooks,
+				authService,
+				userService,
+				license,
+				passwordUtility,
+				userRepository,
+				postHog,
+				eventService,
+			);
+
+			const payload = new AcceptInvitationRequestDto({
+				inviterId: id,
+				firstName: 'John',
+				lastName: 'Doe',
+				password: 'Password123!',
+			});
+
+			const req = mock<AuthlessRequest<{ id: string }>>({
+				body: payload,
+				params: { id },
+			});
+
+			const res = mock<Response>();
+
+			await expect(invitationController.acceptInvitation(req, res, payload, '123')).rejects.toThrow(
+				new BadRequestError('This invite has been accepted already'),
+			);
+		});
+
+		it('accepts the invitation successfully', async () => {
+			jest.spyOn(ssoHelpers, 'isSsoCurrentAuthenticationMethod').mockReturnValue(false);
+			const id = uuidv4();
+			const inviter = mock<User>({
+				id: '124',
+				email: 'valid@email.com',
+				role: GLOBAL_OWNER_ROLE,
+			});
+			const invitee = mock<User>({
+				id: '123',
+				email: 'valid@email.com',
+				password: null,
+				role: GLOBAL_MEMBER_ROLE,
+			});
+
+			jest.spyOn(userRepository, 'find').mockResolvedValue([inviter, invitee]);
+			jest.spyOn(passwordUtility, 'hash').mockResolvedValue('Password123!');
+			jest.spyOn(userRepository, 'save').mockResolvedValue(invitee);
+			jest.spyOn(authService, 'issueCookie').mockResolvedValue(invitee as never);
+			jest.spyOn(eventService, 'emit').mockResolvedValue(invitee as never);
+			jest.spyOn(userService, 'toPublic').mockResolvedValue(invitee as unknown as PublicUser);
+			jest.spyOn(externalHooks, 'run').mockResolvedValue(invitee as never);
+
+			const invitationController = new InvitationController(
+				logger,
+				externalHooks,
+				authService,
+				userService,
+				license,
+				passwordUtility,
+				userRepository,
+				postHog,
+				eventService,
+			);
+
+			const payload = new AcceptInvitationRequestDto({
+				inviterId: id,
+				firstName: 'John',
+				lastName: 'Doe',
+				password: 'Password123!',
+			});
+
+			const req = mock<AuthlessRequest<{ id: string }>>({
+				body: payload,
+				params: { id },
+			});
+			const res = mock<Response>();
+
+			expect(await invitationController.acceptInvitation(req, res, payload, '123')).toEqual(
+				invitee as unknown as PublicUser,
+			);
 		});
 	});
 });

--- a/packages/cli/src/controllers/auth.controller.ts
+++ b/packages/cli/src/controllers/auth.controller.ts
@@ -24,6 +24,7 @@ import {
 	isLdapCurrentAuthenticationMethod,
 	isOidcCurrentAuthenticationMethod,
 	isSamlCurrentAuthenticationMethod,
+	isSsoCurrentAuthenticationMethod,
 } from '@/sso.ee/sso-helpers';
 
 @RestController()
@@ -139,6 +140,15 @@ export class AuthController {
 		_res: Response,
 		@Query payload: ResolveSignupTokenQueryDto,
 	) {
+		if (isSsoCurrentAuthenticationMethod()) {
+			this.logger.debug(
+				'Invite links are not supported on this system, please use single sign on instead.',
+			);
+			throw new BadRequestError(
+				'Invite links are not supported on this system, please use single sign on instead.',
+			);
+		}
+
 		const { inviterId, inviteeId } = payload;
 		const isWithinUsersLimit = this.license.isWithinUsersLimit();
 

--- a/packages/cli/src/controllers/invitation.controller.ts
+++ b/packages/cli/src/controllers/invitation.controller.ts
@@ -97,6 +97,15 @@ export class InvitationController {
 		@Body payload: AcceptInvitationRequestDto,
 		@Param('id') inviteeId: string,
 	) {
+		if (isSsoCurrentAuthenticationMethod()) {
+			this.logger.debug(
+				'Invite links are not supported on this system, please use single sign on instead.',
+			);
+			throw new BadRequestError(
+				'Invite links are not supported on this system, please use single sign on instead.',
+			);
+		}
+
 		const { inviterId, firstName, lastName, password } = payload;
 
 		const users = await this.userRepository.find({


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR blocks acceptance of invite links on SSO enabled systems, to close the loop where an invite can be sent before a system is configured for SSO, and accepted after a system has been configured for SSO.

## Related Linear tickets, Github issues, and Community forum posts

PAY-4094

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
