### PR TITLE
fix(core): Fix html header check

### DIFF
--- a/packages/core/src/__tests__/html-sandbox.test.ts
+++ b/packages/core/src/__tests__/html-sandbox.test.ts
@@ -75,11 +75,15 @@ describe('isHtmlRenderedContentType', () => {
 		});
 	});
 
+	it('should handle content type with extra spaces', () => {
+		expect(isHtmlRenderedContentType('  text/html')).toBe(true);
+		expect(isHtmlRenderedContentType('text/html  ')).toBe(true);
+		expect(isHtmlRenderedContentType('  text/html  ')).toBe(true);
+	});
+
 	it('should handle edge cases', () => {
 		expect(isHtmlRenderedContentType('text/htmlsomething')).toBe(true);
 		expect(isHtmlRenderedContentType('application/xhtml+xmlsomething')).toBe(true);
-		expect(isHtmlRenderedContentType(' text/html')).toBe(false);
-		expect(isHtmlRenderedContentType('text/html ')).toBe(true);
 	});
 });
 

--- a/packages/core/src/html-sandbox.ts
+++ b/packages/core/src/html-sandbox.ts
@@ -17,7 +17,7 @@ export const getWebhookSandboxCSP = (): string => {
  * as HTML.
  */
 export const isHtmlRenderedContentType = (contentType: string) => {
-	const contentTypeLower = contentType.toLowerCase();
+	const contentTypeLower = contentType.trim().toLowerCase();
 
 	return (
 		// The content-type can also contain a charset, e.g. "text/html; charset=utf-8"


### PR DESCRIPTION
## Summary

Handle whitespaces correctly when checking content type. See Linear issue for more details

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1803


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
