### PR TITLE
build: Address TS error regarding Vue slots

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/DateRangePicker/DateRangePicker.vue
+++ b/packages/frontend/@n8n/design-system/src/components/DateRangePicker/DateRangePicker.vue
@@ -17,7 +17,6 @@ import {
 	DateRangePickerTrigger,
 	useForwardPropsEmits,
 } from 'reka-ui';
-import { useSlots } from 'vue';
 
 import Button from '../N8nButton/Button.vue';
 import IconButton from '../N8nIconButton';
@@ -32,8 +31,13 @@ const props = withDefaults(defineProps<N8nDateRangePickerProps>(), {
 });
 
 const emit = defineEmits<N8nDateRangePickerRootEmits>();
+
+defineSlots<{
+	presets?: {};
+	trigger?: {};
+}>();
+
 const forwarded = useForwardPropsEmits(props, emit);
-const slots = useSlots();
 </script>
 
 <template>
@@ -46,7 +50,7 @@ const slots = useSlots();
 
 		<DateRangePickerContent align="start" :side-offset="5" :class="$style.PopoverContent">
 			<DateRangePickerCalendar v-slot="{ weekDays, grid }" :class="$style.Calendar">
-				<template v-if="!!slots.presets">
+				<template v-if="!!$slots.presets">
 					<div :class="$style.Presets">
 						<slot name="presets" />
 					</div>


### PR DESCRIPTION
## Summary

Fix TS error printed when building `@n8n/chat` package
```
  > @n8n/chat@0.67.0 build:vite /home/runner/_work/n8n/n8n/packages/frontend/@n8n/chat
  > cross-env vite build
  
  rolldown-vite v7.1.16 building for production...
  ../design-system/src/components/DateRangePicker/DateRangePicker.vue:36:7 - error TS7022: 'slots' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
  
  36 const slots = useSlots();
           ~~~~~
```

## Related Linear tickets, Github issues, and Community forum posts

N/A


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
