### PR TITLE
feat: Include active version id in `workflowActivated` broadcast event (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/push/workflow.ts
+++ b/packages/@n8n/api-types/src/push/workflow.ts
@@ -2,6 +2,7 @@ export type WorkflowActivated = {
 	type: 'workflowActivated';
 	data: {
 		workflowId: string;
+		activeVersionId: string;
 	};
 };
 

--- a/packages/cli/src/scaling/pubsub/__tests__/pubsub.registry.test.ts
+++ b/packages/cli/src/scaling/pubsub/__tests__/pubsub.registry.test.ts
@@ -12,6 +12,7 @@ describe('PubSubRegistry', () => {
 	let pubsubEventBus: PubSubEventBus;
 	let logger: ReturnType<typeof mockLogger>;
 	const workflowId = 'test-workflow-id';
+	const activeVersionId = 'test-version-id';
 
 	const createTestServiceClass = () => {
 		@Service()
@@ -130,9 +131,9 @@ describe('PubSubRegistry', () => {
 		);
 		pubSubRegistry.init();
 
-		pubsubEventBus.emit('add-webhooks-triggers-and-pollers', { workflowId });
+		pubsubEventBus.emit('add-webhooks-triggers-and-pollers', { workflowId, activeVersionId });
 		expect(onLeaderInstanceSpy).toHaveBeenCalledTimes(1);
-		expect(onLeaderInstanceSpy).toHaveBeenCalledWith({ workflowId });
+		expect(onLeaderInstanceSpy).toHaveBeenCalledWith({ workflowId, activeVersionId });
 
 		pubsubEventBus.emit('restart-event-bus');
 		expect(onFollowerInstanceSpy).not.toHaveBeenCalled();
@@ -152,7 +153,7 @@ describe('PubSubRegistry', () => {
 		);
 		followerPubSubRegistry.init();
 
-		pubsubEventBus.emit('add-webhooks-triggers-and-pollers', { workflowId });
+		pubsubEventBus.emit('add-webhooks-triggers-and-pollers', { workflowId, activeVersionId });
 		expect(onLeaderInstanceSpy).not.toHaveBeenCalled();
 
 		pubsubEventBus.emit('restart-event-bus');
@@ -176,9 +177,9 @@ describe('PubSubRegistry', () => {
 		);
 		pubSubRegistry.init();
 
-		pubsubEventBus.emit('add-webhooks-triggers-and-pollers', { workflowId });
+		pubsubEventBus.emit('add-webhooks-triggers-and-pollers', { workflowId, activeVersionId });
 		expect(onLeaderInstanceSpy).toHaveBeenCalledTimes(1);
-		expect(onLeaderInstanceSpy).toHaveBeenCalledWith({ workflowId });
+		expect(onLeaderInstanceSpy).toHaveBeenCalledWith({ workflowId, activeVersionId });
 	});
 
 	it('should handle dynamic role changes at runtime', () => {
@@ -196,19 +197,19 @@ describe('PubSubRegistry', () => {
 		pubSubRegistry.init();
 
 		// Initially as follower, event should be ignored
-		pubsubEventBus.emit('add-webhooks-triggers-and-pollers', { workflowId });
+		pubsubEventBus.emit('add-webhooks-triggers-and-pollers', { workflowId, activeVersionId });
 		expect(onLeaderInstanceSpy).not.toHaveBeenCalled();
 
 		// Change role to leader
 		instanceSettings.instanceRole = 'leader';
-		pubsubEventBus.emit('add-webhooks-triggers-and-pollers', { workflowId });
+		pubsubEventBus.emit('add-webhooks-triggers-and-pollers', { workflowId, activeVersionId });
 		expect(onLeaderInstanceSpy).toHaveBeenCalledTimes(1);
-		expect(onLeaderInstanceSpy).toHaveBeenCalledWith({ workflowId });
+		expect(onLeaderInstanceSpy).toHaveBeenCalledWith({ workflowId, activeVersionId });
 
 		// Change back to follower
 		onLeaderInstanceSpy.mockClear();
 		instanceSettings.instanceRole = 'follower';
-		pubsubEventBus.emit('add-webhooks-triggers-and-pollers', { workflowId });
+		pubsubEventBus.emit('add-webhooks-triggers-and-pollers', { workflowId, activeVersionId });
 		expect(onLeaderInstanceSpy).not.toHaveBeenCalled();
 	});
 

--- a/packages/cli/src/scaling/pubsub/pubsub.event-map.ts
+++ b/packages/cli/src/scaling/pubsub/pubsub.event-map.ts
@@ -56,6 +56,7 @@ export type PubSubCommandMap = {
 
 	'add-webhooks-triggers-and-pollers': {
 		workflowId: string;
+		activeVersionId: string;
 	};
 
 	'remove-triggers-and-pollers': {
@@ -64,6 +65,7 @@ export type PubSubCommandMap = {
 
 	'display-workflow-activation': {
 		workflowId: string;
+		activeVersionId: string;
 	};
 
 	'display-workflow-deactivation': {

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -378,7 +378,7 @@ export class WorkflowService {
 			await this.workflowTagMappingRepository.overwriteTaggings(workflowId, tagIds);
 		}
 
-		const relations = tagsDisabled ? [] : ['tags'];
+		const relations = tagsDisabled ? ['activeVersion'] : ['tags', 'activeVersion'];
 
 		// We sadly get nothing back from "update". Neither if it updated a record
 		// nor the new value. So query now the hopefully updated entry.

--- a/packages/cli/test/integration/workflows/workflows.controller.ee.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.ee.test.ts
@@ -1442,6 +1442,38 @@ describe('PATCH /workflows/:workflowId', () => {
 			expect(historyVersion!.nodes).toEqual(payload.nodes);
 		});
 	});
+
+	test('should include activeVersion relation in response for active workflows', async () => {
+		const teamProject = await createTeamProject();
+		const workflow = await createActiveWorkflow({}, teamProject);
+
+		const response = await authOwnerAgent.patch(`/workflows/${workflow.id}`).send({
+			name: 'Updated Name',
+			versionId: workflow.versionId,
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body.data).toHaveProperty('activeVersion');
+		expect(response.body.data.activeVersion).toBeDefined();
+		expect(response.body.data.activeVersion).toMatchObject({
+			versionId: expect.any(String),
+			workflowId: workflow.id,
+		});
+	});
+
+	test('should include activeVersion as null for inactive workflows', async () => {
+		const teamProject = await createTeamProject();
+		const workflow = await createWorkflow({}, teamProject);
+
+		const response = await authOwnerAgent.patch(`/workflows/${workflow.id}`).send({
+			name: 'Updated Name',
+			versionId: workflow.versionId,
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body.data).toHaveProperty('activeVersion');
+		expect(response.body.data.activeVersion).toBeNull();
+	});
 });
 
 describe('PUT /:workflowId/transfer', () => {

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowActivated.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowActivated.ts
@@ -1,12 +1,23 @@
 import type { WorkflowActivated } from '@n8n/api-types/push/workflow';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useBannersStore } from '@/features/shared/banners/banners.store';
+import { getWorkflowVersion } from '@n8n/rest-api-client';
+import { useRootStore } from '@n8n/stores/useRootStore';
 
 export async function workflowActivated({ data }: WorkflowActivated) {
 	const workflowsStore = useWorkflowsStore();
 	const bannersStore = useBannersStore();
+	const rootStore = useRootStore();
 
-	workflowsStore.setWorkflowActive(data.workflowId);
+	if (workflowsStore.workflow.activeVersionId !== data.activeVersionId) {
+		const activeVersion = await getWorkflowVersion(
+			rootStore.restApiContext,
+			data.workflowId,
+			data.activeVersionId,
+		);
+
+		workflowsStore.setWorkflowActive(data.workflowId, activeVersion);
+	}
 
 	// Remove auto-deactivated banner if viewing this workflow
 	if (workflowsStore.workflowId === data.workflowId) {

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowActivated.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowActivated.ts
@@ -26,7 +26,7 @@ export async function workflowActivated({ data }: WorkflowActivated) {
 
 		// Only update checksum if there are no unsaved changes
 		if (!uiStore.stateIsDirty) {
-			await workflowsStore.fetchAndUpdateWorkflowChecksum(workflowId);
+			await workflowsStore.updateWorkflowChecksum();
 		}
 	}
 

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowAutoDeactivated.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowAutoDeactivated.ts
@@ -1,14 +1,21 @@
 import type { WorkflowAutoDeactivated } from '@n8n/api-types/push/workflow';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useBannersStore } from '@/features/shared/banners/banners.store';
+import { useUIStore } from '@/app/stores/ui.store';
 
 export async function workflowAutoDeactivated({ data }: WorkflowAutoDeactivated) {
 	const workflowsStore = useWorkflowsStore();
 	const bannersStore = useBannersStore();
+	const uiStore = useUIStore();
 
 	workflowsStore.setWorkflowInactive(data.workflowId);
 
 	if (workflowsStore.workflowId === data.workflowId) {
+		// Only update checksum if there are no unsaved changes
+		if (!uiStore.stateIsDirty) {
+			await workflowsStore.fetchAndUpdateWorkflowChecksum(data.workflowId);
+		}
+
 		bannersStore.pushBannerToStack('WORKFLOW_AUTO_DEACTIVATED');
 	}
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowAutoDeactivated.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowAutoDeactivated.ts
@@ -13,7 +13,7 @@ export async function workflowAutoDeactivated({ data }: WorkflowAutoDeactivated)
 	if (workflowsStore.workflowId === data.workflowId) {
 		// Only update checksum if there are no unsaved changes
 		if (!uiStore.stateIsDirty) {
-			await workflowsStore.fetchAndUpdateWorkflowChecksum(data.workflowId);
+			await workflowsStore.updateWorkflowChecksum();
 		}
 
 		bannersStore.pushBannerToStack('WORKFLOW_AUTO_DEACTIVATED');

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowDeactivated.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowDeactivated.ts
@@ -1,8 +1,17 @@
 import type { WorkflowDeactivated } from '@n8n/api-types/push/workflow';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useUIStore } from '@/app/stores/ui.store';
 
 export async function workflowDeactivated({ data }: WorkflowDeactivated) {
 	const workflowsStore = useWorkflowsStore();
+	const uiStore = useUIStore();
 
 	workflowsStore.setWorkflowInactive(data.workflowId);
+
+	if (workflowsStore.workflowId === data.workflowId) {
+		// Only update checksum if there are no unsaved changes
+		if (!uiStore.stateIsDirty) {
+			await workflowsStore.fetchAndUpdateWorkflowChecksum(data.workflowId);
+		}
+	}
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowDeactivated.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowDeactivated.ts
@@ -11,7 +11,7 @@ export async function workflowDeactivated({ data }: WorkflowDeactivated) {
 	if (workflowsStore.workflowId === data.workflowId) {
 		// Only update checksum if there are no unsaved changes
 		if (!uiStore.stateIsDirty) {
-			await workflowsStore.fetchAndUpdateWorkflowChecksum(data.workflowId);
+			await workflowsStore.updateWorkflowChecksum();
 		}
 	}
 }

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.ts
@@ -110,8 +110,8 @@ export function useWorkflowActivate() {
 			}
 
 			// Update local state
-			if (workflow.activeVersionId !== null) {
-				workflowsStore.setWorkflowActive(currWorkflowId);
+			if (workflow.activeVersion) {
+				workflowsStore.setWorkflowActive(currWorkflowId, workflow.activeVersion);
 			} else {
 				workflowsStore.setWorkflowInactive(currWorkflowId);
 			}

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.ts
@@ -214,6 +214,7 @@ export function useWorkflowActivate() {
 					interpolate: { newStateName: 'published' },
 				}) + ':',
 			);
+			workflowsStore.setWorkflowInactive(workflowId);
 			return false;
 		} finally {
 			updatingWorkflowActivation.value = false;

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
@@ -857,7 +857,7 @@ export function useWorkflowHelpers() {
 		}
 
 		if (workflow.activeVersion) {
-			workflowsStore.setWorkflowActive(workflowId, workflow.activeVersion);
+			workflowsStore.setWorkflowActive(workflowId, workflow.activeVersion, isCurrentWorkflow);
 		} else {
 			workflowsStore.setWorkflowInactive(workflowId);
 		}

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
@@ -856,8 +856,8 @@ export function useWorkflowHelpers() {
 			uiStore.stateIsDirty = false;
 		}
 
-		if (workflow.activeVersionId !== null) {
-			workflowsStore.setWorkflowActive(workflowId);
+		if (workflow.activeVersion) {
+			workflowsStore.setWorkflowActive(workflowId, workflow.activeVersion);
 		} else {
 			workflowsStore.setWorkflowInactive(workflowId);
 		}

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.test.ts
@@ -45,6 +45,7 @@ import {
 import { waitFor } from '@testing-library/vue';
 import { useWorkflowState } from '@/app/composables/useWorkflowState';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
+import type { WorkflowHistory } from '@n8n/rest-api-client';
 
 vi.mock('@/features/ndv/shared/ndv.store', () => ({
 	useNDVStore: vi.fn(() => ({
@@ -892,12 +893,22 @@ describe('useWorkflowsStore', () => {
 	});
 
 	describe('setWorkflowActive()', () => {
-		it('should set workflow as active when it is not already active', () => {
+		it('should set workflow as active when it is not already active', async () => {
 			uiStore.stateIsDirty = true;
 			workflowsStore.workflowsById = { '1': { active: false } as IWorkflowDb };
 			workflowsStore.workflow.id = '1';
 
-			workflowsStore.setWorkflowActive('1');
+			const mockActiveVersion: WorkflowHistory = {
+				versionId: 'test-version-id',
+				name: 'Test Version',
+				authors: 'Test Author',
+				description: 'A test workflow version',
+				createdAt: new Date().toISOString(),
+				updatedAt: new Date().toISOString(),
+				workflowPublishHistory: [],
+			};
+
+			workflowsStore.setWorkflowActive('1', mockActiveVersion);
 
 			expect(workflowsStore.activeWorkflows).toContain('1');
 			expect(workflowsStore.workflowsById['1'].active).toBe(true);
@@ -905,23 +916,44 @@ describe('useWorkflowsStore', () => {
 			expect(uiStore.stateIsDirty).toBe(false);
 		});
 
-		it('should not modify active workflows when workflow is already active', () => {
+		it('should not modify active workflows when workflow is already active', async () => {
 			workflowsStore.activeWorkflows = ['1'];
 			workflowsStore.workflowsById = { '1': { active: true } as IWorkflowDb };
 			workflowsStore.workflow.id = '1';
 
-			workflowsStore.setWorkflowActive('1');
+			const mockActiveVersion: WorkflowHistory = {
+				versionId: 'test-version-id',
+				name: 'Test Version',
+				authors: 'Test Author',
+				description: 'A test workflow version',
+				createdAt: new Date().toISOString(),
+				updatedAt: new Date().toISOString(),
+				workflowPublishHistory: [],
+			};
+
+			workflowsStore.setWorkflowActive('1', mockActiveVersion);
 
 			expect(workflowsStore.activeWorkflows).toEqual(['1']);
 			expect(workflowsStore.workflowsById['1'].active).toBe(true);
 			expect(workflowsStore.workflow.active).toBe(true);
 		});
 
-		it('should not set current workflow as active when it is not the target', () => {
+		it('should not set current workflow as active when it is not the target', async () => {
 			uiStore.stateIsDirty = true;
 			workflowsStore.workflow.id = '1';
 			workflowsStore.workflowsById = { '1': { active: false } as IWorkflowDb };
-			workflowsStore.setWorkflowActive('2');
+
+			const mockActiveVersion: WorkflowHistory = {
+				versionId: 'test-version-id',
+				name: 'Test Version',
+				authors: 'Test Author',
+				description: 'A test workflow version',
+				createdAt: new Date().toISOString(),
+				updatedAt: new Date().toISOString(),
+				workflowPublishHistory: [],
+			};
+
+			workflowsStore.setWorkflowActive('2', mockActiveVersion);
 			expect(workflowsStore.workflowsById['1'].active).toBe(false);
 			expect(uiStore.stateIsDirty).toBe(true);
 		});

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.test.ts
@@ -916,7 +916,7 @@ describe('useWorkflowsStore', () => {
 			expect(uiStore.stateIsDirty).toBe(false);
 		});
 
-		it('should not modify active workflows when workflow is already active', async () => {
+		it('should not modify active workflows when workflow is already active', () => {
 			workflowsStore.activeWorkflows = ['1'];
 			workflowsStore.workflowsById = { '1': { active: true } as IWorkflowDb };
 			workflowsStore.workflow.id = '1';
@@ -938,7 +938,7 @@ describe('useWorkflowsStore', () => {
 			expect(workflowsStore.workflow.active).toBe(true);
 		});
 
-		it('should not set current workflow as active when it is not the target', async () => {
+		it('should not set current workflow as active when it is not the target', () => {
 			uiStore.stateIsDirty = true;
 			workflowsStore.workflow.id = '1';
 			workflowsStore.workflowsById = { '1': { active: false } as IWorkflowDb };

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -898,21 +898,22 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		};
 	}
 
-	function setWorkflowActive(targetWorkflowId: string, activeVersion?: WorkflowHistory) {
-		const index = activeWorkflows.value.indexOf(targetWorkflowId);
-		if (index === -1) {
+	function setWorkflowActive(targetWorkflowId: string, activeVersion: WorkflowHistory) {
+		if (activeWorkflows.value.indexOf(targetWorkflowId) === -1) {
 			activeWorkflows.value.push(targetWorkflowId);
 		}
-		const targetWorkflow = workflowsById.value[targetWorkflowId];
-		if (targetWorkflow) {
-			targetWorkflow.active = true;
-			targetWorkflow.activeVersionId = activeVersion?.versionId ?? targetWorkflow.versionId;
-			targetWorkflow.activeVersion = activeVersion;
+
+		const cachedWorkflow = workflowsById.value[targetWorkflowId];
+		if (cachedWorkflow) {
+			cachedWorkflow.active = true;
+			cachedWorkflow.activeVersionId = activeVersion.versionId;
+			cachedWorkflow.activeVersion = activeVersion;
 		}
+
 		if (targetWorkflowId === workflow.value.id) {
 			uiStore.stateIsDirty = false;
 			workflow.value.active = true;
-			workflow.value.activeVersionId = activeVersion?.versionId ?? workflow.value.versionId;
+			workflow.value.activeVersionId = activeVersion.versionId;
 			workflow.value.activeVersion = activeVersion;
 		}
 	}

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -904,7 +904,11 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		};
 	}
 
-	function setWorkflowActive(targetWorkflowId: string, activeVersion: WorkflowHistory) {
+	function setWorkflowActive(
+		targetWorkflowId: string,
+		activeVersion: WorkflowHistory,
+		clearDirtyState: boolean = true,
+	) {
 		if (activeWorkflows.value.indexOf(targetWorkflowId) === -1) {
 			activeWorkflows.value.push(targetWorkflowId);
 		}
@@ -917,7 +921,9 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		}
 
 		if (targetWorkflowId === workflow.value.id) {
-			uiStore.stateIsDirty = false;
+			if (clearDirtyState) {
+				uiStore.stateIsDirty = false;
+			}
 			workflow.value.active = true;
 			workflow.value.activeVersionId = activeVersion.versionId;
 			workflow.value.activeVersion = activeVersion;

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -748,9 +748,8 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		workflowChecksum.value = checksum;
 	}
 
-	async function fetchAndUpdateWorkflowChecksum(wid: string) {
-		const fetchedWorkflow = await fetchWorkflow(wid);
-		const checksum = await calculateWorkflowChecksum(fetchedWorkflow);
+	async function updateWorkflowChecksum() {
+		const checksum = await calculateWorkflowChecksum(workflow.value);
 		setWorkflowChecksum(checksum);
 	}
 
@@ -2029,7 +2028,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		setUsedCredentials,
 		setWorkflowVersionId,
 		setWorkflowChecksum,
-		fetchAndUpdateWorkflowChecksum,
+		updateWorkflowChecksum,
 		setWorkflowActiveVersion,
 		replaceInvalidWorkflowCredentials,
 		assignCredentialToMatchingNodes,

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -748,6 +748,12 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		workflowChecksum.value = checksum;
 	}
 
+	async function fetchAndUpdateWorkflowChecksum(wid: string) {
+		const fetchedWorkflow = await fetchWorkflow(wid);
+		const checksum = await calculateWorkflowChecksum(fetchedWorkflow);
+		setWorkflowChecksum(checksum);
+	}
+
 	function setWorkflowActiveVersion(version: WorkflowHistory) {
 		workflow.value.activeVersion = deepCopy(version);
 	}
@@ -2017,6 +2023,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		setUsedCredentials,
 		setWorkflowVersionId,
 		setWorkflowChecksum,
+		fetchAndUpdateWorkflowChecksum,
 		setWorkflowActiveVersion,
 		replaceInvalidWorkflowCredentials,
 		assignCredentialToMatchingNodes,


### PR DESCRIPTION
## Summary

- Add `activeVersionId` to broadcasted workflow activated event and update the state correctly
    - update checksum in case there are no ui changes so that user can proceed with other actions straightaway

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-4501](https://linear.app/n8n/issue/ADO-4501/feature-queue-mode-include-active-version-id-in-workflowactivated)


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
