### PR TITLE
chore: Revert add version back to public settings (no-changelog)

### DIFF
--- a/packages/cli/src/services/__tests__/frontend.service.test.ts
+++ b/packages/cli/src/services/__tests__/frontend.service.test.ts
@@ -202,11 +202,6 @@ describe('FrontendService', () => {
 
 	describe('getPublicSettings', () => {
 		it('should return public settings', () => {
-			const { service } = createMockService();
-			service.settings.versionCli = '1.123.0';
-
-			const settings = service.getPublicSettings();
-
 			const expectedPublicSettings: PublicFrontendSettings = {
 				settingsMode: 'public',
 				userManagement: {
@@ -214,7 +209,6 @@ describe('FrontendService', () => {
 					showSetupOnFirstLoad: true,
 					authenticationMethod: 'email',
 				},
-				versionCli: '1.123.0',
 				sso: {
 					saml: { loginEnabled: false },
 					ldap: { loginEnabled: false, loginLabel: '' },
@@ -227,6 +221,10 @@ describe('FrontendService', () => {
 				previewMode: false,
 				enterprise: { saml: false, ldap: false, oidc: false },
 			};
+
+			const { service } = createMockService();
+			const settings = service.getPublicSettings();
+
 			expect(settings).toEqual(expectedPublicSettings);
 		});
 	});

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -39,8 +39,6 @@ export type PublicFrontendSettings = {
 	/** Controls initialization flow in settings store */
 	settingsMode: FrontendSettings['settingsMode'];
 
-	versionCli: string;
-
 	/** Used to bypass authentication on the workflows/demo page */
 	previewMode: FrontendSettings['previewMode'];
 
@@ -542,7 +540,6 @@ export class FrontendService {
 					loginUrl: ssoOidc.loginUrl,
 				},
 			},
-			versionCli: this.settings.versionCli,
 			authCookie,
 			previewMode,
 			enterprise: { saml, ldap, oidc },


### PR DESCRIPTION
Reverts n8n-io/n8n#22804
We don't want to expose this info on an unauthorized response.
See discussion in https://n8nio.slack.com/archives/C069KJBJ8HE/p1764669520148939