### PR TITLE
feat: Support custom encryption keys for imports / exports

### DIFF
--- a/packages/cli/src/commands/export/__tests__/entities.test.ts
+++ b/packages/cli/src/commands/export/__tests__/entities.test.ts
@@ -55,6 +55,33 @@ describe('ExportEntitiesCommand', () => {
 				undefined,
 			);
 		});
+
+		it('should export entities with a custom encryption key', async () => {
+			const command = new ExportEntitiesCommand();
+			// @ts-expect-error Protected property
+			command.flags = {
+				outputDir: './exports',
+				keyFile: './key.txt',
+			};
+			// @ts-expect-error Protected property
+			command.logger = {
+				info: jest.fn(),
+				error: jest.fn(),
+			};
+			await command.run();
+
+			expect(mockExportService.exportEntities).toHaveBeenCalledWith(
+				'./exports',
+				new Set<string>([
+					'execution_annotation_tags',
+					'execution_annotations',
+					'execution_data',
+					'execution_entity',
+					'execution_metadata',
+				]),
+				'key.txt',
+			);
+		});
 	});
 
 	describe('catch', () => {

--- a/packages/cli/src/commands/export/__tests__/entities.test.ts
+++ b/packages/cli/src/commands/export/__tests__/entities.test.ts
@@ -31,6 +31,7 @@ describe('ExportEntitiesCommand', () => {
 					'execution_entity',
 					'execution_metadata',
 				]),
+				undefined,
 			);
 		});
 
@@ -48,7 +49,11 @@ describe('ExportEntitiesCommand', () => {
 			};
 			await command.run();
 
-			expect(mockExportService.exportEntities).toHaveBeenCalledWith('./exports', new Set<string>());
+			expect(mockExportService.exportEntities).toHaveBeenCalledWith(
+				'./exports',
+				new Set<string>(),
+				undefined,
+			);
 		});
 	});
 

--- a/packages/cli/src/commands/export/entities.ts
+++ b/packages/cli/src/commands/export/entities.ts
@@ -17,6 +17,10 @@ const flagsSchema = z.object({
 			'Include execution history data tables, these are excluded by default as they can be very large',
 		)
 		.default(false),
+	keyFile: z
+		.string()
+		.describe('Optional path to a file containing a custom encryption key')
+		.optional(),
 });
 
 @Command({
@@ -27,6 +31,8 @@ const flagsSchema = z.object({
 		'--outputDir=./exports',
 		'--outputDir=/path/to/backup',
 		'--includeExecutionHistoryDataTables=true',
+		'--keyFile=/path/to/key.txt',
+		'--outputDir=./exports --keyFile=/path/to/key.txt',
 	],
 	flagsSchema,
 })
@@ -44,7 +50,11 @@ export class ExportEntitiesCommand extends BaseCommand<z.infer<typeof flagsSchem
 			excludedDataTables.add('execution_metadata');
 		}
 
