### PR TITLE
fix(editor): Fix animation border radii in non-rectangular nodes (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeDefault.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeDefault.vue
@@ -228,6 +228,12 @@ function onActivate(event: MouseEvent) {
 	&.trigger {
 		border-radius: var(--trigger-node--radius) var(--radius--lg) var(--radius--lg)
 			var(--trigger-node--radius);
+
+		&.running::after,
+		&.waiting::after {
+			border-radius: var(--trigger-node--radius) var(--radius--lg) var(--radius--lg)
+				var(--trigger-node--radius);
+		}
 	}
 
 	/**
@@ -239,7 +245,7 @@ function onActivate(event: MouseEvent) {
 
 		&.running::after,
 		&.waiting::after {
-			border-radius: 50%;
+			border-radius: calc(var(--canvas-node--height) / 2);
 		}
 
 		.statusIcons {


### PR DESCRIPTION
## Summary
Fixes a border radii issue in executing/waiting state animations in non-rectangular nodes.

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-1780/bug-broken-loading-state-in-trigger-and-sub-agent-nodes
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
