### PR TITLE
test: Migrate subworkflow tests to workflows/editor/subworkflows/

### DIFF
--- a/packages/testing/playwright/tests/ui/workflows/editor/subworkflows/debugging.spec.ts
+++ b/packages/testing/playwright/tests/ui/workflows/editor/subworkflows/debugging.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../../fixtures/base';
+import { test, expect } from '../../../../../fixtures/base';
 
 const WORKFLOW_FILE = 'Subworkflow-debugging-execute-workflow.json';
 

--- a/packages/testing/playwright/tests/ui/workflows/editor/subworkflows/extraction.spec.ts
+++ b/packages/testing/playwright/tests/ui/workflows/editor/subworkflows/extraction.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../../fixtures/base';
+import { test, expect } from '../../../../../fixtures/base';
 
 const EDIT_FIELDS_NAMES = [
 	'Edit Fields0',

--- a/packages/testing/playwright/tests/ui/workflows/editor/subworkflows/wait.spec.ts
+++ b/packages/testing/playwright/tests/ui/workflows/editor/subworkflows/wait.spec.ts
@@ -1,9 +1,9 @@
 import { readFileSync } from 'fs';
 import type { IWorkflowBase } from 'n8n-workflow';
 
-import { test, expect } from '../../fixtures/base';
-import { resolveFromRoot } from '../../utils/path-helper';
-import { retryUntil } from '../../utils/retry-utils';
+import { test, expect } from '../../../../../fixtures/base';
+import { resolveFromRoot } from '../../../../../utils/path-helper';
+import { retryUntil } from '../../../../../utils/retry-utils';
 
 test.describe('Parent that does not wait for sub-workflow', () => {
 	test('should not wait for the sub-workflow', async ({ api }) => {

--- a/packages/testing/playwright/tests/ui/workflows/editor/subworkflows/workflow-selector.spec.ts
+++ b/packages/testing/playwright/tests/ui/workflows/editor/subworkflows/workflow-selector.spec.ts
@@ -1,6 +1,6 @@
-import { MANUAL_TRIGGER_NODE_NAME } from '../../config/constants';
-import { test, expect } from '../../fixtures/base';
-import { n8nPage } from '../../pages/n8nPage';
+import { MANUAL_TRIGGER_NODE_NAME } from '../../../../../config/constants';
+import { test, expect } from '../../../../../fixtures/base';
+import { n8nPage } from '../../../../../pages/n8nPage';
 
 const EXECUTE_WORKFLOW_NODE_NAME = 'Execute Sub-workflow';
 


### PR DESCRIPTION
## Summary
  - Migrates 4 subworkflow-related tests to `workflows/editor/subworkflows/`
  - Removes numeric prefixes from filenames
  - Updates import paths for new directory depth

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/CAT-1883/workflowseditorsubworkflows-subworkflow-features

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
