### PR TITLE
test: Move project and folder tests to projects/ directory

### DIFF
--- a/packages/testing/playwright/tests/ui/projects/folders-advanced.spec.ts
+++ b/packages/testing/playwright/tests/ui/projects/folders-advanced.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../../fixtures/base';
+import { test, expect } from '../../../fixtures/base';
 
 test.describe('Folders - Advanced Operations', () => {
 	test.describe('Duplicate workflows', () => {

--- a/packages/testing/playwright/tests/ui/projects/folders-basic.spec.ts
+++ b/packages/testing/playwright/tests/ui/projects/folders-basic.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../../fixtures/base';
+import { test, expect } from '../../../fixtures/base';
 
 test.describe('Folders - Basic Operations', () => {
 	const FOLDER_CREATED_NOTIFICATION = 'Folder created';

--- a/packages/testing/playwright/tests/ui/projects/folders-operations.spec.ts
+++ b/packages/testing/playwright/tests/ui/projects/folders-operations.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../../fixtures/base';
+import { test, expect } from '../../../fixtures/base';
 
 test.describe('Folders - Operations', () => {
 	test.describe('Rename and delete folders', () => {

--- a/packages/testing/playwright/tests/ui/projects/project-settings.spec.ts
+++ b/packages/testing/playwright/tests/ui/projects/project-settings.spec.ts
@@ -1,6 +1,6 @@
 import { nanoid } from 'nanoid';
 
-import { test, expect } from '../../fixtures/base';
+import { test, expect } from '../../../fixtures/base';
 
 test.describe('Project Settings - Member Management', () => {
 	test.beforeEach(async ({ n8n }) => {

--- a/packages/testing/playwright/tests/ui/projects/projects.spec.ts
+++ b/packages/testing/playwright/tests/ui/projects/projects.spec.ts
@@ -4,8 +4,8 @@ import {
 	INSTANCE_ADMIN_CREDENTIALS,
 	INSTANCE_MEMBER_CREDENTIALS,
 	INSTANCE_OWNER_CREDENTIALS,
-} from '../../config/test-users';
-import { test, expect } from '../../fixtures/base';
+} from '../../../config/test-users';
+import { test, expect } from '../../../fixtures/base';
 
 const MANUAL_TRIGGER_NODE_NAME = 'Manual Trigger';
 const EXECUTE_WORKFLOW_NODE_NAME = 'Execute Sub-workflow';


### PR DESCRIPTION
## Summary

  - Reorganize project and folder E2E tests into `tests/ui/projects/` directory
  - Remove numeric prefixes from filenames (39-, 49-)
  - Update import paths for new directory depth

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/CAT-1815/projects-organization


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
