### PR TITLE
fix(editor): Don't create duplicate placeholder nodes on agent failure

### DIFF
--- a/packages/frontend/editor-ui/src/features/execution/logs/logs.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/logs.utils.test.ts
@@ -1179,6 +1179,54 @@ describe(createLogTree, () => {
 		expect(logs[0].children).toHaveLength(1);
 		expect(logs[0].children[0].node.name).toBe(aiModelNode.name);
 	});
+
+	it('should not duplicate parent node placeholder when multiple child nodes have the same parent without run data', () => {
+		// This test covers the AI-1726 bug scenario:
+		// When AI Agent execution finishes with error, the agent is NOT in runData
+		// But its child nodes (LLM and tools) ARE in runData
+		// Each child tries to insert the AI Agent as a placeholder
+		// Before the fix: AI Agent appeared twice (once per child)
+		// After the fix: AI Agent appears only once
+		const llmNode = createTestNode({ name: 'Anthropic Chat Model' });
+		const toolNode = createTestNode({ name: 'HTTP Request' });
+		const logs = createLogTree(
+			createTestWorkflowObject({
+				nodes: [aiAgentNode, llmNode, toolNode],
+				connections: {
+					[llmNode.name]: {
+						[NodeConnectionTypes.AiLanguageModel]: [
+							[{ node: aiAgentNode.name, index: 0, type: NodeConnectionTypes.AiLanguageModel }],
+						],
+					},
+					[toolNode.name]: {
+						[NodeConnectionTypes.AiTool]: [
+							[{ node: aiAgentNode.name, index: 0, type: NodeConnectionTypes.AiTool }],
+						],
+					},
+				},
+			}),
+			createTestWorkflowExecutionResponse({
+				data: createRunExecutionData({
+					resultData: {
+						runData: {
+							// AI Agent is NOT in runData (error case)
+							[llmNode.name]: [createTestTaskData()],
+							[toolNode.name]: [createTestTaskData()],
+						},
+					},
+				}),
+			}),
+		);
+
+		// Should have only ONE AI Agent entry (not duplicated)
+		expect(logs).toHaveLength(1);
+		expect(logs[0].node.name).toBe(aiAgentNode.name);
+		expect(logs[0].runData).toBe(undefined); // Placeholder has no runData
+		expect(logs[0].children).toHaveLength(2); // Both child nodes
+		expect(logs[0].children.map((c) => c.node.name)).toEqual(
+			expect.arrayContaining([llmNode.name, toolNode.name]),
+		);
+	});
 });
 
 describe(processFiles, () => {


### PR DESCRIPTION
## Summary
Fixes an issue where AI Agent nodes appeared duplicated in the execution logs view when the agent execution finished with an error.

When the full AI Agent execution fails or doesn't complete, the agent node itself is NOT in the execution's `runData`, but its child nodes (LLM, tools, etc.) ARE present. Each child node independently tried to insert the parent AI Agent as a placeholder node, resulting in the agent appearing multiple times in the logs tree.

- Added deduplication logic in `createLogTreeRec` to track and filter duplicate placeholder entries (nodes without actual task data)
- Updated `mergeStartData` to better handle duplicate runs by checking for exact matches (same executionIndex AND startTime) to prevent duplicates from AI agent cases
- Added comprehensive test coverage for the duplication scenario

## Related Linear tickets, Github issues, and Community forum posts

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
