### PR TITLE
ci: Enable release notes generation for RC releases

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -171,9 +171,7 @@ jobs:
   trigger-release-note:
     name: Trigger a release note
     needs: [publish-to-npm, create-github-release]
-    if: |
-      github.event.pull_request.merged == true &&
-      !contains(needs.publish-to-npm.outputs.release, '-rc.')
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Trigger a release note


### PR DESCRIPTION
## Summary

Remove the RC version filter from the `trigger-release-note` job so that release notes are also generated for release candidate versions.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/CAT-1861/enable-release-notes-generation-for-rc-releases

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
