### PR TITLE
feat(Anthropic Node): Add prompt caching support

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/actions/text/message.operation.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/actions/text/message.operation.test.ts
@@ -1,0 +1,213 @@
+import type { IExecuteFunctions } from 'n8n-workflow';
+import { mockDeep } from 'jest-mock-extended';
+import * as messageOperation from './message.operation';
+
+// Mock the apiRequest function
+jest.mock('../../transport', () => ({
+	apiRequest: jest.fn(),
+}));
+
+// Mock the getTools helper
+jest.mock('../../helpers/utils', () => ({
+	getTools: jest.fn().mockResolvedValue({ tools: [], connectedTools: [] }),
+}));
+
+import { apiRequest } from '../../transport';
+
+describe('Message Operation - Prompt Caching', () => {
+	const executeFunctionsMock = mockDeep<IExecuteFunctions>();
+	const apiRequestMock = apiRequest as jest.MockedFunction<typeof apiRequest>;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		// Setup default mock responses
+		executeFunctionsMock.getNodeParameter.mockImplementation((paramName: string) => {
+			if (paramName === 'modelId') return 'claude-sonnet-4-20250514';
+			if (paramName === 'messages.values') return [{ role: 'user', content: 'Hello' }];
+			if (paramName === 'addAttachments') return false;
+			if (paramName === 'simplify') return true;
+			if (paramName === 'options') return {};
+			if (paramName === 'options.maxToolsIterations') return 15;
+			return undefined;
+		});
+
+		// Mock getNodeInputs to return empty array (no AI tools connected)
+		executeFunctionsMock.getNodeInputs.mockReturnValue([]);
+
+		apiRequestMock.mockResolvedValue({
+			id: 'msg_123',
+			type: 'message',
+			role: 'assistant',
+			content: [{ type: 'text', text: 'Hello!' }],
+			model: 'claude-sonnet-4-20250514',
+			stop_reason: 'end_turn',
+			usage: {
+				input_tokens: 10,
+				output_tokens: 5,
+			},
+		});
+
+		executeFunctionsMock.getExecutionCancelSignal.mockReturnValue(undefined);
+	});
+
+	describe('System message transformation', () => {
+		it('should keep system message as string when prompt caching is disabled', async () => {
+			executeFunctionsMock.getNodeParameter.mockImplementation((paramName: string) => {
+				if (paramName === 'modelId') return 'claude-sonnet-4-20250514';
+				if (paramName === 'messages.values') return [{ role: 'user', content: 'Test' }];
+				if (paramName === 'addAttachments') return false;
+				if (paramName === 'simplify') return true;
+				if (paramName === 'options')
+					return {
+						system: 'You are a helpful assistant',
+						enablePromptCaching: false,
+					};
+				if (paramName === 'options.maxToolsIterations') return 15;
+				return undefined;
+			});
+
+			await messageOperation.execute.call(executeFunctionsMock, 0);
+
+			expect(apiRequestMock).toHaveBeenCalledWith(
+				'POST',
+				'/v1/messages',
+				expect.objectContaining({
+					body: expect.objectContaining({
+						system: 'You are a helpful assistant',
+					}),
+					enableAnthropicBetas: expect.objectContaining({
+						promptCaching: false,
+					}),
+				}),
+			);
+		});
+
+		it('should transform system message to array format when prompt caching is enabled', async () => {
+			executeFunctionsMock.getNodeParameter.mockImplementation((paramName: string) => {
+				if (paramName === 'modelId') return 'claude-sonnet-4-20250514';
+				if (paramName === 'messages.values') return [{ role: 'user', content: 'Test' }];
+				if (paramName === 'addAttachments') return false;
+				if (paramName === 'simplify') return true;
+				if (paramName === 'options')
+					return {
+						system: 'You are a helpful assistant with extensive knowledge',
+						enablePromptCaching: true,
+					};
+				if (paramName === 'options.maxToolsIterations') return 15;
+				return undefined;
+			});
+
+			await messageOperation.execute.call(executeFunctionsMock, 0);
+
+			expect(apiRequestMock).toHaveBeenCalledWith(
+				'POST',
+				'/v1/messages',
+				expect.objectContaining({
+					body: expect.objectContaining({
+						system: [
+							{
+								type: 'text',
+								text: 'You are a helpful assistant with extensive knowledge',
+								cache_control: { type: 'ephemeral' },
+							},
+						],
+					}),
+					enableAnthropicBetas: expect.objectContaining({
+						promptCaching: true,
+					}),
+				}),
+			);
+		});
+
+		it('should not transform system message when caching is enabled but no system message provided', async () => {
+			executeFunctionsMock.getNodeParameter.mockImplementation((paramName: string) => {
+				if (paramName === 'modelId') return 'claude-sonnet-4-20250514';
+				if (paramName === 'messages.values') return [{ role: 'user', content: 'Test' }];
+				if (paramName === 'addAttachments') return false;
+				if (paramName === 'simplify') return true;
+				if (paramName === 'options')
+					return {
+						enablePromptCaching: true,
+					};
+				if (paramName === 'options.maxToolsIterations') return 15;
+				return undefined;
+			});
+
+			await messageOperation.execute.call(executeFunctionsMock, 0);
+
+			expect(apiRequestMock).toHaveBeenCalledWith(
+				'POST',
+				'/v1/messages',
+				expect.objectContaining({
+					body: expect.objectContaining({
+						system: undefined,
+					}),
+				}),
+			);
+		});
+
+		it('should preserve other options when prompt caching is enabled', async () => {
+			executeFunctionsMock.getNodeParameter.mockImplementation((paramName: string) => {
+				if (paramName === 'modelId') return 'claude-sonnet-4-20250514';
+				if (paramName === 'messages.values') return [{ role: 'user', content: 'Test' }];
+				if (paramName === 'addAttachments') return false;
+				if (paramName === 'simplify') return true;
+				if (paramName === 'options')
+					return {
+						system: 'You are a helpful assistant',
+						enablePromptCaching: true,
+						temperature: 0.7,
+						maxTokens: 2048,
+						topP: 0.9,
+					};
+				if (paramName === 'options.maxToolsIterations') return 15;
+				return undefined;
+			});
+
+			await messageOperation.execute.call(executeFunctionsMock, 0);
+
+			expect(apiRequestMock).toHaveBeenCalledWith(
+				'POST',
+				'/v1/messages',
+				expect.objectContaining({
+					body: expect.objectContaining({
+						temperature: 0.7,
+						max_tokens: 2048,
+						top_p: 0.9,
+					}),
+				}),
+			);
+		});
+
+		it('should handle code execution and prompt caching together', async () => {
+			executeFunctionsMock.getNodeParameter.mockImplementation((paramName: string) => {
+				if (paramName === 'modelId') return 'claude-sonnet-4-20250514';
+				if (paramName === 'messages.values') return [{ role: 'user', content: 'Test' }];
+				if (paramName === 'addAttachments') return false;
+				if (paramName === 'simplify') return true;
+				if (paramName === 'options')
+					return {
+						system: 'You are a code assistant',
+						enablePromptCaching: true,
+						codeExecution: true,
+					};
+				if (paramName === 'options.maxToolsIterations') return 15;
+				return undefined;
+			});
+
+			await messageOperation.execute.call(executeFunctionsMock, 0);
+
+			expect(apiRequestMock).toHaveBeenCalledWith(
+				'POST',
+				'/v1/messages',
+				expect.objectContaining({
+					enableAnthropicBetas: {
+						codeExecution: true,
+						promptCaching: true,
+					},
+				}),
+			);
+		});
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/transport/index.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/transport/index.test.ts
@@ -264,4 +264,53 @@ describe('Anthropic transport', () => {
 			},
 		);
 	});
