### PR TITLE
chore: Clean up deprecation warnings

### DIFF
--- a/packages/cli/src/deprecation/__tests__/deprecation.service.test.ts
+++ b/packages/cli/src/deprecation/__tests__/deprecation.service.test.ts
@@ -66,23 +66,6 @@ describe('DeprecationService', () => {
 		toTest(envVar, value, mustWarn);
 	});
 
-	test.each([
-		['default', true],
-		['filesystem', false],
-		['s3', false],
-	])('should handle N8N_BINARY_DATA_MODE as %s', (mode, mustWarn) => {
-		toTest('N8N_BINARY_DATA_MODE', mode, mustWarn);
-	});
-
-	test.each([
-		['sqlite', false],
-		['postgresdb', false],
-		['mysqldb', true],
-		['mariadb', true],
-	])('should handle DB_TYPE as %s', (dbType, mustWarn) => {
-		toTest('DB_TYPE', dbType, mustWarn);
-	});
-
 	describe('OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS', () => {
 		const envVar = 'OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS';
 
@@ -178,53 +161,6 @@ describe('DeprecationService', () => {
 					expect(warningMessage).toContain(envVar);
 				});
 			});
-		});
-	});
-
-	describe('N8N_GIT_NODE_DISABLE_BARE_REPOS', () => {
-		beforeEach(() => {
-			process.env = {
-				N8N_RUNNERS_ENABLED: 'true',
-			};
-			jest.resetAllMocks();
-		});
-
-		test('should warn when N8N_GIT_NODE_DISABLE_BARE_REPOS is not set', () => {
-			delete process.env.N8N_GIT_NODE_DISABLE_BARE_REPOS;
-			deprecationService.warn();
-			expect(logger.warn).toHaveBeenCalled();
-		});
-
-		test.each(['false', 'true'])(
-			'should not warn when N8N_GIT_NODE_DISABLE_BARE_REPOS is %s',
-			(value) => {
-				process.env.N8N_GIT_NODE_DISABLE_BARE_REPOS = value;
-				deprecationService.warn();
-				expect(logger.warn).not.toHaveBeenCalled();
-			},
-		);
-
-		test('should not warn when Git node is excluded', () => {
-			const globalConfig = mockInstance(GlobalConfig, {
-				nodes: { exclude: ['n8n-nodes-base.git'] },
-			});
-			const deprecationService = new DeprecationService(logger, globalConfig, instanceSettings);
-
-			deprecationService.warn();
-
-			expect(logger.warn).not.toHaveBeenCalled();
-		});
-
-		test('should not warn when deployment type is cloud', () => {
-			const globalConfig = mockInstance(GlobalConfig, {
-				nodes: { exclude: [] },
-				deployment: { type: 'cloud' },
-			});
-			const deprecationService = new DeprecationService(logger, globalConfig, instanceSettings);
-
-			deprecationService.warn();
-
-			expect(logger.warn).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/cli/src/deprecation/deprecation.service.ts
+++ b/packages/cli/src/deprecation/deprecation.service.ts
@@ -34,23 +34,8 @@ export class DeprecationService {
 		{ envVar: 'N8N_BINARY_DATA_TTL', message: SAFE_TO_REMOVE },
 		{ envVar: 'N8N_PERSISTED_BINARY_DATA_TTL', message: SAFE_TO_REMOVE },
 		{ envVar: 'EXECUTIONS_DATA_PRUNE_TIMEOUT', message: SAFE_TO_REMOVE },
-		{
-			envVar: 'N8N_BINARY_DATA_MODE',
-			message: '`default` is deprecated. Please switch to `filesystem` mode.',
-			checkValue: (value: string) => value === 'default',
-		},
+		{ envVar: 'N8N_AVAILABLE_BINARY_DATA_MODES', message: SAFE_TO_REMOVE },
 		{ envVar: 'N8N_CONFIG_FILES', message: 'Please use .env files or *_FILE env vars instead.' },
-		{
-			envVar: 'DB_TYPE',
-			message: 'MySQL and MariaDB are deprecated. Please migrate to PostgreSQL.',
-			checkValue: (value: string) => ['mysqldb', 'mariadb'].includes(value),
-		},
-		{
-			envVar: 'DB_SQLITE_POOL_SIZE',
-			message:
-				'Running SQLite without a pool of read connections is deprecated. Please set `DB_SQLITE_POOL_SIZE` to a value higher than zero. See: https://docs.n8n.io/hosting/configuration/environment-variables/database/#sqlite',
-			checkValue: (_: string) => this.globalConfig.database.isLegacySqlite,
-		},
 		{
 			envVar: 'N8N_SKIP_WEBHOOK_DEREGISTRATION_SHUTDOWN',
 			message: `n8n no longer deregisters webhooks at startup and shutdown. ${SAFE_TO_REMOVE}`,
@@ -82,15 +67,6 @@ export class DeprecationService {
 			message:
 				'n8n does not support `own` mode since May 2023. Please remove this environment variable to allow n8n to start. If you need the isolation and performance gains, please consider queue mode: https://docs.n8n.io/hosting/scaling/queue-mode/',
 			checkValue: (value: string) => value === 'own',
-		},
-		{
-			envVar: 'N8N_GIT_NODE_DISABLE_BARE_REPOS',
-			message:
-				'Support for bare repositories in the Git Node will be removed in a future version due to security concerns. If you are not using bare repositories in the Git Node, please set N8N_GIT_NODE_DISABLE_BARE_REPOS=true. Learn more: https://docs.n8n.io/hosting/configuration/environment-variables/security/',
-			checkValue: (value: string | undefined) => value === undefined || value === '',
-			disableIf: () =>
-				this.globalConfig.nodes.exclude.includes('n8n-nodes-base.git') ||
-				this.globalConfig.deployment.type === 'cloud',
 		},
 	];
 


### PR DESCRIPTION
## Summary

- Add `N8N_AVAILABLE_BINARY_DATA_MODES` as safe to remove
- Remove warnings for those that have been remvoed in v2

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
