### PR TITLE
feat(editor): Add missing doc url from backend response. remove feature flag

### DIFF
--- a/packages/cli/src/modules/breaking-changes/breaking-changes.service.ts
+++ b/packages/cli/src/modules/breaking-changes/breaking-changes.service.ts
@@ -147,6 +147,7 @@ export class BreakingChangeService {
 					ruleTitle: rule.getMetadata().title,
 					ruleDescription: rule.getMetadata().description,
 					ruleSeverity: rule.getMetadata().severity,
+					ruleDocumentationUrl: rule.getMetadata().documentationUrl,
 					affectedWorkflows: workflowResults,
 					recommendations: await rule.getRecommendations(workflowResults),
 				});

--- a/packages/frontend/editor-ui/src/app/constants/experiments.ts
+++ b/packages/frontend/editor-ui/src/app/constants/experiments.ts
@@ -87,10 +87,6 @@ export const SSO_JUST_IN_TIME_PROVSIONING_EXPERIMENT = {
 	name: '050_sso_jit_provisioning',
 };
 
-export const MIGRATION_REPORT_EXPERIMENT = {
-	name: '052_migration_report',
-};
-
 export const EXPERIMENTS_TO_TRACK = [
 	EXTRA_TEMPLATE_LINKS_EXPERIMENT.name,
 	TEMPLATE_ONBOARDING_EXPERIMENT.name,

--- a/packages/frontend/editor-ui/src/app/router.ts
+++ b/packages/frontend/editor-ui/src/app/router.ts
@@ -16,7 +16,6 @@ import {
 	VIEWS,
 	EDITABLE_CANVAS_VIEWS,
 	SSO_JUST_IN_TIME_PROVSIONING_EXPERIMENT,
-	MIGRATION_REPORT_EXPERIMENT,
 } from '@/app/constants';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { middleware } from '@/app/utils/rbac/middleware';
@@ -580,14 +579,10 @@ export const routes: RouteRecordRaw[] = [
 					},
 				],
 				meta: {
-					middleware: ['authenticated', 'rbac', 'custom'],
+					middleware: ['authenticated', 'rbac'],
 					middlewareOptions: {
 						rbac: {
 							scope: ['breakingChanges:list'],
-						},
-						custom: () => {
-							const posthogStore = usePostHog();
-							return posthogStore.isFeatureEnabled(MIGRATION_REPORT_EXPERIMENT.name);
 						},
 					},
 					telemetry: {

--- a/packages/frontend/editor-ui/src/features/settings/migrationReport/MigrationRules.vue
+++ b/packages/frontend/editor-ui/src/features/settings/migrationReport/MigrationRules.vue
@@ -216,7 +216,14 @@ const compatibleWorkflowsCount = computed(() => {
 						</div>
 						<N8nText tag="p" color="text-base">
 							{{ issue.ruleDescription }}
-							<N8nLink theme="text" underline href="#">
+							<N8nLink
+								v-if="issue.ruleDocumentationUrl"
+								theme="text"
+								underline
+								:href="issue.ruleDocumentationUrl"
+								target="_blank"
+								rel="noopener noreferrer"
+							>
 								<u :class="$style.NoLineBreak">
 									{{ i18n.baseText('settings.migrationReport.documentation') }}
 									<N8nIcon icon="external-link" />


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR removes the feature flag for the migration report, because official doc is published, so the page can already be visible.
It also fixes an issue with missing documentation url on the page

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-4124/remove-feature-flag


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
