### PR TITLE
feat: Add the time saved node

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nIcon/icons.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nIcon/icons.ts
@@ -198,6 +198,7 @@ import IconLucideTags from '~icons/lucide/tags';
 import IconLucideTerminal from '~icons/lucide/terminal';
 import IconLucideThumbsDown from '~icons/lucide/thumbs-down';
 import IconLucideThumbsUp from '~icons/lucide/thumbs-up';
+import IconLucideTimer from '~icons/lucide/timer';
 import IconLucideToggleRight from '~icons/lucide/toggle-right';
 import IconLucideTrash2 from '~icons/lucide/trash-2';
 import IconLucideTreePine from '~icons/lucide/tree-pine';
@@ -409,6 +410,7 @@ export const deprecatedIconSet = {
 	tasks: IconLucideListChecks,
 	terminal: IconLucideTerminal,
 	'th-large': IconLucideGrid2x2,
+	timer: IconLucideTimer,
 	thumbtack: IconLucidePin,
 	'thumbs-down': IconLucideThumbsDown,
 	'thumbs-up': IconLucideThumbsUp,

--- a/packages/nodes-base/nodes/TimeSaved/TimeSaved.node.json
+++ b/packages/nodes-base/nodes/TimeSaved/TimeSaved.node.json
@@ -1,0 +1,19 @@
+{
+	"node": "n8n-nodes-base.timeSaved",
+	"nodeVersion": "1.0",
+	"codexVersion": "1.0",
+	"details": "Track Saved Time",
+
+	"categories": ["Core Nodes", "Development"],
+	"resources": {
+		"primaryDocumentation": [
+			{
+				"url": "https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.savedTime/"
+			}
+		]
+	},
+	"alias": ["time", "track", "saved"],
+	"subcategories": {
+		"Core Nodes": ["Helpers"]
+	}
+}

--- a/packages/nodes-base/nodes/TimeSaved/TimeSaved.node.ts
+++ b/packages/nodes-base/nodes/TimeSaved/TimeSaved.node.ts
@@ -1,0 +1,111 @@
+import type {
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeType,
+	INodeTypeDescription,
+} from 'n8n-workflow';
+import { assertParamIsNumber, NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
+
+export class TimeSaved implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Track Time Saved',
+		name: 'timeSaved',
+		icon: 'fa:timer',
+		group: ['organization'],
+		version: 1,
+		description: 'Track dynamic time savings for this workflow execution',
+		defaults: {
+			name: 'Time Saved',
+			color: '#1E90FF',
+		},
+		inputs: [NodeConnectionTypes.Main],
+		outputs: [NodeConnectionTypes.Main],
+		properties: [
+			{
+				displayName:
+					'Calculate time saved dynamically based on execution data. This allows you to track variable time savings (e.g., 5 minutes per item processed) instead of using a fixed value in workflow settings.',
+				name: 'notice',
+				type: 'notice',
+				default: '',
+			},
+			{
+				displayName: 'Calculation Mode',
+				name: 'mode',
+				type: 'options',
+				default: 'once',
+				noDataExpression: true,
+				options: [
+					{
+						name: 'Once For All Items',
+						value: 'once',
+						description: 'Counts minutes saved once for all input items',
+					},
+					{
+						name: 'Per Item',
+						value: 'perItem',
+						description: 'Multiply minutes saved by the number of input items',
+					},
+				],
+			},
+			{
+				displayName: 'Minutes Saved',
+				name: 'minutesSaved',
+				type: 'number',
+				default: 0,
+				typeOptions: {
+					minValue: 0,
+				},
+				description: 'Number of minutes saved by this workflow execution',
+			},
+		],
+		hints: [
+			{
+				type: 'info',
+				message:
+					'Multiple Saved Time nodes in the same workflow will have their values summed together.',
+				displayCondition: '=true',
+				whenToDisplay: 'beforeExecution',
+				location: 'outputPane',
+			},
+		],
+		// TODO: see if we can use posthog here
+		hidden: true,
+	};
+
+	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+		const items = this.getInputData();
+		const mode = this.getNodeParameter('mode', 0) as 'fixed' | 'perItem' | 'expression';
+
+		let timeSavedMinutes = this.getNodeParameter('minutesSaved', 0);
+		assertParamIsNumber('minutesSaved', timeSavedMinutes, this.getNode());
+
+		try {
+			if (mode === 'perItem') {
+				timeSavedMinutes = items.length * timeSavedMinutes;
+			}
+
+			// Ensure non-negative
+			if (timeSavedMinutes < 0) {
+				throw new NodeOperationError(
+					this.getNode(),
+					`Time saved cannot be negative, got: ${timeSavedMinutes}`,
+				);
+			}
+
+			// Set metadata using the clean API
+			this.setMetadata({
+				timeSaved: {
+					minutes: timeSavedMinutes,
+				},
+			});
+
+			// Pass through all items unchanged
+			return [items];
+		} catch (error) {
+			if (this.continueOnFail()) {
+				return [[{ json: { error: error.message } }]];
+			}
+			throw error;
+		}
+	}
+}

