### PR TITLE
chore(editor): Improve agent builder prompt field tooltips

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nPromptInput/N8nPromptInput.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nPromptInput/N8nPromptInput.vue
@@ -415,7 +415,7 @@ defineExpose({
 				</div>
 			</template>
 		</div>
-		<!-- :content="creditsTooltipContent" -->
+
 		<!-- Credits bar below input -->
 		<div v-if="showCredits" :class="$style.creditsBar">
 			<div :class="$style.creditsInfoWrapper">

--- a/packages/frontend/@n8n/design-system/src/components/N8nPromptInput/N8nPromptInput.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nPromptInput/N8nPromptInput.vue
@@ -415,7 +415,7 @@ defineExpose({
 				</div>
 			</template>
 		</div>
-
+		<!-- :content="creditsTooltipContent" -->
 		<!-- Credits bar below input -->
 		<div v-if="showCredits" :class="$style.creditsBar">
 			<div :class="$style.creditsInfoWrapper">
@@ -423,6 +423,7 @@ defineExpose({
 				<N8nTooltip
 					:content="creditsTooltipContent"
 					:popper-class="$style.infoPopper"
+					:show-after="300"
 					placement="top"
 				>
 					<N8nIcon icon="info" size="small" />
@@ -432,6 +433,8 @@ defineExpose({
 				:disabled="!showAskOwnerTooltip"
 				:content="t('promptInput.askAdminToUpgrade')"
 				placement="top"
+				:show-after="300"
+				:enterable="false"
 			>
 				<N8nLink size="small" theme="text" @click="() => emit('upgrade-click')">
 					{{ t('promptInput.getMore') }}

--- a/packages/frontend/@n8n/design-system/src/locale/lang/en.ts
+++ b/packages/frontend/@n8n/design-system/src/locale/lang/en.ts
@@ -86,7 +86,7 @@ export default {
 	'promptInput.askAdminToUpgrade': 'Ask your admin to upgrade the instance to get more credits',
 	'promptInput.characterLimitReached': "You've reached the {limit} character limit",
 	'promptInput.remainingCredits': 'Remaining builder AI credits: <b>{count}</b>',
-	'promptInput.monthlyCredits': 'Monthly credits: <b>{count}</b>',
+	'promptInput.monthlyCredits': 'Monthly credits: <b>{count}</b> (1 credit = 1 message)',
 	'promptInput.creditsRenew': 'Credits renew on: <b>{date}</b>',
 	'promptInput.creditsExpire': 'Unused credits expire {date}',
 } as N8nLocale;


### PR DESCRIPTION
## Summary
Updates AI agent builder prompt input tooltips
- Add delay to the tooltips
- Hide the 'Get more' tooltip on mouse out
- Update token count tooltip with info that one message equals to one prompt

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-1709/improve-agent-builder-prompt-field-tooltips
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds 300ms show delay and non-enterable behavior to prompt input tooltips and updates monthly credits text to note 1 credit = 1 message.
> 
> - **Prompt input tooltips** (`components/N8nPromptInput/N8nPromptInput.vue`):
>   - Add `:show-after="300"` to credits info and “Get more” tooltips.
>   - Set `:enterable="false"` for the “Get more” tooltip.
> - **Locale** (`locale/lang/en.ts`):
>   - Update `promptInput.monthlyCredits` to include “(1 credit = 1 message)”.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c23d202a7f9f48a5dd2ae89d560079619c696892. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->