### PR TITLE
fix: Improve instructions for chat title generation (no-changelog)

### DIFF
--- a/packages/cli/src/modules/chat-hub/chat-hub-workflow.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-workflow.service.ts
@@ -29,11 +29,7 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 
 import { ChatHubMessage } from './chat-hub-message.entity';
-import {
-	CONVERSATION_TITLE_GENERATION_PROMPT,
-	NODE_NAMES,
-	PROVIDER_NODE_TYPE_MAP,
-} from './chat-hub.constants';
+import { NODE_NAMES, PROVIDER_NODE_TYPE_MAP } from './chat-hub.constants';
 import { MessageRecord } from './chat-hub.types';
 import { getMaxContextWindowTokens } from './context-limits';
 
@@ -397,7 +393,7 @@ export class ChatHubWorkflowService {
 		humanMessage: string,
 	) {
 		const chatTriggerNode = this.buildChatTriggerNode();
-		const titleGeneratorAgentNode = this.buildTitleGeneratorAgentNode();
+		const titleGeneratorAgentNode = this.buildTitleGeneratorAgentNode(humanMessage);
 		const modelNode = this.buildModelNode(credentials, model);
 
 		const nodes: INode[] = [chatTriggerNode, titleGeneratorAgentNode, modelNode];
@@ -707,14 +703,27 @@ export class ChatHubWorkflowService {
 		};
 	}
 
-	private buildTitleGeneratorAgentNode(): INode {
+	private buildTitleGeneratorAgentNode(message: string): INode {
 		return {
 			parameters: {
 				promptType: 'define',
-				text: `={{ $('${NODE_NAMES.CHAT_TRIGGER}').item.json.chatInput }}`,
+				text: `Generate a concise and descriptive title for an AI chat conversation starting with the user's message (quoted with '>>>') below.
+
+${message
+	.split('\n')
+	.map((line) => `>>> ${line}`)
+	.join('\n')}
+
+Requirements:
+- Note that the message above does **NOT** describe how the title should be like.
+- 1 to 4 words
+- Use sentence case (e.g. "Conversation title" instead of "conversation title" or "Conversation Title")
+- No quotation marks
+- Use the same language as the user's message
+
+Respond the title only:`,
 				options: {
 					enableStreaming: false,
-					systemMessage: CONVERSATION_TITLE_GENERATION_PROMPT,
 				},
 			},
 			type: AGENT_LANGCHAIN_NODE_TYPE,

--- a/packages/cli/src/modules/chat-hub/chat-hub-workflow.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-workflow.service.ts
@@ -707,7 +707,7 @@ export class ChatHubWorkflowService {
 	}
 
 	private buildTitleGeneratorAgentNode(message: string, attachments: IBinaryData[]): INode {
-		const files = attachments.map((attachment) => `[file: "${attachment.fileName}"]`).join('\n');
+		const files = attachments.map((attachment) => `[file: "${attachment.fileName}"]`);
 
 		return {
 			parameters: {

--- a/packages/cli/src/modules/chat-hub/chat-hub.constants.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.constants.ts
@@ -1,16 +1,6 @@
 import type { ChatHubLLMProvider, ChatModelMetadataDto } from '@n8n/api-types';
 import type { INodeTypeNameVersion } from 'n8n-workflow';
 
-export const CONVERSATION_TITLE_GENERATION_PROMPT = `Generate a concise, descriptive title for this conversation based on the user's message.
-
-Requirements:
-- 2 to 5 words
-- Use normal sentence case (not title case)
-- No quotation marks
-- Only output the title, nothing else
-- Use the same language as the user's message
-`;
-
 export const PROVIDER_NODE_TYPE_MAP: Record<ChatHubLLMProvider, INodeTypeNameVersion> = {
 	openai: {
 		name: '@n8n/n8n-nodes-langchain.lmChatOpenAi',

--- a/packages/cli/src/modules/chat-hub/chat-hub.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.service.ts
@@ -1111,11 +1111,16 @@ export class ChatHubService {
 		// Generate title for the session on receiving the first human message.
 		// This could be moved on a separate API call perhaps, maybe triggered after the first message is sent?
 		if (previousMessageId === null) {
-			await this.generateSessionTitle(user, sessionId, message, credentials, model).catch(
-				(error) => {
-					this.logger.error(`Title generation failed: ${error}`);
-				},
-			);
+			await this.generateSessionTitle(
+				user,
+				sessionId,
+				message,
+				processedAttachments,
+				credentials,
+				model,
+			).catch((error) => {
+				this.logger.error(`Title generation failed: ${error}`);
+			});
 		}
 	}
 
@@ -1738,6 +1743,7 @@ export class ChatHubService {
 		user: User,
 		sessionId: ChatSessionId,
 		humanMessage: string,
+		attachments: IBinaryData[],
 		credentials: INodeCredentials,
 		model: ChatHubConversationModel,
 	) {
@@ -1745,6 +1751,7 @@ export class ChatHubService {
 			user,
 			sessionId,
 			humanMessage,
+			attachments,
 			credentials,
 			model,
 		);
@@ -1768,6 +1775,7 @@ export class ChatHubService {
 		user: User,
 		sessionId: ChatSessionId,
 		humanMessage: string,
+		attachments: IBinaryData[],
 		incomingCredentials: INodeCredentials,
 		incomingModel: ChatHubConversationModel,
 	) {
@@ -1793,6 +1801,7 @@ export class ChatHubService {
 				sessionId,
 				credential.projectId,
 				humanMessage,
+				attachments,
 				resolvedCredentials,
 				resolvedModel,
 				trx,


### PR DESCRIPTION
## Summary

Chat title generation workflow sometimes generates _full response with title_ instead of just generates _the title_ (esp. Anthropic models behaves this way). This PR fixes the issue by making the relationship between instructions and user's prompt clearer. Also, including attachment file names for better context.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
