### PR TITLE
ci: Skip release notes trigger for RC versions

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -158,7 +158,9 @@ jobs:
   trigger-release-note:
     name: Trigger a release note
     needs: [publish-to-npm, create-github-release]
-    if: github.event.pull_request.merged == true
+    if: |
+      github.event.pull_request.merged == true &&
+      !contains(needs.publish-to-npm.outputs.release, '-rc.')
     runs-on: ubuntu-latest
     steps:
       - name: Trigger a release note


### PR DESCRIPTION
## Summary
Skip triggering the docs release notes webhook for Release Candidate (RC) versions.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/CAT-1832


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
