### PR TITLE
fix(OpenAI Node): Use new model for text classification

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/OpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/OpenAi.node.ts
@@ -15,7 +15,7 @@ export class OpenAi extends VersionedNodeType {
 			name: 'openAi',
 			icon: { light: 'file:openAi.svg', dark: 'file:openAi.dark.svg' },
 			group: ['transform'],
-			defaultVersion: 2,
+			defaultVersion: 2.1,
 			subtitle: `={{(${prettifyOperation})($parameter.resource, $parameter.operation)}}`,
 			description: 'Message an assistant or GPT, analyze images, generate audio, etc.',
 			codex: {
@@ -55,6 +55,7 @@ export class OpenAi extends VersionedNodeType {
 			1.7: new OpenAiV1(baseDescription),
 			1.8: new OpenAiV1(baseDescription),
 			2: new OpenAiV2(baseDescription),
+			2.1: new OpenAiV2(baseDescription),
 		};
 
 		super(nodeVersions, baseDescription);

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/test/v2/actions/text/classify.operation.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/test/v2/actions/text/classify.operation.test.ts
@@ -1,0 +1,102 @@
+import { mockDeep } from 'jest-mock-extended';
+import type { IExecuteFunctions, INode } from 'n8n-workflow';
+
+import * as transport from '../../../../transport';
+import * as classify from '../../../../v2/actions/text/classify.operation';
+
+describe('OpenAI Classify Operation', () => {
+	const executeFunctions = mockDeep<IExecuteFunctions>();
+	const node = {
+		id: '123',
+		name: 'OpenAI Node',
+		type: '@n8n/n8n-nodes-langchain.openAi',
+		typeVersion: 2.1,
+		position: [0, 0],
+		parameters: {},
+	} as INode;
+	const apiRequestSpy = jest.spyOn(transport, 'apiRequest');
+
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
+	it('should use omni-moderation-latest model when version is 2.1', async () => {
+		executeFunctions.getNode.mockReturnValue(node);
+		executeFunctions.getNodeParameter.mockImplementation((param: string) => {
+			const params = {
+				input: 'Lorem ipsum',
+				simplify: false,
+			};
+			return params[param as keyof typeof params];
+		});
+		apiRequestSpy.mockResolvedValueOnce({ results: [{ flagged: true }] });
+
+		const result = await classify.execute.call(executeFunctions, 0);
+
+		expect(apiRequestSpy).toHaveBeenCalledWith('POST', '/moderations', {
+			body: { input: 'Lorem ipsum', model: 'omni-moderation-latest' },
+		});
+		expect(result).toEqual([
+			{
+				json: { flagged: true },
+				pairedItem: { item: 0 },
+			},
+		]);
+	});
+
+	it('should use text-moderation-stable model when version is less than 2.1 and useStableModel is true', async () => {
+		executeFunctions.getNode.mockReturnValue({
+			...node,
+			typeVersion: 2,
+		});
+		executeFunctions.getNodeParameter.mockImplementation((param: string) => {
+			const params = {
+				input: 'Lorem ipsum',
+				simplify: false,
+				options: { useStableModel: true },
+			};
+			return params[param as keyof typeof params];
+		});
+		apiRequestSpy.mockResolvedValueOnce({ results: [{ flagged: true }] });
+
+		const result = await classify.execute.call(executeFunctions, 0);
+
+		expect(apiRequestSpy).toHaveBeenCalledWith('POST', '/moderations', {
+			body: { input: 'Lorem ipsum', model: 'text-moderation-stable' },
+		});
+		expect(result).toEqual([
+			{
+				json: { flagged: true },
+				pairedItem: { item: 0 },
+			},
+		]);
+	});
+
+	it('should use text-moderation-latest model when version is less than 2.1 and useStableModel is false', async () => {
+		executeFunctions.getNode.mockReturnValue({
+			...node,
+			typeVersion: 2,
+		});
+		executeFunctions.getNodeParameter.mockImplementation((param: string) => {
+			const params = {
+				input: 'Lorem ipsum',
+				simplify: false,
+				options: { useStableModel: false },
+			};
+			return params[param as keyof typeof params];
+		});
+		apiRequestSpy.mockResolvedValueOnce({ results: [{ flagged: true }] });
+
+		const result = await classify.execute.call(executeFunctions, 0);
+
+		expect(apiRequestSpy).toHaveBeenCalledWith('POST', '/moderations', {
+			body: { input: 'Lorem ipsum', model: 'text-moderation-latest' },
+		});
+		expect(result).toEqual([
+			{
+				json: { flagged: true },
+				pairedItem: { item: 0 },
+			},
+		]);
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v2/OpenAiV2.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v2/OpenAiV2.node.ts
@@ -23,7 +23,7 @@ export class OpenAiV2 implements INodeType {
 	constructor(baseDescription: INodeTypeBaseDescription) {
 		this.description = {
 			...baseDescription,
-			version: [2],
+			version: [2, 2.1],
 			defaults: {
 				name: 'OpenAI',
 			},

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v2/actions/text/classify.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v2/actions/text/classify.operation.ts
@@ -57,10 +57,10 @@ export const description = updateDisplayOptions(displayOptions, properties);
 
 export async function execute(this: IExecuteFunctions, i: number): Promise<INodeExecutionData[]> {
 	const input = this.getNodeParameter('input', i) as string;
-	const options = this.getNodeParameter('options', i);
 	const version = this.getNode().typeVersion;
 	let model = 'omni-moderation-latest';
 	if (version < 2.1) {
+		const options = this.getNodeParameter('options', i);
 		model = options.useStableModel ? 'text-moderation-stable' : 'text-moderation-latest';
 	}
 

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v2/actions/text/classify.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v2/actions/text/classify.operation.ts
@@ -38,6 +38,11 @@ const properties: INodeProperties[] = [
 					'Whether to use the stable version of the model instead of the latest version, accuracy may be slightly lower',
 			},
 		],
+		displayOptions: {
+			show: {
+				'@version': [{ _cnd: { lt: 2.1 } }],
+			},
+		},
 	},
 ];
 
@@ -53,7 +58,11 @@ export const description = updateDisplayOptions(displayOptions, properties);
 export async function execute(this: IExecuteFunctions, i: number): Promise<INodeExecutionData[]> {
 	const input = this.getNodeParameter('input', i) as string;
 	const options = this.getNodeParameter('options', i);
-	const model = options.useStableModel ? 'text-moderation-stable' : 'text-moderation-latest';
+	const version = this.getNode().typeVersion;
+	let model = 'omni-moderation-latest';
+	if (version < 2.1) {
+		model = options.useStableModel ? 'text-moderation-stable' : 'text-moderation-latest';
+	}
 
 	const body = {
 		input,


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Add a new light version to the OpenAI Node that uses new not deprecated `omni-moderation-latest` model for the Classify Text operation. "Use Stable Model" option is hidden for this version since it's not applicable anymore. Add tests for new behavior

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-3986/openai-node-classify-text-for-violations-uses-old-model-and-fails
https://community.n8n.io/t/alternative-node-for-classify-text-for-violations-after-openai-deprecation/213808

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
