### PR TITLE
fix(editor-ui): correctly parse cURL content-type with parameters (#22699)

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useImportCurlCommand.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useImportCurlCommand.test.ts
@@ -572,6 +572,26 @@ describe('useImportCurlCommand', () => {
 			const curl = 'curl -X POST -d "key=value"';
 			expect(() => toHttpNodeParameters(curl)).toThrow('no URL specified!');
 		});
+
+		test('Should parse cURL command with Content-Type header containing parameters', () => {
+			const curl = `curl --request POST \
+  --url https://example.com/api \
+  --header 'content-type: application/json; charset=UTF-8' \
+  --data '{"userId":"123","active":false,"visited":false}'`;
+
+			const parameters = toHttpNodeParameters(curl);
+
+			expect(parameters.url).toBe('https://example.com/api');
+			expect(parameters.method).toBe('POST');
+			expect(parameters.contentType).toBe('json');
+			expect(parameters.bodyParameters?.parameters).toEqual(
+				expect.arrayContaining([
+					{ name: 'userId', value: '123' },
+					{ name: 'active', value: 'false' },
+					{ name: 'visited', value: 'false' },
+				]),
+			);
+		});
 	});
 });
 

--- a/packages/frontend/editor-ui/src/app/composables/useImportCurlCommand.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useImportCurlCommand.ts
@@ -75,7 +75,9 @@ const getContentTypeHeader = (headers: JSONOutput['headers']): string | undefine
 };
 
 const isContentType = (headers: JSONOutput['headers'], contentType: ContentTypes): boolean => {
-	return getContentTypeHeader(headers) === contentType;
+	const header = getContentTypeHeader(headers);
+	if (!header) return false;
+	return header.split(';')[0].trim() === contentType;
 };
 
 const isJsonRequest = (curlJson: JSONOutput): boolean => {
@@ -320,7 +322,8 @@ export const toHttpNodeParameters = (curlCommand: string): HttpNodeParameters =>
 		httpNodeParameters.options.response.response.responseFormat = 'autodetect';
 	}
 
-	const contentType = curlJson?.headers?.[CONTENT_TYPE_KEY] as ContentTypes;
+	const contentTypeHeader = curlJson?.headers?.[CONTENT_TYPE_KEY];
+	const contentType = contentTypeHeader?.split(';')[0].trim() as ContentTypes;
 
 	if (isBinaryRequest(curlJson)) {
 		return Object.assign(httpNodeParameters, {
@@ -333,7 +336,7 @@ export const toHttpNodeParameters = (curlCommand: string): HttpNodeParameters =>
 		return Object.assign(httpNodeParameters, {
 			sendBody: true,
 			contentType: 'raw',
-			rawContentType: contentType,
+			rawContentType: contentTypeHeader,
 			body: Object.keys(curlJson?.data ?? {})[0],
 		});
 	}

--- a/packages/frontend/editor-ui/src/app/composables/useImportCurlCommand.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useImportCurlCommand.ts
@@ -323,7 +323,7 @@ export const toHttpNodeParameters = (curlCommand: string): HttpNodeParameters =>
 	}
 
 	const contentTypeHeader = curlJson?.headers?.[CONTENT_TYPE_KEY];
-	const contentType = contentTypeHeader?.split(';')[0].trim() as ContentTypes;
+	const contentType = contentTypeHeader?.split(';')[0].trim();
 
 	if (isBinaryRequest(curlJson)) {
 		return Object.assign(httpNodeParameters, {


### PR DESCRIPTION
## Summary

This PR fixes an issue where importing a cURL command with a `Content-Type` header containing parameters (e.g., `application/json; charset=UTF-8`) resulted in incorrect parsing of the body.

Previously, the import logic used a strict equality check against supported content types. This caused headers like `application/json; charset=UTF-8` to be treated as unknown/raw, leading to the body being parsed incorrectly (specifically, it would incorrectly use the first key of the JSON object as the body content).

The fix involves stripping any parameters (everything after `;`) from the `Content-Type` header before validating it against the supported types.

**How to test:**

1. Open a new HTTP node.
2. Click on "Import cURL".
3. Paste the following command:
   ```bash
   curl --request POST \
     --url https://example.com/api \
     --header 'content-type: application/json; charset=UTF-8' \
     --data '{"userId":"123","active":false,"visited":false}'
   ```
4. Verify that the Body Parameters are correctly parsed as JSON key-value pairs (`userId`, `active`, `visited`) instead of the body being set to just `"userId"`.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #22699

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. (N/A - Bug fix)
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
