### PR TITLE
chore(core): Implement stub credential resolver for development

### DIFF
--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/__tests__/resolver-contract-tests.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/__tests__/resolver-contract-tests.ts
@@ -1,0 +1,327 @@
+import type { CredentialResolverConfiguration, ICredentialResolver } from '@n8n/decorators';
+import {
+	CredentialResolverDataNotFoundError,
+	CredentialResolverValidationError,
+} from '@n8n/decorators';
+import type { ICredentialContext, ICredentialDataDecryptedObject } from 'n8n-workflow';
+
+/**
+ * Configuration for resolver contract tests
+ */
+export interface ResolverContractTestConfig {
+	/** Factory function to create a fresh resolver instance for each test */
+	createResolver: () => ICredentialResolver | Promise<ICredentialResolver>;
+
+	/** Optional async setup function called before all tests */
+	beforeAll?: () => Promise<void>;
+
+	/** Optional async teardown function called after all tests */
+	afterAll?: () => Promise<void>;
+
+	/** Optional cleanup function called after each test */
+	afterEach?: () => Promise<void>;
+
+	/** Test cases for options validation */
+	validationTests: {
+		/** Valid options that should pass validation */
+		validOptions: Array<[string, CredentialResolverConfiguration]>;
+		/** Invalid options that should fail validation */
+		invalidOptions: Array<[string, CredentialResolverConfiguration]>;
+	};
+}
+
+/**
+ * Helper functions for creating test data
+ */
+export const testHelpers = {
+	/** Creates a test credential context with the given identity */
+	createContext: (identity: string): ICredentialContext => ({
+		identity,
+		version: 1,
+	}),
+
+	/** Creates test credential data */
+	createCredentialData: (data: Record<string, unknown> = {}): ICredentialDataDecryptedObject => ({
+		apiKey: 'test-key-123',
+		apiSecret: 'test-secret-456',
+		...data,
+	}),
+
+	/** Generates a random credential ID for isolation */
+	randomCredentialId: (): string => `cred-${Math.random().toString(36).substring(7)}`,
+
+	/** Generates a random identity for isolation */
+	randomIdentity: (): string => `identity-${Math.random().toString(36).substring(7)}`,
+};
+
+/**
+ * Reusable test suite for ICredentialResolver contract compliance.
+ * Tests that any resolver implementation correctly implements the interface contract.
+ *
+ * @example
+ * describe('MyResolver', () => {
+ *   testCredentialResolverContract({
+ *     createResolver: () => new MyResolver(deps),
+ *     validationTests: {
+ *       validOptions: [{ endpoint: 'https://api.example.com' }],
+ *       invalidOptions: [{ options: { endpoint: 123 }, description: 'invalid endpoint type' }],
+ *     },
+ *   });
+ * });
+ */
+export function testCredentialResolverContract(config: ResolverContractTestConfig) {
+	const { createResolver, validationTests } = config;
+
+	let resolver: ICredentialResolver;
+
+	describe('ICredentialResolver contract', () => {
+		beforeAll(async () => {
+			if (config.beforeAll) {
+				await config.beforeAll();
+			}
+		});
+
+		afterAll(async () => {
+			if (config.afterAll) {
+				await config.afterAll();
+			}
+		});
+
+		beforeEach(async () => {
+			resolver = await createResolver();
+		});
+
+		afterEach(async () => {
+			if (config.afterEach) {
+				await config.afterEach();
+			}
+		});
+
+		describe('validateOptions', () => {
+			it.each(validationTests.validOptions)(
+				'should accept valid options: %s',
+				async (_, options) => {
+					await expect(resolver.validateOptions(options)).resolves.not.toThrow();
+				},
+			);
+
+			it.each(validationTests.invalidOptions)(
+				'should reject invalid options: %s',
+				async (_, options) => {
+					await expect(resolver.validateOptions(options)).rejects.toThrow(
+						CredentialResolverValidationError,
+					);
+				},
+			);
+		});
+
+		describe('getSecret', () => {
+			it('should throw CredentialResolverDataNotFoundError when data does not exist', async () => {
+				const credentialId = testHelpers.randomCredentialId();
+				const context = testHelpers.createContext(testHelpers.randomIdentity());
+				const options = validationTests.validOptions[0][1];
+
+				await expect(resolver.getSecret(credentialId, context, options)).rejects.toThrow(
+					CredentialResolverDataNotFoundError,
+				);
+			});
+
+			it('should return data that was previously stored', async () => {
+				const credentialId = testHelpers.randomCredentialId();
+				const context = testHelpers.createContext(testHelpers.randomIdentity());
+				const data = testHelpers.createCredentialData();
+				const options = validationTests.validOptions[0][1];
+
+				await resolver.setSecret(credentialId, context, data, options);
+				const retrieved = await resolver.getSecret(credentialId, context, options);
+
+				expect(retrieved).toEqual(data);
+			});
+
+			it('should throw when retrieving after delete (if deleteSecret exists)', async () => {
+				if (!resolver.deleteSecret) {
+					return; // Skip if deleteSecret not implemented
+				}
+
+				const credentialId = testHelpers.randomCredentialId();
+				const context = testHelpers.createContext(testHelpers.randomIdentity());
+				const data = testHelpers.createCredentialData();
+				const options = validationTests.validOptions[0][1];
+
+				await resolver.setSecret(credentialId, context, data, options);
+				await resolver.deleteSecret(credentialId, context, options);
+
+				await expect(resolver.getSecret(credentialId, context, options)).rejects.toThrow(
+					CredentialResolverDataNotFoundError,
+				);
+			});
+		});
+
+		describe('setSecret', () => {
+			it('should store data that can be retrieved', async () => {
+				const credentialId = testHelpers.randomCredentialId();
+				const context = testHelpers.createContext(testHelpers.randomIdentity());
+				const data = testHelpers.createCredentialData();
+				const options = validationTests.validOptions[0][1];
+
+				await resolver.setSecret(credentialId, context, data, options);
+				const retrieved = await resolver.getSecret(credentialId, context, options);
+
+				expect(retrieved).toEqual(data);
+			});
+
+			it('should overwrite existing data', async () => {
+				const credentialId = testHelpers.randomCredentialId();
+				const context = testHelpers.createContext(testHelpers.randomIdentity());
+				const options = validationTests.validOptions[0][1];
+
+				const data1 = testHelpers.createCredentialData({ apiKey: 'key-1' });
+				const data2 = testHelpers.createCredentialData({ apiKey: 'key-2' });
+
+				await resolver.setSecret(credentialId, context, data1, options);
+				await resolver.setSecret(credentialId, context, data2, options);
+
+				const retrieved = await resolver.getSecret(credentialId, context, options);
+				expect(retrieved).toEqual(data2);
+			});
+		});
+
+		describe('deleteSecret (if implemented)', () => {
+			it('should remove stored data', async () => {
+				if (!resolver.deleteSecret) {
+					return; // Skip if deleteSecret not implemented
+				}
+
+				const credentialId = testHelpers.randomCredentialId();
+				const context = testHelpers.createContext(testHelpers.randomIdentity());
+				const data = testHelpers.createCredentialData();
+				const options = validationTests.validOptions[0][1];
+
+				await resolver.setSecret(credentialId, context, data, options);
+				await resolver.deleteSecret(credentialId, context, options);
+
+				await expect(resolver.getSecret(credentialId, context, options)).rejects.toThrow(
+					CredentialResolverDataNotFoundError,
+				);
+			});
+
+			it('should be idempotent (deleting twice should not error)', async () => {
+				if (!resolver.deleteSecret) {
+					return; // Skip if deleteSecret not implemented
+				}
+
+				const credentialId = testHelpers.randomCredentialId();
+				const context = testHelpers.createContext(testHelpers.randomIdentity());
+				const data = testHelpers.createCredentialData();
+				const options = validationTests.validOptions[0][1];
+
+				await resolver.setSecret(credentialId, context, data, options);
+				await resolver.deleteSecret(credentialId, context, options);
+				await expect(resolver.deleteSecret(credentialId, context, options)).resolves.not.toThrow();
+			});
+
+			it('should not error when deleting non-existent data', async () => {
+				if (!resolver.deleteSecret) {
+					return; // Skip if deleteSecret not implemented
+				}
+
+				const credentialId = testHelpers.randomCredentialId();
+				const context = testHelpers.createContext(testHelpers.randomIdentity());
+				const options = validationTests.validOptions[0][1];
+
+				await expect(resolver.deleteSecret(credentialId, context, options)).resolves.not.toThrow();
+			});
+		});
+
+		describe('isolation', () => {
+			it('should isolate data by credential ID', async () => {
+				const credentialId1 = testHelpers.randomCredentialId();
+				const credentialId2 = testHelpers.randomCredentialId();
+				const context = testHelpers.createContext(testHelpers.randomIdentity());
+				const options = validationTests.validOptions[0][1];
+
+				const data1 = testHelpers.createCredentialData({ apiKey: 'key-1' });
+				const data2 = testHelpers.createCredentialData({ apiKey: 'key-2' });
+
+				await resolver.setSecret(credentialId1, context, data1, options);
+				await resolver.setSecret(credentialId2, context, data2, options);
+
+				const retrieved1 = await resolver.getSecret(credentialId1, context, options);
+				const retrieved2 = await resolver.getSecret(credentialId2, context, options);
+
+				expect(retrieved1).toEqual(data1);
+				expect(retrieved2).toEqual(data2);
+			});
+
+			it('should isolate data by identity', async () => {
+				const credentialId = testHelpers.randomCredentialId();
+				const identity1 = testHelpers.randomIdentity();
+				const identity2 = testHelpers.randomIdentity();
+				const options = validationTests.validOptions[0][1];
+
+				const context1 = testHelpers.createContext(identity1);
+				const context2 = testHelpers.createContext(identity2);
+
+				const data1 = testHelpers.createCredentialData({ apiKey: 'key-1' });
+				const data2 = testHelpers.createCredentialData({ apiKey: 'key-2' });
+
+				await resolver.setSecret(credentialId, context1, data1, options);
+				await resolver.setSecret(credentialId, context2, data2, options);
+
+				const retrieved1 = await resolver.getSecret(credentialId, context1, options);
+				const retrieved2 = await resolver.getSecret(credentialId, context2, options);
+
+				expect(retrieved1).toEqual(data1);
+				expect(retrieved2).toEqual(data2);
+			});
+
+			it('should use same storage for same credential ID and identity', async () => {
+				const credentialId = testHelpers.randomCredentialId();
+				const identity = testHelpers.randomIdentity();
+				const context = testHelpers.createContext(identity);
+				const options = validationTests.validOptions[0][1];
+
+				const data = testHelpers.createCredentialData();
+
+				await resolver.setSecret(credentialId, context, data, options);
+
+				// Create a new context with same identity
+				const sameContext = testHelpers.createContext(identity);
+				const retrieved = await resolver.getSecret(credentialId, sameContext, options);
+
+				expect(retrieved).toEqual(data);
+			});
+
+			it('should not affect other identities when deleting (if deleteSecret exists)', async () => {
+				if (!resolver.deleteSecret) {
+					return; // Skip if deleteSecret not implemented
+				}
+
+				const credentialId = testHelpers.randomCredentialId();
+				const identity1 = testHelpers.randomIdentity();
+				const identity2 = testHelpers.randomIdentity();
+				const options = validationTests.validOptions[0][1];
+
+				const context1 = testHelpers.createContext(identity1);
+				const context2 = testHelpers.createContext(identity2);
+
+				const data1 = testHelpers.createCredentialData({ apiKey: 'key-1' });
+				const data2 = testHelpers.createCredentialData({ apiKey: 'key-2' });
+
+				await resolver.setSecret(credentialId, context1, data1, options);
+				await resolver.setSecret(credentialId, context2, data2, options);
+
+				await resolver.deleteSecret(credentialId, context1, options);
+
+				// Identity1 should be deleted
+				await expect(resolver.getSecret(credentialId, context1, options)).rejects.toThrow(
+					CredentialResolverDataNotFoundError,
+				);
+
+				// Identity2 should still exist
+				const retrieved2 = await resolver.getSecret(credentialId, context2, options);
+				expect(retrieved2).toEqual(data2);
+			});
+		});
+	});
+}

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/__tests__/stub-credential-resolver.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/__tests__/stub-credential-resolver.test.ts
@@ -1,0 +1,74 @@
+import type { Logger } from '@n8n/backend-common';
+
+import { testCredentialResolverContract, testHelpers } from './resolver-contract-tests';
+import { StubCredentialResolver } from '../stub-credential-resolver';
+
+describe('StubCredentialResolver', () => {
+	let mockLogger: jest.Mocked<Logger>;
+
+	beforeEach(() => {
+		mockLogger = {
+			debug: jest.fn(),
+			info: jest.fn(),
+			warn: jest.fn(),
+			error: jest.fn(),
+		} as unknown as jest.Mocked<Logger>;
+	});
+
+	// Run the standard contract tests
+	testCredentialResolverContract({
+		createResolver: () => new StubCredentialResolver(mockLogger),
+		validationTests: {
+			validOptions: [
+				['no options', {}], // No options
+				['empty prefix', { prefix: '' }], // Empty prefix
+				['with prefix', { prefix: 'test' }], // With prefix
+				['complex prefix', { prefix: 'namespace:sub' }], // Complex prefix
+			],
+			invalidOptions: [
+				['prefix must be string', { prefix: 123 }],
+				['prefix cannot be null', { prefix: null }],
+			],
+		},
+	});
+
+	// Stub-specific tests (if any unique behavior needs testing)
+	describe('stub-specific behavior', () => {
+		it('should use prefix in key generation', async () => {
+			const resolver = new StubCredentialResolver(mockLogger);
+			const credentialId = 'cred-123';
+			const context = testHelpers.createContext('user-1');
+			const data = { apiKey: 'test-key' };
+
+			// Store with prefix
+			await resolver.setSecret(credentialId, context, data, { prefix: 'test' });
+
+			// Should retrieve with same prefix
+			const retrieved = await resolver.getSecret(credentialId, context, { prefix: 'test' });
+			expect(retrieved).toEqual(data);
+
+			// Should NOT retrieve with different prefix
+			await expect(
+				resolver.getSecret(credentialId, context, { prefix: 'other' }),
+			).rejects.toThrow();
+
+			// Should NOT retrieve without prefix
+			await expect(resolver.getSecret(credentialId, context, {})).rejects.toThrow();
+		});
+
+		it('should store data in memory (lost on restart)', async () => {
+			const resolver1 = new StubCredentialResolver(mockLogger);
+			const resolver2 = new StubCredentialResolver(mockLogger);
+
+			const credentialId = 'cred-123';
+			const context = testHelpers.createContext('user-1');
+			const data = { apiKey: 'test-key' };
+
+			// Store in first instance
+			await resolver1.setSecret(credentialId, context, data, {});
+
+			// Should not be available in second instance (different memory)
+			await expect(resolver2.getSecret(credentialId, context, {})).rejects.toThrow();
+		});
+	});
+});

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/index.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/index.ts
@@ -1,0 +1,1 @@
+import './stub-credential-resolver';

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/stub-credential-resolver.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/stub-credential-resolver.ts
@@ -1,0 +1,110 @@
+import { Logger } from '@n8n/backend-common';
+import {
+	CredentialResolver,
+	CredentialResolverConfiguration,
+	CredentialResolverDataNotFoundError,
+	CredentialResolverValidationError,
+	ICredentialResolver,
+} from '@n8n/decorators';
+import { ICredentialContext, ICredentialDataDecryptedObject } from 'n8n-workflow';
+import z from 'zod/v4';
+
+const StubOptionsSchema = z.object({
+	prefix: z.string().default(''),
+});
+
+type StubOptions = z.infer<typeof StubOptionsSchema>;
+
+/**
+ * Simple in-memory credential resolver for testing purposes.
+ * Stores credentials by identity without authentication or external storage.
+ */
+@CredentialResolver()
+export class StubCredentialResolver implements ICredentialResolver {
+	private secretsStore: Map<string, ICredentialDataDecryptedObject> = new Map();
+
+	constructor(private readonly logger: Logger) {}
+
+	metadata = {
+		name: 'credential-resolver.stub-1.0',
+		description: 'A stub credential resolver for testing purposes',
+		displayName: 'Stub Resolver',
+		options: [
+			{
+				displayName: 'Prefix',
+				name: 'prefix',
+				type: 'string' as const,
+				default: '',
+				placeholder: 'Optional prefix for stored credentials',
+				description: 'An optional prefix to namespace stored credentials (useful for testing)',
+			},
+		],
+	};
+
+	/** Generates storage key from credential ID, identity, and optional prefix */
+	private generateKey(
+		credentialId: string,
+		context: ICredentialContext,
+		options: StubOptions,
+	): string {
+		return `${options.prefix}:${credentialId}:${context.identity}`;
+	}
+
+	/**
+	 * Retrieves stored credential data for the given identity.
+	 * @throws {CredentialResolverDataNotFoundError} When no data exists for the key
+	 */
+	async getSecret(
+		credentialId: string,
+		context: ICredentialContext,
+		options: CredentialResolverConfiguration,
+	): Promise<ICredentialDataDecryptedObject> {
+		const parsedOptions = await this.parseOptions(options);
+		const key = this.generateKey(credentialId, context, parsedOptions);
+		const secret = this.secretsStore.get(key);
+		if (!secret) {
+			throw new CredentialResolverDataNotFoundError();
+		}
+		return secret;
+	}
+
+	/** Stores credential data for the given identity */
+	async setSecret(
+		credentialId: string,
+		context: ICredentialContext,
+		data: ICredentialDataDecryptedObject,
+		options: CredentialResolverConfiguration,
+	): Promise<void> {
+		const parsedOptions = await this.parseOptions(options);
+		const key = this.generateKey(credentialId, context, parsedOptions);
+		this.secretsStore.set(key, data);
+	}
+
+	/** Deletes credential data for the given identity. Succeeds silently if not found. */
+	async deleteSecret(
+		credentialId: string,
+		context: ICredentialContext,
+		options: CredentialResolverConfiguration,
+	): Promise<void> {
+		const parsedOptions = await this.parseOptions(options);
+		const key = this.generateKey(credentialId, context, parsedOptions);
+		this.secretsStore.delete(key);
+	}
+
+	private async parseOptions(options: CredentialResolverConfiguration) {
+		const result = await StubOptionsSchema.safeParseAsync(options);
+		if (result.error) {
+			this.logger.error('Invalid options provided to StubCredentialResolver', {
+				error: result.error,
+			});
+			throw new CredentialResolverValidationError(
+				`Invalid options for StubCredentialResolver: ${result.error.message}`,
+			);
+		}
+		return result.data;
+	}
+
+	async validateOptions(options: CredentialResolverConfiguration): Promise<void> {
+		await this.parseOptions(options);
+	}
+}

--- a/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.module.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.module.ts
@@ -6,6 +6,7 @@ import { Container } from '@n8n/di';
 export class DynamicCredentialsModule implements ModuleInterface {
 	async init() {
 		await import('./context-establishment-hooks');
+		await import('./credential-resolvers');
 		const { CredentialResolverRegistry } = await import('./services');
 
 		await Container.get(CredentialResolverRegistry).init();


### PR DESCRIPTION
## Summary

Implements StubCredentialResolver for testing credential resolution without external dependencies (PAY-4210). The resolver stores credential data in-memory keyed by identity, credential ID, and optional prefix. Includes reusable testCredentialResolverContract() test suite that validates any ICredentialResolver implementation, ensuring consistent behavior across all future resolver types.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/project/dynamic-credential-mvp-02f1b3c010de/issues

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
