### PR TITLE
fix(AI Agent Node): Unify memory management for streaming/non-streaming

### DIFF
--- a/packages/@n8n/nodes-langchain/utils/agent-execution/index.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/index.ts
@@ -11,7 +11,7 @@
 export { createEngineRequests } from './createEngineRequests';
 export { buildSteps } from './buildSteps';
 export { processEventStream } from './processEventStream';
-export { loadMemory, saveToMemory, saveToolResultsToMemory } from './memoryManagement';
+export { loadMemory, saveToMemory, buildToolContext } from './memoryManagement';
 export type {
 	ToolCallRequest,
 	ToolCallData,

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/processEventStream.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/processEventStream.ts
@@ -1,10 +1,8 @@
 import type { StreamEvent } from '@langchain/core/dist/tracers/event_stream';
 import type { IterableReadableStream } from '@langchain/core/dist/utils/stream';
 import type { AIMessageChunk, MessageContentText } from '@langchain/core/messages';
-import type { BaseChatMemory } from 'langchain/memory';
 import type { IExecuteFunctions } from 'n8n-workflow';
 
-import { saveToMemory, saveToolResultsToMemory } from './memoryManagement';
 import type { AgentResult, ToolCallRequest } from './types';
 
 /**
@@ -17,26 +15,16 @@ import type { AgentResult, ToolCallRequest } from './types';
  * @param ctx - The execution context
  * @param eventStream - The stream of events from the agent
  * @param itemIndex - The current item index
- * @param returnIntermediateSteps - Whether to capture intermediate steps
- * @param memory - Optional memory for saving context
- * @param input - The original input prompt
  * @returns AgentResult containing output and optional tool calls/steps
  */
 export async function processEventStream(
 	ctx: IExecuteFunctions,
 	eventStream: IterableReadableStream<StreamEvent>,
 	itemIndex: number,
-	returnIntermediateSteps: boolean = false,
-	memory?: BaseChatMemory,
-	input?: string,
 ): Promise<AgentResult> {
 	const agentResult: AgentResult = {
 		output: '',
 	};
-
-	if (returnIntermediateSteps) {
-		agentResult.intermediateSteps = [];
-	}
 
 	const toolCalls: ToolCallRequest[] = [];
 
@@ -84,52 +72,6 @@ export async function processEventStream(
 								messageLog: [output],
 							});
 						}
-
-						// Also add to intermediate steps if needed
-						if (returnIntermediateSteps) {
-							for (const toolCall of output.tool_calls) {
-								agentResult.intermediateSteps?.push({
-									action: {
-										tool: toolCall.name,
-										toolInput: toolCall.args,
-										log:
-											output.content ||
-											`Calling ${toolCall.name} with input: ${JSON.stringify(toolCall.args)}`,
-										messageLog: [output], // Include the full LLM response
-										toolCallId: toolCall.id || 'unknown',
-										type: toolCall.type || 'tool_call',
-									},
-									observation: '',
-								});
-							}
-						}
-					}
-				}
-				break;
-			case 'on_tool_end':
-				// Capture tool execution results and match with action
-				if (returnIntermediateSteps && event.data && agentResult.intermediateSteps!.length > 0) {
-					const toolData = event.data as { output?: string };
-					// Find the matching intermediate step for this tool call
-					const matchingStep = agentResult.intermediateSteps?.find(
-						(step) => !step.observation && step.action.tool === event.name,
-					);
-					if (matchingStep) {
-						matchingStep.observation = toolData.output || '';
-
-						// Save tool result to memory
-						if (matchingStep.observation && input) {
-							await saveToolResultsToMemory(
-								input,
-								[
-									{
-										action: matchingStep.action,
-										observation: matchingStep.observation,
-									},
-								],
-								memory,
-							);
-						}
 					}
 				}
 				break;
@@ -138,11 +80,6 @@ export async function processEventStream(
 		}
 	}
 	ctx.sendChunk('end', itemIndex);
