### PR TITLE
fix(editor): Fix scope based - move nodes and node pasting

### DIFF
--- a/packages/cli/src/controllers/e2e.controller.ts
+++ b/packages/cli/src/controllers/e2e.controller.ts
@@ -42,6 +42,7 @@ const tablesToTruncate = [
 	'installed_packages',
 	'project',
 	'project_relation',
+	'role',
 	'settings',
 	'shared_credentials',
 	'shared_workflow',

--- a/packages/frontend/editor-ui/src/__tests__/mocks.ts
+++ b/packages/frontend/editor-ui/src/__tests__/mocks.ts
@@ -49,7 +49,7 @@ export const mockNode = ({
 	issues = undefined,
 	typeVersion = 1,
 	parameters = {},
-	draggable = true,
+	draggable = undefined,
 }: {
 	id?: INodeUi['id'];
 	name: INodeUi['name'];

--- a/packages/frontend/editor-ui/src/app/composables/__snapshots__/useCanvasOperations.test.ts.snap
+++ b/packages/frontend/editor-ui/src/app/composables/__snapshots__/useCanvasOperations.test.ts.snap
@@ -14,8 +14,7 @@ exports[`useCanvasOperations > copyNodes > should copy nodes 1`] = `
         40,
         40
       ],
-      "typeVersion": 1,
-      "draggable": true
+      "typeVersion": 1
     },
     {
       "parameters": {},
@@ -26,8 +25,7 @@ exports[`useCanvasOperations > copyNodes > should copy nodes 1`] = `
         40,
         40
       ],
-      "typeVersion": 1,
-      "draggable": true
+      "typeVersion": 1
     }
   ],
   "connections": {},
@@ -54,8 +52,7 @@ exports[`useCanvasOperations > cutNodes > should copy and delete nodes 1`] = `
         40,
         40
       ],
-      "typeVersion": 1,
-      "draggable": true
+      "typeVersion": 1
     },
     {
       "parameters": {},
@@ -66,8 +63,7 @@ exports[`useCanvasOperations > cutNodes > should copy and delete nodes 1`] = `
         40,
         40
       ],
-      "typeVersion": 1,
-      "draggable": true
+      "typeVersion": 1
     }
   ],
   "connections": {},

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -1637,6 +1637,10 @@ function checkIfEditingIsAllowed(): boolean {
 		return false;
 	}
 
