### PR TITLE
feat(AWS Node): Add IRSA to AWS AssumeRole system credential strategies

### DIFF
--- a/packages/nodes-base/credentials/common/aws/system-credentials-utils.test.ts
+++ b/packages/nodes-base/credentials/common/aws/system-credentials-utils.test.ts
@@ -862,19 +862,18 @@ describe('system-credentials-utils', () => {
 
 			expect(mockReadFile).toHaveBeenCalledWith('/tmp/token', 'utf8');
 			expect(global.fetch).toHaveBeenCalledWith(
-				expect.stringContaining('https://sts.amazonaws.com?'),
+				'https://sts.amazonaws.com',
 				expect.objectContaining({
-					method: 'GET',
+					method: 'POST',
 					headers: {
 						'User-Agent': 'n8n-aws-credential',
+						'Content-Type': 'application/x-www-form-urlencoded',
 						Accept: 'application/json',
 					},
+					body: expect.stringContaining('Action=AssumeRoleWithWebIdentity'),
 				}),
 			);
-			expect((global.fetch as jest.Mock).mock.calls[0][0]).toContain(
-				'Action=AssumeRoleWithWebIdentity',
-			);
-			expect((global.fetch as jest.Mock).mock.calls[0][0]).toContain(
+			expect((global.fetch as jest.Mock).mock.calls[0][1].body).toContain(
 				'RoleArn=arn%3Aaws%3Aiam%3A%3A123456789012%3Arole%2Ftest-role',
 			);
 		});

--- a/packages/nodes-base/credentials/common/aws/system-credentials-utils.test.ts
+++ b/packages/nodes-base/credentials/common/aws/system-credentials-utils.test.ts
@@ -20,10 +20,6 @@ jest.mock('@n8n/config', () => ({
 	SecurityConfig: MockSecurityConfig,
 }));
 
-jest.mock('node:fs/promises', () => ({
-	readFile: jest.fn(),
-}));
-
 jest.mock('fs/promises', () => ({
 	readFile: mockReadFile,
 }));

--- a/packages/nodes-base/credentials/common/aws/system-credentials-utils.ts
+++ b/packages/nodes-base/credentials/common/aws/system-credentials-utils.ts
@@ -3,7 +3,12 @@ import { Container } from '@n8n/di';
 import { ApplicationError } from 'n8n-workflow';
 import { readFile } from 'fs/promises';
 
-type Resolvers = 'environment' | 'podIdentity' | 'containerMetadata' | 'instanceMetadata';
+type Resolvers =
+	| 'environment'
+	| 'podIdentity'
+	| 'containerMetadata'
+	| 'instanceMetadata'
+	| 'roleForServiceAccount';
 type ReturnData = {
 	accessKeyId: string;
 	secretAccessKey: string;
@@ -17,6 +22,7 @@ export const credentialsResolver: Record<Resolvers, () => Promise<ReturnData | n
 	instanceMetadata: getInstanceMetadataCredentials,
 	containerMetadata: getContainerMetadataCredentials,
 	podIdentity: getPodIdentityCredentials,
+	roleForServiceAccount: getRoleForServiceAccountCredentials,
 };
 
 /**
@@ -39,6 +45,7 @@ export async function getSystemCredentials() {
 		'podIdentity',
 		'containerMetadata',
 		'instanceMetadata',
+		'roleForServiceAccount',
 	];
 
 	for (const resolver of resolveOrder) {
@@ -262,6 +269,62 @@ async function getPodIdentityCredentials() {
 			accessKeyId: credentialsData.AccessKeyId,
 			secretAccessKey: credentialsData.SecretAccessKey,
 			sessionToken: credentialsData.Token,
+		};
+	} catch (error) {
+		return null;
+	}
+}
+
+async function getRoleForServiceAccountCredentials() {
+	const iamRole = envGetter('AWS_ROLE_ARN');
+	const webIdentityTokenFile = envGetter('AWS_WEB_IDENTITY_TOKEN_FILE');
+
+	try {
+		if (!iamRole || !webIdentityTokenFile) {
+			return null;
+		}
+
+		const token = (await readFile(webIdentityTokenFile, 'utf8')).trim();
+		if (!token) {
+			return null;
+		}
+
+		const headers: Record<string, string> = {
+			'User-Agent': 'n8n-aws-credential',
+			Accept: 'application/json',
+		};
+
+		const qs = new URLSearchParams({
+			Action: 'AssumeRoleWithWebIdentity',
+			RoleArn: iamRole,
+			RoleSessionName: 'n8n-web-identity-session',
+			WebIdentityToken: token,
+			Version: '2011-06-15',
+		});
+
+		// TODO what about endpoints for sts?
+		const credentialsResponse = await fetch(`https://sts.amazonaws.com?${qs.toString()}`, {
+			method: 'GET',
+			headers,
+			signal: AbortSignal.timeout(2000),
+		});
+
+		if (!credentialsResponse.ok) {
+			return null;
+		}
+
+		const data = await credentialsResponse.json();
+		const credentialsData =
+			data?.AssumeRoleWithWebIdentityResponse?.AssumeRoleWithWebIdentityResult?.Credentials;
+
+		if (!credentialsData || !credentialsData?.AccessKeyId || !credentialsData?.SecretAccessKey) {
+			return null;
+		}
+
+		return {
+			accessKeyId: credentialsData.AccessKeyId,
+			secretAccessKey: credentialsData.SecretAccessKey,
+			sessionToken: credentialsData.SessionToken,
 		};
 	} catch (error) {
 		return null;

--- a/packages/nodes-base/credentials/common/aws/system-credentials-utils.ts
+++ b/packages/nodes-base/credentials/common/aws/system-credentials-utils.ts
@@ -276,6 +276,18 @@ async function getPodIdentityCredentials() {
 	}
 }
 
+/**
+ * Retrieves AWS credentials by assuming a role via OIDC web identity (IRSA).
+ * Used when running in EKS with IAM Roles for Service Accounts configured.
+ * Reads the OIDC token from the file at AWS_WEB_IDENTITY_TOKEN_FILE and calls
+ * STS AssumeRoleWithWebIdentity to exchange it for temporary credentials.
+ *
+ * @returns Promise resolving to credentials object or null if IRSA is not configured
+ *
+ * @see {@link https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html IRSA}
+ * @see {@link https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html STS API}
+ * @see {@link https://github.com/aws/aws-sdk-js-v3/blob/main/packages-internal/credential-provider-web-identity/src/fromWebToken.ts AWS SDK v3 implementation}
+ */
 async function getRoleForServiceAccountCredentials() {
 	const iamRole = envGetter('AWS_ROLE_ARN');
 	const webIdentityTokenFile = envGetter('AWS_WEB_IDENTITY_TOKEN_FILE');
@@ -292,10 +304,11 @@ async function getRoleForServiceAccountCredentials() {
 
 		const headers: Record<string, string> = {
 			'User-Agent': 'n8n-aws-credential',
+			'Content-Type': 'application/x-www-form-urlencoded',
 			Accept: 'application/json',
 		};
 
-		const qs = new URLSearchParams({
+		const body = new URLSearchParams({
 			Action: 'AssumeRoleWithWebIdentity',
 			RoleArn: iamRole,
 			RoleSessionName: 'n8n-web-identity-session',
@@ -304,9 +317,11 @@ async function getRoleForServiceAccountCredentials() {
 		});
 
 		// Global STS endpoint; China/GovCloud regions unsupported until region is passed through getSystemCredentials
-		const credentialsResponse = await fetch(`https://sts.amazonaws.com?${qs.toString()}`, {
-			method: 'GET',
+		// STS supports Accept: application/json (undocumented) to return JSON instead of XML.
+		const credentialsResponse = await fetch('https://sts.amazonaws.com', {
+			method: 'POST',
 			headers,
+			body: body.toString(),
 			signal: AbortSignal.timeout(2000),
 		});
 

--- a/packages/nodes-base/credentials/common/aws/system-credentials-utils.ts
+++ b/packages/nodes-base/credentials/common/aws/system-credentials-utils.ts
@@ -5,10 +5,10 @@ import { readFile } from 'fs/promises';
 
 type Resolvers =
 	| 'environment'
+	| 'roleForServiceAccount'
 	| 'podIdentity'
 	| 'containerMetadata'
-	| 'instanceMetadata'
-	| 'roleForServiceAccount';
+	| 'instanceMetadata';
 type ReturnData = {
 	accessKeyId: string;
 	secretAccessKey: string;
@@ -29,9 +29,10 @@ export const credentialsResolver: Record<Resolvers, () => Promise<ReturnData | n
  * Retrieves AWS credentials from various system sources following the AWS credential chain.
  * Attempts to get credentials in the following order:
  * 1. Environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN)
- * 2. EKS Pod Identity (AWS_CONTAINER_CREDENTIALS_FULL_URI)
- * 3. ECS/Fargate container metadata (AWS_CONTAINER_CREDENTIALS_RELATIVE_URI)
- * 4. EC2 instance metadata service
+ * 2. IAM Role for Service Account (AWS_ROLE_ARN + AWS_WEB_IDENTITY_TOKEN_FILE)
+ * 3. EKS Pod Identity (AWS_CONTAINER_CREDENTIALS_FULL_URI)
+ * 4. ECS/Fargate container metadata (AWS_CONTAINER_CREDENTIALS_RELATIVE_URI)
+ * 5. EC2 instance metadata service
  */
 export async function getSystemCredentials() {
 	if (!Container.get(SecurityConfig).awsSystemCredentialsAccess) {
@@ -42,10 +43,10 @@ export async function getSystemCredentials() {
 
 	const resolveOrder: Resolvers[] = [
 		'environment',
+		'roleForServiceAccount',
 		'podIdentity',
 		'containerMetadata',
 		'instanceMetadata',
-		'roleForServiceAccount',
 	];
 
 	for (const resolver of resolveOrder) {
@@ -302,7 +303,7 @@ async function getRoleForServiceAccountCredentials() {
 			Version: '2011-06-15',
 		});
 
-		// TODO what about endpoints for sts?
+		// Global STS endpoint; China/GovCloud regions unsupported until region is passed through getSystemCredentials
 		const credentialsResponse = await fetch(`https://sts.amazonaws.com?${qs.toString()}`, {
 			method: 'GET',
 			headers,
@@ -317,7 +318,7 @@ async function getRoleForServiceAccountCredentials() {
 		const credentialsData =
 			data?.AssumeRoleWithWebIdentityResponse?.AssumeRoleWithWebIdentityResult?.Credentials;
 
-		if (!credentialsData || !credentialsData?.AccessKeyId || !credentialsData?.SecretAccessKey) {
+		if (!credentialsData || !credentialsData.AccessKeyId || !credentialsData.SecretAccessKey) {
 			return null;
 		}
 


### PR DESCRIPTION
## Summary

Add an additional strategy to the AWS SystemCredentials util to support IAM Roles for Service Accounts ([IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)), which is implemented via a token file and the AssumeRoleWithWebIdentity STS API.

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/issues/21961
https://github.com/n8n-io/n8n/pull/20626
https://linear.app/n8n/issue/NODE-3759/assumerole-aws-credentials

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
