### PR TITLE
ci: Add RC release type for v2 release candidates

### DIFF
--- a/.github/workflows/release-create-pr.yml
+++ b/.github/workflows/release-create-pr.yml
@@ -18,6 +18,7 @@ on:
           - minor
           - major
           - experimental
+          - rc
 
 jobs:
   create-release-pr:


### PR DESCRIPTION
## Summary
Adds `rc` release type option for creating v2 release candidates (2.0.0-rc.0, 2.0.0-rc.1, etc.).

- Added `rc` to release-type options in `release-create-pr.yml`
- Added `generateRcVersion()` function in `bump-versions.mjs`
- Updated RELEASE_TYPE regex to include `rc`

## Related Linear tickets, Github issues, and Community forum posts
- https://linear.app/n8n/issue/CAT-1826
- Parent: https://linear.app/n8n/issue/CAT-1823

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
