### PR TITLE
feat(core): Add credential resolver entity for dynamic credential module

### DIFF
--- a/packages/@n8n/db/src/migrations/common/1764682447000-CreateCredentialResolverTable.ts
+++ b/packages/@n8n/db/src/migrations/common/1764682447000-CreateCredentialResolverTable.ts
@@ -1,0 +1,20 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+const tableName = 'dynamic_credential_resolver';
+
+export class CreateDynamicCredentialResolverTable1764682447000 implements ReversibleMigration {
+	async up({ schemaBuilder: { createTable, column } }: MigrationContext) {
+		await createTable(tableName)
+			.withColumns(
+				column('id').varchar(16).primary.notNull,
+				column('name').varchar(128).notNull,
+				column('type').varchar(128).notNull,
+				column('config').text.notNull,
+			)
+			.withTimestamps.withIndexOn('type');
+	}
+
+	async down({ schemaBuilder: { dropTable } }: MigrationContext) {
+		await dropTable(tableName);
+	}
+}

--- a/packages/@n8n/db/src/migrations/common/1764682447000-CreateCredentialResolverTable.ts
+++ b/packages/@n8n/db/src/migrations/common/1764682447000-CreateCredentialResolverTable.ts
@@ -6,10 +6,12 @@ export class CreateDynamicCredentialResolverTable1764682447000 implements Revers
 	async up({ schemaBuilder: { createTable, column } }: MigrationContext) {
 		await createTable(tableName)
 			.withColumns(
-				column('id').varchar(16).primary.notNull,
+				column('id').varchar(16).primary,
 				column('name').varchar(128).notNull,
 				column('type').varchar(128).notNull,
-				column('config').text.notNull,
+				column('config').text.notNull.comment(
+					'Encrypted resolver configuration (JSON encrypted as string)',
+				),
 			)
 			.withTimestamps.withIndexOn('type');
 	}

--- a/packages/@n8n/db/src/migrations/mysqldb/index.ts
+++ b/packages/@n8n/db/src/migrations/mysqldb/index.ts
@@ -120,6 +120,7 @@ import { ChangeOAuthStateColumnToUnboundedVarchar1763572724000 } from '../common
 import { CreateBinaryDataTable1763716655000 } from '../common/1763716655000-CreateBinaryDataTable';
 import { CreateWorkflowPublishHistoryTable1764167920585 } from '../common/1764167920585-CreateWorkflowPublishHistoryTable';
 import { AddCreatorIdToProjectTable1764276827837 } from '../common/1764276827837-AddCreatorIdToProjectTable';
