### PR TITLE
chore(core): Implement identifiers for resolvers

### DIFF
--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/oauth2-introspection-identifier.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/oauth2-introspection-identifier.test.ts
@@ -3,7 +3,7 @@ import { Time } from '@n8n/constants';
 import axios from 'axios';
 import { mock } from 'jest-mock-extended';
 
-import { CacheService } from '@/services/cache/cache.service';
+import type { CacheService } from '@/services/cache/cache.service';
 
 import { IdentifierValidationError } from '../identifier-interface';
 import { OAuth2TokenIntrospectionIdentifier } from '../oauth2-introspection-identifier';
@@ -39,6 +39,7 @@ describe('OAuth2TokenIntrospectionIdentifier', () => {
 
 	const mockContext = {
 		identity: 'mock-access-token',
+		version: 1 as const,
 	};
 
 	beforeEach(() => {
@@ -54,15 +55,15 @@ describe('OAuth2TokenIntrospectionIdentifier', () => {
 			mockedAxios.get.mockResolvedValueOnce({
 				status: 200,
 				data: validMetadata,
-			} as any);
+			});
 
 			// Mock introspection endpoint
 			mockedAxios.post.mockResolvedValueOnce({
 				status: 200,
 				data: validIntrospectionResponse,
-			} as any);
+			});
 
-			const result = await identifier.resolve(mockContext as any, validOptions);
+			const result = await identifier.resolve(mockContext, validOptions);
 
 			expect(result).toBe('user-123');
 			expect(cache.set).toHaveBeenCalledWith(
@@ -89,9 +90,9 @@ describe('OAuth2TokenIntrospectionIdentifier', () => {
 			mockedAxios.get.mockResolvedValueOnce({
 				status: 200,
 				data: validMetadata,
-			} as any);
+			});
 
-			const result = await identifier.resolve(mockContext as any, validOptions);
+			const result = await identifier.resolve(mockContext, validOptions);
 
 			expect(result).toBe('cached-user-123');
 			expect(mockedAxios.post).not.toHaveBeenCalled(); // Should not call introspection
@@ -104,14 +105,14 @@ describe('OAuth2TokenIntrospectionIdentifier', () => {
 			mockedAxios.get.mockResolvedValueOnce({
 				status: 200,
 				data: validMetadata,
-			} as any);
+			});
 
 			mockedAxios.post.mockResolvedValueOnce({
 				status: 200,
 				data: customResponse,
-			} as any);
+			});
 
-			const result = await identifier.resolve(mockContext as any, customOptions);
+			const result = await identifier.resolve(mockContext, customOptions);
 
 			expect(result).toBe('john.doe');
 		});
@@ -121,7 +122,7 @@ describe('OAuth2TokenIntrospectionIdentifier', () => {
 		test('should throw IdentifierValidationError for invalid options', async () => {
 			const invalidOptions = { metadataUri: 'not-a-url' };
 
-			await expect(identifier.resolve(mockContext as any, invalidOptions)).rejects.toThrow(
+			await expect(identifier.resolve(mockContext, invalidOptions)).rejects.toThrow(
 				IdentifierValidationError,
 			);
 		});
@@ -130,17 +131,17 @@ describe('OAuth2TokenIntrospectionIdentifier', () => {
 			mockedAxios.get.mockResolvedValue({
 				status: 200,
 				data: validMetadata,
-			} as any);
+			});
 
 			mockedAxios.post.mockResolvedValue({
 				status: 200,
 				data: { ...validIntrospectionResponse, active: false },
-			} as any);
+			});
 
-			await expect(identifier.resolve(mockContext as any, validOptions)).rejects.toThrow(
+			await expect(identifier.resolve(mockContext, validOptions)).rejects.toThrow(
 				IdentifierValidationError,
 			);
-			await expect(identifier.resolve(mockContext as any, validOptions)).rejects.toThrow(
+			await expect(identifier.resolve(mockContext, validOptions)).rejects.toThrow(
 				'Token is not active',
 			);
 		});
@@ -149,12 +150,12 @@ describe('OAuth2TokenIntrospectionIdentifier', () => {
 			mockedAxios.get.mockResolvedValue({
 				status: 404,
 				data: {},
-			} as any);
+			});
 
-			await expect(identifier.resolve(mockContext as any, validOptions)).rejects.toThrow(
+			await expect(identifier.resolve(mockContext, validOptions)).rejects.toThrow(
 				IdentifierValidationError,
 			);
-			await expect(identifier.resolve(mockContext as any, validOptions)).rejects.toThrow(
+			await expect(identifier.resolve(mockContext, validOptions)).rejects.toThrow(
 				'Failed to fetch OAuth2 metadata',
 			);
 		});
@@ -163,18 +164,18 @@ describe('OAuth2TokenIntrospectionIdentifier', () => {
 			mockedAxios.get.mockResolvedValue({
 				status: 200,
 				data: validMetadata,
-			} as any);
+			});
 
 			const responseWithoutSub = { active: true, exp: validIntrospectionResponse.exp };
 			mockedAxios.post.mockResolvedValue({
 				status: 200,
 				data: responseWithoutSub,
-			} as any);
+			});
 
