### PR TITLE
feat(core): Create chat workflows in archived state (no-changelog)

### DIFF
--- a/packages/cli/src/modules/chat-hub/chat-hub-workflow.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-workflow.service.ts
@@ -413,7 +413,7 @@ export class ChatHubWorkflowService {
 			parameters: {},
 			type: CHAT_TRIGGER_NODE_TYPE,
 			typeVersion: 1.4,
-			position: [0, 0],
+			position: [-448, -112],
 			id: uuidv4(),
 			name: NODE_NAMES.CHAT_TRIGGER,
 			webhookId: uuidv4(),
@@ -436,7 +436,7 @@ export class ChatHubWorkflowService {
 			},
 			type: AGENT_LANGCHAIN_NODE_TYPE,
 			typeVersion: 3,
-			position: [600, 0],
+			position: [608, 0],
 			id: uuidv4(),
 			name: NODE_NAMES.REPLY_AGENT,
 		};
@@ -452,7 +452,7 @@ export class ChatHubWorkflowService {
 
 		const { provider, model } = conversationModel;
 		const common = {
-			position: [600, 300] satisfies [number, number],
+			position: [608, 304] satisfies [number, number],
 			id: uuidv4(),
 			name: NODE_NAMES.CHAT_MODEL,
 			credentials,
@@ -594,7 +594,7 @@ export class ChatHubWorkflowService {
 			},
 			type: MEMORY_BUFFER_WINDOW_NODE_TYPE,
 			typeVersion: 1.3,
-			position: [480, 208],
+			position: [224, 304],
 			id: uuidv4(),
 			name: NODE_NAMES.MEMORY,
 		};
@@ -627,7 +627,7 @@ export class ChatHubWorkflowService {
 			},
 			type: MEMORY_MANAGER_NODE_TYPE,
 			typeVersion: 1.1,
-			position: [224, 0],
+			position: [-192, 48],
 			id: uuidv4(),
 			name: NODE_NAMES.RESTORE_CHAT_MEMORY,
 		};
@@ -657,7 +657,7 @@ export class ChatHubWorkflowService {
 			},
 			type: MERGE_NODE_TYPE,
 			typeVersion: 3.2,
-			position: [224, -100],
+			position: [224, -96],
 			id: uuidv4(),
 			name: NODE_NAMES.MERGE,
 		};

--- a/packages/cli/src/modules/chat-hub/chat-hub-workflow.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-workflow.service.ts
@@ -77,6 +77,10 @@ export class ChatHubWorkflowService {
 
 			const newWorkflow = new WorkflowEntity();
 
+			// Chat workflows are created as archived to hide them
+			// from the user by default while they are being run.
+			newWorkflow.isArchived = true;
+
 			newWorkflow.versionId = uuidv4();
 			newWorkflow.name = `Chat ${sessionId}`;
 			newWorkflow.active = false;


### PR DESCRIPTION
## Summary

Create chat hub workflows in `isArchived = true` state to keep them hidden from users while they're running. They can still be briefly seen if user adjusts their workflow filters, but this way they don't show up unnecessarily. 

Also positioned the nodes on the WFs in a neat way as that was bothering me.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-65

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
