### PR TITLE
fix: Chat UI feedback (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.vue
@@ -116,6 +116,7 @@ const defaultTools = useLocalStorage<INode[] | null>(
 );
 
 const toolsSelection = ref<INode[] | null>(null);
+const shouldSkipNextScrollTrigger = ref(false);
 
 const selectedTools = computed<INode[]>(() => {
 	if (currentConversation.value?.tools) {
@@ -225,6 +226,11 @@ watch(
 	[readyToShowMessages, () => chatMessages.value[chatMessages.value.length - 1]?.id],
 	([ready, lastMessageId]) => {
 		if (!ready || !lastMessageId) {
+			return;
+		}
+
+		if (shouldSkipNextScrollTrigger.value) {
+			shouldSkipNextScrollTrigger.value = false;
 			return;
 		}
 
@@ -376,7 +382,7 @@ function handleRegenerateMessage(message: ChatHubMessageDto) {
 		return;
 	}
 
-	const messageToRetry = message.retryOfMessageId ?? message.id;
+	const messageToRetry = message.id;
 
 	chatStore.regenerateMessage(
 		sessionId.value,
@@ -399,6 +405,7 @@ async function handleSelectModel(selection: ChatModelDto) {
 }
 
 function handleSwitchAlternative(messageId: string) {
+	shouldSkipNextScrollTrigger.value = true;
 	chatStore.switchAlternative(sessionId.value, messageId);
 }
 

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/chat.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/chat.store.ts
@@ -459,7 +459,12 @@ export const useChatStore = defineStore(CHAT_STORE, () => {
 			alternatives: [],
 		});
 
-		streaming.value = { promptId: messageId, sessionId, model, requestType: 'new' };
+		streaming.value = {
+			promptId: messageId,
+			sessionId,
+			model,
+			retryOfMessageId: null,
+		};
 
 		sendMessageApi(
 			rootStore.restApiContext,
@@ -522,7 +527,12 @@ export const useChatStore = defineStore(CHAT_STORE, () => {
 			replaceMessageContent(sessionId, editId, content);
 		}
 
-		streaming.value = { promptId, sessionId, model, requestType: 'edit' };
+		streaming.value = {
+			promptId,
+			sessionId,
+			model,
+			retryOfMessageId: null,
+		};
 
 		editMessageApi(
 			rootStore.restApiContext,
@@ -553,7 +563,12 @@ export const useChatStore = defineStore(CHAT_STORE, () => {
 			throw new Error('No previous message to base regeneration on');
 		}
 
-		streaming.value = { promptId: retryId, sessionId, model, requestType: 'regenerate' };
+		streaming.value = {
+			promptId: retryId,
+			sessionId,
+			model,
+			retryOfMessageId: retryId,
+		};
 
 		regenerateMessageApi(
 			rootStore.restApiContext,

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/chat.types.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/chat.types.ts
@@ -74,6 +74,7 @@ export interface ChatAgentFilter {
 }
 
 export interface ChatStreamingState extends Partial<EnrichedStructuredChunk['metadata']> {
+	requestType: 'new' | 'edit' | 'regenerate';
 	promptId: ChatMessageId;
 	sessionId: ChatSessionId;
 	model: ChatHubConversationModel;

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/chat.types.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/chat.types.ts
@@ -74,10 +74,10 @@ export interface ChatAgentFilter {
 }
 
 export interface ChatStreamingState extends Partial<EnrichedStructuredChunk['metadata']> {
-	requestType: 'new' | 'edit' | 'regenerate';
 	promptId: ChatMessageId;
 	sessionId: ChatSessionId;
 	model: ChatHubConversationModel;
+	retryOfMessageId: ChatMessageId | null;
 }
 
 export interface FlattenedModel {

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/chat.utils.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/chat.utils.ts
@@ -298,7 +298,7 @@ export function buildUiMessages(
 		streaming.promptId === persistedMessages[persistedMessages.length - 1]?.id
 	) {
 		// Append a placeholder AI message as an immediate feedback until backend starts streaming
-		persistedMessages.push(createAiMessageFromStreamingState(sessionId, uuidv4()));
+		persistedMessages.push(createAiMessageFromStreamingState(sessionId, uuidv4(), streaming));
 	}
 
 	return persistedMessages;

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatAgentAvatar.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatAgentAvatar.vue
@@ -20,6 +20,7 @@ defineProps<{
 		/>
 		<N8nAvatar
 			v-else-if="agent.model.provider === 'custom-agent' || agent.model.provider === 'n8n'"
+			:class="[$style.avatar, $style[size]]"
 			:first-name="agent.name"
 			:size="size === 'lg' ? 'medium' : size === 'sm' ? 'xxsmall' : 'xsmall'"
 		/>
@@ -30,3 +31,9 @@ defineProps<{
 		/>
 	</N8nTooltip>
 </template>
+
+<style lang="scss" module>
+.avatar.md {
+	transform: scale(1.2);
+}
+</style>

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatLayout.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatLayout.vue
@@ -1,8 +1,28 @@
 <script setup lang="ts">
-import { MOBILE_MEDIA_QUERY } from '@/features/ai/chatHub/constants';
-import { useMediaQuery } from '@vueuse/core';
+import { CHAT_VIEW, MOBILE_MEDIA_QUERY } from '@/features/ai/chatHub/constants';
+import { useMediaQuery, useEventListener } from '@vueuse/core';
+import { useRouter } from 'vue-router';
+import { useUIStore } from '@/app/stores/ui.store';
+import { useDeviceSupport } from '@n8n/composables/useDeviceSupport';
 
 const isMobileDevice = useMediaQuery(MOBILE_MEDIA_QUERY);
+const router = useRouter();
+const uiStore = useUIStore();
+const { isCtrlKeyPressed } = useDeviceSupport();
+
+// Cmd+Shift+O to start new chat
+useEventListener(document, 'keydown', (event: KeyboardEvent) => {
+	if (
+		event.key.toLowerCase() === 'o' &&
+		isCtrlKeyPressed(event) &&
+		event.shiftKey &&
+		!uiStore.isAnyModalOpen
+	) {
+		event.preventDefault();
+		event.stopPropagation();
+		void router.push({ name: CHAT_VIEW, force: true });
+	}
+});
 </script>
 
 <template>

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.vue
@@ -135,7 +135,7 @@ onBeforeMount(() => {
 		:style="minHeight ? { minHeight: `${minHeight}px` } : undefined"
 		:data-message-id="message.id"
 	>
-		<div :class="$style.avatar">
+		<div :class="[$style.avatar, { [$style.errorAvatar]: message.status === 'error' }]">
 			<N8nIcon v-if="message.type === 'human'" icon="user" width="20" height="20" />
 			<ChatAgentAvatar v-else-if="agent" :agent="agent" size="md" tooltip />
 			<N8nIcon v-else icon="sparkles" width="20" height="20" />
@@ -162,7 +162,7 @@ onBeforeMount(() => {
 				</div>
 			</div>
 			<template v-else>
-				<div :class="$style.chatMessage">
+				<div :class="[$style.chatMessage, { [$style.errorMessage]: message.status === 'error' }]">
 					<VueMarkdown
 						:key="forceReRenderKey"
 						:class="[$style.chatMessageMarkdown, 'chat-message-markdown']"
@@ -235,6 +235,14 @@ onBeforeMount(() => {
 		border-radius: var(--radius--xl);
 		background-color: var(--color--background);
 	}
+}
+
+.errorMessage {
+	padding: var(--spacing--xs) var(--spacing--sm);
+	border-radius: var(--radius--lg);
+	background-color: var(--color--danger--tint-4);
+	border: var(--border-width) var(--border-style) var(--color--danger--tint-3);
+	color: var(--color--danger);
 }
 
 .chatMessageMarkdown {

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.vue
@@ -211,7 +211,7 @@ onBeforeMount(() => {
 	width: 28px;
 	height: 28px;
 	border-radius: 50%;
-	background: var(--color--background--light-3);
+	background: var(--color--background);
 	color: var(--color--text--tint-1);
 
 	.compact & {
@@ -231,7 +231,7 @@ onBeforeMount(() => {
 	max-width: fit-content;
 
 	.user & {
-		padding: var(--spacing--4xs) var(--spacing--md);
+		padding: var(--spacing--3xs) var(--spacing--sm);
 		border-radius: var(--radius--xl);
 		background-color: var(--color--background);
 	}
@@ -323,6 +323,13 @@ onBeforeMount(() => {
 	th {
 		border-bottom: var(--border);
 		border-color: var(--color--text--shade-1);
+	}
+
+	ul,
+	ol {
+		li {
+			margin-bottom: 0.125rem;
+		}
 	}
 }
 

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.vue
@@ -235,57 +235,94 @@ onBeforeMount(() => {
 		border-radius: var(--radius--xl);
 		background-color: var(--color--background);
 	}
+}
 
-	> .chatMessageMarkdown {
-		display: block;
+.chatMessageMarkdown {
+	display: block;
+	box-sizing: border-box;
+
+	> *:first-child {
+		margin-top: 0;
+	}
+
+	> *:last-child {
+		margin-bottom: 0;
+	}
+
+	& * {
+		font-size: var(--font-size--md);
+		line-height: 1.8;
+	}
+
+	p {
+		margin: var(--spacing--xs) 0;
+	}
+
+	// Override heading sizes to be smaller
+	h1 {
+		font-size: var(--font-size--2xl);
+		font-weight: var(--font-weight--bold);
+		line-height: var(--line-height--md);
+	}
+
+	h2 {
+		font-size: var(--font-size--xl);
+		font-weight: var(--font-weight--bold);
+		line-height: var(--line-height--lg);
+	}
+
+	h3 {
+		font-size: var(--font-size--lg);
+		font-weight: var(--font-weight--bold);
+		line-height: var(--line-height--lg);
+	}
+
+	h4 {
+		font-size: var(--font-size--md);
+		font-weight: var(--font-weight--bold);
+		line-height: var(--line-height--xl);
+	}
+
+	h5 {
+		font-size: var(--font-size--sm);
+		font-weight: var(--font-weight--bold);
+		line-height: var(--line-height--xl);
+	}
+
+	h6 {
+		font-size: var(--font-size--sm);
+		font-weight: var(--font-weight--bold);
+		line-height: var(--line-height--xl);
+	}
+
+	pre {
+		font-family: inherit;
+		font-size: inherit;
+		margin: 0;
+		white-space: pre-wrap;
 		box-sizing: border-box;
+		padding: var(--chat--spacing);
+		background: var(--chat--message--pre--background);
+		border-radius: var(--chat--border-radius);
+	}
 
-		> *:first-child {
-			margin-top: 0;
-		}
+	table {
+		width: 100%;
+		border-bottom: var(--border);
+		border-top: var(--border);
+		border-width: 2px;
+		margin-bottom: 1em;
+		border-color: var(--color--text--shade-1);
+	}
 
-		> *:last-child {
-			margin-bottom: 0;
-		}
+	th,
+	td {
+		padding: 0.25em 1em 0.25em 0;
+	}
 
-		& * {
-			font-size: var(--font-size--md);
-			line-height: 1.8;
-		}
-
-		p {
-			margin: var(--spacing--xs) 0;
-		}
-
-		pre {
-			font-family: inherit;
-			font-size: inherit;
-			margin: 0;
-			white-space: pre-wrap;
-			box-sizing: border-box;
-			padding: var(--chat--spacing);
-			background: var(--chat--message--pre--background);
-			border-radius: var(--chat--border-radius);
-		}
-
-		table {
-			width: 100%;
-			border-bottom: var(--border);
-			border-top: var(--border);
-			border-width: 2px;
-			margin-bottom: 1em;
-			border-color: var(--color--text--shade-1);
-		}
-
-		th,
-		td {
-			padding: 0.25em 1em 0.25em 0;
-		}
-
-		th {
-			border-bottom: var(--border);
-			border-color: var(--color--text--shade-1);
-		}
+	th {
+		border-bottom: var(--border);
+		border-color: var(--color--text--shade-1);
 	}
 }
 

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.vue
@@ -135,7 +135,7 @@ onBeforeMount(() => {
 		:style="minHeight ? { minHeight: `${minHeight}px` } : undefined"
 		:data-message-id="message.id"
 	>
-		<div :class="[$style.avatar, { [$style.errorAvatar]: message.status === 'error' }]">
+		<div :class="$style.avatar">
 			<N8nIcon v-if="message.type === 'human'" icon="user" width="20" height="20" />
 			<ChatAgentAvatar v-else-if="agent" :agent="agent" size="md" tooltip />
 			<N8nIcon v-else icon="sparkles" width="20" height="20" />

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessageActions.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessageActions.vue
@@ -87,7 +87,7 @@ function handleReadAloud() {
 			/>
 			<template #content>{{ isSpeaking ? 'Stop reading' : 'Read aloud' }}</template>
 		</N8nTooltip>
-		<N8nTooltip placement="bottom" :show-after="300">
+		<N8nTooltip v-if="message.status === 'success'" placement="bottom" :show-after="300">
 			<N8nIconButton icon="pen" type="tertiary" size="medium" text @click="handleEdit" />
 			<template #content>Edit</template>
 		</N8nTooltip>

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ModelSelector.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ModelSelector.vue
@@ -83,6 +83,12 @@ const credentialsName = computed(() =>
 		? credentialsStore.getCredentialById(credentials?.[selectedAgent.model.provider] ?? '')?.name
 		: undefined,
 );
+const isCredentialsRequired = computed(
+	() =>
+		selectedAgent &&
+		selectedAgent.model.provider !== 'n8n' &&
+		selectedAgent.model.provider !== 'custom-agent',
+);
 
 const menu = computed(() => {
 	const menuItems: (typeof N8nNavigationDropdown)['menu'] = [];
@@ -293,7 +299,7 @@ defineExpose({
 			<ChatAgentAvatar
 				v-if="selectedAgent"
 				:agent="selectedAgent"
-				:size="credentialsName ? 'md' : 'sm'"
+				:size="credentialsName || !isCredentialsRequired ? 'md' : 'sm'"
 				:class="$style.icon"
 			/>
 			<div :class="$style.selected">

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ToolsSelector.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ToolsSelector.vue
@@ -2,7 +2,7 @@
 import NodeIcon from '@/app/components/NodeIcon.vue';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useUIStore } from '@/app/stores/ui.store';
-import { N8nButton, N8nIcon, N8nText } from '@n8n/design-system';
+import { N8nButton } from '@n8n/design-system';
 import type { INode } from 'n8n-workflow';
 import { computed, onMounted } from 'vue';
 import { TOOLS_SELECTOR_MODAL_KEY } from '../constants';
@@ -54,6 +54,7 @@ const onClick = () => {
 		:class="$style.toolsButton"
 		:disabled="disabled"
 		aria-label="Select tools"
+		:icon="toolCount > 0 ? undefined : 'plus'"
 		@click="onClick"
 	>
 		<span v-if="toolCount" :class="$style.iconStack">
@@ -67,11 +68,7 @@ const onClick = () => {
 				:size="12"
 			/>
 		</span>
-		<span v-else :class="$style.iconFallback">
-			<N8nIcon icon="plus" :size="12" />
-		</span>
-
-		<N8nText size="small" bold color="text-dark">{{ toolsLabel }}</N8nText>
+		{{ toolsLabel }}
 	</N8nButton>
 </template>
 
@@ -99,12 +96,5 @@ const onClick = () => {
 
 .iconOverlap {
 	margin-left: -6px;
-}
-
-.iconFallback {
-	padding: var(--spacing--4xs);
-	display: flex;
-	align-items: center;
-	justify-content: center;
 }
 </style>


### PR DESCRIPTION
## Summary

Chat UI fixes based on the feedback table in Notion

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves Chat Hub UX with better streaming placeholders, controlled auto-scroll, safer edit/regenerate actions, a new new-chat shortcut, and various UI/styling tweaks.
> 
> - **Chat rendering & streaming**
>   - Use `buildUiMessages` to derive UI messages in `chat.store.ts`; adds placeholder "running" messages and handles regeneration states.
>   - Extend `ChatStreamingState` with `retryOfMessageId`; propagate in `sendMessage`, `editMessage`, and `regenerateMessage`.
> - **Scrolling**
>   - Add `shouldSkipNextScrollTrigger` in `ChatView.vue` to prevent auto-scroll when switching alternatives.
> - **Message actions & behavior**
>   - Only show Edit for messages with `status === 'success'` in `ChatMessageActions.vue`.
>   - Regenerate now targets `message.id` directly in `ChatView.vue`.
> - **Keyboard shortcut**
>   - Add Cmd/Ctrl+Shift+O to start a new chat in `ChatLayout.vue`.
> - **UI/Styling**
>   - Error message styling and avatar background/padding tweaks in `ChatMessage.vue`.
>   - Adjust markdown heading sizes in `ChatMessage.vue`.
>   - Scale `ChatAgentAvatar` size and improve model selector avatar sizing based on credential requirement.
>   - Simplify `ToolsSelector` button to use built-in icon prop.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82dca6c6e8d0e8721f2019be3323dcb793c422c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->