### PR TITLE
refactor(core): Move the chat link (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/MainSidebar.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainSidebar.vue
@@ -28,7 +28,6 @@ import {
 	EXPERIMENT_TEMPLATES_DATA_QUALITY_KEY,
 } from '@/app/constants';
 import { EXTERNAL_LINKS } from '@/app/constants/externalLinks';
-import { CHAT_VIEW } from '@/features/ai/chatHub/constants';
 import { hasPermission } from '@/app/utils/rbac/permissions';
 import { useCloudPlanStore } from '@/app/stores/cloudPlan.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
@@ -116,16 +115,6 @@ const mainMenuItems = computed<IMenuItem[]>(() => [
 		label: 'Admin Panel',
 		icon: 'cloud',
 		available: settingsStore.isCloudDeployment && hasPermission(['instanceOwner']),
-	},
-	{
-		id: 'chat',
-		icon: 'message-circle',
-		label: 'Chat',
-		position: 'bottom',
-		route: { to: { name: CHAT_VIEW } },
-		available:
-			settingsStore.isChatFeatureEnabled &&
-			hasPermission(['rbac'], { rbac: { scope: 'chatHub:message' } }),
 	},
 	{
 		// Link to in-app pre-built agent templates, available experiment is enabled

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectNavigation.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectNavigation.vue
@@ -9,8 +9,10 @@ import { useI18n } from '@n8n/i18n';
 import { computed, onBeforeMount, onBeforeUnmount } from 'vue';
 import { useProjectsStore } from '../projects.store';
 import type { ProjectListItem } from '../projects.types';
+import { CHAT_VIEW } from '@/features/ai/chatHub/constants';
 
 import { N8nButton, N8nHeading, N8nMenuItem, N8nTooltip } from '@n8n/design-system';
+import { hasPermission } from '@/app/utils/rbac/permissions';
 
 type Props = {
 	collapsed: boolean;
@@ -29,6 +31,11 @@ const usersStore = useUsersStore();
 const isCreatingProject = computed(() => globalEntityCreation.isCreatingProject.value);
 const displayProjects = computed(() => globalEntityCreation.displayProjects.value);
 const isFoldersFeatureEnabled = computed(() => settingsStore.isFoldersFeatureEnabled);
+const isChatLinkAvailable = computed(
+	() =>
+		settingsStore.isChatFeatureEnabled &&
+		hasPermission(['rbac'], { rbac: { scope: 'chatHub:message' } }),
+);
 const hasMultipleVerifiedUsers = computed(
 	() => usersStore.allUsers.filter((user) => !user.isPendingUser).length > 1,
 );
@@ -87,6 +94,14 @@ const activeTabId = computed(() => {
 	);
 });
 
+const chat = computed<IMenuItem>(() => ({
+	id: 'chat',
+	icon: 'message-circle',
+	label: 'Chat',
+	position: 'bottom',
+	route: { to: { name: CHAT_VIEW } },
+}));
+
 async function onSourceControlPull() {
 	// Update myProjects for the sidebar display
 	await projectsStore.getMyProjects();
@@ -127,6 +142,13 @@ onBeforeUnmount(() => {
 				:compact="props.collapsed"
 				:active="activeTabId === 'shared'"
 				data-test-id="project-shared-menu-item"
+			/>
+			<N8nMenuItem
+				v-if="isChatLinkAvailable"
+				:item="chat"
+				:compact="props.collapsed"
+				:active="activeTabId === 'chat'"
+				data-test-id="project-chat-menu-item"
 			/>
 		</div>
 		<N8nHeading


### PR DESCRIPTION
## Summary

Move chat link to the top, under shared with you.

<img width="208" height="216" alt="image" src="https://github.com/user-attachments/assets/a934692b-0fff-4162-abe4-05e9683d8b75" />

We'll have to do this on the v2 branch that has the new sidebar too, but lets do that after the v2 master branch merge.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
