### PR TITLE
fix(editor): Eval trigger node with data table works when underlying data changes

### DIFF
--- a/packages/nodes-base/nodes/Evaluation/EvaluationTrigger/EvaluationTrigger.node.ee.ts
+++ b/packages/nodes-base/nodes/Evaluation/EvaluationTrigger/EvaluationTrigger.node.ee.ts
@@ -208,18 +208,41 @@ export class EvaluationTrigger implements INodeType {
 			const dataTableProxy = await this.helpers.getDataTableProxy(dataTableId);
 
 			const filter = await getDataTableFilter(this, 0);
+			const hasFilters = filter.filters.length > 0;
+
+			const previousRunRowId = inputData?.[0]?.json?.row_id;
+
+			// When filters are applied, we need to start from the next row after the last processed one
+			// to handle cases where the filtered result set changes between executions.
+			// We add a filter condition for id > last processed id.
+			let effectiveFilter = filter;
+			if (hasFilters && typeof previousRunRowId === 'number' && previousRunRowsLeft !== 0) {
+				effectiveFilter = {
+					type: 'and',
+					filters: [
+						...filter.filters,
+						{
+							columnName: 'id',
+							condition: 'gt',
+							value: previousRunRowId,
+						},
+					],
+				};
+			}
 
 			const { data, count } = await dataTableProxy.getManyRowsAndCount({
-				skip: currentIndex,
+				skip: hasFilters ? 0 : currentIndex,
 				take: 1,
-				filter,
+				filter: effectiveFilter,
 			});
 
 			if (data.length === 0) {
 				throw new NodeOperationError(this.getNode(), 'No row found');
 			}
 
-			const effectiveTotal = Math.min(count, maxRows);
+			// When using filters, count represents remaining filtered rows
+			// When not using filters, use the original logic
+			const effectiveTotal = hasFilters ? count + currentIndex : Math.min(count, maxRows);
 			const rowsLeft = Math.max(0, effectiveTotal - (currentIndex + 1));
 
 			const currentRow = {


### PR DESCRIPTION
## Summary
https://www.loom.com/share/24916d251da84a7d902a3c9a2f8afb59

When the trigger node has a filter, and the workflow updates the fields used in the filter, rows were skipped 
As a fix, use cursor based pagination
<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/ADO-4464/eval-trigger-fails-to-fetch-all-matching-rows-from-a-data-table
fixes #22364
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
