### PR TITLE
fix: Add `HOME` env var to distroless runners image

### DIFF
--- a/docker/images/runners/Dockerfile.distroless
+++ b/docker/images/runners/Dockerfile.distroless
@@ -172,7 +172,8 @@ ARG N8N_VERSION=snapshot
 ARG N8N_RELEASE_TYPE=dev
 
 ENV NODE_ENV=production \
-    N8N_RELEASE_TYPE=${N8N_RELEASE_TYPE}
+    N8N_RELEASE_TYPE=${N8N_RELEASE_TYPE} \
+    HOME=/home/runner
 
 # Copy everything from the prepared runtime filesystem
 COPY --from=runtime-prep --chown=root:root /runtime/ /


### PR DESCRIPTION
## Summary

Two days ago I [fixed an image mismatch](https://github.com/n8n-io/n8n-cloud/pull/2767) to address this issue in distroless runners:

```
SystemError [ERR_SYSTEM_ERROR]: A system error occurred: uv_os_homedir returned ENOENT (no such file or directory)
```

That fix assumed that `/etc/passwd` existed for the user but wasn't being found only because of the image mismatch, but distroless runners don't have `/etc/passwd`. `uv_os_homedir` looks for `HOME` or `/etc/passwd` but [does not specify](https://github.com/nodejs/node/blob/e77694631f1642c302f664703197b5aabc65b482/deps/uv/src/unix/core.c#L1195-L1228) which one was not found.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://n8nio.slack.com/archives/C034S4SV6LX/p1764926462240079?thread_ts=1764911984.859129&cid=C034S4SV6LX

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