-			await expect(identifier.resolve(mockContext as any, validOptions)).rejects.toThrow(
+			await expect(identifier.resolve(mockContext, validOptions)).rejects.toThrow(
 				IdentifierValidationError,
 			);
-			await expect(identifier.resolve(mockContext as any, validOptions)).rejects.toThrow(
+			await expect(identifier.resolve(mockContext, validOptions)).rejects.toThrow(
 				'missing subject claim',
 			);
 		});
@@ -190,14 +191,14 @@ describe('OAuth2TokenIntrospectionIdentifier', () => {
 			mockedAxios.get.mockResolvedValueOnce({
 				status: 200,
 				data: metadataWithoutAuthMethods,
-			} as any);
+			});
 
 			mockedAxios.post.mockResolvedValueOnce({
 				status: 200,
 				data: validIntrospectionResponse,
-			} as any);
+			});
 
-			const result = await identifier.resolve(mockContext as any, validOptions);
+			const result = await identifier.resolve(mockContext, validOptions);
 
 			expect(result).toBe('user-123');
 			expect(mockedAxios.post).toHaveBeenCalledWith(
@@ -220,14 +221,14 @@ describe('OAuth2TokenIntrospectionIdentifier', () => {
 			mockedAxios.get.mockResolvedValue({
 				status: 200,
 				data: validMetadata,
-			} as any);
+			});
 
 			mockedAxios.post.mockResolvedValue({
 				status: 200,
 				data: longLivedResponse,
-			} as any);
+			});
 
-			await identifier.resolve(mockContext as any, validOptions);
+			await identifier.resolve(mockContext, validOptions);
 
 			// Check that the subject cache was set with the max TTL
 			// Find the call that sets the subject (not metadata)
@@ -246,14 +247,14 @@ describe('OAuth2TokenIntrospectionIdentifier', () => {
 			mockedAxios.get.mockResolvedValue({
 				status: 200,
 				data: validMetadata,
-			} as any);
+			});
 
 			mockedAxios.post.mockResolvedValue({
 				status: 200,
 				data: expiredButActiveResponse,
-			} as any);
+			});
 
