### PR TITLE
fix(core)!: Switch to image extension for `n8nio/runners`

### DIFF
--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -11,15 +11,6 @@ WORKDIR /app/task-runner-javascript
 
 RUN corepack enable pnpm
 
-# Install extra runtime-only npm packages. Allow usage in the Code node via
-# 'NODE_FUNCTION_ALLOW_EXTERNAL' env variable on n8n-task-runners.json.
-RUN rm -f node_modules/.modules.yaml
-RUN mv package.json package.json.bak
-COPY docker/images/runners/package.json /app/task-runner-javascript/package.json
-RUN pnpm install --prod --no-lockfile --silent
-RUN mv package.json extras.json
-RUN mv package.json.bak package.json
-
 # Remove `catalog` and `workspace` references from package.json to allow `pnpm add` in extended images
 RUN node -e "const pkg = require('./package.json'); \
     Object.keys(pkg.dependencies || {}).forEach(k => { \
@@ -78,11 +69,6 @@ RUN uv sync \
 			--no-dev \
 			--all-extras \
       --no-editable
-
-# Install extra runtime-only Python packages. Allow usage in the Code node via
-# 'N8N_RUNNERS_EXTERNAL_ALLOW' env variable on n8n-task-runners.json.
-COPY docker/images/runners/extras.txt /app/task-runner-python/extras.txt
-RUN uv pip install -r /app/task-runner-python/extras.txt
 
 # ==============================================================================
 # STAGE 3: Task Runner Launcher download

--- a/docker/images/runners/Dockerfile.distroless
+++ b/docker/images/runners/Dockerfile.distroless
@@ -26,14 +26,24 @@ WORKDIR /app/task-runner-javascript
 
 RUN corepack enable pnpm
 
-# Install extra runtime-only npm packages. Allow usage in the Code node via
-# 'NODE_FUNCTION_ALLOW_EXTERNAL' env variable on n8n-task-runners.json.
-RUN rm -f node_modules/.modules.yaml
-RUN mv package.json package.json.bak
-COPY docker/images/runners/package.json /app/task-runner-javascript/package.json
-RUN pnpm install --prod --no-lockfile --silent
-RUN mv package.json extras.json
-RUN mv package.json.bak package.json
+# Remove `catalog` and `workspace` references from package.json to allow `pnpm add`
+RUN node -e "const pkg = require('./package.json'); \
+    Object.keys(pkg.dependencies || {}).forEach(k => { \
+        const val = pkg.dependencies[k]; \
+        if (val === 'catalog:' || val.startsWith('catalog:') || val.startsWith('workspace:')) \
+            delete pkg.dependencies[k]; \
+    }); \
+    Object.keys(pkg.devDependencies || {}).forEach(k => { \
+        const val = pkg.devDependencies[k]; \
+        if (val === 'catalog:' || val.startsWith('catalog:') || val.startsWith('workspace:')) \
+            delete pkg.devDependencies[k]; \
+    }); \
+    delete pkg.devDependencies; \
+    require('fs').writeFileSync('./package.json', JSON.stringify(pkg, null, 2));"
+
+# Install moment by default (special case for n8n cloud)
+RUN rm -f node_modules/.modules.yaml && \
+    pnpm add moment@2.30.1 --prod --no-lockfile
 
 # ==============================================================================
 # STAGE 2: Python runner build (@n8n/task-runner-python) with uv
@@ -80,11 +90,6 @@ RUN uv sync \
 			--no-dev \
 			--all-extras \
       --no-editable
-
-# Install extra runtime-only Python packages. Allow usage in the Code node via
-# 'N8N_RUNNERS_EXTERNAL_ALLOW' env variable on n8n-task-runners.json.
-COPY docker/images/runners/extras.txt /app/task-runner-python/extras.txt
-RUN uv pip install -r /app/task-runner-python/extras.txt
 
 # ==============================================================================
 # STAGE 3: Task Runner Launcher download

--- a/docker/images/runners/extras.txt
+++ b/docker/images/runners/extras.txt
@@ -1,5 +1,0 @@
-# Runtime-only extra Requirements File for installing dependencies in the Python task runner image.
-# Installed at Docker image build time. Allow usage in the Code node
-# via 'N8N_RUNNERS_EXTERNAL_ALLOW' env variable on n8n-task-runners.json.
-
-# numpy==2.3.2

--- a/docker/images/runners/package.json
+++ b/docker/images/runners/package.json
@@ -1,8 +1,0 @@
-{
-  "name": "task-runner-runtime-extras",
-  "description": "Runtime-only extra dependencies for installing packages in the JavaScript task runner image. Installed at Docker image build time. Allow usage in the Code node via 'NODE_FUNCTION_ALLOW_EXTERNAL' env variable on n8n-task-runners.json.",
-  "private": true,
-  "dependencies": {
-    "moment": "2.30.1"
-  }
-}

--- a/packages/cli/BREAKING-CHANGES.md
+++ b/packages/cli/BREAKING-CHANGES.md
@@ -2,6 +2,16 @@
 
 This list shows all the versions which include breaking changes and how to upgrade.
 
+# 1.122.0
+
+### What changed?
+
+The way to add third-party dependencies to the `n8nio/runners` image has changed. More details [here](https://docs.n8n.io/hosting/configuration/task-runners/#adding-extra-dependencies).
+
+### When is action necessary?
+
+If you adding third-party dependencies to the `n8nio/runners` image using `package.json` and `extras.txt` and building the image yourself, please extend the image as instructed in the link above.
+
 # 1.113.0
 
 ### What changed?


### PR DESCRIPTION
## Summary

The original way to add third-party libraries to the `n8nio/runners` image was to specify them in `package.json` and `extras.txt` files and then to build the image from scratch. Based on customer feedback, we've simplified this to having users extend the `n8nio/runners` image, as documented [here](https://docs.n8n.io/hosting/configuration/task-runners/#adding-extra-dependencies).

To avoid supporting two flows for adding dependencies, this PR removes the processing of `package.json` and `extras.txt` files for both runners Dockerfiles. Note that this is a **breaking change** to an image that is currently in beta testing.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1733

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
