### PR TITLE
refactor(editor): Refine dark mode (stickies, sidebar, ndv)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nMenuItem/MenuItem.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMenuItem/MenuItem.vue
@@ -100,7 +100,7 @@ const iconColor = computed(() => {
 
 .router-link-active,
 .active {
-	background-color: var(--color--background);
+	background-color: var(--color--foreground);
 }
 
 .menuItem {
@@ -122,8 +122,8 @@ const iconColor = computed(() => {
 	}
 }
 
-.menuItem:hover {
-	background-color: var(--color--background);
+.menuItem:hover:not(.active) {
+	background-color: var(--color--background--light-1);
 	color: var(--color--text--shade-1);
 }
 
@@ -170,7 +170,7 @@ const iconColor = computed(() => {
 
 .menuItem.active {
 	.menuItemIcon {
-		color: var(--color--foreground--shade-2);
+		color: var(--color--text--shade-1);
 	}
 }
 </style>

--- a/packages/frontend/@n8n/design-system/src/components/N8nMenuItem/MenuItem.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMenuItem/MenuItem.vue
@@ -63,12 +63,12 @@ const iconColor = computed(() => {
 			<template v-if="compact" #content>{{ item.label }}</template>
 
 			<N8nRoute
+				:id="item.id"
 				:to="to"
 				role="menuitem"
 				:class="[$style.menuItem, { [$style.active]: active }]"
 				:aria-label="props.ariaLabel"
 				data-test-id="menu-item"
-				:id="item.id"
 				@click="emit('click')"
 			>
 				<div
@@ -100,7 +100,7 @@ const iconColor = computed(() => {
 
 .router-link-active,
 .active {
-	background-color: var(--color--foreground);
+	background-color: var(--menu--color--background--hover);
 }
 
 .menuItem {

--- a/packages/frontend/@n8n/design-system/src/components/N8nMenuItem/MenuItem.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMenuItem/MenuItem.vue
@@ -100,7 +100,7 @@ const iconColor = computed(() => {
 
 .router-link-active,
 .active {
-	background-color: var(--menu--color--background--hover);
+	background-color: var(--color--background);
 }
 
 .menuItem {
@@ -123,7 +123,7 @@ const iconColor = computed(() => {
 }
 
 .menuItem:hover {
-	background-color: var(--color--foreground);
+	background-color: var(--color--background);
 	color: var(--color--text--shade-1);
 }
 

--- a/packages/frontend/@n8n/design-system/src/components/N8nSticky/Sticky.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nSticky/Sticky.vue
@@ -130,15 +130,6 @@ const onInputScroll = (event: WheelEvent) => {
 
 	background-color: var(--sticky--color--background);
 	border: 1px solid var(--sticky--border-color);
-
-	.wrapper::after {
-		opacity: 0.15;
-		background: linear-gradient(
-			180deg,
-			var(--sticky--color--background) 0.01%,
-			var(--sticky--border-color)
-		);
-	}
 }
 
 .clickable {
@@ -151,16 +142,6 @@ const onInputScroll = (event: WheelEvent) => {
 	position: absolute;
 	padding: var(--spacing--2xs) var(--spacing--xs) 0;
 	overflow: hidden;
-
-	&::after {
-		content: '';
-		width: 100%;
-		height: 24px;
-		left: 0;
-		bottom: 0;
-		position: absolute;
-		border-radius: var(--radius);
-	}
 }
 
 .footer {

--- a/packages/frontend/@n8n/design-system/src/css/_primitives.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_primitives.scss
@@ -123,7 +123,7 @@
 	--color--red-700: hsl(355, 83%, 42%);
 	--color--red-800: hsl(355, 83%, 37%);
 	--color--red-900: hsl(355, 83%, 27%);
-	--color--red-950: hsl(355, 83%, 20%);
+	--color--red-950: hsl(355, 83%, 17%);
 
 	--color--red-alpha-020: hsla(355, 83%, 52%, 0.2);
 

--- a/packages/frontend/@n8n/design-system/src/css/_tokens.dark.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.dark.scss
@@ -13,9 +13,9 @@
 	--color--text--danger: var(--color--red-400);
 
 	// Foreground
-	--color--foreground--shade-2: var(--color--neutral-250);
-	--color--foreground--shade-1: var(--color--neutral-400);
-	--color--foreground: var(--color--neutral-750);
+	--color--foreground--shade-2: var(--color--neutral-400);
+	--color--foreground--shade-1: var(--color--neutral-700);
+	--color--foreground: var(--color--neutral-800);
 	--color--foreground--tint-1: var(--color--neutral-850);
 	--color--foreground--tint-2: var(--color--neutral-950);
 
@@ -102,7 +102,7 @@
 	--sticky--color--background--variant-2: var(--color--gold-900);
 	--sticky--border-color--variant-2: var(--color--gold-800);
 	--sticky--color--background--variant-3: var(--color--red-950);
-	--sticky--border-color--variant-3: var(--color--red-800);
+	--sticky--border-color--variant-3: var(--color--red-900);
 	--sticky--color--background--variant-4: var(--color--green-950);
 	--sticky--border-color--variant-4: var(--color--green-900);
 	--sticky--color--background--variant-5: var(--color--blue-900);
@@ -267,7 +267,7 @@
 	--ndv--droppable-parameter--color--background--active: var(--color--green-alpha-100);
 	--ndv--back--color--text: var(--color--neutral-white);
 	--ndv--background--color: var(--color--background--light-1);
-	--ndv--header--color: var(--color--neutral-700);
+	--ndv--header--color: var(--color--neutral-750);
 
 	// Notice
 	--notice--border-color--warning: var(--color--gold-200);
@@ -275,8 +275,8 @@
 	--notice--color--text: var(--color--neutral-white);
 
 	// Callout
-	--callout--border-color--info: var(--color--neutral-700);
-	--callout--color--background--info: var(--color--neutral-850);
+	--callout--border-color--info: var(--color--foreground);
+	--callout--color--background--info: var(--color--neutral-900);
 	--callout--color--text--info: var(--color--neutral-white);
 	--callout--border-color--success: var(--color--success);
 	--callout--color--background--success: var(--color--green-900);
@@ -284,8 +284,8 @@
 	--callout--border-color--warning: var(--color--warning);
 	--callout--color--background--warning: var(--color--gold-800);
 	--callout--color--text--warning: var(--color--neutral-white);
-	--callout--border-color--danger: var(--color--danger);
-	--callout--color--background--danger: var(--color--red-900);
+	--callout--border-color--danger: var(--color--red-800);
+	--callout--color--background--danger: var(--color--red-950);
 	--callout--color--text--danger: var(--color--neutral-white);
 	--callout--icon-color--danger: var(--color--danger);
 	--callout--border-color--secondary: var(--color--secondary);

--- a/packages/frontend/@n8n/design-system/src/css/_tokens.dark.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.dark.scss
@@ -91,26 +91,26 @@
 	--node--type-main--color: var(--color--neutral-400);
 
 	// Sticky
-	--sticky--color--background: var(--color--yellow-800);
-	--sticky--border-color: var(--color--yellow-700);
+	--sticky--color--background: var(--color--yellow-900);
+	--sticky--border-color: var(--color--yellow-800);
 	--sticky--color--text: var(--color--neutral-125);
 	--sticky--code--color--text: var(--color--purple-300);
 	--sticky--code--color--background: var(--color--neutral-150-alpha-100);
 
 	--sticky--color--background--variant-1: var(--color--yellow-900);
-	--sticky--border-color--variant-1: var(--color--yellow-700);
-	--sticky--color--background--variant-2: var(--color--gold-800);
-	--sticky--border-color--variant-2: var(--color--gold-700);
-	--sticky--color--background--variant-3: var(--color--red-900);
+	--sticky--border-color--variant-1: var(--color--yellow-800);
+	--sticky--color--background--variant-2: var(--color--gold-900);
+	--sticky--border-color--variant-2: var(--color--gold-800);
+	--sticky--color--background--variant-3: var(--color--red-950);
 	--sticky--border-color--variant-3: var(--color--red-800);
-	--sticky--color--background--variant-4: var(--color--green-900);
-	--sticky--border-color--variant-4: var(--color--green-700);
+	--sticky--color--background--variant-4: var(--color--green-950);
+	--sticky--border-color--variant-4: var(--color--green-900);
 	--sticky--color--background--variant-5: var(--color--blue-800);
 	--sticky--border-color--variant-5: var(--color--blue-700);
-	--sticky--color--background--variant-6: var(--color--purple-900);
-	--sticky--border-color--variant-6: var(--color--purple-700);
-	--sticky--color--background--variant-7: var(--color--neutral-850);
-	--sticky--border-color--variant-7: var(--color--neutral-700);
+	--sticky--color--background--variant-6: var(--color--purple-950);
+	--sticky--border-color--variant-6: var(--color--purple-800);
+	--sticky--color--background--variant-7: var(--color--neutral-900);
+	--sticky--border-color--variant-7: var(--color--neutral-800);
 
 	// NodeIcon
 	--node--icon--color--neutral: var(--color--neutral-200);

--- a/packages/frontend/@n8n/design-system/src/css/_tokens.dark.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.dark.scss
@@ -97,7 +97,7 @@
 	--sticky--code--color--text: var(--color--purple-300);
 	--sticky--code--color--background: var(--color--neutral-150-alpha-100);
 
-	--sticky--color--background--variant-1: var(--color--yellow-800);
+	--sticky--color--background--variant-1: var(--color--yellow-900);
 	--sticky--border-color--variant-1: var(--color--yellow-700);
 	--sticky--color--background--variant-2: var(--color--gold-800);
 	--sticky--border-color--variant-2: var(--color--gold-700);
@@ -523,7 +523,7 @@
 	--icon--color: var(--color--text--tint-1);
 	--icon--color--hover: var(--color--orange-300);
 
-	--menu--color--background: var(--color--neutral-850);
+	--menu--color--background: var(--color--neutral-900);
 	--menu--color--background--hover: var(--color--neutral-700);
 	--menu--color--background--active: var(--color--neutral-700);
 

--- a/packages/frontend/@n8n/design-system/src/css/_tokens.dark.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.dark.scss
@@ -105,8 +105,8 @@
 	--sticky--border-color--variant-3: var(--color--red-800);
 	--sticky--color--background--variant-4: var(--color--green-950);
 	--sticky--border-color--variant-4: var(--color--green-900);
-	--sticky--color--background--variant-5: var(--color--blue-800);
-	--sticky--border-color--variant-5: var(--color--blue-700);
+	--sticky--color--background--variant-5: var(--color--blue-900);
+	--sticky--border-color--variant-5: var(--color--blue-800);
 	--sticky--color--background--variant-6: var(--color--purple-950);
 	--sticky--border-color--variant-6: var(--color--purple-800);
 	--sticky--color--background--variant-7: var(--color--neutral-900);

--- a/packages/frontend/@n8n/design-system/src/css/_tokens.dark.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.dark.scss
@@ -266,6 +266,7 @@
 	--ndv--droppable-parameter--color--background: var(--color--orange-alpha-100);
 	--ndv--droppable-parameter--color--background--active: var(--color--green-alpha-100);
 	--ndv--back--color--text: var(--color--neutral-white);
+	--ndv--background--color: var(--color--background--light-1);
 
 	// Notice
 	--notice--border-color--warning: var(--color--gold-200);

--- a/packages/frontend/@n8n/design-system/src/css/_tokens.dark.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.dark.scss
@@ -267,6 +267,7 @@
 	--ndv--droppable-parameter--color--background--active: var(--color--green-alpha-100);
 	--ndv--back--color--text: var(--color--neutral-white);
 	--ndv--background--color: var(--color--background--light-1);
+	--ndv--header--color: var(--color--neutral-700);
 
 	// Notice
 	--notice--border-color--warning: var(--color--gold-200);

--- a/packages/frontend/@n8n/design-system/src/css/_tokens.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.scss
@@ -432,6 +432,7 @@
 	--ndv--droppable-parameter--color--background--active: var(--color--green-alpha-100);
 	--ndv--back--color--text: var(--color--neutral-white);
 	--ndv--background--color: var(--color--background--light-3);
+	--ndv--header--color: var(--color--background);
 
 	// Notice
 	--notice--border-color--warning: var(--color--warning--tint-1);

--- a/packages/frontend/@n8n/design-system/src/css/_tokens.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.scss
@@ -431,6 +431,7 @@
 	--ndv--droppable-parameter--color--background: var(--color--purple-alpha-100);
 	--ndv--droppable-parameter--color--background--active: var(--color--green-alpha-100);
 	--ndv--back--color--text: var(--color--neutral-white);
+	--ndv--background--color: var(--color--background--light-3);
 
 	// Notice
 	--notice--border-color--warning: var(--color--warning--tint-1);

--- a/packages/frontend/@n8n/design-system/src/css/_tokens.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.scss
@@ -464,7 +464,7 @@
 	// Dialogs and overlays
 	--dialog--color--background: var(--color--neutral-white);
 	--dialog--overlay--color--background: var(--color--white-alpha-800);
-	--dialog--overlay--color--background--dark: var(--color--neutral-800-alpha-100);
+	--dialog--overlay--color--background--dark: var(--color--slate-alpha-700);
 	--block-ui--overlay--color: var(--color--neutral-950);
 
 	// Avatar

--- a/packages/frontend/@n8n/design-system/src/css/_tokens.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.scss
@@ -464,7 +464,7 @@
 	// Dialogs and overlays
 	--dialog--color--background: var(--color--neutral-white);
 	--dialog--overlay--color--background: var(--color--white-alpha-800);
-	--dialog--overlay--color--background--dark: var(--color--slate-alpha-700);
+	--dialog--overlay--color--background--dark: var(--color--neutral-800-alpha-100);
 	--block-ui--overlay--color: var(--color--neutral-950);
 
 	// Avatar

--- a/packages/frontend/editor-ui/src/app/components/MainSidebar.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainSidebar.vue
@@ -610,7 +610,7 @@ onClickOutside(createBtn as Ref<VueInstance>, () => {
 	flex-direction: column;
 	border-right: var(--border-width) var(--border-style) var(--color--foreground);
 	width: $sidebar-expanded-width;
-	background-color: var(--menu--color--background, var(--color--background--light-3));
+	background-color: var(--menu--color--background, var(--color--background--light-1));
 
 	.logo {
 		display: flex;

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -2115,7 +2115,7 @@ onBeforeUnmount(() => {
 			</Suspense>
 			<Suspense>
 				<LazyNodeDetailsView
-					v-if="false"
+					v-if="!isNDVV2"
 					:workflow-object="editableWorkflowObject"
 					:read-only="isCanvasReadOnly"
 					:is-production-execution-preview="isProductionExecutionPreview"
@@ -2129,7 +2129,7 @@ onBeforeUnmount(() => {
 			</Suspense>
 			<Suspense>
 				<LazyNodeDetailsViewV2
-					v-if="true"
+					v-if="isNDVV2"
 					:workflow-object="editableWorkflowObject"
 					:read-only="isCanvasReadOnly"
 					:is-production-execution-preview="isProductionExecutionPreview"

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -2115,7 +2115,7 @@ onBeforeUnmount(() => {
 			</Suspense>
 			<Suspense>
 				<LazyNodeDetailsView
-					v-if="!isNDVV2"
+					v-if="false"
 					:workflow-object="editableWorkflowObject"
 					:read-only="isCanvasReadOnly"
 					:is-production-execution-preview="isProductionExecutionPreview"
@@ -2129,7 +2129,7 @@ onBeforeUnmount(() => {
 			</Suspense>
 			<Suspense>
 				<LazyNodeDetailsViewV2
-					v-if="isNDVV2"
+					v-if="true"
 					:workflow-object="editableWorkflowObject"
 					:read-only="isCanvasReadOnly"
 					:is-production-execution-preview="isProductionExecutionPreview"

--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/PanelDragButton.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/PanelDragButton.vue
@@ -75,7 +75,7 @@ const onDragStart = () => {
 	pointer-events: all;
 }
 .dragButton {
-	background-color: var(--color--background);
+	background-color: var(--ndv--header--color);
 	width: 64px;
 	height: 21px;
 	border-top-left-radius: var(--radius);

--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/PanelDragButtonV2.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/PanelDragButtonV2.vue
@@ -52,7 +52,7 @@ const onDragStart = () => {
 	cursor: ew-resize;
 	border: none;
 	outline: none;
-	background: var(--color--background--light-3);
+	background: var(--ndv--background--color);
 
 	display: flex;
 	align-items: baseline;

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
@@ -832,7 +832,7 @@ function handleSelectAction(params: INodeParameters) {
 
 <style lang="scss" module>
 .header {
-	background-color: var(--color--background);
+	background-color: var(--ndv--header--color);
 }
 
 .featureRequest {

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
@@ -857,7 +857,7 @@ function handleSelectAction(params: INodeParameters) {
 	display: flex;
 	flex-direction: column;
 	overflow: hidden;
-	background-color: var(--color--background--light-3);
+	background-color: var(--ndv--background--color);
 	height: 100%;
 	width: 100%;
 

--- a/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsViewV2.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsViewV2.vue
@@ -926,6 +926,7 @@ onBeforeUnmount(() => {
 }
 
 .header {
+	background-color: var(--ndv--background--color);
 	border-bottom: var(--border);
 	border-top-left-radius: var(--radius--lg);
 	border-top-right-radius: var(--radius--lg);


### PR DESCRIPTION

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Refinements to the new dark mode, including:
- Darker sidebar to reduce contrast with sidebar and match canvas header
- Darker sticky notes in darkmode
- Rework old NDV background colors
- Sidebar menuitem status colors (Active, Hover)

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/DS-301/eng-dark-mode-refinments

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Darken sticky notes and sidebar in dark mode, introduce NDV-specific background/header tokens, and tweak menu item hover/active styles.
> 
> - **Design tokens (dark theme)**
>   - Adjust `foreground`/`background` scales and menu background (`--menu--color--background: neutral-900`).
>   - Darken sticky colors and all sticky variants; deepen `--color--red-950`.
>   - Add NDV tokens: `--ndv--background--color`, `--ndv--header--color` (dark and light themes).
>   - Update callouts (info/danger) background and border colors.
> - **Design-system components**
>   - `N8nSticky`: simplify styles (remove gradient overlay); use updated sticky tokens.
>   - `N8nMenuItem`: move `id` prop on `N8nRoute`; change hover to `:not(.active)` with lighter background; active icon color to `--color--text--shade-1`.
> - **Editor UI**
>   - `MainSidebar`: use `--menu--color--background` (fallback `--color--background--light-1`).
>   - NDV: apply new NDV tokens across header, drag buttons, settings, and modal header (`PanelDragButton*`, `NodeSettings`, `NodeDetailsViewV2`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit effd2869ca576d00458a296fcaee36b12e79abbd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->