### PR TITLE
fix: In queue mode "Respond to Webhook" node returns 500 when there is an error in the execution 

### DIFF
--- a/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
@@ -12,6 +12,7 @@ import {
 	Workflow,
 	type IRunExecutionData,
 	type WorkflowExecuteMode,
+	type ExecutionError,
 } from 'n8n-workflow';
 
 import { JobProcessor } from '../job-processor';
@@ -124,6 +125,54 @@ describe('JobProcessor', () => {
 			);
 		},
 	);
+
+	it('should send job-finished with success=false when execution has errors', async () => {
+		const executionRepository = mock<ExecutionRepository>();
+		// First call: initial execution fetch (no error yet)
+		executionRepository.findSingleExecution.mockResolvedValueOnce(
+			mock<IExecutionResponse>({
+				mode: 'manual',
+				workflowData: { nodes: [] },
+				data: mock<IRunExecutionData>({
+					executionData: undefined,
+				}),
+			}),
+		);
+		// Second call: after execution completes, fetch again to check for errors
+		executionRepository.findSingleExecution.mockResolvedValueOnce(
+			mock<IExecutionResponse>({
+				status: 'error',
+				data: {
+					resultData: {
+						error: mock<ExecutionError>(),
+					},
+				},
+			}),
+		);
+
+		const manualExecutionService = mock<ManualExecutionService>();
+		const jobProcessor = new JobProcessor(
+			logger,
+			executionRepository,
+			mock(),
+			mock(),
+			mock(),
+			manualExecutionService,
+			executionsConfig,
+			mock(),
+		);
+
+		const job = mock<Job>();
+
+		await jobProcessor.processJob(job);
+
+		expect(job.progress).toHaveBeenCalledWith(
+			expect.objectContaining({
+				kind: 'job-finished',
+				success: false,
+			}),
+		);
+	});
 
 	it('should pass additional data for partial executions to run', async () => {
 		const executionRepository = mock<ExecutionRepository>();

--- a/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
@@ -110,9 +110,18 @@ describe('JobProcessor', () => {
 				mock(),
 			);
 
-			await jobProcessor.processJob(mock<Job>());
+			const job = mock<Job>();
+
+			await jobProcessor.processJob(job);
 
 			expect(manualExecutionService.runManually).toHaveBeenCalledTimes(1);
+
+			expect(job.progress).toHaveBeenCalledWith(
+				expect.objectContaining({
+					kind: 'job-finished',
+					success: true,
+				}),
+			);
 		},
 	);
 

--- a/packages/cli/src/scaling/__tests__/scaling.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/scaling.service.test.ts
@@ -360,6 +360,71 @@ describe('ScalingService', () => {
 				content: 'test',
 			});
 		});
