### PR TITLE
feat: Remove mysql and mariadb support

### DIFF
--- a/.github/workflows/ci-postgres-mysql.yml
+++ b/.github/workflows/ci-postgres-mysql.yml
@@ -60,6 +60,7 @@ jobs:
     needs: build
     runs-on: blacksmith-4vcpu-ubuntu-2204
     timeout-minutes: 30
+    if: false
     env:
       DB_MYSQLDB_PASSWORD: password
       DB_MYSQLDB_POOL_SIZE: 1
@@ -89,6 +90,7 @@ jobs:
     needs: build
     runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 20
+    if: false
     env:
       DB_MYSQLDB_PASSWORD: password
       DB_MYSQLDB_POOL_SIZE: 1
@@ -140,7 +142,7 @@ jobs:
   notify-on-failure:
     name: Notify Slack on failure
     runs-on: ubuntu-latest
-    needs: [sqlite-pooled, mariadb, postgres, mysql]
+    needs: [sqlite-pooled, postgres]
     steps:
       - name: Notify Slack on failure
         uses: act10ns/slack@44541246747a30eb3102d87f7a4cc5471b0ffb7d # v2.1.0

--- a/packages/@n8n/config/src/configs/database.config.ts
+++ b/packages/@n8n/config/src/configs/database.config.ts
@@ -183,4 +183,10 @@ export class DatabaseConfig {
 
 	@Nested
 	sqlite: SqliteConfig;
+
+	sanitize() {
+		if (this.type === 'mariadb' || this.type === 'mysqldb') {
+			throw new Error('MySQL and MariaDB have been removed. Please migrate to PostgreSQL.');
+		}
+	}
 }

--- a/packages/@n8n/config/src/configs/database.config.ts
+++ b/packages/@n8n/config/src/configs/database.config.ts
@@ -5,6 +5,17 @@ import { Config, Env, Nested } from '../decorators';
 const dbLoggingOptionsSchema = z.enum(['query', 'error', 'schema', 'warn', 'info', 'log', 'all']);
 type DbLoggingOptions = z.infer<typeof dbLoggingOptionsSchema>;
 
+class MySqlMariaDbNotSupportedError extends Error {
+	// Workaround to not get this reported to Sentry
+	readonly cause: { level: 'warning' } = {
+		level: 'warning',
+	};
+
+	constructor() {
+		super('MySQL and MariaDB have been removed. Please migrate to PostgreSQL.');
+	}
+}
+
 @Config
 class LoggingConfig {
 	/** Whether database logging is enabled. */
@@ -186,7 +197,7 @@ export class DatabaseConfig {
 
 	sanitize() {
 		if (this.type === 'mariadb' || this.type === 'mysqldb') {
-			throw new Error('MySQL and MariaDB have been removed. Please migrate to PostgreSQL.');
+			throw new MySqlMariaDbNotSupportedError();
 		}
 	}
 }

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 import type { UserManagementConfig } from '../src/configs/user-management.config';
+import type { DatabaseConfig } from '../src/index';
 import { GlobalConfig } from '../src/index';
 
 jest.mock('fs');
@@ -103,7 +104,7 @@ describe('GlobalConfig', () => {
 			type: 'sqlite',
 			isLegacySqlite: false,
 			pingIntervalSeconds: 2,
-		},
+		} as DatabaseConfig,
 		credentials: {
 			defaultName: 'My credentials',
 			overwrite: {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,14 +26,14 @@
     "test:dev": "N8N_LOG_LEVEL=silent DB_SQLITE_POOL_SIZE=4 DB_TYPE=sqlite jest --watch",
     "test:sqlite": "N8N_LOG_LEVEL=silent DB_SQLITE_POOL_SIZE=4 DB_TYPE=sqlite jest --config=jest.config.integration.js --no-coverage",
     "test:postgres": "N8N_LOG_LEVEL=silent DB_TYPE=postgresdb DB_POSTGRESDB_SCHEMA=alt_schema DB_TABLE_PREFIX=test_ jest --config=jest.config.integration.js --no-coverage",
-    "test:mariadb": "N8N_LOG_LEVEL=silent DB_TYPE=mariadb DB_TABLE_PREFIX=test_ jest --config=jest.config.integration.js --no-coverage",
-    "test:mysql": "N8N_LOG_LEVEL=silent DB_TYPE=mysqldb DB_TABLE_PREFIX=test_ jest --config=jest.config.integration.js --no-coverage --maxWorkers=1",
+    "test:mariadb": "echo true",
+    "test:mysql": "echo true",
     "test:win": "set N8N_LOG_LEVEL=silent&& set DB_SQLITE_POOL_SIZE=4&& set DB_TYPE=sqlite&& jest",
     "test:dev:win": "set N8N_LOG_LEVEL=silent&& set DB_SQLITE_POOL_SIZE=4&& set DB_TYPE=sqlite&& jest --watch",
     "test:sqlite:win": "set N8N_LOG_LEVEL=silent&& set DB_SQLITE_POOL_SIZE=4&& set DB_TYPE=sqlite&& jest --config=jest.config.integration.js",
     "test:postgres:win": "set N8N_LOG_LEVEL=silent&& set DB_TYPE=postgresdb&& set DB_POSTGRESDB_SCHEMA=alt_schema&& set DB_TABLE_PREFIX=test_&& jest --config=jest.config.integration.js --no-coverage",
-    "test:mariadb:win": "set N8N_LOG_LEVEL=silent&& set DB_TYPE=mariadb&& set DB_TABLE_PREFIX=test_&& jest --config=jest.config.integration.js --no-coverage",
-    "test:mysql:win": "set N8N_LOG_LEVEL=silent&& set DB_TYPE=mysqldb&& set DB_TABLE_PREFIX=test_&& jest --config=jest.config.integration.js --no-coverage",
+    "test:mariadb:win": "echo true",
+    "test:mysql:win": "echo true",
     "watch": "tsc-watch -p tsconfig.build.json --onCompilationComplete \"tsc-alias -p tsconfig.build.json\""
   },
   "bin": {


### PR DESCRIPTION
## Summary

Disallow starting n8n with MariaDB and MySQL. Cleanup will follow in CAT-1836.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-48/drop-mysqlmariadb-support

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
