### PR TITLE
fix(core): Validate package version when installing community node

### DIFF
--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.controller.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.controller.test.ts
@@ -31,13 +31,26 @@ describe('CommunityPackagesController', () => {
 		it('should throw error if verify in options but no checksum', async () => {
 			const request = mock<NodeRequest.Post>({
 				user: { id: 'user123' },
-				body: { name: 'n8n-nodes-test', verify: true },
+				body: { name: 'n8n-nodes-test', verify: true, version: '1.0.0' },
 			});
 			communityNodeTypesService.findVetted.mockReturnValue(undefined);
 			await expect(controller.installPackage(request)).rejects.toThrow(
 				'Package n8n-nodes-test is not vetted for installation',
 			);
 		});
+
+		it.each(['foo', 'echo "hello"', '1.a.b'])(
+			'should throw error if version is invalid',
+			async (version) => {
+				const request = mock<NodeRequest.Post>({
+					user: { id: 'user123' },
+					body: { name: 'n8n-nodes-test', verify: true, version },
+				});
+				await expect(controller.installPackage(request)).rejects.toThrow(
+					`Invalid version: ${version}`,
+				);
+			},
+		);
 
 		it('should have correct version', async () => {
 			const request = mock<NodeRequest.Post>({

--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.controller.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.controller.test.ts
@@ -39,7 +39,7 @@ describe('CommunityPackagesController', () => {
 			);
 		});
 
-		it.each(['foo', 'echo "hello"', '1.a.b'])(
+		it.each(['foo', 'echo "hello"', '1.a.b', '0.1.29#;ls'])(
 			'should throw error if version is invalid',
 			async (version) => {
 				const request = mock<NodeRequest.Post>({
@@ -133,7 +133,7 @@ describe('CommunityPackagesController', () => {
 			expect(result).toBe(newInstalledPackage);
 		});
 
-		it.each(['foo', 'echo "hello"', '1.a.b'])(
+		it.each(['foo', 'echo "hello"', '1.a.b', '0.1.29#;ls'])(
 			'should throw error if version is invalid',
 			async (version) => {
 				const req = mock<NodeRequest.Update>({

--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.controller.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.controller.test.ts
@@ -132,5 +132,15 @@ describe('CommunityPackagesController', () => {
 
 			expect(result).toBe(newInstalledPackage);
 		});
+
+		it.each(['foo', 'echo "hello"', '1.a.b'])(
+			'should throw error if version is invalid',
+			async (version) => {
+				const req = mock<NodeRequest.Update>({
+					body: { name: 'n8n-nodes-test', version, checksum: 'a893hfdsy7399' },
+				});
+				await expect(controller.updatePackage(req)).rejects.toThrow(`Invalid version: ${version}`);
+			},
+		);
 	});
 });

--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.service.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.service.test.ts
@@ -101,6 +101,12 @@ describe('CommunityPackagesService', () => {
 			).toThrowError();
 		});
 
+		test.each(['invalid', '1.a.b'])('should fail with invalid version', (version) => {
+			expect(() =>
+				communityPackagesService.parseNpmPackageName(`n8n-nodes-test@${version}`),
+			).toThrow(`Invalid version: ${version}`);
+		});
+
 		test('should parse valid package name', () => {
 			const name = mockPackageName();
 			const parsed = communityPackagesService.parseNpmPackageName(name);

--- a/packages/cli/src/modules/community-packages/community-packages.controller.ts
+++ b/packages/cli/src/modules/community-packages/community-packages.controller.ts
@@ -15,6 +15,7 @@ import { CommunityNodeTypesService } from './community-node-types.service';
 import { CommunityPackagesService } from './community-packages.service';
 import type { CommunityPackages } from './community-packages.types';
 import { InstalledPackages } from './installed-packages.entity';
+import { valid } from 'semver';
 
 const {
 	PACKAGE_NOT_INSTALLED,
@@ -49,6 +50,10 @@ export class CommunityPackagesController {
 
 		if (!name) {
 			throw new BadRequestError(PACKAGE_NAME_NOT_PROVIDED);
+		}
+
+		if (version && !valid(version)) {
+			throw new BadRequestError(`Invalid version: ${version}`);
 		}
 
 		let checksum: string | undefined = undefined;

--- a/packages/cli/src/modules/community-packages/community-packages.controller.ts
+++ b/packages/cli/src/modules/community-packages/community-packages.controller.ts
@@ -258,6 +258,10 @@ export class CommunityPackagesController {
 			throw new BadRequestError(PACKAGE_NAME_NOT_PROVIDED);
 		}
 
+		if (version && !valid(version)) {
+			throw new BadRequestError(`Invalid version: ${version}`);
+		}
+
 		const previouslyInstalledPackage =
 			await this.communityPackagesService.findInstalledPackage(name);
 

--- a/packages/cli/src/modules/community-packages/community-packages.service.ts
+++ b/packages/cli/src/modules/community-packages/community-packages.service.ts
@@ -29,6 +29,7 @@ import type { CommunityPackages } from './community-packages.types';
 import { InstalledPackages } from './installed-packages.entity';
 import { InstalledPackagesRepository } from './installed-packages.repository';
 import { checkIfVersionExistsOrThrow, verifyIntegrity } from './npm-utils';
+import { valid } from 'semver';
 
 const DEFAULT_REGISTRY = 'https://registry.npmjs.org';
 const NPM_COMMON_ARGS = ['--audit=false', '--fund=false'];
@@ -144,6 +145,10 @@ export class CommunityPackagesService {
 		const version = packageNameWithoutScope.includes('@')
 			? packageNameWithoutScope.split('@')[1]
 			: undefined;
+
+		if (version && !valid(version)) {
+			throw new UnexpectedError(`Invalid version: ${version}`);
+		}
 
 		const packageName = version ? rawString.replace(`@${version}`, '') : rawString;
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
Validate package version according to `semver` before installing

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
https://linear.app/n8n/issue/NODE-3890/remote-code-execution-via-command-injection-in-community-package

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Validate package version using semver in community packages controller and service, with tests added for invalid versions.
> 
> - **Community Packages**:
>   - **Validation**:
>     - Enforce semver validation for `version` in `community-packages.controller` (`installPackage`, `updatePackage`).
>     - Validate version in `CommunityPackagesService.parseNpmPackageName()`; throw on invalid versions.
>   - **Tests**:
>     - Add cases to reject invalid versions in controller tests for install/update.
>     - Add service tests to reject invalid versions in `parseNpmPackageName()`.
>   - **Misc**:
>     - Adjust controller test inputs to include `version` where required; keep checksum vetting logic intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e1a540c052285bacb0a0703b894d4436a3723ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->