### PR TITLE
feat(core): Add Mistral cloud provider to chat hub (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/chat-hub.ts
+++ b/packages/@n8n/api-types/src/chat-hub.ts
@@ -18,6 +18,7 @@ export const chatHubLLMProviderSchema = z.enum([
 	'azureOpenAi',
 	'ollama',
 	'awsBedrock',
+	'mistralCloud',
 ]);
 export type ChatHubLLMProvider = z.infer<typeof chatHubLLMProviderSchema>;
 
@@ -42,6 +43,7 @@ export const PROVIDER_CREDENTIAL_TYPE_MAP: Record<
 	ollama: 'ollamaApi',
 	azureOpenAi: 'azureOpenAiApi',
 	awsBedrock: 'aws',
+	mistralCloud: 'mistralCloudApi',
 };
 
 export type ChatHubAgentTool = typeof JINA_AI_TOOL_NODE_TYPE | typeof SEAR_XNG_TOOL_NODE_TYPE;
@@ -79,6 +81,11 @@ const awsBedrockModelSchema = z.object({
 	model: z.string(),
 });
 
+const mistralCloudModelSchema = z.object({
+	provider: z.literal('mistralCloud'),
+	model: z.string(),
+});
+
 const n8nModelSchema = z.object({
 	provider: z.literal('n8n'),
 	workflowId: z.string(),
@@ -96,6 +103,7 @@ export const chatHubConversationModelSchema = z.discriminatedUnion('provider', [
 	azureOpenAIModelSchema,
 	ollamaModelSchema,
 	awsBedrockModelSchema,
+	mistralCloudModelSchema,
 	n8nModelSchema,
 	chatAgentSchema,
 ]);
@@ -106,13 +114,15 @@ export type ChatHubGoogleModel = z.infer<typeof googleModelSchema>;
 export type ChatHubAzureOpenAIModel = z.infer<typeof azureOpenAIModelSchema>;
 export type ChatHubOllamaModel = z.infer<typeof ollamaModelSchema>;
 export type ChatHubAwsBedrockModel = z.infer<typeof awsBedrockModelSchema>;
+export type ChatHubMistralCloudModel = z.infer<typeof mistralCloudModelSchema>;
 export type ChatHubBaseLLMModel =
 	| ChatHubOpenAIModel
 	| ChatHubAnthropicModel
 	| ChatHubGoogleModel
 	| ChatHubAzureOpenAIModel
 	| ChatHubOllamaModel
-	| ChatHubAwsBedrockModel;
+	| ChatHubAwsBedrockModel
+	| ChatHubMistralCloudModel;
 
 export type ChatHubN8nModel = z.infer<typeof n8nModelSchema>;
 export type ChatHubCustomAgentModel = z.infer<typeof chatAgentSchema>;
@@ -154,6 +164,7 @@ export const emptyChatModelsResponse: ChatModelsResponse = {
 	azureOpenAi: { models: [] },
 	ollama: { models: [] },
 	awsBedrock: { models: [] },
+	mistralCloud: { models: [] },
 	n8n: { models: [] },
 	// eslint-disable-next-line @typescript-eslint/naming-convention
 	'custom-agent': { models: [] },

--- a/packages/cli/src/modules/chat-hub/chat-hub-workflow.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-workflow.service.ts
@@ -474,6 +474,15 @@ export class ChatHubWorkflowService {
 					},
 				};
 			}
+			case 'mistralCloud': {
+				return {
+					...common,
+					parameters: {
+						model,
+						options: {},
+					},
+				};
+			}
 			default:
 				throw new OperationalError('Unsupported model provider');
 		}

--- a/packages/cli/src/modules/chat-hub/chat-hub.constants.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.constants.ts
@@ -36,6 +36,10 @@ export const PROVIDER_NODE_TYPE_MAP: Record<ChatHubLLMProvider, INodeTypeNameVer
 		name: '@n8n/n8n-nodes-langchain.lmChatAwsBedrock',
 		version: 1.1,
 	},
+	mistralCloud: {
+		name: '@n8n/n8n-nodes-langchain.lmChatMistralCloud',
+		version: 1,
+	},
 };
 
 export const NODE_NAMES = {

--- a/packages/cli/src/modules/chat-hub/context-limits.ts
+++ b/packages/cli/src/modules/chat-hub/context-limits.ts
@@ -140,6 +140,7 @@ export const maxContextWindowTokens: Record<ChatHubLLMProvider, Record<string, n
 	azureOpenAi: {},
 	ollama: {},
 	awsBedrock: {},
+	mistralCloud: {},
 };
 
 export const getMaxContextWindowTokens = (

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/constants.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/constants.ts
@@ -14,6 +14,7 @@ export const providerDisplayNames: Record<ChatHubProvider, string> = {
 	azureOpenAi: 'Azure OpenAI',
 	ollama: 'Ollama',
 	awsBedrock: 'AWS Bedrock',
+	mistralCloud: 'Mistral Cloud',
 	n8n: 'n8n',
 	'custom-agent': 'Custom Agent',
 };


### PR DESCRIPTION
## Summary

This PR adds Mistral cloud provider support on chat hub.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-63/feature-add-more-models

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
