### PR TITLE
[21867] Fixed source control export logging

### DIFF
--- a/packages/cli/src/environments.ee/source-control/source-control-export.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-export.service.ee.ts
@@ -230,10 +230,8 @@ export class SourceControlExportService {
 				],
 			};
 		} catch (error) {
-			this.logger.error('Failed to export variables to work folder', { error });
-			throw new UnexpectedError('Failed to export variables to work folder', {
-				cause: error,
-			});
+			this.logger.error(`Failed to export variables to work folder: ${(error as Error).message}`);
+			throw error;
 		}
 	}
 
@@ -312,8 +310,8 @@ export class SourceControlExportService {
 				],
 			};
 		} catch (error) {
-			this.logger.error('Failed to export folders to work folder', { error });
-			throw new UnexpectedError('Failed to export folders to work folder', { cause: error });
+			this.logger.error(`Failed to export folders to work folder: ${(error as Error).message}`);
+			throw error;
 		}
 	}
 
@@ -372,8 +370,8 @@ export class SourceControlExportService {
 				files: [{ id: '', name: fileName }],
 			};
 		} catch (error) {
-			this.logger.error('Failed to export tags to work folder', { error });
-			throw new UnexpectedError('Failed to export tags to work folder', { cause: error });
+			this.logger.error(`Failed to export tags to work folder: ${(error as Error).message}`);
+			throw error;
 		}
 	}
 
@@ -474,8 +472,8 @@ export class SourceControlExportService {
 				missingIds,
 			};
 		} catch (error) {
-			this.logger.error('Failed to export credentials to work folder', { error });
-			throw new UnexpectedError('Failed to export credentials to work folder', { cause: error });
+			this.logger.error(`Failed to export credentials to work folder: ${(error as Error).message}`);
+			throw error;
 		}
 	}
 


### PR DESCRIPTION
## Summary

PR fixes error logging for source control export (EE feature). For now it is not possible to understand what happens in source control because the logging system fails to log related errors. Then I made a simple fix, just logged the error message in inplace. Now logging method is the same as in another places. So I think it will work much better.

## Related Linear tickets, Github issues, and Community forum posts

Related to #21867, but it is not closing it.

## Review / Merge checklist

- [*] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Logs error messages and rethrows original errors across EE source control export paths (variables, folders, tags, credentials).
> 
> - **EE Source Control Export**
>   - **Error handling/logging**:
>     - Update `exportGlobalVariablesToWorkFolder`, `exportFoldersToWorkFolder`, `exportTagsToWorkFolder`, and `exportCredentialsToWorkFolder` to log `error.message` and rethrow the original error instead of wrapping in `UnexpectedError`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59b135e1ff06b98d315d293c59367eb660c8f883. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->