### PR TITLE
chore(core): Add "test:unit" scripts to most of the backend packages

### DIFF
--- a/packages/@n8n/api-types/package.json
+++ b/packages/@n8n/api-types/package.json
@@ -12,6 +12,7 @@
     "lint:fix": "eslint . --fix",
     "watch": "tsc -p tsconfig.build.json --watch",
     "test": "jest",
+    "test:unit": "jest",
     "test:dev": "jest --watch"
   },
   "main": "dist/index.js",

--- a/packages/@n8n/api-types/src/dto/workflows/__tests__/import-workflow-from-url.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/__tests__/import-workflow-from-url.dto.test.ts
@@ -6,25 +6,30 @@ describe('ImportWorkflowFromUrlDto', () => {
 			{
 				name: 'valid URL with .json extension',
 				url: 'https://example.com/workflow.json',
+				projectId: '12345',
 			},
 			{
 				name: 'valid URL without .json extension',
 				url: 'https://example.com/workflow',
+				projectId: '12345',
 			},
 			{
 				name: 'valid URL with query parameters',
 				url: 'https://example.com/workflow.json?param=value',
+				projectId: '12345',
 			},
 			{
 				name: 'valid URL with fragments',
 				url: 'https://example.com/workflow.json#section',
+				projectId: '12345',
 			},
 			{
 				name: 'valid API endpoint URL',
 				url: 'https://api.example.com/v1/workflows/123',
+				projectId: '12345',
 			},
-		])('should validate $name', ({ url }) => {
-			const result = ImportWorkflowFromUrlDto.safeParse({ url });
+		])('should validate $name', ({ url, projectId }) => {
+			const result = ImportWorkflowFromUrlDto.safeParse({ url, projectId });
 			expect(result.success).toBe(true);
 		});
 	});

--- a/packages/@n8n/backend-common/package.json
+++ b/packages/@n8n/backend-common/package.json
@@ -12,6 +12,7 @@
     "lint:fix": "eslint . --fix",
     "watch": "tsc -p tsconfig.build.json --watch",
     "test": "jest",
+    "test:unit": "jest",
     "test:dev": "jest --watch"
   },
   "main": "dist/index.js",

--- a/packages/@n8n/client-oauth2/package.json
+++ b/packages/@n8n/client-oauth2/package.json
@@ -12,6 +12,7 @@
     "lint:fix": "eslint . --fix",
     "watch": "tsc -p tsconfig.build.json --watch",
     "test": "jest",
+    "test:unit": "jest",
     "test:dev": "jest --watch"
   },
   "main": "dist/index.js",

--- a/packages/@n8n/codemirror-lang-sql/package.json
+++ b/packages/@n8n/codemirror-lang-sql/package.json
@@ -8,6 +8,7 @@
     "generate:sql:grammar": "lezer-generator --typeScript --output src/grammar.sql.ts src/sql.grammar",
     "generate": "pnpm generate:sql:grammar && pnpm format",
     "build": "tsc -p tsconfig.build.json",
+    "test:unit": "jest",
     "lint": "eslint . --quiet",
     "lint:fix": "eslint . --fix",
     "format": "biome format --write src test",

--- a/packages/@n8n/codemirror-lang/package.json
+++ b/packages/@n8n/codemirror-lang/package.json
@@ -22,6 +22,7 @@
     "generate": "pnpm generate:expressions:grammar && pnpm format",
     "build": "tsc -p tsconfig.build.json",
     "test": "jest",
+    "test:unit": "jest",
     "lint": "eslint . --quiet",
     "lint:fix": "eslint . --fix",
     "format": "biome format --write src test",

--- a/packages/@n8n/config/package.json
+++ b/packages/@n8n/config/package.json
@@ -12,6 +12,7 @@
     "lint:fix": "eslint . --fix",
     "watch": "tsc -p tsconfig.build.json --watch",
     "test": "jest",
