### PR TITLE
feat(n8n Trigger Node): [Draft/Publish] Update copy (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/N8nTrigger/N8nTrigger.node.ts
+++ b/packages/nodes-base/nodes/N8nTrigger/N8nTrigger.node.ts
@@ -32,16 +32,16 @@ export class N8nTrigger implements INodeType {
 				default: [],
 				description: `Specifies under which conditions an execution should happen:
 				<ul>
-					<li><b>Published Workflow Updated</b>: Triggers when workflow version is published from published state (workflow was already active)</li>
+					<li><b>Published Workflow Updated</b>: Triggers when workflow version is published from a published state (workflow was already published)</li>
 					<li><b>Instance Started</b>:  Triggers when this n8n instance is started or re-started</li>
-					<li><b>Workflow Published</b>: Triggers when workflow version is published from unpublished state (workflow was inactive)</li>
+					<li><b>Workflow Published</b>: Triggers when workflow version is published from an unpublished state (workflow was unpublished)</li>
 				</ul>`,
 				options: [
 					{
 						name: 'Published Workflow Updated',
 						value: 'update',
 						description:
-							'Triggers when workflow version is published from published state (workflow was already published)',
+							'Triggers when workflow version is published from a published state (workflow was already published)',
 					},
 					{
 						name: 'Instance Started',
@@ -52,7 +52,7 @@ export class N8nTrigger implements INodeType {
 						name: 'Workflow Published',
 						value: 'activate',
 						description:
-							'Triggers when workflow version is published from unpublished state (workflow was not published)',
+							'Triggers when workflow version is published from an unpublished state (workflow was not published)',
 					},
 				],
 			},

--- a/packages/nodes-base/nodes/N8nTrigger/N8nTrigger.node.ts
+++ b/packages/nodes-base/nodes/N8nTrigger/N8nTrigger.node.ts
@@ -6,7 +6,7 @@ import type {
 } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
 
-type eventType = 'Instance started' | 'Workflow activated' | 'Workflow updated' | undefined;
+type eventType = 'Instance started' | 'Workflow published' | 'Workflow updated' | undefined;
 
 export class N8nTrigger implements INodeType {
 	description: INodeTypeDescription = {
@@ -32,15 +32,16 @@ export class N8nTrigger implements INodeType {
 				default: [],
 				description: `Specifies under which conditions an execution should happen:
 				<ul>
-					<li><b>Active Workflow Updated</b>: Triggers when this workflow is updated</li>
+					<li><b>Published Workflow Updated</b>: Triggers when workflow version is published from published state (workflow was already active)</li>
 					<li><b>Instance Started</b>:  Triggers when this n8n instance is started or re-started</li>
-					<li><b>Workflow Activated</b>: Triggers when this workflow is activated</li>
+					<li><b>Workflow Published</b>: Triggers when workflow version is published from unpublished state (workflow was inactive)</li>
 				</ul>`,
 				options: [
 					{
-						name: 'Active Workflow Updated',
+						name: 'Published Workflow Updated',
 						value: 'update',
-						description: 'Triggers when this workflow is updated',
+						description:
+							'Triggers when workflow version is published from published state (workflow was already published)',
 					},
 					{
 						name: 'Instance Started',
@@ -48,9 +49,10 @@ export class N8nTrigger implements INodeType {
 						description: 'Triggers when this n8n instance is started or re-started',
 					},
 					{
-						name: 'Workflow Activated',
+						name: 'Workflow Published',
 						value: 'activate',
-						description: 'Triggers when this workflow is activated',
+						description:
+							'Triggers when workflow version is published from unpublished state (workflow was not published)',
 					},
 				],
 			},
@@ -65,7 +67,7 @@ export class N8nTrigger implements INodeType {
 		if (events.includes(activationMode)) {
 			let event: eventType;
 			if (activationMode === 'activate') {
-				event = 'Workflow activated';
+				event = 'Workflow published';
 			}
 			if (activationMode === 'update') {
 				event = 'Workflow updated';

--- a/packages/nodes-base/nodes/N8nTrigger/test/trigger.test.ts
+++ b/packages/nodes-base/nodes/N8nTrigger/test/trigger.test.ts
@@ -29,7 +29,7 @@ describe('N8nTrigger', () => {
 			expect(mockTriggerFunctions.emit).toHaveBeenCalledWith([
 				[
 					{
-						event: 'Workflow activated',
+						event: 'Workflow published',
 						timestamp: expect.any(String),
 						workflow_id: 'test-workflow-id',
 					},


### PR DESCRIPTION
## Summary

This PR updates n8n node trigger to use the right terms ("publish" instead of "activate")
<img width="500" height="407" alt="image" src="https://github.com/user-attachments/assets/5cd42e80-0f81-434e-9c57-a73e7dfaf54e" />

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-4461](https://linear.app/n8n/issue/ADO-4461/feature-fe-v2-update-copy-of-n8n-node-triggers)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
