### PR TITLE
fix(core, editor): Support inclusive and exclusive destination node mode in the frontend and API

### DIFF
--- a/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
@@ -130,7 +130,7 @@ describe('WorkflowExecutionService', () => {
 				}),
 				agentRequest: undefined,
 				runData: { [webhookNode.name]: [toITaskData([{ data: { value: 1 } }])] },
-				destinationNode: hackerNewsNode.name,
+				destinationNode: { nodeName: hackerNewsNode.name, mode: 'inclusive' },
 				dirtyNodeNames: [],
 			};
 
@@ -143,10 +143,7 @@ describe('WorkflowExecutionService', () => {
 			const result = await workflowExecutionService.executeManually(runPayload, user);
 
 			expect(workflowRunner.run).toHaveBeenCalledWith({
-				destinationNode: {
-					nodeName: runPayload.destinationNode,
-					mode: 'inclusive',
-				},
+				destinationNode: runPayload.destinationNode,
 				executionMode: 'manual',
 				runData: runPayload.runData,
 				pinData: undefined,
@@ -165,7 +162,7 @@ describe('WorkflowExecutionService', () => {
 			const node = mock<INode>();
 			const runPayload: WorkflowRequest.PartialManualExecutionToDestinationPayload = {
 				workflowData: mock<IWorkflowBase>({ nodes: [node], connections: {} }),
-				destinationNode: node.name,
+				destinationNode: { nodeName: node.name, mode: 'inclusive' },
 				agentRequest: undefined,
 				runData: { [node.name]: [toITaskData([{ data: { value: 1 } }])] },
 				dirtyNodeNames: [],
@@ -181,7 +178,7 @@ describe('WorkflowExecutionService', () => {
 
 			expect(workflowRunner.run).toHaveBeenCalledWith({
 				runData: undefined,
-				destinationNode: { nodeName: runPayload.destinationNode, mode: 'inclusive' },
+				destinationNode: runPayload.destinationNode,
 				executionMode: 'manual',
 				pinData: runPayload.workflowData.pinData,
 				pushRef: undefined,
@@ -232,7 +229,7 @@ describe('WorkflowExecutionService', () => {
 					createdAt: new Date(),
 					updatedAt: new Date(),
 				},
-				destinationNode: hackerNewsNode.name,
+				destinationNode: { nodeName: hackerNewsNode.name, mode: 'inclusive' },
 			};
 
 			workflowRunner.run.mockResolvedValue(executionId);
@@ -240,10 +237,7 @@ describe('WorkflowExecutionService', () => {
 			const result = await workflowExecutionService.executeManually(runPayload, user);
 
 			expect(workflowRunner.run).toHaveBeenCalledWith({
-				destinationNode: {
-					nodeName: runPayload.destinationNode,
-					mode: 'inclusive',
-				},
+				destinationNode: runPayload.destinationNode,
 				executionMode: 'manual',
 				pinData: runPayload.workflowData.pinData,
 				pushRef: undefined,
@@ -327,7 +321,7 @@ describe('WorkflowExecutionService', () => {
 					createdAt: new Date(),
 					updatedAt: new Date(),
 				},
-				destinationNode: node.name,
+				destinationNode: { nodeName: node.name, mode: 'inclusive' },
 			};
 
 			workflowRunner.run.mockResolvedValue(executionId);

--- a/packages/cli/src/workflows/workflow.request.ts
+++ b/packages/cli/src/workflows/workflow.request.ts
@@ -7,6 +7,7 @@ import type {
 	ITaskData,
 	IWorkflowBase,
 	AiAgentRequest,
+	IDestinationNode,
 } from 'n8n-workflow';
 
 import type { ListQuery } from '@/requests';
@@ -35,7 +36,7 @@ export declare namespace WorkflowRequest {
 		workflowData: IWorkflowBase;
 		agentRequest?: AiAgentRequest;
 
-		destinationNode?: string;
+		destinationNode?: IDestinationNode;
 		triggerToStartFrom: { name: string; data?: ITaskData };
 	};
 	// 2. Full Manual Execution from Unknown Trigger
@@ -43,7 +44,7 @@ export declare namespace WorkflowRequest {
 		workflowData: IWorkflowBase;
 		agentRequest?: AiAgentRequest;
 
-		destinationNode: string;
+		destinationNode: IDestinationNode;
 	};
 
 	// 3. Partial Manual Execution to Destination
@@ -52,7 +53,7 @@ export declare namespace WorkflowRequest {
 		agentRequest?: AiAgentRequest;
 
 		runData: IRunData;
-		destinationNode: string;
+		destinationNode: IDestinationNode;
 		dirtyNodeNames: string[];
 	};
 

--- a/packages/frontend/editor-ui/src/Interface.ts
+++ b/packages/frontend/editor-ui/src/Interface.ts
@@ -32,6 +32,7 @@ import type {
 	ITaskData,
 	ISourceData,
 	PublicInstalledPackage,
+	IDestinationNode,
 } from 'n8n-workflow';
 import type { Version } from '@n8n/rest-api-client/api/versions';
 import type { Cloud, InstanceUsage } from '@n8n/rest-api-client/api/cloudPlans';
@@ -183,7 +184,7 @@ export interface IAiDataContent {
 export interface IStartRunData {
 	workflowData: WorkflowData;
 	startNodes?: StartNodeData[];
-	destinationNode?: string;
+	destinationNode?: IDestinationNode;
 	runData?: IRunData;
 	dirtyNodeNames?: string[];
 	triggerToStartFrom?: {

--- a/packages/frontend/editor-ui/src/app/components/FromAiParametersModal.vue
+++ b/packages/frontend/editor-ui/src/app/components/FromAiParametersModal.vue
@@ -265,7 +265,7 @@ const onExecute = async () => {
 	telemetry.track('User clicked execute node button in modal', telemetryPayload);
 
 	await runWorkflow({
-		destinationNode: node.value.name,
+		destinationNode: { nodeName: node.value.name, mode: 'inclusive' },
 	});
 
 	onClose();

--- a/packages/frontend/editor-ui/src/app/components/NodeExecuteButton.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/NodeExecuteButton.test.ts
@@ -318,7 +318,10 @@ describe('NodeExecuteButton', () => {
 
 		expect(externalHooks.run).toHaveBeenCalledWith('nodeExecuteButton.onClick', expect.any(Object));
 		expect(runWorkflow.runWorkflow).toHaveBeenCalledWith({
-			destinationNode: node.name,
+			destinationNode: {
+				nodeName: node.name,
+				mode: 'inclusive',
+			},
 			source: 'RunData.ExecuteNodeButton',
 		});
 		expect(emitted().execute).toBeTruthy();

--- a/packages/frontend/editor-ui/src/app/components/NodeExecuteButton.vue
+++ b/packages/frontend/editor-ui/src/app/components/NodeExecuteButton.vue
@@ -55,12 +55,14 @@ const props = withDefaults(
 		tooltip?: string;
 		tooltipPlacement?: 'top' | 'bottom' | 'left' | 'right';
 		showLoadingSpinner?: boolean;
+		executionMode?: 'inclusive' | 'exclusive';
 	}>(),
 	{
 		disabled: false,
 		transparent: false,
 		square: false,
 		showLoadingSpinner: true,
+		executionMode: 'inclusive',
 	},
 );
 
@@ -384,7 +386,7 @@ async function onClick() {
 				await externalHooks.run('nodeExecuteButton.onClick', telemetryPayload);
 
 				await runWorkflow({
-					destinationNode: props.nodeName,
+					destinationNode: { nodeName: props.nodeName, mode: props.executionMode },
 					source: 'RunData.ExecuteNodeButton',
 				});
 

--- a/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.test.ts
@@ -519,7 +519,7 @@ describe('useRunWorkflow({ router })', () => {
 			vi.mocked(workflowsStore).incomingConnectionsByNodeName.mockReturnValue({});
 
 			// ACT
-			await runWorkflow({ destinationNode: destinationNodeName });
+			await runWorkflow({ destinationNode: { nodeName: destinationNodeName, mode: 'inclusive' } });
 
 			// ASSERT
 			expect(workflowsStore.runWorkflow).toHaveBeenCalledTimes(1);
@@ -593,7 +593,10 @@ describe('useRunWorkflow({ router })', () => {
 
 			const { runWorkflow } = composable;
 
-			await runWorkflow({ destinationNode: 'Code 1', source: 'Node.executeNode' });
+			await runWorkflow({
+				destinationNode: { nodeName: 'Code 1', mode: 'inclusive' },
+				source: 'Node.executeNode',
+			});
 
 			expect(workflowsStore.runWorkflow).toHaveBeenCalledWith(
 				expect.objectContaining({ dirtyNodeNames: [executeName] }),
@@ -774,7 +777,9 @@ describe('useRunWorkflow({ router })', () => {
 			const setWorkflowExecutionData = vi.spyOn(workflowState, 'setWorkflowExecutionData');
 
 			// ACT
-			const result = await runWorkflow({ destinationNode: 'Test node' });
+			const result = await runWorkflow({
+				destinationNode: { nodeName: 'Test node', mode: 'inclusive' },
+			});
 
 			// ASSERT
 			expect(agentRequestStore.getAgentRequest).toHaveBeenCalledWith('WorkflowId', 'Test id');
@@ -785,7 +790,7 @@ describe('useRunWorkflow({ router })', () => {
 						name: 'tool',
 					},
 				},
-				destinationNode: 'Test node',
+				destinationNode: { nodeName: 'Test node', mode: 'inclusive' },
 				dirtyNodeNames: undefined,
 				runData: mockRunData,
 				startNodes: [
@@ -824,7 +829,9 @@ describe('useRunWorkflow({ router })', () => {
 			const setWorkflowExecutionData = vi.spyOn(workflowState, 'setWorkflowExecutionData');
 
 			// ACT
-			const result = await runWorkflow({ destinationNode: 'some node name' });
+			const result = await runWorkflow({
+				destinationNode: { nodeName: 'some node name', mode: 'inclusive' },
+			});
 
 			// ASSERT
 			expect(result).toEqual(mockExecutionResponse);

--- a/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.ts
@@ -14,6 +14,7 @@ import type {
 	INode,
 	IDataObject,
 	IWorkflowBase,
+	IDestinationNode,
 } from 'n8n-workflow';
 import { createRunExecutionData, NodeConnectionTypes, TelemetryHelpers } from 'n8n-workflow';
 import { retry } from '@n8n/utils/retry';
@@ -129,7 +130,7 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 	}
 
 	async function runWorkflow(options: {
-		destinationNode?: string;
+		destinationNode?: IDestinationNode;
 		triggerNode?: string;
 		rerunTriggerNode?: boolean;
 		nodeData?: ITaskData;
@@ -146,7 +147,7 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 			let directParentNodes: string[] = [];
 			if (options.destinationNode !== undefined) {
 				directParentNodes = workflowObject.value.getParentNodes(
-					options.destinationNode,
+					options.destinationNode.nodeName,
 					NodeConnectionTypes.Main,
 					-1,
 				);
@@ -169,7 +170,7 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 
 			const { startNodeNames } = consolidatedData;
 			const destinationNodeType = options.destinationNode
-				? workflowsStore.getNodeByName(options.destinationNode)?.type
+				? workflowsStore.getNodeByName(options.destinationNode.nodeName)?.type
 				: '';
 
 			let executedNode: string | undefined;
@@ -180,15 +181,15 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 				'destinationNode' in options &&
 				options.destinationNode !== undefined
 			) {
-				executedNode = options.destinationNode;
-				startNodeNames.push(options.destinationNode);
+				executedNode = options.destinationNode.nodeName;
+				startNodeNames.push(options.destinationNode.nodeName);
 			} else if (options.triggerNode && options.nodeData && !options.rerunTriggerNode) {
 				// starts execution from downstream nodes of trigger node
 				startNodeNames.push(
 					...workflowObject.value.getChildNodes(options.triggerNode, NodeConnectionTypes.Main, 1),
 				);
 			} else if (options.destinationNode) {
-				executedNode = options.destinationNode;
+				executedNode = options.destinationNode.nodeName;
 			}
 
 			if (options.triggerNode) {
@@ -201,11 +202,11 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 			// If the destination node is specified, check if it is a chat node or has a chat parent
 			if (
 				options.destinationNode &&
-				(workflowsStore.checkIfNodeHasChatParent(options.destinationNode) ||
+				(workflowsStore.checkIfNodeHasChatParent(options.destinationNode.nodeName) ||
 					destinationNodeType === CHAT_TRIGGER_NODE_TYPE) &&
 				options.source !== 'RunData.ManualChatMessage'
 			) {
-				const startNode = workflowObject.value.getStartNode(options.destinationNode);
+				const startNode = workflowObject.value.getStartNode(options.destinationNode.nodeName);
 				if (startNode && startNode.type === CHAT_TRIGGER_NODE_TYPE) {
 					// Check if the chat node has input data or pin data
 					const chatHasInputData =
@@ -215,7 +216,7 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 					// If the chat node has no input data or pin data, open the chat modal
 					// and halt the execution
 					if (!chatHasInputData && !chatHasPinData) {
-						workflowsStore.chatPartialExecutionDestinationNode = options.destinationNode;
+						workflowsStore.chatPartialExecutionDestinationNode = options.destinationNode.nodeName;
 						startChat();
 						return;
 					}
@@ -279,9 +280,9 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 				.filter((node) => {
 					if (
 						options.destinationNode &&
-						workflowsStore.checkIfNodeHasChatParent(options.destinationNode)
+						workflowsStore.checkIfNodeHasChatParent(options.destinationNode.nodeName)
 					) {
-						return node.name !== options.destinationNode;
+						return node.name !== options.destinationNode.nodeName;
 					}
 					return true;
 				});
@@ -322,7 +323,7 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 
 			if ('destinationNode' in options) {
 				startRunData.destinationNode = options.destinationNode;
-				const nodeId = workflowsStore.getNodeByName(options.destinationNode as string)?.id;
+				const nodeId = workflowsStore.getNodeByName(options.destinationNode?.nodeName ?? '')?.id;
 				if (workflowObject.value.id && nodeId) {
 					const agentRequest = agentRequestStore.getAgentRequest(workflowObject.value.id, nodeId);
 
@@ -395,7 +396,7 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 				await displayForm({
 					nodes: workflowData.nodes,
 					runData: workflowsStore.getWorkflowExecution?.data?.resultData?.runData,
-					destinationNode: options.destinationNode,
+					destinationNode: options.destinationNode?.nodeName,
 					triggerNode: options.triggerNode,
 					pinData,
 					directParentNodes,
@@ -405,7 +406,7 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 			} catch (error) {}
 
 			await externalHooks.run('workflowRun.runWorkflow', {
-				nodeName: options.destinationNode,
+				nodeName: options.destinationNode?.nodeName,
 				source: options.source,
 			});
 

--- a/packages/frontend/editor-ui/src/app/types/externalHooks.ts
+++ b/packages/frontend/editor-ui/src/app/types/externalHooks.ts
@@ -3,13 +3,14 @@ import type {
 	ExecutionError,
 	GenericValue,
 	IConnections,
-	IDestinationNode,
 	INodeProperties,
 	INodeTypeDescription,
 	ITelemetryTrackProperties,
 	NodeConnectionType,
 	NodeParameterValue,
 	NodeParameterValueType,
+	IDestinationNode,
+	StartNodeData,
 } from 'n8n-workflow';
 import type { RouteLocation } from 'vue-router';
 import type {
@@ -65,7 +66,12 @@ interface OutputModeChangedEventData {
 }
 interface ExecutionFinishedEventData {
 	runDataExecutedStartData:
-		| { destinationNode?: IDestinationNode; runNodeFilter?: string[] | undefined }
+		| {
+				startNodes?: StartNodeData[];
+				destinationNode?: IDestinationNode | undefined;
+				originalDestinationNode?: IDestinationNode | undefined;
+				runNodeFilter?: string[] | undefined;
+		  }
 		| undefined;
 	nodeName?: string;
 	errorMessage: string;

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -1258,7 +1258,10 @@ async function onRunWorkflowToNode(id: string) {
 		trackRunWorkflowToNode(node);
 		agentRequestStore.clearAgentRequests(workflowsStore.workflowId, node.id);
 
-		void runWorkflow({ destinationNode: node.name, source: 'Node.executeNode' });
+		void runWorkflow({
+			destinationNode: { nodeName: node.name, mode: 'inclusive' },
+			source: 'Node.executeNode',
+		});
 	}
 }
 

--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogsOverviewPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogsOverviewPanel.test.ts
@@ -124,7 +124,9 @@ describe('LogsOverviewPanel', () => {
 
 		await fireEvent.click(within(aiAgentRow).getAllByLabelText('Execute step')[0]);
 		await waitFor(() =>
-			expect(spyRun).toHaveBeenCalledWith(expect.objectContaining({ destinationNode: 'AI Agent' })),
+			expect(spyRun).toHaveBeenCalledWith(
+				expect.objectContaining({ destinationNode: { nodeName: 'AI Agent', mode: 'inclusive' } }),
+			),
 		);
 	});
 });

--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogsOverviewRows.vue
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogsOverviewRows.vue
@@ -52,7 +52,13 @@ async function handleTriggerPartialExecution(treeNode: LogEntry) {
 	const latestName = latestNodeInfo[treeNode.node.id]?.name ?? treeNode.node.name;
 
 	if (latestName) {
-		await runWorkflow.runWorkflow({ destinationNode: latestName });
+		await runWorkflow.runWorkflow({
+			destinationNode: {
+				nodeName: latestName,
+				// TODO(CAT-1265): check that this is the right mode.
+				mode: 'inclusive',
+			},
+		});
 	}
 }
 

--- a/packages/frontend/editor-ui/src/features/execution/logs/composables/useChatState.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/composables/useChatState.ts
@@ -164,7 +164,10 @@ export function useChatState(isReadOnly: boolean): ChatState {
 		};
 
 		if (workflowsStore.chatPartialExecutionDestinationNode) {
-			runWorkflowOptions.destinationNode = workflowsStore.chatPartialExecutionDestinationNode;
+			runWorkflowOptions.destinationNode = {
+				nodeName: workflowsStore.chatPartialExecutionDestinationNode,
+				mode: 'inclusive',
+			};
 			workflowsStore.chatPartialExecutionDestinationNode = null;
 		}
 

--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/InputPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/InputPanel.vue
@@ -477,7 +477,17 @@ function handleChangeCollapsingColumn(columnName: string | null) {
 				<NDVEmptyState v-if="nodeNotRunMessageVariant === 'simple'">
 					<I18nT scope="global" keypath="ndv.input.noOutputData.embeddedNdv.description">
 						<template #link>
-							<a href="#" @click.prevent="runWorkflow({ destinationNode: activeNodeName })">
+							<a
+								href="#"
+								@click.prevent="
+									runWorkflow({
+										destinationNode: {
+											nodeName: activeNodeName,
+											mode: 'exclusive',
+										},
+									})
+								"
+							>
 								{{ i18n.baseText('ndv.input.noOutputData.embeddedNdv.link') }}
 							</a>
 						</template>
@@ -506,6 +516,7 @@ function handleChangeCollapsingColumn(columnName: string | null) {
 									tooltip-placement="bottom"
 									telemetry-source="inputs"
 									data-test-id="execute-previous-node"
+									execution-mode="exclusive"
 									@execute="onNodeExecute"
 								/>
 								<br />
@@ -566,6 +577,7 @@ function handleChangeCollapsingColumn(columnName: string | null) {
 						class="mt-m"
 						telemetry-source="inputs"
 						data-test-id="execute-previous-node"
+						execution-mode="exclusive"
 						tooltip-placement="bottom"
 						:show-loading-spinner="false"
 						@execute="onNodeExecute"

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
@@ -1419,7 +1419,7 @@ function onSearchClear() {
 
 function executeNode(nodeName: string) {
 	void runWorkflow({
-		destinationNode: nodeName,
+		destinationNode: { nodeName, mode: 'inclusive' },
 		source: 'schema-preview',
 	});
 }

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchema.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchema.vue
@@ -259,8 +259,7 @@ const contextItems = computed(() => {
 				const variablesEmptyNotice: RenderNotice = {
 					type: 'notice',
 					id: 'notice-variablesEmpty',
-					// Increase level to indent under $vars
-					level: (renderItem.level ?? 0) + 1,
+					level: renderItem.level ?? 0,
 					message: i18n.baseText('dataMapping.schemaView.variablesEmpty'),
 				};
 				return [renderItem, variablesEmptyNotice];
@@ -558,6 +557,7 @@ const onDragEnd = (el: HTMLElement) => {
 											size="small"
 											type="secondary"
 											hide-icon
+											execution-mode="exclusive"
 										/>
 									</template>
 								</I18nT>

--- a/packages/testing/playwright/tests/ui/execute-previous-nodes.spec.ts
+++ b/packages/testing/playwright/tests/ui/execute-previous-nodes.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '../../fixtures/base';
+
+test.describe('Execute previous nodes', () => {
+	test('should execute only previous nodes and not the current node', async ({ n8n }) => {
+		// Import workflow with Manual Trigger -> Code1 -> Code2
+		await n8n.start.fromImportedWorkflow('execute-previous-nodes.json');
+
+		// Open the second Code node (Code2)
+		await n8n.canvas.openNode('Code2');
+
+		// Click "Execute previous nodes" - this should execute Manual Trigger and Code1, but NOT Code2
+		await n8n.ndv.executePrevious();
+
+		// Wait for execution to complete by checking that input panel has data
+		await expect(n8n.ndv.inputPanel.getDataContainer()).toBeVisible({ timeout: 15000 });
+
+		// Verify that the input panel has data from Code1 (which was executed)
+		await expect(n8n.ndv.inputPanel.get()).toContainText('myNewField');
+
+		// Verify Code2 (current node) was NOT executed.
+		// The output panel should show the placeholder text, not execution results
+		await expect(n8n.ndv.outputPanel.get()).toContainText('Execute this node to view data');
+
+		// Close the NDV
+		await n8n.ndv.close();
+
+		// Open Code1 to verify it WAS executed
+		await n8n.canvas.openNode('Code1');
+
+		// Verify Code1 has execution success indicator and output data
+		await expect(n8n.ndv.getNodeRunSuccessIndicator()).toBeVisible();
+		await expect(n8n.ndv.outputPanel.getItemsCount()).toBeVisible();
+
+		// Close and verify Manual Trigger was also executed
+		await n8n.ndv.close();
+		await n8n.canvas.openNode('Manual Trigger');
+		await expect(n8n.ndv.getNodeRunSuccessIndicator()).toBeVisible();
+	});
+});

--- a/packages/testing/playwright/workflows/execute-previous-nodes.json
+++ b/packages/testing/playwright/workflows/execute-previous-nodes.json
@@ -1,0 +1,58 @@
+{
+	"name": "Execute Previous Nodes Test",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "manual-trigger-node",
+			"name": "Manual Trigger",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [250, 300]
+		},
+		{
+			"parameters": {
+				"jsCode": "for (const item of $input.all()) {\n  item.json.myNewField = 1;\n}\n\nreturn $input.all();"
+			},
+			"id": "code-node-1",
+			"name": "Code1",
+			"type": "n8n-nodes-base.code",
+			"typeVersion": 2,
+			"position": [470, 300]
+		},
+		{
+			"parameters": {
+				"jsCode": "for (const item of $input.all()) {\n  item.json.myNewField = 1;\n}\n\nreturn $input.all();"
+			},
+			"id": "code-node-2",
+			"name": "Code2",
+			"type": "n8n-nodes-base.code",
+			"typeVersion": 2,
+			"position": [690, 300]
+		}
+	],
+	"connections": {
+		"Manual Trigger": {
+			"main": [
+				[
+					{
+						"node": "Code1",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Code1": {
+			"main": [
+				[
+					{
+						"node": "Code2",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"pinData": {}
+}


### PR DESCRIPTION
## Summary
Adds the structured destination node to the API, and passes it where appropriate from the frontend.

New behaviour looks like this: https://www.loom.com/share/f8c41b7275074f15987bafffb1f912f7.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1265

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
