### PR TITLE
fix(editor): Fix displaying of workflow publish info (no-changelog)

### DIFF
--- a/packages/@n8n/backend-test-utils/src/db/workflows.ts
+++ b/packages/@n8n/backend-test-utils/src/db/workflows.ts
@@ -6,6 +6,7 @@ import {
 	SharedWorkflowRepository,
 	WorkflowRepository,
 	WorkflowHistoryRepository,
+	WorkflowPublishHistoryRepository,
 } from '@n8n/db';
 import { Container } from '@n8n/di';
 import type { WorkflowSharingRole } from '@n8n/permissions';
@@ -284,5 +285,15 @@ export async function createActiveWorkflow(
 	await setActiveVersion(workflow.id, workflow.versionId);
 
 	workflow.activeVersionId = workflow.versionId;
+
+	if (userOrProject instanceof User) {
+		await Container.get(WorkflowPublishHistoryRepository).save({
+			workflowId: workflow.id,
+			versionId: workflow.versionId,
+			event: 'activated',
+			userId: userOrProject.id,
+		});
+	}
+
 	return workflow;
 }

--- a/packages/@n8n/db/src/repositories/shared-workflow.repository.ts
+++ b/packages/@n8n/db/src/repositories/shared-workflow.repository.ts
@@ -171,7 +171,7 @@ export class SharedWorkflowRepository extends Repository<SharedWorkflow> {
 					shared: { project: { projectRelations: { user: true } } },
 					tags: includeTags,
 					parentFolder: includeParentFolder,
-					activeVersion: includeActiveVersion,
+					activeVersion: includeActiveVersion ? { workflowPublishHistory: true } : false,
 				},
 			},
 		});

