### PR TITLE
chore(core): Implement generic credential storage provider

### DIFF
--- a/packages/@n8n/backend-test-utils/src/test-db.ts
+++ b/packages/@n8n/backend-test-utils/src/test-db.ts
@@ -87,7 +87,9 @@ type EntityName =
 	| 'AuthorizationCode'
 	| 'AccessToken'
 	| 'RefreshToken'
-	| 'UserConsent';
+	| 'UserConsent'
+	| 'DynamicCredentialEntry'
+	| 'DynamicCredentialResolver';
 
 /**
  * Truncate specific DB tables in a test DB.

--- a/packages/@n8n/db/src/migrations/common/1764689388394-AddDynamicCredentialEntryTable.ts
+++ b/packages/@n8n/db/src/migrations/common/1764689388394-AddDynamicCredentialEntryTable.ts
@@ -1,0 +1,31 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+const tableName = 'dynamic_credential_entry';
+
+export class AddDynamicCredentialEntryTable1764689388394 implements ReversibleMigration {
+	async up({ schemaBuilder: { createTable, column } }: MigrationContext) {
+		await createTable(tableName)
+			.withColumns(
+				column('credential_id').varchar(16).primary.notNull,
+				column('subject_id').varchar(16).primary.notNull,
+				column('resolver_id').varchar(16).primary.notNull,
+				column('data').text.notNull,
+			)
+			.withTimestamps.withForeignKey('credential_id', {
+				tableName: 'credentials_entity',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			})
+			.withForeignKey('resolver_id', {
+				tableName: 'dynamic_credential_resolver',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			})
+			.withIndexOn(['credential_id'])
+			.withIndexOn(['resolver_id']);
+	}
+
+	async down({ schemaBuilder: { dropTable } }: MigrationContext) {
+		await dropTable(tableName);
+	}
+}

--- a/packages/@n8n/db/src/migrations/common/1764689388394-AddDynamicCredentialEntryTable.ts
+++ b/packages/@n8n/db/src/migrations/common/1764689388394-AddDynamicCredentialEntryTable.ts
@@ -21,7 +21,7 @@ export class AddDynamicCredentialEntryTable1764689388394 implements ReversibleMi
 				columnName: 'id',
 				onDelete: 'CASCADE',
 			})
-			.withIndexOn(['credential_id'])
+			.withIndexOn(['subject_id'])
 			.withIndexOn(['resolver_id']);
 	}
 

--- a/packages/@n8n/db/src/migrations/mysqldb/index.ts
+++ b/packages/@n8n/db/src/migrations/mysqldb/index.ts
@@ -121,6 +121,7 @@ import { CreateBinaryDataTable1763716655000 } from '../common/1763716655000-Crea
 import { CreateWorkflowPublishHistoryTable1764167920585 } from '../common/1764167920585-CreateWorkflowPublishHistoryTable';
 import { AddCreatorIdToProjectTable1764276827837 } from '../common/1764276827837-AddCreatorIdToProjectTable';
 import { CreateDynamicCredentialResolverTable1764682447000 } from '../common/1764682447000-CreateCredentialResolverTable';
+import { AddDynamicCredentialEntryTable1764689388394 } from '../common/1764689388394-AddDynamicCredentialEntryTable';
 import type { Migration } from '../migration-types';
 
 export const mysqlMigrations: Migration[] = [
@@ -247,4 +248,5 @@ export const mysqlMigrations: Migration[] = [
 	CreateWorkflowPublishHistoryTable1764167920585,
 	AddCreatorIdToProjectTable1764276827837,
 	CreateDynamicCredentialResolverTable1764682447000,
+	AddDynamicCredentialEntryTable1764689388394,
 ];

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -121,6 +121,7 @@ import { CreateBinaryDataTable1763716655000 } from '../common/1763716655000-Crea
 import { CreateWorkflowPublishHistoryTable1764167920585 } from '../common/1764167920585-CreateWorkflowPublishHistoryTable';
 import { AddCreatorIdToProjectTable1764276827837 } from '../common/1764276827837-AddCreatorIdToProjectTable';
 import { CreateDynamicCredentialResolverTable1764682447000 } from '../common/1764682447000-CreateCredentialResolverTable';
+import { AddDynamicCredentialEntryTable1764689388394 } from '../common/1764689388394-AddDynamicCredentialEntryTable';
 import type { Migration } from '../migration-types';
 
 export const postgresMigrations: Migration[] = [
@@ -247,4 +248,5 @@ export const postgresMigrations: Migration[] = [
 	CreateWorkflowPublishHistoryTable1764167920585,
 	AddCreatorIdToProjectTable1764276827837,
 	CreateDynamicCredentialResolverTable1764682447000,
+	AddDynamicCredentialEntryTable1764689388394,
 ];

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -117,6 +117,7 @@ import { ChangeOAuthStateColumnToUnboundedVarchar1763572724000 } from '../common
 import { CreateBinaryDataTable1763716655000 } from '../common/1763716655000-CreateBinaryDataTable';
 import { CreateWorkflowPublishHistoryTable1764167920585 } from '../common/1764167920585-CreateWorkflowPublishHistoryTable';
 import { CreateDynamicCredentialResolverTable1764682447000 } from '../common/1764682447000-CreateCredentialResolverTable';
+import { AddDynamicCredentialEntryTable1764689388394 } from '../common/1764689388394-AddDynamicCredentialEntryTable';
 import type { Migration } from '../migration-types';
 
 const sqliteMigrations: Migration[] = [
@@ -239,6 +240,7 @@ const sqliteMigrations: Migration[] = [
 	CreateWorkflowPublishHistoryTable1764167920585,
 	AddCreatorIdToProjectTable1764276827837,
 	CreateDynamicCredentialResolverTable1764682447000,
+	AddDynamicCredentialEntryTable1764689388394,
 ];
 
 export { sqliteMigrations };

--- a/packages/@n8n/decorators/src/module/module.ts
+++ b/packages/@n8n/decorators/src/module/module.ts
@@ -16,13 +16,18 @@ export interface BaseEntity {
 	reload(): Promise<void>;
 }
 
-export interface TimestampedEntity {
+export interface TimestampedIdEntity {
 	id: string;
 	createdAt: Date;
 	updatedAt: Date;
 }
 
-export type EntityClass = new () => BaseEntity | TimestampedEntity;
+export interface TimestampedEntity {
+	createdAt: Date;
+	updatedAt: Date;
+}
+
+export type EntityClass = new () => BaseEntity | TimestampedIdEntity | TimestampedEntity;
 
 export type ModuleSettings = Record<string, unknown>;
 export type ModuleContext = Record<string, unknown>;

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/storage/dynamic-credential-entry-storage.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/storage/dynamic-credential-entry-storage.ts
@@ -1,0 +1,64 @@
+import { Service } from '@n8n/di';
+
+import { ICredentialEntriesStorage } from './storage-interface';
+import { DynamicCredentialEntry } from '../../database/entities/dynamic-credential-entry';
+import { DynamicCredentialEntryRepository } from '../../database/repositories/dynamic-credential-entry.repository';
+
+@Service()
+export class DynamicCredentialEntryStorage implements ICredentialEntriesStorage {
+	constructor(
+		private readonly dynamicCredentialEntryRepository: DynamicCredentialEntryRepository,
+	) {}
+
+	async getCredentialData(
+		credentialId: string,
+		subjectId: string,
+		resolverId: string,
+		_: Record<string, unknown>,
+	): Promise<string | null> {
+		const entry = await this.dynamicCredentialEntryRepository.findOne({
+			where: {
+				credentialId,
+				subjectId,
+				resolverId,
+			},
+		});
+
+		return entry?.data ?? null;
+	}
+
+	async setCredentialData(
+		credentialId: string,
+		subjectId: string,
+		resolverId: string,
+		data: string,
+		_: Record<string, unknown>,
+	): Promise<void> {
+		let entry = await this.dynamicCredentialEntryRepository.findOne({
+			where: { credentialId, subjectId, resolverId },
+		});
+
+		if (!entry) {
+			entry = new DynamicCredentialEntry();
+			entry.credentialId = credentialId;
+			entry.subjectId = subjectId;
+			entry.resolverId = resolverId;
+		}
+
+		entry.data = data;
+		await this.dynamicCredentialEntryRepository.save(entry);
+	}
+
+	async deleteCredentialData(
+		credentialId: string,
+		subjectId: string,
+		resolverId: string,
+		_: Record<string, unknown>,
+	): Promise<void> {
+		await this.dynamicCredentialEntryRepository.delete({
+			credentialId,
+			subjectId,
+			resolverId,
+		});
+	}
+}

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/storage/storage-interface.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/storage/storage-interface.ts
@@ -1,0 +1,38 @@
+export interface ICredentialEntriesStorage {
+	/**
+	 * Retrieves credential data for a specific entity from storage.
+	 *
+	 * @returns The credential data object, or null if not found
+	 * @throws {Error} When storage operation fails
+	 */
+	getCredentialData(
+		credentialId: string,
+		subjectId: string,
+		resolverId: string,
+		storageOptions: Record<string, unknown>,
+	): Promise<string | null>;
+
+	/**
+	 * Stores credential data for a specific entity in storage.
+	 * @throws {Error} When storage operation fails
+	 */
+	setCredentialData(
+		credentialId: string,
+		subjectId: string,
+		resolverId: string,
+		data: string,
+		storageOptions: Record<string, unknown>,
+	): Promise<void>;
+
+	/**
+	 * Deletes credential data for a specific entity from storage.
+	 * Optional - not all storage implementations support deletion.
+	 * @throws {Error} When deletion operation fails
+	 */
+	deleteCredentialData?(
+		credentialId: string,
+		subjectId: string,
+		resolverId: string,
+		storageOptions: Record<string, unknown>,
+	): Promise<void>;
+}

