### PR TITLE
fix(core): Move subworfklow binary duplication to workflowExecuteAfter before execution cleaning

### DIFF
--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -230,6 +230,7 @@ async function startExecution(
 			executionId,
 			workflowData,
 			additionalData.userId,
+			options.parentExecution,
 		);
 		additionalDataIntegrated.executionId = executionId;
 		additionalDataIntegrated.parentCallbackManager = options.parentCallbackManager;

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/shared-tests.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/shared-tests.ts
@@ -269,7 +269,7 @@ export const describeCommonTests = (
 
 	describe('executeWorkflow', () => {
 		const data = [[{ json: { test: true } }]];
-		const executeWorkflowData = mock<ExecuteWorkflowData>();
+		const executeWorkflowData = mock<ExecuteWorkflowData>({ data });
 		const workflowInfo = mock<IExecuteWorkflowInfo>();
 		const parentExecution: RelatedExecution = {
 			executionId: 'parent_execution_id',
@@ -278,23 +278,18 @@ export const describeCommonTests = (
 
 		it('should execute workflow and return data', async () => {
 			additionalData.executeWorkflow.mockResolvedValue(executeWorkflowData);
-			binaryDataService.duplicateBinaryData.mockResolvedValue(data);
 
 			const result = await context.executeWorkflow(workflowInfo, undefined, undefined, {
 				parentExecution,
 			});
 
 			expect(result.data).toEqual(data);
-			expect(binaryDataService.duplicateBinaryData).toHaveBeenCalledWith(
-				{ type: 'execution', workflowId: workflow.id, executionId: additionalData.executionId },
-				executeWorkflowData.data,
-			);
+			expect(result).toBe(executeWorkflowData);
 		});
 
 		it('should put execution to wait if waitTill is returned', async () => {
 			const waitTill = new Date();
 			additionalData.executeWorkflow.mockResolvedValue({ ...executeWorkflowData, waitTill });
-			binaryDataService.duplicateBinaryData.mockResolvedValue(data);
 
 			const result = await context.executeWorkflow(workflowInfo, undefined, undefined, {
 				parentExecution,

--- a/packages/core/src/execution-engine/node-execution-context/base-execute-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/base-execute-context.ts
@@ -1,4 +1,3 @@
-import { Container } from '@n8n/di';
 import get from 'lodash/get';
 import type {
 	Workflow,
@@ -33,14 +32,9 @@ import {
 	createEnvProviderState,
 } from 'n8n-workflow';
 
-import { BinaryDataService } from '@/binary-data/binary-data.service';
-import { FileLocation } from '@/binary-data/utils';
-
 import { NodeExecutionContext } from './node-execution-context';
 
 export class BaseExecuteContext extends NodeExecutionContext {
-	protected readonly binaryDataService = Container.get(BinaryDataService);
-
 	constructor(
 		workflow: Workflow,
 		node: INode,
@@ -155,11 +149,7 @@ export class BaseExecuteContext extends NodeExecutionContext {
 			await this.putExecutionToWait(WAIT_INDEFINITELY);
 		}
 
-		const data = await this.binaryDataService.duplicateBinaryData(
-			FileLocation.ofExecution(this.workflow.id, this.additionalData.executionId!),
-			result.data,
-		);
-		return { ...result, data };
+		return result;
 	}
 
 	async getExecutionDataById(executionId: string): Promise<IRunExecutionData | undefined> {


### PR DESCRIPTION

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

**Problem**: When a subworkflow with saveDataOnSuccess=false completes, its binary data was deleted before the parent workflow could access it, causing ENOENT errors. 
**Solution**: Move binary data duplication from base-execute-context.ts to the execution lifecycle hooks. When a subworkflow has a parentExecution, binary data is now duplicated to the parent's location before any cleanup occurs.

### Changes
- execution-lifecycle-hooks.ts: Added duplicateBinaryDataToParent(), duplicate binary data early in workflowExecuteAfter hook
- workflow-execute-additional-data.ts: Pass parentExecution to lifecycle hooks
- base-execute-context.ts: Removed duplicateBinaryData call (now handled by hooks)

Added 2 tests for the new behavior

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-4035/question-enoent-no-such-file-or-directory-open

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
