### PR TITLE
test: Migrate trigger tests to triggers/ directory

### DIFF
--- a/packages/testing/playwright/tests/ui/triggers/scheduler.spec.ts
+++ b/packages/testing/playwright/tests/ui/triggers/scheduler.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../../fixtures/base';
+import { test, expect } from '../../../fixtures/base';
 
 test.describe('Schedule Trigger node', () => {
 	test.beforeEach(async ({ n8n }) => {

--- a/packages/testing/playwright/tests/ui/triggers/webhook-external.spec.ts
+++ b/packages/testing/playwright/tests/ui/triggers/webhook-external.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../../fixtures/base';
+import { test, expect } from '../../../fixtures/base';
 
 test.describe('External Webhook Triggering', () => {
 	test('should create workflow via API, activate it, trigger webhook externally, and verify execution', async ({

--- a/packages/testing/playwright/tests/ui/triggers/webhook-isolation.spec.ts
+++ b/packages/testing/playwright/tests/ui/triggers/webhook-isolation.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../../fixtures/base';
+import { test, expect } from '../../../fixtures/base';
 
 test.describe('Webhook Origin Isolation', () => {
 	test.beforeAll(async ({ api }) => {

--- a/packages/testing/playwright/tests/ui/triggers/webhook.spec.ts
+++ b/packages/testing/playwright/tests/ui/triggers/webhook.spec.ts
@@ -1,8 +1,8 @@
 import { nanoid } from 'nanoid';
 
-import { test, expect } from '../../fixtures/base';
-import type { n8nPage } from '../../pages/n8nPage';
-import { EditFieldsNode } from '../../pages/nodes/EditFieldsNode';
+import { test, expect } from '../../../fixtures/base';
+import type { n8nPage } from '../../../pages/n8nPage';
+import { EditFieldsNode } from '../../../pages/nodes/EditFieldsNode';
 
 const cowBase64 =
 	'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCdABmX/9k=';


### PR DESCRIPTION
## Summary
  - Migrated 4 trigger-related E2E tests to `triggers/` directory
  - Removed numeric prefixes from filenames

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/CAT-1891/triggers-trigger-nodes

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
