### PR TITLE
fix: Remove apk tools from runner image

### DIFF
--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -120,7 +120,8 @@ COPY --from=node-alpine /usr/local/bin/node /usr/local/bin/node
 
 # libstdc++ is required by Node
 # libc6-compat is required by task-runner-launcher
-RUN apk add --no-cache ca-certificates tini libstdc++ libc6-compat
+RUN apk add --no-cache ca-certificates tini libstdc++ libc6-compat && \
+    apk del apk-tools
 
 # Bring corepack and pnpm over, to make the image easier to extend
 COPY --from=node-alpine /usr/local/lib/node_modules /usr/local/lib/node_modules


### PR DESCRIPTION
## Summary

- Runner images shouldn't need APK tools, removed them, this aligns with base image.


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/SEC-394/gpl-20

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
