### PR TITLE
feat(Wordpress Node): Add Media resource and upload operations

### DIFF
--- a/packages/nodes-base/nodes/Wordpress/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Wordpress/GenericFunctions.ts
@@ -34,7 +34,7 @@ export async function wordpressApiRequest(
 		json: true,
 	};
 	options = Object.assign({}, options, option);
-	if (Object.keys(options.body as IDataObject).length === 0) {
+	if (!Buffer.isBuffer(options.body) && Object.keys(options.body as IDataObject).length === 0) {
 		delete options.body;
 	}
 	try {

--- a/packages/nodes-base/nodes/Wordpress/MediaDescription.ts
+++ b/packages/nodes-base/nodes/Wordpress/MediaDescription.ts
@@ -1,0 +1,605 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+export const mediaOperations: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['media'],
+			},
+		},
+		options: [
+			{
+				name: 'Create',
+				value: 'create',
+				description: 'Create a media item',
+				action: 'Create a media item',
+			},
+			{
+				name: 'Delete',
+				value: 'delete',
+				description: 'Delete a media item',
+				action: 'Delete a media item',
+			},
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get a media item',
+				action: 'Get a media item',
+			},
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get many media items',
+				action: 'Get many media items',
+			},
+			{
+				name: 'Update',
+				value: 'update',
+				description: 'Update a media item',
+				action: 'Update a media item',
+			},
+		],
+		default: 'create',
+	},
+];
+
+export const mediaFields: INodeProperties[] = [
+	/* -------------------------------------------------------------------------- */
+	/*                                media:create                                */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'File Name',
+		name: 'fileName',
+		type: 'string',
+		default: '',
+		placeholder: 'image.png',
+		description: 'The name of the file to upload',
+		displayOptions: {
+			show: {
+				resource: ['media'],
+				operation: ['create'],
+			},
+		},
+	},
+	{
+		displayName: 'Binary Property',
+		name: 'binaryPropertyName',
+		type: 'string',
+		default: 'data',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['media'],
+				operation: ['create'],
+			},
+		},
+		description: 'Name of the binary property which contains the data for the file to be uploaded',
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['media'],
+				operation: ['create'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Alt Text',
+				name: 'altText',
+				type: 'string',
+				default: '',
+				description: 'Alternative text to display when attachment is not displayed',
+			},
+			{
+				displayName: 'Author Name or ID',
+				name: 'authorId',
+				type: 'options',
+				typeOptions: {
+					loadOptionsMethod: 'getAuthors',
+				},
+				default: '',
+				description:
+					'The ID for the author of the object. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			},
+			{
+				displayName: 'Caption',
+				name: 'caption',
+				type: 'string',
+				default: '',
+				description: 'The caption for the attachment',
+			},
+			{
+				displayName: 'Comment Status',
+				name: 'commentStatus',
+				type: 'options',
+				options: [
+					{
+						name: 'Open',
+						value: 'open',
+					},
+					{
+						name: 'Close',
+						value: 'closed',
+					},
+				],
+				default: 'open',
+				description: 'Whether or not comments are open on the post',
+			},
+			{
+				displayName: 'Description',
+				name: 'description',
+				type: 'string',
+				default: '',
+				description: 'The description for the attachment',
+			},
+			{
+				displayName: 'Ping Status',
+				name: 'pingStatus',
+				type: 'options',
+				options: [
+					{
+						name: 'Open',
+						value: 'open',
+					},
+					{
+						name: 'Close',
+						value: 'closed',
+					},
+				],
+				default: 'open',
+				description: 'Whether or not comments are open on the post',
+			},
+			{
+				displayName: 'Post ID',
+				name: 'postId',
+				type: 'string',
+				default: '',
+				description: 'The ID of the associated post of the attachment',
+			},
+			{
+				displayName: 'Title',
+				name: 'title',
+				type: 'string',
+				default: '',
+				description: 'The title for the attachment',
+			},
+		],
+	},
+	/* -------------------------------------------------------------------------- */
+	/*                                media:update                                */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Media ID',
+		name: 'mediaId',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['media'],
+				operation: ['update'],
+			},
+		},
+		description: 'Unique identifier for the object',
+	},
+	{
+		displayName: 'Update Fields',
+		name: 'updateFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['media'],
+				operation: ['update'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Alt Text',
+				name: 'altText',
+				type: 'string',
+				default: '',
+				description: 'Alternative text to display when attachment is not displayed',
+			},
+			{
+				displayName: 'Author Name or ID',
+				name: 'authorId',
+				type: 'options',
+				typeOptions: {
+					loadOptionsMethod: 'getAuthors',
+				},
+				default: '',
+				description:
+					'The ID for the author of the object. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			},
+			{
+				displayName: 'Caption',
+				name: 'caption',
+				type: 'string',
+				default: '',
+				description: 'The caption for the attachment',
+			},
+			{
+				displayName: 'Comment Status',
+				name: 'commentStatus',
+				type: 'options',
+				options: [
+					{
+						name: 'Open',
+						value: 'open',
+					},
+					{
+						name: 'Close',
+						value: 'closed',
+					},
+				],
+				default: 'open',
+				description: 'Whether or not comments are open on the post',
+			},
+			{
+				displayName: 'Description',
+				name: 'description',
+				type: 'string',
+				default: '',
+				description: 'The description for the attachment',
+			},
+			{
+				displayName: 'Ping Status',
+				name: 'pingStatus',
+				type: 'options',
+				options: [
+					{
+						name: 'Open',
+						value: 'open',
+					},
+					{
+						name: 'Close',
+						value: 'closed',
+					},
+				],
+				default: 'open',
+				description: 'Whether or not comments are open on the post',
+			},
+			{
+				displayName: 'Post ID',
+				name: 'postId',
+				type: 'string',
+				default: '',
+				description: 'The ID of the associated post of the attachment',
+			},
+			{
+				displayName: 'Title',
+				name: 'title',
+				type: 'string',
+				default: '',
+				description: 'The title for the attachment',
+			},
+		],
+	},
+	/* -------------------------------------------------------------------------- */
+	/*                                  media:get                                 */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Media ID',
+		name: 'mediaId',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['media'],
+				operation: ['get'],
+			},
+		},
+		description: 'Unique identifier for the object',
+	},
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		placeholder: 'Add option',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['media'],
+				operation: ['get'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Context',
+				name: 'context',
+				type: 'options',
+				options: [
+					{
+						name: 'View',
+						value: 'view',
+					},
+					{
+						name: 'Embed',
+						value: 'embed',
+					},
+					{
+						name: 'Edit',
+						value: 'edit',
+					},
+				],
+				default: 'view',
+				description: 'Scope under which the request is made; determines fields present in response',
+			},
+		],
+	},
+	/* -------------------------------------------------------------------------- */
+	/*                                   media:getAll                             */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		displayOptions: {
+			show: {
+				resource: ['media'],
+				operation: ['getAll'],
+			},
+		},
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		displayOptions: {
+			show: {
+				resource: ['media'],
+				operation: ['getAll'],
+				returnAll: [false],
+			},
+		},
+		typeOptions: {
+			minValue: 1,
+			maxValue: 10,
+		},
+		default: 5,
+		description: 'Max number of results to return',
+	},
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		placeholder: 'Add option',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['media'],
+				operation: ['getAll'],
+			},
+		},
+		options: [
+			{
+				displayName: 'After',
+				name: 'after',
+				type: 'dateTime',
+				default: '',
+				description: 'Limit response to posts published after a given ISO8601 compliant date',
+			},
+			{
+				displayName: 'Author Names or IDs',
+				name: 'author',
+				type: 'multiOptions',
+				default: [],
+				typeOptions: {
+					loadOptionsMethod: 'getAuthors',
+				},
+				description:
+					'Limit result set to posts assigned to specific authors. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			},
+			{
+				displayName: 'Before',
+				name: 'before',
+				type: 'dateTime',
+				default: '',
+				description: 'Limit response to posts published before a given ISO8601 compliant date',
+			},
+			{
+				displayName: 'Context',
+				name: 'context',
+				type: 'options',
+				options: [
+					{
+						name: 'View',
+						value: 'view',
+					},
+					{
+						name: 'Embed',
+						value: 'embed',
+					},
+					{
+						name: 'Edit',
+						value: 'edit',
+					},
+				],
+				default: 'view',
+				description: 'Scope under which the request is made; determines fields present in response',
+			},
+			{
+				displayName: 'Media Type',
+				name: 'mediaType',
+				type: 'options',
+				options: [
+					{
+						name: 'Image',
+						value: 'image',
+					},
+					{
+						name: 'Video',
+						value: 'video',
+					},
+					{
+						name: 'Audio',
+						value: 'audio',
+					},
+					{
+						name: 'Application',
+						value: 'application',
+					},
+				],
+				default: 'image',
+				description: 'Limit result set to attachments of a particular media type',
+			},
+			{
+				displayName: 'Mime Type',
+				name: 'mimeType',
+				type: 'string',
+				default: '',
+				description: 'Limit result set to attachments of a particular mime type',
+			},
+			{
+				displayName: 'Order',
+				name: 'order',
+				type: 'options',
+				options: [
+					{
+						name: 'ASC',
+						value: 'asc',
+					},
+					{
+						name: 'DESC',
+						value: 'desc',
+					},
+				],
+				default: 'desc',
+				description: 'Order sort attribute ascending or descending',
+			},
+			{
+				displayName: 'Order By',
+				name: 'orderBy',
+				type: 'options',
+				options: [
+					{
+						name: 'Author',
+						value: 'author',
+					},
+					{
+						name: 'Date',
+						value: 'date',
+					},
+					{
+						name: 'ID',
+						value: 'id',
+					},
+					{
+						name: 'Include',
+						value: 'include',
+					},
+					{
+						name: 'Modified',
+						value: 'modified',
+					},
+					{
+						name: 'Parent',
+						value: 'parent',
+					},
+					{
+						name: 'Relevance',
+						value: 'relevance',
+					},
+					{
+						name: 'Slug',
+						value: 'slug',
+					},
+					{
+						name: 'Title',
+						value: 'title',
+					},
+				],
+				default: 'date',
+				description: 'Sort collection by object attribute',
+			},
+			{
+				displayName: 'Parent ID',
+				name: 'parentId',
+				type: 'string',
+				default: '',
+				description: 'Limit result set to items with particular parent IDs',
+			},
+			{
+				displayName: 'Search',
+				name: 'search',
+				type: 'string',
+				default: '',
+				description: 'Limit results to those matching a string',
+			},
+			{
+				displayName: 'Status',
+				name: 'status',
+				type: 'options',
+				options: [
+					{
+						name: 'Inherit',
+						value: 'inherit',
+					},
+					{
+						name: 'Private',
+						value: 'private',
+					},
+					{
+						name: 'Trash',
+						value: 'trash',
+					},
+				],
+				default: 'inherit',
+				description: 'Limit result set to posts assigned one or more statuses',
+			},
+		],
+	},
+	/* -------------------------------------------------------------------------- */
+	/*                                media:delete                                */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Media ID',
+		name: 'mediaId',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['media'],
+				operation: ['delete'],
+			},
+		},
+		description: 'Unique identifier for the object',
+	},
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		placeholder: 'Add option',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['media'],
+				operation: ['delete'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Force',
+				name: 'force',
+				type: 'boolean',
+				default: true,
+				description: 'Whether to bypass trash and force deletion',
+			},
+		],
+	},
+];

