### PR TITLE
feat(core): Count 'chat' mode executions towards production execution concurrency limits (no-changelog)

### DIFF
--- a/packages/cli/src/concurrency/__tests__/concurrency-control.service.test.ts
+++ b/packages/cli/src/concurrency/__tests__/concurrency-control.service.test.ts
@@ -215,31 +215,34 @@ describe('ConcurrencyControlService', () => {
 				},
 			);
 
-			it.each(['webhook', 'trigger'])('should enqueue on %s mode', async (mode: ExecutionMode) => {
-				/**
-				 * Arrange
-				 */
-				globalConfig.executions.concurrency.productionLimit = 1;
+			it.each(['webhook', 'trigger', 'chat'])(
+				'should enqueue on %s mode',
+				async (mode: ExecutionMode) => {
+					/**
+					 * Arrange
+					 */
+					globalConfig.executions.concurrency.productionLimit = 1;
 
-				const service = new ConcurrencyControlService(
-					logger,
-					executionRepository,
-					telemetry,
-					eventService,
-					globalConfig,
-				);
-				const enqueueSpy = jest.spyOn(ConcurrencyQueue.prototype, 'enqueue');
+					const service = new ConcurrencyControlService(
+						logger,
+						executionRepository,
+						telemetry,
+						eventService,
+						globalConfig,
+					);
+					const enqueueSpy = jest.spyOn(ConcurrencyQueue.prototype, 'enqueue');
 
-				/**
-				 * Act
-				 */
-				await service.throttle({ mode, executionId: '1' });
+					/**
+					 * Act
+					 */
+					await service.throttle({ mode, executionId: '1' });
 
-				/**
-				 * Assert
-				 */
-				expect(enqueueSpy).toHaveBeenCalled();
-			});
+					/**
+					 * Assert
+					 */
+					expect(enqueueSpy).toHaveBeenCalled();
+				},
+			);
 
 			it('should enqueue on evaluation mode', async () => {
 				/**
@@ -298,31 +301,34 @@ describe('ConcurrencyControlService', () => {
 				},
 			);
 
-			it.each(['webhook', 'trigger'])('should dequeue on %s mode', (mode: ExecutionMode) => {
-				/**
-				 * Arrange
-				 */
-				globalConfig.executions.concurrency.productionLimit = 1;
+			it.each(['webhook', 'trigger', 'chat'])(
+				'should dequeue on %s mode',
+				(mode: ExecutionMode) => {
+					/**
+					 * Arrange
+					 */
+					globalConfig.executions.concurrency.productionLimit = 1;
 
-				const service = new ConcurrencyControlService(
-					logger,
-					executionRepository,
-					telemetry,
-					eventService,
-					globalConfig,
-				);
-				const dequeueSpy = jest.spyOn(ConcurrencyQueue.prototype, 'dequeue');
+					const service = new ConcurrencyControlService(
+						logger,
+						executionRepository,
+						telemetry,
+						eventService,
+						globalConfig,
+					);
+					const dequeueSpy = jest.spyOn(ConcurrencyQueue.prototype, 'dequeue');
 
-				/**
-				 * Act
-				 */
-				service.release({ mode });
+					/**
+					 * Act
+					 */
+					service.release({ mode });
 
-				/**
-				 * Assert
-				 */
-				expect(dequeueSpy).toHaveBeenCalled();
-			});
+					/**
+					 * Assert
+					 */
+					expect(dequeueSpy).toHaveBeenCalled();
+				},
+			);
 
 			it('should dequeue on evaluation mode', () => {
 				/**
@@ -381,7 +387,7 @@ describe('ConcurrencyControlService', () => {
 				},
 			);
 
-			it.each(['webhook', 'trigger'])(
+			it.each(['webhook', 'trigger', 'chat'])(
 				'should remove an execution on %s mode',
 				(mode: ExecutionMode) => {
 					/**
@@ -559,6 +565,7 @@ describe('ConcurrencyControlService', () => {
 				 */
 				await service.throttle({ mode: 'trigger', executionId: '1' });
 				await service.throttle({ mode: 'webhook', executionId: '2' });
+				await service.throttle({ mode: 'chat', executionId: '3' });
 
 				/**
 				 * Assert

--- a/packages/cli/src/concurrency/concurrency-control.service.ts
+++ b/packages/cli/src/concurrency/concurrency-control.service.ts
@@ -206,7 +206,9 @@ export class ConcurrencyControlService {
 			return undefined;
 		}
 
-		if (mode === 'webhook' || mode === 'trigger') return this.queues.get('production');
+		if (mode === 'webhook' || mode === 'trigger' || mode === 'chat') {
+			return this.queues.get('production');
+		}
 
 		if (mode === 'evaluation') return this.queues.get('evaluation');
 


### PR DESCRIPTION
## Summary

Alternative approach to https://github.com/n8n-io/n8n/pull/22622, instead counting the `chat` mode executions towards production execution concurrency limits, controlled by `N8N_CONCURRENCY_PRODUCTION_LIMIT`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-73

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