--- a/packages/nodes-base/nodes/TimeSaved/tests/TimeSaved.node.test.ts
+++ b/packages/nodes-base/nodes/TimeSaved/tests/TimeSaved.node.test.ts
@@ -1,0 +1,122 @@
+import { IExecuteFunctions } from 'n8n-workflow';
+import { TimeSaved } from '../TimeSaved.node';
+
+describe('TimeSaved node', () => {
+	it('should be defined', () => {
+		expect(TimeSaved).toBeDefined();
+	});
+
+	it('should set metadata with time saved for fixed option', async () => {
+		const node = new TimeSaved();
+
+		const executionFunctions = {
+			getInputData: jest.fn().mockReturnValue([{ json: {} }]),
+			getNodeParameter: jest.fn().mockReturnValueOnce('fixed').mockReturnValueOnce(10),
+			continueOnFail: jest.fn().mockReturnValue(false),
+			setMetadata: jest.fn(),
+			getNode: jest.fn().mockReturnValue({
+				name: 'TimeSaved',
+				type: 'timeSaved',
+			}),
+		} as any as IExecuteFunctions;
+
+		const result = await node.execute.call(executionFunctions);
+
+		expect(executionFunctions.setMetadata).toHaveBeenCalledWith({
+			timeSaved: {
+				minutes: 10,
+			},
+		});
+
+		expect(result[0].length).toEqual(1);
+	});
+
+	it('should set metadata with time saved for per item option', async () => {
+		const node = new TimeSaved();
+
+		const executionFunctions = {
+			getInputData: jest.fn().mockReturnValueOnce([{ json: {} }, { json: {} }]),
+			getNodeParameter: jest.fn().mockReturnValueOnce('perItem').mockReturnValueOnce(10),
+			continueOnFail: jest.fn().mockReturnValue(false),
+			setMetadata: jest.fn(),
+			getNode: jest.fn().mockReturnValue({
+				name: 'TimeSaved',
+				type: 'timeSaved',
+			}),
+		} as any as IExecuteFunctions;
+
+		const result = await node.execute.call(executionFunctions);
+
+		expect(executionFunctions.setMetadata).toHaveBeenCalledWith({
+			timeSaved: {
+				minutes: 20,
+			},
+		});
+
+		expect(result[0].length).toEqual(2);
+	});
+
+	it('should return an error if the minutes saved is negative', async () => {
+		const node = new TimeSaved();
+
+		const executionFunctions = {
+			getInputData: jest.fn().mockReturnValueOnce([{ json: {} }]),
+			getNodeParameter: jest.fn().mockReturnValueOnce('fixed').mockReturnValueOnce(-1),
+			continueOnFail: jest.fn().mockReturnValue(false),
+			setMetadata: jest.fn(),
+			getNode: jest.fn().mockReturnValue({
+				name: 'TimeSaved',
+				type: 'timeSaved',
+			}),
+		} as any as IExecuteFunctions;
+
+		await expect(node.execute.call(executionFunctions)).rejects.toThrow(
+			'Time saved cannot be negative, got: -1',
+		);
+
+		expect(executionFunctions.setMetadata).not.toHaveBeenCalled();
+	});
+
+	it('should return an error if the minutes saved is not a number', async () => {
+		const node = new TimeSaved();
+
+		const executionFunctions = {
+			getInputData: jest.fn().mockReturnValueOnce([{ json: {} }]),
+			getNodeParameter: jest.fn().mockReturnValueOnce('fixed').mockReturnValueOnce('not a number'),
+			continueOnFail: jest.fn().mockReturnValue(false),
+			setMetadata: jest.fn(),
+			getNode: jest.fn().mockReturnValue({
+				name: 'TimeSaved',
+				type: 'timeSaved',
+			}),
+		} as any as IExecuteFunctions;
+
+		await expect(node.execute.call(executionFunctions)).rejects.toThrow(
+			'Parameter "minutesSaved" is not number',
+		);
+
+		expect(executionFunctions.setMetadata).not.toHaveBeenCalled();
+	});
+
+	it('should continue on fail if the minutes saved is not a number and the config is set to continue on fail', async () => {
+		const node = new TimeSaved();
+
+		const executionFunctions = {
+			getInputData: jest.fn().mockReturnValueOnce([{ json: {} }]),
+			getNodeParameter: jest.fn().mockReturnValueOnce('fixed').mockReturnValueOnce(10),
+			continueOnFail: jest.fn().mockReturnValue(true),
+			setMetadata: jest.fn().mockImplementationOnce(() => {
+				throw new Error('Test error');
+			}),
+			getNode: jest.fn().mockReturnValue({
+				name: 'TimeSaved',
+				type: 'timeSaved',
+			}),
+		} as any as IExecuteFunctions;
+
+		const result = await node.execute.call(executionFunctions);
+
+		expect(result[0].length).toEqual(1);
+		expect(executionFunctions.continueOnFail).toHaveBeenCalled();
+	});
+});

