### PR TITLE
feat(core): Add resolvable fields to credential entity

### DIFF
--- a/packages/@n8n/db/src/entities/credentials-entity.ts
+++ b/packages/@n8n/db/src/entities/credentials-entity.ts
@@ -42,6 +42,25 @@ export class CredentialsEntity extends WithTimestampsAndStringId implements ICre
 	@Column({ default: false })
 	isGlobal: boolean;
 
+	/**
+	 * Whether the credential can be dynamically resolved by a resolver.
+	 */
+	@Column({ default: false })
+	isResolvable: boolean;
+
+	/**
+	 * Whether the credential resolver should allow falling back to static credentials
+	 * if dynamic resolution fails.
+	 */
+	@Column({ default: false })
+	resolvableAllowFallback: boolean;
+
+	/**
+	 * ID of the dynamic credential resolver associated with this credential.
+	 */
+	@Column({ type: 'varchar', nullable: true })
+	resolverId?: string;
+
 	toJSON() {
 		const { shared, ...rest } = this;
 		return rest;

--- a/packages/@n8n/db/src/entities/credentials-entity.ts
+++ b/packages/@n8n/db/src/entities/credentials-entity.ts
@@ -59,7 +59,7 @@ export class CredentialsEntity extends WithTimestampsAndStringId implements ICre
 	 * ID of the dynamic credential resolver associated with this credential.
 	 */
 	@Column({ type: 'varchar', nullable: true })
-	resolverId?: string;
+	resolverId: string | null;
 
 	toJSON() {
 		const { shared, ...rest } = this;

--- a/packages/@n8n/db/src/migrations/common/1765459448000-AddResolvableFieldsToCredentials.ts
+++ b/packages/@n8n/db/src/migrations/common/1765459448000-AddResolvableFieldsToCredentials.ts
@@ -1,0 +1,42 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+const credentialsTableName = 'credentials_entity';
+const resolverTableName = 'dynamic_credential_resolver';
+const FOREIGN_KEY_NAME = 'credentials_entity_resolverId_foreign';
+
+export class AddResolvableFieldsToCredentials1765459448000 implements ReversibleMigration {
+	async up({ schemaBuilder: { addColumns, addForeignKey, column } }: MigrationContext) {
+		// Add isResolvable, resolvableAllowFallback, and resolverId columns to credentials_entity
+		await addColumns(credentialsTableName, [
+			column('isResolvable').bool.notNull.default(false),
+			column('resolvableAllowFallback').bool.notNull.default(false),
+			column('resolverId').varchar(16),
+		]);
+
+		// Add foreign key constraint
+		await addForeignKey(
+			credentialsTableName,
+			'resolverId',
+			[resolverTableName, 'id'],
+			FOREIGN_KEY_NAME,
+			'SET NULL',
+		);
+	}
+
+	async down({ schemaBuilder: { dropColumns, dropForeignKey } }: MigrationContext) {
+		// Drop foreign key constraint
+		await dropForeignKey(
+			credentialsTableName,
+			'resolverId',
+			[resolverTableName, 'id'],
+			FOREIGN_KEY_NAME,
+		);
+
+		// Drop columns from credentials_entity
+		await dropColumns(credentialsTableName, [
+			'isResolvable',
+			'resolvableAllowFallback',
+			'resolverId',
+		]);
+	}
+}

--- a/packages/@n8n/db/src/migrations/common/1765459448000-AddResolvableFieldsToCredentials.ts
+++ b/packages/@n8n/db/src/migrations/common/1765459448000-AddResolvableFieldsToCredentials.ts
@@ -6,14 +6,12 @@ const FOREIGN_KEY_NAME = 'credentials_entity_resolverId_foreign';
 
 export class AddResolvableFieldsToCredentials1765459448000 implements ReversibleMigration {
 	async up({ schemaBuilder: { addColumns, addForeignKey, column } }: MigrationContext) {
-		// Add isResolvable, resolvableAllowFallback, and resolverId columns to credentials_entity
 		await addColumns(credentialsTableName, [
 			column('isResolvable').bool.notNull.default(false),
 			column('resolvableAllowFallback').bool.notNull.default(false),
 			column('resolverId').varchar(16),
 		]);
 
-		// Add foreign key constraint
 		await addForeignKey(
 			credentialsTableName,
 			'resolverId',
@@ -24,7 +22,6 @@ export class AddResolvableFieldsToCredentials1765459448000 implements Reversible
 	}
 
 	async down({ schemaBuilder: { dropColumns, dropForeignKey } }: MigrationContext) {
-		// Drop foreign key constraint
 		await dropForeignKey(
 			credentialsTableName,
 			'resolverId',
@@ -32,7 +29,6 @@ export class AddResolvableFieldsToCredentials1765459448000 implements Reversible
 			FOREIGN_KEY_NAME,
 		);
 
-		// Drop columns from credentials_entity
 		await dropColumns(credentialsTableName, [
 			'isResolvable',
 			'resolvableAllowFallback',

--- a/packages/@n8n/db/src/migrations/mysqldb/index.ts
+++ b/packages/@n8n/db/src/migrations/mysqldb/index.ts
@@ -124,6 +124,7 @@ import { AddCreatorIdToProjectTable1764276827837 } from '../common/1764276827837
 import { CreateDynamicCredentialResolverTable1764682447000 } from '../common/1764682447000-CreateCredentialResolverTable';
 import { AddDynamicCredentialEntryTable1764689388394 } from '../common/1764689388394-AddDynamicCredentialEntryTable';
 import { BackfillMissingWorkflowHistoryRecords1765448186933 } from '../common/1765448186933-BackfillMissingWorkflowHistoryRecords';
+import { AddResolvableFieldsToCredentials1765459448000 } from '../common/1765459448000-AddResolvableFieldsToCredentials';
 import type { Migration } from '../migration-types';
 
 export const mysqlMigrations: Migration[] = [
@@ -253,4 +254,5 @@ export const mysqlMigrations: Migration[] = [
 	CreateDynamicCredentialResolverTable1764682447000,
 	AddDynamicCredentialEntryTable1764689388394,
 	BackfillMissingWorkflowHistoryRecords1765448186933,
+	AddResolvableFieldsToCredentials1765459448000,
 ];

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -124,6 +124,7 @@ import { AddCreatorIdToProjectTable1764276827837 } from '../common/1764276827837
 import { CreateDynamicCredentialResolverTable1764682447000 } from '../common/1764682447000-CreateCredentialResolverTable';
 import { AddDynamicCredentialEntryTable1764689388394 } from '../common/1764689388394-AddDynamicCredentialEntryTable';
 import { BackfillMissingWorkflowHistoryRecords1765448186933 } from '../common/1765448186933-BackfillMissingWorkflowHistoryRecords';
+import { AddResolvableFieldsToCredentials1765459448000 } from '../common/1765459448000-AddResolvableFieldsToCredentials';
 import type { Migration } from '../migration-types';
 
 export const postgresMigrations: Migration[] = [
@@ -253,4 +254,5 @@ export const postgresMigrations: Migration[] = [
 	CreateDynamicCredentialResolverTable1764682447000,
 	AddDynamicCredentialEntryTable1764689388394,
 	BackfillMissingWorkflowHistoryRecords1765448186933,
+	AddResolvableFieldsToCredentials1765459448000,
 ];

--- a/packages/@n8n/db/src/migrations/sqlite/1764689448000-AddResolvableFieldsToCredentials.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/1764689448000-AddResolvableFieldsToCredentials.ts
@@ -1,0 +1,33 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+const credentialsTableName = 'credentials_entity';
+const resolverTableName = 'dynamic_credential_resolver';
+const FOREIGN_KEY_NAME = 'credentials_entity_resolverId_foreign';
+
+export class AddResolvableFieldsToCredentials1764689448000 implements ReversibleMigration {
+	transaction = false as const;
+
+	async up({ schemaBuilder: { addColumns, addForeignKey, column } }: MigrationContext) {
+		await addColumns(credentialsTableName, [
+			column('isResolvable').bool.notNull.default(false),
+			column('resolvableAllowFallback').bool.notNull.default(false),
+			column('resolverId').varchar(16),
+		]);
+
+		await addForeignKey(
+			credentialsTableName,
+			'resolverId',
+			[resolverTableName, 'id'],
+			FOREIGN_KEY_NAME,
+			'SET NULL',
+		);
+	}
+
+	async down({ schemaBuilder: { dropColumns } }: MigrationContext) {
+		await dropColumns(credentialsTableName, [
+			'isResolvable',
+			'resolvableAllowFallback',
+			'resolverId',
+		]);
+	}
+}

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -47,6 +47,7 @@ import { AddProjectIdToVariableTable1758794506893 } from './1758794506893-AddPro
 import { AddWorkflowVersionColumn1761047826451 } from './1761047826451-AddWorkflowVersionColumn';
 import { ChangeDependencyInfoToJson1761655473000 } from './1761655473000-ChangeDependencyInfoToJson';
 import { AddCreatorIdToProjectTable1764276827837 } from './1764276827837-AddCreatorIdToProjectTable';
+import { AddResolvableFieldsToCredentials1764689448000 } from './1764689448000-AddResolvableFieldsToCredentials';
 import { UniqueWorkflowNames1620821879465 } from '../common/1620821879465-UniqueWorkflowNames';
 import { UpdateWorkflowCredentials1630330987096 } from '../common/1630330987096-UpdateWorkflowCredentials';
 import { AddNodeIds1658930531669 } from '../common/1658930531669-AddNodeIds';

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -121,7 +121,6 @@ import { CreateWorkflowPublishHistoryTable1764167920585 } from '../common/176416
 import { CreateDynamicCredentialResolverTable1764682447000 } from '../common/1764682447000-CreateCredentialResolverTable';
 import { AddDynamicCredentialEntryTable1764689388394 } from '../common/1764689388394-AddDynamicCredentialEntryTable';
 import { BackfillMissingWorkflowHistoryRecords1765448186933 } from '../common/1765448186933-BackfillMissingWorkflowHistoryRecords';
-import { AddResolvableFieldsToCredentials1765459448000 } from '../common/1765459448000-AddResolvableFieldsToCredentials';
 import type { Migration } from '../migration-types';
 
 const sqliteMigrations: Migration[] = [
@@ -247,7 +246,7 @@ const sqliteMigrations: Migration[] = [
 	CreateDynamicCredentialResolverTable1764682447000,
 	AddDynamicCredentialEntryTable1764689388394,
 	BackfillMissingWorkflowHistoryRecords1765448186933,
-	AddResolvableFieldsToCredentials1765459448000,
+	AddResolvableFieldsToCredentials1764689448000,
 ];
 
 export { sqliteMigrations };

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -120,6 +120,7 @@ import { CreateWorkflowPublishHistoryTable1764167920585 } from '../common/176416
 import { CreateDynamicCredentialResolverTable1764682447000 } from '../common/1764682447000-CreateCredentialResolverTable';
 import { AddDynamicCredentialEntryTable1764689388394 } from '../common/1764689388394-AddDynamicCredentialEntryTable';
 import { BackfillMissingWorkflowHistoryRecords1765448186933 } from '../common/1765448186933-BackfillMissingWorkflowHistoryRecords';
+import { AddResolvableFieldsToCredentials1765459448000 } from '../common/1765459448000-AddResolvableFieldsToCredentials';
 import type { Migration } from '../migration-types';
 
 const sqliteMigrations: Migration[] = [
@@ -245,6 +246,7 @@ const sqliteMigrations: Migration[] = [
 	CreateDynamicCredentialResolverTable1764682447000,
 	AddDynamicCredentialEntryTable1764689388394,
 	BackfillMissingWorkflowHistoryRecords1765448186933,
+	AddResolvableFieldsToCredentials1765459448000,
 ];
 
 export { sqliteMigrations };

--- a/packages/cli/src/modules/dynamic-credentials.ee/database/repositories/__tests__/credential-resolver.repository.integration.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/database/repositories/__tests__/credential-resolver.repository.integration.test.ts
@@ -1,0 +1,113 @@
+import { testDb, testModules } from '@n8n/backend-test-utils';
+import { CredentialsRepository } from '@n8n/db';
+import { Container } from '@n8n/di';
+
+import { DynamicCredentialResolverRepository } from '../credential-resolver.repository';
+import type { DynamicCredentialResolver } from '../../entities/credential-resolver';
+
+describe('DynamicCredentialResolverRepository', () => {
+	let resolverRepository: DynamicCredentialResolverRepository;
+	let credentialsRepository: CredentialsRepository;
+
+	beforeAll(async () => {
+		await testModules.loadModules(['dynamic-credentials']);
+		await testDb.init();
+		resolverRepository = Container.get(DynamicCredentialResolverRepository);
+		credentialsRepository = Container.get(CredentialsRepository);
+	});
+
+	afterEach(async () => {
+		await testDb.truncate(['CredentialsEntity']);
+		await resolverRepository.clear();
+	});
+
+	afterAll(async () => {
+		await testDb.terminate();
+	});
+
+	it('should create and find a resolver', async () => {
+		const resolver = resolverRepository.create({
+			name: 'Test Resolver',
+			type: 'oauth2',
+			config: JSON.stringify({ clientId: 'test' }),
+		});
+		const saved = await resolverRepository.save(resolver);
+
+		const found = await resolverRepository.findOne({ where: { id: saved.id } });
+
+		expect(found).toMatchObject({
+			id: saved.id,
+			name: 'Test Resolver',
+			type: 'oauth2',
+		});
+	});
+
+	describe('relationship with CredentialsEntity', () => {
+		let resolver: DynamicCredentialResolver;
+
+		beforeEach(async () => {
+			resolver = await resolverRepository.save(
+				resolverRepository.create({
+					name: 'Test Resolver',
+					type: 'oauth2',
+					config: JSON.stringify({}),
+				}),
+			);
+		});
+
+		it('should link credentials to resolver and query them', async () => {
+			await credentialsRepository.save([
+				credentialsRepository.create({
+					name: 'Cred 1',
+					type: 'oauth2',
+					data: '',
+					isResolvable: true,
+					resolverId: resolver.id,
+				}),
+				credentialsRepository.create({
+					name: 'Cred 2',
+					type: 'oauth2',
+					data: '',
+					isResolvable: true,
+					resolvableAllowFallback: true,
+					resolverId: resolver.id,
+				}),
+			]);
+
+			const linked = await credentialsRepository.find({ where: { resolverId: resolver.id } });
+
+			expect(linked).toHaveLength(2);
+			expect(linked[0].resolverId).toBe(resolver.id);
+			expect(linked[1].resolvableAllowFallback).toBe(true);
+		});
+
+		it('should handle nullable resolverId', async () => {
+			const credential = await credentialsRepository.save(
+				credentialsRepository.create({
+					name: 'Standalone',
+					type: 'apiKey',
+					data: '',
+					isResolvable: false,
+				}),
+			);
+
+			expect(credential.resolverId).toBeNull();
+		});
+
+		it('should set resolverId to null on resolver deletion (CASCADE SET NULL)', async () => {
+			const credential = await credentialsRepository.save(
+				credentialsRepository.create({
+					name: 'Linked',
+					type: 'oauth2',
+					data: '',
+					resolverId: resolver.id,
+				}),
+			);
+
+			await resolverRepository.delete(resolver.id);
+			const orphaned = await credentialsRepository.findOne({ where: { id: credential.id } });
+
+			expect(orphaned?.resolverId).toBeNull();
+		});
+	});
+});

--- a/packages/cli/src/modules/dynamic-credentials.ee/database/repositories/__tests__/credential-resolver.repository.integration.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/database/repositories/__tests__/credential-resolver.repository.integration.test.ts
@@ -99,12 +99,13 @@ describe('DynamicCredentialResolverRepository', () => {
 					name: 'Linked',
 					type: 'oauth2',
 					data: '',
+					isResolvable: true,
 					resolverId: resolver.id,
 				}),
 			);
 
 			await resolverRepository.delete(resolver.id);
-			const orphaned = await credentialsRepository.findOne({ where: { id: credential.id } });
+			const orphaned = await credentialsRepository.findOneBy({ id: credential.id });
 
 			expect(orphaned?.resolverId).toBeNull();
 		});

--- a/packages/cli/src/modules/dynamic-credentials.ee/database/repositories/__tests__/credential-resolver.repository.integration.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/database/repositories/__tests__/credential-resolver.repository.integration.test.ts
@@ -17,8 +17,7 @@ describe('DynamicCredentialResolverRepository', () => {
 	});
 
 	afterEach(async () => {
-		await testDb.truncate(['CredentialsEntity']);
-		await resolverRepository.clear();
+		await testDb.truncate(['CredentialsEntity', 'DynamicCredentialResolver']);
 	});
 
 	afterAll(async () => {

--- a/packages/cli/src/modules/mcp/__tests__/webhook-utils.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/webhook-utils.test.ts
@@ -25,6 +25,8 @@ const mockCredentialsService = (
 				shared: [] as SharedCredentials[],
 				isManaged: false,
 				isGlobal: false,
+				isResolvable: false,
+				resolvableAllowFallback: false,
 				id,
 				// Methods present on entities via WithTimestampsAndStringId mixin
 				generateId() {},

--- a/packages/cli/src/modules/mcp/__tests__/webhook-utils.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/webhook-utils.test.ts
@@ -26,6 +26,7 @@ const mockCredentialsService = (
 				isManaged: false,
 				isGlobal: false,
 				isResolvable: false,
+				resolverId: null,
 				resolvableAllowFallback: false,
 				id,
 				// Methods present on entities via WithTimestampsAndStringId mixin

--- a/packages/cli/test/integration/dynamic-credentials/credential-resolver.repository.test.ts
+++ b/packages/cli/test/integration/dynamic-credentials/credential-resolver.repository.test.ts
@@ -2,8 +2,8 @@ import { testDb, testModules } from '@n8n/backend-test-utils';
 import { CredentialsRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 
-import { DynamicCredentialResolverRepository } from '../credential-resolver.repository';
-import type { DynamicCredentialResolver } from '../../entities/credential-resolver';
+import type { DynamicCredentialResolver } from '@/modules/dynamic-credentials.ee/database/entities/credential-resolver';
+import { DynamicCredentialResolverRepository } from '@/modules/dynamic-credentials.ee/database/repositories/credential-resolver.repository';
 
 describe('DynamicCredentialResolverRepository', () => {
 	let resolverRepository: DynamicCredentialResolverRepository;

--- a/packages/cli/test/integration/dynamic-credentials/credential-resolver.repository.test.ts
+++ b/packages/cli/test/integration/dynamic-credentials/credential-resolver.repository.test.ts
@@ -8,8 +8,11 @@ import { DynamicCredentialResolverRepository } from '@/modules/dynamic-credentia
 describe('DynamicCredentialResolverRepository', () => {
 	let resolverRepository: DynamicCredentialResolverRepository;
 	let credentialsRepository: CredentialsRepository;
+	let previousEnvVar: string | undefined;
 
 	beforeAll(async () => {
+		previousEnvVar = process.env.N8N_ENV_FEAT_CONTEXT_ESTABLISHMENT_HOOKS;
+		process.env.N8N_ENV_FEAT_CONTEXT_ESTABLISHMENT_HOOKS = 'true';
 		await testModules.loadModules(['dynamic-credentials']);
 		await testDb.init();
 		resolverRepository = Container.get(DynamicCredentialResolverRepository);
@@ -21,6 +24,7 @@ describe('DynamicCredentialResolverRepository', () => {
 	});
 
 	afterAll(async () => {
+		process.env.N8N_ENV_FEAT_CONTEXT_ESTABLISHMENT_HOOKS = previousEnvVar;
 		await testDb.terminate();
 	});
 

--- a/packages/cli/test/integration/dynamic-credentials/credential-resolver.repository.test.ts
+++ b/packages/cli/test/integration/dynamic-credentials/credential-resolver.repository.test.ts
@@ -11,8 +11,8 @@ describe('DynamicCredentialResolverRepository', () => {
 	let previousEnvVar: string | undefined;
 
 	beforeAll(async () => {
-		previousEnvVar = process.env.N8N_ENV_FEAT_CONTEXT_ESTABLISHMENT_HOOKS;
-		process.env.N8N_ENV_FEAT_CONTEXT_ESTABLISHMENT_HOOKS = 'true';
+		previousEnvVar = process.env.N8N_ENV_FEAT_DYNAMIC_CREDENTIALS;
+		process.env.N8N_ENV_FEAT_DYNAMIC_CREDENTIALS = 'true';
 		await testModules.loadModules(['dynamic-credentials']);
 		await testDb.init();
 		resolverRepository = Container.get(DynamicCredentialResolverRepository);
@@ -24,7 +24,7 @@ describe('DynamicCredentialResolverRepository', () => {
 	});
 
 	afterAll(async () => {
-		process.env.N8N_ENV_FEAT_CONTEXT_ESTABLISHMENT_HOOKS = previousEnvVar;
+		process.env.N8N_ENV_FEAT_DYNAMIC_CREDENTIALS = previousEnvVar;
 		await testDb.terminate();
 	});
 


### PR DESCRIPTION
## Summary

This PR adds fields on the CredentialEntity to support dynamic credential resolution:
- **resolverId**: varchar foreign key (nullable) linking to a credential resolver
- **isResolvable**: boolean to determine whether to try and resolve the credentials at runtime
- **resolvableAllowFallback**: boolean to determine whether credentials should fallback to static credential data if the resolver fails

### Design Decisions

**TypeORM Relationship**: We intentionally omit the `@ManyToOne` decorator because the linked entity is defined in the dynamic credentials module. TypeORM treats `resolverId` as a regular text field while the database handles foreign key constraints. This approach is acceptable since we don't need to load `credential.resolver` via TypeORM—the credential module can independently query the resolver repository with the resolver ID.

**Field Independence**: `isResolvable` can be `true` even when `resolverId` is `null`. This handles cases where the resolver is configured at a higher level in the hierarchy (workflow/project/instance) rather than on the individual credential. This also allows customers to "disable" the resolving mechanism temporarily (e.g., for debugging) while keeping the resolver ID reference.

**Fallback Behavior**: `resolvableAllowFallback` only falls back to static credential data, not to alternative resolvers. The fallback path for credentials goes from the most specific resolver (on the credential) to the least specific (on the workflow, project, or instance). The last possible option is to allow fallback to the static credential data. This supports edge cases like LLM credentials where some users might not have personal credentials and can fall back to a company key.

### Migration Safety

The migration includes `transaction = false` for SQLite to prevent [data loss from SQLite foreign key quirk](https://n8nio.slack.com/archives/C035KBDA917/p1764321309535179?thread_ts=1764258843.340829&cid=C035KBDA917) when dropping foreign keys.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-4214/add-resolvable-fields-to-credential-entity

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)