### PR TITLE
fix(core): Add missing workflowId when creating base subworkflowworkflow additional data

### DIFF
--- a/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
+++ b/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
@@ -203,6 +203,31 @@ describe('WorkflowExecuteAdditionalData', () => {
 				waitTill,
 			});
 		});
+
+		it('should pass workflowId to getBase when executing subworkflow', async () => {
+			const getVariablesSpy = jest.spyOn(WorkflowHelpers, 'getVariables');
+			const workflowId = 'test-workflow-123';
+
+			const workflowWithId = mock<WorkflowEntity>({
+				id: workflowId,
+				name: 'Test Workflow',
+				active: false,
+				activeVersionId: null,
+				activeVersion: null,
+				nodes: [],
+				connections: {},
+			});
+
+			workflowRepository.get.mockResolvedValueOnce(workflowWithId);
+
+			await executeWorkflow(
+				mock<IExecuteWorkflowInfo>({ id: workflowId }),
+				mock<IWorkflowExecuteAdditionalData>(),
+				mock<ExecuteWorkflowOptions>({ loadedWorkflowData: undefined, doNotWaitToFinish: false }),
+			);
+
+			expect(getVariablesSpy).toHaveBeenCalledWith(workflowId, undefined);
+		});
 	});
 
 	describe('getRunData', () => {

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -222,7 +222,9 @@ async function startExecution(
 
 		// Create new additionalData to have different workflow loaded and to call
 		// different webhooks
-		const additionalDataIntegrated = await getBase();
+		const additionalDataIntegrated = await getBase({
+			workflowId: workflowData.id,
+		});
 		additionalDataIntegrated.hooks = getLifecycleHooksForSubExecutions(
 			runData.executionMode,
 			executionId,


### PR DESCRIPTION

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR fixes the fact that subworkflow execution did not pass the workflowId to the additional data, which in turn could not fetch the proper project variables of the workflow variables

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-4179/project-specific-variables-dont-work-on-sub-workflow-executions

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
