### PR TITLE
fix(core): Filter out workflows from custom agents that use too old agents (no-changelog)

### DIFF
--- a/packages/cli/src/modules/chat-hub/chat-hub.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.service.ts
@@ -27,6 +27,7 @@ import type { Response } from 'express';
 import { ErrorReporter, InstanceSettings } from 'n8n-core';
 import {
 	CHAT_TRIGGER_NODE_TYPE,
+	AGENT_LANGCHAIN_NODE_TYPE,
 	OperationalError,
 	ManualExecutionCancelledError,
 	type INodeCredentials,
@@ -938,13 +939,21 @@ export class ChatHubService {
 			}
 
 			const chatTrigger = activeVersion.nodes?.find((node) => node.type === CHAT_TRIGGER_NODE_TYPE);
-
 			if (!chatTrigger) {
 				continue;
 			}
 
 			const chatTriggerParams = validChatTriggerParamsShape.safeParse(chatTrigger.parameters).data;
 			if (!chatTriggerParams) {
+				continue;
+			}
+
+			const agentNodes = activeVersion.nodes?.filter(
+				(node) => node.type === AGENT_LANGCHAIN_NODE_TYPE,
+			);
+
+			// Agents older than this can't do streaming
+			if (agentNodes.some((node) => node.typeVersion < 2.1)) {
 				continue;
 			}
 


### PR DESCRIPTION
## Summary

The feedback item had ideas for showing node issues on chat trigger in these cases, but that doesn't appear to be that straight forwarded thing to implement.

Lets at least not have old agents that can't do streaming qualify for n8n workflow agents here.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
