### PR TITLE
ci: Add cubic.yaml rules in repo root 

### DIFF
--- a/cubic.yaml
+++ b/cubic.yaml
@@ -1,0 +1,149 @@
+# yaml-language-server: $schema=https://cubic.dev/schema/cubic-repository-config.schema.json
+
+# cubic.yaml
+# This file configures AI review behavior, ignore patterns, PR descriptions, and custom rules.
+# Place this file in your repository root to version-control your AI review settings.
+# Settings defined here take precedence over UI-configured settings.
+# See https://docs.cubic.dev/configure/cubic-yaml for documentation.
+
+version: 1
+reviews:
+  enabled: true
+  sensitivity: medium
+  incremental_commits: true
+  show_ai_feedback_buttons: false
+  custom_instructions: |-
+    ## Step 1: Fetch Current Guidelines
+
+    1. Fetch the current [CONTRIBUTING.md](https://github.com/n8n-io/n8n/blob/master/CONTRIBUTING.md) from the repository's main branch
+    2. Navigate to the "Community PR Guidelines" section
+    3. Use ONLY this live version - ignore any cached/embedded rules
+
+    ## Step 2: Review Process
+
+    Evaluate the PR against the rules in the fetched Community PR Guidelines.
+
+    ## Step 3: Test Requirement Interpretation
+
+    BE REASONABLE when evaluating test coverage:
+
+    **PASS if:**
+
+    - Core functionality has tests
+    - Critical paths are tested
+    - Coverage is reasonable (not necessarily 100%)
+
+    **DO NOT require tests for:**
+
+    - Exports, types, configs
+    - Metadata files
+    - Version files
+
+    Approve if reasonably tested. Let humans handle edge cases.
+  custom_rules:
+    - name: Prefer Typeguards over Type casting
+      description: |-
+        - Rule Statement:  
+        Never use `as` keyword for type narrowing; instead, prefer type guards, type annotations, or the `satisfies` keyword. 
+
+        Only use `as` for the following legitimate cases:  
+          - DOM element assertions (e.g., `document.getElementById('foo') as HTMLButtonElement`)
+          - Event type assertions (e.g., `e as MouseEvent`)
+          - Const assertions (`as const`)
+          - Type widening (e.g., `(['a', 'b'] as string[]).includes('c')`)
+          - Generic constraints where no alternative exists
+
+        For type narrowing, use type guard functions. For type checking without losing inference, prefer `satisfies`. For simple type specification, prefer type annotations (`const x: A = y`) over casting (`const x = y as A`).
+
+        - Detection Criteria:  
+          - Identify all usages of the `as` keyword in TypeScript code that perform type assertions (e.g., `expr as SomeType`).
+          - Exclude any usages in tests such as unit test files (*.test.ts or *.spec.ts) or e2e tests under cypress/ folder. 
+          - Exclude usages where the assertion matches `as const`.
+          - Exclude assertions where:
+            - The assertion widens a literal/union type to a broader type (e.g., string literal array to string[])
+            - The left-hand side is a call to a DOM API (e.g., `document.getElementById`, `document.querySelector`, `document.createElement`)
+            - The assertion is applied to a variable named `e` or `event` and the type being asserted ends with `Event`
+          - Flag other usages and suggest alternatives: type guards for narrowing, type annotations for simple typing, or `satisfies` for type verification.
+          - Setting type of empty value  (for example `[] as string[]`)
+
+        - Example Violation:
+          ```typescript
+          function handleShape(shape: Shape) {
+            // Direct type casting without a type guard
+            const rect = shape as Rectangle;
+            return rect.width * rect.height;
+          }
+          ```
+
+        - Example Allowed:
+          ```typescript
+          // DOM element assertion
+          const button = document.getElementById('submit') as HTMLButtonElement;
+          
+          // Event assertion
+          function handle(e: Event) {
+            const mouse = e as MouseEvent;
+            console.log(mouse.clientX);
+          }
+
+          // as const usage
+          const config = { mode: "readonly" } as const;
+
+          // setting types of empty array
+          const arr = [] as string[]
+          ```
+    - name: Tests
+      description: |-
+        BE REASONABLE when evaluating test coverage:
+
+        **PASS if:**
+
+        - Core functionality has tests
+        - Critical paths are tested
+        - Coverage is reasonable (not necessarily 100%)
+
+        **DO NOT require tests for:**
+
+        - Exports, types, configs
+        - Metadata files
+        - Version files
+pr_descriptions:
+  generate: false
+  instructions: Each PR is supposed to have a limited scope. In your review, focus on changes made in the PR and avoid pointing out problems you found in the code that already existed.
+issues:
+  fix_with_cubic_buttons: true
+
+# -----------------------------------------------------------------------------
+# Sample configuration (commented out). Uncomment the sections you need.
+# -----------------------------------------------------------------------------
+# version: 1
+# reviews:
+#   enabled: true
+#   sensitivity: medium
+#   incremental_commits: true
+#   show_ai_feedback_buttons: true
+#   custom_instructions: "Add any reviewer guidance here."
+#   ignore:
+#     files:
+#       - docs/**
+#       - "**/*.md"
+#     head_branches:
+#       - feature/*
+#     base_branches:
+#       - release/*
+#     pr_labels:
+#       - WIP
+#     pr_titles:
+#       - "draft:*"
+#   custom_rules:
+#     - name: Example rule name
+#       description: Explain what should be enforced.
+#       include:
+#         - "src/**/*.ts"
+#       exclude:
+#         - "**/*.spec.ts"
+# pr_descriptions:
+#   generate: true
+#   instructions: "Summaries should highlight risk and testing steps."
+# issues:
+#   fix_with_cubic_buttons: true

--- a/cubic.yaml
+++ b/cubic.yaml
@@ -112,4 +112,4 @@ pr_descriptions:
   instructions: Each PR is supposed to have a limited scope. In your review, focus on changes made in the PR and avoid pointing out problems you found in the code that already existed.
 issues:
   fix_with_cubic_buttons: true
-	
+

--- a/cubic.yaml
+++ b/cubic.yaml
@@ -43,10 +43,10 @@ reviews:
   custom_rules:
     - name: Prefer Typeguards over Type casting
       description: |-
-        - Rule Statement:  
-        Never use `as` keyword for type narrowing; instead, prefer type guards, type annotations, or the `satisfies` keyword. 
+        - Rule Statement:
+        Never use `as` keyword for type narrowing; instead, prefer type guards, type annotations, or the `satisfies` keyword.
 
-        Only use `as` for the following legitimate cases:  
+        Only use `as` for the following legitimate cases:
           - DOM element assertions (e.g., `document.getElementById('foo') as HTMLButtonElement`)
           - Event type assertions (e.g., `e as MouseEvent`)
           - Const assertions (`as const`)
@@ -55,9 +55,9 @@ reviews:
 
         For type narrowing, use type guard functions. For type checking without losing inference, prefer `satisfies`. For simple type specification, prefer type annotations (`const x: A = y`) over casting (`const x = y as A`).
 
-        - Detection Criteria:  
+        - Detection Criteria:
           - Identify all usages of the `as` keyword in TypeScript code that perform type assertions (e.g., `expr as SomeType`).
-          - Exclude any usages in tests such as unit test files (*.test.ts or *.spec.ts) or e2e tests under cypress/ folder. 
+          - Exclude any usages in tests such as unit test files (*.test.ts or *.spec.ts) or e2e tests under cypress/ folder.
           - Exclude usages where the assertion matches `as const`.
           - Exclude assertions where:
             - The assertion widens a literal/union type to a broader type (e.g., string literal array to string[])
@@ -79,7 +79,7 @@ reviews:
           ```typescript
           // DOM element assertion
           const button = document.getElementById('submit') as HTMLButtonElement;
-          
+
           // Event assertion
           function handle(e: Event) {
             const mouse = e as MouseEvent;
@@ -112,38 +112,4 @@ pr_descriptions:
   instructions: Each PR is supposed to have a limited scope. In your review, focus on changes made in the PR and avoid pointing out problems you found in the code that already existed.
 issues:
   fix_with_cubic_buttons: true
-
-# -----------------------------------------------------------------------------
-# Sample configuration (commented out). Uncomment the sections you need.
-# -----------------------------------------------------------------------------
-# version: 1
-# reviews:
-#   enabled: true
-#   sensitivity: medium
-#   incremental_commits: true
-#   show_ai_feedback_buttons: true
-#   custom_instructions: "Add any reviewer guidance here."
-#   ignore:
-#     files:
-#       - docs/**
-#       - "**/*.md"
-#     head_branches:
-#       - feature/*
-#     base_branches:
-#       - release/*
-#     pr_labels:
-#       - WIP
-#     pr_titles:
-#       - "draft:*"
-#   custom_rules:
-#     - name: Example rule name
-#       description: Explain what should be enforced.
-#       include:
-#         - "src/**/*.ts"
-#       exclude:
-#         - "**/*.spec.ts"
-# pr_descriptions:
-#   generate: true
-#   instructions: "Summaries should highlight risk and testing steps."
-# issues:
-#   fix_with_cubic_buttons: true
+	


### PR DESCRIPTION
## Summary

- Adds cubic.yaml at the repository root
- Moves all existing Cubic rules into YAML

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/CAT-1849/move-cubic-rules-from-dashboard-to-n8n-repo


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
