### PR TITLE
feat: Update migration guide with changes in cli and external hooks (no-changelog)

### DIFF
--- a/packages/cli/src/modules/breaking-changes/rules/v2/__tests__/cli-replace-update-workflow-command.rule.test.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/v2/__tests__/cli-replace-update-workflow-command.rule.test.ts
@@ -1,4 +1,4 @@
-import { CliActivateAllWorkflowsRule } from '../cli-activate-all-workflows.rule';
+import { CliActivateAllWorkflowsRule } from '../cli-replace-update-workflow-command.rule';
 
 describe('CliActivateAllWorkflowsRule', () => {
 	let rule: CliActivateAllWorkflowsRule;

--- a/packages/cli/src/modules/breaking-changes/rules/v2/__tests__/cli-replace-update-workflow-command.rule.test.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/v2/__tests__/cli-replace-update-workflow-command.rule.test.ts
@@ -12,7 +12,7 @@ describe('CliActivateAllWorkflowsRule', () => {
 			const metadata = rule.getMetadata();
 
 			expect(metadata.version).toBe('v2');
-			expect(metadata.title).toBe('Remove CLI command operation to activate all workflows');
+			expect(metadata.title).toBe('CLI command update:workflow replaced');
 			expect(metadata.severity).toBe('low');
 		});
 	});
@@ -23,15 +23,15 @@ describe('CliActivateAllWorkflowsRule', () => {
 
 			expect(result.isAffected).toBe(true);
 			expect(result.instanceIssues).toHaveLength(1);
-			expect(result.instanceIssues[0].title).toBe('CLI command to activate all workflows removed');
+			expect(result.instanceIssues[0].title).toBe('CLI command update:workflow replaced');
 			expect(result.instanceIssues[0].level).toBe('info');
 		});
 
