### PR TITLE
fix(output_parser): support tripple backticks coming from markdwon

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/test/OutputParserStructured.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/test/OutputParserStructured.node.test.ts
@@ -765,6 +765,466 @@ describe('OutputParserStructured', () => {
 				});
 			});
 		});
+
+		describe('Markdown Code Fence Handling', () => {
+			beforeEach(() => {
+				thisArg.getNode.mockReturnValue(mock<INode>({ typeVersion: 1.2 }));
+				thisArg.getNodeParameter.calledWith('schemaType', 0).mockReturnValueOnce('manual');
+			});
+
+			it('should parse JSON with single backtick block inside (not in fence)', async () => {
+				const schema = `{
+					"type": "object",
+					"properties": {
+						"message": { "type": "string" },
+						"status": { "type": "string" }
+					},
+					"required": ["message", "status"]
+				}`;
+				thisArg.getNodeParameter.calledWith('inputSchema', 0).mockReturnValueOnce(schema);
+
+				const { response } = (await outputParser.supplyData.call(thisArg, 0)) as {
+					response: N8nStructuredOutputParser;
+				};
+
+				const outputObject = {
+					output: {
+						message: '## Example\n```bash\n--set globals.enable=false\n```\n',
+						status: 'completed',
+					},
+				};
+
+				const parsersOutput = await response.parse(JSON.stringify(outputObject));
+
+				expect(parsersOutput).toEqual(outputObject);
+			});
+
+			it('should parse JSON with multiple backtick blocks inside (not in fence)', async () => {
+				const schema = `{
+					"type": "object",
+					"properties": {
+						"message": { "type": "string" },
+						"tokens_used": { "type": "number" }
+					},
+					"required": ["message", "tokens_used"]
+				}`;
+				thisArg.getNodeParameter.calledWith('inputSchema', 0).mockReturnValueOnce(schema);
+
+				const { response } = (await outputParser.supplyData.call(thisArg, 0)) as {
+					response: N8nStructuredOutputParser;
+				};
+
+				const outputObject = {
+					output: {
+						message:
+							'## Example 1\n```bash\ncommand1\n```\n## Example 2\n```bash\ncommand2\n```\n',
+						tokens_used: 2850,
+					},
+				};
+
+				const parsersOutput = await response.parse(JSON.stringify(outputObject));
+
+				expect(parsersOutput).toEqual(outputObject);
+			});
+
+			it('should parse JSON wrapped in code fence', async () => {
+				const schema = `{
+					"type": "object",
+					"properties": {
+						"name": { "type": "string" },
+						"age": { "type": "number" }
+					},
+					"required": ["name", "age"]
+				}`;
+				thisArg.getNodeParameter.calledWith('inputSchema', 0).mockReturnValueOnce(schema);
+
+				const { response } = (await outputParser.supplyData.call(thisArg, 0)) as {
+					response: N8nStructuredOutputParser;
+				};
+
+				const outputObject = {
+					output: {
+						name: 'Alice',
+						age: 30,
+					},
+				};
+
+				const parsersOutput = await response.parse(`\`\`\`json
+${JSON.stringify(outputObject)}
+\`\`\``);
+
+				expect(parsersOutput).toEqual(outputObject);
+			});
+
+			it('should parse JSON wrapped in code fence (no json marker)', async () => {
+				const schema = `{
+					"type": "object",
+					"properties": {
+						"result": { "type": "string" }
+					},
+					"required": ["result"]
+				}`;
+				thisArg.getNodeParameter.calledWith('inputSchema', 0).mockReturnValueOnce(schema);
+
+				const { response } = (await outputParser.supplyData.call(thisArg, 0)) as {
+					response: N8nStructuredOutputParser;
+				};
+
+				const outputObject = {
+					output: {
+						result: 'success',
+					},
+				};
+
+				const parsersOutput = await response.parse(`\`\`\`
+${JSON.stringify(outputObject)}
+\`\`\``);
+
+				expect(parsersOutput).toEqual(outputObject);
+			});
+
+			it('should parse JSON in code fence WITH backticks inside', async () => {
+				const schema = `{
+					"type": "object",
+					"properties": {
+						"message": { "type": "string" },
+						"status": { "type": "string" },
+						"tokens_used": { "type": "number" }
+					},
+					"required": ["message", "status", "tokens_used"]
+				}`;
+				thisArg.getNodeParameter.calledWith('inputSchema', 0).mockReturnValueOnce(schema);
+
+				const { response } = (await outputParser.supplyData.call(thisArg, 0)) as {
+					response: N8nStructuredOutputParser;
+				};
+
+				const outputObject = {
+					output: {
+						message: '## Example\n```bash\n--set globals.enable=false\n```\n',
+						status: 'completed',
+						tokens_used: 2850,
+					},
+				};
+
+				const parsersOutput = await response.parse(`\`\`\`json
+${JSON.stringify(outputObject)}
+\`\`\``);
+
+				expect(parsersOutput).toEqual(outputObject);
+			});
+
+			it('should parse JSON in code fence WITH MULTIPLE backticks inside', async () => {
+				const schema = `{
+					"type": "object",
+					"properties": {
+						"documentation": { "type": "string" },
+						"examples_count": { "type": "number" }
+					},
+					"required": ["documentation", "examples_count"]
+				}`;
+				thisArg.getNodeParameter.calledWith('inputSchema', 0).mockReturnValueOnce(schema);
+
+				const { response } = (await outputParser.supplyData.call(thisArg, 0)) as {
+					response: N8nStructuredOutputParser;
+				};
+
+				const outputObject = {
+					output: {
+						documentation:
+							'# Usage\n```python\nprint("hello")\n```\n\n```javascript\nconsole.log("world")\n```\n',
+						examples_count: 2,
+					},
+				};
+
+				const parsersOutput = await response.parse(`\`\`\`json
+${JSON.stringify(outputObject)}
+\`\`\``);
+
+				expect(parsersOutput).toEqual(outputObject);
+			});
+
+			it('should parse plain JSON without code fence', async () => {
+				const schema = `{
+					"type": "object",
+					"properties": {
+						"id": { "type": "number" },
+						"value": { "type": "string" }
+					},
+					"required": ["id", "value"]
+				}`;
+				thisArg.getNodeParameter.calledWith('inputSchema', 0).mockReturnValueOnce(schema);
+
+				const { response } = (await outputParser.supplyData.call(thisArg, 0)) as {
+					response: N8nStructuredOutputParser;
+				};
+
+				const outputObject = {
+					output: {
+						id: 42,
+						value: 'test',
+					},
+				};
+
+				const parsersOutput = await response.parse(JSON.stringify(outputObject));
+
+				expect(parsersOutput).toEqual(outputObject);
+			});
+
+			it('should parse JSON with escaped quotes and backticks', async () => {
+				const schema = `{
+					"type": "object",
+					"properties": {
+						"command": { "type": "string" },
+						"description": { "type": "string" }
+					},
+					"required": ["command", "description"]
+				}`;
+				thisArg.getNodeParameter.calledWith('inputSchema', 0).mockReturnValueOnce(schema);
+
+				const { response } = (await outputParser.supplyData.call(thisArg, 0)) as {
+					response: N8nStructuredOutputParser;
+				};
+
+				const outputObject = {
+					output: {
+						command: 'echo "Hello \`World\`"',
+						description: 'Prints: Hello `World`',
+					},
+				};
+
+				const parsersOutput = await response.parse(JSON.stringify(outputObject));
+
+				expect(parsersOutput).toEqual(outputObject);
+			});
+
+			it('should NOT extract from backticks that appear mid-text', async () => {
+				const schema = `{
+					"type": "object",
+					"properties": {
+						"note": { "type": "string" }
+					},
+					"required": ["note"]
+				}`;
+				thisArg.getNodeParameter.calledWith('inputSchema', 0).mockReturnValueOnce(schema);
+
+				const { response } = (await outputParser.supplyData.call(thisArg, 0)) as {
+					response: N8nStructuredOutputParser;
+				};
+
+				const outputObject = {
+					output: {
+						note: 'Some text before ```json\n{"fake": "fence"}\n``` more text after',
+					},
+				};
+
+				// This is NOT wrapped in a fence, so should parse as-is
+				const parsersOutput = await response.parse(JSON.stringify(outputObject));
+
+				expect(parsersOutput).toEqual(outputObject);
+			});
+
+			it('should handle whitespace variations in code fence', async () => {
+				const schema = `{
+					"type": "object",
+					"properties": {
+						"data": { "type": "string" }
+					},
+					"required": ["data"]
+				}`;
+				thisArg.getNodeParameter.calledWith('inputSchema', 0).mockReturnValueOnce(schema);
+
+				const { response } = (await outputParser.supplyData.call(thisArg, 0)) as {
+					response: N8nStructuredOutputParser;
+				};
+
+				const outputObject = {
+					output: {
+						data: 'test',
+					},
+				};
+
+				// Test with extra whitespace
+				const parsersOutput = await response.parse(`\`\`\`json
+
+${JSON.stringify(outputObject)}
+
+\`\`\`  `);
+
+				expect(parsersOutput).toEqual(outputObject);
+			});
+
+			it('should fail when code fence is unclosed (no closing backticks)', async () => {
+				const schema = `{
+					"type": "object",
+					"properties": {
+						"key": { "type": "string" }
+					},
+					"required": ["key"]
+				}`;
+				thisArg.getNodeParameter.calledWith('inputSchema', 0).mockReturnValueOnce(schema);
+
+				const { response } = (await outputParser.supplyData.call(thisArg, 0)) as {
+					response: N8nStructuredOutputParser;
+				};
+
+				const outputObject = {
+					output: {
+						key: 'value',
+					},
+				};
+
+				// Missing closing ``` - fence pattern won't match, tries to parse whole string including ```json prefix
+				await expect(
+					response.parse(`\`\`\`json\n${JSON.stringify(outputObject)}`, undefined, (e) => e),
+				).rejects.toThrow();
+			});
+
+			it('should fail gracefully with invalid JSON in code fence', async () => {
+				const schema = `{
+					"type": "object",
+					"properties": {
+						"test": { "type": "string" }
+					},
+					"required": ["test"]
+				}`;
+				thisArg.getNodeParameter.calledWith('inputSchema', 0).mockReturnValueOnce(schema);
+
+				const { response } = (await outputParser.supplyData.call(thisArg, 0)) as {
+					response: N8nStructuredOutputParser;
+				};
+
+				await expect(
+					response.parse(
+						`\`\`\`json
+{invalid json}
+\`\`\``,
+						undefined,
+						(e) => e,
+					),
+				).rejects.toThrow();
+			});
+
+			it('should fail gracefully when fence contains only opening bracket', async () => {
+				const schema = `{
+					"type": "object",
+					"properties": {
+						"items": { "type": "array" }
+					},
+					"required": ["items"]
+				}`;
+				thisArg.getNodeParameter.calledWith('inputSchema', 0).mockReturnValueOnce(schema);
+
+				const { response } = (await outputParser.supplyData.call(thisArg, 0)) as {
+					response: N8nStructuredOutputParser;
+				};
+
+				// This should extract '[' which passes startsWith check but fails JSON.parse
+				await expect(
+					response.parse(
+						`\`\`\`json
+[
+\`\`\``,
+						undefined,
+						(e) => e,
+					),
+				).rejects.toThrow();
+			});
+
+			it('should NOT match code fence with non-json/non-empty language marker', async () => {
+				const schema = `{
+					"type": "object",
+					"properties": {
+						"result": { "type": "string" }
+					},
+					"required": ["result"]
+				}`;
+				thisArg.getNodeParameter.calledWith('inputSchema', 0).mockReturnValueOnce(schema);
+
+				const { response } = (await outputParser.supplyData.call(thisArg, 0)) as {
+					response: N8nStructuredOutputParser;
+				};
+
+				const outputObject = {
+					output: {
+						result: 'success',
+					},
+				};
+
+				// Regex only matches ```json or ```, not ```python - fence won't match, parse fails
+				await expect(
+					response.parse(
+						`\`\`\`python
+${JSON.stringify(outputObject)}
+\`\`\``,
+						undefined,
+						(e) => e,
+					),
+				).rejects.toThrow();
+			});
+
+			it('should parse array wrapped in code fence', async () => {
+				const schema = `{
+					"type": "object",
+					"properties": {
+						"items": {
+							"type": "array",
+							"items": {
+								"type": "object",
+								"properties": {
+									"id": { "type": "number" }
+								}
+							}
+						}
+					},
+					"required": ["items"]
+				}`;
+				thisArg.getNodeParameter.calledWith('inputSchema', 0).mockReturnValueOnce(schema);
+
+				const { response } = (await outputParser.supplyData.call(thisArg, 0)) as {
+					response: N8nStructuredOutputParser;
+				};
+
+				const outputObject = {
+					output: {
+						items: [{ id: 1 }, { id: 2 }],
+					},
+				};
+
+				// Top-level array inside output object in a fence
+				const parsersOutput = await response.parse(`\`\`\`json
+${JSON.stringify(outputObject)}
+\`\`\``);
+
+				expect(parsersOutput).toEqual(outputObject);
+			});
+
+			it('should NOT match fence with closing backticks on same line as content', async () => {
+				const schema = `{
+					"type": "object",
+					"properties": {
+						"val": { "type": "string" }
+					},
+					"required": ["val"]
+				}`;
+				thisArg.getNodeParameter.calledWith('inputSchema', 0).mockReturnValueOnce(schema);
+
+				const { response } = (await outputParser.supplyData.call(thisArg, 0)) as {
+					response: N8nStructuredOutputParser;
+				};
+
+				const outputObject = {
+					output: {
+						val: 'test',
+					},
+				};
+
+				// Regex requires newline before closing ``` - won't match, parse fails
+				await expect(
+					response.parse(`\`\`\`json\n${JSON.stringify(outputObject)}\`\`\``, undefined, (e) => e),
+				).rejects.toThrow();
+			});
+		});
 	});
 
 	describe('Auto-Fix', () => {

--- a/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/test/OutputParserStructured.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/test/OutputParserStructured.node.test.ts
@@ -765,7 +765,6 @@ describe('OutputParserStructured', () => {
 				});
 			});
 		});
