### PR TITLE
test: Migrate execution tests to workflows/editor/execution/

### DIFF
--- a/packages/testing/playwright/tests/ui/workflows/editor/execution/debug.spec.ts
+++ b/packages/testing/playwright/tests/ui/workflows/editor/execution/debug.spec.ts
@@ -1,5 +1,5 @@
-import { test, expect } from '../../fixtures/base';
-import type { n8nPage } from '../../pages/n8nPage';
+import { test, expect } from '../../../../../fixtures/base';
+import type { n8nPage } from '../../../../../pages/n8nPage';
 
 // Example of using helper functions inside a test
 test.describe('Debug mode', () => {

--- a/packages/testing/playwright/tests/ui/workflows/editor/execution/execution.spec.ts
+++ b/packages/testing/playwright/tests/ui/workflows/editor/execution/execution.spec.ts
@@ -1,5 +1,5 @@
-import { test, expect } from '../../fixtures/base';
-import type { n8nPage } from '../../pages/n8nPage';
+import { test, expect } from '../../../../../fixtures/base';
+import type { n8nPage } from '../../../../../pages/n8nPage';
 
 const NODE_NAMES = {
 	PROCESS_THE_DATA: 'Process The Data',

--- a/packages/testing/playwright/tests/ui/workflows/editor/execution/inject-previous.spec.ts
+++ b/packages/testing/playwright/tests/ui/workflows/editor/execution/inject-previous.spec.ts
@@ -1,5 +1,5 @@
-import { EDIT_FIELDS_SET_NODE_NAME } from '../../config/constants';
-import { test, expect } from '../../fixtures/base';
+import { EDIT_FIELDS_SET_NODE_NAME } from '../../../../../config/constants';
+import { test, expect } from '../../../../../fixtures/base';
 
 const NOTIFICATIONS = {
 	WORKFLOW_EXECUTED_SUCCESSFULLY: 'Workflow executed successfully',

--- a/packages/testing/playwright/tests/ui/workflows/editor/execution/logs.spec.ts
+++ b/packages/testing/playwright/tests/ui/workflows/editor/execution/logs.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../../fixtures/base';
+import { test, expect } from '../../../../../fixtures/base';
 
 // Node name constants
 const NODES = {

--- a/packages/testing/playwright/tests/ui/workflows/editor/execution/partial.spec.ts
+++ b/packages/testing/playwright/tests/ui/workflows/editor/execution/partial.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../../fixtures/base';
+import { test, expect } from '../../../../../fixtures/base';
 
 test.describe('Manual partial execution', () => {
 	test('should not execute parent nodes with no run data', async ({ n8n }) => {

--- a/packages/testing/playwright/tests/ui/workflows/editor/execution/previous-nodes.spec.ts
+++ b/packages/testing/playwright/tests/ui/workflows/editor/execution/previous-nodes.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../../fixtures/base';
+import { test, expect } from '../../../../../fixtures/base';
 
 // eslint-disable-next-line n8n-local-rules/no-skipped-tests -- Flaky in multi-main mode: "execute previous nodes" also executes the current node
 test.describe.skip('Execute previous nodes', () => {


### PR DESCRIPTION
## Summary
  - Migrates 6 execution-related E2E test files to `workflows/editor/execution/`
  - Removes numeric prefixes from filenames
  - Updates import paths for new directory depth

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/CAT-1881/workflowseditorexecution-workflow-execution


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
