### PR TITLE
fix: Update checksum after restoring workflow

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/views/WorkflowHistory.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/views/WorkflowHistory.vue
@@ -27,7 +27,7 @@ import { useRootStore } from '@n8n/stores/useRootStore';
 import { useWorkflowActivate } from '@/app/composables/useWorkflowActivate';
 import { getResourcePermissions } from '@n8n/permissions';
 import { usePageRedirectionHelper } from '@/app/composables/usePageRedirectionHelper';
-import type { IUser } from 'n8n-workflow';
+import { calculateWorkflowChecksum, type IUser } from 'n8n-workflow';
 
 import { N8nBadge, N8nButton, N8nHeading } from '@n8n/design-system';
 import { createEventBus } from '@n8n/utils/event-bus';
@@ -265,6 +265,11 @@ const restoreWorkflowVersion = async (
 		id,
 		deactivateAndRestore,
 	);
+
+	if (workflowId.value === workflowsStore.workflowId) {
+		workflowsStore.setWorkflowChecksum(await calculateWorkflowChecksum(activeWorkflow.value));
+	}
+
 	const history = await workflowHistoryStore.getWorkflowHistory(workflowId.value, {
 		take: 1,
 	});


### PR DESCRIPTION
## Summary

Restoring and publishing right after on workflow history page showed conflict error. This PR fixes this.

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-4513](https://linear.app/n8n/issue/ADO-4513/bug-workflow-history-page-restoring-and-publishing-right-after-shows)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
