### PR TITLE
feat(core): Draft/Publish workflow endpoints follow up (no-changelog)

### DIFF
--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -6,6 +6,7 @@ import type {
 	ListQueryDb,
 	WorkflowFolderUnionFull,
 	WorkflowHistoryUpdate,
+	WorkflowHistory,
 } from '@n8n/db';
 import {
 	SharedWorkflow,
@@ -47,6 +48,12 @@ import * as WorkflowHelpers from '@/workflow-helpers';
 import { WorkflowFinderService } from './workflow-finder.service';
 import { WorkflowHistoryService } from './workflow-history/workflow-history.service';
 import { WorkflowSharingService } from './workflow-sharing.service';
+
+type RollbackPayload = {
+	active: boolean;
+	activeVersionId: string | null;
+	activeVersion: WorkflowHistory | null;
+} & Partial<Omit<WorkflowEntity, 'active' | 'activeVersionId' | 'activeVersion'>>;
 
 @Service()
 export class WorkflowService {
@@ -447,7 +454,14 @@ export class WorkflowService {
 					workflowId,
 					updatedWorkflow,
 					wasActive ? 'update' : 'activate',
-					workflow.versionId,
+					// If workflow could not be activated, set it again to inactive
+					// and revert the versionId and activeVersionId change so UI remains consistent
+					{
+						versionId: workflow.versionId,
+						active: false,
+						activeVersionId: null,
+						activeVersion: null,
+					},
 				);
 			}
 		}
@@ -457,37 +471,25 @@ export class WorkflowService {
 
 	/**
 	 * Private helper to add a workflow to the active workflow manager
-	 * @param originalVersionId - Optional versionId to roll back to if activation fails
+	 * @param rollBackOptions - Optional rollback options
 	 */
 	private async _addToActiveWorkflowManager(
 		user: User,
 		workflowId: string,
 		workflow: WorkflowEntity,
 		mode: 'activate' | 'update',
-		originalVersionId?: string,
+		rollbackPayload: RollbackPayload,
 	): Promise<void> {
 		try {
 			await this.externalHooks.run('workflow.activate', [workflow]);
 			await this.activeWorkflowManager.add(workflowId, mode);
 		} catch (error) {
-			// If workflow could not be activated, set it again to inactive
-			// and revert the versionId and activeVersionId change so UI remains consistent
-			const rollbackPayload: QueryDeepPartialEntity<WorkflowEntity> = {
-				active: false,
-				activeVersion: null,
-			};
-
-			// Roll back versionId if provided (used in update flow)
-			if (originalVersionId !== undefined) {
-				rollbackPayload.versionId = originalVersionId;
-			}
-
 			await this.workflowRepository.update(workflowId, rollbackPayload);
 
 			// Also set it in the returned data
-			workflow.active = false;
-			workflow.activeVersionId = null;
-			workflow.activeVersion = null;
+			workflow.active = rollbackPayload.active;
+			workflow.activeVersionId = rollbackPayload.activeVersionId;
+			workflow.activeVersion = rollbackPayload.activeVersion;
 
 			// Emit deactivation event since activation failed
 			this.eventService.emit('workflow-deactivated', {
@@ -567,7 +569,11 @@ export class WorkflowService {
 			publicApi: false,
 		});
 
-		await this._addToActiveWorkflowManager(user, workflowId, updatedWorkflow, 'activate');
+		await this._addToActiveWorkflowManager(user, workflowId, updatedWorkflow, 'activate', {
+			active: workflow.active,
+			activeVersionId: workflow.activeVersionId,
+			activeVersion: workflow.activeVersion,
+		});
 
 		return updatedWorkflow;
 	}

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -491,13 +491,15 @@ export class WorkflowService {
 			workflow.activeVersionId = rollbackPayload.activeVersionId;
 			workflow.activeVersion = rollbackPayload.activeVersion;
 
-			// Emit deactivation event since activation failed
-			this.eventService.emit('workflow-deactivated', {
-				user,
-				workflowId,
-				workflow,
-				publicApi: false,
-			});
+			if (!workflow.activeVersionId) {
+				// Emit deactivation event since activation failed
+				this.eventService.emit('workflow-deactivated', {
+					user,
+					workflowId,
+					workflow,
+					publicApi: false,
+				});
+			}
 
 			let message;
 			if (error instanceof NodeApiError) message = error.description;

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -556,6 +556,7 @@ export class WorkflowService {
 
 		const updatedWorkflow = await this.workflowRepository.findOne({
 			where: { id: workflowId },
+			relations: ['activeVersion'],
 		});
 
 		if (!updatedWorkflow) {

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -343,7 +343,11 @@ export class WorkflowsController {
 				workflowId,
 				req.user,
 				['workflow:read'],
-				{ includeTags: !this.globalConfig.tags.disabled, includeParentFolder: true },
+				{
+					includeTags: !this.globalConfig.tags.disabled,
+					includeParentFolder: true,
+					includeActiveVersion: true,
+				},
 			);
 
 			if (!workflow) {
@@ -371,7 +375,11 @@ export class WorkflowsController {
 			workflowId,
 			req.user,
 			['workflow:read'],
-			{ includeTags: !this.globalConfig.tags.disabled, includeParentFolder: true },
+			{
+				includeTags: !this.globalConfig.tags.disabled,
+				includeParentFolder: true,
+				includeActiveVersion: true,
+			},
 		);
 
 		if (!workflow) {

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -14,7 +14,7 @@ import {
 	mockInstance,
 } from '@n8n/backend-test-utils';
 import { GlobalConfig } from '@n8n/config';
-import type { User, ListQueryDb, WorkflowFolderUnionFull, Role } from '@n8n/db';
+import type { User, ListQueryDb, WorkflowFolderUnionFull, Role, WorkflowHistory } from '@n8n/db';
 import {
 	ProjectRepository,
 	WorkflowHistoryRepository,
@@ -584,6 +584,20 @@ describe('GET /workflows/:workflowId', () => {
 
 		expect(response.body.data).toMatchObject({
 			tags: [expect.objectContaining({ id: tag.id, name: tag.name })],
+		});
+	});
+
+	test('should return active version', async () => {
+		const workflow = await createActiveWorkflow({}, owner);
+
+		const response = await authOwnerAgent.get(`/workflows/${workflow.id}`).expect(200);
+
+		const { data: responseData } = response.body as { data: { activeVersion: WorkflowHistory } };
+		const { activeVersion } = responseData;
+
+		expect(activeVersion).toMatchObject({
+			versionId: workflow.activeVersionId,
+			workflowId: workflow.id,
 		});
 	});
 

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -2860,6 +2860,7 @@ describe('POST /workflows/:workflowId/activate', () => {
 		const { data } = response.body;
 		expect(data.id).toBe(workflow.id);
 		expect(data.activeVersionId).toBe(workflow.versionId);
+		expect(data.activeVersion.versionId).toBe(workflow.versionId);
 	});
 
 	test('should return 400 when versionId is missing', async () => {


### PR DESCRIPTION
## Summary

- activate workflow now sets active version id to the current active version in case of errors during activation and populates the active version for return data
- get workflow endpoint now populates active version for return data

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4459/feature-be-workflow-endpoints-follow-up

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
