### PR TITLE
fix(core): Prevent execution data from being overwritten on manual workflow resume

### DIFF
--- a/packages/cli/src/__tests__/workflow-runner.test.ts
+++ b/packages/cli/src/__tests__/workflow-runner.test.ts
@@ -2,9 +2,6 @@ import { testDb, createWorkflow, mockInstance } from '@n8n/backend-test-utils';
 import { GlobalConfig } from '@n8n/config';
 import { type User, type ExecutionEntity, GLOBAL_OWNER_ROLE, Project } from '@n8n/db';
 import { Container, Service } from '@n8n/di';
-import { createExecution } from '@test-integration/db/executions';
-import { createUser } from '@test-integration/db/users';
-import { setupTestServer } from '@test-integration/utils';
 import type { Response } from 'express';
 import { mock } from 'jest-mock-extended';
 import { DirectedGraph, WorkflowExecute } from 'n8n-core';
@@ -35,6 +32,9 @@ import { OwnershipService } from '@/services/ownership.service';
 import { Telemetry } from '@/telemetry';
 import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
 import { WorkflowRunner } from '@/workflow-runner';
+import { createExecution } from '@test-integration/db/executions';
+import { createUser } from '@test-integration/db/users';
+import { setupTestServer } from '@test-integration/utils';
 
 let owner: User;
 let runner: WorkflowRunner;
