### PR TITLE
feat(editor): Update frontend external hooks with publish/unpublish (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.ts
@@ -198,10 +198,9 @@ export function useWorkflowActivate() {
 				workflowsStore.setWorkflowChecksum(await calculateWorkflowChecksum(updatedWorkflow));
 			}
 
-			void useExternalHooks().run('workflow.activeChangeCurrent', {
+			void useExternalHooks().run('workflow.published', {
 				workflowId,
 				versionId: updatedWorkflow.activeVersion.versionId,
-				active: true,
 			});
 
 			if (!hadPublishedVersion && useStorage(LOCAL_STORAGE_ACTIVATION_FLAG).value !== 'true') {
@@ -244,10 +243,8 @@ export function useWorkflowActivate() {
 				workflowsStore.setWorkflowChecksum(await calculateWorkflowChecksum(updatedWorkflow));
 			}
 
-			void useExternalHooks().run('workflow.activeChangeCurrent', {
+			void useExternalHooks().run('workflow.unpublished', {
 				workflowId,
-				active: false,
-				versionId: null,
 			});
 
 			return true;

--- a/packages/frontend/editor-ui/src/app/constants/workflows.ts
+++ b/packages/frontend/editor-ui/src/app/constants/workflows.ts
@@ -11,4 +11,5 @@ export const WORKFLOWS_DRAFT_PUBLISH_ENABLED_FLAG = 'WORKFLOWS_DRAFT_PUBLISH_ENA
 
 // TODO: We need to do a proper cleanup of the old functionality (non-draft-publish mode)
 // and then drop this constant
+// make sure to drop the activeChange and activeChangeCurrent external hooks
 export const IS_DRAFT_PUBLISH_ENABLED = true;

--- a/packages/frontend/editor-ui/src/app/types/externalHooks.ts
+++ b/packages/frontend/editor-ui/src/app/types/externalHooks.ts
@@ -224,6 +224,8 @@ export interface ExternalHooks {
 		>;
 		afterUpdate: Array<ExternalHooksMethod<{ workflowData: IWorkflowDb }>>;
 		open: Array<ExternalHooksMethod<{ workflowId: string; workflowName: string }>>;
+		published: Array<ExternalHooksMethod<{ workflowId: string; versionId: string }>>;
+		unpublished: Array<ExternalHooksMethod<{ workflowId: string }>>;
 	};
 	execution: {
 		open: Array<


### PR DESCRIPTION
## Summary

Replacing workflow.activeChangeCurrent and workflow.activeChange with published and unpublished but will drop the old ones with the bigger cleanup (left a comment in thecode)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4470/feature-fe-update-frontend-external-hooks

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