-		await Container.get(ExportService).exportEntities(outputDir, excludedDataTables);
+		await Container.get(ExportService).exportEntities(
+			outputDir,
+			excludedDataTables,
+			this.flags.keyFile,
+		);
 	}
 
 	catch(error: Error) {

--- a/packages/cli/src/commands/export/entities.ts
+++ b/packages/cli/src/commands/export/entities.ts
@@ -11,7 +11,7 @@ const flagsSchema = z.object({
 		.string()
 		.describe('Output directory path')
 		.default(safeJoinPath(__dirname, './outputs')),
-	includeExecutionHistoryDataTables: z
+	includeExecutionHistoryDataTables: z.coerce
 		.boolean()
 		.describe(
 			'Include execution history data tables, these are excluded by default as they can be very large',

--- a/packages/cli/src/commands/export/entities.ts
+++ b/packages/cli/src/commands/export/entities.ts
@@ -39,8 +39,8 @@ const flagsSchema = z.object({
 export class ExportEntitiesCommand extends BaseCommand<z.infer<typeof flagsSchema>> {
 	async run() {
 		const outputDir = this.flags.outputDir;
-
 		const excludedDataTables = new Set<string>();
+		const keyFilePath = this.flags.keyFile ? safeJoinPath(this.flags.keyFile) : undefined;
 
 		if (!this.flags.includeExecutionHistoryDataTables) {
 			excludedDataTables.add('execution_annotation_tags');
@@ -50,11 +50,7 @@ export class ExportEntitiesCommand extends BaseCommand<z.infer<typeof flagsSchem
 			excludedDataTables.add('execution_metadata');
 		}
 
-		await Container.get(ExportService).exportEntities(
-			outputDir,
-			excludedDataTables,
-			this.flags.keyFile,
-		);
+		await Container.get(ExportService).exportEntities(outputDir, excludedDataTables, keyFilePath);
 	}
 
 	catch(error: Error) {

--- a/packages/cli/src/commands/import/__tests__/entities.test.ts
+++ b/packages/cli/src/commands/import/__tests__/entities.test.ts
@@ -79,6 +79,26 @@ describe('ImportEntitiesCommand', () => {
 			expect(mockImportService.importEntities).toHaveBeenCalledWith('./outputs', true, undefined);
 		});
 
+		it('should import entities with a custom encryption key', async () => {
+			const command = new ImportEntitiesCommand();
+			// @ts-expect-error Protected property
+			command.flags = {
+				inputDir: './outputs',
+				truncateTables: false,
+				keyFile: './key.txt',
+			};
+
+			// @ts-expect-error Protected property
+			command.logger = {
+				info: jest.fn(),
+				error: jest.fn(),
+			};
+
+			await command.run();
+
+			expect(mockImportService.importEntities).toHaveBeenCalledWith('./outputs', false, 'key.txt');
+		});
+
 		it('should handle service errors gracefully', async () => {
 			const command = new ImportEntitiesCommand();
 			// @ts-expect-error Protected property

--- a/packages/cli/src/commands/import/__tests__/entities.test.ts
+++ b/packages/cli/src/commands/import/__tests__/entities.test.ts
@@ -31,7 +31,7 @@ describe('ImportEntitiesCommand', () => {
 			await command.run();
 
 			// Verify service call with transaction-based approach
-			expect(mockImportService.importEntities).toHaveBeenCalledWith('./outputs', false);
+			expect(mockImportService.importEntities).toHaveBeenCalledWith('./outputs', false, undefined);
 		});
 
 		it('should import entities with custom input directory', async () => {
@@ -51,7 +51,11 @@ describe('ImportEntitiesCommand', () => {
 
 			await command.run();
 
-			expect(mockImportService.importEntities).toHaveBeenCalledWith('/custom/path', false);
+			expect(mockImportService.importEntities).toHaveBeenCalledWith(
+				'/custom/path',
+				false,
+				undefined,
+			);
 		});
 
 		it('should truncate tables when truncateTables flag is true', async () => {
@@ -72,7 +76,7 @@ describe('ImportEntitiesCommand', () => {
 			await command.run();
 
 			// Verify service call with truncation enabled
-			expect(mockImportService.importEntities).toHaveBeenCalledWith('./outputs', true);
+			expect(mockImportService.importEntities).toHaveBeenCalledWith('./outputs', true, undefined);
 		});
 
 		it('should handle service errors gracefully', async () => {
@@ -93,7 +97,7 @@ describe('ImportEntitiesCommand', () => {
 			await expect(command.run()).rejects.toThrow('Database connection failed');
 
 			// Verify service was called
-			expect(mockImportService.importEntities).toHaveBeenCalledWith('./outputs', false);
+			expect(mockImportService.importEntities).toHaveBeenCalledWith('./outputs', false, undefined);
 		});
 
 		it('should handle import errors with transactions', async () => {
@@ -114,7 +118,7 @@ describe('ImportEntitiesCommand', () => {
 			await expect(command.run()).rejects.toThrow('Transaction failed');
 
 			// Verify service was called with truncation enabled
-			expect(mockImportService.importEntities).toHaveBeenCalledWith('./outputs', true);
+			expect(mockImportService.importEntities).toHaveBeenCalledWith('./outputs', true, undefined);
 		});
 	});
 

--- a/packages/cli/src/commands/import/entities.ts
+++ b/packages/cli/src/commands/import/entities.ts
@@ -4,6 +4,7 @@ import { Container } from '@n8n/di';
 
 import { BaseCommand } from '../base-command';
 import { ImportService } from '../../services/import.service';
+import { safeJoinPath } from '@n8n/backend-common';
 
 const flagsSchema = z.object({
 	inputDir: z
@@ -35,13 +36,14 @@ export class ImportEntitiesCommand extends BaseCommand<z.infer<typeof flagsSchem
 	async run() {
 		const inputDir = this.flags.inputDir;
 		const truncateTables = this.flags.truncateTables;
+		const keyFilePath = this.flags.keyFile ? safeJoinPath(this.flags.keyFile) : undefined;
 
 		this.logger.info('\n⚠️⚠️ This feature is currently under development. ⚠️⚠️');
 		this.logger.info('\n🚀 Starting entity import...');
 		this.logger.info(`📁 Input directory: ${inputDir}`);
 		this.logger.info(`🗑️  Truncate tables: ${truncateTables}`);
 
-		await Container.get(ImportService).importEntities(inputDir, truncateTables, this.flags.keyFile);
+		await Container.get(ImportService).importEntities(inputDir, truncateTables, keyFilePath);
 	}
 
 	catch(error: Error) {

--- a/packages/cli/src/commands/import/entities.ts
+++ b/packages/cli/src/commands/import/entities.ts
@@ -11,6 +11,10 @@ const flagsSchema = z.object({
 		.describe('Input directory that holds output files for import')
 		.default('./outputs'),
 	truncateTables: z.boolean().describe('Truncate tables before import').default(false),
+	keyFile: z
+		.string()
+		.describe('Optional path to a file containing a custom encryption key')
+		.optional(),
 });
 
 @Command({
@@ -22,6 +26,8 @@ const flagsSchema = z.object({
 		'--inputDir=/path/to/backup',
 		'--truncateTables',
 		'--inputDir=./exports --truncateTables',
+		'--keyFile=/path/to/key.txt',
+		'--inputDir=./exports --keyFile=/path/to/key.txt',
 	],
 	flagsSchema,
 })
@@ -35,7 +41,7 @@ export class ImportEntitiesCommand extends BaseCommand<z.infer<typeof flagsSchem
 		this.logger.info(`📁 Input directory: ${inputDir}`);
 		this.logger.info(`🗑️  Truncate tables: ${truncateTables}`);
 
-		await Container.get(ImportService).importEntities(inputDir, truncateTables);
+		await Container.get(ImportService).importEntities(inputDir, truncateTables, this.flags.keyFile);
 	}
 
 	catch(error: Error) {

--- a/packages/cli/src/commands/import/entities.ts
+++ b/packages/cli/src/commands/import/entities.ts
@@ -11,7 +11,7 @@ const flagsSchema = z.object({
 		.string()
 		.describe('Input directory that holds output files for import')
 		.default('./outputs'),
-	truncateTables: z.boolean().describe('Truncate tables before import').default(false),
+	truncateTables: z.coerce.boolean().describe('Truncate tables before import').default(false),
 	keyFile: z
 		.string()
 		.describe('Optional path to a file containing a custom encryption key')

--- a/packages/cli/src/services/__tests__/import.service.test.ts
+++ b/packages/cli/src/services/__tests__/import.service.test.ts
@@ -351,8 +351,8 @@ describe('ImportService', () => {
 				{ id: 1, name: 'Test' },
 				{ id: 2, name: 'Test2' },
 			]);
-			expect(mockCipher.decrypt).toHaveBeenCalledWith('{"id":1,"name":"Test"}');
-			expect(mockCipher.decrypt).toHaveBeenCalledWith('{"id":2,"name":"Test2"}');
+			expect(mockCipher.decrypt).toHaveBeenCalledWith('{"id":1,"name":"Test"}', undefined);
+			expect(mockCipher.decrypt).toHaveBeenCalledWith('{"id":2,"name":"Test2"}', undefined);
 		});
 
 		it('should handle empty lines in JSONL file', async () => {

--- a/packages/cli/src/services/__tests__/import.service.test.ts
+++ b/packages/cli/src/services/__tests__/import.service.test.ts
@@ -489,6 +489,38 @@ describe('ImportService', () => {
 			expect(readFile).toHaveBeenCalledWith('/test/input/user.jsonl', 'utf8');
 			expect(mockEntityManager.insert).not.toHaveBeenCalled();
 		});
+
+		it('should import entities with a custom encryption key', async () => {
+			const importMetadata = {
+				entityFiles: {
+					user: ['/test/input/user.jsonl'],
+				},
+				tableNames: ['user'],
+			};
+
+			mockDataSource.driver.escapeQueryWithParameters = jest
+				.fn()
+				.mockReturnValue(['INSERT COMMAND', { data: 'data' }]);
+
+			const mockEntities = [{ id: 1, name: 'Test User' }];
+			const mockContent = JSON.stringify(mockEntities[0]);
+			jest.mocked(readFile).mockResolvedValue(mockContent);
+
+			await importService.importEntitiesFromFiles(
+				'/test/input',
+				mockEntityManager,
+				Object.keys(importMetadata.entityFiles),
+				importMetadata.entityFiles,
+				'custom-encryption-key',
+			);
+
+			expect(mockCipher.decrypt).toHaveBeenCalledWith(
+				'{"id":1,"name":"Test User"}',
+				'custom-encryption-key',
+			);
+			expect(readFile).toHaveBeenCalledWith('/test/input/user.jsonl', 'utf8');
+			expect(mockEntityManager.query).toHaveBeenCalledWith('INSERT COMMAND', { data: 'data' });
+		});
 	});
 
 	describe('disableForeignKeyConstraints', () => {

--- a/packages/core/src/encryption/__tests__/cipher.test.ts
+++ b/packages/core/src/encryption/__tests__/cipher.test.ts
@@ -37,10 +37,12 @@ describe('Cipher', () => {
 
 	describe('getKeyAndIv', () => {
 		it('should generate a key and iv using instance settings encryption key', () => {
+			const salt = Buffer.from('test-salt');
 			mockInstance(InstanceSettings, { encryptionKey: 'settings-encryption-key' });
+			// Clear the cached Cipher instance to get a new one with the new mock
+			Container.set(Cipher, new Cipher(Container.get(InstanceSettings)));
 			const testCipher = Container.get(Cipher);
 			const bufferFromSpy = jest.spyOn(Buffer, 'from');
-			const salt = Buffer.from('test-salt');
 			// @ts-expect-error - getKeyAndIv is private
 			const [key, iv] = testCipher.getKeyAndIv(salt);
 			expect(key).toBeInstanceOf(Buffer);
@@ -50,10 +52,12 @@ describe('Cipher', () => {
 		});
 
 		it('should generate a key and iv using custom encryption key', () => {
+			const salt = Buffer.from('test-salt');
 			mockInstance(InstanceSettings, { encryptionKey: 'settings-encryption-key' });
+			// Clear the cached Cipher instance to get a new one with the new mock
+			Container.set(Cipher, new Cipher(Container.get(InstanceSettings)));
 			const testCipher = Container.get(Cipher);
 			const bufferFromSpy = jest.spyOn(Buffer, 'from');
-			const salt = Buffer.from('test-salt');
 			// @ts-expect-error - getKeyAndIv is private
 			const [key, iv] = testCipher.getKeyAndIv(salt, 'custom-encryption-key');
 			expect(key).toBeInstanceOf(Buffer);

--- a/packages/core/src/encryption/__tests__/cipher.test.ts
+++ b/packages/core/src/encryption/__tests__/cipher.test.ts
@@ -34,4 +34,25 @@ describe('Cipher', () => {
 			expect(decrypted).toEqual('');
 		});
 	});
+
+	describe('getKeyAndIv', () => {
+		it('should generate a key and iv using instance settings encryption key', () => {
+			mockInstance(InstanceSettings, { encryptionKey: 'settings-encryption-key' });
+			// @ts-expect-error - getKeyAndIv is private
+			const [key, iv] = cipher.getKeyAndIv(Buffer.from('test-salt'));
+			expect(key).toBeInstanceOf(Buffer);
+			expect(iv).toBeInstanceOf(Buffer);
+			expect(jest.spyOn(Buffer, 'from')).toHaveBeenCalledWith('settings-encryption-key', 'binary');
+		});
+
+		it('should generate a key and iv using custom encryption key', () => {
+			mockInstance(InstanceSettings, { encryptionKey: 'custom-encryption-key' });
+			// @ts-expect-error - getKeyAndIv is private
+			const [key, iv] = cipher.getKeyAndIv(Buffer.from('test-salt'), 'custom-encryption-key');
+			expect(key).toBeInstanceOf(Buffer);
+			expect(iv).toBeInstanceOf(Buffer);
+
+			expect(jest.spyOn(Buffer, 'from')).toHaveBeenCalledWith('custom-encryption-key', 'binary');
+		});
+	});
 });

--- a/packages/core/src/encryption/__tests__/cipher.test.ts
+++ b/packages/core/src/encryption/__tests__/cipher.test.ts
@@ -38,21 +38,28 @@ describe('Cipher', () => {
 	describe('getKeyAndIv', () => {
 		it('should generate a key and iv using instance settings encryption key', () => {
 			mockInstance(InstanceSettings, { encryptionKey: 'settings-encryption-key' });
+			const testCipher = Container.get(Cipher);
+			const bufferFromSpy = jest.spyOn(Buffer, 'from');
+			const salt = Buffer.from('test-salt');
 			// @ts-expect-error - getKeyAndIv is private
-			const [key, iv] = cipher.getKeyAndIv(Buffer.from('test-salt'));
+			const [key, iv] = testCipher.getKeyAndIv(salt);
 			expect(key).toBeInstanceOf(Buffer);
 			expect(iv).toBeInstanceOf(Buffer);
-			expect(jest.spyOn(Buffer, 'from')).toHaveBeenCalledWith('settings-encryption-key', 'binary');
+			expect(bufferFromSpy).toHaveBeenCalledWith('settings-encryption-key', 'binary');
+			bufferFromSpy.mockRestore();
 		});
 
 		it('should generate a key and iv using custom encryption key', () => {
-			mockInstance(InstanceSettings, { encryptionKey: 'custom-encryption-key' });
+			mockInstance(InstanceSettings, { encryptionKey: 'settings-encryption-key' });
+			const testCipher = Container.get(Cipher);
+			const bufferFromSpy = jest.spyOn(Buffer, 'from');
+			const salt = Buffer.from('test-salt');
 			// @ts-expect-error - getKeyAndIv is private
-			const [key, iv] = cipher.getKeyAndIv(Buffer.from('test-salt'), 'custom-encryption-key');
+			const [key, iv] = testCipher.getKeyAndIv(salt, 'custom-encryption-key');
 			expect(key).toBeInstanceOf(Buffer);
 			expect(iv).toBeInstanceOf(Buffer);
-
-			expect(jest.spyOn(Buffer, 'from')).toHaveBeenCalledWith('custom-encryption-key', 'binary');
+			expect(bufferFromSpy).toHaveBeenCalledWith('custom-encryption-key', 'binary');
+			bufferFromSpy.mockRestore();
 		});
 	});
 });

--- a/packages/core/src/encryption/cipher.ts
+++ b/packages/core/src/encryption/cipher.ts
@@ -10,26 +10,26 @@ const RANDOM_BYTES = Buffer.from('53616c7465645f5f', 'hex');
 export class Cipher {
 	constructor(private readonly instanceSettings: InstanceSettings) {}
 
-	encrypt(data: string | object) {
+	encrypt(data: string | object, customEncryptionKey?: string) {
 		const salt = randomBytes(8);
-		const [key, iv] = this.getKeyAndIv(salt);
+		const [key, iv] = this.getKeyAndIv(salt, customEncryptionKey);
 		const cipher = createCipheriv('aes-256-cbc', key, iv);
 		const encrypted = cipher.update(typeof data === 'string' ? data : JSON.stringify(data));
 		return Buffer.concat([RANDOM_BYTES, salt, encrypted, cipher.final()]).toString('base64');
 	}
 
-	decrypt(data: string) {
+	decrypt(data: string, customEncryptionKey?: string) {
 		const input = Buffer.from(data, 'base64');
 		if (input.length < 16) return '';
 		const salt = input.subarray(8, 16);
-		const [key, iv] = this.getKeyAndIv(salt);
+		const [key, iv] = this.getKeyAndIv(salt, customEncryptionKey);
 		const contents = input.subarray(16);
 		const decipher = createDecipheriv('aes-256-cbc', key, iv);
 		return Buffer.concat([decipher.update(contents), decipher.final()]).toString('utf-8');
 	}
 
-	private getKeyAndIv(salt: Buffer): [Buffer, Buffer] {
-		const { encryptionKey } = this.instanceSettings;
+	private getKeyAndIv(salt: Buffer, customEncryptionKey?: string): [Buffer, Buffer] {
+		const encryptionKey = customEncryptionKey ?? this.instanceSettings.encryptionKey;
 		const password = Buffer.concat([Buffer.from(encryptionKey, 'binary'), salt]);
 		const hash1 = createHash('md5').update(password).digest();
 		const hash2 = createHash('md5')


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR allows users to provide their own custom encription key for exports and imports

We support passing a custom encryption key to the cipher methods, instead of providing it as an ENV variable that overrides `this.instanceSettings.encryptionKey` within the Cipher service, as there is a check deeper in the code that validates ENV provided encryption keys match those stored on disk within the ~/.n8n folder, which means we cannot provide a custom encryption key via ENV that is different than the instance provided encryption key.

## Related Linear tickets, Github issues, and Community forum posts

PAY-3971

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
