### PR TITLE
fix(editor): Use active workflow nodes to determine wf inputs when executing by parent (no-changelog)

### DIFF
--- a/packages/@n8n/db/src/entities/workflow-history.ts
+++ b/packages/@n8n/db/src/entities/workflow-history.ts
@@ -24,10 +24,10 @@ export class WorkflowHistory extends WithTimestamps {
 	authors: string;
 
 	@Column({ nullable: true })
-	name: string;
+	name: string | null;
 
 	@Column({ nullable: true })
-	description: string;
+	description: string | null;
 
 	@ManyToOne('WorkflowEntity', {
 		onDelete: 'CASCADE',

--- a/packages/@n8n/db/src/entities/workflow-history.ts
+++ b/packages/@n8n/db/src/entities/workflow-history.ts
@@ -23,10 +23,10 @@ export class WorkflowHistory extends WithTimestamps {
 	@Column()
 	authors: string;
 
-	@Column({ nullable: true })
+	@Column({ type: 'text', nullable: true })
 	name: string | null;
 
-	@Column({ nullable: true })
+	@Column({ type: 'text', nullable: true })
 	description: string | null;
 
 	@ManyToOne('WorkflowEntity', {

--- a/packages/cli/src/executions/__tests__/constants.ts
+++ b/packages/cli/src/executions/__tests__/constants.ts
@@ -1,10 +1,10 @@
-import type { IWorkflowBase } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
+import type { IWorkflowDb } from '@n8n/db';
 
 /**
  * Workflow producing an execution whose data will be truncated by an instance crash.
  */
-export const OOM_WORKFLOW: Partial<IWorkflowBase> = {
+export const OOM_WORKFLOW: Partial<IWorkflowDb> = {
 	nodes: [
 		{
 			parameters: {},

--- a/packages/cli/src/interfaces.ts
+++ b/packages/cli/src/interfaces.ts
@@ -48,7 +48,10 @@ export interface IWorkflowResponse extends IWorkflowBase {
 }
 
 export interface IWorkflowToImport
-	extends Omit<IWorkflowBase, 'staticData' | 'pinData' | 'createdAt' | 'updatedAt'> {
+	extends Omit<
+		IWorkflowBase,
+		'staticData' | 'pinData' | 'createdAt' | 'updatedAt' | 'activeVersion'
+	> {
 	owner?:
 		| {
 				type: 'personal';

--- a/packages/cli/test/integration/webhooks.api.test.ts
+++ b/packages/cli/test/integration/webhooks.api.test.ts
@@ -1,9 +1,8 @@
 import { testDb, mockInstance, createActiveWorkflow } from '@n8n/backend-test-utils';
-import type { User } from '@n8n/db';
+import type { IWorkflowDb, User } from '@n8n/db';
 import { readFileSync } from 'fs';
 import {
 	type INode,
-	type IWorkflowBase,
 	NodeConnectionTypes,
 	type INodeType,
 	type INodeTypeDescription,
@@ -74,7 +73,7 @@ describe('Webhook API', () => {
 		parameters: {},
 		webhookId: '5ccef736-be16-4d10-b7fb-feed7a61ff22',
 	};
-	const workflowData = { active: true, nodes: [node] } as IWorkflowBase;
+	const workflowData = { active: true, nodes: [node] } as Partial<IWorkflowDb>;
 
 	const nodeTypes = mockInstance(NodeTypes);
 	nodeTypes.getByName.mockReturnValue(nodeInstance);

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/local-load-options-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/local-load-options-context.test.ts
@@ -1,0 +1,272 @@
+import { mock } from 'jest-mock-extended';
+import type {
+	INode,
+	INodeTypes,
+	IWorkflowBase,
+	IWorkflowExecuteAdditionalData,
+	IWorkflowLoader,
+} from 'n8n-workflow';
+import { ApplicationError, Workflow } from 'n8n-workflow';
+
+import { LocalLoadOptionsContext } from '../local-load-options-context';
+import { LoadWorkflowNodeContext } from '../workflow-node-context';
+
+jest.mock('n8n-workflow', () => ({
+	...jest.requireActual('n8n-workflow'),
+	Workflow: jest.fn(),
+}));
+
+describe('LocalLoadOptionsContext', () => {
+	const nodeTypes = mock<INodeTypes>();
+	const additionalData = mock<IWorkflowExecuteAdditionalData>();
+	const workflowLoader = mock<IWorkflowLoader>();
+	const path = '';
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('getWorkflowNodeContext', () => {
+		const targetNodeType = 'n8n-nodes-base.executeWorkflowTrigger';
+
+		it('should throw TypeError when workflowId parameter is missing', async () => {
+			additionalData.currentNodeParameters = {};
+
+			const context = new LocalLoadOptionsContext(nodeTypes, additionalData, path, workflowLoader);
+
+			await expect(context.getWorkflowNodeContext(targetNodeType)).rejects.toThrow(TypeError);
+		});
+
+		it('should throw ApplicationError when workflowId value is not a string', async () => {
+			additionalData.currentNodeParameters = {
+				workflowId: { value: 123 },
+			};
+
+			const context = new LocalLoadOptionsContext(nodeTypes, additionalData, path, workflowLoader);
+
+			await expect(context.getWorkflowNodeContext(targetNodeType)).rejects.toThrow(
+				ApplicationError,
+			);
+		});
+
+		it('should throw ApplicationError when workflowId value is empty', async () => {
+			additionalData.currentNodeParameters = {
+				workflowId: { value: '' },
+			};
+
+			const context = new LocalLoadOptionsContext(nodeTypes, additionalData, path, workflowLoader);
+
+			await expect(context.getWorkflowNodeContext(targetNodeType)).rejects.toThrow(
+				ApplicationError,
+			);
+		});
+
+		it('should throw ApplicationError when useActiveVersion is true but no activeVersion exists', async () => {
+			const workflowId = 'workflow-123';
+			additionalData.currentNodeParameters = {
+				workflowId: { value: workflowId },
+			};
+
+			const dbWorkflow = mock<IWorkflowBase>({
+				id: workflowId,
+				name: 'Test Workflow',
+				nodes: [],
+				activeVersion: null,
+			});
+			workflowLoader.get.mockResolvedValue(dbWorkflow);
+
+			const context = new LocalLoadOptionsContext(nodeTypes, additionalData, path, workflowLoader);
+
+			await expect(context.getWorkflowNodeContext(targetNodeType, true)).rejects.toThrow(
+				ApplicationError,
+			);
+			await expect(context.getWorkflowNodeContext(targetNodeType, true)).rejects.toThrow(
+				`No active version found for workflow "${workflowId}"!`,
+			);
+		});
+
+		it('should return null when no node of the specified type exists in the workflow', async () => {
+			const workflowId = 'workflow-123';
+			additionalData.currentNodeParameters = {
+				workflowId: { value: workflowId },
+			};
+
+			const otherNode = mock<INode>({
+				type: 'n8n-nodes-base.otherNode',
+				name: 'Other Node',
+			});
+			const dbWorkflow = mock<IWorkflowBase>({
+				id: workflowId,
+				name: 'Test Workflow',
+				nodes: [otherNode],
+			});
+			workflowLoader.get.mockResolvedValue(dbWorkflow);
+
+			const context = new LocalLoadOptionsContext(nodeTypes, additionalData, path, workflowLoader);
+
+			const result = await context.getWorkflowNodeContext(targetNodeType);
+
+			expect(result).toBeNull();
+		});
+
+		it('should return LoadWorkflowNodeContext when node type exists in the workflow', async () => {
+			const workflowId = 'workflow-123';
+			const nodeParameters = { inputSource: 'passthrough' };
+			additionalData.currentNodeParameters = {
+				workflowId: { value: workflowId },
+			};
+
+			const targetNode = mock<INode>({
+				type: targetNodeType,
+				name: 'Execute Workflow Trigger',
+				parameters: nodeParameters,
+			});
+			const dbWorkflow = mock<IWorkflowBase>({
+				id: workflowId,
+				name: 'Test Workflow',
+				nodes: [targetNode],
+			});
+			workflowLoader.get.mockResolvedValue(dbWorkflow);
+
+			const context = new LocalLoadOptionsContext(nodeTypes, additionalData, path, workflowLoader);
+
+			const result = await context.getWorkflowNodeContext(targetNodeType);
+
+			expect(result).toBeInstanceOf(LoadWorkflowNodeContext);
+			expect(Workflow).toHaveBeenCalledWith({
+				id: workflowId,
+				name: 'Test Workflow',
+				nodes: [targetNode],
+				connections: {},
+				active: false,
+				nodeTypes,
+			});
+		});
+
+		it('should use activeVersion nodes when useActiveVersion is true', async () => {
+			const workflowId = 'workflow-123';
+			const nodeParameters = { inputSource: 'passthrough' };
+			additionalData.currentNodeParameters = {
+				workflowId: { value: workflowId },
+			};
+
+			const regularNode = mock<INode>({
+				type: targetNodeType,
+				name: 'Regular Trigger',
+			});
+			const activeVersionNode = mock<INode>({
+				type: targetNodeType,
+				name: 'Active Version Trigger',
+				parameters: nodeParameters,
+			});
+			const dbWorkflow = mock<IWorkflowBase>({
+				id: workflowId,
+				name: 'Test Workflow',
+				nodes: [regularNode],
+				activeVersion: {
+					versionId: 'version-1',
+					workflowId,
+					nodes: [activeVersionNode],
+					connections: {},
+					authors: 'test',
+					name: 'Test Workflow',
+					description: null,
+					createdAt: new Date(),
+					updatedAt: new Date(),
+				},
+			});
+			workflowLoader.get.mockResolvedValue(dbWorkflow);
+
+			const context = new LocalLoadOptionsContext(nodeTypes, additionalData, path, workflowLoader);
+
+			const result = await context.getWorkflowNodeContext(targetNodeType, true);
+
+			expect(result).toBeInstanceOf(LoadWorkflowNodeContext);
+			expect(Workflow).toHaveBeenCalledWith({
+				id: workflowId,
+				name: 'Test Workflow',
+				nodes: [activeVersionNode],
+				connections: {},
+				active: false,
+				nodeTypes,
+			});
+		});
+
+		it('should return null when node type does not exist in activeVersion nodes', async () => {
+			const workflowId = 'workflow-123';
+			additionalData.currentNodeParameters = {
+				workflowId: { value: workflowId },
+			};
+
+			const regularNode = mock<INode>({
+				type: targetNodeType,
+				name: 'Regular Trigger',
+			});
+			const activeVersionNode = mock<INode>({
+				type: 'n8n-nodes-base.otherNode',
+				name: 'Other Node',
+			});
+			const dbWorkflow = mock<IWorkflowBase>({
+				id: workflowId,
+				name: 'Test Workflow',
+				nodes: [regularNode],
+				activeVersion: {
+					versionId: 'version-1',
+					workflowId,
+					nodes: [activeVersionNode],
+					connections: {},
+					authors: 'test',
+					name: 'Test Workflow',
+					description: null,
+					createdAt: new Date(),
+					updatedAt: new Date(),
+				},
+			});
+			workflowLoader.get.mockResolvedValue(dbWorkflow);
+
+			const context = new LocalLoadOptionsContext(nodeTypes, additionalData, path, workflowLoader);
+
+			const result = await context.getWorkflowNodeContext(targetNodeType, true);
+
+			expect(result).toBeNull();
+		});
+	});
+
+	describe('getCurrentNodeParameter', () => {
+		it('should return the parameter value when it exists', () => {
+			additionalData.currentNodeParameters = {
+				testParam: 'testValue',
+			};
+
+			const context = new LocalLoadOptionsContext(nodeTypes, additionalData, path, workflowLoader);
+
+			const result = context.getCurrentNodeParameter('testParam');
+
+			expect(result).toBe('testValue');
+		});
+
+		it('should return undefined when parameter does not exist', () => {
+			additionalData.currentNodeParameters = {};
+
+			const context = new LocalLoadOptionsContext(nodeTypes, additionalData, path, workflowLoader);
+
+			const result = context.getCurrentNodeParameter('nonExistent');
+
+			expect(result).toBeUndefined();
+		});
+
+		it('should resolve nested parameter paths', () => {
+			additionalData.currentNodeParameters = {
+				parent: {
+					child: 'nestedValue',
+				},
+			};
+
+			const context = new LocalLoadOptionsContext(nodeTypes, additionalData, path, workflowLoader);
+
+			const result = context.getCurrentNodeParameter('parent.child');
+
+			expect(result).toBe('nestedValue');
+		});
+	});
+});

--- a/packages/nodes-base/utils/workflowInputsResourceMapping/GenericFunctions.ts
+++ b/packages/nodes-base/utils/workflowInputsResourceMapping/GenericFunctions.ts
@@ -168,7 +168,10 @@ export function getCurrentWorkflowInputData(this: IExecuteFunctions | ISupplyDat
 export async function loadWorkflowInputMappings(
 	this: ILocalLoadOptionsFunctions,
 ): Promise<WorkflowInputsData> {
-	const nodeLoadContext = await this.getWorkflowNodeContext(EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE);
+	const nodeLoadContext = await this.getWorkflowNodeContext(
+		EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE,
+		true,
+	);
 	let fields: ResourceMapperField[] = [];
 	let dataMode: string = PASSTHROUGH;
 	let subworkflowInfo: { workflowId?: string; triggerId?: string } | undefined;

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1130,7 +1130,10 @@ export type IWorkflowNodeContext = ExecuteFunctions.GetNodeParameterFn &
 	Pick<FunctionsBase, 'getNode' | 'getWorkflow'>;
 
 export interface ILocalLoadOptionsFunctions {
-	getWorkflowNodeContext(nodeType: string): Promise<IWorkflowNodeContext | null>;
+	getWorkflowNodeContext(
+		nodeType: string,
+		useActiveVersion?: boolean,
+	): Promise<IWorkflowNodeContext | null>;
 }
 
 export interface IWorkflowLoader {
@@ -2574,8 +2577,21 @@ export interface IWorkflowBase {
 	pinData?: IPinData;
 	versionId?: string;
 	activeVersionId: string | null;
+	activeVersion?: IWorkflowHistory | null;
 	versionCounter?: number;
 	meta?: WorkflowFEMeta;
+}
+
+interface IWorkflowHistory {
+	versionId: string;
+	workflowId: string;
+	nodes: INode[];
+	connections: IConnections;
+	authors: string;
+	name: string | null;
+	description: string | null;
+	createdAt: Date;
+	updatedAt: Date;
 }
 
 export interface IWorkflowCredentials {


### PR DESCRIPTION
## Summary

With the introduction of publishing workflows all workflow invoked as sub workflow should be published and that published version is always what's used by the main workflow. This means that in the main workflow we should always show the child workflow parameters from it's active/published version.

## Related Linear tickets, Github issues, and Community forum posts

https://www.notion.so/n8n/subworkflows-don-t-play-well-with-new-publish-paradigm-2c15b6e0c94f8017abf7cca8289d35d0?source=copy_link


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