+    "test:unit": "jest",
     "test:dev": "jest --watch"
   },
   "main": "dist/index.js",

--- a/packages/@n8n/db/package.json
+++ b/packages/@n8n/db/package.json
@@ -12,6 +12,7 @@
     "lint:fix": "eslint . --fix",
     "watch": "tsc -p tsconfig.build.json --watch",
     "test": "jest",
+    "test:unit": "jest",
     "test:dev": "jest --watch"
   },
   "main": "dist/index.js",

--- a/packages/@n8n/di/package.json
+++ b/packages/@n8n/di/package.json
@@ -12,6 +12,7 @@
     "lint:fix": "eslint . --fix",
     "watch": "tsc -p tsconfig.build.json --watch",
     "test": "jest",
+    "test:unit": "jest",
     "test:dev": "jest --watch"
   },
   "main": "dist/di.js",

--- a/packages/@n8n/eslint-config/package.json
+++ b/packages/@n8n/eslint-config/package.json
@@ -24,6 +24,7 @@
     "format": "biome format --write .",
     "format:check": "biome ci .",
     "test": "vitest run",
+    "test:unit": "vitest run",
     "test:dev": "vitest",
     "typecheck": "tsc --noEmit",
     "watch": "tsc --watch"

--- a/packages/@n8n/eslint-plugin-community-nodes/package.json
+++ b/packages/@n8n/eslint-plugin-community-nodes/package.json
@@ -21,6 +21,7 @@
     "lint:fix": "eslint src --fix",
     "lint:docs": "eslint-doc-generator --check",
     "test": "vitest run",
+    "test:unit": "vitest run",
     "test:dev": "vitest",
     "typecheck": "tsc --noEmit",
     "watch": "tsc --watch --project tsconfig.build.json"

--- a/packages/@n8n/imap/package.json
+++ b/packages/@n8n/imap/package.json
@@ -12,6 +12,7 @@
     "lint:fix": "eslint . --fix",
     "watch": "tsc -p tsconfig.build.json --watch",
     "test": "vitest run",
+    "test:unit": "vitest run",
     "test:dev": "vitest --silent=false"
   },
   "main": "dist/index.js",

--- a/packages/@n8n/json-schema-to-zod/package.json
+++ b/packages/@n8n/json-schema-to-zod/package.json
@@ -29,6 +29,7 @@
     "build": "rimraf ./dist && pnpm run build:types && pnpm run build:cjs && pnpm run build:esm",
     "dry": "pnpm run build && pnpm pub --dry-run",
     "test": "jest",
+    "test:unit": "jest",
     "test:watch": "jest --watch"
   },
   "keywords": [

--- a/packages/@n8n/node-cli/package.json
+++ b/packages/@n8n/node-cli/package.json
@@ -27,6 +27,7 @@
     "build": "tsc -p tsconfig.build.json && pnpm copy-templates",
     "publish:dry": "pnpm run build && pnpm pub --dry-run",
     "test": "vitest run",
+    "test:unit": "vitest run",
     "test:dev": "vitest --silent=false",
     "start": "./bin/n8n-node.mjs"
   },

--- a/packages/@n8n/permissions/package.json
+++ b/packages/@n8n/permissions/package.json
@@ -12,6 +12,7 @@
     "lint:fix": "eslint . --fix",
     "watch": "tsc -p tsconfig.build.json --watch",
     "test": "jest",
+    "test:unit": "jest",
     "test:dev": "jest --watch"
   },
   "main": "dist/index.js",

