### PR TITLE
feat: slack send and wait thread support

### DIFF
--- a/packages/nodes-base/nodes/Slack/V2/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Slack/V2/GenericFunctions.ts
@@ -2,17 +2,17 @@ import get from 'lodash/get';
 import type {
 	IDataObject,
 	IExecuteFunctions,
+	IHttpRequestMethods,
 	ILoadOptionsFunctions,
 	IOAuth2Options,
-	IHttpRequestMethods,
 	IRequestOptions,
 	IWebhookFunctions,
 } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 
-import type { SendAndWaitMessageBody } from './MessageInterface';
 import { getSendAndWaitConfig } from '../../../utils/sendAndWait/utils';
 import { createUtmCampaignLink } from '../../../utils/utilities';
+import type { SendAndWaitMessageBody } from './MessageInterface';
 
 export async function slackApiRequest(
 	this: IExecuteFunctions | ILoadOptionsFunctions | IWebhookFunctions,
@@ -323,6 +323,11 @@ export function createSendAndWaitMessageBody(context: IExecuteFunctions) {
 			},
 		],
 	};
+
+	const options = context.getNodeParameter('options', 0, {}) as IDataObject;
+	const threadOptions = options.thread_ts as IDataObject | undefined;
+	const threadParams = processThreadOptions(threadOptions);
+	Object.assign(body, threadParams);
 
 	if (config.appendAttribution) {
 		const instanceId = context.getInstanceId();

--- a/packages/nodes-base/nodes/Slack/V2/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Slack/V2/GenericFunctions.ts
@@ -265,7 +265,7 @@ export function processThreadOptions(threadOptions: IDataObject | undefined): ID
 
 	if (threadOptions?.replyValues) {
 		const replyValues = threadOptions.replyValues as IDataObject;
-		if (replyValues.thread_ts) {
+		if (replyValues.thread_ts !== undefined) {
 			result.thread_ts = replyValues.thread_ts;
 		}
 		if (replyValues.reply_broadcast !== undefined) {

--- a/packages/nodes-base/nodes/Slack/V2/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V2/MessageDescription.ts
@@ -175,6 +175,40 @@ export const userRLC: INodeProperties = {
 	],
 };
 
+export const replyToMessageOption: INodeProperties = {
+	displayName: 'Reply to a Message',
+	name: 'thread_ts',
+	type: 'fixedCollection',
+	default: {},
+	placeholder: 'Reply to a Message',
+	description: "Provide another message's Timestamp value to make this message a reply",
+	options: [
+		{
+			displayName: 'Reply to a Message',
+			name: 'replyValues',
+			values: [
+				{
+					displayName: 'Message Timestamp to Reply To',
+					name: 'thread_ts',
+					type: 'number',
+					default: undefined,
+					placeholder: '1663233118.856619',
+					description:
+						'Message timestamps are included in output data of Slack nodes, abbreviated to ts',
+				},
+				{
+					displayName: 'Also Send to Channel',
+					name: 'reply_broadcast',
+					type: 'boolean',
+					default: false,
+					description:
+						'Whether the reply should be made visible to everyone in the channel or conversation',
+				},
+			],
+		},
+	],
+};
+
 export const messageFields: INodeProperties[] = [
 	/* ----------------------------------------------------------------------- */
 	/*                                 message:getPermalink
@@ -651,39 +685,7 @@ export const messageFields: INodeProperties[] = [
 				default: false,
 				description: 'Whether to turn @users and #channels in message text into clickable links',
 			},
-			{
-				displayName: 'Reply to a Message',
-				name: 'thread_ts',
-				type: 'fixedCollection',
-				default: {},
-				placeholder: 'Reply to a Message',
-				description: "Provide another message's Timestamp value to make this message a reply",
-				options: [
-					{
-						displayName: 'Reply to a Message',
-						name: 'replyValues',
-						values: [
-							{
-								displayName: 'Message Timestamp to Reply To',
-								name: 'thread_ts',
-								type: 'number',
-								default: undefined,
-								placeholder: '1663233118.856619',
-								description:
-									'Message timestamps are included in output data of Slack nodes, abbreviated to ts',
-							},
-							{
-								displayName: 'Also Send to Channel',
-								name: 'reply_broadcast',
-								type: 'boolean',
-								default: false,
-								description:
-									'Whether the reply should be made visible to everyone in the channel or conversation',
-							},
-						],
-					},
-				],
-			},
+			replyToMessageOption,
 			{
 				displayName: 'Use Markdown?',
 				name: 'mrkdwn',

--- a/packages/nodes-base/nodes/Slack/V2/MessageInterface.ts
+++ b/packages/nodes-base/nodes/Slack/V2/MessageInterface.ts
@@ -35,4 +35,6 @@ export interface ActionsBlock {
 export interface SendAndWaitMessageBody {
 	channel: string;
 	blocks: Array<DividerBlock | SectionBlock | ActionsBlock>;
+	thread_ts?: number | string;
+	reply_broadcast?: boolean;
 }

--- a/packages/nodes-base/nodes/Slack/V2/SlackV2.node.ts
+++ b/packages/nodes-base/nodes/Slack/V2/SlackV2.node.ts
@@ -35,6 +35,7 @@ import {
 	channelRLC,
 	messageFields,
 	messageOperations,
+	replyToMessageOption,
 	sendToSelector,
 	userRLC,
 } from './MessageDescription';
@@ -145,25 +146,32 @@ export class SlackV2 implements INodeType {
 				...channelFields,
 				...messageOperations,
 				...messageFields,
-				...getSendAndWaitProperties([
-					{ ...sendToSelector, default: 'user' },
-					{
-						...channelRLC,
-						displayOptions: {
-							show: {
-								select: ['channel'],
+				...getSendAndWaitProperties(
+					[
+						{ ...sendToSelector, default: 'user' },
+						{
+							...channelRLC,
+							displayOptions: {
+								show: {
+									select: ['channel'],
+								},
 							},
 						},
-					},
-					{
-						...userRLC,
-						displayOptions: {
-							show: {
-								select: ['user'],
+						{
+							...userRLC,
+							displayOptions: {
+								show: {
+									select: ['user'],
+								},
 							},
 						},
+					],
+					'message',
+					[],
+					{
+						additionalOptionsProperties: [replyToMessageOption],
 					},
-				]).filter((p) => p.name !== 'subject'),
+				).filter((p) => p.name !== 'subject'),
 				...starOperations,
 				...starFields,
 				...fileOperations,

--- a/packages/nodes-base/nodes/Slack/V2/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Slack/V2/test/GenericFunctions.test.ts
@@ -180,5 +180,49 @@ describe('Slack V2 GenericFunctions', () => {
 				}),
 			);
 		});
+
+		it('should handle thread_ts with value 0', () => {
+			mockExecuteFunctions.getNodeParameter.mockImplementation(
+				(parameterName, _itemIndex, _fallbackValue, options) => {
+					if (options?.extractValue) {
+						return 'C12345';
+					}
+
+					const params: Record<string, string | object> = {
+						select: 'channel',
+						channelId: { value: 'C12345' },
+						message: 'Test message',
+						subject: 'Test subject',
+						responseType: 'approval',
+						// eslint-disable-next-line @typescript-eslint/naming-convention
+						'approvalOptions.values': {
+							approvalType: 'single',
+							approveLabel: 'Approve',
+							buttonApprovalStyle: 'primary',
+						},
+						options: {
+							thread_ts: {
+								replyValues: {
+									thread_ts: 0,
+								},
+							},
+						},
+					};
+					return params[parameterName];
+				},
+			);
+
+			mockExecuteFunctions.getSignedResumeUrl.mockReturnValue('http://localhost/test');
+
+			const body = createSendAndWaitMessageBody(mockExecuteFunctions);
+
+			expect(body).toEqual(
+				expect.objectContaining({
+					channel: 'C12345',
+					blocks: expect.any(Array),
+					thread_ts: 0,
+				}),
+			);
+		});
 	});
 });

--- a/packages/nodes-base/nodes/Slack/V2/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Slack/V2/test/GenericFunctions.test.ts
@@ -1,0 +1,184 @@
+import { type MockProxy, mock } from 'jest-mock-extended';
+import type { IExecuteFunctions, INode } from 'n8n-workflow';
+
+import { createSendAndWaitMessageBody } from '../GenericFunctions';
+
+describe('Slack V2 GenericFunctions', () => {
+	let mockExecuteFunctions: MockProxy<IExecuteFunctions>;
+
+	beforeEach(() => {
+		mockExecuteFunctions = mock<IExecuteFunctions>();
+		mockExecuteFunctions.getNode.mockReturnValue({ typeVersion: 2.3 } as INode);
+		mockExecuteFunctions.getInstanceId.mockReturnValue('test-instance-id');
+	});
+
+	describe('createSendAndWaitMessageBody', () => {
+		it('should create message body without thread_ts', () => {
+			mockExecuteFunctions.getNodeParameter.mockImplementation(
+				(parameterName, _itemIndex, _fallbackValue, options) => {
+					if (options?.extractValue) {
+						// Handle extractValue option for channelId
+						return 'C12345';
+					}
+
+					const params: Record<string, string | object> = {
+						select: 'channel',
+						channelId: { value: 'C12345' },
+						message: 'Test message',
+						subject: 'Test subject',
+						responseType: 'approval',
+						// eslint-disable-next-line @typescript-eslint/naming-convention
+						'approvalOptions.values': {
+							approvalType: 'single',
+							approveLabel: 'Approve',
+							buttonApprovalStyle: 'primary',
+						},
+						options: {},
+					};
+					return params[parameterName];
+				},
+			);
+
+			mockExecuteFunctions.getSignedResumeUrl.mockReturnValue('http://localhost/test');
+
+			const body = createSendAndWaitMessageBody(mockExecuteFunctions);
+
+			expect(body).toEqual(
+				expect.objectContaining({
+					channel: 'C12345',
+					blocks: expect.any(Array),
+				}),
+			);
+			expect(body).not.toHaveProperty('thread_ts');
+			expect(body).not.toHaveProperty('reply_broadcast');
+		});
+
+		it('should create message body with thread_ts', () => {
+			mockExecuteFunctions.getNodeParameter.mockImplementation(
+				(parameterName, _itemIndex, _fallbackValue, options) => {
+					if (options?.extractValue) {
+						return 'C12345';
+					}
+
+					const params: Record<string, string | object> = {
+						select: 'channel',
+						channelId: { value: 'C12345' },
+						message: 'Test message',
+						subject: 'Test subject',
+						responseType: 'approval',
+						// eslint-disable-next-line @typescript-eslint/naming-convention
+						'approvalOptions.values': {
+							approvalType: 'single',
+							approveLabel: 'Approve',
+							buttonApprovalStyle: 'primary',
+						},
+						options: {
+							thread_ts: {
+								replyValues: {
+									thread_ts: 1663233118.856619,
+								},
+							},
+						},
+					};
+					return params[parameterName];
+				},
+			);
+
+			mockExecuteFunctions.getSignedResumeUrl.mockReturnValue('http://localhost/test');
+
+			const body = createSendAndWaitMessageBody(mockExecuteFunctions);
+
+			expect(body).toEqual(
+				expect.objectContaining({
+					channel: 'C12345',
+					blocks: expect.any(Array),
+					thread_ts: 1663233118.856619,
+				}),
+			);
+			expect(body).not.toHaveProperty('reply_broadcast');
+		});
+
+		it('should create message body with thread_ts and reply_broadcast', () => {
+			mockExecuteFunctions.getNodeParameter.mockImplementation(
+				(parameterName, _itemIndex, _fallbackValue, options) => {
+					if (options?.extractValue) {
+						return 'C12345';
+					}
+
+					const params: Record<string, string | object> = {
+						select: 'channel',
+						channelId: { value: 'C12345' },
+						message: 'Test message',
+						subject: 'Test subject',
+						responseType: 'approval',
+						// eslint-disable-next-line @typescript-eslint/naming-convention
+						'approvalOptions.values': {
+							approvalType: 'single',
+							approveLabel: 'Approve',
+							buttonApprovalStyle: 'primary',
+						},
+						options: {
+							thread_ts: {
+								replyValues: {
+									thread_ts: 1663233118.856619,
+									reply_broadcast: true,
+								},
+							},
+						},
+					};
+					return params[parameterName];
+				},
+			);
+
+			mockExecuteFunctions.getSignedResumeUrl.mockReturnValue('http://localhost/test');
+
+			const body = createSendAndWaitMessageBody(mockExecuteFunctions);
+
+			expect(body).toEqual(
+				expect.objectContaining({
+					channel: 'C12345',
+					blocks: expect.any(Array),
+					thread_ts: 1663233118.856619,
+					reply_broadcast: true,
+				}),
+			);
+		});
+
+		it('should select user target correctly', () => {
+			mockExecuteFunctions.getNodeParameter.mockImplementation(
+				(parameterName, _itemIndex, _fallbackValue, options) => {
+					if (options?.extractValue) {
+						return 'U12345';
+					}
+
+					const params: Record<string, string | object> = {
+						select: 'user',
+						user: { value: 'U12345' },
+						message: 'Test message',
+						subject: 'Test subject',
+						responseType: 'approval',
+						// eslint-disable-next-line @typescript-eslint/naming-convention
+						'approvalOptions.values': {
+							approvalType: 'single',
+							approveLabel: 'Approve',
+							buttonApprovalStyle: 'primary',
+						},
+						options: {},
+					};
+					return params[parameterName];
+				},
+			);
+
+			mockExecuteFunctions.getSignedResumeUrl.mockReturnValue('http://localhost/test');
+
+			const body = createSendAndWaitMessageBody(mockExecuteFunctions);
+
+			expect(body).toEqual(
+				expect.objectContaining({
+					channel: 'U12345',
+					blocks: expect.any(Array),
+				}),
+			);
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Slack/test/v2/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/GenericFunctions.test.ts
@@ -476,6 +476,7 @@ describe('Slack V2 > GenericFunctions', () => {
 			};
 			const result = processThreadOptions(threadOptions);
 			expect(result).toEqual({
+				thread_ts: 0,
 				reply_broadcast: true,
 			});
 		});

--- a/packages/nodes-base/utils/sendAndWait/test/util.test.ts
+++ b/packages/nodes-base/utils/sendAndWait/test/util.test.ts
@@ -45,6 +45,48 @@ describe('Send and Wait utils tests', () => {
 				]),
 			);
 		});
+
+		it('should add additionalOptionsProperties to Options collections', () => {
+			const targetProperties: INodeProperties[] = [
+				{
+					displayName: 'Test Property',
+					name: 'testProperty',
+					type: 'string',
+					default: '',
+				},
+			];
+
+			const additionalOption: INodeProperties = {
+				displayName: 'Custom Option',
+				name: 'customOption',
+				type: 'string',
+				default: '',
+			};
+
+			const result = getSendAndWaitProperties(targetProperties, 'message', [], {
+				additionalOptionsProperties: [additionalOption],
+			});
+
+			// Find all Options collections
+			const optionsCollections = result.filter(
+				(prop) => prop.name === 'options' && prop.type === 'collection',
+			);
+
+			// Should have 2 Options collections (one for approval, one for freeText/customForm)
+			expect(optionsCollections).toHaveLength(2);
+
+			// Both should contain the additional option
+			optionsCollections.forEach((optionsCollection) => {
+				expect(optionsCollection.options).toEqual(
+					expect.arrayContaining([
+						expect.objectContaining({
+							displayName: 'Custom Option',
+							name: 'customOption',
+						}),
+					]),
+				);
+			});
+		});
 	});
 
 	describe('getSendAndWaitConfig', () => {

--- a/packages/nodes-base/utils/sendAndWait/utils.ts
+++ b/packages/nodes-base/utils/sendAndWait/utils.ts
@@ -1,18 +1,26 @@
 import isbot from 'isbot';
+import type {
+	FormFieldsParameter,
+	IDataObject,
+	IExecuteFunctions,
+	INodeProperties,
+	IWebhookFunctions,
+} from 'n8n-workflow';
 import {
 	NodeOperationError,
 	SEND_AND_WAIT_OPERATION,
 	tryToParseJsonToFormFields,
 	updateDisplayOptions,
 } from 'n8n-workflow';
-import type {
-	INodeProperties,
-	IExecuteFunctions,
-	IWebhookFunctions,
-	IDataObject,
-	FormFieldsParameter,
-} from 'n8n-workflow';
 
+import { cssVariables } from '../../nodes/Form/cssVariables';
+import { formFieldsProperties } from '../../nodes/Form/Form.node';
+import {
+	prepareFormData,
+	prepareFormReturnItem,
+	resolveRawData,
+} from '../../nodes/Form/utils/utils';
+import { escapeHtml } from '../utilities';
 import { limitWaitTimeProperties } from './descriptions';
 import {
 	ACTION_RECORDED_PAGE,
@@ -22,14 +30,6 @@ import {
 	createEmailBodyWithoutN8nAttribution,
 } from './email-templates';
 import type { IEmail } from './interfaces';
-import { cssVariables } from '../../nodes/Form/cssVariables';
-import { formFieldsProperties } from '../../nodes/Form/Form.node';
-import {
-	prepareFormData,
-	prepareFormReturnItem,
-	resolveRawData,
-} from '../../nodes/Form/utils/utils';
-import { escapeHtml } from '../utilities';
 
 export type SendAndWaitConfig = {
 	title: string;
@@ -82,6 +82,7 @@ export function getSendAndWaitProperties(
 		noButtonStyle?: boolean;
 		defaultApproveLabel?: string;
 		defaultDisapproveLabel?: string;
+		additionalOptionsProperties?: INodeProperties[];
 	},
 ) {
 	const buttonStyle: INodeProperties = {
@@ -248,7 +249,11 @@ export function getSendAndWaitProperties(
 			type: 'collection',
 			placeholder: 'Add option',
 			default: {},
-			options: [limitWaitTimeOption, appendAttributionOption],
+			options: [
+				...(options?.additionalOptionsProperties ?? []),
+				limitWaitTimeOption,
+				appendAttributionOption,
+			],
 			displayOptions: {
 				show: {
 					responseType: ['approval'],
@@ -262,6 +267,7 @@ export function getSendAndWaitProperties(
 			placeholder: 'Add option',
 			default: {},
 			options: [
+				...(options?.additionalOptionsProperties ?? []),
 				{
 					displayName: 'Message Button Label',
 					name: 'messageButtonLabel',


### PR DESCRIPTION
## Summary
This PR adds thread support (`ts` parameter) to the Slack "Send and Wait for Response" node, enabling messages to be sent as thread replies.

## Changes
- Added `ts` (thread timestamp) parameter option to Slack Send and Wait for Response node
- Messages can now be sent as replies within existing Slack threads

## Motivation
Currently, the "Send and Wait for Response" node always creates new top-level messages in Slack channels. This enhancement addresses the following needs:

- **Keeps channels clean**: By allowing messages to be sent within threads, channels remain organized and easier to navigate
- **Improves context clarity**: Thread-based conversations make it clear which messages are related to each other
- **Better for production workflows**: In business environments, keeping related automated messages in threads significantly improves channel readability

## Use Case Example
When a workflow needs to follow up on a previous message or participate in an ongoing conversation, it can now reply directly to that thread by specifying the `ts` parameter, instead of creating a new top-level message.

## Testing
- [x] Tested manually with real Slack workspace
- [x] Verified thread replies work correctly
- [x] Backward compatible - existing workflows without `ts` parameter continue to work as before

## Checklist
- [x] Code follows n8n coding standards
- [x] No `ts-ignore` used
- [x] Reused existing Slack node components
- [ ] Tests included (if applicable)Note

## Note
If the thread_ts parameter was intentionally excluded from this node for architectural or philosophical reasons, please feel free to close this PR - no problem at all!