--- a/packages/cli/src/modules/dynamic-credentials.ee/database/entities/dynamic-credential-entry.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/database/entities/dynamic-credential-entry.ts
@@ -29,11 +29,11 @@ export class DynamicCredentialEntry extends WithTimestamps {
 	@Column('text')
 	data: string;
 
-	@ManyToOne(() => CredentialsEntity)
+	@ManyToOne(() => CredentialsEntity, { onDelete: 'CASCADE' })
 	@JoinColumn({ name: 'credential_id' })
 	credential: CredentialsEntity;
 
-	@ManyToOne(() => DynamicCredentialResolver)
+	@ManyToOne(() => DynamicCredentialResolver, { onDelete: 'CASCADE' })
 	@JoinColumn({ name: 'resolver_id' })
 	resolver: DynamicCredentialResolver;
 }

--- a/packages/cli/src/modules/dynamic-credentials.ee/database/entities/dynamic-credential-entry.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/database/entities/dynamic-credential-entry.ts
@@ -1,0 +1,39 @@
+import { CredentialsEntity, WithTimestamps } from '@n8n/db';
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from '@n8n/typeorm';
+
+import { DynamicCredentialResolver } from './credential-resolver';
+
+@Entity({
+	name: 'dynamic_credential_entry',
+})
+export class DynamicCredentialEntry extends WithTimestamps {
+	constructor() {
+		super();
+	}
+
+	@PrimaryColumn({
+		name: 'credential_id',
+	})
+	credentialId: string;
+
+	@PrimaryColumn({
+		name: 'subject_id',
+	})
+	subjectId: string;
+
+	@PrimaryColumn({
+		name: 'resolver_id',
+	})
+	resolverId: string;
+
+	@Column('text')
+	data: string;
+
+	@ManyToOne(() => CredentialsEntity)
+	@JoinColumn({ name: 'credential_id' })
+	credential: CredentialsEntity;
+
+	@ManyToOne(() => DynamicCredentialResolver)
+	@JoinColumn({ name: 'resolver_id' })
+	resolver: DynamicCredentialResolver;
+}

