### PR TITLE
fix(editor): Bind color-scheme to app theme setting

### DIFF
--- a/packages/frontend/@n8n/design-system/src/css/_tokens.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.scss
@@ -709,8 +709,6 @@
 	@include theme;
 }
 
-/* Bind color-scheme to n8n's theme setting so light-dark() CSS function
-   resolves correctly regardless of OS preference */
 body[data-theme='light'] {
 	color-scheme: light;
 }
@@ -719,7 +717,6 @@ body[data-theme='dark'] {
 	color-scheme: dark;
 }
 
-/* Auto/default - follow OS preference */
 body:not([data-theme]) {
 	color-scheme: light dark;
 }

--- a/packages/frontend/@n8n/design-system/src/css/_tokens.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.scss
@@ -706,6 +706,20 @@
 }
 
 :root {
-	color-scheme: light dark;
 	@include theme;
+}
+
+/* Bind color-scheme to n8n's theme setting so light-dark() CSS function
+   resolves correctly regardless of OS preference */
+body[data-theme='light'] {
+	color-scheme: light;
+}
+
+body[data-theme='dark'] {
+	color-scheme: dark;
+}
+
+/* Auto/default - follow OS preference */
+body:not([data-theme]) {
+	color-scheme: light dark;
 }


### PR DESCRIPTION
## Summary
Fixes `light-dark()` CSS function resolving based on OS preference instead of n8n's theme setting.

**Problem**
When a user sets n8n to "light" theme while their OS is in dark mode (or vice versa), canvas elements using `light-dark()` would display with the wrong colors because `color-scheme: light dark` on `:root` defers to OS preference.

**Solution**
Bind `color-scheme` explicitly to the `data-theme` attribute on `body`, so `light-dark()` always resolves to match the app's actual theme.

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-1774/fix-light-dark-css-function-not-respecting-app-theme-setting

<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
