### PR TITLE
feat(core): Put Chat users behind license checks (no-changelog)

### DIFF
--- a/packages/cli/test/integration/credentials/credentials.api.test.ts
+++ b/packages/cli/test/integration/credentials/credentials.api.test.ts
@@ -44,6 +44,7 @@ const { any } = expect;
 
 const testServer = setupTestServer({
 	endpointGroups: ['credentials'],
+	enabledFeatures: ['feat:sharing'],
 });
 
 let owner: User;

--- a/packages/frontend/editor-ui/src/features/settings/users/components/InviteUsersModal.vue
+++ b/packages/frontend/editor-ui/src/features/settings/users/components/InviteUsersModal.vue
@@ -88,6 +88,13 @@ const isChatHubEnabled = computed((): boolean => {
 	return settingsStore.isChatFeatureEnabled;
 });
 
+const isChatUsersEnabled = computed((): boolean => {
+	return (
+		isChatHubEnabled.value &&
+		settingsStore.isEnterpriseFeatureEnabled[EnterpriseEditionFeature.AdvancedPermissions]
+	);
+});
+
 const validateEmails = (value: string | number | boolean | null | undefined) => {
 	if (typeof value !== 'string') {
 		return false;
@@ -295,6 +302,7 @@ onMounted(() => {
 								{
 									value: ROLE.ChatUser,
 									label: i18n.baseText('auth.roles.chatUser'),
+									disabled: !isChatUsersEnabled.value,
 								},
 							]
 						: []),

--- a/packages/frontend/editor-ui/src/features/settings/users/views/SettingsUsersView.vue
+++ b/packages/frontend/editor-ui/src/features/settings/users/views/SettingsUsersView.vue
@@ -141,6 +141,11 @@ const userRoles = computed((): Array<{ value: Role; label: string; disabled?: bo
 			label: i18n.baseText('auth.roles.member'),
 		},
 		{
+			value: ROLE.ChatUser,
+			label: i18n.baseText('auth.roles.chatUser'),
+			disabled: !isAdvancedPermissionsEnabled.value,
+		},
+		{
 			value: ROLE.Admin,
 			label: i18n.baseText('auth.roles.admin'),
 			disabled: !isAdvancedPermissionsEnabled.value,


### PR DESCRIPTION
## Summary

Community users can't use Chat users due to lack of credential sharing, so put the feature behind license checks to not confuse people.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
