### PR TITLE
fix(HTTP Node): Handle Azure Storage Shared Key

### DIFF
--- a/packages/nodes-base/credentials/AzureStorageSharedKeyApi.credentials.ts
+++ b/packages/nodes-base/credentials/AzureStorageSharedKeyApi.credentials.ts
@@ -11,6 +11,7 @@ import {
 	getCanonicalizedHeadersString,
 	getCanonicalizedResourceString,
 	HeaderConstants,
+	XMsVersion,
 } from '../nodes/Microsoft/Storage/GenericFunctions';
 
 export class AzureStorageSharedKeyApi implements ICredentialType {
@@ -67,6 +68,9 @@ export class AzureStorageSharedKeyApi implements ICredentialType {
 
 		requestOptions.method ??= 'GET';
 		requestOptions.headers ??= {};
+
+		requestOptions.headers[HeaderConstants.X_MS_VERSION] ??= XMsVersion;
+		requestOptions.headers[HeaderConstants.X_MS_DATE] ??= new Date().toUTCString();
 
 		const stringToSign: string = [
 			requestOptions.method.toUpperCase(),

--- a/packages/nodes-base/credentials/common/http.ts
+++ b/packages/nodes-base/credentials/common/http.ts
@@ -1,6 +1,14 @@
 import type { IHttpRequestOptions, IRequestOptions } from 'n8n-workflow';
 
-export const getUrl = (options: IHttpRequestOptions | IRequestOptions) => {
-	// FIXME: HTTP node uses old IRequestOptions interface
-	return options.url ?? (options as IRequestOptions).uri;
+export const getUrl = (options: IHttpRequestOptions | IRequestOptions): string => {
+	if (options.baseURL && options.url) {
+		return new URL(options.url, options.baseURL).toString();
+	}
+	if (options.url) {
+		return options.url;
+	}
+	if ('uri' in options && options.uri) {
+		return options.uri;
+	}
+	throw new Error('No URL found in request options');
 };

--- a/packages/nodes-base/credentials/common/http.ts
+++ b/packages/nodes-base/credentials/common/http.ts
@@ -1,11 +1,8 @@
 import type { IHttpRequestOptions, IRequestOptions } from 'n8n-workflow';
 
 export const getUrl = (options: IHttpRequestOptions | IRequestOptions): string => {
-	if (options.baseURL && options.url) {
-		return new URL(options.url, options.baseURL).toString();
-	}
 	if (options.url) {
-		return options.url;
+		return new URL(options.url, options.baseURL).toString();
 	}
 	if ('uri' in options && options.uri) {
 		return options.uri;

--- a/packages/nodes-base/credentials/test/common/http.test.ts
+++ b/packages/nodes-base/credentials/test/common/http.test.ts
@@ -1,0 +1,19 @@
+import { getUrl } from '@credentials/common/http';
+
+describe('getUrl', () => {
+	it('should throw an error if no url is provided', () => {
+		expect(() => getUrl({})).toThrow('No URL found in request options');
+	});
+	it('should return the url', () => {
+		const url = getUrl({ url: 'https://example.com' });
+		expect(url).toBe('https://example.com/');
+	});
+	it('should return the url with baseURL', () => {
+		const url = getUrl({ baseURL: 'https://example.com', url: 'https://example.com/test' });
+		expect(url).toBe('https://example.com/test');
+	});
+	it('should return the url with uri', () => {
+		const url = getUrl({ uri: 'https://example.com/test' });
+		expect(url).toBe('https://example.com/test');
+	});
+});

--- a/packages/nodes-base/credentials/test/common/http.test.ts
+++ b/packages/nodes-base/credentials/test/common/http.test.ts
@@ -6,10 +6,10 @@ describe('getUrl', () => {
 	});
 	it('should return the url', () => {
 		const url = getUrl({ url: 'https://example.com' });
-		expect(url).toBe('https://example.com/');
+		expect(url).toBe('https://example.com');
 	});
 	it('should return the url with baseURL', () => {
-		const url = getUrl({ baseURL: 'https://example.com', url: 'https://example.com/test' });
+		const url = getUrl({ baseURL: 'https://example.com', url: '/test' });
 		expect(url).toBe('https://example.com/test');
 	});
 	it('should return the url with uri', () => {

--- a/packages/nodes-base/credentials/test/common/http.test.ts
+++ b/packages/nodes-base/credentials/test/common/http.test.ts
@@ -6,7 +6,7 @@ describe('getUrl', () => {
 	});
 	it('should return the url', () => {
 		const url = getUrl({ url: 'https://example.com' });
-		expect(url).toBe('https://example.com');
+		expect(url).toBe('https://example.com/');
 	});
 	it('should return the url with baseURL', () => {
 		const url = getUrl({ baseURL: 'https://example.com', url: '/test' });

--- a/packages/nodes-base/nodes/Microsoft/Storage/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/Storage/GenericFunctions.ts
@@ -13,10 +13,13 @@ import type {
 	INodeListSearchItems,
 	INodeParameterResourceLocator,
 	ICredentialDataDecryptedObject,
+	IRequestOptions,
 } from 'n8n-workflow';
 import { NodeApiError } from 'n8n-workflow';
 import { Parser } from 'xml2js';
 import { firstCharLowerCase, parseBooleans, parseNumbers } from 'xml2js/lib/processors';
+
+import { getUrl } from '@credentials/common/http';
 
 import { compareHeader } from './compare-header';
 
@@ -252,7 +255,9 @@ export async function handleErrorPostReceive(
 	return data;
 }
 
-export function getCanonicalizedHeadersString(requestOptions: IHttpRequestOptions): string {
+export function getCanonicalizedHeadersString(
+	requestOptions: IHttpRequestOptions | IRequestOptions,
+): string {
 	let headersArray: Array<{ name: string; value: string }> = [];
 	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 	for (const [name, value] of Object.entries(requestOptions.headers!) as unknown as [
@@ -287,10 +292,10 @@ export function getCanonicalizedHeadersString(requestOptions: IHttpRequestOption
 }
 
 export function getCanonicalizedResourceString(
-	requestOptions: IHttpRequestOptions,
+	requestOptions: IHttpRequestOptions | IRequestOptions,
 	credentials: ICredentialDataDecryptedObject,
 ): string {
-	const path: string = new URL(requestOptions.baseURL + requestOptions.url).pathname || '/';
+	const path: string = new URL(getUrl(requestOptions)).pathname || '/';
 	let canonicalizedResourceString = `/${credentials.account as string}${path}`;
 	if (requestOptions.qs && Object.keys(requestOptions.qs).length > 0) {
 		canonicalizedResourceString +=


### PR DESCRIPTION
## Summary

This PR fixes Azure Shared Key behavior in Http Node, which previously caused any request to fail with "Invalid URL" error

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-2833/community-issue-custom-api-call-to-azure-storage-with-shared-key
closes #14485


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
