### PR TITLE
ci: Add 1.x branch support to CI workflows

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -8,7 +8,7 @@ on:
       - synchronize
     branches:
       - 'master'
-      - 'v1.x'
+      - '1.x'
 
 jobs:
   check-pr-title:

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -8,6 +8,7 @@ on:
       - synchronize
     branches:
       - 'master'
+      - 'v1.x'
 
 jobs:
   check-pr-title:

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - v1.x
     paths-ignore:
       - packages/@n8n/task-runner-python/**
 
@@ -48,4 +49,4 @@ jobs:
           status: ${{ job.status }}
           channel: '#alerts-build'
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          message: Master branch (build or test or lint) failed (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          message: ${{ github.ref_name }} branch (build or test or lint) failed (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - v1.x
+      - 1.x
     paths-ignore:
       - packages/@n8n/task-runner-python/**
 


### PR DESCRIPTION
## Summary
@tomi - `Note: We would need to set-up a branch protection rules same as for v2-dev and master`
Adds CI support for the upcoming 1.x maintenance branch.

- Add `1.x` to `ci-master.yml` trigger branches
- Make Slack notification message dynamic (shows actual branch name)
- Add `1.x` to `check-pr-title.yml` for PR validation
- CI will run on v1.x branch pushes after this merges
- PR title validation will work for PRs targeting 1.x
- Slack notifications will show the correct branch name

## Related Linear tickets, Github issues, and Community forum posts
- https://linear.app/n8n/issue/CAT-1824
- https://linear.app/n8n/issue/CAT-1825
- Parent: https://linear.app/n8n/issue/CAT-1823


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
