### PR TITLE
test: Migrate expression and code editor tests

### DIFF
--- a/packages/testing/playwright/tests/ui/workflows/editor/code/code-node.spec.ts
+++ b/packages/testing/playwright/tests/ui/workflows/editor/code/code-node.spec.ts
@@ -4,8 +4,8 @@ import {
 	CODE_NODE_DISPLAY_NAME,
 	CODE_NODE_NAME,
 	MANUAL_TRIGGER_NODE_NAME,
-} from '../../config/constants';
-import { test, expect } from '../../fixtures/base';
+} from '../../../../../config/constants';
+import { test, expect } from '../../../../../fixtures/base';
 
 test.describe('Code node', () => {
 	test.describe('Code editor', () => {

--- a/packages/testing/playwright/tests/ui/workflows/editor/code/editors.spec.ts
+++ b/packages/testing/playwright/tests/ui/workflows/editor/code/editors.spec.ts
@@ -1,8 +1,8 @@
 import fs from 'fs';
 
-import { MANUAL_TRIGGER_NODE_DISPLAY_NAME } from '../../config/constants';
-import { test, expect } from '../../fixtures/base';
-import { resolveFromRoot } from '../../utils/path-helper';
+import { MANUAL_TRIGGER_NODE_DISPLAY_NAME } from '../../../../../config/constants';
+import { test, expect } from '../../../../../fixtures/base';
+import { resolveFromRoot } from '../../../../../utils/path-helper';
 
 test.describe('Editors', () => {
 	test.beforeEach(async ({ n8n }) => {

--- a/packages/testing/playwright/tests/ui/workflows/editor/expressions/inline.spec.ts
+++ b/packages/testing/playwright/tests/ui/workflows/editor/expressions/inline.spec.ts
@@ -3,8 +3,8 @@ import {
 	SCHEDULE_TRIGGER_NODE_NAME,
 	NO_OPERATION_NODE_NAME,
 	HACKER_NEWS_NODE_NAME,
-} from '../../config/constants';
-import { test, expect } from '../../fixtures/base';
+} from '../../../../../config/constants';
+import { test, expect } from '../../../../../fixtures/base';
 
 const SCHEDULE_PARAMETER_NAME = 'daysInterval';
 const HACKER_NEWS_ACTION = 'Get many items';

--- a/packages/testing/playwright/tests/ui/workflows/editor/expressions/mapping.spec.ts
+++ b/packages/testing/playwright/tests/ui/workflows/editor/expressions/mapping.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../../fixtures/base';
+import { test, expect } from '../../../../../fixtures/base';
 
 test.describe('Data Mapping', () => {
 	test.describe

--- a/packages/testing/playwright/tests/ui/workflows/editor/expressions/modal.spec.ts
+++ b/packages/testing/playwright/tests/ui/workflows/editor/expressions/modal.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../../fixtures/base';
+import { test, expect } from '../../../../../fixtures/base';
 
 test.describe('Expression editor modal', () => {
 	test.beforeEach(async ({ n8n }) => {

--- a/packages/testing/playwright/tests/ui/workflows/editor/expressions/transformation.spec.ts
+++ b/packages/testing/playwright/tests/ui/workflows/editor/expressions/transformation.spec.ts
@@ -1,5 +1,5 @@
-import { test, expect } from '../../fixtures/base';
-import type { n8nPage } from '../../pages/n8nPage';
+import { test, expect } from '../../../../../fixtures/base';
+import type { n8nPage } from '../../../../../pages/n8nPage';
 
 test.describe('Data transformation expressions', () => {
 	test.beforeEach(async ({ n8n }) => {


### PR DESCRIPTION
## Summary
  - Migrates 4 expression-related tests to `workflows/editor/expressions/`
  - Migrates 2 code editor tests to `workflows/editor/code/`
  - Removes numeric prefixes from filenames
  - Updates import paths for new directory depth

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/CAT-1882/workflowseditorexpressions-code-expressions-and-code-editing

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
