### PR TITLE
feat: Update upgrade wording for variables

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -3230,7 +3230,7 @@
 	"contextual.workflows.sharing.unavailable.description.tooltip.cloud": "You can collaborate with others on workflows when you upgrade your plan. {action}",
 	"contextual.workflows.sharing.unavailable.button": "View plans",
 	"contextual.workflows.sharing.unavailable.button.cloud": "Upgrade now",
-	"contextual.variables.unavailable.title": "Available on the Enterprise plan",
+	"contextual.variables.unavailable.title": "Upgrade to unlock variables",
 	"contextual.variables.unavailable.title.cloud": "Available on Pro plan",
 	"contextual.variables.unavailable.description": "Variables can be used to store and access data across workflows. Reference them in n8n using the prefix <code>$vars</code> (e.g. <code>$vars.myVariable</code>). Variables are immutable and cannot be modified within your workflows.<br/><a href=\"https://docs.n8n.io/code/variables/\" target=\"_blank\">Learn more in the docs.</a>",
 	"contextual.variables.unavailable.button": "View plans",

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/views/ProjectVariables.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/views/ProjectVariables.vue
@@ -280,7 +280,6 @@ sourceControlStore.$onAction(({ name, after }) => {
 });
 
 const unavailableNoticeProps = computed(() => ({
-	emoji: '👋',
 	heading: i18n.baseText(uiStore.contextBasedTranslationKeys.variables.unavailable.title),
 	description: i18n.baseText(uiStore.contextBasedTranslationKeys.variables.unavailable.description),
 	buttonText: i18n.baseText(uiStore.contextBasedTranslationKeys.variables.unavailable.button),
@@ -391,7 +390,6 @@ onMounted(() => {
 			<N8nActionBox
 				v-else-if="!canCreateVariables"
 				data-test-id="cannot-create-variables"
-				emoji="👋"
 				:heading="
 					i18n.baseText('variables.empty.notAllowedToCreate.heading', {
 						interpolate: { name: usersStore.currentUser?.firstName ?? '' },


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR updates wording for the variables upgrade window, and removes the emoji:

<img width="1493" height="747" alt="image" src="https://github.com/user-attachments/assets/99e09ae1-4daa-4842-9a18-4ae8194d42f3" />

## Related Linear tickets, Github issues, and Community forum posts

PAY-4102

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
