### PR TITLE
fix(cli): register webhooks when activating workflow via REST API

### DIFF
--- a/packages/cli/src/active-workflow-manager.ts
+++ b/packages/cli/src/active-workflow-manager.ts
@@ -1000,7 +1000,7 @@ export class ActiveWorkflowManager {
 		// to prevent issues with users upgrading from a version < 1.15, where the webhook entity
 		// was cleared on shutdown to anything past 1.28.0, where we stopped populating it on init,
 		// causing all webhooks to break
-		if (['init', 'leadershipChange'].includes(activationMode)) return true;
+		if (['init', 'leadershipChange', 'activate'].includes(activationMode)) return true;
 
 		return this.instanceSettings.isLeader; // 'update' or 'activate'
 	}


### PR DESCRIPTION
## Summary

When activating a workflow via REST API (POST /rest/workflows/{id}/activate), webhooks are not being registered because `shouldAddWebhooks()` in `ActiveWorkflowManager` only returns `true` for `init` and `leadershipChange` activation modes, not for `activate`.

## Fix

Added `activate` to the list of activation modes that trigger webhook registration in `shouldAddWebhooks()` method.

**Before:**
```typescript
if (['init', 'leadershipChange'].includes(activationMode)) return true;
```

**After:**
```typescript
if (['init', 'leadershipChange', 'activate'].includes(activationMode)) return true;
```

## Testing

Tested manually on a development build:
1. Created a workflow with a webhook node
2. Activated it via REST API: `POST /rest/workflows/{id}/activate`
3. Verified the webhook responds with 200 OK and "Workflow was started"

## Related Issue

Fixes #21614