### PR TITLE
ci: Fix author/commiter for automated PR

### DIFF
--- a/.github/workflows/update-node-popularity.yml
+++ b/.github/workflows/update-node-popularity.yml
@@ -56,5 +56,5 @@ jobs:
           branch: update-node-popularity
           base: master
           delete-branch: true
-          author: n8n Bot <18347049+n8n-bot@users.noreply.github.com>
-          committer: n8n Bot <18347049+n8n-bot@users.noreply.github.com>
+          author: n8n Bot <191478365+n8n-bot@users.noreply.github.com>
+          committer: n8n Bot <191478365+n8n-bot@users.noreply.github.com>


### PR DESCRIPTION
## Summary

My copy pasta didn't use the correct bot ID!

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
