### PR TITLE
fix(editor): Fix chat telemetry (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/chatHub/chat.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/chat.store.ts
@@ -623,6 +623,13 @@ export const useChatStore = defineStore(CHAT_STORE, () => {
 			onStreamDone,
 			onStreamError,
 		);
+
+		telemetry.track('User edited chat hub message', {
+			...flattenModel(model),
+			is_custom: model.provider === 'custom-agent',
+			chat_session_id: sessionId,
+			chat_message_id: editId,
+		});
 	}
 
 	function regenerateMessage(
@@ -659,6 +666,13 @@ export const useChatStore = defineStore(CHAT_STORE, () => {
 			onStreamDone,
 			onStreamError,
 		);
+
+		telemetry.track('User regenerated chat hub message', {
+			...flattenModel(model),
+			is_custom: model.provider === 'custom-agent',
+			chat_session_id: sessionId,
+			chat_message_id: retryId,
+		});
 	}
 
 	async function stopStreamingMessage(sessionId: ChatSessionId) {

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/CredentialSelectorModal.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/CredentialSelectorModal.vue
@@ -16,7 +16,6 @@ const props = defineProps<{
 		provider: ChatHubLLMProvider;
 		initialValue: string | null;
 		onSelect: (provider: ChatHubLLMProvider, credentialId: string | null) => void;
-		onCreateNew: (provider: ChatHubLLMProvider) => void;
 	};
 }>();
 

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/CredentialSelectorModal.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/CredentialSelectorModal.vue
@@ -8,6 +8,7 @@ import { providerDisplayNames } from '@/features/ai/chatHub/constants';
 import CredentialIcon from '@/features/credentials/components/CredentialIcon.vue';
 import CredentialPicker from '@/features/credentials/components/CredentialPicker/CredentialPicker.vue';
 import { useI18n } from '@n8n/i18n';
+import { useTelemetry } from '@/app/composables/useTelemetry';
 
 const props = defineProps<{
 	modalName: string;
@@ -20,6 +21,8 @@ const props = defineProps<{
 }>();
 
 const i18n = useI18n();
+const telemetry = useTelemetry();
+
 const modalBus = ref(createEventBus());
 const selectedCredentialId = ref<string | null>(props.data.initialValue);
 
@@ -43,6 +46,15 @@ function onDeleteCredential(credentialId: string) {
 	if (credentialId === props.data.initialValue) {
 		props.data.onSelect(props.data.provider, null);
 	}
+}
+
+function onCredentialModalOpened(credentialId?: string) {
+	telemetry.track('User opened Credential modal', {
+		credential_type: credentialType.value,
+		source: 'chat',
+		new_credential: !credentialId,
+		workflow_id: null,
+	});
 }
 
 function onConfirm() {
@@ -106,6 +118,7 @@ function onCancel() {
 						@credential-selected="onCredentialSelect"
 						@credential-deselected="onCredentialDeselect"
 						@credential-deleted="onDeleteCredential"
+						@credential-modal-opened="onCredentialModalOpened"
 					/>
 				</div>
 			</div>

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ModelSelector.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ModelSelector.vue
@@ -270,7 +270,6 @@ function openCredentialsSelectorOrCreate(provider: ChatHubLLMProvider) {
 			provider,
 			initialValue: credentials?.[provider] ?? null,
 			onSelect: handleSelectCredentials,
-			onCreateNew: handleCreateNewCredential,
 		},
 	});
 }
@@ -315,19 +314,6 @@ function onSelect(id: string) {
 	});
 
 	emit('change', parsedModel);
-}
-
-function handleCreateNewCredential(provider: ChatHubLLMProvider) {
-	const credentialType = PROVIDER_CREDENTIAL_TYPE_MAP[provider];
-
-	telemetry.track('User opened Credential modal', {
-		credential_type: credentialType,
-		source: 'chat',
-		new_credential: true,
-		workflow_id: null,
-	});
-
-	uiStore.openNewCredential(credentialType);
 }
 
 onClickOutside(

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ToolsSelectorModal.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ToolsSelectorModal.vue
@@ -23,6 +23,7 @@ import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useI18n } from '@n8n/i18n';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import { getResourcePermissions } from '@n8n/permissions';
+import { useTelemetry } from '@/app/composables/useTelemetry';
 
 const props = defineProps<{
 	modalName: string;
@@ -38,6 +39,7 @@ const credentialsStore = useCredentialsStore();
 const nodeTypesStore = useNodeTypesStore();
 const projectStore = useProjectsStore();
 const uiStore = useUIStore();
+const telemetry = useTelemetry();
 
 const canCreateCredentials = computed(() => {
 	return getResourcePermissions(projectStore.personalProject?.scopes).credential.create;
@@ -140,6 +142,13 @@ function onCredentialSelect(providerKey: ChatHubAgentTool, id: string) {
 function onCreateNewCredential(providerKey: ChatHubAgentTool) {
 	const provider = AVAILABLE_TOOLS[providerKey];
 	if (!provider.credentialType) return;
+
+	telemetry.track('User opened Credential modal', {
+		credential_type: provider.credentialType,
+		source: 'chat',
+		new_credential: true,
+		workflow_id: null,
+	});
 
 	uiStore.openNewCredential(provider.credentialType);
 }

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/module.descriptor.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/module.descriptor.ts
@@ -57,7 +57,6 @@ export const ChatModule: FrontendModuleDescription = {
 					provider: null,
 					initialValue: null,
 					onSelect: () => {},
-					onCreateNew: () => {},
 				},
 			},
 		},

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialPicker/CredentialPicker.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialPicker/CredentialPicker.vue
@@ -25,7 +25,7 @@ const props = defineProps<{
 const emit = defineEmits<{
 	credentialSelected: [credentialId: string];
 	credentialDeselected: [];
-	credentialModalOpened: [];
+	credentialModalOpened: [credentialId?: string];
 	credentialDeleted: [credentialId: string];
 }>();
 
@@ -102,13 +102,13 @@ const onCredentialSelected = (credentialId: string) => {
 const createNewCredential = () => {
 	uiStore.openNewCredential(props.credentialType, true);
 	wasModalOpenedFromHere.value = true;
-	emit('credentialModalOpened');
+	emit('credentialModalOpened', undefined);
 };
 const editCredential = () => {
 	assert(props.selectedCredentialId);
 	uiStore.openExistingCredential(props.selectedCredentialId);
 	wasModalOpenedFromHere.value = true;
-	emit('credentialModalOpened');
+	emit('credentialModalOpened', props.selectedCredentialId);
 };
 const deleteCredential = async () => {
 	assert(props.selectedCredentialId);


### PR DESCRIPTION
## Summary

- Restore `User opened Credential modal` event (it seems was lost when switched to the CredentialPicker component)
- Add `User opened Credential modal` event for opening creds modal from tools modal
- Add more events as per https://www.notion.so/n8n/telemetry-requirements-2bd5b6e0c94f80b4b86de35e67556ac0?source=copy_link

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
