### PR TITLE
fix: Update activate request for benchmark (no-changelog)

### DIFF
--- a/packages/@n8n/benchmark/scenarios/credential-http-node/credential-http-node.json
+++ b/packages/@n8n/benchmark/scenarios/credential-http-node/credential-http-node.json
@@ -228,7 +228,7 @@
 			]
 		}
 	},
-	"active": true,
+	"active": false,
 	"settings": {
 		"executionOrder": "v1"
 	},

--- a/packages/@n8n/benchmark/src/n8n-api-client/n8n-api-client.types.ts
+++ b/packages/@n8n/benchmark/src/n8n-api-client/n8n-api-client.types.ts
@@ -4,6 +4,7 @@
 export type Workflow = {
 	id: string;
 	name: string;
+	versionId: string;
 	tags?: string[];
 };
 

--- a/packages/@n8n/benchmark/src/n8n-api-client/workflows-api-client.ts
+++ b/packages/@n8n/benchmark/src/n8n-api-client/workflows-api-client.ts
@@ -1,6 +1,6 @@
-import type { AuthenticatedN8nApiClient } from './authenticated-n8n-api-client';
-
 import type { Workflow } from '@/n8n-api-client/n8n-api-client.types';
+
+import type { AuthenticatedN8nApiClient } from './authenticated-n8n-api-client';
 
 export class WorkflowApiClient {
 	constructor(private readonly apiClient: AuthenticatedN8nApiClient) {}

--- a/packages/@n8n/benchmark/src/n8n-api-client/workflows-api-client.ts
+++ b/packages/@n8n/benchmark/src/n8n-api-client/workflows-api-client.ts
@@ -1,6 +1,6 @@
-import type { Workflow } from '@/n8n-api-client/n8n-api-client.types';
-
 import type { AuthenticatedN8nApiClient } from './authenticated-n8n-api-client';
+
+import type { Workflow } from '@/n8n-api-client/n8n-api-client.types';
 
 export class WorkflowApiClient {
 	constructor(private readonly apiClient: AuthenticatedN8nApiClient) {}
@@ -18,10 +18,12 @@ export class WorkflowApiClient {
 	}
 
 	async activateWorkflow(workflow: Workflow): Promise<Workflow> {
-		const response = await this.apiClient.patch<{ data: Workflow }>(`/workflows/${workflow.id}`, {
-			...workflow,
-			active: true,
-		});
+		const response = await this.apiClient.post<{ data: Workflow }>(
+			`/workflows/${workflow.id}/activate`,
+			{
+				versionId: workflow.versionId,
+			},
+		);
 
 		return response.data.data;
 	}

--- a/packages/cli/src/workflows/__tests__/workflows.controller.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflows.controller.test.ts
@@ -1,4 +1,5 @@
 import type { ImportWorkflowFromUrlDto } from '@n8n/api-types';
+import type { Logger } from '@n8n/backend-common';
 import type { AuthenticatedRequest, IExecutionResponse, CredentialsEntity, User } from '@n8n/db';
 import { WorkflowEntity } from '@n8n/db';
 import axios from 'axios';
@@ -25,9 +26,11 @@ describe('WorkflowsController', () => {
 	const req = mock<AuthenticatedRequest>();
 	const res = mock<Response>();
 	const projectService = mock<ProjectService>();
+	const logger = mock<Logger>();
 
 	beforeEach(() => {
 		controller.projectService = projectService;
+		controller.logger = logger;
 		jest.clearAllMocks();
 	});
 

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -96,6 +96,18 @@ export class WorkflowsController {
 		// mess with relations of other workflows
 		delete req.body.shared;
 
+		// @ts-expect-error: We shouldn't accept this, this will be set when activating
+		if (req.body.activeVersionId || req.body.active) {
+			this.logger.warn(
+				'Creating a workflow as active is not supported. The workflow will be created as inactive.',
+				{ userId: req.user.id },
+			);
+
+			// @ts-expect-error: We shouldn't accept this
+			req.body.activeVersionId = undefined;
+			req.body.active = false;
+		}
+
 		const newWorkflow = new WorkflowEntity();
 
 		Object.assign(newWorkflow, req.body);

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -255,7 +255,7 @@ describe('POST /workflows', () => {
 		expect(historyVersion!.nodes).toEqual(payload.nodes);
 	});
 
-	test('should create workflow as active when active: true is provided in POST body', async () => {
+	test('should create workflow as inactive even when active: true is provided in POST body', async () => {
 		const payload = {
 			name: 'active workflow',
 			nodes: [
@@ -284,21 +284,12 @@ describe('POST /workflows', () => {
 
 		expect(id).toBeDefined();
 		expect(versionId).toBeDefined();
-		expect(activeVersionId).toBe(versionId); // Should be set to current version
-		expect(active).toBe(true);
+		expect(activeVersionId).toBeNull();
+		expect(active).toBe(false);
 
 		// Verify in database
 		const workflow = await workflowRepository.findOneBy({ id });
-		expect(workflow?.activeVersionId).toBe(versionId);
-
-		// Verify history was created
-		const historyVersion = await workflowHistoryRepository.findOne({
-			where: {
-				workflowId: id,
-				versionId,
-			},
-		});
-		expect(historyVersion).not.toBeNull();
+		expect(workflow?.activeVersionId).toBeNull();
 	});
 
 	test('create workflow in personal project by default', async () => {


### PR DESCRIPTION
## Summary

Now to activate workflows, a separate `activate` request should be sent. This PR:
- calls the correct endpoint for benchmark tests
- forbids creating active workflows
    - `activeVersionId` is a foreign flag, so we have a 🐔  and 🥚  problem: to create a workflow history version, we need a workflow id, and to create an active workflow, we need a workflow history version id. Also, `create` endpoint doesn't have any activation logic inside, so I figured it is better for now to just forbid creating active workflows. It's not possible from the UI anyway.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
