### PR TITLE
feat(core): Add types endpoint to get all credential resolver types

### DIFF
--- a/packages/@n8n/api-types/src/dto/credential-resolver/create-credential-resolver.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credential-resolver/create-credential-resolver.dto.ts
@@ -2,12 +2,12 @@ import { Z } from 'zod-class';
 
 import {
 	credentialResolverNameSchema,
-	credentialResolverTypeSchema,
 	credentialResolverConfigSchema,
+	credentialResolverTypeNameSchema,
 } from '../../schemas/credential-resolver.schema';
 
 export class CreateCredentialResolverDto extends Z.class({
 	name: credentialResolverNameSchema,
-	type: credentialResolverTypeSchema,
+	type: credentialResolverTypeNameSchema,
 	config: credentialResolverConfigSchema,
 }) {}

--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -63,7 +63,10 @@ export { passwordSchema } from './schemas/password.schema';
 export {
 	credentialResolverSchema,
 	credentialResolversSchema,
+	credentialResolverTypeSchema,
+	credentialResolverTypesSchema,
 	type CredentialResolver,
+	type CredentialResolverType,
 } from './schemas/credential-resolver.schema';
 
 export type {

--- a/packages/@n8n/api-types/src/schemas/credential-resolver.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/credential-resolver.schema.ts
@@ -2,18 +2,29 @@ import { z } from 'zod';
 
 export const credentialResolverIdSchema = z.string().max(36);
 export const credentialResolverNameSchema = z.string().trim().min(1).max(255);
-export const credentialResolverTypeSchema = z.string().trim().min(1).max(255);
+export const credentialResolverTypeNameSchema = z.string().trim().min(1).max(255);
 export const credentialResolverConfigSchema = z.record(z.unknown());
 
 export const credentialResolverSchema = z.object({
 	id: credentialResolverIdSchema,
 	name: credentialResolverNameSchema,
-	type: credentialResolverTypeSchema,
+	type: credentialResolverTypeNameSchema,
 	config: z.string(), // Encrypted config
 	decryptedConfig: credentialResolverConfigSchema.optional(),
 	createdAt: z.coerce.date(),
 	updatedAt: z.coerce.date(),
 });
+
+export const credentialResolverTypeSchema = z.object({
+	name: credentialResolverTypeNameSchema,
+	displayName: z.string().trim().min(1).max(255),
+	description: z.string().trim().max(1024).optional(),
+	options: z.array(z.record(z.unknown())).optional(),
+});
+
+export const credentialResolverTypesSchema = z.array(credentialResolverTypeSchema);
+
+export type CredentialResolverType = z.infer<typeof credentialResolverTypeSchema>;
 
 export const credentialResolversSchema = z.array(credentialResolverSchema);
 

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers.controller.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers.controller.ts
@@ -4,6 +4,8 @@ import {
 	credentialResolverSchema,
 	credentialResolversSchema,
 	UpdateCredentialResolverDto,
+	CredentialResolverType,
+	credentialResolverTypesSchema,
 } from '@n8n/api-types';
 import { AuthenticatedRequest } from '@n8n/db';
 import {
@@ -32,12 +34,23 @@ export class CredentialResolversController {
 
 	@Get('/')
 	@GlobalScope('credentialResolver:list')
-	async listResolvers(
-		_req: AuthenticatedRequest,
-		_res: Response,
-	): Promise<Array<CredentialResolver>> {
+	async listResolvers(_req: AuthenticatedRequest, _res: Response): Promise<CredentialResolver[]> {
 		try {
 			return credentialResolversSchema.parse(await this.service.findAll());
+		} catch (e: unknown) {
+			if (e instanceof Error) {
+				throw new InternalServerError(e.message, e);
+			}
+			throw e;
+		}
+	}
+
+	@Get('/types')
+	@GlobalScope('credentialResolver:list')
+	listResolverTypes(_req: AuthenticatedRequest, _res: Response): CredentialResolverType[] {
+		try {
+			const types = this.service.getAvailableTypes();
+			return credentialResolverTypesSchema.parse(types.map((t) => t.metadata));
 		} catch (e: unknown) {
 			if (e instanceof Error) {
 				throw new InternalServerError(e.message, e);

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/credential-resolver.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/credential-resolver.service.ts
@@ -2,6 +2,7 @@ import { Logger } from '@n8n/backend-common';
 import {
 	CredentialResolverConfiguration,
 	CredentialResolverValidationError,
+	ICredentialResolver,
 } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 import { Cipher } from 'n8n-core';
@@ -68,6 +69,13 @@ export class DynamicCredentialResolverService {
 	async findAll(): Promise<DynamicCredentialResolver[]> {
 		const resolvers = await this.repository.find();
 		return resolvers.map((resolver) => this.withDecryptedConfig(resolver));
+	}
+
+	/**
+	 * Retrieves all available resolver types.
+	 */
+	getAvailableTypes(): ICredentialResolver[] {
+		return this.registry.getAllResolvers();
 	}
 
 	/**

--- a/packages/cli/test/integration/dynamic-credentials.ee/credential-resolvers.api.test.ts
+++ b/packages/cli/test/integration/dynamic-credentials.ee/credential-resolvers.api.test.ts
@@ -82,6 +82,31 @@ describe('Credential Resolvers API', () => {
 		});
 	});
 
+	describe('GET /credential-resolvers/types', () => {
+		it('should return available resolver types', async () => {
+			const response = await ownerAgent.get('/credential-resolvers/types').expect(200);
+
+			expect(response.body.data).toBeInstanceOf(Array);
+			expect(response.body.data.length).toBeGreaterThan(0);
+
+			// Verify the stub resolver is present
+			const stubResolver = response.body.data.find(
+				(type: { name: string }) => type.name === 'credential-resolver.stub-1.0',
+			);
+			expect(stubResolver).toBeDefined();
+			expect(stubResolver).toMatchObject({
+				name: 'credential-resolver.stub-1.0',
+				displayName: 'Stub Resolver',
+				description: 'A stub credential resolver for testing purposes',
+				options: expect.any(Array),
+			});
+		});
+
+		it('should reject access for members', async () => {
+			await memberAgent.get('/credential-resolvers/types').expect(403);
+		});
+	});
+
 	describe('POST /credential-resolvers', () => {
 		it('should create a resolver', async () => {
 			const payload = {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR adds a /types endpoint to the Credential resolver controller, in order to list all the credential resolver types (to fill the resolver type select input on the UI when creating a credential resolver)

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-4230/implement-resolver-types-endpoints


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
