### PR TITLE
fix(editor): Notice background colors

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nNotice/Notice.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nNotice/Notice.vue
@@ -109,13 +109,13 @@ const onClick = (event: MouseEvent) => {
 }
 
 .danger {
-	--border-color: var(--color--danger--tint-3);
-	--notice--color--background: var(--color--danger--tint-4);
+	--border-color: var(--callout--border-color--danger);
+	--notice--color--background: var(--callout--color--background--danger);
 }
 
 .success {
-	--border-color: var(--color--success--tint-3);
-	--notice--color--background: var(--color--success--tint-4);
+	--border-color: var(--callout--border-color--success);
+	--notice--color--background: var(--callout--color--background--success);
 }
 
 .info {


### PR DESCRIPTION
## Summary
Fixes the notice colour issue in dark mode.
<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/ADO-4439/bug-error-message-on-mcplovable-oauth-screen-is-unreadable#comment-cffd56c8
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