-
-	// Save conversation to memory if memory is connected
-	if (input && agentResult.output) {
-		await saveToMemory(input, agentResult.output, memory);
-	}
 
 	// Include collected tool calls in the result
 	if (toolCalls.length > 0) {

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/test/memoryManagement.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/test/memoryManagement.test.ts
@@ -3,7 +3,7 @@ import { HumanMessage, AIMessage, SystemMessage, trimMessages } from '@langchain
 import { mock } from 'jest-mock-extended';
 import type { BaseChatMemory } from 'langchain/memory';
 
-import { loadMemory, saveToMemory, saveToolResultsToMemory } from '../memoryManagement';
+import { loadMemory, saveToMemory, buildToolContext } from '../memoryManagement';
 import type { ToolCallData } from '../types';
 
 jest.mock('@langchain/core/messages', () => ({
@@ -134,10 +134,9 @@ describe('memoryManagement', () => {
 		});
 	});
 
-	describe('saveToolResultsToMemory', () => {
-		it('should save tool results to memory', async () => {
-			const input = 'Calculate 2+2';
-			const toolResults: ToolCallData[] = [
+	describe('buildToolContext', () => {
+		it('should build tool context string from single step', () => {
+			const steps: ToolCallData[] = [
 				{
 					action: {
 						tool: 'calculator',
@@ -150,19 +149,13 @@ describe('memoryManagement', () => {
 				},
 			];
 
-			await saveToolResultsToMemory(input, toolResults, mockMemory);
+			const result = buildToolContext(steps);
 
-			expect(mockMemory.saveContext).toHaveBeenCalledWith(
-				{ input },
-				{
-					output: 'Tool: calculator, Input: {"expression":"2+2"}, Result: 4',
-				},
-			);
+			expect(result).toBe('Tool: calculator, Input: {"expression":"2+2"}, Result: 4');
 		});
 
-		it('should save multiple tool results', async () => {
-			const input = 'Get weather and time';
-			const toolResults: ToolCallData[] = [
+		it('should build tool context string from multiple steps', () => {
+			const steps: ToolCallData[] = [
 				{
 					action: {
 						tool: 'weather',
@@ -185,57 +178,21 @@ describe('memoryManagement', () => {
 				},
 			];
 
-			await saveToolResultsToMemory(input, toolResults, mockMemory);
+			const result = buildToolContext(steps);
 
-			expect(mockMemory.saveContext).toHaveBeenCalledTimes(2);
-			expect(mockMemory.saveContext).toHaveBeenNthCalledWith(
-				1,
-				{ input },
-				{
-					output: 'Tool: weather, Input: {"location":"New York"}, Result: Sunny, 72°F',
-				},
-			);
-			expect(mockMemory.saveContext).toHaveBeenNthCalledWith(
-				2,
-				{ input },
-				{
-					output: 'Tool: time, Input: {"timezone":"EST"}, Result: 14:30',
-				},
+			expect(result).toBe(
+				'Tool: weather, Input: {"location":"New York"}, Result: Sunny, 72°F; Tool: time, Input: {"timezone":"EST"}, Result: 14:30',
 			);
 		});
 
-		it('should not save when memory is not provided', async () => {
-			const input = 'Calculate 2+2';
-			const toolResults: ToolCallData[] = [
-				{
-					action: {
-						tool: 'calculator',
-						toolInput: { expression: '2+2' },
-						log: 'Using calculator',
-						toolCallId: 'call_123',
-						type: 'tool_call',
-					},
-					observation: '4',
-				},
-			];
+		it('should return empty string for empty steps array', () => {
+			const result = buildToolContext([]);
 
-			await saveToolResultsToMemory(input, toolResults, undefined);
-
-			expect(mockMemory.saveContext).not.toHaveBeenCalled();
+			expect(result).toBe('');
 		});
 
-		it('should not save when toolResults is empty', async () => {
-			const input = 'Calculate 2+2';
-			const toolResults: ToolCallData[] = [];
-
-			await saveToolResultsToMemory(input, toolResults, mockMemory);
-
-			expect(mockMemory.saveContext).not.toHaveBeenCalled();
-		});
-
-		it('should handle complex tool inputs', async () => {
-			const input = 'Search for information';
-			const toolResults: ToolCallData[] = [
+		it('should handle complex tool inputs', () => {
+			const steps: ToolCallData[] = [
 				{
 					action: {
 						tool: 'search',
@@ -252,14 +209,10 @@ describe('memoryManagement', () => {
 				},
 			];
 
-			await saveToolResultsToMemory(input, toolResults, mockMemory);
+			const result = buildToolContext(steps);
 
-			expect(mockMemory.saveContext).toHaveBeenCalledWith(
-				{ input },
-				{
-					output:
-						'Tool: search, Input: {"query":"typescript testing","filters":{"language":"en","date":"2024"},"limit":10}, Result: Found 10 results',
-				},
+			expect(result).toBe(
+				'Tool: search, Input: {"query":"typescript testing","filters":{"language":"en","date":"2024"},"limit":10}, Result: Found 10 results',
 			);
 		});
 	});


### PR DESCRIPTION
## Summary

Unifies memory management between streaming and non-streaming modes in the AI Agent node. Previously, memory was saved in multiple places, leading to and inconsistent behavior. This PR consolidates memory saving to a single location in runAgent.ts after agent completion.

  - Removed memory saving logic from processEventStream.ts (was being called during on_tool_end events AND at stream completion)
  - Added buildToolContext() helper function for consistent tool call formatting across both modes
  - Extended saveToMemory() to accept optional steps parameter for including tool context
  - Removed redundant saveToolResultsToMemory() function

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
