### PR TITLE
fix(core): Safely handle paths at Data Table CSV imports (no-changelog)

### DIFF
--- a/packages/cli/src/modules/data-table/__tests__/csv-parser.service.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/csv-parser.service.test.ts
@@ -1,0 +1,78 @@
+import { testModules } from '@n8n/backend-test-utils';
+import type { GlobalConfig } from '@n8n/config';
+import { mock } from 'jest-mock-extended';
+
+import { CsvParserService } from '../csv-parser.service';
+
+beforeAll(async () => {
+	await testModules.loadModules(['data-table']);
+});
+describe('CsvParserService', () => {
+	describe('parseFile', () => {
+		it('should not allow path traversal when parsing CSV file metadata', async () => {
+			const globalConfig = mock<GlobalConfig>({
+				dataTable: {
+					uploadDir: '/safe/upload/dir',
+				},
+			});
+
+			const csvParserService = new CsvParserService(globalConfig);
+
+			const maliciousFileId = '../some/other/directory/malicious-file.csv';
+
+			await expect(csvParserService.parseFile(maliciousFileId)).rejects.toThrowError(
+				'Path traversal detected',
+			);
+		});
+
+		it('should try to access file if it is within upload directory', async () => {
+			const globalConfig = mock<GlobalConfig>({
+				dataTable: {
+					uploadDir: '/safe/upload/dir',
+				},
+			});
+
+			const csvParserService = new CsvParserService(globalConfig);
+			const safeFileId = 'valid-file.csv';
+
+			// Since we are not actually testing file reading here, just ensure no error is thrown
+			await expect(csvParserService.parseFile(safeFileId)).rejects.toThrowError(
+				"ENOENT: no such file or directory, open '/safe/upload/dir/valid-file.csv",
+			);
+		});
+	});
+
+	describe('parseFileData', () => {
+		it('should not allow path traversal when parsing CSV file data', async () => {
+			const globalConfig = mock<GlobalConfig>({
+				dataTable: {
+					uploadDir: '/safe/upload/dir',
+				},
+			});
+
+			const csvParserService = new CsvParserService(globalConfig);
+
+			const maliciousFileId = '../some/other/directory/malicious-file.csv';
+
+			await expect(csvParserService.parseFileData(maliciousFileId)).rejects.toThrowError(
+				'Path traversal detected',
+			);
+		});
+
+		it('should try to access file if it is within upload directory', async () => {
+			const globalConfig = mock<GlobalConfig>({
+				dataTable: {
+					uploadDir: '/safe/upload/dir',
+				},
+			});
+
+			const csvParserService = new CsvParserService(globalConfig);
+			const safeFileId = 'valid-file.csv';
+
+			// Since we are not actually testing file reading here, just ensure no error is thrown
+			await expect(csvParserService.parseFileData(safeFileId)).rejects.toThrowError(
+				"ENOENT: no such file or directory, open '/safe/upload/dir/valid-file.csv",
+			);
+		});
+	});
+});

--- a/packages/cli/src/modules/data-table/__tests__/data-table-file-cleanup.service.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/data-table-file-cleanup.service.test.ts
@@ -66,6 +66,14 @@ describe('DataTableFileCleanupService', () => {
 
 			await expect(service.deleteFile(fileId)).rejects.toThrow('Permission denied');
 		});
+
+		it('should not allow path traversal when deleting file', async () => {
+			const maliciousFileId = '../some/other/directory/malicious-file.csv';
+
+			await expect(service.deleteFile(maliciousFileId)).rejects.toThrowError(
+				'Path traversal detected',
+			);
+		});
 	});
 
 	describe('start and shutdown', () => {

--- a/packages/cli/src/modules/data-table/data-table-file-cleanup.service.ts
+++ b/packages/cli/src/modules/data-table/data-table-file-cleanup.service.ts
@@ -1,7 +1,7 @@
+import { safeJoinPath } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
 import { promises as fs } from 'fs';
-import path from 'path';
 
 @Service()
 export class DataTableFileCleanupService {
@@ -47,7 +47,7 @@ export class DataTableFileCleanupService {
 			const maxAge = this.globalConfig.dataTable.fileMaxAgeMs;
 
 			for (const file of files) {
-				const filePath = path.join(this.uploadDir, file);
+				const filePath = safeJoinPath(this.uploadDir, file);
 				try {
 					const stats = await fs.stat(filePath);
 					const fileAge = now - stats.mtimeMs;
@@ -74,7 +74,7 @@ export class DataTableFileCleanupService {
 	 * Deletes a specific CSV file by its fileId
 	 */
 	async deleteFile(fileId: string): Promise<void> {
-		const filePath = path.join(this.uploadDir, fileId);
+		const filePath = safeJoinPath(this.uploadDir, fileId);
 		try {
 			await fs.unlink(filePath);
 		} catch (error) {


### PR DESCRIPTION
## Summary

Ensure the `fileId` cannot be used for path traversal attacks on Data Table CSV imports.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4454

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
