### PR TITLE
test: Disable log colors in benchmark task runners

### DIFF
--- a/packages/@n8n/benchmark/scripts/n8n-setups/postgres/docker-compose.yml
+++ b/packages/@n8n/benchmark/scripts/n8n-setups/postgres/docker-compose.yml
@@ -59,6 +59,7 @@ services:
     environment:
       - N8N_RUNNERS_TASK_BROKER_URI=http://n8n:5679
       - N8N_RUNNERS_AUTH_TOKEN=test
+      - NO_COLOR=1
     depends_on:
       n8n:
         condition: service_healthy

--- a/packages/@n8n/benchmark/scripts/n8n-setups/scaling-multi-main/docker-compose.yml
+++ b/packages/@n8n/benchmark/scripts/n8n-setups/scaling-multi-main/docker-compose.yml
@@ -75,6 +75,7 @@ services:
     environment:
       - N8N_RUNNERS_TASK_BROKER_URI=http://n8n_worker1:5679
       - N8N_RUNNERS_AUTH_TOKEN=test
+      - NO_COLOR=1
     depends_on:
       n8n_worker1:
         condition: service_healthy
@@ -125,6 +126,7 @@ services:
     environment:
       - N8N_RUNNERS_TASK_BROKER_URI=http://n8n_worker2:5679
       - N8N_RUNNERS_AUTH_TOKEN=test
+      - NO_COLOR=1
     depends_on:
       n8n_worker2:
         condition: service_healthy

--- a/packages/@n8n/benchmark/scripts/n8n-setups/scaling-single-main/docker-compose.yml
+++ b/packages/@n8n/benchmark/scripts/n8n-setups/scaling-single-main/docker-compose.yml
@@ -73,6 +73,7 @@ services:
     environment:
       - N8N_RUNNERS_TASK_BROKER_URI=http://n8n_worker1:5679
       - N8N_RUNNERS_AUTH_TOKEN=test
+      - NO_COLOR=1
     depends_on:
       n8n_worker1:
         condition: service_healthy
@@ -121,6 +122,7 @@ services:
     environment:
       - N8N_RUNNERS_TASK_BROKER_URI=http://n8n_worker2:5679
       - N8N_RUNNERS_AUTH_TOKEN=test
+      - NO_COLOR=1
     depends_on:
       n8n_worker2:
         condition: service_healthy

--- a/packages/@n8n/benchmark/scripts/n8n-setups/sqlite/docker-compose.yml
+++ b/packages/@n8n/benchmark/scripts/n8n-setups/sqlite/docker-compose.yml
@@ -39,6 +39,7 @@ services:
     environment:
       - N8N_RUNNERS_TASK_BROKER_URI=http://n8n:5679
       - N8N_RUNNERS_AUTH_TOKEN=test
+      - NO_COLOR=1
     depends_on:
       n8n:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Disable log colors in benchmark task runners

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
