### PR TITLE
fix(MCP Client Node): Fix selecting PKCE auth flow for some servers and request scopes from `scopes_requested` during DCR

### DIFF
--- a/packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts
+++ b/packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts
@@ -341,6 +341,59 @@ describe('OAuth2CredentialController', () => {
 				/Invalid client registration response/,
 			);
 		});
+
+		it('should request scopes from scopes_supported for dynamic client registration', async () => {
+			jest.spyOn(Csrf.prototype, 'secretSync').mockReturnValueOnce(csrfSecret);
+			jest.spyOn(Csrf.prototype, 'create').mockReturnValueOnce('token');
+			jest.spyOn(pkceChallenge, 'default').mockResolvedValueOnce({
+				code_verifier: 'code-verifier',
+				code_challenge: 'code-challenge',
+			});
+			credentialsFinderService.findCredentialForUser.mockResolvedValueOnce(credential);
+			credentialsHelper.getDecrypted.mockResolvedValueOnce({});
+			credentialsHelper.applyDefaultsAndOverwrites.mockResolvedValue({
+				useDynamicClientRegistration: true,
+				serverUrl: 'https://example.com',
+			});
+			nock('https://example.com')
+				.get('/.well-known/oauth-authorization-server')
+				.reply(200, {
+					authorization_endpoint: 'https://example.com/auth',
+					token_endpoint: 'https://example.com/token',
+					registration_endpoint: 'https://example.com/registration',
+					grant_types_supported: ['authorization_code', 'refresh_token'],
+					token_endpoint_auth_methods_supported: ['client_secret_basic'],
+					code_challenge_methods_supported: ['S256'],
+					scopes_supported: ['openid', 'somescope'],
+				})
+				.post('/registration', {
+					redirect_uris: ['http://localhost:5678/rest/oauth2-credential/callback'],
+					token_endpoint_auth_method: 'none',
+					grant_types: ['authorization_code', 'refresh_token'],
+					response_types: ['code'],
+					client_name: 'n8n',
+					client_uri: 'https://n8n.io/',
+					scope: 'openid somescope',
+				})
+				.reply(200, { client_id: 'test-client-id', client_secret: 'test-client-secret' });
+
+			const req = mock<OAuthRequest.OAuth2Credential.Auth>({ user, query: { id: '1' } });
+			const authUri = await controller.getAuthUri(req);
+
+			const url = new URL(authUri);
+			expect(url.origin).toEqual('https://example.com');
+			expect(url.pathname).toEqual('/auth');
+			Object.entries({
+				code_challenge: 'code-challenge',
+				code_challenge_method: 'S256',
+				client_id: 'test-client-id',
+				redirect_uri: 'http://localhost:5678/rest/oauth2-credential/callback',
+				response_type: 'code',
+				scope: 'openid somescope',
+			}).forEach(([param, value]) => {
+				expect(url.searchParams.get(param)).toEqual(value);
+			});
+		});
 	});
 
 	describe('handleCallback', () => {

--- a/packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts
+++ b/packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts
@@ -135,6 +135,7 @@ describe('OAuth2CredentialController', () => {
 			[
 				['authorization_code', 'refresh_token'],
 				['client_secret_basic', 'client_secret_post', 'none'],
+				['S256'],
 				['authorization_code', 'refresh_token'],
 				'none',
 				{
@@ -149,6 +150,22 @@ describe('OAuth2CredentialController', () => {
 			[
 				['authorization_code', 'refresh_token'],
 				['client_secret_basic', 'client_secret_post'],
+				['S256'],
+				['authorization_code', 'refresh_token'],
+				'none',
+				{
+					code_challenge: 'code-challenge',
+					code_challenge_method: 'S256',
+					client_id: 'test-client-id',
+					redirect_uri: 'http://localhost:5678/rest/oauth2-credential/callback',
+					response_type: 'code',
+					scope: 'openid',
+				},
+			],
+			[
+				['authorization_code', 'refresh_token'],
+				['client_secret_basic', 'client_secret_post'],
+				[],
 				['authorization_code', 'refresh_token'],
 				'client_secret_basic',
 				{
@@ -161,6 +178,7 @@ describe('OAuth2CredentialController', () => {
 			[
 				['authorization_code', 'refresh_token'],
 				['client_secret_post'],
+				[],
 				['authorization_code', 'refresh_token'],
 				'client_secret_post',
 				{
@@ -173,6 +191,7 @@ describe('OAuth2CredentialController', () => {
 			[
 				['client_credentials'],
 				['client_secret_basic', 'client_secret_post'],
+				[],
 				['client_credentials'],
 				'client_secret_basic',
 				{
@@ -185,6 +204,7 @@ describe('OAuth2CredentialController', () => {
 			[
 				['client_credentials'],
 				['client_secret_post'],
+				[],
 				['client_credentials'],
 				'client_secret_post',
 				{
@@ -199,6 +219,7 @@ describe('OAuth2CredentialController', () => {
 			async (
 				supportedGrantTypes,
 				supportedTokenEndpointAuthMethods,
+				supportedCodeChallengeMethods,
 				expectedGrantTypes,
 				expectedTokenEndpointAuthMethod,
 				expectedQueryParams,
@@ -223,7 +244,7 @@ describe('OAuth2CredentialController', () => {
 						registration_endpoint: 'https://example.com/registration',
 						grant_types_supported: supportedGrantTypes,
 						token_endpoint_auth_methods_supported: supportedTokenEndpointAuthMethods,
-						code_challenge_methods_supported: ['S256'],
+						code_challenge_methods_supported: supportedCodeChallengeMethods,
 					})
 					.post('/registration', {
 						redirect_uris: ['http://localhost:5678/rest/oauth2-credential/callback'],
@@ -304,7 +325,6 @@ describe('OAuth2CredentialController', () => {
 					registration_endpoint: 'https://example.com/registration',
 					grant_types_supported: ['authorization_code', 'refresh_token'],
 					token_endpoint_auth_methods_supported: ['client_secret_basic'],
-					code_challenge_methods_supported: ['S256'],
 				})
 				.post('/registration', {
 					redirect_uris: ['http://localhost:5678/rest/oauth2-credential/callback'],

--- a/packages/cli/src/controllers/oauth/oauth2-credential.controller.ts
+++ b/packages/cli/src/controllers/oauth/oauth2-credential.controller.ts
@@ -73,12 +73,17 @@ export class OAuth2CredentialController extends AbstractOAuthController {
 				);
 			}
 
-			const { authorization_endpoint, token_endpoint, registration_endpoint } =
+			const { authorization_endpoint, token_endpoint, registration_endpoint, scopes_supported } =
 				metadataValidation.data;
 			oauthCredentials.authUrl = authorization_endpoint;
 			oauthCredentials.accessTokenUrl = token_endpoint;
 			toUpdate.authUrl = authorization_endpoint;
 			toUpdate.accessTokenUrl = token_endpoint;
+			const scope = scopes_supported ? scopes_supported.join(' ') : undefined;
+			if (scope) {
+				oauthCredentials.scope = scope;
+				toUpdate.scope = scope;
+			}
 
 			const { grantType, authentication } = this.selectGrantTypeAndAuthenticationMethod(
 				metadataValidation.data.grant_types_supported ?? ['authorization_code', 'implicit'],
@@ -103,6 +108,7 @@ export class OAuth2CredentialController extends AbstractOAuthController {
 				response_types: ['code'],
 				client_name: 'n8n',
 				client_uri: 'https://n8n.io/',
+				scope,
 			};
 
 			await this.externalHooks.run('oauth2.dynamicClientRegistration', [registerPayload]);

--- a/packages/cli/src/controllers/oauth/oauth2-credential.controller.ts
+++ b/packages/cli/src/controllers/oauth/oauth2-credential.controller.ts
@@ -277,7 +277,7 @@ export class OAuth2CredentialController extends AbstractOAuthController {
 		codeChallengeMethods: string[],
 	): { grantType: OAuth2GrantType; authentication?: OAuth2AuthenticationMethod } {
 		if (grantTypes.includes('authorization_code') && grantTypes.includes('refresh_token')) {
-			if (codeChallengeMethods.includes('S256') && tokenEndpointAuthMethods.includes('none')) {
+			if (codeChallengeMethods.includes('S256')) {
 				return { grantType: 'pkce' };
 			}
 

--- a/packages/cli/src/controllers/oauth/oauth2-dynamic-client-registration.schema.ts
+++ b/packages/cli/src/controllers/oauth/oauth2-dynamic-client-registration.schema.ts
@@ -7,6 +7,7 @@ export const oAuthAuthorizationServerMetadataSchema = z.object({
 	grant_types_supported: z.array(z.string()).optional(),
 	token_endpoint_auth_methods_supported: z.array(z.string()).optional(),
 	code_challenge_methods_supported: z.array(z.string()).optional(),
+	scopes_supported: z.array(z.string()).optional(),
 });
 
 export const dynamicClientRegistrationResponseSchema = z.object({


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

### Description

This PR includes fixes for 2 issues that were discovered when trying to connect to a single MCP server using OAuth2 with Dynamic Client Registration 

#### PKCE flow fix
During DCR, there is a process of selecting which auth flow to use to obtain the token. Previously, PKCE was selected when `code_challenge_methods_supported` includes `S256` and `token_endpoint_auth_methods_supported` includes `none`. However, some servers expect PKCE to be used even if there is `S256` in `code_challenge_methods_supported` and `none` is not present in `token_endpoint_auth_methods_supported`. This PR accounts for this

#### Scopes fix
During DCR, server metadata _may_ include `scopes_supported` which has a list of available scopes that can be requested by the client. Previously, this was ignored which caused n8n to request only `openid` scope. Because of missing scopes some MCP servers couldn't be used. This PR fixes this and request all scopes that are in `scopes_supported` when obtaining the token

**Note**: we are planning to allow users to manually request whatever scopes they would like when connecting to an MCP server, which would be more flexible

### Testing
MCP server to test with: `https://mcp.semilattice.ai` (this is the server with which the issues were discovered)

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-3997/community-issue-remote-mcp-server-oauth2-dcr-pkce-insufficient
Closes #22103

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
