### PR TITLE
fix(ai-builder): Improving workflow builder following model instructions and using AI agent node

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/chains/test-case-generator.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/chains/test-case-generator.ts
@@ -98,37 +98,37 @@ export const basicTestCases: TestCase[] = [
 		id: 'multi-agent-research',
 		name: 'Multi-agent research workflow',
 		prompt:
-			'Create a multi-agent AI workflow using GPT-4.1-mini where several agents work together to research a topic, fact-check the findings, and write a report that\'s sent as an HTML email. One agent should gather recent, credible information about the topic. Another agent should verify the facts and only mark something as "verified" if it appears in at least two independent sources. A third agent should combine the verified information into a clear, well-written report under 1,000 words. A final agent should edit and format the report to make it look clean and professional in the body of the email. Use Gmail to send the report.',
+			'Create a multi-agent AI workflow using `gpt-4.1-mini` where several agents work together to research a topic, fact-check the findings, and write a report that\'s sent as an HTML email. One agent should gather recent, credible information about the topic. Another agent should verify the facts and only mark something as "verified" if it appears in at least two independent sources. A third agent should combine the verified information into a clear, well-written report under 1,000 words. A final agent should edit and format the report to make it look clean and professional in the body of the email. Use Gmail to send the report.',
 	},
 	{
 		id: 'email-summary',
 		name: 'Summarize emails with AI',
 		prompt:
-			'Create an automation that runs on Monday mornings. It reads my Gmail inbox from the weekend, analyzes them with GPT-4.1-mini to find action items and priorities, and emails me a structured email using Gmail.',
+			'Create an automation that runs on Monday mornings. It reads my Gmail inbox from the weekend, analyzes them with `gpt-4.1-mini` to find action items and priorities, and emails me a structured email using Gmail.',
 	},
 	{
 		id: 'ai-news-digest',
 		name: 'Daily AI news digest',
 		prompt:
-			'Build an automation that runs every night 8pm. Use the NewsAPI "/everything" endpoint to search for AI-related news from the day. Pick the top 5 articles and use OpenAI GPT-4.1-mini to summarize each in two sentences. Generate an image using OpenAI based on the top article\'s summary. Send a structured Telegram message.',
+			'Build an automation that runs every night 8pm. Use the NewsAPI "/everything" endpoint to search for AI-related news from the day. Pick the top 5 articles and use OpenAI `gpt-4.1-mini` to summarize each in two sentences. Generate an image using OpenAI based on the top article\'s summary. Send a structured Telegram message.',
 	},
 	{
 		id: 'daily-weather-report',
 		name: 'Daily weather report',
 		prompt:
-			'Create an automation that checks the weather for my location every morning at 5 a.m using OpenWeather. Send me a short weather report by email using Gmail. Use OpenAI GPT-4.1-mini to write a short, fun formatted email body by adding personality when describing the weather and how the day might feel. Include all details relevant to decide on my plans and clothes for the day.',
+			'Create an automation that checks the weather for my location every morning at 5 a.m using OpenWeather. Send me a short weather report by email using Gmail. Use OpenAI `gpt-4.1-mini` to write a short, fun formatted email body by adding personality when describing the weather and how the day might feel. Include all details relevant to decide on my plans and clothes for the day.',
 	},
 	{
 		id: 'invoice-pipeline',
 		name: 'Invoice processing pipeline',
 		prompt:
-			'Create an invoice processing workflow using an n8n Form. When a user submits an invoice file (PDF or image) with their email address, use OpenAI GPT-4.1-mini to extract invoice data. Then, validate the date format is correct, the currency is valid, and the total amount is greater than zero. If validation fails, email the user a clear error message that explains which check failed from my Gmail. If the data passes validation, store the structured result in a datatable plus email the user. Every Monday morning, generate a weekly spending report using GPT-4.1-mini based on stored invoices and send a clean email using Gmail.',
+			'Create an invoice processing workflow using an n8n Form. When a user submits an invoice file (PDF or image) with their email address, use OpenAI `gpt-4.1-mini` to extract invoice data. Then, validate the date format is correct, the currency is valid, and the total amount is greater than zero. If validation fails, email the user a clear error message that explains which check failed from my Gmail. If the data passes validation, store the structured result in a datatable plus email the user. Every Monday morning, generate a weekly spending report using `gpt-4.1-mini` based on stored invoices and send a clean email using Gmail.',
 	},
 	{
 		id: 'rag-assistant',
 		name: 'RAG knowledge assistant',
 		prompt:
-			'Build an automation that creates a document-to-chat RAG pipeline. The workflow starts with an n8n Form where a user uploads one or more files (PDF, CSV, or JSON). Each upload should trigger a process that reads the file, splits it into chunks, and generates embeddings using OpenAI GPT-4.1-mini model, saved in one Pinecone table. Add a second part of the workflow for querying: use a Chat Message Trigger to act as a chatbot interface. When a user sends a question, retrieve the top 5 most relevant chunks from Pinecone, pass them into GPT-4.1-mini as context, and have it answer naturally using only the retrieved information. If a question can\'t be answered confidently, the bot should respond with: "I couldn\'t find that in the uploaded documents." Log each chat interaction in a Data Table with the user query, matched file(s), and timestamp. Send a daily summary email through Gmail showing total questions asked, top files referenced, and any failed lookups.',
+			'Build an automation that creates a document-to-chat RAG pipeline. The workflow starts with an n8n Form where a user uploads one or more files (PDF, CSV, or JSON). Each upload should trigger a process that reads the file, splits it into chunks, and generates embeddings using OpenAI `gpt-4.1-mini` model, saved in one Pinecone table. Add a second part of the workflow for querying: use a Chat Message Trigger to act as a chatbot interface. When a user sends a question, retrieve the top 5 most relevant chunks from Pinecone, pass them into `gpt-4.1-mini` as context, and have it answer naturally using only the retrieved information. If a question can\'t be answered confidently, the bot should respond with: "I couldn\'t find that in the uploaded documents." Log each chat interaction in a Data Table with the user query, matched file(s), and timestamp. Send a daily summary email through Gmail showing total questions asked, top files referenced, and any failed lookups.',
 	},
 	{
 		id: 'lead-qualification',

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/prompts/main-agent.prompt.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/prompts/main-agent.prompt.ts
@@ -69,7 +69,8 @@ Follow this proven sequence for creating robust workflows:
 <node_selection>
 When building AI workflows prefer the AI agent node to other text LLM nodes, unless the user specifies them by name. Summarization, analysis, information
 extraction and classification can all be carried out by an AI agent node, correct system prompt, and structured output parser.
-DO NOT use provider specific nodes for text operations like @n8n/n8n-nodes-langchain.openAi - instead of these use an AI agent node.
+For the purposes of this section provider specific nodes can be described as nodes like @n8n/n8n-nodes-langchain.openAi.
+Do not use provider specific nodes for text operations - instead use an AI agent node.
 For generation/analysis of content other than text (images, video, audio) provider specific nodes should be used.
 </node_selection>
 

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/prompts/main-agent.prompt.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/prompts/main-agent.prompt.ts
@@ -69,7 +69,8 @@ Follow this proven sequence for creating robust workflows:
 <node_selection>
 When building AI workflows prefer the AI agent node to other text LLM nodes, unless the user specifies them by name. Summarization, analysis, information
 extraction and classification can all be carried out by an AI agent node, correct system prompt, and structured output parser.
-DO NOT use provider specific nodes like @n8n/n8n-nodes-langchain.openAi - instead of these use an AI agent node.
+DO NOT use provider specific nodes for text operations like @n8n/n8n-nodes-langchain.openAi - instead of these use an AI agent node.
+For generation/analysis of content other than text (images, video, audio) provider specific nodes should be used.
 </node_selection>
 
 <best_practices_compliance>

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/prompts/main-agent.prompt.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/prompts/main-agent.prompt.ts
@@ -37,7 +37,7 @@ Follow this proven sequence for creating robust workflows:
    - Why: Best practices help to inform which nodes to search for and use to build the workflow plus mistakes to avoid
 
 2. **Discovery Phase** (parallel execution)
-   - Search for all required node types simultaneously
+   - Search for all required node types simultaneously, review the <node_selection> section for tips and best practices
    - Why: Ensures you work with actual available nodes, not assumptions
 
 3. **Analysis Phase** (parallel execution)
@@ -65,6 +65,12 @@ Follow this proven sequence for creating robust workflows:
    - Run validate_workflow after applying changes to refresh the workflow validation report
    - Review <workflow_validation_report> and resolve any violations before finalizing
    - Why: Ensures structural issues are surfaced early; rerun validation after major updates
+
+<node_selection>
+When building AI workflows prefer the AI agent node to other text LLM nodes, unless the user specifies them by name. Summarization, analysis, information
+extraction and classification can all be carried out by an AI agent node, correct system prompt, and structured output parser.
+DO NOT use provider specific nodes like @n8n/n8n-nodes-langchain.openAi - instead of these use an AI agent node.
+</node_selection>
 
 <best_practices_compliance>
 Enforcing best practice compliance is MANDATORY

--- a/packages/frontend/editor-ui/src/app/constants/workflowSuggestions.ts
+++ b/packages/frontend/editor-ui/src/app/constants/workflowSuggestions.ts
@@ -9,37 +9,37 @@ export const WORKFLOW_SUGGESTIONS: WorkflowSuggestion[] = [
 		id: 'multi-agent-research',
 		summary: 'Multi-agent research workflow',
 		prompt:
-			'Create a multi-agent AI workflow using GPT-4.1-mini where several agents work together to research a topic, fact-check the findings, and write a report that\'s sent as an HTML email. One agent should gather recent, credible information about the topic. Another agent should verify the facts and only mark something as "verified" if it appears in at least two independent sources. A third agent should combine the verified information into a clear, well-written report under 1,000 words. A final agent should edit and format the report to make it look clean and professional in the body of the email. Use Gmail to send the report.',
+			'Create a multi-agent AI workflow using `gpt-4.1-mini` where several agents work together to research a topic, fact-check the findings, and write a report that\'s sent as an HTML email. One agent should gather recent, credible information about the topic. Another agent should verify the facts and only mark something as "verified" if it appears in at least two independent sources. A third agent should combine the verified information into a clear, well-written report under 1,000 words. A final agent should edit and format the report to make it look clean and professional in the body of the email. Use Gmail to send the report.',
 	},
 	{
 		id: 'email-summary',
 		summary: 'Summarize emails with AI',
 		prompt:
-			'Create an automation that runs on Monday mornings. It reads my Gmail inbox from the weekend, analyzes them with GPT-4.1-mini to find action items and priorities, and emails me a structured email using Gmail.',
+			'Create an automation that runs on Monday mornings. It reads my Gmail inbox from the weekend, analyzes them with `gpt-4.1-mini` to find action items and priorities, and emails me a structured email using Gmail.',
 	},
 	{
 		id: 'ai-news-digest',
 		summary: 'Daily AI news digest',
 		prompt:
-			'Build an automation that runs every night 8pm. Use the NewsAPI "/everything" endpoint to search for AI-related news from the day. Pick the top 5 articles and use OpenAI GPT-4.1-mini to summarize each in two sentences. Generate an image using OpenAI based on the top article\'s summary. Send a structured Telegram message.',
+			'Build an automation that runs every night 8pm. Use the NewsAPI "/everything" endpoint to search for AI-related news from the day. Pick the top 5 articles and use OpenAI `gpt-4.1-mini` to summarize each in two sentences. Generate an image using OpenAI based on the top article\'s summary. Send a structured Telegram message.',
 	},
 	{
 		id: 'daily-weather-report',
 		summary: 'Daily weather report',
 		prompt:
-			'Create an automation that checks the weather for my location every morning at 5 a.m using OpenWeather. Send me a short weather report by email using Gmail. Use OpenAI GPT-4.1-mini to write a short, fun formatted email body by adding personality when describing the weather and how the day might feel. Include all details relevant to decide on my plans and clothes for the day.',
+			'Create an automation that checks the weather for my location every morning at 5 a.m using OpenWeather. Send me a short weather report by email using Gmail. Use OpenAI `gpt-4.1-mini` to write a short, fun formatted email body by adding personality when describing the weather and how the day might feel. Include all details relevant to decide on my plans and clothes for the day.',
 	},
 	{
 		id: 'invoice-pipeline',
 		summary: 'Invoice processing pipeline',
 		prompt:
-			'Create an invoice processing workflow using an n8n Form. When a user submits an invoice file (PDF or image) with their email address, use OpenAI GPT-4.1-mini to extract invoice data. Then, validate the date format is correct, the currency is valid, and the total amount is greater than zero. If validation fails, email the user a clear error message that explains which check failed from my Gmail. If the data passes validation, store the structured result in a datatable plus email the user. Every Monday morning, generate a weekly spending report using GPT-4.1-mini based on stored invoices and send a clean email using Gmail.',
+			'Create an invoice processing workflow using an n8n Form. When a user submits an invoice file (PDF or image) with their email address, use OpenAI `gpt-4.1-mini` to extract invoice data. Then, validate the date format is correct, the currency is valid, and the total amount is greater than zero. If validation fails, email the user a clear error message that explains which check failed from my Gmail. If the data passes validation, store the structured result in a datatable plus email the user. Every Monday morning, generate a weekly spending report using `gpt-4.1-mini` based on stored invoices and send a clean email using Gmail.',
 	},
 	{
 		id: 'rag-assistant',
 		summary: 'RAG knowledge assistant',
 		prompt:
-			'Build an automation that creates a document-to-chat RAG pipeline. The workflow starts with an n8n Form where a user uploads one or more files (PDF, CSV, or JSON). Each upload should trigger a process that reads the file, splits it into chunks, and generates embeddings using OpenAI GPT-4.1-mini model, saved in one Pinecone table. Add a second part of the workflow for querying: use a Chat Message Trigger to act as a chatbot interface. When a user sends a question, retrieve the top 5 most relevant chunks from Pinecone, pass them into GPT-4.1-mini as context, and have it answer naturally using only the retrieved information. If a question can\'t be answered confidently, the bot should respond with: "I couldn\'t find that in the uploaded documents." Log each chat interaction in a Data Table with the user query, matched file(s), and timestamp. Send a daily summary email through Gmail showing total questions asked, top files referenced, and any failed lookups.',
+			'Build an automation that creates a document-to-chat RAG pipeline. The workflow starts with an n8n Form where a user uploads one or more files (PDF, CSV, or JSON). Each upload should trigger a process that reads the file, splits it into chunks, and generates embeddings using OpenAI `gpt-4.1-mini` model, saved in one Pinecone table. Add a second part of the workflow for querying: use a Chat Message Trigger to act as a chatbot interface. When a user sends a question, retrieve the top 5 most relevant chunks from Pinecone, pass them into `gpt-4.1-mini` as context, and have it answer naturally using only the retrieved information. If a question can\'t be answered confidently, the bot should respond with: "I couldn\'t find that in the uploaded documents." Log each chat interaction in a Data Table with the user query, matched file(s), and timestamp. Send a daily summary email through Gmail showing total questions asked, top files referenced, and any failed lookups.',
 	},
 	{
 		id: 'lead-qualification',


### PR DESCRIPTION
## Summary

Highlighting the model in the workflow suggestions/evals, from my testing as part of the template work this massively improves the chance that the workflow builder doesn't ignore the users request for a specific model - without this it often picks 4o. Also adding a section to the main agent prompt to tell it about using the AI agent node where possible, this reduces the change of using provider specific nodes which are a sub-optimal experience.

In evals `GPT-4.1-mini` very rarely led to that model being used, with the default `GPT-4o-mini` often being picked, but using backticks and referencing the exact model name leads to much larger chance of the model being used.

The agent node recommendation was mentioned in: https://linear.app/n8n/issue/AI-1674/feature-add-best-practices-section-for-ai-nodes-in-workflows-add-node

This also addresses: https://linear.app/n8n/issue/AI-1718/issue-is-causing-builder-to-remove-nodes-and-not-complete-the-workflow

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Emphasizes the exact `gpt-4.1-mini` model in evals/UI suggestions and adds a node selection section guiding preference for the AI Agent node over provider-specific text nodes.
> 
> - **AI Builder Prompt**:
>   - **Node selection guidance**: Added `<node_selection>` section advising preference for `AI Agent` for text tasks and provider-specific nodes for non-text (images/audio/video).
>   - **Workflow sequence tweak**: Discovery phase now references the new `<node_selection>` guidance.
> - **Evals & UI Suggestions**:
>   - Updated prompts in `evaluations/chains/test-case-generator.ts` and `editor-ui/.../workflowSuggestions.ts` to wrap the model name as `gpt-4.1-mini`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 430917450c476918c7d278552655b91fcc098c9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->