### PR TITLE
test: Migrate node-specific tests to nodes/ directory

### DIFF
--- a/packages/testing/playwright/tests/ui/nodes/community-nodes.spec.ts
+++ b/packages/testing/playwright/tests/ui/nodes/community-nodes.spec.ts
@@ -1,9 +1,9 @@
-import { MANUAL_TRIGGER_NODE_NAME } from '../../config/constants';
-import { test, expect } from '../../fixtures/base';
-import customCredential from '../../workflows/Custom_credential.json';
-import customNodeFixture from '../../workflows/Custom_node.json';
-import customNodeWithCustomCredentialFixture from '../../workflows/Custom_node_custom_credential.json';
-import customNodeWithN8nCredentialFixture from '../../workflows/Custom_node_n8n_credential.json';
+import { MANUAL_TRIGGER_NODE_NAME } from '../../../config/constants';
+import { test, expect } from '../../../fixtures/base';
+import customCredential from '../../../workflows/Custom_credential.json';
+import customNodeFixture from '../../../workflows/Custom_node.json';
+import customNodeWithCustomCredentialFixture from '../../../workflows/Custom_node_custom_credential.json';
+import customNodeWithN8nCredentialFixture from '../../../workflows/Custom_node_n8n_credential.json';
 
 const CUSTOM_NODE_NAME = 'E2E Node';
 const CUSTOM_NODE_WITH_N8N_CREDENTIAL = 'E2E Node with native n8n credential';

--- a/packages/testing/playwright/tests/ui/nodes/email-send-node.spec.ts
+++ b/packages/testing/playwright/tests/ui/nodes/email-send-node.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../../fixtures/base';
+import { test, expect } from '../../../fixtures/base';
 
 test.use({ addContainerCapability: { email: true } });
 

--- a/packages/testing/playwright/tests/ui/nodes/form-trigger-node.spec.ts
+++ b/packages/testing/playwright/tests/ui/nodes/form-trigger-node.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../../fixtures/base';
+import { test, expect } from '../../../fixtures/base';
 
 test.describe('Form Trigger', () => {
 	test.beforeEach(async ({ n8n }) => {

--- a/packages/testing/playwright/tests/ui/nodes/http-request-node.spec.ts
+++ b/packages/testing/playwright/tests/ui/nodes/http-request-node.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../../fixtures/base';
+import { test, expect } from '../../../fixtures/base';
 
 test.describe('HTTP Request node', () => {
 	test.beforeEach(async ({ n8n }) => {

--- a/packages/testing/playwright/tests/ui/nodes/if-node.spec.ts
+++ b/packages/testing/playwright/tests/ui/nodes/if-node.spec.ts
@@ -1,5 +1,5 @@
-import { IF_NODE_NAME } from '../../config/constants';
-import { test, expect } from '../../fixtures/base';
+import { IF_NODE_NAME } from '../../../config/constants';
+import { test, expect } from '../../../fixtures/base';
 
 const FILTER_PARAM_NAME = 'conditions';
 

--- a/packages/testing/playwright/tests/ui/nodes/pdf-node.spec.ts
+++ b/packages/testing/playwright/tests/ui/nodes/pdf-node.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '../../fixtures/base';
+import { expect, test } from '../../../fixtures/base';
 
 test.describe('PDF Test', () => {
 	test('Can read and write PDF files and extract text', async ({ n8n }) => {


### PR DESCRIPTION
## Summary
  - Moves 6 test files to tests/ui/nodes/
  - Updates import paths for new directory depth

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1892/nodes-specific-node-types

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
