### PR TITLE
fix(editor): Filtering for archived workflows in error workflows list

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/WorkflowSettings.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowSettings.vue
@@ -293,6 +293,7 @@ const loadTimezones = async () => {
 const loadWorkflows = async (searchTerm?: string) => {
 	const workflowsData = (await workflowsStore.searchWorkflows({
 		query: searchTerm,
+		isArchived: false,
 	})) as IWorkflowShortResponse[];
 	workflowsData.sort((a, b) => {
 		if (a.name.toLowerCase() < b.name.toLowerCase()) {

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.test.ts
@@ -698,6 +698,193 @@ describe('useWorkflowsStore', () => {
 		});
 	});
 
+	describe('searchWorkflows()', () => {
+		beforeEach(() => {
+			vi.mocked(workflowsApi).getWorkflows.mockClear();
+		});
+
+		it('should search workflows with no filters', async () => {
+			const mockWorkflows = [
+				{ id: '1', name: 'Workflow 1', isArchived: false },
+				{ id: '2', name: 'Workflow 2', isArchived: false },
+			] as IWorkflowDb[];
+			vi.mocked(workflowsApi).getWorkflows.mockResolvedValue({
+				count: mockWorkflows.length,
+				data: mockWorkflows,
+			});
+
+			const result = await workflowsStore.searchWorkflows({});
+
+			expect(workflowsApi.getWorkflows).toHaveBeenCalledWith(
+				expect.any(Object),
+				undefined,
+				undefined,
+				undefined,
+			);
+			expect(result).toEqual(mockWorkflows);
+		});
+
+		it('should search workflows with query filter', async () => {
+			const mockWorkflows = [{ id: '1', name: 'Test Workflow' }] as IWorkflowDb[];
+			vi.mocked(workflowsApi).getWorkflows.mockResolvedValue({
+				count: mockWorkflows.length,
+				data: mockWorkflows,
+			});
+
+			const result = await workflowsStore.searchWorkflows({ query: 'test' });
+
+			expect(workflowsApi.getWorkflows).toHaveBeenCalledWith(
+				expect.any(Object),
+				{ query: 'test' },
+				undefined,
+				undefined,
+			);
+			expect(result).toEqual(mockWorkflows);
+		});
+
+		it('should search workflows with isArchived filter set to false', async () => {
+			const mockWorkflows = [
+				{ id: '1', name: 'Active Workflow 1', isArchived: false },
+				{ id: '2', name: 'Active Workflow 2', isArchived: false },
+			] as IWorkflowDb[];
+			vi.mocked(workflowsApi).getWorkflows.mockResolvedValue({
+				count: mockWorkflows.length,
+				data: mockWorkflows,
+			});
+
+			const result = await workflowsStore.searchWorkflows({ isArchived: false });
+
+			expect(workflowsApi.getWorkflows).toHaveBeenCalledWith(
+				expect.any(Object),
+				{ isArchived: false },
+				undefined,
+				undefined,
+			);
+			expect(result).toEqual(mockWorkflows);
+		});
+
+		it('should search workflows with isArchived filter set to true', async () => {
+			const mockWorkflows = [
+				{ id: '3', name: 'Archived Workflow 1', isArchived: true },
+				{ id: '4', name: 'Archived Workflow 2', isArchived: true },
+			] as IWorkflowDb[];
+			vi.mocked(workflowsApi).getWorkflows.mockResolvedValue({
+				count: mockWorkflows.length,
+				data: mockWorkflows,
+			});
+
+			const result = await workflowsStore.searchWorkflows({ isArchived: true });
+
+			expect(workflowsApi.getWorkflows).toHaveBeenCalledWith(
+				expect.any(Object),
+				{ isArchived: true },
+				undefined,
+				undefined,
+			);
+			expect(result).toEqual(mockWorkflows);
+		});
+
+		it('should search workflows with multiple filters including isArchived', async () => {
+			const mockWorkflows = [
+				{ id: '1', name: 'Test Workflow', isArchived: false },
+			] as IWorkflowDb[];
+			vi.mocked(workflowsApi).getWorkflows.mockResolvedValue({
+				count: mockWorkflows.length,
+				data: mockWorkflows,
+			});
+
+			const result = await workflowsStore.searchWorkflows({
+				query: 'test',
+				isArchived: false,
+				projectId: 'project-123',
+				tags: ['tag1', 'tag2'],
+				nodeTypes: ['n8n-nodes-base.httpRequest'],
+			});
+
+			expect(workflowsApi.getWorkflows).toHaveBeenCalledWith(
+				expect.any(Object),
+				{
+					query: 'test',
+					isArchived: false,
+					projectId: 'project-123',
+					tags: ['tag1', 'tag2'],
+					nodeTypes: ['n8n-nodes-base.httpRequest'],
+				},
+				undefined,
+				undefined,
+			);
+			expect(result).toEqual(mockWorkflows);
+		});
+
+		it('should search workflows with select fields', async () => {
+			const mockWorkflows = [
+				{ id: '1', name: 'Workflow 1' },
+				{ id: '2', name: 'Workflow 2' },
+			] as IWorkflowDb[];
+			vi.mocked(workflowsApi).getWorkflows.mockResolvedValue({
+				count: mockWorkflows.length,
+				data: mockWorkflows,
+			});
+
+			const result = await workflowsStore.searchWorkflows({
+				select: ['id', 'name'],
+			});
+
+			expect(workflowsApi.getWorkflows).toHaveBeenCalledWith(
+				expect.any(Object),
+				undefined,
+				undefined,
+				['id', 'name'],
+			);
+			expect(result).toEqual(mockWorkflows);
+		});
+
+		it('should handle empty filter object correctly', async () => {
+			const mockWorkflows = [] as IWorkflowDb[];
+			vi.mocked(workflowsApi).getWorkflows.mockResolvedValue({
+				count: 0,
+				data: mockWorkflows,
+			});
+
+			const result = await workflowsStore.searchWorkflows({
+				projectId: undefined,
+				query: undefined,
+				nodeTypes: undefined,
+				tags: undefined,
+				isArchived: undefined,
+			});
+
+			expect(workflowsApi.getWorkflows).toHaveBeenCalledWith(
+				expect.any(Object),
+				undefined,
+				undefined,
+				undefined,
+			);
+			expect(result).toEqual(mockWorkflows);
+		});
+
+		it('should pass isArchived as undefined when not specified', async () => {
+			const mockWorkflows = [
+				{ id: '1', name: 'Workflow 1', isArchived: false },
+				{ id: '2', name: 'Workflow 2', isArchived: true },
+			] as IWorkflowDb[];
+			vi.mocked(workflowsApi).getWorkflows.mockResolvedValue({
+				count: mockWorkflows.length,
+				data: mockWorkflows,
+			});
+
+			const result = await workflowsStore.searchWorkflows({ query: 'workflow' });
+
+			expect(workflowsApi.getWorkflows).toHaveBeenCalledWith(
+				expect.any(Object),
+				{ query: 'workflow', isArchived: undefined },
+				undefined,
+				undefined,
+			);
+			expect(result).toEqual(mockWorkflows);
+		});
+	});
+
 	describe('setWorkflowActive()', () => {
 		it('should set workflow as active when it is not already active', () => {
 			uiStore.stateIsDirty = true;

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -672,18 +672,21 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		nodeTypes,
 		tags,
 		select,
+		isArchived,
 	}: {
 		projectId?: string;
 		query?: string;
 		nodeTypes?: string[];
 		tags?: string[];
 		select?: string[];
+		isArchived?: boolean;
 	}): Promise<IWorkflowDb[]> {
 		const filter = {
 			projectId,
 			query,
 			nodeTypes,
 			tags,
+			isArchived,
 		};
 
 		const { data: workflows } = await workflowsApi.getWorkflows(

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -67,7 +67,7 @@ import { useRootStore } from '@n8n/stores/useRootStore';
 import * as workflowsApi from '@/app/api/workflows';
 import { useUIStore } from '@/app/stores/ui.store';
 import { dataPinningEventBus } from '@/app/event-bus';
-import { isJsonKeyObject, isEmpty, stringSizeInBytes, isPresent } from '@/app/utils/typesUtils';
+import { isJsonKeyObject, stringSizeInBytes, isPresent } from '@/app/utils/typesUtils';
 import { makeRestApiRequest, ResponseError } from '@n8n/rest-api-client';
 import {
 	unflattenExecutionData,
@@ -689,9 +689,14 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 			isArchived,
 		};
 
+		// Check if filter has meaningful values (not just undefined, null, or empty arrays/strings)
+		const hasFilter = Object.values(filter).some(
+			(v) => isPresent(v) && (Array.isArray(v) ? v.length > 0 : v !== ''),
+		);
+
 		const { data: workflows } = await workflowsApi.getWorkflows(
 			rootStore.restApiContext,
-			isEmpty(filter) ? undefined : filter,
+			hasFilter ? filter : undefined,
 			undefined,
 			select,
 		);


### PR DESCRIPTION
## Summary

The list of workflows in error workflow dropdown should not show archived workflows. 

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/ADO-4403/community-issue-error-workflow-dropdown-lists-archived-workflows
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Exclude archived workflows from the error workflow dropdown and extend store search to support an isArchived filter with comprehensive tests.
> 
> - **Editor UI**
>   - `components/WorkflowSettings.vue`: Load workflows for the error workflow selector with `isArchived: false` to hide archived workflows.
> - **Store**
>   - `stores/workflows.store.ts`:
>     - Extend `searchWorkflows` to accept `isArchived` and include it in the API filter.
>     - Replace `isEmpty` check with a `hasFilter` check using `isPresent` and array/string emptiness; remove `isEmpty` import.
> - **Tests**
>   - `stores/workflows.store.test.ts`: Add tests for `searchWorkflows` covering no filters, query filter, `isArchived` true/false, multiple filters, select fields, empty filter handling, and ensuring `isArchived` is `undefined` when not specified.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c92f3b7935d730ed3fd4b8ef014a22ee956b31c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->