-			await identifier.resolve(mockContext as any, validOptions);
+			await identifier.resolve(mockContext, validOptions);
 
 			// Check that the subject cache was set with the min TTL
 			// Find the call that sets the subject (not metadata)

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/oauth2-introspection-identifier.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/oauth2-introspection-identifier.test.ts
@@ -1,0 +1,266 @@
+import { mockLogger } from '@n8n/backend-test-utils';
+import { Time } from '@n8n/constants';
+import axios from 'axios';
+import { mock } from 'jest-mock-extended';
+
+import { CacheService } from '@/services/cache/cache.service';
+
+import { IdentifierValidationError } from '../identifier-interface';
+import { OAuth2TokenIntrospectionIdentifier } from '../oauth2-introspection-identifier';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('OAuth2TokenIntrospectionIdentifier', () => {
+	const logger = mockLogger();
+	const cache = mock<CacheService>();
+	let identifier: OAuth2TokenIntrospectionIdentifier;
+
+	const validOptions = {
+		metadataUri: 'https://auth.example.com/.well-known/oauth-authorization-server',
+		clientId: 'test-client',
+		clientSecret: 'test-secret',
+		subjectClaim: 'sub',
+	};
+
+	const validMetadata = {
+		issuer: 'https://auth.example.com',
+		introspection_endpoint: 'https://auth.example.com/oauth/introspect',
+		introspection_endpoint_auth_methods_supported: ['client_secret_basic', 'client_secret_post'],
+	};
+
+	const validIntrospectionResponse = {
+		active: true,
+		sub: 'user-123',
+		exp: Math.floor(Date.now() / 1000) + 3600, // 1 hour from now
+		scope: 'read write',
+		client_id: 'test-client',
+	};
+
+	const mockContext = {
+		identity: 'mock-access-token',
+	};
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		identifier = new OAuth2TokenIntrospectionIdentifier(logger, cache);
+		cache.get.mockResolvedValue(undefined);
+		cache.set.mockResolvedValue();
+	});
+
+	describe('Happy Path', () => {
+		test('should resolve subject successfully with client_secret_basic', async () => {
+			// Mock metadata endpoint
+			mockedAxios.get.mockResolvedValueOnce({
+				status: 200,
+				data: validMetadata,
+			} as any);
+
+			// Mock introspection endpoint
+			mockedAxios.post.mockResolvedValueOnce({
+				status: 200,
+				data: validIntrospectionResponse,
+			} as any);
+
+			const result = await identifier.resolve(mockContext as any, validOptions);
+
+			expect(result).toBe('user-123');
+			expect(cache.set).toHaveBeenCalledWith(
+				expect.stringContaining('oauth2-introspection-identifier:subject'),
+				'user-123',
+				expect.any(Number),
+			);
+			expect(mockedAxios.post).toHaveBeenCalledWith(
+				'https://auth.example.com/oauth/introspect',
+				expect.any(URLSearchParams),
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Authorization: expect.stringMatching(/^Basic /),
+					}),
+				}),
+			);
+		});
+
+		test('should return cached result on subsequent calls', async () => {
+			// First cache.get call is for metadata (returns undefined, so will fetch)
+			// Second cache.get call is for subject (returns cached value)
+			cache.get.mockResolvedValueOnce(undefined).mockResolvedValueOnce('cached-user-123');
+
+			mockedAxios.get.mockResolvedValueOnce({
+				status: 200,
+				data: validMetadata,
+			} as any);
+
+			const result = await identifier.resolve(mockContext as any, validOptions);
+
+			expect(result).toBe('cached-user-123');
+			expect(mockedAxios.post).not.toHaveBeenCalled(); // Should not call introspection
+		});
+
+		test('should extract subject from custom claim', async () => {
+			const customOptions = { ...validOptions, subjectClaim: 'username' };
+			const customResponse = { ...validIntrospectionResponse, username: 'john.doe' };
+
+			mockedAxios.get.mockResolvedValueOnce({
+				status: 200,
+				data: validMetadata,
+			} as any);
+
+			mockedAxios.post.mockResolvedValueOnce({
+				status: 200,
+				data: customResponse,
+			} as any);
+
+			const result = await identifier.resolve(mockContext as any, customOptions);
+
+			expect(result).toBe('john.doe');
+		});
+	});
+
+	describe('Critical Errors', () => {
+		test('should throw IdentifierValidationError for invalid options', async () => {
+			const invalidOptions = { metadataUri: 'not-a-url' };
+
+			await expect(identifier.resolve(mockContext as any, invalidOptions)).rejects.toThrow(
+				IdentifierValidationError,
+			);
+		});
+
+		test('should throw IdentifierValidationError when token is not active', async () => {
+			mockedAxios.get.mockResolvedValue({
+				status: 200,
+				data: validMetadata,
+			} as any);
+
+			mockedAxios.post.mockResolvedValue({
+				status: 200,
+				data: { ...validIntrospectionResponse, active: false },
+			} as any);
+
+			await expect(identifier.resolve(mockContext as any, validOptions)).rejects.toThrow(
+				IdentifierValidationError,
+			);
+			await expect(identifier.resolve(mockContext as any, validOptions)).rejects.toThrow(
+				'Token is not active',
+			);
+		});
+
+		test('should throw IdentifierValidationError when metadata fetch fails', async () => {
+			mockedAxios.get.mockResolvedValue({
+				status: 404,
+				data: {},
+			} as any);
+
+			await expect(identifier.resolve(mockContext as any, validOptions)).rejects.toThrow(
+				IdentifierValidationError,
+			);
+			await expect(identifier.resolve(mockContext as any, validOptions)).rejects.toThrow(
+				'Failed to fetch OAuth2 metadata',
+			);
+		});
+
+		test('should throw IdentifierValidationError when subject claim is missing', async () => {
+			mockedAxios.get.mockResolvedValue({
+				status: 200,
+				data: validMetadata,
+			} as any);
+
+			const responseWithoutSub = { active: true, exp: validIntrospectionResponse.exp };
+			mockedAxios.post.mockResolvedValue({
+				status: 200,
+				data: responseWithoutSub,
+			} as any);
+
+			await expect(identifier.resolve(mockContext as any, validOptions)).rejects.toThrow(
+				IdentifierValidationError,
+			);
+			await expect(identifier.resolve(mockContext as any, validOptions)).rejects.toThrow(
+				'missing subject claim',
+			);
+		});
+	});
+
+	describe('Edge Cases', () => {
+		test('should default to client_secret_basic when auth methods not specified', async () => {
+			const metadataWithoutAuthMethods = {
+				issuer: 'https://auth.example.com',
+				introspection_endpoint: 'https://auth.example.com/oauth/introspect',
+			};
+
+			mockedAxios.get.mockResolvedValueOnce({
+				status: 200,
+				data: metadataWithoutAuthMethods,
+			} as any);
+
+			mockedAxios.post.mockResolvedValueOnce({
+				status: 200,
+				data: validIntrospectionResponse,
+			} as any);
+
+			const result = await identifier.resolve(mockContext as any, validOptions);
+
+			expect(result).toBe('user-123');
+			expect(mockedAxios.post).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.any(URLSearchParams),
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						Authorization: expect.stringMatching(/^Basic /),
+					}),
+				}),
+			);
+		});
+
+		test('should cap TTL at MAX_TOKEN_CACHE_TIMEOUT for long-lived token', async () => {
+			const longLivedResponse = {
+				...validIntrospectionResponse,
+				exp: Math.floor(Date.now() / 1000) + 7200, // 2 hours from now
+			};
+
+			mockedAxios.get.mockResolvedValue({
+				status: 200,
+				data: validMetadata,
+			} as any);
+
+			mockedAxios.post.mockResolvedValue({
+				status: 200,
+				data: longLivedResponse,
+			} as any);
+
+			await identifier.resolve(mockContext as any, validOptions);
+
+			// Check that the subject cache was set with the max TTL
+			// Find the call that sets the subject (not metadata)
+			const subjectCacheCall = cache.set.mock.calls.find((call) => call[0].includes(':subject:'));
+
+			expect(subjectCacheCall).toBeDefined();
+			expect(subjectCacheCall![2]).toBe(5 * Time.minutes.toMilliseconds);
+		});
+
+		test('should use MIN_TOKEN_CACHE_TIMEOUT for expired but active token', async () => {
+			const expiredButActiveResponse = {
+				...validIntrospectionResponse,
+				exp: Math.floor(Date.now() / 1000) - 3600, // 1 hour ago
+			};
+
+			mockedAxios.get.mockResolvedValue({
+				status: 200,
+				data: validMetadata,
+			} as any);
+
+			mockedAxios.post.mockResolvedValue({
+				status: 200,
+				data: expiredButActiveResponse,
+			} as any);
+
+			await identifier.resolve(mockContext as any, validOptions);
+
+			// Check that the subject cache was set with the min TTL
+			// Find the call that sets the subject (not metadata)
+			const subjectCacheCall = cache.set.mock.calls.find((call) => call[0].includes(':subject:'));
+
+			expect(subjectCacheCall).toBeDefined();
+			expect(subjectCacheCall![2]).toBe(30 * Time.seconds.toMilliseconds);
+		});
+	});
+});

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/identifier-interface.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/identifier-interface.ts
@@ -1,0 +1,23 @@
+import type { ICredentialContext } from 'n8n-workflow';
+
+export class IdentifierValidationError extends Error {}
+
+export interface ITokenIdentifier {
+	/**
+	 * This validates and resolves a unique identifier for the entity in the given context
+	 *
+	 * @param context - The credential context containing execution and environment details
+	 * @param identifierOptions - Options specific to the identifier implementation
+	 * @returns The unique identifier for the entity in the given context
+	 *
+	 * @throws {IdentifierValidationError} When validation fails
+	 */
+	resolve(context: ICredentialContext, identifierOptions: Record<string, unknown>): Promise<string>;
+
+	/**
+	 * Test is given identifier options are valid
+	 *
+	 * @param identifierOptions - Options specific to the identifier implementation
+	 */
+	validateOptions(identifierOptions: Record<string, unknown>): Promise<void>;
+}

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/identifier-interface.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/identifier-interface.ts
@@ -1,23 +1,29 @@
 import type { ICredentialContext } from 'n8n-workflow';
 
