### PR TITLE
fix(core): OIDC form breaks when enabling OIDC while SAML is active

### DIFF
--- a/packages/cli/src/sso.ee/oidc/oidc.service.ee.ts
+++ b/packages/cli/src/sso.ee/oidc/oidc.service.ee.ts
@@ -412,6 +412,16 @@ export class OidcService {
 	}
 
 	async updateConfig(newConfig: OidcConfigDto) {
+		const isEnablingOidcWhileOtherSsoProtocolIsAlreadyEnabled =
+			newConfig.loginEnabled &&
+			!isEmailCurrentAuthenticationMethod() &&
+			!isOidcCurrentAuthenticationMethod();
+		if (isEnablingOidcWhileOtherSsoProtocolIsAlreadyEnabled) {
+			throw new InternalServerError(
+				`Cannot switch OIDC login enabled state when an authentication method other than email or OIDC is active (current: ${getCurrentAuthenticationMethod()})`,
+			);
+		}
+
 		let discoveryEndpoint: URL;
 		try {
 			// Validating that discoveryEndpoint is a valid URL
@@ -466,7 +476,9 @@ export class OidcService {
 	private async setOidcLoginEnabled(enabled: boolean): Promise<void> {
 		const currentAuthenticationMethod = getCurrentAuthenticationMethod();
 
-		if (enabled && !isEmailCurrentAuthenticationMethod() && !isOidcCurrentAuthenticationMethod()) {
+		const isEnablingOidcWhileOtherSsoProtocolIsAlreadyEnabled =
+			enabled && !isEmailCurrentAuthenticationMethod() && !isOidcCurrentAuthenticationMethod();
+		if (isEnablingOidcWhileOtherSsoProtocolIsAlreadyEnabled) {
 			throw new InternalServerError(
 				`Cannot switch OIDC login enabled state when an authentication method other than email or OIDC is active (current: ${currentAuthenticationMethod})`,
 			);


### PR DESCRIPTION
## Summary

Fixes a bug that breaks the oidc form altogether.

Steps to reproduce:

- Activate SAML SSO login
- Go to OIDC settings
- Check "Single Sign On Activated" in OIDC form
- Submit form
- Error is shown that "cannot activate OIDC while SAML is active"
- But in the database the "isLoginEnabled" of the OIDC settings was still changed.
- GET /rest/sso/oidc/config will now always return 404

## Related Linear tickets, Github issues, and Community forum posts

closes PAY-4202


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
