### PR TITLE
fix(core): Only use the Done output if a Loop node actually has a loop

### DIFF
--- a/packages/core/src/execution-engine/partial-execution-utils/find-start-nodes.ts
+++ b/packages/core/src/execution-engine/partial-execution-utils/find-start-nodes.ts
@@ -83,7 +83,11 @@ function findStartNodesRecursive(
 			// last run
 			-1,
 			NodeConnectionTypes.Main,
-			0,
+			// Although this is a Loop node, the graph may not actually have a loop here e.g.,
+			// while the workflow is under development. If there's not a loop, we treat the loop
+			// node as a normal node and take the data from the first output at index 1.
+			// If there *is* a loop, we take the data from the `done` output at index 0.
+			isALoop(graph, current) ? 0 : 1,
 		);
 
 		if (nodeRunData === null || nodeRunData.length === 0) {
@@ -128,6 +132,10 @@ function findStartNodesRecursive(
 	}
 
 	return startNodes;
+}
+
+function isALoop(graph: DirectedGraph, node: INode): boolean {
+	return graph.getChildren(node).has(node);
 }
 
 /**


### PR DESCRIPTION
## Summary

Only use the Done output of a loop node for start node detection if the graph actually has a loop.

Otherwise, we take the first item since that's the only thing that will be produced.

TODO: add tests.

NOTE: the branch name is wrong, this is actually CAT-891.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-891

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
