### PR TITLE
feat(Aggregate Node): add group by functionality to aggregate node

### DIFF
--- a/packages/nodes-base/nodes/Transform/Aggregate/Aggregate.node.ts
+++ b/packages/nodes-base/nodes/Transform/Aggregate/Aggregate.node.ts
@@ -171,9 +171,19 @@ export class Aggregate implements INodeType {
 				displayName: 'Options',
 				name: 'options',
 				type: 'collection',
-				placeholder: 'Add Field',
+				placeholder: 'Add Option',
 				default: {},
 				options: [
+					{
+						displayName: 'Group By Fields',
+						name: 'groupByFields',
+						type: 'string',
+						default: '',
+						placeholder: 'e.g. category, type',
+						description:
+							'Comma-separated list of fields to group by. Creates one output item per unique combination of these field values. Dot-notation is supported to access nested fields.',
+						requiresDataPath: 'multiple',
+					},
 					{
 						displayName: 'Disable Dot Notation',
 						name: 'disableDotNotation',
@@ -244,6 +254,8 @@ export class Aggregate implements INodeType {
 		const notFoundedFields: { [key: string]: boolean[] } = {};
 
 		const aggregate = this.getNodeParameter('aggregate', 0, '') as string;
+		const groupByFieldsParam = this.getNodeParameter('options.groupByFields', 0, '') as string;
+		const groupByFields = prepareFieldsArray(groupByFieldsParam, 'Group By Fields');
 
 		if (aggregate === 'aggregateIndividualFields') {
 			const disableDotNotation = this.getNodeParameter(
@@ -405,20 +417,6 @@ export class Aggregate implements INodeType {
 			returnData = output;
 		}
 
-		const includeBinaries = this.getNodeParameter('options.includeBinaries', 0, false) as boolean;
-
-		if (includeBinaries) {
-			const pairedItems = (returnData.pairedItem || []) as IPairedItemData[];
-
-			const aggregatedItems = pairedItems.map((item) => {
-				return items[item.item];
-			});
-
-			const keepOnlyUnique = this.getNodeParameter('options.keepOnlyUnique', 0, false) as boolean;
-
-			addBinariesToItem(returnData, aggregatedItems, keepOnlyUnique);
-		}
-
 		if (Object.keys(notFoundedFields).length) {
 			const hints: NodeExecutionHint[] = [];
 
@@ -434,6 +432,246 @@ export class Aggregate implements INodeType {
 			if (hints.length) {
 				this.addExecutionHints(...hints);
 			}
+		}
+
+		// Apply grouping if specified
+		if (groupByFields.length > 0) {
+			const groups: {
+				[key: string]: { items: IDataObject[]; pairedItems: number[]; values: any[] };
+			} = {};
+
+			// Group original items by the specified fields
+			items.forEach((item, index) => {
+				const groupValues = groupByFields.map((field) => {
+					const value = get(item.json, field);
+					if (typeof value === 'object' && value !== null) {
+						throw new NodeOperationError(
+							this.getNode(),
+							`Field "${field}" has a non-scalar value which cannot be used for grouping.`,
+							{
+								description:
+									'Only scalar values (string, number, boolean, null) can be used in "Group By Fields".',
+							},
+						);
+					}
+					return value;
+				});
+				const groupKey = JSON.stringify(groupValues);
+
+				if (!groups[groupKey]) {
+					groups[groupKey] = { items: [], pairedItems: [], values: groupValues };
+				}
+
+				groups[groupKey].items.push(item.json);
+				groups[groupKey].pairedItems.push(index);
+			});
+
+			// Create output items for each group
+			const result: INodeExecutionData[] = [];
+			const groupPairedItems: number[][] = []; // Track all items in each group for binary aggregation
+
+			Object.values(groups).forEach((groupData) => {
+				const groupItem: IDataObject = {};
+
+				// Add the grouping field values to the output
+				groupByFields.forEach((field, index) => {
+					const value = groupData.values[index];
+					set(groupItem, field, value);
+				});
+
+				if (aggregate === 'aggregateAllItemData') {
+					const destinationFieldName = this.getNodeParameter('destinationFieldName', 0) as string;
+
+					// Check for conflicts with group-by field names
+					if (groupByFields.includes(destinationFieldName)) {
+						throw new NodeOperationError(
+							this.getNode(),
+							`The destination field '${destinationFieldName}' conflicts with a Group By field`,
+							{ description: 'Please choose a different destination field name or Group By field' },
+						);
+					}
+
+					const fieldsToExclude = prepareFieldsArray(
+						this.getNodeParameter('fieldsToExclude', 0, '') as string,
+						'Fields To Exclude',
+					);
+					const fieldsToInclude = prepareFieldsArray(
+						this.getNodeParameter('fieldsToInclude', 0, '') as string,
+						'Fields To Include',
+					);
+
+					let groupedAndFilteredItems = groupData.items;
+
+					if (fieldsToExclude.length || fieldsToInclude.length) {
+						groupedAndFilteredItems = groupedAndFilteredItems
+							.map((item) => {
+								const newItem: IDataObject = {};
+								let outputFields = Object.keys(item);
+
+								if (fieldsToExclude.length) {
+									outputFields = outputFields.filter((key) => !fieldsToExclude.includes(key));
+								}
+								if (fieldsToInclude.length) {
+									outputFields = outputFields.filter((key) =>
+										fieldsToInclude.length ? fieldsToInclude.includes(key) : true,
+									);
+								}
+
+								outputFields.forEach((key) => {
+									newItem[key] = item[key];
+								});
+								return newItem;
+							})
+							.filter((item) => !isEmpty(item));
+					}
+
+					groupItem[destinationFieldName] = groupedAndFilteredItems;
+				} else {
+					// For aggregateIndividualFields mode, recompute aggregation for the group
+					const fieldsToAggregate = this.getNodeParameter(
+						'fieldsToAggregate.fieldToAggregate',
+						0,
+						[],
+					) as [{ fieldToAggregate: string; renameField: boolean; outputFieldName: string }];
+					const disableDotNotation = this.getNodeParameter(
+						'options.disableDotNotation',
+						0,
+						false,
+					) as boolean;
+					const mergeLists = this.getNodeParameter('options.mergeLists', 0, false) as boolean;
+					const keepMissing = this.getNodeParameter('options.keepMissing', 0, false) as boolean;
+
+					// Validate that fields are specified
+					if (!fieldsToAggregate.length) {
+						throw new NodeOperationError(this.getNode(), 'No fields specified', {
+							description: 'Please add a field to aggregate',
+						});
+					}
+
+					// Validate unique output field names and detect conflicts with group-by fields
+					const outputFields: string[] = [];
+					for (const { fieldToAggregate, outputFieldName, renameField } of fieldsToAggregate) {
+						const getFieldToAggregate = () =>
+							!disableDotNotation && fieldToAggregate.includes('.')
+								? fieldToAggregate.split('.').pop()
+								: fieldToAggregate;
+
+						const field = renameField ? outputFieldName : (getFieldToAggregate() as string);
+
+						if (outputFields.includes(field)) {
+							throw new NodeOperationError(
+								this.getNode(),
+								`The '${field}' output field is used more than once`,
+								{ description: 'Please make sure each output field name is unique' },
+							);
+						}
+
+						// Check for conflicts with group-by field names
+						if (groupByFields.includes(field)) {
+							throw new NodeOperationError(
+								this.getNode(),
+								`The output field '${field}' conflicts with a Group By field`,
+								{
+									description:
+										'Please rename the aggregated field or choose a different Group By field',
+								},
+							);
+						}
+
+						outputFields.push(field);
+					}
+
+					const values: { [key: string]: any } = {};
+
+					for (const { fieldToAggregate, outputFieldName } of fieldsToAggregate) {
+						const getFieldToAggregate = () =>
+							!disableDotNotation && fieldToAggregate.includes('.')
+								? fieldToAggregate.split('.').pop()
+								: fieldToAggregate;
+
+						const _outputFieldName = outputFieldName
+							? outputFieldName
+							: (getFieldToAggregate() as string);
+
+						if (fieldToAggregate !== '') {
+							values[_outputFieldName] = [];
+							for (const itemJson of groupData.items) {
+								// Track missing fields
+								if (notFoundedFields[fieldToAggregate] === undefined) {
+									notFoundedFields[fieldToAggregate] = [];
+								}
+
+								let value;
+								if (!disableDotNotation) {
+									value = get(itemJson, fieldToAggregate);
+								} else {
+									value = itemJson[fieldToAggregate];
+								}
+
+								notFoundedFields[fieldToAggregate].push(value === undefined ? false : true);
+
+								if (!keepMissing) {
+									if (Array.isArray(value)) {
+										// Align with standard flow: filter only null, not undefined
+										value = value.filter((entry) => entry !== null);
+									} else if (value === null || value === undefined) {
+										continue;
+									}
+								}
+
+								if (Array.isArray(value) && mergeLists) {
+									values[_outputFieldName].push(...value);
+								} else {
+									values[_outputFieldName].push(value);
+								}
+							}
+						}
+					}
+
+					for (const key of Object.keys(values)) {
+						if (!disableDotNotation) {
+							set(groupItem, key, values[key]);
+						} else {
+							groupItem[key] = values[key];
+						}
+					}
+				}
+
+				// Store all paired items for binary aggregation
+				groupPairedItems.push(groupData.pairedItems);
+
+				result.push({
+					json: groupItem,
+					pairedItem: { item: groupData.pairedItems[0] },
+				});
+			});
+
+			const includeBinaries = this.getNodeParameter('options.includeBinaries', 0, false) as boolean;
+			if (includeBinaries) {
+				const keepOnlyUnique = this.getNodeParameter('options.keepOnlyUnique', 0, false) as boolean;
+				for (let i = 0; i < result.length; i++) {
+					const resultItem = result[i];
+					const pairedItemIndices = groupPairedItems[i];
+					const aggregatedItems = pairedItemIndices.map((itemIndex) => items[itemIndex]);
+					addBinariesToItem(resultItem, aggregatedItems, keepOnlyUnique);
+				}
+			}
+
+			return [result];
+		}
+
+		const includeBinaries = this.getNodeParameter('options.includeBinaries', 0, false) as boolean;
+
+		if (includeBinaries) {
+			const pairedItems = (returnData.pairedItem || []) as IPairedItemData[];
+
+			const aggregatedItems = pairedItems.map((item) => {
+				return items[item.item];
+			});
+
+			const keepOnlyUnique = this.getNodeParameter('options.keepOnlyUnique', 0, false) as boolean;
+
+			addBinariesToItem(returnData, aggregatedItems, keepOnlyUnique);
 		}
 
 		return [[returnData]];

--- a/packages/nodes-base/nodes/Transform/Aggregate/test/Aggregate.groupby.test.ts
+++ b/packages/nodes-base/nodes/Transform/Aggregate/test/Aggregate.groupby.test.ts
@@ -1,0 +1,391 @@
+import type { IExecuteFunctions, INode } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
+import { Aggregate } from '../Aggregate.node';
+
+describe('Aggregate Node - Group By Feature', () => {
+	let aggregate: Aggregate;
+	let mockExecuteFunctions: Partial<IExecuteFunctions>;
+	let mockNode: INode;
+
+	beforeEach(() => {
+		aggregate = new Aggregate();
+		mockNode = {
+			id: 'test-node-id',
+			name: 'Aggregate Test',
+			typeVersion: 1,
+			type: 'n8n-nodes-base.aggregate',
+			position: [0, 0],
+			parameters: {},
+		};
+
+		mockExecuteFunctions = {
+			getNode: jest.fn().mockReturnValue(mockNode),
+			getInputData: jest.fn(),
+			getNodeParameter: jest.fn(),
+			addExecutionHints: jest.fn(),
+		};
+	});
+
+	describe('Field Name Conflict Validation', () => {
+		it('should throw error when aggregated field conflicts with group-by field (aggregateIndividualFields)', async () => {
+			const inputData = [
+				{
+					json: { domain: 'yahoo.com', email: 'test1@yahoo.com' },
+					pairedItem: { item: 0 },
+				},
+				{
+					json: { domain: 'gmail.com', email: 'test2@gmail.com' },
+					pairedItem: { item: 1 },
+				},
+			];
+
+			(mockExecuteFunctions.getInputData as jest.Mock).mockReturnValue(inputData);
+			(mockExecuteFunctions.getNodeParameter as jest.Mock).mockImplementation(
+				(paramName: string) => {
+					if (paramName === 'aggregate') return 'aggregateIndividualFields';
+					if (paramName === 'options.groupByFields') return 'domain';
+					if (paramName === 'fieldsToAggregate.fieldToAggregate')
+						return [
+							{
+								fieldToAggregate: 'email',
+								renameField: true,
+								outputFieldName: 'domain', // Conflicts with group-by field
+							},
+						];
+					if (paramName === 'options.disableDotNotation') return false;
+					if (paramName === 'options.mergeLists') return false;
+					if (paramName === 'options.keepMissing') return false;
+					return '';
+				},
+			);
+
+			await expect(
+				aggregate.execute.call(mockExecuteFunctions as IExecuteFunctions),
+			).rejects.toThrow(NodeOperationError);
+			await expect(
+				aggregate.execute.call(mockExecuteFunctions as IExecuteFunctions),
+			).rejects.toThrow("The output field 'domain' conflicts with a Group By field");
+		});
+
+		it('should throw error when destination field conflicts with group-by field (aggregateAllItemData)', async () => {
+			const inputData = [
+				{
+					json: { domain: 'yahoo.com', email: 'test1@yahoo.com' },
+					pairedItem: { item: 0 },
+				},
+			];
+
+			(mockExecuteFunctions.getInputData as jest.Mock).mockReturnValue(inputData);
+			(mockExecuteFunctions.getNodeParameter as jest.Mock).mockImplementation(
+				(paramName: string) => {
+					if (paramName === 'aggregate') return 'aggregateAllItemData';
+					if (paramName === 'options.groupByFields') return 'domain';
+					if (paramName === 'destinationFieldName') return 'domain'; // Conflicts
+					if (paramName === 'fieldsToExclude') return '';
+					if (paramName === 'fieldsToInclude') return '';
+					return '';
+				},
+			);
+
+			await expect(
+				aggregate.execute.call(mockExecuteFunctions as IExecuteFunctions),
+			).rejects.toThrow(NodeOperationError);
+			await expect(
+				aggregate.execute.call(mockExecuteFunctions as IExecuteFunctions),
+			).rejects.toThrow("The destination field 'domain' conflicts with a Group By field");
+		});
+	});
+
+	describe('Duplicate Output Field Validation', () => {
+		it('should throw error when output field names are duplicated in grouped mode', async () => {
+			const inputData = [
+				{
+					json: { domain: 'yahoo.com', email: 'test@yahoo.com', name: 'Test' },
+					pairedItem: { item: 0 },
+				},
+			];
+
+			(mockExecuteFunctions.getInputData as jest.Mock).mockReturnValue(inputData);
+			(mockExecuteFunctions.getNodeParameter as jest.Mock).mockImplementation(
+				(paramName: string) => {
+					if (paramName === 'aggregate') return 'aggregateIndividualFields';
+					if (paramName === 'options.groupByFields') return 'domain';
+					if (paramName === 'fieldsToAggregate.fieldToAggregate')
+						return [
+							{
+								fieldToAggregate: 'email',
+								renameField: false,
+								outputFieldName: '',
+							},
+							{
+								fieldToAggregate: 'name',
+								renameField: true,
+								outputFieldName: 'email', // Duplicate!
+							},
+						];
+					if (paramName === 'options.disableDotNotation') return false;
+					if (paramName === 'options.mergeLists') return false;
+					if (paramName === 'options.keepMissing') return false;
+					return '';
+				},
+			);
+
+			await expect(
+				aggregate.execute.call(mockExecuteFunctions as IExecuteFunctions),
+			).rejects.toThrow(NodeOperationError);
+			await expect(
+				aggregate.execute.call(mockExecuteFunctions as IExecuteFunctions),
+			).rejects.toThrow("The 'email' output field is used more than once");
+		});
+	});
+
+	describe('Empty Fields Validation', () => {
+		it('should throw error when no fields are specified in grouped mode', async () => {
+			const inputData = [
+				{
+					json: { domain: 'yahoo.com', email: 'test@yahoo.com' },
+					pairedItem: { item: 0 },
+				},
+			];
+
+			(mockExecuteFunctions.getInputData as jest.Mock).mockReturnValue(inputData);
+			(mockExecuteFunctions.getNodeParameter as jest.Mock).mockImplementation(
+				(paramName: string) => {
+					if (paramName === 'aggregate') return 'aggregateIndividualFields';
+					if (paramName === 'options.groupByFields') return 'domain';
+					if (paramName === 'fieldsToAggregate.fieldToAggregate') return []; // Empty!
+					if (paramName === 'options.disableDotNotation') return false;
+					return '';
+				},
+			);
+
+			await expect(
+				aggregate.execute.call(mockExecuteFunctions as IExecuteFunctions),
+			).rejects.toThrow(NodeOperationError);
+			await expect(
+				aggregate.execute.call(mockExecuteFunctions as IExecuteFunctions),
+			).rejects.toThrow('No fields specified');
+		});
+	});
+
+	describe('Non-scalar Group By Field Validation', () => {
+		it('should throw error when trying to group by object field', async () => {
+			const inputData = [
+				{
+					json: { user: { name: 'John' }, email: 'john@example.com' },
+					pairedItem: { item: 0 },
+				},
+			];
+
+			(mockExecuteFunctions.getInputData as jest.Mock).mockReturnValue(inputData);
+			(mockExecuteFunctions.getNodeParameter as jest.Mock).mockImplementation(
+				(paramName: string) => {
+					if (paramName === 'aggregate') return 'aggregateAllItemData';
+					if (paramName === 'options.groupByFields') return 'user'; // Object field
+					if (paramName === 'destinationFieldName') return 'data';
+					if (paramName === 'fieldsToExclude') return '';
+					if (paramName === 'fieldsToInclude') return '';
+					return '';
+				},
+			);
+
+			await expect(
+				aggregate.execute.call(mockExecuteFunctions as IExecuteFunctions),
+			).rejects.toThrow(NodeOperationError);
+			await expect(
+				aggregate.execute.call(mockExecuteFunctions as IExecuteFunctions),
+			).rejects.toThrow('non-scalar value which cannot be used for grouping');
+		});
+	});
+
+	describe('Successful Grouping', () => {
+		it('should successfully group items by domain (aggregateAllItemData)', async () => {
+			const inputData = [
+				{
+					json: { domain: 'yahoo.com', email: 'test1@yahoo.com' },
+					pairedItem: { item: 0 },
+				},
+				{
+					json: { domain: 'gmail.com', email: 'test2@gmail.com' },
+					pairedItem: { item: 1 },
+				},
+				{
+					json: { domain: 'yahoo.com', email: 'test3@yahoo.com' },
+					pairedItem: { item: 2 },
+				},
+			];
+
+			(mockExecuteFunctions.getInputData as jest.Mock).mockReturnValue(inputData);
+			(mockExecuteFunctions.getNodeParameter as jest.Mock).mockImplementation(
+				(paramName: string) => {
+					if (paramName === 'aggregate') return 'aggregateAllItemData';
+					if (paramName === 'options.groupByFields') return 'domain';
+					if (paramName === 'destinationFieldName') return 'data';
+					if (paramName === 'fieldsToExclude') return '';
+					if (paramName === 'fieldsToInclude') return '';
+					if (paramName === 'options.includeBinaries') return false;
+					return '';
+				},
+			);
+
+			const result = await aggregate.execute.call(mockExecuteFunctions as IExecuteFunctions);
+
+			expect(result).toHaveLength(1);
+			expect(result[0]).toHaveLength(2); // Two groups: yahoo.com and gmail.com
+
+			// Check yahoo.com group
+			const yahooGroup = result[0].find((item) => item.json.domain === 'yahoo.com');
+			expect(yahooGroup).toBeDefined();
+			expect(yahooGroup?.json.data).toHaveLength(2);
+			expect(yahooGroup?.json.data).toEqual([
+				{ domain: 'yahoo.com', email: 'test1@yahoo.com' },
+				{ domain: 'yahoo.com', email: 'test3@yahoo.com' },
+			]);
+
+			// Check gmail.com group
+			const gmailGroup = result[0].find((item) => item.json.domain === 'gmail.com');
+			expect(gmailGroup).toBeDefined();
+			expect(gmailGroup?.json.data).toHaveLength(1);
+			expect(gmailGroup?.json.data).toEqual([{ domain: 'gmail.com', email: 'test2@gmail.com' }]);
+		});
+
+		it('should successfully group items by domain (aggregateIndividualFields)', async () => {
+			const inputData = [
+				{
+					json: { domain: 'yahoo.com', email: 'test1@yahoo.com', confirmed: true },
+					pairedItem: { item: 0 },
+				},
+				{
+					json: { domain: 'gmail.com', email: 'test2@gmail.com', confirmed: false },
+					pairedItem: { item: 1 },
+				},
+				{
+					json: { domain: 'yahoo.com', email: 'test3@yahoo.com', confirmed: false },
+					pairedItem: { item: 2 },
+				},
+			];
+
+			(mockExecuteFunctions.getInputData as jest.Mock).mockReturnValue(inputData);
+			(mockExecuteFunctions.getNodeParameter as jest.Mock).mockImplementation(
+				(paramName: string) => {
+					if (paramName === 'aggregate') return 'aggregateIndividualFields';
+					if (paramName === 'options.groupByFields') return 'domain';
+					if (paramName === 'fieldsToAggregate.fieldToAggregate')
+						return [
+							{
+								fieldToAggregate: 'email',
+								renameField: false,
+								outputFieldName: '',
+							},
+							{
+								fieldToAggregate: 'confirmed',
+								renameField: false,
+								outputFieldName: '',
+							},
+						];
+					if (paramName === 'options.disableDotNotation') return false;
+					if (paramName === 'options.mergeLists') return false;
+					if (paramName === 'options.keepMissing') return false;
+					if (paramName === 'options.includeBinaries') return false;
+					return '';
+				},
+			);
+
+			const result = await aggregate.execute.call(mockExecuteFunctions as IExecuteFunctions);
+
+			expect(result).toHaveLength(1);
+			expect(result[0]).toHaveLength(2); // Two groups
+
+			// Check yahoo.com group
+			const yahooGroup = result[0].find((item) => item.json.domain === 'yahoo.com');
+			expect(yahooGroup).toBeDefined();
+			expect(yahooGroup?.json.email).toEqual(['test1@yahoo.com', 'test3@yahoo.com']);
+			expect(yahooGroup?.json.confirmed).toEqual([true, false]);
+
+			// Check gmail.com group
+			const gmailGroup = result[0].find((item) => item.json.domain === 'gmail.com');
+			expect(gmailGroup).toBeDefined();
+			expect(gmailGroup?.json.email).toEqual(['test2@gmail.com']);
+			expect(gmailGroup?.json.confirmed).toEqual([false]);
+		});
+
+		it('should include binaries when includeBinaries option is enabled', async () => {
+			const inputData = [
+				{
+					json: { domain: 'yahoo.com', email: 'test1@yahoo.com' },
+					binary: {
+						file1: {
+							data: 'base64data1',
+							mimeType: 'text/plain',
+							fileExtension: 'txt',
+							fileSize: '100',
+							fileType: 'text',
+						} as any,
+					},
+					pairedItem: { item: 0 },
+				},
+				{
+					json: { domain: 'gmail.com', email: 'test2@gmail.com' },
+					binary: {
+						file2: {
+							data: 'base64data2',
+							mimeType: 'image/png',
+							fileExtension: 'png',
+							fileSize: '200',
+							fileType: 'image',
+						} as any,
+					},
+					pairedItem: { item: 1 },
+				},
+				{
+					json: { domain: 'yahoo.com', email: 'test3@yahoo.com' },
+					binary: {
+						file3: {
+							data: 'base64data3',
+							mimeType: 'text/plain',
+							fileExtension: 'txt',
+							fileSize: '150',
+							fileType: 'text',
+						} as any,
+					},
+					pairedItem: { item: 2 },
+				},
+			];
+
+			(mockExecuteFunctions.getInputData as jest.Mock).mockReturnValue(inputData);
+			(mockExecuteFunctions.getNodeParameter as jest.Mock).mockImplementation(
+				(paramName: string) => {
+					if (paramName === 'aggregate') return 'aggregateAllItemData';
+					if (paramName === 'options.groupByFields') return 'domain';
+					if (paramName === 'destinationFieldName') return 'data';
+					if (paramName === 'fieldsToExclude') return '';
+					if (paramName === 'fieldsToInclude') return '';
+					if (paramName === 'options.includeBinaries') return true;
+					if (paramName === 'options.keepOnlyUnique') return false;
+					return '';
+				},
+			);
+
+			const result = await aggregate.execute.call(mockExecuteFunctions as IExecuteFunctions);
+
+			expect(result).toHaveLength(1);
+			expect(result[0]).toHaveLength(2); // Two groups
+
+			// Check yahoo.com group has binaries from both items
+			const yahooGroup = result[0].find((item) => item.json.domain === 'yahoo.com');
+			expect(yahooGroup).toBeDefined();
+			expect(yahooGroup?.binary).toBeDefined();
+			expect(yahooGroup?.binary?.file1).toBeDefined();
+			expect(yahooGroup?.binary?.file3).toBeDefined();
+			expect(yahooGroup?.binary?.file1.mimeType).toBe('text/plain');
+			expect(yahooGroup?.binary?.file3.mimeType).toBe('text/plain');
+
+			// Check gmail.com group has binary
+			const gmailGroup = result[0].find((item) => item.json.domain === 'gmail.com');
+			expect(gmailGroup).toBeDefined();
+			expect(gmailGroup?.binary).toBeDefined();
+			expect(gmailGroup?.binary?.file2).toBeDefined();
+			expect(gmailGroup?.binary?.file2.mimeType).toBe('image/png');
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Transform/Aggregate/test/workflow.groupby.json
+++ b/packages/nodes-base/nodes/Transform/Aggregate/test/workflow.groupby.json
@@ -1,0 +1,298 @@
+{
+	"name": "Aggregate Group By Test",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "6c90bf81-0c0e-4c5f-9f0c-297f06d9668a",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [-440, 260]
+		},
+		{
+			"parameters": {
+				"jsCode": "return [\n  {\n    json: {\n      email: \"Grant.Goyette@hotmail.com\",\n      confirmed: true,\n      domain: 'hotmail.com'\n    }\n  },\n  {\n    json: {\n      email: \"Ian_Schroeder@yahoo.com\",\n      confirmed: false,\n      domain: 'yahoo.com'\n    }\n  },\n  {\n    json: {\n      email: \"Jerome83@yahoo.com\",\n      confirmed: false,\n      domain: 'yahoo.com'\n    }\n  },\n  {\n    json: {\n      email: \"Marie55@gmail.com\",\n      confirmed: false,\n      domain: 'gmail.com'\n    }\n  },\n  {\n    json: {\n      email: \"Rene78@yahoo.com\",\n      confirmed: true,\n      domain: 'yahoo.com'\n    }\n  }\n]"
+			},
+			"id": "2e0011d5-c6a0-4a40-ab8c-9d011cde40d5",
+			"name": "Code",
+			"type": "n8n-nodes-base.code",
+			"typeVersion": 2,
+			"position": [-180, 260]
+		},
+		{
+			"parameters": {
+				"aggregate": "aggregateAllItemData",
+				"options": {
+					"groupByFields": "domain"
+				}
+			},
+			"id": "29086978-669e-49de-a153-8ab5cf423f3a",
+			"name": "Group By - Aggregate All",
+			"type": "n8n-nodes-base.aggregate",
+			"typeVersion": 1,
+			"position": [80, 0]
+		},
+		{
+			"parameters": {
+				"fieldsToAggregate": {
+					"fieldToAggregate": [
+						{
+							"fieldToAggregate": "email"
+						},
+						{
+							"fieldToAggregate": "confirmed",
+							"renameField": true,
+							"outputFieldName": "confirmStatus"
+						}
+					]
+				},
+				"options": {
+					"groupByFields": "domain"
+				}
+			},
+			"id": "68650cbd-3885-4e68-9398-57ac13b75d55",
+			"name": "Group By - Individual Fields",
+			"type": "n8n-nodes-base.aggregate",
+			"typeVersion": 1,
+			"position": [80, 200]
+		},
+		{
+			"parameters": {
+				"aggregate": "aggregateAllItemData",
+				"destinationFieldName": "emails",
+				"include": "specifiedFields",
+				"fieldsToInclude": "email, confirmed",
+				"options": {
+					"groupByFields": "domain"
+				}
+			},
+			"id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+			"name": "Group By - Selected Fields",
+			"type": "n8n-nodes-base.aggregate",
+			"typeVersion": 1,
+			"position": [80, 400]
+		},
+		{
+			"parameters": {
+				"aggregate": "aggregateAllItemData",
+				"destinationFieldName": "items",
+				"include": "allFieldsExcept",
+				"fieldsToExclude": "domain",
+				"options": {
+					"groupByFields": "domain"
+				}
+			},
+			"id": "b2c3d4e5-f6g7-8901-bcde-fg2345678901",
+			"name": "Group By - Exclude Fields",
+			"type": "n8n-nodes-base.aggregate",
+			"typeVersion": 1,
+			"position": [80, 600]
+		}
+	],
+	"pinData": {
+		"Group By - Aggregate All": [
+			{
+				"json": {
+					"domain": "hotmail.com",
+					"data": [
+						{
+							"email": "Grant.Goyette@hotmail.com",
+							"confirmed": true,
+							"domain": "hotmail.com"
+						}
+					]
+				}
+			},
+			{
+				"json": {
+					"domain": "yahoo.com",
+					"data": [
+						{
+							"email": "Ian_Schroeder@yahoo.com",
+							"confirmed": false,
+							"domain": "yahoo.com"
+						},
+						{
+							"email": "Jerome83@yahoo.com",
+							"confirmed": false,
+							"domain": "yahoo.com"
+						},
+						{
+							"email": "Rene78@yahoo.com",
+							"confirmed": true,
+							"domain": "yahoo.com"
+						}
+					]
+				}
+			},
+			{
+				"json": {
+					"domain": "gmail.com",
+					"data": [
+						{
+							"email": "Marie55@gmail.com",
+							"confirmed": false,
+							"domain": "gmail.com"
+						}
+					]
+				}
+			}
+		],
+		"Group By - Individual Fields": [
+			{
+				"json": {
+					"domain": "hotmail.com",
+					"email": ["Grant.Goyette@hotmail.com"],
+					"confirmStatus": [true]
+				}
+			},
+			{
+				"json": {
+					"domain": "yahoo.com",
+					"email": ["Ian_Schroeder@yahoo.com", "Jerome83@yahoo.com", "Rene78@yahoo.com"],
+					"confirmStatus": [false, false, true]
+				}
+			},
+			{
+				"json": {
+					"domain": "gmail.com",
+					"email": ["Marie55@gmail.com"],
+					"confirmStatus": [false]
+				}
+			}
+		],
+		"Group By - Selected Fields": [
+			{
+				"json": {
+					"domain": "hotmail.com",
+					"emails": [
+						{
+							"email": "Grant.Goyette@hotmail.com",
+							"confirmed": true
+						}
+					]
+				}
+			},
+			{
+				"json": {
+					"domain": "yahoo.com",
+					"emails": [
+						{
+							"email": "Ian_Schroeder@yahoo.com",
+							"confirmed": false
+						},
+						{
+							"email": "Jerome83@yahoo.com",
+							"confirmed": false
+						},
+						{
+							"email": "Rene78@yahoo.com",
+							"confirmed": true
+						}
+					]
+				}
+			},
+			{
+				"json": {
+					"domain": "gmail.com",
+					"emails": [
+						{
+							"email": "Marie55@gmail.com",
+							"confirmed": false
+						}
+					]
+				}
+			}
+		],
+		"Group By - Exclude Fields": [
+			{
+				"json": {
+					"domain": "hotmail.com",
+					"items": [
+						{
+							"email": "Grant.Goyette@hotmail.com",
+							"confirmed": true
+						}
+					]
+				}
+			},
+			{
+				"json": {
+					"domain": "yahoo.com",
+					"items": [
+						{
+							"email": "Ian_Schroeder@yahoo.com",
+							"confirmed": false
+						},
+						{
+							"email": "Jerome83@yahoo.com",
+							"confirmed": false
+						},
+						{
+							"email": "Rene78@yahoo.com",
+							"confirmed": true
+						}
+					]
+				}
+			},
+			{
+				"json": {
+					"domain": "gmail.com",
+					"items": [
+						{
+							"email": "Marie55@gmail.com",
+							"confirmed": false
+						}
+					]
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Code",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Code": {
+			"main": [
+				[
+					{
+						"node": "Group By - Aggregate All",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "Group By - Individual Fields",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "Group By - Selected Fields",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "Group By - Exclude Fields",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {},
+	"versionId": "test-groupby-v1",
+	"id": "groupby-test",
+	"meta": {
+		"instanceId": "test"
+	},
+	"tags": []
+}


### PR DESCRIPTION
## Summary

_`Group By and Aggregate go together like peas and carrots 🥕` - Forrest Gump (probably)_

This PR adds Group By support to the Aggregate node, enabling users to group items by field values before aggregating. This is a fundamental data manipulation pattern that brings n8n closer to standards like SQL GROUP BY, Pandas groupby(), or Excel Pivot Tables.

### Features
✅ Group by fields: Split data into groups based on one or multiple fields (comma-separated).
✅ Flexible Modes: Supports both "Individual Fields" and "All Item Data" aggregation modes within the groups.
✅ Binary Support: Full support for including/grouping binary data.

### Why Add This?
Group By is essential for structured data aggregation. It allows users to move from a global aggregation to specific buckets.

Before (One aggregation across all items):
```js
// Output: 1 item
{
  emails: ["user1@yahoo.com", "user2@gmail.com", "user3@yahoo.com", "user4@hotmail.com"]
}
```

After (Group By 'domain'):
```js
// Output: 3 items
[
  { domain: "yahoo.com", emails: ["user1@yahoo.com", "user3@yahoo.com"] },
  { domain: "gmail.com", emails: ["user2@gmail.com"] },
  { domain: "hotmail.com", emails: ["user4@hotmail.com"] }
]
```

### Outstanding Questions

Item Linking (pairedItem): Initially, I mapped all constituent input items to the pairedItem array for the resulting group (which seemed semantically correct). However, I didn't observe any functional use in the UI when compared to just mapping the first item. I found just using the first item at least gives me a way to trace back to an originating item, i.e. allowing `$('previous node').item` to work.

Mapping all related items as an array would return the same as if no mapping took place:
<img width="746" height="152" alt="image" src="https://github.com/user-attachments/assets/0d4ba46e-1bba-4052-8713-27e855df0317" />


### Sample Workflow

<img width="1466" height="508" alt="image" src="https://github.com/user-attachments/assets/2e9f76b2-3848-4f2a-a628-a1fde9f8aae2" />

<details>
<summary> Click to expand workflow JSON</summary>

```json
{
  "nodes": [
    {
      "parameters": {},
      "type": "n8n-nodes-base.manualTrigger",
      "typeVersion": 1,
      "position": [
        0,
        -80
      ],
      "id": "28bdc599-680f-4306-b43f-a972c5ac5ab4",
      "name": "When clicking ‘Execute workflow’"
    },
    {
      "parameters": {
        "aggregate": "aggregateAllItemData",
        "options": {
          "groupByFields": "domain",
          "includeBinaries": true
        }
      },
      "type": "n8n-nodes-base.aggregate",
      "typeVersion": 1,
      "position": [
        880,
        -176
      ],
      "id": "29086978-669e-49de-a153-8ab5cf423f3a",
      "name": "Aggregate All"
    },
    {
      "parameters": {
        "fieldsToAggregate": {
          "fieldToAggregate": [
            {
              "fieldToAggregate": "email"
            },
            {
              "fieldToAggregate": "confirmed",
              "renameField": true,
              "outputFieldName": "T/F"
            }
          ]
        },
        "options": {
          "groupByFields": "domain"
        }
      },
      "type": "n8n-nodes-base.aggregate",
      "typeVersion": 1,
      "position": [
        448,
        16
      ],
      "id": "68650cbd-3885-4e68-9398-57ac13b75d55",
      "name": "Aggregate Individual"
    },
    {
      "parameters": {
        "operation": "toText",
        "sourceProperty": "email",
        "options": {}
      },
      "type": "n8n-nodes-base.convertToFile",
      "typeVersion": 1.1,
      "position": [
        448,
        -176
      ],
      "id": "4facc738-c1ef-4923-a44b-24e687a98adf",
      "name": "Convert to File"
    },
    {
      "parameters": {
        "mode": "raw",
        "jsonOutput": "={{ \n$('Emails').item.json\n}}",
        "includeOtherFields": true,
        "options": {}
      },
      "type": "n8n-nodes-base.set",
      "typeVersion": 3.4,
      "position": [
        656,
        -176
      ],
      "id": "c2ff68b1-7552-444a-93b5-dbe6b5f903a3",
      "name": "Add Fields"
    },
    {
      "parameters": {
        "jsCode": "return [\n  {\n    json: {\n      email: \"Grant.Goyette@hotmail.com\",\n      confirmed: true,\n      domain: 'hotmail.com'\n    }\n  },\n  {\n    json: {\n      email: \"Ian_Schroeder@yahoo.com\",\n      confirmed: false,\n      domain: 'yahoo.com'\n    }\n  },\n  {\n    json: {\n      email: \"Jerome83@yahoo.com\",\n      confirmed: false,\n      domain: 'yahoo.com'\n    }\n  },\n  {\n    json: {\n      email: \"Marie55@gmail.com\",\n      confirmed: false,\n      domain: 'gmail.com'\n    }\n  },\n  {\n    json: {\n      email: \"Rene78@yahoo.com\",\n      confirmed: true,\n      domain: 'yahoo.com'\n    }\n  },\n]"
      },
      "type": "n8n-nodes-base.code",
      "typeVersion": 2,
      "position": [
        224,
        -80
      ],
      "id": "c74ca043-1115-4d60-9834-f08cab7dfd04",
      "name": "Emails"
    },
    {
      "parameters": {
        "assignments": {
          "assignments": [
            {
              "id": "f5422421-b865-4488-b261-33a95f51b724",
              "name": "orig_data",
              "value": "={{ $('Emails').item.json }}",
              "type": "string"
            }
          ]
        },
        "includeOtherFields": true,
        "options": {}
      },
      "type": "n8n-nodes-base.set",
      "typeVersion": 3.4,
      "position": [
        1088,
        -176
      ],
      "id": "12963bce-e1c4-42f3-b86b-ca3e3af8ce7f",
      "name": "PairedItem"
    }
  ],
  "connections": {
    "When clicking ‘Execute workflow’": {
      "main": [
        [
          {
            "node": "Emails",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Aggregate All": {
      "main": [
        [
          {
            "node": "PairedItem",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Convert to File": {
      "main": [
        [
          {
            "node": "Add Fields",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Add Fields": {
      "main": [
        [
          {
            "node": "Aggregate All",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Emails": {
      "main": [
        [
          {
            "node": "Aggregate Individual",
            "type": "main",
            "index": 0
          },
          {
            "node": "Convert to File",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {}
}
```

</details>


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds configurable group-by to `Aggregate` with nested-field conflict checks, per-group aggregation for both modes, and binary handling, plus comprehensive tests and example workflow.
> 
> - **Aggregate node (`packages/nodes-base/nodes/Transform/Aggregate/Aggregate.node.ts`)**:
>   - **Feature**: New `options.groupByFields` enabling grouping by one or more fields (dot-notation supported) with per-group outputs.
>   - **Aggregation**: Supports grouping for both `aggregateIndividualFields` and `aggregateAllItemData`, re-aggregating within each group.
>   - **Validation**:
>     - Reject non-scalar group-by values.
>     - Detect nested field path conflicts via `hasNestedPathConflict` between group-by fields and output/destination fields.
>     - Enforce unique output field names; preserve existing missing/merge behaviors.
>   - **Binaries**: Include binaries per group with optional uniqueness filtering.
>   - Minor: options placeholder changed to `Add Option`.
> - **Tests** (`packages/nodes-base/nodes/Transform/Aggregate/test/Aggregate.groupby.test.ts`):
>   - Cover conflicts (parent/child paths), duplicate outputs, empty fields, non-scalar grouping, success cases, and binary inclusion.
> - **Example workflow** (`packages/nodes-base/nodes/Transform/Aggregate/test/workflow.groupby.json`):
>   - Demonstrates grouping by `domain` for both aggregation modes and field include/exclude variants.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a93b338d0ac916a1c1b0e8c295d4961092237709. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->