### PR TITLE
Fix SendGrid node inline attachments

### DIFF
--- a/packages/nodes-base/nodes/SendGrid/MailDescription.ts
+++ b/packages/nodes-base/nodes/SendGrid/MailDescription.ts
@@ -209,9 +209,54 @@ export const mailFields: INodeProperties[] = [
 			{
 				displayName: 'Attachments',
 				name: 'attachments',
-				type: 'string',
-				default: '',
-				description: 'Comma-separated list of binary properties',
+				type: 'fixedCollection',
+				typeOptions: {
+					multipleValues: true,
+				},
+				default: {},
+				options: [
+					{
+						displayName: 'Attachment',
+						name: 'data',
+						values: [
+							{
+								displayName: 'Property',
+								name: 'property',
+								type: 'string',
+								default: 'data',
+								description: 'Binary property name',
+							},
+							{
+								displayName: 'Content Disposition',
+								name: 'disposition',
+								type: 'options',
+								default: 'attachment',
+								options: [
+									{
+										name: 'Attachment',
+										value: 'attachment',
+									},
+									{
+										name: 'Inline',
+										value: 'inline',
+									},
+								],
+								description:
+									"The attachment's content-disposition specifies how you would like the attachment to be displayed",
+							},
+							{
+								displayName: 'Content ID',
+								name: 'contentId',
+								type: 'string',
+								default: '',
+								description:
+									'The attachment\'s Content ID is used when the Disposition is set to "inline" and the attachment is an image, allowing the file to be displayed within the body of the email',
+								hint: 'Default to "attachmentN", where N is the attachment\'s index (zero-based)',
+							},
+						],
+					},
+				],
+				description: 'File attachments',
 			},
 			{
 				displayName: 'BCC Email',

--- a/packages/nodes-base/nodes/SendGrid/SendGrid.node.json
+++ b/packages/nodes-base/nodes/SendGrid/SendGrid.node.json
@@ -1,7 +1,7 @@
 {
 	"node": "n8n-nodes-base.sendGrid",
-	"nodeVersion": "1.0",
-	"codexVersion": "1.0",
+	"nodeVersion": "1.1",
+	"codexVersion": "1.1",
 	"categories": ["Marketing", "Communication"],
 	"resources": {
 		"credentialDocumentation": [

--- a/packages/nodes-base/nodes/SendGrid/SendGrid.node.json
+++ b/packages/nodes-base/nodes/SendGrid/SendGrid.node.json
@@ -1,7 +1,7 @@
 {
 	"node": "n8n-nodes-base.sendGrid",
-	"nodeVersion": "1.1",
-	"codexVersion": "1.1",
+	"nodeVersion": "1.0",
+	"codexVersion": "1.0",
 	"categories": ["Marketing", "Communication"],
 	"resources": {
 		"credentialDocumentation": [

--- a/packages/nodes-base/nodes/SendGrid/SendGrid.node.ts
+++ b/packages/nodes-base/nodes/SendGrid/SendGrid.node.ts
@@ -531,7 +531,13 @@ export class SendGrid implements INodeType {
 							enableSandbox: boolean;
 							sendAt: string;
 							headers: { details: Array<{ key: string; value: string }> };
-							attachments: string;
+							attachments: {
+								data: {
+									property: string;
+									disposition: 'attachment' | 'inline';
+									contentId: string;
+								}[];
+							};
 							categories: string;
 							ipPoolName: string;
 							replyToEmail: string;
@@ -582,11 +588,11 @@ export class SendGrid implements INodeType {
 							];
 						}
 
-						if (attachments) {
+						if (attachments?.data) {
 							const attachmentsToSend = [];
-							const binaryProperties = attachments.split(',').map((p) => p.trim());
 
-							for (const property of binaryProperties) {
+							for (const ai in attachments.data) {
+								const { property, disposition, contentId } = attachments.data[ai];
 								const binaryData = this.helpers.assertBinaryData(i, property);
 								const dataBuffer = await this.helpers.getBinaryDataBuffer(i, property);
 
@@ -594,6 +600,8 @@ export class SendGrid implements INodeType {
 									content: dataBuffer.toString('base64'),
 									filename: binaryData.fileName || 'unknown',
 									type: binaryData.mimeType,
+									disposition,
+									content_id: contentId || `attachment${ai}`,
 								});
 							}
 

--- a/packages/nodes-base/nodes/SendGrid/SendGrid.node.ts
+++ b/packages/nodes-base/nodes/SendGrid/SendGrid.node.ts
@@ -23,7 +23,7 @@ export class SendGrid implements INodeType {
 		name: 'sendGrid',
 		icon: 'file:sendGrid.svg',
 		group: ['transform'],
-		version: 1,
+		version: [1,2],
 		subtitle: '={{$parameter["operation"] + ":" + $parameter["resource"]}}',
 		description: 'Consume SendGrid API',
 		defaults: {
@@ -130,6 +130,7 @@ export class SendGrid implements INodeType {
 	};
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+		const nodeVersion = this.getNode().typeVersion;
 		const items = this.getInputData();
 		const length = items.length;
 		const qs: IDataObject = {};
@@ -531,7 +532,8 @@ export class SendGrid implements INodeType {
 							enableSandbox: boolean;
 							sendAt: string;
 							headers: { details: Array<{ key: string; value: string }> };
-							attachments: {
+							// Keeping `string` type for backwards compatibility
+							attachments: string | {
 								data: {
 									property: string;
 									disposition: 'attachment' | 'inline';
@@ -588,25 +590,50 @@ export class SendGrid implements INodeType {
 							];
 						}
 
-						if (attachments?.data) {
-							const attachmentsToSend = [];
+						if (nodeVersion === 1) {
+							// Backwards compatibility for node version 1
+							if (attachments) {
+								const attachmentsToSend = [];
+								const binaryProperties = (attachments as string).split(',').map((p) => p.trim());
 
-							for (const ai in attachments.data) {
-								const { property, disposition, contentId } = attachments.data[ai];
-								const binaryData = this.helpers.assertBinaryData(i, property);
-								const dataBuffer = await this.helpers.getBinaryDataBuffer(i, property);
+								for (const property of binaryProperties) {
+									const binaryData = this.helpers.assertBinaryData(i, property);
+									const dataBuffer = await this.helpers.getBinaryDataBuffer(i, property);
 
-								attachmentsToSend.push({
-									content: dataBuffer.toString('base64'),
-									filename: binaryData.fileName || 'unknown',
-									type: binaryData.mimeType,
-									disposition,
-									content_id: contentId || `attachment${ai}`,
-								});
+									attachmentsToSend.push({
+										content: dataBuffer.toString('base64'),
+										filename: binaryData.fileName || 'unknown',
+										type: binaryData.mimeType,
+									});
+								}
+
+								if (attachmentsToSend.length) {
+									body.attachments = attachmentsToSend;
+								}
 							}
+						} else {
+							// New way for node version 2 and onward
+							if ((attachments as any)?.data) {
+								const { data } = (attachments as any);
+								const attachmentsToSend = [];
 
-							if (attachmentsToSend.length) {
-								body.attachments = attachmentsToSend;
+								for (const ai in data) {
+									const { property, disposition, contentId } = data[ai];
+									const binaryData = this.helpers.assertBinaryData(i, property);
+									const dataBuffer = await this.helpers.getBinaryDataBuffer(i, property);
+
+									attachmentsToSend.push({
+										content: dataBuffer.toString('base64'),
+										filename: binaryData.fileName || 'unknown',
+										type: binaryData.mimeType,
+										disposition,
+										content_id: contentId || `attachment${ai}`,
+									});
+								}
+
+								if (attachmentsToSend.length) {
+									body.attachments = attachmentsToSend;
+								}
 							}
 						}
 


### PR DESCRIPTION
## Summary

Introduces support for inline E-mail attachments to the existing SendGrid node.
I've verified this solution locally using inline/attachment and a combination of both disposition options.

This introduces a breaking change in the node's properties structure so I've also bumped the node's version.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