@@ -616,121 +616,5 @@ describe('streaming functionality', () => {
 
 		// ASSERT
 		expect(mockHooks.addHandler).toHaveBeenCalledWith('sendChunk', expect.any(Function));
-	});
-});
-
-describe('offloading manual executions to workers', () => {
-	let originalOffloadManualExecutionsToWorkers: string | undefined;
-	let activeExecutions: ActiveExecutions;
-	let permissionChecker: CredentialsPermissionChecker;
-	let mockHooks: core.ExecutionLifecycleHooks;
-	let mockScalingService: {
-		setupQueue: jest.Mock;
-		addJob: jest.Mock;
-	};
-
-	beforeEach(() => {
-		originalOffloadManualExecutionsToWorkers = process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS;
-		process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS = 'true';
-		globalConfig.executions.mode = 'queue';
-
-		activeExecutions = Container.get(ActiveExecutions);
-		jest.spyOn(activeExecutions, 'add').mockResolvedValue('1');
-		jest.spyOn(activeExecutions, 'attachWorkflowExecution').mockReturnValueOnce();
-
-		permissionChecker = Container.get(CredentialsPermissionChecker);
-		jest.spyOn(permissionChecker, 'check').mockResolvedValueOnce();
-
-		mockHooks = mock<core.ExecutionLifecycleHooks>();
-		jest
-			.spyOn(ExecutionLifecycleHooks, 'getLifecycleHooksForScalingMain')
-			.mockReturnValue(mockHooks);
-
-		mockScalingService = {
-			setupQueue: jest.fn(),
-			addJob: jest.fn().mockResolvedValue({
-				id: 'job-1',
-				data: { executionId: '1', workflowId: 'workflow-1' },
-				finished: jest.fn().mockResolvedValue(undefined),
-			}),
-		};
-		// @ts-expect-error Private property
-		runner.scalingService = mockScalingService;
-	});
-
-	afterEach(() => {
-		process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS = originalOffloadManualExecutionsToWorkers;
-		jest.resetAllMocks();
-	});
-
-	it('when receiving no `runData`, should set `runData` to undefined in `executionData`', async () => {
-		// ARRANGE
-		const data = mock<IWorkflowExecutionDataProcess>({
-			workflowData: { nodes: [], id: 'workflow-1' },
-			executionMode: 'manual',
-			runData: undefined,
-			startNodes: [],
-			destinationNode: undefined,
-			pinData: undefined,
-		});
-
-		// ACT
-		await runner.run(data);
-
-		// ASSERT
-		expect(data.executionData).toBeDefined();
-		expect(data.executionData?.resultData?.runData).toBeUndefined();
-	});
-
-	it('when receiving `runData`, should preserve it in `executionData` for partial execution', async () => {
-		// ARRANGE
-		const runData = {
-			Node1: [
-				{
-					startTime: 123,
-					executionTime: 456,
-					source: [],
-					executionIndex: 0,
-				},
-			],
-		};
-		const data = mock<IWorkflowExecutionDataProcess>({
-			workflowData: { nodes: [], id: 'workflow-1' },
-			executionMode: 'manual',
-			runData,
-			startNodes: [],
-			destinationNode: undefined,
-			pinData: undefined,
-		});
-
-		// ACT
-		await runner.run(data);
-
-		// ASSERT
-		expect(data.executionData).toBeDefined();
-		expect(data.executionData?.resultData?.runData).toEqual(runData);
-	});
-
-	it('should not initialize nested `executionData.executionData` to avoid treating it as resumed execution', async () => {
-		// ARRANGE
-		const data = mock<IWorkflowExecutionDataProcess>({
-			workflowData: { nodes: [], id: 'workflow-1' },
-			executionMode: 'manual',
-			runData: undefined,
-			startNodes: [],
-			destinationNode: undefined,
-			pinData: undefined,
-		});
-
-		// ACT
-		await runner.run(data);
-
-		// ASSERT
-		// Should have executionData at top level with startData and manualData
-		expect(data.executionData).toBeDefined();
-		expect(data.executionData?.startData).toBeDefined();
-		expect(data.executionData?.manualData).toBeDefined();
-		// But nested executionData.executionData should be undefined
-		expect(data.executionData?.executionData).toBeUndefined();
 	});
 });

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -139,40 +139,6 @@ export class WorkflowRunner {
 		restartExecutionId?: string,
 		responsePromise?: IDeferredPromise<IExecuteResponsePromiseData>,
 	): Promise<string> {
-		const offloadingManualExecutionsInQueueMode =
-			this.executionsConfig.mode === 'queue' &&
-			process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS === 'true';
-
-		/**
-		 * Historically, manual executions in scaling mode ran in the main process,
-		 * so some execution details were never persisted in the database.
-		 *
-		 * Currently, manual executions in scaling mode are offloaded to workers,
-		 * so we persist all details to give workers full access to them.
-		 */
-		if (data.executionMode === 'manual' && offloadingManualExecutionsInQueueMode) {
-			data.executionData = createRunExecutionData({
-				startData: {
-					startNodes: data.startNodes,
-					destinationNode: data.destinationNode,
-				},
-				resultData: {
-					pinData: data.pinData,
-					// Set this to null so `createRunExecutionData` doesn't initialize it.
-					// Otherwise this would be treated as a partial execution.
-					runData: data.runData ?? null,
-				},
-				manualData: {
-					userId: data.userId,
-					dirtyNodeNames: data.dirtyNodeNames,
-					triggerToStartFrom: data.triggerToStartFrom,
-				},
-				// Set this to null so `createRunExecutionData` doesn't initialize it.
-				// Otherwise this would be treated as a resumed execution after waiting.
-				executionData: null,
-			});
-		}
-
 		// Register a new execution
 		const executionId = await this.activeExecutions.add(data, restartExecutionId);
 

--- a/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
@@ -1,5 +1,6 @@
 import type { GlobalConfig } from '@n8n/config';
 import type { Project, User, WorkflowEntity, WorkflowRepository } from '@n8n/db';
+import type { MockProxy } from 'jest-mock-extended';
 import { mock } from 'jest-mock-extended';
 import {
 	NodeConnectionTypes,
@@ -465,6 +466,108 @@ describe('WorkflowExecutionService', () => {
 			);
 
 			expect(node).toEqual(secondWebhookNode);
+		});
+	});
+
+	describe('offloading manual executions to workers', () => {
+		let originalOffloadManualExecutionsToWorkers: string | undefined;
+		let globalConfigMock: GlobalConfig;
+		let workflowRunnerMock: MockProxy<WorkflowRunner>;
+		let service: WorkflowExecutionService;
+
+		beforeEach(() => {
+			originalOffloadManualExecutionsToWorkers = process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS;
+			process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS = 'true';
+			globalConfigMock = mock<GlobalConfig>({ executions: { mode: 'queue' } });
+			workflowRunnerMock = mock<WorkflowRunner>();
+			workflowRunnerMock.run.mockResolvedValue('fake-execution-id');
+
+			service = new WorkflowExecutionService(
+				mock(),
+				mock(),
+				mock(),
+				mock(),
+				nodeTypes,
+				mock(),
+				workflowRunnerMock,
+				globalConfigMock,
+				mock(),
+				mock(),
+			);
+		});
+
+		afterEach(() => {
+			process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS = originalOffloadManualExecutionsToWorkers;
+			jest.clearAllMocks();
+		});
+
+		test('when receiving no `runData`, should set `runData` to undefined in `executionData`', async () => {
+			// ACT
+			await service.executeManually(
+				{
+					workflowData: mock<IWorkflowBase>({ nodes: [] }),
+					triggerToStartFrom: executeWorkflowTriggerNode,
+				} satisfies WorkflowRequest.FullManualExecutionFromKnownTriggerPayload,
+				mock<User>({ id: 'user-id' }),
+			);
+
+			// ASSERT
+			const callArgs = workflowRunnerMock.run.mock.calls[0][0];
+			expect(callArgs.executionData?.resultData?.runData).toBeUndefined();
+		});
+
+		test('when receiving `runData`, should preserve it in `executionData` for partial execution', async () => {
+			// ARRANGE
+			const runData = {
+				[webhookNode.name]: [
+					{
+						startTime: 123,
+						executionTime: 456,
+						source: [],
+						executionIndex: 0,
+					},
+				],
+			};
+			const connections = { ...createMainConnection(hackerNewsNode.name, webhookNode.name) };
+
+			jest
+				.spyOn(nodeTypes, 'getByNameAndVersion')
+				.mockReturnValueOnce(mock<INodeType>({ description: { group: [] } }));
+
+			// ACT
+			await service.executeManually(
+				{
+					workflowData: mock<IWorkflowBase>({ nodes: [hackerNewsNode, webhookNode], connections }),
+					runData,
+					destinationNode: { nodeName: hackerNewsNode.name, mode: 'inclusive' },
+					dirtyNodeNames: [],
+				} satisfies WorkflowRequest.PartialManualExecutionToDestinationPayload,
+				mock<User>({ id: 'user-id' }),
+			);
+
+			// ASSERT
+			const callArgs = workflowRunnerMock.run.mock.calls[0][0];
+			expect(callArgs.executionData?.resultData?.runData).toEqual(runData);
+		});
+
+		test('should not initialize nested `executionData.executionData` to avoid treating it as resumed execution', async () => {
+			// ACT
+			await service.executeManually(
+				{
+					workflowData: mock<IWorkflowBase>({ nodes: [] }),
+					triggerToStartFrom: executeWorkflowTriggerNode,
+				} satisfies WorkflowRequest.FullManualExecutionFromKnownTriggerPayload,
+				mock<User>({ id: 'user-id' }),
+			);
+
+			// ASSERT
+			const callArgs = workflowRunnerMock.run.mock.calls[0][0];
+			// Should have executionData at top level with startData and manualData
+			expect(callArgs.executionData).toBeDefined();
+			expect(callArgs.executionData?.startData).toBeDefined();
+			expect(callArgs.executionData?.manualData).toBeDefined();
+			// But nested executionData.executionData should be undefined
+			expect(callArgs.executionData?.executionData).toBeUndefined();
 		});
 	});
 

