### PR TITLE
feat(core): Add 'chat' execution mode concurrency controls support (no-changelog)

### DIFF
--- a/packages/@n8n/config/src/configs/executions.config.ts
+++ b/packages/@n8n/config/src/configs/executions.config.ts
@@ -23,9 +23,13 @@ class ConcurrencyConfig {
 	@Env('N8N_CONCURRENCY_PRODUCTION_LIMIT')
 	productionLimit: number = -1;
 
-	/** Max evaluation executions allowed to run concurrently. `-1` means unlimited. */
+	/** Max 'evaluation' mode executions allowed to run concurrently. `-1` means unlimited. */
 	@Env('N8N_CONCURRENCY_EVALUATION_LIMIT')
 	evaluationLimit: number = -1;
+
+	/** Max 'chat' mode executions allowed to run concurrently. `-1` means unlimited. */
+	@Env('N8N_CONCURRENCY_CHAT_LIMIT')
+	chatLimit: number = -1;
 }
 
 @Config

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -342,6 +342,7 @@ describe('GlobalConfig', () => {
 			concurrency: {
 				productionLimit: -1,
 				evaluationLimit: -1,
+				chatLimit: -1,
 			},
 			queueRecovery: {
 				interval: 180,

--- a/packages/cli/src/concurrency/concurrency-control.service.ts
+++ b/packages/cli/src/concurrency/concurrency-control.service.ts
@@ -15,7 +15,7 @@ import { ConcurrencyQueue } from './concurrency-queue';
 export const CLOUD_TEMP_PRODUCTION_LIMIT = 999;
 export const CLOUD_TEMP_REPORTABLE_THRESHOLDS = [5, 10, 20, 50, 100, 200];
 
-export type ConcurrencyQueueType = 'production' | 'evaluation';
+export type ConcurrencyQueueType = 'production' | 'evaluation' | 'chat';
 
 @Service()
 export class ConcurrencyControlService {
@@ -38,11 +38,13 @@ export class ConcurrencyControlService {
 	) {
 		this.logger = this.logger.scoped('concurrency');
 
-		const { productionLimit, evaluationLimit } = this.globalConfig.executions.concurrency;
+		const { productionLimit, evaluationLimit, chatLimit } =
+			this.globalConfig.executions.concurrency;
 
 		this.limits = new Map([
 			['production', productionLimit],
 			['evaluation', evaluationLimit],
+			['chat', chatLimit],
 		]);
 
 		this.limits.forEach((limit, type) => {
@@ -209,6 +211,8 @@ export class ConcurrencyControlService {
 		if (mode === 'webhook' || mode === 'trigger') return this.queues.get('production');
 
 		if (mode === 'evaluation') return this.queues.get('evaluation');
+
+		if (mode === 'chat') return this.queues.get('chat');
 
 		throw new UnknownExecutionModeError(mode);
 	}


### PR DESCRIPTION
## Summary

Introduce optional `N8N_CONCURRENCY_CHAT_LIMIT` env, default -1 (unlimited) for controlling `chat` execution mode concurrency. This execution mode is used on Chat hub base LLM chats.

For now this will be unlimited, needed to add some handling for the execution mode to avoid hitting `UnknownExecutionModeError` path when concurrency control is enabled.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-73

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
