### PR TITLE
fix(core): Only resolve the filepath once for file operations

### DIFF
--- a/packages/cli/src/active-workflow-manager.ts
+++ b/packages/cli/src/active-workflow-manager.ts
@@ -234,7 +234,7 @@ export class ActiveWorkflowManager {
 		}
 		await this.webhookService.populateCache();
 
-		await this.workflowStaticDataService.saveStaticData(cl);
+		await this.workflowStaticDataService.saveStaticData(workflow);
 
 		this.logger.debug(`Added webhooks for workflow "${workflow.name}" (ID ${workflow.id})`, {
 			workflowId: workflow.id,

--- a/packages/cli/src/active-workflow-manager.ts
+++ b/packages/cli/src/active-workflow-manager.ts
@@ -234,7 +234,7 @@ export class ActiveWorkflowManager {
 		}
 		await this.webhookService.populateCache();
 
-		await this.workflowStaticDataService.saveStaticData(workflow);
+		await this.workflowStaticDataService.saveStaticData(cl);
 
 		this.logger.debug(`Added webhooks for workflow "${workflow.name}" (ID ${workflow.id})`, {
 			workflowId: workflow.id,

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
@@ -15,7 +15,7 @@ import {
 } from '@/constants';
 import { InstanceSettings } from '@/instance-settings';
 
-import { getFileSystemHelperFunctions, isFilePathBlocked } from '../file-system-helper-functions';
+import { getFileSystemHelperFunctions } from '../file-system-helper-functions';
 
 jest.mock('node:fs');
 jest.mock('node:fs/promises');
@@ -39,78 +39,80 @@ beforeEach(() => {
 });
 
 describe('isFilePathBlocked', () => {
+	const node = { type: 'TestNode' } as INode;
+	const { isFilePathBlocked, resolvePath } = getFileSystemHelperFunctions(node);
 	beforeEach(() => {
 		process.env[BLOCK_FILE_ACCESS_TO_N8N_FILES] = 'true';
 	});
 
 	it('should return true for static cache dir', async () => {
 		const filePath = instanceSettings.staticCacheDir;
-		expect(await isFilePathBlocked(filePath)).toBe(true);
+		expect(isFilePathBlocked(await resolvePath(filePath))).toBe(true);
 	});
 
 	it('should return true for restricted paths', async () => {
 		const restrictedPath = instanceSettings.n8nFolder;
-		expect(await isFilePathBlocked(restrictedPath)).toBe(true);
+		expect(isFilePathBlocked(await resolvePath(restrictedPath))).toBe(true);
 	});
 
 	it('should handle empty allowed paths', async () => {
 		securityConfig.restrictFileAccessTo = '';
-		const result = await isFilePathBlocked('/some/random/path');
+		const result = isFilePathBlocked(await resolvePath('/some/random/path'));
 		expect(result).toBe(false);
 	});
 
 	it('should handle multiple allowed paths', async () => {
 		securityConfig.restrictFileAccessTo = '/path1;/path2;/path3';
 		const allowedPath = '/path2/somefile';
-		expect(await isFilePathBlocked(allowedPath)).toBe(false);
+		expect(isFilePathBlocked(await resolvePath(allowedPath))).toBe(false);
 	});
 
 	it('should handle empty strings in allowed paths', async () => {
 		securityConfig.restrictFileAccessTo = '/path1;;/path2';
 		const allowedPath = '/path2/somefile';
-		expect(await isFilePathBlocked(allowedPath)).toBe(false);
+		expect(isFilePathBlocked(await resolvePath(allowedPath))).toBe(false);
 	});
 
 	it('should trim whitespace in allowed paths', async () => {
 		securityConfig.restrictFileAccessTo = ' /path1 ; /path2 ; /path3 ';
 		const allowedPath = '/path2/somefile';
-		expect(await isFilePathBlocked(allowedPath)).toBe(false);
+		expect(isFilePathBlocked(await resolvePath(allowedPath))).toBe(false);
 	});
 
 	it('should return false when BLOCK_FILE_ACCESS_TO_N8N_FILES is false', async () => {
 		process.env[BLOCK_FILE_ACCESS_TO_N8N_FILES] = 'false';
 		const restrictedPath = instanceSettings.n8nFolder;
-		expect(await isFilePathBlocked(restrictedPath)).toBe(false);
+		expect(isFilePathBlocked(await resolvePath(restrictedPath))).toBe(false);
 	});
 
 	it('should return true when path is in allowed paths but still restricted', async () => {
 		securityConfig.restrictFileAccessTo = '/some/allowed/path';
 		const restrictedPath = instanceSettings.n8nFolder;
-		expect(await isFilePathBlocked(restrictedPath)).toBe(true);
+		expect(isFilePathBlocked(await resolvePath(restrictedPath))).toBe(true);
 	});
 
 	it('should return false when path is in allowed paths', async () => {
 		const allowedPath = '/some/allowed/path';
 		securityConfig.restrictFileAccessTo = allowedPath;
-		expect(await isFilePathBlocked(allowedPath)).toBe(false);
+		expect(isFilePathBlocked(await resolvePath(allowedPath))).toBe(false);
 	});
 
 	it('should return true when file paths in CONFIG_FILES', async () => {
 		process.env[CONFIG_FILES] = '/path/to/config1,/path/to/config2';
 		const configPath = '/path/to/config1/somefile';
-		expect(await isFilePathBlocked(configPath)).toBe(true);
+		expect(isFilePathBlocked(await resolvePath(configPath))).toBe(true);
 	});
 
 	it('should return true when file paths in CUSTOM_EXTENSION_ENV', async () => {
 		process.env[CUSTOM_EXTENSION_ENV] = '/path/to/extensions1;/path/to/extensions2';
 		const extensionPath = '/path/to/extensions1/somefile';
-		expect(await isFilePathBlocked(extensionPath)).toBe(true);
+		expect(isFilePathBlocked(await resolvePath(extensionPath))).toBe(true);
 	});
 
 	it('should return true when file paths in BINARY_DATA_STORAGE_PATH', async () => {
 		process.env[BINARY_DATA_STORAGE_PATH] = '/path/to/binary/storage';
 		const binaryPath = '/path/to/binary/storage/somefile';
-		expect(await isFilePathBlocked(binaryPath)).toBe(true);
+		expect(isFilePathBlocked(await resolvePath(binaryPath))).toBe(true);
 	});
 
 	it('should block file paths in email template paths', async () => {
@@ -120,8 +122,8 @@ describe('isFilePathBlocked', () => {
 		const invitePath = '/path/to/invite/templates/invite.html';
 		const pwResetPath = '/path/to/pwreset/templates/reset.html';
 
-		expect(await isFilePathBlocked(invitePath)).toBe(true);
-		expect(await isFilePathBlocked(pwResetPath)).toBe(true);
+		expect(isFilePathBlocked(await resolvePath(invitePath))).toBe(true);
+		expect(isFilePathBlocked(await resolvePath(pwResetPath))).toBe(true);
 	});
 
 	it('should block access to n8n files if restrict and block are set', async () => {
@@ -131,7 +133,7 @@ describe('isFilePathBlocked', () => {
 		securityConfig.restrictFileAccessTo = userHome;
 		process.env[BLOCK_FILE_ACCESS_TO_N8N_FILES] = 'true';
 		const restrictedPath = instanceSettings.n8nFolder;
-		expect(await isFilePathBlocked(restrictedPath)).toBe(true);
+		expect(isFilePathBlocked(await resolvePath(restrictedPath))).toBe(true);
 	});
 
 	it('should allow access to parent folder if restrict and block are set', async () => {
@@ -140,8 +142,8 @@ describe('isFilePathBlocked', () => {
 
 		securityConfig.restrictFileAccessTo = userHome;
 		process.env[BLOCK_FILE_ACCESS_TO_N8N_FILES] = 'true';
-		const restrictedPath = join(userHome, 'somefile.txt');
-		expect(await isFilePathBlocked(restrictedPath)).toBe(false);
+		const restrictedPath = await resolvePath(join(userHome, 'somefile.txt'));
+		expect(isFilePathBlocked(restrictedPath)).toBe(false);
 	});
 
 	it('should not block similar paths', async () => {
@@ -150,8 +152,8 @@ describe('isFilePathBlocked', () => {
 
 		securityConfig.restrictFileAccessTo = userHome;
 		process.env[BLOCK_FILE_ACCESS_TO_N8N_FILES] = 'true';
-		const restrictedPath = join(userHome, '.n8n_x');
-		expect(await isFilePathBlocked(restrictedPath)).toBe(false);
+		const restrictedPath = await resolvePath(join(userHome, '.n8n_x'));
+		expect(isFilePathBlocked(restrictedPath)).toBe(false);
 	});
 
 	it('should return true for a symlink in a allowed path to a restricted path', async () => {
@@ -161,7 +163,7 @@ describe('isFilePathBlocked', () => {
 		(fsRealpath as jest.Mock).mockImplementation((path: string) =>
 			path === allowedPath ? actualPath : path,
 		);
-		expect(await isFilePathBlocked(allowedPath)).toBe(true);
+		expect(isFilePathBlocked(await resolvePath(allowedPath))).toBe(true);
 	});
 
 	it('should handle non-existent file when it is allowed', async () => {
@@ -170,7 +172,7 @@ describe('isFilePathBlocked', () => {
 		// @ts-expect-error undefined property
 		error.code = 'ENOENT';
 		(fsRealpath as jest.Mock).mockRejectedValueOnce(error);
-		expect(await isFilePathBlocked(filePath)).toBe(false);
+		expect(isFilePathBlocked(await resolvePath(filePath))).toBe(false);
 	});
 
 	it('should handle non-existent file when it is not allowed', async () => {
@@ -181,7 +183,7 @@ describe('isFilePathBlocked', () => {
 		// @ts-expect-error undefined property
 		error.code = 'ENOENT';
 		(fsRealpath as jest.Mock).mockRejectedValueOnce(error);
-		expect(await isFilePathBlocked(filePath)).toBe(true);
+		expect(isFilePathBlocked(await resolvePath(filePath))).toBe(true);
 	});
 });
 
@@ -213,17 +215,17 @@ describe('getFileSystemHelperFunctions', () => {
 			error.code = 'ENOENT';
 			(fsAccess as jest.Mock).mockRejectedValueOnce(error);
 
-			await expect(helperFunctions.createReadStream(filePath)).rejects.toThrow(
-				`The file "${filePath}" could not be accessed.`,
-			);
+			await expect(
+				helperFunctions.createReadStream(await helperFunctions.resolvePath(filePath)),
+			).rejects.toThrow(`The file "${filePath}" could not be accessed.`);
 		});
 
 		it('should throw when file access is blocked', async () => {
 			securityConfig.restrictFileAccessTo = '/allowed/path';
 			(fsAccess as jest.Mock).mockResolvedValueOnce({});
-			await expect(helperFunctions.createReadStream('/blocked/path')).rejects.toThrow(
-				'Access to the file is not allowed',
-			);
+			await expect(
+				helperFunctions.createReadStream(await helperFunctions.resolvePath('/blocked/path')),
+			).rejects.toThrow('Access to the file is not allowed');
 		});
 
 		it('should not reveal if file exists if it is within restricted path', async () => {
@@ -234,15 +236,15 @@ describe('getFileSystemHelperFunctions', () => {
 			error.code = 'ENOENT';
 			(fsAccess as jest.Mock).mockRejectedValueOnce(error);
 
-			await expect(helperFunctions.createReadStream('/blocked/path')).rejects.toThrow(
-				'Access to the file is not allowed',
-			);
+			await expect(
+				helperFunctions.createReadStream(await helperFunctions.resolvePath('/blocked/path')),
+			).rejects.toThrow('Access to the file is not allowed');
 		});
 
 		it('should create a read stream if file access is permitted', async () => {
 			const filePath = '/allowed/path';
 			(fsAccess as jest.Mock).mockResolvedValueOnce({});
-			await helperFunctions.createReadStream(filePath);
+			await helperFunctions.createReadStream(await helperFunctions.resolvePath(filePath));
 			expect(createReadStream).toHaveBeenCalledWith(filePath);
 		});
 	});
@@ -253,7 +255,7 @@ describe('getFileSystemHelperFunctions', () => {
 
 			await expect(
 				helperFunctions.writeContentToFile(
-					instanceSettings.n8nFolder + '/test.txt',
+					await helperFunctions.resolvePath(instanceSettings.n8nFolder + '/test.txt'),
 					'content',
 					'w',
 				),

--- a/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
@@ -96,12 +96,15 @@ export const getFileSystemHelperFunctions = (node: INode): FileSystemHelperFunct
 		return safeJoinPath(Container.get(InstanceSettings).n8nFolder, `storage/${node.type}`);
 	},
 
-	async writeContentToFile(filePath, content, flag) {
-		const resolvedFilePath = await resolvePath(filePath as string);
+	async writeContentToFile(resolvedFilePath, content, flag) {
 		if (isFilePathBlocked(resolvedFilePath)) {
-			throw new NodeOperationError(node, `The file "${String(filePath)}" is not writable.`, {
-				level: 'warning',
-			});
+			throw new NodeOperationError(
+				node,
+				`The file "${String(resolvedFilePath)}" is not writable.`,
+				{
+					level: 'warning',
+				},
+			);
 		}
 		return await fsWriteFile(resolvedFilePath, content, { encoding: 'binary', flag });
 	},

--- a/packages/nodes-base/nodes/Files/ReadWriteFile/actions/read.operation.ts
+++ b/packages/nodes-base/nodes/Files/ReadWriteFile/actions/read.operation.ts
@@ -101,7 +101,9 @@ export async function execute(this: IExecuteFunctions, items: INodeExecutionData
 
 			const newItems: INodeExecutionData[] = [];
 			for (const filePath of files) {
-				const stream = await this.helpers.createReadStream(filePath);
+				const stream = await this.helpers.createReadStream(
+					await this.helpers.resolvePath(filePath),
+				);
 				const binaryData = await this.helpers.prepareBinaryData(stream, filePath);
 
 				if (options.fileName !== undefined) {

--- a/packages/nodes-base/nodes/Files/ReadWriteFile/actions/write.operation.ts
+++ b/packages/nodes-base/nodes/Files/ReadWriteFile/actions/write.operation.ts
@@ -90,7 +90,11 @@ export async function execute(this: IExecuteFunctions, items: INodeExecutionData
 			}
 
 			// Write the file to disk
-			await this.helpers.writeContentToFile(fileName, fileContent, flag);
+			await this.helpers.writeContentToFile(
+				await this.helpers.resolvePath(fileName),
+				fileContent,
+				flag,
+			);
 
 			if (item.binary !== undefined) {
 				// Create a shallow copy of the binary data so that the old

--- a/packages/nodes-base/nodes/Git/Git.node.ts
+++ b/packages/nodes-base/nodes/Git/Git.node.ts
@@ -287,7 +287,9 @@ export class Git implements INodeType {
 		for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
 			try {
 				const repositoryPath = this.getNodeParameter('repositoryPath', itemIndex, '') as string;
-				const isFilePathBlocked = await this.helpers.isFilePathBlocked(repositoryPath);
+				const isFilePathBlocked = this.helpers.isFilePathBlocked(
+					await this.helpers.resolvePath(repositoryPath),
+				);
 				if (isFilePathBlocked) {
 					throw new NodeOperationError(
 						this.getNode(),

--- a/packages/nodes-base/nodes/ReadBinaryFile/ReadBinaryFile.node.ts
+++ b/packages/nodes-base/nodes/ReadBinaryFile/ReadBinaryFile.node.ts
@@ -69,7 +69,9 @@ export class ReadBinaryFile implements INodeType {
 
 				const filePath = this.getNodeParameter('filePath', itemIndex);
 
-				const stream = await this.helpers.createReadStream(filePath);
+				const stream = await this.helpers.createReadStream(
+					await this.helpers.resolvePath(filePath),
+				);
 				const dataPropertyName = this.getNodeParameter('dataPropertyName', itemIndex);
 
 				newItem.binary![dataPropertyName] = await this.helpers.prepareBinaryData(stream, filePath);

--- a/packages/nodes-base/nodes/ReadBinaryFiles/ReadBinaryFiles.node.ts
+++ b/packages/nodes-base/nodes/ReadBinaryFiles/ReadBinaryFiles.node.ts
@@ -54,7 +54,7 @@ export class ReadBinaryFiles implements INodeType {
 
 		const items: INodeExecutionData[] = [];
 		for (const filePath of files) {
-			const stream = await this.helpers.createReadStream(filePath);
+			const stream = await this.helpers.createReadStream(await this.helpers.resolvePath(filePath));
 			items.push({
 				binary: {
 					[dataPropertyName]: await this.helpers.prepareBinaryData(stream, filePath),

--- a/packages/nodes-base/nodes/WriteBinaryFile/WriteBinaryFile.node.ts
+++ b/packages/nodes-base/nodes/WriteBinaryFile/WriteBinaryFile.node.ts
@@ -98,7 +98,11 @@ export class WriteBinaryFile implements INodeType {
 
 				// Write the file to disk
 
-				await this.helpers.writeContentToFile(fileName, fileContent, flag);
+				await this.helpers.writeContentToFile(
+					await this.helpers.resolvePath(fileName),
+					fileContent,
+					flag,
+				);
 
 				if (item.binary !== undefined) {
 					// Create a shallow copy of the binary data so that the old

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -694,12 +694,19 @@ export interface BaseHelperFunctions {
 	returnJsonArray(jsonData: IDataObject | IDataObject[]): INodeExecutionData[];
 }
 
+const __brand = Symbol('brand');
+
+export type ResolvedFilePath = string & {
+	[__brand]: 'ResolvedFilePath';
+};
+
 export interface FileSystemHelperFunctions {
-	isFilePathBlocked(filePath: string): Promise<boolean>;
-	createReadStream(path: PathLike): Promise<Readable>;
+	resolvePath(path: PathLike): Promise<ResolvedFilePath>;
+	isFilePathBlocked(filePath: ResolvedFilePath): boolean;
+	createReadStream(filePath: ResolvedFilePath): Promise<Readable>;
 	getStoragePath(): string;
 	writeContentToFile(
-		path: PathLike,
+		path: ResolvedFilePath,
 		content: string | Buffer | Readable,
 		flag?: string,
 	): Promise<void>;


### PR DESCRIPTION
## Summary

Makes it clearer that we're always operating on a resolved path - enforces it on the type level.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1852

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
