### PR TITLE
fix(HTTP Request Node): Case-insensitive header check for Notion API auth

### DIFF
--- a/packages/nodes-base/credentials/NotionApi.credentials.ts
+++ b/packages/nodes-base/credentials/NotionApi.credentials.ts
@@ -42,7 +42,11 @@ export class NotionApi implements ICredentialType {
 		// if version it's not set, set it to last one
 		// version is only set when the request is made from
 		// the notion node, or was set explicitly in the http node
-		if (!requestOptions.headers['Notion-Version']) {
+		const hasNotionVersion = Object.keys(requestOptions.headers).some(
+			(key) => key.toLowerCase() === 'notion-version',
+		);
+
+		if (!hasNotionVersion) {
 			requestOptions.headers = {
 				...requestOptions.headers,
 				'Notion-Version': '2022-02-22',


### PR DESCRIPTION
## Summary
Fixes #22205

When using HTTP Request node with Notion API predefined credentials, manually specified headers like `notion-version` were not being detected due to case-sensitive checking. This caused the authentication to add a default `Notion-Version: 2022-02-22` header even when the user had already specified a different version, resulting in duplicate headers and 400 errors.

## Root Cause
The code checked for the header using bracket notation:
```typescript
if (!requestOptions.headers['Notion-Version']) {
```
This is case-sensitive, so when users set `notion-version: 2025-09-03` in the HTTP Request node, the check failed and added `Notion-Version: 2022-02-22`, resulting in both headers being sent:
```json
{
  "notion-version": "2025-09-03",
  "Notion-Version": "2022-02-22"
}
```

## Changes
- Changed header existence check to be case-insensitive
- Now correctly detects `notion-version`, `Notion-Version`, `NOTION-VERSION`, or any casing variation
- Prevents adding default header when user has already specified one

## Solution
```typescript
// Before (case-sensitive)
if (!requestOptions.headers['Notion-Version']) {
  // adds default header
}

// After (case-insensitive)
const hasNotionVersion = Object.keys(requestOptions.headers).some(
  (key) => key.toLowerCase() === 'notion-version',
);
if (!hasNotionVersion) {
  // adds default header only if truly absent
}
```


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
