### PR TITLE
fix(Sort Node): Fix intermittent "Sort code doesn't return" error

### DIFF
--- a/packages/nodes-base/nodes/Transform/Sort/test/Sort.test.ts
+++ b/packages/nodes-base/nodes/Transform/Sort/test/Sort.test.ts
@@ -1,5 +1,197 @@
+import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
 import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+
+import { sortByCode } from '../utils';
 
 describe('Test Sort Node', () => {
 	new NodeTestHarness().setupTests();
+});
+
+describe('sortByCode', () => {
+	let mockExecuteFunctions: IExecuteFunctions;
+	const mockNode = { name: 'Sort', type: 'n8n-nodes-base.sort' };
+
+	beforeEach(() => {
+		mockExecuteFunctions = {
+			getNodeParameter: jest.fn(),
+			getNode: jest.fn().mockReturnValue(mockNode),
+			getMode: jest.fn().mockReturnValue('manual'),
+		} as unknown as IExecuteFunctions;
+	});
+
+	describe('Multiple consecutive executions (stateful regex bug)', () => {
+		it('should successfully validate code with return statement on multiple consecutive calls', () => {
+			const code = 'return -1';
+			const items: INodeExecutionData[] = [
+				{ json: { value: 3 } },
+				{ json: { value: 1 } },
+				{ json: { value: 2 } },
+			];
+
+			(mockExecuteFunctions.getNodeParameter as jest.Mock).mockReturnValue(code);
+
+			// Call sortByCode multiple times consecutively
+			// This tests the stateful regex bug where the global flag would cause
+			// the regex to fail after 2-3 executions
+			expect(() => sortByCode.call(mockExecuteFunctions, items)).not.toThrow();
+			expect(() => sortByCode.call(mockExecuteFunctions, items)).not.toThrow();
+			expect(() => sortByCode.call(mockExecuteFunctions, items)).not.toThrow();
+			expect(() => sortByCode.call(mockExecuteFunctions, items)).not.toThrow();
+			expect(() => sortByCode.call(mockExecuteFunctions, items)).not.toThrow();
+		});
+
+		it('should consistently throw error for code without return statement on multiple calls', () => {
+			const code = 'a.json.value - b.json.value'; // Missing return statement
+			const items: INodeExecutionData[] = [{ json: { value: 1 } }];
+
+			(mockExecuteFunctions.getNodeParameter as jest.Mock).mockReturnValue(code);
+
+			// Should consistently throw error on every call
+			expect(() => sortByCode.call(mockExecuteFunctions, items)).toThrow(NodeOperationError);
+			expect(() => sortByCode.call(mockExecuteFunctions, items)).toThrow(
+				"Sort code doesn't return. Please add a 'return' statement to your code",
+			);
+			expect(() => sortByCode.call(mockExecuteFunctions, items)).toThrow(NodeOperationError);
+			expect(() => sortByCode.call(mockExecuteFunctions, items)).toThrow(
+				"Sort code doesn't return. Please add a 'return' statement to your code",
+			);
+			expect(() => sortByCode.call(mockExecuteFunctions, items)).toThrow(NodeOperationError);
+		});
+
+		it('should handle alternating valid and invalid code correctly', () => {
+			const validCode = 'return -1';
+			const invalidCode = 'a.json.value - b.json.value';
+			const items: INodeExecutionData[] = [{ json: { value: 1 } }];
+
+			// Alternate between valid and invalid code
+			(mockExecuteFunctions.getNodeParameter as jest.Mock).mockReturnValue(validCode);
+			expect(() => sortByCode.call(mockExecuteFunctions, items)).not.toThrow();
+
+			(mockExecuteFunctions.getNodeParameter as jest.Mock).mockReturnValue(invalidCode);
+			expect(() => sortByCode.call(mockExecuteFunctions, items)).toThrow(NodeOperationError);
+
+			(mockExecuteFunctions.getNodeParameter as jest.Mock).mockReturnValue(validCode);
+			expect(() => sortByCode.call(mockExecuteFunctions, items)).not.toThrow();
+
+			(mockExecuteFunctions.getNodeParameter as jest.Mock).mockReturnValue(invalidCode);
+			expect(() => sortByCode.call(mockExecuteFunctions, items)).toThrow(NodeOperationError);
+
+			(mockExecuteFunctions.getNodeParameter as jest.Mock).mockReturnValue(validCode);
+			expect(() => sortByCode.call(mockExecuteFunctions, items)).not.toThrow();
+		});
+	});
+
+	describe('Return statement validation', () => {
+		it('should accept code with simple return statement', () => {
+			const code = 'return a.json.value - b.json.value';
+			const items: INodeExecutionData[] = [{ json: { value: 1 } }];
+
+			(mockExecuteFunctions.getNodeParameter as jest.Mock).mockReturnValue(code);
+
+			expect(() => sortByCode.call(mockExecuteFunctions, items)).not.toThrow();
+		});
+
+		it('should accept code with return statement in conditional', () => {
+			const code = 'if (a.json.value > b.json.value) return 1; return -1';
+			const items: INodeExecutionData[] = [{ json: { value: 1 } }];
+
+			(mockExecuteFunctions.getNodeParameter as jest.Mock).mockReturnValue(code);
+
+			expect(() => sortByCode.call(mockExecuteFunctions, items)).not.toThrow();
+		});
+
+		it('should accept code with multiple return statements', () => {
+			const code =
+				'if (a.json.value === b.json.value) return 0; return a.json.value - b.json.value';
+			const items: INodeExecutionData[] = [{ json: { value: 1 } }];
+
+			(mockExecuteFunctions.getNodeParameter as jest.Mock).mockReturnValue(code);
+
+			expect(() => sortByCode.call(mockExecuteFunctions, items)).not.toThrow();
+		});
+
+		it('should throw error when return statement is missing', () => {
+			const code = 'a.json.value - b.json.value';
+			const items: INodeExecutionData[] = [{ json: { value: 1 } }];
+
+			(mockExecuteFunctions.getNodeParameter as jest.Mock).mockReturnValue(code);
+
+			expect(() => sortByCode.call(mockExecuteFunctions, items)).toThrow(NodeOperationError);
+			expect(() => sortByCode.call(mockExecuteFunctions, items)).toThrow(
+				"Sort code doesn't return. Please add a 'return' statement to your code",
+			);
+		});
+
+		it('should not accept code with return as part of another word', () => {
+			const code = 'notreturn a.json.value - b.json.value';
+			const items: INodeExecutionData[] = [{ json: { value: 1 } }];
+
+			(mockExecuteFunctions.getNodeParameter as jest.Mock).mockReturnValue(code);
+
+			expect(() => sortByCode.call(mockExecuteFunctions, items)).toThrow(NodeOperationError);
+		});
+	});
+
+	describe('Sorting functionality', () => {
+		it('should sort items correctly with ascending order code', () => {
+			const code = 'return a.json.value - b.json.value';
+			const items: INodeExecutionData[] = [
+				{ json: { value: 3 } },
+				{ json: { value: 1 } },
+				{ json: { value: 2 } },
+			];
+
+			(mockExecuteFunctions.getNodeParameter as jest.Mock).mockReturnValue(code);
+
+			const result = sortByCode.call(mockExecuteFunctions, items);
+
+			expect(result).toEqual([
+				{ json: { value: 1 } },
+				{ json: { value: 2 } },
+				{ json: { value: 3 } },
+			]);
+		});
+
+		it('should sort items correctly with descending order code', () => {
+			const code = 'return b.json.value - a.json.value';
+			const items: INodeExecutionData[] = [
+				{ json: { value: 1 } },
+				{ json: { value: 3 } },
+				{ json: { value: 2 } },
+			];
+
+			(mockExecuteFunctions.getNodeParameter as jest.Mock).mockReturnValue(code);
+
+			const result = sortByCode.call(mockExecuteFunctions, items);
+
+			expect(result).toEqual([
+				{ json: { value: 3 } },
+				{ json: { value: 2 } },
+				{ json: { value: 1 } },
+			]);
+		});
+
+		it('should handle empty items array', () => {
+			const code = 'return a.json.value - b.json.value';
+			const items: INodeExecutionData[] = [];
+
+			(mockExecuteFunctions.getNodeParameter as jest.Mock).mockReturnValue(code);
+
+			const result = sortByCode.call(mockExecuteFunctions, items);
+
+			expect(result).toEqual([]);
+		});
+
+		it('should handle single item array', () => {
+			const code = 'return a.json.value - b.json.value';
+			const items: INodeExecutionData[] = [{ json: { value: 1 } }];
+
+			(mockExecuteFunctions.getNodeParameter as jest.Mock).mockReturnValue(code);
+
+			const result = sortByCode.call(mockExecuteFunctions, items);
+
+			expect(result).toEqual([{ json: { value: 1 } }]);
+		});
+	});
 });

