### PR TITLE
fix(core): Adjust chat hub system prompt to avoid claiming it can generate images (no-changelog)

### DIFF
--- a/packages/cli/src/modules/chat-hub/chat-hub-workflow.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-workflow.service.ts
@@ -474,11 +474,17 @@ export class ChatHubWorkflowService {
 		});
 
 		return `The user's current local date and time is: ${now} (timezone: ${timeZone}).
-When you need to reference “now”, use this date and time.`;
+When you need to reference "now", use this date and time.
+
+You can only produce text responses.
+You cannot create, generate, edit, or display images, videos, or other non-text content.
+If the user asks you to generate or edit an image (or other media), explain that you are not able to do that and, if helpful, describe in words what the image could look like or how they could create it using external tools.`;
 	}
 
 	private getBaseSystemMessage(timeZone: string) {
-		return 'You are a helpful assistant.\n' + this.getSystemMessageMetadata(timeZone);
+		return `You are a helpful assistant.
+
+${this.getSystemMessageMetadata(timeZone)}`;
 	}
 
 	private buildToolsAgentNode(

--- a/packages/cli/src/modules/chat-hub/chat-hub.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.service.ts
@@ -499,7 +499,7 @@ export class ChatHubService {
 		}
 
 		const systemMessage =
-			agent.systemPrompt + '\n' + this.chatHubWorkflowService.getSystemMessageMetadata(timeZone);
+			agent.systemPrompt + '\n\n' + this.chatHubWorkflowService.getSystemMessageMetadata(timeZone);
 
 		const model: ChatHubBaseLLMModel = {
 			provider: agent.provider,


### PR DESCRIPTION
## Summary

Some base LLM models would claim that they can generate images even if they can't and fake it, and we only support text responses for now here - adjust the base system prompt so that they wouldn't do that.

## Related Linear tickets, Github issues, and Community forum posts

https://www.notion.so/n8n/2955b6e0c94f80298ea6e47f0abdd9dc?v=2b55b6e0c94f801d977d000c645642d5&p=2bd5b6e0c94f806db3f8f914d000cf5c&pm=s

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
