### PR TITLE
ci: Auto-detect release_type for Docker builds

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -285,7 +285,9 @@ jobs:
     if: |
       success() &&
       (needs.determine-build-context.outputs.release_type == 'stable' ||
-       needs.determine-build-context.outputs.release_type == 'nightly')
+       needs.determine-build-context.outputs.release_type == 'nightly' ||
+       needs.determine-build-context.outputs.release_type == '1' ||
+       needs.determine-build-context.outputs.release_type == 'rc')
     uses: ./.github/workflows/security-trivy-scan-callable.yml
     with:
       image_ref: ${{ needs.build-and-push-docker.outputs.image_ref }}
@@ -297,7 +299,9 @@ jobs:
     if: |
       success() &&
       (needs.determine-build-context.outputs.release_type == 'stable' ||
-      needs.determine-build-context.outputs.release_type == 'nightly')
+       needs.determine-build-context.outputs.release_type == 'nightly' ||
+       needs.determine-build-context.outputs.release_type == '1' ||
+       needs.determine-build-context.outputs.release_type == 'rc')
     uses: ./.github/workflows/security-trivy-scan-callable.yml
     with:
       image_ref: ${{ needs.build-and-push-docker.outputs.runners_primary_ghcr_manifest_tag }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -34,6 +34,7 @@ jobs:
       NPM_CONFIG_PROVENANCE: true
     outputs:
       release: ${{ steps.set-release.outputs.release }}
+      release_type: ${{ steps.release-type.outputs.type }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -73,8 +74,21 @@ jobs:
         run: npm dist-tag rm n8n rc
         continue-on-error: true
 
-      - id: set-release
+      - name: Set release version
+        id: set-release
         run: echo "release=${{ env.RELEASE }}" >> "$GITHUB_OUTPUT"
+
+      - name: Determine release type
+        id: release-type
+        run: |
+          VERSION="${{ env.RELEASE }}"
+          if [[ "$VERSION" == *"-rc."* ]]; then
+            echo "type=rc" >> "$GITHUB_OUTPUT"
+          elif [[ "$VERSION" == 1.* ]]; then
+            echo "type=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "type=stable" >> "$GITHUB_OUTPUT"
+          fi
 
   publish-to-docker-hub:
     name: Publish to DockerHub
@@ -82,7 +96,7 @@ jobs:
     uses: ./.github/workflows/docker-build-push.yml
     with:
       n8n_version: ${{ needs.publish-to-npm.outputs.release }}
-      release_type: stable
+      release_type: ${{ needs.publish-to-npm.outputs.release_type }}
     secrets: inherit
 
   create-github-release:

--- a/packages/@n8n/api-types/src/frontend-settings.ts
+++ b/packages/@n8n/api-types/src/frontend-settings.ts
@@ -96,7 +96,7 @@ export interface FrontendSettings {
 		secure: boolean;
 	};
 	binaryDataMode: 'default' | 'filesystem' | 's3' | 'database';
-	releaseChannel: 'stable' | 'beta' | 'nightly' | 'dev';
+	releaseChannel: 'stable' | 'beta' | 'nightly' | 'dev' | '1' | 'rc';
 	n8nMetadata?: {
 		userId?: string;
 		[key: string]: string | number | undefined;

--- a/packages/@n8n/config/src/configs/generic.config.ts
+++ b/packages/@n8n/config/src/configs/generic.config.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { Config, Env } from '../decorators';
 
-const releaseChannelSchema = z.enum(['stable', 'beta', 'nightly', 'dev']);
+const releaseChannelSchema = z.enum(['stable', 'beta', 'nightly', 'dev', '1', 'rc']);
 type ReleaseChannel = z.infer<typeof releaseChannelSchema>;
 
 @Config

--- a/packages/frontend/@n8n/design-system/src/components/N8nLogo/Logo.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nLogo/Logo.vue
@@ -15,7 +15,7 @@ const props = defineProps<
 				collapsed: boolean;
 		  }
 	) & {
-		releaseChannel?: 'stable' | 'beta' | 'nightly' | 'dev';
+		releaseChannel?: 'stable' | 'beta' | 'nightly' | 'dev' | '1' | 'rc';
 	}
 >();
 


### PR DESCRIPTION
## Summary
Note: has to be merged on last minor release before v2.
Auto-detect `N8N_RELEASE_TYPE` from version string instead of hardcoding 'stable' for all releases.

### 1. Config schema (`generic.config.ts`)
Added '1' and 'rc' to release channel schema to allow these values at runtime.

### 2. Release detection (`release-publish.yml`)
New step to detect release type from version:
- `-rc.` → 'rc' (release candidates)
- `1.x.x` → '1' (v1 maintenance)
- else → 'stable' (includes v2 and experimental)

### 3. Security scans (`docker-build-push.yml`)
Run security scans for '1' and 'rc' release types (in addition to existing 'stable' and 'nightly').

## Related Linear tickets, Github issues, and Community forum posts
- https://linear.app/n8n/issue/CAT-1827
- Parent: https://linear.app/n8n/issue/CAT-1823


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