--- a/packages/nodes-base/nodes/Wordpress/MediaInterface.ts
+++ b/packages/nodes-base/nodes/Wordpress/MediaInterface.ts
@@ -1,0 +1,26 @@
+export interface IMedia {
+	id?: number;
+	date?: string;
+	date_gmt?: string;
+	guid?: object;
+	modified?: string;
+	modified_gmt?: string;
+	slug?: string;
+	status?: string;
+	type?: string;
+	link?: string;
+	title?: object | string;
+	author?: number;
+	comment_status?: string;
+	ping_status?: string;
+	template?: string;
+	meta?: object;
+	description?: object | string;
+	caption?: object | string;
+	alt_text?: string;
+	media_type?: string;
+	mime_type?: string;
+	media_details?: object;
+	post?: number;
+	source_url?: string;
+}

--- a/packages/nodes-base/nodes/Wordpress/test/Wordpress.node.test.ts
+++ b/packages/nodes-base/nodes/Wordpress/test/Wordpress.node.test.ts
@@ -1,0 +1,35 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock = require('nock');
+
+describe('Wordpress Node', () => {
+	const credentials = {
+		wordpressApi: {
+			username: 'user',
+			password: 'password',
+			url: 'https://example.com',
+		},
+	};
+
+	describe('Media: create', () => {
+		const wordpressNock = nock('https://example.com/wp-json/wp/v2');
+
+		beforeAll(() => {
+			wordpressNock
+				.post('/media')
+				.matchHeader('content-type', 'image/png')
+				.matchHeader('content-disposition', 'attachment; filename="image.png"')
+				.reply(201, {
+					id: 123,
+					title: { rendered: 'image' },
+					source_url: 'http://example.com/wp-content/uploads/2023/10/image.png',
+				});
+		});
+
+		afterAll(() => wordpressNock.done());
+
+		new NodeTestHarness().setupTests({
+			credentials,
+			workflowFiles: ['media-create.workflow.json'],
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Wordpress/test/fixtures/media-create.json
+++ b/packages/nodes-base/nodes/Wordpress/test/fixtures/media-create.json
@@ -1,0 +1,39 @@
+{
+	"id": 123,
+	"date": "2023-10-27T10:00:00",
+	"date_gmt": "2023-10-27T10:00:00",
+	"guid": {
+		"rendered": "http://example.com/wp-content/uploads/2023/10/image.png"
+	},
+	"modified": "2023-10-27T10:00:00",
+	"modified_gmt": "2023-10-27T10:00:00",
+	"slug": "image",
+	"status": "inherit",
+	"type": "attachment",
+	"link": "http://example.com/image/",
+	"title": {
+		"rendered": "image"
+	},
+	"author": 1,
+	"comment_status": "open",
+	"ping_status": "closed",
+	"template": "",
+	"meta": [],
+	"description": {
+		"rendered": "<p class=\"attachment\"> <a href=\"http://example.com/wp-content/uploads/2023/10/image.png\"><img width=\"300\" height=\"300\" src=\"http://example.com/wp-content/uploads/2023/10/image.png\" class=\"attachment-medium size-medium\" alt=\"\" decoding=\"async\" loading=\"lazy\" /></a> </p>"
+	},
+	"caption": {
+		"rendered": ""
+	},
+	"alt_text": "",
+	"media_type": "image",
+	"mime_type": "image/png",
+	"media_details": {
+		"width": 300,
+		"height": 300,
+		"file": "2023/10/image.png",
+		"sizes": {}
+	},
+	"post": null,
+	"source_url": "http://example.com/wp-content/uploads/2023/10/image.png"
+}

--- a/packages/nodes-base/nodes/Wordpress/test/media-create.workflow.json
+++ b/packages/nodes-base/nodes/Wordpress/test/media-create.workflow.json
@@ -1,0 +1,114 @@
+{
+	"name": "Wordpress Media Create",
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0],
+			"id": "trigger",
+			"name": "When clicking ‘Execute workflow’"
+		},
+		{
+			"parameters": {
+				"values": {
+					"string": [
+						{
+							"name": "data",
+							"value": "test content"
+						}
+					]
+				},
+				"options": {}
+			},
+			"type": "n8n-nodes-base.set",
+			"typeVersion": 1,
+			"position": [200, 0],
+			"id": "set",
+			"name": "Set Data"
+		},
+		{
+			"parameters": {
+				"mode": "jsonToBinary",
+				"useSourceProperty": true,
+				"sourceKey": "data",
+				"destinationKey": "data",
+				"options": {
+					"mimeType": "image/png"
+				}
+			},
+			"type": "n8n-nodes-base.moveBinaryData",
+			"typeVersion": 1,
+			"position": [400, 0],
+			"id": "convert",
+			"name": "Convert to File"
+		},
+		{
+			"parameters": {
+				"resource": "media",
+				"operation": "create",
+				"fileName": "image.png",
+				"binaryPropertyName": "data"
+			},
+			"type": "n8n-nodes-base.wordpress",
+			"typeVersion": 1,
+			"position": [600, 0],
+			"id": "wordpress",
+			"name": "Wordpress",
+			"credentials": {
+				"wordpressApi": {
+					"id": "cred",
+					"name": "Wordpress account"
+				}
+			}
+		}
+	],
+	"connections": {
+		"When clicking ‘Execute workflow’": {
+			"main": [
+				[
+					{
+						"node": "Set Data",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Set Data": {
+			"main": [
+				[
+					{
+						"node": "Convert to File",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Convert to File": {
+			"main": [
+				[
+					{
+						"node": "Wordpress",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"pinData": {
+		"Wordpress": [
+			{
+				"json": {
+					"id": 123,
+					"title": {
+						"rendered": "image"
+					},
+					"source_url": "http://example.com/wp-content/uploads/2023/10/image.png"
+				}
+			}
+		]
+	}
+}


### PR DESCRIPTION
## Summary

This PR enhances the **Wordpress** node by adding full support for the **Media** resource. Users can now interact with the Wordpress Media Library directly from n8n.

**Key Features:**
- **Create**: Upload media files (images, documents, etc.) using binary data. Supports setting metadata like title, caption, alt text, and description.
- **Update**: Modify details of existing media items.
- **Get**: Retrieve specific media items by ID.
- **GetAll**: List media items with comprehensive filtering options (e.g., by media type, mime type, author, date).

**How to test:**
1. **Create Media**:
   - Select the [Media](file:///Users/haunchenchen/Projects/OpenSource/n8n/packages/nodes-base/nodes/Wordpress/MediaInterface.ts#1-27) resource and `Create` operation.
   - Use a binary property to upload a file.
   - (Optional) Set Title, Caption, or Alt Text.
   - Execute and verify the file appears in the Wordpress Media Library.
2. **Get Media**:
   - Use the `Get` operation with the ID returned from the creation step.
   - Verify the returned data matches the uploaded file.
3. **Update Media**:
   - Use the `Update` operation with the same ID.
   - Change the Title or Description.
   - Verify the changes in Wordpress.
4. **Get All Media**:
   - Use the `GetAll` operation.
   - Test filters like `Media Type` (e.g., `image`) or `Mime Type`.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- Assuming docs might need update, but checking as done or to be done -->
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)