--- a/packages/cli/src/modules/dynamic-credentials.ee/database/repositories/dynamic-credential-entry.repository.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/database/repositories/dynamic-credential-entry.repository.ts
@@ -1,0 +1,11 @@
+import { Service } from '@n8n/di';
+import { DataSource, Repository } from '@n8n/typeorm';
+
+import { DynamicCredentialEntry } from '../entities/dynamic-credential-entry';
+
+@Service()
+export class DynamicCredentialEntryRepository extends Repository<DynamicCredentialEntry> {
+	constructor(dataSource: DataSource) {
+		super(DynamicCredentialEntry, dataSource.manager);
+	}
+}

--- a/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.module.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.module.ts
@@ -14,8 +14,9 @@ export class DynamicCredentialsModule implements ModuleInterface {
 
 	async entities() {
 		const { DynamicCredentialResolver } = await import('./database/entities/credential-resolver');
+		const { DynamicCredentialEntry } = await import('./database/entities/dynamic-credential-entry');
 
-		return [DynamicCredentialResolver];
+		return [DynamicCredentialResolver, DynamicCredentialEntry];
 	}
 
 	@OnShutdown()

--- a/packages/cli/test/integration/dynamic-credentials/dynamic-credential-entry-storage.test.ts
+++ b/packages/cli/test/integration/dynamic-credentials/dynamic-credential-entry-storage.test.ts
@@ -1,0 +1,263 @@
+import { testDb, testModules } from '@n8n/backend-test-utils';
+import { Container } from '@n8n/di';
+
+import { DynamicCredentialEntryStorage } from '@/modules/dynamic-credentials.ee/credential-resolvers/storage/dynamic-credential-entry-storage';
+
+import { createCredentials } from '../shared/db/credentials';
+import { createDynamicCredentialResolver } from './shared/db-helpers';
+
+describe('DynamicCredentialEntryStorage', () => {
+	let storage: DynamicCredentialEntryStorage;
+
+	beforeAll(async () => {
+		await testModules.loadModules(['dynamic-credentials']);
+		await testDb.init();
+		storage = Container.get(DynamicCredentialEntryStorage);
+	});
+
+	afterAll(async () => {
+		await testDb.terminate();
+	});
+
+	beforeEach(async () => {
+		await testDb.truncate([
+			'DynamicCredentialEntry',
+			'DynamicCredentialResolver',
+			'CredentialsEntity',
+		]);
+	});
+
+	it('should store and retrieve credential data', async () => {
+		// ARRANGE
+		const credential = await createCredentials({
+			name: 'Test Credential',
+			type: 'testType',
+			data: 'test-data',
+		});
+		const resolver = await createDynamicCredentialResolver({
+			name: 'test-resolver',
+			type: 'test',
+			config: 'test-data',
+		});
+
+		const testData = 'encrypted-credential-data';
+
+		// ACT - Store
+		await storage.setCredentialData(credential.id, 'test-subject', resolver.id, testData, {});
+
+		// ACT - Retrieve
+		const retrievedData = await storage.getCredentialData(
+			credential.id,
+			'test-subject',
+			resolver.id,
+			{},
+		);
+
+		// ASSERT
+		expect(retrievedData).toBe(testData);
+	});
+
+	it('should update existing credential data (upsert)', async () => {
+		// ARRANGE
+		const credential = await createCredentials({
+			name: 'Test Credential',
+			type: 'testType',
+			data: 'test-data',
+		});
+		const resolver = await createDynamicCredentialResolver({
+			name: 'test-resolver',
+			type: 'test',
+			config: 'test-data',
+		});
+
+		// ACT - Insert
+		await storage.setCredentialData(
+			credential.id,
+			'upsert-subject',
+			resolver.id,
+			'original-data',
+			{},
+		);
+
+		// ACT - Update
+		await storage.setCredentialData(
+			credential.id,
+			'upsert-subject',
+			resolver.id,
+			'updated-data',
+			{},
+		);
+
+		// ACT - Retrieve
+		const data = await storage.getCredentialData(credential.id, 'upsert-subject', resolver.id, {});
+
+		// ASSERT
+		expect(data).toBe('updated-data');
+	});
+
+	it('should delete credential data', async () => {
+		// ARRANGE
+		const credential = await createCredentials({
+			name: 'Test Credential',
+			type: 'testType',
+			data: 'test-data',
+		});
+		const resolver = await createDynamicCredentialResolver({
+			name: 'test-resolver',
+			type: 'test',
+			config: 'test-data',
+		});
+
+		const testData = 'data-to-delete';
+
+		// Store data first
+		await storage.setCredentialData(credential.id, 'delete-subject', resolver.id, testData, {});
+
+		// Verify it exists
+		const beforeDelete = await storage.getCredentialData(
+			credential.id,
+			'delete-subject',
+			resolver.id,
+			{},
+		);
+		expect(beforeDelete).toBe(testData);
+
+		// ACT - Delete
+		await storage.deleteCredentialData(credential.id, 'delete-subject', resolver.id, {});
+
+		// ASSERT - Verify it's gone
+		const afterDelete = await storage.getCredentialData(
+			credential.id,
+			'delete-subject',
+			resolver.id,
+			{},
+		);
+		expect(afterDelete).toBeNull();
+	});
+
+	it('should isolate entries by composite key (multiple entries do not affect each other)', async () => {
+		// ARRANGE
+		const credential1 = await createCredentials({
+			name: 'Credential 1',
+			type: 'testType',
+			data: 'test-data-1',
+		});
+		const credential2 = await createCredentials({
+			name: 'Credential 2',
+			type: 'testType',
+			data: 'test-data-2',
+		});
+		const resolver1 = await createDynamicCredentialResolver({
+			name: 'resolver-1',
+			type: 'test',
+			config: 'test-config-1',
+		});
+		const resolver2 = await createDynamicCredentialResolver({
+			name: 'resolver-2',
+			type: 'test',
+			config: 'test-config-2',
+		});
+
+		// ACT - Create multiple entries with different combinations
+		// Same credential, different subjects
+		await storage.setCredentialData(
+			credential1.id,
+			'subject-A',
+			resolver1.id,
+			'data-cred1-subjA-res1',
+			{},
+		);
+		await storage.setCredentialData(
+			credential1.id,
+			'subject-B',
+			resolver1.id,
+			'data-cred1-subjB-res1',
+			{},
+		);
+
+		// Same credential and subject, different resolver
+		await storage.setCredentialData(
+			credential1.id,
+			'subject-A',
+			resolver2.id,
+			'data-cred1-subjA-res2',
+			{},
+		);
+
+		// Different credential, same subject and resolver
+		await storage.setCredentialData(
+			credential2.id,
+			'subject-A',
+			resolver1.id,
+			'data-cred2-subjA-res1',
+			{},
+		);
+
+		// ASSERT - Each entry should be isolated and return correct data
+		const data1 = await storage.getCredentialData(credential1.id, 'subject-A', resolver1.id, {});
+		expect(data1).toBe('data-cred1-subjA-res1');
+
+		const data2 = await storage.getCredentialData(credential1.id, 'subject-B', resolver1.id, {});
+		expect(data2).toBe('data-cred1-subjB-res1');
+
+		const data3 = await storage.getCredentialData(credential1.id, 'subject-A', resolver2.id, {});
+		expect(data3).toBe('data-cred1-subjA-res2');
+
+		const data4 = await storage.getCredentialData(credential2.id, 'subject-A', resolver1.id, {});
+		expect(data4).toBe('data-cred2-subjA-res1');
+
+		// ACT - Update one entry
+		await storage.setCredentialData(
+			credential1.id,
+			'subject-A',
+			resolver1.id,
+			'updated-data-cred1-subjA-res1',
+			{},
+		);
+
+		// ASSERT - Only the updated entry should change, others remain unchanged
+		const updatedData1 = await storage.getCredentialData(
+			credential1.id,
+			'subject-A',
+			resolver1.id,
+			{},
+		);
+		expect(updatedData1).toBe('updated-data-cred1-subjA-res1');
+
+		const unchangedData2 = await storage.getCredentialData(
+			credential1.id,
+			'subject-B',
+			resolver1.id,
+			{},
+		);
+		expect(unchangedData2).toBe('data-cred1-subjB-res1');
+
+		const unchangedData3 = await storage.getCredentialData(
+			credential1.id,
+			'subject-A',
+			resolver2.id,
+			{},
+		);
+		expect(unchangedData3).toBe('data-cred1-subjA-res2');
+
+		// ACT - Delete one entry
+		await storage.deleteCredentialData(credential1.id, 'subject-A', resolver1.id, {});
+
+		// ASSERT - Deleted entry should be gone, others remain
+		const deletedData = await storage.getCredentialData(
+			credential1.id,
+			'subject-A',
+			resolver1.id,
+			{},
+		);
+		expect(deletedData).toBeNull();
+
+		const stillExistingData = await storage.getCredentialData(
+			credential1.id,
+			'subject-B',
+			resolver1.id,
+			{},
+		);
+		expect(stillExistingData).toBe('data-cred1-subjB-res1');
+	});
+});

--- a/packages/cli/test/integration/dynamic-credentials/dynamic-credential-entry.repository.test.ts
+++ b/packages/cli/test/integration/dynamic-credentials/dynamic-credential-entry.repository.test.ts
@@ -178,4 +178,282 @@ describe('DynamicCredentialEntryRepository', () => {
 		});
 		expect(entriesAfterDelete).toHaveLength(0);
 	});
