### PR TITLE
fix(core): Update state column type (no-changelog)

### DIFF
--- a/packages/@n8n/db/src/migrations/common/1763572724000-ChangeOAuthStateColumnToUnboundedVarchar.ts
+++ b/packages/@n8n/db/src/migrations/common/1763572724000-ChangeOAuthStateColumnToUnboundedVarchar.ts
@@ -1,0 +1,59 @@
+import type { IrreversibleMigration, MigrationContext } from '../migration-types';
+
+const TABLE_NAME = 'oauth_authorization_codes';
+const TEMP_TABLE_NAME = 'temp_oauth_authorization_codes';
+const COLUMN_NAME = 'state';
+
+export class ChangeOAuthStateColumnToUnboundedVarchar1763572724000
+	implements IrreversibleMigration
+{
+	async up({
+		isSqlite,
+		isMysql,
+		isPostgres,
+		escape,
+		copyTable,
+		queryRunner,
+		schemaBuilder: { createTable, column, dropTable },
+	}: MigrationContext) {
+		const tableName = escape.tableName(TABLE_NAME);
+		const columnName = escape.columnName(COLUMN_NAME);
+
+		if (isSqlite) {
+			const tempTableName = escape.tableName(TEMP_TABLE_NAME);
+
+			await createTable(TEMP_TABLE_NAME)
+				.withColumns(
+					column('code').varchar(255).primary.notNull,
+					column('clientId').varchar().notNull,
+					column('userId').uuid.notNull,
+					column('redirectUri').varchar(255).notNull,
+					column('codeChallenge').varchar(255).notNull,
+					column('codeChallengeMethod').varchar(255).notNull,
+					column('expiresAt').bigint.notNull.comment('Unix timestamp in milliseconds'),
+					column('state').varchar(),
+					column('used').bool.notNull.default(false),
+				)
+				.withForeignKey('clientId', {
+					tableName: 'oauth_clients',
+					columnName: 'id',
+					onDelete: 'CASCADE',
+				})
+				.withForeignKey('userId', {
+					tableName: 'user',
+					columnName: 'id',
+					onDelete: 'CASCADE',
+				}).withTimestamps;
+
+			await copyTable(TABLE_NAME, TEMP_TABLE_NAME);
+
+			await dropTable(TABLE_NAME);
+
+			await queryRunner.query(`ALTER TABLE ${tempTableName} RENAME TO ${tableName};`);
+		} else if (isMysql) {
+			await queryRunner.query(`ALTER TABLE ${tableName} MODIFY COLUMN ${columnName} VARCHAR;`);
+		} else if (isPostgres) {
+			await queryRunner.query(`ALTER TABLE ${tableName} ALTER COLUMN ${columnName} TYPE VARCHAR;`);
+		}
+	}
+}

