### PR TITLE
fix: Fix issue with credential overwrites not working with request defaults

### DIFF
--- a/packages/cli/src/__tests__/credentials-overwrites.test.ts
+++ b/packages/cli/src/__tests__/credentials-overwrites.test.ts
@@ -1242,9 +1242,9 @@ describe('CredentialsOverwrites', () => {
 
 			await localCredentialsOverwrites.init();
 
-			// null value should be overwritten
+			// null value should be overwritten (using as any to bypass type checking for test)
 			const result = localCredentialsOverwrites.applyOverwrite('test', {
-				subdomain: null,
+				subdomain: null as any,
 				clientId: 'client',
 			});
 
@@ -1268,9 +1268,9 @@ describe('CredentialsOverwrites', () => {
 
 			await localCredentialsOverwrites.init();
 
-			// undefined value should be overwritten
+			// undefined value should be overwritten (using as any to bypass type checking for test)
 			const result = localCredentialsOverwrites.applyOverwrite('test', {
-				token: undefined,
+				token: undefined as any,
 				apiKey: 'key',
 			});
 

--- a/packages/cli/src/credentials-helper.ts
+++ b/packages/cli/src/credentials-helper.ts
@@ -379,7 +379,7 @@ export class CredentialsHelper extends ICredentialsHelper {
 			credentialsProperties,
 			dataWithOverwrites as INodeParameters,
 			true,
-			false,
+			true,
 			null,
 			null,
 		) as ICredentialDataDecryptedObject;


### PR DESCRIPTION
## Summary
When using declarative nodes with `requestDefaults.baseURL` and Credential Overwrites the `{{ $credentials.x }}` expression failed to evaluate correctly possibly due to the field being hidden / not available at the time. This PR resolves that issue by making the value available and includes some tests.

### To Test
Enable Credential Overwrites Endpoint
`export CREDENTIALS_OVERWRITE_ENDPOINT=send-credentials`

Start n8n and run the node below changing the values as needed (For Sharepoint they can be found in the usual place)
```
{
  "nodes": [
    {
      "parameters": {},
      "type": "n8n-nodes-base.manualTrigger",
      "typeVersion": 1,
      "position": [
        0,
        0
      ],
      "id": "84693abb-3fe3-4725-a2d9-f1433dcfb48f",
      "name": "When clicking ‘Execute workflow’"
    },
    {
      "parameters": {
        "method": "POST",
        "url": "http://localhost:5678/send-credentials",
        "sendBody": true,
        "specifyBody": "json",
        "jsonBody": "{\n  \"microsoftSharePointOAuth2Api\": {\n    \"authUrl\": \"https://login.microsoftonline.com/common/oauth2/v2.0/authorize\",\n    \"accessTokenUrl\": \"https://login.microsoftonline.com/common/oauth2/v2.0/token\",\n    \"clientId\": \"<INSERT CLIENT ID>\",\n    \"clientSecret\": \"<INSERT CLIENT SECRET>\",\n    \"subdomain\": \"<INSERT SUBDOMAIN>\"\n  }\n}",
        "options": {}
      },
      "type": "n8n-nodes-base.httpRequest",
      "typeVersion": 4.3,
      "position": [
        208,
        0
      ],
      "id": "7af2f42d-0d0b-4090-8899-3bad8b7c3b10",
      "name": "HTTP Request"
    }
  ],
  "connections": {
    "When clicking ‘Execute workflow’": {
      "main": [
        [
          {
            "node": "HTTP Request",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {},
  "meta": {
    "instanceId": "8c8c5237b8e37b006a7adce87f4369350c58e41f3ca9de16196d3197f69eabcd"
  }
}
``` 

Add the node and do a test, Before using this PR you would see an error about the domain being incorrect.


## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-4004/sharepoint-node-enotfound-error-when-connecting-with-subdomain


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
