### PR TITLE
test: Migrate tests to app-config/ and capabilities/ directories

### DIFF
--- a/packages/testing/playwright/tests/ui/app-config/become-creator.spec.ts
+++ b/packages/testing/playwright/tests/ui/app-config/become-creator.spec.ts
@@ -1,5 +1,5 @@
-import { test, expect } from '../../fixtures/base';
-import type { TestRequirements } from '../../Types';
+import { test, expect } from '../../../fixtures/base';
+import type { TestRequirements } from '../../../Types';
 
 test.describe('Become creator CTA', () => {
 	test('should not show the CTA if user is not eligible', async ({ n8n, setupRequirements }) => {

--- a/packages/testing/playwright/tests/ui/app-config/demo.spec.ts
+++ b/packages/testing/playwright/tests/ui/app-config/demo.spec.ts
@@ -1,7 +1,7 @@
-import { test, expect } from '../../fixtures/base';
-import type { TestRequirements } from '../../Types';
-import simpleWorkflow from '../../workflows/Manual_wait_set.json';
-import workflowWithPinned from '../../workflows/Webhook_set_pinned.json';
+import { test, expect } from '../../../fixtures/base';
+import type { TestRequirements } from '../../../Types';
+import simpleWorkflow from '../../../workflows/Manual_wait_set.json';
+import workflowWithPinned from '../../../workflows/Webhook_set_pinned.json';
 
 const requirements: TestRequirements = {
 	config: {

--- a/packages/testing/playwright/tests/ui/app-config/env-feature-flags.spec.ts
+++ b/packages/testing/playwright/tests/ui/app-config/env-feature-flags.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../../fixtures/base';
+import { test, expect } from '../../../fixtures/base';
 
 test.describe
 	.serial('Environment Feature Flags', () => {

--- a/packages/testing/playwright/tests/ui/app-config/nps-survey.spec.ts
+++ b/packages/testing/playwright/tests/ui/app-config/nps-survey.spec.ts
@@ -1,5 +1,5 @@
-import { test, expect } from '../../fixtures/base';
-import type { TestRequirements } from '../../Types';
+import { test, expect } from '../../../fixtures/base';
+import type { TestRequirements } from '../../../Types';
 
 const NOW = Date.now();
 const ONE_DAY = 24 * 60 * 60 * 1000;

--- a/packages/testing/playwright/tests/ui/app-config/security-notifications.spec.ts
+++ b/packages/testing/playwright/tests/ui/app-config/security-notifications.spec.ts
@@ -1,5 +1,5 @@
-import { test, expect } from '../../fixtures/base';
-import type { n8nPage } from '../../pages/n8nPage';
+import { test, expect } from '../../../fixtures/base';
+import type { n8nPage } from '../../../pages/n8nPage';
 
 test.describe('Security Notifications', () => {
 	async function setupVersionsApiMock(

--- a/packages/testing/playwright/tests/ui/app-config/versions.spec.ts
+++ b/packages/testing/playwright/tests/ui/app-config/versions.spec.ts
@@ -1,5 +1,5 @@
-import { test, expect } from '../../fixtures/base';
-import type { TestRequirements } from '../../Types';
+import { test, expect } from '../../../fixtures/base';
+import type { TestRequirements } from '../../../Types';
 
 const requirements: TestRequirements = {
 	config: {

--- a/packages/testing/playwright/tests/ui/capabilities/proxy-server.spec.ts
+++ b/packages/testing/playwright/tests/ui/capabilities/proxy-server.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 
-import { test, expect } from '../../fixtures/base';
+import { test, expect } from '../../../fixtures/base';
 
 test.use({
 	addContainerCapability: {

--- a/packages/testing/playwright/tests/ui/capabilities/task-runner.spec.ts
+++ b/packages/testing/playwright/tests/ui/capabilities/task-runner.spec.ts
@@ -1,5 +1,5 @@
-import { CODE_NODE_NAME, MANUAL_TRIGGER_NODE_NAME } from '../../config/constants';
-import { test, expect } from '../../fixtures/base';
+import { CODE_NODE_NAME, MANUAL_TRIGGER_NODE_NAME } from '../../../config/constants';
+import { test, expect } from '../../../fixtures/base';
 
 test.use({
 	addContainerCapability: {


### PR DESCRIPTION
## Summary

  Moved application configuration tests to `app-config/`:
  - `demo.spec.ts` - preview mode
  - `env-feature-flags.spec.ts` - runtime feature flags
  - `versions.spec.ts` - version updates panel
  - `security-notifications.spec.ts` - security update notifications
  - `nps-survey.spec.ts` - NPS survey modal
  - `become-creator.spec.ts` - template creator CTA

  Moved test infrastructure capability tests to `capabilities/`:
  - `proxy-server.spec.ts` - proxy/mock server container
  - `task-runner.spec.ts` - task runner container for JS/Python

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/CAT-1897/app-config-application-configuration-tests
https://linear.app/n8n/issue/CAT-1907/capabilities-test-infrastructure-capability-tests


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