+
+	it('should fetch CredentialsEntity through ManyToOne relationship', async () => {
+		// ARRANGE
+		const credential = await createCredentials({
+			name: 'Test Credential for Relationship',
+			type: 'testType',
+			data: 'test-data',
+		});
+		const resolver = await createDynamicCredentialResolver({
+			name: 'test-resolver',
+			type: 'test',
+			config: 'test-data',
+		});
+
+		const entry = new DynamicCredentialEntry();
+		entry.credentialId = credential.id;
+		entry.subjectId = 'subject-123';
+		entry.resolverId = resolver.id;
+		entry.data = 'encrypted-test-data';
+
+		await repository.save(entry);
+
+		// ACT - Fetch entry with credential relationship loaded
+		const foundEntry = await repository.findOne({
+			where: {
+				credentialId: credential.id,
+				subjectId: 'subject-123',
+				resolverId: resolver.id,
+			},
+			relations: ['credential'],
+		});
+
+		// ASSERT
+		expect(foundEntry).toBeDefined();
+		expect(foundEntry?.credential).toBeDefined();
+		expect(foundEntry?.credential.id).toBe(credential.id);
+		expect(foundEntry?.credential.name).toBe('Test Credential for Relationship');
+		expect(foundEntry?.credential.type).toBe('testType');
+	});
+
+	it('should fetch DynamicCredentialResolver through ManyToOne relationship', async () => {
+		// ARRANGE
+		const credential = await createCredentials({
+			name: 'Test Credential',
+			type: 'testType',
+			data: 'test-data',
+		});
+		const resolver = await createDynamicCredentialResolver({
+			name: 'test-resolver-for-relationship',
+			type: 'test-type',
+			config: 'test-config-data',
+		});
+
+		const entry = new DynamicCredentialEntry();
+		entry.credentialId = credential.id;
+		entry.subjectId = 'subject-456';
+		entry.resolverId = resolver.id;
+		entry.data = 'encrypted-test-data';
+
+		await repository.save(entry);
+
+		// ACT - Fetch entry with resolver relationship loaded
+		const foundEntry = await repository.findOne({
+			where: {
+				credentialId: credential.id,
+				subjectId: 'subject-456',
+				resolverId: resolver.id,
+			},
+			relations: ['resolver'],
+		});
+
+		// ASSERT
+		expect(foundEntry).toBeDefined();
+		expect(foundEntry?.resolver).toBeDefined();
+		expect(foundEntry?.resolver.id).toBe(resolver.id);
+		expect(foundEntry?.resolver.name).toBe('test-resolver-for-relationship');
+		expect(foundEntry?.resolver.type).toBe('test-type');
+	});
+
+	it('should filter entries by credential type using find method', async () => {
+		// ARRANGE
+		const credential1 = await createCredentials({
+			name: 'OAuth Credential',
+			type: 'oAuth2Api',
+			data: 'oauth-data',
+		});
+		const credential2 = await createCredentials({
+			name: 'API Key Credential',
+			type: 'apiKeyAuth',
+			data: 'api-key-data',
+		});
+		const credential3 = await createCredentials({
+			name: 'Another OAuth Credential',
+			type: 'oAuth2Api',
+			data: 'oauth-data-2',
+		});
+		const resolver = await createDynamicCredentialResolver({
+			name: 'test-resolver',
+			type: 'test',
+			config: 'test-data',
+		});
+
+		// Create entries for different credential types
+		const entry1 = new DynamicCredentialEntry();
+		entry1.credentialId = credential1.id;
+		entry1.subjectId = 'subject-1';
+		entry1.resolverId = resolver.id;
+		entry1.data = 'data-1';
+
+		const entry2 = new DynamicCredentialEntry();
+		entry2.credentialId = credential2.id;
+		entry2.subjectId = 'subject-2';
+		entry2.resolverId = resolver.id;
+		entry2.data = 'data-2';
+
+		const entry3 = new DynamicCredentialEntry();
+		entry3.credentialId = credential3.id;
+		entry3.subjectId = 'subject-3';
+		entry3.resolverId = resolver.id;
+		entry3.data = 'data-3';
+
+		await repository.save([entry1, entry2, entry3]);
+
+		// ACT - Query entries where credential type is 'oAuth2Api'
+		const oauthEntries = await repository.find({
+			where: {
+				credential: {
+					type: 'oAuth2Api',
+				},
+			},
+			relations: ['credential'],
+		});
+
+		// ASSERT
+		expect(oauthEntries).toHaveLength(2);
+		expect(oauthEntries.every((entry) => entry.credential.type === 'oAuth2Api')).toBe(true);
+		expect(oauthEntries.map((e) => e.subjectId).sort()).toEqual(['subject-1', 'subject-3']);
+	});
+
+	it('should filter entries by resolver type using find method', async () => {
+		// ARRANGE
+		const credential = await createCredentials({
+			name: 'Test Credential',
+			type: 'testType',
+			data: 'test-data',
+		});
+		const resolver1 = await createDynamicCredentialResolver({
+			name: 'AWS Resolver',
+			type: 'aws-secrets-manager',
+			config: 'aws-config',
+		});
+		const resolver2 = await createDynamicCredentialResolver({
+			name: 'Azure Resolver',
+			type: 'azure-key-vault',
+			config: 'azure-config',
+		});
+		const resolver3 = await createDynamicCredentialResolver({
+			name: 'Another AWS Resolver',
+			type: 'aws-secrets-manager',
+			config: 'aws-config-2',
+		});
+
+		// Create entries for different resolver types
+		const entry1 = new DynamicCredentialEntry();
+		entry1.credentialId = credential.id;
+		entry1.subjectId = 'subject-1';
+		entry1.resolverId = resolver1.id;
+		entry1.data = 'data-1';
+
+		const entry2 = new DynamicCredentialEntry();
+		entry2.credentialId = credential.id;
+		entry2.subjectId = 'subject-2';
+		entry2.resolverId = resolver2.id;
+		entry2.data = 'data-2';
+
+		const entry3 = new DynamicCredentialEntry();
+		entry3.credentialId = credential.id;
+		entry3.subjectId = 'subject-3';
+		entry3.resolverId = resolver3.id;
+		entry3.data = 'data-3';
+
+		await repository.save([entry1, entry2, entry3]);
+
+		// ACT - Query entries where resolver type is 'aws-secrets-manager'
+		const awsEntries = await repository.find({
+			where: {
+				resolver: {
+					type: 'aws-secrets-manager',
+				},
+			},
+			relations: ['resolver'],
+		});
+
+		// ASSERT
+		expect(awsEntries).toHaveLength(2);
+		expect(awsEntries.every((entry) => entry.resolver.type === 'aws-secrets-manager')).toBe(true);
+		expect(awsEntries.map((e) => e.subjectId).sort()).toEqual(['subject-1', 'subject-3']);
+	});
+
+	it('should filter entries by both credential type and resolver type using find method', async () => {
+		// ARRANGE
+		const credential1 = await createCredentials({
+			name: 'OAuth Credential 1',
+			type: 'oAuth2Api',
+			data: 'oauth-data-1',
+		});
+		const credential2 = await createCredentials({
+			name: 'OAuth Credential 2',
+			type: 'oAuth2Api',
+			data: 'oauth-data-2',
+		});
+		const credential3 = await createCredentials({
+			name: 'API Key Credential',
+			type: 'apiKeyAuth',
+			data: 'api-key-data',
+		});
+
+		const resolver1 = await createDynamicCredentialResolver({
+			name: 'AWS Resolver',
+			type: 'aws-secrets-manager',
+			config: 'aws-config',
+		});
+		const resolver2 = await createDynamicCredentialResolver({
+			name: 'Azure Resolver',
+			type: 'azure-key-vault',
+			config: 'azure-config',
+		});
+
+		// Create entries with various combinations
+		const entry1 = new DynamicCredentialEntry();
+		entry1.credentialId = credential1.id;
+		entry1.subjectId = 'subject-1';
+		entry1.resolverId = resolver1.id;
+		entry1.data = 'data-1';
+
+		const entry2 = new DynamicCredentialEntry();
+		entry2.credentialId = credential1.id;
+		entry2.subjectId = 'subject-2';
+		entry2.resolverId = resolver2.id;
+		entry2.data = 'data-2';
+
+		const entry3 = new DynamicCredentialEntry();
+		entry3.credentialId = credential2.id;
+		entry3.subjectId = 'subject-3';
+		entry3.resolverId = resolver1.id;
+		entry3.data = 'data-3';
+
+		const entry4 = new DynamicCredentialEntry();
+		entry4.credentialId = credential3.id;
+		entry4.subjectId = 'subject-4';
+		entry4.resolverId = resolver1.id;
+		entry4.data = 'data-4';
+
+		await repository.save([entry1, entry2, entry3, entry4]);
+
+		// ACT - Query entries where credential type is 'oAuth2Api' AND resolver type is 'aws-secrets-manager'
+		const filteredEntries = await repository.find({
+			where: {
+				credential: {
+					type: 'oAuth2Api',
+				},
+				resolver: {
+					type: 'aws-secrets-manager',
+				},
+			},
+			relations: ['credential', 'resolver'],
+		});
+
+		// ASSERT - Should only return entries with both OAuth credentials and AWS resolver
+		expect(filteredEntries).toHaveLength(2);
+		expect(
+			filteredEntries.every(
+				(entry) =>
+					entry.credential.type === 'oAuth2Api' && entry.resolver.type === 'aws-secrets-manager',
+			),
+		).toBe(true);
+		expect(filteredEntries.map((e) => e.subjectId).sort()).toEqual(['subject-1', 'subject-3']);
+	});
 });

