### PR TITLE
ci: Fix rc versioning to properly bump major version

### DIFF
--- a/.github/scripts/bump-versions.mjs
+++ b/.github/scripts/bump-versions.mjs
@@ -22,21 +22,6 @@ function generateExperimentalVersion(currentVersion) {
 	return `${parsed.major}.${parsed.minor}.${parsed.patch}-exp.0`;
 }
 
-function generateRcVersion(currentVersion) {
-	const parsed = semver.parse(currentVersion);
-	if (!parsed) throw new Error(`Invalid version: ${currentVersion}`);
-
-	// Check if it's already an RC version
-	if (parsed.prerelease.length > 0 && parsed.prerelease[0] === 'rc') {
-		// Increment the RC number
-		const rcNum = (parsed.prerelease[1] || 0) + 1;
-		return `${parsed.major}.${parsed.minor}.${parsed.patch}-rc.${rcNum}`;
-	}
-
-	// Create new RC version: <major>.<minor>.<patch>-rc.0
-	return `${parsed.major}.${parsed.minor}.${parsed.patch}-rc.0`;
-}
-
 const rootDir = process.cwd();
 const releaseType = process.env.RELEASE_TYPE;
 assert.match(releaseType, /^(patch|minor|major|experimental|rc)$/, 'Invalid RELEASE_TYPE');
@@ -79,7 +64,7 @@ for (const packageName in packageMap) {
 			? releaseType === 'experimental'
 				? generateExperimentalVersion(version)
 				: releaseType === 'rc'
-					? generateRcVersion(version)
+					? semver.inc(version, version.includes('-rc.') ? 'prerelease' : 'premajor', undefined, 'rc')
 					: semver.inc(version, releaseType)
 			: version;
 


### PR DESCRIPTION
## Summary
  - Fix RC release versioning to properly bump major version on first RC (1.123.0 → 2.0.0-rc.0)
  - Use prerelease for subsequent RCs to increment correctly (2.0.0-rc.0 → 2.0.0-rc.1)
  - Remove unused generateRcVersion helper function

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/CAT-1856/fix-rc-release-versioning-to-properly-bump-major-version


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
