### PR TITLE
fix(editor): Refresh insights weekly summary when entering any of the /home routes

### DIFF
--- a/packages/frontend/editor-ui/src/app/init.ts
+++ b/packages/frontend/editor-ui/src/app/init.ts
@@ -4,7 +4,6 @@ import { useExternalHooks } from '@/app/composables/useExternalHooks';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useToast } from '@/app/composables/useToast';
 import { EnterpriseEditionFeature, VIEWS } from '@/app/constants';
-import { useInsightsStore } from '@/features/execution/insights/insights.store';
 import type { UserManagementAuthenticationMethod } from '@/Interface';
 import {
 	registerModuleModals,
@@ -134,7 +133,6 @@ export async function initializeAuthenticatedFeatures(
 	const cloudPlanStore = useCloudPlanStore();
 	const projectsStore = useProjectsStore();
 	const rolesStore = useRolesStore();
-	const insightsStore = useInsightsStore();
 	const bannersStore = useBannersStore();
 	const versionsStore = useVersionsStore();
 	const dataTableStore = useDataTableStore();
@@ -189,10 +187,6 @@ export async function initializeAuthenticatedFeatures(
 			.catch((error) => {
 				console.error('Failed to fetch data table limits:', error);
 			});
-	}
-
-	if (insightsStore.isSummaryEnabled) {
-		void insightsStore.weeklySummary.execute();
 	}
 
 	// Don't check for new versions in preview mode or demo view (ex: executions iframe)

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/projects.routes.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/projects.routes.ts
@@ -2,6 +2,7 @@ import type { RouteLocationNormalized, RouteRecordRaw } from 'vue-router';
 import { VIEWS } from '@/app/constants';
 import { useProjectsStore } from './projects.store';
 import { getResourcePermissions } from '@n8n/permissions';
+import { useInsightsStore } from '@/features/execution/insights/insights.store';
 
 const MainSidebar = async () => await import('@/app/components/MainSidebar.vue');
 const WorkflowsView = async () => await import('@/app/views/WorkflowsView.vue');
@@ -178,6 +179,14 @@ export const projectsRoutes: RouteRecordRaw[] = [
 			middleware: ['authenticated'],
 		},
 		redirect: '/home/workflows',
+		beforeEnter: (_to, _from, next) => {
+			const insightsStore = useInsightsStore();
+			if (insightsStore.isSummaryEnabled) {
+				// refresh the weekly summary when entering the home route
+				void insightsStore.weeklySummary.execute();
+			}
+			next();
+		},
 		children: commonChildRoutes.map((route, idx) => ({
 			...route,
 			name: commonChildRouteExtensions.home[idx].name,

--- a/packages/frontend/editor-ui/src/features/core/dataTable/module.descriptor.ts
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/module.descriptor.ts
@@ -6,6 +6,7 @@ import {
 	DATA_TABLE_VIEW,
 	PROJECT_DATA_TABLES,
 } from '@/features/core/dataTable/constants';
+import { useInsightsStore } from '@/features/execution/insights/insights.store';
 
 const i18n = useI18n();
 
@@ -36,6 +37,14 @@ export const DataTableModule: FrontendModuleDescription = {
 			},
 			meta: {
 				middleware: ['authenticated', 'custom'],
+			},
+			beforeEnter: (_to, _from, next) => {
+				const insightsStore = useInsightsStore();
+				if (insightsStore.isSummaryEnabled) {
+					// refresh the weekly summary when entering the datatables route
+					void insightsStore.weeklySummary.execute();
+				}
+				next();
 			},
 		},
 		{


### PR DESCRIPTION

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Adds a beforeEnter hook on all the /home/... routes where the insights summary is displayed, to refresh the insights summary, so that whenever we enter one of this route, the insights banner numbers are up to date.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-4117/insights-overview-banner-doesnt-update-until-after-a-refresh


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