+/**
+ * Error thrown when token identifier validation or resolution fails
+ */
 export class IdentifierValidationError extends Error {}
 
+/**
+ * Interface for resolving unique identifiers from credential contexts
+ */
 export interface ITokenIdentifier {
 	/**
-	 * This validates and resolves a unique identifier for the entity in the given context
+	 * Resolves a unique identifier for the entity in the given context
 	 *
-	 * @param context - The credential context containing execution and environment details
-	 * @param identifierOptions - Options specific to the identifier implementation
-	 * @returns The unique identifier for the entity in the given context
-	 *
-	 * @throws {IdentifierValidationError} When validation fails
+	 * @param context - Credential context with execution details
+	 * @param identifierOptions - Implementation-specific options
+	 * @returns Unique identifier string
+	 * @throws {IdentifierValidationError} When validation or resolution fails
 	 */
 	resolve(context: ICredentialContext, identifierOptions: Record<string, unknown>): Promise<string>;
 
 	/**
-	 * Test is given identifier options are valid
+	 * Validates identifier options before use
 	 *
-	 * @param identifierOptions - Options specific to the identifier implementation
+	 * @param identifierOptions - Implementation-specific options
+	 * @throws {IdentifierValidationError} When options are invalid
 	 */
 	validateOptions(identifierOptions: Record<string, unknown>): Promise<void>;
 }

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-introspection-identifier.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-introspection-identifier.ts
@@ -1,0 +1,282 @@
+import { Logger } from '@n8n/backend-common';
+import { Service } from '@n8n/di';
+import axios from 'axios';
+import { type ICredentialContext } from 'n8n-workflow';
+import { z } from 'zod';
+
+import { CacheService } from '@/services/cache/cache.service';
+
+import { IdentifierValidationError, ITokenIdentifier } from './identifier-interface';
+import { OAuth2OptionsSchema, sha256 } from './oauth2-utils';
+
+export const OAuth2IntrospectionOptionsSchema = z.object({
+	...OAuth2OptionsSchema.shape,
+	clientId: z.string(),
+	clientSecret: z.string(),
+});
+
+type OAuth2IntrospectionOptions = z.infer<typeof OAuth2IntrospectionOptionsSchema>;
+
+const OAuth2MetadataSchema = z.object({
+	issuer: z.string().url(),
+	introspection_endpoint: z.string().url(),
+	// This could be an well defined enum, but to make sure we are not failing validation
+	// of unknown values, we keep it as string
+	introspection_endpoint_auth_methods_supported: z.array(z.string()).optional(),
+});
+
+type OAuth2Metadata = z.infer<typeof OAuth2MetadataSchema>;
+
+export const TokenIntrospectionResponseSchema = z
+	.object({
+		// Core fields
+		active: z.boolean(),
+
+		// Standard optional fields
+		scope: z.string().optional(),
+		client_id: z.string().optional(),
+		username: z.string().optional(),
+		token_type: z.string().optional(),
+		exp: z.number().int().optional(),
+		iat: z.number().int().optional(),
+		nbf: z.number().int().optional(),
+		sub: z.string().optional(),
+		aud: z.union([z.string(), z.array(z.string())]).optional(),
+		iss: z.string().optional(),
+		jti: z.string().optional(),
+	})
+	.passthrough(); // Allow additional custom claims
+
+export type TokenIntrospectionResponse = z.infer<typeof TokenIntrospectionResponseSchema>;
+
+const CACHE_PREFIX = 'oauth2-introspection-identifier';
+
+@Service()
+export class OAuth2TokenIntrospectionIdentifier implements ITokenIdentifier {
+	constructor(
+		private readonly logger: Logger,
+		private readonly cache: CacheService,
+	) {}
+
+	async validateOptions(identifierOptions: Record<string, unknown>): Promise<void> {
+		const options = this.parseOptions(identifierOptions);
+		const metadata = await this.fetchMetadata(options, true);
+		if (!metadata.introspection_endpoint) {
+			this.logger.error('Metadata does not contain an introspection endpoint');
+			throw new IdentifierValidationError('Metadata does not contain an introspection endpoint');
+		}
+		if (metadata.introspection_endpoint_auth_methods_supported) {
+			const supportedMethods = metadata.introspection_endpoint_auth_methods_supported;
+			if (
+				!supportedMethods.includes('client_secret_basic') &&
+				!supportedMethods.includes('client_secret_post')
+			) {
+				this.logger.error(
+					'No supported client authentication method for introspection endpoint, supported options are client_secret_basic and client_secret_post',
+				);
+				throw new IdentifierValidationError(
+					'No supported client authentication method for introspection endpoint, supported options are client_secret_basic and client_secret_post',
+				);
+			}
+		}
+	}
+
+	async resolve(
+		context: ICredentialContext,
+		identifierOptions: Record<string, unknown>,
+	): Promise<string> {
+		const options = this.parseOptions(identifierOptions);
+		const metadata = await this.fetchMetadata(options);
+
+		const hashedToken = sha256(context.identity);
+
+		const identifierCacheKey = `${CACHE_PREFIX}:subject:${metadata.issuer}:${hashedToken}`;
+		const cached = await this.cache.get<string>(identifierCacheKey);
+		if (cached) {
+			return cached;
+		}
+
+		let ttl = 300;
+		const { subject, ttl: ttlOverwrite } = await this.resolveBasedOnTokenIntrospection(
+			metadata,
+			options,
+			context,
+		);
+		if (ttlOverwrite) {
+			ttl = ttlOverwrite;
+		}
+
+		if (!subject) {
+			this.logger.error('No valid method to validate token found in metadata');
+			throw new IdentifierValidationError('No valid method to validate token found in metadata');
+		}
+
+		await this.cache.set(identifierCacheKey, subject, ttl);
+		return subject;
+	}
+
+	// ------------------------ Private Methods ----------------------- //
+
+	private parseOptions(options: Record<string, unknown>): OAuth2IntrospectionOptions {
+		try {
+			return OAuth2IntrospectionOptionsSchema.parse(options);
+		} catch (error) {
+			this.logger.error('Invalid OAuth2 identifier options', { error });
+			throw new IdentifierValidationError('Invalid OAuth2 identifier options', {
+				cause: error,
+			});
+		}
+	}
+
+	private async fetchMetadata(
+		options: OAuth2IntrospectionOptions,
+		skipCache: boolean = false,
+	): Promise<OAuth2Metadata> {
+		const cacheKey = `${CACHE_PREFIX}:metadata:${options.metadataUri}`;
+		if (!skipCache) {
+			const cached = await this.cache.get<OAuth2Metadata>(cacheKey);
+			if (cached) {
+				return cached;
+			}
+		}
+
+		const response = await axios.get(options.metadataUri, {
+			validateStatus: () => true,
+		});
+
+		if (response.status !== 200) {
+			this.logger.error(
+				`Failed to fetch OAuth2 metadata from ${options.metadataUri}, status code: ${response.status}`,
+			);
+			throw new IdentifierValidationError(
+				`Failed to fetch OAuth2 metadata, status code: ${response.status}`,
+			);
+		}
+
+		try {
+			const metadata = OAuth2MetadataSchema.parse(response.data);
+			if (!skipCache) {
+				await this.cache.set(cacheKey, metadata, 3600); // Cache for 1 hour
+			}
+			return metadata;
+		} catch (error) {
+			this.logger.error('Invalid OAuth2 metadata format', { error });
+			throw new IdentifierValidationError('Invalid OAuth2 metadata format', { cause: error });
+		}
+	}
+
+	private buildClientBasicRequest(options: OAuth2IntrospectionOptions): {
+		headers: Record<string, string>;
+		params: Record<string, string>;
+	} {
+		const authHeaders: Record<string, string> = {};
+		const authParams: Record<string, string> = {};
+
+		const credentials = Buffer.from(`${options.clientId}:${options.clientSecret}`).toString(
+			'base64',
+		);
+		authHeaders['Authorization'] = `Basic ${credentials}`;
+
+		return { headers: authHeaders, params: authParams };
+	}
+
+	private buildClientPostRequest(options: OAuth2IntrospectionOptions): {
+		headers: Record<string, string>;
+		params: Record<string, string>;
+	} {
+		const authHeaders: Record<string, string> = {};
+		const authParams: Record<string, string> = {};
+
+		authParams['client_id'] = options.clientId;
+		authParams['client_secret'] = options.clientSecret;
+
+		return { headers: authHeaders, params: authParams };
+	}
+
+	private parseIntrospectionResponse(data: unknown): TokenIntrospectionResponse {
+		try {
+			return TokenIntrospectionResponseSchema.parse(data);
+		} catch (error) {
+			this.logger.error('Invalid token introspection response format', { error });
+			throw new IdentifierValidationError('Invalid token introspection response format');
+		}
+	}
+
+	private async resolveBasedOnTokenIntrospection(
+		metadata: OAuth2Metadata,
+		options: OAuth2IntrospectionOptions,
+		context: ICredentialContext,
+	) {
+		// Use token introspection to validate and get subject
+		const useBasic =
+			metadata.introspection_endpoint_auth_methods_supported?.includes('client_secret_basic');
+		const usePost =
+			metadata.introspection_endpoint_auth_methods_supported?.includes('client_secret_post');
+
+		let authHeaders: Record<string, string> = {};
+		let authParams: Record<string, string> = {};
+
+		if (useBasic) {
+			const result = this.buildClientBasicRequest(options);
+			authHeaders = result.headers;
+			authParams = result.params;
+		} else if (usePost) {
+			const result = this.buildClientPostRequest(options);
+			authHeaders = result.headers;
+			authParams = result.params;
+		} else {
+			this.logger.error('No supported client authentication method for introspection endpoint');
+			throw new IdentifierValidationError(
+				'No supported client authentication method for introspection endpoint',
+			);
+		}
+
+		const params = new URLSearchParams({
+			token: context.identity,
+			...authParams,
+		});
+
+		const response = await axios.post(metadata.introspection_endpoint, params, {
+			headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...authHeaders },
+		});
+
+		if (response.status !== 200) {
+			this.logger.error('Token introspection failed', {
+				status: response.status,
+				data: response.data,
+			});
+			throw new IdentifierValidationError('Token introspection failed');
+		}
+
+		const introspectionData = this.parseIntrospectionResponse(response.data);
+
+		if (!introspectionData.active) {
+			this.logger.error('Token is not active according to introspection response');
+			throw new IdentifierValidationError('Token is not active');
+		}
+
+		const subject = introspectionData[options.subjectClaim as keyof TokenIntrospectionResponse];
+		if (!subject) {
+			this.logger.error(
+				`Token introspection response missing subject claim (${options.subjectClaim})`,
+			);
+			throw new IdentifierValidationError(
+				`Token introspection response missing subject claim (${options.subjectClaim})`,
+			);
+		}
+
+		const subjectStr = String(subject);
+
+		this.logger.debug('Token introspected successfully', { subject: subjectStr });
+
+		let ttl: number | undefined = undefined;
+		if (introspectionData.exp) {
+			const expiresIn = introspectionData.exp * 1000 - Date.now();
+			if (expiresIn > 0) {
+				ttl = Math.floor(expiresIn / 1000);
+			}
+		}
+
+		return { subject: subjectStr, ttl };
+	}
+}

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-introspection-identifier.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-introspection-identifier.ts
@@ -176,9 +176,9 @@ export class OAuth2TokenIntrospectionIdentifier implements ITokenIdentifier {
 		const authHeaders: Record<string, string> = {};
 		const authParams: Record<string, string> = {};
 
-		const credentials = Buffer.from(`${options.clientId}:${options.clientSecret}`).toString(
-			'base64',
-		);
+		const credentials = Buffer.from(
+			`${encodeURIComponent(options.clientId)}:${encodeURIComponent(options.clientSecret)}`,
+		).toString('base64');
 		authHeaders['Authorization'] = `Basic ${credentials}`;
 
 		return { headers: authHeaders, params: authParams };

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-utils.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-utils.ts
@@ -1,0 +1,13 @@
+import crypto from 'crypto';
+import z from 'zod';
+
+export const OAuth2OptionsSchema = z.object({
+	metadataUri: z.string().url(),
+	subjectClaim: z.string().optional().default('sub'),
+});
+
+export type OAuth2Options = z.infer<typeof OAuth2OptionsSchema>;
+
+export function sha256(token: string): string {
+	return crypto.createHash('sha256').update(token).digest('hex');
+}


### PR DESCRIPTION
## Summary

Implements OAuth2 token introspection (RFC 7662) for dynamic credential resolution. The implementation validates and extracts unique identifiers from access tokens using the OAuth2 introspection endpoint, with support for both `client_secret_basic` and `client_secret_post` authentication methods. Includes intelligent caching with TTL bounds based on token expiration and comprehensive test coverage.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-4226/implement-oauth-token-introspection

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
