### PR TITLE
fix: Renovate will now bump versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -57,12 +57,7 @@
 		},
 		{
 			"description": "Group testing packages",
-			"matchPackageNames": [
-				"*vitest*",
-				"*playwright*",
-				"@testing-library/**",
-				"*jest*"
-			],
+			"matchPackageNames": ["*vitest*", "*playwright*", "@testing-library/**", "*jest*"],
 			"groupName": "testing packages"
 		},
 		{
@@ -72,8 +67,7 @@
 		}
 	],
 	"lockFileMaintenance": {
-		"enabled": true,
-		"schedule": ["before 6am on monday"]
+		"enabled": false
 	},
 	"vulnerabilityAlerts": {
 		"enabled": true,
@@ -90,5 +84,6 @@
 	"ignorePaths": ["**/node_modules/**", "**/dist/**", "**/build/**"],
 	"enabledManagers": ["npm", "dockerfile", "github-actions"],
 	"npmrc": "auto-detect",
-	"updateNotScheduled": false
+	"updateNotScheduled": false,
+	"rangeStrategy": "bump"
 }


### PR DESCRIPTION
## Summary

It will no longer do lockfile maintainence

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