+
+		it('should resolve responsePromise with empty response when job-finished has success=true', async () => {
+			const activeExecutions = mock<ActiveExecutions>();
+			scalingService = new ScalingService(
+				mockLogger(),
+				mock(),
+				activeExecutions,
+				jobProcessor,
+				globalConfig,
+				mock(),
+				instanceSettings,
+				mock(),
+			);
+
+			await scalingService.setupQueue();
+
+			const messageHandler = queue.on.mock.calls.find(
+				([event]) => (event as string) === 'global:progress',
+			)?.[1] as (jobId: JobId, msg: unknown) => void;
+
+			const jobFinishedMessage = {
+				kind: 'job-finished',
+				executionId: 'exec-123',
+				workerId: 'worker-456',
+				success: true,
+			};
+
+			messageHandler('job-789', jobFinishedMessage);
+
+			expect(activeExecutions.resolveResponsePromise).toHaveBeenCalledWith('exec-123', {});
+		});
+
+		it('should resolve responsePromise with error response when job-finished has success=false', async () => {
+			const activeExecutions = mock<ActiveExecutions>();
+			scalingService = new ScalingService(
+				mockLogger(),
+				mock(),
+				activeExecutions,
+				jobProcessor,
+				globalConfig,
+				mock(),
+				instanceSettings,
+				mock(),
+			);
+
+			await scalingService.setupQueue();
+
+			const messageHandler = queue.on.mock.calls.find(
+				([event]) => (event as string) === 'global:progress',
+			)?.[1] as (jobId: JobId, msg: unknown) => void;
+
+			const jobFinishedMessage = {
+				kind: 'job-finished',
+				executionId: 'exec-123',
+				workerId: 'worker-456',
+				success: false,
+			};
+
+			messageHandler('job-789', jobFinishedMessage);
+
+			expect(activeExecutions.resolveResponsePromise).toHaveBeenCalledWith('exec-123', {
+				body: { message: 'Workflow execution failed' },
+				statusCode: 500,
+			});
+		});
 	});
 
 	describe('recoverFromQueue', () => {

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -247,14 +247,7 @@ export class JobProcessor {
 
 		delete this.runningJobs[job.id];
 
-		const fullRunData = await this.executionRepository.findSingleExecution(executionId, {
-			includeData: true,
-			unflattenData: true,
-		});
-
-		const hasErrors =
-			fullRunData?.status === 'error' || fullRunData?.data?.resultData?.error !== undefined;
-
+		const hasErrors = await this.executionHasErrors(executionId);
 		this.logger.info(`Worker finished execution ${executionId} (job ${job.id})`, {
 			executionId,
 			workflowId,
@@ -277,6 +270,15 @@ export class JobProcessor {
 		 */
 
 		return { success: true };
+	}
+
+	private async executionHasErrors(executionId: string): Promise<boolean> {
+		const execution = await this.executionRepository.findSingleExecution(executionId, {
+			includeData: true,
+			unflattenData: true,
+		});
+
+		return execution?.status === 'error' || execution?.data?.resultData?.error !== undefined;
 	}
 
 	stopJob(jobId: JobId) {

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -324,11 +324,22 @@ export class ScalingService {
 					this.activeExecutions.resolveResponsePromise(msg.executionId, decodedResponse);
 					break;
 				case 'job-finished':
-					this.activeExecutions.resolveResponsePromise(msg.executionId, {});
-					this.logger.info(`Execution ${msg.executionId} (job ${jobId}) finished successfully`, {
+					if (msg.success) {
+						this.activeExecutions.resolveResponsePromise(msg.executionId, {});
+					} else {
+						this.activeExecutions.resolveResponsePromise(msg.executionId, {
+							body: {
+								message: 'Workflow execution failed',
+							},
+							statusCode: 500,
+						});
+					}
+
+					this.logger.info(`Execution ${msg.executionId} (job ${jobId}) finished`, {
 						workerId: msg.workerId,
 						executionId: msg.executionId,
 						jobId,
+						success: msg.success,
 					});
 					break;
 				case 'job-failed':

--- a/packages/cli/src/scaling/scaling.types.ts
+++ b/packages/cli/src/scaling/scaling.types.ts
@@ -57,6 +57,7 @@ export type JobFinishedMessage = {
 	kind: 'job-finished';
 	executionId: string;
 	workerId: string;
+	success: boolean;
 };
 
 export type SendChunkMessage = {


### PR DESCRIPTION
## Summary

Fixed response object in `job-finished` event, by returning `500` status code when the execution errored

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

fixes #17040 
fixes PAY-3218


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Propagates a `success` flag from worker to main, detecting execution errors and returning 500 for failed executions in queue-mode webhook responses, with tests added.
> 
> - **Scaling/Queue**:
>   - `JobProcessor`: detect execution errors (`executionHasErrors`), include `success` in `job-finished` progress message and logs.
>   - `ScalingService`: on `job-finished`, resolve webhook response as `{}` when `success=true`, or `{ statusCode: 500, body: { message: 'Workflow execution failed' } }` when `success=false`; include `success` in logs.
>   - Types: extend `JobFinishedMessage` with `success: boolean` in `scaling.types`.
> - **Tests**:
>   - Add/adjust tests for `job-finished` success/failure handling in `job-processor` and `scaling.service` tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1288b9ba4ead3b49392fea928f7ac8f6470c773. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->