--- a/packages/cli/test/integration/dynamic-credentials/dynamic-credential-entry.repository.test.ts
+++ b/packages/cli/test/integration/dynamic-credentials/dynamic-credential-entry.repository.test.ts
@@ -1,0 +1,181 @@
+import { testDb, testModules } from '@n8n/backend-test-utils';
+import { CredentialsRepository } from '@n8n/db';
+import { Container } from '@n8n/di';
+
+import { DynamicCredentialEntryRepository } from '@/modules/dynamic-credentials.ee/database/repositories/dynamic-credential-entry.repository';
+import { DynamicCredentialEntry } from '@/modules/dynamic-credentials.ee/database/entities/dynamic-credential-entry';
+import { DynamicCredentialResolverRepository } from '@/modules/dynamic-credentials.ee/database/repositories/credential-resolver.repository';
+
+import { createCredentials } from '../shared/db/credentials';
+import { createDynamicCredentialResolver } from './shared/db-helpers';
+
+describe('DynamicCredentialEntryRepository', () => {
+	let repository: DynamicCredentialEntryRepository;
+
+	beforeAll(async () => {
+		await testModules.loadModules(['dynamic-credentials']);
+		await testDb.init();
+		repository = Container.get(DynamicCredentialEntryRepository);
+	});
+
+	afterAll(async () => {
+		await testDb.terminate();
+	});
+
+	beforeEach(async () => {
+		await testDb.truncate([
+			'DynamicCredentialEntry',
+			'DynamicCredentialResolver',
+			'CredentialsEntity',
+		]);
+	});
+
+	it('should save and retrieve a dynamic credential entry', async () => {
+		// ARRANGE
+		const credential = await createCredentials({
+			name: 'Test Credential',
+			type: 'testType',
+			data: 'test-data',
+		});
+		const resolver = await createDynamicCredentialResolver({
+			name: 'test-resolver',
+			type: 'test',
+			config: 'test-data',
+		});
+
+		const entry = new DynamicCredentialEntry();
+		entry.credentialId = credential.id;
+		entry.subjectId = 'subject-123';
+		entry.resolverId = resolver.id;
+		entry.data = 'encrypted-test-data';
+
+		// ACT
+		const savedEntry = await repository.save(entry);
+
+		// Retrieve it back
+		const foundEntry = await repository.findOne({
+			where: {
+				credentialId: credential.id,
+				subjectId: 'subject-123',
+				resolverId: resolver.id,
+			},
+		});
+
+		// ASSERT
+		expect(savedEntry).toBeDefined();
+		expect(savedEntry.credentialId).toBe(credential.id);
+		expect(savedEntry.subjectId).toBe('subject-123');
+		expect(savedEntry.resolverId).toBe(resolver.id);
+		expect(savedEntry.data).toBe('encrypted-test-data');
+		expect(savedEntry.createdAt).toBeInstanceOf(Date);
+		expect(savedEntry.updatedAt).toBeInstanceOf(Date);
+
+		expect(foundEntry).toBeDefined();
+		expect(foundEntry?.data).toBe('encrypted-test-data');
+	});
+
+	it('should cascade delete entries when credential is deleted', async () => {
+		// ARRANGE
+		const credential = await createCredentials({
+			name: 'Test Credential',
+			type: 'testType',
+			data: 'test-data',
+		});
+		const resolver = await createDynamicCredentialResolver({
+			name: 'test-resolver',
+			type: 'test',
+			config: 'test-data',
+		});
+
+		// Create multiple entries for the same credential
+		const entry1 = new DynamicCredentialEntry();
+		entry1.credentialId = credential.id;
+		entry1.subjectId = 'subject-1';
+		entry1.resolverId = resolver.id;
+		entry1.data = 'data-1';
+
+		const entry2 = new DynamicCredentialEntry();
+		entry2.credentialId = credential.id;
+		entry2.subjectId = 'subject-2';
+		entry2.resolverId = resolver.id;
+		entry2.data = 'data-2';
+
+		await repository.save(entry1);
+		await repository.save(entry2);
+
+		// Verify entries exist
+		const entriesBeforeDelete = await repository.find({
+			where: {
+				credentialId: credential.id,
+			},
+		});
+		expect(entriesBeforeDelete).toHaveLength(2);
+
+		// ACT - Delete the credential
+		const credentialsRepository = Container.get(CredentialsRepository);
+		await credentialsRepository.delete({ id: credential.id });
+
+		// ASSERT - All entries for this credential should be cascade deleted
+		const entriesAfterDelete = await repository.find({
+			where: {
+				credentialId: credential.id,
+			},
+		});
+		expect(entriesAfterDelete).toHaveLength(0);
+	});
+
+	it('should cascade delete entries when resolver is deleted', async () => {
+		// ARRANGE
+		const credential1 = await createCredentials({
+			name: 'Credential 1',
+			type: 'testType',
+			data: 'test-data-1',
+		});
+		const credential2 = await createCredentials({
+			name: 'Credential 2',
+			type: 'testType',
+			data: 'test-data-2',
+		});
+		const resolver = await createDynamicCredentialResolver({
+			name: 'test-resolver',
+			type: 'test',
+			config: 'test-data',
+		});
+
+		// Create entries for multiple credentials using the same resolver
+		const entry1 = new DynamicCredentialEntry();
+		entry1.credentialId = credential1.id;
+		entry1.subjectId = 'subject-1';
+		entry1.resolverId = resolver.id;
+		entry1.data = 'data-1';
+
+		const entry2 = new DynamicCredentialEntry();
+		entry2.credentialId = credential2.id;
+		entry2.subjectId = 'subject-2';
+		entry2.resolverId = resolver.id;
+		entry2.data = 'data-2';
+
+		await repository.save(entry1);
+		await repository.save(entry2);
+
+		// Verify entries exist
+		const entriesBeforeDelete = await repository.find({
+			where: {
+				resolverId: resolver.id,
+			},
+		});
+		expect(entriesBeforeDelete).toHaveLength(2);
+
+		// ACT - Delete the resolver
+		const resolverRepository = Container.get(DynamicCredentialResolverRepository);
+		await resolverRepository.delete({ id: resolver.id });
+
+		// ASSERT - All entries for this resolver should be cascade deleted
+		const entriesAfterDelete = await repository.find({
+			where: {
+				resolverId: resolver.id,
+			},
+		});
+		expect(entriesAfterDelete).toHaveLength(0);
+	});
+});

