### PR TITLE
refactor(core): Deprecate `workflow.active` field

### DIFF
--- a/packages/@n8n/db/src/entities/workflow-entity.ts
+++ b/packages/@n8n/db/src/entities/workflow-entity.ts
@@ -36,6 +36,7 @@ export class WorkflowEntity extends WithTimestampsAndStringId implements IWorkfl
 	@Column({ type: 'text', nullable: true })
 	description: string | null;
 
+	/** @deprecated Please rely on `activeVersionId` being not `null` instead. */
 	@Column()
 	active: boolean;
 


### PR DESCRIPTION
Folks are still using this, let's deprecate properly.

Follow-up to: https://n8nio.slack.com/archives/C03MZF137FV/p1763653709920919