### PR TITLE
chore: Add telemetry for user role provisioning (no changelog)

### DIFF
--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -702,6 +702,38 @@ describe('TelemetryEventRelay', () => {
 		});
 	});
 
+	describe('SSO events', () => {
+		it('should track on `sso-user-project-access-updated` event', () => {
+			const event: RelayEventMap['sso-user-project-access-updated'] = {
+				userId: 'user123',
+				projectsRemoved: 2,
+				projectsAdded: 3,
+			};
+
+			eventService.emit('sso-user-project-access-updated', event);
+
+			expect(telemetry.track).toHaveBeenCalledWith('Sso user project acess update', {
+				user_id: 'user123',
+				projects_removed: 2,
+				projects_added: 3,
+			});
+		});
+
+		it('should track on `sso-user-instance-role-updated` event', () => {
+			const event: RelayEventMap['sso-user-instance-role-updated'] = {
+				userId: 'user123',
+				role: 'global:admin',
+			};
+
+			eventService.emit('sso-user-instance-role-updated', event);
+
+			expect(telemetry.track).toHaveBeenCalledWith('Sso user instance role update', {
+				user_id: 'user123',
+				role: 'global:admin',
+			});
+		});
+	});
+
 	describe('workflow events', () => {
 		it('should track on `workflow-created` event', async () => {
 			const event: RelayEventMap['workflow-created'] = {

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -533,6 +533,19 @@ export type RelayEventMap = {
 
 	// #endregion
 
+	// #region SSO
+
+	'sso-user-project-access-updated': {
+		projectsRemoved: number;
+		projectsAdded: number;
+		userId: string;
+	};
+
+	'sso-user-instance-role-updated': {
+		role: string;
+		userId: string;
+	};
+
 	// #region runner
 
 	'runner-task-requested': {

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -81,6 +81,8 @@ export class TelemetryEventRelay extends EventRelay {
 			'ldap-settings-updated': (event) => this.ldapSettingsUpdated(event),
 			'ldap-login-sync-failed': (event) => this.ldapLoginSyncFailed(event),
 			'login-failed-due-to-ldap-disabled': (event) => this.loginFailedDueToLdapDisabled(event),
+			'sso-user-project-access-updated': (event) => this.ssoUserProjectAccessUpdated(event),
+			'sso-user-instance-role-updated': (event) => this.ssoUserInstanceRoleUpdated(event),
 			'workflow-created': (event) => this.workflowCreated(event),
 			'workflow-archived': (event) => this.workflowArchived(event),
 			'workflow-unarchived': (event) => this.workflowUnarchived(event),
@@ -527,6 +529,29 @@ export class TelemetryEventRelay extends EventRelay {
 		userId,
 	}: RelayEventMap['login-failed-due-to-ldap-disabled']) {
 		this.telemetry.track('User login failed since ldap disabled', { user_ud: userId });
+	}
+
+	// #endregion
+
+	// #region SSO
+
+	private ssoUserProjectAccessUpdated({
+		projectsRemoved,
+		projectsAdded,
+		userId,
+	}: RelayEventMap['sso-user-project-access-updated']) {
+		this.telemetry.track('Sso user project acess update', {
+			user_id: userId,
+			projects_removed: projectsRemoved,
+			projects_added: projectsAdded,
+		});
+	}
+
+	private ssoUserInstanceRoleUpdated({
+		userId,
+		role,
+	}: RelayEventMap['sso-user-instance-role-updated']) {
+		this.telemetry.track('Sso user instance role update', { user_id: userId, role });
 	}
 
 	// #endregion

--- a/packages/frontend/editor-ui/src/features/settings/sso/components/OidcSettingsForm.vue
+++ b/packages/frontend/editor-ui/src/features/settings/sso/components/OidcSettingsForm.vue
@@ -25,6 +25,7 @@ const telemetry = useTelemetry();
 const toast = useToast();
 const message = useMessage();
 const pageRedirectionHelper = usePageRedirectionHelper();
+const instanceId = useRootStore().instanceId;
 
 const savingForm = ref<boolean>(false);
 
@@ -151,6 +152,7 @@ async function onOidcSettingsSave(provisioningChangesConfirmed: boolean = false)
 
 		if (isUserRoleProvisioningChanged()) {
 			await saveProvisioningConfig();
+			sendTrackingEventForUserProvisioning();
 			showUserRoleProvisioningDialog.value = false;
 		}
 
@@ -171,12 +173,20 @@ async function onOidcSettingsSave(provisioningChangesConfirmed: boolean = false)
 
 function sendTrackingEvent(config: OidcConfigDto) {
 	const trackingMetadata = {
-		instance_id: useRootStore().instanceId,
+		instance_id: instanceId,
 		authentication_method: SupportedProtocols.OIDC,
 		discovery_endpoint: config.discoveryEndpoint,
 		is_active: config.loginEnabled,
 	};
 	telemetry.track('User updated single sign on settings', trackingMetadata);
+}
+
+function sendTrackingEventForUserProvisioning() {
+	telemetry.track('User updated provisioning settings', {
+		instance_id: instanceId,
+		authentication_method: SupportedProtocols.OIDC,
+		updated_setting: userRoleProvisioning.value,
+	});
 }
 
 const goToUpgrade = () => {

--- a/packages/frontend/editor-ui/src/features/settings/sso/components/SamlSettingsForm.vue
+++ b/packages/frontend/editor-ui/src/features/settings/sso/components/SamlSettingsForm.vue
@@ -26,6 +26,7 @@ const telemetry = useTelemetry();
 const toast = useToast();
 const message = useMessage();
 const pageRedirectionHelper = usePageRedirectionHelper();
+const instanceId = useRootStore().instanceId;
 
 const savingForm = ref<boolean>(false);
 
@@ -122,12 +123,20 @@ const sendTrackingEvent = (config?: SamlPreferences) => {
 		return;
 	}
 	const trackingMetadata = {
-		instance_id: useRootStore().instanceId,
+		instance_id: instanceId,
 		authentication_method: SupportedProtocols.SAML,
 		identity_provider: config.metadataUrl ? 'metadata' : 'xml',
 		is_active: config.loginEnabled ?? false,
 	};
 	telemetry.track('User updated single sign on settings', trackingMetadata);
+};
+
+const sendTrackingEventForUserProvisioning = () => {
+	telemetry.track('User updated provisioning settings', {
+		instance_id: instanceId,
+		authentication_method: SupportedProtocols.SAML,
+		updated_setting: userRoleProvisioning.value,
+	});
 };
 
 const promptConfirmDisablingSamlLogin = async () => {
@@ -221,6 +230,7 @@ const onSave = async (provisioningChangesConfirmed: boolean = false) => {
 
 		if (isUserRoleProvisioningChanged()) {
 			await saveProvisioningConfig();
+			sendTrackingEventForUserProvisioning();
 			showUserRoleProvisioningDialog.value = false;
 		}
 


### PR DESCRIPTION
## Summary

Sends telemetry data when user role provisioning setting is changed and when access changes when logging in via SSO

## Related Linear tickets, Github issues, and Community forum posts

PAY-4019


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
