### PR TITLE
fix: shopify typo fixed from limeItemsUi to lineItemsUi

### DIFF
--- a/packages/nodes-base/nodes/Shopify/OrderDescription.ts
+++ b/packages/nodes-base/nodes/Shopify/OrderDescription.ts
@@ -396,7 +396,7 @@ export const orderFields: INodeProperties[] = [
 	},
 	{
 		displayName: 'Line Items',
-		name: 'limeItemsUi',
+		name: 'lineItemsUi',
 		placeholder: 'Add Line Item',
 		type: 'fixedCollection',
 		typeOptions: {

--- a/packages/nodes-base/nodes/Shopify/Shopify.node.ts
+++ b/packages/nodes-base/nodes/Shopify/Shopify.node.ts
@@ -179,7 +179,7 @@ export class Shopify implements INodeType {
 						const discount = additionalFields.discountCodesUi as IDataObject;
 						const billing = additionalFields.billingAddressUi as IDataObject;
 						const shipping = additionalFields.shippingAddressUi as IDataObject;
-						const lineItem = (this.getNodeParameter('limeItemsUi', i) as IDataObject)
+						const lineItem = (this.getNodeParameter('lineItemsUi', i) as IDataObject)
 							.lineItemValues as IDataObject[];
 						if (lineItem === undefined) {
 							throw new NodeOperationError(

--- a/packages/testing/playwright/tests/cli-workflows/workflows/139.json
+++ b/packages/testing/playwright/tests/cli-workflows/workflows/139.json
@@ -115,7 +115,7 @@
 					"tags": "test,",
 					"test": ""
 				},
-				"limeItemsUi": {
+				"lineItemsUi": {
 					"lineItemValues": [
 						{
 							"productId": "={{$node[\"Shopify\"].json[\"id\"]}}",


### PR DESCRIPTION
## Summary
Typo of limeItemsUi fixed to lineItemsUi.

## Related Linear tickets, Github issues, and Community forum posts
#22372


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
