### PR TITLE
fix(editor): Prevent duplicate trigger nodes in "On app event" menu (…

### DIFF
--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/composables/useViewStacks.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/composables/useViewStacks.ts
@@ -447,8 +447,10 @@ export const useViewStacks = defineStore('nodeCreatorViewStacks', () => {
 		// Ensure that the nodes specified in `stack.forceIncludeNodes` are always included,
 		// regardless of whether the subcategory is matched
 		if ((stack.forceIncludeNodes ?? []).length > 0) {
+			const existing_node_keys = new Set(stackItems.map((item) => item.key));
 			const matchedNodes = nodeCreatorStore.mergedNodes
 				.filter((item) => stack.forceIncludeNodes?.includes(item.name))
+				.filter((item) => !existing_node_keys.has(item.name))
 				.map((item) => transformNodeType(item, stack.subcategory));
 
 			stackItems.push(...matchedNodes);


### PR DESCRIPTION
## Summary

  Add deduplication check when adding `forceIncludeNodes` to prevent trigger nodes (e.g., Webhook, Email Trigger) from appearing
  multiple times when reopening the "On app event" menu.

  The issue was caused by nodes that both belong to the current subcategory and are listed in `forceIncludeNodes` being added
  repeatedly each time the panel was opened.

  ## Related Linear tickets, Github issues, and Community forum posts

  Fixes #22638

  ## Review / Merge checklist

  - [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
  - [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
  - [ ] Tests included.
  - [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
