### PR TITLE
fix(API): Correct user creation endpoint response specification

### DIFF
--- a/packages/cli/src/public-api/v1/handlers/users/spec/paths/users.yml
+++ b/packages/cli/src/public-api/v1/handlers/users/spec/paths/users.yml
@@ -52,26 +52,30 @@ post:
             required:
               - email
   responses:
-    '200':
+    '201':
       description: Operation successful.
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              user:
-                type: object
-                properties:
-                  id:
-                    type: string
-                  email:
-                    type: string
-                  inviteAcceptUrl:
-                    type: string
-                  emailSent:
-                    type: boolean
-              error:
-                type: string
+            type: array
+            items:
+              type: object
+              properties:
+                user:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    email:
+                      type: string
+                    inviteAcceptUrl:
+                      type: string
+                    emailSent:
+                      type: boolean
+                    role:
+                      type: string
+                error:
+                  type: string
     '401':
       $ref: '../../../../shared/spec/responses/unauthorized.yml'
     '403':


### PR DESCRIPTION
The OpenAPI specification for the user creation endpoint contained several inconsistencies that misrepresented the actual API behavior:

1. It incorrectly specified a 200 OK response status instead of the semantically correct 201 Created for resource creation
2. Defined the response schema as a single object rather than an array despite the endpoint's capability to create multiple users simultaneously
3. Omitted the role property from the user object schema which is returned by the actual implementation


<img width="2556" height="891" alt="Screenshot From 2025-11-28 19-14-40" src="https://github.com/user-attachments/assets/7d2e2771-4f24-4a98-8f00-39922f4d57b5" />



## Summary

- Change response status code from 200 to 201 for user creation
- Update response schema to return array instead of single object
- Add missing role property to user object in response schema

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

No related issue


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
