### PR TITLE
test: Disable banners for e2e tests

### DIFF
--- a/packages/testing/playwright/playwright.config.ts
+++ b/packages/testing/playwright/playwright.config.ts
@@ -62,6 +62,7 @@ export default defineConfig<CurrentsFixtures, CurrentsWorkerFixtures>({
 					N8N_LOG_LEVEL: 'debug',
 					N8N_METRICS: 'true',
 					N8N_RESTRICT_FILE_ACCESS_TO: '',
+					N8N_DYNAMIC_BANNERS_ENABLED: 'false',
 					...getTestEnv(),
 				},
 			}


### PR DESCRIPTION
## Summary

Disables banners in e2e tests to avoid test interference

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
