### PR TITLE
fix(editor): Stop proxying posthog events temporarily (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/stores/posthog.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/posthog.store.ts
@@ -136,7 +136,8 @@ export const usePostHog = defineStore('posthog', () => {
 		const distinctId = `${instanceId}#${userId}`;
 
 		const options: Parameters<typeof window.posthog.init>[1] = {
-			api_host: settingsStore.settings.posthog.proxy,
+			// FIXME: Removing the proxy for now until we test the fixes properly
+			api_host: 'https://us.i.posthog.com', //settingsStore.settings.posthog.proxy,
 			autocapture: config.autocapture,
 			disable_session_recording: config.disableSessionRecording,
 			debug: config.debug,


### PR DESCRIPTION
## Summary
Temporarily stop proxying PostHog events trough our local proxy.


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
