### PR TITLE
fix: @n8n/scan-community-package not working on Windows

### DIFF
--- a/packages/@n8n/scan-community-package/scanner/scanner.mjs
+++ b/packages/@n8n/scan-community-package/scanner/scanner.mjs
@@ -81,6 +81,7 @@ const downloadAndExtractPackage = async (packageName, version) => {
 		const npmResult = spawnSync('npm', ['-q', 'pack', `${packageName}@${version}`], {
 			cwd: TEMP_DIR,
 			stdio: 'pipe',
+			shell: process.platform === 'win32',
 		});
 		if (npmResult.status !== 0) {
 			throw new Error(`npm pack failed: ${npmResult.stderr?.toString()}`);
@@ -99,6 +100,7 @@ const downloadAndExtractPackage = async (packageName, version) => {
 			{
 				cwd: TEMP_DIR,
 				stdio: 'pipe',
+				shell: process.platform === 'win32',
 			},
 		);
 		if (tarResult.status !== 0) {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Add `shell: true` option to `spawnSync` on Windows to fix the error. This fix is similar to [this one](https://github.com/n8n-io/n8n/pull/20091) for `node-cli`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3903/npx-n8nscan-community-package-fails-on-windows

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
