### PR TITLE
chore: Change killBehavior to `forceful` in launch.json  (no-changelog)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -26,15 +26,11 @@
 			"name": "Launch n8n with debug",
 			"program": "${workspaceFolder}/packages/cli/bin/n8n",
 			"cwd": "${workspaceFolder}/packages/cli/bin",
-			// "args": ["start", "--tunnel"],
 			"request": "launch",
 			"skipFiles": ["<node_internals>/**"],
 			"type": "node",
-			"env": {
-				// "N8N_PORT": "5679",
-			},
 			"outputCapture": "std",
-			"killBehavior": "polite"
+			"killBehavior": "forceful"
 		},
 		{
 			"name": "Launch n8n CLI dev with debug",


### PR DESCRIPTION
## Summary

On Windows `"killBehavior": "polite"` doesn't kill the instance and instead leaves it hanging. "forceful" always kills the instance when debug session is stopped

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