--- a/packages/nodes-base/nodes/TimeSaved/tests/TimeSaved.node.test.ts
+++ b/packages/nodes-base/nodes/TimeSaved/tests/TimeSaved.node.test.ts
@@ -1,4 +1,4 @@
-import { IExecuteFunctions } from 'n8n-workflow';
+import type { IExecuteFunctions } from 'n8n-workflow';
 import { TimeSaved } from '../TimeSaved.node';
 
 describe('TimeSaved node', () => {

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -799,6 +799,7 @@
       "dist/nodes/TheHiveProject/TheHiveProjectTrigger.node.js",
       "dist/nodes/TheHive/TheHive.node.js",
       "dist/nodes/TheHive/TheHiveTrigger.node.js",
+      "dist/nodes/TimeSaved/TimeSaved.node.js",
       "dist/nodes/TimescaleDb/TimescaleDb.node.js",
       "dist/nodes/Todoist/Todoist.node.js",
       "dist/nodes/Toggl/TogglTrigger.node.js",

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2477,6 +2477,17 @@ export interface ITaskMetadata {
 	 * @see AI-1414
 	 */
 	nodeWasResumed?: boolean;
+
+	/**
+	 * Time saved by this workflow execution in minutes. Used by SavedTime nodes to track
+	 * dynamic time savings that can be calculated based on execution data (e.g., number of
+	 * items processed). The behavior determines how this value interacts with the workflow's
+	 * default timeSavedPerExecution setting.
+	 */
+	timeSaved?: {
+		/** Time saved in minutes */
+		minutes: number;
+	};
 }
 
 /** The data that gets returned when a node execution starts */


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR adds the time saved node, currently hidden as the logic to roll up time saved for insights is not yet connected, nor is the documentation ready. I had planned to use posthog here, but there wasn't a sensible way to integrate it cleanly, and no usage of PH within other nodes, so will use the hidden flag as a toggle for the moment.

<img width="1512" height="748" alt="image" src="https://github.com/user-attachments/assets/980a5597-01c2-441a-a047-ed2f30cf0a91" />

<img width="1512" height="748" alt="image" src="https://github.com/user-attachments/assets/04429b2b-c773-4ddc-9887-9df67fcebcea" />

<img width="1512" height="748" alt="image" src="https://github.com/user-attachments/assets/06af2d0f-6279-4114-9d0e-cda5ac91724a" />

## Related Linear tickets, Github issues, and Community forum posts

PAY-4164

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
