### PR TITLE
feat(Google Sheets Node):Add corpora allDrives to enable full spreadsheet discovery

### DIFF
--- a/packages/nodes-base/nodes/Google/Sheet/test/v2/methods/listSearch.test.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/test/v2/methods/listSearch.test.ts
@@ -48,6 +48,7 @@ describe('Google Sheets Search Functions', () => {
 					orderBy: 'modifiedByMeTime desc,name_natural',
 					includeItemsFromAllDrives: true,
 					supportsAllDrives: true,
+					corpora: 'allDrives',
 				},
 				'https://www.googleapis.com/drive/v3/files',
 			);
@@ -84,6 +85,7 @@ describe('Google Sheets Search Functions', () => {
 					orderBy: 'modifiedByMeTime desc,name_natural',
 					includeItemsFromAllDrives: true,
 					supportsAllDrives: true,
+					corpora: 'allDrives',
 				},
 				'https://www.googleapis.com/drive/v3/files',
 			);

--- a/packages/nodes-base/nodes/Google/Sheet/v2/methods/listSearch.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/methods/listSearch.ts
@@ -28,6 +28,7 @@ export async function spreadSheetsSearch(
 		orderBy: 'modifiedByMeTime desc,name_natural',
 		includeItemsFromAllDrives: true,
 		supportsAllDrives: true,
+		corpora: 'allDrives',
 	};
 
 	const res = await apiRequest.call(


### PR DESCRIPTION
## Summary

Add corpora: **allDrives** to the query parameters to allow the **Google Sheets** node to list spreadsheets across **My Drive**, **Shared with me**, and **Shared Drives**. This expands file visibility during load options, enabling users to select any spreadsheet they have access to through Google Workspace.

In many organisations, spreadsheets are stored primarily inside Shared Drives or shared individually with team members. The previous implementation did not expose these files in the node’s Load Options, preventing users from selecting and working with spreadsheets that they can normally see in Google Drive.

This change is fully backwards compatible since it only expands visibility without altering existing workflow behaviour.

**How to test**

- Prepare test spreadsheets
  - One in My Drive, one in a Shared Drive you belong to, and one shared with you (appearing under Shared with me).
 - Add a Google Sheets node and search for spreadsheets
   - Use the dropdown search to look for each spreadsheet by name.
 - Verify the results
   - All three spreadsheets (My Drive, Shared Drive, Shared with me) should appear.
 - Regression check
   - Open an existing workflow using Google Sheets and confirm it still loads and runs normally.

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
