### PR TITLE
fix: Support resolving $fromAI in vector store tools

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/operations/retrieveAsToolOperation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/operations/retrieveAsToolOperation.ts
@@ -33,7 +33,7 @@ export async function handleRetrieveAsToolOperation<T extends VectorStore = Vect
 	const vectorStoreTool = createToolFromNode(node, {
 		name: toolName,
 		description: toolDescription,
-		extraArgs: [{ key: 'query', description: 'Query to search for. Required' }],
+		extraArgs: [{ key: 'input', description: 'Query to search for. Required' }],
 		func: async (query) => {
 			const topK = context.getNodeParameter('topK', itemIndex, 4) as number;
 			const useReranker = context.getNodeParameter('useReranker', itemIndex, false) as boolean;
@@ -47,7 +47,7 @@ export async function handleRetrieveAsToolOperation<T extends VectorStore = Vect
 			const filter = getMetadataFiltersValues(context, itemIndex);
 
 			// Extract the query string - it can be either a string (DynamicTool) or an object with 'input' key (DynamicStructuredTool)
-			const queryString = typeof query === 'string' ? query : query.query;
+			const queryString = typeof query === 'string' ? query : query.input;
 			assert(typeof queryString === 'string', 'Query must be of type string');
 
 			// For each tool use, get a fresh vector store client.

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/operations/retrieveAsToolOperation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/operations/retrieveAsToolOperation.ts
@@ -1,12 +1,11 @@
 import type { Embeddings } from '@langchain/core/embeddings';
 import type { BaseDocumentCompressor } from '@langchain/core/retrievers/document_compressors';
 import type { VectorStore } from '@langchain/core/vectorstores';
-import { DynamicTool } from 'langchain/tools';
-import { NodeConnectionTypes, type ISupplyDataFunctions, type SupplyData } from 'n8n-workflow';
-
+import { createToolFromNode } from '@utils/fromAIToolFactory';
 import { getMetadataFiltersValues } from '@utils/helpers';
-import { nodeNameToToolName } from 'n8n-workflow';
 import { logWrapper } from '@utils/logWrapper';
+import type { ISupplyDataFunctions, SupplyData } from 'n8n-workflow';
+import { assert, NodeConnectionTypes, nodeNameToToolName } from 'n8n-workflow';
 
 import type { VectorStoreNodeConstructorArgs } from '../types';
 
@@ -30,22 +29,27 @@ export async function handleRetrieveAsToolOperation<T extends VectorStore = Vect
 			? (context.getNodeParameter('toolName', itemIndex) as string)
 			: nodeNameToToolName(node);
 
-	const topK = context.getNodeParameter('topK', itemIndex, 4) as number;
-	const useReranker = context.getNodeParameter('useReranker', itemIndex, false) as boolean;
-	const includeDocumentMetadata = context.getNodeParameter(
-		'includeDocumentMetadata',
-		itemIndex,
-		true,
-	) as boolean;
-
-	// Get metadata filters
-	const filter = getMetadataFiltersValues(context, itemIndex);
-
 	// Create a Dynamic Tool that wraps vector store search functionality
-	const vectorStoreTool = new DynamicTool({
+	const vectorStoreTool = createToolFromNode(node, {
 		name: toolName,
 		description: toolDescription,
-		func: async (input) => {
+		extraArgs: [{ key: 'query', description: 'Query to search for. Required' }],
+		func: async (query) => {
+			const topK = context.getNodeParameter('topK', itemIndex, 4) as number;
+			const useReranker = context.getNodeParameter('useReranker', itemIndex, false) as boolean;
+			const includeDocumentMetadata = context.getNodeParameter(
+				'includeDocumentMetadata',
+				itemIndex,
+				true,
+			) as boolean;
+
+			// Get metadata filters
+			const filter = getMetadataFiltersValues(context, itemIndex);
+
+			// Extract the query string - it can be either a string (DynamicTool) or an object with 'input' key (DynamicStructuredTool)
+			const queryString = typeof query === 'string' ? query : query.query;
+			assert(typeof queryString === 'string', 'Query must be of type string');
+
 			// For each tool use, get a fresh vector store client.
 			// We don't pass in a filter here only later in the similaritySearchVectorWithScore
 			// method to avoid an exception with some vector stores like Supabase or Pinecone(#AI-740)
@@ -58,7 +62,7 @@ export async function handleRetrieveAsToolOperation<T extends VectorStore = Vect
 
 			try {
 				// Embed the input query
-				const embeddedPrompt = await embeddings.embedQuery(input);
+				const embeddedPrompt = await embeddings.embedQuery(queryString);
 
 				// Search for similar documents
 				let documents = await vectorStore.similaritySearchVectorWithScore(
@@ -75,7 +79,7 @@ export async function handleRetrieveAsToolOperation<T extends VectorStore = Vect
 					)) as BaseDocumentCompressor;
 
 					const docs = documents.map(([doc]) => doc);
-					const rerankedDocuments = await reranker.compressDocuments(docs, input);
+					const rerankedDocuments = await reranker.compressDocuments(docs, queryString);
 					documents = rerankedDocuments.map((doc) => {
 						const { relevanceScore, ...metadata } = doc.metadata;
 						return [{ ...doc, metadata }, relevanceScore];

--- a/packages/@n8n/nodes-langchain/utils/fromAIToolFactory.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/fromAIToolFactory.test.ts
@@ -1,0 +1,190 @@
+import { DynamicStructuredTool, DynamicTool } from '@langchain/core/tools';
+import type { INode, INodeParameters } from 'n8n-workflow';
+
+import {
+	createToolFromNode,
+	createZodSchemaFromArgs,
+	extractFromAIParameters,
+} from './fromAIToolFactory';
+
+describe('fromAIToolFactory', () => {
+	describe('extractFromAIParameters', () => {
+		it('should extract $fromAI parameters from node parameters', () => {
+			const nodeParameters: INodeParameters = {
+				someField: '$fromAI("name", "The name of the user", "string")',
+				nestedField: {
+					value: '$fromAI("age", "The age of the user", "number")',
+				},
+			};
+
+			const result = extractFromAIParameters(nodeParameters);
+
+			expect(result).toHaveLength(2);
+			expect(result).toContainEqual(
+				expect.objectContaining({
+					key: 'name',
+					description: 'The name of the user',
+					type: 'string',
+				}),
+			);
+			expect(result).toContainEqual(
+				expect.objectContaining({ key: 'age', description: 'The age of the user', type: 'number' }),
+			);
+		});
+
+		it('should deduplicate parameters with the same key', () => {
+			const nodeParameters: INodeParameters = {
+				field1: '$fromAI("name", "First description")',
+				field2: '$fromAI("name", "Second description")',
+			};
+
+			const result = extractFromAIParameters(nodeParameters);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].key).toBe('name');
+		});
+
+		it('should return empty array when no $fromAI parameters exist', () => {
+			const nodeParameters: INodeParameters = {
+				someField: 'regular value',
+				anotherField: 123,
+			};
+
+			const result = extractFromAIParameters(nodeParameters);
+
+			expect(result).toHaveLength(0);
+		});
+
+		it('should handle arrays in node parameters', () => {
+			const nodeParameters: INodeParameters = {
+				items: ['$fromAI("item1", "First item")', '$fromAI("item2", "Second item")'],
+			};
+
+			const result = extractFromAIParameters(nodeParameters);
+
+			expect(result).toHaveLength(2);
+		});
+	});
+
+	describe('createZodSchemaFromArgs', () => {
+		it('should create a Zod schema from arguments', () => {
+			const args = [
+				{ key: 'name', description: 'The name', type: 'string' as const },
+				{ key: 'age', description: 'The age', type: 'number' as const },
+			];
+
+			const schema = createZodSchemaFromArgs(args);
+
+			expect(schema.shape).toHaveProperty('name');
+			expect(schema.shape).toHaveProperty('age');
+		});
+
+		it('should handle boolean type', () => {
+			const args = [{ key: 'isActive', description: 'Is active', type: 'boolean' as const }];
+
+			const schema = createZodSchemaFromArgs(args);
+			const result = schema.safeParse({ isActive: true });
+
+			expect(result.success).toBe(true);
+		});
+
+		it('should handle default values', () => {
+			const args = [
+				{ key: 'name', description: 'The name', type: 'string' as const, defaultValue: 'John' },
+			];
+
+			const schema = createZodSchemaFromArgs(args);
+			const result = schema.safeParse({});
+
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.name).toBe('John');
+			}
+		});
+	});
+
+	describe('createToolFromNode', () => {
+		const createMockNode = (parameters: INodeParameters = {}): INode => ({
+			id: 'test-node',
+			name: 'Test Node',
+			type: 'test',
+			typeVersion: 1,
+			position: [0, 0],
+			parameters,
+		});
+
+		it('should create a DynamicTool when no $fromAI params and no extraArgs', () => {
+			const node = createMockNode({ regularParam: 'value' });
+			const tool = createToolFromNode(node, {
+				name: 'test-tool',
+				description: 'A test tool',
+				func: async () => 'result',
+			});
+
+			expect(tool).toBeInstanceOf(DynamicTool);
+			expect(tool.name).toBe('test-tool');
+			expect(tool.description).toBe('A test tool');
+		});
+
+		it('should create a DynamicStructuredTool when $fromAI params exist', () => {
+			const node = createMockNode({
+				field: '$fromAI("query", "The search query")',
+			});
+			const tool = createToolFromNode(node, {
+				name: 'search-tool',
+				description: 'A search tool',
+				func: async () => 'result',
+			});
+
+			expect(tool).toBeInstanceOf(DynamicStructuredTool);
+			expect(tool.name).toBe('search-tool');
+		});
+
+		it('should create a DynamicStructuredTool when extraArgs are provided', () => {
+			const node = createMockNode({});
+			const tool = createToolFromNode(node, {
+				name: 'tool-with-extra',
+				description: 'A tool with extra args',
+				func: async () => 'result',
+				extraArgs: [{ key: 'input', description: 'The input query' }],
+			});
+
+			expect(tool).toBeInstanceOf(DynamicStructuredTool);
+		});
+
+		it('should combine $fromAI params with extraArgs', () => {
+			const node = createMockNode({
+				field: '$fromAI("filter", "Filter criteria")',
+			});
+			const tool = createToolFromNode(node, {
+				name: 'combined-tool',
+				description: 'A tool with combined args',
+				func: async () => 'result',
+				extraArgs: [{ key: 'input', description: 'The input query' }],
+			}) as DynamicStructuredTool;
+
+			expect(tool).toBeInstanceOf(DynamicStructuredTool);
+			// Verify schema contains both keys by checking if parsing works
+			const schema = tool.schema as unknown as { shape: Record<string, unknown> };
+			expect(schema.shape).toHaveProperty('filter');
+			expect(schema.shape).toHaveProperty('input');
+		});
+
+		it('should pass the func to the tool', async () => {
+			const mockFunc = jest.fn().mockResolvedValue('test result');
+			const node = createMockNode({});
+			const tool = createToolFromNode(node, {
+				name: 'func-test-tool',
+				description: 'Testing func',
+				func: mockFunc,
+			});
+
+			const result = await tool.invoke('test input');
+
+			// Verify the function was called with the input as the first argument
+			expect(mockFunc).toHaveBeenCalled();
+			expect(mockFunc.mock.calls[0][0]).toBe('test input');
+			expect(result).toBe('test result');
+		});
+	});
+});

--- a/packages/@n8n/nodes-langchain/utils/fromAIToolFactory.ts
+++ b/packages/@n8n/nodes-langchain/utils/fromAIToolFactory.ts
@@ -1,0 +1,75 @@
+import type { CallbackManagerForToolRun } from '@langchain/core/callbacks/manager';
+import { DynamicStructuredTool, DynamicTool } from '@langchain/core/tools';
+import type { FromAIArgument, IDataObject, INode, INodeParameters } from 'n8n-workflow';
+import { generateZodSchema, traverseNodeParameters } from 'n8n-workflow';
+import { z } from 'zod';
+
+export type ToolFunc = (
+	query: string | IDataObject,
+	runManager?: CallbackManagerForToolRun,
+) => Promise<string | IDataObject | IDataObject[]>;
+
+export interface CreateToolOptions {
+	name: string;
+	description: string;
+	func: ToolFunc;
+	/**
+	 * Extra arguments to include in the structured tool schema.
+	 * These are added after extracting $fromAI parameters from node parameters.
+	 */
+	extraArgs?: FromAIArgument[];
+}
+
+/**
+ * Extracts $fromAI parameters from node parameters and returns unique arguments.
+ */
+export function extractFromAIParameters(nodeParameters: INodeParameters): FromAIArgument[] {
+	const collectedArguments: FromAIArgument[] = [];
+	traverseNodeParameters(nodeParameters, collectedArguments);
+
+	const uniqueArgsMap = new Map<string, FromAIArgument>();
+	for (const arg of collectedArguments) {
+		uniqueArgsMap.set(arg.key, arg);
+	}
+
+	return Array.from(uniqueArgsMap.values());
+}
+
+/**
+ * Creates a Zod schema from $fromAI arguments.
+ */
+export function createZodSchemaFromArgs(args: FromAIArgument[]): z.ZodObject<z.ZodRawShape> {
+	const schemaObj = args.reduce((acc: Record<string, z.ZodTypeAny>, placeholder) => {
+		acc[placeholder.key] = generateZodSchema(placeholder);
+		return acc;
+	}, {});
+
+	return z.object(schemaObj).required();
+}
+
+/**
+ * Creates a DynamicStructuredTool if node has $fromAI parameters,
+ * otherwise falls back to a simple DynamicTool.
+ *
+ * This is useful for creating AI agent tools that can extract parameters
+ * from node configuration using $fromAI expressions.
+ */
+export function createToolFromNode(
+	node: INode,
+	options: CreateToolOptions,
+): DynamicStructuredTool | DynamicTool {
+	const { name, description, func, extraArgs = [] } = options;
+
+	const collectedArguments = extractFromAIParameters(node.parameters);
+
+	// If there are no $fromAI arguments and no extra args, fallback to simple tool
+	if (collectedArguments.length === 0 && extraArgs.length === 0) {
+		return new DynamicTool({ name, description, func });
+	}
+
+	// Combine collected arguments with extra arguments
+	const allArguments = [...collectedArguments, ...extraArgs];
+	const schema = createZodSchemaFromArgs(allArguments);
+
+	return new DynamicStructuredTool({ schema, name, description, func });
+}

--- a/packages/frontend/editor-ui/src/app/components/FromAiParametersModal.vue
+++ b/packages/frontend/editor-ui/src/app/components/FromAiParametersModal.vue
@@ -6,13 +6,8 @@ import { FROM_AI_PARAMETERS_MODAL_KEY, AI_MCP_TOOL_NODE_TYPE } from '@/app/const
 import { useAgentRequestStore, type IAgentRequest } from '@n8n/stores/useAgentRequestStore';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { createEventBus } from '@n8n/utils/event-bus';
-import {
-	type INode,
-	type FromAIArgument,
-	type IDataObject,
-	NodeConnectionTypes,
-	traverseNodeParameters,
-} from 'n8n-workflow';
+import type { INode, FromAIArgument, IDataObject } from 'n8n-workflow';
+import { traverseNodeParameters, NodeConnectionTypes } from 'n8n-workflow';
 import type { FormFieldValueUpdate, IFormInput } from '@n8n/design-system';
 import { computed, ref, watch } from 'vue';
 import { useRouter } from 'vue-router';
@@ -202,6 +197,8 @@ watch(
 				},
 			});
 		});
+
+		const hasImplicityQuery = hasImplicityQueryParameter(newNode);
 		if (result.length === 0) {
 			let inputQuery = inputOverrides?.query;
 			if (typeof inputQuery === 'object') {
@@ -212,8 +209,8 @@ watch(
 				agentRequestStore.getQueryValue(workflowsStore.workflowId, newNode.id, 'query') ??
 				'';
 
-			result.push({
-				name: 'query',
+			result.unshift({
+				name: hasImplicityQuery ? 'query.query' : 'query',
 				initialValue: (queryValue as string) ?? '',
 				properties: {
 					label: 'Query',
@@ -226,6 +223,17 @@ watch(
 	},
 	{ immediate: true },
 );
+
+function hasImplicityQueryParameter(node: INode) {
+	// Check if this is a Vector Store node with 'retrieve-as-tool' operation
+	// These nodes always have an implicit 'query' parameter for the query
+	const nodeType = nodeTypesStore.getNodeType(node.type, node.typeVersion);
+	const aiSubcategories = nodeType?.codex?.subcategories?.AI;
+	const isVectorStoreToolNode =
+		aiSubcategories?.includes('Vector Stores') && aiSubcategories?.includes('Tools');
+	const mode = node.parameters.mode;
+	return isVectorStoreToolNode && mode === 'retrieve-as-tool';
+}
 
 const onClose = () => {
 	modalBus.emit('close');


### PR DESCRIPTION
## Summary
- Use structured tool for vector store search. Make the input explicit for vector store tools 
- Resolve $fromAI in all node parameters, including filters
- Support query and $fromAI parameters in partial tool execution UI 

https://github.com/user-attachments/assets/4a1ee938-5e8f-416d-bb15-3de9a10f743c



<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts


<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
closes #20394
https://github.com/n8n-io/n8n/issues/20394
https://community.n8n.io/t/adding-a-value-to-the-metadata-filter-using-the-ai-agent/194456


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
