### PR TITLE
fix(core): Handle misformed nodes in credential indexing (no-changelog)

### DIFF
--- a/packages/cli/src/modules/workflow-index/__tests__/workflow-index.service.test.ts
+++ b/packages/cli/src/modules/workflow-index/__tests__/workflow-index.service.test.ts
@@ -243,38 +243,6 @@ describe('WorkflowIndexService', () => {
 			);
 		});
 
-		it('should skip disabled nodes', async () => {
-			mockWorkflowDependencyRepository.updateDependenciesForWorkflow.mockResolvedValue(true);
-
-			const workflow = createWorkflow([
-				createNode({
-					id: 'node-1',
-					type: 'n8n-nodes-base.httpRequest',
-				}),
-				createNode({
-					id: 'node-2',
-					type: 'n8n-nodes-base.webhook',
-					parameters: { path: 'test-path' },
-					disabled: true,
-				}),
-			]);
-
-			await service.updateIndexFor(workflow);
-
-			const call = mockWorkflowDependencyRepository.updateDependenciesForWorkflow.mock.calls[0];
-			const dependencies = call[1].dependencies;
-
-			// Only node-1 dependency should be present
-			expect(dependencies).toHaveLength(1);
-			expect(dependencies).toEqual([
-				expect.objectContaining({
-					dependencyType: 'nodeType',
-					dependencyKey: 'n8n-nodes-base.httpRequest',
-					dependencyInfo: { nodeId: 'node-1', nodeVersion: 1 },
-				}),
-			]);
-		});
-
 		it('should skip credentials with null or empty id', async () => {
 			mockWorkflowDependencyRepository.updateDependenciesForWorkflow.mockResolvedValue(true);
 

--- a/packages/cli/src/modules/workflow-index/workflow-index.service.ts
+++ b/packages/cli/src/modules/workflow-index/workflow-index.service.ts
@@ -94,9 +94,6 @@ export class WorkflowIndexService {
 		const dependencyUpdates = new WorkflowDependencies(workflow.id, workflow.versionCounter);
 
 		workflow.nodes.forEach((node) => {
-			if (node.disabled) {
-				return; // skip disabled nodes.
-			}
 			this.addNodeTypeDependencies(node, dependencyUpdates);
 			this.addCredentialDependencies(node, dependencyUpdates);
 			this.addWorkflowCallDependencies(node, dependencyUpdates);

--- a/packages/cli/src/modules/workflow-index/workflow-index.service.ts
+++ b/packages/cli/src/modules/workflow-index/workflow-index.service.ts
@@ -94,6 +94,9 @@ export class WorkflowIndexService {
 		const dependencyUpdates = new WorkflowDependencies(workflow.id, workflow.versionCounter);
 
 		workflow.nodes.forEach((node) => {
+			if (node.disabled) {
+				return; // skip disabled nodes.
+			}
 			this.addNodeTypeDependencies(node, dependencyUpdates);
 			this.addCredentialDependencies(node, dependencyUpdates);
 			this.addWorkflowCallDependencies(node, dependencyUpdates);
@@ -133,6 +136,9 @@ export class WorkflowIndexService {
 		}
 		for (const credentialDetails of Object.values(node.credentials)) {
 			const { id } = credentialDetails;
+			if (!id) {
+				continue;
+			}
 			dependencyUpdates.add({
 				dependencyType: 'credentialId',
 				dependencyKey: id,

--- a/packages/cli/src/modules/workflow-index/workflow-index.service.ts
+++ b/packages/cli/src/modules/workflow-index/workflow-index.service.ts
@@ -123,11 +123,13 @@ export class WorkflowIndexService {
 	}
 
 	private addNodeTypeDependencies(node: INode, dependencyUpdates: WorkflowDependencies): void {
-		dependencyUpdates.add({
-			dependencyType: 'nodeType',
-			dependencyKey: node.type,
-			dependencyInfo: { nodeId: node.id, nodeVersion: node.typeVersion },
-		});
+		if (node.type) {
+			dependencyUpdates.add({
+				dependencyType: 'nodeType',
+				dependencyKey: node.type,
+				dependencyInfo: { nodeId: node.id, nodeVersion: node.typeVersion },
+			});
+		}
 	}
 
 	private addCredentialDependencies(node: INode, dependencyUpdates: WorkflowDependencies): void {
@@ -167,11 +169,13 @@ export class WorkflowIndexService {
 			return;
 		}
 		const webhookPath = node.parameters.path as string;
-		dependencyUpdates.add({
-			dependencyType: 'webhookPath',
-			dependencyKey: webhookPath,
-			dependencyInfo: { nodeId: node.id, nodeVersion: node.typeVersion },
-		});
+		if (webhookPath) {
+			dependencyUpdates.add({
+				dependencyType: 'webhookPath',
+				dependencyKey: webhookPath,
+				dependencyInfo: { nodeId: node.id, nodeVersion: node.typeVersion },
+			});
+		}
 	}
 
 	private getCalledWorkflowIdFrom(node: INode): string | undefined {


### PR DESCRIPTION
## Summary

We cover a few cases:
- Credential id is null
- Missing node type
- Webhook doesn't have a path

These are all malformed nodes in a sense, but we prefer to tolerate them without throwing errors.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
