### PR TITLE
fix(AI Agent Node): Support thinking mode for Anthropic models

### DIFF
--- a/packages/@n8n/nodes-langchain/utils/agent-execution/buildSteps.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/buildSteps.ts
@@ -2,7 +2,157 @@ import { AIMessage } from '@langchain/core/messages';
 import { nodeNameToToolName } from 'n8n-workflow';
 import type { EngineResponse, IDataObject } from 'n8n-workflow';
 
-import type { RequestResponseMetadata, ToolCallData } from './types';
+import type {
+	RequestResponseMetadata,
+	ToolCallData,
+	ThinkingContentBlock,
+	RedactedThinkingContentBlock,
+	ToolUseContentBlock,
+} from './types';
+
+/**
+ * Provider-specific metadata extracted from tool action metadata
+ */
+interface ProviderMetadata {
+	/** Gemini thought_signature for extended thinking */
+	thoughtSignature?: string;
+	/** Anthropic thinking content */
+	thinkingContent?: string;
+	/** Anthropic thinking type (thinking or redacted_thinking) */
+	thinkingType?: 'thinking' | 'redacted_thinking';
+	/** Anthropic thinking signature */
+	thinkingSignature?: string;
+}
+
+/**
+ * Extracts provider-specific metadata from tool action metadata.
+ * Validates and normalizes metadata from different LLM providers.
+ *
+ * @param metadata - The request/response metadata from tool action
+ * @returns Extracted and validated provider metadata
+ */
+function extractProviderMetadata(metadata?: RequestResponseMetadata): ProviderMetadata {
+	if (!metadata) return {};
+
+	// Extract Google/Gemini metadata
+	const thoughtSignature =
+		typeof metadata.google?.thoughtSignature === 'string'
+			? metadata.google.thoughtSignature
+			: undefined;
+
+	// Extract Anthropic metadata
+	const thinkingContent =
+		typeof metadata.anthropic?.thinkingContent === 'string'
+			? metadata.anthropic.thinkingContent
+			: undefined;
+
+	const thinkingType =
+		metadata.anthropic?.thinkingType === 'thinking' ||
+		metadata.anthropic?.thinkingType === 'redacted_thinking'
+			? metadata.anthropic.thinkingType
+			: undefined;
+
+	const thinkingSignature =
+		typeof metadata.anthropic?.thinkingSignature === 'string'
+			? metadata.anthropic.thinkingSignature
+			: undefined;
+
+	return {
+		thoughtSignature,
+		thinkingContent,
+		thinkingType,
+		thinkingSignature,
+	};
+}
+
+/**
+ * Builds Anthropic-specific content blocks for thinking mode.
+ * Creates an array with thinking block followed by tool_use block.
+ *
+ * IMPORTANT: The thinking block must come before tool_use in the message.
+ * When content is an array, LangChain ignores tool_calls field for Anthropic,
+ * so tool_use blocks must be in the content array.
+ *
+ * @param thinkingContent - The thinking content from Anthropic
+ * @param thinkingType - Type of thinking block (thinking or redacted_thinking)
+ * @param thinkingSignature - Optional signature for thinking block
+ * @param toolInput - The tool input data
+ * @param toolId - The tool call ID
+ * @param toolName - The tool name
+ * @returns Array of content blocks with thinking and tool_use
+ */
+function buildAnthropicContentBlocks(
+	thinkingContent: string,
+	thinkingType: 'thinking' | 'redacted_thinking',
+	thinkingSignature: string | undefined,
+	toolInput: IDataObject,
+	toolId: string,
+	toolName: string,
+): Array<ThinkingContentBlock | RedactedThinkingContentBlock | ToolUseContentBlock> {
+	// Create thinking block with correct field names for Anthropic API
+	const thinkingBlock: ThinkingContentBlock | RedactedThinkingContentBlock =
+		thinkingType === 'thinking'
+			? {
+					type: 'thinking',
+					thinking: thinkingContent,
+					signature: thinkingSignature ?? '', // Use original signature if available
+				}
+			: {
+					type: 'redacted_thinking',
+					data: thinkingContent,
+				};
+
+	// Create tool_use block (required for Anthropic when using structured content)
+	const toolInputData = toolInput.input;
+	const toolUseBlock: ToolUseContentBlock = {
+		type: 'tool_use',
+		id: toolId,
+		name: toolName,
+		input:
+			toolInputData && typeof toolInputData === 'object'
+				? (toolInputData as Record<string, unknown>)
+				: {},
+	};
+
+	return [thinkingBlock, toolUseBlock];
+}
+
+/**
+ * Builds message content for AI message, handling provider-specific formats.
+ * For Anthropic thinking mode, creates content blocks with thinking and tool_use.
+ * For other providers, creates simple string content.
+ *
+ * @param providerMetadata - Provider-specific metadata
+ * @param toolInput - The tool input data
+ * @param toolId - The tool call ID
+ * @param toolName - The tool name
+ * @param nodeName - The node name for fallback string content
+ * @returns Message content (string or content blocks array)
+ */
+function buildMessageContent(
+	providerMetadata: ProviderMetadata,
+	toolInput: IDataObject,
+	toolId: string,
+	toolName: string,
+	nodeName: string,
+): string | Array<ThinkingContentBlock | RedactedThinkingContentBlock | ToolUseContentBlock> {
+	const { thinkingContent, thinkingType, thinkingSignature } = providerMetadata;
+
+	// Anthropic thinking mode: build content blocks
+	if (thinkingContent && thinkingType) {
+		return buildAnthropicContentBlocks(
+			thinkingContent,
+			thinkingType,
+			thinkingSignature,
+			toolInput,
+			toolId,
+			toolName,
+		);
+	}
+
+	// Default: simple string content
+	return `Calling ${nodeName} with input: ${JSON.stringify(toolInput)}`;
+}
 
 /**
  * Rebuilds the agent steps from previous tool call responses.
@@ -43,34 +193,51 @@ export function buildSteps(
 			if (step) {
 				continue;
 			}
-			// Create a synthetic AI message for the messageLog
-			// This represents the AI's decision to call the tool
-			// Extract thought_signature from metadata if present (for Gemini 3)
-			const rawThoughtSignature = tool.action.metadata?.thoughtSignature;
-			const thoughtSignature =
-				typeof rawThoughtSignature === 'string' ? rawThoughtSignature : undefined;
 
-			// Build the tool call object with thought_signature if present
-			// The thought_signature must be part of the tool call itself for Gemini 3
+			// Extract provider-specific metadata (Gemini, Anthropic, etc.)
+			const providerMetadata = extractProviderMetadata(tool.action.metadata);
+
+			// Build tool ID and name for reuse
+			const toolId = typeof toolInput?.id === 'string' ? toolInput.id : 'reconstructed_call';
+			const toolName = nodeNameToToolName(tool.action.nodeName);
+
+			// Build the tool call object with thought_signature if present (for Gemini)
 			const toolCall = {
-				id: typeof toolInput?.id === 'string' ? toolInput.id : 'reconstructed_call',
-				name: nodeNameToToolName(tool.action.nodeName),
+				id: toolId,
+				name: toolName,
 				args: toolInput,
 				type: 'tool_call' as const,
 				additional_kwargs: {
-					...(thoughtSignature && { thought_signature: thoughtSignature }),
+					...(providerMetadata.thoughtSignature && {
+						thought_signature: providerMetadata.thoughtSignature,
+					}),
 				},
 			};
 
+			// Build message content using provider-specific logic
+			const messageContent = buildMessageContent(
+				providerMetadata,
+				toolInput,
+				toolId,
+				toolName,
+				tool.action.nodeName,
+			);
+
 			const syntheticAIMessage = new AIMessage({
-				content: `Calling ${tool.action.nodeName} with input: ${JSON.stringify(toolInput)}`,
-				tool_calls: [toolCall],
+				content: messageContent,
+				// Note: tool_calls is only used when content is a string
+				// When content is an array (thinking mode), tool_use blocks are in the content array
+				...(typeof messageContent === 'string' && { tool_calls: [toolCall] }),
 			});
 
+			const toolInputForResult = toolInput.input;
 			const toolResult = {
 				action: {
 					tool: nodeNameToToolName(tool.action.nodeName),
-					toolInput: (toolInput.input as IDataObject) || {},
+					toolInput:
+						toolInputForResult && typeof toolInputForResult === 'object'
+							? (toolInputForResult as IDataObject)
+							: {},
 					log: toolInput.log || syntheticAIMessage.content,
 					messageLog: [syntheticAIMessage],
 					toolCallId: toolInput?.id,

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/test/buildSteps.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/test/buildSteps.test.ts
@@ -583,7 +583,7 @@ describe('buildSteps', () => {
 			expect(result[0].action.messageLog).toHaveLength(1);
 
 			const message = result[0].action.messageLog![0];
-			const content = message.content as Array<any>;
+			const content = message.content;
 			expect(Array.isArray(content)).toBe(true);
 			expect(content).toHaveLength(2);
 			// First block should be thinking
@@ -642,7 +642,7 @@ describe('buildSteps', () => {
 			expect(result[0].action.messageLog).toHaveLength(1);
 
 			const message = result[0].action.messageLog![0];
-			const content = message.content as Array<any>;
+			const content = message.content;
 			expect(Array.isArray(content)).toBe(true);
 			expect(content).toHaveLength(2);
 			// First block should be redacted_thinking
@@ -789,7 +789,7 @@ describe('buildSteps', () => {
 			expect(result).toHaveLength(1);
 			const message = result[0].action.messageLog![0];
 			// Should use Anthropic thinking blocks in content
-			const content = message.content as Array<any>;
+			const content = message.content;
 			expect(Array.isArray(content)).toBe(true);
 			expect(content).toHaveLength(2);
 			// First block should be thinking

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/test/buildSteps.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/test/buildSteps.test.ts
@@ -538,4 +538,274 @@ describe('buildSteps', () => {
 			expect(result[0].observation).toBe('""');
 		});
 	});
+
+	describe('Anthropic thinking blocks reconstruction', () => {
+		it('should reconstruct AIMessage with thinking content blocks', () => {
+			const response: EngineResponse<RequestResponseMetadata> = {
+				actionResponses: [
+					{
+						action: {
+							actionType: 'ExecutionNodeAction',
+							nodeName: 'Calculator',
+							input: {
+								id: 'call_123',
+								input: { expression: '2+2' },
+							},
+							type: NodeConnectionTypes.AiTool,
+							id: 'call_123',
+							metadata: {
+								itemIndex: 0,
+								anthropic: {
+									thinkingContent: 'I need to calculate 2+2 using the calculator tool.',
+									thinkingType: 'thinking',
+									thinkingSignature: 'test_signature_123',
+								},
+							},
+						},
+						data: {
+							data: {
+								ai_tool: [[{ json: { result: '4' } }]],
+							},
+							executionTime: 0,
+							startTime: 0,
+							executionIndex: 0,
+							source: [],
+						},
+					},
+				],
+				metadata: {},
+			};
+
+			const result = buildSteps(response, itemIndex);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].action.messageLog).toBeDefined();
+			expect(result[0].action.messageLog).toHaveLength(1);
+
+			const message = result[0].action.messageLog![0];
+			const content = message.content as Array<any>;
+			expect(Array.isArray(content)).toBe(true);
+			expect(content).toHaveLength(2);
+			// First block should be thinking
+			expect(content[0]).toEqual({
+				type: 'thinking',
+				thinking: 'I need to calculate 2+2 using the calculator tool.',
+				signature: 'test_signature_123',
+			});
+			// Second block should be tool_use
+			expect(content[1]).toMatchObject({
+				type: 'tool_use',
+				id: 'call_123',
+				name: 'Calculator',
+			});
+		});
+
+		it('should reconstruct AIMessage with redacted_thinking content blocks', () => {
+			const response: EngineResponse<RequestResponseMetadata> = {
+				actionResponses: [
+					{
+						action: {
+							actionType: 'ExecutionNodeAction',
+							nodeName: 'Search',
+							input: {
+								id: 'call_456',
+								input: { query: 'sensitive search' },
+							},
+							type: NodeConnectionTypes.AiTool,
+							id: 'call_456',
+							metadata: {
+								itemIndex: 0,
+								anthropic: {
+									thinkingContent: 'This thinking was redacted by safety systems.',
+									thinkingType: 'redacted_thinking',
+								},
+							},
+						},
+						data: {
+							data: {
+								ai_tool: [[{ json: { results: [] } }]],
+							},
+							executionTime: 0,
+							startTime: 0,
+							executionIndex: 0,
+							source: [],
+						},
+					},
+				],
+				metadata: {},
+			};
+
+			const result = buildSteps(response, itemIndex);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].action.messageLog).toBeDefined();
+			expect(result[0].action.messageLog).toHaveLength(1);
+
+			const message = result[0].action.messageLog![0];
+			const content = message.content as Array<any>;
+			expect(Array.isArray(content)).toBe(true);
+			expect(content).toHaveLength(2);
+			// First block should be redacted_thinking
+			expect(content[0]).toEqual({
+				type: 'redacted_thinking',
+				data: 'This thinking was redacted by safety systems.',
+			});
+			// Second block should be tool_use
+			expect(content[1]).toMatchObject({
+				type: 'tool_use',
+				id: 'call_456',
+				name: 'Search',
+			});
+		});
+
+		it('should use string content when no thinking blocks present', () => {
+			const response: EngineResponse<RequestResponseMetadata> = {
+				actionResponses: [
+					{
+						action: {
+							actionType: 'ExecutionNodeAction',
+							nodeName: 'Calculator',
+							input: {
+								id: 'call_123',
+								input: { expression: '2+2' },
+							},
+							type: NodeConnectionTypes.AiTool,
+							id: 'call_123',
+							metadata: {
+								itemIndex: 0,
+								// No thinking blocks
+							},
+						},
+						data: {
+							data: {
+								ai_tool: [[{ json: { result: '4' } }]],
+							},
+							executionTime: 0,
+							startTime: 0,
+							executionIndex: 0,
+							source: [],
+						},
+					},
+				],
+				metadata: {},
+			};
+
+			const result = buildSteps(response, itemIndex);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].action.messageLog).toBeDefined();
+			expect(result[0].action.messageLog).toHaveLength(1);
+
+			const message = result[0].action.messageLog![0];
+			expect(typeof message.content).toBe('string');
+			expect(message.content).toContain('Calling Calculator');
+			expect(message).toHaveProperty('tool_calls');
+		});
+
+		it('should handle thinking content without thinkingType', () => {
+			const response: EngineResponse<RequestResponseMetadata> = {
+				actionResponses: [
+					{
+						action: {
+							actionType: 'ExecutionNodeAction',
+							nodeName: 'Calculator',
+							input: {
+								id: 'call_123',
+								input: { expression: '2+2' },
+							},
+							type: NodeConnectionTypes.AiTool,
+							id: 'call_123',
+							metadata: {
+								itemIndex: 0,
+								anthropic: {
+									thinkingContent: 'Some thinking content',
+									// Missing thinkingType
+								},
+							},
+						},
+						data: {
+							data: {
+								ai_tool: [[{ json: { result: '4' } }]],
+							},
+							executionTime: 0,
+							startTime: 0,
+							executionIndex: 0,
+							source: [],
+						},
+					},
+				],
+				metadata: {},
+			};
+
+			const result = buildSteps(response, itemIndex);
+
+			expect(result).toHaveLength(1);
+			const message = result[0].action.messageLog![0];
+			// Should fall back to string content when thinkingType is missing
+			expect(typeof message.content).toBe('string');
+		});
+
+		it('should work alongside Gemini thought_signature', () => {
+			const response: EngineResponse<RequestResponseMetadata> = {
+				actionResponses: [
+					{
+						action: {
+							actionType: 'ExecutionNodeAction',
+							nodeName: 'Calculator',
+							input: {
+								id: 'call_123',
+								input: { expression: '2+2' },
+							},
+							type: NodeConnectionTypes.AiTool,
+							id: 'call_123',
+							metadata: {
+								itemIndex: 0,
+								google: {
+									thoughtSignature: 'Gemini thought signature',
+								},
+								anthropic: {
+									thinkingContent: 'Anthropic thinking content',
+									thinkingType: 'thinking',
+									thinkingSignature: 'anthropic_sig_456',
+								},
+							},
+						},
+						data: {
+							data: {
+								ai_tool: [[{ json: { result: '4' } }]],
+							},
+							executionTime: 0,
+							startTime: 0,
+							executionIndex: 0,
+							source: [],
+						},
+					},
+				],
+				metadata: {},
+			};
+
+			const result = buildSteps(response, itemIndex);
+
+			expect(result).toHaveLength(1);
+			const message = result[0].action.messageLog![0];
+			// Should use Anthropic thinking blocks in content
+			const content = message.content as Array<any>;
+			expect(Array.isArray(content)).toBe(true);
+			expect(content).toHaveLength(2);
+			// First block should be thinking
+			expect(content[0]).toEqual({
+				type: 'thinking',
+				thinking: 'Anthropic thinking content',
+				signature: 'anthropic_sig_456',
+			});
+			// Second block should be tool_use
+			expect(content[1]).toMatchObject({
+				type: 'tool_use',
+				id: 'call_123',
+				name: 'Calculator',
+			});
+			// When thinking blocks are present, tool_calls is not used (everything is in content array)
+			// Note: Anthropic thinking and Gemini thought_signature are mutually exclusive
+		});
+	});
 });

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/types.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/types.ts
@@ -49,6 +49,49 @@ export type AgentResult = {
 };
 
 /**
+ * Anthropic thinking content block
+ */
+export type ThinkingContentBlock = {
+	type: 'thinking';
+	thinking: string;
+	signature: string;
+};
+
+/**
+ * Anthropic redacted thinking content block
+ */
+export type RedactedThinkingContentBlock = {
+	type: 'redacted_thinking';
+	data: string;
+};
+
+/**
+ * Anthropic tool use content block
+ */
+export type ToolUseContentBlock = {
+	type: 'tool_use';
+	id: string;
+	name: string;
+	input: Record<string, unknown>;
+};
+
+/**
+ * Gemini thought signature content block
+ */
+export type GeminiThoughtSignatureBlock = {
+	thoughtSignature: string;
+};
+
+/**
+ * Union type for all supported content blocks
+ */
+export type ContentBlock =
+	| ThinkingContentBlock
+	| RedactedThinkingContentBlock
+	| ToolUseContentBlock
+	| GeminiThoughtSignatureBlock;
+
+/**
  * Metadata for engine requests and responses.
  */
 export type RequestResponseMetadata = {
@@ -58,6 +101,62 @@ export type RequestResponseMetadata = {
 	previousRequests?: ToolCallData[];
 	/** Current iteration count (for max iterations enforcement) */
 	iterationCount?: number;
-	/** Thought signature for Gemini 3 tool calls */
-	thoughtSignature?: string;
+	/** Google/Gemini-specific metadata */
+	google?: {
+		/** Thought signature for Gemini extended thinking */
+		thoughtSignature?: string;
+	};
+	/** Anthropic-specific metadata */
+	anthropic?: {
+		/** Thinking content from extended thinking mode */
+		thinkingContent?: string;
+		/** Type of thinking block (thinking or redacted_thinking) */
+		thinkingType?: 'thinking' | 'redacted_thinking';
+		/** Cryptographic signature for thinking blocks */
+		thinkingSignature?: string;
+	};
 };
+
+/**
+ * Type guard to check if a block is a thinking content block
+ */
+export function isThinkingBlock(block: unknown): block is ThinkingContentBlock {
+	return (
+		typeof block === 'object' &&
+		block !== null &&
+		'type' in block &&
+		block.type === 'thinking' &&
+		'thinking' in block &&
+		typeof block.thinking === 'string' &&
+		'signature' in block &&
+		typeof block.signature === 'string'
+	);
+}
+
+/**
+ * Type guard to check if a block is a redacted thinking content block
+ */
+export function isRedactedThinkingBlock(block: unknown): block is RedactedThinkingContentBlock {
+	return (
+		typeof block === 'object' &&
+		block !== null &&
+		'type' in block &&
+		block.type === 'redacted_thinking' &&
+		'data' in block &&
+		typeof block.data === 'string'
+	);
+}
+
+/**
+ * Type guard to check if a block is a Gemini thought signature block
+ */
+export function isGeminiThoughtSignatureBlock(
+	block: unknown,
+): block is GeminiThoughtSignatureBlock {
+	return (
+		typeof block === 'object' &&
+		block !== null &&
+		'thoughtSignature' in block &&
+		typeof block.thoughtSignature === 'string'
+	);
+}


### PR DESCRIPTION
## Summary

 This PR fixes a bug where Anthropic's thinking mode (introduced in Claude Opus 4.5) caused errors in the AI Agent Node. The issue occurred because
   the agent execution logic didn't properly handle the new thinking content blocks returned by Anthropic models when extended thinking is enabled.

  ### Changes:
  - **Enhanced agent execution logic** to extract and process Anthropic thinking metadata
  - **Added support for thinking content blocks** in `buildSteps.ts` and `createEngineRequests.ts`
  - **Improved type definitions** for Anthropic-specific response structures (thinking/redacted_thinking blocks, signatures)

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-1755/bug-thinking-mode-with-anthropic-opus-45-throws-error-about-order-of


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
