### PR TITLE
chore(ai-builder): Build with CLI command for testing prompt changes

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/package.json
+++ b/packages/@n8n/ai-workflow-builder.ee/package.json
@@ -5,6 +5,7 @@
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "build": "tsc -p ./tsconfig.build.json && tsc-alias -p tsconfig.build.json",
+    "build:with-cli": "pnpm build && pnpm --filter=n8n build",
     "format": "biome format --write src",
     "format:check": "biome ci src",
     "test": "jest",


### PR DESCRIPTION
## Summary
Adding a quick command `build:with-cli` which can be used to just build what is needed to test prompt changes in the workflow builder package - builds everything needed in 7 seconds.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `build:with-cli` npm script to build the AI workflow builder package and the `n8n` CLI together.
> 
> - **Scripts**:
>   - Add `build:with-cli` to `packages/@n8n/ai-workflow-builder.ee/package.json` to run `pnpm build` then `pnpm --filter=n8n build`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28949f9aa400cd6c59984c3d8e7e428771992642. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->