### PR TITLE
feat: add debug logs when reinstalling community nodes

### DIFF
--- a/packages/cli/src/modules/community-packages/community-packages.service.ts
+++ b/packages/cli/src/modules/community-packages/community-packages.service.ts
@@ -327,6 +327,11 @@ export class CommunityPackagesService {
 				this.logger.info('Packages reinstalled successfully. Resuming regular initialization.');
 				await this.loadNodesAndCredentials.postProcessLoaders();
 			} catch (error) {
+				this.logger.debug(error.message);
+				if (error.cause instanceof Error) {
+					this.logger.debug(`Caused by: ${error.cause.message}`);
+				}
+
 				this.logger.error('n8n was unable to install the missing packages.');
 			}
 		} else {
@@ -394,6 +399,8 @@ export class CommunityPackagesService {
 		const packageVersion = !options.version ? 'latest' : options.version;
 
 		const shouldValidateChecksum = 'checksum' in options && Boolean(options.checksum);
+
+		this.logger.debug(`Attempting to ${isUpdate ? 'update' : 'install'} ${packageName} ${packageVersion}`);
 		this.checkInstallPermissions(shouldValidateChecksum);
 
 		if (options.checksum) {


### PR DESCRIPTION
## Summary

When reinstalling community nodes at startup, any error in package installation would be silently captured and only the high level "n8n was unable to install the missing packages" message would be visible in the logs.

This adds debug-level logging to shine a bit more light on issues that occur during the reinstallation process.

Specifically:

- "Attempting to <update/install> <package> <version>" on any package installation
- Logging the message of the original error when reinstallation fails
- Logging the message of the `cause` of that original error if it is populated

## Related Linear tickets, Github issues, and Community forum posts

This was kicked off by attempts to debug reinstallation failures of n8n-nodes-mcp due to a zod export issue, related to https://github.com/nerding-io/n8n-nodes-mcp/issues/248

If n8n-nodes-mcp is installed on an instance and that instance is redeployed, reinstallation will fail.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
