### PR TITLE
feat(core): Use new workflow history in mcp tools

### DIFF
--- a/packages/@n8n/db/src/repositories/workflow.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow.repository.ts
@@ -702,7 +702,7 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 
 		// Handle special fields separately
 		const regularFields = Object.entries(select).filter(
-			([field]) => !['ownedBy', 'tags', 'parentFolder'].includes(field),
+			([field]) => !['ownedBy', 'tags', 'parentFolder', 'activeVersion'].includes(field),
 		);
 
 		// Add regular fields
@@ -725,6 +725,7 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 		const areTagsRequested = isDefaultSelect || select?.tags;
 		const isOwnedByIncluded = isDefaultSelect || select?.ownedBy;
 		const isParentFolderIncluded = isDefaultSelect || select?.parentFolder;
+		const isActiveVersionIncluded = select?.activeVersion;
 
 		if (isParentFolderIncluded) {
 			qb.leftJoin('workflow.parentFolder', 'parentFolder').addSelect([
@@ -741,6 +742,18 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 		if (isOwnedByIncluded) {
 			this.applyOwnedByRelation(qb);
 		}
+
+		if (isActiveVersionIncluded) {
+			this.applyActiveVersionRelation(qb);
+		}
+	}
+
+	private applyActiveVersionRelation(qb: SelectQueryBuilder<WorkflowEntity>): void {
+		qb.leftJoin('workflow.activeVersion', 'activeVersion').addSelect([
+			'activeVersion.versionId',
+			'activeVersion.nodes',
+			'activeVersion.connections',
+		]);
 	}
 
 	private applyTagsRelation(qb: SelectQueryBuilder<WorkflowEntity>): void {

--- a/packages/cli/src/modules/mcp/__tests__/execute-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/execute-workflow.tool.test.ts
@@ -87,7 +87,7 @@ describe('execute-workflow MCP tool', () => {
 			});
 
 			test('throws error when workflow is archived', async () => {
-				const workflow = createWorkflow({ isArchived: true });
+				const workflow = createWorkflow({ activeVersionId: uuid(), isArchived: true });
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 
 				await expect(
@@ -103,7 +103,10 @@ describe('execute-workflow MCP tool', () => {
 			});
 
 			test('throws error when workflow is not available in MCP', async () => {
-				const workflow = createWorkflow({ settings: { availableInMCP: false } });
+				const workflow = createWorkflow({
+					activeVersionId: uuid(),
+					settings: { availableInMCP: false },
+				});
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 
 				await expect(
@@ -120,6 +123,7 @@ describe('execute-workflow MCP tool', () => {
 
 			test('throws error when workflow has unsupported trigger nodes', async () => {
 				const workflow = createWorkflow({
+					activeVersionId: uuid(),
 					nodes: [
 						{
 							id: 'node-1',
@@ -159,6 +163,7 @@ describe('execute-workflow MCP tool', () => {
 
 			test('throws error when no supported trigger node is found', async () => {
 				const workflow = createWorkflow({
+					activeVersionId: uuid(),
 					nodes: [
 						{
 							id: 'node-1',

--- a/packages/cli/src/modules/mcp/__tests__/execute-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/execute-workflow.tool.test.ts
@@ -188,6 +188,7 @@ describe('execute-workflow MCP tool', () => {
 		describe('webhook trigger execution', () => {
 			test('executes workflow with webhook trigger and webhook data', async () => {
 				const workflow = createWorkflow({
+					activeVersionId: new Date().getTime(),
 					nodes: [
 						{
 							id: 'node-1',
@@ -257,6 +258,7 @@ describe('execute-workflow MCP tool', () => {
 
 			test('executes workflow with webhook trigger and default GET method', async () => {
 				const workflow = createWorkflow({
+					activeVersionId: new Date().getTime(),
 					nodes: [
 						{
 							id: 'node-1',
@@ -310,6 +312,7 @@ describe('execute-workflow MCP tool', () => {
 		describe('chat trigger execution', () => {
 			test('executes workflow with chat trigger and chat input', async () => {
 				const workflow = createWorkflow({
+					activeVersionId: new Date().getTime(),
 					nodes: [
 						{
 							id: 'node-1',
@@ -366,6 +369,7 @@ describe('execute-workflow MCP tool', () => {
 		describe('form trigger execution', () => {
 			test('executes workflow with form trigger and form data', async () => {
 				const workflow = createWorkflow({
+					activeVersionId: new Date().getTime(),
 					nodes: [
 						{
 							id: 'node-1',
@@ -428,6 +432,7 @@ describe('execute-workflow MCP tool', () => {
 		describe('execution results handling', () => {
 			test('handles successful execution', async () => {
 				const workflow = createWorkflow({
+					activeVersionId: new Date().getTime(),
 					nodes: [
 						{
 							id: 'node-1',
@@ -473,6 +478,7 @@ describe('execute-workflow MCP tool', () => {
 
 			test('handles execution with error status', async () => {
 				const workflow = createWorkflow({
+					activeVersionId: new Date().getTime(),
 					nodes: [
 						{
 							id: 'node-1',
@@ -520,6 +526,7 @@ describe('execute-workflow MCP tool', () => {
 
 			test('handles execution with result data error', async () => {
 				const workflow = createWorkflow({
+					activeVersionId: new Date().getTime(),
 					nodes: [
 						{
 							id: 'node-1',
@@ -567,6 +574,7 @@ describe('execute-workflow MCP tool', () => {
 
 			test('handles workflow returning undefined data', async () => {
 				const workflow = createWorkflow({
+					activeVersionId: new Date().getTime(),
 					nodes: [
 						{
 							id: 'node-1',
@@ -610,6 +618,7 @@ describe('execute-workflow MCP tool', () => {
 		describe('workflow with no inputs', () => {
 			test('executes workflow without any inputs', async () => {
 				const workflow = createWorkflow({
+					activeVersionId: new Date().getTime(),
 					nodes: [
 						{
 							id: 'node-1',
@@ -657,6 +666,7 @@ describe('execute-workflow MCP tool', () => {
 		describe('telemetry tracking', () => {
 			test('tracks successful execution with tool handler', async () => {
 				const workflow = createWorkflow({
+					activeVersionId: new Date().getTime(),
 					nodes: [
 						{
 							id: 'node-1',
@@ -745,6 +755,7 @@ describe('execute-workflow MCP tool', () => {
 		describe('multiple trigger nodes', () => {
 			test('uses first eligible trigger node when multiple are present', async () => {
 				const workflow = createWorkflow({
+					activeVersionId: new Date().getTime(),
 					nodes: [
 						{
 							id: 'node-1',

--- a/packages/cli/src/modules/mcp/__tests__/execute-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/execute-workflow.tool.test.ts
@@ -18,6 +18,7 @@ import { ActiveExecutions } from '@/active-executions';
 import { Telemetry } from '@/telemetry';
 import { WorkflowRunner } from '@/workflow-runner';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
+import { v4 as uuid } from 'uuid';
 
 describe('execute-workflow MCP tool', () => {
 	const user = Object.assign(new User(), { id: 'user-1' });
@@ -188,7 +189,7 @@ describe('execute-workflow MCP tool', () => {
 		describe('webhook trigger execution', () => {
 			test('executes workflow with webhook trigger and webhook data', async () => {
 				const workflow = createWorkflow({
-					activeVersionId: new Date().getTime().toString().toString(),
+					activeVersionId: uuid(),
 					nodes: [
 						{
 							id: 'node-1',
@@ -258,7 +259,7 @@ describe('execute-workflow MCP tool', () => {
 
 			test('executes workflow with webhook trigger and default GET method', async () => {
 				const workflow = createWorkflow({
-					activeVersionId: new Date().getTime().toString().toString(),
+					activeVersionId: uuid(),
 					nodes: [
 						{
 							id: 'node-1',
@@ -312,7 +313,7 @@ describe('execute-workflow MCP tool', () => {
 		describe('chat trigger execution', () => {
 			test('executes workflow with chat trigger and chat input', async () => {
 				const workflow = createWorkflow({
-					activeVersionId: new Date().getTime().toString().toString(),
+					activeVersionId: uuid(),
 					nodes: [
 						{
 							id: 'node-1',
@@ -369,7 +370,7 @@ describe('execute-workflow MCP tool', () => {
 		describe('form trigger execution', () => {
 			test('executes workflow with form trigger and form data', async () => {
 				const workflow = createWorkflow({
-					activeVersionId: new Date().getTime().toString().toString(),
+					activeVersionId: uuid(),
 					nodes: [
 						{
 							id: 'node-1',
@@ -432,7 +433,7 @@ describe('execute-workflow MCP tool', () => {
 		describe('execution results handling', () => {
 			test('handles successful execution', async () => {
 				const workflow = createWorkflow({
-					activeVersionId: new Date().getTime().toString().toString(),
+					activeVersionId: uuid(),
 					nodes: [
 						{
 							id: 'node-1',
@@ -478,7 +479,7 @@ describe('execute-workflow MCP tool', () => {
 
 			test('handles execution with error status', async () => {
 				const workflow = createWorkflow({
-					activeVersionId: new Date().getTime().toString().toString(),
+					activeVersionId: uuid(),
 					nodes: [
 						{
 							id: 'node-1',
@@ -526,7 +527,7 @@ describe('execute-workflow MCP tool', () => {
 
 			test('handles execution with result data error', async () => {
 				const workflow = createWorkflow({
-					activeVersionId: new Date().getTime().toString().toString(),
+					activeVersionId: uuid(),
 					nodes: [
 						{
 							id: 'node-1',
@@ -574,7 +575,7 @@ describe('execute-workflow MCP tool', () => {
 
 			test('handles workflow returning undefined data', async () => {
 				const workflow = createWorkflow({
-					activeVersionId: new Date().getTime().toString().toString(),
+					activeVersionId: uuid(),
 					nodes: [
 						{
 							id: 'node-1',
@@ -618,7 +619,7 @@ describe('execute-workflow MCP tool', () => {
 		describe('workflow with no inputs', () => {
 			test('executes workflow without any inputs', async () => {
 				const workflow = createWorkflow({
-					activeVersionId: new Date().getTime().toString().toString(),
+					activeVersionId: uuid(),
 					nodes: [
 						{
 							id: 'node-1',
@@ -666,7 +667,7 @@ describe('execute-workflow MCP tool', () => {
 		describe('telemetry tracking', () => {
 			test('tracks successful execution with tool handler', async () => {
 				const workflow = createWorkflow({
-					activeVersionId: new Date().getTime().toString().toString(),
+					activeVersionId: uuid(),
 					nodes: [
 						{
 							id: 'node-1',
@@ -755,7 +756,7 @@ describe('execute-workflow MCP tool', () => {
 		describe('multiple trigger nodes', () => {
 			test('uses first eligible trigger node when multiple are present', async () => {
 				const workflow = createWorkflow({
-					activeVersionId: new Date().getTime().toString().toString(),
+					activeVersionId: uuid(),
 					nodes: [
 						{
 							id: 'node-1',

--- a/packages/cli/src/modules/mcp/__tests__/execute-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/execute-workflow.tool.test.ts
@@ -188,7 +188,7 @@ describe('execute-workflow MCP tool', () => {
 		describe('webhook trigger execution', () => {
 			test('executes workflow with webhook trigger and webhook data', async () => {
 				const workflow = createWorkflow({
-					activeVersionId: new Date().getTime(),
+					activeVersionId: new Date().getTime().toString().toString(),
 					nodes: [
 						{
 							id: 'node-1',
@@ -258,7 +258,7 @@ describe('execute-workflow MCP tool', () => {
 
 			test('executes workflow with webhook trigger and default GET method', async () => {
 				const workflow = createWorkflow({
-					activeVersionId: new Date().getTime(),
+					activeVersionId: new Date().getTime().toString().toString(),
 					nodes: [
 						{
 							id: 'node-1',
@@ -312,7 +312,7 @@ describe('execute-workflow MCP tool', () => {
 		describe('chat trigger execution', () => {
 			test('executes workflow with chat trigger and chat input', async () => {
 				const workflow = createWorkflow({
-					activeVersionId: new Date().getTime(),
+					activeVersionId: new Date().getTime().toString().toString(),
 					nodes: [
 						{
 							id: 'node-1',
@@ -369,7 +369,7 @@ describe('execute-workflow MCP tool', () => {
 		describe('form trigger execution', () => {
 			test('executes workflow with form trigger and form data', async () => {
 				const workflow = createWorkflow({
-					activeVersionId: new Date().getTime(),
+					activeVersionId: new Date().getTime().toString().toString(),
 					nodes: [
 						{
 							id: 'node-1',
@@ -432,7 +432,7 @@ describe('execute-workflow MCP tool', () => {
 		describe('execution results handling', () => {
 			test('handles successful execution', async () => {
 				const workflow = createWorkflow({
-					activeVersionId: new Date().getTime(),
+					activeVersionId: new Date().getTime().toString().toString(),
 					nodes: [
 						{
 							id: 'node-1',
@@ -478,7 +478,7 @@ describe('execute-workflow MCP tool', () => {
 
 			test('handles execution with error status', async () => {
 				const workflow = createWorkflow({
-					activeVersionId: new Date().getTime(),
+					activeVersionId: new Date().getTime().toString().toString(),
 					nodes: [
 						{
 							id: 'node-1',
@@ -526,7 +526,7 @@ describe('execute-workflow MCP tool', () => {
 
 			test('handles execution with result data error', async () => {
 				const workflow = createWorkflow({
-					activeVersionId: new Date().getTime(),
+					activeVersionId: new Date().getTime().toString().toString(),
 					nodes: [
 						{
 							id: 'node-1',
@@ -574,7 +574,7 @@ describe('execute-workflow MCP tool', () => {
 
 			test('handles workflow returning undefined data', async () => {
 				const workflow = createWorkflow({
-					activeVersionId: new Date().getTime(),
+					activeVersionId: new Date().getTime().toString().toString(),
 					nodes: [
 						{
 							id: 'node-1',
@@ -618,7 +618,7 @@ describe('execute-workflow MCP tool', () => {
 		describe('workflow with no inputs', () => {
 			test('executes workflow without any inputs', async () => {
 				const workflow = createWorkflow({
-					activeVersionId: new Date().getTime(),
+					activeVersionId: new Date().getTime().toString().toString(),
 					nodes: [
 						{
 							id: 'node-1',
@@ -666,7 +666,7 @@ describe('execute-workflow MCP tool', () => {
 		describe('telemetry tracking', () => {
 			test('tracks successful execution with tool handler', async () => {
 				const workflow = createWorkflow({
-					activeVersionId: new Date().getTime(),
+					activeVersionId: new Date().getTime().toString().toString(),
 					nodes: [
 						{
 							id: 'node-1',
@@ -755,7 +755,7 @@ describe('execute-workflow MCP tool', () => {
 		describe('multiple trigger nodes', () => {
 			test('uses first eligible trigger node when multiple are present', async () => {
 				const workflow = createWorkflow({
-					activeVersionId: new Date().getTime(),
+					activeVersionId: new Date().getTime().toString().toString(),
 					nodes: [
 						{
 							id: 'node-1',

--- a/packages/cli/src/modules/mcp/__tests__/get-workflow-details.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/get-workflow-details.tool.test.ts
@@ -8,6 +8,8 @@ import { CredentialsService } from '@/credentials/credentials.service';
 import { Telemetry } from '@/telemetry';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
+import { v4 as uuid } from 'uuid';
+
 jest.mock('../tools/webhook-utils', () => ({
 	getTriggerDetails: jest.fn().mockResolvedValue('MOCK_TRIGGER_DETAILS'),
 }));
@@ -46,7 +48,7 @@ describe('get-workflow-details MCP tool', () => {
 
 	describe('handler tests', () => {
 		test('returns sanitized workflow and trigger info (active)', async () => {
-			const workflow = createWorkflow({ active: true });
+			const workflow = createWorkflow({ activeVersionId: uuid() });
 			const workflowFinderService = mockInstance(WorkflowFinderService, {
 				findWorkflowForUser: jest.fn().mockResolvedValue(workflow),
 			});
@@ -68,8 +70,11 @@ describe('get-workflow-details MCP tool', () => {
 		});
 
 		test('throws for not found/archived/unavailable workflow', async () => {
-			const archived = createWorkflow({ isArchived: true });
-			const unavailable = createWorkflow({ settings: { availableInMCP: false } });
+			const archived = createWorkflow({ activeVersionId: uuid(), isArchived: true });
+			const unavailable = createWorkflow({
+				activeVersionId: uuid(),
+				settings: { availableInMCP: false },
+			});
 
 			const credentialsService = mockInstance(CredentialsService, {});
 			const endpoints = { webhook: 'webhook', webhookTest: 'webhook-test' };

--- a/packages/cli/src/modules/mcp/__tests__/mcp.settings.controller.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp.settings.controller.test.ts
@@ -284,6 +284,7 @@ describe('McpSettingsController', () => {
 		test('persists MCP availability when validation passes', async () => {
 			const workflow = createWorkflow({
 				activeVersionId: uuid(),
+				settings: { saveManualExecutions: true },
 				nodes: [
 					createWebhookNode({ disabled: false }),
 					{
@@ -313,7 +314,7 @@ describe('McpSettingsController', () => {
 			expect(updateArgs[0]).toEqual(user);
 			expect(updateArgs[1]).toBeInstanceOf(WorkflowEntity);
 			expect(updateArgs[1].settings).toEqual({ saveManualExecutions: true, availableInMCP: true });
-			expect(updateArgs[1].versionId).toEqual('current-version-id');
+			expect(updateArgs[1].versionId).toEqual('some-version-id');
 			expect(updateArgs[2]).toEqual(workflowId);
 			expect(updateArgs[5]).toEqual(false);
 

--- a/packages/cli/src/modules/mcp/__tests__/mcp.settings.controller.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp.settings.controller.test.ts
@@ -4,11 +4,13 @@ import { Container } from '@n8n/di';
 import type { Response } from 'express';
 import { mock, mockDeep } from 'jest-mock-extended';
 import { HTTP_REQUEST_NODE_TYPE, WEBHOOK_NODE_TYPE, type INode } from 'n8n-workflow';
+import { v4 as uuid } from 'uuid';
 
 import { UpdateMcpSettingsDto } from '../dto/update-mcp-settings.dto';
 import { McpServerApiKeyService } from '../mcp-api-key.service';
 import { McpSettingsController } from '../mcp.settings.controller';
 import { McpSettingsService } from '../mcp.settings.service';
+import { createWorkflow } from './mock.utils';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
@@ -199,22 +201,6 @@ describe('McpSettingsController', () => {
 			...overrides,
 		});
 
-		const createWorkflow = (overrides: Partial<WorkflowEntity> = {}) => {
-			const entity = new WorkflowEntity();
-			entity.id = workflowId;
-			entity.active = true;
-			entity.activeVersionId = overrides.active === false ? null : 'current-version-id';
-			entity.nodes = overrides.nodes ?? [createWebhookNode()];
-			entity.settings = { saveManualExecutions: true };
-			entity.versionId = 'current-version-id';
-			// @ts-expect-error activeVersion is a relation, not a plain property
-			entity.activeVersion =
-				overrides.active === false
-					? undefined
-					: { nodes: overrides.nodes ?? [createWebhookNode()] };
-			return Object.assign(entity, overrides);
-		};
-
 		test('throws when workflow cannot be accessed', async () => {
 			workflowFinderService.findWorkflowForUser.mockResolvedValue(null);
 			const req = createReq({}, { user });
@@ -233,7 +219,7 @@ describe('McpSettingsController', () => {
 
 		test('rejects enabling MCP for inactive workflows', async () => {
 			workflowFinderService.findWorkflowForUser.mockResolvedValue(
-				createWorkflow({ active: false }),
+				createWorkflow({ activeVersionId: null }),
 			);
 
 			await expect(
@@ -247,7 +233,7 @@ describe('McpSettingsController', () => {
 
 		test('allows disabling MCP for inactive workflows', async () => {
 			workflowFinderService.findWorkflowForUser.mockResolvedValue(
-				createWorkflow({ active: false }),
+				createWorkflow({ activeVersionId: null }),
 			);
 			workflowService.update.mockResolvedValue({
 				id: workflowId,
@@ -267,6 +253,7 @@ describe('McpSettingsController', () => {
 		test('rejects enabling MCP without active webhook nodes', async () => {
 			workflowFinderService.findWorkflowForUser.mockResolvedValue(
 				createWorkflow({
+					activeVersionId: uuid(),
 					nodes: [
 						createWebhookNode({ disabled: true }),
 						{
@@ -295,7 +282,20 @@ describe('McpSettingsController', () => {
 		});
 
 		test('persists MCP availability when validation passes', async () => {
-			const workflow = createWorkflow();
+			const workflow = createWorkflow({
+				activeVersionId: uuid(),
+				nodes: [
+					createWebhookNode({ disabled: false }),
+					{
+						id: 'node-2',
+						name: 'HTTP Request',
+						type: HTTP_REQUEST_NODE_TYPE,
+						typeVersion: 1,
+						position: [10, 10],
+						parameters: {},
+					},
+				],
+			});
 			workflowFinderService.findWorkflowForUser.mockResolvedValue(workflow);
 			workflowService.update.mockResolvedValue({
 				id: workflowId,

--- a/packages/cli/src/modules/mcp/__tests__/mcp.settings.controller.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp.settings.controller.test.ts
@@ -204,9 +204,14 @@ describe('McpSettingsController', () => {
 			entity.id = workflowId;
 			entity.active = true;
 			entity.activeVersionId = overrides.active === false ? null : 'current-version-id';
-			entity.nodes = [createWebhookNode()];
+			entity.nodes = overrides.nodes ?? [createWebhookNode()];
 			entity.settings = { saveManualExecutions: true };
 			entity.versionId = 'current-version-id';
+			// @ts-expect-error activeVersion is a relation, not a plain property
+			entity.activeVersion =
+				overrides.active === false
+					? undefined
+					: { nodes: overrides.nodes ?? [createWebhookNode()] };
 			return Object.assign(entity, overrides);
 		};
 

--- a/packages/cli/src/modules/mcp/__tests__/mock.utils.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mock.utils.ts
@@ -24,21 +24,23 @@ const testNodes = [
 	},
 ];
 
-export const createWorkflow = (overrides: Partial<WorkflowEntity> = {}) => ({
-	id: 'wf-1',
-	name: 'My wf',
-	nodes: overrides.nodes ?? testNodes,
-	active: overrides.active ?? false,
-	versionId: 'some-version-id',
-	activeVersionId: overrides.activeVersionId ? 'some-version-id' : null,
-	isArchived: overrides.isArchived ?? false,
-	createdAt: overrides.createdAt ?? new Date('2024-01-01T00:00:00.000Z'),
-	updatedAt: overrides.updatedAt ?? new Date('2024-01-02T00:00:00.000Z'),
-	triggerCount: overrides.triggerCount ?? 1,
-	settings: overrides.settings ?? { availableInMCP: true },
-	pinData: overrides.pinData ?? { should: 'be-removed' },
-	activeVersion: overrides.activeVersion ?? {
+export const createWorkflow = (overrides: Partial<WorkflowEntity> = {}) => {
+	const activeVersionId = overrides.activeVersionId ?? null;
+	const testActiveVersion = overrides.activeVersion ?? { nodes: overrides.nodes ?? testNodes };
+	const activeVersion = activeVersionId ? testActiveVersion : undefined;
+	return {
+		id: 'wf-1',
+		name: 'My wf',
 		nodes: overrides.nodes ?? testNodes,
-	},
-	...overrides,
-});
+		versionId: 'some-version-id',
+		activeVersionId,
+		isArchived: overrides.isArchived ?? false,
+		createdAt: overrides.createdAt ?? new Date('2024-01-01T00:00:00.000Z'),
+		updatedAt: overrides.updatedAt ?? new Date('2024-01-02T00:00:00.000Z'),
+		triggerCount: overrides.triggerCount ?? 1,
+		settings: overrides.settings ?? { availableInMCP: true },
+		pinData: overrides.pinData ?? { should: 'be-removed' },
+		activeVersion,
+		...overrides,
+	};
+};

--- a/packages/cli/src/modules/mcp/__tests__/mock.utils.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mock.utils.ts
@@ -34,6 +34,7 @@ export const createWorkflow = (overrides: Partial<WorkflowEntity> = {}) => {
 		nodes: overrides.nodes ?? testNodes,
 		versionId: 'some-version-id',
 		activeVersionId,
+		active: activeVersionId !== null,
 		isArchived: overrides.isArchived ?? false,
 		createdAt: overrides.createdAt ?? new Date('2024-01-01T00:00:00.000Z'),
 		updatedAt: overrides.updatedAt ?? new Date('2024-01-02T00:00:00.000Z'),

--- a/packages/cli/src/modules/mcp/__tests__/mock.utils.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mock.utils.ts
@@ -1,7 +1,7 @@
 import type { WorkflowEntity } from '@n8n/db';
-import { MANUAL_TRIGGER_NODE_TYPE, WEBHOOK_NODE_TYPE } from 'n8n-workflow';
+import { MANUAL_TRIGGER_NODE_TYPE, WEBHOOK_NODE_TYPE, type INode } from 'n8n-workflow';
 
-const testNodes = [
+const testNodes: INode[] = [
 	{
 		id: 'node-1',
 		name: 'Webhook',
@@ -24,14 +24,16 @@ const testNodes = [
 	},
 ];
 
-export const createWorkflow = (overrides: Partial<WorkflowEntity> = {}) => {
+export const createWorkflow = (overrides: Partial<WorkflowEntity> = {}): WorkflowEntity => {
 	const activeVersionId = overrides.activeVersionId ?? null;
 	const testActiveVersion = overrides.activeVersion ?? { nodes: overrides.nodes ?? testNodes };
 	const activeVersion = activeVersionId ? testActiveVersion : undefined;
 	return {
 		id: 'wf-1',
 		name: 'My wf',
+		description: null,
 		nodes: overrides.nodes ?? testNodes,
+		connections: {},
 		versionId: 'some-version-id',
 		activeVersionId,
 		active: activeVersionId !== null,
@@ -43,5 +45,5 @@ export const createWorkflow = (overrides: Partial<WorkflowEntity> = {}) => {
 		pinData: overrides.pinData ?? { should: 'be-removed' },
 		activeVersion,
 		...overrides,
-	};
+	} as WorkflowEntity;
 };

--- a/packages/cli/src/modules/mcp/__tests__/mock.utils.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mock.utils.ts
@@ -1,39 +1,44 @@
 import type { WorkflowEntity } from '@n8n/db';
 import { MANUAL_TRIGGER_NODE_TYPE, WEBHOOK_NODE_TYPE } from 'n8n-workflow';
 
+const testNodes = [
+	{
+		id: 'node-1',
+		name: 'Webhook',
+		type: WEBHOOK_NODE_TYPE,
+		typeVersion: 1,
+		position: [0, 0],
+		disabled: false,
+		parameters: {},
+		credentials: { httpHeaderAuth: { id: 'cred-1', name: 'HeaderAuth' } },
+	},
+	{
+		id: 'node-2',
+		name: 'Start',
+		type: MANUAL_TRIGGER_NODE_TYPE,
+		typeVersion: 1,
+		position: [100, 0],
+		disabled: false,
+		parameters: {},
+		credentials: { httpHeaderAuth: { id: 'cred-2', name: 'HeaderAuth2' } },
+	},
+];
+
 export const createWorkflow = (overrides: Partial<WorkflowEntity> = {}) => ({
 	id: 'wf-1',
 	name: 'My wf',
-	nodes: overrides.nodes ?? [
-		{
-			id: 'node-1',
-			name: 'Webhook',
-			type: WEBHOOK_NODE_TYPE,
-			typeVersion: 1,
-			position: [0, 0],
-			disabled: false,
-			parameters: {},
-			credentials: { httpHeaderAuth: { id: 'cred-1', name: 'HeaderAuth' } },
-		},
-		{
-			id: 'node-2',
-			name: 'Start',
-			type: MANUAL_TRIGGER_NODE_TYPE,
-			typeVersion: 1,
-			position: [100, 0],
-			disabled: false,
-			parameters: {},
-			credentials: { httpHeaderAuth: { id: 'cred-2', name: 'HeaderAuth2' } },
-		},
-	],
+	nodes: overrides.nodes ?? testNodes,
 	active: overrides.active ?? false,
 	versionId: 'some-version-id',
-	activeVersionId: overrides.active ? 'some-version-id' : null,
+	activeVersionId: overrides.activeVersionId ? 'some-version-id' : null,
 	isArchived: overrides.isArchived ?? false,
 	createdAt: overrides.createdAt ?? new Date('2024-01-01T00:00:00.000Z'),
 	updatedAt: overrides.updatedAt ?? new Date('2024-01-02T00:00:00.000Z'),
 	triggerCount: overrides.triggerCount ?? 1,
 	settings: overrides.settings ?? { availableInMCP: true },
 	pinData: overrides.pinData ?? { should: 'be-removed' },
+	activeVersion: overrides.activeVersion ?? {
+		nodes: overrides.nodes ?? testNodes,
+	},
 	...overrides,
 });

--- a/packages/cli/src/modules/mcp/__tests__/search-workflows.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/search-workflows.tool.test.ts
@@ -19,6 +19,7 @@ describe('search-workflows MCP tool', () => {
 			const workflows = [
 				createWorkflow({
 					id: 'wrap-1',
+					activeVersionId: uuid(),
 					name: 'Wrapper',
 					nodes: [{ name: 'Start', type: MANUAL_TRIGGER_NODE_TYPE } as INode],
 				}),
@@ -96,7 +97,7 @@ describe('search-workflows MCP tool', () => {
 		});
 
 		test('applies provided filters and clamps high limit', async () => {
-			const workflows = [createWorkflow({ id: 'x', active: true })];
+			const workflows = [createWorkflow({ id: 'x', activeVersionId: uuid() })];
 			const workflowService = mockInstance(WorkflowService, {
 				getMany: jest.fn().mockResolvedValue({ workflows, count: 1 }),
 			});
@@ -128,7 +129,9 @@ describe('search-workflows MCP tool', () => {
 		});
 
 		test('formats nodes as empty array when missing', async () => {
-			const workflows = [createWorkflow({ id: 'no-nodes', activeVersion: undefined })];
+			const workflows = [
+				createWorkflow({ id: 'no-nodes', activeVersionId: 'version-no-nodes', nodes: [] }),
+			];
 			const workflowService = mockInstance(WorkflowService, {
 				getMany: jest.fn().mockResolvedValue({ workflows, count: 1 }),
 			});

--- a/packages/cli/src/modules/mcp/__tests__/search-workflows.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/search-workflows.tool.test.ts
@@ -49,7 +49,7 @@ describe('search-workflows MCP tool', () => {
 			const workflows = [
 				createWorkflow({
 					id: 'a',
-					activeVersionId: new Date().getTime(),
+					activeVersionId: new Date().getTime().toString(),
 					name: 'Alpha',
 					nodes: [{ name: 'Start', type: MANUAL_TRIGGER_NODE_TYPE } as INode],
 				}),

--- a/packages/cli/src/modules/mcp/__tests__/search-workflows.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/search-workflows.tool.test.ts
@@ -76,7 +76,7 @@ describe('search-workflows MCP tool', () => {
 				{
 					id: 'a',
 					name: 'Alpha',
-					description: undefined,
+					description: null,
 					active: true,
 					createdAt: new Date('2024-01-01T00:00:00.000Z').toISOString(),
 					updatedAt: new Date('2024-01-02T00:00:00.000Z').toISOString(),
@@ -86,7 +86,7 @@ describe('search-workflows MCP tool', () => {
 				{
 					id: 'b',
 					name: 'Beta',
-					description: undefined,
+					description: null,
 					active: true,
 					createdAt: new Date('2024-01-01T00:00:00.000Z').toISOString(),
 					updatedAt: new Date('2024-01-02T00:00:00.000Z').toISOString(),

--- a/packages/cli/src/modules/mcp/__tests__/search-workflows.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/search-workflows.tool.test.ts
@@ -9,6 +9,8 @@ import { Telemetry } from '@/telemetry';
 import { WorkflowService } from '@/workflows/workflow.service';
 import { EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE, MANUAL_TRIGGER_NODE_TYPE } from 'n8n-workflow';
 
+import { v4 as uuid } from 'uuid';
+
 describe('search-workflows MCP tool', () => {
 	const user = Object.assign(new User(), { id: 'user-1' });
 
@@ -49,7 +51,7 @@ describe('search-workflows MCP tool', () => {
 			const workflows = [
 				createWorkflow({
 					id: 'a',
-					activeVersionId: new Date().getTime().toString(),
+					activeVersionId: uuid(),
 					name: 'Alpha',
 					nodes: [{ name: 'Start', type: MANUAL_TRIGGER_NODE_TYPE } as INode],
 				}),

--- a/packages/cli/src/modules/mcp/__tests__/search-workflows.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/search-workflows.tool.test.ts
@@ -49,6 +49,7 @@ describe('search-workflows MCP tool', () => {
 			const workflows = [
 				createWorkflow({
 					id: 'a',
+					activeVersionId: new Date().getTime(),
 					name: 'Alpha',
 					nodes: [{ name: 'Start', type: MANUAL_TRIGGER_NODE_TYPE } as INode],
 				}),
@@ -73,7 +74,7 @@ describe('search-workflows MCP tool', () => {
 					id: 'a',
 					name: 'Alpha',
 					description: undefined,
-					active: false,
+					active: true,
 					createdAt: new Date('2024-01-01T00:00:00.000Z').toISOString(),
 					updatedAt: new Date('2024-01-02T00:00:00.000Z').toISOString(),
 					triggerCount: 1,

--- a/packages/cli/src/modules/mcp/__tests__/search-workflows.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/search-workflows.tool.test.ts
@@ -55,7 +55,7 @@ describe('search-workflows MCP tool', () => {
 				createWorkflow({
 					id: 'b',
 					name: 'Beta',
-					active: true,
+					activeVersionId: 'version-b',
 					nodes: [
 						{ name: 'Execute subworkflow', type: EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE } as INode,
 					],
@@ -72,8 +72,8 @@ describe('search-workflows MCP tool', () => {
 				{
 					id: 'a',
 					name: 'Alpha',
+					description: undefined,
 					active: false,
-					activeVersionId: null,
 					createdAt: new Date('2024-01-01T00:00:00.000Z').toISOString(),
 					updatedAt: new Date('2024-01-02T00:00:00.000Z').toISOString(),
 					triggerCount: 1,
@@ -82,8 +82,8 @@ describe('search-workflows MCP tool', () => {
 				{
 					id: 'b',
 					name: 'Beta',
+					description: undefined,
 					active: true,
-					activeVersionId: workflows[1].versionId,
 					createdAt: new Date('2024-01-01T00:00:00.000Z').toISOString(),
 					updatedAt: new Date('2024-01-02T00:00:00.000Z').toISOString(),
 					triggerCount: 1,
@@ -125,7 +125,7 @@ describe('search-workflows MCP tool', () => {
 		});
 
 		test('formats nodes as empty array when missing', async () => {
-			const workflows = [createWorkflow({ id: 'no-nodes', nodes: undefined })];
+			const workflows = [createWorkflow({ id: 'no-nodes', activeVersion: undefined })];
 			const workflowService = mockInstance(WorkflowService, {
 				getMany: jest.fn().mockResolvedValue({ workflows, count: 1 }),
 			});

--- a/packages/cli/src/modules/mcp/mcp.settings.controller.ts
+++ b/packages/cli/src/modules/mcp/mcp.settings.controller.ts
@@ -74,9 +74,12 @@ export class McpSettingsController {
 		@Param('workflowId') workflowId: string,
 		@Body dto: UpdateWorkflowAvailabilityDto,
 	) {
-		const workflow = await this.workflowFinderService.findWorkflowForUser(workflowId, req.user, [
-			'workflow:update',
-		]);
+		const workflow = await this.workflowFinderService.findWorkflowForUser(
+			workflowId,
+			req.user,
+			['workflow:update'],
+			{ includeActiveVersion: true },
+		);
 
 		if (!workflow) {
 			this.logger.warn('User attempted to update MCP availability without permissions', {
@@ -92,7 +95,8 @@ export class McpSettingsController {
 			throw new BadRequestError('MCP access can only be set for active workflows');
 		}
 
-		const supportedTrigger = findMcpSupportedTrigger(workflow);
+		const nodes = workflow.activeVersion?.nodes ?? [];
+		const supportedTrigger = findMcpSupportedTrigger(nodes);
 
 		if (!supportedTrigger) {
 			throw new BadRequestError(

--- a/packages/cli/src/modules/mcp/mcp.settings.controller.ts
+++ b/packages/cli/src/modules/mcp/mcp.settings.controller.ts
@@ -91,17 +91,18 @@ export class McpSettingsController {
 			);
 		}
 
-		if (!workflow.activeVersionId && dto.availableInMCP) {
-			throw new BadRequestError('MCP access can only be set for active workflows');
-		}
+		if (dto.availableInMCP) {
+			if (!workflow.activeVersionId) {
+				throw new BadRequestError('MCP access can only be set for active workflows');
+			}
+			const nodes = workflow.activeVersion?.nodes ?? [];
+			const supportedTrigger = findMcpSupportedTrigger(nodes);
 
-		const nodes = workflow.activeVersion?.nodes ?? [];
-		const supportedTrigger = findMcpSupportedTrigger(nodes);
-
-		if (!supportedTrigger) {
-			throw new BadRequestError(
-				`MCP access can only be set for active workflows with one of the following trigger nodes: ${Object.values(SUPPORTED_MCP_TRIGGERS).join(', ')}.`,
-			);
+			if (!supportedTrigger) {
+				throw new BadRequestError(
+					`MCP access can only be set for active workflows with one of the following trigger nodes: ${Object.values(SUPPORTED_MCP_TRIGGERS).join(', ')}.`,
+				);
+			}
 		}
 
 		const workflowUpdate = new WorkflowEntity();

--- a/packages/cli/src/modules/mcp/mcp.utils.ts
+++ b/packages/cli/src/modules/mcp/mcp.utils.ts
@@ -1,4 +1,4 @@
-import type { AuthenticatedRequest, WorkflowEntity } from '@n8n/db';
+import type { AuthenticatedRequest } from '@n8n/db';
 import type { Request } from 'express';
 import type { INode } from 'n8n-workflow';
 
@@ -48,14 +48,14 @@ export const getToolArguments = (body: unknown): Record<string, unknown> => {
 };
 
 /**
- * Finds the first supported trigger node in the workflow.
+ * Finds the first supported trigger node in the provided nodes array.
  * Workflow is eligible for MCP access if it contains at least one of these (enabled) trigger nodes:
  * - Schedule trigger
  * - Webhook trigger
  * - Form trigger
  * - Chat trigger
  */
-export const findMcpSupportedTrigger = (workflow: WorkflowEntity): INode | undefined => {
+export const findMcpSupportedTrigger = (nodes: INode[]): INode | undefined => {
 	const triggerNodeTypes = Object.keys(SUPPORTED_MCP_TRIGGERS);
-	return workflow.nodes.find((node) => triggerNodeTypes.includes(node.type) && !node.disabled);
+	return nodes.find((node) => triggerNodeTypes.includes(node.type) && !node.disabled);
 };

--- a/packages/cli/src/modules/mcp/tools/get-workflow-details.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/get-workflow-details.tool.ts
@@ -103,15 +103,21 @@ export async function getWorkflowDetails(
 	endpoints: WebhookEndpoints,
 	{ workflowId }: { workflowId: string },
 ): Promise<WorkflowDetailsResult> {
-	const workflow = await workflowFinderService.findWorkflowForUser(workflowId, user, [
-		'workflow:read',
-	]);
+	const workflow = await workflowFinderService.findWorkflowForUser(
+		workflowId,
+		user,
+		['workflow:read'],
+		{ includeActiveVersion: true },
+	);
 	if (!workflow || workflow.isArchived || !workflow.settings?.availableInMCP) {
 		throw new UserError('Workflow not found');
 	}
 
+	const nodes = workflow.activeVersion?.nodes ?? [];
+	const connections = workflow.activeVersion?.connections ?? {};
+
 	const supportedTriggers = Object.keys(SUPPORTED_MCP_TRIGGERS);
-	const triggers = workflow.nodes.filter(
+	const triggers = nodes.filter(
 		(node) => supportedTriggers.includes(node.type) && node.disabled !== true,
 	);
 
@@ -133,8 +139,8 @@ export async function getWorkflowDetails(
 		createdAt: workflow.createdAt.toISOString(),
 		updatedAt: workflow.updatedAt.toISOString(),
 		settings: workflow.settings ?? null,
-		connections: workflow.connections,
-		nodes: workflow.nodes.map(({ credentials: _credentials, ...node }) => node),
+		connections,
+		nodes: nodes.map(({ credentials: _credentials, ...node }) => node),
 		tags: (workflow.tags ?? []).map((tag) => ({ id: tag.id, name: tag.name })),
 		meta: workflow.meta ?? null,
 		parentFolderId: workflow.parentFolder?.id ?? null,

--- a/packages/cli/src/modules/mcp/tools/search-workflows.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/search-workflows.tool.ts
@@ -146,13 +146,14 @@ export async function searchWorkflows(
 		},
 		select: {
 			id: true,
+			activeVersionId: true,
 			name: true,
 			description: true,
 			active: true,
 			createdAt: true,
 			updatedAt: true,
 			triggerCount: true,
-			nodes: true,
+			activeVersion: true,
 		},
 	};
 
@@ -169,22 +170,23 @@ export async function searchWorkflows(
 			id,
 			name,
 			description,
-			active,
 			activeVersionId,
 			createdAt,
 			updatedAt,
 			triggerCount,
-			nodes,
+			activeVersion,
 		}) => ({
 			id,
 			name,
 			description,
-			active,
-			activeVersionId,
+			active: activeVersionId !== null,
 			createdAt: createdAt.toISOString(),
 			updatedAt: updatedAt.toISOString(),
 			triggerCount,
-			nodes: (nodes ?? []).map((node: INode) => ({ name: node.name, type: node.type })),
+			nodes: (activeVersion?.nodes ?? []).map((node: INode) => ({
+				name: node.name,
+				type: node.type,
+			})),
 		}),
 	);
 


### PR DESCRIPTION
## Summary
Update MCP tools to use active version of workflows according to the new versioning scheme.

## Related Linear tickets, Github issues, and Community forum posts
Closes ADO-4455

## How to test
1. Connect MCP client to your n8n instance
2. Check if workflows in tools results contain nodes and connections from the active version instead of most recent one

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
