### PR TITLE
fix(core): Add version back to public settings (no-changelog)

### DIFF
--- a/packages/cli/src/services/__tests__/frontend.service.test.ts
+++ b/packages/cli/src/services/__tests__/frontend.service.test.ts
@@ -202,6 +202,11 @@ describe('FrontendService', () => {
 
 	describe('getPublicSettings', () => {
 		it('should return public settings', () => {
+			const { service } = createMockService();
+			service.settings.versionCli = '1.123.0';
+
+			const settings = service.getPublicSettings();
+
 			const expectedPublicSettings: PublicFrontendSettings = {
 				settingsMode: 'public',
 				userManagement: {
@@ -209,6 +214,7 @@ describe('FrontendService', () => {
 					showSetupOnFirstLoad: true,
 					authenticationMethod: 'email',
 				},
+				versionCli: '1.123.0',
 				sso: {
 					saml: { loginEnabled: false },
 					ldap: { loginEnabled: false, loginLabel: '' },
@@ -221,10 +227,6 @@ describe('FrontendService', () => {
 				previewMode: false,
 				enterprise: { saml: false, ldap: false, oidc: false },
 			};
-
-			const { service } = createMockService();
-			const settings = service.getPublicSettings();
-
 			expect(settings).toEqual(expectedPublicSettings);
 		});
 	});

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -39,6 +39,8 @@ export type PublicFrontendSettings = {
 	/** Controls initialization flow in settings store */
 	settingsMode: FrontendSettings['settingsMode'];
 
+	versionCli: string;
+
 	/** Used to bypass authentication on the workflows/demo page */
 	previewMode: FrontendSettings['previewMode'];
 
@@ -540,6 +542,7 @@ export class FrontendService {
 					loginUrl: ssoOidc.loginUrl,
 				},
 			},
+			versionCli: this.settings.versionCli,
 			authCookie,
 			previewMode,
 			enterprise: { saml, ldap, oidc },


### PR DESCRIPTION
## Summary

Was removed in https://github.com/n8n-io/n8n/pull/22106, but we need it for automations that share the updated version. See discussion in https://n8nio.slack.com/archives/C069KJBJ8HE/p1764669520148939

Alternative to https://github.com/n8n-io/n8n/pull/22610

## Related Linear tickets, Github issues, and Community forum posts

Closes PAY-4252


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