+	if (!(workflowPermissions.value.update ?? projectPermissions.value.workflow.update)) {
+		return false;
+	}
+
 	if (isReadOnlyRoute.value || isReadOnlyEnvironment.value) {
 		const messageContext = isReadOnlyRoute.value ? 'executions' : 'workflows';
 		readOnlyNotification.value = toast.showMessage({

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.test.ts
@@ -154,7 +154,7 @@ describe('useCanvasMapping', () => {
 					label: manualTriggerNode.name,
 					type: 'canvas-node',
 					position: expect.anything(),
-					draggable: true,
+					draggable: undefined,
 					data: {
 						id: manualTriggerNode.id,
 						name: manualTriggerNode.name,

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.ts
@@ -722,7 +722,7 @@ export function useCanvasMapping({
 					position: { x: node.position[0], y: node.position[1] },
 					data,
 					...additionalNodePropertiesById.value[node.id],
-					draggable: node.draggable ?? true,
+					draggable: node.draggable,
 				};
 			}),
 		];

--- a/packages/testing/playwright/composables/CanvasComposer.ts
+++ b/packages/testing/playwright/composables/CanvasComposer.ts
@@ -28,6 +28,7 @@ export class CanvasComposer {
 	 * Copy selected nodes and verify success toast
 	 */
 	async copySelectedNodesWithToast(): Promise<void> {
+		await this.n8n.clipboard.grant();
 		await this.n8n.canvas.copyNodes();
 		await this.n8n.notifications.waitForNotificationAndClose('Copied to clipboard');
 	}
@@ -36,6 +37,7 @@ export class CanvasComposer {
 	 * Select all nodes and copy them
 	 */
 	async selectAllAndCopy(): Promise<void> {
+		await this.n8n.clipboard.grant();
 		await this.n8n.canvas.selectAll();
 		await this.copySelectedNodesWithToast();
 	}

--- a/packages/testing/playwright/services/api-helper.ts
+++ b/packages/testing/playwright/services/api-helper.ts
@@ -11,6 +11,7 @@ import {
 import { TestError } from '../Types';
 import { CredentialApiHelper } from './credential-api-helper';
 import { ProjectApiHelper } from './project-api-helper';
+import { RoleApiHelper } from './role-api-helper';
 import { TagApiHelper } from './tag-api-helper';
 import { UserApiHelper } from './user-api-helper';
 import { VariablesApiHelper } from './variables-api-helper';
@@ -43,6 +44,7 @@ export class ApiHelpers {
 	variables: VariablesApiHelper;
 	users: UserApiHelper;
 	tags: TagApiHelper;
+	roles: RoleApiHelper;
 
 	constructor(requestContext: APIRequestContext) {
 		this.request = requestContext;
@@ -52,6 +54,7 @@ export class ApiHelpers {
 		this.variables = new VariablesApiHelper(this);
 		this.users = new UserApiHelper(this);
 		this.tags = new TagApiHelper(this);
+		this.roles = new RoleApiHelper(this);
 	}
 
 	// ===== MAIN SETUP METHODS =====

--- a/packages/testing/playwright/services/role-api-helper.ts
+++ b/packages/testing/playwright/services/role-api-helper.ts
@@ -1,0 +1,48 @@
+import { nanoid } from 'nanoid';
+
+import type { ApiHelpers } from './api-helper';
+import { TestError } from '../Types';
+
+export class RoleApiHelper {
+	constructor(private api: ApiHelpers) {}
+
+	/**
+	 * Create a custom role with unique name via REST API
+	 * @param scopes Array of scope strings (e.g., ['project:read', 'workflow:read'])
+	 * @param displayName Base display name for the role (will be made unique with nanoid)
+	 * @returns The created role data including slug
+	 */
+	async createCustomRole(scopes: string[], displayName: string): Promise<{ slug: string }> {
+		const uniqueName = `${displayName} (${nanoid(8)})`;
+		const response = await this.api.request.post('/rest/roles', {
+			data: {
+				displayName: uniqueName,
+				description: `Custom role with scopes: ${scopes.join(', ')}`,
+				roleType: 'project',
+				scopes,
+			},
+		});
+
+		if (!response.ok()) {
+			throw new TestError(`Failed to create custom role: ${await response.text()}`);
+		}
+
+		const result = await response.json();
+		return result.data;
+	}
+
+	/**
+	 * Delete a custom role by slug
+	 * @param slug The role slug to delete
+	 * @returns True if deletion was successful
+	 */
+	async deleteRole(slug: string): Promise<boolean> {
+		const response = await this.api.request.delete(`/rest/roles/${slug}`);
+
+		if (!response.ok()) {
+			throw new TestError(`Failed to delete role: ${await response.text()}`);
+		}
+
+		return true;
+	}
+}

--- a/packages/testing/playwright/tests/ui/56-workflow-viewer-permissions.spec.ts
+++ b/packages/testing/playwright/tests/ui/56-workflow-viewer-permissions.spec.ts
@@ -56,7 +56,7 @@ async function setupProjectWithWorkflowAndSignInAsMember({
 	await n8n.navigate.toHome();
 	await n8n.sideBar.clickProjectMenuItem(createdProjectName);
 	await n8n.workflows.cards.getWorkflows().first().click();
-	await expect(n8n.canvas.getLoadingMask()).toBeHidden({ timeout: 30000 });
+	await expect(n8n.canvas.getLoadingMask()).not.toBeAttached();
 }
 
 test.describe('Workflow Viewer Permissions @isolated', () => {

--- a/packages/testing/playwright/tests/ui/56-workflow-viewer-permissions.spec.ts
+++ b/packages/testing/playwright/tests/ui/56-workflow-viewer-permissions.spec.ts
@@ -1,0 +1,163 @@
+import { nanoid } from 'nanoid';
+
+import { INSTANCE_MEMBER_CREDENTIALS } from '../../config/test-users';
+import { test, expect } from '../../fixtures/base';
+import type { ApiHelpers } from '../../services/api-helper';
+
+const MEMBER_EMAIL = INSTANCE_MEMBER_CREDENTIALS[0].email;
+
+// Helper to create custom roles via REST API with unique names
+async function createCustomRole(
+	api: ApiHelpers,
+	scopes: string[],
+	displayName: string,
+): Promise<{ slug: string }> {
+	const uniqueName = `${displayName} (${nanoid(8)})`;
+	const response = await api.request.post('/rest/roles', {
+		data: {
+			displayName: uniqueName,
+			description: `Custom role with scopes: ${scopes.join(', ')}`,
+			roleType: 'project',
+			scopes,
+		},
+	});
+	const result = await response.json();
+	return result.data;
+}
+
+test.describe('Workflow Viewer Permissions @isolated', () => {
+	test.describe.configure({ mode: 'serial' });
+
+	let readOnlyRole: { slug: string };
+	let editorRole: { slug: string };
+
+	test.beforeAll(async ({ api }) => {
+		await api.resetDatabase();
+		await api.enableFeature('sharing');
+		await api.enableFeature('advancedPermissions');
+		await api.enableFeature('customRoles');
+		await api.setMaxTeamProjectsQuota(-1);
+
+		// Sign in as owner (admin) to create custom roles
+		await api.signin('owner');
+
+		// Create custom read-only role (no workflow:update scope)
+		readOnlyRole = await createCustomRole(
+			api,
+			['project:read', 'workflow:read', 'workflow:list'],
+			'Workflow Read Only',
+		);
+
+		// Create custom editor role (with workflow:update scope)
+		editorRole = await createCustomRole(
+			api,
+			['project:read', 'workflow:read', 'workflow:list', 'workflow:update', 'workflow:execute'],
+			'Workflow Custom Editor',
+		);
+	});
+
+	test('user without workflow:update scope cannot drag nodes @auth:owner', async ({ n8n }) => {
+		// Navigate to home first (page starts at about:blank)
+		await n8n.navigate.toHome();
+
+		// Create project and add member with read-only role
+		const { projectId, projectName } = await n8n.projectComposer.createProject('Test Project');
+		await n8n.api.projects.addUserToProjectByEmail(projectId, MEMBER_EMAIL, readOnlyRole.slug);
+
+		// Create workflow in project
+		await n8n.sideBar.clickProjectMenuItem(projectName);
+		await n8n.workflows.clickNewWorkflowCard();
+		await n8n.canvas.addNode('Manual Trigger');
+		await n8n.canvas.saveWorkflow();
+
+		// Sign in as read-only user
+		await n8n.api.signin('member', 0);
+		await n8n.navigate.toHome();
+		await n8n.sideBar.clickProjectMenuItem(projectName);
+		await n8n.workflows.cards.getWorkflows().first().click();
+
+		// Verify nodes are visible
+		await expect(n8n.canvas.getLoadingMask()).toBeHidden({ timeout: 30000 });
+
+		// Attempt to drag - node should not move (no workflow:update scope)
+		const manualTrigger = n8n.canvas.nodeByName('When clicking ‘Execute workflow’');
+		const initialPosition = await manualTrigger.boundingBox();
+
+		await n8n.canvas.dragNodeToRelativePosition('When clicking ‘Execute workflow’', 100, 50);
+
+		const finalPosition = await manualTrigger.boundingBox();
+
+		// Position should remain unchanged
+		expect(finalPosition?.x).toBe(initialPosition?.x);
+		expect(finalPosition?.y).toBe(initialPosition?.y);
+	});
+
+	test('user without workflow:update can copy but cannot paste @auth:owner', async ({ n8n }) => {
+		// Navigate to home first (page starts at about:blank)
+		await n8n.navigate.toHome();
+
+		// Create project and add member with read-only role
+		const { projectId, projectName } = await n8n.projectComposer.createProject('Copy Test Project');
+		await n8n.api.projects.addUserToProjectByEmail(projectId, MEMBER_EMAIL, readOnlyRole.slug);
+
+		// Create workflow with nodes
+		await n8n.sideBar.clickProjectMenuItem(projectName);
+		await n8n.workflows.clickNewWorkflowCard();
+		await n8n.canvas.addNode('Edit Fields (Set)', { closeNDV: true });
+		await n8n.canvas.saveWorkflow();
+
+		// Sign in as read-only user
+		await n8n.api.signin('member', 0);
+		await n8n.navigate.toHome();
+		await n8n.sideBar.clickProjectMenuItem(projectName);
+		await n8n.workflows.cards.getWorkflows().first().click();
+
+		// Copy SHOULD work (useful for copying to another workflow)
+		await n8n.canvasComposer.selectAllAndCopy();
+
+		// Paste should NOT work (requires workflow:update)
+		const nodeCountBefore = await n8n.canvas.getCanvasNodes().count();
+		await n8n.page.keyboard.press('ControlOrMeta+V');
+		await expect(n8n.canvas.getCanvasNodes()).toHaveCount(nodeCountBefore);
+	});
+
+	test('user with workflow:update scope can drag and paste @auth:owner', async ({ n8n }) => {
+		// Navigate to home first (page starts at about:blank)
+		await n8n.navigate.toHome();
+
+		// Create project and add member with editor role
+		const { projectId, projectName } =
+			await n8n.projectComposer.createProject('Editor Test Project');
+		await n8n.api.projects.addUserToProjectByEmail(projectId, MEMBER_EMAIL, editorRole.slug);
+
+		// Create workflow
+		await n8n.sideBar.clickProjectMenuItem(projectName);
+		await n8n.workflows.clickNewWorkflowCard();
+		await n8n.canvas.addNode('Edit Fields (Set)', { closeNDV: true });
+		await n8n.canvas.saveWorkflow();
+
+		// Sign in as editor
+		await n8n.api.signin('member', 0);
+		await n8n.navigate.toHome();
+		await n8n.sideBar.clickProjectMenuItem(projectName);
+		await n8n.workflows.cards.getWorkflows().first().click();
+
+		// Drag should work
+		await expect(n8n.canvas.getLoadingMask()).toBeHidden({ timeout: 30000 });
+		const node = n8n.canvas.nodeByName('Edit Fields');
+		const initialPosition = await node.boundingBox();
+
+		await n8n.canvas.dragNodeToRelativePosition('Edit Fields', 100, 50);
+
+		const finalPosition = await node.boundingBox();
+
+		// Position SHOULD change
+		expect(finalPosition?.x).not.toBe(initialPosition?.x);
+
+		await n8n.canvasComposer.selectAllAndCopy();
+
+		const nodeCountBefore = await n8n.canvas.getCanvasNodes().count();
+		await n8n.page.keyboard.press('ControlOrMeta+V');
+		await expect(n8n.canvas.getCanvasNodes()).toHaveCount(nodeCountBefore + 1);
+	});
+});


### PR DESCRIPTION
## Summary

Users without the required scope could move nodes around and paste into the canvas.

it's bad UX but there was no security issue since the couldn't persist the changes.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
[PAY-4071](https://linear.app/n8n/issue/PAY-4071/as-a-workflow-viewer-you-can-still-copy-and-paste)


<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
