### PR TITLE
chore: Run evals in CI on schedule

### DIFF
--- a/.github/workflows/ci-evals.yml
+++ b/.github/workflows/ci-evals.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - 'packages/@n8n/ai-workflow-builder.ee/**'
       - '.github/workflows/ci-evals.yml'
+  schedule:
+    - cron: '0 22 * * 6'
   workflow_dispatch:
     inputs:
       branch:
@@ -27,11 +29,20 @@ jobs:
       LANGSMITH_TRACING: true
       LANGSMITH_ENDPOINT: ${{ secrets.EVALS_LANGSMITH_ENDPOINT }}
       LANGSMITH_API_KEY: ${{ secrets.EVALS_LANGSMITH_API_KEY }}
-      LANGSMITH_DATASET_NAME: ${{ github.event.inputs.dataset || 'workflow-builder-canvas-prompts' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.inputs.branch || github.ref }}
+
+      - name: Select dataset
+        run: |
+          DATASET="workflow-builder-canvas-prompts"
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            DATASET="prompts-v2"
+          elif [ -n "${{ github.event.inputs.dataset }}" ]; then
+            DATASET="${{ github.event.inputs.dataset }}"
+          fi
+          echo "LANGSMITH_DATASET_NAME=$DATASET" >> "$GITHUB_ENV"
 
       - name: Setup and Build
         uses: ./.github/actions/setup-nodejs-blacksmith


### PR DESCRIPTION
## Summary

Run workflow builder evals using the large prompts dataset on schedule

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a weekly scheduled run and dynamically selects the LangSmith dataset instead of a hardcoded env var.
> 
> - **CI (GitHub Actions)**:
>   - **Scheduling**: Add weekly cron trigger (`0 22 * * 6`) to run evals.
>   - **Dataset selection**: Replace hardcoded `LANGSMITH_DATASET_NAME` env with a step that sets it dynamically:
>     - Uses `prompts-v2` on scheduled runs, otherwise uses input `dataset` if provided, else defaults to `workflow-builder-canvas-prompts`.
>   - Retains push and manual dispatch triggers; build and eval steps unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f5143dab703e69a9e4ea32657dd542c22b8b58a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->