### PR TITLE
chore: Readd `minimumReleaseAge`

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -79,3 +79,11 @@ catalogs:
     vue-markdown-render: ^2.2.1
     vue-router: ^4.5.0
     vue-tsc: ^2.2.8
+
+minimumReleaseAge: 4320
+
+minimumReleaseAgeExclude:
+  - '@n8n/*'
+  - '@n8n_io/*'
+  - 'tsdown@0.16.5'
+  - eslint-plugin-storybook


### PR DESCRIPTION
## Summary

The setting seems to have been mistakenly removed in #21979, when it was supposed to be removed only for that specific release branch.


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
