### PR TITLE
fix(editor): Fix display of publish info for migrated records (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
@@ -15,7 +15,10 @@ import TimeAgo from '@/app/components/TimeAgo.vue';
 import { getActivatableTriggerNodes } from '@/app/utils/nodeTypesUtils';
 import { useWorkflowSaving } from '@/app/composables/useWorkflowSaving';
 import { useRouter } from 'vue-router';
-import { getLastPublishedByUser } from '@/features/workflows/workflowHistory/utils';
+import {
+	getLastPublishedVersion,
+	generateVersionName,
+} from '@/features/workflows/workflowHistory/utils';
 import { nodeViewEventBus } from '@/app/event-bus';
 import CollaborationPane from '@/features/collaboration/collaboration/components/CollaborationPane.vue';
 
@@ -95,8 +98,15 @@ const showPublishIndicator = computed(() => {
 
 const activeVersion = computed(() => workflowsStore.workflow.activeVersion);
 
+const activeVersionName = computed(() => {
+	if (!activeVersion.value) {
+		return '';
+	}
+	return activeVersion.value.name || generateVersionName(activeVersion.value.versionId);
+});
+
 const latestPublishDate = computed(() => {
-	const latestPublish = getLastPublishedByUser(activeVersion.value?.workflowPublishHistory ?? []);
+	const latestPublish = getLastPublishedVersion(activeVersion.value?.workflowPublishHistory ?? []);
 	return latestPublish?.createdAt;
 });
 
@@ -123,7 +133,7 @@ defineExpose({
 		>
 			<N8nTooltip>
 				<template #content>
-					{{ activeVersion.name }}<br />{{ i18n.baseText('workflowHistory.item.active') }}
+					{{ activeVersionName }}<br />{{ i18n.baseText('workflowHistory.item.active') }}
 					<TimeAgo v-if="latestPublishDate" :date="latestPublishDate" />
 				</template>
 				<N8nIcon icon="circle-check" color="success" size="xlarge" :class="$style.icon" />

--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryContent.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryContent.vue
@@ -9,7 +9,7 @@ import type { IUser } from 'n8n-workflow';
 
 import { N8nButton, N8nIcon, N8nLink, N8nText, N8nTooltip } from '@n8n/design-system';
 import { IS_DRAFT_PUBLISH_ENABLED } from '@/app/constants';
-import { formatTimestamp } from '@/features/workflows/workflowHistory/utils';
+import { formatTimestamp, generateVersionName } from '@/features/workflows/workflowHistory/utils';
 import type { WorkflowHistoryAction } from '@/features/workflows/workflowHistory/types';
 
 const i18n = useI18n();
@@ -50,7 +50,12 @@ const formattedCreatedAt = computed<string>(() => {
 });
 
 const versionNameDisplay = computed(() => {
-	return props.workflowVersion?.name ?? formattedCreatedAt.value;
+	if (props.workflowVersion?.name) {
+		return props.workflowVersion.name;
+	}
+	return props.isVersionActive && props.workflowVersion
+		? generateVersionName(props.workflowVersion.versionId)
+		: formattedCreatedAt.value;
 });
 
 const MAX_DESCRIPTION_LENGTH = 200;

--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryListItem.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryListItem.vue
@@ -11,8 +11,9 @@ import type { IUser } from 'n8n-workflow';
 
 import { N8nActionToggle, N8nTooltip, N8nBadge } from '@n8n/design-system';
 import {
-	getLastPublishedByUser,
+	getLastPublishedVersion,
 	formatTimestamp,
+	generateVersionName,
 } from '@/features/workflows/workflowHistory/utils';
 import { IS_DRAFT_PUBLISH_ENABLED } from '@/app/constants';
 import { useUsersStore } from '@/features/settings/users/users.store';
@@ -67,7 +68,10 @@ const authors = computed<{ size: number; label: string }>(() => {
 });
 
 const versionName = computed(() => {
-	return props.item.name;
+	if (props.item.name) {
+		return props.item.name;
+	}
+	return props.isVersionActive ? generateVersionName(props.item.versionId) : '';
 });
 
 const lastPublishInfo = computed(() => {
@@ -75,7 +79,7 @@ const lastPublishInfo = computed(() => {
 		return null;
 	}
 
-	const lastPublishedByUser = getLastPublishedByUser(props.item.workflowPublishHistory);
+	const lastPublishedByUser = getLastPublishedVersion(props.item.workflowPublishHistory);
 	if (!lastPublishedByUser) {
 		return null;
 	}

--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/utils.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/utils.ts
@@ -1,10 +1,8 @@
 import type { WorkflowPublishHistory } from '@n8n/rest-api-client/api/workflowHistory';
 import dateformat from 'dateformat';
 
-export const getLastPublishedByUser = (workflowPublishHistory: WorkflowPublishHistory[]) => {
-	return workflowPublishHistory.findLast(
-		(history) => history.event === 'activated' && history.userId !== null,
-	);
+export const getLastPublishedVersion = (workflowPublishHistory: WorkflowPublishHistory[]) => {
+	return workflowPublishHistory.findLast((history) => history.event === 'activated');
 };
 
 export const generateVersionName = (versionId: string) => {


### PR DESCRIPTION
## Summary

The workflow publish history records created by the data migration didn't have userId and the workflow history records for those publishes didn't have a name so we had to add fallback.

After the fix:
<img width="443" height="352" alt="image" src="https://github.com/user-attachments/assets/4d7bb871-8d15-4451-9d46-bebbf63fa815" />
<img width="342" height="176" alt="image" src="https://github.com/user-attachments/assets/0172c836-fc01-40b4-aa57-ad5c78846c78" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4499/bug-incorrect-published-state


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
