### PR TITLE
feat(ai-builder): Add autofocus for input field

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.vue
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.vue
@@ -416,6 +416,7 @@ defineExpose({
 								:max-length="maxCharacterLength"
 								:min-lines="2"
 								data-test-id="chat-suggestions-input"
+								autofocus
 								@upgrade-click="emit('upgrade-click')"
 								@submit="onSendMessage"
 								@stop="emit('stop')"
@@ -466,6 +467,7 @@ defineExpose({
 				:max-length="maxCharacterLength"
 				:refocus-after-send="true"
 				data-test-id="chat-input"
+				autofocus
 				@upgrade-click="emit('upgrade-click')"
 				@submit="onSendMessage"
 				@stop="emit('stop')"

--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/__snapshots__/AskAssistantChat.test.ts.snap
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/__snapshots__/AskAssistantChat.test.ts.snap
@@ -86,6 +86,7 @@ exports[`AskAssistantChat > limits maximum input length when maxCharacterLength 
       data-test-id="chat-input-wrapper"
     >
       <n8n-prompt-input-stub
+        autofocus="true"
         data-test-id="chat-input"
         disabled="false"
         maxlength="100"
@@ -320,6 +321,7 @@ exports[`AskAssistantChat > renders chat with messages correctly 1`] = `
       data-test-id="chat-input-wrapper"
     >
       <n8n-prompt-input-stub
+        autofocus="true"
         data-test-id="chat-input"
         disabled="false"
         maxlength="5000"
@@ -422,6 +424,7 @@ exports[`AskAssistantChat > renders default placeholder chat correctly 1`] = `
       data-test-id="chat-input-wrapper"
     >
       <n8n-prompt-input-stub
+        autofocus="true"
         data-test-id="chat-input"
         disabled="false"
         maxlength="5000"
@@ -567,6 +570,7 @@ exports[`AskAssistantChat > renders end of session chat correctly 1`] = `
       data-test-id="chat-input-wrapper"
     >
       <n8n-prompt-input-stub
+        autofocus="true"
         data-test-id="chat-input"
         disabled="true"
         maxlength="5000"
@@ -697,6 +701,7 @@ exports[`AskAssistantChat > renders error message correctly with retry button 1`
       data-test-id="chat-input-wrapper"
     >
       <n8n-prompt-input-stub
+        autofocus="true"
         data-test-id="chat-input"
         disabled="false"
         maxlength="5000"
@@ -827,6 +832,7 @@ exports[`AskAssistantChat > renders message with code snippet 1`] = `
       data-test-id="chat-input-wrapper"
     >
       <n8n-prompt-input-stub
+        autofocus="true"
         data-test-id="chat-input"
         disabled="false"
         maxlength="5000"
@@ -957,6 +963,7 @@ exports[`AskAssistantChat > renders streaming chat correctly 1`] = `
       data-test-id="chat-input-wrapper"
     >
       <n8n-prompt-input-stub
+        autofocus="true"
         data-test-id="chat-input"
         disabled="false"
         maxlength="5000"

--- a/packages/frontend/@n8n/design-system/src/components/N8nPromptInput/N8nPromptInput.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nPromptInput/N8nPromptInput.test.ts
@@ -1077,7 +1077,7 @@ describe('N8nPromptInput', () => {
 
 	describe('autofocus', () => {
 		it('should be focused if enabled', async () => {
-			const { container, emitted } = renderComponent({
+			const { emitted } = renderComponent({
 				props: {
 					autofocus: true,
 				},
@@ -1090,7 +1090,7 @@ describe('N8nPromptInput', () => {
 		});
 
 		it('should not be focused if disabled', () => {
-			const { container, emitted } = renderComponent({
+			const { emitted } = renderComponent({
 				global: {
 					stubs: ['N8nCallout', 'N8nScrollArea', 'N8nSendStopButton'],
 				},

--- a/packages/frontend/@n8n/design-system/src/components/N8nPromptInput/N8nPromptInput.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nPromptInput/N8nPromptInput.test.ts
@@ -1074,4 +1074,28 @@ describe('N8nPromptInput', () => {
 			wrapper.unmount();
 		});
 	});
+
+	describe('autofocus', () => {
+		it('should be focused if enabled', async () => {
+			const { container, emitted } = renderComponent({
+				props: {
+					autofocus: true,
+				},
+				global: {
+					stubs: ['N8nCallout', 'N8nScrollArea', 'N8nSendStopButton'],
+				},
+			});
+
+			expect(emitted('focus')).toBeTruthy();
+		});
+
+		it('should not be focused if disabled', () => {
+			const { container, emitted } = renderComponent({
+				global: {
+					stubs: ['N8nCallout', 'N8nScrollArea', 'N8nSendStopButton'],
+				},
+			});
+			expect(emitted('focus')).toBeFalsy();
+		});
+	});
 });

--- a/packages/frontend/@n8n/design-system/src/components/N8nPromptInput/N8nPromptInput.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nPromptInput/N8nPromptInput.vue
@@ -22,6 +22,7 @@ export interface N8nPromptInputProps {
 	creditsRemaining?: number;
 	showAskOwnerTooltip?: boolean;
 	refocusAfterSend?: boolean;
+	autofocus?: boolean;
 }
 
 const INFINITE_CREDITS = -1;
@@ -38,6 +39,7 @@ const props = withDefaults(defineProps<N8nPromptInputProps>(), {
 	creditsRemaining: undefined,
 	showAskOwnerTooltip: false,
 	refocusAfterSend: false,
+	autofocus: false,
 });
 
 const emit = defineEmits<{
@@ -314,6 +316,10 @@ function focusInput() {
 onMounted(() => {
 	// Adjust height on mount to respect minLines or initial content
 	void nextTick(() => adjustHeight());
+
+	if (props.autofocus) {
+		focusInput();
+	}
 });
 
 defineExpose({


### PR DESCRIPTION
## Summary

The user input field in the AI Builder view is automatically focused when initially opened, but when switching between AI Chat and AI Build tabs the input does not become focused any more.

This PR adds a new `autofocus` property to the prompt input field component as well as setting `autofocus` in the chat component. The default behavior is no autofocus, so there will be no UX changes if the prompt field is used anywhere else.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4051/the-user-input-field-in-the-ai-builder-view-should-be-focused-when

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] ~~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] ~~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~~
