### PR TITLE
ci: Don't fail patch release if no changelog could be generated

### DIFF
--- a/.github/workflows/release-create-pr.yml
+++ b/.github/workflows/release-create-pr.yml
@@ -62,6 +62,23 @@ jobs:
         run: |
           git push -f origin "refs/remotes/origin/${{ env.BASE_BRANCH }}:refs/heads/release/${{ env.NEXT_RELEASE }}"
 
+      - name: Generate PR body
+        id: generate-body
+        run: |
+          set -e
+          CHANGELOG_FILE="CHANGELOG-${{ env.NEXT_RELEASE }}.md"
+          DELIMITER="EOF_$(uuidgen)"
+
+          if [ -f "${CHANGELOG_FILE}" ]; then
+            {
+              echo "content<<${DELIMITER}"
+              cat "${CHANGELOG_FILE}"
+              echo "${DELIMITER}"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "content=No changelog generated. Likely points to fixes in our CI." >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Push the release branch, and Create the PR
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
@@ -71,4 +88,4 @@ jobs:
           delete-branch: true
           labels: release,release:${{ github.event.inputs.release-type }}
           title: ':rocket: Release ${{ env.NEXT_RELEASE }}'
-          body-path: 'CHANGELOG-${{ env.NEXT_RELEASE }}.md'
+          body: ${{ steps.generate-body.outputs.content }}


### PR DESCRIPTION
## Summary

Fixes these failures:
- https://github.com/n8n-io/n8n/actions/runs/19641606528
- https://github.com/n8n-io/n8n/actions/runs/19641024527
- https://github.com/n8n-io/n8n/actions/runs/19640737301

## Related Linear tickets, Github issues, and Community forum posts

PAY-4169

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
