### PR TITLE
fix(core): Allow users to update tools on their Chat sessions (no-changelog)

### DIFF
--- a/packages/cli/src/modules/chat-hub/chat-hub.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.service.ts
@@ -2277,6 +2277,7 @@ export class ChatHubService {
 
 		if (updates.title !== undefined) sessionUpdates.title = updates.title;
 		if (updates.credentialId !== undefined) sessionUpdates.credentialId = updates.credentialId;
+		if (updates.tools !== undefined) sessionUpdates.tools = updates.tools;
 
 		return await this.sessionRepository.updateChatSession(sessionId, sessionUpdates);
 	}


### PR DESCRIPTION
## Summary

Fix an issue that prevented users from saving tools change on the tool selector, if they already had an ongoing discussion. The new selected tools were sent to backend, but the update handler didn't allow saving them on the session, and frontend reset back to the previous state as it got the response from backend.

## Related Linear tickets, Github issues, and Community forum posts

https://www.notion.so/n8n/2955b6e0c94f80298ea6e47f0abdd9dc?v=2955b6e0c94f8169af97000c22abcddb&p=2bd5b6e0c94f80f19f33d4c36e931a75&pm=s

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
