### PR TITLE
feat(core): Add toolCode nodes to the pyodide check for v2 migration

### DIFF
--- a/packages/cli/src/modules/breaking-changes/rules/v2/pyodide-removed.rule.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/v2/pyodide-removed.rule.ts
@@ -55,13 +55,14 @@ export class PyodideRemovedRule implements IBreakingChangeWorkflowRule {
 	): Promise<WorkflowDetectionReport> {
 		// Get all Code nodes (the Code node supports both JavaScript and Python)
 		const codeNodes = nodesGroupedByType.get('n8n-nodes-base.code') ?? [];
+		const codeToolNodes = nodesGroupedByType.get('@n8n/n8n-nodes-langchain.toolCode') ?? [];
 
 		// Filter for Code nodes using the Pyodide-based Python implementation
 		// The 'language' parameter determines which language/implementation is used:
 		// - 'python' = Pyodide (being removed)
 		// - 'pythonNative' = Task runner (new implementation)
 		// - 'javaScript' = JavaScript (not affected)
-		const affectedNodes = codeNodes.filter((node) => {
+		const affectedNodes = codeNodes.concat(codeToolNodes).filter((node) => {
 			const language = node.parameters?.language;
 			// Nodes with language='python' use Pyodide and are affected
 			return language === 'python';


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR adds `'@n8n/n8n-nodes-langchain.toolCode` nodes to the `PyodideRemovedRule` v2 migration rules.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/CAT-1862/add-toolcode-into-migration-report-for-python

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