+import { CreateDynamicCredentialResolverTable1764682447000 } from '../common/1764682447000-CreateCredentialResolverTable';
 import type { Migration } from '../migration-types';
 
 export const mysqlMigrations: Migration[] = [
@@ -245,4 +246,5 @@ export const mysqlMigrations: Migration[] = [
 	CreateBinaryDataTable1763716655000,
 	CreateWorkflowPublishHistoryTable1764167920585,
 	AddCreatorIdToProjectTable1764276827837,
+	CreateDynamicCredentialResolverTable1764682447000,
 ];

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -120,6 +120,7 @@ import { ChangeOAuthStateColumnToUnboundedVarchar1763572724000 } from '../common
 import { CreateBinaryDataTable1763716655000 } from '../common/1763716655000-CreateBinaryDataTable';
 import { CreateWorkflowPublishHistoryTable1764167920585 } from '../common/1764167920585-CreateWorkflowPublishHistoryTable';
 import { AddCreatorIdToProjectTable1764276827837 } from '../common/1764276827837-AddCreatorIdToProjectTable';
+import { CreateDynamicCredentialResolverTable1764682447000 } from '../common/1764682447000-CreateCredentialResolverTable';
 import type { Migration } from '../migration-types';
 
 export const postgresMigrations: Migration[] = [
@@ -245,4 +246,5 @@ export const postgresMigrations: Migration[] = [
 	CreateBinaryDataTable1763716655000,
 	CreateWorkflowPublishHistoryTable1764167920585,
 	AddCreatorIdToProjectTable1764276827837,
+	CreateDynamicCredentialResolverTable1764682447000,
 ];

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -116,6 +116,7 @@ import { AddActiveVersionIdColumn1763047800000 } from '../common/1763047800000-A
 import { ChangeOAuthStateColumnToUnboundedVarchar1763572724000 } from '../common/1763572724000-ChangeOAuthStateColumnToUnboundedVarchar';
 import { CreateBinaryDataTable1763716655000 } from '../common/1763716655000-CreateBinaryDataTable';
 import { CreateWorkflowPublishHistoryTable1764167920585 } from '../common/1764167920585-CreateWorkflowPublishHistoryTable';
+import { CreateDynamicCredentialResolverTable1764682447000 } from '../common/1764682447000-CreateCredentialResolverTable';
 import type { Migration } from '../migration-types';
 
 const sqliteMigrations: Migration[] = [
@@ -237,6 +238,7 @@ const sqliteMigrations: Migration[] = [
 	CreateBinaryDataTable1763716655000,
 	CreateWorkflowPublishHistoryTable1764167920585,
 	AddCreatorIdToProjectTable1764276827837,
+	CreateDynamicCredentialResolverTable1764682447000,
 ];
 
 export { sqliteMigrations };

--- a/packages/cli/src/modules/dynamic-credentials.ee/database/entities/credential-resolver.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/database/entities/credential-resolver.ts
@@ -1,0 +1,14 @@
+import { Column, Entity } from '@n8n/typeorm';
+import { WithTimestampsAndStringId } from '@n8n/db';
+
+@Entity()
+export class DynamicCredentialResolver extends WithTimestampsAndStringId {
+	@Column({ type: 'varchar', length: 128 })
+	name: string;
+
+	@Column({ type: 'varchar', length: 128 })
+	type: string;
+
+	@Column({ type: 'text' })
+	config: string;
+}

--- a/packages/cli/src/modules/dynamic-credentials.ee/database/repositories/credential-resolver.repository.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/database/repositories/credential-resolver.repository.ts
@@ -1,0 +1,11 @@
+import { Service } from '@n8n/di';
+import { DataSource, Repository } from '@n8n/typeorm';
+
+import { DynamicCredentialResolver } from '../entities/credential-resolver';
+
+@Service()
+export class DynamicCredentialResolverRepository extends Repository<DynamicCredentialResolver> {
+	constructor(dataSource: DataSource) {
+		super(DynamicCredentialResolver, dataSource.manager);
+	}
+}

--- a/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.module.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.module.ts
@@ -7,9 +7,15 @@ export class DynamicCredentialsModule implements ModuleInterface {
 	async init() {
 		await import('./context-establishment-hooks');
 		await import('./credential-resolvers');
-		const { CredentialResolverRegistry } = await import('./services');
+		const { DynamicCredentialResolverRegistry } = await import('./services');
 
-		await Container.get(CredentialResolverRegistry).init();
+		await Container.get(DynamicCredentialResolverRegistry).init();
+	}
+
+	async entities() {
+		const { DynamicCredentialResolver } = await import('./database/entities/credential-resolver');
+
+		return [DynamicCredentialResolver];
 	}
 
 	@OnShutdown()

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-resolver-registry.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-resolver-registry.service.test.ts
@@ -8,10 +8,10 @@ import type {
 import { Container } from '@n8n/di';
 import type { ICredentialContext, ICredentialDataDecryptedObject } from 'n8n-workflow';
 
-import { CredentialResolverRegistry } from '../credential-resolver-registry.service';
+import { DynamicCredentialResolverRegistry } from '../credential-resolver-registry.service';
 
-describe('CredentialResolverRegistry', () => {
-	let registry: CredentialResolverRegistry;
+describe('DynamicCredentialResolverRegistry', () => {
+	let registry: DynamicCredentialResolverRegistry;
 	let mockLogger: jest.Mocked<Logger>;
 	let mockMetadata: jest.Mocked<CredentialResolverEntryMetadata>;
 
@@ -62,7 +62,7 @@ describe('CredentialResolverRegistry', () => {
 			getClasses: jest.fn(),
 		} as unknown as jest.Mocked<CredentialResolverEntryMetadata>;
 
-		registry = new CredentialResolverRegistry(mockMetadata, mockLogger);
+		registry = new DynamicCredentialResolverRegistry(mockMetadata, mockLogger);
 	});
 
 	describe('init', () => {

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/credential-resolver-registry.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/credential-resolver-registry.service.ts
@@ -7,7 +7,7 @@ import { Container, Service } from '@n8n/di';
  * Automatically discovers all classes decorated with @CredentialResolver() and makes them available by name.
  */
 @Service()
-export class CredentialResolverRegistry {
+export class DynamicCredentialResolverRegistry {
 	/** Map of resolver names to resolver instances */
 	private resolverMap: Map<string, ICredentialResolver> = new Map();
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR adds the credential resolver entity and db table.
This table will be used by the admin users to create credential resolvers by name, resolver type and configuration (key / value pair). The configuration is stored encrypted in the db

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-4212/create-resolver-database-entity

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
