### PR TITLE
ci: Add consolidated check job so we can change branch protection rules

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,3 +5,4 @@ self-hosted-runner:
     - blacksmith-2vcpu-ubuntu-2204-arm
     - blacksmith-4vcpu-ubuntu-2204-arm
     - blacksmith-8vcpu-ubuntu-2204
+    - ubuntu-slim

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -135,12 +135,14 @@ jobs:
     uses: ./.github/workflows/playwright-test-reusable.yml
     secrets: inherit
 
-  e2e-checks:
-    name: E2E - Checks
-    runs-on: ubuntu-latest
-    needs: [e2e-test]
+  required-checks:
+    name: Required Checks
+    needs: [install-and-build, unit-test, typecheck, lint, e2e-test]
     if: always()
+    runs-on: ubuntu-slim
     steps:
-      - name: Fail if E2E tests failed
-        if: needs.e2e-test.result == 'failure'
+      - name: Fail if any required job failed or was skipped unexpectedly
+        if: |
+          contains(needs.*.result, 'failure') ||
+          (needs.install-and-build.outputs.non_python_changed == 'true' && contains(needs.*.result, 'skipped'))
         run: exit 1

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -135,6 +135,9 @@ jobs:
     uses: ./.github/workflows/playwright-test-reusable.yml
     secrets: inherit
 
+  # This job is required by GitHub branch protection rules.
+  # PRs cannot be merged unless this job passes.
+  # If you add/remove jobs that should block merging, update the 'needs' array below.
   required-checks:
     name: Required Checks
     needs: [install-and-build, unit-test, typecheck, lint, e2e-test]
@@ -142,6 +145,8 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Fail if any required job failed or was skipped unexpectedly
+        # The non_python_changed check allows jobs to be skipped for python-only changes,
+        # since those jobs don't run when only python files are modified.
         if: |
           contains(needs.*.result, 'failure') ||
           (needs.install-and-build.outputs.non_python_changed == 'true' && contains(needs.*.result, 'skipped'))


### PR DESCRIPTION
## Summary

- Adds a single job for all required checks, will allow us to update branch protection rules to this one job instead.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
