### PR TITLE
fix: edit fields array not parsing data #22586

### DIFF
--- a/packages/workflow/test/type-validation.test.ts
+++ b/packages/workflow/test/type-validation.test.ts
@@ -5,6 +5,7 @@ import {
 	tryToParseDateTime,
 	tryToParseJsonToFormFields,
 	validateFieldType,
+	tryToParseArray,
 } from '../src/type-validation';
 
 describe('Type Validation', () => {
@@ -234,10 +235,7 @@ describe('Type Validation', () => {
 		);
 
 		const INVALID_ARRAYS = [
-			'"apples", "oranges"',
-			'1',
 			'1.1',
-			'1, 2',
 			'1. 2. 3',
 			'[1, 2, 3',
 			'1, 2, 3]',
@@ -362,6 +360,34 @@ describe('Type Validation', () => {
 
 			expect(result.zoneName).toEqual('Asia/Tokyo');
 			expect(result.toISO()).toEqual('2025-01-01T00:00:00.000+09:00');
+		});
+	});
+
+	describe('tryToParseArray', () => {
+		it('should parse a JSON array string without any single or double quote', () => {
+			const jsonArray = '[apple, banana, cherry]';
+			const result = tryToParseArray(jsonArray);
+			expect(result).toEqual(['apple', 'banana', 'cherry']);
+		});
+		it('should parse a JSON array string without any square bracket', () => {
+			const jsonArray = 'apple, banana, cherry';
+			const result = tryToParseArray(jsonArray);
+			expect(result).toEqual(['apple', 'banana', 'cherry']);
+		});
+		it('should parse a JSON array string with double quote without any square bracket', () => {
+			const jsonArray = '"apple", "banana", "cherry"';
+			const result = tryToParseArray(jsonArray);
+			expect(result).toEqual(['apple', 'banana', 'cherry']);
+		});
+		it('should throw ApplicationError when given invalid input that is not an array', () => {
+			const jsonObject = '{"key": "value"}';
+			const nonArrayString = 'justasingleword';
+			expect(() => {
+				tryToParseArray(jsonObject);
+			}).toThrow('Value is not a valid array');
+			expect(() => {
+				tryToParseArray(nonArrayString);
+			}).toThrow('Value is not a valid array');
 		});
 	});
 


### PR DESCRIPTION
## Summary

## 🐛 Bug Fix: Manually Defining Array Fields in Edit Fields Node

This PR addresses a bug where users could not correctly define an **Array** type field within the **Edit Fields** node using string input.

fixes: #22586

---

### 📝 Bug Description

When a user defined a field as type `Array` in the **Edit Fields** node and provided a list of values in any of the below fashion user use to get error as code was not able to parse it correctly
* apples,bananas,pears
* "apples","bananas","pears"
* apples, bananas, pears
* [apples, bananas, pears]

**Affected n8n version:** 1.121.3 (and potentially earlier versions)

### 🚀 Solution

This fix introduces logic to correctly detect when the chosen field type is `Array` and attempts to parse the input string into a structured array.

It now successfully handles various common array string formats, including:

* Simple comma-separated values (e.g., `apples, bananas, pears`)
* Quoted comma-separated values (e.g., `"apples", "bananas", "pears"`)
* Bracketed array notation (e.g., `[apples, bananas, pears]` or `["apples", "bananas", "pears"]`)

The output is now consistently a proper JSON array, making the manual array definition functional as intended.

---

### 🧪 Steps to Verify (How to Test)

1.  Start a new workflow and add an **Edit Fields (Set)** node.
2.  In the "Mode" section, keep **Manual Mapping (default)**.
3.  Configure the new field, (click add field):
    * **Field Name:** `fruits`
    * **Field Type (from dropdown):** `Array`
    * **Value:** Enter a comma-separated list, e.g., `apples, bananas, pears`
4.  Run the workflow.
5.  Inspect the output data from the **Edit Fields** node.

**✅ Expected Result:**
The output should contain the field `fruits` as a proper array structure:

```json
{
      "fruits": [
    "apples",
    "bananas",
    "pears"
  ]
}
```
few of the working screen-shot are below
<img width="701" height="453" alt="Screenshot 2025-12-07 at 12 37 06 AM" src="https://github.com/user-attachments/assets/f4753e43-d53b-46f6-8186-8c98a41813c3" />
<img width="700" height="480" alt="Screenshot 2025-12-07 at 12 37 34 AM" src="https://github.com/user-attachments/assets/0acc3932-851c-47d6-8d08-ccc0f79962af" />
<img width="700" height="443" alt="Screenshot 2025-12-07 at 12 37 51 AM" src="https://github.com/user-attachments/assets/ec367cac-aa3a-4e67-bb98-78092cd8c892" />

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
