### PR TITLE
refactor(core): Remove admin API token scopes when user is demoted from admin to member via SSO

### DIFF
--- a/packages/@n8n/db/src/repositories/user.repository.ts
+++ b/packages/@n8n/db/src/repositories/user.repository.ts
@@ -44,6 +44,9 @@ export class UserRepository extends Repository<User> {
 	 * With `update` it would only receive the updated fields, e.g. the `id`
 	 * would be missing. test('does not use `Repository.update`, but
 	 * `Repository.save` instead'.
+	 *
+	 * Also don't use this method to change a user's role.
+	 * Use `UserService.changeUserRole` instead.
 	 */
 	async update(...args: Parameters<Repository<User>['update']>) {
 		return await super.update(...args);

--- a/packages/cli/src/controllers/users.controller.ts
+++ b/packages/cli/src/controllers/users.controller.ts
@@ -344,7 +344,7 @@ export class UsersController {
 			throw new ForbiddenError(NO_OWNER_ON_OWNER);
 		}
 
-		await this.userService.changeUserRole(req.user, targetUser, payload);
+		await this.userService.changeUserRole(targetUser, payload);
 
 		this.eventService.emit('user-changed-role', {
 			userId: req.user.id,

--- a/packages/cli/src/modules/provisioning.ee/__tests__/provisioning.service.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/provisioning.service.ee.test.ts
@@ -20,10 +20,12 @@ import { type ProjectService } from '@/services/project.service.ee';
 import type { EntityManager } from '@n8n/typeorm';
 import { type InstanceSettings } from 'n8n-core';
 import { type EventService } from '@/events/event.service';
+import { type UserService } from '@/services/user.service';
 
 const globalConfig = mock<GlobalConfig>();
 const settingsRepository = mock<SettingsRepository>();
 const userRepository = mock<UserRepository>();
+const userService = mock<UserService>();
 const entityManager = mock<EntityManager>();
 const projectRepository = mock<ProjectRepository>({ manager: entityManager });
 const projectService = mock<ProjectService>();
@@ -42,6 +44,7 @@ const provisioningService = new ProvisioningService(
 	projectService,
 	roleRepository,
 	userRepository,
+	userService,
 	logger,
 	publisher,
 	instanceSettings,
@@ -230,55 +233,52 @@ describe('ProvisioningService', () => {
 			roleRepository.findOneOrFail.mockResolvedValue(
 				mock<Role>({ slug: 'global:member', roleType: 'global' }),
 			);
-
 			provisioningService['isInstanceRoleProvisioningEnabled'] = jest.fn().mockResolvedValue(true);
 
 			await provisioningService.provisionInstanceRoleForUser(user, roleSlug);
-			expect(userRepository.update).toHaveBeenCalledWith(user.id, { role: { slug: roleSlug } });
+
+			expect(userService.changeUserRole).toHaveBeenCalledWith(user, { newRoleName: roleSlug });
 			expect(logger.warn).not.toHaveBeenCalled();
 		});
 
 		it('should provision the instance role for the user', async () => {
 			const user = mock<User>({ role: { slug: 'global:member' } });
 			const roleSlug = 'global:owner';
-
 			roleRepository.findOneOrFail.mockResolvedValue(
 				mock<Role>({ slug: 'global:owner', roleType: 'global' }),
 			);
-
 			provisioningService['isInstanceRoleProvisioningEnabled'] = jest.fn().mockResolvedValue(true);
 
 			await provisioningService.provisionInstanceRoleForUser(user, roleSlug);
-			expect(userRepository.update).toHaveBeenCalledWith(user.id, { role: { slug: roleSlug } });
+
+			expect(userService.changeUserRole).toHaveBeenCalledWith(user, { newRoleName: roleSlug });
 		});
 
 		it('should do nothing if the role has not changed', async () => {
 			const user = mock<User>({ role: { slug: 'global:owner' } });
 			const roleSlug = 'global:owner';
-
 			roleRepository.findOneOrFail.mockResolvedValue(
 				mock<Role>({ slug: 'global:owner', roleType: 'global' }),
 			);
-
 			provisioningService['isInstanceRoleProvisioningEnabled'] = jest.fn().mockResolvedValue(true);
 
 			await provisioningService.provisionInstanceRoleForUser(user, roleSlug);
-			expect(userRepository.update).not.toHaveBeenCalled();
+
+			expect(userService.changeUserRole).not.toHaveBeenCalled();
 			expect(logger.warn).not.toHaveBeenCalled();
 		});
 
 		it('should do nothing if the role is not a global role', async () => {
 			const user = mock<User>({ role: { slug: 'global:member' } });
 			const roleSlug = 'global:owner';
-
 			roleRepository.findOneOrFail.mockResolvedValue(
 				mock<Role>({ slug: 'global:owner', roleType: 'project' }),
 			);
-
 			provisioningService['isInstanceRoleProvisioningEnabled'] = jest.fn().mockResolvedValue(true);
 
 			await provisioningService.provisionInstanceRoleForUser(user, roleSlug);
-			expect(userRepository.update).not.toHaveBeenCalled();
+
+			expect(userService.changeUserRole).not.toHaveBeenCalled();
 			expect(logger.warn).toHaveBeenCalledTimes(1);
 			expect(logger.warn).toHaveBeenCalledWith(
 				`Skipping instance role provisioning. Role ${roleSlug} is not a global role`,

--- a/packages/cli/src/modules/provisioning.ee/provisioning.service.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/provisioning.service.ee.ts
@@ -21,6 +21,7 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ZodError } from 'zod';
 import { ProjectService } from '@/services/project.service.ee';
 import { InstanceSettings } from 'n8n-core';
+import { UserService } from '@/services/user.service';
 
 @Service()
 export class ProvisioningService {
@@ -34,6 +35,7 @@ export class ProvisioningService {
 		private readonly projectService: ProjectService,
 		private readonly roleRepository: RoleRepository,
 		private readonly userRepository: UserRepository,
+		private readonly userService: UserService,
 		private readonly logger: Logger,
 		private readonly publisher: Publisher,
 		private readonly instanceSettings: InstanceSettings,
@@ -109,7 +111,7 @@ export class ProvisioningService {
 
 		// No need to update record if the role hasn't changed
 		if (user.role.slug !== dbRole.slug) {
-			await this.userRepository.update(user.id, { role: { slug: dbRole.slug } });
+			await this.userService.changeUserRole(user, { newRoleName: dbRole.slug });
 
 			this.eventService.emit('sso-user-instance-role-updated', {
 				userId: user.id,


### PR DESCRIPTION
## Summary

Prompted by this feedback: https://n8nio.slack.com/archives/C07SW3BQX8R/p1764169954671589?thread_ts=1764155219.129919&cid=C07SW3BQX8R 

We also know that more logic will be added in `UserService.changeUserRole` in the future, which we want to run when the role is changed via SSO config too.

## Related Linear tickets, Github issues, and Community forum posts

closes PAY-4187


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