--- a/packages/cli/test/integration/workflows/workflow.service.test.ts
+++ b/packages/cli/test/integration/workflows/workflow.service.test.ts
@@ -129,6 +129,11 @@ describe('activateWorkflow()', () => {
 
 		expect(updatedWorkflow.active).toBe(true);
 		expect(updatedWorkflow.activeVersionId).toBe(workflow.versionId);
+		expect(updatedWorkflow.activeVersion?.workflowPublishHistory).toHaveLength(1);
+		expect(updatedWorkflow.activeVersion?.workflowPublishHistory[0]).toMatchObject({
+			event: 'activated',
+			versionId: workflow.versionId,
+		});
 		expect(addRecordSpy).toBeCalledWith({
 			event: 'activated',
 			workflowId: workflow.id,
@@ -153,6 +158,11 @@ describe('activateWorkflow()', () => {
 		expect(updatedWorkflow.active).toBe(true);
 		expect(updatedWorkflow.activeVersionId).toBe(newVersionId);
 		expect(updatedWorkflow.versionId).toBe(workflow.versionId);
+		expect(updatedWorkflow.activeVersion?.workflowPublishHistory).toHaveLength(1);
+		expect(updatedWorkflow.activeVersion?.workflowPublishHistory[0]).toMatchObject({
+			event: 'activated',
+			versionId: newVersionId,
+		});
 
 		expect(addRecordSpy).toBeCalledWith({
 			event: 'activated',

--- a/packages/cli/test/integration/workflows/workflow.service.test.ts
+++ b/packages/cli/test/integration/workflows/workflow.service.test.ts
@@ -22,9 +22,9 @@ import { createWorkflowHistoryItem } from '../shared/db/workflow-history';
 
 let globalConfig: GlobalConfig;
 let workflowService: WorkflowService;
+let workflowPublishHistoryRepository: WorkflowPublishHistoryRepository;
 const activeWorkflowManager = mockInstance(ActiveWorkflowManager);
 const workflowHistoryService = mockInstance(WorkflowHistoryService);
-const workflowPublishHistoryRepository = mockInstance(WorkflowPublishHistoryRepository);
 mockInstance(MessageEventBus);
 mockInstance(Telemetry);
 
@@ -32,6 +32,7 @@ beforeAll(async () => {
 	await testDb.init();
 
 	globalConfig = Container.get(GlobalConfig);
+	workflowPublishHistoryRepository = Container.get(WorkflowPublishHistoryRepository);
 	workflowService = new WorkflowService(
 		mock(),
 		Container.get(SharedWorkflowRepository),
@@ -56,7 +57,7 @@ beforeAll(async () => {
 });
 
 afterEach(async () => {
-	await testDb.truncate(['WorkflowEntity', 'WorkflowHistory']);
+	await testDb.truncate(['WorkflowEntity', 'WorkflowHistory', 'WorkflowPublishHistory']);
 	jest.restoreAllMocks();
 });
 
@@ -129,6 +130,7 @@ describe('activateWorkflow()', () => {
 
 		expect(updatedWorkflow.active).toBe(true);
 		expect(updatedWorkflow.activeVersionId).toBe(workflow.versionId);
+		expect(updatedWorkflow.activeVersion).toBeDefined();
 		expect(updatedWorkflow.activeVersion?.workflowPublishHistory).toHaveLength(1);
 		expect(updatedWorkflow.activeVersion?.workflowPublishHistory[0]).toMatchObject({
 			event: 'activated',

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -591,7 +591,7 @@ describe('GET /workflows/:workflowId', () => {
 		});
 	});
 
-	test('should return active version', async () => {
+	test('should return active version with workflowPublishHistory', async () => {
 		const workflow = await createActiveWorkflow({}, owner);
 
 		const response = await authOwnerAgent.get(`/workflows/${workflow.id}`).expect(200);
@@ -602,6 +602,11 @@ describe('GET /workflows/:workflowId', () => {
 		expect(activeVersion).toMatchObject({
 			versionId: workflow.activeVersionId,
 			workflowId: workflow.id,
+		});
+		expect(activeVersion.workflowPublishHistory).toHaveLength(1);
+		expect(activeVersion.workflowPublishHistory[0]).toMatchObject({
+			event: 'activated',
+			versionId: workflow.activeVersionId,
 		});
 	});
 

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -2755,6 +2755,11 @@ describe('POST /workflows/:workflowId/activate', () => {
 		expect(data.id).toBe(workflow.id);
 		expect(data.activeVersionId).toBe(newVersionId);
 		expect(data.activeVersion.versionId).toBe(newVersionId);
+		expect(data.activeVersion.workflowPublishHistory).toHaveLength(1);
+		expect(data.activeVersion.workflowPublishHistory[0]).toMatchObject({
+			event: 'activated',
+			versionId: newVersionId,
+		});
 
 		expect(addRecordSpy).toBeCalledWith({
 			event: 'activated',

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.test.ts
@@ -169,9 +169,22 @@ describe('WorkflowHeaderDraftPublishActions', () => {
 				],
 			};
 
-			const { getByTestId } = renderComponent();
+			const { getByTestId } = renderComponent({
+				global: {
+					stubs: {
+						N8nTooltip: {
+							template: '<div><slot name="content" /></div>',
+						},
+						TimeAgo: {
+							props: ['date'],
+							template: '<div data-test-id="time-ago-stub">{{ date }}</div>',
+						},
+					},
+				},
+			});
 
 			expect(getByTestId('workflow-active-version-indicator')).toBeInTheDocument();
+			expect(getByTestId('time-ago-stub')).toHaveTextContent(latestActivationDate);
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.test.ts
@@ -134,6 +134,45 @@ describe('WorkflowHeaderDraftPublishActions', () => {
 
 			expect(getByTestId('workflow-active-version-indicator')).toBeInTheDocument();
 		});
+
+		it('should use latest activation date from workflowPublishHistory when available', () => {
+			const oldDate = '2024-01-01T00:00:00.000Z';
+			const latestActivationDate = '2024-06-15T10:30:00.000Z';
+			workflowsStore.workflow.activeVersion = {
+				...createMockActiveVersion('active-version-1'),
+				createdAt: oldDate,
+				workflowPublishHistory: [
+					{
+						id: 1,
+						createdAt: oldDate,
+						event: 'activated' as const,
+						userId: 'user-1',
+						versionId: 'active-version-1',
+						workflowId: '1',
+					},
+					{
+						id: 2,
+						createdAt: '2024-03-01T00:00:00.000Z',
+						event: 'deactivated' as const,
+						userId: 'user-1',
+						versionId: 'active-version-1',
+						workflowId: '1',
+					},
+					{
+						id: 3,
+						createdAt: latestActivationDate,
+						event: 'activated' as const,
+						userId: 'user-1',
+						versionId: 'active-version-1',
+						workflowId: '1',
+					},
+				],
+			};
+
+			const { getByTestId } = renderComponent();
+
+			expect(getByTestId('workflow-active-version-indicator')).toBeInTheDocument();
+		});
 	});
 
 	describe('Publish button behavior', () => {

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
@@ -15,7 +15,7 @@ import TimeAgo from '@/app/components/TimeAgo.vue';
 import { getActivatableTriggerNodes } from '@/app/utils/nodeTypesUtils';
 import { useWorkflowSaving } from '@/app/composables/useWorkflowSaving';
 import { useRouter } from 'vue-router';
-import type { WorkflowPublishHistory } from '@n8n/rest-api-client/api/workflowHistory';
+import { getLastPublishedByUser } from '@/features/workflows/workflowHistory/utils';
 
 const props = defineProps<{
 	readOnly?: boolean;
@@ -89,16 +89,9 @@ const showPublishIndicator = computed(() => {
 
 const activeVersion = computed(() => workflowsStore.workflow.activeVersion);
 
-const getLatestActivation = (
-	publishHistory: WorkflowPublishHistory[] | undefined,
-): WorkflowPublishHistory | undefined => {
-	if (!publishHistory || publishHistory.length === 0) return undefined;
-	return publishHistory.findLast((entry) => entry.event === 'activated');
-};
-
-const latestActivationDate = computed(() => {
-	const latestActivation = getLatestActivation(activeVersion.value?.workflowPublishHistory);
-	return latestActivation?.createdAt ?? activeVersion.value?.createdAt;
+const latestPublishDate = computed(() => {
+	const latestPublish = getLastPublishedByUser(activeVersion.value?.workflowPublishHistory ?? []);
+	return latestPublish?.createdAt;
 });
 
 defineExpose({
@@ -116,7 +109,7 @@ defineExpose({
 			<N8nTooltip>
 				<template #content>
 					{{ activeVersion.name }}<br />{{ i18n.baseText('workflowHistory.item.active') }}
-					<TimeAgo v-if="latestActivationDate" :date="latestActivationDate" />
+					<TimeAgo v-if="latestPublishDate" :date="latestPublishDate" />
 				</template>
 				<N8nIcon icon="circle-check" color="success" size="xlarge" :class="$style.icon" />
 			</N8nTooltip>

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
@@ -15,6 +15,7 @@ import TimeAgo from '@/app/components/TimeAgo.vue';
 import { getActivatableTriggerNodes } from '@/app/utils/nodeTypesUtils';
 import { useWorkflowSaving } from '@/app/composables/useWorkflowSaving';
 import { useRouter } from 'vue-router';
+import type { WorkflowPublishHistory } from '@n8n/rest-api-client/api/workflowHistory';
 
 const props = defineProps<{
 	readOnly?: boolean;
@@ -88,6 +89,18 @@ const showPublishIndicator = computed(() => {
 
 const activeVersion = computed(() => workflowsStore.workflow.activeVersion);
 
+const getLatestActivation = (
+	publishHistory: WorkflowPublishHistory[] | undefined,
+): WorkflowPublishHistory | undefined => {
+	if (!publishHistory || publishHistory.length === 0) return undefined;
+	return publishHistory.findLast((entry) => entry.event === 'activated');
+};
+
+const latestActivationDate = computed(() => {
+	const latestActivation = getLatestActivation(activeVersion.value?.workflowPublishHistory);
+	return latestActivation?.createdAt ?? activeVersion.value?.createdAt;
+});
+
 defineExpose({
 	importFileRef,
 });
@@ -103,7 +116,7 @@ defineExpose({
 			<N8nTooltip>
 				<template #content>
 					{{ activeVersion.name }}<br />{{ i18n.baseText('workflowHistory.item.active') }}
-					<TimeAgo :date="activeVersion.createdAt" />
+					<TimeAgo v-if="latestActivationDate" :date="latestActivationDate" />
 				</template>
 				<N8nIcon icon="circle-check" color="success" size="xlarge" :class="$style.icon" />
 			</N8nTooltip>

--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/views/WorkflowHistory.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/views/WorkflowHistory.vue
@@ -279,13 +279,21 @@ const publishWorkflowVersion = (id: WorkflowVersionId, data: WorkflowHistoryActi
 	const publishEventBus = createEventBus<WorkflowHistoryPublishModalEventBusEvents>();
 
 	publishEventBus.once('publish', (publishData) => {
-		// Update the history list with the new name and description
+		// Refresh the active workflow to get the updated activeVersion with workflowPublishHistory
+		activeWorkflow.value = workflowsStore.getWorkflowById(workflowId.value);
+
+		// Update the history list with the new name, description, and workflowPublishHistory
 		const historyItem = workflowHistory.value.find(
 			(item) => item.versionId === publishData.versionId,
 		);
 		if (historyItem) {
 			historyItem.name = publishData.name;
 			historyItem.description = publishData.description;
+			// Update workflowPublishHistory from the store's activeVersion
+			if (activeWorkflow.value?.activeVersion?.workflowPublishHistory) {
+				historyItem.workflowPublishHistory =
+					activeWorkflow.value.activeVersion.workflowPublishHistory;
+			}
 		}
 
 		// Refresh the selected workflow version if it's the one that was published
@@ -294,11 +302,11 @@ const publishWorkflowVersion = (id: WorkflowVersionId, data: WorkflowHistoryActi
 				...selectedWorkflowVersion.value,
 				name: publishData.name,
 				description: publishData.description,
+				workflowPublishHistory:
+					activeWorkflow.value?.activeVersion?.workflowPublishHistory ??
+					selectedWorkflowVersion.value.workflowPublishHistory,
 			};
 		}
-
-		// Refresh the active workflow to get the updated activeVersion
-		activeWorkflow.value = workflowsStore.getWorkflowById(workflowId.value);
 
 		sendTelemetry('User published version from history');
 	});


### PR DESCRIPTION
## Summary

The workflow publish history was not retuned on the workflows detail endpoint and the activate one but it was needed to be displayed in the UI when publishing respectively from the canvas and the wf history.

## Related Linear tickets, Github issues, and Community forum posts

https://www.notion.so/n8n/Publish-author-and-date-not-correct-2b75b6e0c94f8006b1dcfb801a246072?source=copy_link


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
