### PR TITLE
feat(core): Send the right activation mode for activate endpoint (no-changelog)

### DIFF
--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -544,6 +544,9 @@ export class WorkflowService {
 			return workflow;
 		}
 
+		const wasActive = workflow.activeVersionId !== null;
+		const activationMode = wasActive ? 'update' : 'activate';
+
 		await this.workflowRepository.update(workflowId, {
 			activeVersionId: versionId,
 			active: true,
@@ -572,7 +575,7 @@ export class WorkflowService {
 			publicApi: false,
 		});
 
-		await this._addToActiveWorkflowManager(user, workflowId, updatedWorkflow, 'activate', {
+		await this._addToActiveWorkflowManager(user, workflowId, updatedWorkflow, activationMode, {
 			active: workflow.active,
 			activeVersionId: workflow.activeVersionId,
 			activeVersion: workflow.activeVersion,


### PR DESCRIPTION
## Summary

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4432/update-n8n-node-trigger-invocations

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
