### PR TITLE
ci: Ignore release branches for chromatic ci workflow (no-changelog)

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -36,7 +36,6 @@ jobs:
         github.event_name == 'pull_request_review' &&
         needs.changeset.outputs.has_changes == 'true' &&
         github.event.review.state == 'approved' &&
-        !contains(github.event.pull_request.labels.*.name, 'community') &&
         !startsWith(github.event.pull_request.head.ref, 'release/') &&
         !startsWith(github.event.pull_request.head.ref, 'release-pr/')
       )

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -36,7 +36,9 @@ jobs:
         github.event_name == 'pull_request_review' &&
         needs.changeset.outputs.has_changes == 'true' &&
         github.event.review.state == 'approved' &&
-        !contains(github.event.pull_request.labels.*.name, 'community')
+        !contains(github.event.pull_request.labels.*.name, 'community') &&
+        !startsWith(github.event.pull_request.head.ref, 'release/') &&
+        !startsWith(github.event.pull_request.head.ref, 'release-pr/')
       )
     runs-on: blacksmith-2vcpu-ubuntu-2204
     steps:


### PR DESCRIPTION
## Summary

This pull request updates the workflow conditions in `.github/workflows/chromatic.yml` to prevent certain release-related pull requests from triggering the Chromatic job. The main change is the addition of checks to exclude branches that start with `release/` or `release-pr/` from running the job.

Workflow condition updates:

* Added checks to ensure the Chromatic job does not run for pull requests with head branches starting with `release/` or `release-pr/` (`.github/workflows/chromatic.yml`)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1762/ignore-release-branches-for-chromatic-ci-workflow

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