+
+	it('should include prompt-caching beta when enableAnthropicBetas.promptCaching is true', async () => {
+		executeFunctionsMock.getCredentials.mockResolvedValue({});
+
+		await apiRequest.call(executeFunctionsMock, 'POST', '/v1/messages', {
+			enableAnthropicBetas: {
+				promptCaching: true,
+			},
+		});
+
+		expect(executeFunctionsMock.helpers.httpRequestWithAuthentication).toHaveBeenCalledWith(
+			'anthropicApi',
+			{
+				method: 'POST',
+				url: 'https://api.anthropic.com/v1/messages',
+				json: true,
+				headers: {
+					'anthropic-version': '2023-06-01',
+					'anthropic-beta': 'files-api-2025-04-14,prompt-caching-2024-07-31',
+				},
+			},
+		);
+	});
+
+	it('should include all beta features when all are enabled', async () => {
+		executeFunctionsMock.getCredentials.mockResolvedValue({});
+
+		await apiRequest.call(executeFunctionsMock, 'POST', '/v1/messages', {
+			enableAnthropicBetas: {
+				promptTools: true,
+				codeExecution: true,
+				promptCaching: true,
+			},
+		});
+
+		expect(executeFunctionsMock.helpers.httpRequestWithAuthentication).toHaveBeenCalledWith(
+			'anthropicApi',
+			{
+				method: 'POST',
+				url: 'https://api.anthropic.com/v1/messages',
+				json: true,
+				headers: {
+					'anthropic-version': '2023-06-01',
+					'anthropic-beta':
+						'files-api-2025-04-14,prompt-tools-2025-04-02,code-execution-2025-05-22,prompt-caching-2024-07-31',
+				},
+			},
+		);
+	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/transport/index.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/transport/index.ts
@@ -14,6 +14,7 @@ type RequestParameters = {
 	enableAnthropicBetas?: {
 		promptTools?: boolean;
 		codeExecution?: boolean;
+		promptCaching?: boolean;
 	};
 };
 
@@ -36,6 +37,10 @@ export async function apiRequest(
 
 	if (parameters?.enableAnthropicBetas?.codeExecution) {
 		betas.push('code-execution-2025-05-22');
+	}
+
+	if (parameters?.enableAnthropicBetas?.promptCaching) {
+		betas.push('prompt-caching-2024-07-31');
 	}
 
 	const requestHeaders: IDataObject = {


### PR DESCRIPTION
## Summary

This PR implements Anthropic's prompt caching functionality for the Anthropic Vendor Node, enabling up to 90% cost reduction and improved latency for workflows with repeated system prompts.

### What this PR does:
- Adds an "Enable Prompt Caching" toggle in the Anthropic node options (defaults to OFF for backward compatibility)
- Transforms system messages to array format with `cache_control` markers when caching is enabled
- Registers the `prompt-caching-2024-07-31` beta header with the Anthropic API
- Maintains full backward compatibility - existing workflows continue to work unchanged

### How to test:
1. Create a workflow with an Anthropic node (Vendor node, "Send a Message" action)
2. Add a system message of at least 1024 tokens (~768 words or ~3000 characters)
   - Example long system message provided in testing
3. In Options, toggle "Enable Prompt Caching" to ON
4. Execute the workflow 3 times:
   - **First execution**: Check response usage field for `cache_creation_input_tokens` > 0
   - **Second execution**: Check for `cache_read_input_tokens` > 0 (90% cost savings!)
   - **Third execution**: Verify cache is still being read

**Note**: System messages must be at least 1024 tokens for Anthropic to activate caching. Shorter messages will show cache fields as 0.

### Example response with caching enabled:
```json
"usage": {
  "input_tokens": 15,
  "cache_read_input_tokens": 1098,
  "output_tokens": 281
}
```

## Related Linear tickets, Github issues, and Community forum posts

- Community Request: https://community.n8n.io/t/utilize-cache-for-ai-anthropic/59402/12 (26 votes, 797 views)
- Anthropic Documentation: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [ ] Docs updated or follow-up ticket created
- [x] Tests included (7 new unit tests, all 1532 tests passing)
- [x] Lint and typecheck passing
- [x] Verified manually with test workflow