### PR TITLE
feat(core): Add AWS Bedrock support to chat hub (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/chat-hub.ts
+++ b/packages/@n8n/api-types/src/chat-hub.ts
@@ -17,6 +17,7 @@ export const chatHubLLMProviderSchema = z.enum([
 	'google',
 	'azureOpenAi',
 	'ollama',
+	'awsBedrock',
 ]);
 export type ChatHubLLMProvider = z.infer<typeof chatHubLLMProviderSchema>;
 
@@ -40,6 +41,7 @@ export const PROVIDER_CREDENTIAL_TYPE_MAP: Record<
 	google: 'googlePalmApi',
 	ollama: 'ollamaApi',
 	azureOpenAi: 'azureOpenAiApi',
+	awsBedrock: 'aws',
 };
 
 export type ChatHubAgentTool = typeof JINA_AI_TOOL_NODE_TYPE | typeof SEAR_XNG_TOOL_NODE_TYPE;
@@ -72,6 +74,11 @@ const ollamaModelSchema = z.object({
 	model: z.string(),
 });
 
+const awsBedrockModelSchema = z.object({
+	provider: z.literal('awsBedrock'),
+	model: z.string(),
+});
+
 const n8nModelSchema = z.object({
 	provider: z.literal('n8n'),
 	workflowId: z.string(),
@@ -88,6 +95,7 @@ export const chatHubConversationModelSchema = z.discriminatedUnion('provider', [
 	googleModelSchema,
 	azureOpenAIModelSchema,
 	ollamaModelSchema,
+	awsBedrockModelSchema,
 	n8nModelSchema,
 	chatAgentSchema,
 ]);
@@ -97,12 +105,14 @@ export type ChatHubAnthropicModel = z.infer<typeof anthropicModelSchema>;
 export type ChatHubGoogleModel = z.infer<typeof googleModelSchema>;
 export type ChatHubAzureOpenAIModel = z.infer<typeof azureOpenAIModelSchema>;
 export type ChatHubOllamaModel = z.infer<typeof ollamaModelSchema>;
+export type ChatHubAwsBedrockModel = z.infer<typeof awsBedrockModelSchema>;
 export type ChatHubBaseLLMModel =
 	| ChatHubOpenAIModel
 	| ChatHubAnthropicModel
 	| ChatHubGoogleModel
 	| ChatHubAzureOpenAIModel
-	| ChatHubOllamaModel;
+	| ChatHubOllamaModel
+	| ChatHubAwsBedrockModel;
 
 export type ChatHubN8nModel = z.infer<typeof n8nModelSchema>;
 export type ChatHubCustomAgentModel = z.infer<typeof chatAgentSchema>;
@@ -143,6 +153,7 @@ export const emptyChatModelsResponse: ChatModelsResponse = {
 	google: { models: [] },
 	azureOpenAi: { models: [] },
 	ollama: { models: [] },
+	awsBedrock: { models: [] },
 	n8n: { models: [] },
 	// eslint-disable-next-line @typescript-eslint/naming-convention
 	'custom-agent': { models: [] },

--- a/packages/cli/src/modules/chat-hub/chat-hub-workflow.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-workflow.service.ts
@@ -452,7 +452,7 @@ export class ChatHubWorkflowService {
 				return {
 					...common,
 					parameters: {
-						model: { __rl: true, mode: 'id', value: model },
+						model,
 						options: {},
 					},
 				};
@@ -461,6 +461,15 @@ export class ChatHubWorkflowService {
 					...common,
 					parameters: {
 						model: { __rl: true, mode: 'id', value: model },
+						options: {},
+					},
+				};
+			}
+			case 'awsBedrock': {
+				return {
+					...common,
+					parameters: {
+						model,
 						options: {},
 					},
 				};

--- a/packages/cli/src/modules/chat-hub/chat-hub.constants.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.constants.ts
@@ -32,6 +32,10 @@ export const PROVIDER_NODE_TYPE_MAP: Record<ChatHubLLMProvider, INodeTypeNameVer
 		name: '@n8n/n8n-nodes-langchain.lmChatAzureOpenAi',
 		version: 1,
 	},
+	awsBedrock: {
+		name: '@n8n/n8n-nodes-langchain.lmChatAwsBedrock',
+		version: 1.1,
+	},
 };
 
 export const NODE_NAMES = {

--- a/packages/cli/src/modules/chat-hub/chat-hub.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.service.ts
@@ -275,7 +275,7 @@ export class ChatHubService {
 
 		return {
 			models: results.map((result) => ({
-				name: String(result.value),
+				name: result.name,
 				description: result.description ?? null,
 				model: {
 					provider: 'google',
@@ -333,7 +333,7 @@ export class ChatHubService {
 
 		return {
 			models: results.map((result) => ({
-				name: String(result.value),
+				name: result.name,
 				description: result.description ?? null,
 				model: {
 					provider: 'ollama',
@@ -450,7 +450,7 @@ export class ChatHubService {
 
 		return {
 			models: foundationModels.concat(inferenceProfileModels).map((result) => ({
-				name: String(result.name),
+				name: result.name,
 				description: result.description ?? String(result.value),
 				model: {
 					provider: 'awsBedrock',

--- a/packages/cli/src/modules/chat-hub/chat-hub.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.service.ts
@@ -450,8 +450,8 @@ export class ChatHubService {
 
 		return {
 			models: foundationModels.concat(inferenceProfileModels).map((result) => ({
-				name: String(result.value),
-				description: result.description ?? null,
+				name: String(result.name),
+				description: result.description ?? String(result.value),
 				model: {
 					provider: 'awsBedrock',
 					model: String(result.value),

--- a/packages/cli/src/modules/chat-hub/chat-hub.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.service.ts
@@ -159,6 +159,8 @@ export class ChatHubService {
 				return await this.fetchOllamaModels(credentials, additionalData);
 			case 'azureOpenAi':
 				return await this.fetchAzureOpenAiModels(credentials, additionalData);
+			case 'awsBedrock':
+				return await this.fetchAwsBedrockModels(credentials, additionalData);
 			case 'n8n':
 				return await this.fetchAgentWorkflowsAsModels(user);
 			case 'custom-agent':
@@ -352,6 +354,111 @@ export class ChatHubService {
 		// implementation here too.
 		return {
 			models: [],
+		};
+	}
+
+	private async fetchAwsBedrockModels(
+		credentials: INodeCredentials,
+		additionalData: IWorkflowExecuteAdditionalData,
+	): Promise<ChatModelsResponse['awsBedrock']> {
+		// From AWS Bedrock node
+		// https://github.com/n8n-io/n8n/blob/master/packages/%40n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/LmChatAwsBedrock.node.ts#L100
+		// https://github.com/n8n-io/n8n/blob/master/packages/%40n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/LmChatAwsBedrock.node.ts#L155
+		const foundationModelsRequest = this.nodeParametersService.getOptionsViaLoadOptions(
+			{
+				routing: {
+					request: {
+						method: 'GET',
+						url: '/foundation-models?&byOutputModality=TEXT&byInferenceType=ON_DEMAND',
+					},
+					output: {
+						postReceive: [
+							{
+								type: 'rootProperty',
+								properties: {
+									property: 'modelSummaries',
+								},
+							},
+							{
+								type: 'setKeyValue',
+								properties: {
+									name: '={{$responseItem.modelName}}',
+									description: '={{$responseItem.modelArn}}',
+									value: '={{$responseItem.modelId}}',
+								},
+							},
+							{
+								type: 'sort',
+								properties: {
+									key: 'name',
+								},
+							},
+						],
+					},
+				},
+			},
+			additionalData,
+			PROVIDER_NODE_TYPE_MAP.awsBedrock,
+			{},
+			credentials,
+		);
+
+		const inferenceProfileModelsRequest = this.nodeParametersService.getOptionsViaLoadOptions(
+			{
+				routing: {
+					request: {
+						method: 'GET',
+						url: '/inference-profiles?maxResults=1000',
+					},
+					output: {
+						postReceive: [
+							{
+								type: 'rootProperty',
+								properties: {
+									property: 'inferenceProfileSummaries',
+								},
+							},
+							{
+								type: 'setKeyValue',
+								properties: {
+									name: '={{$responseItem.inferenceProfileName}}',
+									description:
+										'={{$responseItem.description || $responseItem.inferenceProfileArn}}',
+									value: '={{$responseItem.inferenceProfileId}}',
+								},
+							},
+							{
+								type: 'sort',
+								properties: {
+									key: 'name',
+								},
+							},
+						],
+					},
+				},
+			},
+			additionalData,
+			PROVIDER_NODE_TYPE_MAP.awsBedrock,
+			{},
+			credentials,
+		);
+
+		const [foundationModels, inferenceProfileModels] = await Promise.all([
+			foundationModelsRequest,
+			inferenceProfileModelsRequest,
+		]);
+
+		return {
+			models: foundationModels.concat(inferenceProfileModels).map((result) => ({
+				name: String(result.value),
+				description: result.description ?? null,
+				model: {
+					provider: 'awsBedrock',
+					model: String(result.value),
+				},
+				createdAt: null,
+				updatedAt: null,
+			})),
 		};
 	}
 

--- a/packages/cli/src/modules/chat-hub/context-limits.ts
+++ b/packages/cli/src/modules/chat-hub/context-limits.ts
@@ -139,6 +139,7 @@ export const maxContextWindowTokens: Record<ChatHubLLMProvider, Record<string, n
 	},
 	azureOpenAi: {},
 	ollama: {},
+	awsBedrock: {},
 };
 
 export const getMaxContextWindowTokens = (

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/constants.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/constants.ts
@@ -13,6 +13,7 @@ export const providerDisplayNames: Record<ChatHubProvider, string> = {
 	google: 'Google',
 	azureOpenAi: 'Azure OpenAI',
 	ollama: 'Ollama',
+	awsBedrock: 'AWS Bedrock',
 	n8n: 'n8n',
 	'custom-agent': 'Custom Agent',
 };


### PR DESCRIPTION
## Summary

This PR adds Azure Bedrock models support for chat hub. There's two `modelSource` options that the user can choose from but this just fetches models from both options for now to a combined list, and doesn't set the `modelSource` on the generated WF as it doesn't appear to do any difference at runtime 🤔 

Also changed how the Azure models gets set as it doesn't actually use a resource locator, I'll address the separate credential types for the azure model that I discovered on a separate PR.

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/CHA-63/feature-add-more-models

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
