### PR TITLE
fix(editor): Syntax highlighting in chat message not working (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/__tests__/setup.ts
+++ b/packages/frontend/editor-ui/src/__tests__/setup.ts
@@ -147,4 +147,52 @@ Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
 	value: vi.fn(),
 });
 
+class SpeechSynthesisUtterance {
+	text = '';
+	lang = '';
+	voice = null;
+	volume = 1;
+	rate = 1;
+	pitch = 1;
+	onstart = null;
+	onend = null;
+	onerror = null;
+	onpause = null;
+	onresume = null;
+	onmark = null;
+	onboundary = null;
+
+	constructor(text?: string) {
+		if (text) {
+			this.text = text;
+		}
+	}
+
+	addEventListener = vi.fn();
+	removeEventListener = vi.fn();
+	dispatchEvent = vi.fn(() => true);
+}
+
+Object.defineProperty(window, 'SpeechSynthesisUtterance', {
+	writable: true,
+	value: SpeechSynthesisUtterance,
+});
+
+Object.defineProperty(window, 'speechSynthesis', {
+	writable: true,
+	value: {
+		cancel: vi.fn(),
+		speak: vi.fn(),
+		pause: vi.fn(),
+		resume: vi.fn(),
+		getVoices: vi.fn(() => []),
+		pending: false,
+		speaking: false,
+		paused: false,
+		addEventListener: vi.fn(),
+		removeEventListener: vi.fn(),
+		dispatchEvent: vi.fn(() => true),
+	},
+});
+
 loadLanguage('en', englishBaseText as LocaleMessages);

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/__test__/data.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/__test__/data.ts
@@ -1,0 +1,27 @@
+import type {} from '@n8n/api-types';
+import type { ChatMessage } from '../chat.types';
+
+export function createTestChatMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
+	return {
+		id: 'm0',
+		type: 'ai',
+		content: 'test message',
+		status: 'success',
+		sessionId: 's0',
+		createdAt: new Date().toISOString(),
+		model: 'm0',
+		provider: 'anthropic',
+		alternatives: [],
+		attachments: [],
+		responses: [],
+		name: '',
+		workflowId: null,
+		agentId: null,
+		executionId: null,
+		updatedAt: new Date().toISOString(),
+		previousMessageId: null,
+		retryOfMessageId: null,
+		revisionOfMessageId: null,
+		...overrides,
+	};
+}

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createComponentRenderer } from '@/__tests__/render';
+import { createTestingPinia } from '@pinia/testing';
+import ChatMessage from './ChatMessage.vue';
+import type { ChatMessage as ChatMessageType } from '../chat.types';
+import { waitFor } from '@testing-library/vue';
+import { createTestChatMessage } from '../__test__/data';
+
+const renderComponent = createComponentRenderer(ChatMessage);
+
+describe('ChatMessage', () => {
+	let pinia: ReturnType<typeof createTestingPinia>;
+
+	beforeEach(() => {
+		pinia = createTestingPinia();
+	});
+
+	it('should render syntax highlighting for code blocks', async () => {
+		const message: ChatMessageType = createTestChatMessage({
+			content: '```javascript\nconst foo = "bar";\nfunction test() {\n  return true;\n}\n```',
+		});
+
+		const { container } = renderComponent({
+			props: {
+				message,
+				compact: false,
+				isEditing: false,
+				isStreaming: false,
+				cachedAgentDisplayName: null,
+			},
+			pinia,
+		});
+
+		// Wait for highlight.js to load and apply syntax highlighting
+		await waitFor(() => {
+			const highlightedElements = container.querySelectorAll('.hljs-keyword');
+
+			expect(highlightedElements.length).toBeGreaterThan(0);
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.vue
@@ -235,7 +235,7 @@ onBeforeMount(() => {
 					<div v-if="message.type === 'human'">{{ message.content }}</div>
 					<VueMarkdown
 						v-else
-						:key="markdown.forceReRenderKey"
+						:key="markdown.forceReRenderKey.value"
 						:class="[$style.chatMessageMarkdown, 'chat-message-markdown']"
 						:source="
 							message.status === 'error' && !message.content


### PR DESCRIPTION
## Summary

#22678 broke syntax highlighting in the chat UI. This PR fixes it.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
