### PR TITLE
feat(editor): Add medium font weight variable to CLAUDE.md (no-changelog)

### DIFF
--- a/packages/frontend/CLAUDE.md
+++ b/packages/frontend/CLAUDE.md
@@ -99,6 +99,7 @@ application. These variables cover colors, spacing, typography, and borders.
 --line-height--xl: 1.5
 
 --font-weight--regular: 400
+--font-weight--medium: 500;
 --font-weight--bold: 600
 --font-family: InterVariable, sans-serif
 ```


### PR DESCRIPTION
## Summary

The new font weight variables have recently been added but CLAUDE.md hasn't been updated

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
