### PR TITLE
fix(core): Send prod workflow succeeded for wfs in projects

### DIFF
--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -1122,7 +1122,7 @@ describe('TelemetryEventRelay', () => {
 	});
 
 	describe('workflow execution events', () => {
-		it('should track on `first-production-workflow-succeeded` event', () => {
+		it('should track on `first-production-workflow-succeeded` event for personal project', () => {
 			const event: RelayEventMap['first-production-workflow-succeeded'] = {
 				projectId: 'project123',
 				workflowId: 'workflow123',
@@ -1135,6 +1135,22 @@ describe('TelemetryEventRelay', () => {
 				project_id: 'project123',
 				workflow_id: 'workflow123',
 				user_id: 'user123',
+			});
+		});
+
+		it('should track on `first-production-workflow-succeeded` event for team project with null userId', () => {
+			const event: RelayEventMap['first-production-workflow-succeeded'] = {
+				projectId: 'project123',
+				workflowId: 'workflow123',
+				userId: null,
+			};
+
+			eventService.emit('first-production-workflow-succeeded', event);
+
+			expect(telemetry.track).toHaveBeenCalledWith('Workflow first prod success', {
+				project_id: 'project123',
+				workflow_id: 'workflow123',
+				user_id: undefined,
 			});
 		});
 

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -39,7 +39,7 @@ export type RelayEventMap = {
 	'first-production-workflow-succeeded': {
 		projectId: string;
 		workflowId: string;
-		userId: string;
+		userId: string | null;
 	};
 
 	'first-workflow-data-loaded': {

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -912,7 +912,7 @@ export class TelemetryEventRelay extends EventRelay {
 		this.telemetry.track('Workflow first prod success', {
 			project_id: projectId,
 			workflow_id: workflowId,
-			user_id: userId,
+			user_id: userId ?? undefined,
 		});
 	}
 

--- a/packages/cli/src/services/workflow-statistics.service.ts
+++ b/packages/cli/src/services/workflow-statistics.service.ts
@@ -116,8 +116,11 @@ export class WorkflowStatisticsService extends TypedEmitter<WorkflowStatisticsEv
 
 			if (name === StatisticsNames.productionSuccess && upsertResult === 'insert') {
 				const project = await this.ownershipService.getWorkflowProjectCached(workflowId);
+				let userId: string | null = null;
+
 				if (project.type === 'personal') {
 					const owner = await this.ownershipService.getPersonalProjectOwnerCached(project.id);
+					userId = owner?.id ?? null;
 
 					if (owner && !owner.settings?.userActivated) {
 						await this.userService.updateSettings(owner.id, {
@@ -126,13 +129,13 @@ export class WorkflowStatisticsService extends TypedEmitter<WorkflowStatisticsEv
 							userActivatedAt: runData.startedAt.getTime(),
 						});
 					}
-
-					this.eventService.emit('first-production-workflow-succeeded', {
-						projectId: project.id,
-						workflowId,
-						userId: owner!.id,
-					});
 				}
+
+				this.eventService.emit('first-production-workflow-succeeded', {
+					projectId: project.id,
+					workflowId,
+					userId,
+				});
 			}
 		} catch (error) {
 			this.logger.debug('Unable to fire first workflow success telemetry event');


### PR DESCRIPTION
## Summary

The event `Workflow first prod success` is emitted when a workflow succeeds for the first time in prod. 
However, this was only sent for workflows in a personal project. 

This has been changes to include all workflows. 
For workflows in personal project
- project id and user id are sent in the payload

For workflows in other project
- only project id is sent

This behaviour is documented [here](https://www.notion.so/n8n/Workflow-first-prod-success-36aa7e94046e44b68dd26f0e2af90f76?d=a1ef7cd93eb0484b8190094136960aca)

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
https://n8nio.slack.com/archives/C04B1GZ4T0U/p1762944806681249
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
