### PR TITLE
chore: Add nodes test coverage upload to workflow (no-changelog)

### DIFF
--- a/.github/workflows/units-tests-reusable.yml
+++ b/.github/workflows/units-tests-reusable.yml
@@ -52,6 +52,7 @@ jobs:
           name: backend-unit
 
       - name: Upload coverage to Codecov
+        if: env.COVERAGE_ENABLED == 'true'
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -116,7 +117,6 @@ jobs:
           name: nodes-unit
 
       - name: Upload coverage to Codecov
-        if: env.COVERAGE_ENABLED == 'true'
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -164,9 +164,9 @@ jobs:
   unit-test:
     name: Unit tests
     runs-on: ubuntu-latest
-    needs: [unit-test-backend, integration-test-backend, unit-test-frontend]
+    needs: [unit-test-backend, integration-test-backend, unit-test-nodes, unit-test-frontend]
     if: always()
     steps:
       - name: Fail if tests failed
-        if: needs.unit-test-backend.result == 'failure' || needs.integration-test-backend.result == 'failure' || needs.unit-test-frontend.result == 'failure'
+        if: needs.unit-test-backend.result == 'failure' || needs.integration-test-backend.result == 'failure' || needs.unit-test-nodes.result == 'failure' || needs.unit-test-frontend.result == 'failure'
         run: exit 1

--- a/.github/workflows/units-tests-reusable.yml
+++ b/.github/workflows/units-tests-reusable.yml
@@ -30,7 +30,7 @@ jobs:
     name: Backend Unit Tests
     runs-on: blacksmith-4vcpu-ubuntu-2204
     env:
-      COVERAGE_ENABLED: ${{ inputs.collectCoverage }}  # Coverage collected when true
+      COVERAGE_ENABLED: ${{ inputs.collectCoverage }} # Coverage collected when true
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -62,7 +62,7 @@ jobs:
     name: Backend Integration Tests
     runs-on: blacksmith-4vcpu-ubuntu-2204
     env:
-      COVERAGE_ENABLED: ${{ inputs.collectCoverage }}  # Coverage collected when true
+      COVERAGE_ENABLED: ${{ inputs.collectCoverage }} # Coverage collected when true
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -89,6 +89,39 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: backend-integration
           name: backend-integration
+
+  unit-test-nodes:
+    name: Nodes Unit Tests
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    env:
+      COVERAGE_ENABLED: ${{ inputs.collectCoverage }} # Coverage collected when true
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Build
+        uses: n8n-io/n8n/.github/actions/setup-nodejs-blacksmith@f5fbbbe0a28a886451c886cac6b49192a39b0eea # v1.104.1
+        with:
+          node-version: ${{ inputs.nodeVersion }}
+
+      - name: Test Nodes
+        run: pnpm --filter=n8n-nodes-base test
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@47f89e9acb64b76debcd5ea40642d25a4adced9f # v1.1.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          name: nodes-unit
+
+      - name: Upload coverage to Codecov
+        if: env.COVERAGE_ENABLED == 'true'
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: nodes-unit
+          name: nodes-unit
 
   unit-test-frontend:
     name: Frontend (${{ matrix.shard }}/2)

--- a/.github/workflows/units-tests-reusable.yml
+++ b/.github/workflows/units-tests-reusable.yml
@@ -85,6 +85,7 @@ jobs:
           name: backend-integration
 
       - name: Upload coverage to Codecov
+        if: env.COVERAGE_ENABLED == 'true'
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -117,6 +118,7 @@ jobs:
           name: nodes-unit
 
       - name: Upload coverage to Codecov
+        if: env.COVERAGE_ENABLED == 'true'
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -155,6 +157,7 @@ jobs:
           name: frontend-shard-${{ matrix.shard }}
 
       - name: Upload coverage to Codecov
+        if: env.COVERAGE_ENABLED == 'true'
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

This PR fixes an issue where nodes test coverage is not being uploaded to codecov

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `unit-test-nodes` job and makes Codecov uploads conditional on `COVERAGE_ENABLED`, updating workflow dependencies accordingly.
> 
> - **GitHub Actions workflow (`.github/workflows/units-tests-reusable.yml`)**:
>   - **Nodes tests**: Add `unit-test-nodes` job to run `n8n-nodes-base` unit tests and upload results/coverage (`nodes-unit`).
>   - **Codecov gating**: Gate all Codecov coverage uploads behind `if: env.COVERAGE_ENABLED == 'true'` for backend unit, backend integration, nodes unit, and frontend jobs.
>   - **Orchestration**: Update `unit-test` job `needs` and failure condition to include `unit-test-nodes`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff086dffe9187c9d80195a916db6ca52e14d086f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->