### PR TITLE
ci: Move backend-test-utils to dev dependency, remove docker base cache

### DIFF
--- a/.github/workflows/docker-base-image.yml
+++ b/.github/workflows/docker-base-image.yml
@@ -63,5 +63,4 @@ jobs:
             ${{ secrets.DOCKER_USERNAME }}/base:${{ matrix.node_version }}
             ghcr.io/${{ github.repository_owner }}/base:${{ matrix.node_version }}-${{ github.sha }}
             ghcr.io/${{ github.repository_owner }}/base:${{ matrix.node_version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          no-cache: true

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -57,6 +57,7 @@
   ],
   "devDependencies": {
     "@n8n/typescript-config": "workspace:*",
+    "@n8n/backend-test-utils": "workspace:*",
     "@redocly/cli": "^1.28.5",
     "@types/aws4": "^1.5.1",
     "@types/bcryptjs": "^2.4.2",
@@ -97,7 +98,6 @@
     "@n8n/ai-workflow-builder": "workspace:*",
     "@n8n/api-types": "workspace:*",
     "@n8n/backend-common": "workspace:*",
-    "@n8n/backend-test-utils": "workspace:*",
     "@n8n/client-oauth2": "workspace:*",
     "@n8n/config": "workspace:*",
     "@n8n/constants": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1490,9 +1490,6 @@ importers:
       '@n8n/backend-common':
         specifier: workspace:*
         version: link:../@n8n/backend-common
-      '@n8n/backend-test-utils':
-        specifier: workspace:*
-        version: link:../@n8n/backend-test-utils
       '@n8n/client-oauth2':
         specifier: workspace:*
         version: link:../@n8n/client-oauth2
@@ -1773,6 +1770,9 @@ importers:
         specifier: 'catalog:'
         version: 3.25.67
     devDependencies:
+      '@n8n/backend-test-utils':
+        specifier: workspace:*
+        version: link:../@n8n/backend-test-utils
       '@n8n/typescript-config':
         specifier: workspace:*
         version: link:../@n8n/typescript-config


### PR DESCRIPTION
## Summary

Docker caching wasn't allowing us to pull in newer updates due to no changes in the dockerfile

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1845/doublecheck-if-dev-dependencies-are-include-in-our-docker-builds


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
