### PR TITLE
feat(editor): Show templates experiment on empty workflows layout (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/layouts/EmptyStateLayout.vue
+++ b/packages/frontend/editor-ui/src/app/components/layouts/EmptyStateLayout.vue
@@ -10,6 +10,8 @@ import { getResourcePermissions } from '@n8n/permissions';
 import { useProjectPages } from '@/features/collaboration/projects/composables/useProjectPages';
 import { useToast } from '@/app/composables/useToast';
 import { useReadyToRunStore } from '@/features/workflows/readyToRun/stores/readyToRun.store';
+import { useTemplatesDataQualityStore } from '@/experiments/templatesDataQuality/stores/templatesDataQuality.store';
+import TemplatesDataQualityInlineSection from '@/experiments/templatesDataQuality/components/TemplatesDataQualityInlineSection.vue';
 import type { IUser } from 'n8n-workflow';
 
 const emit = defineEmits<{
@@ -24,6 +26,7 @@ const projectsStore = useProjectsStore();
 const sourceControlStore = useSourceControlStore();
 const projectPages = useProjectPages();
 const readyToRunStore = useReadyToRunStore();
+const templatesDataQualityStore = useTemplatesDataQualityStore();
 
 const isLoadingReadyToRun = ref(false);
 
@@ -51,6 +54,14 @@ const showReadyToRunCard = computed(() => {
 	return (
 		isLoadingReadyToRun.value ||
 		readyToRunStore.getCardVisibility(projectPermissions.value.workflow.create, readOnlyEnv.value)
+	);
+});
+
+const showTemplatesDataQualityInline = computed(() => {
+	return (
+		templatesDataQualityStore.isFeatureEnabled() &&
+		!readOnlyEnv.value &&
+		projectPermissions.value.workflow.create
 	);
 });
 
@@ -141,6 +152,7 @@ const addWorkflow = () => {
 					</div>
 				</N8nCard>
 			</div>
+			<TemplatesDataQualityInlineSection v-if="showTemplatesDataQualityInline" />
 		</div>
 	</div>
 </template>
@@ -150,7 +162,8 @@ const addWorkflow = () => {
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	justify-content: center;
+	justify-content: flex-start;
+	padding-top: var(--spacing--3xl);
 	min-height: 100vh;
 }
 
@@ -158,7 +171,7 @@ const addWorkflow = () => {
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	max-width: 600px;
+	max-width: 900px;
 	text-align: center;
 }
 

--- a/packages/frontend/editor-ui/src/experiments/templatesDataQuality/components/TemplatesDataQualityInlineSection.vue
+++ b/packages/frontend/editor-ui/src/experiments/templatesDataQuality/components/TemplatesDataQualityInlineSection.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
+import { useI18n } from '@n8n/i18n';
+import { N8nLink, N8nSpinner, N8nText } from '@n8n/design-system';
+import { TEMPLATES_URLS } from '@/app/constants';
+import type { ITemplatesWorkflowFull } from '@n8n/rest-api-client';
+import { useTemplatesDataQualityStore } from '../stores/templatesDataQuality.store';
+import TemplateCard from './TemplateCard.vue';
+
+const locale = useI18n();
+const templatesStore = useTemplatesDataQualityStore();
+
+const templates = ref<ITemplatesWorkflowFull[]>([]);
+const isLoadingTemplates = ref(false);
+
+onMounted(async () => {
+	isLoadingTemplates.value = true;
+	try {
+		templates.value = await templatesStore.loadExperimentTemplates();
+	} finally {
+		isLoadingTemplates.value = false;
+	}
+});
+</script>
+
+<template>
+	<section :class="$style.container" data-test-id="templates-data-quality-inline">
+		<div :class="$style.header">
+			<N8nText tag="h2" size="large" :bold="true">
+				{{ locale.baseText('workflows.empty.startWithTemplate') }}
+			</N8nText>
+			<N8nLink :href="TEMPLATES_URLS.BASE_WEBSITE_URL" :class="$style.allTemplatesLink">
+				{{ locale.baseText('workflows.templatesDataQuality.seeMoreTemplates') }}
+			</N8nLink>
+		</div>
+
+		<div v-if="isLoadingTemplates" :class="$style.loading">
+			<N8nSpinner size="small" />
+			<N8nText size="small">
+				{{ locale.baseText('workflows.templatesDataQuality.loadingTemplates') }}
+			</N8nText>
+		</div>
+		<div v-else :class="$style.suggestions">
+			<TemplateCard
+				v-for="(template, index) in templates"
+				:key="template.id"
+				:template="template"
+				:tile-number="index + 1"
+			/>
+		</div>
+	</section>
+</template>
+
+<style lang="scss" module>
+.container {
+	width: 900px;
+	margin-top: var(--spacing--4xl);
+	padding: var(--spacing--sm);
+	background-color: var(--color--background--light-3);
+	border: var(--border);
+	border-radius: var(--radius--lg);
+	text-align: left;
+}
+
+.header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--spacing--md);
+	margin-bottom: var(--spacing--md);
+}
+
+.allTemplatesLink {
+	white-space: nowrap;
+}
+
+.suggestions {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: var(--spacing--md);
+	min-height: 182px;
+}
+
+.loading {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: var(--spacing--xs);
+	padding: var(--spacing--lg);
+	color: var(--color--text--tint-1);
+}
+</style>

--- a/packages/frontend/editor-ui/src/features/core/folders/folders.store.ts
+++ b/packages/frontend/editor-ui/src/features/core/folders/folders.store.ts
@@ -23,6 +23,7 @@ export const useFoldersStore = defineStore(STORES.FOLDERS, () => {
 	const rootStore = useRootStore();
 	const i18n = useI18n();
 
+	const workflowsCountLoaded = ref(false);
 	const totalWorkflowCount = ref<number>(0);
 
 	// Resource that is currently being dragged
@@ -98,6 +99,7 @@ export const useFoldersStore = defineStore(STORES.FOLDERS, () => {
 		projectId?: string,
 		parentFolderId?: string,
 	): Promise<number> {
+		workflowsCountLoaded.value = false;
 		const { count } = await workflowsApi.getWorkflowsAndFolders(
 			rootStore.restApiContext,
 			{ projectId, parentFolderId },
@@ -105,6 +107,7 @@ export const useFoldersStore = defineStore(STORES.FOLDERS, () => {
 			true,
 		);
 		totalWorkflowCount.value = count;
+		workflowsCountLoaded.value = true;
 		return count;
 	}
 
@@ -348,6 +351,7 @@ export const useFoldersStore = defineStore(STORES.FOLDERS, () => {
 		createFolder,
 		getFolderPath,
 		totalWorkflowCount,
+		workflowsCountLoaded,
 		deleteFolder,
 		deleteFoldersFromCache,
 		renameFolder,

--- a/packages/frontend/editor-ui/src/features/workflows/readyToRun/composables/useEmptyStateDetection.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/readyToRun/composables/useEmptyStateDetection.test.ts
@@ -12,6 +12,7 @@ const mockRoute = (overrides: Partial<RouteLocationNormalized> = {}) =>
 vi.mock('@/features/core/folders/folders.store', () => ({
 	useFoldersStore: () => ({
 		totalWorkflowCount: 0,
+		workflowsCountLoaded: true,
 	}),
 }));
 

--- a/packages/frontend/editor-ui/src/features/workflows/readyToRun/composables/useEmptyStateDetection.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/readyToRun/composables/useEmptyStateDetection.ts
@@ -20,7 +20,8 @@ export function useEmptyStateDetection() {
 	 * - Not currently refreshing data
 	 */
 	const isTrulyEmpty = (currentRoute: RouteLocationNormalized = route) => {
-		const hasNoWorkflows = foldersStore.totalWorkflowCount === 0;
+		const hasNoWorkflows =
+			foldersStore.workflowsCountLoaded && foldersStore.totalWorkflowCount === 0;
 		const isNotInSpecificFolder = !currentRoute.params?.folderId;
 		const isMainWorkflowsPage = projectPages.isOverviewSubPage;
 


### PR DESCRIPTION
## Summary

In order to get more templates data we've decided to also show the experiment on the empty layout.

<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/bf62dac4-989f-4535-84ba-a02cedcba06a" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4425/feature-show-workflow-templates-inline-on-the-initial-templates-list


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Displays templates recommendations inline on the empty workflows layout, refactors template fetching/tracking into the store, and improves empty-state detection.
> 
> - **UI (Empty workflows layout)**
>   - Show templates recommendations inline via `TemplatesDataQualityInlineSection` when feature enabled, env is writable, and user can create workflows.
>   - Layout tweaks in `EmptyStateLayout.vue` (top padding, align start, wider content).
> - **Templates experiment**
>   - New `TemplatesDataQualityInlineSection.vue` loads and renders a 3-column grid of `TemplateCard`s with “See more” link.
>   - `templatesDataQuality.store.ts`: add `loadExperimentTemplates()` (loads node types, fetches random templates, filters results); expose strongly-typed getters.
>   - `TemplateCard.vue`: add `tileNumber` prop and IntersectionObserver-based “shown” tracking; minor style updates; keep click-to-use behavior.
>   - `NodeRecommendationModal.vue`: simplify to use `loadExperimentTemplates()` and pass `tile-number` to cards.
> - **Empty-state detection**
>   - `folders.store.ts`: add `workflowsCountLoaded` flag, set around total count fetch.
>   - `useEmptyStateDetection.ts`: require `workflowsCountLoaded` before treating as empty; update unit test mocks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d291b8dfc3f83a154b2ef1134ab9660c08ab2b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->