### PR TITLE
fix(elasticsearch): Prevent mixing bulk and non-bulk operations

### DIFF
--- a/packages/nodes-base/nodes/Elastic/Elasticsearch/Elasticsearch.node.ts
+++ b/packages/nodes-base/nodes/Elastic/Elasticsearch/Elasticsearch.node.ts
@@ -74,8 +74,9 @@ export class Elasticsearch implements INodeType {
 
 		let bulkBody: IDataObject = {};
 
+		const bulkOperation = this.getNodeParameter('options.bulkOperation', 0, false);
+
 		for (let i = 0; i < items.length; i++) {
-			const bulkOperation = this.getNodeParameter('options.bulkOperation', i, false);
 			if (resource === 'document') {
 				// **********************************************************************
 				//                                document


### PR DESCRIPTION
## Summary

Move `bulkOperation` parameter retrieval outside the loop to enforce consistent bulk mode across all items. Previously, output order was not preserved when mixing bulk and non-bulk operations because non-bulk results were added immediately during the loop while bulk results were added later after the bulk API call.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