--- a/packages/nodes-base/nodes/Transform/Sort/utils.ts
+++ b/packages/nodes-base/nodes/Transform/Sort/utils.ts
@@ -2,12 +2,14 @@ import { NodeVM } from '@n8n/vm2';
 import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 
-const returnRegExp = /\breturn\b/g;
+const returnRegExp = /\breturn\b/;
 export function sortByCode(
 	this: IExecuteFunctions,
 	items: INodeExecutionData[],
 ): INodeExecutionData[] {
 	const code = this.getNodeParameter('code', 0) as string;
+	// Reset regex state
+	returnRegExp.lastIndex = 0;
 	if (!returnRegExp.test(code)) {
 		throw new NodeOperationError(
 			this.getNode(),


### PR DESCRIPTION
## Summary

Fixes #12391 

The Sort node's code validation was failing intermittently due to a stateful regex bug. The `returnRegExp` regex was defined with the global flag (`/g`), causing it to maintain a `lastIndex` property that persisted between calls to `.test()`. This created an alternating pass/fail pattern where valid sort code would be incorrectly rejected on every other execution.

Fixed by:
- Removing the `/g` flag from `returnRegExp` (only need single match check)
- Adding defensive `lastIndex = 0` reset before validation

## Related Linear tickets, Github issues, and Community forum posts

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes stateful regex usage in `sortByCode` validation to prevent intermittent "doesn't return" errors and adds unit tests covering validation and sorting behavior.
> 
> - **Fix**:
>   - In `packages/nodes-base/nodes/Transform/Sort/utils.ts`, replace `returnRegExp` with non-global `/\breturn\b/` and defensively reset `lastIndex` before `.test()` to avoid stateful behavior across executions.
> - **Tests**:
>   - Add `packages/nodes-base/nodes/Transform/Sort/test/Sort.test.ts` covering:
>     - Multiple consecutive executions to ensure stable validation.
>     - Return statement validation (simple, conditional, multiple, missing, false positives).
>     - Sorting behavior (ascending, descending, empty, single item).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a749e2c633e6b49f815cdde707eb60daf1235ed4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->