### PR TITLE
fix: Do not add publish history relation for get version endpoint (no-changelog)

### DIFF
--- a/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
@@ -143,6 +143,7 @@ export = {
 					req.user,
 					workflowId,
 					versionId,
+					{ includePublishHistory: false },
 				);
 
 				Container.get(EventService).emit('user-retrieved-workflow-version', {

--- a/packages/cli/src/workflows/workflow-history/workflow-history.service.ts
+++ b/packages/cli/src/workflows/workflow-history/workflow-history.service.ts
@@ -54,7 +54,12 @@ export class WorkflowHistoryService {
 		});
 	}
 
-	async getVersion(user: User, workflowId: string, versionId: string): Promise<WorkflowHistory> {
+	async getVersion(
+		user: User,
+		workflowId: string,
+		versionId: string,
+		settings?: { includePublishHistory?: boolean },
+	): Promise<WorkflowHistory> {
 		const workflow = await this.workflowFinderService.findWorkflowForUser(workflowId, user, [
 			'workflow:read',
 		]);
@@ -63,12 +68,15 @@ export class WorkflowHistoryService {
 			throw new SharedWorkflowNotFoundError('');
 		}
 
+		const includePublishHistory = settings?.includePublishHistory ?? true;
+		const relations = includePublishHistory ? ['workflowPublishHistory'] : [];
+
 		const hist = await this.workflowHistoryRepository.findOne({
 			where: {
 				workflowId: workflow.id,
 				versionId,
 			},
-			relations: ['workflowPublishHistory'],
+			relations,
 		});
 		if (!hist) {
 			throw new WorkflowHistoryVersionNotFoundError('');


### PR DESCRIPTION
## Summary

The new public endpoint `getVersion` does not need the workflow publish history relation in the response.
I'm setting `includeWorkflowHistory` to `true` by default to quickly fix the issue. We might refactor this method later.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
