### PR TITLE
Fix/form custom css html encoding

### DIFF
--- a/packages/nodes-base/nodes/Form/utils/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils/utils.ts
@@ -123,13 +123,18 @@ export const prepareFormFields = (context: IWebhookFunctions, fields: FormFields
 export function sanitizeCustomCss(css: string | undefined): string | undefined {
 	if (!css) return undefined;
 
-	// Use sanitize-html with custom settings for CSS
-	return sanitize(css, {
-		allowedTags: [], // No HTML tags allowed
-		allowedAttributes: {}, // No attributes allowed
-		// This ensures we're only keeping the text content
-		// which should be the CSS, while removing any HTML/script tags
-	});
+	// Remove potentially dangerous HTML/script tags and prevent style tag breakout
+	// This preserves CSS syntax (>, <, &, etc.) while preventing XSS attacks
+	return (
+		css
+			// Remove closing style tags to prevent breaking out of <style> tag
+			.replace(/<\/style>/gi, '')
+			// Remove script tags (case-insensitive, handles various formats)
+			.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+			// Remove any other HTML tags
+			.replace(/<[^>]*>/g, '')
+			.trim()
+	);
 }
 
 export function createDescriptionMetadata(description: string) {


### PR DESCRIPTION
## Summary

Fixes issue where custom CSS styling in the Form node gets HTML encoded (turning `>` into `&gt;` etc.), breaking CSS selectors. The `sanitizeCustomCss` function was using `sanitize-html` which HTML-encodes special characters, making CSS selectors like `#n8n-form > div.form-header > p` non-functional.

**Changes:**
- Replace `sanitize-html` with regex-based sanitization for CSS
- Preserves CSS syntax (`>`, `<`, `&`, etc.) while preventing XSS attacks
- Removes closing `</style>` tags to prevent breaking out of style tag
- Removes script tags and other HTML tags (maintains security)

**Testing:**
- Verified CSS selectors with `>` work correctly (e.g., `#n8n-form > div.form-header > p`)
- Verified script tags are still removed (security maintained)
- Verified closing style tags are removed (prevents XSS breakout)
- Tested with various CSS selectors containing `>`, `<`, `&` characters
<img width="1252" height="389" alt="image" src="https://github.com/user-attachments/assets/e3063d08-5a69-4207-8df9-b45dfc53f9f0" />


## Related Linear tickets, Github issues, and Community forum posts

Fixes #21959

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update CSS sanitization to strip HTML/script and closing style tags without HTML-encoding, preserving CSS selectors.
> 
> - **Form utils** (`packages/nodes-base/nodes/Form/utils/utils.ts`):
>   - Update `sanitizeCustomCss` to use regex-based sanitization instead of `sanitize-html`.
>     - Removes closing `</style>`, `<script>` blocks, and other HTML tags.
>     - Preserves CSS characters (`>`, `<`, `&`) to avoid breaking selectors.
>     - Trims sanitized output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31940171afb732308990e003e44654c515280826. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->