### PR TITLE
fix(core): Update migration that activate workflows with executeWorkflowTrigger

### DIFF
--- a/packages/cli/test/migration/1763048000000-activate-execute-workflow-trigger-workflows.test.ts
+++ b/packages/cli/test/migration/1763048000000-activate-execute-workflow-trigger-workflows.test.ts
@@ -102,6 +102,8 @@ describe('ActivateExecuteWorkflowTriggerWorkflows Migration', () => {
 			passthrough: randomUUID(),
 			jsonExample: randomUUID(),
 			legacy: randomUUID(),
+			version1NoParams: randomUUID(),
+			version11MissingType: randomUUID(),
 			invalid: randomUUID(),
 			errorTrigger: randomUUID(),
 			multipleTriggers: randomUUID(),
@@ -186,8 +188,56 @@ describe('ActivateExecuteWorkflowTriggerWorkflows Migration', () => {
 						id: randomUUID(),
 						name: 'Execute Workflow Trigger',
 						type: 'n8n-nodes-base.executeWorkflowTrigger',
+						parameters: {
+							workflowInputs: {
+								values: [{ type: 'string' }], // missing 'name' field
+							},
+						},
+						typeVersion: 1,
+						position: [0, 0],
+					},
+				],
+				connections: {},
+				active: false,
+				versionId: randomUUID(),
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			});
+
+			await insertTestWorkflow(context, {
+				id: workflowIds.version1NoParams,
+				name: 'Test Version 1 No Parameters',
+				nodes: [
+					{
+						id: randomUUID(),
+						name: 'Execute Workflow Trigger',
+						type: 'n8n-nodes-base.executeWorkflowTrigger',
 						parameters: {},
 						typeVersion: 1,
+						position: [0, 0],
+					},
+				],
+				connections: {},
+				active: false,
+				versionId: randomUUID(),
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			});
+
+			await insertTestWorkflow(context, {
+				id: workflowIds.version11MissingType,
+				name: 'Test Version 1.1 Missing Type',
+				nodes: [
+					{
+						id: randomUUID(),
+						name: 'Execute Workflow Trigger',
+						type: 'n8n-nodes-base.executeWorkflowTrigger',
+						parameters: {
+							workflowInputs: {
+								values: [{ name: 'chatInput' }, { name: 'sessionId' }, { name: 'env' }],
+							},
+						},
+						typeVersion: 1.1,
 						position: [0, 0],
 					},
 				],
@@ -372,6 +422,26 @@ describe('ActivateExecuteWorkflowTriggerWorkflows Migration', () => {
 			const workflow = await getWorkflowById(context, workflowIds.legacy);
 
 			expect(workflow?.active).toBeTruthy();
+
+			await context.queryRunner.release();
+		});
+
+		it('should activate workflows with Version 1 Execute Workflow Trigger (no parameters)', async () => {
+			const context = createTestMigrationContext(dataSource);
+			const workflow = await getWorkflowById(context, workflowIds.version1NoParams);
+
+			expect(workflow?.active).toBeTruthy();
+			expect(workflow?.activeVersionId).toBeTruthy();
+
+			await context.queryRunner.release();
+		});
+
+		it('should activate workflows with Version 1.1 Execute Workflow Trigger (missing type fields)', async () => {
+			const context = createTestMigrationContext(dataSource);
+			const workflow = await getWorkflowById(context, workflowIds.version11MissingType);
+
+			expect(workflow?.active).toBeTruthy();
+			expect(workflow?.activeVersionId).toBeTruthy();
 
 			await context.queryRunner.release();
 		});


### PR DESCRIPTION
## Summary

Fixes the `ActivateExecuteWorkflowTriggerWorkflows` migration to properly handle all valid Execute Workflow Trigger configurations, including:
- Version 1 nodes with empty parameters
- Version 1.1 nodes with missing `type` fields in workflowInputs (which default to "string")

## Root cause

The migration logic was too strict in validating Execute Workflow Trigger nodes:

1. **Version 1 nodes**: These nodes have no `inputSource` parameter and use empty `parameters: {}`. The migration was not recognizing empty parameters as valid, failing to activate workflows with v1 Execute Workflow Trigger nodes.

2. **Version 1.1 nodes with missing types**: The Execute Workflow Trigger v1.1 has a default type of "string" for workflow inputs. When users don't explicitly set a type, it's not included in the JSON. The migration's `hasValidWorkflowInputs()` validation required the `type` field to exist, incorrectly rejecting valid configurations.

## Changes

### Migration ([1763048000000-ActivateExecuteWorkflowTriggerWorkflows.ts](packages/@n8n/db/src/migrations/common/1763048000000-ActivateExecuteWorkflowTriggerWorkflows.ts))

1. **Version 1 support** (lines 99-102): Added check for empty or missing parameters object. If `!params || Object.keys(params).length === 0`, the workflow is considered valid and will be activated.

2. **Version 1.1 missing type support** (lines 195-196): Updated `hasValidWorkflowInputs()` to treat missing `type` field as valid:
   ```typescript
   // type is optional (defaults to 'string' in version 1.1)
   (!('type' in value) || (typeof value.type === 'string' && value.type.length > 0))
