### PR TITLE
fix: Fetch workflow before updating checksum

### DIFF
--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -754,7 +754,8 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 	}
 
 	async function updateWorkflowChecksum() {
-		const checksum = await calculateWorkflowChecksum(workflow.value);
+		const updatedWorkflow = await fetchWorkflow(workflow.value.id);
+		const checksum = await calculateWorkflowChecksum(updatedWorkflow);
 		setWorkflowChecksum(checksum);
 	}
 


### PR DESCRIPTION
## Summary

We were incorrectly updating checksum for multi-main taking it from state. It should be calculated from the backend response as frontend state differs from what we get from backend (e.g. it sets default values).

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-4514](https://linear.app/n8n/issue/ADO-4514/feature-update-checksum-correctly-for-multi-main)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