-		it('should include description about CLI command removal', async () => {
+		it('should include description about CLI command replacement', async () => {
 			const result = await rule.detect();
 
 			expect(result.instanceIssues[0].description).toContain('CLI command');
-			expect(result.instanceIssues[0].description).toContain('removed');
+			expect(result.instanceIssues[0].description).toContain('replaced');
 		});
 
 		it('should have 2 recommendations', async () => {

--- a/packages/cli/src/modules/breaking-changes/rules/v2/__tests__/workflow-hooks-deprecated.rule.test.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/v2/__tests__/workflow-hooks-deprecated.rule.test.ts
@@ -1,0 +1,55 @@
+import { WorkflowHooksDeprecatedRule } from '../workflow-hooks-deprecated.rule';
+
+describe('WorkflowHooksDeprecatedRule', () => {
+	let rule: WorkflowHooksDeprecatedRule;
+
+	beforeEach(() => {
+		rule = new WorkflowHooksDeprecatedRule();
+	});
+
+	describe('getMetadata()', () => {
+		it('should return correct metadata', () => {
+			const metadata = rule.getMetadata();
+
+			expect(metadata.version).toBe('v2');
+			expect(metadata.title).toBe('Deprecated frontend workflow hooks');
+			expect(metadata.severity).toBe('medium');
+			expect(metadata.documentationUrl).toBe(
+				'https://docs.n8n.io/2-0-breaking-changes/#deprecated-frontend-workflow-hooks',
+			);
+		});
+	});
+
+	describe('detect()', () => {
+		it('should always be affected (informational)', async () => {
+			const result = await rule.detect();
+
+			expect(result.isAffected).toBe(true);
+			expect(result.instanceIssues).toHaveLength(1);
+			expect(result.instanceIssues[0].title).toContain('workflow.activeChange');
+			expect(result.instanceIssues[0].title).toContain('workflow.activeChangeCurrent');
+			expect(result.instanceIssues[0].level).toBe('warning');
+		});
+
+		it('should include description about deprecated hooks', async () => {
+			const result = await rule.detect();
+
+			expect(result.instanceIssues[0].description).toContain('workflow.activeChange');
+			expect(result.instanceIssues[0].description).toContain('workflow.activeChangeCurrent');
+			expect(result.instanceIssues[0].description).toContain('workflow.published');
+		});
+
+		it('should have 3 recommendations', async () => {
+			const result = await rule.detect();
+
+			expect(result.recommendations).toHaveLength(3);
+			expect(result.recommendations[0].action).toContain(
+				'Replace workflow.activeChange with workflow.published',
+			);
+			expect(result.recommendations[1].action).toContain(
+				'Replace workflow.activeChangeCurrent with workflow.published',
+			);
+			expect(result.recommendations[2].action).toContain('Review custom integrations');
+		});
+	});
+});

--- a/packages/cli/src/modules/breaking-changes/rules/v2/__tests__/workflow-hooks-deprecated.rule.test.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/v2/__tests__/workflow-hooks-deprecated.rule.test.ts
@@ -13,7 +13,7 @@ describe('WorkflowHooksDeprecatedRule', () => {
 
 			expect(metadata.version).toBe('v2');
 			expect(metadata.title).toBe('Deprecated frontend workflow hooks');
-			expect(metadata.severity).toBe('medium');
+			expect(metadata.severity).toBe('low');
 			expect(metadata.documentationUrl).toBe(
 				'https://docs.n8n.io/2-0-breaking-changes/#deprecated-frontend-workflow-hooks',
 			);

--- a/packages/cli/src/modules/breaking-changes/rules/v2/cli-replace-update-workflow-command.rule.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/v2/cli-replace-update-workflow-command.rule.ts
@@ -14,8 +14,9 @@ export class CliActivateAllWorkflowsRule implements IBreakingChangeInstanceRule 
 	getMetadata(): BreakingChangeRuleMetadata {
 		return {
 			version: 'v2',
-			title: 'Remove CLI command operation to activate all workflows',
-			description: 'The CLI command to activate all workflows has been removed for simplification',
+			title: 'CLI command update:workflow replaced',
+			description:
+				'The CLI command update:workflow has been replaced with publish:workflow and unpublish:workflow for better clarity.',
 			category: BreakingChangeCategory.instance,
 			severity: 'low',
 			documentationUrl:
@@ -28,9 +29,9 @@ export class CliActivateAllWorkflowsRule implements IBreakingChangeInstanceRule 
 			isAffected: true,
 			instanceIssues: [
 				{
-					title: 'CLI command to activate all workflows removed',
+					title: 'CLI command update:workflow replaced',
 					description:
-						'The CLI command to activate all workflows in bulk has been removed. If you were using this command in scripts or automation, you will need to update your approach.',
+						'The CLI command update:workflow has been replaced with publish:workflow and unpublish:workflow. If you were using this command in scripts or automation, you will need to update your approach.',
 					level: 'info',
 				},
 			],

--- a/packages/cli/src/modules/breaking-changes/rules/v2/cli-replace-update-workflow-command.rule.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/v2/cli-replace-update-workflow-command.rule.ts
@@ -19,7 +19,7 @@ export class CliActivateAllWorkflowsRule implements IBreakingChangeInstanceRule 
 			category: BreakingChangeCategory.instance,
 			severity: 'low',
 			documentationUrl:
-				'https://docs.n8n.io/2-0-breaking-changes/#remove-cli-command-operation-to-activate-all-workflows',
+				'https://docs.n8n.io/2-0-breaking-changes/#replace-cli-command-updateworkflow',
 		};
 	}
 

--- a/packages/cli/src/modules/breaking-changes/rules/v2/index.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/v2/index.ts
@@ -1,5 +1,5 @@
 import { BinaryDataStorageRule } from './binary-data-storage.rule';
-import { CliActivateAllWorkflowsRule } from './cli-activate-all-workflows.rule';
+import { CliActivateAllWorkflowsRule } from './cli-replace-update-workflow-command.rule';
 import { DisabledNodesRule } from './disabled-nodes.rule';
 import { DotenvUpgradeRule } from './dotenv-upgrade.rule';
 import { FileAccessRule } from './file-access.rule';
@@ -16,6 +16,7 @@ import { TaskRunnerDockerImageRule } from './task-runner-docker-image.rule';
 import { TaskRunnersRule } from './task-runners.rule';
 import { TunnelOptionRule } from './tunnel-option.rule';
 import { WaitNodeSubworkflowRule } from './wait-node-subworkflow.rule';
+import { WorkflowHooksDeprecatedRule } from './workflow-hooks-deprecated.rule';
 
 const v2Rules = [
 	// Workflow-level rules
@@ -30,6 +31,7 @@ const v2Rules = [
 	DotenvUpgradeRule,
 	OAuthCallbackAuthRule,
 	CliActivateAllWorkflowsRule,
+	WorkflowHooksDeprecatedRule,
 	QueueWorkerMaxStalledCountRule,
 	TunnelOptionRule,
 	RemovedDatabaseTypesRule,

--- a/packages/cli/src/modules/breaking-changes/rules/v2/workflow-hooks-deprecated.rule.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/v2/workflow-hooks-deprecated.rule.ts
@@ -1,0 +1,59 @@
+import { Service } from '@n8n/di';
+
+import type {
+	BreakingChangeRuleMetadata,
+	IBreakingChangeInstanceRule,
+	InstanceDetectionReport,
+} from '../../types';
+import { BreakingChangeCategory } from '../../types';
+
+@Service()
+export class WorkflowHooksDeprecatedRule implements IBreakingChangeInstanceRule {
+	id: string = 'workflow-hooks-deprecated-v2';
+
+	getMetadata(): BreakingChangeRuleMetadata {
+		return {
+			version: 'v2',
+			title: 'Deprecated frontend workflow hooks',
+			description:
+				'The hooks workflow.activeChange and workflow.activeChangeCurrent are deprecated and replaced by workflow.published',
+			category: BreakingChangeCategory.instance,
+			severity: 'low',
+			documentationUrl:
+				'https://docs.n8n.io/2-0-breaking-changes/#deprecated-frontend-workflow-hooks',
+		};
+	}
+
+	async detect(): Promise<InstanceDetectionReport> {
+		const result: InstanceDetectionReport = {
+			isAffected: true,
+			instanceIssues: [
+				{
+					title: 'Workflow hooks workflow.activeChange and workflow.activeChangeCurrent deprecated',
+					description:
+						'The workflow.activeChange and workflow.activeChangeCurrent hooks are deprecated and will be removed. These hooks are being replaced by a new workflow.published hook that provides more consistent behavior and is triggered when any version of a workflow is published.',
+					level: 'warning',
+				},
+			],
+			recommendations: [
+				{
+					action: 'Replace workflow.activeChange with workflow.published',
+					description:
+						'Update your code to use the new workflow.published hook instead of workflow.activeChange. The new hook will be triggered whenever a workflow version is published.',
+				},
+				{
+					action: 'Replace workflow.activeChangeCurrent with workflow.published',
+					description:
+						'Update your code to use the new workflow.published hook instead of workflow.activeChangeCurrent. This provides more consistent behavior across workflow publishing actions.',
+				},
+				{
+					action: 'Review custom integrations and extensions',
+					description:
+						'Check any custom integrations, plugins, or extensions that may be using the deprecated workflow hooks and update them to use workflow.published.',
+				},
+			],
+		};
+
+		return result;
+	}
+}


### PR DESCRIPTION
## Summary

Docs have been updated with [this PR ](https://github.com/n8n-io/n8n-docs/pull/3944)
New changes in migration guide
- Replace update:workflow command
- Replace external frontend hook 
<img width="729" height="851" alt="Screenshot 2025-12-01 at 11 55 35" src="https://github.com/user-attachments/assets/a9d02f82-8292-47fe-9029-1d72cecb8622" />

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
