### PR TITLE
fix: [Draft/Publish]: Reactivate active version if settings change (no-changelog)

### DIFF
--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -23,6 +23,7 @@ import type { EntityManager } from '@n8n/typeorm';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In } from '@n8n/typeorm';
 import type { QueryDeepPartialEntity } from '@n8n/typeorm/query-builder/QueryPartialEntity';
+import isEqual from 'lodash/isEqual';
 import omit from 'lodash/omit';
 import pick from 'lodash/pick';
 import { FileLocation, BinaryDataService } from 'n8n-core';
@@ -299,7 +300,7 @@ export class WorkflowService {
 		// Check if settings actually changed
 		const settingsChanged =
 			workflowUpdateData.settings !== undefined &&
-			JSON.stringify(workflow.settings) !== JSON.stringify(workflowUpdateData.settings);
+			!isEqual(workflow.settings, workflowUpdateData.settings);
 
 		await this.externalHooks.run('workflow.update', [workflowUpdateData]);
 


### PR DESCRIPTION
## Summary

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-4480](https://linear.app/n8n/issue/ADO-4480/bug-active-version-is-not-reactivated-when-workflow-settings-change)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
