### PR TITLE
fix(core): During partial execution don't include loop as start node if the loop isn't closed

### DIFF
--- a/packages/core/src/execution-engine/partial-execution-utils/__tests__/find-start-nodes.test.ts
+++ b/packages/core/src/execution-engine/partial-execution-utils/__tests__/find-start-nodes.test.ts
@@ -639,7 +639,7 @@ describe('findStartNodes', () => {
 			const inLoop = createNodeData({ name: 'inLoop' });
 			const graph = new DirectedGraph().addNodes(trigger, loop, inLoop).addConnections(
 				{ from: trigger, to: loop },
-				// Note: loop connects to afterLoop via output 1, but there's no connection
+				// Note: loop connects to inLoop via output 1, but there's no connection
 				// back to loop, so it's not actually a loop
 				{ from: loop, outputIndex: 1, to: inLoop },
 			);
@@ -661,7 +661,7 @@ describe('findStartNodes', () => {
 			// ASSERT
 			// Because the loop node doesn't form an actual loop, it should check output 1
 			// for run data (not output 0). Since output 1 has data, the loop node should
-			// not be a start node, and we should continue to afterLoop.
+			// not be a start node, and we should continue to inLoop.
 			expect(startNodes.size).toBe(1);
 			expect(startNodes).toContainEqual(inLoop);
 		});

--- a/packages/core/src/execution-engine/partial-execution-utils/__tests__/find-start-nodes.test.ts
+++ b/packages/core/src/execution-engine/partial-execution-utils/__tests__/find-start-nodes.test.ts
@@ -624,5 +624,46 @@ describe('findStartNodes', () => {
 			expect(startNodes.size).toBe(1);
 			expect(startNodes).toContainEqual(afterLoop);
 		});
+
+		// 	                      done (empty)
+		//                      ┌────►
+		// ┌─────────┐1 ┌────┐1 │
+		// │ trigger ┼──►loop┼─┬┘  ►►
+		// └─────────┘  └────┘ │  ┌────────┐
+		//                     └─►│in loop │
+		//                        └────────┘
+		test('if a loop node does not actually form a loop in the graph, it uses loop output instead of done output', () => {
+			// ARRANGE
+			const trigger = createNodeData({ name: 'trigger' });
+			const loop = createNodeData({ name: 'loop', type: 'n8n-nodes-base.splitInBatches' });
+			const inLoop = createNodeData({ name: 'inLoop' });
+			const graph = new DirectedGraph().addNodes(trigger, loop, inLoop).addConnections(
+				{ from: trigger, to: loop },
+				// Note: loop connects to afterLoop via output 1, but there's no connection
+				// back to loop, so it's not actually a loop
+				{ from: loop, outputIndex: 1, to: inLoop },
+			);
+			const runData: IRunData = {
+				[trigger.name]: [toITaskData([{ data: { name: 'trigger' } }])],
+				// The loop node has data on output 1 (the first output), but not on output 0 (done)
+				[loop.name]: [toITaskData([{ outputIndex: 1, data: { name: 'loop' } }])],
+			};
+
+			// ACT
+			const startNodes = findStartNodes({
+				graph,
+				trigger,
+				destination: inLoop,
+				runData,
+				pinData: {},
+			});
+
+			// ASSERT
+			// Because the loop node doesn't form an actual loop, it should check output 1
+			// for run data (not output 0). Since output 1 has data, the loop node should
+			// not be a start node, and we should continue to afterLoop.
+			expect(startNodes.size).toBe(1);
+			expect(startNodes).toContainEqual(inLoop);
+		});
 	});
 });

--- a/packages/core/src/execution-engine/partial-execution-utils/find-start-nodes.ts
+++ b/packages/core/src/execution-engine/partial-execution-utils/find-start-nodes.ts
@@ -83,7 +83,11 @@ function findStartNodesRecursive(
 			// last run
 			-1,
 			NodeConnectionTypes.Main,
-			0,
+			// Although this is a Loop node, the graph may not actually have a loop here e.g.,
+			// while the workflow is under development. If there's not a loop, we treat the loop
+			// node as a normal node and take the data from the first output at index 1.
+			// If there *is* a loop, we take the data from the `done` output at index 0.
+			isALoop(graph, current) ? 0 : 1,
 		);
 
 		if (nodeRunData === null || nodeRunData.length === 0) {
@@ -128,6 +132,10 @@ function findStartNodesRecursive(
 	}
 
 	return startNodes;
+}
+
+function isALoop(graph: DirectedGraph, node: INode): boolean {
+	return graph.getChildren(node).has(node);
 }
 
 /**


### PR DESCRIPTION
## Summary

In partial executions, while searching for the start nodes, if we see a Loop node we check the output at index 0 (the `done` output). If there's no data, we treat the whole loop as needing to be re-run.

However, some Loop nodes don't actually represent a loop in the graph e.g., while a workflow is under development. In this case we want to check the `loop` output (index 1) to determine whether it should be included as a start node.

## Related Linear tickets, Github issues, and Community forum posts

Closes https://linear.app/n8n/issue/CAT-891.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
