### PR TITLE
fix(core): Hide migration rule issues not relevant to cloud

### DIFF
--- a/packages/cli/src/modules/breaking-changes/rules/v2/__tests__/task-runner-docker-image.rule.test.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/v2/__tests__/task-runner-docker-image.rule.test.ts
@@ -1,10 +1,16 @@
+import type { GlobalConfig } from '@n8n/config';
+import { mock } from 'jest-mock-extended';
+
 import { TaskRunnerDockerImageRule } from '../task-runner-docker-image.rule';
 
 describe('TaskRunnerDockerImageRule', () => {
 	let rule: TaskRunnerDockerImageRule;
 
 	beforeEach(() => {
-		rule = new TaskRunnerDockerImageRule();
+		const mockGlobalConfig = mock<GlobalConfig>({
+			deployment: { type: 'default' },
+		});
+		rule = new TaskRunnerDockerImageRule(mockGlobalConfig);
 	});
 
 	describe('getMetadata()', () => {
@@ -18,6 +24,19 @@ describe('TaskRunnerDockerImageRule', () => {
 	});
 
 	describe('detect()', () => {
+		it('should not be affected on cloud deployments', async () => {
+			const mockGlobalConfig = mock<GlobalConfig>({
+				deployment: { type: 'cloud' },
+			});
+			const cloudRule = new TaskRunnerDockerImageRule(mockGlobalConfig);
+
+			const result = await cloudRule.detect();
+
+			expect(result.isAffected).toBe(false);
+			expect(result.instanceIssues).toHaveLength(0);
+			expect(result.recommendations).toHaveLength(0);
+		});
+
 		it('should always be affected (informational)', async () => {
 			const result = await rule.detect();
 

--- a/packages/cli/src/modules/breaking-changes/rules/v2/__tests__/task-runners.rule.test.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/v2/__tests__/task-runners.rule.test.ts
@@ -1,12 +1,30 @@
-import type { TaskRunnersConfig } from '@n8n/config';
+import type { GlobalConfig, TaskRunnersConfig } from '@n8n/config';
+import { mock } from 'jest-mock-extended';
 
 import { TaskRunnersRule } from '../task-runners.rule';
 
 describe('TaskRunnersRule', () => {
 	describe('detect()', () => {
+		it('should not be affected on cloud deployments', async () => {
+			const mockConfig = { enabled: false } as TaskRunnersConfig;
+			const mockGlobalConfig = mock<GlobalConfig>({
+				deployment: { type: 'cloud' },
+			});
+			const rule = new TaskRunnersRule(mockConfig, mockGlobalConfig);
+
+			const result = await rule.detect();
+
+			expect(result.isAffected).toBe(false);
+			expect(result.instanceIssues).toHaveLength(0);
+			expect(result.recommendations).toHaveLength(0);
+		});
+
 		it('should not be affected when runners are already enabled', async () => {
 			const mockConfig = { enabled: true } as TaskRunnersConfig;
-			const rule = new TaskRunnersRule(mockConfig);
+			const mockGlobalConfig = mock<GlobalConfig>({
+				deployment: { type: 'default' },
+			});
+			const rule = new TaskRunnersRule(mockConfig, mockGlobalConfig);
 
 			const result = await rule.detect();
 
@@ -16,7 +34,10 @@ describe('TaskRunnersRule', () => {
 
 		it('should be affected when runners are not enabled', async () => {
 			const mockConfig = { enabled: false } as TaskRunnersConfig;
-			const rule = new TaskRunnersRule(mockConfig);
+			const mockGlobalConfig = mock<GlobalConfig>({
+				deployment: { type: 'default' },
+			});
+			const rule = new TaskRunnersRule(mockConfig, mockGlobalConfig);
 
 			const result = await rule.detect();
 
@@ -27,7 +48,10 @@ describe('TaskRunnersRule', () => {
 
 		it('should be affected when runners are explicitly disabled', async () => {
 			const mockConfig = { enabled: false } as TaskRunnersConfig;
-			const rule = new TaskRunnersRule(mockConfig);
+			const mockGlobalConfig = mock<GlobalConfig>({
+				deployment: { type: 'default' },
+			});
+			const rule = new TaskRunnersRule(mockConfig, mockGlobalConfig);
 
 			const result = await rule.detect();
 

--- a/packages/cli/src/modules/breaking-changes/rules/v2/__tests__/task-runners.rule.test.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/v2/__tests__/task-runners.rule.test.ts
@@ -4,13 +4,21 @@ import { mock } from 'jest-mock-extended';
 import { TaskRunnersRule } from '../task-runners.rule';
 
 describe('TaskRunnersRule', () => {
+	let mockGlobalConfig: GlobalConfig;
+
+	beforeEach(() => {
+		mockGlobalConfig = mock<GlobalConfig>({
+			deployment: { type: 'default' },
+		});
+	});
+
 	describe('detect()', () => {
 		it('should not be affected on cloud deployments', async () => {
 			const mockConfig = { enabled: false } as TaskRunnersConfig;
-			const mockGlobalConfig = mock<GlobalConfig>({
+			const cloudGlobalConfig = mock<GlobalConfig>({
 				deployment: { type: 'cloud' },
 			});
-			const rule = new TaskRunnersRule(mockConfig, mockGlobalConfig);
+			const rule = new TaskRunnersRule(mockConfig, cloudGlobalConfig);
 
 			const result = await rule.detect();
 
@@ -21,9 +29,6 @@ describe('TaskRunnersRule', () => {
 
 		it('should not be affected when runners are already enabled', async () => {
 			const mockConfig = { enabled: true } as TaskRunnersConfig;
-			const mockGlobalConfig = mock<GlobalConfig>({
-				deployment: { type: 'default' },
-			});
 			const rule = new TaskRunnersRule(mockConfig, mockGlobalConfig);
 
 			const result = await rule.detect();
@@ -34,9 +39,6 @@ describe('TaskRunnersRule', () => {
 
 		it('should be affected when runners are not enabled', async () => {
 			const mockConfig = { enabled: false } as TaskRunnersConfig;
-			const mockGlobalConfig = mock<GlobalConfig>({
-				deployment: { type: 'default' },
-			});
 			const rule = new TaskRunnersRule(mockConfig, mockGlobalConfig);
 
 			const result = await rule.detect();
@@ -44,13 +46,11 @@ describe('TaskRunnersRule', () => {
 			expect(result.isAffected).toBe(true);
 			expect(result.instanceIssues).toHaveLength(1);
 			expect(result.instanceIssues[0].title).toBe('Task Runners will be enabled by default');
+			expect(result.recommendations).toHaveLength(3);
 		});
 
 		it('should be affected when runners are explicitly disabled', async () => {
 			const mockConfig = { enabled: false } as TaskRunnersConfig;
-			const mockGlobalConfig = mock<GlobalConfig>({
-				deployment: { type: 'default' },
-			});
 			const rule = new TaskRunnersRule(mockConfig, mockGlobalConfig);
 
 			const result = await rule.detect();

--- a/packages/cli/src/modules/breaking-changes/rules/v2/settings-file-permissions.rule.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/v2/settings-file-permissions.rule.ts
@@ -1,4 +1,4 @@
-import { InstanceSettingsConfig } from '@n8n/config';
+import { GlobalConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
 
 import type {
@@ -10,7 +10,7 @@ import { BreakingChangeCategory } from '../../types';
 
 @Service()
 export class SettingsFilePermissionsRule implements IBreakingChangeInstanceRule {
-	constructor(private readonly instanceSettingsConfig: InstanceSettingsConfig) {}
+	constructor(private readonly globalConfig: GlobalConfig) {}
 
 	id: string = 'settings-file-permissions-v2';
 
@@ -28,9 +28,18 @@ export class SettingsFilePermissionsRule implements IBreakingChangeInstanceRule 
 	}
 
 	async detect(): Promise<InstanceDetectionReport> {
-		// If enforceSettingsFilePermissions is explicitly set to 'false', users are not affected
-		// because they've configured the system to not enforce file permissions
-		if (!this.instanceSettingsConfig.enforceSettingsFilePermissions) {
+		// Not relevant for cloud deployments - cloud manages infrastructure and file permissions
+		if (this.globalConfig.deployment.type === 'cloud') {
+			return {
+				isAffected: false,
+				instanceIssues: [],
+				recommendations: [],
+			};
+		}
+
+		// If N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS is explicitly set to any value, users are not affected
+		// because they've already handled the configuration and are aware of this setting.
+		if (process.env.N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS) {
 			return {
 				isAffected: false,
 				instanceIssues: [],

--- a/packages/cli/src/modules/breaking-changes/rules/v2/task-runner-docker-image.rule.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/v2/task-runner-docker-image.rule.ts
@@ -1,3 +1,4 @@
+import { GlobalConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
 
 import type {
@@ -9,6 +10,8 @@ import { BreakingChangeCategory } from '../../types';
 
 @Service()
 export class TaskRunnerDockerImageRule implements IBreakingChangeInstanceRule {
+	constructor(private readonly globalConfig: GlobalConfig) {}
+
 	id: string = 'task-runner-docker-image-v2';
 
 	getMetadata(): BreakingChangeRuleMetadata {
@@ -25,6 +28,15 @@ export class TaskRunnerDockerImageRule implements IBreakingChangeInstanceRule {
 	}
 
 	async detect(): Promise<InstanceDetectionReport> {
+		// Not relevant for cloud deployments - cloud manages Docker images
+		if (this.globalConfig.deployment.type === 'cloud') {
+			return {
+				isAffected: false,
+				instanceIssues: [],
+				recommendations: [],
+			};
+		}
+
 		const result: InstanceDetectionReport = {
 			isAffected: true,
 			instanceIssues: [

--- a/packages/cli/src/modules/breaking-changes/rules/v2/task-runners.rule.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/v2/task-runners.rule.ts
@@ -1,4 +1,4 @@
-import { TaskRunnersConfig } from '@n8n/config';
+import { GlobalConfig, TaskRunnersConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
 
 import type {
@@ -10,7 +10,10 @@ import { BreakingChangeCategory } from '../../types';
 
 @Service()
 export class TaskRunnersRule implements IBreakingChangeInstanceRule {
-	constructor(private readonly taskRunnersConfig: TaskRunnersConfig) {}
+	constructor(
+		private readonly taskRunnersConfig: TaskRunnersConfig,
+		private readonly globalConfig: GlobalConfig,
+	) {}
 
 	id: string = 'task-runners-v2';
 
@@ -27,6 +30,15 @@ export class TaskRunnersRule implements IBreakingChangeInstanceRule {
 	}
 
 	async detect(): Promise<InstanceDetectionReport> {
+		// Not relevant for cloud deployments - cloud manages task runner infrastructure
+		if (this.globalConfig.deployment.type === 'cloud') {
+			return {
+				isAffected: false,
+				instanceIssues: [],
+				recommendations: [],
+			};
+		}
+
 		const result: InstanceDetectionReport = {
 			isAffected: false,
 			instanceIssues: [],


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR exclude the task runner docker image rule and task runner settings detection from cloud environment, because cloud deployment handles the docker image.
Also fixes the SettingsFilePermissionsRule to check if the user explicitly set the related env variable, and thus is aware of the impact.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-4265/hide-migration-rule-issues-not-relevant-to-cloud

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
