### PR TITLE
chore: Reword the hint for the intermediateSteps field in set metrics node

### DIFF
--- a/packages/nodes-base/nodes/Evaluation/Evaluation/Description.node.ts
+++ b/packages/nodes-base/nodes/Evaluation/Evaluation/Description.node.ts
@@ -338,7 +338,7 @@ const toolsUsedFields: INodeProperties[] = [
 		name: 'intermediateSteps',
 		type: 'string',
 		default: '',
-		hint: 'The output field of the agent containing the tools called. To see it, enable returning intermediate steps in the agent’s options',
+		hint: 'Map the <code>intermediateSteps</code> field here. To see it, enable returning intermediate steps in the agent’s options',
 		displayOptions: {
 			show: {
 				operation: ['setMetrics'],


### PR DESCRIPTION
## Summary

Quick change to reword the hint for the `intermediateSteps` field on the set metrics operation in the evaluation node.

<img width="426" height="123" alt="image" src="https://github.com/user-attachments/assets/da7a5b3a-c144-488c-a90f-16b17c19c6db" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-1696/rename-output-field-in-evaluation-node-to-intermediate-steps-field

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Rewords the `toolsUsed` metric’s `intermediateSteps` hint to explicitly instruct mapping the `intermediateSteps` field.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4f6fb861bb61dd39dc509e15f5faa8e1cbd06bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->