### PR TITLE
fix(Git Node): Throw an error if the repository path is blocked

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
@@ -99,6 +99,8 @@ export const getFileSystemHelperFunctions = (node: INode): FileSystemHelperFunct
 		}
 		return await fsWriteFile(filePath, content, { encoding: 'binary', flag });
 	},
+
+	isFilePathBlocked,
 });
 
 /**

--- a/packages/nodes-base/nodes/Git/Git.node.ts
+++ b/packages/nodes-base/nodes/Git/Git.node.ts
@@ -5,7 +5,12 @@ import type {
 	INodeType,
 	INodeTypeDescription,
 } from 'n8n-workflow';
-import { NodeConnectionTypes, assertParamIsBoolean, assertParamIsString } from 'n8n-workflow';
+import {
+	NodeConnectionTypes,
+	NodeOperationError,
+	assertParamIsBoolean,
+	assertParamIsString,
+} from 'n8n-workflow';
 import type { LogOptions, SimpleGit, SimpleGitOptions } from 'simple-git';
 import simpleGit from 'simple-git';
 import { URL } from 'url';
@@ -282,6 +287,14 @@ export class Git implements INodeType {
 		for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
 			try {
 				const repositoryPath = this.getNodeParameter('repositoryPath', itemIndex, '') as string;
+				const isFilePathBlocked = await this.helpers.isFilePathBlocked(repositoryPath);
+				if (isFilePathBlocked) {
+					throw new NodeOperationError(
+						this.getNode(),
+						'Access to the repository path is not allowed',
+					);
+				}
+
 				const options = this.getNodeParameter('options', itemIndex, {});
 
 				if (operation === 'clone') {

--- a/packages/nodes-base/nodes/Git/__test__/Git.node.test.ts
+++ b/packages/nodes-base/nodes/Git/__test__/Git.node.test.ts
@@ -39,6 +39,7 @@ describe('Git Node', () => {
 			getInputData: jest.fn().mockReturnValue([{ json: {} }]),
 			getNodeParameter: jest.fn(),
 			helpers: {
+				isFilePathBlocked: jest.fn(),
 				returnJsonArray: jest
 					.fn()
 					.mockImplementation((data: unknown[]) => data.map((item: unknown) => ({ json: item }))),
@@ -138,6 +139,16 @@ describe('Git Node', () => {
 				expect.objectContaining({
 					config: [],
 				}),
+			);
+		});
+	});
+
+	describe('Restricted file paths', () => {
+		it('should throw an error if the repository path is blocked', async () => {
+			(executeFunctions.helpers.isFilePathBlocked as jest.Mock).mockResolvedValue(true);
+
+			await expect(gitNode.execute.call(executeFunctions)).rejects.toThrow(
+				'Access to the repository path is not allowed',
 			);
 		});
 	});

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -695,6 +695,7 @@ export interface BaseHelperFunctions {
 }
 
 export interface FileSystemHelperFunctions {
+	isFilePathBlocked(filePath: string): Promise<boolean>;
 	createReadStream(path: PathLike): Promise<Readable>;
 	getStoragePath(): string;
 	writeContentToFile(


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Check if the repository path is blocked before executing any commands. Default blocked paths include the `.n8n` folder, folders for custom nodes, config files, binary data storage path. This implementation uses existing `isFilePathBlocked` function that is used in other places, like Read/Write Files node. This way, the behavior is consisted

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-3993/rce-via-arbitrary-file-write

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
