### PR TITLE
chore(core): Add instance state with instance type as filter flag for backend modules

### DIFF
--- a/packages/@n8n/backend-common/src/index.ts
+++ b/packages/@n8n/backend-common/src/index.ts
@@ -1,3 +1,4 @@
+export * from './instance-state';
 export * from './license-state';
 export type * from './types';
 

--- a/packages/@n8n/backend-common/src/instance-state.ts
+++ b/packages/@n8n/backend-common/src/instance-state.ts
@@ -1,0 +1,44 @@
+import type { InstanceType } from '@n8n/constants';
+import { Service } from '@n8n/di';
+import { UnexpectedError } from 'n8n-workflow';
+
+import type { InstanceStateProvider } from './types';
+
+class ProviderNotSetError extends UnexpectedError {
+	constructor() {
+		super('Cannot query instance state because instance state provider has not been set');
+	}
+}
+
+@Service()
+export class InstanceState {
+	instanceStateProvider: InstanceStateProvider | null = null;
+
+	setInstanceStateProvider(provider: InstanceStateProvider) {
+		this.instanceStateProvider = provider;
+	}
+
+	private assertProvider(): asserts this is { instanceStateProvider: InstanceStateProvider } {
+		if (!this.instanceStateProvider) throw new ProviderNotSetError();
+	}
+
+	get instanceType(): InstanceType {
+		this.assertProvider();
+
+		return this.instanceStateProvider.instanceType;
+	}
+
+	/*
+	 * If singular, checks if the current instance type matches,
+	 * if multiple, checks if the current instance type is any of them
+	 */
+	isInstanceType(instanceType: InstanceType | InstanceType[]): boolean {
+		this.assertProvider();
+
+		if (typeof instanceType === 'string') {
+			return this.instanceStateProvider.instanceType === instanceType;
+		}
+
+		return instanceType.includes(this.instanceStateProvider.instanceType);
+	}
+}

--- a/packages/@n8n/backend-common/src/modules/modules.config.ts
+++ b/packages/@n8n/backend-common/src/modules/modules.config.ts
@@ -7,10 +7,10 @@ export const MODULE_NAMES = [
 	'external-secrets',
 	'community-packages',
 	'data-table',
-	'mcp',
 	'chat-hub',
 	'provisioning',
 	'breaking-changes',
+	'mcp',
 ] as const;
 
 export type ModuleName = (typeof MODULE_NAMES)[number];

--- a/packages/@n8n/backend-common/src/types.ts
+++ b/packages/@n8n/backend-common/src/types.ts
@@ -1,4 +1,4 @@
-import type { BooleanLicenseFeature, NumericLicenseFeature } from '@n8n/constants';
+import type { BooleanLicenseFeature, InstanceType, NumericLicenseFeature } from '@n8n/constants';
 
 export type FeatureReturnType = Partial<
 	{
@@ -12,4 +12,9 @@ export interface LicenseProvider {
 
 	/** Returns the value of a feature in the user's license plan, typically a boolean or integer. */
 	getValue<T extends keyof FeatureReturnType>(feature: T): FeatureReturnType[T];
+}
+
+export interface InstanceStateProvider {
+	/** Returns the current instance type. */
+	readonly instanceType: InstanceType;
 }

--- a/packages/@n8n/decorators/src/module/module-metadata.ts
+++ b/packages/@n8n/decorators/src/module/module-metadata.ts
@@ -1,3 +1,4 @@
+import { InstanceType } from '@n8n/constants';
 import { Service } from '@n8n/di';
 
 import type { LicenseFlag, ModuleClass } from './module';
@@ -9,6 +10,12 @@ type ModuleEntry = {
 	 * if multiple, checks that any of the features are licensed
 	 */
 	licenseFlag?: LicenseFlag | LicenseFlag[];
+
+	/*
+	 * If singular, only enables the module for that instance type,
+	 * if multiple, enables the module for any of the instance types
+	 */
+	instanceType?: InstanceType | InstanceType[];
 };
 
 @Service()

--- a/packages/@n8n/decorators/src/module/module.ts
+++ b/packages/@n8n/decorators/src/module/module.ts
@@ -1,4 +1,4 @@
-import type { LICENSE_FEATURES } from '@n8n/constants';
+import type { InstanceType, LICENSE_FEATURES } from '@n8n/constants';
 import { Container, Service, type Constructable } from '@n8n/di';
 
 import { ModuleMetadata } from './module-metadata';
@@ -84,11 +84,16 @@ export type ModuleClass = Constructable<ModuleInterface>;
 export type LicenseFlag = (typeof LICENSE_FEATURES)[keyof typeof LICENSE_FEATURES];
 
 export const BackendModule =
-	(opts: { name: string; licenseFlag?: LicenseFlag | LicenseFlag[] }): ClassDecorator =>
+	(opts: {
+		name: string;
+		licenseFlag?: LicenseFlag | LicenseFlag[];
+		instanceType?: InstanceType | InstanceType[];
+	}): ClassDecorator =>
 	(target) => {
 		Container.get(ModuleMetadata).register(opts.name, {
 			class: target as unknown as ModuleClass,
 			licenseFlag: opts?.licenseFlag,
+			instanceType: opts?.instanceType,
 		});
 
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-return

--- a/packages/cli/src/commands/base-command.ts
+++ b/packages/cli/src/commands/base-command.ts
@@ -2,6 +2,7 @@ import 'reflect-metadata';
 import {
 	inDevelopment,
 	inTest,
+	InstanceState,
 	LicenseState,
 	Logger,
 	ModuleRegistry,
@@ -79,6 +80,9 @@ export abstract class BaseCommand<F = never> {
 	async init(): Promise<void> {
 		this.dbConnection = Container.get(DbConnection);
 		this.errorReporter = Container.get(ErrorReporter);
+
+		// Set instance state provider early so modules can access it
+		Container.get(InstanceState).setInstanceStateProvider(this.instanceSettings);
 
 		const { backendDsn, environment, deploymentName } = this.globalConfig.sentry;
 		await this.errorReporter.init({


### PR DESCRIPTION

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR adds the possibility for backend module to be loaded conditionally based on the instance type of the currently running instance.
- adds instance state with injected provider from the cli package
- conditionally init modules based on the instance type
- updates tests

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-4121/conditionally-load-modules-depending-on-the-instance-type

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
