### PR TITLE
fix(PostgreSQL Node): Input items with array being modified

### DIFF
--- a/packages/nodes-base/nodes/Postgres/test/v2/utils.test.ts
+++ b/packages/nodes-base/nodes/Postgres/test/v2/utils.test.ts
@@ -535,14 +535,39 @@ describe('Test PostgresV2, convertArraysToPostgresFormat', () => {
 			},
 		];
 
-		convertArraysToPostgresFormat(item, schema, node, 0);
+		const result = convertArraysToPostgresFormat(item, schema, node, 0);
 
-		expect(item).toEqual({
+		expect(result).toEqual({
 			jsonb_array: '{"{\\"key\\":\\"value44\\"}"}',
 			json_array: '{"{\\"key\\":\\"value54\\"}"}',
 			int_array: '{1,2,5}',
 			text_array: '{"one","t\\"w\\"o"}',
 			bool_array: '{"true","false"}',
 		});
+	});
+
+	it('should not modify the original data object', () => {
+		const referenceItem = {
+			arr: [1, 2, 3],
+		};
+		const item = {
+			arr: [1, 2, 3],
+		};
+		const schema: ColumnInfo[] = [
+			{
+				column_name: 'arr',
+				data_type: 'ARRAY',
+				is_nullable: 'YES',
+				udt_name: '_int4',
+				column_default: null,
+			},
+		];
+
+		const result = convertArraysToPostgresFormat(item, schema, node, 0);
+
+		expect(result).toEqual({
+			arr: '{1,2,3}',
+		});
+		expect(item).toEqual(referenceItem);
 	});
 });