-
 		describe('Markdown Code Fence Handling', () => {
 			beforeEach(() => {
 				thisArg.getNode.mockReturnValue(mock<INode>({ typeVersion: 1.2 }));
@@ -1199,7 +1198,7 @@ ${JSON.stringify(outputObject)}
 				expect(parsersOutput).toEqual(outputObject);
 			});
 
-			it('should NOT match fence with closing backticks on same line as content', async () => {
+			it('should match fence with closing backticks on same line as content (inline fence)', async () => {
 				const schema = `{
 					"type": "object",
 					"properties": {
@@ -1219,10 +1218,10 @@ ${JSON.stringify(outputObject)}
 					},
 				};
 
-				// Regex requires newline before closing ``` - won't match, parse fails
-				await expect(
-					response.parse(`\`\`\`json\n${JSON.stringify(outputObject)}\`\`\``, undefined, (e) => e),
-				).rejects.toThrow();
+				// With optional newlines, inline fences should now parse successfully
+				const parsersOutput = await response.parse(`\`\`\`json\n${JSON.stringify(outputObject)}\`\`\``);
+
+				expect(parsersOutput).toEqual(outputObject);
 			});
 		});
 	});

--- a/packages/@n8n/nodes-langchain/utils/output_parsers/N8nStructuredOutputParser.ts
+++ b/packages/@n8n/nodes-langchain/utils/output_parsers/N8nStructuredOutputParser.ts
@@ -33,7 +33,6 @@ export class N8nStructuredOutputParser extends StructuredOutputParser<
 		]);
 
 		try {
-			const jsonString = text.includes('```') ? text.split(/```(?:json)?/)[1] : text;
 			// Extract JSON from markdown code fence if present
 			// Using regex to properly match code fences, even if backticks appear in the JSON content
 			let jsonString = text.trim();

--- a/packages/@n8n/nodes-langchain/utils/output_parsers/N8nStructuredOutputParser.ts
+++ b/packages/@n8n/nodes-langchain/utils/output_parsers/N8nStructuredOutputParser.ts
@@ -36,10 +36,15 @@ export class N8nStructuredOutputParser extends StructuredOutputParser<
 			// Extract JSON from markdown code fence if present
 			// Using regex to properly match code fences, even if backticks appear in the JSON content
 			let jsonString = text.trim();
-			// Look for a markdown code fence pattern: ```json or ``` followed by content and closing ```
-			// We use non-greedy matching and require newlines around the fence to avoid matching backticks inside JSON strings
-			// Allow whitespace before the closing ``` to handle indented code blocks
-			const codeFenceMatch = jsonString.match(/```(?:json)?\s*\n([\s\S]+?)\n\s*```/);
+			// Look for a code fence with proper opening and closing
+			// Use GREEDY matching ([\s\S]+) to match to the LAST occurrence of closing ```
+			// This prevents matching backticks that appear inside JSON string values
+			// The pattern matches:
+			//   - Opening: ``` or ```json followed by optional whitespace and optional newline
+			//   - Content: Any characters (greedy - matches to last ```)
+			//   - Closing: Optional newline, optional whitespace, then ```
+			// This handles both standard fences (with newlines) and inline fences (without)
+			const codeFenceMatch = jsonString.match(/```(?:json)?\s*\n?([\s\S]+)\n?\s*```/);
 			if (codeFenceMatch) {
 				// Extract the content between the fences
 				const potentialJson = codeFenceMatch[1].trim();


### PR DESCRIPTION
## Summary

Fix for output parser node to handle properly cases when AI agent returned correct string but with backticks in it.
See linked issue.

## Related Linear tickets, Github issues, and Community forum posts
resolves https://github.com/n8n-io/n8n/issues/21174

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
