### PR TITLE
feat(core): Make n8n workflows on Chat require streaming response mode (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
@@ -532,7 +532,7 @@ export class ChatTrigger extends Node {
 						displayName: 'Response Mode',
 						name: 'responseMode',
 						type: 'options',
-						options: [lastNodeResponseMode, respondNodesResponseMode],
+						options: [lastNodeResponseMode, respondNodesResponseMode, streamingResponseMode],
 						default: 'lastNode',
 						description: 'When and how to respond to the chat',
 					},

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
@@ -278,7 +278,7 @@ export class ChatTrigger extends Node {
 				name: 'default',
 				httpMethod: 'POST',
 				responseMode:
-					'={{$parameter.options?.["responseMode"] || $parameter.availableInChat ? "streaming" : "lastNode" }}',
+					'={{$parameter.options?.["responseMode"] ?? ($parameter.availableInChat ? "streaming" : "lastNode") }}',
 				path: CHAT_TRIGGER_PATH_IDENTIFIER,
 				ndvHideMethod: true,
 				ndvHideUrl: '={{ !$parameter.public }}',

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
@@ -425,7 +425,8 @@ export class ChatTrigger extends Node {
 				type: 'string',
 				default: '',
 				noDataExpression: true,
-				description: 'The name of the agent on n8n Chat',
+				description:
+					'The name of the agent on n8n Chat. Name of the workflow is used if left empty.',
 				displayOptions: {
 					show: {
 						availableInChat: [true],

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
@@ -408,7 +408,7 @@ export class ChatTrigger extends Node {
 			},
 			{
 				displayName:
-					'Your n8n users will be able to use this agent in <a href="/home/chat/" target="_blank">Chat</a> once this workflow is published. Make sure to share this workflow with at least \'workflow:execute-chat\' access to all users who should use it. Currently, only streaming response mode is supported.',
+					'Your n8n users will be able to use this agent in <a href="/home/chat/" target="_blank">Chat</a> once this workflow is published. Make sure to share this workflow with at least Project Chat User access to all users who should use it. Currently, only streaming response mode is supported.',
 				name: 'availableInChatNotice',
 				type: 'notice',
 				displayOptions: {

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/ChatTrigger.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/ChatTrigger.node.test.ts
@@ -202,6 +202,74 @@ describe('ChatTrigger Node', () => {
 			});
 		});
 
+		it('should enable streaming when availableInChat is true and responseMode is not set', async () => {
+			// Mock options with availableInChat true and no responseMode
+			mockContext.getNodeParameter.mockImplementation(
+				(
+					paramName: string,
+					defaultValue?: boolean | string | object,
+				): boolean | string | object | undefined => {
+					if (paramName === 'public') return true;
+					if (paramName === 'mode') return 'hostedChat';
+					if (paramName === 'options') return {};
+					if (paramName === 'availableInChat') return true;
+					return defaultValue;
+				},
+			);
+
+			// Call the webhook method
+			const result = await chatTrigger.webhook(mockContext);
+
+			// Verify streaming headers are set
+			expect(mockResponse.writeHead).toHaveBeenCalledWith(200, {
+				'Content-Type': 'application/json; charset=utf-8',
+				'Transfer-Encoding': 'chunked',
+				'Cache-Control': 'no-cache',
+				Connection: 'keep-alive',
+			});
+			expect(mockResponse.flushHeaders).toHaveBeenCalled();
+
+			// Verify response structure for streaming
+			expect(result).toEqual({
+				workflowData: expect.any(Array),
+				noWebhookResponse: true,
+			});
+		});
+
+		it('should enable streaming when availableInChat is true and responseMode is "streaming"', async () => {
+			// Mock options with availableInChat true and streaming responseMode
+			mockContext.getNodeParameter.mockImplementation(
+				(
+					paramName: string,
+					defaultValue?: boolean | string | object,
+				): boolean | string | object | undefined => {
+					if (paramName === 'public') return true;
+					if (paramName === 'mode') return 'hostedChat';
+					if (paramName === 'options') return { responseMode: 'streaming' };
+					if (paramName === 'availableInChat') return true;
+					return defaultValue;
+				},
+			);
+
+			// Call the webhook method
+			const result = await chatTrigger.webhook(mockContext);
+
+			// Verify streaming headers are set
+			expect(mockResponse.writeHead).toHaveBeenCalledWith(200, {
+				'Content-Type': 'application/json; charset=utf-8',
+				'Transfer-Encoding': 'chunked',
+				'Cache-Control': 'no-cache',
+				Connection: 'keep-alive',
+			});
+			expect(mockResponse.flushHeaders).toHaveBeenCalled();
+
+			// Verify response structure for streaming
+			expect(result).toEqual({
+				workflowData: expect.any(Array),
+				noWebhookResponse: true,
+			});
+		});
+
 		it('should handle multipart form data with streaming enabled', async () => {
 			// Mock multipart form data request
 			mockRequest.contentType = 'multipart/form-data';

--- a/packages/cli/src/modules/chat-hub/chat-hub-workflow.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-workflow.service.ts
@@ -31,7 +31,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { ChatHubMessage } from './chat-hub-message.entity';
 import { NODE_NAMES, PROVIDER_NODE_TYPE_MAP } from './chat-hub.constants';
-import { MessageRecord } from './chat-hub.types';
+import { MessageRecord, type ChatTriggerResponseMode } from './chat-hub.types';
 import { getMaxContextWindowTokens } from './context-limits';
 
 @Service()
@@ -55,7 +55,11 @@ export class ChatHubWorkflowService {
 		tools: INode[],
 		timeZone: string,
 		trx?: EntityManager,
-	): Promise<{ workflowData: IWorkflowBase; executionData: IRunExecutionData }> {
+	): Promise<{
+		workflowData: IWorkflowBase;
+		executionData: IRunExecutionData;
+		responseMode: ChatTriggerResponseMode;
+	}> {
 		return await withTransaction(this.workflowRepository.manager, trx, async (em) => {
 			this.logger.debug(
 				`Creating chat workflow for user ${userId} and session ${sessionId}, provider ${model.provider}`,
@@ -69,9 +73,8 @@ export class ChatHubWorkflowService {
 				attachments,
 				credentials,
 				model,
-				systemMessage,
+				systemMessage: systemMessage ?? this.getBaseSystemMessage(timeZone),
 				tools,
-				timeZone,
 			});
 
 			const newWorkflow = new WorkflowEntity();
@@ -103,6 +106,7 @@ export class ChatHubWorkflowService {
 			return {
 				workflowData: workflow,
 				executionData,
+				responseMode: 'streaming',
 			};
 		});
 	}
@@ -261,7 +265,6 @@ export class ChatHubWorkflowService {
 		model,
 		systemMessage,
 		tools,
-		timeZone,
 	}: {
 		userId: string;
 		sessionId: ChatSessionId;
@@ -270,12 +273,11 @@ export class ChatHubWorkflowService {
 		attachments: IBinaryData[];
 		credentials: INodeCredentials;
 		model: ChatHubConversationModel;
-		systemMessage?: string;
+		systemMessage: string;
 		tools: INode[];
-		timeZone: string;
 	}) {
 		const chatTriggerNode = this.buildChatTriggerNode();
-		const toolsAgentNode = this.buildToolsAgentNode(model, timeZone, systemMessage);
+		const toolsAgentNode = this.buildToolsAgentNode(model, systemMessage);
 		const modelNode = this.buildModelNode(credentials, model);
 		const memoryNode = this.buildMemoryNode(20);
 		const restoreMemoryNode = this.buildRestoreMemoryNode(history);
@@ -483,20 +485,20 @@ When you need to reference “now”, use this date and time.`;
 
 	private buildToolsAgentNode(
 		model: ChatHubConversationModel,
-		timeZone: string,
-		systemMessage?: string,
+		systemMessage: string,
+		enableStreaming = true,
 	): INode {
 		return {
 			parameters: {
 				promptType: 'define',
 				text: `={{ $('${NODE_NAMES.CHAT_TRIGGER}').item.json.chatInput }}`,
 				options: {
-					enableStreaming: true,
+					enableStreaming,
 					maxTokensFromMemory:
 						model.provider !== 'n8n' && model.provider !== 'custom-agent'
 							? getMaxContextWindowTokens(model.provider, model.model)
 							: undefined,
-					systemMessage: systemMessage ?? this.getBaseSystemMessage(timeZone),
+					systemMessage,
 				},
 			},
 			type: AGENT_LANGCHAIN_NODE_TYPE,

--- a/packages/cli/src/modules/chat-hub/chat-hub.constants.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.constants.ts
@@ -1,5 +1,14 @@
 import type { ChatHubLLMProvider, ChatModelMetadataDto } from '@n8n/api-types';
-import type { INodeTypeNameVersion } from 'n8n-workflow';
+import type { ExecutionStatus, INodeTypeNameVersion } from 'n8n-workflow';
+
+export const EXECUTION_POLL_INTERVAL = 1000;
+export const EXECUTION_FINISHED_STATUSES: ExecutionStatus[] = [
+	'canceled',
+	'crashed',
+	'error',
+	'success',
+];
+export const TOOLS_AGENT_NODE_MIN_VERSION = 2.2;
 
 export const PROVIDER_NODE_TYPE_MAP: Record<ChatHubLLMProvider, INodeTypeNameVersion> = {
 	openai: {

--- a/packages/cli/src/modules/chat-hub/chat-hub.models.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.models.service.ts
@@ -10,22 +10,21 @@ import {
 import { In, WorkflowRepository, type User } from '@n8n/db';
 import { Service } from '@n8n/di';
 import {
-	AGENT_LANGCHAIN_NODE_TYPE,
 	CHAT_TRIGGER_NODE_TYPE,
 	type INodeCredentials,
 	type INodePropertyOptions,
 	type IWorkflowExecuteAdditionalData,
 } from 'n8n-workflow';
 
+import { ChatHubAgentService } from './chat-hub-agent.service';
+import { ChatHubWorkflowService } from './chat-hub-workflow.service';
+import { getModelMetadata, PROVIDER_NODE_TYPE_MAP } from './chat-hub.constants';
+import { chatTriggerParamsShape } from './chat-hub.types';
+
 import { CredentialsFinderService } from '@/credentials/credentials-finder.service';
 import { DynamicNodeParametersService } from '@/services/dynamic-node-parameters.service';
 import { getBase } from '@/workflow-execute-additional-data';
 import { WorkflowService } from '@/workflows/workflow.service';
-
-import { ChatHubAgentService } from './chat-hub-agent.service';
-import { ChatHubWorkflowService } from './chat-hub-workflow.service';
-import { getModelMetadata, PROVIDER_NODE_TYPE_MAP } from './chat-hub.constants';
-import { validChatTriggerParamsShape } from './chat-hub.types';
 
 @Service()
 export class ChatHubModelsService {
@@ -747,17 +746,8 @@ export class ChatHubModelsService {
 				continue;
 			}
 
-			const chatTriggerParams = validChatTriggerParamsShape.safeParse(chatTrigger.parameters).data;
-			if (!chatTriggerParams) {
-				continue;
-			}
-
-			const agentNodes = activeVersion.nodes?.filter(
-				(node) => node.type === AGENT_LANGCHAIN_NODE_TYPE,
-			);
-
-			// Agents older than this can't do streaming
-			if (agentNodes.some((node) => node.typeVersion < 2.1)) {
+			const chatTriggerParams = chatTriggerParamsShape.safeParse(chatTrigger.parameters).data;
+			if (!chatTriggerParams?.availableInChat) {
 				continue;
 			}
 

--- a/packages/cli/src/modules/chat-hub/chat-hub.models.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.models.service.ts
@@ -729,14 +729,14 @@ export class ChatHubModelsService {
 			.filter((workflow) => !!workflow.activeVersionId);
 
 		const workflows = await this.workflowRepository.find({
-			select: { id: true },
+			select: { id: true, name: true },
 			where: { id: In(activeWorkflows.map((workflow) => workflow.id)) },
 			relations: { activeVersion: true },
 		});
 
 		const models: ChatModelDto[] = [];
 
-		for (const { id, activeVersion } of workflows) {
+		for (const { id, name, activeVersion } of workflows) {
 			if (!activeVersion) {
 				continue;
 			}
@@ -755,8 +755,13 @@ export class ChatHubModelsService {
 				chatTriggerParams.options,
 			);
 
+			const agentName =
+				chatTriggerParams.agentName && chatTriggerParams.agentName.trim().length > 0
+					? chatTriggerParams.agentName
+					: name;
+
 			models.push({
-				name: chatTriggerParams.agentName ?? activeVersion.name ?? 'Unknown Agent',
+				name: agentName,
 				description: chatTriggerParams.agentDescription ?? null,
 				model: {
 					provider: 'n8n',

--- a/packages/cli/src/modules/chat-hub/chat-hub.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.service.ts
@@ -571,7 +571,7 @@ export class ChatHubService {
 
 		const chatTrigger = chatTriggers[0];
 
-		if (chatTrigger.typeVersion < 1.2) {
+		if (chatTrigger.typeVersion < 1.4) {
 			throw new BadRequestError(
 				'Chat Trigger node version is too old to support Chat. Please update the node.',
 			);
@@ -586,14 +586,12 @@ export class ChatHubService {
 			throw new BadRequestError('Chat Trigger node must be made available in Chat');
 		}
 
-		if (chatTriggerParams.options?.responseMode !== 'streaming') {
+		const responseMode = chatTriggerParams.options?.responseMode ?? 'streaming';
+		if (responseMode !== 'streaming') {
 			throw new BadRequestError(
 				'Chat Trigger node response mode must be set to streaming to use the workflow on Chat',
 			);
 		}
-
-		// TODO: Support other response modes
-		const responseMode = chatTriggerParams.options?.responseMode;
 
 		const chatResponseNodes = workflow.activeVersion.nodes.filter(
 			(node) => node.type === RESPOND_TO_CHAT_NODE_TYPE,

--- a/packages/cli/src/modules/chat-hub/chat-hub.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.service.ts
@@ -38,7 +38,7 @@ import {
 	type IBinaryData,
 	createRunExecutionData,
 	WorkflowExecuteMode,
-	ExecutionStatus,
+	AGENT_LANGCHAIN_NODE_TYPE,
 } from 'n8n-workflow';
 
 import { ChatHubAgentService } from './chat-hub-agent.service';
@@ -47,12 +47,21 @@ import type { ChatHubMessage } from './chat-hub-message.entity';
 import type { ChatHubSession } from './chat-hub-session.entity';
 import { ChatHubWorkflowService } from './chat-hub-workflow.service';
 import { ChatHubAttachmentService } from './chat-hub.attachment.service';
-import { JSONL_STREAM_HEADERS, NODE_NAMES, PROVIDER_NODE_TYPE_MAP } from './chat-hub.constants';
+import {
+	EXECUTION_FINISHED_STATUSES,
+	EXECUTION_POLL_INTERVAL,
+	JSONL_STREAM_HEADERS,
+	NODE_NAMES,
+	PROVIDER_NODE_TYPE_MAP,
+	TOOLS_AGENT_NODE_MIN_VERSION,
+} from './chat-hub.constants';
 import { ChatHubSettingsService } from './chat-hub.settings.service';
 import {
 	HumanMessagePayload,
 	RegenerateMessagePayload,
 	EditMessagePayload,
+	chatTriggerParamsShape,
+	ChatTriggerResponseMode,
 } from './chat-hub.types';
 import { ChatHubMessageRepository } from './chat-message.repository';
 import { ChatHubSessionRepository } from './chat-session.repository';
@@ -64,9 +73,6 @@ import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { ExecutionService } from '@/executions/execution.service';
 import { WorkflowExecutionService } from '@/workflows/workflow-execution.service';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
-
-const EXECUTION_POLL_INTERVAL = 1000;
-const EXECUTION_FINISHED_STATUSES: ExecutionStatus[] = ['canceled', 'crashed', 'error', 'success'];
 
 @Service()
 export class ChatHubService {
@@ -159,6 +165,7 @@ export class ChatHubService {
 
 		let executionData: IRunExecutionData;
 		let workflowData: IWorkflowBase;
+		let responseMode: ChatTriggerResponseMode;
 
 		try {
 			const result = await this.messageRepository.manager.transaction(async (trx) => {
@@ -203,6 +210,7 @@ export class ChatHubService {
 
 			executionData = result.executionData;
 			workflowData = result.workflowData;
+			responseMode = result.responseMode;
 		} catch (error) {
 			if (processedAttachments.length > 0) {
 				try {
@@ -224,6 +232,8 @@ export class ChatHubService {
 			sessionId,
 			messageId,
 			model,
+			null,
+			responseMode,
 		);
 
 		// Generate title for the session on receiving the first human message.
@@ -301,7 +311,7 @@ export class ChatHubService {
 			return;
 		}
 
-		const { workflowData, executionData } = workflow;
+		const { workflowData, executionData, responseMode } = workflow;
 
 		await this.executeChatWorkflowWithCleanup(
 			res,
@@ -311,6 +321,8 @@ export class ChatHubService {
 			sessionId,
 			messageId,
 			model,
+			null,
+			responseMode,
 		);
 	}
 
@@ -319,7 +331,7 @@ export class ChatHubService {
 		const tz = timeZone ?? this.globalConfig.generic.timezone;
 
 		const {
-			workflow: { workflowData, executionData },
+			workflow: { workflowData, executionData, responseMode },
 			retryOfMessageId,
 			previousMessageId,
 		} = await this.messageRepository.manager.transaction(async (trx) => {
@@ -383,6 +395,7 @@ export class ChatHubService {
 			previousMessageId,
 			model,
 			retryOfMessageId,
+			responseMode,
 		);
 	}
 
@@ -537,18 +550,18 @@ export class ChatHubService {
 		message: string,
 		attachments: IBinaryData[],
 	) {
-		const workflowEntity = await this.workflowFinderService.findWorkflowForUser(
+		const workflow = await this.workflowFinderService.findWorkflowForUser(
 			workflowId,
 			user,
 			['workflow:execute-chat'],
 			{ includeTags: false, includeParentFolder: false, includeActiveVersion: true },
 		);
 
-		if (!workflowEntity?.activeVersion) {
+		if (!workflow?.activeVersion) {
 			throw new BadRequestError('Workflow not found');
 		}
 
-		const chatTriggers = workflowEntity.activeVersion.nodes.filter(
+		const chatTriggers = workflow.activeVersion.nodes.filter(
 			(node) => node.type === CHAT_TRIGGER_NODE_TYPE,
 		);
 
@@ -556,9 +569,33 @@ export class ChatHubService {
 			throw new BadRequestError('Workflow must have exactly one chat trigger');
 		}
 
-		const chatTriggerNode = chatTriggers[0];
+		const chatTrigger = chatTriggers[0];
 
-		const chatResponseNodes = workflowEntity.activeVersion.nodes.filter(
+		if (chatTrigger.typeVersion < 1.2) {
+			throw new BadRequestError(
+				'Chat Trigger node version is too old to support Chat. Please update the node.',
+			);
+		}
+
+		const chatTriggerParams = chatTriggerParamsShape.safeParse(chatTrigger.parameters).data;
+		if (!chatTriggerParams) {
+			throw new BadRequestError('Chat Trigger node has invalid parameters');
+		}
+
+		if (!chatTriggerParams.availableInChat) {
+			throw new BadRequestError('Chat Trigger node must be made available in Chat');
+		}
+
+		if (chatTriggerParams.options?.responseMode !== 'streaming') {
+			throw new BadRequestError(
+				'Chat Trigger node response mode must be set to streaming to use the workflow on Chat',
+			);
+		}
+
+		// TODO: Support other response modes
+		const responseMode = chatTriggerParams.options?.responseMode;
+
+		const chatResponseNodes = workflow.activeVersion.nodes.filter(
 			(node) => node.type === RESPOND_TO_CHAT_NODE_TYPE,
 		);
 
@@ -568,8 +605,19 @@ export class ChatHubService {
 			);
 		}
 
+		const agentNodes = workflow.activeVersion.nodes?.filter(
+			(node) => node.type === AGENT_LANGCHAIN_NODE_TYPE,
+		);
+
+		// Agents older than this can't do streaming
+		if (agentNodes.some((node) => node.typeVersion < TOOLS_AGENT_NODE_MIN_VERSION)) {
+			throw new BadRequestError(
+				'Agent node version is too old to support streaming responses. Please update the node.',
+			);
+		}
+
 		const nodeExecutionStack = this.chatHubWorkflowService.prepareExecutionData(
-			chatTriggerNode,
+			chatTrigger,
 			sessionId,
 			message,
 			attachments,
@@ -585,14 +633,15 @@ export class ChatHubService {
 		});
 
 		const workflowData: IWorkflowBase = {
-			...workflowEntity,
-			nodes: workflowEntity.activeVersion.nodes,
-			connections: workflowEntity.activeVersion.connections,
+			...workflow,
+			nodes: workflow.activeVersion.nodes,
+			connections: workflow.activeVersion.connections,
 		};
 
 		return {
 			workflowData,
 			executionData,
+			responseMode,
 		};
 	}
 
@@ -653,10 +702,15 @@ export class ChatHubService {
 		model: ChatHubConversationModel,
 		retryOfMessageId: ChatMessageId | null = null,
 		executionMode: WorkflowExecuteMode = 'chat',
+		responseMode: ChatTriggerResponseMode,
 	) {
 		this.logger.debug(
 			`Starting execution of workflow "${workflowData.name}" with ID ${workflowData.id}`,
 		);
+
+		if (responseMode !== 'streaming') {
+			throw new BadRequestError(`Response mode "${responseMode}" is not supported yet.`);
+		}
 
 		// Capture the streaming response as it's being generated to save
 		// partial messages in the database when generation gets cancelled.
@@ -842,7 +896,8 @@ export class ChatHubService {
 		sessionId: ChatSessionId,
 		previousMessageId: ChatMessageId,
 		model: ChatHubConversationModel,
-		retryOfMessageId: ChatMessageId | null = null,
+		retryOfMessageId: ChatMessageId | null,
+		responseMode: ChatTriggerResponseMode,
 	) {
 		try {
 			// 'n8n' provider executions count towards execution limits and they are run with the usual 'webhook' mode.
@@ -859,6 +914,7 @@ export class ChatHubService {
 				model,
 				retryOfMessageId,
 				executionMode,
+				responseMode,
 			);
 		} finally {
 			if (model.provider !== 'n8n') {

--- a/packages/cli/src/modules/chat-hub/chat-hub.types.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.types.ts
@@ -60,7 +60,7 @@ const ChatTriggerResponseModeSchema = z.enum([
 export type ChatTriggerResponseMode = z.infer<typeof ChatTriggerResponseModeSchema>;
 
 export const chatTriggerParamsShape = z.object({
-	availableInChat: z.boolean(),
+	availableInChat: z.boolean().optional().default(false),
 	agentName: z.string().min(1).optional(),
 	agentDescription: z.string().min(1).optional(),
 	options: z

--- a/packages/cli/src/modules/chat-hub/chat-hub.types.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.types.ts
@@ -51,14 +51,23 @@ export interface MessageRecord {
 	hideFromUI: boolean;
 }
 
-export const validChatTriggerParamsShape = z.object({
-	availableInChat: z.literal(true),
+const ChatTriggerResponseModeSchema = z.enum([
+	'streaming',
+	'lastNode',
+	'responseNode',
+	'responseNodes',
+]);
+export type ChatTriggerResponseMode = z.infer<typeof ChatTriggerResponseModeSchema>;
+
+export const chatTriggerParamsShape = z.object({
+	availableInChat: z.boolean(),
 	agentName: z.string().min(1).optional(),
 	agentDescription: z.string().min(1).optional(),
 	options: z
 		.object({
 			allowFileUploads: z.boolean().optional(),
 			allowedFilesMimeTypes: z.string().optional(),
+			responseMode: ChatTriggerResponseModeSchema.optional(),
 		})
 		.optional(),
 });

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/chat.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/chat.store.ts
@@ -453,6 +453,26 @@ export const useChatStore = defineStore(CHAT_STORE, () => {
 		await fetchSessions(true);
 	}
 
+	function getErrorMessageByStatusCode(
+		statusCode: number | undefined,
+		message: string | undefined,
+	): string {
+		const errorMessages: Record<number, string> = {
+			[413]: i18n.baseText('chatHub.error.payloadTooLarge'),
+			[400]: message ?? i18n.baseText('chatHub.error.badRequest'),
+			[403]: i18n.baseText('chatHub.error.forbidden'),
+			[500]: message
+				? i18n.baseText('chatHub.error.serverErrorWithReason', {
+						interpolate: { error: message },
+					})
+				: i18n.baseText('chatHub.error.serverError'),
+		};
+
+		return (
+			(statusCode && errorMessages[statusCode]) || message || i18n.baseText('chatHub.error.unknown')
+		);
+	}
+
 	function onStreamError(error: Error) {
 		if (!streaming.value) {
 			return;
@@ -468,26 +488,6 @@ export const useChatStore = defineStore(CHAT_STORE, () => {
 		toast.showError(cause, i18n.baseText('chatHub.error.sendMessageFailed'));
 
 		streaming.value = undefined;
-	}
-
-	function getErrorMessageByStatusCode(
-		statusCode: number | undefined,
-		message: string | undefined,
-	): string {
-		const errorMessages: Record<number, string> = {
-			[413]: i18n.baseText('chatHub.error.payloadTooLarge'),
-			[400]: i18n.baseText('chatHub.error.badRequest'),
-			[403]: i18n.baseText('chatHub.error.forbidden'),
-			[500]: message
-				? i18n.baseText('chatHub.error.serverErrorWithReason', {
-						interpolate: { error: message },
-					})
-				: i18n.baseText('chatHub.error.serverError'),
-		};
-
-		return (
-			(statusCode && errorMessages[statusCode]) || message || i18n.baseText('chatHub.error.unknown')
-		);
 	}
 
 	async function sendMessage(

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/CollectionParameter.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/CollectionParameter.vue
@@ -75,9 +75,29 @@ function displayNodeParameter(parameter: INodeProperties) {
 	return nodeHelpers.displayParameter(props.nodeValues, parameter, props.path, ndvStore.activeNode);
 }
 
-function getOptionProperties(optionName: string) {
+const filteredOptions = computed<Array<INodePropertyOptions | INodeProperties>>(() => {
+	return (props.parameter.options as Array<INodePropertyOptions | INodeProperties>).filter(
+		(option) => {
+			return displayNodeParameter(option as INodeProperties);
+		},
+	);
+});
+const propertyNames = computed<string[]>(() => {
+	if (props.values) {
+		return Object.keys(props.values);
+	}
+	return [];
+});
+const parameterOptions = computed(() => {
+	return filteredOptions.value.filter((option) => {
+		return !propertyNames.value.includes(option.name);
+	});
+});
+
+function getOptionProperties(optionName: string, filter: boolean = false) {
 	const properties = [];
-	for (const option of props.parameter.options ?? []) {
+	const options = filter ? parameterOptions.value : props.parameter.options;
+	for (const option of options ?? []) {
 		if (option.name === optionName) {
 			properties.push(option);
 		}
@@ -85,12 +105,7 @@ function getOptionProperties(optionName: string) {
 
 	return properties;
 }
-const propertyNames = computed<string[]>(() => {
-	if (props.values) {
-		return Object.keys(props.values);
-	}
-	return [];
-});
+
 const getProperties = computed(() => {
 	const returnProperties = [];
 	let tempProperties;
@@ -102,21 +117,9 @@ const getProperties = computed(() => {
 	}
 	return returnProperties;
 });
-const filteredOptions = computed<Array<INodePropertyOptions | INodeProperties>>(() => {
-	return (props.parameter.options as Array<INodePropertyOptions | INodeProperties>).filter(
-		(option) => {
-			return displayNodeParameter(option as INodeProperties);
-		},
-	);
-});
-const parameterOptions = computed(() => {
-	return filteredOptions.value.filter((option) => {
-		return !propertyNames.value.includes(option.name);
-	});
-});
 
 function optionSelected(optionName: string) {
-	const options = getOptionProperties(optionName);
+	const options = getOptionProperties(optionName, true);
 	if (options.length === 0) {
 		return;
 	}


### PR DESCRIPTION
## Summary

Chat will initially ship with just `streaming`  response mode support, and before we've been forcing the workflows to be run in this response mode, which has led to some confusion.

Instead of forcing the response mode to `streaming` make the `streaming` mode a requirement, making it so that the agent can't be used on Chat unless the correct streaming mode is selected.

To not make this clunky to use make it so that if the `availableInChat` toggle is enabled the available Response Mode options change to only `streaming`, and the default changes. Since `availableInChat` is a new field in 1.4 version of the node this shouldn't cause regressions, as the field is default: false.

Also make it possible to have `streaming` response mode in non public workflows, and improve Chat error handling on 400 errors, displaying the error text on the error toast.

## Related Linear tickets, Github issues, and Community forum posts

https://www.notion.so/n8n/2955b6e0c94f80298ea6e47f0abdd9dc?v=2955b6e0c94f8169af97000c22abcddb&p=2ac5b6e0c94f8074b992fbde609ed7b9&pm=s

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
