### PR TITLE
feat(core): Block access to env in code and expressions by default

### DIFF
--- a/packages/cli/src/deprecation/__tests__/deprecation.service.test.ts
+++ b/packages/cli/src/deprecation/__tests__/deprecation.service.test.ts
@@ -20,7 +20,6 @@ describe('DeprecationService', () => {
 		// Ignore environment variables coming in from the environment when running
 		// this test suite.
 		process.env = {
-			N8N_BLOCK_ENV_ACCESS_IN_NODE: 'false',
 			N8N_GIT_NODE_DISABLE_BARE_REPOS: 'false',
 		};
 
@@ -117,7 +116,6 @@ describe('DeprecationService', () => {
 		beforeEach(() => {
 			process.env = {
 				N8N_RUNNERS_ENABLED: 'true',
-				N8N_BLOCK_ENV_ACCESS_IN_NODE: 'false',
 				N8N_GIT_NODE_DISABLE_BARE_REPOS: 'false',
 			};
 		});
@@ -210,37 +208,10 @@ describe('DeprecationService', () => {
 		});
 	});
 
-	describe('N8N_BLOCK_ENV_ACCESS_IN_NODE', () => {
-		beforeEach(() => {
-			process.env = {
-				N8N_RUNNERS_ENABLED: 'true',
-				N8N_GIT_NODE_DISABLE_BARE_REPOS: 'false',
-			};
-
-			jest.resetAllMocks();
-		});
-
-		test('should warn when N8N_BLOCK_ENV_ACCESS_IN_NODE is not set', () => {
-			delete process.env.N8N_BLOCK_ENV_ACCESS_IN_NODE;
-			deprecationService.warn();
-			expect(logger.warn).toHaveBeenCalled();
-		});
-
-		test.each(['false', 'true'])(
-			'should not warn when N8N_BLOCK_ENV_ACCESS_IN_NODE is %s',
-			(value) => {
-				process.env.N8N_BLOCK_ENV_ACCESS_IN_NODE = value;
-				deprecationService.warn();
-				expect(logger.warn).not.toHaveBeenCalled();
-			},
-		);
-	});
-
 	describe('N8N_GIT_NODE_DISABLE_BARE_REPOS', () => {
 		beforeEach(() => {
 			process.env = {
 				N8N_RUNNERS_ENABLED: 'true',
-				N8N_BLOCK_ENV_ACCESS_IN_NODE: 'false',
 			};
 			jest.resetAllMocks();
 		});

--- a/packages/cli/src/deprecation/deprecation.service.ts
+++ b/packages/cli/src/deprecation/deprecation.service.ts
@@ -92,12 +92,6 @@ export class DeprecationService {
 			checkValue: (value: string) => value === 'own',
 		},
 		{
-			envVar: 'N8N_BLOCK_ENV_ACCESS_IN_NODE',
-			message:
-				'The default value of N8N_BLOCK_ENV_ACCESS_IN_NODE will be changed from false to true in a future version. If you need to access environment variables from the Code Node or from expressions, please set N8N_BLOCK_ENV_ACCESS_IN_NODE=false. Learn more: https://docs.n8n.io/hosting/configuration/environment-variables/security/',
-			checkValue: (value: string | undefined) => value === undefined || value === '',
-		},
-		{
 			envVar: 'N8N_GIT_NODE_DISABLE_BARE_REPOS',
 			message:
 				'Support for bare repositories in the Git Node will be removed in a future version due to security concerns. If you are not using bare repositories in the Git Node, please set N8N_GIT_NODE_DISABLE_BARE_REPOS=true. Learn more: https://docs.n8n.io/hosting/configuration/environment-variables/security/',

--- a/packages/nodes-base/nodes/Code/PythonSandbox.ts
+++ b/packages/nodes-base/nodes/Code/PythonSandbox.ts
@@ -11,7 +11,7 @@ type PythonSandboxContext = {
 
 type PyodideError = Error & { type: string };
 
-const envAccessBlocked = process.env.N8N_BLOCK_ENV_ACCESS_IN_NODE === 'true';
+const envAccessBlocked = process.env.N8N_BLOCK_ENV_ACCESS_IN_NODE !== 'false';
 
 export class PythonSandbox extends Sandbox {
 	private readonly context: PythonSandboxContext;

--- a/packages/workflow/src/expression.ts
+++ b/packages/workflow/src/expression.ts
@@ -282,7 +282,7 @@ export class Expression {
 			typeof process !== 'undefined'
 				? {
 						arch: process.arch,
-						env: process.env.N8N_BLOCK_ENV_ACCESS_IN_NODE === 'true' ? {} : process.env,
+						env: process.env.N8N_BLOCK_ENV_ACCESS_IN_NODE !== 'false' ? {} : process.env,
 						platform: process.platform,
 						pid: process.pid,
 						ppid: process.ppid,

--- a/packages/workflow/src/workflow-data-proxy-env-provider.ts
+++ b/packages/workflow/src/workflow-data-proxy-env-provider.ts
@@ -13,7 +13,7 @@ export type EnvProviderState = {
 export function createEnvProviderState(): EnvProviderState {
 	const isProcessAvailable = typeof process !== 'undefined';
 	const isEnvAccessBlocked = isProcessAvailable
-		? process.env.N8N_BLOCK_ENV_ACCESS_IN_NODE === 'true'
+		? process.env.N8N_BLOCK_ENV_ACCESS_IN_NODE !== 'false'
 		: false;
 	const env: Record<string, string> =
 		!isProcessAvailable || isEnvAccessBlocked ? {} : (process.env as Record<string, string>);

--- a/packages/workflow/test/workflow-data-proxy-env-provider.test.ts
+++ b/packages/workflow/test/workflow-data-proxy-env-provider.test.ts
@@ -7,6 +7,8 @@ describe('createEnvProviderState', () => {
 	});
 
 	it('should return the state with process available and env access allowed', () => {
+		process.env.N8N_BLOCK_ENV_ACCESS_IN_NODE = 'false';
+
 		expect(createEnvProviderState()).toEqual({
 			isProcessAvailable: true,
 			isEnvAccessBlocked: false,
@@ -17,6 +19,14 @@ describe('createEnvProviderState', () => {
 	it('should block env access when N8N_BLOCK_ENV_ACCESS_IN_NODE is set to "true"', () => {
 		process.env.N8N_BLOCK_ENV_ACCESS_IN_NODE = 'true';
 
+		expect(createEnvProviderState()).toEqual({
+			isProcessAvailable: true,
+			isEnvAccessBlocked: true,
+			env: {},
+		});
+	});
+
+	it('should block env access when N8N_BLOCK_ENV_ACCESS_IN_NODE is not set', () => {
 		expect(createEnvProviderState()).toEqual({
 			isProcessAvailable: true,
 			isEnvAccessBlocked: true,
@@ -42,12 +52,18 @@ describe('createEnvProviderState', () => {
 });
 
 describe('createEnvProvider', () => {
+	afterEach(() => {
+		delete process.env.N8N_BLOCK_ENV_ACCESS_IN_NODE;
+	});
+
 	it('should return true when checking for a property using "has"', () => {
 		const proxy = createEnvProvider(0, 0, createEnvProviderState());
 		expect('someProperty' in proxy).toBe(true);
 	});
 
 	it('should return the value from process.env if access is allowed', () => {
+		process.env.N8N_BLOCK_ENV_ACCESS_IN_NODE = 'false';
+
 		process.env.TEST_ENV_VAR = 'test_value';
 		const proxy = createEnvProvider(0, 0, createEnvProviderState());
 		expect(proxy.TEST_ENV_VAR).toBe('test_value');

--- a/packages/workflow/test/workflow.test.ts
+++ b/packages/workflow/test/workflow.test.ts
@@ -1743,6 +1743,8 @@ describe('Workflow', () => {
 
 		for (const testData of tests) {
 			test(testData.description, () => {
+				process.env.N8N_BLOCK_ENV_ACCESS_IN_NODE = 'false';
+
 				const nodes: INode[] = [
 					{
 						name: 'Node1',


### PR DESCRIPTION
## Summary

Changes the default value of `N8N_BLOCK_ENV_ACCESS_IN_NODE` to true. This means Code node and expressions don't have access to `process.env` anymore unless explicitly enabled by setting `N8N_BLOCK_ENV_ACCESS_IN_NODE=false`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-691/block-env-access-from-code-node-by-default


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
