### PR TITLE
fix(editor): Align execute button in modal when executing tools

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/FromAiParametersModal.vue
+++ b/packages/frontend/editor-ui/src/app/components/FromAiParametersModal.vue
@@ -328,16 +328,13 @@ const onUpdate = (change: FormFieldValueUpdate) => {
 			</ElCol>
 		</template>
 		<template v-if="!error" #footer>
-			<ElRow justify="end">
-				<ElCol :span="5" :offset="19">
-					<N8nButton
-						data-test-id="execute-workflow-button"
-						icon="flask-conical"
-						:label="i18n.baseText('fromAiParametersModal.execute')"
-						@click="onExecute"
-					/>
-				</ElCol>
-			</ElRow>
+			<N8nButton
+				data-test-id="execute-workflow-button"
+				icon="flask-conical"
+				:label="i18n.baseText('fromAiParametersModal.execute')"
+				float="right"
+				@click="onExecute"
+			/>
 		</template>
 	</Modal>
 </template>


### PR DESCRIPTION
## Summary
Fixes the layout of the execute button in the fromAiParametersModal

Before:
<img width="1548" height="918" alt="image" src="https://github.com/user-attachments/assets/f50b26de-ac5b-420f-b8ba-b7efa752ed49" />

After:
<img width="639" height="355" alt="image" src="https://github.com/user-attachments/assets/ba980a80-0daa-4843-8a62-283c9ded83f0" />


## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-1750/partial-tool-execution-modal-execute-step-button-not-correctly-aligned


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
