### PR TITLE
fix(core): Address review feedback for sub-workflow wait fix

### DIFF
--- a/packages/@n8n/db/src/repositories/execution.repository.ts
+++ b/packages/@n8n/db/src/repositories/execution.repository.ts
@@ -429,7 +429,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 	 * @param executionId - The ID of the execution to update
 	 * @param execution - Partial execution data to update
 	 * @param requireStatus - Optional status requirement. If provided, update only succeeds if execution has this status
-	 * @returns true if update succeeded, false if requireStatus condition was not met
+	 * @returns true if update succeeded, false if no execution was found or requireStatus condition was not met
 	 */
 	async updateExistingExecution(
 		executionId: string,
@@ -493,7 +493,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 
 				// If requireStatus was set and the update failed, abort the
 				// transaction early and return false.
-				if (requireStatus && executionTableAffectedRows === 0) {
+				if (executionTableAffectedRows === 0) {
 					return false;
 				}
 			}

--- a/packages/cli/src/workflow-helpers.ts
+++ b/packages/cli/src/workflow-helpers.ts
@@ -247,24 +247,21 @@ export async function updateParentExecutionWithChildResults(
 		unflattenData: true,
 	});
 
-	if (!parent || parent.status !== 'waiting') {
+	if (parent?.status !== 'waiting') {
 		return;
 	}
 
 	const parentWithSubWorkflowResults = { data: { ...parent.data } };
 
-	if (
-		!parentWithSubWorkflowResults.data.executionData?.nodeExecutionStack ||
-		parentWithSubWorkflowResults.data.executionData.nodeExecutionStack.length === 0
-	) {
+	const nodeExecutionStack = parentWithSubWorkflowResults.data.executionData?.nodeExecutionStack;
+	if (!nodeExecutionStack || nodeExecutionStack?.length === 0) {
 		return;
 	}
 
 	// Copy the sub workflow result to the parent execution's Execute Workflow node inputs
 	// so that the Execute Workflow node returns the correct data when parent execution is resumed
 	// and the Execute Workflow node is executed again in disabled mode.
-	parentWithSubWorkflowResults.data.executionData.nodeExecutionStack[0].data =
-		lastExecutedNodeData.data;
+	nodeExecutionStack[0].data = lastExecutedNodeData.data;
 
 	await executionRepository.updateExistingExecution(
 		parentExecutionId,


### PR DESCRIPTION
## Summary

Follow-up to #22611 addressing code review feedback.

## Changes

1. **Readability improvements** in `updateParentExecutionWithChildResults()`
   - Extract `nodeExecutionStack` variable for cleaner code
   - Simplify null checks

2. **Improve `updateExistingExecution` behavior**
   - Now returns `false` when update affects 0 rows (execution not found)
   - Previously always returned `true` for backward compatibility
   - Updated JSDoc to document the new return behavior

3. **Test improvements**
   - Refactor integration tests to use `test.each` pattern
   - Add test for "execution not found" case
   - Cleaner test structure with parameterized cases

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to https://github.com/n8n-io/n8n/pull/22611

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~