### PR TITLE
feat(core): Introduce native Python code tool for AI agent

### DIFF
--- a/packages/@n8n/task-runner-python/src/message_serde.py
+++ b/packages/@n8n/task-runner-python/src/message_serde.py
@@ -50,6 +50,7 @@ def _parse_task_settings(d: dict) -> BrokerTaskSettings:
         workflow_id = settings_dict.get("workflowId", "Unknown")
         node_name = settings_dict.get("nodeName", "Unknown")
         node_id = settings_dict.get("nodeId", "Unknown")
+        query = settings_dict.get("query")
     except KeyError as e:
         raise ValueError(f"Missing field in task settings message: {e}")
 
@@ -64,6 +65,7 @@ def _parse_task_settings(d: dict) -> BrokerTaskSettings:
             workflow_id=workflow_id,
             node_name=node_name,
             node_id=node_id,
+            query=query,
         ),
     )
 

--- a/packages/@n8n/task-runner-python/src/message_types/broker.py
+++ b/packages/@n8n/task-runner-python/src/message_types/broker.py
@@ -32,6 +32,8 @@ NodeMode = Literal["all_items", "per_item"]
 
 Items = list[dict[str, Any]]  # INodeExecutionData[]
 
+Query = str | dict[str, Any] | None  # tool input
+
 
 @dataclass
 class TaskSettings:
@@ -43,6 +45,7 @@ class TaskSettings:
     workflow_id: str
     node_name: str
     node_id: str
+    query: Query = None
 
 
 @dataclass

--- a/packages/@n8n/task-runner-python/src/pipe_reader.py
+++ b/packages/@n8n/task-runner-python/src/pipe_reader.py
@@ -79,8 +79,6 @@ class PipeReader(threading.Thread):
         if has_result and has_error:
             raise InvalidPipeMsgContentError("Msg has both 'result' and 'error' keys")
 
-        if has_result and not isinstance(msg["result"], list):
-            raise InvalidPipeMsgContentError("'result' must be a list")
 
         if has_error and not isinstance(msg["error"], dict):
             raise InvalidPipeMsgContentError("'error' must be a dict")

--- a/packages/@n8n/task-runner-python/src/pipe_reader.py
+++ b/packages/@n8n/task-runner-python/src/pipe_reader.py
@@ -79,7 +79,6 @@ class PipeReader(threading.Thread):
         if has_result and has_error:
             raise InvalidPipeMsgContentError("Msg has both 'result' and 'error' keys")
 
-
         if has_error and not isinstance(msg["error"], dict):
             raise InvalidPipeMsgContentError("'error' must be a dict")
 

--- a/packages/@n8n/task-runner-python/src/task_executor.py
+++ b/packages/@n8n/task-runner-python/src/task_executor.py
@@ -227,7 +227,7 @@ class TaskExecutor:
         items: Items,
         write_conn,
         security_config: SecurityConfig,
-        _query: Query = None, # unused, only to keep signatures consistent across modes
+        _query: Query = None,  # unused, only to keep signatures consistent across modes
     ):
         """Execute a Python code task in per-item mode."""
 

--- a/packages/@n8n/task-runner-python/src/task_executor.py
+++ b/packages/@n8n/task-runner-python/src/task_executor.py
@@ -20,7 +20,7 @@ from src.errors import (
 from src.import_validation import validate_module_import
 from src.config.security_config import SecurityConfig
 
-from src.message_types.broker import NodeMode, Items
+from src.message_types.broker import NodeMode, Items, Query
 from src.message_types.pipe import (
     PipeResultMessage,
     PipeErrorMessage,
@@ -59,6 +59,7 @@ class TaskExecutor:
         node_mode: NodeMode,
         items: Items,
         security_config: SecurityConfig,
+        query: Query = None,
     ) -> tuple[ForkServerProcess, PipeConnection, PipeConnection]:
         """Create a subprocess for executing a Python code task and a pipe for communication."""
 
@@ -78,6 +79,7 @@ class TaskExecutor:
                 items,
                 write_conn,
                 security_config,
+                query,
             ),
         )
 
@@ -186,6 +188,7 @@ class TaskExecutor:
         items: Items,
         write_conn,
         security_config: SecurityConfig,
+        query: Query = None,
     ):
         """Execute a Python code task in all-items mode."""
 
@@ -204,6 +207,7 @@ class TaskExecutor:
             globals = {
                 "__builtins__": TaskExecutor._filter_builtins(security_config),
                 "_items": items,
+                "_query": query,
                 "print": TaskExecutor._create_custom_print(print_args),
             }
 
@@ -223,6 +227,7 @@ class TaskExecutor:
         items: Items,
         write_conn,
         security_config: SecurityConfig,
+        _query: Query = None, # unused, only to keep signatures consistent across modes
     ):
         """Execute a Python code task in per-item mode."""
 

--- a/packages/@n8n/task-runner-python/src/task_runner.py
+++ b/packages/@n8n/task-runner-python/src/task_runner.py
@@ -315,6 +315,7 @@ class TaskRunner:
                 node_mode=task_settings.node_mode,
                 items=task_settings.items,
                 security_config=self.security_config,
+                query=task_settings.query,
             )
 
             task_state.process = process

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
@@ -251,7 +251,7 @@ const parameterOptions = computed(() => {
 	const safeOptions = (options ?? []).filter(isValidParameterOption);
 
 	// temporary until native Python runner is GA
-	if (props.parameter.name === 'language') {
+	if (props.parameter.name === 'language' && node.value?.type === 'n8n-nodes-base.code') {
 		if (settingsStore.isNativePythonRunnerEnabled) {
 			return safeOptions.filter((o) => o.value !== 'python');
 		} else {


### PR DESCRIPTION
## Summary

Introduce native Python as an option for the Code Tool that can be invoked by the AI Agent node.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1848

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
