### PR TITLE
fix(core): Mark `''` and `[]` as empty when filtering numbers

### DIFF
--- a/packages/nodes-base/nodes/Filter/Filter.node.ts
+++ b/packages/nodes-base/nodes/Filter/Filter.node.ts
@@ -13,7 +13,7 @@ export class Filter extends VersionedNodeType {
 			iconColor: 'light-blue',
 			group: ['transform'],
 			description: 'Remove items matching a condition',
-			defaultVersion: 2.2,
+			defaultVersion: 2.3,
 		};
 
 		const nodeVersions: IVersionedNodeType['nodeVersions'] = {
@@ -21,6 +21,7 @@ export class Filter extends VersionedNodeType {
 			2: new FilterV2(baseDescription),
 			2.1: new FilterV2(baseDescription),
 			2.2: new FilterV2(baseDescription),
+			2.3: new FilterV2(baseDescription),
 		};
 
 		super(nodeVersions, baseDescription);

--- a/packages/nodes-base/nodes/Filter/V2/FilterV2.node.ts
+++ b/packages/nodes-base/nodes/Filter/V2/FilterV2.node.ts
@@ -20,7 +20,7 @@ export class FilterV2 implements INodeType {
 	constructor(baseDescription: INodeTypeBaseDescription) {
 		this.description = {
 			...baseDescription,
-			version: [2, 2.1, 2.2],
+			version: [2, 2.1, 2.2, 2.3],
 			defaults: {
 				name: 'Filter',
 				color: '#229eff',
@@ -40,7 +40,7 @@ export class FilterV2 implements INodeType {
 						filter: {
 							caseSensitive: '={{!$parameter.options.ignoreCase}}',
 							typeValidation: getTypeValidationStrictness(2.1),
-							version: '={{ $nodeVersion >= 2.2 ? 2 : 1 }}',
+							version: '={{ $nodeVersion >= 2.3 ? 3 : $nodeVersion >= 2.2 ? 2 : 1 }}',
 						},
 					},
 				},

--- a/packages/nodes-base/nodes/If/If.node.ts
+++ b/packages/nodes-base/nodes/If/If.node.ts
@@ -13,7 +13,7 @@ export class If extends VersionedNodeType {
 			iconColor: 'green',
 			group: ['transform'],
 			description: 'Route items to different branches (true/false)',
-			defaultVersion: 2.2,
+			defaultVersion: 2.3,
 		};
 
 		const nodeVersions: IVersionedNodeType['nodeVersions'] = {
@@ -21,6 +21,7 @@ export class If extends VersionedNodeType {
 			2: new IfV2(baseDescription),
 			2.1: new IfV2(baseDescription),
 			2.2: new IfV2(baseDescription),
+			2.3: new IfV2(baseDescription),
 		};
 
 		super(nodeVersions, baseDescription);

--- a/packages/nodes-base/nodes/If/V2/IfV2.node.ts
+++ b/packages/nodes-base/nodes/If/V2/IfV2.node.ts
@@ -20,7 +20,7 @@ export class IfV2 implements INodeType {
 	constructor(baseDescription: INodeTypeBaseDescription) {
 		this.description = {
 			...baseDescription,
-			version: [2, 2.1, 2.2],
+			version: [2, 2.1, 2.2, 2.3],
 			defaults: {
 				name: 'If',
 				color: '#408000',
@@ -40,7 +40,7 @@ export class IfV2 implements INodeType {
 						filter: {
 							caseSensitive: '={{!$parameter.options.ignoreCase}}',
 							typeValidation: getTypeValidationStrictness(2.1),
-							version: '={{ $nodeVersion >= 2.2 ? 2 : 1 }}',
+							version: '={{ $nodeVersion >= 2.3 ? 3 : $nodeVersion >= 2.2 ? 2 : 1 }}',
 						},
 					},
 				},

--- a/packages/nodes-base/nodes/Switch/Switch.node.ts
+++ b/packages/nodes-base/nodes/Switch/Switch.node.ts
@@ -14,7 +14,7 @@ export class Switch extends VersionedNodeType {
 			iconColor: 'light-blue',
 			group: ['transform'],
 			description: 'Route items depending on defined expression or rules',
-			defaultVersion: 3.3,
+			defaultVersion: 3.4,
 		};
 
 		const nodeVersions: IVersionedNodeType['nodeVersions'] = {
@@ -24,6 +24,7 @@ export class Switch extends VersionedNodeType {
 			3.1: new SwitchV3(baseDescription),
 			3.2: new SwitchV3(baseDescription),
 			3.3: new SwitchV3(baseDescription),
+			3.4: new SwitchV3(baseDescription),
 		};
 
 		super(nodeVersions, baseDescription);

--- a/packages/nodes-base/nodes/Switch/V3/SwitchV3.node.ts
+++ b/packages/nodes-base/nodes/Switch/V3/SwitchV3.node.ts
@@ -52,7 +52,7 @@ export class SwitchV3 implements INodeType {
 		this.description = {
 			...baseDescription,
 			subtitle: `=mode: {{(${capitalize})($parameter["mode"])}}`,
-			version: [3, 3.1, 3.2, 3.3],
+			version: [3, 3.1, 3.2, 3.3, 3.4],
 			defaults: {
 				name: 'Switch',
 				color: '#506000',
@@ -177,7 +177,7 @@ export class SwitchV3 implements INodeType {
 										filter: {
 											caseSensitive: '={{!$parameter.options.ignoreCase}}',
 											typeValidation: getTypeValidationStrictness(3.1),
-											version: '={{ $nodeVersion >= 3.2 ? 2 : 1 }}',
+											version: '={{ $nodeVersion >=3.4 ? 3 : $nodeVersion >= 3.2 ? 2 : 1 }}',
 										},
 									},
 								},

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1497,7 +1497,7 @@ type NonEmptyArray<T> = [T, ...T[]];
 export type FilterTypeCombinator = 'and' | 'or';
 
 export type FilterTypeOptions = {
-	version: 1 | 2 | {}; // required so nodes are pinned on a version
+	version: 1 | 2 | 3 | {}; // required so nodes are pinned on a version
 	caseSensitive?: boolean | string; // default = true
 	leftValue?: string; // when set, user can't edit left side of condition
 	allowedCombinators?: NonEmptyArray<FilterTypeCombinator>; // default = ['and', 'or']
@@ -3092,7 +3092,7 @@ export type FilterOptionsValue = {
 	caseSensitive: boolean;
 	leftValue: string;
 	typeValidation: 'strict' | 'loose';
-	version: 1 | 2;
+	version: 1 | 2 | 3;
 };
 
 export type FilterValue = {

--- a/packages/workflow/src/node-parameters/filter-parameter.ts
+++ b/packages/workflow/src/node-parameters/filter-parameter.ts
@@ -1,6 +1,6 @@
+import { ApplicationError } from '@n8n/errors';
 import type { DateTime } from 'luxon';
 
-import { ApplicationError } from '@n8n/errors';
 import type {
 	FilterConditionValue,
 	FilterOperatorType,
@@ -48,8 +48,16 @@ function parseSingleFilterValue(
 		return { valid: true, newValue: Boolean(value) };
 	}
 
-	if (type === 'number' && Number.isNaN(value)) {
-		return { valid: true, newValue: value };
+	if (type === 'number') {
+		if (Number.isNaN(value)) {
+			return { valid: true, newValue: value };
+		}
+		const isEmptyString = typeof value === 'string' && value.trim() === '';
+		const isEmptyArray = Array.isArray(value) && value.length === 0;
+		// Number('') and Number([]) convert to 0 in validateFieldType, which is not intuitive, consider them empty values
+		if ((isEmptyString || isEmptyArray) && version >= 3) {
+			return { valid: true, newValue: null };
+		}
 	}
 
 	return validateFieldType('filter', value, type, { strict, parseStrings: true });

--- a/packages/workflow/src/schemas.ts
+++ b/packages/workflow/src/schemas.ts
@@ -371,7 +371,7 @@ export const FilterOptionsValueSchema: z.ZodType<FilterOptionsValue> = z.object(
 	caseSensitive: z.boolean(),
 	leftValue: z.string(),
 	typeValidation: z.enum(['strict', 'loose']),
-	version: z.union([z.literal(1), z.literal(2)]),
+	version: z.union([z.literal(1), z.literal(2), z.literal(3)]),
 });
 
 export const FilterOperatorTypeSchema: z.ZodType<FilterOperatorType> = z.enum([

--- a/packages/workflow/test/filter-parameter.test.ts
+++ b/packages/workflow/test/filter-parameter.test.ts
@@ -20,7 +20,7 @@ const filterFactory = (data: DeepPartial<FilterValue> = {}): FilterValue =>
 			combinator: 'and',
 			conditions: [],
 			options: {
-				version: 1,
+				version: 3,
 				leftValue: '',
 				caseSensitive: false,
 				typeValidation: 'strict',
@@ -578,6 +578,33 @@ describe('FilterParameter', () => {
 			});
 
 			describe('number', () => {
+				describe('loose validation', () => {
+					it.each([
+						{ left: 0, expected: false },
+						{ left: 15, expected: false },
+						{ left: -15.4, expected: false },
+						{ left: NaN, expected: true },
+						{ left: null, expected: true },
+						{ left: '', expected: true },
+						{ left: '  ', expected: true },
+						{ left: [], expected: true },
+					])('number:empty($left) === $expected', ({ left, expected }) => {
+						const result = executeFilter(
+							filterFactory({
+								conditions: [
+									{
+										id: '1',
+										leftValue: left,
+										operator: { operation: 'empty', type: 'number' },
+									},
+								],
+								options: { typeValidation: 'loose' },
+							}),
+						);
+						expect(result).toBe(expected);
+					});
+				});
+
 				it.each([
 					{ left: 0, expected: true },
 					{ left: 15, expected: true },


### PR DESCRIPTION
## Summary

This PR fixes an issue when filtering in If node would allow empty string to pass through it

<img width="1383" height="918" alt="изображение" src="https://github.com/user-attachments/assets/fa7e45f7-cdeb-44c2-bab5-5ac0305082f2" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3887/community-issue-filters-and-google-sheets-nodes-malfunctioning

closes #21130

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