--- a/packages/cli/test/integration/dynamic-credentials/shared/db-helpers.ts
+++ b/packages/cli/test/integration/dynamic-credentials/shared/db-helpers.ts
@@ -1,0 +1,22 @@
+import { Container } from '@n8n/di';
+
+import type { DynamicCredentialResolver } from '@/modules/dynamic-credentials.ee/database/entities/credential-resolver';
+import { DynamicCredentialResolverRepository } from '@/modules/dynamic-credentials.ee/database/repositories/credential-resolver.repository';
+
+/**
+ * Creates a dynamic credential resolver for testing
+ */
+export async function createDynamicCredentialResolver(
+	attributes: Partial<DynamicCredentialResolver>,
+): Promise<DynamicCredentialResolver> {
+	const repository = Container.get(DynamicCredentialResolverRepository);
+
+	const resolver = repository.create({
+		name: attributes.name ?? 'test-resolver',
+		type: attributes.type ?? 'test-type',
+		config: attributes.config ?? '{}',
+		...attributes,
+	});
+
+	return await repository.save(resolver);
+}


### PR DESCRIPTION
## Summary

Implements generic credential storage provider with database-backed persistence for entity-specific credential data. The storage layer uses a composite primary key (credential_id, subject_id, resolver_id) with CASCADE DELETE foreign key constraints to ensure data integrity. Includes comprehensive integration tests verifying CRUD operations, upsert functionality, cascade deletes, and entry isolation.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-4225/implement-generic-credential-storage-provider

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
