### PR TITLE
feat(gotify Node): Add optional URL field on message create

### DIFF
--- a/packages/nodes-base/nodes/Gotify/Gotify.node.ts
+++ b/packages/nodes-base/nodes/Gotify/Gotify.node.ts
@@ -223,20 +223,23 @@ export class Gotify implements INodeType {
 							message,
 						};
 
+						// set body.extras if needed
 						if (options.contentType || additionalFields.url) {
-							body.extras = body.extras || {};
+							const extras: IDataObject = {};
 
 							if (options.contentType) {
-								(body.extras as IDataObject)['client::display'] = {
+								extras['client::display'] = {
 									contentType: options.contentType,
 								};
 							}
 
 							if (additionalFields.url) {
-								(body.extras as IDataObject)['client::notification'] = {
+								extras['client::notification'] = {
 									click: { url: additionalFields.url },
 								};
 							}
+
+							body.extras = extras;
 						}
 
 						// add other additionalFields (title & priority) directly to the root of the body

--- a/packages/nodes-base/nodes/Gotify/Gotify.node.ts
+++ b/packages/nodes-base/nodes/Gotify/Gotify.node.ts
@@ -115,6 +115,13 @@ export class Gotify implements INodeType {
 						default: '',
 						description: 'The title of the message',
 					},
+					{
+						displayName: 'URL On Click',
+						name: 'url',
+						type: 'string',
+						default: '',
+						description: 'The URL to open when clicking on the notification',
+					},
 				],
 			},
 			{
@@ -216,15 +223,27 @@ export class Gotify implements INodeType {
 							message,
 						};
 
-						if (options.contentType) {
-							body.extras = {
-								'client::display': {
+						if (options.contentType || additionalFields.url) {
+							body.extras = body.extras || {};
+
+							if (options.contentType) {
+								(body.extras as IDataObject)['client::display'] = {
 									contentType: options.contentType,
-								},
-							};
+								};
+							}
+
+							if (additionalFields.url) {
+								(body.extras as IDataObject)['client::notification'] = {
+									click: { url: additionalFields.url },
+								};
+							}
 						}
 
-						Object.assign(body, additionalFields);
+						// add other additionalFields (title & priority) directly to the root of the body
+						Object.assign(body, {
+							title: additionalFields.title,
+							priority: additionalFields.priority,
+						});
 
 						responseData = await gotifyApiRequest.call(this, 'POST', '/message', body);
 					}

--- a/packages/nodes-base/nodes/Gotify/test/Gotify.node.test.ts
+++ b/packages/nodes-base/nodes/Gotify/test/Gotify.node.test.ts
@@ -1,0 +1,311 @@
+import type { INodeExecutionData } from 'n8n-workflow';
+import { Gotify } from '../Gotify.node';
+import * as transport from '../GenericFunctions';
+import { createMockExecuteFunction } from './helpers';
+
+jest.mock('../GenericFunctions', () => ({
+	gotifyApiRequest: jest.fn().mockResolvedValue({}),
+	gotifyApiRequestAllItems: jest.fn().mockResolvedValue([]),
+}));
+
+describe('Test Gotify Node', () => {
+	let gotifyNode: Gotify;
+
+	beforeEach(() => {
+		gotifyNode = new Gotify();
+		jest.clearAllMocks();
+	});
+
+	describe('create operation', () => {
+		it('should create message with basic fields', async () => {
+			const mockResponse = { id: 123, message: 'Test message', priority: 5 };
+			(transport.gotifyApiRequest as jest.Mock).mockResolvedValue(mockResponse);
+
+			const nodeParameters = {
+				resource: 'message',
+				operation: 'create',
+				message: 'Test message',
+				additionalFields: {},
+				options: {},
+			};
+
+			const mockExecute = createMockExecuteFunction(nodeParameters);
+			const result = await gotifyNode.execute.call(mockExecute);
+
+			expect(transport.gotifyApiRequest).toHaveBeenCalledWith('POST', '/message', {
+				message: 'Test message',
+			});
+			expect(result).toEqual([
+				[
+					{
+						json: mockResponse,
+						pairedItem: { item: 0 },
+					},
+				],
+			]);
+		});
+
+		it('should create message with title and priority', async () => {
+			const mockResponse = { id: 124, message: 'Important message', priority: 10, title: 'Alert' };
+			(transport.gotifyApiRequest as jest.Mock).mockResolvedValue(mockResponse);
+
+			const nodeParameters = {
+				resource: 'message',
+				operation: 'create',
+				message: 'Important message',
+				additionalFields: {
+					title: 'Alert',
+					priority: 10,
+				},
+				options: {},
+			};
+
+			const mockExecute = createMockExecuteFunction(nodeParameters);
+			await gotifyNode.execute.call(mockExecute);
+
+			expect(transport.gotifyApiRequest).toHaveBeenCalledWith('POST', '/message', {
+				message: 'Important message',
+				title: 'Alert',
+				priority: 10,
+			});
+		});
+
+		it('should create message with markdown content type', async () => {
+			const mockResponse = { id: 125, message: '# Markdown Title' };
+			(transport.gotifyApiRequest as jest.Mock).mockResolvedValue(mockResponse);
+
+			const nodeParameters = {
+				resource: 'message',
+				operation: 'create',
+				message: '# Markdown Title',
+				additionalFields: {},
+				options: {
+					contentType: 'text/markdown',
+				},
+			};
+
+			const mockExecute = createMockExecuteFunction(nodeParameters);
+			await gotifyNode.execute.call(mockExecute);
+
+			expect(transport.gotifyApiRequest).toHaveBeenCalledWith('POST', '/message', {
+				message: '# Markdown Title',
+				extras: {
+					'client::display': {
+						contentType: 'text/markdown',
+					},
+				},
+			});
+		});
+
+		it('should create message with URL click action', async () => {
+			const mockResponse = { id: 126, message: 'Click me' };
+			(transport.gotifyApiRequest as jest.Mock).mockResolvedValue(mockResponse);
+
+			const nodeParameters = {
+				resource: 'message',
+				operation: 'create',
+				message: 'Click me',
+				additionalFields: {
+					url: 'https://example.com',
+				},
+				options: {},
+			};
+
+			const mockExecute = createMockExecuteFunction(nodeParameters);
+			await gotifyNode.execute.call(mockExecute);
+
+			expect(transport.gotifyApiRequest).toHaveBeenCalledWith('POST', '/message', {
+				message: 'Click me',
+				extras: {
+					'client::notification': {
+						click: { url: 'https://example.com' },
+					},
+				},
+			});
+		});
+
+		it('should create message with all options', async () => {
+			const mockResponse = { id: 127, message: '# Full featured message' };
+			(transport.gotifyApiRequest as jest.Mock).mockResolvedValue(mockResponse);
+
+			const nodeParameters = {
+				resource: 'message',
+				operation: 'create',
+				message: '# Full featured message',
+				additionalFields: {
+					title: 'Important Alert',
+					priority: 8,
+					url: 'https://example.com/details',
+				},
+				options: {
+					contentType: 'text/markdown',
+				},
+			};
+
+			const mockExecute = createMockExecuteFunction(nodeParameters);
+			await gotifyNode.execute.call(mockExecute);
+
+			expect(transport.gotifyApiRequest).toHaveBeenCalledWith('POST', '/message', {
+				message: '# Full featured message',
+				title: 'Important Alert',
+				priority: 8,
+				extras: {
+					'client::display': {
+						contentType: 'text/markdown',
+					},
+					'client::notification': {
+						click: { url: 'https://example.com/details' },
+					},
+				},
+			});
+		});
+	});
+
+	describe('delete operation', () => {
+		it('should delete message by ID', async () => {
+			(transport.gotifyApiRequest as jest.Mock).mockResolvedValue({});
+
+			const nodeParameters = {
+				resource: 'message',
+				operation: 'delete',
+				messageId: '123',
+			};
+
+			const mockExecute = createMockExecuteFunction(nodeParameters);
+			const result = await gotifyNode.execute.call(mockExecute);
+
+			expect(transport.gotifyApiRequest).toHaveBeenCalledWith('DELETE', '/message/123');
+			expect(result).toEqual([
+				[
+					{
+						json: { success: true },
+						pairedItem: { item: 0 },
+					},
+				],
+			]);
+		});
+	});
+
+	describe('getAll operation', () => {
+		it('should get all messages with returnAll true', async () => {
+			const mockMessages = [
+				{ id: 1, message: 'Message 1' },
+				{ id: 2, message: 'Message 2' },
+				{ id: 3, message: 'Message 3' },
+			];
+			(transport.gotifyApiRequestAllItems as jest.Mock).mockResolvedValue(mockMessages);
+
+			const nodeParameters = {
+				resource: 'message',
+				operation: 'getAll',
+				returnAll: true,
+			};
+
+			const mockExecute = createMockExecuteFunction(nodeParameters);
+			const result = await gotifyNode.execute.call(mockExecute);
+
+			expect(transport.gotifyApiRequestAllItems).toHaveBeenCalledWith(
+				'messages',
+				'GET',
+				'/message',
+				{},
+				{},
+			);
+			expect(result[0]).toHaveLength(3);
+			expect(result[0][0].json).toEqual(mockMessages[0]);
+		});
+
+		it('should use custom limit value', async () => {
+			const mockResponse = {
+				messages: [{ id: 1, message: 'Message 1' }],
+			};
+			(transport.gotifyApiRequest as jest.Mock).mockResolvedValue(mockResponse);
+
+			const nodeParameters = {
+				resource: 'message',
+				operation: 'getAll',
+				returnAll: false,
+				limit: 5,
+			};
+
+			const mockExecute = createMockExecuteFunction(nodeParameters);
+			await gotifyNode.execute.call(mockExecute);
+
+			expect(transport.gotifyApiRequest).toHaveBeenCalledWith('GET', '/message', {}, { limit: 5 });
+		});
+	});
+
+	describe('error handling', () => {
+		it('should handle errors when continueOnFail is true', async () => {
+			const error = new Error('API Error');
+			(transport.gotifyApiRequest as jest.Mock).mockRejectedValue(error);
+
+			const nodeParameters = {
+				resource: 'message',
+				operation: 'create',
+				message: 'Test message',
+				additionalFields: {},
+				options: {},
+			};
+
+			const mockExecute = createMockExecuteFunction(nodeParameters);
+			mockExecute.continueOnFail = () => true;
+
+			const result = await gotifyNode.execute.call(mockExecute);
+
+			expect(result).toEqual([
+				[
+					{
+						json: { error: 'API Error' },
+					},
+				],
+			]);
+		});
+
+		it('should throw error when continueOnFail is false', async () => {
+			const error = new Error('API Error');
+			(transport.gotifyApiRequest as jest.Mock).mockRejectedValue(error);
+
+			const nodeParameters = {
+				resource: 'message',
+				operation: 'create',
+				message: 'Test message',
+				additionalFields: {},
+				options: {},
+			};
+
+			const mockExecute = createMockExecuteFunction(nodeParameters);
+
+			await expect(gotifyNode.execute.call(mockExecute)).rejects.toThrow('API Error');
+		});
+	});
+
+	describe('multiple items processing', () => {
+		it('should process multiple items in a single execution', async () => {
+			const mockResponse1 = { id: 200, message: 'First message' };
+			const mockResponse2 = { id: 201, message: 'Second message' };
+
+			(transport.gotifyApiRequest as jest.Mock)
+				.mockResolvedValueOnce(mockResponse1)
+				.mockResolvedValueOnce(mockResponse2);
+
+			const nodeParameters = {
+				resource: 'message',
+				operation: 'create',
+				message: 'Test message',
+				additionalFields: {},
+				options: {},
+			};
+
+			const mockExecute = createMockExecuteFunction(nodeParameters);
+			mockExecute.getInputData = () => [{ json: {} }, { json: {} }] as INodeExecutionData[];
+
+			const result = await gotifyNode.execute.call(mockExecute);
+
+			expect(transport.gotifyApiRequest).toHaveBeenCalledTimes(2);
+			expect(result[0]).toHaveLength(2);
+			expect(result[0][0].json).toEqual(mockResponse1);
+			expect(result[0][1].json).toEqual(mockResponse2);
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Gotify/test/Gotify.node.test.ts
+++ b/packages/nodes-base/nodes/Gotify/test/Gotify.node.test.ts
@@ -2,24 +2,28 @@ import type { INodeExecutionData } from 'n8n-workflow';
 import { Gotify } from '../Gotify.node';
 import * as transport from '../GenericFunctions';
 import { createMockExecuteFunction } from './helpers';
+import type { Mock } from 'vitest';
 
-jest.mock('../GenericFunctions', () => ({
-	gotifyApiRequest: jest.fn().mockResolvedValue({}),
-	gotifyApiRequestAllItems: jest.fn().mockResolvedValue([]),
+vi.mock('../GenericFunctions', () => ({
+	gotifyApiRequest: vi.fn().mockResolvedValue({}),
+	gotifyApiRequestAllItems: vi.fn().mockResolvedValue([]),
 }));
+
+const gotifyApiRequestMock = transport.gotifyApiRequest as Mock;
+const gotifyApiRequestAllItemsMock = transport.gotifyApiRequestAllItems as Mock;
 
 describe('Test Gotify Node', () => {
 	let gotifyNode: Gotify;
 
 	beforeEach(() => {
 		gotifyNode = new Gotify();
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	});
 
 	describe('create operation', () => {
 		it('should create message with basic fields', async () => {
 			const mockResponse = { id: 123, message: 'Test message', priority: 5 };
-			(transport.gotifyApiRequest as jest.Mock).mockResolvedValue(mockResponse);
+			gotifyApiRequestMock.mockResolvedValue(mockResponse);
 
 			const nodeParameters = {
 				resource: 'message',
@@ -47,7 +51,7 @@ describe('Test Gotify Node', () => {
 
 		it('should create message with title and priority', async () => {
 			const mockResponse = { id: 124, message: 'Important message', priority: 10, title: 'Alert' };
-			(transport.gotifyApiRequest as jest.Mock).mockResolvedValue(mockResponse);
+			gotifyApiRequestMock.mockResolvedValue(mockResponse);
 
 			const nodeParameters = {
 				resource: 'message',
@@ -72,7 +76,7 @@ describe('Test Gotify Node', () => {
 
 		it('should create message with markdown content type', async () => {
 			const mockResponse = { id: 125, message: '# Markdown Title' };
-			(transport.gotifyApiRequest as jest.Mock).mockResolvedValue(mockResponse);
+			gotifyApiRequestMock.mockResolvedValue(mockResponse);
 
 			const nodeParameters = {
 				resource: 'message',
@@ -99,7 +103,7 @@ describe('Test Gotify Node', () => {
 
 		it('should create message with URL click action', async () => {
 			const mockResponse = { id: 126, message: 'Click me' };
-			(transport.gotifyApiRequest as jest.Mock).mockResolvedValue(mockResponse);
+			gotifyApiRequestMock.mockResolvedValue(mockResponse);
 
 			const nodeParameters = {
 				resource: 'message',
@@ -126,7 +130,7 @@ describe('Test Gotify Node', () => {
 
 		it('should create message with all options', async () => {
 			const mockResponse = { id: 127, message: '# Full featured message' };
-			(transport.gotifyApiRequest as jest.Mock).mockResolvedValue(mockResponse);
+			gotifyApiRequestMock.mockResolvedValue(mockResponse);
 
 			const nodeParameters = {
 				resource: 'message',
@@ -163,7 +167,7 @@ describe('Test Gotify Node', () => {
 
 	describe('delete operation', () => {
 		it('should delete message by ID', async () => {
-			(transport.gotifyApiRequest as jest.Mock).mockResolvedValue({});
+			gotifyApiRequestMock.mockResolvedValue({});
 
 			const nodeParameters = {
 				resource: 'message',
@@ -193,7 +197,7 @@ describe('Test Gotify Node', () => {
 				{ id: 2, message: 'Message 2' },
 				{ id: 3, message: 'Message 3' },
 			];
-			(transport.gotifyApiRequestAllItems as jest.Mock).mockResolvedValue(mockMessages);
+			gotifyApiRequestAllItemsMock.mockResolvedValue(mockMessages);
 
 			const nodeParameters = {
 				resource: 'message',
@@ -219,7 +223,7 @@ describe('Test Gotify Node', () => {
 			const mockResponse = {
 				messages: [{ id: 1, message: 'Message 1' }],
 			};
-			(transport.gotifyApiRequest as jest.Mock).mockResolvedValue(mockResponse);
+			gotifyApiRequestMock.mockResolvedValue(mockResponse);
 
 			const nodeParameters = {
 				resource: 'message',
@@ -238,7 +242,7 @@ describe('Test Gotify Node', () => {
 	describe('error handling', () => {
 		it('should handle errors when continueOnFail is true', async () => {
 			const error = new Error('API Error');
-			(transport.gotifyApiRequest as jest.Mock).mockRejectedValue(error);
+			gotifyApiRequestMock.mockRejectedValue(error);
 
 			const nodeParameters = {
 				resource: 'message',
@@ -264,7 +268,7 @@ describe('Test Gotify Node', () => {
 
 		it('should throw error when continueOnFail is false', async () => {
 			const error = new Error('API Error');
-			(transport.gotifyApiRequest as jest.Mock).mockRejectedValue(error);
+			gotifyApiRequestMock.mockRejectedValue(error);
 
 			const nodeParameters = {
 				resource: 'message',
@@ -285,7 +289,7 @@ describe('Test Gotify Node', () => {
 			const mockResponse1 = { id: 200, message: 'First message' };
 			const mockResponse2 = { id: 201, message: 'Second message' };
 
-			(transport.gotifyApiRequest as jest.Mock)
+			gotifyApiRequestMock
 				.mockResolvedValueOnce(mockResponse1)
 				.mockResolvedValueOnce(mockResponse2);
 

--- a/packages/nodes-base/nodes/Gotify/test/helpers.ts
+++ b/packages/nodes-base/nodes/Gotify/test/helpers.ts
@@ -1,0 +1,46 @@
+import get from 'lodash/get';
+import { constructExecutionMetaData } from 'n8n-core';
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	IGetNodeParameterOptions,
+	INode,
+	INodeExecutionData,
+} from 'n8n-workflow';
+
+export const node: INode = {
+	id: '1',
+	name: 'Gotify node',
+	typeVersion: 1,
+	type: 'n8n-nodes-base.gotify',
+	position: [10, 10],
+	parameters: {},
+};
+
+export const createMockExecuteFunction = (nodeParameters: IDataObject) => {
+	return {
+		getInputData(): INodeExecutionData[] {
+			return [{ json: {} }];
+		},
+		getNodeParameter(
+			parameterName: string,
+			_itemIndex: number,
+			fallbackValue?: IDataObject,
+			options?: IGetNodeParameterOptions,
+		) {
+			const parameter = options?.extractValue ? `${parameterName}.value` : parameterName;
+			return get(nodeParameters, parameter, fallbackValue);
+		},
+		getNode() {
+			return node;
+		},
+		helpers: {
+			constructExecutionMetaData,
+			returnJsonArray: (data: IDataObject | IDataObject[]) => {
+				const dataArray = Array.isArray(data) ? data : [data];
+				return dataArray.map((item) => ({ json: item })) as INodeExecutionData[];
+			},
+		},
+		continueOnFail: () => false,
+	} as unknown as IExecuteFunctions;
+};


### PR DESCRIPTION
## Summary

When creating a new message with the Gotify node, you can now optionally specify a URL which will be opened once the notification is clicked.

<img width="1881" height="1302" alt="image" src="https://github.com/user-attachments/assets/000ce560-04ab-466b-884a-322bc99d4c1c" />

According to the [Gotify docs](https://gotify.net/docs/msgextras) this can be achieved by adding the `client::notification` message extra. I tested this with my personal Gotify instance, and it works like a charm.

Also added additional unit tests, because there were none for this node.

## Related Linear tickets, Github issues, and Community forum posts

- [Community feature request](https://community.n8n.io/t/gotify-node-url-on-click/277324)

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
