### PR TITLE
feat: Send checksum for archive endpoint

### DIFF
--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -59,6 +59,7 @@ export { GenerateCredentialNameRequestQuery } from './credentials/generate-crede
 export { ImportWorkflowFromUrlDto } from './workflows/import-workflow-from-url.dto';
 export { TransferWorkflowBodyDto } from './workflows/transfer.dto';
 export { ActivateWorkflowDto } from './workflows/activate-workflow.dto';
+export { ArchiveWorkflowDto } from './workflows/archive-workflow.dto';
 
 export { CreateOrUpdateTagRequestDto } from './tag/create-or-update-tag-request.dto';
 export { RetrieveTagQueryDto } from './tag/retrieve-tag-query.dto';

--- a/packages/@n8n/api-types/src/dto/workflows/archive-workflow.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/archive-workflow.dto.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod';
+import { Z } from 'zod-class';
+
+export class ArchiveWorkflowDto extends Z.class({
+	expectedChecksum: z.string().optional(),
+}) {}

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -732,6 +732,7 @@ export class WorkflowService {
 		user: User,
 		workflowId: string,
 		skipArchived: boolean = false,
+		expectedChecksum?: string,
 	): Promise<WorkflowEntity | undefined> {
 		const workflow = await this.workflowFinderService.findWorkflowForUser(workflowId, user, [
 			'workflow:delete',
@@ -747,6 +748,10 @@ export class WorkflowService {
 			}
 
 			throw new BadRequestError('Workflow is already archived.');
+		}
+
+		if (expectedChecksum) {
+			await this._detectConflicts(workflow, expectedChecksum);
 		}
 
 		if (workflow.activeVersionId !== null) {

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -1,5 +1,6 @@
 import {
 	ActivateWorkflowDto,
+	ArchiveWorkflowDto,
 	ImportWorkflowFromUrlDto,
 	ROLE,
 	TransferWorkflowBodyDto,
@@ -477,8 +478,15 @@ export class WorkflowsController {
 		req: AuthenticatedRequest,
 		_res: Response,
 		@Param('workflowId') workflowId: string,
+		@Body body: ArchiveWorkflowDto,
 	) {
-		const workflow = await this.workflowService.archive(req.user, workflowId);
+		const { expectedChecksum } = body;
+		const workflow = await this.workflowService.archive(
+			req.user,
+			workflowId,
+			false,
+			expectedChecksum,
+		);
 		if (!workflow) {
 			this.logger.warn('User attempted to archive a workflow without permissions', {
 				workflowId,

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -856,21 +856,16 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 	async function archiveWorkflow(id: string) {
 		const isCurrentWorkflow = id === workflow.value.id;
 		const currentChecksum = isCurrentWorkflow ? workflowChecksum.value : undefined;
-		const options = currentChecksum ? { expectedChecksum: currentChecksum } : {};
 
 		const updatedWorkflow = await makeRestApiRequest<IWorkflowDb>(
 			rootStore.restApiContext,
 			'POST',
 			`/workflows/${id}/archive`,
-			options,
+			currentChecksum ? { expectedChecksum: currentChecksum } : undefined,
 		);
 		if (workflowsById.value[id]) {
 			workflowsById.value[id].isArchived = true;
 			workflowsById.value[id].versionId = updatedWorkflow.versionId;
-		}
-
-		if (id === workflow.value.id) {
-			setWorkflowChecksum(await calculateWorkflowChecksum(updatedWorkflow));
 		}
 
 		setWorkflowInactive(id);
@@ -878,6 +873,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		if (id === workflow.value.id) {
 			setIsArchived(true);
 			setWorkflowVersionId(updatedWorkflow.versionId);
+			setWorkflowChecksum(await calculateWorkflowChecksum(updatedWorkflow));
 		}
 	}
 

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -854,10 +854,15 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 	}
 
 	async function archiveWorkflow(id: string) {
+		const isCurrentWorkflow = id === workflow.value.id;
+		const currentChecksum = isCurrentWorkflow ? workflowChecksum.value : undefined;
+		const options = currentChecksum ? { expectedChecksum: currentChecksum } : {};
+
 		const updatedWorkflow = await makeRestApiRequest<IWorkflowDb>(
 			rootStore.restApiContext,
 			'POST',
 			`/workflows/${id}/archive`,
+			options,
 		);
 		if (workflowsById.value[id]) {
 			workflowsById.value[id].isArchived = true;


### PR DESCRIPTION
## Summary

- Send checksum for `archive` endpoint so that if one user published the workflow and another is trying to archive it without having the latest updates, they would get a conflict error.
- Forbid updating and activating archived workflows as you need to unarchive them first.

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-4506](https://linear.app/n8n/issue/ADO-4506/feature-send-checksum-for-archive-endpoint)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
