### PR TITLE
chore(core): Add instanceType condition to load insights module only for main aand webhook

### DIFF
--- a/packages/cli/src/modules/insights/__tests__/insights.module.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.module.test.ts
@@ -7,6 +7,7 @@ import { mock } from 'jest-mock-extended';
 import { InstanceSettings } from 'n8n-core';
 
 import { InsightsModule } from '../insights.module';
+import { InsightsService } from '../insights.service';
 
 describe('InsightsModule', () => {
 	let insightsModule: InsightsModule;
@@ -23,11 +24,23 @@ describe('InsightsModule', () => {
 	beforeEach(async () => {
 		jest.clearAllMocks();
 		await testDb.truncate(['Project']);
-		insightsModule = Container.get(InsightsModule);
+
 		mockInstanceSettings = mock<InstanceSettings>();
 		Container.set(InstanceSettings, mockInstanceSettings);
 		Container.set(Logger, mockLogger());
 		Container.set(LicenseState, mock<LicenseState>());
+		Container.set(
+			InsightsService,
+			new InsightsService(
+				mock(),
+				mock(),
+				mock(),
+				Container.get(LicenseState),
+				mockInstanceSettings,
+				Container.get(Logger),
+			),
+		);
+		insightsModule = Container.get(InsightsModule);
 		await createTeamProject();
 	});
 

--- a/packages/cli/src/modules/insights/insights.module.ts
+++ b/packages/cli/src/modules/insights/insights.module.ts
@@ -1,17 +1,14 @@
 import type { ModuleInterface } from '@n8n/decorators';
 import { BackendModule, OnShutdown } from '@n8n/decorators';
 import { Container } from '@n8n/di';
-import { InstanceSettings } from 'n8n-core';
 
-@BackendModule({ name: 'insights' })
+/**
+ * Only main- and webhook-type instances collect insights because
+ * only they are informed of finished workflow executions.
+ */
+@BackendModule({ name: 'insights', instanceTypes: ['main', 'webhook'] })
 export class InsightsModule implements ModuleInterface {
 	async init() {
-		/**
-		 * Only main- and webhook-type instances collect insights because
-		 * only they are informed of finished workflow executions.
-		 */
-		if (Container.get(InstanceSettings).instanceType === 'worker') return;
-
 		await import('./insights.controller');
 
 		const { InsightsService } = await import('./insights.service');


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR makes use of the new `instanceTypes` backend module filtering field to completely prevent insights module from initializing on workers instance.
We keep the guardrails inside the service though

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-4121/conditionally-load-insights-depending-on-the-instance-type

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
