### PR TITLE
feat: Stop bumping `versionId` on every workflow change (no-changelog)

### DIFF
--- a/packages/cli/src/workflows/workflow.request.ts
+++ b/packages/cli/src/workflows/workflow.request.ts
@@ -27,6 +27,7 @@ export declare namespace WorkflowRequest {
 		projectId: string;
 		parentFolderId?: string;
 		uiContext?: string;
+		expectedChecksum?: string;
 	}>;
 
 	// TODO: Use a discriminator when CAT-1809 lands
@@ -96,7 +97,7 @@ export declare namespace WorkflowRequest {
 	type Activate = AuthenticatedRequest<
 		{ workflowId: string },
 		{},
-		{ versionId: string; name?: string; description?: string }
+		{ versionId: string; name?: string; description?: string; expectedChecksum?: string }
 	>;
 
 	type Deactivate = AuthenticatedRequest<{ workflowId: string }>;

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -259,9 +259,10 @@ export class WorkflowService {
 
 		// Update the workflow's version when changing nodes or connections
 		const saveNewVersion =
-			('nodes' in workflowUpdateData && workflowUpdateData.nodes !== workflow.nodes) ||
+			('nodes' in workflowUpdateData && !isEqual(workflowUpdateData.nodes, workflow.nodes)) ||
 			('connections' in workflowUpdateData &&
-				workflowUpdateData.connections !== workflow.connections);
+				!isEqual(workflowUpdateData.connections, workflow.connections));
+
 		if (saveNewVersion) {
 			workflowUpdateData.versionId = uuid();
 			this.logger.debug(

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -24,7 +24,6 @@ import type { EntityManager } from '@n8n/typeorm';
 import { In } from '@n8n/typeorm';
 import type { QueryDeepPartialEntity } from '@n8n/typeorm/query-builder/QueryPartialEntity';
 import isEqual from 'lodash/isEqual';
-import omit from 'lodash/omit';
 import pick from 'lodash/pick';
 import { FileLocation, BinaryDataService } from 'n8n-core';
 import { NodeApiError, PROJECT_ROOT, assert, calculateWorkflowChecksum } from 'n8n-workflow';
@@ -258,15 +257,12 @@ export class WorkflowService {
 			await this._detectConflicts(workflow, expectedChecksum);
 		}
 
-		if (
-			Object.keys(omit(workflowUpdateData, ['id', 'versionId', 'active', 'activeVersionId']))
-				.length > 0
-		) {
-			// Update the workflow's version when changing properties such as
-			// `name`, `pinData`, `nodes`, `connections`, `settings` or `tags`
-			// This is necessary for collaboration to work properly - even when only name or settings
-			// change, we need to update the version to detect conflicts when multiple users are editing.
-
+		// Update the workflow's version when changing nodes or connections
+		const saveNewVersion =
+			('nodes' in workflowUpdateData && workflowUpdateData.nodes !== workflow.nodes) ||
+			('connections' in workflowUpdateData &&
+				workflowUpdateData.connections !== workflow.connections);
+		if (saveNewVersion) {
 			workflowUpdateData.versionId = uuid();
 			this.logger.debug(
 				`Updating versionId for workflow ${workflowId} for user ${user.id} after saving`,
@@ -275,15 +271,13 @@ export class WorkflowService {
 					newVersionId: workflowUpdateData.versionId,
 				},
 			);
-		}
 
-		const versionChanged =
-			workflowUpdateData.versionId && workflowUpdateData.versionId !== workflow.versionId;
-
-		if (versionChanged) {
 			// To save a version, we need both nodes and connections
 			workflowUpdateData.nodes = workflowUpdateData.nodes ?? workflow.nodes;
 			workflowUpdateData.connections = workflowUpdateData.connections ?? workflow.connections;
+		} else {
+			// Do not let users change versionId directly
+			workflowUpdateData.versionId = workflow.versionId;
 		}
 
 		// check credentials for old format
@@ -353,7 +347,7 @@ export class WorkflowService {
 		);
 
 		// Save the workflow to history first, so we can retrieve the complete version object for the update
-		if (versionChanged) {
+		if (saveNewVersion) {
 			await this.workflowHistoryService.saveVersion(user, workflowUpdateData, workflowId);
 		}
 

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -404,7 +404,7 @@ export class WorkflowsController {
 		const forceSave = req.query.forceSave === 'true';
 
 		let updateData = new WorkflowEntity();
-		const { tags, parentFolderId, ...rest } = req.body;
+		const { tags, parentFolderId, expectedChecksum, ...rest } = req.body;
 
 		// TODO: Add zod validation for entire `rest` object before assigning to `updateData`
 		if (
@@ -429,6 +429,7 @@ export class WorkflowsController {
 			tagIds: tags,
 			parentFolderId,
 			forceSave: isSharingEnabled ? forceSave : true,
+			expectedChecksum,
 		});
 
 		const scopes = await this.workflowService.getWorkflowScopes(req.user, workflowId);
@@ -499,7 +500,7 @@ export class WorkflowsController {
 	@ProjectScope('workflow:update')
 	async activate(req: WorkflowRequest.Activate) {
 		const { workflowId } = req.params;
-		const { versionId, name, description } = req.body;
+		const { versionId, name, description, expectedChecksum } = req.body;
 
 		if (!versionId) {
 			throw new BadRequestError('versionId is required');
@@ -509,6 +510,7 @@ export class WorkflowsController {
 			versionId,
 			name,
 			description,
+			expectedChecksum,
 		});
 
 		const scopes = await this.workflowService.getWorkflowScopes(req.user, workflowId);

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -2497,7 +2497,7 @@ describe('PATCH /workflows/:workflowId', () => {
 		const response = await authOwnerAgent.patch(`/workflows/${workflow.id}`).send(payload);
 
 		const {
-			data: { id, versionId: updatedVersionId },
+			data: { id },
 		} = response.body as { data: WorkflowEntity };
 
 		expect(response.statusCode).toBe(200);

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -2435,11 +2435,10 @@ describe('GET /workflows?includeFolders=true', () => {
 });
 
 describe('PATCH /workflows/:workflowId', () => {
-	test('should always create workflow history version', async () => {
+	test('should always create workflow history version on nodes and connection changes', async () => {
 		const workflow = await createWorkflowWithHistory({}, owner);
 		const payload = {
 			name: 'name updated',
-			versionId: workflow.versionId,
 			nodes: [
 				{
 					id: 'uuid-1234',
@@ -2476,23 +2475,59 @@ describe('PATCH /workflows/:workflowId', () => {
 
 		const {
 			data: { id, versionId: updatedVersionId },
-		} = response.body;
+		} = response.body as { data: WorkflowEntity };
 
 		expect(response.statusCode).toBe(200);
-		expect(response.body.data.settings.timeSavedMode).toBe('fixed');
-		expect(response.body.data.settings.timeSavedPerExecution).toBe(10);
 
 		expect(id).toBe(workflow.id);
-		expect(await workflowHistoryRepository.count({ where: { workflowId: id } })).toBe(2);
-		const historyVersion = await workflowHistoryRepository.findOne({
-			where: {
-				workflowId: id,
-				versionId: updatedVersionId,
-			},
-		});
-		expect(historyVersion).not.toBeNull();
-		expect(historyVersion!.connections).toEqual(payload.connections);
-		expect(historyVersion!.nodes).toEqual(payload.nodes);
+		const versions = await workflowHistoryRepository.find({ where: { workflowId: id } });
+		expect(versions).toHaveLength(2);
+		const newVersion = versions.find((v) => v.versionId === updatedVersionId);
+		expect(newVersion).not.toBeNull();
+		expect(newVersion!.connections).toEqual(payload.connections);
+		expect(newVersion!.nodes).toEqual(payload.nodes);
+	});
+
+	test('should not create workflow history version on other changes', async () => {
+		const workflow = await createWorkflowWithHistory({}, owner);
+		const payload = {
+			name: 'name updated',
+		};
+
+		const response = await authOwnerAgent.patch(`/workflows/${workflow.id}`).send(payload);
+
+		const {
+			data: { id, versionId: updatedVersionId },
+		} = response.body as { data: WorkflowEntity };
+
+		expect(response.statusCode).toBe(200);
+
+		expect(id).toBe(workflow.id);
+		const versions = await workflowHistoryRepository.find({ where: { workflowId: id } });
+		expect(versions).toHaveLength(1);
+		expect(versions[0].versionId).toBe(workflow.versionId);
+	});
+
+	test('should ignore provided version id', async () => {
+		const workflow = await createWorkflowWithHistory({}, owner);
+		const newVersionId = uuid();
+		const payload = {
+			description: 'description updated',
+			newVersionId,
+		};
+
+		const response = await authOwnerAgent.patch(`/workflows/${workflow.id}`).send(payload);
+
+		const {
+			data: { id: workflowId },
+		} = response.body as { data: WorkflowEntity };
+
+		expect(response.statusCode).toBe(200);
+
+		expect(workflowId).toBe(workflow.id);
+		const versions = await workflowHistoryRepository.find({ where: { workflowId } });
+		expect(versions).toHaveLength(1);
+		expect(versions[0].versionId).toBe(workflow.versionId);
 	});
 
 	test('should update the version counter', async () => {
@@ -2504,10 +2539,9 @@ describe('PATCH /workflows/:workflowId', () => {
 
 		const response = await authOwnerAgent.patch(`/workflows/${workflow.id}`).send(payload);
 
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 		const {
 			data: { id, versionCounter },
-		} = response.body;
+		} = response.body as { data: WorkflowEntity };
 
 		expect(response.statusCode).toBe(200);
 
@@ -2521,8 +2555,7 @@ describe('PATCH /workflows/:workflowId', () => {
 		await setActiveVersion(workflow.id, workflow.versionId);
 
 		const payload = {
-			name: 'Updated Workflow',
-			versionId: workflow.versionId,
+			nodes: [],
 		};
 
 		const response = await authOwnerAgent.patch(`/workflows/${workflow.id}`).send(payload);
@@ -2532,8 +2565,8 @@ describe('PATCH /workflows/:workflowId', () => {
 		expect(activeWorkflowManagerLike.add).not.toBeCalled();
 		expect(addRecordSpy).not.toBeCalled();
 
-		const { data } = response.body;
-		expect(data.name).toBe('Updated Workflow');
+		const { data } = response.body as { data: WorkflowEntity };
+		expect(data.nodes).toEqual([]);
 		expect(data.versionId).not.toBe(workflow.versionId); // New version created
 		expect(data.activeVersionId).toBe(workflow.versionId); // Should remain active
 	});
@@ -2549,7 +2582,7 @@ describe('PATCH /workflows/:workflowId', () => {
 
 		const response = await authOwnerAgent.patch(`/workflows/${workflow.id}`).send(payload);
 
-		const { data: updatedWorkflow } = response.body;
+		const { data: updatedWorkflow } = response.body as { data: WorkflowEntity };
 
 		expect(response.statusCode).toBe(200);
 
@@ -2646,7 +2679,7 @@ describe('PATCH /workflows/:workflowId', () => {
 		expect(response.statusCode).toBe(200);
 		expect(activeWorkflowManagerLike.add).not.toBeCalled();
 
-		const { data } = response.body;
+		const { data } = response.body as { data: WorkflowEntity };
 		expect(data.active).toBe(false);
 		expect(data.activeVersionId).toBeNull();
 	});
@@ -2667,7 +2700,7 @@ describe('PATCH /workflows/:workflowId', () => {
 		expect(activeWorkflowManagerLike.remove).not.toBeCalled();
 		expect(addRecordSpy).not.toBeCalled();
 
-		const { data } = response.body;
+		const { data } = response.body as { data: WorkflowEntity };
 		expect(data.active).toBe(true);
 		expect(data.activeVersionId).toBe(workflow.versionId);
 	});
@@ -2684,7 +2717,7 @@ describe('PATCH /workflows/:workflowId', () => {
 		expect(response.statusCode).toBe(200);
 		expect(activeWorkflowManagerLike.add).not.toBeCalled();
 
-		const { data } = response.body;
+		const { data } = response.body as { data: WorkflowEntity };
 		expect(data.activeVersionId).toBeNull(); // Should not be activated
 	});
 

--- a/packages/frontend/@n8n/rest-api-client/src/api/workflows.ts
+++ b/packages/frontend/@n8n/rest-api-client/src/api/workflows.ts
@@ -38,6 +38,8 @@ export interface WorkflowDataUpdate {
 	meta?: WorkflowMetadata;
 	parentFolderId?: string;
 	uiContext?: string;
+	// checksum of workflow snapshot for conflict detection
+	expectedChecksum?: string;
 }
 
 export interface WorkflowDataCreate extends WorkflowDataUpdate {

--- a/packages/frontend/editor-ui/src/app/components/WorkflowSettings.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowSettings.vue
@@ -15,7 +15,7 @@ import {
 } from '@/app/constants';
 import { N8nButton, N8nIcon, N8nInput, N8nOption, N8nSelect, N8nTooltip } from '@n8n/design-system';
 import type { WorkflowSettings } from 'n8n-workflow';
-import { deepCopy } from 'n8n-workflow';
+import { calculateWorkflowChecksum, deepCopy } from 'n8n-workflow';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useWorkflowsEEStore } from '@/app/stores/workflows.ee.store';
@@ -419,10 +419,12 @@ const saveSettings = async () => {
 
 	isLoading.value = true;
 	data.versionId = workflowsStore.workflowVersionId;
+	data.expectedChecksum = workflowsStore.workflowChecksum;
 
 	try {
 		const workflowData = await workflowsStore.updateWorkflow(String(route.params.name), data);
 		workflowsStore.setWorkflowVersionId(workflowData.versionId);
+		workflowsStore.setWorkflowChecksum(await calculateWorkflowChecksum(workflowData));
 	} catch (error) {
 		toast.showError(error, i18n.baseText('workflowSettings.showError.saveSettings3.title'));
 		isLoading.value = false;

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -3253,7 +3253,7 @@ describe('useCanvasOperations', () => {
 	});
 
 	describe('initializeWorkspace', () => {
-		it('should initialize the workspace', () => {
+		it('should initialize the workspace', async () => {
 			const workflowsStore = mockedStore(useWorkflowsStore);
 			const workflow = createTestWorkflow({
 				nodes: [createTestNode()],
@@ -3261,13 +3261,13 @@ describe('useCanvasOperations', () => {
 			});
 
 			const { initializeWorkspace } = useCanvasOperations();
-			initializeWorkspace(workflow);
+			await initializeWorkspace(workflow);
 
 			expect(workflowsStore.setNodes).toHaveBeenCalled();
 			expect(workflowsStore.setConnections).toHaveBeenCalled();
 		});
 
-		it('should initialize node data from node type description', () => {
+		it('should initialize node data from node type description', async () => {
 			const nodeTypesStore = mockedStore(useNodeTypesStore);
 			const type = SET_NODE_TYPE;
 			const version = 1;
@@ -3292,7 +3292,7 @@ describe('useCanvasOperations', () => {
 			});
 
 			const { initializeWorkspace } = useCanvasOperations();
-			initializeWorkspace(workflow);
+			await initializeWorkspace(workflow);
 
 			expect(workflow.nodes[0].parameters).toEqual({ value: true });
 		});

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -1736,8 +1736,8 @@ export function useCanvasOperations() {
 		nodeHelpers.credentialsUpdated.value = false;
 	}
 
-	function initializeWorkspace(data: IWorkflowDb) {
-		workflowHelpers.initState(data);
+	async function initializeWorkspace(data: IWorkflowDb) {
+		await workflowHelpers.initState(data);
 		data.nodes.forEach((node) => {
 			const nodeTypeDescription = requireNodeTypeDescription(node.type, node.typeVersion);
 			const isUnknownNode =
@@ -2308,7 +2308,7 @@ export function useCanvasOperations() {
 			toast.showMessage({ title, message, type: 'error', duration: 0 });
 		}
 
-		initializeWorkspace(data.workflowData);
+		await initializeWorkspace(data.workflowData);
 
 		workflowState.setWorkflowExecutionData(data);
 

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.ts
@@ -115,6 +115,10 @@ export function useWorkflowActivate() {
 			} else {
 				workflowsStore.setWorkflowInactive(currWorkflowId);
 			}
+
+			if (isCurrentWorkflow) {
+				workflowsStore.setWorkflowChecksum(await calculateWorkflowChecksum(workflow));
+			}
 		} catch (error) {
 			const newStateName = newActiveState ? 'activated' : 'deactivated';
 			toast.showError(
@@ -234,7 +238,11 @@ export function useWorkflowActivate() {
 		void useExternalHooks().run('workflowActivate.updateWorkflowActivation', telemetryPayload);
 
 		try {
-			await workflowsStore.deactivateWorkflow(workflowId);
+			const updatedWorkflow = await workflowsStore.deactivateWorkflow(workflowId);
+
+			if (workflowId === workflowsStore.workflowId) {
+				workflowsStore.setWorkflowChecksum(await calculateWorkflowChecksum(updatedWorkflow));
+			}
 
 			void useExternalHooks().run('workflow.activeChangeCurrent', {
 				workflowId,

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.ts
@@ -188,8 +188,11 @@ export function useWorkflowActivate() {
 			}
 
 			workflowsStore.setWorkflowActive(workflowId, updatedWorkflow.activeVersion);
-			workflowsStore.setWorkflowVersionId(updatedWorkflow.versionId);
-			workflowsStore.setWorkflowChecksum(await calculateWorkflowChecksum(updatedWorkflow));
+
+			if (workflowId === workflowsStore.workflowId) {
+				workflowsStore.setWorkflowVersionId(updatedWorkflow.versionId);
+				workflowsStore.setWorkflowChecksum(await calculateWorkflowChecksum(updatedWorkflow));
+			}
 
 			void useExternalHooks().run('workflow.activeChangeCurrent', {
 				workflowId,

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.test.ts
@@ -221,7 +221,7 @@ describe('useWorkflowHelpers', () => {
 	});
 
 	describe('initState', () => {
-		it('should initialize workflow state with provided data', () => {
+		it('should initialize workflow state with provided data', async () => {
 			const { initState } = useWorkflowHelpers();
 
 			const workflowData = createTestWorkflow({
@@ -249,7 +249,7 @@ describe('useWorkflowHelpers', () => {
 			const setWorkflowTagIdsSpy = vi.spyOn(workflowState, 'setWorkflowTagIds');
 			const upsertTagsSpy = vi.spyOn(tagsStore, 'upsertTags');
 
-			initState(workflowData);
+			await initState(workflowData);
 
 			expect(addWorkflowSpy).toHaveBeenCalledWith(workflowData);
 			expect(setActiveSpy).toHaveBeenCalledWith('v1');
@@ -275,7 +275,7 @@ describe('useWorkflowHelpers', () => {
 			expect(upsertTagsSpy).toHaveBeenCalledWith([]);
 		});
 
-		it('should handle missing `usedCredentials` and `sharedWithProjects` gracefully', () => {
+		it('should handle missing `usedCredentials` and `sharedWithProjects` gracefully', async () => {
 			const { initState } = useWorkflowHelpers();
 
 			const workflowData = createTestWorkflow({
@@ -290,13 +290,13 @@ describe('useWorkflowHelpers', () => {
 			const setUsedCredentialsSpy = vi.spyOn(workflowsStore, 'setUsedCredentials');
 			const setWorkflowSharedWithSpy = vi.spyOn(workflowsEEStore, 'setWorkflowSharedWith');
 
-			initState(workflowData);
+			await initState(workflowData);
 
 			expect(setUsedCredentialsSpy).not.toHaveBeenCalled();
 			expect(setWorkflowSharedWithSpy).not.toHaveBeenCalled();
 		});
 
-		it('should handle missing `tags` gracefully', () => {
+		it('should handle missing `tags` gracefully', async () => {
 			const { initState } = useWorkflowHelpers();
 
 			const workflowData = createTestWorkflow({
@@ -310,7 +310,7 @@ describe('useWorkflowHelpers', () => {
 			const setWorkflowTagIdsSpy = vi.spyOn(workflowState, 'setWorkflowTagIds');
 			const upsertTagsSpy = vi.spyOn(tagsStore, 'upsertTags');
 
-			initState(workflowData);
+			await initState(workflowData);
 
 			expect(setWorkflowTagIdsSpy).toHaveBeenCalledWith([]);
 			expect(upsertTagsSpy).toHaveBeenCalledWith([]);

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
@@ -23,6 +23,7 @@ import type {
 	Workflow,
 } from 'n8n-workflow';
 import {
+	calculateWorkflowChecksum,
 	CHAT_TRIGGER_NODE_TYPE,
 	createEmptyRunExecutionData,
 	FORM_TRIGGER_NODE_TYPE,
@@ -848,6 +849,7 @@ export function useWorkflowHelpers() {
 
 		const workflow = await workflowsStore.updateWorkflow(workflowId, data);
 		workflowsStore.setWorkflowVersionId(workflow.versionId);
+		workflowsStore.setWorkflowChecksum(await calculateWorkflowChecksum(workflow));
 
 		if (isCurrentWorkflow) {
 			workflowState.setActive(workflow.activeVersionId);
@@ -938,7 +940,7 @@ export function useWorkflowHelpers() {
 		}
 	}
 
-	function initState(workflowData: IWorkflowDb) {
+	async function initState(workflowData: IWorkflowDb) {
 		workflowsStore.addWorkflow(workflowData);
 		workflowState.setActive(workflowData.activeVersionId);
 		workflowsStore.setIsArchived(workflowData.isArchived);
@@ -951,6 +953,7 @@ export function useWorkflowHelpers() {
 		workflowState.setWorkflowSettings(workflowData.settings ?? {});
 		workflowsStore.setWorkflowPinData(workflowData.pinData ?? {});
 		workflowsStore.setWorkflowVersionId(workflowData.versionId);
+		workflowsStore.setWorkflowChecksum(await calculateWorkflowChecksum(workflowData));
 		workflowsStore.setWorkflowMetadata(workflowData.meta);
 		workflowsStore.setWorkflowScopes(workflowData.scopes);
 

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
@@ -19,6 +19,7 @@ import { useCanvasStore } from '@/app/stores/canvas.store';
 import type { IUpdateInformation, IWorkflowDb, NotificationOptions } from '@/Interface';
 import type { ITag } from '@n8n/rest-api-client/api/tags';
 import type { WorkflowDataCreate, WorkflowDataUpdate } from '@n8n/rest-api-client/api/workflows';
+import { calculateWorkflowChecksum } from 'n8n-workflow';
 import type { IDataObject, INode, IWorkflowSettings } from 'n8n-workflow';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useToast } from './useToast';
@@ -220,6 +221,8 @@ export function useWorkflowSaving({
 
 			workflowDataRequest.versionId = workflowsStore.workflowVersionId;
 
+			workflowDataRequest.expectedChecksum = workflowsStore.workflowChecksum;
+
 			const deactivateReason = await getWorkflowDeactivationInfo(
 				currentWorkflow,
 				workflowDataRequest,
@@ -240,6 +243,7 @@ export function useWorkflowSaving({
 				forceSave,
 			);
 			workflowsStore.setWorkflowVersionId(workflowData.versionId);
+			workflowsStore.setWorkflowChecksum(await calculateWorkflowChecksum(workflowData));
 
 			if (name) {
 				workflowState.setWorkflowName({ newName: workflowData.name, setStateDirty: false });

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -850,6 +850,10 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 			workflowsById.value[id].versionId = updatedWorkflow.versionId;
 		}
 
+		if (id === workflow.value.id) {
+			setWorkflowChecksum(await calculateWorkflowChecksum(updatedWorkflow));
+		}
+
 		setWorkflowInactive(id);
 
 		if (id === workflow.value.id) {
@@ -867,6 +871,11 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		if (workflowsById.value[id]) {
 			workflowsById.value[id].isArchived = false;
 			workflowsById.value[id].versionId = updatedWorkflow.versionId;
+		}
+
+		// Update checksum if unarchiving the currently open workflow
+		if (id === workflow.value.id) {
+			setWorkflowChecksum(await calculateWorkflowChecksum(updatedWorkflow));
 		}
 
 		if (id === workflow.value.id) {

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -726,6 +726,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 
 	function resetWorkflow() {
 		workflow.value = createEmptyWorkflow();
+		workflowChecksum.value = '';
 	}
 
 	function setUsedCredentials(data: IUsedCredential[]) {
@@ -1690,7 +1691,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		const updated = await updateWorkflow(id, {
 			versionId: currentVersionId,
 			settings: newSettings,
-			expectedChecksum: currentChecksum,
+			...(currentChecksum ? { expectedChecksum: currentChecksum } : {}),
 		});
 
 		// Update local store state to reflect the change

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -55,6 +55,7 @@ import type {
 	ITaskStartedData,
 } from 'n8n-workflow';
 import {
+	calculateWorkflowChecksum,
 	deepCopy,
 	NodeConnectionTypes,
 	SEND_AND_WAIT_OPERATION,
@@ -161,6 +162,8 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 	const workflowId = computed(() => workflow.value.id);
 
 	const workflowVersionId = computed(() => workflow.value.versionId);
+
+	const workflowChecksum = ref<string>('');
 
 	const workflowSettings = computed(() => workflow.value.settings ?? { ...defaults.settings });
 
@@ -735,6 +738,10 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 
 	function setWorkflowVersionId(versionId: string) {
 		workflow.value.versionId = versionId;
+	}
+
+	function setWorkflowChecksum(checksum: string) {
+		workflowChecksum.value = checksum;
 	}
 
 	function setWorkflowActiveVersion(version: WorkflowHistory) {
@@ -1614,7 +1621,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 
 	async function publishWorkflow(
 		id: string,
-		data: { versionId: string; name?: string; description?: string },
+		data: { versionId: string; name?: string; description?: string; expectedChecksum?: string },
 	): Promise<IWorkflowDb> {
 		const updatedWorkflow = await makeRestApiRequest<IWorkflowDb>(
 			rootStore.restApiContext,
@@ -1647,11 +1654,13 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		// Determine current settings and versionId for the target workflow
 		let currentSettings: IWorkflowSettings = {} as IWorkflowSettings;
 		let currentVersionId = '';
+		let currentChecksum = '';
 		const isCurrentWorkflow = id === workflow.value.id;
 
 		if (isCurrentWorkflow) {
 			currentSettings = workflow.value.settings ?? ({} as IWorkflowSettings);
 			currentVersionId = workflow.value.versionId;
+			currentChecksum = workflowChecksum.value;
 		} else {
 			const cached = workflowsById.value[id];
 			if (cached && cached.versionId) {
@@ -1672,11 +1681,13 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		const updated = await updateWorkflow(id, {
 			versionId: currentVersionId,
 			settings: newSettings,
+			expectedChecksum: currentChecksum,
 		});
 
 		// Update local store state to reflect the change
 		if (isCurrentWorkflow) {
 			setWorkflowVersionId(updated.versionId);
+			setWorkflowChecksum(await calculateWorkflowChecksum(updated));
 			setWorkflowSettings(updated.settings ?? {});
 		} else if (workflowsById.value[id]) {
 			workflowsById.value[id] = {
@@ -1694,10 +1705,12 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		description: string | null,
 	): Promise<IWorkflowDb> {
 		let currentVersionId = '';
+		let currentChecksum = '';
 		const isCurrentWorkflow = id === workflow.value.id;
 
 		if (isCurrentWorkflow) {
 			currentVersionId = workflow.value.versionId;
+			currentChecksum = workflowChecksum.value;
 		} else {
 			const cached = workflowsById.value[id];
 			if (cached?.versionId) {
@@ -1711,6 +1724,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		const updated = await updateWorkflow(id, {
 			versionId: currentVersionId,
 			description,
+			expectedChecksum: currentChecksum,
 		});
 
 		// Update local store state
@@ -1719,6 +1733,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 			if (updated.versionId !== currentVersionId) {
 				setWorkflowVersionId(updated.versionId);
 			}
+			setWorkflowChecksum(await calculateWorkflowChecksum(updated));
 		} else if (workflowsById.value[id]) {
 			workflowsById.value[id] = {
 				...workflowsById.value[id],
@@ -1926,6 +1941,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		workflowName,
 		workflowId,
 		workflowVersionId,
+		workflowChecksum,
 		workflowSettings,
 		workflowTags,
 		allWorkflows,
@@ -1985,6 +2001,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		addNodeExecutionStartedData,
 		setUsedCredentials,
 		setWorkflowVersionId,
+		setWorkflowChecksum,
 		setWorkflowActiveVersion,
 		replaceInvalidWorkflowCredentials,
 		assignCredentialToMatchingNodes,

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -477,7 +477,7 @@ async function initializeWorkspaceForExistingWorkflow(id: string) {
 	try {
 		const workflowData = await workflowsStore.fetchWorkflow(id);
 
-		openWorkflow(workflowData);
+		await openWorkflow(workflowData);
 
 		if (workflowData.parentFolder) {
 			workflowsStore.setParentFolder(workflowData.parentFolder);
@@ -538,11 +538,11 @@ function updateNodesIssues() {
  * Workflow
  */
 
-function openWorkflow(data: IWorkflowDb) {
+async function openWorkflow(data: IWorkflowDb) {
 	resetWorkspace();
 	documentTitle.setDocumentTitle(data.name, 'IDLE');
 
-	initializeWorkspace(data);
+	await initializeWorkspace(data);
 
 	void externalHooks.run('workflow.open', {
 		workflowId: data.id,
@@ -997,7 +997,7 @@ async function importWorkflowExact({ workflow: workflowData }: { workflow: Workf
 
 	await initializeData();
 
-	initializeWorkspace({
+	await initializeWorkspace({
 		...workflowData,
 		nodes: getNodesWithNormalizedPosition<INodeUi>(workflowData.nodes),
 	} as IWorkflowDb);
@@ -1505,7 +1505,7 @@ async function onSourceControlPull() {
 			const workflowData = await workflowsStore.fetchWorkflow(workflowId.value);
 			if (workflowData) {
 				documentTitle.setDocumentTitle(workflowData.name, 'IDLE');
-				openWorkflow(workflowData);
+				await openWorkflow(workflowData);
 			}
 		}
 	} catch (error) {

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/EvaluationsRootView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/EvaluationsRootView.vue
@@ -96,7 +96,7 @@ const { isReady } = useAsyncState(async () => {
 					await nodeTypesStore.getNodeTypes();
 				}
 
-				initializeWorkspace(data);
+				await initializeWorkspace(data);
 			} catch (error) {
 				toast.showError(error, locale.baseText('nodeView.showError.openWorkflow.title'));
 			}

--- a/packages/frontend/editor-ui/src/features/execution/executions/views/WorkflowExecutionsView.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/views/WorkflowExecutionsView.vue
@@ -142,7 +142,7 @@ async function fetchWorkflow() {
 			try {
 				await workflowsStore.fetchActiveWorkflows();
 				const data = await workflowsStore.fetchWorkflow(workflowId.value);
-				initializeWorkspace(data);
+				await initializeWorkspace(data);
 			} catch (error) {
 				toast.showError(error, i18n.baseText('nodeView.showError.openWorkflow.title'));
 			}

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -24,6 +24,7 @@ export * from './tool-helpers';
 export * from './node-reference-parser-utils';
 export * from './metadata-utils';
 export * from './workflow';
+export * from './workflow-checksum';
 export * from './workflow-data-proxy';
 export * from './workflow-data-proxy-env-provider';
 export * from './versioned-node-type';

--- a/packages/workflow/src/utils.ts
+++ b/packages/workflow/src/utils.ts
@@ -18,8 +18,19 @@ BigInt.prototype.toJSON = function () {
 	return this.toString();
 };
 
+/**
+ * Type guard for plain objects suitable for key-based traversal/serialization.
+ *
+ * Returns `true` for objects whose prototype is `Object.prototype` (object literals)
+ * or `null` (`Object.create(null)`), and `false` for arrays and non-plain objects
+ * such as `Date`, `Map`, `Set`, and class instances.
+ */
 export function isObject(value: unknown): value is Record<string, unknown> {
-	return value !== null && typeof value === 'object' && !Array.isArray(value);
+	if (value === null || typeof value !== 'object') return false;
+	if (Array.isArray(value)) return false;
+	if (Object.prototype.toString.call(value) !== '[object Object]') return false;
+
+	return Object.getPrototypeOf(value) === Object.prototype || Object.getPrototypeOf(value) === null;
 }
 
 export const isObjectEmpty = (obj: object | null | undefined): boolean => {

--- a/packages/workflow/src/utils.ts
+++ b/packages/workflow/src/utils.ts
@@ -18,6 +18,10 @@ BigInt.prototype.toJSON = function () {
 	return this.toString();
 };
 
+export function isObject(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
 export const isObjectEmpty = (obj: object | null | undefined): boolean => {
 	if (obj === undefined || obj === null) return true;
 	if (typeof obj === 'object') {

--- a/packages/workflow/src/workflow-checksum.ts
+++ b/packages/workflow/src/workflow-checksum.ts
@@ -1,4 +1,5 @@
 import type { IConnections, INode, IPinData, IWorkflowSettings } from './interfaces';
+import { isObject } from './utils';
 
 /**
  * Data structure containing workflow fields used for checksum calculation.
@@ -39,15 +40,18 @@ function sortObjectKeys(value: unknown): unknown {
 		return value.map((element) => sortObjectKeys(element));
 	}
 
-	const objectValue = value as Record<string, unknown>;
-	const sortedKeys = Object.keys(objectValue).sort();
+	if (isObject(value)) {
+		const sortedKeys = Object.keys(value).sort();
 
-	const sortedObject: Record<string, unknown> = {};
-	for (const key of sortedKeys) {
-		sortedObject[key] = sortObjectKeys(objectValue[key]);
+		const sortedObject: Record<string, unknown> = {};
+		for (const key of sortedKeys) {
+			sortedObject[key] = sortObjectKeys(value[key]);
+		}
+
+		return sortedObject;
 	}
 
-	return sortedObject;
+	return value;
 }
 
 /**

--- a/packages/workflow/src/workflow-checksum.ts
+++ b/packages/workflow/src/workflow-checksum.ts
@@ -1,0 +1,84 @@
+import type { IConnections, INode, IPinData, IWorkflowSettings } from './interfaces';
+
+/**
+ * Data structure containing workflow fields used for checksum calculation.
+ * Excludes id, versionId, active, timestamps, etc.
+ */
+export interface WorkflowSnapshot {
+	name?: string;
+	description?: string | null;
+	nodes?: INode[];
+	connections?: IConnections;
+	settings?: IWorkflowSettings;
+	meta?: unknown;
+	pinData?: IPinData;
+	isArchived?: boolean;
+	activeVersionId?: string | null;
+}
+
+const CHECKSUM_FIELDS = [
+	'name',
+	'description',
+	'nodes',
+	'connections',
+	'settings',
+	'meta',
+	'pinData',
+	'isArchived',
+	'activeVersionId',
+] as const satisfies ReadonlyArray<keyof WorkflowSnapshot>;
+
+/**
+ * Recursively sorts object keys alphabetically for consistent serialization.
+ * Arrays keep their order; their elements are normalized recursively.
+ */
+function sortObjectKeys(value: unknown): unknown {
+	if (value === null || typeof value !== 'object') return value;
+
+	if (Array.isArray(value)) {
+		return value.map((element) => sortObjectKeys(element));
+	}
+
+	const objectValue = value as Record<string, unknown>;
+	const sortedKeys = Object.keys(objectValue).sort();
+
+	const sortedObject: Record<string, unknown> = {};
+	for (const key of sortedKeys) {
+		sortedObject[key] = sortObjectKeys(objectValue[key]);
+	}
+
+	return sortedObject;
+}
+
+/**
+ * Calculates SHA-256 checksum of workflow content fields for conflict detection.
+ * Excludes: id, versionId, timestamps, staticData, relations.
+ */
+export async function calculateWorkflowChecksum(workflow: WorkflowSnapshot): Promise<string> {
+	const checksumPayload: Record<string, unknown> = {};
+
+	for (const field of CHECKSUM_FIELDS) {
+		const value = workflow[field];
+		if (value !== undefined) {
+			checksumPayload[field] = value;
+		}
+	}
+
+	const normalizedPayload = sortObjectKeys(checksumPayload);
+	const serializedPayload = JSON.stringify(normalizedPayload);
+
+	const data = new TextEncoder().encode(serializedPayload);
+	const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+	return arrayBufferToHex(hashBuffer);
+}
+
+function arrayBufferToHex(arrayBuffer: ArrayBuffer): string {
+	const bytes = new Uint8Array(arrayBuffer);
+	let hexString = '';
+
+	for (let index = 0; index < bytes.length; index++) {
+		hexString += bytes[index].toString(16).padStart(2, '0');
+	}
+
+	return hexString;
+}

--- a/packages/workflow/test/workflow-checksum.test.ts
+++ b/packages/workflow/test/workflow-checksum.test.ts
@@ -27,7 +27,7 @@ describe('calculateWorkflowChecksum', () => {
 		expect(checksum1).toBe(checksum2);
 	});
 
-	it('should generate different checksums when settings.timezone changes', async () => {
+	it('should generate different checksums when a setting changes', async () => {
 		const workflow1: WorkflowSnapshot = {
 			...baseWorkflow,
 			settings: {
@@ -47,15 +47,10 @@ describe('calculateWorkflowChecksum', () => {
 		const checksum1 = await calculateWorkflowChecksum(workflow1);
 		const checksum2 = await calculateWorkflowChecksum(workflow2);
 
-		console.log('Workflow 1 settings:', workflow1.settings);
-		console.log('Workflow 2 settings:', workflow2.settings);
-		console.log('Checksum 1:', checksum1);
-		console.log('Checksum 2:', checksum2);
-
 		expect(checksum1).not.toBe(checksum2);
 	});
 
-	it('should generate different checksums when timezone is added', async () => {
+	it('should generate different checksums when a setting is added', async () => {
 		const workflow1: WorkflowSnapshot = {
 			...baseWorkflow,
 			settings: {
@@ -74,15 +69,10 @@ describe('calculateWorkflowChecksum', () => {
 		const checksum1 = await calculateWorkflowChecksum(workflow1);
 		const checksum2 = await calculateWorkflowChecksum(workflow2);
 
-		console.log('Workflow 1 settings:', workflow1.settings);
-		console.log('Workflow 2 settings:', workflow2.settings);
-		console.log('Checksum 1:', checksum1);
-		console.log('Checksum 2:', checksum2);
-
 		expect(checksum1).not.toBe(checksum2);
 	});
 
-	it('should generate different checksums when timezone is removed', async () => {
+	it('should generate different checksums when a setting is removed', async () => {
 		const workflow1: WorkflowSnapshot = {
 			...baseWorkflow,
 			settings: {
@@ -101,15 +91,10 @@ describe('calculateWorkflowChecksum', () => {
 		const checksum1 = await calculateWorkflowChecksum(workflow1);
 		const checksum2 = await calculateWorkflowChecksum(workflow2);
 
-		console.log('Workflow 1 settings:', workflow1.settings);
-		console.log('Workflow 2 settings:', workflow2.settings);
-		console.log('Checksum 1:', checksum1);
-		console.log('Checksum 2:', checksum2);
-
 		expect(checksum1).not.toBe(checksum2);
 	});
 
-	it('should generate same checksum when timezone is undefined vs missing', async () => {
+	it('should generate same checksum when a setting is undefined i.e. missing', async () => {
 		const workflow1: WorkflowSnapshot = {
 			...baseWorkflow,
 			settings: {
@@ -127,11 +112,6 @@ describe('calculateWorkflowChecksum', () => {
 
 		const checksum1 = await calculateWorkflowChecksum(workflow1);
 		const checksum2 = await calculateWorkflowChecksum(workflow2);
-
-		console.log('Workflow 1 settings:', workflow1.settings);
-		console.log('Workflow 2 settings:', workflow2.settings);
-		console.log('Checksum 1:', checksum1);
-		console.log('Checksum 2:', checksum2);
 
 		// undefined fields should be ignored, so checksums should be the same
 		expect(checksum1).toBe(checksum2);

--- a/packages/workflow/test/workflow-checksum.test.ts
+++ b/packages/workflow/test/workflow-checksum.test.ts
@@ -1,0 +1,166 @@
+import { calculateWorkflowChecksum, type WorkflowSnapshot } from '../src/workflow-checksum';
+
+describe('calculateWorkflowChecksum', () => {
+	const baseWorkflow: WorkflowSnapshot = {
+		name: 'Test Workflow',
+		nodes: [
+			{
+				id: 'node1',
+				name: 'Start',
+				type: 'n8n-nodes-base.start',
+				typeVersion: 1,
+				position: [250, 300],
+				parameters: {},
+			},
+		],
+		connections: {},
+		settings: {
+			executionOrder: 'v1',
+			timezone: 'America/New_York',
+		},
+	};
+
+	it('should generate the same checksum for identical workflows', async () => {
+		const checksum1 = await calculateWorkflowChecksum(baseWorkflow);
+		const checksum2 = await calculateWorkflowChecksum(baseWorkflow);
+
+		expect(checksum1).toBe(checksum2);
+	});
+
+	it('should generate different checksums when settings.timezone changes', async () => {
+		const workflow1: WorkflowSnapshot = {
+			...baseWorkflow,
+			settings: {
+				executionOrder: 'v1',
+				timezone: 'America/New_York',
+			},
+		};
+
+		const workflow2: WorkflowSnapshot = {
+			...baseWorkflow,
+			settings: {
+				executionOrder: 'v1',
+				timezone: 'Europe/London',
+			},
+		};
+
+		const checksum1 = await calculateWorkflowChecksum(workflow1);
+		const checksum2 = await calculateWorkflowChecksum(workflow2);
+
+		console.log('Workflow 1 settings:', workflow1.settings);
+		console.log('Workflow 2 settings:', workflow2.settings);
+		console.log('Checksum 1:', checksum1);
+		console.log('Checksum 2:', checksum2);
+
+		expect(checksum1).not.toBe(checksum2);
+	});
+
+	it('should generate different checksums when timezone is added', async () => {
+		const workflow1: WorkflowSnapshot = {
+			...baseWorkflow,
+			settings: {
+				executionOrder: 'v1',
+			},
+		};
+
+		const workflow2: WorkflowSnapshot = {
+			...baseWorkflow,
+			settings: {
+				executionOrder: 'v1',
+				timezone: 'America/New_York',
+			},
+		};
+
+		const checksum1 = await calculateWorkflowChecksum(workflow1);
+		const checksum2 = await calculateWorkflowChecksum(workflow2);
+
+		console.log('Workflow 1 settings:', workflow1.settings);
+		console.log('Workflow 2 settings:', workflow2.settings);
+		console.log('Checksum 1:', checksum1);
+		console.log('Checksum 2:', checksum2);
+
+		expect(checksum1).not.toBe(checksum2);
+	});
+
+	it('should generate different checksums when timezone is removed', async () => {
+		const workflow1: WorkflowSnapshot = {
+			...baseWorkflow,
+			settings: {
+				executionOrder: 'v1',
+				timezone: 'America/New_York',
+			},
+		};
+
+		const workflow2: WorkflowSnapshot = {
+			...baseWorkflow,
+			settings: {
+				executionOrder: 'v1',
+			},
+		};
+
+		const checksum1 = await calculateWorkflowChecksum(workflow1);
+		const checksum2 = await calculateWorkflowChecksum(workflow2);
+
+		console.log('Workflow 1 settings:', workflow1.settings);
+		console.log('Workflow 2 settings:', workflow2.settings);
+		console.log('Checksum 1:', checksum1);
+		console.log('Checksum 2:', checksum2);
+
+		expect(checksum1).not.toBe(checksum2);
+	});
+
+	it('should generate same checksum when timezone is undefined vs missing', async () => {
+		const workflow1: WorkflowSnapshot = {
+			...baseWorkflow,
+			settings: {
+				executionOrder: 'v1',
+				timezone: undefined,
+			},
+		};
+
+		const workflow2: WorkflowSnapshot = {
+			...baseWorkflow,
+			settings: {
+				executionOrder: 'v1',
+			},
+		};
+
+		const checksum1 = await calculateWorkflowChecksum(workflow1);
+		const checksum2 = await calculateWorkflowChecksum(workflow2);
+
+		console.log('Workflow 1 settings:', workflow1.settings);
+		console.log('Workflow 2 settings:', workflow2.settings);
+		console.log('Checksum 1:', checksum1);
+		console.log('Checksum 2:', checksum2);
+
+		// undefined fields should be ignored, so checksums should be the same
+		expect(checksum1).toBe(checksum2);
+	});
+
+	it('should handle complex nested metadata', async () => {
+		const workflow1: WorkflowSnapshot = {
+			...baseWorkflow,
+			meta: {
+				nested: {
+					foo: 'bar',
+					baz: 123,
+				},
+			},
+		};
+
+		const workflow2: WorkflowSnapshot = {
+			...baseWorkflow,
+			meta: {
+				nested: {
+					foo: 'bar',
+					baz: 456, // Changed
+				},
+			},
+		};
+
+		const checksum1 = await calculateWorkflowChecksum(workflow1);
+		const checksum2 = await calculateWorkflowChecksum(workflow2);
+
+		expect(checksum1).not.toBe(checksum2);
+	});
+});


### PR DESCRIPTION
## Summary

This PR solves the problem with bumping `versionId` on any workflow changes for conflict detection.

- Implement workflow checksum for conflict detection using only meaningful workflow fields  (nodes/connections/settings/etc.), excluding ids/timestamps.
- Bump and save workflow versions in workflow history only on `nodes` or `connections` changes.

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-4481](https://linear.app/n8n/issue/ADO-4481/feature-be-fix-problem-with-having-duplicate-workflow-versions)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
