### PR TITLE
ci: Auto-detect RC releases for orange logo and [RC] tab indicator

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -285,7 +285,8 @@ jobs:
     if: |
       success() &&
       (needs.determine-build-context.outputs.release_type == 'stable' ||
-       needs.determine-build-context.outputs.release_type == 'nightly')
+       needs.determine-build-context.outputs.release_type == 'nightly' ||
+       needs.determine-build-context.outputs.release_type == 'rc')
     uses: ./.github/workflows/security-trivy-scan-callable.yml
     with:
       image_ref: ${{ needs.build-and-push-docker.outputs.image_ref }}
@@ -297,7 +298,8 @@ jobs:
     if: |
       success() &&
       (needs.determine-build-context.outputs.release_type == 'stable' ||
-      needs.determine-build-context.outputs.release_type == 'nightly')
+       needs.determine-build-context.outputs.release_type == 'nightly' ||
+       needs.determine-build-context.outputs.release_type == 'rc')
     uses: ./.github/workflows/security-trivy-scan-callable.yml
     with:
       image_ref: ${{ needs.build-and-push-docker.outputs.runners_primary_ghcr_manifest_tag }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -34,12 +34,23 @@ jobs:
       NPM_CONFIG_PROVENANCE: true
     outputs:
       release: ${{ steps.set-release.outputs.release }}
+      release_type: ${{ steps.set-release.outputs.release_type }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set release version in env
         run: echo "RELEASE=$(node -e 'console.log(require("./package.json").version)')" >> "$GITHUB_ENV"
+
+      - name: Determine release type
+        id: release-type
+        run: |
+          VERSION="${{ env.RELEASE }}"
+          if [[ "$VERSION" == *"-rc."* ]]; then
+            echo "type=rc" >> "$GITHUB_OUTPUT"
+          else
+            echo "type=stable" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Setup and Build
         uses: ./.github/actions/setup-nodejs-github
@@ -57,7 +68,7 @@ jobs:
           node .github/scripts/trim-fe-packageJson.js
           node .github/scripts/ensure-provenance-fields.mjs
           cp README.md packages/cli/README.md
-          sed -i "s/default: 'dev'/default: 'stable'/g" packages/cli/dist/config/schema.js
+          sed -i "s/default: 'dev'/default: '${{ steps.release-type.outputs.type }}'/g" packages/cli/dist/config/schema.js
 
       - name: Publish n8n to NPM with rc tag
         env:
@@ -74,7 +85,9 @@ jobs:
         continue-on-error: true
 
       - id: set-release
-        run: echo "release=${{ env.RELEASE }}" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "release=${{ env.RELEASE }}" >> "$GITHUB_OUTPUT"
+          echo "release_type=${{ steps.release-type.outputs.type }}" >> "$GITHUB_OUTPUT"
 
   publish-to-docker-hub:
     name: Publish to DockerHub
@@ -82,7 +95,7 @@ jobs:
     uses: ./.github/workflows/docker-build-push.yml
     with:
       n8n_version: ${{ needs.publish-to-npm.outputs.release }}
-      release_type: stable
+      release_type: ${{ needs.publish-to-npm.outputs.release_type }}
     secrets: inherit
 
   create-github-release:

--- a/packages/@n8n/api-types/src/frontend-settings.ts
+++ b/packages/@n8n/api-types/src/frontend-settings.ts
@@ -96,7 +96,7 @@ export interface FrontendSettings {
 		secure: boolean;
 	};
 	binaryDataMode: 'default' | 'filesystem' | 's3' | 'database';
-	releaseChannel: 'stable' | 'beta' | 'nightly' | 'dev';
+	releaseChannel: 'stable' | 'beta' | 'nightly' | 'dev' | 'rc';
 	n8nMetadata?: {
 		userId?: string;
 		[key: string]: string | number | undefined;

--- a/packages/@n8n/config/src/configs/generic.config.ts
+++ b/packages/@n8n/config/src/configs/generic.config.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { Config, Env } from '../decorators';
 
-const releaseChannelSchema = z.enum(['stable', 'beta', 'nightly', 'dev']);
+const releaseChannelSchema = z.enum(['stable', 'beta', 'nightly', 'dev', 'rc']);
 type ReleaseChannel = z.infer<typeof releaseChannelSchema>;
 
 @Config

--- a/packages/frontend/@n8n/design-system/src/components/N8nLogo/Logo.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nLogo/Logo.vue
@@ -15,7 +15,7 @@ const props = defineProps<
 				collapsed: boolean;
 		  }
 	) & {
-		releaseChannel?: 'stable' | 'beta' | 'nightly' | 'dev';
+		releaseChannel?: 'stable' | 'beta' | 'nightly' | 'dev' | 'rc';
 	}
 >();
 


### PR DESCRIPTION
## Summary
Automatically detect Release Candidate versions during publish and set `N8N_RELEASE_TYPE=rc` so RC users see an orange logo and `[RC]` in their browser tab.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/CAT-1833

### Schema & Types
- Add `'rc'` to `releaseChannelSchema` in backend config
- Add `'rc'` to `releaseChannel` type in frontend settings
- Add `'rc'` to Logo component prop type

### Release Workflow
- Auto-detect RC versions (contains `-rc.`) in `release-publish.yml`
- Set `release_type=rc` for both npm and Docker builds
- Add `'rc'` to security scan conditions in `docker-build-push.yml`

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
