### PR TITLE
fix(MCP Client Node): Make "Use Dynamic Client Registration" toggle not required

### DIFF
--- a/packages/@n8n/nodes-langchain/credentials/McpOAuth2Api.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/McpOAuth2Api.credentials.ts
@@ -15,7 +15,6 @@ export class McpOAuth2Api implements ICredentialType {
 			name: 'useDynamicClientRegistration',
 			type: 'boolean',
 			default: true,
-			required: true,
 		},
 	];
 }


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
After a change in #22213, which prevents credentials from being saved if there are missing required fields, MCP OAuth2 credentials broke. This is because `useDynamicClientRegistration` field is `required` and has `default: true`. This only happens in this particular case, so if `default` is `false` or the field is not of type `boolean` it still works with a `default` value. Since it doesn't make much sense to have a toggle as `required` (and given we expect that it _can_ be turned off), I removed `required: true`

#### To test
1. Try connecting to any MCP server using OAuth2 with DCR, such as `https://mcp.notion.com/mcp`
2. Observe the error

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
https://linear.app/n8n/issue/NODE-4006/mcp-clients-oauth-is-not-working-with-gleancom#comment-ff76e915

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
