### PR TITLE
fix(Guardrails Node): Remove Guardrails from "Source for Prompt"

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/Agent.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/Agent.node.ts
@@ -28,7 +28,7 @@ export class Agent extends VersionedNodeType {
 					],
 				},
 			},
-			defaultVersion: 3,
+			defaultVersion: 3.1,
 		};
 
 		const nodeVersions: IVersionedNodeType['nodeVersions'] = {
@@ -45,7 +45,9 @@ export class Agent extends VersionedNodeType {
 			2: new AgentV2(baseDescription),
 			2.1: new AgentV2(baseDescription),
 			2.2: new AgentV2(baseDescription),
+			2.3: new AgentV2(baseDescription),
 			3: new AgentV3(baseDescription),
+			3.1: new AgentV3(baseDescription),
 			// IMPORTANT Reminder to update AgentTool
 		};
 

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/V1/AgentV1.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/V1/AgentV1.node.ts
@@ -12,7 +12,7 @@ import type {
 } from 'n8n-workflow';
 
 import {
-	promptTypeOptions,
+	promptTypeOptionsDeprecated,
 	textFromGuardrailsNode,
 	textFromPreviousNode,
 	textInput,
@@ -374,7 +374,7 @@ export class AgentV1 implements INodeType {
 					default: 'toolsAgent',
 				},
 				{
-					...promptTypeOptions,
+					...promptTypeOptionsDeprecated,
 					displayOptions: {
 						hide: {
 							'@version': [{ _cnd: { lte: 1.2 } }],

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/V2/AgentV2.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/V2/AgentV2.node.ts
@@ -8,7 +8,7 @@ import type {
 } from 'n8n-workflow';
 
 import {
-	promptTypeOptions,
+	promptTypeOptionsDeprecated,
 	textFromGuardrailsNode,
 	textFromPreviousNode,
 	textInput,
@@ -24,7 +24,7 @@ export class AgentV2 implements INodeType {
 	constructor(baseDescription: INodeTypeBaseDescription) {
 		this.description = {
 			...baseDescription,
-			version: [2, 2.1, 2.2],
+			version: [2, 2.1, 2.2, 2.3],
 			defaults: {
 				name: 'AI Agent',
 				color: '#404040',
@@ -58,7 +58,7 @@ export class AgentV2 implements INodeType {
 					},
 					default: '',
 				},
-				promptTypeOptions,
+				promptTypeOptionsDeprecated,
 				{
 					...textFromGuardrailsNode,
 					displayOptions: {

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/V2/AgentV2.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/V2/AgentV2.node.ts
@@ -24,7 +24,7 @@ export class AgentV2 implements INodeType {
 	constructor(baseDescription: INodeTypeBaseDescription) {
 		this.description = {
 			...baseDescription,
-			version: [2, 2.1, 2.2, 2.3],
+			version: [2, 2.1, 2.2],
 			defaults: {
 				name: 'AI Agent',
 				color: '#404040',

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/V3/AgentV3.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/V3/AgentV3.node.ts
@@ -11,6 +11,7 @@ import type {
 
 import {
 	promptTypeOptions,
+	promptTypeOptionsDeprecated,
 	textFromGuardrailsNode,
 	textFromPreviousNode,
 	textInput,
@@ -27,7 +28,7 @@ export class AgentV3 implements INodeType {
 	constructor(baseDescription: INodeTypeBaseDescription) {
 		this.description = {
 			...baseDescription,
-			version: [3],
+			version: [3, 3.1],
 			defaults: {
 				name: 'AI Agent',
 				color: '#404040',
@@ -47,7 +48,14 @@ export class AgentV3 implements INodeType {
 					type: 'callout',
 					default: '',
 				},
-				promptTypeOptions,
+				{
+					...promptTypeOptionsDeprecated,
+					displayOptions: { show: { '@version': [{ _cnd: { lt: 3.1 } }] } },
+				},
+				{
+					...promptTypeOptions,
+					displayOptions: { show: { '@version': [{ _cnd: { gte: 3.1 } }] } },
+				},
 				{
 					...textFromGuardrailsNode,
 					displayOptions: {

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/description.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/description.ts
@@ -1,7 +1,7 @@
 import type { INodeProperties } from 'n8n-workflow';
 
 import {
-	promptTypeOptions,
+	promptTypeOptionsDeprecated,
 	textFromGuardrailsNode,
 	textFromPreviousNode,
 	textInput,
@@ -110,7 +110,7 @@ export const sqlAgentAgentProperties: INodeProperties[] = [
 		},
 	},
 	{
-		...promptTypeOptions,
+		...promptTypeOptionsDeprecated,
 		displayOptions: {
 			hide: {
 				'@version': [{ _cnd: { lte: 1.2 } }],

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
@@ -27,7 +27,7 @@ export class ChainLlm implements INodeType {
 		icon: 'fa:link',
 		iconColor: 'black',
 		group: ['transform'],
-		version: [1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7],
+		version: [1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8],
 		description: 'A simple chain to prompt a large language model',
 		defaults: {
 			name: 'Basic LLM Chain',

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/config.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/config.ts
@@ -8,6 +8,7 @@ import { NodeConnectionTypes } from 'n8n-workflow';
 
 import {
 	promptTypeOptions,
+	promptTypeOptionsDeprecated,
 	textFromGuardrailsNode,
 	textFromPreviousNode,
 } from '@utils/descriptions';
@@ -95,10 +96,18 @@ export const nodeProperties: INodeProperties[] = [
 		},
 	},
 	{
-		...promptTypeOptions,
+		...promptTypeOptionsDeprecated,
 		displayOptions: {
 			hide: {
-				'@version': [1, 1.1, 1.2, 1.3],
+				'@version': [{ _cnd: { lte: 1.3 } }, { _cnd: { gte: 1.8 } }],
+			},
+		},
+	},
+	{
+		...promptTypeOptions,
+		displayOptions: {
+			show: {
+				'@version': [{ _cnd: { gte: 1.8 } }],
 			},
 		},
 	},

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/ChainRetrievalQa.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/ChainRetrievalQa.node.ts
@@ -8,6 +8,7 @@ import {
 
 import {
 	promptTypeOptions,
+	promptTypeOptionsDeprecated,
 	textFromGuardrailsNode,
 	textFromPreviousNode,
 } from '@utils/descriptions';
@@ -23,7 +24,7 @@ export class ChainRetrievalQa implements INodeType {
 		icon: 'fa:link',
 		iconColor: 'black',
 		group: ['transform'],
-		version: [1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6],
+		version: [1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7],
 		description: 'Answer questions about retrieved documents',
 		defaults: {
 			name: 'Question and Answer Chain',
@@ -100,10 +101,18 @@ export class ChainRetrievalQa implements INodeType {
 				},
 			},
 			{
-				...promptTypeOptions,
+				...promptTypeOptionsDeprecated,
 				displayOptions: {
 					hide: {
-						'@version': [{ _cnd: { lte: 1.2 } }],
+						'@version': [{ _cnd: { lte: 1.2 } }, { _cnd: { gte: 1.7 } }],
+					},
+				},
+			},
+			{
+				...promptTypeOptions,
+				displayOptions: {
+					show: {
+						'@version': [{ _cnd: { gte: 1.7 } }],
 					},
 				},
 			},

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v1/actions/assistant/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v1/actions/assistant/message.operation.ts
@@ -18,7 +18,7 @@ import {
 } from 'n8n-workflow';
 import { OpenAI as OpenAIClient } from 'openai';
 
-import { promptTypeOptions } from '@utils/descriptions';
+import { promptTypeOptionsDeprecated } from '@utils/descriptions';
 import { getConnectedTools, getPromptInputByType } from '@utils/helpers';
 import { getTracingConfig } from '@utils/tracing';
 
@@ -29,7 +29,7 @@ import { getProxyAgent } from '@utils/httpProxyAgent';
 const properties: INodeProperties[] = [
 	assistantRLC,
 	{
-		...promptTypeOptions,
+		...promptTypeOptionsDeprecated,
 		name: 'prompt',
 	},
 	{

--- a/packages/@n8n/nodes-langchain/utils/descriptions.ts
+++ b/packages/@n8n/nodes-langchain/utils/descriptions.ts
@@ -100,7 +100,7 @@ export const buildInputSchemaField = (props?: {
 
 export const inputSchemaField = buildInputSchemaField();
 
-export const promptTypeOptions: INodeProperties = {
+export const promptTypeOptionsDeprecated: INodeProperties = {
 	displayName: 'Source for Prompt (User Message)',
 	name: 'promptType',
 	type: 'options',
@@ -116,6 +116,26 @@ export const promptTypeOptions: INodeProperties = {
 			value: 'guardrails',
 			description:
 				"Looks for an input field called 'guardrailsInput' that is coming from a directly connected Guardrails Node",
+		},
+		{
+			name: 'Define below',
+			value: 'define',
+			description: 'Use an expression to reference data in previous nodes or enter static text',
+		},
+	],
+	default: 'auto',
+};
+
+export const promptTypeOptions: INodeProperties = {
+	displayName: 'Source for Prompt (User Message)',
+	name: 'promptType',
+	type: 'options',
+	options: [
+		{
+			name: 'Connected Chat Trigger Node',
+			value: 'auto',
+			description:
+				"Looks for an input field called 'chatInput' that is coming from a directly connected Chat Trigger",
 		},
 		{
 			name: 'Define below',


### PR DESCRIPTION
## Summary

This PR removes Guardrails option from "Source for Prompt". Old major node versions will still have it, but new versions - won't

<img width="662" height="463" alt="изображение" src="https://github.com/user-attachments/assets/a74be6d4-afc6-4397-b0bc-f1d6fbbf21aa" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3905/bug-remove-guardrails-option-from-agent-prompt


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