--- a/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
@@ -497,7 +497,11 @@ describe('WorkflowExecutionService', () => {
 		});
 
 		afterEach(() => {
-			process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS = originalOffloadManualExecutionsToWorkers;
+			if (originalOffloadManualExecutionsToWorkers === undefined) {
+				delete process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS;
+			} else {
+				process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS = originalOffloadManualExecutionsToWorkers;
+			}
 			jest.clearAllMocks();
 		});
 


### PR DESCRIPTION
## Summary

Fixes issue where manual workflow executions would lose trigger outputs (e.g., from form triggers) when resumed after waiting for webhook/form submission.

**Root cause:** Execution data initialization logic in `WorkflowRunner.run()` ran unconditionally for every manual execution in queue mode. When a workflow resumed after waiting, this would overwrite the existing execution data that contained the trigger outputs.

**Solution:** Move queue mode offloading logic from `WorkflowRunner` to `WorkflowExecutionService` to ensure execution data is initialized only once at workflow start, not when resuming from a wait state.

This issue was introduced with this refactor: https://github.com/n8n-io/n8n/pull/22219

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1857/bug-double-execution-of-workflow-missing-output-from-form-trigger
https://linear.app/n8n/issue/CAT-1859/item-not-showing-when-manually-executing-a-form-trigger
https://linear.app/n8n/issue/GHC-5739/community-issue-the-node-returns-an-empty-result-after-the-form
https://github.com/n8n-io/n8n/issues/22589

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] ~Docs updated or follow-up ticket created~
- [x] Tests included
- [x] PR Labeled with `release/backport` (if urgent fix that needs backporting)