### PR TITLE
fix: Fixing failing CI tests for `nodes-langchain` package

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/prepareItemContext.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/prepareItemContext.test.ts
@@ -1,13 +1,12 @@
 import type { ChatPromptTemplate } from '@langchain/core/prompts';
 import { mock } from 'jest-mock-extended';
 import type { Tool } from 'langchain/tools';
-import type { IExecuteFunctions, INode, EngineResponse } from 'n8n-workflow';
+import type { IExecuteFunctions, INode } from 'n8n-workflow';
 
 import * as helpers from '@utils/helpers';
 import * as outputParsers from '@utils/output_parsers/N8nOutputParser';
 
 import * as commonHelpers from '../../../common';
-import type { RequestResponseMetadata } from '../../types';
 import { prepareItemContext } from '../prepareItemContext';
 
 jest.mock('@utils/helpers', () => ({
@@ -33,15 +32,12 @@ beforeEach(() => {
 });
 
 describe('processItem', () => {
-	it('should return null when item was already processed', async () => {
-		const response: EngineResponse<RequestResponseMetadata> = {
-			actionResponses: [],
-			metadata: { itemIndex: 0, previousRequests: [] },
-		};
+	it('should throw error when text parameter is empty', async () => {
+		jest.spyOn(helpers, 'getPromptInputByType').mockReturnValue(undefined as any);
 
-		const result = await prepareItemContext(mockContext, 0, response);
-
-		expect(result).toBeNull();
+		await expect(prepareItemContext(mockContext, 0)).rejects.toThrow(
+			'The "text" parameter is empty.',
+		);
 	});
 
 	it('should process item and return context', async () => {

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/__test__/McpClientTool.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/__test__/McpClientTool.node.test.ts
@@ -229,6 +229,7 @@ describe('McpClientTool', () => {
 			expect(SSEClientTransport).toHaveBeenCalledTimes(1);
 			expect(SSEClientTransport).toHaveBeenCalledWith(url, {
 				eventSourceInit: { fetch: expect.any(Function) },
+				fetch: expect.any(Function),
 				requestInit: { headers: { 'my-header': 'header-value' } },
 			});
 
@@ -278,6 +279,7 @@ describe('McpClientTool', () => {
 			expect(SSEClientTransport).toHaveBeenCalledTimes(1);
 			expect(SSEClientTransport).toHaveBeenCalledWith(url, {
 				eventSourceInit: { fetch: expect.any(Function) },
+				fetch: expect.any(Function),
 				requestInit: { headers: { Authorization: 'Bearer my-token' } },
 			});
 

--- a/packages/@n8n/nodes-langchain/package.json
+++ b/packages/@n8n/nodes-langchain/package.json
@@ -16,6 +16,7 @@
     "lint:fix": "eslint nodes credentials utils --fix",
     "watch": "tsup --watch nodes --watch credentials --watch utils --watch types --tsconfig tsconfig.build.json --onSuccess \"node ./scripts/post-build.js\"",
     "test": "jest",
+    "test:unit": "jest",
     "test:dev": "jest --watch"
   },
   "files": [


### PR DESCRIPTION
## Summary

There were some failing tests in the `nodes-langchain` package, these happened because CI tests were not being ran on the package due to some recent changes. I've enabled the tests again in CI by adding `test:unit` command and luckily the failing tests were just an oversight, simply test mocks not having been updated fully.

Addresses: https://linear.app/n8n/issue/AI-1723/ci-tests

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