--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/insert.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/insert.operation.ts
@@ -234,7 +234,7 @@ export async function execute(
 		tableSchema = await updateTableSchema(db, tableSchema, schema, table);
 
 		if (nodeVersion >= 2.4) {
-			convertArraysToPostgresFormat(item, tableSchema, this.getNode(), i);
+			item = convertArraysToPostgresFormat(item, tableSchema, this.getNode(), i);
 		}
 
 		values.push(checkItemAgainstSchema(this.getNode(), item, tableSchema, i));

--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/update.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/update.operation.ts
@@ -302,7 +302,7 @@ export async function execute(
 		tableSchema = await updateTableSchema(db, tableSchema, schema, table);
 
 		if (nodeVersion >= 2.4) {
-			convertArraysToPostgresFormat(item, tableSchema, this.getNode(), i);
+			item = convertArraysToPostgresFormat(item, tableSchema, this.getNode(), i);
 		}
 
 		item = checkItemAgainstSchema(this.getNode(), item, tableSchema, i);

--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/upsert.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/upsert.operation.ts
@@ -271,7 +271,7 @@ export async function execute(
 		tableSchema = await updateTableSchema(db, tableSchema, schema, table);
 
 		if (nodeVersion >= 2.4) {
-			convertArraysToPostgresFormat(item, tableSchema, this.getNode(), i);
+			item = convertArraysToPostgresFormat(item, tableSchema, this.getNode(), i);
 		}
 
 		item = checkItemAgainstSchema(this.getNode(), item, tableSchema, i);


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

When using "Insert", "Update" or "Insert or Update" operation in a Postgres node and input items have array fields, input items for other nodes might get modified, which is not desired. This is due to the fact that the arrays are converted to the Postgres format in-place, instead of creating a new item. This PR fixes it

#### Testing
For Postgres setup: create a table `test_with_arr` (or other name) with a column `id` of type `text` (the primary key) and column `some_array` of type `text[]`

Use the following workflow (operation can be changed to "Insert" or "Update" and the bug still occurs). Check the sticky in the workflow for more info:
```json
{
  "nodes": [
    {
      "parameters": {},
      "type": "n8n-nodes-base.manualTrigger",
      "typeVersion": 1,
      "position": [
        -352,
        160
      ],
      "id": "fe152fd1-413c-460e-9d8f-65efce276fde",
      "name": "When clicking ‘Execute workflow’"
    },
    {
      "parameters": {
        "jsCode": "return [\n  {\n    \"id\": \"123\",\n    \"some_array\": [\n      \"foo\",\n      \"bar\",\n      \"baz\",\n    ]\n  }\n]"
      },
      "type": "n8n-nodes-base.code",
      "typeVersion": 2,
      "position": [
        -128,
        160
      ],
      "id": "92c6f28f-5362-40b0-935c-55a1854a4c93",
      "name": "Code in JavaScript"
    },
    {
      "parameters": {
        "conditions": {
          "options": {
            "caseSensitive": true,
            "leftValue": "",
            "typeValidation": "strict",
            "version": 2
          },
          "conditions": [
            {
              "id": "42a784f4-b2eb-40e9-b701-ad4043baaebb",
              "leftValue": "={{ Array.isArray($json.some_array) }}",
              "rightValue": "array",
              "operator": {
                "type": "boolean",
                "operation": "true",
                "singleValue": true
              }
            }
          ],
          "combinator": "and"
        },
        "options": {}
      },
      "type": "n8n-nodes-base.filter",
      "typeVersion": 2.2,
      "position": [
        96,
        256
      ],
      "id": "7589bf53-b9ab-4be8-8b7d-e6aa3ef51f05",
      "name": "Filter"
    },
    {
      "parameters": {
        "content": "This should have items.\n\nIf no items then the array has been mangled\nExpected: \nAlways 1 item outputted\n\nActual\n1 item when Postgres is disabled\n0 item when Postgres is enabled\n",
        "height": 192,
        "width": 496
      },
      "type": "n8n-nodes-base.stickyNote",
      "position": [
        368,
        112
      ],
      "typeVersion": 1,
      "id": "6790a749-889b-489a-9ed2-e4b4ce06aa30",
      "name": "Sticky Note"
    },
    {
      "parameters": {
        "operation": "upsert",
        "schema": {
          "__rl": true,
          "mode": "list",
          "value": "public"
        },
        "table": {
          "__rl": true,
          "value": "test_with_arr",
          "mode": "list",
          "cachedResultName": "test_with_arr"
        },
        "columns": {
          "mappingMode": "autoMapInputData",
          "value": {},
          "matchingColumns": [
            "id"
          ],
          "schema": [
            {
              "id": "id",
              "displayName": "id",
              "required": true,
              "defaultMatch": true,
              "display": true,
              "type": "string",
              "canBeUsedToMatch": true
            },
            {
              "id": "some_array",
              "displayName": "some_array",
              "required": false,
              "defaultMatch": false,
              "display": true,
              "type": "array",
              "canBeUsedToMatch": false
            }
          ],
          "attemptToConvertTypes": false,
          "convertFieldsToString": false
        },
        "options": {}
      },
      "type": "n8n-nodes-base.postgres",
      "typeVersion": 2.6,
      "position": [
        96,
        64
      ],
      "id": "37bbb309-76b7-4fe0-a928-44c85a841b2b",
      "name": "Insert or update rows in a table",
      "credentials": {
        "postgres": {
          "id": "OsVhEIlX1uCmsd71",
          "name": "Postgres (localhost)"
        }
      }
    }
  ],
  "connections": {
    "When clicking ‘Execute workflow’": {
      "main": [
        [
          {
            "node": "Code in JavaScript",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Code in JavaScript": {
      "main": [
        [
          {
            "node": "Filter",
            "type": "main",
            "index": 0
          },
          {
            "node": "Insert or update rows in a table",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {},
  "meta": {
    "templateCredsSetupCompleted": true,
    "instanceId": "eeda9e3069aca300d1dfceeb64beb5b53d715db44a50461bbc5cb0cf6daa01e3"
  }
}
```

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-4001/postgres-node-postgres-node-with-map-automatically-mangles-string
https://community.n8n.io/t/bug-postgres-node-with-map-automatically-mangles-string-arrays/226171

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
