### PR TITLE
fix(editor): Inconsistent syntax highlight color

### DIFF
--- a/packages/frontend/@n8n/chat/src/css/markdown.scss
+++ b/packages/frontend/@n8n/chat/src/css/markdown.scss
@@ -6,15 +6,13 @@
 	@include meta.load-css('highlight.js/styles/github-dark-dimmed.css');
 }
 
-body {
-	&[data-theme='dark'] {
-		@include hljs-dark-theme;
-	}
+body[data-theme='dark'] {
+	@include hljs-dark-theme;
+}
 
-	@media (prefers-color-scheme: dark) {
-		body:not([data-theme]) {
-			@include hljs-dark-theme;
-		}
+@media (prefers-color-scheme: dark) {
+	body:not([data-theme]) {
+		@include hljs-dark-theme;
 	}
 }
 

--- a/packages/frontend/@n8n/chat/src/css/markdown.scss
+++ b/packages/frontend/@n8n/chat/src/css/markdown.scss
@@ -12,7 +12,9 @@ body {
 	}
 
 	@media (prefers-color-scheme: dark) {
-		@include hljs-dark-theme;
+		body:not([data-theme]) {
+			@include hljs-dark-theme;
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

When n8n theme color (light) overrides OS theme color (dark), language syntax highlighting in markdown text was off because color scheme from dark theme is partially applied.

| Before | After fix |
|--------|--------|
|<img width="788" height="218" alt="Screenshot 2025-11-19 at 09 52 22" src="https://github.com/user-attachments/assets/35438727-8a4c-4c17-a3d8-d718b3ab7863" /> |<img width="793" height="208" alt="Screenshot 2025-11-19 at 09 52 36" src="https://github.com/user-attachments/assets/4afb9c57-fb15-4abb-9c99-9b56dabccb19" /> | 


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
