### PR TITLE
fix(core): Add project id on /new and /from-url endpoints to add project scope auth

### DIFF
--- a/packages/@n8n/api-types/src/dto/workflows/import-workflow-from-url.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/import-workflow-from-url.dto.ts
@@ -3,4 +3,5 @@ import { Z } from 'zod-class';
 
 export class ImportWorkflowFromUrlDto extends Z.class({
 	url: z.string().url(),
+	projectId: z.string(),
 }) {}

--- a/packages/cli/src/workflows/workflow.request.ts
+++ b/packages/cli/src/workflows/workflow.request.ts
@@ -67,7 +67,7 @@ export declare namespace WorkflowRequest {
 		{ forceSave?: string }
 	>;
 
-	type NewName = AuthenticatedRequest<{}, {}, {}, { name?: string }>;
+	type NewName = AuthenticatedRequest<{}, {}, {}, { name?: string; projectId: string }>;
 
 	type ManualRun = AuthenticatedRequest<{ workflowId: string }, {}, ManualRunPayload, {}>;
 

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -33,14 +33,6 @@ import express from 'express';
 import { UnexpectedError } from 'n8n-workflow';
 import { v4 as uuid } from 'uuid';
 
-import { WorkflowExecutionService } from './workflow-execution.service';
-import { WorkflowFinderService } from './workflow-finder.service';
-import { WorkflowHistoryService } from './workflow-history/workflow-history.service';
-import { WorkflowRequest } from './workflow.request';
-import { WorkflowService } from './workflow.service';
-import { EnterpriseWorkflowService } from './workflow.service.ee';
-import { CredentialsService } from '../credentials/credentials.service';
-
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { InternalServerError } from '@/errors/response-errors/internal-server.error';
@@ -60,6 +52,14 @@ import { TagService } from '@/services/tag.service';
 import { UserManagementMailer } from '@/user-management/email';
 import * as utils from '@/utils';
 import * as WorkflowHelpers from '@/workflow-helpers';
+
+import { WorkflowExecutionService } from './workflow-execution.service';
+import { WorkflowFinderService } from './workflow-finder.service';
+import { WorkflowHistoryService } from './workflow-history/workflow-history.service';
+import { WorkflowRequest } from './workflow.request';
+import { WorkflowService } from './workflow.service';
+import { EnterpriseWorkflowService } from './workflow.service.ee';
+import { CredentialsService } from '../credentials/credentials.service';
 
 @RestController('/workflows')
 export class WorkflowsController {
@@ -244,6 +244,14 @@ export class WorkflowsController {
 
 	@Get('/new')
 	async getNewName(req: WorkflowRequest.NewName) {
+		const projectId = req.query.projectId;
+		if (
+			!(await this.projectService.getProjectWithScope(req.user, projectId, ['workflow:create']))
+		) {
+			throw new ForbiddenError(
+				"You don't have the permissions to create a workflow in this project.",
+			);
+		}
 		const requestedName = req.query.name ?? this.globalConfig.workflows.defaultName;
 
 		const name = await this.namingService.getUniqueWorkflowName(requestedName);
@@ -252,10 +260,18 @@ export class WorkflowsController {
 
 	@Get('/from-url')
 	async getFromUrl(
-		_req: AuthenticatedRequest,
+		req: AuthenticatedRequest,
 		_res: express.Response,
 		@Query query: ImportWorkflowFromUrlDto,
 	) {
+		const projectId = query.projectId;
+		if (
+			!(await this.projectService.getProjectWithScope(req.user, projectId, ['workflow:create']))
+		) {
+			throw new ForbiddenError(
+				"You don't have the permissions to create a workflow in this project.",
+			);
+		}
 		let workflowData: IWorkflowResponse | undefined;
 		try {
 			const { data } = await axios.get<IWorkflowResponse>(query.url);

--- a/packages/cli/test/integration/access-control/resource-access-matrix.test.ts
+++ b/packages/cli/test/integration/access-control/resource-access-matrix.test.ts
@@ -192,8 +192,8 @@ describe('Resource Access Control Matrix Tests', () => {
 				expect(response.body.data.length).toBeGreaterThan(0);
 			});
 
-			test('GET /workflows/new should return 200', async () => {
-				await testUserAgent.get('/workflows/new').expect(200);
+			test('GET /workflows/new should return 403', async () => {
+				await testUserAgent.get(`/workflows/new?projectId=${teamProject.id}`).expect(403);
 			});
 
 			test('GET /workflows/:id should return 200', async () => {
@@ -276,7 +276,7 @@ describe('Resource Access Control Matrix Tests', () => {
 			});
 
 			test('GET /workflows/new should return 200', async () => {
-				await testUserAgent.get('/workflows/new').expect(200);
+				await testUserAgent.get(`/workflows/new?projectId=${teamProject.id}`).expect(200);
 			});
 
 			test('GET /workflows/:id should return 200', async () => {

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -109,13 +109,12 @@ import {
 	NodeHelpers,
 	TelemetryHelpers,
 	isCommunityPackageName,
-	assertParamIsOfAnyTypes,
 } from 'n8n-workflow';
 import { computed, nextTick, ref } from 'vue';
 import { useClipboard } from '@/app/composables/useClipboard';
 import { useUniqueNodeName } from '@/app/composables/useUniqueNodeName';
 import { injectWorkflowState } from '@/app/composables/useWorkflowState';
-import { isPresent } from '@/app/utils/typesUtils';
+import { isPresent, tryToParseNumber } from '@/app/utils/typesUtils';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import type { CanvasLayoutEvent } from '@/features/workflows/canvas/composables/useCanvasLayout';
 import { chatEventBus } from '@n8n/chat/event-buses';
@@ -129,7 +128,6 @@ import { useFocusPanelStore } from '@/app/stores/focusPanel.store';
 import type { TelemetryNdvSource, TelemetryNdvType } from '@/app/types/telemetry';
 import { useRoute, useRouter } from 'vue-router';
 import { useTemplatesStore } from '@/features/workflows/templates/templates.store';
-import { tryToParseNumber } from '@/app/utils/typesUtils';
 import { isValidNodeConnectionType } from '@/app/utils/typeGuards';
 import { useParentFolder } from '@/features/core/folders/composables/useParentFolder';
 

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -2141,14 +2141,16 @@ export function useCanvasOperations() {
 	async function fetchWorkflowDataFromUrl(url: string): Promise<WorkflowDataUpdate | undefined> {
 		let workflowData: WorkflowDataUpdate;
 
-		if (!projectsStore.currentProjectId) {
+		const projectId = projectsStore.currentProjectId ?? projectsStore.personalProject?.id;
+		if (!projectId) {
 			// We should never reach this point because the project should be selected before
 			throw new Error('No project selected');
+			return;
 		}
 
 		canvasStore.startLoading();
 		try {
-			workflowData = await workflowsStore.getWorkflowFromUrl(url, projectsStore.currentProjectId);
+			workflowData = await workflowsStore.getWorkflowFromUrl(url, projectId);
 		} catch (error) {
 			toast.showError(error, i18n.baseText('nodeView.showError.getWorkflowDataFromUrl.title'));
 			return;

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -109,6 +109,7 @@ import {
 	NodeHelpers,
 	TelemetryHelpers,
 	isCommunityPackageName,
+	assertParamIsOfAnyTypes,
 } from 'n8n-workflow';
 import { computed, nextTick, ref } from 'vue';
 import { useClipboard } from '@/app/composables/useClipboard';
@@ -2142,9 +2143,14 @@ export function useCanvasOperations() {
 	async function fetchWorkflowDataFromUrl(url: string): Promise<WorkflowDataUpdate | undefined> {
 		let workflowData: WorkflowDataUpdate;
 
+		if (!projectsStore.currentProjectId) {
+			// We should never reach this point because the project should be selected before
+			throw new Error('No project selected');
+		}
+
 		canvasStore.startLoading();
 		try {
-			workflowData = await workflowsStore.getWorkflowFromUrl(url);
+			workflowData = await workflowsStore.getWorkflowFromUrl(url, projectsStore.currentProjectId);
 		} catch (error) {
 			toast.showError(error, i18n.baseText('nodeView.showError.getWorkflowDataFromUrl.title'));
 			return;

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -581,9 +581,10 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		return createWorkflowObject(nodes, connections);
 	}
 
-	async function getWorkflowFromUrl(url: string): Promise<IWorkflowDb> {
+	async function getWorkflowFromUrl(url: string, projectId: string): Promise<IWorkflowDb> {
 		return await makeRestApiRequest(rootStore.restApiContext, 'GET', '/workflows/from-url', {
 			url,
+			projectId,
 		});
 	}
 


### PR DESCRIPTION

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Before this PR, the /new and /from-url endpoints of the workflows controller did not do any project scope authorization check.
This PR adds the projectId as a query param for both routes and implement project role check on it

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
