### PR TITLE
test: Fix publish workflow test by dismissing activation modal

### DIFF
--- a/packages/testing/playwright/pages/CanvasPage.ts
+++ b/packages/testing/playwright/pages/CanvasPage.ts
@@ -525,6 +525,12 @@ export class CanvasPage extends BasePage {
 		await this.getProductionChecklistActionItem(actionText).click();
 	}
 
+	async closeProductionChecklistIfVisible(): Promise<void> {
+		if (await this.getProductionChecklistPopover().isVisible()) {
+			await this.clickProductionChecklistButton();
+		}
+	}
+
 	async duplicateNode(nodeName: string): Promise<void> {
 		await this.nodeByName(nodeName).click({ button: 'right' });
 		await this.page.getByTestId('context-menu').getByText('Duplicate').click();

--- a/packages/testing/playwright/pages/WorkflowActivationModal.ts
+++ b/packages/testing/playwright/pages/WorkflowActivationModal.ts
@@ -28,4 +28,10 @@ export class WorkflowActivationModal extends BasePage {
 	async clickGotIt(): Promise<void> {
 		await this.getGotItButton().click();
 	}
+
+	async closeIfVisible(): Promise<void> {
+		if (await this.getModal().isVisible()) {
+			await this.getGotItButton().click();
+		}
+	}
 }

--- a/packages/testing/playwright/tests/ui/7-workflow-actions.spec.ts
+++ b/packages/testing/playwright/tests/ui/7-workflow-actions.spec.ts
@@ -114,6 +114,7 @@ test.describe('Workflow Actions', () => {
 
 		await n8n.canvas.publishWorkflow();
 		await n8n.workflowActivationModal.closeIfVisible();
+		await n8n.canvas.closeProductionChecklistIfVisible();
 
 		await expect(n8n.canvas.getPublishedIndicator()).toBeVisible();
 	});
@@ -149,6 +150,7 @@ test.describe('Workflow Actions', () => {
 
 		await n8n.canvas.publishWorkflow();
 		await n8n.workflowActivationModal.closeIfVisible();
+		await n8n.canvas.closeProductionChecklistIfVisible();
 
 		await expect(n8n.canvas.getPublishedIndicator()).toBeVisible();
 	});

--- a/packages/testing/playwright/tests/ui/7-workflow-actions.spec.ts
+++ b/packages/testing/playwright/tests/ui/7-workflow-actions.spec.ts
@@ -148,7 +148,18 @@ test.describe('Workflow Actions', () => {
 		const nodeName = await n8n.canvas.getCanvasNodes().last().getAttribute('data-node-name');
 		await n8n.canvas.toggleNodeEnabled(nodeName!);
 
-		await n8n.canvas.publishWorkflow();
+		// Wait for publish response after clicking
+		const responsePromise = n8n.page.waitForResponse(
+			(response) =>
+				response.url().includes('/rest/workflows/') &&
+				response.url().includes('/activate') &&
+				response.request().method() === 'POST',
+		);
+		await n8n.canvas.getOpenPublishModalButton().click();
+		await expect(n8n.canvas.getPublishButton()).toBeEnabled();
+		await n8n.canvas.getPublishButton().click();
+		await responsePromise;
+
 		await n8n.workflowActivationModal.closeIfVisible();
 		await n8n.canvas.closeProductionChecklistIfVisible();
 

--- a/packages/testing/playwright/tests/ui/7-workflow-actions.spec.ts
+++ b/packages/testing/playwright/tests/ui/7-workflow-actions.spec.ts
@@ -113,6 +113,7 @@ test.describe('Workflow Actions', () => {
 		await expect(n8n.canvas.getPublishedIndicator()).not.toBeVisible();
 
 		await n8n.canvas.publishWorkflow();
+		await n8n.workflowActivationModal.closeIfVisible();
 
 		await expect(n8n.canvas.getPublishedIndicator()).toBeVisible();
 	});
@@ -147,6 +148,7 @@ test.describe('Workflow Actions', () => {
 		await n8n.canvas.toggleNodeEnabled(nodeName!);
 
 		await n8n.canvas.publishWorkflow();
+		await n8n.workflowActivationModal.closeIfVisible();
 
 		await expect(n8n.canvas.getPublishedIndicator()).toBeVisible();
 	});


### PR DESCRIPTION
## Summary
  - Add `closeIfVisible()` method to `WorkflowActivationModal` page object
  - Add `closeProductionChecklistIfVisible()` method to `CanvasPage`
  - Wait for button enabled state and API response

  The "Workflow published" modal only shows on first publish (when localStorage flag is not set), so we conditionally dismiss it.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1899/fix-playwright-test-dismiss-activation-modal-after-workflow-publish

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
