### PR TITLE
feat(API): Set OpenAPI version dynamically from N8N_VERSION

### DIFF
--- a/packages/cli/src/public-api/index.ts
+++ b/packages/cli/src/public-api/index.ts
@@ -9,6 +9,7 @@ import type { JsonObject } from 'swagger-ui-express';
 import validator from 'validator';
 import YAML from 'yamljs';
 
+import { N8N_VERSION } from '@/constants';
 import { License } from '@/license';
 import { PublicApiKeyService } from '@/services/public-api-key.service';
 import { UrlService } from '@/services/url.service';
@@ -28,6 +29,10 @@ async function createApiRouter(
 			url: `${Container.get(UrlService).getInstanceBaseUrl()}/${publicApiEndpoint}/${version}}`,
 		},
 	];
+
+	// set version from N8N_VERSION
+	swaggerDocument.info.version = N8N_VERSION;
+
 	const apiController = express.Router();
 
 	if (!Container.get(GlobalConfig).publicApi.swaggerUiDisabled) {

--- a/packages/cli/src/public-api/v1/openapi.yml
+++ b/packages/cli/src/public-api/v1/openapi.yml
@@ -9,7 +9,7 @@ info:
   license:
     name: Sustainable Use License
     url: https://github.com/n8n-io/n8n/blob/master/LICENSE.md
-  version: 1.1.1
+  version: ''
 externalDocs:
   description: n8n API documentation
   url: https://docs.n8n.io/api/


### PR DESCRIPTION
## Summary

Remove hardcoded version from `openapi.yml` and inject version dynamically from `N8N_VERSION` constant to ensure API documentation version always matches the actual n8n version.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

N/A


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
