### PR TITLE
fix(editor): Reduce length of the component and update position

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNode.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNode.vue
@@ -452,7 +452,7 @@ onBeforeUnmount(() => {
 .canvasNodeToolbar {
 	position: absolute;
 	bottom: 100%;
-	left: 0;
+	right: 0;
 	z-index: 1;
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNode.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNode.vue
@@ -452,7 +452,7 @@ onBeforeUnmount(() => {
 .canvasNodeToolbar {
 	position: absolute;
 	bottom: 100%;
-	right: 0;
+	left: 0;
 	z-index: 1;
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNodeToolbar.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNodeToolbar.vue
@@ -194,7 +194,7 @@ function onFocusNode() {
 	padding-bottom: var(--spacing--xs);
 	display: flex;
 	justify-content: flex-end;
-	width: 100%;
+	width: fit-content;
 	cursor: default;
 
 	&.isExperimentalNdvActive {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNodeToolbar.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNodeToolbar.vue
@@ -194,8 +194,9 @@ function onFocusNode() {
 	padding-bottom: var(--spacing--xs);
 	display: flex;
 	justify-content: flex-end;
-	width: fit-content;
+	width: 100%;
 	cursor: default;
+	pointer-events: none;
 
 	&.isExperimentalNdvActive {
 		justify-content: space-between;
@@ -213,6 +214,7 @@ function onFocusNode() {
 	justify-content: center;
 	background-color: var(--canvas--color--background);
 	border-radius: var(--radius);
+	pointer-events: auto;
 
 	:global(.button) {
 		--button--color--text: var(--color--text--tint-1);


### PR DESCRIPTION
## Summary
https://www.loom.com/share/bc3f0a8c02ac451686fbbcd5e0728068
<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/ADO-4402/bug-sticky-note-hover-menu-blocks-canvas-actions
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make the toolbar container non-interactive while keeping toolbar buttons interactive to prevent it from blocking canvas actions.
> 
> - **Editor UI**
>   - **Canvas node toolbar styles** (`CanvasNodeToolbar.vue`):
>     - Add `pointer-events: none` to `canvasNodeToolbar` so the container doesn't intercept canvas interactions.
>     - Add `pointer-events: auto` to `canvasNodeToolbarItems` to keep toolbar buttons clickable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e934b0157d533f90556a832ff2ffc6bd958a4b88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->