--- a/packages/@n8n/db/src/migrations/common/1763572724000-ChangeOAuthStateColumnToUnboundedVarchar.ts
+++ b/packages/@n8n/db/src/migrations/common/1763572724000-ChangeOAuthStateColumnToUnboundedVarchar.ts
@@ -50,13 +50,13 @@ export class ChangeOAuthStateColumnToUnboundedVarchar1763572724000
 			await queryRunner.query(`ALTER TABLE ${tempTableName} RENAME TO ${tableName};`);
 		} else if (isMysql) {
 			await queryRunner.query(
-				`ALTER TABLE ${tableName} MODIFY COLUMN ${escape.columnName('state')} VARCHAR;`,
+				`ALTER TABLE ${tableName} MODIFY COLUMN ${escape.columnName('state')} TEXT;`,
 			);
 			await queryRunner.query(
-				`ALTER TABLE ${tableName} MODIFY COLUMN ${escape.columnName('codeChallenge')} VARCHAR;`,
+				`ALTER TABLE ${tableName} MODIFY COLUMN ${escape.columnName('codeChallenge')} TEXT NOT NULL;`,
 			);
 			await queryRunner.query(
-				`ALTER TABLE ${tableName} MODIFY COLUMN ${escape.columnName('redirectUri')} VARCHAR;`,
+				`ALTER TABLE ${tableName} MODIFY COLUMN ${escape.columnName('redirectUri')} TEXT NOT NULL;`,
 			);
 		} else if (isPostgres) {
 			await queryRunner.query(

--- a/packages/@n8n/db/src/migrations/common/1763572724000-ChangeOAuthStateColumnToUnboundedVarchar.ts
+++ b/packages/@n8n/db/src/migrations/common/1763572724000-ChangeOAuthStateColumnToUnboundedVarchar.ts
@@ -50,9 +50,13 @@ export class ChangeOAuthStateColumnToUnboundedVarchar1763572724000
 			await queryRunner.query(`ALTER TABLE ${tempTableName} RENAME TO ${tableName};`);
 		} else if (isMysql) {
 			await queryRunner.query(
-				`ALTER TABLE ${tableName} MODIFY COLUMN ${escape.columnName('state')} VARCHAR,` +
-					` MODIFY COLUMN ${escape.columnName('codeChallenge')} VARCHAR,` +
-					` MODIFY COLUMN ${escape.columnName('redirectUri')} VARCHAR;`,
+				`ALTER TABLE ${tableName} MODIFY COLUMN ${escape.columnName('state')} VARCHAR;`,
+			);
+			await queryRunner.query(
+				`ALTER TABLE ${tableName} MODIFY COLUMN ${escape.columnName('codeChallenge')} VARCHAR;`,
+			);
+			await queryRunner.query(
+				`ALTER TABLE ${tableName} MODIFY COLUMN ${escape.columnName('redirectUri')} VARCHAR;`,
 			);
 		} else if (isPostgres) {
 			await queryRunner.query(

--- a/packages/@n8n/db/src/migrations/mysqldb/index.ts
+++ b/packages/@n8n/db/src/migrations/mysqldb/index.ts
@@ -113,6 +113,7 @@ import { CreateOAuthEntities1760116750277 } from '../common/1760116750277-Create
 import { CreateWorkflowDependencyTable1760314000000 } from '../common/1760314000000-CreateWorkflowDependencyTable';
 import { AddWorkflowDescriptionColumn1762177736257 } from '../common/1762177736257-AddWorkflowDescriptionColumn';
 import { BackfillMissingWorkflowHistoryRecords1762763704614 } from '../common/1762763704614-BackfillMissingWorkflowHistoryRecords';
+import { ChangeOAuthStateColumnToUnboundedVarchar1763572724000 } from '../common/1763572724000-ChangeOAuthStateColumnToUnboundedVarchar';
 import type { Migration } from '../migration-types';
 
 export const mysqlMigrations: Migration[] = [
@@ -231,4 +232,5 @@ export const mysqlMigrations: Migration[] = [
 	BackfillMissingWorkflowHistoryRecords1762763704614,
 	AddWorkflowHistoryAutoSaveFields1762847206508,
 	AddToolsColumnToChatHubTables1761830340990,
+	ChangeOAuthStateColumnToUnboundedVarchar1763572724000,
 ];

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -113,6 +113,7 @@ import { AddToolsColumnToChatHubTables1761830340990 } from '../common/1761830340
 import { AddWorkflowDescriptionColumn1762177736257 } from '../common/1762177736257-AddWorkflowDescriptionColumn';
 import { BackfillMissingWorkflowHistoryRecords1762763704614 } from '../common/1762763704614-BackfillMissingWorkflowHistoryRecords';
 import { AddWorkflowHistoryAutoSaveFields1762847206508 } from '../common/1762847206508-AddWorkflowHistoryAutoSaveFields';
+import { ChangeOAuthStateColumnToUnboundedVarchar1763572724000 } from '../common/1763572724000-ChangeOAuthStateColumnToUnboundedVarchar';
 import type { Migration } from '../migration-types';
 
 export const postgresMigrations: Migration[] = [
@@ -231,4 +232,5 @@ export const postgresMigrations: Migration[] = [
 	ChangeDefaultForIdInUserTable1762771264000,
 	AddWorkflowHistoryAutoSaveFields1762847206508,
 	AddToolsColumnToChatHubTables1761830340990,
+	ChangeOAuthStateColumnToUnboundedVarchar1763572724000,
 ];

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -109,6 +109,7 @@ import { AddToolsColumnToChatHubTables1761830340990 } from '../common/1761830340
 import { AddWorkflowDescriptionColumn1762177736257 } from '../common/1762177736257-AddWorkflowDescriptionColumn';
 import { BackfillMissingWorkflowHistoryRecords1762763704614 } from '../common/1762763704614-BackfillMissingWorkflowHistoryRecords';
 import { AddWorkflowHistoryAutoSaveFields1762847206508 } from '../common/1762847206508-AddWorkflowHistoryAutoSaveFields';
+import { ChangeOAuthStateColumnToUnboundedVarchar1763572724000 } from '../common/1763572724000-ChangeOAuthStateColumnToUnboundedVarchar';
 import type { Migration } from '../migration-types';
 
 const sqliteMigrations: Migration[] = [
@@ -223,6 +224,7 @@ const sqliteMigrations: Migration[] = [
 	BackfillMissingWorkflowHistoryRecords1762763704614,
 	AddWorkflowHistoryAutoSaveFields1762847206508,
 	AddToolsColumnToChatHubTables1761830340990,
+	ChangeOAuthStateColumnToUnboundedVarchar1763572724000,
 ];
 
 export { sqliteMigrations };


### PR DESCRIPTION
## Summary

This column is generated by Lovable (the client), and it appears they use some instance metadata to calculate it. Because of this, the flow works in some instances but not in others, as the state value can exceed the initial VARCHAR(256) limit. This is why it worked fine during the internal testing of the feature.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADOP-10/bug-fix-issue-doing-oauth-flow-for-some-instances

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
