### PR TITLE
refactor(core): Make Sentry init non-fatal for JS runner

### DIFF
--- a/packages/@n8n/task-runner/src/start.ts
+++ b/packages/@n8n/task-runner/src/start.ts
@@ -54,7 +54,15 @@ void (async function start() {
 	});
 
 	sentry = Container.get(TaskRunnerSentry);
-	await sentry.initIfEnabled();
+	try {
+		await sentry.initIfEnabled();
+	} catch (error) {
+		console.error(
+			'FAILED TO INITIALIZE SENTRY. ERROR REPORTING WILL BE DISABLED. THIS IS LIKELY A CONFIGURATION OR ENVIRONMENT ISSUE.',
+			error,
+		);
+		sentry = undefined;
+	}
 
 	runner = new JsTaskRunner(config);
 	runner.on('runner:reached-idle-timeout', () => {


### PR DESCRIPTION
## Summary

We recently had an issue where [Sentry init failing](https://github.com/n8n-io/n8n-cloud/pull/2767) led to the JS runner crashing. This case should be non-fatal, even at the cost of silently losing Sentry reporting.

Only an issue for the JS runner. Python runner already handles this gracefully:

https://github.com/n8n-io/n8n/blob/132f9c6f707176f1fbd5b5d7d8177ea4b0f8df3c/packages/%40n8n/task-runner-python/src/sentry.py#L85-L88

## Related Linear tickets, Github issues, and Community forum posts

n/a
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
