### PR TITLE
ci: Prevent RC versions from being promoted to stable/beta channels

### DIFF
--- a/.github/workflows/release-push-to-channel.yml
+++ b/.github/workflows/release-push-to-channel.yml
@@ -41,6 +41,17 @@ jobs:
             exit 1
           fi
 
+      - name: Block RC promotion to stable/beta
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          CHANNEL: ${{ github.event.inputs.release-channel }}
+        run: |
+          if [[ "$INPUT_VERSION" == *"-rc."* ]]; then
+            echo "::error::RC versions cannot be promoted to '$CHANNEL' channel. Version '$INPUT_VERSION' contains '-rc.'"
+            exit 1
+          fi
+          echo "✅ Version '$INPUT_VERSION' is allowed for '$CHANNEL' channel"
+
   release-to-npm:
     name: Release to NPM
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Added validation in the `validate-inputs` job that blocks any version containing `-rc.` from being promoted to stable or beta channels.

## Related Linear tickets, Github issues, and Community forum posts
- https://linear.app/n8n/issue/CAT-1830
- Parent: https://linear.app/n8n/issue/CAT-1823


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
