### PR TITLE
fix: PAY-4106 - Make workers memory constraints more container aware

### DIFF
--- a/packages/@n8n/api-types/src/scaling.ts
+++ b/packages/@n8n/api-types/src/scaling.ts
@@ -13,6 +13,23 @@ export type RunningJobSummary = {
 export type WorkerStatus = {
 	senderId: string;
 	runningJobsSummary: RunningJobSummary[];
+	isInContainer: boolean;
+	process: {
+		memory: {
+			available: number;
+			constraint: number;
+			rss: number;
+			heapTotal: number;
+			heapUsed: number;
+		};
+		uptime: number;
+	};
+	host: {
+		memory: {
+			total: number;
+			free: number;
+		};
+	};
 	freeMem: number;
 	totalMem: number;
 	uptime: number;

--- a/packages/cli/src/scaling/worker-status.service.ee.ts
+++ b/packages/cli/src/scaling/worker-status.service.ee.ts
@@ -3,6 +3,7 @@ import { OnPubSubEvent } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 import { InstanceSettings } from 'n8n-core';
 import os from 'node:os';
+import process from 'node:process';
 
 import { N8N_VERSION } from '@/constants';
 import { Push } from '@/push';
@@ -46,9 +47,29 @@ export class WorkerStatusService {
 	}
 
 	private generateStatus(): WorkerStatus {
+		const constrainedMemory = process.constrainedMemory();
+
+		// See https://github.com/nodejs/node/issues/59227 for information about why we cap at MAX_SAFE_INTEGER
+		// The number 18446744073709552000 does come back when running in a container with no constraints
+		const isInContainer = constrainedMemory > 0 && constrainedMemory < Number.MAX_SAFE_INTEGER;
 		return {
 			senderId: this.instanceSettings.hostId,
 			runningJobsSummary: this.jobProcessor.getRunningJobsSummary(),
+			isInContainer,
+			process: {
+				memory: {
+					available: process.availableMemory(),
+					constraint: process.constrainedMemory(),
+					...process.memoryUsage(),
+				},
+				uptime: process.uptime(),
+			},
+			host: {
+				memory: {
+					total: os.totalmem(),
+					free: os.freemem(),
+				},
+			},
 			freeMem: os.freemem(),
 			totalMem: os.totalmem(),
 			uptime: process.uptime(),
@@ -73,6 +94,6 @@ export class WorkerStatusService {
 
 		if (cpus.length === 0) return 'no CPU info';
 
-		return `${cpus.length}x ${cpus[0].model} - speed: ${cpus[0].speed}`;
+		return `${cpus.length}x ${cpus[0].model}`;
 	}
 }

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -1068,6 +1068,7 @@
 	"workerList.item.jobList.empty": "No current jobs",
 	"workerList.item.jobListTitle": "Current Jobs",
 	"workerList.item.netListTitle": "Network Interfaces",
+	"workerList.item.memoryMonitorTitle": "Memory Monitoring",
 	"workerList.item.chartsTitle": "Performance Monitoring",
 	"workerList.item.copyAddressToClipboard": "Address copied to clipboard",
 	"workerList.actionBox.title": "Available on the Enterprise plan",

--- a/packages/frontend/editor-ui/src/features/settings/orchestration.ee/components/WorkerCard.vue
+++ b/packages/frontend/editor-ui/src/features/settings/orchestration.ee/components/WorkerCard.vue
@@ -7,6 +7,7 @@ import { averageWorkerLoadFromLoadsAsString, memAsGb } from '../orchestration.ut
 import WorkerJobAccordion from './WorkerJobAccordion.vue';
 import WorkerNetAccordion from './WorkerNetAccordion.vue';
 import WorkerChartsAccordion from './WorkerChartsAccordion.vue';
+import WorkerMemoryMonitorAccordion from './WorkerMemoryMonitorAccordion.vue';
 import { sortByProperty } from '@n8n/utils/sort/sortByProperty';
 import { useI18n } from '@n8n/i18n';
 
@@ -69,8 +70,13 @@ onBeforeUnmount(() => {
 				data-test-id="worker-card-name"
 			>
 				Name: {{ worker.senderId }} ({{ worker.hostname }}) <br />
-				Average Load: {{ averageWorkerLoadFromLoadsAsString(worker.loadAvg ?? [0]) }} | Free Memory:
-				{{ memAsGb(worker.freeMem).toFixed(2) }}GB / {{ memAsGb(worker.totalMem).toFixed(2) }}GB
+				Average Load: {{ averageWorkerLoadFromLoadsAsString(worker.loadAvg ?? [0]) }} | Free memory:
+				{{ memAsGb(worker.process.memory.available) }}Gb /
+				{{
+					memAsGb(
+						worker.isInContainer ? worker.process.memory.constraint : worker.host.memory.total,
+					)
+				}}Gb
 				{{ stale ? ' (stale)' : '' }}
 			</N8nHeading>
 		</template>
@@ -81,9 +87,11 @@ onBeforeUnmount(() => {
 					ago | n8n-Version: {{ worker.version }} | Architecture: {{ worker.arch }} (
 					{{ worker.platform }}) | Uptime: {{ upTime(worker.uptime) }}</span
 				>
+				<br />
 				<WorkerJobAccordion :items="worker.runningJobsSummary" />
 				<WorkerNetAccordion :items="sortedWorkerInterfaces" />
 				<WorkerChartsAccordion :worker-id="worker.senderId" />
+				<WorkerMemoryMonitorAccordion :worker="worker" />
 			</N8nText>
 		</div>
 		<template #append>

--- a/packages/frontend/editor-ui/src/features/settings/orchestration.ee/components/WorkerCard.vue
+++ b/packages/frontend/editor-ui/src/features/settings/orchestration.ee/components/WorkerCard.vue
@@ -71,12 +71,12 @@ onBeforeUnmount(() => {
 			>
 				Name: {{ worker.senderId }} ({{ worker.hostname }}) <br />
 				Average Load: {{ averageWorkerLoadFromLoadsAsString(worker.loadAvg ?? [0]) }} | Free memory:
-				{{ memAsGb(worker.process.memory.available) }}Gb /
+				{{ memAsGb(worker.process.memory.available) }}GB /
 				{{
 					memAsGb(
 						worker.isInContainer ? worker.process.memory.constraint : worker.host.memory.total,
 					)
-				}}Gb
+				}}GB
 				{{ stale ? ' (stale)' : '' }}
 			</N8nHeading>
 		</template>

--- a/packages/frontend/editor-ui/src/features/settings/orchestration.ee/components/WorkerChartsAccordion.vue
+++ b/packages/frontend/editor-ui/src/features/settings/orchestration.ee/components/WorkerChartsAccordion.vue
@@ -85,7 +85,10 @@ orchestrationStore.$onAction(({ name, store }) => {
 			newDataJobs.labels?.push(new Date(item.timestamp).toLocaleTimeString());
 			newDataCPU.datasets[0].data.push(averageWorkerLoadFromLoads(item.data.loadAvg));
 
-			newDataCPU.labels = dataCPU.value.labels;
+			//	Map the x axis timestamps to the labels
+			newDataCPU.labels = newDataJobs.labels;
+			newDataMemoryUsage.labels = newDataJobs.labels;
+
 			const totalMem = item.data.isInContainer
 				? item.data.process.memory.constraint
 				: item.data.host.memory.total;
@@ -93,8 +96,8 @@ orchestrationStore.$onAction(({ name, store }) => {
 			const usedMem = totalMem - item.data.process.memory.available;
 
 			const usage = (usedMem / totalMem) * 100;
-			newDataMemoryUsage.labels = dataMemoryUsage.value.labels;
-			newDataMemoryUsage.datasets[0].data.push(usage.toFixed(2));
+			// newDataMemoryUsage.labels = dataMemoryUsage.value.labels;
+			newDataMemoryUsage.datasets[0].data.push(usage);
 		});
 		dataJobs.value = newDataJobs;
 		dataCPU.value = newDataCPU;

--- a/packages/frontend/editor-ui/src/features/settings/orchestration.ee/components/WorkerChartsAccordion.vue
+++ b/packages/frontend/editor-ui/src/features/settings/orchestration.ee/components/WorkerChartsAccordion.vue
@@ -5,9 +5,8 @@ import { ref } from 'vue';
 import type { ChartData, ChartOptions } from 'chart.js';
 import type { ChartComponentRef } from 'vue-chartjs';
 import { Chart } from 'vue-chartjs';
-import { averageWorkerLoadFromLoads, memAsGb } from '../orchestration.utils';
+import { averageWorkerLoadFromLoads } from '../orchestration.utils';
 import { useI18n } from '@n8n/i18n';
-import { worker } from '@/features/shared/editors/plugins/codemirror/typescript/worker/typescript.worker';
 
 const props = defineProps<{
 	workerId: string;

--- a/packages/frontend/editor-ui/src/features/settings/orchestration.ee/components/WorkerChartsAccordion.vue
+++ b/packages/frontend/editor-ui/src/features/settings/orchestration.ee/components/WorkerChartsAccordion.vue
@@ -7,6 +7,7 @@ import type { ChartComponentRef } from 'vue-chartjs';
 import { Chart } from 'vue-chartjs';
 import { averageWorkerLoadFromLoads, memAsGb } from '../orchestration.utils';
 import { useI18n } from '@n8n/i18n';
+import { worker } from '@/features/shared/editors/plugins/codemirror/typescript/worker/typescript.worker';
 
 const props = defineProps<{
 	workerId: string;
@@ -28,7 +29,7 @@ const blankDataSet = (label: string, color: string, prefill: number = 0) => ({
 const orchestrationStore = useOrchestrationStore();
 const chartRefJobs = ref<ChartComponentRef | undefined>(undefined);
 const chartRefCPU = ref<ChartComponentRef | undefined>(undefined);
-const chartRefMemory = ref<ChartComponentRef | undefined>(undefined);
+const chartRefMemoryUsage = ref<ChartComponentRef | undefined>(undefined);
 const optionsBase: () => Partial<ChartOptions<'line'>> = () => ({
 	responsive: true,
 	maintainAspectRatio: true,
@@ -49,9 +50,8 @@ const optionsBase: () => Partial<ChartOptions<'line'>> = () => ({
 const optionsJobs: Partial<ChartOptions<'line'>> = optionsBase();
 const optionsCPU: Partial<ChartOptions<'line'>> = optionsBase();
 if (optionsCPU.scales?.y) optionsCPU.scales.y.suggestedMax = 100;
-const maxMemory = memAsGb(orchestrationStore.workers[props.workerId]?.totalMem) ?? 1;
 const optionsMemory: Partial<ChartOptions<'line'>> = optionsBase();
-if (optionsMemory.scales?.y) optionsMemory.scales.y.suggestedMax = maxMemory;
+if (optionsMemory.scales?.y) optionsMemory.scales.y.suggestedMax = 100;
 
 // prefilled initial arrays
 const dataJobs = ref<ChartData>(
@@ -60,8 +60,8 @@ const dataJobs = ref<ChartData>(
 const dataCPU = ref<ChartData>(
 	blankDataSet('Processor Usage', 'rgb(19, 205, 103)', WORKER_HISTORY_LENGTH),
 );
-const dataMemory = ref<ChartData>(
-	blankDataSet('Memory Usage', 'rgb(244, 216, 174)', WORKER_HISTORY_LENGTH),
+const dataMemoryUsage = ref<ChartData>(
+	blankDataSet('Memory Usage (%)', 'rgb(244, 216, 174)', WORKER_HISTORY_LENGTH),
 );
 
 orchestrationStore.$onAction(({ name, store }) => {
@@ -74,22 +74,31 @@ orchestrationStore.$onAction(({ name, store }) => {
 			'rgb(19, 205, 103)',
 			prefillCount,
 		);
-		const newDataMemory: ChartData = blankDataSet(
-			'Memory Usage',
+		const newDataMemoryUsage: ChartData = blankDataSet(
+			'Memory Usage (%)',
 			'rgb(244, 216, 174)',
 			prefillCount,
 		);
+
 		store.workersHistory[props.workerId]?.forEach((item) => {
 			newDataJobs.datasets[0].data.push(item.data.runningJobsSummary.length);
 			newDataJobs.labels?.push(new Date(item.timestamp).toLocaleTimeString());
 			newDataCPU.datasets[0].data.push(averageWorkerLoadFromLoads(item.data.loadAvg));
-			newDataCPU.labels = newDataJobs.labels;
-			newDataMemory.datasets[0].data.push(maxMemory - memAsGb(item.data.freeMem));
-			newDataMemory.labels = newDataJobs.labels;
+
+			newDataCPU.labels = dataCPU.value.labels;
+			const totalMem = item.data.isInContainer
+				? item.data.process.memory.constraint
+				: item.data.host.memory.total;
+
+			const usedMem = totalMem - item.data.process.memory.available;
+
+			const usage = (usedMem / totalMem) * 100;
+			newDataMemoryUsage.labels = dataMemoryUsage.value.labels;
+			newDataMemoryUsage.datasets[0].data.push(usage.toFixed(2));
 		});
 		dataJobs.value = newDataJobs;
 		dataCPU.value = newDataCPU;
-		dataMemory.value = newDataMemory;
+		dataMemoryUsage.value = newDataMemoryUsage;
 	}
 });
 </script>
@@ -116,9 +125,9 @@ orchestrationStore.$onAction(({ name, store }) => {
 					:class="$style.chart"
 				/>
 				<Chart
-					ref="chartRefMemory"
+					ref="chartRefMemoryUsage"
 					type="line"
-					:data="dataMemory"
+					:data="dataMemoryUsage"
 					:options="optionsMemory"
 					:class="$style.chart"
 				/>

--- a/packages/frontend/editor-ui/src/features/settings/orchestration.ee/components/WorkerChartsAccordion.vue
+++ b/packages/frontend/editor-ui/src/features/settings/orchestration.ee/components/WorkerChartsAccordion.vue
@@ -95,7 +95,6 @@ orchestrationStore.$onAction(({ name, store }) => {
 			const usedMem = totalMem - item.data.process.memory.available;
 
 			const usage = (usedMem / totalMem) * 100;
-			// newDataMemoryUsage.labels = dataMemoryUsage.value.labels;
 			newDataMemoryUsage.datasets[0].data.push(usage);
 		});
 		dataJobs.value = newDataJobs;

--- a/packages/frontend/editor-ui/src/features/settings/orchestration.ee/components/WorkerMemoryMonitorAccordion.vue
+++ b/packages/frontend/editor-ui/src/features/settings/orchestration.ee/components/WorkerMemoryMonitorAccordion.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
 import type { WorkerStatus } from '@n8n/api-types';
 import WorkerAccordion from './WorkerAccordion.vue';
-import { useClipboard } from '@/app/composables/useClipboard';
 import { useI18n } from '@n8n/i18n';
-import { useToast } from '@/app/composables/useToast';
 import { memAsGb, memAsMb } from '@/features/settings/orchestration.ee/orchestration.utils';
 
 const props = defineProps<{
@@ -25,11 +23,11 @@ const i18n = useI18n();
 					<tbody>
 						<tr>
 							<th>Total (os.totalmem)</th>
-							<td>{{ memAsGb(worker.host.memory.total) }}Gb</td>
+							<td>{{ memAsGb(worker.host.memory.total) }}GB</td>
 						</tr>
 						<tr>
 							<th>Free (os.freemem)</th>
-							<td>{{ memAsGb(worker.host.memory.free) }}Gb</td>
+							<td>{{ memAsGb(worker.host.memory.free) }}GB</td>
 						</tr>
 					</tbody>
 				</table>
@@ -39,23 +37,23 @@ const i18n = useI18n();
 					<tbody>
 						<tr v-if="worker.isInContainer">
 							<th>Constraint: (process.constrainedMemory)</th>
-							<td>{{ memAsMb(worker.process.memory.constraint) }}Mb</td>
+							<td>{{ memAsMb(worker.process.memory.constraint) }}MB</td>
 						</tr>
 						<tr>
 							<th>Available: (process.availableMemory)</th>
-							<td>{{ memAsMb(worker.process.memory.available) }}Mb</td>
+							<td>{{ memAsMb(worker.process.memory.available) }}MB</td>
 						</tr>
 						<tr>
 							<th>RSS: (process.memoryUsage().rss)</th>
-							<td>{{ memAsMb(worker.process.memory.rss) }}Mb</td>
+							<td>{{ memAsMb(worker.process.memory.rss) }}MB</td>
 						</tr>
 						<tr>
 							<th>Heap total: (process.memoryUsage().heapTotal)</th>
-							<td>{{ memAsMb(worker.process.memory.heapTotal) }}Mb</td>
+							<td>{{ memAsMb(worker.process.memory.heapTotal) }}MB</td>
 						</tr>
 						<tr>
 							<th>Heap used: (process.memoryUsage().heapUsed)</th>
-							<td>{{ memAsMb(worker.process.memory.heapUsed) }}Mb</td>
+							<td>{{ memAsMb(worker.process.memory.heapUsed) }}MB</td>
 						</tr>
 					</tbody>
 				</table>

--- a/packages/frontend/editor-ui/src/features/settings/orchestration.ee/components/WorkerMemoryMonitorAccordion.vue
+++ b/packages/frontend/editor-ui/src/features/settings/orchestration.ee/components/WorkerMemoryMonitorAccordion.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import type { WorkerStatus } from '@n8n/api-types';
+import WorkerAccordion from './WorkerAccordion.vue';
+import { useClipboard } from '@/app/composables/useClipboard';
+import { useI18n } from '@n8n/i18n';
+import { useToast } from '@/app/composables/useToast';
+import { memAsGb, memAsMb } from '@/features/settings/orchestration.ee/orchestration.utils';
+
+const props = defineProps<{
+	worker: WorkerStatus;
+}>();
+
+const i18n = useI18n();
+</script>
+
+<template>
+	<WorkerAccordion icon="list-checks" icon-color="text-dark" :initial-expanded="false">
+		<template #title>
+			{{ i18n.baseText('workerList.item.memoryMonitorTitle') }}
+		</template>
+		<template #content>
+			<div :class="$style['accordion-content']">
+				<strong>Host/OS Memory:</strong>
+				<table>
+					<tbody>
+						<tr>
+							<th>Total (os.totalmem)</th>
+							<td>{{ memAsGb(worker.host.memory.total) }}Gb</td>
+						</tr>
+						<tr>
+							<th>Free (os.freemem)</th>
+							<td>{{ memAsGb(worker.host.memory.free) }}Gb</td>
+						</tr>
+					</tbody>
+				</table>
+				<br />
+				<strong>Process Memory:</strong><br />
+				<table>
+					<tbody>
+						<tr v-if="worker.isInContainer">
+							<th>Constraint: (process.constrainedMemory)</th>
+							<td>{{ memAsMb(worker.process.memory.constraint) }}Mb</td>
+						</tr>
+						<tr>
+							<th>Available: (process.availableMemory)</th>
+							<td>{{ memAsMb(worker.process.memory.available) }}Mb</td>
+						</tr>
+						<tr>
+							<th>RSS: (process.memoryUsage().rss)</th>
+							<td>{{ memAsMb(worker.process.memory.rss) }}Mb</td>
+						</tr>
+						<tr>
+							<th>Heap total: (process.memoryUsage().heapTotal)</th>
+							<td>{{ memAsMb(worker.process.memory.heapTotal) }}Mb</td>
+						</tr>
+						<tr>
+							<th>Heap used: (process.memoryUsage().heapUsed)</th>
+							<td>{{ memAsMb(worker.process.memory.heapUsed) }}Mb</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+		</template>
+	</WorkerAccordion>
+</template>
+
+<style lang="scss" module>
+table {
+	th,
+	td {
+		text-align: left;
+		font-weight: normal;
+	}
+	td {
+		font-variant-numeric: tabular-nums;
+		padding-left: 8px;
+	}
+}
+
+.accordion-content {
+	padding: var(--spacing--2xs);
+}
+</style>

--- a/packages/frontend/editor-ui/src/features/settings/orchestration.ee/components/WorkerMemoryMonitorAccordion.vue
+++ b/packages/frontend/editor-ui/src/features/settings/orchestration.ee/components/WorkerMemoryMonitorAccordion.vue
@@ -23,11 +23,11 @@ const i18n = useI18n();
 					<tbody>
 						<tr>
 							<th>Total (os.totalmem)</th>
-							<td>{{ memAsGb(worker.host.memory.total) }}GB</td>
+							<td>{{ memAsGb(props.worker.host.memory.total) }}GB</td>
 						</tr>
 						<tr>
 							<th>Free (os.freemem)</th>
-							<td>{{ memAsGb(worker.host.memory.free) }}GB</td>
+							<td>{{ memAsGb(props.worker.host.memory.free) }}GB</td>
 						</tr>
 					</tbody>
 				</table>
@@ -37,23 +37,23 @@ const i18n = useI18n();
 					<tbody>
 						<tr v-if="worker.isInContainer">
 							<th>Constraint: (process.constrainedMemory)</th>
-							<td>{{ memAsMb(worker.process.memory.constraint) }}MB</td>
+							<td>{{ memAsMb(props.worker.process.memory.constraint) }}MB</td>
 						</tr>
 						<tr>
 							<th>Available: (process.availableMemory)</th>
-							<td>{{ memAsMb(worker.process.memory.available) }}MB</td>
+							<td>{{ memAsMb(props.worker.process.memory.available) }}MB</td>
 						</tr>
 						<tr>
 							<th>RSS: (process.memoryUsage().rss)</th>
-							<td>{{ memAsMb(worker.process.memory.rss) }}MB</td>
+							<td>{{ memAsMb(props.worker.process.memory.rss) }}MB</td>
 						</tr>
 						<tr>
 							<th>Heap total: (process.memoryUsage().heapTotal)</th>
-							<td>{{ memAsMb(worker.process.memory.heapTotal) }}MB</td>
+							<td>{{ memAsMb(props.worker.process.memory.heapTotal) }}MB</td>
 						</tr>
 						<tr>
 							<th>Heap used: (process.memoryUsage().heapUsed)</th>
-							<td>{{ memAsMb(worker.process.memory.heapUsed) }}MB</td>
+							<td>{{ memAsMb(props.worker.process.memory.heapUsed) }}MB</td>
 						</tr>
 					</tbody>
 				</table>

--- a/packages/frontend/editor-ui/src/features/settings/orchestration.ee/orchestration.utils.ts
+++ b/packages/frontend/editor-ui/src/features/settings/orchestration.ee/orchestration.utils.ts
@@ -6,6 +6,10 @@ export function averageWorkerLoadFromLoadsAsString(loads: number[]): string {
 	return averageWorkerLoadFromLoads(loads).toFixed(2);
 }
 
-export function memAsGb(mem: number): number {
-	return mem / 1024 / 1024 / 1024;
+export function memAsGb(mem: number, decimalPlaces: number = 2): number {
+	return (mem / 1024 / 1024 / 1024).toFixed(decimalPlaces);
+}
+
+export function memAsMb(mem: number, decimalPlaces: number = 2): number {
+	return (mem / 1024 / 1024).toFixed(decimalPlaces);
 }

--- a/packages/frontend/editor-ui/src/features/settings/orchestration.ee/orchestration.utils.ts
+++ b/packages/frontend/editor-ui/src/features/settings/orchestration.ee/orchestration.utils.ts
@@ -7,9 +7,9 @@ export function averageWorkerLoadFromLoadsAsString(loads: number[]): string {
 }
 
 export function memAsGb(mem: number, decimalPlaces: number = 2): number {
-	return (mem / 1024 / 1024 / 1024).toFixed(decimalPlaces);
+	return Number((mem / 1024 / 1024 / 1024).toFixed(decimalPlaces));
 }
 
 export function memAsMb(mem: number, decimalPlaces: number = 2): number {
-	return (mem / 1024 / 1024).toFixed(decimalPlaces);
+	return Number((mem / 1024 / 1024).toFixed(decimalPlaces));
 }


### PR DESCRIPTION
## Summary
Moves to use `process.constrainedMemory` instead of `os.totalmem()` for determinig total available memory. According to the docs since Node 22 it backs off to `uv_get_constrained_memory` in [libuv](https://docs.libuv.org/en/v1.x/misc.html#c.uv_get_constrained_memory) which means it should lookup from cgroups when available. 

> ⚠️ Worth noting that if no `limit` or constraint is set on the container we revert back to looking up the host value as this is the "theoretical max"

Also adds an accordion section with other memory stats in it to give a better picture. 

Changes the free memory chart to a more useful `Memory usage (%)` one.

Will raise a follow up ticket for this PR as the workers details page has a mix of os/host, process and job information on it.
  

## Related Linear tickets, Github issues, and Community forum
closes PAY-4106

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported
