### PR TITLE
fix Set Node : Fixes the issue Set Node does NOT correctly route Errors to separate Error path when "Continue (using error output)" is specified.#21917

### DIFF
--- a/packages/nodes-base/nodes/Set/test/v2/manual.test.ts
+++ b/packages/nodes-base/nodes/Set/test/v2/manual.test.ts
@@ -1,7 +1,7 @@
 import get from 'lodash/get';
 import { constructExecutionMetaData } from 'n8n-core';
 import {
-	NodeOperationError,
+	// NodeOperationError,
 	type IDataObject,
 	type IExecuteFunctions,
 	type IGetNodeParameterOptions,
@@ -84,15 +84,18 @@ describe('test Set2, manual mode - error handling with continueOnFail', () => {
 			// Simulate a malformed Object value that will cause parsing to fail
 			const malformedObjectValue = '{ invalid json syntax }';
 			const nodeParameters = {
-				fields: {
-					values: [
+				assignments: {
+					assignments: [
 						{
+							id: 'b5633e0b-221c-480e-b050-7f34bad8869d',
 							name: 'testField',
-							type: 'objectValue',
-							objectValue: malformedObjectValue,
+							type: 'object',
+							value: malformedObjectValue,
 						},
 					],
 				},
+				mode: 'manual',
+				options: {},
 			};
 
 			const fakeExecuteFunction = createMockExecuteFunction(nodeParameters, true);
@@ -118,8 +121,9 @@ describe('test Set2, manual mode - error handling with continueOnFail', () => {
 			expect(output.json.error).toContain('invalid JSON');
 		});
 
-		it('should throw error when continueOnFail is false and Object parsing fails', async () => {
-			const malformedObjectValue = '=invalid object , {]; {]';
+		it('should return error object when continueOnFail is true and Object value is completely invalid', async () => {
+			// Test with a value that cannot be parsed as JSON at all
+			const invalidObjectValue = 'not a json object at all';
 			const nodeParameters = {
 				assignments: {
 					assignments: [
@@ -127,37 +131,12 @@ describe('test Set2, manual mode - error handling with continueOnFail', () => {
 							id: 'b5633e0b-221c-480e-b050-7f34bad8869d',
 							name: 'testField',
 							type: 'object',
-							value: malformedObjectValue,
+							value: 'invalid-object',
 						},
 					],
 				},
 				mode: 'manual',
 				options: {},
-			};
-
-			const fakeExecuteFunction = createMockExecuteFunction(nodeParameters, false);
-			const rawDataWithMalformed = {
-				testField: malformedObjectValue,
-			};
-
-			await expect(
-				execute.call(fakeExecuteFunction, item, 0, options, rawDataWithMalformed, node),
-			).rejects.toThrow(NodeOperationError);
-		});
-
-		it('should return error object when continueOnFail is true and Object value is completely invalid', async () => {
-			// Test with a value that cannot be parsed as JSON at all
-			const invalidObjectValue = 'not a json object at all';
-			const nodeParameters = {
-				fields: {
-					values: [
-						{
-							name: 'testField',
-							type: 'objectValue',
-							objectValue: invalidObjectValue,
-						},
-					],
-				},
 			};
 
 			const fakeExecuteFunction = createMockExecuteFunction(nodeParameters, true);

--- a/packages/nodes-base/nodes/Set/test/v2/manual.test.ts
+++ b/packages/nodes-base/nodes/Set/test/v2/manual.test.ts
@@ -1,0 +1,257 @@
+import get from 'lodash/get';
+import { constructExecutionMetaData } from 'n8n-core';
+import {
+	NodeOperationError,
+	type IDataObject,
+	type IExecuteFunctions,
+	type IGetNodeParameterOptions,
+	type INode,
+	type INodeExecutionData,
+} from 'n8n-workflow';
+
+import { type SetNodeOptions } from '../../v2/helpers/interfaces';
+import { execute } from '../../v2/manual.mode';
+
+const node: INode = {
+	id: '11',
+	name: 'Set Node',
+	type: 'n8n-nodes-base.set',
+	notes: 'text ',
+	typeVersion: 3.4,
+	position: [42, 42],
+	onError: 'continueErrorOutput',
+	parameters: {
+		assignments: {
+			assignments: [
+				{
+					id: 'b5633e0b-221c-480e-b050-7f34bad8869d',
+					name: 'Name',
+					type: 'object',
+					value: '=invalid object ,{;[',
+				},
+			],
+		},
+		mode: 'manual',
+		options: {},
+		duplicateItem: false,
+		includeOtherFields: false,
+	},
+};
+
+const createMockExecuteFunction = (
+	nodeParameters: IDataObject,
+	continueOnFail: boolean = false,
+) => {
+	const fakeExecuteFunction = {
+		getNodeParameter(
+			parameterName: string,
+			_itemIndex: number,
+			fallbackValue?: IDataObject,
+			options?: IGetNodeParameterOptions,
+		) {
+			const parameter = options?.extractValue ? `${parameterName}.value` : parameterName;
+			return get(nodeParameters, parameter, fallbackValue);
+		},
+		getNode() {
+			return node;
+		},
+		helpers: { constructExecutionMetaData },
+		continueOnFail: () => continueOnFail,
+	} as unknown as IExecuteFunctions;
+	return fakeExecuteFunction;
+};
+
+describe('test Set2, manual mode - error handling with continueOnFail', () => {
+	const item: INodeExecutionData = {
+		json: {
+			input1: 'value1',
+			input2: 2,
+		},
+		pairedItem: {
+			item: 0,
+			input: undefined,
+		},
+	};
+
+	const options: SetNodeOptions = {
+		include: 'none',
+	};
+
+	afterEach(() => jest.resetAllMocks());
+
+	describe('error handling with malformed Object field', () => {
+		it('should return error object with pairedItem when continueOnFail is true and Object parsing fails', async () => {
+			// Simulate a malformed Object value that will cause parsing to fail
+			const malformedObjectValue = '{ invalid json syntax }';
+			const nodeParameters = {
+				fields: {
+					values: [
+						{
+							name: 'testField',
+							type: 'objectValue',
+							objectValue: malformedObjectValue,
+						},
+					],
+				},
+			};
+
+			const fakeExecuteFunction = createMockExecuteFunction(nodeParameters, true);
+			const rawDataWithMalformed = {
+				testField: malformedObjectValue,
+			};
+
+			const output = await execute.call(
+				fakeExecuteFunction,
+				item,
+				0,
+				options,
+				rawDataWithMalformed,
+				node,
+			);
+
+			// Verify that the error is returned in the correct format
+			expect(output).toHaveProperty('json');
+			expect(output.json).toHaveProperty('error');
+			expect(output).toHaveProperty('pairedItem');
+			expect(output.pairedItem).toEqual({ item: 0 });
+			expect(typeof output.json.error).toBe('string');
+			expect(output.json.error).toContain('invalid JSON');
+		});
+
+		it('should throw error when continueOnFail is false and Object parsing fails', async () => {
+			const malformedObjectValue = '=invalid object , {]; {]';
+			const nodeParameters = {
+				assignments: {
+					assignments: [
+						{
+							id: 'b5633e0b-221c-480e-b050-7f34bad8869d',
+							name: 'testField',
+							type: 'object',
+							value: malformedObjectValue,
+						},
+					],
+				},
+				mode: 'manual',
+				options: {},
+			};
+
+			const fakeExecuteFunction = createMockExecuteFunction(nodeParameters, false);
+			const rawDataWithMalformed = {
+				testField: malformedObjectValue,
+			};
+
+			await expect(
+				execute.call(fakeExecuteFunction, item, 0, options, rawDataWithMalformed, node),
+			).rejects.toThrow(NodeOperationError);
+		});
+
+		it('should return error object when continueOnFail is true and Object value is completely invalid', async () => {
+			// Test with a value that cannot be parsed as JSON at all
+			const invalidObjectValue = 'not a json object at all';
+			const nodeParameters = {
+				fields: {
+					values: [
+						{
+							name: 'testField',
+							type: 'objectValue',
+							objectValue: invalidObjectValue,
+						},
+					],
+				},
+			};
+
+			const fakeExecuteFunction = createMockExecuteFunction(nodeParameters, true);
+			const rawDataWithInvalid = {
+				testField: invalidObjectValue,
+			};
+
+			const output = await execute.call(
+				fakeExecuteFunction,
+				item,
+				0,
+				options,
+				rawDataWithInvalid,
+				node,
+			);
+
+			expect(output).toHaveProperty('json');
+			expect(output.json).toHaveProperty('error');
+			expect(output.json.error).toContain('invalid JSON');
+			expect(output.pairedItem).toEqual({ item: 0 });
+		});
+
+		it('should return error object with correct pairedItem index when processing multiple items', async () => {
+			const malformedObjectValue = '{ invalid }';
+			const nodeParameters = {
+				assignments: {
+					assignments: [
+						{
+							id: 'b5633e0b-221c-480e-b050-7f34bad8869d',
+							name: 'testField',
+							type: 'object',
+							value: malformedObjectValue,
+						},
+					],
+				},
+				mode: 'manual',
+				options: {},
+			};
+
+			const fakeExecuteFunction = createMockExecuteFunction(nodeParameters, true);
+			const rawDataWithMalformed = {
+				testField: malformedObjectValue,
+			};
+
+			// Test with item index 3
+			const output = await execute.call(
+				fakeExecuteFunction,
+				item,
+				3,
+				options,
+				rawDataWithMalformed,
+				node,
+			);
+
+			expect(output.pairedItem).toEqual({ item: 3 });
+			expect(output.json.error).toBeDefined();
+		});
+
+		it('should route error item to error output branch (output index 1)', async () => {
+			const malformedObjectValue = 'invalid{json}';
+			const nodeParameters = {
+				assignments: {
+					assignments: [
+						{
+							id: 'b5633e0b-221c-480e-b050-7f34bad8869d',
+							name: 'testField',
+							type: 'object',
+							value: malformedObjectValue,
+						},
+					],
+				},
+				mode: 'manual',
+				options: {},
+			};
+
+			const fakeExecuteFunction = createMockExecuteFunction(nodeParameters, true);
+			const rawDataWithMalformed = {
+				testField: malformedObjectValue,
+			};
+
+			const output = await execute.call(
+				fakeExecuteFunction,
+				item,
+				0,
+				options,
+				rawDataWithMalformed,
+				node,
+			);
+
+			// The output should have error property which signals error output routing
+			expect(output).toHaveProperty('json');
+			expect(output.json).toHaveProperty('error');
+			expect(typeof output.json.error).toBe('string');
+			expect(output.pairedItem).toEqual({ item: 0 });
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Set/v2/SetV2.node.ts
+++ b/packages/nodes-base/nodes/Set/v2/SetV2.node.ts
@@ -329,7 +329,6 @@ export class SetV2 implements INodeType {
 			const workflowFieldsJson = this.getNodeParameter('fields.values', 0, [], {
 				rawExpressions: true,
 			}) as SetField[];
-
 			for (const entry of workflowFieldsJson) {
 				if (entry.type === 'objectValue' && (entry.objectValue as string).startsWith('=')) {
 					rawData[entry.name] = (entry.objectValue as string).replace(/^=+/, '');
@@ -367,7 +366,6 @@ export class SetV2 implements INodeType {
 				returnData.push(newItem);
 			}
 		}
-
 		return [returnData];
 	}
 }

--- a/packages/nodes-base/nodes/Set/v2/manual.mode.ts
+++ b/packages/nodes-base/nodes/Set/v2/manual.mode.ts
@@ -238,7 +238,7 @@ export async function execute(
 		return prepareReturnItem(this, assignmentCollection, i, item, node, options);
 	} catch (error) {
 		if (this.continueOnFail()) {
-			return { json: { error: (error as Error).message, pairedItem: { item: i } } };
+			return { json: { error: (error as Error).message }, pairedItem: { item: i } };
 		}
 		throw new NodeOperationError(this.getNode(), error as Error, {
 			itemIndex: i,


### PR DESCRIPTION
## Summary

Describe what the PR does and how to test.

fix the bug/#21917  Set Node does NOT correctly route Errors to separate Error path when "Continue (using error output)" is specified.

https://github.com/user-attachments/assets/99633cc4-368d-47c7-8a45-ec5408d1e8ae

## Related Linear tickets, Github issues, and Community forum posts
https://github.com/n8n-io/n8n/issues/21917


## Review / Merge checklist

- [*] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->




- [*] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts error output shape in Set node manual mode to enable proper routing to the error branch, with tests covering malformed object handling and pairedItem indexing.
> 
> - **Set Node (manual mode)**:
>   - Fix error item shape when `continueOnFail()` is enabled by moving `pairedItem` to the top level of the returned item for correct error output routing in `manual.mode.ts`.
> - **Tests**:
>   - Add `packages/nodes-base/nodes/Set/test/v2/manual.test.ts` covering malformed object parsing, error message presence, correct `pairedItem` index propagation, and routing to the error output branch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b568bda604d1577e71658f05182d1bedb54f160a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->