### PR TITLE
feat(core): Only fetch credentials available in user's personal project on Chat (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/chatHub/SettingsChatHubView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/SettingsChatHubView.vue
@@ -86,9 +86,11 @@ onMounted(async () => {
 	if (!settingsStore.isChatFeatureEnabled) {
 		return;
 	}
-	await fetchSettings();
-	await credentialsStore.fetchAllCredentials();
-	await credentialsStore.fetchCredentialTypes(false);
+	await Promise.all([
+		fetchSettings(),
+		credentialsStore.fetchAllCredentials(),
+		credentialsStore.fetchCredentialTypes(false),
+	]);
 });
 </script>
 <template>

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useChatCredentials.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useChatCredentials.ts
@@ -1,6 +1,5 @@
 import { LOCAL_STORAGE_CHAT_HUB_CREDENTIALS } from '@/app/constants';
 import { useSettingsStore } from '@/app/stores/settings.store';
-import { hasPermission } from '@/app/utils/rbac/permissions';
 import { credentialsMapSchema, type CredentialsMap } from '@/features/ai/chatHub/chat.types';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
@@ -102,16 +101,9 @@ export function useChatCredentials(userId: string) {
 		() => projectStore.personalProject,
 		async (personalProject) => {
 			if (personalProject) {
-				const hasGlobalCredentialRead = hasPermission(['rbac'], {
-					rbac: { scope: 'credential:read' },
-				});
-
 				await Promise.all([
 					credentialsStore.fetchCredentialTypes(false),
-					// For non-owner users only fetch credentials from personal project.
-					hasGlobalCredentialRead
-						? credentialsStore.fetchAllCredentials()
-						: credentialsStore.fetchAllCredentials(personalProject.id),
+					credentialsStore.fetchAllCredentialsForWorkflow({ projectId: personalProject.id }),
 				]);
 
 				isInitialized.value = true;


### PR DESCRIPTION
## Summary

Instead of fetching every available credential limit those to personal project scope. This should reduce the too large credential responses to more manageable ones, though admin users on environments like our internal will still see a lot of credentials returned...

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-69/make-credential-query-fe-does-only-target-users-personal-project

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
