### PR TITLE
fix(ClickUp Node): Fix minute to millisecond conversion

### DIFF
--- a/packages/nodes-base/nodes/ClickUp/ClickUp.node.ts
+++ b/packages/nodes-base/nodes/ClickUp/ClickUp.node.ts
@@ -910,7 +910,7 @@ export class ClickUp implements INodeType {
 							body.due_date_time = additionalFields.dueDateTime as boolean;
 						}
 						if (additionalFields.timeEstimate) {
-							body.time_estimate = (additionalFields.timeEstimate as number) * 6000;
+							body.time_estimate = (additionalFields.timeEstimate as number) * 60000;
 						}
 						if (additionalFields.startDate) {
 							body.start_date = new Date(additionalFields.startDate as string).getTime();
@@ -952,7 +952,7 @@ export class ClickUp implements INodeType {
 							body.due_date_time = updateFields.dueDateTime as boolean;
 						}
 						if (updateFields.timeEstimate) {
-							body.time_estimate = (updateFields.timeEstimate as number) * 6000;
+							body.time_estimate = (updateFields.timeEstimate as number) * 60000;
 						}
 						if (updateFields.startDate) {
 							body.start_date = new Date(updateFields.startDate as string).getTime();


### PR DESCRIPTION
## Summary

Fix minute to millisecond conversion

<img width="507" height="649" alt="image" src="https://github.com/user-attachments/assets/66e3826a-0156-48ae-ad29-a094268ad1d8" />
<br>
<img width="548" height="788" alt="image" src="https://github.com/user-attachments/assets/f2f65649-7aec-46b4-8a16-6b7acc1995cd" />
<br>
<br>
From ClickUp:
<br>
<img width="409" height="52" alt="image" src="https://github.com/user-attachments/assets/96f3ea7e-95cd-4efe-9303-3c9cb82b47fd" />

As specified in https://developer.clickup.com/docs/tasks `time_estimate` has values in milliseconds. 

## Related Linear tickets, Github issues, and Community forum posts
fixes #21712

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
