### PR TITLE
fix(editor): Fixing tag style on canvas

### DIFF
--- a/packages/frontend/editor-ui/src/features/shared/tags/components/TagsContainer.vue
+++ b/packages/frontend/editor-ui/src/features/shared/tags/components/TagsContainer.vue
@@ -167,6 +167,11 @@ onBeforeUnmount(() => {
 	visibility: hidden;
 }
 
+.tags {
+	display: flex;
+	gap: var(--spacing--4xs);
+}
+
 .count-container {
 	position: absolute;
 	max-width: 40px;

--- a/packages/frontend/editor-ui/src/features/shared/tags/components/TagsContainer.vue
+++ b/packages/frontend/editor-ui/src/features/shared/tags/components/TagsContainer.vue
@@ -7,7 +7,8 @@ import IntersectionObserved from '@/app/components/IntersectionObserved.vue';
 import { createEventBus } from '@n8n/utils/event-bus';
 import debounce from 'lodash/debounce';
 
-import { ElTag } from 'element-plus';
+import { N8nTag } from '@n8n/design-system';
+
 interface TagsContainerProps {
 	tagIds: string[];
 	tagsById: { [id: string]: ITag };
@@ -137,16 +138,13 @@ onBeforeUnmount(() => {
 				:class="{ clickable: !tag.hidden }"
 				@click="(e) => onClick(e, tag)"
 			>
-				<ElTag
+				<N8nTag
 					v-if="tag.isCount"
 					:title="tag.title"
-					type="info"
-					size="small"
+					:text="tag.name"
+					:clickable="false"
 					class="count-container"
-					:disable-transitions="true"
-				>
-					{{ tag.name }}
-				</ElTag>
+				/>
 				<IntersectionObserved
 					v-else
 					:class="{ hideTag: tag.hidden }"
@@ -154,15 +152,12 @@ onBeforeUnmount(() => {
 					:enabled="responsive"
 					:event-bus="intersectionEventBus"
 				>
-					<ElTag
+					<N8nTag
 						:title="tag.name"
-						type="info"
-						size="small"
+						:text="tag.name"
+						:clickable="clickable"
 						:class="{ hoverable }"
-						:disable-transitions="true"
-					>
-						{{ tag.name }}
-					</ElTag>
+					/>
 				</IntersectionObserved>
 			</span>
 		</span>
@@ -175,23 +170,8 @@ onBeforeUnmount(() => {
 	max-width: 300px;
 }
 
-.tags {
-	display: block;
-	white-space: nowrap;
-	overflow: hidden;
-	max-width: 100%;
-
-	> span {
-		padding-right: 4px; // why not margin? for space between tags to be clickable
-	}
-}
-
 .hideTag {
 	visibility: hidden;
-}
-
-.el-tag.hoverable:hover {
-	border-color: $color-primary;
 }
 
 .count-container {

--- a/packages/frontend/editor-ui/src/features/shared/tags/components/TagsContainer.vue
+++ b/packages/frontend/editor-ui/src/features/shared/tags/components/TagsContainer.vue
@@ -15,14 +15,12 @@ interface TagsContainerProps {
 	limit?: number;
 	clickable?: boolean;
 	responsive?: boolean;
-	hoverable?: boolean;
 }
 
 const props = withDefaults(defineProps<TagsContainerProps>(), {
 	limit: 20,
 	clickable: false,
 	responsive: false,
-	hoverable: false,
 });
 
 const emit = defineEmits<{
@@ -81,8 +79,8 @@ const tags = computed(() => {
 
 // Methods
 const setMaxWidth = () => {
-	const container = tagsContainer.value?.$el as HTMLElement;
-	const parent = container?.parentNode as HTMLElement;
+	const container = (tagsContainer.value as { $el?: HTMLElement })?.$el;
+	const parent = container?.parentNode as HTMLElement | null;
 
 	if (parent) {
 		maxWidth.value = 0;
@@ -152,12 +150,7 @@ onBeforeUnmount(() => {
 					:enabled="responsive"
 					:event-bus="intersectionEventBus"
 				>
-					<N8nTag
-						:title="tag.name"
-						:text="tag.name"
-						:clickable="clickable"
-						:class="{ hoverable }"
-					/>
+					<N8nTag :title="tag.name" :text="tag.name" :clickable="clickable" />
 				</IntersectionObserved>
 			</span>
 		</span>

--- a/packages/frontend/editor-ui/src/features/shared/tags/components/TagsDropdown.vue
+++ b/packages/frontend/editor-ui/src/features/shared/tags/components/TagsDropdown.vue
@@ -9,6 +9,7 @@ import { v4 as uuid } from 'uuid';
 import { useToast } from '@/app/composables/useToast';
 
 import { N8nIcon, N8nOption, N8nSelect } from '@n8n/design-system';
+
 interface TagsDropdownProps {
 	placeholder: string;
 	modelValue: string[];
@@ -286,17 +287,24 @@ onClickOutside(
 
 	.el-tag,
 	.el-tag.el-tag--info {
-		padding: var(--spacing--5xs) var(--spacing--4xs);
-		color: var(--color--text);
-		background-color: var(--color--background);
-		border-radius: var(--radius);
-		font-size: var(--font-size--2xs);
-		border: 0;
+		height: var(--tag--height);
+		padding: var(--tag--padding);
+		line-height: var(--tag--line-height);
+		color: var(--tag--color--text);
+		background-color: var(--tag--color--background);
+		border: 1px solid var(--tag--border-color);
+		border-radius: var(--tag--radius);
+		font-size: var(--tag--font-size);
 
 		.el-tag__close {
 			max-height: 14px;
 			max-width: 14px;
 			line-height: 14px;
+
+			&:hover {
+				background-color: transparent !important;
+				color: var(--color--primary--shade-1);
+			}
 		}
 	}
 }

--- a/packages/frontend/editor-ui/src/features/shared/tags/components/WorkflowTagsContainer.vue
+++ b/packages/frontend/editor-ui/src/features/shared/tags/components/WorkflowTagsContainer.vue
@@ -9,7 +9,6 @@ interface Props {
 	limit?: number;
 	clickable?: boolean;
 	responsive?: boolean;
-	hoverable?: boolean;
 }
 
 defineProps<Props>();
@@ -34,7 +33,6 @@ function onClick(tagId: string) {
 		:limit="limit"
 		:clickable="clickable"
 		:responsive="responsive"
-		:hoverable="hoverable"
 		@click="onClick"
 	/>
 </template>


### PR DESCRIPTION
## Summary

This PR addresses: https://linear.app/n8n/issue/AI-1695/tag-styles-broken-in-canvas-header

The tags on the canvas used an old tag component, updating to use the `N8nTag` component instead - this matches the tags on the workflow list now.


## Screenshots
On canvas:
<img width="699" height="60" alt="image" src="https://github.com/user-attachments/assets/324f88a5-8308-4269-94cf-3354bc788ead" />

Multiple:
<img width="732" height="59" alt="image" src="https://github.com/user-attachments/assets/92271e6a-5067-42d9-ac6c-6c390dbf7acc" />

On workflow list:
<img width="454" height="59" alt="image" src="https://github.com/user-attachments/assets/dc15ee95-1cce-435f-917b-4f8edcc4a642" />

Also fixing tag dropdown for selecting:
<img width="500" height="232" alt="image" src="https://github.com/user-attachments/assets/b4eb9d40-07cd-47d5-9d62-8f68ac22949d" />

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrate tag UI to `N8nTag` and align tag styles/behavior across the editor, removing legacy props and updating layout/styling.
> 
> - **Editor UI – Tags**:
>   - **TagsContainer (`TagsContainer.vue`)**:
>     - Replace `ElTag` with `N8nTag` for regular and count tags; pass `text`, `clickable` accordingly.
>     - Remove `hoverable` prop and related classes.
>     - Tweak width calculation typing and make tag list layout flex with gaps.
>   - **WorkflowTagsContainer (`WorkflowTagsContainer.vue`)**:
>     - Drop `hoverable` prop passthrough.
>   - **TagsDropdown (`TagsDropdown.vue`)**:
>     - Update `.el-tag` styling to design-system tag variables and adjust close hover behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88cbfe210f3c91659c448ad75ddc2614f52a5204. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->