--- a/packages/@n8n/permissions/src/__tests__/__snapshots__/scope-information.test.ts.snap
+++ b/packages/@n8n/permissions/src/__tests__/__snapshots__/scope-information.test.ts.snap
@@ -143,6 +143,7 @@ exports[`Scope Information ensure scopes are defined correctly 1`] = `
   "role:manage",
   "role:*",
   "mcp:manage",
+  "mcp:oauth",
   "mcp:*",
   "mcpApiKey:create",
   "mcpApiKey:rotate",

--- a/packages/@n8n/stylelint-config/package.json
+++ b/packages/@n8n/stylelint-config/package.json
@@ -20,6 +20,7 @@
     "format": "biome format --write .",
     "format:check": "biome ci .",
     "test": "jest",
+    "test:unit": "jest",
     "test:dev": "jest --watch",
     "typecheck": "tsc --noEmit",
     "watch": "tsc --watch"

--- a/packages/@n8n/task-runner/package.json
+++ b/packages/@n8n/task-runner/package.json
@@ -10,6 +10,7 @@
     "format": "biome format --write src",
     "format:check": "biome ci src",
     "test": "jest",
+    "test:unit": "jest",
     "test:watch": "jest --watch",
     "lint": "eslint . --quiet",
     "lint:fix": "eslint . --fix",

--- a/packages/@n8n/utils/package.json
+++ b/packages/@n8n/utils/package.json
@@ -31,6 +31,7 @@
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "test:unit": "vitest run",
     "test:dev": "vitest --silent=false",
     "lint": "eslint src --quiet",
     "lint:fix": "eslint src --fix",

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -15,6 +15,7 @@
     "lint:fix": "eslint nodes credentials utils test --fix",
     "watch": "tsc-watch -p tsconfig.build.cjs.json --onCompilationComplete \"pnpm copy-nodes-json && tsc-alias -p tsconfig.build.cjs.json\" --onSuccess \"pnpm n8n-generate-metadata\"",
     "test": "jest",
+    "test:unit": "jest",
     "test:dev": "jest --watch"
   },
   "files": [

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -15,7 +15,6 @@
     "lint:fix": "eslint nodes credentials utils test --fix",
     "watch": "tsc-watch -p tsconfig.build.cjs.json --onCompilationComplete \"pnpm copy-nodes-json && tsc-alias -p tsconfig.build.cjs.json\" --onSuccess \"pnpm n8n-generate-metadata\"",
     "test": "jest",
-    "test:unit": "jest",
     "test:dev": "jest --watch"
   },
   "files": [

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -30,6 +30,7 @@
     "lint:fix": "eslint src --fix",
     "watch": "tsc --build tsconfig.build.esm.json tsconfig.build.cjs.json --watch",
     "test": "vitest run",
+    "test:unit": "vitest run",
     "test:dev": "vitest --watch"
   },
   "files": [


### PR DESCRIPTION
## Summary

https://github.com/n8n-io/n8n/pull/21438 split the test execution in the CI to speed it up. Some backend packages where missing the necessary npm script "test:unit". This reintroduces it.

These tests were missing and not executed in the CI:

Added test:unit scripts to 18 packages with passing tests:

  Jest-based packages (12 packages):
  - @n8n/api-types (658 tests)
  - @n8n/backend-common (81 tests)
  - @n8n/client-oauth2 (32 tests)
  - @n8n/config (30 tests)
  - @n8n/db (154 tests)
  - @n8n/di (25 tests)
  - @n8n/json-schema-to-zod (76 tests)
  - @n8n/permissions (85 tests)
  - @n8n/stylelint-config (85 tests)
  - @n8n/task-runner (257 tests)
  - @n8n/codemirror-lang (41 tests)
  - @n8n/codemirror-lang-sql (42 tests)

  Vitest-based packages (6 packages):
  - n8n-workflow (1,498 tests)
  - @n8n/eslint-config (49 tests)
  - @n8n/eslint-plugin-community-nodes (179 tests)
  - @n8n/imap (25 tests)
  - @n8n/node-cli (99 tests)
  - @n8n/utils (39 tests)

One package (@n8n/nodes-langchain) still has failing tests and was not updated.

The package n8n-nodes-base is now tested in its own check in the CI (https://github.com/n8n-io/n8n/pull/21836)

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-4155/check-all-backend-packages-for-the-npm-script-testunit

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
