### PR TITLE
test: Migrate data tables tests to data-tables/ directory

### DIFF
--- a/packages/testing/playwright/tests/ui/data-tables/details.spec.ts
+++ b/packages/testing/playwright/tests/ui/data-tables/details.spec.ts
@@ -1,7 +1,7 @@
 import { nanoid } from 'nanoid';
 
-import { test, expect } from '../../fixtures/base';
-import type { n8nPage } from '../../pages/n8nPage';
+import { test, expect } from '../../../fixtures/base';
+import type { n8nPage } from '../../../pages/n8nPage';
 
 test.describe('Data Table details view', () => {
 	let testDataTableName: string;

--- a/packages/testing/playwright/tests/ui/data-tables/tables.spec.ts
+++ b/packages/testing/playwright/tests/ui/data-tables/tables.spec.ts
@@ -1,6 +1,6 @@
 import { nanoid } from 'nanoid';
 
-import { test, expect } from '../../fixtures/base';
+import { test, expect } from '../../../fixtures/base';
 
 test.describe('Data Table list view', () => {
 	test.beforeEach(async ({ n8n, api }) => {


### PR DESCRIPTION
## Summary
  - Migrate `data-tables.spec.ts` → `data-tables/tables.spec.ts`
  - Migrate `data-table-details.spec.ts` → `data-tables/details.spec.ts`

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/CAT-1895/data-tables-data-table-features

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
