### PR TITLE
fix(editor): Data table color adjustments (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/core/dataTable/components/dataGrid/DataTableTable.vue
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/components/dataGrid/DataTableTable.vue
@@ -224,7 +224,7 @@ defineExpose({
 	--ag-cell-text-color: var(--color--text--shade-1);
 	--ag-accent-color: var(--color--purple-600);
 	--ag-row-hover-color: var(--color--background--light-1);
-	--ag-background-color: var(--color--background--light-3);
+	--ag-background-color: var(--color--background--light-2);
 	--ag-border-color: var(--border-color);
 	--ag-border-radius: var(--radius);
 	--ag-wrapper-border-radius: 0;
@@ -241,7 +241,7 @@ defineExpose({
 	--ag-header-column-border-height: 100%;
 	--ag-range-selection-border-color: var(--color--purple-600);
 	--ag-input-padding-start: var(--spacing--2xs);
-	--ag-input-background-color: var(--color--text--tint-3);
+	--ag-input-background-color: var(--color--background--light-2);
 	--ag-focus-shadow: none;
 
 	:global(.ag-cell) {
@@ -322,7 +322,7 @@ defineExpose({
 		padding: 0;
 
 		textarea {
-			padding-top: var(--spacing--2xs);
+			padding-top: var(--spacing--3xs);
 
 			&:where(:focus-within, :active) {
 				border: var(--grid--cell--border-color--editing);

--- a/packages/frontend/editor-ui/src/features/core/dataTable/components/dataGrid/DataTableTable.vue
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/components/dataGrid/DataTableTable.vue
@@ -232,7 +232,7 @@ defineExpose({
 	--ag-font-size: var(--font-size--xs);
 	--ag-font-color: var(--color--text);
 	--ag-row-height: calc(var(--ag-grid-size) * 0.8 + 32px);
-	--ag-header-background-color: var(--color--background--light-1);
+	--ag-header-background-color: var(--color--foreground--tint-1);
 	--ag-header-font-size: var(--font-size--xs);
 	--ag-header-font-weight: var(--font-weight--medium);
 	--ag-header-foreground-color: var(--color--text--shade-1);


### PR DESCRIPTION
## Summary
Fixes the issue raised in the linear ticket, also adjust the header color and slight padding decrease of the active cell to match padding in normal cell.

When reviewing double check looks OK in both light and dark mode.

## Related Linear tickets, Github issues, and Community forum posts

Fixes: https://linear.app/n8n/issue/ADO-4452/ux-dark-mode-highlight-color-on-edit-text-within-data-tables-is-hard

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
