### PR TITLE
fix(core): Allowlist `HOME` env var in JS runner config

### DIFF
--- a/docker/images/runners/n8n-task-runners.json
+++ b/docker/images/runners/n8n-task-runners.json
@@ -20,7 +20,8 @@
 				"N8N_SENTRY_DSN",
 				"N8N_VERSION",
 				"ENVIRONMENT",
-				"DEPLOYMENT_NAME"
+				"DEPLOYMENT_NAME",
+				"HOME"
 			],
 			"env-overrides": {
 				"NODE_FUNCTION_ALLOW_BUILTIN": "crypto",


### PR DESCRIPTION
## Summary

We need to ensure the launcher passes `HOME` to the JS runner's environment, otherwise #22796 has no effect.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1851/task-runner-failures-and-recurring-community-node-uninstalls-grafana#comment-a4bd3ef5

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
