### PR TITLE
chore: Hide Github document loader (deprecated)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/document_loaders/DocumentGithubLoader/DocumentGithubLoader.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/document_loaders/DocumentGithubLoader/DocumentGithubLoader.node.ts
@@ -39,6 +39,7 @@ export class DocumentGithubLoader implements INodeType {
 		version: [1, 1.1],
 		defaultVersion: 1.1,
 		description: 'Use GitHub data as input to this chain',
+		hidden: true,
 		defaults: {
 			name: 'GitHub Document Loader',
 		},


### PR DESCRIPTION
## Summary

Hiding Github document loader, it is currently broken and should have been hidden already.

Addresses: https://linear.app/n8n/issue/AI-1694/github-document-loader-fully-broken

Adding deprecation warning to docs: https://github.com/n8n-io/n8n-docs/pull/3907

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
