### PR TITLE
feat(core): Use 'chat' and 'webhook' execution modes on chat hub (no-changelog)

### DIFF
--- a/packages/cli/src/modules/chat-hub/chat-hub.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.service.ts
@@ -38,18 +38,8 @@ import {
 	INode,
 	type IBinaryData,
 	createRunExecutionData,
+	WorkflowExecuteMode,
 } from 'n8n-workflow';
-
-import { ActiveExecutions } from '@/active-executions';
-import { CredentialsFinderService } from '@/credentials/credentials-finder.service';
-import { BadRequestError } from '@/errors/response-errors/bad-request.error';
-import { NotFoundError } from '@/errors/response-errors/not-found.error';
-import { ExecutionService } from '@/executions/execution.service';
-import { DynamicNodeParametersService } from '@/services/dynamic-node-parameters.service';
-import { getBase } from '@/workflow-execute-additional-data';
-import { WorkflowExecutionService } from '@/workflows/workflow-execution.service';
-import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
-import { WorkflowService } from '@/workflows/workflow.service';
 
 import { ChatHubAgentService } from './chat-hub-agent.service';
 import { ChatHubCredentialsService, CredentialWithProjectId } from './chat-hub-credentials.service';
@@ -67,6 +57,17 @@ import {
 import { ChatHubMessageRepository } from './chat-message.repository';
 import { ChatHubSessionRepository } from './chat-session.repository';
 import { interceptResponseWrites, createStructuredChunkAggregator } from './stream-capturer';
+
+import { ActiveExecutions } from '@/active-executions';
+import { CredentialsFinderService } from '@/credentials/credentials-finder.service';
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { ExecutionService } from '@/executions/execution.service';
+import { DynamicNodeParametersService } from '@/services/dynamic-node-parameters.service';
+import { getBase } from '@/workflow-execute-additional-data';
+import { WorkflowExecutionService } from '@/workflows/workflow-execution.service';
+import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
+import { WorkflowService } from '@/workflows/workflow.service';
 
 @Service()
 export class ChatHubService {
@@ -1457,6 +1458,7 @@ export class ChatHubService {
 		previousMessageId: ChatMessageId,
 		model: ChatHubConversationModel,
 		retryOfMessageId: ChatMessageId | null = null,
+		executionMode: WorkflowExecuteMode = 'chat',
 	) {
 		this.logger.debug(
 			`Starting execution of workflow "${workflowData.name}" with ID ${workflowData.id}`,
@@ -1560,6 +1562,7 @@ export class ChatHubService {
 			user,
 			stream,
 			true,
+			executionMode,
 		);
 
 		executionId = execution.executionId;
@@ -1597,6 +1600,10 @@ export class ChatHubService {
 		retryOfMessageId: ChatMessageId | null = null,
 	) {
 		try {
+			// 'n8n' provider executions count towards execution limits and they are run with the usual 'webhook' mode.
+			// Chats with base LLM providers use 'chat' execution mode that doesn't count towards limits.
+			const executionMode = model.provider === 'n8n' ? 'webhook' : 'chat';
+
 			await this.executeChatWorkflow(
 				res,
 				user,
@@ -1606,6 +1613,7 @@ export class ChatHubService {
 				previousMessageId,
 				model,
 				retryOfMessageId,
+				executionMode,
 			);
 		} finally {
 			if (model.provider !== 'n8n') {

--- a/packages/cli/src/public-api/v1/handlers/executions/spec/schemas/execution.yml
+++ b/packages/cli/src/public-api/v1/handlers/executions/spec/schemas/execution.yml
@@ -11,7 +11,18 @@ properties:
   mode:
     type: string
     enum:
-      ['cli', 'error', 'integrated', 'internal', 'manual', 'retry', 'trigger', 'webhook', 'chat']
+      [
+        'cli',
+        'error',
+        'integrated',
+        'internal',
+        'manual',
+        'retry',
+        'trigger',
+        'webhook',
+        'evaluation',
+        'chat',
+      ]
   retryOf:
     type: number
     nullable: true

--- a/packages/cli/src/public-api/v1/handlers/executions/spec/schemas/execution.yml
+++ b/packages/cli/src/public-api/v1/handlers/executions/spec/schemas/execution.yml
@@ -10,7 +10,8 @@ properties:
     example: true
   mode:
     type: string
-    enum: ['cli', 'error', 'integrated', 'internal', 'manual', 'retry', 'trigger', 'webhook']
+    enum:
+      ['cli', 'error', 'integrated', 'internal', 'manual', 'retry', 'trigger', 'webhook', 'chat']
   retryOf:
     type: number
     nullable: true

--- a/packages/cli/src/services/workflow-statistics.service.ts
+++ b/packages/cli/src/services/workflow-statistics.service.ts
@@ -44,7 +44,7 @@ const isModeRootExecution = {
 	manual: false,
 
 	// n8n Chat hub messages
-	chat: true,
+	chat: false,
 } satisfies Record<WorkflowExecuteMode, boolean>;
 
 type WorkflowStatisticsEvents = {

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -239,9 +239,10 @@ export class WorkflowExecutionService {
 		user: User,
 		httpResponse?: Response,
 		streamingEnabled?: boolean,
+		executionMode: WorkflowExecuteMode = 'chat',
 	) {
 		const data: IWorkflowExecutionDataProcess = {
-			executionMode: 'chat',
+			executionMode,
 			workflowData,
 			userId: user.id,
 			executionData,


### PR DESCRIPTION
## Summary

Change which execution modes are used on chat hub:
- `chat` is used when chatting with base LLM chats, this doesn't count towards execution limits
- `webhook` is used when chatting with n8n workflows, this counts towards execution limits

Related cloud hooks PR will be opened.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-64

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
